### PR TITLE
Check extension rather than mimetype

### DIFF
--- a/cms/templates/import.html
+++ b/cms/templates/import.html
@@ -72,7 +72,7 @@ $('#fileupload').fileupload({
     add: function(e, data) {
         submitBtn.unbind('click');
         var file = data.files[0];
-        if (file.type == "application/x-gzip") {
+        if (file.name.match(/tar\.gz$/)) {
             submitBtn.click(function(e){
                 e.preventDefault();
                 submitBtn.hide();


### PR DESCRIPTION
@chrisndodge I still can't really reproduce your issue, but I tried playing with the if-expr, and it seems pretty certain it was caused by the file.type not matching "application/x-gzip". Switched to matching the filename extension - let me know if this works for you.
@cahrens Another pair of eyes?
