### PR TITLE
Avoid CS search endpoint for non-search queries

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,12 @@ Blades: Fix bug when the speed can only be changed when the video is playing.
 LMS: Change bulk email implementation to use less memory, and to better handle
 duplicate tasks in celery.
 
+LMS: When a topic is selected in the forums navigation sidebar, fetch
+the thread list using the /threads endpoint of the comments service
+instead of /search/threads, which does not sort and paginate
+correctly. This requires at least version 31ef160 of
+cs_comments_service.
+
 LMS: Improve forum error handling so that errors in the logs are
 clearer and HTTP status codes from the comments service indicating
 client error are correctly passed through to the client.

--- a/lms/lib/comment_client/thread.py
+++ b/lms/lib/comment_client/thread.py
@@ -34,7 +34,7 @@ class Thread(models.Model):
                           'recursive': False}
         params = merge_dict(default_params, strip_blank(strip_none(query_params)))
 
-        if query_params.get('text') or query_params.get('tags') or query_params.get('commentable_ids'):
+        if query_params.get('text') or query_params.get('tags'):
             url = cls.url(action='search')
         else:
             url = cls.url(action='get_all', params=extract(params, 'commentable_id'))


### PR DESCRIPTION
This change requires cs_comments_service version 31ef160 or later. Now
that the /threads endpoint can filter by commentable_ids, use that
instead of the /search/threads endpoint, which does not sort and
paginate correctly.

@jimabramson 
