### PR TITLE
Add get_child_descriptors to the list of module_attrs in XModuleDescriptor

### DIFF
--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -748,6 +748,7 @@ class XModuleDescriptor(XModuleMixin, HTMLSnippet, ResourceTemplates, XBlock):
     handle_ajax = module_attr('handle_ajax')
     max_score = module_attr('max_score')
     student_view = module_attr('student_view')
+    get_child_descriptors = module_attr('get_child_descriptors')
 
     # ~~~~~~~~~~~~~~~ XBlock API Wrappers ~~~~~~~~~~~~~~~~
     def studio_view(self, _context):


### PR DESCRIPTION
This was a hotfix to address LMS-1367 which was breaking progress pages on courses that used the RandomizeDescriptor.
