### PR TITLE
Peter fogg/explicit course settings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -48,6 +48,8 @@ moved to be edited as metadata.
 
 XModule: Only write out assets files if the contents have changed.
 
+Studio: Course settings are now saved explicitly.
+
 XModule: Don't delete generated xmodule asset files when compiling (for
 instance, when XModule provides a coffeescript file, don't delete
 the associated javascript)

--- a/cms/djangoapps/contentstore/features/advanced-settings.feature
+++ b/cms/djangoapps/contentstore/features/advanced-settings.feature
@@ -46,3 +46,9 @@ Feature: Advanced (manual) course policy
     Then it is displayed as a string
     And I reload the page
     Then it is displayed as a string
+
+  Scenario: Confirmation is shown on save
+    Given I am on the Advanced Course Settings page in Studio
+    When I edit the value of a policy key
+    And I press the "Save" notification button
+    Then I see a confirmation that my changes have been saved

--- a/cms/djangoapps/contentstore/features/advanced-settings.py
+++ b/cms/djangoapps/contentstore/features/advanced-settings.py
@@ -2,8 +2,8 @@
 #pylint: disable=W0621
 
 from lettuce import world, step
-from nose.tools import assert_false, assert_equal, assert_regexp_matches
-from common import type_in_codemirror
+from nose.tools import assert_false, assert_equal, assert_regexp_matches, assert_true
+from common import type_in_codemirror, press_the_notification_button
 
 KEY_CSS = '.key input.policy-key'
 VALUE_CSS = 'textarea.json'
@@ -23,20 +23,6 @@ def i_select_advanced_settings(step):
 def i_am_on_advanced_course_settings(step):
     step.given('I have opened a new course in Studio')
     step.given('I select the Advanced Settings')
-
-
-@step(u'I press the "([^"]*)" notification button$')
-def press_the_notification_button(step, name):
-    css = 'a.action-%s' % name.lower()
-
-    # Save was clicked if either the save notification bar is gone, or we have a error notification
-    # overlaying it (expected in the case of typing Object into display_name).
-    def save_clicked():
-        confirmation_dismissed = world.is_css_not_present('.is-shown.wrapper-notification-warning')
-        error_showing = world.is_css_present('.is-shown.wrapper-notification-error')
-        return confirmation_dismissed or error_showing
-
-    world.css_click(css, success_condition=save_clicked)
 
 
 @step(u'I edit the value of a policy key$')

--- a/cms/djangoapps/contentstore/features/common.py
+++ b/cms/djangoapps/contentstore/features/common.py
@@ -56,34 +56,40 @@ def i_press_the_category_delete_icon(_step, category):
 def i_have_opened_a_new_course(_step):
     open_new_course()
 
+
 @step(u'I press the "([^"]*)" notification button$')
-def press_the_notification_button(step, name):
+def press_the_notification_button(_step, name):
     css = 'a.action-%s' % name.lower()
 
-    # Save was clicked if either the save notification bar is gone, or we have a error notification
-    # overlaying it (expected in the case of typing Object into display_name).
-    def save_clicked():
+    # The button was clicked if either the notification bar is gone,
+    # or we see an error overlaying it (expected for invalid inputs).
+    def button_clicked():
         confirmation_dismissed = world.is_css_not_present('.is-shown.wrapper-notification-warning')
         error_showing = world.is_css_present('.is-shown.wrapper-notification-error')
         return confirmation_dismissed or error_showing
 
-    assert_true(world.css_click(css, success_condition=save_clicked), 'Save button not clicked after 5 attempts.')
+    assert_true(world.css_click(css, success_condition=button_clicked), '%s button not clicked after 5 attempts.' % name)
 
 
 @step('I change the "(.*)" field to "(.*)"$')
-def i_change_field_to_value(step, field, value):
-    # Special casing this because we should type into CodeMirror
+def i_change_field_to_value(_step, field, value):
     field_css = '#%s' % '-'.join([s.lower() for s in field.split()])
-    if field_css == '#course-overview':
-        type_in_codemirror(0, value)
-    else:
-        ele = world.css_find(field_css).first
-        ele.fill(value)
-        ele._element.send_keys(Keys.ENTER)
+    ele = world.css_find(field_css).first
+    ele.fill(value)
+    ele._element.send_keys(Keys.ENTER)
 
 
 @step('I reset the database')
-def reset_the_db(step):
+def reset_the_db(_step):
+    """
+    When running Lettuce tests using examples (i.e. "Confirmation is
+    shown on save" in course-settings.feature), the normal hooks
+    aren't called between examples. reset_data should run before each
+    scenario to flush the test database. When this doesn't happen we
+    get errors due to trying to insert a non-unique entry. So instead,
+    we delete the database manually. This has the effect of removing
+    any users and courses that have been created during the test run.
+    """
     reset_data(None)
 
 

--- a/cms/djangoapps/contentstore/features/common.py
+++ b/cms/djangoapps/contentstore/features/common.py
@@ -55,6 +55,12 @@ def i_have_opened_a_new_course(_step):
     open_new_course()
 
 
+@step('I (save|cancel) my changes$')
+def save_changes(step, action):
+    button_css = '.action-%s' % action
+    world.css_click(button_css)
+
+
 ####### HELPER FUNCTIONS ##############
 def open_new_course():
     world.clear_courses()

--- a/cms/djangoapps/contentstore/features/common.py
+++ b/cms/djangoapps/contentstore/features/common.py
@@ -68,7 +68,7 @@ def press_the_notification_button(_step, name):
         error_showing = world.is_css_present('.is-shown.wrapper-notification-error')
         return confirmation_dismissed or error_showing
 
-    assert_true(world.css_click(css, success_condition=button_clicked), '%s button not clicked after 5 attempts.' % name)
+    world.css_click(css, success_condition=button_clicked), '%s button not clicked after 5 attempts.' % name
 
 
 @step('I change the "(.*)" field to "(.*)"$')
@@ -226,6 +226,13 @@ def shows_captions(step, show_captions):
         assert world.css_find('.video')[0].has_class('closed')
     else:
         assert world.is_css_not_present('.video.closed')
+
+
+@step('the save button is disabled$')
+def save_button_disabled(step):
+    button_css = '.action-save'
+    disabled = 'is-disabled'
+    assert world.css_find(button_css)[0].has_class(disabled)
 
 
 def type_in_codemirror(index, text):

--- a/cms/djangoapps/contentstore/features/course-settings.feature
+++ b/cms/djangoapps/contentstore/features/course-settings.feature
@@ -5,15 +5,18 @@ Feature: Course Settings
     Given I have opened a new course in Studio
     When I select Schedule and Details
     And I set course dates
