### PR TITLE
Studio: FIX - Italicize in xmodule/block previews

### DIFF
--- a/cms/static/sass/elements/_xmodules.scss
+++ b/cms/static/sass/elements/_xmodules.scss
@@ -1,4 +1,15 @@
-// studio - elements - xmodules
+// studio - elements - xmodules & xblocks
+// ====================
+
+// general - display mode (xblock-student_view or xmodule_display)
+.xmodule_display, .xblock-student_view {
+
+  // font styling
+  i, em {
+    font-style: italic;
+  }
+}
+
 // ====================
 
 // Video Alpha


### PR DESCRIPTION
This work adds basic italicize text styling back into xmodule/block preview. Note, its unclear exactly where the original browser agent styling is being trumped (I couldn't track down the case in the xmodule-compiled CSS where this was happening and Studio's _reset.scss file didn't seem to be to blame either).
