### PR TITLE
Add datadog tracking for bulk email

### DIFF
--- a/lms/djangoapps/bulk_email/tasks.py
+++ b/lms/djangoapps/bulk_email/tasks.py
@@ -16,6 +16,7 @@ from celery import task, current_task
 from celery.utils.log import get_task_logger
 from django.core.urlresolvers import reverse
 from statsd import statsd
+from dogapi import dog_stats_api
 
 from bulk_email.models import (
     CourseEmail, Optout, CourseEmailTemplate,
@@ -116,6 +117,13 @@ def course_email(email_id, to_list, course_title, course_url, image_url, throttl
     Sends to all addresses contained in to_list.  Emails are sent multi-part, in both plain
     text and html.
     """
+    with dog_stats_api.timer('course_email.single_task.time.overall', tags=[_statsd_tag(course_title)]):
+        _send_course_email(email_id, to_list, course_title, course_url, image_url, throttle)
+
+def _send_course_email(email_id, to_list, course_title, course_url, image_url, throttle):
+    """
+    Performs the email sending task.
+    """
     try:
         msg = CourseEmail.objects.get(id=email_id)
     except CourseEmail.DoesNotExist:
@@ -181,7 +189,8 @@ def course_email(email_id, to_list, course_title, course_url, image_url, throttl
                 time.sleep(0.2)
 
             try:
-                connection.send_messages([email_msg])
+                with dog_stats_api.timer('course_email.single_send.time.overall', tags=[_statsd_tag(course_title)]):
+                    connection.send_messages([email_msg])
 
                 statsd.increment('course_email.sent', tags=[_statsd_tag(course_title)])
 


### PR DESCRIPTION
@brianhw 

Adds datadog tracking calls like we talked about, to aggregate the time it takes both each task and a single send.

Modelled the call after the calls in lms/djangoapps/instructor_task/tasks_helper.py (l 134; 213)
