### PR TITLE
Yarko/debug toolbar 1.0 fixes - completes changes for django-debug-toolbar 1.0.1

### DIFF
--- a/cms/envs/dev.py
+++ b/cms/envs/dev.py
@@ -165,7 +165,7 @@ DEBUG_TOOLBAR_PANELS = (
     #  Django=1.3.1/1.4 where requests to views get duplicated (your method gets
     #  hit twice). So you can uncomment when you need to diagnose performance
     #  problems, but you shouldn't leave it on.
-    #  'debug_toolbar.panels.profiling.ProfilingDebugPanel',
+    #  'debug_toolbar.panels.profiling.ProfilingPanel',
 )
 
 DEBUG_TOOLBAR_CONFIG = {

--- a/cms/envs/dev_dbperf.py
+++ b/cms/envs/dev_dbperf.py
@@ -9,21 +9,21 @@ This configuration is to turn on the Django Toolbar stats for DB access stats, f
 from .dev import *
 
 DEBUG_TOOLBAR_PANELS = (
-    'debug_toolbar.panels.version.VersionDebugPanel',
-    'debug_toolbar.panels.timer.TimerDebugPanel',
-    'debug_toolbar.panels.settings_vars.SettingsVarsDebugPanel',
-    'debug_toolbar.panels.headers.HeaderDebugPanel',
-    'debug_toolbar.panels.request_vars.RequestVarsDebugPanel',
-    'debug_toolbar.panels.sql.SQLDebugPanel',
-    'debug_toolbar.panels.signals.SignalDebugPanel',
-    'debug_toolbar.panels.logger.LoggingPanel',
-    'debug_toolbar_mongo.panel.MongoDebugPanel'
+    'debug_toolbar.panels.versions.VersionsPanel',
+    'debug_toolbar.panels.timer.TimerPanel',
+    'debug_toolbar.panels.settings.SettingsPanel',
+    'debug_toolbar.panels.headers.HeadersPanel',
+    'debug_toolbar.panels.request.RequestPanel',
+    'debug_toolbar.panels.sql.SQLPanel',
+    'debug_toolbar.panels.signals.SignalsPanel',
+    'debug_toolbar.panels.logging.LoggingPanel',
+    'debug_toolbar_mongo.panel.MongoDebugPanel',
 
     #  Enabling the profiler has a weird bug as of django-debug-toolbar==0.9.4 and
     #  Django=1.3.1/1.4 where requests to views get duplicated (your method gets
     #  hit twice). So you can uncomment when you need to diagnose performance
     #  problems, but you shouldn't leave it on.
-    #  'debug_toolbar.panels.profiling.ProfilingDebugPanel',
+    #  'debug_toolbar.panels.profiling.ProfilingPanel',
 )
 
 # To see stacktraces for MongoDB queries, set this to True.

--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -37,14 +37,20 @@ MIDDLEWARE_CLASSES += ('debug_toolbar.middleware.DebugToolbarMiddleware',)
 INTERNAL_IPS = ('127.0.0.1',)
 
 DEBUG_TOOLBAR_PANELS = (
-    'debug_toolbar.panels.version.VersionDebugPanel',
-    'debug_toolbar.panels.timer.TimerDebugPanel',
-    'debug_toolbar.panels.settings_vars.SettingsVarsDebugPanel',
-    'debug_toolbar.panels.headers.HeaderDebugPanel',
-    'debug_toolbar.panels.request_vars.RequestVarsDebugPanel',
-    'debug_toolbar.panels.sql.SQLDebugPanel',
-    'debug_toolbar.panels.signals.SignalDebugPanel',
-    'debug_toolbar.panels.logger.LoggingPanel',
+    'debug_toolbar.panels.versions.VersionsPanel',
+    'debug_toolbar.panels.timer.TimerPanel',
+    'debug_toolbar.panels.settings.SettingsPanel',
+    'debug_toolbar.panels.headers.HeadersPanel',
+    'debug_toolbar.panels.request.RequestPanel',
+    'debug_toolbar.panels.sql.SQLPanel',
+    'debug_toolbar.panels.signals.SignalsPanel',
+    'debug_toolbar.panels.logging.LoggingPanel',
+
+    #  Enabling the profiler has a weird bug as of django-debug-toolbar==0.9.4 and
+    #  Django=1.3.1/1.4 where requests to views get duplicated (your method gets
+    #  hit twice). So you can uncomment when you need to diagnose performance
+    #  problems, but you shouldn't leave it on.
+    #  'debug_toolbar.panels.profiling.ProfilingPanel',
 )
 
 DEBUG_TOOLBAR_CONFIG = {

--- a/common/test/data/test_unicode/static/unicø∂é.txt
+++ b/common/test/data/test_unicode/static/unicø∂é.txt
@@ -1,0 +1,10 @@
+
+Upside down unicode text (http://www.sunnyneo.com/upsidedowntext.php?)
+
+˙ʇʇɐld uoɯəl plos əɥs ˙pəʌıl əuɹʎq ʎʇʇəq əɹəɥʍ pɐoɹ əɥʇ uʍop əɯɐɔ ʍoɔ-ooɯ əɥʇ 
+˙ooʞɔnʇ ʎqɐq sɐʍ əɥ ˙əɔɐɟ ʎɹıɐɥ ɐ pɐɥ əɥ :ssɐlƃ ɐ ɥƃnoɹɥʇ ɯıɥ ʇɐ pəʞool ɹəɥʇɐɟ 
+sıɥ :ʎɹoʇs ʇɐɥʇ ɯıɥ ploʇ ɹəɥʇɐɟ sıɥ 
+
+˙˙˙ooʞɔnʇ ʎqɐq pəɯɐu ʎoq əlʇʇıl suəɔıu ɐ ʇəɯ pɐoɹ əɥʇ ƃuolɐ uʍop ƃuıɯoɔ sɐʍ ʇɐɥʇ 
+ʍoɔ-ooɯ sıɥʇ puɐ pɐoɹ əɥʇ ƃuolɐ uʍop ƃuıɯoɔ ʍoɔ-ooɯ ɐ sɐʍ əɹəɥʇ sɐʍ ʇı əɯıʇ pooƃ 
+ʎɹəʌ ɐ puɐ əɯıʇ ɐ uodn əɔuo

--- a/lms/envs/content.py
+++ b/lms/envs/content.py
@@ -19,18 +19,19 @@ INSTALLED_APPS += ('debug_toolbar',)
 MIDDLEWARE_CLASSES += ('debug_toolbar.middleware.DebugToolbarMiddleware',)
 
 DEBUG_TOOLBAR_PANELS = (
-   'debug_toolbar.panels.version.VersionDebugPanel',
-   'debug_toolbar.panels.timer.TimerDebugPanel',
-   'debug_toolbar.panels.settings_vars.SettingsVarsDebugPanel',
-   'debug_toolbar.panels.headers.HeaderDebugPanel',
-   'debug_toolbar.panels.request_vars.RequestVarsDebugPanel',
-   'debug_toolbar.panels.sql.SQLDebugPanel',
-   'debug_toolbar.panels.signals.SignalDebugPanel',
-   'debug_toolbar.panels.logger.LoggingPanel',
+   'debug_toolbar.panels.versions.VersionsPanel',
+   'debug_toolbar.panels.timer.TimerPanel',
+   'debug_toolbar.panels.settings.SettingsPanel',
+   'debug_toolbar.panels.headers.HeadersPanel',
+   'debug_toolbar.panels.request.RequestPanel',
+   'debug_toolbar.panels.sql.SQLPanel',
+   'debug_toolbar.panels.signals.SignalsPanel',
+   'debug_toolbar.panels.logging.LoggingPanel',
 
 #  Enabling the profiler has a weird bug as of django-debug-toolbar==0.9.4 and
 #  Django=1.3.1/1.4 where requests to views get duplicated (your method gets
 #  hit twice). So you can uncomment when you need to diagnose performance
 #  problems, but you shouldn't leave it on.
-#  'debug_toolbar.panels.profiling.ProfilingDebugPanel',
+#  'debug_toolbar.panels.profiling.ProfilingPanel',
 )
+

--- a/lms/envs/dev.py
+++ b/lms/envs/dev.py
@@ -235,7 +235,7 @@ DEBUG_TOOLBAR_PANELS = (
 #  Django=1.3.1/1.4 where requests to views get duplicated (your method gets
 #  hit twice). So you can uncomment when you need to diagnose performance
 #  problems, but you shouldn't leave it on.
-#  'debug_toolbar.panels.profiling.ProfilingDebugPanel',
+#  'debug_toolbar.panels.profiling.ProfilingPanel',
 )
 
 DEBUG_TOOLBAR_CONFIG = {

--- a/lms/envs/devplus.py
+++ b/lms/envs/devplus.py
@@ -57,20 +57,20 @@ MIDDLEWARE_CLASSES += ('debug_toolbar.middleware.DebugToolbarMiddleware',)
 INTERNAL_IPS = ('127.0.0.1',)
 
 DEBUG_TOOLBAR_PANELS = (
-   'debug_toolbar.panels.version.VersionDebugPanel',
-   'debug_toolbar.panels.timer.TimerDebugPanel',
-   'debug_toolbar.panels.settings_vars.SettingsVarsDebugPanel',
-   'debug_toolbar.panels.headers.HeaderDebugPanel',
-   'debug_toolbar.panels.request_vars.RequestVarsDebugPanel',
-   'debug_toolbar.panels.sql.SQLDebugPanel',
-   'debug_toolbar.panels.signals.SignalDebugPanel',
-   'debug_toolbar.panels.logger.LoggingPanel',
+   'debug_toolbar.panels.versions.VersionsPanel',
+   'debug_toolbar.panels.timer.TimerPanel',
+   'debug_toolbar.panels.settings.SettingsPanel',
+   'debug_toolbar.panels.headers.HeadersPanel',
+   'debug_toolbar.panels.request.RequestPanel',
+   'debug_toolbar.panels.sql.SQLPanel',
+   'debug_toolbar.panels.signals.SignalsPanel',
+   'debug_toolbar.panels.logging.LoggingPanel',
 
 #  Enabling the profiler has a weird bug as of django-debug-toolbar==0.9.4 and
 #  Django=1.3.1/1.4 where requests to views get duplicated (your method gets
 #  hit twice). So you can uncomment when you need to diagnose performance
 #  problems, but you shouldn't leave it on.
-  'debug_toolbar.panels.profiling.ProfilingDebugPanel',
+  'debug_toolbar.panels.profiling.ProfilingPanel',
 )
 
 #PIPELINE = True

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -35,14 +35,20 @@ MIDDLEWARE_CLASSES += ('django_comment_client.utils.QueryCountDebugMiddleware',
 INTERNAL_IPS = ('127.0.0.1',)
 
 DEBUG_TOOLBAR_PANELS = (
-    'debug_toolbar.panels.version.VersionDebugPanel',
-    'debug_toolbar.panels.timer.TimerDebugPanel',
-    'debug_toolbar.panels.settings_vars.SettingsVarsDebugPanel',
-    'debug_toolbar.panels.headers.HeaderDebugPanel',
-    'debug_toolbar.panels.request_vars.RequestVarsDebugPanel',
-    'debug_toolbar.panels.sql.SQLDebugPanel',
-    'debug_toolbar.panels.signals.SignalDebugPanel',
-    'debug_toolbar.panels.logger.LoggingPanel',
+    'debug_toolbar.panels.versions.VersionsPanel',
+    'debug_toolbar.panels.timer.TimerPanel',
+    'debug_toolbar.panels.settings.SettingsPanel',
+    'debug_toolbar.panels.headers.HeadersPanel',
+    'debug_toolbar.panels.request.RequestPanel',
+    'debug_toolbar.panels.sql.SQLPanel',
+    'debug_toolbar.panels.signals.SignalsPanel',
+    'debug_toolbar.panels.logging.LoggingPanel',
+
+#  Enabling the profiler has a weird bug as of django-debug-toolbar==0.9.4 and
+#  Django=1.3.1/1.4 where requests to views get duplicated (your method gets
+#  hit twice). So you can uncomment when you need to diagnose performance
+#  problems, but you shouldn't leave it on.
+#  'debug_toolbar.panels.profiling.ProfilingPanel',
 )
 
 DEBUG_TOOLBAR_CONFIG = {


### PR DESCRIPTION
#2117 began changes, but left commented ProfilingDebugPanel in old form - this fixes;
#2208 added two files, but left out remaining files - this pull adds them;

Also, this pull corrects / adds trailing ',' at MongoDebugPanel in cms/envs/dev_dbperf.py,
In addition to #2208 & #2117, this also updates the 3 remaining files which needed updating.

Note - earlier today, I'd posted a patch (https://gist.github.com/yarko/8473409) of these files prior to #2208 being merged, and posted that patch on edx-code groups, to help  people stuck there.  Sometime today, #2215 was created, but with errors.  Rather than comment on the errors in #2215, I've created this pull based on my work last night, merged with todays master.
