### PR TITLE
Fix for static path parsing

### DIFF
--- a/common/djangoapps/static_replace/test/test_static_replace.py
+++ b/common/djangoapps/static_replace/test/test_static_replace.py
@@ -90,6 +90,20 @@ def test_raw_static_check():
     assert_equals(path, replace_static_urls(path, text))
 
 
+@patch('static_replace.staticfiles_storage')
+@patch('static_replace.modulestore')
+def test_static_url_with_query(mock_modulestore, mock_storage):
+    """
+    Make sure urls with query have the parameter section unaltered
+    """
+    mock_storage.exists.return_value = False
+    mock_modulestore.return_value = Mock(MongoModuleStore)
+
+    pre_text = 'EMBED src ="/static/LAlec04_controller.swf?csConfigFile=/c4x/org/course/asset/LAlec04_config.xml"'
+    post_text = 'EMBED src ="/c4x/org/course/asset/LAlec04_controller.swf?csConfigFile=/c4x/org/course/asset/LAlec04_config.xml"'
+    assert_equals(post_text, replace_static_urls(pre_text, DATA_DIRECTORY, COURSE_ID))
+
+
 def test_regex():
     yes = ('"/static/foo.png"',
            '"/static/foo.png"',

--- a/common/lib/xmodule/xmodule/contentstore/content.py
+++ b/common/lib/xmodule/xmodule/contentstore/content.py
@@ -6,6 +6,7 @@ XASSET_THUMBNAIL_TAIL_NAME = '.jpg'
 import os
 import logging
 import StringIO
+from urlparse import urlparse, urlunparse
 
 from xmodule.modulestore import Location
 from .django import contentstore
@@ -125,8 +126,14 @@ class StaticContent(object):
         a course_id
         """
         org, course_num, __ = course_id.split("/")
-        loc = StaticContent.compute_location(org, course_num, path)
-        return StaticContent.get_url_path_from_location(loc)
+
+        # Generate url of urlparse.path component
+        scheme, netloc, orig_path, params, query, fragment = urlparse(path)
+        loc = StaticContent.compute_location(org, course_num, orig_path)
+        loc_url = StaticContent.get_url_path_from_location(loc)
+
+        # Reconstruct with new path
+        return urlunparse((scheme, netloc, loc_url, params, query, fragment))
 
     def stream_data(self):
         yield self._data


### PR DESCRIPTION
When a url contains a query parameter it gets incorrectly parsed
when replacing the /static portion.

This fix introduces a special case for urls with query parameters.

Fix for JIRA issue: LMS-1377
