### PR TITLE
WIP: Change tab URL to be restful.

### DIFF
--- a/cms/djangoapps/contentstore/features/static-pages.feature
+++ b/cms/djangoapps/contentstore/features/static-pages.feature
@@ -9,10 +9,8 @@ Feature: CMS.Static Pages
         Then I should see a static page named "Empty"
 
     Scenario: Users can delete static pages
-        Given I have opened a new course in Studio
-        And I go to the static pages page
-        And I add a new page
-        And I "delete" the static page
+        Given I have created a static page
+        When I "delete" the static page
         Then I am shown a prompt
         When I confirm the prompt
         Then I should not see any static pages
@@ -20,9 +18,17 @@ Feature: CMS.Static Pages
     # Safari won't update the name properly
     @skip_safari
     Scenario: Users can edit static pages
-        Given I have opened a new course in Studio
-        And I go to the static pages page
-        And I add a new page
+        Given I have created a static page
         When I "edit" the static page
         And I change the name to "New"
         Then I should see a static page named "New"
+
+    # Safari won't update the name properly
+    @skip_safari
+    Scenario: Users can reorder static pages
+        Given I have created two different static pages
+        When I reorder the tabs
+        Then the tabs are in the reverse order
+        And I reload the page
+        Then the tabs are in the reverse order
+

--- a/cms/djangoapps/contentstore/features/static-pages.py
+++ b/cms/djangoapps/contentstore/features/static-pages.py
@@ -48,3 +48,47 @@ def change_name(step, new_name):
         world.trigger_event(input_css)
     save_button = 'a.save-button'
     world.css_click(save_button)
+
+
+@step(u'I reorder the tabs')
+def reorder_tabs(_step):
+    # For some reason, the drag_and_drop method did not work in this case.
+    draggables = world.css_find('.drag-handle')
+    source = draggables.first
+    target = draggables.last
+    source.action_chains.click_and_hold(source._element).perform()
+    source.action_chains.move_to_element_with_offset(target._element, 0, 50).perform()
+    source.action_chains.release().perform()
+
+
+@step(u'I have created a static page')
+def create_static_page(step):
+    step.given('I have opened a new course in Studio')
+    step.given('I go to the static pages page')
+    step.given('I add a new page')
+
+
+@step(u'I have created two different static pages')
+def create_two_pages(step):
+    step.given('I have created a static page')
+    step.given('I "edit" the static page')
+    step.given('I change the name to "First"')
+    step.given('I add a new page')
+    # Verify order of tabs
+    _verify_tab_names('First', 'Empty')
+
+
+@step(u'the tabs are in the reverse order')
+def tabs_in_reverse_order(step):
+    _verify_tab_names('Empty', 'First')
+
+
+def _verify_tab_names(first, second):
+    world.wait_for(
+        func=lambda _: len(world.css_find('.xmodule_StaticTabModule')) == 2,
+        timeout=200,
+        timeout_msg="Timed out waiting for two tabs to be present"
+    )
+    tabs = world.css_find('.xmodule_StaticTabModule')
+    assert tabs[0].text == first
+    assert tabs[1].text == second

--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -170,7 +170,7 @@ class ContentStoreToyCourseTest(ModuleStoreTestCase):
             resp = self.client.get_html(reverse('edit_unit', kwargs={'location': descriptor.location.url()}))
             self.assertEqual(resp.status_code, 200)
 
-    def lockAnAsset(self, content_store, course_location):
+    def _lock_an_asset(self, content_store, course_location):
         """
         Lock an arbitrary asset in the course
         :param course_location:
@@ -425,10 +425,10 @@ class ContentStoreToyCourseTest(ModuleStoreTestCase):
 
         course = module_store.get_item(course_location)
         num_tabs = len(course.tabs)
-        url_slug = (course.tabs[num_tabs-1])['url_slug']
-        tab_id =  'i4x://edX/999/static_tab/{0}'.format(url_slug)
+        url_slug = (course.tabs[num_tabs - 1])['url_slug']
+        tab_id = 'i4x://edX/999/static_tab/{0}'.format(url_slug)
 
-        self.client.delete(new_location.url_reverse('tabs')+ '/' + tab_id)
+        self.client.delete(new_location.url_reverse('tabs') + '/' + tab_id)
 
         course = module_store.get_item(course_location)
         self.assertEqual(num_tabs - 1, len(course.tabs))
@@ -638,7 +638,7 @@ class ContentStoreToyCourseTest(ModuleStoreTestCase):
             thumbnail = content_store.find(thumbnail_location, throw_on_not_found=False)
             self.assertIsNotNone(thumbnail)
 
-    def _delete_asset_in_course (self):
+    def _delete_asset_in_course(self):
         """
         Helper method for:
           1) importing course from xml
