### PR TITLE
Fix var name issue

### DIFF
--- a/cms/djangoapps/contentstore/views/assets.py
+++ b/cms/djangoapps/contentstore/views/assets.py
@@ -167,7 +167,7 @@ def upload_asset(request, org, course, coursename):
     sc_partial = partial(StaticContent, content_loc, filename, mime_type)
     if chunked:
         content = sc_partial(upload_file.chunks())
-        temp_filepath = upload_file.temporary_file_path()
+        tempfile_path = upload_file.temporary_file_path()
     else:
         content = sc_partial(upload_file.read())
         tempfile_path = None


### PR DESCRIPTION
Wrong var name causes django-chunked (> 10MB?) asset upload to fail. 
