### PR TITLE
Add delete confirmation to static pages.

### DIFF
--- a/cms/djangoapps/contentstore/features/static-pages.feature
+++ b/cms/djangoapps/contentstore/features/static-pages.feature
@@ -11,8 +11,9 @@ Feature: Static Pages
         Given I have opened a new course in Studio
         And I go to the static pages page
         And I add a new page
-        When I will confirm all alerts
         And I "delete" the "Empty" page
+        Then I am shown a prompt
+        When I confirm the prompt
         Then I should not see a "Empty" static page
 
     # Safari won't update the name properly

--- a/cms/static/coffee/src/views/tabs.coffee
+++ b/cms/static/coffee/src/views/tabs.coffee
@@ -64,20 +64,31 @@ class CMS.Views.TabsEdit extends Backbone.View
       course: course_location_analytics
 
   deleteTab: (event) =>
-    if not confirm 'Are you sure you want to delete this component? This action cannot be undone.'
-      return
-    $component = $(event.currentTarget).parents('.component')
+    confirm = new CMS.Views.Prompt.Warning
+      title: gettext('Delete Component Confirmation')
+      message: gettext('Are you sure you want to delete this component? This action cannot be undone.')
+      actions:
+        primary:
+          text: gettext("OK")
+          click: (view) ->
+            view.hide()
+            $component = $(event.currentTarget).parents('.component')
 
-    analytics.track "Deleted Static Page",
-      course: course_location_analytics
-      id: $component.data('id')
-
-    $.post('/delete_item', {
-      id: $component.data('id')
-    }, =>
-      $component.remove()
-    )
-
-
-
-
+            analytics.track "Deleted Static Page",
+              course: course_location_analytics
+              id: $component.data('id')
+            deleting = new CMS.Views.Notification.Mini
+              title: gettext('Deleting') + '&hellip;'
+            deleting.show()
+            $.post('/delete_item', {
+              id: $component.data('id')
+            }, =>
+              $component.remove()
+              deleting.hide()
+            )
+        secondary: [
+          text: gettext('Cancel')
+          click: (view) ->
+            view.hide()
+        ]
+    confirm.show()


### PR DESCRIPTION
While looking into the static pages I noticed that we were still using a JS `confirm` on deletion; this makes the UI consistent with the rest of Studio.
@singingwolfboy @talbs 
