### PR TITLE
fix for ie bug where drop down menus were still clickable when collapsed

### DIFF
--- a/cms/static/sass/elements/_navigation.scss
+++ b/cms/static/sass/elements/_navigation.scss
@@ -64,12 +64,14 @@ nav {
     opacity: 0.0;
     pointer-events: none;
     width: ($baseline*8);
+    overflow: hidden;
 
 
     // dropped down state
     &.is-shown {
       opacity: 1.0;
       pointer-events: auto;
+      overflow: visible;
     }
   }
 


### PR DESCRIPTION
Just added overflow hidden to fix the bug in IE where the drop-down navs were still clickable when collapsed. @talbs can you give this a quick review?
