### PR TITLE
move setting changes in tests to override_settings

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_request_event.py
+++ b/cms/djangoapps/contentstore/tests/test_request_event.py
@@ -1,4 +1,6 @@
 """Tests for CMS's requests to logs"""
+import mock
+
 from django.test import TestCase
 from django.core.urlresolvers import reverse
 from contentstore.views.requests import event as cms_user_track
@@ -18,9 +20,10 @@ class CMSLogTest(TestCase):
             {"event": "my_event", "event_type": "my_event_type", "page": "my_page"},
             {"event": "{'json': 'object'}", "event_type": unichr(512), "page": "my_page"}
         ]
-        for request_params in requests:
-            response = self.client.post(reverse(cms_user_track), request_params)
-            self.assertEqual(response.status_code, 204)
+        with mock.patch.dict('django.conf.settings.MITX_FEATURES', {'ENABLE_SQL_TRACKING_LOGS': True}):
+            for request_params in requests:
+                response = self.client.post(reverse(cms_user_track), request_params)
+                self.assertEqual(response.status_code, 204)
 
     def test_get_answers_to_log(self):
         """
@@ -31,6 +34,7 @@ class CMSLogTest(TestCase):
             {"event": "my_event", "event_type": "my_event_type", "page": "my_page"},
             {"event": "{'json': 'object'}", "event_type": unichr(512), "page": "my_page"}
         ]
-        for request_params in requests:
-            response = self.client.get(reverse(cms_user_track), request_params)
-            self.assertEqual(response.status_code, 204)
+        with mock.patch.dict('django.conf.settings.MITX_FEATURES', {'ENABLE_SQL_TRACKING_LOGS': True}):
+            for request_params in requests:
+                response = self.client.get(reverse(cms_user_track), request_params)
+                self.assertEqual(response.status_code, 204)

--- a/cms/envs/test.py
+++ b/cms/envs/test.py
@@ -141,8 +141,5 @@ MITX_FEATURES['STUDIO_NPS_SURVEY'] = False
 
 MITX_FEATURES['ENABLE_SERVICE_STATUS'] = True
 
-# Enabling SQL tracking logs for testing on common/djangoapps/track
-MITX_FEATURES['ENABLE_SQL_TRACKING_LOGS'] = True
-
 # This is to disable a test under the common directory that will not pass when run under CMS
 MITX_FEATURES['DISABLE_PASSWORD_RESET_EMAIL_TEST'] = True

--- a/common/djangoapps/track/tests.py
+++ b/common/djangoapps/track/tests.py
@@ -1,4 +1,6 @@
 """Tests for student tracking"""
+import mock
+
 from django.test import TestCase
 from django.core.urlresolvers import reverse, NoReverseMatch
 from track.models import TrackingLog
@@ -20,18 +22,19 @@ class TrackingTest(TestCase):
             {"event": "my_event", "event_type": "my_event_type", "page": "my_page"},
             {"event": "{'json': 'object'}", "event_type": unichr(512), "page": "my_page"}
         ]
-        for request_params in requests:
-            try:  # because /event maps to two different views in lms and cms, we're only going to test lms here
-                response = self.client.post(reverse(user_track), request_params)
-            except NoReverseMatch:
-                raise SkipTest()
-            self.assertEqual(response.status_code, 200)
-            self.assertEqual(response.content, 'success')
-            tracking_logs = TrackingLog.objects.order_by('-dtcreated')
-            log = tracking_logs[0]
-            self.assertEqual(log.event, request_params["event"])
-            self.assertEqual(log.event_type, request_params["event_type"])
-            self.assertEqual(log.page, request_params["page"])
+        with mock.patch.dict('django.conf.settings.MITX_FEATURES', {'ENABLE_SQL_TRACKING_LOGS': True}):
+            for request_params in requests:
+                try:  # because /event maps to two different views in lms and cms, we're only going to test lms here
+                    response = self.client.post(reverse(user_track), request_params)
+                except NoReverseMatch:
+                    raise SkipTest()
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.content, 'success')
+                tracking_logs = TrackingLog.objects.order_by('-dtcreated')
+                log = tracking_logs[0]
+                self.assertEqual(log.event, request_params["event"])
+                self.assertEqual(log.event_type, request_params["event_type"])
+                self.assertEqual(log.page, request_params["page"])
 
     def test_get_answers_to_log(self):
         """
@@ -42,15 +45,16 @@ class TrackingTest(TestCase):
             {"event": "my_event", "event_type": "my_event_type", "page": "my_page"},
             {"event": "{'json': 'object'}", "event_type": unichr(512), "page": "my_page"}
         ]
-        for request_params in requests:
-            try:  # because /event maps to two different views in lms and cms, we're only going to test lms here
-                response = self.client.get(reverse(user_track), request_params)
-            except NoReverseMatch:
-                raise SkipTest()
-            self.assertEqual(response.status_code, 200)
-            self.assertEqual(response.content, 'success')
-            tracking_logs = TrackingLog.objects.order_by('-dtcreated')
-            log = tracking_logs[0]
-            self.assertEqual(log.event, request_params["event"])
-            self.assertEqual(log.event_type, request_params["event_type"])
-            self.assertEqual(log.page, request_params["page"])
+        with mock.patch.dict('django.conf.settings.MITX_FEATURES', {'ENABLE_SQL_TRACKING_LOGS': True}):
+            for request_params in requests:
+                try:  # because /event maps to two different views in lms and cms, we're only going to test lms here
+                    response = self.client.get(reverse(user_track), request_params)
+                except NoReverseMatch:
+                    raise SkipTest()
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.content, 'success')
+                tracking_logs = TrackingLog.objects.order_by('-dtcreated')
+                log = tracking_logs[0]
+                self.assertEqual(log.event, request_params["event"])
+                self.assertEqual(log.event_type, request_params["event_type"])
+                self.assertEqual(log.page, request_params["page"])

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -29,9 +29,6 @@ MITX_FEATURES['ENABLE_SERVICE_STATUS'] = True
 
 MITX_FEATURES['ENABLE_HINTER_INSTRUCTOR_VIEW'] = True
 
-# Enabling SQL tracking logs for testing on common/djangoapps/track
-MITX_FEATURES['ENABLE_SQL_TRACKING_LOGS'] = True
-
 # Need wiki for courseware views to work. TODO (vshnayder): shouldn't need it.
 WIKI_ENABLED = True
 


### PR DESCRIPTION
Addresses an issue (raised by my previous commit: https://github.com/edx/edx-platform/commit/03aee3ed79188863d333cff041639b1ccf105e83) where many RuntimeWarnings were being generated upon trackinglog testing.

@wedaly does this look ok?
@nedbat 
