### PR TITLE
Encode header row (LMS-197)

### DIFF
--- a/lms/djangoapps/instructor/views/legacy.py
+++ b/lms/djangoapps/instructor/views/legacy.py
@@ -133,8 +133,10 @@ def instructor_dashboard(request, course_id):
         else:
             response = file_pointer
         writer = csv.writer(response, dialect='excel', quotechar='"', quoting=csv.QUOTE_ALL)
-        writer.writerow(datatable['header'])
+        encoded_row = [unicode(s).encode('utf-8') for s in datatable['header']]
+        writer.writerow(encoded_row)
         for datarow in datatable['data']:
+            # 's' here may be an integer, float (eg score) or string (eg student name)
             encoded_row = [unicode(s).encode('utf-8') for s in datarow]
             writer.writerow(encoded_row)
         return response

--- a/lms/djangoapps/instructor_task/tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tasks_helper.py
@@ -523,7 +523,8 @@ def push_grades_to_s3(_xmodule_instance_args, _entry_id, course_id, _task_input,
             # We were able to successfully grade this student for this course.
             num_succeeded += 1
             if not header:
-                header = [section['label'] for section in gradeset[u'section_breakdown']]
+                # Encode the header row in utf-8 encoding in case there are unicode characters
+                header = [section['label'].encode('utf-8') for section in gradeset[u'section_breakdown']]
                 rows.append(["id", "email", "username", "grade"] + header)
 
             percents = {


### PR DESCRIPTION
@ormsbee 

I was going to extend this to do some encoding on the new gradesstore store_rows writerows call, but based on our conversation (currently that data won't have unicode characters, and we should modularize/abstract that stuff better), I think this simple fix should just go in and we can tackle the other part separately.