@@ -976,7 +976,7 @@ class ContentStoreToyCourseTest(ModuleStoreTestCase):
 
         self.assertIn(private_location_no_draft.url(), sequential.children)
 
-        locked_asset = self.lockAnAsset(content_store, location)
+        locked_asset = self._lock_an_asset(content_store, location)
         locked_asset_attrs = content_store.get_attrs(locked_asset)
         # the later import will reupload
         del locked_asset_attrs['uploadDate']
@@ -1031,7 +1031,7 @@ class ContentStoreToyCourseTest(ModuleStoreTestCase):
         shutil.rmtree(root_dir)
 
     def check_import(self, module_store, root_dir, draft_store, content_store, stub_location, course_location,
-        locked_asset, locked_asset_attrs):
+                     locked_asset, locked_asset_attrs):
         # reimport
         import_from_xml(
             module_store, root_dir, ['test_export'], draft_store=draft_store,
@@ -1406,7 +1406,7 @@ class ContentStoreTest(ModuleStoreTestCase):
         second_course_data = self.assert_created_course(number_suffix=uuid4().hex)
 
         # unseed the forums for the first course
-        course_id =_get_course_id(test_course_data)
+        course_id = _get_course_id(test_course_data)
         delete_course_and_groups(course_id, commit=True)
         self.assertFalse(are_permissions_roles_seeded(course_id))
 
@@ -1662,14 +1662,16 @@ class ContentStoreTest(ModuleStoreTestCase):
 
         # go look at a subsection page
         subsection_location = loc.replace(category='sequential', name='test_sequence')
-        resp = self.client.get_html(reverse('edit_subsection',
-                                       kwargs={'location': subsection_location.url()}))
+        resp = self.client.get_html(
+            reverse('edit_subsection', kwargs={'location': subsection_location.url()})
+        )
         self.assertEqual(resp.status_code, 200)
 
         # go look at the Edit page
         unit_location = loc.replace(category='vertical', name='test_vertical')
-        resp = self.client.get_html(reverse('edit_unit',
-                                       kwargs={'location': unit_location.url()}))
+        resp = self.client.get_html(
+            reverse('edit_unit', kwargs={'location': unit_location.url()})
+        )
         self.assertEqual(resp.status_code, 200)
 
         # delete a component

--- a/cms/djangoapps/contentstore/views/tabs.py
+++ b/cms/djangoapps/contentstore/views/tabs.py
@@ -4,20 +4,25 @@ Views related to course tabs
 from access import has_access
 from util.json_request import expect_json
 
-from django.http import HttpResponse, HttpResponseBadRequest
+from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseNotFound
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
 from django_future.csrf import ensure_csrf_cookie
 from mitxmako.shortcuts import render_to_response
 from xmodule.modulestore import Location
 from xmodule.modulestore.inheritance import own_metadata
-from xmodule.modulestore.django import modulestore
+from xmodule.modulestore.django import modulestore, loc_mapper
+from xmodule.modulestore.locator import BlockUsageLocator
 
-from ..utils import get_course_for_item, get_modulestore
+from ..utils import get_modulestore
+from .item import delete_item_at_location
 
 from django.utils.translation import ugettext as _
+from django.views.decorators.http import require_http_methods
+from util.json_request import JsonResponse
+import json
 
-__all__ = ['edit_tabs', 'reorder_static_tabs']
+__all__ = ['tabs_handler']
 
 
 def initialize_course_tabs(course):
@@ -39,93 +44,107 @@ def initialize_course_tabs(course):
         {"type": "progress", "name": _("Progress")},
     ] 
 
-    modulestore('direct').update_metadata(course.location.url(), own_metadata(course))
-
-
-@login_required
-@expect_json
-def reorder_static_tabs(request):
-    "Order the static tabs in the requested order"
-    tabs = request.json['tabs']
-    course = get_course_for_item(tabs[0])
-
-    if not has_access(request.user, course.location):
-        raise PermissionDenied()
-
-    # get list of existing static tabs in course
-    # make sure they are the same lengths (i.e. the number of passed in tabs equals the number
-    # that we know about) otherwise we can drop some!
-
-    existing_static_tabs = [t for t in course.tabs if t['type'] == 'static_tab']
-    if len(existing_static_tabs) != len(tabs):
-        return HttpResponseBadRequest()
-
-    # load all reference tabs, return BadRequest if we can't find any of them
-    tab_items = []
-    for tab in tabs:
-        item = modulestore('direct').get_item(Location(tab))
-        if item is None:
-            return HttpResponseBadRequest()
-
-        tab_items.append(item)
-
-    # now just go through the existing course_tabs and re-order the static tabs
-    reordered_tabs = []
-    static_tab_idx = 0
-    for tab in course.tabs:
-        if tab['type'] == 'static_tab':
-            reordered_tabs.append({'type': 'static_tab',
-                                   'name': tab_items[static_tab_idx].display_name,
-                                   'url_slug': tab_items[static_tab_idx].location.name})
-            static_tab_idx += 1
-        else:
-            reordered_tabs.append(tab)
-
-    # OK, re-assemble the static tabs in the new order
-    course.tabs = reordered_tabs
-    # Save the data that we've just changed to the underlying
-    # MongoKeyValueStore before we update the mongo datastore.
-    course.save()
     modulestore('direct').update_metadata(course.location, own_metadata(course))
