### PR TITLE
Set the registry for node in prereqs

### DIFF
--- a/rakelib/prereqs.rake
+++ b/rakelib/prereqs.rake
@@ -1,4 +1,5 @@
 PREREQS_MD5_DIR = ENV["PREREQ_CACHE_DIR"] || File.join(REPO_ROOT, '.prereqs_cache')
+NPM_REGISTRY = "http://registry.npmjs.org/"
 
 CLOBBER.include(PREREQS_MD5_DIR)
 
@@ -11,6 +12,7 @@ desc "Install all node prerequisites for the lms and cms"
 task :install_node_prereqs => "ws:migrate" do
     unchanged = 'Node requirements unchanged, nothing to install'
     when_changed(unchanged, ['package.json']) do
+        sh("npm config set registry '#{NPM_REGISTRY}'")
         sh('npm install')
     end unless ENV['NO_PREREQ_INSTALL']
 end


### PR DESCRIPTION
I believe the recent build failures in Jenkins are caused by trying to install Node modules via HTTPS through a proxy.
http://stackoverflow.com/questions/11773509/npm-behind-a-proxy-fails-with-status-403

This change sets the npm registry to use HTTP.  I've verified that this change resolves the issue on the Jenkins worker box.

@jzoldak @feanil 
