### PR TITLE
Add cronjob analytics to instructor dashbaord

### DIFF
--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -5,6 +5,7 @@ Unit tests for instructor.api methods.
 import unittest
 import json
 from urllib import quote
+from django.conf import settings
 from django.test import TestCase
 from nose.tools import raises
 from mock import Mock
@@ -23,6 +24,7 @@ from student.models import CourseEnrollment
 from courseware.models import StudentModule
 
 from instructor.access import allow_access
+import instructor.views.api
 from instructor.views.api import (
     _split_input_list, _msk_from_problem_urlname, common_exceptions_400)
 from instructor_task.api_helper import AlreadyRunningError
@@ -118,6 +120,7 @@ class TestInstructorAPIDenyLevels(ModuleStoreTestCase, LoginEnrollmentTestCase):
             'list_instructor_tasks',
             'list_forum_members',
             'update_forum_role_membership',
+            'proxy_legacy_analytics',
         ]
         for endpoint in staff_level_endpoints:
             url = reverse(endpoint, kwargs={'course_id': self.course.id})
@@ -751,6 +754,95 @@ class TestInstructorAPITaskLists(ModuleStoreTestCase, LoginEnrollmentTestCase):
         expected_tasks = [ftask.to_dict() for ftask in self.tasks]
         expected_res = {'tasks': expected_tasks}
         self.assertEqual(json.loads(response.content), expected_res)
+
+
+@override_settings(MODULESTORE=TEST_DATA_MONGO_MODULESTORE)
+@override_settings(ANALYTICS_SERVER_URL="http://robotanalyticsserver.netbot:900/")
+@override_settings(ANALYTICS_API_KEY="robot_api_key")
+class TestInstructorAPIAnalyticsProxy(ModuleStoreTestCase, LoginEnrollmentTestCase):
+    """
+    Test instructor analytics proxy endpoint.
+    """
+
+    class FakeProxyResponse(object):
+        """ Fake successful requests response object. """
+        def __init__(self):
+            self.status_code = instructor.views.api.codes.OK
+            self.content = '{"test_content": "robot test content"}'
+
+    class FakeBadProxyResponse(object):
+        """ Fake strange-failed requests response object. """
+        def __init__(self):
+            self.status_code = 'notok.'
+            self.content = '{"test_content": "robot test content"}'
+
+    def setUp(self):
+        self.instructor = AdminFactory.create()
+        self.course = CourseFactory.create()
+        self.client.login(username=self.instructor.username, password='test')
+
+    def test_analytics_proxy_url(self):
+        """ Test legacy analytics proxy url generation. """
+        act = Mock(return_value=self.FakeProxyResponse())
+        instructor.views.api.requests.get = act
+
+        url = reverse('proxy_legacy_analytics', kwargs={'course_id': self.course.id})
+        response = self.client.get(url, {
+            'aname': 'ProblemGradeDistribution'
+        })
+        print response.content
+        self.assertEqual(response.status_code, 200)
+
+        # check request url
+        expected_url = "{url}get?aname={aname}&course_id={course_id}&apikey={api_key}".format(
+            url="http://robotanalyticsserver.netbot:900/",
+            aname="ProblemGradeDistribution",
+            course_id=self.course.id,
+            api_key="robot_api_key",
+        )
+        act.assert_called_once_with(expected_url)
+
+    def test_analytics_proxy(self):
+        """
+        Test legacy analytics content proxying.
+        """
+        act = Mock(return_value=self.FakeProxyResponse())
+        instructor.views.api.requests.get = act
+
+        url = reverse('proxy_legacy_analytics', kwargs={'course_id': self.course.id})
+        response = self.client.get(url, {
+            'aname': 'ProblemGradeDistribution'
+        })
+        print response.content
+        self.assertEqual(response.status_code, 200)
+
+        # check response
+        self.assertTrue(act.called)
+        expected_res = {'test_content': "robot test content"}
+        self.assertEqual(json.loads(response.content), expected_res)
+
+    def test_analytics_proxy_reqfailed(self):
+        """ Test proxy when server reponds with failure. """
+        act = Mock(return_value=self.FakeBadProxyResponse())
+        instructor.views.api.requests.get = act
+
+        url = reverse('proxy_legacy_analytics', kwargs={'course_id': self.course.id})
+        response = self.client.get(url, {
+            'aname': 'ProblemGradeDistribution'
+        })
+        print response.content
+        self.assertEqual(response.status_code, 500)
+
+    def test_analytics_proxy_missing_param(self):
+        """ Test proxy when missing the aname query parameter. """
+        act = Mock(return_value=self.FakeProxyResponse())
+        instructor.views.api.requests.get = act
+
+        url = reverse('proxy_legacy_analytics', kwargs={'course_id': self.course.id})
+        response = self.client.get(url, {})
+        print response.content
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(act.called)
 
 
 class TestInstructorAPIHelpers(TestCase):

