### PR TITLE
add inline style flag to formulaequationinput

### DIFF
--- a/common/lib/capa/capa/inputtypes.py
+++ b/common/lib/capa/capa/inputtypes.py
@@ -1081,7 +1081,10 @@ class FormulaEquationInput(InputTypeBase):
         """
         Can set size of text field.
         """
-        return [Attribute('size', '20'), ]
+        return [
+            Attribute('size', '20'),
+            Attribute('inline', False),
+        ]
 
     def _extra_context(self):
         """

--- a/common/lib/capa/capa/templates/formulaequationinput.html
+++ b/common/lib/capa/capa/templates/formulaequationinput.html
@@ -1,4 +1,5 @@
-<section id="formulaequationinput_${id}" class="inputtype formulaequationinput">
+<% doinline = 'style="display:inline-block;vertical-align:top"' if inline else "" %>
+<section id="formulaequationinput_${id}" class="inputtype formulaequationinput" ${doinline}>
   <div class="${reported_status}" id="status_${id}">
     <input type="text" name="input_${id}" id="input_${id}"
 	   data-input-id="${id}" value="${value|h}"

--- a/common/lib/capa/capa/tests/test_inputtypes.py
+++ b/common/lib/capa/capa/tests/test_inputtypes.py
@@ -808,6 +808,7 @@ class FormulaEquationTest(unittest.TestCase):
             'msg': '',
             'size': self.size,
             'previewer': '/static/js/capa/src/formula_equation_preview.js',
+            'inline': False,
         }
         self.assertEqual(context, expected)
 


### PR DESCRIPTION
`formulaequationinput` should honor the `inline` flag, just like other input elements (important for inline math problems)
