### PR TITLE
Add error recovery to inline discussion loading

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,9 @@ Blades: Update the calculator hints tooltip with full information. BLD-400.
 
 Blades: Fix transcripts 500 error in studio (BLD-530)
 
+LMS: Add error recovery when a user loads or switches pages in an
+inline discussion.
+
 Blades: Allow multiple strings as the correct answer to a string response question. BLD-474.
 
 Blades: a11y - Videos will alert screenreaders when the video is over.


### PR DESCRIPTION
Now the interface will reset apropriately and allow a user to retry
expanding the discussion or loading a new page, and the alert message
will ask the user to retry.

JIRA: FOR-300, FOR-301

@jimabramson @marcotuts 
