### PR TITLE
Fix/cdodge/courseware index perf tweek

### DIFF
--- a/lms/djangoapps/courseware/views.py
+++ b/lms/djangoapps/courseware/views.py
@@ -375,9 +375,14 @@ def index(request, course_id, chapter=None, section=None,
             # html, which in general will need all of its children
             section_field_data_cache = FieldDataCache.cache_for_descriptor_descendents(
                 course_id, user, section_descriptor, depth=None)
-            section_module = get_module(request.user, request,
-                                section_descriptor.location,
-                                section_field_data_cache, course_id, position, depth=None)
+
+            section_module = get_module_for_descriptor(request.user,
+                request,
+                section_descriptor,
+                section_field_data_cache,
+                course_id,
+                position
+            )
 
             if section_module is None:
                 # User may be trying to be clever and access something


### PR DESCRIPTION
@cpennington @ormsbee 

It seems like were doing some unnecessary roundtrips to MongoDB (MongoHQ) in the index() function of courseware, which gets a lot of traffic in prod.

We already have the descriptor w/ children (just a few lines up), so we don't need to call get_module() which refetches the descriptor and its children. This saves about 3 or 4 round trips to MongoDB per page load on the index() view.
