### PR TITLE
Added explicit wait to failing JS test

### DIFF
--- a/cms/static/js_spec/transcripts/editor_spec.js
+++ b/cms/static/js_spec/transcripts/editor_spec.js
@@ -161,9 +161,15 @@ function ($, Backbone, _, Utils, Editor, MetadataView, MetadataModel, MetadataCo
                 it('Correct data', function () {
                     transcripts.syncBasicTab(metadataCollection, metadataView);
 
-                    var collection = transcripts.collection.models,
-                        displayNameValue = collection[0].getValue(),
-                        videoUrlValue = collection[1].getValue();
+                    var collection = transcripts.collection.models;
+
+                    waitsFor(function() {
+                        var displayNameValue = collection[0].getValue();
+                        return (displayNameValue !== "" && displayNameValue != "video_id");
+                    }, "Defaults never loaded", 1000);
+
+                    var displayNameValue = collection[0].getValue();
+                    var videoUrlValue = collection[1].getValue();
 
                     expect(displayNameValue).toBe('default');
                     expect(videoUrlValue).toEqual([


### PR DESCRIPTION
Saw this failure in master:
https://jenkins.testeng.edx.org/job/edx-all-tests-auto-master/250/SHARD=1,TEST_SUITE=unit/testReport/junit/JavaScript/firefox/Transcripts_Editor_Test_synchronization_Test_Basic_to_Advanced_synchronization__Correct_data/

This test has been passing consistently for a long time, and it continues to pass for me locally.  I'm guessing this is a race condition between the test and Backbone.js, so I added an explicit wait for the default value to go away.

Not super-elegant, but safer.

@jzoldak
