### PR TITLE
Move "stringy" functionality into xblock fields

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,10 @@ These are notable changes in edx-platform.  This is a rolling list of changes,
 in roughly chronological order, most recent first.  Add your entries at or near
 the top.  Include a label indicating the component affected.
 
+Studio, LMS: Make ModelTypes more strict about their expected content (for
+instance, Boolean, Integer, String), but also allow them to hold either the
+typed value, or a String that can be converted to their typed value. For example,
+an Integer can contain 3 or '3'. This changed an update to the xblock library.
 
 LMS: Some errors handling Non-ASCII data in XML courses have been fixed.
 

--- a/cms/djangoapps/contentstore/features/advanced-settings.feature
+++ b/cms/djangoapps/contentstore/features/advanced-settings.feature
@@ -28,10 +28,15 @@ Feature: Advanced (manual) course policy
 
   Scenario: Test how multi-line input appears
     Given I am on the Advanced Course Settings page in Studio
-    When I create a JSON object as a value
+    When I create a JSON object as a value for "discussion_topics"
     Then it is displayed as formatted
     And I reload the page
     Then it is displayed as formatted
+
+  Scenario: Test error if value supplied is of the wrong type
+    Given I am on the Advanced Course Settings page in Studio
+    When I create a JSON object as a value for "display_name"
+    Then I get an error on save
 
   Scenario: Test automatic quoting of non-JSON values
     Given I am on the Advanced Course Settings page in Studio

--- a/cms/djangoapps/contentstore/features/advanced-settings.feature
+++ b/cms/djangoapps/contentstore/features/advanced-settings.feature
@@ -37,6 +37,8 @@ Feature: Advanced (manual) course policy
     Given I am on the Advanced Course Settings page in Studio
     When I create a JSON object as a value for "display_name"
     Then I get an error on save
+    And I reload the page
+    Then the policy key value is unchanged
 
   Scenario: Test automatic quoting of non-JSON values
     Given I am on the Advanced Course Settings page in Studio

--- a/cms/djangoapps/contentstore/features/problem-editor.py
+++ b/cms/djangoapps/contentstore/features/problem-editor.py
@@ -41,7 +41,9 @@ def i_see_five_settings_with_values(step):
 
 @step('I can modify the display name')
 def i_can_modify_the_display_name(step):
-    world.get_setting_entry(DISPLAY_NAME).find_by_css('.setting-input')[0].fill('modified')
+    # Verifying that the display name can be a string containing a floating point value
+    # (to confirm that we don't throw an error because it is of the wrong type).
+    world.get_setting_entry(DISPLAY_NAME).find_by_css('.setting-input')[0].fill('3.4')
     verify_modified_display_name()
 
 
@@ -172,7 +174,7 @@ def verify_modified_randomization():
 
 
 def verify_modified_display_name():
-    world.verify_setting_entry(world.get_setting_entry(DISPLAY_NAME), DISPLAY_NAME, 'modified', True)
+    world.verify_setting_entry(world.get_setting_entry(DISPLAY_NAME), DISPLAY_NAME, '3.4', True)
 
 
 def verify_modified_display_name_with_special_chars():

--- a/cms/djangoapps/contentstore/tests/test_checklists.py
+++ b/cms/djangoapps/contentstore/tests/test_checklists.py
@@ -19,6 +19,24 @@ class ChecklistTestCase(CourseTestCase):
         modulestore = get_modulestore(self.course.location)
         return modulestore.get_item(self.course.location).checklists
 
+
+    def compare_checklists(self, persisted, request):
+        """
+        Handles url expansion as possible difference and descends into guts
+        :param persisted:
+        :param request:
+        """
+        self.assertEqual(persisted['short_description'], request['short_description'])
+        compare_urls = (persisted.get('action_urls_expanded') == request.get('action_urls_expanded'))
+        for pers, req in zip(persisted['items'], request['items']):
+            self.assertEqual(pers['short_description'], req['short_description'])
+        self.assertEqual(pers['long_description'], req['long_description'])
+        self.assertEqual(pers['is_checked'], req['is_checked'])
+        if compare_urls:
+            self.assertEqual(pers['action_url'], req['action_url'])
+        self.assertEqual(pers['action_text'], req['action_text'])
+        self.assertEqual(pers['action_external'], req['action_external'])
+
     def test_get_checklists(self):
         """ Tests the get checklists method. """
         checklists_url = get_url_reverse('Checklists', self.course)
@@ -31,9 +49,9 @@ class ChecklistTestCase(CourseTestCase):
         self.course.checklists = None
         modulestore = get_modulestore(self.course.location)
         modulestore.update_metadata(self.course.location, own_metadata(self.course))
-        self.assertEquals(self.get_persisted_checklists(), None)
+        self.assertEqual(self.get_persisted_checklists(), None)
         response = self.client.get(checklists_url)
-        self.assertEquals(payload, response.content)
+        self.assertEqual(payload, response.content)
 
     def test_update_checklists_no_index(self):
         """ No checklist index, should return all of them. """
@@ -43,7 +61,8 @@ class ChecklistTestCase(CourseTestCase):
             'name': self.course.location.name})
 
         returned_checklists = json.loads(self.client.get(update_url).content)
-        self.assertListEqual(self.get_persisted_checklists(), returned_checklists)
+        for pay, resp in zip(self.get_persisted_checklists(), returned_checklists):
+            self.compare_checklists(pay, resp)
 
     def test_update_checklists_index_ignored_on_get(self):
         """ Checklist index ignored on get. """
@@ -53,7 +72,8 @@ class ChecklistTestCase(CourseTestCase):
                                                            'checklist_index': 1})
 
         returned_checklists = json.loads(self.client.get(update_url).content)
-        self.assertListEqual(self.get_persisted_checklists(), returned_checklists)
+        for pay, resp in zip(self.get_persisted_checklists(), returned_checklists):
+            self.compare_checklists(pay, resp)
 
     def test_update_checklists_post_no_index(self):
         """ No checklist index, will error on post. """
@@ -78,13 +98,18 @@ class ChecklistTestCase(CourseTestCase):
                                                            'course': self.course.location.course,
                                                            'name': self.course.location.name,
                                                            'checklist_index': 2})
+
+        def get_first_item(checklist):
+            return checklist['items'][0]
+
         payload = self.course.checklists[2]
