### PR TITLE
Add a python prefix for `diff-quality` task

### DIFF
--- a/rakelib/quality.rake
+++ b/rakelib/quality.rake
@@ -54,6 +54,7 @@ task :quality => dquality_dir do
     sh("diff-quality --violations=pep8")
 
     # Generage diff-quality html report for pylint, and print to console
-    sh("diff-quality --violations=pylint --html-report #{dquality_dir}/diff_quality_pylint.html")
-    sh("diff-quality --violations=pylint")
+    pythonpath_prefix = "PYTHONPATH=$PYTHONPATH:lms:lms/djangoapps:lms/lib:cms:cms/djangoapps:cms/lib:common:common/djangoapps:common/lib"
+    sh("#{pythonpath_prefix} diff-quality --violations=pylint --html-report #{dquality_dir}/diff_quality_pylint.html")
+    sh("#{pythonpath_prefix} diff-quality --violations=pylint")
 end


### PR DESCRIPTION
@wedaly `diff-quality` is reporting extra violations because we don't set the python path properly. `rake pylint` sets the path, and thus is more accurate in reporting violations. I'd like to fix this in the same manner as rake pylint - from further up in `quality.rake` - so that the two reports are analogous. 

However... this doesn't work, and I can't figure out why it's unhappy. Rake seems to be failing on the `#{pythonpath_prefix}` bit, in the line `sh("#{pythonpath_prefix} diff-quality --violations=pylint")`, as seen here: https://gist.github.com/sarina/5c98dd3109c6d3f6cac5

Adding a semicolon, a la `sh("#{pythonpath_prefix}; diff-quality --violations=pylint")`, doesn't work, because while both commands execute, the first command doesn't seem to permanently set the PYTHONPATH for the second command's run.

Any ideas, anyone?
