### PR TITLE
django-admin command for enabling email per course

### DIFF
--- a/lms/djangoapps/bulk_email/admin.py
+++ b/lms/djangoapps/bulk_email/admin.py
@@ -3,8 +3,8 @@ Django admin page for bulk email models
 """
 from django.contrib import admin
 
-from bulk_email.models import CourseEmail, Optout, CourseEmailTemplate
-from bulk_email.forms import CourseEmailTemplateForm
+from bulk_email.models import CourseEmail, Optout, CourseEmailTemplate, CourseAuthorization
+from bulk_email.forms import CourseEmailTemplateForm, CourseAuthorizationAdminForm
 
 
 class CourseEmailAdmin(admin.ModelAdmin):
@@ -57,6 +57,23 @@ unsupported tags will cause email sending to fail.
         return False
 
 
+class CourseAuthorizationAdmin(admin.ModelAdmin):
+    """Admin for enabling email on a course-by-course basis."""
+    form = CourseAuthorizationAdminForm
+    fieldsets = (
+        (None, {
+            'fields': ('course_id', 'email_enabled'),
+            'description': '''
+Enter a course id in the following form: Org/Course/CourseRun, eg MITx/6.002x/2012_Fall
+Do not enter leading or trailing slashes. There is no need to surround the course ID with quotes.
+Validation will be performed on the course name, and if it is invalid, an error message will display.
+
+To enable email for the course, check the "Email enabled" box, then click "Save".
+'''
+        }),
+    )
+
 admin.site.register(CourseEmail, CourseEmailAdmin)
 admin.site.register(Optout, OptoutAdmin)
 admin.site.register(CourseEmailTemplate, CourseEmailTemplateAdmin)
+admin.site.register(CourseAuthorization, CourseAuthorizationAdmin)

--- a/lms/djangoapps/bulk_email/migrations/0008_add_course_authorizations.py
+++ b/lms/djangoapps/bulk_email/migrations/0008_add_course_authorizations.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'CourseAuthorization'
+        db.create_table('bulk_email_courseauthorization', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('course_id', self.gf('django.db.models.fields.CharField')(max_length=255, db_index=True)),
+            ('email_enabled', self.gf('django.db.models.fields.BooleanField')(default=False)),
+        ))
+        db.send_create_signal('bulk_email', ['CourseAuthorization'])
+
+
+    def backwards(self, orm):
+        # Deleting model 'CourseAuthorization'
+        db.delete_table('bulk_email_courseauthorization')
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'bulk_email.courseauthorization': {
+            'Meta': {'object_name': 'CourseAuthorization'},
+            'course_id': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'email_enabled': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'bulk_email.courseemail': {
+            'Meta': {'object_name': 'CourseEmail'},
+            'course_id': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'html_message': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'sender': ('django.db.models.fields.related.ForeignKey', [], {'default': '1', 'to': "orm['auth.User']", 'null': 'True', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.CharField', [], {'max_length': '128', 'db_index': 'True'}),
+            'subject': ('django.db.models.fields.CharField', [], {'max_length': '128', 'blank': 'True'}),
+            'text_message': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'to_option': ('django.db.models.fields.CharField', [], {'default': "'myself'", 'max_length': '64'})
+        },
+        'bulk_email.courseemailtemplate': {
+            'Meta': {'object_name': 'CourseEmailTemplate'},
+            'html_template': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'plain_template': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'})
+        },
+        'bulk_email.optout': {
+            'Meta': {'unique_together': "(('user', 'course_id'),)", 'object_name': 'Optout'},
+            'course_id': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']", 'null': 'True'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        }
+    }
+
+    complete_apps = ['bulk_email']

--- a/lms/djangoapps/bulk_email/models.py
+++ b/lms/djangoapps/bulk_email/models.py
@@ -16,7 +16,16 @@ from django.db import models, transaction
 from django.contrib.auth.models import User
 from html_to_text import html_to_text
 
+from django.conf import settings
+
 log = logging.getLogger(__name__)
+
+# Bulk email to_options - the send to options that users can
+# select from when they send email.
+SEND_TO_MYSELF = 'myself'
+SEND_TO_STAFF = 'staff'
+SEND_TO_ALL = 'all'
+TO_OPTIONS = [SEND_TO_MYSELF, SEND_TO_STAFF, SEND_TO_ALL]
 
 
 class Email(models.Model):
@@ -33,12 +42,6 @@ class Email(models.Model):
 
     class Meta:  # pylint: disable=C0111
         abstract = True
-
-
-SEND_TO_MYSELF = 'myself'
-SEND_TO_STAFF = 'staff'
-SEND_TO_ALL = 'all'
-TO_OPTIONS = [SEND_TO_MYSELF, SEND_TO_STAFF, SEND_TO_ALL]
 
 
 class CourseEmail(Email):
@@ -209,3 +212,38 @@ class CourseEmailTemplate(models.Model):
         stored HTML template and the provided `context` dict.
         """
         return CourseEmailTemplate._render(self.html_template, htmltext, context)
