### PR TITLE
Add in instructor dashboard support for downloading open ended grading data.

### DIFF
--- a/lms/djangoapps/instructor/views/api_urls.py
+++ b/lms/djangoapps/instructor/views/api_urls.py
@@ -43,4 +43,6 @@ urlpatterns = patterns('',  # nopep8
         'instructor.views.api.list_grade_downloads', name="list_grade_downloads"),
     url(r'calculate_grades_csv$',
         'instructor.views.api.calculate_grades_csv', name="calculate_grades_csv"),
+    url(r'^get_open_ended_data$',
+        'instructor.views.api.get_open_ended_data', name="get_open_ended_data"),
 )

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -23,6 +23,7 @@ from courseware.courses import get_course_by_id, get_cms_course_link
 from django_comment_client.utils import has_forum_access
 from django_comment_common.models import FORUM_ROLE_ADMINISTRATOR
 from student.models import CourseEnrollment
+from open_ended_grading.utils import check_if_open_ended_problems_exist
 from bulk_email.models import CourseAuthorization
 from lms.lib.xblock.runtime import handler_prefix
 
@@ -173,6 +174,9 @@ def _section_data_download(course_id, access):
         'list_instructor_tasks_url': reverse('list_instructor_tasks', kwargs={'course_id': course_id}),
         'list_grade_downloads_url': reverse('list_grade_downloads', kwargs={'course_id': course_id}),
         'calculate_grades_csv_url': reverse('calculate_grades_csv', kwargs={'course_id': course_id}),
+        'open_ended_problems_exist_in_course': check_if_open_ended_problems_exist(course_id),
+        'get_open_ended_data_url': reverse('get_open_ended_data', kwargs={'course_id': course_id}),
+
     }
     return section_data
 

--- a/lms/djangoapps/open_ended_grading/tests.py
+++ b/lms/djangoapps/open_ended_grading/tests.py
@@ -468,3 +468,51 @@ class TestStudentProblemList(ModuleStoreTestCase):
         self.assertEqual(len(valid_problems), 2)
         # Ensure that human names are being set properly.
         self.assertEqual(valid_problems[0]['grader_type_display_name'], "Instructor Assessment")
+
+    def test_get_problems_success(self):
+        """
+        Test to see if we find any open ended modules when they exist.
+        """
+
+        items_exist = utils.check_if_open_ended_problems_exist(self.course_name)
+        self.assertTrue(items_exist)
+
+    def test_get_problems_fail(self):
+        """
+        Test to see if we find any open ended modules when they exist.
+        """
+
+        items_exist = utils.check_if_open_ended_problems_exist("random course")
+        self.assertFalse(items_exist)
+
+
+class TestCourseDataService(ModuleStoreTestCase):
+    """
+    Test the course data service to see if it initializes properly.
+    """
+
+    # Fake grading interface to pass into course data service.
+    GRADING_INTERFACE = {
+        'url': '',
+        'username': '',
+        'password': '',
+        'staff_grading': '',
+        'peer_grading': '',
+        'system': '',
+        'grading_controller': '',
+    }
+
+    def test_initialize_service(self):
+        """
+        Try to initialize a course data service and verify its settings.
+        """
+
+        # Initialize the service.
+        course_data_service = utils.CourseDataService(self.GRADING_INTERFACE)
+
+        # Verify that everything is setup properly.
+        self.assertEqual(course_data_service.url, '')
+        self.assertEqual(course_data_service.course_data_url, '/get_course_data/')
+        self.assertEqual(course_data_service.login_url, '/login/')
+        self.assertEqual(course_data_service.username, '')
+        self.assertEqual(course_data_service.password, '')

--- a/lms/djangoapps/open_ended_grading/utils.py
+++ b/lms/djangoapps/open_ended_grading/utils.py
@@ -11,10 +11,8 @@ from django.utils.translation import ugettext as _
 from django.conf import settings
 
 from lms.lib.xblock.runtime import LmsModuleSystem
-from mitxmako.shortcuts import render_to_string
-from xmodule.course_module import CourseDescriptor
 from edxmako.shortcuts import render_to_string
