### PR TITLE
Ensure contentstore has no assets before generating test set

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_assets.py
+++ b/cms/djangoapps/contentstore/tests/test_assets.py
@@ -174,6 +174,8 @@ class TestAssetIndex(CourseTestCase):
         course_filter = Location(
             XASSET_LOCATION_TAG, category='asset', course=self.course.location.course, org=self.course.location.org
         )
+        # purge existing entries (a bit brutal but hopefully tests are independent enuf to not trip on this)
+        cstore.fs_files.remove(course_filter.dict())
         base_entry = {
             'displayname': 'foo.jpg',
             'chunkSize': 262144,


### PR DESCRIPTION
Although I can't reproduce it, jenkins had a failure where it reported there were 270 entries on the page rather than 100. I believe that could be left-over cruft from some other test; so, I wrote the code to clear the asset list before generating the test set.

@cahrens @wedaly please review
