### PR TITLE
Updated js-test-tool version to v0.1.0

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -17,4 +17,4 @@
 -e git+https://github.com/edx/XBlock.git@aa0d60627#egg=XBlock
 -e git+https://github.com/edx/codejail.git@0a1b468#egg=codejail
 -e git+https://github.com/edx/diff-cover.git@v0.2.2#egg=diff_cover
--e git+https://github.com/edx/js-test-tool.git@v0.0.7#egg=js_test_tool
+-e git+https://github.com/edx/js-test-tool.git@v0.1.0#egg=js_test_tool


### PR DESCRIPTION
Big change: supports RequireJS

Small changes:
- Alerts stubbed in dev mode as well as test mode
- Cleaner console output (dots to indicate success)
- Better tolerance for JSCover failure.  Persistent JSCover failures due to memory limitations will no longer fail the build.

@singingwolfboy 
