### PR TITLE
Disabled video updateplaytime JS test

### DIFF
--- a/common/lib/xmodule/xmodule/js/spec/video/video_player_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_player_spec.js
@@ -673,7 +673,8 @@
             });
         });
 
-        describe('updatePlayTime when start & end times are defined', function () {
+        // Disabled 1/13/14 due to flakiness observed in master
+        xdescribe('updatePlayTime when start & end times are defined', function () {
             var START_TIME = 1,
                 END_TIME = 2;
 


### PR DESCRIPTION
Still seeing failures: https://jenkins.testeng.edx.org/job/edx-all-tests-auto-master/726/SHARD=1,TEST_SUITE=unit/
I suspect this could be a YouTube network issue.  I verified that the video player is still working correctly on master in my sandbox.

@polesye @valera-rozuvan
