### PR TITLE
Added tags to acceptance tests to define multiple shards.

### DIFF
--- a/cms/djangoapps/contentstore/features/advanced-settings.feature
+++ b/cms/djangoapps/contentstore/features/advanced-settings.feature
@@ -1,5 +1,5 @@
 @shard_1
-Feature: Advanced (manual) course policy
+Feature: CMS.Advanced (manual) course policy
   In order to specify course policy settings for which no custom user interface exists
   I want to be able to manually enter JSON key /value pairs
 

--- a/cms/djangoapps/contentstore/features/advanced-settings.feature
+++ b/cms/djangoapps/contentstore/features/advanced-settings.feature
@@ -1,3 +1,4 @@
+@shard_1
 Feature: Advanced (manual) course policy
   In order to specify course policy settings for which no custom user interface exists
   I want to be able to manually enter JSON key /value pairs

--- a/cms/djangoapps/contentstore/features/checklists.feature
+++ b/cms/djangoapps/contentstore/features/checklists.feature
@@ -1,5 +1,5 @@
 @shard_1
-Feature: Course checklists
+Feature: CMS.Course checklists
 
   Scenario: A course author sees checklists defined by edX
     Given I have opened a new course in Studio

--- a/cms/djangoapps/contentstore/features/checklists.feature
+++ b/cms/djangoapps/contentstore/features/checklists.feature
@@ -1,3 +1,4 @@
+@shard_1
 Feature: Course checklists
 
   Scenario: A course author sees checklists defined by edX

--- a/cms/djangoapps/contentstore/features/component.feature
+++ b/cms/djangoapps/contentstore/features/component.feature
@@ -1,3 +1,4 @@
+@shard_1
 Feature: Component Adding
     As a course author, I want to be able to add a wide variety of components
 

--- a/cms/djangoapps/contentstore/features/component.feature
+++ b/cms/djangoapps/contentstore/features/component.feature
@@ -1,5 +1,5 @@
 @shard_1
-Feature: Component Adding
+Feature: CMS.Component Adding
     As a course author, I want to be able to add a wide variety of components
 
     @skip

--- a/cms/djangoapps/contentstore/features/course-overview.feature
+++ b/cms/djangoapps/contentstore/features/course-overview.feature
@@ -1,3 +1,4 @@
+@shard_1
 Feature: Course Overview
     In order to quickly view the details of a course's section and set release dates and grading
     As a course author

--- a/cms/djangoapps/contentstore/features/course-overview.feature
+++ b/cms/djangoapps/contentstore/features/course-overview.feature
@@ -1,5 +1,5 @@
 @shard_1
-Feature: Course Overview
+Feature: CMS.Course Overview
     In order to quickly view the details of a course's section and set release dates and grading
     As a course author
     I want to use the course overview page

--- a/cms/djangoapps/contentstore/features/course-settings.feature
+++ b/cms/djangoapps/contentstore/features/course-settings.feature
@@ -1,5 +1,5 @@
 @shard_2
-Feature: Course Settings
+Feature: CMS.Course Settings
   As a course author, I want to be able to configure my course settings.
 
   # Safari has trouble keeps dates on refresh

--- a/cms/djangoapps/contentstore/features/course-settings.feature
+++ b/cms/djangoapps/contentstore/features/course-settings.feature
@@ -1,3 +1,4 @@
+@shard_2
 Feature: Course Settings
   As a course author, I want to be able to configure my course settings.
 

--- a/cms/djangoapps/contentstore/features/course-team.feature
+++ b/cms/djangoapps/contentstore/features/course-team.feature
@@ -1,3 +1,4 @@
+@shard_2
 Feature: Course Team
     As a course author, I want to be able to add others to my team
 

--- a/cms/djangoapps/contentstore/features/course-team.feature
+++ b/cms/djangoapps/contentstore/features/course-team.feature
@@ -1,5 +1,5 @@
 @shard_2
-Feature: Course Team
+Feature: CMS.Course Team
     As a course author, I want to be able to add others to my team
 
     Scenario: Admins can add other users

--- a/cms/djangoapps/contentstore/features/course-updates.feature
+++ b/cms/djangoapps/contentstore/features/course-updates.feature
@@ -1,5 +1,5 @@
 @shard_2
