### PR TITLE
Disabled video autoplay for students

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/video/03_video_player.js
+++ b/common/lib/xmodule/xmodule/js/src/video/03_video_player.js
@@ -420,12 +420,15 @@ function (HTML5Video) {
             this.videoPlayer.player.setPlaybackRate(this.speed);
         }
 
+        /* The following has been commented out to make sure autoplay is 
+           disabled for students.
         if (
             !onTouchBasedDevice() &&
             $('.video:first').data('autoplay') === 'True'
         ) {
             this.videoPlayer.play();
         }
+        */
     }
 
     function onStateChange(event) {

--- a/common/lib/xmodule/xmodule/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module.py
@@ -188,7 +188,7 @@ class VideoModule(VideoFields, XModule):
             'show_captions': json.dumps(self.show_captions),
             'start': self.start_time,
             'end': self.end_time,
-            'autoplay': settings.MITX_FEATURES.get('AUTOPLAY_VIDEOS', True),
+            'autoplay': settings.MITX_FEATURES.get('AUTOPLAY_VIDEOS', False),
             # TODO: Later on the value 1500 should be taken from some global
             # configuration setting field.
             'yt_test_timeout': 1500,

--- a/lms/djangoapps/courseware/features/video.feature
+++ b/lms/djangoapps/courseware/features/video.feature
@@ -8,9 +8,9 @@ Feature: Video component
 
   # Firefox doesn't have HTML5 (only mp4 - fix here)
   @skip_firefox
-  Scenario: Autoplay is enabled in LMS for a Video component
+  Scenario: Autoplay is disabled in LMS for a Video component
   Given the course has a Video component in HTML5 mode
-  Then when I view the video it has autoplay enabled
+  Then when I view the video it does not have autoplay enabled
 
 # Youtube testing
 Scenario: Video component is fully rendered in the LMS in Youtube mode with HTML5 sources

--- a/lms/djangoapps/courseware/features/video.py
+++ b/lms/djangoapps/courseware/features/video.py
@@ -16,9 +16,9 @@ HTML5_SOURCES_INCORRECT = [
     'https://s3.amazonaws.com/edx-course-videos/edx-intro/edX-FA12-cware-1_100.mp99'
 ]
 
-@step('when I view the (.*) it has autoplay enabled$')
+@step('when I view the (.*) it does not have autoplay enabled$')
 def does_autoplay_video(_step, video_type):
-    assert(world.css_find('.%s' % video_type)[0]['data-autoplay'] == 'True')
+    assert(world.css_find('.%s' % video_type)[0]['data-autoplay'] == 'False')
 
 
 @step('the course has a Video component in (.*) mode$')

--- a/lms/djangoapps/courseware/features/video.py
+++ b/lms/djangoapps/courseware/features/video.py
@@ -17,7 +17,7 @@ HTML5_SOURCES_INCORRECT = [
 ]
 
 @step('when I view the (.*) it does not have autoplay enabled$')
-def does_autoplay_video(_step, video_type):
+def does_not_autoplay(_step, video_type):
     assert(world.css_find('.%s' % video_type)[0]['data-autoplay'] == 'False')
 
 

--- a/lms/djangoapps/courseware/tests/test_video_mongo.py
+++ b/lms/djangoapps/courseware/tests/test_video_mongo.py
@@ -61,7 +61,7 @@ class TestVideo(BaseTestXmodule):
             'sub': u'a_sub_file.srt.sjson',
             'track': '',
             'youtube_streams': _create_youtube_string(self.item_module),
-            'autoplay': settings.MITX_FEATURES.get('AUTOPLAY_VIDEOS', True),
+            'autoplay': settings.MITX_FEATURES.get('AUTOPLAY_VIDEOS', False),
             'yt_test_timeout': 1500,
             'yt_test_url': 'https://gdata.youtube.com/feeds/api/videos/'
         }

--- a/lms/djangoapps/courseware/tests/test_video_xml.py
+++ b/lms/djangoapps/courseware/tests/test_video_xml.py
@@ -94,7 +94,7 @@ class VideoModuleUnitTest(unittest.TestCase):
             'sources': sources,
             'youtube_streams': _create_youtube_string(module),
             'track': '',
-            'autoplay': settings.MITX_FEATURES.get('AUTOPLAY_VIDEOS', True),
+            'autoplay': settings.MITX_FEATURES.get('AUTOPLAY_VIDEOS', False),
             'yt_test_timeout': 1500,
             'yt_test_url': 'https://gdata.youtube.com/feeds/api/videos/'
         }

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -144,8 +144,8 @@ MITX_FEATURES = {
     # Toggle to indicate use of a custom theme
     'USE_CUSTOM_THEME': False,
 
-    # Do autoplay videos for students
-    'AUTOPLAY_VIDEOS': True,
+    # Don't autoplay videos for students
+    'AUTOPLAY_VIDEOS': False,
 
     # Enable instructor dash to submit background tasks
     'ENABLE_INSTRUCTOR_BACKGROUND_TASKS': True,


### PR DESCRIPTION
The autoplay functionality is turned off now. Should we just remove it altogether? 
