### PR TITLE
Allow instructors to specify minimums for peer and AI scoring

### DIFF
--- a/common/lib/xmodule/xmodule/combined_open_ended_module.py
+++ b/common/lib/xmodule/xmodule/combined_open_ended_module.py
@@ -6,7 +6,10 @@ from pkg_resources import resource_string
 from xmodule.raw_module import RawDescriptor
 from .x_module import XModule
 from xblock.fields import Integer, Scope, String, List, Float, Boolean
-from xmodule.open_ended_grading_classes.combined_open_ended_modulev1 import CombinedOpenEndedV1Module, CombinedOpenEndedV1Descriptor
+from xmodule.open_ended_grading_classes.combined_open_ended_modulev1 import (
+    CombinedOpenEndedV1Module, CombinedOpenEndedV1Descriptor,
+    STAFF_DEFAULT_FOR_AI_GRADING, STAFF_DEFAULT_FOR_PEER_GRADING
+)
 from collections import namedtuple
 from .fields import Date, Timedelta
 import textwrap
@@ -27,6 +30,8 @@ V1_SETTINGS_ATTRIBUTES = [
     "peer_grader_count",
     "required_peer_grading",
     "peer_grade_finished_submissions_when_none_pending",
+    "staff_minimum_for_peer_grading",
+    "staff_minimum_for_ai_grading",
 ]
 
 V1_STUDENT_ATTRIBUTES = [
@@ -303,6 +308,20 @@ class CombinedOpenEndedFields(object):
         default=3,
         scope=Scope.settings,
         values={"min": 1, "step": "1", "max": 5}
+    )
+    staff_minimum_for_peer_grading = Integer(
+        display_name="Staff Grading Needed For Peer Grading",
+        help="The number of responses that need to be staff graded before peer grading can start.  Must be higher than the maximum number of calibration essays shown to peer graders (specified by the Maximum Peer Grading Calibrations setting).",
+        default=STAFF_DEFAULT_FOR_PEER_GRADING,
+        scope=Scope.settings,
+        values={"min": 1, "step": "1", "max": 50}
+    )
+    staff_minimum_for_ai_grading = Integer(
+        display_name="Staff Grading Needed For AI Grading",
+        help="The number of responses that need to be staff graded before AI grading can start.  Must be higher than 50.  At least 100 is recommended.",
+        default=STAFF_DEFAULT_FOR_AI_GRADING,
+        scope=Scope.settings,
+        values={"min": 50, "step": "1", "max": 300}
     )
     peer_grade_finished_submissions_when_none_pending = Boolean(
         display_name='Allow "overgrading" of peer submissions',

--- a/common/lib/xmodule/xmodule/open_ended_grading_classes/combined_open_ended_modulev1.py
+++ b/common/lib/xmodule/xmodule/open_ended_grading_classes/combined_open_ended_modulev1.py
@@ -29,6 +29,12 @@ IS_SCORED = False
 # Metadata overrides this.
 ACCEPT_FILE_UPLOAD = False
 
+# The default number of essays that need to be scored by staff to enable AI scoring.
+STAFF_DEFAULT_FOR_AI_GRADING = 100
+
+# The default number of essays that need to be scored by staff to enable peer scoring.
+STAFF_DEFAULT_FOR_PEER_GRADING = 10
+
 # Contains all reasonable bool and case combinations of True
 TRUE_DICT = ["True", True, "TRUE", "true"]
 
@@ -130,6 +136,8 @@ class CombinedOpenEndedV1Module():
         self.peer_grade_finished_submissions_when_none_pending = instance_state.get(
             'peer_grade_finished_submissions_when_none_pending', False
         )
+        self.staff_minimum_for_peer_grading = instance_state.get('staff_minimum_for_peer_grading', STAFF_DEFAULT_FOR_PEER_GRADING)
+        self.staff_minimum_for_ai_grading = instance_state.get('staff_minimum_for_ai_grading', STAFF_DEFAULT_FOR_AI_GRADING)
 
         due_date = instance_state.get('due', None)
 
@@ -164,6 +172,8 @@ class CombinedOpenEndedV1Module():
                 'peer_grade_finished_submissions_when_none_pending': (
                     self.peer_grade_finished_submissions_when_none_pending
                 ),
+                'staff_minimum_for_peer_grading': self.staff_minimum_for_peer_grading,
+                'staff_minimum_for_ai_grading': self.staff_minimum_for_ai_grading,
             }
         }
 

--- a/common/lib/xmodule/xmodule/tests/test_combined_open_ended.py
+++ b/common/lib/xmodule/xmodule/tests/test_combined_open_ended.py
@@ -18,7 +18,9 @@ from webob.multidict import MultiDict
 
 from xmodule.open_ended_grading_classes.openendedchild import OpenEndedChild
 from xmodule.open_ended_grading_classes.open_ended_module import OpenEndedModule
-from xmodule.open_ended_grading_classes.combined_open_ended_modulev1 import CombinedOpenEndedV1Module
+from xmodule.open_ended_grading_classes.combined_open_ended_modulev1 import (
+    CombinedOpenEndedV1Module, STAFF_DEFAULT_FOR_AI_GRADING, STAFF_DEFAULT_FOR_PEER_GRADING
+)
 from xmodule.open_ended_grading_classes.grading_service_module import GradingServiceError
 from xmodule.combined_open_ended_module import CombinedOpenEndedModule
 from xmodule.modulestore import Location
@@ -76,6 +78,8 @@ class OpenEndedChildTest(unittest.TestCase):
             'min_to_calibrate': 3,
             'max_to_calibrate': 6,
             'peer_grade_finished_submissions_when_none_pending': False,
+            'staff_minimum_for_peer_grading': STAFF_DEFAULT_FOR_PEER_GRADING,
+            'staff_minimum_for_ai_grading': STAFF_DEFAULT_FOR_AI_GRADING,
         }
     }
     definition = Mock()

--- a/common/lib/xmodule/xmodule/tests/test_self_assessment.py
+++ b/common/lib/xmodule/xmodule/tests/test_self_assessment.py
@@ -5,6 +5,9 @@ from webob.multidict import MultiDict
 
 from xmodule.open_ended_grading_classes.self_assessment_module import SelfAssessmentModule
 from xmodule.modulestore import Location
+from xmodule.open_ended_grading_classes.combined_open_ended_modulev1 import (
+    STAFF_DEFAULT_FOR_AI_GRADING, STAFF_DEFAULT_FOR_PEER_GRADING
+)
 from lxml import etree
 
 from . import get_test_system
@@ -51,7 +54,9 @@ class SelfAssessmentTest(unittest.TestCase):
                 'min_to_calibrate': 3,
                 'max_to_calibrate': 6,
                 'peer_grade_finished_submissions_when_none_pending': False,
-            }
+                'staff_minimum_for_peer_grading': STAFF_DEFAULT_FOR_PEER_GRADING,
+                'staff_minimum_for_ai_grading': STAFF_DEFAULT_FOR_AI_GRADING,
+                }
         }
 
         system = get_test_system()


### PR DESCRIPTION
Settings that allow instructors to specify how many submissions should go to them before peer or AI kick in.  

https://github.com/edx/edx-ora/pull/144  enables this on the ORA side.

@brianhw Please look when you can.
