### PR TITLE
Student Dash: Disable "Email Settings" when course isn't authorized

### DIFF
--- a/common/djangoapps/student/tests/test_bulk_email_settings.py
+++ b/common/djangoapps/student/tests/test_bulk_email_settings.py
@@ -1,0 +1,134 @@
+"""
+Unit tests for email feature flag in student dashboard. Additionally tests
+that bulk email is always disabled for non-Mongo backed courses, regardless
+of email feature flag, and that the view is conditionally available when
+Course Auth is turned on.
+"""
+
+from django.test.utils import override_settings
+from django.conf import settings
+from django.core.urlresolvers import reverse, NoReverseMatch
+from unittest.case import SkipTest
+
+from courseware.tests.tests import TEST_DATA_MONGO_MODULESTORE
+from student.tests.factories import UserFactory, CourseEnrollmentFactory
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory
+from courseware.tests.modulestore_config import TEST_DATA_MIXED_MODULESTORE
+
+from bulk_email.models import CourseAuthorization
+
+from mock import patch
+
+
+@override_settings(MODULESTORE=TEST_DATA_MONGO_MODULESTORE)
+class TestStudentDashboardEmailView(ModuleStoreTestCase):
+    """
+    Check for email view displayed with flag
+    """
+    def setUp(self):
+        self.course = CourseFactory.create()
+
+        # Create student account
+        student = UserFactory.create()
+        CourseEnrollmentFactory.create(user=student, course_id=self.course.id)
+        self.client.login(username=student.username, password="test")
+
+        try:
+            # URL for dashboard
+            self.url = reverse('dashboard')
+        except NoReverseMatch:
+            raise SkipTest("Skip this test if url cannot be found (ie running from CMS tests)")
+        # URL for email settings modal
+        self.email_modal_link = (
+            ('<a href="#email-settings-modal" class="email-settings" rel="leanModal" '
+             'data-course-id="{0}/{1}/{2}" data-course-number="{1}" '
+             'data-optout="False">Email Settings</a>').format(
+                 self.course.org,
+                 self.course.number,
+                 self.course.display_name.replace(' ', '_')
+             )
+        )
+
+    def tearDown(self):
+        """
+        Undo all patches.
+        """
+        patch.stopall()
+
+    @patch.dict(settings.MITX_FEATURES, {'ENABLE_INSTRUCTOR_EMAIL': True, 'REQUIRE_COURSE_EMAIL_AUTH': False})
+    def test_email_flag_true(self):
+        # Assert that the URL for the email view is in the response
+        response = self.client.get(self.url)
+        self.assertTrue(self.email_modal_link in response.content)
+
+    @patch.dict(settings.MITX_FEATURES, {'ENABLE_INSTRUCTOR_EMAIL': False})
+    def test_email_flag_false(self):
+        # Assert that the URL for the email view is not in the response
+        response = self.client.get(self.url)
+        self.assertFalse(self.email_modal_link in response.content)
+
+    @patch.dict(settings.MITX_FEATURES, {'ENABLE_INSTRUCTOR_EMAIL': True, 'REQUIRE_COURSE_EMAIL_AUTH': True})
+    def test_email_unauthorized(self):
+        # Assert that instructor email is not enabled for this course
+        self.assertFalse(CourseAuthorization.instructor_email_enabled(self.course.id))
+        # Assert that the URL for the email view is not in the response
+        # if this course isn't authorized
+        response = self.client.get(self.url)
+        self.assertFalse(self.email_modal_link in response.content)
+
+    @patch.dict(settings.MITX_FEATURES, {'ENABLE_INSTRUCTOR_EMAIL': True, 'REQUIRE_COURSE_EMAIL_AUTH': True})
+    def test_email_authorized(self):
+        # Authorize the course to use email
+        cauth = CourseAuthorization(course_id=self.course.id, email_enabled=True)
+        cauth.save()
+        # Assert that instructor email is enabled for this course
+        self.assertTrue(CourseAuthorization.instructor_email_enabled(self.course.id))
+        # Assert that the URL for the email view is not in the response
+        # if this course isn't authorized
+        response = self.client.get(self.url)
+        self.assertTrue(self.email_modal_link in response.content)
+
+
+@override_settings(MODULESTORE=TEST_DATA_MIXED_MODULESTORE)
+class TestStudentDashboardEmailViewXMLBacked(ModuleStoreTestCase):
+    """
+    Check for email view on student dashboard, with XML backed course.
+    """
+    def setUp(self):
+        self.course_name = 'edX/toy/2012_Fall'
+
+        # Create student account
+        student = UserFactory.create()
+        CourseEnrollmentFactory.create(user=student, course_id=self.course_name)
+        self.client.login(username=student.username, password="test")
+
+        try:
+            # URL for dashboard
+            self.url = reverse('dashboard')
+        except NoReverseMatch:
+            raise SkipTest("Skip this test if url cannot be found (ie running from CMS tests)")
+
+        # URL for email settings modal
+        self.email_modal_link = (
+            ('<a href="#email-settings-modal" class="email-settings" rel="leanModal" '
+             'data-course-id="{0}/{1}/{2}" data-course-number="{1}" '
+             'data-optout="False">Email Settings</a>').format(
+                 'edX',
+                 'toy',
+                 '2012_Fall'
+             )
+        )
+
+    @patch.dict(settings.MITX_FEATURES, {'ENABLE_INSTRUCTOR_EMAIL': True, 'REQUIRE_COURSE_EMAIL_AUTH': False})
+    def test_email_flag_true_xml_store(self):
+        # The flag is enabled, and since REQUIRE_COURSE_EMAIL_AUTH is False, all courses should
+        # be authorized to use email. But the course is not Mongo-backed (should not work)
+        response = self.client.get(self.url)
+        self.assertFalse(self.email_modal_link in response.content)
+
+    @patch.dict(settings.MITX_FEATURES, {'ENABLE_INSTRUCTOR_EMAIL': False, 'REQUIRE_COURSE_EMAIL_AUTH': False})
+    def test_email_flag_false_xml_store(self):
+        # Email disabled, shouldn't see link.
+        response = self.client.get(self.url)
+        self.assertFalse(self.email_modal_link in response.content)

