### PR TITLE
Fix video progress slider method.

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/video/06_video_progress_slider.js
+++ b/common/lib/xmodule/xmodule/js/src/video/06_video_progress_slider.js
@@ -57,7 +57,7 @@ function () {
     function _renderElements(state) {
         state.videoProgressSlider.el = state.videoControl.sliderEl;
 
-        buildSlider(state);
+        state.videoProgressSlider.buildSlider();
         _buildHandle(state);
     }
 
@@ -86,15 +86,15 @@ function () {
     // them available and sets up their context is makeFunctionsPublic().
     // ***************************************************************
 
-    function buildSlider(state) {
-        state.videoProgressSlider.slider = state.videoProgressSlider.el
+    function buildSlider() {
+        this.videoProgressSlider.slider = this.videoProgressSlider.el
             .slider({
                 range: 'min',
-                slide: state.videoProgressSlider.onSlide,
-                stop: state.videoProgressSlider.onStop
+                slide: this.videoProgressSlider.onSlide,
+                stop: this.videoProgressSlider.onStop
             });
 
-        state.videoProgressSlider.sliderProgress = state.videoProgressSlider
+        this.videoProgressSlider.sliderProgress = this.videoProgressSlider
             .slider
             .find('.ui-slider-range.ui-widget-header.ui-slider-range-min');
     }


### PR DESCRIPTION
**Description**

In each Video JavaScript module, methods are either private, or public. When a method is public, it is made available via the state variable. It seems that a while ago one method was made public, but throughout the code it  is used as a private method. This has been corrected.

**Reviewers**
- @wedaly 
