### PR TITLE
Added wait for course updates dialog to disappear

### DIFF
--- a/cms/djangoapps/contentstore/features/course-updates.py
+++ b/cms/djangoapps/contentstore/features/course-updates.py
@@ -123,6 +123,7 @@ def change_text(text):
     type_in_codemirror(0, text)
     save_css = 'a.save-button'
     world.css_click(save_css)
+    world.wait_for_invisible('form.new-update-form')
 
 
 def verify_text_in_editor_and_update(button_css, before, after):


### PR DESCRIPTION
Response to this failure: https://jenkins.testeng.edx.org/job/edx-all-tests-auto-master/449/SHARD=2,TEST_SUITE=cms-acceptance/

From the screenshot, it looks like the dialog didn't finish closing before the test tried to edit the fields on the page.  I added a wait for the form to disappear to make this more robust.

Neither the test nor the code had been touched in a long time, so I'm not especially worried about this test.

@jzoldak 
