### PR TITLE
Add apostrophe to lorem and fix single-quoted strings

### DIFF
--- a/cms/templates/component.html
+++ b/cms/templates/component.html
@@ -31,6 +31,6 @@
   <a href="#" class="edit-button standard"><span class="edit-icon"></span>${_("Edit")}</a>
   <a href="#" class="delete-button standard"><span class="delete-icon"></span>${_("Delete")}</a>
 </div>
-<span data-tooltip='${_("Drag to reorder")}' class="drag-handle"></span>
+<span data-tooltip="${_("Drag to reorder")}" class="drag-handle"></span>
 ${preview}
 

--- a/cms/templates/import.html
+++ b/cms/templates/import.html
@@ -163,10 +163,10 @@ var allStats = $('#status-infos');
 var feedbackUrl = "${import_status_url}";
 
 var defaults = [
-    '${_("There was an error during the upload process.")}\n',
-    '${_("There was an error while unpacking the file.")}\n',
-    '${_("There was an error while verifying the file you submitted.")}\n',
-    '${_("There was an error while importing the new course to our database.")}\n'
+    "${_("There was an error during the upload process.")}\n",
+    "${_("There was an error while unpacking the file.")}\n",
+    "${_("There was an error while verifying the file you submitted.")}\n",
+    "${_("There was an error while importing the new course to our database.")}\n"
 ];
 
 $('#fileupload').fileupload({
@@ -201,12 +201,12 @@ $('#fileupload').fileupload({
                             CourseImport.stageError(stage, defaults[stage] + errMsg);
                         }
                         else {
-                            alert('${_("Your import has failed.")}\n\n' + errMsg);
+                            alert("${_("Your import has failed.")}\n\n" + errMsg);
                         }
-                        chooseBtn.html('${_("Choose new file")}').show();
+                        chooseBtn.html("${_("Choose new file")}").show();
                         bar.hide();
                     }
-                    chooseBtn.html('${_("Choose new file")}').show();
+                    chooseBtn.html("${_("Choose new file")}").show();
                     bar.hide();
                 });
             });
