### PR TITLE
Silence doc test errors/warnings

### DIFF
--- a/docs/course_authors/Makefile
+++ b/docs/course_authors/Makefile
@@ -15,13 +15,13 @@ endif
 Q_FLAG        = 
 
 ifeq ($(quiet), true)
-Q_FLAG = -q
+Q_FLAG = -Q
 endif
 
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = -q -d $(BUILDDIR)/doctrees -c source $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
+ALLSPHINXOPTS   = $(Q_FLAG) -d $(BUILDDIR)/doctrees -c source $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
 

--- a/docs/data/Makefile
+++ b/docs/data/Makefile
@@ -15,13 +15,13 @@ endif
 Q_FLAG        = 
 
 ifeq ($(quiet), true)
-Q_FLAG = -q
+Q_FLAG = -Q
 endif
 
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = -q -d $(BUILDDIR)/doctrees -c source $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
+ALLSPHINXOPTS   = $(Q_FLAG) -d $(BUILDDIR)/doctrees -c source $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
 

--- a/docs/developers/Makefile
+++ b/docs/developers/Makefile
@@ -15,7 +15,7 @@ endif
 Q_FLAG        = 
 
 ifeq ($(quiet), true)
-Q_FLAG = -q
+Q_FLAG = -Q
 endif
 
 # Internal variables.

--- a/rakelib/docs.rake
+++ b/rakelib/docs.rake
@@ -18,7 +18,7 @@ task :builddocs, [:type, :quiet] do |t, args|
         if args.quiet == 'verbose'
             sh('make html quiet=false')
         else
-            sh('make html')
+            sh('make html quiet=true')
         end
     end
 end


### PR DESCRIPTION
The doc tests print a lot of warnings/errors to the console when running the test suite.  This silences those errors, but will still fail if exceptions are raised during the build.

Reviewer: @jzoldak
