### PR TITLE
Fix bug STUD-103. The url base for about page links needs to be www.edx....

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_utils.py
@@ -4,6 +4,7 @@ import mock
 import collections
 import copy
 from django.test import TestCase
+from django.test.utils import override_settings
 from xmodule.modulestore.tests.factories import CourseFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 
@@ -11,11 +12,27 @@ from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 class LMSLinksTestCase(TestCase):
     """ Tests for LMS links. """
     def about_page_test(self):
-        """ Get URL for about page. """
+        """ Get URL for about page, no marketing site """
+        # default for ENABLE_MKTG_SITE is False.
+        self.assertEquals(self.get_about_page_link(), "//localhost:8000/courses/mitX/101/test/about")
+
+    @override_settings(MKTG_URLS={'ROOT': 'dummy-root'})
+    def about_page_marketing_site_test(self):
+        """ Get URL for about page, marketing root present. """
+        with mock.patch.dict('django.conf.settings.MITX_FEATURES', {'ENABLE_MKTG_SITE': True}):
+            self.assertEquals(self.get_about_page_link(), "//dummy-root/courses/mitX/101/test/about")
+        with mock.patch.dict('django.conf.settings.MITX_FEATURES', {'ENABLE_MKTG_SITE': False}):
+            self.assertEquals(self.get_about_page_link(), "//localhost:8000/courses/mitX/101/test/about")
+
+    @override_settings(LMS_BASE=None)
+    def about_page_no_lms_base_test(self):
+        """ No LMS_BASE, nor is ENABLE_MKTG_SITE True """
+        self.assertEquals(self.get_about_page_link(), None)
+
+    def get_about_page_link(self):
         location = 'i4x', 'mitX', '101', 'course', 'test'
         utils.get_course_id = mock.Mock(return_value="mitX/101/test")
-        link = utils.get_lms_link_for_about_page(location)
-        self.assertEquals(link, "//localhost:8000/courses/mitX/101/test/about")
+        return utils.get_lms_link_for_about_page(location)
 
     def lms_link_test(self):
         """ Tests get_lms_link_for_item. """

--- a/cms/djangoapps/contentstore/tests/test_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_utils.py
@@ -30,6 +30,7 @@ class LMSLinksTestCase(TestCase):
         self.assertEquals(self.get_about_page_link(), None)
 
     def get_about_page_link(self):
+        """ create mock course and return the about page link """
         location = 'i4x', 'mitX', '101', 'course', 'test'
         utils.get_course_id = mock.Mock(return_value="mitX/101/test")
         return utils.get_lms_link_for_about_page(location)

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -107,9 +107,18 @@ def get_lms_link_for_about_page(location):
     """
     Returns the url to the course about page from the location tuple.
     """
-    if settings.LMS_BASE is not None:
-        lms_link = "//{lms_base}/courses/{course_id}/about".format(
-            lms_base=settings.LMS_BASE,
+    if settings.MITX_FEATURES.get('ENABLE_MKTG_SITE', False):
+        # Root will be "www.edx.org". The complete URL will still not be exactly correct,
+        # but redirects exist from www.edx.org to get to the drupal course about page URL.
+        about_base = settings.MKTG_URLS.get('ROOT')
+    elif settings.LMS_BASE is not None:
+        about_base = settings.LMS_BASE
+    else:
+        about_base = None
+
+    if about_base is not None:
+        lms_link = "//{about_base_url}/courses/{course_id}/about".format(
+            about_base_url=about_base,
             course_id=get_course_id(location)
         )
     else:


### PR DESCRIPTION
...org for Drupal site, vs. LMS_BASE which is used for Studio. Note that the complete URL is still not correct, but a redirect exists to take it to the new location.

Here is my code coverage result:
Diff Coverage

Coverage Report: reports/cms/coverage.xml

Diff: master

Source File Diff Coverage (%)   Missing Line(s)
cms/djangoapps/contentstore/utils.py    100%  
cms/djangoapps/contentstore/tests/test_utils.py 100%  
Total: 24 line(s)
Missing: 0 line(s)
Coverage: 100%
