### PR TITLE
Fix broken tests for video player

### DIFF
--- a/cms/djangoapps/contentstore/features/video-editor.feature
+++ b/cms/djangoapps/contentstore/features/video-editor.feature
@@ -15,17 +15,12 @@ Feature: CMS.Video Component Editor
     Then I can modify the display name
     And my video display name change is persisted on save
 
-  # Disabling this 10/7/13 due to nondeterministic behavior
-  # in master.  The failure seems to occur when YouTube does
-  # not respond quickly enough, so that the video player
-  # doesn't load.
-  #
   # Sauce Labs cannot delete cookies
-  #  @skip_sauce
-  #Scenario: Captions are hidden when "show captions" is false
-  #  Given I have created a Video component with subtitles
-  #  And I have set "show captions" to False
-  #  Then when I view the video it does not show the captions
+  @skip_sauce
+  Scenario: Captions are hidden when "show captions" is false
+    Given I have created a Video component with subtitles
+    And I have set "show captions" to False
+    Then when I view the video it does not show the captions
 
   # Sauce Labs cannot delete cookies
   @skip_sauce

--- a/cms/djangoapps/contentstore/features/video.feature
+++ b/cms/djangoapps/contentstore/features/video.feature
@@ -69,3 +69,11 @@ Feature: CMS.Video Component
   #  Then Captions become "invisible" after 3 seconds
   #  And I hover over button "volume"
   #  Then Captions are "invisible"
+
+  # 10
+  #Scenario: When enter key is pressed on a caption shows an outline around it
+  #  Given I have created a Video component with subtitles
+  #  And Make sure captions are opened
+  #  Then I focus on caption line with data-index 0
+  #  Then I press "enter" button on caption line with data-index 0
+  #  And I see caption line with data-index 0 has class "focused"

--- a/cms/djangoapps/contentstore/features/video.feature
+++ b/cms/djangoapps/contentstore/features/video.feature
@@ -15,11 +15,11 @@ Feature: CMS.Video Component
 
   # 3
   # Sauce Labs cannot delete cookies
-  #  @skip_sauce
-  #Scenario: Captions are hidden correctly
-  #  Given I have created a Video component with subtitles
-  #  And I have hidden captions
-  #  Then when I view the video it does not show the captions
+  @skip_sauce
+  Scenario: Captions are hidden correctly
+    Given I have created a Video component with subtitles
+    And I have hidden captions
+    Then when I view the video it does not show the captions
 
   # 4
   # Sauce Labs cannot delete cookies
@@ -43,37 +43,37 @@ Feature: CMS.Video Component
     Then the correct Youtube video is shown
 
   # 7
-  #  Scenario: Closed captions become visible when the mouse hovers over CC button
-  #  Given I have created a Video component with subtitles
-  #  And Make sure captions are closed
-  #  Then Captions become "invisible" after 3 seconds
-  #  And I hover over button "CC"
-  #  Then Captions become "visible"
-  #  And I hover over button "volume"
-  #  Then Captions become "invisible" after 3 seconds
+    Scenario: Closed captions become visible when the mouse hovers over CC button
+    Given I have created a Video component with subtitles
+    And Make sure captions are closed
+    Then Captions become "invisible" after 3 seconds
+    And I hover over button "CC"
+    Then Captions become "visible"
+    And I hover over button "volume"
+    Then Captions become "invisible" after 3 seconds
 
   # 8
-  #Scenario: Open captions never become invisible
-  #  Given I have created a Video component with subtitles
-  #  And Make sure captions are open
-  #  Then Captions are "visible"
-  #  And I hover over button "CC"
-  #  Then Captions are "visible"
-  #  And I hover over button "volume"
-  #  Then Captions are "visible"
+  Scenario: Open captions never become invisible
+    Given I have created a Video component with subtitles
+    And Make sure captions are open
+    Then Captions are "visible"
+    And I hover over button "CC"
+    Then Captions are "visible"
+    And I hover over button "volume"
+    Then Captions are "visible"
 
   # 9
