### PR TITLE
Create management command to edit course's tabs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,9 @@ the top.  Include a label indicating the component affected.
 
 LMS: Add split testing functionality for internal use.
 
+CMS: Add edit_course_tabs management command, providing a primitive
+editing capability for a course's list of tabs.
+
 Studio and LMS: add ability to lock assets (cannot be viewed unless registered for class).
 
 LMS: Improved accessibility of parts of forum navigation sidebar.

--- a/cms/djangoapps/contentstore/management/commands/edit_course_tabs.py
+++ b/cms/djangoapps/contentstore/management/commands/edit_course_tabs.py
@@ -1,0 +1,88 @@
+###
+### Script for editing the course's tabs
+###
+
+#
+# Run it this way:
+#   ./manage.py cms --settings dev edit_course_tabs --course Stanford/CS99/2013_spring
+# Or via rake:
+#   rake django-admin[edit_course_tabs,cms,dev,"--course Stanford/CS99/2013_spring --delete 4"]
+#
+from optparse import make_option
+from django.core.management.base import BaseCommand, CommandError
+from .prompt import query_yes_no
+
+from courseware.courses import get_course_by_id
+
+from contentstore.views import tabs
+
+
+def print_course(course):
+    "Prints out the course id and a numbered list of tabs."
+    print course.id
+    for index, item in enumerate(course.tabs):
+        print index + 1, '"' + item.get('type') + '"', '"' + item.get('name', '') + '"'
+
+
+# course.tabs looks like this
+# [{u'type': u'courseware'}, {u'type': u'course_info', u'name': u'Course Info'}, {u'type': u'textbooks'},
+# {u'type': u'discussion', u'name': u'Discussion'}, {u'type': u'wiki', u'name': u'Wiki'},
+# {u'type': u'progress', u'name': u'Progress'}]
+
+
+class Command(BaseCommand):
+    help = """See and edit a course's tabs list.
+Only supports insertion and deletion. Move and
+rename etc. can be done with a delete
+followed by an insert.
+The tabs are numbered starting with 1.
+Tabs 1 and 2 cannot be changed, and tabs of type
+static_tab cannot be edited (use Studio for those).
+"""
+    # Making these option objects separately, so can refer to their .help below
+    course_option = make_option('--course',
+                                action='store',
+                                dest='course',
+                                default=False,
+                                help='--course <id> required, e.g. Stanford/CS99/2013_spring')
+    delete_option = make_option('--delete',
+                                action='store_true',
+                                dest='delete',
+                                default=False,
+                                help='--delete <tab-number>')
+    insert_option = make_option('--insert',
+                                action='store_true',
+                                dest='insert',
+                                default=False,
+                                help='--insert <tab-number> <type> <name>, e.g. 2 "course_info" "Course Info"')
+
+    option_list = BaseCommand.option_list + (course_option, delete_option, insert_option)
+
+    def handle(self, *args, **options):
+        if not options['course']:
+            raise CommandError(Command.course_option.help)
+
+        course = get_course_by_id(options['course'])
+
+        print 'Warning: this command directly edits the list of course tabs in mongo.'
+        print 'Tabs before any changes:'
+        print_course(course)
+
+        try:
+            if options['delete']:
+                if len(args) != 1:
+                    raise CommandError(Command.delete_option.help)
+                num = int(args[0])
+                if query_yes_no('Deleting tab {0} Confirm?'.format(num), default='no'):
+                    tabs.primitive_delete(course, num - 1)  # -1 for 0-based indexing
+            elif options['insert']:
+                if len(args) != 3:
+                    raise CommandError(Command.insert_option.help)
+                num = int(args[0])
+                tab_type = args[1]
+                name = args[2]
+                if query_yes_no('Inserting tab {0} "{1}" "{2}" Confirm?'.format(num, tab_type, name), default='no'):
+                    tabs.primitive_insert(course, num - 1, tab_type, name)  # -1 as above
+        except ValueError as e:
+            # Cute: translate to CommandError so the CLI error prints nicely.
+            raise CommandError(e)

--- a/cms/djangoapps/contentstore/tests/test_tabs.py
+++ b/cms/djangoapps/contentstore/tests/test_tabs.py
@@ -1,0 +1,41 @@
+""" Tests for tab functions (just primitive). """
+
+from contentstore.views import tabs
+from django.test import TestCase
+from xmodule.modulestore.tests.factories import CourseFactory
+from courseware.courses import get_course_by_id
+
+
+class PrimitiveTabEdit(TestCase):
+    """Tests for the primitive tab edit data manipulations"""
+
+    def test_delete(self):
+        """Test primitive tab deletion."""
+        course = CourseFactory.create(org='edX', course='999')
+        with self.assertRaises(ValueError):
+            tabs.primitive_delete(course, 0)
+        with self.assertRaises(ValueError):
+            tabs.primitive_delete(course, 1)
+        with self.assertRaises(IndexError):
+            tabs.primitive_delete(course, 6)
+        tabs.primitive_delete(course, 2)
+        self.assertFalse({u'type': u'textbooks'} in course.tabs)
+        # Check that discussion has shifted down
+        self.assertEquals(course.tabs[2], {'type': 'discussion', 'name': 'Discussion'})
+
+    def test_insert(self):
+        """Test primitive tab insertion."""
+        course = CourseFactory.create(org='edX', course='999')
+        tabs.primitive_insert(course, 2, 'atype', 'aname')
+        self.assertEquals(course.tabs[2], {'type': 'atype', 'name': 'aname'})
+        with self.assertRaises(ValueError):
+            tabs.primitive_insert(course, 0, 'atype', 'aname')
+        with self.assertRaises(ValueError):
+            tabs.primitive_insert(course, 3, 'static_tab', 'aname')
+
+    def test_save(self):
+        """Test course saving."""
+        course = CourseFactory.create(org='edX', course='999')
+        tabs.primitive_insert(course, 3, 'atype', 'aname')
+        course2 = get_course_by_id(course.id)
+        self.assertEquals(course2.tabs[3], {'type': 'atype', 'name': 'aname'})


### PR DESCRIPTION
@chrisndodge @jinpa @sefk  Hey Chris -- could you take a look at this small command. Sef thought you were the right guy for this level of muck-with-data code.

This is a small script that our ops people could use to adjust the tabs per course, which apparently is quite common. Currently they use import/export, so this command both easier and more reliable. That said of course, it's a power tool to be used with care. If the cost/benefit makes sense, we could upgrade this to a real GUI driving the same sort of underlying logic.

Jane tested an earlier version with the same core logic on a real imported class and it seemed to work.

Jane: could you try --insert and then click around a bit to see that the class still works? I think we only tried --delete this morning (and of course I'm happy sit next to you and we can test it together).
