### PR TITLE
Annotations Tool with AWS fix

### DIFF
--- a/lms/templates/notes.html
+++ b/lms/templates/notes.html
@@ -169,6 +169,7 @@
         },
     };
 	
+	tinyMCE.baseURL = "${settings.STATIC_URL}" + "js/vendor/ova";
 	var imgURLRoot = "${settings.STATIC_URL}" + "js/vendor/ova/catch/img/";
 	
 	//remove old instances

--- a/lms/templates/static_htmlbook.html
+++ b/lms/templates/static_htmlbook.html
@@ -13,6 +13,7 @@
 
 <%block name="js_extra">
   <script type="text/javascript">
+	tinyMCE.baseURL = "${settings.STATIC_URL}" + "js/vendor/ova";
 (function($) {
     $.fn.myHTMLViewer = function(options) {
         var urlToLoad = null;

--- a/lms/templates/textannotation.html
+++ b/lms/templates/textannotation.html
@@ -162,8 +162,9 @@
         },
     };
 	
-	var imgURLRoot = window.location.protocol;
-    imgURLRoot +="//" + uri.replace(imgURLRoot+"//","").split('/')[0] + "/static/js/vendor/ova/catch/img/";
+
+	var imgURLRoot = "${settings.STATIC_URL}" + "js/vendor/ova/catch/img/";
+	tinyMCE.baseURL = "${settings.STATIC_URL}" + "js/vendor/ova";
 	
 	//remove old instances
     if (Annotator._instances.length !== 0) {

--- a/lms/templates/videoannotation.html
+++ b/lms/templates/videoannotation.html
@@ -163,9 +163,8 @@
         },
     };
 	
-	var imgURLRoot = window.location.protocol;
-    imgURLRoot +="//" + uri.replace(imgURLRoot+"//","").split('/')[0] + "/static/js/vendor/ova/catch/img/";
-
+	var imgURLRoot = "${settings.STATIC_URL}" + "js/vendor/ova/catch/img/";
+	tinyMCE.baseURL = "${settings.STATIC_URL}" + "js/vendor/ova";
 	
 	//remove old instances
     if (Annotator._instances.length !== 0) {


### PR DESCRIPTION
First set of fixes from the pull request

This does not include some of the testing files. The textannotation and
videoannotation test files are not ready. waiting for an answer on the
issue.

Deleted token line in api.py and added test for token generator

Added notes_spec.coffee

remove spec file

fixed minor error with the test

fixes some quality errors

fixed unit test

fixed unit test

added advanced module

Added notes_spec.coffee

remove spec file

Quality and  Testing Coverage
1. in test_textannotation.py I already check for line 75 as it states
   in the diff in line 43, same with test_videoanntotation
2. Like you said, exceptions cannot be checked for
   firebase_token_generator.py. The version of python that is active on
   the edx server is 2.7 or higher, but the code is there for correctness.
   Error checking works the same way.
3. I added a test for student/views/.py within tests and deleted the
   unused secret assignment.
4. test_token_generator.py is now its own file

Added Secret Token data input

fixed token generator

Annotation Tools in Place

The purpose of this pull request is to install two major modules: (1) a
module to annotate text and (2) a module to annotate video. In either
case an instructor can declare them in advanced settings under
advanced_modules and input content (HTML in text, mp4 or YouTube videos
for video). Students will be able to highlight portions and add their
comments as well as reply to each other. There needs to be a storage
server set up per course as well as a secret token to talk with said
storage.

Changes:
1. Added test to check for the creation of a token in tests.py (along
with the rest of the tests for student/view.py)
2. Removed items in cms pertaining to annotation as this will only be
possible in the lms
3. Added more comments to firebase_token_generator.py, the test files,
students/views.py
4. Added some internationalization stuff to textannotation.html and
videoannotation.html. I need some help with doing it in javascript, but
the html is covered.

incorporated lib for traslate

fixed quality errors

fixed my notes with catch token

Text and Video Annotation Modules - First Iteration

The following code-change is the first iteration of the modules for
text and video annotation.

Installing Modules:
1. Under “Advanced Settings”, add “textannotation” and
“videoannotation” to the list of advanced_modules.
2. Add link to an external storage for annotations under
“annotation_storage_url”
3. Add the secret token for talking with said storage under
“annotation_token_secret”

Using Modules
1. When creating  new unit, you can find Text and Video annotation
modules under “Advanced” component
2. Make sure you have either Text or Video in one unit, but not both.
3. Annotations are only allowed on Live/Public version and not Studio.

Added missing templates and fixed more of the quality errors

Fixed annotator not existing issue in cmd and tried to find the get_html() from the annotation module class to the descriptor

Added a space after # in comments

Fixed issue with an empty Module and token links

Added licenses and fixed vis naming scheme and location.

Updating Annotator CSS

The change in the css keeps fonts as they were and does not change them
purely based on annotating a section.

Fixed Annotation issue with static_url oversight
