### PR TITLE
edx.org-related Login, Registration, and Course Register Button Styling Clean Up (WIP - Do Not Merge)

### DIFF
--- a/lms/static/sass/_shame.scss
+++ b/lms/static/sass/_shame.scss
@@ -213,7 +213,42 @@
     overflow: hidden;
   }
 
-  // button elements - not a better place to put these, sadly
+  // nav list
+  .list-actions {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+
+    .item {
+      margin: 0;
+    }
+  }
+
+  .action {
+    @include font-size(16);
+    font-weight: 500;
+
+    // register or access courseware
+    &.action-register, &.access-courseware {
+      @extend .mktg-btn-primary-blue;
+      display: block;
+    }
+
+    // already registered but course not started or registration is closed
+    &.is-registered, &.registration-closed {
+      @extend .mktg-btn-primary-pink;
+      pointer-events: none !important;
+      display: block;
+    }
+
+    // coming soon
+    &.coming-soon {
+      @extend .mktg-btn-primary-pink;
+      pointer-events: none !important;
+      outline: none;
+      display: block;
+    }
+  }
 }
 
 

--- a/lms/static/sass/_shame.scss
+++ b/lms/static/sass/_shame.scss
@@ -2,9 +2,211 @@
 // shame file - used for any bad-form/orphaned scss that knowingly violate edX FED architecture/standards (see - http://csswizardry.com/2013/04/shame-css/)
 // ====================
 
