### PR TITLE
Adding settings and requirements for dogslow.

### DIFF
--- a/lms/envs/aws_dogslow.py
+++ b/lms/envs/aws_dogslow.py
@@ -1,0 +1,33 @@
+# We intentionally define lots of variables that aren't used, and
+# want to import all variables from base settings files
+# pylint: disable=W0401, W0614
+
+# Import everything from .aws so that our settings are based on those.
+from .aws import *
+
+CURRENT_MIDDLEWARE_CLASSES = MIDDLEWARE_CLASSES
+MIDDLEWARE_CLASSES = ('dogslow.WatchdogMiddleware',) + CURRENT_MIDDLEWARE_CLASSES
+# Watchdog is enabled by default, to temporarily disable, set to False:
+DOGSLOW = True
+
+# By default, Watchdog will create log files with the backtraces.
+# You can also set the location where it stores them:
+DOGSLOW_LOG_TO_FILE = True
+DOGSLOW_OUTPUT = '/tmp'
+
+# Log requests taking longer than 25 seconds:
+DOGSLOW_TIMER = 25
+
+# When both specified, emails backtraces:
+DOGSLOW_EMAIL_TO = 'admin@edx.org'
+DOGSLOW_EMAIL_FROM = 'no-reply@edx.org'
+
+# Tuple of url pattern names that should not be monitored:
+# (defaults to none -- everything monitored)
+# Note: this option is not compatible with Django < 1.3
+#DOGSLOW_IGNORE_URLS = ('some_view', 'other_view')
+
+# Print (potentially huge!) local stack variables (off by default, use
+# True for more detailed, but less manageable reports)
+DOGSLOW_STACK_VARS = True
+

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -111,3 +111,6 @@ git+https://github.com/mfogel/django-settings-context-processor.git
 
 # django-cas version 2.0.3 with patch to be compatible with django 1.4
 git+https://github.com/mitocw/django-cas.git
+
+# used for performance root cause determination
+dogslow==0.9.7


### PR DESCRIPTION
@cpennington @jarv @feanil 

@jtauber for the new requirement

The creates a new environment that inherits everything from aws.py and does the following
- prepends the doglow middleware to the inherited list of middleware classes.
- configures dog slow.

This PR does not integrate dogslow directly into aws.py as I'd like to run in selectively for a while before blessing it.

We should also change the logging directory, but that will require an additional PR against the config repo to create a sensible directory and/or integrate dogslow with rsyslog.
