### PR TITLE
Add management command to Studio for exporting all courses

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/export.py
+++ b/cms/djangoapps/contentstore/management/commands/export.py
@@ -30,4 +30,4 @@ class Command(BaseCommand):
         root_dir = os.path.dirname(output_path)
         course_dir = os.path.splitext(os.path.basename(output_path))[0]
 
-        export_to_xml(modulestore('direct'), contentstore(), location, root_dir, course_dir)
+        export_to_xml(modulestore('direct'), contentstore(), location, root_dir, course_dir, modulestore())

--- a/cms/djangoapps/contentstore/management/commands/export.py
+++ b/cms/djangoapps/contentstore/management/commands/export.py
@@ -18,7 +18,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         if len(args) != 2:
-            raise CommandError("import requires two arguments: <course location> <output path>")
+            raise CommandError("export requires two arguments: <course location> <output path>")
 
         course_id = args[0]
         output_path = args[1]

--- a/cms/djangoapps/contentstore/management/commands/export.py
+++ b/cms/djangoapps/contentstore/management/commands/export.py
@@ -14,7 +14,7 @@ unnamed_modules = 0
 
 
 class Command(BaseCommand):
-    help = 'Import the specified data directory into the default ModuleStore'
+    help = 'Export the specified data directory into the default ModuleStore'
 
     def handle(self, *args, **options):
         if len(args) != 2:

--- a/cms/djangoapps/contentstore/management/commands/export_all_courses.py
+++ b/cms/djangoapps/contentstore/management/commands/export_all_courses.py
@@ -40,7 +40,7 @@ class Command(BaseCommand):
                 try:
                     location = CourseDescriptor.id_to_location(course_id)
                     course_dir = course_id.replace('/','...')
-                    export_to_xml(ms, cs, location, root_dir, course_dir)
+                    export_to_xml(ms, cs, location, root_dir, course_dir, modulestore())
                 except Exception as err:
                     print "="*30 + "> Oops, failed to export %s" % course_id
                     print "Error:"

--- a/cms/djangoapps/contentstore/management/commands/export_all_courses.py
+++ b/cms/djangoapps/contentstore/management/commands/export_all_courses.py
@@ -39,11 +39,9 @@ class Command(BaseCommand):
             if 1:
                 try:
                     location = CourseDescriptor.id_to_location(course_id)
-                    course_dir = course_id.replace('/','...')
+                    course_dir = course_id.replace('/', '...')
                     export_to_xml(ms, cs, location, root_dir, course_dir, modulestore())
                 except Exception as err:
                     print "="*30 + "> Oops, failed to export %s" % course_id
                     print "Error:"
                     print err
-                    
-

--- a/cms/djangoapps/contentstore/management/commands/export_all_courses.py
+++ b/cms/djangoapps/contentstore/management/commands/export_all_courses.py
@@ -1,0 +1,49 @@
+###
+### Script for exporting all courseware from Mongo to a directory
+###
+import os
+
+from django.core.management.base import BaseCommand, CommandError
+from xmodule.modulestore.xml_exporter import export_to_xml
+from xmodule.modulestore.django import modulestore
+from xmodule.contentstore.django import contentstore
+from xmodule.course_module import CourseDescriptor
+
+
+unnamed_modules = 0
+
+
+class Command(BaseCommand):
+    help = 'Export all courses from mongo to the specified data directory'
+
+    def handle(self, *args, **options):
+        if len(args) != 1:
+            raise CommandError("import requires one argument: <output path>")
+
+        output_path = args[0]
+
+        cs = contentstore()
+        ms = modulestore('direct')
+        root_dir = output_path
+        courses = ms.get_courses()
+
+        print "%d courses to export:" % len(courses)
+        cids = [x.id for x in courses]
+        print cids
+
+        for course_id in cids:
+
+            print "-"*77
+            print "Exporting course id = {0} to {1}".format(course_id, output_path)
+
+            if 1:
+                try:
+                    location = CourseDescriptor.id_to_location(course_id)
+                    course_dir = course_id.replace('/','...')
+                    export_to_xml(ms, cs, location, root_dir, course_dir)
+                except Exception as err:
+                    print "="*30 + "> Oops, failed to export %s" % course_id
+                    print "Error:"
+                    print err
+                    
+

--- a/cms/djangoapps/contentstore/management/commands/export_all_courses.py
+++ b/cms/djangoapps/contentstore/management/commands/export_all_courses.py
@@ -18,7 +18,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         if len(args) != 1:
-            raise CommandError("import requires one argument: <output path>")
+            raise CommandError("export requires one argument: <output path>")
 
         output_path = args[0]
 


### PR DESCRIPTION
Studio currently keeps no history of courses authored in the system.  This is an issue for researchers studying course data, as well as for course teams who may need to look back to see what changes were made, or who need to recover earlier revisions.

This PR adds a management script to allow all courses stored in the mongo db to be exported to a directory.

At MIT, we're using this with a cronjob and a git repository, to regularly take snapshots of all Studio course content.
