### PR TITLE
Provide a null log function for OpenID to keep it from spewing during tests

### DIFF
--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -195,3 +195,11 @@ PASSWORD_HASHERS = (
     'django.contrib.auth.hashers.MD5PasswordHasher',
     # 'django.contrib.auth.hashers.CryptPasswordHasher',
 )
+
+################### Make tests quieter
+
+# OpenID spews messages like this to stderr, we don't need to see them:
+#   Generated checkid_setup request to http://testserver/openid/provider/login/ with assocication {HMAC-SHA1}{51d49995}{s/kRmA==}
+
+import openid.oidutil
+openid.oidutil.log = lambda message, level=0: None


### PR DESCRIPTION
Removes the three blot messages from this output:

```
.........----..........................................Generated checkid_setup request to http://testserver/openid/provider/login/ with assocication {HMAC-SHA1}{51db1888}{hGUNRw==}
.Generated checkid_setup request to http://testserver/openid/provider/login/ with assocication {HMAC-SHA1}{51db1888}{7hK/iw==}
.....................
.............................................................................
.............................................................................
.............................................................................
.............................................................................
.......................Generated checkid_setup request to http://testserver/openid/provider/login/ with assocication {HMAC-SHA1}{51db1914}{U3rCMQ==}
..--......
```

Nicer, right, @jzoldak and @cpennington ?