-Feature: Course updates
+Feature: CMS.Course updates
     As a course author, I want to be able to provide updates to my students
 
     # Internet explorer can't select all so the update appears weirdly

--- a/cms/djangoapps/contentstore/features/course-updates.feature
+++ b/cms/djangoapps/contentstore/features/course-updates.feature
@@ -1,3 +1,4 @@
+@shard_2
 Feature: Course updates
     As a course author, I want to be able to provide updates to my students
 

--- a/cms/djangoapps/contentstore/features/courses.feature
+++ b/cms/djangoapps/contentstore/features/courses.feature
@@ -1,5 +1,5 @@
 @shard_2
-Feature: Create Course
+Feature: CMS.Create Course
   In order offer a course on the edX platform
   As a course author
   I want to create courses

--- a/cms/djangoapps/contentstore/features/courses.feature
+++ b/cms/djangoapps/contentstore/features/courses.feature
@@ -1,3 +1,4 @@
+@shard_2
 Feature: Create Course
   In order offer a course on the edX platform
   As a course author

--- a/cms/djangoapps/contentstore/features/discussion-editor.feature
+++ b/cms/djangoapps/contentstore/features/discussion-editor.feature
@@ -1,3 +1,4 @@
+@shard_2
 Feature: Discussion Component Editor
   As a course author, I want to be able to create discussion components.
 

--- a/cms/djangoapps/contentstore/features/discussion-editor.feature
+++ b/cms/djangoapps/contentstore/features/discussion-editor.feature
@@ -1,5 +1,5 @@
 @shard_2
-Feature: Discussion Component Editor
+Feature: CMS.Discussion Component Editor
   As a course author, I want to be able to create discussion components.
 
   Scenario: User can view metadata

--- a/cms/djangoapps/contentstore/features/grading.feature
+++ b/cms/djangoapps/contentstore/features/grading.feature
@@ -1,3 +1,4 @@
+@shard_1
 Feature: Course Grading
     As a course author, I want to be able to configure how my course is graded
 

--- a/cms/djangoapps/contentstore/features/grading.feature
+++ b/cms/djangoapps/contentstore/features/grading.feature
@@ -1,5 +1,5 @@
 @shard_1
-Feature: Course Grading
+Feature: CMS.Course Grading
     As a course author, I want to be able to configure how my course is graded
 
     Scenario: Users can add grading ranges

--- a/cms/djangoapps/contentstore/features/html-editor.feature
+++ b/cms/djangoapps/contentstore/features/html-editor.feature
@@ -1,5 +1,5 @@
 @shard_3
-Feature: HTML Editor
+Feature: CMS.HTML Editor
   As a course author, I want to be able to create HTML blocks.
 
   Scenario: User can view metadata

--- a/cms/djangoapps/contentstore/features/html-editor.feature
+++ b/cms/djangoapps/contentstore/features/html-editor.feature
@@ -1,3 +1,4 @@
+@shard_3
 Feature: HTML Editor
   As a course author, I want to be able to create HTML blocks.
 

--- a/cms/djangoapps/contentstore/features/problem-editor.feature
+++ b/cms/djangoapps/contentstore/features/problem-editor.feature
@@ -1,5 +1,5 @@
 @shard_3
-Feature: Problem Editor
+Feature: CMS.Problem Editor
   As a course author, I want to be able to create problems and edit their settings.
 
   Scenario: User can view metadata

--- a/cms/djangoapps/contentstore/features/problem-editor.feature
+++ b/cms/djangoapps/contentstore/features/problem-editor.feature
@@ -1,3 +1,4 @@
+@shard_3
 Feature: Problem Editor
   As a course author, I want to be able to create problems and edit their settings.
 

--- a/cms/djangoapps/contentstore/features/section.feature
+++ b/cms/djangoapps/contentstore/features/section.feature
@@ -1,5 +1,5 @@
 @shard_2
-Feature: Create Section
+Feature: CMS.Create Section
   In order offer a course on the edX platform
   As a course author
   I want to create and edit sections

--- a/cms/djangoapps/contentstore/features/section.feature
+++ b/cms/djangoapps/contentstore/features/section.feature
@@ -1,3 +1,4 @@
+@shard_2
 Feature: Create Section
   In order offer a course on the edX platform
   As a course author

