### PR TITLE
Fix capa optioninput template to honor inline flag

### DIFF
--- a/common/lib/capa/capa/inputtypes.py
+++ b/common/lib/capa/capa/inputtypes.py
@@ -325,7 +325,7 @@ class OptionInput(InputTypeBase):
         Convert options to a convenient format.
         """
         return [Attribute('options', transform=cls.parse_options),
-                Attribute('inline', '')]
+                Attribute('inline', False)]
 
 registry.register(OptionInput)
 

--- a/common/lib/capa/capa/templates/optioninput.html
+++ b/common/lib/capa/capa/templates/optioninput.html
@@ -1,4 +1,6 @@
-<form class="inputtype option-input">
+<% doinline = "inline" if inline else "" %>
+
+<form class="inputtype option-input ${doinline}">
    <select name="input_${id}" id="input_${id}" aria-describedby="answer_${id}">
       <option value="option_${id}_dummy_default">  </option>
       % for option_id, option_description in options:

--- a/common/lib/capa/capa/tests/test_inputtypes.py
+++ b/common/lib/capa/capa/tests/test_inputtypes.py
@@ -55,7 +55,7 @@ class OptionInputTest(unittest.TestCase):
                     'options': [('Up', 'Up'), ('Down', 'Down')],
                     'status': 'answered',
                     'msg': '',
-                    'inline': '',
+                    'inline': False,
                     'id': 'sky_input'}
 
         self.assertEqual(context, expected)


### PR DESCRIPTION
The "inline" flag is used to allow capa input elements to be displayed inline.  This is useful, for example, when questions are written as paragraph text, with inputs embedded within the text.  

The `textline` input element honors the inline flag -- see https://github.com/edx/edx-platform/blob/master/common/lib/capa/capa/templates/textline.html#L1

This PR fixes the `optioninput` template to also honor the inline flag (note that https://github.com/edx/edx-platform/blob/master/common/lib/capa/capa/inputtypes.py#L328 already provides the inline flag in the mako context).
