### PR TITLE
Fix/adam/i18n templates

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -25,7 +25,7 @@ Longer TODO:
 
 import sys
 import lms.envs.common
-from lms.envs.common import USE_TZ, TECH_SUPPORT_EMAIL
+from lms.envs.common import USE_TZ, TECH_SUPPORT_EMAIL, PLATFORM_NAME, BUGS_EMAIL
 from path import path
 
 ############################ FEATURE CONFIGURATION #############################

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1037,7 +1037,11 @@ def password_reset(request):
                                         'error': _('Invalid e-mail or user')}))
 
 
-def password_reset_confirm_wrapper(request, uidb36=None, token=None):
+def password_reset_confirm_wrapper(
+    request,
+    uidb36=None,
+    token=None,
+):
     ''' A wrapper around django.contrib.auth.views.password_reset_confirm.
         Needed because we want to set the user as active at this step.
     '''
@@ -1049,7 +1053,12 @@ def password_reset_confirm_wrapper(request, uidb36=None, token=None):
         user.save()
     except (ValueError, User.DoesNotExist):
         pass
-    return password_reset_confirm(request, uidb36=uidb36, token=token)
+    # we also want to pass settings.PLATFORM_NAME in as extra_context
+
+    extra_context = {"platform_name": settings.PLATFORM_NAME}
+    return password_reset_confirm(
+        request, uidb36=uidb36, token=token, extra_context=extra_context
+    )
 
 
 def reactivation_email_for_user(user):

--- a/lms/templates/registration/password_reset_complete.html
+++ b/lms/templates/registration/password_reset_complete.html
@@ -1,4 +1,3 @@
-<%! from django.utils.translation import ugettext as _ %>
 {% load i18n %}
 {% load compressed %}
 {% load staticfiles %}
@@ -6,7 +5,7 @@
 <html>
 <head>
 
-  <title>${_("Your Password Reset is Complete")}</title>
+  <title>{% trans "Your Password Reset is Complete" %}</title>
 
   {% compressed_css 'application' %}
 
@@ -54,13 +53,15 @@
   <section class="passwordreset container">
     <section class="introduction">
       <header>
-        <h1>${_("Your Password Reset is Complete")}</h1>
+        <h1>{% trans "Your Password Reset is Complete" %}</h1>
       </header>
     </section>
 
     {% block content %}
     <section role="main" class="content">
-      <p>${_('Your password has been set.  You may go ahead and {link_start}log in{link_end} now.').format(link_start='<a href="/login">', link_end='</a>')}</p>
+      {% blocktrans with link_start='<a href="/login">' link_end='</a>' %}
+      Your password has been set.  You may go ahead and {{ link_start }}log in{{ link_end }} now.
+      {% endblocktrans %}
     </section>
     {% endblock %}
   </section>

--- a/lms/templates/registration/password_reset_confirm.html
+++ b/lms/templates/registration/password_reset_confirm.html
@@ -1,11 +1,11 @@
-<%! from django.utils.translation import ugettext as _ %>
+{% load i18n %}
 {% load compressed %}
 {% load staticfiles %}
 <!DOCTYPE html>
 <html>
 <head>
 
-  <title>${_("Reset Your {platform_name} Password").format(platform_name=settings.PLATFORM_NAME)}</title>
+<title>{% trans "Reset Your edX Password" %}</title>
 
   {% compressed_css 'application' %}
 
@@ -53,78 +53,77 @@
   <section class="passwordreset container">
     <section class="introduction">
       <header>
-        <h1>${_("Reset Your {platform_name} Password").format(platform_name=settings.PLATFORM_NAME)}</h1>
+        <h1>{% trans "Reset Your edX Password" %}</h1>
       </header>
     </section>
 
     <section role="main" class="content">
       {% if validlink %}
       <header>
-      <h2 class="sr">${_("Password Reset Form")}</h2>
+      <h2 class="sr">{% trans "Password Reset Form" %}</h2>
       </header>
 
       <form role="form" id="passwordreset-form" method="post" data-remote="true" action="">{% csrf_token %}
         <!-- status messages -->
         <div role="alert" class="status message">
