### PR TITLE
Commit/rollback transaction after rendering response

### DIFF
--- a/common/djangoapps/student/tests/test_email.py
+++ b/common/djangoapps/student/tests/test_email.py
@@ -25,6 +25,9 @@ def mock_render_to_string(template_name, context):
 
 def mock_render_to_response(template_name, context):
     """Return an HttpResponse with content that encodes template_name and context"""
+    # View confirm_email_change uses @transaction.commit_manually.
+    # This simulates any db access in the templates.
+    UserProfile.objects.exists()
     return HttpResponse(mock_render_to_string(template_name, context))
 
 

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1315,8 +1315,9 @@ def confirm_email_change(request, key):
         try:
             pec = PendingEmailChange.objects.get(activation_key=key)
         except PendingEmailChange.DoesNotExist:
+            response = render_to_response("invalid_email_key.html", {})
             transaction.rollback()
-            return render_to_response("invalid_email_key.html", {})
+            return response
 
         user = pec.user
         address_context = {
@@ -1325,8 +1326,9 @@ def confirm_email_change(request, key):
         }
 
         if len(User.objects.filter(email=pec.new_email)) != 0:
+            response = render_to_response("email_exists.html", {})
             transaction.rollback()
-            return render_to_response("email_exists.html", {})
+            return response
 
         subject = render_to_string('emails/email_change_subject.txt', address_context)
         subject = ''.join(subject.splitlines())
@@ -1342,9 +1344,10 @@ def confirm_email_change(request, key):
         try:
             user.email_user(subject, message, settings.DEFAULT_FROM_EMAIL)
         except Exception:
-            transaction.rollback()
             log.warning('Unable to send confirmation email to old address', exc_info=True)
-            return render_to_response("email_change_failed.html", {'email': user.email})
+            response = render_to_response("email_change_failed.html", {'email': user.email})
+            transaction.rollback()
+            return response
 
         user.email = pec.new_email
         user.save()
@@ -1353,12 +1356,14 @@ def confirm_email_change(request, key):
         try:
             user.email_user(subject, message, settings.DEFAULT_FROM_EMAIL)
         except Exception:
-            transaction.rollback()
             log.warning('Unable to send confirmation email to new address', exc_info=True)
-            return render_to_response("email_change_failed.html", {'email': pec.new_email})
+            response = render_to_response("email_change_failed.html", {'email': pec.new_email})
+            transaction.rollback()
+            return response
 
+        response = render_to_response("email_change_successful.html", address_context)
         transaction.commit()
-        return render_to_response("email_change_successful.html", address_context)
+        return response
     except Exception:
         # If we get an unexpected exception, be sure to rollback the transaction
         transaction.rollback()


### PR DESCRIPTION
https://edx-wiki.atlassian.net/browse/LMS-1222

667a1eadb5abd6af589b56911dfdd66664f337dc introduced a database access in every template render which includes navigation.html (if the shopping cart is enabled). Since student.view.confirm_email_change does manual commit and the templates are being rendered after doing a commit or rollback, the render call does a database access which starts a new transaction and a "Transaction managed block ended with pending COMMIT/ROLLBACK" exception. This PR moves the rendering up so that it happens before the transaction rollback/commit.

https://github.com/edx/edx-platform/commit/667a1eadb5abd6af589b56911dfdd66664f337dc#diff-048caae8c14e1173bb610853315c5b7f

@jbau @cpennington, can you review this? I tried to get the existing tests to fail by trying to patch the settings but apparently the templates are not really rendered and so that did not work. If we need tests for this any suggestions?
