### PR TITLE
Tweak behavior of submit buttons on register and login pages

### DIFF
--- a/lms/templates/login.html
+++ b/lms/templates/login.html
@@ -38,13 +38,12 @@
         toggleSubmitButton(false);
       });
 
-      $('#login-form').on('ajax:complete', function() {
+      $('#login-form').on('ajax:error', function() {
         toggleSubmitButton(true);
       });
 
       $('#login-form').on('ajax:success', function(event, json, xhr) {
         if(json.success) {
-          $('.message.submission-error').removeClass('is-shown');
           var u=decodeURI(window.location.search);
           next=u.split("next=")[1];
           if (next) {
@@ -53,6 +52,7 @@
             location.href="${reverse('dashboard')}";
           }
         } else {
+          toggleSubmitButton(true);
           $('.message.submission-error').addClass('is-shown').focus();
           $('.message.submission-error .message-copy').html(json.value);
         }

--- a/lms/templates/register.html
+++ b/lms/templates/register.html
@@ -45,15 +45,15 @@
         toggleSubmitButton(false);
       });
 
-      $('#register-form').on('ajax:complete', function() {
+      $('#register-form').on('ajax:error', function() {
         toggleSubmitButton(true);
       });
 
       $('#register-form').on('ajax:success', function(event, json, xhr) {
         if(json.success) {
-          $('.message.submission-error').removeClass('is-shown');
           location.href="${reverse('dashboard')}";
        } else {
+         toggleSubmitButton(true);
          $('.status.message.submission-error').addClass('is-shown').focus();
          $('.status.message.submission-error .message-copy').html(json.value).stop().css("display", "block");
          $(".field-error").removeClass('field-error');


### PR DESCRIPTION
The buttons are not re-enabled if the registration/login submission succeeds
(and, therefore, the user is about to be directed to another page). Also, any
error message that is present does not disappear immediately before the page
redirects.