--- a/lms/djangoapps/instructor/views/api_urls.py
+++ b/lms/djangoapps/instructor/views/api_urls.py
@@ -30,4 +30,6 @@ urlpatterns = patterns('',  # nopep8
         'instructor.views.api.list_forum_members', name="list_forum_members"),
     url(r'^update_forum_role_membership$',
         'instructor.views.api.update_forum_role_membership', name="update_forum_role_membership"),
+    url(r'^proxy_legacy_analytics$',
+        'instructor.views.api.proxy_legacy_analytics', name="proxy_legacy_analytics"),
 )

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -142,5 +142,6 @@ def _section_analytics(course_id):
         'section_key': 'analytics',
         'section_display_name': 'Analytics',
         'get_distribution_url': reverse('get_distribution', kwargs={'course_id': course_id}),
+        'proxy_legacy_analytics_url': reverse('proxy_legacy_analytics', kwargs={'course_id': course_id}),
     }
     return section_data

--- a/lms/static/coffee/src/instructor_dashboard/analytics.coffee
+++ b/lms/static/coffee/src/instructor_dashboard/analytics.coffee
@@ -8,10 +8,10 @@ std_ajax_err = -> window.InstructorDashboard.util.std_ajax_err.apply this, argum
 
 
 class ProfileDistributionWidget
-  constructor: ({@$container, @feature, title, @endpoint}) ->
+  constructor: ({@$container, @feature, @title, @endpoint}) ->
     # render template
     template_params =
-      title: title
+      title: @title
       feature: @feature
       endpoint: @endpoint
     template_html = $("#profile-distribution-widget-template").html()

--- a/lms/static/coffee/src/instructor_dashboard/analytics.coffee
+++ b/lms/static/coffee/src/instructor_dashboard/analytics.coffee
@@ -6,60 +6,32 @@
 plantTimeout = -> window.InstructorDashboard.util.plantTimeout.apply this, arguments
 std_ajax_err = -> window.InstructorDashboard.util.std_ajax_err.apply this, arguments
 
-# Analytics Section
-class Analytics
-  constructor: (@$section) ->
-    @$section.data 'wrapper', @
 
-    # gather elements
-    @$display                = @$section.find '.distribution-display'
-    @$display_text           = @$display.find '.distribution-display-text'
-    @$display_graph          = @$display.find '.distribution-display-graph'
-    @$display_table          = @$display.find '.distribution-display-table'
-    @$distribution_select    = @$section.find 'select#distributions'
-    @$request_response_error = @$display.find '.request-response-error'
-
-    @populate_selector => @$distribution_select.change => @on_selector_change()
+class ProfileDistributionWidget
+  constructor: ({@$container, @feature, title, @endpoint}) ->
+    # render template
+    template_params =
+      title: title
+      feature: @feature
+      endpoint: @endpoint
+    template_html = $("#profile-distribution-widget-template").html()
+    @$container.html Mustache.render template_html, template_params
 
   reset_display: ->
-      @$display_text.empty()
-      @$display_graph.empty()
-      @$display_table.empty()
-      @$request_response_error.empty()
+      @$container.find('.display-errors').empty()
+      @$container.find('.display-text').empty()
+      @$container.find('.display-graph').empty()
+      @$container.find('.display-table').empty()
 
-  # fetch and list available distributions
-  # `cb` is a callback to be run after
-  populate_selector: (cb) ->
-    # ask for no particular distribution to get list of available distribuitions.
-    @get_profile_distributions undefined,
-      # on error, print to console and dom.
-      error: std_ajax_err => @$request_response_error.text "Error getting available distributions."
-      success: (data) =>
-        # replace loading text in drop-down with "-- Select Distribution --"
-        @$distribution_select.find('option').eq(0).text "-- Select Distribution --"
-
-        # add all fetched available features to drop-down
-        for feature in data.available_features
-          opt = $ '<option/>',
-            text: data.feature_display_names[feature]
-            data:
-              feature: feature
-
-          @$distribution_select.append opt
-
-        # call callback if one was supplied
-        cb?()
+  show_error: (msg) ->
+    @$container.find('.display-errors').text msg
 
   # display data
