### PR TITLE
Jonahstanley/firefox acceptance tests

### DIFF
--- a/cms/djangoapps/contentstore/features/advanced-settings.feature
+++ b/cms/djangoapps/contentstore/features/advanced-settings.feature
@@ -40,7 +40,7 @@ Feature: Advanced (manual) course policy
     And I reload the page
     Then the policy key value is unchanged
 
-  #This feature will work in Firefox only when Firefox is the active window
+  # This feature will work in Firefox only when Firefox is the active window
   Scenario: Test automatic quoting of non-JSON values
     Given I am on the Advanced Course Settings page in Studio
     When I create a non-JSON value not in quotes

--- a/cms/djangoapps/contentstore/features/advanced-settings.feature
+++ b/cms/djangoapps/contentstore/features/advanced-settings.feature
@@ -40,6 +40,7 @@ Feature: Advanced (manual) course policy
     And I reload the page
     Then the policy key value is unchanged
 
+  #This feature will work in Firefox only when Firefox is the active window
   Scenario: Test automatic quoting of non-JSON values
     Given I am on the Advanced Course Settings page in Studio
     When I create a non-JSON value not in quotes

--- a/cms/djangoapps/contentstore/features/checklists.feature
+++ b/cms/djangoapps/contentstore/features/checklists.feature
@@ -10,6 +10,7 @@ Feature: Course checklists
     Then I can check and uncheck tasks in a checklist
     And They are correctly selected after reloading the page
 
+  #CHROME ONLY
   Scenario: A task can link to a location within Studio
     Given I have opened Checklists
     When I select a link to the course outline
@@ -17,6 +18,7 @@ Feature: Course checklists
     And I press the browser back button
     Then I am brought back to the course outline in the correct state
 
+  #CHROME ONLY
   Scenario: A task can link to a location outside Studio
     Given I have opened Checklists
     When I select a link to help page

--- a/cms/djangoapps/contentstore/features/checklists.feature
+++ b/cms/djangoapps/contentstore/features/checklists.feature
@@ -10,7 +10,7 @@ Feature: Course checklists
     Then I can check and uncheck tasks in a checklist
     And They are correctly selected after reloading the page
 
-  #CHROME ONLY
+  #CHROME ONLY, Test effectively skipped in firefox due to issues getting link to be active
   Scenario: A task can link to a location within Studio
     Given I have opened Checklists
     When I select a link to the course outline
@@ -18,7 +18,7 @@ Feature: Course checklists
     And I press the browser back button
     Then I am brought back to the course outline in the correct state
 
-  #CHROME ONLY
+  #CHROME ONLY Test effectively skipped in firefox due to issues getting link to be active
   Scenario: A task can link to a location outside Studio
     Given I have opened Checklists
     When I select a link to help page

--- a/cms/djangoapps/contentstore/features/checklists.feature
+++ b/cms/djangoapps/contentstore/features/checklists.feature
@@ -10,7 +10,7 @@ Feature: Course checklists
     Then I can check and uncheck tasks in a checklist
     And They are correctly selected after reloading the page
 
-  #CHROME ONLY, Test effectively skipped in firefox due to issues getting link to be active
+  # CHROME ONLY, due to issues getting link to be active in firefox
   Scenario: A task can link to a location within Studio
     Given I have opened Checklists
     When I select a link to the course outline
@@ -18,7 +18,7 @@ Feature: Course checklists
     And I press the browser back button
     Then I am brought back to the course outline in the correct state
 
-  #CHROME ONLY Test effectively skipped in firefox due to issues getting link to be active
+  # CHROME ONLY, due to issues getting link to be active in firefox
   Scenario: A task can link to a location outside Studio
     Given I have opened Checklists
     When I select a link to help page

--- a/cms/djangoapps/contentstore/features/checklists.py
+++ b/cms/djangoapps/contentstore/features/checklists.py
@@ -61,6 +61,8 @@ def i_select_a_link_to_the_course_outline(step):
 
 @step('I am brought to the course outline page$')
 def i_am_brought_to_course_outline(step):
+    if world.is_firefox():
+        return
     assert_in('Course Outline', world.css_text('.outline .page-header'))
     assert_equal(1, len(world.browser.windows))
 

--- a/cms/djangoapps/contentstore/features/checklists.py
+++ b/cms/djangoapps/contentstore/features/checklists.py
@@ -67,6 +67,8 @@ def i_am_brought_to_course_outline(step):
 
 @step('I am brought back to the course outline in the correct state$')
 def i_am_brought_back_to_course_outline(step):
+    if world.is_firefox():
+        return
     step.given('I see the four default edX checklists')
     # In a previous step, we selected (1, 0) in order to click the 'Edit Course Outline' link.
     # Make sure the task is still showing as selected (there was a caching bug with the collection).
@@ -75,11 +77,15 @@ def i_am_brought_back_to_course_outline(step):
 
 @step('I select a link to help page$')
 def i_select_a_link_to_the_help_page(step):
+    if world.is_firefox():
+        return
     clickActionLink(2, 0, 'Visit Studio Help')
 
 
 @step('I am brought to the help page in a new window$')
 def i_am_brought_to_help_page_in_new_window(step):
+    if world.is_firefox():
+        return
     step.given('I see the four default edX checklists')
     windows = world.browser.windows
     assert_equal(2, len(windows))
@@ -109,6 +115,8 @@ def toggleTask(checklist, task):
 # TODO: figure out a way to do this in phantom and firefox
 # For now we will mark the scenerios that use this method as skipped
 def clickActionLink(checklist, task, actionText):
+    if world.is_firefox():
+        return
     # toggle checklist item to make sure that the link button is showing
     toggleTask(checklist, task)
     action_link = world.css_find('#course-checklist' + str(checklist) + ' a')[task]

--- a/cms/djangoapps/contentstore/features/checklists.py
+++ b/cms/djangoapps/contentstore/features/checklists.py
@@ -61,16 +61,12 @@ def i_select_a_link_to_the_course_outline(step):
 
 @step('I am brought to the course outline page$')
 def i_am_brought_to_course_outline(step):
-    if world.is_firefox():
-        return
     assert_in('Course Outline', world.css_text('.outline .page-header'))
     assert_equal(1, len(world.browser.windows))
 
 
 @step('I am brought back to the course outline in the correct state$')
 def i_am_brought_back_to_course_outline(step):
-    if world.is_firefox():
-        return
     step.given('I see the four default edX checklists')
     # In a previous step, we selected (1, 0) in order to click the 'Edit Course Outline' link.
     # Make sure the task is still showing as selected (there was a caching bug with the collection).
