### PR TITLE
Revert PR 1711; disabling JS tests again

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,8 +5,6 @@ These are notable changes in edx-platform.  This is a rolling list of changes,
 in roughly chronological order, most recent first.  Add your entries at or near
 the top.  Include a label indicating the component affected.
 
-Blades: Enabled several Video Jasmine tests. BLD-463.
-
 Studio: Continued modification of Studio pages to follow a RESTful framework.
 includes Settings pages, edit page for Subsection and Unit, and interfaces
 for updating xblocks (xmodules) and getting their editing HTML.

--- a/common/lib/xmodule/xmodule/js/spec/video/general_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/general_spec.js
@@ -270,18 +270,8 @@
             }
         });
 
-        // Disabled 10/29/13 due to flakiness in master
-        //
-        // Update: Turned on test back again. Passing locally and on
-        // Jenkins in a large number of runs.
-        //
-        // Will observe for a little while to see if any failures arise.
-        // Most probable cause of test passing is:
-        //
-        // https://github.com/edx/edx-platform/pull/1642
-        //
-        // : )
-        describe('multiple YT on page', function () {
+        // Disabled 11/25/13 due to flakiness in master
+        xdescribe('multiple YT on page', function () {
             var state1, state2, state3;
 
             beforeEach(function () {

--- a/common/lib/xmodule/xmodule/js/spec/video/video_caption_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_caption_spec.js
@@ -456,18 +456,8 @@
                     expect(videoCaption.currentIndex).toEqual(5);
                 });
 
-                // Disabled 10/25/13 due to flakiness in master
-                //
-                // Update: Turned on test back again. Passing locally and on
-                // Jenkins in a large number of runs.
-                //
-                // Will observe for a little while to see if any failures arise.
-                // Most probable cause of test passing is:
-                //
-                // https://github.com/edx/edx-platform/pull/1642
-                //
-                // : )
-                it('scroll caption to new position', function () {
+                // Disabled 11/25/13 due to flakiness in master
+                xit('scroll caption to new position', function () {
                     expect($.fn.scrollTo).toHaveBeenCalled();
                 });
             });
@@ -547,18 +537,8 @@
             });
         });
 
-        // Disabled 10/23/13 due to flakiness in master
-        //
-        // Update: Turned on test back again. Passing locally and on
-        // Jenkins in a large number of runs.
-        //
-        // Will observe for a little while to see if any failures arise.
-        // Most probable cause of test passing is:
-        //
-        // https://github.com/edx/edx-platform/pull/1642
-        //
-        // : )
-        describe('scrollCaption', function () {
+        // Disabled 11/25/13 due to flakiness in master
+        xdescribe('scrollCaption', function () {
             beforeEach(function () {
                 initialize();
             });
@@ -702,18 +682,8 @@
                         .toHaveAttr('title', 'Turn off captions');
                 });
 
-                // Test turned off due to flakiness (30.10.2013).
-                //
-                // Update: Turned on test back again. Passing locally and on
-                // Jenkins in a large number of runs.
-                //
-                // Will observe for a little while to see if any failures arise.
-                // Most probable cause of test passing is:
-                //
-                // https://github.com/edx/edx-platform/pull/1642
-                //
-                // : )
-                it('scroll the caption', function () {
+                // Test turned off due to flakiness (11/25/13)
+                xit('scroll the caption', function () {
                     // After transcripts are shown, and the video plays for a
                     // bit.
                     jasmine.Clock.tick(1000);

--- a/common/lib/xmodule/xmodule/js/spec/video/video_progress_slider_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_progress_slider_spec.js
@@ -153,18 +153,8 @@
                 });
             });
 
-            // Turned off test due to flakiness (30.10.2013).
-            //
-            // Update: Turned on test back again. Passing locally and on
-            // Jenkins in a large number of runs.
-            //
-            // Will observe for a little while to see if any failures arise.
-            // Most probable cause of test passing is:
-            //
-            //     https://github.com/edx/edx-platform/pull/1642
-            //
-            // : )
-            it('trigger seek event', function() {
+            // Turned off test due to flakiness (11/25/13)
+            xit('trigger seek event', function() {
                 runs(function () {
                     videoProgressSlider.onSlide(
                         jQuery.Event('slide'), { value: 20 }
@@ -229,18 +219,8 @@
                 });
             });
 
-            // Turned off test due to flakiness (30.10.2013).
-            //
-            // Update: Turned on test back again. Passing locally and on
-            // Jenkins in a large number of runs.
-            //
-            // Will observe for a little while to see if any failures arise.
-            // Most probable cause of test passing is:
-            //
-            //     https://github.com/edx/edx-platform/pull/1642
-            //
-            // : )
-            it('trigger seek event', function() {
+            // Turned off test due to flakiness (11/25/13)
+            xit('trigger seek event', function() {
                 runs(function () {
                     videoProgressSlider.onStop(
                         jQuery.Event('stop'), { value: 20 }


### PR DESCRIPTION
Saw a failure in master on one of the JS video tests that was recently enabled:
https://jenkins.testeng.edx.org/job/edx-all-tests-auto-master/447/

The rationale for re-enabling them was that the tests had been fixed by another PR.  I'm not sure if all of these are flakey, but I'm disabling them just in case.

@jzoldak 
