### PR TITLE
Fix grade range names not being editable.

### DIFF
--- a/cms/djangoapps/contentstore/features/grading.feature
+++ b/cms/djangoapps/contentstore/features/grading.feature
@@ -84,3 +84,12 @@ Feature: Course Grading
         And I am viewing the grading settings
         When I change assignment type "Homework" to ""
         Then the save button is disabled
+
+    Scenario: User can edit grading range names
+        Given I have opened a new course in Studio
+        And I have populated the course
+        And I am viewing the grading settings
+        When I change the highest grade range to "Good"
+        And I press the "Save" notification button
+        And I reload the page
+        Then I see the highest grade range is "Good"

--- a/cms/djangoapps/contentstore/features/grading.py
+++ b/cms/djangoapps/contentstore/features/grading.py
@@ -117,6 +117,19 @@ def i_see_the_assignment_type(_step, name):
       assert name in types
 
 
+@step(u'I change the highest grade range to "(.*)"$')
+def change_grade_range(_step, range_name):
+    range_css = 'span.letter-grade'
+    grade = world.css_find(range_css).first
+    grade.value = range_name
+
+
+@step(u'I see the highest grade range is "(.*)"$')
+def i_see_highest_grade_range(_step, range_name):
+    range_css = 'span.letter-grade'
+    grade = world.css_find(range_css).first
+    assert grade.value == range_name
+
 def get_type_index(name):
     name_id = '#course-grading-assignment-name'
     all_types = world.css_find(name_id)

--- a/cms/static/js/views/settings/settings_grading_view.js
+++ b/cms/static/js/views/settings/settings_grading_view.js
@@ -8,7 +8,7 @@ CMS.Views.Settings.Grading = CMS.Views.ValidatingView.extend({
         // Leaving change in as fallback for older browsers
         "change input" : "updateModel",
         "change textarea" : "updateModel",
-        "change span[contenteditable=true]" : "updateDesignation",
+        "input span[contenteditable]" : "updateDesignation",
         "click .settings-extra header" : "showSettingsExtras",
         "click .new-grade-button" : "addNewGrade",
         "click .remove-button" : "removeGrade",


### PR DESCRIPTION
@dmitchell Simple fix -- span elements don't receive the change event. Added a quick test as well.
