### PR TITLE
Internationalize "Not Graded" on front end (STUD-989)

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -312,7 +312,7 @@ class CourseGradingTest(CourseTestCase):
         descriptor = get_modulestore(self.course.location).get_item(self.course.location)
         section_grader_type = CourseGradingModel.get_section_grader_type(self.course_locator)
 
-        self.assertEqual('Not Graded', section_grader_type['graderType'])
+        self.assertEqual('notgraded', section_grader_type['graderType'])
         self.assertEqual(None, descriptor.format)
         self.assertEqual(False, descriptor.graded)
 
@@ -325,12 +325,12 @@ class CourseGradingTest(CourseTestCase):
         self.assertEqual('Homework', descriptor.format)
         self.assertEqual(True, descriptor.graded)
 
-        # Change the grader type back to Not Graded, which should also unmark the section as graded
-        CourseGradingModel.update_section_grader_type(self.course, 'Not Graded')
+        # Change the grader type back to notgraded, which should also unmark the section as graded
+        CourseGradingModel.update_section_grader_type(self.course, 'notgraded')
         descriptor = get_modulestore(self.course.location).get_item(self.course.location)
         section_grader_type = CourseGradingModel.get_section_grader_type(self.course_locator)
 
-        self.assertEqual('Not Graded', section_grader_type['graderType'])
+        self.assertEqual('notgraded', section_grader_type['graderType'])
         self.assertEqual(None, descriptor.format)
         self.assertEqual(False, descriptor.graded)
 
@@ -406,10 +406,10 @@ class CourseGradingTest(CourseTestCase):
         response = self.client.get_json(grade_type_url + '?fields=graderType')
         self.assertEqual(json.loads(response.content).get('graderType'), u'Homework')
         # and unset
-        response = self.client.ajax_post(grade_type_url, {'graderType': u'Not Graded'})
+        response = self.client.ajax_post(grade_type_url, {'graderType': u'notgraded'})
         self.assertEqual(200, response.status_code)
         response = self.client.get_json(grade_type_url + '?fields=graderType')
-        self.assertEqual(json.loads(response.content).get('graderType'), u'Not Graded')
+        self.assertEqual(json.loads(response.content).get('graderType'), u'notgraded')
 
 
 class CourseMetadataEditingTest(CourseTestCase):

--- a/cms/djangoapps/models/settings/course_grading.py
+++ b/cms/djangoapps/models/settings/course_grading.py
@@ -173,13 +173,13 @@ class CourseGradingModel(object):
         old_location = loc_mapper().translate_locator_to_location(location)
         descriptor = get_modulestore(old_location).get_item(old_location)
         return {
-            "graderType": descriptor.format if descriptor.format is not None else 'Not Graded',
+            "graderType": descriptor.format if descriptor.format is not None else 'notgraded',
             "location": unicode(location),
         }
 
     @staticmethod
     def update_section_grader_type(descriptor, grader_type):
-        if grader_type is not None and grader_type != u"Not Graded":
+        if grader_type is not None and grader_type != u'notgraded':
             descriptor.format = grader_type
             descriptor.graded = True
         else:

