### PR TITLE
Notify instructors that static page content is publicly accessible

### DIFF
--- a/cms/templates/edit-tabs.html
+++ b/cms/templates/edit-tabs.html
@@ -47,6 +47,7 @@ require(["js/models/explicit_url", "coffee/src/views/tabs"], function(TabsModel,
   <section class="content">
     <div class="introduction has-links">
       <p class="copy">${_("Use Static Pages to share a syllabus, a calendar, handouts, or other supplements to your courseware.")}</p>
+      <p class="copy">${_("NOTE: all content on Static Pages will be visible to anyone who knows the URL, regardless of whether they are registered in the course or not.")}</p>
       <nav class="nav-introduction-supplementary">
         <ul>
           <li class="nav-item">


### PR DESCRIPTION
@singingwolfboy - Here is a PR to address an issue brought up by an instructor who was  upset that he wasn't told that Static Pages are publicly accessible.
