### PR TITLE
Send JSON messages to Software Secure in UTF-8, without escaping

### DIFF
--- a/lms/djangoapps/verify_student/models.py
+++ b/lms/djangoapps/verify_student/models.py
@@ -500,7 +500,7 @@ class SoftwareSecurePhotoVerification(PhotoVerification):
         header_txt = "\n".join(
             "{}: {}".format(h, v) for h,v in sorted(headers.items())
         )
-        body_txt = json.dumps(body, indent=2, sort_keys=True)
+        body_txt = json.dumps(body, indent=2, sort_keys=True, ensure_ascii=False)
 
         return header_txt + "\n\n" + body_txt
 
@@ -509,7 +509,7 @@ class SoftwareSecurePhotoVerification(PhotoVerification):
         response = requests.post(
             settings.VERIFY_STUDENT["SOFTWARE_SECURE"]["API_URL"],
             headers=headers,
-            data=json.dumps(body, indent=2, sort_keys=True)
+            data=json.dumps(body, indent=2, sort_keys=True, ensure_ascii=False)
         )
         log.debug("Sent request to Software Secure for {}".format(self.receipt_id))
         log.debug("Headers:\n{}\n\n".format(headers))


### PR DESCRIPTION
We used to send unicode strings in the JSON like "\u{code}\u{code}" -- this changes the behavior to actually just send the raw bytes.
