### PR TITLE
fixed typo in faculty member settings text

### DIFF
--- a/cms/templates/settings_discussions_faculty.html
+++ b/cms/templates/settings_discussions_faculty.html
@@ -37,7 +37,7 @@ from contentstore import utils
             <section class="settings-faculty-members">
               <header>
                 <h3>${_("Faculty Members")}</h3>
-                <span class="detail">${_("Individuals instructing and help with this course")}</span>
+                <span class="detail">${_("Individuals instructing and helping with this course")}</span>
               </header>
 
               <div class="row">


### PR DESCRIPTION
This was confusing translators as didn't make sense in English
