### PR TITLE
Feature/cdodge/mongo perf tracker

### DIFF
--- a/common/djangoapps/mongo_perf_tracker/middleware.py
+++ b/common/djangoapps/mongo_perf_tracker/middleware.py
@@ -1,0 +1,139 @@
+"""
+Provide a means to aggregate and store MongoDB related performance in our product
+"""
+import threading
+import time
+import logging
+from xmodule.contentstore.content import XASSET_LOCATION_TAG
+from django.conf import settings
+
+_mongo_perf_tracker_threadlocal = threading.local()
+_mongo_perf_tracker_threadlocal.data = {}
+
+# counter to keep track of how many requests we've processed. This is used to
+# keer track of when we need to flush out internal buffers out to some persistence
+# layer
+last_dump_time = time.time()
+
+# global object which retains a mapping of URL to DB performance information
+db_stats_per_url = {}
+
+log = logging.getLogger("common.mongo_perf_tracker")
+
+_perf_tracker = None
+
+class MongoPerfTracker(object):
+    """
+    Implements Django middleware object which manages the lifetime of
+    the performance tracker for our MongoDB store provider
+    """
+    @property
+    def perf_tracker_data(self):
+        """
+        Returns the dictionary that is in the threadlocal
+        """
+        return _mongo_perf_tracker_threadlocal.data
+
+    def set_perf_tracker_data_entry(self, key, value):
+        """
+        Sets a piece of tracking data
+        """
+        _mongo_perf_tracker_threadlocal.data[key] = value
+
+    def increment_perf_tracker_counter(self, key):
+        """
+        Increases a counter by one
+        """
+        self.add_to_float_perf_tracker_counter(key, 1.0)
+
+    def add_to_float_perf_tracker_counter(self, key, increment_float):
+        """
+        Adds a number to a tracking element which is a float
+        """
+        counter = self.perf_tracker_data[key] if key in self.perf_tracker_data else 0.0
+        counter = counter + increment_float
+
+        self.set_perf_tracker_data_entry(key, counter)
+
+    def _is_trackable_path(self, request):
+        """
+        Returns whether this path is something we want to set up stats gathering for
+        """
+        # don't track requests for GridFS hosted assets
+        if request.path.startswith('/' + XASSET_LOCATION_TAG + '/'):
+            return False
+
+        # don't track requests for things in /static/...
+        if request.path.startswith('/static/'):
+            return False
+
+        # don't track POST-backs, for now at least
+        if request.method in ('POST', 'PUT'):
+            return False
+
+        return True
+
+    def clear_perf_tracker_data(self):
+        """
+        Resets all data in our threadlocal
+        """
+        _mongo_perf_tracker_threadlocal.data = {}
+
+    def process_request(self, request):
+        """
+        Middleware entry point that is called on every received thread
+        """
+        self.clear_perf_tracker_data()
+
+        return None
+
+    def process_response(self, request, response):
+        """
+        Django middleware entry point that is called on every response sent back to client
+        """
+        global trackable_requests_processed, db_stats_per_url, last_dump_time
+
+        try:
+            if self._is_trackable_path(request):
+                # copy over any stats gathered in this request and put in the global dictionary
+                # to get written out on a periodic basis
+
+                set_entry = True
+
+                # take what the overwrite key should be from settings, if defined
+                overwrite_key = getattr(settings, 'MONGO_PERF_TRACKER_OVERWITE_KEY', None)
+
+                # first see if we have an entry for this path, if so see if an overwrite key
+                # has been specified so that we can use that value to compare to what exists
+                # this can be used to implement a high-water mark
+                if request.path in db_stats_per_url and overwrite_key:
+                    existing_level = db_stats_per_url[request.path].get(overwrite_key, 0)
+                    new_level = self.perf_tracker_data.get(overwrite_key, 0)
+                    set_entry = existing_level < new_level
+
+                if set_entry and len(self.perf_tracker_data.keys()) > 0:
+                    db_stats_per_url[request.path] = self.perf_tracker_data
+
+                # dump stats after a certain period of time, default 1 hr
+                dump_time_delta = getattr(settings, 'MONGO_PERF_DUMP_AFTER_N_MINUTES', 60.0) * 60.0
+
+                if time.time() - last_dump_time > dump_time_delta and len(db_stats_per_url.keys()) > 0:
+                    # Note, we use info level so they don't get filtered out in the logs
+                    log.info('mongo_db_stats dump = {0}'.format(db_stats_per_url))
+                    last_dump_time = time.time()
+                    db_stats_per_url = {}
+        except:
+            # This is just optional perf metering, so trap all unhandled exceptions and continue
+            pass
+
+        self.clear_perf_tracker_data()
+        return response
+
+    @classmethod
+    def get_perf_tracker(cls):
+        global _perf_tracker
+        
+        if not _perf_tracker:
+            _perf_tracker = MongoPerfTracker()
+
+        return _perf_tracker

--- a/common/djangoapps/request_cache/middleware.py
+++ b/common/djangoapps/request_cache/middleware.py
@@ -1,20 +1,39 @@
+"""
+Implement a request scoped cache which is setup and torn down after every request
+"""
 import threading
 
 _request_cache_threadlocal = threading.local()
 _request_cache_threadlocal.data = {}
 
