### PR TITLE
Fix broken tests by simplifying the CourseFactory

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/tests/factories.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/factories.py
@@ -51,17 +51,13 @@ class XModuleCourseFactory(Factory):
             ]
         )
 
-        data = kwargs.pop('data', None)
-        if data is not None:
-            store.update_item(new_course.location, data)
-
         # The rest of kwargs become attributes on the course:
         for k, v in kwargs.iteritems():
             setattr(new_course, k, v)
 
         # Update the data in the mongo datastore
-        store.update_metadata(new_course.location.url(), own_metadata(new_course))
-        store.update_item(new_course.location.url(), new_course._model_data._kvs._data)
+        store.update_metadata(new_course.location, own_metadata(new_course))
+        store.update_item(new_course.location, new_course._model_data._kvs._data)
 
         # update_item updates the the course as it exists in the modulestore, but doesn't
         # update the instance we are working with, so have to refetch the course after updating it.

--- a/lms/djangoapps/courseware/tests/__init__.py
+++ b/lms/djangoapps/courseware/tests/__init__.py
@@ -32,13 +32,11 @@ class BaseTestXmodule(ModuleStoreTestCase):
         1. TEMPLATE_NAME
         2. DATA
         3. MODEL_DATA
-        4. COURSE_DATA and USER_COUNT if needed
 
     This class should not contain any tests, because TEMPLATE_NAME
     should be defined in child class.
     """
     USER_COUNT = 2
-    COURSE_DATA = {}
 
     # Data from YAML common/lib/xmodule/xmodule/templates/NAME/default.yaml
     TEMPLATE_NAME = ""
@@ -47,7 +45,7 @@ class BaseTestXmodule(ModuleStoreTestCase):
 
     def setUp(self):
 
-        self.course = CourseFactory.create(data=self.COURSE_DATA)
+        self.course = CourseFactory.create()
 
         # Turn off cache.
         modulestore().request_cache = None

--- a/lms/djangoapps/instructor/tests/test_gradebook.py
+++ b/lms/djangoapps/instructor/tests/test_gradebook.py
@@ -27,11 +27,11 @@ class TestGradebook(ModuleStoreTestCase):
 
         modulestore().request_cache = modulestore().metadata_inheritance_cache_subsystem = None
 
-        course_data = {}
+        kwargs = {}
         if self.grading_policy is not None:
-            course_data['grading_policy'] = self.grading_policy
+            kwargs['grading_policy'] = self.grading_policy
 
-        self.course = CourseFactory.create(data=course_data)
+        self.course = CourseFactory.create(**kwargs)
         chapter = ItemFactory.create(
             parent_location=self.course.location,
             template="i4x://edx/templates/sequential/Empty",


### PR DESCRIPTION
The data argument was being treated specially, but that was just
because we didn't have **kwargs support.  Now we do.  There are
two uses of data=, one we convert to kwargs, the other was actually
unused, so remove it completely.

Already reviewed face-to-face by @cpennington and @dmitchell 
