### PR TITLE
Rename CourseLocator.revision to branch

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_crud.py
+++ b/cms/djangoapps/contentstore/tests/test_crud.py
@@ -127,7 +127,7 @@ class TemplateTests(unittest.TestCase):
         persistent_factories.ItemFactory.create(display_name='chapter 1',
             parent_location=test_course.location)
 
-        id_locator = CourseLocator(course_id=test_course.location.course_id, revision='draft')
+        id_locator = CourseLocator(course_id=test_course.location.course_id, branch='draft')
         guid_locator = CourseLocator(version_guid=test_course.location.version_guid)
         # verify it can be retireved by id
         self.assertIsInstance(modulestore('split').get_course(id_locator), CourseDescriptor)

--- a/common/lib/xmodule/xmodule/modulestore/locator.py
+++ b/common/lib/xmodule/xmodule/modulestore/locator.py
@@ -91,13 +91,13 @@ class CourseLocator(Locator):
      CourseLocator(version_guid=ObjectId('519665f6223ebd6980884f2b'))
      CourseLocator(course_id='edu.mit.eecs.6002x')
      CourseLocator(course_id='edu.mit.eecs.6002x;published')
-     CourseLocator(course_id='edu.mit.eecs.6002x', revision='published')
+     CourseLocator(course_id='edu.mit.eecs.6002x', branch='published')
      CourseLocator(url='edx://@519665f6223ebd6980884f2b')
      CourseLocator(url='edx://edu.mit.eecs.6002x')
      CourseLocator(url='edx://edu.mit.eecs.6002x;published')
 
     Should have at lease a specific course_id (id for the course as if it were a project w/
-    versions) with optional 'revision' (must be 'draft', 'published', or None),
+    versions) with optional 'branch',
     or version_guid (which points to a specific version). Can contain both in which case
     the persistence layer may raise exceptions if the given version != the current such version
     of the course.
@@ -106,7 +106,7 @@ class CourseLocator(Locator):
     # Default values
     version_guid = None
     course_id = None
-    revision = None
+    branch = None
 
     def __unicode__(self):
         """
@@ -114,8 +114,8 @@ class CourseLocator(Locator):
         """
         if self.course_id:
             result = self.course_id
-            if self.revision:
-                result += ';' + self.revision
+            if self.branch:
+                result += ';' + self.branch
             return result
         elif self.version_guid:
             return '@' + str(self.version_guid)
@@ -131,7 +131,7 @@ class CourseLocator(Locator):
 
     # -- unused args which are used via inspect
     # pylint: disable= W0613
-    def validate_args(self, url, version_guid, course_id, revision):
+    def validate_args(self, url, version_guid, course_id, branch):
         """
         Validate provided arguments.
         """
@@ -144,12 +144,12 @@ class CourseLocator(Locator):
 
     def is_fully_specified(self):
         """
-        Returns True if either version_guid is specified, or course_id+revision
+        Returns True if either version_guid is specified, or course_id+branch
         are specified.
         This should always return True, since this should be validated in the constructor.
         """
         return self.version_guid is not None \
-            or (self.course_id is not None and self.revision is not None)
+            or (self.course_id is not None and self.branch is not None)
 
     def set_course_id(self, new):
         """
@@ -158,12 +158,12 @@ class CourseLocator(Locator):
         """
         self.set_property('course_id', new)
 
-    def set_revision(self, new):
+    def set_branch(self, new):
         """
-        Initialize revision to new value.
-        If revision has already been initialized to a different value, raise an exception.
+        Initialize branch to new value.
+        If branch has already been initialized to a different value, raise an exception.
         """
-        self.set_property('revision', new)
+        self.set_property('branch', new)
 
     def set_version_guid(self, new):
         """
@@ -181,29 +181,29 @@ class CourseLocator(Locator):
         """
         return CourseLocator(course_id=self.course_id,
                              version_guid=self.version_guid,
-                             revision=self.revision)
+                             branch=self.branch)
 
-    def __init__(self, url=None, version_guid=None, course_id=None, revision=None):
+    def __init__(self, url=None, version_guid=None, course_id=None, branch=None):
         """
         Construct a CourseLocator
         Caller may provide url (but no other parameters).
         Caller may provide version_guid (but no other parameters).
-        Caller may provide course_id (optionally provide revision).
+        Caller may provide course_id (optionally provide branch).
 
         Resulting CourseLocator will have either a version_guid property
-        or a course_id (with optional revision) property, or both.
+        or a course_id (with optional branch) property, or both.
 
         version_guid must be an instance of bson.objectid.ObjectId or None
-        url, course_id, and revision must be strings or None
+        url, course_id, and branch must be strings or None
 
         """
-        self.validate_args(url, version_guid, course_id, revision)
+        self.validate_args(url, version_guid, course_id, branch)
         if url:
             self.init_from_url(url)
         if version_guid:
             self.init_from_version_guid(version_guid)
-        if course_id or revision:
-            self.init_from_course_id(course_id, revision)
+        if course_id or branch:
+            self.init_from_course_id(course_id, branch)
         assert self.version_guid or self.course_id, \
             "Either version_guid or course_id should be set."
 
@@ -223,7 +223,7 @@ class CourseLocator(Locator):
     def init_from_url(self, url):
         """
         url must be a string beginning with 'edx://' and containing
-        either a valid version_guid or course_id (with optional revision)
+        either a valid version_guid or course_id (with optional branch)
         If a block ('#HW3') is present, it is ignored.
         """
         if isinstance(url, Locator):
@@ -237,7 +237,7 @@ class CourseLocator(Locator):
             self.set_version_guid(self.as_object_id(new_guid))
         else:
             self.set_course_id(parse['id'])
-            self.set_revision(parse['revision'])
+            self.set_branch(parse['branch'])
 
     def init_from_version_guid(self, version_guid):
         """
@@ -251,14 +251,14 @@ class CourseLocator(Locator):
             '%s is not an instance of ObjectId' % version_guid
         self.set_version_guid(version_guid)
 
-    def init_from_course_id(self, course_id, explicit_revision=None):
+    def init_from_course_id(self, course_id, explicit_branch=None):
         """
         Course_id is a string like 'edu.mit.eecs.6002x' or 'edu.mit.eecs.6002x;published'.
 
         Revision (optional) is a string like 'published'.
-        It may be provided explicitly (explicit_revision) or embedded into course_id.
-        If revision is part of course_id ("...;published"), parse it out separately.
-        If revision is provided both ways, that's ok as long as they are the same value.
+        It may be provided explicitly (explicit_branch) or embedded into course_id.
+        If branch is part of course_id ("...;published"), parse it out separately.
+        If branch is provided both ways, that's ok as long as they are the same value.
 
         If a block ('#HW3') is a part of course_id, it is ignored.
 
@@ -272,11 +272,11 @@ class CourseLocator(Locator):
             parse = parse_course_id(course_id)
             assert parse, 'Could not parse "%s" as a course_id' % course_id
             self.set_course_id(parse['id'])
-            rev = parse['revision']
+            rev = parse['branch']
             if rev:
-                self.set_revision(rev)
-        if explicit_revision:
-            self.set_revision(explicit_revision)
+                self.set_branch(rev)
+        if explicit_branch:
+            self.set_branch(explicit_branch)
 
     def version(self):
         """
@@ -305,37 +305,37 @@ class BlockUsageLocator(CourseLocator):
     the defined element in the course. Courses can be a version of an offering, the
     current draft head, or the current production version.
 
-    Locators can contain both a version and a course_id w/ revision. The split mongo functions
-    may raise errors if these conflict w/ the current db state (i.e., the course's revision !=
+    Locators can contain both a version and a course_id w/ branch. The split mongo functions
+    may raise errors if these conflict w/ the current db state (i.e., the course's branch !=
     the version_guid)
 
     Locations can express as urls as well as dictionaries. They consist of
         course_identifier: course_guid | version_guid
         block : guid
-        revision : 'draft' | 'published' (optional)
+        branch : string
     """
 
     # Default value
     usage_id = None
 
     def __init__(self, url=None, version_guid=None, course_id=None,
-                 revision=None, usage_id=None):
+                 branch=None, usage_id=None):
         """
         Construct a BlockUsageLocator
-        Caller may provide url, version_guid, or course_id, and optionally provide revision.
+        Caller may provide url, version_guid, or course_id, and optionally provide branch.
 
         The usage_id may be specified, either explictly or as part of
         the url or course_id. If omitted, the locator is created but it
         has not yet been initialized.
 
         Resulting BlockUsageLocator will have a usage_id property.
-        It will have either a version_guid property or a course_id (with optional revision) property, or both.
+        It will have either a version_guid property or a course_id (with optional branch) property, or both.
 
         version_guid must be an instance of bson.objectid.ObjectId or None
-        url, course_id, revision, and usage_id must be strings or None
+        url, course_id, branch, and usage_id must be strings or None
 
         """
-        self.validate_args(url, version_guid, course_id, revision)
+        self.validate_args(url, version_guid, course_id, branch)
         if url:
             self.init_block_ref_from_url(url)
         if course_id:
@@ -346,7 +346,7 @@ class BlockUsageLocator(CourseLocator):
                                url=url,
                                version_guid=version_guid,
                                course_id=course_id,
