### PR TITLE
Change console logging stream from stdout to stderr

### DIFF
--- a/common/lib/logsettings.py
+++ b/common/lib/logsettings.py
@@ -72,7 +72,7 @@ def get_logger_config(log_dir,
                 'level': console_loglevel,
                 'class': 'logging.StreamHandler',
                 'formatter': 'standard',
-                'stream': sys.stdout,
+                'stream': sys.stderr,
             },
             'syslogger-remote': {
                 'level': 'INFO',


### PR DESCRIPTION
Having the root logger send its output to stdout makes it hard to have django management commands that produce output that can be consumed by shell commands.

@cpennington @jzoldak @brianhw @jarv 

any unintented consequence of this change?
