### PR TITLE
Fix AssertionErrors that were raised when creation of an XModule failed

### DIFF
--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -735,11 +735,16 @@ class XModuleDescriptor(XModuleMixin, HTMLSnippet, ResourceTemplates, XBlock):
                 )
                 self.xmodule_runtime.xmodule_instance.save()
             except Exception:  # pylint: disable=broad-except
+                if isinstance(self, self.xmodule_runtime.error_descriptor_class):
+                    log.exception('Error creating an ErrorModule from an ErrorDescriptor')
+                    raise
+
                 log.exception('Error creating xmodule')
                 descriptor = self.xmodule_runtime.error_descriptor_class.from_descriptor(
                     self,
                     error_msg=exc_info_to_str(sys.exc_info())
                 )
+                descriptor.xmodule_runtime = self.xmodule_runtime
                 self.xmodule_runtime.xmodule_instance = descriptor._xmodule  # pylint: disable=protected-access
         return self.xmodule_runtime.xmodule_instance
 


### PR DESCRIPTION
The ErrorDescriptor wasn't getting the appropriate xmodule_runtime set, and
thus immediately raising an AssertionError when we tried to retrieve and
_xmodule from it.

[LMS-1388[
