### PR TITLE
Properly display student progress

### DIFF
--- a/common/lib/xmodule/xmodule/open_ended_grading_classes/combined_open_ended_modulev1.py
+++ b/common/lib/xmodule/xmodule/open_ended_grading_classes/combined_open_ended_modulev1.py
@@ -5,11 +5,11 @@ from xmodule.timeinfo import TimeInfo
 from xmodule.capa_module import ComplexEncoder
 from xmodule.progress import Progress
 from xmodule.stringify import stringify_children
-import self_assessment_module
-import open_ended_module
+from  xmodule.open_ended_grading_classes import self_assessment_module
+from  xmodule.open_ended_grading_classes import open_ended_module
 from functools import partial
 from .combined_open_ended_rubric import CombinedOpenEndedRubric, GRADER_TYPE_IMAGE_DICT, HUMAN_GRADER_TYPE, LEGEND_LIST
-from peer_grading_service import PeerGradingService, MockPeerGradingService, GradingServiceError
+from xmodule.open_ended_grading_classes.peer_grading_service import PeerGradingService, MockPeerGradingService, GradingServiceError
 
 log = logging.getLogger("mitx.courseware")
 
@@ -547,6 +547,11 @@ class CombinedOpenEndedV1Module():
         return last_response_dict
 
     def extract_human_name_from_task(self, task_xml):
+        """
+        Given the xml for a task, pull out the human name for it.
+        Input: xml string
+        Output: a human readable task name (ie Self Assessment)
+        """
         tree = etree.fromstring(task_xml)
         payload = tree.xpath("/openended/openendedparam/grader_payload")
         if len(payload) == 0:
@@ -644,7 +649,13 @@ class CombinedOpenEndedV1Module():
         all_responses = []
         success, can_see_rubric, error = self.check_if_student_has_done_needed_grading()
         if not can_see_rubric:
-            return {'html' : self.system.render_template('{0}/combined_open_ended_hidden_results.html'.format(self.TEMPLATE_DIR), {'error' : error}), 'success' : True, 'hide_reset' : True}
+            return {
+                'html': self.system.render_template(
+                    '{0}/combined_open_ended_hidden_results.html'.format(self.TEMPLATE_DIR),
+                    {'error': error}),
+                'success': True,
+                'hide_reset': True
+            }
 
         contexts = []
         rubric_number = self.current_task_number
@@ -717,6 +728,9 @@ class CombinedOpenEndedV1Module():
         return json.dumps(d, cls=ComplexEncoder)
 
     def get_current_state(self, data):
+        """
+        Gets the current state of the module.
+        """
         return self.get_context()
 
     def get_last_response_ajax(self, data):
@@ -866,7 +880,6 @@ class CombinedOpenEndedV1Module():
             if len(score_mat) > 0:
                 # Currently, assume that the final step is the correct one, and that those are the final scores.
                 # This will change in the future, which is why the machinery above exists to extract all scores on all steps
-                # TODO: better final score handling.
                 scores = score_mat[-1]
                 score = max(scores)
             else:

--- a/common/lib/xmodule/xmodule/open_ended_grading_classes/combined_open_ended_modulev1.py
+++ b/common/lib/xmodule/xmodule/open_ended_grading_classes/combined_open_ended_modulev1.py
@@ -906,17 +906,11 @@ class CombinedOpenEndedV1Module():
         """
 
         d = self.get_score()
-        score = d['score']
-        total = d['total']
 
-        if total > 0 and self.is_scored:
-            if self.weight is not None:
-                # scale score and total by weight/total:
-                score = score * self.get_weight() / total
-                total = self.get_weight()
+        if d['total'] > 0 and self.is_scored:
 
             try:
-                return Progress(score, total)
+                return Progress(d['score'], d['total'])
             except (TypeError, ValueError):
                 log.exception("Got bad progress")
                 return None

--- a/common/lib/xmodule/xmodule/tests/test_combined_open_ended.py
+++ b/common/lib/xmodule/xmodule/tests/test_combined_open_ended.py
@@ -22,6 +22,7 @@ from xmodule.open_ended_grading_classes.grading_service_module import GradingSer
 from xmodule.combined_open_ended_module import CombinedOpenEndedModule
 from xmodule.modulestore import Location
 from xmodule.tests import get_test_system, test_util_open_ended
+from xmodule.progress import Progress
 from xmodule.tests.test_util_open_ended import (MockQueryDict, DummyModulestore, TEST_STATE_SA_IN,
     MOCK_INSTANCE_STATE, TEST_STATE_SA, TEST_STATE_AI, TEST_STATE_AI2, TEST_STATE_AI2_INVALID,
     TEST_STATE_SINGLE, TEST_STATE_PE_SINGLE)
@@ -479,6 +480,29 @@ class CombinedOpenEndedModuleTest(unittest.TestCase):
         #The progress view requires that this function be exposed
         max_score = self.combinedoe_container.max_score()
         self.assertEqual(max_score, None)
+
+    def test_container_get_progress(self):
+        """
+        See if we can get the progress from the actual xmodule
+        """
+        progress = self.combinedoe_container.max_score()
+        self.assertEqual(progress, None)
+
+    def test_get_progress(self):
+        """
+        Test if we can get the correct progress from the combined open ended class
+        """
+        self.combinedoe.update_task_states()
+        self.combinedoe.state = "done"
+        self.combinedoe.is_scored = True
+        progress = self.combinedoe.get_progress()
+        self.assertIsInstance(progress, Progress)
+
+        #progress._a is the score of the xmodule, which is 0 right now
+        self.assertEqual(progress._a, 0)
+
+        #progress._b is the max_score (which is 1), divided by the weight (which is 1)
+        self.assertEqual(progress._b, 1)
 
     def test_container_weight(self):
         """

--- a/common/lib/xmodule/xmodule/tests/test_combined_open_ended.py
+++ b/common/lib/xmodule/xmodule/tests/test_combined_open_ended.py
@@ -498,10 +498,10 @@ class CombinedOpenEndedModuleTest(unittest.TestCase):
         progress = self.combinedoe.get_progress()
         self.assertIsInstance(progress, Progress)
 
-        #progress._a is the score of the xmodule, which is 0 right now
+        # progress._a is the score of the xmodule, which is 0 right now.
         self.assertEqual(progress._a, 0)
 
-        #progress._b is the max_score (which is 1), divided by the weight (which is 1)
+        # progress._b is the max_score (which is 1), divided by the weight (which is 1).
         self.assertEqual(progress._b, 1)
 
     def test_container_weight(self):


### PR DESCRIPTION
Fix progress display for open ended problems.  Previously, progress was different from the notion of progress in capa.  Made them consistent, and added tests.
