### PR TITLE
Vagrant: Add support for Vagrant install (`vagrant up`)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
 *.sh text eol=lf
+*.txt text eol=lf
+*.py text eol=lf
+*.rb text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,1 @@
-*.sh text eol=lf
-*.txt text eol=lf
-*.py text eol=lf
-*.rb text eol=lf
+* -text

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ node_modules
 .prereqs_cache
 autodeploy.properties
 .ws_migrations_complete
+.vagrant/

--- a/README.md
+++ b/README.md
@@ -2,8 +2,132 @@ This is the main edX platform which consists of LMS and Studio.
 
 See [code.edx.org](http://code.edx.org/) for other parts of the edX code base.
 
-Installation
-============
+Installation - The first time
+=============================
+
+The following instructions will help you to download and setup a virtual machine 
+with a minimal amount of steps, using Vagrant. It is recommended for a first 
+installation, as it will save you from many of the common pitfalls of the
+installation process.
+
+1. Install Git: http://git-scm.com/downloads
+2. Install VirtualBox: https://www.virtualbox.org/wiki/Downloads
+3. Install Vagrant: http://www.vagrantup.com/ (Vagrant 1.2.2 or later)
+4. Open a terminal
+5. Download the project: `git clone git://github.com/edx/edx-platform.git`
+6. Enter the project directory: `cd edx-platform/`
+7. Start: `vagrant up`
+
+The last step might require your administrator password to setup NFS. 
+
+Afterwards, it will download an image, install all the dependencies and configure 
+the VM. It will take a while, go grab a coffee.
+
+Once completed, hopefully you should see a "Success!" message indicating that the 
+installation went fine. (If not, refer to the Troubleshooting section below.)
+
+Accessing the VM
+----------------
+
+Vagrant should automatically log you in the virtual machine once the installation
+is finished. You can also type, from another terminal:
+
+```
+$ vagrant ssh
+```
+
+Note: This won't work from Windows, install install PuTTY from 
+http://www.chiark.greenend.org.uk/%7Esgtatham/putty/download.html instead. Then 
+connect to 127.0.0.1, port 2222, using vagrant/vagrant as a user/password.
+
+Using edX
+---------
+
+Once inside the VM, you can start Studio and LMS with the following commands
+(from the `/edx/edx-platform` folder):
+
+Learning management system (LMS):
+
+```
+$ rake lms[cms.dev,0.0.0.0:8000]
+```
+
+Studio:
+
+```
+$ rake cms[dev,0.0.0.0:8001]
+```
+
+Once started, open the following URLs in your browser:
+
+* Learning management system (LMS): http://192.168.20.40:8000/ 
+* Studio (CMS): http://192.168.20.40:8001/
+
+You can develop by editing the files directly in the `edx-platform/` directory you 
+downloaded before, you don't need to connect to the VM to edit them (the VM uses
+those files to run edX, mirroring the folder in `/edx/edx-platform`).
+
+Stopping & starting
+-------------------
+
+To stop the VM (from your `edx-platform/` directory):
+
+```
+$ vagrant halt
+```
+
+To restart:
+
+```
+$ vagrant up
+```
+
+or, to start without attempting to update the dependencies:
+
+```
+$ vagrant up --no-provision
+```
+
+Troubleshooting
+---------------
+
+### Reinstalling
+
+If something goes wrong, you can easily recreate the installation from scratch by 
+typing:
+
+```
+$ vagrant destroy -f && vagrant up
+```
+
+This will delete the current VM, create a new VM, re-install all the dependencies,
+and reconfigure.
+
+### "Mounting NFS shared folders failed"
+
+If you get the following error message when you run `$ vagrant up`:
+
+```
+It appears your machine doesn't support NFS, or there is not an
+adapter to enable NFS on this machine for Vagrant. Please verify
+that `nfsd` is installed on your machine, and try again. If you're
+on Windows, NFS isn't supported.
+```
+
+You need to install NFS. Under Debian/Ubuntu, for example:
+
+```
+$ sudo apt-get install nfs-common nfs-kernel-server
+```
+
+Installation - Advanced
+=======================
+
+Note: The following installation instructions are for advanced users & developers
+who are familiar with setting up Python, Ruby & node.js virtual environments.
+Even if you know what you are doing, edX has a large code base with multiple 
+dependencies, so you might still want to use the method described above the
+first time, as Vagrant helps avoiding issues due to the different environments.
 
 There is a `scripts/create-dev-env.sh` that will attempt to set up a development
 environment.

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ See [code.edx.org](http://code.edx.org/) for other parts of the edX code base.
 Installation - The first time
 =============================
 
-The following instructions will help you to download and setup a virtual machine 
-with a minimal amount of steps, using Vagrant. It is recommended for a first 
+The following instructions will help you to download and setup a virtual machine
+with a minimal amount of steps, using Vagrant. It is recommended for a first
 installation, as it will save you from many of the common pitfalls of the
 installation process.
 
@@ -18,12 +18,12 @@ installation process.
 6. Enter the project directory: `cd edx-platform/`
 7. Start: `vagrant up`
 
-The last step might require your administrator password to setup NFS. 
+The last step might require your administrator password to setup NFS.
 
-Afterwards, it will download an image, install all the dependencies and configure 
+Afterwards, it will download an image, install all the dependencies and configure
 the VM. It will take a while, go grab a coffee.
 
-Once completed, hopefully you should see a "Success!" message indicating that the 
+Once completed, hopefully you should see a "Success!" message indicating that the
 installation went fine. (If not, refer to the Troubleshooting section below.)
 
 Accessing the VM
@@ -36,15 +36,15 @@ is finished. You can also type, from another terminal:
 $ vagrant ssh
 ```
 
-Note: This won't work from Windows, install install PuTTY from 
-http://www.chiark.greenend.org.uk/%7Esgtatham/putty/download.html instead. Then 
+Note: This won't work from Windows, install install PuTTY from
+http://www.chiark.greenend.org.uk/%7Esgtatham/putty/download.html instead. Then
 connect to 127.0.0.1, port 2222, using vagrant/vagrant as a user/password.
 
 Using edX
 ---------
 
 Once inside the VM, you can start Studio and LMS with the following commands
-(from the `/edx/edx-platform` folder):
+(from the `/opt/edx-platform` folder):
 
 Learning management system (LMS):
 
@@ -60,12 +60,12 @@ $ rake cms[dev,0.0.0.0:8001]
 
 Once started, open the following URLs in your browser:
 
-* Learning management system (LMS): http://192.168.20.40:8000/ 
+* Learning management system (LMS): http://192.168.20.40:8000/
 * Studio (CMS): http://192.168.20.40:8001/
 
-You can develop by editing the files directly in the `edx-platform/` directory you 
+You can develop by editing the files directly in the `edx-platform/` directory you
 downloaded before, you don't need to connect to the VM to edit them (the VM uses
-those files to run edX, mirroring the folder in `/edx/edx-platform`).
+those files to run edX, mirroring the folder in `/opt/edx-platform`).
 
 Stopping & starting
 -------------------
@@ -93,7 +93,7 @@ Troubleshooting
 
 ### Reinstalling
 
-If something goes wrong, you can easily recreate the installation from scratch by 
+If something goes wrong, you can easily recreate the installation from scratch by
 typing:
 
 ```
@@ -125,7 +125,7 @@ Installation - Advanced
 
 Note: The following installation instructions are for advanced users & developers
 who are familiar with setting up Python, Ruby & node.js virtual environments.
-Even if you know what you are doing, edX has a large code base with multiple 
+Even if you know what you are doing, edX has a large code base with multiple
 dependencies, so you might still want to use the method described above the
 first time, as Vagrant helps avoiding issues due to the different environments.
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Using edX
 ---------
 
 Once inside the VM, you can start Studio and LMS with the following commands
-(from the `/opt/edx-platform` folder):
+(from the `/opt/edx/edx-platform` folder):
 
 Learning management system (LMS):
 
@@ -65,7 +65,7 @@ Once started, open the following URLs in your browser:
 
 You can develop by editing the files directly in the `edx-platform/` directory you
 downloaded before, you don't need to connect to the VM to edit them (the VM uses
-those files to run edX, mirroring the folder in `/opt/edx-platform`).
+those files to run edX, mirroring the folder in `/opt/edx/edx-platform`).
 
 Stopping & starting
 -------------------

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ installation process.
 5. Open a terminal
 6. Download the project: `git clone git://github.com/edx/edx-platform.git`
 7. Enter the project directory: `cd edx-platform/`
