### PR TITLE
Some dasbhoard template cleanup

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ in roughly chronological order, most recent first.  Add your entries at or near
 the top.  Include a label indicating the component affected.
 
 
+LMS: Refactor and clean student dashboard templates.
+
 LMS: Fix issue with CourseMode expiration dates
 
 LMS: Add PaidCourseRegistration mode, where payment is required before course registration.

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -48,6 +48,7 @@ from certificates.models import CertificateStatuses, certificate_status_for_stud
 from xmodule.course_module import CourseDescriptor
 from xmodule.modulestore.exceptions import ItemNotFoundError
 from xmodule.modulestore.django import modulestore
+from xmodule.modulestore import MONGO_MODULESTORE_TYPE
 
 from collections import namedtuple
 
@@ -295,6 +296,11 @@ def dashboard(request):
 
     cert_statuses = {course.id: cert_info(request.user, course) for course, _enrollment in courses}
 
+    # only show email settings for Mongo course and when bulk email is turned on
+    show_email_settings_for = frozenset(course.id for course, _enrollment in courses
+                                        if (settings.MITX_FEATURES['ENABLE_INSTRUCTOR_EMAIL'] and
+                                            modulestore().get_modulestore_type(course.id) == MONGO_MODULESTORE_TYPE))
+
     # get info w.r.t ExternalAuthMap
     external_auth_map = None
     try:
@@ -310,6 +316,7 @@ def dashboard(request):
                'errored_courses': errored_courses,
                'show_courseware_links_for': show_courseware_links_for,
                'cert_statuses': cert_statuses,
+               'show_email_settings_for': show_email_settings_for,
                }
 
     return render_to_response('dashboard.html', context)

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -295,8 +295,6 @@ def dashboard(request):
 
     cert_statuses = {course.id: cert_info(request.user, course) for course, _enrollment in courses}
 
-    exam_registrations = {course.id: exam_registration_info(request.user, course) for course, _enrollment in courses}
-
     # get info w.r.t ExternalAuthMap
     external_auth_map = None
     try:
@@ -312,7 +310,6 @@ def dashboard(request):
                'errored_courses': errored_courses,
                'show_courseware_links_for': show_courseware_links_for,
                'cert_statuses': cert_statuses,
-               'exam_registrations': exam_registrations,
                }
 
     return render_to_response('dashboard.html', context)

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -157,7 +157,8 @@
         % for course, enrollment in courses:
             <% show_courseware_link = (course.id in show_courseware_links_for) %>
             <% cert_status = cert_statuses.get(course.id) %>
-            <%include file='dashboard/dashboard_course_listing.html' args="course=course, enrollment=enrollment, show_courseware_link=show_courseware_link, cert_status=cert_status" />
+            <% show_email_settings = (course.id in show_email_settings_for) %>
+            <%include file='dashboard/dashboard_course_listing.html' args="course=course, enrollment=enrollment, show_courseware_link=show_courseware_link, cert_status=cert_status, show_email_settings=show_email_settings" />
       % endfor
 
       </ul>

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -212,55 +212,6 @@
               </hgroup>
 
               <%
