### PR TITLE
dashboard.html: Setup handlers before js for leanModal is loaded

### DIFF
--- a/lms/static/js/toggle_login_modal.js
+++ b/lms/static/js/toggle_login_modal.js
@@ -87,17 +87,19 @@
     }
   });
 
-  $("a[rel*=leanModal]").each(function(){
-    $(this).leanModal({ top : 120, overlay: 1, closeButton: ".close-modal", position: 'absolute' });
-    embed = $($(this).attr('href')).find('iframe')
-    if(embed.length > 0) {
-      if(embed.attr('src').indexOf("?") > 0) {
-          embed.data('src', embed.attr('src') + '&autoplay=1&rel=0');
-          embed.attr('src', '');
-      } else {
-          embed.data('src', embed.attr('src') + '?autoplay=1&rel=0');
-          embed.attr('src', '');
-      }
-    }
+  $(document).ready(function($) {
+      $("a[rel*=leanModal]").each(function(){
+        $(this).leanModal({ top : 120, overlay: 1, closeButton: ".close-modal", position: 'absolute' });
+        embed = $($(this).attr('href')).find('iframe')
+        if(embed.length > 0) {
+          if(embed.attr('src').indexOf("?") > 0) {
+              embed.data('src', embed.attr('src') + '&autoplay=1&rel=0');
+              embed.attr('src', '');
+          } else {
+              embed.data('src', embed.attr('src') + '?autoplay=1&rel=0');
+              embed.attr('src', '');
+          }
+        }
+      });
   });
 })(jQuery);

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -35,7 +35,7 @@
           $("#unenroll_course_id").val() + "&enrollment_action=unenroll";
       } else {
         $('#unenroll_error').html(
-          xhr.responseText ? xhr.responseText : "An error occurred. Please try again later."
+          xhr.responseText ? xhr.responseText : "${_('An error occurred. Please try again later.')}"
         ).stop().css("display", "block");
       }
     });
@@ -56,11 +56,10 @@
                {"new_email" : new_email, "password" : new_password},
                function(data) {
                  if (data.success) {
-                   $("#change_email_title").html("Please verify your new email");
-                   $("#change_email_form").html("<p>You'll receive a confirmation in your " +
-                                                "in-box. Please click the link in the " +
-                                                "email to confirm the email change.</p>");
-                   $("#change_email_form").html("<p>${_('You\'ll receive a confirmation in your in-box. Please click the link in the email to confirm the email change.')}</p>");
+                   $("#change_email_title").html("${_('Please verify your new email')}");
+                   $("#change_email_form").html("<p>${_(('You\'ll receive a confirmation in your in-box.'
+                                                    ' Please click the link in the email to confirm'
+                                                    ' the email change.'))}</p>");
                  } else {
                    $("#change_email_error").html(data.error).stop().css("display", "block");
                  }
@@ -77,7 +76,6 @@
              function(data) {
                if(data.success) {
                  location.reload();
-                 // $("#change_name_body").html("<p>Name changed.</p>");
                } else {
                  $("#change_name_error").html(data.error).stop().css("display", "block");
                }


### PR DESCRIPTION
https://edx-wiki.atlassian.net/browse/LMS-930

In dashboard.html event handlers are registered on the **unregister** and **email settings** links in the js_extra block. These copy the course id to the **unenroll** and **email settings** forms respectively.

The js_extra block is at the end of the page after lms-application.js and lms-modules.js and since the leanModal handlers are setup in lms-application.js in case the unregister or email settings button is clicked before the page finishes loading the course id is not copied to the form and results in an error.

This PR adds a js block which comes before the scripts and moves the dashboard.html js to this.

@singingwolfboy Is this a good way to do this?

![missing course number](https://f.cloud.github.com/assets/5305552/1313895/599206d8-3264-11e3-8507-c6254513fca3.png)
