### PR TITLE
capa optioninput template was missing msg output (needed for hints)

### DIFF
--- a/common/lib/capa/capa/templates/optioninput.html
+++ b/common/lib/capa/capa/templates/optioninput.html
@@ -29,4 +29,9 @@
     <span class="sr">Status: incomplete</span>
   </span>
   % endif
+
+  % if msg:
+      <span class="message">${msg|n}</span>
+  % endif
+
 </form>


### PR DESCRIPTION
compare with textline template (https://github.com/edx/edx-platform/blob/master/common/lib/capa/capa/templates/textline.html#L61)
