### PR TITLE
Remove the stores_state field from XModule

### DIFF
--- a/common/lib/xmodule/xmodule/annotatable_module.py
+++ b/common/lib/xmodule/xmodule/annotatable_module.py
@@ -125,6 +125,5 @@ class AnnotatableModule(AnnotatableFields, XModule):
 
 class AnnotatableDescriptor(AnnotatableFields, RawDescriptor):
     module_class = AnnotatableModule
-    stores_state = True
     template_dir_name = "annotatable"
     mako_template = "widgets/raw-edit.html"

--- a/common/lib/xmodule/xmodule/capa_module.py
+++ b/common/lib/xmodule/xmodule/capa_module.py
@@ -902,7 +902,6 @@ class CapaDescriptor(CapaFields, RawDescriptor):
 
     module_class = CapaModule
 
-    stores_state = True
     has_score = True
     template_dir_name = 'problem'
     mako_template = "widgets/problem-edit.html"

--- a/common/lib/xmodule/xmodule/combined_open_ended_module.py
+++ b/common/lib/xmodule/xmodule/combined_open_ended_module.py
@@ -239,7 +239,6 @@ class CombinedOpenEndedDescriptor(CombinedOpenEndedFields, RawDescriptor):
     mako_template = "widgets/open-ended-edit.html"
     module_class = CombinedOpenEndedModule
 
-    stores_state = True
     has_score = True
     always_recalculate_grades = True
     template_dir_name = "combinedopenended"

--- a/common/lib/xmodule/xmodule/conditional_module.py
+++ b/common/lib/xmodule/xmodule/conditional_module.py
@@ -92,7 +92,7 @@ class ConditionalModule(ConditionalFields, XModule):
         if xml_value and self.required_modules:
             for module in self.required_modules:
                 if not hasattr(module, attr_name):
-                    # We don't throw an exception here because it is possible for 
+                    # We don't throw an exception here because it is possible for
                     # the descriptor of a required module to have a property but
                     # for the resulting module to be a (flavor of) ErrorModule.
                     # So just log and return false.
@@ -161,7 +161,6 @@ class ConditionalDescriptor(ConditionalFields, SequenceDescriptor):
 
     filename_extension = "xml"
 
-    stores_state = True
     has_score = False
 
     @staticmethod

--- a/common/lib/xmodule/xmodule/foldit_module.py
+++ b/common/lib/xmodule/xmodule/foldit_module.py
@@ -183,7 +183,6 @@ class FolditDescriptor(FolditFields, XmlDescriptor, EditingDescriptor):
     module_class = FolditModule
     filename_extension = "xml"
 
-    stores_state = True
     has_score = True
     template_dir_name = "foldit"
 

--- a/common/lib/xmodule/xmodule/open_ended_grading_classes/combined_open_ended_modulev1.py
+++ b/common/lib/xmodule/xmodule/open_ended_grading_classes/combined_open_ended_modulev1.py
@@ -823,7 +823,6 @@ class CombinedOpenEndedV1Descriptor():
     module_class = CombinedOpenEndedV1Module
     filename_extension = "xml"
 
-    stores_state = True
     has_score = True
     template_dir_name = "combinedopenended"
 

--- a/common/lib/xmodule/xmodule/open_ended_grading_classes/open_ended_module.py
+++ b/common/lib/xmodule/xmodule/open_ended_grading_classes/open_ended_module.py
@@ -731,7 +731,6 @@ class OpenEndedDescriptor():
     module_class = OpenEndedModule
     filename_extension = "xml"
 
-    stores_state = True
     has_score = True
     template_dir_name = "openended"
 

--- a/common/lib/xmodule/xmodule/open_ended_grading_classes/self_assessment_module.py
+++ b/common/lib/xmodule/xmodule/open_ended_grading_classes/self_assessment_module.py
@@ -286,7 +286,6 @@ class SelfAssessmentDescriptor():
     module_class = SelfAssessmentModule
     filename_extension = "xml"
 
-    stores_state = True
     has_score = True
     template_dir_name = "selfassessment"
 

--- a/common/lib/xmodule/xmodule/peer_grading_module.py
+++ b/common/lib/xmodule/xmodule/peer_grading_module.py
@@ -603,7 +603,6 @@ class PeerGradingDescriptor(PeerGradingFields, RawDescriptor):
     module_class = PeerGradingModule
     filename_extension = "xml"
 
-    stores_state = True
     has_score = True
     always_recalculate_grades = True
     template_dir_name = "peer_grading"