-    # TODO: above two lines are used for the primitive-save case. Maybe factor them out?
-    return HttpResponse()
 
 
 @login_required
 @ensure_csrf_cookie
-def edit_tabs(request, org, course, coursename):
-    "Edit tabs"
-    location = ['i4x', org, course, 'course', coursename]
-    store = get_modulestore(location)
-    course_item = store.get_item(location)
+@require_http_methods(("GET", "DELETE", "POST", "PUT"))
+def tabs_handler(request, tag=None, course_id=None, branch=None, version_guid=None, block=None, tab_id=None):
+    """
+    The restful handler for static tabs.
 
-    # check that logged in user has permissions to this item
+    GET
+        html: return page for editing static tabs
+        json: not supported
+    PUT or POST
+        json: update the tab order. It is expected that the request body contains a JSON-encoded dict with entry "tabs".
+        The value for "tabs" is an array of tab id's, indicating the desired order of the tabs.
+
+        Currently, creating a tab or changing its contents is not supported through this method.
+    DELETE
+        json: delete the tab with the given id
+    """
+    location = BlockUsageLocator(course_id=course_id, branch=branch, version_guid=version_guid, usage_id=block)
     if not has_access(request.user, location):
         raise PermissionDenied()
 
-    # see tabs have been uninitialized (e.g. supporing courses created before tab support in studio)
-    if course_item.tabs is None or len(course_item.tabs) == 0:
-        initialize_course_tabs(course_item)
+    old_location = loc_mapper().translate_locator_to_location(location)
+    store = get_modulestore(old_location)
+    course_item = store.get_item(old_location)
 
-    # first get all static tabs from the tabs list
-    # we do this because this is also the order in which items are displayed in the LMS
-    static_tabs_refs = [t for t in course_item.tabs if t['type'] == 'static_tab']
+    if 'application/json' in request.META.get('HTTP_ACCEPT', 'application/json'):
+        if request.method == 'GET':
+            raise NotImplementedError('coming soon')
+        elif request.method == 'DELETE':
+            delete_item_at_location(Location(tab_id))
+            return JsonResponse()
+        else:
+            request_body = (json.loads(request.body))
+            if 'tabs' in request_body:
+                tabs = request_body['tabs']
 
-    static_tabs = []
-    for static_tab_ref in static_tabs_refs:
-        static_tab_loc = Location(location)._replace(category='static_tab', name=static_tab_ref['url_slug'])
-        static_tabs.append(modulestore('direct').get_item(static_tab_loc))
+                # get list of existing static tabs in course
+                # make sure they are the same lengths (i.e. the number of passed in tabs equals the number
+                # that we know about) otherwise we can drop some!
+                existing_static_tabs = [t for t in course_item.tabs if t['type'] == 'static_tab']
+                if len(existing_static_tabs) != len(tabs):
+                    return HttpResponseBadRequest()
 
-    components = [
-        static_tab.location.url()
-        for static_tab
-        in static_tabs
-    ]
+                # load all reference tabs, return BadRequest if we can't find any of them
+                tab_items = []
+                for tab in tabs:
+                    item = modulestore('direct').get_item(Location(tab))
+                    if item is None:
+                        return HttpResponseBadRequest()
 
