### PR TITLE
Add handful of events to the Segment.io whitelist

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/capa/display.coffee
+++ b/common/lib/xmodule/xmodule/js/src/capa/display.coffee
@@ -138,7 +138,7 @@ class @Problem
   #       maybe preferable to consolidate all dispatches to use FormData
   ###
   check_fd: =>
-    Logger.log 'problem_check', answers: @answers
+    Logger.log 'problem_check', @answers
 
     # If there are no file inputs in the problem, we can fall back on @check
     if $('input:file').length == 0
@@ -212,7 +212,8 @@ class @Problem
       $.ajaxWithPrefix("#{@url}/problem_check", settings)
 
   check: =>
-    Logger.log 'problem_check', answers: @answers
+    # Calling check from within check_fd will result in firing the 'problem_check' event twice
+    # Logger.log 'problem_check', @answers
     $.postWithPrefix "#{@url}/problem_check", @answers, (response) =>
       switch response.success
         when 'incorrect', 'correct'
@@ -224,7 +225,7 @@ class @Problem
           @gentle_alert response.success
 
   reset: =>
-    Logger.log 'problem_reset', answers: @answers
+    Logger.log 'problem_reset', @answers
     $.postWithPrefix "#{@url}/problem_reset", id: @id, (response) =>
         @render(response.html)
         @updateProgress response
@@ -284,7 +285,7 @@ class @Problem
     @el.find('.capa_alert').css(opacity: 0).animate(opacity: 1, 700)
 
   save: =>
-    Logger.log 'problem_save', answers: @answers
+    Logger.log 'problem_save', @answers
     $.postWithPrefix "#{@url}/problem_save", @answers, (response) =>
       saveMessage = response.msg
       @gentle_alert saveMessage

--- a/common/lib/xmodule/xmodule/js/src/capa/display.coffee
+++ b/common/lib/xmodule/xmodule/js/src/capa/display.coffee
@@ -138,7 +138,7 @@ class @Problem
   #       maybe preferable to consolidate all dispatches to use FormData
   ###
   check_fd: =>
-    Logger.log 'problem_check', @answers
+    Logger.log 'problem_check', answers: @answers
 
     # If there are no file inputs in the problem, we can fall back on @check
     if $('input:file').length == 0
@@ -212,7 +212,7 @@ class @Problem
       $.ajaxWithPrefix("#{@url}/problem_check", settings)
 
   check: =>
-    Logger.log 'problem_check', @answers
+    Logger.log 'problem_check', answers: @answers
     $.postWithPrefix "#{@url}/problem_check", @answers, (response) =>
       switch response.success
         when 'incorrect', 'correct'
@@ -224,7 +224,7 @@ class @Problem
           @gentle_alert response.success
 
   reset: =>
-    Logger.log 'problem_reset', @answers
+    Logger.log 'problem_reset', answers: @answers
     $.postWithPrefix "#{@url}/problem_reset", id: @id, (response) =>
         @render(response.html)
         @updateProgress response
@@ -284,7 +284,7 @@ class @Problem
     @el.find('.capa_alert').css(opacity: 0).animate(opacity: 1, 700)
 
   save: =>
-    Logger.log 'problem_save', @answers
+    Logger.log 'problem_save', answers: @answers
     $.postWithPrefix "#{@url}/problem_save", @answers, (response) =>
       saveMessage = response.msg
       @gentle_alert saveMessage

--- a/common/lib/xmodule/xmodule/js/src/capa/display.coffee
+++ b/common/lib/xmodule/xmodule/js/src/capa/display.coffee
@@ -138,7 +138,8 @@ class @Problem
   #       maybe preferable to consolidate all dispatches to use FormData
   ###
   check_fd: =>
-    Logger.log 'problem_check', @answers
+    # Calling check from check_fd will result in firing the 'problem_check' event twice, since it is also called in the check function.
+    #Logger.log 'problem_check', @answers
 
     # If there are no file inputs in the problem, we can fall back on @check
     if $('input:file').length == 0
@@ -212,8 +213,7 @@ class @Problem
       $.ajaxWithPrefix("#{@url}/problem_check", settings)
 
   check: =>
-    # Calling check from within check_fd will result in firing the 'problem_check' event twice
-    # Logger.log 'problem_check', @answers
+    Logger.log 'problem_check', @answers
     $.postWithPrefix "#{@url}/problem_check", @answers, (response) =>
       switch response.success
         when 'incorrect', 'correct'

--- a/common/static/coffee/spec/logger_spec.coffee
+++ b/common/static/coffee/spec/logger_spec.coffee
@@ -3,10 +3,15 @@ describe 'Logger', ->
     expect(window.log_event).toBe Logger.log
 
   describe 'log', ->
-    it 'sends an event to Segment.io, if the event is whitelisted', ->
+    it 'sends an event to Segment.io, if the event is whitelisted and the data is not a dictionary', ->
       spyOn(analytics, 'track')
       Logger.log 'seq_goto', 'data'
-      expect(analytics.track).toHaveBeenCalledWith 'seq_goto', 'data'
+      expect(analytics.track).toHaveBeenCalledWith 'seq_goto', value: 'data'
+
+    it 'sends an event to Segment.io, if the event is whitelisted and the data is a dictionary', ->
+      spyOn(analytics, 'track')
+      Logger.log 'seq_goto', value: 'data'
+      expect(analytics.track).toHaveBeenCalledWith 'seq_goto', value: 'data'
 
     it 'send a request to log event', ->
       spyOn $, 'getWithPrefix'

--- a/common/static/coffee/src/logger.coffee
+++ b/common/static/coffee/src/logger.coffee
@@ -3,9 +3,13 @@ class @Logger
   SEGMENT_IO_WHITELIST = ["seq_goto", "seq_next", "seq_prev", "problem_check", "problem_reset", "problem_show", "problem_save"]
 
   @log: (event_type, data) ->
+    # Segment.io event tracking
     if event_type in SEGMENT_IO_WHITELIST
-      # Segment.io event tracking
-      analytics.track event_type, data
+      # to avoid changing the format of data sent to our servers, we only massage it here
+      if typeof data isnt 'object' or data is null
+        analytics.track event_type, value: data
+      else
+        analytics.track event_type, data
 
     $.getWithPrefix '/event',
       event_type: event_type

--- a/common/static/coffee/src/logger.coffee
+++ b/common/static/coffee/src/logger.coffee
@@ -1,6 +1,6 @@
 class @Logger
   # events we want sent to Segment.io for tracking
-  SEGMENT_IO_WHITELIST = ["seq_goto", "seq_next", "seq_prev"]
+  SEGMENT_IO_WHITELIST = ["seq_goto", "seq_next", "seq_prev", "problem_check", "problem_reset", "problem_show", "problem_save"]
 
   @log: (event_type, data) ->
     if event_type in SEGMENT_IO_WHITELIST


### PR DESCRIPTION
This is a conservative expansion of the whitelist of events being routed through Segment.io. I modified the logger calls because the Segment.io API requires that dictionaries be passed to it. @sarina and @shnayder, please review?
