### PR TITLE
Added developer-specific settings to devstack

### DIFF
--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -53,6 +53,11 @@ DEBUG_TOOLBAR_CONFIG = {
 
 PIPELINE_SASS_ARGUMENTS = '--debug-info --require {proj_dir}/static/sass/bourbon/lib/bourbon.rb'.format(proj_dir=PROJECT_ROOT)
 
+########################### VERIFIED CERTIFICATES #################################
+
+FEATURES['AUTOMATIC_VERIFY_STUDENT_IDENTITY_FOR_TESTING'] = True
+FEATURES['ENABLE_PAYMENT_FAKE'] = True
+CC_PROCESSOR['CyberSource']['PURCHASE_ENDPOINT'] = '/shoppingcart/payment_fake/'
 
 #####################################################################
 # Lastly, see if the developer has any local overrides.


### PR DESCRIPTION
Devstack uses lms/envs/devstack.py instead of lms/envs/dev.py for development-specific settings.

This commit adds a few settings so that verified certificates flow can be used on local devstacks.

@wedaly @dianakhuang 
