### PR TITLE
Valera/bugfix tabbing video controls

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/video/07_video_volume_control.js
+++ b/common/lib/xmodule/xmodule/js/src/video/07_video_volume_control.js
@@ -116,9 +116,9 @@ function () {
         state.videoVolumeControl.volumeSliderEl.find('a')
             .on('blur', function () {
                 // Hide the volume slider. This is done so that we can
-                // contrinue to the next (or previous) element by tabbing.
+                // continue to the next (or previous) element by tabbing.
                 // Otherwise, after next tab we would come back to the volume
-                // slider because it is the next element sisible element that
+                // slider because it is the next element visible element that
                 // we can tab to after the volume button.
                 state.videoVolumeControl.el.removeClass('open');
 

--- a/common/lib/xmodule/xmodule/js/src/video/07_video_volume_control.js
+++ b/common/lib/xmodule/xmodule/js/src/video/07_video_volume_control.js
@@ -77,20 +77,25 @@ function () {
             $(this).addClass('open');
         });
 
-        state.videoVolumeControl.buttonEl.on('focus', function() {
-            $(this).parent().addClass('open');
-        });
-
         state.videoVolumeControl.el.on('mouseleave', function() {
             $(this).removeClass('open');
         });
 
         state.videoVolumeControl.buttonEl.on('blur', function() {
-            state.videoVolumeControl.volumeSliderEl.find('a').focus();
+            if (state.volumeBlur !== true) {
+                state.videoVolumeControl.el.addClass('open');
+                state.videoVolumeControl.volumeSliderEl.find('a').focus();
+            } else {
+                state.volumeBlur = false;
+            }
         });
 
         state.videoVolumeControl.volumeSliderEl.find('a').on('blur', function () {
             state.videoVolumeControl.el.removeClass('open');
+
+            state.videoVolumeControl.buttonEl.focus();
+
+            state.volumeBlur = true;
         });
     }
 

--- a/common/lib/xmodule/xmodule/js/src/video/07_video_volume_control.js
+++ b/common/lib/xmodule/xmodule/js/src/video/07_video_volume_control.js
@@ -67,36 +67,68 @@ function () {
         state.videoVolumeControl.el.toggleClass('muted', state.videoVolumeControl.currentVolume === 0);
     }
 
-    // function _bindHandlers(state)
-    //
-    //     Bind any necessary function callbacks to DOM events (click, mousemove, etc.).
+    /**
+     * @desc Bind any necessary function callbacks to DOM events (click,
+     *     mousemove, etc.).
+     *
+     * @type {function}
+     * @access private
+     *
+     * @param {object} state The object containg the state of the video player.
+     *     All other modules, their parameters, public variables, etc. are
+     *     available via this object.
+     *
+     * @this {object} The global window object.
+     *
+     * @returns {undefined}
+     */
     function _bindHandlers(state) {
-        state.videoVolumeControl.buttonEl.on('click', state.videoVolumeControl.toggleMute);
+        state.videoVolumeControl.buttonEl
+            .on('click', state.videoVolumeControl.toggleMute);
 
         state.videoVolumeControl.el.on('mouseenter', function() {
-            $(this).addClass('open');
+            state.videoVolumeControl.el.addClass('open');
         });
 
         state.videoVolumeControl.el.on('mouseleave', function() {
-            $(this).removeClass('open');
+            state.videoVolumeControl.el.removeClass('open');
         });
 
+        // Attach a focus event to the volume button.
         state.videoVolumeControl.buttonEl.on('blur', function() {
-            if (state.volumeBlur !== true) {
+            // If the focus is being trasnfered from the volume slider, then we
+            // don't do anything except for unsetting the special flag.
+            if (state.volumeBlur === true) {
+                state.volumeBlur = false;
+            }
+
+            //If the focus is comming from elsewhere, then we must show the
+            // volume slider and set focus to it.
+            else {
                 state.videoVolumeControl.el.addClass('open');
                 state.videoVolumeControl.volumeSliderEl.find('a').focus();
-            } else {
-                state.volumeBlur = false;
             }
         });
 
-        state.videoVolumeControl.volumeSliderEl.find('a').on('blur', function () {
-            state.videoVolumeControl.el.removeClass('open');
+        // Attach a blur event handler (loss of focus) to the volume slider
+        // element. More specifically, we are attaching to the handle on
+        // the slider with which you can change the volume.
+        state.videoVolumeControl.volumeSliderEl.find('a')
+            .on('blur', function () {
+                // Hide the volume slider. This is done so that we can
+                // contrinue to the next (or previous) element by tabbing.
+                // Otherwise, after next tab we would come back to the volume
+                // slider because it is the next element sisible element that
+                // we can tab to after the volume button.
+                state.videoVolumeControl.el.removeClass('open');
 
-            state.videoVolumeControl.buttonEl.focus();
+                // Set focus to the volume button.
+                state.videoVolumeControl.buttonEl.focus();
 
-            state.volumeBlur = true;
-        });
+                // We store the fact that previous element that lost focus was
+                // the volume clontrol.
+                state.volumeBlur = true;
+            });
     }
 
     // ***************************************************************

--- a/common/lib/xmodule/xmodule/js/src/video/07_video_volume_control.js
+++ b/common/lib/xmodule/xmodule/js/src/video/07_video_volume_control.js
@@ -61,9 +61,6 @@ function () {
             slide: state.videoVolumeControl.onChange
         });
 
-        // Make sure that we can focus the actual volume slider while Tabing.
-        state.videoVolumeControl.volumeSliderEl.find('a').attr('tabindex', '0');
-
         state.videoVolumeControl.el.toggleClass('muted', state.videoVolumeControl.currentVolume === 0);
     }
 

