### PR TITLE
these values are set implicitly at :147, setting them here clobbers them

### DIFF
--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -178,10 +178,6 @@ for name, value in ENV_TOKENS.get("CODE_JAIL", {}).items():
 
 COURSES_WITH_UNSAFE_CODE = ENV_TOKENS.get("COURSES_WITH_UNSAFE_CODE", [])
 
-# automatic log in for load testing
-MITX_FEATURES['AUTOMATIC_AUTH_FOR_LOAD_TESTING'] = ENV_TOKENS.get('AUTOMATIC_AUTH_FOR_LOAD_TESTING')
-MITX_FEATURES['MAX_AUTO_AUTH_USERS'] = ENV_TOKENS.get('MAX_AUTO_AUTH_USERS')
-
 ############################## SECURE AUTH ITEMS ###############
 # Secret things: passwords, access keys, etc.
 


### PR DESCRIPTION
This issue is the same as that fixed in https://github.com/edx/edx-platform/pull/529

There's a lack of clarity about how MITX feature flags are handled.  A value will not be returned by the RHS of either statement as the keys in config are under MIT_FEATURES not at the root.

@wedaly 
