### PR TITLE
Will/fix rake test

### DIFF
--- a/rakefiles/tests.rake
+++ b/rakefiles/tests.rake
@@ -45,12 +45,6 @@ end
 directory REPORT_DIR
 
 task :clean_test_files do
-
-    # Delete all files in the reports directory, while preserving
-    # the directory structure.
-    sh("find #{REPORT_DIR} -type f -print0 | xargs --no-run-if-empty -0 rm")
-
-    # Reset the test fixtures
     sh("git clean -fqdx test_root")
 end
 


### PR DESCRIPTION
Removes cleaning of reports directory.

This fixes an error on Mac OS X in which xargs was being passed an unsupported argument.
It also fixes an issue in Jenkins in which `rake test` reports were being deleted.

This means that we will need to run `rake clobber` before collecting coverage info to prevent old results from being used.

@jzoldak can you please review?  This needs to be merged ASAP to fix the rake test command.
