### PR TITLE
Jonahstanley/make units parallel

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -23,7 +23,7 @@ from xmodule.modulestore import Location
 from xmodule.modulestore.store_utilities import clone_course
 from xmodule.modulestore.store_utilities import delete_course
 from xmodule.modulestore.django import modulestore
-from xmodule.contentstore.django import contentstore
+from xmodule.contentstore.django import contentstore, _CONTENTSTORE
 from xmodule.templates import update_templates
 from xmodule.modulestore.xml_exporter import export_to_xml
 from xmodule.modulestore.xml_importer import import_from_xml, perform_xlint
@@ -41,7 +41,6 @@ from xmodule.exceptions import NotFoundError
 
 from django_comment_common.utils import are_permissions_roles_seeded
 from xmodule.exceptions import InvalidVersionError
-import xmodule.contentstore.django
 import datetime
 from pytz import UTC
 from uuid import uuid4
@@ -92,7 +91,7 @@ class ContentStoreToyCourseTest(ModuleStoreTestCase):
     def tearDown(self):
         mongo = MongoClient()
         mongo.drop_database(TEST_DATA_CONTENTSTORE['OPTIONS']['db'])
-        xmodule.contentstore.django._CONTENTSTORE.clear()
+        _CONTENTSTORE.clear()
 
     def check_components_on_page(self, component_types, expected_types):
         """
@@ -857,7 +856,7 @@ class ContentStoreTest(ModuleStoreTestCase):
     def tearDown(self):
         mongo = MongoClient()
         mongo.drop_database(TEST_DATA_CONTENTSTORE['OPTIONS']['db'])
-        xmodule.contentstore.django._CONTENTSTORE.clear()
+        _CONTENTSTORE.clear()
 
     def test_create_course(self):
         """Test new course creation - happy path"""

--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -43,11 +43,12 @@ from django_comment_common.utils import are_permissions_roles_seeded
 from xmodule.exceptions import InvalidVersionError
 import datetime
 from pytz import UTC
-#from uuid import uuid4
+from uuid import uuid4
+import pymongo
 
 
 TEST_DATA_CONTENTSTORE = copy.deepcopy(settings.CONTENTSTORE)
-TEST_DATA_CONTENTSTORE['OPTIONS']['db'] = 'test_xcontent_%s' % 4  #uuid4().hex
+TEST_DATA_CONTENTSTORE['OPTIONS']['db'] = 'test_xcontent_%s' % uuid4().hex
 
 
 class MongoCollectionFindWrapper(object):
@@ -88,7 +89,10 @@ class ContentStoreToyCourseTest(ModuleStoreTestCase):
         self.client = Client()
         self.client.login(username=uname, password=password)
 
-
+    def tearDown(self):
+        m = pymongo.MongoClient()
+        m.drop_database(TEST_DATA_CONTENTSTORE['OPTIONS']['db'])
+        #contentstore().fs_files.drop()
 
     def check_components_on_page(self, component_types, expected_types):
         """
@@ -449,7 +453,6 @@ class ContentStoreToyCourseTest(ModuleStoreTestCase):
         content_store = contentstore()
         trash_store = contentstore('trashcan')
         module_store = modulestore('direct')
-
         import_from_xml(module_store, 'common/test/data/', ['full'], static_content_store=content_store)
 
         # look up original (and thumbnail) in content store, should be there after import
@@ -852,6 +855,11 @@ class ContentStoreTest(ModuleStoreTestCase):
             'number': '999',
             'display_name': 'Robot Super Course',
         }
+
+    def tearDown(self):
+        m = pymongo.MongoClient()
+        m.drop_database(TEST_DATA_CONTENTSTORE['OPTIONS']['db'])
+        #contentstore().fs_files.drop()
 
     def test_create_course(self):
         """Test new course creation - happy path"""

--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -45,9 +45,7 @@ import datetime
 from pytz import UTC
 #from uuid import uuid4
 
