### PR TITLE
Adam/fix/stringresponse no type specified

### DIFF
--- a/common/lib/capa/capa/responsetypes.py
+++ b/common/lib/capa/capa/responsetypes.py
@@ -1054,8 +1054,11 @@ class StringResponse(LoncapaResponse):
     def setup_response(self):
 
         self.backward = '_or_' in self.xml.get('answer').lower()
-        self.regexp = 'regexp' in self.xml.get('type').lower().split(' ')
-        self.case_insensitive = 'ci' in self.xml.get('type').lower().split(' ')
+        self.regexp = False
+        self.case_insensitive = False
+        if self.xml.get('type') is not None:
+            self.regexp = 'regexp' in self.xml.get('type').lower().split(' ')
+            self.case_insensitive = 'ci' in self.xml.get('type').lower().split(' ')
 
         # backward compatibility, can be removed in future, it is up to @Lyla Fisher.
         if self.backward:

--- a/common/lib/capa/capa/tests/response_xml_factory.py
+++ b/common/lib/capa/capa/tests/response_xml_factory.py
@@ -700,7 +700,7 @@ class StringResponseXMLFactory(ResponseXMLFactory):
         """
         # Retrieve the **kwargs
         answer = kwargs.get("answer", None)
-        case_sensitive = kwargs.get("case_sensitive", True)
+        case_sensitive = kwargs.get("case_sensitive", None)
         hint_list = kwargs.get('hints', None)
         hint_fn = kwargs.get('hintfn', None)
         regexp = kwargs.get('regexp', None)
@@ -714,9 +714,12 @@ class StringResponseXMLFactory(ResponseXMLFactory):
         response_element.set("answer", unicode(answer))
 
         # Set the case sensitivity and regexp:
-        type_value = "cs" if case_sensitive else "ci"
+        type_value = ''
+        if case_sensitive is not None:
+            type_value += "cs" if case_sensitive else "ci"
         type_value += ' regexp' if regexp else ''
-        response_element.set("type", type_value)
+        if type_value:
+            response_element.set("type", type_value.strip())
 
         # Add the hints if specified
         if hint_list or hint_fn:

--- a/common/lib/capa/capa/tests/test_responsetypes.py
+++ b/common/lib/capa/capa/tests/test_responsetypes.py
@@ -564,6 +564,10 @@ class StringResponseTest(ResponseTest):
         problem = self.build_problem(answer=".*tre+", case_sensitive=False, regexp=True)
         self.assert_grade(problem, "There is a tree", "correct")
 
+        # test with case_sensitive not specified
+        problem = self.build_problem(answer=".*tre+", regexp=True)
+        self.assert_grade(problem, "There is a tree", "correct")
+
         answers = [
             "Martin Luther King Junior",
             "Doctor Martin Luther King Junior",
@@ -611,6 +615,7 @@ class StringResponseTest(ResponseTest):
         self.assert_grade(problem, u"î", "incorrect")
         self.assert_grade(problem, u"o", "incorrect")
 
+
     def test_backslash_and_unicode_regexps(self):
         """
         Test some special cases of [unicode] regexps.
@@ -643,26 +648,39 @@ class StringResponseTest(ResponseTest):
 
     def test_case_sensitive(self):
         # Test single answer
-        problem = self.build_problem(answer="Second", case_sensitive=True)
+        problem_specified = self.build_problem(answer="Second", case_sensitive=True)
+        
+        # should also be case_sensitive if case sensitivity is not specified
+        problem_not_specified = self.build_problem(answer="Second")
+        problems = [problem_specified, problem_not_specified]
 
-        # Exact string should be correct
-        self.assert_grade(problem, "Second", "correct")
+        for problem in problems:
+            # Exact string should be correct
+            self.assert_grade(problem, "Second", "correct")
 
-        # Other strings and the lowercase version of the string are incorrect
-        self.assert_grade(problem, "Other String", "incorrect")
-        self.assert_grade(problem, "second", "incorrect")
+            # Other strings and the lowercase version of the string are incorrect
+            self.assert_grade(problem, "Other String", "incorrect")
+            self.assert_grade(problem, "second", "incorrect")
 
         # Test multiple answers
         answers = ["Second", "Third", "Fourth"]
-        problem = self.build_problem(answer="sample_answer", case_sensitive=True, additional_answers=answers)
 
-        for answer in answers:
-            # Exact string should be correct
-            self.assert_grade(problem, answer, "correct")
+        # set up problems
+        problem_specified = self.build_problem(
+            answer="sample_answer", case_sensitive=True, additional_answers=answers
+        )
+        problem_not_specified = self.build_problem(
+            answer="sample_answer", additional_answers=answers
+        )
+        problems = [problem_specified, problem_not_specified]
+        for problem in problems:
+            for answer in answers:
+                # Exact string should be correct
+                self.assert_grade(problem, answer, "correct")
 
-        # Other strings and the lowercase version of the string are incorrect
-        self.assert_grade(problem, "Other String", "incorrect")
-        self.assert_grade(problem, "second", "incorrect")
+            # Other strings and the lowercase version of the string are incorrect
+            self.assert_grade(problem, "Other String", "incorrect")
+            self.assert_grade(problem, "second", "incorrect")
 
     def test_bogus_escape_not_raised(self):
         """


### PR DESCRIPTION
@polesye and @valera-rozuvan , the commit with https://github.com/edx/edx-platform/commit/ee1953b37a00e86d716b72d41377b63e77f3306d broke stringresponse problems where type wasn't specified, which is still possible for xml courses. Here's a fix!
