### PR TITLE
Replace /faq route in LMS urls

### DIFF
--- a/lms/urls.py
+++ b/lms/urls.py
@@ -98,6 +98,8 @@ if not settings.MITX_FEATURES["USE_CUSTOM_THEME"]:
         url(r'^press$', 'student.views.press', name="press"),
         url(r'^media-kit$', 'static_template_view.views.render',
             {'template': 'media-kit.html'}, name="media-kit"),
+        url(r'^faq$', 'static_template_view.views.render',
+            {'template': 'faq.html'}, name="faq_edx"),
         url(r'^help$', 'static_template_view.views.render',
             {'template': 'help.html'}, name="help_edx"),
 
@@ -125,7 +127,7 @@ for key, value in settings.MKTG_URL_LINK_MAP.items():
         continue
 
     # These urls are enabled separately
-    if key == "ROOT" or key == "COURSES":
+    if key == "ROOT" or key == "COURSES" or key == "FAQ":
         continue
 
     # Make the assumptions that the templates are all in the same dir


### PR DESCRIPTION
This route was mistakenly removed by the theming changes since the
`FAQ` marketing link actually points to `help_edx`, not `faq_edx`.

It would be good to rename the `FAQ` key in the `MKTG_URL_LINK_MAP` to `HELP` instead, since this would fix the issues we have in dynamically adding these marketing routes. That involves changing all instances of `marketing_link("FAQ")`, however.
