### PR TITLE
Fix video code duplication.

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/video/06_video_progress_slider.js
+++ b/common/lib/xmodule/xmodule/js/src/video/06_video_progress_slider.js
@@ -156,19 +156,13 @@ function () {
                        'ui-widget-header ' +
                        'ui-corner-all ' +
                        'slider-range'
-            }).css({
-                left: rangeParams.left,
-                width: rangeParams.width
-            });
+            }).css(rangeParams);
 
             this.videoProgressSlider.sliderProgress
                 .after(this.videoProgressSlider.sliderRange);
         } else {
             this.videoProgressSlider.sliderRange
-                .css({
-                    left: rangeParams.left,
-                    width: rangeParams.width
-                });
+                .css(rangeParams);
         }
     }
 


### PR DESCRIPTION
**Description**

rangeParams returned from getRangeParams() function is already an object that contains the left and width  properties. It can be passed directly to the jQuery css() function.

**Reviewers**
- @singingwolfboy 
