### PR TITLE
To increase portability of courses, have the Asset Index page display the classic /static/... URL shorthand.

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_assets.py
+++ b/cms/djangoapps/contentstore/tests/test_assets.py
@@ -10,6 +10,8 @@ from unittest import TestCase, skip
 from .utils import CourseTestCase
 from django.core.urlresolvers import reverse
 from contentstore.views import assets
+from xmodule.contentstore.content import StaticContent
+from xmodule.modulestore import Location
 
 
 class AssetsTestCase(CourseTestCase):
@@ -34,6 +36,11 @@ class AssetsTestCase(CourseTestCase):
         self.assertEquals(resp.status_code, 200)
         content = json.loads(resp.content)
         self.assertIsInstance(content, list)
+
+    def test_static_url_generation(self):
+        location = Location(['i4x', 'foo', 'bar', 'asset', 'my_file_name.jpg'])
+        path = StaticContent.get_static_path_from_location(location)
+        self.assertEquals(path, '/static/my_file_name.jpg')
 
 
 class UploadTestCase(CourseTestCase):

--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -303,6 +303,16 @@ class ContentStoreToyCourseTest(ModuleStoreTestCase):
         num_drafts = self._get_draft_counts(course)
         self.assertEqual(num_drafts, 1)
 
+    def test_no_static_link_rewrites_on_import(self):
+        module_store = modulestore('direct')
+        import_from_xml(module_store, 'common/test/data/', ['toy'])
+
+        handouts = module_store.get_item(Location(['i4x', 'edX', 'toy', 'course_info', 'handouts', None]))
+        self.assertIn('/static/', handouts.data)
+
+        handouts = module_store.get_item(Location(['i4x', 'edX', 'toy', 'html', 'toyhtml', None]))
+        self.assertIn('/static/', handouts.data)
+
     def test_import_textbook_as_content_element(self):
         module_store = modulestore('direct')
         import_from_xml(module_store, 'common/test/data/', ['toy'])

--- a/cms/djangoapps/contentstore/views/assets.py
+++ b/cms/djangoapps/contentstore/views/assets.py
@@ -105,6 +105,7 @@ def asset_index(request, org, course, name):
 
         asset_location = StaticContent.compute_location(asset_id['org'], asset_id['course'], asset_id['name'])
         display_info['url'] = StaticContent.get_url_path_from_location(asset_location)
+        display_info['portable_url'] = StaticContent.get_static_path_from_location(asset_location)
 
         # note, due to the schema change we may not have a 'thumbnail_location' in the result set
         _thumbnail_location = asset.get('thumbnail_location', None)
@@ -187,12 +188,13 @@ def upload_asset(request, org, course, coursename):
     response_payload = {'displayname': content.name,
                         'uploadDate': get_default_time_display(readback.last_modified_at),
                         'url': StaticContent.get_url_path_from_location(content.location),
+                        'portable_url': StaticContent.get_static_path_from_location(content.location),
                         'thumb_url': StaticContent.get_url_path_from_location(thumbnail_location) if thumbnail_content is not None else None,
                         'msg': 'Upload completed'
                         }
 
     response = JsonResponse(response_payload)
-    response['asset_url'] = StaticContent.get_url_path_from_location(content.location)
+    response['asset_url'] = StaticContent.get_static_path_from_location(content.location)
     return response
 
 

--- a/cms/djangoapps/contentstore/views/assets.py
+++ b/cms/djangoapps/contentstore/views/assets.py
@@ -194,7 +194,6 @@ def upload_asset(request, org, course, coursename):
                         }
 
     response = JsonResponse(response_payload)
-    response['asset_url'] = StaticContent.get_static_path_from_location(content.location)
     return response
 
 

--- a/cms/static/js/views/assets.js
+++ b/cms/static/js/views/assets.js
@@ -96,7 +96,7 @@ function displayFinishedUpload(xhr) {
     }
 
     var resp = JSON.parse(xhr.responseText);
-    $('.upload-modal .embeddable-xml-input').val(xhr.getResponseHeader('asset_url'));
+    $('.upload-modal .embeddable-xml-input').val(resp.portable_url);
     $('.upload-modal .embeddable').show();
     $('.upload-modal .file-name').hide();
     $('.upload-modal .progress-fill').html(resp.msg);

