### PR TITLE
Default to unicode for sass compilation.

### DIFF
--- a/rakefiles/assets.rake
+++ b/rakefiles/assets.rake
@@ -52,7 +52,7 @@ def sass_cmd(watch=false, debug=false)
     "sass #{debug ? '--debug-info' : '--style compressed'} " +
           "--load-path #{sass_load_paths.join(' ')} " +
           "--require ./common/static/sass/bourbon/lib/bourbon.rb " +
-          "#{watch ? '--watch' : '--update'} #{sass_watch_paths.join(' ')}"
+          "#{watch ? '--watch' : '--update'} -E utf-8 #{sass_watch_paths.join(' ')}"
 end
 
 desc "Compile all assets"


### PR DESCRIPTION
If no default is provided, sass falls back to the system
default. This fails when the system default is not unicode because
various sass files have unicode characters in them.
