### PR TITLE
Install steps - Fixes syntax of `update_templates` django command

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ CMS templates. Fortunately, `rake` will do all of this for you! Just run:
 
     $ rake django-admin[syncdb]
     $ rake django-admin[migrate]
-    $ rake django-admin[update_templates]
+    $ rake cms:update_templates
 
 If you are running these commands using the [`zsh`](http://www.zsh.org/) shell,
 zsh will assume that you are doing

--- a/scripts/create-dev-env.sh
+++ b/scripts/create-dev-env.sh
@@ -207,7 +207,8 @@ case `uname -s` in
         distro=`lsb_release -cs`
         case $distro in
             wheezy|jessie|maya|olivia|nadia|precise|quantal) 
-                warning "Debian support is not fully debugged. Assuming you have standard
+                warning "
+                        Debian support is not fully debugged. Assuming you have standard
                         development packages already working like scipy rvm, the 
                         installation should go fine, but this is still a work in progress.
 
@@ -219,7 +220,8 @@ case `uname -s` in
                 read dummy
                 sudo apt-get install git ;;  
             squeeze|lisa|katya|oneiric|natty|raring)
-                warning "It seems like you're using $distro which has been deprecated.
+                warning "
+                          It seems like you're using $distro which has been deprecated.
                           While we don't technically support this release, the install
                           script will probably still work.
 
@@ -499,7 +501,7 @@ mkdir "$BASE/data" || true
 
 rake django-admin[syncdb]
 rake django-admin[migrate]
-rake django-admin[update-templates]
+rake cms:update_templates
 # Configure Git
 
 output "Fixing your git default settings"


### PR DESCRIPTION
The command `rake django-admin[update_templates]`, mentioned in the installation instructions, didn't seem to work:

```
[edx-platform] antoviaque@antoviaque-laptop ~/prog/edx/edx-platform (master)
$ rake django-admin[update_templates]
django-admin.py update_templates --traceback --settings=lms.envs.dev --pythonpath=.
Unknown command: 'update_templates'
Type 'django-admin.py help' for usage.
rake aborted!
Command failed with status (1): [django-admin.py update_templates --traceba...]
[...]
Tasks: TOP => django-admin
(See full trace by running task with --trace)
```

Looking at the rakefiles, I saw `rake cms:update_templates`, which seemed to run fine for me (and both the LMS & CMS seemed to work fine afterwards) - not completely sure this is the same thing though: 

```
[edx-platform] antoviaque@antoviaque-laptop ~/prog/edx/edx-platform/rakefiles (master)
$ rake cms:update_templates
(in /home/antoviaque/prog/edx/edx-platform)
django-admin.py update_templates --traceback --settings=cms.envs.dev --pythonpath=.
2013-06-01 10:35:53,904 WARNING 9931 [xmodule.x_module] x_module.py:297 - No resource directory templates/customtag found when loading CustomTagDescriptor templates
2013-06-01 10:35:53,913 WARNING 9931 [xmodule.x_module] x_module.py:297 - No resource directory templates/poll found when loading PollDescriptor templates
2013-06-01 10:35:53,977 WARNING 9931 [xmodule.x_module] x_module.py:297 - No resource directory templates/foldit found when loading FolditDescriptor templates
2013-06-01 10:35:54,019 WARNING 9931 [xmodule.x_module] x_module.py:297 - No resource directory templates/abtest found when loading ABTestDescriptor templates
2013-06-01 10:35:55,171 WARNING 9931 [xmodule.x_module] x_module.py:297 - No resource directory templates/graphical_slider_tool found when loading GraphicalSliderToolDescriptor templates
```

(Also fixed a broken indentation, I can remove this part if needed, or isolate to a different patch.)
