### PR TITLE
Added explicit wait to avoid reading default grading value

### DIFF
--- a/cms/djangoapps/contentstore/features/grading.py
+++ b/cms/djangoapps/contentstore/features/grading.py
@@ -195,8 +195,12 @@ def i_change_grace_period(_step, grace_period):
 @step(u'I see the grace period is "(.*)"$')
 def the_grace_period_is(_step, grace_period):
     grace_period_css = '#course-grading-graceperiod'
-    ele = world.css_find(grace_period_css).first
-    assert_equal(ele.value, grace_period)
+
+    # The default value is 00:00
+    # so we need to wait for it to change
+    world.wait_for(
+        lambda _: world.css_has_value(grace_period_css, grace_period)
+    )
 
 
 def get_type_index(name):


### PR DESCRIPTION
This should fix this failure: https://jenkins.testeng.edx.org/job/edx-all-tests-auto-master/184/SHARD=1,TEST_SUITE=cms-acceptance/testReport/junit/CMS/Course%20Grading%20_%20User%20can%20set%20a%20grace%20period%20greater%20than%20one%20day/Then_I_see_the_grace_period_is__48_00_/

I haven't been able to reproduce it locally, but I think the issue is that backbone is putting in a default value "00:00" before changing it to the actual value.  When we read the value too soon, the test fails.

Reviewer: @jzoldak 
