### PR TITLE
Christina/fix asset index

### DIFF
--- a/cms/static/js/base.js
+++ b/cms/static/js/base.js
@@ -18,6 +18,7 @@ $(document).ready(function() {
     // pipelining (note, this doesn't happen on local runtimes). So if we set it on window, when we can access it from other
     // scopes (namely the course-info tab)
     window.$modalCover = $modalCover;
+    window.$modal = $modal;
 
     $body.append($modalCover);
     $newComponentItem = $('.new-component-item');
@@ -433,6 +434,8 @@ function hideModal(e) {
         $modalCover.hide();
     }
 }
+// Have to put hideModal on the window object because of AWS pipelining (being used by asset_index.html).
+window.hideModal = hideModal;
 
 function toggleSock(e) {
     e.preventDefault();

--- a/cms/templates/asset_index.html
+++ b/cms/templates/asset_index.html
@@ -24,15 +24,14 @@
 
         $(document).ready(function() {
             $('.uploads .upload-button').bind('click', showUploadModal);
-            $('.upload-modal .close-button').bind('click', hideModal);
+            $('.upload-modal .close-button').bind('click', window.hideModal);
             $('.upload-modal .choose-file-button').bind('click', showFileSelectionMenu);
         });
 
         var showUploadModal = function (e) {
             e.preventDefault();
             resetUploadModal();
-            // $modal has to be global for hideModal to work.
-            $modal = $('.upload-modal').show();
+            window.$modal = $('.upload-modal').show();
             $('.file-input').bind('change', startUpload);
             $('.upload-modal .file-chooser').fileupload({
                 dataType: 'json',
@@ -56,7 +55,7 @@
 
             });
 
-            $modalCover.show();
+            window.$modalCover.show();
         };
 
         var showFileSelectionMenu = function(e) {


### PR DESCRIPTION
On AWS, JavaScript is pipelined in such a way that JavaScript defined in base.js is not defined in other files that do not also go through the pipelining.

Following a practice that we have already had, assigned $modal and hideModal to the window object.

@chrisndodge @jkarni Please review. Unfortunately I don't have a good way to test if there are any other issues until we push to staging.