-TEST_DATA_MODULESTORE = copy.deepcopy(settings.MODULESTORE)
-TEST_DATA_MODULESTORE['default']['OPTIONS']['fs_root'] = path('common/test/data')
-TEST_DATA_MODULESTORE['direct']['OPTIONS']['fs_root'] = path('common/test/data')
+
 TEST_DATA_CONTENTSTORE = copy.deepcopy(settings.CONTENTSTORE)
 TEST_DATA_CONTENTSTORE['OPTIONS']['db'] = 'test_xcontent_%s' % 4  #uuid4().hex
 
@@ -62,7 +60,7 @@ class MongoCollectionFindWrapper(object):
         return self.original(query, *args, **kwargs)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MODULESTORE)
+#@override_settings(MODULESTORE=TEST_DATA_MODULESTORE)
 @override_settings(CONTENTSTORE=TEST_DATA_CONTENTSTORE)
 class ContentStoreToyCourseTest(ModuleStoreTestCase):
     """
@@ -70,6 +68,9 @@ class ContentStoreToyCourseTest(ModuleStoreTestCase):
     TODO: refactor using CourseFactory so they do not.
     """
     def setUp(self):
+
+        settings.MODULESTORE['default']['OPTIONS']['fs_root'] = path('common/test/data')
+        settings.MODULESTORE['direct']['OPTIONS']['fs_root'] = path('common/test/data')
         uname = 'testuser'
         email = 'test+courses@edx.org'
         password = 'foo'
@@ -86,6 +87,7 @@ class ContentStoreToyCourseTest(ModuleStoreTestCase):
 
         self.client = Client()
         self.client.login(username=uname, password=password)
+
 
 
     def check_components_on_page(self, component_types, expected_types):

--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -90,8 +90,8 @@ class ContentStoreToyCourseTest(ModuleStoreTestCase):
         self.client.login(username=uname, password=password)
 
     def tearDown(self):
-        m = MongoClient()
-        m.drop_database(TEST_DATA_CONTENTSTORE['OPTIONS']['db'])
+        mongo = MongoClient()
+        mongo.drop_database(TEST_DATA_CONTENTSTORE['OPTIONS']['db'])
         xmodule.contentstore.django._CONTENTSTORE.clear()
 
     def check_components_on_page(self, component_types, expected_types):
@@ -414,7 +414,7 @@ class ContentStoreToyCourseTest(ModuleStoreTestCase):
         self.assertGreater(len(all_assets), 0)
 
         # make sure we have some thumbnails in our contentstore
-        all_thumbnails = content_store.get_all_content_thumbnails_for_course(course_location)
+        content_store.get_all_content_thumbnails_for_course(course_location)
 
         #
         # cdodge: temporarily comment out assertion on thumbnails because many environments
@@ -543,7 +543,6 @@ class ContentStoreToyCourseTest(ModuleStoreTestCase):
         all_assets = trash_store.get_all_content_for_course(course_location)
         self.assertEqual(len(all_assets), 0)
 
-
         all_thumbnails = trash_store.get_all_content_thumbnails_for_course(course_location)
         self.assertEqual(len(all_thumbnails), 0)
 
@@ -607,7 +606,6 @@ class ContentStoreToyCourseTest(ModuleStoreTestCase):
             {'due': datetime.datetime.now(UTC)})
 
         self.assertRaises(InvalidVersionError, draft_store.unpublish, location)
-
 
     def test_bad_contentstore_request(self):
         resp = self.client.get('http://localhost:8001/c4x/CDX/123123/asset/&images_circuits_Lab7Solution2.png')
@@ -857,8 +855,8 @@ class ContentStoreTest(ModuleStoreTestCase):
         }
 
     def tearDown(self):
-        m = MongoClient()
-        m.drop_database(TEST_DATA_CONTENTSTORE['OPTIONS']['db'])
+        mongo = MongoClient()
+        mongo.drop_database(TEST_DATA_CONTENTSTORE['OPTIONS']['db'])
         xmodule.contentstore.django._CONTENTSTORE.clear()
 
     def test_create_course(self):

--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -45,7 +45,7 @@ import xmodule.contentstore.django
 import datetime
 from pytz import UTC
 from uuid import uuid4
