### PR TITLE
LMS: General Disabled Link/Button State Styling

### DIFF
--- a/lms/static/sass/base/_base.scss
+++ b/lms/static/sass/base/_base.scss
@@ -82,6 +82,12 @@ a:link, a:visited {
   &:hover {
     text-decoration: underline;
   }
+
+  &:disabled, &.is-disabled, &.disabled {
+    pointer-events: none;
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
 }
 
 a:focus {

--- a/lms/static/sass/shared/_forms.scss
+++ b/lms/static/sass/shared/_forms.scss
@@ -43,8 +43,7 @@ textarea {
 
 input[type="submit"],
 input[type="button"],
-button,
-.button {
+button,.button {
   border-radius: 3px;
   @include button(shiny, $button-color);
   font: normal 1.2rem/1.6rem $sans-serif;
@@ -53,4 +52,10 @@ button,
   text-transform: uppercase;
   vertical-align: top;
   -webkit-font-smoothing: antialiased;
+
+  &:disabled, &.is-disabled, &.disabled {
+    pointer-events: none;
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
 }


### PR DESCRIPTION
LMS: adds in pseudo-state styling for disabled buttons/links (by attribute or standard class names). The style is triggered on the following elements by adding a "disabled" attribute or a class name of "disabled" or "is-disabled".
- button
- input with a type="button" or submit
- any anchor tag (a)
