### PR TITLE
Fix/cdodge/update localdev setting for unsafe courses

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -368,3 +368,5 @@ MKTG_URL_LINK_MAP = {
     'HONOR': 'honor',
     'PRIVACY': 'privacy_edx',
 }
+
+COURSES_WITH_UNSAFE_CODE = []

--- a/common/djangoapps/util/sandboxing.py
+++ b/common/djangoapps/util/sandboxing.py
@@ -14,7 +14,9 @@ def can_execute_unsafe_code(course_id):
     """
     # To decide if we can run unsafe code, we check the course id against
     # a list of regexes configured on the server.
-    for regex in settings.COURSES_WITH_UNSAFE_CODE:
+    # If this is not defined in the environment variables then default to the most restrictive, which
+    # is 'no unsafe courses'
+    for regex in getattr(settings, 'COURSES_WITH_UNSAFE_CODE', []):
         if re.match(regex, course_id):
             return True
     return False

--- a/common/djangoapps/util/tests/test_sandboxing.py
+++ b/common/djangoapps/util/tests/test_sandboxing.py
@@ -25,3 +25,10 @@ class SandboxingTest(TestCase):
         """
         self.assertTrue(can_execute_unsafe_code('edX/full/2012_Fall'))
         self.assertTrue(can_execute_unsafe_code('edX/full/2013_Spring'))
+
+    def test_courses_with_unsafe_code_default(self):
+        """
+        Test that the default setting for COURSES_WITH_UNSAFE_CODE is an empty setting, e.g. we don't use @override_settings in these tests
+        """
+        self.assertFalse(can_execute_unsafe_code('edX/full/2012_Fall'))
+        self.assertFalse(can_execute_unsafe_code('edX/full/2013_Spring'))


### PR DESCRIPTION
Not sure I know why - maybe @cpennington or @ormsbee might have an idea - but the "COURSES_WITH_UNSAFE_CODE" was not getting into the localdev CMS settings (dev.py), even though cms.envs.common.py imports lms.envs.common.py.

So added an explicit setting in cms.common.py as well as adding a highly restrictive default value.

@nedbat @cahrens can you review?
