### PR TITLE
Switch from RVM to rbenv

### DIFF
--- a/scripts/create-dev-env.sh
+++ b/scripts/create-dev-env.sh
@@ -62,7 +62,7 @@ info() {
     cat<<EO
     edX base dir : $BASE
     Python virtualenv dir : $PYTHON_DIR
-    Ruby RVM dir : $RUBY_DIR
+    Ruby rbenv dir : $RUBY_DIR
     Ruby ver : $RUBY_VER
 
 EO
@@ -101,7 +101,7 @@ set_base_default() {  # if PROJECT_HOME not set
 
     # See if remote's url is named edx-platform (this works for forks too, but
     # not if the name was changed).
-    cd "$( dirname "${BASH_SOURCE[0]}" )" 
+    cd "$( dirname "${BASH_SOURCE[0]}" )"
     this_repo=$(basename $(git ls-remote --get-url 2>/dev/null) 2>/dev/null) ||
         echo -n ""
 
@@ -128,7 +128,7 @@ PYTHON_DIR=${WORKON_HOME:-"$HOME/.virtualenvs"}
 
 # RVM defaults its install to ~/.rvm, but use the overridden rvm_path
 # if that's what's preferred.
-RUBY_DIR=${rvm_path:-"$HOME/.rvm"}
+RUBY_DIR=${rbenv_path:-"$HOME/.rbenv"}
 
 LOG="/var/tmp/install-$(date +%Y%m%d-%H%M%S).log"
 
@@ -293,7 +293,7 @@ EO
 esac
 
 
-# Clone MITx repositories
+# Clone edx repositories
 
 clone_repos
 
@@ -309,89 +309,50 @@ fi
 
 # Install system-level dependencies
 
-output "Installing RVM, Ruby, and required gems"
-
-# If we're not installing RVM in the default location, then we'll do some
-# funky stuff to make sure that we load in the RVM stuff properly on login.
-if [ "$HOME/.rvm" != $RUBY_DIR ]; then
-  if ! grep -q "export rvm_path=$RUBY_DIR" ~/.rvmrc; then
-      if [[ -f $HOME/.rvmrc ]]; then
-          output "Copying existing .rvmrc to .rvmrc.bak"
-          cp $HOME/.rvmrc $HOME/.rvmrc.bak
-      fi
-      output "Creating $HOME/.rvmrc so rvm uses $RUBY_DIR"
-      echo "export rvm_path=$RUBY_DIR" > $HOME/.rvmrc
-  fi
+# Find rbenv root (~/.rbenv by default)
+if [ -z "${RBENV_ROOT}" ]; then
+  RBENV_ROOT="${HOME}/.rbenv"
+else
+  RBENV_ROOT="${RBENV_ROOT%/}"
 fi
-
-# rvm has issues in debian family, this is taken from stack overflow
-case `uname -s` in
-    Darwin)
-        curl -sL get.rvm.io | bash -s -- --version 1.15.7
-    ;;
-
-    [Ll]inux)
-        warning "Setting up rvm on linux. This is a known pain point. If the script fails here
-                refer to the following stack overflow question:
-                http://stackoverflow.com/questions/9056008/installed-ruby-1-9-3-with-rvm-but-command-line-doesnt-show-ruby-v/9056395#9056395"
-        sudo apt-get --purge remove ruby-rvm
-        sudo rm -rf /usr/share/ruby-rvm /etc/rvmrc /etc/profile.d/rvm.sh
-        curl -sL https://get.rvm.io | bash -s stable --ruby --autolibs=enable --auto-dotfiles
-    ;;
-esac
-
-
-# Ensure we have RVM available as a shell function so that it can mess
-# with the environment and set everything up properly. The RVM install
-# process adds this line to login scripts, so this shouldn't be necessary
-# for the user to do each time.
-if [[ `type -t rvm` != "function" ]]; then
-  source $RUBY_DIR/scripts/rvm
-fi
-
-# Ruby doesn't like to build with clang, which is the default on OS X, so
-# use gcc instead. This may not work, since if your gcc was installed with
-# XCode 4.2 or greater, you have an LLVM-based gcc, which also doesn't
-# always play nicely with Ruby, though it seems to be better than clang.
-# You may have to install apple-gcc42 using Homebrew if this doesn't work.
-# See `rvm requirements` for more information.
-case `uname -s` in
-    Darwin)
-        export CC=gcc
-        ;;
-esac
-
 # Let the repo override the version of Ruby to install
 if [[ -r $BASE/edx-platform/.ruby-version ]]; then
   RUBY_VER=`cat $BASE/edx-platform/.ruby-version`
 fi
 
-# Current stable version of RVM (1.19.0) requires the following to build Ruby:
-#
-# autoconf automake libtool pkg-config libyaml libxml2 libxslt libksba openssl
-#
-# If we decide to upgrade from the current version (1.15.7), can run
-#
-# LESS="-E" rvm install $RUBY_VER --autolibs=3 --with-readline
-#
-# to have RVM look for a package manager like Homebrew and install any missing
-# libs automatically. RVM's --autolibs flag defaults to 2, which will fail if
-# any required libs are missing.
-LESS="-E" rvm install $RUBY_VER --with-readline
+if [[ ! -d $RBENV_ROOT ]]; then
+    output "Installing rbenv"
+    git clone https://github.com/sstephenson/rbenv.git $RBENV_ROOT
+fi
+if [[ ! -d $RBENV_ROOT/plugins/ruby-build ]]; then
+    output "Installing ruby-build"
+    git clone https://github.com/sstephenson/ruby-build.git $RBENV_ROOT/plugins/ruby-build
+fi
+shelltype=$(basename $SHELL)
+if ! hash rbenv 2>/dev/null; then
+    output "Adding rbenv to \$PATH in ~/.${shelltype}rc"
+    echo "export PATH=\"$RBENV_ROOT/bin:\$PATH\"" >> $HOME/.${shelltype}rc
+    echo 'eval "$(rbenv init -)"' >> $HOME/.${shelltype}rc
+    export PATH="$RBENV_ROOT/bin:$PATH"
+    eval "$(rbenv init -)"
+fi
 
-# Create the "edx" gemset
-rvm use "$RUBY_VER@edx-platform" --create
-rvm rubygems latest
+if [[ ! -d $RBENV_ROOT/versions/$RUBY_VER ]]; then
+    output "Installing Ruby $RUBY_VER"
+    rbenv install $RUBY_VER
+    rbenv global $RUBY_VER
+fi
 
-output "Installing gem bundler"
-gem install bundler
+if ! hash bundle 2>/dev/null; then
+    output "Installing gem bundler"
+    gem install bundler
+fi
+rbenv rehash
 
 output "Installing ruby packages"
 bundle install --gemfile $BASE/edx-platform/Gemfile
 
-
 # Install Python virtualenv
-
 output "Installing python virtualenv"
 
 case `uname -s` in


### PR DESCRIPTION
rbenv is smaller and simpler than RVM. Since we don't particularly care about the extra features of RVM (gemsets, etc) it's better to use the simplest possible solution. This pull request switches the create-dev-env.sh script to using rbenv.