-                  testcenter_exam_info = course.current_test_center_exam
-                  registration = exam_registrations.get(course.id)
-                  testcenter_register_target = reverse('begin_exam_registration', args=[course.id])
-              %>
-              % if testcenter_exam_info is not None:
-
-                  % if registration is None and testcenter_exam_info.is_registering():
-                  <div class="message message-status is-shown exam-register">
-                    <a href="${testcenter_register_target}" class="button exam-button" id="exam_register_button">${_("Register for Pearson exam")}</a>
-                    <p class="message-copy">${_("Registration for the Pearson exam is now open and will close on {end_date}").format(end_date="<strong>{}</strong>".format(testcenter_exam_info.registration_end_date_text))}</p>
-                  </div>
-                  % endif
-                  <!-- display a registration for a current exam, even if the registration period is over -->
-                  % if registration is not None:
-                      % if registration.is_accepted:
-                  <div class="message message-status is-shown exam-schedule">
-                     <a href="${registration.registration_signup_url}" class="button exam-button">${_("Schedule Pearson exam")}</a>
-                     <p class="exam-registration-number">${_("{link_start}Registration{link_end} number: {number}").format(
-                        link_start='<a href="{url}" id="exam_register_link">'.format(url=testcenter_register_target),
-                        link_end='</a>',
-                        number=registration.client_candidate_id,
-                      )}</p>
-                     <p class="message-copy">${_("Write this down! You'll need it to schedule your exam.")}</p>
-                  </div>
-                      % endif
-                      % if  registration.is_rejected:
-                  <div class="message message-status is-shown exam-schedule">
-                    <p class="message-copy">
-                      <strong>${_("Your registration for the Pearson exam has been rejected. Please {link_start}see your registration status details{link_end}.").format(
-                        link_start='<a href="{url}" id="exam_register_link">'.format(url=testcenter_register_target),
-                        link_end='</a>')}</strong>
-                      ${_("Otherwise {link_start}contact edX at {email}{link_end} for further help.").format(
-                        link_start='<a class="contact-link" href="mailto:{email}?subject=Pearson VUE Exam - {about} {number}">'.format(email="exam-help@edx.org", about=get_course_about_section(course, 'university'), number=course.display_number_with_default),
-                        link_end='</a>',
-                        email="exam-help@edx.org",
-                       )}
-                  </div>
-                      % endif
-                     	% if not registration.is_accepted and not registration.is_rejected:
-  	            <div class="message message-status is-shown">
-                    <p class="message-copy"><strong>${_("Your {link_start}registration for the Pearson exam{link_end} is pending.").format(link_start='<a href="{url}" id="exam_register_link">'.format(url=testcenter_register_target), link_end='</a>')}</strong>
-                    ${_("Within a few days, you should see a confirmation number here, which can be used to schedule your exam.")}
-                    </p>
-                  </div>
-                      % endif
-                  % endif
-              % endif
-
-              <%
               cert_status = cert_statuses.get(course.id)
               %>
               % if course.has_ended() and cert_status:

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -2,14 +2,6 @@
 
 <%!
   from django.core.urlresolvers import reverse
-  from courseware.courses import course_image_url, get_course_about_section
-  from courseware.access import has_access
-  from certificates.models import CertificateStatuses
-  
-  from xmodule.modulestore import MONGO_MODULESTORE_TYPE
-  from xmodule.modulestore.django import modulestore
-
-  import waffle
 %>
 <%inherit file="main.html" />
 
@@ -163,127 +155,9 @@
     % if len(courses) > 0:
       <ul class="listing-courses">
         % for course, enrollment in courses:
