### PR TITLE
Studio: FIX - correcting hiding state of notification UI for < IE9

### DIFF
--- a/cms/static/sass/contexts/_ie.scss
+++ b/cms/static/sass/contexts/_ie.scss
@@ -10,6 +10,10 @@
     &.is-shown {
       bottom: 0;
     }
+
+    &.is-hiding {
+      bottom: -($ui-notification-height);
+    }
   }
 }
 


### PR DESCRIPTION
 This work adds a state to cater to styling notifications that have the class "is-hiding" in < IE9. IE9 doesn't support CSS transitions/animations, thus this state of hiding also needs to be accommodated for.
