### PR TITLE
Added back on hover CC button functionality.

### DIFF
--- a/cms/djangoapps/contentstore/features/video.feature
+++ b/cms/djangoapps/contentstore/features/video.feature
@@ -43,14 +43,14 @@ Feature: CMS.Video Component
     Then the correct Youtube video is shown
 
   # 7
-  #    Scenario: Closed captions become visible when the mouse hovers over CC button
-  #  Given I have created a Video component with subtitles
-  #  And Make sure captions are closed
-  #  Then Captions become "invisible" after 3 seconds
-  #  And I hover over button "CC"
-  #  Then Captions become "visible"
-  #  And I hover over button "volume"
-  #  Then Captions become "invisible" after 3 seconds
+  Scenario: Closed captions become visible when the mouse hovers over CC button
+    Given I have created a Video component with subtitles
+    And Make sure captions are closed
+    Then Captions become "invisible" after 3 seconds
+    And I hover over button "CC"
+    Then Captions become "visible"
+    And I hover over button "volume"
+    Then Captions become "invisible" after 3 seconds
 
   # 8
   Scenario: Open captions never become invisible

--- a/common/lib/xmodule/xmodule/css/video/display.scss
+++ b/common/lib/xmodule/xmodule/css/video/display.scss
@@ -633,8 +633,6 @@ div.video {
     ol.subtitles {
         width: 0;
         height: 0;
-
-        visibility: hidden;
     }
 
     ol.subtitles.html5 {
@@ -668,8 +666,6 @@ div.video {
       ol.subtitles {
         right: -(flex-grid(4));
         width: auto;
-
-        visibility: hidden;
       }
     }
 


### PR DESCRIPTION
This PR restores functionality added in PR #1344. 

On mouse over CC button, auto show transcripts if they are hidden; hide them again once the mouse leaves the CC button or transcripts.

@wedaly @valera-rozuvan please review.
