### PR TITLE
Jbau/shib bugfixes

### DIFF
--- a/common/djangoapps/external_auth/tests/test_shib.py
+++ b/common/djangoapps/external_auth/tests/test_shib.py
@@ -514,8 +514,16 @@ class ShibUtilFnTest(TestCase):
     """
     def test__flatten_to_ascii(self):
         DIACRITIC = u"àèìòùÀÈÌÒÙáéíóúýÁÉÍÓÚÝâêîôûÂÊÎÔÛãñõÃÑÕäëïöüÿÄËÏÖÜŸåÅçÇ"  # pylint: disable=C0103
+        STR_DIACRI = "àèìòùÀÈÌÒÙáéíóúýÁÉÍÓÚÝâêîôûÂÊÎÔÛãñõÃÑÕäëïöüÿÄËÏÖÜŸåÅçÇ"  # pylint: disable=C0103
         FLATTENED = u"aeiouAEIOUaeiouyAEIOUYaeiouAEIOUanoANOaeiouyAEIOUYaAcC"  # pylint: disable=C0103
         self.assertEqual(_flatten_to_ascii(u'jas\xf6n'), u'jason')  # umlaut
         self.assertEqual(_flatten_to_ascii(u'Jason\u5305'), u'Jason')  # mandarin, so it just gets dropped
         self.assertEqual(_flatten_to_ascii(u'abc'), u'abc')  # pass through
-        self.assertEqual(_flatten_to_ascii(DIACRITIC), FLATTENED)
+
+        unicode_test = _flatten_to_ascii(DIACRITIC)
+        self.assertEqual(unicode_test, FLATTENED)
+        self.assertIsInstance(unicode_test, unicode)
+
+        str_test = _flatten_to_ascii(STR_DIACRI)
+        self.assertEqual(str_test, FLATTENED)
+        self.assertIsInstance(str_test, str)

--- a/common/djangoapps/external_auth/views.py
+++ b/common/djangoapps/external_auth/views.py
@@ -34,7 +34,6 @@ try:
 except ImportError:
     from django.contrib.csrf.middleware import csrf_exempt
 from django_future.csrf import ensure_csrf_cookie
-from util.cache import cache_if_anonymous
 
 import django_openid_auth.views as openid_views
 from django_openid_auth import auth as openid_auth
@@ -137,8 +136,6 @@ def _external_login_or_signup(request,
                               fullname,
                               retfun=None):
     """Generic external auth login or signup"""
-    logout(request)
-
     # see if we have a map from this external_id to an edX username
     try:
         eamap = ExternalAuthMap.objects.get(external_id=external_id,
@@ -242,7 +239,6 @@ def _flatten_to_ascii(txt):
         return unicode(unicodedata.normalize('NFKD', txt).encode('ASCII', 'ignore'))
 
 @ensure_csrf_cookie
-@cache_if_anonymous
 def _signup(request, eamap):
     """
     Present form to complete for signup via external authentication.

--- a/common/djangoapps/external_auth/views.py
+++ b/common/djangoapps/external_auth/views.py
@@ -233,10 +233,13 @@ def _flatten_to_ascii(txt):
     """
     Flattens possibly unicode txt to ascii (django username limitation)
     @param name:
-    @return:
+    @return: the flattened txt (in the same type as was originally passed in)
     """
-    return unicodedata.normalize('NFKD', txt).encode('ASCII', 'ignore')
-
+    if isinstance(txt, str):
+        txt = txt.decode('utf-8')
+        return unicodedata.normalize('NFKD', txt).encode('ASCII', 'ignore')
+    else:
+        return unicode(unicodedata.normalize('NFKD', txt).encode('ASCII', 'ignore'))
 
 @ensure_csrf_cookie
 @cache_if_anonymous


### PR DESCRIPTION
@brianhw 

2 bugfixes from our hotfix on Stanford's prod today.

1st was that the flatten_to_ascii function wasn't handling `str` input properly.  That has tests to show the fix does now

2nd was that the `@cache_if_anonymous` decorator on `_signup` was causing that view function to not be run sometimes.  But since the function writes the ExternalAuthMap to the user's session so that the later POST from the registration page can access it, this caused registration failures since things like email which would be supplied by the ExternalAuthMap were missing.
