### PR TITLE
Valera/no autoplay videoalpha studio

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/videoalpha/display/video_player.coffee
+++ b/common/lib/xmodule/xmodule/js/src/videoalpha/display/video_player.coffee
@@ -99,7 +99,7 @@ class @VideoPlayerAlpha extends SubviewAlpha
     @video.log 'load_video'
     if @video.videoType is 'html5'
       @player.setPlaybackRate @video.speed
-    unless onTouchBasedDevice()
+    unless onTouchBasedDevice() or $('.video:first').data('autoplay') == 'False'
       $('.video-load-complete:first').data('video').player.play()
 
   onStateChange: (event) =>

--- a/common/lib/xmodule/xmodule/js/src/videoalpha/display/video_player.coffee
+++ b/common/lib/xmodule/xmodule/js/src/videoalpha/display/video_player.coffee
@@ -99,7 +99,7 @@ class @VideoPlayerAlpha extends SubviewAlpha
     @video.log 'load_video'
     if @video.videoType is 'html5'
       @player.setPlaybackRate @video.speed
-    unless onTouchBasedDevice() or $('.video:first').data('autoplay') == 'False'
+    if not onTouchBasedDevice() and $('.video:first').data('autoplay') is 'True'
       $('.video-load-complete:first').data('video').player.play()
 
   onStateChange: (event) =>

--- a/common/lib/xmodule/xmodule/videoalpha_module.py
+++ b/common/lib/xmodule/xmodule/videoalpha_module.py
@@ -5,6 +5,7 @@ from lxml import etree
 from pkg_resources import resource_string, resource_listdir
 
 from django.http import Http404
+from django.conf import settings
 
 from xmodule.x_module import XModule
 from xmodule.raw_module import RawDescriptor
@@ -147,7 +148,8 @@ class VideoAlphaModule(VideoAlphaFields, XModule):
             'caption_asset_path': caption_asset_path,
             'show_captions': self.show_captions,
             'start': self.start_time,
-            'end': self.end_time
+            'end': self.end_time,
+            'autoplay': settings.MITX_FEATURES.get('AUTOPLAY_VIDEOS', True)
         })
 
 

--- a/lms/djangoapps/courseware/features/videoalpha.feature
+++ b/lms/djangoapps/courseware/features/videoalpha.feature
@@ -1,0 +1,6 @@
+Feature: Video Alpha component
+  As a student, I want to view course videos in LMS.
+
+  Scenario: Autoplay is enabled in LMS
+    Given the course has a Video component
+    Then when I view the video it has autoplay enabled

--- a/lms/djangoapps/courseware/features/videoalpha.py
+++ b/lms/djangoapps/courseware/features/videoalpha.py
@@ -1,0 +1,34 @@
+#pylint: disable=C0111
+
+from lettuce import world, step
+from lettuce.django import django_url
+from common import TEST_COURSE_NAME, TEST_SECTION_NAME, i_am_registered_for_the_course, section_location
+
+############### ACTIONS ####################
+
+
+@step('when I view the video it has autoplay enabled')
+def does_autoplay(step):
+    assert(world.css_find('.videoalpha')[0]['data-autoplay'] == 'True')
+
+
+@step('the course has a Video component')
+def view_videoalpha(step):
+    coursename = TEST_COURSE_NAME.replace(' ', '_')
+    i_am_registered_for_the_course(step, coursename)
+
+    # Make sure we have a videoalpha
+    add_videoalpha_to_course(coursename)
+    chapter_name = TEST_SECTION_NAME.replace(" ", "_")
+    section_name = chapter_name
+    url = django_url('/courses/edx/Test_Course/Test_Course/courseware/%s/%s' %
+                     (chapter_name, section_name))
+
+    world.browser.visit(url)
+
+
+def add_videoalpha_to_course(course):
+    template_name = 'i4x://edx/templates/videoalpha/default'
+    world.ItemFactory.create(parent_location=section_location(course),
+                             template=template_name,
+                             display_name='Video Alpha 1')

--- a/lms/djangoapps/courseware/features/videoalpha.py
+++ b/lms/djangoapps/courseware/features/videoalpha.py
@@ -1,4 +1,6 @@
 #pylint: disable=C0111
+#pylint: disable=W0613
+#pylint: disable=W0621
 
 from lettuce import world, step
 from lettuce.django import django_url

--- a/lms/templates/videoalpha.html
+++ b/lms/templates/videoalpha.html
@@ -18,6 +18,7 @@
       data-start="${start}"
       data-end="${end}"
       data-caption-asset-path="${caption_asset_path}"
+      data-autoplay="${settings.MITX_FEATURES['AUTOPLAY_VIDEOS']}"
   >
     <div class="tc-wrapper">
       <article class="video-wrapper">

--- a/lms/templates/videoalpha.html
+++ b/lms/templates/videoalpha.html
@@ -18,7 +18,7 @@
       data-start="${start}"
       data-end="${end}"
       data-caption-asset-path="${caption_asset_path}"
-      data-autoplay="${settings.MITX_FEATURES['AUTOPLAY_VIDEOS']}"
+      data-autoplay="${autoplay}"
   >
     <div class="tc-wrapper">
       <article class="video-wrapper">


### PR DESCRIPTION
Added autoplay attribute to videoalpha. Now in Studio the videos will not autoplay when Video Alpha advanced component will be used. In LMS the Video Alpha will auto play.

This functionality, along with the tests, was copied over from the original Video, and modified according to the new Xmodule.

@rocha please review.
