### PR TITLE
Add underscore to staff grading template

### DIFF
--- a/lms/templates/instructor/staff_grading.html
+++ b/lms/templates/instructor/staff_grading.html
@@ -6,6 +6,7 @@
 <%block name="headextra">
 <%static:css group='style-course-vendor'/>
 <%static:css group='style-course'/>
+<script type="text/javascript" src="${static.url('js/vendor/underscore-min.js')}"></script>
 </%block>
 
 <%block name="title"><title>${_("{course_number} Staff Grading").format(course_number=course.display_number_with_default) | h}</title></%block>


### PR DESCRIPTION
Fix for a regression caused by i18n changes in #1792 

I verified that this fixes the issue in the Open Ended Panel staff grading (student responses stopped appearing because of an undefined reference JS error).  However, I'm concerned that #1792 may have introduced other errors like this.

@sarina @singingwolfboy Please review
