### PR TITLE
Disable video caption test seen to fail in master.

### DIFF
--- a/common/lib/xmodule/xmodule/js/spec/video/video_caption_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_caption_spec.js
@@ -522,7 +522,8 @@
             });
         });
 
-        describe('scrollCaption', function () {
+        // Disabled 10/23/13 due to flakiness in master
+        xdescribe('scrollCaption', function () {
             beforeEach(function () {
                 initialize();
             });


### PR DESCRIPTION
@jzoldak 
@valera-rozuvan 

Failed here: https://jenkins.testeng.edx.org/job/edx-all-tests-auto-master/SHARD=1,TEST_SUITE=unit/239/testReport/junit/JavaScript/firefox/VideoCaption_scrollCaption_when_frozen__does_not_scroll_the_caption/
