### PR TITLE
Fix bug when editing video causes other components to lose their header

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/tabs/tabs-aggregator.coffee
+++ b/common/lib/xmodule/xmodule/js/src/tabs/tabs-aggregator.coffee
@@ -9,7 +9,7 @@ class @TabsEditingDescriptor
     ###
 
     # hide editor/settings bar
-    $('.component-edit-header').hide()
+    @element.closest('.component-editor').find('.component-edit-header').hide()
 
     @$tabs = $(".tab", @element)
     @$content = $(".component-tab", @element)


### PR DESCRIPTION
It's a fix for bug BLD-315.

@adampalay, @singingwolfboy  please review.
