### PR TITLE
LMS: add CSRF token to register form

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -95,4 +95,4 @@ Nicolas Chevalier <nicolas.chevalier@epitech.eu>
 Gabe Mulley <gabe@edx.org>
 Iain Dunning <idunning@mit.edu>
 Olivier Marquez <oliviermarquez@gmail.com>
-
+Florian Dufour <neurolit@gmail.com>

--- a/lms/templates/register.html
+++ b/lms/templates/register.html
@@ -100,6 +100,7 @@
 <section class="register container">
   <section role="main" class="content">
     <form role="form" id="register-form" method="post" data-remote="true" action="/create_account" novalidate>
+      <input type="hidden" name="csrfmiddlewaretoken" value="${ csrf_token }">
 
       <!-- status messages -->
       <div role="alert" class="status message">


### PR DESCRIPTION
Hi!

We noticed that registering a new account doesn't work with Lynx browser (used by some visually-impaired people). It is related to CSRF token, which is added by some Javascript magic during the submit, but not present in the form itself. As Lynx doesn't understand Javascript, there is no CSRF token in the submitted data, and a 403 error is raised.

This PR adds the CSRF token in the form, as a hidden field as usual, allowing registering to work without Javascript.