+    And I save my changes
     Then I see the set dates on refresh
 
   Scenario: User can clear previously set course dates (except start date)
     Given I have set course dates
     And I clear all the dates except start
+    And I save my changes
     Then I see cleared dates on refresh
 
   Scenario: User cannot clear the course start date
     Given I have set course dates
+    And I save my changes
     And I clear the course start date
     Then I receive a warning about course start date
     And The previously set start date is shown on refresh
@@ -21,5 +24,13 @@ Feature: Course Settings
   Scenario: User can correct the course start date warning
     Given I have tried to clear the course start
     And I have entered a new course start date
+    And I save my changes
     Then The warning about course start date goes away
     And My new course start date is shown on refresh
+
+  Scenario: Settings are only persisted when saved
+    Given I have set course dates
+    And I save my changes
+    When I change fields
+    And I cancel my changes
+    Then I do not see the new changes persisted on refresh

--- a/cms/djangoapps/contentstore/features/course-settings.feature
+++ b/cms/djangoapps/contentstore/features/course-settings.feature
@@ -65,3 +65,9 @@ Feature: Course Settings
     And I change the course overview
     And I press the "Save" notification button
     Then I see a confirmation that my changes have been saved
+
+  Scenario: User cannot save invalid settings
+    Given I have opened a new course in Studio
+    When I select Schedule and Details
+    And I change the "Course Start Date" field to ""
+    Then the save button is disabled

--- a/cms/djangoapps/contentstore/features/course-settings.feature
+++ b/cms/djangoapps/contentstore/features/course-settings.feature
@@ -32,8 +32,14 @@ Feature: Course Settings
     Given I have set course dates
     And I press the "Save" notification button
     When I change fields
-    And I press the "Cancel" notification button
     Then I do not see the new changes persisted on refresh
+
+  Scenario: Settings are reset on cancel
+    Given I have set course dates
+    And I press the "Save" notification button
+    When I change fields
+    And I press the "Cancel" notification button
+    Then I do not see the changes
 
   Scenario: Confirmation is shown on save
     Given I have opened a new course in Studio
@@ -49,6 +55,13 @@ Feature: Course Settings
   Examples:
     | field                     | value             |
     | Course Start Time         | 11:00             |
-    | Course Overview           | <h1>Overview</h1> |
     | Course Introduction Video | 4r7wHMg5Yjg       |
     | Course Effort             | 200:00            |
+
+  # Special case because we have to type in code mirror
+  Scenario: Changes in Course Overview show a confirmation
+    Given I have opened a new course in Studio
+    When I select Schedule and Details
+    And I change the course overview
+    And I press the "Save" notification button
+    Then I see a confirmation that my changes have been saved

--- a/cms/djangoapps/contentstore/features/course-settings.feature
+++ b/cms/djangoapps/contentstore/features/course-settings.feature
@@ -5,18 +5,18 @@ Feature: Course Settings
     Given I have opened a new course in Studio
     When I select Schedule and Details
     And I set course dates
-    And I save my changes
+    And I press the "Save" notification button
     Then I see the set dates on refresh
 
   Scenario: User can clear previously set course dates (except start date)
     Given I have set course dates
     And I clear all the dates except start
-    And I save my changes
+    And I press the "Save" notification button
     Then I see cleared dates on refresh
 
   Scenario: User cannot clear the course start date
     Given I have set course dates
-    And I save my changes
+    And I press the "Save" notification button
     And I clear the course start date
     Then I receive a warning about course start date
     And The previously set start date is shown on refresh
@@ -24,13 +24,31 @@ Feature: Course Settings
   Scenario: User can correct the course start date warning
     Given I have tried to clear the course start
     And I have entered a new course start date
-    And I save my changes
+    And I press the "Save" notification button
     Then The warning about course start date goes away
     And My new course start date is shown on refresh
 
   Scenario: Settings are only persisted when saved
     Given I have set course dates
-    And I save my changes
+    And I press the "Save" notification button
     When I change fields
-    And I cancel my changes
+    And I press the "Cancel" notification button
     Then I do not see the new changes persisted on refresh
+
+  Scenario: Confirmation is shown on save
+    Given I have opened a new course in Studio
+    When I select Schedule and Details
+    And I change the "<field>" field to "<value>"
+    And I press the "Save" notification button
+    Then I see a confirmation that my changes have been saved
+    # Lettuce hooks don't get called between each example, so we need
+    # to run the before.each_scenario hook manually to avoid database
+    # errors.
+    And I reset the database
+
+  Examples:
+    | field                     | value             |
+    | Course Start Time         | 11:00             |
+    | Course Overview           | <h1>Overview</h1> |
+    | Course Introduction Video | 4r7wHMg5Yjg       |
+    | Course Effort             | 200:00            |

--- a/cms/djangoapps/contentstore/features/course-settings.py
+++ b/cms/djangoapps/contentstore/features/course-settings.py
@@ -4,6 +4,7 @@
 from lettuce import world, step
 from terrain.steps import reload_the_page
 from selenium.webdriver.common.keys import Keys
+from common import type_in_codemirror
 import time
 
 from nose.tools import assert_true, assert_false, assert_equal

--- a/cms/djangoapps/contentstore/features/course-settings.py
+++ b/cms/djangoapps/contentstore/features/course-settings.py
@@ -47,8 +47,6 @@ def test_and_i_set_course_dates(step):
     set_date_or_time(COURSE_START_TIME_CSS, DUMMY_TIME)
     set_date_or_time(ENROLLMENT_END_TIME_CSS, DUMMY_TIME)
 
-    pause()
-
 
 @step('Then I see the set dates on refresh$')
 def test_then_i_see_the_set_dates_on_refresh(step):
@@ -70,8 +68,6 @@ def test_and_i_clear_all_the_dates_except_start(step):
     set_date_or_time(COURSE_END_DATE_CSS, '')
     set_date_or_time(ENROLLMENT_START_DATE_CSS, '')
     set_date_or_time(ENROLLMENT_END_DATE_CSS, '')
-
-    pause()
 
 
 @step('Then I see cleared dates on refresh$')
@@ -119,7 +115,6 @@ def test_i_have_tried_to_clear_the_course_start(step):
 @step('I have entered a new course start date$')
 def test_i_have_entered_a_new_course_start_date(step):
     set_date_or_time(COURSE_START_DATE_CSS, '12/22/2013')
-    pause()
 
 
 @step('The warning about course start date goes away$')
