### PR TITLE
move url() wrapper into SASS variable

### DIFF
--- a/lms/static/sass/base/_variables.scss
+++ b/lms/static/sass/base/_variables.scss
@@ -132,7 +132,7 @@ $footer_margin: ($baseline/4) 0 ($baseline*1.5) 0;
 //-----------------
 $homepage-bg-image: '../images/homepage-bg.jpg';
 
-$login-banner-image: '../images/bg-banner-login.png';
-$register-banner-image: '../images/bg-banner-register.png';
+$login-banner-image: url(../images/bg-banner-login.png);
+$register-banner-image: url(../images/bg-banner-register.png);
 
 $video-thumb-url: '../images/courses/video-thumb.jpg';

--- a/lms/static/sass/multicourse/_account.scss
+++ b/lms/static/sass/multicourse/_account.scss
@@ -493,7 +493,7 @@
     header {
       height: 120px;
       border-bottom: 1px solid $m-gray;
-      background: transparent url($login-banner-image) 0 0 no-repeat;
+      background: transparent $login-banner-image 0 0 no-repeat;
     }
   }
 }
@@ -507,7 +507,7 @@
     header {
       height: 120px;
       border-bottom: 1px solid $m-gray;
-      background: transparent url($register-banner-image) 0 0 no-repeat;
+      background: transparent $register-banner-image 0 0 no-repeat;
     }
   }
 }


### PR DESCRIPTION
@talbs - had to move url() css wrapper inside of the SASS variables because if themes try to not have that image and set that variable to none, collectstatic crashes...