--- a/cms/static/js/models/assignment_grade.js
+++ b/cms/static/js/models/assignment_grade.js
@@ -1,7 +1,7 @@
 define(["backbone", "underscore"], function(Backbone, _) {
     var AssignmentGrade = Backbone.Model.extend({
         defaults : {
-            graderType : null, // the type label (string). May be "Not Graded" which implies None. 
+            graderType : null, // the type label (string). May be "notgraded" which implies None.
             locator : null // locator for the block
         },
         idAttribute: 'locator',

--- a/cms/static/js/views/overview_assignment_grader.js
+++ b/cms/static/js/views/overview_assignment_grader.js
@@ -1,5 +1,6 @@
 define(["js/views/baseview", "underscore", "gettext", "js/models/assignment_grade", "js/views/feedback_notification"],
         function(BaseView, _, gettext, AssignmentGrade, NotificationView) {
+    var l10nNotGraded = gettext('Not Graded');
     var OverviewAssignmentGrader = BaseView.extend({
         // instantiate w/ { graders : CourseGraderCollection, el : <the gradable-status div> }
         events : {
@@ -18,7 +19,9 @@ define(["js/views/baseview", "underscore", "gettext", "js/models/assignment_grad
                         '<% graders.each(function(option) { %>' +
                             '<li><a <% if (option.get("type") == assignmentType) {%>class="is-selected" <%}%> href="#"><%= option.get("type") %></a></li>' +
                         '<% }) %>' +
-                        '<li><a class="gradable-status-notgraded" href="#">Not Graded</a></li>' +
+                        '<li><a class="gradable-status-notgraded" href="#">' +
+                        l10nNotGraded +
+                        '</a></li>' +
                     '</ul>');
             this.assignmentGrade = new AssignmentGrade({
                 locator : this.$el.closest('.id-holder').data('locator'),
@@ -36,9 +39,15 @@ define(["js/views/baseview", "underscore", "gettext", "js/models/assignment_grad
             this.render();
         },
         render : function() {
-            this.$el.html(this.template({ assignmentType : this.assignmentGrade.get('graderType'), graders : this.graders,
-                hideSymbol : this.hideSymbol }));
-            if (this.assignmentGrade.has('graderType') && this.assignmentGrade.get('graderType') != "Not Graded") {
+            var graderType = this.assignmentGrade.get('graderType');
+            this.$el.html(this.template(
+                {
+                    assignmentType : (graderType == 'notgraded') ? l10nNotGraded : graderType,
+                    graders : this.graders,
+                    hideSymbol : this.hideSymbol
+                }
+            ));
+            if (this.assignmentGrade.has('graderType') && this.assignmentGrade.get('graderType') != "notgraded") {
                 this.$el.addClass('is-set');
             }
             else {
@@ -64,10 +73,10 @@ define(["js/views/baseview", "underscore", "gettext", "js/models/assignment_grad
                   saving.show();
 
               // TODO I'm not happy with this string fetch via the html for what should be an id. I'd rather use the id attr
-              // of the CourseGradingPolicy model or null for Not Graded (NOTE, change template's if check for is-selected accordingly)
+              // of the CourseGradingPolicy model or null for notgraded (NOTE, change template's if check for is-selected accordingly)
               this.assignmentGrade.save(
                       'graderType',
-                      $(e.target).text(),
+                      ($(e.target).hasClass('gradable-status-notgraded')) ? 'notgraded' : $(e.target).text(),
                       {success: function () { saving.hide(); }}
                   );
 

--- a/cms/templates/edit_subsection.html
+++ b/cms/templates/edit_subsection.html
@@ -62,7 +62,7 @@
     <div class="row gradable">
       <label>${_("Graded as:")}</label>
 
-    <div class="gradable-status" data-initial-status="${subsection.format if subsection.format is not None else _('Not Graded')}">
+    <div class="gradable-status" data-initial-status="${subsection.format if subsection.format is not None else 'notgraded'}">
     </div>
 
     <div class="due-date-input row">

--- a/cms/templates/overview.html
+++ b/cms/templates/overview.html
@@ -228,7 +228,7 @@ require(["domReady!", "jquery", "js/models/location", "js/models/section", "js/v
 
                           <ul class="actions-list">
                             <li class="actions-item grades">
-                              <div class="gradable-status" data-initial-status="${subsection.format if subsection.format is not None else _('Not Graded')}"></div>
+                              <div class="gradable-status" data-initial-status="${subsection.format if subsection.format is not None else 'notgraded'}"></div>
                             </li>
                             <li class="actions-item delete">
                               <a href="#" data-tooltip="${_('Delete this subsection')}" class="action delete-subsection-button"><i class="icon-trash"></i> <span class="sr">${_("Delete subsection")}</span></a>


### PR DESCRIPTION
@dmitchell @singingwolfboy an update of https://github.com/edx/edx-platform/pull/2067

(for some reason, that pull request didn't like the rebasing I was doing on it)

Anyways, I found the simplest thing was to keep passing around "Not Graded" in the backend, but display the internationalized version in the front end.
