### PR TITLE
Update mode appropriately when user enrolls

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -825,7 +825,7 @@ class CourseEnrollment(models.Model):
         verified the user authentication and access.
         """
         enrollment = cls.get_or_create_enrollment(user, course_id)
-        enrollment.update_enrollment(is_active=True)
+        enrollment.update_enrollment(is_active=True, mode=mode)
         return enrollment
 
     @classmethod

--- a/common/djangoapps/student/tests/tests.py
+++ b/common/djangoapps/student/tests/tests.py
@@ -342,6 +342,14 @@ class EnrollInCourseTest(TestCase):
         )
         self.assertFalse(enrollment_record.is_active)
 
+        # Make sure mode is updated properly if user unenrolls & re-enrolls
+        enrollment = CourseEnrollment.enroll(user, course_id, "verified")
+        self.assertEquals(enrollment.mode, "verified")
+        CourseEnrollment.unenroll(user, course_id)
+        enrollment = CourseEnrollment.enroll(user, course_id, "audit")
+        self.assertTrue(CourseEnrollment.is_enrolled(user, course_id))
+        self.assertEquals(enrollment.mode, "audit")
+
     def assert_no_events_were_emitted(self):
         """Ensures no events were emitted since the last event related assertion"""
         self.assertFalse(self.mock_server_track.called)


### PR DESCRIPTION
The "mode" was remaining unchanged when a student unenrolled & re-enrolled in a course--i.e., someone who was verified when first registering would still be verified when unenrolling and re-registering in audit mode.  This commit fixes this problem.

LMS-1526
