### PR TITLE
Fix issue with tabs not being populated

### DIFF
--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -407,7 +407,7 @@ class CourseDescriptor(CourseFields, SequenceDescriptor):
                     continue
 
         # TODO check that this is still needed here and can't be by defaults.
-        if self.tabs is None:
+        if self.tabs is None or (isinstance(self.tabs, list) and len(self.tabs) == 0):
             # When calling the various _tab methods, can omit the 'type':'blah' from the
             # first arg, since that's only used for dispatch
             tabs = []


### PR DESCRIPTION
In Studio, tabs are [] by default, not None.  The course descriptor regenerates the tabs if they are None, but not if they are [].  This is okay if tabs stay as an empty list when they are passed to the LMS, because the LMS (courseware/tabs.py) accepts an empty list.  But a list with one item (such as when the open ended or notes tab are added in Studio) will break it.

Adding in the [] check ensures that tabs are current.
