### PR TITLE
Make problem types pluggable.

### DIFF
--- a/common/lib/xmodule/xmodule/tests/templates/test/announcement.yaml
+++ b/common/lib/xmodule/xmodule/tests/templates/test/announcement.yaml
@@ -1,0 +1,23 @@
+---
+metadata:
+    display_name: Announcement
+data: |
+      <ol>
+      <li>
+      <h2> September 21 </h2>
+      <section class='update-description'>
+      	       <section class='primary'>
+      	       		<p> Words of encouragement! This is a short note that most students will read. </p>
+      	       		<p class='author'>Anant  Agarwal (6.002x Principal Instructor)</p>
+      	       </section>
+      	       <p><h3>Primary versus Secondary Updates:</h3> Unfortunately, the internet throws a lot of text at students, and they
+      	       do not read everything that they are given. However, many students <em>do</em> read all that they are
+      	       given, and so detailed explainations in this section will benefit the most concientious.
+      	       Any essential information should be extremely quickly summarized in the primary section for skimmers.</p>
+      	       <p><h3>Star Forum Poster</h3>
+      	       Students appreciate knowing that the course staff is reading what they post, and one of several ways
+      	       that you can do this is by acknowledging the star posters in your announcements.
+      	       </p>
+      </section>
+      </li>
+      </ol>

--- a/common/lib/xmodule/xmodule/tests/templates/test/anon_user_id.yaml
+++ b/common/lib/xmodule/xmodule/tests/templates/test/anon_user_id.yaml
@@ -1,0 +1,19 @@
+---
+metadata:
+    display_name: Anonymous User ID
+data: |
+      <p>Your explanatory text here.</p>
+      <p><a href="https://YOUR_UNIVERSITY.qualtrics.com/SE/?SID=SV_###############&a=%%USER_ID%%" target="_blank">YOUR_LINK_TEXT</a></p>
+      
+      <!-- You can include %%USER_ID%% to include an anonymized user ID in your outside services so that you can relate them later.
+        
+        This example is a Qualtrics template:
+          - Replace the "###############" with your Survey ID.
+          - Also replace "YOUR_UNIVERSITY" with your qualtrics ID.
+          - Finally, replace "YOUR_LINK_TEXT" with your link text.
+          - If you wish to embed your survey into the courseware instead of opening a new tab, replace the above HTML with what is provided below.
+            
+            <p>Your explanatory text here.</p>
+            <iframe src="https://YOUR_UNIVERSITY.qualtrics.com/SE/?SID=SV_###############&a=%%USER_ID%%" height="1000" width="800" />
+        
+      -->

--- a/common/lib/xmodule/xmodule/tests/templates/test/latex_html.yaml
+++ b/common/lib/xmodule/xmodule/tests/templates/test/latex_html.yaml
@@ -1,0 +1,21 @@
+---
+metadata:
+    display_name: E-text Written in LaTeX
+    source_code: |
+        \subsection{Example of E-text in LaTeX}
+
+        It is very convenient to write complex equations in LaTeX.
+
+        \begin{equation}
+                x = \frac{-b\pm\sqrt{b^2-4*a*c}}{2a}
+        \end{equation}
+
+        Seize the moment.
+
+data: |
+    <html>
+        <h2>Example: E-text page</h2>
+        <p>
+          It is very convenient to write complex equations in LaTeX.
+        </p>
+    </html>

--- a/common/lib/xmodule/xmodule/tests/templates/test/zooming_image.yaml
+++ b/common/lib/xmodule/xmodule/tests/templates/test/zooming_image.yaml
@@ -1,0 +1,26 @@
+---
+metadata:
+    display_name: Zooming Image
+data: |
+      <h2>ZOOMING DIAGRAMS</h2>
+      <p>Some edX classes use extremely large, extremely detailed graphics. To make it easier to understand we can offer two versions of those graphics, with the zoomed section showing when you click on the main view.</p>
+      <p>The example below is from <a href="https://www.edx.org/course/mit/7-00x/introduction-biology-secret-life/1014" target="_blank">7.00x: Introduction to Biology</a> and shows a subset of the biochemical reactions that cells carry out. </p>
+      <p>You can view the chemical structures of the molecules by clicking on them. The magnified view also lists the enzymes involved in each step.</p>
+
+      <div class="zooming-image-place" style="position: relative;">
+        <a class="loupe" href="https://studio.edx.org/c4x/edX/DemoX/asset/pathways_detail_01.png">
+            <img alt="magnify" src="https://studio.edx.org/c4x/edX/DemoX/asset/pathways_overview_01.png" />
+          </a>
+        <div class="script_placeholder" data-src="https://studio.edx.org/c4x/edX/DemoX/asset/jquery.loupeAndLightbox.js" />
+      </div>
+      <script type="text/javascript">// <![CDATA[
+      JavascriptLoader.executeModuleScripts($('.zooming-image-place').eq(0), function() {
+        $('.loupe').loupeAndLightbox({
+          width: 350,
+          height: 350,
+          lightbox: false
+        });
+      });
+      // ]]></script>
+      <div id="ap_listener_added"></div>
+

--- a/common/lib/xmodule/xmodule/tests/test_resource_templates.py
+++ b/common/lib/xmodule/xmodule/tests/test_resource_templates.py
@@ -1,0 +1,56 @@
+"""
+Tests for xmodule.x_module.ResourceTemplates
+"""
+import unittest
+
+from xmodule.x_module import ResourceTemplates
+
+
+class ResourceTemplatesTests(unittest.TestCase):
+    """
+    Tests for xmodule.x_module.ResourceTemplates
+    """
+    def test_templates(self):
+        expected = set([
+            'latex_html.yaml',
+            'zooming_image.yaml',
+            'announcement.yaml',
+            'anon_user_id.yaml'])
+        got = set((t['template_id'] for t in TestClass.templates()))
+        self.assertEqual(expected, got)
+
+    def test_templates_no_suchdir(self):
+        self.assertEqual(len(TestClass2.templates()), 0)
+
+    def test_get_template(self):
+        self.assertEqual(
+            TestClass.get_template('latex_html.yaml')['template_id'],
+            'latex_html.yaml')
+
+
+class TestClass(ResourceTemplates):
+    """
+    Derives from the class under test for testing purposes.
+
+    Since `ResourceTemplates` is intended to be used as a mixin, we need to
+    derive a class from it in order to fill in some data it's expecting to find
+    in its mro.
+    """
+    template_packages = [__name__]
+
+    @classmethod
+    def get_template_dir(cls):
+        return 'templates/test'
+
+
+class TestClass2(TestClass):
+    """
+    Like TestClass, but `get_template_dir` returns a directory that doesn't
+    exist.
+
+    See `TestClass`.
+    """
+
+    @classmethod
+    def get_template_dir(cls):
+        return 'foo'


### PR DESCRIPTION
This patch adds the ability for arbitrary packages to register
themselves with xmodule.x_module.ResourceTemplates as being providers of
boiler plate templates used for defining the types of problems
instructors can add to a course.  This allows third party add-ons to
define new problem types that can then be available to instructors to
use.

This patch is the result of discussion with Ned Batchelder on the right
way to approach this problem.  The solution provided here is,
admittedly, a little bit of a hack.  But the focus was on making a least
invasive fix to make something work, in anticipation that when problems
get moved into the newere XBlock architecture something a little nicer
will be in place.
