### PR TITLE
Change Ruby gemset to edx-platform

### DIFF
--- a/.ruby-gemset
+++ b/.ruby-gemset
@@ -1,1 +1,1 @@
-mitx
+edx-platform


### PR DESCRIPTION
The `create-dev-env.sh` script now creates a gemset called edx-
platform, so make sure that this matches.

The right thing to do would be to have `create-dev-env.sh` peek at
this file and create a gemset with the appropriate name.
