### PR TITLE
changing http:// to // on intro video urls

### DIFF
--- a/cms/djangoapps/models/settings/course_details.py
+++ b/cms/djangoapps/models/settings/course_details.py
@@ -173,7 +173,7 @@ class CourseDetails(object):
         # the right thing
         result = None
         if video_key:
-            result = '<iframe width="560" height="315" src="http://www.youtube.com/embed/' + \
+            result = '<iframe width="560" height="315" src="//www.youtube.com/embed/' + \
                 video_key + '?autoplay=1&rel=0" frameborder="0" allowfullscreen=""></iframe>'
         return result
 

--- a/cms/static/js/models/settings/course_details.js
+++ b/cms/static/js/models/settings/course_details.js
@@ -75,7 +75,7 @@ CMS.Models.Settings.CourseDetails = Backbone.Model.extend({
         return this.videosourceSample();
     },
     videosourceSample : function() {
-        if (this.has('intro_video')) return "http://www.youtube.com/embed/" + this.get('intro_video');
+        if (this.has('intro_video')) return "//www.youtube.com/embed/" + this.get('intro_video');
         else return "";
     }
 });

--- a/lms/templates/index.html
+++ b/lms/templates/index.html
@@ -186,7 +186,7 @@
       else:
         youtube_video_id = "XNaiOGxWeto"
     %>
-    <iframe width="640" height="360" src="http://www.youtube.com/embed/${youtube_video_id}?showinfo=0" frameborder="0" allowfullscreen></iframe>
+    <iframe width="640" height="360" src="//www.youtube.com/embed/${youtube_video_id}?showinfo=0" frameborder="0" allowfullscreen></iframe>
   </div>
 </section>
 


### PR DESCRIPTION
Firefox 23 has started blocking mixed content (https://blog.mozilla.org/tanvi/2013/04/10/mixed-content-blocking-enabled-in-firefox-23/) so the urls should be changed to https. (or "//" as per @nedbat's comment)

Tested manually in firefox by changing http to https in inspector and it worked. I also tested to make sure that my changes work, but they do require db updates to make sure the videos have https in their records...

Laundry list of mentions: @ormsbee, @nedbat, @singingwolfboy
