### PR TITLE
Move nose arguments around so that we can run tests with manage.py

### DIFF
--- a/cms/envs/test.py
+++ b/cms/envs/test.py
@@ -20,6 +20,16 @@ from warnings import filterwarnings
 # Nose Test Runner
 TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 
+_system = 'cms'
+_report_dir = REPO_ROOT / 'reports' / _system
+_report_dir.makedirs_p()
+
+NOSE_ARGS = [
+    '--tests', PROJECT_ROOT / 'djangoapps', COMMON_ROOT / 'djangoapps',
+    '--id-file', REPO_ROOT / '.testids' / _system / 'noseids',
+    '--xunit-file', _report_dir / 'nosetests.xml',
+]
+
 TEST_ROOT = path('test_root')
 
 # Want static files in the same dir for running on jenkins.

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -17,6 +17,8 @@ import os
 from path import path
 from warnings import filterwarnings
 
+os.environ['DJANGO_LIVE_TEST_SERVER_ADDRESS'] = 'localhost:8000-9000'
+
 # can't test start dates with this True, but on the other hand,
 # can test everything else :)
 MITX_FEATURES['DISABLE_START_DATES'] = True
@@ -42,6 +44,17 @@ SOUTH_TESTS_MIGRATE = False   # To disable migrations and use syncdb instead
 
 # Nose Test Runner
 TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
+
+_system = 'lms'
+
+_report_dir = REPO_ROOT / 'reports' / _system
+_report_dir.makedirs_p()
+
+NOSE_ARGS = [
+    '--tests', PROJECT_ROOT / 'djangoapps', COMMON_ROOT / 'djangoapps',
+    '--id-file', REPO_ROOT / '.testids' / _system / 'noseids',
+    '--xunit-file', _report_dir / 'nosetests.xml',
+]
 
 # Local Directories
 TEST_ROOT = path("test_root")

--- a/rakelib/tests.rake
+++ b/rakelib/tests.rake
@@ -17,16 +17,8 @@ def run_under_coverage(cmd, root)
 end
 
 def run_tests(system, report_dir, test_id=nil, stop_on_failure=true)
-    ENV['NOSE_XUNIT_FILE'] = File.join(report_dir, "nosetests.xml")
-    test_id_file = File.join(test_id_dir(system), "noseids")
-    dirs = Dir["common/djangoapps/*"] + Dir["#{system}/djangoapps/*"]
-    test_id = dirs.join(' ') if test_id.nil? or test_id == ''
-    cmd = django_admin(
-        system, :test, 'test',
-        '--logging-clear-handlers',
-        '--liveserver=localhost:8000-9000',
-        "--id-file=#{test_id_file}",
-        test_id)
+    test_id = '' if test_id.nil?
+    cmd = django_admin(system, :test, 'test', test_id)
     test_sh(run_under_coverage(cmd, system))
 end
 


### PR DESCRIPTION
@wedaly, @nedbat:  This makes it so that manage.py can run tests the same way rake currently does
