### PR TITLE
LMS: Developer-centric Sass Area

### DIFF
--- a/lms/static/sass/_developer.scss
+++ b/lms/static/sass/_developer.scss
@@ -1,0 +1,10 @@
+// edX LMS - developer
+// ====================
+// NOTE: use this area for any developer-needed or created styling that needs to be refactored into patterns or visually polished. Please list any template/view that your styles reference when definining them (example below):
+
+// Views: Login, Sign Up
+// .crazy-new-feature {
+//   background: transparent;
+// }
+
+// --------------------

--- a/lms/static/sass/_shame.scss
+++ b/lms/static/sass/_shame.scss
@@ -1,6 +1,7 @@
 // edX LMS - shame
-// shame file - used for any bad-form/orphaned scss that knowingly violate edX FED architecture/standards (see - http://csswizardry.com/2013/04/shame-css/)
 // ====================
+// NOTE: use for any bad-form/orphaned scss that knowingly violate edX FED architecture/standards
+// see - http://csswizardry.com/2013/04/shame-css/
 
 // edx.org marketing site - 7/2013 visual button revamp
 

--- a/lms/static/sass/application-extend1.scss.mako
+++ b/lms/static/sass/application-extend1.scss.mako
@@ -57,5 +57,6 @@
 @import 'multicourse/help';
 @import 'multicourse/edge';
 
+@import 'developer'; // used for any developer-created scss that needs further polish/refactoring
+@import 'shame';     // used for any bad-form/orphaned scss
 ## NOTE: needed here for cascade and dependency purposes, but not a great permanent solution
-@import 'shame'; // shame file - used for any bad-form/orphaned scss that knowingly violate edX FED architecture/standards (see - http://csswizardry.com/2013/04/shame-css/)

--- a/lms/static/sass/application-extend2.scss.mako
+++ b/lms/static/sass/application-extend2.scss.mako
@@ -50,5 +50,7 @@
 @import 'discussion';
 @import 'news';
 
+// temp - shame and developer
+@import 'developer'; // used for any developer-created scss that needs further polish/refactoring
+@import 'shame';     // used for any bad-form/orphaned scss
 ## NOTE: needed here for cascade and dependency purposes, but not a great permanent solution
-@import 'shame'; // shame file - used for any bad-form/orphaned scss that knowingly violate edX FED architecture/standards (see - http://csswizardry.com/2013/04/shame-css/)

--- a/lms/static/sass/application.scss.mako
+++ b/lms/static/sass/application.scss.mako
@@ -51,5 +51,6 @@
 @import 'shared/activation_messages';
 @import 'shared/unsubscribe';
 
+@import 'developer'; // used for any developer-created scss that needs further polish/refactoring
+@import 'shame';     // used for any bad-form/orphaned scss
 ## NOTE: needed here for cascade and dependency purposes, but not a great permanent solution
-@import 'shame'; // shame file - used for any bad-form/orphaned scss that knowingly violate edX FED architecture/standards (see - http://csswizardry.com/2013/04/shame-css/)


### PR DESCRIPTION
This work adds in a known area for developers to add in new Sass, especially when needed and the current styling/UI patterns cannot support the features and bugs they are actively working on. Benefits of this include: 
- a known area in the cascade where styles will be inherited
- a designated area for developer use and design visual polishing and front end re-factoring (rather than hunting through the entire codebase).
- a location for developers to learn, request post-production support, receive feedback on any front end work, and ask questions of designers.