-        <li class="course-item">
-          <article class="course ${enrollment.mode}">
-            <%
-              if waffle.flag_is_active(request, 'merge_course_tabs'):
-                  course_target = reverse('courseware', args=[course.id])
-              else:
-                  course_target = reverse('info', args=[course.id])
-            %>
-
-            % if course.id in show_courseware_links_for:
-              <a href="${course_target}" class="cover">
-                <img src="${course_image_url(course)}" alt="${_('{course_number} {course_name} Cover Image').format(course_number=course.number, course_name=course.display_name_with_default) |h}" />
-              </a>
-            % else:
-              <div class="cover">
-                <img src="${course_image_url(course)}" alt="${_('{course_number} {course_name} Cover Image').format(course_number=course.number, course_name=course.display_name_with_default) | h}" />
-              </div>
-            % endif
-
-            % if enrollment.mode == "verified":
-            <span class="sts-enrollment">
-              <span class="label">${_("Enrolled as: ")}</span>
-              <img class="deco-graphic" src="${static.url('images/vcert-ribbon-s.png')}" alt="ID Verified Ribbon/Badge">
-              <span class="sts-enrollment-value">${_("ID Verified")}</span>
-            </span>
-            % endif
-
-            <section class="info">
-              <hgroup>
-                <p class="date-block">
-                % if course.has_ended():
-                ${_("Course Completed - {end_date}").format(end_date=course.end_date_text)}
-                % elif course.has_started():
-                ${_("Course Started - {start_date}").format(start_date=course.start_date_text)}
-                % else:   # hasn't started yet
-                ${_("Course Starts - {start_date}").format(start_date=course.start_date_text)}
-                % endif
-                </p>
-                <h2 class="university">${get_course_about_section(course, 'university')}</h2>
-                <h3>
-                  % if course.id in show_courseware_links_for:
-                    <a href="${course_target}">${course.display_number_with_default | h} ${course.display_name_with_default}</a>
-                  % else:
-                    <span>${course.display_number_with_default | h} ${course.display_name_with_default}</span>
-                  % endif
-                </h3>
-              </hgroup>
-
-              <%
-              cert_status = cert_statuses.get(course.id)
-              %>
-              % if course.has_ended() and cert_status:
-                  <%
-                  if cert_status['status'] == 'generating':
-                      status_css_class = 'course-status-certrendering'
-                  elif cert_status['status'] == 'ready':
-                      status_css_class = 'course-status-certavailable'
-                  elif cert_status['status'] == 'notpassing':
-                      status_css_class = 'course-status-certnotavailable'
-                  else:
-                      status_css_class = 'course-status-processing'
-                  %>
-                  <div class="message message-status ${status_css_class} is-shown">
-
-                  % if cert_status['status'] == 'processing':
-                        <p class="message-copy">${_("Final course details are being wrapped up at this time. Your final standing will be available shortly.")}</p>
-                  % elif cert_status['status'] in ('generating', 'ready', 'notpassing', 'restricted'):
-                        <p class="message-copy">${_("Your final grade:")}
-                        <span class="grade-value">${"{0:.0f}%".format(float(cert_status['grade'])*100)}</span>.
-                        % if cert_status['status'] == 'notpassing':
-                           ${_("Grade required for a certificate:")} <span class="grade-value">
-                             ${"{0:.0f}%".format(float(course.lowest_passing_grade)*100)}</span>.
-                        % elif cert_status['status'] == 'restricted':
-                            <p class="message-copy">
-                            ${_("Your certificate is being held pending confirmation that the issuance of your certificate is in compliance with strict U.S. embargoes on Iran, Cuba, Syria and Sudan. If you think our system has mistakenly identified you as being connected with one of those countries, please let us know by contacting {email}.").format(email='<a class="contact-link" href="mailto:{email}">{email}</a>.'.format(email=settings.CONTACT_EMAIL))}
-                            </p>
-                        % endif
-                        </p>
-                  % endif
-
-                  % if cert_status['show_disabled_download_button'] or cert_status['show_download_url'] or cert_status['show_survey_button']:
-                    <ul class="actions">
-                      % if cert_status['show_disabled_download_button']:
-                        <li class="action"><span class="disabled">
-                            ${_("Your Certificate is Generating")}</span></li>
-                      % elif cert_status['show_download_url']:
-                        <li class="action">
-                        <a class="btn" href="${cert_status['download_url']}"
-                           title="${_('This link will open/download a PDF document')}">
-                           Download Your PDF Certificate</a></li>
-                      % endif
-
-                      % if cert_status['show_survey_button']:
-                        <li class="action"><a class="cta" href="${cert_status['survey_url']}">
-                               ${_('Complete our course feedback survey')}</a></li>
-                      % endif
-                    </ul>
-                  % endif
-                  </div>
-
-              % endif
-
-              % if course.id in show_courseware_links_for:
-                % if course.has_ended():
-                  <a href="${course_target}" class="enter-course archived">${_('View Archived Course')}</a>
-                % else:
-                  <a href="${course_target}" class="enter-course">${_('View Course')}</a>
-                % endif
-              % endif
-
-
-
-              <a href="#unenroll-modal" class="unenroll" rel="leanModal" data-course-id="${course.id}" data-course-number="${course.number}">${_('Unregister')}</a>
-
-  	    % if settings.MITX_FEATURES['ENABLE_INSTRUCTOR_EMAIL'] and modulestore().get_modulestore_type(course.id) == MONGO_MODULESTORE_TYPE:
-  	      <!-- Only show the Email Settings link/modal if this course has bulk email feature enabled -->
-                <a href="#email-settings-modal" class="email-settings" rel="leanModal" data-course-id="${course.id}" data-course-number="${course.number}" data-optout="${course.id in course_optouts}">${_('Email Settings')}</a>
-  	    % endif
-          </section>
-        </article>
-      </li>
+            <% show_courseware_link = (course.id in show_courseware_links_for) %>
+            <% cert_status = cert_statuses.get(course.id) %>
+            <%include file='dashboard/dashboard_course_listing.html' args="course=course, enrollment=enrollment, show_courseware_link=show_courseware_link, cert_status=cert_status" />
       % endfor
 
       </ul>