--- a/common/lib/xmodule/xmodule/js/src/video/08_video_speed_control.js
+++ b/common/lib/xmodule/xmodule/js/src/video/08_video_speed_control.js
@@ -148,7 +148,7 @@ function () {
             // individual speed entries.
             state.videoSpeedControl.videoSpeedsEl.find('a.speed_link:last')
                 .on('blur', function () {
-                    // If we have reached the last speed enrty, and the focus
+                    // If we have reached the last speed entry, and the focus
                     // changes to the next element, we need to hide the speeds
                     // control drop-down.
                     state.videoSpeedControl.el.removeClass('open');

--- a/common/lib/xmodule/xmodule/js/src/video/08_video_speed_control.js
+++ b/common/lib/xmodule/xmodule/js/src/video/08_video_speed_control.js
@@ -58,6 +58,8 @@ function () {
                 );
         });
 
+        state.videoSpeedControl.videoSpeedsEl.find('a:first').addClass('first_speed_el');
+
         state.videoSpeedControl.setSpeed(state.speed);
     }
 
@@ -89,7 +91,13 @@ function () {
 
             state.videoSpeedControl.el.children('a')
                 .on('focus', function () {
-                    $(this).parent().addClass('open');
+                    if (state.firstSpeedBlur === true) {
+                        $(this).parent().removeClass('open');
+
+                        state.firstSpeedBlur = false;
+                    } else {
+                        $(this).parent().addClass('open');
+                    }
                 })
                 .on('blur', function () {
                     state.videoSpeedControl.videoSpeedsEl
@@ -100,6 +108,16 @@ function () {
             state.videoSpeedControl.videoSpeedsEl.find('a.speed_link:last')
                 .on('blur', function () {
                     state.videoSpeedControl.el.removeClass('open');
+                });
+
+            state.videoSpeedControl.videoSpeedsEl.find('a.speed_link:first')
+                .on('blur', function () {
+                    state.firstSpeedBlur = true;
+                });
+
+            state.videoSpeedControl.videoSpeedsEl.find('a.speed_link')
+                .on('focus', function () {
+                    state.firstSpeedBlur = false;
                 });
         }
     }
@@ -161,6 +179,10 @@ function () {
 
             _this.videoSpeedControl.videoSpeedsEl.prepend(listItem);
         });
+
+        this.videoSpeedControl.videoSpeedsEl
+            .find('a:first')
+            .addClass('first_speed_el');
 
         _bindHandlers(this);
     }

