### PR TITLE
Remove CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,0 @@
-This file has been converted to CONTRIBUTING.rst


### PR DESCRIPTION
Github includes a "Please review the guidelines for contributing
to this repository" link when creating a pull request, and it links
to the Markdown version of this file, which is annoying. Removing
the file should redirect the link to the reStructuredText version
of this file.

@nedbat can you review?
