### PR TITLE
Oleg/fix rearrange bug in problems

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,9 @@ These are notable changes in edx-platform.  This is a rolling list of changes,
 in roughly chronological order, most recent first.  Add your entries at or near
 the top.  Include a label indicating the component affected.
 
+Blades: Fix answer choices rearranging if user tries to stylize something in the
+text like with bold or italics. (BLD-449)
+
 LMS: Beta instructor dashboard will only count actively enrolled students for
 course enrollment numbers.
 

--- a/common/lib/capa/capa/inputtypes.py
+++ b/common/lib/capa/capa/inputtypes.py
@@ -52,6 +52,7 @@ from chem import chemcalc
 from calc.preview import latex_preview
 import xqueue_interface
 from datetime import datetime
+from xmodule.stringify import stringify_children
 
 log = logging.getLogger(__name__)
 
@@ -406,13 +407,7 @@ class ChoiceGroup(InputTypeBase):
                 raise Exception(
                     "[capa.inputtypes.extract_choices] Expected a <choice> tag; got %s instead"
                     % choice.tag)
-            choice_text = ''.join([etree.tostring(x) for x in choice])
-            if choice.text is not None:
-                # TODO: fix order?
-                choice_text += choice.text
-
-            choices.append((choice.get("name"), choice_text))
-
+            choices.append((choice.get("name"), stringify_children(choice)))
         return choices
 
 

--- a/common/lib/capa/capa/tests/test_inputtypes.py
+++ b/common/lib/capa/capa/tests/test_inputtypes.py
@@ -92,6 +92,7 @@ class ChoiceGroupTest(unittest.TestCase):
     <choice correct="false" name="foil1"><text>This is foil One.</text></choice>
     <choice correct="false" name="foil2"><text>This is foil Two.</text></choice>
     <choice correct="true" name="foil3">This is foil Three.</choice>
+    <choice correct="false" name="foil4">This is <b>foil</b> Four.</choice>
   </{tag}>
         """.format(tag=tag)
 
@@ -114,7 +115,8 @@ class ChoiceGroupTest(unittest.TestCase):
             'input_type': expected_input_type,
             'choices': [('foil1', '<text>This is foil One.</text>'),
                         ('foil2', '<text>This is foil Two.</text>'),
-                        ('foil3', 'This is foil Three.'), ],
+                        ('foil3', 'This is foil Three.'),
+                        ('foil4', 'This is <b>foil</b> Four.'), ],
             'show_correctness': 'always',
             'submitted_message': 'Answer received.',
             'name_array_suffix': expected_suffix,   # what is this for??


### PR DESCRIPTION
If you try the code below in studio, the wording for the answer choices will rearrange themselves if you try to stylize something in the text like with bold or italics.

Issue: https://edx-wiki.atlassian.net/browse/BLD-449

@singingwolfboy please review.
