### PR TITLE
Make server errors return JSON if requested via AJAX

### DIFF
--- a/cms/djangoapps/contentstore/views/error.py
+++ b/cms/djangoapps/contentstore/views/error.py
@@ -1,20 +1,45 @@
-from django.http import HttpResponseServerError, HttpResponseNotFound
+from django.http import (HttpResponse, HttpResponseServerError,
+                         HttpResponseNotFound)
 from mitxmako.shortcuts import render_to_string, render_to_response
+import functools
+import json
 
 __all__ = ['not_found', 'server_error', 'render_404', 'render_500']
 
 
+def jsonable_error(status=500, message="The Studio servers encountered an error"):
+    """
+    A decorator to make an error view return an JSON-formatted message if
+    it was requested via AJAX.
+    """
+    def outer(func):
+        @functools.wraps(func)
+        def inner(request, *args, **kwargs):
+            if request.is_ajax():
+                content = json.dumps({"error": message})
+                return HttpResponse(content, content_type="application/json",
+                                    status=status)
+            else:
+                return func(request, *args, **kwargs)
+        return inner
+    return outer
+
+
+@jsonable_error(404, "Resource not found")
 def not_found(request):
     return render_to_response('error.html', {'error': '404'})
 
 
+@jsonable_error(500, "The Studio servers encountered an error")
 def server_error(request):
     return render_to_response('error.html', {'error': '500'})
 
 
+@jsonable_error(404, "Resource not found")
 def render_404(request):
     return HttpResponseNotFound(render_to_string('404.html', {}))
 
 
+@jsonable_error(500, "The Studio servers encountered an error")
 def render_500(request):
     return HttpResponseServerError(render_to_string('500.html', {}))

--- a/cms/static/coffee/src/main.coffee
+++ b/cms/static/coffee/src/main.coffee
@@ -19,7 +19,10 @@ $ ->
     if ajaxSettings.notifyOnError is false
       return
     if jqXHR.responseText
-        message = _.str.truncate(jqXHR.responseText, 300)
+        try
+          message = JSON.parse(jqXHR.responseText).error
+        catch
+          message = _.str.truncate(jqXHR.responseText, 300)
     else
         message = gettext("This may be happening because of an error with our server or your internet connection. Try refreshing the page or making sure you are online.")
     msg = new CMS.Views.Notification.Error(

--- a/cms/static/coffee/src/main.coffee
+++ b/cms/static/coffee/src/main.coffee
@@ -19,15 +19,15 @@ $ ->
     if ajaxSettings.notifyOnError is false
       return
     if jqXHR.responseText
-        try
-          message = JSON.parse(jqXHR.responseText).error
-        catch
-          message = _.str.truncate(jqXHR.responseText, 300)
+      try
+        message = JSON.parse(jqXHR.responseText).error
+      catch
+        message = _.str.truncate(jqXHR.responseText, 300)
     else
-        message = gettext("This may be happening because of an error with our server or your internet connection. Try refreshing the page or making sure you are online.")
+      message = gettext("This may be happening because of an error with our server or your internet connection. Try refreshing the page or making sure you are online.")
     msg = new CMS.Views.Notification.Error(
-        "title": gettext("Studio's having trouble saving your work")
-        "message": message
+      "title": gettext("Studio's having trouble saving your work")
+      "message": message
     )
     msg.show()
 

--- a/cms/static/coffee/src/main.coffee
+++ b/cms/static/coffee/src/main.coffee
@@ -21,7 +21,7 @@ $ ->
     if jqXHR.responseText
       try
         message = JSON.parse(jqXHR.responseText).error
-      catch
+      catch error
         message = _.str.truncate(jqXHR.responseText, 300)
     else
       message = gettext("This may be happening because of an error with our server or your internet connection. Try refreshing the page or making sure you are online.")


### PR DESCRIPTION
Our default error handler is popping up rendered HTML error pages because our error handlers are returning HTML. It would be much saner to return JSON when requested via AJAX, even on errors. This pull request makes that happen.