--- a/cms/djangoapps/contentstore/features/signup.feature
+++ b/cms/djangoapps/contentstore/features/signup.feature
@@ -1,5 +1,5 @@
 @shard_3
-Feature: Sign in
+Feature: CMS.Sign in
   In order to use the edX content
   As a new user
   I want to signup for a student account

--- a/cms/djangoapps/contentstore/features/signup.feature
+++ b/cms/djangoapps/contentstore/features/signup.feature
@@ -1,3 +1,4 @@
+@shard_3
 Feature: Sign in
   In order to use the edX content
   As a new user

--- a/cms/djangoapps/contentstore/features/static-pages.feature
+++ b/cms/djangoapps/contentstore/features/static-pages.feature
@@ -1,3 +1,4 @@
+@shard_3
 Feature: Static Pages
     As a course author, I want to be able to add static pages
 

--- a/cms/djangoapps/contentstore/features/static-pages.feature
+++ b/cms/djangoapps/contentstore/features/static-pages.feature
@@ -1,5 +1,5 @@
 @shard_3
-Feature: Static Pages
+Feature: CMS.Static Pages
     As a course author, I want to be able to add static pages
 
     Scenario: Users can add static pages

--- a/cms/djangoapps/contentstore/features/subsection.feature
+++ b/cms/djangoapps/contentstore/features/subsection.feature
@@ -1,5 +1,5 @@
 @shard_2
-Feature: Create Subsection
+Feature: CMS.Create Subsection
   In order offer a course on the edX platform
   As a course author
   I want to create and edit subsections

--- a/cms/djangoapps/contentstore/features/subsection.feature
+++ b/cms/djangoapps/contentstore/features/subsection.feature
@@ -1,3 +1,4 @@
+@shard_2
 Feature: Create Subsection
   In order offer a course on the edX platform
   As a course author

--- a/cms/djangoapps/contentstore/features/textbooks.feature
+++ b/cms/djangoapps/contentstore/features/textbooks.feature
@@ -1,5 +1,5 @@
 @shard_3
-Feature: Textbooks
+Feature: CMS.Textbooks
 
   Scenario: No textbooks
     Given I have opened a new course in Studio

--- a/cms/djangoapps/contentstore/features/textbooks.feature
+++ b/cms/djangoapps/contentstore/features/textbooks.feature
@@ -1,3 +1,4 @@
+@shard_3
 Feature: Textbooks
 
   Scenario: No textbooks

--- a/cms/djangoapps/contentstore/features/upload.feature
+++ b/cms/djangoapps/contentstore/features/upload.feature
@@ -1,3 +1,4 @@
+@shard_3
 Feature: Upload Files
     As a course author, I want to be able to upload files for my students
 

--- a/cms/djangoapps/contentstore/features/upload.feature
+++ b/cms/djangoapps/contentstore/features/upload.feature
@@ -1,5 +1,5 @@
 @shard_3
-Feature: Upload Files
+Feature: CMS.Upload Files
     As a course author, I want to be able to upload files for my students
 
     # Uploading isn't working on safari with sauce labs

--- a/cms/djangoapps/contentstore/features/video-editor.feature
+++ b/cms/djangoapps/contentstore/features/video-editor.feature
@@ -1,5 +1,5 @@
 @shard_3
-Feature: Video Component Editor
+Feature: CMS.Video Component Editor
   As a course author, I want to be able to create video components.
 
   Scenario: User can view Video metadata

--- a/cms/djangoapps/contentstore/features/video-editor.feature
+++ b/cms/djangoapps/contentstore/features/video-editor.feature
@@ -1,3 +1,4 @@
+@shard_3
 Feature: Video Component Editor
   As a course author, I want to be able to create video components.
 

--- a/cms/djangoapps/contentstore/features/video.feature
+++ b/cms/djangoapps/contentstore/features/video.feature
@@ -1,5 +1,5 @@
 @shard_3
-Feature: Video Component
+Feature: CMS.Video Component
   As a course author, I want to be able to view my created videos in Studio.
 
   # Video Alpha Features will work in Firefox only when Firefox is the active window

--- a/cms/djangoapps/contentstore/features/video.feature
+++ b/cms/djangoapps/contentstore/features/video.feature
@@ -1,3 +1,4 @@
+@shard_3
 Feature: Video Component
   As a course author, I want to be able to view my created videos in Studio.
 

