### PR TITLE
fixes delete state on dashboard

### DIFF
--- a/lms/djangoapps/instructor/views/legacy.py
+++ b/lms/djangoapps/instructor/views/legacy.py
@@ -342,7 +342,7 @@ def instructor_dashboard(request, course_id):
                     student_module.delete()
                     msg += "<font color='red'>Deleted student module state for {0}!</font>".format(module_state_key)
                     event = {
-                        "problem": problem_url,
+                        "problem": module_state_key,
                         "student": unique_student_identifier,
                         "course": course_id
                     }


### PR DESCRIPTION
problem_url was undefined throwing an error when student state was attempted to be deleted. We had meant to put module_state_key, which is set to get_module_url(problem_urlname)

@mlsteele 
@sarina 
