### PR TITLE
make tooltips screen-readable

### DIFF
--- a/lms/templates/seq_module.html
+++ b/lms/templates/seq_module.html
@@ -18,7 +18,7 @@
            data-id="${item['id']}"
            data-element="${idx+1}"
            href="javascript:void(0);">
-            <p>${item['title']}<span class="sr">, ${item['type']}</span></p>
+            <p aria-hidden="false">${item['title']}<span class="sr">, ${item['type']}</span></p>
           </a>
         </li>
         % endfor


### PR DESCRIPTION
Makes the contents of sequentials' navbars' dropdowns readable to screen readers.

Addresses https://edx-wiki.atlassian.net/browse/LMS-585

@talbs 
@caesar2164 
