### PR TITLE
Catch WebDriver exceptions when creating selenium browser

### DIFF
--- a/common/djangoapps/terrain/browser.py
+++ b/common/djangoapps/terrain/browser.py
@@ -99,16 +99,18 @@ def initial_setup(server):
         success = False
         num_attempts = 0
         while (not success) and num_attempts < MAX_VALID_BROWSER_ATTEMPTS:
-            world.browser = Browser(browser_driver)
 
-            # Try to visit the main page
-            # If the browser session is invalid, this will
+            # Load the browser and try to visit the main page
+            # If the browser couldn't be reached or
+            # the browser session is invalid, this will
             # raise a WebDriverException
             try:
+                world.browser = Browser(browser_driver)
                 world.visit('/')
 
             except WebDriverException:
-                world.browser.quit()
+                if hasattr(world, 'browser'):
+                    world.browser.quit()
                 num_attempts += 1
 
             else:


### PR DESCRIPTION
Observed this exception twice in the cluster:

```
selenium.common.exceptions.WebDriverException: Message: u'chrome not reachable\n  (Driver info: chromedriver=2.1,platform=Linux 3.2.0-40-virtual x86_64)' 
```

I was able to reproduce locally in about 1/50 trials.  This change appears to have resolved this issue (ran 200 trials successfully).

@jzoldak 
