### PR TITLE
updating boto to get boto.elasticache.layer1

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -10,7 +10,7 @@ beautifulsoup4==4.1.3
 beautifulsoup==3.2.1
 bleach==1.2.2
 html5lib==0.95
-boto==2.6.0
+boto==2.13.3
 celery==3.0.19
 dealer==0.2.3
 distribute>=0.6.28, <0.7


### PR DESCRIPTION
@wedaly @jzoldak @rocha We are many versions behind the latest of boto and I'd like to upgrade.  This pulls in some features we are using and numerous bug fixes, none of which is urgent.

The tests pass, but I'm not sure what our coverage is for boto related features.
