### PR TITLE
LMS: Quick Clean Up of Old Index

### DIFF
--- a/lms/djangoapps/courseware/tests/test_microsites.py
+++ b/lms/djangoapps/courseware/tests/test_microsites.py
@@ -114,12 +114,6 @@ class TestMicrosites(ModuleStoreTestCase, LoginEnrollmentTestCase):
         # assert that footer template has been properly overriden on homepage
         self.assertNotContains(resp, 'This is a Test Microsite footer')
 
-        # assert that the edX partners section is not in the HTML
-        self.assertContains(resp, '<section class="university-partners university-partners2x6">')
-
-        # assert that the edX partners tag line is not in the HTML
-        self.assertContains(resp, 'Explore free courses from')
-
 
     def test_microsite_course_enrollment(self):
         """

--- a/lms/static/sass/base/_variables.scss
+++ b/lms/static/sass/base/_variables.scss
@@ -285,6 +285,13 @@ $footer_margin: ($baseline/4) 0 ($baseline*1.5) 0;
 
 // ====================
 
+// VIEWS: homepage
+$homepage__header--gradient__color--alpha: lighten($blue, 15%);
+$homepage__header--gradient__color--bravo: saturate($blue, 30%);
+$homepage__header--background: lighten($blue, 15%);
+
+// ====================
+
 // IMAGES: backgrounds
 $homepage-bg-image: '../images/homepage-bg.jpg';
 

--- a/lms/static/sass/multicourse/_home.scss
+++ b/lms/static/sass/multicourse/_home.scss
@@ -7,8 +7,7 @@
   }
 
   > header {
-    background: $dashboard-profile-color;
-    @include background-image(url($homepage-bg-image));
+    @include linear-gradient($homepage__header--gradient__color--alpha, $homepage__header--gradient__color--bravo);
     background-size: cover;
     border-bottom: 1px solid $border-color-3;
     box-shadow: 0 1px 0 0 $course-header-bg, inset 0 -1px 5px 0 rgba(0,0,0, 0.1);

--- a/lms/templates/index.html
+++ b/lms/templates/index.html
@@ -12,7 +12,7 @@
 
   show_homepage_promo_video = MicrositeConfiguration.get_microsite_configuration_value('show_homepage_promo_video', True)
   homepage_promo_video_youtube_id = MicrositeConfiguration.get_microsite_configuration_value('homepage_promo_video_youtube_id', "XNaiOGxWeto")
-  
+
   show_partners = MicrositeConfiguration.get_microsite_configuration_value('show_partners', True)
 
 %>
@@ -70,116 +70,6 @@
   </header>
   <section class="container">
     <section class="highlighted-courses">
-      ## Disable university partner logos and sites for non-edX sites
-      % if not self.theme_enabled() and show_partners:
-        <h2>${_('Explore free courses from {span_start}{platform_name}{span_end} universities').format(platform_name="edX", span_start='<span class="edx">', span_end='</span>')}</h2>
-
-        <section class="university-partners university-partners2x6">
-          <ol class="partners">
-            <li class="partner mit">
-              <a href="#">
-                <img src="${static.url('images/university/mit/mit.png')}" />
-                <div class="name">
-                  <span>MITx</span>
-                </div>
-              </a>
-            </li>
-            <li class="partner">
-              <a href="#">
-                <img src="${static.url('images/university/harvard/harvard.png')}" />
-                <div class="name">
-                  <span>HarvardX</span>
-                </div>
-              </a>
-            </li>
-            <li class="partner">
-              <a href="#">
-                <img src="${static.url('images/university/berkeley/berkeley.png')}" />
-                <div class="name">
-                  <span>BerkeleyX</span>
-                </div>
-              </a>
-            </li>
-            <li class="partner">
-              <a href="#">
-                <img src="${static.url('images/university/ut/ut-rollover_350x150.png')}" />
-                <div class="name">
-                  <span>UTx</span>
-                </div>
-              </a>
-            </li>
-            <li class="partner">
-              <a href="#">
-                <img src="${static.url('images/university/mcgill/mcgill.png')}" />
-                <div class="name">
-                  <span>McGillX</span>
-                </div>
-              </a>
-            </li>
-            <li class="partner">
-              <a href="#">
-                <img src="${static.url('images/university/anu/anu.png')}" />
-                <div class="name">
-                  <span>ANUx</span>
-                </div>
-              </a>
-            </li>
-          </ol>
-
-          <hr />
-
-          <ol class="partners">
-            <li class="partner">
-              <a href="#">
-                <img src="${static.url('images/university/wellesley/wellesley-rollover_350x150.png')}" />
-                <div class="name">
-                  <span>WellesleyX</span>
-                </div>
-              </a>
-            </li>
-            <li class="partner">
-              <a href="#">
-                <img src="${static.url('images/university/georgetown/georgetown-rollover_350x150.png')}" />
-                <div class="name">
-                  <span>GeorgetownX</span>
-                </div>
-              </a>
-            </li>
-            <li class="partner">
-              <a href="#">
-                <img src="${static.url('images/university/toronto/toronto.png')}" />
-                <div class="name">
-                  <span>University of TorontoX</span>
-                </div>
-              </a>
-            </li>
-            <li class="partner">
-              <a href="#">
-                <img src="${static.url('images/university/epfl/epfl.png')}" />
-                <div class="name">
-                  <span>EPFLx</span>
-                </div>
-              </a>
-            </li>
-            <li class="partner">
-              <a href="#">
-                <img src="${static.url('images/university/delft/delft.png')}" />
-                <div class="name">
-                  <span>DelftX</span>
-                </div>
-              </a>
-            </li>
-            <li class="partner">
-              <a href="#">
-                <img src="${static.url('images/university/rice/rice.png')}" />
-                <div class="name">
-                  <span>RiceX</span>
-                </div>
-              </a>
-            </li>
-          </ol>
-        </section>
-      % endif
 
       % if settings.FEATURES.get('COURSES_ARE_BROWSABLE'):
         <section class="courses">
@@ -192,6 +82,7 @@
             </ul>
         </section>
       % endif
+
     </section>
   </section>
 </section>


### PR DESCRIPTION
This work resolves a few things with the old edX homepage/current Open Source LMS Homepage:
- removes edX-specific university partners (and their now broken images)
- updated the background of the header area to correct for a missing image reference and added a basic starting gradient
