### PR TITLE
Fix forums nav sidebar overlapping content

### DIFF
--- a/common/static/coffee/src/discussion/views/discussion_thread_list_view.coffee
+++ b/common/static/coffee/src/discussion/views/discussion_thread_list_view.coffee
@@ -64,10 +64,8 @@ if Backbone?
 
       sidebar = $(".sidebar")
       if scrollTop > discussionsBodyTop - @sidebar_padding
-        sidebar.addClass('fixed');
-        sidebar.css('top', @sidebar_padding);
+        sidebar.css('top', scrollTop - discussionsBodyTop + @sidebar_padding);
       else
-        sidebar.removeClass('fixed');
         sidebar.css('top', '0');
 
       sidebarWidth = .31 * $(".discussion-body").width();

--- a/lms/static/sass/_discussion.scss
+++ b/lms/static/sass/_discussion.scss
@@ -690,14 +690,6 @@ body.discussion {
     border-radius: 3px;
     background: #f6f6f6;
     box-shadow: 0 1px 2px rgba(0, 0, 0, .05);
-
-    &.fixed {
-      @include box-sizing(border-box);
-      position: fixed;
-      top: 0px;
-      width: 32%;
-    }
-
   }
 
   .browse-search {
@@ -1283,10 +1275,6 @@ body.discussion {
     border-radius: 3px;
     background: $white;
     box-shadow: 0 1px 2px rgba(0, 0, 0, .05);
-
-    &.sidebar-fixed {
-      margin-left: 32%;
-    }
   }
 
   .blank-slate {


### PR DESCRIPTION
Previously, when the window was scrolled down past the top of the
discussion content pane, scrolling right would cause the sidebar to
appear above the background of the content pane but below the text.
This is only an issue with very small windows or with the text size
increased significantly, which is why this came up in an accessibility
audit. Now the sidebar is fixed to the left side of the page instead
of the left side of the viewport.

@marcotuts @jimabramson @kevinchugh 
