### PR TITLE
Tie the USE_I18N setting to DEBUG setting

### DIFF
--- a/cms/envs/acceptance.py
+++ b/cms/envs/acceptance.py
@@ -79,11 +79,6 @@ DATABASES = {
 # Use the auto_auth workflow for creating users and logging them in
 MITX_FEATURES['AUTOMATIC_AUTH_FOR_TESTING'] = True
 
-# HACK
-# Setting this flag to false causes imports to not load correctly in the lettuce python files
-# We do not yet understand why this occurs. Setting this to true is a stopgap measure
-USE_I18N = True
-
 # Include the lettuce app for acceptance testing, including the 'harvest' django-admin command
 INSTALLED_APPS += ('lettuce.django',)
 LETTUCE_APPS = ('contentstore',)

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -218,7 +218,10 @@ STATICFILES_DIRS = [
 TIME_ZONE = 'America/New_York'  # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
 LANGUAGE_CODE = 'en'  # http://www.i18nguy.com/unicode/language-identifiers.html
 
-USE_I18N = False
+# We want i18n to be turned off in production, at least until we have full
+# localizations. It's disconcerting for everything on the page to be in English
+# except for one or two strings like "login" which are correctly localized.
+USE_I18N = DEBUG
 USE_L10N = True
 
 # Localization strings (e.g. django.po) are under this directory

--- a/lms/envs/acceptance.py
+++ b/lms/envs/acceptance.py
@@ -102,11 +102,6 @@ CC_PROCESSOR['CyberSource']['MERCHANT_ID'] = "edx"
 CC_PROCESSOR['CyberSource']['SERIAL_NUMBER'] = "0123456789012345678901"
 CC_PROCESSOR['CyberSource']['PURCHASE_ENDPOINT'] = "/shoppingcart/payment_fake"
 
-# HACK
-# Setting this flag to false causes imports to not load correctly in the lettuce python files
-# We do not yet understand why this occurs. Setting this to true is a stopgap measure
-USE_I18N = True
-
 MITX_FEATURES['ENABLE_FEEDBACK_SUBMISSION'] = True
 FEEDBACK_SUBMISSION_EMAIL = 'dummy@example.com'
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -454,7 +454,11 @@ FAVICON_PATH = 'images/favicon.ico'
 # Locale/Internationalization
 TIME_ZONE = 'America/New_York'  # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
 LANGUAGE_CODE = 'en'  # http://www.i18nguy.com/unicode/language-identifiers.html
-USE_I18N = False
+
+# We want i18n to be turned off in production, at least until we have full
+# localizations. It's disconcerting for everything on the page to be in English
+# except for one or two strings like "login" which are correctly localized.
+USE_I18N = DEBUG
 USE_L10N = True
 
 # Localization strings (e.g. django.po) are under this directory


### PR DESCRIPTION
We want USE_I18N to be on in development, but off in production. Tying
this setting to the DEBUG setting accomplishes that neatly.
