### PR TITLE
Fix failing grade label being editable but not saved.

### DIFF
--- a/cms/djangoapps/contentstore/features/grading.feature
+++ b/cms/djangoapps/contentstore/features/grading.feature
@@ -93,3 +93,9 @@ Feature: Course Grading
         And I press the "Save" notification button
         And I reload the page
         Then I see the highest grade range is "Good"
+
+    Scenario: User cannot edit failing grade range name
+        Given I have opened a new course in Studio
+        And I have populated the course
+        And I am viewing the grading settings
+        Then I cannot edit the "Fail" grade range

--- a/cms/djangoapps/contentstore/features/grading.py
+++ b/cms/djangoapps/contentstore/features/grading.py
@@ -4,6 +4,7 @@
 from lettuce import world, step
 from common import *
 from terrain.steps import reload_the_page
+from selenium.common.exceptions import InvalidElementStateException
 
 
 @step(u'I am viewing the grading settings')
@@ -129,6 +130,18 @@ def i_see_highest_grade_range(_step, range_name):
     range_css = 'span.letter-grade'
     grade = world.css_find(range_css).first
     assert grade.value == range_name
+
+
+@step(u'I cannot edit the "Fail" grade range$')
+def cannot_edit_fail(_step):
+    range_css = 'span.letter-grade'
+    ranges = world.css_find(range_css)
+    assert len(ranges) == 2
+    try:
+        ranges.last.value = 'Failure'
+        assert False, "Should not be able to edit failing range"
+    except InvalidElementStateException:
+        pass  # We should get this exception on failing to edit the element
 
 def get_type_index(name):
     name_id = '#course-grading-assignment-name'

--- a/cms/static/js/views/settings/settings_grading_view.js
+++ b/cms/static/js/views/settings/settings_grading_view.js
@@ -8,7 +8,7 @@ CMS.Views.Settings.Grading = CMS.Views.ValidatingView.extend({
         // Leaving change in as fallback for older browsers
         "change input" : "updateModel",
         "change textarea" : "updateModel",
-        "input span[contenteditable]" : "updateDesignation",
+        "input span[contenteditable=true]" : "updateDesignation",
         "click .settings-extra header" : "showSettingsExtras",
         "click .new-grade-button" : "addNewGrade",
         "click .remove-button" : "removeGrade",
@@ -20,7 +20,7 @@ CMS.Views.Settings.Grading = CMS.Views.ValidatingView.extend({
     initialize : function() {
         //  load template for grading view
         var self = this;
-        this.gradeCutoffTemplate = _.template('<li class="grade-specific-bar" style="width:<%= width %>%"><span class="letter-grade" contenteditable>' +
+        this.gradeCutoffTemplate = _.template('<li class="grade-specific-bar" style="width:<%= width %>%"><span class="letter-grade" contenteditable="true">' +
                 '<%= descriptor %>' +
                 '</span><span class="range"></span>' +
                 '<% if (removable) {%><a href="#" class="remove-button">remove</a><% ;} %>' +
@@ -168,9 +168,12 @@ CMS.Views.Settings.Grading = CMS.Views.ValidatingView.extend({
         },
         this);
         // add fail which is not in data
-        var failBar = this.gradeCutoffTemplate({ descriptor : this.failLabel(),
-            width : nextWidth, removable : false});
-        $(failBar).find("span[contenteditable=true]").attr("contenteditable", false);
+        var failBar = $(this.gradeCutoffTemplate({
+            descriptor : this.failLabel(),
+            width : nextWidth,
+            removable : false
+        }));
+        failBar.find("span[contenteditable=true]").attr("contenteditable", false);
         gradelist.append(failBar);
         gradelist.children().last().resizable({
             handles: "e",


### PR DESCRIPTION
The root cause was that `failBar` was a string on line 173. Thus, wrapping it with `$` created a new DOM element, set its child span's `contenteditable` to `false`, and promptly threw it away and appended a new element to `gradelist` on 174 (with `contenteditable` as it was in the template). @cahrens, can you confirm the fix?
