### PR TITLE
Load xblock fragment resources in studio preview - DO NOT MERGE

### DIFF
--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -81,9 +81,14 @@ def preview_component(request, location):
         component,
         'xmodule_edit.html'
     )
+
+    fragment = component.runtime.render(component, None, 'studio_view')
+
     return render_to_response('component.html', {
         'preview': get_preview_html(request, component, 0),
-        'editor': component.runtime.render(component, None, 'studio_view').content,
+        'editor': fragment.content,
+        'resources': fragment.resources_to_html("head") + fragment.resources_to_html("foot"),
+        'initialize_js': fragment.js_init[0],
     })
 
 

--- a/cms/templates/component.html
+++ b/cms/templates/component.html
@@ -6,6 +6,11 @@
 <script src="${static.url('js/vendor/html5-input-polyfills/number-polyfill.js')}"></script>
 <link rel="stylesheet" type="text/css" href="${static.url('css/vendor/html5-input-polyfills/number-polyfill.css')}" />
 
+${resources}
+<script type="text/javascript">
+    ${initialize_js}
+</script>
+
 <div class="wrapper wrapper-component-editor">
 	<div class="component-editor">
 		<div class="component-edit-header">


### PR DESCRIPTION
Loads xblock resources by eval'ing them on the page.

Doesn't yet use hashes to avoid loading resources more than once.

Requires newer xblock.fragments.

@cpennington @nedbat  
