### PR TITLE
Fix/adam/add edge reqs

### DIFF
--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -1,3 +1,4 @@
 numpy==1.6.2
 networkx==1.7
 sympy==0.7.1
+pyparsing==1.5.6

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -41,6 +41,7 @@ pycrypto>=2.6
 pygments==1.5
 pygraphviz==1.1
 pymongo==2.4.1
+pyparsing==1.5.6
 python-memcached==1.48
 python-openid==2.2.5
 pytz==2012h


### PR DESCRIPTION
@nedbat @cpennington 

To add the correct packages to edx-sandbox, should we add pyparsing explicitly to the requirements, or should we install the local dependencies in editable mode (like https://github.com/edx/edx-platform/blob/master/requirements/edx/local.txt does)?
