### PR TITLE
Failing JavaScript tests in Firefox

### DIFF
--- a/cms/static/coffee/spec/views/metadata_edit_spec.coffee
+++ b/cms/static/coffee/spec/views/metadata_edit_spec.coffee
@@ -1,3 +1,11 @@
+verifyInputType = (input, expectedType) ->
+    # Some browsers (e.g. FireFox) do not support the "number"
+    # input type.  We can accept a "text" input instead
+    # and still get acceptable behavior in the UI.
+    if expectedType == 'number' and input.type != 'number'
+        expectedType = 'text'
+    expect(input.type).toBe(expectedType)
+
 describe "Test Metadata Editor", ->
     editorTemplate = readFixtures('metadata-editor.underscore')
     numberEntryTemplate = readFixtures('metadata-number-entry.underscore')
@@ -113,14 +121,7 @@ describe "Test Metadata Editor", ->
 
             verifyEntry = (index, display_name, type) ->
                 expect(childModels[index].get('display_name')).toBe(display_name)
-
-                # Some browsers (e.g. FireFox) do not support the "number"
-                # input type.  We can accept a "text" input instead
-                # and still get acceptable behavior in the UI.
-                if type == 'number' and childViews[index].type != 'number'
-                    type = 'text'
-
-                expect(childViews[index].type).toBe(type)
+                verifyInputType(childViews[index], type)
 
             verifyEntry(0, 'Display Name', 'text')
             verifyEntry(1, 'Inputs', 'number')
@@ -171,14 +172,7 @@ describe "Test Metadata Editor", ->
     assertInputType = (view, expectedType) ->
         input = view.$el.find('.setting-input')
         expect(input.length).toEqual(1)
-
-        # Some browsers (e.g. FireFox) do not support the "number"
-        # input type.  We can accept a "text" input instead
-        # and still get acceptable behavior in the UI.
-        if expectedType == 'number' and input[0].type != 'number'
-            expectedType = 'text'
-
-        expect(input[0].type).toEqual(expectedType)
+        verifyInputType(input[0], expectedType)
 
     assertValueInView = (view, expectedValue) ->
         expect(view.getValueFromEditor()).toEqual(expectedValue)

--- a/cms/static/coffee/spec/views/metadata_edit_spec.coffee
+++ b/cms/static/coffee/spec/views/metadata_edit_spec.coffee
@@ -113,6 +113,13 @@ describe "Test Metadata Editor", ->
 
             verifyEntry = (index, display_name, type) ->
                 expect(childModels[index].get('display_name')).toBe(display_name)
+
+                # Some browsers (e.g. FireFox) do not support the "number"
+                # input type.  We can accept a "text" input instead
+                # and still get acceptable behavior in the UI.
+                if type == 'number' and childViews[index].type != 'number'
+                    type = 'text'
+
                 expect(childViews[index].type).toBe(type)
 
             verifyEntry(0, 'Display Name', 'text')
@@ -164,6 +171,13 @@ describe "Test Metadata Editor", ->
     assertInputType = (view, expectedType) ->
         input = view.$el.find('.setting-input')
         expect(input.length).toEqual(1)
+
+        # Some browsers (e.g. FireFox) do not support the "number"
+        # input type.  We can accept a "text" input instead
+        # and still get acceptable behavior in the UI.
+        if expectedType == 'number' and input[0].type != 'number'
+            expectedType = 'text'
+
         expect(input[0].type).toEqual(expectedType)
 
     assertValueInView = (view, expectedValue) ->


### PR DESCRIPTION
Updated tests to weaken "number" input field requirement.  This is an HTML5 feature that isn't supported in FireFox, so FF changes the input type to "text".

This is basically how feature detection libraries like modernizr (http://modernizr.com/) do this: create an input element, set its type to "number" and see if it ends up being "text".  See: http://diveintohtml5.info/detect.html#input-types

Since we allow the input type to be "text" in the UI, I think it's okay to weaken the expectation in the JavaScript tests as well.

@jzoldak @cahrens What do you think about this approach?
