### PR TITLE
JavaScript xunit reports.

### DIFF
--- a/rakelib/js_test.rake
+++ b/rakelib/js_test.rake
@@ -32,7 +32,8 @@ end
 # command line arguments
 def js_test_tool(env, command, do_coverage)
     suite = suite_for_env(env)
-    cmd = "js-test-tool #{command} #{suite} --use-firefox --timeout-sec 600"
+    xunit_report = File.join(JS_REPORT_DIR, 'javascript_xunit.xml')
+    cmd = "js-test-tool #{command} #{suite} --use-firefox --timeout-sec 600 --xunit-report #{xunit_report}"
 
     if do_coverage
         report_dir = File.join(JS_REPORT_DIR, 'coverage.xml')

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -18,5 +18,5 @@
 -e git+https://github.com/edx/XBlock.git@cee38a15f#egg=XBlock
 -e git+https://github.com/edx/codejail.git@0a1b468#egg=codejail
 -e git+https://github.com/edx/diff-cover.git@v0.2.6#egg=diff_cover
--e git+https://github.com/edx/js-test-tool.git@v0.1.1#egg=js_test_tool
+-e git+https://github.com/edx/js-test-tool.git@v0.1.3#egg=js_test_tool
 -e git+https://github.com/edx/django-waffle.git@823a102e48#egg=django-waffle


### PR DESCRIPTION
- Configure js-test-tool to generate xunit XML reports of test results.  This will allow us to see test results for JavaScript along with all the other test results in Jenkins (instead of looking at the console).
- Clean up js-test-tool console output.

@jzoldak Does the test output look reasonable in Jenkins?
@singingwolfboy This increments the version of js-test-tool one beyond what you're using in the RequireJS branch.
