### PR TITLE
FIX: videosequence was not inheriting metadata, eg start date

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -313,7 +313,7 @@ class MongoModuleStore(ModuleStoreBase):
         query = {'_id.org': location.org,
                  '_id.course': location.course,
                  '_id.category': {'$in': ['course', 'chapter', 'sequential', 'vertical', 'videosequence',
-                                          'wrapper', 'problemset', 'conditional', 'randomize', 'proctor']}
+                                          'wrapper', 'problemset', 'conditional', 'randomize']}
                  }
         # we just want the Location, children, and inheritable metadata
         record_filter = {'_id': 1, 'definition.children': 1}

--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -312,8 +312,8 @@ class MongoModuleStore(ModuleStoreBase):
         # note this is a bit ugly as when we add new categories of containers, we have to add it here
         query = {'_id.org': location.org,
                  '_id.course': location.course,
-                 '_id.category': {'$in': ['course', 'chapter', 'sequential', 'vertical',
-                                          'wrapper', 'problemset', 'conditional', 'randomize']}
+                 '_id.category': {'$in': ['course', 'chapter', 'sequential', 'vertical', 'videosequence',
+                                          'wrapper', 'problemset', 'conditional', 'randomize', 'proctor']}
                  }
         # we just want the Location, children, and inheritable metadata
         record_filter = {'_id': 1, 'definition.children': 1}


### PR DESCRIPTION
For a module to be able to inherit metadata from its parent, it needs to be included in a list in `common/lib/xmodule/xmodule/modulestore/mongo/base.py`.  The list left out `videosequence` by mistake.

This was breaking a number of MIT courses, eg 2.01x.  

A symptom of this error is when "start" dates are not being inherited by problems inside videosequence containers; they show up as the default 1970 instead.
