### PR TITLE
save lock state in contentstore

### DIFF
--- a/cms/djangoapps/contentstore/views/assets.py
+++ b/cms/djangoapps/contentstore/views/assets.py
@@ -10,7 +10,6 @@ from django.views.decorators.http import require_POST
 
 from mitxmako.shortcuts import render_to_response
 from cache_toolbox.core import del_cached_content
-from auth.authz import create_all_course_groups
 
 from xmodule.contentstore.django import contentstore
 from xmodule.modulestore.django import modulestore

--- a/common/lib/xmodule/xmodule/contentstore/content.py
+++ b/common/lib/xmodule/xmodule/contentstore/content.py
@@ -15,9 +15,9 @@ from PIL import Image
 
 class StaticContent(object):
     def __init__(self, loc, name, content_type, data, last_modified_at=None, thumbnail_location=None, import_path=None,
-                 length=None):
+                 length=None, locked=False):
         self.location = loc
-        self.name = name   # a display string which can be edited, and thus not part of the location which needs to be fixed
+        self.name = name  # a display string which can be edited, and thus not part of the location which needs to be fixed
         self.content_type = content_type
         self._data = data
         self.length = length

--- a/common/lib/xmodule/xmodule/contentstore/content.py
+++ b/common/lib/xmodule/xmodule/contentstore/content.py
@@ -26,6 +26,7 @@ class StaticContent(object):
         # optional information about where this file was imported from. This is needed to support import/export
         # cycles
         self.import_path = import_path
+        self.locked = locked
 
     @property
     def is_thumbnail(self):
@@ -133,10 +134,10 @@ class StaticContent(object):
 
 class StaticContentStream(StaticContent):
     def __init__(self, loc, name, content_type, stream, last_modified_at=None, thumbnail_location=None, import_path=None,
-                 length=None):
+                 length=None, locked=False):
         super(StaticContentStream, self).__init__(loc, name, content_type, None, last_modified_at=last_modified_at,
                                                   thumbnail_location=thumbnail_location, import_path=import_path,
-                                                  length=length)
+                                                  length=length, locked=locked)
         self._stream = stream
 
     def stream_data(self):
@@ -153,7 +154,7 @@ class StaticContentStream(StaticContent):
         self._stream.seek(0)
         content = StaticContent(self.location, self.name, self.content_type, self._stream.read(),
                                 last_modified_at=self.last_modified_at, thumbnail_location=self.thumbnail_location,
-                                import_path=self.import_path, length=self.length)
+                                import_path=self.import_path, length=self.length, locked=self.locked)
         return content
 
 


### PR DESCRIPTION
Does not handle export/import as that's a much bigger change and I wanted to get this in to unblock other work. The crux of the change is in mongo.py. There are unit tests for get/set of attr, but there are no unit tests for lock set during asset save and retrieved during asset find yet. I'd like to know whether to add these to the xmodule test file or put them in the cms/django ones.

@cdodge @cahrens pls review
