### PR TITLE
bugfix: Course static_tabs importing with display_name = "None"

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_import_nostatic.py
+++ b/cms/djangoapps/contentstore/tests/test_import_nostatic.py
@@ -127,3 +127,9 @@ class ContentStoreImportNoStaticTest(ModuleStoreTestCase):
 
         handouts = module_store.get_item(Location(['i4x', 'edX', 'toy', 'html', 'toyhtml', None]))
         self.assertIn('/static/', handouts.data)
+
+    def test_tab_name_imports_correctly(self):
+        module_store, content_store, course, course_location = self.load_test_import_course()
+        print "course tabs = {0}".format(course.tabs)
+        self.assertEqual(course.tabs[2]['name'],'Syllabus')
+        

--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -794,7 +794,7 @@ class MongoModuleStore(ModuleStoreBase):
             existing_tabs = course.tabs or []
             for tab in existing_tabs:
                 if tab.get('url_slug') == loc.name:
-                    tab['name'] = metadata.get('display_name')
+                    tab['name'] = tab.get('name', metadata.get('display_name'))
                     break
             course.tabs = existing_tabs
             # Save the updates to the course to the MongoKeyValueStore

--- a/common/test/data/test_import_course/tabs/resources.html
+++ b/common/test/data/test_import_course/tabs/resources.html
@@ -1,0 +1,1 @@
+<div>resources!</div>

--- a/common/test/data/test_import_course/tabs/syllabus.html
+++ b/common/test/data/test_import_course/tabs/syllabus.html
@@ -1,0 +1,1 @@
+<h1>This is a syllabus</h1>


### PR DESCRIPTION
There is special code in `common/lib/xmodule/xmodule/modulestore/mongo/base.py` to handle setting of `tab['name']` in the course module, for `static_tab` modules which are imported.  This code can overwrite a perfectly fine `tab['name']` value with a `None` during a course import, if the metadata for the static tab module doesn't specify the `display_name`.  

This PR fixes that bug.  Test included.

(it may be that the hack in there should go away entirely: https://github.com/edx/edx-platform/blob/493d8d26e592400230f51905851a23ccfc634d5b/common/lib/xmodule/xmodule/modulestore/mongo/base.py#L679)