-  on_selector_change: ->
-    opt = @$distribution_select.children('option:selected')
-    feature = opt.data 'feature'
-
+  load: ->
     @reset_display()
-    # only proceed if there is a feature attached to the selected option.
-    return unless feature
-    @get_profile_distributions feature,
-      error: std_ajax_err => @$request_response_error.text "Error getting distribution for '#{feature}'."
+
+    @get_profile_distributions @feature,
+      error: std_ajax_err => @show_error "Error fetching distribution."
       success: (data) =>
         feature_res = data.feature_results
         if feature_res.type is 'EASY_CHOICE'
@@ -70,9 +42,9 @@ class Analytics
             forceFitColumns: true
 
           columns = [
-            id: feature
-            field: feature
-            name: feature
+            id: @feature
+            field: @feature
+            name: data.feature_display_names[@feature]
           ,
             id: 'count'
             field: 'count'
@@ -81,16 +53,16 @@ class Analytics
 
           grid_data = _.map feature_res.data, (value, key) ->
             datapoint = {}
-            datapoint[feature] = feature_res.choices_display_names[key]
+            datapoint[@feature] = feature_res.choices_display_names[key]
             datapoint['count'] = value
             datapoint
 
           table_placeholder = $ '<div/>', class: 'slickgrid'
-          @$display_table.append table_placeholder
+          @$container.find('.display-table').append table_placeholder
           grid = new Slick.Grid(table_placeholder, grid_data, columns, options)
         else if feature_res.feature is 'year_of_birth'
-          graph_placeholder = $ '<div/>', class: 'year-of-birth'
-          @$display_graph.append graph_placeholder
+          graph_placeholder = $ '<div/>', class: 'graph-placeholder'
+          @$container.find('.display-graph').append graph_placeholder
 
           graph_data = _.map feature_res.data, (value, key) -> [parseInt(key), value]
 
@@ -99,7 +71,7 @@ class Analytics
           ]
         else
           console.warn("unable to show distribution #{feature_res.type}")
-          @$display_text.text 'Unavailable Metric Display\n' + JSON.stringify(feature_res)
+          @show_error 'Unavailable metric display.'
 
   # fetch distribution data from server.
   # `handler` can be either a callback for success
@@ -107,7 +79,7 @@ class Analytics
   get_profile_distributions: (feature, handler) ->
     settings =
       dataType: 'json'
-      url: @$distribution_select.data 'endpoint'
+      url: @endpoint
       data: feature: feature
 
     if typeof handler is 'function'
@@ -117,13 +89,138 @@ class Analytics
 
     $.ajax settings
 
-  # slickgrid's layout collapses when rendered
-  # in an invisible div. use this method to reload
-  # the AuthList widget
-  refresh: ->
-    @on_selector_change()
 
