### PR TITLE
Correctly persist checklist settings.

### DIFF
--- a/cms/djangoapps/contentstore/features/checklists.feature
+++ b/cms/djangoapps/contentstore/features/checklists.feature
@@ -8,9 +8,8 @@ Feature: Course checklists
   Scenario: A course author can mark tasks as complete
     Given I have opened Checklists
     Then I can check and uncheck tasks in a checklist
-    And They are correctly selected after I reload the page
+    And They are correctly selected after reloading the page
 
-  @skip
   Scenario: A task can link to a location within Studio
     Given I have opened Checklists
     When I select a link to the course outline

--- a/cms/djangoapps/contentstore/features/checklists.py
+++ b/cms/djangoapps/contentstore/features/checklists.py
@@ -45,7 +45,7 @@ def i_can_check_and_uncheck_tasks(step):
     verifyChecklist2Status(2, 7, 29)
 
 
-@step('They are correctly selected after I reload the page$')
+@step('They are correctly selected after reloading the page$')
 def tasks_correctly_selected_after_reload(step):
     reload_the_page(step)
     verifyChecklist2Status(2, 7, 29)

--- a/cms/djangoapps/contentstore/views/checklist.py
+++ b/cms/djangoapps/contentstore/views/checklist.py
@@ -37,6 +37,7 @@ def get_checklists(request, org, course, name):
 
     checklists, modified = expand_checklist_action_urls(course_module)
     if copied or modified:
+        course_module.save()
         modulestore.update_metadata(location, own_metadata(course_module))
     return render_to_response('checklists.html',
                               {
@@ -69,6 +70,7 @@ def update_checklist(request, org, course, name, checklist_index=None):
             # seeming noop which triggers kvs to record that the metadata is not default
             course_module.checklists = course_module.checklists
             checklists, _ = expand_checklist_action_urls(course_module)
+            course_module.save()
             modulestore.update_metadata(location, own_metadata(course_module))
             return JsonResponse(checklists[index])
         else:
@@ -79,6 +81,7 @@ def update_checklist(request, org, course, name, checklist_index=None):
         # In the JavaScript view initialize method, we do a fetch to get all the checklists.
         checklists, modified = expand_checklist_action_urls(course_module)
         if modified:
+            course_module.save()
             modulestore.update_metadata(location, own_metadata(course_module))
         return JsonResponse(checklists)
 


### PR DESCRIPTION
Incidentally, fixes an acceptance test (which would have caught this
bug) not running. Its step regex was "They are correctly selected
after I reload the page$", which happens to be matched by "I reload
the page$", another step definition. Lettuce seems to arbitrarily pick
between definitions if they both match a step, so it's good to ensure
that each step isn't a sub-regex of another.
