### PR TITLE
Improve forum error handling

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,10 @@ These are notable changes in edx-platform.  This is a rolling list of changes,
 in roughly chronological order, most recent first.  Add your entries at or near
 the top.  Include a label indicating the component affected.
 
+LMS: Improve forum error handling so that errors in the logs are
+clearer and HTTP status codes from the comments service indicating
+client error are correctly passed through to the client.
+
 LMS: The wiki markup cheatsheet dialog is now accessible to people with
 disabilites.  (LMS-1303)
 

--- a/lms/djangoapps/django_comment_client/middleware.py
+++ b/lms/djangoapps/django_comment_client/middleware.py
@@ -1,4 +1,4 @@
-from comment_client import CommentClientError
+from comment_client import CommentClientRequestError
 from django_comment_client.utils import JsonError
 import json
 import logging
@@ -8,17 +8,17 @@ log = logging.getLogger(__name__)
 
 class AjaxExceptionMiddleware(object):
     """
-    Middleware that captures CommentClientErrors during ajax requests
+    Middleware that captures CommentClientRequestErrors during ajax requests
     and tranforms them into json responses
     """
     def process_exception(self, request, exception):
         """
-        Processes CommentClientErrors in ajax requests. If the request is an ajax request,
+        Processes CommentClientRequestErrors in ajax requests. If the request is an ajax request,
         returns a http response that encodes the error as json
         """
-        if isinstance(exception, CommentClientError) and request.is_ajax():
+        if isinstance(exception, CommentClientRequestError) and request.is_ajax():
             try:
-                return JsonError(json.loads(exception.message), 500)
+                return JsonError(json.loads(exception.message), exception.status_code)
             except ValueError:
-                return JsonError(exception.message, 500)
+                return JsonError(exception.message, exception.status_code)
         return None

--- a/lms/djangoapps/django_comment_client/tests/test_middleware.py
+++ b/lms/djangoapps/django_comment_client/tests/test_middleware.py
@@ -1,32 +1,38 @@
+import django.http
 from django.test import TestCase
+import json
 
 import comment_client
-import django.http
 import django_comment_client.middleware as middleware
 
 
 class AjaxExceptionTestCase(TestCase):
-
-# TODO: check whether the correct error message is produced.
-# The error message should be the same as the argument to CommentClientError
     def setUp(self):
         self.a = middleware.AjaxExceptionMiddleware()
         self.request1 = django.http.HttpRequest()
         self.request0 = django.http.HttpRequest()
-        self.exception1 = comment_client.CommentClientError('{}')
-        self.exception2 = comment_client.CommentClientError('Foo!')
-        self.exception0 = ValueError()
+        self.exception1 = comment_client.CommentClientRequestError('{}', 401)
+        self.exception2 = comment_client.CommentClientRequestError('Foo!', 404)
+        self.exception0 = comment_client.CommentClient500Error("Holy crap the server broke!")
         self.request1.META['HTTP_X_REQUESTED_WITH'] = "XMLHttpRequest"
         self.request0.META['HTTP_X_REQUESTED_WITH'] = "SHADOWFAX"
 
     def test_process_exception(self):
         response1 = self.a.process_exception(self.request1, self.exception1)
         self.assertIsInstance(response1, middleware.JsonError)
-        self.assertEqual(500, response1.status_code)
+        self.assertEqual(self.exception1.status_code, response1.status_code)
+        self.assertEqual(
+            {"errors": json.loads(self.exception1.message)},
+            json.loads(response1.content)
+        )
 
         response2 = self.a.process_exception(self.request1, self.exception2)
         self.assertIsInstance(response2, middleware.JsonError)
-        self.assertEqual(500, response2.status_code)
+        self.assertEqual(self.exception2.status_code, response2.status_code)
+        self.assertEqual(
+            {"errors": [self.exception2.message]},
+            json.loads(response2.content)
+        )
 
         self.assertIsNone(self.a.process_exception(self.request1, self.exception0))
         self.assertIsNone(self.a.process_exception(self.request0, self.exception1))

--- a/lms/lib/comment_client/__init__.py
+++ b/lms/lib/comment_client/__init__.py
@@ -1,2 +1,5 @@
 from .comment_client import *
-from .utils import CommentClientError, CommentClientUnknownError
+from .utils import (
+    CommentClientError, CommentClientRequestError,
+    CommentClient500Error, CommentClientMaintenanceError
+)

--- a/lms/lib/comment_client/comment.py
+++ b/lms/lib/comment_client/comment.py
@@ -1,4 +1,4 @@
-from .utils import CommentClientError, perform_request
+from .utils import CommentClientRequestError, perform_request
 
 from .thread import Thread, _url_for_flag_abuse_thread, _url_for_unflag_abuse_thread
 import models
@@ -48,7 +48,7 @@ class Comment(models.Model):
         elif voteable.type == 'comment':
             url = _url_for_flag_abuse_comment(voteable.id)
         else:
