### PR TITLE
fix emission of enrollment events from the CMS

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -157,6 +157,7 @@ MIDDLEWARE_CLASSES = (
     'cache_toolbox.middleware.CacheBackedAuthenticationMiddleware',
     'student.middleware.UserStandingMiddleware',
     'contentserver.middleware.StaticContentServer',
+    'crum.CurrentRequestUserMiddleware',
 
     'django.contrib.messages.middleware.MessageMiddleware',
     'track.middleware.TrackMiddleware',


### PR DESCRIPTION
I suspect there are very few circumstances that an enrollment event is emitted from the CMS, but if it ever were to happen, it would bomb out because the "crum" middleware is not used in that app.  We are hoping to replace this request caching hack in the near future, but for now it is the best option we could come up with.

I noticed the stack appear when I created a new course in my dev environment.  Presumably the course author is automatically enrolled in the course, which, causes the tracking code to bomb out.  Luckily we catch the error and just log it, but we really should be capturing this type of enrollment event.

Reviewers: @rocha, @cahrens
