### PR TITLE
tz fix in openendedchild

### DIFF
--- a/common/lib/xmodule/xmodule/open_ended_grading_classes/openendedchild.py
+++ b/common/lib/xmodule/xmodule/open_ended_grading_classes/openendedchild.py
@@ -11,7 +11,7 @@ from .peer_grading_service import PeerGradingService, MockPeerGradingService
 import controller_query_service
 
 from datetime import datetime
-from django.utils.timezone import UTC
+from pytz import UTC
 
 log = logging.getLogger("mitx.courseware")
 
@@ -126,7 +126,7 @@ class OpenEndedChild(object):
         pass
 
     def closed(self):
-        if self.close_date is not None and datetime.now(UTC()) > self.close_date:
+        if self.close_date is not None and datetime.now(UTC) > self.close_date:
             return True
         return False
 


### PR DESCRIPTION
uses django.utils.timezone.UTC object that needs to be instantiated to be used with datetime.now. See line 129:https://github.com/edx/edx-platform/blob/d7d115df67a16d222622d2e256d630ce119e3f1a/common/lib/xmodule/xmodule/open_ended_grading_classes/openendedchild.py#L129

@dmitchell 
@dianakhuang 
