### PR TITLE
Make URL patterns to exclude from tracking configurable

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -127,6 +127,10 @@ LOGGING = get_logger_config(LOG_DIR,
 #theming start:
 PLATFORM_NAME = ENV_TOKENS.get('PLATFORM_NAME', 'edX')
 
+# Event Tracking
+if "TRACKING_IGNORE_URL_PATTERNS" in ENV_TOKENS:
+    TRACKING_IGNORE_URL_PATTERNS = ENV_TOKENS.get("TRACKING_IGNORE_URL_PATTERNS")
+
 
 ################ SECURE AUTH ITEMS ###############################
 # Secret things: passwords, access keys, etc.

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -404,3 +404,7 @@ TRACKING_BACKENDS = {
         }
     }
 }
+
+# We're already logging events, and we don't want to capture user
+# names/passwords.  Heartbeat events are likely not interesting.
+TRACKING_IGNORE_URL_PATTERNS = [r'^/event', r'^/login', r'^/heartbeat']

--- a/common/djangoapps/track/tests/test_middleware.py
+++ b/common/djangoapps/track/tests/test_middleware.py
@@ -1,0 +1,46 @@
+import re
+
+from mock import patch
+
+from django.test import TestCase
+from django.test.client import RequestFactory
+from django.test.utils import override_settings
+
+from track.middleware import TrackMiddleware
+
+
+@patch('track.views.server_track')
+class TrackMiddlewareTestCase(TestCase):
+
+    def setUp(self):
+        self.track_middleware = TrackMiddleware()
+        self.request_factory = RequestFactory()
+
+    def test_normal_request(self, mock_server_track):
+        request = self.request_factory.get('/somewhere')
+        self.track_middleware.process_request(request)
+        self.assertTrue(mock_server_track.called)
+
+    def test_default_filters_do_not_render_view(self, mock_server_track):
+        for url in ['/event', '/event/1', '/login', '/heartbeat']:
+            request = self.request_factory.get(url)
+            self.track_middleware.process_request(request)
+            self.assertFalse(mock_server_track.called)
+            mock_server_track.reset_mock()
+
+    @override_settings(TRACKING_IGNORE_URL_PATTERNS=[])
+    def test_reading_filtered_urls_from_settings(self, mock_server_track):
+        request = self.request_factory.get('/event')
+        self.track_middleware.process_request(request)
+        self.assertTrue(mock_server_track.called)
+
+    @override_settings(TRACKING_IGNORE_URL_PATTERNS=[r'^/some/excluded.*'])
+    def test_anchoring_of_patterns_at_beginning(self, mock_server_track):
+        request = self.request_factory.get('/excluded')
+        self.track_middleware.process_request(request)
+        self.assertTrue(mock_server_track.called)
+        mock_server_track.reset_mock()
+
+        request = self.request_factory.get('/some/excluded/url')
+        self.track_middleware.process_request(request)
+        self.assertFalse(mock_server_track.called)

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -187,6 +187,10 @@ for name, value in ENV_TOKENS.get("CODE_JAIL", {}).items():
 
 COURSES_WITH_UNSAFE_CODE = ENV_TOKENS.get("COURSES_WITH_UNSAFE_CODE", [])
 
+# Event Tracking
+if "TRACKING_IGNORE_URL_PATTERNS" in ENV_TOKENS:
+    TRACKING_IGNORE_URL_PATTERNS = ENV_TOKENS.get("TRACKING_IGNORE_URL_PATTERNS")
+
 ############################## SECURE AUTH ITEMS ###############
 # Secret things: passwords, access keys, etc.
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -334,6 +334,10 @@ if MITX_FEATURES.get('ENABLE_SQL_TRACKING_LOGS'):
         }
     })
 
+# We're already logging events, and we don't want to capture user
+# names/passwords.  Heartbeat events are likely not interesting.
+TRACKING_IGNORE_URL_PATTERNS = [r'^/event', r'^/login', r'^/heartbeat']
+
 ######################## subdomain specific settings ###########################
 COURSE_LISTINGS = {}
 SUBDOMAIN_BRANDING = {}


### PR DESCRIPTION
A small change intended to exclude heartbeat requests from our tracking logs.