-                               revision=revision)
+                               branch=branch)
 
     def is_initialized(self):
         """
@@ -366,11 +366,11 @@ class BlockUsageLocator(CourseLocator):
         """
         if self.course_id and self.version_guid:
             return BlockUsageLocator(version_guid=self.version_guid,
-                                     revision=self.revision,
+                                     branch=self.branch,
                                      usage_id=self.usage_id)
         else:
             return BlockUsageLocator(course_id=self.course_id,
-                                     revision=self.revision,
+                                     branch=self.branch,
                                      usage_id=self.usage_id)
 
     def set_usage_id(self, new):

--- a/common/lib/xmodule/xmodule/modulestore/locator.py
+++ b/common/lib/xmodule/xmodule/modulestore/locator.py
@@ -45,7 +45,7 @@ class Locator(object):
 
     def __repr__(self):
         '''
-        repr(self) returns something like this: CourseLocator("edu.mit.eecs.6002x")
+        repr(self) returns something like this: CourseLocator("mit.eecs.6002x")
         '''
         classname = self.__class__.__name__
         if classname.find('.') != -1:
@@ -54,13 +54,13 @@ class Locator(object):
 
     def __str__(self):
         '''
-        str(self) returns something like this: "edu.mit.eecs.6002x"
+        str(self) returns something like this: "mit.eecs.6002x"
         '''
         return unicode(self).encode('utf8')
 
     def __unicode__(self):
         '''
-        unicode(self) returns something like this: "edu.mit.eecs.6002x"
+        unicode(self) returns something like this: "mit.eecs.6002x"
         '''
         return self.url()
 
@@ -89,12 +89,12 @@ class CourseLocator(Locator):
     """
     Examples of valid CourseLocator specifications:
      CourseLocator(version_guid=ObjectId('519665f6223ebd6980884f2b'))
-     CourseLocator(course_id='edu.mit.eecs.6002x')
-     CourseLocator(course_id='edu.mit.eecs.6002x;published')
-     CourseLocator(course_id='edu.mit.eecs.6002x', branch='published')
+     CourseLocator(course_id='mit.eecs.6002x')
+     CourseLocator(course_id='mit.eecs.6002x;published')
+     CourseLocator(course_id='mit.eecs.6002x', branch='published')
      CourseLocator(url='edx://@519665f6223ebd6980884f2b')
-     CourseLocator(url='edx://edu.mit.eecs.6002x')
-     CourseLocator(url='edx://edu.mit.eecs.6002x;published')
+     CourseLocator(url='edx://mit.eecs.6002x')
+     CourseLocator(url='edx://mit.eecs.6002x;published')
 
     Should have at lease a specific course_id (id for the course as if it were a project w/
     versions) with optional 'branch',
@@ -253,7 +253,7 @@ class CourseLocator(Locator):
 
     def init_from_course_id(self, course_id, explicit_branch=None):
         """
-        Course_id is a string like 'edu.mit.eecs.6002x' or 'edu.mit.eecs.6002x;published'.
+        Course_id is a string like 'mit.eecs.6002x' or 'mit.eecs.6002x;published'.
 
         Revision (optional) is a string like 'published'.
         It may be provided explicitly (explicit_branch) or embedded into course_id.

--- a/common/lib/xmodule/xmodule/modulestore/parsers.py
+++ b/common/lib/xmodule/xmodule/modulestore/parsers.py
@@ -20,7 +20,7 @@ def parse_url(string):
     with key 'version_guid' and the value,
 
     If it can be parsed as a course_id, returns a dict
-    with keys 'id' and 'revision' (value of 'revision' may be None),
+    with keys 'id' and 'branch' (value of 'branch' may be None),
 
     """
     match = URL_RE.match(string)
@@ -69,14 +69,14 @@ def parse_guid(string):
         return None
 
 
-COURSE_ID_RE = re.compile(r'^(?P<id>(\w+)(\.\w+\w*)*)(;(?P<revision>\w+))?(#(?P<block>\w+))?$', re.IGNORECASE)
+COURSE_ID_RE = re.compile(r'^(?P<id>(\w+)(\.\w+\w*)*)(;(?P<branch>\w+))?(#(?P<block>\w+))?$', re.IGNORECASE)
 
 
 def parse_course_id(string):
     r"""
 
     A course_id has a main id component.
