### PR TITLE
we are already being passed in the module descriptor so we don't need to...

### DIFF
--- a/lms/djangoapps/courseware/grades.py
+++ b/lms/djangoapps/courseware/grades.py
@@ -283,7 +283,7 @@ def progress_summary(student, request, course, field_data_cache):
 
     # TODO: We need the request to pass into here. If we could forego that, our arguments
     # would be simpler
-    course_module = get_module(student, request, course.location, field_data_cache, course.id, depth=None)
+    course_module = get_module_for_descriptor(student, request, course, field_data_cache, course.id)
     if not course_module:
         # This student must not have access to the course.
         return None


### PR DESCRIPTION
... re-fetch it (and children)
