### PR TITLE
Set to old xml defaults IFF no specified policy for problem nor course.

### DIFF
--- a/common/lib/xmodule/xmodule/capa_module.py
+++ b/common/lib/xmodule/xmodule/capa_module.py
@@ -1152,10 +1152,11 @@ class CapaDescriptor(CapaFields, RawDescriptor):
         Augment regular translation w/ setting the pre-Studio defaults.
         """
         problem = super(CapaDescriptor, cls).from_xml(xml_data, system, org, course)
+        course_policy = system.policy.setdefault('course/{}'.format(system.url_name), {})
         # pylint: disable=W0212
-        if 'showanswer' not in problem._model_data:
+        if 'showanswer' not in problem._model_data and 'showanswer' not in course_policy:
             problem.showanswer = "closed"
-        if 'rerandomize' not in problem._model_data:
+        if 'rerandomize' not in problem._model_data and 'rerandomize' not in course_policy:
             problem.rerandomize = "always"
         return problem
 


### PR DESCRIPTION
@sarina @cpennington @Lyla-Fischer Can you test/review (as appropriate)?
- Need to test that xml backed lms behaves as expected when the policy file does and does not override rerandomize & showanswer at the course and problem levels (2 x 2)
- Need to test that importing an xml course into Studio where the same 2x2 are set/defaulted ends up behaving correctly
- Need to test that newly created problems in Studio
  - use the course overrides of those values if overridden at course in xml import
  - use the Studio defaults (never/completed) otherwise
