### PR TITLE
Jonahstanley/upgrade chrome version

### DIFF
--- a/cms/djangoapps/contentstore/features/common.py
+++ b/cms/djangoapps/contentstore/features/common.py
@@ -242,9 +242,7 @@ def save_button_disabled(step):
 @step('I confirm the prompt')
 def confirm_the_prompt(step):
     prompt_css = 'a.button.action-primary'
-    world.wait_for(lambda _driver: world.css_visible(prompt_css))
-    world.css_click(prompt_css)
-    world.wait_for(lambda _driver: not world.css_visible(prompt_css))
+    world.css_click(prompt_css, success_condition=lambda: not world.css_visible(prompt_css))
 
 
 @step(u'I am shown a (.*)$')

--- a/cms/djangoapps/contentstore/features/common.py
+++ b/cms/djangoapps/contentstore/features/common.py
@@ -242,7 +242,9 @@ def save_button_disabled(step):
 @step('I confirm the prompt')
 def confirm_the_prompt(step):
     prompt_css = 'a.button.action-primary'
+    world.wait_for(lambda _driver: world.css_visible(prompt_css))
     world.css_click(prompt_css)
+    world.wait_for(lambda _driver: not world.css_visible(prompt_css))
 
 
 @step(u'I am shown a (.*)$')
@@ -252,6 +254,7 @@ def i_am_shown_a_notification(step, notification_type):
 
 def type_in_codemirror(index, text):
     world.css_click(".CodeMirror", index=index)
+    world.browser.execute_script("$('div.CodeMirror.CodeMirror-focused > div').css('overflow', '')")
     g = world.css_find("div.CodeMirror.CodeMirror-focused > div > textarea")
     if world.is_mac():
         g._element.send_keys(Keys.COMMAND + 'a')

--- a/cms/djangoapps/contentstore/features/component_settings_editor_helpers.py
+++ b/cms/djangoapps/contentstore/features/component_settings_editor_helpers.py
@@ -39,7 +39,7 @@ def click_component_from_menu(category, boilerplate, expected_css):
         elem_css = "a[data-category='{}']:not([data-boilerplate])".format(category)
     elements = world.css_find(elem_css)
     assert_equal(len(elements), 1)
-    world.css_click(elem_css)
+    world.css_click(elem_css, success_condition=lambda: 1 == len(world.css_find(expected_css)))
 
 
 @world.absorb

