### PR TITLE
Change the default FROM address for bulk email

### DIFF
--- a/lms/djangoapps/bulk_email/tasks.py
+++ b/lms/djangoapps/bulk_email/tasks.py
@@ -142,7 +142,16 @@ def _send_course_email(email_id, to_list, course_title, course_url, image_url, t
     subject = "[" + course_title + "] " + msg.subject
 
     course_title_no_quotes = re.sub(r'"', '', course_title)
-    from_addr = '"{0}" Course Staff <{1}>'.format(course_title_no_quotes, settings.DEFAULT_BULK_FROM_EMAIL)
+    course_num = msg.course_id.split('/')[1]  # course_id = 'org/course_num/run'
+    # Substitute a '_' anywhere a non-(ascii, period, or dash) character appears.
+    INVALID_CHARS = re.compile(r"[^\w.-]")
+    course_num = INVALID_CHARS.sub('_', course_num)
+
+    # Make a unique from name and address for each course, eg
+    # "COURSE_TITLE" Course Staff <coursenum-no-reply@courseupdates.edx.org>
+    from_addr = '"{0}" Course Staff <{1}-{2}>'.format(
+        course_title_no_quotes, course_num, settings.DEFAULT_BULK_FROM_EMAIL
+    )
 
     course_email_template = CourseEmailTemplate.get_template()
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -428,7 +428,7 @@ IGNORABLE_404_ENDS = ('favicon.ico')
 # Email
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 DEFAULT_FROM_EMAIL = 'registration@edx.org'
-DEFAULT_BULK_FROM_EMAIL = 'course-updates@edx.org'
+DEFAULT_BULK_FROM_EMAIL = 'no-reply@courseupdates.edx.org'
 EMAILS_PER_TASK = 100
 EMAILS_PER_QUERY = 1000
 DEFAULT_FEEDBACK_EMAIL = 'feedback@edx.org'


### PR DESCRIPTION
With https://edx-wiki.atlassian.net/browse/TKTS-336 we have a new subdomain to send email from.

Additionally, per conversation with devops, making a unique from address for each course will allow us to better track bounces and spam labelling.

@brianhw 
