### PR TITLE
instructor dash fixes

### DIFF
--- a/lms/templates/courseware/instructor_dashboard.html
+++ b/lms/templates/courseware/instructor_dashboard.html
@@ -145,22 +145,22 @@ function goto( mode)
     </p>
 
     <p>
-    <input type="submit" name="action" value="${_("Dump list of enrolled students")}">
+    <input type="submit" name="action" value="Dump list of enrolled students">
     </p>
 
     <p>
-    <input type="submit" name="action" value="${_("Dump Grades for all students in this course")}">
-    <input type="submit" name="action" value="${_("Download CSV of all student grades for this course")}">
+    <input type="submit" name="action" value="Dump Grades for all students in this course">
+    <input type="submit" name="action" value="Download CSV of all student grades for this course">
     </p>
 
     <p>
-    <input type="submit" name="action" value="${_("Dump all RAW grades for all students in this course")}">
-    <input type="submit" name="action" value="${_("Download CSV of all RAW grades")}">
+    <input type="submit" name="action" value="Dump all RAW grades for all students in this course">
+    <input type="submit" name="action" value="Download CSV of all RAW grades">
     </p>
 
     <p>
-    <input type="submit" name="action" value="${_("Download CSV of answer distributions")}">
-    <input type="submit" name="action" value="${_("Dump description of graded assignments configuration")}">
+    <input type="submit" name="action" value="Download CSV of answer distributions">
+    <input type="submit" name="action" value="Dump description of graded assignments configuration">
     </p>
     <hr width="40%" style="align:left">
 
@@ -177,21 +177,21 @@ function goto( mode)
     <li>${_("Gradebook name:")} <font color="green">${rg.get('name','None defined!')}</font>
     <br/>
     <br/>
-    <input type="submit" name="action" value="${_("List assignments available in remote gradebook")}">
-    <input type="submit" name="action" value="${_("List enrolled students matching remote gradebook")}">
+    <input type="submit" name="action" value="List assignments available in remote gradebook">
+    <input type="submit" name="action" value="List enrolled students matching remote gradebook">
     <br/>
     <br/>
     </li>
-    <li><input type="submit" name="action" value="${_("List assignments available for this course")}">
+    <li><input type="submit" name="action" value="List assignments available for this course">
     <br/>
     <br/>
     </li>
     <li>${_("Assignment name:")} <input type="text" name="assignment_name" size=40 >
     <br/>
     <br/>
-    <input type="submit" name="action" value="${_("Display grades for assignment")}">
-    <input type="submit" name="action" value="${_("Export grades for assignment to remote gradebook")}">
-    <input type="submit" name="action" value="${_("Export CSV file of grades for assignment")}">
+    <input type="submit" name="action" value="Display grades for assignment">
+    <input type="submit" name="action" value="Export grades for assignment to remote gradebook">
+    <input type="submit" name="action" value="Export CSV file of grades for assignment">
     </li>
     </ul>
     <hr width="40%" style="align:left">
@@ -213,14 +213,14 @@ function goto( mode)
     </p>
     <p>
       ${_("Then select an action:")}
-      <input type="submit" name="action" value="${_("Reset ALL students' attempts")}">
-      <input type="submit" name="action" value="${_("Rescore ALL students' problem submissions")}">
+      <input type="submit" name="action" value="Reset ALL students' attempts">
+      <input type="submit" name="action" value="Rescore ALL students' problem submissions">
     </p>
     <p>
     <p>${_("These actions run in the background, and status for active tasks will appear in a table below. To see status for all tasks submitted for this problem, click on this button:")}
     </p>
     <p>
-      <input type="submit" name="action" value="${_("Show Background Task History")}">
+      <input type="submit" name="action" value="Show Background Task History">
     </p>
 
     <hr width="40%" style="align:left">
@@ -233,7 +233,7 @@ function goto( mode)
     </p>
     <p>
       ${_("Click this, and a link to student's progress page will appear below:")}
-      <input type="submit" name="action" value="${_("Get link to student's progress page")}">
+      <input type="submit" name="action" value="Get link to student's progress page">
     </p>
     <p>
       ${_("Specify a particular problem in the course here by its url:")}
@@ -248,16 +248,16 @@ function goto( mode)
     </p>
     <p>
       ${_("Then select an action:")}
