### PR TITLE
dummy object creation without conditionals

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -75,3 +75,4 @@ Frances Botsford <frances@edx.org>
 Jonah Stanley <Jonah_Stanley@brown.edu>
 Slater Victoroff <slater.r.victoroff@gmail.com>
 Peter Fogg <peter.p.fogg@gmail.com>
+Renzo Lucioni <renzolucioni@gmail.com>

--- a/lms/templates/widgets/segment-io.html
+++ b/lms/templates/widgets/segment-io.html
@@ -1,7 +1,8 @@
-% if settings.MITX_FEATURES.get('SEGMENT_IO_LMS'):
 <!-- begin Segment.io -->
 <script type="text/javascript">
   var analytics=analytics||[];analytics.load=function(e){var t=document.createElement("script");t.type="text/javascript",t.async=!0,t.src=("https:"===document.location.protocol?"https://":"http://")+"d2dq2ahtl5zl1z.cloudfront.net/analytics.js/v1/"+e+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n);var r=function(e){return function(){analytics.push([e].concat(Array.prototype.slice.call(arguments,0)))}},i=["identify","track","trackLink","trackForm","trackClick","trackSubmit","pageview","ab","alias","ready"];for(var s=0;s<i.length;s++)analytics[i[s]]=r(i[s])};
+
+% if settings.MITX_FEATURES.get('SEGMENT_IO_LMS'):
   analytics.load("${ settings.SEGMENT_IO_LMS_KEY }");
 
   % if user.is_authenticated():
@@ -11,14 +12,6 @@
   });
 
   % endif
+% endif
 </script>
 <!-- end Segment.io -->
-% else:
-<!-- dummy segment.io -->
-<script type="text/javascript">
-  var analytics = {
-    track: function() { return; }
-  };
-</script>
-<!-- end dummy segment.io -->
-% endif

--- a/lms/templates/widgets/segment-io.html
+++ b/lms/templates/widgets/segment-io.html
@@ -1,5 +1,6 @@
 <!-- begin Segment.io -->
 <script type="text/javascript">
+  // Leaving this line out of the feature flag block is intentional. Pulling the line outside of the if statement allows it to serve as its own dummy object.
   var analytics=analytics||[];analytics.load=function(e){var t=document.createElement("script");t.type="text/javascript",t.async=!0,t.src=("https:"===document.location.protocol?"https://":"http://")+"d2dq2ahtl5zl1z.cloudfront.net/analytics.js/v1/"+e+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n);var r=function(e){return function(){analytics.push([e].concat(Array.prototype.slice.call(arguments,0)))}},i=["identify","track","trackLink","trackForm","trackClick","trackSubmit","pageview","ab","alias","ready"];for(var s=0;s<i.length;s++)analytics[i[s]]=r(i[s])};
 
 % if settings.MITX_FEATURES.get('SEGMENT_IO_LMS'):


### PR DESCRIPTION
This is an implementation of Ian's comment, found here https://github.com/edx/edx-platform/pull/65#issuecomment-19172768.

Pulling the first line of the Segment.io snippet outside of the `if` statement allows it to serve as its own dummy object, and cover all of Segment.io's methods. Leaving the `analytics.load` line inside the `if` statement will only load it when an API key is available.
