### PR TITLE
Studio: Resolves Notifications UI showing in IE9 + CSS Split

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -258,6 +258,12 @@ PIPELINE_CSS = {
         ],
         'output_filename': 'css/cms-style-app.css',
     },
+    'style-app-extend1': {
+        'source_filenames': [
+            'sass/style-app-extend1.css',
+        ],
+        'output_filename': 'css/cms-style-app-extend1.css',
+    },
     'style-xmodule': {
         'source_filenames': [
             'sass/style-xmodule.css',

--- a/cms/static/sass/contexts/_ie.scss
+++ b/cms/static/sass/contexts/_ie.scss
@@ -4,6 +4,13 @@
 // CASE: less than or equal to IE9
 .lte9 {
 
+  // CASE: IE9 doesn't support css animations and negative positioning
+  .wrapper-notification {
+
+    &.is-shown {
+      bottom: 0;
+    }
+  }
 }
 
 // ====================

--- a/cms/static/sass/style-app-extend1.scss
+++ b/cms/static/sass/style-app-extend1.scss
@@ -27,14 +27,28 @@
 @import 'elements/typography';
 @import 'elements/icons'; // references to icons used
 @import 'elements/controls'; // buttons, link styles, sliders, etc.
-@import 'elements/navigation'; // all archetypes of navigation
-@import 'elements/forms';
-@import 'elements/header';
-@import 'elements/footer';
-@import 'elements/sock';
-@import 'elements/tender-widget';
-@import 'elements/system-feedback'; // alerts, notifications, states
-@import 'elements/system-help'; // help UI
-@import 'elements/modal'; // interstitial UI, dialogs, modal windows
-@import 'elements/vendor'; // overrides to vendor-provided styling
-@import 'elements/uploads';
+
+// base - specific views
+@import 'views/account';
+@import 'views/assets';
+@import 'views/updates';
+@import 'views/dashboard';
+@import 'views/export';
+@import 'views/index';
+@import 'views/import';
+@import 'views/outline';
+@import 'views/settings';
+@import 'views/static-pages';
+@import 'views/subsection';
+@import 'views/unit';
+@import 'views/users';
+@import 'views/checklists';
+@import 'views/textbooks';
+
+// base - contexts
+@import 'contexts/ie'; // ie-specific rules (mostly for known/older bugs)
+
+// temp - inherited
+@import 'assets/content-types';
+
+@import 'shame'; // shame file - used for any bad-form/orphaned scss that knowingly violate edX FED architecture/standards (see - http://csswizardry.com/2013/04/shame-css/)

--- a/cms/templates/base.html
+++ b/cms/templates/base.html
@@ -24,6 +24,7 @@
 
     <%static:css group='style-vendor'/>
     <%static:css group='style-app'/>
+    <%static:css group='style-app-extend1'/>
     <%static:css group='style-xmodule'/>
 
     <%include file="widgets/segment-io.html" />


### PR DESCRIPTION
This Studio work does the following:
- provides a fallback to displaying "is-shown" notification UI elements for IE9. 
- splits our application-centric CSS (formally stye-app.scss/css) into two css files to resolve Studio's styling going over the IE 9 rule/selector CSS limits (http://blogs.msdn.com/b/ieinternals/archive/2011/05/14/10164546.aspx).

If you want to test the number of rules being used, crack open your console and run this gist in a view - https://gist.github.com/psebborn/1885511
