### PR TITLE
make template string unicode

### DIFF
--- a/lms/templates/courseware/welcome-back.html
+++ b/lms/templates/courseware/welcome-back.html
@@ -2,7 +2,7 @@
 <h2>${chapter_module.display_name_with_default}</h2>
 
 <p>${_("You were most recently in {section_link}.  If you\'re done with that, choose another section on the left.").format(
-	    section_link='<a href="{url}">{section_name}</a>'.format(
+	    section_link=u'<a href="{url}">{section_name}</a>'.format(
 	        url=prev_section_url,
 	        section_name=prev_section.display_name_with_default,
 	    )


### PR DESCRIPTION
because "prev_section.display_name_with_default" contained unicode, it broke the string formatting for section_link. I changed "section_link" to unicode, and now this is no longer an issue

@sarina 
@dianakhuang 

fixes https://edx-wiki.atlassian.net/browse/LMS-856
