### PR TITLE
Don't show course about page link when we have the marketing site.

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -118,7 +118,8 @@ class CourseDetailsTestCase(CourseTestCase):
 
         with mock.patch.dict('django.conf.settings.MITX_FEATURES', {'ENABLE_MKTG_SITE': True}):
             response = self.client.get(settings_details_url)
-            self.assertContains(response, "Course Summary Page")
+            self.assertNotContains(response, "Course Summary Page")
+            self.assertNotContains(response, "Send a note to students via email")
             self.assertContains(response, "course summary page will not be viewable")
 
             self.assertContains(response, "Course Start Date")
@@ -143,6 +144,7 @@ class CourseDetailsTestCase(CourseTestCase):
         with mock.patch.dict('django.conf.settings.MITX_FEATURES', {'ENABLE_MKTG_SITE': False}):
             response = self.client.get(settings_details_url)
             self.assertContains(response, "Course Summary Page")
+            self.assertContains(response, "Send a note to students via email")
             self.assertNotContains(response, "course summary page will not be viewable")
 
             self.assertContains(response, "Course Start Date")

--- a/cms/templates/settings.html
+++ b/cms/templates/settings.html
@@ -91,6 +91,7 @@ from contentstore import utils
             </li>
           </ol>
 
+          % if about_page_editable:
           <div class="note note-promotion note-promotion-courseURL has-actions">
             <h3 class="title">${_("Course Summary Page")} <span class="tip">${_("(for student enrollment and access)")}</span></h3>
             <div class="copy">
@@ -103,6 +104,7 @@ from contentstore import utils
               </li>
             </ul>
           </div>
+          % endif
 
           % if not about_page_editable:
           <div class="notice notice-incontext notice-workflow">


### PR DESCRIPTION
STUD-733

@chrisndodge Can you review? There is currently no way for us to know what the about page URL will be on the Drupal site. Karen had set up redirects for courses running last semester, but there is no plan to do this going forward. And also, the about page isn't visible on the marketing site while the course is still under development.

To reduce course team confusion, removing the advertising of the about page URL until we have the API to communicate with Drupal.
