### PR TITLE
add unicode support for course_wiki

### DIFF
--- a/lms/djangoapps/course_wiki/views.py
+++ b/lms/djangoapps/course_wiki/views.py
@@ -96,7 +96,7 @@ def course_wiki_redirect(request, course_id):
             root,
             course_slug,
             title=course_slug,
-            content=cgi.escape("This is the wiki for **{0}**'s _{1}_.".format(course.display_org_with_default, course.display_name_with_default)),
+            content=cgi.escape(u"This is the wiki for **{0}**'s _{1}_.".format(course.display_org_with_default, course.display_name_with_default)),
             user_message="Course page automatically created.",
             user=None,
             ip_address=None,


### PR DESCRIPTION
Clicking on "wiki" returns a 500 for courses with unicode display_orgs. So all of Peking's course wikis are breaking.

https://edx-wiki.atlassian.net/browse/LMS-1174

@sarina @cpennington 
