### PR TITLE
Video Player: minor fixes

### DIFF
--- a/cms/djangoapps/contentstore/features/video-editor.py
+++ b/cms/djangoapps/contentstore/features/video-editor.py
@@ -5,7 +5,7 @@ from lettuce import world, step
 from terrain.steps import reload_the_page
 
 
-@step('I have set "show captions" to (.*)')
+@step('I have set "show captions" to (.*)$')
 def set_show_captions(step, setting):
     world.css_click('a.edit-button')
     world.wait_for(lambda _driver: world.css_visible('a.save-button'))
@@ -13,7 +13,7 @@ def set_show_captions(step, setting):
     world.css_click('a.save-button')
 
 
-@step('when I view the (video.*) it (.*) show the captions')
+@step('when I view the (video.*) it (.*) show the captions$')
 def shows_captions(_step, video_type, show_captions):
     # Prevent cookies from overriding course settings
     world.browser.cookies.delete('hide_captions')
@@ -39,7 +39,7 @@ def correct_video_settings(_step):
                                       ['Youtube ID for 1.5x speed', '', False]])
 
 
-@step('my video display name change is persisted on save')
+@step('my video display name change is persisted on save$')
 def video_name_persisted(step):
     world.css_click('a.save-button')
     reload_the_page(step)

--- a/cms/djangoapps/contentstore/features/video.py
+++ b/cms/djangoapps/contentstore/features/video.py
@@ -19,25 +19,25 @@ def i_created_a_video_component(step):
     )
 
 
-@step('when I view the (.*) it does not have autoplay enabled')
+@step('when I view the (.*) it does not have autoplay enabled$')
 def does_not_autoplay(_step, video_type):
     assert world.css_find('.%s' % video_type)[0]['data-autoplay'] == 'False'
     assert world.css_has_class('.video_control', 'play')
 
 
-@step('creating a video takes a single click')
+@step('creating a video takes a single click$')
 def video_takes_a_single_click(_step):
     assert(not world.is_css_present('.xmodule_VideoModule'))
     world.css_click("a[data-category='video']")
     assert(world.is_css_present('.xmodule_VideoModule'))
 
 
-@step('I edit the component')
+@step('I edit the component$')
 def i_edit_the_component(_step):
     world.edit_component()
 
 
-@step('I have (hidden|toggled) captions')
+@step('I have (hidden|toggled) captions$')
 def hide_or_show_captions(step, shown):
     button_css = 'a.hide-subtitles'
     if shown == 'hidden':
@@ -54,7 +54,7 @@ def hide_or_show_captions(step, shown):
         world.css_click(button_css)
 
 
-@step('I have created a video with only XML data')
+@step('I have created a video with only XML data$')
 def xml_only_video(step):
     # Create a new video *without* metadata. This requires a certain
     # amount of rummaging to make sure all the correct data is present
@@ -84,7 +84,7 @@ def xml_only_video(step):
     reload_the_page(step)
 
 
-@step('The correct Youtube video is shown')
+@step('The correct Youtube video is shown$')
 def the_youtube_video_is_shown(_step):
     ele = world.css_find('.video').first
     assert ele['data-streams'].split(':')[1] == world.scenario_dict['YOUTUBE_ID']

--- a/lms/djangoapps/courseware/features/video.py
+++ b/lms/djangoapps/courseware/features/video.py
@@ -12,12 +12,12 @@ HTML5_SOURCES = [
     'https://s3.amazonaws.com/edx-course-videos/edx-intro/edX-FA12-cware-1_100.ogv'
 ]
 
-@step('when I view the (.*) it has autoplay enabled')
+@step('when I view the (.*) it has autoplay enabled$')
 def does_autoplay_video(_step, video_type):
     assert(world.css_find('.%s' % video_type)[0]['data-autoplay'] == 'True')
 
 
-@step('the course has a Video component in (.*) mode')
+@step('the course has a Video component in (.*) mode$')
 def view_video(_step, player_mode):
     coursenum = 'test_course'
     i_am_registered_for_the_course(step, coursenum)
@@ -55,7 +55,7 @@ def add_video_to_course(course, player_mode):
     world.ItemFactory.create(**kwargs)
 
 
-@step('when I view the video it has rendered in (.*) mode')
+@step('when I view the video it has rendered in (.*) mode$')
 def video_is_rendered(_step, mode):
     modes = {
         'html5': 'video',
@@ -64,7 +64,7 @@ def video_is_rendered(_step, mode):
     html_tag = modes[mode.lower()]
     assert world.css_find('.video {0}'.format(html_tag)).first
 
-@step('all sources are correct')
+@step('all sources are correct$')
 def all_sources_are_correct(_step):
     sources = world.css_find('.video video source')
     assert set(source['src'] for source in sources) == set(HTML5_SOURCES)

--- a/lms/djangoapps/courseware/features/video.py
+++ b/lms/djangoapps/courseware/features/video.py
@@ -61,10 +61,8 @@ def video_is_rendered(_step, mode):
         'html5': 'video',
         'youtube': 'iframe'
     }
-    if mode.lower() in modes:
-        assert world.css_find('.video {0}'.format(modes[mode.lower()])).first
-    else:
-        assert False
+    html_tag = modes[mode.lower()]
+    assert world.css_find('.video {0}'.format(html_tag)).first
 
 @step('all sources are correct')
 def all_sources_are_correct(_step):

--- a/lms/djangoapps/courseware/tests/test_video_xml.py
+++ b/lms/djangoapps/courseware/tests/test_video_xml.py
@@ -20,8 +20,7 @@ import unittest
 
 from django.conf import settings
 
-from xmodule.video_module import (
-    VideoDescriptor, _create_youtube_string)
+from xmodule.video_module import VideoDescriptor, _create_youtube_string
 from xmodule.modulestore import Location
 from xmodule.tests import get_test_system, LogicTest
 


### PR DESCRIPTION
In this PR are fixed minor issues mentioned in PR #637 .

1) Is it necessary to assert False if mode isn't present? Seems like we could just assume that whoever's writing the feature will use the right mode. 
2) It's usually good to end steps (especially short ones) with a $ regex anchor -- we've had bugs that weren't caught because two definitions happened to match a step, and the wrong test was chosen by Lettuce. Making these definitions as specific as possible can avoid this.
3) Minor nitpick, but this and line 24 should probably be one for nicer formatting.

@peter-fogg review, please.
