### PR TITLE
Update MathJax to the latest stable version (2.2), to fix IE10 bug LMS-194

### DIFF
--- a/common/templates/mathjax_include.html
+++ b/common/templates/mathjax_include.html
@@ -33,4 +33,4 @@
 <!-- This must appear after all mathjax-config blocks, so it is after the imports from the other templates.
      It can't be run through static.url because MathJax uses crazy url introspection to do lazy loading of
      MathJax extension libraries -->
-<script type="text/javascript" src="https://edx-static.s3.amazonaws.com/mathjax-MathJax-07669ac/MathJax.js?config=TeX-MML-AM_HTMLorMML-full"></script>
+<script type="text/javascript" src="https://edx-static.s3.amazonaws.com/mathjax-MathJax-727332c/MathJax.js?config=TeX-MML-AM_HTMLorMML-full"></script>


### PR DESCRIPTION
I uploaded a new MathJax bucket. I'm going to attach a new CORS config to those buckets to get rid of cross-site violations and by extension allow IE to display pretty fonts for math. But this should unbreak IE10 at least.
