### PR TITLE
Bump up pip requirement to latest.

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -35,7 +35,7 @@ nltk==2.0.4
 paramiko==1.9.0
 path.py==3.0.1
 Pillow==1.7.8
-pip>=1.3
+pip>=1.4
 polib==1.0.3
 pycrypto>=2.6
 pygments==1.5


### PR DESCRIPTION
Solves an issue with using git > 1.8.1 for github based pip requirements.
