### PR TITLE
add university_profile/edge.html for edge landing page

### DIFF
--- a/lms/djangoapps/branding/views.py
+++ b/lms/djangoapps/branding/views.py
@@ -2,8 +2,10 @@ from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.shortcuts import redirect
 from django_future.csrf import ensure_csrf_cookie
+from mitxmako.shortcuts import render_to_response
 
 import student.views
+import branding
 import courseware.views
 from mitxmako.shortcuts import marketing_link
 from util.cache import cache_if_anonymous
@@ -25,7 +27,11 @@ def index(request):
     if settings.MITX_FEATURES.get('ENABLE_MKTG_SITE'):
         return redirect(settings.MKTG_URLS.get('ROOT'))
 
-    return student.views.index(request, user=request.user)
+    university = branding.get_university(request.META.get('HTTP_HOST'))
+    if university is None:
+        return student.views.index(request, user=request.user)
+
+    return render_to_response('university_profile/edge.html', {})
 
 
 @ensure_csrf_cookie
@@ -39,4 +45,8 @@ def courses(request):
     if settings.MITX_FEATURES.get('ENABLE_MKTG_SITE', False):
         return redirect(marketing_link('COURSES'), permanent=True)
 
-    return courseware.views.courses(request)
+    university = branding.get_university(request.META.get('HTTP_HOST'))
+    if university is None:
+        return courseware.views.courses(request)
+
+    return render_to_response('university_profile/edge.html', {})

--- a/lms/djangoapps/branding/views.py
+++ b/lms/djangoapps/branding/views.py
@@ -28,10 +28,13 @@ def index(request):
         return redirect(settings.MKTG_URLS.get('ROOT'))
 
     university = branding.get_university(request.META.get('HTTP_HOST'))
-    if university is None:
-        return student.views.index(request, user=request.user)
+    if university == 'edge':
+        return render_to_response('university_profile/edge.html', {})
 
-    return render_to_response('university_profile/edge.html', {})
+    #  we do not expect this case to be reached in cases where
+    #  marketing and edge are enabled
+    return student.views.index(request, user=request.user)
+
 
 
 @ensure_csrf_cookie
@@ -46,7 +49,9 @@ def courses(request):
         return redirect(marketing_link('COURSES'), permanent=True)
 
     university = branding.get_university(request.META.get('HTTP_HOST'))
-    if university is None:
-        return courseware.views.courses(request)
+    if university == 'edge':
+        return render_to_response('university_profile/edge.html', {})
 
-    return render_to_response('university_profile/edge.html', {})
+    #  we do not expect this case to be reached in cases where
+    #  marketing and edge are enabled
+    return courseware.views.courses(request)

--- a/lms/templates/university_profile/edge.html
+++ b/lms/templates/university_profile/edge.html
@@ -1,0 +1,65 @@
+<%inherit file="../stripped-main.html" />
+<%! from django.core.urlresolvers import reverse %>
+<%block name="title"><title>edX edge</title></%block>
+<%block name="bodyclass">no-header edge-landing</%block>
+
+<%block name="content">
+<div class="main-wrapper">
+  <div class="edx-edge-logo-large">edX edge</div>
+  <div class="content">
+    <div class="log-in-form">
+      <h2>Log in to your courses</h2>
+      <form id="login_form" data-remote="true" method="post" action="/login">
+        <div class="row">
+          <label>Email</label>
+          <input name="email" type="email" class="email-field" tabindex="1">
+        </div>
+        <div class="row">
+          <label>Password</label>
+          <input name="password" type="password" class="password-field" tabindex="2">
+        </div>
+        <div class="row submit">
+          <input name="submit" type="submit" value="Log In" class="log-in-submit-button" tabindex="3">
+          <a href="#forgot-password-modal"  rel="leanModal" class="pwd-reset forgot-button">Forgot password?</a>
+        </div>
+      </form>
+    </div>
+    <div class="sign-up">
+      <h3>Register for classes</h3>
+      <p>Take free online courses from today's leading universities.</p>
+      <p><a href="#signup-modal" id="signup" rel="leanModal" class="register-button">Register</a></p>
+    </div>
+  </div>
+</div>
+
+</%block>
+
+<%block name="js_extra">
+<script type="text/javascript">
+  (function() {
+    $(document).ready(function() {
+      if ($.deparam.fragment()['forgot-password-modal'] !== undefined) {
+        $('.pwd-reset').click();
+      }
+    })
+    $(document).delegate('#login_form', 'ajax:success', function(data, json, xhr) {
+     if(json.success) {
+        next = getParameterByName('next');
+        if(next) {
+           location.href = next;
+       } else {
+           location.href = "${reverse('dashboard')}";
+       }
+     } else {
+       if($('#login_error').length == 0) {
+         $('#login_form').prepend('<div id="login_error" class="modal-form-error"></div>');
+       }
+       $('#login_error').html(json.value).stop().css("display", "block");
+     }
+    });
+  })(this)
+</script>
+</%block>
+
+<%include file="../signup_modal.html" />
+<%include file="../forgot_password_modal.html" />


### PR DESCRIPTION
resets branding/views to https://github.com/edx/edx-platform/blob/93cbb2e42201d6fe3edb3054ebf6b2ed6deba8c1/lms/djangoapps/branding/views.py

puts back university_profile/edge.html

basically, if a user is logged out in edge, the user will be presented with edge.html, which is a log in page. This is how it worked before.

@brianhw , @feanil 
