### PR TITLE
[HOTFIX] add a default XML serialization if the 'data' field is empty or None. So...

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -792,6 +792,37 @@ class ContentStoreToyCourseTest(ModuleStoreTestCase):
 
         shutil.rmtree(root_dir)
 
+    def test_export_course_with_metadata_only_video(self):
+        module_store = modulestore('direct')
+        draft_store = modulestore('draft')
+        content_store = contentstore()
+
+        import_from_xml(module_store, 'common/test/data/', ['toy'])
+        location = CourseDescriptor.id_to_location('edX/toy/2012_Fall')
+
+        # create a new video module and add it as a child to a vertical
+        # this re-creates a bug whereby since the video template doesn't have
+        # anything in 'data' field, the export was blowing up
+        verticals = module_store.get_items(['i4x', 'edX', 'toy', 'vertical', None, None])
+
+        self.assertGreater(len(verticals), 0)
+
+        new_component_location = Location('i4x', 'edX', 'toy', 'video', 'new_component')
+        source_template_location = Location('i4x', 'edx', 'templates', 'video', 'default')
+
+        module_store.clone_item(source_template_location, new_component_location)
+        parent = verticals[0]
+        module_store.update_children(parent.location, parent.children + [new_component_location.url()])
+
+        root_dir = path(mkdtemp_clean())
+
+        print 'Exporting to tempdir = {0}'.format(root_dir)
+
+        # export out to a tempdir
+        export_to_xml(module_store, content_store, location, root_dir, 'test_export', draft_modulestore=draft_store)
+
+        shutil.rmtree(root_dir)
+
     def test_course_handouts_rewrites(self):
         module_store = modulestore('direct')
 

--- a/common/lib/xmodule/xmodule/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module.py
@@ -118,6 +118,13 @@ class VideoDescriptor(VideoFields,
         _parse_video_xml(video, xml_data)
         return video
 
+    def definition_to_xml(self, resource_fs):
+        """
+        Override the base implementation. We don't actually have anything in the 'data' field
+        (it's an empty string), so we just return a simple XML element
+        """
+        return etree.fromstring('<video />')
+
 
 def _parse_video_xml(video, xml_data):
     """

--- a/common/test/data/toy/vertical/vertical_test.xml
+++ b/common/test/data/toy/vertical/vertical_test.xml
@@ -1,4 +1,5 @@
 <sequential>
+        <video display_name="default" youtube_id_0_75="JMD_ifUUfsU" youtube_id_1_0="OEoXaMPEzfM" youtube_id_1_25="AKqURZnYqpk" youtube_id_1_5="DYpADpL7jAY" name="sample_video"/>
         <poll_question name="T1_changemind_poll_foo_2" display_name="Change your answer" reset="false">
         <p>Have you changed your mind?</p>
         <answer id="yes">Yes</answer>


### PR DESCRIPTION
...me XModules now - like video XModule - do not have XML set in the 'data' field