-// marketing site - registration iframe band-aid (poor form enough to isolate out)
+// edx.org marketing site visual tweaks - needed, but poorly architected/adopted for now
+
+// extends type
+.mktg-hd, .mktg-copy, .mktg-action {
+  font-family: $sans-serif;
+}
+
+// headers
+.mktg-hd-lv1 {
+  @extend .mktg-hd;
+  @include font-size(60);
+  @include line-height(60);
+  margin: 0 0 ($baseline*2) 0;
+  color: $mktg-gray-d4;
+  font-weight: 300;
+}
+
+.mktg-hd-lv2 {
+  @extend .mktg-hd;
+  @include font-size(24);
+  @include line-height(24);
+  margin: 0 0 ($baseline*0.75) 0;
+  border-bottom: 1px solid $mktg-gray-l3;
+  padding-bottom: ($baseline/2);
+  color: $mktg-gray-d4;
+  font-weight: 300;
+}
+
+.mktg-hd-lv3 {
+  @extend .mktg-hd;
+  @include font-size(18);
+  @include line-height(18);
+  color: $mktg-gray-d4;
+  margin: 0 0 ($baseline) 0;
+  font-weight: 600;
+}
+
+.mktg-hd-lv4 {
+  @extend .mktg-hd;
+  @include font-size(18);
+  @include line-height(18);
+  color: $mktg-gray-d4;
+  margin: 0 0 ($baseline) 0;
+  font-weight: 400;
+}
+
+// copy
+.mktg-copy-base {
+  @extend .mktg-copy;
+  @include font-size(16);
+  @include line-height(16);
+  color: $mktg-gray-d2;
+}
+
+.mktg-copy-lead1 {
+  @extend .mktg-copy;
+  @include font-size(21);
+  @include line-height(21);
+  color: $mktg-gray;
+}
+
+.mktg-copy-detail {
+  @extend .mktg-copy;
+  @include font-size(14);
+  @include line-height(14);
+  color: $mktg-gray-d2;
+}
+
+.mktg-copy-metadata {
+  @extend .mktg-copy;
+  @include font-size(12);
+  @include line-height(12);
+  color: $mktg-gray-d4;
+
+
+  .mktg-copy-metadata-value {
+    font-weight: 400;
+  }
+
+  .mktg-copy-metadata-value {
+    font-weight: 700;
+  }
+}
+
+
+// links
+.mktg-copy-link {
+  @extend .mktg-copy;
+  @include transition(all ease-in-out 0.25s 0);
+  color: $mktg-blue;
+  text-decoration: none !important;
+  border-bottom: 1px dotted transparent;
+
+  &:link, &:visited {
+    color: $blue;
+  }
+
+  &:hover, &:active {
+    color: $mktg-blue-l1;
+    border-color: $mktg-blue;
+  }
+}
+
+
+// extends btn
+.btn {
+  @include box-sizing(border-box);
+  @include transition(color 0.25s ease-in-out, background 0.25s ease-in-out, box-shadow 0.25s ease-in-out);
+  display: inline-block;
+  cursor: pointer;
+  text-decoration: none;
+
+  &:hover, &:active {
+
+  }
+
+  &.disabled, &[disabled] {
+    cursor: default;
+    pointer-events: none;
+  }
+}
+
+.btn-pill {
+  border-radius: ($baseline/5);
+}
+
+.btn-rounded {
+  border-radius: ($baseline/2);
+}
+
+.btn-edged {
+  border-radius: ($baseline/10);
+}
+
+// primary button
+.mktg-btn-primary {
+  @extend .btn;
+  @extend .btn-edged;
+  border: none;
+  padding:($baseline/2) ($baseline);
+  text-align: center;
+  text-shadow: none;
+  font-weight: 500;
+
+  &.disabled, &[disabled] {
+    background: $mktg-gray-d3;
+  }
+}
+
+// blue primary button
+.mktg-btn-primary-blue {
+  @extend .mktg-btn-primary;
+  box-shadow: 0 2px 1px 0 $mktg-blue-d4;
+  background: $mktg-blue-d3;
+  color: $white;
+
+  &:hover, &:active {
+    background: $mktg-blue-d1;
+  }
+
+  &.current, &.active {
+    box-shadow: inset 0 2px 1px 1px $mktg-blue-d2;
+    background: $mktg-blue;
+    color: $mktg-blue-d2;
+
+    &:hover, &:active {
+      box-shadow: inset 0 2px 1px 1px $mktg-blue-d3;
+      color: $mktg-blue-d3;
+    }
+  }
+
+  &.disabled, &[disabled] {
+    box-shadow: none;
+  }
+}
+
+// pink primary button
+.mktg-btn-primary-pink {
+  @extend .mktg-btn-primary;
+  box-shadow: 0 2px 1px 0 $mktg-pink-d2;
+  background: $mktg-pink;
+  color: $white;
+
+  &:hover, &:active {
+    background: $mktg-pink-l3;
+  }
+
+  &.current, &.active {
+    box-shadow: inset 0 2px 1px 1px $mktg-pink-d1;
+    background: $mktg-pink-l2;
+    color: $mktg-pink-d1;
+
+    &:hover, &:active {
+      box-shadow: inset 0 2px 1px 1px $mktg-pink-d2;
+      color: $mktg-pink-d3;
+    }
+  }
+
+  &.disabled, &[disabled] {
+    box-shadow: none;
+  }
+}
+
+// iframed button band-aid
 .view-partial-mktgregister {
-  background: transparent;
 
   // dimensions needed for course about page on marketing site
   .wrapper-view {
@@ -12,97 +214,12 @@
   }
 
   // button elements - not a better place to put these, sadly
-  .btn {
-    @include box-sizing('border-box');
-    display: block;
-    padding: $baseline/2;
-    text-transform: lowercase;
-    color: $white;
-    letter-spacing: 0.1rem;
-    cursor: pointer;
-    text-align: center;
-    border: none !important;
-    text-decoration: none;
-    text-shadow: none;
-    letter-spacing: 0.1rem;
-    font-size: 17px;
-    font-weight: 300;
-    box-shadow: 0 !important;
-
-    strong {
-      font-weight: 400;
-      text-transform: none;
-    }
-  }
-
-  .btn-primary {
-    @extend .btn;
-    @include linear-gradient($m-blue-s1 5%, $m-blue-d1 95%);
-
-    // no hover state conventions to follow from marketing :/
-    &:hover, &:active {
-
-    }
-  }
-
-  .btn-secondary {
-    @extend .btn;
-    @include linear-gradient($m-gray 5%, $m-gray-d1 95%);
-
-    // no hover state conventions to follow from marketing :/
-    &:hover, &:active {
-
-    }
-  }
-
-  .btn-tertiary {
-    @extend .btn;
-    background: $m-blue-l1;
-    color: $m-blue;
-
-    // no hover state conventions to follow from marketing :/
-    &:hover, &:active {
-
-    }
-  }
-
-  // nav list
-  .list-actions {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-
-    .item {
-      margin: 0;
-    }
-  }
-
-  .action {
-
-    // register or access courseware
-    &.action-register, &.access-courseware {
-      @extend .btn-primary;
-    }
-
-    // already registered but course not started or registration is closed
-    &.is-registered, &.registration-closed {
-      @extend .btn-secondary;
-      pointer-events: none !important;
-    }
-
-    // coming soon
-    &.coming-soon {
-      @extend .btn-tertiary;
-      pointer-events: none !important;
-      outline: none;
-    }
-  }
 }
 
