### PR TITLE
RFC: removing the request debugger entirely.

### DIFF
--- a/common/djangoapps/util/views.py
+++ b/common/djangoapps/util/views.py
@@ -209,30 +209,3 @@ def accepts(request, media_type):
     accept = parse_accept_header(request.META.get("HTTP_ACCEPT", ""))
     return media_type in [t for (t, p, q) in accept]
 
-
-def debug_request(request):
-    """Return a pretty printed version of the request"""
-
-    return HttpResponse("""<html>
-<h1>request:</h1>
-<pre>{0}</pre>
-
-<h1>request.GET</h1>:
-
-<pre>{1}</pre>
-
-<h1>request.POST</h1>:
-<pre>{2}</pre>
-
-<h1>request.REQUEST</h1>:
-<pre>{3}</pre>
-
-
-
-</html>
-""".format(
-    pprint.pformat(request),
-    pprint.pformat(dict(request.GET)),
-    pprint.pformat(dict(request.POST)),
-    pprint.pformat(dict(request.REQUEST)),
-    ))

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -330,13 +330,6 @@ if settings.DEBUG or settings.MITX_FEATURES.get('ENABLE_DJANGO_ADMIN_SITE'):
     ## Jasmine and admin
     urlpatterns += (url(r'^admin/', include(admin.site.urls)),)
 
-if settings.DEBUG:
-    # Originally added to allow debugging issues when prod is
-    # mysteriously different from staging (specifically missing get
-    # parameters in certain cases), but removing from prod because
-    # it's a security risk.
-    urlpatterns += (url(r'^debug_request$', 'util.views.debug_request'),)
-
 if settings.MITX_FEATURES.get('AUTH_USE_OPENID'):
     urlpatterns += (
         url(r'^openid/login/$', 'django_openid_auth.views.login_begin', name='openid-login'),


### PR DESCRIPTION
This code is subject to a secure finding.

A change was made to make it available only in debug mode, but that undermines the original purpose of the feature which was to debug differences between production in p minus n environments.

This code isn't needed in developer environments because the Django console provided the same information.

If this code isn't needed I think we should remove it entirely.
