### PR TITLE
Feature/cdodge/allow setting of session cookie name

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -92,7 +92,7 @@ CACHES = ENV_TOKENS['CACHES']
 SESSION_COOKIE_DOMAIN = ENV_TOKENS.get('SESSION_COOKIE_DOMAIN')
 
 # allow for environments to specify what cookie name our login subsystem should use
-# this is to fix a bug regarding simultaneous loging between edx.org and edge.edx.org which can
+# this is to fix a bug regarding simultaneous logins between edx.org and edge.edx.org which can
 # happen with some browsers (e.g. Firefox)
 if ENV_TOKENS.get('SESSION_COOKIE_NAME', None):
     SESSION_COOKIE_NAME = ENV_TOKENS.get('SESSION_COOKIE_NAME')

--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -91,6 +91,12 @@ CACHES = ENV_TOKENS['CACHES']
 
 SESSION_COOKIE_DOMAIN = ENV_TOKENS.get('SESSION_COOKIE_DOMAIN')
 
+# allow for environments to specify what cookie name our login subsystem should use
+# this is to fix a bug regarding simultaneous loging between edx.org and edge.edx.org which can
+# happen with some browsers (e.g. Firefox)
+if ENV_TOKENS.get('SESSION_COOKIE_NAME', None):
+    SESSION_COOKIE_NAME = ENV_TOKENS.get('SESSION_COOKIE_NAME')
+
 #Email overrides
 DEFAULT_FROM_EMAIL = ENV_TOKENS.get('DEFAULT_FROM_EMAIL', DEFAULT_FROM_EMAIL)
 DEFAULT_FEEDBACK_EMAIL = ENV_TOKENS.get('DEFAULT_FEEDBACK_EMAIL', DEFAULT_FEEDBACK_EMAIL)

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -103,7 +103,7 @@ SITE_NAME = ENV_TOKENS['SITE_NAME']
 SESSION_COOKIE_DOMAIN = ENV_TOKENS.get('SESSION_COOKIE_DOMAIN')
 
 # allow for environments to specify what cookie name our login subsystem should use
-# this is to fix a bug regarding simultaneous loging between edx.org and edge.edx.org which can
+# this is to fix a bug regarding simultaneous logins between edx.org and edge.edx.org which can
 # happen with some browsers (e.g. Firefox)
 if ENV_TOKENS.get('SESSION_COOKIE_NAME', None):
     SESSION_COOKIE_NAME = ENV_TOKENS.get('SESSION_COOKIE_NAME')

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -102,6 +102,12 @@ with open(ENV_ROOT / CONFIG_PREFIX + "env.json") as env_file:
 SITE_NAME = ENV_TOKENS['SITE_NAME']
 SESSION_COOKIE_DOMAIN = ENV_TOKENS.get('SESSION_COOKIE_DOMAIN')
 
+# allow for environments to specify what cookie name our login subsystem should use
+# this is to fix a bug regarding simultaneous loging between edx.org and edge.edx.org which can
+# happen with some browsers (e.g. Firefox)
+if ENV_TOKENS.get('SESSION_COOKIE_NAME', None):
+    SESSION_COOKIE_NAME = ENV_TOKENS.get('SESSION_COOKIE_NAME')
+
 BOOK_URL = ENV_TOKENS['BOOK_URL']
 MEDIA_URL = ENV_TOKENS['MEDIA_URL']
 LOG_DIR = ENV_TOKENS['LOG_DIR']


### PR DESCRIPTION
Since this is a change in aws.py which is the configuration top-level file for production environments, we're not going to be able to test locally. @e0d @singingwolfboy can you code review and I'll see if I can deploy to stage to at least make sure it doesn't blow up. However we can't really test the bug fix in stage since the domain names there does not overlap, e.g. (stage-edge.edx.org and stage.edx.org), which is unfortunate.
