### PR TITLE
Add ignore patterns for staticfiles to avoid processing symlink dirs

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -310,6 +310,10 @@ STATICFILES_IGNORE_PATTERNS = (
     "coffee/*/*.coffee",
     "coffee/*/*/*.coffee",
     "coffee/*/*/*/*.coffee",
+
+    # Symlinks used by js-test-tool
+    "xmodule_js",
+    "common_static",
 )
 
 PIPELINE_YUI_BINARY = 'yui-compressor'

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -817,6 +817,10 @@ PIPELINE_JS_COMPRESSOR = None
 STATICFILES_IGNORE_PATTERNS = (
     "sass/*",
     "coffee/*",
+
+    # Symlinks used by js-test-tool
+    "xmodule_js",
+    "common_static",
 )
 
 PIPELINE_YUI_BINARY = 'yui-compressor'


### PR DESCRIPTION
For complicated reasons, js-test-tool requires that we create symlinks in edx-platform for JavaScript dependencies.  These symlinks were being followed when Django collected staticfiles, resulting in staticfiles being collected multiple times.

This PR adds the symlinks to `STATICFILES_IGNORE_PATTERNS` to skip those directories, which should speed up asset collection (especially on the Vagrant images, where disk writes to shared directories are expensive).

Ideally we wouldn't have to use symlinks at all, but that's a task for another day :)

Suggested reviewers: @cpennington @singingwolfboy 
