### PR TITLE
fix some gaps which would allow the temporary xml attributes 'parent_seq...

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -945,8 +945,23 @@ class ContentStoreToyCourseTest(ModuleStoreTestCase):
                                                   'vertical', 'vertical_test', None]), depth=1)
 
         self.assertTrue(getattr(vertical, 'is_draft', False))
+        self.assertNotIn('index_in_children_list', child.xml_attributes)
+        if hasattr(vertical, 'data'):
+            self.assertNotIn('index_in_children_list', vertical.data)
+        self.assertNotIn('parent_sequential_url', vertical.xml_attributes)
+        if hasattr(vertical, 'data'):
+            self.assertNotIn('parent_sequential_url', vertical.data)
+                
         for child in vertical.get_children():
             self.assertTrue(getattr(child, 'is_draft', False))
+            self.assertNotIn('index_in_children_list', child.xml_attributes)
+            if hasattr(child, 'data'):
+                self.assertNotIn('index_in_children_list', child.data)
+            self.assertNotIn('parent_sequential_url', child.xml_attributes)
+            if hasattr(child, 'data'):
+                self.assertNotIn('parent_sequential_url', child.data)
+
+
 
         # make sure that we don't have a sequential that is in draft mode
         sequential = draft_store.get_item(Location(['i4x', 'edX', 'toy',

--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -946,11 +946,7 @@ class ContentStoreToyCourseTest(ModuleStoreTestCase):
 
         self.assertTrue(getattr(vertical, 'is_draft', False))
         self.assertNotIn('index_in_children_list', child.xml_attributes)
-        if hasattr(vertical, 'data'):
-            self.assertNotIn('index_in_children_list', vertical.data)
         self.assertNotIn('parent_sequential_url', vertical.xml_attributes)
-        if hasattr(vertical, 'data'):
-            self.assertNotIn('parent_sequential_url', vertical.data)
                 
         for child in vertical.get_children():
             self.assertTrue(getattr(child, 'is_draft', False))
@@ -960,8 +956,6 @@ class ContentStoreToyCourseTest(ModuleStoreTestCase):
             self.assertNotIn('parent_sequential_url', child.xml_attributes)
             if hasattr(child, 'data'):
                 self.assertNotIn('parent_sequential_url', child.data)
-
-
 
         # make sure that we don't have a sequential that is in draft mode
         sequential = draft_store.get_item(Location(['i4x', 'edX', 'toy',


### PR DESCRIPTION
...uential_url' and 'index_in_children_list' to get persisted in the database, whereas they are meant to be only scoped during export/import
