### PR TITLE
Fix 500 error in transcripts.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ These are notable changes in edx-platform.  This is a rolling list of changes,
 in roughly chronological order, most recent first.  Add your entries at or near
 the top.  Include a label indicating the component affected.
 
+Blades: Fix transcripts 500 error in studio (BLD-530)
+
 Blades: Allow multiple strings as the correct answer to a string response question. BLD-474.
 
 Blades: a11y - Videos will alert screenreaders when the video is over.

--- a/cms/djangoapps/contentstore/features/transcripts.feature
+++ b/cms/djangoapps/contentstore/features/transcripts.feature
@@ -641,6 +641,7 @@ Feature: Video Component Editor
 
         And I save changes
         Then when I view the video it does show the captions
+        And I see "好 各位同学" text in the captions
         And I edit the component
 
         And I open tab "Advanced"

--- a/cms/djangoapps/contentstore/features/transcripts.py
+++ b/cms/djangoapps/contentstore/features/transcripts.py
@@ -116,6 +116,7 @@ def i_see_status_message(_step, status):
     world.wait(DELAY)
     world.wait_for_ajax_complete()
 
+    assert not world.css_visible(SELECTORS['error_bar'])
     assert world.css_has_text(SELECTORS['status_bar'], STATUSES[status.strip()])
 
 

--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -249,9 +249,12 @@ def edit_unit(request, location):
         )
 
     components = [
-        loc_mapper().translate_location(
-            course.location.course_id, component.location, False, True
-        )
+        [
+            component.location.url(),
+            loc_mapper().translate_location(
+                course.location.course_id, component.location, False, True
+            )
+        ]
         for component
         in item.get_children()
     ]

--- a/cms/templates/unit.html
+++ b/cms/templates/unit.html
@@ -48,8 +48,8 @@ require(["domReady!", "jquery", "js/models/module_info", "coffee/src/views/unit"
         <article class="unit-body window">
         <p class="unit-name-input"><label>${_("Display Name:")}</label><input type="text" value="${unit.display_name_with_default | h}" class="unit-display-name-input" /></p>
           <ol class="components">
-            % for locator in components:
-            <li class="component" data-locator="${locator}"/>
+            % for id, locator in components:
+            <li class="component" data-locator="${locator}" data-id="${id}" />
             % endfor
             <li class="new-component-item adding">
               <div class="new-component">


### PR DESCRIPTION
When ID was removed from unit html (in https://github.com/edx/edx-platform/pull/1680) , transcripts were left broken, as they use id (location) and get_item(item_location) to obtain transcripts files.

This is CAT-1 blades bug: https://edx-wiki.atlassian.net/browse/BLD-530 (Can't import or add transcripts for video)

In longer term - @cahrens what should be changed in transcripts files to support (https://github.com/edx/edx-platform/pull/1680) change?

@polesye can we add tests for this case?

@lyla FYI
