### PR TITLE
Add template for checkboxes to studio.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ These are notable changes in edx-platform.  This is a rolling list of changes,
 in roughly chronological order, most recent first.  Add your entries at or near
 the top.  Include a label indicating the component affected.
 
+Blades: Add template for checkboxes response to studio. BLD-193.
+
 Blades: Video player:
   - Add spinner;
   - Improve initialization of modules;
@@ -20,7 +22,7 @@ text like with bold or italics. (BLD-449)
 LMS: Beta instructor dashboard will only count actively enrolled students for
 course enrollment numbers.
 
-Blades: Blades: Fix speed menu that is not rendered correctly when YouTube is unavailable. (BLD-457).
+Blades: Fix speed menu that is not rendered correctly when YouTube is unavailable. (BLD-457).
 
 LMS: Users with is_staff=True no longer have the STAFF label appear on
 their forum posts.

--- a/cms/djangoapps/contentstore/features/component.feature
+++ b/cms/djangoapps/contentstore/features/component.feature
@@ -39,6 +39,7 @@ Feature: CMS.Component Adding
        When I add this type of Problem component:
            | Component            |
            | Blank Common Problem |
+           | Checkboxes           |
            | Dropdown             |
            | Multiple Choice      |
            | Numerical Input      |
@@ -46,6 +47,7 @@ Feature: CMS.Component Adding
        Then I see Problem components in this order:
            | Component            |
            | Blank Common Problem |
+           | Checkboxes           |
            | Dropdown             |
            | Multiple Choice      |
            | Numerical Input      |

--- a/common/lib/xmodule/xmodule/templates/problem/checkboxes_response.yaml
+++ b/common/lib/xmodule/xmodule/templates/problem/checkboxes_response.yaml
@@ -1,0 +1,23 @@
+---
+metadata:
+    display_name: Checkboxes
+    markdown: |
+      A checkboxes problem presents checkbox buttons for student input. Students can select more
+      than one option presented.
+
+      [x] correct
+      [ ] incorrect
+      [x] correct
+
+data: |
+      <problem>
+        <p>A checkboxes problem presents checkbox buttons for student input. Students can select more than one option presented.</p>
+        <choiceresponse>
+          <checkboxgroup direction="vertical">
+            <choice correct="true">correct</choice>
+            <choice correct="false">incorrect</choice>
+            <choice correct="true">correct</choice>
+          </checkboxgroup>
+        </choiceresponse>
+      </problem>
+


### PR DESCRIPTION
This adds template for the checkboxes response to studio.
It is available now by following path: _Problem_ -> _Checkboxes_ .

@auraz, @Lyla-Fischer  please review.
