### PR TITLE
Activate Markdown editor buttons on keypress

### DIFF
--- a/lms/static/js/Markdown.Editor.js
+++ b/lms/static/js/Markdown.Editor.js
@@ -1377,6 +1377,18 @@
                         doClick(this);
                         return false;
                     }
+                    util.addEvent(button, "keydown", function(event) {
+                        var keyCode = event.charCode || event.keyCode;
+                        if (keyCode == 32 || keyCode == 13) {
+                            if (event.preventDefault) {
+                                event.preventDefault();
+                            }
+                            if (window.event) {
+                                window.event.returnValue = false;
+                            }
+                            doClick(button);
+                        }
+                    })
                 }
             }
             else {


### PR DESCRIPTION
The buttons now activate on pressing space or enter.

JIRA: FOR-66

@jimabramson @marcotuts 

I tested manually in Firefox, Chrome, Safari, and IE 10.
