### PR TITLE
Fix a bug in diff-cover

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -10,4 +10,4 @@
 # Our libraries:
 -e git+https://github.com/edx/XBlock.git@4d8735e883#egg=XBlock
 -e git+https://github.com/edx/codejail.git@0a1b468#egg=codejail
--e git+https://github.com/edx/diff-cover.git@v0.1.1#egg=diff_cover
+-e git+https://github.com/edx/diff-cover.git@v0.1.2#egg=diff_cover


### PR DESCRIPTION
This updates `diff-cover` to version 0.1.2, which fixes a bug in which missing lines were over-reported.

Here are the changes in the `diff-cover` repo: https://github.com/edx/diff-cover/pull/8
(So far, I've been merging changes in the `diff-cover` repo myself so I can iterate quickly and get the tool integrated into code review.  From this point onward, PR's in the `diff-cover` repo will follow the normal code review process.)

Suggested reviewers: @cpennington @brianhw 
