### PR TITLE
Longer wait for video component to appear

### DIFF
--- a/cms/djangoapps/contentstore/features/video-editor.py
+++ b/cms/djangoapps/contentstore/features/video-editor.py
@@ -19,9 +19,14 @@ def set_show_captions(step, setting):
 @step('when I view the video it (.*) show the captions$')
 def shows_captions(_step, show_captions):
     world.wait_for_js_variable_truthy("Video")
-    world.wait(0.5)
+
     if show_captions == 'does not':
-        assert world.is_css_present('div.video.closed')
+
+        # 30 seconds is a long time to wait for the video to
+        # appear, but it seems to be necessary for this test to pass
+        # consistently.  If the video appears sooner, then this
+        # check won't wait the full 30 seconds.
+        assert world.is_css_present('div.video.closed', wait_time=30)
     else:
         assert world.is_css_not_present('div.video.closed')
 

--- a/cms/djangoapps/contentstore/features/video.py
+++ b/cms/djangoapps/contentstore/features/video.py
@@ -1,23 +1,37 @@
 #pylint: disable=C0111
 
 from lettuce import world, step
+from nose.tools import assert_equal
 from xmodule.modulestore import Location
 from contentstore.utils import get_modulestore
 
 
 @step('I have created a Video component$')
 def i_created_a_video_component(step):
-    world.create_component_instance(
-        step, '.large-video-icon',
-        'video',
-        '.xmodule_VideoModule',
-        has_multiple_templates=False
-    )
+
+    success = False
+    attempts = 0
+
+    # Occassionally, the first click will not create a video
+    # This is not an ideal solution, but it should improve stability
+    while not success and attempts < 2:
+        world.create_component_instance(
+            step, '.large-video-icon',
+            'video',
+            '.xmodule_VideoModule',
+            has_multiple_templates=False
+        )
+        success = world.is_css_present('div.video', wait_time=30)
+        attempts += 1
+
+    if not success:
+        assert_true(False, msg="Could not create video")
 
 
 @step('I have created a Video component with subtitles$')
 def i_created_a_video_with_subs(_step):
     _step.given('I have created a Video component with subtitles "OEoXaMPEzfM"')
+
 
 @step('I have created a Video component with subtitles "([^"]*)"$')
 def i_created_a_video_with_subs_with_name(_step, sub_id):


### PR DESCRIPTION
Fix for an acceptance test that would fail non-deterministically when it couldn't find `div.video.closed`

It appeared that the video was loading correctly, just not within the 10 second default timeout.  I set the timeout much higher (30 seconds) to improve stability -- if the video appears sooner, the test won't wait the full 30 seconds.  I don't know why the video is taking so long to load, but in the short term, I think this is a reasonable solution.

This also adds retry logic to the creation of a new video component.  I've observed that occasionally clicking the new video component immediately after the page loads doesn't work (I've tested it manually, and the delay is small enough that users would never notice).  Adding an explicit world.wait() is unreliable and inefficient, so I've added retry logic that clicks again if the video doesn't appear immediately.  Again, not ideal, but it should improve stability.

Reviewer: @auraz 
