### PR TITLE
Removed an inclusion of t-copy-sub1 in SCSS for Video.

### DIFF
--- a/common/lib/xmodule/xmodule/css/tabs/tabs.scss
+++ b/common/lib/xmodule/xmodule/css/tabs/tabs.scss
@@ -32,7 +32,6 @@
 
     //Component Name
     .component-name {
-      @extend .t-copy-sub1;
       position: relative;
       top: 0;
       left: 0;


### PR DESCRIPTION
A line of SCSS code was not doing anything and simply causing a warning while SASS was compiling. The following is the warning that this PR takes care of:

WARNING on line 35 of /home/valera/edx_all/edx-platform/common/static
/xmodule/descriptors/css/_000-5df8e10160f918d31f2b2e8be3ce247d.scss:
".xmodule_edit.xmodule_VideoDescriptor .editor-with-tabs .edit-header
.component-name" failed to @extend ".t-copy-sub1".

The selector ".t-copy-sub1" was not found.
Use "@extend .t-copy-sub1 !optional" if the extend should be able to fail.
