### PR TITLE
Jonahstanley/refactor global to world

### DIFF
--- a/cms/djangoapps/contentstore/features/common.py
+++ b/cms/djangoapps/contentstore/features/common.py
@@ -156,7 +156,7 @@ def create_a_course():
     # Add the user to the instructor group of the course
     # so they will have the permissions to see it in studio
 
-    course = world.GroupFactory.create(name='instructor_MITx/{course_num}/{course_name}'.format(course_num=world.scenario_dict['COURSE'].number, course_name=world.scenario_dict['COURSE_NAME'].display_name.replace(" ", "_")))
+    course = world.GroupFactory.create(name='instructor_MITx/{course_num}/{course_name}'.format(course_num=world.scenario_dict['COURSE'].number, course_name=world.scenario_dict['COURSE'].display_name.replace(" ", "_")))
     if world.scenario_dict['USER']:
         user = world.scenario_dict['USER']
     else:

--- a/cms/djangoapps/contentstore/features/common.py
+++ b/cms/djangoapps/contentstore/features/common.py
@@ -156,8 +156,9 @@ def create_a_course():
     # Add the user to the instructor group of the course
     # so they will have the permissions to see it in studio
 
-    course = world.GroupFactory.create(name='instructor_MITx/{course_num}/{course_name}'.format(course_num=world.scenario_dict['COURSE'].number, course_name=world.scenario_dict['COURSE'].display_name.replace(" ", "_")))
-    if world.scenario_dict['USER']:
+    course = world.GroupFactory.create(name='instructor_MITx/{}/{}'.format(world.scenario_dict['COURSE'].number,
+                                                                    world.scenario_dict['COURSE'].display_name.replace(" ", "_")))
+    if world.scenario_dict.get('USER') is None:
         user = world.scenario_dict['USER']
     else:
         user = get_user_by_email('robot+studio@edx.org')

--- a/cms/djangoapps/contentstore/features/common.py
+++ b/cms/djangoapps/contentstore/features/common.py
@@ -14,10 +14,6 @@ logger = getLogger(__name__)
 
 from terrain.browser import reset_data
 
-_COURSE_NAME = 'Robot Super Course'
-_COURSE_NUM = '999'
-_COURSE_ORG = 'MITx'
-
 ###########  STEP HELPERS ##############
 
 
@@ -124,9 +120,9 @@ def create_studio_user(
 
 
 def fill_in_course_info(
-        name=_COURSE_NAME,
-        org=_COURSE_ORG,
-        num=_COURSE_NUM):
+        name=world.scenario_dict['COURSE_NAME'],
+        org=world.scenario_dict['COURSE_ORG'],
+        num=world.scenario_dict['COURSE_NUM']):
     world.css_fill('.new-course-name', name)
     world.css_fill('.new-course-org', org)
     world.css_fill('.new-course-number', num)
