### PR TITLE
Test HTML returned from view methods for "i4X".

### DIFF
--- a/cms/static/js/models/course_info.js
+++ b/cms/static/js/models/course_info.js
@@ -5,12 +5,9 @@ define(["backbone"], function(Backbone) {
         url: '',
 
         defaults: {
-            "courseId": "", // the location url
             "updates" : null,   // UpdateCollection
             "handouts": null    // HandoutCollection
-            },
-
-        idAttribute : "courseId"
+            }
     });
     return CourseInfo;
 });

--- a/cms/templates/asset_index.html
+++ b/cms/templates/asset_index.html
@@ -187,7 +187,7 @@ require(["domReady", "jquery", "gettext", "js/models/asset", "js/collections/ass
     <a href="#" class="close-button"><i class="icon-remove-sign"></i> <span class="sr">${_('close')}</span></a>
     <div class="modal-body">
         <h1 class="title">${_("Upload New File")}</h1>
-        <p class="file-name"></a>
+        <p class="file-name">
         <div class="progress-bar">
             <div class="progress-fill"></div>
         </div>

--- a/cms/templates/course_info.html
+++ b/cms/templates/course_info.html
@@ -33,7 +33,6 @@ require(["domReady!", "jquery", "js/collections/course_update", "js/models/modul
     var editor = new CourseInfoEditView({
       el: $('.main-wrapper'),
       model : new CourseInfoModel({
-        courseId : '${context_course.location}',
         updates : course_updates,
         base_asset_url : '${base_asset_url}',
         handouts : course_handouts

--- a/cms/templates/settings.html
+++ b/cms/templates/settings.html
@@ -87,7 +87,7 @@ require(["domReady!", "jquery", "js/models/settings/course_details", "js/views/s
           <div class="note note-promotion note-promotion-courseURL has-actions">
             <h3 class="title">${_("Course Summary Page")} <span class="tip">${_("(for student enrollment and access)")}</span></h3>
             <div class="copy">
-              <p><a class="link-courseURL" rel="external" href="https:${utils.get_lms_link_for_about_page(course_location)}" />https:${utils.get_lms_link_for_about_page(course_location)}</a></p>
+              <p><a class="link-courseURL" rel="external" href="https:${utils.get_lms_link_for_about_page(course_location)}" >https:${utils.get_lms_link_for_about_page(course_location)}</a></p>
             </div>
 
             <ul class="list-actions">

--- a/cms/templates/widgets/segment-io.html
+++ b/cms/templates/widgets/segment-io.html
@@ -1,9 +1,20 @@
+<%!
+from xmodule.modulestore.django import loc_mapper
+%>
+
+% if context_course:
+<%
+    ctx_loc = context_course.location
+    locator = loc_mapper().translate_location(ctx_loc.course_id, ctx_loc, False, True)
+%>
+% endif
+
 % if settings.MITX_FEATURES.get('SEGMENT_IO'):
 <!-- begin Segment.io -->
 <script type="text/javascript">
   // if inside course, inject the course location into the JS namespace
   %if context_course:
-  var course_location_analytics = "${context_course.location}";
+      var course_location_analytics = "${locator}";
   %endif
 
   var analytics=analytics||[];analytics.load=function(e){var t=document.createElement("script");t.type="text/javascript",t.async=!0,t.src=("https:"===document.location.protocol?"https://":"http://")+"d2dq2ahtl5zl1z.cloudfront.net/analytics.js/v1/"+e+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n);var r=function(e){return function(){analytics.push([e].concat(Array.prototype.slice.call(arguments,0)))}},i=["identify","track","trackLink","trackForm","trackClick","trackSubmit","pageview","ab","alias","ready"];for(var s=0;s<i.length;s++)analytics[i[s]]=r(i[s])};
@@ -22,7 +33,7 @@
 <!-- dummy segment.io -->
 <script type="text/javascript">
   %if context_course:
-  var course_location_analytics = "${context_course.location}";
+  var course_location_analytics = "${locator}";
   %endif
   var analytics = {
     "track": function() {}


### PR DESCRIPTION
Note that I still have to allow "View Live" links which have a jump_to to the old course ID (on port 8000).

@dmitchell Here's another quick one to review. Let me know if you think there is a better way to search for old locations (besides just looking for "i4X").
