### PR TITLE
Get rid of course_index shim.

### DIFF
--- a/cms/djangoapps/contentstore/features/grading.py
+++ b/cms/djangoapps/contentstore/features/grading.py
@@ -67,9 +67,13 @@ def change_assignment_name(step, old_name, new_name):
 
 @step(u'I go back to the main course page')
 def main_course_page(step):
-    main_page_link = '/{}/{}/course/{}'.format(world.scenario_dict['COURSE'].org,
-                                               world.scenario_dict['COURSE'].number,
-                                               world.scenario_dict['COURSE'].display_name.replace(' ', '_'),)
+    course_name = world.scenario_dict['COURSE'].display_name.replace(' ', '_')
+    main_page_link = '/course/{org}.{number}.{name}/branch/draft/block/{name}'.format(
+        org=world.scenario_dict['COURSE'].org,
+        number=world.scenario_dict['COURSE'].number,
+        name=course_name
+    )
+
     world.visit(main_page_link)
     assert_in('Course Outline', world.css_text('h1.page-header'))
 

--- a/cms/djangoapps/contentstore/features/signup.feature
+++ b/cms/djangoapps/contentstore/features/signup.feature
@@ -14,11 +14,11 @@ Feature: CMS.Sign in
   Scenario: Login with a valid redirect
     Given I have opened a new course in Studio
     And I am not logged in
-    And I visit the url "/MITx/999/course/Robot_Super_Course"
-    And I should see that the path is "/signin?next=/MITx/999/course/Robot_Super_Course"
+    And I visit the url "/course/MITx.999.Robot_Super_Course/branch/draft/block/Robot_Super_Course"
+    And I should see that the path is "/signin?next=/course/MITx.999.Robot_Super_Course/branch/draft/block/Robot_Super_Course"
     When I fill in and submit the signin form
     And I wait for "2" seconds
-    Then I should see that the path is "/MITx/999/course/Robot_Super_Course"
+    Then I should see that the path is "/course/MITx.999.Robot_Super_Course/branch/draft/block/Robot_Super_Course"
 
   Scenario: Login with an invalid redirect
     Given I have opened a new course in Studio

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -107,17 +107,6 @@ def course_handler(request, tag=None, course_id=None, branch=None, version_guid=
 
 @login_required
 @ensure_csrf_cookie
-def old_course_index_shim(request, org, course, name):
-    """
-    A shim for any unconverted uses of course_index
-    """
-    old_location = Location(['i4x', org, course, 'course', name])
-    locator = loc_mapper().translate_location(old_location.course_id, old_location, False, True)
-    return course_index(request, locator.course_id, locator.branch, locator.version_guid, locator.usage_id)
-
-
-@login_required
-@ensure_csrf_cookie
 def course_index(request, course_id, branch, version_guid, block):
     """
     Display an editable course overview.
@@ -164,7 +153,9 @@ def course_index(request, course_id, branch, version_guid, block):
 @expect_json
 def create_new_course(request):
     """
-    Create a new course
+    Create a new course.
+
+    Returns the URL for the course overview page.
     """
     if not is_user_in_creator_group(request.user):
         raise PermissionDenied()
@@ -255,7 +246,8 @@ def create_new_course(request):
     # work.
     CourseEnrollment.enroll(request.user, new_course.location.course_id)
 
-    return JsonResponse({'id': new_course.location.url()})
+    new_location = loc_mapper().translate_location(new_course.location.course_id, new_course.location, False, True)
+    return JsonResponse({'url': new_location.url_reverse("course/", "")})
 
 
 @login_required

--- a/cms/static/js/index.js
+++ b/cms/static/js/index.js
@@ -39,8 +39,8 @@ require(["domReady", "jquery", "underscore", "js/utils/cancel_on_escape"],
                     'run': run
                 },
                 function (data) {
-                    if (data.id !== undefined) {
-                        window.location = '/' + data.id.replace(/.*:\/\//, '');
+                    if (data.url !== undefined) {
+                        window.location = data.url;
                     } else if (data.ErrMsg !== undefined) {
                         $('.wrap-error').addClass('is-shown');
                         $('#course_creation_error').html('<p>' + data.ErrMsg + '</p>');

--- a/cms/templates/unit.html
+++ b/cms/templates/unit.html
@@ -2,6 +2,7 @@
 <%!
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
+from xmodule.modulestore.django import loc_mapper
 %>
 <%namespace name="units" file="widgets/units.html" />
 <%block name="title">${_("Individual Unit")}</%block>
@@ -179,7 +180,11 @@ require(["domReady!", "jquery", "coffee/src/models/module", "coffee/src/views/un
             </div>
             <ol>
               <li>
-                <a href="${reverse('course_index', kwargs=dict(org=context_course.location.org, course=context_course.location.course, name=context_course.location.name))}" class="section-item">${section.display_name_with_default}</a>
+                <%
+                  ctx_loc = context_course.location
+                  index_url = loc_mapper().translate_location(ctx_loc.course_id, ctx_loc, False, True).url_reverse('course/', '')
+                %>
+                <a href="${index_url}" class="section-item">${section.display_name_with_default}</a>
                 <ol>
                   <li>
                     <a href="${reverse('edit_subsection', args=[subsection.location])}" class="section-item">

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -135,13 +135,6 @@ urlpatterns += patterns(
 # restful api
 urlpatterns += patterns(
     'contentstore.views',
-    # index page, course outline page, and course structure json access
-    # replaces url(r'^listing', 'contentstore.views.index', name='index'),
-    # ? url(r'^create_new_course', 'contentstore.views.create_new_course', name='create_new_course')
-    # TODO remove shim and this pattern once import_export and test_contentstore no longer use
-    url(r'^(?P<org>[^/]+)/(?P<course>[^/]+)/course/(?P<name>[^/]+)$',
-        'course.old_course_index_shim', name='course_index'
-    ),
 
     url(r'^course$', 'index'),
     # (?ix) == ignore case and verbose (multiline regex)


### PR DESCRIPTION
@dmitchell Please review. Let's cleanup as we go along instead of creating shims.

Things to test:
1) Create a new course
2) Import into existing course, click to go to course overview.
3) Export of something that fails (I wish I knew how to do this...). Should take you to the course overview page.
4) From unit page, click on Section in RHS to go to the course overview page.
