### PR TITLE
Stop forcing video player’s speeds widget width

### DIFF
--- a/common/lib/xmodule/xmodule/css/video/display.scss
+++ b/common/lib/xmodule/xmodule/css/video/display.scss
@@ -307,9 +307,10 @@ div.video {
             padding-left: 15px;
             position: relative;
             -webkit-font-smoothing: antialiased;
-            width: 116px;
+            min-width: 116px;
 
             @media (max-width: 1024px) {
+              min-width: 0;
               width: 86px;
             }
 


### PR DESCRIPTION
When translating the “Speed” label using a longer word, the speeds
button gets really ugly.  The dropdown and the button will not always
have equal widths, but it’s better than having the text overlap the
other buttons.
