### PR TITLE
Use comments to skip tests instead of a tag

### DIFF
--- a/cms/djangoapps/contentstore/features/component.feature
+++ b/cms/djangoapps/contentstore/features/component.feature
@@ -2,72 +2,70 @@
 Feature: CMS.Component Adding
     As a course author, I want to be able to add a wide variety of components
 
-    @skip
-    Scenario: I can add components
-        Given I have opened a new course in studio
-        And I am editing a new unit
-        When I add the following components:
-            | Component    |
-            | Discussion   |
-            | Blank HTML   |
-            | LaTex        |
-            | Blank Problem|
-            | Dropdown     |
-            | Multi Choice |
-            | Numerical    |
-            | Text Input   |
-            | Advanced     |
-            | Circuit      |
-            | Custom Python|
-            | Image Mapped |
-            | Math Input   |
-            | Problem LaTex|
-            | Adaptive Hint|
-            | Video        |
-        Then I see the following components:
-            | Component    |
-            | Discussion   |
-            | Blank HTML   |
-            | LaTex        |
-            | Blank Problem|
-            | Dropdown     |
-            | Multi Choice |
-            | Numerical    |
-            | Text Input   |
-            | Advanced     |
-            | Circuit      |
-            | Custom Python|
-            | Image Mapped |
-            | Math Input   |
-            | Problem LaTex|
-            | Adaptive Hint|
-            | Video        |
+    #Scenario: I can add components
+    #    Given I have opened a new course in studio
+    #    And I am editing a new unit
+    #    When I add the following components:
+    #        | Component    |
+    #        | Discussion   |
+    #        | Blank HTML   |
+    #        | LaTex        |
+    #        | Blank Problem|
+    #        | Dropdown     |
+    #        | Multi Choice |
+    #        | Numerical    |
+    #        | Text Input   |
+    #        | Advanced     |
+    #        | Circuit      |
+    #        | Custom Python|
+    #        | Image Mapped |
+    #        | Math Input   |
+    #        | Problem LaTex|
+    #        | Adaptive Hint|
+    #        | Video        |
+    #    Then I see the following components:
+    #        | Component    |
+    #        | Discussion   |
+    #        | Blank HTML   |
+    #        | LaTex        |
+    #        | Blank Problem|
+    #        | Dropdown     |
+    #        | Multi Choice |
+    #        | Numerical    |
+    #        | Text Input   |
+    #        | Advanced     |
+    #        | Circuit      |
+    #        | Custom Python|
+    #        | Image Mapped |
+    #        | Math Input   |
+    #        | Problem LaTex|
+    #        | Adaptive Hint|
+    #        | Video        |
 
-    @skip
-    Scenario: I can delete Components
-        Given I have opened a new course in studio
-        And I am editing a new unit
-        And I add the following components:
-            | Component    |
-            | Discussion   |
-            | Blank HTML   |
-            | LaTex        |
-            | Blank Problem|
-            | Dropdown     |
-            | Multi Choice |
-            | Numerical    |
-            | Text Input   |
-            | Advanced     |
-            | Circuit      |
-            | Custom Python|
-            | Image Mapped |
-            | Math Input   |
-            | Problem LaTex|
-            | Adaptive Hint|
-            | Video        |
-        When I will confirm all alerts
-        And I delete all components
-        Then I see no components
+    #Scenario: I can delete Components
+    #    Given I have opened a new course in studio
+    #    And I am editing a new unit
+    #    And I add the following components:
+    #        | Component    |
+    #        | Discussion   |
+    #        | Blank HTML   |
+    #        | LaTex        |
+    #        | Blank Problem|
+    #        | Dropdown     |
+    #        | Multi Choice |
+    #        | Numerical    |
+    #        | Text Input   |
+    #        | Advanced     |
+    #        | Circuit      |
+    #        | Custom Python|
+    #        | Image Mapped |
+    #        | Math Input   |
+    #        | Problem LaTex|
+    #        | Adaptive Hint|
+    #        | Video        |
+    #    When I will confirm all alerts
+    #    And I delete all components
+    #    Then I see no components
 
     Scenario: I see a prompt on delete
         Given I have opened a new course in studio

--- a/cms/djangoapps/contentstore/features/course-overview.feature
+++ b/cms/djangoapps/contentstore/features/course-overview.feature
@@ -69,7 +69,7 @@ Feature: CMS.Course Overview
     # Safari does not have moveMouseTo implemented
     @skip_internetexplorer
     @skip_safari
-   Scenario: Notification is shown on subsection reorder
+    Scenario: Notification is shown on subsection reorder
         Given I have opened a new course section in Studio
         And I have added a new subsection
         And I have added a new subsection

--- a/lms/djangoapps/courseware/features/certificates.feature
+++ b/lms/djangoapps/courseware/features/certificates.feature
@@ -11,59 +11,54 @@ Feature: LMS.Verified certificates
 
     # There is currently no way to avoid trying to upload
     # the photos to S3 for processing
