### PR TITLE
startup-theme-templates: Load theme before running apps startups

### DIFF
--- a/lms/startup.py
+++ b/lms/startup.py
@@ -15,6 +15,9 @@ def run():
     """
     Executed during django startup
     """
+    if settings.FEATURES.get('USE_CUSTOM_THEME', False):
+        enable_theme()
+
     autostartup()
 
     # Trigger a forced initialization of our modulestores since this can take a
@@ -22,9 +25,6 @@ def run():
     if settings.INIT_MODULESTORE_ON_STARTUP:
         for store_name in settings.MODULESTORE:
             modulestore(store_name)
-
-    if settings.FEATURES.get('USE_CUSTOM_THEME', False):
-        enable_theme()
 
 
 def enable_theme():


### PR DESCRIPTION
The theme needs to be loaded before the apps startup code is executed, otherwise the settings variables don't include the alterations made for the theme, like the extra template path, resulting in mako not knowing where to find the extra theme templates.

@singingwolfboy Can you check if this is sane? It seem to come from https://github.com/edx/edx-platform/commit/08c9fd94d922c570eb1ec78e2d4cb64491e732ea