-8. (Windows only) Make sure files have the proper line ending: 
-   `git rm --cached -r . && git reset --hard`
+8. (Windows only) Run the commands to 
+   [deal with line endings and symlinks under Windows](https://github.com/edx/edx-platform/wiki/Simplified-install-with-vagrant#dealing-with-line-endings-and-symlinks-under-windows)
 9. Start: `vagrant up`
 
 The last step might require your host machine's administrator password to setup NFS.

--- a/README.md
+++ b/README.md
@@ -19,9 +19,11 @@ installation process.
 5. Open a terminal
 6. Download the project: `git clone git://github.com/edx/edx-platform.git`
 7. Enter the project directory: `cd edx-platform/`
-8. Start: `vagrant up`
+8. (Windows only) Make sure files have the proper line ending: 
+   `git rm --cached -r . && git reset --hard`
+9. Start: `vagrant up`
 
-The last step might require your administrator password to setup NFS.
+The last step might require your host machine's administrator password to setup NFS.
 
 Afterwards, it will download an image, install all the dependencies and configure
 the VM. It will take a while, go grab a coffee.
@@ -30,11 +32,15 @@ Once completed, hopefully you should see a "Success!" message indicating that th
 installation went fine. (If not, refer to the 
 [troubleshooting section](https://github.com/edx/edx-platform/wiki/Simplified-install-with-vagrant#troubleshooting).)
 
+Note: by default, the VM will get the IP `192.168.20.40`. If you need to use a 
+different IP, you can edit the file `Vagrantfile`. If you have already started the 
+VM with `vagrant up`, see "Stopping and restarting the VM" below to take the change 
+into account.
+
 Accessing the VM
 ----------------
 
-Vagrant should automatically log you in the virtual machine once the installation
-is finished. You can also type, from another terminal:
+Once the installation is finished, to log into the virtual machine:
 
 ```
 $ vagrant ssh
@@ -70,6 +76,26 @@ Once started, open the following URLs in your browser:
 You can develop by editing the files directly in the `edx-platform/` directory you
 downloaded before, you don't need to connect to the VM to edit them (the VM uses
 those files to run edX, mirroring the folder in `/opt/edx/edx-platform`).
+
+You may also want to create a super-user with:
+
+```
+$ rake django-admin["createsuperuser"]
+```
+
+Also note that if you register a new user through the web interface,
+the activiation email will be posted to your VM's terminal window (search for
+lines similar to):
+
+```
+Subject: Your account for edX Studio
+From: registration@edx.org
+```
+
+and find the activation URL for the account you've created.
+
+See the [Frequently Asked Questions](https://github.com/edx/edx-platform/wiki/Frequently-Asked-Questions)
+for more usage tips.
 
 Stopping & starting
 -------------------

--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ installation process.
 
 1. Make sure you have plenty of available disk space, >5GB
 2. Install Git: http://git-scm.com/downloads
-3. Install VirtualBox: https://www.virtualbox.org/wiki/Downloads (VirtualBox 4.2.14
-   or later)
+3. Install VirtualBox: https://www.virtualbox.org/wiki/Download_Old_Builds_4_2
+   (you need version 4.2.12, as later/earlier versions might not work well with 
+   Vagrant)
 4. Install Vagrant: http://www.vagrantup.com/ (Vagrant 1.2.2 or later)
 5. Open a terminal
 6. Download the project: `git clone git://github.com/edx/edx-platform.git`

--- a/README.md
+++ b/README.md
@@ -10,13 +10,15 @@ with a minimal amount of steps, using Vagrant. It is recommended for a first
 installation, as it will save you from many of the common pitfalls of the
 installation process.
 
-1. Install Git: http://git-scm.com/downloads
-2. Install VirtualBox: https://www.virtualbox.org/wiki/Downloads
-3. Install Vagrant: http://www.vagrantup.com/ (Vagrant 1.2.2 or later)
-4. Open a terminal
-5. Download the project: `git clone git://github.com/edx/edx-platform.git`
-6. Enter the project directory: `cd edx-platform/`
-7. Start: `vagrant up`
+1. Make sure you have plenty of available disk space, >5GB
+2. Install Git: http://git-scm.com/downloads
+3. Install VirtualBox: https://www.virtualbox.org/wiki/Downloads (VirtualBox 4.2.14
+   or later)
+4. Install Vagrant: http://www.vagrantup.com/ (Vagrant 1.2.2 or later)
+5. Open a terminal
+6. Download the project: `git clone git://github.com/edx/edx-platform.git`
+7. Enter the project directory: `cd edx-platform/`
+8. Start: `vagrant up`
 
 The last step might require your administrator password to setup NFS.
 
@@ -24,7 +26,8 @@ Afterwards, it will download an image, install all the dependencies and configur
 the VM. It will take a while, go grab a coffee.
 
 Once completed, hopefully you should see a "Success!" message indicating that the
-installation went fine. (If not, refer to the Troubleshooting section below.)
+installation went fine. (If not, refer to the 
+[troubleshooting section](https://github.com/edx/edx-platform/wiki/Simplified-install-with-vagrant#troubleshooting).)
 
 Accessing the VM
 ----------------
@@ -91,34 +94,8 @@ $ vagrant up --no-provision
 Troubleshooting
 ---------------
 
-### Reinstalling
-
-If something goes wrong, you can easily recreate the installation from scratch by
-typing:
-
-```
-$ vagrant destroy -f && vagrant up
-```
-
-This will delete the current VM, create a new VM, re-install all the dependencies,
-and reconfigure.
-
-### "Mounting NFS shared folders failed"
-
-If you get the following error message when you run `$ vagrant up`:
-
-```
-It appears your machine doesn't support NFS, or there is not an
-adapter to enable NFS on this machine for Vagrant. Please verify
-that `nfsd` is installed on your machine, and try again. If you're
-on Windows, NFS isn't supported.
-```
-
-You need to install NFS. Under Debian/Ubuntu, for example:
-
-```
-$ sudo apt-get install nfs-common nfs-kernel-server
-```
+If anything doesn't work as expected, see the 
+[troubleshooting section](https://github.com/edx/edx-platform/wiki/Simplified-install-with-vagrant#troubleshooting).
 
 Installation - Advanced
 =======================

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,33 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "precise32"
+  config.vm.box_url = "http://files.vagrantup.com/precise32.box"
+
+  config.vm.network :forwarded_port, guest: 8000, host: 9000
+  config.vm.network :forwarded_port, guest: 8001, host: 9001
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  config.vm.network :private_network, ip: "192.168.20.40"
+
+  nfs_setting = RUBY_PLATFORM =~ /darwin/ || RUBY_PLATFORM =~ /linux/
+  config.vm.synced_folder ".", "/edx/edx-platform", id: "vagrant-root", :nfs => nfs_setting
+
+  # Make it so that network access from the vagrant guest is able to
+  # use SSH private keys that are present on the host without copying
+  # them into the VM.
+  config.ssh.forward_agent = true
+
+  config.vm.provider :virtualbox do |vb|
+    # Use VBoxManage to customize the VM. For example to change memory:
+    vb.customize ["modifyvm", :id, "--memory", "1024"]
+
+    # This setting makes it so that network access from inside the vagrant guest
+    # is able to resolve DNS using the hosts VPN connection.
+    vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+  end
+
+  config.vm.provision :shell, :path => "scripts/vagrant-provisioning.sh"
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,7 +13,7 @@ Vagrant.configure("2") do |config|
   config.vm.network :private_network, ip: "192.168.20.40"
 
   nfs_setting = RUBY_PLATFORM =~ /darwin/ || RUBY_PLATFORM =~ /linux/
-  config.vm.synced_folder ".", "/edx/edx-platform", id: "vagrant-root", :nfs => nfs_setting
+  config.vm.synced_folder ".", "/opt/edx-platform", id: "vagrant-root", :nfs => nfs_setting
 
   # Make it so that network access from the vagrant guest is able to
   # use SSH private keys that are present on the host without copying

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,7 +13,7 @@ Vagrant.configure("2") do |config|
   config.vm.network :private_network, ip: "192.168.20.40"
 
   nfs_setting = RUBY_PLATFORM =~ /darwin/ || RUBY_PLATFORM =~ /linux/
-  config.vm.synced_folder ".", "/opt/edx-platform", id: "vagrant-root", :nfs => nfs_setting
+  config.vm.synced_folder ".", "/opt/edx/edx-platform", id: "vagrant-root", :nfs => nfs_setting
 
   # Make it so that network access from the vagrant guest is able to
   # use SSH private keys that are present on the host without copying

--- a/rakelib/workspace.rake
+++ b/rakelib/workspace.rake
@@ -7,7 +7,8 @@ namespace :ws do
     task :migrate => MIGRATION_MARKER_DIR do
         Dir['ws_migrations/*'].select{|m| File.executable?(m)}.each do |migration|
             completion_file = File.join(MIGRATION_MARKER_DIR, File.basename(migration))
-            if ! File.exist?(completion_file)
+            is_excluded = File.basename(migration).start_with?("README")
+            if ! File.exist?(completion_file) && ! is_excluded
                 sh(migration)
                 File.write(completion_file, "")
             end

--- a/scripts/create-dev-env.sh
+++ b/scripts/create-dev-env.sh
@@ -364,7 +364,7 @@ case `uname -s` in
         warning "Setting up rvm on linux. This is a known pain point. If the script fails here
                 refer to the following stack overflow question:
                 http://stackoverflow.com/questions/9056008/installed-ruby-1-9-3-with-rvm-but-command-line-doesnt-show-ruby-v/9056395#9056395"
-        sudo apt-get --purge remove ruby-rvm
+        sudo apt-get --purge remove -yq ruby-rvm
         sudo rm -rf /usr/share/ruby-rvm /etc/rvmrc /etc/profile.d/rvm.sh
         curl -sSL https://get.rvm.io | bash -s stable --ruby=$RUBY_VER --autolibs=enable --auto-dotfiles
     ;;
@@ -451,14 +451,14 @@ fi
 # Create edX virtualenv and link it to repo
 # virtualenvwrapper automatically sources the activation script
 if [[ $systempkgs ]]; then
-    mkvirtualenv -a "$HOME/.virtualenvs" --system-site-packages edx-platform || {
+    mkvirtualenv -q -a "$HOME/.virtualenvs" --system-site-packages edx-platform || {
       error "mkvirtualenv exited with a non-zero error"
       return 1
     }
 else
     # default behavior for virtualenv>1.7 is
     # --no-site-packages
-    mkvirtualenv -a "$HOME/.virtualenvs" edx-platform || {
+    mkvirtualenv -q -a "$HOME/.virtualenvs" edx-platform || {
       error "mkvirtualenv exited with a non-zero error"
       return 1
     }

--- a/scripts/create-dev-env.sh
+++ b/scripts/create-dev-env.sh
@@ -543,7 +543,7 @@ mkdir -p "$BASE/log"
 mkdir -p "$BASE/db"
 mkdir -p "$BASE/data"
 
-rake django-admin[syncdb]
+rake django-admin[syncdb,lms,dev,--noinput]
 rake django-admin[migrate]
 rake cms:update_templates
 # Configure Git

--- a/scripts/create-dev-env.sh
+++ b/scripts/create-dev-env.sh
@@ -349,6 +349,11 @@ if [ "$HOME/.rvm" != $RUBY_DIR ]; then
   fi
 fi
 
+# Let the repo override the version of Ruby to install
+if [[ -r $BASE/edx-platform/.ruby-version ]]; then
+  RUBY_VER=`cat $BASE/edx-platform/.ruby-version`
+fi
+
 # rvm has issues in debian family, this is taken from stack overflow
 case `uname -s` in
     Darwin)
@@ -361,7 +366,7 @@ case `uname -s` in
                 http://stackoverflow.com/questions/9056008/installed-ruby-1-9-3-with-rvm-but-command-line-doesnt-show-ruby-v/9056395#9056395"
         sudo apt-get --purge remove ruby-rvm
         sudo rm -rf /usr/share/ruby-rvm /etc/rvmrc /etc/profile.d/rvm.sh
-        curl -sL https://get.rvm.io | bash -s stable --ruby --autolibs=enable --auto-dotfiles
+        curl -sSL https://get.rvm.io | bash -s stable --ruby=$RUBY_VER --autolibs=enable --auto-dotfiles
     ;;
 esac
 
@@ -385,11 +390,6 @@ case `uname -s` in
         export CC=gcc
         ;;
 esac
-
-# Let the repo override the version of Ruby to install
-if [[ -r $BASE/edx-platform/.ruby-version ]]; then
-  RUBY_VER=`cat $BASE/edx-platform/.ruby-version`
-fi
 
 # Current stable version of RVM (1.19.0) requires the following to build Ruby:
 #

--- a/scripts/create-dev-env.sh
+++ b/scripts/create-dev-env.sh
@@ -357,7 +357,7 @@ fi
 # rvm has issues in debian family, this is taken from stack overflow
 case `uname -s` in
     Darwin)
-        curl -sL get.rvm.io | bash -s -- --version 1.15.7
+        curl -sSL get.rvm.io | bash -s -- --version 1.15.7
     ;;
 
     [Ll]inux)
@@ -472,8 +472,8 @@ SCIPY_VER="0.10.1"
 
 if [[ -n $compile ]]; then
     output "Downloading numpy and scipy"
-    curl -sL -o numpy.tar.gz http://downloads.sourceforge.net/project/numpy/NumPy/${NUMPY_VER}/numpy-${NUMPY_VER}.tar.gz
-    curl -sL -o scipy.tar.gz http://downloads.sourceforge.net/project/scipy/scipy/${SCIPY_VER}/scipy-${SCIPY_VER}.tar.gz
+    curl -sSL -o numpy.tar.gz http://downloads.sourceforge.net/project/numpy/NumPy/${NUMPY_VER}/numpy-${NUMPY_VER}.tar.gz
+    curl -sSL -o scipy.tar.gz http://downloads.sourceforge.net/project/scipy/scipy/${SCIPY_VER}/scipy-${SCIPY_VER}.tar.gz
     tar xf numpy.tar.gz
     tar xf scipy.tar.gz
     rm -f numpy.tar.gz scipy.tar.gz
@@ -492,7 +492,7 @@ DISTRIBUTE_VER="0.6.28"
 output "Building Distribute"
 SITE_PACKAGES="$HOME/.virtualenvs/edx-platform/lib/python2.7/site-packages"
 cd "$SITE_PACKAGES"
-curl -O http://pypi.python.org/packages/source/d/distribute/distribute-${DISTRIBUTE_VER}.tar.gz
+curl -sSO http://pypi.python.org/packages/source/d/distribute/distribute-${DISTRIBUTE_VER}.tar.gz
 tar -xzvf distribute-${DISTRIBUTE_VER}.tar.gz
 cd distribute-${DISTRIBUTE_VER}
 python setup.py install

--- a/scripts/create-dev-env.sh
+++ b/scripts/create-dev-env.sh
@@ -492,7 +492,7 @@ DISTRIBUTE_VER="0.6.28"
 output "Building Distribute"
 SITE_PACKAGES="$HOME/.virtualenvs/edx-platform/lib/python2.7/site-packages"
 cd "$SITE_PACKAGES"
-curl -sSO http://pypi.python.org/packages/source/d/distribute/distribute-${DISTRIBUTE_VER}.tar.gz
+curl -sSLO http://pypi.python.org/packages/source/d/distribute/distribute-${DISTRIBUTE_VER}.tar.gz
 tar -xzvf distribute-${DISTRIBUTE_VER}.tar.gz
 cd distribute-${DISTRIBUTE_VER}
 python setup.py install

--- a/scripts/install-system-req.sh
+++ b/scripts/install-system-req.sh
@@ -35,18 +35,13 @@ case `uname -s` in
             squeeze|wheezy|jessie|maya|lisa|olivia|nadia|natty|oneiric|precise|quantal|raring)
                 output "Installing Debian family requirements"
 
-                # DEBIAN_FRONTEND=noninteractive is required for silent mysql-server installation
-                export DEBIAN_FRONTEND=noninteractive
-
                 # add repositories
                 cat $APT_REPOS_FILE | xargs -n 1 sudo add-apt-repository -y
-                sudo apt-get -y update
-                sudo apt-get -y install gfortran
-                sudo apt-get -y install graphviz libgraphviz-dev graphviz-dev
-                sudo apt-get -y install libatlas-dev libblas-dev 
-                sudo apt-get -y install ruby-rvm
+                sudo apt-get -yq update
+                sudo DEBIAN_FRONTEND=noninteractive apt-get -yq install gfortran graphviz \
+                            libgraphviz-dev graphviz-dev libatlas-dev libblas-dev ruby-rvm
                 # install packages listed in APT_PKGS_FILE
-                cat $APT_PKGS_FILE | xargs sudo apt-get -y install
+                cat $APT_PKGS_FILE | xargs sudo DEBIAN_FRONTEND=noninteractive apt-get -yq install
                 ;;
             *)
                 error "Unsupported distribution - $distro"

--- a/scripts/install-system-req.sh
+++ b/scripts/install-system-req.sh
@@ -39,7 +39,7 @@ case `uname -s` in
                 cat $APT_REPOS_FILE | xargs -n 1 sudo add-apt-repository -y
                 sudo apt-get -yq update
                 sudo DEBIAN_FRONTEND=noninteractive apt-get -yq install gfortran graphviz \
-                            libgraphviz-dev graphviz-dev libatlas-dev libblas-dev ruby-rvm
+                            libgraphviz-dev graphviz-dev libatlas-dev libblas-dev
                 # install packages listed in APT_PKGS_FILE
                 cat $APT_PKGS_FILE | xargs sudo DEBIAN_FRONTEND=noninteractive apt-get -yq install
                 ;;

--- a/scripts/vagrant-provisioning.sh
+++ b/scripts/vagrant-provisioning.sh
@@ -1,0 +1,110 @@
+#!/bin/bash -e
+#
+# Copyright (C) 2013 edX <info@edx.org>
+#
+# Authors: Xavier Antoviaque <xavier@antoviaque.org>
+#
+# This software's license gives you freedom; you can copy, convey,
+# propagate, redistribute and/or modify this program under the terms of
+# the GNU Affero General Public License (AGPL) as published by the Free
+# Software Foundation (FSF), either version 3 of the License, or (at your
+# option) any later version of the AGPL published by the FSF.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program in a file in the toplevel directory called
+# "AGPLv3".  If not, see <http://www.gnu.org/licenses/>.
+
+
+###############################################################################
+
+# vagrant-provisioning.sh:
+#
+# Script to setup base environment on Vagrant, based on `precise32` image
+# Runs ./scripts/create-dev-env.sh for the actual setup
+#
+# This script is ran by `$ vagrant up`, see the README for more explanations
+
+
+# APT - Packages ##############################################################
+
+apt-get update
+apt-get install -y python-software-properties vim
+
+
+# Curl - No progress bar ######################################################
+
+[[ -f ~vagrant/.curlrc ]] || echo "silent show-error" > ~vagrant/.curlrc
+chown vagrant.vagrant ~vagrant/.curlrc
+
+
+# SSH - Known hosts ###########################################################
+
+# Github
+([[ -f ~vagrant/.ssh/known_hosts ]] && grep "zBX7bKA= ssh" ~vagrant/.ssh/known_hosts) || {
+    echo "|1|4DtBcMsTM4zgl/jTS7h3ZkmS/Vc=|XkRnn2xEhr8ixOxeskJAzBX7bKA= ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==" >> ~vagrant/.ssh/known_hosts
+}
+([[ -f ~vagrant/.ssh/known_hosts ]] && grep "jO3J5bvw= ssh" ~vagrant/.ssh/known_hosts) || {
+    echo "|1|9rANf/qOAPgKH/TXpGuZCAgGxMs=|x9VYWEDI8kiotbhhNXqjO3J5bvw= ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==" >> ~vagrant/.ssh/known_hosts
+}
+chown vagrant.vagrant ~vagrant/.ssh/known_hosts
+
+
+# edX - Development environment ###############################################
+
+chown vagrant.vagrant /edx
+
+# For convenience with `vagrant ssh`, the `edx-plateform` virtualenv is always 
+# loaded after the first run, so we need to deactivate that behavior to run
+# `create-dev-env.sh`.
+[[ -f ~vagrant/.bash_profile ]] && {
+    mv ~vagrant/.bash_profile ~vagrant/.bash_profile.bak
+}
+sudo -u vagrant -i bash -c "cd /edx/edx-platform && ./scripts/create-dev-env.sh -ynq"
+
+
+# Virtualenv - Always load ####################################################
+
+([[ -f ~vagrant/.bash_profile ]] && grep "edx-platform/bin/activate" ~vagrant/.bash_profile) || {
+    echo -e "\n. /home/vagrant/.virtualenvs/edx-platform/bin/activate\n" >> ~vagrant/.bash_profile
+}
+
+
+# Directory ###################################################################
+
+grep "cd /edx/edx-platform" ~vagrant/.bash_profile || {
+    echo -e "\ncd /edx/edx-platform\n" >> ~vagrant/.bash_profile
+}
+
+
+# End #########################################################################
+
+cat << EOF
+==============================================================================
+Success!
+==============================================================================
+
+Now, from the virtual machine (connect with "vagrant ssh" if vagrant didn't
+log you in already), you can start Studio & LMS with the following commands:
+
+- Learning management system (LMS):
+    $ rake lms[cms.dev,0.0.0.0:8000]
+
+    =>  http://192.168.20.40:8000/
+
+- Studio: 
+    $ rake cms[dev,0.0.0.0:8001]
+
+    => http://192.168.20.40:8001/
+
+
+See the README for details.
+
+
+EOF
+
+

--- a/scripts/vagrant-provisioning.sh
+++ b/scripts/vagrant-provisioning.sh
@@ -3,6 +3,7 @@
 # Copyright (C) 2013 edX <info@edx.org>
 #
 # Authors: Xavier Antoviaque <xavier@antoviaque.org>
+#          David Baumgold <david@davidbaumgold.com>
 #
 # This software's license gives you freedom; you can copy, convey,
 # propagate, redistribute and/or modify this program under the terms of
@@ -55,16 +56,15 @@ chown vagrant.vagrant ~vagrant/.ssh/known_hosts
 
 
 # edX - Development environment ###############################################
+sudo -u vagrant chown vagrant.vagrant /opt/edx-platform
 
-chown vagrant.vagrant /edx
-
-# For convenience with `vagrant ssh`, the `edx-plateform` virtualenv is always 
+# For convenience with `vagrant ssh`, the `edx-platform` virtualenv is always
 # loaded after the first run, so we need to deactivate that behavior to run
 # `create-dev-env.sh`.
 [[ -f ~vagrant/.bash_profile ]] && {
     mv ~vagrant/.bash_profile ~vagrant/.bash_profile.bak
 }
-sudo -u vagrant -i bash -c "cd /edx/edx-platform && ./scripts/create-dev-env.sh -ynq"
+sudo -u vagrant -i bash -c "cd /opt/edx-platform && ./scripts/create-dev-env.sh -ynq"
 
 
 # Virtualenv - Always load ####################################################
@@ -76,8 +76,8 @@ sudo -u vagrant -i bash -c "cd /edx/edx-platform && ./scripts/create-dev-env.sh 
 
 # Directory ###################################################################
 
-grep "cd /edx/edx-platform" ~vagrant/.bash_profile || {
-    echo -e "\ncd /edx/edx-platform\n" >> ~vagrant/.bash_profile
+grep "cd /opt/edx-platform" ~vagrant/.bash_profile || {
+    echo -e "\ncd /opt/edx-platform\n" >> ~vagrant/.bash_profile
 }
 
 
@@ -96,7 +96,7 @@ log you in already), you can start Studio & LMS with the following commands:
 
     =>  http://192.168.20.40:8000/
 
-- Studio: 
+- Studio:
     $ rake cms[dev,0.0.0.0:8001]
 
     => http://192.168.20.40:8001/

--- a/scripts/vagrant-provisioning.sh
+++ b/scripts/vagrant-provisioning.sh
@@ -61,6 +61,9 @@ chown vagrant.vagrant ~vagrant/.ssh/known_hosts
 mkdir -p /opt/edx/node_modules /opt/edx/edx-platform/node_modules
 mount -o bind /opt/edx/node_modules /opt/edx/edx-platform/node_modules
 
+# Force rechecking all prerequisites (could have been fetched outside of the VM)
+rm -rf /opt/edx/edx-platform/.prereqs_cache
+
 # Permissions
 chown vagrant.vagrant /opt/edx /opt/edx/node_modules /opt/edx/edx-platform/node_modules
 

--- a/scripts/vagrant-provisioning.sh
+++ b/scripts/vagrant-provisioning.sh
@@ -65,7 +65,7 @@ chown vagrant.vagrant /opt/edx
 [[ -f ~vagrant/.bash_profile ]] && {
     mv ~vagrant/.bash_profile ~vagrant/.bash_profile.bak
 }
-sudo -u vagrant -i bash -c "cd /opt/edx/edx-platform && ./scripts/create-dev-env.sh -ynq"
+sudo -u vagrant -i bash -c "cd /opt/edx/edx-platform && PROJECT_HOME=/opt/edx ./scripts/create-dev-env.sh -ynq"
 
 
 # Virtualenv - Always load ####################################################

--- a/scripts/vagrant-provisioning.sh
+++ b/scripts/vagrant-provisioning.sh
@@ -57,7 +57,12 @@ chown vagrant.vagrant ~vagrant/.ssh/known_hosts
 
 # edX - Development environment ###############################################
 
-chown vagrant.vagrant /opt/edx
+# Node modules require a filesystem with symlinks (Windows support)
+mkdir -p /opt/edx/node_modules /opt/edx/edx-platform/node_modules
+mount -o bind /opt/edx/node_modules /opt/edx/edx-platform/node_modules
+
+# Permissions
+chown vagrant.vagrant /opt/edx /opt/edx/node_modules /opt/edx/edx-platform/node_modules
 
 # For convenience with `vagrant ssh`, the `edx-platform` virtualenv is always
 # loaded after the first run, so we need to deactivate that behavior to run

--- a/scripts/vagrant-provisioning.sh
+++ b/scripts/vagrant-provisioning.sh
@@ -56,7 +56,8 @@ chown vagrant.vagrant ~vagrant/.ssh/known_hosts
 
 
 # edX - Development environment ###############################################
-sudo -u vagrant chown vagrant.vagrant /opt/edx-platform
+
+chown vagrant.vagrant /opt/edx
 
 # For convenience with `vagrant ssh`, the `edx-platform` virtualenv is always
 # loaded after the first run, so we need to deactivate that behavior to run
@@ -64,7 +65,7 @@ sudo -u vagrant chown vagrant.vagrant /opt/edx-platform
 [[ -f ~vagrant/.bash_profile ]] && {
     mv ~vagrant/.bash_profile ~vagrant/.bash_profile.bak
 }
-sudo -u vagrant -i bash -c "cd /opt/edx-platform && ./scripts/create-dev-env.sh -ynq"
+sudo -u vagrant -i bash -c "cd /opt/edx/edx-platform && ./scripts/create-dev-env.sh -ynq"
 
 
 # Virtualenv - Always load ####################################################
@@ -76,8 +77,8 @@ sudo -u vagrant -i bash -c "cd /opt/edx-platform && ./scripts/create-dev-env.sh 
 
 # Directory ###################################################################
 
-grep "cd /opt/edx-platform" ~vagrant/.bash_profile || {
-    echo -e "\ncd /opt/edx-platform\n" >> ~vagrant/.bash_profile
+grep "cd /opt/edx/edx-platform" ~vagrant/.bash_profile || {
+    echo -e "\ncd /opt/edx/edx-platform\n" >> ~vagrant/.bash_profile
 }
 
 


### PR DESCRIPTION
This adds support to install and setup a dev instance through Vagrant. The Vagrantfile at the root handles the vagrant commands like `vagrant up`.

Provisioning is done by the shell script `vagrant-provisionning.sh`, which is a light wrapper around the `create-dev-setup.sh` which does most of the job using the standard process, but limiting possible side-effect by ensuring the environment on which the install is performed is clean.

Based on an Ubuntu precise 12.04 LTS. See details in the README on how to use.

Other fixes included with this patch, which were necessary to either fix issues with the current install script, or allow it to complete in the context of Vagrant shell provisioning:
- Fix install script freeze (syncdb superuser account creation): Since the output is passed through tee, when the django admin asks the user if he would like to create a super user account, it blocks the install, without even showing the question. Disabled interactivity for syncdb.
- Fix use of DEBIAN_FRONTEND: Before executing a command, for security reasons `sudo` clears the environment, so the value of DEBIAN_FRONTEND was never passed to apt-get. This was causing the mysql packqge to still prompt for a value interactively.
- Improves ruby/rvm install by directly installing the right version: The script used to download the latest version of ruby through rvm, then later on install the one used by the project. Now we directly download the version of the project when rvm is installed.
- Options "-q" (quiet), "-n" (no pull), "-y" (non interactive): Added several options to the `create-dev-env.sh` script to improve its ability to be used by another script:
  *\* -y -- non interactive mode (no prompt, proceed immediately)
  *\* -n -- do not attempt to pull edx-platform
  *\* -q -- be more quiet (removes info at beginning & end)
- Make curl options more consistent, add logging of errors: The options passed to curl were not always the same - added logging of error (-S) everywhere (was only used for Mac before) and made it quiet in the rare few cases where it wasn't yet (-s).
- Make `apt-get` and `mkvirtualenv` output log friendly: Added options to make the output of `apt-get` and `mkvirtualenv` friendlier to getting logged. This allows to be more easily recorded in log files or when the install is performed through utilities - like Vagrant.
- Also included "create-dev-env.sh: if run from repo, set $BASE appropriately" from Yarko - cf https://github.com/edx/edx-platform/pull/32
