### PR TITLE
Fix STUD-1129: handle out-of-range page numbers

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_assets.py
+++ b/cms/djangoapps/contentstore/tests/test_assets.py
@@ -60,6 +60,11 @@ class AssetsToyCourseTestCase(CourseTestCase):
         self.assert_correct_asset_response(url + "?page_size=2", 0, 2, 3)
         self.assert_correct_asset_response(url + "?page_size=2&page=1", 2, 1, 3)
 
+        # Verify querying outside the range of valid pages
+        self.assert_correct_asset_response(url + "?page_size=2&page=-1", 0, 2, 3)
+        self.assert_correct_asset_response(url + "?page_size=2&page=2", 2, 1, 3)
+        self.assert_correct_asset_response(url + "?page_size=3&page=1", 0, 3, 3)
+
     def assert_correct_asset_response(self, url, expected_start, expected_length, expected_total):
         resp = self.client.get(url, HTTP_ACCEPT='application/json')
         json_response = json.loads(resp.content)


### PR DESCRIPTION
I've fixed the assets REST API to return the last page of assets if querying out-of-range. This means that the UI cannot accidentally show a blank page of results. I've added tests that verify the correct behavior in out-of-range conditions.

@cahrens please review.
