### PR TITLE
Incremented diff cover version to fix 100% coverage bug.

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -10,5 +10,5 @@
 # Our libraries:
 -e git+https://github.com/edx/XBlock.git@446668fddc75b78512eef4e9425cbc9a3327606f#egg=XBlock
 -e git+https://github.com/edx/codejail.git@0a1b468#egg=codejail
--e git+https://github.com/edx/diff-cover.git@v0.2.1#egg=diff_cover
+-e git+https://github.com/edx/diff-cover.git@v0.2.2#egg=diff_cover
 -e git+https://github.com/edx/js-test-tool.git@v0.0.7#egg=js_test_tool


### PR DESCRIPTION
Increments the version number to get bugfixes described here: https://github.com/edx/diff-cover/blob/master/CHANGELOG

The most important one is that combining coverage XML reports (LMS/CMS/XModule/Capa) would report 100% coverage for any source file not represented in all reports.

@sarina 
