### PR TITLE
Ensure location is valid before trying to fetch

### DIFF
--- a/common/lib/xmodule/xmodule/contentstore/mongo.py
+++ b/common/lib/xmodule/xmodule/contentstore/mongo.py
@@ -177,6 +177,8 @@ class MongoContentStore(ContentStore):
 
         :param location:  a c4x asset location
         """
+        # raises exception if location is not fully specified
+        Location.ensure_fully_specified(location)
         for attr in attr_dict.iterkeys():
             if attr in ['_id', 'md5', 'uploadDate', 'length']:
                 raise AttributeError("{} is a protected attribute.".format(attr))

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_mongo.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_mongo.py
@@ -22,6 +22,7 @@ from xmodule.contentstore.mongo import MongoContentStore
 from xmodule.modulestore.tests.test_modulestore import check_path_to_location
 from IPython.testing.nose_assert_methods import assert_in, assert_not_in
 from xmodule.exceptions import NotFoundError
+from xmodule.modulestore.exceptions import InsufficientSpecificationError
 
 log = logging.getLogger(__name__)
 
@@ -227,11 +228,11 @@ class TestMongoModuleStore(object):
             TestMongoModuleStore.content_store.set_attrs(content['_id'], {'miscel': 99})
             assert_equals(TestMongoModuleStore.content_store.get_attr(content['_id'], 'miscel'), 99)
         assert_raises(
-            AttributeError, TestMongoModuleStore.content_store.set_attr, course_content[0],
+            AttributeError, TestMongoModuleStore.content_store.set_attr, course_content[0]['_id'],
             'md5', 'ff1532598830e3feac91c2449eaa60d6'
         )
         assert_raises(
-            AttributeError, TestMongoModuleStore.content_store.set_attrs, course_content[0],
+            AttributeError, TestMongoModuleStore.content_store.set_attrs, course_content[0]['_id'],
             {'foo': 9, 'md5': 'ff1532598830e3feac91c2449eaa60d6'}
         )
         assert_raises(
@@ -251,6 +252,11 @@ class TestMongoModuleStore(object):
         assert_raises(
             NotFoundError, TestMongoModuleStore.content_store.set_attrs,
             Location('bogus', 'bogus', 'bogus', 'asset', 'bogus'),
+            {'displayname': 'hello'}
+        )
+        assert_raises(
+            InsufficientSpecificationError, TestMongoModuleStore.content_store.set_attrs,
+            Location('bogus', 'bogus', 'bogus', 'asset', None),
             {'displayname': 'hello'}
         )
 


### PR DESCRIPTION
Prevent accidental wildcarding.

@cahrens @chrisndodge Pls review. It fixes a bug @cahrens found where for some reason find_one was finding all and doing a mass update b/c the location had wildcards :-(
