### PR TITLE
hides latex compiler in settings tab by making previously specific css s...

### DIFF
--- a/cms/static/sass/views/_unit.scss
+++ b/cms/static/sass/views/_unit.scss
@@ -962,6 +962,6 @@ body.unit {
 }
 
 //  hides latex compiler button if settings mode is-active
-div.wrapper-comp-editor.is-inactive + div.launch-latex-compiler{
+div.wrapper-comp-editor.is-inactive ~ div.launch-latex-compiler{
  display: none;
 }


### PR DESCRIPTION
...ibling selector general enough to find and hide the appropriate div

@cahrens - here's the tiny fix. we're now loading some templates/scripts ahead of the latex div so the css wasn't being triggered. could you verify? 
