### PR TITLE
Added explicit wait for payment page to load

### DIFF
--- a/lms/djangoapps/courseware/features/certificates.py
+++ b/lms/djangoapps/courseware/features/certificates.py
@@ -186,7 +186,7 @@ def confirm_details_match(step):
 
 @step(u'I am at the payment page')
 def at_the_payment_page(step):
-    assert world.css_find('input[name=transactionSignature]')
+    world.wait_for_present('input[name=transactionSignature]') 
 
 
 @step(u'I submit valid payment information$')


### PR DESCRIPTION
Fix for this failure observed in master: https://jenkins.testeng.edx.org/job/edx-all-tests-auto-master/376/SHARD=2,TEST_SUITE=lms-acceptance/

The screenshot verifies that the page loaded correctly; the assertion just executed too soon.
The fix adds an explicit wait (with a timeout) for the element to appear.

@dianakhuang 
