### PR TITLE
Dependency installation fixes for Debian/Ubuntu

### DIFF
--- a/requirements/system/ubuntu/apt-packages.txt
+++ b/requirements/system/ubuntu/apt-packages.txt
@@ -30,7 +30,6 @@ libreadline6-dev
 mongodb
 nodejs
 coffeescript
-mysql
-libmysqlclient-dev
+mysql-client
 virtualenvwrapper
 libgeos-ruby1.8

--- a/scripts/create-dev-env.sh
+++ b/scripts/create-dev-env.sh
@@ -316,7 +316,7 @@ case `uname -s` in
                 http://stackoverflow.com/questions/9056008/installed-ruby-1-9-3-with-rvm-but-command-line-doesnt-show-ruby-v/9056395#9056395"
         sudo apt-get --purge remove ruby-rvm
         sudo rm -rf /usr/share/ruby-rvm /etc/rvmrc /etc/profile.d/rvm.sh
-        curl -sL https://get.rvm.io | bash -s stable --ruby --autolibs=enable --autodotfiles
+        curl -sL https://get.rvm.io | bash -s stable --ruby --autolibs=enable --auto-dotfiles
     ;;
 esac
         

--- a/scripts/create-dev-env.sh
+++ b/scripts/create-dev-env.sh
@@ -310,7 +310,7 @@ case `uname -s` in
         curl -sL get.rvm.io | bash -s -- --version 1.15.7
     ;;
 
-    squeeze|wheezy|jessie|maya|lisa|olivia|nadia|natty|oneiric|precise|quantal|raring)
+    [Ll]inux)
         warning "Setting up rvm on linux. This is a known pain point. If the script fails here
                 refer to the following stack overflow question: 
                 http://stackoverflow.com/questions/9056008/installed-ruby-1-9-3-with-rvm-but-command-line-doesnt-show-ruby-v/9056395#9056395"
@@ -392,7 +392,7 @@ if [[ `type -t mkvirtualenv` != "function" ]]; then
             source `which virtualenvwrapper.sh`
         ;;
 
-        squeeze|wheezy|jessie|maya|lisa|olivia|nadia|natty|oneiric|precise|quantal|raring)
+        [Ll]inux)
         if [[ -f "/etc/bash_completion.d/virtualenvwrapper" ]]; then
             source /etc/bash_completion.d/virtualenvwrapper
         else

--- a/scripts/create-dev-env.sh
+++ b/scripts/create-dev-env.sh
@@ -483,7 +483,7 @@ pip install -r $BASE/edx-platform/requirements/edx/pre.txt
 output "Installing edX requirements"
 # Install prereqs
 cd $BASE/edx-platform
-rvm use $RUBY_VER
+rvm use "$RUBY_VER@edx-platform"
 rake install_prereqs
 
 # Final dependecy


### PR DESCRIPTION
A series of small fixes for issues with dependency installations, which were making `scripts/create-dev-env.sh` crash, or skip some necessary dependencies. The test was on a VM with Ubuntu 12.04 LTS (precise), freshly installed for the occasion.
