### PR TITLE
Check that SSL certificate is passed before redirecting to SSL authentication.

### DIFF
--- a/common/djangoapps/external_auth/tests/test_ssl.py
+++ b/common/djangoapps/external_auth/tests/test_ssl.py
@@ -199,6 +199,13 @@ class SSLClientTest(TestCase):
         that user doesn't get presented with the login page if they
         have a certificate.
         """
+        # Test that they do signin if they don't have a cert
+        response = self.client.get(reverse('signin_user'))
+        self.assertEqual(200, response.status_code)
+        self.assertTrue('login_form' in response.content
+                        or 'login-form' in response.content)
+
+        # And get directly logged in otherwise
         response = self.client.get(
             reverse('signin_user'), follow=True,
             SSL_CLIENT_S_DN=self.AUTH_DN.format(self.USER_NAME, self.USER_EMAIL))

--- a/common/djangoapps/external_auth/views.py
+++ b/common/djangoapps/external_auth/views.py
@@ -330,7 +330,7 @@ def _ssl_dn_extract_info(dn_string):
     return (user, email, fullname)
 
 
-def _ssl_get_cert_from_request(request):
+def ssl_get_cert_from_request(request):
     """
     Extract user information from certificate, if it exists, returning (user, email, fullname).
     Else return None.
@@ -369,7 +369,7 @@ def ssl_login_shortcut(fn):
         if request.user and request.user.is_authenticated():  # don't re-authenticate
             return fn(*args, **kwargs)
 
-        cert = _ssl_get_cert_from_request(request)
+        cert = ssl_get_cert_from_request(request)
         if not cert:		# no certificate information - show normal login window
             return fn(*args, **kwargs)
 
@@ -411,7 +411,7 @@ def ssl_login(request):
     if not settings.FEATURES['AUTH_USE_MIT_CERTIFICATES']:
         return HttpResponseForbidden()
 
-    cert = _ssl_get_cert_from_request(request)
+    cert = ssl_get_cert_from_request(request)
 
     if not cert:
         # no certificate information - go onward to main index

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -239,9 +239,11 @@ def signin_user(request):
     """
     This view will display the non-modal login form
     """
-    if settings.FEATURES['AUTH_USE_MIT_CERTIFICATES']:
+    if (settings.FEATURES['AUTH_USE_MIT_CERTIFICATES'] and
+            external_auth.views.ssl_get_cert_from_request(request)):
         # SSL login doesn't require a view, so redirect
-        # branding and allow that to process the login.
+        # branding and allow that to process the login if it
+        # is enabled and the header is in the request.
         return redirect(reverse('root'))
     if request.user.is_authenticated():
         return redirect(reverse('dashboard'))


### PR DESCRIPTION
This is an enhancement to #1913 as a result of #1924.  It checks to make sure that your certificate information is available before redirecting the user to the ssl login.  As an important note, it converts the _ssl_get_cert_from_request to ssl_get_cert_from_request, and if merged before #1862 will require that PR to be rebased.

@sarina @ichuang @singingwolfboy
