### PR TITLE
adjusting fix for studio drop-down nav in IE9

### DIFF
--- a/cms/static/sass/elements/_navigation.scss
+++ b/cms/static/sass/elements/_navigation.scss
@@ -65,6 +65,7 @@ nav {
     pointer-events: none;
     width: ($baseline*8);
     overflow: hidden;
+    height: 0;
 
 
     // dropped down state
@@ -72,6 +73,7 @@ nav {
       opacity: 1.0;
       pointer-events: auto;
       overflow: visible;
+      height: auto;
     }
   }
 


### PR DESCRIPTION
This should fix the drop down nav links still being clickable even when the menu is collapsed. @talbs can you review one more time? and @singingwolfboy can you verify that this fixes the issue you were experiencing?
