### PR TITLE
Studio: Fix - HTML <body> class regressions

### DIFF
--- a/cms/static/sass/views/_unit.scss
+++ b/cms/static/sass/views/_unit.scss
@@ -1,7 +1,7 @@
 // studio - views - unit
 // ====================
 
-.view-unit {
+body.course.unit,.view-unit {
 
   .main-wrapper {
     margin-top: ($baseline*2);

--- a/cms/templates/course_info.html
+++ b/cms/templates/course_info.html
@@ -4,7 +4,7 @@
 
 <!-- TODO decode course # from context_course into title -->
 <%block name="title">${_("Course Updates")}</%block>
-<%block name="bodyclass">is-signedin course view-updates</%block>
+<%block name="bodyclass">is-signedin course course-info updates view-updates</%block>
 
 <%block name="header_extras">
 % for template_name in ["course_info_update", "course_info_handouts"]:

--- a/cms/templates/unit.html
+++ b/cms/templates/unit.html
@@ -3,7 +3,7 @@
 <%! from django.core.urlresolvers import reverse %>
 <%namespace name="units" file="widgets/units.html" />
 <%block name="title">${_("Individual Unit")}</%block>
-<%block name="bodyclass">is-signedin course unit</%block>
+<%block name="bodyclass">is-signedin course unit view-unit</%block>
 
 <%block name="jsextra">
   <script type='text/javascript'>


### PR DESCRIPTION
This work resolves the failed tests/broken styling and functionality caused by https://github.com/edx/edx-platform/pull/1192. Older classes were added back in when needed to the course updates and unit views.
