### PR TITLE
Fix the LaTeX problems/HTML so high level source is saved.

### DIFF
--- a/cms/djangoapps/contentstore/features/advanced-settings.py
+++ b/cms/djangoapps/contentstore/features/advanced-settings.py
@@ -3,11 +3,7 @@
 
 from lettuce import world, step
 from nose.tools import assert_false, assert_equal, assert_regexp_matches
-
-"""
-http://selenium.googlecode.com/svn/trunk/docs/api/py/webdriver/selenium.webdriver.common.keys.html
-"""
-from selenium.webdriver.common.keys import Keys
+from common import type_in_codemirror
 
 KEY_CSS = '.key input.policy-key'
 VALUE_CSS = 'textarea.json'
@@ -37,13 +33,7 @@ def press_the_notification_button(step, name):
 
 @step(u'I edit the value of a policy key$')
 def edit_the_value_of_a_policy_key(step):
-    """
-    It is hard to figure out how to get into the CodeMirror
-    area, so cheat and do it from the policy key field :)
-    """
-    world.css_find(".CodeMirror")[get_index_of(DISPLAY_NAME_KEY)].click()
-    g = world.css_find("div.CodeMirror.CodeMirror-focused > div > textarea")
-    g._element.send_keys(Keys.ARROW_LEFT, ' ', 'X')
+    type_in_codemirror(get_index_of(DISPLAY_NAME_KEY), 'X')
 
 
 @step(u'I edit the value of a policy key and save$')
@@ -132,13 +122,5 @@ def change_display_name_value(step, new_value):
 
 
 def change_value(step, key, new_value):
-    index = get_index_of(key)
-    world.css_find(".CodeMirror")[index].click()
-    g = world.css_find("div.CodeMirror.CodeMirror-focused > div > textarea")
-    current_value = world.css_find(VALUE_CSS)[index].value
-    g._element.send_keys(Keys.CONTROL + Keys.END)
-    for count in range(len(current_value)):
-        g._element.send_keys(Keys.END, Keys.BACK_SPACE)
-        # Must delete "" before typing the JSON value
-    g._element.send_keys(Keys.END, Keys.BACK_SPACE, Keys.BACK_SPACE, new_value)
+    type_in_codemirror(get_index_of(key), new_value)
     press_the_notification_button(step, "Save")

--- a/cms/djangoapps/contentstore/features/common.py
+++ b/cms/djangoapps/contentstore/features/common.py
@@ -169,3 +169,14 @@ def open_new_unit(step):
     step.given('I have added a new subsection')
     step.given('I expand the first section')
     world.css_click('a.new-unit-item')
+
+
+def type_in_codemirror(index, text):
+    world.css_find(".CodeMirror")[index].click()
+    g = world.css_find("div.CodeMirror.CodeMirror-focused > div > textarea")
+    if world.is_mac():
+        g._element.send_keys(Keys.COMMAND + 'a')
+    else:
+        g._element.send_keys(Keys.CONTROL + 'a')
+    g._element.send_keys(Keys.DELETE)
+    g._element.send_keys(text)

--- a/cms/djangoapps/contentstore/features/problem-editor.feature
+++ b/cms/djangoapps/contentstore/features/problem-editor.feature
@@ -65,3 +65,9 @@ Feature: Problem Editor
     Given I have created a LaTeX Problem
     And I edit and select Settings
     Then Edit High Level Source is visible
+
+  Scenario: High Level source is persisted for LaTeX problem (bug STUD-280)
+    Given I have created a LaTeX Problem
+    And I edit the High Level Source
+    Then my change to the High Level Source is persisted
+    And when I view the High Level Source I see my changes

--- a/cms/djangoapps/contentstore/features/problem-editor.py
+++ b/cms/djangoapps/contentstore/features/problem-editor.py
@@ -3,6 +3,7 @@
 
 from lettuce import world, step
 from nose.tools import assert_equal
+from common import type_in_codemirror
 
 DISPLAY_NAME = "Display Name"
 MAXIMUM_ATTEMPTS = "Maximum Attempts"
