### PR TITLE
Moving unregistration of change listener into asset_index.html.

### DIFF
--- a/cms/static/js/base.js
+++ b/cms/static/js/base.js
@@ -429,7 +429,6 @@ function hideModal(e) {
     // of the editor. Users must press Cancel or Save to exit the editor.
     // module_edit adds and removes the "is-fixed" class.
     if (!$modalCover.hasClass("is-fixed")) {
-        $('.file-input').unbind('change', startUpload);
         $modal.hide();
         $modalCover.hide();
     }

--- a/cms/templates/asset_index.html
+++ b/cms/templates/asset_index.html
@@ -74,6 +74,8 @@
         };
 
         var resetUploadModal = function () {
+            $('.file-input').unbind('change', startUpload);
+
             // Reset modal so it no longer displays information about previously
             // completed uploads.
             var percentVal = '0%';


### PR DESCRIPTION
Fixes broken integration test on master (the integration test was related to setting the release date of a section-- when the modal was closed, it was going through the code in base.js that tried to unbind the change listener on something unrelated and non-existent).

I verified:

1) base.js does not call any of the other methods I changed from global to local variables in asset_index.html
2) Course import works properly (there are a couple of places where '.file-input' appears in base.js, related to course import). Course import did not use the startUpload callback.

@jkarni Can you please review? I will kick off the tests manually in Jenkins.

@wedaly This is the fix for the broken integration test. I had changed "startUpload" so it was no longer globally defined, but one place in base.js was attempting to call it.
