### PR TITLE
Force save of photo_id_key on upload

### DIFF
--- a/lms/djangoapps/verify_student/models.py
+++ b/lms/djangoapps/verify_student/models.py
@@ -410,6 +410,7 @@ class SoftwareSecurePhotoVerification(PhotoVerification):
 
         # Update our record fields
         self.photo_id_key = rsa_encrypted_aes_key.encode('base64')
+        self.save()
 
     @status_before_must_be("must_retry", "ready", "submitted")
     def submit(self):


### PR DESCRIPTION
Force a save of the model when we're uploading a photo ID so our generated key is always saved. @dianakhuang 
