### PR TITLE
Fix Lyla showing up everywhere.

### DIFF
--- a/common/lib/xmodule/xmodule/tests/test_video_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_video_module.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import unittest
 
+from xmodule.modulestore import Location
 from xmodule.video_module import VideoDescriptor
 from .test_import import DummySystem
 
@@ -9,6 +10,33 @@ class VideoDescriptorImportTestCase(unittest.TestCase):
     """
     Make sure that VideoDescriptor can import an old XML-based video correctly.
     """
+
+    def test_constructor(self):
+        sample_xml = '''
+            <video display_name="Test Video"
+                   youtube="1.0:p2Q6BrNhdh8,0.75:izygArpw-Qo,1.25:1EeWXzPdhSA,1.5:rABDYkeK0x8"
+                   show_captions="false"
+                   from="00:00:01"
+                   to="00:01:00">
+              <source src="http://www.example.com/source.mp4"/>
+              <track src="http://www.example.com/track"/>
+            </video>
+        '''
+        location = Location(["i4x", "edX", "video", "default",
+                             "SampleProblem1"])
+        model_data = {'data': sample_xml,
+                      'location': location}
+        system = DummySystem(load_error_modules=True)
+        descriptor = VideoDescriptor(system, model_data)
+        self.assertEquals(descriptor.youtube_id_0_75, 'izygArpw-Qo')
+        self.assertEquals(descriptor.youtube_id_1_0, 'p2Q6BrNhdh8')
+        self.assertEquals(descriptor.youtube_id_1_25, '1EeWXzPdhSA')
+        self.assertEquals(descriptor.youtube_id_1_5, 'rABDYkeK0x8')
+        self.assertEquals(descriptor.show_captions, False)
+        self.assertEquals(descriptor.start_time, 1.0)
+        self.assertEquals(descriptor.end_time, 60)
+        self.assertEquals(descriptor.track, 'http://www.example.com/track')
+        self.assertEquals(descriptor.source, 'http://www.example.com/source.mp4')
 
     def test_from_xml(self):
         module_system = DummySystem(load_error_modules=True)


### PR DESCRIPTION
Previously XML data wasn't parsed in VideoDescriptor.**init**, leading
to the defaults being used for video settings.