--- a/cms/templates/asset_index.html
+++ b/cms/templates/asset_index.html
@@ -29,7 +29,7 @@
         {{uploadDate}}
       </td>
       <td class="embed-col">
-        <input type="text" class="embeddable-xml-input" value='{{url}}' readonly>
+        <input type="text" class="embeddable-xml-input" value='{{portable_url}}' readonly>
       </td>
       <td class="delete-col">
         <a href="#" data-tooltip="${_('Delete this asset')}" class="remove-asset-button"><span class="delete-icon"></span></a>
@@ -89,7 +89,7 @@
                 ${asset['uploadDate']}
               </td>
               <td class="embed-col">
-                <input type="text" class="embeddable-xml-input" value="${asset['url']}" readonly>
+                <input type="text" class="embeddable-xml-input" value="${asset['portable_url']}" readonly>
               </td>
               <td class="delete-col">
                 <a href="#" data-tooltip="${_('Delete this asset')}" class="remove-asset-button"><span class="delete-icon"></span></a>

--- a/cms/templates/widgets/html-edit.html
+++ b/cms/templates/widgets/html-edit.html
@@ -1,6 +1,6 @@
 <%! from django.utils.translation import ugettext as _ %>
 
-<div class="wrapper-comp-editor" id="editor-tab">
+<div class="wrapper-comp-editor" id="editor-tab" data-base-asset-url="${base_asset_url}">
     <section class="html-editor editor">
       <ul class="editor-tabs">
         <li><a href="#" class="visual-tab tab current" data-tab="visual">${_("Visual")}</a></li>

--- a/common/lib/xmodule/xmodule/contentstore/content.py
+++ b/common/lib/xmodule/xmodule/contentstore/content.py
@@ -59,6 +59,13 @@ class StaticContent(object):
             return None
 
     @staticmethod
+    def get_static_path_from_location(location):
+        if location is not None:
+            return "/static/{name}".format(**location.dict())
+        else:
+            return None
+
+    @staticmethod
     def get_base_url_path_for_course_assets(loc):
         if loc is not None:
             return "/c4x/{org}/{course}/asset".format(**loc.dict())

--- a/common/lib/xmodule/xmodule/contentstore/content.py
+++ b/common/lib/xmodule/xmodule/contentstore/content.py
@@ -60,6 +60,13 @@ class StaticContent(object):
 
     @staticmethod
     def get_static_path_from_location(location):
+        """
+        This utility static method will take a location identifier and create a 'durable' /static/.. URL representation of it.
+        This link is 'durable' as it can maintain integrity across cloning of courseware across course-ids, e.g. reruns of
+        courses.
+        In the LMS/CMS, we have runtime link-rewriting, so at render time, this /static/... format will get translated into
+        the actual /c4x/... path which the client needs to reference static content
+        """
         if location is not None:
             return "/static/{name}".format(**location.dict())
         else:

--- a/common/lib/xmodule/xmodule/html_module.py
+++ b/common/lib/xmodule/xmodule/html_module.py
@@ -82,8 +82,8 @@ class HtmlDescriptor(HtmlFields, XmlDescriptor, EditingDescriptor):
 
     def get_context(self):
         _context = EditingDescriptor.get_context(self)
-        # Add our specific template information (the raw data body)
-
+        # Add some specific HTML rendering context when editing HTML modules where we pass
+        # the root /c4x/ url for assets. This allows client-side substitutions to occur.
         _context.update({'base_asset_url': StaticContent.get_base_url_path_for_course_assets(self.location) + '/'})
         return _context
 

--- a/common/lib/xmodule/xmodule/html_module.py
+++ b/common/lib/xmodule/xmodule/html_module.py
@@ -14,6 +14,7 @@ from xmodule.stringify import stringify_children
 from xmodule.x_module import XModule
 from xmodule.xml_module import XmlDescriptor, name_to_pathname
 import textwrap
+from xmodule.contentstore.content import StaticContent
 
 log = logging.getLogger("mitx.courseware")
 
@@ -78,6 +79,13 @@ class HtmlDescriptor(HtmlFields, XmlDescriptor, EditingDescriptor):
             if candidate.endswith('.xml'):
                 nc.append(candidate[:-4] + '.html')
         return candidates + nc