-//--------------------------------------
-//   The Following is to enable themes to
-//   display H1s on login and register pages
-//--------------------------------------
+
+// ====================
+
+// The Following is to enable themes to display H1s on login and register pages
 .view-login .introduction header h1,
 .view-register .introduction header h1 {
   @include login_register_h1_style;

--- a/lms/static/sass/base/_mixins.scss
+++ b/lms/static/sass/base/_mixins.scss
@@ -1,10 +1,11 @@
-@function em($pxval, $base: 16) {
-  @return #{$pxval / $base}em;
+
+@mixin font-size($sizeValue: 16){
+  font-size: $sizeValue + px;
 }
 
-// Line-height
-@function lh($amount: 1) {
-  @return $body-line-height * $amount;
+// line height
+@mixin line-height($fontSize: auto){
+  line-height: ($fontSize*1.48) + px;
 }
 
 // image-replacement hidden text
@@ -30,6 +31,19 @@
   overflow: hidden;
   display: block;
 }
+
+// older font mixins
+@function em($pxval, $base: 16) {
+  @return #{$pxval / $base}em;
+}
+
+// Line-height
+@function lh($amount: 1) {
+  @return $body-line-height * $amount;
+}
+
+
+// ====================
 
 
 //-----------------

--- a/lms/static/sass/base/_variables.scss
+++ b/lms/static/sass/base/_variables.scss
@@ -116,8 +116,8 @@ $border-color-4: rgb(252,252,252);
 
 $link-color: $mktg-blue;
 $link-color-d1: $mktg-blue-d1;
-$link-hover: $pink;
-$site-status-color: $pink;
+$link-hover: $mktg-pink;
+$site-status-color: $mktg-pink;
 
 $button-color: $blue;
 $button-archive-color: #eee;

--- a/lms/static/sass/base/_variables.scss
+++ b/lms/static/sass/base/_variables.scss
@@ -39,22 +39,33 @@ $outer-border-color: rgb(170, 170, 170);
 $light-gray: #ddd;
 $dark-gray: #333;
 
-// edx.org-related
-$m-gray-l1: rgb(203,203,203);
-$m-gray-l2: rgb(246,246,246);
-$m-gray: rgb(153,153,153);
-$m-gray-d1: rgb(102,102,102);
-$m-gray-d2: rgb(51,51,51);
-$m-gray-a1: rgb(80,80,80);
-$m-blue: rgb(65, 116, 170);
-// $m-blue: rgb(85, 151, 221); (used in marketing redesign)
-$m-blue-l1: rgb(85, 151, 221);
-$m-blue-d1: shade($m-blue,15%);
-$m-blue-s1: saturate($m-blue,15%);
-$m-pink: rgb(204,51,102);
+// edx.org marketing site variables
+$mktg-gray: #8A8C8F;
+$mktg-gray-l1: #97999B;
+$mktg-gray-l2: #A4A6A8;
+$mktg-gray-l3: #B1B2B4;
+$mktg-gray-l4: #F5F5F5;
+$mktg-gray-d1: #7D7F83;
+$mktg-gray-d2: #707276;
+$mktg-gray-d3: #646668;
+$mktg-gray-d4: #050505;
 
-$m-base-font-size: em(15);
+$mktg-blue: #1AA1DE;
+$mktg-blue-l1: #2BACE6;
+$mktg-blue-l2: #42B5E9;
+$mktg-blue-l3: #59BEEC;
+$mktg-blue-d1: #1790C7;
+$mktg-blue-d2: #1580B0;
+$mktg-blue-d3: #126F9A;
+$mktg-blue-d4: #0A4A67;
 
+$mktg-pink: #B52A67;
+$mktg-pink-l1: #CA2F73;
+$mktg-pink-l2: #D33F80;
+$mktg-pink-l3: #D7548E;
+$mktg-pink-d1: #A0255B;
+$mktg-pink-d2: #8C204F;
+$mktg-pink-d3: #771C44;
 
 $base-font-color: rgb(60,60,60);
 $baseFontColor: rgb(60,60,60);
@@ -103,8 +114,8 @@ $border-color-2: rgb(200,200,200);
 $border-color-3: rgb(100,100,100);
 $border-color-4: rgb(252,252,252);
 
-$link-color: $blue;
-$link-color-d1: $m-blue;
+$link-color: $mktg-blue;
+$link-color-d1: $mktg-blue-d1;
 $link-hover: $pink;
 $site-status-color: $pink;
 

--- a/lms/static/sass/multicourse/_account.scss
+++ b/lms/static/sass/multicourse/_account.scss
@@ -13,87 +13,36 @@
   // edx.org - marketing typography
   .heading-1, .heading-2, .heading-3, .heading-4, .heading-5, .body-text-emphasized, .body-text, .button-primary, .button-secondary {
     display: block;
-    font-family: $sans-serif;
-    line-height: lh(1);
   }
 
   .heading-2 {
-    font-size: 25px;
-    margin: 0 0 $baseline 0;
-    font-weight: 300;
-    text-transform: uppercase;
-    color: $link-color-d1;
+    @extend .mktg-hd-lv2;
   }
 
   .heading-3 {
-    font-size: 21px;
-    margin: 0 0 $baseline 0;
-    font-weight: 300;
-    color: $base-font-color;
+    @extend .mktg-hd-lv3;
   }
 
   .heading-4 {
-    font-size: 14px;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0 !important;
-    color: saturate($link-color-d1,15%);
-  }
-
-  .heading-5 {
+    @extend .mktg-hd-lv4;
   }
 
   // specific examples - body
   .body-text-emphasized {
-    font-size: 18px;
-    margin: 0 0 $baseline 0;
-    font-weight: 300;
-    color: $base-font-color;
-    font-family: 'Open Sans', sans-serif;
-    line-height: lh(1.1);
+
   }
 
   .body-text {
-    font-size: 15px;
-    margin: 0 0 $baseline 0;
-    color: $base-font-color;
-    line-height: lh(1);
+    @extend .mktg-copy-base;
   }
 
   // specific examples - buttons
   .button-primary {
-    border-radius: 0;
-    @include linear-gradient(saturate($link-color-d1,15%) 5%, shade($link-color-d1,15%) 95%);
-    display: inline-block;
-    padding: $baseline/2 $baseline*2.5;
-    text-transform: lowercase;
-    color: $very-light-text;
-    letter-spacing: 0.1rem;
-    font-weight: 500;
-    cursor: pointer;
-    text-align: center;
-    border: none !important;
-    text-shadow: none;
-    letter-spacing: 0;
-    font-size: 16px;
-    box-shadow: none !important;
+    @extend .mktg-btn-primary-blue;
   }
 
   .button-secondary {
-    @include linear-gradient($outer-border-color 5%, $lighter-base-font-color 95%);
-    display: inline-block;
-    padding: $baseline/2 $baseline*2.5;
-    text-transform: lowercase;
-    color: $very-light-text;
-    letter-spacing: 0.1rem;
-    font-weight: 600;
-    cursor: pointer;
-    text-align: center;
-    border: none !important;
-    text-shadow: none;
-    letter-spacing: 0;
-    font-size: 16px;
-    box-shadow: 0 !important;
+    @extend .mktg-btn-primary-pink;
   }
 
   // layout
@@ -139,19 +88,8 @@
   }
 
   a {
-    @include transition(color 0.15s ease-in-out 0s, border 0.15s ease-in-out 0s);
-
-    &:link, &:visited, &:hover, &:active {
-      color: $link-color-d1;
-      font-weight: 400;
-      text-decoration: none !important; // needed but nasty
-      font-family: $sans-serif;
-    }
-
-    &:hover, &:active {
-      text-decoration: none !important; // needed but nasty
-      border-bottom: 1px dotted $link-color-d1;
-    }
+    @extend .mktg-copy-link;
+    font-family: $sans-serif !important;
   }
 
   strong {
@@ -175,7 +113,7 @@
     float: left;
 
     p, ol, ul {
-      font-size: 14px !important;
+      @extend .mktg-copy-detail;
     }
   }
 
@@ -194,8 +132,13 @@
       }
 
       h3 {
-        @extend .heading-4;
-        margin: 0 0 ($baseline/4) 0;
+        @include font-size(16);
+        color: $mktg-gray-d4;
+        margin-bottom: ($baseline/4) !important;
+      }
+
+      p {
+        @extend .mktg-copy-detail;
       }
     }
   }
