### PR TITLE
Fix/adam/redirect

### DIFF
--- a/cms/djangoapps/contentstore/views/requests.py
+++ b/cms/djangoapps/contentstore/views/requests.py
@@ -12,7 +12,7 @@ def landing(request, org, course, coursename):
 
 # points to the temporary edge page
 def edge(request):
-    return redirect('/dashboard')
+    return redirect('/')
 
 
 def event(request):

--- a/lms/djangoapps/branding/views.py
+++ b/lms/djangoapps/branding/views.py
@@ -4,7 +4,6 @@ from django.shortcuts import redirect
 from django_future.csrf import ensure_csrf_cookie
 
 import student.views
-import branding
 import courseware.views
 from mitxmako.shortcuts import marketing_link
 from util.cache import cache_if_anonymous
@@ -26,11 +25,7 @@ def index(request):
     if settings.MITX_FEATURES.get('ENABLE_MKTG_SITE'):
         return redirect(settings.MKTG_URLS.get('ROOT'))
 
-    university = branding.get_university(request.META.get('HTTP_HOST'))
-    if university is None:
-        return student.views.index(request, user=request.user)
-
-    return redirect('/')
+    return student.views.index(request, user=request.user)
 
 
 @ensure_csrf_cookie
@@ -44,8 +39,4 @@ def courses(request):
     if settings.MITX_FEATURES.get('ENABLE_MKTG_SITE', False):
         return redirect(marketing_link('COURSES'), permanent=True)
 
-    university = branding.get_university(request.META.get('HTTP_HOST'))
-    if university is None:
-        return courseware.views.courses(request)
-
-    return redirect('/')
+    return courseware.views.courses(request)


### PR DESCRIPTION
@feanil 

I had pinpointed the wrong file to change the redirects in. Here are the lms views that redirect to "/". I'm changing them to redirect to student.views.index. The CMS view should be changed back to redirect to "/". (or we can rebase that earlier commit out). "/dashboard" is not a valid url for cms anyway.

It turns out that the original "edge" view wasn't even pointing to a valid template. It returned "render_to_response('university_profiles/edge.html', {})". But "edge.html" was in a directory called "university_profile", no "s". So that would have returned a 404 if it were ever called. (https://github.com/edx/edx-platform/blob/32a902ca57e449a5101786545217f022edf825cb/cms/djangoapps/contentstore/views/requests.py#L14)

When I test the the "/courses" url out on stage, it redirects to "/" and then falls into that loop. Originally I had thought to redirect it to the dashboard view by calling "redirect(reverse('dashboard'))". But, as we're not using branding, it made more sense just directly to call "student.views.index" rather than have an extra bit of logic. 

@chrisndodge  and @brianhw ?