+
+    def get_context(self):
+        _context = EditingDescriptor.get_context(self)
+        # Add our specific template information (the raw data body)
+
+        _context.update({'base_asset_url': StaticContent.get_base_url_path_for_course_assets(self.location) + '/'})
+        return _context
 
     # NOTE: html descriptors are special.  We do not want to parse and
     # export them ourselves, because that can break things (e.g. lxml

--- a/common/lib/xmodule/xmodule/html_module.py
+++ b/common/lib/xmodule/xmodule/html_module.py
@@ -81,6 +81,10 @@ class HtmlDescriptor(HtmlFields, XmlDescriptor, EditingDescriptor):
         return candidates + nc
 
     def get_context(self):
+        """
+        an override to add in specific rendering context, in this case we need to
+        add in a base path to our c4x content addressing scheme
+        """
         _context = EditingDescriptor.get_context(self)
         # Add some specific HTML rendering context when editing HTML modules where we pass
         # the root /c4x/ url for assets. This allows client-side substitutions to occur.

--- a/common/lib/xmodule/xmodule/js/fixtures/html-edit-with-links.html
+++ b/common/lib/xmodule/xmodule/js/fixtures/html-edit-with-links.html
@@ -1,0 +1,10 @@
+<section class="html-edit">
+    <ul class="editor-tabs">
+        <li><a href="#" class="visual-tab tab current" data-tab="visual">Visual</a></li>
+        <li><a href="#" class="html-tab tab" data-tab="advanced">HTML</a></li>
+    </ul>
+    <div class="row">
+        <textarea class="tiny-mce">dummy text</textarea>
+        <textarea name="" class="edit-box">Advanced Editor Text with link /static/dummy.jpg</textarea>
+    </div>
+</section>

--- a/common/lib/xmodule/xmodule/js/spec/html/edit_spec.coffee
+++ b/common/lib/xmodule/xmodule/js/spec/html/edit_spec.coffee
@@ -48,6 +48,16 @@ describe 'HTMLEditingDescriptor', ->
       expect(@descriptor.showingVisualEditor).toEqual(true)
       data = @descriptor.save().data
       expect(data).toEqual('from visual editor')
+    it 'Performs link rewriting for static assets when saving', ->
+      visualEditorStub =
+        isDirty: () -> true
+        getContent: () -> 'from visual editor with /c4x/foo/bar/asset/image.jpg'
+      spyOn(@descriptor, 'getVisualEditor').andCallFake () ->
+        visualEditorStub
+      expect(@descriptor.showingVisualEditor).toEqual(true)
+      @descriptor.base_asset_url = '/c4x/foo/bar/asset/'
+      data = @descriptor.save().data
+      expect(data).toEqual('from visual editor with /static/image.jpg')
   describe 'Can switch to Advanced Editor', ->
     beforeEach ->
       loadFixtures 'html-edit.html'
@@ -88,3 +98,23 @@ describe 'HTMLEditingDescriptor', ->
       expect(visualEditorStub.isDirty()).toEqual(false)
       expect(visualEditorStub.getContent()).toEqual('Advanced Editor Text')
       expect(visualEditorStub.startContent).toEqual('Advanced Editor Text')
+    it 'When switching to Advanced Editors links are rewritten to c4x format', ->
+      loadFixtures 'html-edit-with-links.html'
+      @descriptor = new HTMLEditingDescriptor($('.html-edit'))
+      @descriptor.base_asset_url = '/c4x/foo/bar/asset/'
+      @descriptor.showingVisualEditor = false
+
+      visualEditorStub =
+        isNotDirty: false
+        content: 'not set'
+        startContent: 'not set',
+        focus: () -> true
+        isDirty: () -> not @isNotDirty
+        setContent: (x) -> @content = x
+        getContent: -> @content
+
+      @descriptor.showVisualEditor(visualEditorStub)
+      expect(@descriptor.showingVisualEditor).toEqual(true)
+      expect(visualEditorStub.isDirty()).toEqual(false)
+      expect(visualEditorStub.getContent()).toEqual('Advanced Editor Text with link /c4x/foo/bar/asset/dummy.jpg')
+      expect(visualEditorStub.startContent).toEqual('Advanced Editor Text with link /c4x/foo/bar/asset/dummy.jpg')

