### PR TITLE
Add skip link to django template pages.

### DIFF
--- a/lms/templates/main_django.html
+++ b/lms/templates/main_django.html
@@ -22,15 +22,16 @@
 
 
   <!--[if lt IE 9]>
-  <script src="${static.url('js/html5shiv.js')}"></script>
+  <script src="{% static 'js/html5shiv.js' %}"></script>
   <![endif]-->
 
   <meta name="path_prefix" content="{{MITX_ROOT_URL}}">
 </head>
 
 <body class="{% block bodyclass %}{% endblock %}">
+  <a class="nav-skip" href="#content">{% trans "Skip to this view's content" %}</a>
   {% include "navigation.html" %}
-  <section class="content-wrapper">
+  <section class="content-wrapper" id="content">
     {% block body %}{% endblock %}
     {% block bodyextra %}{% endblock %}
   </section>


### PR DESCRIPTION
Not just for wiki, but for any page that uses django_main. Hooray. I also fixed a small error where we were using mako syntax on this page.

@adampalay @talbs 

Bug: LMS-1387
