### PR TITLE
Link virtualenv to repo directory

### DIFF
--- a/scripts/create-dev-env.sh
+++ b/scripts/create-dev-env.sh
@@ -408,14 +408,14 @@ fi
 # Create edX virtualenv and link it to repo
 # virtualenvwrapper automatically sources the activation script
 if [[ $systempkgs ]]; then
-    mkvirtualenv -a "$HOME/.virtualenvs" --system-site-packages edx-platform || {
+    mkvirtualenv -a "$BASE/edx-platform" --system-site-packages edx-platform || {
       error "mkvirtualenv exited with a non-zero error"
       return 1
     }
 else
     # default behavior for virtualenv>1.7 is
     # --no-site-packages
-    mkvirtualenv -a "$HOME/.virtualenvs" edx-platform || {
+    mkvirtualenv -a "$BASE/edx-platform" edx-platform || {
       error "mkvirtualenv exited with a non-zero error"
       return 1
     }


### PR DESCRIPTION
This reverts a change whereby the installation script would link
the newly-created virtualenv to the `$HOME/.virtualenvs` directory,
which isn't what we want. We _actually_ want the virtualenv to link
to the project/repo directory so that `workon <virtualenv>` takes
us to the code that we want to work on.

@Slater-Victoroff, could you take a look please?
