### PR TITLE
Yarko/vagrant upfix

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -80,3 +80,5 @@ Renzo Lucioni <renzolucioni@gmail.com>
 Felix Sun <felixsun@mit.edu>
 Adam Palay <adam@edx.org>
 Ian Hoover <ihoover@edx.org>
+Yarko Tymciurak <yarkot1@gmail.com>
+

--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ installation process.
 
 The initial `vagrant up` will download a Linux image, then boot and ask for your
 administrator password to setup NFS.
-Once NFS is up, edx-platform/scripts/create-dev-env.sh will
+Once NFS is up, `edx-platform/scripts/create-dev-env.sh` will
 run, and install all system dependencies and configure the VM.
 This will take a while.  Once this starts, go grab a coffee.
 
-When complete, you should see a **"Success!"** message.
+When complete, you should see a _"Success!"_ message.
 If not, refer to the 
 [troubleshooting section](https://github.com/edx/edx-platform/wiki/Simplified-install-with-vagrant#troubleshooting).
 
@@ -67,8 +67,8 @@ You can develop by editing from your host computer, in the `edx-platform/` direc
 which you cloned from github.
 
 After logging into your VM with `vagrant ssh`,
-you can start the **Studio** and
-**Learning management system (LMS)**
+you can start the _Studio_ and
+_Learning management system (LMS)_
 servers as follows
 (run these from the `/opt/edx/edx-platform` folder):
 
@@ -86,8 +86,8 @@ $ rake cms[dev,0.0.0.0:8001]
 
 Once started, open the following URLs in your browser:
 
-* LMS: http://192.168.20.40:8000/
-* CMS: http://192.168.20.40:8001/
+- LMS: http://192.168.20.40:8000/
+- CMS: http://192.168.20.40:8001/
 
 Your VM's port 8000 is forwarded to host port 9000
 so you can also access the LMS with [http://localhost:9000/]().
@@ -118,6 +118,7 @@ your edx-platfrom/lms/envs/common.py instance:
    - ```
      'ENABLE_DJANGO_ADMIN_SITE': True
 ```
+
  - enable debug toolbar by uncommenting:
    - ```
     # 'debug_toolbar.middleware.DebugToolbarMiddleware',

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Once NFS is up, edx-platform/scripts/create-dev-env.sh will
 run, and install all system dependencies and configure the VM.
 This will take a while.  Once this starts, go grab a coffee.
 
-When complete, you should see a **"Success!"** message.
+When complete, you should see a _"Success!"_ message.
 If not, refer to the 
 [troubleshooting section](https://github.com/edx/edx-platform/wiki/Simplified-install-with-vagrant#troubleshooting).
 
@@ -67,8 +67,8 @@ You can develop by editing from your host computer, in the `edx-platform/` direc
 which you cloned from github.
 
 After logging into your VM with `vagrant ssh`,
-you can start the **Studio** and
-**Learning management system (LMS)**
+you can start the _Studio_ and
+_Learning management system (LMS)_
 servers as follows
 (run these from the `/opt/edx/edx-platform` folder):
 
@@ -86,8 +86,8 @@ $ rake cms[dev,0.0.0.0:8001]
 
 Once started, open the following URLs in your browser:
 
-* LMS: http://192.168.20.40:8000/
-* CMS: http://192.168.20.40:8001/
+- LMS: http://192.168.20.40:8000/
+- CMS: http://192.168.20.40:8001/
 
 Your VM's port 8000 is forwarded to host port 9000
 so you can also access the LMS with [http://localhost:9000/]().
@@ -118,6 +118,7 @@ your edx-platfrom/lms/envs/common.py instance:
    - ```
      'ENABLE_DJANGO_ADMIN_SITE': True
 ```
+
  - enable debug toolbar by uncommenting:
    - ```
     # 'debug_toolbar.middleware.DebugToolbarMiddleware',

--- a/README.md
+++ b/README.md
@@ -28,18 +28,18 @@ installation process.
 
 The last step might require your host machine's administrator password to setup NFS.
 
-Afterwards, it will download an image, install all the dependencies and configure
-the VM. It will take a while, go grab a coffee.
+The initial `vagrant up` will download a Linux image, install all dependencies and configure
+the VM. This will take a while - go grab a coffee.
 
-Once completed, you should see a "Success!" message.
+Once completed, you should see a *"Success!"* message.
 If not, refer to the 
 [troubleshooting section](https://github.com/edx/edx-platform/wiki/Simplified-install-with-vagrant#troubleshooting).
 
 Your development environment is initialized only on the first bring-up.
-Subsequently, you can boot your virtual machine normally using `vagrant up`.
+Subsequently `vagrant up` commands will boot your virtual machine normally.
 
 Note: by default, the VM will get the IP `192.168.20.40`.
-You can change this in your `Vagrantfile` (the startup message will reflect your VMs actual IP).
+You can change this in your `Vagrantfile` (the startup message will reflect your VM's actual IP).
 
 Accessing the VM
 ----------------
@@ -66,11 +66,10 @@ You can develop by editing from your host computer, in the `edx-platform/` direc
 which you cloned from github.
 
 After logging into your VM with `vagrant ssh`,
-you can start Studio and the
-Learning management system (LMS)
-with the commands such as the following
-
-(you need to be in the `/opt/edx/edx-platform` folder on the client VM):
+you can start the **Studio** and
+**Learning management system (LMS)**
+servers as follows
+(run these from the `/opt/edx/edx-platform` folder):
 
 Learning management system (LMS):
 
@@ -89,9 +88,9 @@ Once started, open the following URLs in your browser:
 * LMS: http://192.168.20.40:8000/
 * CMS: http://192.168.20.40:8001/
 
-Your client VM's port 8000 is forwarded to host port 9000
-so you can also access the LMS with http://localhost:9000/.
-Similarly, client port 8001 is forwarded to host port 9001.
+Your VM's port 8000 is forwarded to host port 9000
+so you can also access the LMS with [http://localhost:9000/]().
+Similarly, development VM port 8001 is forwarded to host port 9001.
 These are set in your `Vagrantfile`.
 
 Note that when you register a new user through the web interface,
@@ -119,9 +118,8 @@ $ rake django-admin["createsuperuser"]
 
 Normally the django admin interface and the site's debug toolbar
 are only active during local operation.
-To use these, specifically forward one of client VM's localhost ports to your host.
-You cannot do this with `vagrant ssh`.
-Instead, login from a host terminal like this:
+To use these, specifically forward one of VM's localhost ports to your computer.
+To do this, login to the VM like this:
 
 ```
 $ ssh -L 8080:127.0.0.1:8080 vagrant@192.168.20.40
@@ -131,14 +129,15 @@ with a password of `vagrant`.
 The specific host and client ports can be whatever you want,
 so long as they don't conflict with any ports in use.
 
-Now, start your LMS as a localhost instance:
+From your VM, start the LMS as a localhost instance:
 
 ```
 $ rake lms[cms.dev,127.0.0.1:8080]
 ```
 
-You should see the debug toolbar when you navigate to http:/localhost:8080.
-You should now also see a login if you navigate to http://localhost:8080/admin/.
+You should see the debug toolbar when you navigate to [http:/localhost:8080/]().
+You should now also see a login when you navigate to [http://localhost:8080/admin/]()
+(you can use the django super-user account for this).
 
 
 Stopping & starting

--- a/README.md
+++ b/README.md
@@ -107,12 +107,23 @@ and find the activation URL.
 See the [Frequently Asked Questions](https://github.com/edx/edx-platform/wiki/Frequently-Asked-Questions)
 for more usage tips.
 
-Django admin & debugging toolbar
+Django admin & debug toolbar
 -----------------------------------
 
-Normally the django admin interface and the site's debug toolbar
-are only active during local operation.
-To use these, explicitly forward one of VM's localhost ports to your computer.
+You can enable admin logins and the debug_toolbar by editing
+your edx-platfrom/lms/envs/common.py instance:
+
+ - enable ADMIN login page by setting: ```
+     'ENABLE_DJANGO_ADMIN_SITE': True
+```
+ - enable debug toolbar by uncommenting: ```
+    # 'debug_toolbar.middleware.DebugToolbarMiddleware',
+```
+
+Alternatively, these are defined in edx-platform/lms/envs/dev.py,
+and as such only active for local servers.
+
+To use the dev settings, explicitly forward one of VM's localhost ports to your computer.
 To do this, login to the VM like this:
 
 ```

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ $ rake django-admin["createsuperuser"]
 
 Normally the django admin interface and the site's debug toolbar
 are only active during local operation.
-To use these, specifically forward one of VM's localhost ports to your computer.
+To use these, explicitly forward one of VM's localhost ports to your computer.
 To do this, login to the VM like this:
 
 ```

--- a/README.md
+++ b/README.md
@@ -114,10 +114,12 @@ Django admin & debug toolbar
 You can enable admin logins and the debug_toolbar by editing
 your edx-platfrom/lms/envs/common.py instance:
 
- - enable ADMIN login page by setting: ```
+ - enable ADMIN login page by setting:
+   - ```
      'ENABLE_DJANGO_ADMIN_SITE': True
 ```
- - enable debug toolbar by uncommenting: ```
+ - enable debug toolbar by uncommenting:
+   - ```
     # 'debug_toolbar.middleware.DebugToolbarMiddleware',
 ```
 
@@ -168,7 +170,7 @@ $ vagrant up
 To suspend and resume tasks in progress on your VM (such as tests):
 ```
 $ vagrant suspend
-# and later...
+$ # and later...
 $ vagrant resume
 ```
 

--- a/README.md
+++ b/README.md
@@ -110,12 +110,6 @@ for more usage tips.
 Django admin & debugging toolbar
 -----------------------------------
 
-You may create a CMS/LMS super-user with:
-
-```
-$ rake django-admin["createsuperuser"]
-```
-
 Normally the django admin interface and the site's debug toolbar
 are only active during local operation.
 To use these, explicitly forward one of VM's localhost ports to your computer.
@@ -137,7 +131,11 @@ $ rake lms[cms.dev,127.0.0.1:8080]
 
 You should see the debug toolbar when you navigate to [http:/localhost:8080/]().
 You should now also see a login when you navigate to [http://localhost:8080/admin/]()
-(you can use the django super-user account you created).
+You will need a privileged user for the admin login.
+You can create a CMS/LMS super-user with:
+```
+$ rake django-admin["createsuperuser"]
+```
 
 
 Stopping & starting

--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ installation process.
 9. Create the development environment and start it: `vagrant up`
 
 The initial `vagrant up` will download a Linux image, then boot and ask for your
-host machine's administrator password to setup NFS.
-Once NFS is up, edx-platform/scripts/create-dev-env.sh will
-run, and install all system dependencies and configure the VM.
-This will take a while.  Once this starts, go grab a coffee.
+host machine's administrator password to setup file sharing between your computer and the VM.
+Once file sharing is established, `edx-platform/scripts/create-dev-env.sh` will
+install dependencies and configure the VM.
+This will take a while; go grab a coffee.
 
 When complete, you should see a _"Success!"_ message.
 If not, refer to the 
@@ -60,17 +60,16 @@ Using edX
 ---------
 
 When you login to your VM, you are in
-the `/opt/edx/edx-platform` folder by default, which is NFS mounted from you host workspace.
+the `/opt/edx/edx-platform` by default, which is shared from your host workspace.
 Your host computer contains the edx-project development code and repository.
-Your VM contains system dependencies, and runs development code mounted from your host.
-You can develop by editing from your host computer, in the `edx-platform/` directory
-which you cloned from github.
+Your VM runs edx-platform code mounted from your host.
+You can develop by editing on your host computer, in the directory
+you cloned from github.
 
 After logging into your VM with `vagrant ssh`,
-you can start the _Studio_ and
+start the _Studio_ and
 _Learning management system (LMS)_
-servers as follows
-(run these from the `/opt/edx/edx-platform` folder):
+servers (run these from the `/opt/edx/edx-platform`):
 
 Learning management system (LMS):
 
@@ -84,7 +83,7 @@ Studio (CMS):
 $ rake cms[dev,0.0.0.0:8001]
 ```
 
-Once started, open the following URLs in your browser:
+When the servers have come up, open their URLs:
 
 - LMS: http://192.168.20.40:8000/
 - CMS: http://192.168.20.40:8001/
@@ -112,7 +111,7 @@ Django admin & debug toolbar
 -----------------------------------
 
 You can enable admin logins and the debug_toolbar by editing
-your edx-platfrom/lms/envs/common.py instance:
+`lms/envs/common.py`:
 
 - enable ADMIN login page by setting:
   - ```
@@ -125,19 +124,19 @@ your edx-platfrom/lms/envs/common.py instance:
     # 'debug_toolbar.middleware.DebugToolbarMiddleware',
 ```
 
-Alternatively, these are defined in edx-platform/lms/envs/dev.py,
-and as such only active for local servers.
+These are also defined in `lms/envs/dev.py`,
+and usually active on local servers.
 
-To use the dev settings, explicitly forward one of VM's localhost ports to your computer.
-To do this, login to the VM like this:
+To use the `dev.py` settings, explicitly forward one of VM's localhost ports to your computer.
+Instead of `vagrant ssh`, login with:
 
 ```
 $ ssh -L 8080:127.0.0.1:8080 vagrant@192.168.20.40
 ```
 
-with a password of `vagrant`.
-The specific host and client ports can be whatever you want,
-so long as they don't conflict with any ports in use.
+The password is _vagrant_.
+Chose host and client ports which
+don't conflict with any currently in use.
 
 From your VM, start the LMS as a localhost instance:
 
@@ -145,8 +144,8 @@ From your VM, start the LMS as a localhost instance:
 $ rake lms[cms.dev,127.0.0.1:8080]
 ```
 
-You should see the debug toolbar when you navigate to [http:/localhost:8080/]().
-You should now also see a login when you navigate to [http://localhost:8080/admin/]()
+You should see the debug toolbar now on [http:/localhost:8080/]().
+You should now also see a login on [http://localhost:8080/admin/]()
 You will need a privileged user for the admin login.
 You can create a CMS/LMS super-user with:
 ```
@@ -169,7 +168,7 @@ To restart:
 $ vagrant up
 ```
 
-To suspend and resume tasks in progress on your VM (such as tests):
+To suspend and resume tasks in progress on your VM:
 ```
 $ vagrant suspend
 $ # and later...
@@ -177,9 +176,9 @@ $ vagrant resume
 ```
 
 Your development environment is normally created once, on first `vagrant up`.
-The usual development process from there would be to `git pull` any changes in edx-platform,
-and continue working with your configured box (VM).
-If you want to create a fresh development environment, you can:
+You can continue to fetch changes in edx-platform
+as you work with your VM.
+To re-initialize your VM and create a fresh development environment:
 ```
 $ vagrant destroy
 $ vagrant up

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ installation process.
 9. Create the development environment and start it: `vagrant up`
 
 The initial `vagrant up` will download a Linux image, then boot and ask for your
-administrator password to setup NFS.
+host machine's administrator password to setup NFS.
 Once NFS is up, edx-platform/scripts/create-dev-env.sh will
 run, and install all system dependencies and configure the VM.
 This will take a while.  Once this starts, go grab a coffee.
@@ -114,13 +114,14 @@ Django admin & debug toolbar
 You can enable admin logins and the debug_toolbar by editing
 your edx-platfrom/lms/envs/common.py instance:
 
- - enable ADMIN login page by setting:
-   - ```
+- enable ADMIN login page by setting:
+  - ```
      'ENABLE_DJANGO_ADMIN_SITE': True
 ```
 
- - enable debug toolbar by uncommenting:
-   - ```
+
+- enable debug toolbar by uncommenting:
+  - ```
     # 'debug_toolbar.middleware.DebugToolbarMiddleware',
 ```
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Using edX
 ---------
 
 When you login to your VM, you are in
-the `/opt/edx/edx-platform` by default, which is shared from your host workspace.
+`/opt/edx/edx-platform` by default, which is shared from your host workspace.
 Your host computer contains the edx-project development code and repository.
 Your VM runs edx-platform code mounted from your host.
 You can develop by editing on your host computer, in the directory
@@ -69,7 +69,7 @@ you cloned from github.
 After logging into your VM with `vagrant ssh`,
 start the _Studio_ and
 _Learning management system (LMS)_
-servers (run these from the `/opt/edx/edx-platform`):
+servers (run these from `/opt/edx/edx-platform`):
 
 Learning management system (LMS):
 
@@ -83,14 +83,14 @@ Studio (CMS):
 $ rake cms[dev,0.0.0.0:8001]
 ```
 
-When the servers have come up, open their URLs:
+The servers will come up to these URLs:
 
 - LMS: http://192.168.20.40:8000/
 - CMS: http://192.168.20.40:8001/
 
 Your VM's port 8000 is forwarded to host port 9000
 so you can also access the LMS with [http://localhost:9000/]().
-Similarly, development VM port 8001 is forwarded to host port 9001.
+Similarly, VM port 8001 is forwarded to host port 9001.
 These are set in your `Vagrantfile`.
 
 Note that when you register a new user through the web interface,
@@ -108,7 +108,7 @@ See the [Frequently Asked Questions](https://github.com/edx/edx-platform/wiki/Fr
 for more usage tips.
 
 Django admin & debug toolbar
------------------------------------
+-----------------------------
 
 You can enable admin logins and the debug_toolbar by editing
 `lms/envs/common.py`:
@@ -125,18 +125,16 @@ You can enable admin logins and the debug_toolbar by editing
 ```
 
 These are also defined in `lms/envs/dev.py`,
-and usually active on local servers.
+and usually active on localhost.
 
-To use the `dev.py` settings, explicitly forward one of VM's localhost ports to your computer.
+To get at your VM's 127.0.0.1, explicitly forward one of VM's available localhost ports to your computer.
 Instead of `vagrant ssh`, login with:
 
 ```
-$ ssh -L 8080:127.0.0.1:8080 vagrant@192.168.20.40
+$ ssh -L 6080:127.0.0.1:8080 vagrant@192.168.20.40
 ```
 
 The password is _vagrant_.
-Chose host and client ports which
-don't conflict with any currently in use.
 
 From your VM, start the LMS as a localhost instance:
 
@@ -144,8 +142,8 @@ From your VM, start the LMS as a localhost instance:
 $ rake lms[cms.dev,127.0.0.1:8080]
 ```
 
-You should see the debug toolbar now on [http:/localhost:8080/]().
-You should now also see a login on [http://localhost:8080/admin/]()
+You should see the debug toolbar now on [http:/localhost:6080/]().
+You should now also see a login on [http://localhost:6080/admin/]()
 You will need a privileged user for the admin login.
 You can create a CMS/LMS super-user with:
 ```
@@ -178,10 +176,10 @@ $ vagrant resume
 Your development environment is normally created once, on first `vagrant up`.
 You can continue to fetch changes in edx-platform
 as you work with your VM.
-To re-initialize your VM and create a fresh development environment:
+To re-create your VM and create a fresh development environment:
 ```
 $ vagrant destroy
-$ vagrant up
+$ vagrant up  # will make a new VM
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -62,9 +62,8 @@ Using edX
 When you login to your VM, you are in
 `/opt/edx/edx-platform` by default, which is shared from your host workspace.
 Your host computer contains the edx-project development code and repository.
-Your VM runs edx-platform code mounted from your host.
-You can develop by editing on your host computer, in the directory
-you cloned from github.
+Your VM runs edx-platform code mounted from your host, so 
+you can develop by editing on your host.
 
 After logging into your VM with `vagrant ssh`,
 start the _Studio_ and

--- a/README.md
+++ b/README.md
@@ -107,10 +107,10 @@ and find the activation URL.
 See the [Frequently Asked Questions](https://github.com/edx/edx-platform/wiki/Frequently-Asked-Questions)
 for more usage tips.
 
-Access to django debugging & admin
+Django admin & debugging toolbar
 -----------------------------------
 
-You may create a CMS super-user with:
+You may create a CMS/LMS super-user with:
 
 ```
 $ rake django-admin["createsuperuser"]
@@ -137,7 +137,7 @@ $ rake lms[cms.dev,127.0.0.1:8080]
 
 You should see the debug toolbar when you navigate to [http:/localhost:8080/]().
 You should now also see a login when you navigate to [http://localhost:8080/admin/]()
-(you can use the django super-user account for this).
+(you can use the django super-user account you created).
 
 
 Stopping & starting

--- a/README.md
+++ b/README.md
@@ -26,12 +26,13 @@ installation process.
    [deal with line endings and symlinks under Windows](https://github.com/edx/edx-platform/wiki/Simplified-install-with-vagrant#dealing-with-line-endings-and-symlinks-under-windows)
 9. Create the development environment and start it: `vagrant up`
 
-The last step might require your host machine's administrator password to setup NFS.
+The initial `vagrant up` will download a Linux image, then boot and ask for your
+administrator password to setup NFS.
+Once NFS is up, edx-platform/scripts/create-dev-env.sh will
+run, and install all system dependencies and configure the VM.
+This will take a while.  Once this starts, go grab a coffee.
 
-The initial `vagrant up` will download a Linux image, install all dependencies and configure
-the VM. This will take a while - go grab a coffee.
-
-Once completed, you should see a *"Success!"* message.
+When complete, you should see a **"Success!"** message.
 If not, refer to the 
 [troubleshooting section](https://github.com/edx/edx-platform/wiki/Simplified-install-with-vagrant#troubleshooting).
 

--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ installation process.
 
 The initial `vagrant up` will download a Linux image, then boot and ask for your
 administrator password to setup NFS.
-Once NFS is up, `edx-platform/scripts/create-dev-env.sh` will
+Once NFS is up, edx-platform/scripts/create-dev-env.sh will
 run, and install all system dependencies and configure the VM.
 This will take a while.  Once this starts, go grab a coffee.
 
-When complete, you should see a _"Success!"_ message.
+When complete, you should see a **"Success!"** message.
 If not, refer to the 
 [troubleshooting section](https://github.com/edx/edx-platform/wiki/Simplified-install-with-vagrant#troubleshooting).
 
@@ -67,8 +67,8 @@ You can develop by editing from your host computer, in the `edx-platform/` direc
 which you cloned from github.
 
 After logging into your VM with `vagrant ssh`,
-you can start the _Studio_ and
-_Learning management system (LMS)_
+you can start the **Studio** and
+**Learning management system (LMS)**
 servers as follows
 (run these from the `/opt/edx/edx-platform` folder):
 
@@ -86,8 +86,8 @@ $ rake cms[dev,0.0.0.0:8001]
 
 Once started, open the following URLs in your browser:
 
-- LMS: http://192.168.20.40:8000/
-- CMS: http://192.168.20.40:8001/
+* LMS: http://192.168.20.40:8000/
+* CMS: http://192.168.20.40:8001/
 
 Your VM's port 8000 is forwarded to host port 9000
 so you can also access the LMS with [http://localhost:9000/]().
@@ -118,7 +118,6 @@ your edx-platfrom/lms/envs/common.py instance:
    - ```
      'ENABLE_DJANGO_ADMIN_SITE': True
 ```
-
  - enable debug toolbar by uncommenting:
    - ```
     # 'debug_toolbar.middleware.DebugToolbarMiddleware',

--- a/scripts/vagrant-provisioning.sh
+++ b/scripts/vagrant-provisioning.sh
@@ -107,6 +107,7 @@ EOF
 ## only initialize / setup the development environment once:
 #   we create node_modules, so that's a good test:
 [[ -d /opt/edx/node_modules ]] || on_create
+# on_create
 
 # grab what the Vagrantfile spec'd our IP to be:
 #  expecting:

--- a/scripts/vagrant-provisioning.sh
+++ b/scripts/vagrant-provisioning.sh
@@ -4,6 +4,7 @@
 #
 # Authors: Xavier Antoviaque <xavier@antoviaque.org>
 #          David Baumgold <david@davidbaumgold.com>
+#          Yarko Tymciurak <yarkot1@gmail.com>
 #
 # This software's license gives you freedom; you can copy, convey,
 # propagate, redistribute and/or modify this program under the terms of
@@ -30,95 +31,102 @@
 #
 # This script is ran by `$ vagrant up`, see the README for more explanations
 
+on_create()
+{
+    # APT - Packages ##############################################################
 
-# APT - Packages ##############################################################
-
-apt-get update
-apt-get install -y python-software-properties vim
-
-
-# Curl - No progress bar ######################################################
-
-[[ -f ~vagrant/.curlrc ]] || echo "silent show-error" > ~vagrant/.curlrc
-chown vagrant.vagrant ~vagrant/.curlrc
+    apt-get update
+    apt-get install -y python-software-properties vim
 
 
-# SSH - Known hosts ###########################################################
+    # Curl - No progress bar ######################################################
 
-# Github
-([[ -f ~vagrant/.ssh/known_hosts ]] && grep "zBX7bKA= ssh" ~vagrant/.ssh/known_hosts) || {
-    echo "|1|4DtBcMsTM4zgl/jTS7h3ZkmS/Vc=|XkRnn2xEhr8ixOxeskJAzBX7bKA= ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==" >> ~vagrant/.ssh/known_hosts
-}
-([[ -f ~vagrant/.ssh/known_hosts ]] && grep "jO3J5bvw= ssh" ~vagrant/.ssh/known_hosts) || {
-    echo "|1|9rANf/qOAPgKH/TXpGuZCAgGxMs=|x9VYWEDI8kiotbhhNXqjO3J5bvw= ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==" >> ~vagrant/.ssh/known_hosts
-}
-chown vagrant.vagrant ~vagrant/.ssh/known_hosts
+    [[ -f ~vagrant/.curlrc ]] || echo "silent show-error" > ~vagrant/.curlrc
+    chown vagrant.vagrant ~vagrant/.curlrc
 
 
-# edX - Development environment ###############################################
+    # SSH - Known hosts ###########################################################
 
-# Node modules require a filesystem with symlinks (Windows support)
-mkdir -p /opt/edx/node_modules /opt/edx/edx-platform/node_modules
-mount -o bind /opt/edx/node_modules /opt/edx/edx-platform/node_modules
-
-# Force rechecking all prerequisites (could have been fetched outside of the VM)
-rm -rf /opt/edx/edx-platform/.prereqs_cache
-
-# Permissions
-chown vagrant.vagrant /opt/edx /opt/edx/node_modules /opt/edx/edx-platform/node_modules
-
-# For convenience with `vagrant ssh`, the `edx-platform` virtualenv is always
-# loaded after the first run, so we need to deactivate that behavior to run
-# `create-dev-env.sh`.
-[[ -f ~vagrant/.bash_profile ]] && {
-    mv ~vagrant/.bash_profile ~vagrant/.bash_profile.bak
-}
-sudo -u vagrant -i bash -c "cd /opt/edx/edx-platform && PROJECT_HOME=/opt/edx ./scripts/create-dev-env.sh -ynq"
-
-# Load .bashrc ################################################################
-([[ -f ~vagrant/.bash_profile ]] && grep ".bashrc" ~vagrant/.bash_profile) || {
-    echo -e "\n. /home/vagrant/.bashrc\n" >> ~vagrant/.bash_profile
-}
+    # Github
+    ([[ -f ~vagrant/.ssh/known_hosts ]] && grep "zBX7bKA= ssh" ~vagrant/.ssh/known_hosts) || {
+	echo "|1|4DtBcMsTM4zgl/jTS7h3ZkmS/Vc=|XkRnn2xEhr8ixOxeskJAzBX7bKA= ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==" >> ~vagrant/.ssh/known_hosts
+    }
+    ([[ -f ~vagrant/.ssh/known_hosts ]] && grep "jO3J5bvw= ssh" ~vagrant/.ssh/known_hosts) || {
+	echo "|1|9rANf/qOAPgKH/TXpGuZCAgGxMs=|x9VYWEDI8kiotbhhNXqjO3J5bvw= ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==" >> ~vagrant/.ssh/known_hosts
+    }
+    chown vagrant.vagrant ~vagrant/.ssh/known_hosts
 
 
-# Virtualenv - Always load ####################################################
+    # edX - Development environment ###############################################
 
-([[ -f ~vagrant/.bash_profile ]] && grep "edx-platform/bin/activate" ~vagrant/.bash_profile) || {
-    echo -e "\n. /home/vagrant/.virtualenvs/edx-platform/bin/activate\n" >> ~vagrant/.bash_profile
-}
+    # Node modules require a filesystem with symlinks (Windows support)
+    mkdir -p /opt/edx/node_modules /opt/edx/edx-platform/node_modules
+    mount -o bind /opt/edx/node_modules /opt/edx/edx-platform/node_modules
+
+    # Force rechecking all prerequisites (could have been fetched outside of the VM)
+    rm -rf /opt/edx/edx-platform/.prereqs_cache
+
+    # Permissions
+    chown vagrant.vagrant /opt/edx /opt/edx/node_modules /opt/edx/edx-platform/node_modules
+
+    # For convenience with `vagrant ssh`, the `edx-platform` virtualenv is always
+    # loaded after the first run, so we need to deactivate that behavior to run
+    # `create-dev-env.sh`.
+    [[ -f ~vagrant/.bash_profile ]] && {
+	mv ~vagrant/.bash_profile ~vagrant/.bash_profile.bak
+    }
+    sudo -u vagrant -i bash -c "cd /opt/edx/edx-platform && PROJECT_HOME=/opt/edx ./scripts/create-dev-env.sh -ynq"
+
+    # Load .bashrc ################################################################
+    ([[ -f ~vagrant/.bash_profile ]] && grep ".bashrc" ~vagrant/.bash_profile) || {
+	echo -e "\n. /home/vagrant/.bashrc\n" >> ~vagrant/.bash_profile
+    }
 
 
-# Directory ###################################################################
+    # Virtualenv - Always load ####################################################
 
-grep "cd /opt/edx/edx-platform" ~vagrant/.bash_profile || {
-    echo -e "\ncd /opt/edx/edx-platform\n" >> ~vagrant/.bash_profile
-}
+    ([[ -f ~vagrant/.bash_profile ]] && grep "edx-platform/bin/activate" ~vagrant/.bash_profile) || {
+	echo -e "\n. /home/vagrant/.virtualenvs/edx-platform/bin/activate\n" >> ~vagrant/.bash_profile
+    }
 
 
-# End #########################################################################
+    # Directory ###################################################################
 
-cat << EOF
+    grep "cd /opt/edx/edx-platform" ~vagrant/.bash_profile || {
+	echo -e "\ncd /opt/edx/edx-platform\n" >> ~vagrant/.bash_profile
+    }
+
+    cat << EOF
 ==============================================================================
-Success!
+Success - Created your development environment!
 ==============================================================================
-
-Now, from the virtual machine (connect with "vagrant ssh" if vagrant didn't
-log you in already), you can start Studio & LMS with the following commands:
-
-- Learning management system (LMS):
-    $ rake lms[cms.dev,0.0.0.0:8000]
-
-    =>  http://192.168.20.40:8000/
-
-- Studio:
-    $ rake cms[dev,0.0.0.0:8001]
-
-    => http://192.168.20.40:8001/
-
-
-See the README for details.
-
 
 EOF
+}    # End on_create() ########################################################
 
+## only initialize / setup the development environment once:
+#   we create node_modules, so that's a good test:
+[[ -d /opt/edx/node_modules ]] || on_create
 
+# grab what the Vagrantfile spec'd our IP to be:
+#  expecting:
+#  - relevant ip on eth1;
+#  - line of interest to look like:
+#    inet 192.168.20.40/24 brd 192.168.20.255 scope global eth1
+MY_IP=$(ip addr show dev eth1 | sed -n '/inet /{s/.*[ ]\(.*\)\/.*/\1/;p}')
+
+cat << EOF
+Connect to your virtual machine with "vagrant ssh".
+Some examples you can use from your virtual machine:
+
+- Start Learning management system (LMS):
+    $ rake lms[cms.dev,0.0.0.0:8000]
+    =>  http://${MY_IP}:8000/
+
+- Start Studio:
+    $ rake cms[dev,0.0.0.0:8001]
+    => http://${MY_IP}:8001/
+
+See the README for more.
+
+EOF

--- a/scripts/vagrant-provisioning.sh
+++ b/scripts/vagrant-provisioning.sh
@@ -66,9 +66,6 @@ on_create()
     # Force rechecking all prerequisites (could have been fetched outside of the VM)
     rm -rf /opt/edx/edx-platform/.prereqs_cache
 
-    # Permissions
-    chown vagrant.vagrant /opt/edx /opt/edx/node_modules /opt/edx/edx-platform/node_modules
-
     # For convenience with `vagrant ssh`, the `edx-platform` virtualenv is always
     # loaded after the first run, so we need to deactivate that behavior to run
     # `create-dev-env.sh`.
@@ -79,22 +76,25 @@ on_create()
 
     # Load .bashrc ################################################################
     ([[ -f ~vagrant/.bash_profile ]] && grep ".bashrc" ~vagrant/.bash_profile) || {
-	echo -e "\n. /home/vagrant/.bashrc\n" >> ~vagrant/.bash_profile
+	echo ". /home/vagrant/.bashrc" >> ~vagrant/.bash_profile
     }
 
 
     # Virtualenv - Always load ####################################################
 
     ([[ -f ~vagrant/.bash_profile ]] && grep "edx-platform/bin/activate" ~vagrant/.bash_profile) || {
-	echo -e "\n. /home/vagrant/.virtualenvs/edx-platform/bin/activate\n" >> ~vagrant/.bash_profile
+	echo ". /home/vagrant/.virtualenvs/edx-platform/bin/activate" >> ~vagrant/.bash_profile
     }
 
 
     # Directory ###################################################################
 
     grep "cd /opt/edx/edx-platform" ~vagrant/.bash_profile || {
-	echo -e "\ncd /opt/edx/edx-platform\n" >> ~vagrant/.bash_profile
+	echo "cd /opt/edx/edx-platform" >> ~vagrant/.bash_profile
     }
+
+    # fix up Permissions
+    chown vagrant.vagrant ~vagrant/.bash_profile /opt/edx /opt/edx/node_modules /opt/edx/edx-platform/node_modules
 
     cat << EOF
 ==============================================================================

--- a/scripts/vagrant-provisioning.sh
+++ b/scripts/vagrant-provisioning.sh
@@ -66,6 +66,9 @@ on_create()
     # Force rechecking all prerequisites (could have been fetched outside of the VM)
     rm -rf /opt/edx/edx-platform/.prereqs_cache
 
+    # Permissions
+    chown vagrant.vagrant /opt/edx /opt/edx/node_modules /opt/edx/edx-platform/node_modules
+
     # For convenience with `vagrant ssh`, the `edx-platform` virtualenv is always
     # loaded after the first run, so we need to deactivate that behavior to run
     # `create-dev-env.sh`.
@@ -93,8 +96,8 @@ on_create()
 	echo "cd /opt/edx/edx-platform" >> ~vagrant/.bash_profile
     }
 
-    # fix up Permissions
-    chown vagrant.vagrant ~vagrant/.bash_profile /opt/edx /opt/edx/node_modules /opt/edx/edx-platform/node_modules
+    # Permissions
+    chown vagrant.vagrant ~vagrant/.bash_profile
 
     cat << EOF
 ==============================================================================

--- a/scripts/vagrant-provisioning.sh
+++ b/scripts/vagrant-provisioning.sh
@@ -107,7 +107,6 @@ EOF
 ## only initialize / setup the development environment once:
 #   we create node_modules, so that's a good test:
 [[ -d /opt/edx/node_modules ]] || on_create
-# on_create
 
 # grab what the Vagrantfile spec'd our IP to be:
 #  expecting:


### PR DESCRIPTION
This fixes a recent vagrant pull merge to mirror development usage for native installations, that is usual workflow is
- git clone;
- create-dev-env.sh
- (work);
- git pull;
- (work);
- ...

(current master runs `scripts/create-dev-env.sh` on each VM bringup - which besides not being usual, has side effects: re-initialized CMS db's on osx host, re-installations, etc.).

scripts/vagrant-provisioning.sh:   changed to only create / initialize the workspace the first time.   Also, reported "up" IP address now reflects the VM's actual address.

README.md:  cleaned up previous notes, add info on how to create a clean VM; added section for django debug toolbar and admin access