@@ -151,15 +147,24 @@ def log_into_studio(
         login_form.find_by_name('submit').click()
     world.retry_on_exception(fill_login_form)
     assert_true(world.is_css_present('.new-course-button'))
+    world.scenario_dict['username'] = uname
+    world.scenario_dict['userpassword'] = password
+    world.scenario_dict['useremail'] = email
 
 
 def create_a_course():
-    world.CourseFactory.create(org=_COURSE_ORG, course=_COURSE_NUM, display_name=_COURSE_NAME)
+    world.scenario_dict['COURSE_NAME'] = 'Robot Super Course'
+    world.scenario_dict['COURSE_NUM'] = '999'
+    world.scenario_dict['COURSE_ORG'] = 'MITx'
+    world.CourseFactory.create(org=world.scenario_dict['COURSE_ORG'], course=world.scenario_dict['COURSE_NUM'], display_name=world.scenario_dict['COURSE_NAME'])
 
     # Add the user to the instructor group of the course
     # so they will have the permissions to see it in studio
-    course = world.GroupFactory.create(name='instructor_MITx/{course_num}/{course_name}'.format(course_num=_COURSE_NUM, course_name=_COURSE_NAME.replace(" ", "_")))
-    user = get_user_by_email('robot+studio@edx.org')
+    course = world.GroupFactory.create(name='instructor_MITx/{course_num}/{course_name}'.format(course_num=world.scenario_dict['COURSE_NUM'], course_name=world.scenario_dict['COURSE_NAME'].replace(" ", "_")))
+    if world.scenario_dict['useremail']:
+        user = get_user_by_email(world.scenario_dict['useremail'])
+    else:
+        user = get_user_by_email('robot+studio@edx.org')
     user.groups.add(course)
     user.save()
     world.browser.reload()

--- a/cms/djangoapps/contentstore/features/common.py
+++ b/cms/djangoapps/contentstore/features/common.py
@@ -147,22 +147,18 @@ def log_into_studio(
         login_form.find_by_name('submit').click()
     world.retry_on_exception(fill_login_form)
     assert_true(world.is_css_present('.new-course-button'))
-    world.scenario_dict['username'] = uname
-    world.scenario_dict['userpassword'] = password
-    world.scenario_dict['useremail'] = email
+    world.scenario_dict['USER'] = get_user_by_email(email)
 
 
 def create_a_course():
-    world.scenario_dict['COURSE_NAME'] = 'Robot Super Course'
-    world.scenario_dict['COURSE_NUM'] = '999'
-    world.scenario_dict['COURSE_ORG'] = 'MITx'
-    world.CourseFactory.create(org=world.scenario_dict['COURSE_ORG'], course=world.scenario_dict['COURSE_NUM'], display_name=world.scenario_dict['COURSE_NAME'])
+    world.scenario_dict['COURSE'] = world.CourseFactory.create(org='MITx', course='999', display_name='Robot Super Course')
 
     # Add the user to the instructor group of the course
     # so they will have the permissions to see it in studio
-    course = world.GroupFactory.create(name='instructor_MITx/{course_num}/{course_name}'.format(course_num=world.scenario_dict['COURSE_NUM'], course_name=world.scenario_dict['COURSE_NAME'].replace(" ", "_")))
-    if world.scenario_dict['useremail']:
-        user = get_user_by_email(world.scenario_dict['useremail'])
+
+    course = world.GroupFactory.create(name='instructor_MITx/{course_num}/{course_name}'.format(course_num=world.scenario_dict['COURSE'].number, course_name=world.scenario_dict['COURSE_NAME'].display_name.replace(" ", "_")))
+    if world.scenario_dict['USER']:
+        user = world.scenario_dict['USER']
     else:
         user = get_user_by_email('robot+studio@edx.org')
     user.groups.add(course)

--- a/cms/djangoapps/contentstore/features/common.py
+++ b/cms/djangoapps/contentstore/features/common.py
@@ -120,9 +120,9 @@ def create_studio_user(
 
 
 def fill_in_course_info(
-        name=world.scenario_dict['COURSE_NAME'],
-        org=world.scenario_dict['COURSE_ORG'],
-        num=world.scenario_dict['COURSE_NUM']):
+        name='Robot Super Course',
+        org='MITx',
+        num='999'):
     world.css_fill('.new-course-name', name)
     world.css_fill('.new-course-org', org)
     world.css_fill('.new-course-number', num)

--- a/cms/djangoapps/contentstore/features/course-team.py
+++ b/cms/djangoapps/contentstore/features/course-team.py
@@ -2,7 +2,7 @@
 #pylint: disable=W0621
 
 from lettuce import world, step
-from common import create_studio_user, log_into_studio, _COURSE_NAME
+from common import create_studio_user, log_into_studio
 
 PASSWORD = 'test'
 EMAIL_EXTENSION = '@edx.org'
@@ -50,9 +50,9 @@ def see_course(_step, doesnt_see_course, gender):
     all_courses = world.css_find(class_css, wait_time=1)
     all_names = [item.html for item in all_courses]
     if doesnt_see_course:
-        assert not _COURSE_NAME in all_names
+        assert not world.scenario_dict['COURSE_NAME'] in all_names
     else:
-        assert _COURSE_NAME in all_names
+        assert world.scenario_dict['COURSE_NAME'] in all_names
 
 
 @step(u's?he cannot delete users')

--- a/cms/djangoapps/contentstore/features/course-team.py
+++ b/cms/djangoapps/contentstore/features/course-team.py
@@ -50,9 +50,9 @@ def see_course(_step, doesnt_see_course, gender):
     all_courses = world.css_find(class_css, wait_time=1)
     all_names = [item.html for item in all_courses]
     if doesnt_see_course:
-        assert not world.scenario_dict['COURSE_NAME'] in all_names
+        assert not world.scenario_dict['COURSE'].display_name in all_names
     else:
-        assert world.scenario_dict['COURSE_NAME'] in all_names
+        assert world.scenario_dict['COURSE'].display_name in all_names
 
 
 @step(u's?he cannot delete users')

--- a/cms/djangoapps/contentstore/features/courses.py
+++ b/cms/djangoapps/contentstore/features/courses.py
@@ -45,7 +45,7 @@ def courseware_page_has_loaded_in_studio(step):
 @step('I see the course listed in My Courses$')
 def i_see_the_course_in_my_courses(step):
     course_css = 'span.class-name'
-    assert world.css_has_text(course_css, 'Robot Super Course')
+    assert world.css_has_text(course_css, world.scenario_dict['COURSE_NAME'])
 
 
 @step('I am on the "([^"]*)" tab$')

--- a/cms/djangoapps/contentstore/features/courses.py
+++ b/cms/djangoapps/contentstore/features/courses.py
@@ -45,7 +45,7 @@ def courseware_page_has_loaded_in_studio(step):
 @step('I see the course listed in My Courses$')
 def i_see_the_course_in_my_courses(step):
     course_css = 'span.class-name'
-    assert world.css_has_text(course_css, world.scenario_dict['COURSE_NAME'])
+    assert world.css_has_text(course_css, world.scenario_dict['COURSE'].display_name)
 
 
 @step('I am on the "([^"]*)" tab$')

--- a/cms/djangoapps/contentstore/features/grading.py
+++ b/cms/djangoapps/contentstore/features/grading.py
@@ -64,7 +64,7 @@ def change_assignment_name(step, old_name, new_name):
 
 @step(u'I go back to the main course page')
 def main_course_page(step):
-    main_page_link_css = 'a[href="/MITx/999/course/Robot_Super_Course"]'
+    main_page_link_css = 'a[href="/%s/%s/course/%s"]' % (world.scenario_dict['COURSE_ORG'], world.scenario_dict['COURSE_NUM'], world.scenario_dict['COURSE_NAME'].replace(' ', '_'),)
     world.css_click(main_page_link_css)
 
 

--- a/cms/djangoapps/contentstore/features/grading.py
+++ b/cms/djangoapps/contentstore/features/grading.py
@@ -64,7 +64,9 @@ def change_assignment_name(step, old_name, new_name):
 
 @step(u'I go back to the main course page')
 def main_course_page(step):
-    main_page_link_css = 'a[href="/%s/%s/course/%s"]' % (world.scenario_dict['COURSE'].org, world.scenario_dict['COURSE'].number, world.scenario_dict['COURSE'].display_name.replace(' ', '_'),)
+    main_page_link_css = 'a[href="/%s/%s/course/%s"]' % (world.scenario_dict['COURSE'].org,
+                                                        world.scenario_dict['COURSE'].number,
+                                                        world.scenario_dict['COURSE'].display_name.replace(' ', '_'),)
     world.css_click(main_page_link_css)
 
 

--- a/cms/djangoapps/contentstore/features/grading.py
+++ b/cms/djangoapps/contentstore/features/grading.py
@@ -64,7 +64,7 @@ def change_assignment_name(step, old_name, new_name):
 
 @step(u'I go back to the main course page')
 def main_course_page(step):
-    main_page_link_css = 'a[href="/%s/%s/course/%s"]' % (world.scenario_dict['COURSE_ORG'], world.scenario_dict['COURSE_NUM'], world.scenario_dict['COURSE_NAME'].replace(' ', '_'),)
+    main_page_link_css = 'a[href="/%s/%s/course/%s"]' % (world.scenario_dict['COURSE'].org, world.scenario_dict['COURSE'].number, world.scenario_dict['COURSE'].display_name.replace(' ', '_'),)
     world.css_click(main_page_link_css)
 
 

--- a/common/djangoapps/terrain/browser.py
+++ b/common/djangoapps/terrain/browser.py
@@ -79,6 +79,7 @@ def initial_setup(server):
 
     # Set the browser size to 1280x1024
     world.browser.driver.set_window_size(1280, 1024)
+    #world.absorb({}, 'scenario_dict')
 
 
 @before.each_scenario
@@ -89,6 +90,13 @@ def reset_data(scenario):
     """
     LOGGER.debug("Flushing the test database...")
     call_command('flush', interactive=False)
+    world.absorb({}, 'scenario_dict')
+
+
+@after.each_scenario
+def clear_data(scenario):
+    world.spew('scenario_dict')
+
 
 
 @after.each_scenario

--- a/common/djangoapps/terrain/browser.py
+++ b/common/djangoapps/terrain/browser.py
@@ -79,7 +79,6 @@ def initial_setup(server):
 
     # Set the browser size to 1280x1024
     world.browser.driver.set_window_size(1280, 1024)
-    #world.absorb({}, 'scenario_dict')
 
 
 @before.each_scenario

--- a/common/djangoapps/terrain/course_helpers.py
+++ b/common/djangoapps/terrain/course_helpers.py
@@ -44,7 +44,7 @@ def log_in(username, password):
 
     # Authenticate the user
     world.scenario_dict['USER'] = authenticate(username=username, password=password)
-    assert(user is not None and user.is_active)
+    assert(world.scenario_dict['USER'] is not None and world.scenario_dict['USER'].is_active)
 
     # Send a fake HttpRequest to log the user in
     # We need to process the request using
@@ -53,7 +53,7 @@ def log_in(username, password):
     request = HttpRequest()
     SessionMiddleware().process_request(request)
     AuthenticationMiddleware().process_request(request)
-    login(request, user)
+    login(request, world.scenario_dict['USER'])
 
     # Save the session
     request.session.save()

--- a/common/djangoapps/terrain/course_helpers.py
+++ b/common/djangoapps/terrain/course_helpers.py
@@ -43,7 +43,7 @@ def log_in(username, password):
     """
 
     # Authenticate the user
-    user = authenticate(username=username, password=password)
+    world.scenario_dict['USER'] = authenticate(username=username, password=password)
     assert(user is not None and user.is_active)
 
     # Send a fake HttpRequest to log the user in
@@ -62,8 +62,6 @@ def log_in(username, password):
     cookie_dict = {settings.SESSION_COOKIE_NAME: request.session.session_key}
     world.browser.cookies.delete()
     world.browser.cookies.add(cookie_dict)
-    world.scenario_dict['username'] = username
-    world.scenario_dict['userpassword'] = password
 
 
 @world.absorb

--- a/common/djangoapps/terrain/course_helpers.py
+++ b/common/djangoapps/terrain/course_helpers.py
@@ -17,14 +17,14 @@ from urllib import quote_plus
 
 
 @world.absorb
-def create_user(uname):
+def create_user(uname, password):
 
     # If the user already exists, don't try to create it again
     if len(User.objects.filter(username=uname)) > 0:
         return
 
     portal_user = UserFactory.build(username=uname, email=uname + '@edx.org')
-    portal_user.set_password('test')
+    portal_user.set_password(password)
     portal_user.save()
 
     registration = world.RegistrationFactory(user=portal_user)
@@ -62,6 +62,8 @@ def log_in(username, password):
     cookie_dict = {settings.SESSION_COOKIE_NAME: request.session.session_key}
     world.browser.cookies.delete()
     world.browser.cookies.add(cookie_dict)
+    world.scenario_dict['username'] = username
+    world.scenario_dict['userpassword'] = password
 
 
 @world.absorb

--- a/common/djangoapps/terrain/steps.py
+++ b/common/djangoapps/terrain/steps.py
@@ -93,7 +93,7 @@ def i_log_in(step):
 
 @step('I am a logged in user$')
 def i_am_logged_in_user(step):
-    world.create_user('robot')
+    world.create_user('robot', 'test')
     world.log_in('robot', 'test')
 
 
@@ -139,7 +139,7 @@ def should_see_in_the_page(step, doesnt_appear, text):
 
 @step('I am logged in$')
 def i_am_logged_in(step):
-    world.create_user('robot')
+    world.create_user('robot', 'test')
     world.log_in('robot', 'test')
     world.browser.visit(django_url('/'))
     # You should not see the login link
@@ -148,12 +148,12 @@ def i_am_logged_in(step):
 
 @step(u'I am an edX user$')
 def i_am_an_edx_user(step):
-    world.create_user('robot')
+    world.create_user('robot', 'test')
 
 
 @step(u'User "([^"]*)" is an edX user$')
 def registered_edx_user(step, uname):
-    world.create_user(uname)
+    world.create_user(uname, 'test')
 
 
 @step(u'All dialogs should be closed$')

--- a/common/test/data/uploads/test
+++ b/common/test/data/uploads/test
@@ -1,1 +1,1 @@
-R2FUIGM88K
+This is an arbitrary file for testing uploads

--- a/lms/djangoapps/courseware/features/common.py
+++ b/lms/djangoapps/courseware/features/common.py
@@ -21,10 +21,6 @@ logger = getLogger(__name__)
 
 @step(u'The course "([^"]*)" exists$')
 def create_course(step, course):
-    world.scenario_dict['COURSE_NUM'] = course
-    world.scenario_dict['SECTION_NAME'] = 'Test Section'
-    world.scenario_dict['COURSE_NAME'] = 'Test Course'
-    world.scenario_dict['COURSE_ORG'] = 'edx'
 
     # First clear the modulestore so we don't try to recreate
     # the same course twice
@@ -34,17 +30,17 @@ def create_course(step, course):
     # Create the course
     # We always use the same org and display name,
     # but vary the course identifier (e.g. 600x or 191x)
-    course = world.CourseFactory.create(org=world.scenario_dict['COURSE_ORG'],
+    world.scenario_dict['COURSE'] = world.CourseFactory.create(org='edx',
                                         number=course,
-                                        display_name=world.scenario_dict['COURSE_NAME'])
+                                        display_name='Test Course')
 
     # Add a section to the course to contain problems
-    section = world.ItemFactory.create(parent_location=course.location,
-                                       display_name=world.scenario_dict['SECTION_NAME'])
+    world.scenario_dict['SECTION'] = world.ItemFactory.create(parent_location=world.scenario_dict['COURSE'].location,
+                                       display_name='Test Section')
 
-    problem_section = world.ItemFactory.create(parent_location=section.location,
+    problem_section = world.ItemFactory.create(parent_location=world.scenario_dict['SECTION'].location,
                                                template='i4x://edx/templates/sequential/Empty',
-                                               display_name=world.scenario_dict['SECTION_NAME'])
+                                               display_name='Test Section')
 
 
 @step(u'I am registered for the course "([^"]*)"$')
@@ -71,24 +67,24 @@ def add_tab_to_course(step, course, extra_tab_name):
 
 
 def course_id(course_num):
-    return "%s/%s/%s" % (world.scenario_dict['COURSE_ORG'], course_num,
-                         world.scenario_dict['COURSE_NAME'].replace(" ", "_"))
+    return "%s/%s/%s" % (world.scenario_dict['COURSE'].org, course_num,
+                         world.scenario_dict['COURSE'].display_name.replace(" ", "_"))
 
 
 def course_location(course_num):
     return Location(loc_or_tag="i4x",
-                    org=world.scenario_dict['COURSE_ORG'],
+                    org=world.scenario_dict['COURSE'].org,
                     course=course_num,
                     category='course',
-                    name=world.scenario_dict['COURSE_NAME'].replace(" ", "_"))
+                    name=world.scenario_dict['COURSE'].display_name.replace(" ", "_"))
 
 
 def section_location(course_num):
     return Location(loc_or_tag="i4x",
-                    org=world.scenario_dict['COURSE_ORG'],
+                    org=world.scenario_dict['COURSE'].org,
                     course=course_num,
                     category='sequential',
-                    name=world.scenario_dict['SECTION_NAME'].replace(" ", "_"))
+                    name=world.scenario_dict['SECTION'].display_name.replace(" ", "_"))
 
 
 def get_courses():