-        self.assertFalse(payload.get('is_checked'))
-        payload['is_checked'] = True
+        self.assertFalse(get_first_item(payload).get('is_checked'))
+        get_first_item(payload)['is_checked'] = True
 
         returned_checklist = json.loads(self.client.post(update_url, json.dumps(payload), "application/json").content)
-        self.assertTrue(returned_checklist.get('is_checked'))
-        self.assertEqual(self.get_persisted_checklists()[2], returned_checklist)
+        self.assertTrue(get_first_item(returned_checklist).get('is_checked'))
+        pers = self.get_persisted_checklists()
+        self.compare_checklists(pers[2], returned_checklist)
 
     def test_update_checklists_delete_unsupported(self):
         """ Delete operation is not supported. """

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -401,8 +401,11 @@ def course_advanced_updates(request, org, course, name):
                         request_body.update({'tabs': new_tabs})
                         #Indicate that tabs should *not* be filtered out of the metadata
                         filter_tabs = False
-
-        response_json = json.dumps(CourseMetadata.update_from_json(location,
+        try:
+            response_json = json.dumps(CourseMetadata.update_from_json(location,
                                                                    request_body,
                                                                    filter_tabs=filter_tabs))
+        except (TypeError, ValueError), e:
+            return HttpResponseBadRequest("Incorrect setting format. " + str(e), content_type="text/plain")
+
         return HttpResponse(response_json, mimetype="application/json")

--- a/cms/xmodule_namespace.py
+++ b/cms/xmodule_namespace.py
@@ -5,7 +5,6 @@ Namespace defining common fields used by Studio for all blocks
 import datetime
 
 from xblock.core import Namespace, Scope, ModelType, String
-from xmodule.fields import StringyBoolean
 
 
 class DateTuple(ModelType):
@@ -28,4 +27,3 @@ class CmsNamespace(Namespace):
     """
     published_date = DateTuple(help="Date when the module was published", scope=Scope.settings)
     published_by = String(help="Id of the user who published this module", scope=Scope.settings)
-

--- a/common/lib/xmodule/xmodule/abtest_module.py
+++ b/common/lib/xmodule/xmodule/abtest_module.py
@@ -6,7 +6,7 @@ from xmodule.x_module import XModule
 from xmodule.raw_module import RawDescriptor
 from xmodule.xml_module import XmlDescriptor
 from xmodule.exceptions import InvalidDefinitionError
-from xblock.core import String, Scope, Object
+from xblock.core import String, Scope, Dict
 
 DEFAULT = "_DEFAULT_GROUP"
 
@@ -32,9 +32,9 @@ def group_from_value(groups, v):
 
 
 class ABTestFields(object):
-    group_portions = Object(help="What proportions of students should go in each group", default={DEFAULT: 1}, scope=Scope.content)
-    group_assignments = Object(help="What group this user belongs to", scope=Scope.preferences, default={})
-    group_content = Object(help="What content to display to each group", scope=Scope.content, default={DEFAULT: []})
+    group_portions = Dict(help="What proportions of students should go in each group", default={DEFAULT: 1}, scope=Scope.content)
+    group_assignments = Dict(help="What group this user belongs to", scope=Scope.preferences, default={})
+    group_content = Dict(help="What content to display to each group", scope=Scope.content, default={DEFAULT: []})
     experiment = String(help="Experiment that this A/B test belongs to", scope=Scope.content)
     has_children = True
 

--- a/common/lib/xmodule/xmodule/capa_module.py
+++ b/common/lib/xmodule/xmodule/capa_module.py
@@ -18,7 +18,7 @@ from .progress import Progress
 from xmodule.x_module import XModule
 from xmodule.raw_module import RawDescriptor
 from xmodule.exceptions import NotFoundError, ProcessingError
-from xblock.core import Scope, String, Boolean, Object, Integer, Float
+from xblock.core import Scope, String, Boolean, Dict, Integer, Float
 from .fields import Timedelta, Date
 from xmodule.util.date_utils import time_to_datetime
 
@@ -95,9 +95,9 @@ class CapaFields(object):
                                                         {"display_name": "Per Student", "value": "per_student"}]
     )
     data = String(help="XML data for the problem", scope=Scope.content)
-    correct_map = Object(help="Dictionary with the correctness of current student answers", scope=Scope.user_state, default={})
-    input_state = Object(help="Dictionary for maintaining the state of inputtypes", scope=Scope.user_state)
-    student_answers = Object(help="Dictionary with the current student responses", scope=Scope.user_state)
+    correct_map = Dict(help="Dictionary with the correctness of current student answers", scope=Scope.user_state, default={})
+    input_state = Dict(help="Dictionary for maintaining the state of inputtypes", scope=Scope.user_state)
+    student_answers = Dict(help="Dictionary with the current student responses", scope=Scope.user_state)
     done = Boolean(help="Whether the student has answered the problem", scope=Scope.user_state)
     seed = Integer(help="Random seed for this student", scope=Scope.user_state)
     weight = Float(

--- a/common/lib/xmodule/xmodule/capa_module.py
+++ b/common/lib/xmodule/xmodule/capa_module.py
@@ -18,8 +18,8 @@ from .progress import Progress
 from xmodule.x_module import XModule
 from xmodule.raw_module import RawDescriptor
 from xmodule.exceptions import NotFoundError, ProcessingError
-from xblock.core import Scope, String, Boolean, Object
-from .fields import Timedelta, Date, StringyInteger, StringyFloat
+from xblock.core import Scope, String, Boolean, Object, Integer, Float
+from .fields import Timedelta, Date
 from xmodule.util.date_utils import time_to_datetime
 
 log = logging.getLogger("mitx.courseware")
@@ -65,8 +65,8 @@ class ComplexEncoder(json.JSONEncoder):
 
 
 class CapaFields(object):
-    attempts = StringyInteger(help="Number of attempts taken by the student on this problem", default=0, scope=Scope.user_state)
-    max_attempts = StringyInteger(
+    attempts = Integer(help="Number of attempts taken by the student on this problem", default=0, scope=Scope.user_state)
+    max_attempts = Integer(
         display_name="Maximum Attempts",
         help="Defines the number of times a student can try to answer this problem. If the value is not set, infinite attempts are allowed.",
         values={"min": 1}, scope=Scope.settings
@@ -99,8 +99,8 @@ class CapaFields(object):
     input_state = Object(help="Dictionary for maintaining the state of inputtypes", scope=Scope.user_state)
     student_answers = Object(help="Dictionary with the current student responses", scope=Scope.user_state)
     done = Boolean(help="Whether the student has answered the problem", scope=Scope.user_state)
-    seed = StringyInteger(help="Random seed for this student", scope=Scope.user_state)
-    weight = StringyFloat(
+    seed = Integer(help="Random seed for this student", scope=Scope.user_state)
+    weight = Float(
         display_name="Problem Weight",
         help="Defines the number of points each problem is worth. If the value is not set, each response field in the problem is worth one point.",
         values={"min": 0, "step": .1},
@@ -315,7 +315,7 @@ class CapaModule(CapaFields, XModule):
         # If the user has forced the save button to display,
         # then show it as long as the problem is not closed
         # (past due / too many attempts)
-        if self.force_save_button == "true":
+        if self.force_save_button:
             return not self.closed()
         else:
             is_survey_question = (self.max_attempts == 0)
@@ -782,7 +782,7 @@ class CapaModule(CapaFields, XModule):
                 return {'success': msg}
             raise
 
-        self.attempts = self.attempts + 1
+        self.attempts += 1
         self.lcp.done = True
 
         self.set_state_from_lcp()

--- a/common/lib/xmodule/xmodule/capa_module.py
+++ b/common/lib/xmodule/xmodule/capa_module.py
@@ -782,7 +782,7 @@ class CapaModule(CapaFields, XModule):
                 return {'success': msg}
             raise
 
-        self.attempts += 1
+        self.attempts = self.attempts + 1
         self.lcp.done = True
 
         self.set_state_from_lcp()

--- a/common/lib/xmodule/xmodule/capa_module.py
+++ b/common/lib/xmodule/xmodule/capa_module.py
@@ -315,7 +315,7 @@ class CapaModule(CapaFields, XModule):
         # If the user has forced the save button to display,
         # then show it as long as the problem is not closed
         # (past due / too many attempts)
-        if self.force_save_button == "true":
+        if self.force_save_button:
             return not self.closed()
         else:
             is_survey_question = (self.max_attempts == 0)

--- a/common/lib/xmodule/xmodule/combined_open_ended_module.py
+++ b/common/lib/xmodule/xmodule/combined_open_ended_module.py
@@ -5,10 +5,10 @@ from pkg_resources import resource_string
 
 from xmodule.raw_module import RawDescriptor
 from .x_module import XModule
-from xblock.core import Integer, Scope, String, List
+from xblock.core import Integer, Scope, String, List, Float, Boolean
 from xmodule.open_ended_grading_classes.combined_open_ended_modulev1 import CombinedOpenEndedV1Module, CombinedOpenEndedV1Descriptor
 from collections import namedtuple
-from .fields import Date, StringyFloat, StringyInteger, StringyBoolean
+from .fields import Date
 
 log = logging.getLogger("mitx.courseware")
 
@@ -53,27 +53,27 @@ class CombinedOpenEndedFields(object):
         help="This name appears in the horizontal navigation at the top of the page.",
         default="Open Ended Grading", scope=Scope.settings
     )
-    current_task_number = StringyInteger(help="Current task that the student is on.", default=0, scope=Scope.user_state)
+    current_task_number = Integer(help="Current task that the student is on.", default=0, scope=Scope.user_state)
     task_states = List(help="List of state dictionaries of each task within this module.", scope=Scope.user_state)
     state = String(help="Which step within the current task that the student is on.", default="initial",
                    scope=Scope.user_state)
-    student_attempts = StringyInteger(help="Number of attempts taken by the student on this problem", default=0,
+    student_attempts = Integer(help="Number of attempts taken by the student on this problem", default=0,
                                       scope=Scope.user_state)
-    ready_to_reset = StringyBoolean(
+    ready_to_reset = Boolean(
         help="If the problem is ready to be reset or not.", default=False,
         scope=Scope.user_state
     )
-    attempts = StringyInteger(
+    attempts = Integer(
         display_name="Maximum Attempts",
         help="The number of times the student can try to answer this problem.", default=1,
         scope=Scope.settings, values = {"min" : 1 }
     )
-    is_graded = StringyBoolean(display_name="Graded", help="Whether or not the problem is graded.", default=False, scope=Scope.settings)
-    accept_file_upload = StringyBoolean(
+    is_graded = Boolean(display_name="Graded", help="Whether or not the problem is graded.", default=False, scope=Scope.settings)
+    accept_file_upload = Boolean(
         display_name="Allow File Uploads",
         help="Whether or not the student can submit files as a response.", default=False, scope=Scope.settings
     )
-    skip_spelling_checks = StringyBoolean(
+    skip_spelling_checks = Boolean(
         display_name="Disable Quality Filter",
         help="If False, the Quality Filter is enabled and submissions with poor spelling, short length, or poor grammar will not be peer reviewed.",
         default=False, scope=Scope.settings
@@ -86,7 +86,7 @@ class CombinedOpenEndedFields(object):
     )
     version = VersionInteger(help="Current version number", default=DEFAULT_VERSION, scope=Scope.settings)
     data = String(help="XML data for the problem", scope=Scope.content)
-    weight = StringyFloat(
+    weight = Float(
         display_name="Problem Weight",
         help="Defines the number of points each problem is worth. If the value is not set, each problem is worth one point.",
         scope=Scope.settings, values = {"min" : 0 , "step": ".1"}

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -17,7 +17,7 @@ from xmodule.graders import grader_from_conf
 from xmodule.util.date_utils import time_to_datetime
 import json
 
-from xblock.core import Scope, List, String, Object, Boolean
+from xblock.core import Scope, List, String, Dict, Boolean
 from .fields import Date
 
 
@@ -154,25 +154,25 @@ class CourseFields(object):
     start = Date(help="Start time when this module is visible", scope=Scope.settings)
     end = Date(help="Date that this class ends", scope=Scope.settings)
     advertised_start = String(help="Date that this course is advertised to start", scope=Scope.settings)
-    grading_policy = Object(help="Grading policy definition for this class", scope=Scope.content)
+    grading_policy = Dict(help="Grading policy definition for this class", scope=Scope.content)
     show_calculator = Boolean(help="Whether to show the calculator in this course", default=False, scope=Scope.settings)
     display_name = String(help="Display name for this module", scope=Scope.settings)
     tabs = List(help="List of tabs to enable in this course", scope=Scope.settings)
     end_of_course_survey_url = String(help="Url for the end-of-course survey", scope=Scope.settings)
     discussion_blackouts = List(help="List of pairs of start/end dates for discussion blackouts", scope=Scope.settings)
-    discussion_topics = Object(
+    discussion_topics = Dict(
         help="Map of topics names to ids",
         scope=Scope.settings
         )
-    testcenter_info = Object(help="Dictionary of Test Center info", scope=Scope.settings)
+    testcenter_info = Dict(help="Dictionary of Test Center info", scope=Scope.settings)
     announcement = Date(help="Date this course is announced", scope=Scope.settings)
-    cohort_config = Object(help="Dictionary defining cohort configuration", scope=Scope.settings)
+    cohort_config = Dict(help="Dictionary defining cohort configuration", scope=Scope.settings)
     is_new = Boolean(help="Whether this course should be flagged as new", scope=Scope.settings)
     no_grade = Boolean(help="True if this course isn't graded", default=False, scope=Scope.settings)
     disable_progress_graph = Boolean(help="True if this course shouldn't display the progress graph", default=False, scope=Scope.settings)
     pdf_textbooks = List(help="List of dictionaries containing pdf_textbook configuration", scope=Scope.settings)
     html_textbooks = List(help="List of dictionaries containing html_textbook configuration", scope=Scope.settings)
-    remote_gradebook = Object(scope=Scope.settings)
+    remote_gradebook = Dict(scope=Scope.settings)
     allow_anonymous = Boolean(scope=Scope.settings, default=True)
     allow_anonymous_to_peers = Boolean(scope=Scope.settings, default=False)
     advanced_modules = List(help="Beta modules used in your course", scope=Scope.settings)

--- a/common/lib/xmodule/xmodule/fields.py
+++ b/common/lib/xmodule/xmodule/fields.py
@@ -2,12 +2,10 @@ import time
 import logging
 import re
 
-from datetime import timedelta
 from xblock.core import ModelType
 import datetime
 import dateutil.parser
 
-from xblock.core import Integer, Float, Boolean
 from django.utils.timezone import UTC
 
 log = logging.getLogger(__name__)

--- a/common/lib/xmodule/xmodule/fields.py
+++ b/common/lib/xmodule/xmodule/fields.py
@@ -7,8 +7,6 @@ from xblock.core import ModelType
 import datetime
 import dateutil.parser
 
-from xblock.core import Integer, Float, Boolean
-
 log = logging.getLogger(__name__)
 
 
@@ -83,42 +81,3 @@ class Timedelta(ModelType):
             if cur_value > 0:
                 values.append("%d %s" % (cur_value, attr))
         return ' '.join(values)
-
-
-class StringyInteger(Integer):
-    """
-    A model type that converts from strings to integers when reading from json.
-    If value does not parse as an int, returns None.
-    """
-    def from_json(self, value):
-        try:
-            return int(value)
-        except:
-            return None
-
-
-class StringyFloat(Float):
-    """
-    A model type that converts from string to floats when reading from json.
-    If value does not parse as a float, returns None.
-    """
-    def from_json(self, value):
-        try:
-            return float(value)
-        except:
-            return None
-
-
-class StringyBoolean(Boolean):
-    """
-    Reads strings from JSON as booleans.
-
-    If the string is 'true' (case insensitive), then return True,
-    otherwise False.
-
-    JSON values that aren't strings are returned as-is.
-    """
-    def from_json(self, value):
-        if isinstance(value, basestring):
-            return value.lower() == 'true'
-        return value

--- a/common/lib/xmodule/xmodule/peer_grading_module.py
+++ b/common/lib/xmodule/xmodule/peer_grading_module.py
@@ -10,7 +10,7 @@ from .x_module import XModule
 from xmodule.raw_module import RawDescriptor
 from xmodule.modulestore.django import modulestore
 from .timeinfo import TimeInfo
-from xblock.core import Object, String, Scope, Boolean, Integer, Float
+from xblock.core import Dict, String, Scope, Boolean, Integer, Float
 from xmodule.fields import Date
 
 from xmodule.open_ended_grading_classes.peer_grading_service import PeerGradingService, GradingServiceError, MockPeerGradingService
@@ -49,7 +49,7 @@ class PeerGradingFields(object):
         help="The maximum grade that a student can receive for this problem.", default=MAX_SCORE,
         scope=Scope.settings, values={"min": 0}
     )
-    student_data_for_location = Object(
+    student_data_for_location = Dict(
         help="Student data for a given peer grading problem.",
         scope=Scope.user_state
     )

--- a/common/lib/xmodule/xmodule/peer_grading_module.py
+++ b/common/lib/xmodule/xmodule/peer_grading_module.py
@@ -54,7 +54,7 @@ class PeerGradingFields(object):
         help="Student data for a given peer grading problem.",
         scope=Scope.user_state
     )
-    weight = StringyFloat(
+    weight = Float(
         display_name="Problem Weight",
         help="Defines the number of points each problem is worth. If the value is not set, each problem is worth one point.",
         scope=Scope.settings, values={"min": 0, "step": ".1"}
@@ -112,7 +112,7 @@ class PeerGradingModule(PeerGradingFields, XModule):
         if not self.ajax_url.endswith("/"):
             self.ajax_url = self.ajax_url + "/"
 
-        # StringyInteger could return None, so keep this check.
+        # Integer could return None, so keep this check.
         if not isinstance(self.max_grade, int):
             raise TypeError("max_grade needs to be an integer.")
 

--- a/common/lib/xmodule/xmodule/poll_module.py
+++ b/common/lib/xmodule/xmodule/poll_module.py
@@ -19,7 +19,7 @@ from xmodule.x_module import XModule
 from xmodule.stringify import stringify_children
 from xmodule.mako_module import MakoModuleDescriptor
 from xmodule.xml_module import XmlDescriptor
-from xblock.core import Scope, String, Object, Boolean, List
+from xblock.core import Scope, String, Dict, Boolean, List
 
 log = logging.getLogger(__name__)
 
@@ -30,7 +30,7 @@ class PollFields(object):
 
     voted = Boolean(help="Whether this student has voted on the poll", scope=Scope.user_state, default=False)
     poll_answer = String(help="Student answer", scope=Scope.user_state, default='')
-    poll_answers = Object(help="All possible answers for the poll fro other students", scope=Scope.content)
+    poll_answers = Dict(help="All possible answers for the poll fro other students", scope=Scope.content)
 
     answers = List(help="Poll answers from xml", scope=Scope.content, default=[])
     question = String(help="Poll question", scope=Scope.content, default='')

--- a/common/lib/xmodule/xmodule/tests/test_fields.py
+++ b/common/lib/xmodule/xmodule/tests/test_fields.py
@@ -2,7 +2,7 @@
 import datetime
 import unittest
 from django.utils.timezone import UTC
-from xmodule.fields import Date
+from xmodule.fields import Date, Timedelta
 import time
 
 class DateTest(unittest.TestCase):
@@ -92,4 +92,41 @@ class DateTest(unittest.TestCase):
         self.assertEqual(
             '2012-12-31T23:59:59Z',
             DateTest.date.deserialize('"2012-12-31T23:59:59Z"'),
+        )
+
+
+class TimedeltaTest(unittest.TestCase):
+    delta = Timedelta()
+
+    def test_from_json(self):
+        self.assertEqual(
+            TimedeltaTest.delta.from_json('1 day 12 hours 59 minutes 59 seconds'),
+            datetime.timedelta(days=1, hours=12, minutes=59, seconds=59)
+        )
+
+        self.assertEqual(
+            TimedeltaTest.delta.from_json('1 day 46799 seconds'),
+            datetime.timedelta(days=1, seconds=46799)
+        )
+
+    def test_to_json(self):
+        self.assertEqual(
+            '1 days 46799 seconds',
+            TimedeltaTest.delta.to_json(datetime.timedelta(days=1, hours=12, minutes=59, seconds=59))
+        )
+
+    def test_serialize(self):
+        self.assertEqual(
+            TimedeltaTest.delta.serialize('1 day 12 hours 59 minutes 59 seconds'),
+            '"1 day 12 hours 59 minutes 59 seconds"'
+        )
+
+    def test_deserialize(self):
+        self.assertEqual(
+            '1 day 12 hours 59 minutes 59 seconds',
+            TimedeltaTest.delta.deserialize('1 day 12 hours 59 minutes 59 seconds')
+        )
+        self.assertEqual(
+            '1 day 12 hours 59 minutes 59 seconds',
+            TimedeltaTest.delta.deserialize('"1 day 12 hours 59 minutes 59 seconds"')
         )

--- a/common/lib/xmodule/xmodule/tests/test_fields.py
+++ b/common/lib/xmodule/xmodule/tests/test_fields.py
@@ -2,7 +2,7 @@
 import datetime
 import unittest
 from django.utils.timezone import UTC
-from xmodule.fields import Date, StringyFloat, StringyInteger, StringyBoolean
+from xmodule.fields import Date
 import time
 
 class DateTest(unittest.TestCase):
@@ -77,56 +77,4 @@ class DateTest(unittest.TestCase):
             DateTest.date.to_json(
                 DateTest.date.from_json("2012-12-31T23:00:01-01:00")),
             "2013-01-01T00:00:01Z")
-
-
-class StringyIntegerTest(unittest.TestCase):
-    def assertEquals(self, expected, arg):
-        self.assertEqual(expected, StringyInteger().from_json(arg))
-
-    def test_integer(self):
-        self.assertEquals(5, '5')
-        self.assertEquals(0, '0')
-        self.assertEquals(-1023, '-1023')
-
-    def test_none(self):
-        self.assertEquals(None, None)
-        self.assertEquals(None, 'abc')
-        self.assertEquals(None, '[1]')
-        self.assertEquals(None, '1.023')
-
-
-class StringyFloatTest(unittest.TestCase):
-
-    def assertEquals(self, expected, arg):
-        self.assertEqual(expected, StringyFloat().from_json(arg))
-
-    def test_float(self):
-        self.assertEquals(.23, '.23')
-        self.assertEquals(5, '5')
-        self.assertEquals(0, '0.0')
-        self.assertEquals(-1023.22, '-1023.22')
-
-    def test_none(self):
-        self.assertEquals(None, None)
-        self.assertEquals(None, 'abc')
-        self.assertEquals(None, '[1]')
-
-
-class StringyBooleanTest(unittest.TestCase):
-
-    def assertEquals(self, expected, arg):
-        self.assertEqual(expected, StringyBoolean().from_json(arg))
-
-    def test_false(self):
-        self.assertEquals(False, "false")
-        self.assertEquals(False, "False")
-        self.assertEquals(False, "")
-        self.assertEquals(False, "hahahahah")
-
-    def test_true(self):
-        self.assertEquals(True, "true")
-        self.assertEquals(True, "TruE")
-
-    def test_pass_through(self):
-        self.assertEquals(123, 123)
 

--- a/common/lib/xmodule/xmodule/tests/test_fields.py
+++ b/common/lib/xmodule/xmodule/tests/test_fields.py
@@ -78,22 +78,6 @@ class DateTest(unittest.TestCase):
                 DateTest.date.from_json("2012-12-31T23:00:01-01:00")),
             "2013-01-01T00:00:01Z")
 
-    def test_serialize(self):
-        self.assertEqual(
-            DateTest.date.serialize("2012-12-31T23:59:59Z"),
-            '"2012-12-31T23:59:59Z"'
-        )
-
-    def test_deserialize(self):
-        self.assertEqual(
-            '2012-12-31T23:59:59Z',
-            DateTest.date.deserialize("2012-12-31T23:59:59Z"),
-        )
-        self.assertEqual(
-            '2012-12-31T23:59:59Z',
-            DateTest.date.deserialize('"2012-12-31T23:59:59Z"'),
-        )
-
 
 class TimedeltaTest(unittest.TestCase):
     delta = Timedelta()
@@ -113,20 +97,4 @@ class TimedeltaTest(unittest.TestCase):
         self.assertEqual(
             '1 days 46799 seconds',
             TimedeltaTest.delta.to_json(datetime.timedelta(days=1, hours=12, minutes=59, seconds=59))
-        )
-
-    def test_serialize(self):
-        self.assertEqual(
-            TimedeltaTest.delta.serialize('1 day 12 hours 59 minutes 59 seconds'),
-            '"1 day 12 hours 59 minutes 59 seconds"'
-        )
-
-    def test_deserialize(self):
-        self.assertEqual(
-            '1 day 12 hours 59 minutes 59 seconds',
-            TimedeltaTest.delta.deserialize('1 day 12 hours 59 minutes 59 seconds')
-        )
-        self.assertEqual(
-            '1 day 12 hours 59 minutes 59 seconds',
-            TimedeltaTest.delta.deserialize('"1 day 12 hours 59 minutes 59 seconds"')
         )

--- a/common/lib/xmodule/xmodule/tests/test_fields.py
+++ b/common/lib/xmodule/xmodule/tests/test_fields.py
@@ -78,3 +78,18 @@ class DateTest(unittest.TestCase):
                 DateTest.date.from_json("2012-12-31T23:00:01-01:00")),
             "2013-01-01T00:00:01Z")
 
+    def test_serialize(self):
+        self.assertEqual(
+            DateTest.date.serialize("2012-12-31T23:59:59Z"),
+            '"2012-12-31T23:59:59Z"'
+        )
+
+    def test_deserialize(self):
+        self.assertEqual(
+            '2012-12-31T23:59:59Z',
+            DateTest.date.deserialize("2012-12-31T23:59:59Z"),
+        )
+        self.assertEqual(
+            '2012-12-31T23:59:59Z',
+            DateTest.date.deserialize('"2012-12-31T23:59:59Z"'),
+        )

--- a/common/lib/xmodule/xmodule/tests/test_xml_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_xml_module.py
@@ -2,7 +2,7 @@
 #pylint: disable=C0111
 
 from xmodule.x_module import XModuleFields
-from xblock.core import Scope, String, Object, Boolean, Integer, Float, Any, List
+from xblock.core import Scope, String, Dict, Boolean, Integer, Float, Any, List
 from xmodule.fields import Date, Timedelta
 from xmodule.xml_module import XmlDescriptor, serialize_field, deserialize_field
 import unittest
@@ -22,7 +22,7 @@ class TestFields(object):
     # Will not be returned by editable_metadata_fields because filtered out by non_editable_metadata_fields.
     due = Date(scope=Scope.settings)
     # Will not be returned by editable_metadata_fields because is not Scope.settings.
-    student_answers = Object(scope=Scope.user_state)
+    student_answers = Dict(scope=Scope.user_state)
     # Will be returned, and can override the inherited value from XModule.
     display_name = String(scope=Scope.settings, default='local default', display_name='Local Display Name',
                           help='local help')

--- a/common/lib/xmodule/xmodule/tests/test_xml_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_xml_module.py
@@ -2,8 +2,8 @@
 #pylint: disable=C0111
 
 from xmodule.x_module import XModuleFields
-from xblock.core import Scope, String, Object, Boolean
-from xmodule.fields import Date, StringyInteger, StringyFloat
+from xblock.core import Scope, String, Object, Boolean, Integer, Float
+from xmodule.fields import Date
 from xmodule.xml_module import XmlDescriptor
 import unittest
 from .import test_system
@@ -17,7 +17,7 @@ class CrazyJsonString(String):
 
 class TestFields(object):
     # Will be returned by editable_metadata_fields.
-    max_attempts = StringyInteger(scope=Scope.settings, default=1000, values={'min': 1, 'max': 10})
+    max_attempts = Integer(scope=Scope.settings, default=1000, values={'min': 1, 'max': 10})
     # Will not be returned by editable_metadata_fields because filtered out by non_editable_metadata_fields.
     due = Date(scope=Scope.settings)
     # Will not be returned by editable_metadata_fields because is not Scope.settings.
@@ -33,9 +33,9 @@ class TestFields(object):
                 {'display_name': 'second', 'value': 'value b'}]
     )
     # Used for testing select type
-    float_select = StringyFloat(scope=Scope.settings, default=.999, values=[1.23, 0.98])
+    float_select = Float(scope=Scope.settings, default=.999, values=[1.23, 0.98])
     # Used for testing float type
-    float_non_select = StringyFloat(scope=Scope.settings, default=.999, values={'min': 0, 'step': .3})
+    float_non_select = Float(scope=Scope.settings, default=.999, values={'min': 0, 'step': .3})
     # Used for testing that Booleans get mapped to select type
     boolean_select = Boolean(scope=Scope.settings)
 

--- a/common/lib/xmodule/xmodule/tests/test_xml_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_xml_module.py
@@ -188,6 +188,18 @@ def assertDeserializeEqual(field, expected, arg):
     assert_equals(expected, deserialize_field(field, arg))
 
 
+def assertDeserializeNonString(field):
+    """
+    Asserts input value is returned for None or something that is not a string.
+    """
+    assertDeserializeEqual(field, None, None)
+    assertDeserializeEqual(field, 3.14, 3.14)
+    assertDeserializeEqual(field, True, True)
+    assertDeserializeEqual(field, [10], [10])
+    assertDeserializeEqual(field, {}, {})
+    assertDeserializeEqual(field, [], [])
+
+
 class TestSerializeInteger(unittest.TestCase):
     """ Tests serialize/deserialize as related to Integer type. """
 
@@ -208,7 +220,7 @@ class TestSerializeInteger(unittest.TestCase):
 
     def test_deserialize_unsupported_types(self):
         assertDeserializeEqual(Integer(), '[3]', '[3]')
-        self.assertRaises(TypeError, deserialize_field, None)
+        assertDeserializeNonString(Integer())
 
 
 class FloatTest(unittest.TestCase):
@@ -235,7 +247,7 @@ class FloatTest(unittest.TestCase):
 
     def test_deserialize_unsupported_types(self):
         assertDeserializeEqual(Float(), '[3]', '[3]')
-        self.assertRaises(TypeError, deserialize_field, None)
+        assertDeserializeNonString(Float())
 
 
 class BooleanTest(unittest.TestCase):
@@ -264,8 +276,7 @@ class BooleanTest(unittest.TestCase):
         assertDeserializeEqual(Boolean(), 'fAlse', '"fAlse"')
         assertDeserializeEqual(Boolean(), "TruE", '"TruE"')
 
-    def test_deserialize_unsupported_types(self):
-        self.assertRaises(TypeError, deserialize_field, None)
+        assertDeserializeNonString(Boolean())
 
 
 class StringTest(unittest.TestCase):
@@ -286,7 +297,7 @@ class StringTest(unittest.TestCase):
         assertDeserializeEqual(String(), 'false', 'false')
         assertDeserializeEqual(String(), '2', '2')
         assertDeserializeEqual(String(), '[3]', '[3]')
-        self.assertRaises(TypeError, deserialize_field, None)
+        assertDeserializeNonString(String())
 
 
 class AnyTest(unittest.TestCase):
@@ -307,9 +318,7 @@ class AnyTest(unittest.TestCase):
         assertDeserializeEqual(Any(), '[', '[')
         assertDeserializeEqual(Any(), False, 'false')
         assertDeserializeEqual(Any(), 3.4, '3.4')
-
-    def test_deserialize_unsupported_types(self):
-        self.assertRaises(TypeError, deserialize_field, None)
+        assertDeserializeNonString(Any())
 
 
 class ListTest(unittest.TestCase):
@@ -330,7 +339,7 @@ class ListTest(unittest.TestCase):
         assertDeserializeEqual(List(), '3.4', '3.4')
         assertDeserializeEqual(List(), 'false', 'false')
         assertDeserializeEqual(List(), '2', '2')
-        self.assertRaises(TypeError, deserialize_field, None)
+        assertDeserializeNonString(List())
 
 
 class DateTest(unittest.TestCase):
@@ -342,9 +351,11 @@ class DateTest(unittest.TestCase):
     def test_deserialize(self):
         assertDeserializeEqual(Date(), '2012-12-31T23:59:59Z', "2012-12-31T23:59:59Z")
         assertDeserializeEqual(Date(), '2012-12-31T23:59:59Z', '"2012-12-31T23:59:59Z"')
+        assertDeserializeNonString(Date())
 
 
 class TimedeltaTest(unittest.TestCase):
+    """ Tests serialize/deserialize as related to Timedelta type. """
 
     def test_serialize(self):
         assertSerializeEqual('"1 day 12 hours 59 minutes 59 seconds"',
@@ -355,3 +366,4 @@ class TimedeltaTest(unittest.TestCase):
             '1 day 12 hours 59 minutes 59 seconds')
         assertDeserializeEqual(Timedelta(), '1 day 12 hours 59 minutes 59 seconds',
             '"1 day 12 hours 59 minutes 59 seconds"')
+        assertDeserializeNonString(Timedelta())

--- a/common/lib/xmodule/xmodule/tests/test_xml_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_xml_module.py
@@ -105,7 +105,7 @@ class EditableMetadataFieldsTest(unittest.TestCase):
 
     def test_type_and_options(self):
         # test_display_name_field verifies that a String field is of type "Generic".
-        # test_integer_field verifies that a StringyInteger field is of type "Integer".
+        # test_integer_field verifies that a Integer field is of type "Integer".
 
         descriptor = self.get_descriptor({})
         editable_fields = descriptor.editable_metadata_fields

--- a/common/lib/xmodule/xmodule/word_cloud_module.py
+++ b/common/lib/xmodule/xmodule/word_cloud_module.py
@@ -14,7 +14,7 @@ from xmodule.raw_module import RawDescriptor
 from xmodule.editing_module import MetadataOnlyEditingDescriptor
 from xmodule.x_module import XModule
 
-from xblock.core import Scope, Object, Boolean, List, Integer
+from xblock.core import Scope, Dict, Boolean, List, Integer
 
 log = logging.getLogger(__name__)
 
@@ -63,11 +63,11 @@ class WordCloudFields(object):
         scope=Scope.user_state,
         default=[]
     )
-    all_words = Object(
+    all_words = Dict(
         help="All possible words from all students.",
         scope=Scope.content
     )
-    top_words = Object(
+    top_words = Dict(
         help="Top num_top_words words for word cloud.",
         scope=Scope.content
     )

--- a/common/lib/xmodule/xmodule/word_cloud_module.py
+++ b/common/lib/xmodule/xmodule/word_cloud_module.py
@@ -14,8 +14,7 @@ from xmodule.raw_module import RawDescriptor
 from xmodule.editing_module import MetadataOnlyEditingDescriptor
 from xmodule.x_module import XModule
 
-from xblock.core import Scope, Object, Boolean, List
-from fields import StringyBoolean, StringyInteger
+from xblock.core import Scope, Object, Boolean, List, Integer
 
 log = logging.getLogger(__name__)
 
@@ -32,21 +31,21 @@ def pretty_bool(value):
 
 class WordCloudFields(object):
     """XFields for word cloud."""
-    num_inputs = StringyInteger(
+    num_inputs = Integer(
         display_name="Inputs",
         help="Number of text boxes available for students to input words/sentences.",
         scope=Scope.settings,
         default=5,
         values={"min": 1}
     )
-    num_top_words = StringyInteger(
+    num_top_words = Integer(
         display_name="Maximum Words",
         help="Maximum number of words to be displayed in generated word cloud.",
         scope=Scope.settings,
         default=250,
         values={"min": 1}
     )
-    display_student_percents = StringyBoolean(
+    display_student_percents = Boolean(
         display_name="Show Percents",
         help="Statistics are shown for entered words near that word.",
         scope=Scope.settings,

--- a/common/lib/xmodule/xmodule/xml_module.py
+++ b/common/lib/xmodule/xmodule/xml_module.py
@@ -6,7 +6,7 @@ import sys
 from collections import namedtuple
 from lxml import etree
 
-from xblock.core import Object, Scope
+from xblock.core import Dict, Scope
 from xmodule.x_module import (XModuleDescriptor, policy_key)
 from xmodule.modulestore import Location
 from xmodule.modulestore.inheritance import own_metadata
@@ -120,7 +120,7 @@ class XmlDescriptor(XModuleDescriptor):
     Mixin class for standardized parsing of from xml
     """
 
-    xml_attributes = Object(help="Map of unhandled xml attributes, used only for storage between import and export",
+    xml_attributes = Dict(help="Map of unhandled xml attributes, used only for storage between import and export",
         default={}, scope=Scope.settings)
 
     # Extension to append to filename paths

--- a/common/test/data/full/course.xml
+++ b/common/test/data/full/course.xml
@@ -1,1 +1,1 @@
-<course filename="6.002_Spring_2012" slug="6.002_Spring_2012" graceperiod="1 day 12 hours 59 minutes 59 seconds" showanswer="attempted" rerandomize="never" name="6.002 Spring 2012" start="2015-07-17T12:00" course="full" org="edX" show_timezone="true"/>
+<course filename="6.002_Spring_2012" slug="6.002_Spring_2012" graceperiod="1 day 12 hours 59 minutes 59 seconds" showanswer="attempted" rerandomize="never" name="6.002 Spring 2012" start="2015-07-17T12:00" course="full" org="edX" show_timezone="true" advanced_modules="[&quot;videoalpha&quot;]"/>

--- a/lms/xmodule_namespace.py
+++ b/lms/xmodule_namespace.py
@@ -1,15 +1,15 @@
 """
 Namespace that defines fields common to all blocks used in the LMS
 """
-from xblock.core import Namespace, Boolean, Scope, String
-from xmodule.fields import Date, Timedelta, StringyFloat, StringyBoolean
+from xblock.core import Namespace, Boolean, Scope, String, Float
+from xmodule.fields import Date, Timedelta
 
 
 class LmsNamespace(Namespace):
     """
     Namespace that defines fields common to all blocks used in the LMS
     """
-    hide_from_toc = StringyBoolean(
+    hide_from_toc = Boolean(
         help="Whether to display this module in the table of contents",
         default=False,
         scope=Scope.settings
@@ -37,7 +37,7 @@ class LmsNamespace(Namespace):
     )
     showanswer = String(help="When to show the problem answer to the student", scope=Scope.settings, default="closed")
     rerandomize = String(help="When to rerandomize the problem", default="always", scope=Scope.settings)
-    days_early_for_beta = StringyFloat(
+    days_early_for_beta = Float(
         help="Number of days early to show content to beta users",
         default=None,
         scope=Scope.settings

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -8,7 +8,6 @@
 -e git://github.com/eventbrite/zendesk.git@d53fe0e81b623f084e91776bcf6369f8b7b63879#egg=zendesk
 
 # Our libraries:
-
--e git+https://github.com/edx/XBlock.git@3464c0fbfe#egg=XBlock
+-e git+https://github.com/edx/XBlock.git@4d8735e883#egg=XBlock
 -e git+https://github.com/edx/codejail.git@0a1b468#egg=codejail
 -e git+https://github.com/edx/diff-cover.git@v0.1.1#egg=diff_cover

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -9,6 +9,6 @@
 
 # Our libraries:
 
--e git+https://github.com/edx/XBlock.git@3464c0fbfe07bb16791386b26979f66ee2708b06#egg=XBlock
--e git+https://github.com/edx/codejail.git@5fb5fa0#egg=codejail
--e git+https://github.com/edx/diff-cover.git@v0.1.0#egg=diff_cover
+-e git+https://github.com/edx/XBlock.git@3464c0fbfe#egg=XBlock
+-e git+https://github.com/edx/codejail.git@0a1b468#egg=codejail
+-e git+https://github.com/edx/diff-cover.git@v0.1.1#egg=diff_cover

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -8,6 +8,6 @@
 -e git://github.com/eventbrite/zendesk.git@d53fe0e81b623f084e91776bcf6369f8b7b63879#egg=zendesk
 
 # Our libraries:
--e git+https://github.com/edx/XBlock.git@eaaf4831#egg=XBlock
+-e git+https://github.com/edx/XBlock.git@4c5d2397#egg=XBlock
 -e git+https://github.com/edx/codejail.git@5fb5fa0#egg=codejail
 -e git+https://github.com/edx/diff-cover.git@v0.1.0#egg=diff_cover

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -9,6 +9,6 @@
 
 # Our libraries:
 
--e git+https://github.com/edx/XBlock.git@2abd2937e134e2f78dfa118d6cfd56ec510fd3a4#egg=XBlock
+-e git+https://github.com/edx/XBlock.git@3464c0fbfe07bb16791386b26979f66ee2708b06#egg=XBlock
 -e git+https://github.com/edx/codejail.git@5fb5fa0#egg=codejail
 -e git+https://github.com/edx/diff-cover.git@v0.1.0#egg=diff_cover

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -8,6 +8,6 @@
 -e git://github.com/eventbrite/zendesk.git@d53fe0e81b623f084e91776bcf6369f8b7b63879#egg=zendesk
 
 # Our libraries:
--e git+https://github.com/edx/XBlock.git@2144a25d#egg=XBlock
+-e git+https://github.com/edx/XBlock.git@a56a79d8#egg=XBlock
 -e git+https://github.com/edx/codejail.git@5fb5fa0#egg=codejail
 -e git+https://github.com/edx/diff-cover.git@v0.1.0#egg=diff_cover

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -8,6 +8,7 @@
 -e git://github.com/eventbrite/zendesk.git@d53fe0e81b623f084e91776bcf6369f8b7b63879#egg=zendesk
 
 # Our libraries:
--e git+https://github.com/edx/XBlock.git@4c5d2397#egg=XBlock
+
+-e git+https://github.com/edx/XBlock.git@2abd2937e134e2f78dfa118d6cfd56ec510fd3a4#egg=XBlock
 -e git+https://github.com/edx/codejail.git@5fb5fa0#egg=codejail
 -e git+https://github.com/edx/diff-cover.git@v0.1.0#egg=diff_cover

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -8,6 +8,6 @@
 -e git://github.com/eventbrite/zendesk.git@d53fe0e81b623f084e91776bcf6369f8b7b63879#egg=zendesk
 
 # Our libraries:
--e git+https://github.com/edx/XBlock.git@a56a79d8#egg=XBlock
+-e git+https://github.com/edx/XBlock.git@eaaf4831#egg=XBlock
 -e git+https://github.com/edx/codejail.git@5fb5fa0#egg=codejail
 -e git+https://github.com/edx/diff-cover.git@v0.1.0#egg=diff_cover


### PR DESCRIPTION
Also removes the need for the explicit listing of Booleans to be exported (by changing what we serialize/deserialize-- see notes about this in xblock pull request).  edx/XBlock#28

Note that the xblock version number needs to be updated after the corresponding xblock pull request is merged.
