### PR TITLE
Fixed LMS-1062

### DIFF
--- a/common/djangoapps/course_modes/views.py
+++ b/common/djangoapps/course_modes/views.py
@@ -34,7 +34,8 @@ class ChooseModeView(View):
     @method_decorator(login_required)
     def get(self, request, course_id, error=None):
         """ Displays the course mode choice page """
-        if CourseEnrollment.enrollment_mode_for_user(request.user, course_id) == 'verified':
+        # if the user is already enrolled, don't let them try to register again
+        if CourseEnrollment.enrollment_mode_for_user(request.user, course_id) != None:
             return redirect(reverse('dashboard'))
         modes = CourseMode.modes_for_course_dict(course_id)
 


### PR DESCRIPTION
If you chose to register for a course using audit/honors certificate option, then went back to the "choose track" link in your history, you were able to register for the course a second time, despite already having been registered.

Now, if you are registered for a course already, you are redirected to the courseware page.

@dianakhuang @ormsbee 
