### PR TITLE
Added wait for JS before clicking nav menus

### DIFF
--- a/common/djangoapps/terrain/ui_helpers.py
+++ b/common/djangoapps/terrain/ui_helpers.py
@@ -546,18 +546,21 @@ def save_the_html(path='/tmp'):
 
 @world.absorb
 def click_course_content():
+    world.wait_for_js_to_load()
     course_content_css = 'li.nav-course-courseware'
     css_click(course_content_css)
 
 
 @world.absorb
 def click_course_settings():
+    world.wait_for_js_to_load()
     course_settings_css = 'li.nav-course-settings'
     css_click(course_settings_css)
 
 
 @world.absorb
 def click_tools():
+    world.wait_for_js_to_load()
     tools_css = 'li.nav-course-tools'
     css_click(tools_css)
 


### PR DESCRIPTION
Fix for this failure:

https://jenkins.testeng.edx.org/job/edx-all-tests-auto-master/366/SHARD=1,TEST_SUITE=cms-acceptance/

I'm not happy that this solution is so ad-hoc, but in the short term I want to make master stable without disabling tests.

@singingwolfboy 
