### PR TITLE
Use randomized mongo collection names in Studio tests

### DIFF
--- a/cms/djangoapps/contentstore/tests/modulestore_config.py
+++ b/cms/djangoapps/contentstore/tests/modulestore_config.py
@@ -1,0 +1,8 @@
+"""
+Define test configuration for modulestores.
+"""
+
+from xmodule.modulestore.tests.django_utils import studio_store_config
+from django.conf import settings
+
+TEST_MODULESTORE = studio_store_config(settings.TEST_ROOT / "data")

--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -25,6 +25,7 @@ from contentstore.tests.utils import parse_json
 from auth.authz import add_user_to_creator_group
 
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from contentstore.tests.modulestore_config import TEST_MODULESTORE
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
 from xmodule.modulestore import Location, mongo
@@ -68,7 +69,7 @@ class MongoCollectionFindWrapper(object):
         return self.original(query, *args, **kwargs)
 
 
-@override_settings(CONTENTSTORE=TEST_DATA_CONTENTSTORE)
+@override_settings(CONTENTSTORE=TEST_DATA_CONTENTSTORE, MODULESTORE=TEST_MODULESTORE)
 class ContentStoreToyCourseTest(ModuleStoreTestCase):
     """
     Tests that rely on the toy courses.
@@ -1180,7 +1181,7 @@ class ContentStoreToyCourseTest(ModuleStoreTestCase):
         export_to_xml(module_store, content_store, location, root_dir, 'test_export')
 
 
-@override_settings(CONTENTSTORE=TEST_DATA_CONTENTSTORE)
+@override_settings(CONTENTSTORE=TEST_DATA_CONTENTSTORE, MODULESTORE=TEST_MODULESTORE)
 class ContentStoreTest(ModuleStoreTestCase):
     """
     Tests for the CMS ContentStore application.
@@ -1707,6 +1708,7 @@ class ContentStoreTest(ModuleStoreTestCase):
         content_store.find(location)
 
 
+@override_settings(MODULESTORE=TEST_MODULESTORE)
 class MetadataSaveTestCase(ModuleStoreTestCase):
     """Test that metadata is correctly cached and decached."""
 

--- a/cms/djangoapps/contentstore/tests/test_i18n.py
+++ b/cms/djangoapps/contentstore/tests/test_i18n.py
@@ -3,10 +3,13 @@ from unittest import skip
 from django.core.urlresolvers import reverse
 from django.contrib.auth.models import User
 from django.test.client import Client
+from django.test.utils import override_settings
 
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from contentstore.tests.modulestore_config import TEST_MODULESTORE
 
 
+@override_settings(MODULESTORE=TEST_MODULESTORE)
 class InternationalizationTest(ModuleStoreTestCase):
     """
     Tests to validate Internationalization.

--- a/cms/djangoapps/contentstore/tests/test_import_nostatic.py
+++ b/cms/djangoapps/contentstore/tests/test_import_nostatic.py
@@ -12,6 +12,7 @@ import copy
 from django.contrib.auth.models import User
 
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from contentstore.tests.modulestore_config import TEST_MODULESTORE
 
 from xmodule.modulestore import Location
 from xmodule.modulestore.django import modulestore
@@ -30,7 +31,7 @@ TEST_DATA_CONTENTSTORE = copy.deepcopy(settings.CONTENTSTORE)
 TEST_DATA_CONTENTSTORE['OPTIONS']['db'] = 'test_xcontent_%s' % uuid4().hex
 
 
-@override_settings(CONTENTSTORE=TEST_DATA_CONTENTSTORE)
+@override_settings(CONTENTSTORE=TEST_DATA_CONTENTSTORE, MODULESTORE=TEST_MODULESTORE)
 class ContentStoreImportNoStaticTest(ModuleStoreTestCase):
     """
     Tests that rely on the toy and test_import_course courses.

--- a/cms/djangoapps/contentstore/tests/tests.py
+++ b/cms/djangoapps/contentstore/tests/tests.py
@@ -1,15 +1,18 @@
 from django.test.client import Client
+from django.test.utils import override_settings
 from django.core.cache import cache
 from django.core.urlresolvers import reverse
 
-from .utils import parse_json, user, registration
+from contentstore.tests.utils import parse_json, user, registration
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from contentstore.tests.test_course_settings import CourseTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
+from contentstore.tests.modulestore_config import TEST_MODULESTORE
 import datetime
 from pytz import UTC
 
 
+@override_settings(MODULESTORE=TEST_MODULESTORE)
 class ContentStoreTestCase(ModuleStoreTestCase):
     def _login(self, email, password):
         """

--- a/cms/djangoapps/contentstore/tests/utils.py
+++ b/cms/djangoapps/contentstore/tests/utils.py
@@ -7,9 +7,11 @@ import json
 from student.models import Registration
 from django.contrib.auth.models import User
 from django.test.client import Client
+from django.test.utils import override_settings
 
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
+from contentstore.tests.modulestore_config import TEST_MODULESTORE
 
 
 def parse_json(response):
@@ -27,6 +29,7 @@ def registration(email):
     return Registration.objects.get(user__email=email)
 
 
+@override_settings(MODULESTORE=TEST_MODULESTORE)
 class CourseTestCase(ModuleStoreTestCase):
     def setUp(self):
         """

--- a/common/lib/xmodule/xmodule/modulestore/tests/django_utils.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/django_utils.py
@@ -110,6 +110,41 @@ def xml_store_config(data_dir):
     return store
 
 
+def studio_store_config(data_dir):
+    """
+    Defines modulestore structure used by Studio tests.
+    """
+    options = {
+        'default_class': 'xmodule.raw_module.RawDescriptor',
+        'host': 'localhost',
+        'db': 'test_xmodule',
+        'collection': 'modulestore_%s' % uuid4().hex,
+        'fs_root': data_dir,
+        'render_template': 'mitxmako.shortcuts.render_to_string',
+    }
+
+    store = {
+        'default': {
+            'ENGINE': 'xmodule.modulestore.draft.DraftModuleStore',
+            'OPTIONS': options
+        },
+        'direct': {
+            'ENGINE': 'xmodule.modulestore.mongo.MongoModuleStore',
+            'OPTIONS': options
+        },
+        'draft': {
+            'ENGINE': 'xmodule.modulestore.draft.DraftModuleStore',
+            'OPTIONS': options
+        },
+        'split': {
+            'ENGINE': 'xmodule.modulestore.split_mongo.SplitMongoModuleStore',
+            'OPTIONS': options
+        }
+    }
+
+    return store
+
+
 class ModuleStoreTestCase(TestCase):
     """
     Subclass for any test case that uses a ModuleStore.


### PR DESCRIPTION
This fixes the cause of a recent deploy branch failure.  All `ModuleStoreTestCase` subclasses in the Studio test suite now correctly override settings to use randomized collection names, thus avoiding parallelization conflicts in Jenkins.

@jzoldak
