### PR TITLE
add display_coursenumber and display_organization fields on the CourseModule

### DIFF
--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -13,7 +13,7 @@
       <h2 class="info-course">
         <span class="sr">${_("Current Course:")}</span>
         <a class="course-link" href="${reverse('course_index', kwargs=dict(org=ctx_loc.org, course=ctx_loc.course, name=ctx_loc.name))}">
-          <span class="course-org">${ctx_loc.org}</span><span class="course-number">${ctx_loc.course}</span>
+          <span class="course-org">${context_course.display_org_with_default}</span><span class="course-number">${context_course.display_number_with_default}</span>
           <span class="course-title" title="${context_course.display_name_with_default}">${context_course.display_name_with_default}</span>
         </a>
       </h2>

--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -13,7 +13,7 @@
       <h2 class="info-course">
         <span class="sr">${_("Current Course:")}</span>
         <a class="course-link" href="${reverse('course_index', kwargs=dict(org=ctx_loc.org, course=ctx_loc.course, name=ctx_loc.name))}">
-          <span class="course-org">${context_course.display_org_with_default}</span><span class="course-number">${context_course.display_number_with_default}</span>
+          <span class="course-org">${context_course.display_org_with_default | h}</span><span class="course-number">${context_course.display_number_with_default | h}</span>
           <span class="course-title" title="${context_course.display_name_with_default}">${context_course.display_name_with_default}</span>
         </a>
       </h2>

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -6,7 +6,6 @@ from path import path  # NOTE (THK): Only used for detecting presence of syllabu
 import requests
 from datetime import datetime
 import dateutil.parser
-import cgi
 
 from xmodule.modulestore import Location
 from xmodule.seq_module import SequenceDescriptor, SequenceModule
@@ -945,7 +944,7 @@ class CourseDescriptor(CourseFields, SequenceDescriptor):
         Return a display course number if it has been specified, otherwise return the 'course' that is in the location
         """
         if self.display_coursenumber:
-            return cgi.escape(self.display_coursenumber)
+            return self.display_coursenumber
 
         return self.number
 
@@ -959,6 +958,6 @@ class CourseDescriptor(CourseFields, SequenceDescriptor):
         Return a display organization if it has been specified, otherwise return the 'org' that is in the location
         """
         if self.display_organization:
-            return cgi.escape(self.display_organization)
+            return self.display_organization
 
         return self.org

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -362,6 +362,11 @@ class CourseFields(object):
     # Explicit comparison to True because we always want to return a bool.
     hide_progress_tab = Boolean(help="DO NOT USE THIS", scope=Scope.settings)
 
+    display_organization = String(help="An optional display string for the course organization that will get rendered in the LMS",
+                                  scope=Scope.settings)
+
+    display_coursenumber = String(help="An optional display string for the course number that will get rendered in the LMS",
+                                  scope=Scope.settings)
 
 class CourseDescriptor(CourseFields, SequenceDescriptor):
     module_class = SequenceModule
@@ -934,5 +939,25 @@ class CourseDescriptor(CourseFields, SequenceDescriptor):
         return self.location.course
 
     @property
+    def display_number_with_default(self):
+        """
+        Return a display course number if it has been specified, otherwise return the 'course' that is in the location
+        """
+        if self.display_coursenumber:
+            return self.display_coursenumber
+
+        return self.location.course
+
+    @property
     def org(self):
+        return self.location.org
+
+    @property
+    def display_org_with_default(self):
+        """
+        Return a display organization if it has been specified, otherwise return the 'org' that is in the location
+        """
+        if self.display_organization:
+            return self.display_organization
+
         return self.location.org

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -6,6 +6,7 @@ from path import path  # NOTE (THK): Only used for detecting presence of syllabu
 import requests
 from datetime import datetime
 import dateutil.parser
+import cgi
 
 from xmodule.modulestore import Location
 from xmodule.seq_module import SequenceDescriptor, SequenceModule
@@ -944,9 +945,9 @@ class CourseDescriptor(CourseFields, SequenceDescriptor):
         Return a display course number if it has been specified, otherwise return the 'course' that is in the location
         """
         if self.display_coursenumber:
-            return self.display_coursenumber
+            return cgi.escape(self.display_coursenumber)
 
-        return self.location.course
+        return self.number
 
     @property
     def org(self):
@@ -958,6 +959,6 @@ class CourseDescriptor(CourseFields, SequenceDescriptor):
         Return a display organization if it has been specified, otherwise return the 'org' that is in the location
         """
         if self.display_organization:
-            return self.display_organization
+            return cgi.escape(self.display_organization)
 
-        return self.location.org
+        return self.org