--- a/lms/djangoapps/courseware/features/common.py
+++ b/lms/djangoapps/courseware/features/common.py
@@ -18,13 +18,13 @@ from xmodule import seq_module, vertical_module
 from logging import getLogger
 logger = getLogger(__name__)
 
-TEST_COURSE_ORG = 'edx'
-TEST_COURSE_NAME = 'Test Course'
-TEST_SECTION_NAME = 'Test Section'
-
 
 @step(u'The course "([^"]*)" exists$')
 def create_course(step, course):
+    world.scenario_dict['COURSE_NUM'] = course
+    world.scenario_dict['SECTION_NAME'] = 'Test Section'
+    world.scenario_dict['COURSE_NAME'] = 'Test Course'
+    world.scenario_dict['COURSE_ORG'] = 'edx'
 
     # First clear the modulestore so we don't try to recreate
     # the same course twice
@@ -34,17 +34,17 @@ def create_course(step, course):
     # Create the course
     # We always use the same org and display name,
     # but vary the course identifier (e.g. 600x or 191x)
-    course = world.CourseFactory.create(org=TEST_COURSE_ORG,
+    course = world.CourseFactory.create(org=world.scenario_dict['COURSE_ORG'],
                                         number=course,
-                                        display_name=TEST_COURSE_NAME)
+                                        display_name=world.scenario_dict['COURSE_NAME'])
 
     # Add a section to the course to contain problems
     section = world.ItemFactory.create(parent_location=course.location,
-                                       display_name=TEST_SECTION_NAME)
+                                       display_name=world.scenario_dict['SECTION_NAME'])
 
     problem_section = world.ItemFactory.create(parent_location=section.location,
                                                template='i4x://edx/templates/sequential/Empty',
-                                               display_name=TEST_SECTION_NAME)
+                                               display_name=world.scenario_dict['SECTION_NAME'])
 
 
 @step(u'I am registered for the course "([^"]*)"$')
