### PR TITLE
Make video debug messages consistent.

### DIFF
--- a/common/lib/xmodule/xmodule/js/spec/video/resizer_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/resizer_spec.js
@@ -163,7 +163,7 @@ function (Resizer) {
                 function ()
             {
                 var methods = ['add', 'once'],
-                    errorMessage = 'TypeError: Argument is not a function.',
+                    errorMessage = '[Video info]: TypeError: Argument is not a function.',
                     arg = {};
 
                 spyOn(console, 'error');

--- a/common/lib/xmodule/xmodule/js/src/video/00_resizer.js
+++ b/common/lib/xmodule/xmodule/js/src/video/00_resizer.js
@@ -127,7 +127,7 @@ function () {
             if ($.isFunction(func)) {
                 callbacksList.push(func);
             } else {
-                console.error('TypeError: Argument is not a function.');
+                console.error('[Video info]: TypeError: Argument is not a function.');
             }
 
             return module;
@@ -142,7 +142,7 @@ function () {
 
                 addCallback(decorator);
             } else {
-                console.error('TypeError: Argument is not a function.');
+                console.error('[Video info]: TypeError: Argument is not a function.');
             }
 
             return module;


### PR DESCRIPTION
**Description**

In the JavaScript console all messages from the Video player should begin with "[Video info]: ". This way it is easier to see which console.log() messages are from the Video player, and which console.log() messages are temporary, and should be removed before a merge/commit.

**Reviewers**
- @sarina  