--- a/common/lib/xmodule/xmodule/tests/test_course_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_course_module.py
@@ -53,7 +53,7 @@ def get_dummy_course(start, announcement=None, is_new=None, advertised_start=Non
     end = to_attrb('end', end)
 
     start_xml = '''
-         <course org="{org}" course="{course}"
+         <course org="{org}" course="{course}" display_organization="{org}_display" display_coursenumber="{course}_display"
                 graceperiod="1 day" url_name="test"
                 start="{start}"
                 {announcement}
@@ -140,6 +140,16 @@ class IsNewCourseTestCase(unittest.TestCase):
             d = get_dummy_course(start=s[0], advertised_start=s[1])
             print "Checking start=%s advertised=%s" % (s[0], s[1])
             self.assertEqual(d.start_date_text, s[2])
+
+    def test_display_organization(self):
+        descriptor = get_dummy_course(start='2012-12-02T12:00', is_new=True)
+        self.assertNotEqual(descriptor.location.org, descriptor.display_org_with_default)
+        self.assertEqual(descriptor.display_org_with_default, "{0}_display".format(ORG))
+
+    def test_display_coursenumber(self):
+        descriptor = get_dummy_course(start='2012-12-02T12:00', is_new=True)
+        self.assertNotEqual(descriptor.location.course, descriptor.display_number_with_default)
+        self.assertEqual(descriptor.display_number_with_default, "{0}_display".format(COURSE))
 
     def test_is_newish(self):
         descriptor = get_dummy_course(start='2012-12-02T12:00', is_new=True)

--- a/common/test/data/toy/roots/2012_Fall.xml
+++ b/common/test/data/toy/roots/2012_Fall.xml
@@ -1,1 +1,1 @@
-<course org="edX" course="toy" url_name="2012_Fall"/>
+<course org="edX" course="toy" url_name="2012_Fall" display_organization="edX_display" display_coursenum="2012_Fall_Display" />

--- a/lms/djangoapps/course_wiki/views.py
+++ b/lms/djangoapps/course_wiki/views.py
@@ -95,7 +95,7 @@ def course_wiki_redirect(request, course_id):
             root,
             course_slug,
             title=course_slug,
-            content="This is the wiki for **{0}**'s _{1}_.".format(course.org, course.display_name_with_default),
+            content="This is the wiki for **{0}**'s _{1}_.".format(course.display_org_with_default, course.display_name_with_default),
             user_message="Course page automatically created.",
             user=None,
             ip_address=None,

--- a/lms/djangoapps/course_wiki/views.py
+++ b/lms/djangoapps/course_wiki/views.py
@@ -1,5 +1,6 @@
 import logging
 import re
+import cgi
 
 from django.conf import settings
 from django.contrib.sites.models import Site
@@ -95,7 +96,7 @@ def course_wiki_redirect(request, course_id):
             root,
             course_slug,
             title=course_slug,
-            content="This is the wiki for **{0}**'s _{1}_.".format(course.display_org_with_default, course.display_name_with_default),
+            content=cgi.escape("This is the wiki for **{0}**'s _{1}_.".format(course.display_org_with_default, course.display_name_with_default)),
             user_message="Course page automatically created.",
             user=None,
             ip_address=None,

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -174,9 +174,9 @@ def get_course_about_section(course, section_key):
     elif section_key == "title":
         return course.display_name_with_default
     elif section_key == "university":
-        return course.location.org
+        return course.display_org_with_default
     elif section_key == "number":
-        return course.number
+        return course.display_number_with_default
 
     raise KeyError("Invalid about key " + str(section_key))
 

--- a/lms/templates/course.html
+++ b/lms/templates/course.html
@@ -14,13 +14,13 @@ from courseware.courses import course_image_url, get_course_about_section
   <div class="inner-wrapper">
       <header class="course-preview">
         <hgroup>
-          <h2><span class="course-number">${course.display_number_with_default}</span> ${get_course_about_section(course, 'title')}</h2>
+          <h2><span class="course-number">${course.display_number_with_default | h}</span> ${get_course_about_section(course, 'title')}</h2>
         </hgroup>
         <div class="info-link">&#x2794;</div>
       </header>
       <section class="info">
         <div class="cover-image">
-          <img src="${course_image_url(course)}" alt="${course.display_number_with_default} ${get_course_about_section(course, 'title')} Cover Image" />
+          <img src="${course_image_url(course)}" alt="${course.display_number_with_default | h} ${get_course_about_section(course, 'title')} Cover Image" />
         </div>
         <div class="desc">
           <p>${get_course_about_section(course, 'short_description')}</p>

--- a/lms/templates/course.html
+++ b/lms/templates/course.html
@@ -14,13 +14,13 @@ from courseware.courses import course_image_url, get_course_about_section
   <div class="inner-wrapper">
       <header class="course-preview">
         <hgroup>
-          <h2><span class="course-number">${course.number}</span> ${get_course_about_section(course, 'title')}</h2>
+          <h2><span class="course-number">${course.display_number_with_default}</span> ${get_course_about_section(course, 'title')}</h2>
         </hgroup>
         <div class="info-link">&#x2794;</div>
       </header>
       <section class="info">
         <div class="cover-image">
-          <img src="${course_image_url(course)}" alt="${course.number} ${get_course_about_section(course, 'title')} Cover Image" />
+          <img src="${course_image_url(course)}" alt="${course.display_number_with_default} ${get_course_about_section(course, 'title')} Cover Image" />
         </div>
         <div class="desc">
           <p>${get_course_about_section(course, 'short_description')}</p>

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -94,7 +94,7 @@
                     </a>
                 %endif
         %else:
-            <a href="#" class="register">${_("Register for {course.display_number_with_default}").format(course=course)}</a>
+            <a href="#" class="register">${_("Register for {course.display_number_with_default}").format(course=course) | h}</a>
 
             <div id="register_error"></div>
         %endif

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -88,7 +88,7 @@
                     <a href="${course_target}">
                 %endif
 
-                <span class="register disabled">${_("You are registered for this course {course.display_number_with_default}").
+                <span class="register disabled">${_("You are registered for this course {course.display_number_with_default}").format(course=course) | h}</span>
                 %if show_courseware_link:
                     <strong>${_("View Courseware")}</strong>
                     </a>

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -66,15 +66,7 @@
   <script src="${static.url('js/course_info.js')}"></script>
 </%block>
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-<%block name="title"><title>${_("About {course.number}").format(course=course)}</title></%block>
-=======
-<%block name="title"><title>About ${course.display_number_with_default}</title></%block>
->>>>>>> add display_coursenumber and display_organization fields on the CourseModule, with some property accessors. Update LMS/CMS pages to use those display strings as appropraite.
-=======
-<%block name="title"><title>About ${course.display_number_with_default | h}</title></%block>
->>>>>>> add escaping
+<%block name="title"><title>${_("About {course.display_number_with_default}").format(course=course) | h}</title></%block>
 
 <section class="course-info">
   <header class="course-profile">
@@ -95,25 +87,15 @@
 	              %if show_courseware_link:
                     <a href="${course_target}">
                 %endif
-<<<<<<< HEAD
-                <span class="register disabled">${_("You are registered for this course {course.number}").format(course=course)}</span>
-=======
-                <span class="register disabled">You are registered for this course (${course.display_number_with_default})</span>
->>>>>>> add display_coursenumber and display_organization fields on the CourseModule, with some property accessors. Update LMS/CMS pages to use those display strings as appropraite.
+
+                <span class="register disabled">${_("You are registered for this course {course.display_number_with_default}").
                 %if show_courseware_link:
                     <strong>${_("View Courseware")}</strong>
                     </a>
                 %endif
         %else:
-<<<<<<< HEAD
-<<<<<<< HEAD
-            <a href="#" class="register">${_("Register for {course.number}").format(course=course)}</a>
-=======
-            <a href="#" class="register">Register for ${course.display_number_with_default}</a>
->>>>>>> add display_coursenumber and display_organization fields on the CourseModule, with some property accessors. Update LMS/CMS pages to use those display strings as appropraite.
-=======
-            <a href="#" class="register">Register for ${course.display_number_with_default | h}</a>
->>>>>>> add escaping
+            <a href="#" class="register">${_("Register for {course.display_number_with_default}").format(course=course)}</a>
+
             <div id="register_error"></div>
         %endif
         </div>
@@ -182,17 +164,8 @@
         </header>
 
         <ol class="important-dates">
-<<<<<<< HEAD
-<<<<<<< HEAD
-          <li><div class="icon course-number"></div><p>${_("Course Number")}</p><span class="course-number">${course.number}</span></li>
+          <li><div class="icon course-number"></div><p>${_("Course Number")}</p><span class="course-number">${course.display_number_with_default | h}</span></li>
           <li><div class="icon start"></div><p>${_("Classes Start")}</p><span class="start-date">${course.start_date_text}</span></li>
-=======
-          <li><div class="icon course-number"></div><p>Course Number</p><span class="course-number">${course.display_number_with_default}</span></li>
-=======
-          <li><div class="icon course-number"></div><p>Course Number</p><span class="course-number">${course.display_number_with_default | h}</span></li>
->>>>>>> add escaping
-          <li><div class="icon start"></div><p>Classes Start</p><span class="start-date">${course.start_date_text}</span></li>
->>>>>>> add display_coursenumber and display_organization fields on the CourseModule, with some property accessors. Update LMS/CMS pages to use those display strings as appropraite.
 
             ## We plan to ditch end_date (which is not stored in course metadata),
             ## but for backwards compatibility, show about/end_date blob if it exists.

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -67,10 +67,14 @@
 </%block>
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 <%block name="title"><title>${_("About {course.number}").format(course=course)}</title></%block>
 =======
 <%block name="title"><title>About ${course.display_number_with_default}</title></%block>
 >>>>>>> add display_coursenumber and display_organization fields on the CourseModule, with some property accessors. Update LMS/CMS pages to use those display strings as appropraite.
+=======
+<%block name="title"><title>About ${course.display_number_with_default | h}</title></%block>
+>>>>>>> add escaping
 
 <section class="course-info">
   <header class="course-profile">
@@ -79,7 +83,7 @@
       <section class="intro">
         <hgroup>
           <h1>
-            ${course.display_number_with_default}: ${get_course_about_section(course, "title")}
+            ${course.display_number_with_default | h}: ${get_course_about_section(course, "title")}
             % if not self.theme_enabled():
               <a href="#">${get_course_about_section(course, "university")}</a>
             % endif
@@ -102,10 +106,14 @@
                 %endif
         %else:
 <<<<<<< HEAD
+<<<<<<< HEAD
             <a href="#" class="register">${_("Register for {course.number}").format(course=course)}</a>
 =======
             <a href="#" class="register">Register for ${course.display_number_with_default}</a>
 >>>>>>> add display_coursenumber and display_organization fields on the CourseModule, with some property accessors. Update LMS/CMS pages to use those display strings as appropraite.
+=======
+            <a href="#" class="register">Register for ${course.display_number_with_default | h}</a>
+>>>>>>> add escaping
             <div id="register_error"></div>
         %endif
         </div>
@@ -175,10 +183,14 @@
 
         <ol class="important-dates">
 <<<<<<< HEAD
+<<<<<<< HEAD
           <li><div class="icon course-number"></div><p>${_("Course Number")}</p><span class="course-number">${course.number}</span></li>
           <li><div class="icon start"></div><p>${_("Classes Start")}</p><span class="start-date">${course.start_date_text}</span></li>
 =======
           <li><div class="icon course-number"></div><p>Course Number</p><span class="course-number">${course.display_number_with_default}</span></li>
+=======
+          <li><div class="icon course-number"></div><p>Course Number</p><span class="course-number">${course.display_number_with_default | h}</span></li>
+>>>>>>> add escaping
           <li><div class="icon start"></div><p>Classes Start</p><span class="start-date">${course.start_date_text}</span></li>
 >>>>>>> add display_coursenumber and display_organization fields on the CourseModule, with some property accessors. Update LMS/CMS pages to use those display strings as appropraite.
 

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -66,7 +66,11 @@
   <script src="${static.url('js/course_info.js')}"></script>
 </%block>
 
+<<<<<<< HEAD
 <%block name="title"><title>${_("About {course.number}").format(course=course)}</title></%block>
+=======
+<%block name="title"><title>About ${course.display_number_with_default}</title></%block>
+>>>>>>> add display_coursenumber and display_organization fields on the CourseModule, with some property accessors. Update LMS/CMS pages to use those display strings as appropraite.
 
 <section class="course-info">
   <header class="course-profile">
@@ -75,7 +79,7 @@
       <section class="intro">
         <hgroup>
           <h1>
-            ${course.number}: ${get_course_about_section(course, "title")}
+            ${course.display_number_with_default}: ${get_course_about_section(course, "title")}
             % if not self.theme_enabled():
               <a href="#">${get_course_about_section(course, "university")}</a>
             % endif
@@ -87,13 +91,21 @@
 	              %if show_courseware_link:
                     <a href="${course_target}">
                 %endif
+<<<<<<< HEAD
                 <span class="register disabled">${_("You are registered for this course {course.number}").format(course=course)}</span>
+=======
+                <span class="register disabled">You are registered for this course (${course.display_number_with_default})</span>
+>>>>>>> add display_coursenumber and display_organization fields on the CourseModule, with some property accessors. Update LMS/CMS pages to use those display strings as appropraite.
                 %if show_courseware_link:
                     <strong>${_("View Courseware")}</strong>
                     </a>
                 %endif
         %else:
+<<<<<<< HEAD
             <a href="#" class="register">${_("Register for {course.number}").format(course=course)}</a>
+=======
+            <a href="#" class="register">Register for ${course.display_number_with_default}</a>
+>>>>>>> add display_coursenumber and display_organization fields on the CourseModule, with some property accessors. Update LMS/CMS pages to use those display strings as appropraite.
             <div id="register_error"></div>
         %endif
         </div>
@@ -162,8 +174,13 @@
         </header>
 
         <ol class="important-dates">
+<<<<<<< HEAD
           <li><div class="icon course-number"></div><p>${_("Course Number")}</p><span class="course-number">${course.number}</span></li>
           <li><div class="icon start"></div><p>${_("Classes Start")}</p><span class="start-date">${course.start_date_text}</span></li>
+=======
+          <li><div class="icon course-number"></div><p>Course Number</p><span class="course-number">${course.display_number_with_default}</span></li>
+          <li><div class="icon start"></div><p>Classes Start</p><span class="start-date">${course.start_date_text}</span></li>
+>>>>>>> add display_coursenumber and display_organization fields on the CourseModule, with some property accessors. Update LMS/CMS pages to use those display strings as appropraite.
 
             ## We plan to ditch end_date (which is not stored in course metadata),
             ## but for backwards compatibility, show about/end_date blob if it exists.

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -2,7 +2,7 @@
 <%inherit file="/main.html" />
 <%namespace name='static' file='/static_content.html'/>
 <%block name="bodyclass">courseware ${course.css_class}</%block>
-<%block name="title"><title>${_("{course_number} Courseware").format(course_number=course.number)}</title></%block>
+<%block name="title"><title>${_("{course_number} Courseware").format(course_number=course.display_number_with_default)}</title></%block>
 
 <%block name="headextra">
   <%static:css group='course'/>

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -2,7 +2,11 @@
 <%inherit file="/main.html" />
 <%namespace name='static' file='/static_content.html'/>
 <%block name="bodyclass">courseware ${course.css_class}</%block>
+<<<<<<< HEAD
 <%block name="title"><title>${_("{course_number} Courseware").format(course_number=course.display_number_with_default)}</title></%block>
+=======
+<%block name="title"><title>${course.display_number_with_default | h} Courseware</title></%block>
+>>>>>>> add escaping
 
 <%block name="headextra">
   <%static:css group='course'/>

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -2,11 +2,7 @@
 <%inherit file="/main.html" />
 <%namespace name='static' file='/static_content.html'/>
 <%block name="bodyclass">courseware ${course.css_class}</%block>
-<<<<<<< HEAD
-<%block name="title"><title>${_("{course_number} Courseware").format(course_number=course.display_number_with_default)}</title></%block>
-=======
-<%block name="title"><title>${course.display_number_with_default | h} Courseware</title></%block>
->>>>>>> add escaping
+<%block name="title"><title>${_("{course_number} Courseware").format(course_number=course.display_number_with_default) | h}</title></%block>
 
 <%block name="headextra">
   <%static:css group='course'/>

--- a/lms/templates/courseware/info.html
+++ b/lms/templates/courseware/info.html
@@ -7,7 +7,7 @@
   <%static:css group='course'/>
 </%block>
 
-<%block name="title"><title>${_("{course.number} Course Info").format(course=course.display_number_with_default) | h}</title></%block>
+<%block name="title"><title>${_("{course.number} Course Info").format(course=course) | h}</title></%block>
 <%include file="/courseware/course_navigation.html" args="active_page='info'" />
 <%!
   from courseware.courses import get_course_info_section

--- a/lms/templates/courseware/info.html
+++ b/lms/templates/courseware/info.html
@@ -7,7 +7,7 @@
   <%static:css group='course'/>
 </%block>
 
-<%block name="title"><title>${_("{course.number} Course Info").format(course=course) | h}</title></%block>
+<%block name="title"><title>${_("{course.display_number_with_default} Course Info").format(course=course) | h}</title></%block>
 <%include file="/courseware/course_navigation.html" args="active_page='info'" />
 <%!
   from courseware.courses import get_course_info_section

--- a/lms/templates/courseware/info.html
+++ b/lms/templates/courseware/info.html
@@ -7,7 +7,11 @@
   <%static:css group='course'/>
 </%block>
 
+<<<<<<< HEAD
 <%block name="title"><title>${_("{course.number} Course Info").format(course=course.display_number_with_default)}</title></%block>
+=======
+<%block name="title"><title>${course.display_number_with_default | h} Course Info</title></%block>
+>>>>>>> add escaping
 
 <%include file="/courseware/course_navigation.html" args="active_page='info'" />
 <%!

--- a/lms/templates/courseware/info.html
+++ b/lms/templates/courseware/info.html
@@ -7,12 +7,7 @@
   <%static:css group='course'/>
 </%block>
 
-<<<<<<< HEAD
-<%block name="title"><title>${_("{course.number} Course Info").format(course=course.display_number_with_default)}</title></%block>
-=======
-<%block name="title"><title>${course.display_number_with_default | h} Course Info</title></%block>
->>>>>>> add escaping
-
+<%block name="title"><title>${_("{course.number} Course Info").format(course=course.display_number_with_default) | h}</title></%block>
 <%include file="/courseware/course_navigation.html" args="active_page='info'" />
 <%!
   from courseware.courses import get_course_info_section

--- a/lms/templates/courseware/info.html
+++ b/lms/templates/courseware/info.html
@@ -7,7 +7,7 @@
   <%static:css group='course'/>
 </%block>
 
-<%block name="title"><title>${_("{course.number} Course Info").format(course=course)}</title></%block>
+<%block name="title"><title>${_("{course.number} Course Info").format(course=course.display_number_with_default)}</title></%block>
 
 <%include file="/courseware/course_navigation.html" args="active_page='info'" />
 <%!

--- a/lms/templates/courseware/mktg_course_about.html
+++ b/lms/templates/courseware/mktg_course_about.html
@@ -8,11 +8,7 @@
 
 <%inherit file="../mktg_iframe.html" />
 
-<<<<<<< HEAD
-<%block name="title"><title>${_("About {course_number}").format(course_number=course.display_number_with_default)}</title></%block>
-=======
-<%block name="title"><title>About ${course.display_number_with_default | h}</title></%block>
->>>>>>> add escaping
+<%block name="title"><title>${_("About {course_number}").format(course_number=course.display_number_with_default) | h}</title></%block>
 
 <%block name="bodyclass">view-partial-mktgregister</%block>
 
@@ -56,11 +52,7 @@
             <div class="action is-registered">${_("You Are Registered")}</div>
           %endif
         %elif allow_registration:
-<<<<<<< HEAD
-          <a class="action action-register register" href="#">${_("Register for")} <strong>${course.display_number_with_default}</strong></a>
-=======
-          <a class="action action-register register" href="#">Register for <strong>${course.display_number_with_default | h}</strong></a>
->>>>>>> add escaping
+          <a class="action action-register register" href="#">${_("Register for")} <strong>${course.display_number_with_default | h}</strong></a>
         %else:
           <div class="action registration-closed is-disabled">${_("Registration Is Closed")}</div>
         %endif

--- a/lms/templates/courseware/mktg_course_about.html
+++ b/lms/templates/courseware/mktg_course_about.html
@@ -8,7 +8,11 @@
 
 <%inherit file="../mktg_iframe.html" />
 
+<<<<<<< HEAD
 <%block name="title"><title>${_("About {course_number}").format(course_number=course.display_number_with_default)}</title></%block>
+=======
+<%block name="title"><title>About ${course.display_number_with_default | h}</title></%block>
+>>>>>>> add escaping
 
 <%block name="bodyclass">view-partial-mktgregister</%block>
 
@@ -52,7 +56,11 @@
             <div class="action is-registered">${_("You Are Registered")}</div>
           %endif
         %elif allow_registration:
+<<<<<<< HEAD
           <a class="action action-register register" href="#">${_("Register for")} <strong>${course.display_number_with_default}</strong></a>
+=======
+          <a class="action action-register register" href="#">Register for <strong>${course.display_number_with_default | h}</strong></a>
+>>>>>>> add escaping
         %else:
           <div class="action registration-closed is-disabled">${_("Registration Is Closed")}</div>
         %endif

--- a/lms/templates/courseware/mktg_course_about.html
+++ b/lms/templates/courseware/mktg_course_about.html
@@ -8,7 +8,7 @@
 
 <%inherit file="../mktg_iframe.html" />
 
-<%block name="title"><title>${_("About {course_number}").format(course_number=course.number)}</title></%block>
+<%block name="title"><title>${_("About {course_number}").format(course_number=course.display_number_with_default)}</title></%block>
 
 <%block name="bodyclass">view-partial-mktgregister</%block>
 
@@ -52,7 +52,7 @@
             <div class="action is-registered">${_("You Are Registered")}</div>
           %endif
         %elif allow_registration:
-          <a class="action action-register register" href="#">${_("Register for")} <strong>${course.number}</strong></a>
+          <a class="action action-register register" href="#">${_("Register for")} <strong>${course.display_number_with_default}</strong></a>
         %else:
           <div class="action registration-closed is-disabled">${_("Registration Is Closed")}</div>
         %endif

--- a/lms/templates/courseware/progress.html
+++ b/lms/templates/courseware/progress.html
@@ -8,7 +8,7 @@
 
 <%namespace name="progress_graph" file="/courseware/progress_graph.js"/>
 
-<%block name="title"><title>${_("{course_number} Progress").format(course_number=course.number)}</title></%block>
+<%block name="title"><title>${_("{course_number} Progress").format(course_number=course.display_number_with_default)}</title></%block>
 
 <%!
     from django.core.urlresolvers import reverse

--- a/lms/templates/courseware/progress.html
+++ b/lms/templates/courseware/progress.html
@@ -8,11 +8,7 @@
 
 <%namespace name="progress_graph" file="/courseware/progress_graph.js"/>
 
-<<<<<<< HEAD
-<%block name="title"><title>${_("{course_number} Progress").format(course_number=course.display_number_with_default)}</title></%block>
-=======
-<%block name="title"><title>${course.display_number_with_default | h} Progress</title></%block>
->>>>>>> add escaping
+<%block name="title"><title>${_("{course_number} Progress").format(course_number=course.display_number_with_default) | h}</title></%block>
 
 <%!
     from django.core.urlresolvers import reverse

--- a/lms/templates/courseware/progress.html
+++ b/lms/templates/courseware/progress.html
@@ -8,7 +8,11 @@
 
 <%namespace name="progress_graph" file="/courseware/progress_graph.js"/>
 
+<<<<<<< HEAD
 <%block name="title"><title>${_("{course_number} Progress").format(course_number=course.display_number_with_default)}</title></%block>
+=======
+<%block name="title"><title>${course.display_number_with_default | h} Progress</title></%block>
+>>>>>>> add escaping
 
 <%!
     from django.core.urlresolvers import reverse

--- a/lms/templates/courseware/static_tab.html
+++ b/lms/templates/courseware/static_tab.html
@@ -6,7 +6,7 @@
   <%static:css group='course'/>
 </%block>
 
-<%block name="title"><title>${course.number} ${tab['name']}</title></%block>
+<%block name="title"><title>${course.display_number_with_default} ${tab['name']}</title></%block>
 
 <%include file="/courseware/course_navigation.html" args="active_page='static_tab_{0}'.format(tab['url_slug'])" />
 

--- a/lms/templates/courseware/static_tab.html
+++ b/lms/templates/courseware/static_tab.html
@@ -6,7 +6,7 @@
   <%static:css group='course'/>
 </%block>
 
-<%block name="title"><title>${course.display_number_with_default} ${tab['name']}</title></%block>
+<%block name="title"><title>${course.display_number_with_default | h} ${tab['name']}</title></%block>
 
 <%include file="/courseware/course_navigation.html" args="active_page='static_tab_{0}'.format(tab['url_slug'])" />
 

--- a/lms/templates/courseware/syllabus.html
+++ b/lms/templates/courseware/syllabus.html
@@ -6,7 +6,11 @@
   <%static:css group='course'/>
 </%block>
 
+<<<<<<< HEAD
 <%block name="title"><title>${_("{course.display_number_with_default} Course Info").format(course=course)}</title></%block>
+=======
+<%block name="title"><title>${course.display_number_with_default | h} Course Info</title></%block>
+>>>>>>> add escaping
 
 <%include file="/courseware/course_navigation.html" args="active_page='syllabus'" />
 <%!

--- a/lms/templates/courseware/syllabus.html
+++ b/lms/templates/courseware/syllabus.html
@@ -6,11 +6,7 @@
   <%static:css group='course'/>
 </%block>
 
-<<<<<<< HEAD
-<%block name="title"><title>${_("{course.display_number_with_default} Course Info").format(course=course)}</title></%block>
-=======
-<%block name="title"><title>${course.display_number_with_default | h} Course Info</title></%block>
->>>>>>> add escaping
+<%block name="title"><title>${_("{course.display_number_with_default} Course Info").format(course=course) | h}</title></%block>
 
 <%include file="/courseware/course_navigation.html" args="active_page='syllabus'" />
 <%!

--- a/lms/templates/courseware/syllabus.html
+++ b/lms/templates/courseware/syllabus.html
@@ -6,7 +6,7 @@
   <%static:css group='course'/>
 </%block>
 
-<%block name="title"><title>${_("{course.number} Course Info").format(course=course)}</title></%block>
+<%block name="title"><title>${_("{course.display_number_with_default} Course Info").format(course=course)}</title></%block>
 
 <%include file="/courseware/course_navigation.html" args="active_page='syllabus'" />
 <%!

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -141,6 +141,7 @@
           % if course.id in show_courseware_links_for:
             <a href="${course_target}" class="cover">
 <<<<<<< HEAD
+<<<<<<< HEAD
               <img src="${course_image_url(course)}" alt="${_('{course_number} {course_name} Cover Image').format(course_number='${course.number}', course_name='${course.display_name_with_default}')}" />
             </a>
           % else:
@@ -153,6 +154,13 @@
             <div class="cover">
               <img src="${course_image_url(course)}" alt="${course.display_number_with_default} ${course.display_name_with_default} Cover Image" />
 >>>>>>> add display_coursenumber and display_organization fields on the CourseModule, with some property accessors. Update LMS/CMS pages to use those display strings as appropraite.
+=======
+              <img src="${course_image_url(course)}" alt="${course.display_number_with_default | h} ${course.display_name_with_default} Cover Image" />
+            </a>
+          % else:
+            <div class="cover">
+              <img src="${course_image_url(course)}" alt="${course.display_number_with_default | h} ${course.display_name_with_default} Cover Image" />
+>>>>>>> add escaping
             </div>
           % endif
 
@@ -170,9 +178,9 @@
               <h2 class="university">${get_course_about_section(course, 'university')}</h2>
               <h3>
                 % if course.id in show_courseware_links_for:
-                  <a href="${course_target}">${course.display_number_with_default} ${course.display_name_with_default}</a>
+                  <a href="${course_target}">${course.display_number_with_default | h} ${course.display_name_with_default}</a>
                 % else:
-                  <span>${course.display_number_with_default} ${course.display_name_with_default}</span>
+                  <span>${course.display_number_with_default | h} ${course.display_name_with_default}</span>
                 % endif
               </h3>
             </hgroup>
@@ -206,6 +214,7 @@
                     % if  registration.is_rejected:
                 <div class="message message-status is-shown exam-schedule">
 <<<<<<< HEAD
+<<<<<<< HEAD
                   <p class="message-copy">
                     <strong>${_("Your registration for the Pearson exam has been rejected. Please {link_start}see your registration status details{link_end}.").format(
                       link_start='<a href="{url}" id="exam_register_link">'.format(url=testcenter_register_target),
@@ -218,6 +227,9 @@
 =======
                   <p class="message-copy"><strong>Your registration for the Pearson exam has been rejected. Please <a href="${testcenter_register_target}" id="exam_register_link">see your registration status details</a></strong>. Otherwise <a class="contact-link" href="mailto:exam-help@edx.org?subject=Pearson VUE Exam - ${get_course_about_section(course, 'university')} ${course.display_number_with_default}">contact edX at exam-help@edx.org</a> for further help.</p>
 >>>>>>> add display_coursenumber and display_organization fields on the CourseModule, with some property accessors. Update LMS/CMS pages to use those display strings as appropraite.
+=======
+                  <p class="message-copy"><strong>Your registration for the Pearson exam has been rejected. Please <a href="${testcenter_register_target}" id="exam_register_link">see your registration status details</a></strong>. Otherwise <a class="contact-link" href="mailto:exam-help@edx.org?subject=Pearson VUE Exam - ${get_course_about_section(course, 'university')} ${course.display_number_with_default | h}">contact edX at exam-help@edx.org</a> for further help.</p>
+>>>>>>> add escaping
                 </div>
                     % endif
                    	% if not registration.is_accepted and not registration.is_rejected:

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -140,11 +140,19 @@
 
           % if course.id in show_courseware_links_for:
             <a href="${course_target}" class="cover">
+<<<<<<< HEAD
               <img src="${course_image_url(course)}" alt="${_('{course_number} {course_name} Cover Image').format(course_number='${course.number}', course_name='${course.display_name_with_default}')}" />
             </a>
           % else:
             <div class="cover">
               <img src="${course_image_url(course)}" alt="${_('{course_number} {course_name} Cover Image').format(course_number='${course.number}', course_name='${course.display_name_with_default}')}" />
+=======
+              <img src="${course_image_url(course)}" alt="${course.display_number_with_default} ${course.display_name_with_default} Cover Image" />
+            </a>
+          % else:
+            <div class="cover">
+              <img src="${course_image_url(course)}" alt="${course.display_number_with_default} ${course.display_name_with_default} Cover Image" />
+>>>>>>> add display_coursenumber and display_organization fields on the CourseModule, with some property accessors. Update LMS/CMS pages to use those display strings as appropraite.
             </div>
           % endif
 
@@ -162,9 +170,9 @@
               <h2 class="university">${get_course_about_section(course, 'university')}</h2>
               <h3>
                 % if course.id in show_courseware_links_for:
-                  <a href="${course_target}">${course.number} ${course.display_name_with_default}</a>
+                  <a href="${course_target}">${course.display_number_with_default} ${course.display_name_with_default}</a>
                 % else:
-                  <span>${course.number} ${course.display_name_with_default}</span>
+                  <span>${course.display_number_with_default} ${course.display_name_with_default}</span>
                 % endif
               </h3>
             </hgroup>
@@ -197,6 +205,7 @@
                     % endif
                     % if  registration.is_rejected:
                 <div class="message message-status is-shown exam-schedule">
+<<<<<<< HEAD
                   <p class="message-copy">
                     <strong>${_("Your registration for the Pearson exam has been rejected. Please {link_start}see your registration status details{link_end}.").format(
                       link_start='<a href="{url}" id="exam_register_link">'.format(url=testcenter_register_target),
@@ -206,6 +215,9 @@
                       link_end='</a>',
                       email="exam-help@edx.org",
                      )}
+=======
+                  <p class="message-copy"><strong>Your registration for the Pearson exam has been rejected. Please <a href="${testcenter_register_target}" id="exam_register_link">see your registration status details</a></strong>. Otherwise <a class="contact-link" href="mailto:exam-help@edx.org?subject=Pearson VUE Exam - ${get_course_about_section(course, 'university')} ${course.display_number_with_default}">contact edX at exam-help@edx.org</a> for further help.</p>
+>>>>>>> add display_coursenumber and display_organization fields on the CourseModule, with some property accessors. Update LMS/CMS pages to use those display strings as appropraite.
                 </div>
                     % endif
                    	% if not registration.is_accepted and not registration.is_rejected:

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -140,27 +140,11 @@
 
           % if course.id in show_courseware_links_for:
             <a href="${course_target}" class="cover">
-<<<<<<< HEAD
-<<<<<<< HEAD
-              <img src="${course_image_url(course)}" alt="${_('{course_number} {course_name} Cover Image').format(course_number='${course.number}', course_name='${course.display_name_with_default}')}" />
+              <img src="${course_image_url(course)}" alt="${_('{course_number} {course_name} Cover Image').format(course_number='${course.number}', course_name='${course.display_name_with_default}') |h}" />
             </a>
           % else:
             <div class="cover">
               <img src="${course_image_url(course)}" alt="${_('{course_number} {course_name} Cover Image').format(course_number='${course.number}', course_name='${course.display_name_with_default}')}" />
-=======
-              <img src="${course_image_url(course)}" alt="${course.display_number_with_default} ${course.display_name_with_default} Cover Image" />
-            </a>
-          % else:
-            <div class="cover">
-              <img src="${course_image_url(course)}" alt="${course.display_number_with_default} ${course.display_name_with_default} Cover Image" />
->>>>>>> add display_coursenumber and display_organization fields on the CourseModule, with some property accessors. Update LMS/CMS pages to use those display strings as appropraite.
-=======
-              <img src="${course_image_url(course)}" alt="${course.display_number_with_default | h} ${course.display_name_with_default} Cover Image" />
-            </a>
-          % else:
-            <div class="cover">
-              <img src="${course_image_url(course)}" alt="${course.display_number_with_default | h} ${course.display_name_with_default} Cover Image" />
->>>>>>> add escaping
             </div>
           % endif
 
@@ -213,23 +197,15 @@
                     % endif
                     % if  registration.is_rejected:
                 <div class="message message-status is-shown exam-schedule">
-<<<<<<< HEAD
-<<<<<<< HEAD
                   <p class="message-copy">
                     <strong>${_("Your registration for the Pearson exam has been rejected. Please {link_start}see your registration status details{link_end}.").format(
                       link_start='<a href="{url}" id="exam_register_link">'.format(url=testcenter_register_target),
                       link_end='</a>')}</strong>
                     ${_("Otherwise {link_start}contact edX at {email}{link_end} for further help.").format(
-                      link_start='<a class="contact-link" href="mailto:{email}?subject=Pearson VUE Exam - {about} {number}">'.format(email="exam-help@edx.org", about=get_course_about_section(course, 'university'), number=course.number),
+                      link_start='<a class="contact-link" href="mailto:{email}?subject=Pearson VUE Exam - {about} {number}">'.format(email="exam-help@edx.org", about=get_course_about_section(course, 'university'), number=course.display_number_with_default),
                       link_end='</a>',
                       email="exam-help@edx.org",
                      )}
-=======
-                  <p class="message-copy"><strong>Your registration for the Pearson exam has been rejected. Please <a href="${testcenter_register_target}" id="exam_register_link">see your registration status details</a></strong>. Otherwise <a class="contact-link" href="mailto:exam-help@edx.org?subject=Pearson VUE Exam - ${get_course_about_section(course, 'university')} ${course.display_number_with_default}">contact edX at exam-help@edx.org</a> for further help.</p>
->>>>>>> add display_coursenumber and display_organization fields on the CourseModule, with some property accessors. Update LMS/CMS pages to use those display strings as appropraite.
-=======
-                  <p class="message-copy"><strong>Your registration for the Pearson exam has been rejected. Please <a href="${testcenter_register_target}" id="exam_register_link">see your registration status details</a></strong>. Otherwise <a class="contact-link" href="mailto:exam-help@edx.org?subject=Pearson VUE Exam - ${get_course_about_section(course, 'university')} ${course.display_number_with_default | h}">contact edX at exam-help@edx.org</a> for further help.</p>
->>>>>>> add escaping
                 </div>
                     % endif
                    	% if not registration.is_accepted and not registration.is_rejected:

--- a/lms/templates/discussion/index.html
+++ b/lms/templates/discussion/index.html
@@ -6,7 +6,7 @@
 <%inherit file="../main.html" />
 <%namespace name='static' file='../static_content.html'/>
 <%block name="bodyclass">discussion</%block>
-<%block name="title"><title>${_("Discussion - {course_number}").format(course_number=course.number) | h}</title></%block>
+<%block name="title"><title>${_("Discussion - {course_number}").format(course_number=course.display_number_with_default) | h}</title></%block>
 
 <%block name="headextra">
 <%static:css group='course'/>

--- a/lms/templates/discussion/single_thread.html
+++ b/lms/templates/discussion/single_thread.html
@@ -7,7 +7,7 @@
 <%inherit file="../main.html" />
 <%namespace name='static' file='../static_content.html'/>
 <%block name="bodyclass">discussion</%block>
-<%block name="title"><title>${_("Discussion - {course_number}").format(course_number=course.number) | h}</title></%block>
+<%block name="title"><title>${_("Discussion - {course_number}").format(course_number=course.display_number_with_default) | h}</title></%block>
 
 <%block name="headextra">
 <%static:css group='course'/>

--- a/lms/templates/discussion/single_thread.html
+++ b/lms/templates/discussion/single_thread.html
@@ -7,7 +7,11 @@
 <%inherit file="../main.html" />
 <%namespace name='static' file='../static_content.html'/>
 <%block name="bodyclass">discussion</%block>
+<<<<<<< HEAD
 <%block name="title"><title>${_("Discussion - {course_number}").format(course_number=course.display_number_with_default) | h}</title></%block>
+=======
+<%block name="title"><title>Discussion – ${course.display_number_with_default | h}</title></%block>
+>>>>>>> add escaping
 
 <%block name="headextra">
 <%static:css group='course'/>

--- a/lms/templates/discussion/single_thread.html
+++ b/lms/templates/discussion/single_thread.html
@@ -7,11 +7,7 @@
 <%inherit file="../main.html" />
 <%namespace name='static' file='../static_content.html'/>
 <%block name="bodyclass">discussion</%block>
-<<<<<<< HEAD
 <%block name="title"><title>${_("Discussion - {course_number}").format(course_number=course.display_number_with_default) | h}</title></%block>
-=======
-<%block name="title"><title>Discussion – ${course.display_number_with_default | h}</title></%block>
->>>>>>> add escaping
 
 <%block name="headextra">
 <%static:css group='course'/>

--- a/lms/templates/discussion/user_profile.html
+++ b/lms/templates/discussion/user_profile.html
@@ -4,7 +4,7 @@
 <%inherit file="../main.html" />
 <%namespace name='static' file='../static_content.html'/>
 <%block name="bodyclass">discussion</%block>
-<%block name="title"><title>${_("Discussion - {course_number}").format(course_number=course.number) | h}</title></%block>
+<%block name="title"><title>${_("Discussion - {course_number}").format(course_number=course.display_number_with_default) | h}</title></%block>
 
 <%block name="headextra">
 <%static:css group='course'/>

--- a/lms/templates/instructor/staff_grading.html
+++ b/lms/templates/instructor/staff_grading.html
@@ -7,7 +7,11 @@
   <%static:css group='course'/>
 </%block>
 
+<<<<<<< HEAD
 <%block name="title"><title>${_("{course_number} Staff Grading").format(course_number=course.display_number_with_default)}</title></%block>
+=======
+<%block name="title"><title>${course.display_number_with_default | h} Staff Grading</title></%block>
+>>>>>>> add escaping
 
 <%include file="/courseware/course_navigation.html" args="active_page='staff_grading'" />
 

--- a/lms/templates/instructor/staff_grading.html
+++ b/lms/templates/instructor/staff_grading.html
@@ -7,11 +7,7 @@
   <%static:css group='course'/>
 </%block>
 
-<<<<<<< HEAD
-<%block name="title"><title>${_("{course_number} Staff Grading").format(course_number=course.display_number_with_default)}</title></%block>
-=======
-<%block name="title"><title>${course.display_number_with_default | h} Staff Grading</title></%block>
->>>>>>> add escaping
+<%block name="title"><title>${_("{course_number} Staff Grading").format(course_number=course.display_number_with_default) | h}</title></%block>
 
 <%include file="/courseware/course_navigation.html" args="active_page='staff_grading'" />
 

--- a/lms/templates/instructor/staff_grading.html
+++ b/lms/templates/instructor/staff_grading.html
@@ -7,7 +7,7 @@
   <%static:css group='course'/>
 </%block>
 
-<%block name="title"><title>${_("{course_number} Staff Grading").format(course_number=course.number)}</title></%block>
+<%block name="title"><title>${_("{course_number} Staff Grading").format(course_number=course.display_number_with_default)}</title></%block>
 
 <%include file="/courseware/course_navigation.html" args="active_page='staff_grading'" />
 

--- a/lms/templates/navigation.html
+++ b/lms/templates/navigation.html
@@ -50,7 +50,7 @@ site_status_msg = get_site_status_msg(course_id)
   </h1>
 
     % if course:
-      <h2><span class="provider">${course.display_org_with_default}:</span> ${course.display_number_with_default} ${course.display_name_with_default}</h2>
+      <h2><span class="provider">${course.display_org_with_default | h}:</span> ${course.display_number_with_default | h} ${course.display_name_with_default}</h2>
     % endif
 
     % if user.is_authenticated():

--- a/lms/templates/navigation.html
+++ b/lms/templates/navigation.html
@@ -50,7 +50,7 @@ site_status_msg = get_site_status_msg(course_id)
   </h1>
 
     % if course:
-      <h2><span class="provider">${course.org}:</span> ${course.number} ${course.display_name_with_default}</h2>
+      <h2><span class="provider">${course.display_org_with_default}:</span> ${course.display_number_with_default} ${course.display_name_with_default}</h2>
     % endif
 
     % if user.is_authenticated():

--- a/lms/templates/open_ended_problems/combined_notifications.html
+++ b/lms/templates/open_ended_problems/combined_notifications.html
@@ -7,11 +7,7 @@
 <%static:css group='course'/>
 </%block>
 
-<<<<<<< HEAD
-<%block name="title"><title>${_("{course_number} Combined Notifications").format(course_number=course.display_number_with_default)}</title></%block>
-=======
-<%block name="title"><title>${course.display_number_with_default | h} Combined Notifications</title></%block>
->>>>>>> add escaping
+<%block name="title"><title>${_("{course_number} Combined Notifications").format(course_number=course.display_number_with_default) | h}</title></%block>
 
 <%include file="/courseware/course_navigation.html" args="active_page='open_ended'" />
 

--- a/lms/templates/open_ended_problems/combined_notifications.html
+++ b/lms/templates/open_ended_problems/combined_notifications.html
@@ -7,7 +7,11 @@
 <%static:css group='course'/>
 </%block>
 
+<<<<<<< HEAD
 <%block name="title"><title>${_("{course_number} Combined Notifications").format(course_number=course.display_number_with_default)}</title></%block>
+=======
+<%block name="title"><title>${course.display_number_with_default | h} Combined Notifications</title></%block>
+>>>>>>> add escaping
 
 <%include file="/courseware/course_navigation.html" args="active_page='open_ended'" />
 

--- a/lms/templates/open_ended_problems/combined_notifications.html
+++ b/lms/templates/open_ended_problems/combined_notifications.html
@@ -7,7 +7,7 @@
 <%static:css group='course'/>
 </%block>
 
-<%block name="title"><title>${_("{course_number} Combined Notifications").format(course_number=course.number)}</title></%block>
+<%block name="title"><title>${_("{course_number} Combined Notifications").format(course_number=course.display_number_with_default)}</title></%block>
 
 <%include file="/courseware/course_navigation.html" args="active_page='open_ended'" />
 

--- a/lms/templates/open_ended_problems/open_ended_flagged_problems.html
+++ b/lms/templates/open_ended_problems/open_ended_flagged_problems.html
@@ -7,11 +7,7 @@
 <%static:css group='course'/>
 </%block>
 
-<<<<<<< HEAD
-<%block name="title"><title>${_("{course_number} Flagged Open Ended Problems").format(course_number=course.display_number_with_default)}</title></%block>
-=======
-<%block name="title"><title>${course.display_number_with_default | h} Flagged Open Ended Problems</title></%block>
->>>>>>> add escaping
+<%block name="title"><title>${_("{course_number} Flagged Open Ended Problems").format(course_number=course.display_number_with_default) | h}</title></%block>
 
 <%include file="/courseware/course_navigation.html" args="active_page='open_ended_flagged_problems'" />
 

--- a/lms/templates/open_ended_problems/open_ended_flagged_problems.html
+++ b/lms/templates/open_ended_problems/open_ended_flagged_problems.html
@@ -7,7 +7,7 @@
 <%static:css group='course'/>
 </%block>
 
-<%block name="title"><title>${_("{course_number} Flagged Open Ended Problems").format(course_number=course.number)}</title></%block>
+<%block name="title"><title>${_("{course_number} Flagged Open Ended Problems").format(course_number=course.display_number_with_default)}</title></%block>
 
 <%include file="/courseware/course_navigation.html" args="active_page='open_ended_flagged_problems'" />
 

--- a/lms/templates/open_ended_problems/open_ended_flagged_problems.html
+++ b/lms/templates/open_ended_problems/open_ended_flagged_problems.html
@@ -7,7 +7,11 @@
 <%static:css group='course'/>
 </%block>
 
+<<<<<<< HEAD
 <%block name="title"><title>${_("{course_number} Flagged Open Ended Problems").format(course_number=course.display_number_with_default)}</title></%block>
+=======
+<%block name="title"><title>${course.display_number_with_default | h} Flagged Open Ended Problems</title></%block>
+>>>>>>> add escaping
 
 <%include file="/courseware/course_navigation.html" args="active_page='open_ended_flagged_problems'" />
 

--- a/lms/templates/open_ended_problems/open_ended_problems.html
+++ b/lms/templates/open_ended_problems/open_ended_problems.html
@@ -7,7 +7,11 @@
 <%static:css group='course'/>
 </%block>
 
+<<<<<<< HEAD
 <%block name="title"><title>${_("{course_number} Open Ended Problems").format(course_number=course.display_number_with_default)}</title></%block>
+=======
+<%block name="title"><title>${course.display_number_with_default | h} Open Ended Problems</title></%block>
+>>>>>>> add escaping
 
 <%include file="/courseware/course_navigation.html" args="active_page='open_ended_problems'" />
 

--- a/lms/templates/open_ended_problems/open_ended_problems.html
+++ b/lms/templates/open_ended_problems/open_ended_problems.html
@@ -7,11 +7,7 @@
 <%static:css group='course'/>
 </%block>
 
-<<<<<<< HEAD
-<%block name="title"><title>${_("{course_number} Open Ended Problems").format(course_number=course.display_number_with_default)}</title></%block>
-=======
-<%block name="title"><title>${course.display_number_with_default | h} Open Ended Problems</title></%block>
->>>>>>> add escaping
+<%block name="title"><title>${_("{course_number} Open Ended Problems").format(course_number=course.display_number_with_default) | h}</title></%block>
 
 <%include file="/courseware/course_navigation.html" args="active_page='open_ended_problems'" />
 

--- a/lms/templates/open_ended_problems/open_ended_problems.html
+++ b/lms/templates/open_ended_problems/open_ended_problems.html
@@ -7,7 +7,7 @@
 <%static:css group='course'/>
 </%block>
 
-<%block name="title"><title>${_("{course_number} Open Ended Problems").format(course_number=course.number)}</title></%block>
+<%block name="title"><title>${_("{course_number} Open Ended Problems").format(course_number=course.display_number_with_default)}</title></%block>
 
 <%include file="/courseware/course_navigation.html" args="active_page='open_ended_problems'" />
 

--- a/lms/templates/static_htmlbook.html
+++ b/lms/templates/static_htmlbook.html
@@ -2,8 +2,12 @@
 
 <%inherit file="main.html" />
 <%namespace name='static' file='static_content.html'/>
+<<<<<<< HEAD
 <%block name="title"><title>${_('{course_number} Textbook').format(course_number=course.display_number_with_default)}</title>
 
+=======
+<%block name="title"><title>${course.display_number_with_default | h} Textbook</title>
+>>>>>>> add escaping
 </%block>
 
 <%block name="headextra">

--- a/lms/templates/static_htmlbook.html
+++ b/lms/templates/static_htmlbook.html
@@ -2,7 +2,8 @@
 
 <%inherit file="main.html" />
 <%namespace name='static' file='static_content.html'/>
-<%block name="title"><title>${_('{course_number} Textbook').format(course_number=course.number)}</title>
+<%block name="title"><title>${_('{course_number} Textbook').format(course_number=course.display_number_with_default)}</title>
+
 </%block>
 
 <%block name="headextra">

--- a/lms/templates/static_htmlbook.html
+++ b/lms/templates/static_htmlbook.html
@@ -2,12 +2,7 @@
 
 <%inherit file="main.html" />
 <%namespace name='static' file='static_content.html'/>
-<<<<<<< HEAD
-<%block name="title"><title>${_('{course_number} Textbook').format(course_number=course.display_number_with_default)}</title>
-
-=======
-<%block name="title"><title>${course.display_number_with_default | h} Textbook</title>
->>>>>>> add escaping
+<%block name="title"><title>${_('{course_number} Textbook').format(course_number=course.display_number_with_default) | h}</title>
 </%block>
 
 <%block name="headextra">

--- a/lms/templates/static_pdfbook.html
+++ b/lms/templates/static_pdfbook.html
@@ -3,10 +3,16 @@
 <%inherit file="main.html" />
 <%namespace name='static' file='static_content.html'/>
 <%block name="title">
+<<<<<<< HEAD
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
 <title>${_('{course_number} Textbook').format(course_number=course.display_number_with_default)}</title>
 
+=======
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+    <title>${course.display_number_with_default | h} Textbook</title>
+>>>>>>> add escaping
 </%block>
 
 <%block name="headextra">

--- a/lms/templates/static_pdfbook.html
+++ b/lms/templates/static_pdfbook.html
@@ -5,7 +5,8 @@
 <%block name="title">
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
-<title>${_('{course_number} Textbook').format(course_number=course.number)}</title>
+<title>${_('{course_number} Textbook').format(course_number=course.display_number_with_default)}</title>
+
 </%block>
 
 <%block name="headextra">

--- a/lms/templates/static_pdfbook.html
+++ b/lms/templates/static_pdfbook.html
@@ -3,16 +3,9 @@
 <%inherit file="main.html" />
 <%namespace name='static' file='static_content.html'/>
 <%block name="title">
-<<<<<<< HEAD
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
-<title>${_('{course_number} Textbook').format(course_number=course.display_number_with_default)}</title>
-
-=======
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
-    <title>${course.display_number_with_default | h} Textbook</title>
->>>>>>> add escaping
+<title>${_('{course_number} Textbook').format(course_number=course.display_number_with_default) | h}</title>
 </%block>
 
 <%block name="headextra">

--- a/lms/templates/staticbook.html
+++ b/lms/templates/staticbook.html
@@ -2,7 +2,11 @@
 
 <%inherit file="main.html" />
 <%namespace name='static' file='static_content.html'/>
+<<<<<<< HEAD
 <%block name="title"><title>${_("{course_number} Textbook").format(course_number=course.display_number_with_default)}</title></%block>
+=======
+<%block name="title"><title>${course.display_number_with_default | h} Textbook</title></%block>
+>>>>>>> add escaping
 
 <%block name="headextra">
 <%static:css group='course'/>

--- a/lms/templates/staticbook.html
+++ b/lms/templates/staticbook.html
@@ -2,11 +2,7 @@
 
 <%inherit file="main.html" />
 <%namespace name='static' file='static_content.html'/>
-<<<<<<< HEAD
-<%block name="title"><title>${_("{course_number} Textbook").format(course_number=course.display_number_with_default)}</title></%block>
-=======
-<%block name="title"><title>${course.display_number_with_default | h} Textbook</title></%block>
->>>>>>> add escaping
+<%block name="title"><title>${_("{course_number} Textbook").format(course_number=course.display_number_with_default) | h}</title></%block>
 
 <%block name="headextra">
 <%static:css group='course'/>

--- a/lms/templates/staticbook.html
+++ b/lms/templates/staticbook.html
@@ -2,7 +2,7 @@
 
 <%inherit file="main.html" />
 <%namespace name='static' file='static_content.html'/>
-<%block name="title"><title>${_("{course_number} Textbook").format(course_number=course.number)}</title></%block>
+<%block name="title"><title>${_("{course_number} Textbook").format(course_number=course.display_number_with_default)}</title></%block>
 
 <%block name="headextra">
 <%static:css group='course'/>

--- a/lms/templates/test_center_register.html
+++ b/lms/templates/test_center_register.html
@@ -95,7 +95,7 @@
   <section class="introduction">
     <header>
       <hgroup>
-        <h2><a href="${reverse('dashboard')}">${get_course_about_section(course, 'university')} ${course.display_number_with_default | h} ${course.display_name_with_default}</a></h2>
+        <h2><a href="${reverse('dashboard')}">${get_course_about_section(course, 'university')} ${course.display_number_with_default | h} ${course.display_name_with_default | h}</a></h2>
 
         % if registration:
         <h1>${_('Your Pearson VUE Proctored Exam Registration')}</h1>
@@ -442,7 +442,7 @@
    % endif
 
     <div class="details details-course">
-      <h4>${_("About {university} {course_number}").format(university=get_course_about_section(course, 'university'), course_number=course.course.display_number_with_default)}</h4>
+      <h4>${_("About {university} {course_number}").format(university=get_course_about_section(course, 'university'), course_number=course.course.display_number_with_default) | h}</h4>
       <p>
       % if course.has_ended():
       <span class="label">${_('Course Completed:')}</span> <span class="value">${course.end_date_text}</span>

--- a/lms/templates/test_center_register.html
+++ b/lms/templates/test_center_register.html
@@ -95,7 +95,7 @@
   <section class="introduction">
     <header>
       <hgroup>
-        <h2><a href="${reverse('dashboard')}">${get_course_about_section(course, 'university')} ${course.display_number_with_default} ${course.display_name_with_default}</a></h2>
+        <h2><a href="${reverse('dashboard')}">${get_course_about_section(course, 'university')} ${course.display_number_with_default | h} ${course.display_name_with_default}</a></h2>
 
         % if registration:
         <h1>${_('Your Pearson VUE Proctored Exam Registration')}</h1>
@@ -442,7 +442,7 @@
    % endif
 
     <div class="details details-course">
-      <h4>${_("About {university} {course_number}").format(university=get_course_about_section(course, 'university'), course_number=course.display_number_with_default)}</h4>
+      <h4>${_("About {university} {course_number}").format(university=get_course_about_section(course, 'university'), course_number=course.course.display_number_with_default)}</h4>
       <p>
       % if course.has_ended():
       <span class="label">${_('Course Completed:')}</span> <span class="value">${course.end_date_text}</span>

--- a/lms/templates/test_center_register.html
+++ b/lms/templates/test_center_register.html
@@ -95,7 +95,7 @@
   <section class="introduction">
     <header>
       <hgroup>
-        <h2><a href="${reverse('dashboard')}">${get_course_about_section(course, 'university')} ${course.number} ${course.display_name_with_default}</a></h2>
+        <h2><a href="${reverse('dashboard')}">${get_course_about_section(course, 'university')} ${course.display_number_with_default} ${course.display_name_with_default}</a></h2>
 
         % if registration:
         <h1>${_('Your Pearson VUE Proctored Exam Registration')}</h1>
@@ -442,7 +442,7 @@
    % endif
 
     <div class="details details-course">
-      <h4>${_("About {university} {course_number}").format(university=get_course_about_section(course, 'university'), course_number=course.number)}</h4>
+      <h4>${_("About {university} {course_number}").format(university=get_course_about_section(course, 'university'), course_number=course.display_number_with_default)}</h4>
       <p>
       % if course.has_ended():
       <span class="label">${_('Course Completed:')}</span> <span class="value">${course.end_date_text}</span>


### PR DESCRIPTION
Review notes:

This PR decouples the display of ORG/COURSE from the underlying URL/Location scheme which has some 'legal character' constraints. This will be needed for these two use cases in the near term:

a) We have international course authors that may wish to use non ascii characters in their ORG/COURSE pairs. 

b) We want to be able to allow authors to override the display behavior, particular vis-a-vis course-reruns which may require unique ORG/COURSE pairs but authors want the display of the re-run to be something else than exposing the raw underlying URL/Location-based information

@cpennington @dmitchell @ormsbee Can you review? 

Existing tests pass locally. I need to build out some more unit tests, but I wanted to get the review process started.

NOTE: I wasn't sure what we should do regarding sorting behavior, so I left that alone.
