### PR TITLE
Added devstack settings

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -136,6 +136,7 @@ XQUEUE_INTERFACE = {
 STATICFILES_FINDERS = (
     'staticfiles.finders.FileSystemFinder',
     'staticfiles.finders.AppDirectoriesFinder',
+    'pipeline.finders.PipelineFinder',
 )
 
 # List of callables that know how to import templates from various sources.

--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -1,0 +1,53 @@
+"""
+Specific overrides to the base prod settings to make development easier.
+"""
+
+from .aws import * # pylint: disable=wildcard-import, unused-wildcard-import
+
+DEBUG = True
+USE_I18N = True
+TEMPLATE_DEBUG = DEBUG
+
+################################ EMAIL ########################################
+
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+
+################################# LMS INTEGRATION ######################################
+
+MITX_FEATURES['PREVIEW_LMS_BASE'] = "preview.localhost:8000"
+
+################################# CELERY ######################################
+
+# By default don't use a worker, execute tasks as if they were local functions
+CELERY_ALWAYS_EAGER = True
+
+################################ DEBUG TOOLBAR #################################
+INSTALLED_APPS += ('debug_toolbar', 'debug_toolbar_mongo')
+MIDDLEWARE_CLASSES += ('debug_toolbar.middleware.DebugToolbarMiddleware',)
+INTERNAL_IPS = ('127.0.0.1',)
+
+DEBUG_TOOLBAR_PANELS = (
+    'debug_toolbar.panels.version.VersionDebugPanel',
+    'debug_toolbar.panels.timer.TimerDebugPanel',
+    'debug_toolbar.panels.settings_vars.SettingsVarsDebugPanel',
+    'debug_toolbar.panels.headers.HeaderDebugPanel',
+    'debug_toolbar.panels.request_vars.RequestVarsDebugPanel',
+    'debug_toolbar.panels.sql.SQLDebugPanel',
+    'debug_toolbar.panels.signals.SignalDebugPanel',
+    'debug_toolbar.panels.logger.LoggingPanel',
+)
+
+DEBUG_TOOLBAR_CONFIG = {
+    'INTERCEPT_REDIRECTS': False
+}
+
+# To see stacktraces for MongoDB queries, set this to True.
+# Stacktraces slow down page loads drastically (for pages with lots of queries).
+DEBUG_TOOLBAR_MONGO_STACKTRACES = False
+
+#####################################################################
+# Lastly, see if the developer has any local overrides.
+try:
+    from .private import *  # pylint: disable=F0401
+except ImportError:
+    pass

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -573,6 +573,7 @@ WAFFLE_MAX_AGE = 1209600
 STATICFILES_FINDERS = (
     'staticfiles.finders.FileSystemFinder',
     'staticfiles.finders.AppDirectoriesFinder',
+    'pipeline.finders.PipelineFinder',
 )
 
 # List of callables that know how to import templates from various sources.

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -1,0 +1,54 @@
+"""
+Specific overrides to the base prod settings to make development easier.
+"""
+
+from .aws import * # pylint: disable=wildcard-import, unused-wildcard-import
+
+DEBUG = True
+USE_I18N = True
+TEMPLATE_DEBUG = True
+
+# By default don't use a worker, execute tasks as if they were local functions
+CELERY_ALWAYS_EAGER = True
+
+
+################################ EMAIL ########################################
+
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+MITX_FEATURES['ENABLE_INSTRUCTOR_EMAIL'] = True     # Enable email for all Studio courses
+MITX_FEATURES['REQUIRE_COURSE_EMAIL_AUTH'] = False  # Give all courses email (don't require django-admin perms)
+
+
+################################ DEBUG TOOLBAR ################################
+
+INSTALLED_APPS += ('debug_toolbar',)
+MIDDLEWARE_CLASSES += ('django_comment_client.utils.QueryCountDebugMiddleware',
+                       'debug_toolbar.middleware.DebugToolbarMiddleware',)
+INTERNAL_IPS = ('127.0.0.1',)
+
+DEBUG_TOOLBAR_PANELS = (
+    'debug_toolbar.panels.version.VersionDebugPanel',
+    'debug_toolbar.panels.timer.TimerDebugPanel',
+    'debug_toolbar.panels.settings_vars.SettingsVarsDebugPanel',
+    'debug_toolbar.panels.headers.HeaderDebugPanel',
+    'debug_toolbar.panels.request_vars.RequestVarsDebugPanel',
+    'debug_toolbar.panels.sql.SQLDebugPanel',
+    'debug_toolbar.panels.signals.SignalDebugPanel',
+    'debug_toolbar.panels.logger.LoggingPanel',
+)
+
+DEBUG_TOOLBAR_CONFIG = {
+    'INTERCEPT_REDIRECTS': False
+}
+
+########################### PIPELINE #################################
+
+PIPELINE_SASS_ARGUMENTS = '--debug-info --require {proj_dir}/static/sass/bourbon/lib/bourbon.rb'.format(proj_dir=PROJECT_ROOT)
+
+
+#####################################################################
+# Lastly, see if the developer has any local overrides.
+try:
+    from .private import *      # pylint: disable=F0401
+except ImportError:
+    pass


### PR DESCRIPTION
Adds settings for use with vagrant-devstack: https://github.com/edx/configuration/pull/427

The goal is to use the same settings as prod without sacrificing convenience.  Many of the settings in dev.py are set by JSON configuration files in the deploy scripts.  For this reason, `devstack` settings inherit from `aws`.

This shouldn't conflict with anyone's current dev environment.  If we transition to using vagrant-devstack, though, I'd want to make these settings the defaults in manage.py.

I'm primarily looking for feedback on other settings that should be enabled that I might be forgetting.  You can see the default settings in the configuration repo:

https://github.com/edx/configuration/blob/master/playbooks/roles/edxapp/defaults/main.yml

UPDATE: Some more background on how this works.  In prod, we use `aws.py` settings, which load settings (including feature flags) from lms.envs.json and cms.envs.json.  The JSON files, in turn, are created by the Ansible scripts (see link above) and will be installed in the Vagrant image.

Basically, I want to use the same default settings as prod, except for specific overrides to make development easier (like the Django debug toolbar).

Suggested reviewers: @sarina  @cahrens 
