### PR TITLE
Add comment to dynamically-generated asset files

### DIFF
--- a/common/djangoapps/mitxmako/management/commands/preprocess_assets.py
+++ b/common/djangoapps/mitxmako/management/commands/preprocess_assets.py
@@ -14,6 +14,7 @@ from django.core.management.base import NoArgsCommand
 from django.conf import settings
 
 from mako.template import Template
+import textwrap
 
 class Command(NoArgsCommand):
     """
@@ -61,5 +62,12 @@ class Command(NoArgsCommand):
         result in `outfile`.
         """
         with open(outfile, "w") as _outfile:
+            _outfile.write(textwrap.dedent("""\
+            /*
+             * This file is dynamically generated and ignored by Git.
+             * DO NOT MAKE CHANGES HERE. Instead, go edit its template:
+             * %s
+             */
+            """ % infile))
             _outfile.write(Template(filename=str(infile)).render(env=self.__context()))
 


### PR DESCRIPTION
To avoid confusion about where these files come from, add a header
comment upon preprocessing that warns people to not modify the
generated files directly, and points them to the appropriate
template file.

For @cpennington and @marcotuts, based on our conversation this morning.
