### PR TITLE
Added missing slash to avoid 302 when calling /notification_prefs/status

### DIFF
--- a/common/static/coffee/src/discussion/utils.coffee
+++ b/common/static/coffee/src/discussion/utils.coffee
@@ -86,7 +86,7 @@ class @DiscussionUtil
       threads                 : "/courses/#{$$course_id}/discussion/forum"
       "enable_notifications"  : "/notification_prefs/enable/"
       "disable_notifications" : "/notification_prefs/disable/"
-      "notifications_status" : "/notification_prefs/status"
+      "notifications_status" : "/notification_prefs/status/"
     }[name]
 
   @activateOnEnter: (event, func) ->


### PR DESCRIPTION
The URL in urls.py has the missing slash.  I had a misconfigured proxy forwarded protocol header so it was breaking the discussion home page.