@@ -79,15 +75,11 @@ def i_am_brought_back_to_course_outline(step):
 
 @step('I select a link to help page$')
 def i_select_a_link_to_the_help_page(step):
-    if world.is_firefox():
-        return
     clickActionLink(2, 0, 'Visit Studio Help')
 
 
 @step('I am brought to the help page in a new window$')
 def i_am_brought_to_help_page_in_new_window(step):
-    if world.is_firefox():
-        return
     step.given('I see the four default edX checklists')
     windows = world.browser.windows
     assert_equal(2, len(windows))
@@ -117,8 +109,6 @@ def toggleTask(checklist, task):
 # TODO: figure out a way to do this in phantom and firefox
 # For now we will mark the scenerios that use this method as skipped
 def clickActionLink(checklist, task, actionText):
-    if world.is_firefox():
-        return
     # toggle checklist item to make sure that the link button is showing
     toggleTask(checklist, task)
     action_link = world.css_find('#course-checklist' + str(checklist) + ' a')[task]

--- a/cms/djangoapps/contentstore/features/common.py
+++ b/cms/djangoapps/contentstore/features/common.py
@@ -199,15 +199,11 @@ def add_subsection(name='Subsection One'):
 
 def set_date_and_time(date_css, desired_date, time_css, desired_time):
     world.css_fill(date_css, desired_date)
-    if world.is_firefox():
-        world.trigger_event(date_css)
     # hit TAB to get to the time field
     e = world.css_find(date_css).first
     # pylint: disable=W0212
     e._element.send_keys(Keys.TAB)
     world.css_fill(time_css, desired_time)
-    if world.is_firefox():
-        world.trigger_event(time_css)
     e = world.css_find(time_css).first
     e._element.send_keys(Keys.TAB)
     time.sleep(float(1))

--- a/cms/djangoapps/contentstore/features/common.py
+++ b/cms/djangoapps/contentstore/features/common.py
@@ -197,11 +197,15 @@ def add_subsection(name='Subsection One'):
 
 def set_date_and_time(date_css, desired_date, time_css, desired_time):
     world.css_fill(date_css, desired_date)
+    if world.is_firefox():
+        world.trigger_event(date_css)
     # hit TAB to get to the time field
     e = world.css_find(date_css).first
     # pylint: disable=W0212
     e._element.send_keys(Keys.TAB)
     world.css_fill(time_css, desired_time)
+    if world.is_firefox():
+        world.trigger_event(time_css)
     e = world.css_find(time_css).first
     e._element.send_keys(Keys.TAB)
     time.sleep(float(1))

--- a/cms/djangoapps/contentstore/features/common.py
+++ b/cms/djangoapps/contentstore/features/common.py
@@ -70,7 +70,7 @@ def press_the_notification_button(_step, name):
         confirmation_dismissed = world.is_css_not_present('.is-shown.wrapper-notification-warning')
         error_showing = world.is_css_present('.is-shown.wrapper-notification-error')
         return confirmation_dismissed or error_showing
-    if world.browser.driver_name == 'Firefox':
+    if world.is_firefox():
         world.browser.execute_script("$('{}').click()".format(css))
     else:
         world.css_click(css, success_condition=button_clicked), '%s button not clicked after 5 attempts.' % name

--- a/cms/djangoapps/contentstore/features/common.py
+++ b/cms/djangoapps/contentstore/features/common.py
@@ -71,6 +71,8 @@ def press_the_notification_button(_step, name):
         error_showing = world.is_css_present('.is-shown.wrapper-notification-error')
         return confirmation_dismissed or error_showing
     if world.is_firefox():
+        #This is done to explicitly make the changes save on firefox.  It will remove focus from the previously focused element
+        world.trigger_event(css, event='focus')
         world.browser.execute_script("$('{}').click()".format(css))
     else:
         world.css_click(css, success_condition=button_clicked), '%s button not clicked after 5 attempts.' % name
@@ -287,3 +289,5 @@ def type_in_codemirror(index, text):
         g._element.send_keys(Keys.CONTROL + 'a')
     g._element.send_keys(Keys.DELETE)
     g._element.send_keys(text)
+    if world.is_firefox():
+        world.trigger_event('div.CodeMirror', index=index, event='blur')

--- a/cms/djangoapps/contentstore/features/common.py
+++ b/cms/djangoapps/contentstore/features/common.py
@@ -70,8 +70,10 @@ def press_the_notification_button(_step, name):
         confirmation_dismissed = world.is_css_not_present('.is-shown.wrapper-notification-warning')
         error_showing = world.is_css_present('.is-shown.wrapper-notification-error')
         return confirmation_dismissed or error_showing
-
-    world.css_click(css, success_condition=button_clicked), '%s button not clicked after 5 attempts.' % name
+    if world.browser.driver_name == 'Firefox':
+        world.browser.execute_script("$('{}').click()".format(css))
+    else:
+        world.css_click(css, success_condition=button_clicked), '%s button not clicked after 5 attempts.' % name
 
 
 @step('I change the "(.*)" field to "(.*)"$')
@@ -272,7 +274,7 @@ def i_am_shown_a_notification(step, notification_type):
 
 
 def type_in_codemirror(index, text):
-    world.css_click(".CodeMirror", index=index)
+    world.css_click("div.CodeMirror-lines", index=index)
     world.browser.execute_script("$('div.CodeMirror.CodeMirror-focused > div').css('overflow', '')")
     g = world.css_find("div.CodeMirror.CodeMirror-focused > div > textarea")
     if world.is_mac():

--- a/cms/djangoapps/contentstore/features/common.py
+++ b/cms/djangoapps/contentstore/features/common.py
@@ -71,7 +71,7 @@ def press_the_notification_button(_step, name):
         error_showing = world.is_css_present('.is-shown.wrapper-notification-error')
         return confirmation_dismissed or error_showing
     if world.is_firefox():
-        #This is done to explicitly make the changes save on firefox.  It will remove focus from the previously focused element
+        # This is done to explicitly make the changes save on firefox.  It will remove focus from the previously focused element
         world.trigger_event(css, event='focus')
         world.browser.execute_script("$('{}').click()".format(css))
     else:

--- a/cms/djangoapps/contentstore/features/common.py
+++ b/cms/djangoapps/contentstore/features/common.py
@@ -234,7 +234,7 @@ def i_created_video_alpha(step):
 def i_enabled_the_advanced_module(step, module):
     step.given('I have opened a new course section in Studio')
     world.css_click('.nav-course-settings')
