### PR TITLE
Studio: Adds HTML5 data-* Attributes as Test Logic Hooks (WIP - DO NOT MERGE)

### DIFF
--- a/cms/templates/asset_index.html
+++ b/cms/templates/asset_index.html
@@ -5,6 +5,7 @@
 %>
 <%block name="title">${_("Files &amp; Uploads")}</%block>
 <%block name="bodyclass">is-signedin course uploads view-uploads</%block>
+<%block name='dataview'>view-uploads</%block>
 
 <%namespace name='static' file='static_content.html'/>
 

--- a/cms/templates/base.html
+++ b/cms/templates/base.html
@@ -32,7 +32,7 @@
     <%block name="header_extras"></%block>
   </head>
 
-  <body class="<%block name='bodyclass'></%block> hide-wip">
+  <body class="<%block name='bodyclass'></%block> hide-wip" data-view="<%block name='dataview'></%block>">
     <a class="nav-skip" href="#content">${_("Skip to this view's content")}</a>
 
     <script type="text/javascript">

--- a/cms/templates/checklists.html
+++ b/cms/templates/checklists.html
@@ -5,6 +5,7 @@
 %>
 <%block name="title">Course Checklists</%block>
 <%block name="bodyclass">is-signedin course view-checklists</%block>
+<%block name='dataview'>view-checklists</%block>
 
 <%namespace name='static' file='static_content.html'/>
 

--- a/cms/templates/course_info.html
+++ b/cms/templates/course_info.html
@@ -1,4 +1,4 @@
-<%! 
+<%!
     from django.utils.translation import ugettext as _
 %>
 <%inherit file="base.html" />
@@ -7,6 +7,7 @@
 <!-- TODO decode course # from context_course into title -->
 <%block name="title">${_("Course Updates")}</%block>
 <%block name="bodyclass">is-signedin course course-info updates view-updates</%block>
+<%block name='dataview'>view-updates</%block>
 
 <%block name="header_extras">
 <link rel="stylesheet" type="text/css" href="${static.url('js/vendor/timepicker/jquery.timepicker.css')}" />
@@ -19,7 +20,7 @@
 
 <%block name="jsextra">
   <script type="text/javascript" charset="utf-8">
