### PR TITLE
Disabled static pages and course team test seen to fail in master

### DIFF
--- a/cms/djangoapps/contentstore/features/course-team.feature
+++ b/cms/djangoapps/contentstore/features/course-team.feature
@@ -61,19 +61,20 @@ Feature: CMS.Course Team
         And he cannot add users
         And he cannot delete users
 
-    Scenario: Admins should be able to give course ownership to someone else
-        Given I have opened a new course in Studio
-        And the user "gina" exists
-        And I am viewing the course team settings
-        When I add "gina" to the course team
-        And I make "gina" a course team admin
-        And I remove admin rights from myself
-        And "gina" logs in
-        And she selects the new course
-        And she views the course team settings
-        And she deletes me from the course team
-        And I am logged into studio
-        Then I do not see the course on my page
+    # Disabled 1/13/14 due to flakiness observed in master
+    #Scenario: Admins should be able to give course ownership to someone else
+    #    Given I have opened a new course in Studio
+    #    And the user "gina" exists
+    #    And I am viewing the course team settings
+    #    When I add "gina" to the course team
+    #    And I make "gina" a course team admin
+    #    And I remove admin rights from myself
+    #    And "gina" logs in
+    #    And she selects the new course
+    #    And she views the course team settings
+    #    And she deletes me from the course team
+    #    And I am logged into studio
+    #    Then I do not see the course on my page
 
     Scenario: Admins should be able to remove their own admin rights
         Given I have opened a new course in Studio

--- a/cms/djangoapps/contentstore/features/static-pages.feature
+++ b/cms/djangoapps/contentstore/features/static-pages.feature
@@ -8,12 +8,13 @@ Feature: CMS.Static Pages
         When I add a new page
         Then I should see a static page named "Empty"
 
-    Scenario: Users can delete static pages
-        Given I have created a static page
-        When I "delete" the static page
-        Then I am shown a prompt
-        When I confirm the prompt
-        Then I should not see any static pages
+    # Disabled 1/13/14 due to flakiness observed in master
+    #Scenario: Users can delete static pages
+    #    Given I have created a static page
+    #    When I "delete" the static page
+    #    Then I am shown a prompt
+    #    When I confirm the prompt
+    #    Then I should not see any static pages
 
     # Safari won't update the name properly
     @skip_safari


### PR DESCRIPTION
Seen to fail in this build: https://jenkins.testeng.edx.org/job/edx-all-tests-auto-master/SHARD=2,TEST_SUITE=cms-acceptance/721/

Created Studio bugs to get these fixed: STUD-1181 and STUD-1183

:(