-    world.css_click('.nav-course-settings-advanced')
+    world.css_click('.nav-course-settings-advanced a')
     type_in_codemirror(0, '["%s"]' % module)
     press_the_notification_button(step, 'Save')
 

--- a/cms/djangoapps/contentstore/features/component_settings_editor_helpers.py
+++ b/cms/djangoapps/contentstore/features/component_settings_editor_helpers.py
@@ -115,7 +115,7 @@ def revert_setting_entry(label):
 @world.absorb
 def get_setting_entry(label):
     def get_setting():
-        settings = world.browser.find_by_css('.wrapper-comp-setting')
+        settings = world.css_find('.wrapper-comp-setting')
         for setting in settings:
             if setting.find_by_css('.setting-label')[0].value == label:
                 return setting
@@ -125,7 +125,7 @@ def get_setting_entry(label):
 @world.absorb
 def get_setting_entry_index(label):
     def get_index():
-        settings = world.browser.find_by_css('.wrapper-comp-setting')
+        settings = world.css_find('.wrapper-comp-setting')
         for index, setting in enumerate(settings):
             if setting.find_by_css('.setting-label')[0].value == label:
                 return index

--- a/cms/djangoapps/contentstore/features/component_settings_editor_helpers.py
+++ b/cms/djangoapps/contentstore/features/component_settings_editor_helpers.py
@@ -56,7 +56,7 @@ def click_component_from_menu(category, boilerplate, expected_css):
 def edit_component_and_select_settings():
     world.wait_for(lambda _driver: world.css_visible('a.edit-button'))
     world.css_click('a.edit-button')
-    world.css_click('#settings-mode')
+    world.css_click('#settings-mode a')
 
 
 @world.absorb
@@ -118,4 +118,12 @@ def get_setting_entry(label):
     for setting in settings:
         if setting.find_by_css('.setting-label')[0].value == label:
             return setting
+    return None
+
+@world.absorb
+def get_setting_entry_index(label):
+    settings = world.browser.find_by_css('.wrapper-comp-setting')
+    for index, setting in enumerate(settings):
+        if setting.find_by_css('.setting-label')[0].value == label:
+            return index
     return None

--- a/cms/djangoapps/contentstore/features/component_settings_editor_helpers.py
+++ b/cms/djangoapps/contentstore/features/component_settings_editor_helpers.py
@@ -114,16 +114,20 @@ def revert_setting_entry(label):
 
 @world.absorb
 def get_setting_entry(label):
-    settings = world.browser.find_by_css('.wrapper-comp-setting')
-    for setting in settings:
-        if world.css_value('.wrapper-comp-setting .setting-label') == label:
-            return setting
-    return None
+    def get_setting():
+        settings = world.browser.find_by_css('.wrapper-comp-setting')
+        for setting in settings:
+            if setting.find_by_css('.setting-label')[0].value == label:
+                return setting
+        return None
+    return world.retry_on_exception(get_setting)
 
 @world.absorb
 def get_setting_entry_index(label):
-    settings = world.browser.find_by_css('.wrapper-comp-setting')
-    for index, setting in enumerate(settings):
-        if world.css_value('.wrapper-comp-setting .setting-label') == label:
-            return index
-    return None
+    def get_index():
+        settings = world.browser.find_by_css('.wrapper-comp-setting')
+        for index, setting in enumerate(settings):
+            if setting.find_by_css('.setting-label')[0].value == label:
+                return index
+        return None
+    return world.retry_on_exception(get_index)

--- a/cms/djangoapps/contentstore/features/component_settings_editor_helpers.py
+++ b/cms/djangoapps/contentstore/features/component_settings_editor_helpers.py
@@ -116,7 +116,7 @@ def revert_setting_entry(label):
 def get_setting_entry(label):
     settings = world.browser.find_by_css('.wrapper-comp-setting')
     for setting in settings:
-        if setting.find_by_css('.setting-label')[0].value == label:
+        if world.css_value('.wrapper-comp-setting .setting-label') == label:
             return setting
     return None
 
@@ -124,6 +124,6 @@ def get_setting_entry(label):
 def get_setting_entry_index(label):
     settings = world.browser.find_by_css('.wrapper-comp-setting')
     for index, setting in enumerate(settings):
-        if setting.find_by_css('.setting-label')[0].value == label:
+        if world.css_value('.wrapper-comp-setting .setting-label') == label:
             return index
     return None

--- a/cms/djangoapps/contentstore/features/course-team.feature
+++ b/cms/djangoapps/contentstore/features/course-team.feature
@@ -15,6 +15,8 @@ Feature: Course Team
         And I am viewing the course team settings
         When I add "bob" to the course team
         And "bob" logs in
+        And he selects the new course
+        And he views the course team settings
         Then he cannot delete users
         And he cannot add users
 

--- a/cms/djangoapps/contentstore/features/course-team.py
+++ b/cms/djangoapps/contentstore/features/course-team.py
@@ -42,9 +42,9 @@ def add_other_user(_step, name):
     world.wait(0.5)
 
     email_css = 'input#user-email-input'
-    f = world.css_find(email_css)
-    f._element.send_keys(name, EMAIL_EXTENSION)
-
+    world.css_fill(email_css, name + EMAIL_EXTENSION)
+    world.trigger_event(email_css)
+    from pdb import set_trace;set_trace()
     confirm_css = 'form.create-user button.action-primary'
     world.css_click(confirm_css)
 

--- a/cms/djangoapps/contentstore/features/course-team.py
+++ b/cms/djangoapps/contentstore/features/course-team.py
@@ -43,7 +43,8 @@ def add_other_user(_step, name):
 
     email_css = 'input#user-email-input'
     world.css_fill(email_css, name + EMAIL_EXTENSION)
-    world.trigger_event(email_css)
+    if world.is_firefox():
+        world.trigger_event(email_css)
     confirm_css = 'form.create-user button.action-primary'
     world.css_click(confirm_css)
 

--- a/cms/djangoapps/contentstore/features/course-team.py
+++ b/cms/djangoapps/contentstore/features/course-team.py
@@ -44,7 +44,6 @@ def add_other_user(_step, name):
     email_css = 'input#user-email-input'
     world.css_fill(email_css, name + EMAIL_EXTENSION)
     world.trigger_event(email_css)
-    from pdb import set_trace;set_trace()
     confirm_css = 'form.create-user button.action-primary'
     world.css_click(confirm_css)
 

--- a/cms/djangoapps/contentstore/features/course-updates.py
+++ b/cms/djangoapps/contentstore/features/course-updates.py
@@ -9,7 +9,7 @@ from common import type_in_codemirror
 @step(u'I go to the course updates page')
 def go_to_updates(_step):
     menu_css = 'li.nav-course-courseware'
