### PR TITLE
Expose site-wide anonymized ids to HTML module

### DIFF
--- a/common/lib/xmodule/xmodule/html_module.py
+++ b/common/lib/xmodule/xmodule/html_module.py
@@ -32,6 +32,8 @@ class HtmlModule(HtmlFields, XModule):
     css = {'scss': [resource_string(__name__, 'css/html/display.scss')]}
 
     def get_html(self):
+        if self.system.anonymous_student_id: 
+            return self.data.replace("%%USER_ID%%", self.system.anonymous_student_id)
         return self.data
 
 

--- a/common/lib/xmodule/xmodule/tests/test_html_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_html_module.py
@@ -1,0 +1,40 @@
+import unittest
+
+from mock import Mock
+
+from xmodule.html_module import HtmlModule
+from xmodule.modulestore import Location
+
+from . import test_system
+
+class HtmlModuleSubstitutionTestCase(unittest.TestCase):
+    location = Location(["i4x", "edX", "toy", "html", "simple_html"])
+    descriptor = Mock()
+
+    def test_substitution_works(self):
+        sample_xml = '''%%USER_ID%%'''
+        module_data = {'data': sample_xml}
+        module_system = test_system()
+        module = HtmlModule(module_system, self.location, self.descriptor, module_data)
+        self.assertEqual(module.get_html(), str(module_system.anonymous_student_id))
+
+
+    def test_substitution_without_magic_string(self):
+        sample_xml = '''
+            <html>
+                <p>Hi USER_ID!11!</p>
+            </html>
+        '''
+        module_data = {'data': sample_xml}
+        module = HtmlModule(test_system(), self.location, self.descriptor, module_data)
+        self.assertEqual(module.get_html(), sample_xml)
+
+
+    def test_substitution_without_anonymous_student_id(self):
+        sample_xml = '''%%USER_ID%%'''
+        module_data = {'data': sample_xml}
+        module_system = test_system()
+        module_system.anonymous_student_id = None
+        module = HtmlModule(module_system, self.location, self.descriptor, module_data)
+        self.assertEqual(module.get_html(), sample_xml)
+


### PR DESCRIPTION
Co-authored-by: Nate Hardison natehardison@gmail.com

@cpennington and @sefk, please.

This doesn't do a per-course secret and it doesn't generate a new unique hash per user, but today I was told this would be sufficient for our one course that needs this, for the time being. I can't afford to spend any more time on doing it right at the moment, so we'd like to pull this in and move on, and circle back around to building a general mechanism for anonymization later in the Summer.
