### PR TITLE
Don't catch all exceptions.

### DIFF
--- a/common/lib/xmodule/xmodule/contentstore/mongo.py
+++ b/common/lib/xmodule/xmodule/contentstore/mongo.py
@@ -100,7 +100,7 @@ class MongoContentStore(ContentStore):
     def close_stream(self, handle):
         try:
             handle.close()
-        except:
+        except Exception:
             pass
 
     def export(self, location, output_directory):

--- a/common/lib/xmodule/xmodule/contentstore/utils.py
+++ b/common/lib/xmodule/xmodule/contentstore/utils.py
@@ -45,5 +45,5 @@ def restore_asset_from_trashcan(location):
         try:
             thumbnail_content = trash.find(content.thumbnail_location)
             store.save(thumbnail_content)
-        except:
+        except Exception:
             pass  # OK if this is left dangling


### PR DESCRIPTION
Catching "except:" means you'll interfere with Ctrl-C and system.exit().  It's better not to catch those.
