### PR TITLE
Valera/fix empty captions panel no captions

### DIFF
--- a/common/lib/xmodule/xmodule/js/spec/video/video_caption_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_caption_spec.js
@@ -126,6 +126,22 @@
           expect(videoCaption.rendered).toBeFalsy();
         });
       });
+
+      describe('when no captions file was specified', function () {
+        beforeEach(function () {
+          loadFixtures('video_all.html');
+
+          // Unspecify the captions file.
+          $('#example').find('#video_id').data('sub', '');
+
+          state = new Video('#example');
+          videoCaption = state.videoCaption;
+        });
+
+        it('captions panel is not shown', function () {
+          expect(videoCaption.hideSubtitlesEl.css('display')).toBe('none');
+        });
+      });
     });
 
     describe('mouse movement', function() {

--- a/common/lib/xmodule/xmodule/js/spec/video/video_caption_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_caption_spec.js
@@ -140,7 +140,7 @@
         });
 
         it('captions panel is not shown', function () {
-          expect(videoCaption.hideSubtitlesEl.css('display')).toBe('none');
+          expect(videoCaption.hideSubtitlesEl).toBeHidden();
         });
       });
     });

--- a/common/lib/xmodule/xmodule/js/spec/video/video_caption_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_caption_spec.js
@@ -53,7 +53,8 @@
               expect($.ajaxWithPrefix).toHaveBeenCalledWith({
                 url: videoCaption.captionURL(),
                 notifyOnError: false,
-                success: jasmine.any(Function)
+                success: jasmine.any(Function),
+                error: jasmine.any(Function),
               });
           });
         });
@@ -462,7 +463,7 @@
         });
 
         // Temporarily disabled due to intermittent failures
-        // Fails with error: "InvalidStateError: An attempt was made to 
+        // Fails with error: "InvalidStateError: An attempt was made to
         // use an object that is not, or is no longer, usable
         // Expected 0 to equal 14.91."
         // on Firefox

