### PR TITLE
vagrant: Add flag to ensure install is completed at least once

### DIFF
--- a/scripts/vagrant-provisioning.sh
+++ b/scripts/vagrant-provisioning.sh
@@ -106,6 +106,9 @@ on_create()
     # Permissions
     chown vagrant.vagrant ~vagrant/.bash_profile
 
+    # Install completed entirely & successfully - set flag to skip in future runs
+    touch /opt/edx/.install_succeeded
+
     cat << EOF
 ==============================================================================
 Success - Created your development environment!
@@ -114,9 +117,8 @@ Success - Created your development environment!
 EOF
 }    # End on_create() ########################################################
 
-## only initialize / setup the development environment once:
-#   we create node_modules, so that's a good test:
-[[ -d /opt/edx/node_modules ]] || on_create
+## only initialize / setup the development environment once: 
+[[ -f /opt/edx/.install_succeeded ]] || on_create
 
 # grab what the Vagrantfile spec'd our IP to be:
 #  expecting:


### PR DESCRIPTION
The provisioning script used to check for the existence of the `/opt/edx/node_modules` folder to decide if the installation has already been completed. However, since additional instructions were executed by the installer afterwards, any installation error (eg. download timeouts on low quality connections) happening between the creation of that folder and the end of the installation wouldn't be recovered from on the next vagrant instance boot.
