### PR TITLE
Enable beta dashboard, add copy

### DIFF
--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -2,6 +2,7 @@
 Instructor Dashboard Views
 """
 
+from django.utils.translation import ugettext as _
 from django_future.csrf import ensure_csrf_cookie
 from django.views.decorators.cache import cache_control
 from mitxmako.shortcuts import render_to_response
@@ -72,7 +73,7 @@ def _section_course_info(course_id):
 
     section_data = {}
     section_data['section_key'] = 'course_info'
-    section_data['section_display_name'] = 'Course Info'
+    section_data['section_display_name'] = _('Course Info')
     section_data['course_id'] = course_id
     section_data['course_display_name'] = course.display_name
     section_data['enrollment_count'] = CourseEnrollment.objects.filter(course_id=course_id).count()
@@ -87,7 +88,7 @@ def _section_course_info(course_id):
     # section_data['offline_grades'] = offline_grades_available(course_id)
 
     try:
-        section_data['course_errors'] = [(escape(a), '') for (a, _) in modulestore().get_item_errors(course.location)]
+        section_data['course_errors'] = [(escape(a), '') for (a, _unused) in modulestore().get_item_errors(course.location)]
     except Exception:
         section_data['course_errors'] = [('Error fetching errors', '')]
 
@@ -98,7 +99,7 @@ def _section_membership(course_id, access):
     """ Provide data for the corresponding dashboard section """
     section_data = {
         'section_key': 'membership',
-        'section_display_name': 'Membership',
+        'section_display_name': _('Membership'),
         'access': access,
         'enroll_button_url': reverse('students_update_enrollment', kwargs={'course_id': course_id}),
         'unenroll_button_url': reverse('students_update_enrollment', kwargs={'course_id': course_id}),
@@ -114,7 +115,7 @@ def _section_student_admin(course_id, access):
     """ Provide data for the corresponding dashboard section """
     section_data = {
         'section_key': 'student_admin',
-        'section_display_name': 'Student Admin',
+        'section_display_name': _('Student Admin'),
         'access': access,
         'get_student_progress_url_url': reverse('get_student_progress_url', kwargs={'course_id': course_id}),
         'enrollment_url': reverse('students_update_enrollment', kwargs={'course_id': course_id}),
@@ -129,7 +130,7 @@ def _section_data_download(course_id):
     """ Provide data for the corresponding dashboard section """
     section_data = {
         'section_key': 'data_download',
-        'section_display_name': 'Data Download',
+        'section_display_name': _('Data Download'),
         'get_grading_config_url': reverse('get_grading_config', kwargs={'course_id': course_id}),
         'get_students_features_url': reverse('get_students_features', kwargs={'course_id': course_id}),
     }
@@ -140,7 +141,7 @@ def _section_analytics(course_id):
     """ Provide data for the corresponding dashboard section """
     section_data = {
         'section_key': 'analytics',
-        'section_display_name': 'Analytics',
+        'section_display_name': _('Analytics'),
         'get_distribution_url': reverse('get_distribution', kwargs={'course_id': course_id}),
         'proxy_legacy_analytics_url': reverse('proxy_legacy_analytics', kwargs={'course_id': course_id}),
     }

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -145,7 +145,7 @@ MITX_FEATURES = {
     'ENABLE_INSTRUCTOR_BACKGROUND_TASKS': True,
 
     # Enable instructor dash beta version link
-    'ENABLE_INSTRUCTOR_BETA_DASHBOARD': False,
+    'ENABLE_INSTRUCTOR_BETA_DASHBOARD': True,
 
     # Allow use of the hint managment instructor view.
     'ENABLE_HINTER_INSTRUCTOR_VIEW': False,

--- a/lms/static/coffee/src/instructor_dashboard/membership.coffee
+++ b/lms/static/coffee/src/instructor_dashboard/membership.coffee
@@ -463,6 +463,8 @@ class Membership
         text: auth_list.$container.data 'display-name'
         data:
           auth_list: auth_list
+    if @auth_lists.length is 0
+      @$list_selector.hide()
 
     @$list_selector.change =>
       $opt = @$list_selector.children('option:selected')

--- a/lms/templates/instructor/instructor_dashboard_2/analytics.html
+++ b/lms/templates/instructor/instructor_dashboard_2/analytics.html
@@ -1,3 +1,4 @@
+<%! from django.utils.translation import ugettext as _ %>
 <%page args="section_data"/>
 
 <script type="text/template" id="profile-distribution-widget-template">
@@ -17,9 +18,9 @@
 <script type="text/template" id="grade-distributions-widget-template">
   <div class="grade-distributions-widget">
     <div class="header">
-      <h2 class="title"> Grade Distribution </h2>
-      Problem: <select class="problem-selector">
-        <option> Loading problem list... </option>
+      <h2 class="title"> ${_("Grade Distribution")} </h2>
+      ${_("Problem")}: <select class="problem-selector">
+        <option> ${_("Loading problem list...")} </option>
       </select>
       <div class="last-updated"></div>
     </div>
@@ -36,19 +37,19 @@
 ></div>
 
 <div class="profile-distribution-widget-container"
-  data-title="Year of Birth"
+  data-title="${_("Year of Birth")}"
   data-feature="year_of_birth"
   data-endpoint="${ section_data['get_distribution_url'] }"
 ></div>
 
 <div class="profile-distribution-widget-container"
-  data-title="Gender Distribution"
+  data-title="${_("Gender Distribution")}"
   data-feature="gender"
   data-endpoint="${ section_data['get_distribution_url'] }"
 ></div>
 
 <div class="profile-distribution-widget-container"
-  data-title="Level of Education"
+  data-title="${_("Level of Education")}"
   data-feature="level_of_education"
   data-endpoint="${ section_data['get_distribution_url'] }"
 ></div>

--- a/lms/templates/instructor/instructor_dashboard_2/course_info.html
+++ b/lms/templates/instructor/instructor_dashboard_2/course_info.html
@@ -1,34 +1,35 @@
+<%! from django.utils.translation import ugettext as _ %>
 <%page args="section_data"/>
 
 <h2>Course Information</h2>
 
 <div class="basic-data">
-  Course Name:
+  ${_("Course Name")}:
   ${ section_data['course_display_name'] }
 </div>
 
 <div class="basic-data">
-  Course ID:
+  ${_("Course ID")}:
   ${ section_data['course_id'] }
 </div>
 
 <div class="basic-data">
-  Students Enrolled:
+  ${_("Students Enrolled")}:
   ${ section_data['enrollment_count'] }
 </div>
 
 <div class="basic-data">
-  Started:
+  ${_("Started")}:
   ${ section_data['has_started'] }
 </div>
 
 <div class="basic-data">
-  Ended:
+  ${_("Ended")}:
   ${ section_data['has_ended'] }
 </div>
 
 <div class="basic-data">
-  Grade Cutoffs:
+  ${_("Grade Cutoffs")}:
   ${ section_data['grade_cutoffs'] }
 </div>
 
@@ -40,7 +41,7 @@
 %if len(section_data['course_errors']):
   <div class="course-errors-wrapper">
     <div class="toggle-wrapper">
-      <h2 class="title">Course Warnings:</h2>
+      <h2 class="title">${_("Course Warnings")}:</h2>
       <div class="triangle"></div>
     </div>
     <div class="course-errors-visibility-wrapper">

--- a/lms/templates/instructor/instructor_dashboard_2/data_download.html
+++ b/lms/templates/instructor/instructor_dashboard_2/data_download.html
@@ -1,6 +1,7 @@
+<%! from django.utils.translation import ugettext as _ %>
 <%page args="section_data"/>
 
-<input type="button" name="list-profiles" value="List enrolled students with profile information" data-endpoint="${ section_data['get_students_features_url'] }" >
+<input type="button" name="list-profiles" value="${_("List enrolled students with profile information")}" data-endpoint="${ section_data['get_students_features_url'] }" >
 <input type="button" name="list-profiles" value="CSV" data-csv="true" class="csv" data-endpoint="${ section_data['get_students_features_url'] }" >
 <br>
 ## <input type="button" name="list-grades" value="Student grades">
@@ -8,7 +9,7 @@
 ## <br>
 ## <input type="button" name="list-answer-distributions" value="Answer distributions (x students got y points)">
 ## <br>
-<input type="button" name="dump-gradeconf" value="Grading Configuration" data-endpoint="${ section_data['get_grading_config_url'] }">
+<input type="button" name="dump-gradeconf" value="${_("Grading Configuration")}" data-endpoint="${ section_data['get_grading_config_url'] }">
 
 <div class="data-display">
   <div class="data-display-text"></div>

--- a/lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html
+++ b/lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html
@@ -1,3 +1,4 @@
+<%! from django.utils.translation import ugettext as _ %>
 <%inherit file="/main.html" />
 <%! from django.core.urlresolvers import reverse %>
 <%namespace name='static' file='/static_content.html'/>
@@ -38,7 +39,7 @@
   ## when the javascript loads, it clicks on the first section
   <h2 class="instructor-nav">
     % for section_data in sections:
-      <a href="" data-section="${ section_data['section_key'] }">${ section_data['section_display_name'] }</a>
+      <a href="" data-section="${ section_data['section_key'] }">${_(section_data['section_display_name'])}</a>
     % endfor
   </h2>
 

--- a/lms/templates/instructor/instructor_dashboard_2/membership.html
+++ b/lms/templates/instructor/instructor_dashboard_2/membership.html
@@ -1,3 +1,4 @@
+<%! from django.utils.translation import ugettext as _ %>
 <%page args="section_data"/>
 
 <script type="text/template" id="member-list-widget-template">
@@ -27,18 +28,17 @@
 </script>
 
 <div class="vert-left batch-enrollment">
-  <h2>Batch Enrollment</h2>
-  <p>Enter student emails separated by new lines or commas.</p>
-  <textarea rows="6" cols="50" name="student-emails" placeholder="Student Emails" spellcheck="false"></textarea>
+  <h2> ${_("Batch Enrollment")} </h2>
+  <p> ${_("Enter student emails separated by new lines or commas.")} </p>
+  <textarea rows="6" cols="50" name="student-emails" placeholder="${_("Student Emails")}" spellcheck="false"></textarea>
   <br>
-  <input type="button" name="enroll" value="Enroll" data-endpoint="${ section_data['enroll_button_url'] }" >
-  <input type="button" name="unenroll" value="Unenroll" data-endpoint="${ section_data['unenroll_button_url'] }" >
-  <input type="checkbox" name="auto-enroll" value="Auto-Enroll" style="margin-top: 1em;">
-  <label for="auto-enroll">Auto Enroll</label>
+  <input type="button" name="enroll" value="${_("Enroll")}" data-endpoint="${ section_data['enroll_button_url'] }" >
+  <input type="button" name="unenroll" value="${_("Unenroll")}" data-endpoint="${ section_data['unenroll_button_url'] }" >
+  <input type="checkbox" name="auto-enroll" value="${_("Auto-Enroll")}" style="margin-top: 1em;">
+  <label for="auto-enroll">${_("Auto Enroll")}</label>
   <div class="auto-enroll-hint">
-    <p> If auto enroll is <span class="emph">checked</span>, students who have not yet registered for edX will be automatically enrolled.
-        If auto enroll is left <span class="emph">unchecked</span>, students who have not yet registered for edX will not be enrolled,
-        but will be allowed to enroll.
+    <p> ${_("If auto enroll is")} <span class="emph">${_("checked")}</span>${_(", students who have not yet registered for edX will be automatically enrolled.")}
+        ${_("If auto enroll is left")} <span class="emph">${_("unchecked")}</span>, ${_("students who have not yet registered for edX will not be enrolled, but will be allowed to enroll.")}
     </p>
   </div>
   <div class="request-response"></div>
@@ -46,92 +46,92 @@
 </div>
 
 <div class="vert-right member-lists-management">
-  <h2> Administration List Management </h2>
+  <h2> ${_("Administration List Management")} </h2>
 
   <select id="member-lists-selector">
-    <option> Getting available lists... </option>
+    <option> ${_("Getting available lists...")} </option>
   </select>
 
   <div class="request-response-error"></div>
 
   %if not section_data['access']['instructor']:
     <p>
-      Staff cannot modify staff or beta tester lists. To modify these lists,
-      contact your instructor and ask them to add you as an instructor for staff
-      and beta lists, or a forum admin for forum management.
+      ${_("Staff cannot modify staff or beta tester lists. To modify these lists, "
+      "contact your instructor and ask them to add you as an instructor for staff "
+      "and beta lists, or a forum admin for forum management.")}
     </p>
   %endif
 
   %if section_data['access']['instructor']:
     <div class="auth-list-container"
       data-rolename="staff"
-      data-display-name="Course Staff"
+      data-display-name="${_("Course Staff")}"
       data-info-text="
-        Course staff can help you manage limited aspects of your course. Staff
-        can enroll and unenroll students, as well as modify their grades and
-        see all course data. Course staff are not automatically given access
-        to Studio and will not be able to edit your course."
+        ${_("Course staff can help you manage limited aspects of your course. Staff "
+        "can enroll and unenroll students, as well as modify their grades and "
+        "see all course data. Course staff are not automatically given access "
+        "to Studio and will not be able to edit your course.")}"
       data-list-endpoint="${ section_data['list_course_role_members_url'] }"
       data-modify-endpoint="${ section_data['modify_access_url'] }"
-      data-add-button-label="Add Staff"
+      data-add-button-label="${_("Add Staff")}"
     ></div>
 
     <div class="auth-list-container"
       data-rolename="instructor"
-      data-display-name="Instructors"
+      data-display-name="${_("Instructors")}"
       data-info-text="
-        Instructors are the core administration of your course. Instructors can
-        add and remove course staff, as well as administer forum access."
+        ${_("Instructors are the core administration of your course. Instructors can "
+        "add and remove course staff, as well as administer forum access.")}"
       data-list-endpoint="${ section_data['list_course_role_members_url'] }"
       data-modify-endpoint="${ section_data['modify_access_url'] }"
-      data-add-button-label="Add Instructor"
+      data-add-button-label="${_("Add Instructor")}"
     ></div>
 
     <div class="auth-list-container"
       data-rolename="beta"
-      data-display-name="Beta Testers"
+      data-display-name="${_("Beta Testers")}"
       data-info-text="
-        Beta testers can see course content before the rest of the students.
-        They can make sure that the content works, but have no additional
-        privileges."
+        ${_("Beta testers can see course content before the rest of the students. "
+        "They can make sure that the content works, but have no additional "
+        "privileges.")}"
       data-list-endpoint="${ section_data['list_course_role_members_url'] }"
       data-modify-endpoint="${ section_data['modify_access_url'] }"
-      data-add-button-label="Add Beta Tester"
+      data-add-button-label="Add ${_("Beta Tester")}"
     ></div>
 
     <div class="auth-list-container"
       data-rolename="Administrator"
-      data-display-name="Forum Admins"
+      data-display-name="${_("Forum Admins")}"
       data-info-text="
-        Forum admins can moderate the course forums as well as administer
-        other forum roles."
+        ${_("Forum admins can moderate the course forums as well as administer "
+        "other forum roles.")}"
       data-list-endpoint="${ section_data['list_forum_members_url'] }"
       data-modify-endpoint="${ section_data['update_forum_role_membership_url'] }"
-      data-add-button-label="Add Forum Admin"
+      data-add-button-label="Add ${_("Forum Admin")}"
     ></div>
   %endif
 
   %if section_data['access']['instructor'] or section_data['access']['forum_admin']:
     <div class="auth-list-container"
       data-rolename="Moderator"
-      data-display-name="Forum Moderators"
+      data-display-name="${_("Forum Moderators")}"
       data-info-text="
-        Forum moderators can moderate the course forums. They cannot add other
-        moderators."
+        ${_("Forum moderators can moderate the course forums. They cannot add other "
+        "moderators.")}"
       data-list-endpoint="${ section_data['list_forum_members_url'] }"
       data-modify-endpoint="${ section_data['update_forum_role_membership_url'] }"
-      data-add-button-label="Add Moderator"
+      data-add-button-label="${_("Add Moderator")}"
     ></div>
 
     <div class="auth-list-container"
       data-rolename="Community TA"
-      data-display-name="Forum Community TAs"
+      data-display-name="${_("Forum Community TAs")}"
       data-info-text="
-        Community TA's are members of the community whom you deem particularly
-        helpful on the forums."
+        ${_("Community TA's are members of the community whom you deem particularly "
+        "helpful on the forums.")}"
       data-list-endpoint="${ section_data['list_forum_members_url'] }"
       data-modify-endpoint="${ section_data['update_forum_role_membership_url'] }"
-      data-add-button-label="Add Community TA"
+      data-add-button-label="Add ${_("Community TA")}"
     ></div>
   %endif
 

--- a/lms/templates/instructor/instructor_dashboard_2/membership.html
+++ b/lms/templates/instructor/instructor_dashboard_2/membership.html
@@ -37,8 +37,8 @@
   <input type="checkbox" name="auto-enroll" value="${_("Auto-Enroll")}" style="margin-top: 1em;">
   <label for="auto-enroll">${_("Auto Enroll")}</label>
   <div class="auto-enroll-hint">
-    <p> ${_("If auto enroll is")} <span class="emph">${_("checked")}</span>${_(", students who have not yet registered for edX will be automatically enrolled.")}
-        ${_("If auto enroll is left")} <span class="emph">${_("unchecked")}</span>, ${_("students who have not yet registered for edX will not be enrolled, but will be allowed to enroll.")}
+    <p> ${_("If auto enroll is <em>checked</em>, students who have not yet registered for edX will be automatically enrolled.")}
+        ${_("If auto enroll is left <em>unchecked</em>, students who have not yet registered for edX will not be enrolled, but will be allowed to enroll.")}
     </p>
   </div>
   <div class="request-response"></div>

--- a/lms/templates/instructor/instructor_dashboard_2/membership.html
+++ b/lms/templates/instructor/instructor_dashboard_2/membership.html
@@ -59,10 +59,10 @@
       data-rolename="staff"
       data-display-name="Course Staff"
       data-info-text="
-        Course staff can help you manage limited aspects of your course. Staff can
-        enroll and unenroll students, as well as modify their grades and see all
-        course data. Course staff are not given access to Studio will not be able to
-        edit your course."
+        Course staff can help you manage limited aspects of your course. Staff
+        can enroll and unenroll students, as well as modify their grades and
+        see all course data. Course staff are not automatically given access
+        to Studio and will not be able to edit your course."
       data-list-endpoint="${ section_data['list_course_role_members_url'] }"
       data-modify-endpoint="${ section_data['modify_access_url'] }"
       data-add-button-label="Add Staff"
@@ -74,8 +74,7 @@
         data-display-name="Instructors"
         data-info-text="
           Instructors are the core administration of your course. Instructors can
-          add and remove course staff, as well as administer forum access.
-          "
+          add and remove course staff, as well as administer forum access."
         data-list-endpoint="${ section_data['list_course_role_members_url'] }"
         data-modify-endpoint="${ section_data['modify_access_url'] }"
         data-add-button-label="Add Instructor"
@@ -88,7 +87,7 @@
       data-info-text="
         Beta testers can see course content before the rest of the students.
         They can make sure that the content works, but have no additional
-        privelages."
+        privileges."
       data-list-endpoint="${ section_data['list_course_role_members_url'] }"
       data-modify-endpoint="${ section_data['modify_access_url'] }"
       data-add-button-label="Add Beta Tester"
@@ -99,6 +98,9 @@
       <div class="auth-list-container"
         data-rolename="Administrator"
         data-display-name="Forum Admins"
+        data-info-text="
+          Forum admins can moderate the course forums as well as administer
+          other forum roles."
         data-list-endpoint="${ section_data['list_forum_members_url'] }"
         data-modify-endpoint="${ section_data['update_forum_role_membership_url'] }"
         data-add-button-label="Add Forum Admin"
@@ -109,6 +111,9 @@
     <div class="auth-list-container"
       data-rolename="Moderator"
       data-display-name="Forum Moderators"
+      data-info-text="
+        Forum moderators can moderate the course forums. They cannot add other
+        moderators."
       data-list-endpoint="${ section_data['list_forum_members_url'] }"
       data-modify-endpoint="${ section_data['update_forum_role_membership_url'] }"
       data-add-button-label="Add Moderator"
@@ -117,6 +122,9 @@
     <div class="auth-list-container"
       data-rolename="Community TA"
       data-display-name="Forum Community TAs"
+      data-info-text="
+        Community TA's are members of the community whom you deem particularly
+        helpful on the forums."
       data-list-endpoint="${ section_data['list_forum_members_url'] }"
       data-modify-endpoint="${ section_data['update_forum_role_membership_url'] }"
       data-add-button-label="Add Community TA"

--- a/lms/templates/instructor/instructor_dashboard_2/membership.html
+++ b/lms/templates/instructor/instructor_dashboard_2/membership.html
@@ -54,6 +54,14 @@
 
   <div class="request-response-error"></div>
 
+  %if not section_data['access']['instructor']:
+    <p>
+      Staff cannot modify staff or beta tester lists. To modify these lists,
+      contact your instructor and ask them to add you as an instructor for staff
+      and beta lists, or a forum admin for forum management.
+    </p>
+  %endif
+
   %if section_data['access']['instructor']:
     <div class="auth-list-container"
       data-rolename="staff"
@@ -68,18 +76,16 @@
       data-add-button-label="Add Staff"
     ></div>
 
-    %if section_data['access']['instructor']:
-      <div class="auth-list-container"
-        data-rolename="instructor"
-        data-display-name="Instructors"
-        data-info-text="
-          Instructors are the core administration of your course. Instructors can
-          add and remove course staff, as well as administer forum access."
-        data-list-endpoint="${ section_data['list_course_role_members_url'] }"
-        data-modify-endpoint="${ section_data['modify_access_url'] }"
-        data-add-button-label="Add Instructor"
-      ></div>
-    %endif
+    <div class="auth-list-container"
+      data-rolename="instructor"
+      data-display-name="Instructors"
+      data-info-text="
+        Instructors are the core administration of your course. Instructors can
+        add and remove course staff, as well as administer forum access."
+      data-list-endpoint="${ section_data['list_course_role_members_url'] }"
+      data-modify-endpoint="${ section_data['modify_access_url'] }"
+      data-add-button-label="Add Instructor"
+    ></div>
 
     <div class="auth-list-container"
       data-rolename="beta"
@@ -92,19 +98,17 @@
       data-modify-endpoint="${ section_data['modify_access_url'] }"
       data-add-button-label="Add Beta Tester"
     ></div>
-  %endif
 
-  %if section_data['access']['instructor']:
-      <div class="auth-list-container"
-        data-rolename="Administrator"
-        data-display-name="Forum Admins"
-        data-info-text="
-          Forum admins can moderate the course forums as well as administer
-          other forum roles."
-        data-list-endpoint="${ section_data['list_forum_members_url'] }"
-        data-modify-endpoint="${ section_data['update_forum_role_membership_url'] }"
-        data-add-button-label="Add Forum Admin"
-      ></div>
+    <div class="auth-list-container"
+      data-rolename="Administrator"
+      data-display-name="Forum Admins"
+      data-info-text="
+        Forum admins can moderate the course forums as well as administer
+        other forum roles."
+      data-list-endpoint="${ section_data['list_forum_members_url'] }"
+      data-modify-endpoint="${ section_data['update_forum_role_membership_url'] }"
+      data-add-button-label="Add Forum Admin"
+    ></div>
   %endif
 
   %if section_data['access']['instructor'] or section_data['access']['forum_admin']:

--- a/lms/templates/instructor/instructor_dashboard_2/student_admin.html
+++ b/lms/templates/instructor/instructor_dashboard_2/student_admin.html
@@ -22,11 +22,12 @@
   <p> Specify a particular problem in the course here by its url: </p>
   <input type="text" name="problem-select-single" placeholder="${_("Problem urlname")}">
   <p>
-    ${_('You may use just the "urlname" if a problem, or "modulename/urlname" if not. '
-    '(For example, if the location is <tt>i4x://university/course/problem/problemname</tt>, '
-    'then just provide the <tt>problemname</tt>. '
-    'If the location is <tt>i4x://university/course/notaproblem/someothername</tt>, then '
-    'provide <tt>notaproblem/someothername</tt>.)')}
+    ${_('You may use just the "urlname" if a problem, or "modulename/urlname" if not. (For example, if the location is {location1}, then just provide the {urlname1}. If the location is {location2}, then provide {urlname2}.)').format(
+    location1="<tt>i4x://university/course/problem/problemname</tt>",
+    urlname1="<tt>problemname</tt>",
+    location2="<tt>i4x://university/course/notaproblem/someothername</tt>",
+    urlname2="<tt>notaproblem/someothername</tt>")
+    }
   </p>
   <input type="button" name="reset-attempts-single" value="${_("Reset Student Attempts")}" data-endpoint="${ section_data['reset_student_attempts_url'] }">
 
@@ -61,11 +62,12 @@
       <input type="text" name="problem-select-all" size="60">
     </p>
     <p>
-      ${_('You may use just the "urlname" if a problem, or "modulename/urlname" if not. '
-      '(For example, if the location is <tt>i4x://university/course/problem/problemname</tt>, '
-      'then just provide the <tt>problemname</tt>. '
-      'If the location is <tt>i4x://university/course/notaproblem/someothername</tt>, then '
-      'provide <tt>notaproblem/someothername</tt>.)')}
+      ${_('You may use just the "urlname" if a problem, or "modulename/urlname" if not. (For example, if the location is {location1}, then just provide the {urlname1}. If the location is {location2}, then provide {urlname2}.)').format(
+      location1="<tt>i4x://university/course/problem/problemname</tt>",
+      urlname1="<tt>problemname</tt>",
+      location2="<tt>i4x://university/course/notaproblem/someothername</tt>",
+      urlname2="<tt>notaproblem/someothername</tt>")
+      }
     </p>
     <p>
       ${_("Then select an action")}:

--- a/lms/templates/instructor/instructor_dashboard_2/student_admin.html
+++ b/lms/templates/instructor/instructor_dashboard_2/student_admin.html
@@ -1,50 +1,51 @@
+<%! from django.utils.translation import ugettext as _ %>
 <%page args="section_data"/>
 
 <div class="student-specific-container action-type-container">
-  <H2>Student-specific grade adjustment</h2>
+  <H2>${_("Student-specific grade adjustment")}</h2>
   <div class="request-response-error"></div>
 
-  <input type="text" name="student-select" placeholder="Student Email">
+  <input type="text" name="student-select" placeholder="${_("Student Email")}">
   <br>
 
   <div class="progress-link-wrapper">
-    <a href="" class="progress-link" data-endpoint="${ section_data['get_student_progress_url_url'] }">Student Progress Page</a>
+    <a href="" class="progress-link" data-endpoint="${ section_data['get_student_progress_url_url'] }"> ${_("Student Progress Page")} </a>
   </div>
 
   <br>
-  <input type="button" name="enroll" value="Enroll" data-endpoint="${ section_data['enrollment_url'] }">
-  <input type="button" name="unenroll" value="Unenroll" data-endpoint="${ section_data['enrollment_url'] }">
+  <input type="button" name="enroll" value="${_("Enroll")}" data-endpoint="${ section_data['enrollment_url'] }">
+  <input type="button" name="unenroll" value="${_("Unenroll")}" data-endpoint="${ section_data['enrollment_url'] }">
   ## <select class="problems">
   ##   <option>Getting problems...</option>
   ## </select>
 
   <p> Specify a particular problem in the course here by its url: </p>
-  <input type="text" name="problem-select-single" placeholder="Problem urlname">
+  <input type="text" name="problem-select-single" placeholder="${_("Problem urlname")}">
   <p>
-    You may use just the "urlname" if a problem, or "modulename/urlname" if not.
-    (For example, if the location is <tt>i4x://university/course/problem/problemname</tt>,
-    then just provide the <tt>problemname</tt>.
-    If the location is <tt>i4x://university/course/notaproblem/someothername</tt>, then
-    provide <tt>notaproblem/someothername</tt>.)
+    ${_('You may use just the "urlname" if a problem, or "modulename/urlname" if not. '
+    '(For example, if the location is <tt>i4x://university/course/problem/problemname</tt>, '
+    'then just provide the <tt>problemname</tt>. '
+    'If the location is <tt>i4x://university/course/notaproblem/someothername</tt>, then '
+    'provide <tt>notaproblem/someothername</tt>.)')}
   </p>
-  <input type="button" name="reset-attempts-single" value="Reset Student Attempts" data-endpoint="${ section_data['reset_student_attempts_url'] }">
+  <input type="button" name="reset-attempts-single" value="${_("Reset Student Attempts")}" data-endpoint="${ section_data['reset_student_attempts_url'] }">
 
   %if section_data['access']['instructor']:
     <p> You may also delete the entire state of a student for the specified module: </p>
-    <input type="button" class="molly-guard" name="delete-state-single" value="Delete Student State for Module" data-endpoint="${ section_data['reset_student_attempts_url'] }">
+    <input type="button" class="molly-guard" name="delete-state-single" value="${_("Delete Student State for Module")}" data-endpoint="${ section_data['reset_student_attempts_url'] }">
   %endif
 
   %if settings.MITX_FEATURES.get('ENABLE_INSTRUCTOR_BACKGROUND_TASKS') and section_data['access']['instructor']:
-    <input type="button" name="rescore-problem-single" value="Rescore Student Submission" data-endpoint="${ section_data['rescore_problem_url'] }">
+    <input type="button" name="rescore-problem-single" value="${_("Rescore Student Submission")}" data-endpoint="${ section_data['rescore_problem_url'] }">
   %endif
 
   %if settings.MITX_FEATURES.get('ENABLE_INSTRUCTOR_BACKGROUND_TASKS') and section_data['access']['instructor']:
     <p>
-      Rescoring runs in the background, and status for active tasks will appear in a table below.
-      To see status for all tasks submitted for this course and student, click on this button:
+      ${_("Rescoring runs in the background, and status for active tasks will appear in a table below. "
+      "To see status for all tasks submitted for this problem and student, click on this button:")}
     </p>
 
-    <input type="button" name="task-history-single" value="Show Background Task History for Student" data-endpoint="${ section_data['list_instructor_tasks_url'] }">
+    <input type="button" name="task-history-single" value="${_("Show Background Task History for Student")}" data-endpoint="${ section_data['list_instructor_tasks_url'] }">
     <div class="task-history-single-table"></div>
   %endif
   <hr>
@@ -56,26 +57,27 @@
     <div class="request-response-error"></div>
 
     <p>
-      Specify a particular problem in the course here by its url:
+      ${_("Specify a particular problem in the course here by its url:")}
       <input type="text" name="problem-select-all" size="60">
     </p>
     <p>
-      You may use just the "urlname" if a problem, or "modulename/urlname" if not.
-      (For example, if the location is <tt>i4x://university/course/problem/problemname</tt>,
-      then just provide the <tt>problemname</tt>.
-      If the location is <tt>i4x://university/course/notaproblem/someothername</tt>, then
-      provide <tt>notaproblem/someothername</tt>.)
+      ${_('You may use just the "urlname" if a problem, or "modulename/urlname" if not. '
+      '(For example, if the location is <tt>i4x://university/course/problem/problemname</tt>, '
+      'then just provide the <tt>problemname</tt>. '
+      'If the location is <tt>i4x://university/course/notaproblem/someothername</tt>, then '
+      'provide <tt>notaproblem/someothername</tt>.)')}
     </p>
     <p>
-      Then select an action:
-      <input type="button" class="molly-guard" name="reset-attempts-all" value="Reset ALL students' attempts" data-endpoint="${ section_data['reset_student_attempts_url'] }">
-      <input type="button" class="molly-guard" name="rescore-problem-all" value="Rescore ALL students' problem submissions" data-endpoint="${ section_data['rescore_problem_url'] }">
+      ${_("Then select an action")}:
+      <input type="button" class="molly-guard" name="reset-attempts-all" value="${_("Reset ALL students' attempts")}" data-endpoint="${ section_data['reset_student_attempts_url'] }">
+      <input type="button" class="molly-guard" name="rescore-problem-all" value="${_("Rescore ALL students' problem submissions")}" data-endpoint="${ section_data['rescore_problem_url'] }">
     </p>
     <p>
-    <p>These actions run in the background, and status for active tasks will appear in a table below.
-       To see status for all tasks submitted for this problem, click on this button:
+    <p>
+      ${_("These actions run in the background, and status for active tasks will appear in a table below. "
+      "To see status for all tasks submitted for this problem, click on this button")}:
     </p>
-      <input type="button" name="task-history-all" value="Show Background Task History for Problem" data-endpoint="${ section_data['list_instructor_tasks_url'] }">
+      <input type="button" name="task-history-all" value="${_("Show Background Task History for Problem")}" data-endpoint="${ section_data['list_instructor_tasks_url'] }">
       <div class="task-history-all-table"></div>
     </p>
   </div>
@@ -83,7 +85,7 @@
 
   <div class="running-tasks-container action-type-container">
     <hr>
-    <h2> Pending Instructor Tasks </h2>
+    <h2> ${_("Pending Instructor Tasks")} </h2>
     <div class="running-tasks-table" data-endpoint="${ section_data['list_instructor_tasks_url'] }"></div>
   </div>
 %endif


### PR DESCRIPTION
Enable beta dashboard. The existing dashboard remains the default, but a link in the top right that say "Try New Beta Dashboard" points to the new dashboard.

Add some copy for list descriptions. Hide the drop-down for list management when the user has no rights, and offer an instructional message.

@jkarni 
@rocha 
