### PR TITLE
Acceptance tests use asset pipeline

### DIFF
--- a/cms/envs/acceptance.py
+++ b/cms/envs/acceptance.py
@@ -80,6 +80,12 @@ DATABASES = {
     }
 }
 
+# Enable asset pipeline
+# Our fork of django-pipeline uses `PIPELINE` instead of `PIPELINE_ENABLED`
+# PipelineFinder is explained here: http://django-pipeline.readthedocs.org/en/1.1.24/storages.html
+PIPELINE = True
+STATICFILES_FINDERS += ('pipeline.finders.PipelineFinder', )
+
 # Use the auto_auth workflow for creating users and logging them in
 MITX_FEATURES['AUTOMATIC_AUTH_FOR_TESTING'] = True
 

--- a/lms/envs/acceptance.py
+++ b/lms/envs/acceptance.py
@@ -82,6 +82,13 @@ TRACKING_BACKENDS.update({
     }
 })
 
+
+# Enable asset pipeline
+# Our fork of django-pipeline uses `PIPELINE` instead of `PIPELINE_ENABLED`
+# PipelineFinder is explained here: http://django-pipeline.readthedocs.org/en/1.1.24/storages.html
+PIPELINE = True
+STATICFILES_FINDERS += ('pipeline.finders.PipelineFinder', )
+
 BULK_EMAIL_DEFAULT_FROM_EMAIL = "test@test.org"
 
 # Forums are disabled in test.py to speed up unit tests, but we do not have

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -8,7 +8,7 @@
 
 # Third-party:
 -e git+https://github.com/edx/django-staticfiles.git@6d2504e5c8#egg=django-staticfiles
--e git+https://github.com/edx/django-pipeline.git#egg=django-pipeline
+-e git+https://github.com/edx/django-pipeline.git@88ec8a011e481918fdc9d2682d4017c835acd8be#egg=django-pipeline
 -e git+https://github.com/edx/django-wiki.git@41815e2ef1b0323f92900f8e60711b0f0c37766b#egg=django-wiki
 -e git+https://github.com/edx/lettuce.git@503fe2d2599290c45b021d6c424ab5ea899e42be#egg=lettuce
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev


### PR DESCRIPTION
Update the acceptance tests to use Django-pipeline.

This required an update to our fork of django-pipeline that hasn't been merged yet: https://github.com/edx/django-pipeline/pull/1

Since our requirements.txt doesn't specify a commit in the django-pipeline repo, I think it makes sense to merge this PR first, then merge the django-pipeline PR.

@cpennington @jarv please review
