### PR TITLE
Hide staticpages preview on render

### DIFF
--- a/common/static/css/vendor/normalize.css
+++ b/common/static/css/vendor/normalize.css
@@ -404,3 +404,11 @@ table {
     border-collapse: collapse;
     border-spacing: 0;
 }
+
+/**
+ * Hide staticpage preview on load (Studio).
+ */
+
+#preview-lms-staticpages {
+    display: none;
+}


### PR DESCRIPTION
STUD-1071
@talbs

Hide staticpages preview on rendering as it hides eventually and also there is a link (What do static pages look like in my course?) to show this preview.
