### PR TITLE
Improvements in forums nav sidebar

### DIFF
--- a/common/static/coffee/src/discussion/views/discussion_thread_list_view.coffee
+++ b/common/static/coffee/src/discussion/views/discussion_thread_list_view.coffee
@@ -95,6 +95,7 @@ if Backbone?
       @timer = 0
       @$el.html(@template())
 
+      $(window).bind "load", @updateSidebar
       $(window).bind "scroll", @updateSidebar
       $(window).bind "resize", @updateSidebar
 

--- a/common/static/coffee/src/discussion/views/discussion_thread_list_view.coffee
+++ b/common/static/coffee/src/discussion/views/discussion_thread_list_view.coffee
@@ -144,6 +144,18 @@ if Backbone?
             options.group_id = @group_id
         
     
+      lastThread = @collection.last()?.get('id')
+      if lastThread
+        # Pagination; focus the first thread after what was previously the last thread
+        @once("threads:rendered", ->
+          $(".post-list li:has(a[data-id='#{lastThread}']) + li a").focus()
+        )
+      else
+        # Totally refreshing the list (e.g. from clicking a sort button); focus the first thread
+        @once("threads:rendered", ->
+          $(".post-list a").first()?.focus()
+        )
+
       @collection.retrieveAnotherPage(@mode, options, {sort_key: @sortBy})
 
     renderThread: (thread) =>


### PR DESCRIPTION
@kevinchugh @marcotuts 

Caveat: Apparently, when you click "Load more", the newly loaded threads are not always appended to the end of the list. The focus simply goes to whatever thread is after the thread that was previously the last one in the list. If all of the newly loaded threads are inserted higher in the list, then focus will be lost.
