### PR TITLE
Broken image in Studio component help sidebar

### DIFF
--- a/cms/templates/widgets/problem-edit.html
+++ b/cms/templates/widgets/problem-edit.html
@@ -39,7 +39,7 @@
             <div class="row">
                 <h6>${_("Heading 1")}</h6>
                 <div class="col sample heading-1">
-                    <img src="${static.url("/img/header-example.png")}" />
+                    <img src="${static.url("img/header-example.png")}" />
                 </div>
                 <div class="col">
 <pre><code>H1


### PR DESCRIPTION
Fixed the path to the header example image in the Studio html editor help sidebar (bug STUD-981). @cahrens and @talbs can you review?
