### PR TITLE
set default value for empty integer and float fields

### DIFF
--- a/cms/static/coffee/spec/views/metadata_edit_spec.coffee
+++ b/cms/static/coffee/spec/views/metadata_edit_spec.coffee
@@ -49,7 +49,7 @@ define ["js/models/metadata", "js/collections/metadata", "js/views/metadata", "c
       }
 
       integerEntry = {
-          default_value: 5,
+          default_value: 6,
           display_name: "Inputs",
           explicitly_set: false,
           field_name: "num_inputs",
@@ -247,6 +247,11 @@ define ["js/models/metadata", "js/collections/metadata", "js/views/metadata", "c
               expect(@view.getValueFromEditor()).toBe('always')
 
       describe "MetadataView.Number supports integer or float type and has clear functionality", ->
+          verifyValueAfterChanged = (view, value, expectedResult) ->
+              view.setValueInEditor(value)
+              view.changed()
+              expect(view.getValueFromEditor()).toBe(expectedResult)
+
           beforeEach ->
               integerModel = new MetadataModel(integerEntry)
               @integerView = new MetadataView.Number({model: integerModel})
@@ -267,7 +272,7 @@ define ["js/models/metadata", "js/collections/metadata", "js/views/metadata", "c
               assertCanUpdateView(@floatView, "-2.4")
 
           it "has a clear method to revert to the model default", ->
-              assertClear(@integerView, 5, '5')
+              assertClear(@integerView, 6, '6')
               assertClear(@floatView, 2.7, '2.7')
 
           it "has an update model method", ->
@@ -290,11 +295,6 @@ define ["js/models/metadata", "js/collections/metadata", "js/views/metadata", "c
               verifyAttributes(@floatView, 1.3, .1, 100.2)
 
           it "corrects values that are out of range", ->
-              verifyValueAfterChanged = (view, value, expectedResult) ->
-                  view.setValueInEditor(value)
-                  view.changed()
-                  expect(view.getValueFromEditor()).toBe(expectedResult)
-
               verifyValueAfterChanged(@integerView, '-4', '1')
               verifyValueAfterChanged(@integerView, '1', '1')
               verifyValueAfterChanged(@integerView, '0', '1')
@@ -305,6 +305,10 @@ define ["js/models/metadata", "js/collections/metadata", "js/views/metadata", "c
               verifyValueAfterChanged(@floatView, '1.2', '1.3')
               verifyValueAfterChanged(@floatView, '100.2', '100.2')
               verifyValueAfterChanged(@floatView, '100.3', '100.2')
+
+          it "sets default values for integer and float fields that are empty", ->
+              verifyValueAfterChanged(@integerView, '', '6')
+              verifyValueAfterChanged(@floatView, '', '2.7')
 
           it "disallows invalid characters", ->
               verifyValueAfterKeyPressed = (view, character, reject) ->

--- a/cms/static/js/views/metadata.js
+++ b/cms/static/js/views/metadata.js
@@ -189,14 +189,19 @@ function(Backbone, _, MetadataModel, AbstractEditor, VideoList) {
 
         changed: function () {
             // Limit value to the range specified by min and max (necessary for browsers that aren't using polyfill).
+            // Prevent integer/float fields value to be empty (set them to their defaults)
             var value = this.getValueFromEditor();
-            if ((this.max !== undefined) && value > this.max) {
-                value = this.max;
-            } else if ((this.min != undefined) && value < this.min) {
-                value = this.min;
+            if (value) {
+                if ((this.max !== undefined) && value > this.max) {
+                    value = this.max;
+                } else if ((this.min != undefined) && value < this.min) {
+                    value = this.min;
+                }
+                this.setValueInEditor(value);
+                this.updateModel();
+            } else {
+                this.clear();
             }
-            this.setValueInEditor(value);
-            this.updateModel();
         }
 
     });


### PR DESCRIPTION
STUD-894

@cahrens @polesye
When deleting float/integer field values in Studio, set Model value to default value of that field.
