### PR TITLE
Bug fixes related to unicode support in export workflow.

### DIFF
--- a/common/lib/xmodule/xmodule/poll_module.py
+++ b/common/lib/xmodule/xmodule/poll_module.py
@@ -182,13 +182,13 @@ class PollDescriptor(PollFields, MakoModuleDescriptor, XmlDescriptor):
 
     def definition_to_xml(self, resource_fs):
         """Return an xml element representing to this definition."""
-        poll_str = '<{tag_name}>{text}</{tag_name}>'.format(
+        poll_str = u'<{tag_name}>{text}</{tag_name}>'.format(
             tag_name=self._tag_name, text=self.question)
         xml_object = etree.fromstring(poll_str)
         xml_object.set('display_name', self.display_name)
 
         def add_child(xml_obj, answer):
-            child_str = '<{tag_name} id="{id}">{text}</{tag_name}>'.format(
+            child_str = u'<{tag_name} id="{id}">{text}</{tag_name}>'.format(
                 tag_name=self._child_tag_name, id=answer['id'],
                 text=answer['text'])
             child_node = etree.fromstring(child_str)

--- a/common/lib/xmodule/xmodule/xml_module.py
+++ b/common/lib/xmodule/xmodule/xml_module.py
@@ -387,7 +387,10 @@ class XmlDescriptor(XModuleDescriptor):
                 try:
                     xml_object.set(attr, val)
                 except Exception, e:
-                    logging.exception('Failed to serialize metadata attribute {0} with value {1}. This could mean data loss!!!  Exception: {2}'.format(attr, val, e))
+                    logging.exception(
+                        u'Failed to serialize metadata attribute %s with value %s in module %s. This could mean data loss!!! Exception: %s',
+                        attr, val, self.url_name, e
+                    )
                     pass
 
         for key, value in self.xml_attributes.items():

--- a/common/test/data/toy/chapter/poll_test.xml
+++ b/common/test/data/toy/chapter/poll_test.xml
@@ -1,6 +1,6 @@
 <sequential>
 	<poll_question name="T1_changemind_poll_foo" display_name="Change your answer" reset="false">
-        <p>Have you changed your mind?</p>
+        <p>Have you changed your mind? ’</p>
         <answer id="yes">Yes</answer>
         <answer id="no">No</answer>
     </poll_question>


### PR DESCRIPTION
This fixes 2 issues sited in STUD-868:

1) poll_module did not handle unicode characters in the answer text. I modified the toy course so that existing "roundtrip" export tests cover this fix.

2) Fix the logging exception message that is currently breaking UT.2.01x.

@adampalay @singingwolfboy Please review.

@zubair-arbi This bug may also interest you.
