### PR TITLE
Fixes and improvement to LTI.

### DIFF
--- a/common/lib/xmodule/xmodule/tests/test_lti_unit.py
+++ b/common/lib/xmodule/xmodule/tests/test_lti_unit.py
@@ -99,7 +99,8 @@ class LTIModuleTest(LogicTest):
             'action': action
         }
 
-    def test_authorization_header_not_present(self):
+    @patch('xmodule.lti_module.LTIModule.get_client_key_secret', return_value=('test_client_key', u'test_client_secret'))
+    def test_authorization_header_not_present(self, get_key_secret):
         """
         Request has no Authorization header.
 
@@ -112,14 +113,15 @@ class LTIModuleTest(LogicTest):
         expected_response = {
             'action': None,
             'code_major': 'failure',
-            'description': 'OAuth verification error.',
+            'description': 'OAuth verification error: Malformed authorization header',
             'messageIdentifier': self.DEFAULTS['messageIdentifier'],
         }
 
         self.assertEqual(response.status_code, 200)
         self.assertDictEqual(expected_response, real_response)
 
-    def test_authorization_header_empty(self):
+    @patch('xmodule.lti_module.LTIModule.get_client_key_secret', return_value=('test_client_key', u'test_client_secret'))
+    def test_authorization_header_empty(self, get_key_secret):
         """
         Request Authorization header has no value.
 
@@ -133,7 +135,7 @@ class LTIModuleTest(LogicTest):
         expected_response = {
             'action': None,
             'code_major': 'failure',
-            'description': 'OAuth verification error.',
+            'description': 'OAuth verification error: Malformed authorization header',
             'messageIdentifier': self.DEFAULTS['messageIdentifier'],
         }
         self.assertEqual(response.status_code, 200)
@@ -171,7 +173,7 @@ class LTIModuleTest(LogicTest):
         expected_response = {
             'action': None,
             'code_major': 'failure',
-            'description': 'Request body XML parsing error.',
+            'description': 'Request body XML parsing error: score value outside the permitted range of 0-1.',
             'messageIdentifier': 'unknown',
         }
         self.assertEqual(response.status_code, 200)
@@ -189,7 +191,7 @@ class LTIModuleTest(LogicTest):
         expected_response = {
             'action': None,
             'code_major': 'failure',
-            'description': 'Request body XML parsing error.',
+            'description': 'Request body XML parsing error: invalid literal for float(): 0,5',
             'messageIdentifier': 'unknown',
         }
         self.assertEqual(response.status_code, 200)

--- a/lms/djangoapps/courseware/features/lti_setup.py
+++ b/lms/djangoapps/courseware/features/lti_setup.py
@@ -36,9 +36,8 @@ def setup_mock_lti_server():
         'lti_endpoint': 'correct_lti_endpoint'
     }
 
-    # Flag for acceptance tests used for creating right callback_url and sending
-    # graded result. Used in MockLTIRequestHandler.
-    server.test_mode = True
+    # For testing on localhost make callback url using referer host.
+    server.real_callback_url_on = False
 
     # Store the server instance in lettuce's world
     # so that other steps can access it

--- a/lms/djangoapps/courseware/mock_lti_server/server_start.py
+++ b/lms/djangoapps/courseware/mock_lti_server/server_start.py
@@ -19,10 +19,10 @@ server.oauth_settings = {
     'lti_endpoint': 'correct_lti_endpoint'
 }
 server.server_host = server_host
+server.server_port = server_port
 
-# If in test mode mock lti server will make callback url using referer host.
-# Used in MockLTIRequestHandler when sending graded result.
-server.test_mode = True
+# For testing on localhost make callback url using referer host.
+server.use_real_callback_url = False
 
 try:
     server.serve_forever()

--- a/lms/djangoapps/courseware/mock_lti_server/test_mock_lti_server.py
+++ b/lms/djangoapps/courseware/mock_lti_server/test_mock_lti_server.py
@@ -36,6 +36,9 @@ class MockLTIServerTest(unittest.TestCase):
         #flag for creating right callback_url
         self.server.test_mode = True
 
+        self.server.server_host = server_host
+        self.server.server_port = server_port
+
         # Start the server in a separate daemon thread
         server_thread = threading.Thread(target=self.server.serve_forever)
         server_thread.daemon = True


### PR DESCRIPTION
1. Do not use SSL certificate verification when sending grade back to Tool Consumer.
2. Add better messaging to LTI.
3. Use protocol relative submit URL.

@auraz please review.
