### PR TITLE
Send student email to xqueue with coderesponse (lms setting controls)

### DIFF
--- a/common/lib/capa/capa/responsetypes.py
+++ b/common/lib/capa/capa/responsetypes.py
@@ -1473,6 +1473,9 @@ class CodeResponse(LoncapaResponse):
             'anonymous_student_id': anonymous_student_id,
             'submission_time': qtime,
         }
+        if getattr(self.system, 'send_users_emailaddr_with_coderesponse', False):
+            student_info.update({'student_email': self.system.deanonymized_user_email})
+
         contents.update({'student_info': json.dumps(student_info)})
 
         # Submit request. When successful, 'msg' is the prior length of the

--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -379,6 +379,12 @@ def get_module_for_descriptor_internal(user, descriptor, field_data_cache, cours
         # TODO: When we merge the descriptor and module systems, we can stop reaching into the mixologist (cpennington)
         mixins=descriptor.system.mixologist._mixins,
     )
+    if settings.MITX_FEATURES.get('SEND_USERS_EMAILADDR_WITH_CODERESPONSE', False):
+        system.set('send_users_emailaddr_with_coderesponse', True)
+        if user.is_authenticated():
+            system.set('deanonymized_user_email', user.email)
+        else:
+            system.set('deanonymized_user_email', '')
 
     # pass position specified in URL to module through ModuleSystem
     system.set('position', position)

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -171,6 +171,10 @@ MITX_FEATURES = {
 
     # Toggle storing detailed billing information
     'STORE_BILLING_INFO': False,
+
+    # Sends the user's deanonymized email address to xqueue with code responses
+    # DO NOT SET if you don't want the anonymous user id to be linked with user.email in xqueue (Stanford does)
+    'SEND_USERS_EMAILADDR_WITH_CODERESPONSE': False,
 }
 
 # Used for A/B testing


### PR DESCRIPTION
@cpennington 

This feature is behind an LMS MITX_FEATURES flag: 'SEND_USERS_EMAILADDR_WITH_CODERESPONSE'.

It may cause you to hold your nose a bit, but Stanford's instance is beholden to the needs of our faculty.

The feature, when enabled, sends the email address of the student to xqueue for coderesponses.  This obviously creates a place where anonymous_student_id is linked with non-anonymous student email, causing a de-anonymization risk, but our faculty need to get students' email when they write graders that pull from xqueue.  And we run all of our "external" graders ourselves, no xqueues are exposed to entities outside Stanford, so we're not in FERPA jeopardy.  I don't expect edx-east to ever enable this feature.

Tests included: quality and coverage are both 100%
