### PR TITLE
Add additional events for tracking

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/videoalpha/display/video_caption.coffee
+++ b/common/lib/xmodule/xmodule/js/src/videoalpha/display/video_caption.coffee
@@ -140,12 +140,16 @@ class @VideoCaptionAlpha extends SubviewAlpha
 
   hideCaptions: (hide_captions) =>
     if hide_captions
+      type = 'hide_transcript'
       @$('.hide-subtitles').attr('title', 'Turn on captions')
       @el.addClass('closed')
     else
+      type = 'show_transcript'
       @$('.hide-subtitles').attr('title', 'Turn off captions')
       @el.removeClass('closed')
       @scrollCaption()
+    @video.log type,
+      currentTime: @player.currentTime
     $.cookie('hide_captions', hide_captions, expires: 3650, path: '/')
 
   captionHeight: ->

--- a/common/lib/xmodule/xmodule/js/src/videoalpha/display/video_player.coffee
+++ b/common/lib/xmodule/xmodule/js/src/videoalpha/display/video_player.coffee
@@ -45,6 +45,8 @@ class @VideoPlayerAlpha extends SubviewAlpha
     if @video.show_captions is true
       @caption = new VideoCaptionAlpha
         el: @el
+        video: @video
+        player: @
         youtubeId: @video.youtubeId('1.0')
         currentSpeed: @currentSpeed()
         captionAssetPath: @video.caption_asset_path
@@ -277,11 +279,15 @@ class @VideoPlayerAlpha extends SubviewAlpha
   toggleFullScreen: (event) =>
     event.preventDefault()
     if @el.hasClass('fullscreen')
+      type = 'not_fullscreen'
       @$('.add-fullscreen').attr('title', 'Fill browser')
       @el.removeClass('fullscreen')
     else
+      type = 'fullscreen'
       @el.addClass('fullscreen')
       @$('.add-fullscreen').attr('title', 'Exit fill browser')
+    @video.log type,
+      currentTime: @currentTime
     if @video.show_captions is true
       @caption.resize()
 


### PR DESCRIPTION
Additional events to logging for Video Alpha are added. 
More information can be found on the wiki https://edx-wiki.atlassian.net/wiki/display/ENG/Video+event+logging . 

Tests for those additional events will be added on the branch https://github.com/edx/edx-platform/tree/anton/videoalpha_tests .

 @rocha : please review.
@vaxXxa please review