-import pymongo
+from pymongo import MongoClient
 
 
 TEST_DATA_CONTENTSTORE = copy.deepcopy(settings.CONTENTSTORE)
@@ -62,7 +62,6 @@ class MongoCollectionFindWrapper(object):
         return self.original(query, *args, **kwargs)
 
 
-#@override_settings(MODULESTORE=TEST_DATA_MODULESTORE)
 @override_settings(CONTENTSTORE=TEST_DATA_CONTENTSTORE)
 class ContentStoreToyCourseTest(ModuleStoreTestCase):
     """
@@ -91,7 +90,7 @@ class ContentStoreToyCourseTest(ModuleStoreTestCase):
         self.client.login(username=uname, password=password)
 
     def tearDown(self):
-        m = pymongo.MongoClient()
+        m = MongoClient()
         m.drop_database(TEST_DATA_CONTENTSTORE['OPTIONS']['db'])
         xmodule.contentstore.django._CONTENTSTORE.clear()
 
@@ -858,7 +857,7 @@ class ContentStoreTest(ModuleStoreTestCase):
         }
 
     def tearDown(self):
-        m = pymongo.MongoClient()
+        m = MongoClient()
         m.drop_database(TEST_DATA_CONTENTSTORE['OPTIONS']['db'])
         xmodule.contentstore.django._CONTENTSTORE.clear()
 

--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -41,6 +41,7 @@ from xmodule.exceptions import NotFoundError
 
 from django_comment_common.utils import are_permissions_roles_seeded
 from xmodule.exceptions import InvalidVersionError
+import xmodule.contentstore.django
 import datetime
 from pytz import UTC
 from uuid import uuid4
@@ -92,7 +93,7 @@ class ContentStoreToyCourseTest(ModuleStoreTestCase):
     def tearDown(self):
         m = pymongo.MongoClient()
         m.drop_database(TEST_DATA_CONTENTSTORE['OPTIONS']['db'])
-        #contentstore().fs_files.drop()
+        xmodule.contentstore.django._CONTENTSTORE.clear()
 
     def check_components_on_page(self, component_types, expected_types):
         """
@@ -859,7 +860,7 @@ class ContentStoreTest(ModuleStoreTestCase):
     def tearDown(self):
         m = pymongo.MongoClient()
         m.drop_database(TEST_DATA_CONTENTSTORE['OPTIONS']['db'])
-        #contentstore().fs_files.drop()
+        xmodule.contentstore.django._CONTENTSTORE.clear()
 
     def test_create_course(self):
         """Test new course creation - happy path"""

--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -43,10 +43,13 @@ from django_comment_common.utils import are_permissions_roles_seeded
 from xmodule.exceptions import InvalidVersionError
 import datetime
 from pytz import UTC
+#from uuid import uuid4
 
 TEST_DATA_MODULESTORE = copy.deepcopy(settings.MODULESTORE)
 TEST_DATA_MODULESTORE['default']['OPTIONS']['fs_root'] = path('common/test/data')
 TEST_DATA_MODULESTORE['direct']['OPTIONS']['fs_root'] = path('common/test/data')
+TEST_DATA_CONTENTSTORE = copy.deepcopy(settings.CONTENTSTORE)
+TEST_DATA_CONTENTSTORE['OPTIONS']['db'] = 'test_xcontent_%s' % 4  #uuid4().hex
 
 
 class MongoCollectionFindWrapper(object):
@@ -60,6 +63,7 @@ class MongoCollectionFindWrapper(object):
 
 
 @override_settings(MODULESTORE=TEST_DATA_MODULESTORE)
+@override_settings(CONTENTSTORE=TEST_DATA_CONTENTSTORE)
 class ContentStoreToyCourseTest(ModuleStoreTestCase):
     """
     Tests that rely on the toy courses.
@@ -82,6 +86,7 @@ class ContentStoreToyCourseTest(ModuleStoreTestCase):
 
         self.client = Client()
         self.client.login(username=uname, password=password)
+
 
     def check_components_on_page(self, component_types, expected_types):
         """
