### PR TITLE
add accessibility message if mathjax is detected

### DIFF
--- a/lms/static/coffee/src/mathjax_accessible.coffee
+++ b/lms/static/coffee/src/mathjax_accessible.coffee
@@ -1,0 +1,16 @@
+$ ->
+	isMPInstalled = (boolean) ->
+	# check if MathPlayer is installed
+	# (from http://www.dessci.com/en/products/mathplayer/check.htm)
+		try
+			oMP = new ActiveXObject("MathPlayer.Factory.1")
+			true
+		catch e
+			false
+
+	# detect if there is mathjax on the page
+	# if not, set 'aria-hidden' to 'true'
+	if MathJax? and not isMPInstalled()
+		$("#mathjax-accessibility-message").attr("aria-hidden", "false")
+	else
+		$("#mathjax-accessibility-message").attr("aria-hidden", "true")

--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -76,6 +76,7 @@
 </head>
 
 <body class="<%block name='bodyclass'/>">
+  <%include file="mathjax_accessible.html" />
 
 % if theme_enabled():
   <%include file="theme-header.html" />

--- a/lms/templates/mathjax_accessible.html
+++ b/lms/templates/mathjax_accessible.html
@@ -1,0 +1,22 @@
+<%! from django.utils.translation import ugettext as _ %>
+
+<div class="sr message-accessibility message" id="mathjax-accessibility-message" aria-hidden="false">
+	<p class="copy">${
+		_("This page features MathJax technology to render mathematical "
+		  "formulae. To make math accessibile, we suggest using the MathPlayer "
+		  "plugin. Please visit the {link_start}MathPlayer Download "
+		  "Page{link_end} to download the plugin for your browser.").format(
+			  link_start = u'<a href="//www.dessci.com/en/products/mathplayer/'
+			                'download.htm">',
+			  link_end = u'</a>')
+	}</p>
+</div>
+
+<!--[if (lt IE6)|(gt IE 9)|!(IE)]><!-->
+<div class="sr message-accessibility message" id="mathplayer-browser-message" aria-hidden="false">
+	<p class="copy">
+	 ${_("Your browser does not support the MathPlayer plugin. To use "
+	 	 "MathPlayer, please use Internet Explorer 6 through 9.")}
+	 </p>
+</div>
+<!--[endif]-->


### PR DESCRIPTION
Checks to see if MathJax is present. If not, (and mathplayer is not yet currently installed), directs the user to download the plugin and to use it with IE 6-9.

@talbs 
@singingwolfboy 
@brianhw 

Addresses https://edx-wiki.atlassian.net/browse/LMS-586
