### PR TITLE
Switch to django.contrib.staticfiles

### DIFF
--- a/cms/envs/acceptance.py
+++ b/cms/envs/acceptance.py
@@ -81,9 +81,8 @@ DATABASES = {
 }
 
 # Enable asset pipeline
-# Our fork of django-pipeline uses `PIPELINE` instead of `PIPELINE_ENABLED`
 # PipelineFinder is explained here: http://django-pipeline.readthedocs.org/en/1.1.24/storages.html
-PIPELINE = True
+PIPELINE_ENABLED = True
 STATICFILES_FINDERS += ('pipeline.finders.PipelineFinder', )
 
 # Use the auto_auth workflow for creating users and logging them in

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -134,8 +134,8 @@ XQUEUE_INTERFACE = {
 # List of finder classes that know how to find static files in
 # various locations.
 STATICFILES_FINDERS = (
-    'staticfiles.finders.FileSystemFinder',
-    'staticfiles.finders.AppDirectoriesFinder',
+    'django.contrib.staticfiles.finders.FileSystemFinder',
+    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
     'pipeline.finders.PipelineFinder',
 )
 
@@ -404,7 +404,7 @@ INSTALLED_APPS = (
     # For asset pipelining
     'edxmako',
     'pipeline',
-    'staticfiles',
+    'django.contrib.staticfiles',
     'static_replace',
 
     # comment common

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -37,8 +37,6 @@ from dealer.git import git
 ############################ FEATURE CONFIGURATION #############################
 
 FEATURES = {
-    'USE_DJANGO_PIPELINE': True,
-
     'GITHUB_PUSH': False,
 
     'ENABLE_DISCUSSION_SERVICE': False,
@@ -243,6 +241,7 @@ MESSAGE_STORAGE = 'django.contrib.messages.storage.session.SessionStorage'
 ############################### Pipeline #######################################
 
 STATICFILES_STORAGE = 'pipeline.storage.PipelineCachedStorage'
+PIPELINE_ENABLED = True
 
 from rooted_paths import rooted_glob
 

--- a/cms/envs/dev_ike.py
+++ b/cms/envs/dev_ike.py
@@ -11,6 +11,6 @@ from .dev import *
 
 FEATURES['AUTH_USE_MIT_CERTIFICATES'] = True
 
-FEATURES['USE_DJANGO_PIPELINE'] = False      # don't recompile scss
+PIPELINE_ENABLED = False  # don't recompile scss
 
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTOCOL', 'https')  	# django 1.4 for nginx ssl proxy

--- a/common/djangoapps/pipeline_js/views.py
+++ b/common/djangoapps/pipeline_js/views.py
@@ -4,7 +4,7 @@ Views for returning XModule JS (used by requirejs)
 import json
 from django.conf import settings
 from django.http import HttpResponse
-from staticfiles.storage import staticfiles_storage
+from django.contrib.staticfiles.storage import staticfiles_storage
 from edxmako.shortcuts import render_to_response
 
 

--- a/common/djangoapps/pipeline_mako/__init__.py
+++ b/common/djangoapps/pipeline_mako/__init__.py
@@ -14,7 +14,7 @@ def compressed_css(package_name):
 
     package = packager.package_for('css', package_name)
 
-    if settings.PIPELINE:
+    if getattr(settings, "PIPELINE_ENABLED", False):
         return render_css(package, package.output_filename)
     else:
         paths = packager.compile(package.paths)
@@ -46,7 +46,7 @@ def compressed_js(package_name):
 
     package = packager.package_for('js', package_name)
 
-    if settings.PIPELINE:
+    if getattr(settings, "PIPELINE_ENABLED", False):
         return render_js(package, package.output_filename)
     else:
         paths = packager.compile(package.paths)

--- a/common/djangoapps/pipeline_mako/templates/static_content.html
+++ b/common/djangoapps/pipeline_mako/templates/static_content.html
@@ -11,7 +11,7 @@ except:
 %>${url}</%def>
 
 <%def name='css(group)'>
-  % if settings.FEATURES['USE_DJANGO_PIPELINE']:
+  % if getattr(settings, "PIPELINE_ENABLED", False):
     ${compressed_css(group)}
   % else:
     % for filename in settings.PIPELINE_CSS[group]['source_filenames']:
@@ -20,7 +20,7 @@ except:
   %endif
 </%def>
 <%def name='js(group)'>
-  % if settings.FEATURES['USE_DJANGO_PIPELINE']:
+  % if getattr(settings, "PIPELINE_ENABLED", False):
     ${compressed_js(group)}
   % else:
     % for filename in settings.PIPELINE_JS[group]['source_filenames']:

--- a/common/djangoapps/pipeline_mako/templates/static_content.html
+++ b/common/djangoapps/pipeline_mako/templates/static_content.html
@@ -1,5 +1,5 @@
 <%!
-from staticfiles.storage import staticfiles_storage
+from django.contrib.staticfiles.storage import staticfiles_storage
 from pipeline_mako import compressed_css, compressed_js
 %>
 

--- a/common/djangoapps/static_replace/__init__.py
+++ b/common/djangoapps/static_replace/__init__.py
@@ -1,8 +1,8 @@
 import logging
 import re
 
-from staticfiles.storage import staticfiles_storage
-from staticfiles import finders
+from django.contrib.staticfiles.storage import staticfiles_storage
+from django.contrib.staticfiles import finders
 from django.conf import settings
 
 from xmodule.modulestore.django import modulestore

--- a/common/djangoapps/terrain/browser.py
+++ b/common/djangoapps/terrain/browser.py
@@ -20,22 +20,6 @@ from pymongo import MongoClient
 import xmodule.modulestore.django
 from xmodule.contentstore.django import _CONTENTSTORE
 
-# There is an import issue when using django-staticfiles with lettuce
-# Lettuce assumes that we are using django.contrib.staticfiles,
-# but the rest of the app assumes we are using django-staticfiles
-# (in particular, django-pipeline and our mako implementation)
-# To resolve this, we check whether staticfiles is installed,
-# then redirect imports for django.contrib.staticfiles
-# to use staticfiles.
-try:
-    import staticfiles
-    import staticfiles.handlers
-except ImportError:
-    pass
-else:
-    import sys
-    sys.modules['django.contrib.staticfiles'] = staticfiles
-    sys.modules['django.contrib.staticfiles.handlers'] = staticfiles.handlers
 
 LOGGER = getLogger(__name__)
 LOGGER.info("Loading the lettuce acceptance testing terrain file...")

--- a/lms/envs/acceptance.py
+++ b/lms/envs/acceptance.py
@@ -84,9 +84,8 @@ TRACKING_BACKENDS.update({
 
 
 # Enable asset pipeline
-# Our fork of django-pipeline uses `PIPELINE` instead of `PIPELINE_ENABLED`
-# PipelineFinder is explained here: http://django-pipeline.readthedocs.org/en/1.1.24/storages.html
-PIPELINE = True
+# PipelineFinder is explained here: http://django-pipeline.readthedocs.org/en/1.3.16/storages.html
+PIPELINE_ENABLED = True
 STATICFILES_FINDERS += ('pipeline.finders.PipelineFinder', )
 
 BULK_EMAIL_DEFAULT_FROM_EMAIL = "test@test.org"

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -52,7 +52,6 @@ DISCUSSION_SETTINGS = {
 # Features
 FEATURES = {
     'SAMPLE': False,
-    'USE_DJANGO_PIPELINE': True,
     'DISPLAY_HISTOGRAMS_TO_STAFF': True,
     'REROUTE_ACTIVATION_EMAIL': False,  # nonempty string = address for all activation emails
     'DEBUG_LEVEL': 0,  # 0 = lowest level, least verbose, 255 = max level, most verbose
@@ -203,6 +202,7 @@ FEATURES = {
     # only edX superusers can perform the downloads)
     'ALLOW_COURSE_STAFF_GRADE_DOWNLOADS': False,
 }
+PIPELINE_ENABLED = True
 
 # Used for A/B testing
 DEFAULT_GROUPS = []

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -587,8 +587,8 @@ WAFFLE_MAX_AGE = 1209600
 # List of finder classes that know how to find static files in
 # various locations.
 STATICFILES_FINDERS = (
-    'staticfiles.finders.FileSystemFinder',
-    'staticfiles.finders.AppDirectoriesFinder',
+    'django.contrib.staticfiles.finders.FileSystemFinder',
+    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
     'pipeline.finders.PipelineFinder',
 )
 
@@ -936,7 +936,7 @@ INSTALLED_APPS = (
     # For asset pipelining
     'edxmako',
     'pipeline',
-    'staticfiles',
+    'django.contrib.staticfiles',
     'static_replace',
 
     # Our courseware

--- a/lms/envs/dev_ike.py
+++ b/lms/envs/dev_ike.py
@@ -24,13 +24,13 @@ FEATURES['SUBDOMAIN_BRANDING'] = False
 FEATURES['FORCE_UNIVERSITY_DOMAIN'] = None		# show all university courses if in dev (ie don't use HTTP_HOST)
 
 FEATURES['DISABLE_START_DATES'] = True
-# FEATURES['USE_DJANGO_PIPELINE']=False      # don't recompile scss
+# PIPELINE_ENABLED = False  # don't recompile scss
 
 myhost = socket.gethostname()
 if ('edxvm' in myhost) or ('ocw' in myhost):
     FEATURES['DISABLE_LOGIN_BUTTON'] = True  	# auto-login with MIT certificate
     FEATURES['USE_XQA_SERVER'] = 'https://qisx.mit.edu/xqa'  	# needs to be ssl or browser blocks it
-    FEATURES['USE_DJANGO_PIPELINE'] = False      # don't recompile scss
+    PIPELINE_ENABLED = False  # don't recompile scss
 
 if ('ocw' in myhost):
     FEATURES['ACCESS_REQUIRE_STAFF_FOR_COURSE'] = False
@@ -38,7 +38,7 @@ if ('ocw' in myhost):
 if ('domU' in myhost):
     EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
     FEATURES['REROUTE_ACTIVATION_EMAIL'] = 'ichuang@edX.mit.edu'  	# nonempty string = address for all activation emails
-    FEATURES['USE_DJANGO_PIPELINE'] = False      # don't recompile scss
+    PIPELINE_ENABLED = False  # don't recompile scss
 
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTOCOL', 'https')  	# django 1.4 for nginx ssl proxy
 

--- a/lms/envs/devplus.py
+++ b/lms/envs/devplus.py
@@ -73,4 +73,4 @@ DEBUG_TOOLBAR_PANELS = (
   'debug_toolbar.panels.profiling.ProfilingDebugPanel',
 )
 
-#PIPELINE = True
+#PIPELINE_ENABLED = True

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -25,6 +25,7 @@ django-model-utils==1.4.0
 django-masquerade==0.1.6
 django-mptt==0.5.5
 django-openid-auth==0.4
+django-pipeline==1.3.19
 django-robots==0.9.1
 django-sekizai==0.6.1
 django-ses==0.4.1

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -7,8 +7,6 @@
 # Python libraries to install directly from github
 
 # Third-party:
--e git+https://github.com/edx/django-staticfiles.git@d89aae2a82f2b#egg=django-staticfiles
--e git+https://github.com/edx/django-pipeline.git@88ec8a011e481918fdc9d2682d4017c835acd8be#egg=django-pipeline
 -e git+https://github.com/edx/django-wiki.git@41815e2ef1b0323f92900f8e60711b0f0c37766b#egg=django-wiki
 -e git+https://github.com/edx/lettuce.git@503fe2d2599290c45b021d6c424ab5ea899e42be#egg=lettuce
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev


### PR DESCRIPTION
This allows us to pull in new features and bugfixes from the mainline of development for both `django.contrib.staticfiles` and `django-pipeline`, rather than using [our](https://github.com/edx/django-staticfiles) [forks](https://github.com/edx/django-pipeline) of these projects.

This PR was inspired by #1889 -- which would not have broken the build if we were using `django.contrib.staticfiles`. The bug that bit us [was caught and fixed by the Django development team a year ago](https://github.com/django/django/commit/1aa0d8ac4d3149fad6ebe80834d9e6f83021cf55).
