### PR TITLE
Simple cleanups of DictFieldData

### DIFF
--- a/common/lib/xmodule/xmodule/tests/test_annotatable_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_annotatable_module.py
@@ -13,7 +13,6 @@ from xmodule.modulestore import Location
 from . import get_test_system
 
 class AnnotatableModuleTestCase(unittest.TestCase):
-    location = Location(["i4x", "edX", "toy", "annotatable", "guided_discussion"])
     sample_xml = '''
         <annotatable display_name="Iliad">
             <instructions>Read the text.</instructions>
@@ -30,14 +29,12 @@ class AnnotatableModuleTestCase(unittest.TestCase):
             <annotation title="footnote" body="the end">The Iliad of Homer by Samuel Butler</annotation>
         </annotatable>
     '''
-    descriptor = Mock()
-    field_data = DictFieldData({'data': sample_xml})
 
     def setUp(self):
         self.annotatable = AnnotatableModule(
-            self.descriptor,
+            Mock(),
             get_test_system(),
-            self.field_data,
+            DictFieldData({'data': self.sample_xml}),
             ScopeIds(None, None, None, None)
         )
 

--- a/common/lib/xmodule/xmodule/tests/test_xblock_wrappers.py
+++ b/common/lib/xmodule/xmodule/tests/test_xblock_wrappers.py
@@ -68,6 +68,8 @@ NOT_STUDIO_EDITABLE = (
 
 
 class TestXBlockWrapper(object):
+    """Helper methods used in test case classes below."""
+
     @property
     def leaf_module_runtime(self):
         runtime = ModuleSystem(

--- a/common/lib/xmodule/xmodule/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module.py
@@ -28,8 +28,6 @@ from xmodule.xml_module import is_pointer_tag, name_to_pathname, deserialize_fie
 from xmodule.modulestore import Location
 from xblock.fields import Scope, String, Boolean, Float, List, Integer, ScopeIds
 
-from xblock.field_data import DictFieldData
-
 from xmodule.modulestore.inheritance import InheritanceKeyValueStore
 from xblock.runtime import DbModel
 

--- a/lms/djangoapps/open_ended_grading/utils.py
+++ b/lms/djangoapps/open_ended_grading/utils.py
@@ -12,8 +12,6 @@ from django.conf import settings
 
 from mitxmako.shortcuts import render_to_string
 
-from xblock.field_data import DictFieldData
-
 import logging
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
I tried to make DictFieldData strict about only being used with one
block.  That effort failed ultimately, but these are reasonable changes
I made along the way.
