### PR TITLE
Run all tests on jenkins

### DIFF
--- a/doc/testing.md
+++ b/doc/testing.md
@@ -141,21 +141,36 @@ Very handy: if you uncomment the `pdb=1` line in `setup.cfg`, it will drop you i
 
 ### Running Javascript Unit Tests
 
-These commands start a development server with jasmine testing enabled, and launch your default browser
-pointing to those tests
+To run all of the javascript unit tests, use
 
-    rake browse_jasmine_{lms,cms}
+    rake jasmine
 
-To run the tests headless, you must install [phantomjs](http://phantomjs.org/download.html), then run:
+If the `phantomjs` binary is on the path, or the `PHANTOMJS_PATH` environment variable is
+set to point to it, then the tests will be run headless. Otherwise, they will be run in
+your default browser
 
-    rake phantomjs_jasmine_{lms,cms}
+    export PATH=/path/to/phantomjs:$PATH
+    rake jasmine  # Runs headless
 
-If the `phantomjs` binary is not on the path, set the `PHANTOMJS_PATH` environment variable to point to it
+or
 
-    PHANTOMJS_PATH=/path/to/phantomjs rake phantomjs_jasmine_{lms,cms}
+    PHANTOMJS_PATH=/path/to/phantomjs rake jasmine  # Runs headless
 
-Once you have run the `rake` command, your browser should open to
-to `http://localhost/_jasmine/`, which displays the test results.
+or
+
+    rake jasmine  # Runs in browser
+
+You can also force a run using phantomjs or the browser using the commands
+
+    rake jasmine:browser  # Runs in browser
+    rake jasmine:phantomjs  # Runs headless
+
+You can run tests for a specific subsystems as well
+
+    rake jasmine:lms  # Runs all lms javascript unit tests using the default method
+    rake jasmine:cms:browser  # Runs all cms javascript unit tests in the browser
+
+Use `rake -T` to get a list of all available subsystems
 
 **Troubleshooting**: If you get an error message while running the `rake` task,
 try running `bundle install` to install the required ruby gems.

--- a/jenkins/test.sh
+++ b/jenkins/test.sh
@@ -70,23 +70,11 @@ rake clobber
 rake pep8 > pep8.log || cat pep8.log
 rake pylint > pylint.log || cat pylint.log
 
-TESTS_FAILED=0
-
-# Run the python unit tests
-rake test_cms || TESTS_FAILED=1
-rake test_lms || TESTS_FAILED=1
-rake test_common/lib/capa || TESTS_FAILED=1
-rake test_common/lib/xmodule || TESTS_FAILED=1
-
-# Run the javascript unit tests
-rake phantomjs_jasmine_lms || TESTS_FAILED=1
-rake phantomjs_jasmine_cms || TESTS_FAILED=1
-rake phantomjs_jasmine_common/lib/xmodule || TESTS_FAILED=1
-rake phantomjs_jasmine_common/static/coffee || TESTS_FAILED=1
+# Run the unit tests (use phantomjs for javascript unit tests)
+rake test
 
 rake coverage:xml coverage:html
 
-[ $TESTS_FAILED == '0' ]
 rake autodeploy_properties
 
 github_status state:success "passed"

--- a/rakefiles/deprecated.rake
+++ b/rakefiles/deprecated.rake
@@ -1,0 +1,23 @@
+
+require 'colorize'
+
+def deprecated(deprecated, deprecated_by)
+    task deprecated do
+        puts("Task #{deprecated} has been deprecated. Use #{deprecated_by} instead. Waiting 5 seconds...".red)
+        sleep(5)
+        Rake::Task[deprecated_by].invoke
+    end
+end
+
+[:lms, :cms].each do |system|
+    deprecated("browse_jasmine_#{system}", "jasmine:#{system}:browser")
+    deprecated("phantomjs_jasmine_#{system}", "jasmine:#{system}:phantomjs")
+end
+
+Dir["common/lib/*"].select{|lib| File.directory?(lib)}.each do |lib|
+    deprecated("browse_jasmine_#{lib}", "jasmine:#{lib}:browser")
+    deprecated("phantomjs_jasmine_#{lib}", "jasmine:#{lib}:phantomjs")
+end
+
+deprecated("browse_jasmine_discussion", "jasmine:common/static/coffee:browser")
+deprecated("phantomjs_jasmine_discussion", "jasmine:common/static/coffee:phantomjs")

--- a/rakefiles/tests.rake
+++ b/rakefiles/tests.rake
@@ -1,8 +1,5 @@
-
 # Set up the clean and clobber tasks
 CLOBBER.include(REPORT_DIR, 'test_root/*_repo', 'test_root/staticfiles')
-
-$failed_tests = 0
 
 def run_under_coverage(cmd, root)
     cmd0, cmd_rest = cmd.split(" ", 2)
@@ -17,12 +14,7 @@ def run_tests(system, report_dir, test_id=nil, stop_on_failure=true)
     dirs = Dir["common/djangoapps/*"] + Dir["#{system}/djangoapps/*"]
     test_id = dirs.join(' ') if test_id.nil? or test_id == ''
     cmd = django_admin(system, :test, 'test', '--logging-clear-handlers', test_id)
-    sh(run_under_coverage(cmd, system)) do |ok, res|
-        if !ok and stop_on_failure
-            abort "Test failed!"
-        end
-        $failed_tests += 1 unless ok
-    end
+    test_sh(run_under_coverage(cmd, system))
 end
 
 def run_acceptance_tests(system, report_dir, harvest_args)
@@ -38,7 +30,7 @@ def run_acceptance_tests(system, report_dir, harvest_args)
     end
     sh(django_admin(system, 'acceptance', 'syncdb', '--noinput'))
     sh(django_admin(system, 'acceptance', 'migrate', '--noinput'))
-    sh(django_admin(system, 'acceptance', 'harvest', '--debug-mode', '--tag -skip', harvest_args))
+    test_sh(django_admin(system, 'acceptance', 'harvest', '--debug-mode', '--tag -skip', harvest_args))
 end
 
 
@@ -55,13 +47,13 @@ TEST_TASK_DIRS = []
 
     # Per System tasks
     desc "Run all django tests on our djangoapps for the #{system}"
-    task "test_#{system}", [:test_id, :stop_on_failure] => ["clean_test_files", :predjango, "#{system}:gather_assets:test", "fasttest_#{system}"]
+    task "test_#{system}", [:test_id] => ["clean_test_files", :predjango, "#{system}:gather_assets:test", "fasttest_#{system}"]
 
     # Have a way to run the tests without running collectstatic -- useful when debugging without
     # messing with static files.
-    task "fasttest_#{system}", [:test_id, :stop_on_failure] => [report_dir, :install_prereqs, :predjango] do |t, args|
-        args.with_defaults(:stop_on_failure => 'true', :test_id => nil)
-        run_tests(system, report_dir, args.test_id, args.stop_on_failure)
+    task "fasttest_#{system}", [:test_id] => [report_dir, :install_prereqs, :predjango] do |t, args|
+        args.with_defaults(:test_id => nil)
+        run_tests(system, report_dir, args.test_id)
     end
 
     # Run acceptance tests
@@ -89,9 +81,7 @@ Dir["common/lib/*"].select{|lib| File.directory?(lib)}.each do |lib|
     task task_name => report_dir do
         ENV['NOSE_XUNIT_FILE'] = File.join(report_dir, "nosetests.xml")
         cmd = "nosetests #{lib}"
-        sh(run_under_coverage(cmd, lib)) do |ok, res|
-            $failed_tests += 1 unless ok
-        end
+        test_sh(run_under_coverage(cmd, lib))
     end
     TEST_TASK_DIRS << lib
 
@@ -107,17 +97,11 @@ TEST_TASK_DIRS.each do |dir|
     report_dir = report_dir_path(dir)
     directory report_dir
     task :report_dirs => [REPORT_DIR, report_dir]
+    task :test => "test_#{dir}"
 end
 
-task :test do
-    TEST_TASK_DIRS.each do |dir|
-        Rake::Task["test_#{dir}"].invoke(nil, false)
-    end
-
-    if $failed_tests > 0
-        abort "Tests failed!"
-    end
-end
+desc "Run all tests"
+task :test
 
 namespace :coverage do
     desc "Build the html coverage reports"


### PR DESCRIPTION
We used to specify specific rake test tasks so that we could run all of
them even if early ones failed. However, that meant that as new tasks
were added, they weren't being run on jenkins.

Now, there is a facility in the rake scripts so that tests can run using
the test_sh function, which will delay failure until the end of the rake
run, unless the TESTS_FAIL_FAST environment variable is set.

Furthermore, this reorganizes the jasmine test tasks so that we can run
those as part of `rake test` as well.

@jzoldak @brianhw @nedbat: Review?