@@ -53,7 +53,7 @@ def i_am_registered_for_the_course(step, course):
     create_course(step, course)
 
     # Create the user
-    world.create_user('robot')
+    world.create_user('robot', 'test')
     u = User.objects.get(username='robot')
 
     # If the user is not already enrolled, enroll the user.
@@ -71,24 +71,24 @@ def add_tab_to_course(step, course, extra_tab_name):
 
 
 def course_id(course_num):
-    return "%s/%s/%s" % (TEST_COURSE_ORG, course_num,
-                         TEST_COURSE_NAME.replace(" ", "_"))
+    return "%s/%s/%s" % (world.scenario_dict['COURSE_ORG'], course_num,
+                         world.scenario_dict['COURSE_NAME'].replace(" ", "_"))
 
 
 def course_location(course_num):
     return Location(loc_or_tag="i4x",
-                    org=TEST_COURSE_ORG,
+                    org=world.scenario_dict['COURSE_ORG'],
                     course=course_num,
                     category='course',
-                    name=TEST_COURSE_NAME.replace(" ", "_"))
+                    name=world.scenario_dict['COURSE_NAME'].replace(" ", "_"))
 
 
 def section_location(course_num):
     return Location(loc_or_tag="i4x",
-                    org=TEST_COURSE_ORG,
+                    org=world.scenario_dict['COURSE_ORG'],
                     course=course_num,
                     category='sequential',
-                    name=TEST_SECTION_NAME.replace(" ", "_"))
+                    name=world.scenario_dict['SECTION_NAME'].replace(" ", "_"))
 
 
 def get_courses():

