### PR TITLE
Add ARIA dialog role to Markdown editor dialogs

### DIFF
--- a/lms/static/js/Markdown.Editor.js
+++ b/lms/static/js/Markdown.Editor.js
@@ -1063,6 +1063,7 @@
 
             // The main dialog box.
             dialog = doc.createElement("div");
+            dialog.setAttribute("role", "dialog");
             dialog.className = "wmd-prompt-dialog";
             dialog.style.padding = "10px;";
             dialog.style.position = "fixed";


### PR DESCRIPTION
I verified that the role is properly inserted into both the Insert Hyperlink and Insert Image dialogs and that ChromeVox responds appropriately.

@marcotuts @kevinchugh @jimabramson 