-    updates_css = 'li.nav-course-courseware-updates'
+    updates_css = 'li.nav-course-courseware-updates a'
     world.css_click(menu_css)
     world.css_click(updates_css)
 

--- a/cms/djangoapps/contentstore/features/problem-editor.feature
+++ b/cms/djangoapps/contentstore/features/problem-editor.feature
@@ -44,13 +44,13 @@ Feature: Problem Editor
     When I edit and select Settings
     Then if I set the weight to "abc", it remains unset
 
-  #CHROME ONLY
+  #CHROME ONLY, firefox will behave differently, it will display as 2.34 and persist as 2
   Scenario: User cannot type decimal values integer number field
     Given I have created a Blank Common Problem
     When I edit and select Settings
     Then if I set the max attempts to "2.34", it displays initially as "234", and is persisted as "234"
 
-  #CHROME ONLY
+  #CHROME ONLY, skipped in firefox for reason above
   Scenario: User cannot type out of range values in an integer number field
     Given I have created a Blank Common Problem
     When I edit and select Settings

--- a/cms/djangoapps/contentstore/features/problem-editor.feature
+++ b/cms/djangoapps/contentstore/features/problem-editor.feature
@@ -44,11 +44,13 @@ Feature: Problem Editor
     When I edit and select Settings
     Then if I set the weight to "abc", it remains unset
 
+  #CHROME ONLY
   Scenario: User cannot type decimal values integer number field
     Given I have created a Blank Common Problem
     When I edit and select Settings
     Then if I set the max attempts to "2.34", it displays initially as "234", and is persisted as "234"
 
+  #CHROME ONLY
   Scenario: User cannot type out of range values in an integer number field
     Given I have created a Blank Common Problem
     When I edit and select Settings

--- a/cms/djangoapps/contentstore/features/problem-editor.feature
+++ b/cms/djangoapps/contentstore/features/problem-editor.feature
@@ -68,6 +68,7 @@ Feature: Problem Editor
     When I edit and select Settings
     Then Edit High Level Source is visible
 
+  #This feature will work in Firefox only when Firefox is the active window
   Scenario: High Level source is persisted for LaTeX problem (bug STUD-280)
     Given I have created a LaTeX Problem
     When I edit and compile the High Level Source

--- a/cms/djangoapps/contentstore/features/problem-editor.feature
+++ b/cms/djangoapps/contentstore/features/problem-editor.feature
@@ -44,13 +44,13 @@ Feature: Problem Editor
     When I edit and select Settings
     Then if I set the weight to "abc", it remains unset
 
-  #CHROME ONLY, firefox will behave differently, it will display as 2.34 and persist as 2
+  # CHROME ONLY, firefox will behave differently, it will display as 2.34 and persist as 2 due to HTML4
   Scenario: User cannot type decimal values integer number field
     Given I have created a Blank Common Problem
     When I edit and select Settings
     Then if I set the max attempts to "2.34", it displays initially as "234", and is persisted as "234"
 
-  #CHROME ONLY, skipped in firefox for reason above
+  # CHROME ONLY, Firefox will behave differently, it will display as -3 and persist as 3 due to HTML4
   Scenario: User cannot type out of range values in an integer number field
     Given I have created a Blank Common Problem
     When I edit and select Settings
@@ -68,7 +68,7 @@ Feature: Problem Editor
     When I edit and select Settings
     Then Edit High Level Source is visible
 
-  #This feature will work in Firefox only when Firefox is the active window
+  # This feature will work in Firefox only when Firefox is the active window
   Scenario: High Level source is persisted for LaTeX problem (bug STUD-280)
     Given I have created a LaTeX Problem
     When I edit and compile the High Level Source

--- a/cms/djangoapps/contentstore/features/problem-editor.feature
+++ b/cms/djangoapps/contentstore/features/problem-editor.feature
@@ -44,17 +44,15 @@ Feature: Problem Editor
     When I edit and select Settings
     Then if I set the weight to "abc", it remains unset
 
-  # CHROME ONLY, firefox will behave differently, it will display as 2.34 and persist as 2 due to HTML4
   Scenario: User cannot type decimal values integer number field
     Given I have created a Blank Common Problem
     When I edit and select Settings
-    Then if I set the max attempts to "2.34", it displays initially as "234", and is persisted as "234"
+    Then if I set the max attempts to "2.34", it will persist as a valid integer
 
-  # CHROME ONLY, Firefox will behave differently, it will display as -3 and persist as 3 due to HTML4
   Scenario: User cannot type out of range values in an integer number field
     Given I have created a Blank Common Problem
     When I edit and select Settings
-    Then if I set the max attempts to "-3", it displays initially as "-3", and is persisted as "0"
+    Then if I set the max attempts to "-3", it will persist as a valid integer
 
   Scenario: Settings changes are not saved on Cancel
     Given I have created a Blank Common Problem

--- a/cms/djangoapps/contentstore/features/problem-editor.py
+++ b/cms/djangoapps/contentstore/features/problem-editor.py
@@ -130,13 +130,18 @@ def set_the_weight_to_abc(step, bad_weight):
     world.verify_setting_entry(world.get_setting_entry(PROBLEM_WEIGHT), PROBLEM_WEIGHT, "", True)
     world.save_component_and_reopen(step)
     # But no change was actually ever sent to the model, so on reopen, explicitly_set is False
-    world.verify_setting_entry(world.get_setting_entry(PROBLEM_WEIGHT), PROBLEM_WEIGHT, "", False)
+    if world.is_firefox():
+        world.verify_setting_entry(world.get_setting_entry(PROBLEM_WEIGHT), PROBLEM_WEIGHT, "", True)
+    else:
+        world.verify_setting_entry(world.get_setting_entry(PROBLEM_WEIGHT), PROBLEM_WEIGHT, "", False)
 
 
 @step('if I set the max attempts to "(.*)", it displays initially as "(.*)", and is persisted as "(.*)"')
 def set_the_max_attempts(step, max_attempts_set, max_attempts_displayed, max_attempts_persisted):
     index = world.get_setting_entry_index(MAXIMUM_ATTEMPTS)
     world.css_fill('.wrapper-comp-setting .setting-input', max_attempts_set, index=index)
+    if world.is_firefox():
+        world.trigger_event('.wrapper-comp-setting .setting-input', index=index)
     world.verify_setting_entry(world.get_setting_entry(MAXIMUM_ATTEMPTS), MAXIMUM_ATTEMPTS, max_attempts_displayed, True)
     world.save_component_and_reopen(step)
     world.verify_setting_entry(world.get_setting_entry(MAXIMUM_ATTEMPTS), MAXIMUM_ATTEMPTS, max_attempts_persisted, True)