-    return render_to_response('edit-tabs.html', {
-        'context_course': course_item,
-        'components': components
-    })
+                    tab_items.append(item)
+
+                # now just go through the existing course_tabs and re-order the static tabs
+                reordered_tabs = []
+                static_tab_idx = 0
+                for tab in course_item.tabs:
+                    if tab['type'] == 'static_tab':
+                        reordered_tabs.append({'type': 'static_tab',
+                                               'name': tab_items[static_tab_idx].display_name,
+                                               'url_slug': tab_items[static_tab_idx].location.name})
+                        static_tab_idx += 1
+                    else:
+                        reordered_tabs.append(tab)
+
+                # OK, re-assemble the static tabs in the new order
+                course_item.tabs = reordered_tabs
+                # Save the data that we've just changed to the underlying
+                # MongoKeyValueStore before we update the mongo datastore.
+                course_item.save()
+                modulestore('direct').update_metadata(course_item.location, own_metadata(course_item))
+                # TODO: above two lines are used for the primitive-save case. Maybe factor them out?
+                return HttpResponse()
+            else:
+                raise NotImplementedError('creating or changing a tabs content is not currently supported')
+    elif request.method == 'GET':  # assume html
+        # see tabs have been uninitialized (e.g. supporing courses created before tab support in studio)
+        if course_item.tabs is None or len(course_item.tabs) == 0:
+            initialize_course_tabs(course_item)
+
+        # first get all static tabs from the tabs list
+        # we do this because this is also the order in which items are displayed in the LMS
+        static_tabs_refs = [t for t in course_item.tabs if t['type'] == 'static_tab']
+
+        static_tabs = []
+        for static_tab_ref in static_tabs_refs:
+            static_tab_loc = Location(old_location)._replace(category='static_tab', name=static_tab_ref['url_slug'])
+            static_tabs.append(modulestore('direct').get_item(static_tab_loc))
+
+        components = [static_tab.location.url() for static_tab in static_tabs]
+
+        return render_to_response('edit-tabs.html', {
+            'context_course': course_item,
+            'components': components,
+            'handler_url': location.url_reverse('tabs')
+        })
+    else:
+        return HttpResponseNotFound()
 
 
 # "primitive" tab edit functions driven by the command line.

--- a/cms/static/coffee/src/views/tabs.coffee
+++ b/cms/static/coffee/src/views/tabs.coffee
@@ -24,6 +24,7 @@ define ["jquery", "jquery.ui", "backbone", "js/views/feedback_prompt", "js/views
         axis: 'y'
         items: '> .component'
       )
+      @updateUrl = @options.url
 
     tabMoved: (event, ui) =>
       tabs = []
@@ -34,14 +35,16 @@ define ["jquery", "jquery.ui", "backbone", "js/views/feedback_prompt", "js/views
       analytics.track "Reordered Static Pages",
         course: course_location_analytics
 
+      saving = new NotificationView.Mini({title: gettext("Saving&hellip;")})
+      saving.show()
       $.ajax({
         type:'POST',
-        url: '/reorder_static_tabs',
+        url: @updateUrl,
         data: JSON.stringify({
           tabs : tabs
         }),
         contentType: 'application/json'
-      })
+      }).success(=> saving.hide())
 
     addNewTab: (event) =>
       event.preventDefault()