--- a/common/lib/xmodule/xmodule/js/src/video/08_video_speed_control.js
+++ b/common/lib/xmodule/xmodule/js/src/video/08_video_speed_control.js
@@ -77,6 +77,8 @@ function () {
      * @returns {undefined}
      */
     function _bindHandlers(state) {
+        var speedLinks;
+
         state.videoSpeedControl.videoSpeedsEl.find('a')
             .on('click', state.videoSpeedControl.changeVideoSpeed);
 
@@ -146,29 +148,29 @@ function () {
             // ******************************
             // Attach 'focus', and 'blur' events to elements which represent
             // individual speed entries.
-            state.videoSpeedControl.videoSpeedsEl.find('a.speed_link:last')
-                .on('blur', function () {
-                    // If we have reached the last speed entry, and the focus
-                    // changes to the next element, we need to hide the speeds
-                    // control drop-down.
-                    state.videoSpeedControl.el.removeClass('open');
-                });
-            state.videoSpeedControl.videoSpeedsEl.find('a.speed_link:first')
-                .on('blur', function () {
-                    // This flag will indicate that the focus to the next
-                    // element that will receive it is comming from the first
-                    // speed entry.
-                    //
-                    // This flag will be used to correctly handle scenario of
-                    // tabbing backwards.
-                    state.firstSpeedBlur = true;
-                });
-            state.videoSpeedControl.videoSpeedsEl.find('a.speed_link')
-                .on('focus', function () {
-                    // Clear the flag which is only set when we are un-focusing
-                    // (the blur event) from the first speed entry.
-                    state.firstSpeedBlur = false;
-                });
+            speedLinks = state.videoSpeedControl.videoSpeedsEl
+                .find('a.speed_link');
+
+            speedLinks.last().on('blur', function () {
+                // If we have reached the last speed entry, and the focus
+                // changes to the next element, we need to hide the speeds
+                // control drop-down.
+                state.videoSpeedControl.el.removeClass('open');
+            });
+            speedLinks.first().on('blur', function () {
+                // This flag will indicate that the focus to the next
+                // element that will receive it is comming from the first
+                // speed entry.
+                //
+                // This flag will be used to correctly handle scenario of
+                // tabbing backwards.
+                state.firstSpeedBlur = true;
+            });
+            speedLinks.on('focus', function () {
+                // Clear the flag which is only set when we are un-focusing
+                // (the blur event) from the first speed entry.
+                state.firstSpeedBlur = false;
+            });
         }
     }
 

--- a/common/lib/xmodule/xmodule/js/src/video/08_video_speed_control.js
+++ b/common/lib/xmodule/xmodule/js/src/video/08_video_speed_control.js
@@ -58,65 +58,115 @@ function () {
                 );
         });
 
-        state.videoSpeedControl.videoSpeedsEl.find('a:first').addClass('first_speed_el');
-
         state.videoSpeedControl.setSpeed(state.speed);
     }
 
