### PR TITLE
tracking in idashboard should only log json-serializable objects

### DIFF
--- a/lms/djangoapps/instructor/views.py
+++ b/lms/djangoapps/instructor/views.py
@@ -374,7 +374,7 @@ def instructor_dashboard(request, course_id):
         msg += message
         if student is not None:
             progress_url = reverse('student_progress', kwargs={'course_id': course_id, 'student_id': student.id})
-            track.views.server_track(request, "get-student-progress-page", {"student": student, "instructor": request.user, "course": course_id}, page="idashboard")
+            track.views.server_track(request, "get-student-progress-page", {"student": str(student), "instructor": str(request.user), "course": course_id}, page="idashboard")
             msg += "<a href='{0}' target='_blank'> Progress page for username: {1} with email address: {2}</a>.".format(progress_url, student.username, student.email)
 
     #----------------------------------------
@@ -472,7 +472,7 @@ def instructor_dashboard(request, course_id):
             msg += '<font color="green">Added {0} to instructor group = {1}</font>'.format(user, group.name)
             log.debug('staffgrp={0}'.format(group.name))
             user.groups.add(group)
-            track.views.server_track(request, "add-instructor", {"instructor": user}, page="idashboard")
+            track.views.server_track(request, "add-instructor", {"instructor": str(user)}, page="idashboard")
 
     elif action == 'Remove course staff':
         uname = request.POST['staffuser']
@@ -491,7 +491,7 @@ def instructor_dashboard(request, course_id):
             msg += '<font color="green">Removed {0} from instructor group = {1}</font>'.format(user, group.name)
             log.debug('instructorgrp={0}'.format(group.name))
             user.groups.remove(group)
-            track.views.server_track(request, "remove-instructor", {"instructor": user}, page="idashboard")
+            track.views.server_track(request, "remove-instructor", {"instructor": str(user)}, page="idashboard")
 
     #----------------------------------------
     # DataDump
@@ -658,7 +658,7 @@ def instructor_dashboard(request, course_id):
         problem = request.POST['Problem']
         nmsg, plots = psychoanalyze.generate_plots_for_problem(problem)
         msg += nmsg
-        track.views.server_track(request, "psychometrics-histogram-generation", {"problem": problem}, page="idashboard")
+        track.views.server_track(request, "psychometrics-histogram-generation", {"problem": str(problem)}, page="idashboard")
 
     if idash_mode == 'Psychometrics':
         problems = psychoanalyze.problems_with_psychometric_data(course_id)
@@ -911,7 +911,7 @@ def _add_or_remove_user_group(request, username_or_email, group, group_title, ev
         else:
             user.groups.remove(group)
         event = "add" if do_add else "remove"
-        track.views.server_track(request, "add-or-remove-user-group", {"event_name": event_name, "user": user, "event": event}, page="idashboard")
+        track.views.server_track(request, "add-or-remove-user-group", {"event_name": event_name, "user": str(user), "event": event}, page="idashboard")
 
     return msg
 

--- a/lms/djangoapps/instructor/views.py
+++ b/lms/djangoapps/instructor/views.py
@@ -374,7 +374,7 @@ def instructor_dashboard(request, course_id):
         msg += message
         if student is not None:
             progress_url = reverse('student_progress', kwargs={'course_id': course_id, 'student_id': student.id})
-            track.views.server_track(request, "get-student-progress-page", {"student": str(student), "instructor": str(request.user), "course": course_id}, page="idashboard")
+            track.views.server_track(request, "get-student-progress-page", {"student": unicode(student), "instructor": unicode(request.user), "course": course_id}, page="idashboard")
             msg += "<a href='{0}' target='_blank'> Progress page for username: {1} with email address: {2}</a>.".format(progress_url, student.username, student.email)
 
     #----------------------------------------
@@ -472,7 +472,7 @@ def instructor_dashboard(request, course_id):
             msg += '<font color="green">Added {0} to instructor group = {1}</font>'.format(user, group.name)
             log.debug('staffgrp={0}'.format(group.name))
             user.groups.add(group)
-            track.views.server_track(request, "add-instructor", {"instructor": str(user)}, page="idashboard")
+            track.views.server_track(request, "add-instructor", {"instructor": unicode(user)}, page="idashboard")
 
     elif action == 'Remove course staff':
         uname = request.POST['staffuser']
@@ -491,7 +491,7 @@ def instructor_dashboard(request, course_id):
             msg += '<font color="green">Removed {0} from instructor group = {1}</font>'.format(user, group.name)
             log.debug('instructorgrp={0}'.format(group.name))
             user.groups.remove(group)
-            track.views.server_track(request, "remove-instructor", {"instructor": str(user)}, page="idashboard")
+            track.views.server_track(request, "remove-instructor", {"instructor": unicode(user)}, page="idashboard")
 
     #----------------------------------------
     # DataDump
@@ -658,7 +658,7 @@ def instructor_dashboard(request, course_id):
         problem = request.POST['Problem']
         nmsg, plots = psychoanalyze.generate_plots_for_problem(problem)
         msg += nmsg
-        track.views.server_track(request, "psychometrics-histogram-generation", {"problem": str(problem)}, page="idashboard")
+        track.views.server_track(request, "psychometrics-histogram-generation", {"problem": unicode(problem)}, page="idashboard")
 
     if idash_mode == 'Psychometrics':
         problems = psychoanalyze.problems_with_psychometric_data(course_id)
@@ -911,7 +911,7 @@ def _add_or_remove_user_group(request, username_or_email, group, group_title, ev
         else:
             user.groups.remove(group)
         event = "add" if do_add else "remove"
-        track.views.server_track(request, "add-or-remove-user-group", {"event_name": event_name, "user": str(user), "event": event}, page="idashboard")
+        track.views.server_track(request, "add-or-remove-user-group", {"event_name": event_name, "user": unicode(user), "event": event}, page="idashboard")
 
     return msg
 


### PR DESCRIPTION
This PR fixes an error in the instructor dashboard, in which users are getting an exception when adding staff.  The error is caused by `track.views.server_track` trying to log a non JSON-serializable object, eg instance of User.

Error found and logged by Joe Martis.
