### PR TITLE
Studio: adds a space back to the phrase 'Welcome to edX Studio'

### DIFF
--- a/cms/static/sass/views/_index.scss
+++ b/cms/static/sass/views/_index.scss
@@ -71,8 +71,13 @@ body.index {
         color: $white;
       }
 
+      .wrapper-text-welcome, .logo {
+        display: inline-block;
+      }
+
       .logo {
         font-weight: 600;
+        margin-left: ($baseline/2);
       }
 
       .tagline {

--- a/cms/templates/howitworks.html
+++ b/cms/templates/howitworks.html
@@ -11,7 +11,7 @@
   <section class="content content-header">
     <header>
       ## "edX Studio" should not be translated
-      <h1>${_('Welcome to ')}<span class="logo">edX Studio</span></h1>
+      <h1><span class="wrapper-text-welcome">${_('Welcome to')}</span><span class="logo">edX Studio</span></h1>
       <p class="tagline">${_("Studio helps manage your courses online, so you can focus on teaching them")}</p>
     </header>
   </section>

--- a/cms/templates/howitworks.html
+++ b/cms/templates/howitworks.html
@@ -11,7 +11,7 @@
   <section class="content content-header">
     <header>
       ## "edX Studio" should not be translated
-      <h1>${_('Welcome to')}<span class="logo">&nbsp;edX Studio</span></h1>
+      <h1>${_('Welcome to ')}<span class="logo">edX Studio</span></h1>
       <p class="tagline">${_("Studio helps manage your courses online, so you can focus on teaching them")}</p>
     </header>
   </section>


### PR DESCRIPTION
The space on the Studio welcome page seemed to go missing recently. Its back, and better than ever.
