### PR TITLE
Fix `xhr.restore()` in JS test

### DIFF
--- a/cms/static/coffee/spec/views/course_info_spec.coffee
+++ b/cms/static/coffee/spec/views/course_info_spec.coffee
@@ -28,10 +28,9 @@ define ["js/views/course_info_handout", "js/views/course_info_update", "js/model
             setFixtures($("<script>", {id: "course_info_update-tpl", type: "text/template"}).text(courseInfoTemplate))
             appendSetFixtures courseInfoPage
 
-            courseUpdatesXhr = sinon.useFakeXMLHttpRequest()
-            @courseUpdatesRequests = requests = []
-            courseUpdatesXhr.onCreate = (xhr) -> requests.push(xhr)
-            @xhrRestore = courseUpdatesXhr.restore
+            @requests = requests = []
+            @xhr = sinon.useFakeXMLHttpRequest()
+            @xhr.onCreate = (xhr) -> requests.push(xhr)
 
             @collection = new CourseUpdateCollection()
             @collection.url = 'course_info_update/'
@@ -92,7 +91,7 @@ define ["js/views/course_info_handout", "js/views/course_info_update", "js/model
                     modalCover.click()
 
         afterEach ->
-            @xhrRestore()
+            @xhr.restore()
 
         it "does not rewrite links on save", ->
             # Create a new update, verifying that the model is created
@@ -109,7 +108,7 @@ define ["js/views/course_info_handout", "js/views/course_info_update", "js/model
             expect(model.save).toHaveBeenCalled()
 
             # Verify content sent to server does not have rewritten links.
-            contentSaved = JSON.parse(@courseUpdatesRequests[@courseUpdatesRequests.length - 1].requestBody).content
+            contentSaved = JSON.parse(@requests[@requests.length - 1].requestBody).content
             expect(contentSaved).toEqual('/static/image.jpg')
 
         it "does rewrite links for preview", ->
@@ -146,10 +145,9 @@ define ["js/views/course_info_handout", "js/views/course_info_update", "js/model
             setFixtures($("<script>", {id: "course_info_handouts-tpl", type: "text/template"}).text(handoutsTemplate))
             appendSetFixtures courseInfoPage
 
-            courseHandoutsXhr = sinon.useFakeXMLHttpRequest()
-            @handoutsRequests = requests = []
-            courseHandoutsXhr.onCreate = (xhr) -> requests.push(xhr)
-            @handoutsXhrRestore = courseHandoutsXhr.restore
+            @requests = requests = []
+            @xhr = sinon.useFakeXMLHttpRequest()
+            @xhr.onCreate = (xhr) -> requests.push(xhr)
 
             @model = new ModuleInfo({
                 id: 'handouts-id',
@@ -165,7 +163,7 @@ define ["js/views/course_info_handout", "js/views/course_info_update", "js/model
             @handoutsEdit.render()
 
         afterEach ->
-            @handoutsXhrRestore()
+            @xhr.restore()
 
         it "does not rewrite links on save", ->
             # Enter something in the handouts section, verifying that the model is saved
@@ -176,7 +174,7 @@ define ["js/views/course_info_handout", "js/views/course_info_update", "js/model
             @handoutsEdit.$el.find('.save-button').click()
             expect(@model.save).toHaveBeenCalled()
 
-            contentSaved = JSON.parse(@handoutsRequests[@handoutsRequests.length - 1].requestBody).data
+            contentSaved = JSON.parse(@requests[@requests.length - 1].requestBody).data
             expect(contentSaved).toEqual('/static/image.jpg')
 
         it "does rewrite links in initial content", ->

--- a/cms/static/coffee/spec/views/overview_spec.coffee
+++ b/cms/static/coffee/spec/views/overview_spec.coffee
@@ -328,7 +328,7 @@ define ["js/views/overview", "js/views/feedback_notification", "sinon", "js/base
                 )
                 expect($('#subsection-2')).not.toHaveClass('collapsed')
 
-        xdescribe "AJAX", ->
+        describe "AJAX", ->
             beforeEach ->
                 @requests = requests = []
                 @xhr = sinon.useFakeXMLHttpRequest()


### PR DESCRIPTION
This test was failing sporadically -- in my testing, I discovered that when it failed, it did so because `this.xhr` was the [`FakeXMLHttpRequest`](http://sinonjs.org/docs/#FakeXMLHttpRequest) class, and had no `restore` method to call on it. However, `this.xhrRestore` did exist, and I hypothesize that something about the test setup and cleanup was behaving weirdly because one test saved just this method, rather than the full `xhr` object. This pull request seems to make the problem go away, although I still don't understand _why_ the test was failing. If this test turns out to be still failing sporadically again, it should be disabled again.

Reviewers: @jzoldak or @wedaly.
