### PR TITLE
script bombs if comments include unicode

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -97,20 +97,20 @@ def generate_table(commit_range, include_merge=False):
     """
     Return a string corresponding to a commit table to embed in Confluence
     """
-    header = "||Author||Summary||Commit||JIRA||Verified?||"
+    header = u"||Author||Summary||Commit||JIRA||Verified?||"
     commit_link = "[commit|https://github.com/edx/edx-platform/commit/{sha}]"
     rows = [header]
     cbe = commits_by_email(commit_range, include_merge)
     for email, commits in cbe.items():
         for i, commit in enumerate(commits):
-            rows.append("| {author} | {summary} | {commit} | {jira} | {verified} |".format(
+            rows.append(u"| {author} | {summary} | {commit} | {jira} | {verified} |".format(
                 author=email if i == 0 else "",
-                summary=commit.summary.replace("|", "\|").encode('ascii',errors='ignore'),
+                summary=commit.summary.replace("|", "\|"),
                 commit=commit_link.format(sha=commit.hexsha),
                 jira=", ".join(parse_ticket_references(commit.message)),
                 verified="",
             ))
-    return "\n".join(rows)
+    return u"\n".join(rows)
 
 
 def generate_email(commit_range, release_date=None):

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -105,7 +105,7 @@ def generate_table(commit_range, include_merge=False):
         for i, commit in enumerate(commits):
             rows.append("| {author} | {summary} | {commit} | {jira} | {verified} |".format(
                 author=email if i == 0 else "",
-                summary=commit.summary.replace("|", "\|"),
+                summary=commit.summary.replace("|", "\|").encode('ascii',errors='ignore'),
                 commit=commit_link.format(sha=commit.hexsha),
                 jira=", ".join(parse_ticket_references(commit.message)),
                 verified="",


### PR DESCRIPTION
@cpennington 

```
./scripts/release.py --previous 25958e87a2ee687ecd7d76e6a94739172714bc45 --current a78400a8d887aedc025aeb7d0490bcdf29be48e4 --date 2013-12-18
```

```
Traceback (most recent call last):
  File "./scripts/release.py", line 167, in <module>
    main()
  File "./scripts/release.py", line 164, in main
    print(generate_table(commit_range, include_merge=args.merge))
  File "./scripts/release.py", line 111, in generate_table
    verified="",
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2019' in position 25: ordinal not in range(128)


.encode('ascii',errors='ignore')
```
