### PR TITLE
Specify UTF-8 encoding when loading Mako template

### DIFF
--- a/common/djangoapps/mitxmako/makoloader.py
+++ b/common/djangoapps/mitxmako/makoloader.py
@@ -44,7 +44,11 @@ class MakoLoader(object):
 
         if source.startswith("## mako\n"):
             # This is a mako template
-            template = Template(filename=file_path, module_directory=self.module_directory, uri=template_name)
+            template = Template(filename=file_path,
+                                module_directory=self.module_directory,
+                                input_encoding='utf-8',
+                                output_encoding='utf-8',
+                                uri=template_name)
             return template, None
         else:
             # This is a regular template


### PR DESCRIPTION
For @cpennington and/or @nedbat, since yours are the names I see in this file's log :-)

When loading a Mako template from a Django template, the file encoding of the Mako template was left unspecified. This happens in `lms/templates/main_django.html`, for example, which is the base template used to render the wiki.

Most of the time, this isn't an issue. The problem we saw was happening in https://github.com/edx/edx-platform/blob/nate/fix-mako-templ-encoding/lms/templates/main_django.html#L32, when the `lms/templates/footer.html` template is loaded. That template happens to be a UTF-8 template, because of the curly quote in [this line](https://github.com/edx/edx-platform/blob/nate/fix-mako-templ-encoding/lms/templates/footer.html#L41). Anyway, I'd get an error that looks like this:

![screen shot 2013-06-03 at 5 40 18 pm](https://f.cloud.github.com/assets/1433806/603024/5e10405a-ccaf-11e2-9011-3949fceac8fd.png)

Granted, this is with our theming settings enabled, since I'm trying to theme the `main_django.html` template right now. I narrowed the problem down to the `enable_theme` function in [`lms/envs/common.py`](https://github.com/edx/edx-platform/blob/nate/fix-mako-templ-encoding/lms/envs/common.py#L726), which toggles an `MITX_FEATURE` and adds theming paths to `TEMPLATE_DIRS`, `MAKO_TEMPLATES['main']`, and `STATICFILES_DIRS`.

@jbau and I worked for a long time to try and reproduce this off of `master`, and we couldn't get anything reliable. As far as we can tell, it may be some weird path through the Mako cache that's causing this, and for some reason adding the theme template paths to the Mako lookup paths triggers it. Regardless, this patch fixes the problem for us.

Another weird thing to note is that this problem _still_ occurs even if the `{% include "footer.html" %}` is wrapped in a conditional that doesn't trigger, like:

```
{% if MITX_FEATURES.USE_CUSTOM_THEME %}
    {% include "theme-footer.html" %}
{% else %}
    {% include "footer.html" %}
{% endif %}
```

Removing the `{% include "footer.html" %}` line solves the problem though. This is probably because Django just renders the `include` block anyway (?).