@@ -204,7 +147,7 @@
   form {
 
     .instructions {
-      @extend .body-text-emphasized;
+      @extend .mktg-copy-base;
       margin-bottom: $baseline;
     }
 
@@ -249,33 +192,35 @@
 
       // elements
       label, input, textarea {
+        @extend .mktg-copy-base;
         border-radius: 0;
         display: block;
         height: auto;
-        font-family: $sans-serif;
         font-style: normal;
-        font-weight: 500;
-        color: $base-font-color;
       }
 
       label {
         @include transition(color 0.15s ease-in-out 0s);
         margin: 0 0 ($baseline/4) 0;
-        color: tint($black, 20%);
+        color: $mktg-gray-d4 !important;
+        font-weight: 500;
       }
 
       .tip {
+        @include font-size(13);
+        @include line-height(13);
         @include transition(color 0.15s ease-in-out 0s);
         display: block;
         margin-top: ($baseline/4);
-        color: $lighter-base-font-color;
-        font-size: em(13);
+        color: $mktg-gray-l2;
       }
 
       input, textarea {
         width: 100%;
         margin: 0;
         padding: ($baseline/2) ($baseline*.75);
+        color: $mktg-gray-d4 !important;
+        font-weight: 500;
 
         &.long {
           width: 100%;
@@ -340,11 +285,11 @@
       &.is-focused {
 
         label {
-          color: saturate($link-color-d1,15%);
+          color: $mktg-blue !important;
         }
 
         .tip {
-          color: saturate($link-color-d1,15%);
+          color: $mktg-blue;
         }
       }
 
@@ -359,7 +304,7 @@
       &.error {
 
         label {
-          color: $red;
+          color: $red !important;
         }
 
         input, textarea {
@@ -390,12 +335,15 @@
     @include clearfix();
 
     button[type="submit"] {
-      @extend .button-primary;
-
-      &:disabled, &.is-disabled {
-        opacity: 0.3;
-        cursor: default !important;
-      }
+      @extend .mktg-btn-primary-blue;
+      float: none;
+      display: block !important;
+      width: 100%;
+      text-transform: none !important;
+      vertical-align: middle;
+      letter-spacing: 0 !important;
+      font-weight: 600 !important;
+      line-height: auto;
     }
 
     .action-primary {
@@ -409,8 +357,6 @@
       float: right;
       width: flex-grid(3,8);
       margin: $baseline $baseline 0 0;
-      font-size: em(14);
-      text-align: right;
     }
 
     &.error {
@@ -427,15 +373,12 @@
     background: tint($yellow,20%);
 
     .message-title {
-      @extend .heading-4;
+      @extend .mktg-hd-lv4;
       margin: 0 0 ($baseline/4) 0;
-      font-size: em(14);
-      font-weight: 600;
-      color: $m-gray-d2 !important;
     }
 
     .message-copy {
-      @extend .body-text;
+      @extend .mktg-copy-base;
       margin: 0 !important;
       padding: 0;
       list-style: none;
@@ -492,7 +435,7 @@
 
     header {
       height: 120px;
-      border-bottom: 1px solid $m-gray;
+      border-bottom: 1px solid $mktg-gray;
       background: transparent $login-banner-image 0 0 no-repeat;
     }
   }
@@ -506,7 +449,7 @@
 
     header {
       height: 120px;
-      border-bottom: 1px solid $m-gray;
+      border-bottom: 1px solid $mktg-gray;
       background: transparent $register-banner-image 0 0 no-repeat;
     }
   }
@@ -560,7 +503,7 @@
       }
 
       h2 {
-        @extend .heading-2;
+        @extend .mktg-hd-lv2;
         text-align: left;
       }
     }
@@ -603,13 +546,29 @@
           float: none;
           display: block !important;
           width: 100%;
+          text-transform: none !important;
+          vertical-align: middle;
+          letter-spacing: 0 !important;
+          font-weight: 600 !important;
+          line-height: auto;
+        }
+
+        button[type="submit"] {
+          float: none;
+          display: block !important;
+          width: 100%;
+          text-transform: none !important;
+          vertical-align: middle;
+          letter-spacing: 0 !important;
+          font-weight: 600 !important;
+          line-height: auto;
         }
       }
     }
   }
 
   .modal-form-error {
-    @extend .body-text;
+    @extend .mktg-copy-base;
     box-shadow: inset 0 -1px 2px 0 tint($red, 85%);
     @include box-sizing(border-box);
     margin: $baseline 0 ($baseline/2) 0 !important;

--- a/lms/static/sass/multicourse/_account.scss
+++ b/lms/static/sass/multicourse/_account.scss
@@ -172,12 +172,16 @@
         display: block;
         float: left;
         border-bottom: none;
-        margin: 0 ($baseline*1.5) 0 0;
+        margin: 0 $baseline 0 0;
         padding-bottom: 0;
 
         input, textarea {
           width: 100%;
           font-weight: 600;
+        }
+
+        &:last-child {
+          margin-right: 0;
         }
       }
 
