### PR TITLE
(reapply) Redirect CMS help links to Stanford Google Group

### DIFF
--- a/cms/templates/login.html
+++ b/cms/templates/login.html
@@ -46,7 +46,7 @@
 
       <div class="bit">
         <h3 class="title-3">Need Help?</h3>
-        <p>Having trouble with your account? Use <a href="http://help.edge.edx.org" rel="external">our support center</a> to look over self help steps, find solutions others have found to the same problem, or let us know of your issue.</p>
+        <p>Having trouble with your account? Use <a href="https://groups.google.com/d/forum/studio-users" rel="external">our Google Group</a> to look over self help steps, find solutions others have found to the same problem, or let us know of your issue.</p>
       </div>
     </aside>
   </section>

--- a/cms/templates/widgets/footer.html
+++ b/cms/templates/widgets/footer.html
@@ -6,7 +6,7 @@
     <div class="colophon">
       <p>&copy; 2013 <a href="http://www.edx.org" rel="external">edX</a>. ${ _("All rights reserved.")}</p>
     </div>
-    
+
     <nav class="nav-peripheral">
       <ol>
         <!-- <li class="nav-item nav-peripheral-tos">
@@ -17,9 +17,9 @@
         </li> -->
         % if user.is_authenticated():
         <li class="nav-item nav-peripheral-feedback">
-          <a href="http://help.edge.edx.org/discussion/new" class="show-tender" title="${_('Use our feedback tool, Tender, to share your feedback')}">${_("Contact Us")}</a>
+          <a href="mailto:studio-users@googlegroups.com" rel="external" title="${_('Use our Google Group to share your feedback')}">${_("Contact Us")}</a>
         </li>
-        % endif    
+        % endif
       </ol>
     </nav>
   </footer>

--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -86,7 +86,7 @@
               <div class="nav-sub">
                 <ul>
                   <li class="nav-item nav-account-dashboard"><a href="/">My Courses</a></li>
-                  <li class="nav-item nav-account-help"><a href="http://help.edge.edx.org/" rel="external">Studio Help</a></li>
+                  <li class="nav-item nav-account-help"><a href="https://groups.google.com/d/forum/studio-users" rel="external">studio-users group</a></li>
                   <li class="nav-item nav-account-signout"><a class="action action-signout" href="${reverse('logout')}">Sign Out</a></li>
                 </ul>
               </div>
@@ -102,7 +102,7 @@
             <a href="/">How Studio Works</a>
           </li>
           <li class="nav-item nav-not-signedin-help">
-            <a href="http://help.edge.edx.org/" rel="external">Studio Help</a>
+            <a href="https://groups.google.com/d/forum/studio-users" rel="external">studio-users group</a>
           </li>
           <li class="nav-item nav-not-signedin-signup">
             <a class="action action-signup" href="${reverse('signup')}">Sign Up</a>

--- a/cms/templates/widgets/sock.html
+++ b/cms/templates/widgets/sock.html
@@ -25,29 +25,14 @@
           <span class="tip">How to use Studio to build your course</span>
         </li>
         <li class="action-item">
-          <a href="http://help.edge.edx.org/" rel="external" class="action action-primary">Studio Help Center</a>
-          <span class="tip">Studio Help Center</span>
+          <a href="https://groups.google.com/d/forum/studio-users" rel="external" class="action action-primary">studio-users group</a>
+          <span class="tip"><i class="ss-icon ss-symbolicons-block icon-help">&#xEE11;</i> studio-users group</span>
         </li>
         <li class="action-item">
           <a href="https://edge.edx.org/courses/edX/edX101/How_to_Create_an_edX_Course/about" rel="external" class="action action-primary">Enroll in edX101</a>
           <span class="tip">How to use Studio to build your course</span>
         </li>
       </ul>
-      </div>
-
-      <div class="feedback">
-        <h3 class="title">Contact us about Studio</h3>
-
-        <div class="copy">
-           <p>Have problems, questions, or suggestions about Studio? We're also here to listen to any feedback you want to share.</p>
-        </div>
-
-        <ul class="list-actions">
-          <li class="action-item">
-
-            <a href="http://help.edge.edx.org/discussion/new" class="action action-primary show-tender" title="Use our feedback tool, Tender, to share your feedback"><i class="icon-comments"></i> Contact Us</a>
-          </li>
-        </ul>
       </div>
     </section>
   </div>


### PR DESCRIPTION
cherry-picked from 12b79db6fc5dfd3ae9f3c558b151e004852eee7d

Move help links from `help.edge.edx.org` to the new studio-users Google Group. Change references to `Studio Help` to the group as well. Replace the `Contact Us` Tender widget with a `mailto` to the Google Group email address.

@jbau review pls.
