### PR TITLE
Require login for followed_threads

### DIFF
--- a/lms/djangoapps/django_comment_client/forum/views.py
+++ b/lms/djangoapps/django_comment_client/forum/views.py
@@ -371,6 +371,7 @@ def user_profile(request, course_id, user_id):
         raise Http404
 
 
+@login_required
 def followed_threads(request, course_id, user_id):
     course = get_course_with_access(request.user, course_id, 'load_forum')
     try:


### PR DESCRIPTION
Without the login_required decorator, an error would occur, causing a
500 to be returned. This fixes FOR-155.

@jimabramson 