--- a/common/lib/xmodule/xmodule/poll_module.py
+++ b/common/lib/xmodule/xmodule/poll_module.py
@@ -141,7 +141,6 @@ class PollDescriptor(PollFields, MakoModuleDescriptor, XmlDescriptor):
 
     module_class = PollModule
     template_dir_name = 'poll'
-    stores_state = True
 
     @classmethod
     def definition_from_xml(cls, xml_object, system):

--- a/common/lib/xmodule/xmodule/randomize_module.py
+++ b/common/lib/xmodule/xmodule/randomize_module.py
@@ -94,7 +94,6 @@ class RandomizeDescriptor(RandomizeFields, SequenceDescriptor):
 
     filename_extension = "xml"
 
-    stores_state = True
 
     def definition_to_xml(self, resource_fs):
 

--- a/common/lib/xmodule/xmodule/seq_module.py
+++ b/common/lib/xmodule/xmodule/seq_module.py
@@ -121,8 +121,6 @@ class SequenceDescriptor(SequenceFields, MakoModuleDescriptor, XmlDescriptor):
     mako_template = 'widgets/sequence-edit.html'
     module_class = SequenceModule
 
-    stores_state = True  # For remembering where in the sequence the student is
-
     js = {'coffee': [resource_string(__name__, 'js/src/sequence/edit.coffee')]}
     js_module_name = "SequenceDescriptor"
 

--- a/common/lib/xmodule/xmodule/timelimit_module.py
+++ b/common/lib/xmodule/xmodule/timelimit_module.py
@@ -123,9 +123,6 @@ class TimeLimitDescriptor(TimeLimitFields, XMLEditingDescriptor, XmlDescriptor):
 
     module_class = TimeLimitModule
 
-    # For remembering when a student started, and when they should end
-    stores_state = True
-
     @classmethod
     def definition_from_xml(cls, xml_object, system):
         children = []

--- a/common/lib/xmodule/xmodule/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module.py
@@ -138,5 +138,4 @@ class VideoModule(VideoFields, XModule):
 class VideoDescriptor(VideoFields, RawDescriptor):
     """Descriptor for `VideoModule`."""
     module_class = VideoModule
-    stores_state = True
     template_dir_name = "video"

--- a/common/lib/xmodule/xmodule/videoalpha_module.py
+++ b/common/lib/xmodule/xmodule/videoalpha_module.py
@@ -153,5 +153,4 @@ class VideoAlphaModule(VideoAlphaFields, XModule):
 
 class VideoAlphaDescriptor(VideoAlphaFields, RawDescriptor):
     module_class = VideoAlphaModule
-    stores_state = True
     template_dir_name = "videoalpha"

--- a/common/lib/xmodule/xmodule/word_cloud_module.py
+++ b/common/lib/xmodule/xmodule/word_cloud_module.py
@@ -239,4 +239,3 @@ class WordCloudDescriptor(MetadataOnlyEditingDescriptor, RawDescriptor, WordClou
     """Descriptor for WordCloud Xmodule."""
     module_class = WordCloudModule
     template_dir_name = 'word_cloud'
-    stores_state = True

--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -327,10 +327,6 @@ class XModuleDescriptor(XModuleFields, HTMLSnippet, ResourceTemplates, XBlock):
 
     # Attributes for inspection of the descriptor
 
-    # Indicates whether the xmodule state should be
-    # stored in a database (independent of shared state)
-    stores_state = False
-
     # This indicates whether the xmodule is a problem-type.
     # It should respond to max_score() and grade(). It can be graded or ungraded
     # (like a practice problem).

--- a/lms/djangoapps/courseware/grades.py
+++ b/lms/djangoapps/courseware/grades.py
@@ -364,7 +364,7 @@ def get_score(course_id, user, problem_descriptor, module_creator, model_data_ca
         else:
             return (None, None)
 
-    if not (problem_descriptor.stores_state and problem_descriptor.has_score):
+    if not problem_descriptor.has_score:
         # These are not problems, and do not have a score
         return (None, None)
 

--- a/lms/djangoapps/courseware/tests/test_model_data.py
+++ b/lms/djangoapps/courseware/tests/test_model_data.py
@@ -26,7 +26,6 @@ def mock_field(scope, name):
 
 def mock_descriptor(fields=[], lms_fields=[]):
     descriptor = Mock()
-    descriptor.stores_state = True
     descriptor.location = location('def_id')
     descriptor.module_class.fields = fields
     descriptor.module_class.lms.fields = lms_fields


### PR DESCRIPTION
stores_state is now only used in a single test, in conjunction with
has_score. In practice, it's never the case that stores_state is false
when has_score is true, so we can delete stores_state entirely, and just
use has_score for the grading test.

@dianakhuang @ormsbee: Review?
