### PR TITLE
Three more A11Y fixes (medium priority ones).

### DIFF
--- a/lms/templates/forgot_password_modal.html
+++ b/lms/templates/forgot_password_modal.html
@@ -21,7 +21,7 @@
           <ol class="list-input">
             <li class="field required text" id="forgot-password-modal-field-email">
               <label for="pwd_reset_email">${_("Your E-mail Address")}</label>
-              <input class="" id="pwd_reset_email" type="email" name="email" value="" placeholder="example: username@domain.com" aria-describedby="pwd_reset_email-tip" />
+              <input class="" id="pwd_reset_email" type="email" name="email" value="" placeholder="example: username@domain.com" aria-describedby="pwd_reset_email-tip" aria-required="true" />
               <span class="tip tip-input" id="pwd_reset_email-tip">${_("This is the e-mail address you used to register with {platform}").format(platform=settings.PLATFORM_NAME)}</span>
             </li>
           </ol>

--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -16,10 +16,10 @@
 </%def>
 
 <!DOCTYPE html>
-<!--[if IE 7]><html class="ie ie7 lte9 lte8 lte7"><![endif]-->
-<!--[if IE 8]><html class="ie ie8 lte9 lte8"><![endif]-->
-<!--[if IE 9]><html class="ie ie9 lte9"><![endif]-->
-<!--[if gt IE 9]><!--><html><!--<![endif]-->
+<!--[if IE 7]><html class="ie ie7 lte9 lte8 lte7" lang="en-us"><![endif]-->
+<!--[if IE 8]><html class="ie ie8 lte9 lte8" lang="en-us"><![endif]-->
+<!--[if IE 9]><html class="ie ie9 lte9" lang="en-us"><![endif]-->
+<!--[if gt IE 9]><!--><html lang="en-us"><!--<![endif]-->
 <head>
   <%block name="title">
     % if stanford_theme_enabled():

--- a/lms/templates/video.html
+++ b/lms/templates/video.html
@@ -44,7 +44,7 @@
     <div class="focus_grabber first"></div>
 
     <div class="tc-wrapper">
-      <a href="#transcript-captions" class="sr">Skip to clickable transcript video links.</a>
+      <a href="#before-transcript" class="nav-skip">${_("Skip to a navigable version of this video's transcript.")}</a>
       
       <article class="video-wrapper">
           <div class="video-player-pre"></div>
@@ -85,25 +85,29 @@
                   </div>
               </div>
           </section>
+          <a class="nav-skip" id="before-transcript" href="#after-transcript">${_('Skip to end of transcript.')}</a>
       </article>
-
-      <ol id="transcript-captions" class="subtitles" tabindex="0" title="${_('Captions')}" role="group" aria-label="${_('Activating an item in this group will spool the video to the corresponding time point')}"><li></li></ol>
+      
+      <ol id="transcript-captions" class="subtitles" tabindex="0" title="${_('Captions')}" role="group" aria-label="${_('Activating an item in this group will spool the video to the corresponding time point. To skip transcript, go to previous item.')}">
+        <li></li>
+      </ol>
     </div>
-
+    
+    <a class="nav-skip" id="after-transcript" href="#before-transcript">${_('Go back to start of transcript.')}</a>
+    
     <div class="focus_grabber last"></div>
-<ul class="wrapper-downloads">
-% if sources.get('main'):
-    <li class="video-sources">
-        ${('<a href="%s">' + _('Download video') + '</a>') % sources.get('main')}
-    </li>
-% endif
-
-% if track:
-    <li class="video-tracks">
-        ${('<a href="%s">' + _('Download timed transcript') + '</a>') % track}
-    </li>
-% endif
-</ul>
+  <ul class="wrapper-downloads">
+    % if sources.get('main'):
+        <li class="video-sources">
+            ${('<a href="%s">' + _('Download video') + '</a>') % sources.get('main')}
+        </li>
+    % endif
+    % if track:
+        <li class="video-tracks">
+            ${('<a href="%s">' + _('Download timed transcript') + '</a>') % track}
+        </li>
+    % endif
+  </ul>
 </div>
 
 


### PR DESCRIPTION
- Make email field in forgot password modal aria-required = true.
- Added Transcript skip links to both before and after the transcript.
- Add language code to main.html so that screenreaders know what language/region to speak for.

@adampalay, here are the last of this round of A11Y fixes. (also, who else should review this? @talbs?)