+
+
+class CourseAuthorization(models.Model):
+    """
+    Enable the course email feature on a course-by-course basis.
+    """
+    # The course that these features are attached to.
+    course_id = models.CharField(max_length=255, db_index=True)
+
+    # Whether or not to enable instructor email
+    email_enabled = models.BooleanField(default=False)
+
+    @classmethod
+    def instructor_email_enabled(cls, course_id):
+        """
+        Returns whether or not email is enabled for the given course id.
+
+        If email has not been explicitly enabled, returns False.
+        """
+        # If settings.MITX_FEATURES['REQUIRE_COURSE_EMAIL_AUTH'] is
+        # set to False, then we enable email for every course.
+        if not settings.MITX_FEATURES['REQUIRE_COURSE_EMAIL_AUTH']:
+            return True
+
+        try:
+            record = cls.objects.get(course_id=course_id)
+            return record.email_enabled
+        except cls.DoesNotExist:
+            return False
+
+    def __unicode__(self):
+        not_en = "Not "
+        if self.email_enabled:
+            not_en = ""
+        return u"Course '{}': Instructor Email {}Enabled".format(self.course_id, not_en)

--- a/lms/djangoapps/bulk_email/tasks.py
+++ b/lms/djangoapps/bulk_email/tasks.py
@@ -8,9 +8,6 @@ import random
 from uuid import uuid4
 from time import sleep
 
