### PR TITLE
XBlock integration for Studio: student view

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -1237,7 +1237,7 @@ class ContentStoreTest(ModuleStoreTestCase):
                                                'course': loc.course,
                                                'name': loc.name}))
 
-        self.assertEqual(200, resp.status_code)
+        self.assert2XX(resp.status_code)
         self.assertContains(resp, 'Chapter 2')
 
         # go to various pages
@@ -1247,92 +1247,92 @@ class ContentStoreTest(ModuleStoreTestCase):
                                        kwargs={'org': loc.org,
                                                'course': loc.course,
                                                'name': loc.name}))
-        self.assertEqual(200, resp.status_code)
+        self.assert2XX(resp.status_code)
 
         # export page
         resp = self.client.get(reverse('export_course',
                                        kwargs={'org': loc.org,
                                                'course': loc.course,
                                                'name': loc.name}))
-        self.assertEqual(200, resp.status_code)
+        self.assert2XX(resp.status_code)
 
         # manage users
         resp = self.client.get(reverse('manage_users',
                                        kwargs={'org': loc.org,
                                                'course': loc.course,
                                                'name': loc.name}))
-        self.assertEqual(200, resp.status_code)
+        self.assert2XX(resp.status_code)
 
         # course info
         resp = self.client.get(reverse('course_info',
                                        kwargs={'org': loc.org,
                                                'course': loc.course,
                                                'name': loc.name}))
-        self.assertEqual(200, resp.status_code)
+        self.assert2XX(resp.status_code)
 
         # settings_details
         resp = self.client.get(reverse('settings_details',
                                        kwargs={'org': loc.org,
                                                'course': loc.course,
                                                'name': loc.name}))
-        self.assertEqual(200, resp.status_code)
+        self.assert2XX(resp.status_code)
 
         # settings_details
         resp = self.client.get(reverse('settings_grading',
                                        kwargs={'org': loc.org,
                                                'course': loc.course,
                                                'name': loc.name}))
-        self.assertEqual(200, resp.status_code)
+        self.assert2XX(resp.status_code)
 
         # static_pages
         resp = self.client.get(reverse('static_pages',
                                        kwargs={'org': loc.org,
                                                'course': loc.course,
                                                'coursename': loc.name}))
-        self.assertEqual(200, resp.status_code)
+        self.assert2XX(resp.status_code)
 
         # static_pages
         resp = self.client.get(reverse('asset_index',
                                        kwargs={'org': loc.org,
                                                'course': loc.course,
                                                'name': loc.name}))
-        self.assertEqual(200, resp.status_code)
+        self.assert2XX(resp.status_code)
 
         # go look at a subsection page
         subsection_location = loc.replace(category='sequential', name='test_sequence')
         resp = self.client.get(reverse('edit_subsection',
                                        kwargs={'location': subsection_location.url()}))
-        self.assertEqual(200, resp.status_code)
+        self.assert2XX(resp.status_code)
 
         # go look at the Edit page
         unit_location = loc.replace(category='vertical', name='test_vertical')
         resp = self.client.get(reverse('edit_unit',
                                        kwargs={'location': unit_location.url()}))
-        self.assertEqual(200, resp.status_code)
+        self.assert2XX(resp.status_code)
 
         # delete a component
         del_loc = loc.replace(category='html', name='test_html')
         resp = self.client.post(reverse('delete_item'),
                                 json.dumps({'id': del_loc.url()}), "application/json")
-        self.assertEqual(200, resp.status_code)
+        self.assert2XX(resp.status_code)
 
         # delete a unit
         del_loc = loc.replace(category='vertical', name='test_vertical')
         resp = self.client.post(reverse('delete_item'),
                                 json.dumps({'id': del_loc.url()}), "application/json")
-        self.assertEqual(200, resp.status_code)
+        self.assert2XX(resp.status_code)
 
         # delete a unit
         del_loc = loc.replace(category='sequential', name='test_sequence')
         resp = self.client.post(reverse('delete_item'),
                                 json.dumps({'id': del_loc.url()}), "application/json")