-  
+
 require(["domReady!", "jquery", "js/collections/course_update", "js/models/module_info", "js/models/course_info", "js/views/course_info_edit"],
   function(doc, $, CourseUpdateCollection, ModuleInfoModel, CourseInfoModel, CourseInfoEditView) {
     var course_updates = new CourseUpdateCollection();

--- a/cms/templates/edit-tabs.html
+++ b/cms/templates/edit-tabs.html
@@ -6,6 +6,7 @@
 %>
 <%block name="title">Static Pages</%block>
 <%block name="bodyclass">is-signedin course view-static-pages</%block>
+<%block name='dataview'>view-static-pages</%block>
 
 <%block name="jsextra">
   <script type='text/javascript'>

--- a/cms/templates/edit_subsection.html
+++ b/cms/templates/edit_subsection.html
@@ -7,6 +7,7 @@
 %>
 <%block name="title">${_("CMS Subsection")}</%block>
 <%block name="bodyclass">is-signedin course view-subsection</%block>
+<%block name='dataview'>view-subsection</%block>
 
 
 <%namespace name="units" file="widgets/units.html" />

--- a/cms/templates/error.html
+++ b/cms/templates/error.html
@@ -2,6 +2,7 @@
 <%inherit file="base.html" />
 <%! from django.core.urlresolvers import reverse %>
 <%block name="bodyclass">error</%block>
+<%block name='dataview'>view-error</%block>
 <%block name="title">
   % if error == '404':
     404 - ${_("Page Not Found")}

--- a/cms/templates/export.html
+++ b/cms/templates/export.html
@@ -8,6 +8,7 @@
 %>
 <%block name="title">${_("Course Export")}</%block>
 <%block name="bodyclass">is-signedin course tools view-export</%block>
+<%block name='dataview'>view-export</%block>
 
 <%block name="jsextra">
   % if in_err:

--- a/cms/templates/howitworks.html
+++ b/cms/templates/howitworks.html
@@ -7,6 +7,7 @@
 
 <%block name="title">${_("Welcome")}</%block>
 <%block name="bodyclass">not-signedin index view-howitworks</%block>
+<%block name='dataview'>view-howitworks</%block>
 
 <%block name="content">
 

--- a/cms/templates/import.html
+++ b/cms/templates/import.html
@@ -5,6 +5,7 @@
 %>
 <%block name="title">${_("Course Import")}</%block>
 <%block name="bodyclass">is-signedin course tools view-import</%block>
+<%block name='dataview'>view-import</%block>
 
 <%block name="content">
 <div class="wrapper-mast wrapper">

--- a/cms/templates/index.html
+++ b/cms/templates/index.html
@@ -4,6 +4,7 @@
 
 <%block name="title">${_("My Courses")}</%block>
 <%block name="bodyclass">is-signedin index view-dashboard</%block>
+<%block name='dataview'>view-dashboard</%block>
 
 <%block name="jsextra">
 <script type="text/javascript">
@@ -154,7 +155,7 @@ require(["domReady!", "jquery", "jquery.form", "js/index"], function(doc, $) {
 
             <ul  class="item-actions course-actions">
               <li class="action">
-                <a href="${lms_link}" rel="external" class="button view-button view-live-button">${_("View Live")}</a>
+                <a href="${lms_link}" rel="external" data-rel="external" class="button view-button view-live-button">${_("View Live")}</a>
               </li>
             </ul>
           </li>

--- a/cms/templates/login.html
+++ b/cms/templates/login.html
@@ -5,6 +5,7 @@ from django.utils.translation import ugettext as _
 %>
 <%block name="title">${_("Sign In")}</%block>
 <%block name="bodyclass">not-signedin view-signin</%block>
+<%block name='dataview'>view-signin</%block>
 
 <%block name="content">
 
@@ -49,7 +50,7 @@ from django.utils.translation import ugettext as _
 
       <div class="bit">
         <h3 class="title-3">${_("Need Help?")}</h3>
-        <p>${_('Having trouble with your account? Use {link_start}our support center{link_end} to look over self help steps, find solutions others have found to the same problem, or let us know of your issue.').format(link_start='<a href="http://help.edge.edx.org" rel="external">', link_end='</a>')}</p>
+        <p>${_('Having trouble with your account? Use {link_start}our support center{link_end} to look over self help steps, find solutions others have found to the same problem, or let us know of your issue.').format(link_start='<a href="http://help.edge.edx.org" rel="external" data-rel="external">', link_end='</a>')}</p>
       </div>
     </aside>
   </section>

--- a/cms/templates/manage_users.html
+++ b/cms/templates/manage_users.html
@@ -6,6 +6,7 @@
 <%inherit file="base.html" />
 <%block name="title">${_("Course Team Settings")}</%block>
 <%block name="bodyclass">is-signedin course users view-team</%block>
+<%block name='dataview'>view-team</%block>
 
 <%block name="content">
 
@@ -143,7 +144,7 @@
       <div class="bit">
         <h3 class="title-3">${_("Course Team Roles")}</h3>
         <p>${_("Course team members, or staff, are course co-authors. They have full writing and editing privileges on all course content.")}</p>
-        <p>${_("Admins are course team members who can add and remove other course team members.")}</p>      
+        <p>${_("Admins are course team members who can add and remove other course team members.")}</p>
       </div>
 
       % if user_is_instuctor and len(instructors) == 1:

--- a/cms/templates/overview.html
+++ b/cms/templates/overview.html
@@ -7,7 +7,9 @@
   from xmodule.modulestore.django import loc_mapper
 %>
 <%block name="title">${_("Course Outline")}</%block>
+
 <%block name="bodyclass">is-signedin course view-outline feature-edit-dialog</%block>
+<%block name='dataview'>view-outline</%block>
 
 <%namespace name='static' file='static_content.html'/>
 <%namespace name="units" file="widgets/units.html" />
@@ -135,7 +137,7 @@ require(["domReady!", "jquery", "js/models/location", "js/models/section", "js/v
             <a href="#" class="button new-button new-courseware-section-button"><i class="icon-plus"></i> ${_("New Section")}</a>
           </li>
           <li class="nav-item">
-            <a href="${lms_link}" rel="external" class="button view-button view-live-button">${_("View Live")}</a>
+            <a href="${lms_link}" rel="external" data-rel="external" class="button view-button view-live-button">${_("View Live")}</a>
           </li>
         </ul>
       </nav>
@@ -312,7 +314,4 @@ require(["domReady!", "jquery", "js/models/location", "js/models/section", "js/v
       </form>
     </div>
   </div>
-
-
-
 </%block>

--- a/cms/templates/settings.html
+++ b/cms/templates/settings.html
@@ -1,6 +1,7 @@
 <%inherit file="base.html" />
 <%block name="title">${_("Schedule &amp; Details Settings")}</%block>
-<%block name="bodyclass">is-signedin course schedule view-settings feature-upload</%block>
+<%block name="bodyclass">is-signedin course schedule view-settings view-settings-details feature-upload</%block>
+<%block name='dataview'>view-settings-details</%block>
 
 <%namespace name='static' file='static_content.html'/>
 <%!
@@ -67,19 +68,19 @@ require(["domReady!", "jquery", "js/models/settings/course_details", "js/views/s
           <ol class="list-input">
             <li class="field text is-not-editable" id="field-course-organization">
               <label for="course-organization">${_("Organization")}</label>
-              <input title="${_('This field is disabled: this information cannot be changed.')}" type="text" 
+              <input title="${_('This field is disabled: this information cannot be changed.')}" type="text"
                 class="long" id="course-organization" readonly />
             </li>
 
             <li class="field text is-not-editable" id="field-course-number">
               <label for="course-number">${_("Course Number")}</label>
-              <input title="${_('This field is disabled: this information cannot be changed.')}" type="text" 
+              <input title="${_('This field is disabled: this information cannot be changed.')}" type="text"
                 class="short" id="course-number" readonly>
             </li>
 
             <li class="field text is-not-editable" id="field-course-name">
               <label for="course-name">${_("Course Name")}</label>
-              <input title="${_('This field is disabled: this information cannot be changed.')}" type="text" 
+              <input title="${_('This field is disabled: this information cannot be changed.')}" type="text"
                 class="long" id="course-name" readonly />
             </li>
           </ol>
@@ -88,12 +89,12 @@ require(["domReady!", "jquery", "js/models/settings/course_details", "js/views/s
           <div class="note note-promotion note-promotion-courseURL has-actions">
             <h3 class="title">${_("Course Summary Page")} <span class="tip">${_("(for student enrollment and access)")}</span></h3>
             <div class="copy">
-              <p><a class="link-courseURL" rel="external" href="https:${lms_link_for_about_page}">https:${lms_link_for_about_page}</a></p>
+              <p><a class="link-courseURL" rel="external" data-rel="external" href="https:${lms_link_for_about_page}">https:${lms_link_for_about_page}</a></p>
             </div>
 
             <ul class="list-actions">
               <li class="action-item">
-                <a title="${_('Send a note to students via email')}" 
+                <a title="${_('Send a note to students via email')}"
                     href="mailto:someone@domain.com?Subject=Enroll%20in%20${context_course.display_name_with_default}&body=The%20course%20&quot;${context_course.display_name_with_default}&quot;,%20provided%20by%20edX,%20is%20open%20for%20enrollment.%20Please%20navigate%20to%20this%20course%20at%20https:${lms_link_for_about_page}%20to%20enroll." class="action action-primary">
                     <i class="icon-envelope-alt icon-inline"></i>${_("Invite your students")}</a>
               </li>
@@ -200,7 +201,7 @@ require(["domReady!", "jquery", "js/models/settings/course_details", "js/views/s
                   <label for="course-overview">${_("Course Overview")}</label>
                   <textarea class="tinymce text-editor" id="course-overview"></textarea>
                   <%def name='overview_text()'><%
-                    a_link_start = '<a class="link-courseURL" rel="external" href="'
+                    a_link_start = '<a class="link-courseURL" rel="external" data-rel="external" href="'
                     a_link_end = '">' + _("your course summary page") + '</a>'
                     a_link = a_link_start + lms_link_for_about_page + a_link_end
                     text = _("Introductions, prerequisites, FAQs that are used on %s (formatted in HTML)") % a_link

--- a/cms/templates/settings_advanced.html
+++ b/cms/templates/settings_advanced.html
@@ -6,7 +6,8 @@
   from xmodule.modulestore.django import loc_mapper
 %>
 <%block name="title">${_("Advanced Settings")}</%block>
-<%block name="bodyclass">is-signedin course advanced view-settings</%block>
+<%block name="bodyclass">is-signedin course advanced view-settings view-settings-advanced</%block>
+<%block name='dataview'>view-settings-advanced</%block>
 
 <%block name="jsextra">
 % for template_name in ["advanced_entry"]:

--- a/cms/templates/settings_graders.html
+++ b/cms/templates/settings_graders.html
@@ -1,6 +1,7 @@
 <%inherit file="base.html" />
 <%block name="title">${_("Grading Settings")}</%block>
-<%block name="bodyclass">is-signedin course grading view-settings</%block>
+<%block name="bodyclass">is-signedin course grading view-settings view-settings-grading</%block>
+<%block name='dataview'>view-settings-grading</%block>
 
 <%namespace name='static' file='static_content.html'/>
 <%!

--- a/cms/templates/signup.html
+++ b/cms/templates/signup.html
@@ -4,6 +4,7 @@
 
 <%block name="title">${_("Sign Up")}</%block>
 <%block name="bodyclass">not-signedin view-signup</%block>
+<%block name='dataview'>view-signup</%block>
 
 <%block name="content">
 

--- a/cms/templates/temp-course-landing.html
+++ b/cms/templates/temp-course-landing.html
@@ -2,6 +2,7 @@
 <%! from django.core.urlresolvers import reverse %>
 <%block name="title">Landing</%block>
 <%block name="bodyclass">no-header class-landing</%block>
+<%block name='dataview'>view-class-landing</%block>
 
 <%block name="content">
 <div class="main-wrapper">

--- a/cms/templates/textbooks.html
+++ b/cms/templates/textbooks.html
@@ -5,6 +5,7 @@
 
 <%block name="title">${_("Textbooks")}</%block>
 <%block name="bodyclass">is-signedin course view-textbooks feature-upload</%block>
+<%block name='dataview'>view-textbooks</%block>
 
 <%block name="header_extras">
 % for template_name in ["edit-textbook", "show-textbook", "edit-chapter", "no-textbooks", "upload-dialog"]:

--- a/cms/templates/unit.html
+++ b/cms/templates/unit.html
@@ -7,6 +7,7 @@ from xmodule.modulestore.django import loc_mapper
 <%namespace name="units" file="widgets/units.html" />
 <%block name="title">${_("Individual Unit")}</%block>
 <%block name="bodyclass">is-signedin course unit view-unit</%block>
+<%block name='dataview'>view-unit</%block>
 
 <%block name="jsextra">
   <script type='text/javascript'>

--- a/cms/templates/widgets/footer.html
+++ b/cms/templates/widgets/footer.html
@@ -4,7 +4,7 @@
 <div class="wrapper-footer wrapper">
   <footer class="primary" role="contentinfo">
     <div class="colophon">
-      <p>&copy; 2013 <a href="http://www.edx.org" rel="external">edX</a>. ${ _("All rights reserved.")}</p>
+      <p>&copy; 2013 <a href="http://www.edx.org" rel="external" data-rel="external">edX</a>. ${ _("All rights reserved.")}</p>
     </div>
 
     <nav class="nav-peripheral">

--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -40,10 +40,10 @@
       <nav class="nav-course nav-dd ui-left">
         <h2 class="sr">${_("{course_name}'s Navigation:").format(course_name=context_course.display_name_with_default)}</h2>
         <ol>
-          <li class="nav-item nav-course-courseware">
-            <h3 class="title"><span class="label"><span class="label-prefix sr">${_("Course")} </span>${_("Content")}</span> <i class="icon-caret-down ui-toggle-dd"></i></h3>
+          <li class="nav-item nav-course-courseware" data-menu="dropdown">
+            <h3 class="title" data-menu="dropdown--control"><span class="label"><span class="label-prefix sr">${_("Course")} </span>${_("Content")}</span> <i class="icon-caret-down ui-toggle-dd"></i></h3>
 
-            <div class="wrapper wrapper-nav-sub">
+            <div class="wrapper wrapper-nav-sub" data-menu="dropdown--content">
               <div class="nav-sub">
                 <ul>
                   <li class="nav-item nav-course-courseware-outline">
@@ -66,10 +66,10 @@
             </div>
           </li>
 
-          <li class="nav-item nav-course-settings">
-            <h3 class="title"><span class="label"><span class="label-prefix sr">${_("Course")} </span>${_("Settings")}</span> <i class="icon-caret-down ui-toggle-dd"></i></h3>
+          <li class="nav-item nav-course-settings" data-menu="dropdown">
+            <h3 class="title" data-menu="dropdown--control"><span class="label"><span class="label-prefix sr">${_("Course")} </span>${_("Settings")}</span> <i class="icon-caret-down ui-toggle-dd"></i></h3>
 
-            <div class="wrapper wrapper-nav-sub">
+            <div class="wrapper wrapper-nav-sub" data-menu="dropdown--content">
               <div class="nav-sub">
                 <ul>
                   <li class="nav-item nav-course-settings-schedule">
@@ -89,10 +89,10 @@
             </div>
           </li>
 
-          <li class="nav-item nav-course-tools">
-            <h3 class="title"><span class="label">${_("Tools")}</span> <i class="icon-caret-down ui-toggle-dd"></i></h3>
+          <li class="nav-item nav-course-tools" data-menu="dropdown">
+            <h3 class="title" data-menu="dropdown--control"><span class="label">${_("Tools")}</span> <i class="icon-caret-down ui-toggle-dd"></i></h3>
 
-            <div class="wrapper wrapper-nav-sub">
+            <div class="wrapper wrapper-nav-sub" data-menu="dropdown--content">
               <div class="nav-sub">
                 <ul>
                   <li class="nav-item nav-course-tools-checklists">
@@ -119,17 +119,17 @@
         <h2 class="sr">${_("Help &amp; Account Navigation")}</h2>
 
         <ol>
-          <li class="nav-item nav-account-help">
-            <h3 class="title"><span class="label">${_("Help")}</span> <i class="icon-caret-down ui-toggle-dd"></i></h3>
+          <li class="nav-item nav-account-help" data-menu="dropdown">
+            <h3 class="title" data-menu="dropdown--control"><span class="label">${_("Help")}</span> <i class="icon-caret-down ui-toggle-dd"></i></h3>
 
-            <div class="wrapper wrapper-nav-sub">
+            <div class="wrapper wrapper-nav-sub" data-menu="dropdown--content">
               <div class="nav-sub">
                 <ul>
                   <li class="nav-item nav-help-documentation">
                     <a href="http://files.edx.org/Getting_Started_with_Studio.pdf" title="${_("This is a PDF Document")}">${_("Studio Documentation")}</a>
                   </li>
                   <li class="nav-item nav-help-helpcenter">
-                    <a href="http://help.edge.edx.org/" rel="external">${_("Studio Help Center")}</a>
+                    <a href="http://help.edge.edx.org/" rel="external" data-rel="external">${_("Studio Help Center")}</a>
                   </li>
                   <li class="nav-item nav-help-feedback">
                     <a href="http://help.edge.edx.org/discussion/new" class="show-tender" title="${_("Use our feedback tool, Tender, to share your feedback")}">${_("Contact Us")}</a>
@@ -139,10 +139,10 @@
             </div>
           </li>
 
-          <li class="nav-item nav-account-user">
-            <h3 class="title"><span class="label"><span class="label-prefix sr">${_("Currently signed in as:")}</span><span class="account-username" title="${ user.username }">${ user.username }</span></span> <i class="icon-caret-down ui-toggle-dd"></i></h3>
+          <li class="nav-item nav-account-user" data-menu="dropdown">
+            <h3 class="title" data-menu="dropdown--control"><span class="label"><span class="label-prefix sr">${_("Currently signed in as:")}</span><span class="account-username" title="${ user.username }">${ user.username }</span></span> <i class="icon-caret-down ui-toggle-dd"></i></h3>
 
-            <div class="wrapper wrapper-nav-sub">
+            <div class="wrapper wrapper-nav-sub" data-menu="dropdown--content">
               <div class="nav-sub">
                 <ul>
                   <li class="nav-item nav-account-dashboard">
@@ -166,7 +166,7 @@
             <a href="/">${_("How Studio Works")}</a>
           </li>
           <li class="nav-item nav-not-signedin-help">
-            <a href="http://help.edge.edx.org/" rel="external">${_("Studio Help")}</a>
+            <a href="http://help.edge.edx.org/" rel="external" data-rel="external">${_("Studio Help")}</a>
           </li>
           <li class="nav-item nav-not-signedin-signup">
             <a class="action action-signup" href="${reverse('signup')}">${_("Sign Up")}</a>

--- a/cms/templates/widgets/sock.html
+++ b/cms/templates/widgets/sock.html
@@ -26,11 +26,11 @@
           <span class="tip">${_("How to use Studio to build your course")}</span>
         </li>
         <li class="action-item">
-          <a href="http://help.edge.edx.org/" rel="external" class="action action-primary">${_("Studio Help Center")}</a>
+          <a href="http://help.edge.edx.org/" rel="external" data-rel="external" class="action action-primary">${_("Studio Help Center")}</a>
           <span class="tip">${_("Studio Help Center")}</span>
         </li>
         <li class="action-item">
-          <a href="https://edge.edx.org/courses/edX/edX101/How_to_Create_an_edX_Course/about" rel="external" class="action action-primary">${_("Enroll in edX101")}</a>
+          <a href="https://edge.edx.org/courses/edX/edX101/How_to_Create_an_edX_Course/about" rel="external" data-rel="external" class="action action-primary">${_("Enroll in edX101")}</a>
           <span class="tip">${_("How to use Studio to build your course")}</span>
         </li>
       </ul>


### PR DESCRIPTION
This experimental work aims to help the test engineering group with more solid (and less often to be edited) HTML attributes to use as points of logic when writing interface/state tests.

Currently the attributes added include:
- _data-view_ -- this is used on each whole view's &lt;body&gt; element
- _data-menu_ -- this is used to denote any non-native but common UI menu type we may be using (values used: "dropdown")
- _data-rel_ -- this is used on any link to clarify its scope in relation to the current browser window/domain (values used now: "external" -- an outside site or third party)

Other suggestions are welcome and I will reach out to @jzoldak and @wedaly to see what other UI hooks (elements/states) might be useful to make.
