### PR TITLE
Use a better metadata_cache_key

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -246,7 +246,9 @@ def location_to_query(location, wildcard=True):
     return query
 
 
-metadata_cache_key = attrgetter('org', 'course')
+def metadata_cache_key(location):
+    """Turn a `Location` into a useful cache key."""
+    return u"{0.org}/{0.course}".format(location)
 
 
 class MongoModuleStore(ModuleStoreBase):


### PR DESCRIPTION
The old code created keys like "('course', 'org')", and the space
character caused a warning from Django during tests.  Also, strings are
probably better than tuples for keys.
