### PR TITLE
Staff information about duplicate ORA submissions

### DIFF
--- a/common/lib/xmodule/xmodule/css/combinedopenended/display.scss
+++ b/common/lib/xmodule/xmodule/css/combinedopenended/display.scss
@@ -964,3 +964,11 @@ section.peer-grading-container{
         }
     }
 }
+
+div.staff-info{
+    background-color: #eee;
+    border-radius: 10px;
+    border-bottom: 1px solid lightgray;
+    padding: 10px;
+    margin: 10px 0px 10px 0px;
+}

--- a/common/lib/xmodule/xmodule/open_ended_grading_classes/combined_open_ended_modulev1.py
+++ b/common/lib/xmodule/xmodule/open_ended_grading_classes/combined_open_ended_modulev1.py
@@ -386,7 +386,8 @@ class CombinedOpenEndedV1Module():
             'accept_file_upload': self.accept_file_upload,
             'location': self.location,
             'legend_list': LEGEND_LIST,
-            'human_state': HUMAN_STATES.get(self.state, "Not started.")
+            'human_state': HUMAN_STATES.get(self.state, "Not started."),
+            'is_staff': self.system.user_is_staff
         }
 
         return context

--- a/common/lib/xmodule/xmodule/open_ended_grading_classes/combined_open_ended_modulev1.py
+++ b/common/lib/xmodule/xmodule/open_ended_grading_classes/combined_open_ended_modulev1.py
@@ -387,7 +387,7 @@ class CombinedOpenEndedV1Module():
             'location': self.location,
             'legend_list': LEGEND_LIST,
             'human_state': HUMAN_STATES.get(self.state, "Not started."),
-            'is_staff': self.system.user_is_staff
+            'is_staff': self.system.user_is_staff,
         }
 
         return context

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -807,7 +807,11 @@ def _msk_from_problem_urlname(course_id, urlname):
     if urlname.endswith(".xml"):
         urlname = urlname[:-4]
 
-    urlname = "problem/" + urlname
+    # Combined open ended problems also have state that can be deleted.  However,
+    # appending "problem" will only allow capa problems to be reset.
+    # Get around this for combinedopenended problems.
+    if "combinedopenended" not in urlname:
+        urlname = "problem/" + urlname
 
     (org, course_name, __) = course_id.split("/")
     module_state_key = "i4x://" + org + "/" + course_name + "/" + urlname

--- a/lms/templates/combinedopenended/combined_open_ended.html
+++ b/lms/templates/combinedopenended/combined_open_ended.html
@@ -56,5 +56,10 @@
         <div class="result-container">
         </div>
     </div>
+    % if is_staff:
+        <div class="staff-info">
+            Staff Warning: Please note that if you submit a duplicate of text that has already been submitted for grading, it will not show up in the staff grading view.  It will be given the same grade that the original received automatically, and will be returned within 30 minutes if the original is already graded, or when the original is graded if not.
+        </div>
+    % endif
 </section>
 

--- a/lms/templates/instructor/staff_grading.html
+++ b/lms/templates/instructor/staff_grading.html
@@ -27,7 +27,7 @@
 <section class="problem-list-container">
   <h2>${_("Instructions")}</h2>
   <div class="instructions">
-    <p>${_("This is the list of problems that currently need to be graded in order to train the machine learning models. Each problem needs to be trained separately, and we have indicated the number of student submissions that need to be graded in order for a model to be generated. You can grade more than the minimum required number of submissions--this will improve the accuracy of machine learning, though with diminishing returns. You can see the current accuracy of machine learning while grading.")}</p>
+    <p>${_("This is the list of problems that currently need to be graded in order to train AI grading and create calibration essays for peer grading. Each problem needs to be treated separately, and we have indicated the number of student submissions that need to be graded.  You can grade more than the minimum required number of submissions--this will improve the accuracy of AI grading, though with diminishing returns. You can see the current accuracy of AI grading in the problem view.")}</p>
   </div>
 
   <h2>${_("Problem List")}</h2>
@@ -45,6 +45,9 @@
       <div class="problem-meta-info-container">
       </div>
       <div class="ml-error-info-container">
+      </div>
+      <div class="checkout-warning">
+          <p>${_("Please note that when you see a submission here, it has been temporarily removed from the grading pool.  The submission will return to the grading pool after 30 minutes without any grade being submitted.  Hitting the back button will result in a 30 minute wait to be able to grade this submission again.")}</p>
       </div>
   </div>
   <div class="prompt-information-container">


### PR DESCRIPTION
Pulled out for review, please don't merge yet.

The open response assessor checks for duplicate submissions, and doesn't let staff grade anything that is a duplicate.  So if you make a submission and it is a duplicate, you will have to wait for up to 30 minutes for a grade to come back, and have no warning of what is happening.

Staff have expressed some frustration over this, because it results in them submitting something, going to the staff grading view, and not seeing anything to grade.  They then think that it is a bug, when it is not.

This PR gives them information about duplicate submissions.

Other ways to address the same problem:
- Give staff a way to reset submissions (ie, make reset state in the instructor dashboard work for ORA and capa, not just capa)
- Have some more info/warnings in edX101 (I don't think this is sufficient).
- A popup in studio with the information?

Pulling this out so that we can discuss how to best communicate this information.  @marcotuts your input would be great here, as would yours, @stroilova .

Here is a screenshot of how it looks (see the very bottom):

![staff_warning](https://f.cloud.github.com/assets/913340/1089989/3951658a-164e-11e3-9526-13e9176cbb5c.png)

Another issue is that when a submission is shown to the staff to grade, it is "checked out" on the backend and removed from the grading pool.  If there is no response for 30 minutes, the submission is put back into the pool.  When staff view a submission, and then hit back, they are surprised about why the submission "disappears", but it will in fact return in 30 minutes.  Add some messaging around this:

![selection_009](https://f.cloud.github.com/assets/913340/1089994/454deaf2-164e-11e3-90a1-414f1b907554.png)
