### PR TITLE
/register_post is an invalid URL

### DIFF
--- a/cms/templates/signup.html
+++ b/cms/templates/signup.html
@@ -17,7 +17,7 @@
     <p class="introduction">${_("Ready to start creating online courses? Sign up below and start creating your first edX course today.")}</p>
 
     <article class="content-primary" role="main">
-      <form id="register_form" method="post" action="register_post">
+      <form id="register_form" method="post">
         <div id="register_error" name="register_error" class="message message-status message-status error">
         </div>
 


### PR DESCRIPTION
We're not using this value anywhere, and I just got a weird test failure with it: https://jenkins.testeng.edx.org/job/edx-all-tests-auto-pr/4472/SHARD=2,TEST_SUITE=cms-acceptance/