-          <h3 class="message-title">${_("We're sorry, {platform_name} enrollment is not available in your region").format(platform_name=settings.PLATFORM_NAME)}</h3>
+          <h3 class="message-title">{% trans "We're sorry, edX enrollment is not available in your region" %}</h3>
         </div>
 
         <div role="alert" class="status message submission-error">
-          <h3 class="message-title">${_("The following errors occured while processing your registration: ")}</h3>
+          <h3 class="message-title">{% trans "The following errors occured while processing your registration: " %}</h3>
           <ul class="message-copy">
-            <li>${_("You must complete all fields.")}</li>
-            <li>${_("The two password fields didn't match.")}</li>
+            <li>{% trans "You must complete all fields." %}</li>
+            <li>{% trans "The two password fields didn't match." %}</li>
           </ul>
         </div>
 
         <div role="alert" class="status message system-error">
-          <h3 class="message-title">${_("We're sorry, our systems seem to be having trouble processing your password reset")}</h3>
-          <p class="message-copy">${_('Someone has been made aware of this issue. Please try again shortly. Please <a href="{{MKTG_URL_CONTACT}}">contact us</a> about any concerns you have.')}</p>
+          <h3 class="message-title">{% trans "We're sorry, our systems seem to be having trouble processing your password reset" %}</h3>
+          <p class="message-copy">{% trans 'Someone has been made aware of this issue. Please try again shortly. Please <a href="{{MKTG_URL_CONTACT}}">contact us</a> about any concerns you have.' %}</p>
         </div>
 
         <p class="instructions">
-        ${_('Please enter your new password twice so we can verify you typed it in correctly. <br /> '
-            'Required fields are noted by <strong class="indicator">bold text and an asterisk (*)</strong>.')}
+        {% trans 'Please enter your new password twice so we can verify you typed it in correctly. <br /> Required fields are noted by <strong class="indicator">bold text and an asterisk (*)</strong>.' %}
         </p>
 
         <fieldset class="group group-form group-form-requiredinformation">
-          <legend class="sr">${_("Required Information")}</legend>
+          <legend class="sr">{% trans "Required Information" %}</legend>
 
           <ol class="list-input">
             <li class="field required password" id="field-new_password1">
-              <label for="new_password1">${_("Your New Password")}</label>
+              <label for="new_password1">{% trans "Your New Password" %}</label>
               <input id="new_password1" type="password" name="new_password1" placeholder="*****" />
             </li>
             <li class="field required password" id="field-new_password2">
-              <label for="new_password2">${_("Your New Password Again")}</label>
+              <label for="new_password2">{% trans "Your New Password Again" %}</label>
               <input id="new_password2" type="password" name="new_password2" placeholder="*****" />
             </li>
           </ol>
         </fieldset>
 
         <div class="form-actions">
-          <button name="submit" type="submit" id="submit" class="action action-primary action-update">${_("Change My Password")}</button>
+          <button name="submit" type="submit" id="submit" class="action action-primary action-update">{% trans "Change My Password" %}</button>
         </div>
       </form>
 
       {% else %}
 
       <header>
-        <h2 class="sr">${_("Your Password Reset Was Unsuccessful")}</h2>
+        <h2 class="sr">{% trans "Your Password Reset Was Unsuccessful" %}</h2>
       </header>
-      <p>${_('The password reset link was invalid, possibly because the link has already been used.  Please return to the <a href="/login">login page</a> and start the password reset process again.')}</p>
+      <p>{% trans 'The password reset link was invalid, possibly because the link has already been used.  Please return to the <a href="/login">login page</a> and start the password reset process again.' %}</p>
 
       {% endif %}
     </section>
 
     <aside role="complementary">
       <header>
-      <h3 class="sr">${_("Password Reset Help")}</h3>
+      <h3 class="sr">{% trans "Password Reset Help" %}</h3>
       </header>
 
       <div class="cta cta-help">
-        <h3>${_("Need Help?")}</h3>
-        <p>${_('View our <a href="{{MKTG_URL_FAQ}}">help section for contact information and answers to commonly asked questions</a>')}</p>
+        <h3>{% trans "Need Help?" %}</h3>
+        <p>{% trans 'View our <a href="{{MKTG_URL_FAQ}}">help section for contact information and answers to commonly asked questions</a>' %}</p>
       </div>
     </aside>
   </section>

