### PR TITLE
make edxapp work when not run from a git repo

### DIFF
--- a/common/djangoapps/mitxmako/middleware.py
+++ b/common/djangoapps/mitxmako/middleware.py
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from dealer.git import git
+from dealer.auto import auto
 from django.template import RequestContext
 requestcontext = None
 
@@ -24,4 +24,4 @@ class MakoMiddleware(object):
         requestcontext = RequestContext(request)
         requestcontext['is_secure'] = request.is_secure()
         requestcontext['site'] = request.get_host()
-        requestcontext['REVISION'] = git.revision
+        requestcontext['REVISION'] = auto.revision


### PR DESCRIPTION
@singingwolfboy (from git blame)

edx-platform, before this change, has to be run from a directory that is also a git repo!  That doesn't seem like a dependency we want, so this fixes things.

To test, try checking out master, the move your .git to .gitbak.  lms should crash.

Then, move .gitbak -> .git, checkout this branch, move .git -> .gitback, and lms should work.

Also, here's more proof in ipython that this works:

```
(mitx)Jasons-MacBook-Pro-4:edx-platform jbau$ cd ..
(mitx)Jasons-MacBook-Pro-4:mitx_all jbau$ ipython   <<<<---- NOT A GIT REPO
Python 2.7.5 (default, Aug 25 2013, 00:04:04) 
Type "copyright", "credits" or "license" for more information.

IPython 0.13.1 -- An enhanced Interactive Python.
?         -> Introduction and overview of IPython's features.
%quickref -> Quick reference.
help      -> Python's own help system.
object?   -> Details about 'object', use 'object??' for extra details.

In [1]: from dealer.git import git

In [2]: git.revision
No handlers could be found for logger "DEALER"
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-2-7f3bd7645466> in <module>()
----> 1 git.revision

/Users/jbau/.virtualenv/mitx/lib/python2.7/site-packages/dealer/base.pyc in revision(self)
     31     @property
     32     def revision(self):
---> 33         return self.repo and self._revision
     34 
     35     @abc.abstractmethod

/Users/jbau/.virtualenv/mitx/lib/python2.7/site-packages/dealer/base.pyc in repo(self)
     27     @property
     28     def repo(self):
---> 29         return self._repo or self.init_repo()
     30 
     31     @property

/Users/jbau/.virtualenv/mitx/lib/python2.7/site-packages/dealer/git.pyc in init_repo(self)
     75                 logger.error(e)
     76 
---> 77             raise TypeError(e)
     78 
     79 

TypeError: fatal: Not a git repository (or any of the parent directories): .git

In [3]: from dealer.auto import auto

In [4]: auto.revision
Out[4]: 'null'

```
