### PR TITLE
add condition - log speed change / loading video

### DIFF
--- a/common/lib/xmodule/xmodule/js/spec/video/video_player_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_player_spec.js
@@ -196,6 +196,17 @@
                     });
                 });
 
+                it('speed_change_video event is not logged when speed not change', function () {
+                    expect(state.videoPlayer.log).not.toHaveBeenCalledWith(
+                        'speed_change_video',
+                        {
+                            current_time: state.videoPlayer.currentTime,
+                            old_speed: state.speed,
+                            new_speed: state.speed
+                        }
+                    );
+                });
+
                 it('log the play_video event', function () {
                     expect(state.videoPlayer.log).toHaveBeenCalledWith(
                         'play_video', { currentTime: 0 }

--- a/common/lib/xmodule/xmodule/js/src/video/03_video_player.js
+++ b/common/lib/xmodule/xmodule/js/src/video/03_video_player.js
@@ -338,14 +338,16 @@ function (HTML5Video, Resizer) {
 
         newSpeed = parseFloat(newSpeed).toFixed(2).replace(/\.00$/, '.0');
 
-        this.videoPlayer.log(
-            'speed_change_video',
-            {
-                current_time: time,
-                old_speed: this.speed,
-                new_speed: newSpeed
-            }
-        );
+        if (this.speed != newSpeed) {
+            this.videoPlayer.log(
+                'speed_change_video',
+                {
+                    current_time: time,
+                    old_speed: this.speed,
+                    new_speed: newSpeed
+                }
+            );
+        }
 
         this.setSpeed(newSpeed, true);
 


### PR DESCRIPTION
Event "speed_change_video" (in tracking.log) without state change when a video is load for the first time
