### PR TITLE
Made the lambda statement more resistant to errors

### DIFF
--- a/cms/djangoapps/contentstore/features/common.py
+++ b/cms/djangoapps/contentstore/features/common.py
@@ -152,7 +152,8 @@ def log_into_studio(
     world.log_in(username=uname, password=password, email=email, name=name)
     # Navigate to the studio dashboard
     world.visit('/')
-    world.wait_for(lambda _driver: uname in world.css_find('h2.title')[0].text)
+
+    assert uname in world.css_text('h2.title', max_attempts=15)
 
 def create_a_course():
     course = world.CourseFactory.create(org='MITx', course='999', display_name='Robot Super Course')


### PR DESCRIPTION
Suggested Reviewers: @wedaly @jzoldak 

The error that is being returned in the console on jenkins is ElementNotFoundException. 

From the splinter documentation
'If element not found, find methods returns a empty list. But, if you try, access a element in list raises the splinter.element_list.ElementDoesNotExist exception.'

Thus, the lambda statement will not return false as predicted.

This change will instead use css_text (which prevents some type of errors) and a try, except block around this.

The try except block is to catch the following scenario:
css_text calls retry_on_exception.  However, retry_on_exception asserts that the function worked within a certain amount of attempts.  While this is fine in most cases, if the page is taking a while to load (on sauce or on jenkins), the attempts will run out due to how quickly they are fired and an assertion error will rise.  Thus, the try except block will return false indicating that the implicit wait should continue

I will run the this branch as many times as I can today to see if this fixes the issue.

One other thing that was changed is: Before auto-auth logs the user in, it should always go to the logout page to ensure no one else is logged in.  There may have been potential errors if someone else was logged in already
