### PR TITLE
Revert django-debug-toolbar related updates on master, set version to 0....

### DIFF
--- a/cms/envs/dev.py
+++ b/cms/envs/dev.py
@@ -152,14 +152,14 @@ MIDDLEWARE_CLASSES += ('debug_toolbar.middleware.DebugToolbarMiddleware',)
 INTERNAL_IPS = ('127.0.0.1',)
 
 DEBUG_TOOLBAR_PANELS = (
-    'debug_toolbar.panels.versions.VersionsPanel',
-    'debug_toolbar.panels.timer.TimerPanel',
-    'debug_toolbar.panels.settings.SettingsPanel',
-    'debug_toolbar.panels.headers.HeadersPanel',
-    'debug_toolbar.panels.request.RequestPanel',
-    'debug_toolbar.panels.sql.SQLPanel',
-    'debug_toolbar.panels.signals.SignalsPanel',
-    'debug_toolbar.panels.logging.LoggingPanel',
+    'debug_toolbar.panels.version.VersionDebugPanel',
+    'debug_toolbar.panels.timer.TimerDebugPanel',
+    'debug_toolbar.panels.settings_vars.SettingsVarsDebugPanel',
+    'debug_toolbar.panels.headers.HeaderDebugPanel',
+    'debug_toolbar.panels.request_vars.RequestVarsDebugPanel',
+    'debug_toolbar.panels.sql.SQLDebugPanel',
+    'debug_toolbar.panels.signals.SignalDebugPanel',
+    'debug_toolbar.panels.logger.LoggingPanel',
 
     #  Enabling the profiler has a weird bug as of django-debug-toolbar==0.9.4 and
     #  Django=1.3.1/1.4 where requests to views get duplicated (your method gets

--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -37,14 +37,14 @@ MIDDLEWARE_CLASSES += ('debug_toolbar.middleware.DebugToolbarMiddleware',)
 INTERNAL_IPS = ('127.0.0.1',)
 
 DEBUG_TOOLBAR_PANELS = (
-    'debug_toolbar.panels.versions.VersionsPanel',
-    'debug_toolbar.panels.timer.TimerPanel',
-    'debug_toolbar.panels.settings.SettingsPanel',
-    'debug_toolbar.panels.headers.HeadersPanel',
-    'debug_toolbar.panels.request.RequestPanel',
-    'debug_toolbar.panels.sql.SQLPanel',
-    'debug_toolbar.panels.signals.SignalsPanel',
-    'debug_toolbar.panels.logging.LoggingPanel',
+    'debug_toolbar.panels.version.VersionDebugPanel',
+    'debug_toolbar.panels.timer.TimerDebugPanel',
+    'debug_toolbar.panels.settings_vars.SettingsVarsDebugPanel',
+    'debug_toolbar.panels.headers.HeaderDebugPanel',
+    'debug_toolbar.panels.request_vars.RequestVarsDebugPanel',
+    'debug_toolbar.panels.sql.SQLDebugPanel',
+    'debug_toolbar.panels.signals.SignalDebugPanel',
+    'debug_toolbar.panels.logger.LoggingPanel',
 )
 
 DEBUG_TOOLBAR_CONFIG = {

--- a/lms/envs/dev.py
+++ b/lms/envs/dev.py
@@ -222,14 +222,14 @@ MIDDLEWARE_CLASSES += ('django_comment_client.utils.QueryCountDebugMiddleware',
 INTERNAL_IPS = ('127.0.0.1',)
 
 DEBUG_TOOLBAR_PANELS = (
-   'debug_toolbar.panels.versions.VersionsPanel',
-   'debug_toolbar.panels.timer.TimerPanel',
-   'debug_toolbar.panels.settings.SettingsPanel',
-   'debug_toolbar.panels.headers.HeadersPanel',
-   'debug_toolbar.panels.request.RequestPanel',
-   'debug_toolbar.panels.sql.SQLPanel',
-   'debug_toolbar.panels.signals.SignalsPanel',
-   'debug_toolbar.panels.logging.LoggingPanel',
+   'debug_toolbar.panels.version.VersionDebugPanel',
+   'debug_toolbar.panels.timer.TimerDebugPanel',
+   'debug_toolbar.panels.settings_vars.SettingsVarsDebugPanel',
+   'debug_toolbar.panels.headers.HeaderDebugPanel',
+   'debug_toolbar.panels.request_vars.RequestVarsDebugPanel',
+   'debug_toolbar.panels.sql.SQLDebugPanel',
+   'debug_toolbar.panels.signals.SignalDebugPanel',
+   'debug_toolbar.panels.logger.LoggingPanel',
 
 #  Enabling the profiler has a weird bug as of django-debug-toolbar==0.9.4 and
 #  Django=1.3.1/1.4 where requests to views get duplicated (your method gets

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -35,14 +35,14 @@ MIDDLEWARE_CLASSES += ('django_comment_client.utils.QueryCountDebugMiddleware',
 INTERNAL_IPS = ('127.0.0.1',)
 
 DEBUG_TOOLBAR_PANELS = (
-   'debug_toolbar.panels.versions.VersionsPanel',
-   'debug_toolbar.panels.timer.TimerPanel',
-   'debug_toolbar.panels.settings.SettingsPanel',
-   'debug_toolbar.panels.headers.HeadersPanel',
-   'debug_toolbar.panels.request.RequestPanel',
-   'debug_toolbar.panels.sql.SQLPanel',
-   'debug_toolbar.panels.signals.SignalsPanel',
-   'debug_toolbar.panels.logging.LoggingPanel',
+    'debug_toolbar.panels.version.VersionDebugPanel',
+    'debug_toolbar.panels.timer.TimerDebugPanel',
+    'debug_toolbar.panels.settings_vars.SettingsVarsDebugPanel',
+    'debug_toolbar.panels.headers.HeaderDebugPanel',
+    'debug_toolbar.panels.request_vars.RequestVarsDebugPanel',
+    'debug_toolbar.panels.sql.SQLDebugPanel',
+    'debug_toolbar.panels.signals.SignalDebugPanel',
+    'debug_toolbar.panels.logger.LoggingPanel',
 )
 
 DEBUG_TOOLBAR_CONFIG = {

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -103,7 +103,7 @@ rednose==0.3
 selenium==2.34.0
 splinter==0.5.4
 django_nose==1.1
-django_debug_toolbar==1.0.1
+django_debug_toolbar==0.9.4
 django-debug-toolbar-mongo
 nose-ignore-docstring
 nose-exclude


### PR DESCRIPTION
...9.4

(STUD-1201)

Revert "Specific django-toolbar version (stable released) and update the panels in dev envs"

This reverts commit a465b082da3e45604f7b4ccb210ce2826e79e72d.

Revert "Updated settings for devstack django debug toolbar"

This reverts commit 30199e8a615c54640116a6c223ba90e32a6967d2.

The latest version of ddt conflicts with requirejs when running locally, so rolling back the version to one that was known to work.

@cahrens 
@wedaly 