-    // function _bindHandlers(state)
-    //
-    //     Bind any necessary function callbacks to DOM events (click,
-    //     mousemove, etc.).
+    /**
+     * @desc Bind any necessary function callbacks to DOM events (click,
+     *     mousemove, etc.).
+     *
+     * @type {function}
+     * @access private
+     *
+     * @param {object} state The object containg the state of the video player.
+     *     All other modules, their parameters, public variables, etc. are
+     *     available via this object.
+     *
+     * @this {object} The global window object.
+     *
+     * @returns {undefined}
+     */
     function _bindHandlers(state) {
         state.videoSpeedControl.videoSpeedsEl.find('a')
             .on('click', state.videoSpeedControl.changeVideoSpeed);
 
         if (onTouchBasedDevice()) {
             state.videoSpeedControl.el.on('click', function(event) {
+                // So that you can't highlight this control via a drag
+                // operation, we disable the default browser actions on a
+                // click event.
                 event.preventDefault();
-                $(this).toggleClass('open');
+
+                state.videoSpeedControl.el.toggleClass('open');
             });
         } else {
             state.videoSpeedControl.el
                 .on('mouseenter', function () {
-                    $(this).addClass('open');
+                    state.videoSpeedControl.el.addClass('open');
                 })
                 .on('mouseleave', function () {
-                    $(this).removeClass('open');
+                    state.videoSpeedControl.el.removeClass('open');
                 })
                 .on('click', function (event) {
+                    // So that you can't highlight this control via a drag
+                    // operation, we disable the default browser actions on a
+                    // click event.
                     event.preventDefault();
-                    $(this).removeClass('open');
+
+                    state.videoSpeedControl.el.removeClass('open');
                 });
 
+            // ******************************
+            // Attach 'focus', and 'blur' events to the speed button which
+            // either brings up the speed dialog with individual speed entries,
+            // or closes it.
             state.videoSpeedControl.el.children('a')
                 .on('focus', function () {
+                    // If the focus is comming from the first speed entry, this
+                    // means we are tabbing backwards. In this case we have to
+                    // hide the speed entries which will allow us to change the
+                    // focus further backwards.
                     if (state.firstSpeedBlur === true) {
-                        $(this).parent().removeClass('open');
+                        state.videoSpeedControl.el.removeClass('open');
 
                         state.firstSpeedBlur = false;
-                    } else {
-                        $(this).parent().addClass('open');
+                    }
+
+                    // If the focus is comming from some other element, show
+                    // the drop down with the speed entries.
+                    else {
+                        state.videoSpeedControl.el.addClass('open');
                     }
                 })
                 .on('blur', function () {
+                    // When the focus leaves this element, if the speed entries
+                    // dialog is shown (tabbing forwards), then we will set
+                    // focus to the first speed entry.
+                    //
+                    // If the selector does not select anything, then this
+                    // means that the speed entries dialog is closed, and we
+                    // are tabbing backwads. The browser will select the
+                    // previous element to tab to by itself.
                     state.videoSpeedControl.videoSpeedsEl
                         .find('a.speed_link:first')
                         .focus();
                 });
 
+
+            // ******************************
+            // Attach 'focus', and 'blur' events to elements which represent
+            // individual speed entries.
             state.videoSpeedControl.videoSpeedsEl.find('a.speed_link:last')
                 .on('blur', function () {
+                    // If we have reached the last speed enrty, and the focus
+                    // changes to the next element, we need to hide the speeds
+                    // control drop-down.
                     state.videoSpeedControl.el.removeClass('open');
                 });
-
             state.videoSpeedControl.videoSpeedsEl.find('a.speed_link:first')
                 .on('blur', function () {
+                    // This flag will indicate that the focus to the next
+                    // element that will receive it is comming from the first
+                    // speed entry.
+                    //
+                    // This flag will be used to correctly handle scenario of
+                    // tabbing backwards.
                     state.firstSpeedBlur = true;
                 });
-
             state.videoSpeedControl.videoSpeedsEl.find('a.speed_link')
                 .on('focus', function () {
+                    // Clear the flag which is only set when we are un-focusing
+                    // (the blur event) from the first speed entry.
                     state.firstSpeedBlur = false;
                 });
         }
@@ -180,10 +230,8 @@ function () {
             _this.videoSpeedControl.videoSpeedsEl.prepend(listItem);
         });
 
-        this.videoSpeedControl.videoSpeedsEl
-            .find('a:first')
-            .addClass('first_speed_el');
-
+        // Re-attach all events with their appropriate callbacks to the
+        // newly generated elements.
         _bindHandlers(this);
     }
 

