### PR TITLE
Tests for behavior of export with & in HTML and XML-based components

### DIFF
--- a/cms/djangoapps/contentstore/features/component_settings_editor_helpers.py
+++ b/cms/djangoapps/contentstore/features/component_settings_editor_helpers.py
@@ -4,6 +4,7 @@
 from lettuce import world
 from nose.tools import assert_equal, assert_in  # pylint: disable=E0611
 from terrain.steps import reload_the_page
+from common import type_in_codemirror
 
 
 @world.absorb
@@ -112,6 +113,17 @@ def edit_component_and_select_settings():
 def edit_component():
     world.wait_for(lambda _driver: world.css_visible('a.edit-button'))
     world.css_click('a.edit-button')
+
+
+@world.absorb
+def enter_xml_in_advanced_problem(step, text):
+    """
+    Edits an advanced problem (assumes only on page),
+    types the provided XML, and saves the component.
+    """
+    world.edit_component()
+    type_in_codemirror(0, text)
+    world.save_component(step)
 
 
 @world.absorb

--- a/cms/djangoapps/contentstore/features/component_settings_editor_helpers.py
+++ b/cms/djangoapps/contentstore/features/component_settings_editor_helpers.py
@@ -115,7 +115,6 @@ def edit_component():
     world.css_click('a.edit-button')
 
 
-@world.absorb
 def enter_xml_in_advanced_problem(step, text):
     """
     Edits an advanced problem (assumes only on page),

--- a/cms/djangoapps/contentstore/features/course-export.feature
+++ b/cms/djangoapps/contentstore/features/course-export.feature
@@ -9,3 +9,11 @@ Feature: Course export
     And I export the course
     Then I get an error dialog
     And I can click to go to the unit with the error
+
+  Scenario: User is directed to problem with & in it when export fails
+    Given I am in Studio editing a new unit
+    When I add a "Blank Advanced Problem" "Advanced Problem" component
+    And I edit and enter an ampersand
+    And I export the course
+    Then I get an error dialog
+    And I can click to go to the unit with the error

--- a/cms/djangoapps/contentstore/features/course-export.py
+++ b/cms/djangoapps/contentstore/features/course-export.py
@@ -2,7 +2,6 @@
 #pylint: disable=C0111
 
 from lettuce import world, step
-from common import type_in_codemirror
 from nose.tools import assert_true, assert_equal
 
 
@@ -16,9 +15,7 @@ def i_export_the_course(step):
 
 @step('I edit and enter bad XML$')
 def i_enter_bad_xml(step):
-    world.edit_component()
-    type_in_codemirror(
-        0,
+    world.enter_xml_in_advanced_problem(step,
         """<problem><h1>Smallest Canvas</h1>
             <p>You want to make the smallest canvas you can.</p>
             <multiplechoiceresponse>
@@ -29,7 +26,11 @@ def i_enter_bad_xml(step):
             </multiplechoiceresponse>
             </problem>"""
     )
-    world.save_component(step)
+
+
+@step('I edit and enter an ampersand$')
+def i_enter_bad_xml(step):
+    world.enter_xml_in_advanced_problem(step, "<problem>&</problem>")
 
 
 @step('I get an error dialog$')

--- a/cms/djangoapps/contentstore/features/course-export.py
+++ b/cms/djangoapps/contentstore/features/course-export.py
@@ -2,6 +2,7 @@
 #pylint: disable=C0111
 
 from lettuce import world, step
+from component_settings_editor_helpers import enter_xml_in_advanced_problem
 from nose.tools import assert_true, assert_equal
 
 
@@ -15,7 +16,7 @@ def i_export_the_course(step):
 
 @step('I edit and enter bad XML$')
 def i_enter_bad_xml(step):
-    world.enter_xml_in_advanced_problem(step,
+    enter_xml_in_advanced_problem(step,
         """<problem><h1>Smallest Canvas</h1>
             <p>You want to make the smallest canvas you can.</p>
             <multiplechoiceresponse>
@@ -30,7 +31,7 @@ def i_enter_bad_xml(step):
 
 @step('I edit and enter an ampersand$')
 def i_enter_bad_xml(step):
-    world.enter_xml_in_advanced_problem(step, "<problem>&</problem>")
+    enter_xml_in_advanced_problem(step, "<problem>&</problem>")
 
 
 @step('I get an error dialog$')

--- a/common/test/data/simple/html/toylab.html
+++ b/common/test/data/simple/html/toylab.html
@@ -1,3 +1,3 @@
 <b>Lab 2A: Superposition Experiment</b>
 
-<p>Isn't the toy course great?</p>
+<p>Isn't the toy course great? &</p>


### PR DESCRIPTION
These are tests to nail down the current behavior of export with & exists in an HTML component or a problem (XML) component.

See STUD-91

& is OK in an HTML component, and there is an import/export roundtrip test that uses the toy course. Therefore I added & to an existing HTML component in the toy course.

& is not OK in a problem (XML-based component). I added a test that export will fail with a way to click to the failing component. The Studio preview view of the component shows the error, so this failure should be clear to users.

@jzoldak Please review.
