### PR TITLE
Add a command to transfer students from one course to another.

### DIFF
--- a/common/djangoapps/student/management/commands/transfer_students.py
+++ b/common/djangoapps/student/management/commands/transfer_students.py
@@ -1,0 +1,64 @@
+from optparse import make_option
+from django.core.management.base import BaseCommand
+from django.contrib.auth.models import User
+from student.models import CourseEnrollment
+from shoppingcart.models import CertificateItem
+
+
+class Command(BaseCommand):
+    help = """
+    This command takes two course ids as input and transfers
+    all students enrolled in one course into the other.  This will
+    remove them from the first class and enroll them in the second
+    class in the same mode as the first one. eg. honor, verified,
+    audit.
+
+    example:
+        # Transfer students from the old demoX class to a new one.
+        manage.py ... transfer_students -f edX/Open_DemoX/edx_demo_course -t edX/Open_DemoX/new_demoX
+    """
+
+    option_list = BaseCommand.option_list + (
+        make_option('-f', '--from',
+                    metavar='SOURCE_COURSE',
+                    dest='source_course',
+                    help='The course to transfer students from.'),
+        make_option('-t', '--to',
+                    metavar='DEST_COURSE',
+                    dest='dest_course',
+                    help='The new course to enroll the student into.'),
+    )
+
+    def handle(self, *args, **options):
+        source = options['source_course']
+        dest = options['dest_course']
+
+        source_students = User.objects.filter(
+            courseenrollment__course_id=source,
+            courseenrollment__is_active=True)
+
+        for user in source_students:
+            print("Moving {}.".format(user.username))
+            # Find the old enrollment.
+            enrollment = CourseEnrollment.objects.get(user=user,
+                course_id=source)
+            # Move the Student between the classes.
+            mode = enrollment.mode
+            CourseEnrollment.unenroll(user,source)
+            CourseEnrollment.enroll(user, dest, mode=mode)
+
+            if mode == 'verified':
+                try:
+                    certificate_item = CertificateItem.objects.get(
+                        course_id=source,
+                        course_enrollment=enrollment)
+                except CertificateItem.DoesNotExist:
+                    print("No certificate for {}".format(user))
+                    continue
+
+                new_enrollment = CourseEnrollment.objects.get(user=user,
+                    course_id=dest)
+
+                certificate_item.course_id = dest
+                certificate_item.course_enrollment = new_enrollment
+                certificate_item.save()

--- a/common/djangoapps/student/management/commands/transfer_students.py
+++ b/common/djangoapps/student/management/commands/transfer_students.py
@@ -44,11 +44,14 @@ class Command(BaseCommand):
 
             # Move the Student between the classes.
             mode = enrollment.mode
+            old_is_active = enrollment.is_active
             CourseEnrollment.unenroll(user,source)
             new_enrollment = CourseEnrollment.enroll(user, dest, mode=mode)
 
-            if not enrollment.is_active:
-                CourseEnrollment.unenroll(user,dest)
+            # Unenroll from the new coures if the user had unenrolled
+            # form the old course.
+            if not old_is_active:
+                new_enrollment.update_enrollment(is_active=False)
 
             if mode == 'verified':
                 try:


### PR DESCRIPTION
Reviewers: @jarv @dianakhuang 

@dianakhuang Is this sufficient for transferring students that have been verified? A use case for this is for students that were initially in an XML course but now need to be moved to a mongo version of the same course.

See [TKTS-462].
