### PR TITLE
Support non-ascii chars as arguments to format.

### DIFF
--- a/common/lib/xmodule/xmodule/conditional_module.py
+++ b/common/lib/xmodule/xmodule/conditional_module.py
@@ -241,7 +241,7 @@ class ConditionalDescriptor(ConditionalFields, SequenceDescriptor):
         for child in self.get_children():
             location = str(child.location)
             if location in self.show_tag_list:
-                show_str = '<{tag_name} sources="{sources}" />'.format(
+                show_str = u'<{tag_name} sources="{sources}" />'.format(
                     tag_name='show', sources=location)
                 xml_object.append(etree.fromstring(show_str))
             else:

--- a/common/lib/xmodule/xmodule/crowdsource_hinter.py
+++ b/common/lib/xmodule/xmodule/crowdsource_hinter.py
@@ -392,7 +392,7 @@ class CrowdsourceHinterDescriptor(CrowdsourceHinterFields, RawDescriptor):
             except Exception as e:
                 log.exception("Unable to load child when parsing CrowdsourceHinter. Continuing...")
                 if system.error_tracker is not None:
-                    system.error_tracker("ERROR: " + str(e))
+                    system.error_tracker(u"ERROR: {0}".format(e))
                 continue
         return {}, children
 

--- a/common/lib/xmodule/xmodule/gst_module.py
+++ b/common/lib/xmodule/xmodule/gst_module.py
@@ -218,13 +218,13 @@ class GraphicalSliderToolDescriptor(GraphicalSliderToolFields, XMLEditingDescrip
         expected_children_level_0 = ['render', 'configuration']
         for child in expected_children_level_0:
             if len(xml_object.xpath(child)) != 1:
-                raise ValueError("Graphical Slider Tool definition must include \
+                raise ValueError(u"Graphical Slider Tool definition must include \
                     exactly one '{0}' tag".format(child))
 
         expected_children_level_1 = ['functions']
         for child in expected_children_level_1:
             if len(xml_object.xpath('configuration')[0].xpath(child)) != 1:
-                raise ValueError("Graphical Slider Tool definition must include \
+                raise ValueError(u"Graphical Slider Tool definition must include \
                     exactly one '{0}' tag".format(child))
         # finished
 
@@ -234,7 +234,7 @@ class GraphicalSliderToolDescriptor(GraphicalSliderToolFields, XMLEditingDescrip
 
     def definition_to_xml(self, resource_fs):
         '''Return an xml element representing this definition.'''
-        data = '<{tag}>{body}</{tag}>'.format(
+        data = u'<{tag}>{body}</{tag}>'.format(
             tag='graphical_slider_tool',
             body=self.data)
         xml_object = etree.fromstring(data)

--- a/common/lib/xmodule/xmodule/open_ended_grading_classes/combined_open_ended_modulev1.py
+++ b/common/lib/xmodule/xmodule/open_ended_grading_classes/combined_open_ended_modulev1.py
@@ -1122,7 +1122,7 @@ class CombinedOpenEndedV1Descriptor():
             if len(xml_object.xpath(child)) == 0:
                 # This is a staff_facing_error
                 raise ValueError(
-                    "Combined Open Ended definition must include at least one '{0}' tag. Contact the learning sciences group for assistance. {1}".format(
+                    u"Combined Open Ended definition must include at least one '{0}' tag. Contact the learning sciences group for assistance. {1}".format(
                         child, xml_object))
 
         def parse_task(k):
@@ -1141,7 +1141,7 @@ class CombinedOpenEndedV1Descriptor():
         elt = etree.Element('combinedopenended')
 
         def add_child(k):
-            child_str = '<{tag}>{body}</{tag}>'.format(tag=k, body=self.definition[k])
+            child_str = u'<{tag}>{body}</{tag}>'.format(tag=k, body=self.definition[k])
             child_node = etree.fromstring(child_str)
             elt.append(child_node)
 

--- a/common/lib/xmodule/xmodule/open_ended_grading_classes/open_ended_module.py
+++ b/common/lib/xmodule/xmodule/open_ended_grading_classes/open_ended_module.py
@@ -804,7 +804,7 @@ class OpenEndedDescriptor():
             if len(xml_object.xpath(child)) != 1:
                 # This is a staff_facing_error
                 raise ValueError(
-                    "Open Ended definition must include exactly one '{0}' tag. Contact the learning sciences group for assistance.".format(
+                    u"Open Ended definition must include exactly one '{0}' tag. Contact the learning sciences group for assistance.".format(
                         child))
 
         def parse(k):
@@ -820,7 +820,7 @@ class OpenEndedDescriptor():
         elt = etree.Element('openended')
 
         def add_child(k):
-            child_str = '<{tag}>{body}</{tag}>'.format(tag=k, body=self.definition[k])
+            child_str = u'<{tag}>{body}</{tag}>'.format(tag=k, body=self.definition[k])
             child_node = etree.fromstring(child_str)
             elt.append(child_node)
 

--- a/common/lib/xmodule/xmodule/open_ended_grading_classes/self_assessment_module.py
+++ b/common/lib/xmodule/xmodule/open_ended_grading_classes/self_assessment_module.py
@@ -304,7 +304,7 @@ class SelfAssessmentDescriptor():
             if len(xml_object.xpath(child)) != 1:
                 # This is a staff_facing_error
                 raise ValueError(
-                    "Self assessment definition must include exactly one '{0}' tag. Contact the learning sciences group for assistance.".format(
+                    u"Self assessment definition must include exactly one '{0}' tag. Contact the learning sciences group for assistance.".format(
                         child))
 
         def parse(k):
@@ -318,7 +318,7 @@ class SelfAssessmentDescriptor():
         elt = etree.Element('selfassessment')
 
         def add_child(k):
-            child_str = '<{tag}>{body}</{tag}>'.format(tag=k, body=getattr(self, k))
+            child_str = u'<{tag}>{body}</{tag}>'.format(tag=k, body=getattr(self, k))
             child_node = etree.fromstring(child_str)
             elt.append(child_node)
 

--- a/common/lib/xmodule/xmodule/raw_module.py
+++ b/common/lib/xmodule/xmodule/raw_module.py
@@ -28,7 +28,7 @@ class RawDescriptor(XmlDescriptor, XMLEditingDescriptor):
             # re-raise
             lines = self.data.split('\n')
             line, offset = err.position
-            msg = ("Unable to create xml for module {loc}. "
+            msg = (u"Unable to create xml for module {loc}. "
                    "Context: '{context}'".format(
                    context=lines[line - 1][offset - 40:offset + 40],
                    loc=self.location))

--- a/common/lib/xmodule/xmodule/seq_module.py
+++ b/common/lib/xmodule/xmodule/seq_module.py
@@ -131,7 +131,7 @@ class SequenceDescriptor(SequenceFields, MakoModuleDescriptor, XmlDescriptor):
             except Exception as e:
                 log.exception("Unable to load child when parsing Sequence. Continuing...")
                 if system.error_tracker is not None:
-                    system.error_tracker("ERROR: " + unicode(e))
+                    system.error_tracker(u"ERROR: {0}".format(e))
                 continue
         return {}, children
 


### PR DESCRIPTION
We've had errors in export related to non-ascii chars being passed to format. Proactively making these usages of format robut to non-ascii chars.

Part of STUD-868
