### PR TITLE
Caption functionality announced when tabbing to list

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
@@ -432,14 +432,18 @@ function () {
         // outline has to be drawn (tabbing) or not (mouse click).
         this.videoCaption.isMouseFocus = false;
 
+        // Set top and bottom spacing heigh and make sure they are taken out of
+        // the tabbing order.
         this.videoCaption.subtitlesEl
             .prepend(
                 $('<li class="spacing">')
                     .height(this.videoCaption.topSpacingHeight())
+                    .attr('tabindex', -1)
             )
             .append(
                 $('<li class="spacing">')
                     .height(this.videoCaption.bottomSpacingHeight())
+                    .attr('tabindex', -1)
             );
 
         this.videoCaption.rendered = true;

--- a/lms/templates/video.html
+++ b/lms/templates/video.html
@@ -85,7 +85,7 @@
             </section>
         </article>
 
-        <ol class="subtitles" tabindex="0" title="Captions"><li></li></ol>
+        <ol class="subtitles" tabindex="0" title="${_('Captions')}" role="group" aria-label="${_('Activating an item in this group will spool the video to the corresponding time point')}"><li></li></ol>
     </div>
 
     <div class="focus_grabber last"></div>


### PR DESCRIPTION
@valera-rozuvan @polesye Please review.

This PR actually fixes two issues:
1. The two spacing li elements had a tab index equal to 0 (inherited from ol parent). They were therefore selectable with a mouse click, resulting in an unwanted outline appearing around the the entire caption container. It has been set to -1.
2. A role='group' attribute has been added to the caption container (ol element) as well as an ARIA attribute, aria-label, which describes the functionality of tabbing to a caption and selecting it. It addresses the following issue:

https://edx-wiki.atlassian.net/browse/BLD-404

On tabbing to the ol element, this will be announced:

'Activating an item in this group will spool the video to the corresponding time point.  group with … items'

Information on the group value for the role attribute can be found here:

http://www.w3.org/TR/wai-aria/roles#group

It is mentioned that 'authors MUST limit its children to listitem'. Doing that will result in the captions not being read by a screen reader like Voice Over. The other alternative, set the role of ol to 'list' and the li children to 'listitem'  will have the adverse effect of reading the above help when tabbing to the first caption, after reading its text.  
