### PR TITLE
Handle self-signed cert from Software Secure

### DIFF
--- a/lms/djangoapps/verify_student/models.py
+++ b/lms/djangoapps/verify_student/models.py
@@ -529,7 +529,8 @@ class SoftwareSecurePhotoVerification(PhotoVerification):
         response = requests.post(
             settings.VERIFY_STUDENT["SOFTWARE_SECURE"]["API_URL"],
             headers=headers,
-            data=json.dumps(body, indent=2, sort_keys=True, ensure_ascii=False).encode('utf-8')
+            data=json.dumps(body, indent=2, sort_keys=True, ensure_ascii=False).encode('utf-8'),
+            verify=False
         )
         log.debug("Sent request to Software Secure for {}".format(self.receipt_id))
         log.debug("Headers:\n{}\n\n".format(headers))


### PR DESCRIPTION
Don't verify SSL cert when submitting to Software Secure (they're using self-signed cert for the moment). @dianakhuang 
