### PR TITLE
Allow rake test to run individual tests again

### DIFF
--- a/cms/envs/test.py
+++ b/cms/envs/test.py
@@ -25,7 +25,6 @@ _report_dir = REPO_ROOT / 'reports' / _system
 _report_dir.makedirs_p()
 
 NOSE_ARGS = [
-    '--tests', PROJECT_ROOT / 'djangoapps', COMMON_ROOT / 'djangoapps',
     '--id-file', REPO_ROOT / '.testids' / _system / 'noseids',
     '--xunit-file', _report_dir / 'nosetests.xml',
 ]

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -51,7 +51,6 @@ _report_dir = REPO_ROOT / 'reports' / _system
 _report_dir.makedirs_p()
 
 NOSE_ARGS = [
-    '--tests', PROJECT_ROOT / 'djangoapps', COMMON_ROOT / 'djangoapps',
     '--id-file', REPO_ROOT / '.testids' / _system / 'noseids',
     '--xunit-file', _report_dir / 'nosetests.xml',
 ]

--- a/rakelib/tests.rake
+++ b/rakelib/tests.rake
@@ -17,7 +17,19 @@ def run_under_coverage(cmd, root)
 end
 
 def run_tests(system, report_dir, test_id=nil, stop_on_failure=true)
-    test_id = '' if test_id.nil?
+
+    # If no test id is provided, we need to limit the test runner
+    # to the Djangoapps we want to test.  Otherwise, it will
+    # run tests on all installed packages.
+    if test_id.nil?
+        test_id = "#{system}/djangoapps common/djangoapps"
+
+    # Handle "--failed" as a special case: we want to re-run only
+    # the tests that failed within our Django apps
+    elsif test_id == '--failed'
+        test_id = "#{system}/djangoapps common/djangoapps --failed"
+    end
+
     cmd = django_admin(system, :test, 'test', test_id)
     test_sh(run_under_coverage(cmd, system))
 end


### PR DESCRIPTION
This fixes a recent regression in rake test command.  Previously, you could specify an individual test or set of tests to run using `rake test[path/to/test]`.

We recently moved some of the nose arguments out of the rake file and into Django settings.  In particular, we added a flag `--tests` to limit the test runner to just LMS or CMS Django apps.  Otherwise, nose would find and run tests for all installed system packages.

Unfortunately, adding the `--tests` flag caused nose to ignore specific paths to test files, so it would always run all tests for LMS or CMS.

This PR moves the logic for determining the test suite back into the rake file, so we can control what the test runner will run.

As a side-effect of this change, calling `manage.py lms test` without specifying a Django app or path will cause the test runner to run everything, including tests in system packages.  I think this is a reasonable trade-off, but I'm open to discussion.

@brianhw @jzoldak 
