### PR TITLE
Fix unicode for errors on capa problems

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,6 +42,8 @@ setting now run entirely outside the Python sandbox.
 
 Blades: Added tests for Video Alpha player.
 
+Common: Have the capa module handle unicode better (especially errors)
+
 Blades: Video Alpha bug fix for speed changing to 1.0 in Firefox.
 
 Blades: Additional event tracking added to Video Alpha: fullscreen switch, show/hide

--- a/common/lib/calc/calc.py
+++ b/common/lib/calc/calc.py
@@ -93,7 +93,7 @@ def check_variables(string, variables):
     Pyparsing uses a left-to-right parser, which makes a more
     elegant approach pretty hopeless.
     """
-    general_whitespace = re.compile('[^\\w]+')
+    general_whitespace = re.compile('[^\\w]+')  # TODO consider non-ascii
     # List of all alnums in string
     possible_variables = re.split(general_whitespace, string)
     bad_variables = []

--- a/common/lib/xmodule/xmodule/capa_module.py
+++ b/common/lib/xmodule/xmodule/capa_module.py
@@ -22,7 +22,7 @@ from xblock.core import Scope, String, Boolean, Dict, Integer, Float
 from .fields import Timedelta, Date
 from django.utils.timezone import UTC
 
-log = logging.getLogger("mitx.courseware")  # pylint: disable=C0103
+log = logging.getLogger("mitx.courseware")
 
 
 # Generate this many different variants of problems with rerandomize=per_student
@@ -51,9 +51,6 @@ class Randomization(String):
     Define a field to store how to randomize a problem.
     """
     def from_json(self, value):
-        """
-        For backward compatability?
-        """
         if value in ("", "true"):
             return "always"
         elif value == "false":
@@ -865,8 +862,8 @@ class CapaModule(CapaFields, XModule):
 
         except Exception as err:
             if self.system.DEBUG:
-                msg = "Error checking problem: " + err.message
-                msg += '\nTraceback:\n' + traceback.format_exc()
+                msg = u"Error checking problem: {}".format(err.message)
+                msg += u'\nTraceback:\n{}'.format(traceback.format_exc())
                 return {'success': msg}
             raise
 

--- a/common/lib/xmodule/xmodule/capa_module.py
+++ b/common/lib/xmodule/xmodule/capa_module.py
@@ -781,7 +781,7 @@ class CapaModule(CapaFields, XModule):
             # Otherwise, display just an error message,
             # without a stack trace
             else:
-                msg = "Error: %s" % str(inst.message)
+                msg = u"Error: {msg}".format(msg=inst.message)
 
             return {'success': msg}
 

