### PR TITLE
Logging to catch duplicate instructor tasks

### DIFF
--- a/lms/djangoapps/instructor_task/api_helper.py
+++ b/lms/djangoapps/instructor_task/api_helper.py
@@ -52,7 +52,20 @@ def _reserve_task(course_id, task_type, task_key, task_input, requester):
     """
 
     if _task_is_running(course_id, task_type, task_key):
+        log.warning("Duplicate task found for task_type %s and task_key %s", task_type, task_key)
         raise AlreadyRunningError("requested task is already running")
+
+    try:
+        most_recent_id = InstructorTask.objects.latest('id').id
+    except InstructorTask.DoesNotExist:
+        most_recent_id = "None found"
+    finally:
+        log.warning(
+            "No duplicate tasks found: task_type %s, task_key %s, and most recent task_id = %s",
+            task_type,
+            task_key,
+            most_recent_id
+        )
 
     # Create log entry now, so that future requests will know it's running.
     return InstructorTask.create(course_id, task_type, task_key, task_input, requester)


### PR DESCRIPTION
@ormsbee do you think this logging is sufficient to help us trace and debug https://edx-wiki.atlassian.net/browse/LMS-1582 since we won't be able to focus other attention on that story this sprint, but releasing the grades download feature widely may mean we hit the issue a few times?