--- a/lms/templates/registration/password_reset_confirm.html
+++ b/lms/templates/registration/password_reset_confirm.html
@@ -91,7 +91,11 @@
 
         <div role="alert" class="status message system-error">
           <h3 class="message-title">{% trans "We're sorry, our systems seem to be having trouble processing your password reset" %}</h3>
-          <p class="message-copy">{% trans 'Someone has been made aware of this issue. Please try again shortly. Please <a href="{{MKTG_URL_CONTACT}}">contact us</a> about any concerns you have.' %}</p>
+          <p class="message-copy">
+            {% blocktrans with start_link='<a href="{{MKTG_URL_CONTACT}}">' end_link='</a>' %}
+                Someone has been made aware of this issue. Please try again shortly. Please {{ start_link }}contact us{{ end_link }} about any concerns you have.
+            {% endblocktrans %}
+          </p>
         </div>
 
         <p class="instructions">
@@ -123,7 +127,11 @@
       <header>
         <h2 class="sr">{% trans "Your Password Reset Was Unsuccessful" %}</h2>
       </header>
-      <p>{% trans 'The password reset link was invalid, possibly because the link has already been used.  Please return to the <a href="/login">login page</a> and start the password reset process again.' %}</p>
+      <p>
+        {% blocktrans with start_link='<a href="/login">' end_link='</a>' %}
+            The password reset link was invalid, possibly because the link has already been used.  Please return to the {{ start_link }}login page{{ end_link }} and start the password reset process again.
+        {% endblocktrans %}
+      </p>
 
       {% endif %}
     </section>
@@ -135,7 +143,11 @@
 
       <div class="cta cta-help">
         <h3>{% trans "Need Help?" %}</h3>
-        <p>{% trans 'View our <a href="{{MKTG_URL_FAQ}}">help section for contact information and answers to commonly asked questions</a>' %}</p>
+        <p>
+          {% blocktrans with start_link='<a href="{{MKTG_URL_FAQ}}">' end_link='</a>' %}
+              View our {{ start_link }}help section for contact information and answers to commonly asked questions{{ end_link }}
+          {% endblocktrans %}
+        </p>
       </div>
     </aside>
   </section>

--- a/lms/templates/registration/password_reset_confirm.html
+++ b/lms/templates/registration/password_reset_confirm.html
@@ -5,7 +5,11 @@
 <html>
 <head>
 
-<title>{% trans "Reset Your edX Password" %}</title>
+<title>
+  {% blocktrans with platform_name=platform_name %}
+      Reset Your {{ platform_name }} Password
+  {% endblocktrans %}
+</title>
 
   {% compressed_css 'application' %}
 
@@ -53,7 +57,11 @@
   <section class="passwordreset container">
     <section class="introduction">
       <header>
-        <h1>{% trans "Reset Your edX Password" %}</h1>
+        <h1>
+          {% blocktrans with platform_name=platform_name %}
+          Reset Your {{ platform_name }} Password
+          {% endblocktrans %}
+        </h1>
       </header>
     </section>
 
@@ -66,7 +74,11 @@
       <form role="form" id="passwordreset-form" method="post" data-remote="true" action="">{% csrf_token %}
         <!-- status messages -->
         <div role="alert" class="status message">
-          <h3 class="message-title">{% trans "We're sorry, edX enrollment is not available in your region" %}</h3>
+          <h3 class="message-title">
+            {% blocktrans with platform_name=platform_name %}
+                We're sorry, {{ platform_name }} enrollment is not available in your region
+            {% endblocktrans %}
+          </h3>
         </div>
 
         <div role="alert" class="status message submission-error">

--- a/lms/templates/wiki/includes/cheatsheet.html
+++ b/lms/templates/wiki/includes/cheatsheet.html
@@ -1,21 +1,24 @@
-<%! from django.utils.translation import ugettext as _ %>
+{% load i18n %}
 <div class="modal hide fade" id="cheatsheetModal">
 	<a href="#" class="close-btn">×</a>
 	<div id="cheatsheet-body" class="modal-body">
 		<div class="left-column">
 			<section>
