### PR TITLE
Fix for a sass cleanup issue on the Studio sign in page

### DIFF
--- a/cms/static/sass/views/_account.scss
+++ b/cms/static/sass/views/_account.scss
@@ -233,13 +233,6 @@
 
     }
   }
-}
-
-.signup {
-
-}
-
-.signin {
 
   #field-password {
     position: relative;


### PR DESCRIPTION
This is a quick fix for a bug I found on the Studio sign-in page from some of the sass cleanup (specifically, the "forgot password" link was no longer in the right place). @talbs and @cahrens can you review (round 2)?
