### PR TITLE
Use <span> for course preview’s university

### DIFF
--- a/lms/static/sass/shared/_course_object.scss
+++ b/lms/static/sass/shared/_course_object.scss
@@ -231,10 +231,6 @@
             letter-spacing: 1px;
             margin-right: 10px;
             padding-right: 10px;
-
-            &:hover, &:focus {
-              color: $link-color;
-            }
           }
 
           .start-date  {

--- a/lms/templates/course.html
+++ b/lms/templates/course.html
@@ -1,5 +1,4 @@
 <%namespace name='static' file='static_content.html'/>
-<%namespace file='main.html' import="stanford_theme_enabled"/>
 <%!
 from django.utils.translation import ugettext as _
 from django.core.urlresolvers import reverse
@@ -26,11 +25,7 @@ from courseware.courses import course_image_url, get_course_about_section
           <p>${get_course_about_section(course, 'short_description')}</p>
         </div>
         <div class="bottom">
-          % if stanford_theme_enabled():
-            <span class="university">${get_course_about_section(course, 'university')}</span>
-          % else:
-            <a href="#" class="university">${get_course_about_section(course, 'university')}</a>
-          % endif
+          <span class="university">${get_course_about_section(course, 'university')}</span>
           <span class="start-date">${course.start_date_text}</span>
         </div>
       </section>


### PR DESCRIPTION
The course’s university was displayed using a `<a>` tag that points to
nothing ('#'). There was some stanford specific behavior to replace that
`<a>` tag with a `<span>`. This commit removes that.
## 

I couldn’t find any code relying on the `<a>` tag to be present.
Having a `<a>` tag here breaks the layout, displays the university and the start date on two different lines (caused by https://github.com/tusbar/edx-platform/blob/course-bottom-university-span/lms/static/sass/shared/_course_object.scss#L71)

Another option would be to add `display: inline` to https://github.com/tusbar/edx-platform/blob/course-bottom-university-span/lms/static/sass/shared/_course_object.scss#L228