-				<h2>${_("Wiki Syntax Help")}</h2>
-				<p>${_("This wiki uses <strong>Markdown</strong> for styling. There are several useful guides online. See any of the links below for in-depth details:")}</p>
+				<h2>{% trans "Wiki Syntax Help" %}</h2>
+				<p>{% trans "This wiki uses <strong>Markdown</strong> for styling. There are several useful guides online. See any of the links below for in-depth details:" %}</p>
 				<ul>
-					<li>${_('<a href="http://daringfireball.net/projects/markdown/basics" target="_blank">Markdown: Basics</a>')}</li>
-					<li>${_('<a href="http://greg.vario.us/doc/markdown.txt" target="_blank">Quick Markdown Syntax Guide</a>')}</li>
-					<li>${_('<a href="http://www.lowendtalk.com/discussion/6/miniature-markdown-guide" target="_blank">Miniature Markdown Guide</a>')}</li>
+					<li>{% trans '<a href="http://daringfireball.net/projects/markdown/basics" target="_blank">Markdown: Basics</a>' %}</li>
+					<li>{% trans '<a href="http://greg.vario.us/doc/markdown.txt" target="_blank">Quick Markdown Syntax Guide</a>' %}</li>
+					<li>{% trans '<a href="http://www.lowendtalk.com/discussion/6/miniature-markdown-guide" target="_blank">Miniature Markdown Guide</a>' %}</li>
 				</ul>
-				<p>${_("To create a new wiki article, create a link to it. Clicking the link gives you the creation page.")}</p>
-                                <pre>${_("[Article Name](wiki:ArticleName)")}</pre>
+				<p>{% trans "To create a new wiki article, create a link to it. Clicking the link gives you the creation page." %}</p>
+                                <pre>{% trans "[Article Name](wiki:ArticleName)" %}</pre>
 			</section>
 			<section>
-				<h3>${_("{edX} Additions:").format(edX="edX")}</h3>
+				{% comment %}
+					Translators: Do not translate "edX"
+				{% endcomment %}
+				<h3>{% trans "edX Additions:" %}</h3>
 				<pre>
 circuit-schematic:</pre>
 				<pre>
@@ -25,30 +28,34 @@ $LaTeX Math Expression$</pre>
 
 		<div class="right-column">
 			<section>
-				<h3>${_("Useful examples:")}</h3>
+				<h3>{% trans "Useful examples:" %}</h3>
 				<pre>
-${_("http://wikipedia.org\
-[{Wikipedia}](http://wikipedia.org)\
-[{edX} Wiki](wiki:/edx/)").format(edX="edX", Wikipedia="Wikipedia")}</pre>
+{% comment %}
+	Translators: Do not translate "edX" or "Wikipedia"
+{% endcomment %}
+{% trans "http://wikipedia.org" %}
+{% trans "[Wikipedia](http://wikipedia.org)" %}
+{% trans "[edX Wiki](wiki:/edx/)" %}
+				</pre>
 				<pre>
-${_("Huge Header")}
+{% trans "Huge Header" %}
 ===========</pre>
 				<pre>
-${_("Smaller Header")}
+{% trans "Smaller Header" %}
 --------------</pre>
 				<pre>
-${_("*emphasis* or _emphasis_")}</pre>
+{% trans "*emphasis* or _emphasis_" %}</pre>
 				<pre>
-${_("**strong** or __strong__")}</pre>
+{% trans "**strong** or __strong__" %}</pre>
 				<pre>
-${_("- Unordered List\
-	- Sub Item 1\
-        - Sub Item 2")}</pre>
+- {% trans "Unordered List" %}
+	- {% trans "Sub Item 1" %}
+    	- {% trans "Sub Item 2" %}</pre>
 				<pre>
-${_("1. Ordered\
-2. List")}</pre>
+1. {% trans "Ordered" %}
+2. {% trans "List" %}</pre>
 				<pre>
