### PR TITLE
Collect coverage for bok-choy tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ conf/locale/ko_KR
 .noseids
 nosetests.xml
 .coverage
+.coverage.*
 coverage.xml
 cover/
 cover_html/

--- a/common/test/acceptance/.coveragerc
+++ b/common/test/acceptance/.coveragerc
@@ -1,0 +1,15 @@
+[run]
+data_file = reports/bok_choy/.coverage
+source = lms, cms, common/djangoapps, common/lib
+omit = lms/envs/*, cms/envs/*, common/djangoapps/terrain/*, common/djangoapps/*/migrations/*, */test*, */management/*, */urls*, */wsgi*
+parallel = True
+
+[report]
+ignore_errors = True
+
+[html]
+title = Bok Choy Test Coverage Report
+directory = reports/bok_choy/cover
+
+[xml]
+output = reports/bok_choy/coverage.xml


### PR DESCRIPTION
- Collect coverage from LMS and Studio when running the bok-choy test suite (`rake test:bok_choy` from within devstack)
- Combine and generate coverage reports with `rake test:bok_choy:coverage`
- Reports are written to "reports/bok_choy"

@jzoldak @nedbat 
