### PR TITLE
improve error reporting for reload_forum_users cmd (one-liner)

### DIFF
--- a/lms/djangoapps/django_comment_client/management/commands/reload_forum_users.py
+++ b/lms/djangoapps/django_comment_client/management/commands/reload_forum_users.py
@@ -16,7 +16,7 @@ class Command(BaseCommand):
             cc_user = cc.User.from_django_user(user)
             cc_user.save()
         except Exception as err:
-            print "update user info to discussion failed for user with id: %s" % user
+            print "update user info to discussion failed for user with id: %s, error=%s" % (user, str(err))
 
     def handle(self, *args, **options):
         if len(args) != 0:


### PR DESCRIPTION
If this management command fails it's tough to figure out why without
seeing the text from the exception.  Luckily comment service does
return useful feedback, we just have to show it.  This one-line
change just add the exception text to the error message.

Before (with spurrious debug msgs removed):

```
sefk@util1:~$ ./manage.sh reload_forum_users Anthonyhubendurance
update user info to discussion failed for user with id: Anthonyhubendurance
```

After:

```
sefk@util1:~$ ./manage.sh reload_forum_users Anthonyhubendurance
update user info to discussion failed for user with id: Anthonyhubendurance, error=u'["Email is already taken"]'
```

No unit testing (sorry) added since this doesn't have coverage
already, and it's just a simple error case.