--- a/lms/djangoapps/courseware/features/certificates.feature
+++ b/lms/djangoapps/courseware/features/certificates.feature
@@ -1,5 +1,5 @@
 @shard_2
-Feature: Verified certificates
+Feature: LMS.Verified certificates
     As a student,
     In order to earn a verified certificate
     I want to sign up for a verified certificate course.

--- a/lms/djangoapps/courseware/features/certificates.feature
+++ b/lms/djangoapps/courseware/features/certificates.feature
@@ -1,3 +1,4 @@
+@shard_2
 Feature: Verified certificates
     As a student,
     In order to earn a verified certificate

--- a/lms/djangoapps/courseware/features/help.feature
+++ b/lms/djangoapps/courseware/features/help.feature
@@ -1,5 +1,5 @@
 @shard_2
-Feature: The help module should work
+Feature: LMS.The help module should work
   In order to get help
   As a student
   I want to be able to report a problem

--- a/lms/djangoapps/courseware/features/help.feature
+++ b/lms/djangoapps/courseware/features/help.feature
@@ -1,3 +1,4 @@
+@shard_2
 Feature: The help module should work
   In order to get help
   As a student

--- a/lms/djangoapps/courseware/features/high-level-tabs.feature
+++ b/lms/djangoapps/courseware/features/high-level-tabs.feature
@@ -1,3 +1,4 @@
+@shard_1
 Feature: All the high level tabs should work
   In order to preview the courseware
   As a student

--- a/lms/djangoapps/courseware/features/high-level-tabs.feature
+++ b/lms/djangoapps/courseware/features/high-level-tabs.feature
@@ -1,5 +1,5 @@
 @shard_1
-Feature: All the high level tabs should work
+Feature: LMS.All the high level tabs should work
   In order to preview the courseware
   As a student
   I want to navigate through the high level tabs

--- a/lms/djangoapps/courseware/features/homepage.feature
+++ b/lms/djangoapps/courseware/features/homepage.feature
@@ -1,5 +1,5 @@
 @shard_1
-Feature: Homepage for web users
+Feature: LMS.Homepage for web users
   In order to get an idea what edX is about
   As a an anonymous web user
   I want to check the information on the home page

--- a/lms/djangoapps/courseware/features/homepage.feature
+++ b/lms/djangoapps/courseware/features/homepage.feature
@@ -1,3 +1,4 @@
+@shard_1
 Feature: Homepage for web users
   In order to get an idea what edX is about
   As a an anonymous web user

--- a/lms/djangoapps/courseware/features/login.feature
+++ b/lms/djangoapps/courseware/features/login.feature
@@ -1,3 +1,4 @@
+@shard_1
 Feature: Login in as a registered user
   As a registered user
   In order to access my content

--- a/lms/djangoapps/courseware/features/login.feature
+++ b/lms/djangoapps/courseware/features/login.feature
@@ -1,5 +1,5 @@
 @shard_1
-Feature: Login in as a registered user
+Feature: LMS.Login in as a registered user
   As a registered user
   In order to access my content
   I want to be able to login in to edX

--- a/lms/djangoapps/courseware/features/lti.feature
+++ b/lms/djangoapps/courseware/features/lti.feature
@@ -1,5 +1,5 @@
 @shard_1
-Feature: LTI component
+Feature: LMS.LTI component
   As a student, I want to view LTI component in LMS.
 
   Scenario: LTI component in LMS is not rendered

--- a/lms/djangoapps/courseware/features/lti.feature
+++ b/lms/djangoapps/courseware/features/lti.feature
@@ -1,3 +1,4 @@
+@shard_1
 Feature: LTI component
   As a student, I want to view LTI component in LMS.
 

--- a/lms/djangoapps/courseware/features/navigation.feature
+++ b/lms/djangoapps/courseware/features/navigation.feature
@@ -1,3 +1,4 @@
+@shard_1
 Feature: Navigate Course
     As a student in an edX course
     In order to view the course properly

--- a/lms/djangoapps/courseware/features/navigation.feature
+++ b/lms/djangoapps/courseware/features/navigation.feature
@@ -1,5 +1,5 @@
 @shard_1