-      <input type="submit" name="action" value="${_("Reset student's attempts")}">
+      <input type="submit" name="action" value="Reset student's attempts">
       %if settings.MITX_FEATURES.get('ENABLE_INSTRUCTOR_BACKGROUND_TASKS'):
-      <input type="submit" name="action" value="${_("Rescore student's problem submission")}">
+      <input type="submit" name="action" value="Rescore student's problem submission">
       %endif
     </p>
 
     %if instructor_access:
     <p>
       ${_("You may also delete the entire state of a student for the specified module:")}
-      <input type="submit" name="action" value="${_("Delete student state for module")}">
+      <input type="submit" name="action" value="Delete student state for module">
     </p>
     %endif
     %if settings.MITX_FEATURES.get('ENABLE_INSTRUCTOR_BACKGROUND_TASKS'):
@@ -265,7 +265,7 @@ function goto( mode)
            "To see status for all tasks submitted for this problem and student, click on this button:")}
     </p>
     <p>
-      <input type="submit" name="action" value="${_("Show Background Task History for Student")}">
+      <input type="submit" name="action" value="Show Background Task History for Student">
     </p>
     %endif
 
@@ -285,7 +285,7 @@ function goto( mode)
     </select>
     </p>
     <p>
-    <input type="submit" name="action" value="${_("Generate Histogram and IRT Plot")}">
+    <input type="submit" name="action" value="Generate Histogram and IRT Plot">
     </p>
 
     <p></p>
@@ -298,28 +298,28 @@ function goto( mode)
   %if instructor_access:
     <hr width="40%" style="align:left">
     <p>
-    <input type="submit" name="action" value="${_("List course staff members")}">
+    <input type="submit" name="action" value="List course staff members">
     <p>
     <input type="text" name="staffuser">
-    <input type="submit" name="action" value="${_("Remove course staff")}">
-    <input type="submit" name="action" value="${_("Add course staff")}">
+    <input type="submit" name="action" value="Remove course staff">
+    <input type="submit" name="action" value="Add course staff">
     <hr width="40%" style="align:left">
   %endif
 
   %if admin_access:
     <hr width="40%" style="align:left">
     <p>
-    <input type="submit" name="action" value="${_("List course instructors")}">
+    <input type="submit" name="action" value="List course instructors">
     <p>
-    <input type="text" name="instructor"> <input type="submit" name="action" value="${_("Remove instructor")}">
-    <input type="submit" name="action" value="${_("Add instructor")}">
+    <input type="text" name="instructor"> <input type="submit" name="action" value="Remove instructor">
+    <input type="submit" name="action" value="Add instructor">
     <hr width="40%" style="align:left">
   %endif
 
   %if settings.MITX_FEATURES['ENABLE_MANUAL_GIT_RELOAD'] and admin_access:
     <p>
-    <input type="submit" name="action" value="${_("Reload course from XML files")}">
-    <input type="submit" name="action" value="${_("GIT pull and Reload course")}">
+    <input type="submit" name="action" value="Reload course from XML files">
+    <input type="submit" name="action" value="GIT pull and Reload course">
   %endif
 %endif
 
@@ -328,23 +328,23 @@ function goto( mode)
   %if instructor_access:
     <hr width="40%" style="align:left">
     <p>
-    <input type="submit" name="action" value="${_("List course forum admins")}">
+    <input type="submit" name="action" value="List course forum admins">
     <p>
-    <input type="text" name="forumadmin"> <input type="submit" name="action" value="${_("Remove forum admin")}">
-    <input type="submit" name="action" value="${_("Add forum admin")}">
+    <input type="text" name="forumadmin"> <input type="submit" name="action" value="Remove forum admin">
+    <input type="submit" name="action" value="Add forum admin">
     <hr width="40%" style="align:left">
   %endif
 
   %if instructor_access or forum_admin_access:
     <p>
-    <input type="submit" name="action" value="${_("List course forum moderators")}">
-    <input type="submit" name="action" value="${_("List course forum community TAs")}">
+    <input type="submit" name="action" value="List course forum moderators">
+    <input type="submit" name="action" value="List course forum community TAs">
     <p>
     <input type="text" name="forummoderator">
