### PR TITLE
Fix/ichuang/instructor dashboard grades for assignment

### DIFF
--- a/lms/djangoapps/instructor/views/legacy.py
+++ b/lms/djangoapps/instructor/views/legacy.py
@@ -469,7 +469,15 @@ def instructor_dashboard(request, course_id):
             else:
                 aidx = allgrades['assignments'].index(aname)
                 datatable = {'header': ['External email', aname]}
-                datatable['data'] = [[x.email, x.grades[aidx]] for x in allgrades['students']]
+                # datatable['data'] = [[x.email, x.grades[aidx]] for x in allgrades['students']] 
+                ddata = []
+                for x in allgrades['students']:
+                    try:
+                        ddata.append([x.email, x.grades[aidx]])
+                    except IndexError:
+                        log.debug('No grade for assignment %s (%s) for student %s'  % (aidx, aname, x.email))
+                datatable['data'] = ddata
+                    
                 datatable['title'] = 'Grades for assignment "%s"' % aname
 
                 if 'Export CSV' in action:

--- a/lms/djangoapps/instructor/views/legacy.py
+++ b/lms/djangoapps/instructor/views/legacy.py
@@ -469,9 +469,8 @@ def instructor_dashboard(request, course_id):
             else:
                 aidx = allgrades['assignments'].index(aname)
                 datatable = {'header': ['External email', aname]}
-                # datatable['data'] = [[x.email, x.grades[aidx]] for x in allgrades['students']] 
                 ddata = []
-                for x in allgrades['students']:
+                for x in allgrades['students']:	  # do one by one in case there is a student who has only partial grades
                     try:
                         ddata.append([x.email, x.grades[aidx]])
                     except IndexError:


### PR DESCRIPTION
Dumping of grades for a specific assignment is an important feature for residential use of edx-platform.

The instructor dashboard (what has been renamed to become the "legacy" version) has a bug in the code which provides this feature.  If a student's grades are missing entries, the dump will hit an exception due to an IndexError.  Instead, the student missing grades for that assignment should be skipped.  This PR makes that fix.