-  # handler for when the section title is clicked.
+class GradeDistributionDisplay
+  constructor: ({@$container, @endpoint}) ->
+    template_params = {}
+    template_html = $('#grade-distributions-widget-template').html()
+    @$container.html Mustache.render template_html, template_params
+    @$problem_selector = @$container.find '.problem-selector'
+
+  reset_display: ->
+    @$container.find('.display-errors').empty()
+    @$container.find('.display-text').empty()
+    @$container.find('.display-graph').empty()
+
+  show_error: (msg) ->
+    @$container.find('.display-errors').text msg
+
+  load: ->
+    @get_grade_distributions
+      error: std_ajax_err => @show_error "Error fetching grade distributions."
+      success: (data) =>
+        @$container.find('.last-updated').text "Last Updated: #{data.time}"
+
+        # populate selector
+        @$problem_selector.empty()
+        for {module_id, grade_info} in data.data
+          I4X_PROBLEM = /i4x:\/\/.*\/.*\/problem\/(.*)/
+          label = (I4X_PROBLEM.exec module_id)?[1]
+          label ?= module_id
+
+          @$problem_selector.append $ '<option/>',
+            text: label
+            data:
+              module_id: module_id
+              grade_info: grade_info
+
+        @$problem_selector.change =>
+          $opt = @$problem_selector.children('option:selected')
+          return unless $opt.length > 0
+          @reset_display()
+          @render_distribution
+            module_id:  $opt.data 'module_id'
+            grade_info: $opt.data 'grade_info'
+
+        # one-time first selection of first list item.
+        @$problem_selector.change()
+
+  render_distribution: ({module_id, grade_info}) ->
+    $display_graph = @$container.find('.display-graph')
+
+    graph_data = grade_info.map ({grade, max_grade, num_students}) -> [grade, num_students]
+    total_students = _.reduce ([0].concat grade_info),
+      (accum, {grade, max_grade, num_students}) -> accum + num_students
+
+    # show total students
+    @$container.find('.display-text').text "#{total_students} students scored."
+
+    # render to graph
+    graph_placeholder = $ '<div/>', class: 'graph-placeholder'
+    $display_graph.append graph_placeholder
+
+    graph_data = graph_data
+
+    $.plot graph_placeholder, [
+      data: graph_data
+      bars: show: true
+      color: '#1d9dd9'
+    ]
+
+
+  # `handler` can be either a callback for success
+  # or a mapping e.g. {success: ->, error: ->, complete: ->}
+  #
+  # the data passed to the success handler takes this form:
+  # {
+  #   "aname": "ProblemGradeDistribution",
+  #   "time": "2013-07-31T20:25:56+00:00",
+  #   "course_id": "MITx/6.002x/2013_Spring",
+  #   "options": {
+  #     "course_id": "MITx/6.002x/2013_Spring",
+  #   "_id": "6fudge2b49somedbid1e1",
+  #   "data": [
+  #     {
+  #       "module_id": "i4x://MITx/6.002x/problem/Capacitors_and_Energy_Storage",
+  #       "grade_info": [
+  #         {
+  #           "grade": 0.0,
+  #           "max_grade": 100.0,
+  #           "num_students": 3
+  #         }, ... for each grade number between 0 and max_grade
+  #   ],
+  # }
+  get_grade_distributions: (handler) ->
+    settings =
+      dataType: 'json'
+      url: @endpoint
+      data: aname: 'ProblemGradeDistribution'
+
+    if typeof handler is 'function'
+      _.extend settings, success: handler
+    else
+      _.extend settings, handler
+
+    $.ajax settings
+
+
+# Analytics Section
+class Analytics
+  constructor: (@$section) ->
+    @$section.data 'wrapper', @
+
+    @$pd_containers = @$section.find '.profile-distribution-widget-container'
+    @$gd_containers = @$section.find '.grade-distributions-widget-container'
+
+    @pdws = _.map (@$pd_containers), (container) =>
+      new ProfileDistributionWidget
+        $container: $(container)
+        feature:    $(container).data 'feature'
+        title:      $(container).data 'title'
+        endpoint:   $(container).data 'endpoint'
+
+    @gdws = _.map (@$gd_containers), (container) =>
+      new GradeDistributionDisplay
+        $container: $(container)
+        endpoint:   $(container).data 'endpoint'
+
+  refresh: ->
+    for pdw in @pdws
+      pdw.load()
+
+    for gdw in @gdws
+      gdw.load()
+
   onClickTitle: ->
     @refresh()
 

--- a/lms/static/coffee/src/instructor_dashboard/analytics.coffee
+++ b/lms/static/coffee/src/instructor_dashboard/analytics.coffee
@@ -51,7 +51,7 @@ class ProfileDistributionWidget
             name: 'Count'
           ]
 
-          grid_data = _.map feature_res.data, (value, key) ->
+          grid_data = _.map feature_res.data, (value, key) =>
             datapoint = {}
             datapoint[@feature] = feature_res.choices_display_names[key]
             datapoint['count'] = value

--- a/lms/static/coffee/src/instructor_dashboard/analytics.coffee
+++ b/lms/static/coffee/src/instructor_dashboard/analytics.coffee
@@ -14,7 +14,7 @@ class ProfileDistributionWidget
       title: @title
       feature: @feature
       endpoint: @endpoint
-    template_html = $("#profile-distribution-widget-template").html()
+    template_html = $("#profile-distribution-widget-template").text()
     @$container.html Mustache.render template_html, template_params
 
   reset_display: ->
