### PR TITLE
Don't remove course update when clicking outside modal.

### DIFF
--- a/cms/static/js/views/course_info_update.js
+++ b/cms/static/js/views/course_info_update.js
@@ -2,7 +2,6 @@ define(["backbone", "underscore", "codemirror", "js/models/course_update",
     "js/views/feedback_prompt", "js/views/feedback_notification", "js/views/course_info_helper"],
     function(Backbone, _, CodeMirror, CourseUpdateModel, PromptView, NotificationView, CourseInfoHelper) {
 
-    var $modalCover = $(".modal-cover");
     var CourseInfoUpdateView = Backbone.View.extend({
         // collection is CourseUpdateCollection
         events: {
@@ -18,6 +17,8 @@ define(["backbone", "underscore", "codemirror", "js/models/course_update",
             this.render();
             // when the client refetches the updates as a whole, re-render them
             this.listenTo(this.collection, 'reset', this.render);
+
+            this.$modalCover = $(".modal-cover");
         },
 
         render: function () {
@@ -63,8 +64,8 @@ define(["backbone", "underscore", "codemirror", "js/models/course_update",
             $newForm.addClass('editing');
             this.$currentPost = $newForm.closest('li');
 
-            $modalCover.show();
-            $modalCover.bind('click', function() {
+            this.$modalCover.show();
+            this.$modalCover.bind('click', function() {
                 self.closeEditor(true);
             });
 
@@ -120,9 +121,9 @@ define(["backbone", "underscore", "codemirror", "js/models/course_update",
             this.$codeMirror = CourseInfoHelper.editWithCodeMirror(
                 targetModel, 'content', self.options['base_asset_url'], $textArea.get(0));
 
-            $modalCover.show();
-            $modalCover.bind('click', function() {
-                self.closeEditor(self);
+            this.$modalCover.show();
+            this.$modalCover.bind('click', function() {
+                self.closeEditor(false);
             });
         },
 
@@ -197,8 +198,8 @@ define(["backbone", "underscore", "codemirror", "js/models/course_update",
                 this.$currentPost.find('.CodeMirror').remove();
             }
 
-            $modalCover.unbind('click');
-            $modalCover.hide();
+            this.$modalCover.unbind('click');
+            this.$modalCover.hide();
             this.$codeMirror = null;
         },
 


### PR DESCRIPTION
Fixes bug STUD-822.

@dmitchell Please review. The acceptance test that failed is unrelated to the change (I reported it to Will).

Note that the bug fix is the one-word change to pass false to closeEditor instead of self. I had to change how the modalCover variable was defined so that I could unit test the bug fix. When I first wrote the tests, they were trivially passing in the "click outside of modal" case because that wasn't actually closing the dialog (variable was undefined when the test ran). I added the spy checks to show and hide to make sure the modalCover is really being used.
