### PR TITLE
fix bug with anonymous access to / with future start courses

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -97,7 +97,7 @@ def index(request, extra_context={}, user=None):
     if domain is False:
         domain = request.META.get('HTTP_HOST')
 
-    courses = get_courses(None, domain=domain)
+    courses = get_courses(user, domain=domain)
     courses = sort_by_announcement(courses)
 
     context = {'courses': courses}

--- a/lms/djangoapps/branding/tests.py
+++ b/lms/djangoapps/branding/tests.py
@@ -1,0 +1,46 @@
+"""
+Tests for branding page
+"""
+import datetime
+from pytz import UTC
+from django.conf import settings
+from django.test.utils import override_settings
+
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.django import editable_modulestore
+from xmodule.modulestore.tests.factories import CourseFactory
+from courseware.tests.tests import TEST_DATA_MONGO_MODULESTORE
+import student.views
+
+MITX_FEATURES_WITH_STARTDATE = settings.MITX_FEATURES.copy()
+MITX_FEATURES_WITH_STARTDATE['DISABLE_START_DATES'] = False
+MITX_FEATURES_WO_STARTDATE = settings.MITX_FEATURES.copy()
+MITX_FEATURES_WO_STARTDATE['DISABLE_START_DATES'] = True
+
+
+@override_settings(MODULESTORE=TEST_DATA_MONGO_MODULESTORE)
+class AnonymousIndexPageTest(ModuleStoreTestCase):
+    """
+    Tests that anonymous users can access the '/' page,  Need courses with start date
+    """
+    def setUp(self):
+        self.store = editable_modulestore()
+        self.course = CourseFactory.create()
+        self.course.days_early_for_beta = 5
+        self.course.enrollment_start = datetime.datetime.now(UTC) + datetime.timedelta(days=3)
+        self.store.save_xmodule(self.course)
+
+    @override_settings(MITX_FEATURES=MITX_FEATURES_WITH_STARTDATE)
+    def test_none_user_index_access_with_startdate_fails(self):
+        with self.assertRaises(Exception):
+            student.views.index(self.factory.get('/'), user=None)  # pylint: disable=E1101
+
+    @override_settings(MITX_FEATURES=MITX_FEATURES_WITH_STARTDATE)
+    def test_anon_user_with_startdate_index(self):
+        response = self.client.get('/')
+        self.assertEqual(response.status_code, 200)
+
+    @override_settings(MITX_FEATURES=MITX_FEATURES_WO_STARTDATE)
+    def test_anon_user_no_startdate_index(self):
+        response = self.client.get('/')
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
@brianhw @shnayder 

So this is one of those fixes where it was a 4 character fix but a much longer test.

One of the tests illustrates the problem, which is exercised when an anonymous user tries to access student.views.index (/) when there's a course with a future start date and MITX_FEATURES['DISABLE_START_DATES'] = False
