### PR TITLE
Quiet down exceptions at startup, and during tests

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/xml.py
+++ b/common/lib/xmodule/xmodule/modulestore/xml.py
@@ -179,7 +179,7 @@ class ImportSystem(XMLParsingSystem, MakoDescriptorSystem):
                 # Normally, we don't want lots of exception traces in our logs from common
                 # content problems.  But if you're debugging the xml loading code itself,
                 # uncomment the next line.
-                log.exception(msg)
+                #   log.exception(msg)
 
                 self.error_tracker(msg)
                 err_msg = msg + "\n" + exc_info_to_str(sys.exc_info())

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -363,6 +363,10 @@ MODULESTORE = {
 }
 CONTENTSTORE = None
 
+# Should we initialize the modulestores at startup, or wait until they are
+# needed?
+INIT_MODULESTORE_ON_STARTUP = True
+
 ############# XBlock Configuration ##########
 
 # This should be moved into an XBlock Runtime/Application object

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -110,6 +110,10 @@ MODULESTORE = {
     }
 }
 
+# Starting modulestores generates log messages.  If we wait to init modulestores,
+# then those messages will be silenced by the test runner.
+INIT_MODULESTORE_ON_STARTUP = False
+
 CONTENTSTORE = {
     'ENGINE': 'xmodule.contentstore.mongo.MongoContentStore',
     'OPTIONS': {

--- a/lms/startup.py
+++ b/lms/startup.py
@@ -19,7 +19,8 @@ def run():
     """
     autostartup()
 
-    # trigger a forced initialization of our modulestores since this can take a while to complete
-    # and we want this done before HTTP requests are accepted
-    for store_name in settings.MODULESTORE:
-    	modulestore(store_name)
+    # Trigger a forced initialization of our modulestores since this can take a while to complete
+    # and we want this done before HTTP requests are accepted.
+    if settings.INIT_MODULESTORE_ON_STARTUP:
+        for store_name in settings.MODULESTORE:
+            modulestore(store_name)


### PR DESCRIPTION
There's no need to display a traceback for every failed content load,
the comment before the log line even says so.

The exceptions shown before tests are run are because of the eager
initialization of the modulestores.  They don't need to be initialized
then, that just speeds the responsiveness of servers.  Putting off the
initialization means they get inited as needed, and the log lines get
swallowed by the test runner.

@cdodge @wedaly Thoughts?
