### PR TITLE
Change `rake pep8` to ignore migrations files

### DIFF
--- a/.pep8
+++ b/.pep8
@@ -1,2 +1,3 @@
 [pep8]
 ignore=E501
+exclude=migrations


### PR DESCRIPTION
@wedaly @cpennington 

The rake task we use on Jenkins to report our violations wasn't excluding migrations files, so I made it do so.

We do decrease pep8 by ~70 violations with this addition.
