### PR TITLE
Added wait for JavaScript when navigating to textbook page

### DIFF
--- a/cms/djangoapps/contentstore/features/textbooks.py
+++ b/cms/djangoapps/contentstore/features/textbooks.py
@@ -11,6 +11,7 @@ TEST_ROOT = settings.COMMON_TEST_DATA_ROOT
 
 @step(u'I go to the textbooks page')
 def go_to_uploads(_step):
+    world.wait_for_js_to_load()
     world.click_course_content()
     menu_css = 'li.nav-course-courseware-textbooks a'
     world.css_click(menu_css)


### PR DESCRIPTION
To fix this issue:

https://jenkins.testeng.edx.org/job/edx-all-tests-auto-master/275/SHARD=3,TEST_SUITE=cms-acceptance/testReport/junit/CMS/Textbooks%20_%20No%20textbooks/When_I_go_to_the_textbooks_page/

@singingwolfboy 
