### PR TITLE
Focus speed control

### DIFF
--- a/common/lib/xmodule/xmodule/js/spec/video/video_speed_control_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_speed_control_spec.js
@@ -140,24 +140,22 @@
       });
 
       describe('make sure the speed control gets the focus afterwards', function() {
-        var focusSpy;
+        var spyEvent;
 
         beforeEach(function() {
           initialize();
           videoSpeedControl.setSpeed(1.0);
-          focusSpy = spyOn($.fn, 'focus').andCallThrough();
+          spyEvent = spyOnEvent('.speeds > a', 'focus');
         });
 
         it('when the speed is the same', function() {
           $('li[data-speed="1.0"] a').click();
-          expect(focusSpy).toHaveBeenCalled();
-          expect(focusSpy.mostRecentCall.object.selector).toEqual('.parent().parent().siblings(a)');
+          expect(spyEvent).toHaveBeenTriggered();
         });
 
         it('when the speed is not the same', function() {
           $('li[data-speed="0.75"] a').click();
-          expect(focusSpy).toHaveBeenCalled();
-          expect(focusSpy.mostRecentCall.object.selector).toEqual('.parent().parent().siblings(a)');
+          expect(spyEvent).toHaveBeenTriggered();;
         });
       });
     });

--- a/common/lib/xmodule/xmodule/js/spec/video/video_speed_control_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_speed_control_spec.js
@@ -140,20 +140,22 @@
       });
 
       describe('make sure the speed control gets the focus afterwards', function() {
-          beforeEach(function() {
+        var anchor;
+        beforeEach(function() {
           initialize();
+          anchor= $('.speeds > a').first();
           videoSpeedControl.setSpeed(1.0);
-          spyOnEvent(state.videoSpeedControl.mainAnchor, 'focus');
+          spyOnEvent(anchor, 'focus');
         });
 
         it('when the speed is the same', function() {
           $('li[data-speed="1.0"] a').click();
-          expect('focus').toHaveBeenTriggeredOn(state.videoSpeedControl.mainAnchor);
+          expect('focus').toHaveBeenTriggeredOn(anchor);
         });
 
         it('when the speed is not the same', function() {
           $('li[data-speed="0.75"] a').click();
-          expect('focus').toHaveBeenTriggeredOn(state.videoSpeedControl.mainAnchor);
+          expect('focus').toHaveBeenTriggeredOn(anchor);
         });
       });
     });

--- a/common/lib/xmodule/xmodule/js/spec/video/video_speed_control_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_speed_control_spec.js
@@ -138,6 +138,28 @@
           expect(videoSpeedControl.currentSpeed).toEqual(0.75);
         });
       });
+
+      describe('make sure the speed control gets the focus afterwards', function() {
+        var focusSpy;
+
+        beforeEach(function() {
+          initialize();
+          videoSpeedControl.setSpeed(1.0);
+          focusSpy = spyOn($.fn, 'focus').andCallThrough();
+        });
+
+        it('when the speed is the same', function() {
+          $('li[data-speed="1.0"] a').click();
+          expect(focusSpy).toHaveBeenCalled();
+          expect(focusSpy.mostRecentCall.object.selector).toEqual('.parent().parent().siblings(a)');
+        });
+
+        it('when the speed is not the same', function() {
+          $('li[data-speed="0.75"] a').click();
+          expect(focusSpy).toHaveBeenCalled();
+          expect(focusSpy.mostRecentCall.object.selector).toEqual('.parent().parent().siblings(a)');
+        });
+      });
     });
 
     describe('onSpeedChange', function() {

--- a/common/lib/xmodule/xmodule/js/spec/video/video_speed_control_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_speed_control_spec.js
@@ -140,22 +140,20 @@
       });
 
       describe('make sure the speed control gets the focus afterwards', function() {
-        var spyEvent;
-
-        beforeEach(function() {
+          beforeEach(function() {
           initialize();
           videoSpeedControl.setSpeed(1.0);
-          spyEvent = spyOnEvent('.speeds > a', 'focus');
+          spyOnEvent(state.videoSpeedControl.mainAnchor, 'focus');
         });
 
         it('when the speed is the same', function() {
           $('li[data-speed="1.0"] a').click();
-          expect(spyEvent).toHaveBeenTriggered();
+          expect('focus').toHaveBeenTriggeredOn(state.videoSpeedControl.mainAnchor);
         });
 
         it('when the speed is not the same', function() {
           $('li[data-speed="0.75"] a').click();
-          expect(spyEvent).toHaveBeenTriggered();;
+          expect('focus').toHaveBeenTriggeredOn(state.videoSpeedControl.mainAnchor);
         });
       });
     });

--- a/common/lib/xmodule/xmodule/js/src/video/08_video_speed_control.js
+++ b/common/lib/xmodule/xmodule/js/src/video/08_video_speed_control.js
@@ -283,6 +283,9 @@ function () {
                 this.videoSpeedControl.currentSpeed
             );
         }
+        // When a speed entry has been selected, we want the speed control to 
+        // regain focus.
+        parentEl.parent().siblings('a').focus();
     }
 
     function reRender(params) {

--- a/common/lib/xmodule/xmodule/js/src/video/08_video_speed_control.js
+++ b/common/lib/xmodule/xmodule/js/src/video/08_video_speed_control.js
@@ -62,6 +62,8 @@ function () {
 
         state.videoSpeedControl.el = state.el.find('div.speeds');
 
+        state.videoSpeedControl.mainAnchor = state.videoSpeedControl.el.children('a');
+
         state.videoSpeedControl.videoSpeedsEl = state.videoSpeedControl.el
             .find('.video_speeds');
 

--- a/common/lib/xmodule/xmodule/js/src/video/08_video_speed_control.js
+++ b/common/lib/xmodule/xmodule/js/src/video/08_video_speed_control.js
@@ -62,8 +62,6 @@ function () {
 
         state.videoSpeedControl.el = state.el.find('div.speeds');
 
-        state.videoSpeedControl.mainAnchor = state.videoSpeedControl.el.children('a');
-
         state.videoSpeedControl.videoSpeedsEl = state.videoSpeedControl.el
             .find('.video_speeds');
 


### PR DESCRIPTION
Video player speed control now regains focus after a speed entry has been selected with the keyboard. Tested on latest versions of Chrome/Firefox/Safari in LMS and CMS.
