### PR TITLE
Add '' default to bodyclass in courseware templates

### DIFF
--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -6,7 +6,7 @@
  <% return _("{course_number} Courseware").format(course_number=course.display_number_with_default) %>
 </%def>
 
-<%block name="bodyclass">courseware ${course.css_class}</%block>
+<%block name="bodyclass">courseware ${course.css_class or ''}</%block>
 <%block name="title"><title>
     % if section_title: 
 ${page_title_breadcrumbs(section_title, course_name())}

--- a/lms/templates/courseware/info.html
+++ b/lms/templates/courseware/info.html
@@ -26,7 +26,7 @@ $(document).ready(function(){
   </script>
 </%block>
 
-<%block name="bodyclass">${course.css_class}</%block>
+<%block name="bodyclass">${course.css_class or ''}</%block>
 <section class="container">
   <div class="info-wrapper">
     % if user.is_authenticated():

--- a/lms/templates/courseware/static_tab.html
+++ b/lms/templates/courseware/static_tab.html
@@ -1,5 +1,5 @@
 <%inherit file="/main.html" />
-<%block name="bodyclass">${course.css_class}</%block>
+<%block name="bodyclass">${course.css_class or ''}</%block>
 <%namespace name='static' file='/static_content.html'/>
 
 <%block name="headextra">


### PR DESCRIPTION
This prevents from having a `'None'` CSS class in the `<body>` tag when no `css_class` is defined for the course.
