### PR TITLE
Fix static links for footer images

### DIFF
--- a/lms/djangoapps/branding/__init__.py
+++ b/lms/djangoapps/branding/__init__.py
@@ -47,8 +47,10 @@ def get_logo_url(domain=None):
     university = get_university(domain)
 
     if university is None:
-        return '/static/images/header-logo.png'
+        return '{static_url}images/header-logo.png'.format(
+            static_url=settings.STATIC_URL
+        )
 
-    return '/static/images/{uni}-on-edx-logo.png'.format(
-        uni=university
+    return '{static_url}images/{uni}-on-edx-logo.png'.format(
+        static_url=settings.STATIC_URL, uni=university
     )

--- a/lms/templates/footer.html
+++ b/lms/templates/footer.html
@@ -37,7 +37,7 @@
       </nav>
 
       <div class="colophon-about">
-        <img src="${MITX_ROOT_URL}/lms/static/images/header-logo.png" />
+        <img src="${static.url('images/header-logo.png')}" />
 
         <p>${_("{platform_name} is a non-profit created by founding partners {Harvard} and {MIT} whose mission is to bring the best of higher education to students of all ages anywhere in the world, wherever there is Internet access. {platform_name}'s free online MOOCs are interactive and subjects include computer science, public health, and artificial intelligence.").format(platform_name="EdX", Harvard="Harvard", MIT="MIT")}</p>
       </div>

--- a/lms/templates/registration/password_reset_complete.html
+++ b/lms/templates/registration/password_reset_complete.html
@@ -44,7 +44,7 @@
 <header class="global">
   <nav>
     <h1 class="logo">
-      <a href="{{MKTG_URL_ROOT}}"><img src="/static/images/header-logo.png"></a>
+      <a href="{{MKTG_URL_ROOT}}"><img src="${static.url('images/header-logo.png')}"></a>
     </h1>
   </nav>
 </header>

--- a/lms/templates/registration/password_reset_confirm.html
+++ b/lms/templates/registration/password_reset_confirm.html
@@ -48,7 +48,7 @@
 <header class="global">
   <nav>
     <h1 class="logo">
-      <a href="{{MKTG_URL_ROOT}}"><img src="/static/images/header-logo.png"></a>
+      <a href="{{MKTG_URL_ROOT}}"><img src="${static.url('images/header-logo.png')}"></a>
     </h1>
   </nav>
 </header>


### PR DESCRIPTION
Our edX image in the footer is hardcoding static links, which may cause broken images. This pull-request corrects that.
