### PR TITLE
require distribute >= because there is an old branch out there that messes up the build server

### DIFF
--- a/common/lib/capa/setup.py
+++ b/common/lib/capa/setup.py
@@ -4,5 +4,5 @@ setup(
     name="capa",
     version="0.1",
     packages=find_packages(exclude=["tests"]),
-    install_requires=["distribute==0.6.28"],
+    install_requires=["distribute>=0.6.28"],
 )

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -4,7 +4,7 @@ beautifulsoup4==4.1.3
 beautifulsoup==3.2.1
 boto==2.6.0
 celery==3.0.19
-distribute==0.6.28
+distribute>=0.6.28
 django-celery==3.0.17
 django-countries==1.5
 django-followit==0.0.3


### PR DESCRIPTION
@cpennington pls review
