### PR TITLE
Disabled flakey open-ended tests

### DIFF
--- a/common/lib/xmodule/xmodule/tests/test_combined_open_ended.py
+++ b/common/lib/xmodule/xmodule/tests/test_combined_open_ended.py
@@ -265,6 +265,9 @@ class OpenEndedModuleTest(unittest.TestCase):
         self.openendedmodule = OpenEndedModule(self.test_system, self.location,
                                                self.definition, self.descriptor, self.static_data, self.metadata)
 
+    # Disabled 1/27/14 due to flakiness in master
+    # Should not be comparing the submission time to the current time!
+    @unittest.skip
     def test_message_post(self):
         get = {'feedback': 'feedback text',
                'submission_id': '1',
@@ -289,6 +292,9 @@ class OpenEndedModuleTest(unittest.TestCase):
         state = json.loads(self.openendedmodule.get_instance_state())
         self.assertIsNotNone(state['child_state'], OpenEndedModule.DONE)
 
+    # Disabled 1/27/14 due to flakiness in master
+    # Should not be comparing the submission time to the current time!
+    @unittest.skip
     def test_send_to_grader(self):
         submission = "This is a student submission"
         qtime = datetime.strftime(datetime.now(UTC), xqueue_interface.dateformat)


### PR DESCRIPTION
These tests compare the submission time to the current system clock time.  Depending on how quickly different instructions execute, this can cause intermittent failures if the two times don't match, as shown in this test failure:

https://jenkins.testeng.edx.org/job/edx-all-tests-auto-master/845/SHARD=1,TEST_SUITE=unit/

Disabling this until the tests can be added to the ORA backlog and fixed.

@adampalay Please review.  Also, I'm not sure which JIRA board to add this to -- could you please advise?