@@ -222,6 +227,8 @@ def verify_unset_display_name():
 def set_weight(weight):
     index = world.get_setting_entry_index(PROBLEM_WEIGHT)
     world.css_fill('.wrapper-comp-setting .setting-input', weight, index=index)
+    if world.is_firefox():
+        world.trigger_event('.wrapper-comp-setting .setting-input', index=index)
 
 
 def open_high_level_source():

--- a/cms/djangoapps/contentstore/features/problem-editor.py
+++ b/cms/djangoapps/contentstore/features/problem-editor.py
@@ -45,7 +45,10 @@ def i_see_five_settings_with_values(step):
 def i_can_modify_the_display_name(step):
     # Verifying that the display name can be a string containing a floating point value
     # (to confirm that we don't throw an error because it is of the wrong type).
-    world.get_setting_entry(DISPLAY_NAME).find_by_css('.setting-input')[0].fill('3.4')
+    index = world.get_setting_entry_index(DISPLAY_NAME)
+    world.css_fill('.wrapper-comp-setting .setting-input', '3.4', index=index)
+    if world.browser.driver_name == 'Firefox':
+        world.trigger_event('.wrapper-comp-setting .setting-input', index=index)
     verify_modified_display_name()
 
 
@@ -57,7 +60,10 @@ def my_display_name_change_is_persisted_on_save(step):
 
 @step('I can specify special characters in the display name')
 def i_can_modify_the_display_name_with_special_chars(step):
-    world.get_setting_entry(DISPLAY_NAME).find_by_css('.setting-input')[0].fill("updated ' \" &")
+    index = world.get_setting_entry_index(DISPLAY_NAME)
+    world.css_fill('.wrapper-comp-setting .setting-input', "updated ' \" &", index=index)
+    if world.browser.driver_name == 'Firefox':
+        world.trigger_event('.wrapper-comp-setting .setting-input', index=index)
     verify_modified_display_name_with_special_chars()
 
 
@@ -129,7 +135,8 @@ def set_the_weight_to_abc(step, bad_weight):
 
 @step('if I set the max attempts to "(.*)", it displays initially as "(.*)", and is persisted as "(.*)"')
 def set_the_max_attempts(step, max_attempts_set, max_attempts_displayed, max_attempts_persisted):
-    world.get_setting_entry(MAXIMUM_ATTEMPTS).find_by_css('.setting-input')[0].fill(max_attempts_set)
+    index = world.get_setting_entry_index(MAXIMUM_ATTEMPTS)
+    world.css_fill('.wrapper-comp-setting .setting-input', max_attempts_set, index=index)
     world.verify_setting_entry(world.get_setting_entry(MAXIMUM_ATTEMPTS), MAXIMUM_ATTEMPTS, max_attempts_displayed, True)
     world.save_component_and_reopen(step)
     world.verify_setting_entry(world.get_setting_entry(MAXIMUM_ATTEMPTS), MAXIMUM_ATTEMPTS, max_attempts_persisted, True)
@@ -213,7 +220,8 @@ def verify_unset_display_name():
 
 
 def set_weight(weight):
-    world.get_setting_entry(PROBLEM_WEIGHT).find_by_css('.setting-input')[0].fill(weight)
+    index = world.get_setting_entry_index(PROBLEM_WEIGHT)
+    world.css_fill('.wrapper-comp-setting .setting-input', weight, index=index)
 
 
 def open_high_level_source():

--- a/cms/djangoapps/contentstore/features/problem-editor.py
+++ b/cms/djangoapps/contentstore/features/problem-editor.py
@@ -135,7 +135,7 @@ def set_the_weight_to_abc(step, bad_weight):
 
 @step('if I set the max attempts to "(.*)", it will persist as a valid integer$')
 def set_the_max_attempts(step, max_attempts_set):
-    #on firefox with selenium, the behaviour is different.  eg 2.34 displays as 2.34 and is persisted as 2
+    # on firefox with selenium, the behaviour is different.  eg 2.34 displays as 2.34 and is persisted as 2
     index = world.get_setting_entry_index(MAXIMUM_ATTEMPTS)
     world.css_fill('.wrapper-comp-setting .setting-input', max_attempts_set, index=index)
     if world.is_firefox():

--- a/cms/djangoapps/contentstore/features/problem-editor.py
+++ b/cms/djangoapps/contentstore/features/problem-editor.py
@@ -130,11 +130,7 @@ def set_the_weight_to_abc(step, bad_weight):
     world.verify_setting_entry(world.get_setting_entry(PROBLEM_WEIGHT), PROBLEM_WEIGHT, "", True)
     world.save_component_and_reopen(step)
     # But no change was actually ever sent to the model, so on reopen, explicitly_set is False
-    # On firefox with selenium, it will register as still being a change despite the weight remaining blank
-    if world.is_firefox():
-        world.verify_setting_entry(world.get_setting_entry(PROBLEM_WEIGHT), PROBLEM_WEIGHT, "", True)
-    else:
-        world.verify_setting_entry(world.get_setting_entry(PROBLEM_WEIGHT), PROBLEM_WEIGHT, "", False)
+    world.verify_setting_entry(world.get_setting_entry(PROBLEM_WEIGHT), PROBLEM_WEIGHT, "", False)
 
 
 @step('if I set the max attempts to "(.*)", it displays initially as "(.*)", and is persisted as "(.*)"')
@@ -228,7 +224,8 @@ def set_weight(weight):
     index = world.get_setting_entry_index(PROBLEM_WEIGHT)
     world.css_fill('.wrapper-comp-setting .setting-input', weight, index=index)
     if world.is_firefox():
-        world.trigger_event('.wrapper-comp-setting .setting-input', index=index)
+        world.trigger_event('.wrapper-comp-setting .setting-input', index=index, event='blur')
+        world.trigger_event('a.save-button', event='focus')
 
 
 def open_high_level_source():

--- a/cms/djangoapps/contentstore/features/problem-editor.py
+++ b/cms/djangoapps/contentstore/features/problem-editor.py
@@ -133,14 +133,16 @@ def set_the_weight_to_abc(step, bad_weight):
     world.verify_setting_entry(world.get_setting_entry(PROBLEM_WEIGHT), PROBLEM_WEIGHT, "", False)
 
 
