### PR TITLE
put block around main_vendor js in main_django.html

### DIFF
--- a/lms/templates/main_django.html
+++ b/lms/templates/main_django.html
@@ -7,7 +7,9 @@
   <link rel="icon" type="image/x-icon" href="{% static "images/favicon.ico" %}" />
   
   {% compressed_css 'application' %}
+  {% block main_vendor_js %}
   {% compressed_js 'main_vendor' %}
+  {% endblock %}
   {% block headextra %}{% endblock %}
   {% render_block "css" %}
   


### PR DESCRIPTION
should be a no-op for edx-east, but allow edx-west to remove
vendor.js (with an empty {% block %}) in our password_reset_confirm.html to fix a bug

@frrrances @talbs 