@@ -135,6 +130,20 @@ def test_my_new_course_start_date_is_shown_on_refresh(step):
     verify_date_or_time(COURSE_START_DATE_CSS, '12/22/2013')
     # Time should have stayed from before attempt to clear date.
     verify_date_or_time(COURSE_START_TIME_CSS, DUMMY_TIME)
+
+
+@step('I change fields$')
+def test_i_change_fields(step):
+    set_date_or_time(COURSE_START_DATE_CSS, '7/7/7777')
+    set_date_or_time(COURSE_END_DATE_CSS, '7/7/7777')
+    set_date_or_time(ENROLLMENT_START_DATE_CSS, '7/7/7777')
+    set_date_or_time(ENROLLMENT_END_DATE_CSS, '7/7/7777')
+
+
+@step('I do not see the new changes persisted on refresh$')
+def test_changes_not_shown_on_refresh(step):
+    reload_the_page(step)
+    step.then('Then I see the set dates on refresh')
 
 
 ############### HELPER METHODS ####################
@@ -153,11 +162,3 @@ def verify_date_or_time(css, date_or_time):
     Verifies date or time field.
     """
     assert_equal(date_or_time, world.css_find(css).first.value)
-
-
-def pause():
-    """
-    Must sleep briefly to allow last time save to finish,
-    else refresh of browser will fail.
-    """
-    time.sleep(float(1))

--- a/cms/djangoapps/contentstore/features/course-settings.py
+++ b/cms/djangoapps/contentstore/features/course-settings.py
@@ -5,7 +5,6 @@ from lettuce import world, step
 from terrain.steps import reload_the_page
 from selenium.webdriver.common.keys import Keys
 from common import type_in_codemirror
-import time
 
 from nose.tools import assert_true, assert_false, assert_equal
 
@@ -52,16 +51,7 @@ def test_and_i_set_course_dates(step):
 @step('Then I see the set dates on refresh$')
 def test_then_i_see_the_set_dates_on_refresh(step):
     reload_the_page(step)
-    verify_date_or_time(COURSE_START_DATE_CSS, '12/20/2013')
-    verify_date_or_time(COURSE_END_DATE_CSS, '12/26/2013')
-    verify_date_or_time(ENROLLMENT_START_DATE_CSS, '12/01/2013')
-    verify_date_or_time(ENROLLMENT_END_DATE_CSS, '12/10/2013')
-
-    verify_date_or_time(COURSE_START_TIME_CSS, DUMMY_TIME)
-    # Unset times get set to 12 AM once the corresponding date has been set.
-    verify_date_or_time(COURSE_END_TIME_CSS, DEFAULT_TIME)
-    verify_date_or_time(ENROLLMENT_START_TIME_CSS, DEFAULT_TIME)
-    verify_date_or_time(ENROLLMENT_END_TIME_CSS, DUMMY_TIME)
+    i_see_the_set_dates()
 
 
 @step('And I clear all the dates except start$')
@@ -143,8 +133,18 @@ def test_i_change_fields(step):
 
 @step('I do not see the new changes persisted on refresh$')
 def test_changes_not_shown_on_refresh(step):
-    reload_the_page(step)
     step.then('Then I see the set dates on refresh')
+
+
+@step('I do not see the changes')
+def test_i_do_not_see_changes(_step):
+    i_see_the_set_dates()
+
+
+@step('I change the course overview')
+def test_change_course_overview(_step):
+    type_in_codemirror(0, "<h1>Overview</h1>")
+
 
 
 ############### HELPER METHODS ####################
@@ -163,3 +163,19 @@ def verify_date_or_time(css, date_or_time):
     Verifies date or time field.
     """
     assert_equal(date_or_time, world.css_find(css).first.value)
+
+
+def i_see_the_set_dates():
+    """
+    Ensure that each field has the value set in `test_and_i_set_course_dates`.
+    """
+    verify_date_or_time(COURSE_START_DATE_CSS, '12/20/2013')
+    verify_date_or_time(COURSE_END_DATE_CSS, '12/26/2013')
+    verify_date_or_time(ENROLLMENT_START_DATE_CSS, '12/01/2013')
+    verify_date_or_time(ENROLLMENT_END_DATE_CSS, '12/10/2013')
+
+    verify_date_or_time(COURSE_START_TIME_CSS, DUMMY_TIME)
+    # Unset times get set to 12 AM once the corresponding date has been set.
+    verify_date_or_time(COURSE_END_TIME_CSS, DEFAULT_TIME)
+    verify_date_or_time(ENROLLMENT_START_TIME_CSS, DEFAULT_TIME)
+    verify_date_or_time(ENROLLMENT_END_TIME_CSS, DUMMY_TIME)

--- a/cms/djangoapps/contentstore/features/grading.feature
+++ b/cms/djangoapps/contentstore/features/grading.feature
@@ -32,6 +32,7 @@ Feature: Course Grading
         And I have populated the course
         And I am viewing the grading settings
         When I change assignment type "Homework" to "New Type"
+        And I save my changes
         And I go back to the main course page
         Then I do see the assignment name "New Type"
         And I do not see the assignment name "Homework"
@@ -49,5 +50,14 @@ Feature: Course Grading
         And I have populated the course
         And I am viewing the grading settings
         When I add a new assignment type "New Type"
+        And I save my changes
         And I go back to the main course page
         Then I do see the assignment name "New Type"
+
+    Scenario: Settings are only persisted when saved
+        Given I have opened a new course in Studio
+        And I have populated the course
+        And I am viewing the grading settings
+        When I change assignment type "Homework" to "New Type"
+        And I cancel my changes
+        Then I do not see the changes persisted on refresh

--- a/cms/djangoapps/contentstore/features/grading.feature
+++ b/cms/djangoapps/contentstore/features/grading.feature
@@ -77,3 +77,10 @@ Feature: Course Grading
         When I change assignment type "Homework" to "New Type"
         And I press the "Save" notification button
         Then I see a confirmation that my changes have been saved
+
+    Scenario: User cannot save invalid settings
+        Given I have opened a new course in Studio
+        And I have populated the course
+        And I am viewing the grading settings
+        When I change assignment type "Homework" to ""
+        Then the save button is disabled

--- a/cms/djangoapps/contentstore/features/grading.feature
+++ b/cms/djangoapps/contentstore/features/grading.feature
@@ -32,7 +32,7 @@ Feature: Course Grading
         And I have populated the course
         And I am viewing the grading settings
         When I change assignment type "Homework" to "New Type"