-from sys import exc_info
-from traceback import format_exc
-
 from dogapi import dog_stats_api
 from smtplib import SMTPServerDisconnected, SMTPDataError, SMTPConnectError, SMTPException
 from boto.ses.exceptions import (
@@ -30,7 +27,6 @@ from celery.exceptions import RetryTaskError
 from django.conf import settings
 from django.contrib.auth.models import User, Group
 from django.core.mail import EmailMultiAlternatives, get_connection
-from django.http import Http404
 from django.core.urlresolvers import reverse
 
 from bulk_email.models import (
@@ -387,8 +383,8 @@ def _get_source_address(course_id, course_title):
     # in an email address, by substituting a '_' anywhere a non-(ascii, period, or dash)
     # character appears.
     course_num = course_id.split('/')[1]
-    INVALID_CHARS = re.compile(r"[^\w.-]")
-    course_num = INVALID_CHARS.sub('_', course_num)
+    invalid_chars = re.compile(r"[^\w.-]")
+    course_num = invalid_chars.sub('_', course_num)
 
     from_addr = '"{0}" Course Staff <{1}-{2}>'.format(course_title_no_quotes, course_num, settings.BULK_EMAIL_DEFAULT_FROM_EMAIL)
     return from_addr

--- a/lms/djangoapps/bulk_email/tests/test_course_optout.py
+++ b/lms/djangoapps/bulk_email/tests/test_course_optout.py
@@ -59,7 +59,7 @@ class TestOptoutCourseEmails(ModuleStoreTestCase):
         selected_email_link = '<a href="#" onclick="goto(\'Email\')" class="selectedmode">Email</a>'
         self.assertTrue(selected_email_link in response.content)
 
-    @patch.dict(settings.MITX_FEATURES, {'ENABLE_INSTRUCTOR_EMAIL': True})
+    @patch.dict(settings.MITX_FEATURES, {'ENABLE_INSTRUCTOR_EMAIL': True, 'REQUIRE_COURSE_EMAIL_AUTH': False})
     def test_optout_course(self):
         """
         Make sure student does not receive course email after opting out.
@@ -88,7 +88,7 @@ class TestOptoutCourseEmails(ModuleStoreTestCase):
         # Assert that self.student.email not in mail.to, outbox should be empty
         self.assertEqual(len(mail.outbox), 0)
 
-    @patch.dict(settings.MITX_FEATURES, {'ENABLE_INSTRUCTOR_EMAIL': True})
+    @patch.dict(settings.MITX_FEATURES, {'ENABLE_INSTRUCTOR_EMAIL': True, 'REQUIRE_COURSE_EMAIL_AUTH': False})
     def test_optin_course(self):
         """
         Make sure student receives course email after opting in.

--- a/lms/djangoapps/bulk_email/tests/test_email.py
+++ b/lms/djangoapps/bulk_email/tests/test_email.py
@@ -44,7 +44,7 @@ class TestEmailSendFromDashboard(ModuleStoreTestCase):
     Test that emails send correctly.
     """
 
-    @patch.dict(settings.MITX_FEATURES, {'ENABLE_INSTRUCTOR_EMAIL': True})
+    @patch.dict(settings.MITX_FEATURES, {'ENABLE_INSTRUCTOR_EMAIL': True, 'REQUIRE_COURSE_EMAIL_AUTH': False})
     def setUp(self):
         self.course = CourseFactory.create()
         self.instructor = UserFactory.create(username="instructor", email="robot+instructor@edx.org")

--- a/lms/djangoapps/bulk_email/tests/test_forms.py
+++ b/lms/djangoapps/bulk_email/tests/test_forms.py
@@ -1,0 +1,105 @@
+"""
+Unit tests for bulk-email-related forms.
+"""
+from django.test.utils import override_settings
+from django.conf import settings
+
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory
+from courseware.tests.tests import TEST_DATA_MONGO_MODULESTORE
+from courseware.tests.modulestore_config import TEST_DATA_MIXED_MODULESTORE
+
+from xmodule.modulestore.django import modulestore
+from xmodule.modulestore import MONGO_MODULESTORE_TYPE
+
+from mock import patch
+
+from bulk_email.models import CourseAuthorization
+from bulk_email.forms import CourseAuthorizationAdminForm
+
+
+@override_settings(MODULESTORE=TEST_DATA_MONGO_MODULESTORE)
+class CourseAuthorizationFormTest(ModuleStoreTestCase):
+    """Test the CourseAuthorizationAdminForm form for Mongo-backed courses."""
+
+    def setUp(self):
+        # Make a mongo course
+        self.course = CourseFactory.create()
+
+    def tearDown(self):
+        """
+        Undo all patches.
+        """
+        patch.stopall()
+
+    @patch.dict(settings.MITX_FEATURES, {'ENABLE_INSTRUCTOR_EMAIL': True, 'REQUIRE_COURSE_EMAIL_AUTH': True})
+    def test_authorize_mongo_course(self):
+        # Initially course shouldn't be authorized
+        self.assertFalse(CourseAuthorization.instructor_email_enabled(self.course.id))
+        # Test authorizing the course, which should totally work
+        form_data = {'course_id': self.course.id, 'email_enabled': True}
+        form = CourseAuthorizationAdminForm(data=form_data)
+        # Validation should work
+        self.assertTrue(form.is_valid())
+        form.save()
+        # Check that this course is authorized
+        self.assertTrue(CourseAuthorization.instructor_email_enabled(self.course.id))
+
+    @patch.dict(settings.MITX_FEATURES, {'ENABLE_INSTRUCTOR_EMAIL': True, 'REQUIRE_COURSE_EMAIL_AUTH': True})
+    def test_form_typo(self):
+        # Munge course id
+        bad_id = self.course.id + '_typo'
+
+        form_data = {'course_id': bad_id, 'email_enabled': True}
+        form = CourseAuthorizationAdminForm(data=form_data)
+        # Validation shouldn't work
+        self.assertFalse(form.is_valid())
+
+        msg = u'Error encountered (Course not found.)'
+        msg += ' --- Entered course id was: "{0}". '.format(bad_id)
+        msg += 'Please recheck that you have supplied a course id in the format: ORG/COURSE/RUN'
+        self.assertEquals(msg, form._errors['course_id'][0])  # pylint: disable=protected-access
+
+        with self.assertRaisesRegexp(ValueError, "The CourseAuthorization could not be created because the data didn't validate."):
+            form.save()
+
+    @patch.dict(settings.MITX_FEATURES, {'ENABLE_INSTRUCTOR_EMAIL': True, 'REQUIRE_COURSE_EMAIL_AUTH': True})
+    def test_course_name_only(self):
+        # Munge course id - common
+        bad_id = self.course.id.split('/')[-1]
+
+        form_data = {'course_id': bad_id, 'email_enabled': True}
+        form = CourseAuthorizationAdminForm(data=form_data)
+        # Validation shouldn't work
+        self.assertFalse(form.is_valid())
+
+        msg = u'Error encountered (Need more than 1 value to unpack)'
+        msg += ' --- Entered course id was: "{0}". '.format(bad_id)
+        msg += 'Please recheck that you have supplied a course id in the format: ORG/COURSE/RUN'
+        self.assertEquals(msg, form._errors['course_id'][0])  # pylint: disable=protected-access
+
+        with self.assertRaisesRegexp(ValueError, "The CourseAuthorization could not be created because the data didn't validate."):
+            form.save()
+
+
+@override_settings(MODULESTORE=TEST_DATA_MIXED_MODULESTORE)
+class CourseAuthorizationXMLFormTest(ModuleStoreTestCase):
+    """Check that XML courses cannot be authorized for email."""
+
+    @patch.dict(settings.MITX_FEATURES, {'ENABLE_INSTRUCTOR_EMAIL': True, 'REQUIRE_COURSE_EMAIL_AUTH': True})
+    def test_xml_course_authorization(self):
+        course_id = 'edX/toy/2012_Fall'
+        # Assert this is an XML course
+        self.assertTrue(modulestore().get_modulestore_type(course_id) != MONGO_MODULESTORE_TYPE)
+
+        form_data = {'course_id': course_id, 'email_enabled': True}
+        form = CourseAuthorizationAdminForm(data=form_data)
+        # Validation shouldn't work
+        self.assertFalse(form.is_valid())
+
+        msg = u"Course Email feature is only available for courses authored in Studio. "
+        msg += '"{0}" appears to be an XML backed course.'.format(course_id)
+        self.assertEquals(msg, form._errors['course_id'][0])  # pylint: disable=protected-access
+
+        with self.assertRaisesRegexp(ValueError, "The CourseAuthorization could not be created because the data didn't validate."):
+            form.save()

--- a/lms/djangoapps/instructor/tests/test_legacy_email.py
+++ b/lms/djangoapps/instructor/tests/test_legacy_email.py
@@ -41,7 +41,7 @@ class TestInstructorDashboardEmailView(ModuleStoreTestCase):
         """
         patch.stopall()
 
-    @patch.dict(settings.MITX_FEATURES, {'ENABLE_INSTRUCTOR_EMAIL': True})
+    @patch.dict(settings.MITX_FEATURES, {'ENABLE_INSTRUCTOR_EMAIL': True, 'REQUIRE_COURSE_EMAIL_AUTH': False})
     def test_email_flag_true(self):
         # Assert that the URL for the email view is in the response
         response = self.client.get(self.url)

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -22,6 +22,7 @@ from courseware.courses import get_course_by_id
 from django_comment_client.utils import has_forum_access
 from django_comment_common.models import FORUM_ROLE_ADMINISTRATOR
 from student.models import CourseEnrollment
+from bulk_email.models import CourseAuthorization
 
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
@@ -57,7 +58,9 @@ def instructor_dashboard_2(request, course_id):
     if max_enrollment_for_buttons is not None:
         disable_buttons = enrollment_count > max_enrollment_for_buttons
 
-    if settings.MITX_FEATURES['ENABLE_INSTRUCTOR_EMAIL'] and is_studio_course:
+    # Gate access by feature flag & by course-specific authorization
+    if settings.MITX_FEATURES['ENABLE_INSTRUCTOR_EMAIL'] and \
+       is_studio_course and CourseAuthorization.instructor_email_enabled(course_id):
         sections.append(_section_send_email(course_id, access, course))
 
     context = {

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -114,8 +114,12 @@ MITX_FEATURES = {
     # analytics experiments
     'ENABLE_INSTRUCTOR_ANALYTICS': False,
 
-    # bulk email available to instructors:
-    'ENABLE_INSTRUCTOR_EMAIL': False,
+    # Enables the LMS bulk email feature for course staff
+    'ENABLE_INSTRUCTOR_EMAIL': True,
+    # If True and ENABLE_INSTRUCTOR_EMAIL: Forces email to be explicitly turned on
+    #   for each course via django-admin interface.
+    # If False and ENABLE_INSTRUCTOR_EMAIL: Email will be turned on by default for all courses.
+    'REQUIRE_COURSE_EMAIL_AUTH': True,
 
     # enable analytics server.
     # WARNING: THIS SHOULD ALWAYS BE SET TO FALSE UNDER NORMAL


### PR DESCRIPTION
Add in a django-admin feature to restrict access to the bulk email feature to those we explicitly grant access.

This PR:
- Adds a new model to bulk_email/models
- Adds a new form to bulk_email/forms, with course id validation
- Changes the way the instructor dashboard decides whether to show the feature - both must be present: the CourseAuthorization must be explicitly set for the course, AND the settings flag for the feature must be enabled. This allows us to revoke access to the course at any point in time.

Both beta dash and legacy dash email tabs are gated in this manner.