--- a/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
+++ b/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
@@ -25,7 +25,9 @@ function (VideoPlayer) {
      *
      * Initialize module exports this function.
      *
-     * @param {Object} state A place for all properties, and methods of Video.
+     * @param {object} state The object containg the state of the video player.
+     *     All other modules, their parameters, public variables, etc. are
+     *     available via this object.
      * @param {DOM element} element Container of the entire Video DOM element.
      */
     return function (state, element) {
@@ -40,10 +42,12 @@ function (VideoPlayer) {
     /**
      * @function _makeFunctionsPublic
      *
-     * Functions which will be accessible via 'state' object. When called, these functions will get the 'state'
+     * Functions which will be accessible via 'state' object. When called,
+     * these functions will get the 'state'
      * object as a context.
      *
-     * @param {Object} state A place for all properties, and methods of Video.
+     * @param {object} state The object containg the state (properties,
+     *     methods, modules) of the Video player.
      */
     function _makeFunctionsPublic(state) {
         state.setSpeed    = _.bind(setSpeed, state);

--- a/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
@@ -6,7 +6,20 @@ define(
 [],
 function () {
 
-    // VideoCaption() function - what this module "exports".
+    /**
+     * @desc VideoCaption module exports a function.
+     *
+     * @type {function}
+     * @access public
+     *
+     * @param {object} state - The object containg the state of the video
+     *     player. All other modules, their parameters, public variables, etc.
+     *     are available via this object.
+     *
+     * @this {object} The global window object.
+     *
+     * @returns {undefined}
+     */
     return function (state) {
         state.videoCaption = {};
 
@@ -64,11 +77,25 @@ function () {
     // The magic private function that makes them available and sets up their context is makeFunctionsPublic().
     // ***************************************************************
 
-    // function renderElements()
-    //
-    //     Create any necessary DOM elements, attach them, and set their initial configuration. Also
-    //     make the created DOM elements available via the 'state' object. Much easier to work this
-    //     way - you don't have to do repeated jQuery element selects.
+    /**
+     * @desc Create any necessary DOM elements, attach them, and set their
+     *     initial configuration. Also make the created DOM elements available
+     *     via the 'state' object. Much easier to work this way - you don't
+     *     have to do repeated jQuery element selects.
+     *
+     * @type {function}
+     * @access public
+     *
+     * @this {object} - The object containg the state of the video
+     *     player. All other modules, their parameters, public variables, etc.
+     *     are available via this object.
+     *
+     * @returns {boolean}
+     *     true: The function fethched captions successfully, and compltely
+     *         rendered everything related to captions.
+     *     false: The captions were not fetched. Nothing will be rendered,
+     *         and the CC button will be hidden.
+     */
     function renderElements() {
         this.videoCaption.loaded = false;
 
@@ -79,12 +106,10 @@ function () {
         this.el.find('.video-controls .secondary-controls').append(this.videoCaption.hideSubtitlesEl);
 
         // Fetch the captions file. If no file was specified, then we hide
-        // the "CC" button, and exit from this module. No further caption
-        // initialization will happen.
+        // the "CC" button, and return.
         if (!this.videoCaption.fetchCaption()) {
             this.videoCaption.hideSubtitlesEl.hide();
 
-            // Abandon all further operations with captions panel.
             return false;
         }
 
@@ -136,6 +161,25 @@ function () {
         }
     }
 
+    /**
+     * @desc Fetch the caption file specified by the user. Upn successful
+     *     receival of the file, the captions will be rendered.
+     *
+     * @type {function}
+     * @access public
+     *
+     * @this {object} - The object containg the state of the video
+     *     player. All other modules, their parameters, public variables, etc.
+     *     are available via this object.
+     *
+     * @returns {boolean}
+     *     true: The user specified a caption file. NOTE: if an error happens
+     *         while the specified file is being retrieved (for example the
+     *         file is missing on the server), this function will still return
+     *         true.
+     *     false: No caption file was specified, or an empty string was
+     *         specified.
+     */
     function fetchCaption() {
         var _this = this;
 

--- a/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
@@ -28,11 +28,9 @@ function () {
         // Depending on whether captions file could be loaded, the following
         // function invocation can succeed or fail. If it fails, we do not
         // go on with binding handlers to events.
-        if (!state.videoCaption.renderElements()) {
-            return;
+        if (state.videoCaption.renderElements()) {
+            state.videoCaption.bindHandlers();
         }
-
-        state.videoCaption.bindHandlers();
     };
 
     // ***************************************************************
@@ -102,9 +100,6 @@ function () {
         this.videoCaption.subtitlesEl = this.el.find('ol.subtitles');
         this.videoCaption.hideSubtitlesEl = this.el.find('a.hide-subtitles');
 
-        this.el.find('.video-wrapper').after(this.videoCaption.subtitlesEl);
-        this.el.find('.video-controls .secondary-controls').append(this.videoCaption.hideSubtitlesEl);
-
         // Fetch the captions file. If no file was specified, then we hide
         // the "CC" button, and return.
         if (!this.videoCaption.fetchCaption()) {
@@ -112,6 +107,9 @@ function () {
 
             return false;
         }
+
+        this.el.find('.video-wrapper').after(this.videoCaption.subtitlesEl);
+        this.el.find('.video-controls .secondary-controls').append(this.videoCaption.hideSubtitlesEl);
 
         this.videoCaption.setSubtitlesHeight();
 

--- a/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
@@ -95,7 +95,10 @@ function () {
         this.videoCaption.subtitlesEl = this.el.find('ol.subtitles');
         this.videoCaption.hideSubtitlesEl = this.el.find('a.hide-subtitles');
 
-        this.videoCaption.fetchCaption();
+        if (!this.videoCaption.fetchCaption()) {
+            this.videoCaption.hideCaptions(true);
+            this.videoCaption.hideSubtitlesEl.hide();
+        }
     }
 
     // function bindHandlers()
@@ -190,7 +193,6 @@ function () {
                 console.log(
                     'STATUS:', textStatus + ', MESSAGE:', '' + errorThrown
                 );
-                console.log('arguments:', arguments);
 
                 _this.videoCaption.hideCaptions(true);
                 _this.videoCaption.hideSubtitlesEl.hide();
@@ -281,9 +283,8 @@ function () {
     }
 
     function renderCaption() {
-        var container,
+        var container = $('<ol>'),
             _this = this;
-        container = $('<ol>');
 
         this.el.find('.video-wrapper').after(this.videoCaption.subtitlesEl);
         this.el.find('.video-controls .secondary-controls').append(this.videoCaption.hideSubtitlesEl);


### PR DESCRIPTION
Fix for bug BLD-277: "There is a white panel over a non-youtube video."

When a captions file was not specified, we do not show the captions panel. Also when an empty line was specified for the captions, we don't show the panel.

I the file was specified, but for some reason the browser wasn't able to retrieve it, a blank captions panel will be shown.

<i>Reviewers</i>
@polesye 