--- a/lms/djangoapps/instructor/tests/test_email.py
+++ b/lms/djangoapps/instructor/tests/test_email.py
@@ -1,7 +1,8 @@
 """
 Unit tests for email feature flag in new instructor dashboard.
 Additionally tests that bulk email is always disabled for
-non-Mongo backed courses, regardless of email feature flag.
+non-Mongo backed courses, regardless of email feature flag, and
+that the view is conditionally available when Course Auth is turned on.
 """
 
 from django.test.utils import override_settings

--- a/lms/djangoapps/instructor/tests/test_email.py
+++ b/lms/djangoapps/instructor/tests/test_email.py
@@ -90,7 +90,7 @@ class TestNewInstructorDashboardEmailViewMongoBacked(ModuleStoreTestCase):
 
         # Assert that instructor email is enabled for this course
         self.assertTrue(CourseAuthorization.instructor_email_enabled(self.course.id))
-        # Assert that the URL for the email view is not in the response
+        # Assert that the URL for the email view is in the response
         response = self.client.get(self.url)
         self.assertTrue(self.email_link in response.content)
 

--- a/lms/djangoapps/instructor/tests/test_legacy_email.py
+++ b/lms/djangoapps/instructor/tests/test_legacy_email.py
@@ -1,16 +1,15 @@
 """
-Unit tests for email feature flag in legacy instructor dashboard
-and student dashboard. Additionally tests that bulk email
-is always disabled for non-Mongo backed courses, regardless
-of email feature flag.
+Unit tests for email feature flag in legacy instructor dashboard.
+Additionally tests that bulk email is always disabled for non-Mongo
+backed courses, regardless of email feature flag, and that the
+view is conditionally available when Course Auth is turned on.
 """
-
 from django.test.utils import override_settings
 from django.conf import settings
 from django.core.urlresolvers import reverse
 
 from courseware.tests.tests import TEST_DATA_MONGO_MODULESTORE
-from student.tests.factories import AdminFactory, UserFactory, CourseEnrollmentFactory
+from student.tests.factories import AdminFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 from xmodule.modulestore import XML_MODULESTORE_TYPE
@@ -109,62 +108,3 @@ class TestInstructorDashboardEmailView(ModuleStoreTestCase):
             # Assert that the URL for the email view is not in the response
             response = self.client.get(self.url)
             self.assertFalse(self.email_link in response.content)
