### PR TITLE
Change width of labels for multiple-choice capa problems to width of text, not 100%

### DIFF
--- a/lms/static/sass/course/base/_base.scss
+++ b/lms/static/sass/course/base/_base.scss
@@ -46,6 +46,13 @@ form {
   }
 }
 
+form.choicegroup {
+  label {
+    clear: both;
+    float: left;
+  }
+}
+
 textarea,
 input[type="text"],
 input[type="email"],


### PR DESCRIPTION
@talbs @frrrances @caesar2164 

Stanford got some feedback from our students/faculty that students
were making accidental clicks on radio-button capa questions.
They would click way to the right of the label text, but it would
still select the corresponding input, which caused some students
to make unintentional changes to their answers.  This was because
labels for these inputs were display:block and width:100%

Changing these labels to float:left clear:both should fix it.
