### PR TITLE
Fix unicode error in subsection

### DIFF
--- a/common/djangoapps/microsite_configuration/templatetags/microsite.py
+++ b/common/djangoapps/microsite_configuration/templatetags/microsite.py
@@ -18,7 +18,7 @@ def page_title_breadcrumbs(*crumbs, **kwargs):
     """
     separator = kwargs.get("separator", " | ")
     if crumbs:
-        return '{}{}{}'.format(separator.join(crumbs), separator, platform_name())
+        return u'{}{}{}'.format(separator.join(crumbs), separator, platform_name())
     else:
         return platform_name()
 

--- a/common/djangoapps/microsite_configuration/test_microsites.py
+++ b/common/djangoapps/microsite_configuration/test_microsites.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+"""
+Tests microsite_configuration templatetags and helper functions.
+"""
+from django.test import TestCase
+from django.conf import settings
+from .templatetags import microsite
+
+
+class MicroSiteTests(TestCase):
+    def test_breadcrumbs(self):
+        crumbs = ['my', 'less specific', 'Page']
+        expected = u'my | less specific | Page | edX'
+        title = microsite.page_title_breadcrumbs(*crumbs)
+        self.assertEqual(expected, title)
+
+    def test_unicode_title(self):
+        crumbs = [u'øo', u'π tastes gréât', u'驴']
+        expected = u'øo | π tastes gréât | 驴 | edX'
+        title = microsite.page_title_breadcrumbs(*crumbs)
+        self.assertEqual(expected, title)
+
+    def test_platform_name(self):
+        pname = microsite.platform_name()
+        self.assertEqual(pname, settings.PLATFORM_NAME)
+    
+    def test_breadcrumb_tag(self):
+        crumbs = ['my', 'less specific', 'Page']
+        expected = u'my | less specific | Page | edX'
+        title = microsite.page_title_breadcrumbs_tag(None, *crumbs)
+        self.assertEqual(expected, title)
+        


### PR DESCRIPTION
@chrisndodge this fixes a bug brought up on the mailing list, see my response to this: https://groups.google.com/forum/#!topic/edx-code/cdsQafpz0aA

@wedaly I don't know the best place to add a test for creating a course with sections, subsections, and problem names with Unicode, but obviously this is a needed test! Can you please advise?