@@ -809,6 +814,7 @@ class ContentStoreToyCourseTest(ModuleStoreTestCase):
         export_to_xml(module_store, content_store, location, root_dir, 'test_export')
 
 
+@override_settings(CONTENTSTORE=TEST_DATA_CONTENTSTORE)
 class ContentStoreTest(ModuleStoreTestCase):
     """
     Tests for the CMS ContentStore application.

--- a/cms/envs/test.py
+++ b/cms/envs/test.py
@@ -70,7 +70,7 @@ CONTENTSTORE = {
     'ENGINE': 'xmodule.contentstore.mongo.MongoContentStore',
     'OPTIONS': {
         'host': 'localhost',
-        'db': 'test_xmodule',
+        'db': 'test_xcontent',
     },
     # allow for additional options that can be keyed on a name, e.g. 'trashcan'
     'ADDITIONAL_OPTIONS': {

--- a/common/lib/xmodule/xmodule/modulestore/tests/django_utils.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/django_utils.py
@@ -27,6 +27,7 @@ class ModuleStoreTestCase(TestCase):
 
         # Remove everything except templates
         modulestore.collection.remove(query)
+        modulestore.collection.drop()
 
     @staticmethod
     def load_templates_if_necessary():

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_mongo.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_mongo.py
@@ -13,11 +13,12 @@ from xmodule.templates import update_templates
 
 from .test_modulestore import check_path_to_location
 from . import DATA_DIR
+from uuid import uuid4
 
 
 HOST = 'localhost'
 PORT = 27017
-DB = 'test'
+DB = 'test_mongo_%s' % uuid4().hex
 COLLECTION = 'modulestore'
 FS_ROOT = DATA_DIR  # TODO (vshnayder): will need a real fs_root for testing load_item
 DEFAULT_CLASS = 'xmodule.raw_module.RawDescriptor'
@@ -39,7 +40,8 @@ class TestMongoModuleStore(object):
 
     @classmethod
     def teardownClass(cls):
-        pass
+        cls.connection = pymongo.connection.Connection(HOST, PORT)
+        cls.connection.drop_database(DB)
 
     @staticmethod
     def initdb():

--- a/jenkins/test.sh
+++ b/jenkins/test.sh
@@ -60,9 +60,6 @@ fi
 
 export PIP_DOWNLOAD_CACHE=/mnt/pip-cache
 
-# Allow django liveserver tests to use a range of ports
-export DJANGO_LIVE_TEST_SERVER_ADDRESS=${DJANGO_LIVE_TEST_SERVER_ADDRESS-localhost:8000-9000}
-
 source /mnt/virtualenvs/"$JOB_NAME"/bin/activate
 
 bundle install

--- a/rakelib/tests.rake
+++ b/rakelib/tests.rake
@@ -16,7 +16,7 @@ def run_tests(system, report_dir, test_id=nil, stop_on_failure=true)
     ENV['NOSE_XUNIT_FILE'] = File.join(report_dir, "nosetests.xml")
     dirs = Dir["common/djangoapps/*"] + Dir["#{system}/djangoapps/*"]
     test_id = dirs.join(' ') if test_id.nil? or test_id == ''
-    cmd = django_admin(system, :test, 'test', '--logging-clear-handlers', test_id)
+    cmd = django_admin(system, :test, 'test', '--logging-clear-handlers', '--liveserver=localhost:8000-9000', test_id)
     test_sh(run_under_coverage(cmd, system))
 end
 


### PR DESCRIPTION
Suggested reviewers: @jzoldak @cdodge 
With this pull request, unit tests should be able to run in parallel.  This change was accomplished by doing the following:
1. All contentstore tests will pull from their unique database name
2. All contentstore tests will drop their database and clear the singleton during tear down resulting in no lingering database at the end of the unit tests.
3. This was already implemented but... for only the Jenkins server in test.sh, Jenkins is given a list of ports to try for the live server tests.  Therefore, if a port is being used by a different test run, it will try the other ports until it can connect safely.
