### PR TITLE
Use wait_for to allow course image time to update

### DIFF
--- a/cms/djangoapps/contentstore/features/course-settings.py
+++ b/cms/djangoapps/contentstore/features/course-settings.py
@@ -151,9 +151,10 @@ def i_see_new_course_image(_step):
     assert len(images) == 1
     img = images[0]
     expected_src = '/c4x/MITx/999/asset/image.jpg'
+
     # Don't worry about the domain in the URL
-    assert img['src'].endswith(expected_src), "Was looking for {expected}, found {actual}".format(
-        expected=expected_src, actual=img['src'])
+    success_func = lambda _: img['src'].endswith(expected_src)
+    world.wait_for(success_func)
 
 
 @step('the image URL should be present in the field')


### PR DESCRIPTION
I can't reproduce this failure locally, but it's occurred in Jenkins:

```
AssertionError: Was looking for /c4x/MITx/999/asset/image.jpg,
found http://127.0.0.1:46777/c4x/MITx/999/asset/images_course_image.jpg
```

This is a possible fix, and a better option than #1242 

@cahrens Does it make sense to merge this first, then #1242 if we see another failure?
