### PR TITLE
Update Babel and Transifex libraries

### DIFF
--- a/docs/shared/requirements.txt
+++ b/docs/shared/requirements.txt
@@ -3,7 +3,7 @@
 # Installing modules with C dependencies on RTD can be tricky, and pip doesn't
 # have an 'ignore-errors' option, so all requirements fail. Here we keep the
 # maximal list of modules that still works.
-# 
+#
 beautifulsoup4==4.1.3
 beautifulsoup==3.2.1
 boto==2.6.0
@@ -61,8 +61,8 @@ dogstatsd-python==0.2.1
 newrelic==1.8.0.13
 
 # Used for Internationalization and localization
-Babel==0.9.6
-transifex-client==0.8
+Babel==1.3
+transifex-client==0.9.1
 
 
 -e common/lib/calc

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -69,8 +69,8 @@ newrelic==1.8.0.13
 sphinx==1.1.3
 
 # Used for Internationalization and localization
-Babel==0.9.6
-transifex-client==0.8
+Babel==1.3
+transifex-client==0.9.1
 
 # Used for testing
 coverage==3.6


### PR DESCRIPTION
Babel recently had a major release: the first release its had in years. (A new maintainer has taken over the project.) There are a lot of changes and improvements, and I want to make sure that we can use the new i18n hotness in our project. I also noticed that the Transifex client library has been updated, so I bumped that, too.
