### PR TITLE
Make the UrlResetMixin load the urlconf after resetting it, and fix the ...

### DIFF
--- a/common/djangoapps/util/testing.py
+++ b/common/djangoapps/util/testing.py
@@ -1,7 +1,7 @@
 import sys
 
 from django.conf import settings
-from django.core.urlresolvers import clear_url_caches
+from django.core.urlresolvers import clear_url_caches, resolve
 
 
 class UrlResetMixin(object):
@@ -26,6 +26,9 @@ class UrlResetMixin(object):
         if urlconf in sys.modules:
             reload(sys.modules[urlconf])
         clear_url_caches()
+
+        # Resolve a URL so that the new urlconf gets loaded
+        resolve('/')
 
     def setUp(self):
         """Reset django default urlconf before tests and after tests"""

--- a/lms/djangoapps/django_comment_client/base/tests.py
+++ b/lms/djangoapps/django_comment_client/base/tests.py
@@ -1,6 +1,5 @@
 import logging
 
-from django.conf import settings
 from django.test.utils import override_settings
 from django.test.client import Client
 from django.contrib.auth.models import User
@@ -21,16 +20,13 @@ log = logging.getLogger(__name__)
 @override_settings(MODULESTORE=TEST_DATA_MONGO_MODULESTORE)
 @patch('comment_client.utils.requests.request')
 class ViewsTestCase(UrlResetMixin, ModuleStoreTestCase):
+
+    @patch.dict("django.conf.settings.MITX_FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
 
-        # This feature affects the contents of urls.py, so we change
-        # it before the call to super.setUp() which reloads urls.py (because
+        # Patching the ENABLE_DISCUSSION_SERVICE value affects the contents of urls.py,
+        # so we need to call super.setUp() which reloads urls.py (because
         # of the UrlResetMixin)
-
-        # This setting is cleaned up at the end of the test by @override_settings, which
-        # restores all of the old settings
-        settings.MITX_FEATURES['ENABLE_DISCUSSION_SERVICE'] = True
-
         super(ViewsTestCase, self).setUp()
 
         # create a course


### PR DESCRIPTION
...comment client test that was leaving ENABLE_DISCUSSION_SERVICE at True
@cpennington @sarina  
