### PR TITLE
Bok choy tests output XUnit reports

### DIFF
--- a/rakelib/bok_choy.rake
+++ b/rakelib/bok_choy.rake
@@ -16,6 +16,9 @@ BOK_CHOY_TEST_DIR = File.join(REPO_ROOT, "common", "test", "acceptance", "tests"
 BOK_CHOY_LOG_DIR = File.join(REPO_ROOT, "test_root", "log")
 directory BOK_CHOY_LOG_DIR
 
+BOK_CHOY_XUNIT_REPORT = report_dir_path("bok_choy_xunit.xml")
+
+
 BOK_CHOY_SERVERS = {
     :lms => { :port =>  8003, :log => File.join(BOK_CHOY_LOG_DIR, "bok_choy_lms.log") },
     :cms => { :port => 8031, :log => File.join(BOK_CHOY_LOG_DIR, "bok_choy_studio.log") }
@@ -74,15 +77,6 @@ def is_mysql_running()
 end
 
 
-def nose_cmd(test_spec)
-    cmd = ["SCREENSHOT_DIR='#{BOK_CHOY_LOG_DIR}'", "nosetests", test_spec]
-    if BOK_CHOY_NUM_PARALLEL > 1
-        cmd += ["--processes=#{BOK_CHOY_NUM_PARALLEL}", "--process-timeout=#{BOK_CHOY_TEST_TIMEOUT}"]
-    end
-    return cmd.join(" ")
-end
-
-
 # Run the bok choy tests
 # `test_spec` is a nose-style test specifier relative to the test directory
 # Examples:
@@ -91,11 +85,27 @@ end
 # - path/to/test.py:TestFoo.test_bar
 # It can also be left blank to run all tests in the suite.
 def run_bok_choy(test_spec)
+
+    # Default to running all tests if no specific test is specified
     if test_spec.nil?
-        sh(nose_cmd(BOK_CHOY_TEST_DIR))
+        test_spec = BOK_CHOY_TEST_DIR
     else
-        sh(nose_cmd(File.join(BOK_CHOY_TEST_DIR, test_spec)))
+        test_spec = File.join(BOK_CHOY_TEST_DIR, test_spec)
     end
+
+    # Construct the nosetests command, specifying where to save screenshots and XUnit XML reports
+    cmd = [
+        "SCREENSHOT_DIR='#{BOK_CHOY_LOG_DIR}'", "nosetests", test_spec,
+        "--with-xunit", "--xunit-file=#{BOK_CHOY_XUNIT_REPORT}"
+    ]
+
+    # Configure parallel test execution, if specified
+    if BOK_CHOY_NUM_PARALLEL > 1
+        cmd += ["--processes=#{BOK_CHOY_NUM_PARALLEL}", "--process-timeout=#{BOK_CHOY_TEST_TIMEOUT}"]
+    end
+
+    # Run the nosetests command
+    sh(cmd.join(" "))
 end
 
 


### PR DESCRIPTION
Output test results from the bok-choy test suite to "reports/bok_choy_xunit.xml"

The results include the full package name (`acceptance.tests.test_ora.OpenResponseTest`).  I couldn't get nose to exclude the top-level packages, but I think this is actually what we want, since it will cause Jenkins to group the tests together.

@jzoldak 
