### PR TITLE
re-enable tender

### DIFF
--- a/cms/templates/base.html
+++ b/cms/templates/base.html
@@ -207,6 +207,7 @@ require(['js/models/course'], function(Course) {
       % endif
 
       <%include file="widgets/footer.html" />
+      <%include file="widgets/tender.html" />
 
       <div id="page-notification"></div>
     </div>


### PR DESCRIPTION
Tender fixed their buggy Javascript: https://help.tenderapp.com/discussions/problems/53496-tender-breaks-javascript-on-pages-with-requirejs
