### PR TITLE
Use pre-generated reports for pep8/pylint when running diff-quality

### DIFF
--- a/rakelib/quality.rake
+++ b/rakelib/quality.rake
@@ -48,13 +48,20 @@ dquality_dir = File.join(REPORT_DIR, "diff_quality")
 directory dquality_dir
 
 desc "Build the html diff quality reports, and print the reports to the console."
-task :quality => dquality_dir do
+task :quality => [dquality_dir, :install_python_prereqs] do
+
     # Generage diff-quality html report for pep8, and print to console
-    sh("diff-quality --violations=pep8 --html-report #{dquality_dir}/diff_quality_pep8.html")
-    sh("diff-quality --violations=pep8")
+    # If pep8 reports exist, use those
+    # Otherwise, `diff-quality` will call pep8 itself
+    pep8_reports = FileList[File.join(REPORT_DIR, '**/pep8.report')].join(' ')
+    sh("diff-quality --violations=pep8 --html-report #{dquality_dir}/diff_quality_pep8.html #{pep8_reports}")
+    sh("diff-quality --violations=pep8 #{pep8_reports}")
 
     # Generage diff-quality html report for pylint, and print to console
+    # If pylint reports exist, use those
+    # Otherwise, `diff-quality` will call pylint itself
+    pylint_reports = FileList[File.join(REPORT_DIR, '**/pylint.report')].join(' ')
     pythonpath_prefix = "PYTHONPATH=$PYTHONPATH:lms:lms/djangoapps:lms/lib:cms:cms/djangoapps:cms/lib:common:common/djangoapps:common/lib"
-    sh("#{pythonpath_prefix} diff-quality --violations=pylint --html-report #{dquality_dir}/diff_quality_pylint.html")
-    sh("#{pythonpath_prefix} diff-quality --violations=pylint")
+    sh("#{pythonpath_prefix} diff-quality --violations=pylint --html-report #{dquality_dir}/diff_quality_pylint.html #{pylint_reports}")
+    sh("#{pythonpath_prefix} diff-quality --violations=pylint #{pylint_reports}")
 end

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -16,6 +16,6 @@
 # Our libraries:
 -e git+https://github.com/edx/XBlock.git@8a66ca3#egg=XBlock
 -e git+https://github.com/edx/codejail.git@0a1b468#egg=codejail
--e git+https://github.com/edx/diff-cover.git@v0.2.4#egg=diff_cover
+-e git+https://github.com/edx/diff-cover.git@v0.2.5#egg=diff_cover
 -e git+https://github.com/edx/js-test-tool.git@v0.1.1#egg=js_test_tool
 -e git+https://github.com/edx/django-waffle.git@823a102e48#egg=django-waffle


### PR DESCRIPTION
This updates `diff-quality` so it can accept pre-generated pep8/pylint reports.  This should speed up the unit test job, because `diff-quality` won't have to re-run pep8/pylint on all the files in the diff.

@sarina @cpennington