-        And I save my changes
+        And I press the "Save" notification button
         And I go back to the main course page
         Then I do see the assignment name "New Type"
         And I do not see the assignment name "Homework"
@@ -42,6 +42,7 @@ Feature: Course Grading
         And I have populated the course
         And I am viewing the grading settings
         When I delete the assignment type "Homework"
+        And I press the "Save" notification button
         And I go back to the main course page
         Then I do not see the assignment name "Homework"
 
@@ -50,7 +51,7 @@ Feature: Course Grading
         And I have populated the course
         And I am viewing the grading settings
         When I add a new assignment type "New Type"
-        And I save my changes
+        And I press the "Save" notification button
         And I go back to the main course page
         Then I do see the assignment name "New Type"
 
@@ -59,5 +60,22 @@ Feature: Course Grading
         And I have populated the course
         And I am viewing the grading settings
         When I change assignment type "Homework" to "New Type"
-        And I cancel my changes
+        And I press the "Cancel" notification button
         Then I do not see the changes persisted on refresh
+
+    Scenario: Confirmation is shown on save
+        Given I have opened a new course in Studio
+        And I have populated the course
+        And I am viewing the grading settings
+        When I change the "<field>" field to "<value>"
+        And I press the "Save" notification button
+        Then I see a confirmation that my changes have been saved
+        # Lettuce hooks don't get called between each example, so we need
+        # to run the before.each_scenario hook manually to avoid database
+        # errors.
+        And I reset the database
+
+    Examples:
+        | field                          | value               |
+        | Course Grading Graceperiod     | 1:00                |
+        | Course Grading Assignment Name | New Assignment Name |

--- a/cms/djangoapps/contentstore/features/grading.feature
+++ b/cms/djangoapps/contentstore/features/grading.feature
@@ -60,22 +60,20 @@ Feature: Course Grading
         And I have populated the course
         And I am viewing the grading settings
         When I change assignment type "Homework" to "New Type"
-        And I press the "Cancel" notification button
         Then I do not see the changes persisted on refresh
+
+    Scenario: Settings are reset on cancel
+        Given I have opened a new course in Studio
+        And I have populated the course
+        And I am viewing the grading settings
+        When I change assignment type "Homework" to "New Type"
+        And I press the "Cancel" notification button
+        Then I see the assignment type "Homework"
 
     Scenario: Confirmation is shown on save
         Given I have opened a new course in Studio
         And I have populated the course
         And I am viewing the grading settings
-        When I change the "<field>" field to "<value>"
+        When I change assignment type "Homework" to "New Type"
         And I press the "Save" notification button
         Then I see a confirmation that my changes have been saved
-        # Lettuce hooks don't get called between each example, so we need
-        # to run the before.each_scenario hook manually to avoid database
-        # errors.
-        And I reset the database
-
-    Examples:
-        | field                          | value               |
-        | Course Grading Graceperiod     | 1:00                |
-        | Course Grading Assignment Name | New Assignment Name |

--- a/cms/djangoapps/contentstore/features/grading.py
+++ b/cms/djangoapps/contentstore/features/grading.py
@@ -112,6 +112,14 @@ def changes_not_persisted(step):
     assert(ele.value == 'Homework')
 
 
+@step(u'I see the assignment type "(.*)"$')
+def i_see_the_assignment_type(_step, name):
+      assignment_css = '#course-grading-assignment-name'
+      assignments = world.css_find(assignment_css)
+      types = [ele['value'] for ele in assignments]
+      assert name in types
+
+
 def get_type_index(name):
     name_id = '#course-grading-assignment-name'
     f = world.css_find(name_id)

--- a/cms/djangoapps/contentstore/features/grading.py
+++ b/cms/djangoapps/contentstore/features/grading.py
@@ -3,6 +3,7 @@
 
 from lettuce import world, step
 from common import *
+from terrain.steps import reload_the_page
 
 
 @step(u'I am viewing the grading settings')
@@ -59,6 +60,8 @@ def change_assignment_name(step, old_name, new_name):
     for count in range(len(old_name)):
         f._element.send_keys(Keys.END, Keys.BACK_SPACE)
     f._element.send_keys(new_name)
+    # Without this, the "you've made changes" notification won't pop up
+    f._element.send_keys(Keys.ENTER)
 
 
 @step(u'I go back to the main course page')
@@ -91,12 +94,22 @@ def add_assignment_type(step, new_name):
     name_id = '#course-grading-assignment-name'
     f = world.css_find(name_id)[4]
     f._element.send_keys(new_name)
+    # Without this, the "you've made changes" notification won't pop up
+    f._element.send_keys(Keys.ENTER)
 
 
 @step(u'I have populated the course')
 def populate_course(step):
     step.given('I have added a new section')
     step.given('I have added a new subsection')
+
+
+@step(u'I do not see the changes persisted on refresh$')
+def changes_not_persisted(step):
+    reload_the_page(step)
+    name_id = '#course-grading-assignment-name'
+    ele = world.css_find(name_id)[0]
+    assert(ele.value == 'Homework')
 
 
 def get_type_index(name):

--- a/cms/djangoapps/contentstore/features/grading.py
+++ b/cms/djangoapps/contentstore/features/grading.py
@@ -60,8 +60,6 @@ def change_assignment_name(step, old_name, new_name):
     for count in range(len(old_name)):
         f._element.send_keys(Keys.END, Keys.BACK_SPACE)
     f._element.send_keys(new_name)
-    # Without this, the "you've made changes" notification won't pop up
-    f._element.send_keys(Keys.ENTER)
 
 
 @step(u'I go back to the main course page')
@@ -94,8 +92,6 @@ def add_assignment_type(step, new_name):
     name_id = '#course-grading-assignment-name'
     f = world.css_find(name_id)[4]
     f._element.send_keys(new_name)
-    # Without this, the "you've made changes" notification won't pop up
-    f._element.send_keys(Keys.ENTER)
 
 
 @step(u'I have populated the course')

--- a/cms/static/coffee/spec/views/feedback_spec.coffee
+++ b/cms/static/coffee/spec/views/feedback_spec.coffee
@@ -37,6 +37,10 @@ describe "CMS.Views.SystemFeedback", ->
         @renderSpy = spyOn(CMS.Views.Alert.Confirmation.prototype, 'render').andCallThrough()
         @showSpy = spyOn(CMS.Views.Alert.Confirmation.prototype, 'show').andCallThrough()
         @hideSpy = spyOn(CMS.Views.Alert.Confirmation.prototype, 'hide').andCallThrough()
+        @clock = sinon.useFakeTimers()
+
+    afterEach ->
+        @clock.restore()
 
     it "requires a type and an intent", ->
         neither = =>
