### PR TITLE
Disable non-deterministic test to get stability on master

### DIFF
--- a/cms/djangoapps/contentstore/features/video-editor.feature
+++ b/cms/djangoapps/contentstore/features/video-editor.feature
@@ -15,12 +15,17 @@ Feature: CMS.Video Component Editor
     Then I can modify the display name
     And my video display name change is persisted on save
 
+  # Disabling this 10/7/13 due to nondeterministic behavior
+  # in master.  The failure seems to occur when YouTube does
+  # not respond quickly enough, so that the video player
+  # doesn't load.
+  #
   # Sauce Labs cannot delete cookies
-  @skip_sauce
-  Scenario: Captions are hidden when "show captions" is false
-    Given I have created a Video component with subtitles
-    And I have set "show captions" to False
-    Then when I view the video it does not show the captions
+  #  @skip_sauce
+  #Scenario: Captions are hidden when "show captions" is false
+  #  Given I have created a Video component with subtitles
+  #  And I have set "show captions" to False
+  #  Then when I view the video it does not show the captions
 
   # Sauce Labs cannot delete cookies
   @skip_sauce


### PR DESCRIPTION
Sad to do this, but I think it's necessary to get stability on master.  I'll create backlog items to ensure that we don't forget to circle back and fix this.

@jzoldak @cahrens what do you think?
