### PR TITLE
Video: Fix speed menu when YouTube is unavailable.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ the top.  Include a label indicating the component affected.
 LMS: Beta instructor dashboard will only count actively enrolled students for
 course enrollment numbers.
 
+Blades: Blades: Fix speed menu that is not rendered correctly when YouTube is unavailable. (BLD-457).
+
 LMS: Users with is_staff=True no longer have the STAFF label appear on
 their forum posts.
 

--- a/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
+++ b/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
@@ -167,7 +167,7 @@ function (VideoPlayer) {
     // function _prepareHTML5Video(state)
     // The function prepare HTML5 video, parse HTML5
     // video sources etc.
-    function _prepareHTML5Video(state, html5Mode) {
+    function _prepareHTML5Video(state) {
         state.parseVideoSources(
             {
                 mp4: state.config.mp4Source,
@@ -176,15 +176,13 @@ function (VideoPlayer) {
             }
         );
 
-        if (html5Mode) {
-            state.speeds = ['0.75', '1.0', '1.25', '1.50'];
-            state.videos = {
-                '0.75': state.config.sub,
-                '1.0':  state.config.sub,
-                '1.25': state.config.sub,
-                '1.5':  state.config.sub
-            };
-        }
+        state.speeds = ['0.75', '1.0', '1.25', '1.50'];
+        state.videos = {
+            '0.75': state.config.sub,
+            '1.0':  state.config.sub,
+            '1.25': state.config.sub,
+            '1.5':  state.config.sub
+        };
 
         // We must have at least one non-YouTube video source available.
         // Otherwise, return a negative.
@@ -313,7 +311,7 @@ function (VideoPlayer) {
         if (!(_parseYouTubeIDs(this))) {
 
             // If we do not have YouTube ID's, try parsing HTML5 video sources.
-            if (!_prepareHTML5Video(this, true)) {
+            if (!_prepareHTML5Video(this)) {
 
                 // Non-YouTube sources were not found either.
                 return;

--- a/common/lib/xmodule/xmodule/js/src/video/08_video_speed_control.js
+++ b/common/lib/xmodule/xmodule/js/src/video/08_video_speed_control.js
@@ -13,7 +13,7 @@ function () {
         if (state.videoType === 'html5') {
             _initialize(state);
         } else if (state.videoType === 'youtube' && state.youtubeXhr) {
-            state.youtubeXhr.done(function () {
+            state.youtubeXhr.always(function () {
                 _initialize(state);
             });
         }

--- a/lms/djangoapps/courseware/features/video.py
+++ b/lms/djangoapps/courseware/features/video.py
@@ -94,6 +94,7 @@ def video_is_rendered(_step, mode):
     }
     html_tag = modes[mode.lower()]
     assert world.css_find('.video {0}'.format(html_tag)).first
+    assert world.is_css_present('.speed_link')
 
 
 @step('all sources are correct$')


### PR DESCRIPTION
This PR provides fix for [BLD-457](https://edx-wiki.atlassian.net/browse/BLD-457).

There is 2 cases that should be checked:
- Video player with Youtube link and without html5 sources and slow connection. Message in console: `Continue loading YouTube video`.
- Video player with Youtube link and with html5 sources and slow connection. Message in console: `Change player mode to HTML5`.

@valera-rozuvan please review.
