### PR TITLE
Install: Fixes "Don't know how to build task 'cms:update_templates'"

### DIFF
--- a/scripts/create-dev-env.sh
+++ b/scripts/create-dev-env.sh
@@ -497,7 +497,7 @@ mkdir -p "$BASE/data"
 
 rake django-admin[syncdb,lms,dev,--noinput]
 rake django-admin[migrate]
-rake cms:update_templates
+
 # Configure Git
 
 output "Fixing your git default settings"


### PR DESCRIPTION
Remove the `update_templates command from the installation script, this
command was removed by
https://github.com/edx/edx-platform/commit/3722685e1a185ff4a0a085bb380ed793cf6d1e59