--- a/lms/templates/dashboard/dashboard_course_listing.html
+++ b/lms/templates/dashboard/dashboard_course_listing.html
@@ -4,8 +4,6 @@
 <%!
   from django.core.urlresolvers import reverse
   from courseware.courses import course_image_url, get_course_about_section
-  from courseware.access import has_access
-  from certificates.models import CertificateStatuses
   import waffle
 %>
 <li class="course-item">

--- a/lms/templates/dashboard/dashboard_course_listing.html
+++ b/lms/templates/dashboard/dashboard_course_listing.html
@@ -1,4 +1,4 @@
-<%page args="course, enrollment, show_courseware_link, cert_status" />
+<%page args="course, enrollment, show_courseware_link, cert_status, show_email_settings" />
 
 <%! from django.utils.translation import ugettext as _ %>
 <%!
@@ -6,10 +6,6 @@
   from courseware.courses import course_image_url, get_course_about_section
   from courseware.access import has_access
   from certificates.models import CertificateStatuses
-  
-  from xmodule.modulestore import MONGO_MODULESTORE_TYPE
-  from xmodule.modulestore.django import modulestore
-
   import waffle
 %>
 <li class="course-item">
@@ -123,8 +119,7 @@
 
       <a href="#unenroll-modal" class="unenroll" rel="leanModal" data-course-id="${course.id}" data-course-number="${course.number}">${_('Unregister')}</a>
 
-% if settings.MITX_FEATURES['ENABLE_INSTRUCTOR_EMAIL'] and modulestore().get_modulestore_type(course.id) == MONGO_MODULESTORE_TYPE:
-  <!-- Only show the Email Settings link/modal if this course has bulk email feature enabled -->
+% if show_email_settings:
         <a href="#email-settings-modal" class="email-settings" rel="leanModal" data-course-id="${course.id}" data-course-number="${course.number}" data-optout="${course.id in course_optouts}">${_('Email Settings')}</a>
 % endif
 

