### PR TITLE
Updating Annotator CSS

### DIFF
--- a/common/static/css/vendor/ova/edx-annotator.css
+++ b/common/static/css/vendor/ova/edx-annotator.css
@@ -20,7 +20,7 @@
         line-height: 1!important;
         float: left;
 }
-span .annotator-hl{
+span.annotator-hl{
 	font:inherit;
 }
 .vjs-has-started .vjs-loading-spinner {


### PR DESCRIPTION
The change in the css keeps fonts as they were and does not change them
purely based on annotating a section.
