### PR TITLE
Adding Pillow jpeg and tiff system libs

### DIFF
--- a/requirements/system/mac_os_x/brew-formulas.txt
+++ b/requirements/system/mac_os_x/brew-formulas.txt
@@ -11,3 +11,5 @@ mysql
 geos
 mongodb
 lynx
+libjpeg
+libtiff

--- a/requirements/system/ubuntu/apt-packages.txt
+++ b/requirements/system/ubuntu/apt-packages.txt
@@ -16,6 +16,8 @@ gfortran
 libfreetype6-dev
 libpng12-dev
 libjpeg-dev
+libtiff4-dev
+zlib1g-dev
 libxml2-dev
 libxslt-dev
 yui-compressor


### PR DESCRIPTION
The two libraries that we need to render jpeg and tiff functionality in Pillow.

@cpennington @chrisndodge 
