### PR TITLE
Fix error seen in combinedopenended modules

### DIFF
--- a/common/lib/xmodule/xmodule/combined_open_ended_module.py
+++ b/common/lib/xmodule/xmodule/combined_open_ended_module.py
@@ -8,7 +8,7 @@ from .x_module import XModule
 from xblock.core import Integer, Scope, String, List, Float, Boolean
 from xmodule.open_ended_grading_classes.combined_open_ended_modulev1 import CombinedOpenEndedV1Module, CombinedOpenEndedV1Descriptor
 from collections import namedtuple
-from .fields import Date
+from .fields import Date, Timedelta
 import textwrap
 
 log = logging.getLogger("mitx.courseware")
@@ -229,7 +229,7 @@ class CombinedOpenEndedFields(object):
         default=None,
         scope=Scope.settings
     )
-    graceperiod = String(
+    graceperiod = Timedelta(
         help="Amount of time after the due date that submissions will be accepted",
         default=None,
         scope=Scope.settings

--- a/common/lib/xmodule/xmodule/fields.py
+++ b/common/lib/xmodule/xmodule/fields.py
@@ -82,6 +82,9 @@ TIMEDELTA_REGEX = re.compile(r'^((?P<days>\d+?) day(?:s?))?(\s)?((?P<hours>\d+?)
 
 
 class Timedelta(ModelType):
+    # Timedeltas are immutable, see http://docs.python.org/2/library/datetime.html#available-types
+    MUTABLE = False
+
     def from_json(self, time_str):
         """
         time_str: A string with the following components:


### PR DESCRIPTION
Had to change graceperiod to be a Timedelta, as it is in:

```
common/lib/xmodule/xmodule/capa_module.py:97:    graceperiod = Timedelta(
common/lib/xmodule/xmodule/peer_grading_module.py:51:    graceperiod = Timedelta(
lms/xmodule_namespace.py:40:    graceperiod = Timedelta(
```

Also, change `Timedelta`s to be immutable field types. This will alleviate a lot of the errors we see because the Timedelta class doesn't do json roundtrips correctly, and only mutable types are marked as dirty when we access them (immutable types are only marked as dirty on a **set**). Plus, Timedeltas ARE immutable, so this is safe. See http://docs.python.org/2/library/datetime.html#available-types

@cpennington 

Not sure who else to tag
