### PR TITLE
Configure MathJax using require.js

### DIFF
--- a/cms/static/coffee/spec/main.coffee
+++ b/cms/static/coffee/spec/main.coffee
@@ -33,7 +33,7 @@ requirejs.config({
         "draggabilly": "xmodule_js/common_static/js/vendor/draggabilly.pkgd",
         "domReady": "xmodule_js/common_static/js/vendor/domReady",
 
-        "mathjax": "//edx-static.s3.amazonaws.com/mathjax-MathJax-727332c/MathJax.js?config=TeX-MML-AM_HTMLorMML-full",
+        "mathjax": "//edx-static.s3.amazonaws.com/mathjax-MathJax-727332c/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&delayStartupUntil=configured",
         "youtube": "//www.youtube.com/player_api?noext",
         "tender": "//edxedge.tenderapp.com/tender_widget"
 
@@ -114,7 +114,19 @@ requirejs.config({
             exports: "tinymce"
         },
         "mathjax": {
-            exports: "MathJax"
+            exports: "MathJax",
+            init: ->
+              MathJax.Hub.Config
+                tex2jax:
+                  inlineMath: [
+                    ["\\(","\\)"],
+                    ['[mathjaxinline]','[/mathjaxinline]']
+                  ]
+                  displayMath: [
+                    ["\\[","\\]"],
+                    ['[mathjax]','[/mathjax]']
+                  ]
+              MathJax.Hub.Configured()
         },
         "xmodule": {
             exports: "XModule"

--- a/cms/static/coffee/spec/main_squire.coffee
+++ b/cms/static/coffee/spec/main_squire.coffee
@@ -33,7 +33,7 @@ requirejs.config({
         "draggabilly": "xmodule_js/common_static/js/vendor/draggabilly.pkgd",
         "domReady": "xmodule_js/common_static/js/vendor/domReady",
 
-        "mathjax": "//edx-static.s3.amazonaws.com/mathjax-MathJax-727332c/MathJax.js?config=TeX-MML-AM_HTMLorMML-full",
+        "mathjax": "//edx-static.s3.amazonaws.com/mathjax-MathJax-727332c/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&delayStartupUntil=configured",
         "youtube": "//www.youtube.com/player_api?noext",
         "tender": "//edxedge.tenderapp.com/tender_widget.js"
 
@@ -114,7 +114,19 @@ requirejs.config({
             exports: "tinymce"
         },
         "mathjax": {
-            exports: "MathJax"
+            exports: "MathJax",
+            init: ->
+              MathJax.Hub.Config
+                tex2jax:
+                  inlineMath: [
+                    ["\\(","\\)"],
+                    ['[mathjaxinline]','[/mathjaxinline]']
+                  ]
+                  displayMath: [
+                    ["\\[","\\]"],
+                    ['[mathjax]','[/mathjax]']
+                  ]
+              MathJax.Hub.Configured();
         },
         "xmodule": {
             exports: "XModule"

--- a/cms/templates/base.html
+++ b/cms/templates/base.html
@@ -69,7 +69,7 @@ var require = {
 
         // externally hosted files
         "tender": "//edxedge.tenderapp.com/tender_widget",
-        "mathjax": "//edx-static.s3.amazonaws.com/mathjax-MathJax-727332c/MathJax.js?config=TeX-MML-AM_HTMLorMML-full",
+        "mathjax": "//edx-static.s3.amazonaws.com/mathjax-MathJax-727332c/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&delayStartupUntil=configured",
         // youtube URL does not end in ".js". We add "?noext" to the path so
         // that require.js adds the ".js" to the query component of the URL,
         // and leaves the path component intact.
@@ -157,7 +157,22 @@ var require = {
             exports: "tinymce"
         },
         "mathjax": {
-            exports: "MathJax"
+            exports: "MathJax",
+            init: function() {
+              MathJax.Hub.Config({
+                tex2jax: {
+                  inlineMath: [
+                    ["\\(","\\)"],
+                    ['[mathjaxinline]','[/mathjaxinline]']
+                  ],
+                  displayMath: [
+                    ["\\[","\\]"],
+                    ['[mathjax]','[/mathjax]']
+                  ]
+                }
+              });
+              MathJax.Hub.Configured();
+            }
         },
 
         "coffee/src/main": {


### PR DESCRIPTION
This was originally being included from `common/templates/mathjax_include.html`. This is a nicer way of including the MathJax configuration.
