### PR TITLE
Will/acceptance test fixes

### DIFF
--- a/common/djangoapps/terrain/ui_helpers.py
+++ b/common/djangoapps/terrain/ui_helpers.py
@@ -44,6 +44,12 @@ REQUIREJS_WAIT = {
     re.compile('^My Courses \|'): [
         "js/sock", "gettext", "js/base",
         "jquery.ui", "coffee/src/main", "underscore"],
+
+    # Upload
+    re.compile(r'^\s*Files & Uploads'): [
+        'js/base', 'jquery.ui', 'coffee/src/main', 'underscore',
+        'js/views/assets', 'js/views/asset'
+    ]
 }
 
 
@@ -389,12 +395,14 @@ def css_find(css, wait_time=30):
 
 
 @world.absorb
-def css_click(css_selector, index=0, wait_time=30):
+def css_click(css_selector, index=0, wait_time=30, dismiss_alert=False):
     """
     Perform a click on a CSS selector, first waiting for the element
     to be present and clickable.
 
     This method will return True if the click worked.
+
+    If `dismiss_alert` is true, dismiss any alerts that appear.
     """
     wait_for_clickable(css_selector, timeout=wait_time)
     wait_for_visible(css_selector, index=index, timeout=wait_time)
@@ -403,10 +411,16 @@ def css_click(css_selector, index=0, wait_time=30):
         msg="Element {}[{}] is present but not visible".format(css_selector, index)
     )
 
-    result = retry_on_exception(lambda: css_find(css_selector)[index].click())
-    if result:
-        wait_for_js_to_load()
-    return result
+    retry_on_exception(lambda: css_find(css_selector)[index].click())
+
+    # Dismiss any alerts that occur.
+    # We need to do this before calling `wait_for_js_to_load()`
+    # to avoid getting an unexpected alert exception
+    if dismiss_alert:
+        world.browser.get_alert().accept()
+
+    wait_for_js_to_load()
+    return True
 
 
 @world.absorb

--- a/lms/djangoapps/courseware/features/problems.py
+++ b/lms/djangoapps/courseware/features/problems.py
@@ -107,6 +107,9 @@ def check_problem(step):
     world.browser.execute_script("window.scrollTo(0,1024)")
     world.css_click("input.check")
 
+    # Wait for the problem to finish re-rendering
+    world.wait_for_ajax_complete()
+
 
 @step(u'The "([^"]*)" problem displays a "([^"]*)" answer')
 def assert_problem_has_answer(step, problem_type, answer_class):
@@ -126,6 +129,9 @@ def assert_problem_has_answer(step, problem_type, answer_class):
 @step(u'I reset the problem')
 def reset_problem(_step):
     world.css_click('input.reset')
+
+    # Wait for the problem to finish re-rendering
+    world.wait_for_ajax_complete()
 
 
 @step(u'I press the button with the label "([^"]*)"$')
@@ -172,7 +178,6 @@ def assert_answer_mark(_step, problem_type, isnt_marked, correctness):
     *problem_type* is a string identifying the type of problem (e.g. 'drop down')
     *correctness* is in ['correct', 'incorrect', 'unanswered']
     """
-
     # Determine which selector(s) to look for based on correctness
     assert(correctness in ['correct', 'incorrect', 'unanswered'])
     assert(problem_type in PROBLEM_DICT)

--- a/lms/djangoapps/instructor/features/bulk_email.py
+++ b/lms/djangoapps/instructor/features/bulk_email.py
@@ -115,10 +115,7 @@ def when_i_send_an_email(step, recipient):
         editor.fill('test message')
 
     # Click send
-    world.css_click('input[name="send"]')
-
-    # Confirm the alert
-    world.browser.get_alert().accept()
+    world.css_click('input[name="send"]', dismiss_alert=True)
 
     # Expect to see a message that the email was sent
     expected_msg = "Your email was successfully queued for sending."


### PR DESCRIPTION
Fixes for some failures I noticed on (my) PR tests.

1) Added explicit waits for the problem to reload after resetting or checking it.
2) Added JavaScript waits for the Uploads page in Studio
3) Discovered that `click()` does not actually return anything, so none of the `wait_for_js_to_load()` calls were being executed in `css_click()`

@jzoldak 
