### PR TITLE
Studio: Fix - HTML <body> class regressions

### DIFF
--- a/cms/templates/asset_index.html
+++ b/cms/templates/asset_index.html
@@ -3,7 +3,7 @@
 <%! from django.utils.translation import ugettext as _ %>
 
 <%block name="title">${_("Files &amp; Uploads")}</%block>
-<%block name="bodyclass">is-signedin course view-uploads</%block>
+<%block name="bodyclass">is-signedin course uploads view-uploads</%block>
 
 <%namespace name='static' file='static_content.html'/>
 


### PR DESCRIPTION
This work resolves the failed file/asset upload tests caused by #1192. An older class was added back in to the Files & Uploads view.
