### PR TITLE
Problem Show Answer/Check Button Line Height Syncing

### DIFF
--- a/cms/static/sass/_base.scss
+++ b/cms/static/sass/_base.scss
@@ -14,7 +14,7 @@ body {
   color: $gray-d2;
 }
 
-body, input {
+body, input, button {
   font-family: 'Open Sans', sans-serif;
 }
 

--- a/common/lib/xmodule/xmodule/css/capa/display.scss
+++ b/common/lib/xmodule/xmodule/css/capa/display.scss
@@ -555,11 +555,11 @@ section.problem {
       @extend .blue-button;
     }
 
-    input.check {
+    .check {
       height: ($baseline*2);
     }
 
-    button.show {
+    .show {
       height: ($baseline*2);
 
       .show-label {

--- a/common/lib/xmodule/xmodule/css/capa/display.scss
+++ b/common/lib/xmodule/xmodule/css/capa/display.scss
@@ -555,10 +555,14 @@ section.problem {
       @extend .blue-button;
     }
 
+    input.check {
+      height: ($baseline*2);
+    }
+
     button.show {
       height: ($baseline*2);
 
-      span {
+      .show-label {
         font-size: 1.0em;
         font-weight: 600;
       }

--- a/common/lib/xmodule/xmodule/css/capa/display.scss
+++ b/common/lib/xmodule/xmodule/css/capa/display.scss
@@ -553,7 +553,8 @@ section.problem {
 
     .save, .check, .show {
       height: ($baseline*2);
-      font-weight: 600;
+      font-weight: 500;
+      vertical-align: middle;
     }
 
     .save {
@@ -564,7 +565,7 @@ section.problem {
 
       .show-label {
         font-size: 1.0em;
-        font-weight: 600;
+        font-weight: 500;
       }
     }
 

--- a/common/lib/xmodule/xmodule/css/capa/display.scss
+++ b/common/lib/xmodule/xmodule/css/capa/display.scss
@@ -551,16 +551,16 @@ section.problem {
   section.action {
     margin-top: 20px;
 
-    input.save {
+    .save, .check, .show {
+      height: ($baseline*2);
+      font-weight: 600;
+    }
+
+    .save {
       @extend .blue-button;
     }
 
-    .check {
-      height: ($baseline*2);
-    }
-
     .show {
-      height: ($baseline*2);
 
       .show-label {
         font-size: 1.0em;

--- a/common/lib/xmodule/xmodule/css/capa/display.scss
+++ b/common/lib/xmodule/xmodule/css/capa/display.scss
@@ -553,7 +553,7 @@ section.problem {
 
     .save, .check, .show {
       height: ($baseline*2);
-      font-weight: 500;
+      font-weight: 600;
       vertical-align: middle;
     }
 
@@ -565,7 +565,7 @@ section.problem {
 
       .show-label {
         font-size: 1.0em;
-        font-weight: 500;
+        font-weight: 600;
       }
     }
 


### PR DESCRIPTION
These changes sync up the visual height of the check/show answer elements who's height was not consistent after the .show element was changed to an HTML button element rather than an input.