-
+from xmodule.course_module import CourseDescriptor
 log = logging.getLogger(__name__)
 
 GRADER_DISPLAY_NAMES = {

--- a/lms/djangoapps/open_ended_grading/utils.py
+++ b/lms/djangoapps/open_ended_grading/utils.py
@@ -5,14 +5,15 @@ from xmodule.modulestore import search
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError, NoPathToItem
 from xmodule.open_ended_grading_classes.controller_query_service import ControllerQueryService
-from xmodule.open_ended_grading_classes.grading_service_module import GradingServiceError
+from xmodule.open_ended_grading_classes.grading_service_module import GradingServiceError, GradingService
 
 from django.utils.translation import ugettext as _
 from django.conf import settings
 
 from lms.lib.xblock.runtime import LmsModuleSystem
+from mitxmako.shortcuts import render_to_string
+from xmodule.course_module import CourseDescriptor
 from edxmako.shortcuts import render_to_string
-
 
 log = logging.getLogger(__name__)
 
@@ -172,3 +173,53 @@ class StudentProblemList(object):
             problem['grader_type_display_name'] = grader_type_display_name
             valid_problems.append(problem)
         return valid_problems
+
+
+def check_if_open_ended_problems_exist(course_id):  # pylint: disable=invalid-name
+    """
+    Check to see if there are any open ended problems in the course.
+    """
+
+    try:
+        # Get the course object.
+        course_location = CourseDescriptor.id_to_location(course_id)
+    except ValueError:
+        # If we get a ValueError, the course id is invalid.
+        return False
+
+    # See if we can find any items in the modulestore.
+    items = modulestore().get_items(
+        ['i4x', course_location.org, course_location.course, 'combinedopenended', None],
+        course_id=course_id
+    )
+
+    return len(items) > 0
+
+
+class CourseDataService(GradingService):
+    """
+    A service that queries the ORA server for course data.
+    """
+    def __init__(self, config):
+        config['system'] = SYSTEM
+        super(CourseDataService, self).__init__(config)
+        self.url = config['url'] + config['grading_controller']
+        self.course_data_url = self.url + "/get_course_data/"
+        self.login_url = self.url + '/login/'
+
+    def get_course_data(self, course_id):
+        """
+        Get a url for the course data dump for a given course.
+
+        Args:
+            course_id: course id that we want the data dump for.
+
+        Returns:
+            json string with the response from the service.  Contains a boolean success, and a key 'file_url'
+            if success is True.
+
+        Raises:
+            GradingServiceError: something went wrong with the connection.
+        """
+        params = {'course': course_id}
+        return json.loads(self.get(self.course_data_url, params))

--- a/lms/static/coffee/src/instructor_dashboard/data_download.coffee
+++ b/lms/static/coffee/src/instructor_dashboard/data_download.coffee
@@ -30,8 +30,11 @@ class DataDownload
     @$grades                        = @$section.find '.grades-download-container'
     @$grades_request_response       = @$grades.find '.request-response'
     @$grades_request_response_error = @$grades.find '.request-response-error'
-
     @grade_downloads = new GradeDownloads(@$section)
+    @$oe_data_download_btn = @$section.find("input[name='get-open-ended-data-url']'")
+    @$oe_display                = @$section.find '.oe-data-display'
+    @$oe_display_text           = @$oe_display.find '.data-display-text'
+    @$oe_request_response_error = @$oe_display.find '.request-response-error'
     @instructor_tasks = new (PendingInstructorTasks()) @$section
     @clear_display()
 
@@ -40,6 +43,25 @@ class DataDownload
     @$list_anon_btn.click (e) =>
       url = @$list_anon_btn.data 'endpoint'
       location.href = url
+
+    # This handler properly calls the api endpoint for open ended data.
+    # Displays an error if there is a problem fetching the data,
+    # and a link to the data otherwise.
+    @$oe_data_download_btn.click (e) =>
+      url = @$oe_data_download_btn.data 'endpoint'
+      $.ajax
+        dataType: 'json'
+        url: url
+        error: std_ajax_err =>
+          @clear_oe_display()
+          @$oe_request_response_error.text gettext("Error getting open response assessment data.  Please notify technical support if this persists.")
+        success: (data) =>
+          @clear_oe_display()
+          if data.success == true
+            button_text = gettext("Click to download data")
+            @$oe_display_text.html "<a href='" + data.file_url + "' target='_blank'>" + button_text + "</a>"
+          else
+            @$oe_request_response_error.text gettext("No open response assessment data is available.  Please check again later.")
 
     # this handler binds to both the download
     # and the csv button
@@ -133,6 +155,9 @@ class DataDownload
     $(".msg-confirm").css({"display":"none"})
     $(".msg-error").css({"display":"none"})
 
+  clear_oe_display: ->
+    @$oe_display_text.empty()
+    @$oe_request_response_error.empty()
 
 class GradeDownloads
   ### Grade Downloads -- links expire quickly, so we refresh every 5 mins ####

--- a/lms/templates/instructor/instructor_dashboard_2/data_download.html
+++ b/lms/templates/instructor/instructor_dashboard_2/data_download.html
@@ -57,3 +57,21 @@
     <div class="running-tasks-table" data-endpoint="${ section_data['list_instructor_tasks_url'] }"></div>
   </div>
 %endif
+
+%if section_data['open_ended_problems_exist_in_course']:
+<div class="open-ended-download-container action-type-container">
+    <hr>
+    <h2> ${_("Download open response assessment data")} </h2>
+    <p>${_("Data for your open response assessment problems can be downloaded using the button below.  The data will consist of information about all student submissions for all open response assessment problems in the course, including current status, grades, and feedback where applicable.  The data will be in CSV format.")}</p>
+    <p>${_("This data is regenerated every 12 hours, so if there is nothing to download now or you see an error, please check back later.")}</p>
+    <br/>
+    <input type="button" name="get-open-ended-data-url" value="${_("Get Open Response Assessment Data CSV")}" data-endpoint="${ section_data['get_open_ended_data_url'] }">
+
+    <div class="oe-data-display">
+        <div class="data-display-text"></div>
+        <div class="request-response-error"></div>
+    </div>
+</div>
+
+%endif
+


### PR DESCRIPTION
Enable instructors in courses that have combinedopenended problems to download a csv of data from the ORA server.  They will be shown an error message if the data could not be retrieved, and a link to download the data (ORA generates a temporary link) if there is data waiting.  Data is regenerated on the ORA side every 12 hours.

This creates an area in the Data download section of the beta instructor dashboard where a button to download the open response assessment data appears (only appears if you have open ended problems in your course).

This must be merged after https://github.com/edx/edx-ora/pull/145 .

@sarina @brianhw Please look when you get a chance.
![selection_012](https://f.cloud.github.com/assets/913340/1317190/adbaf69a-32a3-11e3-9adc-33e803fb8d4d.png)