--- a/common/lib/xmodule/xmodule/capa_module.py
+++ b/common/lib/xmodule/xmodule/capa_module.py
@@ -412,7 +412,7 @@ class CapaModule(CapaFields, XModule):
 
         `err` is the Exception encountered while rendering the problem HTML.
         """
-        log.exception(err)
+        log.exception(err.message)
 
         # TODO (vshnayder): another switch on DEBUG.
         if self.system.DEBUG:

--- a/common/lib/xmodule/xmodule/capa_module.py
+++ b/common/lib/xmodule/xmodule/capa_module.py
@@ -22,7 +22,7 @@ from xblock.core import Scope, String, Boolean, Dict, Integer, Float
 from .fields import Timedelta, Date
 from django.utils.timezone import UTC
 
-log = logging.getLogger("mitx.courseware")
+log = logging.getLogger("mitx.courseware")  # pylint: disable=C0103
 
 
 # Generate this many different variants of problems with rerandomize=per_student
@@ -65,17 +65,23 @@ class ComplexEncoder(json.JSONEncoder):
 
 
 class CapaFields(object):
-    attempts = Integer(help="Number of attempts taken by the student on this problem", default=0, scope=Scope.user_state)
+    attempts = Integer(help="Number of attempts taken by the student on this problem",
+                       default=0, scope=Scope.user_state)
     max_attempts = Integer(
         display_name="Maximum Attempts",
-        help="Defines the number of times a student can try to answer this problem. If the value is not set, infinite attempts are allowed.",
+        help=("Defines the number of times a student can try to answer this problem. "
+              "If the value is not set, infinite attempts are allowed."),
         values={"min": 0}, scope=Scope.settings
     )
     due = Date(help="Date that this problem is due by", scope=Scope.settings)
-    graceperiod = Timedelta(help="Amount of time after the due date that submissions will be accepted", scope=Scope.settings)
+    graceperiod = Timedelta(
+        help="Amount of time after the due date that submissions will be accepted",
+        scope=Scope.settings
+    )
     showanswer = String(
         display_name="Show Answer",
-        help="Defines when to show the answer to the problem. A default value can be set in Advanced Settings.",
+        help=("Defines when to show the answer to the problem. "
+              "A default value can be set in Advanced Settings."),
         scope=Scope.settings, default="closed",
         values=[
             {"display_name": "Always", "value": "always"},
@@ -86,23 +92,33 @@ class CapaFields(object):
             {"display_name": "Past Due", "value": "past_due"},
             {"display_name": "Never", "value": "never"}]
     )
-    force_save_button = Boolean(help="Whether to force the save button to appear on the page", scope=Scope.settings, default=False)
+    force_save_button = Boolean(
+        help="Whether to force the save button to appear on the page",
+        scope=Scope.settings, default=False
+    )
     rerandomize = Randomization(
-        display_name="Randomization", help="Defines how often inputs are randomized when a student loads the problem. This setting only applies to problems that can have randomly generated numeric values. A default value can be set in Advanced Settings.",
-        default="always", scope=Scope.settings, values=[{"display_name": "Always", "value": "always"},
-                                                        {"display_name": "On Reset", "value": "onreset"},
-                                                        {"display_name": "Never", "value": "never"},
-                                                        {"display_name": "Per Student", "value": "per_student"}]
+        display_name="Randomization",
+        help="Defines how often inputs are randomized when a student loads the problem. "
+        "This setting only applies to problems that can have randomly generated numeric values. "
+        "A default value can be set in Advanced Settings.",
+        default="always", scope=Scope.settings, values=[
+            {"display_name": "Always", "value": "always"},
+            {"display_name": "On Reset", "value": "onreset"},
+            {"display_name": "Never", "value": "never"},
+            {"display_name": "Per Student", "value": "per_student"}
+        ]
     )
     data = String(help="XML data for the problem", scope=Scope.content)
-    correct_map = Dict(help="Dictionary with the correctness of current student answers", scope=Scope.user_state, default={})
+    correct_map = Dict(help="Dictionary with the correctness of current student answers",
+                       scope=Scope.user_state, default={})
     input_state = Dict(help="Dictionary for maintaining the state of inputtypes", scope=Scope.user_state)
     student_answers = Dict(help="Dictionary with the current student responses", scope=Scope.user_state)
     done = Boolean(help="Whether the student has answered the problem", scope=Scope.user_state)
     seed = Integer(help="Random seed for this student", scope=Scope.user_state)
     weight = Float(
         display_name="Problem Weight",
-        help="Defines the number of points each problem is worth. If the value is not set, each response field in the problem is worth one point.",
+        help=("Defines the number of points each problem is worth. "
+              "If the value is not set, each response field in the problem is worth one point."),
         values={"min": 0, "step": .1},
         scope=Scope.settings
     )
@@ -998,7 +1014,8 @@ class CapaDescriptor(CapaFields, RawDescriptor):
     mako_template = "widgets/problem-edit.html"
     js = {'coffee': [resource_string(__name__, 'js/src/problem/edit.coffee')]}
     js_module_name = "MarkdownEditingDescriptor"
-    css = {'scss': [resource_string(__name__, 'css/editor/edit.scss'), resource_string(__name__, 'css/problem/edit.scss')]}
+    css = {'scss': [resource_string(__name__, 'css/editor/edit.scss'),
+                    resource_string(__name__, 'css/problem/edit.scss')]}
 
     # Capa modules have some additional metadata:
     # TODO (vshnayder): do problems have any other metadata?  Do they

--- a/common/lib/xmodule/xmodule/tests/test_capa_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_capa_module.py
@@ -11,11 +11,12 @@ import datetime
 from mock import Mock, patch
 import unittest
 import random
+import json
 
 import xmodule
-from capa.responsetypes import StudentInputError, \
-    LoncapaProblemError, ResponseError
-from xmodule.capa_module import CapaModule
+from capa.responsetypes import (StudentInputError, LoncapaProblemError,
+                                ResponseError)
+from xmodule.capa_module import CapaModule, ComplexEncoder
 from xmodule.modulestore import Location
 
 from django.http import QueryDict
@@ -529,6 +530,32 @@ class CapaModuleTest(unittest.TestCase):
 
             # Expect that the number of attempts is NOT incremented
             self.assertEqual(module.attempts, 1)
+
+    def test_check_problem_other_errors(self):
+        """
+        Test that errors other than the expected kinds give an appropriate message.
+
+        See also `test_check_problem_error` for the "expected kinds" or errors.
+        """
+        # Create the module
+        module = CapaFactory.create(attempts=1)
+
+        # Ensure that the user is NOT staff
+        module.system.user_is_staff = False
+
+        # Ensure that DEBUG is on
+        module.system.DEBUG = True
+
+        # Simulate answering a problem that raises the exception
+        with patch('capa.capa_problem.LoncapaProblem.grade_answers') as mock_grade:
+            error_msg = u"Superterrible error happened: ☠"
+            mock_grade.side_effect = Exception(error_msg)
+
+            get_request_dict = {CapaFactory.input_key(): '3.14'}
+            result = module.check_problem(get_request_dict)
+
+        # Expect an AJAX alert message in 'success'
+        self.assertTrue(error_msg in result['success'])
 
     def test_check_problem_error_nonascii(self):
 
@@ -1059,6 +1086,33 @@ class CapaModuleTest(unittest.TestCase):
         # Expect that the module has created a new dummy problem with the error
         self.assertNotEqual(original_problem, module.lcp)
 
+    def test_get_problem_html_error_w_debug(self):
+        """
+        Test the html response when an error occurs with DEBUG on
+        """
+        module = CapaFactory.create()
+
+        # Simulate throwing an exception when the capa problem
+        # is asked to render itself as HTML
+        error_msg = u"Superterrible error happened: ☠"
+        module.lcp.get_html = Mock(side_effect=Exception(error_msg))
+
+        # Stub out the get_test_system rendering function
+        module.system.render_template = Mock(return_value="<div>Test Template HTML</div>")
+
+        # Make sure DEBUG is on
+        module.system.DEBUG = True
+
+        # Try to render the module with DEBUG turned on
+        html = module.get_problem_html()
+
+        self.assertTrue(html is not None)
+
+        # Check the rendering context
+        render_args, _ = module.system.render_template.call_args
+        context = render_args[1]
+        self.assertTrue(error_msg in context['problem']['html'])
+
     def test_random_seed_no_change(self):
 
         # Run the test for each possible rerandomize value
@@ -1164,3 +1218,28 @@ class CapaModuleTest(unittest.TestCase):
             for i in range(200):
                 module = CapaFactory.create(rerandomize=rerandomize)
                 assert 0 <= module.seed < 1000
+
+    @patch('xmodule.capa_module.log')
+    @patch('xmodule.capa_module.Progress')
+    def test_get_progress_error(self, mock_progress, mock_log):
+        """
+        Check that an exception given in `Progress` produces a `log.exception` call.
+        """
+        error_types = [TypeError, ValueError]
+        for error_type in error_types:
+            mock_progress.side_effect = error_type
+            module = CapaFactory.create()
+            self.assertIsNone(module.get_progress())
+            mock_log.exception.assert_called_once_with('Got bad progress')
+            mock_log.reset_mock()
+
+
+class ComplexEncoderTest(unittest.TestCase):
+    def test_default(self):
+        """
+        Check that complex numbers can be encoded into JSON.
+        """
+        complex_num = 1 - 1j
+        expected_str = '1-1*j'
+        json_str = json.dumps(complex_num, cls=ComplexEncoder)
+        self.assertEqual(expected_str, json_str[1:-1])  # ignore quotes

--- a/common/lib/xmodule/xmodule/tests/test_capa_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_capa_module.py
@@ -505,9 +505,10 @@ class CapaModuleTest(unittest.TestCase):
     def test_check_problem_error(self):
 
         # Try each exception that capa_module should handle
-        for exception_class in [StudentInputError,
-                                LoncapaProblemError,
-                                ResponseError]:
+        exception_classes = [StudentInputError,
+                             LoncapaProblemError,
+                             ResponseError]
+        for exception_class in exception_classes:
 
             # Create the module
             module = CapaFactory.create(attempts=1)
@@ -532,9 +533,10 @@ class CapaModuleTest(unittest.TestCase):
     def test_check_problem_error_nonascii(self):
 
         # Try each exception that capa_module should handle
-        for exception_class in [StudentInputError,
-                                LoncapaProblemError,
-                                ResponseError]:
+        exception_classes = [StudentInputError,
+                             LoncapaProblemError,
+                             ResponseError]
+        for exception_class in exception_classes:
 
             # Create the module
             module = CapaFactory.create(attempts=1)

--- a/common/lib/xmodule/xmodule/tests/test_capa_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_capa_module.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-"""Tests of the Capa XModule"""
+"""
+Tests of the Capa XModule
+"""
 #pylint: disable=C0111
 #pylint: disable=R0904
 #pylint: disable=C0103
@@ -48,12 +50,16 @@ class CapaFactory(object):
 
     @staticmethod
     def input_key():
-        """ Return the input key to use when passing GET parameters """
+        """
+        Return the input key to use when passing GET parameters
+        """
         return ("input_" + CapaFactory.answer_key())
 
     @staticmethod
     def answer_key():
-        """ Return the key stored in the capa problem answer dict """
+        """
+        Return the key stored in the capa problem answer dict
+        """
         return ("-".join(['i4x', 'edX', 'capa_test', 'problem',
                          'SampleProblem%d' % CapaFactory.num]) +
                 "_2_1")
@@ -362,7 +368,9 @@ class CapaModuleTest(unittest.TestCase):
             result = CapaModule.make_dict_of_responses(invalid_get_dict)
 
     def _querydict_from_dict(self, param_dict):
-        """ Create a Django QueryDict from a Python dictionary """
+        """
+        Create a Django QueryDict from a Python dictionary
+        """
 
         # QueryDict objects are immutable by default, so we make
         # a copy that we can update.


### PR DESCRIPTION
When a problem is checked and gives an error, if the message has non-ascii characters, it should still display correctly. 

JIRA LMS-468

@sarina @nedbat 
