### PR TITLE
Fix offline_gradecalc

### DIFF
--- a/lms/djangoapps/instructor/offline_gradecalc.py
+++ b/lms/djangoapps/instructor/offline_gradecalc.py
@@ -44,12 +44,14 @@ def offline_grade_calculation(course_id):
         def is_secure(self):
             return False
 
-    request = DummyRequest()
-
     print "%d enrolled students" % len(enrolled_students)
     course = get_course_by_id(course_id)
 
     for student in enrolled_students:
+        request = DummyRequest()
+        request.user = student
+        request.session = {}
+
         gradeset = grades.grade(student, request, course, keep_raw_scores=True)
         gs = enc.encode(gradeset)
         ocg, created = models.OfflineComputedGrade.objects.get_or_create(user=student, course_id=course_id)


### PR DESCRIPTION
Bug: Throws error when can't find a user on the request object for grading or can't find a session attribute.

Fix: Added to DummyRequest a user attribute with a value of the current student and a session attribute with a value of an empty dictionary.

@sefk 
@ormsbee 
@ichuang 
