### PR TITLE
Remove dot from a scenario name so the results roll up in Jenkins

### DIFF
--- a/lms/djangoapps/courseware/features/certificates.feature
+++ b/lms/djangoapps/courseware/features/certificates.feature
@@ -75,7 +75,7 @@ Feature: LMS.Verified certificates
         Then I should see the course on my dashboard
         And a "edx.course.enrollment.activated" server event is emitted
 
-    Scenario: The upsell offer is on the dashboard if I am auditing.
+    Scenario: The upsell offer is on the dashboard if I am auditing
         Given I am logged in
         When I select the audit track
         And I navigate to my dashboard


### PR DESCRIPTION
@dianakhuang @wedaly 
The dot was causing this scenario's results to not roll up into the "LMS" results.
E.g. see https://jenkins.testeng.edx.org/job/edx-all-tests-auto-pr/2760/SHARD=2,TEST_SUITE=lms-acceptance/testReport/?
