### PR TITLE
Revert "Use CodeJail with FSIZE support, and default to 50k"

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -312,8 +312,6 @@ CODE_JAIL = {
     'limits': {
         # How many CPU seconds can jailed code use?
         'CPU': 1,
-        # How large a file can jailed code write?
-        'FSIZE': 50000,
     },
 }
 

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -9,5 +9,5 @@
 
 # Our libraries:
 -e git+https://github.com/edx/XBlock.git@b697bebd45deebd0f868613fab6722a0460ca0c1#egg=XBlock
--e git+https://github.com/edx/codejail.git@c08967fb44d1bcdb259d3ec58812e3ac592539c2#egg=codejail
+-e git+https://github.com/edx/codejail.git@0a1b468#egg=codejail
 -e git+https://github.com/edx/diff-cover.git@v0.1.3#egg=diff_cover


### PR DESCRIPTION
This reverts commit 89c48f4a3047ca6cf0985b92e004fb584dd22a30.

Conflicts:
    requirements/edx/github.txt
