### PR TITLE
Fixing accessibility bug where users could not tab through on wiki

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ Studio: Change course overview page, checklists, assets, and course staff manage
 page URLs to a RESTful interface. Also removed "\listing", which duplicated
 "\index".
 
+LMS: Fixed accessibility bug where users could not tab through wiki (LMS-1307)
+
 Blades: When start time and end time are specified for a video, a visual range
 will be shown on the time slider to highlight the place in the video that will
 be played.

--- a/lms/djangoapps/course_wiki/editors.py
+++ b/lms/djangoapps/course_wiki/editors.py
@@ -58,6 +58,7 @@ class CodeMirror(BaseEditor):
         js = ("js/vendor/CodeMirror/codemirror.js",
               "js/vendor/CodeMirror/xml.js",
               "js/vendor/CodeMirror/mitx_markdown.js",
+              "js/wiki/accessible.js",
               "js/wiki/CodeMirror.init.js",
               "js/wiki/cheatsheet.js",
               )

--- a/lms/static/js/wiki/CodeMirror.init.js
+++ b/lms/static/js/wiki/CodeMirror.init.js
@@ -5,6 +5,7 @@ $(document).ready(function() {
     matchBrackets: true,
     theme: "default",
     lineWrapping: true,
+    keyMap: "accessible"
   });
       
   //Store the inital contents so we can compare for unsaved changes

--- a/lms/static/js/wiki/accessible.js
+++ b/lms/static/js/wiki/accessible.js
@@ -4,23 +4,10 @@
 
 (function() {
   var keyMap = CodeMirror.keyMap.accessible = {
-  	"Left": "goCharLeft", 
-  	"Right": "goCharRight", 
-  	"Up": "goLineUp", 
-  	"Down": "goLineDown",
-    "End": "goLineEnd", 
-    "Home": "goLineStartSmart", 
-    "PageUp": "goPageUp", 
-    "PageDown": "goPageDown",
-    "Delete": "delCharAfter", 
-    "Backspace": "delCharBefore", 
-    "Shift-Backspace": "delCharBefore",
     "Alt-Tab": "insertTab",
     "Alt-Shift-Tab": "insertTab",
     "Tab": false,
     "Shift-Tab": false, 
-    "Enter": "newlineAndIndent", 
-    "Insert": "toggleOverwrite", 
     fallthrough: "default"
   };
 })();

--- a/lms/static/js/wiki/accessible.js
+++ b/lms/static/js/wiki/accessible.js
@@ -4,8 +4,6 @@
 
 (function() {
   var keyMap = CodeMirror.keyMap.accessible = {
-    "Alt-Tab": "insertTab",
-    "Alt-Shift-Tab": "insertTab",
     "Tab": false,
     "Shift-Tab": false, 
     fallthrough: "default"

--- a/lms/static/js/wiki/accessible.js
+++ b/lms/static/js/wiki/accessible.js
@@ -2,9 +2,25 @@
    users to "tab through" elements on a page.  Including this file and setting keyMap to 
    "accessible" removes the "tab" from CodeMirror's default KeyMap to remedy this problem */
 
-var keyMap = CodeMirror.keyMap.accessible = {
-  "Left": "goCharLeft", "Right": "goCharRight", "Up": "goLineUp", "Down": "goLineDown",
-  "End": "goLineEnd", "Home": "goLineStartSmart", "PageUp": "goPageUp", "PageDown": "goPageDown",
-  "Delete": "delCharRight", "Backspace": "delCharLeft", "Shift-Tab": "indentAuto",
-  "Enter": "newlineAndIndent", "Insert": "toggleOverwrite"
-};
+(function() {
+  var keyMap = CodeMirror.keyMap.accessible = {
+  	"Left": "goCharLeft", 
+  	"Right": "goCharRight", 
+  	"Up": "goLineUp", 
+  	"Down": "goLineDown",
+    "End": "goLineEnd", 
+    "Home": "goLineStartSmart", 
+    "PageUp": "goPageUp", 
+    "PageDown": "goPageDown",
+    "Delete": "delCharAfter", 
+    "Backspace": "delCharBefore", 
+    "Shift-Backspace": "delCharBefore",
+    "Alt-Tab": "insertTab",
+    "Alt-Shift-Tab": "insertTab",
+    "Tab": false,
+    "Shift-Tab": false, 
+    "Enter": "newlineAndIndent", 
+    "Insert": "toggleOverwrite", 
+    fallthrough: "default"
+  };
+})();

--- a/lms/static/js/wiki/accessible.js
+++ b/lms/static/js/wiki/accessible.js
@@ -1,0 +1,10 @@
+/* By default, CodeMirror turns tabs into indents, which makes it difficult for keyboard-only
+   users to "tab through" elements on a page.  Including this file and setting keyMap to 
+   "accessible" removes the "tab" from CodeMirror's default KeyMap to remedy this problem */
+
+var keyMap = CodeMirror.keyMap.accessible = {
+  "Left": "goCharLeft", "Right": "goCharRight", "Up": "goLineUp", "Down": "goLineDown",
+  "End": "goLineEnd", "Home": "goLineStartSmart", "PageUp": "goPageUp", "PageDown": "goPageDown",
+  "Delete": "delCharRight", "Backspace": "delCharLeft", "Shift-Tab": "indentAuto",
+  "Enter": "newlineAndIndent", "Insert": "toggleOverwrite"
+};


### PR DESCRIPTION
On course wiki pages, when a user's focus was on the content-editing/markdown area, tabs were translated into indents—meaning keyboard-only users could not tab through to other inputs/buttons/elements on the page.  This commit returns tab to its default behavior.

@adampalay @talbs 

LMS-1307
