### PR TITLE
add raise error and tests

### DIFF
--- a/lms/lib/comment_client/tests/__init__.py
+++ b/lms/lib/comment_client/tests/__init__.py
@@ -1,0 +1,1 @@
+__author__ = 'edward'

--- a/lms/lib/comment_client/tests/tests.py
+++ b/lms/lib/comment_client/tests/tests.py
@@ -1,0 +1,35 @@
+import logging
+
+from django.test import TestCase
+from django.contrib.auth.models import User, AnonymousUser
+from mock import patch
+from comment_client.utils import *
+import comment_client as cc
+
+log = logging.getLogger(__name__)
+
+class CommentClientTest(TestCase):
+
+    def test_from_django_user(self):
+        """
+        Simple test of the comment service User class' static
+        factory method which expects a django.contrib.auth.models.User and
+        returns a comment_client.User
+        """
+        with patch('student.models.cc.User.save'):
+            user = User("fred","fred@edx.org")
+            comment_user = cc.User.from_django_user(user)
+
+    def test_from_django_user_anon(self):
+        """
+        Test for a production bug occurring when a user is passed to the
+        static factory method in an unauthenticated contenxt.  The
+        AnonymousUser class has no attribute email.  Working around this,
+        doesn't make much sense, the first change is to raise an error if
+        the object passed to from_django_user hasn't received a django user.
+        The next step is to handle this case properly upstream.
+        """
+        with patch('student.models.cc.User.save'):
+            # Test that the appropriate error is raised.
+            anon = AnonymousUser()
+            self.assertRaises(CommentClientError, cc.User.from_django_user, anon)

--- a/lms/lib/comment_client/user.py
+++ b/lms/lib/comment_client/user.py
@@ -25,7 +25,10 @@ class User(models.Model):
     def from_django_user(cls, user):
 
         if type(user) is not django_user:
-            raise CommentClientError("Cannot convert unexpected class to User")
+            raise CommentClientError(
+                "Cannot convert unexpected class to User. "
+                "Type recieved was {type}".format(
+                type=user.__class__.__name__))
 
         return cls(id=str(user.id),
                    external_id=str(user.id),

--- a/lms/lib/comment_client/user.py
+++ b/lms/lib/comment_client/user.py
@@ -1,4 +1,5 @@
 from .utils import merge_dict, perform_request, CommentClientError
+from django.contrib.auth.models import User as django_user
 
 import models
 import settings
@@ -22,6 +23,10 @@ class User(models.Model):
 
     @classmethod
     def from_django_user(cls, user):
+
+        if type(user) is not django_user:
+            raise CommentClientError("Cannot convert unexpected class to User")
+
         return cls(id=str(user.id),
                    external_id=str(user.id),
                    username=user.username,


### PR DESCRIPTION
We are getting these in production periodically

```
Jun  6 20:30:47 prod-edxapp-007 [service_variant=lms][django.request][env:prod_edx] ERROR [prod-edxapp-007  26287] [base.py:215] - Internal Server Error: /courses/HarvardX/CB22x/2013_Spring/discussion/forum/users/1423155/followed
Traceback (most recent call last):
  File "/opt/edx/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 111, in get_response
    response = callback(request, *callback_args, **callback_kwargs)
  File "/opt/edx/local/lib/python2.7/site-packages/newrelic-1.8.0.13/newrelic/api/object_wrapper.py", line 220, in __call__
    self._nr_instance, args, kwargs)
  File "/opt/edx/local/lib/python2.7/site-packages/newrelic-1.8.0.13/newrelic/hooks/framework_django.py", line 471, in wrapper
    return wrapped(*args, **kwargs)
  File "/opt/wwc/edx-platform/lms/djangoapps/django_comment_client/forum/views.py", line 391, in followed_threads
    user_info = cc.User.from_django_user(request.user).to_dict()
  File "/opt/wwc/edx-platform/lms/lib/comment_client/user.py", line 28, in from_django_user
    email=user.email)
  File "/opt/edx/local/lib/python2.7/site-packages/django/utils/functional.py", line 185, in inner
    return func(self._wrapped, *args)
AttributeError: 'AnonymousUser' object has no attribute 'email'
```

This pull request changes the behavior of User.from_django_user(request.user) to throw an error if it received the wrong type.  This will not fix the errors, but will hopefully make the root cause more clear.  The call to this method without a real user cannot succeed in a useful way, so raising an error seems appropriate.

Run with

```
rake test_lms[comment_client.tests.tests:CommentClientTest]
```
