### PR TITLE
Include / Link to How To Contribute wiki page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,8 +2,8 @@ Contributions are very welcome. The easiest way is to fork the repo and then mak
 
 Please review:
 
-* [[Python Guidelines]]
-* [[Javascript Guidelines]]
+* [Python Guidelines](https://github.com/edx/edx-platform/wiki/Python-Guidelines)
+* [Javascript Guidelines](https://github.com/edx/edx-platform/wiki/Javascript-Guidelines)
 * [Testing](https://github.com/edx/edx-platform/blob/master/docs/internal/testing.md)
 
 Coding conventions should be followed and your commit should *increase* test coverage, not decrease it. For more involved contributions, you may want to discuss your intentions on the mailing list *before* you start coding.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+Contributions are very welcome. The easiest way is to fork the repo and then make a pull request from your fork. Before your pull request is merged, it will be reviewed by at least one person. There may be feedback so expect comments on the pull request. Add yourself to the AUTHORS file in your first pull request.
+
+Please review:
+
+* [[Python Guidelines]]
+* [[Javascript Guidelines]]
+* [Testing](https://github.com/edx/edx-platform/blob/master/docs/internal/testing.md)
+
+Coding conventions should be followed and your commit should *increase* test coverage, not decrease it. For more involved contributions, you may want to discuss your intentions on the mailing list *before* you start coding.
+
+Before your first pull request is merged, you'll need to sign the [individual contributor agreement](http://code.edx.org/individual-contributor-agreement.pdf) and send it in. This confirms you have the authority to contribute the code in the pull request and ensures we can relicense it.
+
+If you have any questions, please ask on the [mailing list](https://groups.google.com/forum/#!forum/edx-code).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,7 @@
-Contributions are very welcome. The easiest way is to fork the repo and then make a pull request from your fork. Before your pull request is merged, it will be reviewed by at least one person. There may be feedback so expect comments on the pull request. Add yourself to the AUTHORS file in your first pull request.
+Contributions are very welcome. The easiest way is to fork the repo and then
+make a pull request from your fork. Before your pull request is merged, it will
+be reviewed by at least one person. There may be feedback so expect comments on
+the pull request. Add yourself to the AUTHORS file in your first pull request.
 
 Please review:
 
@@ -6,8 +9,14 @@ Please review:
 * [Javascript Guidelines](https://github.com/edx/edx-platform/wiki/Javascript-Guidelines)
 * [Testing](https://github.com/edx/edx-platform/blob/master/docs/internal/testing.md)
 
-Coding conventions should be followed and your commit should *increase* test coverage, not decrease it. For more involved contributions, you may want to discuss your intentions on the mailing list *before* you start coding.
+Coding conventions should be followed and your commit should *increase* test
+coverage, not decrease it. For more involved contributions, you may want to
+discuss your intentions on the mailing list *before* you start coding.
 
-Before your first pull request is merged, you'll need to sign the [individual contributor agreement](http://code.edx.org/individual-contributor-agreement.pdf) and send it in. This confirms you have the authority to contribute the code in the pull request and ensures we can relicense it.
+Before your first pull request is merged, you'll need to sign the
+[individual contributor agreement](http://code.edx.org/individual-contributor-agreement.pdf)
+and send it in. This confirms you have the authority to contribute the code in
+the pull request and ensures we can relicense it.
 
-If you have any questions, please ask on the [mailing list](https://groups.google.com/forum/#!forum/edx-code).
+If you have any questions, please ask on the
+[mailing list](https://groups.google.com/forum/#!forum/edx-code).

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,6 @@
+How To Contribute
+=================
+
+Contributions are very welcome.
+
+Please read `How To Contribute <https://github.com/edx/edx-platform/wiki/How-To-Contribute>`_ for details.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,6 +1,0 @@
-How To Contribute
-=================
-
-Contributions are very welcome.
-
-Please read `How To Contribute <https://github.com/edx/edx-platform/wiki/How-To-Contribute>`_ for details.

--- a/README.md
+++ b/README.md
@@ -345,9 +345,9 @@ with `overview.md` to get an introduction to the architecture of the system.
 How to Contribute
 -----------------
 
-Contributions are very welcome. The easiest way is to fork this repo, and then
-make a pull request from your fork. The first time you make a pull request, you
-may be asked to sign a Contributor Agreement.
+Contributions are very welcome.
+
+Please read [How To Contribute](https://github.com/edx/edx-platform/wiki/How-To-Contribute) for details.
 
 Reporting Security Issues
 -------------------------


### PR DESCRIPTION
Created a CONTRIBUTING.md which GitHub will pick up and included the contents of the How To Contribute wiki page there. Also added a link to the wiki page in the README "How To Contribute" section.