-        self.assertEqual(200, resp.status_code)
+        self.assert2XX(resp.status_code)
 
         # delete a chapter
         del_loc = loc.replace(category='chapter', name='chapter_2')
         resp = self.client.post(reverse('delete_item'),
                                 json.dumps({'id': del_loc.url()}), "application/json")
-        self.assertEqual(200, resp.status_code)
+        self.assert2XX(resp.status_code)
 
     def test_import_metadata_with_attempts_empty_string(self):
         module_store = modulestore('direct')

--- a/cms/djangoapps/contentstore/tests/test_item.py
+++ b/cms/djangoapps/contentstore/tests/test_item.py
@@ -34,7 +34,7 @@ class DeleteItem(CourseTestCase):
             resp.content,
             "application/json"
         )
-        self.assertEqual(resp.status_code, 200)
+        self.assert2XX(resp.status_code)
 
 
 class TestCreateItem(CourseTestCase):

--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -165,7 +165,7 @@ def load_preview_module(request, preview_id, descriptor):
 
 def get_preview_html(request, descriptor, idx):
     module = load_preview_module(request, str(idx), descriptor)
-    return module.runtime.render(module, None, "student_view")
+    return module.runtime.render(module, None, "student_view").content
 
 
 def get_module_previews(request, descriptor):

--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -165,7 +165,7 @@ def load_preview_module(request, preview_id, descriptor):
 
 def get_preview_html(request, descriptor, idx):
     module = load_preview_module(request, str(idx), descriptor)
-    return module.get_html()
+    return module.runtime.render(module, None, "student_view")
 
 
 def get_module_previews(request, descriptor):

--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -76,7 +76,7 @@ def preview_component(request, location):
     component = modulestore().get_item(location)
 
     return render_to_response('component.html', {
-        'preview': get_module_previews(request, component)[0],
+        'preview': get_preview_html(request, component, 0),
         'editor': wrap_xmodule(component.get_html, component, 'xmodule_edit.html')(),
     })
 
@@ -169,14 +169,3 @@ def get_preview_html(request, descriptor, idx):
     """
     module = load_preview_module(request, str(idx), descriptor)
     return module.runtime.render(module, None, "student_view").content
-
-
-def get_module_previews(request, descriptor):
-    """
-    Returns a tuple of preview XModule html contents. One preview is returned for each
-    pair of states returned by get_sample_state() for the supplied descriptor.
-
-    descriptor: An XModuleDescriptor
-    """
-    return tuple(get_preview_html(request, descriptor, idx)
-                 for idx in range(len(descriptor.get_sample_state())))

--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -163,6 +163,11 @@ def load_preview_module(request, preview_id, descriptor):
     return module
 
 
+def get_preview_html(request, descriptor, idx):
+    module = load_preview_module(request, str(idx), descriptor)
+    return module.get_html()
+
+
 def get_module_previews(request, descriptor):
     """
     Returns a list of preview XModule html contents. One preview is returned for each
@@ -170,8 +175,5 @@ def get_module_previews(request, descriptor):
 
     descriptor: An XModuleDescriptor
     """
-    preview_html = []
-    for idx, (_instance_state, _shared_state) in enumerate(descriptor.get_sample_state()):
-        module = load_preview_module(request, str(idx), descriptor)
-        preview_html.append(module.get_html())
-    return preview_html
+    return tuple(get_preview_html(request, descriptor, idx)
+                 for idx in range(len(descriptor.get_sample_state())))

--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -164,13 +164,16 @@ def load_preview_module(request, preview_id, descriptor):
 
 
 def get_preview_html(request, descriptor, idx):
+    """
+    Returns the HTML for the XModule specified by the descriptor and idx.
+    """
     module = load_preview_module(request, str(idx), descriptor)
     return module.runtime.render(module, None, "student_view").content
 
 
 def get_module_previews(request, descriptor):
     """
-    Returns a list of preview XModule html contents. One preview is returned for each
+    Returns a tuple of preview XModule html contents. One preview is returned for each
     pair of states returned by get_sample_state() for the supplied descriptor.
 
     descriptor: An XModuleDescriptor

