### PR TITLE
turn off i18n

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -201,7 +201,7 @@ STATICFILES_DIRS = [
 TIME_ZONE = 'America/New_York'  # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
 LANGUAGE_CODE = 'en'  # http://www.i18nguy.com/unicode/language-identifiers.html
 
-USE_I18N = True
+USE_I18N = False
 USE_L10N = True
 
 # Localization strings (e.g. django.po) are under this directory

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -378,7 +378,7 @@ FAVICON_PATH = 'images/favicon.ico'
 # Locale/Internationalization
 TIME_ZONE = 'America/New_York'  # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
 LANGUAGE_CODE = 'en'  # http://www.i18nguy.com/unicode/language-identifiers.html
-USE_I18N = True
+USE_I18N = False
 USE_L10N = True
 
 # Localization strings (e.g. django.po) are under this directory


### PR DESCRIPTION
Turns off i18n to stop django from automatically translating prewritten templates

@jtauber 
@cpennington , fixes https://edx-wiki.atlassian.net/browse/LMS-912
