### PR TITLE
Catch IOError and ignore if OS X companion file

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/xml_importer.py
+++ b/common/lib/xmodule/xmodule/modulestore/xml_importer.py
@@ -33,14 +33,22 @@ def import_static_content(modules, course_loc, course_data_path, static_content_
                 if verbose:
                     log.debug('importing static content %s...', content_path)
 
+                try:
+                    with open(content_path, 'rb') as f:
+                        data = f.read()
+                except IOError:
+                    if filename.startswith('._'):
+                        # OS X "companion files". See http://www.diigo.com/annotated/0c936fda5da4aa1159c189cea227e174
+                        continue
+                    # Not a 'hidden file', then re-raise exception
+                    raise
+
                 fullname_with_subpath = content_path.replace(static_dir, '')  # strip away leading path from the name
                 if fullname_with_subpath.startswith('/'):
                     fullname_with_subpath = fullname_with_subpath[1:]
                 content_loc = StaticContent.compute_location(target_location_namespace.org, target_location_namespace.course, fullname_with_subpath)
                 mime_type = mimetypes.guess_type(filename)[0]
 
-                with open(content_path, 'rb') as f:
-                    data = f.read()
 
                 content = StaticContent(content_loc, filename, mime_type, data, import_path=fullname_with_subpath)
 

--- a/common/lib/xmodule/xmodule/modulestore/xml_importer.py
+++ b/common/lib/xmodule/xmodule/modulestore/xml_importer.py
@@ -28,46 +28,43 @@ def import_static_content(modules, course_loc, course_data_path, static_content_
     for dirname, _, filenames in os.walk(static_dir):
         for filename in filenames:
 
+            content_path = os.path.join(dirname, filename)
+            if verbose:
+                log.debug('importing static content %s...', content_path)
+
             try:
-                content_path = os.path.join(dirname, filename)
-                if verbose:
-                    log.debug('importing static content %s...', content_path)
-
-                try:
-                    with open(content_path, 'rb') as f:
-                        data = f.read()
-                except IOError:
-                    if filename.startswith('._'):
-                        # OS X "companion files". See http://www.diigo.com/annotated/0c936fda5da4aa1159c189cea227e174
-                        continue
-                    # Not a 'hidden file', then re-raise exception
-                    raise
-
-                fullname_with_subpath = content_path.replace(static_dir, '')  # strip away leading path from the name
-                if fullname_with_subpath.startswith('/'):
-                    fullname_with_subpath = fullname_with_subpath[1:]
-                content_loc = StaticContent.compute_location(target_location_namespace.org, target_location_namespace.course, fullname_with_subpath)
-                mime_type = mimetypes.guess_type(filename)[0]
-
-
-                content = StaticContent(content_loc, filename, mime_type, data, import_path=fullname_with_subpath)
-
-                # first let's save a thumbnail so we can get back a thumbnail location
-                (thumbnail_content, thumbnail_location) = static_content_store.generate_thumbnail(content)
-
-                if thumbnail_content is not None:
-                    content.thumbnail_location = thumbnail_location
-
-                #then commit the content
-                try:
-                    static_content_store.save(content)
-                except Exception as err:
-                    log.exception('Error importing {0}, error={1}'.format(fullname_with_subpath, err))
-
-                #store the remapping information which will be needed to subsitute in the module data
-                remap_dict[fullname_with_subpath] = content_loc.name
-            except:
+                with open(content_path, 'rb') as f:
+                    data = f.read()
+            except IOError:
+                if filename.startswith('._'):
+                    # OS X "companion files". See http://www.diigo.com/annotated/0c936fda5da4aa1159c189cea227e174
+                    continue
+                # Not a 'hidden file', then re-raise exception
                 raise
+
+            fullname_with_subpath = content_path.replace(static_dir, '')  # strip away leading path from the name
+            if fullname_with_subpath.startswith('/'):
+                fullname_with_subpath = fullname_with_subpath[1:]
+            content_loc = StaticContent.compute_location(target_location_namespace.org, target_location_namespace.course, fullname_with_subpath)
+            mime_type = mimetypes.guess_type(filename)[0]
+
+
+            content = StaticContent(content_loc, filename, mime_type, data, import_path=fullname_with_subpath)
+
+            # first let's save a thumbnail so we can get back a thumbnail location
+            (thumbnail_content, thumbnail_location) = static_content_store.generate_thumbnail(content)
+
+            if thumbnail_content is not None:
+                content.thumbnail_location = thumbnail_location
+
+            #then commit the content
+            try:
+                static_content_store.save(content)
+            except Exception as err:
+                log.exception('Error importing {0}, error={1}'.format(fullname_with_subpath, err))
+
+            #store the remapping information which will be needed to subsitute in the module data
+            remap_dict[fullname_with_subpath] = content_loc.name
 
     return remap_dict
 


### PR DESCRIPTION
@dmitchell @chrisndodge 

Chris added a similar try-except block elsewhere in this file, but this call to `open` was also giving trouble for more or less the same reason. I moved the `open` up since we wait to `continue` before doing anything else.

Most of the function is wrapped in another `try` (ln. 31) - `except` (ln. 69) that I didn't change, but has been bugging me. It just catches anything and re-raises it. Since I might be missing something, I didn't change it, but if two other pairs of eyes say it can go, I'll do that too.
