### PR TITLE
prevent failure when module does not have a data field

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_item.py
+++ b/cms/djangoapps/contentstore/tests/test_item.py
@@ -65,6 +65,20 @@ class ItemTest(CourseTestCase):
         return self.client.ajax_post('/xblock', json.dumps(data))
 
 
+class GetItem(ItemTest):
+    """Tests for '/xblock' GET url."""
+
+    def test_get_vertical(self):
+        # Add a vertical
+        resp = self.create_xblock(category='vertical')
+        self.assertEqual(resp.status_code, 200)
+
+        # Retrieve it
+        resp_content = json.loads(resp.content)
+        resp = self.client.get('/xblock/' + resp_content['locator'])
+        self.assertEqual(resp.status_code, 200)
+
+
 class DeleteItem(ItemTest):
     """Tests for '/xblock' DELETE url."""
     def test_delete_static_page(self):

--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -365,12 +365,12 @@ def _get_module_info(usage_loc, rewrite_static_links=True):
         else:
             raise
 
-    data = module.data
+    data = getattr(module, 'data', '')
     if rewrite_static_links:
         # we pass a partially bogus course_id as we don't have the RUN information passed yet
         # through the CMS. Also the contentstore is also not RUN-aware at this point in time.
         data = replace_static_urls(
-            module.data,
+            data,
             None,
             course_id=module.location.org + '/' + module.location.course + '/BOGUS_RUN_REPLACE_WHEN_AVAILABLE'
         )


### PR DESCRIPTION
This raised an AttributeError when I tried to retrieve a vertical or a course using the REST API.

Reviewers: @dmitchell, @singingwolfboy
