### PR TITLE
Remove unused reactivation email function

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -985,19 +985,6 @@ def password_reset(request):
                                         'error': 'Invalid e-mail'}))
 
 
-@ensure_csrf_cookie
-def reactivation_email(request):
-    ''' Send an e-mail to reactivate a deactivated account, or to
-    resend an activation e-mail. Untested. '''
-    email = request.POST['email']
-    try:
-        user = User.objects.get(email='email')
-    except User.DoesNotExist:
-        return HttpResponse(json.dumps({'success': False,
-                                        'error': 'No inactive user with this e-mail exists'}))
-    return reactivation_email_for_user(user)
-
-
 def reactivation_email_for_user(user):
     reg = Registration.objects.get(user=user)
 

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -116,8 +116,6 @@ if not settings.MITX_FEATURES["USE_CUSTOM_THEME"]:
 
         url(r'^submit_feedback$', 'util.views.submit_feedback'),
 
-        # TODO: These urls no longer work. They need to be updated before they are re-enabled
-        # url(r'^reactivate/(?P<key>[^/]*)$', 'student.views.reactivation_email'),
     )
 
 # Only enable URLs for those marketing links actually enabled in the


### PR DESCRIPTION
`reactivation_email` is deprecated in favor of `reactivation_email_for_user`. Remove this deprecated function and the only reference to it.

@ormsbee 
