### PR TITLE
Fix enroll-multiple button

### DIFF
--- a/lms/templates/courseware/instructor_dashboard.html
+++ b/lms/templates/courseware/instructor_dashboard.html
@@ -385,7 +385,7 @@ function goto( mode)
   <input type="checkbox" name="email_students"> ${_("Notify students by email")}
   <p>
   <input type="checkbox" name="auto_enroll"> ${_("Auto-enroll students when they activate")}
-  <input type="submit" name="action" value="$_("Enroll multiple students")}">
+  <input type="submit" name="action" value="${_("Enroll multiple students")}">
   <p>
   <input type="submit" name="action" value="${_("Unenroll multiple students")}">
 

--- a/lms/templates/module-error.html
+++ b/lms/templates/module-error.html
@@ -1,7 +1,7 @@
 <%! from django.utils.translation import ugettext as _ %>
 
 <section class="outside-app">
-  <h1>${_("There has been an error on the <em>{platform_name}</em> servers")}</h1>
+  <h1>${_("There has been an error on the <em>{platform_name}</em> servers").format(platform_name=settings.PLATFORM_NAME)}</h1>
   <p>${_("We're sorry, this module is temporarily unavailable. Our staff is working to fix it as soon as possible. Please email us at <a href=\"mailto:{tech_support_email}\">{tech_support_email}</a> to report any problems or downtime.").format(platform_name=settings.PLATFORM_NAME, tech_support_email=settings.TECH_SUPPORT_EMAIL)}</p>
 
 % if staff_access:


### PR DESCRIPTION
Fix i18n syntax so that "Enroll multiple students" displays properly.
Currently (on edx.org) it displays as a button with "$_(" on it and doesn't work because the post request uses the button string to trigger an action.

Also, this means that the buttons will NOT work if internalization actually occurs because it will send a translated string up to the server. As a worst case scenario, if there is any language which for example translates "Enroll multiple students" into "Unenroll multiple students" then that would be problematic.

@adampalay @jkarni 
