### PR TITLE
Add additional logging for importing course from git

### DIFF
--- a/lms/djangoapps/dashboard/management/commands/tests/test_git_add_course.py
+++ b/lms/djangoapps/dashboard/management/commands/tests/test_git_add_course.py
@@ -102,3 +102,21 @@ class TestGitAddCourse(ModuleStoreTestCase):
 
         with self.assertRaisesRegexp(GitImportError, GitImportError.BAD_REPO):
             git_import.add_repo('file://{0}'.format(bare_repo), None)
+
+    def test_detached_repo(self):
+        """
+        Test repo that is in detached head state.
+        """
+        repo_dir = getattr(settings, 'GIT_REPO_DIR')
+        # Test successful import from command
+        try:
+            os.mkdir(repo_dir)
+        except OSError:
+            pass
+        self.addCleanup(shutil.rmtree, repo_dir)
+        git_import.add_repo(self.TEST_REPO, repo_dir / 'edx4edx_lite')
+        subprocess.check_output(['git', 'checkout', 'HEAD~2', ],
+                                stderr=subprocess.STDOUT,
+                                cwd=repo_dir / 'edx4edx_lite')
+        with self.assertRaisesRegexp(GitImportError, GitImportError.CANNOT_PULL):
+            git_import.add_repo(self.TEST_REPO, repo_dir / 'edx4edx_lite')


### PR DESCRIPTION
We are running into issues with git raising permission denied errors or other issues that are hard to troubleshoot, so I'm adding exception logging of the command output on external commands.

I also added a test to see if I couldn't get coverage on the git branch command, but moving the repo into detached head state causes the pull to fail before the branch checking code is exercised.  I left the test and the exception code in there anyway.

Potential reviewers: @singingwolfboy @cpennington @nedbat
Heads up to @sarina
