### PR TITLE
Fix for acceptance test static file issue

### DIFF
--- a/common/djangoapps/terrain/browser.py
+++ b/common/djangoapps/terrain/browser.py
@@ -29,11 +29,13 @@ from xmodule.contentstore.django import _CONTENTSTORE
 # to use staticfiles.
 try:
     import staticfiles
+    import staticfiles.handlers
 except ImportError:
     pass
 else:
     import sys
     sys.modules['django.contrib.staticfiles'] = staticfiles
+    sys.modules['django.contrib.staticfiles.handlers'] = staticfiles.handlers
 
 LOGGER = getLogger(__name__)
 LOGGER.info("Loading the lettuce acceptance testing terrain file...")


### PR DESCRIPTION
Recent changes to how we start up django apps broke lettuce tests.

1) Previously, we replaced django.contrib.staticfiles with django-staticfiles to satisfy both lettuce (uses the built-in library) and mitxmako (uses external library).

2) Changes to how we initialize Django apps caused django.contrib.staticfiles.handlers to no longer point to django-staticfiles.handlers.

3) This PR replaces django.contrib.staticfiles.handlers explicitly to avoid this issue.

@jzoldak 
