### PR TITLE
Blank common and advanced problems now display an inline score of "0 points" upon creation

### DIFF
--- a/common/lib/xmodule/xmodule/progress.py
+++ b/common/lib/xmodule/xmodule/progress.py
@@ -146,7 +146,7 @@ class Progress(object):
         sending Progress objects to js to limit dependencies.
         '''
         if progress is None:
-            return "NA"
+            return "0"
         return progress.ternary_str()
 
     @staticmethod
@@ -157,5 +157,5 @@ class Progress(object):
         passing Progress objects to js to limit dependencies.
         '''
         if progress is None:
-            return "NA"
+            return "0"
         return str(progress)

--- a/common/lib/xmodule/xmodule/tests/test_progress.py
+++ b/common/lib/xmodule/xmodule/tests/test_progress.py
@@ -90,15 +90,15 @@ class ProgressTest(unittest.TestCase):
         self.assertEqual(Progress.to_js_status_str(self.not_started), "none")
         self.assertEqual(Progress.to_js_status_str(self.half_done), "in_progress")
         self.assertEqual(Progress.to_js_status_str(self.done), "done")
-        self.assertEqual(Progress.to_js_status_str(None), "NA")
+        self.assertEqual(Progress.to_js_status_str(None), "0")
 
     def test_to_js_detail_str(self):
         '''Test the Progress.to_js_detail_str() method'''
         f = Progress.to_js_detail_str
         for p in (self.not_started, self.half_done, self.done):
             self.assertEqual(f(p), str(p))
-        # But None should be encoded as NA
-        self.assertEqual(f(None), "NA")
+        # But None should be encoded as 0
+        self.assertEqual(f(None), "0")
 
     def test_add(self):
         '''Test the Progress.add_counts() method'''


### PR DESCRIPTION
This resolves an issue discussed earlier in the week concerning inline scores. Blank common or advanced problems currently display an inline score of "NA points" upon creation because they contain no gradable content, and as such, assigning points to these problems is not valid. Sylvia Pierce and @sarina both mentioned it might make sense to switch the "NA" to "0", since there is "zero content" to grade. 

@sarina and @marcotuts, what do you think?
