### PR TITLE
Changed error message on failure and made test more robust

### DIFF
--- a/cms/djangoapps/contentstore/features/common.py
+++ b/cms/djangoapps/contentstore/features/common.py
@@ -265,9 +265,8 @@ def type_in_codemirror(index, text):
 
 
 def upload_file(filename):
-    file_css = '.upload-dialog input[type=file]'
-    upload = world.css_find(file_css).first
     path = os.path.join(TEST_ROOT, filename)
-    upload._element.send_keys(os.path.abspath(path))
+    world.browser.execute_script("$('input.file-input').css('display', 'block')")
+    world.browser.attach_file('file', os.path.abspath(path))
     button_css = '.upload-dialog .action-upload'
     world.css_click(button_css)

--- a/cms/djangoapps/contentstore/features/course-settings.py
+++ b/cms/djangoapps/contentstore/features/course-settings.py
@@ -168,15 +168,18 @@ def i_see_new_course_image(_step):
     img = images[0]
     expected_src = '/c4x/MITx/999/asset/image.jpg'
     # Don't worry about the domain in the URL
-    assert img['src'].endswith(expected_src)
+    try:
+        assert img['src'].endswith(expected_src)
+    except AssertionError as e:
+        e.args += ('Was looking for {}'.format(expected_src), 'Found {}'.format(img['src']))
+        raise
 
 
 @step('the image URL should be present in the field')
 def image_url_present(_step):
     field_css = '#course-image-url'
-    field = world.css_find(field_css).first
     expected_value = '/c4x/MITx/999/asset/image.jpg'
-    assert field.value == expected_value
+    assert world.css_value(field_css) == expected_value
 
 
 ############### HELPER METHODS ####################


### PR DESCRIPTION
Suggested Reviewers: @wedaly @jzoldak 
Made the image upload test a bit more robust and added in the ability for the value obtained to be printed in case of an error.  

The javascript injection is because in some cases, we hide the actual input-form button and selenium will complain on some browsers.  For the upload file function, I follow the guidelines from upload.py
