### PR TITLE
Coffee compile command now executes for just *.coffee items.

### DIFF
--- a/rakelib/assets.rake
+++ b/rakelib/assets.rake
@@ -30,7 +30,11 @@ def coffee_cmd(watch=false, debug=false)
 
         end
     end
-    "node_modules/.bin/coffee --compile #{watch ? '--watch' : ''} ."
+    if watch
+        "node_modules/.bin/coffee --compile --watch . "
+    else
+        "node_modules/.bin/coffee --compile `find . -name *.coffee` "
+    end
 end
 
 def sass_cmd(watch=false, debug=false)


### PR DESCRIPTION
This resolves an error that would sometimes occur on Mac OS X:

```
node_modules/.bin/coffee --compile  .

/Users/will/edx_all/edx-platform/node_modules/coffee-script/lib/coffee-script/command.js:486
    cwd = process.cwd();
                  ^
Error: EMFILE, too many open files
    at compileOptions (/Users/will/edx_all/edx-platform/node_modules/coffee-script/lib/coffee-script/command.js:486:23)
    at compileScript (/Users/will/edx_all/edx-platform/node_modules/coffee-script/lib/coffee-script/command.js:158:15)
    at fs.stat.notSources.(anonymous function) (/Users/will/edx_all/edx-platform/node_modules/coffee-script/lib/coffee-script/command.js:143:18)
    at fs.readFile (fs.js:176:14)
    at Object.oncomplete (fs.js:297:15)
```

I think this is because the node script has a bug in which it opens all the files it wants to compile, but doesn't close the file handles until it finishes executing (see node_modules/coffee-script/lib/coffee-script/command.js line 136).

@cpennington does this seem like a reasonable fix?
