### PR TITLE
Login/Register Page Headings Tweaks

### DIFF
--- a/lms/templates/login.html
+++ b/lms/templates/login.html
@@ -86,10 +86,6 @@
 
 <section class="login container">
   <section role="main" class="content">
-    <header>
-      <h2 class="sr">${_("Login Form")}</h2>
-    </header>
-
     <form role="form" id="login-form" method="post" data-remote="true" action="/login_ajax">
 
       <!-- status messages -->

--- a/lms/templates/register.html
+++ b/lms/templates/register.html
@@ -83,16 +83,12 @@
 
 <section class="introduction">
   <header>
-    <h1 class="sr">Register for ${settings.PLATFORM_NAME}</h1>
+    <h1 class="sr">${_("Welcome! Register below to create your %(platform_name)s account") % {'platform_name': settings.PLATFORM_NAME}</h1>
   </header>
 </section>
 
 <section class="register container">
   <section role="main" class="content">
-    <header>
-      <h2 class="sr">${_("Welcome! Register below to create your edX account")}</h2>
-    </header>
-
     <form role="form" id="register-form" method="post" data-remote="true" action="/create_account">
 
       <!-- status messages -->

--- a/lms/templates/register.html
+++ b/lms/templates/register.html
@@ -83,7 +83,7 @@
 
 <section class="introduction">
   <header>
-    <h1 class="sr">${_("Welcome! Register below to create your %(platform_name)s account") % {'platform_name': settings.PLATFORM_NAME}</h1>
+    <h1 class="sr">${_("Welcome! Register below to create your %(platform_name)s account") % {'platform_name': settings.PLATFORM_NAME}}</h1>
   </header>
 </section>
 


### PR DESCRIPTION
A quick change to the login/register views to remove redundant heading and sync up main title text to graphical banners.
