### PR TITLE
Fix intermittent failure in OpenID test

### DIFF
--- a/common/djangoapps/external_auth/tests/test_openid_provider.py
+++ b/common/djangoapps/external_auth/tests/test_openid_provider.py
@@ -273,3 +273,20 @@ class OpenIdProviderLiveServerTest(LiveServerTestCase):
             self.assertEqual(resp.status_code, code,
                              "got code {0} for url '{1}'. Expected code {2}"
                              .format(resp.status_code, url, code))
+
+    @classmethod
+    def tearDownClass(cls):
+        """
+        Workaround for a runtime error that occurs
+        intermittently when the server thread doesn't shut down
+        within 2 seconds.
+
+        Since the server is running in a Django thread and will
+        be terminated when the test suite terminates,
+        this shouldn't cause a resource allocation issue.
+        """
+        try:
+            super(OpenIdProviderLiveServerTest, cls).tearDownClass()
+        except RuntimeError:
+            print "Warning: Could not shut down test server."
+            pass


### PR DESCRIPTION
This should fix the intermittent failure in master:
http://jenkins.edx.org:8080/job/edx-deploy-branch-tests/1612/testReport/?

I suspect this may also get fixed when we upgrade Django, as there's a closed issue for it: https://code.djangoproject.com/ticket/19051  I'd like to get this in anyway to avoid failures in the short term.

@jzoldak 
