### PR TITLE
add sysadmin dashboard for Studio

### DIFF
--- a/cms/djangoapps/contentstore/views/__init__.py
+++ b/cms/djangoapps/contentstore/views/__init__.py
@@ -16,6 +16,9 @@ from .preview import *
 from .public import *
 from .user import *
 from .tabs import *
+from .requests import *
+from .sysadmin import * 
+
 try:
     from .dev import *
 except ImportError:

--- a/cms/djangoapps/contentstore/views/__init__.py
+++ b/cms/djangoapps/contentstore/views/__init__.py
@@ -16,7 +16,6 @@ from .preview import *
 from .public import *
 from .user import *
 from .tabs import *
-from .requests import *
 from .sysadmin import * 
 
 try:

--- a/cms/djangoapps/contentstore/views/sysadmin.py
+++ b/cms/djangoapps/contentstore/views/sysadmin.py
@@ -17,6 +17,9 @@ import json
 sysadmin
 """
 
+
+@login_required
+@ensure_csrf_cookie
 def sysadmin(request):
     """
     sysadmin page: for now, just list courses and allow deletion
@@ -92,7 +95,6 @@ def sysadmin(request):
         cinfo = db.modulestore.find_one({'_id.course':course, '_id.category':'course'}) or {}
         id = cinfo.get('_id',cinfo)
         name = id.get('name',id)
-        #print "course %s: %s" % (course, name)
         ctab[course] = name
         idtab[course] = id
 

--- a/cms/djangoapps/contentstore/views/sysadmin.py
+++ b/cms/djangoapps/contentstore/views/sysadmin.py
@@ -2,10 +2,11 @@ import subprocess
 import logging
 
 from django_future.csrf import ensure_csrf_cookie
-from django.core.context_processors import csrf
+from django.contrib.auth.decorators import login_required
 from django.shortcuts import redirect
 from django.conf import settings
 from django.http import HttpResponse
+from django.utils.translation import ugettext as _
 
 from mitxmako.shortcuts import render_to_response
 
@@ -38,15 +39,15 @@ def sysadmin(request):
 
     if action=='delete':
         if not course_id:
-            msg += "<font color='red'>Error - no course specified</font>"
+            msg += "<font color='red'>{0}</font>".format(_('Error - no course specified'))
         else:
             nrec = db.modulestore.find({'_id.course': course_id}).count()
             if not 'really' in request.GET:
-                msg += "Really delete course %s?\n" % course_id
-                msg += "%d records for this course in the database" % nrec
+                msg += _("Really delete course {0}?\n").format(course_id)
+                msg += _("{0} records for this course in the database").format(nrec)
                 logging.debug('Delete course %s requested' % course_id)
             else:
-                msg += "deleting %s" % course_id
+                msg += _("deleting {0}").format(course_id)
                 data = db.modulestore.find({'_id.course': course_id})
                 fn = 'course-%s-dump-%s.json' % (course_id, time.ctime(time.time()).replace(' ','_'))
                 fp = open('%s/%s' % (bdir,fn), 'w')
@@ -54,13 +55,13 @@ def sysadmin(request):
                     fp.write(json.dumps(d)+'\n')
                 fp.close()
                 db.modulestore.remove({'_id.course': course_id})
-                msg += "%d records for %s removed (backup file %s)" % (nrec, course_id, fn)
+                msg += _("{0} records for {1} removed (backup file {2})").format(nrec, course_id, fn)
                 logging.debug('Course %s deleted!' % course_id)
                 action = ""
 
     elif action=='dump':
         if not course_id:
-            msg += "<font color='red'>Error - no course specified</font>"
+            msg += "<font color='red'>{0}</font>".format(_("Error - no course specified"))
         else:
             data = db.modulestore.find({'_id.course': course_id})
             response = HttpResponse(mimetype='text/json')
