### PR TITLE
Fix/cdodge/get items needs courseid

### DIFF
--- a/lms/djangoapps/courseware/tests/tests.py
+++ b/lms/djangoapps/courseware/tests/tests.py
@@ -64,7 +64,7 @@ class PageLoaderTestCase(LoginEnrollmentTestCase):
         location_query = Location(course_loc.tag, course_loc.org,
                                   course_loc.course, None, None, None)
 
-        items = module_store.get_items(location_query)
+        items = module_store.get_items(location_query, course_id=course_id)
 
         if len(items) < 1:
             self.fail('Could not retrieve any items from course')

--- a/lms/djangoapps/courseware/views.py
+++ b/lms/djangoapps/courseware/views.py
@@ -458,7 +458,10 @@ def jump_to_id(request, course_id, module_id):
 
     course_location = CourseDescriptor.id_to_location(course_id)
 
-    items = modulestore().get_items(['i4x', course_location.org, course_location.course, None, module_id])
+    items = modulestore().get_items(
+        ['i4x', course_location.org, course_location.course, None, module_id],
+        course_id=course_id
+    )
 
     if len(items) == 0:
         raise Http404("Could not find id = {0} in course_id = {1}. Referer = {2}".

--- a/lms/djangoapps/instructor/hint_manager.py
+++ b/lms/djangoapps/instructor/hint_manager.py
@@ -89,7 +89,7 @@ def get_hints(request, course_id, field):
 
     for hints_by_problem in all_hints:
         loc = Location(hints_by_problem.definition_id)
-        name = location_to_problem_name(loc)
+        name = location_to_problem_name(course_id, loc)
         if name is None:
             continue
         id_to_name[hints_by_problem.definition_id] = name
@@ -119,13 +119,13 @@ def get_hints(request, course_id, field):
     return render_dict
 
 
-def location_to_problem_name(loc):
+def location_to_problem_name(course_id, loc):
     """
     Given the location of a crowdsource_hinter module, try to return the name of the
     problem it wraps around.  Return None if the hinter no longer exists.
     """
     try:
-        descriptor = modulestore().get_items(loc)[0]
+        descriptor = modulestore().get_items(loc, course_id=course_id)[0]
         return descriptor.get_children()[0].display_name
     except IndexError:
         # Sometimes, the problem is no longer in the course.  Just

--- a/lms/djangoapps/instructor/tests/test_hint_manager.py
+++ b/lms/djangoapps/instructor/tests/test_hint_manager.py
@@ -42,7 +42,7 @@ class HintManagerTest(ModuleStoreTestCase):
                               value=5)
         # Mock out location_to_problem_name, which ordinarily accesses the modulestore.
         # (I can't figure out how to get fake structures into the modulestore.)
-        view.location_to_problem_name = lambda loc: "Test problem"
+        view.location_to_problem_name = lambda course_id, loc: "Test problem"
 
     def test_student_block(self):
         """


### PR DESCRIPTION
@wedaly @rocha @fephsun 

In preparations to the switchover to the mixedModuleStore, there were some new calls to get_item() which need to have the course_id passed in, otherwise the MixedModuleStore will throw an exception.

Felix/Carlos, I'm tagging you because on of them was in the hint_manager.