-  #Scenario: Closed captions are invisible when mouse doesn't hover on CC button
-  #  Given I have created a Video component with subtitles
-  #  And Make sure captions are closed
-  #  Then Captions become "invisible" after 3 seconds
-  #  And I hover over button "volume"
-  #  Then Captions are "invisible"
+  Scenario: Closed captions are invisible when mouse doesn't hover on CC button
+    Given I have created a Video component with subtitles
+    And Make sure captions are closed
+    Then Captions become "invisible" after 3 seconds
+    And I hover over button "volume"
+    Then Captions are "invisible"
 
   # 10
-  #Scenario: When enter key is pressed on a caption shows an outline around it
-  #  Given I have created a Video component with subtitles
-  #  And Make sure captions are opened
-  #  Then I focus on caption line with data-index 0
-  #  Then I press "enter" button on caption line with data-index 0
-  #  And I see caption line with data-index 0 has class "focused"
+  Scenario: When enter key is pressed on a caption shows an outline around it
+    Given I have created a Video component with subtitles
+    And Make sure captions are opened
+    Then I focus on caption line with data-index 0
+    Then I press "enter" button on caption line with data-index 0
+    And I see caption line with data-index 0 has class "focused"

--- a/cms/djangoapps/contentstore/features/video.py
+++ b/cms/djangoapps/contentstore/features/video.py
@@ -3,6 +3,7 @@
 from lettuce import world, step
 from xmodule.modulestore import Location
 from contentstore.utils import get_modulestore
+from selenium.webdriver.common.keys import Keys
 
 BUTTONS = {
     'CC': '.hide-subtitles',
@@ -154,3 +155,25 @@ def check_captions_visibility_state(_step, visibility_state, timeout):
         assert world.css_visible('.subtitles')
     else:
         assert not world.css_visible('.subtitles')
+
+
+def find_caption_line_by_data_index(index):
+    SELECTOR = ".subtitles > li[data-index='{index}']".format(index=index)
+    return world.css_find(SELECTOR).first
+
+
+@step('I focus on caption line with data-index (\d+)$')
+def focus_on_caption_line(_step, index):
+    find_caption_line_by_data_index(int(index.strip()))._element.send_keys(Keys.TAB)
+
+
+@step('I press "enter" button on caption line with data-index (\d+)$')
+def focus_on_caption_line(_step, index):
+    find_caption_line_by_data_index(int(index.strip()))._element.send_keys(Keys.ENTER)
+
+
+@step('I see caption line with data-index (\d+) has class "([^"]*)"$')
+def caption_line_has_class(_step, index, className):
+    SELECTOR = ".subtitles > li[data-index='{index}']".format(index=int(index.strip()))
+    world.css_has_class(SELECTOR, className.strip())
+

--- a/common/lib/xmodule/xmodule/js/spec/video/video_caption_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_caption_spec.js
@@ -756,44 +756,6 @@
                     expect(videoCaption.autoScrolling).toBe(true);
                 });
             });
-
-            describe('when enter key is pressed on a caption', function () {
-
-                var assertCaptions = function (expectations) {
-
-                        waitsFor(function () {
-                            return videoCaption.captions.length;
-                        }, "Captions are not loaded.", WAIT_TIMEOUT);
-
-                        runs(expectations);
-                    },
-                    initializeClick = function () {
-                        var e,
-                        subDataLiIdx__0 = $('.subtitles li[data-index=0]');
-
-                        spyOn(videoCaption, 'seekPlayer').andCallThrough();
-                        videoCaption.isMouseFocus = false;
-                        subDataLiIdx__0.trigger(jQuery.Event('focus'));
-                        e = jQuery.Event('keydown');
-                        e.which = 13; // ENTER key
-                        subDataLiIdx__0.trigger(e);
-                    };
-
-                it('shows an outline around it' , function () {
-                    assertCaptions(function() {
-                        var subDataLiIdx__0 = $('.subtitles li[data-index=0]');
-                        initializeClick();
-                        expect(subDataLiIdx__0).toHaveClass('focused');
-                    });
-                });
-
-                it('calls seekPlayer', function () {
-                    assertCaptions(function() {
-                        initializeClick();
-                        expect(videoCaption.seekPlayer).toHaveBeenCalled();
-                    });
-                });
-            });
         });
     });
 

