### PR TITLE
UX explaining inst dash email subject length (128 characters)

### DIFF
--- a/lms/static/sass/course/instructor/_instructor.scss
+++ b/lms/static/sass/course/instructor/_instructor.scss
@@ -14,15 +14,15 @@
     right: 2em;
   }
 
-	section.instructor-dashboard-content {
-		@extend .content;
+  section.instructor-dashboard-content {
+    @extend .content;
     padding: 40px;
     width: 100%;
 
     h1 {
       @extend .top-header;
     }
-	}
+  }
 
   // form fields
   .list-fields {
@@ -37,7 +37,16 @@
       &:last-child {
         margin-bottom: 0;
       }
+
+      .tip {
+        display: block;
+        margin-top: ($baseline/4);
+        color: tint(rgb(127,127,127),50%);
+        @include font-size(12);
+      }
+
     }
+
   }
 
   // ====================

--- a/lms/static/sass/course/instructor/_instructor_2.scss
+++ b/lms/static/sass/course/instructor/_instructor_2.scss
@@ -16,7 +16,7 @@
     position: absolute;
     top: 17px;
     right: 15px;
-    font-size: 11pt;
+    @include font-size(14);
   }
 
   // system feedback - messages
@@ -254,6 +254,12 @@ section.instructor-dashboard-content-2 {
       &:last-child {
         margin-bottom: 0;
       }
+      .tip {
+        display: block;
+        margin-top: ($baseline/4);
+        color: tint(rgb(127,127,127),50%);
+        @include font-size(12);
+      }
     }
   }
 }
@@ -432,7 +438,7 @@ section.instructor-dashboard-content-2 {
 
   .last-updated {
     line-height: 2.2em;
-    font-size: 10pt;
+    @include font-size(10);
   }
 
   .display-graph .graph-placeholder {
@@ -470,7 +476,7 @@ section.instructor-dashboard-content-2 {
   }
 
   .title {
-    font-size: 16pt;
+    @include font-size(16);
   }
 
   .label {

--- a/lms/templates/courseware/instructor_dashboard.html
+++ b/lms/templates/courseware/instructor_dashboard.html
@@ -522,10 +522,11 @@ function goto( mode)
       <li class="field">
         <label for="id_subject">${_("Subject: ")}</label>
         %if subject:
-          <input type="text" id="id_subject" name="subject" maxlength="100" size="75" value="${subject}">
+          <input type="text" id="id_subject" name="subject" maxlength="128" size="75" value="${subject}">
         %else:
-          <input type="text" id="id_subject" name="subject" maxlength="100" size="75">
+          <input type="text" id="id_subject" name="subject" maxlength="128" size="75">
         %endif
+        <span class="tip">${_("(Max 128 characters)")}</span>
       </li>
 
       <li class="field">

--- a/lms/templates/instructor/instructor_dashboard_2/send_email.html
+++ b/lms/templates/instructor/instructor_dashboard_2/send_email.html
@@ -24,7 +24,12 @@
   <br/>
   <li class="field">
     <label for="id_subject">${_("Subject: ")}</label><br/>
-    <input type="text" id="id_subject" name="subject">
+     %if subject:
+      <input type="text" id="id_subject" name="subject" maxlength="128" size="75" value="${subject}">
+     %else:
+      <input type="text" id="id_subject" name="subject" maxlength="128" size="75">
+     %endif
+     <span class="tip">${_("(Max 128 characters)")}</span>
   </li>
   <li class="field">
     <label>Message:</label>


### PR DESCRIPTION
@marcotuts or @talbs mind doing a quick design review? Should take 2 minutes.

Addresses https://edx-wiki.atlassian.net/browse/LMS-1187

Limits the length of the input box to 128 characters (the backend model has this restriction) and adds explanatory text.

_Beta dash screenshot:_
![screen shot 2013-10-23 at 11 30 54 am](https://f.cloud.github.com/assets/1985317/1391165/86828d28-3bf8-11e3-9a6b-d2d167bbb268.png)

_Legacy dash screenshot_
![screen shot 2013-10-23 at 11 29 22 am](https://f.cloud.github.com/assets/1985317/1391166/8682830a-3bf8-11e3-89c2-200e80c0f1c4.png)

@flowerhack take a quick look as well, thanks.