-${_("> Quotes")}</pre>
+> {% trans "Quotes" %}</pre>
 			</section>
 		</div>
 

--- a/lms/templates/wiki/includes/cheatsheet.html
+++ b/lms/templates/wiki/includes/cheatsheet.html
@@ -7,9 +7,9 @@
 				<h2>{% trans "Wiki Syntax Help" %}</h2>
 				<p>{% trans "This wiki uses <strong>Markdown</strong> for styling. There are several useful guides online. See any of the links below for in-depth details:" %}</p>
 				<ul>
-					<li>{% trans '<a href="http://daringfireball.net/projects/markdown/basics" target="_blank">Markdown: Basics</a>' %}</li>
-					<li>{% trans '<a href="http://greg.vario.us/doc/markdown.txt" target="_blank">Quick Markdown Syntax Guide</a>' %}</li>
-					<li>{% trans '<a href="http://www.lowendtalk.com/discussion/6/miniature-markdown-guide" target="_blank">Miniature Markdown Guide</a>' %}</li>
+					<li><a href="http://daringfireball.net/projects/markdown/basics" target="_blank">{% trans 'Markdown: Basics' %}</a></li>
+					<li><a href="http://greg.vario.us/doc/markdown.txt" target="_blank">{% trans 'Quick Markdown Syntax Guide' %}</a></li>
+					<li><a href="http://www.lowendtalk.com/discussion/6/miniature-markdown-guide" target="_blank">{% trans 'Miniature Markdown Guide' %}</a></li>
 				</ul>
 				<p>{% trans "To create a new wiki article, create a link to it. Clicking the link gives you the creation page." %}</p>
                                 <pre>{% trans "[Article Name](wiki:ArticleName)" %}</pre>

--- a/lms/templates/wiki/includes/editor_widget.html
+++ b/lms/templates/wiki/includes/editor_widget.html
@@ -4,5 +4,7 @@
 	{% comment %}
 		Translators: Do not translate 'cheatsheetLink'
 	{% endcomment %}
-	{% trans "Markdown syntax is allowed. See the <a id='cheatsheetLink' href='#'>cheatsheet</a> for help." %}
+	{% blocktrans with start_link="<a id='cheatsheetLink' href='#'>" end_link="</a>" %}
+	    Markdown syntax is allowed. See the {{ start_link }}cheatsheet{{ end_link }} for help.
+	{% endblocktrans %}
 </p>

--- a/lms/templates/wiki/includes/editor_widget.html
+++ b/lms/templates/wiki/includes/editor_widget.html
@@ -1,5 +1,8 @@
-<%! from django.utils.translation import ugettext as _ %>
+{% load i18n %}
 <textarea {{ attrs }}>{{ content }}</textarea>
 <p id="hint_id_content" class="help-block">
- ${_('Markdown syntax is allowed. See the <a id="cheatsheetLink" href="#">_{("cheatsheet")}</a> for help.')}
+	{% comment %}
+		Translators: Do not translate 'cheatsheetLink'
+	{% endcomment %}
+	{% trans "Markdown syntax is allowed. See the <a id='cheatsheetLink' href='#'>cheatsheet</a> for help." %}
 </p>

--- a/lms/templates/wiki/preview_inline.html
+++ b/lms/templates/wiki/preview_inline.html
@@ -1,4 +1,3 @@
-<%! from django.utils.translation import ugettext as _ %>
 <!DOCTYPE html>
 {% load wiki_tags i18n %}{% load compressed %}
 <html>
@@ -29,8 +28,8 @@
 
       {% if revision and revision.deleted %}
         <div class="warning">
-          <strong>${_("This revision has been deleted.")}</strong> 
-          <p>${_("Restoring to this revision will mark the article as deleted.")}</p>
+          <strong>{% trans "This revision has been deleted." %}</strong> 
+          <p>{% trans "Restoring to this revision will mark the article as deleted." %}</p>
         </div>
       {% else %}
         {% wiki_render article content %}


### PR DESCRIPTION
i18n templating fixes for password reseting and the wiki.

The common error here was with the conflation of mako and django syntax. I took the mako syntax out of these django template files.

@jzoldak 
@sarina  
