### PR TITLE
XBlock studio view render for module previews

### DIFF
--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -165,7 +165,7 @@ def load_preview_module(request, preview_id, descriptor):
 
 def get_preview_html(request, descriptor, idx):
     module = load_preview_module(request, str(idx), descriptor)
-    return module.get_html()
+    return module.runtime.render(module, None, "studio_view")
 
 
 def get_module_previews(request, descriptor):

--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -163,6 +163,11 @@ def load_preview_module(request, preview_id, descriptor):
     return module
 
 
+def get_preview_html(request, descriptor, idx):
+    module = load_preview_module(request, str(idx), descriptor)
+    return module.get_html()
+
+
 def get_module_previews(request, descriptor):
     """
     Returns a list of preview XModule html contents. One preview is returned for each
@@ -170,8 +175,5 @@ def get_module_previews(request, descriptor):
 
     descriptor: An XModuleDescriptor
     """
-    preview_html = []
-    for idx, (_instance_state, _shared_state) in enumerate(descriptor.get_sample_state()):
-        module = load_preview_module(request, str(idx), descriptor)
-        preview_html.append(module.get_html())
-    return preview_html
+    return tuple(get_preview_html(request, descriptor, idx)
+                 for idx in range(len(descriptor.get_sample_state())))

--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -711,20 +711,20 @@ class XModuleDescriptor(XModuleFields, HTMLSnippet, ResourceTemplates, XBlock):
 
     # =============================== BUILTIN METHODS ==========================
     def __eq__(self, other):
-        eq = (self.__class__ == other.__class__ and
+        return (self.__class__ == other.__class__ and
                 all(getattr(self, attr, None) == getattr(other, attr, None)
                     for attr in self.equality_attributes))
 
-        return eq
-
     def __repr__(self):
-        return ("{class_}({system!r}, location={location!r},"
-                " model_data={model_data!r})".format(
-            class_=self.__class__.__name__,
-            system=self.system,
-            location=self.location,
-            model_data=self._model_data,
-        ))
+        return (
+            "{class_}({system!r}, location={location!r},"
+            " model_data={model_data!r})".format(
+                class_=self.__class__.__name__,
+                system=self.system,
+                location=self.location,
+                model_data=self._model_data,
+            )
+        )
 
     @property
     def non_editable_metadata_fields(self):
@@ -783,15 +783,17 @@ class XModuleDescriptor(XModuleFields, HTMLSnippet, ResourceTemplates, XBlock):
                 editor_type = "Integer"
             elif isinstance(field, Float):
                 editor_type = "Float"
-            metadata_fields[field.name] = {'field_name': field.name,
-                                           'type': editor_type,
-                                           'display_name': field.display_name,
-                                           'value': field.to_json(value),
-                                           'options': values,
-                                           'default_value': field.to_json(default_value),
-                                           'inheritable': inheritable,
-                                           'explicitly_set': explicitly_set,
-                                           'help': field.help}
+            metadata_fields[field.name] = {
+                'field_name': field.name,
+                'type': editor_type,
+                'display_name': field.display_name,
+                'value': field.to_json(value),
+                'options': values,
+                'default_value': field.to_json(default_value),
+                'inheritable': inheritable,
+                'explicitly_set': explicitly_set,
+                'help': field.help,
+            }
 
         return metadata_fields
 
@@ -902,7 +904,7 @@ class ModuleSystem(Runtime):
                  s3_interface=None,
                  cache=None,
                  can_execute_unsafe_code=None,
-    ):
+        ):
         '''
         Create a closure around the system environment.
 


### PR DESCRIPTION
Replace `module.get_html()` with `runtime.render()` for XBlock integration with Studio. This branch also reformats and cleans up a bit of code surrounding this area.
