### PR TITLE
update version numbers of calc, chem, sandbox-packages, symmath

### DIFF
--- a/common/lib/calc/setup.py
+++ b/common/lib/calc/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="calc",
-    version="0.1.1",
+    version="0.1.2",
     py_modules=["calc"],
     install_requires=[
         "pyparsing==1.5.6",

--- a/common/lib/chem/setup.py
+++ b/common/lib/chem/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="chem",
-    version="0.1.1",
+    version="0.1.2",
     packages=["chem"],
     install_requires=[
         "pyparsing==1.5.6",

--- a/common/lib/sandbox-packages/setup.py
+++ b/common/lib/sandbox-packages/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="sandbox-packages",
-    version="0.1.1",
+    version="0.1.2",
     packages=[
         "loncapa",
         "verifiers",

--- a/common/lib/symmath/setup.py
+++ b/common/lib/symmath/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="symmath",
-    version="0.1",
+    version="0.2",
     packages=["symmath"],
     install_requires=[
         "sympy",


### PR DESCRIPTION
This pull request should fix the issues we're seeing with sandboxing not working for customresponse problems.

If version numbers are not updated on required packages, then setup is not run on them to save time on code deploys. Updating the version numbers would require setup scripts to be run, which should do things like add pyparsing to the sandbox virtualenvs.

Deploying to stage-edge will confirm if this works or not.

Addresses https://edx-wiki.atlassian.net/browse/LMS-972

@nedbat 
@jarv 
