### PR TITLE
Anton/word cloud total count in studio bug

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/word_cloud/word_cloud_main.js
+++ b/common/lib/xmodule/xmodule/js/src/word_cloud/word_cloud_main.js
@@ -239,6 +239,7 @@ define('WordCloudMain', ['logme'], function (logme) {
         cloudSectionEl
             .addClass('active')
             .find('.your_words').html(studentWordsStr)
+            .end()
             .find('.total_num_words').html(response.total_count);
 
         $(cloudSectionEl.attr('id') + ' .word_cloud').empty();
@@ -282,7 +283,7 @@ define('WordCloudMain', ['logme'], function (logme) {
             .attr('transform', function (d) {
                 return 'translate(' + [d.x, d.y] + ')rotate(' + d.rotate + ')scale(' + scale + ')';
             })
-            .text(function (d) {               
+            .text(function (d) {
                 return d.text;
             });
     }; // End-of: WordCloudMain.prototype.drawWordCloud = function (words, bounds) {


### PR DESCRIPTION
In this PR `save` button is hidden in the Studio and `Total count` is correctly displayed now.

Ticket: [BLD-205: Word Cloud save button in studio errors out](https://edx-wiki.atlassian.net/browse/BLD-205)

@Lyla-Fischer , @valera-rozuvan please review.
