### PR TITLE
Jbau/fix/remove revision from middleware

### DIFF
--- a/common/djangoapps/mitxmako/middleware.py
+++ b/common/djangoapps/mitxmako/middleware.py
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from dealer.git import git
+from dealer.auto import auto
 from django.template import RequestContext
 requestcontext = None
 
@@ -24,4 +24,4 @@ class MakoMiddleware(object):
         requestcontext = RequestContext(request)
         requestcontext['is_secure'] = request.is_secure()
         requestcontext['site'] = request.get_host()
-        requestcontext['REVISION'] = git.revision
+        requestcontext['REVISION'] = auto.revision

--- a/common/djangoapps/mitxmako/middleware.py
+++ b/common/djangoapps/mitxmako/middleware.py
@@ -12,7 +12,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from dealer.auto import auto
 from django.template import RequestContext
 requestcontext = None
 
@@ -24,4 +23,3 @@ class MakoMiddleware(object):
         requestcontext = RequestContext(request)
         requestcontext['is_secure'] = request.is_secure()
         requestcontext['site'] = request.get_host()
-        requestcontext['REVISION'] = auto.revision


### PR DESCRIPTION
@singingwolfboy 

here is a version that actually just removes REVISION from middleware.

Done in 2 commits because Stanford already installed the first commit.

MERGE THIS OR #1638, BUT NOT BOTH.

@wedaly @e0d @jarv FYI.  Does this break anything used for devops or testeng?
