### PR TITLE
Don't display docstrings when talking about tests, use real test names.

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -82,5 +82,6 @@ django_nose==1.1
 django-jasmine==0.3.2
 django_debug_toolbar
 django-debug-toolbar-mongo
+nose-ignore-docstring
 
 git+https://github.com/mfogel/django-settings-context-processor.git

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,7 @@
 logging-clear-handlers=1
 with-xunit=1
 rednose=1
+with-ignore-docstrings=1
 
 # Uncomment the following line to open pdb when a test fails
 #pdb=1


### PR DESCRIPTION
I think this is better.  @singingwolfboy do you agree?
