### PR TITLE
Fixed test that was failing in Vagrant due to filesystem encoding mismatch

### DIFF
--- a/common/lib/xmodule/xmodule/tests/test_import.py
+++ b/common/lib/xmodule/xmodule/tests/test_import.py
@@ -385,7 +385,7 @@ class ImportTestCase(BaseCourseTestCase):
         print("course errors:")
 
         # Expect to find an error/exception about characters in "®esources"
-        expect = "Invalid characters in '®esources'"
+        expect = "Invalid characters"
         errors = [(msg.encode("utf-8"), err.encode("utf-8"))
                     for msg, err in
                     modulestore.get_item_errors(course.location)]


### PR DESCRIPTION
This test would fail on Vagrant images.  Deep in the XML import process, Python gets the pathname and attempts to decode it using the filesystem encoding.  On Vagrant, the paths are actually encoded using ISO Latin, but Python tries to decode them as UTF-8.  This causes a failure when the expected failure string isn't found in the error messages.

This is a quick and dirty fix: just check that there's an error message about invalid characters.

@flowerhack can you confirm that this passes in your environment?
