### PR TITLE
Pin dateutil version to 2.1

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -57,6 +57,7 @@ pymongo==2.4.1
 pyparsing==1.5.6
 python-memcached==1.48
 python-openid==2.2.5
+python-dateutil==2.1
 pytz==2012h
 pysrt==0.4.7
 PyYAML==3.10


### PR DESCRIPTION
The latest release of dateutil (2.2) from 11/1 has made the parser stricter about handling `None` values.  It used to return a date; now it raises an exception.

This causes an error when we have course descriptors with advertised start dates set to `None`, as verified by tests in common/lib/xmodule/xmodule/tests/test_course_module.py", line 165, in test_is_newish

I couldn't find dateutil in our requirements directory, so I think it's a dependency of a dependency.  I added the requirement and pinned it to version 2.1

@nedbat @e0d 