-    @skip
-    Scenario: I can submit photos to verify my identity
-        Given I am logged in
-        When I select the verified track
-        And I go to step "1"
-        And I capture my "face" photo
-        And I approve my "face" photo
-        And I go to step "2"
-        And I capture my "photo_id" photo
-        And I approve my "photo_id" photo
-        And I go to step "3"
-        And I select a contribution amount
-        And I confirm that the details match
-        And I go to step "4"
-        Then I am at the payment page
+    #Scenario: I can submit photos to verify my identity
+    #    Given I am logged in
+    #    When I select the verified track
+    #    And I go to step "1"
+    #    And I capture my "face" photo
+    #    And I approve my "face" photo
+    #    And I go to step "2"
+    #    And I capture my "photo_id" photo
+    #    And I approve my "photo_id" photo
+    #    And I go to step "3"
+    #    And I select a contribution amount
+    #    And I confirm that the details match
+    #    And I go to step "4"
+    #    Then I am at the payment page
 
     # There is currently no way to avoid trying to upload
     # the photos to S3 for processing
-    @skip
-    Scenario: I can pay for a verified certificate
-        Given I have submitted photos to verify my identity
-        When I submit valid payment information
-        Then I see that my payment was successful
+    #Scenario: I can pay for a verified certificate
+    #    Given I have submitted photos to verify my identity
+    #    When I submit valid payment information
+    #    Then I see that my payment was successful
 
 
     # There is currently no way to avoid trying to upload
     # the photos to S3 for processing
-    @skip
-    Scenario: Verified courses display correctly on dashboard
-        Given I have submitted photos to verify my identity
-        When I submit valid payment information
-        And I navigate to my dashboard
-        Then I see the course on my dashboard
-        And I see that I am on the verified track
+    #Scenario: Verified courses display correctly on dashboard
+    #    Given I have submitted photos to verify my identity
+    #    When I submit valid payment information
+    #    And I navigate to my dashboard
+    #    Then I see the course on my dashboard
+    #    And I see that I am on the verified track
 
     # Not easily automated
-    @skip
-    Scenario: I can re-take photos
-        Given I have submitted my "<PhotoType>" photo
-        When I retake my "<PhotoType>" photo
-        Then I see the new photo on the confirmation page.
-
-        Examples:
-        | PhotoType     |
-        | face          |
-        | ID            |
+    #Scenario: I can re-take photos
+    #    Given I have submitted my "<PhotoType>" photo
+    #    When I retake my "<PhotoType>" photo
+    #    Then I see the new photo on the confirmation page.
+    #
+    #    Examples:
+    #    | PhotoType     |
+    #    | face          |
+    #    | ID            |
 
     # Not yet implemented LMS-983
-    @skip
-    Scenario: I can edit identity information
-        Given I have submitted face and ID photos
-        When I edit my name
-        Then I see the new name on the confirmation page.
+    #Scenario: I can edit identity information
+    #    Given I have submitted face and ID photos
+    #    When I edit my name
+    #    Then I see the new name on the confirmation page.
 
     Scenario: I can return to the verify flow
         Given I have submitted photos to verify my identity
@@ -71,12 +66,11 @@ Feature: LMS.Verified certificates
         Then I am at the verified page
 
     # Currently broken LMS-1009
-    @skip
-    Scenario: I can pay from the return flow
-        Given I have submitted photos to verify my identity
-        When I leave the flow and return
-        And I press the payment button
-        Then I am at the payment page
+    #Scenario: I can pay from the return flow
+    #    Given I have submitted photos to verify my identity
+    #    When I leave the flow and return
+    #    And I press the payment button
+    #    Then I am at the payment page
 
     Scenario: I can take a verified certificate course for free
         Given I am logged in

--- a/rakelib/acceptance_test.rake
+++ b/rakelib/acceptance_test.rake
@@ -9,7 +9,7 @@ def run_acceptance_tests(system, harvest_args)
 
     report_file = File.join(ACCEPTANCE_REPORT_DIR, "#{system}.xml")
     report_args = "--with-xunit --xunit-file #{report_file}"
-    test_sh(django_admin(system, 'acceptance', 'harvest', '--debug-mode', '--verbosity 2', '--tag -skip', report_args, harvest_args))
+    test_sh(django_admin(system, 'acceptance', 'harvest', '--debug-mode', '--verbosity 2', report_args, harvest_args))
 end
 
 task :setup_acceptance_db do


### PR DESCRIPTION
Lettuce behaves strangely with "exclude" tags.  If you have a scenario marked with two tags:

```
@skip @tag_1
Scenario: ...
```

And you run lettuce with `--tag -skip -tag tag_1` (EXCLUDE `skip`, INCLUDE `tag_1`), then the scenario will get run.  Looking at the code, lettuce seems to handle this inconsistently: if a scenario has just ONE tag, then it will be run only if it satisfies ALL the specified tags.

I'm going to submit a PR later to the lettuce project, but until then, the quick fix is to comment out the scenarios instead of relying on `skip` tags.  This will allow me to correctly shard the tests in the Jenkins cluster.

@jzoldak 
