### PR TITLE
Fix mako syntax in rubric template.

### DIFF
--- a/lms/templates/combinedopenended/combined_open_ended_results.html
+++ b/lms/templates/combinedopenended/combined_open_ended_results.html
@@ -1,5 +1,5 @@
 <%! from django.utils.translation import ugettext as _ %>
-% num_results = len(results)
+<% num_results = len(results) %>
 % for (i,result) in enumerate(results):
     % if 'task_name' in result and 'result' in result:
         <div class="combined-rubric-container"


### PR DESCRIPTION
Rubric syntax fix.  @caesar2164 Please look at this, will need to get a hotfix in on our side.
