### PR TITLE
Make split mongo read-only API consistent with other modulestores.

### DIFF
--- a/cms/djangoapps/auth/tests/test_authz.py
+++ b/cms/djangoapps/auth/tests/test_authz.py
@@ -181,7 +181,7 @@ class CourseGroupTest(TestCase):
         create_all_course_groups(self.creator, self.location)
         add_user_to_course_group(self.creator, self.staff, self.location, STAFF_ROLE_NAME)
 
-        location2 = 'i4x', 'mitX', '103', 'course2', 'test2'
+        location2 = 'i4x', 'mitX', '103', 'course', 'test2'
         staff2 = User.objects.create_user('teststaff2', 'teststaff2+courses@edx.org', 'foo')
         create_all_course_groups(self.creator, location2)
         add_user_to_course_group(self.creator, staff2, location2, STAFF_ROLE_NAME)
@@ -193,7 +193,7 @@ class CourseGroupTest(TestCase):
         create_all_course_groups(self.creator, self.location)
         add_user_to_course_group(self.creator, self.staff, self.location, STAFF_ROLE_NAME)
 
-        location2 = 'i4x', 'mitX', '103', 'course2', 'test2'
+        location2 = 'i4x', 'mitX', '103', 'course', 'test2'
         creator2 = User.objects.create_user('testcreator2', 'testcreator2+courses@edx.org', 'foo')
         staff2 = User.objects.create_user('teststaff2', 'teststaff2+courses@edx.org', 'foo')
         create_all_course_groups(creator2, location2)

--- a/cms/djangoapps/contentstore/tests/test_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_utils.py
@@ -56,21 +56,27 @@ class LMSLinksTestCase(TestCase):
     def get_about_page_link(self):
         """ create mock course and return the about page link """
         location = 'i4x', 'mitX', '101', 'course', 'test'
-        utils.get_course_id = mock.Mock(return_value="mitX/101/test")
         return utils.get_lms_link_for_about_page(location)
 
     def lms_link_test(self):
         """ Tests get_lms_link_for_item. """
         location = 'i4x', 'mitX', '101', 'vertical', 'contacting_us'
-        utils.get_course_id = mock.Mock(return_value="mitX/101/test")
-        link = utils.get_lms_link_for_item(location, False)
+        link = utils.get_lms_link_for_item(location, False, "mitX/101/test")
         self.assertEquals(link, "//localhost:8000/courses/mitX/101/test/jump_to/i4x://mitX/101/vertical/contacting_us")
-        link = utils.get_lms_link_for_item(location, True)
+        link = utils.get_lms_link_for_item(location, True, "mitX/101/test")
         self.assertEquals(
             link,
             "//preview/courses/mitX/101/test/jump_to/i4x://mitX/101/vertical/contacting_us"
         )
 
+        # If no course_id is passed in, it is obtained from the location. This is the case for
+        # Studio dashboard.
+        location = 'i4x', 'mitX', '101', 'course', 'test'
+        link = utils.get_lms_link_for_item(location)
+        self.assertEquals(
+            link,
+            "//localhost:8000/courses/mitX/101/test/jump_to/i4x://mitX/101/course/test"
+        )
 
 class ExtraPanelTabTestCase(TestCase):
     """ Tests adding and removing extra course tabs. """

--- a/cms/djangoapps/contentstore/tests/test_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_utils.py
@@ -5,8 +5,6 @@ import collections
 import copy
 from django.test import TestCase
 from django.test.utils import override_settings
-from xmodule.modulestore.tests.factories import CourseFactory
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 
 
 class LMSLinksTestCase(TestCase):
@@ -77,6 +75,7 @@ class LMSLinksTestCase(TestCase):
             link,
             "//localhost:8000/courses/mitX/101/test/jump_to/i4x://mitX/101/course/test"
         )
+
 
 class ExtraPanelTabTestCase(TestCase):
     """ Tests adding and removing extra course tabs. """
@@ -151,4 +150,3 @@ class ExtraPanelTabTestCase(TestCase):
                 changed, actual_tabs = utils.remove_extra_panel_tab(tab_type, course)
                 self.assertFalse(changed)
                 self.assertEqual(actual_tabs, expected_tabs)
