### PR TITLE
Remove use of keyword "delete" in forum coffee code to fix IE8 bug LMS-441

### DIFF
--- a/common/static/coffee/src/discussion/content.coffee
+++ b/common/static/coffee/src/discussion/content.coffee
@@ -109,7 +109,7 @@ if Backbone?
       'downvote'    : -> DiscussionUtil.urlFor("downvote_#{@get('type')}", @id)
       'close'       : -> DiscussionUtil.urlFor('openclose_thread', @id)
       'update'      : -> DiscussionUtil.urlFor('update_thread', @id)
-      'delete'      : -> DiscussionUtil.urlFor('delete_thread', @id)
+      '_delete'      : -> DiscussionUtil.urlFor('delete_thread', @id)
       'follow'      : -> DiscussionUtil.urlFor('follow_thread', @id)
       'unfollow'    : -> DiscussionUtil.urlFor('unfollow_thread', @id)
       'flagAbuse'   : -> DiscussionUtil.urlFor("flagAbuse_#{@get('type')}", @id)
@@ -168,7 +168,7 @@ if Backbone?
       'downvote': -> DiscussionUtil.urlFor("downvote_#{@get('type')}", @id)
       'endorse': -> DiscussionUtil.urlFor('endorse_comment', @id)
       'update': -> DiscussionUtil.urlFor('update_comment', @id)
-      'delete': -> DiscussionUtil.urlFor('delete_comment', @id)
+      '_delete': -> DiscussionUtil.urlFor('delete_comment', @id)
       'flagAbuse'   : -> DiscussionUtil.urlFor("flagAbuse_#{@get('type')}", @id)
       'unFlagAbuse' : -> DiscussionUtil.urlFor("unFlagAbuse_#{@get('type')}", @id)
 

--- a/common/static/coffee/src/discussion/views/discussion_thread_show_view.coffee
+++ b/common/static/coffee/src/discussion/views/discussion_thread_show_view.coffee
@@ -7,7 +7,7 @@ if Backbone?
       "click .admin-pin": "togglePin"
       "click .action-follow": "toggleFollowing"
       "click .action-edit": "edit"
-      "click .action-delete": "delete"
+      "click .action-delete": "_delete"
       "click .action-openclose": "toggleClosed"
 
     $: (selector) ->
@@ -125,8 +125,8 @@ if Backbone?
     edit: (event) ->
       @trigger "thread:edit", event
 
-    delete: (event) ->
-      @trigger "thread:delete", event
+    _delete: (event) ->
+      @trigger "thread:_delete", event
 
     togglePin: (event) ->
       event.preventDefault()

--- a/common/static/coffee/src/discussion/views/discussion_thread_view.coffee
+++ b/common/static/coffee/src/discussion/views/discussion_thread_view.coffee
@@ -185,7 +185,7 @@ if Backbone?
         @editView = null
 
       @showView = new DiscussionThreadShowView(model: @model)
-      @showView.bind "thread:delete", @delete
+      @showView.bind "thread:_delete", @_delete
       @showView.bind "thread:edit", @edit
 
     renderShowView: () ->
@@ -196,9 +196,11 @@ if Backbone?
       @createShowView()
       @renderShowView()
 
-
-    delete: (event) =>
-      url = @model.urlFor('delete')
+    # If you use "delete" here, it will compile down into JS that includes the
+    # use of DiscussionThreadView.prototype.delete, and that will break IE8
+    # because "delete" is a keyword. So, using an underscore to prevent that.
+    _delete: (event) =>
+      url = @model.urlFor('_delete')
       if not @model.can('can_delete')
         return
       if not confirm "Are you sure to delete thread \"#{@model.get('title')}\"?"

--- a/common/static/coffee/src/discussion/views/discussion_thread_view_inline.coffee
+++ b/common/static/coffee/src/discussion/views/discussion_thread_view_inline.coffee
@@ -48,7 +48,7 @@ if Backbone?
         @editView.$el.empty()
         @editView = null
       @showView = new DiscussionThreadInlineShowView(model: @model)
-      @showView.bind "thread:delete", @delete
+      @showView.bind "thread:_delete", @_delete
       @showView.bind "thread:edit", @edit
 
     renderResponses: ->

--- a/common/static/coffee/src/discussion/views/thread_response_show_view.coffee
+++ b/common/static/coffee/src/discussion/views/thread_response_show_view.coffee
@@ -3,7 +3,7 @@ if Backbone?
     events:
         "click .vote-btn": "toggleVote"
         "click .action-endorse": "toggleEndorse"
-        "click .action-delete": "delete"
+        "click .action-delete": "_delete"
         "click .action-edit": "edit"
         "click .discussion-flag-abuse": "toggleFlagAbuse"
 
@@ -77,8 +77,8 @@ if Backbone?
     edit: (event) ->
         @trigger "response:edit", event
 
-    delete: (event) ->
-        @trigger "response:delete", event
+    _delete: (event) ->
+        @trigger "response:_delete", event
 
     toggleEndorse: (event) ->
       event.preventDefault()

--- a/common/static/coffee/src/discussion/views/thread_response_view.coffee
+++ b/common/static/coffee/src/discussion/views/thread_response_view.coffee
@@ -93,13 +93,13 @@ if Backbone?
           comment.set(response.content)
           view.render() # This is just to update the id for the most part, but might be useful in general
 
-    delete: (event) =>
+    _delete: (event) =>
       event.preventDefault()
       if not @model.can('can_delete')
         return
       if not confirm "Are you sure to delete this response? "
         return
-      url = @model.urlFor('delete')
+      url = @model.urlFor('_delete')
       @model.remove()
       @$el.remove()
       $elem = $(event.target)
@@ -141,7 +141,7 @@ if Backbone?
         @editView = null
 
       @showView = new ThreadResponseShowView(model: @model)
-      @showView.bind "response:delete", @delete
+      @showView.bind "response:_delete", @_delete
       @showView.bind "response:edit", @edit
 
     renderShowView: () ->


### PR DESCRIPTION
Change client-side code references from "delete" to "_delete". Some of these were method names (or would generate method names), which breaks in IE8 because "delete" is a JavaScript reserved keyword. foo["delete"] is ok, but foo.delete is not. This also makes forums marginally functional in IE8, though the left-nav still has some display issues.
