### PR TITLE
E0d/specify coffee sources

### DIFF
--- a/rakelib/assets.rake
+++ b/rakelib/assets.rake
@@ -31,9 +31,9 @@ def coffee_cmd(watch=false, debug=false)
         end
     end
     if watch
-        "node_modules/.bin/coffee --compile --watch . "
+        "node_modules/.bin/coffee --compile --watch lms/ cms/ common/"
     else
-        "node_modules/.bin/coffee --compile `find . -name *.coffee` "
+        "node_modules/.bin/coffee --compile `find lms/ cms/ common/ -type f -name *.coffee` "
     end
 end
 


### PR DESCRIPTION
@cpennington 
@singingwolfboy 
@ormsbee 

Because we were pulling in all coffee files under edx-platform, this means we are occasionally compiling things in build that come from pypi packages.  There's a definite incompatibility with coffee in the pygment source and our version.  This was breaking on dev-edxapp-002 which was the victim of an aborted deploy.  I think this was a likely cause of some of these issues:

https://groups.google.com/forum/#!msg/edx-code/S9jHLu3MMNY/Ztl3QOdPWVEJ

_I haven't tested on a Mac_
