### PR TITLE
Added videoalpha to advanced components in component.py file.

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -34,7 +34,7 @@ from xmodule.course_module import CourseDescriptor
 from xmodule.seq_module import SequenceDescriptor
 from xmodule.modulestore.exceptions import ItemNotFoundError
 
-from contentstore.views.component import ADVANCED_COMPONENT_TYPES, ADVANCED_COMPONENT_POLICY_KEY
+from contentstore.views.component import ADVANCED_COMPONENT_TYPES
 
 from django_comment_common.utils import are_permissions_roles_seeded
 

--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -100,6 +100,7 @@ class ContentStoreToyCourseTest(ModuleStoreTestCase):
         self.assertIn('Word cloud', resp.content)
         self.assertIn('Annotation', resp.content)
         self.assertIn('Open Ended Response', resp.content)
+        self.assertIn('Peer Grading Interface', resp.content)
 
     def check_edit_unit(self, test_course_name):
         import_from_xml(modulestore('direct'), 'common/test/data/', [test_course_name])

--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -34,6 +34,8 @@ from xmodule.course_module import CourseDescriptor
 from xmodule.seq_module import SequenceDescriptor
 from xmodule.modulestore.exceptions import ItemNotFoundError
 
+from contentstore.views.component import ADVANCED_COMPONENT_TYPES, ADVANCED_COMPONENT_POLICY_KEY
+
 from django_comment_common.utils import are_permissions_roles_seeded
 
 TEST_DATA_MODULESTORE = copy.deepcopy(settings.MODULESTORE)
@@ -74,6 +76,30 @@ class ContentStoreToyCourseTest(ModuleStoreTestCase):
 
         self.client = Client()
         self.client.login(username=uname, password=password)
+
+    def test_advanced_components_in_edit_unit(self):
+        store = modulestore('direct')
+        import_from_xml(store, 'common/test/data/', ['simple'])
+
+        course = store.get_item(Location(['i4x', 'edX', 'simple',
+                                          'course', '2012_Fall', None]), depth=None)
+
+        course.advanced_modules = ADVANCED_COMPONENT_TYPES
+
+        store.update_metadata(course.location, own_metadata(course))
+
+        # just pick one vertical
+        descriptor = store.get_items(Location('i4x', 'edX', 'simple', 'vertical', None, None))[0]
+
+        resp = self.client.get(reverse('edit_unit', kwargs={'location': descriptor.location.url()}))
+        self.assertEqual(resp.status_code, 200)
+
+        # This could be made better, but for now let's just assert that we see the advanced modules mentioned in the page
+        # response HTML
+        self.assertIn('Video Alpha', resp.content)
+        self.assertIn('Word cloud', resp.content)
+        self.assertIn('Annotation', resp.content)
+        self.assertIn('Open Ended Response', resp.content)
 
     def check_edit_unit(self, test_course_name):
         import_from_xml(modulestore('direct'), 'common/test/data/', [test_course_name])

--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -42,7 +42,7 @@ COMPONENT_TYPES = ['customtag', 'discussion', 'html', 'problem', 'video']
 
 OPEN_ENDED_COMPONENT_TYPES = ["combinedopenended", "peergrading"]
 NOTE_COMPONENT_TYPES = ['notes']
-ADVANCED_COMPONENT_TYPES = ['annotatable', 'word_cloud'] + OPEN_ENDED_COMPONENT_TYPES + NOTE_COMPONENT_TYPES
+ADVANCED_COMPONENT_TYPES = ['annotatable', 'word_cloud', 'videoalpha'] + OPEN_ENDED_COMPONENT_TYPES + NOTE_COMPONENT_TYPES
 ADVANCED_COMPONENT_CATEGORY = 'advanced'
 ADVANCED_COMPONENT_POLICY_KEY = 'advanced_modules'
 


### PR DESCRIPTION
Without this, Video Alpha will not appear under the Advanced Components section. It escapes me how this was missed in the original pull request https://github.com/edx/edx-platform-pre-clean/pull/1714 which was merged recently.

@vaxXxa and @auraz please review!