--- a/cms/djangoapps/contentstore/features/component_settings_editor_helpers.py
+++ b/cms/djangoapps/contentstore/features/component_settings_editor_helpers.py
@@ -13,6 +13,10 @@ def create_component_instance(step, component_button_css, category,
 
     click_new_component_button(step, component_button_css)
 
+    def animation_done(_driver):
+        return world.browser.evaluate_script("$('div.new-component').css('display')") == 'none'
+    world.wait_for(animation_done)
+
     if has_multiple_templates:
         click_component_from_menu(category, boilerplate, expected_css)
 
@@ -39,11 +43,13 @@ def click_component_from_menu(category, boilerplate, expected_css):
         elem_css = "a[data-category='{}']:not([data-boilerplate])".format(category)
     elements = world.css_find(elem_css)
     assert_equal(len(elements), 1)
+    world.wait_for(lambda _driver: world.css_visible(elem_css))
     world.css_click(elem_css, success_condition=lambda: 1 == len(world.css_find(expected_css)))
 
 
 @world.absorb
 def edit_component_and_select_settings():
+    world.wait_for(lambda _driver: world.css_visible('a.edit-button'))
     world.css_click('a.edit-button')
     world.css_click('#settings-mode')
 

--- a/cms/djangoapps/contentstore/features/component_settings_editor_helpers.py
+++ b/cms/djangoapps/contentstore/features/component_settings_editor_helpers.py
@@ -12,15 +12,16 @@ def create_component_instance(step, component_button_css, category,
                               has_multiple_templates=True):
 
     click_new_component_button(step, component_button_css)
-
-    def animation_done(_driver):
-        return world.browser.evaluate_script("$('div.new-component').css('display')") == 'none'
-    world.wait_for(animation_done)
+    if category == 'problem' or category == 'html':
+        def animation_done(_driver):
+            return world.browser.evaluate_script("$('div.new-component').css('display')") == 'none'
+        world.wait_for(animation_done)
 
     if has_multiple_templates:
         click_component_from_menu(category, boilerplate, expected_css)
 
     assert_equal(1, len(world.css_find(expected_css)))
+
 
 @world.absorb
 def click_new_component_button(step, component_button_css):

--- a/cms/djangoapps/contentstore/features/component_settings_editor_helpers.py
+++ b/cms/djangoapps/contentstore/features/component_settings_editor_helpers.py
@@ -12,7 +12,7 @@ def create_component_instance(step, component_button_css, category,
                               has_multiple_templates=True):
 
     click_new_component_button(step, component_button_css)
-    if category == 'problem' or category == 'html':
+    if category in ('problem', 'html'):
         def animation_done(_driver):
             return world.browser.evaluate_script("$('div.new-component').css('display')") == 'none'
         world.wait_for(animation_done)

--- a/cms/djangoapps/contentstore/features/problem-editor.py
+++ b/cms/djangoapps/contentstore/features/problem-editor.py
@@ -156,7 +156,7 @@ def cancel_does_not_save_changes(step):
 def create_latex_problem(step):
     world.click_new_component_button(step, '.large-problem-icon')
     # Go to advanced tab.
-    world.css_click('#ui-id-2')
+    world.css_click('#ui-id-2', success_condition=lambda: world.css_has_class('div.ui-tabs li', 'ui-state-active', index=1))
     world.click_component_from_menu("problem", "latex_problem.yaml", '.xmodule_CapaModule')
 
 

--- a/cms/djangoapps/contentstore/features/problem-editor.py
+++ b/cms/djangoapps/contentstore/features/problem-editor.py
@@ -155,8 +155,12 @@ def cancel_does_not_save_changes(step):
 @step('I have created a LaTeX Problem')
 def create_latex_problem(step):
     world.click_new_component_button(step, '.large-problem-icon')
+
+    def animation_done(_driver):
+            return world.browser.evaluate_script("$('div.new-component').css('display')") == 'none'
+    world.wait_for(animation_done)
     # Go to advanced tab.
-    world.css_click('#ui-id-2', success_condition=lambda: world.css_has_class('div.ui-tabs li', 'ui-state-active', index=1))
+    world.css_click('#ui-id-2')
     world.click_component_from_menu("problem", "latex_problem.yaml", '.xmodule_CapaModule')
 
 

--- a/cms/djangoapps/contentstore/features/problem-editor.py
+++ b/cms/djangoapps/contentstore/features/problem-editor.py
@@ -157,7 +157,7 @@ def create_latex_problem(step):
     world.click_new_component_button(step, '.large-problem-icon')
 
     def animation_done(_driver):
-            return world.browser.evaluate_script("$('div.new-component').css('display')") == 'none'
+        return world.browser.evaluate_script("$('div.new-component').css('display')") == 'none'
     world.wait_for(animation_done)
     # Go to advanced tab.
     world.css_click('#ui-id-2')

--- a/cms/djangoapps/contentstore/features/upload.py
+++ b/cms/djangoapps/contentstore/features/upload.py
@@ -58,7 +58,7 @@ def delete_file(_step, file_name):
     world.css_click(delete_css, index=index)
 
     prompt_confirm_css = 'li.nav-item > a.action-primary'
-    world.css_click(prompt_confirm_css)
+    world.css_click(prompt_confirm_css, success_condition=lambda: not world.css_visible(prompt_confirm_css))
 
 
 @step(u'I should see only one "([^"]*)"$')

--- a/cms/djangoapps/contentstore/features/video-editor.py
+++ b/cms/djangoapps/contentstore/features/video-editor.py
@@ -19,5 +19,6 @@ def i_see_the_correct_settings_and_values(step):
 @step('I have set "show captions" to (.*)')
 def set_show_captions(step, setting):
     world.css_click('a.edit-button')
+    world.wait_for(lambda _driver: world.css_visible('a.save-button'))
     world.browser.select('Show Captions', setting)
     world.css_click('a.save-button')

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -186,8 +186,8 @@ uses [Selenium](http://docs.seleniumhq.org/) to control the Chrome browser.
 
 **Prerequisite**: You must have [ChromeDriver](https://code.google.com/p/selenium/wiki/ChromeDriver)
 installed to run the tests in Chrome.  The tests are confirmed to run
-with Chrome (not Chromium) version 26.0.0.1410.63 with ChromeDriver
-version r195636.
+with Chrome (not Chromium) version 28.0.1500.71 with ChromeDriver
+version 2.1.210398.
 
 To run all the acceptance tests:
 

--- a/lms/djangoapps/courseware/features/homepage.py
+++ b/lms/djangoapps/courseware/features/homepage.py
@@ -8,7 +8,7 @@ from nose.tools import assert_in, assert_equals
 @step(u'I should see the following Partners in the Partners section')
 def i_should_see_partner(step):
     partners = world.browser.find_by_css(".partner .name span")
-    names = set(span.text for span in partners)
+    names = set(span.html for span in partners)
     for partner in step.hashes:
         assert_in(partner['Partner'], names)
 


### PR DESCRIPTION
suggested reviewers: @singingwolfboy @jzoldak 
The following features had issues with chrome/chrome driver versions

lms/djangoapps/courseware/features/homepage.feature
cms/djangoapps/contentstore/features/advanced-settings.feature
cms/djangoapps/contentstore/features/html-editor.feature
cms/djangoapps/contentstore/features/problem-editor.feature
cms/djangoapps/contentstore/features/section.feature
cms/djangoapps/contentstore/features/subsection.feature
cms/djangoapps/contentstore/features/upload.feature
cms/djangoapps/contentstore/features/video-editor.feature
cms/djangoapps/contentstore/features/video.feature

In order to fix these, the following things were changed:
1. In homepage.feature, partners could no longer be accessed with .text or .value so .html was used
2. Code mirror was very awkward to deal with and the place to accept user input is technically hidden so by making it visible, the previous interaction could be kept.
3. The other issues were fixed by adding implicit waits and success conditions to clicks.  These were mostly failing due to animation speeds.  One of the animation endings could only be detected through its styling, thus the evaluate_script is used in order to access it.

These changes were tested in chrome version 28.0.1500.71 and chromedriver 2.1.210398
testing.md was updated accordingly.  It is also important to note that this version of chromedriver is compatible with versions 27-30 meaning that it won't work with chrome 26 (what a lot of people might be running) explaining why both need to be updated at once.

All changes that were made should be backwards compatible due to the nature of the changes (since mostly only verification steps were added).  world.wait_for is an implicit wait so these tests shouldn't take any longer to run.
