### PR TITLE
Defined baseUrl in the legacy instructor dashboard template

### DIFF
--- a/lms/templates/courseware/instructor_dashboard.html
+++ b/lms/templates/courseware/instructor_dashboard.html
@@ -15,6 +15,9 @@
   <script type="text/javascript" src="${static.url('js/vendor/tiny_mce/jquery.tinymce.js')}"></script>
   <script type="text/javascript" src="${static.url('js/vendor/CodeMirror/htmlmixed.js')}"></script>
   <script type="text/javascript" src="${static.url('js/vendor/CodeMirror/css.js')}"></script>
+  <script type="text/javascript">
+    (function() {window.baseUrl = "${settings.STATIC_URL}";})(this);
+  </script>
   <%static:js group='module-descriptor-js'/>
 %if instructor_tasks is not None:
   <script type="text/javascript" src="${static.url('js/pending_tasks.js')}"></script>


### PR DESCRIPTION
Defined baseURL in the legacy instructor dashboard template, fixing a bug where the HTML editor fails to load.

This is similar to https://github.com/edx/edx-platform/pull/1258 , but fixes the HTML editor on the _legacy_ dashboard (the previous commit only fixed it on the beta dashboard).