-    There may also be an optional revision (;published or ;draft).
+    There may also be an optional branch (;published or ;draft).
     There may also be an optional block (#HW3 or #Quiz2).
 
     Examples of valid course_ids:
@@ -89,11 +89,11 @@ def parse_course_id(string):
 
     Syntax:
 
-      course_id = main_id [; revision] [# block]
+      course_id = main_id [; branch] [# block]
 
       main_id = name [. name]*
 
-      revision = name
+      branch = name
 
       block = name
 
@@ -104,8 +104,8 @@ def parse_course_id(string):
     and the underscore. (see definition of \w in python regular expressions,
     at http://docs.python.org/dev/library/re.html)
 
-    If string is a course_id, returns a dict with keys 'id', 'revision', and 'block'.
-    Revision is optional: if missing returned_dict['revision'] is None.
+    If string is a course_id, returns a dict with keys 'id', 'branch', and 'block'.
+    Revision is optional: if missing returned_dict['branch'] is None.
     Block is optional: if missing returned_dict['block'] is None.
     Else returns None.
     """

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/caching_descriptor_system.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/caching_descriptor_system.py
@@ -81,7 +81,7 @@ class CachingDescriptorSystem(MakoDescriptorSystem):
             version_guid=course_entry_override['_id'],
             usage_id=usage_id,
             course_id=course_entry_override.get('course_id'),
-            revision=course_entry_override.get('revision')
+            branch=course_entry_override.get('branch')
         )
 
         kvs = SplitMongoKVS(

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_locators.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_locators.py
@@ -23,7 +23,7 @@ class LocatorTest(TestCase):
             CourseLocator,
             url='edx://edu.mit.eecs.6002x',
             course_id='edu.harvard.history',
-            revision='published',
+            branch='published',
             version_guid=ObjectId())
         self.assertRaises(
             OverSpecificationError,
@@ -35,16 +35,16 @@ class LocatorTest(TestCase):
             OverSpecificationError,
             CourseLocator,
             url='edx://edu.mit.eecs.6002x;published',
-            revision='draft')
+            branch='draft')
         self.assertRaises(
             OverSpecificationError,
             CourseLocator,
             course_id='edu.mit.eecs.6002x;published',
-            revision='draft')
+            branch='draft')
 
     def test_course_constructor_underspecified(self):
         self.assertRaises(InsufficientSpecificationError, CourseLocator)
-        self.assertRaises(InsufficientSpecificationError, CourseLocator, revision='published')
+        self.assertRaises(InsufficientSpecificationError, CourseLocator, branch='published')
 
     def test_course_constructor_bad_version_guid(self):
         self.assertRaises(ValueError, CourseLocator, version_guid="012345")
@@ -114,9 +114,9 @@ class LocatorTest(TestCase):
         testobj = CourseLocator(course_id=testurn, url='edx://' + testurn)
         self.check_course_locn_fields(testobj, 'course_id',
                                       course_id=expected_urn,
-                                      revision=expected_rev)
+                                      branch=expected_rev)
 
-    def test_course_constructor_course_id_no_revision(self):
+    def test_course_constructor_course_id_no_branch(self):
         testurn = 'edu.mit.eecs.6002x'
         testobj = CourseLocator(course_id=testurn)
         self.check_course_locn_fields(testobj, 'course_id', course_id=testurn)
@@ -124,61 +124,61 @@ class LocatorTest(TestCase):
         self.assertEqual(str(testobj), testurn)
         self.assertEqual(testobj.url(), 'edx://' + testurn)
 
-    def test_course_constructor_course_id_with_revision(self):
+    def test_course_constructor_course_id_with_branch(self):
         testurn = 'edu.mit.eecs.6002x;published'
         expected_id = 'edu.mit.eecs.6002x'
-        expected_revision = 'published'
+        expected_branch = 'published'
         testobj = CourseLocator(course_id=testurn)
-        self.check_course_locn_fields(testobj, 'course_id with revision',
+        self.check_course_locn_fields(testobj, 'course_id with branch',
                                       course_id=expected_id,
-                                      revision=expected_revision,
+                                      branch=expected_branch,
                                       )
         self.assertEqual(testobj.course_id, expected_id)
-        self.assertEqual(testobj.revision, expected_revision)
+        self.assertEqual(testobj.branch, expected_branch)
         self.assertEqual(str(testobj), testurn)
         self.assertEqual(testobj.url(), 'edx://' + testurn)
 
-    def test_course_constructor_course_id_separate_revision(self):
+    def test_course_constructor_course_id_separate_branch(self):
         test_id = 'edu.mit.eecs.6002x'
-        test_revision = 'published'
+        test_branch = 'published'
         expected_urn = 'edu.mit.eecs.6002x;published'
-        testobj = CourseLocator(course_id=test_id, revision=test_revision)
-        self.check_course_locn_fields(testobj, 'course_id with separate revision',
+        testobj = CourseLocator(course_id=test_id, branch=test_branch)
+        self.check_course_locn_fields(testobj, 'course_id with separate branch',
                                       course_id=test_id,
-                                      revision=test_revision,
+                                      branch=test_branch,
                                       )
         self.assertEqual(testobj.course_id, test_id)
-        self.assertEqual(testobj.revision, test_revision)
+        self.assertEqual(testobj.branch, test_branch)
         self.assertEqual(str(testobj), expected_urn)
         self.assertEqual(testobj.url(), 'edx://' + expected_urn)
 
-    def test_course_constructor_course_id_repeated_revision(self):
+    def test_course_constructor_course_id_repeated_branch(self):
         """
-        The same revision appears in the course_id and the revision field.
+        The same branch appears in the course_id and the branch field.
         """
         test_id = 'edu.mit.eecs.6002x;published'
-        test_revision = 'published'
+        test_branch = 'published'
         expected_id = 'edu.mit.eecs.6002x'
         expected_urn = 'edu.mit.eecs.6002x;published'
-        testobj = CourseLocator(course_id=test_id, revision=test_revision)
-        self.check_course_locn_fields(testobj, 'course_id with repeated revision',
+        testobj = CourseLocator(course_id=test_id, branch=test_branch)
+        self.check_course_locn_fields(testobj, 'course_id with repeated branch',
                                       course_id=expected_id,
-                                      revision=test_revision,
+                                      branch=test_branch,
                                       )
         self.assertEqual(testobj.course_id, expected_id)
-        self.assertEqual(testobj.revision, test_revision)
+        self.assertEqual(testobj.branch, test_branch)
         self.assertEqual(str(testobj), expected_urn)
         self.assertEqual(testobj.url(), 'edx://' + expected_urn)
 
     def test_block_constructor(self):
         testurn = 'edu.mit.eecs.6002x;published#HW3'
         expected_id = 'edu.mit.eecs.6002x'
-        expected_revision = 'published'
+        expected_branch = 'published'
         expected_block_ref = 'HW3'
         testobj = BlockUsageLocator(course_id=testurn)
         self.check_block_locn_fields(testobj, 'test_block constructor',
                                      course_id=expected_id,
-                                     revision=expected_revision,
+                                     branch=expected_branch,
                                      block=expected_block_ref)
         self.assertEqual(str(testobj), testurn)
         self.assertEqual(testobj.url(), 'edx://' + testurn)
@@ -225,10 +225,10 @@ class LocatorTest(TestCase):
         testobj = CourseLocator(testurn)
         self.check_course_locn_fields(testobj, testurn, course_id='courseid')
 
-        testurn = 'crx/courseid@revision/blockid'
+        testurn = 'crx/courseid@branch/blockid'
         testobj = CourseLocator(testurn)
         self.check_course_locn_fields(testobj, testurn, course_id='courseid',
-                                      revision='revision')
+                                      branch='branch')
         self.assertEqual(testobj, CourseLocator(testobj),
                          'run initialization from another instance')
 
@@ -242,23 +242,23 @@ class LocatorTest(TestCase):
         self.check_course_locn_fields(testobj, 'courseid arg',
                                       course_id='courseid')
 
-        testobj = CourseLocator(course_id='courseid', revision='rev')
+        testobj = CourseLocator(course_id='courseid', branch='rev')
         self.check_course_locn_fields(testobj, 'rev arg',
                                       course_id='courseid',
-                                      revision='rev')
+                                      branch='rev')
         # ignores garbage
-        testobj = CourseLocator(course_id='courseid', revision='rev',
+        testobj = CourseLocator(course_id='courseid', branch='rev',
                                 potato='spud')
         self.check_course_locn_fields(testobj, 'extra keyword arg',
                                       course_id='courseid',
-                                      revision='rev')
+                                      branch='rev')
 
         # url w/ keyword override
-        testurn = 'crx/courseid@revision/blockid'
-        testobj = CourseLocator(testurn, revision='rev')
+        testurn = 'crx/courseid@branch/blockid'
+        testobj = CourseLocator(testurn, branch='rev')
         self.check_course_locn_fields(testobj, 'rev override',
                                       course_id='courseid',
-                                      revision='rev')
+                                      branch='rev')
 
     def test_course_dict(self):
         raise SkipTest()
@@ -270,29 +270,29 @@ class LocatorTest(TestCase):
         self.check_course_locn_fields(testobj, 'courseid dict',
                                       course_id='courseid')
 
-        testobj = CourseLocator({"course_id": 'courseid', "revision": 'rev'})
+        testobj = CourseLocator({"course_id": 'courseid', "branch": 'rev'})
         self.check_course_locn_fields(testobj, 'rev dict',
                                       course_id='courseid',
-                                      revision='rev')
+                                      branch='rev')
         # ignores garbage
-        testobj = CourseLocator({"course_id": 'courseid', "revision": 'rev',
+        testobj = CourseLocator({"course_id": 'courseid', "branch": 'rev',
                                  "potato": 'spud'})
         self.check_course_locn_fields(testobj, 'extra keyword dict',
                                       course_id='courseid',
-                                      revision='rev')
-        testobj = CourseLocator({"course_id": 'courseid', "revision": 'rev'},
-                                revision='alt')
+                                      branch='rev')
+        testobj = CourseLocator({"course_id": 'courseid', "branch": 'rev'},
+                                branch='alt')
         self.check_course_locn_fields(testobj, 'rev dict',
                                       course_id='courseid',
-                                      revision='alt')
+                                      branch='alt')
 
         # urn init w/ dict & keyword overwrites
         testobj = CourseLocator('crx/notcourse@notthis',
                                 {"course_id": 'courseid'},
-                                revision='alt')
+                                branch='alt')
         self.check_course_locn_fields(testobj, 'rev dict',
                                       course_id='courseid',
-                                      revision='alt')
+                                      branch='alt')
 
     def test_url(self):
         '''
@@ -310,7 +310,7 @@ class LocatorTest(TestCase):
         self.assertEqual(testobj, CourseLocator(testobj.url()),
                          'courseid conversion through url')
 
-        testobj = CourseLocator(course_id='courseid', revision='rev')
+        testobj = CourseLocator(course_id='courseid', branch='rev')
         self.assertEqual(testobj.url(), 'crx/courseid@rev', 'rev')
         self.assertEqual(testobj, CourseLocator(testobj.url()),
                          'rev conversion through url')
@@ -330,7 +330,7 @@ class LocatorTest(TestCase):
         self.assertEqual(testobj, CourseLocator(testobj.html_id()),
                          'courseid conversion through html_id')
 
-        testobj = CourseLocator(course_id='courseid', revision='rev')
+        testobj = CourseLocator(course_id='courseid', branch='rev')
         self.assertEqual(testobj.html_id(), 'crx/courseid%40rev', 'rev')
         self.assertEqual(testobj, CourseLocator(testobj.html_id()),
                          'rev conversion through html_id')
@@ -379,10 +379,10 @@ class LocatorTest(TestCase):
         self.check_block_locn_fields(testobj, testurn, course_id='courseid',
                                      block='blockid')
 
-        testurn = 'crx/courseid@revision/blockid'
+        testurn = 'crx/courseid@branch/blockid'
         testobj = BlockUsageLocator(testurn)
         self.check_block_locn_fields(testobj, testurn, course_id='courseid',
-                                     revision='revision', block='blockid')
+                                     branch='branch', block='blockid')
         self.assertEqual(testobj, BlockUsageLocator(testobj),
                          'run initialization from another instance')
 
@@ -400,22 +400,22 @@ class LocatorTest(TestCase):
         self.check_block_locn_fields(testobj, 'courseid arg',
                                      course_id='courseid')
 
-        testobj = BlockUsageLocator(course_id='courseid', revision='rev')
+        testobj = BlockUsageLocator(course_id='courseid', branch='rev')
         self.check_block_locn_fields(testobj, 'rev arg',
                                      course_id='courseid',
-                                     revision='rev')
+                                     branch='rev')
         # ignores garbage
-        testobj = BlockUsageLocator(course_id='courseid', revision='rev',
+        testobj = BlockUsageLocator(course_id='courseid', branch='rev',
                                     usage_id='this_block', potato='spud')
         self.check_block_locn_fields(testobj, 'extra keyword arg',
-                                     course_id='courseid', block='this_block', revision='rev')
+                                     course_id='courseid', block='this_block', branch='rev')
 
         # url w/ keyword override
-        testurn = 'crx/courseid@revision/blockid'
-        testobj = BlockUsageLocator(testurn, revision='rev')
+        testurn = 'crx/courseid@branch/blockid'
+        testobj = BlockUsageLocator(testurn, branch='rev')
         self.check_block_locn_fields(testobj, 'rev override',
                                      course_id='courseid', block='blockid',
-                                     revision='rev')
+                                     branch='rev')
 
     def test_block_keywords(self):
         # dict init w/ keyword overwrites
@@ -430,29 +430,29 @@ class LocatorTest(TestCase):
         self.check_block_locn_fields(testobj, 'courseid dict',
                                      block='dictblock', course_id='courseid')
 
-        testobj = BlockUsageLocator({"course_id": 'courseid', "revision": 'rev',
+        testobj = BlockUsageLocator({"course_id": 'courseid', "branch": 'rev',
                                      'usage_id': 'dictblock'})
         self.check_block_locn_fields(testobj, 'rev dict',
                                      course_id='courseid', block='dictblock',
-                                     revision='rev')
+                                     branch='rev')
         # ignores garbage
-        testobj = BlockUsageLocator({"course_id": 'courseid', "revision": 'rev',
+        testobj = BlockUsageLocator({"course_id": 'courseid', "branch": 'rev',
                                      'usage_id': 'dictblock', "potato": 'spud'})
         self.check_block_locn_fields(testobj, 'extra keyword dict',
                                      course_id='courseid', block='dictblock',
-                                     revision='rev')
-        testobj = BlockUsageLocator({"course_id": 'courseid', "revision": 'rev',
-                                     'usage_id': 'dictblock'}, revision='alt', usage_id='anotherblock')
+                                     branch='rev')
+        testobj = BlockUsageLocator({"course_id": 'courseid', "branch": 'rev',
+                                     'usage_id': 'dictblock'}, branch='alt', usage_id='anotherblock')
         self.check_block_locn_fields(testobj, 'rev dict',
                                      course_id='courseid', block='anotherblock',
-                                     revision='alt')
+                                     branch='alt')
 
         # urn init w/ dict & keyword overwrites
         testobj = BlockUsageLocator('crx/notcourse@notthis/northis',
-                                    {"course_id": 'courseid'}, revision='alt', usage_id='anotherblock')
+                                    {"course_id": 'courseid'}, branch='alt', usage_id='anotherblock')
         self.check_block_locn_fields(testobj, 'rev dict',
                                      course_id='courseid', block='anotherblock',
-                                     revision='alt')
+                                     branch='alt')
 
     def test_ensure_fully_specd(self):
         '''
@@ -494,7 +494,7 @@ class LocatorTest(TestCase):
         self.assertIsInstance(BlockUsageLocator.ensure_fully_specified(testurn),
                               BlockUsageLocator, testurn)
 
-        testurn = 'crx/courseid@revision/blockid'
+        testurn = 'crx/courseid@branch/blockid'
         self.assertIsInstance(BlockUsageLocator.ensure_fully_specified(testurn),
                               BlockUsageLocator, testurn)
 
@@ -505,7 +505,7 @@ class LocatorTest(TestCase):
         self.assertRaises(InsufficientSpecificationError,
                           BlockUsageLocator.ensure_fully_specified, testobj)
 
-        testurn = 'crx/courseid@revision/blockid'
+        testurn = 'crx/courseid@branch/blockid'
         testobj = BlockUsageLocator(version_guid='versionid', usage_id='myblock')
         self.assertIsInstance(BlockUsageLocator.ensure_fully_specified(testurn),
                               BlockUsageLocator, testurn)
@@ -514,11 +514,11 @@ class LocatorTest(TestCase):
         self.assertRaises(InsufficientSpecificationError,
                           BlockUsageLocator.ensure_fully_specified, testobj)
 
-        testobj = BlockUsageLocator(course_id='courseid', revision='rev')
+        testobj = BlockUsageLocator(course_id='courseid', branch='rev')
         self.assertRaises(InsufficientSpecificationError,
                           BlockUsageLocator.ensure_fully_specified, testobj)
 
-        testobj = BlockUsageLocator(course_id='courseid', revision='rev',
+        testobj = BlockUsageLocator(course_id='courseid', branch='rev',
                                     usage_id='this_block')
         self.assertIsInstance(BlockUsageLocator.ensure_fully_specified(testurn),
                               BlockUsageLocator, testurn)
@@ -527,13 +527,13 @@ class LocatorTest(TestCase):
     # Utilities
 
     def check_course_locn_fields(self, testobj, msg, version_guid=None,
-                                 course_id=None, revision=None):
+                                 course_id=None, branch=None):
         self.assertEqual(testobj.version_guid, version_guid, msg)
         self.assertEqual(testobj.course_id, course_id, msg)
-        self.assertEqual(testobj.revision, revision, msg)
+        self.assertEqual(testobj.branch, branch, msg)
 
     def check_block_locn_fields(self, testobj, msg, version_guid=None,
-                                course_id=None, revision=None, block=None):
+                                course_id=None, branch=None, block=None):
         self.check_course_locn_fields(testobj, msg, version_guid, course_id,
-                                      revision)
+                                      branch)
         self.assertEqual(testobj.usage_id, block)

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_locators.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_locators.py
@@ -4,12 +4,10 @@ Created on Mar 14, 2013
 @author: dmitchell
 '''
 from unittest import TestCase
-from nose.plugins.skip import SkipTest
 
 from bson.objectid import ObjectId
 from xmodule.modulestore.locator import Locator, CourseLocator, BlockUsageLocator
-from xmodule.modulestore.exceptions import InvalidLocationError, \
-    InsufficientSpecificationError, OverSpecificationError
+from xmodule.modulestore.exceptions import InsufficientSpecificationError, OverSpecificationError
 
 
 class LocatorTest(TestCase):
@@ -21,25 +19,25 @@ class LocatorTest(TestCase):
         self.assertRaises(
             OverSpecificationError,
             CourseLocator,
-            url='edx://edu.mit.eecs.6002x',
-            course_id='edu.harvard.history',
+            url='edx://mit.eecs.6002x',
+            course_id='harvard.history',
             branch='published',
             version_guid=ObjectId())
         self.assertRaises(
             OverSpecificationError,
             CourseLocator,
-            url='edx://edu.mit.eecs.6002x',
-            course_id='edu.harvard.history',
+            url='edx://mit.eecs.6002x',
+            course_id='harvard.history',
             version_guid=ObjectId())
         self.assertRaises(
             OverSpecificationError,
             CourseLocator,
-            url='edx://edu.mit.eecs.6002x;published',
+            url='edx://mit.eecs.6002x;published',
             branch='draft')
         self.assertRaises(
             OverSpecificationError,
             CourseLocator,
-            course_id='edu.mit.eecs.6002x;published',
+            course_id='mit.eecs.6002x;published',
             branch='draft')
 
     def test_course_constructor_underspecified(self):
@@ -73,43 +71,43 @@ class LocatorTest(TestCase):
         """
         Test all sorts of badly-formed course_ids (and urls with those course_ids)
         """
-        for bad_id in ('edu.mit.',
-                       ' edu.mit.eecs',
-                       'edu.mit.eecs ',
-                       '@edu.mit.eecs',
-                       '#edu.mit.eecs',
-                       'edu.mit.ee cs',
-                       'edu.mit.ee,cs',
-                       'edu.mit.ee/cs',
-                       'edu.mit.ee$cs',
-                       'edu.mit.ee&cs',
-                       'edu.mit.ee()cs',
+        for bad_id in ('mit.',
+                       ' mit.eecs',
+                       'mit.eecs ',
+                       '@mit.eecs',
+                       '#mit.eecs',
+                       'mit.ee cs',
+                       'mit.ee,cs',
+                       'mit.ee/cs',
+                       'mit.ee$cs',
+                       'mit.ee&cs',
+                       'mit.ee()cs',
                        ';this',
-                       'edu.mit.eecs;',
-                       'edu.mit.eecs;this;that',
-                       'edu.mit.eecs;this;',
-                       'edu.mit.eecs;this ',
-                       'edu.mit.eecs;th%is ',
+                       'mit.eecs;',
+                       'mit.eecs;this;that',
+                       'mit.eecs;this;',
+                       'mit.eecs;this ',
+                       'mit.eecs;th%is ',
                        ):
             self.assertRaises(AssertionError, CourseLocator, course_id=bad_id)
             self.assertRaises(AssertionError, CourseLocator, url='edx://' + bad_id)
 
     def test_course_constructor_bad_url(self):
         for bad_url in ('edx://',
-                        'edx:/edu.mit.eecs',
-                        'http://edu.mit.eecs',
-                        'edu.mit.eecs',
-                        'edx//edu.mit.eecs'):
+                        'edx:/mit.eecs',
+                        'http://mit.eecs',
+                        'mit.eecs',
+                        'edx//mit.eecs'):
             self.assertRaises(AssertionError, CourseLocator, url=bad_url)
 
     def test_course_constructor_redundant_001(self):
-        testurn = 'edu.mit.eecs.6002x'
+        testurn = 'mit.eecs.6002x'
         testobj = CourseLocator(course_id=testurn, url='edx://' + testurn)
         self.check_course_locn_fields(testobj, 'course_id', course_id=testurn)
 
     def test_course_constructor_redundant_002(self):
-        testurn = 'edu.mit.eecs.6002x;published'
-        expected_urn = 'edu.mit.eecs.6002x'
+        testurn = 'mit.eecs.6002x;published'
+        expected_urn = 'mit.eecs.6002x'
         expected_rev = 'published'
         testobj = CourseLocator(course_id=testurn, url='edx://' + testurn)
         self.check_course_locn_fields(testobj, 'course_id',
@@ -117,7 +115,7 @@ class LocatorTest(TestCase):
                                       branch=expected_rev)
 
     def test_course_constructor_course_id_no_branch(self):
-        testurn = 'edu.mit.eecs.6002x'
+        testurn = 'mit.eecs.6002x'
         testobj = CourseLocator(course_id=testurn)
         self.check_course_locn_fields(testobj, 'course_id', course_id=testurn)
         self.assertEqual(testobj.course_id, testurn)
@@ -125,8 +123,8 @@ class LocatorTest(TestCase):
         self.assertEqual(testobj.url(), 'edx://' + testurn)
 
     def test_course_constructor_course_id_with_branch(self):
-        testurn = 'edu.mit.eecs.6002x;published'
-        expected_id = 'edu.mit.eecs.6002x'
+        testurn = 'mit.eecs.6002x;published'
+        expected_id = 'mit.eecs.6002x'
         expected_branch = 'published'
         testobj = CourseLocator(course_id=testurn)
         self.check_course_locn_fields(testobj, 'course_id with branch',
@@ -139,9 +137,9 @@ class LocatorTest(TestCase):
         self.assertEqual(testobj.url(), 'edx://' + testurn)
 
     def test_course_constructor_course_id_separate_branch(self):
-        test_id = 'edu.mit.eecs.6002x'
+        test_id = 'mit.eecs.6002x'
         test_branch = 'published'
-        expected_urn = 'edu.mit.eecs.6002x;published'
+        expected_urn = 'mit.eecs.6002x;published'
         testobj = CourseLocator(course_id=test_id, branch=test_branch)
         self.check_course_locn_fields(testobj, 'course_id with separate branch',
                                       course_id=test_id,
@@ -156,10 +154,10 @@ class LocatorTest(TestCase):
         """
         The same branch appears in the course_id and the branch field.
         """
-        test_id = 'edu.mit.eecs.6002x;published'
+        test_id = 'mit.eecs.6002x;published'
         test_branch = 'published'
-        expected_id = 'edu.mit.eecs.6002x'
-        expected_urn = 'edu.mit.eecs.6002x;published'
+        expected_id = 'mit.eecs.6002x'
+        expected_urn = 'mit.eecs.6002x;published'
         testobj = CourseLocator(course_id=test_id, branch=test_branch)
         self.check_course_locn_fields(testobj, 'course_id with repeated branch',
                                       course_id=expected_id,
@@ -171,8 +169,8 @@ class LocatorTest(TestCase):
         self.assertEqual(testobj.url(), 'edx://' + expected_urn)
 
     def test_block_constructor(self):
-        testurn = 'edu.mit.eecs.6002x;published#HW3'
-        expected_id = 'edu.mit.eecs.6002x'
+        testurn = 'mit.eecs.6002x;published#HW3'
+        expected_id = 'mit.eecs.6002x'
         expected_branch = 'published'
         expected_block_ref = 'HW3'
         testobj = BlockUsageLocator(course_id=testurn)
@@ -183,345 +181,6 @@ class LocatorTest(TestCase):
         self.assertEqual(str(testobj), testurn)
         self.assertEqual(testobj.url(), 'edx://' + testurn)
 
-    # ------------------------------------------------------------
-    # Disabled tests
-
-    def test_course_urls(self):
-        '''
-        Test constructor and property accessors.
-        '''
-        raise SkipTest()
-        self.assertRaises(TypeError, CourseLocator, 'empty constructor')
-
-        # url inits
-        testurn = 'edx://org/course/category/name'
-        self.assertRaises(InvalidLocationError, CourseLocator, url=testurn)
-        testurn = 'unknown/versionid/blockid'
-        self.assertRaises(InvalidLocationError, CourseLocator, url=testurn)
-
-        testurn = 'cvx/versionid'
-        testobj = CourseLocator(testurn)
-        self.check_course_locn_fields(testobj, testurn, 'versionid')
-        self.assertEqual(testobj, CourseLocator(testobj),
-                         'initialization from another instance')
-
-        testurn = 'cvx/versionid/'
-        testobj = CourseLocator(testurn)
-        self.check_course_locn_fields(testobj, testurn, 'versionid')
-
-        testurn = 'cvx/versionid/blockid'
-        testobj = CourseLocator(testurn)
-        self.check_course_locn_fields(testobj, testurn, 'versionid')
-
-        testurn = 'cvx/versionid/blockid/extraneousstuff?including=args'
-        testobj = CourseLocator(testurn)
-        self.check_course_locn_fields(testobj, testurn, 'versionid')
-
-        testurn = 'cvx://versionid/blockid'
-        testobj = CourseLocator(testurn)
-        self.check_course_locn_fields(testobj, testurn, 'versionid')
-
-        testurn = 'crx/courseid/blockid'
-        testobj = CourseLocator(testurn)
-        self.check_course_locn_fields(testobj, testurn, course_id='courseid')
-
-        testurn = 'crx/courseid@branch/blockid'
-        testobj = CourseLocator(testurn)
-        self.check_course_locn_fields(testobj, testurn, course_id='courseid',
-                                      branch='branch')
-        self.assertEqual(testobj, CourseLocator(testobj),
-                         'run initialization from another instance')
-
-    def test_course_keyword_setters(self):
-        raise SkipTest()
-        # arg list inits
-        testobj = CourseLocator(version_guid='versionid')
-        self.check_course_locn_fields(testobj, 'versionid arg', 'versionid')
-
-        testobj = CourseLocator(course_id='courseid')
-        self.check_course_locn_fields(testobj, 'courseid arg',
-                                      course_id='courseid')
-
-        testobj = CourseLocator(course_id='courseid', branch='rev')
-        self.check_course_locn_fields(testobj, 'rev arg',
-                                      course_id='courseid',
-                                      branch='rev')
-        # ignores garbage
-        testobj = CourseLocator(course_id='courseid', branch='rev',
-                                potato='spud')
-        self.check_course_locn_fields(testobj, 'extra keyword arg',
-                                      course_id='courseid',
-                                      branch='rev')
-
-        # url w/ keyword override
-        testurn = 'crx/courseid@branch/blockid'
-        testobj = CourseLocator(testurn, branch='rev')
-        self.check_course_locn_fields(testobj, 'rev override',
-                                      course_id='courseid',
-                                      branch='rev')
-
-    def test_course_dict(self):
-        raise SkipTest()
-        # dict init w/ keyword overwrites
-        testobj = CourseLocator({"version_guid": 'versionid'})
-        self.check_course_locn_fields(testobj, 'versionid dict', 'versionid')
-
-        testobj = CourseLocator({"course_id": 'courseid'})
-        self.check_course_locn_fields(testobj, 'courseid dict',
-                                      course_id='courseid')
-
-        testobj = CourseLocator({"course_id": 'courseid', "branch": 'rev'})
-        self.check_course_locn_fields(testobj, 'rev dict',
-                                      course_id='courseid',
-                                      branch='rev')
-        # ignores garbage
-        testobj = CourseLocator({"course_id": 'courseid', "branch": 'rev',
-                                 "potato": 'spud'})
-        self.check_course_locn_fields(testobj, 'extra keyword dict',
-                                      course_id='courseid',
-                                      branch='rev')
-        testobj = CourseLocator({"course_id": 'courseid', "branch": 'rev'},
-                                branch='alt')
-        self.check_course_locn_fields(testobj, 'rev dict',
-                                      course_id='courseid',
-                                      branch='alt')
-
-        # urn init w/ dict & keyword overwrites
-        testobj = CourseLocator('crx/notcourse@notthis',
-                                {"course_id": 'courseid'},
-                                branch='alt')
-        self.check_course_locn_fields(testobj, 'rev dict',
-                                      course_id='courseid',
-                                      branch='alt')
-
-    def test_url(self):
-        '''
-        Ensure CourseLocator generates expected urls.
-        '''
-        raise SkipTest()
-
-        testobj = CourseLocator(version_guid='versionid')
-        self.assertEqual(testobj.url(), 'cvx/versionid', 'versionid')
-        self.assertEqual(testobj, CourseLocator(testobj.url()),
-                         'versionid conversion through url')
-
-        testobj = CourseLocator(course_id='courseid')
-        self.assertEqual(testobj.url(), 'crx/courseid', 'courseid')
-        self.assertEqual(testobj, CourseLocator(testobj.url()),
-                         'courseid conversion through url')
-
-        testobj = CourseLocator(course_id='courseid', branch='rev')
-        self.assertEqual(testobj.url(), 'crx/courseid@rev', 'rev')
-        self.assertEqual(testobj, CourseLocator(testobj.url()),
-                         'rev conversion through url')
-
-    def test_html(self):
-        '''
-        Ensure CourseLocator generates expected urls.
-        '''
-        raise SkipTest()
-        testobj = CourseLocator(version_guid='versionid')
-        self.assertEqual(testobj.html_id(), 'cvx/versionid', 'versionid')
-        self.assertEqual(testobj, CourseLocator(testobj.html_id()),
-                         'versionid conversion through html_id')
-
-        testobj = CourseLocator(course_id='courseid')
-        self.assertEqual(testobj.html_id(), 'crx/courseid', 'courseid')
-        self.assertEqual(testobj, CourseLocator(testobj.html_id()),
-                         'courseid conversion through html_id')
-
-        testobj = CourseLocator(course_id='courseid', branch='rev')
-        self.assertEqual(testobj.html_id(), 'crx/courseid%40rev', 'rev')
-        self.assertEqual(testobj, CourseLocator(testobj.html_id()),
-                         'rev conversion through html_id')
-
-    def test_block_locator(self):
-        '''
-        Test constructor and property accessors.
-        '''
-        raise SkipTest()
-        self.assertIsInstance(BlockUsageLocator(), BlockUsageLocator,
-                              'empty constructor')
-
-        # url inits
-        testurn = 'edx://org/course/category/name'
-        self.assertRaises(InvalidLocationError, BlockUsageLocator, testurn)
-        testurn = 'unknown/versionid/blockid'
-        self.assertRaises(InvalidLocationError, BlockUsageLocator, testurn)
-
-        testurn = 'cvx/versionid'
-        testobj = BlockUsageLocator(testurn)
-        self.check_block_locn_fields(testobj, testurn, 'versionid')
-        self.assertEqual(testobj, BlockUsageLocator(testobj),
-                         'initialization from another instance')
-
-        testurn = 'cvx/versionid/'
-        testobj = BlockUsageLocator(testurn)
-        self.check_block_locn_fields(testobj, testurn, 'versionid')
-
-        testurn = 'cvx/versionid/blockid'
-        testobj = BlockUsageLocator(testurn)
-        self.check_block_locn_fields(testobj, testurn, 'versionid',
-                                     block='blockid')
-
-        testurn = 'cvx/versionid/blockid/extraneousstuff?including=args'
-        testobj = BlockUsageLocator(testurn)
-        self.check_block_locn_fields(testobj, testurn, 'versionid',
-                                     block='blockid')
-
-        testurn = 'cvx://versionid/blockid'
-        testobj = BlockUsageLocator(testurn)
-        self.check_block_locn_fields(testobj, testurn, 'versionid',
-                                     block='blockid')
-
-        testurn = 'crx/courseid/blockid'
-        testobj = BlockUsageLocator(testurn)
-        self.check_block_locn_fields(testobj, testurn, course_id='courseid',
-                                     block='blockid')
-
-        testurn = 'crx/courseid@branch/blockid'
-        testobj = BlockUsageLocator(testurn)
-        self.check_block_locn_fields(testobj, testurn, course_id='courseid',
-                                     branch='branch', block='blockid')
-        self.assertEqual(testobj, BlockUsageLocator(testobj),
-                         'run initialization from another instance')
-
-    def test_block_keyword_init(self):
-        # arg list inits
-        raise SkipTest()
-        testobj = BlockUsageLocator(version_guid='versionid')
-        self.check_block_locn_fields(testobj, 'versionid arg', 'versionid')
-
-        testobj = BlockUsageLocator(version_guid='versionid', usage_id='myblock')
-        self.check_block_locn_fields(testobj, 'versionid arg', 'versionid',
-                                     block='myblock')
-
-        testobj = BlockUsageLocator(course_id='courseid')
-        self.check_block_locn_fields(testobj, 'courseid arg',
-                                     course_id='courseid')
-
-        testobj = BlockUsageLocator(course_id='courseid', branch='rev')
-        self.check_block_locn_fields(testobj, 'rev arg',
-                                     course_id='courseid',
-                                     branch='rev')
-        # ignores garbage
-        testobj = BlockUsageLocator(course_id='courseid', branch='rev',
-                                    usage_id='this_block', potato='spud')
-        self.check_block_locn_fields(testobj, 'extra keyword arg',
-                                     course_id='courseid', block='this_block', branch='rev')
-
-        # url w/ keyword override
-        testurn = 'crx/courseid@branch/blockid'
-        testobj = BlockUsageLocator(testurn, branch='rev')
-        self.check_block_locn_fields(testobj, 'rev override',
-                                     course_id='courseid', block='blockid',
-                                     branch='rev')
-
-    def test_block_keywords(self):
-        # dict init w/ keyword overwrites
-        raise SkipTest()
-        testobj = BlockUsageLocator({"version_guid": 'versionid',
-                                     'usage_id': 'dictblock'})
-        self.check_block_locn_fields(testobj, 'versionid dict', 'versionid',
-                                     block='dictblock')
-
-        testobj = BlockUsageLocator({"course_id": 'courseid',
-                                     'usage_id': 'dictblock'})
-        self.check_block_locn_fields(testobj, 'courseid dict',
-                                     block='dictblock', course_id='courseid')
-
-        testobj = BlockUsageLocator({"course_id": 'courseid', "branch": 'rev',
-                                     'usage_id': 'dictblock'})
-        self.check_block_locn_fields(testobj, 'rev dict',
-                                     course_id='courseid', block='dictblock',
-                                     branch='rev')
-        # ignores garbage
-        testobj = BlockUsageLocator({"course_id": 'courseid', "branch": 'rev',
-                                     'usage_id': 'dictblock', "potato": 'spud'})
-        self.check_block_locn_fields(testobj, 'extra keyword dict',
-                                     course_id='courseid', block='dictblock',
-                                     branch='rev')
-        testobj = BlockUsageLocator({"course_id": 'courseid', "branch": 'rev',
-                                     'usage_id': 'dictblock'}, branch='alt', usage_id='anotherblock')
-        self.check_block_locn_fields(testobj, 'rev dict',
-                                     course_id='courseid', block='anotherblock',
-                                     branch='alt')
-
-        # urn init w/ dict & keyword overwrites
-        testobj = BlockUsageLocator('crx/notcourse@notthis/northis',
-                                    {"course_id": 'courseid'}, branch='alt', usage_id='anotherblock')
-        self.check_block_locn_fields(testobj, 'rev dict',
-                                     course_id='courseid', block='anotherblock',
-                                     branch='alt')
-
-    def test_ensure_fully_specd(self):
-        '''
-        Test constructor and property accessors.
-        '''
-        raise SkipTest()
-        self.assertRaises(InsufficientSpecificationError,
-                          BlockUsageLocator.ensure_fully_specified, BlockUsageLocator())
-
-        # url inits
-        testurn = 'edx://org/course/category/name'
-        self.assertRaises(InvalidLocationError,
-                          BlockUsageLocator.ensure_fully_specified, testurn)
-        testurn = 'unknown/versionid/blockid'
-        self.assertRaises(InvalidLocationError,
-                          BlockUsageLocator.ensure_fully_specified, testurn)
-
-        testurn = 'cvx/versionid'
-        self.assertRaises(InsufficientSpecificationError,
-                          BlockUsageLocator.ensure_fully_specified, testurn)
-
-        testurn = 'cvx/versionid/'
-        self.assertRaises(InsufficientSpecificationError,
-                          BlockUsageLocator.ensure_fully_specified, testurn)
-
-        testurn = 'cvx/versionid/blockid'
-        self.assertIsInstance(BlockUsageLocator.ensure_fully_specified(testurn),
-                              BlockUsageLocator, testurn)
-
-        testurn = 'cvx/versionid/blockid/extraneousstuff?including=args'
-        self.assertIsInstance(BlockUsageLocator.ensure_fully_specified(testurn),
-                              BlockUsageLocator, testurn)
-
-        testurn = 'cvx://versionid/blockid'
-        self.assertIsInstance(BlockUsageLocator.ensure_fully_specified(testurn),
-                              BlockUsageLocator, testurn)
-
-        testurn = 'crx/courseid/blockid'
-        self.assertIsInstance(BlockUsageLocator.ensure_fully_specified(testurn),
-                              BlockUsageLocator, testurn)
-
-        testurn = 'crx/courseid@branch/blockid'
-        self.assertIsInstance(BlockUsageLocator.ensure_fully_specified(testurn),
-                              BlockUsageLocator, testurn)
-
-    def test_ensure_fully_via_keyword(self):
-        # arg list inits
-        raise SkipTest()
-        testobj = BlockUsageLocator(version_guid='versionid')
-        self.assertRaises(InsufficientSpecificationError,
-                          BlockUsageLocator.ensure_fully_specified, testobj)
-
-        testurn = 'crx/courseid@branch/blockid'
-        testobj = BlockUsageLocator(version_guid='versionid', usage_id='myblock')
-        self.assertIsInstance(BlockUsageLocator.ensure_fully_specified(testurn),
-                              BlockUsageLocator, testurn)
-
-        testobj = BlockUsageLocator(course_id='courseid')
-        self.assertRaises(InsufficientSpecificationError,
-                          BlockUsageLocator.ensure_fully_specified, testobj)
-
-        testobj = BlockUsageLocator(course_id='courseid', branch='rev')
-        self.assertRaises(InsufficientSpecificationError,
-                          BlockUsageLocator.ensure_fully_specified, testobj)
-
-        testobj = BlockUsageLocator(course_id='courseid', branch='rev',
-                                    usage_id='this_block')
-        self.assertIsInstance(BlockUsageLocator.ensure_fully_specified(testurn),
-                              BlockUsageLocator, testurn)
 
     # ------------------------------------------------------------------
     # Utilities

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore.py
@@ -331,7 +331,7 @@ class SplitModuleItemTests(SplitModuleTest):
             block.grade_cutoffs, {"Pass": 0.45},
         )
 
-        # try to look up other branchs
+        # try to look up other branches
         self.assertRaises(ItemNotFoundError,
                           modulestore().get_item,
                           BlockUsageLocator(course_id=locator.as_course_locator(),

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore.py
@@ -129,8 +129,8 @@ class SplitModuleCourseTests(SplitModuleTest):
         self.assertEqual(str(course.previous_version), self.GUID_D1)
         self.assertDictEqual(course.grade_cutoffs, {"Pass": 0.45})
 
-    def test_revision_requests(self):
-        # query w/ revision qualifier (both draft and published)
+    def test_branch_requests(self):
+        # query w/ branch qualifier (both draft and published)
         courses_published = modulestore().get_courses('published')
         self.assertEqual(len(courses_published), 1, len(courses_published))
         course = self.findByIdInResult(courses_published, "head23456")
@@ -182,7 +182,7 @@ class SplitModuleCourseTests(SplitModuleTest):
         self.assertEqual(course.edited_by, "testassist@edx.org")
         self.assertDictEqual(course.grade_cutoffs, {"Pass": 0.55})
 
-        locator = CourseLocator(course_id='GreekHero', revision='draft')
+        locator = CourseLocator(course_id='GreekHero', branch='draft')
         course = modulestore().get_course(locator)
         self.assertEqual(course.location.course_id, "GreekHero")
         self.assertEqual(str(course.location.version_guid), self.GUID_D0)
@@ -195,12 +195,12 @@ class SplitModuleCourseTests(SplitModuleTest):
         self.assertEqual(course.edited_by, "testassist@edx.org")
         self.assertDictEqual(course.grade_cutoffs, {"Pass": 0.45})
 
-        locator = CourseLocator(course_id='wonderful', revision='published')
+        locator = CourseLocator(course_id='wonderful', branch='published')
         course = modulestore().get_course(locator)
         self.assertEqual(course.location.course_id, "wonderful")
         self.assertEqual(str(course.location.version_guid), self.GUID_P)
 
-        locator = CourseLocator(course_id='wonderful', revision='draft')
+        locator = CourseLocator(course_id='wonderful', branch='draft')
         course = modulestore().get_course(locator)
         self.assertEqual(str(course.location.version_guid), self.GUID_D2)
 
@@ -209,10 +209,10 @@ class SplitModuleCourseTests(SplitModuleTest):
         self.assertRaises(InsufficientSpecificationError,
                           modulestore().get_course, CourseLocator(course_id='edu.meh.blah'))
         self.assertRaises(ItemNotFoundError,
-                          modulestore().get_course, CourseLocator(course_id='nosuchthing', revision='draft'))
+                          modulestore().get_course, CourseLocator(course_id='nosuchthing', branch='draft'))
         self.assertRaises(ItemNotFoundError,
                           modulestore().get_course,
-                          CourseLocator(course_id='GreekHero', revision='published'))
+                          CourseLocator(course_id='GreekHero', branch='published'))
 
     def test_course_successors(self):
         """
@@ -250,7 +250,7 @@ class SplitModuleItemTests(SplitModuleTest):
         self.assertTrue(modulestore().has_item(locator),
                         "couldn't find in %s" % self.GUID_D1)
 
-        locator = BlockUsageLocator(course_id='GreekHero', usage_id='head12345', revision='draft')
+        locator = BlockUsageLocator(course_id='GreekHero', usage_id='head12345', branch='draft')
         self.assertTrue(
             modulestore().has_item(locator),
             "couldn't find in 12345"
@@ -258,7 +258,7 @@ class SplitModuleItemTests(SplitModuleTest):
         self.assertTrue(
             modulestore().has_item(BlockUsageLocator(
                 course_id=locator.course_id,
-                revision='draft',
+                branch='draft',
                 usage_id=locator.usage_id
             )),
             "couldn't find in draft 12345"
@@ -266,38 +266,38 @@ class SplitModuleItemTests(SplitModuleTest):
         self.assertFalse(
             modulestore().has_item(BlockUsageLocator(
                 course_id=locator.course_id,
-                revision='published',
+                branch='published',
                 usage_id=locator.usage_id)),
             "found in published 12345"
         )
-        locator.revision = 'draft'
+        locator.branch = 'draft'
         self.assertTrue(
             modulestore().has_item(locator),
             "not found in draft 12345"
         )
 
         # not a course obj
-        locator = BlockUsageLocator(course_id='GreekHero', usage_id='chapter1', revision='draft')
+        locator = BlockUsageLocator(course_id='GreekHero', usage_id='chapter1', branch='draft')
         self.assertTrue(
             modulestore().has_item(locator),
             "couldn't find chapter1"
         )
 
         # in published course
-        locator = BlockUsageLocator(course_id="wonderful", usage_id="head23456", revision='draft')
+        locator = BlockUsageLocator(course_id="wonderful", usage_id="head23456", branch='draft')
         self.assertTrue(modulestore().has_item(BlockUsageLocator(course_id=locator.course_id,
                                                                  usage_id=locator.usage_id,
-                                                                 revision='published')),
+                                                                 branch='published')),
                         "couldn't find in 23456")
-        locator.revision = 'published'
+        locator.branch = 'published'
         self.assertTrue(modulestore().has_item(locator), "couldn't find in 23456")
 
     def test_negative_has_item(self):
         # negative tests--not found
         # no such course or block
-        locator = BlockUsageLocator(course_id="doesnotexist", usage_id="head23456", revision='draft')
+        locator = BlockUsageLocator(course_id="doesnotexist", usage_id="head23456", branch='draft')
         self.assertFalse(modulestore().has_item(locator))
-        locator = BlockUsageLocator(course_id="wonderful", usage_id="doesnotexist", revision='draft')
+        locator = BlockUsageLocator(course_id="wonderful", usage_id="doesnotexist", branch='draft')
         self.assertFalse(modulestore().has_item(locator))
 
         # negative tests--insufficient specification
@@ -316,7 +316,7 @@ class SplitModuleItemTests(SplitModuleTest):
         block = modulestore().get_item(locator)
         self.assertIsInstance(block, CourseDescriptor)
 
-        locator = BlockUsageLocator(course_id='GreekHero', usage_id='head12345', revision='draft')
+        locator = BlockUsageLocator(course_id='GreekHero', usage_id='head12345', branch='draft')
         block = modulestore().get_item(locator)
         self.assertEqual(block.location.course_id, "GreekHero")
         # look at this one in detail
@@ -331,13 +331,13 @@ class SplitModuleItemTests(SplitModuleTest):
             block.grade_cutoffs, {"Pass": 0.45},
         )
 
-        # try to look up other revisions
+        # try to look up other branchs
         self.assertRaises(ItemNotFoundError,
                           modulestore().get_item,
                           BlockUsageLocator(course_id=locator.as_course_locator(),
                                             usage_id=locator.usage_id,
-                                            revision='published'))
-        locator.revision = 'draft'
+                                            branch='published'))
+        locator.branch = 'draft'
         self.assertIsInstance(
             modulestore().get_item(locator),
             CourseDescriptor
@@ -345,7 +345,7 @@ class SplitModuleItemTests(SplitModuleTest):
 
     def test_get_non_root(self):
         # not a course obj
-        locator = BlockUsageLocator(course_id='GreekHero', usage_id='chapter1', revision='draft')
+        locator = BlockUsageLocator(course_id='GreekHero', usage_id='chapter1', branch='draft')
         block = modulestore().get_item(locator)
         self.assertEqual(block.location.course_id, "GreekHero")
         self.assertEqual(block.category, 'chapter')
@@ -354,7 +354,7 @@ class SplitModuleItemTests(SplitModuleTest):
         self.assertEqual(block.edited_by, "testassist@edx.org")
 
         # in published course
-        locator = BlockUsageLocator(course_id="wonderful", usage_id="head23456", revision='published')
+        locator = BlockUsageLocator(course_id="wonderful", usage_id="head23456", branch='published')
         self.assertIsInstance(
             modulestore().get_item(locator),
             CourseDescriptor
@@ -362,10 +362,10 @@ class SplitModuleItemTests(SplitModuleTest):
 
         # negative tests--not found
         # no such course or block
-        locator = BlockUsageLocator(course_id="doesnotexist", usage_id="head23456", revision='draft')
+        locator = BlockUsageLocator(course_id="doesnotexist", usage_id="head23456", branch='draft')
         with self.assertRaises(ItemNotFoundError):
             modulestore().get_item(locator)
-        locator = BlockUsageLocator(course_id="wonderful", usage_id="doesnotexist", revision='draft')
+        locator = BlockUsageLocator(course_id="wonderful", usage_id="doesnotexist", branch='draft')
         with self.assertRaises(ItemNotFoundError):
             modulestore().get_item(locator)
 
@@ -373,7 +373,7 @@ class SplitModuleItemTests(SplitModuleTest):
         with self.assertRaises(InsufficientSpecificationError):
             modulestore().get_item(BlockUsageLocator(version_guid=self.GUID_D1))
         with self.assertRaises(InsufficientSpecificationError):
-            modulestore().get_item(BlockUsageLocator(course_id='GreekHero', revision='draft'))
+            modulestore().get_item(BlockUsageLocator(course_id='GreekHero', branch='draft'))
 
     # pylint: disable=W0212
     def test_matching(self):
@@ -404,7 +404,7 @@ class SplitModuleItemTests(SplitModuleTest):
 
     def test_get_items(self):
         '''
-        get_items(locator, qualifiers, [revision])
+        get_items(locator, qualifiers, [branch])
         '''
         locator = CourseLocator(version_guid=self.GUID_D0)
         # get all modules
@@ -429,9 +429,9 @@ class SplitModuleItemTests(SplitModuleTest):
 
     def test_get_parents(self):
         '''
-        get_parent_locations(locator, [usage_id], [revision]): [BlockUsageLocator]
+        get_parent_locations(locator, [usage_id], [branch]): [BlockUsageLocator]
         '''
-        locator = CourseLocator(course_id="GreekHero", revision='draft')
+        locator = CourseLocator(course_id="GreekHero", branch='draft')
         parents = modulestore().get_parent_locations(locator, usage_id='chapter1')
         self.assertEqual(len(parents), 1)
         self.assertEqual(parents[0].usage_id, 'head12345')
@@ -447,7 +447,7 @@ class SplitModuleItemTests(SplitModuleTest):
         """
         Test the existing get_children method on xdescriptors
         """
-        locator = BlockUsageLocator(course_id="GreekHero", usage_id="head12345", revision='draft')
+        locator = BlockUsageLocator(course_id="GreekHero", usage_id="head12345", branch='draft')
         block = modulestore().get_item(locator)
         children = block.get_children()
         expected_ids = [
@@ -490,7 +490,7 @@ class TestItemCrud(SplitModuleTest):
         metadata=None): new_desciptor
         """
         # grab link to course to ensure new versioning works
-        locator = CourseLocator(course_id="GreekHero", revision='draft')
+        locator = CourseLocator(course_id="GreekHero", branch='draft')
         premod_course = modulestore().get_course(locator)
         premod_time = datetime.datetime.now(UTC) - datetime.timedelta(seconds=1)
         # add minimal one w/o a parent
@@ -527,7 +527,7 @@ class TestItemCrud(SplitModuleTest):
         """
         Test create_item w/ specifying the parent of the new item
         """
-        locator = BlockUsageLocator(course_id="wonderful", usage_id="head23456", revision='draft')
+        locator = BlockUsageLocator(course_id="wonderful", usage_id="head23456", branch='draft')
         premod_course = modulestore().get_course(locator)
         category = 'chapter'
         new_module = modulestore().create_item(
@@ -547,7 +547,7 @@ class TestItemCrud(SplitModuleTest):
         a definition id and new def data that it branches the definition in the db.
         Actually, this tries to test all create_item features not tested above.
         """
-        locator = BlockUsageLocator(course_id="contender", usage_id="head345679", revision='draft')
+        locator = BlockUsageLocator(course_id="contender", usage_id="head345679", branch='draft')
         category = 'problem'
         premod_time = datetime.datetime.now(UTC) - datetime.timedelta(seconds=1)
         new_payload = "<problem>empty</problem>"
@@ -585,7 +585,7 @@ class TestItemCrud(SplitModuleTest):
         """
         test updating an items metadata ensuring the definition doesn't version but the course does if it should
         """
-        locator = BlockUsageLocator(course_id="GreekHero", usage_id="problem3_2", revision='draft')
+        locator = BlockUsageLocator(course_id="GreekHero", usage_id="problem3_2", branch='draft')
         problem = modulestore().get_item(locator)
         pre_def_id = problem.definition_locator.definition_id
         pre_version_guid = problem.location.version_guid
@@ -622,7 +622,7 @@ class TestItemCrud(SplitModuleTest):
         """
         test updating an item's children ensuring the definition doesn't version but the course does if it should
         """
-        locator = BlockUsageLocator(course_id="GreekHero", usage_id="chapter3", revision='draft')
+        locator = BlockUsageLocator(course_id="GreekHero", usage_id="chapter3", branch='draft')
         block = modulestore().get_item(locator)
         pre_def_id = block.definition_locator.definition_id
         pre_version_guid = block.location.version_guid
@@ -646,7 +646,7 @@ class TestItemCrud(SplitModuleTest):
         """
         test updating an item's definition: ensure it gets versioned as well as the course getting versioned
         """
-        locator = BlockUsageLocator(course_id="GreekHero", usage_id="head12345", revision='draft')
+        locator = BlockUsageLocator(course_id="GreekHero", usage_id="head12345", branch='draft')
         block = modulestore().get_item(locator)
         pre_def_id = block.definition_locator.definition_id
         pre_version_guid = block.location.version_guid
@@ -663,7 +663,7 @@ class TestItemCrud(SplitModuleTest):
         Test updating metadata, children, and definition in a single call ensuring all the versioning occurs
         """
         # first add 2 children to the course for the update to manipulate
-        locator = BlockUsageLocator(course_id="contender", usage_id="head345679", revision='draft')
+        locator = BlockUsageLocator(course_id="contender", usage_id="head345679", branch='draft')
         category = 'problem'
         new_payload = "<problem>empty</problem>"
         modulestore().create_item(
@@ -707,14 +707,14 @@ class TestItemCrud(SplitModuleTest):
         reusable_location = BlockUsageLocator(
             course_id=course.location.course_id,
             usage_id=course.location.usage_id,
-            revision='draft')
+            branch='draft')
 
         # delete a leaf
         problems = modulestore().get_items(reusable_location, {'category': 'problem'})
         locn_to_del = problems[0].location
         new_course_loc = modulestore().delete_item(locn_to_del, 'deleting_user')
         deleted = BlockUsageLocator(course_id=reusable_location.course_id,
-                                    revision=reusable_location.revision,
+                                    branch=reusable_location.branch,
                                     usage_id=locn_to_del.usage_id)
         self.assertFalse(modulestore().has_item(deleted))
         self.assertRaises(VersionConflictError, modulestore().has_item, locn_to_del)
@@ -736,7 +736,7 @@ class TestItemCrud(SplitModuleTest):
                 self.assertFalse(modulestore().has_item(
                     BlockUsageLocator(
                         course_id=node_loc.course_id,
-                        revision=node_loc.revision,
+                        branch=node_loc.branch,
                         usage_id=node.location.usage_id)))
                 locator = BlockUsageLocator(
                     version_guid=node.location.version_guid,
@@ -752,7 +752,7 @@ class TestItemCrud(SplitModuleTest):
         root = BlockUsageLocator(
             course_id=course.location.course_id,
             usage_id=course.location.usage_id,
-            revision='draft')
+            branch='draft')
         for _ in range(4):
             self.create_subtree_for_deletion(root, ['chapter', 'vertical', 'problem'])
         return modulestore().get_item(root)
@@ -807,7 +807,7 @@ class TestCourseCreation(SplitModuleTest):
         Test making a course which points to an existing draft and published but not making any changes to either.
         """
         pre_time = datetime.datetime.now(UTC)
-        original_locator = CourseLocator(course_id="wonderful", revision='draft')
+        original_locator = CourseLocator(course_id="wonderful", branch='draft')
         original_index = modulestore().get_course_index_info(original_locator)
         new_draft = modulestore().create_course(
             'leech', 'best_course', 'leech_master', id_root='best',
@@ -824,7 +824,7 @@ class TestCourseCreation(SplitModuleTest):
         self.assertLessEqual(new_index["edited_on"], datetime.datetime.now(UTC))
         self.assertEqual(new_index['edited_by'], 'leech_master')
 
-        new_published_locator = CourseLocator(course_id=new_draft_locator.course_id, revision='published')
+        new_published_locator = CourseLocator(course_id=new_draft_locator.course_id, branch='published')
         new_published = modulestore().get_course(new_published_locator)
         self.assertEqual(new_published.edited_by, 'test@edx.org')
         self.assertLess(new_published.edited_on, pre_time)
@@ -863,7 +863,7 @@ class TestCourseCreation(SplitModuleTest):
         Create a new course which overrides metadata and course_data
         """
         pre_time = datetime.datetime.now(UTC)
-        original_locator = CourseLocator(course_id="contender", revision='draft')
+        original_locator = CourseLocator(course_id="contender", branch='draft')
         original = modulestore().get_course(original_locator)
         original_index = modulestore().get_course_index_info(original_locator)
         data_payload = {}
@@ -902,7 +902,7 @@ class TestCourseCreation(SplitModuleTest):
         """
         Test changing the org, pretty id, etc of a course. Test that it doesn't allow changing the id, etc.
         """
-        locator = CourseLocator(course_id="GreekHero", revision='draft')
+        locator = CourseLocator(course_id="GreekHero", branch='draft')
         modulestore().update_course_index(locator, {'org': 'funkyU'})
         course_info = modulestore().get_course_index_info(locator)
         self.assertEqual(course_info['org'], 'funkyU')
@@ -938,7 +938,7 @@ class TestCourseCreation(SplitModuleTest):
         # an allowed but not recommended way to publish a course
         versions['published'] = self.GUID_D1
         modulestore().update_course_index(locator, {'versions': versions}, update_versions=True)
-        course = modulestore().get_course(CourseLocator(course_id=locator.course_id, revision="published"))
+        course = modulestore().get_course(CourseLocator(course_id=locator.course_id, branch="published"))
         self.assertEqual(str(course.location.version_guid), self.GUID_D1)
 
 
@@ -952,11 +952,11 @@ class TestInheritance(SplitModuleTest):
         """
         # Note, not testing value where defined (course) b/c there's no
         # defined accessor for it on CourseDescriptor.
-        locator = BlockUsageLocator(course_id="GreekHero", usage_id="problem3_2", revision='draft')
+        locator = BlockUsageLocator(course_id="GreekHero", usage_id="problem3_2", branch='draft')
         node = modulestore().get_item(locator)
         # inherited
         self.assertEqual(node.graceperiod, datetime.timedelta(hours=2))
-        locator = BlockUsageLocator(course_id="GreekHero", usage_id="problem1", revision='draft')
+        locator = BlockUsageLocator(course_id="GreekHero", usage_id="problem1", branch='draft')
         node = modulestore().get_item(locator)
         # overridden
         self.assertEqual(node.graceperiod, datetime.timedelta(hours=4))


### PR DESCRIPTION
and all related vars and methods.

Wanted to better convey the idea of not just a variant but an evolving variant. Only affects split mongo.

@cdodge @cpennington pls review
