### PR TITLE
PdfViewer: Added missing link to compatibility.js

### DIFF
--- a/lms/templates/static_pdfbook.html
+++ b/lms/templates/static_pdfbook.html
@@ -13,6 +13,7 @@
 <%static:js group='courseware'/>
 <link rel="stylesheet" href="/static/css/pdfviewer.css"/>
 <script type="text/javascript" src="/static/js/vendor/pdfjs/pdf.js"></script>
+<script type="text/javascript" src="/static/js/vendor/pdfjs/compatibility.js"></script>
 <script type="text/javascript" src="/static/js/pdfviewer.js"></script>
 </%block>
 


### PR DESCRIPTION
Addresses: https://edx-wiki.atlassian.net/browse/LMS-1167

compatibility.js is needed for the pdf viewer to work in IE as per https://github.com/mozilla/pdf.js. Just added the missing link to the template.

@frrrances, @brianhw please review.
