### PR TITLE
Added two states to HD control: HD off - HD on

### DIFF
--- a/common/lib/xmodule/xmodule/js/fixtures/video.html
+++ b/common/lib/xmodule/xmodule/js/fixtures/video.html
@@ -45,7 +45,7 @@
                     </div>
                   </div>
                   <a href="#" class="add-fullscreen" title="Fill browser" role="button" aria-disabled="false">Fill Browser</a>
-                  <a href="#" class="quality_control" title="HD" role="button" aria-disabled="false">HD</a>
+                  <a href="#" class="quality_control" title="HD off" role="button" aria-disabled="false">HD off</a>
                   <a href="#" class="hide-subtitles" title="Turn off captions" role="button" aria-disabled="false">Captions</a>
                 </div>
               </div>

--- a/common/lib/xmodule/xmodule/js/fixtures/video_all.html
+++ b/common/lib/xmodule/xmodule/js/fixtures/video_all.html
@@ -48,7 +48,7 @@
                     </div>
                   </div>
                   <a href="#" class="add-fullscreen" title="Fill browser" role="button" aria-disabled="false">Fill Browser</a>
-                  <a href="#" class="quality_control" title="HD" role="button" aria-disabled="false">HD</a>
+                  <a href="#" class="quality_control" title="HD off" role="button" aria-disabled="false">HD off</a>
                   <a href="#" class="hide-subtitles" title="Turn off captions" role="button" aria-disabled="false">Captions</a>
                 </div>
               </div>

--- a/common/lib/xmodule/xmodule/js/fixtures/video_yt_multiple.html
+++ b/common/lib/xmodule/xmodule/js/fixtures/video_yt_multiple.html
@@ -45,7 +45,7 @@
                     </div>
                   </div>
                   <a href="#" class="add-fullscreen" title="Fill browser" role="button" aria-disabled="false">Fill Browser</a>
-                  <a href="#" class="quality_control" title="HD" role="button" aria-disabled="false">HD</a>
+                  <a href="#" class="quality_control" title="HD off" role="button" aria-disabled="false">HD off</a>
                   <a href="#" class="hide-subtitles" title="Turn off captions" role="button" aria-disabled="false">Captions</a>
                 </div>
               </div>

--- a/common/lib/xmodule/xmodule/js/src/video/05_video_quality_control.js
+++ b/common/lib/xmodule/xmodule/js/src/video/05_video_quality_control.js
@@ -59,16 +59,22 @@ function () {
     // ***************************************************************
 
     function onQualityChange(value) {
+        var controlStateStr;
         this.videoQualityControl.quality = value;
 
         if (_.indexOf(this.config.availableQualities, value) !== -1) {
-            this.videoQualityControl.el.addClass('active');
-            this.videoQualityControl.el.attr('title', gettext('HD on'))
-                                       .text(gettext('HD on'));
+            controlStateStr = gettext('HD on');
+            this.videoQualityControl.el
+                                    .addClass('active')
+                                    .attr('title', controlStateStr)
+                                    .text(controlStateStr);
         } else {
-            this.videoQualityControl.el.removeClass('active');
-            this.videoQualityControl.el.attr('title', gettext('HD off'))
-                                       .text(gettext('HD off'));
+            controlStateStr = gettext('HD off');
+            this.videoQualityControl.el
+                                    .removeClass('active')
+                                    .attr('title', controlStateStr)
+                                    .text(controlStateStr);
+
         }
     }       
 

--- a/common/lib/xmodule/xmodule/js/src/video/05_video_quality_control.js
+++ b/common/lib/xmodule/xmodule/js/src/video/05_video_quality_control.js
@@ -63,10 +63,14 @@ function () {
 
         if (_.indexOf(this.config.availableQualities, value) !== -1) {
             this.videoQualityControl.el.addClass('active');
+            this.videoQualityControl.el.attr('title', gettext('HD on'))
+                                       .text(gettext('HD on'));
         } else {
             this.videoQualityControl.el.removeClass('active');
+            this.videoQualityControl.el.attr('title', gettext('HD off'))
+                                       .text(gettext('HD off'));
         }
-    }
+    }       
 
     // This function change quality of video.
     // Right now we haven't ability to choose quality of HD video,

--- a/lms/templates/video.html
+++ b/lms/templates/video.html
@@ -77,7 +77,7 @@
                             </div>
                         </div>
                         <a href="#" class="add-fullscreen" title="${_('Fill browser')}" role="button" aria-disabled="false">${_('Fill browser')}</a>
-                        <a href="#" class="quality_control" title="${_('HD')}" role="button" aria-disabled="false">${_('HD')}</a>
+                        <a href="#" class="quality_control" title="${_('HD')}" role="button" aria-disabled="false">${_('HD off')}</a>
 
                         <a href="#" class="hide-subtitles" title="${_('Turn off captions')}" role="button" aria-disabled="false">${_('Turn off captions')}</a>
                     </div>

--- a/lms/templates/video.html
+++ b/lms/templates/video.html
@@ -77,7 +77,7 @@
                             </div>
                         </div>
                         <a href="#" class="add-fullscreen" title="${_('Fill browser')}" role="button" aria-disabled="false">${_('Fill browser')}</a>
-                        <a href="#" class="quality_control" title="${_('HD')}" role="button" aria-disabled="false">${_('HD off')}</a>
+                        <a href="#" class="quality_control" title="${_('HD off')}" role="button" aria-disabled="false">${_('HD off')}</a>
 
                         <a href="#" class="hide-subtitles" title="${_('Turn off captions')}" role="button" aria-disabled="false">${_('Turn off captions')}</a>
                     </div>


### PR DESCRIPTION
@valera-rozuvan @polesye Added state tracking to the last video player control that didn't have it, the Quality Control. Acceptance test for its WAI-ARIA features will be written at the same time as for the other controls, in upcoming BLD-386. This PR takes care of issue: https://edx-wiki.atlassian.net/browse/BLD-387
