### PR TITLE
If empty dict passed for data, don't call update_item

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/tests/factories.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/factories.py
@@ -51,8 +51,8 @@ class XModuleCourseFactory(Factory):
             ]
         )
 
-        data = kwargs.pop('data', None)
-        if data is not None:
+        data = kwargs.pop('data', {})
+        if data:
             store.update_item(new_course.location, data)
 
         # The rest of kwargs become attributes on the course:

--- a/common/lib/xmodule/xmodule/modulestore/tests/factories.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/factories.py
@@ -22,6 +22,7 @@ class XModuleCourseFactory(Factory):
     def _create(cls, target_class, **kwargs):
 
         template = Location('i4x', 'edx', 'templates', 'course', 'Empty')
+        kwargs.pop('template', None)
         org = kwargs.pop('org', None)
         number = kwargs.pop('number', None)
         display_name = kwargs.pop('display_name', None)
@@ -53,7 +54,11 @@ class XModuleCourseFactory(Factory):
 
         data = kwargs.pop('data', {})
         if data:
-            store.update_item(new_course.location, data)
+            if isinstance(data, dict):
+                for k, v in data.iteritems():
+                    setattr(new_course, k, v)
+            else:
+                store.update_item(new_course.location, data)
 
         # The rest of kwargs become attributes on the course:
         for k, v in kwargs.iteritems():


### PR DESCRIPTION
@nedbat @singingwolfboy Please review. Unit tests were passing dicts for the data and it was forcing what should have been an innocuous save_item for the empty dict.