-Feature: Navigate Course
+Feature: LMS.Navigate Course
     As a student in an edX course
     In order to view the course properly
     I want to be able to navigate through the content

--- a/lms/djangoapps/courseware/features/openended.feature
+++ b/lms/djangoapps/courseware/features/openended.feature
@@ -1,4 +1,4 @@
-Feature: Open ended grading
+Feature: LMS.Open ended grading
   As a student in an edX course
   In order to complete the courseware questions
   I want the machine learning grading to be functional

--- a/lms/djangoapps/courseware/features/problems.feature
+++ b/lms/djangoapps/courseware/features/problems.feature
@@ -1,3 +1,4 @@
+@shard_1
 Feature: Answer problems
     As a student in an edX course
     In order to test my understanding of the material

--- a/lms/djangoapps/courseware/features/problems.feature
+++ b/lms/djangoapps/courseware/features/problems.feature
@@ -1,5 +1,5 @@
 @shard_1
-Feature: Answer problems
+Feature: LMS.Answer problems
     As a student in an edX course
     In order to test my understanding of the material
     I want to answer problems

--- a/lms/djangoapps/courseware/features/registration.feature
+++ b/lms/djangoapps/courseware/features/registration.feature
@@ -1,16 +1,17 @@
+@shard_1
 Feature: Register for a course
   As a registered user
   In order to access my class content
   I want to register for a class on the edX website
 
-  	Scenario: I can register for a course
+  Scenario: I can register for a course
     Given The course "6.002x" exists
     And I am logged in
     And I visit the courses page
     When I register for the course "6.002x"
-  	Then I should see the course numbered "6.002x" in my dashboard
+    Then I should see the course numbered "6.002x" in my dashboard
 
-    Scenario: I can unregister for a course
+  Scenario: I can unregister for a course
     Given I am registered for the course "6.002x"
     And I visit the dashboard
     Then I should see the course numbered "6.002x" in my dashboard

--- a/lms/djangoapps/courseware/features/registration.feature
+++ b/lms/djangoapps/courseware/features/registration.feature
@@ -1,5 +1,5 @@
 @shard_1
-Feature: Register for a course
+Feature: LMS.Register for a course
   As a registered user
   In order to access my class content
   I want to register for a class on the edX website

--- a/lms/djangoapps/courseware/features/signup.feature
+++ b/lms/djangoapps/courseware/features/signup.feature
@@ -1,3 +1,4 @@
+@shard_2
 Feature: Sign in
   In order to use the edX content
   As a new user

--- a/lms/djangoapps/courseware/features/signup.feature
+++ b/lms/djangoapps/courseware/features/signup.feature
@@ -1,5 +1,5 @@
 @shard_2
-Feature: Sign in
+Feature: LMS.Sign in
   In order to use the edX content
   As a new user
   I want to signup for a student account

--- a/lms/djangoapps/courseware/features/video.feature
+++ b/lms/djangoapps/courseware/features/video.feature
@@ -1,5 +1,5 @@
 @shard_2
-Feature: Video component
+Feature: LMS.Video component
   As a student, I want to view course videos in LMS.
 
   Scenario: Video component is fully rendered in the LMS in HTML5 mode

--- a/lms/djangoapps/courseware/features/video.feature
+++ b/lms/djangoapps/courseware/features/video.feature
@@ -1,39 +1,40 @@
+@shard_2
 Feature: Video component
   As a student, I want to view course videos in LMS.
 
   Scenario: Video component is fully rendered in the LMS in HTML5 mode
-  Given the course has a Video component in HTML5 mode
-  Then when I view the video it has rendered in HTML5 mode
-  And all sources are correct
+    Given the course has a Video component in HTML5 mode
+    Then when I view the video it has rendered in HTML5 mode
+    And all sources are correct
 
   # Firefox doesn't have HTML5 (only mp4 - fix here)
   @skip_firefox
   Scenario: Autoplay is disabled in LMS for a Video component
-  Given the course has a Video component in HTML5 mode
-  Then when I view the video it does not have autoplay enabled
+    Given the course has a Video component in HTML5 mode
+    Then when I view the video it does not have autoplay enabled
 
