### PR TITLE
Pause install script for Mac users to turn on Mongo

### DIFF
--- a/scripts/create-dev-env.sh
+++ b/scripts/create-dev-env.sh
@@ -507,7 +507,7 @@ case `uname -s` in Darwin)
         output "If you'd like Mongo automatically started up, press m"
         output "Otherwise start up Mongo, then press enter to continue. Or to quit, press control-C."
         read dummy
-        if [ "$dummy" = "m" ]; then mongod; fi
+        if [ "$dummy" = "m" ]; then mongod --fork; fi
         ;;
 esac
 

--- a/scripts/create-dev-env.sh
+++ b/scripts/create-dev-env.sh
@@ -501,6 +501,14 @@ mkdir "$BASE/data" || true
 
 rake django-admin[syncdb]
 rake django-admin[migrate]
+
+case `uname -s` in Darwin)
+        output "This next step needs Mongo to run"
+        output "Ensure that Mongo is running, then press Enter, or press control-C to quit"
+        read dummy
+        ;;
+esac
+
 rake cms:update_templates
 # Configure Git
 

--- a/scripts/create-dev-env.sh
+++ b/scripts/create-dev-env.sh
@@ -504,8 +504,10 @@ rake django-admin[migrate]
 
 case `uname -s` in Darwin)
         output "This next step needs Mongo to run"
-        output "Ensure that Mongo is running, then press Enter, or press control-C to quit"
+        output "If you'd like Mongo automatically started up, press m"
+        output "Otherwise start up Mongo, then press enter to continue. Or to quit, press control-C."
         read dummy
+        if [ "$dummy" = "m" ]; then mongod; fi
         ;;
 esac
 


### PR DESCRIPTION
After Mongo is installed, it is not turned on for mac users
but running `rake cms:update_templates` requires Mongo to be started,
so the script usually crashes. Pausing the script to allow users to
start Mongo should solve this problem.

I thought it would be best to simply pause it and allow users to
turn on Mongo themselves. Another option would be to just
start Mongo automatically.

@natehardison @Slater-Victoroff  Take a look! :)
