### PR TITLE
Increased timeout in LaTeX acceptance test.

### DIFF
--- a/cms/djangoapps/contentstore/features/problem-editor.py
+++ b/cms/djangoapps/contentstore/features/problem-editor.py
@@ -187,7 +187,7 @@ def high_level_source_persisted(step):
         css_sel = '.problem div>span'
         return world.css_text(css_sel) == 'hi'
 
-    world.wait_for(verify_text)
+    world.wait_for(verify_text, timeout=10)
 
 
 @step('I view the High Level Source I see my changes')


### PR DESCRIPTION
@jzoldak I observed a timeout failure for one of the acceptance tests on the cluster:

https://gist.github.com/wedaly/6795352

I'm unable to reproduce locally, and this happened once out of many, many builds.  But given that we're going to be running these much more frequently, it seems prudent to increase the timeout a bit just to be safe.