--- a/lms/templates/dashboard/dashboard_course_listing.html
+++ b/lms/templates/dashboard/dashboard_course_listing.html
@@ -1,0 +1,133 @@
+<%page args="course, enrollment, show_courseware_link, cert_status" />
+
+<%! from django.utils.translation import ugettext as _ %>
+<%!
+  from django.core.urlresolvers import reverse
+  from courseware.courses import course_image_url, get_course_about_section
+  from courseware.access import has_access
+  from certificates.models import CertificateStatuses
+  
+  from xmodule.modulestore import MONGO_MODULESTORE_TYPE
+  from xmodule.modulestore.django import modulestore
+
+  import waffle
+%>
+<li class="course-item">
+  <article class="course ${enrollment.mode}">
+    <%
+      if waffle.flag_is_active(request, 'merge_course_tabs'):
+          course_target = reverse('courseware', args=[course.id])
+      else:
+          course_target = reverse('info', args=[course.id])
+    %>
+
+    % if show_courseware_link:
+      <a href="${course_target}" class="cover">
+        <img src="${course_image_url(course)}" alt="${_('{course_number} {course_name} Cover Image').format(course_number=course.number, course_name=course.display_name_with_default) |h}" />
+      </a>
+    % else:
+      <div class="cover">
+        <img src="${course_image_url(course)}" alt="${_('{course_number} {course_name} Cover Image').format(course_number=course.number, course_name=course.display_name_with_default) | h}" />
+      </div>
+    % endif
+
+    % if enrollment.mode == "verified":
+    <span class="sts-enrollment">
+      <span class="label">${_("Enrolled as: ")}</span>
+      <img class="deco-graphic" src="${static.url('images/vcert-ribbon-s.png')}" alt="ID Verified Ribbon/Badge">
+      <span class="sts-enrollment-value">${_("ID Verified")}</span>
+    </span>
+    % endif
+
+    <section class="info">
+      <hgroup>
+        <p class="date-block">
+        % if course.has_ended():
+        ${_("Course Completed - {end_date}").format(end_date=course.end_date_text)}
+        % elif course.has_started():
+        ${_("Course Started - {start_date}").format(start_date=course.start_date_text)}
+        % else:   # hasn't started yet
+        ${_("Course Starts - {start_date}").format(start_date=course.start_date_text)}
+        % endif
+        </p>
+        <h2 class="university">${get_course_about_section(course, 'university')}</h2>
+        <h3>
+          % if show_courseware_link:
+            <a href="${course_target}">${course.display_number_with_default | h} ${course.display_name_with_default}</a>
+          % else:
+            <span>${course.display_number_with_default | h} ${course.display_name_with_default}</span>
+          % endif
+        </h3>
+      </hgroup>
+
+      % if course.has_ended() and cert_status:
+          <%
+          if cert_status['status'] == 'generating':
+              status_css_class = 'course-status-certrendering'
+          elif cert_status['status'] == 'ready':
+              status_css_class = 'course-status-certavailable'
+          elif cert_status['status'] == 'notpassing':
+              status_css_class = 'course-status-certnotavailable'
+          else:
+              status_css_class = 'course-status-processing'
+          %>
+          <div class="message message-status ${status_css_class} is-shown">
+
+          % if cert_status['status'] == 'processing':
+                <p class="message-copy">${_("Final course details are being wrapped up at this time. Your final standing will be available shortly.")}</p>
+          % elif cert_status['status'] in ('generating', 'ready', 'notpassing', 'restricted'):
+                <p class="message-copy">${_("Your final grade:")}
+                <span class="grade-value">${"{0:.0f}%".format(float(cert_status['grade'])*100)}</span>.
+                % if cert_status['status'] == 'notpassing':
+                   ${_("Grade required for a certificate:")} <span class="grade-value">
+                     ${"{0:.0f}%".format(float(course.lowest_passing_grade)*100)}</span>.
+                % elif cert_status['status'] == 'restricted':
+                    <p class="message-copy">
+                    ${_("Your certificate is being held pending confirmation that the issuance of your certificate is in compliance with strict U.S. embargoes on Iran, Cuba, Syria and Sudan. If you think our system has mistakenly identified you as being connected with one of those countries, please let us know by contacting {email}.").format(email='<a class="contact-link" href="mailto:{email}">{email}</a>.'.format(email=settings.CONTACT_EMAIL))}
+                    </p>
+                % endif
+                </p>
+          % endif
+
+          % if cert_status['show_disabled_download_button'] or cert_status['show_download_url'] or cert_status['show_survey_button']:
+            <ul class="actions">
+              % if cert_status['show_disabled_download_button']:
+                <li class="action"><span class="disabled">
+                    ${_("Your Certificate is Generating")}</span></li>
+              % elif cert_status['show_download_url']:
+                <li class="action">
+                <a class="btn" href="${cert_status['download_url']}"
+                   title="${_('This link will open/download a PDF document')}">
+                   Download Your PDF Certificate</a></li>
+              % endif
+
+              % if cert_status['show_survey_button']:
+                <li class="action"><a class="cta" href="${cert_status['survey_url']}">
+                       ${_('Complete our course feedback survey')}</a></li>
+              % endif
+            </ul>
+          % endif
+          </div>
+
+      % endif
+
+      % if show_courseware_link:
+        % if course.has_ended():
+          <a href="${course_target}" class="enter-course archived">${_('View Archived Course')}</a>
+        % else:
+          <a href="${course_target}" class="enter-course">${_('View Course')}</a>
+        % endif
+      % endif
+
+
+
+      <a href="#unenroll-modal" class="unenroll" rel="leanModal" data-course-id="${course.id}" data-course-number="${course.number}">${_('Unregister')}</a>
+
+% if settings.MITX_FEATURES['ENABLE_INSTRUCTOR_EMAIL'] and modulestore().get_modulestore_type(course.id) == MONGO_MODULESTORE_TYPE:
+  <!-- Only show the Email Settings link/modal if this course has bulk email feature enabled -->
+        <a href="#email-settings-modal" class="email-settings" rel="leanModal" data-course-id="${course.id}" data-course-number="${course.number}" data-optout="${course.id in course_optouts}">${_('Email Settings')}</a>
+% endif
+
+  </section>
+</article>
+</li>


### PR DESCRIPTION
- Removes all Pearson registration logic
- Refactors out the course tile/listing into its own template.

I've done some cursory verification to make sure that this doesn't break anything.

@ormsbee @talbs 
