### PR TITLE
Bug fix -- subcategories in forums topic list should now be sorted alphabetically

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,9 @@ These are notable changes in edx-platform.  This is a rolling list of changes,
 in roughly chronological order, most recent first.  Add your entries at or near
 the top.  Include a label indicating the component affected.
 
+LMS: Added alphabetical sorting of forum categories and subcategories.
+It is hidden behind a false defaulted course level flag.
+
 Studio: Allow course authors to set their course image on the schedule
 and details page, with support for JPEG and PNG images.
 

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -198,10 +198,8 @@ class CourseFields(object):
     tabs = List(help="List of tabs to enable in this course", scope=Scope.settings)
     end_of_course_survey_url = String(help="Url for the end-of-course survey", scope=Scope.settings)
     discussion_blackouts = List(help="List of pairs of start/end dates for discussion blackouts", scope=Scope.settings)
-    discussion_topics = Dict(
-        help="Map of topics names to ids",
-        scope=Scope.settings
-    )
+    discussion_topics = Dict(help="Map of topics names to ids", scope=Scope.settings)
+    discussion_sort_alpha = Boolean(scope=Scope.settings, default=False, help="Sort forum categories and subcategories alphabetically.")
     testcenter_info = Dict(help="Dictionary of Test Center info", scope=Scope.settings)
     announcement = Date(help="Date this course is announced", scope=Scope.settings)
     cohort_config = Dict(help="Dictionary defining cohort configuration", scope=Scope.settings)

--- a/lms/djangoapps/django_comment_client/tests/test_utils.py
+++ b/lms/djangoapps/django_comment_client/tests/test_utils.py
@@ -2,7 +2,6 @@ from django.test import TestCase
 from student.tests.factories import UserFactory, CourseEnrollmentFactory
 from django_comment_common.models import Role, Permission
 from factories import RoleFactory
-from copy import deepcopy
 import django_comment_client.utils as utils
 
 
@@ -29,8 +28,10 @@ class DictionaryTestCase(TestCase):
         expected = {'cats': 'meow', 'dogs': 'woof', 'lions': 'roar', 'ducks': 'quack'}
         self.assertEqual(utils.merge_dict(d1, d2), expected)
 
