### PR TITLE
Jonahstanley/help acceptance test

### DIFF
--- a/lms/djangoapps/courseware/features/common.py
+++ b/lms/djangoapps/courseware/features/common.py
@@ -66,6 +66,13 @@ def add_tab_to_course(_step, course, extra_tab_name):
         display_name=str(extra_tab_name))
 
 
+@step(u'I am in a course$')
+def go_into_course(step):
+    step.given('I am registered for the course "6.002x"')
+    step.given('And I am logged in')
+    step.given('And I click on View Courseware')
+
+
 def course_id(course_num):
     return "%s/%s/%s" % (world.scenario_dict['COURSE'].org, course_num,
                          world.scenario_dict['COURSE'].display_name.replace(" ", "_"))

--- a/lms/djangoapps/courseware/features/help.feature
+++ b/lms/djangoapps/courseware/features/help.feature
@@ -8,11 +8,11 @@ Feature: The help module should work
     Given I visit the homepage
     When I open the help form
     And I report a "problem"
-    Then I should see confirmation that the problem was received
+    Then I should see confirmation that the issue was received
 
   Scenario: I can submit a problem when I am logged in
     Given I am in a course
     When I open the help form
     And I report a "problem" without saying who I am
-    Then I should see confirmation that the problem was received
+    Then I should see confirmation that the issue was received
 

--- a/lms/djangoapps/courseware/features/help.feature
+++ b/lms/djangoapps/courseware/features/help.feature
@@ -6,23 +6,13 @@ Feature: The help module should work
 
   Scenario: I can submit a problem when I am not logged in
     Given I visit the homepage
-    When I click the help modal
+    When I open the help form
     And I report a "problem"
-    And I fill "name" with "Robot"
-    And I fill "email" with "Robot@edx.org"
-    And I fill "subject" with "Test Issue"
-    And I fill "details" with "I am having a problem"
-    And I submit the issue
-    Then The submit button should be disabled
+    Then I should see confirmation that the problem was received
 
   Scenario: I can submit a problem when I am logged in
-    Given I am registered for the course "6.002x"
-    And I am logged in
-    And I click on View Courseware
-    When I click the help modal
-    And I report a "problem"
-    And I fill "subject" with "Test Issue"
-    And I fill "details" with "I am having a problem"
-    And I submit the issue
-    Then The submit button should be disabled
+    Given I am in a course
+    When I open the help form
+    And I report a "problem" without saying who I am
+    Then I should see confirmation that the problem was received
 

--- a/lms/djangoapps/courseware/features/help.feature
+++ b/lms/djangoapps/courseware/features/help.feature
@@ -7,12 +7,25 @@ Feature: The help module should work
   Scenario: I can submit a problem when I am not logged in
     Given I visit the homepage
     When I open the help form
-    And I report a "problem"
+    And I report a "<FeedbackType>"
     Then I should see confirmation that the issue was received
+
+        Examples:
+        | FeedbackType      |
+        | problem           |
+        | suggestion        |
+        | question          |
+
 
   Scenario: I can submit a problem when I am logged in
     Given I am in a course
     When I open the help form
-    And I report a "problem" without saying who I am
+    And I report a "<FeedbackType>" without saying who I am
     Then I should see confirmation that the issue was received
+
+        Examples:
+        | FeedbackType      |
+        | problem           |
+        | suggestion        |
+        | question          |
 

--- a/lms/djangoapps/courseware/features/help.feature
+++ b/lms/djangoapps/courseware/features/help.feature
@@ -1,0 +1,28 @@
+Feature: The help module should work
+  In order to get help
+  As a student
+  I want to be able to report a problem
+
+
+  Scenario: I can submit a problem when I am not logged in
+    Given I visit the homepage
+    When I click the help modal
+    And I report a "problem"
+    And I fill "name" with "Robot"
+    And I fill "email" with "Robot@edx.org"
+    And I fill "subject" with "Test Issue"
+    And I fill "details" with "I am having a problem"
+    And I submit the issue
+    Then The submit button should be disabled
+
+  Scenario: I can submit a problem when I am logged in
+    Given I am registered for the course "6.002x"
+    And I am logged in
+    And I click on View Courseware
+    When I click the help modal
+    And I report a "problem"
+    And I fill "subject" with "Test Issue"
+    And I fill "details" with "I am having a problem"
+    And I submit the issue
+    Then The submit button should be disabled
+

--- a/lms/djangoapps/courseware/features/help.py
+++ b/lms/djangoapps/courseware/features/help.py
@@ -44,6 +44,8 @@ def go_into_course(step):
 
 
 def fill_field(name, info):
-    form_css = 'form.feedback_form'
-    form = world.css_find(form_css)
-    form.find_by_name(name).fill(info)
+    def fill_info():
+        form_css = 'form.feedback_form'
+        form = world.css_find(form_css)
+        form.find_by_name(name).fill(info)
+    world.retry_on_exception(fill_info)

--- a/lms/djangoapps/courseware/features/help.py
+++ b/lms/djangoapps/courseware/features/help.py
@@ -3,6 +3,7 @@
 
 from lettuce import world, step
 
+
 @step(u'I open the help form')
 def open_help_modal(step):
     help_css = 'div.help-tab'

--- a/lms/djangoapps/courseware/features/help.py
+++ b/lms/djangoapps/courseware/features/help.py
@@ -36,13 +36,6 @@ def see_confirmation(step):
     assert world.browser.evaluate_script("$('input[value=\"Submit\"]').attr('disabled')") == 'disabled'
 
 