@@ -93,7 +93,7 @@ class ProfileDistributionWidget
 class GradeDistributionDisplay
   constructor: ({@$container, @endpoint}) ->
     template_params = {}
-    template_html = $('#grade-distributions-widget-template').html()
+    template_html = $('#grade-distributions-widget-template').text()
     @$container.html Mustache.render template_html, template_params
     @$problem_selector = @$container.find '.problem-selector'
 

--- a/lms/static/coffee/src/instructor_dashboard/instructor_dashboard.coffee
+++ b/lms/static/coffee/src/instructor_dashboard/instructor_dashboard.coffee
@@ -61,10 +61,8 @@ class SafeWaiter
     =>
       @waitFor_handlers = @waitFor_handlers.filter (g) -> g isnt f
       if @waitFor_handlers.length is 0
-        plantTimeout 0, =>
-          @fired = true
-          for cb in @after_handlers
-            cb()
+        @fired = true
+        @after_handlers.map (cb) -> plantTimeout 0, cb
 
       f.apply this, arguments
 

--- a/lms/static/coffee/src/instructor_dashboard/util.coffee
+++ b/lms/static/coffee/src/instructor_dashboard/util.coffee
@@ -5,6 +5,7 @@
 plantTimeout = (ms, cb) -> setTimeout cb, ms
 plantInterval = (ms, cb) -> setInterval cb, ms
 
+
 # standard ajax error wrapper
 #
 # wraps a `handler` function so that first
@@ -16,6 +17,26 @@ std_ajax_err = (handler) -> (jqXHR, textStatus, errorThrown) ->
   handler.apply this, arguments
 
 
+# Helper class for managing the execution of interval tasks.
+# Handles pausing and restarting.
+class IntervalManager
+  # Create a manager which will call `fn`
+  # after a call to .start every `ms` milliseconds.
+  constructor: (@ms, @fn) ->
+    @intervalID = null
+
+  # Start or restart firing every `ms` milliseconds.
+  # Soes not fire immediately.
+  start: ->
+    if @intervalID is null
+      @intervalID = setInterval @fn, @ms
+
+  # Pause firing.
+  stop: ->
+    clearInterval @intervalID
+    @intervalID = null
+
+
 # export for use
 # create parent namespaces if they do not already exist.
 # abort if underscore can not be found.
@@ -25,3 +46,4 @@ if _?
     plantTimeout: plantTimeout
     plantInterval: plantInterval
     std_ajax_err: std_ajax_err
+    IntervalManager: IntervalManager

