### PR TITLE
Restore Pylint/Pep8 reports

### DIFF
--- a/jenkins/test.sh
+++ b/jenkins/test.sh
@@ -69,11 +69,13 @@ bundle install
 
 rake install_prereqs
 rake clobber
-rake pep8 > pep8.log || cat pep8.log
-rake pylint > pylint.log || cat pylint.log
 
 # Run the unit tests (use phantomjs for javascript unit tests)
 rake test
+
+# Generate pylint and pep8 reports
+rake pep8 > pep8.log || cat pep8.log
+rake pylint > pylint.log || cat pylint.log
 
 # Generate coverage reports
 rake coverage


### PR DESCRIPTION
Moved generation of pylint/pep8 reports to after running the test suite, so the clean reports command doesn't blow
away the reports.

Reviewer: @cpennington 
