### PR TITLE
Added setting to disable 'find courses' links

### DIFF
--- a/lms/djangoapps/branding/views.py
+++ b/lms/djangoapps/branding/views.py
@@ -52,10 +52,6 @@ def courses(request):
     if not settings.MITX_FEATURES.get('COURSES_ARE_BROWSABLE'):        
         raise Http404
 
-    university = branding.get_university(request.META.get('HTTP_HOST'))
-    if university == 'edge':
-        return render_to_response('university_profile/edge.html', {})
-
     #  we do not expect this case to be reached in cases where
-    #  marketing and edge are enabled
+    #  marketing is enabled or the courses are not browsable
     return courseware.views.courses(request)

--- a/lms/djangoapps/branding/views.py
+++ b/lms/djangoapps/branding/views.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.core.urlresolvers import reverse
+from django.http import Http404
 from django.shortcuts import redirect
 from django_future.csrf import ensure_csrf_cookie
 from mitxmako.shortcuts import render_to_response
@@ -47,6 +48,9 @@ def courses(request):
     """
     if settings.MITX_FEATURES.get('ENABLE_MKTG_SITE', False):
         return redirect(marketing_link('COURSES'), permanent=True)
+
+    if not settings.MITX_FEATURES.get('COURSES_ARE_BROWSABLE'):        
+        raise Http404
 
     university = branding.get_university(request.META.get('HTTP_HOST'))
     if university == 'edge':

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -103,6 +103,9 @@ MITX_FEATURES = {
     # with Shib.  Feature was requested by Stanford's office of general counsel
     'SHIB_DISABLE_TOS': False,
 
+    # Can be turned off if all courses are invite-only. Effects views and templates.
+    'ENABLE_STUDENT_SELF_ENROLLMENT': True,
+
     # Enables ability to restrict enrollment in specific courses by the user account login method
     'RESTRICT_ENROLL_BY_REG_METHOD': False,
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -103,8 +103,8 @@ MITX_FEATURES = {
     # with Shib.  Feature was requested by Stanford's office of general counsel
     'SHIB_DISABLE_TOS': False,
 
-    # Can be turned off if all courses are invite-only. Effects views and templates.
-    'ENABLE_STUDENT_SELF_ENROLLMENT': True,
+    # Can be turned off if course lists need to be hidden. Effects views and templates.
+    'COURSES_ARE_BROWSABLE': True,
 
     # Enables ability to restrict enrollment in specific courses by the user account login method
     'RESTRICT_ENROLL_BY_REG_METHOD': False,

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -332,7 +332,7 @@
       </ul>
     % else:
       <section class="empty-dashboard-message">
-        % if settings.MITX_FEATURES.get('ENABLE_STUDENT_SELF_ENROLLMENT'):
+        % if settings.MITX_FEATURES.get('COURSES_ARE_BROWSABLE'):
           <p>${_("Looks like you haven't registered for any courses yet.")}</p>
           <a href="${marketing_link('COURSES')}">
             ${_("Find courses now!")}

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -338,7 +338,7 @@
             ${_("Find courses now!")}
           </a>
         % else:
-          <p>${_("Looks like you haven't joined any courses yet.")}</p>
+          <p>${_("Looks like you haven't been enrolled in any courses yet.")}</p>
         %endif
       </section>
     % endif

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -332,10 +332,14 @@
       </ul>
     % else:
       <section class="empty-dashboard-message">
-        <p>${_("Looks like you haven't registered for any courses yet.")}</p>
-        <a href="${marketing_link('COURSES')}">
+        % if settings.MITX_FEATURES.get('ENABLE_STUDENT_SELF_ENROLLMENT'):
+          <p>${_("Looks like you haven't registered for any courses yet.")}</p>
+          <a href="${marketing_link('COURSES')}">
             ${_("Find courses now!")}
-        </a>
+          </a>
+        % else:
+          <p>${_("Looks like you haven't joined any courses yet.")}</p>
+        %endif
       </section>
     % endif
 

--- a/lms/templates/index.html
+++ b/lms/templates/index.html
@@ -165,15 +165,17 @@
         </section>
       % endif
 
-      <section class="courses">
-          <ul class="courses-listing">
-          %for course in courses:
-            <li class="courses-listing-item">
-              <%include file="course.html" args="course=course" />
-            </li>
-          %endfor
-          </ul>
-      </section>
+      % if settings.MITX_FEATURES.get('COURSES_ARE_BROWSABLE'):
+        <section class="courses">
+            <ul class="courses-listing">
+            %for course in courses:
+              <li class="courses-listing-item">
+                <%include file="course.html" args="course=course" />
+              </li>
+            %endfor
+            </ul>
+        </section>
+      % endif
     </section>
   </section>
 </section>

--- a/lms/templates/navigation.html
+++ b/lms/templates/navigation.html
@@ -57,9 +57,11 @@ site_status_msg = get_site_status_msg(course_id)
 
     <ol class="left nav-global authenticated">
       <%block name="navigation_global_links_authenticated">
-        <li class="nav-global-01">
-          <a href="${marketing_link('COURSES')}">${_('Find Courses')}</a>
-        </li>
+        % if settings.MITX_FEATURES.get('ENABLE_STUDENT_SELF_ENROLLMENT'):
+          <li class="nav-global-01">
+            <a href="${marketing_link('COURSES')}">${_('Find Courses')}</a>
+          </li>
+        % endif  
       </%block>
     </ol>
     <ol class="user">

--- a/lms/templates/navigation.html
+++ b/lms/templates/navigation.html
@@ -57,7 +57,7 @@ site_status_msg = get_site_status_msg(course_id)
 
     <ol class="left nav-global authenticated">
       <%block name="navigation_global_links_authenticated">
-        % if settings.MITX_FEATURES.get('ENABLE_STUDENT_SELF_ENROLLMENT'):
+        % if settings.MITX_FEATURES.get('COURSES_ARE_BROWSABLE'):
           <li class="nav-global-01">
             <a href="${marketing_link('COURSES')}">${_('Find Courses')}</a>
           </li>


### PR DESCRIPTION
This is needed for edge where courses are invite only and 'Find Courses' links in the student dashboard redirect to the login page.

https://edx-wiki.atlassian.net/browse/LMS-1026

@adampalay 
