### PR TITLE
Add mitxmako.middleware to fix workers

### DIFF
--- a/common/djangoapps/mitxmako/shortcuts.py
+++ b/common/djangoapps/mitxmako/shortcuts.py
@@ -17,6 +17,7 @@ from django.http import HttpResponse
 import logging
 
 import mitxmako
+import mitxmako.middleware
 from django.conf import settings
 from django.core.urlresolvers import reverse
 log = logging.getLogger(__name__)


### PR DESCRIPTION
If mitxmako.middleware has ever been imported, then render_to_string works
correctly (which is why we didn't see this in the rest of edx-platform).
However, if it hasn't (like in a celery worker), then using
mitxmako.middleware errors out.

[LMS-1085]
