### PR TITLE
Fix LTI max_score method.

### DIFF
--- a/common/lib/xmodule/xmodule/lti_module.py
+++ b/common/lib/xmodule/xmodule/lti_module.py
@@ -375,7 +375,7 @@ oauth_consumer_key="", oauth_signature="frVp4JuvT1mVXlxktiAUjQ7%2F1cw%3D"'}
         return params
 
     def max_score(self):
-        return self.weight
+        return self.weight if self.graded else 0
 
 
     @XBlock.handler

--- a/common/lib/xmodule/xmodule/lti_module.py
+++ b/common/lib/xmodule/xmodule/lti_module.py
@@ -94,6 +94,7 @@ class LTIFields(object):
         scope=Scope.settings,
         values={"min": 0},
     )
+    has_score = Boolean(help="Does this LTI module have score?", default=False, scope=Scope.settings)
 
 
 class LTIModule(LTIFields, XModule):
@@ -380,7 +381,7 @@ oauth_consumer_key="", oauth_signature="frVp4JuvT1mVXlxktiAUjQ7%2F1cw%3D"'}
         return params
 
     def max_score(self):
-        return self.weight if self.graded else 0
+        return self.weight if self.has_score else None
 
 
     @XBlock.handler
@@ -586,6 +587,5 @@ class LTIDescriptor(LTIFields, MetadataOnlyEditingDescriptor, EmptyDataRawDescri
     """
     Descriptor for LTI Xmodule.
     """
-    has_score = True
     module_class = LTIModule
     grade_handler = module_attr('grade_handler')

--- a/common/lib/xmodule/xmodule/lti_module.py
+++ b/common/lib/xmodule/xmodule/lti_module.py
@@ -88,7 +88,12 @@ class LTIFields(object):
     custom_parameters = List(help="Custom parameters (vbid, book_location, etc..)", scope=Scope.settings)
     open_in_a_new_page = Boolean(help="Should LTI be opened in new page?", default=True, scope=Scope.settings)
     graded = Boolean(help="Grades will be considered in overall score.", default=False, scope=Scope.settings)
-    weight = Float(help="Weight for student grades.", default=1.0, scope=Scope.settings)
+    weight = Float(
+        help="Weight for student grades.",
+        default=1.0,
+        scope=Scope.settings,
+        values={"min": 0},
+    )
 
 
 class LTIModule(LTIFields, XModule):

--- a/common/lib/xmodule/xmodule/tests/test_lti_unit.py
+++ b/common/lib/xmodule/xmodule/tests/test_lti_unit.py
@@ -194,6 +194,7 @@ class LTIModuleTest(LogicTest):
         Response from Tool Provider is correct.
         """
         self.xmodule.verify_oauth_body_sign = Mock()
+        self.xmodule.has_score = True
         request = Request(self.environ)
         request.body = self.get_request_body()
         response = self.xmodule.grade_handler(request, '')

--- a/common/lib/xmodule/xmodule/tests/test_lti_unit.py
+++ b/common/lib/xmodule/xmodule/tests/test_lti_unit.py
@@ -253,9 +253,12 @@ class LTIModuleTest(LogicTest):
         self.xmodule.weight = 100.0
 
         self.xmodule.graded = True
-        self.assertEqual(self.xmodule.max_score(), 100)
+        self.assertEqual(self.xmodule.max_score(), None)
+
+        self.xmodule.has_score = True
+        self.assertEqual(self.xmodule.max_score(), 100.0)
 
         self.xmodule.graded = False
-        self.assertEqual(self.xmodule.max_score(), 0)
+        self.assertEqual(self.xmodule.max_score(), 100.0)
 
 

--- a/common/lib/xmodule/xmodule/tests/test_lti_unit.py
+++ b/common/lib/xmodule/xmodule/tests/test_lti_unit.py
@@ -249,3 +249,13 @@ class LTIModuleTest(LogicTest):
     def test_client_key_secret(self):
         pass
 
+    def test_max_score(self):
+        self.xmodule.weight = 100.0
+
+        self.xmodule.graded = True
+        self.assertEqual(self.xmodule.max_score(), 100)
+
+        self.xmodule.graded = False
+        self.assertEqual(self.xmodule.max_score(), 0)
+
+

--- a/lms/djangoapps/courseware/features/lti.feature
+++ b/lms/djangoapps/courseware/features/lti.feature
@@ -44,8 +44,8 @@ Feature: LMS.LTI component
   Scenario: Graded LTI component in LMS is correctly works
   Given the course has correct LTI credentials
   And the course has an LTI component with correct fields:
-  | open_in_a_new_page | weight | is_graded |
-  | False              | 10     | True      |
+  | open_in_a_new_page | weight | is_graded | has_score |
+  | False              | 10     | True      | True |
   And I submit answer to LTI question
   And I click on the "Progress" tab
   Then I see text "Problem Scores: 5/10"


### PR DESCRIPTION
This PR adds fix for LTI's `max_score` method.

When LTI module is not graded (attribute `graded=False`) method `max_score` returns value of `weight` attribute, that is `1.0` by default.
It should not be so, because it affects on total score (each additional module adds +1 to the total max score). 

@nedbat review, please.
