### PR TITLE
Remove due date setting

### DIFF
--- a/common/lib/xmodule/xmodule/peer_grading_module.py
+++ b/common/lib/xmodule/xmodule/peer_grading_module.py
@@ -124,9 +124,6 @@ class PeerGradingModule(PeerGradingFields, XModule):
                 log.error("Linked location {0} for peer grading module {1} cannot be linked to.".format(
                     self.link_to_location, self.location))
                 raise
-            due_date = self.linked_problem.due
-            if due_date:
-                self.due = due_date
 
         try:
             self.timeinfo = TimeInfo(self.due, self.graceperiod)


### PR DESCRIPTION
Previously, the peer grading module pulled its due date from the combinedopenended module it was linked to in single problem mode.  Now, it is set to inherit the due date from the section.

Setting the due date in an xmodule works locally, but not on production.  This new due date behavior may also be more desired and is certainly more consistent.

Update:  This may have also been a case of some functionality not being tested in the exact same way that course staff were using it.  Will look into it more next week.

Hotfix PR (against release) at https://github.com/edx/edx-platform/pull/992 .
