### PR TITLE
Change dummy locale to Esperanto

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ cms/envs/private.py
 *.mo
 conf/locale/en/LC_MESSAGES/*.po
 !messages.po
+### Remove when we have real Esperanto translations. For now, ignore
+### dummy Esperanto files.
+conf/locale/eo/*
 
 ### Testing artifacts
 .testids/

--- a/cms/djangoapps/contentstore/tests/test_i18n.py
+++ b/cms/djangoapps/contentstore/tests/test_i18n.py
@@ -73,8 +73,8 @@ class InternationalizationTest(ModuleStoreTestCase):
     # ****
     #
     # This test will break when we replace this fake 'test' language
-    # with actual French. This test will need to be updated with
-    # actual French at that time.
+    # with actual Esperanto. This test will need to be updated with
+    # actual Esperanto at that time.
     # Test temporarily disable since it depends on creation of dummy strings
     @skip
     def test_course_with_accents(self):
@@ -82,10 +82,11 @@ class InternationalizationTest(ModuleStoreTestCase):
         self.client = AjaxEnabledTestClient()
         self.client.login(username=self.uname, password=self.password)
 
-        resp = self.client.get_html('/course',
-                               {},
-                               HTTP_ACCEPT_LANGUAGE='fr'
-                               )
+        resp = self.client.get_html(
+            '/course',
+            {},
+            HTTP_ACCEPT_LANGUAGE='eo'
+        )
 
         TEST_STRING = (
             u'<h1 class="title-1">'

--- a/cms/envs/dev.py
+++ b/cms/envs/dev.py
@@ -12,7 +12,7 @@ DEBUG = True
 USE_I18N = True
 # For displaying the dummy text, we need to provide a language mapping.
 LANGUAGES = (
-    ('fr', 'Francais'),
+    ('eo', 'Esperanto'),
 )
 TEMPLATE_DEBUG = DEBUG
 LOGGING = get_logger_config(ENV_ROOT / "log",

--- a/conf/locale/config
+++ b/conf/locale/config
@@ -1,4 +1,4 @@
 {
  "locales" : ["en"],
- "dummy-locale" : "fr"
+ "dummy-locale" : "eo"
 }

--- a/i18n/config.py
+++ b/i18n/config.py
@@ -49,7 +49,7 @@ class Configuration:
     @property
     def dummy_locale(self):
         """
-        Returns a locale to use for the dummy text, e.g. 'fr'.
+        Returns a locale to use for the dummy text, e.g. 'eo'.
         Throws exception if no dummy-locale is declared. 
         The locale is a string.
         """

--- a/i18n/make_dummy.py
+++ b/i18n/make_dummy.py
@@ -7,7 +7,8 @@
 # see http://www.loc.gov/standards/iso639-2/php/code_list.php
 #
 # Django will not localize in languages that django itself has not been
-# localized for. So we are using a well-known language (default='fr').
+# localized for. So we are using a well-known language (default='eo').
+# Django languages are listed in django.conf.global_settings.LANGUAGES
 #
 # po files can be generated with this:
 # django-admin.py makemessages --all --extension html -l en
@@ -19,7 +20,7 @@
 # $ ./make_dummy.py ../conf/locale/en/LC_MESSAGES/django.po
 #
 # generates output to
-#    mitx/conf/locale/fr/LC_MESSAGES/django.po
+#    mitx/conf/locale/eo/LC_MESSAGES/django.po
 
 import os, sys
 import polib

--- a/i18n/tests/test_config.py
+++ b/i18n/tests/test_config.py
@@ -29,5 +29,5 @@ class TestConfiguration(TestCase):
         self.assertIsNotNone(locales)
         self.assertIsInstance(locales, list)
         self.assertIn('en', locales)
-        self.assertEqual('fr', CONFIGURATION.dummy_locale)
+        self.assertEqual('eo', CONFIGURATION.dummy_locale)
         self.assertEqual('en', CONFIGURATION.source_locale)

--- a/lms/envs/dev.py
+++ b/lms/envs/dev.py
@@ -19,7 +19,7 @@ DEBUG = True
 USE_I18N = True
 # For displaying the dummy text, we need to provide a language mapping.
 LANGUAGES = (
-    ('fr', 'Francais'),
+    ('eo', 'Esperanto'),
 )
 TEMPLATE_DEBUG = True
 

--- a/rakelib/i18n.rake
+++ b/rakelib/i18n.rake
@@ -18,7 +18,7 @@ namespace :i18n do
   desc "Simulate international translation by generating dummy strings corresponding to source strings."
   task :dummy do
     source_files = Dir["#{REPO_ROOT}/conf/locale/en/LC_MESSAGES/*.po"]
-    dummy_locale = 'fr'
+    dummy_locale = 'eo'
     cmd = File.join(REPO_ROOT, "i18n", "make_dummy.py")
     for file in source_files do
       sh("#{cmd} #{file} #{dummy_locale}")


### PR DESCRIPTION
It seems dangerous to use French. Our only restriction in changing the dummy locale is that it must be a locale listed in `django.conf.global_settings.LANGUAGES`. Thus, Esperanto.

@nedbat @wedaly 

Once this change goes in I'll update the wiki pages on i18n appropriately.
