### PR TITLE
Pass student grade label to certification process

### DIFF
--- a/lms/djangoapps/certificates/queue.py
+++ b/lms/djangoapps/certificates/queue.py
@@ -192,6 +192,7 @@ class XQueueCertInterface(object):
                         'username': student.username,
                         'course_id': course_id,
                         'name': profile.name,
+                        'grade': grade['grade'],
                     }
                     cert.status = status.generating
                     cert.save()


### PR DESCRIPTION
This is a tiny change to add the label associated to the student's score to the other metadata passed to the certificates server on the xqueue. This way the certificates server can use that label to render certificates differently based on how the student did.

@jarv and @ormsbee please.

(note, changes to certificate server to take advantage of this are forthcoming, but for the moment this doesn't break certs master since the extra xqueue_body parameters are ignored.)
