### PR TITLE
Add variable to set location of config files on aws

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -12,20 +12,24 @@ from .common import *
 from logsettings import get_logger_config
 import os
 
-# specified as an environment variable.  Typically this is set
-# in the service's upstart script and corresponds exactly to the service name.
-# Service variants apply config differences via env and auth JSON files,
-# the names of which correspond to the variant.
+
+# SERVICE_VARIANT specifies name of the variant used, which decides what JSON
+# configuration files are read during startup.
 SERVICE_VARIANT = os.environ.get('SERVICE_VARIANT', None)
 
-# when not variant is specified we attempt to load an unvaried
-# config set.
-CONFIG_PREFIX = ""
+# CONFIG_ROOT specifies the directory where the JSON configuration
+# files are expected to be found. If not specified, use the project
+# directory.
+CONFIG_ROOT = os.environ.get('CONFIG_ROOT', ENV_ROOT)
 
-if SERVICE_VARIANT:
-    CONFIG_PREFIX = SERVICE_VARIANT + "."
+# CONFIG_PREFIX specifies the prefix of the JSON configuration files,
+# based on the service variant. If no variant is use, don't use a
+# prefix.
+CONFIG_PREFIX = SERVICE_VARIANT + "." if SERVICE_VARIANT else ""
+
 
 ############### ALWAYS THE SAME ################################
+
 DEBUG = False
 TEMPLATE_DEBUG = False
 
@@ -77,7 +81,7 @@ CELERY_QUEUES = {
 
 ############# NON-SECURE ENV CONFIG ##############################
 # Things like server locations, ports, etc.
-with open(ENV_ROOT / CONFIG_PREFIX + "env.json") as env_file:
+with open(CONFIG_ROOT / CONFIG_PREFIX + "env.json") as env_file:
     ENV_TOKENS = json.load(env_file)
 
 EMAIL_BACKEND = ENV_TOKENS.get('EMAIL_BACKEND', EMAIL_BACKEND)
@@ -134,7 +138,7 @@ if "TRACKING_IGNORE_URL_PATTERNS" in ENV_TOKENS:
 
 ################ SECURE AUTH ITEMS ###############################
 # Secret things: passwords, access keys, etc.
-with open(ENV_ROOT / CONFIG_PREFIX + "auth.json") as auth_file:
+with open(CONFIG_ROOT / CONFIG_PREFIX + "auth.json") as auth_file:
     AUTH_TOKENS = json.load(auth_file)
 
 # If Segment.io key specified, load it and turn on Segment.io if the feature flag is set

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -17,18 +17,20 @@ from .common import *
 from logsettings import get_logger_config
 import os
 
-# specified as an environment variable.  Typically this is set
-# in the service's upstart script and corresponds exactly to the service name.
-# Service variants apply config differences via env and auth JSON files,
-# the names of which correspond to the variant.
+
+# SERVICE_VARIANT specifies name of the variant used, which decides what JSON
+# configuration files are read during startup.
 SERVICE_VARIANT = os.environ.get('SERVICE_VARIANT', None)
 
-# when not variant is specified we attempt to load an unvaried
-# config set.
-CONFIG_PREFIX = ""
+# CONFIG_ROOT specifies the directory where the JSON configuration
+# files are expected to be found. If not specified, use the project
+# directory.
+CONFIG_ROOT = os.environ.get('CONFIG_ROOT', ENV_ROOT)
 
-if SERVICE_VARIANT:
-    CONFIG_PREFIX = SERVICE_VARIANT + "."
+# CONFIG_PREFIX specifies the prefix of the JSON configuration files,
+# based on the service variant. If no variant is use, don't use a
+# prefix.
+CONFIG_PREFIX = SERVICE_VARIANT + "." if SERVICE_VARIANT else ""
 
 
 ################################ ALWAYS THE SAME ##############################
@@ -96,7 +98,7 @@ CELERY_QUEUES = {
 ########################## NON-SECURE ENV CONFIG ##############################
 # Things like server locations, ports, etc.
 
-with open(ENV_ROOT / CONFIG_PREFIX + "env.json") as env_file:
+with open(CONFIG_ROOT / CONFIG_PREFIX + "env.json") as env_file:
     ENV_TOKENS = json.load(env_file)
 
 PLATFORM_NAME = ENV_TOKENS.get('PLATFORM_NAME', PLATFORM_NAME)
@@ -198,7 +200,7 @@ if "TRACKING_IGNORE_URL_PATTERNS" in ENV_TOKENS:
 ############################## SECURE AUTH ITEMS ###############
 # Secret things: passwords, access keys, etc.
 
-with open(ENV_ROOT / CONFIG_PREFIX + "auth.json") as auth_file:
+with open(CONFIG_ROOT / CONFIG_PREFIX + "auth.json") as auth_file:
     AUTH_TOKENS = json.load(auth_file)
 
 ############### Mixed Related(Secure/Not-Secure) Items ##########


### PR DESCRIPTION
The env variable CONFIG_ROOT is used to determine the location of the
JSON configuration files. This is useful when a deployment of the
platform is used to access different environments when executing django
commands.
