### PR TITLE
Parse locator url better

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_course_index.py
+++ b/cms/djangoapps/contentstore/tests/test_course_index.py
@@ -61,7 +61,7 @@ class TestCourseIndex(CourseTestCase):
         Test the error conditions for the access
         """
         locator = loc_mapper().translate_location(self.course.location.course_id, self.course.location, False, True)
-        outline_url = reverse('contentstore.views.course_handler', kwargs={'course_url': unicode(locator)})
+        outline_url = locator.url_reverse('course/', '')
         # register a non-staff member and try to delete the course branch
         non_staff_client, _ = self.createNonStaffAuthedUserClient()
         response = non_staff_client.delete(outline_url, {}, HTTP_ACCEPT='application/json')

--- a/cms/djangoapps/contentstore/views/user.py
+++ b/cms/djangoapps/contentstore/views/user.py
@@ -47,12 +47,13 @@ def index(request):
 
     def format_course_for_view(course):
         # published = false b/c studio manipulates draft versions not b/c the course isn't pub'd
-        course_url = loc_mapper().translate_location(
+        course_loc = loc_mapper().translate_location(
             course.location.course_id, course.location, published=False, add_entry_if_missing=True
         )
         return (
             course.display_name,
-            reverse("contentstore.views.course_handler", kwargs={'course_url': course_url}),
+            # note, couldn't get django reverse to work; so, wrote workaround
+            course_loc.url_reverse('course/', ''),
             get_lms_link_for_item(
                 course.location
             ),

--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -15,10 +15,7 @@
       % if context_course:
       <% 
             ctx_loc = context_course.location
-            index_url = reverse(
-                'contentstore.views.course_handler', 
-                kwargs={'course_url': loc_mapper().translate_location(ctx_loc.course_id, ctx_loc, False, True)}
-            )
+            index_url = loc_mapper().translate_location(ctx_loc.course_id, ctx_loc, False, True).url_reverse('course/', '')
       %>
       <h2 class="info-course">
         <span class="sr">${_("Current Course:")}</span>

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -1,8 +1,10 @@
+import re
 from django.conf import settings
 from django.conf.urls import patterns, include, url
 
 # TODO: This should be removed once the CMS is running via wsgi on all production servers
 import cms.startup as startup
+from xmodule.modulestore import parsers
 startup.run()
 
 # There is a course creators admin table.
@@ -136,7 +138,8 @@ urlpatterns += patterns(
     ),
 
     url(r'^course$', 'index'),
-    url(r'^course/(?P<course_url>.*)$', 'course_handler'),
+    # (?ix) == ignore case and verbose (multiline regex)
+    url(r'(?ix)^course/{}$'.format(parsers.URL_RE_SOURCE), 'course_handler'),
 )
 
 js_info_dict = {

--- a/common/lib/xmodule/xmodule/modulestore/exceptions.py
+++ b/common/lib/xmodule/xmodule/modulestore/exceptions.py
@@ -42,7 +42,7 @@ class VersionConflictError(Exception):
     """
     The caller asked for either draft or published head and gave a version which conflicted with it.
     """
-    def __init__(self, requestedLocation, currentHead):
+    def __init__(self, requestedLocation, currentHeadVersionGuid):
         super(VersionConflictError, self).__init__()
         self.requestedLocation = requestedLocation
-        self.currentHead = currentHead
+        self.currentHeadVersionGuid = currentHeadVersionGuid

--- a/common/lib/xmodule/xmodule/modulestore/locator.py
+++ b/common/lib/xmodule/xmodule/modulestore/locator.py
@@ -266,8 +266,8 @@ class CourseLocator(Locator):
     def url_reverse(self, prefix, postfix):
         """
         Do what reverse is supposed to do but seems unable to do. Generate a url using prefix unicode(self) postfix
