### PR TITLE
Will/fix jscover failures

### DIFF
--- a/rakelib/js_test.rake
+++ b/rakelib/js_test.rake
@@ -55,7 +55,7 @@ end
 namespace :'test:js' do
 
     desc "Run the JavaScript tests and print results to the console"
-    task :run, [:env] => [:clean_test_files, :'assets:coffee'] do |t, args|
+    task :run, [:env] => [:clean_test_files, :'assets:coffee', JS_REPORT_DIR] do |t, args|
         if args[:env].nil?
             puts "Running all test suites.  To run a specific test suite, try:"
             print_js_test_cmds('run')

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -18,6 +18,6 @@
 -e git+https://github.com/edx/XBlock.git@cee38a15f#egg=XBlock
 -e git+https://github.com/edx/codejail.git@0a1b468#egg=codejail
 -e git+https://github.com/edx/diff-cover.git@v0.2.6#egg=diff_cover
--e git+https://github.com/edx/js-test-tool.git@v0.1.3#egg=js_test_tool
+-e git+https://github.com/edx/js-test-tool.git@v0.1.4#egg=js_test_tool
 -e git+https://github.com/edx/django-waffle.git@823a102e48#egg=django-waffle
 -e git+https://github.com/edx/event-tracking.git@f0211d702d#egg=event-tracking


### PR DESCRIPTION
Fixes two issues with javascript tests:

1) Updates js-test-tool version to fail gracefully when JSCover dies.  Coverage reports won't be generated, but the build won't fail.

2) Create `reports/javascript` when calling `test:js`.  This is necessary now that the tool generates XUnit reports.

@singingwolfboy 
