### PR TITLE
Remove js log_event (keep compatibility)

### DIFF
--- a/common/static/coffee/src/logger.coffee
+++ b/common/static/coffee/src/logger.coffee
@@ -42,5 +42,7 @@ class @Logger
           page: window.location.href
         async: false
 
-# Keeping this for compatibility issue only.
+
+# log_event exists for compatibility reasons
+# and will soon be deprecated.
 @log_event = Logger.log

--- a/common/static/js/pdfviewer.js
+++ b/common/static/js/pdfviewer.js
@@ -157,7 +157,7 @@ PDFJS.disableWorker = true;
             }
 
             // Update logging:
-            log_event("book", { "type" : "gotopage", "old" : pageNum, "new" : num });
+            Logger.log("book", { "type" : "gotopage", "old" : pageNum, "new" : num });
 
             parentElement = viewerElement;
             while (parentElement.hasChildNodes())
@@ -207,7 +207,7 @@ PDFJS.disableWorker = true;
             if (pageNum <= 1)
                 return;
             renderPage(pageNum - 1);
-            log_event("book", { "type" : "prevpage", "new" : pageNum });
+            Logger.log("book", { "type" : "prevpage", "new" : pageNum });
         }
 
         // Go to next page
@@ -215,7 +215,7 @@ PDFJS.disableWorker = true;
             if (pageNum >= pdfDocument.numPages)
                 return;
             renderPage(pageNum + 1);
-            log_event("book", { "type" : "nextpage", "new" : pageNum });
+            Logger.log("book", { "type" : "nextpage", "new" : pageNum });
         }
 
         selectScaleOption = function(value) {

--- a/lms/static/coffee/spec/navigation_spec.coffee
+++ b/lms/static/coffee/spec/navigation_spec.coffee
@@ -57,8 +57,7 @@ describe 'Navigation', ->
 
   describe 'log', ->
     beforeEach ->
-      window.log_event = ->
-      spyOn window, 'log_event'
+      spyOn Logger, 'log'
 
     it 'submit event log', ->
       @navigation.log {}, {
@@ -68,6 +67,6 @@ describe 'Navigation', ->
           text: -> "old"
       }
 
-      expect(window.log_event).toHaveBeenCalledWith 'accordion',
+      expect(Logger.log).toHaveBeenCalledWith 'accordion',
         newheader: 'new'
         oldheader: 'old'

--- a/lms/static/coffee/src/navigation.coffee
+++ b/lms/static/coffee/src/navigation.coffee
@@ -20,7 +20,7 @@ class @Navigation
       $('#accordion a').click @setChapter
 
   log: (event, ui) ->
-    log_event 'accordion',
+    Logger.log 'accordion',
       newheader: ui.newHeader.text()
       oldheader: ui.oldHeader.text()
 

--- a/lms/templates/staticbook.html
+++ b/lms/templates/staticbook.html
@@ -25,7 +25,7 @@ $(document).ready(function(){
 });
 
 function goto_page(n) {
-  log_event("book", {"type":"gotopage","old":page,"new":n});
+  Logger.log("book", {"type":"gotopage","old":page,"new":n});
   page=n;
   var prefix = "";
   if(n<100) {
@@ -42,14 +42,14 @@ function prev_page() {
   var newpage=page-1;
   if(newpage< ${start_page}) newpage=${start_page};
   goto_page(newpage);
-  log_event("book", {"type":"prevpage","new":page});
+  Logger.log("book", {"type":"prevpage","new":page});
 }
 
 function next_page() {
   var newpage=page+1;
   if(newpage> ${end_page}) newpage=${end_page};
   goto_page(newpage);
-  log_event("book", {"type":"nextpage","new":page});
+  Logger.log("book", {"type":"nextpage","new":page});
 }
 
 $("#open_close_accordion a").click(function(){


### PR DESCRIPTION
window.log_event was kept for compatibility. It points to window.Logger.log. Not very many things were actually using log_event on the client. Removing window.log_event will reduce clutter in landscape of tracking APIs on the client.

The tests still pass, but other than that how I verify that this works?

@rocha 
