### PR TITLE
Fixed duplicate ID attributes in registration & login

### DIFF
--- a/lms/templates/forgot_password_modal.html
+++ b/lms/templates/forgot_password_modal.html
@@ -1,7 +1,7 @@
 <%! from django.utils.translation import ugettext as _ %>
 
 <%! from django.core.urlresolvers import reverse %>
-<section id="forgot-password-modal" class="modal forgot-password-modal">
+<section id="forgot-password-modal" class="modal forgot-password-modal" role="dialog" aria-label="Password Reset">
   <div class="inner-wrapper">
     <div id="password-reset">
       <header>
@@ -17,7 +17,7 @@
           <legend class="is-hidden">${_("Required Information")}</legend>
 
           <ol class="list-input">
-            <li class="field required text" id="field-email">
+            <li class="field required text" id="field-email-for-forgot-pwd">
               <label for="pwd_reset_email">${_("Your E-mail Address")}</label>
               <input class="" id="pwd_reset_email" type="email" name="email" value="" placeholder="example: username@domain.com" aria-describedby="pwd_reset_email-tip" />
               <span class="tip tip-input" id="pwd_reset_email-tip">${_("This is the e-mail address you used to register with {platform}").format(platform=settings.PLATFORM_NAME)}</span>

--- a/lms/templates/forgot_password_modal.html
+++ b/lms/templates/forgot_password_modal.html
@@ -17,7 +17,7 @@
           <legend class="is-hidden">${_("Required Information")}</legend>
 
           <ol class="list-input">
-            <li class="field required text" id="field-email-for-forgot-pwd">
+            <li class="field required text" id="forgot-password-modal-field-email">
               <label for="pwd_reset_email">${_("Your E-mail Address")}</label>
               <input class="" id="pwd_reset_email" type="email" name="email" value="" placeholder="example: username@domain.com" aria-describedby="pwd_reset_email-tip" />
               <span class="tip tip-input" id="pwd_reset_email-tip">${_("This is the e-mail address you used to register with {platform}").format(platform=settings.PLATFORM_NAME)}</span>

--- a/lms/templates/forgot_password_modal.html
+++ b/lms/templates/forgot_password_modal.html
@@ -1,7 +1,7 @@
 <%! from django.utils.translation import ugettext as _ %>
 
 <%! from django.core.urlresolvers import reverse %>
-<section id="forgot-password-modal" class="modal forgot-password-modal" role="dialog" aria-label="Password Reset">
+<section id="forgot-password-modal" class="modal forgot-password-modal" role="dialog" aria-label="${_(Password Reset")}>
   <div class="inner-wrapper">
     <div id="password-reset">
       <header>

--- a/lms/templates/forgot_password_modal.html
+++ b/lms/templates/forgot_password_modal.html
@@ -1,7 +1,7 @@
 <%! from django.utils.translation import ugettext as _ %>
 
 <%! from django.core.urlresolvers import reverse %>
-<section id="forgot-password-modal" class="modal forgot-password-modal" role="dialog" aria-label="${_(Password Reset")}>
+<section id="forgot-password-modal" class="modal forgot-password-modal" role="dialog" aria-label=${_("Password Reset")}>
   <div class="inner-wrapper">
     <div id="password-reset">
       <header>

--- a/lms/templates/login.html
+++ b/lms/templates/login.html
@@ -128,7 +128,7 @@
             <label for="password">${_('Password')}</label>
             <input id="password" type="password" name="password" value="" required aria-required="true" />
             <span class="tip tip-input">
-              <a href="#forgot-password-modal" rel="leanModal" class="pwd-reset action action-forgotpw">${_('Forgot password?')}</a>
+              <a href="#forgot-password-modal" rel="leanModal" class="pwd-reset action action-forgotpw" role="button" aria-haspopup="true">${_('Forgot password?')}</a>
             </span>
           </li>
         </ol>


### PR DESCRIPTION
Fixed pages that were presenting duplicate "field-email" ID attributes, as described in

https://edx-wiki.atlassian.net/browse/LMS-601
https://edx-wiki.atlassian.net/browse/LMS-599

@adampalay @talbs 
