### PR TITLE
Keep comments in capa XML from causing failures

### DIFF
--- a/common/lib/capa/capa/capa_problem.py
+++ b/common/lib/capa/capa/capa_problem.py
@@ -555,6 +555,13 @@ class LoncapaProblem(object):
 
         Used by get_html.
         '''
+        if not isinstance(problemtree.tag, basestring):
+            # Comment and ProcessingInstruction nodes are not Elements,
+            # and we're ok leaving those behind.
+            # BTW: etree gives us no good way to distinguish these things
+            # other than to examine .tag to see if it's a string. :(
+            return
+
         if (problemtree.tag == 'script' and problemtree.get('type')
             and 'javascript' in problemtree.get('type')):
             # leave javascript intact.

--- a/common/lib/capa/capa/tests/test_html_render.py
+++ b/common/lib/capa/capa/tests/test_html_render.py
@@ -226,6 +226,26 @@ class CapaHtmlRenderTest(unittest.TestCase):
         span_element = rendered_html.find('span')
         self.assertEqual(span_element.get('attr'), "TEST")
 
+    def test_xml_comments_and_other_odd_things(self):
+        # Comments and processing instructions should be skipped.
+        xml_str = textwrap.dedent("""\
+            <?xml version="1.0" encoding="utf-8"?>
+            <!DOCTYPE html [
+                <!ENTITY % wacky "lxml.etree is wacky!">
+            ]>
+            <problem>
+            <!-- A commment. -->
+            <?ignore this processing instruction. ?>
+            </problem>
+        """)
+
+        # Create the problem
+        problem = new_loncapa_problem(xml_str)
+
+        # Render the HTML
+        the_html = problem.get_html()
+        self.assertRegexpMatches(the_html, r"<div>\s+</div>")
+
     def _create_test_file(self, path, content_str):
         test_fp = self.system.filestore.open(path, "w")
         test_fp.write(content_str)


### PR DESCRIPTION
Comments (and processing instructions!) are handled oddly in lxml.
This change will keep them from causing failures.  They will be omitted
from the HTML generated, which is fine, since they aren't needed there.

@cpennington, @adampalay: Look good?
