### PR TITLE
save the cert record immediately after we set the status

### DIFF
--- a/lms/djangoapps/certificates/queue.py
+++ b/lms/djangoapps/certificates/queue.py
@@ -194,6 +194,7 @@ class XQueueCertInterface(object):
                 # on the queue
                 if self.restricted.filter(user=student).exists():
                     cert.status = status.restricted
+                    cert.save()
                 else:
                     contents = {
                         'action': 'create',
@@ -202,15 +203,15 @@ class XQueueCertInterface(object):
                         'name': profile.name,
                     }
                     cert.status = status.generating
+                    cert.save()
                     self._send_to_xqueue(contents, key)
-                cert.save()
             else:
                 cert_status = status.notpassing
                 cert.grade = grade['percent']
-                cert.status = cert_status
                 cert.user = student
                 cert.course_id = course_id
                 cert.name = profile.name
+                cert.status = cert_status
                 cert.save()
 
         return cert_status


### PR DESCRIPTION
There was a potential though unlikely race condition because the .save()
was after the certificate request was put on the queue.

Now calling .save() immediately after we update the
cert.
