### PR TITLE
Change pylint settings to not report in importing assert_* from nose.tools

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -100,6 +100,11 @@ ignore-mixin-members=yes
 # (useful for classes with attributes dynamically set).
 ignored-classes=SQLObject
 
+# See http://stackoverflow.com/questions/17156240/nose-tools-and-pylint
+# Pylint does not like the way that nose tools inspects and makes available
+# the assert classes
+ignored-classes=nose.tools,nose.tools.trivial
+
 # When zope mode is activated, add a predefined set of Zope acquired attributes
 # to generated-members.
 zope=no


### PR DESCRIPTION
@wedaly @chrisndodge 

I anticipate that this is also going to affect our pylint violations metric. We should monitor and bump it down some after this is merged into master and peoples's branches.
