### PR TITLE
in studio fix latex source edit to save source_code metadata properly

### DIFF
--- a/cms/templates/widgets/metadata-edit.html
+++ b/cms/templates/widgets/metadata-edit.html
@@ -27,17 +27,18 @@
 
 <% showHighLevelSource='source_code' in editable_metadata_fields and editable_metadata_fields['source_code']['explicitly_set'] %>
 <% metadata_field_copy = copy.copy(editable_metadata_fields) %>
-## Delete 'source_code' field (if it exists) so metadata editor view does not attempt to render it.
-% if 'source_code' in editable_metadata_fields:
-    ## source-edit.html needs access to the 'source_code' value, so delete from a copy.
-    <% del metadata_field_copy['source_code'] %>
-% endif
 
 % if showHighLevelSource:
     <div class="launch-latex-compiler">
       <a href="#hls-modal-${hlskey}" id="hls-trig-${hlskey}">${_("Launch Latex Source Compiler")}</a>
     </div>
     <%include file="source-edit.html" />
+% else:
+%   if 'source_code' in editable_metadata_fields:
+    ## Delete 'source_code' field (if it exists) so metadata editor view does not attempt to render it.
+    ## source-edit.html needs access to the 'source_code' value, so delete from a copy.
+    <% del metadata_field_copy['source_code'] %>
+%   endif
 % endif
 
 <div class="wrapper-comp-settings metadata_edit" id="settings-tab" data-metadata='${json.dumps(metadata_field_copy) | h}'/>

--- a/cms/templates/widgets/source-edit.html
+++ b/cms/templates/widgets/source-edit.html
@@ -162,12 +162,10 @@
       ## copy textarea contents to metadata editor input element
       var melin = el.closest('.component').find('.metadata_edit').find('.wrapper-comp-setting').find('label:contains("source_code")').parent().find('input');
       var datval = el.data('editor').getValue();
-      console.log(datval);
       melin.after('<textarea class="input setting-input" id="'+melin[0].id+'">' + datval + '</textarea>')
       melin[0].id = "old";
       melin.trigger('change');
 
-      ## el.find('.hls-data').val(el.data('editor').getValue());
       el.closest('.component').find('.save-button').click();
   }
 

--- a/cms/templates/widgets/source-edit.html
+++ b/cms/templates/widgets/source-edit.html
@@ -159,7 +159,15 @@
   });
 
   function save_hls(el) {
-      el.find('.hls-data').val(el.data('editor').getValue());
+      ## copy textarea contents to metadata editor input element
+      var melin = el.closest('.component').find('.metadata_edit').find('.wrapper-comp-setting').find('label:contains("source_code")').parent().find('input');
+      var datval = el.data('editor').getValue();
+      console.log(datval);
+      melin.after('<textarea class="input setting-input" id="'+melin[0].id+'">' + datval + '</textarea>')
+      melin[0].id = "old";
+      melin.trigger('change');
+
+      ## el.find('.hls-data').val(el.data('editor').getValue());
       el.closest('.component').find('.save-button').click();
   }
 


### PR DESCRIPTION
metadata is being managed by the new backbone code, and thus saving of `source_code` in the Studio latex2edx source editor must be done through that framework.

Note that `source_code` is multiline text, whereas `CMS.Views.Metadata.String` uses a `<input type="text">` which cannot accept multiline text.  Thus the replacement with textarea, done in source-edit.
