### PR TITLE
assets: add theme path to coffeescript's processing;  rakefile: fix feature/env settings

### DIFF
--- a/cms/startup.py
+++ b/cms/startup.py
@@ -1,16 +1,1 @@
-"""
-Module with code executed during Studio startup
-"""
-from django.conf import settings
-
-# Force settings to run so that the python path is modified
-settings.INSTALLED_APPS  # pylint: disable=W0104
-
-from django_startup import autostartup
-
-
-def run():
-    """
-    Executed during django startup
-    """
-    autostartup()
+../lms/startup.py

--- a/rakefile
+++ b/rakefile
@@ -23,7 +23,7 @@ if not SERVICE_VARIANT
     # consider only the words remaining (parse out separators);
     clean_args = clean_args.join(' ').split(/\W/)
     # if lms or cms is among command line words, use it's env:
-    SERVICE_VARIANT = clean_args.include?('lms') ? "lms" : 
+    SERVICE_VARIANT = clean_args.include?('lms') ? "lms" :
 	(clean_args.include?('studio') or clean_args.include?('cms')) ? "cms" :
 	SERVICE_VARIANT
 end

--- a/rakefile
+++ b/rakefile
@@ -15,6 +15,18 @@ REPORT_DIR = File.join(REPO_ROOT, "reports")
 
 # Environment constants
 SERVICE_VARIANT = ENV['SERVICE_VARIANT']
+# if service variant, honor that;
+#  - if not, pass the correct ENV tokens for lms or cms
+if not SERVICE_VARIANT
+    # ignore command line environments, e.g. "rake e1=this"
+    clean_args = ARGV.delete_if { |x| /=/.match(x) }
+    # consider only the words remaining (parse out separators);
+    clean_args = clean_args.join(' ').split(/\W/)
+    # if lms or cms is among command line words, use it's env:
+    SERVICE_VARIANT = clean_args.include?('lms') ? "lms" : 
+	(clean_args.include?('studio') or clean_args.include?('cms')) ? "cms" :
+	SERVICE_VARIANT
+end
 CONFIG_PREFIX = SERVICE_VARIANT ? SERVICE_VARIANT + "." : ""
 ENV_FILE = File.join(ENV_ROOT, CONFIG_PREFIX + "env.json")
 ENV_TOKENS = File.exists?(ENV_FILE) ? JSON.parse(File.read(ENV_FILE)) : {}

--- a/rakelib/assets.rake
+++ b/rakelib/assets.rake
@@ -1,4 +1,5 @@
 # Theming constants
+
 USE_CUSTOM_THEME = ENV_TOKENS.has_key?('FEATURES') && ENV_TOKENS['FEATURES']['USE_CUSTOM_THEME']
 if USE_CUSTOM_THEME
     THEME_NAME = ENV_TOKENS['THEME_NAME']
@@ -23,17 +24,22 @@ def xmodule_cmd(watch=false, debug=false)
 end
 
 def coffee_cmd(watch=false, debug=false)
+    brew_paths = ["lms/", "cms/", "common/"]
+    if USE_CUSTOM_THEME
+      # put theme path first just to be safe;
+      brew_paths.unshift(THEME_ROOT)
+    end
+
     if watch && Launchy::Application.new.host_os_family.darwin?
         available_files = Process::getrlimit(:NOFILE)[0]
         if available_files < MINIMAL_DARWIN_NOFILE_LIMIT
             Process.setrlimit(:NOFILE, MINIMAL_DARWIN_NOFILE_LIMIT)
-
         end
     end
     if watch
-        "node_modules/.bin/coffee --compile --watch lms/ cms/ common/"
+        "node_modules/.bin/coffee --compile --watch #{brew_paths.join(' ')}"
     else
-        "node_modules/.bin/coffee --compile `find lms/ cms/ common/ -type f -name *.coffee` "
+        "node_modules/.bin/coffee --compile `find #{brew_paths.join(' ')} -type f -name *.coffee` "
     end
 end
 


### PR DESCRIPTION
This is another step towards enabling product development off of Open edX:

rakefile setup ENV_TOKENS (supposed to b django settings & feature flags) based on SERVICE_VARIANT, but the *.env.json files which  are commonly set in the baseline are cms.env.json and lms.env.json - yet the feature settings weren't getting passed on to assets processing.

This corrects the base rakefile:
- if SERVICE_VARIANT is set from the environment or call, it is honored.
- if not, the rake command line ARGV is parsed for command specifiers indicating either lms or studio/cms;
- if lms or studio is found, then the appropriate *.env.json file is setup for parsing, and passing on to tasks;

The standard installation creates both lms.env.json and cms.env.json in /edx/app/edxapp - copies of the respective django environment settings.

I didn't expect both to be present (for example:  `rake devstack[lms]` or `rake cms:gather_assets:devstack` seem to preclude both lms and [studio, cms] being present on the command line.   If there were such an instance, lms would win.

With this change, it is possible to effect lms theming and "have it just work".

There is a remaining issue with cms theming, where manage.py cms preprocess_assets  seems to edit and overwrite the theme includ settings configured by other tasks in the various standard *.scss files.   That will be addressed in another pull request.

This pull also enables automatic "working" for an associated pull [TBD] for configuration, where vagrant/base bringups are setup for specific ("nailed") repositories & versions (branches), so this is part of enabling that also.
