### PR TITLE
Changed some logic in grade_sheet calculation. If a graded section consi...

### DIFF
--- a/lms/djangoapps/courseware/grades.py
+++ b/lms/djangoapps/courseware/grades.py
@@ -219,7 +219,7 @@ def grade(student, request, course, model_data_cache=None, keep_raw_scores=False
                 if graded_total.possible > 0:
                     format_scores.append(graded_total)
 
-                log.exception("Unable to grade a section with a total possible score of zero. " +
+                log.warning("Unable to grade a section with a total possible score of zero. " +
                               str(section_descriptor.location))
 
         totaled_scores[section_format] = format_scores

--- a/lms/djangoapps/courseware/grades.py
+++ b/lms/djangoapps/courseware/grades.py
@@ -212,6 +212,13 @@ def grade(student, request, course, model_data_cache=None, keep_raw_scores=False
             if graded_total.possible > 0:
                 format_scores.append(graded_total)
             else:
+                #Check if overriding subparts being graded lets possible > 0.
+                #This occurs if there's an error in the course data.
+                graded_total ,_ = graders.aggregate_scores(scores, section_name)
+
+                if graded_total.possible > 0:
+                    format_scores.append(graded_total)
+
                 log.exception("Unable to grade a section with a total possible score of zero. " +
                               str(section_descriptor.location))
 


### PR DESCRIPTION
...sts only of ungraded sub-parts, those are now overridden to graded, with an exception logged, so that the graded section is still added to the grade_sheet.

This fixes [LMS-285](https://edx-wiki.atlassian.net/browse/LMS-285).

All four problems in Hour 4 Question Set had "graded=False", so when they were graded, Hour 4 Question Set was not added to the grade sheet, throwing everything off.

This edit changes how grade_sheet is calculated. When a graded section is not added to the grade sheet because it has ungraded subparts which make its overall possible score 0, the subparts are treated as graded so that the graded section won't be omitted from the grade sheet

The other fix -- changing the problems in Question Set 4 so that they don't have graded=False -- has not yet happened.

@ormsbee @dianakhuang

Could you check that this is sane and won't break other courses? It seems like omitting things which have graded=False is intended behavior. (The issue is that these are then excluded from being graphed at all, even if part of a series of graded assignments.)
