### PR TITLE
Fix 500 we're seeing on password reset confirm page

### DIFF
--- a/lms/templates/registration/password_reset_complete.html
+++ b/lms/templates/registration/password_reset_complete.html
@@ -1,5 +1,6 @@
 {% extends "main_django.html" %}
 {% load i18n %}
+{% load compressed %}
 {% load staticfiles %}
 
 <!DOCTYPE html>


### PR DESCRIPTION
Just a simple missing import on the mako template.  For you @jbau 

Tested in my dev environment: got the 500, added the line, reload, no more 500.
