### PR TITLE
Renzo/segment io refactor

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/sequence/display.coffee
+++ b/common/lib/xmodule/xmodule/js/src/sequence/display.coffee
@@ -119,7 +119,7 @@ class @Sequence
         current_sequential: @position
         target_sequential: new_position
 
-      # On Sequence chage, destroy any existing polling thread
+      # On Sequence change, destroy any existing polling thread
       #   for queued submissions, see ../capa/display.coffee
       if window.queuePollerID
         window.clearTimeout(window.queuePollerID)

--- a/common/lib/xmodule/xmodule/js/src/sequence/display.coffee
+++ b/common/lib/xmodule/xmodule/js/src/sequence/display.coffee
@@ -111,6 +111,14 @@ class @Sequence
     if (1 <= new_position) and (new_position <= @num_contents)
       Logger.log "seq_goto", old: @position, new: new_position, id: @id
 
+      analytics.pageview @id
+
+      # navigation by clicking the tab directly
+      analytics.track "Accessed Sequential Directly",
+        sequence_id: @id
+        current_sequential: @position
+        target_sequential: new_position
+
       # On Sequence chage, destroy any existing polling thread
       #   for queued submissions, see ../capa/display.coffee
       if window.queuePollerID
@@ -125,12 +133,30 @@ class @Sequence
     event.preventDefault()
     new_position = @position + 1
     Logger.log "seq_next", old: @position, new: new_position, id: @id
+
+    analytics.pageview @id
+
+    # navigation using the next arrow
+    analytics.track "Accessed Next Sequential",
+      sequence_id: @id
+      current_sequential: @position
+      target_sequential: new_position 
+
     @render new_position
 
   previous: (event) =>
     event.preventDefault()
     new_position = @position - 1
     Logger.log "seq_prev", old: @position, new: new_position, id: @id
+
+    analytics.pageview @id
+
+    # navigation using the previous arrow
+    analytics.track "Accessed Previous Sequential",
+      sequence_id: @id
+      current_sequential: @position
+      target_sequential: new_position
+
     @render new_position
 
   link_for: (position) ->

--- a/common/static/coffee/spec/logger_spec.coffee
+++ b/common/static/coffee/spec/logger_spec.coffee
@@ -3,16 +3,6 @@ describe 'Logger', ->
     expect(window.log_event).toBe Logger.log
 
   describe 'log', ->
-    it 'sends an event to Segment.io, if the event is whitelisted and the data is not a dictionary', ->
-      spyOn(analytics, 'track')
-      Logger.log 'seq_goto', 'data'
-      expect(analytics.track).toHaveBeenCalledWith 'seq_goto', value: 'data'
-
-    it 'sends an event to Segment.io, if the event is whitelisted and the data is a dictionary', ->
-      spyOn(analytics, 'track')
-      Logger.log 'seq_goto', value: 'data'
-      expect(analytics.track).toHaveBeenCalledWith 'seq_goto', value: 'data'
-
     it 'send a request to log event', ->
       spyOn $, 'postWithPrefix'
       Logger.log 'example', 'data'

--- a/common/static/coffee/src/logger.coffee
+++ b/common/static/coffee/src/logger.coffee
@@ -42,5 +42,5 @@ class @Logger
           page: window.location.href
         async: false
 
-# Keeping this for conpatibility issue only.
+# Keeping this for compatibility issue only.
 @log_event = Logger.log

--- a/common/static/coffee/src/logger.coffee
+++ b/common/static/coffee/src/logger.coffee
@@ -1,19 +1,8 @@
 class @Logger
 
-  # events we want sent to Segment.io for tracking
-  SEGMENT_IO_WHITELIST = ["seq_goto", "seq_next", "seq_prev", "problem_check", "problem_reset", "problem_show", "problem_save"]
-
   # listeners[event_type][element] -> list of callbacks
   listeners = {}
   @log: (event_type, data, element = null) ->
-    # Segment.io event tracking
-    if event_type in SEGMENT_IO_WHITELIST
-      # to avoid changing the format of data sent to our servers, we only massage it here
-      if typeof data isnt 'object' or data is null
-        analytics.track event_type, value: data
-      else
-        analytics.track event_type, data
-
     # Check to see if we're listening for the event type.
     if event_type of listeners
       # Cool.  Do the elements also match?
@@ -42,7 +31,6 @@ class @Logger
       listeners[event_type][element] = [callback]
     else
       listeners[event_type][element].push callback
-
 
   @bind: ->
     window.onunload = ->

--- a/lms/static/coffee/src/instructor_dashboard_tracking.coffee
+++ b/lms/static/coffee/src/instructor_dashboard_tracking.coffee
@@ -1,0 +1,4 @@
+if $('.instructor-dashboard-wrapper').length == 1
+    analytics.track "Loaded an Instructor Dashboard Page", 
+        location: window.location.pathname
+        dashboard_page: $('.navbar .selectedmode').text()

--- a/lms/templates/courseware/instructor_dashboard.html
+++ b/lms/templates/courseware/instructor_dashboard.html
@@ -104,7 +104,7 @@ function goto( mode)
   <section class="instructor-dashboard-content">
     <h1>Instructor Dashboard</h1>
 
-    <h2>[ <a href="#" onclick="goto('Grades');" class="${modeflag.get('Grades')}">Grades</a> |
+    <h2 class="navbar">[ <a href="#" onclick="goto('Grades');" class="${modeflag.get('Grades')}">Grades</a> |
           %if settings.MITX_FEATURES.get('ENABLE_PSYCHOMETRICS'):
             <a href="#" onclick="goto('Psychometrics');" class="${modeflag.get('Psychometrics')}">Psychometrics</a> |
           %endif

--- a/lms/templates/widgets/segment-io.html
+++ b/lms/templates/widgets/segment-io.html
@@ -17,7 +17,8 @@
 <!-- dummy segment.io -->
 <script type="text/javascript">
   var analytics = {
-    track: function() { return; }
+    track: function() { return; },
+    pageview: function() { return; }
   };
 </script>
 <!-- end dummy segment.io -->


### PR DESCRIPTION
@rocha and @shnayder, please review?

I've added a forced increment to the page load counter each time a user navigates to a sequential, creating the illusion of page loads. Each of these `pageview` events is associated with the ID of the sequential it was fired by. In light of conversations with Mark and Victor, I've also refactored my previous integration of Segment.io. We now call the API directly (instead of through the Logger), and the events have proper names and well-named fields.

In addition, I've added the ability to track which tab/page an instructor is on in the current instructor dashboard, as requested by Mark and Victor. This wasn't possible before since the URL doesn't change. Miles' refactor will require a forced "page load" count using Segment.io's `pageview` method, but this will allow us to track instructor navigation behavior before then.
