### PR TITLE
Video player: speed change bug

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ These are notable changes in edx-platform.  This is a rolling list of changes,
 in roughly chronological order, most recent first.  Add your entries at or near
 the top.  Include a label indicating the component affected.
 
+Blades: Fix bug when the speed can only be changed when the video is playing.
+
 LMS: Change bulk email implementation to use less memory, and to better handle
 duplicate tasks in celery.
 
@@ -12,7 +14,7 @@ LMS: Improve forum error handling so that errors in the logs are
 clearer and HTTP status codes from the comments service indicating
 client error are correctly passed through to the client.
 
-LMS: Improve performance of page load and thread list load for 
+LMS: Improve performance of page load and thread list load for
 discussion tab
 
 LMS: The wiki markup cheatsheet dialog is now accessible to people with
@@ -28,12 +30,12 @@ Blades: When start time and end time are specified for a video, a visual range
 will be shown on the time slider to highlight the place in the video that will
 be played.
 
-Studio: added restful interface for finding orphans in courses. 
-An orphan is an xblock to which no children relation points and whose type is not 
+Studio: added restful interface for finding orphans in courses.
+An orphan is an xblock to which no children relation points and whose type is not
 in the set contentstore.views.item.DETACHED_CATEGORIES nor 'course'.
-    GET http://host/orphan/org.course returns json array of ids. 
+    GET http://host/orphan/org.course returns json array of ids.
         Requires course author access.
-    DELETE http://orphan/org.course deletes all the orphans in that course. 
+    DELETE http://orphan/org.course deletes all the orphans in that course.
         Requires is_staff access
 
 Studio: Bug fix for text loss in Course Updates when the text exists

--- a/common/lib/xmodule/xmodule/js/src/video/02_html5_video.js
+++ b/common/lib/xmodule/xmodule/js/src/video/02_html5_video.js
@@ -210,11 +210,11 @@ function () {
             // Attach a 'click' event on the <video> element. It will cause the video to pause/play.
             this.videoEl.on('click', function (event) {
                 if (_this.playerState === HTML5Video.PlayerState.PAUSED) {
-                    _this.video.play();
+                    _this.playVideo();
                     _this.playerState = HTML5Video.PlayerState.PLAYING;
                     _this.callStateChangeCallback();
                 } else if (_this.playerState === HTML5Video.PlayerState.PLAYING) {
-                    _this.video.pause();
+                    _this.pauseVideo();
                     _this.playerState = HTML5Video.PlayerState.PAUSED;
                     _this.callStateChangeCallback();
                 }
@@ -268,19 +268,6 @@ function () {
             this.video.addEventListener('ended', function () {
                 _this.playerState = HTML5Video.PlayerState.ENDED;
                 _this.callStateChangeCallback();
-            }, false);
-
-            // Register the 'timeupdate' event. This is the place where we control when the video ends.
-            // If an ending time was specified, then after the video plays through to this spot, pauses, we
-            // must make sure to update the ending time to the end of the video. This way, the user can watch
-            // any parts of it afterwards.
-            this.video.addEventListener('timeupdate', function (data) {
-                if (_this.end < _this.video.currentTime) {
-                    // When we call video.pause(), a 'pause' event will be formed, and we will catch it
-                    // in another handler (see above).
-                    _this.video.pause();
-                    _this.end = _this.video.duration;
-                }
             }, false);
 
             // Place the <video> element on the page.

--- a/common/lib/xmodule/xmodule/js/src/video/03_video_player.js
+++ b/common/lib/xmodule/xmodule/js/src/video/03_video_player.js
@@ -62,6 +62,14 @@ function (HTML5Video, Resizer) {
     function _initialize(state) {
         var youTubeId;
 
+        // The function is called just once to apply pre-defined configurations
+        // by student before video starts playing. Waits until the video's metadata
+        // is loaded, which normally happens just after the video starts playing.
+        // Just after that configurations can be applied.
+        state.videoPlayer.ready = _.once(function () {
+            state.videoPlayer.onSpeedChange(state.speed);
+        });
+
         if (state.videoType === 'youtube') {
             state.videoPlayer.PlayerState = YT.PlayerState;
             state.videoPlayer.PlayerState.UNSTARTED = -1;
@@ -314,6 +322,8 @@ function (HTML5Video, Resizer) {
         if (this.config.show_captions) {
             this.trigger('videoCaption.play', null);
         }
+
+        this.videoPlayer.ready();
     }
 
     function onUnstarted() { }

--- a/common/lib/xmodule/xmodule/js/src/video/06_video_progress_slider.js
+++ b/common/lib/xmodule/xmodule/js/src/video/06_video_progress_slider.js
@@ -181,13 +181,16 @@ function () {
     // Changed for tests -- JM: Check if it is the cause of Chrome Bug Valera
     // noticed
     function updatePlayTime(params) {
+        var time = Math.floor(params.time),
+            duration = Math.floor(params.duration);
+
         if (
             (this.videoProgressSlider.slider) &&
             (!this.videoProgressSlider.frozen)
         ) {
             this.videoProgressSlider.slider
-                .slider('option', 'max', params.duration)
-                .slider('option', 'value', params.time);
+                .slider('option', 'max', duration)
+                .slider('option', 'value', time);
         }
     }
 


### PR DESCRIPTION
This PR fixes [BLD-424: Speed does not change if changed before video starts playing](https://edx-wiki.atlassian.net/browse/BLD-424) .

**Description**: The speed can only be changed when the video is playing. Changing the speed while the video is paused (stopped, or initially loaded) has no effect on playback rate, but the speed menu shows the changed speed.

@valera-rozuvan please review.