@@ -192,7 +196,7 @@
 
       // elements
       label, input, textarea {
-        @extend .mktg-copy-base;
+        @include font-size(15);
         border-radius: 0;
         display: block;
         height: auto;
@@ -342,7 +346,7 @@
       text-transform: none !important;
       vertical-align: middle;
       letter-spacing: 0 !important;
-      font-weight: 600 !important;
+      font-weight: 500 !important;
       line-height: auto;
     }
 

--- a/lms/static/sass/shared/_footer.scss
+++ b/lms/static/sass/shared/_footer.scss
@@ -1,6 +1,6 @@
 .wrapper-footer {
   box-shadow: 0 -1px 5px 0 rgba(0,0,0, 0.1);
-  border-top: 1px solid tint($m-gray,50%);
+  border-top: 1px solid tint($mktg-gray,50%);
   padding: 25px ($baseline/2) ($baseline*1.5) ($baseline/2);
   background: $footer-bg;
 
@@ -70,11 +70,11 @@
         }
 
         p {
+          @extend .mktg-copy-metadata;
           float: left;
           width: flex-grid(6,8);
           margin-left: $baseline;
           padding-left: $baseline;
-          font-size: em(13);
           background: transparent url(/static/images/bg-footer-divider.jpg) 0 0 no-repeat;
         }
       }
