### PR TITLE
Added back on hover CC button functionality.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,11 @@ These are notable changes in edx-platform.  This is a rolling list of changes,
 in roughly chronological order, most recent first.  Add your entries at or near
 the top.  Include a label indicating the component affected.
 
+Blades: Hovering over CC button in video player, when transcripts are hidden,
+will cause them to show up. Moving the mouse from the CC button will auto hide
+them. You can hover over the CC button and then move the mouse to the
+transcripts which will allow you to select some video position in 1 click.
+
 Blades: Add possibility to use multiple LTI tools per page.
 
 Blades: LTI module can now load external content in a new window.

--- a/cms/djangoapps/contentstore/features/component_settings_editor_helpers.py
+++ b/cms/djangoapps/contentstore/features/component_settings_editor_helpers.py
@@ -35,7 +35,7 @@ def click_new_component_button(step, component_button_css):
     step.given('I have clicked the new unit button')
     world.wait_for_requirejs(
         ["jquery", "js/models/course", "coffee/src/models/module",
-         "coffee/src/views/unit", "jquery.ui"]
+         "coffee/src/views/unit", "jquery.ui", "domReady!"]
     )
     world.css_click(component_button_css)
 

--- a/common/lib/xmodule/xmodule/css/video/display.scss
+++ b/common/lib/xmodule/xmodule/css/video/display.scss
@@ -638,8 +638,6 @@ div.video {
     ol.subtitles {
         width: 0;
         height: 0;
-
-        visibility: hidden;
     }
 
     ol.subtitles.html5 {
@@ -673,8 +671,6 @@ div.video {
       ol.subtitles {
         right: -(flex-grid(4));
         width: auto;
-
-        visibility: hidden;
       }
     }
 

--- a/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
@@ -182,7 +182,6 @@ function () {
 
             this.videoCaption.hideSubtitlesEl.on({
                 mousemove: this.videoCaption.autoShowCaptions,
-                focus: this.videoCaption.autoShowCaptions,
 
                 mouseout: this.videoCaption.autoHideCaptions,
                 blur: this.videoCaption.autoHideCaptions
@@ -677,6 +676,7 @@ function () {
         event.preventDefault();
 
         if (this.el.hasClass('closed')) {
+            this.videoCaption.autoShowCaptions();
             this.videoCaption.hideCaptions(false);
         } else {
             this.videoCaption.hideCaptions(true);


### PR DESCRIPTION
<b>Description</b>
When https://github.com/edx/edx-platform/pull/1183 was merged, somehow the functionality:
- on mouse over CC button, auto show transcripts if they are hidden; hide them again once the mouse leaves the CC button or transcripts

was lost. This PR enables it.

<b>Reviewers</b>
- @jmclaus 
