### PR TITLE
Catch InvalidLocationError

### DIFF
--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -12,12 +12,11 @@ from xmodule.modulestore import Location
 from xmodule.modulestore.django import modulestore
 from xmodule.contentstore.content import StaticContent
 from xmodule.modulestore.xml import XMLModuleStore
-from xmodule.modulestore.exceptions import ItemNotFoundError
+from xmodule.modulestore.exceptions import ItemNotFoundError, InvalidLocationError
 from courseware.model_data import ModelDataCache
 from static_replace import replace_static_urls
 from courseware.access import has_access
 import branding
-from xmodule.modulestore.exceptions import ItemNotFoundError
 
 log = logging.getLogger(__name__)
 
@@ -49,7 +48,8 @@ def get_course_by_id(course_id, depth=0):
         return modulestore().get_instance(course_id, course_loc, depth=depth)
     except (KeyError, ItemNotFoundError):
         raise Http404("Course not found.")
-
+    except InvalidLocationError:
+        raise Http404("Invalid location")
 
 def get_course_with_access(user, course_id, action, depth=0):
     """

--- a/lms/djangoapps/courseware/tests/test_courses.py
+++ b/lms/djangoapps/courseware/tests/test_courses.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+from django.test import TestCase
+from django.http import Http404
+from courseware.courses import get_course_by_id
+
+class CoursesTest(TestCase):
+    def test_get_course_by_id_invalid_chars(self):
+        """
+        Test that `get_course_by_id` throws a 404, rather than
+        an exception, when faced with unexpected characters 
+        (such as unicode characters, and symbols such as = and ' ')
+        """
+        with self.assertRaises(Http404):
+            get_course_by_id('MITx/foobar/statistics=introduction')
+            get_course_by_id('MITx/foobar/business and management')
+            get_course_by_id('MITx/foobar/NiñøJoséMaríáßç')


### PR DESCRIPTION
When invalid characters are given in a URL (unicode or other characters such as equals sign or literal space) we give a 500 error; we should catch the invalid location error that's thrown and generate a 404. 

See https://edx-wiki.atlassian.net/browse/LMS-28, https://edx-wiki.atlassian.net/browse/LMS-26

Review: @adampalay @JonahStanley 
