### PR TITLE
Disable multiple YT test due to flakinesss

### DIFF
--- a/common/lib/xmodule/xmodule/js/spec/video/general_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/general_spec.js
@@ -240,7 +240,8 @@
             }
         });
 
-        describe('multiple YT on page', function () {
+        // Disabled 10/29/13 due to flakiness in master
+        xdescribe('multiple YT on page', function () {
             var state1, state2, state3;
 
             beforeEach(function () {


### PR DESCRIPTION
Seen to fail twice in master now; disabling.

https://jenkins.testeng.edx.org/job/edx-all-tests-auto-master/SHARD=1,TEST_SUITE=unit/282/testReport/junit/JavaScript/firefox/Video_multiple_YT_on_page__check_for_YT_availability_is_performed_only_once/
