### PR TITLE
Defined baseUrl in the LMS template

### DIFF
--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -36,6 +36,7 @@
           if (window.location !== window.top.location) {
             window.top.location = window.location;
           }
+          window.baseUrl = "${settings.STATIC_URL}";
         })(this);
       </script>
     % endif


### PR DESCRIPTION
fixing a bug where HTML editors called within LMS would fail to load
