### PR TITLE
Mock servers shouldn't pollute test output.

### DIFF
--- a/common/lib/xmodule/xmodule/util/mock_youtube_server/mock_youtube_server.py
+++ b/common/lib/xmodule/xmodule/util/mock_youtube_server/mock_youtube_server.py
@@ -1,11 +1,14 @@
 from BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler
-import urlparse
-import mock
-import threading
 import json
-from logging import getLogger
-logger = getLogger(__name__)
+import mock
+import sys
+import threading
 import time
+import urlparse
+from logging import getLogger
+
+
+logger = getLogger(__name__)
 
 class MockYoutubeRequestHandler(BaseHTTPRequestHandler):
     '''
@@ -13,6 +16,15 @@ class MockYoutubeRequestHandler(BaseHTTPRequestHandler):
     '''
 
     protocol = "HTTP/1.0"
+
+    def log_message(self, format, *args):
+        """Log an arbitrary message."""
+        # Code copied from BaseHTTPServer.py. Changed to write to sys.stdout
+        # so that messages won't pollute test output.
+        sys.stdout.write("%s - - [%s] %s\n" %
+                         (self.client_address[0],
+                          self.log_date_time_string(),
+                          format % args))
 
     def do_HEAD(self):
         code = 200


### PR DESCRIPTION
BY writing to stderr, BaseHTTPRequestHandler writes log messages to the
console during testing.  This makes the output harder to interpret.
Write the log messages to stdout instead, so that test runners will
suppress them during passing tests, and show them during failing tests.

It would be nice to have a place to write this method just once for the
Youtube and LTI mock servers, but we don't seem to have a place for code
as common as that.