@@ -243,7 +243,7 @@ $('#fileupload').fileupload({
     },
     start: function(e) {
         window.onbeforeunload = function() {
-            return '${_("Your import is in progress; navigating away will abort it.")}';
+            return "${_("Your import is in progress; navigating away will abort it.")}";
         }
     },
     sequentialUploads: true,

--- a/cms/templates/widgets/problem-edit.html
+++ b/cms/templates/widgets/problem-edit.html
@@ -7,24 +7,24 @@
         %if enable_markdown:
         <div class="editor-bar">
             <ul class="format-buttons">
-                <li><a href="#" class="header-button" data-tooltip='${_("Heading 1")}'><span
+                <li><a href="#" class="header-button" data-tooltip="${_("Heading 1")}"><span
                         class="problem-editor-icon heading1"></span></a></li>
-                <li><a href="#" class="multiple-choice-button" data-tooltip='${_("Multiple Choice")}'><span
+                <li><a href="#" class="multiple-choice-button" data-tooltip="${_("Multiple Choice")}"><span
                         class="problem-editor-icon multiple-choice"></span></a></li>
-                <li><a href="#" class="checks-button" data-tooltip='${_("Checkboxes")}'><span
+                <li><a href="#" class="checks-button" data-tooltip="${_("Checkboxes")}"><span
                         class="problem-editor-icon checks"></span></a></li>
-                <li><a href="#" class="string-button" data-tooltip='${_("Text Input")}'><span
+                <li><a href="#" class="string-button" data-tooltip="${_("Text Input")}"><span
                         class="problem-editor-icon string"></span></a></li>
-                <li><a href="#" class="number-button" data-tooltip='${_("Numerical Input")}'><span
+                <li><a href="#" class="number-button" data-tooltip="${_("Numerical Input")}"><span
                         class="problem-editor-icon number"></span></a></li>
-                <li><a href="#" class="dropdown-button" data-tooltip='${_("Dropdown")}'><span
+                <li><a href="#" class="dropdown-button" data-tooltip="${_("Dropdown")}"><span
                         class="problem-editor-icon dropdown"></span></a></li>
-                <li><a href="#" class="explanation-button" data-tooltip='${_("Explanation")}'><span
+                <li><a href="#" class="explanation-button" data-tooltip="${_("Explanation")}"><span
                         class="problem-editor-icon explanation"></span></a></li>
             </ul>
             <ul class="editor-tabs">
                 <li><a href="#" class="xml-tab advanced-toggle" data-tab="xml">${_("Advanced Editor")}</a></li>
-                <li><a href="#" class="cheatsheet-toggle" data-tooltip='${_("Toggle Cheatsheet")}'>?</a></li>
+                <li><a href="#" class="cheatsheet-toggle" data-tooltip="${_("Toggle Cheatsheet")}">?</a></li>
             </ul>
         </div>
         <textarea class="markdown-box">${markdown | h}</textarea>

--- a/cms/templates/widgets/sock.html
+++ b/cms/templates/widgets/sock.html
@@ -22,7 +22,7 @@
 
       <ul class="list-actions">
         <li class="action-item">
-          <a href="http://files.edx.org/Getting_Started_with_Studio.pdf" class="action action-primary" title='${_("This is a PDF Document")}'>${_("Download Studio Documentation")}</a>
+          <a href="http://files.edx.org/Getting_Started_with_Studio.pdf" class="action action-primary" title="${_("This is a PDF Document")}">${_("Download Studio Documentation")}</a>
           <span class="tip">${_("How to use Studio to build your course")}</span>
         </li>
         <li class="action-item">
@@ -46,7 +46,7 @@
         <ul class="list-actions">
           <li class="action-item">
 
-            <a href="http://help.edge.edx.org/discussion/new" class="action action-primary show-tender" title='${_("Use our feedback tool, Tender, to share your feedback")}'><i class="icon-comments"></i>${_("Contact Us")}</a>
+            <a href="http://help.edge.edx.org/discussion/new" class="action action-primary show-tender" title="${_("Use our feedback tool, Tender, to share your feedback")}"><i class="icon-comments"></i>${_("Contact Us")}</a>
           </li>
         </ul>
       </div>

--- a/i18n/dummy.py
+++ b/i18n/dummy.py
@@ -53,10 +53,12 @@ TABLE = {
 
 # The print industry's standard dummy text, in use since the 1500s
 # see http://www.lipsum.com/, then fed through a "fancy-text" converter.
-# The string should start with a space.
+# The string should start with a space, so that it joins nicely with the text
+# that precedes it.  The Lorem contains an apostrophe since French often does,
+# and translated strings get put into single-quoted strings, which then break.
 LOREM = " " + " ".join(     # join and split just make the string easier here.
     u"""
-    Ⱡσяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя α∂ιριѕι¢ιηg єłιт, ѕє∂ ∂σ єιυѕмσ∂
+    Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя α∂ιριѕι¢ιηg єłιт, ѕє∂ ∂σ єιυѕмσ∂
     тємρσя ιη¢ι∂ι∂υηт υт łαвσяє єт ∂σłσяє мαgηα αłιqυα. υт єηιм α∂ мιηιм
     νєηιαм, qυιѕ ησѕтяυ∂ єχєя¢ιтαтιση υłłαм¢σ łαвσяιѕ ηιѕι υт αłιqυιρ єχ єα
     ¢σммσ∂σ ¢σηѕєqυαт.  ∂υιѕ αυтє ιяυяє ∂σłσя ιη яєρяєнєη∂єяιт ιη νσłυρтαтє
@@ -68,7 +70,7 @@ LOREM = " " + " ".join(     # join and split just make the string easier here.
 
 # To simulate more verbose languages (like German), pad the length of a string
 # by a multiple of PAD_FACTOR
-PAD_FACTOR = 1.3
+PAD_FACTOR = 1.33
 
 
 class Dummy(Converter):

--- a/i18n/tests/test_dummy.py
+++ b/i18n/tests/test_dummy.py
@@ -34,13 +34,13 @@ class TestDummy(TestCase):
 
     @ddt.data(
         (u"hello my name is Bond, James Bond",
-         u"héllø mý nämé ïs Bønd, Jämés Bønd Ⱡσяєм ι#"),
+         u"héllø mý nämé ïs Bønd, Jämés Bønd Ⱡ'σяєм ι#"),
 
         (u"don't convert <a href='href'>tag ids</a>",
-         u"døn't çønvért <a href='href'>täg ïds</a> Ⱡσяєм ιρѕυ#"),
+         u"døn't çønvért <a href='href'>täg ïds</a> Ⱡ'σяєм ιρѕυ#"),
 
         (u"don't convert %(name)s tags on %(date)s",
-         u"døn't çønvért %(name)s tägs øn %(date)s Ⱡσяєм ιρѕ#"),
+         u"døn't çønvért %(name)s tägs øn %(date)s Ⱡ'σяєм ιρѕ#"),
     )
     def test_dummy(self, data):
         """
@@ -53,17 +53,17 @@ class TestDummy(TestCase):
 
     def test_singular(self):
         entry = POEntry()
-        entry.msgid = 'A lovely day for a cup of tea.'
-        expected = u'À løvélý däý før ä çüp øf téä. Ⱡσяєм ι#'
+        entry.msgid = "A lovely day for a cup of tea."
+        expected = u"À løvélý däý før ä çüp øf téä. Ⱡ'σяєм #"
         self.converter.convert_msg(entry)
         self.assertUnicodeEquals(entry.msgstr, expected)
 
     def test_plural(self):
         entry = POEntry()
-        entry.msgid = 'A lovely day for a cup of tea.'
-        entry.msgid_plural = 'A lovely day for some cups of tea.'
-        expected_s = u'À løvélý däý før ä çüp øf téä. Ⱡσяєм ι#'
-        expected_p = u'À løvélý däý før sømé çüps øf téä. Ⱡσяєм ιρ#'
+        entry.msgid = "A lovely day for a cup of tea."
+        entry.msgid_plural = "A lovely day for some cups of tea."
+        expected_s = u"À løvélý däý før ä çüp øf téä. Ⱡ'σяєм #"
+        expected_p = u"À løvélý däý før sømé çüps øf téä. Ⱡ'σяєм ιρ#"
         self.converter.convert_msg(entry)
         result = entry.msgstr_plural
         self.assertUnicodeEquals(result['0'], expected_s)

--- a/lms/templates/courseware/instructor_dashboard.html
+++ b/lms/templates/courseware/instructor_dashboard.html
@@ -153,7 +153,7 @@ function goto( mode)
     %if offline_grade_log:
       <p>
         <span class="copy-warning">Pre-computed grades ${offline_grade_log} available: Use?
-          <input type='checkbox' name='use_offline_grades' value='${_("yes")}'>
+          <input type='checkbox' name='use_offline_grades' value="${_("yes")}">
         </span>
       </p>
     %endif

--- a/lms/templates/courseware/mktg_course_about.html
+++ b/lms/templates/courseware/mktg_course_about.html
@@ -37,7 +37,7 @@
         window.top.location.href = "${reverse('register_user')}?course_id=${course.id}&enrollment_action=enroll";
       } else {
         $('#register_error').html(
-            (xhr.responseText ? xhr.responseText : '${_("An error occurred. Please try again later.")}')
+            (xhr.responseText ? xhr.responseText : "${_("An error occurred. Please try again later.")}")
         ).css("display", "block");
       }
     });

--- a/lms/templates/help_modal.html
+++ b/lms/templates/help_modal.html
@@ -12,7 +12,7 @@
   <a href="#help-modal" rel="leanModal" role="button">${_("Help")}</a>
 </div>
 
-<section id="help-modal" class="modal" aria-hidden="true" role="dialog" aria-label='${_("{platform_name} Help").format(platform_name=settings.PLATFORM_NAME)}'>
+<section id="help-modal" class="modal" aria-hidden="true" role="dialog" aria-label="${_("{platform_name} Help").format(platform_name=settings.PLATFORM_NAME)}">
   <div class="inner-wrapper" id="help_wrapper">
     ## TODO: find a way to refactor this
     <button class="close-modal "tabindex="0">&#10005; <span class="sr">${_('Close Modal')}</span></button>


### PR DESCRIPTION
Translated strings (think French) can have apostrophes in them.  Translated strings are sometimes placed into single-quoted string literals, this will break French translations.  Add an apostrophe to the dummy text to help flush out these problems.  Also fix the dozen or so that I found with grep.
