### PR TITLE
Studio: Developer-centric Sass Area

### DIFF
--- a/cms/static/sass/_developer.scss
+++ b/cms/static/sass/_developer.scss
@@ -1,0 +1,10 @@
+// studio - developer
+// ====================
+// NOTE: use this area for any developer-needed or created styling that needs to be refactored into patterns or visually polished. Please list any template/view that your styles reference when definining them (example below):
+
+// Views: Login, Sign Up
+// .crazy-new-feature {
+//   background: transparent;
+// }
+
+// --------------------

--- a/cms/static/sass/_shame.scss
+++ b/cms/static/sass/_shame.scss
@@ -1,6 +1,7 @@
 // studio - shame
-// // shame file - used for any bad-form/orphaned scss that knowingly violate edX FED architecture/standards (see - http://csswizardry.com/2013/04/shame-css/)
 // ====================
+// NOTE: use for any bad-form/orphaned scss that knowingly violate edX FED architecture/standards
+// see - http://csswizardry.com/2013/04/shame-css/
 
 // view - dashboard
 .view-dashboard {

--- a/cms/static/sass/style-app-extend1.scss
+++ b/cms/static/sass/style-app-extend1.scss
@@ -51,4 +51,5 @@
 // temp - inherited
 @import 'assets/content-types';
 
-@import 'shame'; // shame file - used for any bad-form/orphaned scss that knowingly violate edX FED architecture/standards (see - http://csswizardry.com/2013/04/shame-css/)
+@import 'developer'; // used for any developer-created scss that needs further polish/refactoring
+@import 'shame';     // used for any bad-form/orphaned scss


### PR DESCRIPTION
This work adds in a known area for developers to add in new Sass when needed, especially when the current styling/UI patterns cannot support the features and bugs they are actively working on. Benefits of this include: 
- a known area in the cascade where styles will be inherited
- a designated area for developer use and design visual polishing and front end re-factoring (rather than hunting through the entire codebase).
- a location for developers to learn, request post-production support, receive feedback on any front end work, and ask questions of designers.
