### PR TITLE
Small change to email registration template

### DIFF
--- a/lms/djangoapps/instructor/tests/test_legacy_enrollment.py
+++ b/lms/djangoapps/instructor/tests/test_legacy_enrollment.py
@@ -217,7 +217,7 @@ class TestInstructorEnrollsStudent(ModuleStoreTestCase, LoginEnrollmentTestCase)
 
         self.assertEqual(mail.outbox[1].subject, 'You have been invited to register for MITx/999/Robot_Super_Course')
         self.assertEqual(mail.outbox[1].body, "Dear student,\n\nYou have been invited to join MITx/999/Robot_Super_Course at edx.org by a member of the course staff.\n\n" +
-                                              "To finish your registration, please visit https://edx.org/register and fill out the registration form.\n" +
+                                              "To finish your registration, please visit https://edx.org/register and fill out the registration form making sure to use student3_1@test.com in the E-mail field.\n" +
                                               "Once you have registered and activated your account, you will see MITx/999/Robot_Super_Course listed on your dashboard.\n\n" +
                                               "----\nThis email was automatically sent from edx.org to student3_1@test.com")
 

--- a/lms/templates/emails/enroll_email_allowedmessage.txt
+++ b/lms/templates/emails/enroll_email_allowedmessage.txt
@@ -2,7 +2,7 @@ Dear student,
 
 You have been invited to join ${course_id} at ${site_name} by a member of the course staff.
 
-To finish your registration, please visit ${registration_url} and fill out the registration form.
+To finish your registration, please visit ${registration_url} and fill out the registration form making sure to use ${email_address} in the E-mail field.
 % if auto_enroll:
 Once you have registered and activated your account, you will see ${course_id} listed on your dashboard.
 % else:


### PR DESCRIPTION
```
Fix to guide students how to register

Added some text to guide the student to register with a particular email address.
This is the one that was entered into the enrollment/invitation form by the instructor.
Modified the template and associated test.
```
