### PR TITLE
Clarify USE_I18N settings

### DIFF
--- a/cms/envs/acceptance.py
+++ b/cms/envs/acceptance.py
@@ -79,6 +79,11 @@ DATABASES = {
 # Use the auto_auth workflow for creating users and logging them in
 MITX_FEATURES['AUTOMATIC_AUTH_FOR_TESTING'] = True
 
+# HACK
+# Setting this flag to false causes imports to not load correctly in the lettuce python files
+# We do not yet understand why this occurs. Setting this to true is a stopgap measure
+USE_I18N = True
+
 # Include the lettuce app for acceptance testing, including the 'harvest' django-admin command
 INSTALLED_APPS += ('lettuce.django',)
 LETTUCE_APPS = ('contentstore',)

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -218,9 +218,11 @@ STATICFILES_DIRS = [
 TIME_ZONE = 'America/New_York'  # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
 LANGUAGE_CODE = 'en'  # http://www.i18nguy.com/unicode/language-identifiers.html
 
-# We want i18n to be turned off in production, at least until we have full
-# localizations. It's disconcerting for everything on the page to be in English
-# except for one or two strings like "login" which are correctly localized.
+# We want i18n to be turned off in production, at least until we have full localizations.
+# Thus we want the Django translation engine to be disabled. Otherwise even without
+# localization files, if the user's browser is set to a language other than us-en,
+# strings like "login" and "password" will be translated and the rest of the page will be
+# in English, which is confusing.
 USE_I18N = False
 USE_L10N = True
 

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -221,7 +221,7 @@ LANGUAGE_CODE = 'en'  # http://www.i18nguy.com/unicode/language-identifiers.html
 # We want i18n to be turned off in production, at least until we have full
 # localizations. It's disconcerting for everything on the page to be in English
 # except for one or two strings like "login" which are correctly localized.
-USE_I18N = DEBUG
+USE_I18N = False
 USE_L10N = True
 
 # Localization strings (e.g. django.po) are under this directory

--- a/cms/envs/dev.py
+++ b/cms/envs/dev.py
@@ -9,6 +9,7 @@ from .common import *
 from logsettings import get_logger_config
 
 DEBUG = True
+USE_I18N = True
 TEMPLATE_DEBUG = DEBUG
 LOGGING = get_logger_config(ENV_ROOT / "log",
                             logging_env="dev",

--- a/lms/envs/acceptance.py
+++ b/lms/envs/acceptance.py
@@ -102,6 +102,11 @@ CC_PROCESSOR['CyberSource']['MERCHANT_ID'] = "edx"
 CC_PROCESSOR['CyberSource']['SERIAL_NUMBER'] = "0123456789012345678901"
 CC_PROCESSOR['CyberSource']['PURCHASE_ENDPOINT'] = "/shoppingcart/payment_fake"
 
+# HACK
+# Setting this flag to false causes imports to not load correctly in the lettuce python files
+# We do not yet understand why this occurs. Setting this to true is a stopgap measure
+USE_I18N = True
+
 MITX_FEATURES['ENABLE_FEEDBACK_SUBMISSION'] = True
 FEEDBACK_SUBMISSION_EMAIL = 'dummy@example.com'
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -455,9 +455,11 @@ FAVICON_PATH = 'images/favicon.ico'
 TIME_ZONE = 'America/New_York'  # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
 LANGUAGE_CODE = 'en'  # http://www.i18nguy.com/unicode/language-identifiers.html
 
-# We want i18n to be turned off in production, at least until we have full
-# localizations. It's disconcerting for everything on the page to be in English
-# except for one or two strings like "login" which are correctly localized.
+# We want i18n to be turned off in production, at least until we have full localizations.
+# Thus we want the Django translation engine to be disabled. Otherwise even without
+# localization files, if the user's browser is set to a language other than us-en,
+# strings like "login" and "password" will be translated and the rest of the page will be
+# in English, which is confusing.
 USE_I18N = False
 USE_L10N = True
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -458,7 +458,7 @@ LANGUAGE_CODE = 'en'  # http://www.i18nguy.com/unicode/language-identifiers.html
 # We want i18n to be turned off in production, at least until we have full
 # localizations. It's disconcerting for everything on the page to be in English
 # except for one or two strings like "login" which are correctly localized.
-USE_I18N = DEBUG
+USE_I18N = False
 USE_L10N = True
 
 # Localization strings (e.g. django.po) are under this directory

--- a/lms/envs/dev.py
+++ b/lms/envs/dev.py
@@ -16,6 +16,7 @@ from .common import *
 from logsettings import get_logger_config
 
 DEBUG = True
+USE_I18N = True
 TEMPLATE_DEBUG = True
 
 


### PR DESCRIPTION
@jzoldak showed me that setting `USE_I18N = DEBUG` didn't actually accomplish
what I had hoped it would -- changing DEBUG didn't also change USE_I18N.
This pull request accomplishes what I was trying to accomplish, without being
quite so clever about it.
