### PR TITLE
Studio: Fix - Forgot Password Modal

### DIFF
--- a/cms/djangoapps/contentstore/views/public.py
+++ b/cms/djangoapps/contentstore/views/public.py
@@ -38,7 +38,7 @@ def login_page(request):
     csrf_token = csrf(request)['csrf_token']
     return render_to_response('login.html', {
         'csrf': csrf_token,
-        'forgot_password_link': "//{base}/#forgot-password-modal".format(base=settings.LMS_BASE),
+        'forgot_password_link': "//{base}/login#forgot-password-modal".format(base=settings.LMS_BASE),
     })
 
 

--- a/lms/templates/login.html
+++ b/lms/templates/login.html
@@ -16,6 +16,11 @@
       // adding js class for styling with accessibility in mind
       $('body').addClass('js').addClass(view_name);
 
+      // show forgot password modal UI if URL contains matching DOM ID
+      if ($.deparam.fragment()['forgot-password-modal'] !== undefined) {
+        $('.pwd-reset').click();
+      }
+
       // new window/tab opening
       $('a[rel="external"], a[class="new-vp"]')
       .click( function() {


### PR DESCRIPTION
This work corrects the "forgot password" link on the Studio Sign In view to point to the login view (on the LMS side) which now consistently houses the Forgot Password modal UI (rather than the older homepage view that was replaced on edx.org some time ago). 
