### PR TITLE
Fix for STUD-582

### DIFF
--- a/cms/djangoapps/contentstore/views/user.py
+++ b/cms/djangoapps/contentstore/views/user.py
@@ -179,7 +179,7 @@ def course_team_user(request, org, course, name, email):
         return JsonResponse()
 
     # all other operations require the requesting user to specify a role
-    if request.META.get("CONTENT_TYPE", "") == "application/json" and request.body:
+    if request.META.get("CONTENT_TYPE", "").startswith("application/json") and request.body:
         try:
             payload = json.loads(request.body)
         except:


### PR DESCRIPTION
https://edx-wiki.atlassian.net/browse/STUD-582

When Chrome sends the AJAX request to add a user to the course team, it sets the
Content-type to "application/json". However, when Firefox sends the same request,
it sets the Content-type to "application/json; charset=UTF-8". This commit only
checks that the Content-type begins with "application/json", not is identical
to it; that way, Firefox can play, too.
