### PR TITLE
[STUD-431] Seems like the Edit/QA links in LMS are triggered by a ENABLE_LMS_MIGRAT...

### DIFF
--- a/lms/envs/cms/dev.py
+++ b/lms/envs/cms/dev.py
@@ -13,6 +13,11 @@ MITX_FEATURES['AUTH_USE_MIT_CERTIFICATES'] = False
 SUBDOMAIN_BRANDING['edge'] = 'edge'
 SUBDOMAIN_BRANDING['preview.edge'] = 'edge'
 VIRTUAL_UNIVERSITIES = ['edge']
+
+# Turn off this flag because it will render 'Edit / QA' links for all instructor viewings of
+# modules. Since - for now - those links point to github (for XML based authoring), it seems broken
+# to people using it. Once we can update those links to properly link back to Studio,
+# then we can turn this flag back on, as well as enabling in aws.py configurations.
 MITX_FEATURES['ENABLE_LMS_MIGRATION'] = False
 
 META_UNIVERSITIES = {}

--- a/lms/envs/cms/dev.py
+++ b/lms/envs/cms/dev.py
@@ -13,6 +13,8 @@ MITX_FEATURES['AUTH_USE_MIT_CERTIFICATES'] = False
 SUBDOMAIN_BRANDING['edge'] = 'edge'
 SUBDOMAIN_BRANDING['preview.edge'] = 'edge'
 VIRTUAL_UNIVERSITIES = ['edge']
+MITX_FEATURES['ENABLE_LMS_MIGRATION'] = False
+
 META_UNIVERSITIES = {}
 
 modulestore_options = {


### PR DESCRIPTION
...ION feature flag. So when running as mongo-backed, set that to False.

Note, this bug report came in from the Open Source community.

Also, in the future, it would be nice to have edit 'backlinks' to Studio from the LMS.
