### PR TITLE
Jonahstanley/fix alert tests

### DIFF
--- a/cms/djangoapps/contentstore/features/section.feature
+++ b/cms/djangoapps/contentstore/features/section.feature
@@ -29,6 +29,6 @@ Feature: Create Section
   Scenario: Delete section
     Given I have opened a new course in Studio
     And I have added a new section
-    When I confirm all alerts
+    When I will confirm all alerts
     And I press the "section" delete icon
     Then the section does not exist

--- a/cms/djangoapps/contentstore/features/section.feature
+++ b/cms/djangoapps/contentstore/features/section.feature
@@ -26,11 +26,9 @@ Feature: Create Section
     And I save a new section release date
     Then the section release date is updated
 
-  # Skipped because Ubuntu ChromeDriver hangs on alert
-  @skip
   Scenario: Delete section
     Given I have opened a new course in Studio
     And I have added a new section
-    When I press the "section" delete icon
-    And I confirm the alert
+    When I confirm all alerts
+    And I press the "section" delete icon
     Then the section does not exist

--- a/cms/djangoapps/contentstore/features/section.py
+++ b/cms/djangoapps/contentstore/features/section.py
@@ -69,8 +69,8 @@ def i_see_complete_section_name_with_quote_in_editor(step):
 
 @step('the section does not exist$')
 def section_does_not_exist(step):
-    css = 'span.section-name-span'
-    assert world.browser.is_element_not_present_by_css(css)
+    css = 'h3[data-name="My Section"]'
+    assert world.is_css_not_present(css)
 
 
 @step('I see a release date for my section$')

--- a/cms/djangoapps/contentstore/features/studio-overview-togglesection.feature
+++ b/cms/djangoapps/contentstore/features/studio-overview-togglesection.feature
@@ -5,29 +5,27 @@ Feature: Overview Toggle Section
 
 	Scenario: The default layout for the overview page is to show sections in expanded view
 		Given I have a course with multiple sections
-    When I navigate to the course overview page
-    Then I see the "Collapse All Sections" link
-    And all sections are expanded
+        When I navigate to the course overview page
+        Then I see the "Collapse All Sections" link
+        And all sections are expanded
 
 	Scenario: Expand /collapse for a course with no sections
 		Given I have a course with no sections
-    When I navigate to the course overview page
-    Then I do not see the "Collapse All Sections" link
+        When I navigate to the course overview page
+        Then I do not see the "Collapse All Sections" link
 
 	Scenario: Collapse link appears after creating first section of a course
 		Given I have a course with no sections
-    When I navigate to the course overview page
-    And I add a section
-    Then I see the "Collapse All Sections" link
-    And all sections are expanded
+        When I navigate to the course overview page
+        And I add a section
+        Then I see the "Collapse All Sections" link
+        And all sections are expanded
 
-    # Skipped because Ubuntu ChromeDriver hangs on alert
-    @skip
 	Scenario: Collapse link is not removed after last section of a course is deleted
 		Given I have a course with 1 section
-    And I navigate to the course overview page
-    When I press the "section" delete icon
-    And I confirm the alert
+        And I navigate to the course overview page
+        When I confirm all alerts
+        And I press the "section" delete icon
 		Then I see the "Collapse All Sections" link
 
 	Scenario: Collapsing all sections when all sections are expanded

--- a/cms/djangoapps/contentstore/features/studio-overview-togglesection.feature
+++ b/cms/djangoapps/contentstore/features/studio-overview-togglesection.feature
@@ -24,7 +24,7 @@ Feature: Overview Toggle Section
     Scenario: Collapse link is not removed after last section of a course is deleted
         Given I have a course with 1 section
         And I navigate to the course overview page
-        When I confirm all alerts
+        When I will confirm all alerts
         And I press the "section" delete icon
         Then I see the "Collapse All Sections" link
 

--- a/cms/djangoapps/contentstore/features/studio-overview-togglesection.feature
+++ b/cms/djangoapps/contentstore/features/studio-overview-togglesection.feature
@@ -1,59 +1,59 @@
 Feature: Overview Toggle Section
-	In order to quickly view the details of a course's section or to scan the inventory of sections
+    In order to quickly view the details of a course's section or to scan the inventory of sections
     As a course author
     I want to toggle the visibility of each section's  subsection details in the overview listing
 
-	Scenario: The default layout for the overview page is to show sections in expanded view
-		Given I have a course with multiple sections
+    Scenario: The default layout for the overview page is to show sections in expanded view
+        Given I have a course with multiple sections
         When I navigate to the course overview page
         Then I see the "Collapse All Sections" link
         And all sections are expanded
 
-	Scenario: Expand /collapse for a course with no sections
-		Given I have a course with no sections
+    Scenario: Expand /collapse for a course with no sections
+        Given I have a course with no sections
         When I navigate to the course overview page
         Then I do not see the "Collapse All Sections" link
 