--- a/lms/djangoapps/courseware/features/navigation.py
+++ b/lms/djangoapps/courseware/features/navigation.py
@@ -16,11 +16,11 @@ TEST_SUBSECTION_NAME = 'Test Subsection'
 def view_course_multiple_sections(step):
     create_course()
     # Add a section to the course to contain problems
-    section1 = world.ItemFactory.create(parent_location=course_location(world.scenario_dict['COURSE_NUM']),
+    section1 = world.ItemFactory.create(parent_location=course_location(world.scenario_dict['COURSE'].number),
                                        display_name=section_name(1))
 
     # Add a section to the course to contain problems
-    section2 = world.ItemFactory.create(parent_location=course_location(world.scenario_dict['COURSE_NUM']),
+    section2 = world.ItemFactory.create(parent_location=course_location(world.scenario_dict['COURSE'].number),
                                        display_name=section_name(2))
 
     place1 = world.ItemFactory.create(parent_location=section1.location,
@@ -42,7 +42,7 @@ def view_course_multiple_subsections(step):
     create_course()
 
     # Add a section to the course to contain problems
-    section1 = world.ItemFactory.create(parent_location=course_location(world.scenario_dict['COURSE_NUM']),
+    section1 = world.ItemFactory.create(parent_location=course_location(world.scenario_dict['COURSE'].number),
                                        display_name=section_name(1))
 
     place1 = world.ItemFactory.create(parent_location=section1.location,
@@ -62,7 +62,7 @@ def view_course_multiple_subsections(step):
 def view_course_multiple_sequences(step):
     create_course()
     # Add a section to the course to contain problems
-    section1 = world.ItemFactory.create(parent_location=course_location(world.scenario_dict['COURSE_NUM']),
+    section1 = world.ItemFactory.create(parent_location=course_location(world.scenario_dict['COURSE'].number),
                                        display_name=section_name(1))
 
     place1 = world.ItemFactory.create(parent_location=section1.location,
@@ -142,19 +142,14 @@ def subsection_name(section):
 def create_course():
     world.clear_courses()
 
-    world.scenario_dict['COURSE_NAME'] = 'Test Course'
-    world.scenario_dict['COURSE_ORG'] = 'edx'
-    world.scenario_dict['COURSE_NUM'] = 'model_course'
-    world.CourseFactory.create(org=world.scenario_dict['COURSE_ORG'],
-                                        number=world.scenario_dict['COURSE_NUM'],
-                                        display_name=world.scenario_dict['COURSE_NAME'])
+    world.scenario_dict['COURSE'] = world.CourseFactory.create(org='edx', number='model_course', display_name='Test Course')
 
 
 def create_user_and_visit_course():
     world.create_user('robot', 'test')
     u = User.objects.get(username='robot')
 
-    CourseEnrollment.objects.get_or_create(user=u, course_id=course_id(world.scenario_dict['COURSE_NUM']))
+    CourseEnrollment.objects.get_or_create(user=u, course_id=course_id(world.scenario_dict['COURSE'].number))
 
     world.log_in('robot', 'test')
     chapter_name = (TEST_SECTION_NAME + "1").replace(" ", "_")

--- a/lms/djangoapps/courseware/features/navigation.py
+++ b/lms/djangoapps/courseware/features/navigation.py
@@ -8,8 +8,6 @@ from student.models import CourseEnrollment
 from common import course_id, course_location
 from problems_setup import PROBLEM_DICT
 
-TEST_COURSE_ORG = 'edx'
-TEST_COURSE_NAME = 'Test Course'
 TEST_SECTION_NAME = 'Test Section'
 TEST_SUBSECTION_NAME = 'Test Subsection'
 
@@ -18,11 +16,11 @@ TEST_SUBSECTION_NAME = 'Test Subsection'
 def view_course_multiple_sections(step):
     create_course()
     # Add a section to the course to contain problems
-    section1 = world.ItemFactory.create(parent_location=course_location('model_course'),
+    section1 = world.ItemFactory.create(parent_location=course_location(world.scenario_dict['COURSE_NUM']),
                                        display_name=section_name(1))
 
     # Add a section to the course to contain problems
-    section2 = world.ItemFactory.create(parent_location=course_location('model_course'),
+    section2 = world.ItemFactory.create(parent_location=course_location(world.scenario_dict['COURSE_NUM']),
                                        display_name=section_name(2))
 
     place1 = world.ItemFactory.create(parent_location=section1.location,
@@ -44,7 +42,7 @@ def view_course_multiple_subsections(step):
     create_course()
 
     # Add a section to the course to contain problems
-    section1 = world.ItemFactory.create(parent_location=course_location('model_course'),
+    section1 = world.ItemFactory.create(parent_location=course_location(world.scenario_dict['COURSE_NUM']),
                                        display_name=section_name(1))
 
     place1 = world.ItemFactory.create(parent_location=section1.location,
@@ -64,7 +62,7 @@ def view_course_multiple_subsections(step):
 def view_course_multiple_sequences(step):
     create_course()
     # Add a section to the course to contain problems
-    section1 = world.ItemFactory.create(parent_location=course_location('model_course'),
+    section1 = world.ItemFactory.create(parent_location=course_location(world.scenario_dict['COURSE_NUM']),
                                        display_name=section_name(1))
 
     place1 = world.ItemFactory.create(parent_location=section1.location,
@@ -144,16 +142,19 @@ def subsection_name(section):
 def create_course():
     world.clear_courses()
 
-    world.CourseFactory.create(org=TEST_COURSE_ORG,
-                                        number="model_course",
-                                        display_name=TEST_COURSE_NAME)
+    world.scenario_dict['COURSE_NAME'] = 'Test Course'
+    world.scenario_dict['COURSE_ORG'] = 'edx'
+    world.scenario_dict['COURSE_NUM'] = 'model_course'
+    world.CourseFactory.create(org=world.scenario_dict['COURSE_ORG'],
+                                        number=world.scenario_dict['COURSE_NUM'],
+                                        display_name=world.scenario_dict['COURSE_NAME'])
 
 
 def create_user_and_visit_course():
-    world.create_user('robot')
+    world.create_user('robot', 'test')
     u = User.objects.get(username='robot')
 
-    CourseEnrollment.objects.get_or_create(user=u, course_id=course_id("model_course"))
+    CourseEnrollment.objects.get_or_create(user=u, course_id=course_id(world.scenario_dict['COURSE_NUM']))
 
     world.log_in('robot', 'test')
     chapter_name = (TEST_SECTION_NAME + "1").replace(" ", "_")

--- a/lms/djangoapps/courseware/features/problems.py
+++ b/lms/djangoapps/courseware/features/problems.py
@@ -17,14 +17,15 @@ def view_problem_with_attempts(step, problem_type, attempts):
     i_am_registered_for_the_course(step, 'model_course')
 
     # Ensure that the course has this problem type
-    add_problem_to_course(world.scenario_dict['COURSE_NUM'], problem_type, {'attempts': attempts})
+    add_problem_to_course(world.scenario_dict['COURSE'].number, problem_type, {'attempts': attempts})
 
     # Go to the one section in the factory-created course
     # which should be loaded with the correct problem
     chapter_name = world.scenario_dict['SECTION_NAME'].replace(" ", "_")
     section_name = chapter_name
     url = django_url('/courses/%s/%s/%s/courseware/%s/%s' %
-                    (world.scenario_dict['COURSE_ORG'], world.scenario_dict['COURSE_NUM'], world.scenario_dict['COURSE_NAME'].replace(' ', '_'), chapter_name, section_name,))
+                    (world.scenario_dict['COURSE'].org, world.scenario_dict['COURSE'].number, world.scenario_dict['COURSE'].display_name.replace(' ', '_'),
+                        chapter_name, section_name,))
     world.browser.visit(url)
 
 
@@ -40,8 +41,8 @@ def view_problem_with_show_answer(step, problem_type, answer):
     chapter_name = world.scenario_dict['SECTION_NAME'].replace(" ", "_")
     section_name = chapter_name
     url = django_url('/courses/%s/%s/%s/courseware/%s/%s' %
-                    (world.scenario_dict['COURSE_ORG'], world.scenario_dict['COURSE_NUM'], world.scenario_dict['COURSE_NAME'].replace(' ', '_'), chapter_name, section_name,))
-
+                    (world.scenario_dict['COURSE'].org, world.scenario_dict['COURSE'].number, world.scenario_dict['COURSE'].display_name.replace(' ', '_'),
+                        chapter_name, section_name,))
     world.browser.visit(url)
 
 
@@ -57,8 +58,8 @@ def view_problem(step, problem_type):
     chapter_name = world.scenario_dict['SECTION_NAME'].replace(" ", "_")
     section_name = chapter_name
     url = django_url('/courses/%s/%s/%s/courseware/%s/%s' %
-                    (world.scenario_dict['COURSE_ORG'], world.scenario_dict['COURSE_NUM'], world.scenario_dict['COURSE_NAME'].replace(' ', '_'), chapter_name, section_name,))
-
+                    (world.scenario_dict['COURSE'].org, world.scenario_dict['COURSE'].number, world.scenario_dict['COURSE'].display_name.replace(' ', '_'),
+                        chapter_name, section_name,))
     world.browser.visit(url)
 
 

--- a/lms/djangoapps/courseware/features/problems.py
+++ b/lms/djangoapps/courseware/features/problems.py
@@ -7,7 +7,7 @@ Steps for problem.feature lettuce tests
 
 from lettuce import world, step
 from lettuce.django import django_url
-from common import i_am_registered_for_the_course, TEST_SECTION_NAME
+from common import i_am_registered_for_the_course
 from problems_setup import PROBLEM_DICT, answer_problem, problem_has_answer, add_problem_to_course
 from nose.tools import assert_equal
 
@@ -17,15 +17,14 @@ def view_problem_with_attempts(step, problem_type, attempts):
     i_am_registered_for_the_course(step, 'model_course')
 
     # Ensure that the course has this problem type
-    add_problem_to_course('model_course', problem_type, {'attempts': attempts})
+    add_problem_to_course(world.scenario_dict['COURSE_NUM'], problem_type, {'attempts': attempts})
 
     # Go to the one section in the factory-created course
     # which should be loaded with the correct problem
-    chapter_name = TEST_SECTION_NAME.replace(" ", "_")
+    chapter_name = world.scenario_dict['SECTION_NAME'].replace(" ", "_")
     section_name = chapter_name
-    url = django_url('/courses/edx/model_course/Test_Course/courseware/%s/%s' %
-                    (chapter_name, section_name))
-
+    url = django_url('/courses/%s/%s/%s/courseware/%s/%s' %
+                    (world.scenario_dict['COURSE_ORG'], world.scenario_dict['COURSE_NUM'], world.scenario_dict['COURSE_NAME'].replace(' ', '_'), chapter_name, section_name,))
     world.browser.visit(url)
 
 
@@ -38,10 +37,10 @@ def view_problem_with_show_answer(step, problem_type, answer):
 
     # Go to the one section in the factory-created course
     # which should be loaded with the correct problem
-    chapter_name = TEST_SECTION_NAME.replace(" ", "_")
+    chapter_name = world.scenario_dict['SECTION_NAME'].replace(" ", "_")
     section_name = chapter_name
-    url = django_url('/courses/edx/model_course/Test_Course/courseware/%s/%s' %
-                    (chapter_name, section_name))
+    url = django_url('/courses/%s/%s/%s/courseware/%s/%s' %
+                    (world.scenario_dict['COURSE_ORG'], world.scenario_dict['COURSE_NUM'], world.scenario_dict['COURSE_NAME'].replace(' ', '_'), chapter_name, section_name,))
 
     world.browser.visit(url)
 
@@ -55,10 +54,10 @@ def view_problem(step, problem_type):
 
     # Go to the one section in the factory-created course
     # which should be loaded with the correct problem
-    chapter_name = TEST_SECTION_NAME.replace(" ", "_")
+    chapter_name = world.scenario_dict['SECTION_NAME'].replace(" ", "_")
     section_name = chapter_name
-    url = django_url('/courses/edx/model_course/Test_Course/courseware/%s/%s' %
-                    (chapter_name, section_name))
+    url = django_url('/courses/%s/%s/%s/courseware/%s/%s' %
+                    (world.scenario_dict['COURSE_ORG'], world.scenario_dict['COURSE_NUM'], world.scenario_dict['COURSE_NAME'].replace(' ', '_'), chapter_name, section_name,))
 
     world.browser.visit(url)
 

--- a/lms/djangoapps/courseware/features/problems.py
+++ b/lms/djangoapps/courseware/features/problems.py
@@ -21,7 +21,7 @@ def view_problem_with_attempts(step, problem_type, attempts):
 
     # Go to the one section in the factory-created course
     # which should be loaded with the correct problem
-    chapter_name = world.scenario_dict['SECTION_NAME'].replace(" ", "_")
+    chapter_name = world.scenario_dict['SECTION'].display_name.replace(" ", "_")
     section_name = chapter_name
     url = django_url('/courses/%s/%s/%s/courseware/%s/%s' %
                     (world.scenario_dict['COURSE'].org, world.scenario_dict['COURSE'].number, world.scenario_dict['COURSE'].display_name.replace(' ', '_'),
@@ -38,7 +38,7 @@ def view_problem_with_show_answer(step, problem_type, answer):
 
     # Go to the one section in the factory-created course
     # which should be loaded with the correct problem
-    chapter_name = world.scenario_dict['SECTION_NAME'].replace(" ", "_")
+    chapter_name = world.scenario_dict['SECTION'].display_name.replace(" ", "_")
     section_name = chapter_name
     url = django_url('/courses/%s/%s/%s/courseware/%s/%s' %
                     (world.scenario_dict['COURSE'].org, world.scenario_dict['COURSE'].number, world.scenario_dict['COURSE'].display_name.replace(' ', '_'),
@@ -55,7 +55,7 @@ def view_problem(step, problem_type):
 
     # Go to the one section in the factory-created course
     # which should be loaded with the correct problem
-    chapter_name = world.scenario_dict['SECTION_NAME'].replace(" ", "_")
+    chapter_name = world.scenario_dict['SECTION'].display_name.replace(" ", "_")
     section_name = chapter_name
     url = django_url('/courses/%s/%s/%s/courseware/%s/%s' %
                     (world.scenario_dict['COURSE'].org, world.scenario_dict['COURSE'].number, world.scenario_dict['COURSE'].display_name.replace(' ', '_'),

--- a/lms/djangoapps/courseware/features/registration.py
+++ b/lms/djangoapps/courseware/features/registration.py
@@ -3,13 +3,12 @@
 
 from lettuce import world, step
 from lettuce.django import django_url
-from common import TEST_COURSE_ORG, TEST_COURSE_NAME
 
 
 @step('I register for the course "([^"]*)"$')
 def i_register_for_the_course(_step, course):
-    cleaned_name = TEST_COURSE_NAME.replace(' ', '_')
-    url = django_url('courses/%s/%s/%s/about' % (TEST_COURSE_ORG, course, cleaned_name))
+    cleaned_name = world.scenario_dict['COURSE_NAME'].replace(' ', '_')
+    url = django_url('courses/%s/%s/%s/about' % (world.scenario_dict['COURSE_ORG'], course, cleaned_name))
     world.browser.visit(url)
     world.css_click('section.intro a.register')
 

--- a/lms/djangoapps/courseware/features/registration.py
+++ b/lms/djangoapps/courseware/features/registration.py
@@ -7,8 +7,8 @@ from lettuce.django import django_url
 
 @step('I register for the course "([^"]*)"$')
 def i_register_for_the_course(_step, course):
-    cleaned_name = world.scenario_dict['COURSE_NAME'].replace(' ', '_')
-    url = django_url('courses/%s/%s/%s/about' % (world.scenario_dict['COURSE_ORG'], course, cleaned_name))
+    cleaned_name = world.scenario_dict['COURSE'].display_name.replace(' ', '_')
+    url = django_url('courses/%s/%s/%s/about' % (world.scenario_dict['COURSE'].org, course, cleaned_name))
     world.browser.visit(url)
     world.css_click('section.intro a.register')
 

--- a/lms/djangoapps/courseware/features/video.py
+++ b/lms/djangoapps/courseware/features/video.py
@@ -22,8 +22,8 @@ def view_video(_step):
     chapter_name = world.scenario_dict['SECTION_NAME'].replace(" ", "_")
     section_name = chapter_name
     url = django_url('/courses/%s/%s/%s/courseware/%s/%s' %
-                    (world.scenario_dict['COURSE_ORG'], world.scenario_dict['COURSE_NUM'], world.scenario_dict['COURSE_NAME'].replace(' ', '_'), chapter_name, section_name,))
-
+                    (world.scenario_dict['COURSE'].org, world.scenario_dict['COURSE'].number, world.scenario_dict['COURSE'].display_name.replace(' ', '_'),
+                        chapter_name, section_name,))
     world.browser.visit(url)
 
 
@@ -37,8 +37,8 @@ def view_videoalpha(step):
     chapter_name = world.scenario_dict['SECTION_NAME'].replace(" ", "_")
     section_name = chapter_name
     url = django_url('/courses/%s/%s/%s/courseware/%s/%s' %
-                    (world.scenario_dict['COURSE_ORG'], world.scenario_dict['COURSE_NUM'], world.scenario_dict['COURSE_NAME'].replace(' ', '_'), chapter_name, section_name,))
-
+                    (world.scenario_dict['COURSE'].org, world.scenario_dict['COURSE'].number, world.scenario_dict['COURSE'].display_name.replace(' ', '_'),
+                        chapter_name, section_name,))
     world.browser.visit(url)
 
 

--- a/lms/djangoapps/courseware/features/video.py
+++ b/lms/djangoapps/courseware/features/video.py
@@ -2,7 +2,7 @@
 
 from lettuce import world, step
 from lettuce.django import django_url
-from common import TEST_COURSE_NAME, TEST_SECTION_NAME, i_am_registered_for_the_course, section_location
+from common import i_am_registered_for_the_course, section_location
 
 ############### ACTIONS ####################
 
@@ -14,30 +14,30 @@ def does_autoplay(_step):
 
 @step('the course has a Video component')
 def view_video(_step):
-    coursename = TEST_COURSE_NAME.replace(' ', '_')
+    coursename = world.scenario_dict['COURSE_NAME'].replace(' ', '_')
     i_am_registered_for_the_course(step, coursename)
 
     # Make sure we have a video
     add_video_to_course(coursename)
-    chapter_name = TEST_SECTION_NAME.replace(" ", "_")
+    chapter_name = world.scenario_dict['SECTION_NAME'].replace(" ", "_")
     section_name = chapter_name
-    url = django_url('/courses/edx/Test_Course/Test_Course/courseware/%s/%s' %
-                     (chapter_name, section_name))
+    url = django_url('/courses/%s/%s/%s/courseware/%s/%s' %
+                    (world.scenario_dict['COURSE_ORG'], world.scenario_dict['COURSE_NUM'], world.scenario_dict['COURSE_NAME'].replace(' ', '_'), chapter_name, section_name,))
 
     world.browser.visit(url)
 
 
 @step('the course has a VideoAlpha component')
 def view_videoalpha(step):
-    coursename = TEST_COURSE_NAME.replace(' ', '_')
+    coursename = world.scenario_dict['COURSE_NAME'].replace(' ', '_')
     i_am_registered_for_the_course(step, coursename)
 
     # Make sure we have a videoalpha
     add_videoalpha_to_course(coursename)
-    chapter_name = TEST_SECTION_NAME.replace(" ", "_")
+    chapter_name = world.scenario_dict['SECTION_NAME'].replace(" ", "_")
     section_name = chapter_name
-    url = django_url('/courses/edx/Test_Course/Test_Course/courseware/%s/%s' %
-                     (chapter_name, section_name))
+    url = django_url('/courses/%s/%s/%s/courseware/%s/%s' %
+                    (world.scenario_dict['COURSE_ORG'], world.scenario_dict['COURSE_NUM'], world.scenario_dict['COURSE_NAME'].replace(' ', '_'), chapter_name, section_name,))
 
     world.browser.visit(url)
 

--- a/lms/djangoapps/courseware/features/video.py
+++ b/lms/djangoapps/courseware/features/video.py
@@ -19,7 +19,7 @@ def view_video(_step):
 
     # Make sure we have a video
     add_video_to_course(coursenum)
-    chapter_name = world.scenario_dict['SECTION_NAME'].replace(" ", "_")
+    chapter_name = world.scenario_dict['SECTION'].display_name.replace(" ", "_")
     section_name = chapter_name
     url = django_url('/courses/%s/%s/%s/courseware/%s/%s' %
                     (world.scenario_dict['COURSE'].org, world.scenario_dict['COURSE'].number, world.scenario_dict['COURSE'].display_name.replace(' ', '_'),
@@ -34,7 +34,7 @@ def view_videoalpha(step):
 
     # Make sure we have a videoalpha
     add_videoalpha_to_course(coursenum)
-    chapter_name = world.scenario_dict['SECTION_NAME'].replace(" ", "_")
+    chapter_name = world.scenario_dict['SECTION'].display_name.replace(" ", "_")
     section_name = chapter_name
     url = django_url('/courses/%s/%s/%s/courseware/%s/%s' %
                     (world.scenario_dict['COURSE'].org, world.scenario_dict['COURSE'].number, world.scenario_dict['COURSE'].display_name.replace(' ', '_'),

--- a/lms/djangoapps/courseware/features/video.py
+++ b/lms/djangoapps/courseware/features/video.py
@@ -14,11 +14,11 @@ def does_autoplay(_step):
 
 @step('the course has a Video component')
 def view_video(_step):
-    coursename = world.scenario_dict['COURSE_NAME'].replace(' ', '_')
-    i_am_registered_for_the_course(step, coursename)
+    coursenum = 'test_course'
+    i_am_registered_for_the_course(step, coursenum)
 
     # Make sure we have a video
-    add_video_to_course(coursename)
+    add_video_to_course(coursenum)
     chapter_name = world.scenario_dict['SECTION_NAME'].replace(" ", "_")
     section_name = chapter_name
     url = django_url('/courses/%s/%s/%s/courseware/%s/%s' %
@@ -29,11 +29,11 @@ def view_video(_step):
 
 @step('the course has a VideoAlpha component')
 def view_videoalpha(step):
-    coursename = world.scenario_dict['COURSE_NAME'].replace(' ', '_')
-    i_am_registered_for_the_course(step, coursename)
+    coursenum = 'test_course'
+    i_am_registered_for_the_course(step, coursenum)
 
     # Make sure we have a videoalpha
-    add_videoalpha_to_course(coursename)
+    add_videoalpha_to_course(coursenum)
     chapter_name = world.scenario_dict['SECTION_NAME'].replace(" ", "_")
     section_name = chapter_name
     url = django_url('/courses/%s/%s/%s/courseware/%s/%s' %


### PR DESCRIPTION
Suggested Reviewers: @wedaly @jzoldak 
Lettuce tests have been refactored to use a common dictionary that is local to each scenario.  At the beginning/end of each scenario, the scenario_dict is absorbed and spewed respectively.
This dictionary should be used instead of hard coding constants or importing constants from other files.
So far, this is only used in order to keep access to the course name, number and org that was created and the information relating to the current logged in user.

These changes are based off of the fact that the world is designed to be monkeypatched.  Things can be added to the scenario dictionary in the given statement and then accessed through the rest of the scenario.  However, keys and values must be set in functions (that is not at the top with other constants)

This is a bit cleaner than hard coding or importing variables as it at least keeps them in one place.  Variables that are global to only one file (different CSS selectors for example) were not refactored.