-    def test_sort(self):
-        d1 = {
+
+class CategorySortTestCase(TestCase):
+    def setUp(self):
+        self.category_map = {
             'entries': {
                 u'General': {
                     'sort_key': u'General'
@@ -64,8 +65,9 @@ class DictionaryTestCase(TestCase):
                 }
             }
         }
-        
-        expected_1 = {
+
+    def test_alpha_sort_true(self):
+        expected_true = {
             'entries': {
                 u'General': {
                     'sort_key': u'General'
@@ -103,7 +105,11 @@ class DictionaryTestCase(TestCase):
             }
         }
         
-        expected_2 = {
+        utils.sort_map_entries(self.category_map, True)
+        self.assertEqual(self.category_map, expected_true)
+
+    def test_alpha_sort_false(self):
+        expected_false = {
             'entries': {
                 u'General': {
                     'sort_key': u'General'
@@ -141,11 +147,8 @@ class DictionaryTestCase(TestCase):
             }
         }
         
-        d2 = deepcopy(d1)
-        utils.sort_map_entries(d1, True)
-        utils.sort_map_entries(d2, False)
-        self.assertEqual(d1, expected_1)
-        self.assertEqual(d2, expected_2)
+        utils.sort_map_entries(self.category_map, False)
+        self.assertEqual(self.category_map, expected_false)
 
 
 class AccessUtilsTestCase(TestCase):

--- a/lms/djangoapps/django_comment_client/tests/test_utils.py
+++ b/lms/djangoapps/django_comment_client/tests/test_utils.py
@@ -2,6 +2,7 @@ from django.test import TestCase
 from student.tests.factories import UserFactory, CourseEnrollmentFactory
 from django_comment_common.models import Role, Permission
 from factories import RoleFactory
+from copy import deepcopy
 import django_comment_client.utils as utils
 
 
@@ -27,6 +28,124 @@ class DictionaryTestCase(TestCase):
         d2 = {'lions': 'roar', 'ducks': 'quack'}
         expected = {'cats': 'meow', 'dogs': 'woof', 'lions': 'roar', 'ducks': 'quack'}
         self.assertEqual(utils.merge_dict(d1, d2), expected)
+
+    def test_sort(self):
+        d1 = {
+            'entries': {
+                u'General': {
+                    'sort_key': u'General'
+                }
+            },
+            'subcategories': {
+                u'Tests': {
+                    'sort_key': u'Tests',
+                    'subcategories': {},
+                    'entries': {
+                        u'Quizzes': {
+                            'sort_key': None
+                        }, u'All': {
+                            'sort_key': None
+                        }, u'Final Exam': {
+                            'sort_key': None
+                        },
+                    }
+                },
+                u'Assignments': {
+                    'sort_key': u'Assignments',
+                    'subcategories': {},
+                    'entries': {
+                        u'Homework': {
+                            'sort_key': None
+                        },
+                        u'All': {
+                            'sort_key': None
+                        },
+                    }
+                }
+            }
+        }
+        
+        expected_1 = {
+            'entries': {
+                u'General': {
+                    'sort_key': u'General'
+                }
+            },
+            'children': [u'Assignments', u'General', u'Tests'],
+            'subcategories': {
+                u'Tests': {
+                    'sort_key': u'Tests',
+                    'subcategories': {},
+                    'children': [u'All', u'Final Exam', u'Quizzes'],
+                    'entries': {
+                        u'All': {
+                            'sort_key': 'All'
+                        }, u'Final Exam': {
+                            'sort_key': 'Final Exam'
+                        }, u'Quizzes': {
+                            'sort_key': 'Quizzes'
+                        }
+                    }
+                },
+                u'Assignments': {
+                    'sort_key': u'Assignments',
+                    'subcategories': {},
+                    'children': [u'All', u'Homework'],
+                    'entries': {
+                        u'Homework': {
+                            'sort_key': 'Homework'
+                        },
+                        u'All': {
+                            'sort_key': 'All'
+                        },
+                    }
+                }
+            }
+        }
+        
+        expected_2 = {
+            'entries': {
+                u'General': {
+                    'sort_key': u'General'
+                }
+            },
+            'children': [u'Assignments', u'General', u'Tests'],
+            'subcategories': {
+                u'Tests': {
+                    'sort_key': u'Tests',
+                    'subcategories': {},
+                    'children': [u'Quizzes', u'All', u'Final Exam'],
+                    'entries': {
+                        u'Quizzes': {
+                            'sort_key': None
+                        }, u'All': {
+                            'sort_key': None
+                        }, u'Final Exam': {
+                            'sort_key': None
+                        },
+                    }
+                },
+                u'Assignments': {
+                    'sort_key': u'Assignments',
+                    'subcategories': {},
+                    'children': [u'All', u'Homework'],
+                    'entries': {
+                        u'Homework': {
+                            'sort_key': None
+                        },
+                        u'All': {
+                            'sort_key': None
+                        },
+                    }
+                }
+            }
+        }
+        
+        d2 = deepcopy(d1)
+        utils.sort_map_entries(d1, True)
+        utils.sort_map_entries(d2, False)
+        self.assertEqual(d1, expected_1)
+        self.assertEqual(d2, expected_2)
 
 
 class AccessUtilsTestCase(TestCase):

--- a/lms/djangoapps/django_comment_client/utils.py
+++ b/lms/djangoapps/django_comment_client/utils.py
@@ -129,6 +129,8 @@ def filter_unstarted_categories(category_map):
 def sort_map_entries(category_map):
     things = []
     for title, entry in category_map["entries"].items():
+        if entry["sort_key"] == None:
+            entry["sort_key"] = title
         things.append((title, entry))
     for title, category in category_map["subcategories"].items():
         things.append((title, category))

--- a/lms/djangoapps/django_comment_client/utils.py
+++ b/lms/djangoapps/django_comment_client/utils.py
@@ -125,16 +125,16 @@ def filter_unstarted_categories(category_map):
 
     return result_map
 
-
-def sort_map_entries(category_map):
+    
+def sort_map_entries(category_map, sort_alpha):
     things = []
     for title, entry in category_map["entries"].items():
-        if entry["sort_key"] == None:
+        if entry["sort_key"] == None and sort_alpha:
             entry["sort_key"] = title
         things.append((title, entry))
     for title, category in category_map["subcategories"].items():
         things.append((title, category))
-        sort_map_entries(category_map["subcategories"][title])
+        sort_map_entries(category_map["subcategories"][title], sort_alpha)
     category_map["children"] = [x[0] for x in sorted(things, key=lambda x: x[1]["sort_key"])]
 
 
@@ -213,7 +213,8 @@ def initialize_discussion_info(course):
         category_map['entries'][topic] = {"id": entry["id"],
                                           "sort_key": entry.get("sort_key", topic),
                                           "start_date": datetime.now(UTC())}
-    sort_map_entries(category_map)
+
+    sort_map_entries(category_map, course.discussion_sort_alpha)
 
     _DISCUSSIONINFO[course.id]['id_map'] = discussion_id_map
     _DISCUSSIONINFO[course.id]['category_map'] = category_map

--- a/lms/templates/discussion/_filter_dropdown.html
+++ b/lms/templates/discussion/_filter_dropdown.html
@@ -2,6 +2,7 @@
 <%! import json %>
 
 <%def name="render_dropdown(map)">
+    ${map["children"].sort()}
     % for child in map["children"]:
         % if child in map["entries"]:
             ${render_entry(map["entries"], child)}

--- a/lms/templates/discussion/_filter_dropdown.html
+++ b/lms/templates/discussion/_filter_dropdown.html
@@ -2,7 +2,6 @@
 <%! import json %>
 
 <%def name="render_dropdown(map)">
-    ${map["children"].sort()}
     % for child in map["children"]:
         % if child in map["entries"]:
             ${render_entry(map["entries"], child)}


### PR DESCRIPTION
@kevinchugh @caesar2164

We figured out that the reason subcategories weren't getting sorted was that they had a sort_key of None, whereas the entries had a sort_key of their title, so with this simple fix, the already existing sorting mechanism should take care of the subcategory sorting as well.