-        :param prefix: the beginning of the url (should begin and end with / if non-empty)
-        :param postfix: the part to append to the url (should begin w/ / if non-empty)
+        :param prefix: the beginning of the url (will be forced to begin and end with / if non-empty)
+        :param postfix: the part to append to the url (will be forced to begin w/ / if non-empty)
         """
         if prefix:
             if not prefix.endswith('/'):
@@ -278,13 +278,9 @@ class CourseLocator(Locator):
             prefix = '/'
         if postfix and not postfix.startswith('/'):
             postfix = '/' + postfix
+        elif postfix is None:
+            postfix = ''
         return prefix + unicode(self) + postfix
-
-    def reverse_kwargs(self):
-        """
-        Get the kwargs list to supply to reverse (basically, a dict of the set properties)
-        """
-        return {key: value for key, value in self.__dict__.iteritems() if value is not None}
 
     def init_from_url(self, url):
         """
@@ -451,16 +447,6 @@ class BlockUsageLocator(CourseLocator):
             return BlockUsageLocator(course_id=self.course_id,
                                      branch=self.branch,
                                      usage_id=self.usage_id)
-
-    def reverse_kwargs(self):
-        """
-        Get the kwargs list to supply to reverse (basically, a dict of the set properties)
-        """
-        result = super(BlockUsageLocator, self).reverse_kwargs()
-        if self.usage_id:
-            del result['usage_id']
-            result['block'] = self.usage_id
-        return result
 
     def set_usage_id(self, new):
         """

--- a/common/lib/xmodule/xmodule/modulestore/locator.py
+++ b/common/lib/xmodule/xmodule/modulestore/locator.py
@@ -13,7 +13,7 @@ from bson.errors import InvalidId
 from xmodule.modulestore.exceptions import InsufficientSpecificationError, OverSpecificationError
 
 from .parsers import parse_url, parse_course_id, parse_block_ref
-from .parsers import BRANCH_PREFIX, BLOCK_PREFIX, URL_VERSION_PREFIX
+from .parsers import BRANCH_PREFIX, BLOCK_PREFIX, VERSION_PREFIX
 import re
 from xmodule.modulestore import Location
 
@@ -190,8 +190,8 @@ class CourseLocator(Locator):
             self.init_from_version_guid(version_guid)
         if course_id or branch:
             self.init_from_course_id(course_id, branch)
-        assert self.version_guid or self.course_id, \
-            "Either version_guid or course_id should be set."
+        if self.version_guid is None and self.course_id is None:
+            raise ValueError("Either version_guid or course_id should be set: {}".format(url))
 
     def __unicode__(self):
         """
@@ -200,10 +200,10 @@ class CourseLocator(Locator):
         if self.course_id:
             result = self.course_id
             if self.branch:
-                result += BRANCH_PREFIX + self.branch
+                result += '/' + BRANCH_PREFIX + self.branch
             return result
         elif self.version_guid:
-            return URL_VERSION_PREFIX + str(self.version_guid)
+            return VERSION_PREFIX + str(self.version_guid)
         else:
             # raise InsufficientSpecificationError("missing course_id or version_guid")
             return '<InsufficientSpecificationError: missing course_id or version_guid>'
@@ -263,22 +263,46 @@ class CourseLocator(Locator):
                              version_guid=self.version_guid,
                              branch=self.branch)
 
+    def url_reverse(self, prefix, postfix):
+        """
+        Do what reverse is supposed to do but seems unable to do. Generate a url using prefix unicode(self) postfix
+        :param prefix: the beginning of the url (should begin and end with / if non-empty)
+        :param postfix: the part to append to the url (should begin w/ / if non-empty)
+        """
+        if prefix:
+            if not prefix.endswith('/'):
+                prefix += '/'
+            if not prefix.startswith('/'):
+                prefix = '/' + prefix
+        else:
+            prefix = '/'
+        if postfix and not postfix.startswith('/'):
+            postfix = '/' + postfix
+        return prefix + unicode(self) + postfix
+
+    def reverse_kwargs(self):
+        """
+        Get the kwargs list to supply to reverse (basically, a dict of the set properties)
+        """
+        return {key: value for key, value in self.__dict__.iteritems() if value is not None}
+
     def init_from_url(self, url):
         """
         url must be a string beginning with 'edx://' and containing
         either a valid version_guid or course_id (with optional branch), or both.
         """
         if isinstance(url, Locator):
