### PR TITLE
Change forum role granted to staff on enrollment

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,10 @@ Common: Switch over from MITX_FEATURES to just FEATURES. To override items in
   the FEATURES dict, the environment variable you must set to do so is also
   now called FEATURES instead of MITX_FEATURES.
 
+LMS: Change the forum role granted to global staff on enrollment in a
+course. Previously, staff were given the Moderator role; now, they are
+given the Student role.
+
 Blades: Fix Numerical input to support mathematical operations. BLD-525.
 
 Blades: Improve calculator's tooltip accessibility. Add possibility to navigate

--- a/common/djangoapps/django_comment_common/models.py
+++ b/common/djangoapps/django_comment_common/models.py
@@ -32,13 +32,8 @@ def assign_default_role(sender, instance, **kwargs):
     #     instance.user.roles.remove(*course_roles)
     #     return
 
-    # We've enrolled the student, so make sure they have a default role
-    if instance.user.is_staff:
-        role = Role.objects.get_or_create(course_id=instance.course_id, name="Moderator")[0]
-    else:
-        role = Role.objects.get_or_create(course_id=instance.course_id, name="Student")[0]
-
-    logging.info("assign_default_role: adding %s as %s" % (instance.user, role))
+    # We've enrolled the student, so make sure they have the Student role
+    role = Role.objects.get_or_create(course_id=instance.course_id, name="Student")[0]
     instance.user.roles.add(role)
 
 

--- a/common/djangoapps/django_comment_common/tests.py
+++ b/common/djangoapps/django_comment_common/tests.py
@@ -10,6 +10,7 @@ class RoleAssignmentTest(TestCase):
     """
 
     def setUp(self):
+        # Check a staff account because those used to get the Moderator role
         self.staff_user = User.objects.create_user(
             "patty",
             "patty@fake.edx.org",
@@ -25,18 +26,13 @@ class RoleAssignmentTest(TestCase):
         CourseEnrollment.enroll(self.student_user, self.course_id)
 
     def test_enrollment_auto_role_creation(self):
-        moderator_role = Role.objects.get(
-            course_id=self.course_id,
-            name="Moderator"
-        )
         student_role = Role.objects.get(
             course_id=self.course_id,
             name="Student"
         )
-        self.assertIn(moderator_role, self.staff_user.roles.all())
 
-        self.assertIn(student_role, self.student_user.roles.all())
-        self.assertNotIn(moderator_role, self.student_user.roles.all())
+        self.assertEqual([student_role], list(self.staff_user.roles.all()))
+        self.assertEqual([student_role], list(self.student_user.roles.all()))
 
     # The following was written on the assumption that unenrolling from a course
     # should remove all forum Roles for that student for that course. This is


### PR DESCRIPTION
This applies to global staff (is_staff=True), not course staff.
Previously, staff were granted the Moderator role but not the Student
role upon enrolling in a course. If the Moderator role were later
revoked, then the user would have no role and be unable to post in the
forums, which is confusing for the user. edX staff indicated they would
prefer to not automatically receive the Moderator role, so the Student
role is granted instead. Note that staff will still be able to grant
themselves Moderator privileges through the instructor dashboard if
they wish.

JIRA: FOR-338

@jimabramson 