+
 class RequestCache(object):
+    """
+    Implementation of a request scoped cache
+    """
     @classmethod
     def get_request_cache(cls):
+        """
+        Returns the data associated with the threadlocal
+        """
         return _request_cache_threadlocal
-            
+
     def clear_request_cache(self):
+        """
+        Resets the content in the threadlocal
+        """
         _request_cache_threadlocal.data = {}
 
     def process_request(self, request):
+        """
+        Django middleware entry point for request processing
+        """
         self.clear_request_cache()
         return None
 
     def process_response(self, request, response):
+        """
+        Django middleware entry point for response processing
+        """
         self.clear_request_cache()
         return response

--- a/common/lib/xmodule/xmodule/modulestore/__init__.py
+++ b/common/lib/xmodule/xmodule/modulestore/__init__.py
@@ -397,7 +397,7 @@ class ModuleStoreBase(ModuleStore):
     '''
     Implement interface functionality that can be shared.
     '''
-    def __init__(self, metadata_inheritance_cache_subsystem=None, request_cache=None, modulestore_update_signal=None, xblock_mixins=()):
+    def __init__(self, metadata_inheritance_cache_subsystem=None, request_cache=None, perf_tracker=None, modulestore_update_signal=None, xblock_mixins=()):
         '''
         Set up the error-tracking logic.
         '''
@@ -406,6 +406,7 @@ class ModuleStoreBase(ModuleStore):
         self.modulestore_update_signal = modulestore_update_signal
         self.request_cache = request_cache
         self.xblock_mixins = xblock_mixins
+        self.perf_tracker = perf_tracker
 
     def _get_errorlog(self, location):
         """

--- a/common/lib/xmodule/xmodule/modulestore/django.py
+++ b/common/lib/xmodule/xmodule/modulestore/django.py
@@ -22,6 +22,12 @@ try:
 except ImportError:
     HAS_REQUEST_CACHE = False
 
+try:
+    from mongo_per_tracker.middleware import MongoPerfTracker
+    HAS_PERF_COUNTER = True
+except ImportError:
+    HAS_PERF_TRACKER = False
+
 _MODULESTORES = {}
 
 FUNCTION_KEYS = ['render_template']
@@ -56,6 +62,11 @@ def create_modulestore_instance(engine, options):
     else:
         request_cache = None
 
+    if HAS_PERF_TRACKER:
+        perf_tracker = MongoPerfTracker.get_perf_tracker()
+    else:
+        perf_tracker = None
+
     try:
         metadata_inheritance_cache = get_cache('mongo_metadata_inheritance')
     except InvalidCacheBackendError:
@@ -63,7 +74,7 @@ def create_modulestore_instance(engine, options):
 
     return class_(
         metadata_inheritance_cache_subsystem=metadata_inheritance_cache,
-        request_cache=request_cache,
+        request_cache=request_cache, perf_tracker=perf_tracker,
         modulestore_update_signal=Signal(providing_args=['modulestore', 'course_id', 'location']),
         xblock_mixins=getattr(settings, 'XBLOCK_MIXINS', ()),
         **_options

--- a/common/lib/xmodule/xmodule/modulestore/mongo/draft.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/draft.py
@@ -143,6 +143,7 @@ class DraftModuleStore(MongoModuleStore):
         :param source: the location of the source (its revision must be None)
         """
         original = self.collection.find_one(location_to_query(source_location))
+        self._increment_read_perf_counter()
         draft_location = as_draft(source_location)
         if draft_location.category in DIRECT_ONLY_CATEGORIES:
             raise InvalidVersionError(source_location)
@@ -278,6 +279,7 @@ class DraftModuleStore(MongoModuleStore):
             '_id': {'$in': [namedtuple_to_son(as_draft(Location(item))) for item in items]}
         }
         to_process_drafts = list(self.collection.find(query))
+        self._increment_read_perf_counter()
 
         # now we have to go through all drafts and replace the non-draft
         # with the draft. This is because the semantics of the DraftStore is to

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -577,6 +577,9 @@ TEMPLATE_LOADERS = (
 
 )
 
+MONGO_PERF_READ_ACCESS_COUTNER_KEY = 'query_db_call'
+MONGO_PERF_TRACKER_OVERWITE_KEY = MONGO_PERF_READ_ACCESS_COUTNER_KEY
+
 MIDDLEWARE_CLASSES = (
     'request_cache.middleware.RequestCache',
     'django_comment_client.middleware.AjaxExceptionMiddleware',
@@ -588,6 +591,7 @@ MIDDLEWARE_CLASSES = (
     'cache_toolbox.middleware.CacheBackedAuthenticationMiddleware',
     'contentserver.middleware.StaticContentServer',
     'crum.CurrentRequestUserMiddleware',
+    'mongo_perf_tracker.middleware.MongoPerfTracker',
 
     'django.contrib.messages.middleware.MessageMiddleware',
     'track.middleware.TrackMiddleware',


### PR DESCRIPTION
Maintains a URL-># DB round trip mapping and dumps them to the log file periodically. This can be used to surface URLs that cause too many round trips to the database.

Right now we just turn on the middleware for the LMS since that gets most of the load

@cpennington @jarv -or - @e0d can you review, it'd be good to get a Dev and a DevOps person to look at this.