-            url = url.url()
-        if not isinstance(url, basestring):
+            parse = url.__dict__
+        elif not isinstance(url, basestring):
             raise TypeError('%s is not an instance of basestring' % url)
-        parse = parse_url(url, tag_optional=True)
-        if not parse:
-            raise ValueError('Could not parse "%s" as a url' % url)
+        else:
+            parse = parse_url(url, tag_optional=True)
+            if not parse:
+                raise ValueError('Could not parse "%s" as a url' % url)
         self._set_value(
             parse, 'version_guid', lambda (new_guid): self.set_version_guid(self.as_object_id(new_guid))
         )
-        self._set_value(parse, 'id', lambda (new_id): self.set_course_id(new_id))
+        self._set_value(parse, 'course_id', lambda (new_id): self.set_course_id(new_id))
         self._set_value(parse, 'branch', lambda (new_branch): self.set_branch(new_branch))
 
     def init_from_version_guid(self, version_guid):
@@ -313,9 +337,9 @@ class CourseLocator(Locator):
                     raise ValueError("%s does not have a valid course_id" % course_id)
 
             parse = parse_course_id(course_id)
-            if not parse:
+            if not parse or parse['course_id'] is None:
                 raise ValueError('Could not parse "%s" as a course_id' % course_id)
-            self.set_course_id(parse['id'])
+            self.set_course_id(parse['course_id'])
             rev = parse['branch']
             if rev:
                 self.set_branch(rev)
@@ -396,11 +420,12 @@ class BlockUsageLocator(CourseLocator):
             self.init_block_ref_from_course_id(course_id)
         if usage_id:
             self.init_block_ref(usage_id)
-        CourseLocator.__init__(self,
-                               url=url,
-                               version_guid=version_guid,
-                               course_id=course_id,
-                               branch=branch)
+        super(BlockUsageLocator, self).__init__(
+            url=url,
+            version_guid=version_guid,
+            course_id=course_id,
+            branch=branch
+        )
 
     def is_initialized(self):
         """
@@ -426,6 +451,16 @@ class BlockUsageLocator(CourseLocator):
             return BlockUsageLocator(course_id=self.course_id,
                                      branch=self.branch,
                                      usage_id=self.usage_id)
+
+    def reverse_kwargs(self):
+        """
+        Get the kwargs list to supply to reverse (basically, a dict of the set properties)
+        """
+        result = super(BlockUsageLocator, self).reverse_kwargs()
+        if self.usage_id:
+            del result['usage_id']
+            result['block'] = self.usage_id
+        return result
 
     def set_usage_id(self, new):
         """
@@ -459,10 +494,12 @@ class BlockUsageLocator(CourseLocator):
 
     def init_block_ref_from_course_id(self, course_id):
         if isinstance(course_id, CourseLocator):
+            # FIXME the parsed course_id should never contain a block ref
             course_id = course_id.course_id
             assert course_id, "%s does not have a valid course_id"
         parse = parse_course_id(course_id)
-        assert parse, 'Could not parse "%s" as a course_id' % course_id
+        if parse is None:
+            raise ValueError('Could not parse "%s" as a course_id' % course_id)
         self._set_value(parse, 'block', lambda(new_block): self.set_usage_id(new_block))
 
     def __unicode__(self):
@@ -470,7 +507,7 @@ class BlockUsageLocator(CourseLocator):
         Return a string representing this location.
         """
         rep = super(BlockUsageLocator, self).__unicode__()
-        return rep + BLOCK_PREFIX + unicode(self.usage_id)
+        return rep + '/' + BLOCK_PREFIX + unicode(self.usage_id)
 
 
 class DefinitionLocator(Locator):
@@ -478,7 +515,7 @@ class DefinitionLocator(Locator):
     Container for how to locate a description (the course-independent content).
     """
 
