### PR TITLE
[STUD-177] Fix/cdodge/bad link in activation page

### DIFF
--- a/cms/djangoapps/contentstore/tests/tests.py
+++ b/cms/djangoapps/contentstore/tests/tests.py
@@ -111,6 +111,18 @@ class AuthTestCase(ContentStoreTestCase):
         # Now login should work
         self.login(self.email, self.pw)
 
+    def test_login_link_on_activation_age(self):
+        self.create_account(self.username, self.email, self.pw)
+        # we want to test the rendering of the activation page when the user isn't logged in
+        self.client.logout()
+        resp = self._activate_user(self.email)
+        self.assertEqual(resp.status_code, 200)
+
+        # check the the HTML has links to the right login page. Note that this is merely a content
+        # check and thus could be fragile should the wording change on this page
+        expected = 'You can now <a href="' + reverse('login') + '">login</a>.'
+        self.assertIn(expected, resp.content)
+
     def test_private_pages_auth(self):
         """Make sure pages that do require login work."""
         auth_pages = (

--- a/cms/templates/registration/activation_complete.html
+++ b/cms/templates/registration/activation_complete.html
@@ -18,7 +18,7 @@
       %if user_logged_in:
         Visit your <a href="/">dashboard</a> to see your courses.
       %else:
-        You can now <a href="#login-modal" rel="leanModal">login</a>.
+        You can now <a href="${reverse('login')}">login</a>.
       %endif
     </p>
   </section>

--- a/cms/templates/registration/activation_complete.html
+++ b/cms/templates/registration/activation_complete.html
@@ -3,6 +3,12 @@
 
 <%namespace name='static' file='../static_content.html'/>
 
+%if not user_logged_in: 
+<%block name="bodyclass">
+  not-signedin 
+</%block>
+%endif
+
 <%block name="content">
 <section class="container activation">
 


### PR DESCRIPTION
To test:

1) signup
2) clear all cookies. close browser. reopen fresh browser session.
3) go to activation page which is dumped in the CMS console output

Check login link in body and headers