-@step('if I set the max attempts to "(.*)", it displays initially as "(.*)", and is persisted as "(.*)"')
-def set_the_max_attempts(step, max_attempts_set, max_attempts_displayed, max_attempts_persisted):
+@step('if I set the max attempts to "(.*)", it will persist as a valid integer$')
+def set_the_max_attempts(step, max_attempts_set):
     #on firefox with selenium, the behaviour is different.  eg 2.34 displays as 2.34 and is persisted as 2
     index = world.get_setting_entry_index(MAXIMUM_ATTEMPTS)
     world.css_fill('.wrapper-comp-setting .setting-input', max_attempts_set, index=index)
-    world.verify_setting_entry(world.get_setting_entry(MAXIMUM_ATTEMPTS), MAXIMUM_ATTEMPTS, max_attempts_displayed, True)
+    if world.is_firefox():
+        world.trigger_event('.wrapper-comp-setting .setting-input', index=index)
     world.save_component_and_reopen(step)
-    world.verify_setting_entry(world.get_setting_entry(MAXIMUM_ATTEMPTS), MAXIMUM_ATTEMPTS, max_attempts_persisted, True)
+    value =  int(world.css_value('input.setting-input', index=index))
+    assert value >= 0
 
 
 @step('Edit High Level Source is not visible')

--- a/cms/djangoapps/contentstore/features/problem-editor.py
+++ b/cms/djangoapps/contentstore/features/problem-editor.py
@@ -130,6 +130,7 @@ def set_the_weight_to_abc(step, bad_weight):
     world.verify_setting_entry(world.get_setting_entry(PROBLEM_WEIGHT), PROBLEM_WEIGHT, "", True)
     world.save_component_and_reopen(step)
     # But no change was actually ever sent to the model, so on reopen, explicitly_set is False
+    # On firefox with selenium, it will register as still being a change despite the weight remaining blank
     if world.is_firefox():
         world.verify_setting_entry(world.get_setting_entry(PROBLEM_WEIGHT), PROBLEM_WEIGHT, "", True)
     else:
@@ -138,10 +139,11 @@ def set_the_weight_to_abc(step, bad_weight):
 
 @step('if I set the max attempts to "(.*)", it displays initially as "(.*)", and is persisted as "(.*)"')
 def set_the_max_attempts(step, max_attempts_set, max_attempts_displayed, max_attempts_persisted):
+    #on firefox with selenium, the behaviour is different.  eg 2.34 displays as 2.34 and is persisted as 2
+    if world.is_firefox():
+        return
     index = world.get_setting_entry_index(MAXIMUM_ATTEMPTS)
     world.css_fill('.wrapper-comp-setting .setting-input', max_attempts_set, index=index)
-    if world.is_firefox():
-        world.trigger_event('.wrapper-comp-setting .setting-input', index=index)
     world.verify_setting_entry(world.get_setting_entry(MAXIMUM_ATTEMPTS), MAXIMUM_ATTEMPTS, max_attempts_displayed, True)
     world.save_component_and_reopen(step)
     world.verify_setting_entry(world.get_setting_entry(MAXIMUM_ATTEMPTS), MAXIMUM_ATTEMPTS, max_attempts_persisted, True)

--- a/cms/djangoapps/contentstore/features/problem-editor.py
+++ b/cms/djangoapps/contentstore/features/problem-editor.py
@@ -47,7 +47,7 @@ def i_can_modify_the_display_name(step):
     # (to confirm that we don't throw an error because it is of the wrong type).
     index = world.get_setting_entry_index(DISPLAY_NAME)
     world.css_fill('.wrapper-comp-setting .setting-input', '3.4', index=index)
-    if world.browser.driver_name == 'Firefox':
+    if world.is_firefox():
         world.trigger_event('.wrapper-comp-setting .setting-input', index=index)
     verify_modified_display_name()
 
@@ -140,8 +140,6 @@ def set_the_weight_to_abc(step, bad_weight):
 @step('if I set the max attempts to "(.*)", it displays initially as "(.*)", and is persisted as "(.*)"')
 def set_the_max_attempts(step, max_attempts_set, max_attempts_displayed, max_attempts_persisted):
     #on firefox with selenium, the behaviour is different.  eg 2.34 displays as 2.34 and is persisted as 2
-    if world.is_firefox():
-        return
     index = world.get_setting_entry_index(MAXIMUM_ATTEMPTS)
     world.css_fill('.wrapper-comp-setting .setting-input', max_attempts_set, index=index)
     world.verify_setting_entry(world.get_setting_entry(MAXIMUM_ATTEMPTS), MAXIMUM_ATTEMPTS, max_attempts_displayed, True)

--- a/cms/djangoapps/contentstore/features/problem-editor.py
+++ b/cms/djangoapps/contentstore/features/problem-editor.py
@@ -62,7 +62,7 @@ def my_display_name_change_is_persisted_on_save(step):
 def i_can_modify_the_display_name_with_special_chars(step):
     index = world.get_setting_entry_index(DISPLAY_NAME)
     world.css_fill('.wrapper-comp-setting .setting-input', "updated ' \" &", index=index)
-    if world.browser.driver_name == 'Firefox':
+    if world.is_firefox():
         world.trigger_event('.wrapper-comp-setting .setting-input', index=index)
     verify_modified_display_name_with_special_chars()
 

--- a/cms/djangoapps/contentstore/features/section.feature
+++ b/cms/djangoapps/contentstore/features/section.feature
@@ -3,7 +3,6 @@ Feature: Create Section
   As a course author
   I want to create and edit sections
 
-  @skip
   Scenario: Add a new section to a course
     Given I have opened a new course in Studio
     When I click the New Section link

--- a/cms/djangoapps/contentstore/features/static-pages.py
+++ b/cms/djangoapps/contentstore/features/static-pages.py
@@ -8,7 +8,7 @@ from selenium.webdriver.common.keys import Keys
 @step(u'I go to the static pages page')
 def go_to_static(_step):
     menu_css = 'li.nav-course-courseware'
-    static_css = 'li.nav-course-courseware-pages'
+    static_css = 'li.nav-course-courseware-pages a'
     world.css_click(menu_css)
     world.css_click(static_css)
 
@@ -38,13 +38,15 @@ def click_edit_delete(_step, edit_delete, page):
 
 @step(u'I change the name to "([^"]*)"$')
 def change_name(_step, new_name):
-    settings_css = '#settings-mode'
+    settings_css = '#settings-mode a'
     world.css_click(settings_css)
     input_css = 'input.setting-input'
     name_input = world.css_find(input_css)
