### PR TITLE
Unauthenticated handlers

### DIFF
--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -371,7 +371,6 @@ class XModule(XModuleMixin, HTMLSnippet, XBlock):  # pylint: disable=abstract-me
         See the HTML module for a simple example.
     """
 
-
     has_score = descriptor_attr('has_score')
     _field_data_cache = descriptor_attr('_field_data_cache')
     _field_data = descriptor_attr('_field_data')
@@ -402,6 +401,7 @@ class XModule(XModuleMixin, HTMLSnippet, XBlock):  # pylint: disable=abstract-me
             data is a dictionary-like object with the content of the request"""
         return u""
 
+    @XBlock.handler
     def xmodule_handler(self, request, suffix=None):
         """
         XBlock handler that wraps `handle_ajax`

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -185,9 +185,11 @@ class TestHandleXBlockCallback(ModuleStoreTestCase, LoginEnrollmentTestCase):
         return mock_file
 
     def test_invalid_location(self):
+        request = self.request_factory.post('dummy_url', data={'position': 1})
+        request.user = self.mock_user
         with self.assertRaises(Http404):
             render.handle_xblock_callback(
-                None,
+                request,
                 'dummy/course/id',
                 'invalid Location',
                 'dummy_handler'

--- a/lms/lib/xblock/runtime.py
+++ b/lms/lib/xblock/runtime.py
@@ -60,9 +60,29 @@ def unquote_slashes(text):
 
 def handler_url(course_id, block, handler, suffix='', query=''):
     """
-    Return an xblock handler url for the specified course, block and handler
+    Return an XBlock handler url for the specified course, block and handler.
+
+    If handler is an empty string, this function is being used to create a
+    prefix of the general URL, which is assumed to be followed by handler name
+    and suffix.
+
+    If handler is specified, then it is checked for being a valid handler
+    function, and ValueError is raised if not.
+
     """
-    return reverse('xblock_handler', kwargs={
+    view_name = 'xblock_handler'
+    if handler:
+        # Be sure this is really a handler.
+        func = getattr(block, handler, None)
+        if not func:
+            raise ValueError("{!r} is not a function name".format(handler))
+        if not getattr(func, "_is_xblock_handler", False):
+            raise ValueError("{!r} is not a handler name".format(handler))
+
+        if getattr(func, "_is_unauthenticated", False):
+            view_name = 'xblock_handler_noauth'
+
+    return reverse(view_name, kwargs={
         'course_id': course_id,
         'usage_id': quote_slashes(str(block.scope_ids.usage_id)),
         'handler': handler,
@@ -72,8 +92,11 @@ def handler_url(course_id, block, handler, suffix='', query=''):
 
 def handler_prefix(course_id, block):
     """
-    Returns a prefix for use by the javascript handler_url function.
-    The prefix is a valid handler url the handler name is appended to it.
+    Returns a prefix for use by the Javascript handler_url function.
+
+    The prefix is a valid handler url after the handler name is slash-appended
+    to it.
+
     """
     return handler_url(course_id, block, '').rstrip('/')
 

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -178,7 +178,9 @@ if settings.COURSEWARE_ENABLED:
         url(r'^courses/(?P<course_id>[^/]+/[^/]+/[^/]+)/xblock/(?P<usage_id>[^/]*)/handler/(?P<handler>[^/]*)(?:/(?P<suffix>.*))?$',
             'courseware.module_render.handle_xblock_callback',
             name='xblock_handler'),
-
+        url(r'^courses/(?P<course_id>[^/]+/[^/]+/[^/]+)/xblock/(?P<usage_id>[^/]*)/handler_noauth/(?P<handler>[^/]*)(?:/(?P<suffix>.*))?$',
+            'courseware.module_render.handle_xblock_callback_noauth',
+            name='xblock_handler_noauth'),
 
         # Software Licenses
 

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -15,7 +15,7 @@
 -e git+https://github.com/eventbrite/zendesk.git@d53fe0e81b623f084e91776bcf6369f8b7b63879#egg=zendesk
 
 # Our libraries:
--e git+https://github.com/edx/XBlock.git@d6d2fc91#egg=XBlock
+-e git+https://github.com/edx/XBlock.git@7e387ce17e4421434fce549fca2c3ceb2bc769ee#egg=XBlock
 -e git+https://github.com/edx/codejail.git@0a1b468#egg=codejail
 -e git+https://github.com/edx/diff-cover.git@v0.2.6#egg=diff_cover
 -e git+https://github.com/edx/js-test-tool.git@v0.1.4#egg=js_test_tool


### PR DESCRIPTION
Decorate an XBlock handler with @XBlock.unauthenticated, and it will be
handled by a Django view with no authentication or csrf protection.