-

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -89,8 +89,17 @@ def get_course_for_item(location):
 
 
 def get_lms_link_for_item(location, preview=False, course_id=None):
+    """
+    Returns an LMS link to the course with a jump_to to the provided location.
+
+    :param location: the location to jump to
+    :param preview: True if the preview version of LMS should be returned. Default value is false.
+    :param course_id: the course_id within which the location lives. If not specified, the course_id is obtained
+           by calling Location(location).course_id; note that this only works for locations representing courses
+           instead of elements within courses.
+    """
     if course_id is None:
-        course_id = get_course_id(location)
+        course_id = Location(location).course_id
 
     if settings.LMS_BASE is not None:
         if preview:
@@ -136,20 +145,12 @@ def get_lms_link_for_about_page(location):
     if about_base is not None:
         lms_link = "//{about_base_url}/courses/{course_id}/about".format(
             about_base_url=about_base,
-            course_id=get_course_id(location)
+            course_id=Location(location).course_id
         )
     else:
         lms_link = None
 
     return lms_link
-
-
-def get_course_id(location):
-    """
-    Returns the course_id from a given the location tuple.
-    """
-    # TODO: These will need to be changed to point to the particular instance of this problem in the particular course
-    return modulestore().get_containing_courses(Location(location))[0].id
 
 
 class UnitState(object):

--- a/cms/djangoapps/contentstore/views/user.py
+++ b/cms/djangoapps/contentstore/views/user.py
@@ -54,8 +54,7 @@ def index(request):
                 'name': course.location.name,
             }),
             get_lms_link_for_item(
-                course.location,
-                course_id=course.location.course_id,
+                course.location
             ),
             course.display_org_with_default,
             course.display_number_with_default,

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -274,7 +274,7 @@ def dashboard(request):
     # Global staff can see what courses errored on their dashboard
     staff_access = False
     errored_courses = {}
-    if has_access(user, 'global', 'staff') and callable(getattr(modulestore(), 'get_errored_courses')):
+    if has_access(user, 'global', 'staff'):
         # Show any courses that errored on load
         staff_access = True
         errored_courses = modulestore().get_errored_courses()

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -274,7 +274,7 @@ def dashboard(request):
     # Global staff can see what courses errored on their dashboard
     staff_access = False
     errored_courses = {}
-    if has_access(user, 'global', 'staff'):
+    if has_access(user, 'global', 'staff') and callable(getattr(modulestore(), 'get_errored_courses')):
         # Show any courses that errored on load
         staff_access = True
         errored_courses = modulestore().get_errored_courses()

--- a/common/lib/xmodule/xmodule/modulestore/__init__.py
+++ b/common/lib/xmodule/xmodule/modulestore/__init__.py
@@ -370,21 +370,6 @@ class ModuleStore(object):
         '''
         raise NotImplementedError
 
-    def get_containing_courses(self, location):
-        '''
-        Returns the list of courses that contains the specified location
-
-        TODO (cpennington): This should really take a module instance id,
-        rather than a location
-        '''
-        courses = [
-            course
-            for course in self.get_courses()
-            if course.location.org == location.org and course.location.course == location.course
-        ]
-
-        return courses
-
 
 class ModuleStoreBase(ModuleStore):
     '''

--- a/common/lib/xmodule/xmodule/modulestore/__init__.py
+++ b/common/lib/xmodule/xmodule/modulestore/__init__.py
@@ -235,8 +235,15 @@ class Location(_LocationBase):
 
     @property
     def course_id(self):
-        """Return the ID of the Course that this item belongs to by looking
-        at the location URL hierachy"""
+        """
+        Return the ID of the Course that this item belongs to by looking
+        at the location URL hierachy.
+
+        Throws an InvalidLocationError is this location does not represent a course.
+        """
+        if self.category != 'course':
+            raise InvalidLocationError('Cannot call course_id for {0} because it is not of category course'.format(self))
+
         return "/".join([self.org, self.course, self.name])
 
     def replace(self, **kwargs):
