### PR TITLE
LMS: CSS Fixes for Re-architected Pipeline

### DIFF
--- a/lms/static/sass/base/_reset.scss
+++ b/lms/static/sass/base/_reset.scss
@@ -54,7 +54,6 @@ input[type="search"]::-webkit-search-decoration, input[type="search"]::-webkit-s
 button::-moz-focus-inner, input::-moz-focus-inner { border: 0; padding: 0; }
 textarea { overflow: auto; vertical-align: top; resize: vertical; }
 input:valid, textarea:valid {  }
-input:invalid, textarea:invalid { background-color: #f0dddd; }
 
 table { border-collapse: collapse; border-spacing: 0; }
 td { vertical-align: top; }
@@ -70,7 +69,7 @@ td { vertical-align: top; }
 
 
 @media only screen and (min-width: 35em) {
-  
+
 
 }
 
@@ -85,13 +84,13 @@ td { vertical-align: top; }
 .clearfix { *zoom: 1; }
 
 @media print {
-  * { background: transparent !important; color: black !important; box-shadow:none !important; text-shadow: none !important; filter:none !important; -ms-filter: none !important; } 
+  * { background: transparent !important; color: black !important; box-shadow:none !important; text-shadow: none !important; filter:none !important; -ms-filter: none !important; }
   a, a:visited { text-decoration: underline; }
   a[href]:after { content: " (" attr(href) ")"; }
   abbr[title]:after { content: " (" attr(title) ")"; }
-  .ir a:after, a[href^="javascript:"]:after, a[href^="#"]:after { content: ""; } 
+  .ir a:after, a[href^="javascript:"]:after, a[href^="#"]:after { content: ""; }
   pre, blockquote { border: 1px solid #999; page-break-inside: avoid; }
-  thead { display: table-header-group; } 
+  thead { display: table-header-group; }
   tr, img { page-break-inside: avoid; }
   img { max-width: 100% !important; }
   @page { margin: 0.5cm; }

--- a/lms/static/sass/ie.scss
+++ b/lms/static/sass/ie.scss
@@ -187,7 +187,7 @@
   }
 }
 
-.lte8 {
+.lte9 {
 
   .ie-banner {
     display: block !important;

--- a/lms/static/sass/ie.scss
+++ b/lms/static/sass/ie.scss
@@ -154,10 +154,6 @@
     display: none;
   }
 
-  .ie-banner {
-    display: block !important;
-  }
-
   div.course-wrapper {
     display: block !important;
 
@@ -186,4 +182,14 @@
     }
   }
 
+  .course-wrapper {
+    clear: both !important;
+  }
+}
+
+.lte8 {
+
+  .ie-banner {
+    display: block !important;
+  }
 }

--- a/lms/templates/stripped-main.html
+++ b/lms/templates/stripped-main.html
@@ -14,6 +14,8 @@
 
   <%static:css group='style-vendor'/>
   <%static:css group='style-app'/>
+  <%static:css group='style-app-extend1'/>
+  <%static:css group='style-app-extend2'/>
 
   <%static:js group='main_vendor'/>
   <%block name="headextra"/>


### PR DESCRIPTION
This work contains the following minutia CSS fixes:
- removing default :invalid pseudo classes from input elements (was clobbering basic form styling and is not needed)
- changing the IE banner warning to use the new IE classes applied to the HTML element
- syncing up edge-based views with new pipeline asset references
