### PR TITLE
fix for missing sass variable for LTI

### DIFF
--- a/common/static/sass/_mixins-inherited.scss
+++ b/common/static/sass/_mixins-inherited.scss
@@ -281,7 +281,7 @@
   }
 }
 
-@mixin gray-button {
+.gray-button {
   @include button;
   @include linear-gradient(top, $white-t1, rgba(255, 255, 255, 0));
   box-shadow: 0 1px 0 $white-t1 inset;


### PR DESCRIPTION
This fixes the gray-button optional sass warning. @talbs and @jzoldak can you review?
