### PR TITLE
Dev Environment: Disabling Sass Debug Mode

### DIFF
--- a/rakelib/assets.rake
+++ b/rakelib/assets.rake
@@ -45,7 +45,7 @@ def sass_cmd(watch=false, debug=false)
       sass_watch_paths << THEME_SASS
     end
 
-    "sass #{debug ? '--debug-info' : '--style compressed'} " +
+    "sass #{debug ? '' : '--style compressed'} " +
           "--load-path #{sass_load_paths.join(' ')} " +
           "#{watch ? '--watch' : '--update'} -E utf-8 #{sass_watch_paths.join(' ')}"
 end


### PR DESCRIPTION
This work turns off the sass debug mode setting in assets.rake. The reason for this is to have our local apps' output CSS mimmic the production-level output more closely (to help with resolving issues we're seeing in staging/production, locally).
