### PR TITLE
fix crash in peer eval xmodule

### DIFF
--- a/common/lib/xmodule/xmodule/timeinfo.py
+++ b/common/lib/xmodule/xmodule/timeinfo.py
@@ -14,20 +14,23 @@ class TimeInfo(object):
 
     """
     _delta_standin = Timedelta()
-    def __init__(self, due_date, grace_period_string):
+    def __init__(self, due_date, grace_period_string_or_timedelta):
         if due_date is not None:
             self.display_due_date = due_date
 
         else:
             self.display_due_date = None
 
-        if grace_period_string is not None and self.display_due_date:
-            try:
-                self.grace_period = TimeInfo._delta_standin.from_json(grace_period_string)
-                self.close_date = self.display_due_date + self.grace_period
-            except:
-                log.error("Error parsing the grace period {0}".format(grace_period_string))
-                raise
+        if grace_period_string_or_timedelta is not None and self.display_due_date:
+            if isinstance(grace_period_string_or_timedelta, basestring):
+                try:
+                    self.grace_period = TimeInfo._delta_standin.from_json(grace_period_string_or_timedelta)
+                except:
+                    log.error("Error parsing the grace period {0}".format(grace_period_string_or_timedelta))
+                    raise
+            else:
+                self.grace_period = grace_period_string_or_timedelta
+            self.close_date = self.display_due_date + self.grace_period
         else:
             self.grace_period = None
             self.close_date = self.display_due_date


### PR DESCRIPTION
As documented in [LMS-806](https://edx-wiki.atlassian.net/browse/LMS-806):

Steps to reproduce:
- as one user, for a peer evaluated problem, enter something that needs peer grading
- as another user, log in and fire up the peer grading panel. You should see something that needs attention, a yellow exclamation badge
- clicking on the "do grading" panel will fail with a 500, stacktrace attached.
- it's possible that the question where this is being done must first have professor calibration done in order for peers to be able to actually get work to grade.

@dmitchell debugged this with me and saw some problems in the ways that the peer_evaluation xmodule code was accessing dates. Instead of using the normal lms accessors, by going straight into the _module_data
it would be bypassing some important code (caching?). Fixing this to be more standard did the trick.

I'd like two reviewers.  @dmitchell please look over.  Should be simple since you and I basically pair-programmed this, but would still like the confirm.  and @VikParuchuri since it was your code originally (I think), and you offered. :smile:.  Thanks.