-    URL_RE = re.compile(r'^defx://' + URL_VERSION_PREFIX + '([^/]+)$', re.IGNORECASE)
+    URL_RE = re.compile(r'^defx://' + VERSION_PREFIX + '([^/]+)$', re.IGNORECASE)
     def __init__(self, definition_id):
         if isinstance(definition_id, basestring):
             regex_match = self.URL_RE.match(definition_id)
@@ -491,7 +528,7 @@ class DefinitionLocator(Locator):
         Return a string representing this location.
         unicode(self) returns something like this: "version/519665f6223ebd6980884f2b"
         '''
-        return URL_VERSION_PREFIX + str(self.definition_id)
+        return VERSION_PREFIX + str(self.definition_id)
 
     def url(self):
         """

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
@@ -234,7 +234,7 @@ class SplitMongoModuleStore(ModuleStoreBase):
             version_guid = index['versions'][course_locator.branch]
             if course_locator.version_guid is not None and version_guid != course_locator.version_guid:
                 # This may be a bit too touchy but it's hard to infer intent
-                raise VersionConflictError(course_locator, CourseLocator(course_locator, version_guid=version_guid))
+                raise VersionConflictError(course_locator, version_guid)
         else:
             # TODO should this raise an exception if branch was provided?
             version_guid = course_locator.version_guid
@@ -1005,7 +1005,14 @@ class SplitMongoModuleStore(ModuleStoreBase):
                 self._update_head(index_entry, xblock.location.branch, new_id)
 
             # fetch and return the new item--fetching is unnecessary but a good qc step
-            return self.get_item(BlockUsageLocator(xblock.location, version_guid=new_id))
+            return self.get_item(
+                BlockUsageLocator(
+                    course_id=xblock.location.course_id,
+                    usage_id=xblock.location.usage_id,
+                    branch=xblock.location.branch,
+                    version_guid=new_id
+                )
+            )
         else:
             return xblock
 
@@ -1364,10 +1371,8 @@ class SplitMongoModuleStore(ModuleStoreBase):
             else:
                 raise VersionConflictError(
                     locator,
-                    CourseLocator(
-                        course_id=index_entry['_id'],
-                        version_guid=index_entry['versions'][locator.branch],
-                        branch=locator.branch))
+                    index_entry['versions'][locator.branch]
+                )
 
     def _version_structure(self, structure, user_id):
         """

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_locators.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_locators.py
@@ -285,6 +285,28 @@ class LocatorTest(TestCase):
             Locator.to_locator_or_location("hello.world.not.a.url")
         self.assertIsNone(Locator.parse_url("unknown://foo.bar/baz"))
 
+    def test_url_reverse(self):
+        """
+        Test the url_reverse method
+        """
+        locator = CourseLocator(course_id="a.fancy_course-id", branch="branch_1.2-3")
+        self.assertEqual(
+            '/expression/{}/format'.format(unicode(locator)),
+            locator.url_reverse('expression', 'format')
+        )
+        self.assertEqual(
+            '/expression/{}/format'.format(unicode(locator)),
+            locator.url_reverse('/expression', '/format')
+        )
+        self.assertEqual(
+            '/expression/{}'.format(unicode(locator)),
+            locator.url_reverse('expression/', None)
+        )
+        self.assertEqual(
+            '/expression/{}'.format(unicode(locator)),
+            locator.url_reverse('/expression/', '')
+        )
+
     def test_description_locator_url(self):
         object_id = '{:024x}'.format(random.randrange(16 ** 24))
         definition_locator = DefinitionLocator(object_id)

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_locators.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_locators.py
@@ -5,7 +5,7 @@ from unittest import TestCase
 
 from bson.objectid import ObjectId
 from xmodule.modulestore.locator import Locator, CourseLocator, BlockUsageLocator, DefinitionLocator
-from xmodule.modulestore.parsers import BRANCH_PREFIX, BLOCK_PREFIX, VERSION_PREFIX, URL_VERSION_PREFIX
+from xmodule.modulestore.parsers import BRANCH_PREFIX, BLOCK_PREFIX, VERSION_PREFIX
 from xmodule.modulestore.exceptions import InsufficientSpecificationError, OverSpecificationError
 from xmodule.modulestore import Location
 import random
@@ -36,12 +36,12 @@ class LocatorTest(TestCase):
         self.assertRaises(
             OverSpecificationError,
             CourseLocator,
-            url='edx://mit.eecs.6002x' + BRANCH_PREFIX + 'published',
+            url='edx://mit.eecs.6002x/' + BRANCH_PREFIX + 'published',
             branch='draft')
         self.assertRaises(
             OverSpecificationError,
             CourseLocator,
-            course_id='mit.eecs.6002x' + BRANCH_PREFIX + 'published',
+            course_id='mit.eecs.6002x/' + BRANCH_PREFIX + 'published',
             branch='draft')
 
     def test_course_constructor_underspecified(self):
@@ -59,8 +59,8 @@ class LocatorTest(TestCase):
         testobj_1 = CourseLocator(version_guid=test_id_1)
         self.check_course_locn_fields(testobj_1, 'version_guid', version_guid=test_id_1)
         self.assertEqual(str(testobj_1.version_guid), test_id_1_loc)
-        self.assertEqual(str(testobj_1), URL_VERSION_PREFIX + test_id_1_loc)
-        self.assertEqual(testobj_1.url(), 'edx://' + URL_VERSION_PREFIX + test_id_1_loc)
+        self.assertEqual(str(testobj_1), VERSION_PREFIX + test_id_1_loc)
+        self.assertEqual(testobj_1.url(), 'edx://' + VERSION_PREFIX + test_id_1_loc)
 
         # Test using a given string
         test_id_2_loc = '519665f6223ebd6980884f2b'
@@ -68,8 +68,8 @@ class LocatorTest(TestCase):
         testobj_2 = CourseLocator(version_guid=test_id_2)
         self.check_course_locn_fields(testobj_2, 'version_guid', version_guid=test_id_2)
         self.assertEqual(str(testobj_2.version_guid), test_id_2_loc)
-        self.assertEqual(str(testobj_2), URL_VERSION_PREFIX + test_id_2_loc)
-        self.assertEqual(testobj_2.url(), 'edx://' + URL_VERSION_PREFIX + test_id_2_loc)
+        self.assertEqual(str(testobj_2), VERSION_PREFIX + test_id_2_loc)
+        self.assertEqual(testobj_2.url(), 'edx://' + VERSION_PREFIX + test_id_2_loc)
 
     def test_course_constructor_bad_course_id(self):
         """
@@ -77,19 +77,19 @@ class LocatorTest(TestCase):
         """
         for bad_id in (' mit.eecs',
                        'mit.eecs ',
-                       URL_VERSION_PREFIX + 'mit.eecs',
-                       BLOCK_PREFIX + 'block/mit.eecs',
+                       VERSION_PREFIX + 'mit.eecs',
+                       BLOCK_PREFIX + 'black/mit.eecs',
                        'mit.ee cs',
                        'mit.ee,cs',
                        'mit.ee/cs',
                        'mit.ee&cs',
                        'mit.ee()cs',
                        BRANCH_PREFIX + 'this',
-                       'mit.eecs' + BRANCH_PREFIX,
-                       'mit.eecs' + BRANCH_PREFIX + 'this' + BRANCH_PREFIX + 'that',
-                       'mit.eecs' + BRANCH_PREFIX + 'this' + BRANCH_PREFIX,
-                       'mit.eecs' + BRANCH_PREFIX + 'this ',
-                       'mit.eecs' + BRANCH_PREFIX + 'th%is ',
+                       'mit.eecs/' + BRANCH_PREFIX,
+                       'mit.eecs/' + BRANCH_PREFIX + 'this/' + BRANCH_PREFIX + 'that',
+                       'mit.eecs/' + BRANCH_PREFIX + 'this/' + BRANCH_PREFIX,
+                       'mit.eecs/' + BRANCH_PREFIX + 'this ',
+                       'mit.eecs/' + BRANCH_PREFIX + 'th%is ',
                        ):
             self.assertRaises(ValueError, CourseLocator, course_id=bad_id)
             self.assertRaises(ValueError, CourseLocator, url='edx://' + bad_id)
@@ -107,7 +107,7 @@ class LocatorTest(TestCase):
         self.check_course_locn_fields(testobj, 'course_id', course_id=testurn)
 
     def test_course_constructor_redundant_002(self):
-        testurn = 'mit.eecs.6002x' + BRANCH_PREFIX + 'published'
+        testurn = 'mit.eecs.6002x/' + BRANCH_PREFIX + 'published'
         expected_urn = 'mit.eecs.6002x'
         expected_rev = 'published'
         testobj = CourseLocator(course_id=testurn, url='edx://' + testurn)
@@ -119,7 +119,7 @@ class LocatorTest(TestCase):
         # Test parsing a url when it starts with a version ID and there is also a block ID.
         # This hits the parsers parse_guid method.
         test_id_loc = '519665f6223ebd6980884f2b'
-        testobj = CourseLocator(url="edx://" + URL_VERSION_PREFIX + test_id_loc + BLOCK_PREFIX + "hw3")
+        testobj = CourseLocator(url="edx://{}{}/{}hw3".format(VERSION_PREFIX, test_id_loc, BLOCK_PREFIX))
         self.check_course_locn_fields(
             testobj,
             'test_block constructor',
@@ -128,14 +128,14 @@ class LocatorTest(TestCase):
 
     def test_course_constructor_url_course_id_and_version_guid(self):
         test_id_loc = '519665f6223ebd6980884f2b'
-        testobj = CourseLocator(url='edx://mit.eecs-honors.6002x' + VERSION_PREFIX + test_id_loc)
+        testobj = CourseLocator(url='edx://mit.eecs-honors.6002x/' + VERSION_PREFIX + test_id_loc)
         self.check_course_locn_fields(testobj, 'error parsing url with both course ID and version GUID',
                                       course_id='mit.eecs-honors.6002x',
                                       version_guid=ObjectId(test_id_loc))
 
     def test_course_constructor_url_course_id_branch_and_version_guid(self):
         test_id_loc = '519665f6223ebd6980884f2b'
-        testobj = CourseLocator(url='edx://mit.eecs.~6002x' + BRANCH_PREFIX + 'draft-1' + VERSION_PREFIX + test_id_loc)
+        testobj = CourseLocator(url='edx://mit.eecs.~6002x/' + BRANCH_PREFIX + 'draft-1/' + VERSION_PREFIX + test_id_loc)
         self.check_course_locn_fields(testobj, 'error parsing url with both course ID branch, and version GUID',
                                       course_id='mit.eecs.~6002x',
                                       branch='draft-1',
@@ -150,7 +150,7 @@ class LocatorTest(TestCase):
         self.assertEqual(testobj.url(), 'edx://' + testurn)
 
     def test_course_constructor_course_id_with_branch(self):
-        testurn = 'mit.eecs.6002x' + BRANCH_PREFIX + 'published'
+        testurn = 'mit.eecs.6002x/' + BRANCH_PREFIX + 'published'
         expected_id = 'mit.eecs.6002x'
         expected_branch = 'published'
         testobj = CourseLocator(course_id=testurn)
@@ -166,7 +166,7 @@ class LocatorTest(TestCase):
     def test_course_constructor_course_id_separate_branch(self):
         test_id = 'mit.eecs.6002x'
         test_branch = 'published'
-        expected_urn = 'mit.eecs.6002x' + BRANCH_PREFIX + 'published'
+        expected_urn = 'mit.eecs.6002x/' + BRANCH_PREFIX + 'published'
         testobj = CourseLocator(course_id=test_id, branch=test_branch)
         self.check_course_locn_fields(testobj, 'course_id with separate branch',
                                       course_id=test_id,
@@ -181,7 +181,7 @@ class LocatorTest(TestCase):
         """
         The same branch appears in the course_id and the branch field.
         """
-        test_id = 'mit.eecs.6002x' + BRANCH_PREFIX + 'published'
+        test_id = 'mit.eecs.6002x/' + BRANCH_PREFIX + 'published'
         test_branch = 'published'
         expected_id = 'mit.eecs.6002x'
         expected_urn = test_id
@@ -196,7 +196,7 @@ class LocatorTest(TestCase):
         self.assertEqual(testobj.url(), 'edx://' + expected_urn)
 
     def test_block_constructor(self):
-        testurn = 'mit.eecs.6002x' + BRANCH_PREFIX + 'published' + BLOCK_PREFIX + 'HW3'
+        testurn = 'mit.eecs.6002x/' + BRANCH_PREFIX + 'published/' + BLOCK_PREFIX + 'HW3'
         expected_id = 'mit.eecs.6002x'
         expected_branch = 'published'
         expected_block_ref = 'HW3'
@@ -217,7 +217,7 @@ class LocatorTest(TestCase):
     def test_block_constructor_url_version_prefix(self):
         test_id_loc = '519665f6223ebd6980884f2b'
         testobj = BlockUsageLocator(
-            url='edx://mit.eecs.6002x' + VERSION_PREFIX + test_id_loc + BLOCK_PREFIX + 'lab2'
+            url='edx://mit.eecs.6002x/{}{}/{}lab2'.format(VERSION_PREFIX, test_id_loc, BLOCK_PREFIX)
         )
         self.check_block_locn_fields(
             testobj, 'error parsing URL with version and block',
@@ -237,7 +237,9 @@ class LocatorTest(TestCase):
     def test_block_constructor_url_kitchen_sink(self):
         test_id_loc = '519665f6223ebd6980884f2b'
         testobj = BlockUsageLocator(
-            url='edx://mit.eecs.6002x' + BRANCH_PREFIX + 'draft' + VERSION_PREFIX + test_id_loc + BLOCK_PREFIX + 'lab2'
+            url='edx://mit.eecs.6002x/{}draft/{}{}/{}lab2'.format(
+                BRANCH_PREFIX, VERSION_PREFIX, test_id_loc, BLOCK_PREFIX
+            )
         )
         self.check_block_locn_fields(
             testobj, 'error parsing URL with branch, version, and block',
@@ -248,7 +250,7 @@ class LocatorTest(TestCase):
         )
 
     def test_repr(self):
-        testurn = 'mit.eecs.6002x' + BRANCH_PREFIX + 'published' + BLOCK_PREFIX + 'HW3'
+        testurn = 'mit.eecs.6002x/' + BRANCH_PREFIX + 'published/' + BLOCK_PREFIX + 'HW3'
         testobj = BlockUsageLocator(course_id=testurn)
         self.assertEqual('BlockUsageLocator("mit.eecs.6002x/branch/published/block/HW3")', repr(testobj))
 
@@ -286,7 +288,7 @@ class LocatorTest(TestCase):
     def test_description_locator_url(self):
         object_id = '{:024x}'.format(random.randrange(16 ** 24))
         definition_locator = DefinitionLocator(object_id)
-        self.assertEqual('defx://' + URL_VERSION_PREFIX + object_id, definition_locator.url())
+        self.assertEqual('defx://' + VERSION_PREFIX + object_id, definition_locator.url())
         self.assertEqual(definition_locator, DefinitionLocator(definition_locator.url()))
 
     def test_description_locator_version(self):


### PR DESCRIPTION
Move all parsing to one url and use it wherever it's needed. Try to clean up some confusing code paths. Also, don't allow init'g new Locator using an old Locator w/ version and an override version spec (too confusing).

@cahrens @singingwolfboy please review
