### PR TITLE
fix edit tab name bug and add unit test

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -348,6 +348,43 @@ class ContentStoreToyCourseTest(ModuleStoreTestCase):
 
         self.assertEqual(course.tabs, expected_tabs)
 
+    def test_create_static_tab_and_rename(self):
+        module_store = modulestore('direct')
+        CourseFactory.create(org='edX', course='999', display_name='Robot Super Course')
+        course_location = Location(['i4x', 'edX', '999', 'course', 'Robot_Super_Course', None])    
+
+        item = ItemFactory.create(parent_location=course_location, category='static_tab', display_name="My Tab")
+
+        course = module_store.get_item(course_location)
+
+        expected_tabs = []
+        expected_tabs.append({u'type': u'courseware'})
+        expected_tabs.append({u'type': u'course_info', u'name': u'Course Info'})
+        expected_tabs.append({u'type': u'textbooks'})
+        expected_tabs.append({u'type': u'discussion', u'name': u'Discussion'})
+        expected_tabs.append({u'type': u'wiki', u'name': u'Wiki'})
+        expected_tabs.append({u'type': u'progress', u'name': u'Progress'})
+        expected_tabs.append({u'type': u'static_tab', u'name': u'My Tab', u'url_slug': u'My_Tab'})
+
+        self.assertEqual(course.tabs, expected_tabs)
+
+        item.display_name = 'Updated'
+        item.save()
+        module_store.update_metadata(item.location, own_metadata(item))
+
+        course = module_store.get_item(course_location)
+
+        expected_tabs = []
+        expected_tabs.append({u'type': u'courseware'})
+        expected_tabs.append({u'type': u'course_info', u'name': u'Course Info'})
+        expected_tabs.append({u'type': u'textbooks'})
+        expected_tabs.append({u'type': u'discussion', u'name': u'Discussion'})
+        expected_tabs.append({u'type': u'wiki', u'name': u'Wiki'})
+        expected_tabs.append({u'type': u'progress', u'name': u'Progress'})
+        expected_tabs.append({u'type': u'static_tab', u'name': u'Updated', u'url_slug': u'My_Tab'})
+
+        self.assertEqual(course.tabs, expected_tabs)
+
     def test_static_tab_reordering(self):
         module_store = modulestore('direct')
         CourseFactory.create(org='edX', course='999', display_name='Robot Super Course')

--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -794,7 +794,7 @@ class MongoModuleStore(ModuleStoreBase):
             existing_tabs = course.tabs or []
             for tab in existing_tabs:
                 if tab.get('url_slug') == loc.name:
-                    tab['name'] = tab.get('name', metadata.get('display_name'))
+                    tab['name'] = metadata.get('display_name', tab.get('name'))
                     break
             course.tabs = existing_tabs
             # Save the updates to the course to the MongoKeyValueStore


### PR DESCRIPTION
@dmitchell can you review?

@ichuang , seems like your change made it so we can't rename tabs. Sorry, I should have caught that in the code review. Can you look at this PR and see if this change will work for your use case (I believe you were saying 'display_name' was None in your case).