--- a/common/lib/xmodule/xmodule/js/spec/html/edit_spec.coffee
+++ b/common/lib/xmodule/xmodule/js/spec/html/edit_spec.coffee
@@ -98,7 +98,7 @@ describe 'HTMLEditingDescriptor', ->
       expect(visualEditorStub.isDirty()).toEqual(false)
       expect(visualEditorStub.getContent()).toEqual('Advanced Editor Text')
       expect(visualEditorStub.startContent).toEqual('Advanced Editor Text')
-    it 'When switching to Advanced Editors links are rewritten to c4x format', ->
+    it 'When switching to visual editor links are rewritten to c4x format', ->
       loadFixtures 'html-edit-with-links.html'
       @descriptor = new HTMLEditingDescriptor($('.html-edit'))
       @descriptor.base_asset_url = '/c4x/foo/bar/asset/'

--- a/common/lib/xmodule/xmodule/js/src/html/edit.coffee
+++ b/common/lib/xmodule/xmodule/js/src/html/edit.coffee
@@ -3,6 +3,7 @@ class @HTMLEditingDescriptor
 
   constructor: (element) ->
     @element = element;
+    @base_asset_url = @element.find("#editor-tab").data('base-asset-url')
 
     @advanced_editor = CodeMirror.fromTextArea($(".edit-box", @element)[0], {
       mode: "text/html"
@@ -95,7 +96,10 @@ class @HTMLEditingDescriptor
   # Show the Advanced (codemirror) Editor. Pulled out as a helper method for unit testing.
   showAdvancedEditor: (visualEditor) ->
     if visualEditor.isDirty()
-      @advanced_editor.setValue(visualEditor.getContent({no_events: 1}))
+      content = visualEditor.getContent({no_events: 1})
+      regex = new RegExp(@base_asset_url, 'g')
+      content = content.replace(regex, '/static/')
+      @advanced_editor.setValue(content)
       @advanced_editor.setCursor(0)
     @advanced_editor.refresh()
     @advanced_editor.focus()
@@ -103,7 +107,6 @@ class @HTMLEditingDescriptor
 
   # Show the Visual (tinyMCE) Editor. Pulled out as a helper method for unit testing.
   showVisualEditor: (visualEditor) ->
-    visualEditor.setContent(@advanced_editor.getValue())
     # In order for isDirty() to return true ONLY if edits have been made after setting the text,
     # both the startContent must be sync'ed up and the dirty flag set to false.
     visualEditor.startContent = visualEditor.getContent({format: "raw", no_events: 1});
@@ -111,6 +114,11 @@ class @HTMLEditingDescriptor
     @showingVisualEditor = true
 
   focusVisualEditor: (visualEditor) =>
+    content = @advanced_editor.getValue()
+    regex = new RegExp('/static/', 'g')
+    content = content.replace(regex, @base_asset_url)
+    visualEditor.setContent(content)
+
     visualEditor.focus()
     # Need to mark editor as not dirty both when it is initially created and when we switch back to it.
     visualEditor.isNotDirty = true
@@ -132,4 +140,6 @@ class @HTMLEditingDescriptor
     visualEditor = @getVisualEditor()
     if @showingVisualEditor and visualEditor.isDirty()
       text = visualEditor.getContent({no_events: 1})
+      regex = new RegExp(@base_asset_url, 'g')
+      text = text.replace(regex, '/static/')
     data: text

--- a/common/lib/xmodule/xmodule/js/src/html/edit.coffee
+++ b/common/lib/xmodule/xmodule/js/src/html/edit.coffee
@@ -4,6 +4,8 @@ class @HTMLEditingDescriptor
   constructor: (element) ->
     @element = element;
     @base_asset_url = @element.find("#editor-tab").data('base-asset-url')
+    if @base_asset_url == undefined
+      @base_asset_url = null
 
     @advanced_editor = CodeMirror.fromTextArea($(".edit-box", @element)[0], {
       mode: "text/html"
@@ -104,6 +106,9 @@ class @HTMLEditingDescriptor
     @showingVisualEditor = false
 
   rewriteStaticLinks: (content, from, to) ->
+    if from == null || to == null
+      return content
+
     regex = new RegExp(from, 'g')
     return content.replace(regex, to)    
 

--- a/common/lib/xmodule/xmodule/js/src/html/edit.coffee
+++ b/common/lib/xmodule/xmodule/js/src/html/edit.coffee
@@ -48,7 +48,7 @@ class @HTMLEditingDescriptor
       setup : @setupTinyMCE,
       # Cannot get access to tinyMCE Editor instance (for focusing) until after it is rendered.
       # The tinyMCE callback passes in the editor as a paramter.
-      init_instance_callback: @focusVisualEditor
+      init_instance_callback: @initInstanceCallback
     })
 
     @showingVisualEditor = true
@@ -96,29 +96,32 @@ class @HTMLEditingDescriptor
   # Show the Advanced (codemirror) Editor. Pulled out as a helper method for unit testing.
   showAdvancedEditor: (visualEditor) ->
     if visualEditor.isDirty()
-      content = visualEditor.getContent({no_events: 1})
-      regex = new RegExp(@base_asset_url, 'g')
-      content = content.replace(regex, '/static/')
+      content = @rewriteStaticLinks(visualEditor.getContent({no_events: 1}), @base_asset_url, '/static/')
       @advanced_editor.setValue(content)
       @advanced_editor.setCursor(0)
     @advanced_editor.refresh()
     @advanced_editor.focus()
     @showingVisualEditor = false
 
+  rewriteStaticLinks: (content, from, to) ->
+    regex = new RegExp(from, 'g')
+    return content.replace(regex, to)    
+
   # Show the Visual (tinyMCE) Editor. Pulled out as a helper method for unit testing.
   showVisualEditor: (visualEditor) ->
     # In order for isDirty() to return true ONLY if edits have been made after setting the text,
     # both the startContent must be sync'ed up and the dirty flag set to false.
-    visualEditor.startContent = visualEditor.getContent({format: "raw", no_events: 1});
+    content = @rewriteStaticLinks(@advanced_editor.getValue(), '/static/', @base_asset_url)
+    visualEditor.setContent(content)
+    visualEditor.startContent = content
     @focusVisualEditor(visualEditor)
     @showingVisualEditor = true
 
-  focusVisualEditor: (visualEditor) =>
-    content = @advanced_editor.getValue()
-    regex = new RegExp('/static/', 'g')
-    content = content.replace(regex, @base_asset_url)
-    visualEditor.setContent(content)
+  initInstanceCallback: (visualEditor) =>
+    visualEditor.setContent(@rewriteStaticLinks(@advanced_editor.getValue(), '/static/', @base_asset_url))
+    @focusVisualEditor(visualEditor)
 
+  focusVisualEditor: (visualEditor) =>
     visualEditor.focus()
     # Need to mark editor as not dirty both when it is initially created and when we switch back to it.
     visualEditor.isNotDirty = true
@@ -139,7 +142,5 @@ class @HTMLEditingDescriptor
     text = @advanced_editor.getValue()
     visualEditor = @getVisualEditor()
     if @showingVisualEditor and visualEditor.isDirty()
-      text = visualEditor.getContent({no_events: 1})
-      regex = new RegExp(@base_asset_url, 'g')
-      text = text.replace(regex, '/static/')
+      text = @rewriteStaticLinks(visualEditor.getContent({no_events: 1}), @base_asset_url, '/static/')
     data: text

--- a/common/test/data/toy/course/2012_Fall.xml
+++ b/common/test/data/toy/course/2012_Fall.xml
@@ -4,6 +4,7 @@
     <videosequence url_name="Toy_Videos">
       <html url_name="secret:toylab"/>
       <html url_name="toyjumpto"/>
+      <html url_name="toyhtml"/>
       <video url_name="Video_Resources" youtube_id_1_0="1bK-WdDi6Qw" display_name="Video Resources"/>
     </videosequence>
     <video url_name="Welcome" youtube_id_1_0="p2Q6BrNhdh8" display_name="Welcome"/>

--- a/common/test/data/toy/html/toyhtml.html
+++ b/common/test/data/toy/html/toyhtml.html
@@ -1,0 +1,1 @@
+<a href='/static/handouts/sample_handout.txt'>Sample</a>

--- a/common/test/data/toy/html/toyhtml.xml
+++ b/common/test/data/toy/html/toyhtml.xml
@@ -1,0 +1,1 @@
+<html filename="toyhtml.html"/>


### PR DESCRIPTION
which is more portable across course runs

Note, unfortunately our unit tests do not support File Upload testing. Per @jzoldak this is a known issue that has not yet been resolved. I'll write some unit tests again importing a course from XML and then verifying the Asset Index page returns the expected portable_url.

@cahrens @dmitchell can you get started on the review.
