### PR TITLE
fixed encoding declaration

### DIFF
--- a/common/djangoapps/student/management/commands/anonymized_id_mapping.py
+++ b/common/djangoapps/student/management/commands/anonymized_id_mapping.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 """Dump username,unique_id_for_user pairs as CSV.
 
 Give instructors easy access to the mapping from anonymized IDs to user IDs


### PR DESCRIPTION
xgettext seems to only like `utf-8` not `utf8` so string extraction
was failing without this change

Please review @jrbl 
