### PR TITLE
Create urls/views/templates for dev-only views

### DIFF
--- a/cms/djangoapps/contentstore/views/__init__.py
+++ b/cms/djangoapps/contentstore/views/__init__.py
@@ -15,3 +15,7 @@ from .public import *
 from .user import *
 from .tabs import *
 from .requests import *
+try:
+    from .dev import *
+except ImportError:
+    pass

--- a/cms/djangoapps/contentstore/views/dev.py
+++ b/cms/djangoapps/contentstore/views/dev.py
@@ -1,0 +1,5 @@
+from mitxmako.shortcuts import render_to_response
+
+
+def dev_mode(request):
+    return render_to_response("dev/dev_mode.html")

--- a/cms/djangoapps/contentstore/views/dev.py
+++ b/cms/djangoapps/contentstore/views/dev.py
@@ -1,5 +1,12 @@
+"""
+Views that are only activated when the project is running in development mode.
+These views will NOT be shown on production: trying to access them will result
+in a 404 error.
+"""
+# pylint: disable=W0613
 from mitxmako.shortcuts import render_to_response
 
 
 def dev_mode(request):
+    "Sample static view"
     return render_to_response("dev/dev_mode.html")

--- a/cms/templates/dev/dev_mode.html
+++ b/cms/templates/dev/dev_mode.html
@@ -1,0 +1,4 @@
+<%inherit file="../base.html" />
+<%block name="content">
+You're in dev mode!
+</%block>

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -137,9 +137,7 @@ urlpatterns += (
 
 
 if settings.ENABLE_JASMINE:
-    # # Jasmine
-    urlpatterns = urlpatterns + (url(r'^_jasmine/', include('django_jasmine.urls')),)
-
+    urlpatterns += (url(r'^_jasmine/', include('django_jasmine.urls')),)
 
 if settings.MITX_FEATURES.get('ENABLE_SERVICE_STATUS'):
     urlpatterns += (
@@ -153,6 +151,13 @@ if settings.MITX_FEATURES.get('AUTOMATIC_AUTH_FOR_LOAD_TESTING'):
     urlpatterns += (
         url(r'^auto_auth$', 'student.views.auto_auth'),
     )
+
+if settings.DEBUG:
+    try:
+        from .urls_dev import urlpatterns as dev_urlpatterns
+        urlpatterns += dev_urlpatterns
+    except ImportError:
+        pass
 
 urlpatterns = patterns(*urlpatterns)
 

--- a/cms/urls_dev.py
+++ b/cms/urls_dev.py
@@ -1,0 +1,5 @@
+from django.conf.urls import url
+
+urlpatterns = (
+    url(r'^dev_mode$', 'contentstore.views.dev.dev_mode', name='dev_mode'),
+)

--- a/cms/urls_dev.py
+++ b/cms/urls_dev.py
@@ -1,3 +1,8 @@
+"""
+URLconf for development-only views.
+This gets imported by urls.py and added to its URLconf if we are running in
+development mode; otherwise, it is ignored.
+"""
 from django.conf.urls import url
 
 urlpatterns = (


### PR DESCRIPTION
Our designers find it helpful to be able to stub out simple views that aren't ready
to be seen for production yet, and check them into version control so that other
people can see them and provide feedback. This commit introduces a few new files
and directories for this purpose, as well as a sample view that will only be seen
in dev mode, and never in production.
