### PR TITLE
hidden-module-unicode: Return unicode string to pass assertion

### DIFF
--- a/common/lib/xmodule/xmodule/hidden_module.py
+++ b/common/lib/xmodule/xmodule/hidden_module.py
@@ -5,9 +5,9 @@ from xmodule.raw_module import RawDescriptor
 class HiddenModule(XModule):
     def get_html(self):
         if self.system.user_is_staff:
-            return "ERROR: This module is unknown--students will not see it at all"
+            return u"ERROR: This module is unknown--students will not see it at all"
         else:
-            return ""
+            return u""
 
 
 class HiddenDescriptor(RawDescriptor):


### PR DESCRIPTION
XBlock Fragments expect unicode strings, and fail on an assertion when it isn't:

```
2013-11-14 07:55:50,774 ERROR 3788 [django.request] base.py:215 - Internal Server Error: /courses/TestU/TST101/now/courseware/41d55c576a574fde99319420228f7f88/5fef5794e34842f4a2d45ebcdeaa9a3a/
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 111, in get_response
    response = callback(request, *callback_args, **callback_kwargs)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/contrib/auth/decorators.py", line 20, in _wrapped_view
    return view_func(request, *args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/utils/decorators.py", line 91, in _wrapped_view
    response = view_func(request, *args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/views/decorators/cache.py", line 75, in _cache_controlled
    response = viewfunc(request, *args, **kw)
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/views.py", line 407, in index
    context['fragment'] = section_module.render('student_view')
  File "/edx/app/edxapp/venvs/edxapp/src/xblock/xblock/core.py", line 156, in render
    return self.runtime.render(self, view, context)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 903, in render
    return block.xmodule_runtime.render(to_render, view_name, context)
  File "/edx/app/edxapp/venvs/edxapp/src/xblock/xblock/runtime.py", line 356, in render
    frag = view_fn(context)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/seq_module.py", line 77, in student_view
    rendered_child = child.render('student_view', context)
  File "/edx/app/edxapp/venvs/edxapp/src/xblock/xblock/core.py", line 156, in render
    return self.runtime.render(self, view, context)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 903, in render
    return block.xmodule_runtime.render(to_render, view_name, context)
  File "/edx/app/edxapp/venvs/edxapp/src/xblock/xblock/runtime.py", line 356, in render
    frag = view_fn(context)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/vertical_module.py", line 27, in student_view
    rendered_child = child.render('student_view', context)
  File "/edx/app/edxapp/venvs/edxapp/src/xblock/xblock/core.py", line 156, in render
    return self.runtime.render(self, view, context)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 903, in render
    return block.xmodule_runtime.render(to_render, view_name, context)
  File "/edx/app/edxapp/venvs/edxapp/src/xblock/xblock/runtime.py", line 356, in render
    frag = view_fn(context)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 464, in student_view
    return Fragment(self.get_html())
  File "/edx/app/edxapp/venvs/edxapp/src/xblock/xblock/fragment.py", line 34, in __init__
    self.add_content(content)
  File "/edx/app/edxapp/venvs/edxapp/src/xblock/xblock/fragment.py", line 71, in add_content
    assert isinstance(content, unicode)
AssertionError
```
