### PR TITLE
Remove authority name from url.

### DIFF
--- a/lms/djangoapps/linkedin/management/commands/linkedin_mailusers.py
+++ b/lms/djangoapps/linkedin/management/commands/linkedin_mailusers.py
@@ -167,7 +167,6 @@ class Command(BaseCommand):
             'gf'])
         query = [
             ('pfCertificationName', course.display_name_with_default),
-            ('pfAuthorityName', settings.PLATFORM_NAME),
             ('pfAuthorityId', settings.LINKEDIN_API['COMPANY_ID']),
             ('pfCertificationUrl', certificate.download_url),
             ('pfLicenseNo', certificate.course_id),

--- a/lms/djangoapps/linkedin/management/commands/tests/test_mailusers.py
+++ b/lms/djangoapps/linkedin/management/commands/tests/test_mailusers.py
@@ -165,7 +165,7 @@ class MailusersTests(TestCase):
         self.assertEqual(
             fut(self.cert1),
             'http://www.linkedin.com/profile/guided?'
-            'pfCertificationName=TEST1&pfAuthorityName=edX&'
+            'pfCertificationName=TEST1&'
             'pfAuthorityId=0000000&'
             'pfCertificationUrl=http%3A%2F%2Ftest.foo%2Ftest&pfLicenseNo=TESTX%2F1%2FTEST1&'
             'pfCertStartDate=201005&_mSplash=1&'


### PR DESCRIPTION
By LinkedIn request.

@ormsbee 
