### PR TITLE
Converted expiration_date from Date to DateTime

### DIFF
--- a/common/djangoapps/course_modes/migrations/0005_auto__chg_field_coursemode_expiration_date.py
+++ b/common/djangoapps/course_modes/migrations/0005_auto__chg_field_coursemode_expiration_date.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+
+        # Changing field 'CourseMode.expiration_date'
+        db.alter_column('course_modes_coursemode', 'expiration_date', self.gf('django.db.models.fields.DateTimeField')(null=True))
+
+    def backwards(self, orm):
+
+        # Changing field 'CourseMode.expiration_date'
+        db.alter_column('course_modes_coursemode', 'expiration_date', self.gf('django.db.models.fields.DateField')(null=True))
+
+    models = {
+        'course_modes.coursemode': {
+            'Meta': {'unique_together': "(('course_id', 'mode_slug', 'currency'),)", 'object_name': 'CourseMode'},
+            'course_id': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'currency': ('django.db.models.fields.CharField', [], {'default': "'usd'", 'max_length': '8'}),
+            'expiration_date': ('django.db.models.fields.DateTimeField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'min_price': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'mode_display_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'mode_slug': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'suggested_prices': ('django.db.models.fields.CommaSeparatedIntegerField', [], {'default': "''", 'max_length': '255', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['course_modes']

--- a/common/djangoapps/course_modes/models.py
+++ b/common/djangoapps/course_modes/models.py
@@ -36,7 +36,7 @@ class CourseMode(models.Model):
     currency = models.CharField(default="usd", max_length=8)
 
     # turn this mode off after the given expiration date
-    expiration_date = models.DateField(default=None, null=True, blank=True)
+    expiration_date = models.DateTimeField(default=None, null=True, blank=True)
 
     DEFAULT_MODE = Mode('honor', _('Honor Code Certificate'), 0, '', 'usd', None)
     DEFAULT_MODE_SLUG = 'honor'

--- a/common/djangoapps/course_modes/tests/test_models.py
+++ b/common/djangoapps/course_modes/tests/test_models.py
@@ -106,7 +106,7 @@ class CourseModeModelTest(TestCase):
         expiration_date = datetime.now(pytz.UTC) + timedelta(days=1)
         expired_mode.expiration_date = expiration_date
         expired_mode.save()
-        expired_mode_value = Mode(u'verified', u'Verified Certificate', 0, '', 'usd', expiration_date.date())
+        expired_mode_value = Mode(u'verified', u'Verified Certificate', 0, '', 'usd', expiration_date)
         modes = CourseMode.modes_for_course(self.course_id)
         self.assertEqual([expired_mode_value, mode1], modes)
 

--- a/common/djangoapps/student/tests/tests.py
+++ b/common/djangoapps/student/tests/tests.py
@@ -243,7 +243,7 @@ class DashboardTest(TestCase):
             course_id=self.course.id,
             mode_slug='verified',
             mode_display_name='Verified',
-            expiration_date=(datetime.now(pytz.UTC) + timedelta(days=1)).date()
+            expiration_date=datetime.now(pytz.UTC) + timedelta(days=1)
         )
         enrollment = CourseEnrollment.enroll(self.user, self.course.id)
         course_mode_info = complete_course_mode_info(self.course.id, enrollment)
@@ -261,13 +261,13 @@ class DashboardTest(TestCase):
             course_id=self.course.id,
             mode_slug='verified',
             mode_display_name='Verified',
-            expiration_date=(datetime.now(pytz.UTC) + timedelta(days=1)).date()
+            expiration_date=datetime.now(pytz.UTC) + timedelta(days=1)
         )
         enrollment = CourseEnrollment.enroll(self.user, self.course.id, mode='verified')
 
         self.assertTrue(enrollment.refundable())
 
-        verified_mode.expiration_date = (datetime.now(pytz.UTC) - timedelta(days=1)).date()
+        verified_mode.expiration_date = datetime.now(pytz.UTC) - timedelta(days=1)
         verified_mode.save()
         self.assertFalse(enrollment.refundable())
 

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -286,7 +286,7 @@ def complete_course_mode_info(course_id, enrollment):
         # if there is an expiration date, find out how long from now it is
         if modes['verified'].expiration_date:
             today = datetime.datetime.now(UTC).date()
-            mode_info['days_for_upsell'] = (modes['verified'].expiration_date - today).days
+            mode_info['days_for_upsell'] = (modes['verified'].expiration_date.date() - today).days
 
     return mode_info
 

--- a/lms/djangoapps/shoppingcart/tests/test_models.py
+++ b/lms/djangoapps/shoppingcart/tests/test_models.py
@@ -384,7 +384,7 @@ class CertificateItemTest(ModuleStoreTestCase):
                                  mode_slug="verified",
                                  mode_display_name="verified cert",
                                  min_price=self.cost,
-                                 expiration_date=(datetime.datetime.now(pytz.utc).date() + many_days))
+                                 expiration_date=(datetime.datetime.now(pytz.utc) + many_days))
         course_mode.save()
 
         CourseEnrollment.enroll(self.user, course_id, 'verified')
@@ -407,7 +407,7 @@ class CertificateItemTest(ModuleStoreTestCase):
                                  mode_slug="verified",
                                  mode_display_name="verified cert",
                                  min_price=self.cost,
-                                 expiration_date=(datetime.datetime.now(pytz.utc).date() + many_days))
+                                 expiration_date=(datetime.datetime.now(pytz.utc) + many_days))
         course_mode.save()
 
         CourseEnrollment.enroll(self.user, course_id, 'verified')
@@ -436,7 +436,7 @@ class CertificateItemTest(ModuleStoreTestCase):
         CertificateItem.add_to_order(cart, course_id, self.cost, 'verified')
         cart.purchase()
 
-        course_mode.expiration_date = (datetime.datetime.now(pytz.utc).date() - many_days)
+        course_mode.expiration_date = (datetime.datetime.now(pytz.utc) - many_days)
         course_mode.save()
 
         CourseEnrollment.unenroll(self.user, course_id)


### PR DESCRIPTION
Now CourseModes have DateTimes for expiration instead of Dates

Tests run fine locally, this migration file seems reasonable, but—if there's any extra testing/considerations I need to do around migrations, let me know?

@dianakhuang @ormsbee 

LMS-1454
