### PR TITLE
Jonahstanley/fix codemirror tests

### DIFF
--- a/cms/djangoapps/contentstore/features/advanced-settings.feature
+++ b/cms/djangoapps/contentstore/features/advanced-settings.feature
@@ -11,8 +11,6 @@ Feature: Advanced (manual) course policy
     Given I am on the Advanced Course Settings page in Studio
     Then the settings are alphabetized
 
-  # Skipped because Ubuntu ChromeDriver cannot click notification "Cancel"
-  @skip
   Scenario: Test cancel editing key value
     Given I am on the Advanced Course Settings page in Studio
     When I edit the value of a policy key
@@ -21,8 +19,6 @@ Feature: Advanced (manual) course policy
     And I reload the page
     Then the policy key value is unchanged
 
-  # Skipped because Ubuntu ChromeDriver cannot click notification "Save"
-  @skip
   Scenario: Test editing key value
     Given I am on the Advanced Course Settings page in Studio
     When I edit the value of a policy key and save
@@ -30,8 +26,6 @@ Feature: Advanced (manual) course policy
     And I reload the page
     Then the policy key value is changed
 
-  # Skipped because Ubuntu ChromeDriver cannot edit CodeMirror input
-  @skip
   Scenario: Test how multi-line input appears
     Given I am on the Advanced Course Settings page in Studio
     When I create a JSON object as a value
@@ -39,8 +33,6 @@ Feature: Advanced (manual) course policy
     And I reload the page
     Then it is displayed as formatted
 
-  # Skipped because Ubuntu ChromeDriver cannot edit CodeMirror input
-  @skip
   Scenario: Test automatic quoting of non-JSON values
     Given I am on the Advanced Course Settings page in Studio
     When I create a non-JSON value not in quotes

--- a/cms/djangoapps/contentstore/features/advanced-settings.py
+++ b/cms/djangoapps/contentstore/features/advanced-settings.py
@@ -42,12 +42,8 @@ def edit_the_value_of_a_policy_key(step):
     It is hard to figure out how to get into the CodeMirror
     area, so cheat and do it from the policy key field :)
     """
-    #world.css_find(".CodeMirror")[12].click()
-    all_mirrors = world.css_find(".CodeMirror")
-    for codeMirror in all_mirrors:
-        if codeMirror.text == DISPLAY_NAME_VALUE:
-            codeMirror.click()
-    g = world.css_find("div.CodeMirror.CodeMirror-focused > div > textarea")[0]
+    world.css_find(".CodeMirror")[get_index_of(DISPLAY_NAME_KEY)].click()
+    g = world.css_find("div.CodeMirror.CodeMirror-focused > div > textarea")
     g._element.send_keys(Keys.ARROW_LEFT, ' ', 'X')
 
 
@@ -129,11 +125,8 @@ def get_display_name_value():
 
 def change_display_name_value(step, new_value):
 
-    all_mirrors = world.css_find(".CodeMirror")
-    for codeMirror in all_mirrors:
-        if codeMirror.text == DISPLAY_NAME_VALUE:
-            codeMirror.click()
-    g = world.css_find("div.CodeMirror.CodeMirror-focused > div > textarea")[0]
+    world.css_find(".CodeMirror")[get_index_of(DISPLAY_NAME_KEY)].click()
+    g = world.css_find("div.CodeMirror.CodeMirror-focused > div > textarea")
     display_name = get_display_name_value()
     for count in range(len(display_name)):
         g._element.send_keys(Keys.END, Keys.BACK_SPACE)

--- a/cms/djangoapps/contentstore/features/advanced-settings.py
+++ b/cms/djangoapps/contentstore/features/advanced-settings.py
@@ -42,8 +42,13 @@ def edit_the_value_of_a_policy_key(step):
     It is hard to figure out how to get into the CodeMirror
     area, so cheat and do it from the policy key field :)
     """
-    e = world.css_find(KEY_CSS)[get_index_of(DISPLAY_NAME_KEY)]
-    e._element.send_keys(Keys.TAB, Keys.END, Keys.ARROW_LEFT, ' ', 'X')
+    #world.css_find(".CodeMirror")[12].click()
+    all_mirrors = world.css_find(".CodeMirror")
+    for codeMirror in all_mirrors:
+        if codeMirror.text == DISPLAY_NAME_VALUE:
+            codeMirror.click()
+    g = world.css_find("div.CodeMirror.CodeMirror-focused > div > textarea")[0]
+    g._element.send_keys(Keys.ARROW_LEFT, ' ', 'X')
 
 
 @step(u'I edit the value of a policy key and save$')
@@ -123,10 +128,15 @@ def get_display_name_value():
 
 
 def change_display_name_value(step, new_value):
-    e = world.css_find(KEY_CSS)[get_index_of(DISPLAY_NAME_KEY)]
+
+    all_mirrors = world.css_find(".CodeMirror")
+    for codeMirror in all_mirrors:
+        if codeMirror.text == DISPLAY_NAME_VALUE:
+            codeMirror.click()
+    g = world.css_find("div.CodeMirror.CodeMirror-focused > div > textarea")[0]
     display_name = get_display_name_value()
     for count in range(len(display_name)):
-        e._element.send_keys(Keys.TAB, Keys.END, Keys.BACK_SPACE)
+        g._element.send_keys(Keys.END, Keys.BACK_SPACE)
         # Must delete "" before typing the JSON value
-    e._element.send_keys(Keys.TAB, Keys.END, Keys.BACK_SPACE, Keys.BACK_SPACE, new_value)
+    g._element.send_keys(Keys.END, Keys.BACK_SPACE, Keys.BACK_SPACE, new_value)
     press_the_notification_button(step, "Save")


### PR DESCRIPTION
Suggested Reviewers: @jzoldak  @cahrens 

Fixed code mirror editing issues and now the tests run successfully

The fix:

It turns out that when the code mirror area that we want to edit is focused, the place to edit can be found through:
div.CodeMirror.CodeMirror-focused > div > textarea
Keys can be sent to the element corresponding to this css selector.

In order to focus on the correct value, the element is found through the index of the key (which is unique).  ".CodeMirror" is the list of all of the code mirror objects.  Since there is a one-to-one correspondence between the keys and values, the index of the key is the same as the index of the value.
