### PR TITLE
Add cache-based locking to subtasks to ensure that the same task is not ...

### DIFF
--- a/lms/djangoapps/bulk_email/tests/test_err_handling.py
+++ b/lms/djangoapps/bulk_email/tests/test_err_handling.py
@@ -24,6 +24,7 @@ from instructor_task.models import InstructorTask
 from instructor_task.subtasks import (
     create_subtask_status,
     initialize_subtask_info,
+    check_subtask_is_valid,
     update_subtask_status,
     DuplicateTaskException,
 )
@@ -217,7 +218,7 @@ class TestEmailErrors(ModuleStoreTestCase):
         subtask_id = "subtask-id-value"
         subtask_status = create_subtask_status(subtask_id)
         email_id = 1001
-        with self.assertRaisesRegexp(DuplicateTaskException, 'unable to find email subtasks of instructor task'):
+        with self.assertRaisesRegexp(DuplicateTaskException, 'unable to find subtasks of instructor task'):
             send_course_email(entry_id, email_id, to_list, global_email_context, subtask_status)
 
     def test_send_email_missing_subtask(self):
@@ -231,7 +232,7 @@ class TestEmailErrors(ModuleStoreTestCase):
         different_subtask_id = "bogus-subtask-id-value"
         subtask_status = create_subtask_status(different_subtask_id)
         bogus_email_id = 1001
-        with self.assertRaisesRegexp(DuplicateTaskException, 'unable to find status for email subtask of instructor task'):
+        with self.assertRaisesRegexp(DuplicateTaskException, 'unable to find status for subtask of instructor task'):
             send_course_email(entry_id, bogus_email_id, to_list, global_email_context, subtask_status)
 
     def test_send_email_completed_subtask(self):
@@ -248,6 +249,21 @@ class TestEmailErrors(ModuleStoreTestCase):
         new_subtask_status = create_subtask_status(subtask_id)
         with self.assertRaisesRegexp(DuplicateTaskException, 'already completed'):
             send_course_email(entry_id, bogus_email_id, to_list, global_email_context, new_subtask_status)
+
+    def test_send_email_running_subtask(self):
+        # test at a lower level, to ensure that the course gets checked down below too.
+        entry = InstructorTask.create(self.course.id, "task_type", "task_key", "task_input", self.instructor)
+        entry_id = entry.id  # pylint: disable=E1101
+        subtask_id = "subtask-id-value"
+        initialize_subtask_info(entry, "emailed", 100, [subtask_id])
+        subtask_status = create_subtask_status(subtask_id)
+        update_subtask_status(entry_id, subtask_id, subtask_status)
+        check_subtask_is_valid(entry_id, subtask_id)
+        bogus_email_id = 1001
+        to_list = ['test@test.com']
+        global_email_context = {'course_title': 'dummy course'}
+        with self.assertRaisesRegexp(DuplicateTaskException, 'already being executed'):
+            send_course_email(entry_id, bogus_email_id, to_list, global_email_context, subtask_status)
 
     def dont_test_send_email_undefined_email(self):
         # test at a lower level, to ensure that the course gets checked down below too.


### PR DESCRIPTION
...running in two workers at the same time.

Cherry-pick of https://github.com/edx/edx-platform/pull/1438.
