### PR TITLE
Use a forked version of lettuce that fixes a bug with tag inheritance

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -85,7 +85,6 @@ transifex-client==0.9.1
 # Used for testing
 coverage==3.6
 factory_boy==2.0.2
-lettuce==0.2.16
 mock==1.0.1
 nosexcover==1.0.7
 pep8==1.4.5

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -10,6 +10,7 @@
 -e git+https://github.com/edx/django-staticfiles.git@6d2504e5c8#egg=django-staticfiles
 -e git+https://github.com/edx/django-pipeline.git#egg=django-pipeline
 -e git+https://github.com/edx/django-wiki.git@41815e2ef1b0323f92900f8e60711b0f0c37766b#egg=django-wiki
+-e git+https://github.com/edx/lettuce.git@503fe2d2599290c45b021d6c424ab5ea899e42be#egg=lettuce
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev
 -e git+https://github.com/eventbrite/zendesk.git@d53fe0e81b623f084e91776bcf6369f8b7b63879#egg=zendesk
 


### PR DESCRIPTION
Lettuce had a bug in which tags applied to a Feature were not inherited by all scenarios.  They were inherited only by (a) the first scenario and (b) scenarios that already had tags.

I forked the repo, fixed the bug, and have updated our requirements to point to the fork.  This ensures that sharding by tag will work correctly.

To verify that this is working, run:

```
rake test:acceptance:lms["-v 3 --tag shard_1"]
```

You should see all scenarios for each feature execute (previously it would only execute some of them).

@dianakhuang could you review this?  There are some tests acceptance tests failing, but you can verify from the build results that it's running scenarios that were skipped before.
