### PR TITLE
Restrict us to less than distribute 0.7, which breaks setuptools

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -4,7 +4,7 @@ beautifulsoup4==4.1.3
 beautifulsoup==3.2.1
 boto==2.6.0
 celery==3.0.19
-distribute>=0.6.28
+distribute>=0.6.28, <0.7
 django-celery==3.0.17
 django-countries==1.5
 django-filter==0.6.0


### PR DESCRIPTION
@sarina @nedbat: Review?