@@ -80,8 +84,8 @@ describe "CMS.Views.SystemFeedback", ->
     it "close button sends a .hide() message", ->
         view = new CMS.Views.Alert.Confirmation(@options).show()
         view.$(".action-close").click()
-
         expect(@hideSpy).toHaveBeenCalled()
+        @clock.tick(900)
         expect(view.$('.wrapper')).toBeHiding()
 
 describe "CMS.Views.Prompt", ->

--- a/cms/static/js/models/settings/advanced.js
+++ b/cms/static/js/models/settings/advanced.js
@@ -5,8 +5,6 @@ CMS.Models.Settings.Advanced = Backbone.Model.extend({
     defaults: {
         // the properties are whatever the user types in (in addition to whatever comes originally from the server)
     },
-    // which keys to send as the deleted keys on next save
-    deleteKeys : [],
 
     validate: function (attrs) {
         // Keys can no longer be edited. We are currently not validating values.
@@ -18,32 +16,8 @@ CMS.Models.Settings.Advanced = Backbone.Model.extend({
         // add saveSuccess to the success
         var success = options.success;
         options.success = function(model, resp, options) {
-          model.afterSave(model);
           if (success) success(model, resp, options);
         };
         Backbone.Model.prototype.save.call(this, attrs, options);
-    },
-
-    afterSave : function(self) {
-        // remove deleted attrs
-        if (!_.isEmpty(self.deleteKeys)) {
-            // remove the to be deleted keys from the returned model
-            _.each(self.deleteKeys, function(key) { self.unset(key); });
-            // not able to do via backbone since we're not destroying the model
-            $.ajax({
-                url : self.url,
-                // json to and fro
-                contentType : "application/json",
-                dataType : "json",
-                // delete
-                type : 'DELETE',
-                // data
-                data : JSON.stringify({ deleteKeys : self.deleteKeys})
-            })
-            .done(function(data, status, error) {
-                // clear deleteKeys on success
-                self.deleteKeys = [];
-            });
-        }
     }
 });

--- a/cms/static/js/models/settings/course_details.js
+++ b/cms/static/js/models/settings/course_details.js
@@ -63,13 +63,13 @@ CMS.Models.Settings.CourseDetails = Backbone.Model.extend({
     },
 
     _videokey_illegal_chars : /[^a-zA-Z0-9_-]/g,
-    save_videosource: function(newsource) {
+    set_videosource: function(newsource) {
         // newsource either is <video youtube="speed:key, *"/> or just the "speed:key, *" string
         // returns the videosource for the preview which iss the key whose speed is closest to 1
-        if (_.isEmpty(newsource) && !_.isEmpty(this.get('intro_video'))) this.save({'intro_video': null});
+        if (_.isEmpty(newsource) && !_.isEmpty(this.get('intro_video'))) this.set({'intro_video': null}, {validate: true});
         // TODO remove all whitespace w/in string
         else {
-            if (this.get('intro_video') !== newsource) this.save('intro_video', newsource);
+            if (this.get('intro_video') !== newsource) this.set('intro_video', newsource, {validate: true});
         }
 
         return this.videosourceSample();

--- a/cms/static/js/models/settings/course_grading_policy.js
+++ b/cms/static/js/models/settings/course_grading_policy.js
@@ -77,18 +77,19 @@ CMS.Models.Settings.CourseGrader = Backbone.Model.extend({
             }
             else {
                 // FIXME somehow this.collection is unbound sometimes. I can't track down when
-                var existing = this.collection && this.collection.some(function(other) { return (other != this) && (other.get('type') == attrs['type']);}, this);
+                var existing = this.collection && this.collection.some(function(other) { return (other.cid != this.cid) && (other.get('type') == attrs['type']);}, this);
                 if (existing) {
                     errors.type = "There's already another assignment type with this name.";
                 }
             }
         }
         if (_.has(attrs, 'weight')) {
-            if (!isFinite(attrs.weight) || /\D+/.test(attrs.weight)) {
+            var intWeight = parseInt(attrs.weight); // see if this ensures value saved is int
+            if (!isFinite(intWeight) || /\D+/.test(attrs.weight) || intWeight < 0 || intWeight > 100) {
                 errors.weight = "Please enter an integer between 0 and 100.";
             }
             else {
-                attrs.weight = parseInt(attrs.weight); // see if this ensures value saved is int
+                attrs.weight = intWeight;
                 if (this.collection && attrs.weight > 0) {
                     // FIXME b/c saves don't update the models if validation fails, we should
                     // either revert the field value to the one in the model and make them make room

--- a/cms/static/js/models/settings/course_grading_policy.js
+++ b/cms/static/js/models/settings/course_grading_policy.js
@@ -71,7 +71,7 @@ CMS.Models.Settings.CourseGrader = Backbone.Model.extend({
     },
     validate : function(attrs) {
         var errors = {};
-        if (attrs['type']) {
+        if (_.has(attrs, 'type')) {
             if (_.isEmpty(attrs['type'])) {
                 errors.type = "The assignment type must have a name.";
             }
@@ -83,7 +83,7 @@ CMS.Models.Settings.CourseGrader = Backbone.Model.extend({
                 }
             }
         }
-        if (attrs['weight']) {
+        if (_.has(attrs, 'weight')) {
             if (!isFinite(attrs.weight) || /\D+/.test(attrs.weight)) {
                 errors.weight = "Please enter an integer between 0 and 100.";
             }
@@ -97,19 +97,19 @@ CMS.Models.Settings.CourseGrader = Backbone.Model.extend({
 //                  errors.weight = "The weights cannot add to more than 100.";
                 }
             }}
-        if (attrs['min_count']) {
+        if (_.has(attrs, 'min_count')) {
             if (!isFinite(attrs.min_count) || /\D+/.test(attrs.min_count)) {
                 errors.min_count = "Please enter an integer.";
             }
             else attrs.min_count = parseInt(attrs.min_count);
         }
-        if (attrs['drop_count']) {
+        if (_.has(attrs, 'drop_count')) {
             if (!isFinite(attrs.drop_count) || /\D+/.test(attrs.drop_count)) {
                 errors.drop_count = "Please enter an integer.";
             }
             else attrs.drop_count = parseInt(attrs.drop_count);
         }
-        if (attrs['min_count'] && attrs['drop_count'] && attrs.drop_count > attrs.min_count) {
+        if (_.has(attrs, 'min_count') && _.has(attrs, 'drop_count') && attrs.drop_count > attrs.min_count) {
             errors.drop_count = "Cannot drop more " + attrs.type + " than will assigned.";
         }
         if (!_.isEmpty(errors)) return errors;

--- a/cms/static/js/views/feedback.js
+++ b/cms/static/js/views/feedback.js
@@ -140,7 +140,21 @@ CMS.Views.SystemFeedback = Backbone.View.extend({
 CMS.Views.Alert = CMS.Views.SystemFeedback.extend({
     options: $.extend({}, CMS.Views.SystemFeedback.prototype.options, {
         type: "alert"
-    })
+    }),
+    slide_speed: 900,
+    show: function() {
+        CMS.Views.SystemFeedback.prototype.show.apply(this, arguments);
+        this.$el.hide();
+        this.$el.slideDown(this.slide_speed);
+        return this;
+    },
+    hide: function () {
+        this.$el.slideUp({
+            duration: this.slide_speed
+        });
+        setTimeout(_.bind(CMS.Views.SystemFeedback.prototype.hide, this, arguments),
+                   this.slideSpeed);
+    }
 });
 CMS.Views.Notification = CMS.Views.SystemFeedback.extend({
     options: $.extend({}, CMS.Views.SystemFeedback.prototype.options, {

--- a/cms/static/js/views/settings/advanced_view.js
+++ b/cms/static/js/views/settings/advanced_view.js
@@ -57,8 +57,14 @@ CMS.Views.Settings.Advanced = CMS.Views.ValidatingView.extend({
             mode: "application/json", lineNumbers: false, lineWrapping: false,
             onChange: function(instance, changeobj) {
                 // this event's being called even when there's no change :-(
-                if (instance.getValue() !== oldValue && !self.notificationBarShowing) {
-                    self.showNotificationBar();
+                if (instance.getValue() !== oldValue) {
+                    var message = gettext("Your changes will not take effect until you save your progress. Take care with key and value formatting, as validation is not implemented.");
+                    self.showNotificationBar(message,
+                                             _.bind(self.saveView, self),
+                                             _.bind(self.revertView, self));
+                    if(self.saved) {
+                        self.saved.hide();
+                    }
                 }
             },
             onFocus : function(mirror) {
@@ -96,38 +102,6 @@ CMS.Views.Settings.Advanced = CMS.Views.ValidatingView.extend({
                 }
             }
         });
-    },
-    showNotificationBar: function() {
-        var self = this;
-        var message = gettext("Your changes will not take effect until you save your progress. Take care with key and value formatting, as validation is not implemented.")
-        var confirm = new CMS.Views.Notification.Warning({
-            title: gettext("You've Made Some Changes"),
-            message: message,
-            actions: {
-                primary: {
-                    "text": gettext("Save Changes"),
-                    "class": "action-save",
-                    "click": function() {
-                        self.saveView();
-                        confirm.hide();
-                        self.notificationBarShowing = false;
-                    }
-                },
-                secondary: [{
-                    "text": gettext("Cancel"),
-                    "class": "action-cancel",
-                    "click": function() {
-                        self.revertView();
-                        confirm.hide();
-                        self.notificationBarShowing = false;
-                    }
-                }]
-            }});
-        this.notificationBarShowing = true;
-        confirm.show();
-        if(this.saved) {
-            this.saved.hide();
-        }
     },
     saveView : function() {
         // TODO one last verification scan:

--- a/cms/static/js/views/settings/advanced_view.js
+++ b/cms/static/js/views/settings/advanced_view.js
@@ -56,6 +56,7 @@ CMS.Views.Settings.Advanced = CMS.Views.ValidatingView.extend({
         CodeMirror.fromTextArea(textarea, {
             mode: "application/json", lineNumbers: false, lineWrapping: false,
             onChange: function(instance, changeobj) {
+                instance.save()
                 // this event's being called even when there's no change :-(
                 if (instance.getValue() !== oldValue) {
                     var message = gettext("Your changes will not take effect until you save your progress. Take care with key and value formatting, as validation is not implemented.");
@@ -94,8 +95,7 @@ CMS.Views.Settings.Advanced = CMS.Views.ValidatingView.extend({
                     }
                 }
                 if (JSONValue !== undefined) {
-                    self.clearValidationErrors();
-                    self.model.set(key, JSONValue, {validate: true});
+                    self.model.set(key, JSONValue);
                 }
             }
         });
@@ -115,7 +115,8 @@ CMS.Views.Settings.Advanced = CMS.Views.ValidatingView.extend({
                 analytics.track('Saved Advanced Settings', {
                     'course': course_location_analytics
                 });
-            }
+            },
+            silent: true
         });
     },
     revertView: function() {

--- a/cms/static/js/views/settings/advanced_view.js
+++ b/cms/static/js/views/settings/advanced_view.js
@@ -61,7 +61,10 @@ CMS.Views.Settings.Advanced = CMS.Views.ValidatingView.extend({
                     var message = gettext("Your changes will not take effect until you save your progress. Take care with key and value formatting, as validation is not implemented.");
                     self.showNotificationBar(message,
                                              _.bind(self.saveView, self),
-                                             _.bind(self.revertView, self));
+                                             function() {
+                                                 self.model.deleteKeys = [];
+                                                 self.revertView();
+                                             });
                     if(self.saved) {
                         self.saved.hide();
                     }
@@ -112,25 +115,19 @@ CMS.Views.Settings.Advanced = CMS.Views.ValidatingView.extend({
             {
             success : function() {
                 self.render();
+                var title = gettext("Your policy changes have been saved.");
                 var message = gettext("Please note that validation of your policy key and value pairs is not currently in place yet. If you are having difficulties, please review your policy pairs.");
-                self.saved = new CMS.Views.Alert.Confirmation({
-                    title: gettext("Your policy changes have been saved."),
-                    message: message,
-                    closeIcon: false
-                });
-                self.saved.show();
+                self.showSavedBar(title, message);
                 analytics.track('Saved Advanced Settings', {
                     'course': course_location_analytics
                 });
             }
         });
     },
-    revertView : function() {
+    revertView: function() {
         var self = this;
-        this.model.deleteKeys = [];
-        this.model.clear({silent : true});
         this.model.fetch({
-            success : function() { self.render(); },
+            success: function() { self.render(); },
             reset: true
         });
     },

--- a/cms/static/js/views/settings/advanced_view.js
+++ b/cms/static/js/views/settings/advanced_view.js
@@ -61,13 +61,7 @@ CMS.Views.Settings.Advanced = CMS.Views.ValidatingView.extend({
                     var message = gettext("Your changes will not take effect until you save your progress. Take care with key and value formatting, as validation is not implemented.");
                     self.showNotificationBar(message,
                                              _.bind(self.saveView, self),
-                                             function() {
-                                                 self.model.deleteKeys = [];
-                                                 self.revertView();
-                                             });
-                    if(self.saved) {
-                        self.saved.hide();
-                    }
+                                             _.bind(self.revertView, self));
                 }
             },
             onFocus : function(mirror) {

--- a/cms/static/js/views/settings/main_settings_view.js
+++ b/cms/static/js/views/settings/main_settings_view.js
@@ -144,7 +144,8 @@ CMS.Views.Settings.Details = CMS.Views.ValidatingView.extend({
         }
         var self = this;
         this.showNotificationBar(this.save_message,
-                                 _.bind(this.saveModel, this));
+                                 _.bind(this.saveView, this),
+                                 _.bind(this.revertView, this));
     },
 
     removeSyllabus: function() {
@@ -185,12 +186,29 @@ CMS.Views.Settings.Details = CMS.Views.ValidatingView.extend({
                     if (cachethis.model.get(field) != newVal) {
                         cachethis.model.set(field, newVal);
                         cachethis.showNotificationBar(cachethis.save_message,
-                                                      _.bind(cachethis.saveModel, cachethis));
+                                                      _.bind(cachethis.saveView, cachethis),
+                                                      _.bind(cachethis.revertView, cachethis));
                     }
                 }
             });
         }
-    }
+    },
 
+    revertView: function() {
+        // Make sure that the CodeMirror instance has the correct
+        // data from its corresponding textarea
+        var self = this;
+        this.model.fetch({
+            success: function() {
+                self.render();
+                _.each(self.codeMirrors,
+                       function(mirror) {
+                           var ele = mirror.getTextArea();
+                           var field = self.selectorToField[ele.id];
+                           mirror.setValue(self.model.get(field));
+                       });
+            },
+            reset: true});
+    }
 });
 

--- a/cms/static/js/views/validating_view.js
+++ b/cms/static/js/views/validating_view.js
@@ -67,5 +67,39 @@ CMS.Views.ValidatingView = Backbone.View.extend({
             // put error on the contained inputs
             return $(ele).find(inputElements);
         }
+    },
+
+    showNotificationBar: function(message, primaryClick, secondaryClick) {
+        if(this.notificationBarShowing) {
+            return;
+        }
+        var self = this;
+        this.confirmation = new CMS.Views.Notification.Warning({
+            title: gettext("You've made some changes"),
+            message: message,
+            actions: {
+                primary: {
+                    "text": gettext("Save Changes"),
+                    "class": "action-save",
+                    "click": function() {
+                        primaryClick();
+                        self.confirmation.hide();
+                        self.notificationBarShowing = false;
+                    }
+                },
+                secondary: [{
+                    "text": gettext("Cancel"),
+                    "class": "action-cancel",
+                    "click": function() {
+                        if(secondaryClick) {
+                            secondaryClick();
+                        }
+                        self.confirmation.hide();
+                        self.notificationBarShowing = false;
+                    }
+                }]
+            }});
+        this.notificationBarShowing = true;
+        this.confirmation.show();
     }
 });

--- a/cms/static/js/views/validating_view.js
+++ b/cms/static/js/views/validating_view.js
@@ -45,7 +45,8 @@ CMS.Views.ValidatingView = Backbone.View.extend({
         this.clearValidationErrors();
         var field = this.selectorToField[event.currentTarget.id];
         var newVal = $(event.currentTarget).val();
-        this.model.set(field, newVal, {validate: true});
+        this.model.set(field, newVal);
+        this.model.isValid();
         return newVal;
     },
     // these should perhaps go into a superclass but lack of event hash inheritance demotivates me
@@ -68,8 +69,17 @@ CMS.Views.ValidatingView = Backbone.View.extend({
     },
 
     showNotificationBar: function(message, primaryClick, secondaryClick) {
+        // Show a notification with message. primaryClick is called on
+        // pressing the save button, and secondaryClick (if it's
+        // passed, which it may not be) will be called on
+        // cancel. Takes care of hiding the notification bar at the
+        // appropriate times.
         if(this.notificationBarShowing) {
             return;
+        }
+        // If we've already saved something, hide the alert.
+        if(this.saved) {
+            this.saved.hide();
         }
         var self = this;
         this.confirmation = new CMS.Views.Notification.Warning({
@@ -93,10 +103,6 @@ CMS.Views.ValidatingView = Backbone.View.extend({
                             secondaryClick();
                         }
                         self.model.clear({silent : true});
-                        /*self.model.fetch({
-                            success : function() { self.render(); },
-                            reset: true
-                        });*/
                         self.confirmation.hide();
                         self.notificationBarShowing = false;
                     }
@@ -114,13 +120,23 @@ CMS.Views.ValidatingView = Backbone.View.extend({
             closeIcon: false
         });
         this.saved.show();
+        $.smoothScroll({
+            offset: 0,
+            easing: 'swing',
+            speed: 1000
+        });
     },
 
     saveView: function() {
         var self = this;
-        this.model.save({},
-                        {success: function() {
-                            self.showSavedBar();
-                        }});
+        this.model.save(
+            {},
+            {
+                success: function() {
+                    self.showSavedBar();
+                },
+                silent: true
+            }
+        );
     }
 });

--- a/cms/static/js/views/validating_view.js
+++ b/cms/static/js/views/validating_view.js
@@ -92,6 +92,11 @@ CMS.Views.ValidatingView = Backbone.View.extend({
                         if(secondaryClick) {
                             secondaryClick();
                         }
+                        self.model.clear({silent : true});
+                        /*self.model.fetch({
+                            success : function() { self.render(); },
+                            reset: true
+                        });*/
                         self.confirmation.hide();
                         self.notificationBarShowing = false;
                     }
@@ -111,7 +116,7 @@ CMS.Views.ValidatingView = Backbone.View.extend({
         this.saved.show();
     },
 
-    saveModel: function() {
+    saveView: function() {
         var self = this;
         this.model.save({},
                         {success: function() {

--- a/cms/static/js/views/validating_view.js
+++ b/cms/static/js/views/validating_view.js
@@ -9,7 +9,10 @@ CMS.Views.ValidatingView = Backbone.View.extend({
 
     errorTemplate : _.template('<span class="message-error"><%= message %></span>'),
 
+    save_title: gettext("You've made some changes"),
     save_message: gettext("Your changes will not take effect until you save your progress."),
+    error_title: gettext("You've made some changes, but there are some errors"),
+    error_message: gettext("Please address the errors on this page first, and then save your progress."),
 
     events : {
         "change input" : "clearValidationErrors",
@@ -22,6 +25,7 @@ CMS.Views.ValidatingView = Backbone.View.extend({
     _cacheValidationErrors : [],
 
     handleValidationError : function(model, error) {
+        this.clearValidationErrors();
         // error is object w/ fields and error strings
         for (var field in error) {
             var ele = this.$el.find('#' + this.fieldToSelectorMap[field]);
@@ -29,6 +33,11 @@ CMS.Views.ValidatingView = Backbone.View.extend({
             this.getInputElements(ele).addClass('error');
             $(ele).parent().append(this.errorTemplate({message : error[field]}));
         }
+        $('.wrapper-notification-warning').addClass('wrapper-notification-warning-w-errors');
+        $('.action-save').addClass('is-disabled');
+        // TODO: (pfogg) should this text fade in/out on change?
+        $('#notification-warning-title').text(this.error_title);
+        $('#notification-warning-description').text(this.error_message);
     },
 
     clearValidationErrors : function() {
@@ -38,6 +47,10 @@ CMS.Views.ValidatingView = Backbone.View.extend({
             this.getInputElements(ele).removeClass('error');
             $(ele).nextAll('.message-error').remove();
         }
+        $('.wrapper-notification-warning').removeClass('wrapper-notification-warning-w-errors');
+        $('.action-save').removeClass('is-disabled');
+        $('#notification-warning-title').text(this.save_title);
+        $('#notification-warning-description').text(this.save_message);
     },
 
     setField : function(event) {
@@ -83,7 +96,7 @@ CMS.Views.ValidatingView = Backbone.View.extend({
         }
         var self = this;
         this.confirmation = new CMS.Views.Notification.Warning({
-            title: gettext("You've made some changes"),
+            title: this.save_title,
             message: message,
             actions: {
                 primary: {
@@ -110,6 +123,8 @@ CMS.Views.ValidatingView = Backbone.View.extend({
             }});
         this.notificationBarShowing = true;
         this.confirmation.show();
+        // Make sure the bar is in the right state
+        this.model.isValid();
     },
 
     showSavedBar: function(title, message) {

--- a/cms/static/js/views/validating_view.js
+++ b/cms/static/js/views/validating_view.js
@@ -9,6 +9,8 @@ CMS.Views.ValidatingView = Backbone.View.extend({
 
     errorTemplate : _.template('<span class="message-error"><%= message %></span>'),
 
+    save_message: gettext("Your changes will not take effect until you save your progress."),
+
     events : {
         "change input" : "clearValidationErrors",
         "change textarea" : "clearValidationErrors"
@@ -38,17 +40,13 @@ CMS.Views.ValidatingView = Backbone.View.extend({
         }
     },
 
-    saveIfChanged : function(event) {
-        // returns true if the value changed and was thus sent to server
+    setField : function(event) {
+        // Set model field and return the new value.
+        this.clearValidationErrors();
         var field = this.selectorToField[event.currentTarget.id];
-        var currentVal = this.model.get(field);
         var newVal = $(event.currentTarget).val();
-        this.clearValidationErrors(); // curr = new if user reverts manually
-        if (currentVal != newVal) {
-            this.model.save(field, newVal);
-            return true;
-        }
-        else return false;
+        this.model.set(field, newVal, {validate: true});
+        return newVal;
     },
     // these should perhaps go into a superclass but lack of event hash inheritance demotivates me
     inputFocus : function(event) {
@@ -101,5 +99,23 @@ CMS.Views.ValidatingView = Backbone.View.extend({
             }});
         this.notificationBarShowing = true;
         this.confirmation.show();
+    },
+
+    showSavedBar: function(title, message) {
+        var defaultTitle = gettext('Your changes have been saved.');
+        this.saved = new CMS.Views.Alert.Confirmation({
+            title: title || defaultTitle,
+            message: message,
+            closeIcon: false
+        });
+        this.saved.show();
+    },
+
+    saveModel: function() {
+        var self = this;
+        this.model.save({},
+                        {success: function() {
+                            self.showSavedBar();
+                        }});
     }
 });

--- a/cms/static/sass/elements/_system-feedback.scss
+++ b/cms/static/sass/elements/_system-feedback.scss
@@ -665,14 +665,8 @@
     }
   }
 
-  // alert showing/hiding
-  .wrapper-alert {
-    display: none;
-
-    &.is-shown {
-      display: block;
-    }
-  }
+  // alert showing/hiding done by jQuery
+  .wrapper-alert { }
 
   // notification showing/hiding
   .wrapper-notification {

--- a/common/static/sass/_mixins-inherited.scss
+++ b/common/static/sass/_mixins-inherited.scss
@@ -126,7 +126,7 @@
   padding: ($baseline/5) $baseline ($baseline/4);
   font-weight: 700;
 
-  &.disabled {
+  &.disabled, &.is-disabled {
     border: 1px solid $gray-l1 !important;
     border-radius: 3px !important;
     background: $gray-l1 !important;
@@ -157,7 +157,7 @@
     color: $white;
   }
 
-  &.disabled {
+  &.disabled, &.is-disabled {
     border: 1px solid $green-l3 !important;
     background: $green-l3 !important;
     color: $white !important;
@@ -178,7 +178,7 @@
     color: $white;
   }
 
-  &.disabled {
+  &.disabled, &.is-disabled {
     box-shadow: none;
     border: 1px solid $blue-l3 !important;
     background: $blue-l3 !important;
@@ -199,7 +199,7 @@
     color: $white;
   }
 
-  &.disabled {
+  &.disabled, &.is-disabled {
     box-shadow: none;
     border: 1px solid $red-l3 !important;
     background: $red-l3 !important;
@@ -220,7 +220,7 @@
     color: $white;
   }
 
-  &.disabled {
+  &.disabled, &.is-disabled {
     box-shadow: none;
     border: 1px solid $pink-l3 !important;
     background: $pink-l3 !important;
@@ -242,7 +242,7 @@
     color: $gray-d2;
   }
 
-  &.disabled {
+  &.disabled, &.is-disabled {
     border: 1px solid $orange-l3 !important;
     background: $orange-l2 !important;
     color: $gray-l1 !important;


### PR DESCRIPTION
Change the save model for all settings pages from an asynchronous save `onBlur` to an explicit save with notifications. There's a bit of refactoring around this new model -- where we previously called `model.save`, we now call `model.set` and pop up a confirmation. Settings are all reverted when the user hits the cancel button on said bar.
