### PR TITLE
Bugfix for stanford shib

### DIFF
--- a/common/djangoapps/external_auth/views.py
+++ b/common/djangoapps/external_auth/views.py
@@ -176,6 +176,7 @@ def external_login_or_signup(request,
 
     # We trust shib's authentication, so no need to authenticate using the password again
     if settings.MITX_FEATURES.get('AUTH_USE_SHIB'):
+        uname = internal_user.username
         user = internal_user
         # Assuming this 'AUTHENTICATION_BACKENDS' is set in settings, which I think is safe
         if settings.AUTHENTICATION_BACKENDS:


### PR DESCRIPTION
External_auth.views.login_or_signup fix codepath that didn't set uname which caused UnboundLocalError.  Added tests for this case

@cpennington 
