### PR TITLE
removes choiceresponse wiping after clicking Show Answer

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/capa/display.coffee
+++ b/common/lib/xmodule/xmodule/js/src/capa/display.coffee
@@ -364,8 +364,6 @@ class @Problem
     choicegroup: (element, display, answers) =>
       element = $(element)
 
-      element.find('input').attr('disabled', 'disabled')
-
       input_id = element.attr('id').replace(/inputtype_/,'')
       answer = answers[input_id]
       for choice in answer
@@ -379,7 +377,6 @@ class @Problem
   inputtypeHideAnswerMethods:
     choicegroup: (element, display) =>
       element = $(element)
-      element.find('input').attr('disabled', null)
       element.find('label').removeClass('choicegroup_correct')
 
     javascriptinput: (element, display) =>


### PR DESCRIPTION
From the ticket: "If you click "show answers", then click "check", your own answers are wiped out (presumably because the radio buttons are disabled). I think this is a general issue with multiple choice questions. The only way around this is to click "show answers", navigate to another page, go back to the original page, then hit "check" again."

Support is receiving a lot of mail about this, and numerous professors have complained.

Description in https://edx-wiki.atlassian.net/browse/BLD-128, complaints in https://edx.lighthouseapp.com/projects/101932/tickets/219-Multiple-Choice-clears-answers

Sample problems (for easy testing) added to https://github.com/MITx/content-demos repo in /Testing/Testing:Choiceresponsebug/ sequence.

@sarina @arjun810  please review.
