### PR TITLE
LMS: FIX - Sass Extend Class Name References

### DIFF
--- a/lms/templates/discussion/_thread_list_template.html
+++ b/lms/templates/discussion/_thread_list_template.html
@@ -4,13 +4,13 @@
         <div class="home">
             <a href="#" class="home-icon">
                 <i class="icon icon-home"></i>
-                <span class="text-sr">${_("Discussion Home")}</span>
+                <span class="sr">${_("Discussion Home")}</span>
             </a>
         </div>
         <div class="browse is-open">
             <a href="#" class="browse-topic-drop-icon">
                 <i class="icon icon-reorder"></i>
-                <span class="text-sr">${_("Discussion Topics")}</span>
+                <span class="sr">${_("Discussion Topics")}</span>
             </a>
             <a href="#" class="browse-topic-drop-btn"><span class="current-board">${_("Show All Discussions")}</span> <span class="drop-arrow">▾</span></a>
         </div>


### PR DESCRIPTION
This resolves direct class name references to extends that have been converted to placeholder Sass syntax.
