### PR TITLE
Static URL double-slash

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -90,7 +90,10 @@ with open(CONFIG_ROOT / CONFIG_PREFIX + "env.json") as env_file:
 STATIC_URL_BASE = ENV_TOKENS.get('STATIC_URL_BASE', None)
 if STATIC_URL_BASE:
     # collectstatic will fail if STATIC_URL is a unicode string
-    STATIC_URL = STATIC_URL_BASE.encode('ascii') + "/" + git.revision + "/"
+    STATIC_URL = STATIC_URL_BASE.encode('ascii')
+    if not STATIC_URL.endswith("/"):
+        STATIC_URL += "/"
+    STATIC_URL += git.revision + "/"
 
 # GITHUB_REPO_ROOT is the base directory
 # for course data

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -124,7 +124,9 @@ if STATIC_ROOT_BASE:
 STATIC_URL_BASE = ENV_TOKENS.get('STATIC_URL_BASE', None)
 if STATIC_URL_BASE:
     # collectstatic will fail if STATIC_URL is a unicode string
-    STATIC_URL = STATIC_URL_BASE.encode('ascii') + "/"
+    STATIC_URL = STATIC_URL_BASE.encode('ascii')
+    if not STATIC_URL.endswith("/"):
+        STATIC_URL += "/"
 
 PLATFORM_NAME = ENV_TOKENS.get('PLATFORM_NAME', PLATFORM_NAME)
 # For displaying on the receipt. At Stanford PLATFORM_NAME != MERCHANT_NAME, but PLATFORM_NAME is a fine default

--- a/lms/templates/footer.html
+++ b/lms/templates/footer.html
@@ -48,27 +48,27 @@
         <ul>
           <li class="nav-social-01">
             <a href="http://www.meetup.com/edX-Global-Community/" rel="external">
-              <img src="${EDX_ROOT_URL}/static/images/social/ico-social-meetup.png" alt="edX on Meetup" />
+              <img src="${static.url('images/social/ico-social-meetup.png')}" alt="edX on Meetup" />
             </a>
           </li>
           <li class="nav-social-02">
             <a href="http://www.facebook.com/EdxOnline" rel="external">
-              <img src="${EDX_ROOT_URL}/static/images/social/ico-social-facebook.png" alt="edX on Facebook" />
+              <img src="${static.url('images/social/ico-social-facebook.png')}" alt="edX on Facebook" />
             </a>
           </li>
           <li class="nav-social-03">
             <a href="https://twitter.com/edXOnline" rel="external">
-              <img src="${EDX_ROOT_URL}/static/images/social/ico-social-twitter.png" alt="edX on Twitter" />
+              <img src="${static.url('images/social/ico-social-twitter.png')}" alt="edX on Twitter" />
             </a>
           </li>
           <li class="nav-social-04">
             <a href="https://plus.google.com/108235383044095082735/posts" rel="external">
-              <img src="${EDX_ROOT_URL}/static/images/social/ico-social-google.png" alt="edX on Google+" />
+              <img src="${static.url('images/social/ico-social-google.png')}" alt="edX on Google+" />
             </a>
           </li>
           <li class="nav-social-05">
             <a href="http://youtube.com/user/edxonline" rel="external">
-              <img src="${EDX_ROOT_URL}/static/images/social/ico-social-youtube.png" alt="edX on YouTube" />
+              <img src="${static.url('images/social/ico-social-youtube.png')}" alt="edX on YouTube" />
             </a>
           </li>
         </ul>


### PR DESCRIPTION
While using vagrant-devstack, I noticed that certain URLs that were hard-coded to use "/static/" weren't loading.  This included links in the LMS footer template as well as links in the courseware (e.g. the Demo course about page)

It turns out that the aws.py settings were setting `STATIC_URL = "/static//"` with two trailing slashes.  In production, these links will resolve correctly because they are served by nginx.  When using django staticfiles, however, any URL that uses `/static/` (with only one trailing slash) will result in a 404.

This PR addresses the issue in two ways:
1) Append the trailing slash to `STATIC_URL_BASE` only if it doesn't already end in a slash.
2) Stop hardcoding static URLs in the LMS footer.  As far as I know, this page shows up only in the sandbox.
