### PR TITLE
remove instances of @edx.org email addresses in our default settings (Bug: LMS-1363)

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -195,9 +195,9 @@ IGNORABLE_404_ENDS = ('favicon.ico')
 
 # Email
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
-DEFAULT_FROM_EMAIL = 'registration@edx.org'
-DEFAULT_FEEDBACK_EMAIL = 'feedback@edx.org'
-SERVER_EMAIL = 'devops@edx.org'
+DEFAULT_FROM_EMAIL = 'registration@example.com'
+DEFAULT_FEEDBACK_EMAIL = 'feedback@example.com'
+SERVER_EMAIL = 'devops@example.com'
 ADMINS = ()
 MANAGERS = ADMINS
 

--- a/cms/templates/404.html
+++ b/cms/templates/404.html
@@ -11,7 +11,9 @@
     <p>${_('The page that you were looking for was not found.')}
        ${_('Go back to the {homepage} or let us know about any pages that may have been moved at {email}.').format(
             homepage='<a href="/">homepage</a>',
-            email='<a href="mailto:technical@edx.org">technical@edx.org</a>')}
+            email=u'<a href="mailto:{address}">{address}</a>'.format(
+                address=settings.TECH_SUPPORT_EMAIL,
+            ))}
     </p>
   </section>
 </div>

--- a/cms/templates/500.html
+++ b/cms/templates/500.html
@@ -11,7 +11,11 @@
     <p>
       ${_("An error occurred in Studio and the page could not be loaded. Please try again in a few moments.")}
       ${_("We've logged the error and our staff is currently working to resolve this error as soon as possible.")}
-      ${_('If the problem persists, please email us at {email}.').format(email='<a href="mailto:technical@edx.org">technical@edx.org</a>')}
+      ${_('If the problem persists, please email us at {email_link}.').format(
+            email_link=u'<a href="mailto:{email_address}">{email_address}</a>'.format(
+                email_address=settings.TECH_SUPPORT_EMAIL,
+            )
+        )}
     </p>
   </section>
 </div>

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -437,12 +437,12 @@ IGNORABLE_404_ENDS = ('favicon.ico')
 
 # Platform Email
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
-DEFAULT_FROM_EMAIL = 'registration@edx.org'
-DEFAULT_FEEDBACK_EMAIL = 'feedback@edx.org'
-SERVER_EMAIL = 'devops@edx.org'
-TECH_SUPPORT_EMAIL = 'technical@edx.org'
-CONTACT_EMAIL = 'info@edx.org'
-BUGS_EMAIL = 'bugs@edx.org'
+DEFAULT_FROM_EMAIL = 'registration@example.com'
+DEFAULT_FEEDBACK_EMAIL = 'feedback@example.com'
+SERVER_EMAIL = 'devops@example.com'
+TECH_SUPPORT_EMAIL = 'technical@example.com'
+CONTACT_EMAIL = 'info@example.com'
+BUGS_EMAIL = 'bugs@example.com'
 ADMINS = ()
 MANAGERS = ADMINS
 
@@ -511,7 +511,7 @@ WIKI_LINK_DEFAULT_LEVEL = 2
 ################################# Pearson TestCenter config  ################
 
 PEARSONVUE_SIGNINPAGE_URL = "https://www1.pearsonvue.com/testtaker/signin/SignInPage/EDX"
-# TESTCENTER_ACCOMMODATION_REQUEST_EMAIL = "exam-help@edx.org"
+# TESTCENTER_ACCOMMODATION_REQUEST_EMAIL = "exam-help@example.com"
 
 ##### Feedback submission mechanism #####
 FEEDBACK_SUBMISSION_EMAIL = None
@@ -522,7 +522,7 @@ ZENDESK_USER = None
 ZENDESK_API_KEY = None
 
 ##### shoppingcart Payment #####
-PAYMENT_SUPPORT_EMAIL = 'payment@edx.org'
+PAYMENT_SUPPORT_EMAIL = 'payment@example.com'
 ##### Using cybersource by default #####
 CC_PROCESSOR = {
     'CyberSource': {
@@ -540,7 +540,7 @@ PAID_COURSE_REGISTRATION_CURRENCY = ['usd', '$']
 #By setting up the default settings with an incorrect user name and password,
 # will get an error when attempting to connect
 OPEN_ENDED_GRADING_INTERFACE = {
-    'url': 'http://sandbox-grader-001.m.edx.org/peer_grading',
+    'url': 'http://example.com/peer_grading',
     'username': 'incorrect_user',
     'password': 'incorrect_pass',
     'staff_grading': 'staff_grading',
@@ -853,7 +853,7 @@ CELERYD_HIJACK_ROOT_LOGGER = False
 
 # Suffix used to construct 'from' email address for bulk emails.
 # A course-specific identifier is prepended.
-BULK_EMAIL_DEFAULT_FROM_EMAIL = 'no-reply@courseupdates.edx.org'
+BULK_EMAIL_DEFAULT_FROM_EMAIL = 'no-reply@example.com'
 
 # Parameters for breaking down course enrollment into subtasks.
 BULK_EMAIL_EMAILS_PER_TASK = 100


### PR DESCRIPTION
These are the main places where we have domain-specific email addresses either as default settings or hard-coded in. 

@jarv , will these override our normal prod and edge settings?
@cpennington 

See https://edx-wiki.atlassian.net/browse/LMS-1363
