### PR TITLE
Minor cleanup.

### DIFF
--- a/cms/static/coffee/spec/models/textbook_spec.coffee
+++ b/cms/static/coffee/spec/models/textbook_spec.coffee
@@ -25,7 +25,7 @@ describe "CMS.Models.Textbook", ->
             expect(@model.isEmpty()).toBeTruthy()
 
         it "should have a URL set", ->
-            expect(_.result(@model, "url")).toBeTruthy()
+            expect(@model.url()).toBeTruthy()
 
         it "should be able to reset itself", ->
             @model.set("name", "foobar")
@@ -124,14 +124,14 @@ describe "CMS.Models.Textbook", ->
 
 describe "CMS.Collections.TextbookSet", ->
     beforeEach ->
-        CMS.URL.TEXTBOOK = "/textbooks"
+        CMS.URL.TEXTBOOKS = "/textbooks"
         @collection = new CMS.Collections.TextbookSet()
 
     afterEach ->
-        delete CMS.URL.TEXTBOOK
+        delete CMS.URL.TEXTBOOKS
 
     it "should have a url set", ->
-        expect(_.result(@collection, "url"), "/textbooks")
+        expect(@collection.url()).toEqual("/textbooks")
 
     it "can call save", ->
         spyOn(@collection, "sync")

--- a/cms/static/js/views/textbook.js
+++ b/cms/static/js/views/textbook.js
@@ -156,7 +156,6 @@ CMS.Views.ListTextbooks = Backbone.View.extend({
     initialize: function() {
         this.emptyTemplate = _.template($("#no-textbooks-tpl").text());
         this.listenTo(this.collection, 'all', this.render);
-        this.listenTo(this.collection, 'destroy', this.handleDestroy);
     },
     tagName: "div",
     className: "textbooks-list",
@@ -185,9 +184,6 @@ CMS.Views.ListTextbooks = Backbone.View.extend({
     addOne: function(e) {
         if(e && e.preventDefault) { e.preventDefault(); }
         this.collection.add([{editing: true}]);
-    },
-    handleDestroy: function(model, collection, options) {
-        collection.remove(model);
     }
 });
 CMS.Views.EditChapter = Backbone.View.extend({


### PR DESCRIPTION
@singingwolfboy A couple of minor things I noticed while using the textbooks as an example for assets.

1) The _.result syntax isn't working. I'm not sure why, but the asserts always pass, no matter what you are testing for. Calling the methods directly seems simpler anyway.

2) Related to #1, the URL key was wrong for CMS.Collections.TextbookSet.

3) Calling destroy on a model removes it from the collection automatically.
