### PR TITLE
Really large posts to ORA like peer grading feedback fixed.

### DIFF
--- a/common/lib/xmodule/xmodule/peer_grading_module.py
+++ b/common/lib/xmodule/xmodule/peer_grading_module.py
@@ -23,6 +23,7 @@ log = logging.getLogger(__name__)
 
 
 EXTERNAL_GRADER_NO_CONTACT_ERROR = "Failed to contact external graders.  Please notify course staff."
+MAX_ALLOWED_FEEDBACK_LENGTH = 5000
 
 
 class PeerGradingFields(object):
@@ -344,6 +345,10 @@ class PeerGradingModule(PeerGradingFields, XModule):
         if not success:
             return self._err_response(message)
 
+        success, message = self._check_feedback_length(data)
+        if not success:
+            return self._err_response(message)
+
         data_dict = {k:data.get(k) for k in required}
         if 'rubric_scores[]' in required:
             data_dict['rubric_scores'] = data.getall('rubric_scores[]')
@@ -637,6 +642,15 @@ class PeerGradingModule(PeerGradingFields, XModule):
         }
 
         return json.dumps(state)
+
+    def _check_feedback_length(self, data):
+        feedback = data.get("feedback")
+        if feedback and len(feedback) > MAX_ALLOWED_FEEDBACK_LENGTH:
+            return False, "Feedback is too long, Max length is {0} characters.".format(
+                MAX_ALLOWED_FEEDBACK_LENGTH
+            )
+        else:
+            return True, ""
 
 
 class PeerGradingDescriptor(PeerGradingFields, RawDescriptor):

--- a/common/lib/xmodule/xmodule/tests/test_peer_grading.py
+++ b/common/lib/xmodule/xmodule/tests/test_peer_grading.py
@@ -11,7 +11,7 @@ from xmodule.modulestore import Location
 from xmodule.tests import get_test_system, get_test_descriptor_system
 from xmodule.tests.test_util_open_ended import DummyModulestore
 from xmodule.open_ended_grading_classes.peer_grading_service import MockPeerGradingService
-from xmodule.peer_grading_module import PeerGradingModule, PeerGradingDescriptor
+from xmodule.peer_grading_module import PeerGradingModule, PeerGradingDescriptor, MAX_ALLOWED_FEEDBACK_LENGTH
 from xmodule.modulestore.exceptions import ItemNotFoundError, NoPathToItem
 
 log = logging.getLogger(__name__)
@@ -157,6 +157,27 @@ class PeerGradingModuleTest(unittest.TestCase, DummyModulestore):
         @return:
         """
         self.peer_grading.get_instance_state()
+
+    def test_save_grade_with_long_feedback(self):
+        """
+        Test if feedback is too long save_grade() should return error message.
+        """
+
+        feedback_fragment = "This is very long feedback."
+        self.save_dict["feedback"] = feedback_fragment * (
+            (MAX_ALLOWED_FEEDBACK_LENGTH / len(feedback_fragment) + 1)
+        )
+
+        response = self.peer_grading.save_grade(self.save_dict)
+
+        # Should not succeed.
+        self.assertEqual(response['success'], False)
+        self.assertEqual(
+            response['error'],
+            "Feedback is too long, Max length is {0} characters.".format(
+                MAX_ALLOWED_FEEDBACK_LENGTH
+            )
+        )
 
 
 class MockPeerGradingServiceProblemList(MockPeerGradingService):


### PR DESCRIPTION
ORA-201

When scores and comments are posted back to LMS, really large comments (>100K characters) can cause database issues. Character limit is applied on peer and staff grading feedback.