-# Youtube testing
-Scenario: Video component is fully rendered in the LMS in Youtube mode with HTML5 sources
-Given youtube server is up and response time is  0.4 seconds
-And the course has a Video component in Youtube_HTML5 mode
-Then when I view the video it has rendered in Youtube mode
+  # Youtube testing
+  Scenario: Video component is fully rendered in the LMS in Youtube mode with HTML5 sources
+    Given youtube server is up and response time is  0.4 seconds
+    And the course has a Video component in Youtube_HTML5 mode
+    Then when I view the video it has rendered in Youtube mode
 
-Scenario: Video component is not rendered in the LMS in Youtube mode with HTML5 sources
-Given youtube server is up and response time is 2 seconds
-And the course has a Video component in Youtube_HTML5 mode
-Then when I view the video it has rendered in HTML5 mode
+  Scenario: Video component is not rendered in the LMS in Youtube mode with HTML5 sources
+    Given youtube server is up and response time is 2 seconds
+    And the course has a Video component in Youtube_HTML5 mode
+    Then when I view the video it has rendered in HTML5 mode
 
-Scenario: Video component is rendered in the LMS in Youtube mode without HTML5 sources
-Given youtube server is up and response time is 2 seconds
-And the course has a Video component in Youtube mode
-Then when I view the video it has rendered in Youtube mode
+  Scenario: Video component is rendered in the LMS in Youtube mode without HTML5 sources
+    Given youtube server is up and response time is 2 seconds
+    And the course has a Video component in Youtube mode
+    Then when I view the video it has rendered in Youtube mode
 
-Scenario: Video component is rendered in the LMS in Youtube mode with HTML5 sources that doesn't supported by browser
-Given youtube server is up and response time is 2 seconds
-And the course has a Video component in Youtube_HTML5_Unsupported_Video mode
-Then when I view the video it has rendered in Youtube mode
+  Scenario: Video component is rendered in the LMS in Youtube mode with HTML5 sources that doesn't supported by browser
+    Given youtube server is up and response time is 2 seconds
+    And the course has a Video component in Youtube_HTML5_Unsupported_Video mode
+    Then when I view the video it has rendered in Youtube mode
 
-Scenario: Video component is rendered in the LMS in HTML5 mode with HTML5 sources that doesn't supported by browser
-Given the course has a Video component in HTML5_Unsupported_Video mode
-Then error message is shown
-And error message has correct text
+  Scenario: Video component is rendered in the LMS in HTML5 mode with HTML5 sources that doesn't supported by browser
+    Given the course has a Video component in HTML5_Unsupported_Video mode
+    Then error message is shown
+    And error message has correct text

--- a/lms/djangoapps/courseware/features/word_cloud.feature
+++ b/lms/djangoapps/courseware/features/word_cloud.feature
@@ -1,6 +1,6 @@
 @shard_2
-Feature: World Cloud component
-    As a student, I want to view Word Cloud component in LMS.
+Feature: LMS.World Cloud component
+  As a student, I want to view Word Cloud component in LMS.
 
   Scenario: Word Cloud component in LMS is rendered with empty result
     Given the course has a Word Cloud component

--- a/lms/djangoapps/courseware/features/word_cloud.feature
+++ b/lms/djangoapps/courseware/features/word_cloud.feature
@@ -1,15 +1,16 @@
+@shard_2
 Feature: World Cloud component
-  As a student, I want to view Word Cloud component in LMS.
+    As a student, I want to view Word Cloud component in LMS.
 
   Scenario: Word Cloud component in LMS is rendered with empty result
-  Given the course has a Word Cloud component
-  Then I view the word cloud and it has rendered
-  When I press the Save button
-  Then I see the empty result
+    Given the course has a Word Cloud component
+    Then I view the word cloud and it has rendered
+    When I press the Save button
+    Then I see the empty result
 
   Scenario: Word Cloud component in LMS is rendered with result
-  Given the course has a Word Cloud component
-  Then I view the word cloud and it has rendered
-  When I fill inputs
-  And I press the Save button
-  Then I see the result with words count
+    Given the course has a Word Cloud component
+    Then I view the word cloud and it has rendered
+    When I fill inputs
+    And I press the Save button
+    Then I see the result with words count


### PR DESCRIPTION
Define two shards each for LMS and CMS, based on running time of XUnit reports.
Small indentation fixes.

@jzoldak
