### PR TITLE
Fix for bug Blades/BLD-152

### DIFF
--- a/common/lib/xmodule/xmodule/videoalpha_module.py
+++ b/common/lib/xmodule/xmodule/videoalpha_module.py
@@ -70,7 +70,10 @@ class VideoAlphaModule(VideoAlphaFields, XModule):
     def __init__(self, *args, **kwargs):
         XModule.__init__(self, *args, **kwargs)
         xmltree = etree.fromstring(self.data)
-        self.youtube_streams = xmltree.get('youtube')
+
+        # Front-end expects an empty string, or a properly formatted string with YouTube IDs.
+        self.youtube_streams = xmltree.get('youtube', '')
+
         self.sub = xmltree.get('sub')
         self.position = 0
         self.show_captions = xmltree.get('show_captions', 'true')

--- a/lms/djangoapps/courseware/tests/test_videoalpha_mongo.py
+++ b/lms/djangoapps/courseware/tests/test_videoalpha_mongo.py
@@ -52,3 +52,47 @@ class TestVideo(BaseTestXmodule):
             'autoplay': settings.MITX_FEATURES.get('AUTOPLAY_VIDEOS', True)
         }
         self.assertDictEqual(context, expected_context)
+
+
+class TestVideoNonYouTube(TestVideo):
+    """Integration tests: web client + mongo."""
+
+    DATA = """
+        <videoalpha show_captions="true"
+        data_dir=""
+        caption_asset_path=""
+        autoplay="true"
+        start_time="01:00:03" end_time="01:00:10"
+        >
+            <source src=".../mit-3091x/M-3091X-FA12-L21-3_100.mp4"/>
+            <source src=".../mit-3091x/M-3091X-FA12-L21-3_100.webm"/>
+            <source src=".../mit-3091x/M-3091X-FA12-L21-3_100.ogv"/>
+        </videoalpha>
+    """
+    MODEL_DATA = {
+        'data': DATA
+    }
+
+    def test_videoalpha_constructor(self):
+        """Make sure that if the 'youtube' attribute is omitted in XML, then
+            the template generates an empty string for the YouTube streams.
+        """
+
+        # `get_html` return only context, cause we
+        # overwrite `system.render_template`
+        context = self.item_module.get_html()
+        expected_context = {
+            'data_dir': getattr(self, 'data_dir', None),
+            'caption_asset_path': '/c4x/MITx/999/asset/subs_',
+            'show_captions': self.item_module.show_captions,
+            'display_name': self.item_module.display_name_with_default,
+            'end': self.item_module.end_time,
+            'id': self.item_module.location.html_id(),
+            'sources': self.item_module.sources,
+            'start': self.item_module.start_time,
+            'sub': self.item_module.sub,
+            'track': self.item_module.track,
+            'youtube_streams': '',
+            'autoplay': settings.MITX_FEATURES.get('AUTOPLAY_VIDEOS', True)
+        }
+        self.assertDictEqual(context, expected_context)


### PR DESCRIPTION
## Original problem (including description from https://edx-wiki.atlassian.net/browse/BLD-152 ):

If I remove the youtube attribute of the videoalpha player, I get an error from youtube rather than failing over to the other videos that I have provided.

<videoalpha show_captions="true" sub="name_of_file" >
<source src="https://s3.amazonaws.com/edx-course-videos/edx-intro/edX-FA12-cware-1_100.mp4"/>
<source src="https://s3.amazonaws.com/edx-course-videos/edx-intro/edX-FA12-cware-1_100.webm"/>
<source src="https://s3.amazonaws.com/edx-course-videos/edx-intro/edX-FA12-cware-1_100.ogv"/>
## </videoalpha>

The fix is basically making sure that either an empty string is passed or a correctly formated string of YouTube IDs.

@rocha Please review.
