### PR TITLE
LMS: Header Logo/Brand alt Attribute Value Fix

### DIFF
--- a/lms/templates/navigation.html
+++ b/lms/templates/navigation.html
@@ -44,7 +44,7 @@ site_status_msg = get_site_status_msg(course_id)
   <h1 class="logo">
     <a href="${marketing_link('ROOT')}">
       <%block name="navigation_logo">
-        <img src="${static.url(branding.get_logo_url(request.META.get('HTTP_HOST')))}" alt="${_('{settings.PLATFORM_NAME} home')}" />
+        <img src="${static.url(branding.get_logo_url(request.META.get('HTTP_HOST')))}" alt="${settings.PLATFORM_NAME} ${_('Home')}" />
       </%block>
     </a>
   </h1>


### PR DESCRIPTION
This resolves a couple of issues with the alt attribute value of the app's/brand's logo (within the app's navigation) - both the settings.PLATFORM_NAME I8TN syntax have been corrected.
