### PR TITLE
Fix nopathtoitem error

### DIFF
--- a/lms/djangoapps/open_ended_grading/utils.py
+++ b/lms/djangoapps/open_ended_grading/utils.py
@@ -1,6 +1,6 @@
 from xmodule.modulestore import search
 from xmodule.modulestore.django import modulestore
-from xmodule.modulestore.exceptions import ItemNotFoundError
+from xmodule.modulestore.exceptions import ItemNotFoundError, NoPathToItem
 
 def does_location_exist(course_id, location):
     """
@@ -12,5 +12,8 @@ def does_location_exist(course_id, location):
         search.path_to_location(modulestore(), course_id, location)
         return True
     except ItemNotFoundError:
-        #If the problem cannot be found at the location received from the grading controller server, it has been deleted by the course author.
+        # If the problem cannot be found at the location received from the grading controller server, it has been deleted by the course author.
+        return False
+    except NoPathToItem:
+        # If the problem can be found, but there is no path to it, then it is a draft.
         return False

--- a/lms/djangoapps/open_ended_grading/utils.py
+++ b/lms/djangoapps/open_ended_grading/utils.py
@@ -1,6 +1,9 @@
 from xmodule.modulestore import search
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError, NoPathToItem
+import logging
+
+log = logging.getLogger(__name__)
 
 def does_location_exist(course_id, location):
     """
@@ -12,8 +15,13 @@ def does_location_exist(course_id, location):
         search.path_to_location(modulestore(), course_id, location)
         return True
     except ItemNotFoundError:
-        # If the problem cannot be found at the location received from the grading controller server, it has been deleted by the course author.
+        # If the problem cannot be found at the location received from the grading controller server,
+        # it has been deleted by the course author.
         return False
     except NoPathToItem:
-        # If the problem can be found, but there is no path to it, then it is a draft.
+        # If the problem can be found, but there is no path to it, then we assume it is a draft.
+        # Log a warning if the problem is not a draft (location does not end in "draft").
+        if not location.endswith("draft"):
+            log.warn(("Got an unexpected NoPathToItem error in staff grading with a non-draft location {0}. "
+                      "Ensure that the location is valid.").format(location))
         return False


### PR DESCRIPTION
@nedbat @brianhw Short PR to fix https://edx-wiki.atlassian.net/browse/OEE-125 .  When course staff made a draft and submitted a response to open ended grading using it, then the location was stored.  When the staff grading module later tried to lookup the location, it encountered a NoPathtoItem error.  This catches that exception.
