### PR TITLE
Adding Codekit IDE assets/config to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ cms/envs/private.py
 /nbproject
 .idea/
 .redcar/
+codekit-config.json
 
 ### OS X artifacts
 *.DS_Store


### PR DESCRIPTION
This work adds additional IDE ([Codekit](http://incident57.com/codekit)) files to global .gitignore
