### PR TITLE
Studio: HTML body class and view-styling naming conventions

### DIFF
--- a/cms/static/sass/views/_account.scss
+++ b/cms/static/sass/views/_account.scss
@@ -1,7 +1,7 @@
 // studio - views - sign up/in
 // ====================
 
-body.signup, body.signin {
+.view-signup, .view-signin {
 
   .wrapper-content {
     margin: ($baseline*1.5) 0 0 0;

--- a/cms/static/sass/views/_assets.scss
+++ b/cms/static/sass/views/_assets.scss
@@ -1,7 +1,7 @@
 // studio - views - assets
 // ====================
 
-body.course.uploads {
+.view-uploads {
 
   .content-primary, .content-supplementary {
     @include box-sizing(border-box);

--- a/cms/static/sass/views/_checklists.scss
+++ b/cms/static/sass/views/_checklists.scss
@@ -1,6 +1,7 @@
 // Studio - Course Settings
 // ====================
-body.course.checklists {
+
+.view-checklists {
 
   .content-primary, .content-supplementary {
     @include box-sizing(border-box);

--- a/cms/static/sass/views/_dashboard.scss
+++ b/cms/static/sass/views/_dashboard.scss
@@ -1,7 +1,7 @@
 // studio - views - user dashboard
 // ====================
 
-body.dashboard {
+.view-dashboard {
 
 	// temp
 	.content {

--- a/cms/static/sass/views/_export.scss
+++ b/cms/static/sass/views/_export.scss
@@ -1,7 +1,7 @@
 // studio - views - course export
 // ====================
 
-body.course.export {
+.view-export {
 
   .export-overview {
     @extend %ui-window;

--- a/cms/static/sass/views/_import.scss
+++ b/cms/static/sass/views/_import.scss
@@ -1,7 +1,7 @@
 // studio - views - course import
 // ====================
 
-body.course.import {
+.view-import {
 
   .import-overview {
     @extend %ui-window;

--- a/cms/static/sass/views/_index.scss
+++ b/cms/static/sass/views/_index.scss
@@ -1,7 +1,7 @@
 // studio - views - how it works
 // ====================
 
-body.index {
+.view-howitworks {
 
   &.not-signedin {
 

--- a/cms/static/sass/views/_outline.scss
+++ b/cms/static/sass/views/_outline.scss
@@ -1,7 +1,7 @@
 // studio - views - course outline
 // ====================
 
-body.course.outline {
+.view-outline {
 
   input.courseware-unit-search-input {
       float: left;

--- a/cms/static/sass/views/_settings.scss
+++ b/cms/static/sass/views/_settings.scss
@@ -1,7 +1,7 @@
 // studio - views - course settings
 // ====================
 
-body.course.settings {
+.view-settings {
 
   .content-primary, .content-supplementary {
     @include box-sizing(border-box);

--- a/cms/static/sass/views/_static-pages.scss
+++ b/cms/static/sass/views/_static-pages.scss
@@ -1,7 +1,7 @@
 // studio - views - course static pages
 // ====================
 
-body.course.static-pages {
+.view-static-pages {
 
   .new-static-page-button {
     @include grey-button;

--- a/cms/static/sass/views/_subsection.scss
+++ b/cms/static/sass/views/_subsection.scss
@@ -1,7 +1,7 @@
 // studio - views - course subsection
 // ====================
 
-body.course.subsection {
+.view-subsection {
 
   .main-wrapper {
     margin-top: ($baseline*2);

--- a/cms/static/sass/views/_textbooks.scss
+++ b/cms/static/sass/views/_textbooks.scss
@@ -1,7 +1,7 @@
 // studio - views - textbooks
 // ====================
 
-body.course.textbooks {
+.view-textbooks {
 
   .content-primary, .content-supplementary {
     @include box-sizing(border-box);

--- a/cms/static/sass/views/_unit.scss
+++ b/cms/static/sass/views/_unit.scss
@@ -1,7 +1,7 @@
 // studio - views - unit
 // ====================
 
-body.course.unit {
+.view-unit {
 
   .main-wrapper {
     margin-top: ($baseline*2);

--- a/cms/static/sass/views/_updates.scss
+++ b/cms/static/sass/views/_updates.scss
@@ -1,7 +1,7 @@
 // studio - views - course updates
 // ====================
 
-body.course.updates {
+.view-updates {
 
 	.course-info-wrapper {
 		display: table;

--- a/cms/static/sass/views/_users.scss
+++ b/cms/static/sass/views/_users.scss
@@ -1,7 +1,7 @@
 // studio - views - course users
 // ====================
 
-body.course.users {
+.view-team {
 
   // LAYOUT: page
   .content-primary, .content-supplementary {

--- a/cms/templates/asset_index.html
+++ b/cms/templates/asset_index.html
@@ -3,7 +3,7 @@
 <%! from django.utils.translation import ugettext as _ %>
 
 <%block name="title">${_("Files &amp; Uploads")}</%block>
-<%block name="bodyclass">is-signedin course uploads</%block>
+<%block name="bodyclass">is-signedin course view-uploads</%block>
 
 <%namespace name='static' file='static_content.html'/>
 

--- a/cms/templates/checklists.html
+++ b/cms/templates/checklists.html
@@ -2,7 +2,7 @@
 <%inherit file="base.html" />
 <%! from django.core.urlresolvers import reverse %>
 <%block name="title">Course Checklists</%block>
-<%block name="bodyclass">is-signedin course uxdesign checklists</%block>
+<%block name="bodyclass">is-signedin course view-checklists</%block>
 
 <%namespace name='static' file='static_content.html'/>
 

--- a/cms/templates/course_info.html
+++ b/cms/templates/course_info.html
@@ -4,7 +4,7 @@
 
 <!-- TODO decode course # from context_course into title -->
 <%block name="title">${_("Course Updates")}</%block>
-<%block name="bodyclass">is-signedin course course-info updates</%block>
+<%block name="bodyclass">is-signedin course view-updates</%block>
 
 <%block name="header_extras">
 % for template_name in ["course_info_update", "course_info_handouts"]:

--- a/cms/templates/edit-tabs.html
+++ b/cms/templates/edit-tabs.html
@@ -2,7 +2,7 @@
 <%! from django.utils.translation import ugettext as _ %>
 <%! from django.core.urlresolvers import reverse %>
 <%block name="title">Static Pages</%block>
-<%block name="bodyclass">is-signedin course pages static-pages</%block>
+<%block name="bodyclass">is-signedin course view-static-pages</%block>
 
 <%block name="jsextra">
   <script type='text/javascript'>

--- a/cms/templates/edit_subsection.html
+++ b/cms/templates/edit_subsection.html
@@ -6,7 +6,7 @@
   from django.core.urlresolvers import reverse
 %>
 <%block name="title">${_("CMS Subsection")}</%block>
-<%block name="bodyclass">is-signedin course subsection</%block>
+<%block name="bodyclass">is-signedin course view-subsection</%block>
 
 
 <%namespace name="units" file="widgets/units.html" />

--- a/cms/templates/export.html
+++ b/cms/templates/export.html
@@ -4,7 +4,7 @@
 
 <%! from django.core.urlresolvers import reverse %>
 <%block name="title">${_("Course Export")}</%block>
-<%block name="bodyclass">is-signedin course tools export</%block>
+<%block name="bodyclass">is-signedin course tools view-export</%block>
 
 <%block name="jsextra">
   % if in_err:

--- a/cms/templates/howitworks.html
+++ b/cms/templates/howitworks.html
@@ -3,7 +3,7 @@
 <%! from django.core.urlresolvers import reverse %>
 
 <%block name="title">${_("Welcome")}</%block>
-<%block name="bodyclass">not-signedin index howitworks</%block>
+<%block name="bodyclass">not-signedin index view-howitworks</%block>
 
 <%block name="content">
 

--- a/cms/templates/import.html
+++ b/cms/templates/import.html
@@ -4,7 +4,7 @@
 
 <%! from django.core.urlresolvers import reverse %>
 <%block name="title">${_("Course Import")}</%block>
-<%block name="bodyclass">is-signedin course tools import</%block>
+<%block name="bodyclass">is-signedin course tools view-import</%block>
 
 <%block name="content">
 <div class="wrapper-mast wrapper">
@@ -82,7 +82,7 @@ $('#fileupload').fileupload({
                         alert('${_("Your import has failed.")}\n\n' + errMsg);
                         submitBtn.show();
                         bar.hide();
-                    } 
+                    }
                 });
             });
         } else {

--- a/cms/templates/index.html
+++ b/cms/templates/index.html
@@ -3,7 +3,7 @@
 <%inherit file="base.html" />
 
 <%block name="title">${_("My Courses")}</%block>
-<%block name="bodyclass">is-signedin index dashboard</%block>
+<%block name="bodyclass">is-signedin index view-dashboard</%block>
 
 <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7/jquery.js"></script>
 <script src="http://malsup.github.com/jquery.form.js"></script>

--- a/cms/templates/login.html
+++ b/cms/templates/login.html
@@ -2,7 +2,7 @@
 <%inherit file="base.html" />
 <%! from django.core.urlresolvers import reverse %>
 <%block name="title">${_("Sign In")}</%block>
-<%block name="bodyclass">not-signedin signin</%block>
+<%block name="bodyclass">not-signedin view-signin</%block>
 
 <%block name="content">
 

--- a/cms/templates/manage_users.html
+++ b/cms/templates/manage_users.html
@@ -4,7 +4,7 @@
 <%! import json %>
 <%inherit file="base.html" />
 <%block name="title">${_("Course Team Settings")}</%block>
-<%block name="bodyclass">is-signedin course users team</%block>
+<%block name="bodyclass">is-signedin course users view-team</%block>
 
 
 <%block name="content">

--- a/cms/templates/overview.html
+++ b/cms/templates/overview.html
@@ -6,7 +6,7 @@
   from django.core.urlresolvers import reverse
 %>
 <%block name="title">${_("Course Outline")}</%block>
-<%block name="bodyclass">is-signedin course outline</%block>
+<%block name="bodyclass">is-signedin course view-outline</%block>
 
 <%namespace name='static' file='static_content.html'/>
 <%namespace name="units" file="widgets/units.html" />

--- a/cms/templates/registration/activation_complete.html
+++ b/cms/templates/registration/activation_complete.html
@@ -5,9 +5,7 @@
 <%namespace name='static' file='../static_content.html'/>
 
 %if not user_logged_in:
-<%block name="bodyclass">
-  not-signedin
-</%block>
+<%block name="bodyclass">not-signedin view-activation</%block>
 %endif
 
 <%block name="content">

--- a/cms/templates/settings.html
+++ b/cms/templates/settings.html
@@ -2,7 +2,7 @@
 
 <%inherit file="base.html" />
 <%block name="title">${_("Schedule &amp; Details Settings")}</%block>
-<%block name="bodyclass">is-signedin course schedule settings feature-upload</%block>
+<%block name="bodyclass">is-signedin course schedule view-settings feature-upload</%block>
 
 <%namespace name='static' file='static_content.html'/>
 <%!

--- a/cms/templates/settings_advanced.html
+++ b/cms/templates/settings_advanced.html
@@ -4,7 +4,7 @@
 <%! from django.utils.translation import ugettext as _ %>
 <%! from contentstore import utils %>
 <%block name="title">${_("Advanced Settings")}</%block>
-<%block name="bodyclass">is-signedin course advanced settings</%block>
+<%block name="bodyclass">is-signedin course advanced view-settings</%block>
 
 <%block name="jsextra">
 % for template_name in ["advanced_entry"]:

--- a/cms/templates/settings_discussions_faculty.html
+++ b/cms/templates/settings_discussions_faculty.html
@@ -2,7 +2,7 @@
 <!-- NOTE not used currently but retained b/c it's yet-to-be-wired functionality -->
 <%inherit file="base.html" />
 <%block name="title">${_("Schedule and details")}</%block>
-<%block name="bodyclass">is-signedin course settings</%block>
+<%block name="bodyclass">is-signedin course view-settings</%block>
 
 
 <%namespace name='static' file='static_content.html'/>

--- a/cms/templates/settings_graders.html
+++ b/cms/templates/settings_graders.html
@@ -1,6 +1,6 @@
 <%inherit file="base.html" />
 <%block name="title">${_("Grading Settings")}</%block>
-<%block name="bodyclass">is-signedin course grading settings</%block>
+<%block name="bodyclass">is-signedin course grading view-settings</%block>
 
 <%namespace name='static' file='static_content.html'/>
 <%!

--- a/cms/templates/signup.html
+++ b/cms/templates/signup.html
@@ -3,7 +3,7 @@
 <%! from django.core.urlresolvers import reverse %>
 
 <%block name="title">${_("Sign Up")}</%block>
-<%block name="bodyclass">not-signedin signup</%block>
+<%block name="bodyclass">not-signedin view-signup</%block>
 
 <%block name="content">
 

--- a/cms/templates/static-pages.html
+++ b/cms/templates/static-pages.html
@@ -2,14 +2,14 @@
 <%inherit file="base.html" />
 <%! from django.core.urlresolvers import reverse %>
 <%block name="title">${_("Static Pages")}</%block>
-<%block name="bodyclass">static-pages</%block>
+<%block name="bodyclass">view-static-pages</%block>
 
 <%block name="content">
 <div class="main-wrapper">
   <div class="inner-wrapper">
     <h1>Static Pages</h1>
     <div class="page-actions">
-      
+
     </div>
     <article class="static-page-overview">
     <a href="#" class="new-static-page-button wip-box"><span class="plus-icon"></span> ${_("New Static Page")}</a>

--- a/cms/templates/textbooks.html
+++ b/cms/templates/textbooks.html
@@ -4,7 +4,7 @@
 <%! from django.utils.translation import ugettext as _ %>
 
 <%block name="title">${_("Textbooks")}</%block>
-<%block name="bodyclass">is-signedin course textbooks feature-upload</%block>
+<%block name="bodyclass">is-signedin course view-textbooks feature-upload</%block>
 
 <%block name="header_extras">
 % for template_name in ["edit-textbook", "show-textbook", "edit-chapter", "no-textbooks", "upload-dialog"]:


### PR DESCRIPTION
This work revises the class naming conventions applied to the <body> element which are used to scope view-specific styling and presentation within our Sass/CSS. This originated from @frrrances good feedback here - https://github.com/edx/edx-platform/pull/1043#discussion_r6696043.

All unique views should now have a class added to the body that consists of a "view-" prefix and a logical/semantic name for the view. This class will be used to scope things.

No styling was changed, just selector an attribute names.