@@ -114,7 +114,7 @@
       .copyright {
         margin: -2px 0 8px 0;
         font-size: em(11);
-        color: tint($m-gray,50%);
+        color: tint($mktg-gray,50%);
         text-align: right;
       }
 

--- a/lms/static/sass/shared/_header.scss
+++ b/lms/static/sass/shared/_header.scss
@@ -1,5 +1,5 @@
 header.global {
-  border-bottom: 1px solid $m-gray;
+  border-bottom: 1px solid $mktg-gray;
   box-shadow: 0 1px 5px 0 rgba(0,0,0, 0.1);
   background: $header-bg;
   height: 76px;
@@ -278,26 +278,9 @@ header.global {
     li {
       display: inline-block;
 
-      a {
-        border-radius: 0;
-        @include linear-gradient(saturate($link-color-d1,15%) 5%, shade($link-color-d1,15%) 95%);
-        display: inline-block;
-        padding: $baseline/2 $baseline*2.5;
-        text-transform: lowercase;
-        color: $very-light-text;
-        letter-spacing: 0.1rem;
-        font-weight: 300;
-        cursor: pointer;
-        text-align: center;
-        border: none !important;
-        text-shadow: none;
-        letter-spacing: 0.1rem;
-        font-size: 14px;
-        box-shadow: none !important;
-
-        &:hover {
-          text-decoration: none;
-        }
+      .cta {
+        @extend .mktg-btn-primary-blue;
+        @include font-size(16);
       }
     }
 

--- a/lms/templates/login.html
+++ b/lms/templates/login.html
@@ -66,7 +66,7 @@
         $submitButton.
           removeClass('is-disabled').
           removeProp('disabled').
-          html('Log into My ${settings.PLATFORM_NAME} Account <span class="orn-plus">+</span> Access My Courses');
+          html('Log into My ${settings.PLATFORM_NAME} Account');
       }
       else {
         $submitButton.
@@ -158,19 +158,21 @@
     </div> -->
     % endif
 
-    <div class="cta cta-help">
+    <div class="cta cta-sign up">
       <h3>Not Enrolled?</h3>
       <p><a href="${reverse('register_user')}">Sign up for ${settings.PLATFORM_NAME} today!</a></p>
-
-      ## Disable help unless the FAQ marketing link is enabled
-      % if settings.MKTG_URL_LINK_MAP.get('FAQ'):
-        <h3>Need Help?</h3>
-        <p>Looking for help in logging in or with your ${settings.PLATFORM_NAME} account?
-        <a href="${marketing_link('FAQ')}">
-            View our help section for answers to commonly asked questions.
-        </a></p>
-      % endif
     </div>
+
+    ## Disable help unless the FAQ marketing link is enabled
+    % if settings.MKTG_URL_LINK_MAP.get('FAQ'):
+    <div class="cta cta-help">
+      <h3>Need Help?</h3>
+      <p>Looking for help in logging in or with your ${settings.PLATFORM_NAME} account?
+      <a href="${marketing_link('FAQ')}">
+          View our help section for answers to commonly asked questions.
+      </a></p>
+    </div>
+    % endif
   </aside>
   </section>
 

--- a/lms/templates/mktg_iframe.html
+++ b/lms/templates/mktg_iframe.html
@@ -26,7 +26,7 @@
   % endif
 
   <!-- repeated button styles needed for IE (copied from _shame.scss) -->
-  <style type="text/css" media="screen">
+  <!-- <style type="text/css" media="screen">
 
     .view-partial-mktgregister{background:transparent}.view-partial-mktgregister .wrapper-view{overflow:hidden}.view-partial-mktgregister .btn,.view-partial-mktgregister .btn-primary,.view-partial-mktgregister .action.action-register,.view-partial-mktgregister .action.access-courseware,.view-partial-mktgregister .btn-secondary,.view-partial-mktgregister .action.is-registered,.view-partial-mktgregister .action.registration-closed,.view-partial-mktgregister .btn-tertiary,.view-partial-mktgregister .action.coming-soon{-webkit-box-sizing:"border-box";-moz-box-sizing:"border-box";box-sizing:"border-box";display:block;padding:10px;text-transform:lowercase;color:#fff;letter-spacing:0.1rem;cursor:pointer;text-align:center;border:none !important;text-decoration:none;text-shadow:none;letter-spacing:0.1rem;font-size:17px;font-weight:300;box-shadow:0 !important}.view-partial-mktgregister .btn strong,.view-partial-mktgregister .btn-primary strong,.view-partial-mktgregister .action.action-register strong,.view-partial-mktgregister .action.access-courseware strong,.view-partial-mktgregister .btn-secondary strong,.view-partial-mktgregister .action.is-registered strong,.view-partial-mktgregister .action.registration-closed strong,.view-partial-mktgregister .btn-tertiary strong,.view-partial-mktgregister .action.coming-soon strong{font-weight:400;text-transform:none}.view-partial-mktgregister .btn-primary,.view-partial-mktgregister .action.action-register,.view-partial-mktgregister .action.access-courseware{background-color:#4697ec;background-image:-webkit-gradient(linear, left top, left bottom, color-stop(5%, #4697ec),color-stop(95%, #4880bb));background-image:-webkit-linear-gradient(#4697ec 5%,#4880bb 95%);background-image:linear-gradient(#4697ec 5%,#4880bb 95%)}.view-partial-mktgregister .btn-secondary,.view-partial-mktgregister .action.is-registered,.view-partial-mktgregister .action.registration-closed{background-color:#999;background-image:-webkit-gradient(linear, left top, left bottom, color-stop(5%, #999),color-stop(95%, #666));background-image:-webkit-linear-gradient(#999 5%,#666 95%);background-image:linear-gradient(#999 5%,#666 95%)}.view-partial-mktgregister .btn-tertiary,.view-partial-mktgregister .action.coming-soon{background:#e6f5fc;color:#5597dd}.view-partial-mktgregister .list-actions{list-style:none;margin:0;padding:0}.view-partial-mktgregister .list-actions .item{margin:0}.view-partial-mktgregister .action.is-registered,.view-partial-mktgregister .action.registration-closed{pointer-events:none !important}.view-partial-mktgregister .action.coming-soon{pointer-events:none !important;outline:none}
 
@@ -36,7 +36,7 @@
 
 
 
-  </style>
+  </style> -->
 </head>
 
 <body class="<%block name='bodyclass'></%block>">

--- a/lms/templates/register.html
+++ b/lms/templates/register.html
@@ -141,32 +141,32 @@
         </div>
 
         <ol class="list-input">
-          
+
           % if ask_for_email:
 
           <li class="field required text" id="field-email">
             <label for="email">E-mail</label>
             <input class="" id="email" type="email" name="email" value="" placeholder="example: username@domain.com" />
           </li>
-          
+
           % endif
-          
+
           <li class="field required text" id="field-username">
             <label for="username">Public Username</label>
             <input id="username" type="text" name="username" value="${extauth_username}" placeholder="example: JaneDoe" required aria-required="true" />
             <span class="tip tip-input">Will be shown in any discussions or forums you participate in</span>
           </li>
-          
+
           % if ask_for_fullname:
-          
+
           <li class="field required text" id="field-name">
             <label for="name">Full Name</label>
             <input id="name" type="text" name="name" value="" placeholder="example: Jane Doe" />
             <span class="tip tip-input">Needed for any certificates you may earn <strong>(cannot be changed later)</strong></span>
           </li>
-          
+
           % endif
-          
+
         </ol>
 
         % endif
@@ -282,7 +282,7 @@
         </a>
       </p>
     </div>
-      
+
     % endif
 
     ## TODO: Use a %block tag or something to allow themes to
@@ -303,6 +303,7 @@
       % endif
     </div>
 
+    ## Disable help unless the FAQ marketing link is enabled
     % if settings.MKTG_URL_LINK_MAP.get('FAQ'):
       <div class="cta cta-help">
         <h3>Need Help?</h3>


### PR DESCRIPTION
This pull request aims to sync up style revisions happening on edx.org with key edx.org marketing flow views within our app, including:
- Login
- Register
- iframe-based needed register/courseware access button

The changes are a bit sweeping, and I've added a lot of the same extends used to architect the edx.org FED to shame.scss. Also, a lot of overriding is written here to overcome to LMS' broken cascade/specificity and existing marketing site quick fixes With that said, I'm hoping these changes are scoped using the $mktg- prefix to variables and extends and that their longevity is fairly temporary (while we revamp edx.org further).

@frrrances - would you mind reviewing this from a code perspective

@caesar2164 - this may affect your work and Stanford's instance. Would you mind reviewing to make sure I did not change anything that negatively affects you or theming in general (there's even more variables now)?
