### PR TITLE
Microsites

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -9,6 +9,7 @@ This is the default template for our main set of AWS servers.
 import json
 
 from .common import *
+
 from logsettings import get_logger_config
 import os
 
@@ -145,7 +146,6 @@ COURSES_WITH_UNSAFE_CODE = ENV_TOKENS.get("COURSES_WITH_UNSAFE_CODE", [])
 #Timezone overrides
 TIME_ZONE = ENV_TOKENS.get('TIME_ZONE', TIME_ZONE)
 
-
 ENV_FEATURES = ENV_TOKENS.get('FEATURES', ENV_TOKENS.get('MITX_FEATURES', {}))
 for feature, value in ENV_FEATURES.items():
     FEATURES[feature] = value
@@ -213,3 +213,5 @@ BROKER_URL = "{0}://{1}:{2}@{3}/{4}".format(CELERY_BROKER_TRANSPORT,
 
 # Event tracking
 TRACKING_BACKENDS.update(AUTH_TOKENS.get("TRACKING_BACKENDS", {}))
+
+MICROSITES = ENV_TOKENS.get('MICROSITES', {})

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -105,14 +105,14 @@ LOGIN_REDIRECT_URL = EDX_ROOT_URL + '/signin'
 LOGIN_URL = EDX_ROOT_URL + '/signin'
 
 
-TEMPLATE_CONTEXT_PROCESSORS = (
+TEMPLATE_CONTEXT_PROCESSORS = [
     'django.core.context_processors.request',
     'django.core.context_processors.static',
     'django.contrib.messages.context_processors.messages',
     'django.contrib.auth.context_processors.auth',  # this is required for admin
     'django.core.context_processors.csrf',
     'dealer.contrib.django.staff.context_processor',  # access git revision
-)
+]
 
 # use the ratelimit backend to prevent brute force attacks
 AUTHENTICATION_BACKENDS = (
@@ -459,3 +459,4 @@ YOUTUBE_API = {
     'url': "http://video.google.com/timedtext",
     'params': {'lang': 'en', 'v': 'set_youtube_id_of_11_symbols_here'}
 }
+

--- a/common/djangoapps/edxmako/middleware.py
+++ b/common/djangoapps/edxmako/middleware.py
@@ -14,6 +14,7 @@
 
 from django.template import RequestContext
 from util.request import safe_get_host
+from student.microsites import get_microsite_config, get_microsite_tpl_func
 requestcontext = None
 
 
@@ -24,3 +25,5 @@ class MakoMiddleware(object):
         requestcontext = RequestContext(request)
         requestcontext['is_secure'] = request.is_secure()
         requestcontext['site'] = safe_get_host(request)
+        requestcontext['microsite'] = get_microsite_config(request)
+        requestcontext['microsite_tpl'] = get_microsite_tpl_func(request)

--- a/common/djangoapps/student/context_processors.py
+++ b/common/djangoapps/student/context_processors.py
@@ -1,0 +1,10 @@
+from django.conf import settings
+from .microsites import get_microsite_config
+
+
+def microsite_processor(request):
+    # these will be automatically injected into every template, under the
+    # name `django_context`
+    return {
+        "microsite": get_microsite_config(request)
+    }

--- a/common/djangoapps/student/microsites.py
+++ b/common/djangoapps/student/microsites.py
@@ -1,0 +1,35 @@
+from django.conf import settings
+from path import path
+
+
+def get_microsite_config(request):
+    if not settings.FEATURES.get("MICROSITES"):
+        # microsites is not enabled
+        return {}
+
+    domain = request.META.get('HTTP_HOST')
+    domain_parts = domain.split(".")
+    # which site are we in?
+    for subdomain, config in settings.MICROSITES.items():
+        if domain_parts[0] == subdomain:
+            return config
+
+    # not found
+    return {}
+
+
+def get_microsite_tpl_func(request):
+    config = get_microsite_config(request)
+
+    def microsite_tpl_path(tpl_path):
+        if not config:
+            return tpl_path
+
+        subdomain = request.META.get("HTTP_HOST").split(".")[0]
+        dirname = config.get("directory", subdomain)
+        tpl = path(dirname) / "templates" / tpl_path
+        if tpl.isfile():
+            return str(tpl)
+        return tpl_path
+
+    return microsite_tpl_path

--- a/common/djangoapps/util/request.py
+++ b/common/djangoapps/util/request.py
@@ -1,5 +1,6 @@
 """ Utility functions related to HTTP requests """
 from django.conf import settings
+from student.microsites import get_microsite_config
 
 
 def safe_get_host(request):
@@ -14,4 +15,5 @@ def safe_get_host(request):
     if isinstance(settings.ALLOWED_HOSTS, (list, tuple)) and '*' not in settings.ALLOWED_HOSTS:
         return request.get_host()
     else:
-        return settings.SITE_NAME
+        mscfg = get_microsite_config(request)
+        return mscfg.get("site_domain", settings.SITE_NAME)

--- a/lms/djangoapps/branding/__init__.py
+++ b/lms/djangoapps/branding/__init__.py
@@ -3,48 +3,51 @@ from xmodule.course_module import CourseDescriptor
 from django.conf import settings
 
 
-def pick_subdomain(domain, options, default='default'):
-    for option in options:
-        if domain.startswith(option):
-            return option
-    return default
-
-
-def get_visible_courses(domain=None):
+def get_visible_courses(microsite=None):
     """
     Return the set of CourseDescriptors that should be visible in this branded instance
     """
+    microsite = microsite or {}
     _courses = modulestore().get_courses()
 
     courses = [c for c in _courses
                if isinstance(c, CourseDescriptor)]
     courses = sorted(courses, key=lambda course: course.number)
 
-    if domain and settings.FEATURES.get('SUBDOMAIN_COURSE_LISTINGS'):
-        subdomain = pick_subdomain(domain, settings.COURSE_LISTINGS.keys())
-        visible_ids = frozenset(settings.COURSE_LISTINGS[subdomain])
-        return [course for course in courses if course.id in visible_ids]
+    subdomain = microsite.get("subdomain")
+
+    # See if we have filtered course listings in this domain
+    filtered_visible_ids = None
+
+    # this is legacy format which is outside of the microsite feature
+    if hasattr(settings, 'COURSE_LISTINGS') and subdomain in settings.COURSE_LISTINGS:
+        filtered_visible_ids = frozenset(settings.COURSE_LISTINGS[subdomain])
+
+    filtered_by_org = microsite.get('course_org_filter')
+
+    if filtered_by_org:
+        return [course for course in courses if course.location.org == filtered_by_org]
+    if filtered_visible_ids:
+        return [course for course in courses if course.id in filtered_visible_ids]
     else:
         return courses
 
 
-def get_university(domain=None):
-    """
-    Return the university name specified for the domain, or None
-    if no university was specified
-    """
-    if not settings.FEATURES['SUBDOMAIN_BRANDING'] or domain is None:
-        return None
-
-    subdomain = pick_subdomain(domain, settings.SUBDOMAIN_BRANDING.keys())
-    return settings.SUBDOMAIN_BRANDING.get(subdomain)
-
-
-def get_logo_url(domain=None):
+def get_logo_url(microsite=None):
     """
     Return the url for the branded logo image to be used
     """
-    university = get_university(domain)
+    microsite = microsite or {}
+
+    # if the microsite config has a value for the logo_image_url, use that
+    image_url = microsite.get('logo_image_url')
+    if image_url:
+        return '{static_url}{image_url}'.format(
+            static_url=settings.STATIC_URL, image_url=image_url
+        )
+
+    # otherwise, use the legacy means to configure this
+    university = microsite.get('university')
 
     if university is None:
         return '{static_url}images/header-logo.png'.format(

--- a/lms/djangoapps/branding/views.py
+++ b/lms/djangoapps/branding/views.py
@@ -6,8 +6,9 @@ from django_future.csrf import ensure_csrf_cookie
 from edxmako.shortcuts import render_to_response
 
 import student.views
-import branding
 import courseware.views
+
+from student.microsites import get_microsite_config
 from edxmako.shortcuts import marketing_link
 from util.cache import cache_if_anonymous
 
@@ -25,10 +26,19 @@ def index(request):
     if settings.FEATURES.get('AUTH_USE_MIT_CERTIFICATES'):
         from external_auth.views import ssl_login
         return ssl_login(request)
-    if settings.FEATURES.get('ENABLE_MKTG_SITE'):
+
+    mscfg = get_microsite_config(request)
+
+    enable_mktg_site = (settings.FEATURES.get('ENABLE_MKTG_SITE') or
+                        mscfg.get('ENABLE_MKTG_SITE'))
+
+    if enable_mktg_site:
         return redirect(settings.MKTG_URLS.get('ROOT'))
 
-    university = branding.get_university(request.META.get('HTTP_HOST'))
+    university = mscfg.get("university")
+
+    # keep specialized logic for Edge until we can migrate over Edge to fully use
+    # microsite definitions
     if university == 'edge':
         return render_to_response('university_profile/edge.html', {})
 
@@ -46,7 +56,11 @@ def courses(request):
     to that. Otherwise, if subdomain branding is on, this is the university
     profile page. Otherwise, it's the edX courseware.views.courses page
     """
-    if settings.FEATURES.get('ENABLE_MKTG_SITE', False):
+    mscfg = get_microsite_config(request)
+    enable_mktg_site = (settings.FEATURES.get('ENABLE_MKTG_SITE') or
+                        mscfg.get('ENABLE_MKTG_SITE'))
+
+    if enable_mktg_site:
         return redirect(marketing_link('COURSES'), permanent=True)
 
     if not settings.FEATURES.get('COURSES_ARE_BROWSABLE'):

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -294,7 +294,11 @@ def get_courses(user, domain=None):
     '''
     Returns a list of courses available, sorted by course.number
     '''
-    courses = branding.get_visible_courses(domain)
+    if settings.FEATURES.get("MICROSITES") and domain in settings.MICROSITES:
+        microsite = settings.MICROSITES[domain]
+    else:
+        microsite = {}
+    courses = branding.get_visible_courses(microsite=microsite)
     courses = [c for c in courses if has_access(user, c, 'see_exists')]
 
     courses = sorted(courses, key=lambda course: course.number)

--- a/lms/djangoapps/instructor/enrollment.py
+++ b/lms/djangoapps/instructor/enrollment.py
@@ -11,6 +11,7 @@ from django.core.urlresolvers import reverse
 from django.core.mail import send_mail
 
 from student.models import CourseEnrollment, CourseEnrollmentAllowed
+from student.microsites import get_microsite_config
 from courseware.models import StudentModule
 from edxmako.shortcuts import render_to_string
 
@@ -202,7 +203,7 @@ def get_email_params(course, auto_enroll):
     return email_params
 
 
-def send_mail_to_student(student, param_dict):
+def send_mail_to_student(student, param_dict, microsite=None):
     """
     Construct the email using templates and then send it.
     `student` is the student's email address (a `str`),
@@ -222,23 +223,41 @@ def send_mail_to_student(student, param_dict):
 
     Returns a boolean indicating whether the email was sent successfully.
     """
+    microsite = microsite or {}
+
+    # add some helpers and microconfig subsitutions
+    if 'course' in param_dict:
+        param_dict['course_name'] = param_dict['course'].display_name_with_default
+
+    param_dict['site_name'] = microsite.get("SITE_NAME", param_dict['site_name'])
+
+    subject = None
+    message = None
+
+    # see if we are running in a microsite and that there is an
+    # activation email template definition available as configuration, if so, then render that
+    message_type = param_dict['message']
 
     email_template_dict = {'allowed_enroll': ('emails/enroll_email_allowedsubject.txt', 'emails/enroll_email_allowedmessage.txt'),
-                           'enrolled_enroll': ('emails/enroll_email_enrolledsubject.txt', 'emails/enroll_email_enrolledmessage.txt'),
-                           'allowed_unenroll': ('emails/unenroll_email_subject.txt', 'emails/unenroll_email_allowedmessage.txt'),
-                           'enrolled_unenroll': ('emails/unenroll_email_subject.txt', 'emails/unenroll_email_enrolledmessage.txt')}
+       'enrolled_enroll': ('emails/enroll_email_enrolledsubject.txt', 'emails/enroll_email_enrolledmessage.txt'),
+       'allowed_unenroll': ('emails/unenroll_email_subject.txt', 'emails/unenroll_email_allowedmessage.txt'),
+       'enrolled_unenroll': ('emails/unenroll_email_subject.txt', 'emails/unenroll_email_enrolledmessage.txt')
+    }
 
-    subject_template, message_template = email_template_dict.get(param_dict['message'], (None, None))
+    subject_template, message_template = email_template_dict.get(message_type, (None, None))
     if subject_template is not None and message_template is not None:
         subject = render_to_string(subject_template, param_dict)
         message = render_to_string(message_template, param_dict)
 
+    if subject and message:
         # Remove leading and trailing whitespace from body
         message = message.strip()
 
         # Email subject *must not* contain newlines
         subject = ''.join(subject.splitlines())
-        send_mail(subject, message, settings.DEFAULT_FROM_EMAIL, [student], fail_silently=False)
+        from_address = microsite.get("email_from_address", settings.DEFAULT_FROM_EMAIL)
+
+        send_mail(subject, message, from_address, [student], fail_silently=False)
 
 
 def uses_shib(course):

--- a/lms/djangoapps/instructor/views/legacy.py
+++ b/lms/djangoapps/instructor/views/legacy.py
@@ -57,6 +57,7 @@ from edxmako.shortcuts import render_to_response, render_to_string
 from psychometrics import psychoanalyze
 from student.models import CourseEnrollment, CourseEnrollmentAllowed, unique_id_for_user
 from student.views import course_from_id
+from student.microsites import get_microsite_config
 import track.views
 from xblock.field_data import DictFieldData
 from xblock.fields import ScopeIds
@@ -99,6 +100,8 @@ def instructor_dashboard(request, course_id):
     problems = []
     plots = []
     datatable = {}
+
+    mscfg = get_microsite_config(request)
 
     # the instructor dashboard page is modal: grades, psychometrics, admin
     # keep that state in request.session (defaults to grades mode)
@@ -695,7 +698,9 @@ def instructor_dashboard(request, course_id):
 
         students = request.POST.get('multiple_students', '')
         email_students = bool(request.POST.get('email_students'))
-        ret = _do_unenroll_students(course_id, students, email_students=email_students)
+        ret = _do_unenroll_students(
+            course_id, students, email_students=email_students, microsite=mscfg,
+        )
         datatable = ret['datatable']
 
     elif action == 'List sections available in remote gradebook':
@@ -714,7 +719,7 @@ def instructor_dashboard(request, course_id):
         if not 'List' in action:
             students = ','.join([x['email'] for x in datatable['retdata']])
             overload = 'Overload' in action
-            ret = _do_enroll_students(course, course_id, students, overload=overload)
+            ret = _do_enroll_students(course, course_id, students, overload=overload, microsite=mscfg)
             datatable = ret['datatable']
 
     #----------------------------------------
@@ -1253,7 +1258,9 @@ def grade_summary(request, course_id):
 #-----------------------------------------------------------------------------
 # enrollment
 
-def _do_enroll_students(course, course_id, students, overload=False, auto_enroll=False, email_students=False, is_shib_course=False):
+def _do_enroll_students(
+        course, course_id, students, overload=False, auto_enroll=False,
+        email_students=False, is_shib_course=False, microsite=None):
     """
     Do the actual work of enrolling multiple students, presented as a string
     of emails separated by commas or returns
@@ -1264,6 +1271,7 @@ def _do_enroll_students(course, course_id, students, overload=False, auto_enroll
     `auto_enroll` is user input preference (a `boolean`)
     `email_students` is user input preference (a `boolean`)
     """
+    microsite = microsite or {}
 
     new_students, new_students_lc = get_and_clean_student_list(students)
     status = dict([x, 'unprocessed'] for x in new_students)
@@ -1282,7 +1290,7 @@ def _do_enroll_students(course, course_id, students, overload=False, auto_enroll
         ceaset.delete()
 
     if email_students:
-        stripped_site_name = settings.SITE_NAME
+        stripped_site_name = microsite.get("SITE_NAME", settings.SITE_NAME)
         registration_url = 'https://' + stripped_site_name + reverse('student.views.register_user')
         #Composition of email
         d = {'site_name': stripped_site_name,
@@ -1291,7 +1299,7 @@ def _do_enroll_students(course, course_id, students, overload=False, auto_enroll
              'auto_enroll': auto_enroll,
              'course_url': 'https://' + stripped_site_name + '/courses/' + course_id,
              'course_about_url': 'https://' + stripped_site_name + '/courses/' + course_id + '/about',
-             'is_shib_course': is_shib_course,
+             'is_shib_course': is_shib_course
              }
 
     for student in new_students:
@@ -1322,7 +1330,7 @@ def _do_enroll_students(course, course_id, students, overload=False, auto_enroll
                 #User is allowed to enroll but has not signed up yet
                 d['email_address'] = student
                 d['message'] = 'allowed_enroll'
-                send_mail_ret = send_mail_to_student(student, d)
+                send_mail_ret = send_mail_to_student(student, d, microsite)
                 status[student] += (', email sent' if send_mail_ret else '')
             continue
 
@@ -1341,7 +1349,7 @@ def _do_enroll_students(course, course_id, students, overload=False, auto_enroll
                 d['email_address'] = student
                 d['full_name'] = user.profile.name
                 d['message'] = 'enrolled_enroll'
-                send_mail_ret = send_mail_to_student(student, d)
+                send_mail_ret = send_mail_to_student(student, d, microsite)
                 status[student] += (', email sent' if send_mail_ret else '')
 
         except:
@@ -1361,7 +1369,8 @@ def _do_enroll_students(course, course_id, students, overload=False, auto_enroll
 
 
 #Unenrollment
-def _do_unenroll_students(course_id, students, email_students=False):
+def _do_unenroll_students(
+        course_id, students, email_students=False, microsite=None):
     """
     Do the actual work of un-enrolling multiple students, presented as a string
     of emails separated by commas or returns
@@ -1369,11 +1378,12 @@ def _do_unenroll_students(course_id, students, email_students=False):
     `students` is string of student emails separated by commas or returns (a `str`)
     `email_students` is user input preference (a `boolean`)
     """
+    microsite = microsite or {}
 
     old_students, _ = get_and_clean_student_list(students)
     status = dict([x, 'unprocessed'] for x in old_students)
 
-    stripped_site_name = settings.SITE_NAME
+    stripped_site_name = microsite.get("SITE_NAME", settings.SITE_NAME)
     if email_students:
         course = course_from_id(course_id)
         #Composition of email
@@ -1398,7 +1408,7 @@ def _do_unenroll_students(course_id, students, email_students=False):
                 #User was allowed to join but had not signed up yet
                 d['email_address'] = student
                 d['message'] = 'allowed_unenroll'
-                send_mail_ret = send_mail_to_student(student, d)
+                send_mail_ret = send_mail_to_student(student, d, microsite)
                 status[student] += (', email sent' if send_mail_ret else '')
 
             continue
@@ -1413,7 +1423,7 @@ def _do_unenroll_students(course_id, students, email_students=False):
                     d['email_address'] = student
                     d['full_name'] = user.profile.name
                     d['message'] = 'enrolled_unenroll'
-                    send_mail_ret = send_mail_to_student(student, d)
+                    send_mail_ret = send_mail_to_student(student, d, microsite)
                     status[student] += (', email sent' if send_mail_ret else '')
 
             except Exception:
@@ -1428,7 +1438,7 @@ def _do_unenroll_students(course_id, students, email_students=False):
     return data
 
 
-def send_mail_to_student(student, param_dict):
+def send_mail_to_student(student, param_dict, microsite=None):
     """
     Construct the email using templates and then send it.
     `student` is the student's email address (a `str`),
@@ -1446,23 +1456,39 @@ def send_mail_to_student(student, param_dict):
                                         ]
     Returns a boolean indicating whether the email was sent successfully.
     """
+    microsite = microsite or {}
 
-    EMAIL_TEMPLATE_DICT = {'allowed_enroll': ('emails/enroll_email_allowedsubject.txt', 'emails/enroll_email_allowedmessage.txt'),
-                           'enrolled_enroll': ('emails/enroll_email_enrolledsubject.txt', 'emails/enroll_email_enrolledmessage.txt'),
-                           'allowed_unenroll': ('emails/unenroll_email_subject.txt', 'emails/unenroll_email_allowedmessage.txt'),
-                           'enrolled_unenroll': ('emails/unenroll_email_subject.txt', 'emails/unenroll_email_enrolledmessage.txt')}
+    # add some helpers and microconfig subsitutions
+    if 'course' in param_dict:
+        param_dict['course_name'] = param_dict['course'].display_name_with_default
+    param_dict['site_name'] = microsite.get("SITE_NAME", param_dict.get("site_name", ""))
 
-    subject_template, message_template = EMAIL_TEMPLATE_DICT.get(param_dict['message'], (None, None))
+    subject = None
+    message = None
+
+    message_type = param_dict['message']
+
+    email_template_dict = {
+        'allowed_enroll': ('emails/enroll_email_allowedsubject.txt', 'emails/enroll_email_allowedmessage.txt'),
+        'enrolled_enroll': ('emails/enroll_email_enrolledsubject.txt', 'emails/enroll_email_enrolledmessage.txt'),
+        'allowed_unenroll': ('emails/unenroll_email_subject.txt', 'emails/unenroll_email_allowedmessage.txt'),
+        'enrolled_unenroll': ('emails/unenroll_email_subject.txt', 'emails/unenroll_email_enrolledmessage.txt')
+    }
+
+    subject_template, message_template = email_template_dict.get(message_type, (None, None))
     if subject_template is not None and message_template is not None:
         subject = render_to_string(subject_template, param_dict)
         message = render_to_string(message_template, param_dict)
 
+    if subject and message:
         # Remove leading and trailing whitespace from body
         message = message.strip()
 
         # Email subject *must not* contain newlines
         subject = ''.join(subject.splitlines())
-        send_mail(subject, message, settings.DEFAULT_FROM_EMAIL, [student], fail_silently=False)
+        from_address = microsite.get("email_from_address", settings.DEFAULT_FROM_EMAIL)
+
+        send_mail(subject, message, from_address, [student], fail_silently=False)
 
         return True
     else:

--- a/lms/envs/cms/microsite_test.py
+++ b/lms/envs/cms/microsite_test.py
@@ -1,0 +1,29 @@
+# We intentionally define lots of variables that aren't used, and
+# want to import all variables from base settings files
+# pylint: disable=W0401, W0614
+
+from .dev import *
+
+FEATURES["MICROSITES"] = True
+MICROSITES = {
+    "openedx": {
+        "domain_prefix": "openedx",
+        "university": "openedx",
+        "platform_name": "Open edX",
+        "logo_image_url": "openedx/images/header-logo.png",
+        "show_only_org_on_student_dashboard": True,
+        "email_from_address": "openedx@edx.org",
+        "payment_support_email": "openedx@edx.org",
+        "ENABLE_MKTG_SITE": False,
+        "SITE_NAME": "openedx.localhost",
+        "course_org_filter": "CDX",
+        "show_only_org_on_student_dashboard": True,
+        "course_about_show_social_links": False,
+        "css_overrides_file": "openedx/css/openedx.css",
+        "show_partners": False,
+        "show_homepage_promo_video": False,
+        "course_index_overlay_text": "Explore free courses from leading universities.",
+        "course_index_overlay_logo_file": "openedx/images/header-logo.png",
+        "homepage_overlay_html": "<h1>Take an Open edX Course</h1>"
+    },
+}

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -25,6 +25,7 @@ Longer TODO:
 
 import sys
 import os
+import json
 
 from path import path
 
@@ -377,7 +378,6 @@ TRACKING_ENABLED = True
 ######################## subdomain specific settings ###########################
 COURSE_LISTINGS = {}
 SUBDOMAIN_BRANDING = {}
-
 
 ############################### XModule Store ##################################
 MODULESTORE = {

--- a/lms/envs/dev.py
+++ b/lms/envs/dev.py
@@ -130,6 +130,8 @@ SUBDOMAIN_BRANDING = {
     'mit': 'MITx',
     'berkeley': 'BerkeleyX',
     'harvard': 'HarvardX',
+    'openedx': 'openedx',
+    'edge': 'edge'
 }
 
 # List of `university` landing pages to display, even though they may not
@@ -291,3 +293,5 @@ try:
     from .private import *      # pylint: disable=F0401
 except ImportError:
     pass
+
+

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -277,3 +277,27 @@ PASSWORD_HASHERS = (
 
 import openid.oidutil
 openid.oidutil.log = lambda message, level = 0: None
+
+# set up some testing for microsites
+MICROSITES = {
+    "openedx": {
+        "domain_prefix": "openedx",
+        "university": "openedx",
+        "platform_name": "Open edX",
+        "logo_image_url": "openedx/images/header-logo.png",
+        "show_only_org_on_student_dashboard": True,
+        "email_from_address": "openedx@edx.org",
+        "payment_support_email": "openedx@edx.org",
+        "ENABLE_MKTG_SITE": False,
+        "SITE_NAME": "openedx.localhost",
+        "course_org_filter": "CDX",
+        "show_only_org_on_student_dashboard": True,
+        "course_about_show_social_links": False,
+        "css_overrides_file": "openedx/css/openedx.css",
+        "show_partners": False,
+        "show_homepage_promo_video": False,
+        "course_index_overlay_text": "Explore free courses from leading universities.",
+        "course_index_overlay_logo_file": "openedx/images/header-logo.png",
+        "homepage_overlay_html": "<h1>Take an Open edX Course</h1>"
+    }
+}

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -15,11 +15,15 @@
 <%inherit file="../main.html" />
 
 <%block name="headextra">
-  % if self.theme_enabled():
-    <%include file="../theme-google-analytics.html" />
-  % else:
-    <%include file="../google_analytics.html" />
-  % endif
+
+  <%
+    if self.theme_enabled():
+      google_analytics_file = u'../' + microsite.get('google_analytics_file', 'theme-google-analytics.html')
+    else:
+      google_analytics_file = '../google_analytics.html'
+  %>
+
+  <%include file="${google_analytics_file}" />
 </%block>
 
 <%block name="js_extra">
@@ -196,6 +200,7 @@
     <section class="course-sidebar">
       <section class="course-summary">
         <header>
+          % if microsite.get('course_about_show_social_links', True):
           <div class="social-sharing">
             <div class="sharing-message">${_("Share with friends and family!")}</div>
             ## TODO: this should probably be an overrideable block,
@@ -209,17 +214,28 @@
                 <img src="${static.url('images/social/email-sharing.png')}" alt="Email someone to say you've registered for this course">
               </a>
             % else:
-              <a href="http://twitter.com/intent/tweet?text=I+just+registered+for+${course.number}+${get_course_about_section(course, 'title')}+through+@edxonline:+http://www.edx.org${reverse('about_course', args=[course.id])}" class="share">
+              <%
+                site_domain = microsite.get('site_domain', 'www.edx.org')
+                platform_name = microsite.get('platform_name', 'edX')
+
+                tweet_action = "http://twitter.com/intent/tweet?text=I+just+registered+for+"+course.number+"+"+get_course_about_section(course, 'title')+"+through+"+microsite.get('course_about_twitter_account', '@edxonline')+":+http://"+site_domain+reverse('about_course', args=[course.id])
+
+                facebook_link = microsite.get('course_about_facebook_link', 'http://www.facebook.com/EdxOnline')
+
+                email_subject = "mailto:?subject=Take%20a%20course%20with%20"+platform_name+"%20online&body=I%20just%20registered%20for%20"+course.number+"%20"+get_course_about_section(course, 'title')+"%20through%20"+platform_name+"%20http://"+site_domain+reverse('about_course', args=[course.id])
+              %>
+              <a href="${tweet_action}" class="share">
                 <img src="${static.url('images/social/twitter-sharing.png')}" alt="Tweet that you've registered for this course">
               </a>
-              <a href="http://www.facebook.com/EdxOnline" class="share">
+              <a href="${facebook_link}" class="share">
                 <img src="${static.url('images/social/facebook-sharing.png')}" alt="Post a Facebook message to say you've registered for this course">
               </a>
-              <a href="mailto:?subject=Take%20a%20course%20with%20edX%20online&body=I%20just%20registered%20for%20${course.number}%20${get_course_about_section(course, 'title')}%20through%20edX:+http://edx.org/${reverse('about_course', args=[course.id])}" class="share">
+              <a href="${email_subject}" class="share">
                 <img src="${static.url('images/social/email-sharing.png')}" alt="Email someone to say you've registered for this course">
               </a>
             % endif
           </div>
+          % endif
         </header>
 
         <ol class="important-dates">

--- a/lms/templates/courseware/courses.html
+++ b/lms/templates/courseware/courses.html
@@ -6,6 +6,22 @@
 <%block name="title"><title>${_("Courses")}</title></%block>
 
 <section class="find-courses">
+
+<%
+  course_index_overlay_text = microsite.get(
+    'course_index_overlay_text',
+    _("Explore free courses from leading universities.")
+  )
+
+  # not sure why this is, but if I use static.url('images/edx_bw.png') then the HTML rendering
+  # of this template goes wonky
+
+  logo_file = microsite.get(
+    'course_index_overlay_logo_file',
+    settings.STATIC_URL + 'images/edx_bw.png'
+  )
+%>
+
   <header class="search">
     <div class="inner-wrapper main-search">
       <hgroup>
@@ -13,13 +29,13 @@
           % if self.stanford_theme_enabled():
             <img src="${static.url('themes/stanford/images/seal.png')}" alt="Stanford Seal Logo" />
           % else:
-            <img src="${static.url('images/edx_bw.png')}" alt="Black and White edX Logo" />
+            <img src='${logo_file}' alt="${microsite.get('platform_name', settings.PLATFORM_NAME)} Logo" />
           % endif
         </div>
         % if self.stanford_theme_enabled():
           <h2>${_("Explore free courses from {university_name}.").format(university_name="Stanford University")}</h2>
         % else:
-          <h2>${_("Explore free courses from leading universities.")}</h2>
+          <h2>${course_index_overlay_text}</h2>
         % endif
       </hgroup>
     </div>

--- a/lms/templates/forgot_password_modal.html
+++ b/lms/templates/forgot_password_modal.html
@@ -22,7 +22,7 @@
             <li class="field required text" id="forgot-password-modal-field-email">
               <label for="pwd_reset_email">${_("Your E-mail Address")}</label>
               <input class="" id="pwd_reset_email" type="email" name="email" value="" placeholder="example: username@domain.com" aria-describedby="pwd_reset_email-tip" aria-required="true" />
-              <span class="tip tip-input" id="pwd_reset_email-tip">${_("This is the e-mail address you used to register with {platform}").format(platform=settings.PLATFORM_NAME)}</span>
+              <span class="tip tip-input" id="pwd_reset_email-tip">${_("This is the e-mail address you used to register with {platform}").format(platform=microsite.get('platform_name', settings.PLATFORM_NAME))}</span>
             </li>
           </ol>
         </fieldset>

--- a/lms/templates/help_modal.html
+++ b/lms/templates/help_modal.html
@@ -12,13 +12,13 @@
   <a href="#help-modal" rel="leanModal" role="button">${_("Help")}</a>
 </div>
 
-<section id="help-modal" class="modal" aria-hidden="true" role="dialog" aria-label='${_("{platform_name} Help").format(platform_name=settings.PLATFORM_NAME)}'>
+<section id="help-modal" class="modal" aria-hidden="true" role="dialog" aria-label='${_("{platform_name} Help").format(platform_name=microsite.get("platform_name", settings.PLATFORM_NAME))}'>
   <div class="inner-wrapper" id="help_wrapper">
     ## TODO: find a way to refactor this
     <button class="close-modal "tabindex="0">&#10005; <span class="sr">${_('Close Modal')}</span></button>
 
     <header>
-      <h2>${_('{span_start}{platform_name}{span_end} Help').format(span_start='<span class="edx">', span_end='</span>', platform_name=settings.PLATFORM_NAME)}</h2>
+      <h2>${_('{span_start}{platform_name}{span_end} Help').format(span_start='<span class="edx">', span_end='</span>', platform_name=microsite.get('platform_name', settings.PLATFORM_NAME))}</h2>
       <hr>
     </header>
 
@@ -39,10 +39,10 @@ discussion_link = get_discussion_link(course) if course else None
           url=marketing_link('FAQ')
         ),
         link_end='</a>',
-        platform_name=settings.PLATFORM_NAME)}
+        platform_name=microsite.get('platform_name', settings.PLATFORM_NAME))}
       </p>
 
-    <p>${_('Have a <strong>question about something specific</strong>? You can contact the {platform_name} general support team directly:').format(platform_name=settings.PLATFORM_NAME)}</p>
+    <p>${_('Have a <strong>question about something specific</strong>? You can contact the {platform_name} general support team directly:').format(platform_name=microsite.get('platform_name', settings.PLATFORM_NAME))}</p>
     <hr>
 
     <div class="help-buttons">

--- a/lms/templates/index.html
+++ b/lms/templates/index.html
@@ -5,17 +5,31 @@
 <%inherit file="main.html" />
 <%namespace name='static' file='static_content.html'/>
 
+<%
+  homepage_overlay_html = microsite.get('homepage_overlay_html')
+
+  show_homepage_promo_video = microsite.get('show_homepage_promo_video', True)
+  homepage_promo_video_youtube_id = microsite.get('homepage_promo_video_youtube_id', "XNaiOGxWeto")
+
+  show_partners = microsite.get('show_partners', True)
+
+%>
+
 <section class="home">
   <header>
     <div class="outer-wrapper">
       <div class="title">
         <hgroup>
-          % if self.stanford_theme_enabled():
-            <h1>${_("Free courses from <strong>{university_name}</strong>").format(university_name="Stanford")}</h1>
+          % if homepage_overlay_html:
+            ${homepage_overlay_html}
           % else:
-            <h1>${_("The Future of Online Education")}</h1>
+            % if self.stanford_theme_enabled():
+              <h1>${_("Free courses from <strong>{university_name}</strong>").format(university_name="Stanford")}</h1>
+            % else:
+              <h1>${_("The Future of Online Education")}</h1>
+            % endif
+            <h2>${_("For anyone, anywhere, anytime")}</h2>
           % endif
-          <h2>${_("For anyone, anywhere, anytime")}</h2>
         </hgroup>
 
         ## Disable social buttons for non-edX sites
@@ -40,22 +54,22 @@
               </div>
             </div>
           </section>
-        % endif
+          % endif
       </div>
 
+      % if show_homepage_promo_video:
         <a href="#video-modal" class="media" rel="leanModal">
           <div class="hero">
             <div class="play-intro"></div>
           </div>
         </a>
-
+      % endif
     </div>
   </header>
-
   <section class="container">
     <section class="highlighted-courses">
       ## Disable university partner logos and sites for non-edX sites
-      % if not self.theme_enabled():
+      % if not self.theme_enabled() and show_partners:
         <h2>${_('Explore free courses from {span_start}{platform_name}{span_end} universities').format(platform_name="edX", span_start='<span class="edx">', span_end='</span>')}</h2>
 
         <section class="university-partners university-partners2x6">
@@ -183,10 +197,9 @@
 <section id="video-modal" class="modal home-page-video-modal video-modal">
   <div class="inner-wrapper">
     <%
+      youtube_video_id = homepage_promo_video_youtube_id
       if self.stanford_theme_enabled():
         youtube_video_id = "2gmreZObCY4"
-      else:
-        youtube_video_id = "XNaiOGxWeto"
     %>
     <iframe width="640" height="360" src="//www.youtube.com/embed/${youtube_video_id}?showinfo=0" frameborder="0" allowfullscreen></iframe>
   </div>

--- a/lms/templates/login-sidebar.html
+++ b/lms/templates/login-sidebar.html
@@ -1,0 +1,30 @@
+<%!
+from django.utils.translation import ugettext as _
+from django.core.urlresolvers import reverse
+%>
+
+<header>
+  <h2 class="sr">${_("Helpful Information")}</h2>
+</header>
+
+% if settings.FEATURES.get('AUTH_USE_OPENID'):
+<!-- <div class="cta cta-login-options-openid">
+  <h3>${_("Login via OpenID")}</h3>
+  <p>${_('You can now start learning with {platform_name} by logging in with your <a rel="external" href="http://openid.net/">OpenID account</a>.').format(platform_name=microsite.get("platform_name", settings.PLATFORM_NAME))}</p>
+  <a class="action action-login-openid" href="#">${_("Login via OpenID")}</a>
+</div> -->
+% endif
+
+<div class="cta cta-help">
+  <h3>${_("Not Enrolled?")}</h3>
+  <p><a href="${reverse('register_user')}">${_("Sign up for {platform_name} today!").format(platform_name=microsite.get("platform_name", settings.PLATFORM_NAME))}</a></p>
+
+  ## Disable help unless the FAQ marketing link is enabled
+  % if settings.MKTG_URL_LINK_MAP.get('FAQ'):
+    <h3>${_("Need Help?")}</h3>
+    <p>${_("Looking for help in logging in or with your {platform_name} account?").format(platform_name=microsite.get("platform_name", settings.PLATFORM_NAME))}
+    <a href="${marketing_link('FAQ')}">
+        ${_("View our help section for answers to commonly asked questions.")}
+    </a></p>
+  % endif
+</div>

--- a/lms/templates/login.html
+++ b/lms/templates/login.html
@@ -1,11 +1,10 @@
 <%inherit file="main.html" />
-
 <%namespace name='static' file='static_content.html'/>
 
 <%! from django.core.urlresolvers import reverse %>
 <%! from django.utils.translation import ugettext as _ %>
 
-<%block name="title"><title>${_("Log into your {platform_name} Account").format(platform_name=settings.PLATFORM_NAME)}</title></%block>
+<%block name="title"><title>${_("Log into your {platform_name} Account").format(platform_name=microsite.get("platform_name", settings.PLATFORM_NAME))}</title></%block>
 
 <%block name="js_extra">
   <script type="text/javascript">
@@ -83,7 +82,7 @@
         $submitButton.
           removeClass('is-disabled').
           removeProp('disabled').
-          html("${_('Log into My {platform_name} Account').format(platform_name=settings.PLATFORM_NAME)} <span class='orn-plus'>+</span> ${_('Access My Courses')}");
+          html("${_('Log into My {platform_name} Account').format(platform_name=microsite.get("platform_name", settings.PLATFORM_NAME))} <span class='orn-plus'>+</span> ${_('Access My Courses')}");
       }
       else {
         $submitButton.
@@ -110,7 +109,7 @@
 
       <!-- status messages -->
       <div role="alert" class="status message">
-        <h3 class="message-title">${_("We're Sorry, {platform_name} accounts are unavailable currently").format(platform_name=settings.PLATFORM_NAME)}</h3>
+        <h3 class="message-title">${_("We're Sorry, {platform_name} accounts are unavailable currently").format(platform_name=microsite.get("platform_name", settings.PLATFORM_NAME))}</h3>
       </div>
 
       <div role="alert" class="status message submission-error" tabindex="-1">
@@ -121,7 +120,7 @@
       </div>
 
       <p class="instructions sr">
-        ${_('Please provide the following information to log into your {platform_name} account. Required fields are noted by <strong class="indicator">bold text and an asterisk (*)</strong>.').format(platform_name=settings.PLATFORM_NAME)}
+        ${_('Please provide the following information to log into your {platform_name} account. Required fields are noted by <strong class="indicator">bold text and an asterisk (*)</strong>.').format(platform_name=microsite.get("platform_name", settings.PLATFORM_NAME))}
       </p>
 
       <div class="group group-form group-form-requiredinformation">
@@ -131,7 +130,7 @@
           <li class="field required text" id="field-email">
             <label for="email">${_('E-mail')}</label>
             <input class="" id="email" type="email" name="email" value="" placeholder="example: username@domain.com" required aria-required="true" aria-described-by="email-tip" />
-            <span class="tip tip-input" id="email-tip">${_("This is the e-mail address you used to register with {platform}").format(platform=settings.PLATFORM_NAME)}</span>
+            <span class="tip tip-input" id="email-tip">${_("This is the e-mail address you used to register with {platform}").format(platform=microsite.get("platform_name", settings.PLATFORM_NAME))}</span>
           </li>
           <li class="field required password" id="field-password">
             <label for="password">${_('Password')}</label>
@@ -166,31 +165,14 @@
   </section>
 
   <aside role="complementary">
-    <header>
-      <h2 class="sr">${_("Helpful Information")}</h2>
-    </header>
 
-    % if settings.FEATURES.get('AUTH_USE_OPENID'):
-    <!-- <div class="cta cta-login-options-openid">
-      <h3>${_("Login via OpenID")}</h3>
-      <p>${_('You can now start learning with {platform_name} by logging in with your <a rel="external" href="http://openid.net/">OpenID account</a>.').format(platform_name=settings.PLATFORM_NAME)}</p>
-      <a class="action action-login-openid" href="#">${_("Login via OpenID")}</a>
-    </div> -->
-    % endif
+<%
+  # allow for microsite overrides on the registration sidebars, otherwise default to pre-existing ones
+  sidebar_file = microsite_tpl("login-sidebar.html")
+%>
 
-    <div class="cta cta-help">
-      <h3>${_("Not Enrolled?")}</h3>
-      <p><a href="${reverse('register_user')}">${_("Sign up for {platform_name} today!").format(platform_name=settings.PLATFORM_NAME)}</a></p>
+    <%include file="${sidebar_file}" />
 
-      ## Disable help unless the FAQ marketing link is enabled
-      % if settings.MKTG_URL_LINK_MAP.get('FAQ'):
-        <h3>${_("Need Help?")}</h3>
-        <p>${_("Looking for help in logging in or with your {platform_name} account?").format(platform_name=settings.PLATFORM_NAME)}
-        <a href="${marketing_link('FAQ')}">
-            ${_("View our help section for answers to commonly asked questions.")}
-        </a></p>
-      % endif
-    </div>
   </aside>
   </section>
 

--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -12,7 +12,17 @@
 </%def>
 
 <%def name="stanford_theme_enabled()">
-  <% return theme_enabled() and getattr(settings, "THEME_NAME") == "stanford" %>
+  <%
+    if not theme_enabled():
+      return False
+
+    theme_name = microsite.get("THEME_NAME")
+
+    if hasattr(settings, "THEME_NAME"):
+      theme_name = getattr(settings, "THEME_NAME")
+
+    return theme_enabled and theme_name == "stanford"
+  %>
 </%def>
 
 <!DOCTYPE html>
@@ -25,8 +35,7 @@
     % if stanford_theme_enabled():
       <title>${_("Home")} | class.stanford.edu</title>
     % else:
-      ## "edX" should not be translated
-      <title>edX</title>
+      <title>${microsite.get("platform_name", settings.PLATFORM_NAME)}</title>
 
       <meta http-equiv="X-UA-Compatible" content="IE=edge">
       <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -44,7 +53,7 @@
 
   <script type="text/javascript" src="/jsi18n/"></script>
 
-  <link rel="icon" type="image/x-icon" href="${static.url(settings.FAVICON_PATH)}" />
+  <link rel="icon" type="image/x-icon" href="${static.url(microsite.get('favicon_path', settings.FAVICON_PATH))}"/>
 
   <%static:css group='style-vendor'/>
   <%static:css group='style-app'/>
@@ -54,8 +63,27 @@
   <%static:js group='main_vendor'/>
 
   <%block name="headextra"/>
-  % if theme_enabled():
-    <%include file="theme-head-extra.html" />
+
+<%
+  if theme_enabled():
+    header_extra_file = 'theme-head-extra.html'
+    header_file = 'theme-header.html'
+    google_analytics_file = 'theme-google-analytics.html'
+    footer_file = 'theme-footer.html'
+
+    style_overrides_file = None
+
+  else:
+    header_extra_file = None
+    header_file = microsite_tpl('navigation.html')
+    google_analytics_file = microsite_tpl('google_analytics.html')
+    footer_file = microsite_tpl('footer.html')
+
+    style_overrides_file = microsite_tpl('css_overrides_file')
+%>
+
+  % if header_extra_file:
+    <%include file="${header_extra_file}" />
   % endif
 
   <!--[if lt IE 9]>
@@ -66,14 +94,15 @@
   <meta name="google-site-verification" content="_mipQ4AtZQDNmbtOkwehQDOgCxUUV2fb_C0b6wbiRHY" />
 
   % if not course:
-    % if theme_enabled():
-      <%include file="theme-google-analytics.html" />
-    % else:
-      <%include file="google_analytics.html" />
-    % endif
+    <%include file="${google_analytics_file}" />
   % endif
 
   <%include file="widgets/segment-io.html" />
+
+
+% if style_overrides_file:
+  <link rel="stylesheet" type="text/css" href="${static.url(style_overrides_file)}" />
+% endif
 
 </head>
 
@@ -82,21 +111,17 @@
 
   <%include file="mathjax_accessible.html" />
 
-% if theme_enabled():
-  <%include file="theme-header.html" />
-% elif not suppress_toplevel_navigation:
-  <%include file="navigation.html" />
-% endif
+% if not suppress_toplevel_navigation:
+  <%include file="${header_file}" />
+%endif
 
   <section class="content-wrapper" id="content">
     ${self.body()}
     <%block name="bodyextra"/>
   </section>
 
-% if theme_enabled():
-  <%include file="theme-footer.html" />
-% elif not suppress_toplevel_navigation:
-  <%include file="footer.html" />
+% if not suppress_toplevel_navigation:
+  <%include file="${footer_file}" />
 % endif
 
   <script>window.baseUrl = "${settings.STATIC_URL}";</script>
@@ -113,3 +138,5 @@
     html.escape(enrollment_action)
   ) if course_id and enrollment_action else ""
 }</%def>
+
+

--- a/lms/templates/navigation.html
+++ b/lms/templates/navigation.html
@@ -44,7 +44,7 @@ site_status_msg = get_site_status_msg(course_id)
   <h1 class="logo">
     <a href="${marketing_link('ROOT')}">
       <%block name="navigation_logo">
-        <img src="${static.url(branding.get_logo_url(request.META.get('HTTP_HOST')))}" alt="${settings.PLATFORM_NAME} ${_('Home')}" />
+          <img src="${static.url(branding.get_logo_url())}" alt="${microsite.get("platform_name", settings.PLATFORM_NAME)} ${_('Home')}" />
       </%block>
     </a>
   </h1>

--- a/lms/templates/register-sidebar.html
+++ b/lms/templates/register-sidebar.html
@@ -1,0 +1,53 @@
+<%!
+from django.utils.translation import ugettext as _
+from django.core.urlresolvers import reverse
+%>
+<%namespace file='main.html' import="login_query, stanford_theme_enabled"/>
+<%namespace name='static' file='static_content.html'/>
+
+
+<header>
+  <h3 class="sr">${_("Registration Help")}</h3>
+</header>
+
+% if has_extauth_info is UNDEFINED:
+
+<div class="cta">
+  <h3>${_("Already registered?")}</h3>
+  <p class="instructions">
+    <a href="${reverse('signin_user')}${login_query()}">
+      ${_("Click here to log in.")}
+    </a>
+  </p>
+</div>
+
+% endif
+
+    ## TODO: Use a %block tag or something to allow themes to
+##       override in a more generalizable fashion.
+% if not stanford_theme_enabled():
+  <div class="cta cta-welcome">
+    <h3>${_("Welcome to {platform_name}").format(platform_name=microsite.get("platform_name", settings.PLATFORM_NAME))}</h3>
+    <p>${_("Registering with {platform_name} gives you access to all of our current and future free courses. Not ready to take a course just yet? Registering puts you on our mailing list - we will update you as courses are added.").format(platform_name=microsite.get("platform_name", settings.PLATFORM_NAME))}</p>
+  </div>
+% endif
+
+<div class="cta cta-nextsteps">
+  <h3>${_("Next Steps")}</h3>
+  % if stanford_theme_enabled():
+    <p>${_("You will receive an activation email.  You must click on the activation link to complete the process.  Don't see the email?  Check your spam folder and mark emails from class.stanford.edu as 'not spam', since you'll want to be able to receive email from your courses.")}</p>
+  % else:
+  <p>${_("As part of joining {platform_name}, you will receive an activation email.  You must click on the activation link to complete the process.  Don't see the email?  Check your spam folder and mark {platform_name} emails as 'not spam'.  At {platform_name}, we communicate mostly through email.").format(platform_name=microsite.get("platform_name", settings.PLATFORM_NAME))}</p>
+  % endif
+</div>
+
+% if settings.MKTG_URL_LINK_MAP.get('FAQ'):
+  <div class="cta cta-help">
+    <h3>${_("Need Help?")}</h3>
+    <p>${_("Need help in registering with {platform_name}?").format(platform_name=microsite.get("platform_name", settings.PLATFORM_NAME))}
+      <a href="${marketing_link('FAQ')}">
+          ${_("View our FAQs for answers to commonly asked questions.")}
+      </a>
+      ${_("Once registered, most questions can be answered in the course specific discussion forums or through the FAQs.")}</p>
+  </div>
+% endif

--- a/lms/templates/register.html
+++ b/lms/templates/register.html
@@ -13,7 +13,8 @@
 <%! from datetime import date %>
 <%! import calendar %>
 
-<%block name="title"><title>${_("Register for {platform_name}").format(platform_name=settings.PLATFORM_NAME)}</title></%block>
+<%block name="title"><title>${_("Register for {platform_name}").format(
+  platform_name=microsite.get("platform_name", settings.PLATFORM_NAME))}</title></%block>
 
 <%block name="js_extra">
   <script type="text/javascript">
@@ -76,7 +77,7 @@
         $submitButton.
           removeClass('is-disabled').
           removeProp('disabled').
-          text("${_('Create My {platform_name} Account').format(platform_name=settings.PLATFORM_NAME)}");
+          text("${_('Create My {platform_name} Account').format(platform_name=microsite.get("platform_name", settings.PLATFORM_NAME))}");
       }
       else {
         $submitButton.
@@ -92,7 +93,7 @@
   <header>
     <h1 class="title">
       <span class="title-super">${_("Welcome!")}</span>
-      <span class="title-sub">${_("Register below to create your {platform_name} account").format(platform_name=settings.PLATFORM_NAME)}</span>
+      <span class="title-sub">${_("Register below to create your {platform_name} account").format(platform_name=microsite.get("platform_name", settings.PLATFORM_NAME))}</span>
     </h1>
   </header>
 </section>
@@ -104,7 +105,7 @@
 
       <!-- status messages -->
       <div role="alert" class="status message">
-        <h3 class="message-title">${_("We're sorry, {platform_name} enrollment is not available in your region").format(platform_name=settings.PLATFORM_NAME)}</h3>
+        <h3 class="message-title">${_("We're sorry, {platform_name} enrollment is not available in your region").format(platform_name=microsite.get("platform_name", settings.PLATFORM_NAME))}</h3>
       </div>
 
       <div role="alert" class="status message submission-error" tabindex="-1">
@@ -241,7 +242,7 @@
 
           % if 'goals' in settings.REGISTRATION_OPTIONAL_FIELDS:
           <li class="field text" id="field-goals">
-            <label for="goals">${_("Please share with us your reasons for registering with {platform_name}").format(platform_name=settings.PLATFORM_NAME)}</label>
+            <label for="goals">${_("Please share with us your reasons for registering with {platform_name}").format(platform_name=microsite.get("platform_name", settings.PLATFORM_NAME))}</label>
             <textarea id="goals" name="goals" value=""></textarea>
           </li>
           % endif
@@ -294,50 +295,13 @@
   </section>
 
   <aside role="complementary">
-    <header>
-      <h3 class="sr">${_("Registration Help")}</h3>
-    </header>
 
-    % if has_extauth_info is UNDEFINED:
+<%
+  # allow for microsite overrides on the registration sidebars, otherwise default to pre-existing ones
+  sidebar_file = microsite_tpl('register-sidebar.html')
+%>
 
-    <div class="cta">
-      <h3>${_("Already registered?")}</h3>
-      <p class="instructions">
-        <a href="${reverse('signin_user')}${login_query()}">
-          ${_("Click here to log in.")}
-        </a>
-      </p>
-    </div>
+    <%include file="${sidebar_file}" />
 
-    % endif
-
-    ## TODO: Use a %block tag or something to allow themes to
-    ##       override in a more generalizable fashion.
-    % if not self.stanford_theme_enabled():
-      <div class="cta cta-welcome">
-        <h3>${_("Welcome to {platform_name}").format(platform_name=settings.PLATFORM_NAME)}</h3>
-        <p>${_("Registering with {platform_name} gives you access to all of our current and future free courses. Not ready to take a course just yet? Registering puts you on our mailing list - we will update you as courses are added.").format(platform_name=settings.PLATFORM_NAME)}</p>
-      </div>
-    % endif
-
-    <div class="cta cta-nextsteps">
-      <h3>${_("Next Steps")}</h3>
-      % if self.stanford_theme_enabled():
-        <p>${_("You will receive an activation email.  You must click on the activation link to complete the process.  Don't see the email?  Check your spam folder and mark emails from class.stanford.edu as 'not spam', since you'll want to be able to receive email from your courses.")}</p>
-      % else:
-      <p>${_("As part of joining {platform_name}, you will receive an activation email.  You must click on the activation link to complete the process.  Don't see the email?  Check your spam folder and mark {platform_name} emails as 'not spam'.  At {platform_name}, we communicate mostly through email.").format(platform_name=settings.PLATFORM_NAME)}</p>
-      % endif
-    </div>
-
-    % if settings.MKTG_URL_LINK_MAP.get('FAQ'):
-      <div class="cta cta-help">
-        <h3>${_("Need Help?")}</h3>
-        <p>${_("Need help in registering with {platform_name}?").format(platform_name=settings.PLATFORM_NAME)}
-          <a href="${marketing_link('FAQ')}">
-              ${_("View our FAQs for answers to commonly asked questions.")}
-          </a>
-          ${_("Once registered, most questions can be answered in the course specific discussion forums or through the FAQs.")}</p>
-      </div>
-    % endif
   </aside>
 </section>


### PR DESCRIPTION
@chrisndodge has submitted pull request #2061 for the microsites feature, which is apparently on a tight deadline to be merged by Monday. I took a look at that pull request, and I have several concerns about the architecture of that solution. Since Chris has been crazy busy lately, I decided to create a new branch, working off of his, to try to show what I believe to be a better architecture. The main differences are:
- # 2061 creates a new middleware (common/djangoapps/microsite_configuration/middleware.py) that runs at the start and end of every single request, whether the request is for a page that would be modified by the presence of a microsite or not. This pull request replaces that middleware with a set of functions (common/djangoapps/student/microsites.py) that are called wherever microsite information is necessary, so there are some requests that don't ever call it.
- Because the middleware ran at the start and end of every request, it was possible to set information on and read information from the MicrositeConfiguration object at any time -- and #2061 takes full advantage of that, treating it as a global variable. It was very difficult to trace where the information on that object comes from, where it is modified, and so on. By contrast, because there is no global object in this PR, it's easier to trace the logic of where the microsite information comes from.
- # 2061 defines an `enable_microsites()` function in a settings file, which must be run after all of the microsite logic is defined in that same file -- which makes it almost impossible to cleanly change or reorder the microsite settings without also looking at every single place where that function is called. This PR moves that function into `lms/startup.py`, which is called _after_ all the settings logic is completed, so that we don't need to worry about ordering of the settings.
- # 2061 has a very verbose, layered API: a `MicrositeConfiguration` object with a `get_microsite_configuration_value()` class method, that wraps a Python dict. I've removed this API entirely, so that the Python dict is available, with stardard indexing and `get()` syntax, which is much more familiar, concise, and readable.
- # 2061 defines the microsite settings as a dictionary of key-value pairs, where the key is the name of a directory on disk, and the value is another dict that has configuration information for the microsite. My PR is similar, but rather than the key being the name of a directory, it is the subdomain where the microsite is available: that way, you can't define overlapping microsite subdomains, and you _can_ define two domains that point to the same microsite (like mit.edx.org and mitx.edx.org).

Unfortunately, I haven't been able to test this at all, because I haven't gotten the microsite assets that Chris has been using to test his branch. However, I believe the code is more concise, more readable, and more maintainable, and I'd like to at least have other developers compare the the two pull requests, so that whatever goes in has a decent code review.
