### PR TITLE
Turn off AUTH_USE_MIT_CERTIFICATES

### DIFF
--- a/lms/envs/dev.py
+++ b/lms/envs/dev.py
@@ -200,7 +200,7 @@ OPENID_PROVIDER_TRUSTED_ROOTS = ['*']
 
 ######################## MIT Certificates SSL Auth ############################
 
-FEATURES['AUTH_USE_MIT_CERTIFICATES'] = True
+FEATURES['AUTH_USE_MIT_CERTIFICATES'] = False
 
 ################################# CELERY ######################################
 


### PR DESCRIPTION
When I try to login with the latest master, I get redirected back to the homepage. It appears that a feature flag is the culprit -- this flag should not be turned on in master.

Review: @cahrens 
