### PR TITLE
For capa modules if weight is 0 don't try to create Progress objects.

### DIFF
--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -328,6 +328,10 @@ class CapaMixin(CapaFields):
 
         if total > 0:
             if self.weight is not None:
+                # Progress objects expect total > 0
+                if self.weight == 0:
+                    return None
+
                 # scale score and total by weight/total:
                 score = score * self.weight / total
                 total = self.weight

--- a/common/lib/xmodule/xmodule/tests/test_capa_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_capa_module.py
@@ -1350,6 +1350,18 @@ class CapaModuleTest(unittest.TestCase):
             mock_log.reset_mock()
 
     @patch('xmodule.capa_base.Progress')
+    def test_get_progress_no_error_if_weight_zero(self, mock_progress):
+        """
+        Check that if the weight is 0 get_progress does not try to create a Progress object.
+        """
+        mock_progress.return_value = True
+        module = CapaFactory.create()
+        module.weight = 0
+        progress = module.get_progress()
+        self.assertIsNone(progress)
+        self.assertFalse(mock_progress.called)
+
+    @patch('xmodule.capa_base.Progress')
     def test_get_progress_calculate_progress_fraction(self, mock_progress):
         """
         Check that score and total are calculated correctly for the progress fraction.


### PR DESCRIPTION
LMS-1494

Otherwise we get lots of unnecessary error logs.
