### PR TITLE
Studio: FIX - Cutting the Tender Tag

### DIFF
--- a/cms/static/sass/elements/_tender-widget.scss
+++ b/cms/static/sass/elements/_tender-widget.scss
@@ -1,6 +1,11 @@
 // tender help/support widget
 // ====================
 
+// UI: hiding the default tender help "tag" element
+#tender_toggler {
+  display: none;
+}
+
 #tender_frame, #tender_window {
   background-image: none !important;
   background: none;


### PR DESCRIPTION
visually hides the tender widget tag UI, again
