### PR TITLE
Added resource_link_id to lti xmodule as it is a required parrameter in ...

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -97,3 +97,4 @@ Iain Dunning <idunning@mit.edu>
 Olivier Marquez <oliviermarquez@gmail.com>
 Florian Dufour <neurolit@gmail.com>
 Manuel Freire <manuel.freire@fdi.ucm.es>
+John Zornig <j.zornig@uq.edu.au>

--- a/common/lib/xmodule/xmodule/lti_module.py
+++ b/common/lib/xmodule/xmodule/lti_module.py
@@ -257,6 +257,7 @@ class LTIModule(LTIFields, XModule):
             u'launch_presentation_return_url': '',
             u'lti_message_type': u'basic-lti-launch-request',
             u'lti_version': 'LTI-1p0',
+            u'resource_link_id': self.location.html_id(),
             u'role': u'student'
         }
 


### PR DESCRIPTION
...LTI launches.

This is a required parameter and many tools will not launch without it.
