### PR TITLE
add error handling for update_score for OEE when no child_history

### DIFF
--- a/common/lib/xmodule/xmodule/open_ended_grading_classes/open_ended_module.py
+++ b/common/lib/xmodule/xmodule/open_ended_grading_classes/open_ended_module.py
@@ -281,9 +281,23 @@ class OpenEndedModule(openendedchild.OpenEndedChild):
         if not new_score_msg['valid']:
             new_score_msg['feedback'] = 'Invalid grader reply. Please contact the course staff.'
 
-        self.record_latest_score(new_score_msg['score'])
-        self.record_latest_post_assessment(score_msg)
-        self.child_state = self.POST_ASSESSMENT
+        if self.child_history:
+            self.record_latest_score(new_score_msg['score'])
+            self.record_latest_post_assessment(score_msg)
+            self.child_state = self.POST_ASSESSMENT
+        else:
+            log.error((
+                "Trying to update score without existing studentmodule child_history:\n"
+                "   location: {location}\n"
+                "   score: {score}\n"
+                "   grader_ids: {grader_ids}\n"
+                "   submission_ids: {submission_ids}").format(
+                    location=self.location_string,
+                    score=new_score_msg['score'],
+                    grader_ids=new_score_msg['grader_ids'],
+                    submission_ids=new_score_msg['submission_ids']
+                )
+            )
 
         return True
 

--- a/common/lib/xmodule/xmodule/open_ended_grading_classes/open_ended_module.py
+++ b/common/lib/xmodule/xmodule/open_ended_grading_classes/open_ended_module.py
@@ -281,6 +281,10 @@ class OpenEndedModule(openendedchild.OpenEndedChild):
         if not new_score_msg['valid']:
             new_score_msg['feedback'] = 'Invalid grader reply. Please contact the course staff.'
 
+        # self.child_history is initialized as [].  record_latest_score() and record_latest_post_assessment()
+        # operate on self.child_history[-1].  Thus we have to make sure child_history is not [].
+        # Handle at this level instead of in record_*() because this is a good place to reduce the number of conditions
+        # and also keep the persistent state from changing.
         if self.child_history:
             self.record_latest_score(new_score_msg['score'])
             self.record_latest_post_assessment(score_msg)


### PR DESCRIPTION
@VikParuchuri @brianhw 

For some reason (not yet root caused), we are getting a lot of 500s like this:

```

<WSGIRequest
path:/courses/Medicine/SciWrite/Fall2013/xqueue/110204/i4x://Medicine/SciWrite/combinedopenended/ba076c1a6e4246f5b767c33603b27d39/score_update>

Traceback (most recent call last):

  File "/opt/edx/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 111, in get_response
    response = callback(request, *callback_args, **callback_kwargs)

  File "/opt/edx/local/lib/python2.7/site-packages/django/views/decorators/csrf.py", line 77, in wrapped_view
    return view_func(*args, **kwargs)

  File "/opt/wwc/edx-platform/lms/djangoapps/courseware/module_render.py", line 503, in xqueue_callback
    instance.handle_ajax(dispatch, data)

  File "/opt/wwc/edx-platform/common/lib/xmodule/xmodule/combined_open_ended_module.py", line 448, in handle_ajax
    return_value = self.child_module.handle_ajax(dispatch, data)

  File "/opt/wwc/edx-platform/common/lib/xmodule/xmodule/open_ended_grading_classes/combined_open_ended_modulev1.py", line 731, in handle_ajax
    return_html = self.current_task.handle_ajax(dispatch, data, self.system)

  File "/opt/wwc/edx-platform/common/lib/xmodule/xmodule/open_ended_grading_classes/open_ended_module.py", line 618, in handle_ajax
    d = handlers[dispatch](data, system)

  File "/opt/wwc/edx-platform/common/lib/xmodule/xmodule/open_ended_grading_classes/open_ended_module.py", line 676, in update_score
    self._update_score(score_msg, queuekey, system)

  File "/opt/wwc/edx-platform/common/lib/xmodule/xmodule/open_ended_grading_classes/open_ended_module.py", line 284, in _update_score
    self.record_latest_score(new_score_msg['score'])

  File "/opt/wwc/edx-platform/common/lib/xmodule/xmodule/open_ended_grading_classes/openendedchild.py", line 253, in record_latest_score
    self.child_history[-1]['score'] = score

IndexError: list index out of range

```

Which is weird, since if there's no submission, there shouldn't be anything in ORA to be peer graded.  But evidently there was a submission in ORA, which did get peer-graded, and did cause the callbacks to update_score to happen.

This is a patch to handle this case for now, because as things stand currently if this case happens, the error will not stop happening without human intervention. (i.e edx-ora-celery will keep pushing to xqueue which will keep pushing to lms, because all the response codes will be 500s which propagate back and don't cause any state changes in the respective databases)