-
-
-@override_settings(MODULESTORE=TEST_DATA_MONGO_MODULESTORE)
-class TestStudentDashboardEmailView(ModuleStoreTestCase):
-    """
-    Check for email view displayed with flag
-    """
-    def setUp(self):
-        self.course = CourseFactory.create()
-
-        # Create student account
-        student = UserFactory.create()
-        CourseEnrollmentFactory.create(user=student, course_id=self.course.id)
-        self.client.login(username=student.username, password="test")
-
-        # URL for dashboard
-        self.url = reverse('dashboard')
-        # URL for email settings modal
-        self.email_modal_link = (('<a href="#email-settings-modal" class="email-settings" rel="leanModal" '
-                                 'data-course-id="{0}/{1}/{2}" data-course-number="{1}" '
-                                 'data-optout="False">Email Settings</a>')
-                                 .format(self.course.org,
-                                         self.course.number,
-                                         self.course.display_name.replace(' ', '_')))
-
-    def tearDown(self):
-        """
-        Undo all patches.
-        """
-        patch.stopall()
-
-    @patch.dict(settings.MITX_FEATURES, {'ENABLE_INSTRUCTOR_EMAIL': True})
-    def test_email_flag_true(self):
-        # Assert that the URL for the email view is in the response
-        response = self.client.get(self.url)
-        self.assertTrue(self.email_modal_link in response.content)
-
-    @patch.dict(settings.MITX_FEATURES, {'ENABLE_INSTRUCTOR_EMAIL': False})
-    def test_email_flag_false(self):
-        # Assert that the URL for the email view is not in the response
-        response = self.client.get(self.url)
-        self.assertFalse(self.email_modal_link in response.content)
-
-    @patch.dict(settings.MITX_FEATURES, {'ENABLE_INSTRUCTOR_EMAIL': True})
-    def test_email_flag_true_xml_store(self):
-        # If the enable email setting is enabled, but this is an XML backed course,
-        # the email view shouldn't be available on the instructor dashboard.
-
-        # The course factory uses a MongoModuleStore backing, so patch the
-        # `get_modulestore_type` method to pretend to be XML-backed.
-        # This is OK; we're simply testing that the `is_mongo_modulestore_type` flag
-        # in `instructor/views/legacy.py` is doing the correct thing.
-
-        with patch('xmodule.modulestore.mongo.base.MongoModuleStore.get_modulestore_type') as mock_modulestore:
-            mock_modulestore.return_value = XML_MODULESTORE_TYPE
-
-            # Assert that the URL for the email view is not in the response
-            response = self.client.get(self.url)
-            self.assertFalse(self.email_modal_link in response.content)

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -9,6 +9,8 @@
   from xmodule.modulestore import MONGO_MODULESTORE_TYPE
   from xmodule.modulestore.django import modulestore
 
+  from bulk_email.models import CourseAuthorization
+
   import waffle
 %>
 <%inherit file="main.html" />
@@ -326,7 +328,7 @@
 
               <a href="#unenroll-modal" class="unenroll" rel="leanModal" data-course-id="${course.id}" data-course-number="${course.number}">${_('Unregister')}</a>
 
-  	    % if settings.MITX_FEATURES['ENABLE_INSTRUCTOR_EMAIL'] and modulestore().get_modulestore_type(course.id) == MONGO_MODULESTORE_TYPE:
+  	    % if settings.MITX_FEATURES['ENABLE_INSTRUCTOR_EMAIL'] and modulestore().get_modulestore_type(course.id) == MONGO_MODULESTORE_TYPE and CourseAuthorization.instructor_email_enabled(course.id):
   	      <!-- Only show the Email Settings link/modal if this course has bulk email feature enabled -->
                 <a href="#email-settings-modal" class="email-settings" rel="leanModal" data-course-id="${course.id}" data-course-number="${course.number}" data-optout="${course.id in course_optouts}">${_('Email Settings')}</a>
   	    % endif


### PR DESCRIPTION
I missed this in PR https://github.com/edx/edx-platform/pull/1322 - whoops.

I also added some missing course auth tests around the legacy dashboard, and moved the student view tests into common/djangoapps/student/tests because that makes a ton more sense.