--- a/common/lib/xmodule/xmodule/js/src/video/08_video_speed_control.js
+++ b/common/lib/xmodule/xmodule/js/src/video/08_video_speed_control.js
@@ -151,7 +151,7 @@ function () {
         $.each(this.videoSpeedControl.speeds, function(index, speed) {
             var link, listItem;
 
-            link = '<a href="#">' + speed + 'x</a>';
+            link = '<a class="speed_link" href="#">' + speed + 'x</a>';
 
             listItem = $('<li data-speed="' + speed + '">' + link + '</li>');
 
@@ -162,11 +162,7 @@ function () {
             _this.videoSpeedControl.videoSpeedsEl.prepend(listItem);
         });
 
-        this.videoSpeedControl.videoSpeedsEl.find('a')
-            .on('click', this.videoSpeedControl.changeVideoSpeed);
-
-        // TODO: After the control was re-rendered, we should attach 'focus'
-        // and 'blur' events once more.
+        _bindHandlers(this);
     }
 
 });

--- a/lms/templates/video.html
+++ b/lms/templates/video.html
@@ -45,15 +45,15 @@
                     <div class="secondary-controls">
                         <div class="speeds">
                             <a href="#" tabindex="0" title="Speeds">
-                                <h3 tabindex="-1">${_('Speed')}</h3>
-                                <p tabindex="-1" class="active"></p>
+                                <h3>${_('Speed')}</h3>
+                                <p class="active"></p>
                             </a>
-                            <ol tabindex="-1" class="video_speeds"></ol>
+                            <ol class="video_speeds"></ol>
                         </div>
                         <div class="volume">
                             <a href="#" tabindex="0" title="Volume"></a>
-                            <div tabindex="-1" class="volume-slider-container">
-                                <div tabindex="-1" class="volume-slider"></div>
+                            <div class="volume-slider-container">
+                                <div class="volume-slider"></div>
                             </div>
                         </div>
                         <a href="#" class="add-fullscreen" tabindex="0" title="${_('Fill browser')}">${_('Fill browser')}</a>

--- a/lms/templates/video.html
+++ b/lms/templates/video.html
@@ -39,25 +39,25 @@
 
                 <div>
                     <ul class="vcr">
-                        <li><a class="video_control" href="#" tabindex="0" title="${_('Play')}"></a></li>
+                        <li><a class="video_control" href="#" title="${_('Play')}"></a></li>
                         <li><div class="vidtime">0:00 / 0:00</div></li>
                     </ul>
                     <div class="secondary-controls">
                         <div class="speeds">
-                            <a href="#" tabindex="0" title="Speeds">
+                            <a href="#" title="Speeds">
                                 <h3>${_('Speed')}</h3>
                                 <p class="active"></p>
                             </a>
                             <ol class="video_speeds"></ol>
                         </div>
                         <div class="volume">
-                            <a href="#" tabindex="0" title="Volume"></a>
+                            <a href="#" title="Volume"></a>
                             <div class="volume-slider-container">
                                 <div class="volume-slider"></div>
                             </div>
                         </div>
-                        <a href="#" class="add-fullscreen" tabindex="0" title="${_('Fill browser')}">${_('Fill browser')}</a>
-                        <a href="#" class="quality_control" tabindex="0" title="${_('HD')}">${_('HD')}</a>
+                        <a href="#" class="add-fullscreen" title="${_('Fill browser')}">${_('Fill browser')}</a>
+                        <a href="#" class="quality_control" title="${_('HD')}">${_('HD')}</a>
 
                         <a href="#" class="hide-subtitles" title="${_('Turn off captions')}">${_('Captions')}</a>
                     </div>


### PR DESCRIPTION
This PR provides fixes for bugs:

1.) When tabbing backwards, focus should switch in succession ( https://edx-wiki.atlassian.net/browse/BLD-228 ).
2.) Tabbing from speeds to volume control doesn't close Speeds dialog ( https://edx-wiki.atlassian.net/browse/BLD-233 ).

<b>Reviewers</b>
- @polesye 
- @peter-fogg 
- @talbs Please have a quick look from the point of view of user interface. Ease of tabbing from one control to the next.