-	Scenario: Collapse link appears after creating first section of a course
-		Given I have a course with no sections
+    Scenario: Collapse link appears after creating first section of a course
+        Given I have a course with no sections
         When I navigate to the course overview page
         And I add a section
         Then I see the "Collapse All Sections" link
         And all sections are expanded
 
-	Scenario: Collapse link is not removed after last section of a course is deleted
-		Given I have a course with 1 section
+    Scenario: Collapse link is not removed after last section of a course is deleted
+        Given I have a course with 1 section
         And I navigate to the course overview page
         When I confirm all alerts
         And I press the "section" delete icon
-		Then I see the "Collapse All Sections" link
+        Then I see the "Collapse All Sections" link
 
-	Scenario: Collapsing all sections when all sections are expanded
-		Given I navigate to the courseware page of a course with multiple sections
-		And all sections are expanded
-		When I click the "Collapse All Sections" link
-		Then I see the "Expand All Sections" link
-		And all sections are collapsed
+    Scenario: Collapsing all sections when all sections are expanded
+        Given I navigate to the courseware page of a course with multiple sections
+        And all sections are expanded
+        When I click the "Collapse All Sections" link
+        Then I see the "Expand All Sections" link
+        And all sections are collapsed
 
-	Scenario: Collapsing all sections when 1 or more sections are already collapsed
-		Given I navigate to the courseware page of a course with multiple sections
-		And all sections are expanded
-		When I collapse the first section
-		And I click the "Collapse All Sections" link
-		Then I see the "Expand All Sections" link
-		And all sections are collapsed
+    Scenario: Collapsing all sections when 1 or more sections are already collapsed
+        Given I navigate to the courseware page of a course with multiple sections
+        And all sections are expanded
+        When I collapse the first section
+        And I click the "Collapse All Sections" link
+        Then I see the "Expand All Sections" link
+        And all sections are collapsed
 
-	Scenario: Expanding all sections when all sections are collapsed
-		Given I navigate to the courseware page of a course with multiple sections
-		And I click the "Collapse All Sections" link
-		When I click the "Expand All Sections" link
-		Then I see the "Collapse All Sections" link
-		And all sections are expanded
+    Scenario: Expanding all sections when all sections are collapsed
+        Given I navigate to the courseware page of a course with multiple sections
+        And I click the "Collapse All Sections" link
+        When I click the "Expand All Sections" link
+        Then I see the "Collapse All Sections" link
+        And all sections are expanded
 
-	Scenario: Expanding all sections when 1 or more sections are already expanded
-		Given I navigate to the courseware page of a course with multiple sections
-		And I click the "Collapse All Sections" link
-		When I expand the first section
-		And I click the "Expand All Sections" link
-		Then I see the "Collapse All Sections" link
-		And all sections are expanded
+    Scenario: Expanding all sections when 1 or more sections are already expanded
+        Given I navigate to the courseware page of a course with multiple sections
+        And I click the "Collapse All Sections" link
+        When I expand the first section
+        And I click the "Expand All Sections" link
+        Then I see the "Collapse All Sections" link
+        And all sections are expanded

--- a/cms/djangoapps/contentstore/features/subsection.feature
+++ b/cms/djangoapps/contentstore/features/subsection.feature
@@ -36,6 +36,6 @@ Feature: Create Subsection
     Given I have opened a new course section in Studio
     And I have added a new subsection
     And I see my subsection on the Courseware page
-    When I confirm all alerts
+    When I will confirm all alerts
     And I press the "subsection" delete icon
     Then the subsection does not exist

--- a/cms/djangoapps/contentstore/features/subsection.feature
+++ b/cms/djangoapps/contentstore/features/subsection.feature
@@ -32,12 +32,10 @@ Feature: Create Subsection
     And I reload the page
     Then I see the correct dates
 
-  # Skipped because Ubuntu ChromeDriver hangs on alert
-  @skip
   Scenario: Delete a subsection
     Given I have opened a new course section in Studio
     And I have added a new subsection
     And I see my subsection on the Courseware page
-    When I press the "subsection" delete icon
-    And I confirm the alert
+    When I confirm all alerts
+    And I press the "subsection" delete icon
     Then the subsection does not exist

--- a/common/djangoapps/terrain/steps.py
+++ b/common/djangoapps/terrain/steps.py
@@ -159,3 +159,18 @@ def registered_edx_user(step, uname):
 @step(u'All dialogs should be closed$')
 def dialogs_are_closed(step):
     assert world.dialogs_closed()
+
+
+@step('I confirm all alerts')
+def i_confirm_with_ok(step):
+    world.browser.execute_script('window.confirm = function(){return true;} ; window.alert = function(){return;}')
+
+
+@step('I dismiss all alerts')
+def i_dismiss_with_ok(step):
+    world.browser.execute_script('window.confirm = function(){return false;}')
+
+
+@step('I answer all prompts with "([^"]*)"')
+def i_answer_prompts_with(step, prompt):
+    world.browser.execute_script('window.prompt = function(){return %s;}') % prompt