@@ -135,12 +136,12 @@ def set_the_max_attempts(step, max_attempts_set, max_attempts_displayed, max_att
 
 @step('Edit High Level Source is not visible')
 def edit_high_level_source_not_visible(step):
-    verify_high_level_source(step, False)
+    verify_high_level_source_links(step, False)
 
 
 @step('Edit High Level Source is visible')
-def edit_high_level_source_visible(step):
-    verify_high_level_source(step, True)
+def edit_high_level_source_links_visible(step):
+    verify_high_level_source_links(step, True)
 
 
 @step('If I press Cancel my changes are not persisted')
@@ -159,7 +160,33 @@ def create_latex_problem(step):
     world.click_component_from_menu("i4x://edx/templates/problem/Problem_Written_in_LaTeX", '.xmodule_CapaModule')
 
 
-def verify_high_level_source(step, visible):
+@step('I edit the High Level Source')
+def edit_latex_source(step):
+    world.css_click('a.edit-button')
+    world.css_find('.launch-latex-compiler').find_by_css('a').click()
+    # Without the wait, the second code mirror is not yet clickable.
+    world.wait(1)
+    type_in_codemirror(1, "hi")
+    world.css_click('.hls-compile')
+
+
+@step('my change to the High Level Source is persisted')
+def high_level_source_persisted(step):
+    def verify_text(driver):
+        return world.css_find('.problem').text == 'hi'
+
+    world.wait_for(verify_text)
+
+
+@step('I view the High Level Source I see my changes')
+def high_level_source_in_editor(step):
+    world.css_click('a.edit-button')
+    world.css_find('.launch-latex-compiler').find_by_css('a').click()
+    world.wait(2)
+    assert_equal('hi', world.css_find('.source-edit-box').value)
+
+
+def verify_high_level_source_links(step, visible):
     assert_equal(visible, world.is_css_present('.launch-latex-compiler'))
     world.cancel_component(step)
     assert_equal(visible, world.is_css_present('.upload-button'))

--- a/cms/static/coffee/src/views/module_edit.coffee
+++ b/cms/static/coffee/src/views/module_edit.coffee
@@ -44,8 +44,17 @@ class CMS.Views.ModuleEdit extends Backbone.View
         [@metadataEditor.getDisplayName()])
       @$el.find('.component-name').html(title)
 
+  customMetadata: ->
+      # Hack to support metadata fields that aren't part of the metadata editor (ie, LaTeX high level source).
+      # Walk through the set of elements which have the 'data-metadata_name' attribute and
+      # build up an object to pass back to the server on the subsequent POST.
+      # Note that these values will always be sent back on POST, even if they did not actually change.
+      _metadata = {}
+      _metadata[$(el).data("metadata-name")] = el.value for el in $('[data-metadata-name]',  @$component_editor())
+      return _metadata
+
   changedMetadata: ->
-    return @metadataEditor.getModifiedMetadataValues()
+    return _.extend(@metadataEditor.getModifiedMetadataValues(), @customMetadata())
 
   cloneTemplate: (parent, template) ->
     $.post("/clone_item", {

--- a/common/djangoapps/terrain/ui_helpers.py
+++ b/common/djangoapps/terrain/ui_helpers.py
@@ -3,6 +3,7 @@
 
 from lettuce import world
 import time
+import platform
 from urllib import quote_plus
 from selenium.common.exceptions import WebDriverException, StaleElementReferenceException
 from selenium.webdriver.support import expected_conditions as EC
@@ -158,3 +159,8 @@ def click_tools():
     tools_css = 'li.nav-course-tools'
     if world.browser.is_element_present_by_css(tools_css):
         world.css_click(tools_css)
+
+
+@world.absorb
+def is_mac():
+    return platform.mac_ver()[0] is not ''


### PR DESCRIPTION
Adds an integration test that verifies the bug fix.

Create helper method for typing in CodeMirror (which hopefully will now work on Mac as well).

@dmitchell Please try running the tests on your machine
@JonahStanley can you code review the tests? I do have two waits in the test, which I'd love to get rid of. I think I just need to figure out the right things to wait on.
@cdodge Can you code review the "hack" code that I restored in module_edit.coffee? This is code that was there previously, and it was how we saved all the metadata values. Now the only thing that will get picked up is source_code, as the other fields won't be marked with the class we are looking for.

@ichuang FYI, here is my pull request.