@@ -82,7 +83,7 @@ def sysadmin(request):
         ret = subprocess.Popen(cmd, shell=True, executable = "/bin/bash",
                                stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
         ret = ''.join(ret)
-        msg = "<font color='red'>Added course from {0}</font>".format(giturl)
+        msg = "<font color='red'>{0} {1}</font>".format(_("Added course from"), giturl)
         msg += "<pre>{0}</pre>".format(ret.replace('<','&lt;'))
 
     #-----------------------------------------------------------------------------

--- a/cms/djangoapps/contentstore/views/sysadmin.py
+++ b/cms/djangoapps/contentstore/views/sysadmin.py
@@ -1,0 +1,105 @@
+import subprocess
+import logging
+
+from django_future.csrf import ensure_csrf_cookie
+from django.core.context_processors import csrf
+from django.shortcuts import redirect
+from django.conf import settings
+from django.http import HttpResponse
+
+from mitxmako.shortcuts import render_to_response
+
+import pymongo
+import time
+import json
+
+"""
+sysadmin
+"""
+
+def sysadmin(request):
+    """
+    sysadmin page: for now, just list courses and allow deletion
+    """
+    if (not request.user) or (not request.user.is_staff):
+        return redirect('login')
+    
+    client = pymongo.MongoClient()
+    db = client.xmodule
+
+    msg = ''
+    bdir = "DATA-BACKUP"
+    
+    action = request.GET.get('action', request.POST.get('action', ''))
+    course_id = request.GET.get('course_id', '')
+
+    if action=='delete':
+        if not course_id:
+            msg += "<font color='red'>Error - no course specified</font>"
+        else:
+            nrec = db.modulestore.find({'_id.course': course_id}).count()
+            if not 'really' in request.GET:
+                msg += "Really delete course %s?\n" % course_id
+                msg += "%d records for this course in the database" % nrec
+                logging.debug('Delete course %s requested' % course_id)
+            else:
+                msg += "deleting %s" % course_id
+                data = db.modulestore.find({'_id.course': course_id})
+                fn = 'course-%s-dump-%s.json' % (course_id, time.ctime(time.time()).replace(' ','_'))
+                fp = open('%s/%s' % (bdir,fn), 'w')
+                for d in data:
+                    fp.write(json.dumps(d)+'\n')
+                fp.close()
+                db.modulestore.remove({'_id.course': course_id})
+                msg += "%d records for %s removed (backup file %s)" % (nrec, course_id, fn)
+                logging.debug('Course %s deleted!' % course_id)
+                action = ""
+
+    elif action=='dump':
+        if not course_id:
+            msg += "<font color='red'>Error - no course specified</font>"
+        else:
+            data = db.modulestore.find({'_id.course': course_id})
+            response = HttpResponse(mimetype='text/json')
+            fn = 'course-%s-dump-%s.json' % (course_id, time.ctime(time.time()).replace(' ','_'))
+            response['Content-Disposition'] = 'attachment; filename={0}'.format(fn)
+            data = db.modulestore.find({'_id.course': course_id})
+            for d in data:
+                response.write(json.dumps(d)+'\n')
+            return response
+        
+    elif action=='Add Course' and request.method=='POST':
+        '''
+        Add course by running external script, given git URL provided in input form
+        '''
+        giturl = request.POST.get('giturl', '')
+        acscript = getattr(settings, 'CMS_ADD_COURSE_SCRIPT', '')
+        cmd = '{0} "{1}"'.format(acscript, giturl)
+        logging.debug('Adding course with command: {0}'.format(cmd))
+        ret = subprocess.Popen(cmd, shell=True, executable = "/bin/bash",
+                               stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
+        ret = ''.join(ret)
+        msg = "<font color='red'>Added course from {0}</font>".format(giturl)
+        msg += "<pre>{0}</pre>".format(ret.replace('<','&lt;'))
+
+    #-----------------------------------------------------------------------------
+    # get list of courses
+    
+    ctab = {}
+    idtab = {}
+    courses = db.modulestore.distinct('_id.course')
+    for course in courses:
+        cinfo = db.modulestore.find_one({'_id.course':course, '_id.category':'course'}) or {}
+        id = cinfo.get('_id',cinfo)
+        name = id.get('name',id)
+        #print "course %s: %s" % (course, name)
+        ctab[course] = name
+        idtab[course] = id
+
+    context = {'ctab': ctab,
+               'idtab': idtab,
+               'msg': msg, 
+               'course_id': course_id, 
+               'action': action,
+               }
+    return render_to_response('sysadmin.html', context)

--- a/cms/djangoapps/contentstore/views/sysadmin.py
+++ b/cms/djangoapps/contentstore/views/sysadmin.py
@@ -32,7 +32,7 @@ def sysadmin(request):
     db = client.xmodule
 
     msg = ''
-    bdir = "DATA-BACKUP"
+    bdir = settings.getattr('DELETED_COURSE_BACKUPS_DIR', None)
     
     action = request.GET.get('action', request.POST.get('action', ''))
     course_id = request.GET.get('course_id', '')
@@ -50,10 +50,11 @@ def sysadmin(request):
                 msg += _("deleting {0}").format(course_id)
                 data = db.modulestore.find({'_id.course': course_id})
                 fn = 'course-%s-dump-%s.json' % (course_id, time.ctime(time.time()).replace(' ','_'))
-                fp = open('%s/%s' % (bdir,fn), 'w')
-                for d in data:
-                    fp.write(json.dumps(d)+'\n')
-                fp.close()
+                if bdir is not None:
+                    fp = open('%s/%s' % (bdir,fn), 'w')
+                    for d in data:
+                        fp.write(json.dumps(d)+'\n')
+                    fp.close()
                 db.modulestore.remove({'_id.course': course_id})
                 msg += _("{0} records for {1} removed (backup file {2})").format(nrec, course_id, fn)
                 logging.debug('Course %s deleted!' % course_id)

--- a/cms/djangoapps/contentstore/views/sysadmin.py
+++ b/cms/djangoapps/contentstore/views/sysadmin.py
@@ -32,7 +32,7 @@ def sysadmin(request):
     db = client.xmodule
 
     msg = ''
-    bdir = settings.getattr('DELETED_COURSE_BACKUPS_DIR', None)
+    bdir = getattr(settings, 'DELETED_COURSE_BACKUPS_DIR', None)
     
     action = request.GET.get('action', request.POST.get('action', ''))
     course_id = request.GET.get('course_id', '')

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -81,6 +81,11 @@ sys.path.append(PROJECT_ROOT / 'lib')
 sys.path.append(COMMON_ROOT / 'djangoapps')
 sys.path.append(COMMON_ROOT / 'lib')
 
+########## DIRECTORY WHERE DELETED COURSE CONTENT IS BACKED UP ##############
+
+# for example:
+# DELETED_COURSE_BACKUPS_DIR = ENV_ROOT / "data_backup"
+DELETED_COURSE_BACKUPS_DIR = None    # no backups
 
 ############################# WEB CONFIGURATION #############################
 # This is where we stick our compiled template files.

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -62,6 +62,9 @@ MITX_FEATURES = {
     # If set to True, new Studio users won't be able to author courses unless
     # edX has explicitly added them to the course creator group.
     'ENABLE_CREATOR_GROUP': False,
+
+    # Turns on or off the 'sysadmin' page used by MITx instances
+    'ENABLE_MITX_SYSADMIN_PAGE': False
 }
 ENABLE_JASMINE = False
 

--- a/cms/templates/sysadmin.html
+++ b/cms/templates/sysadmin.html
@@ -1,0 +1,42 @@
+<%inherit file="base.html" />
+
+<%block name="content">
+  <article>
+    % if action=="delete":
+      <font color="red">Really delete ${course_id}?</font>
+      <a href="/sysadmin">No (Cancel)</a>
+      <a style="float:right" href="/sysadmin?action=delete&course_id=${course_id}&really=1">Yes&nbsp;&nbsp;</a>
+    % endif
+
+    <pre>
+     ${msg}
+    </pre>
+    <hr width="50%"/>
+    <table border="1">
+    % for cid in sorted(ctab.iterkeys()):
+        <%
+	    id = idtab[cid]
+	    org = id.get('org','')
+	    name = id.get('name','')
+	    nameurl = name.replace(' ','_')
+	%>
+        <tr>
+	    <td><a href="/${org}/${cid}/course/${nameurl}">GO</a>&nbsp;| </td>
+	    <td><a href="/${org}/${cid}/generate_export/${nameurl}">tar.gz export</a>&nbsp; |</td>
+	    <td><a href="/sysadmin?action=dump&course_id=${cid}">db dump</a>&nbsp; |</td>
+	    <td><a href="/sysadmin?action=delete&course_id=${cid}">delete</a>&nbsp; |</td>
+	    <td>${cid}</td>
+	    <td>${name}</td>
+	</tr>
+    % endfor
+    </table>
+    
+    <br/>
+    <hr width="75%" />
+    <form name="sysadminform" method="POST" action="/sysadmin">
+    <input type="hidden" name="csrfmiddlewaretoken" value="${ csrf_token }">
+        git ssh url: <input size="60" name="giturl" />
+	<input type="submit" name="action" value="Add Course"/>
+    </form>
+  </article>
+</%block>

--- a/cms/templates/sysadmin.html
+++ b/cms/templates/sysadmin.html
@@ -1,11 +1,12 @@
 <%inherit file="base.html" />
+<%! from django.utils.translation import ugettext as _ %>
 
 <%block name="content">
   <article>
     % if action=="delete":
-      <font color="red">Really delete ${course_id}?</font>
+      <font color="red">${_("Really delete {0}").format(course_id)}?</font>
       <a href="/sysadmin">No (Cancel)</a>
-      <a style="float:right" href="/sysadmin?action=delete&course_id=${course_id}&really=1">Yes&nbsp;&nbsp;</a>
+      <a style="float:right" href="/sysadmin?action=delete&course_id=${course_id}&really=1">${_("Yes")}&nbsp;&nbsp;</a>
     % endif
 
     <pre>
@@ -21,10 +22,10 @@
 	    nameurl = name.replace(' ','_')
 	%>
         <tr>
-	    <td><a href="/${org}/${cid}/course/${nameurl}">GO</a>&nbsp;| </td>
-	    <td><a href="/${org}/${cid}/generate_export/${nameurl}">tar.gz export</a>&nbsp; |</td>
-	    <td><a href="/sysadmin?action=dump&course_id=${cid}">db dump</a>&nbsp; |</td>
-	    <td><a href="/sysadmin?action=delete&course_id=${cid}">delete</a>&nbsp; |</td>
+	    <td><a href="/${org}/${cid}/course/${nameurl}">${_("GO")}</a>&nbsp;| </td>
+	    <td><a href="/${org}/${cid}/generate_export/${nameurl}">${_("tar.gz export")}</a>&nbsp; |</td>
+	    <td><a href="/sysadmin?action=dump&course_id=${cid}">${_("db dump")}</a>&nbsp; |</td>
+	    <td><a href="/sysadmin?action=delete&course_id=${cid}">${_("delete")}</a>&nbsp; |</td>
 	    <td>${cid}</td>
 	    <td>${name}</td>
 	</tr>
@@ -36,7 +37,7 @@
     <form name="sysadminform" method="POST" action="/sysadmin">
     <input type="hidden" name="csrfmiddlewaretoken" value="${ csrf_token }">
         git ssh url: <input size="60" name="giturl" />
-	<input type="submit" name="action" value="Add Course"/>
+	<input type="submit" name="action" value="${_("Add Course")}"/>
     </form>
   </article>
 </%block>

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -24,6 +24,7 @@ urlpatterns = patterns('',  # nopep8
     url(r'^unpublish_unit$', 'contentstore.views.unpublish_unit', name='unpublish_unit'),
     url(r'^create_new_course', 'contentstore.views.create_new_course', name='create_new_course'),
     url(r'^reorder_static_tabs', 'contentstore.views.reorder_static_tabs', name='reorder_static_tabs'),
+    url(r'^sysadmin', 'contentstore.views.sysadmin', name='sysadmin'),
 
     url(r'^(?P<org>[^/]+)/(?P<course>[^/]+)/import/(?P<name>[^/]+)$',
         'contentstore.views.import_course', name='import_course'),


### PR DESCRIPTION
It is useful for sysadmin staff to be able to:
- Purge the mongodb of course fragments, which match course id's but are not deleted through the normal django management command (which deletes only entries linked in the course tree).  We've seen such course content corruption in the database happen several times, associated with course teams importing `.tar.gz` files with errors.
- Load course from a git url via a web interface
- Get JSON dump of course content directly from the mongodb (eg for quick and exact transfer of course modules to another Studio instance).

This PR provides those features, via a rudimentary but functional dashboard.

No tests provided. 
