### PR TITLE
Add acceptance test for XML-only video content.

### DIFF
--- a/cms/djangoapps/contentstore/features/video.feature
+++ b/cms/djangoapps/contentstore/features/video.feature
@@ -47,3 +47,7 @@ Feature: Video Component
     Given I have created a Video Alpha component
     And I have set "show captions" to True
     Then when I view the videoalpha it does show the captions
+
+  Scenario: Video data is shown correctly
+    Given I have created a video with only XML data
+    Then the correct Youtube video is shown


### PR DESCRIPTION
Since we've had issues with the default video being incorrectly shown,
this creates an XML-only video and ensures that the correct
(non-default) Youtube ID is sent to the client.

@cpennington 
