### PR TITLE
Fix error on external_auth djangostore

### DIFF
--- a/common/djangoapps/external_auth/djangostore.py
+++ b/common/djangoapps/external_auth/djangostore.py
@@ -87,7 +87,7 @@ class DjangoOpenIDStore(OpenIDStore):
                 cache.delete(key)
                 removed = True
             else:
-                assoc = associations.pop(handle)
+                assoc = associations.pop(handle, None)
                 if assoc:
                     cache.set(key, associations, DEFAULT_ASSOCIATIONS_TIMEOUT)
                     removed = True


### PR DESCRIPTION
Don't raise an exception when an association is not found.
