### PR TITLE
Fix a bug in links on forum user profile pages

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,9 @@ These are notable changes in edx-platform.  This is a rolling list of changes,
 in roughly chronological order, most recent first.  Add your entries at or near
 the top.  Include a label indicating the component affected.
 
+LMS: Fixed a bug that caused links from forum user profile pages to
+threads to lead to 404s if the course id contained a '-' character.
+
 Common: Added configurable backends for tracking events. Tracking events using
 the python logging module is the default backend. Support for MongoDB and a
 Django database is also available.

--- a/lms/templates/discussion/user_profile.html
+++ b/lms/templates/discussion/user_profile.html
@@ -30,7 +30,7 @@
       </nav>
     </section>
 
-    <section class="course-content container discussion-user-threads" data-user-id="${django_user.id | escapejs}" data-course-id="${course.id | escapejs}" data-threads="${threads}" data-user-info="${user_info}">
+    <section class="course-content container discussion-user-threads" data-user-id="${django_user.id | h}" data-course-id="${course.id | h}" data-threads="${threads}" data-user-info="${user_info}">
         <h2>${_("Active Threads")}</h2>
     </section>
   </div>


### PR DESCRIPTION
Previously, if a course id contained a '-' character, links from that
page to threads would lead to 404s.

@jimabramson @kevinchugh 
