### PR TITLE
Do theme post-processing in startup hook

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,11 @@ the top.  Include a label indicating the component affected.
 Studio: Add sorting by column to the Files & Uploads page.
 See mongo_indexes.md for new indices that should be added.
 
+Common: Previously, theming was activated by providing a value for the THEME_NAME
+  setting. Now, theming is activated by setting the "USE_CUSTOM_THEME" feature
+  flag to True -- a THEME_NAME setting is still required to determine *which*
+  theme to use.
+
 Studio: Newly-created courses default to being published on Jan 1, 2030
 
 Studio: Added pagination to the Files & Uploads page.

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -188,14 +188,6 @@ BULK_EMAIL_ROUTING_KEY = HIGH_PRIORITY_QUEUE
 
 # Theme overrides
 THEME_NAME = ENV_TOKENS.get('THEME_NAME', None)
-# Workaround for setting THEME_NAME to an empty
-# string which is the default due to this ansible
-# bug: https://github.com/ansible/ansible/issues/4812
-if THEME_NAME == "":
-    THEME_NAME = None
-if not THEME_NAME is None:
-    enable_theme(THEME_NAME)
-    FAVICON_PATH = 'themes/%s/images/favicon.ico' % THEME_NAME
 
 # Marketing link overrides
 MKTG_URL_LINK_MAP.update(ENV_TOKENS.get('MKTG_URL_LINK_MAP', {}))

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1038,33 +1038,6 @@ MKTG_URL_LINK_MAP = {
 }
 
 
-############################### THEME ################################
-def enable_theme(theme_name):
-    """
-    Enable the settings for a custom theme, whose files should be stored
-    in ENV_ROOT/themes/THEME_NAME (e.g., edx_all/themes/stanford).
-
-    The THEME_NAME setting should be configured separately since it can't
-    be set here (this function closes too early). An idiom for doing this
-    is:
-
-    THEME_NAME = "stanford"
-    enable_theme(THEME_NAME)
-    """
-    FEATURES['USE_CUSTOM_THEME'] = True
-
-    # Calculate the location of the theme's files
-    theme_root = ENV_ROOT / "themes" / theme_name
-
-    # Include the theme's templates in the template search paths
-    TEMPLATE_DIRS.append(theme_root / 'templates')
-    MAKO_TEMPLATES['main'].append(theme_root / 'templates')
-
-    # Namespace the theme's static files to 'themes/<theme_name>' to
-    # avoid collisions with default edX static files
-    STATICFILES_DIRS.append((u'themes/%s' % theme_name,
-                             theme_root / 'static'))
-
 ################# Student Verification #################
 VERIFY_STUDENT = {
     "DAYS_GOOD_FOR": 365,  # How many days is a verficiation good for?

--- a/lms/startup.py
+++ b/lms/startup.py
@@ -22,3 +22,37 @@ def run():
     if settings.INIT_MODULESTORE_ON_STARTUP:
         for store_name in settings.MODULESTORE:
             modulestore(store_name)
+
+    if settings.FEATURES.get('USE_CUSTOM_THEME', False):
+        enable_theme()
+
+
+def enable_theme():
+    """
+    Enable the settings for a custom theme, whose files should be stored
+    in ENV_ROOT/themes/THEME_NAME (e.g., edx_all/themes/stanford).
+    """
+    # Workaround for setting THEME_NAME to an empty
+    # string which is the default due to this ansible
+    # bug: https://github.com/ansible/ansible/issues/4812
+    if settings.THEME_NAME == "":
+        settings.THEME_NAME = None
+        return
+
+    assert settings.FEATURES['USE_CUSTOM_THEME']
+    settings.FAVICON_PATH = 'themes/{name}/images/favicon.ico'.format(
+        name=settings.THEME_NAME
+    )
+
+    # Calculate the location of the theme's files
+    theme_root = settings.ENV_ROOT / "themes" / settings.THEME_NAME
+
+    # Include the theme's templates in the template search paths
+    settings.TEMPLATE_DIRS.append(theme_root / 'templates')
+    settings.MAKO_TEMPLATES['main'].append(theme_root / 'templates')
+
+    # Namespace the theme's static files to 'themes/<theme_name>' to
+    # avoid collisions with default edX static files
+    settings.STATICFILES_DIRS.append(
+        (u'themes/{}'.format(settings.THEME_NAME), theme_root / 'static')
+    )

--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -8,7 +8,7 @@
 ## templates have access to these functions, and we can import these
 ## into non-inheriting templates via the %namespace tag.
 <%def name="theme_enabled()">
-  <% return settings.FEATURES["USE_CUSTOM_THEME"] %>
+  <% return settings.FEATURES.get("USE_CUSTOM_THEME", False) %>
 </%def>
 
 <%def name="stanford_theme_enabled()">


### PR DESCRIPTION
@cpennington told me that we have a `startup.py` specifically for post-settings processing. The theme post-processing function belongs in this file.

Reviewers: @cpennington @sefk @feanil 
