### PR TITLE
Mention " vs. ' syntax in help text

### DIFF
--- a/cms/templates/settings_advanced.html
+++ b/cms/templates/settings_advanced.html
@@ -64,7 +64,7 @@ require(["domReady!", "jquery", "js/models/settings/advanced", "js/views/setting
         <section class="group-settings advanced-policies">
           <header>
             <h2 class="title-2">${_("Manual Policy Definition")}</h2>
-            <span class="tip">${_("Manually Edit Course Policy Values (JSON Key / Value pairs)")}</span>
+            <span class="tip">${_("Manually Edit Course Policy Values (JSON Key / Value pairs, use &quot; not &apos;)")}</span>
           </header>
 
           <p class="instructions">${_("<strong>Warning</strong>: Do not modify these policies unless you are familiar with their purpose.")}</p>


### PR DESCRIPTION
Hey @cahrens -- as we discussed

I figure if we ever get around to making real user-syntax-error feedback, then we can shrink the help text, but for now it's better to just hang it out there.
