### PR TITLE
Added rake commands for devstack

### DIFF
--- a/rakelib/devstack.rake
+++ b/rakelib/devstack.rake
@@ -1,0 +1,47 @@
+DEVSTACK_PORTS = {
+    "lms" => '8000',
+    "studio" => '8001'
+}
+
+# Abort if system is not one we recognize
+def check_devstack_sys(sys_name)
+    if not DEVSTACK_PORTS.has_key?(sys_name)
+        puts "Devstack system must be either 'lms' or 'studio'"
+        exit 1
+    end
+end
+
+# Convert "studio" to "cms"
+def old_system(sys_name)
+    if sys_name == "studio"
+        return "cms"
+    else
+        return sys_name
+    end
+end
+
+namespace :devstack do
+
+    desc "Start the server"
+    task :start, [:system] do |t, args|
+        check_devstack_sys(args.system)
+        port = DEVSTACK_PORTS[args.system]
+        sys = old_system(args.system)
+        sh("./manage.py #{sys} runserver --settings=devstack 0.0.0.0:#{port}")
+    end
+
+    desc "Update static assets"
+    task :assets, [:system] do |t, args|
+        check_devstack_sys(args.system)
+        Rake::Task["assets"].invoke(old_system(args.system), 'devstack')
+    end
+
+    desc "Update Python, Ruby, and Node requirements"
+    task :install => [:install_prereqs]
+end
+
+
+desc "Start the devstack lms or studio server"
+task :devstack, [:system] => ['devstack:install', 'devstack:assets'] do |t, args|
+    Rake::Task['devstack:start'].invoke(args.system)
+end


### PR DESCRIPTION
An attempt to simplify running LMS/Studio in the devstack vagrant image.

```
# Start LMS/Studio (including asset collection and installing prereqs)
rake devstack[lms]
rake devstack[studio]

# Start LMS/Studio skipping asset collection/prereqs
rake devstack:start[lms]
rake devstack:start[studio]
```

Some of the controversial decisions:
- Replacing "cms" with "studio", for consistency with the rest of the devstack documentation.
- Not using Sass watchers, on the assumption that the design team prefers custom tools like CodeKit

Currently, prereq installation is disabled in devstack by an environment variable.  I've put in a PR to change this:
https://github.com/edx/configuration/pull/548  Until then, you'll need to `unset NO_PREREQ_INSTALL` so that prereqs get installed.

Suggested reviewers:

@cpennington for rake file sanity checks
@flowerhack since you asked for simpler devstack commands :) 
