### PR TITLE
Made Grading Clearer on Progress Page

### DIFF
--- a/lms/djangoapps/courseware/views.py
+++ b/lms/djangoapps/courseware/views.py
@@ -644,6 +644,16 @@ def _progress(request, course_id, student_id):
 
     grade_summary = grades.grade(student, request, course)
 
+    normalized_grades = {}
+    grades_total = 0;
+    for category in grade_summary['grade_breakdown']:
+      normalized_grade = {}
+      normalized_grade['number_dropped'] = category['number_dropped']
+      normalized_grade['weight'] = category['weight']
+      normalized_grades[category['category']] = normalized_grade
+      grades_total += category['weight']
+    if grades_total == 0:
+      grades_total = 1
     if courseware_summary is None:
         #This means the student didn't have access to the course (which the instructor requested)
         raise Http404
@@ -652,6 +662,8 @@ def _progress(request, course_id, student_id):
         'course': course,
         'courseware_summary': courseware_summary,
         'grade_summary': grade_summary,
+        'normalized_grades': normalized_grades,
+        'grades_total': grades_total,
         'staff_access': staff_access,
         'student': student,
     }

--- a/lms/static/sass/course/_profile.scss
+++ b/lms/static/sass/course/_profile.scss
@@ -1,4 +1,5 @@
 div.profile-wrapper {
+  position: relative;
   color: #000;
 
   section.user-info {
@@ -237,6 +238,26 @@ div.profile-wrapper {
               }
             }
           }
+        }
+      }
+    }
+    
+    div#graph-sidebar {
+      position: absolute;
+      top: 100px;
+      right: 50px;
+      height: 450px;
+      width: 250px;
+      
+      h2 {
+        text-transform: none;
+        padding: 7px 0;
+        margin: 0 0 10px 0;
+        border-bottom: 1px solid #e3e3e3;
+      }
+      p {
+        span.dropped {
+          color: $lighter-base-font-color;
         }
       }
     }

--- a/lms/templates/courseware/progress.html
+++ b/lms/templates/courseware/progress.html
@@ -38,6 +38,21 @@ ${progress_graph.body(grade_summary, course.grade_cutoffs, "grade-detail-graph",
 
       %if not course.disable_progress_graph:
         <div id="grade-detail-graph" aria-hidden="true"></div>
+        <div id="graph-sidebar" aria-hidden="true">
+            <h2>Grade Weighting</h2>
+            %for item in normalized_grades:
+              <%
+                normalized_grade = normalized_grades[item]['weight']
+                number_dropped = normalized_grades[item]['number_dropped']
+              %>
+              <p>
+                <strong>${item}: </strong> ${"{0:.1%}".format(normalized_grade)}
+                %if number_dropped > 0:
+                  <br /><span class="dropped">Lowest ${number_dropped} Dropped</span>
+                %endif
+              </p>
+            %endfor
+        </div>
       %endif
 
       <ol class="chapters">

--- a/lms/templates/courseware/progress_graph.js
+++ b/lms/templates/courseware/progress_graph.js
@@ -47,7 +47,7 @@ $(function () {
       
       categoryData = categories[ section['category'] ]
     
-      categoryData['data'].append( [tickIndex, section['percent']] )
+      categoryData['data'].append( tickIndex, [section['percent']] )
       ticks.append( [tickIndex, section['label'] ] )
     
       if section['category'] in detail_tooltips:
@@ -56,7 +56,7 @@ $(function () {
           detail_tooltips[ section['category'] ] = [ section['detail'], ]
           
       if 'mark' in section:
-          droppedScores.append( [tickIndex, 0.05] )
+          droppedScores.append( [tickIndex, .05] )
           dropped_score_tooltips.append( section['mark']['detail'] )
         
       tickIndex += 1
@@ -71,7 +71,8 @@ $(function () {
   overviewBarX = tickIndex
   extraColorIndex = len(categories) #Keeping track of the next color to use for categories not in categories[]
   
-  if show_grade_breakdown:    
+  if show_grade_breakdown:
+    tickIndex += sectionSpacer
     for section in grade_summary['grade_breakdown']:
         if section['percent'] > 0:
             if section['category'] in categories:
@@ -82,19 +83,17 @@ $(function () {
         
             series.append({
                 'label' : section['category'] + "-grade_breakdown",
-                'data' : [ [overviewBarX, section['percent']] ],
+                'data' : [ [overviewBarX, section['percent']] ], ##
                 'color' : color
             })
             
             detail_tooltips[section['category'] + "-grade_breakdown"] = [ section['detail'] ]
-  
+    
     ticks += [ [overviewBarX, "Total"] ]
-    tickIndex += 1 + sectionSpacer
+    tickIndex += 5*sectionSpacer
   
   totalScore = grade_summary['percent']
   detail_tooltips['Dropped Scores'] = dropped_score_tooltips
-  
-  
   ## ----------------------------- Grade cutoffs ------------------------- ##
   
   grade_cutoff_ticks = [ [1, "100%"], [0, "0%"] ]
@@ -116,7 +115,13 @@ $(function () {
   var grade_cutoff_ticks = ${ json.dumps(grade_cutoff_ticks) }
   
   //Always be sure that one series has the xaxis set to 2, or the second xaxis labels won't show up
-  series.push( {label: 'Dropped Scores', data: droppedScores, points: {symbol: "cross", show: true, radius: 3}, bars: {show: false}, color: "#333"} );
+  series.push( {
+    label: 'Dropped Scores',
+    data: droppedScores,
+    points: {show: false, symbol: "cross", radius: 3}, // Points have been hidden, change this to "show: true" to make visible again.
+    bars: {show: false},
+    color: "#333"
+  });
   
   // Allow for arbitrary grade markers e.g. ['A', 'B', 'C'], ['Pass'], etc.
   var ascending_grades = grade_cutoff_ticks.map(function (el) { return el[0]; }); // Percentage point (in decimal) of each grade cutoff


### PR DESCRIPTION
- Hid dropped markers as they were confusing users into thinking they had done something wrong.
- Added side pane to show course grade weighting more obviously to users

@marcotuts, @frrrances, @sarina, @pmitros, @shnayder - here's the PR for the progress page updates. (You don't all have to review this, but since you all commented on the design, I thought you'd like to know that this was done and under review.)

@jinpa - here's the PR for the progress page!
