### PR TITLE
Use the publish() api from xblock.runtime.Runtime

### DIFF
--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -838,11 +838,14 @@ class CapaMixin(CapaFields):
         Publishes the student's current grade to the system as an event
         """
         score = self.lcp.get_score()
-        self.runtime.publish({
-            'event_name': 'grade',
-            'value': score['score'],
-            'max_value': score['total'],
-        })
+        self.runtime.publish(
+            self,
+            {
+                'event_name': 'grade',
+                'value': score['score'],
+                'max_value': score['total'],
+            }
+        )
 
         return {'grade': score['score'], 'max_grade': score['total']}
 

--- a/common/lib/xmodule/xmodule/lti_module.py
+++ b/common/lib/xmodule/xmodule/lti_module.py
@@ -510,7 +510,8 @@ oauth_consumer_key="", oauth_signature="frVp4JuvT1mVXlxktiAUjQ7%2F1cw%3D"'}
 
         if action == 'replaceResultRequest':
             self.system.publish(
-                event={
+                self,
+                {
                     'event_name': 'grade',
                     'value': score * self.max_score(),
                     'max_value': self.max_score(),

--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -988,11 +988,14 @@ class DescriptorSystem(ConfigurableFragmentWrapper, Runtime):  # pylint: disable
             # global function that the application can override.
             return descriptor_global_handler_url(block, handler_name, suffix, query, thirdparty)
 
-    def resources_url(self, resource):
+    def resource_url(self, resource):
         raise NotImplementedError("edX Platform doesn't currently implement XBlock resource urls")
 
     def local_resource_url(self, block, uri):
         raise NotImplementedError("edX Platform doesn't currently implement XBlock resource urls")
+
+    def publish(self, block, event):
+        raise NotImplementedError("edX Platform doesn't currently implement XBlock publish")
 
 
 class XMLParsingSystem(DescriptorSystem):
@@ -1101,10 +1104,8 @@ class ModuleSystem(ConfigurableFragmentWrapper, Runtime):  # pylint: disable=abs
         self.course_id = course_id
         self.user_is_staff = user is not None and user.is_staff
 
-        if publish is None:
-            publish = lambda e: None
-
-        self.publish = publish
+        if publish:
+            self.publish = publish
 
         self.open_ended_grading_interface = open_ended_grading_interface
         self.s3_interface = s3_interface
@@ -1143,11 +1144,14 @@ class ModuleSystem(ConfigurableFragmentWrapper, Runtime):  # pylint: disable=abs
     def get_block(self, block_id):
         raise NotImplementedError("XModules must use get_module to load other modules")
 
-    def resources_url(self, resource):
+    def resource_url(self, resource):
         raise NotImplementedError("edX Platform doesn't currently implement XBlock resource urls")
 
     def local_resource_url(self, block, uri):
         raise NotImplementedError("edX Platform doesn't currently implement XBlock resource urls")
+
+    def publish(self, block, event):
+        pass
 
 
 class DoNothingCache(object):

--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -291,7 +291,7 @@ def get_module_for_descriptor_internal(user, descriptor, field_data_cache, cours
                                                   position, wrap_xmodule_display, grade_bucket_type,
                                                   static_asset_path)
 
-    def publish(event, custom_user=None):
+    def publish(block, event, custom_user=None):
         """A function that allows XModules to publish events. This only supports grade changes right now."""
         if event.get('event_name') != 'grade':
             return

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -15,7 +15,7 @@
 -e git+https://github.com/eventbrite/zendesk.git@d53fe0e81b623f084e91776bcf6369f8b7b63879#egg=zendesk
 
 # Our libraries:
--e git+https://github.com/edx/XBlock.git@a1a3e76b269d15b7bbd11976d8aef63e1db6c4c2#egg=XBlock
+-e git+https://github.com/edx/XBlock.git@de92d3bf798699a6bbd06b54012ef15934c41ac0#egg=XBlock
 -e git+https://github.com/edx/codejail.git@e3d98f9455#egg=codejail
 -e git+https://github.com/edx/diff-cover.git@v0.2.9#egg=diff_cover
 -e git+https://github.com/edx/js-test-tool.git@v0.1.5#egg=js_test_tool


### PR DESCRIPTION
This will adapt edx-platform to use the latest version of XBlock, including the pull request currently under review in XBlock (https://github.com/edx/XBlock/pull/168). The plan is to submit the XBlock pull request, then submit this shortly after. 
