### PR TITLE
fixes unicode error in course image filenames on /courses page

### DIFF
--- a/common/lib/xmodule/xmodule/contentstore/content.py
+++ b/common/lib/xmodule/xmodule/contentstore/content.py
@@ -55,7 +55,7 @@ class StaticContent(object):
     @staticmethod
     def get_url_path_from_location(location):
         if location is not None:
-            return "/{tag}/{org}/{course}/{category}/{name}".format(**location.dict())
+            return u"/{tag}/{org}/{course}/{category}/{name}".format(**location.dict())
         else:
             return None
 


### PR DESCRIPTION
1) Turns off "courses are browsable" to turn off the /courses urls on edge

2) Just in case, replaces url_path with unicode string for cases like a course image having unicode in its file name

@symbolist 
@singingwolfboy 

addresses https://edx-wiki.atlassian.net/browse/LMS-1365
