### PR TITLE
Rename xblock_field_data to xmodule_field_data

### DIFF
--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -113,7 +113,7 @@ def preview_module_system(request, preview_id, descriptor):
         debug=True,
         replace_urls=partial(static_replace.replace_static_urls, data_directory=None, course_id=course_id),
         user=request.user,
-        xblock_field_data=preview_field_data,
+        xmodule_field_data=preview_field_data,
         can_execute_unsafe_code=(lambda: can_execute_unsafe_code(course_id)),
         mixins=settings.XBLOCK_MIXINS,
         course_id=course_id,

--- a/common/lib/xmodule/xmodule/tests/__init__.py
+++ b/common/lib/xmodule/xmodule/tests/__init__.py
@@ -65,7 +65,7 @@ def get_test_system(course_id=''):
         hostname="edx.org",
         xqueue={'interface': None, 'callback_url': '/', 'default_queuename': 'testqueue', 'waittime': 10, 'construct_callback' : Mock(side_effect="/")},
         node_path=os.environ.get("NODE_PATH", "/usr/local/lib/node_modules"),
-        xblock_field_data=lambda descriptor: descriptor._field_data,
+        xmodule_field_data=lambda descriptor: descriptor._field_data,
         anonymous_student_id='student',
         open_ended_grading_interface=open_ended_grading_interface,
         course_id=course_id,

--- a/common/lib/xmodule/xmodule/tests/test_xblock_wrappers.py
+++ b/common/lib/xmodule/xmodule/tests/test_xblock_wrappers.py
@@ -74,7 +74,7 @@ class TestXBlockWrapper(object):
             anonymous_student_id='dummy_anonymous_student_id',
             open_ended_grading_interface={},
             ajax_url='dummy_ajax_url',
-            xblock_field_data=lambda d: d._field_data,
+            xmodule_field_data=lambda d: d._field_data,
             get_module=Mock(),
             replace_urls=Mock(),
             track_function=Mock(),

--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -537,7 +537,7 @@ class XModuleDescriptor(XModuleFields, HTMLSnippet, ResourceTemplates, XBlock):
         module = system.construct_xblock_from_class(
             self.module_class,
             descriptor=self,
-            field_data=system.xblock_field_data(self),
+            field_data=system.xmodule_field_data(self),
             scope_ids=self.scope_ids,
         )
         module.save()
