### PR TITLE
Fix/frances/vcert receipt

### DIFF
--- a/lms/templates/shoppingcart/error.html
+++ b/lms/templates/shoppingcart/error.html
@@ -9,6 +9,4 @@
 <section class="container">
     <p><h1>${_("There was an error processing your order!")}</h1></p>
     ${error_html}
-
-    <p><a href="${reverse('shoppingcart.views.show_cart')}">${_("Return to cart to retry payment")}</a></p>
 </section>

--- a/lms/templates/shoppingcart/verified_cert_receipt.html
+++ b/lms/templates/shoppingcart/verified_cert_receipt.html
@@ -202,10 +202,7 @@
 
             <div class="copy">
               <p>${_("Billed To")}:
-                <span class="name-first">${order.bill_to_first}</span> <span class="name-last">${order.bill_to_last}</span><br />
-                <span class="address-street1">${order.bill_to_street1}</span> <span class="address-street2">${order.bill_to_street2}</span><br />
-                <span class="address-city">${order.bill_to_city}</span>, <span class="address-state">${order.bill_to_state}</span> <span class="address-postalcode">${order.bill_to_postalcode}</span><br />
-                <span class="address-country">${order.bill_to_country.upper()}</span>
+                <span class="name-first">${order.bill_to_first}</span> <span class="name-last">${order.bill_to_last}</span> (<span class="address-city">${order.bill_to_city}</span>, <span class="address-state">${order.bill_to_state}</span> <span class="address-postalcode">${order.bill_to_postalcode}</span> <span class="address-country">${order.bill_to_country.upper()}</span>)
               </p>
             </div>
           </li>


### PR DESCRIPTION
removed return to cart link from the error page since we aren't using the cart, and removed unused variables from the billing info to prevent weird spacing. @dianakhuang can you review?
