### PR TITLE
Added sphinx_rtd_theme to requirements

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -86,6 +86,7 @@ newrelic==2.4.0.4
 
 # Used for documentation gathering
 sphinx==1.1.3
+sphinx_rtd_theme==0.1.5
 
 # Used for Internationalization and localization
 Babel==1.3


### PR DESCRIPTION
A [recent commit](https://github.com/edx/edx-platform/commit/2cb2e2c52a8c161ebe2ec99892f3f25544d8af25) imported `sphinx_rtd_theme` without adding it to the installation requirements.  When the library was not installed on the user's system, sphinx would fail when trying to build the docs.

This commit adds the new requirement to ensure that the docs build without error.  The requirement is under the MIT license.

@mhoeboer 
