### PR TITLE
Developer-private settings files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@
 .AppleDouble
 database.sqlite
 requirements/private.txt
+lms/envs/private.py
+cms/envs/private.py
 courseware/static/js/mathjax/*
 flushdb.sh
 build

--- a/cms/envs/dev.py
+++ b/cms/envs/dev.py
@@ -165,3 +165,11 @@ MITX_FEATURES['ENABLE_SERVICE_STATUS'] = True
 
 # segment-io key for dev
 SEGMENT_IO_KEY = 'mty8edrrsg'
+
+
+#####################################################################
+# Lastly, see if the developer has any local overrides.
+try:
+    from .private import *
+except ImportError:
+    pass

--- a/lms/envs/dev.py
+++ b/lms/envs/dev.py
@@ -243,3 +243,11 @@ MITX_FEATURES['ENABLE_PEARSON_LOGIN'] = False
 
 ANALYTICS_SERVER_URL = "http://127.0.0.1:9000/"
 ANALYTICS_API_KEY = ""
+
+
+#####################################################################
+# Lastly, see if the developer has any local overrides.
+try:
+    from .private import *
+except ImportError:
+    pass


### PR DESCRIPTION
Developers can have private settings files by creating
lms/envs/private.py or cms/envs/private.py.  They are imported
at the end of dev.py.  Note that they won't be imported if you
are using one of the other dev*.py variants.