@@ -370,6 +377,13 @@ class ModuleStore(object):
         '''
         raise NotImplementedError
 
+    def get_errored_courses(self):
+        """
+        Return a dictionary of course_dir -> [(msg, exception_str)], for each
+        course_dir where course loading failed.
+        """
+        raise NotImplementedError
+
 
 class ModuleStoreBase(ModuleStore):
     '''
@@ -408,6 +422,15 @@ class ModuleStoreBase(ModuleStore):
 
         errorlog = self._get_errorlog(location)
         return errorlog.errors
+
+    def get_errored_courses(self):
+        """
+        Returns an empty dict.
+
+        It is up to subclasses to extend this method if the concept
+        of errored courses makes sense for their implementation.
+        """
+        return {}
 
     def get_course(self, course_id):
         """Default impl--linear search through course list"""

--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -841,13 +841,6 @@ class MongoModuleStore(ModuleStoreBase):
                                      {'_id': True})
         return [i['_id'] for i in items]
 
-    def get_errored_courses(self):
-        """
-        This function doesn't make sense for the mongo modulestore, as courses
-        are loaded on demand, rather than up front
-        """
-        return {}
-
     def _create_new_model_data(self, category, location, definition_data, metadata):
         """
         To instantiate a new xmodule which will be saved latter, set up the dbModel and kvs

--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -681,7 +681,7 @@ class MongoModuleStore(ModuleStoreBase):
         # we should remove this once we can break this reference from the course to static tabs
         # TODO move this special casing to app tier (similar to attaching new element to parent)
         if location.category == 'static_tab':
-            course = self.get_course_for_item(location)
+            course = self._get_course_for_item(location)
             existing_tabs = course.tabs or []
             existing_tabs.append({
                 'type': 'static_tab',
@@ -701,7 +701,7 @@ class MongoModuleStore(ModuleStoreBase):
             self.modulestore_update_signal.send(self, modulestore=self, course_id=course_id,
                                                 location=location)
 
-    def get_course_for_item(self, location, depth=0):
+    def _get_course_for_item(self, location, depth=0):
         '''
         VS[compat]
         cdodge: for a given Xmodule, return the course that it belongs to
@@ -790,7 +790,7 @@ class MongoModuleStore(ModuleStoreBase):
         # we should remove this once we can break this reference from the course to static tabs
         loc = Location(location)
         if loc.category == 'static_tab':
-            course = self.get_course_for_item(loc)
+            course = self._get_course_for_item(loc)
             existing_tabs = course.tabs or []
             for tab in existing_tabs:
                 if tab.get('url_slug') == loc.name:
@@ -818,7 +818,7 @@ class MongoModuleStore(ModuleStoreBase):
         # we should remove this once we can break this reference from the course to static tabs
         if location.category == 'static_tab':
             item = self.get_item(location)
-            course = self.get_course_for_item(item.location)
+            course = self._get_course_for_item(item.location)
             existing_tabs = course.tabs or []
             course.tabs = [tab for tab in existing_tabs if tab.get('url_slug') != location.name]
             # Save the updates to the course to the MongoKeyValueStore

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
@@ -345,6 +345,19 @@ class SplitMongoModuleStore(ModuleStoreBase):
         else:
             return []
 
+    def get_instance(self, course_id, location, depth=0):
+        """
+        Get an instance of this location.
+
+        For now, just delegate to get_item and ignore course policy.
+
+        depth (int): An argument that some module stores may use to prefetch
+            descendants of the queried modules for more efficient results later
+            in the request. The depth is counted in the number of
+            calls to get_children() to cache. None indicates to cache all descendants.
+        """
+        return self.get_item(location, depth=depth)
+
     def get_parent_locations(self, locator, usage_id=None):
         '''
         Return the locations (Locators w/ usage_ids) for the parents of this location in this

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_location.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_location.py
@@ -159,3 +159,12 @@ def test_clean_for_html():
 def test_html_id():
     loc = Location("tag://org/course/cat/name:more_name@rev")
     assert_equals(loc.html_id(), "tag-org-course-cat-name_more_name-rev")
+
+
+def test_course_id():
+    loc = Location('i4x', 'mitX', '103', 'course', 'test2')
+    assert_equals('mitX/103/test2', loc.course_id)
+
+    loc = Location('i4x', 'mitX', '103', '_not_a_course', 'test2')
+    with assert_raises(InvalidLocationError):
+        loc.course_id

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore.py
@@ -327,21 +327,29 @@ class SplitModuleItemTests(SplitModuleTest):
         locator = BlockUsageLocator(version_guid=self.GUID_D1, usage_id='head12345')
         block = modulestore().get_item(locator)
         self.assertIsInstance(block, CourseDescriptor)
+        # get_instance just redirects to get_item, ignores course_id
+        self.assertIsInstance(modulestore().get_instance("course_id", locator), CourseDescriptor)
+
+        def verify_greek_hero(block):
+            self.assertEqual(block.location.course_id, "GreekHero")
+
+
+            # look at this one in detail
+            self.assertEqual(len(block.tabs), 6, "wrong number of tabs")
+            self.assertEqual(block.display_name, "The Ancient Greek Hero")
+            self.assertEqual(block.advertised_start, "Fall 2013")
+            self.assertEqual(len(block.children), 3)
+            self.assertEqual(block.definition_locator.definition_id, "head12345_12")
+            # check dates and graders--forces loading of descriptor
+            self.assertEqual(block.edited_by, "testassist@edx.org")
+            self.assertDictEqual(
+                block.grade_cutoffs, {"Pass": 0.45},
+            )
 
         locator = BlockUsageLocator(course_id='GreekHero', usage_id='head12345', branch='draft')
-        block = modulestore().get_item(locator)
-        self.assertEqual(block.location.course_id, "GreekHero")
-        # look at this one in detail
-        self.assertEqual(len(block.tabs), 6, "wrong number of tabs")
-        self.assertEqual(block.display_name, "The Ancient Greek Hero")
-        self.assertEqual(block.advertised_start, "Fall 2013")
-        self.assertEqual(len(block.children), 3)
-        self.assertEqual(block.definition_locator.definition_id, "head12345_12")
-        # check dates and graders--forces loading of descriptor
-        self.assertEqual(block.edited_by, "testassist@edx.org")
-        self.assertDictEqual(
-            block.grade_cutoffs, {"Pass": 0.45},
-        )
+        verify_greek_hero(modulestore().get_item(locator))
+        # get_instance just redirects to get_item, ignores course_id
+        verify_greek_hero(modulestore().get_instance("course_id", locator))
 
         # try to look up other branches
         self.assertRaises(ItemNotFoundError,

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore.py
@@ -332,9 +332,6 @@ class SplitModuleItemTests(SplitModuleTest):
 
         def verify_greek_hero(block):
             self.assertEqual(block.location.course_id, "GreekHero")
-
-
-            # look at this one in detail
             self.assertEqual(len(block.tabs), 6, "wrong number of tabs")
             self.assertEqual(block.display_name, "The Ancient Greek Hero")
             self.assertEqual(block.advertised_start, "Fall 2013")
@@ -463,7 +460,7 @@ class SplitModuleItemTests(SplitModuleTest):
         parents = modulestore().get_parent_locations(locator)
         self.assertEqual(len(parents), 1)
         self.assertEqual(parents[0].usage_id, 'head12345')
-        locator.usage_id='nosuchblock'
+        locator.usage_id = 'nosuchblock'
         parents = modulestore().get_parent_locations(locator)
         self.assertEqual(len(parents), 0)
 


### PR DESCRIPTION
https://edx-wiki.atlassian.net/browse/STUD-617

Some details:
1. modulestore().get_containing_courses was only used in one place, and wasn't actually needed there. I deleted it.
2. get_errored_courses only makes sense for XML modulestore (it wasn't a method of the base class) and was only used in one place. I made that place check if the modulestore has the method.  Deleted dummy implementations from the other modulestores.
3. mongo's get_course_for_item method is just a helper function internal to that modulestore. Renamed it to make it more obvious, and deleted dummy implementation in split.
4. Had to add arguments to some of the split methods to make the API consistent. Documented when these arguments are not used.