--- a/lms/static/sass/course/instructor/_instructor_2.scss
+++ b/lms/static/sass/course/instructor/_instructor_2.scss
@@ -269,6 +269,10 @@ section.instructor-dashboard-content-2 {
 
 
 .instructor-dashboard-wrapper-2 section.idash-section#student_admin > {
+  .action-type-container{
+    margin-bottom: $baseline * 2;
+  }
+
   .progress-link-wrapper {
     margin-top: 0.7em;
   }

--- a/lms/static/sass/course/instructor/_instructor_2.scss
+++ b/lms/static/sass/course/instructor/_instructor_2.scss
@@ -36,6 +36,11 @@ section.instructor-dashboard-content-2 {
     color: $error-red;
   }
 
+  .display-errors {
+    line-height: 3em;
+    color: $error-red;
+  }
+
   .slickgrid {
     margin-left: 1px;
     color:#333333;
@@ -320,25 +325,40 @@ section.instructor-dashboard-content-2 {
 }
 
 
-.instructor-dashboard-wrapper-2 section.idash-section#analytics {
-  .distribution-display {
-    margin-top: 1.2em;
+.profile-distribution-widget {
+  margin-bottom: $baseline * 2;
 
-    .distribution-display-graph {
-      .year-of-birth {
-        width: 750px;
-        height: 250px;
-      }
-    }
+  .display-text {}
 
-    .distribution-display-table {
-      .slickgrid {
-        height: 400px;
-      }
+  .display-graph .graph-placeholder {
+    width: 750px;
+    height: 250px;
+  }
+
+  .display-table {
+    .slickgrid {
+      height: 250px;
     }
   }
 }
 
+.grade-distributions-widget {
+  margin-bottom: $baseline * 2;
+
+  .last-updated {
+    line-height: 2.2em;
+    font-size: 10pt;
+  }
+
+  .display-graph .graph-placeholder {
+    width: 750px;
+    height: 200px;
+  }
+
+  .display-text {
+    line-height: 2em;
+  }
+}
 
 .member-list-widget {
   $width: 20 * $baseline;

--- a/lms/templates/instructor/instructor_dashboard_2/analytics.html
+++ b/lms/templates/instructor/instructor_dashboard_2/analytics.html
@@ -1,12 +1,54 @@
 <%page args="section_data"/>
 
-<h2>Distributions</h2>
-<select id="distributions" data-endpoint="${ section_data['get_distribution_url'] }">
-  <option> Getting available distributions... </option>
-</select>
-<div class="distribution-display">
-  <div class="distribution-display-text"></div>
-  <div class="distribution-display-graph"></div>
-  <div class="distribution-display-table"></div>
-  <div class="request-response-error"></div>
-</div>
+<script type="text/template" id="profile-distribution-widget-template">
+  <div class="profile-distribution-widget">
+    <div class="header">
+      <h2 class="title"> {{title}} </h2>
+    </div>
+    <div class="view">
+      <div class="display-errors"></div>
+      <div class="display-text"></div>
+      <div class="display-graph"></div>
+      <div class="display-table"></div>
+    </div>
+  </div>
+</script>
+
+<script type="text/template" id="grade-distributions-widget-template">
+  <div class="grade-distributions-widget">
+    <div class="header">
+      <h2 class="title"> Grade Distribution </h2>
+      Problem: <select class="problem-selector">
+        <option> Loading problem list... </option>
+      </select>
+      <div class="last-updated"></div>
+    </div>
+    <div class="view">
+      <div class="display-errors"></div>
+      <div class="display-text"></div>
+      <div class="display-graph"></div>
+    </div>
+  </div>
+</script>
+
+<div class="grade-distributions-widget-container"
+  data-endpoint="${ section_data['proxy_legacy_analytics_url'] }"
+></div>
+
+<div class="profile-distribution-widget-container"
+  data-title="Year of Birth"
+  data-feature="year_of_birth"
+  data-endpoint="${ section_data['get_distribution_url'] }"
+></div>
+
+<div class="profile-distribution-widget-container"
+  data-title="Gender Distribution"
+  data-feature="gender"
+  data-endpoint="${ section_data['get_distribution_url'] }"
+></div>
+
+<div class="profile-distribution-widget-container"
+  data-title="Level of Education"
+  data-feature="level_of_education"
+  data-endpoint="${ section_data['get_distribution_url'] }"
+></div>

--- a/lms/templates/instructor/instructor_dashboard_2/student_admin.html
+++ b/lms/templates/instructor/instructor_dashboard_2/student_admin.html
@@ -1,6 +1,6 @@
 <%page args="section_data"/>
 
-<div class="student-specific-container">
+<div class="student-specific-container action-type-container">
   <H2>Student-specific grade adjustment</h2>
   <div class="request-response-error"></div>
 
@@ -47,12 +47,11 @@
     <input type="button" name="task-history-single" value="Show Background Task History for Student" data-endpoint="${ section_data['list_instructor_tasks_url'] }">
     <div class="task-history-single-table"></div>
   %endif
+  <hr>
 </div>
 
 %if settings.MITX_FEATURES.get('ENABLE_INSTRUCTOR_BACKGROUND_TASKS') and section_data['access']['instructor']:
-  <hr>
-
-  <div class="course-specific-container">
+  <div class="course-specific-container action-type-container">
     <H2>Course-specific grade adjustment</h2>
     <div class="request-response-error"></div>
 
@@ -81,9 +80,9 @@
     </p>
   </div>
 
-  <hr>
 
-  <div class="running-tasks-container">
+  <div class="running-tasks-container action-type-container">
+    <hr>
     <h2> Pending Instructor Tasks </h2>
     <div class="running-tasks-table" data-endpoint="${ section_data['list_instructor_tasks_url'] }"></div>
   </div>


### PR DESCRIPTION
Add a graph and dropdown for analytics from the analytics cronjob.
Refactor analytics section to have widgets (things with a template which can instantiate from a div with data attributes), like the list widget in the membership section.

![gd](https://f.cloud.github.com/assets/705646/910758/e541f54e-fddf-11e2-9fec-b79ff27c8053.png)

Also, space out the student admin section a little.

Reviewers:
@singingwolfboy 
@rocha 
