### PR TITLE
Make course dashboard more robust against bad courses (eg ErrorDescriptor)

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -153,7 +153,7 @@ def cert_info(user, course):
     'survey_url': url, only if show_survey_button is True
     'grade': if status is not 'processing'
     """
-    if not course.has_ended():
+    if hasattr(course, 'has_ended') and not course.has_ended():
         return {}
 
     return _cert_info(user, course, certificate_status_for_student(user, course.id))
@@ -741,8 +741,11 @@ def exam_registration_info(user, course):
     exam of the course.  Returns None if the user is not registered, or if there is no
     current exam for the course.
     """
-    exam_info = course.current_test_center_exam
-    if exam_info is None:
+    if hasattr(course, 'current_test_center_exam'):
+        exam_info =  course.current_test_center_exam
+        if exam_info is None:
+            return None
+    else:
         return None
 
     exam_code = exam_info.exam_series_code

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -204,8 +204,12 @@
 
         <article class="my-course">
           <%
-            course_target = reverse('info', args=[course.id])
+	    try:
+	        course_target = reverse('info', args=[course.id])
+	    except Exception as err:
+	        continue
           %>
+
 
 
 

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -204,31 +204,31 @@
 
         <article class="my-course">
           <%
-	    try:
-	        course_target = reverse('info', args=[course.id])
-	    except Exception as err:
-	        course_target = "Error"
-		if not user.is_staff:
-		    continue
+            try:
+                course_target = reverse('info', args=[course.id])
+            except Exception as err:
+                course_target = "Error"
+                if not user.is_staff:
+                    continue
           %>
 
           % if course_target=="Error":
             <div class="cover">
-	       Error
+               Error
             </div>
           <section class="info">
             <hgroup>
               <h3>
                   <span>Error loading ${course.id}</span>
               </h3>
-	      <span>${course.error_msg}</span>
+              <span>${course.error_msg}</span>
             </hgroup>
-	  </section>
+          </section>
         </article>
-	    <%
-	        continue
-	    %>
-	  % endif
+            <%
+                continue
+            %>
+          % endif
 
           % if course.id in show_courseware_links_for:
             <a href="${course_target}" class="cover">

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -207,11 +207,28 @@
 	    try:
 	        course_target = reverse('info', args=[course.id])
 	    except Exception as err:
-	        continue
+	        course_target = "Error"
+		if not user.is_staff:
+		    continue
           %>
 
-
-
+          % if course_target=="Error":
+            <div class="cover">
+	       Error
+            </div>
+          <section class="info">
+            <hgroup>
+              <h3>
+                  <span>Error loading ${course.id}</span>
+              </h3>
+	      <span>${course.error_msg}</span>
+            </hgroup>
+	  </section>
+        </article>
+	    <%
+	        continue
+	    %>
+	  % endif
 
           % if course.id in show_courseware_links_for:
             <a href="${course_target}" class="cover">


### PR DESCRIPTION
Currently, when bad course data is loaded, producing an ErrorDescriptor, this crashes the course dashboard, because the dashboard views assumes the course descriptor has valid methods like `has_ended()` and attributes like `course.current_test_center_exam`.  

This PR modifies student.views and dashboard.html to not crash on bad courses.
