### PR TITLE
Adding a YAML file to demonstrate how to include anonymized user IDs in Studio elements.

### DIFF
--- a/common/lib/xmodule/xmodule/templates/html/anon_user_id.yaml
+++ b/common/lib/xmodule/xmodule/templates/html/anon_user_id.yaml
@@ -1,0 +1,19 @@
+---
+metadata:
+    display_name: Anonymous User ID
+data: |
+      <p>Your explanatory text here.</p>
+      <p><a href="https://YOUR_UNIVERSITY.qualtrics.com/SE/?SID=SV_###############&a=%%USER_ID%%" target="_blank">YOUR_LINK_TEXT</a></p>
+      
+      <!-- You can include %%USER_ID%% to include an anonymized user ID in your outside services so that you can relate them later.
+        
+        This example is a Qualtrics template:
+          - Replace the "###############" with your Survey ID.
+          - Also replace "YOUR_UNIVERSITY" with your qualtrics ID.
+          - Finally, replace "YOUR_LINK_TEXT" with your link text.
+          - If you wish to embed your survey into the courseware instead of opening a new tab, replace the above HTML with what is provided below.
+            
+            <p>Your explanatory text here.</p>
+            <iframe src="https://YOUR_UNIVERSITY.qualtrics.com/SE/?SID=SV_###############&a=%%USER_ID%%" height="1000" width="800" />
+        
+      -->


### PR DESCRIPTION
@singingwolfboy, @cahrens, & @dmitchell - here's a more generalized version of the Studio YML PR. Sorry for the earlier confusion.

In short this PR is to show that Anonymized User IDs can be included for use with outside services, like Qualtrics to   relate users.

Here are the previous PRs for reference:
- The original PR that shows the intent of this feature: #1684 
- The previous too-specific master PR: #1689 
