### PR TITLE
Video player: Fix multi speed bug

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
+++ b/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
@@ -138,25 +138,7 @@ function (VideoPlayer) {
     //     support HTML5. When we have this setting in cookies, we can select
     //     the proper mode from the start (not having to change mode later on).
     function _setPlayerMode(state) {
-        (function (currentPlayerMode) {
-            if (
-                (currentPlayerMode === 'html5') ||
-                (currentPlayerMode === 'flash')
-            ) {
-                state.currentPlayerMode = currentPlayerMode;
-            } else {
-                $.cookie('current_player_mode', 'html5', {
-                    expires: 3650,
-                    path: '/'
-                });
-                state.currentPlayerMode = 'html5';
-            }
-
-            console.log(
-                '[Video info]: YouTube player mode is "' +
-                state.currentPlayerMode + '".'
-            );
-        }($.cookie('current_player_mode')));
+        state.currentPlayerMode = 'html5';
     }
 
     // function _parseYouTubeIDs(state)

--- a/common/lib/xmodule/xmodule/js/src/video/03_video_player.js
+++ b/common/lib/xmodule/xmodule/js/src/video/03_video_player.js
@@ -146,11 +146,6 @@ function (HTML5Video) {
         // Remove from the page current iFrame with HTML5 video.
         state.videoPlayer.player.destroy();
 
-        // Remember for future page loads that we should use Flash mode.
-        $.cookie('current_player_mode', 'flash', {
-            'expires': 3650,
-            'path': '/'
-        });
         state.currentPlayerMode = 'flash';
 
         console.log('[Video info]: Changing YouTube player mode to "flash".');


### PR DESCRIPTION
There is a fix for [BLD-287: multi-speed does not work on some configurations](https://edx-wiki.atlassian.net/browse/BLD-287).
When user worked in FF19 before (that doesn't support html5 video fully), then updated it to version 20 or higher (that supports html5 video), he still saw just 1 speed, because Flash mode supports just 1 speed. 
The issue was in storing current_player_mode in cookie. After starting player at first time in FF19 'flash' mode was stored in cookie and when we opened it again player just got it from cookie (where 'flash' mode was stored).

Steps to reproduce on master:
- open page with video in FF19, clear cookies, refresh page;
- update FF or open FF with higher version, you will still see just 1 speed;
- clear cookies and all should works okay.

@valera-rozuvan @Lyla-Fischer please review.
