### PR TITLE
Certs - bugfix cert_whitelist output

### DIFF
--- a/lms/djangoapps/certificates/management/commands/cert_whitelist.py
+++ b/lms/djangoapps/certificates/management/commands/cert_whitelist.py
@@ -67,7 +67,7 @@ class Command(BaseCommand):
                 cert_whitelist.whitelist = False
             cert_whitelist.save()
 
-        whitelist = CertificateWhitelist.objects.all()
+        whitelist = CertificateWhitelist.objects.filter(course_id=course_id)
         print "User whitelist for course {0}:\n{1}".format(course_id,
               '\n'.join(["{0} {1} {2}".format(
                   u.user.username, u.user.email, u.whitelist)


### PR DESCRIPTION
- output after cert_whitelist -a or -d purported to be the whitelist entries
  for the requested course, but in fact were all of the entries in every
  course. This commit fixes that.
