### PR TITLE
"Public Display Name" -> "Public Username" on registration page [LMS-139...

### DIFF
--- a/lms/templates/register.html
+++ b/lms/templates/register.html
@@ -131,7 +131,7 @@
             <input id="password" type="password" name="password" value="" required aria-required="true" />
           </li>
           <li class="field required text" id="field-username">
-            <label for="username">${_('Public Display Name')}</label>
+            <label for="username">${_('Public Username')}</label>
             <input id="username" type="text" name="username" value="" placeholder="${_('example: JaneDoe')}" required aria-required="true" aria-describedby="username-tip"/>
             <span class="tip tip-input" id="username-tip">${_('Will be shown in any discussions or forums you participate in')} <strong>(${_('cannot be changed later')})</strong></span>
           </li>


### PR DESCRIPTION
...3]

The field "Public Display Name" was causing confusion with a lot of students. Changing it back to "Public Username".

@caesar2164 
@marcotuts 
