### PR TITLE
some layout tweaks to the verification choose your track page

### DIFF
--- a/lms/static/sass/views/_verification.scss
+++ b/lms/static/sass/views/_verification.scss
@@ -751,6 +751,7 @@
 
             .action {
               @extend %btn-verify-primary;
+              padding: ($baseline/2) ($baseline*0.75);
             }
           }
         }

--- a/lms/static/sass/views/_verification.scss
+++ b/lms/static/sass/views/_verification.scss
@@ -1210,7 +1210,7 @@
       background: $m-gray-l4;
 
       &:last-child {
-        margin-bottom: none;
+        margin-bottom: 0;
       }
 
       .wrapper-copy, .list-actions {
@@ -1797,7 +1797,7 @@
         &:last-child {
           margin-bottom: 0;
           border-bottom: none;
-          padding-bottom: none;
+          padding-bottom: 0;
         }
 
         > .title {

--- a/lms/static/sass/views/_verification.scss
+++ b/lms/static/sass/views/_verification.scss
@@ -1190,7 +1190,7 @@
     .form-register-choose {
       @include clearfix();
       width: flex-grid(12,12);
-      margin: $baseline 0;
+      margin: ($baseline*2) 0;
 
       .deco-divider {
         width: flex-grid(8,12);
@@ -1352,12 +1352,13 @@
 
       .field {
         float: left;
-        margin-right: ($baseline/2);
+        margin: 0 ($baseline/2) ($baseline/2) 0;
         padding: ($baseline/2) ($baseline*0.75);
         background: $m-gray-t0;
 
         input {
           width: auto;
+          padding: 0;
         }
 
         &:last-child {


### PR DESCRIPTION
A few small alignment tweaks to the chose your track page that I noticed, namely setting an explicit padding on the radio inputs for IE, adding the margin-bottom back in on the price options so they have spacing when wrapping, and adding some extra padding to the form as a whole so the verification badge doesn't bump the title underline. @talbs can you review?
