### PR TITLE
Disabled LaTeX acceptance test

### DIFF
--- a/cms/djangoapps/contentstore/features/problem-editor.feature
+++ b/cms/djangoapps/contentstore/features/problem-editor.feature
@@ -81,14 +81,19 @@ Feature: CMS.Problem Editor
     When I edit and select Settings
     Then Edit High Level Source is visible
 
+  # Disabled 11/13/2013 after failing in master
+  # The screenshot showed that the LaTeX editor had the text "hi",
+  # but Selenium timed out waiting for the text to appear.
+  # It also caused later tests to fail with "UnexpectedAlertPresent"
+  #
   # This feature will work in Firefox only when Firefox is the active window
   # IE will not interact with the high level source in sauce labs
-  @skip_internetexplorer
-  Scenario: High Level source is persisted for LaTeX problem (bug STUD-280)
-    Given I have created a LaTeX Problem
-    When I edit and compile the High Level Source
-    Then my change to the High Level Source is persisted
-    And when I view the High Level Source I see my changes
+  #@skip_internetexplorer
+  #Scenario: High Level source is persisted for LaTeX problem (bug STUD-280)
+  #  Given I have created a LaTeX Problem
+  #  When I edit and compile the High Level Source
+  #  Then my change to the High Level Source is persisted
+  #  And when I view the High Level Source I see my changes
 
     # Disabled 10/28/13 due to flakiness observed in master
     #  Scenario: Exceptions don't cause problem to be uneditable (bug STUD-786)


### PR DESCRIPTION
This test failed yesterday morning, then caused a bunch of other tests to fail with "UnexpectedAlertPresent".  I couldn't see anything obviously wrong with the test, and the screenshot shows that the editor was working correctly.

@cahrens please review.  When I merge this, I'll create an issue in the Studio backlog to fix this test.
