### PR TITLE
Cache course location translations

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -122,6 +122,12 @@ SITE_NAME = ENV_TOKENS['SITE_NAME']
 LOG_DIR = ENV_TOKENS['LOG_DIR']
 
 CACHES = ENV_TOKENS['CACHES']
+# Cache used for location mapping -- called many times with the same key/value
+# in a given request.
+CACHES['loc_cache'] = {
+    'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+    'LOCATION': 'edx_location_mem_cache',
+}
 
 SESSION_COOKIE_DOMAIN = ENV_TOKENS.get('SESSION_COOKIE_DOMAIN')
 SESSION_ENGINE = ENV_TOKENS.get('SESSION_ENGINE', SESSION_ENGINE)

--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -124,10 +124,11 @@ LOG_DIR = ENV_TOKENS['LOG_DIR']
 CACHES = ENV_TOKENS['CACHES']
 # Cache used for location mapping -- called many times with the same key/value
 # in a given request.
-CACHES['loc_cache'] = {
-    'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
-    'LOCATION': 'edx_location_mem_cache',
-}
+if 'loc_cache' not in CACHES:
+    CACHES['loc_cache'] = {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        'LOCATION': 'edx_location_mem_cache',
+    }
 
 SESSION_COOKIE_DOMAIN = ENV_TOKENS.get('SESSION_COOKIE_DOMAIN')
 SESSION_ENGINE = ENV_TOKENS.get('SESSION_ENGINE', SESSION_ENGINE)

--- a/common/djangoapps/student/roles.py
+++ b/common/djangoapps/student/roles.py
@@ -239,4 +239,4 @@ class CourseCreatorRole(GroupBasedRole):
     """
     ROLE = "course_creator_group"
     def __init__(self, *args, **kwargs):
-        super(CourseCreatorRole, self).__init__(self.ROLE, *args, **kwargs)
+        super(CourseCreatorRole, self).__init__([self.ROLE], *args, **kwargs)

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_location_mapper.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_location_mapper.py
@@ -397,11 +397,11 @@ class TrivialCache(object):
     def __init__(self):
         self.cache = {}
 
-    def get(self, key):
+    def get(self, key, default=None):
         """
         Mock the .get
         """
-        return self.cache.get(key)
+        return self.cache.get(key, default)
 
     def set_many(self, entries):
         """

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_location_mapper.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_location_mapper.py
@@ -408,3 +408,9 @@ class TrivialCache(object):
         mock set_many
         """
         self.cache.update(entries)
+
+    def set(self, key, entry):
+        """
+        mock set
+        """
+        self.cache[key] = entry

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_split_migrator.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_split_migrator.py
@@ -20,6 +20,7 @@ from xmodule.modulestore.split_mongo.split import SplitMongoModuleStore
 from xmodule.modulestore.mongo.base import MongoModuleStore
 from xmodule.modulestore.split_migrator import SplitMigrator
 from xmodule.modulestore.mongo import draft
+from xmodule.modulestore.tests import test_location_mapper
 
 
 class TestMigration(unittest.TestCase):
@@ -43,10 +44,8 @@ class TestMigration(unittest.TestCase):
 
     def setUp(self):
         super(TestMigration, self).setUp()
-        noop_cache = mock.Mock(spec=['get', 'set_many'])
-        noop_cache.configure_mock(**{'get.return_value': None})
         # pylint: disable=W0142
-        self.loc_mapper = LocMapperStore(noop_cache, **self.db_config)
+        self.loc_mapper = LocMapperStore(test_location_mapper.TrivialCache(), **self.db_config)
         self.old_mongo = MongoModuleStore(self.db_config, **self.modulestore_options)
         self.draft_mongo = DraftModuleStore(self.db_config, **self.modulestore_options)
         self.split_mongo = SplitMongoModuleStore(

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -157,10 +157,11 @@ LOG_DIR = ENV_TOKENS['LOG_DIR']
 CACHES = ENV_TOKENS['CACHES']
 # Cache used for location mapping -- called many times with the same key/value
 # in a given request.
-CACHES['loc_cache'] = {
-    'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
-    'LOCATION': 'edx_location_mem_cache',
-}
+if 'loc_cache' not in CACHES:
+    CACHES['loc_cache'] = {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        'LOCATION': 'edx_location_mem_cache',
+    }
 
 # Email overrides
 DEFAULT_FROM_EMAIL = ENV_TOKENS.get('DEFAULT_FROM_EMAIL', DEFAULT_FROM_EMAIL)

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -155,6 +155,12 @@ MEDIA_URL = ENV_TOKENS['MEDIA_URL']
 LOG_DIR = ENV_TOKENS['LOG_DIR']
 
 CACHES = ENV_TOKENS['CACHES']
+# Cache used for location mapping -- called many times with the same key/value
+# in a given request.
+CACHES['loc_cache'] = {
+    'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+    'LOCATION': 'edx_location_mem_cache',
+}
 
 # Email overrides
 DEFAULT_FROM_EMAIL = ENV_TOKENS.get('DEFAULT_FROM_EMAIL', DEFAULT_FROM_EMAIL)


### PR DESCRIPTION
@ormsbee @chrisndodge @cpennington Ok, now this is ready to review. Sorry for the not quite ready version yesterday. After 24h of game jam development on the small mac screen, my eyes weren't working well enough. This one is against release as it should be.

This reduces the mongo db queries for accessing 6.002 from around 1100 on courseware page to 7. I still want to keep has_access from querying for instructor and staff access until it's failed on the student access query. I also want to perhaps memoize the ...Role() instantiation as it has no dependency on request nor user just course.

I have unit tests for the translate_location_to_course_locator on master. I could pull those over as well. This version differs from master in that this uses caching whereas the one on master explicitly says it shouldn't (I hadn't thought of using this approach).

As to query count unit tests, we should discuss w/ @wedaly and others b/c it involves reconfiguring middleware and will make the tests a lot slower. I think we may want to do a separate suite of perf tests which use query counting only for the perf tests.
