### PR TITLE
Modify acceptance tests to account for the new text_customization...

### DIFF
--- a/cms/djangoapps/contentstore/features/component_settings_editor_helpers.py
+++ b/cms/djangoapps/contentstore/features/component_settings_editor_helpers.py
@@ -65,13 +65,29 @@ def edit_component():
 
 @world.absorb
 def verify_setting_entry(setting, display_name, value, explicitly_set):
+    """
+    Verify the capa module fields are set as expected in the
+    Advanced Settings editor.
+
+    Parameters
+    ----------
+    setting: the WebDriverElement object found in the browser
+    display_name: the string expected as the label
+    value: the expected field value
+    explicitly_set: True if the value is expected to have been explicitly set
+        for the problem, rather than derived from the defaults. This is verified
+        by the existence of a "Clear" button next to the field value.
+    """
     assert_equal(display_name, setting.find_by_css('.setting-label')[0].value)
-    # Check specifically for the list type; it has a different structure
+
+    # Check if the web object is a list type
+    # If so, we use a slightly different mechanism for determining its value
     if setting.has_class('metadata-list-enum'):
         list_value = ', '.join(ele.value for ele in setting.find_by_css('.list-settings-item'))
         assert_equal(value, list_value)
     else:
         assert_equal(value, setting.find_by_css('.setting-input')[0].value)
+
     settingClearButton = setting.find_by_css('.setting-clear')[0]
     assert_equal(explicitly_set, settingClearButton.has_class('active'))
     assert_equal(not explicitly_set, settingClearButton.has_class('inactive'))

--- a/cms/djangoapps/contentstore/features/problem-editor.feature
+++ b/cms/djangoapps/contentstore/features/problem-editor.feature
@@ -5,7 +5,7 @@ Feature: CMS.Problem Editor
   Scenario: User can view metadata
     Given I have created a Blank Common Problem
     When I edit and select Settings
-    Then I see five alphabetized settings and their expected values
+    Then I see the advanced settings and their expected values
     And Edit High Level Source is not visible
 
   # Safari is having trouble saving the values on sauce

--- a/cms/djangoapps/contentstore/features/problem-editor.py
+++ b/cms/djangoapps/contentstore/features/problem-editor.py
@@ -10,9 +10,9 @@ MAXIMUM_ATTEMPTS = "Maximum Attempts"
 PROBLEM_WEIGHT = "Problem Weight"
 RANDOMIZATION = 'Randomization'
 SHOW_ANSWER = "Show Answer"
+TEXT_CUSTOMIZATION = "text_customization"
 
 
-############### ACTIONS ####################
 @step('I have created a Blank Common Problem$')
 def i_created_blank_common_problem(step):
     world.create_component_instance(
@@ -29,15 +29,16 @@ def i_edit_and_select_settings(step):
     world.edit_component_and_select_settings()
 
 
-@step('I see five alphabetized settings and their expected values$')
-def i_see_five_settings_with_values(step):
+@step('I see the advanced settings and their expected values$')
+def i_see_advanced_settings_with_values(step):
     world.verify_all_setting_entries(
         [
             [DISPLAY_NAME, "Blank Common Problem", True],
             [MAXIMUM_ATTEMPTS, "", False],
             [PROBLEM_WEIGHT, "", False],
             [RANDOMIZATION, "Never", False],
-            [SHOW_ANSWER, "Finished", False]
+            [SHOW_ANSWER, "Finished", False],
+            [TEXT_CUSTOMIZATION, "[object Object]", False]
         ])
 
 
@@ -159,7 +160,7 @@ def edit_high_level_source_links_visible(step):
 def cancel_does_not_save_changes(step):
     world.cancel_component(step)
     step.given("I edit and select Settings")
-    step.given("I see five alphabetized settings and their expected values")
+    step.given("I see the advanced settings and their expected values")
 
 
 @step('I have created a LaTeX Problem')


### PR DESCRIPTION
capa field.

@wedaly 

All tests passed in new jenkins: https://jenkins.testeng.edx.org/job/edx-all-tests-manual-pr/5/
