### PR TITLE
Backbone notifications secondary actions

### DIFF
--- a/cms/static/coffee/spec/views/feedback_spec.coffee
+++ b/cms/static/coffee/spec/views/feedback_spec.coffee
@@ -100,11 +100,10 @@ describe "CMS.Views.SystemFeedback click events", ->
                     text: "Save",
                     class: "save-button",
                     click: @primaryClickSpy
-                secondary: [{
+                secondary:
                     text: "Revert",
                     class: "cancel-button",
                     click: @secondaryClickSpy
-                }]
         )
         @view.show()
 
@@ -123,6 +122,46 @@ describe "CMS.Views.SystemFeedback click events", ->
 
     it "should apply class to secondary action", ->
         expect(@view.$(".action-secondary")).toHaveClass("cancel-button")
+
+
+describe "CMS.Views.SystemFeedback multiple secondary actions", ->
+    beforeEach ->
+        @secondarySpyOne = jasmine.createSpy('secondarySpyOne')
+        @secondarySpyTwo = jasmine.createSpy('secondarySpyTwo')
+        @view = new CMS.Views.Notification.Warning(
+            title: "No Primary",
+            message: "Pick a secondary action",
+            actions:
+                secondary: [
+                    {
+                        text: "Option One"
+                        class: "option-one"
+                        click: @secondarySpyOne
+                    }, {
+                        text: "Option Two"
+                        class: "option-two"
+                        click: @secondarySpyTwo
+                    }
+                ]
+        )
+        @view.show()
+
+    it "should render both", ->
+        expect(@view.el).toContain(".action-secondary.option-one")
+        expect(@view.el).toContain(".action-secondary.option-two")
+        expect(@view.el).not.toContain(".action-secondary.option-one.option-two")
+        expect(@view.$(".action-secondary.option-one")).toContainText("Option One")
+        expect(@view.$(".action-secondary.option-two")).toContainText("Option Two")
+
+    it "should differentiate clicks (1)", ->
+        @view.$(".option-one").click()
+        expect(@secondarySpyOne).toHaveBeenCalled()
+        expect(@secondarySpyTwo).not.toHaveBeenCalled()
+
+    it "should differentiate clicks (2)", ->
+        @view.$(".option-two").click()
+        expect(@secondarySpyOne).not.toHaveBeenCalled()
+        expect(@secondarySpyTwo).toHaveBeenCalled()
 
 describe "CMS.Views.Notification minShown and maxShown", ->
     beforeEach ->

--- a/cms/static/js/views/feedback.js
+++ b/cms/static/js/views/feedback.js
@@ -49,6 +49,11 @@ CMS.Views.SystemFeedback = Backbone.View.extend({
         }
         this.template = _.template(tpl);
         this.setElement($("#page-"+this.options.type));
+        // handle single "secondary" action
+        if (this.options.actions && this.options.actions.secondary &&
+            !_.isArray(this.options.actions.secondary)) {
+            this.options.actions.secondary = [this.options.actions.secondary];
+        }
         return this;
     },
     // public API: show() and hide()


### PR DESCRIPTION
Handle secondary actions on notifications either specified as a single object,
or as a list of objects. Under the hood, the initialize method converts a single
object to a list containing a single object.
