### PR TITLE
Write Django logs to file during acceptance tests

### DIFF
--- a/cms/envs/acceptance.py
+++ b/cms/envs/acceptance.py
@@ -14,9 +14,10 @@ from lms.envs.sauce import *
 # otherwise the browser will not render the pages correctly
 DEBUG = True
 
-# Disable warnings for acceptance tests, to make the logs readable
+# Output Django logs to a file
 import logging
-logging.disable(logging.ERROR)
+logging.basicConfig(filename=TEST_ROOT / "log" / "cms_acceptance.log", level=logging.ERROR)
+
 import os
 from random import choice, randint
 

--- a/docs/internal/testing.md
+++ b/docs/internal/testing.md
@@ -231,6 +231,8 @@ Acceptance tests will run on a randomized port and can be run in the background 
 To specify the port, change the LETTUCE_SERVER_PORT constant in cms/envs/acceptance.py and lms/envs/acceptance.py
 as well as the port listed in cms/djangoapps/contentstore/feature/upload.py
 
+During acceptance test execution, Django log files are written to `test_root/log/lms_acceptance.log` and `test_root/log/cms_acceptance.log`.
+
 **Note**: The acceptance tests can *not* currently run in parallel.
 
 ## Viewing Test Coverage

--- a/lms/envs/acceptance.py
+++ b/lms/envs/acceptance.py
@@ -14,9 +14,10 @@ from .sauce import *
 # otherwise the browser will not render the pages correctly
 DEBUG = True
 
-# Disable warnings for acceptance tests, to make the logs readable
+# Output Django logs to a file
 import logging
-logging.disable(logging.ERROR)
+logging.basicConfig(filename=TEST_ROOT / "log" / "lms_acceptance.log", level=logging.ERROR)
+
 import os
 from random import choice, randint
 import string


### PR DESCRIPTION
The log file is pretty cluttered right now, but this could be useful for tracking down server errors.  This writes the log to `test_root/log/lms_acceptance.log` and `test_root/log/cms_acceptance.log`, which the Jenkins jobs can then archive and make available.

@jzoldak 
