### PR TITLE
Workaround for "xhr.restore" failures.

### DIFF
--- a/cms/static/coffee/spec/main.coffee
+++ b/cms/static/coffee/spec/main.coffee
@@ -41,9 +41,10 @@ requirejs.config({
 
         "mathjax": "//edx-static.s3.amazonaws.com/mathjax-MathJax-727332c/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&delayStartupUntil=configured",
         "youtube": "//www.youtube.com/player_api?noext",
-        "tender": "//edxedge.tenderapp.com/tender_widget"
+        "tender": "//edxedge.tenderapp.com/tender_widget",
 
-        "coffee/src/ajax_prefix": "xmodule_js/common_static/coffee/src/ajax_prefix"
+        "coffee/src/ajax_prefix": "xmodule_js/common_static/coffee/src/ajax_prefix",
+        "js/spec/test_utils": "js/spec/test_utils",
     }
     shim: {
         "gettext": {

--- a/cms/static/coffee/spec/main_spec.coffee
+++ b/cms/static/coffee/spec/main_spec.coffee
@@ -1,5 +1,5 @@
-require ["jquery", "backbone", "coffee/src/main", "sinon", "jasmine-stealth", "jquery.cookie"],
-($, Backbone, main, sinon) ->
+require ["jquery", "backbone", "coffee/src/main", "js/spec/create_sinon", "jasmine-stealth", "jquery.cookie"],
+($, Backbone, main, create_sinon) ->
     describe "CMS", ->
         it "should initialize URL", ->
             expect(window.CMS.URL).toBeDefined()
@@ -26,30 +26,30 @@ require ["jquery", "backbone", "coffee/src/main", "sinon", "jasmine-stealth", "j
         beforeEach ->
             setFixtures($("<script>", {id: "system-feedback-tpl", type: "text/template"}).text(tpl))
             appendSetFixtures(sandbox({id: "page-notification"}))
-            @requests = requests = []
-            @xhr = sinon.useFakeXMLHttpRequest()
-            @xhr.onCreate = (xhr) -> requests.push(xhr)
-
-        afterEach ->
-            @xhr.restore()
 
         it "successful AJAX request does not pop an error notification", ->
+            server = create_sinon['server'](200, this)
+
             expect($("#page-notification")).toBeEmpty()
             $.ajax("/test")
             expect($("#page-notification")).toBeEmpty()
-            @requests[0].respond(200)
+            server.respond()
             expect($("#page-notification")).toBeEmpty()
 
         it "AJAX request with error should pop an error notification", ->
+            server = create_sinon['server'](500, this)
+
             $.ajax("/test")
-            @requests[0].respond(500)
+            server.respond()
             expect($("#page-notification")).not.toBeEmpty()
             expect($("#page-notification")).toContain('div.wrapper-notification-error')
 
         it "can override AJAX request with error so it does not pop an error notification", ->
+            server = create_sinon['server'](500, this)
+
             $.ajax
                 url: "/test"
                 notifyOnError: false
-            @requests[0].respond(500)
-            expect($("#page-notification")).toBeEmpty()
 
+            server.respond()
+            expect($("#page-notification")).toBeEmpty()

--- a/cms/static/coffee/spec/models/section_spec.coffee
+++ b/cms/static/coffee/spec/models/section_spec.coffee
@@ -1,4 +1,4 @@
-define ["js/models/section", "sinon", "js/utils/module"], (Section, sinon, ModuleUtils) ->
+define ["js/models/section", "js/spec/create_sinon", "js/utils/module"], (Section, create_sinon, ModuleUtils) ->
     describe "Section", ->
         describe "basic", ->
             beforeEach ->
@@ -32,21 +32,19 @@ define ["js/models/section", "sinon", "js/utils/module"], (Section, sinon, Modul
                     id: 42
                     name: "Life, the Universe, and Everything"
                 })
-                @requests = requests = []
-                @xhr = sinon.useFakeXMLHttpRequest()
-                @xhr.onCreate = (xhr) -> requests.push(xhr)
-
-            afterEach ->
-                @xhr.restore()
 
             it "show/hide a notification when it saves to the server", ->
+                server = create_sinon['server'](200, this)
+
                 @model.save()
                 expect(Section.prototype.showNotification).toHaveBeenCalled()
-                @requests[0].respond(200)
+                server.respond()
                 expect(Section.prototype.hideNotification).toHaveBeenCalled()
 
             it "don't hide notification when saving fails", ->
                 # this is handled by the global AJAX error handler
+                server = create_sinon['server'](500, this)
+
                 @model.save()
-                @requests[0].respond(500)
+                server.respond()
                 expect(Section.prototype.hideNotification).not.toHaveBeenCalled()

--- a/cms/static/coffee/spec/views/section_spec.coffee
+++ b/cms/static/coffee/spec/views/section_spec.coffee
@@ -1,4 +1,4 @@
-define ["js/models/section", "js/views/section_show", "js/views/section_edit", "sinon"], (Section, SectionShow, SectionEdit, sinon) ->
+define ["js/models/section", "js/views/section_show", "js/views/section_edit", "js/spec/create_sinon"], (Section, SectionShow, SectionEdit, create_sinon) ->
 
     describe "SectionShow", ->
         describe "Basic", ->
@@ -39,9 +39,6 @@ define ["js/models/section", "js/views/section_show", "js/views/section_edit", "
                     .andCallThrough()
                 window.analytics = jasmine.createSpyObj('analytics', ['track'])
                 window.course_location_analytics = jasmine.createSpy()
-                @requests = requests = []
-                @xhr = sinon.useFakeXMLHttpRequest()
-                @xhr.onCreate = (xhr) -> requests.push(xhr)
 
                 @model = new Section({
                     id: 42
@@ -51,7 +48,6 @@ define ["js/models/section", "js/views/section_show", "js/views/section_edit", "
                 @view.render()
 
             afterEach ->
-                @xhr.restore()
                 delete window.analytics
                 delete window.course_location_analytics
 
@@ -68,8 +64,10 @@ define ["js/models/section", "js/views/section_show", "js/views/section_edit", "
                 expect(@model.save).toHaveBeenCalled()
 
             it "should call switchToShowView when save() is successful", ->
+                requests = create_sinon["requests"](this)
+
                 @view.$("input[type=submit]").click()
-                @requests[0].respond(200)
+                requests[0].respond(200)
                 expect(@view.switchToShowView).toHaveBeenCalled()
 
             it "should call showInvalidMessage when validation is unsuccessful", ->

--- a/cms/static/coffee/spec/views/upload_spec.coffee
+++ b/cms/static/coffee/spec/views/upload_spec.coffee
@@ -1,4 +1,4 @@
-define ["js/models/uploads", "js/views/uploads", "js/models/chapter", "sinon"], (FileUpload, UploadDialog, Chapter, sinon) ->
+define ["js/models/uploads", "js/views/uploads", "js/models/chapter", "js/spec/create_sinon"], (FileUpload, UploadDialog, Chapter, create_sinon) ->
 
     feedbackTpl = readFixtures('system-feedback.underscore')
 
@@ -78,20 +78,18 @@ define ["js/models/uploads", "js/views/uploads", "js/models/chapter", "sinon"], 
 
         describe "Uploads", ->
             beforeEach ->
-                @requests = requests = []
-                @xhr = sinon.useFakeXMLHttpRequest()
-                @xhr.onCreate = (xhr) -> requests.push(xhr)
                 @clock = sinon.useFakeTimers()
 
             afterEach ->
-                @xhr.restore()
                 @clock.restore()
 
             it "can upload correctly", ->
+                requests = create_sinon["requests"](this)
+
                 @view.upload()
                 expect(@model.get("uploading")).toBeTruthy()
-                expect(@requests.length).toEqual(1)
-                request = @requests[0]
+                expect(requests.length).toEqual(1)
+                request = requests[0]
                 expect(request.url).toEqual("/upload")
                 expect(request.method).toEqual("POST")
 
@@ -102,14 +100,18 @@ define ["js/models/uploads", "js/views/uploads", "js/models/chapter", "sinon"], 
                 expect(@dialogResponse.pop()).toEqual("dummy_response")
 
             it "can handle upload errors", ->
+                requests = create_sinon["requests"](this)
+
                 @view.upload()
-                @requests[0].respond(500)
+                requests[0].respond(500)
                 expect(@model.get("title")).toMatch(/error/)
                 expect(@view.remove).not.toHaveBeenCalled()
 
             it "removes itself after two seconds on successful upload", ->
+                requests = create_sinon["requests"](this)
+
                 @view.upload()
-                @requests[0].respond(200, {"Content-Type": "application/json"},
+                requests[0].respond(200, {"Content-Type": "application/json"},
                         '{"response": "dummy_response"}')
                 expect(@view.remove).not.toHaveBeenCalled()
                 @clock.tick(2001)

--- a/cms/static/js/spec/create_sinon.js
+++ b/cms/static/js/spec/create_sinon.js
@@ -1,4 +1,20 @@
 define(["sinon"], function(sinon) {
+    /* These utility methods are used by Jasmine tests to create a mock server or
+     * get reference to mock requests. In either case, the cleanup (restore) is done with
+     * an after function.
+     *
+     * This pattern is being used instead of the more common beforeEach/afterEach pattern
+     * because we were seeing sporadic failures in the afterEach restore call. The cause of the
+     * errors were that one test suite was incorrectly being linked as the parent of an unrelated
+     * test suite (causing both suites' afterEach methods to be called). No solution for the root
+     * cause has been found, but initializing sinon and cleaning it up on a method-by-method
+     * basis seems to work. For more details, see STUD-1040.
+     */
+
+    /**
+     * Get a reference to the mocked server, and respond
+     * to all requests with the specified statusCode.
+     */
     var fakeServer = function (statusCode, that) {
         var server = sinon.fakeServer.create();
         that.after(function() {
@@ -8,6 +24,11 @@ define(["sinon"], function(sinon) {
         return server;
     };
 
+    /**
+     * Keep track of all requests to a fake server, and
+     * return a reference to the Array. This allows tests
+     * to respond for individual requests.
+     */
     var fakeRequests = function (that) {
         var requests = [];
         var xhr = sinon.useFakeXMLHttpRequest();

--- a/cms/static/js/spec/create_sinon.js
+++ b/cms/static/js/spec/create_sinon.js
@@ -1,0 +1,29 @@
+define(["sinon"], function(sinon) {
+    var fakeServer = function (statusCode, that) {
+        var server = sinon.fakeServer.create();
+        that.after(function() {
+            server.restore();
+        });
+        server.respondWith([statusCode, {}, '']);
+        return server;
+    };
+
+    var fakeRequests = function (that) {
+        var requests = [];
+        var xhr = sinon.useFakeXMLHttpRequest();
+        xhr.onCreate = function(request) {
+            requests.push(request)
+        };
+
+        that.after(function() {
+            xhr.restore();
+        });
+
+        return requests;
+    };
+
+    return {
+        "server": fakeServer,
+        "requests": fakeRequests
+    };
+});

--- a/rakelib/js_test.rake
+++ b/rakelib/js_test.rake
@@ -1,7 +1,7 @@
 JS_TEST_SUITES = {
     'lms' => 'lms/static/js_test.yml',
     'cms' => 'cms/static/js_test.yml',
-    # 'cms-squire' => 'cms/static/js_test_squire.yml',
+    'cms-squire' => 'cms/static/js_test_squire.yml',
     'xmodule' => 'common/lib/xmodule/xmodule/js/js_test.yml',
     'common' => 'common/static/js_test.yml',
 }


### PR DESCRIPTION
STUD-1040

@wedaly and @singingwolfboy Please review.

Add ?w=1 to review (especially for course_info_spec).

This also enables the assets_spec test-- for some reason, the special "squire" test runner was commented out.

Note that this does not fix the underlying problem of one suite becoming the "parent" of another. However, it prevents multiple cleanup operations from happening. I will write extensive notes in the Jira ticket itself.