-            raise CommentClientError("Can only flag/unflag threads or comments")
+            raise CommentClientRequestError("Can only flag/unflag threads or comments")
         params = {'user_id': user.id}
         request = perform_request('put', url, params)
         voteable.update_attributes(request)
@@ -59,7 +59,7 @@ class Comment(models.Model):
         elif voteable.type == 'comment':
             url = _url_for_unflag_abuse_comment(voteable.id)
         else:
-            raise CommentClientError("Can flag/unflag for threads or comments")
+            raise CommentClientRequestError("Can flag/unflag for threads or comments")
         params = {'user_id': user.id}
 
         if removeAll:

--- a/lms/lib/comment_client/models.py
+++ b/lms/lib/comment_client/models.py
@@ -119,13 +119,13 @@ class Model(object):
     @classmethod
     def url(cls, action, params={}):
         if cls.base_url is None:
-            raise CommentClientError("Must provide base_url when using default url function")
+            raise CommentClientRequestError("Must provide base_url when using default url function")
         if action not in cls.DEFAULT_ACTIONS:
             raise ValueError("Invalid action {0}. The supported action must be in {1}".format(action, str(cls.DEFAULT_ACTIONS)))
         elif action in cls.DEFAULT_ACTIONS_WITH_ID:
             try:
                 return cls.url_with_id(params)
             except KeyError:
-                raise CommentClientError("Cannot perform action {0} without id".format(action))
+                raise CommentClientRequestError("Cannot perform action {0} without id".format(action))
         else:   # action must be in DEFAULT_ACTIONS_WITHOUT_ID now
             return cls.url_without_id()

--- a/lms/lib/comment_client/thread.py
+++ b/lms/lib/comment_client/thread.py
@@ -1,5 +1,5 @@
 from .utils import merge_dict, strip_blank, strip_none, extract, perform_request
-from .utils import CommentClientError
+from .utils import CommentClientRequestError
 import models
 import settings
 
@@ -88,7 +88,7 @@ class Thread(models.Model):
         elif voteable.type == 'comment':
             url = _url_for_flag_comment(voteable.id)
         else:
-            raise CommentClientError("Can only flag/unflag threads or comments")
+            raise CommentClientRequestError("Can only flag/unflag threads or comments")
         params = {'user_id': user.id}
         request = perform_request('put', url, params)
         voteable.update_attributes(request)
@@ -99,7 +99,7 @@ class Thread(models.Model):
         elif voteable.type == 'comment':
             url = _url_for_unflag_comment(voteable.id)
         else:
-            raise CommentClientError("Can only flag/unflag for threads or comments")
+            raise CommentClientRequestError("Can only flag/unflag for threads or comments")
         params = {'user_id': user.id}
         #if you're an admin, when you unflag, remove ALL flags
         if removeAll:

--- a/lms/lib/comment_client/user.py
+++ b/lms/lib/comment_client/user.py
@@ -1,4 +1,4 @@
-from .utils import merge_dict, perform_request, CommentClientError
+from .utils import merge_dict, perform_request, CommentClientRequestError
 
 import models
 import settings
@@ -41,7 +41,7 @@ class User(models.Model):
         elif voteable.type == 'comment':
             url = _url_for_vote_comment(voteable.id)
         else:
-            raise CommentClientError("Can only vote / unvote for threads or comments")
+            raise CommentClientRequestError("Can only vote / unvote for threads or comments")
         params = {'user_id': self.id, 'value': value}
         request = perform_request('put', url, params)
         voteable.update_attributes(request)
@@ -52,14 +52,14 @@ class User(models.Model):
         elif voteable.type == 'comment':
             url = _url_for_vote_comment(voteable.id)
         else:
-            raise CommentClientError("Can only vote / unvote for threads or comments")
+            raise CommentClientRequestError("Can only vote / unvote for threads or comments")
         params = {'user_id': self.id}
         request = perform_request('delete', url, params)
         voteable.update_attributes(request)
 
     def active_threads(self, query_params={}):
         if not self.course_id:
-            raise CommentClientError("Must provide course_id when retrieving active threads for the user")
+            raise CommentClientRequestError("Must provide course_id when retrieving active threads for the user")
         url = _url_for_user_active_threads(self.id)
         params = {'course_id': self.course_id}
         params = merge_dict(params, query_params)
@@ -68,7 +68,7 @@ class User(models.Model):
 
     def subscribed_threads(self, query_params={}):
         if not self.course_id:
-            raise CommentClientError("Must provide course_id when retrieving subscribed threads for the user")
+            raise CommentClientRequestError("Must provide course_id when retrieving subscribed threads for the user")
         url = _url_for_user_subscribed_threads(self.id)
         params = {'course_id': self.course_id}
         params = merge_dict(params, query_params)


### PR DESCRIPTION
CommentClientError now has sane subclasses that are meaningfully
distinct, and each subclass is handled appropriately. Errors raised by
the requests library are no longer handled by turning them into
CommentClientErrors, since there is no meaningful handling we can do,
and this way we will get more visibility into why errors are occurring.
Also, HTTP status codes from the comments service indicating client
error are correctly passed through to the client.

@jimabramson 
