### PR TITLE
The forcing of IDs to non-draft must happen in base.py instead of draft....

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -778,7 +778,11 @@ class MongoModuleStore(ModuleStoreWriteBase):
         children: A list of child item identifiers
         """
 
-        self._update_single_item(location, {'definition.children': children})
+        # We expect the children IDs to always be the non-draft version. With view refactoring
+        # for split, we are now passing the draft version in some cases.
+        children_ids = [Location(child).replace(revision=None).url() for child in children]
+
+        self._update_single_item(location, {'definition.children': children_ids})
         # recompute (and update) the metadata inheritance tree which is cached
         self.refresh_cached_metadata_inheritance_tree(Location(location))
         # fire signal that we've written to DB

--- a/common/lib/xmodule/xmodule/modulestore/mongo/draft.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/draft.py
@@ -184,17 +184,12 @@ class DraftModuleStore(MongoModuleStore):
         location: Something that can be passed to Location
         children: A list of child item identifiers
         """
-
-        # We expect the children IDs to always be the non-draft version. With view refactoring
-        # for split, we are now passing the draft version in some cases.
-        children_ids = [as_published(child).url() for child in children]
-
         draft_loc = as_draft(location)
         draft_item = self.get_item(location)
         if not getattr(draft_item, 'is_draft', False):
             self.convert_to_draft(as_published(location))
 
-        return super(DraftModuleStore, self).update_children(draft_loc, children_ids)
+        return super(DraftModuleStore, self).update_children(draft_loc, children)
 
     def update_metadata(self, location, metadata):
         """

--- a/lms/djangoapps/courseware/tests/__init__.py
+++ b/lms/djangoapps/courseware/tests/__init__.py
@@ -46,7 +46,7 @@ class BaseTestXmodule(ModuleStoreTestCase):
     COURSE_DATA = {}
 
     # Data from YAML common/lib/xmodule/xmodule/templates/NAME/default.yaml
-    CATEGORY = ""
+    CATEGORY = "vertical"
     DATA = ''
     MODEL_DATA = {'data': '<some_module></some_module>'}
 


### PR DESCRIPTION
...py.

The draft.py solution only worked when the parent was also in the draft store.

@dmitchell Please review.
