### PR TITLE
Make CMS user view not show ErrorDescriptor courses

### DIFF
--- a/cms/djangoapps/contentstore/views/user.py
+++ b/cms/djangoapps/contentstore/views/user.py
@@ -13,6 +13,7 @@ from django.core.context_processors import csrf
 
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore import Location
+from xmodule.error_module import ErrorDescriptor
 from contentstore.utils import get_lms_link_for_item
 from util.json_request import JsonResponse
 from auth.authz import (
@@ -62,7 +63,7 @@ def index(request):
         )
 
     return render_to_response('index.html', {
-        'courses': [format_course_for_view(c) for c in courses],
+        'courses': [format_course_for_view(c) for c in courses if not isinstance(c, ErrorDescriptor)],
         'user': request.user,
         'request_course_creator_url': reverse('request_course_creator'),
         'course_creator_status': _get_course_creator_status(request.user),


### PR DESCRIPTION
If a bad course gets into the mongodb, then it crashes the CMS user view showing the list of courses.

This PR fixes this by suppressing courses which are ErrorDescriptor instances.

Someday in the future, it may be desirable to make ErrorDescriptor instances show up with red flags to staff.
