### PR TITLE
Studio - truncates longer course settings sharing urls

### DIFF
--- a/cms/static/sass/views/_settings.scss
+++ b/cms/static/sass/views/_settings.scss
@@ -316,6 +316,12 @@ body.course.settings {
 
           .link-courseURL {
             @extend .t-copy-lead1;
+            @include box-sizing(border-box);
+            display: block;
+            width: 100%;
+            overflow: hidden;
+            white-space: nowrap;
+            text-overflow: ellipsis;
 
             &:hover {
 


### PR DESCRIPTION
This Pull Request provides a quick styling revision to account for very long course URLs that are publicized on the main/Schedule & Details settings view.
