### PR TITLE
Remove comment for how to install PIL

### DIFF
--- a/common/lib/xmodule/xmodule/contentstore/content.py
+++ b/common/lib/xmodule/xmodule/contentstore/content.py
@@ -10,7 +10,6 @@ from urlparse import urlparse, urlunparse
 
 from xmodule.modulestore import Location
 from .django import contentstore
-# to install PIL on MacOSX: 'easy_install http://dist.repoze.org/PIL-1.1.6.tar.gz'
 from PIL import Image
 
 


### PR DESCRIPTION
We use Pillow now, which can be installed via PyPI
