### PR TITLE
move marketing iframe breakout script to inside existing conditional

### DIFF
--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -21,17 +21,17 @@
       <title>Home | class.stanford.edu</title>
     % else:
       <title>edX</title>
+      
+      <script type="text/javascript">
+        /* immediately break out of an iframe if coming from the marketing website */
+        (function(window) {
+          if (window.location !== window.top.location) {
+            window.top.location = window.location;
+          }
+        })(this);
+      </script>
     % endif
   </%block>
-  <script type="text/javascript">
-  /* immediately break out of an iframe if coming
-     from the marketing website */
-  (function(window) {
-    if (window.location !== window.top.location) {
-      window.top.location = window.location;
-    }
-  })(this);
-  </script>
 
   <link rel="icon" type="image/x-icon" href="${static.url(settings.FAVICON_PATH)}" />
 


### PR DESCRIPTION
@cpennington & @talbs - here's a super quick PR to enable us to have edX iframed into pages...

This is necessary as we want to iframe our instance in and that marketing code isn't letting us...
