### PR TITLE
Bind runserver to all 0.0.0.0 instead of localhost

### DIFF
--- a/rakelib/django.rake
+++ b/rakelib/django.rake
@@ -1,6 +1,6 @@
 default_options = {
-    :lms => '8000',
-    :cms => '8001',
+    :lms => '0.0.0.0:8000',
+    :cms => '0.0.0.0:8001',
 }
 
 task :predjango => :install_python_prereqs do


### PR DESCRIPTION
This will make it easier for developers using VMs without a GUI such as those provisioned by Vagrant. Considering the installation script is so large and includes so many dependencies, being friendly for VMs might make it feel safer for new developers to get involved.
