### PR TITLE
Static CSS and Developer Stack Remnants to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,14 +48,18 @@ reports/
 .prereqs_cache
 .vagrant/
 node_modules
+.bundle/
+bin/
 
 ### Static assets pipeline artifacts
 *.scssc
+lms/static/css/
 lms/static/sass/*.css
 lms/static/sass/application.scss
 lms/static/sass/application-extend1.scss
 lms/static/sass/application-extend2.scss
 lms/static/sass/course.scss
+cms/static/css/
 cms/static/sass/*.css
 
 ### Logging artifacts


### PR DESCRIPTION
This work revises .gitignore file to include:
- static css directories (in the case of us ever wanting to output Sass compilations there)
- remnants of edX Developer Stack setup (see https://github.com/edx/configuration/wiki/edX-Developer-Stack)
