### PR TITLE
ignore jscover logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ coverage.xml
 cover/
 cover_html/
 reports/
+jscover.log.*
 
 ### Installation artifacts
 *.egg-info


### PR DESCRIPTION
If you run the Jasmine tests with JSCover installed, it writes files like `jscover.log.1`, `jscover.log.2`, etc. We don't want to accidentally commit these to the repo.

@wedaly, can you review?
