### PR TITLE
Install steps - Add numpy requirement in manual installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ environment), and Node has a library installer called
 Once you've got your languages and virtual environments set up, install
 the libraries like so:
 
+    $ pip install -r requirements/edx/pre.txt
     $ pip install -r requirements/edx/base.txt
     $ pip install -r requirements/edx/post.txt
     $ bundle install


### PR DESCRIPTION
Manual installation steps were missing the `requirements/edx/pre.txt` file. So when I followed instructions from the README, without using `scripts/create-dev-env.sh`, I ran `pip install -r requirements/edx/base.txt` directly, which used my system-wide numpy. It had a different version, which caused API versions mistmatch later on when I ran `make cms`, as `make cms` would automatically run pip with pre.txt and install a different version of numpy, _after_ base.txt and post.txt have been run through pip.

Hope this make sense : )
