### PR TITLE
Rename CMS.Views.Notification.Saving to Mini.

### DIFF
--- a/cms/static/coffee/spec/views/feedback_spec.coffee
+++ b/cms/static/coffee/spec/views/feedback_spec.coffee
@@ -98,9 +98,9 @@ describe "CMS.Views.Prompt", ->
         view.hide()
         # expect($("body")).not.toHaveClass("prompt-is-shown")
 
-describe "CMS.Views.Notification.Saving", ->
+describe "CMS.Views.Notification.Mini", ->
     beforeEach ->
-        @view = new CMS.Views.Notification.Saving()
+        @view = new CMS.Views.Notification.Mini()
 
     it "should have minShown set to 1250 by default", ->
         expect(@view.options.minShown).toEqual(1250)

--- a/cms/static/coffee/spec/views/overview_spec.coffee
+++ b/cms/static/coffee/spec/views/overview_spec.coffee
@@ -43,7 +43,7 @@ describe "Course Overview", ->
         spyOn(window, 'saveSetSectionScheduleDate').andCallThrough()
         # Have to do this here, as it normally gets bound in document.ready()
         $('a.save-button').click(saveSetSectionScheduleDate)
-        @notificationSpy = spyOn(CMS.Views.Notification.Saving.prototype, 'show').andCallThrough()
+        @notificationSpy = spyOn(CMS.Views.Notification.Mini.prototype, 'show').andCallThrough()
         window.analytics = jasmine.createSpyObj('analytics', ['track'])
         window.course_location_analytics = jasmine.createSpy()
         sinon.useFakeXMLHttpRequest()

--- a/cms/static/coffee/spec/views/textbook_spec.coffee
+++ b/cms/static/coffee/spec/views/textbook_spec.coffee
@@ -73,7 +73,7 @@ describe "CMS.Views.ShowTextbook", ->
             @xhr = sinon.useFakeXMLHttpRequest()
             @xhr.onCreate = (xhr) -> requests.push(xhr)
 
-            @savingSpies = spyOnConstructor(CMS.Views.Notification, "Saving",
+            @savingSpies = spyOnConstructor(CMS.Views.Notification, "Mini",
                 ["show", "hide"])
             @savingSpies.show.andReturn(@savingSpies)
 

--- a/cms/static/js/base.js
+++ b/cms/static/js/base.js
@@ -712,7 +712,7 @@ function saveSetSectionScheduleDate(e) {
         'start': start
     });
 
-    var saving = new CMS.Views.Notification.Saving({
+    var saving = new CMS.Views.Notification.Mini({
         title: gettext("Saving") + "&hellip;",
         maxShown: 1250
     });

--- a/cms/static/js/models/section.js
+++ b/cms/static/js/models/section.js
@@ -22,7 +22,7 @@ CMS.Models.Section = Backbone.Model.extend({
     },
     showNotification: function() {
         if(!this.msg) {
-            this.msg = new CMS.Views.Notification.Saving({
+            this.msg = new CMS.Views.Notification.Mini({
                 title: gettext("Saving") + "&hellip;"
             });
         }

--- a/cms/static/js/views/feedback.js
+++ b/cms/static/js/views/feedback.js
@@ -171,7 +171,7 @@ CMS.Views.Prompt = CMS.Views.SystemFeedback.extend({
 var capitalCamel, types, intents;
 capitalCamel = _.compose(_.str.capitalize, _.str.camelize);
 types = ["alert", "notification", "prompt"];
-intents = ["warning", "error", "confirmation", "announcement", "step-required", "help", "saving"];
+intents = ["warning", "error", "confirmation", "announcement", "step-required", "help", "mini"];
 _.each(types, function(type) {
     _.each(intents, function(intent) {
         // "class" is a reserved word in Javascript, so use "klass" instead
@@ -187,8 +187,7 @@ _.each(types, function(type) {
     });
 });
 
-// set more sensible defaults for Notification-Saving views
-var savingOptions = CMS.Views.Notification.Saving.prototype.options;
-savingOptions.minShown = 1250;
-savingOptions.closeIcon = false;
-
+// set more sensible defaults for Notification-Mini views
+var miniOptions = CMS.Views.Notification.Mini.prototype.options;
+miniOptions.minShown = 1250;
+miniOptions.closeIcon = false;

--- a/cms/static/js/views/textbook.js
+++ b/cms/static/js/views/textbook.js
@@ -34,7 +34,7 @@ CMS.Views.ShowTextbook = Backbone.View.extend({
                     text: gettext("Delete"),
                     click: function(view) {
                         view.hide();
-                        var delmsg = new CMS.Views.Notification.Saving({
+                        var delmsg = new CMS.Views.Notification.Mini({
                             title: gettext("Deleting") + "&hellip;"
                         }).show();
                         textbook.destroy({
@@ -121,7 +121,7 @@ CMS.Views.EditTextbook = Backbone.View.extend({
         if(e && e.preventDefault) { e.preventDefault(); }
         this.setValues();
         if(!this.model.isValid()) { return; }
-        var saving = new CMS.Views.Notification.Saving({
+        var saving = new CMS.Views.Notification.Mini({
             title: gettext("Saving") + "&hellip;"
         }).show();
         var that = this;


### PR DESCRIPTION
Since the Saving notification is being used for more things (which, notably, are not all saving), rename it to more accurately reflect its usage.
