### PR TITLE
Fix for bug BLD-359: Unnecessary focus outline around Video Player.

### DIFF
--- a/common/lib/xmodule/xmodule/css/video/display.scss
+++ b/common/lib/xmodule/xmodule/css/video/display.scss
@@ -10,6 +10,11 @@ div.video {
   padding: 12px;
   border-radius: 5px;
 
+  &:focus, &:active, &:hover {
+    outline: 0;
+    border: 0;
+  }
+
   div.tc-wrapper {
     position: relative;
     @include clearfix;


### PR DESCRIPTION
On Chrome or Safari, if you click on one of the video controls, a large focus outline will surround the entire div containing the video itself, the controls, and the captions. It disappears when you click outside of that div.

On Firefox, none of this behavior but if you click on the edge of that div, a dotted outline will appear that reaches to the far left of the window, disappearing for a while under the navigation accordeon.

Analysis: This is due to the fact that the main video container now has tabindex set to "-1". We can programmability set focus to it now. Chrome and Safari puts a border around it when some child element receives focus.

Solution: Style the element so that the outline is 0 when the main container receives focus.
