### PR TITLE
Handle taking registrations on a course with TBD start date

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,10 @@ These are notable changes in edx-platform.  This is a rolling list of changes,
 in roughly chronological order, most recent first.  Add your entries at or near
 the top.  Include a label indicating the component affected.
 
+LMS:  If the course start date is kept at the default studio value (Jan 1, 2030)
+and advertised_start is not set, the start date is not displayed in the
+/courses tile view, the course about page, or the dashboard
+
 Blades: Add role parameter to LTI. BLD-583.
 
 Blades: Bugfix "In Firefox YouTube video with start time plays from 00:00:00".

--- a/common/lib/xmodule/xmodule/tests/test_course_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_course_module.py
@@ -134,22 +134,28 @@ class IsNewCourseTestCase(unittest.TestCase):
             print "Comparing %s to %s" % (a, b)
             assertion(a_score, b_score)
 
+    start_advertised_settings = [
+        # start, advertised, result, is_still_default
+        ('2012-12-02T12:00', None, 'Dec 02, 2012', False),
+        ('2012-12-02T12:00', '2011-11-01T12:00', 'Nov 01, 2011', False),
+        ('2012-12-02T12:00', 'Spring 2012', 'Spring 2012', False),
+        ('2012-12-02T12:00', 'November, 2011', 'November, 2011', False),
+        (xmodule.course_module.CourseFields.start.default, None, 'TBD', True),
+        (xmodule.course_module.CourseFields.start.default, 'January 2014', 'January 2014', False),
+    ]
+
     @patch('xmodule.course_module.datetime.now')
     def test_start_date_text(self, gmtime_mock):
         gmtime_mock.return_value = NOW
-
-        settings = [
-            # start, advertized, result
-            ('2012-12-02T12:00', None, 'Dec 02, 2012'),
-            ('2012-12-02T12:00', '2011-11-01T12:00', 'Nov 01, 2011'),
-            ('2012-12-02T12:00', 'Spring 2012', 'Spring 2012'),
-            ('2012-12-02T12:00', 'November, 2011', 'November, 2011'),
-        ]
-
-        for s in settings:
+        for s in self.start_advertised_settings:
             d = get_dummy_course(start=s[0], advertised_start=s[1])
             print "Checking start=%s advertised=%s" % (s[0], s[1])
             self.assertEqual(d.start_date_text, s[2])
+
+    def test_start_date_is_default(self):
+        for s in self.start_advertised_settings:
+            d = get_dummy_course(start=s[0], advertised_start=s[1])
+            self.assertEqual(d.start_date_is_still_default, s[3])
 
     def test_display_organization(self):
         descriptor = get_dummy_course(start='2012-12-02T12:00', is_new=True)

--- a/lms/static/sass/shared/_course_object.scss
+++ b/lms/static/sass/shared/_course_object.scss
@@ -226,14 +226,14 @@
           width: 100%;
 
           .university {
-            border-right: 1px solid $border-color-2;
             color: $lighter-base-font-color;
             letter-spacing: 1px;
-            margin-right: 10px;
-            padding-right: 10px;
           }
 
           .start-date  {
+            border-left: 1px solid $border-color-2;
+            margin-left: 5px;
+            padding-left: 10px;
             color: $lighter-base-font-color;
             letter-spacing: 1px;
           }

--- a/lms/templates/course.html
+++ b/lms/templates/course.html
@@ -26,7 +26,9 @@ from courseware.courses import course_image_url, get_course_about_section
         </div>
         <div class="bottom">
           <span class="university">${get_course_about_section(course, 'university')}</span>
+          % if not course.start_date_is_still_default:
           <span class="start-date">${course.start_date_text}</span>
+          % endif
         </div>
       </section>
     </div>

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -248,8 +248,9 @@
 
         <ol class="important-dates">
           <li><div class="icon course-number"></div><p>${_("Course Number")}</p><span class="course-number">${course.display_number_with_default | h}</span></li>
+          % if not course.start_date_is_still_default:
           <li><div class="icon start"></div><p>${_("Classes Start")}</p><span class="start-date">${course.start_date_text}</span></li>
-
+          % endif
             ## We plan to ditch end_date (which is not stored in course metadata),
             ## but for backwards compatibility, show about/end_date blob if it exists.
             % if get_course_about_section(course, "end_date") or course.end:

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -43,6 +43,8 @@
         ${_("Course Completed - {end_date}").format(end_date=course.end_date_text)}
         % elif course.has_started():
         ${_("Course Started - {start_date}").format(start_date=course.start_date_text)}
+        % elif course.start_date_is_still_default: # Course start date TBD
+        ${_("Course has not yet started")}
         % else:   # hasn't started yet
         ${_("Course Starts - {start_date}").format(start_date=course.start_date_text)}
         % endif


### PR DESCRIPTION
(EDITED 1/27/14 11:48 PST)

At Stanford we sometimes would like to advertise a course publicly before committing to a start date.  This small patch allows us to do that.  If `course.start` is left as default and `course.advertised_start` is not set, then the LMS won't display start date in the tiles, the course about page, or the dashboard.
