### PR TITLE
Software Secure message signing pt. 2

### DIFF
--- a/lms/djangoapps/verify_student/models.py
+++ b/lms/djangoapps/verify_student/models.py
@@ -356,6 +356,26 @@ class PhotoVerification(StatusModel):
         self.status = "denied"
         self.save()
 
+    @status_before_must_be("must_retry", "submitted", "approved", "denied")
+    def system_error(self,
+                     error_msg,
+                     error_code="",
+                     reviewing_user=None,
+                     reviewing_service=""):
+        """
+        Mark that this attempt could not be completed because of a system error.
+        Status should be moved to `must_retry`.
+        """
+        if self.status in ["approved", "denied"]:
+            return # If we were already approved or denied, just leave it.
+
+        self.error_msg = error_msg
+        self.error_code = error_code
+        self.reviewing_user = reviewing_user
+        self.reviewing_service = reviewing_service
+        self.status = "must_retry"
+        self.save()
+
 
 class SoftwareSecurePhotoVerification(PhotoVerification):
     """

--- a/lms/djangoapps/verify_student/models.py
+++ b/lms/djangoapps/verify_student/models.py
@@ -500,7 +500,7 @@ class SoftwareSecurePhotoVerification(PhotoVerification):
         header_txt = "\n".join(
             "{}: {}".format(h, v) for h,v in sorted(headers.items())
         )
-        body_txt = json.dumps(body, indent=2, sort_keys=True, ensure_ascii=False)
+        body_txt = json.dumps(body, indent=2, sort_keys=True, ensure_ascii=False).encode('utf-8')
 
         return header_txt + "\n\n" + body_txt
 
@@ -509,7 +509,7 @@ class SoftwareSecurePhotoVerification(PhotoVerification):
         response = requests.post(
             settings.VERIFY_STUDENT["SOFTWARE_SECURE"]["API_URL"],
             headers=headers,
-            data=json.dumps(body, indent=2, sort_keys=True, ensure_ascii=False)
+            data=json.dumps(body, indent=2, sort_keys=True, ensure_ascii=False).encode('utf-8')
         )
         log.debug("Sent request to Software Secure for {}".format(self.receipt_id))
         log.debug("Headers:\n{}\n\n".format(headers))

--- a/lms/djangoapps/verify_student/ssencrypt.py
+++ b/lms/djangoapps/verify_student/ssencrypt.py
@@ -164,9 +164,9 @@ def header_string(headers_dict):
 
 def body_string(body_dict, prefix=""):
     """
-    This version actually doesn't support nested lists and dicts. The code for
-    that was a little gnarly and we don't use that functionality, so there's no
-    real test for correctness.
+    Return a canonical string representation of the body of a JSON request or
+    response. This canonical representation will be used as an input to the
+    hashing used to generate a signature.
     """
     body_list = []
     for key, value in sorted(body_dict.items()):


### PR DESCRIPTION
Fixes another unicode bug (turns out json.dumps can return str or unicode depending on args). Also extends Software Secure message signing code to handle more complex data structures. That being said, we are still getting incompatibilities on the receive side, so I'm falling back to authenticating messages using the shared access key rather than signing. We still sign messages to SS, which has always worked. @dianakhuang 