@@ -66,6 +69,7 @@ define ["jquery", "jquery.ui", "backbone", "js/views/feedback_prompt", "js/views
         course: course_location_analytics
 
     deleteTab: (event) =>
+      updateUrl = @updateUrl
       confirm = new PromptView.Warning
         title: gettext('Delete Component Confirmation')
         message: gettext('Are you sure you want to delete this component? This action cannot be undone.')
@@ -82,12 +86,15 @@ define ["jquery", "jquery.ui", "backbone", "js/views/feedback_prompt", "js/views
               deleting = new NotificationView.Mini
                 title: gettext('Deleting&hellip;')
               deleting.show()
-              $.postJSON('/delete_item', {
-                id: $component.data('id')
-              }, =>
+              $.ajax({
+                type:'DELETE',
+                url: updateUrl+'/'+$component.data('id'),
+                contentType: 'application/json'
+              }).success(=>
                 $component.remove()
                 deleting.hide()
               )
+
           secondary: [
             text: gettext('Cancel')
             click: (view) ->

--- a/cms/templates/edit-tabs.html
+++ b/cms/templates/edit-tabs.html
@@ -15,7 +15,8 @@ require(["coffee/src/views/tabs", "coffee/src/models/module"], function(TabsEdit
       model: new ModuleModel({
         id: '${context_course.location}'
       }),
-      mast: $('.wrapper-mast')
+      mast: $('.wrapper-mast'),
+      url: "${handler_url}"
     });
 });
   </script>

--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -16,11 +16,12 @@
       <% 
             ctx_loc = context_course.location
             location = loc_mapper().translate_location(ctx_loc.course_id, ctx_loc, False, True)
-            index_url = location.url_reverse('course/', '')
-            checklists_url = location.url_reverse('checklists/', '')
-            course_team_url = location.url_reverse('course_team/', '')
-            assets_url = location.url_reverse('assets/', '')
-            import_url = location.url_reverse('import/', '')
+            index_url = location.url_reverse('course')
+            checklists_url = location.url_reverse('checklists')
+            course_team_url = location.url_reverse('course_team')
+            assets_url = location.url_reverse('assets')
+            import_url = location.url_reverse('import')
+            tabs_url = location.url_reverse('tabs')
       %>
       <h2 class="info-course">
         <span class="sr">${_("Current Course:")}</span>
@@ -46,7 +47,7 @@
                     <a href="${reverse('course_info', kwargs=dict(org=ctx_loc.org, course=ctx_loc.course, name=ctx_loc.name))}">${_("Updates")}</a>
                   </li>
                   <li class="nav-item nav-course-courseware-pages">
-                    <a href="${reverse('edit_tabs', kwargs=dict(org=ctx_loc.org, course=ctx_loc.course, coursename=ctx_loc.name))}">${_("Static Pages")}</a>
+                    <a href="${tabs_url}">${_("Static Pages")}</a>
                   </li>
                   <li class="nav-item nav-course-courseware-uploads">
                     <a href="${assets_url}">${_("Files &amp; Uploads")}</a>

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -30,7 +30,6 @@ urlpatterns = patterns('',  # nopep8
     url(r'^create_draft$', 'contentstore.views.create_draft', name='create_draft'),
     url(r'^publish_draft$', 'contentstore.views.publish_draft', name='publish_draft'),
     url(r'^unpublish_unit$', 'contentstore.views.unpublish_unit', name='unpublish_unit'),
-    url(r'^reorder_static_tabs', 'contentstore.views.reorder_static_tabs', name='reorder_static_tabs'),
 
     url(r'^(?P<org>[^/]+)/(?P<course>[^/]+)/export/(?P<name>[^/]+)$',
         'contentstore.views.export_course', name='export_course'),
@@ -61,9 +60,6 @@ urlpatterns = patterns('',  # nopep8
 
     url(r'^(?P<org>[^/]+)/(?P<course>[^/]+)/(?P<category>[^/]+)/(?P<name>[^/]+)/gradeas.*$',
         'contentstore.views.assignment_type_update', name='assignment_type_update'),
-
-    url(r'^edit_tabs/(?P<org>[^/]+)/(?P<course>[^/]+)/course/(?P<coursename>[^/]+)$',
-        'contentstore.views.edit_tabs', name='edit_tabs'),
 
     url(r'^(?P<org>[^/]+)/(?P<course>[^/]+)/textbooks/(?P<name>[^/]+)$',
         'contentstore.views.textbook_index', name='textbook_index'),
@@ -124,6 +120,7 @@ urlpatterns += patterns(
     url(r'(?ix)^assets/{}(/)?(?P<asset_id>.+)?$'.format(parsers.URL_RE_SOURCE), 'assets_handler'),
     url(r'(?ix)^import/{}$'.format(parsers.URL_RE_SOURCE), 'import_handler'),
     url(r'(?ix)^import_status/{}/(?P<filename>.+)$'.format(parsers.URL_RE_SOURCE), 'import_status_handler'),
+    url(r'(?ix)^tabs/{}(/)?(?P<tab_id>.+)?$'.format(parsers.URL_RE_SOURCE), 'tabs_handler'),
 )
 
 js_info_dict = {

--- a/common/lib/xmodule/xmodule/modulestore/locator.py
+++ b/common/lib/xmodule/xmodule/modulestore/locator.py
@@ -263,7 +263,7 @@ class CourseLocator(Locator):
                              version_guid=self.version_guid,
                              branch=self.branch)
 
-    def url_reverse(self, prefix, postfix):
+    def url_reverse(self, prefix, postfix=""):
         """
         Do what reverse is supposed to do but seems unable to do. Generate a url using prefix unicode(self) postfix
         :param prefix: the beginning of the url (will be forced to begin and end with / if non-empty)


### PR DESCRIPTION
I will re-visit this PR after the item.py refactoring is done.

Here are some caveats:
1) Creating and saving static tabs is still done through the generic save_item and create_item view methods. Changing the tabs to use the tabs URL for this seemed like a pretty big change, especially since we have a desire to revamp the static tabs page to allow more control over all the bas.

2) Reordering of the tabs IS done through the tabs URL, but it is perhaps a little weird (in the fact that it just sends a list of IDs). I documented the expected payload, but I can imagine this will change in the future.

3) No Jasmine tests exist for the tabs coffee file. I didn't feel like creating these tests (especially given the desire to revamp the UI), but I did extend the existing Selenium tests (which covered addition and deletion of static tabs) to cover reordering. Therefore, the code I changed is covered by automated tests.