--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -165,7 +165,8 @@ def load_preview_module(request, preview_id, descriptor):
 
 def get_preview_html(request, descriptor, idx):
     """
-    Returns the HTML for the XModule specified by the descriptor and idx.
+    Returns the HTML returned by the XModule's student_view,
+    specified by the descriptor and idx.
     """
     module = load_preview_module(request, str(idx), descriptor)
     return module.runtime.render(module, None, "student_view").content

--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -711,20 +711,20 @@ class XModuleDescriptor(XModuleFields, HTMLSnippet, ResourceTemplates, XBlock):
 
     # =============================== BUILTIN METHODS ==========================
     def __eq__(self, other):
-        eq = (self.__class__ == other.__class__ and
+        return (self.__class__ == other.__class__ and
                 all(getattr(self, attr, None) == getattr(other, attr, None)
                     for attr in self.equality_attributes))
 
-        return eq
-
     def __repr__(self):
-        return ("{class_}({system!r}, location={location!r},"
-                " model_data={model_data!r})".format(
-            class_=self.__class__.__name__,
-            system=self.system,
-            location=self.location,
-            model_data=self._model_data,
-        ))
+        return (
+            "{class_}({system!r}, location={location!r},"
+            " model_data={model_data!r})".format(
+                class_=self.__class__.__name__,
+                system=self.system,
+                location=self.location,
+                model_data=self._model_data,
+            )
+        )
 
     @property
     def non_editable_metadata_fields(self):
@@ -785,15 +785,17 @@ class XModuleDescriptor(XModuleFields, HTMLSnippet, ResourceTemplates, XBlock):
                 editor_type = "Float"
             elif isinstance(field, List):
                 editor_type = "List"
-            metadata_fields[field.name] = {'field_name': field.name,
-                                           'type': editor_type,
-                                           'display_name': field.display_name,
-                                           'value': field.to_json(value),
-                                           'options': [] if values is None else values,
-                                           'default_value': field.to_json(default_value),
-                                           'inheritable': inheritable,
-                                           'explicitly_set': explicitly_set,
-                                           'help': field.help}
+            metadata_fields[field.name] = {
+               'field_name': field.name,
+               'type': editor_type,
+               'display_name': field.display_name,
+               'value': field.to_json(value),
+               'options': [] if values is None else values,
+               'default_value': field.to_json(default_value),
+               'inheritable': inheritable,
+               'explicitly_set': explicitly_set,
+               'help': field.help,
+            }
 
         return metadata_fields
 
@@ -885,28 +887,14 @@ class ModuleSystem(Runtime):
     Note that these functions can be closures over e.g. a django request
     and user, or other environment-specific info.
     '''
-    def __init__(self,
-                 ajax_url,
-                 track_function,
-                 get_module,
-                 render_template,
-                 replace_urls,
-                 xblock_model_data,
-                 user=None,
-                 filestore=None,
-                 debug=False,
-                 xqueue=None,
-                 publish=None,
-                 node_path="",
-                 anonymous_student_id='',
-                 course_id=None,
-                 open_ended_grading_interface=None,
-                 s3_interface=None,
-                 cache=None,
-                 can_execute_unsafe_code=None,
-                 replace_course_urls=None,
-                 replace_jump_to_id_urls=None
-    ):
+    def __init__(
+            self, ajax_url, track_function, get_module, render_template,
+            replace_urls, xblock_model_data, user=None, filestore=None,
+            debug=False, xqueue=None, publish=None, node_path="",
+            anonymous_student_id='', course_id=None,
+            open_ended_grading_interface=None, s3_interface=None,
+            cache=None, can_execute_unsafe_code=None, replace_course_urls=None,
+            replace_jump_to_id_urls=None):
         '''
         Create a closure around the system environment.
 


### PR DESCRIPTION
Replace module.get_html() with runtime.render() for XBlock integration with Studio. This branch also reformats and cleans up a bit of code surrounding this area.
