### PR TITLE
Remove unnecessary call from wordcloud test

### DIFF
--- a/lms/djangoapps/courseware/features/word_cloud.py
+++ b/lms/djangoapps/courseware/features/word_cloud.py
@@ -33,8 +33,6 @@ def view_word_cloud(_step):
 @step('I press the Save button')
 def press_the_save_button(_step):
     button_css = '.input_cloud_section input.save'
-    elem = world.css_find(button_css).first
-    world.css_has_text(button_css, elem)
     world.css_click(button_css)
 
 


### PR DESCRIPTION
The WordCloud acceptance test was calling `world.css_has_text` without actually making an assertion.  When I refactored `css_has_text` to wait for the element to be non-blank, this caused the tests to time out.

Since `world.css_has_text` wasn't being used to assert anything and since `world.css_click` now has logic to wait for the button to be visible, I'm removing the call.

@jzoldak 
