### PR TITLE
Add base package to edxapp page object setup.py

### DIFF
--- a/common/test/bok_choy/setup.py
+++ b/common/test/bok_choy/setup.py
@@ -25,5 +25,5 @@ setup(
         'Topic :: Software Development :: Testing',
         'Topic :: Software Development :: Quality Assurance'
     ],
-    packages=['edxapp_pages.lms', 'edxapp_pages.studio']
+    packages=['edxapp_pages', 'edxapp_pages.lms', 'edxapp_pages.studio']
 )


### PR DESCRIPTION
I misunderstood how setup.py installs packages.  You need both the base package and the subpackages for this to be able to import `edxapp_pages.lms` and `edxapp_pages.studio`.

@jzoldak 
