### PR TITLE
Fix course url link in enrollment emails.

### DIFF
--- a/lms/djangoapps/instructor/tests/test_enrollment.py
+++ b/lms/djangoapps/instructor/tests/test_enrollment.py
@@ -194,7 +194,7 @@ class TestInstructorEnrollsStudent(ModuleStoreTestCase, LoginEnrollmentTestCase)
         course = self.course
 
         #Create activated, but not enrolled, user
-        UserFactory.create(username="student3_0", email="student3_0@test.com")
+        UserFactory.create(username="student3_0", email="student3_0@test.com", first_name="Jim", last_name="Tester")
 
         url = reverse('instructor_dashboard', kwargs={'course_id': course.id})
         response = self.client.post(url, {'action': 'Enroll multiple students', 'multiple_students': 'student3_0@test.com, student3_1@test.com, student3_2@test.com', 'auto_enroll': 'on', 'email_students': 'on'})
@@ -209,6 +209,10 @@ class TestInstructorEnrollsStudent(ModuleStoreTestCase, LoginEnrollmentTestCase)
         #Check the outbox
         self.assertEqual(len(mail.outbox), 3)
         self.assertEqual(mail.outbox[0].subject, 'You have been enrolled in MITx/999/Robot_Super_Course')
+        self.assertEqual(mail.outbox[0].body, "Dear Jim Tester\n\nYou have been enrolled in MITx/999/Robot_Super_Course at edx.org by a member of the course staff. " +
+                                              "The course should now appear on your edx.org dashboard.\n\n" +
+                                              "To start accessing course materials, please visit https://edx.org/courses/MITx/999/Robot_Super_Course\n\n" +
+                                              "----\nThis email was automatically sent from edx.org to Jim Tester")
 
         self.assertEqual(mail.outbox[1].subject, 'You have been invited to register for MITx/999/Robot_Super_Course')
         self.assertEqual(mail.outbox[1].body, "Dear student,\n\nYou have been invited to join MITx/999/Robot_Super_Course at edx.org by a member of the course staff.\n\n" +

--- a/lms/djangoapps/instructor/views.py
+++ b/lms/djangoapps/instructor/views.py
@@ -1091,7 +1091,7 @@ def _do_enroll_students(course, course_id, students, overload=False, auto_enroll
              'registration_url': registration_url,
              'course_id': course_id,
              'auto_enroll': auto_enroll,
-             'course_url': registration_url + '/courses/' + course_id,
+             'course_url': 'https://' + settings.SITE_NAME + '/courses/' + course_id,
              }
 
     for student in new_students:

--- a/lms/djangoapps/instructor/views.py
+++ b/lms/djangoapps/instructor/views.py
@@ -346,10 +346,10 @@ def instructor_dashboard(request, course_id):
                     # save
                     student_module.state = json.dumps(problem_state)
                     student_module.save()
-                    event = {"old_attempts": old_number_of_attempts, 
-                             "student": student, 
-                             "problem": student_module.module_state_key, 
-                             "instructor": request.user, 
+                    event = {"old_attempts": old_number_of_attempts,
+                             "student": student,
+                             "problem": student_module.module_state_key,
+                             "instructor": request.user,
                              "course": course_id}
                     track.views.server_track(request, "reset-student-attempts", event, page="idashboard")
                     msg += "<font color='green'>Module state successfully reset!</font>"
@@ -1234,7 +1234,7 @@ def send_mail_to_student(student, param_dict):
     """
     Construct the email using templates and then send it.
     `student` is the student's email address (a `str`),
-    
+
     `param_dict` is a `dict` with keys [
     `site_name`: name given to edX instance (a `str`)
     `registration_url`: url for registration (a `str`)


### PR DESCRIPTION
Course link within the enrollment emails was being constructed incorrectly.