-    old_name = name_input.value
-    for count in range(len(old_name)):
-        name_input._element.send_keys(Keys.END, Keys.BACK_SPACE)
+    if world.is_mac():
+        name_input._element.send_keys(Keys.COMMAND + 'a')
+    else:
+        name_input._element.send_keys(Keys.CONTROL + 'a')
+    name_input._element.send_keys(Keys.DELETE)
     name_input._element.send_keys(new_name)
     save_button = 'a.save-button'
     world.css_click(save_button)

--- a/cms/djangoapps/contentstore/features/static-pages.py
+++ b/cms/djangoapps/contentstore/features/static-pages.py
@@ -41,13 +41,9 @@ def change_name(_step, new_name):
     settings_css = '#settings-mode a'
     world.css_click(settings_css)
     input_css = 'input.setting-input'
-    name_input = world.css_find(input_css)
-    if world.is_mac():
-        name_input._element.send_keys(Keys.COMMAND + 'a')
-    else:
-        name_input._element.send_keys(Keys.CONTROL + 'a')
-    name_input._element.send_keys(Keys.DELETE)
-    name_input._element.send_keys(new_name)
+    world.css_fill(input_css, new_name)
+    if world.is_firefox():
+        world.trigger_event(input_css)
     save_button = 'a.save-button'
     world.css_click(save_button)
 

--- a/cms/djangoapps/contentstore/features/textbooks.py
+++ b/cms/djangoapps/contentstore/features/textbooks.py
@@ -11,8 +11,8 @@ TEST_ROOT = settings.COMMON_TEST_DATA_ROOT
 @step(u'I go to the textbooks page')
 def go_to_uploads(_step):
     world.click_course_content()
-    menu_css = 'li.nav-course-courseware-textbooks'
-    world.css_find(menu_css).click()
+    menu_css = 'li.nav-course-courseware-textbooks a'
+    world.css_click(menu_css)
 
 
 @step(u'I should see a message telling me to create a new textbook')

--- a/cms/djangoapps/contentstore/features/textbooks.py
+++ b/cms/djangoapps/contentstore/features/textbooks.py
@@ -45,6 +45,8 @@ def click_new_textbook(_step, on):
 def name_textbook(_step, name):
     input_css = ".textbook input[name=textbook-name]"
     world.css_fill(input_css, name)
+    if world.is_firefox():
+        world.trigger_event(input_css)
 
 
 @step(u'I name the (first|second|third) chapter "([^"]*)"')
@@ -52,6 +54,8 @@ def name_chapter(_step, ordinal, name):
     index = ["first", "second", "third"].index(ordinal)
     input_css = ".textbook .chapter{i} input.chapter-name".format(i=index+1)
     world.css_fill(input_css, name)
+    if world.is_firefox():
+        world.trigger_event(input_css)
 
 
 @step(u'I type in "([^"]*)" for the (first|second|third) chapter asset')
@@ -59,6 +63,8 @@ def asset_chapter(_step, name, ordinal):
     index = ["first", "second", "third"].index(ordinal)
     input_css = ".textbook .chapter{i} input.chapter-asset-path".format(i=index+1)
     world.css_fill(input_css, name)
+    if world.is_firefox():
+        world.trigger_event(input_css)
 
 
 @step(u'I click the Upload Asset link for the (first|second|third) chapter')

--- a/cms/djangoapps/contentstore/features/upload.py
+++ b/cms/djangoapps/contentstore/features/upload.py
@@ -13,7 +13,7 @@ TEST_ROOT = settings.COMMON_TEST_DATA_ROOT
 @step(u'I go to the files and uploads page')
 def go_to_uploads(_step):
     menu_css = 'li.nav-course-courseware'
-    uploads_css = 'li.nav-course-courseware-uploads'
+    uploads_css = 'li.nav-course-courseware-uploads a'
     world.css_click(menu_css)
     world.css_click(uploads_css)
 

--- a/cms/djangoapps/contentstore/features/video.feature
+++ b/cms/djangoapps/contentstore/features/video.feature
@@ -23,6 +23,7 @@ Feature: Video Component
     And I have toggled captions
     Then when I view the video it does show the captions
 
+  #Video Alpha Features will work in Firefox only when Firefox is the active window
   Scenario: Autoplay is disabled in Studio for Video Alpha
     Given I have created a Video Alpha component
     Then when I view the videoalpha it does not have autoplay enabled

--- a/cms/djangoapps/contentstore/features/video.feature
+++ b/cms/djangoapps/contentstore/features/video.feature
@@ -23,7 +23,7 @@ Feature: Video Component
     And I have toggled captions
     Then when I view the video it does show the captions
 
-  #Video Alpha Features will work in Firefox only when Firefox is the active window
+  # Video Alpha Features will work in Firefox only when Firefox is the active window
   Scenario: Autoplay is disabled in Studio for Video Alpha
     Given I have created a Video Alpha component
     Then when I view the videoalpha it does not have autoplay enabled

--- a/cms/djangoapps/contentstore/features/video.py
+++ b/cms/djangoapps/contentstore/features/video.py
@@ -33,6 +33,7 @@ def hide_or_show_captions(step, shown):
         # click the button rather than the tooltip, so move the mouse
         # away to make it disappear.
         button = world.css_find(button_css)
+        # mouse_out is not implemented on firefox with selenium
         if not world.is_firefox:
             button.mouse_out()
         world.css_click(button_css)

--- a/cms/djangoapps/contentstore/features/video.py
+++ b/cms/djangoapps/contentstore/features/video.py
@@ -33,7 +33,8 @@ def hide_or_show_captions(step, shown):
         # click the button rather than the tooltip, so move the mouse
         # away to make it disappear.
         button = world.css_find(button_css)
-        button.mouse_out()
+        if world.browser.driver_name != 'Firefox':
+            button.mouse_out()
         world.css_click(button_css)
 
 @step('I edit the component')

--- a/cms/djangoapps/contentstore/features/video.py
+++ b/cms/djangoapps/contentstore/features/video.py
@@ -33,7 +33,7 @@ def hide_or_show_captions(step, shown):
         # click the button rather than the tooltip, so move the mouse
         # away to make it disappear.
         button = world.css_find(button_css)
-        if world.browser.driver_name != 'Firefox':
+        if not world.is_firefox:
             button.mouse_out()
         world.css_click(button_css)
 

--- a/common/djangoapps/terrain/ui_helpers.py
+++ b/common/djangoapps/terrain/ui_helpers.py
@@ -235,6 +235,13 @@ def click_tools():
 def is_mac():
     return platform.mac_ver()[0] is not ''
 
