### PR TITLE
Pin test lib versions (fix to test failures in master)

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -108,6 +108,8 @@ django-debug-toolbar-mongo
 nose-ignore-docstring
 nose-exclude
 django-crum==0.5
+python-subunit==0.0.16
+testtools==0.9.34
 
 git+https://github.com/mfogel/django-settings-context-processor.git
 


### PR DESCRIPTION
Pin subunit and testtools libraries to prevent test failures after release of these libraries on 1/29/14.
