### PR TITLE
adjustment to sidebar help text on PDF textbook page in studio

### DIFF
--- a/cms/templates/textbooks.html
+++ b/cms/templates/textbooks.html
@@ -76,7 +76,7 @@ $(function() {
         </div>
         <div class="bit">
           <h3 class="title-3">${_("What if my book isn't divided into chapters?")}</h3>
-          <p>${_("If you haven't broken your textbook into chapters, you can upload the entire text as Chapter 1.")}</p>
+          <p>${_("If you haven't broken your text into chapters, you can upload the entire text as a single chapter and enter a name of your choice in the Chapter Name field.")}</p>
         </div>
       </aside>
     </section>


### PR DESCRIPTION
Krister asked that we adjust the wording a little on the sidebar help on PDF Textbooks to be more clear about the chapter name when a text isn't broken into chapters. @markchang and @talbs can you review?
