### PR TITLE
Video Player: replace the description in the studio editing module for "subtitles" with "timed transcript"

### DIFF
--- a/cms/djangoapps/contentstore/features/video-editor.py
+++ b/cms/djangoapps/contentstore/features/video-editor.py
@@ -29,7 +29,7 @@ def correct_video_settings(_step):
                                       ['Download Track', '', False],
                                       ['Download Video', '', False],
                                       ['End Time', '0', False],
-                                      ['HTML5 Subtitles', '', False],
+                                      ['HTML5 Timed Transcript', '', False],
                                       ['Show Captions', 'True', False],
                                       ['Start Time', '0', False],
                                       ['Video Sources', '', False],

--- a/common/lib/xmodule/xmodule/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module.py
@@ -104,14 +104,14 @@ class VideoFields(object):
         default=[]
     )
     track = String(
-        help="The external URL to download the subtitle track. This appears as a link beneath the video.",
+        help="The external URL to download the timed transcript track. This appears as a link beneath the video.",
         display_name="Download Track",
         scope=Scope.settings,
         default=""
     )
     sub = String(
-        help="The name of the subtitle track (for non-Youtube videos).",
-        display_name="HTML5 Subtitles",
+        help="The name of the timed transcript track (for non-Youtube videos).",
+        display_name="HTML5 Timed Transcript",
         scope=Scope.settings,
         default=""
     )


### PR DESCRIPTION
Fix for BLD-263: " Replace the description in the studio editing module for "subtitles" with "timed transcript" ".

"Timed transcript" is the more accurate word, and it will make us look better to be more accurate.

_Reviewers_
**@valera-rozuvan**
