### PR TITLE
Rebalance acceptance test shards

### DIFF
--- a/cms/djangoapps/contentstore/features/html-editor.feature
+++ b/cms/djangoapps/contentstore/features/html-editor.feature
@@ -1,4 +1,4 @@
-@shard_3
+@shard_2
 Feature: CMS.HTML Editor
   As a course author, I want to be able to create HTML blocks.
 

--- a/cms/djangoapps/contentstore/features/problem-editor.feature
+++ b/cms/djangoapps/contentstore/features/problem-editor.feature
@@ -1,4 +1,4 @@
-@shard_3
+@shard_1
 Feature: CMS.Problem Editor
   As a course author, I want to be able to create problems and edit their settings.
 

--- a/cms/djangoapps/contentstore/features/signup.feature
+++ b/cms/djangoapps/contentstore/features/signup.feature
@@ -1,4 +1,4 @@
-@shard_3
+@shard_2
 Feature: CMS.Sign in
   In order to use the edX content
   As a new user

--- a/cms/djangoapps/contentstore/features/static-pages.feature
+++ b/cms/djangoapps/contentstore/features/static-pages.feature
@@ -1,4 +1,4 @@
-@shard_3
+@shard_2
 Feature: CMS.Static Pages
     As a course author, I want to be able to add static pages
 

--- a/cms/djangoapps/contentstore/features/textbooks.feature
+++ b/cms/djangoapps/contentstore/features/textbooks.feature
@@ -1,4 +1,4 @@
-@shard_3
+@shard_2
 Feature: CMS.Textbooks
 
   Scenario: No textbooks

--- a/cms/djangoapps/contentstore/features/transcripts.feature
+++ b/cms/djangoapps/contentstore/features/transcripts.feature
@@ -1,5 +1,5 @@
 @shard_3
-Feature: Video Component Editor
+Feature: CMS.Transcripts
   As a course author, I want to be able to create video components.
 
     # For transcripts acceptance tests there are 3 available caption

--- a/cms/djangoapps/contentstore/features/upload.feature
+++ b/cms/djangoapps/contentstore/features/upload.feature
@@ -1,4 +1,4 @@
-@shard_3
+@shard_2
 Feature: CMS.Upload Files
     As a course author, I want to be able to upload files for my students
 


### PR DESCRIPTION
Enabling the transcript tests caused one of the shards to take much longer (7 minutes -> 26).  As a short-term fix, I've rebalanced the tests so that they are closer to even.

I also renamed the transcript test so its test results will be reported correctly.

@jzoldak 