-@step(u'I am in a course')
-def go_into_course(step):
-    step.given('I am registered for the course "6.002x"')
-    step.given('And I am logged in')
-    step.given('And I click on View Courseware')
-
-
 def fill_field(name, info):
     def fill_info():
         form_css = 'form.feedback_form'

--- a/lms/djangoapps/courseware/features/help.py
+++ b/lms/djangoapps/courseware/features/help.py
@@ -31,7 +31,7 @@ def submit_partial_problem_type(step, submission_type):
     world.css_click(submit_css)
 
 
-@step(u'I should see confirmation that the problem was received')
+@step(u'I should see confirmation that the issue was received')
 def see_confirmation(step):
     assert world.browser.evaluate_script("$('input[value=\"Submit\"]').attr('disabled')") == 'disabled'
 

--- a/lms/djangoapps/courseware/features/help.py
+++ b/lms/djangoapps/courseware/features/help.py
@@ -3,31 +3,47 @@
 
 from lettuce import world, step
 
-@step(u'I click the help modal')
+@step(u'I open the help form')
 def open_help_modal(step):
-	help_css = 'div.help-tab'
-	world.css_click(help_css)
+    help_css = 'div.help-tab'
+    world.css_click(help_css)
 
 
 @step(u'I report a "([^"]*)"$')
-def select_problem_type(step, submission_type):
-	type_css = '#feedback_link_{}'.format(submission_type)
-	world.css_click(type_css)
+def submit_problem_type(step, submission_type):
+    type_css = '#feedback_link_{}'.format(submission_type)
+    world.css_click(type_css)
+    fill_field('name', 'Robot')
+    fill_field('email', 'robot@edx.org')
+    fill_field('subject', 'Test Issue')
+    fill_field('details', 'I am having a problem')
+    submit_css = 'div.submit'
+    world.css_click(submit_css)
 
 
-@step(u'I fill "([^"]*)" with "([^"]*)"$')
-def fill_field(step, name, info):
-	form_css = 'form.feedback_form'
-	form = world.css_find(form_css)
-	form.find_by_name(name).fill(info)
+@step(u'I report a "([^"]*)" without saying who I am$')
+def submit_partial_problem_type(step, submission_type):
+    type_css = '#feedback_link_{}'.format(submission_type)
+    world.css_click(type_css)
+    fill_field('subject', 'Test Issue')
+    fill_field('details', 'I am having a problem')
+    submit_css = 'div.submit'
+    world.css_click(submit_css)
 
 
-@step(u'I submit the issue')
-def submit_issue(step):
-	submit_css = 'div.submit'
-	world.css_click(submit_css)
-
-
-@step(u'The submit button should be disabled')
+@step(u'I should see confirmation that the problem was received')
 def see_confirmation(step):
-	assert world.browser.evaluate_script("$('input[value=\"Submit\"]').attr('disabled')") == 'disabled'
+    assert world.browser.evaluate_script("$('input[value=\"Submit\"]').attr('disabled')") == 'disabled'
+
+
+@step(u'I am in a course')
+def go_into_course(step):
+    step.given('I am registered for the course "6.002x"')
+    step.given('And I am logged in')
+    step.given('And I click on View Courseware')
+
+
+def fill_field(name, info):
+    form_css = 'form.feedback_form'
+    form = world.css_find(form_css)
+    form.find_by_name(name).fill(info)

--- a/lms/djangoapps/courseware/features/help.py
+++ b/lms/djangoapps/courseware/features/help.py
@@ -1,0 +1,33 @@
+#pylint: disable=C0111
+#pylint: disable=W0621
+
+from lettuce import world, step
+
+@step(u'I click the help modal')
+def open_help_modal(step):
+	help_css = 'div.help-tab'
+	world.css_click(help_css)
+
+
+@step(u'I report a "([^"]*)"$')
+def select_problem_type(step, submission_type):
+	type_css = '#feedback_link_{}'.format(submission_type)
+	world.css_click(type_css)
+
+
+@step(u'I fill "([^"]*)" with "([^"]*)"$')
+def fill_field(step, name, info):
+	form_css = 'form.feedback_form'
+	form = world.css_find(form_css)
+	form.find_by_name(name).fill(info)
+
+
+@step(u'I submit the issue')
+def submit_issue(step):
+	submit_css = 'div.submit'
+	world.css_click(submit_css)
+
+
+@step(u'The submit button should be disabled')
+def see_confirmation(step):
+	assert world.browser.evaluate_script("$('input[value=\"Submit\"]').attr('disabled')") == 'disabled'

--- a/lms/envs/acceptance.py
+++ b/lms/envs/acceptance.py
@@ -87,6 +87,9 @@ MITX_FEATURES['AUTOMATIC_AUTH_FOR_TESTING'] = True
 # We do not yet understand why this occurs. Setting this to true is a stopgap measure
 USE_I18N = True
 
+MITX_FEATURES['ENABLE_FEEDBACK_SUBMISSION'] = True
+FEEDBACK_SUBMISSION_EMAIL = 'dummy@example.com'
+
 # Include the lettuce app for acceptance testing, including the 'harvest' django-admin command
 INSTALLED_APPS += ('lettuce.django',)
 LETTUCE_APPS = ('courseware',)


### PR DESCRIPTION
Suggested Reviewers: @wedaly @jzoldak 
This is a feature to test the help modal.  In order to turn on the feature, the two feature flags are used in acceptance.py.  I have confirmed locally that this will not affect the other acceptance tests.

This feature has two scenarios, one when the user is logged in and one when the user isn't.  The difference being that when the user is logged in, they do not need to enter in their name or email address.  The only confirmation it seems that the problem was submitted is that the submit button becomes disabled.  The only way to check for this is to check its attribute using jquery.  
