### PR TITLE
Note to Instructors on Regular & Beta Dashboard

### DIFF
--- a/lms/static/coffee/src/instructor_dashboard/membership.coffee
+++ b/lms/static/coffee/src/instructor_dashboard/membership.coffee
@@ -28,24 +28,9 @@ class MemberListWidget
     template_html = $("#member-list-widget-template").html()
     @$container.html Mustache.render template_html, params
 
-    # bind info toggle
-    @$('.info-badge').click => @toggle_info()
-
     # bind add button
     @$('input[type="button"].add').click =>
       params.add_handler? @$('.add-field').val()
-
-  show_info: ->
-      @$('.info').show()
-      @$('.member-list').hide()
-
-  show_list: ->
-      @$('.info').hide()
-      @$('.member-list').show()
-
-  toggle_info: ->
-      @$('.info').toggle()
-      @$('.member-list').toggle()
 
   # clear the input text field
   clear_input: -> @$('.add-field').val ''
@@ -102,8 +87,6 @@ class AuthListWidget extends MemberListWidget
     @clear_errors()
     @clear_input()
     @reload_list()
-    @$('.info').hide()
-    @$('.member-list').show()
 
   # handle clicks on the add button
   add_handler: (input) ->
@@ -120,15 +103,12 @@ class AuthListWidget extends MemberListWidget
   # reload the list of members
   reload_list: ->
     # @clear_rows()
-    # @show_info()
     @get_member_list (error, member_list) =>
       # abort on error
       return @show_errors error unless error is null
 
       # only show the list of there are members
       @clear_rows()
-      @show_info()
-      # @show_info()
 
       # use _.each instead of 'for' so that member
       # is bound in the button callback.
@@ -145,8 +125,6 @@ class AuthListWidget extends MemberListWidget
               @clear_errors()
               @reload_list()
         @add_row [member.username, member.email, $revoke_btn]
-        # make sure the list is shown because there are members.
-        @show_list()
 
   # clear error display
   clear_errors: -> @$error_section?.text ''

--- a/lms/static/sass/course/instructor/_instructor_2.scss
+++ b/lms/static/sass/course/instructor/_instructor_2.scss
@@ -526,30 +526,15 @@ section.instructor-dashboard-content-2 {
     font-size: $body-font-size * 4/5;
   }
 
-  .info-badge {
-    // float: right;
-    position: absolute;
-    top: $baseline / 2;
-    right: $baseline / 2;
-    width: 17px;
-    height: 17px;
-    background: url('../images/info-icon-dark.png') left center no-repeat;
-    opacity: 0.35;
-    &:hover, &:focus  { opacity: 0.45; }
-    &:active { opacity: 0.5; }
-  }
-
   .info {
-    display: none;
-
     @include box-sizing(border-box);
     max-height: $content-height;
     padding: $baseline;
 
     border: 1px solid $light-gray;
-    border-top: none;
     color: $lighter-base-font-color;
     line-height: 1.3em;
+    font-size: .85em;
   }
 
   .member-list {

--- a/lms/templates/courseware/instructor_dashboard.html
+++ b/lms/templates/courseware/instructor_dashboard.html
@@ -392,6 +392,14 @@ function goto( mode)
   %else:
   <p>${_("User requires forum administrator privileges to perform administration tasks.  See instructor.")}</p>
   %endif
+  
+  <br />
+  <h2>${_("Explanation of Roles:")}</h2>
+  <p>${_("Forum Moderators: can edit or delete any post, remove misuse flags, close and re-open threads, endorse "
+  "responses, and see posts from all cohorts (if the course is cohorted). Moderators' posts are marked as 'staff'.")}</p>
+  <p>${_("Forum Admins: have moderator privileges, as well as the ability to edit the list of forum moderators "
+  "(e.g. to appoint a new moderator). Admins' posts are marked as 'staff'.")}</p>
+  <p>${_("Community TAs: have forum moderator privileges, and their posts are labelled 'Community TA'.")}</p>
 %endif
 
 ##-----------------------------------------------------------------------------

--- a/lms/templates/instructor/instructor_dashboard_2/membership.html
+++ b/lms/templates/instructor/instructor_dashboard_2/membership.html
@@ -5,9 +5,7 @@
   <div class="member-list-widget">
     <div class="header">
       <div class="title"> {{title}} </div>
-      <div class="info-badge"></div>
     </div>
-    <div class="info"> {{info}} </div>
     <div class="member-list">
       <table>
         <thead>
@@ -20,6 +18,7 @@
         <tbody></tbody>
       </table>
     </div>
+    <div class="info"> {{info}} </div>
     <div class="bottom-bar">
       <input type="text" name="add-field" class="add-field" placeholder="{{add_placeholder}}">
       <input type="button" name="add" class="add" value="{{add_btn_label}}">
@@ -117,8 +116,9 @@
       data-rolename="Administrator"
       data-display-name="${_("Forum Admins")}"
       data-info-text="
-        ${_("Forum admins can moderate the course forums as well as administer "
-        "other forum roles.")}"
+        ${_("Forum admins can edit or delete any post, clear misuse flags, close "
+         "and re-open threads, endorse responses, and see posts from all cohorts. "
+         "They CAN add/delete other moderators and their posts are marked as 'staff'.")}"
       data-list-endpoint="${ section_data['list_forum_members_url'] }"
       data-modify-endpoint="${ section_data['update_forum_role_membership_url'] }"
       data-add-button-label="Add ${_("Forum Admin")}"
@@ -130,8 +130,9 @@
       data-rolename="Moderator"
       data-display-name="${_("Forum Moderators")}"
       data-info-text="
-        ${_("Forum moderators can moderate the course forums. They cannot add other "
-        "moderators.")}"
+        ${_("Forum moderators can edit or delete any post, clear misuse flags, close "
+         "and re-open threads, endorse responses, and see posts from all cohorts. "
+         "They CANNOT add/delete other moderators and their posts are marked as 'staff'.")}"
       data-list-endpoint="${ section_data['list_forum_members_url'] }"
       data-modify-endpoint="${ section_data['update_forum_role_membership_url'] }"
       data-add-button-label="${_("Add Moderator")}"
@@ -142,7 +143,9 @@
       data-display-name="${_("Forum Community TAs")}"
       data-info-text="
         ${_("Community TA's are members of the community whom you deem particularly "
-        "helpful on the forums.")}"
+        "helpful on the forums. They can edit or delete any post, clear misuse flags, "
+        "close and re-open threads, endorse responses, and see posts from all cohorts. "
+        "Their posts are marked 'Community TA'.")}"
       data-list-endpoint="${ section_data['list_forum_members_url'] }"
       data-modify-endpoint="${ section_data['update_forum_role_membership_url'] }"
       data-add-button-label="Add ${_("Community TA")}"


### PR DESCRIPTION
- Added note to instructors on Forum Admin page of Instructor Dashboard.
- Made Role Info divs permanently displayed, but under the user list.

@sarina, @singingwolfboy - here's the PR to give better/more info to instructors about forum roles.
@jinpa - here's the PR