-    <input type="submit" name="action" value="${_("Remove forum moderator")}">
-    <input type="submit" name="action" value="${_("Add forum moderator")}">
-    <input type="submit" name="action" value="${_("Remove forum community TA")}">
-    <input type="submit" name="action" value="${_("Add forum community TA")}">
+    <input type="submit" name="action" value="Remove forum moderator">
+    <input type="submit" name="action" value="Add forum moderator">
+    <input type="submit" name="action" value="Remove forum community TA">
+    <input type="submit" name="action" value="Add forum community TA">
     <hr width="40%" style="align:left">
   %else:
   <p>${_("User requires forum administrator privileges to perform administration tasks.  See instructor.")}</p>
@@ -356,8 +356,8 @@ function goto( mode)
 
     <hr width="40%" style="align:left">
     <p>
-    <input type="submit" name="action" value="${_("List enrolled students")}">
-    <input type="submit" name="action" value="${_("List students who may enroll but may not have yet signed up")}">
+    <input type="submit" name="action" value="List enrolled students">
+    <input type="submit" name="action" value="List students who may enroll but may not have yet signed up">
     <hr width="40%" style="align:left">
 
   %if settings.MITX_FEATURES.get('REMOTE_GRADEBOOK_URL','') and instructor_access:
@@ -371,10 +371,10 @@ function goto( mode)
     <li>${_("Gradebook name:")} <font color="green">${rg.get('name','None defined!')}</font>
     <li>${_("Section:")} <input type="text" name="gradebook_section" size=40 value="${rg.get('section','')}"></li>
     </ul>
-    <input type="submit" name="action" value="${_("List sections available in remote gradebook")}">
-    <input type="submit" name="action" value="${_("List students in section in remote gradebook")}">
-    <input type="submit" name="action" value="${_("Overload enrollment list using remote gradebook")}">
-    <input type="submit" name="action" value="${_("Merge enrollment list with remote gradebook")}">
+    <input type="submit" name="action" value="List sections available in remote gradebook">
+    <input type="submit" name="action" value="List students in section in remote gradebook">
+    <input type="submit" name="action" value="Overload enrollment list using remote gradebook">
+    <input type="submit" name="action" value="Merge enrollment list with remote gradebook">
     <hr width="40%" style="align:left">
 
   %endif
@@ -385,9 +385,9 @@ function goto( mode)
   <input type="checkbox" name="email_students"> ${_("Notify students by email")}
   <p>
   <input type="checkbox" name="auto_enroll"> ${_("Auto-enroll students when they activate")}
-  <input type="submit" name="action" value="${_("Enroll multiple students")}">
+  <input type="submit" name="action" value="Enroll multiple students">
   <p>
-  <input type="submit" name="action" value="${_("Unenroll multiple students")}">
+  <input type="submit" name="action" value="Unenroll multiple students">
 
 %endif
 
@@ -396,11 +396,11 @@ function goto( mode)
 %if modeflag.get('Data'):
     <hr width="40%" style="align:left">
     <p>
-    <input type="submit" name="action" value="${_("Download CSV of all student profile data")}">
+    <input type="submit" name="action" value="Download CSV of all student profile data">
     </p>
     <p> ${_("Problem urlname:")}
         <input type="text" name="problem_to_dump" size="40">
-        <input type="submit" name="action" value="${_("Download CSV of all responses to problem")}">
+        <input type="submit" name="action" value="Download CSV of all responses to problem">
     </p>
     <hr width="40%" style="align:left">
 %endif
@@ -411,7 +411,7 @@ function goto( mode)
   %if instructor_access:
     <hr width="40%" style="align:left">
     <p>
-    <input type="submit" name="action" value="${_("List beta testers")}">
+    <input type="submit" name="action" value="List beta testers">
     <p>
     ## Translators: days_early_for_beta should not be translated
     ${_("Enter usernames or emails for students who should be beta-testers, one per line, or separated by commas.  They will get to "
@@ -419,8 +419,8 @@ function goto( mode)
     </p>
     <p>
     <textarea cols="50" row="30" name="betausers"></textarea>
-    <input type="submit" name="action" value="${_("Remove beta testers")}">
-    <input type="submit" name="action" value="${_("Add beta testers")}">
+    <input type="submit" name="action" value="Remove beta testers">
+    <input type="submit" name="action" value="Add beta testers">
     </p>
     <hr width="40%" style="align:left">
 


### PR DESCRIPTION
Because the legacy instructor dash code has lines in it like "elif 'List course staff' in action", running ugettext on the input buttons' values in the dashboard template can cause buttons to break, such as the enroll students button. Since we're going to be renovating the instructor dash, we should revert i18n on the legacy template to ensure against such breakages.

@mlsteele 
@sarina 