+@world.absorb
+def is_firefox():
+    return world.browser.driver_name is 'Firefox'
+
+@world.absorb
+def trigger_event(css_selector, event='change', index=0):
+    world.browser.execute_script("$('{}:eq({})').trigger('{}')".format(css_selector, index, event))
 
 @world.absorb
 def retry_on_exception(func, max_attempts=5):

--- a/common/djangoapps/terrain/ui_helpers.py
+++ b/common/djangoapps/terrain/ui_helpers.py
@@ -44,8 +44,8 @@ def is_css_not_present(css_selector, wait_time=5):
 
 
 @world.absorb
-def css_has_text(css_selector, text):
-    return world.css_text(css_selector) == text
+def css_has_text(css_selector, text, index=0, max_attempts=5):
+    return world.css_text(css_selector, index=index, max_attempts=max_attempts) == text
 
 
 @world.absorb

--- a/lms/djangoapps/courseware/features/high-level-tabs.py
+++ b/lms/djangoapps/courseware/features/high-level-tabs.py
@@ -8,4 +8,5 @@ def i_click_on_the_tab_and_check(step):
         tab_text = tab_title['TabName']
         title = tab_title['PageTitle']
         world.click_link(tab_text)
+        world.wait_for(lambda _driver:title in world.browser.title)
         assert(title in world.browser.title)

--- a/lms/djangoapps/courseware/features/login.feature
+++ b/lms/djangoapps/courseware/features/login.feature
@@ -11,6 +11,7 @@ Feature: Login in as a registered user
     And I submit my credentials on the login form
     Then I should see the login error message "This account has not been activated"
 
+    #CHROME ONLY, firefox will not redirect properly
     Scenario: Login to an activated account
     Given I am an edX user
     And I am an activated user

--- a/lms/djangoapps/courseware/features/login.feature
+++ b/lms/djangoapps/courseware/features/login.feature
@@ -11,7 +11,7 @@ Feature: Login in as a registered user
     And I submit my credentials on the login form
     Then I should see the login error message "This account has not been activated"
 
-    #CHROME ONLY, firefox will not redirect properly
+    # CHROME ONLY, firefox will not redirect properly
     Scenario: Login to an activated account
     Given I am an edX user
     And I am an activated user

--- a/lms/djangoapps/courseware/features/problems_setup.py
+++ b/lms/djangoapps/courseware/features/problems_setup.py
@@ -226,7 +226,6 @@ def answer_problem(problem_type, correctness):
 
         input_value = "8" if correctness == 'correct' else "5"
         choice = "choiceinput_0bc" if correctness == 'correct' else "choiceinput_1bc"
-        world.css_check(inputfield(problem_type, choice=choice))
         world.css_fill(
             inputfield(
                 problem_type,
@@ -234,6 +233,7 @@ def answer_problem(problem_type, correctness):
             ),
             input_value
         )
+        world.css_check(inputfield(problem_type, choice=choice))
 
 
 def problem_has_answer(problem_type, answer_class):

--- a/lms/djangoapps/courseware/features/signup.feature
+++ b/lms/djangoapps/courseware/features/signup.feature
@@ -3,6 +3,7 @@ Feature: Sign in
   As a new user
   I want to signup for a student account
 
+  #CHROME ONLY, firefox will not redirect properly
   Scenario: Sign up from the homepage
     Given I visit the homepage
     When I click the link with the text "Register Now"

--- a/lms/djangoapps/courseware/features/signup.feature
+++ b/lms/djangoapps/courseware/features/signup.feature
@@ -3,7 +3,7 @@ Feature: Sign in
   As a new user
   I want to signup for a student account
 
-  #CHROME ONLY, firefox will not redirect properly
+  # CHROME ONLY, firefox will not redirect properly
   Scenario: Sign up from the homepage
     Given I visit the homepage
     When I click the link with the text "Register Now"

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -81,7 +81,7 @@ nosexcover==1.0.7
 pep8==1.4.5
 pylint==0.28
 rednose==0.3
-selenium==2.33.0
+selenium==2.34.0
 splinter==0.5.4
 django_nose==1.1
 django-jasmine==0.3.2


### PR DESCRIPTION
Suggested reviewers: @wedaly @jzoldak 

Making a pull request so that this can be merged in and I can work on fixing the remaining tests separately and tests in firefox can begin (and start catching more bugs).  In order to run the acceptance tests in firefox, set LETTUCE_BROWSER = 'firefox' in acceptance.py or the browser_driver to 'firefox' in browser.py.

With these changes, only the following will not work in firefox and are marked:
- Checklist links could not be activated.  This is skipped in firefox for now
- There is a redirect issue in firefox that only occurs when running the whole suite.  This is not skipped yet due to the fact that it works individually and technically spans multiple steps.  This affects signup and login features on the lms side

The following things were added in order to get the acceptance tests to run on firefox:
- Links had to be clicked explicitly.  This involved changing the css selector and can be applied to chrome
- Notification bars could not be clicked through the webdriver so instead they are clicked through javascript on firefox
- A function called is_firefox() was added that will return if the browser_driver name is 'firefox' allowing for some specific solutions / skipping based on browser
- Firefox will not trigger certain events through the webdriver, thus the function trigger_event was added.  This will trigger a jquery event on the given selector.  By default, it triggers the 'change' event on index 0.  This was helpful in getting certain input fields to update properly.  This function should be avoided when possible.
- Code Mirror will now work on firefox, this was done by forcibly blurring the codemirror field
- Certain things could not be clicked or touched by firefox because they were underneath other elements.  On firefox, they are made visible through javascript
- Some small changes were made to the code so that less needed to be different between firefox and chrome.  

These tests were verified to still work with the latest version of chrome and chrome driver.  The version of firefox that was tested was 22.0 and 23.0.  The tests were run on both ubuntu and mac OS with the same results

One other major issue is that firefox will not fire certain events if firefox is not the active window.  As far as I know, this will only affect the LaTex scenario in problem-editor.feature, the testing automatic quoting in advanced-settings.feature and some of the video alpha tests.  Splinter will start the firefox browser as the active window.  However, this means that it needs to remain the active window making testing a pain due to not being able to run in the background.  Also, this will have implications on running multiple acceptance tests in parallel on firefox as only one of them can be in the foreground.

When this is ready to be merged, I would like to run this branch once in jenkins to verifiy that I did not introduce anything as this is a larger pull request.

AS OF LATE:
The only errors in the test suite for firefox are in the following features:
cms/checklists.feature - due to firefox not being able to make links active afftecting those two scenarios
lms/login.feature - due to firefox having a weird redirect issue only when the whole suite is run
lms/signup.feature - due to firefox having a weird redirect issue only when the whole suite is run