--- a/common/djangoapps/terrain/steps.py
+++ b/common/djangoapps/terrain/steps.py
@@ -163,14 +163,29 @@ def dialogs_are_closed(step):
 
 @step('I will confirm all alerts')
 def i_confirm_all_alerts(step):
+    """
+    Please note: This method must be called RIGHT BEFORE an expected alert
+    Window variables are page local and thus all changes are removed upon navigating to a new page
+    In addition, this method changes the functionality of ONLY future alerts
+    """
     world.browser.execute_script('window.confirm = function(){return true;} ; window.alert = function(){return;}')
 
 
 @step('I will cancel all alerts')
 def i_cancel_all_alerts(step):
+    """
+    Please note: This method must be called RIGHT BEFORE an expected alert
+    Window variables are page local and thus all changes are removed upon navigating to a new page
+    In addition, this method changes the functionality of ONLY future alerts
+    """
     world.browser.execute_script('window.confirm = function(){return false;} ; window.alert = function(){return;}')
 
 
 @step('I will answer all prompts with "([^"]*)"')
 def i_answer_prompts_with(step, prompt):
+    """
+    Please note: This method must be called RIGHT BEFORE an expected alert
+    Window variables are page local and thus all changes are removed upon navigating to a new page
+    In addition, this method changes the functionality of ONLY future alerts
+    """
     world.browser.execute_script('window.prompt = function(){return %s;}') % prompt

--- a/common/djangoapps/terrain/steps.py
+++ b/common/djangoapps/terrain/steps.py
@@ -166,9 +166,9 @@ def i_confirm_with_ok(step):
     world.browser.execute_script('window.confirm = function(){return true;} ; window.alert = function(){return;}')
 
 
-@step('I dismiss all alerts')
+@step('I cancel all alerts')
 def i_dismiss_with_ok(step):
-    world.browser.execute_script('window.confirm = function(){return false;}')
+    world.browser.execute_script('window.confirm = function(){return false;} ; window.alert = function(){return;}')
 
 
 @step('I answer all prompts with "([^"]*)"')

--- a/common/djangoapps/terrain/steps.py
+++ b/common/djangoapps/terrain/steps.py
@@ -162,12 +162,12 @@ def dialogs_are_closed(step):
 
 
 @step('I confirm all alerts')
-def i_confirm_with_ok(step):
+def i_confirm_all_alerts(step):
     world.browser.execute_script('window.confirm = function(){return true;} ; window.alert = function(){return;}')
 
 
 @step('I cancel all alerts')
-def i_dismiss_with_ok(step):
+def i_cancel_all_alerts(step):
     world.browser.execute_script('window.confirm = function(){return false;} ; window.alert = function(){return;}')
 
 

--- a/common/djangoapps/terrain/steps.py
+++ b/common/djangoapps/terrain/steps.py
@@ -161,16 +161,16 @@ def dialogs_are_closed(step):
     assert world.dialogs_closed()
 
 
-@step('I confirm all alerts')
+@step('I will confirm all alerts')
 def i_confirm_all_alerts(step):
     world.browser.execute_script('window.confirm = function(){return true;} ; window.alert = function(){return;}')
 
 
-@step('I cancel all alerts')
+@step('I will cancel all alerts')
 def i_cancel_all_alerts(step):
     world.browser.execute_script('window.confirm = function(){return false;} ; window.alert = function(){return;}')
 
 
-@step('I answer all prompts with "([^"]*)"')
+@step('I will answer all prompts with "([^"]*)"')
 def i_answer_prompts_with(step, prompt):
     world.browser.execute_script('window.prompt = function(){return %s;}') % prompt


### PR DESCRIPTION
Suggested Reviewers @wedaly @cahrens @jzoldak 

In this pull request, I have fixed the issue of chrome hanging on alerts.

This was done by changing how alerts work on the javascript level:
Alerts are created through window.alert(), window.confirm(), window.prompt()
These methods have some functionality that creates the popup box and upon the user clicking/typing either return (alert), return true or false (confirm) or return with a string (prompt)

Selenium can inject javascript through world.browser.execute_script()
Now, there are steps to cut out the middleman so to speak.  
"I confirm all alerts" will redefine 
window.alert = function(){return;}
window.confirm = function(){return true;}

"I dismiss all alerts" will redefine
window.confirm = function(){return false;}

'I answer all prompts with "([^"]*)"' will redefine
window.prompt = function(){return %s}  %prompt

The window variable only persists on a given page so changing these functions will only affect the page they are on.  While this does make it safer to modify these functions, this also means that these steps must be called right before the alert is generated.

In following this, I have also fixed the features that required this functionality and they all now work on my local machine.
