### PR TITLE
Add test for large asset upload

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_assets.py
+++ b/cms/djangoapps/contentstore/tests/test_assets.py
@@ -3,11 +3,10 @@ Unit tests for the asset upload endpoint.
 """
 
 import json
-import os
 from datetime import datetime
-from io import BytesIO
+from tempfile import TemporaryFile
 from pytz import UTC
-from unittest import TestCase, skipIf
+from unittest import TestCase
 from .utils import CourseTestCase
 from django.core.urlresolvers import reverse
 from contentstore.views import assets
@@ -56,22 +55,18 @@ class UploadTestCase(CourseTestCase):
             'coursename': self.course.location.name,
         })
 
-    skipOnJenkins = lambda x: skipIf(os.getenv("JENKINS_URL"), x)
-
-    @skipOnJenkins("CorruptGridFile error on continuous integration server")
     def test_happy_path(self):
-        f = BytesIO("sample content")
-        f.name = "sample.txt"
-        resp = self.client.post(self.url, {"name": "my-name", "file": f})
-        self.assert2XX(resp.status_code)
+        with TemporaryFile() as temp:
+            temp.write('This is a test')
+            resp = self.client.post(self.url, {"name": "my-name", "file": temp})
+            self.assert2XX(resp.status_code)
 
-    @skipOnJenkins("CorruptGridFile error on continuous integration server")
     def test_large(self):
-        f = BytesIO("some content")
-        f.truncate(20 * 1024 * 1024)
-        f.name = "sample2.txt"
-        resp = self.client.post(self.url, {"name": "my-name", "file": f})
-        self.assert2XX(resp.status_code)
+        with TemporaryFile() as f:
+            f.write('Some Content')
+            f.truncate(20 * 1024 * 1024)
+            resp = self.client.post(self.url, {"name": "my-name", "file": f})
+            self.assert2XX(resp.status_code)
 
     def test_no_file(self):
         resp = self.client.post(self.url, {"name": "file.txt"})


### PR DESCRIPTION
@jzoldak @cahrens 

`skipOnJenkins` is an ugly hack, but just using `skip` seems even worse. If any of you know of some prettier way of doing, I would love to get this hack out.