--- a/common/lib/xmodule/xmodule/js/spec/video/video_caption_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_caption_spec.js
@@ -1,7 +1,6 @@
 (function () {
     describe('VideoCaption', function () {
-        var state, videoPlayer, videoCaption, videoSpeedControl, oldOTBD,
-            WAIT_TIMEOUT = 1000;
+        var state, videoPlayer, videoCaption, videoSpeedControl, oldOTBD;
 
         function initialize() {
             loadFixtures('video_all.html');

--- a/common/lib/xmodule/xmodule/js/spec/video/video_caption_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_caption_spec.js
@@ -1,6 +1,7 @@
 (function () {
     describe('VideoCaption', function () {
-        var state, videoPlayer, videoCaption, videoSpeedControl, oldOTBD;
+        var state, videoPlayer, videoCaption, videoSpeedControl, oldOTBD,
+            WAIT_TIMEOUT = 1000;
 
         function initialize() {
             loadFixtures('video_all.html');
@@ -48,7 +49,7 @@
                         }
 
                         return false;
-                    }, 'Expect captions to be loaded.', 1000);
+                    }, 'Expect captions to be loaded.', WAIT_TIMEOUT);
 
                     runs(function () {
                         expect($.ajaxWithPrefix).toHaveBeenCalledWith({
@@ -469,9 +470,7 @@
             });
 
             describe('set the height of caption container', function () {
-                // Temporarily disabled due to intermittent failures
-                // with error "Expected 745 to be close to 805, 2." in Firefox
-                xit('when CC button is enabled', function () {
+                it('when CC button is enabled', function () {
                     var realHeight = parseInt(
                             $('.subtitles').css('maxHeight'), 10
                         ),
@@ -576,12 +575,7 @@
                     $('.subtitles li[data-start="14910"]').trigger('click');
                 });
 
-                // Temporarily disabled due to intermittent failures
-                // Fails with error: "InvalidStateError: An attempt was made to
-                // use an object that is not, or is no longer, usable
-                // Expected 0 to equal 14.91."
-                // on Firefox
-                xit('trigger seek event with the correct time', function () {
+                it('trigger seek event with the correct time', function () {
                     expect(videoPlayer.currentTime).toEqual(14.91);
                 });
             });
@@ -763,33 +757,41 @@
                 });
             });
 
-            xdescribe('when enter key is pressed on a caption', function () {
-                var subDataLiIdx__0;
+            describe('when enter key is pressed on a caption', function () {
 
-                beforeEach(function () {
-                    var e;
+                var assertCaptions = function (expectations) {
 
-                    subDataLiIdx__0 = $('.subtitles li[data-index=0]');
+                        waitsFor(function () {
+                            return videoCaption.captions.length;
+                        }, "Captions are not loaded.", WAIT_TIMEOUT);
 
-                    spyOn(videoCaption, 'seekPlayer').andCallThrough();
-                    videoCaption.isMouseFocus = false;
-                    subDataLiIdx__0.trigger(jQuery.Event('focus'));
-                    e = jQuery.Event('keydown');
-                    e.which = 13; // ENTER key
-                    subDataLiIdx__0.trigger(e);
+                        runs(expectations);
+                    },
+                    initializeClick = function () {
+                        var e,
+                        subDataLiIdx__0 = $('.subtitles li[data-index=0]');
+
+                        spyOn(videoCaption, 'seekPlayer').andCallThrough();
+                        videoCaption.isMouseFocus = false;
+                        subDataLiIdx__0.trigger(jQuery.Event('focus'));
+                        e = jQuery.Event('keydown');
+                        e.which = 13; // ENTER key
+                        subDataLiIdx__0.trigger(e);
+                    };
+
+                it('shows an outline around it' , function () {
+                    assertCaptions(function() {
+                        var subDataLiIdx__0 = $('.subtitles li[data-index=0]');
+                        initializeClick();
+                        expect(subDataLiIdx__0).toHaveClass('focused');
+                    });
                 });
 
-                // Temporarily disabled due to intermittent failures.
-                //
-                // Fails with error: "InvalidStateError: InvalidStateError: An
-                // attempt was made to use an object that is not, or is no
-                // longer, usable".
-                xit('shows an outline around it', function () {
-                    expect(subDataLiIdx__0).toHaveClass('focused');
-                });
-
-                xit('calls seekPlayer', function () {
-                    expect(videoCaption.seekPlayer).toHaveBeenCalled();
+                it('calls seekPlayer', function () {
+                    assertCaptions(function() {
+                        initializeClick();
+                        expect(videoCaption.seekPlayer).toHaveBeenCalled();
+                    });
                 });
             });
         });

--- a/common/lib/xmodule/xmodule/js/spec/video/video_player_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_player_spec.js
@@ -701,8 +701,13 @@
       });
 
       it('set the player volume', function() {
+        var expectedValue = 60,
+            realValue;
+
         player.setVolume(60);
-        expect(player.getVolume()).toEqual(0.6);
+        realValue = Math.round(player.getVolume()*100);
+
+        expect(realValue).toEqual(expectedValue);
       });
     });
   });

--- a/common/lib/xmodule/xmodule/js/spec/video/video_progress_slider_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_progress_slider_spec.js
@@ -154,7 +154,7 @@
         // function might (and probably will) fail.
         oldSetTimeout = window.setTimeout;
         // Redefine window.setTimeout() function as a spy.
-        window.setTimeout = jasmine.createSpy().andCallFake(function(callback, timeout) { return 5; })
+        window.setTimeout = jasmine.createSpy().andCallFake(function(callback, timeout) { return 5; });
         window.setTimeout.andReturn(100);
 
         initialize();
@@ -180,9 +180,7 @@
         expect(videoPlayer.currentTime).toEqual(20);
       });
 
-      // Temporarily disabled due to intermittent failures
-      // Fails with error: " Expected true to be falsy."
-      xit('set timeout to unfreeze the slider', function() {
+      it('set timeout to unfreeze the slider', function() {
         expect(window.setTimeout).toHaveBeenCalledWith(jasmine.any(Function), 200);
         window.setTimeout.mostRecentCall.args[0]();
         expect(videoProgressSlider.frozen).toBeFalsy();

--- a/common/lib/xmodule/xmodule/js/spec/video/video_quality_control_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_quality_control_spec.js
@@ -11,7 +11,9 @@
 
     beforeEach(function() {
       oldOTBD = window.onTouchBasedDevice;
-      window.onTouchBasedDevice = jasmine.createSpy('onTouchBasedDevice').andReturn(false);
+      window.onTouchBasedDevice = jasmine
+                                      .createSpy('onTouchBasedDevice')
+                                      .andReturn(false);
     });
 
     afterEach(function() {
@@ -20,7 +22,8 @@
     });
 
     describe('constructor', function() {
-      var oldYT = window.YT;
+      var oldYT = window.YT,
+      SELECTOR = 'a.quality_control';
 
       beforeEach(function() {
         window.YT = {
@@ -37,21 +40,13 @@
       });
 
       it('render the quality control', function() {
-        expect(videoControl.secondaryControlsEl.html())
-          .toContain(
-            '<a ' +
-              'href="#" ' +
-              'class="quality_control" ' +
-              'title="HD off" ' +
-              'role="button" ' +
-              'aria-disabled="false"' +
-            '>HD off</a>'
-          );
+        var container = videoControl.secondaryControlsEl;
+        expect(container).toContain(SELECTOR);
       });
 
       it('bind the quality control', function() {
-        expect($('.quality_control'))
-          .toHandleWith('click', videoQualityControl.toggleQuality);
+        var handler = videoQualityControl.toggleQuality;
+        expect($(SELECTOR)).toHandleWith('click', handler);
       });
     });
   });


### PR DESCRIPTION
This PR provide fix for disabled video tests.
After enabling some of the JavaScript unit tests works well.
Some tests are fixed. 
One test is rewritten to acceptance test.

@wedaly @valera-rozuvan @jzoldak  please review.
