### PR TITLE
Enable the django_nose app by default

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -332,6 +332,9 @@ INSTALLED_APPS = (
     # Monitor the status of services
     'service_status',
 
+    # Testing
+    'django_nose',
+
     # For CMS
     'contentstore',
     'auth',
@@ -339,7 +342,7 @@ INSTALLED_APPS = (
     'student',  # misleading name due to sharing with lms
     'course_groups',  # not used in cms (yet), but tests run
 
-    # tracking
+    # Tracking
     'track',
 
     # For asset pipelining

--- a/cms/envs/test.py
+++ b/cms/envs/test.py
@@ -18,7 +18,6 @@ from path import path
 from warnings import filterwarnings
 
 # Nose Test Runner
-INSTALLED_APPS += ('django_nose',)
 TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 
 TEST_ROOT = path('test_root')

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -758,6 +758,7 @@ INSTALLED_APPS = (
 
     # For testing
     'django.contrib.admin',  # only used in DEBUG mode
+    'django_nose',
     'debug',
 
     # Discussion forums
@@ -816,4 +817,3 @@ def enable_theme(theme_name):
     # avoid collisions with default edX static files
     STATICFILES_DIRS.append((u'themes/%s' % theme_name,
                              theme_root / 'static'))
-

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -39,8 +39,6 @@ WIKI_ENABLED = True
 SOUTH_TESTS_MIGRATE = False   # To disable migrations and use syncdb instead
 
 # Nose Test Runner
-INSTALLED_APPS += ('django_nose',)
-
 TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 
 # Local Directories


### PR DESCRIPTION
The django_nose it is very useful, even outside the test environment. For example, it lets you to easily run test from manage.py without additional changes to the test packages.
