### PR TITLE
Fix error when reading tokens on aws configuration

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -12,6 +12,7 @@ from .common import *
 from logsettings import get_logger_config
 import os
 
+from path import path
 
 # SERVICE_VARIANT specifies name of the variant used, which decides what JSON
 # configuration files are read during startup.
@@ -20,7 +21,7 @@ SERVICE_VARIANT = os.environ.get('SERVICE_VARIANT', None)
 # CONFIG_ROOT specifies the directory where the JSON configuration
 # files are expected to be found. If not specified, use the project
 # directory.
-CONFIG_ROOT = os.environ.get('CONFIG_ROOT', ENV_ROOT)
+CONFIG_ROOT = path(os.environ.get('CONFIG_ROOT', ENV_ROOT))
 
 # CONFIG_PREFIX specifies the prefix of the JSON configuration files,
 # based on the service variant. If no variant is use, don't use a

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -17,6 +17,7 @@ from .common import *
 from logsettings import get_logger_config
 import os
 
+from path import path
 
 # SERVICE_VARIANT specifies name of the variant used, which decides what JSON
 # configuration files are read during startup.
@@ -25,7 +26,7 @@ SERVICE_VARIANT = os.environ.get('SERVICE_VARIANT', None)
 # CONFIG_ROOT specifies the directory where the JSON configuration
 # files are expected to be found. If not specified, use the project
 # directory.
-CONFIG_ROOT = os.environ.get('CONFIG_ROOT', ENV_ROOT)
+CONFIG_ROOT = path(os.environ.get('CONFIG_ROOT', ENV_ROOT))
 
 # CONFIG_PREFIX specifies the prefix of the JSON configuration files,
 # based on the service variant. If no variant is use, don't use a


### PR DESCRIPTION
The error was caused by the CONFIG_ROOT environmental variable,
which was incorrectly assumed to be a path.py valid path.
