### PR TITLE
Visual fix hides component action header when unit is in public mode as ...

### DIFF
--- a/cms/static/sass/views/_unit.scss
+++ b/cms/static/sass/views/_unit.scss
@@ -895,7 +895,7 @@ body.unit {
       display: inline-block;
       float: right;
       vertical-align: middle;
-      text-align: center; 
+      text-align: center;
     }
 
     &.editing {
@@ -1212,7 +1212,7 @@ body.unit {
 
 .edit-state-public {
   .delete-draft,
-  .component-actions,
+  .wrapper-component-action-header,
   .new-component-item,
   .editing-draft-alert,
   .publish-draft-message,


### PR DESCRIPTION
...editing tools should not be accessible 
STUD-1229

@cahrens - this fixes the visibility of component actions on Public unit pages. tagged you for review and confirmed with @mhoeber what the scope of the issue was. 
