### PR TITLE
Provide CAS authentication integration

### DIFF
--- a/common/djangoapps/external_auth/views.py
+++ b/common/djangoapps/external_auth/views.py
@@ -392,7 +392,7 @@ def cas_login(request, next_page=None, required=False):
         Uses django_cas for authentication.
         CAS is a common authentcation method pioneered by Yale.
         See http://en.wikipedia.org/wiki/Central_Authentication_Service
-        
+
         Does normal CAS login then generates user_profile if nonexistent,
         and if login was successful.  We assume that user details are
         maintained by the central service, and thus an empty user profile
@@ -400,12 +400,12 @@ def cas_login(request, next_page=None, required=False):
     """
 
     ret = django_cas_login(request, next_page, required)
-    
+
     if request.user.is_authenticated():
         user = request.user
         if not UserProfile.objects.filter(user=user):
-            up = UserProfile(name=user.username, user=user)
-            up.save()
+            user_profile = UserProfile(name=user.username, user=user)
+            user_profile.save()
 
     return ret
 

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -409,6 +409,8 @@ def change_enrollment(request):
 
 @ensure_csrf_cookie
 def accounts_login(request, error=""):
+    if settings.MITX_FEATURES.get('AUTH_USE_CAS'):
+        return redirect(reverse('cas-login'))
     return render_to_response('login.html', {'error': error})
 
 # Need different levels of logging
@@ -505,7 +507,11 @@ def logout_user(request):
     # We do not log here, because we have a handler registered
     # to perform logging on successful logouts.
     logout(request)
-    response = redirect('/')
+    if settings.MITX_FEATURES.get('AUTH_USE_CAS'):
+        target = reverse('cas-logout')
+    else:
+        target = '/'
+    response = redirect(target)
     response.delete_cookie(settings.EDXMKTG_COOKIE_NAME,
                            path='/',
                            domain=settings.SESSION_COOKIE_DOMAIN)

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -92,6 +92,7 @@ MITX_FEATURES = {
     'AUTH_USE_MIT_CERTIFICATES': False,
     'AUTH_USE_OPENID_PROVIDER': False,
     'AUTH_USE_SHIB': False,
+    'AUTH_USE_CAS': False,
 
     # This flag disables the requirement of having to agree to the TOS for users registering
     # with Shib.  Feature was requested by Stanford's office of general counsel
@@ -853,3 +854,15 @@ def enable_theme(theme_name):
     # avoid collisions with default edX static files
     STATICFILES_DIRS.append((u'themes/%s' % theme_name,
                              theme_root / 'static'))
+
+######################## CAS authentication ###########################
+
+if MITX_FEATURES.get('AUTH_USE_CAS'):
+    CAS_SERVER_URL = 'https://provide_your_cas_url_here'
+    AUTHENTICATION_BACKENDS = (
+        'django.contrib.auth.backends.ModelBackend',
+        'django_cas.backends.CASBackend',
+        )
+    INSTALLED_APPS += ('django_cas',)
+    MIDDLEWARE_CLASSES += ('django_cas.middleware.CASMiddleware',)
+    

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -862,7 +862,6 @@ if MITX_FEATURES.get('AUTH_USE_CAS'):
     AUTHENTICATION_BACKENDS = (
         'django.contrib.auth.backends.ModelBackend',
         'django_cas.backends.CASBackend',
-        )
+    )
     INSTALLED_APPS += ('django_cas',)
     MIDDLEWARE_CLASSES += ('django_cas.middleware.CASMiddleware',)
-    

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -363,6 +363,12 @@ if settings.MITX_FEATURES.get('AUTH_USE_SHIB'):
         url(r'^shib-login/$', 'external_auth.views.shib_login', name='shib-login'),
     )
 
+if settings.MITX_FEATURES.get('AUTH_USE_CAS'):
+    urlpatterns += (
+        url(r'^cas-auth/login/$', 'external_auth.views.cas_login', name="cas-login"),
+        url(r'^cas-auth/logout/$', 'django_cas.views.logout', {'next_page': '/'}, name="cas-logout"),
+    )
+
 if settings.MITX_FEATURES.get('RESTRICT_ENROLL_BY_REG_METHOD'):
     urlpatterns += (
         url(r'^course_specific_login/(?P<course_id>[^/]+/[^/]+/[^/]+)/$',

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -92,3 +92,6 @@ nose-ignore-docstring
 nose-exclude
 
 git+https://github.com/mfogel/django-settings-context-processor.git
+
+# django-cas version 2.0.3 with patch to be compatible with django 1.4
+git+https://github.com/mitocw/django-cas.git


### PR DESCRIPTION
CAS authentication (http://en.wikipedia.org/wiki/Central_Authentication_Service) is a widely employed standard, which is also very convenient to use.  It works in the native nginx setup used by edX, for example.

This PR provides CAS authentication via a small set of changes, and a stub in `external_auth` for dealing with the need for UserProfile.  This builds on `django_cas` (using a version which has been updated to work in Django 1.4: https://github.com/mitocw/django-cas).

MIT is currently using this PR for authentication to its Shibboleth service.  It employs a separate CAS provider which runs behind Apache2; this is convenient, since nginx doesn't natively handle Shibboleth.  The CAS provider can also handle openid authentication.  The code has been in production use for some time.

Note that there are no tests provided in this PR.
