### PR TITLE
changes to allow multiple choicetextresponses in one problem

### DIFF
--- a/common/lib/capa/capa/templates/choicetext.html
+++ b/common/lib/capa/capa/templates/choicetext.html
@@ -55,7 +55,7 @@
                 % else:
                     <% my_id = content_node.get('contents','') %>
                     <% my_val = value.get(my_id,'') %>
-                    <input class="ctinput" type="text" name="${content_node['contents']}" id="${content_node['contents']}" value="${my_val|h} "/>
+                    <input class="ctinput" type="text" name="${content_node['contents']}" id="${content_node['contents']}" value="${my_val|h}"/>
                 %endif
                 <span class="mock_label">
                     ${content_node['tail_text']}

--- a/common/static/js/capa/choicetextinput.js
+++ b/common/static/js/capa/choicetextinput.js
@@ -1,13 +1,13 @@
 (function () {
     var update = function () {
         // Whenever a value changes create a new serialized version of this
-        // problem's inputs and set the hidden input fields value to equal it.
-        var parent = $(this).closest('.problems-wrapper');
+        // problem's inputs and set the hidden input field's value to equal it.
+        var parent = $(this).closest('section.choicetextinput');
         // find the closest parent problems-wrapper and use that as the problem
         // grab the input id from the input
         // real_input is the hidden input field
         var real_input = $('input.choicetextvalue', parent);
-        var all_inputs = $('.choicetextinput .ctinput', parent);
+        var all_inputs = $('input.ctinput', parent);
         var user_inputs = {};
         $(all_inputs).each(function (index, elt) {
             var node = $(elt);


### PR DESCRIPTION
This fixes a bug which prevented multiple `choicetextresponse` inside of a single problem. Previously the values that were sent to be checked contained a serialized version of all of the inputs inside of a problem, so having two separate input groups would cause extra incorrect values and make it impossible to get the problem correct. This changes so that the submitted value for an input group will only contain a serialized version of the inputs inside of its section.

Also removed an erroneous space from the template.
