### PR TITLE
Email Receipts and Billing Information

### DIFF
--- a/lms/djangoapps/shoppingcart/models.py
+++ b/lms/djangoapps/shoppingcart/models.py
@@ -2,6 +2,7 @@ import pytz
 import logging
 from datetime import datetime
 from django.db import models
+from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.contrib.auth.models import User
 from django.utils.translation import ugettext as _
@@ -102,15 +103,16 @@ class Order(models.Model):
         self.purchase_time = datetime.now(pytz.utc)
         self.bill_to_first = first
         self.bill_to_last = last
-        self.bill_to_street1 = street1
-        self.bill_to_street2 = street2
         self.bill_to_city = city
         self.bill_to_state = state
-        self.bill_to_postalcode = postalcode
         self.bill_to_country = country
-        self.bill_to_ccnum = ccnum
-        self.bill_to_cardtype = cardtype
-        self.processor_reply_dump = processor_reply_dump
+        self.bill_to_postalcode = postalcode
+        if settings.MITX_FEATURES['STORE_BILLING_INFO']:
+            self.bill_to_street1 = street1
+            self.bill_to_street2 = street2
+            self.bill_to_ccnum = ccnum
+            self.bill_to_cardtype = cardtype
+            self.processor_reply_dump = processor_reply_dump
         # save these changes on the order, then we can tell when we are in an
         # inconsistent state
         self.save()

--- a/lms/djangoapps/shoppingcart/processors/tests/test_CyberSource.py
+++ b/lms/djangoapps/shoppingcart/processors/tests/test_CyberSource.py
@@ -116,14 +116,10 @@ class CyberSourceTests(TestCase):
         order2 = Order.get_cart_for_user(student2)
         record_purchase(params_cc, order1)
         record_purchase(params_nocc, order2)
-        self.assertEqual(order1.bill_to_ccnum, '1234')
-        self.assertEqual(order1.bill_to_cardtype, 'Visa')
         self.assertEqual(order1.bill_to_first, student1.first_name)
         self.assertEqual(order1.status, 'purchased')
 
         order2 = Order.objects.get(user=student2)
-        self.assertEqual(order2.bill_to_ccnum, '####')
-        self.assertEqual(order2.bill_to_cardtype, 'MasterCard')
         self.assertEqual(order2.bill_to_first, student2.first_name)
         self.assertEqual(order2.status, 'purchased')
 

--- a/lms/djangoapps/shoppingcart/tests/test_models.py
+++ b/lms/djangoapps/shoppingcart/tests/test_models.py
@@ -6,6 +6,7 @@ from factory import DjangoModelFactory
 from mock import patch
 from django.test import TestCase
 from django.test.utils import override_settings
+from django.conf import settings
 from django.db import DatabaseError
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
@@ -87,6 +88,53 @@ class OrderTest(TestCase):
                 # verify that we rolled back the entire transaction
                 self.assertFalse(CourseEnrollment.is_enrolled(self.user, self.course_id))
 
+    def purchase_with_data(self, cart):
+        """ purchase a cart with billing information """
+        CertificateItem.add_to_order(cart, self.course_id, self.cost, 'verified')
+        cart.purchase(
+            first='John',
+            last='Smith',
+            street1='11 Cambridge Center',
+            street2='Suite 101',
+            city='Cambridge',
+            state='MA',
+            postalcode='02412',
+            country='US',
+            ccnum='1111',
+            cardtype='001',
+        )
+
+    @patch.dict(settings.MITX_FEATURES, {'STORE_BILLING_INFO': True})
+    def test_billing_info_storage_on(self):
+        cart = Order.get_cart_for_user(self.user)
+        self.purchase_with_data(cart)
+        self.assertNotEqual(cart.bill_to_first, '')
+        self.assertNotEqual(cart.bill_to_last, '')
+        self.assertNotEqual(cart.bill_to_street1, '')
+        self.assertNotEqual(cart.bill_to_street2, '')
+        self.assertNotEqual(cart.bill_to_postalcode, '')
+        self.assertNotEqual(cart.bill_to_ccnum, '')
+        self.assertNotEqual(cart.bill_to_cardtype, '')
+        self.assertNotEqual(cart.bill_to_city, '')
+        self.assertNotEqual(cart.bill_to_state, '')
+        self.assertNotEqual(cart.bill_to_country, '')
+
+    @patch.dict(settings.MITX_FEATURES, {'STORE_BILLING_INFO': False})
+    def test_billing_info_storage_off(self):
+        cart = Order.get_cart_for_user(self.user)
+        cart = Order.get_cart_for_user(self.user)
+        self.purchase_with_data(cart)
+        self.assertNotEqual(cart.bill_to_first, '')
+        self.assertNotEqual(cart.bill_to_last, '')
+        self.assertNotEqual(cart.bill_to_city, '')
+        self.assertNotEqual(cart.bill_to_state, '')
+        self.assertNotEqual(cart.bill_to_country, '')
+        self.assertNotEqual(cart.bill_to_postalcode, '')
+        # things we expect to be missing when the feature is off
+        self.assertEqual(cart.bill_to_street1, '')
+        self.assertEqual(cart.bill_to_street2, '')
+        self.assertEqual(cart.bill_to_ccnum, '')
+        self.assertEqual(cart.bill_to_cardtype, '')
 
 class OrderItemTest(TestCase):
     def setUp(self):

--- a/lms/djangoapps/shoppingcart/tests/test_views.py
+++ b/lms/djangoapps/shoppingcart/tests/test_views.py
@@ -191,7 +191,6 @@ class ShoppingCartViewsTests(ModuleStoreTestCase):
         resp = self.client.get(reverse('shoppingcart.views.show_receipt', args=[self.cart.id]))
         self.assertEqual(resp.status_code, 200)
         self.assertIn('FirstNameTesting123', resp.content)
-        self.assertIn('StreetTesting123', resp.content)
         self.assertIn('80.00', resp.content)
 
         ((template, context), _) = render_mock.call_args

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -156,7 +156,10 @@ MITX_FEATURES = {
     'ENABLE_CHAT': False,
 
     # Toggle the availability of the shopping cart page
-    'ENABLE_SHOPPING_CART': False
+    'ENABLE_SHOPPING_CART': False,
+
+    # Toggle storing detailed billing information
+    'STORE_BILLING_INFO': False
 }
 
 # Used for A/B testing

--- a/lms/templates/emails/order_confirmation_email.txt
+++ b/lms/templates/emails/order_confirmation_email.txt
@@ -1,0 +1,15 @@
+<%! from django.utils.translation import ugettext as _ %>
+
+${_("Thank you for your order! Payment was successful, and you should be able to see the results on your dashboard.")}
+
+${_("Your order number is: {order_number}").format(order_number=order.id)}
+
+${_("Items in your order:")}
+
+${_("Quantity - Description - Price")}
+%for order_item in order_items:
+    ${order_item.qty} - ${order_item.line_desc} - $(order_item.line_cost}
+%endfor
+${_("Total: {total_cost}").format(total_cost=order.total_cost)}
+
+${_("If you have any issues, please contact us at {billing_email}").format(billing_email=settings.PAYMENT_SUPPORT_EMAIL)}


### PR DESCRIPTION
- Send an e-mail receipt once purchase is completed.
- Only save certain pieces of billing information when a setting is turned on.

@ormsbee