@@ -838,7 +838,7 @@ class ModuleSystem(Runtime):
     '''
     def __init__(
             self, ajax_url, track_function, get_module, render_template,
-            replace_urls, xblock_field_data, user=None, filestore=None,
+            replace_urls, xmodule_field_data, user=None, filestore=None,
             debug=False, hostname="", xqueue=None, publish=None, node_path="",
             anonymous_student_id='', course_id=None,
             open_ended_grading_interface=None, s3_interface=None,
@@ -883,7 +883,7 @@ class ModuleSystem(Runtime):
 
         publish(event) - A function that allows XModules to publish events (such as grade changes)
 
-        xblock_field_data - A function that constructs a field_data for an xblock from its
+        xmodule_field_data - A function that constructs a field_data for an xblock from its
             corresponding descriptor
 
         cache - A cache object with two methods:
@@ -910,7 +910,7 @@ class ModuleSystem(Runtime):
         self.anonymous_student_id = anonymous_student_id
         self.course_id = course_id
         self.user_is_staff = user is not None and user.is_staff
-        self.xblock_field_data = xblock_field_data
+        self.xmodule_field_data = xmodule_field_data
 
         if publish is None:
             publish = lambda e: None

--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -294,7 +294,7 @@ def get_module_for_descriptor_internal(user, descriptor, field_data_cache, cours
                                                   position, wrap_xmodule_display, grade_bucket_type,
                                                   static_asset_path)
 
-    def xblock_field_data(descriptor):
+    def xmodule_field_data(descriptor):
         student_data = DbModel(DjangoKeyValueStore(field_data_cache))
         return lms_field_data(descriptor._field_data, student_data)
 
@@ -368,7 +368,7 @@ def get_module_for_descriptor_internal(user, descriptor, field_data_cache, cours
             jump_to_id_base_url=reverse('jump_to_id', kwargs={'course_id': course_id, 'module_id': ''})
         ),
         node_path=settings.NODE_PATH,
-        xblock_field_data=xblock_field_data,
+        xmodule_field_data=xmodule_field_data,
         publish=publish,
         anonymous_student_id=unique_id_for_user(user),
         course_id=course_id,

--- a/lms/djangoapps/courseware/tests/__init__.py
+++ b/lms/djangoapps/courseware/tests/__init__.py
@@ -48,7 +48,7 @@ class BaseTestXmodule(ModuleStoreTestCase):
     DATA = ''
     MODEL_DATA = {'data': '<some_module></some_module>'}
 
-    def xblock_field_data(self, descriptor):
+    def xmodule_field_data(self, descriptor):
         field_data = {}
         field_data.update(self.MODEL_DATA)
         student_data = DictFieldData(field_data)
@@ -91,7 +91,7 @@ class BaseTestXmodule(ModuleStoreTestCase):
         # different code paths while maintaining the type returned by render_template
         self.runtime.render_template = lambda template, context: u'{!r}, {!r}'.format(template, sorted(context.items()))
 
-        self.runtime.xblock_field_data = self.xblock_field_data
+        self.runtime.xmodule_field_data = self.xmodule_field_data
 
         self.item_module = self.item_descriptor.xmodule(self.runtime)
 

--- a/lms/djangoapps/open_ended_grading/open_ended_notifications.py
+++ b/lms/djangoapps/open_ended_grading/open_ended_notifications.py
@@ -13,6 +13,8 @@ from xmodule.x_module import ModuleSystem
 from mitxmako.shortcuts import render_to_string
 import datetime
 
+from xblock.field_data import DictFieldData
+
 log = logging.getLogger(__name__)
 
 NOTIFICATION_CACHE_TIME = 300
@@ -68,7 +70,7 @@ def peer_grading_notifications(course, user):
         get_module = None,
         render_template=render_to_string,
         replace_urls=None,
-        xblock_field_data= {}
+        xmodule_field_data=DictFieldData({}),
     )
     peer_gs = peer_grading_service.PeerGradingService(settings.OPEN_ENDED_GRADING_INTERFACE, system)
     pending_grading = False
@@ -129,7 +131,7 @@ def combined_notifications(course, user):
         get_module = None,
         render_template=render_to_string,
         replace_urls=None,
-        xblock_field_data= {}
+        xmodule_field_data=DictFieldData({})
     )
     #Initialize controller query service using our mock system
     controller_qs = ControllerQueryService(settings.OPEN_ENDED_GRADING_INTERFACE, system)

--- a/lms/djangoapps/open_ended_grading/staff_grading_service.py
+++ b/lms/djangoapps/open_ended_grading/staff_grading_service.py
@@ -9,6 +9,8 @@ from xmodule.open_ended_grading_classes.grading_service_module import GradingSer
 from django.conf import settings
 from django.http import HttpResponse, Http404
 
+from xblock.field_data import DictFieldData
+
 from courseware.access import has_access
 from util.json_request import expect_json
 from xmodule.course_module import CourseDescriptor
@@ -73,7 +75,7 @@ class StaffGradingService(GradingService):
             get_module = None,
             render_template=render_to_string,
             replace_urls=None,
-            xblock_field_data= {}
+            xmodule_field_data=DictFieldData({})
         )
         super(StaffGradingService, self).__init__(config)
         self.url = config['url'] + config['staff_grading']

--- a/lms/djangoapps/open_ended_grading/tests.py
+++ b/lms/djangoapps/open_ended_grading/tests.py
@@ -167,7 +167,7 @@ class TestPeerGradingService(ModuleStoreTestCase, LoginEnrollmentTestCase):
             get_module=None,
             render_template=render_to_string,
             replace_urls=None,
-            xblock_field_data=lambda d: d._field_data,
+            xmodule_field_data=lambda d: d._field_data,
             s3_interface=test_util_open_ended.S3_INTERFACE,
             open_ended_grading_interface=test_util_open_ended.OPEN_ENDED_GRADING_INTERFACE,
             mixins=settings.XBLOCK_MIXINS,

--- a/lms/djangoapps/open_ended_grading/views.py
+++ b/lms/djangoapps/open_ended_grading/views.py
@@ -7,6 +7,8 @@ from django.views.decorators.cache import cache_control
 from mitxmako.shortcuts import render_to_response
 from django.core.urlresolvers import reverse
 
+from xblock.field_data import DictFieldData
+
 from student.models import unique_id_for_user
 from courseware.courses import get_course_with_access
 
@@ -33,7 +35,7 @@ system = ModuleSystem(
     get_module=None,
     render_template=render_to_string,
     replace_urls=None,
-    xblock_field_data={}
+    xmodule_field_data=DictFieldData({}),
 )
 
 controller_qs = ControllerQueryService(settings.OPEN_ENDED_GRADING_INTERFACE, system)


### PR DESCRIPTION
@nedbat, @sarina: Review?

Having it be named `xblock_field_data` was confusing, since it's actually only used for `XModule`s.
