### PR TITLE
Enable debugging of a single Jasmine test.

### DIFF
--- a/cms/static/js_test.yml
+++ b/cms/static/js_test.yml
@@ -58,6 +58,7 @@ lib_paths:
     - xmodule_js/common_static/js/vendor/jquery.smooth-scroll.min.js
     - xmodule_js/common_static/coffee/src/jquery.immediateDescendents.js
     - xmodule_js/common_static/coffee/src/xblock
+    - xmodule_js/common_static/js/vendor/jasmine-debug.js
 
 # Paths to source JavaScript files
 src_paths:

--- a/cms/static/js_test_squire.yml
+++ b/cms/static/js_test_squire.yml
@@ -51,6 +51,7 @@ lib_paths:
     - xmodule_js/src/xmodule.js
     - xmodule_js/common_static/coffee/src/jquery.immediateDescendents.js
     - xmodule_js/common_static/js/test/i18n.js
+    - xmodule_js/common_static/js/vendor/jasmine-debug.js
 
 # Paths to source JavaScript files
 src_paths:

--- a/common/lib/xmodule/xmodule/js/js_test.yml
+++ b/common/lib/xmodule/xmodule/js/js_test.yml
@@ -33,6 +33,7 @@ src_paths:
 
 # Paths to library JavaScript files (optional)
 lib_paths:
+    - common_static/js/vendor/jasmine-debug.js
     - common_static/coffee/src/ajax_prefix.js
     - common_static/coffee/src/logger.js
     - common_static/js/vendor/jasmine-jquery.js

--- a/common/static/js/vendor/jasmine-debug.js
+++ b/common/static/js/vendor/jasmine-debug.js
@@ -1,0 +1,27 @@
+/**
+ * Jasmine debug for xmodule test suite.
+ *
+ * If you set `window.debugJasmineTests` to `true` then none of the it() calls
+ * will run in the test suite files. This is intentional. To run 1 or more it()
+ * calls, just add a prefix "_" - i.e. you should replace "it(" with "_it(".
+ * This will accomplish running a single (or a few) it() tests for the purpose
+ * of speeding up the process of debugging Jasmine tests.
+ *
+ * IMPORTANT: Do not forget to change `window.debugJasmineTests` back to
+ * `false` before committing, along with any "_it(" to "it("!
+ */
+
+window.debugJasmineTests = false;
+
+if (window.debugJasmineTests) {
+    (function () {
+        var oldIt = window.it;
+
+        window.it = function () {};
+
+        window._it = function() {
+            return oldIt.apply(this, arguments);
+        };
+    }());
+}
+

--- a/common/static/js_test.yml
+++ b/common/static/js_test.yml
@@ -28,6 +28,7 @@ prepend_path: common/static
 
 # Paths to library JavaScript files (optional)
 lib_paths:
+    - js/vendor/jasmine-debug.js
     - js/vendor/jquery.min.js
     - js/vendor/jasmine-jquery.js
     - js/vendor/underscore-min.js

--- a/lms/static/js_test.yml
+++ b/lms/static/js_test.yml
@@ -28,6 +28,7 @@ prepend_path: lms/static
 
 # Paths to library JavaScript files (optional)
 lib_paths:
+    - xmodule_js/common_static/js/vendor/jasmine-debug.js
     - xmodule_js/common_static/coffee/src/ajax_prefix.js
     - xmodule_js/common_static/coffee/src/logger.js
     - xmodule_js/common_static/js/vendor/jasmine-jquery.js


### PR DESCRIPTION
Manually alter the line (change `false` to `true`):

```
window.debugJasmineTests = false;
```

in file:

```
common/static/js/vendor/jasmine-debug.js
```

And all of `it()` tests will be disabled. Then proceed to enable a specific `it()` test by changing `it(` to `_it(`.

PS: Don't forget to change everything back!
