### PR TITLE
Fix broken Studio signup.feature acceptance test

### DIFF
--- a/cms/djangoapps/contentstore/features/signup.feature
+++ b/cms/djangoapps/contentstore/features/signup.feature
@@ -8,8 +8,7 @@ Feature: Sign in
     When I click the link with the text "Sign Up"
     And I fill in the registration form
     And I press the Create My Account button on the registration form
-    Then I should see be on the studio home page
-    And I should see the message "complete your sign up we need you to verify your email address"
+    Then I should see an email verification prompt
 
   Scenario: Login with a valid redirect
     Given I have opened a new course in Studio

--- a/cms/djangoapps/contentstore/features/signup.py
+++ b/cms/djangoapps/contentstore/features/signup.py
@@ -22,14 +22,10 @@ def i_press_the_button_on_the_registration_form(step):
     world.css_click(submit_css)
 
 
-@step('I should see be on the studio home page$')
-def i_should_see_be_on_the_studio_home_page(step):
-    step.given('I should see the message "My Courses"')
-
-
-@step(u'I should see the message "([^"]*)"$')
-def i_should_see_the_message(step, msg):
-    assert world.browser.is_text_present(msg, 5)
+@step('I should see an email verification prompt')
+def i_should_see_an_email_verification_prompt(step):
+    world.css_has_text('h1.page-header', u'My Courses')
+    world.css_has_text('div.msg h3.title', u'We need to verify your email address')
 
 
 @step(u'I fill in and submit the signin form$')


### PR DESCRIPTION
Replaced direct call to `browser.is_text_present()` with `world.css_find()` to protect against StaleElementException
in Jenkins.

All tests pass: http://jenkins.edx.org:8080/job/release-acceptance-tests/62/console

Review: @jzoldak @JonahStanley
