### PR TITLE
Validate date/time settings when typed in directly.

### DIFF
--- a/cms/static/js/views/settings/main_settings_view.js
+++ b/cms/static/js/views/settings/main_settings_view.js
@@ -107,6 +107,7 @@ CMS.Views.Settings.Details = CMS.Views.ValidatingView.extend({
         // to pick up when the date is typed directly in the field.
         datefield.change(setfield);
         timefield.on('changeTime', setfield);
+        timefield.on('input', setfield);
 
         datefield.datepicker('setDate', this.model.get(fieldName));
         // timepicker doesn't let us set null, so check that we have a time


### PR DESCRIPTION
The changeTime event isn't fired when the user types in the field, but
only when clicking on the time in the dropdown. I'd consider this a
timepicker bug, but for now we can just listen to the user typing in
the field and update the value (and thus validate) like we do with
other field types.
