### PR TITLE
Will/jenkins diff cover

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -10,4 +10,4 @@
 # Our libraries:
 -e git+https://github.com/edx/XBlock.git@2144a25d#egg=XBlock
 -e git+https://github.com/edx/codejail.git@5fb5fa0#egg=codejail
--e git+https://github.com/edx/diff-cover.git@v0.1.0#egg=diff_cover
+-e git+https://github.com/edx/diff-cover.git@v0.1.1#egg=diff_cover


### PR DESCRIPTION
This PR updates `diff-cover` version 0.1.1, which uses `git diff origin/master...HEAD` instead of `git diff master...HEAD`.  Since the local `master` branch is not always current in Jenkins, this ensures that we're comparing to the most recent version of `master`.

Suggested reviewers: @jzoldak @cpennington
