### PR TITLE
Fix error when there is an invalid YouTube property in a video module

### DIFF
--- a/common/lib/xmodule/xmodule/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module.py
@@ -287,19 +287,17 @@ class VideoDescriptor(VideoFields, TabsEditingDescriptor, EmptyDataRawDescriptor
         XML-based courses.
         """
         ret = {'0.75': '', '1.00': '', '1.25': '', '1.50': ''}
-        if data == '':
-            return ret
+
         videos = data.split(',')
         for video in videos:
             pieces = video.split(':')
-            # HACK
-            # To elaborate somewhat: in many LMS tests, the keys for
-            # Youtube IDs are inconsistent. Sometimes a particular
-            # speed isn't present, and formatting is also inconsistent
-            # ('1.0' versus '1.00'). So it's necessary to either do
-            # something like this or update all the tests to work
-            # properly.
-            ret['%.2f' % float(pieces[0])] = pieces[1]
+            try:
+                speed = '%.2f' % float(pieces[0])  # normalize speed
+                youtube_id = pieces[1]
+                ret[speed] = youtube_id
+            except (ValueError, IndexError):
+                log.warning('Invalid YouTube ID: %s' % video)
+
         return ret
 
     @staticmethod


### PR DESCRIPTION
Courses with invalid YouTube ID were crashing on load. Instead log an warning and continue.

@peter-fogg @dianakhuang please review
