### PR TITLE
add a new django-admin command to dump out a course structure document. ...

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/dump_course_structure.py
+++ b/cms/djangoapps/contentstore/management/commands/dump_course_structure.py
@@ -1,0 +1,55 @@
+from django.core.management.base import BaseCommand, CommandError
+from xmodule.course_module import CourseDescriptor
+from xmodule.modulestore.django import modulestore
+from json import dumps
+from xmodule.modulestore.inheritance import own_metadata
+from django.conf import settings
+
+filter_list = ['xml_attributes', 'checklists']
+
+
+class Command(BaseCommand):
+    help = '''Write out to stdout a structural and metadata information about a course in a flat dictionary serialized
+              in a JSON format. This can be used for analytics.'''
+
+    def handle(self, *args, **options):
+        if len(args) < 2 or len(args) > 3:
+            raise CommandError("dump_course_structure requires two or more arguments: <location> <outfile> |<db>|")
+
+        course_id = args[0]
+        outfile = args[1]
+
+        # use a user-specified database name, if present
+        # this is useful for doing dumps from databases restored from prod backups
+        if len(args) == 3:
+            settings.MODULESTORE['direct']['OPTIONS']['db'] = args[2]
+
+        loc = CourseDescriptor.id_to_location(course_id)
+
+        store = modulestore()
+
+        course = None
+        try:
+            course = store.get_item(loc, depth=4)
+        except:
+            print 'Could not find course at {0}'.format(course_id)
+            return
+
+        info = {}
+
+        def dump_into_dict(module, info):
+            filtered_metadata = dict((key, value) for key, value in own_metadata(module).iteritems()
+                                     if key not in filter_list)
+            info[module.location.url()] = {
+                'category': module.location.category,
+                'children': module.children if hasattr(module, 'children') else [],
+                'metadata': filtered_metadata
+            }
+
+            for child in module.get_children():
+                dump_into_dict(child, info)
+
+        dump_into_dict(course, info)
+
+        with open(outfile, 'w') as f:
+            f.write(dumps(info))


### PR DESCRIPTION
...This is response to an emergency request from Harvard researchers.

NOTE: This was written for Jim Waldo as he needed a mapping table from the i4x://.... identifiers to some contextual information (e.g. where is that object in relation to the whole tree, what is the metadata, etc.). Jim Waldo signed off on the utility of it so I'd like to get this on master so that it can be part of the weekly analytics dump that is provided for Harvard.

NOTE: There's uncertainty as to whether this dump really fulfills the requirements or not. Keeping PR open for discussion.
