### PR TITLE
JSON serialization error fixed.

### DIFF
--- a/common/lib/xmodule/xmodule/open_ended_grading_classes/combined_open_ended_modulev1.py
+++ b/common/lib/xmodule/xmodule/open_ended_grading_classes/combined_open_ended_modulev1.py
@@ -651,7 +651,7 @@ class CombinedOpenEndedV1Module():
                 last_post_evaluation = task.format_feedback_with_evaluation(self.system, last_post_assessment)
             last_post_assessment = last_post_evaluation
             try:
-                rubric_data = task._parse_score_msg(task.child_history[-1].get('post_assessment', ""), self.system)
+                rubric_data = task._parse_score_msg(task.child_history[-1].get('post_assessment', "{}"), self.system)
             except Exception:
                 log.debug("Could not parse rubric data from child history.  "
                           "Likely we have not yet initialized a previous step, so this is perfectly fine.")

--- a/common/lib/xmodule/xmodule/open_ended_grading_classes/open_ended_module.py
+++ b/common/lib/xmodule/xmodule/open_ended_grading_classes/open_ended_module.py
@@ -503,6 +503,9 @@ class OpenEndedModule(openendedchild.OpenEndedChild):
             fail['feedback'] = error_message
             return fail
 
+        if not score_result:
+            return fail
+
         for tag in ['score', 'feedback', 'grader_type', 'success', 'grader_id', 'submission_id']:
             if tag not in score_result:
                 # This is a dev_facing_error
@@ -586,7 +589,7 @@ class OpenEndedModule(openendedchild.OpenEndedChild):
             return ""
 
         feedback_dict = self._parse_score_msg(
-            self.child_history[-1].get('post_assessment', ""),
+            self.child_history[-1].get('post_assessment', "{}"),
             system,
             join_feedback=join_feedback
         )
@@ -756,7 +759,7 @@ class OpenEndedModule(openendedchild.OpenEndedChild):
         """
         attempt = self.child_history[index]
         score = attempt.get('score')
-        post_assessment_data = self._parse_score_msg(attempt.get('post_assessment'), self.system)
+        post_assessment_data = self._parse_score_msg(attempt.get('post_assessment', "{}"), self.system)
         grader_types = post_assessment_data.get('grader_types')
 
         # According to _parse_score_msg in ML grading there should be only one grader type.

--- a/common/lib/xmodule/xmodule/tests/test_combined_open_ended.py
+++ b/common/lib/xmodule/xmodule/tests/test_combined_open_ended.py
@@ -390,6 +390,14 @@ class OpenEndedModuleTest(unittest.TestCase):
         # Confirm that the answer is stored properly.
         self.assertEqual(test_module.latest_answer(), submitted_response)
 
+    def test_parse_score_msg(self):
+        """
+        Test _parse_score_msg with empty dict.
+        """
+
+        assessment = self.openendedmodule._parse_score_msg("{}", self.test_system)
+        self.assertEqual(assessment.get("valid"), False)
+
 
 class CombinedOpenEndedModuleTest(unittest.TestCase):
     """


### PR DESCRIPTION
ORA-195
An empty string is passing to _parse_score_msg function when post_assessment key is not found in dict which causes an exception of JSON serialization.

Fixed this by giving default value to get function an empty dict as a string e.g.("{}").
