### PR TITLE
Refactor rake tasks for pylint/pep8

### DIFF
--- a/rakelib/quality.rake
+++ b/rakelib/quality.rake
@@ -20,26 +20,26 @@ end
     report_dir = report_dir_path(system)
     directory report_dir
 
-    desc "Run pep8 on all #{system} code"
-    task "pep8_#{system}" => [report_dir, :install_python_prereqs] do
-        sh("pep8 #{system} | tee #{report_dir}/pep8.report")
-    end
-    task :pep8 => "pep8_#{system}"
+    namespace :pylint do
+        namespace system do
+            desc "Run pylint checking for #{system} checking for errors only, and aborting if there are any"
+            task :errors do
+                run_pylint(system, report_dir, '-E')
+            end
+        end
 
-    desc "Run pylint on all #{system} code"
-    task "pylint_#{system}" => [report_dir, :install_python_prereqs] do
-        run_pylint(system, report_dir)
-    end
-    namespace "pylint_#{system}" do
-        desc "Run pylint checking for errors only, and aborting if there are any"
-        task :errors do
-            run_pylint(system, report_dir, '-E')
+        desc "Run pylint on all #{system} code"
+        task system do
+            run_pylint(system, report_dir)
         end
     end
-    namespace :pylint do
-        task :errors => "pylint_#{system}:errors"
+    task :pylint => :"pylint:#{system}"
+
+    namespace :pep8 do
+        desc "Run pep8 on all #{system} code"
+        task system => [report_dir, :install_python_prereqs] do
+            sh("pep8 #{system} | tee #{report_dir}/pep8.report")
+        end
     end
-
-    task :pylint => "pylint_#{system}"
-
+    task :pep8 => :"pep8:#{system}"
 end

--- a/rakelib/quality.rake
+++ b/rakelib/quality.rake
@@ -29,7 +29,7 @@ end
         end
 
         desc "Run pylint on all #{system} code"
-        task system do
+        task system => [report_dir, :install_python_prereqs] do
             run_pylint(system, report_dir)
         end
     end


### PR DESCRIPTION
Split components with `:` instead of `_`

Note: this may require changing how Jenkins calls pylint and pep8.
