### PR TITLE
Added matplotlib and pandas to sandbox requirements

### DIFF
--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -9,3 +9,6 @@ networkx==1.7
 sympy==0.7.1
 pyparsing==1.5.6
 nltk==2.0.4
+matplotlib==1.3.1
+pandas==0.12.0
+requests==1.2.3


### PR DESCRIPTION
@sarina @jarvis

We have some residential courses including matplotlib and pandas libraries in their courseware. We would like to add these to the sandbox requirements.
