### PR TITLE
updating DEBUG_TOOLBAR_PANELS in all related envs settings file to work with the new debug-toolbar version

### DIFF
--- a/cms/envs/dev_dbperf.py
+++ b/cms/envs/dev_dbperf.py
@@ -9,15 +9,14 @@ This configuration is to turn on the Django Toolbar stats for DB access stats, f
 from .dev import *
 
 DEBUG_TOOLBAR_PANELS = (
-    'debug_toolbar.panels.version.VersionDebugPanel',
-    'debug_toolbar.panels.timer.TimerDebugPanel',
-    'debug_toolbar.panels.settings_vars.SettingsVarsDebugPanel',
-    'debug_toolbar.panels.headers.HeaderDebugPanel',
-    'debug_toolbar.panels.request_vars.RequestVarsDebugPanel',
-    'debug_toolbar.panels.sql.SQLDebugPanel',
-    'debug_toolbar.panels.signals.SignalDebugPanel',
-    'debug_toolbar.panels.logger.LoggingPanel',
-    'debug_toolbar_mongo.panel.MongoDebugPanel'
+    'debug_toolbar.panels.versions.VersionsPanel',
+    'debug_toolbar.panels.timer.TimerPanel',
+    'debug_toolbar.panels.settings.SettingsPanel',
+    'debug_toolbar.panels.headers.HeadersPanel',
+    'debug_toolbar.panels.request.RequestPanel',
+    'debug_toolbar.panels.sql.SQLPanel',
+    'debug_toolbar.panels.signals.SignalsPanel',
+    'debug_toolbar.panels.logging.LoggingPanel',
 
     #  Enabling the profiler has a weird bug as of django-debug-toolbar==0.9.4 and
     #  Django=1.3.1/1.4 where requests to views get duplicated (your method gets

--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -37,14 +37,14 @@ MIDDLEWARE_CLASSES += ('debug_toolbar.middleware.DebugToolbarMiddleware',)
 INTERNAL_IPS = ('127.0.0.1',)
 
 DEBUG_TOOLBAR_PANELS = (
-    'debug_toolbar.panels.version.VersionDebugPanel',
-    'debug_toolbar.panels.timer.TimerDebugPanel',
-    'debug_toolbar.panels.settings_vars.SettingsVarsDebugPanel',
-    'debug_toolbar.panels.headers.HeaderDebugPanel',
-    'debug_toolbar.panels.request_vars.RequestVarsDebugPanel',
-    'debug_toolbar.panels.sql.SQLDebugPanel',
-    'debug_toolbar.panels.signals.SignalDebugPanel',
-    'debug_toolbar.panels.logger.LoggingPanel',
+    'debug_toolbar.panels.versions.VersionsPanel',
+    'debug_toolbar.panels.timer.TimerPanel',
+    'debug_toolbar.panels.settings.SettingsPanel',
+    'debug_toolbar.panels.headers.HeadersPanel',
+    'debug_toolbar.panels.request.RequestPanel',
+    'debug_toolbar.panels.sql.SQLPanel',
+    'debug_toolbar.panels.signals.SignalsPanel',
+    'debug_toolbar.panels.logging.LoggingPanel',
 )
 
 DEBUG_TOOLBAR_CONFIG = {

--- a/lms/envs/content.py
+++ b/lms/envs/content.py
@@ -19,14 +19,15 @@ INSTALLED_APPS += ('debug_toolbar',)
 MIDDLEWARE_CLASSES += ('debug_toolbar.middleware.DebugToolbarMiddleware',)
 
 DEBUG_TOOLBAR_PANELS = (
-   'debug_toolbar.panels.version.VersionDebugPanel',
-   'debug_toolbar.panels.timer.TimerDebugPanel',
-   'debug_toolbar.panels.settings_vars.SettingsVarsDebugPanel',
-   'debug_toolbar.panels.headers.HeaderDebugPanel',
-   'debug_toolbar.panels.request_vars.RequestVarsDebugPanel',
-   'debug_toolbar.panels.sql.SQLDebugPanel',
-   'debug_toolbar.panels.signals.SignalDebugPanel',
-   'debug_toolbar.panels.logger.LoggingPanel',
+   'debug_toolbar.panels.versions.VersionsPanel',
+   'debug_toolbar.panels.timer.TimerPanel',
+   'debug_toolbar.panels.settings.SettingsPanel',
+   'debug_toolbar.panels.headers.HeadersPanel',
+   'debug_toolbar.panels.request.RequestPanel',
+   'debug_toolbar.panels.sql.SQLPanel',
+   'debug_toolbar.panels.signals.SignalsPanel',
+   'debug_toolbar.panels.logging.LoggingPanel',
+
 
 #  Enabling the profiler has a weird bug as of django-debug-toolbar==0.9.4 and
 #  Django=1.3.1/1.4 where requests to views get duplicated (your method gets

--- a/lms/envs/devplus.py
+++ b/lms/envs/devplus.py
@@ -57,14 +57,15 @@ MIDDLEWARE_CLASSES += ('debug_toolbar.middleware.DebugToolbarMiddleware',)
 INTERNAL_IPS = ('127.0.0.1',)
 
 DEBUG_TOOLBAR_PANELS = (
-   'debug_toolbar.panels.version.VersionDebugPanel',
-   'debug_toolbar.panels.timer.TimerDebugPanel',
-   'debug_toolbar.panels.settings_vars.SettingsVarsDebugPanel',
-   'debug_toolbar.panels.headers.HeaderDebugPanel',
-   'debug_toolbar.panels.request_vars.RequestVarsDebugPanel',
-   'debug_toolbar.panels.sql.SQLDebugPanel',
-   'debug_toolbar.panels.signals.SignalDebugPanel',
-   'debug_toolbar.panels.logger.LoggingPanel',
+   'debug_toolbar.panels.versions.VersionsPanel',
+   'debug_toolbar.panels.timer.TimerPanel',
+   'debug_toolbar.panels.settings.SettingsPanel',
+   'debug_toolbar.panels.headers.HeadersPanel',
+   'debug_toolbar.panels.request.RequestPanel',
+   'debug_toolbar.panels.sql.SQLPanel',
+   'debug_toolbar.panels.signals.SignalsPanel',
+   'debug_toolbar.panels.logging.LoggingPanel',
+
 
 #  Enabling the profiler has a weird bug as of django-debug-toolbar==0.9.4 and
 #  Django=1.3.1/1.4 where requests to views get duplicated (your method gets

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -35,14 +35,14 @@ MIDDLEWARE_CLASSES += ('django_comment_client.utils.QueryCountDebugMiddleware',
 INTERNAL_IPS = ('127.0.0.1',)
 
 DEBUG_TOOLBAR_PANELS = (
-    'debug_toolbar.panels.version.VersionDebugPanel',
-    'debug_toolbar.panels.timer.TimerDebugPanel',
-    'debug_toolbar.panels.settings_vars.SettingsVarsDebugPanel',
-    'debug_toolbar.panels.headers.HeaderDebugPanel',
-    'debug_toolbar.panels.request_vars.RequestVarsDebugPanel',
-    'debug_toolbar.panels.sql.SQLDebugPanel',
-    'debug_toolbar.panels.signals.SignalDebugPanel',
-    'debug_toolbar.panels.logger.LoggingPanel',
+    'debug_toolbar.panels.versions.VersionsPanel',
+    'debug_toolbar.panels.timer.TimerPanel',
+    'debug_toolbar.panels.settings.SettingsPanel',
+    'debug_toolbar.panels.headers.HeadersPanel',
+    'debug_toolbar.panels.request.RequestPanel',
+    'debug_toolbar.panels.sql.SQLPanel',
+    'debug_toolbar.panels.signals.SignalsPanel',
+    'debug_toolbar.panels.logging.LoggingPanel',
 )
 
 DEBUG_TOOLBAR_CONFIG = {


### PR DESCRIPTION
updating DEBUG_TOOLBAR_PANELS in all related envs settings file to work with the new debug-toolbar version.
