### PR TITLE
Jbau/edx west/stop ajax track 500s

### DIFF
--- a/common/djangoapps/track/views.py
+++ b/common/djangoapps/track/views.py
@@ -60,10 +60,10 @@ def user_track(request):
         "session": scookie,
         "ip": request.META['REMOTE_ADDR'],
         "event_source": "browser",
-        "event_type": request.REQUEST['event_type'],
-        "event": request.REQUEST['event'],
+        "event_type": request.REQUEST.get('event_type','unknown'),
+        "event": request.REQUEST.get('event','unknown'),
         "agent": agent,
-        "page": request.REQUEST['page'],
+        "page": request.REQUEST.get('page', 'unknown'),
         "time": datetime.datetime.now(UTC).isoformat(),
         "host": request.META['SERVER_NAME'],
     }


### PR DESCRIPTION
@sefk @jrbl 
This only provides defaults for REQUEST, which is a concat of POST and GET:
https://docs.djangoproject.com/en/1.4/ref/request-response/#django.http.HttpRequest.REQUEST
