### PR TITLE
Improved randomize module: DO NOT MERGE - sample code for @shnayder

### DIFF
--- a/common/lib/xmodule/xmodule/randomize_module.py
+++ b/common/lib/xmodule/xmodule/randomize_module.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import random
 
@@ -6,10 +7,9 @@ from xmodule.seq_module import SequenceDescriptor
 
 from lxml import etree
 
-from xblock.fields import Scope, Integer
-from xblock.fragment import Fragment
+from xblock.core import Scope, Integer
 
-log = logging.getLogger('edx.' + __name__)
+log = logging.getLogger('mitx.' + __name__)
 
 
 class RandomizeFields(object):
@@ -39,7 +39,7 @@ class RandomizeModule(RandomizeFields, XModule):
         modules.
 """
     def __init__(self, *args, **kwargs):
-        super(RandomizeModule, self).__init__(*args, **kwargs)
+        XModule.__init__(self, *args, **kwargs)
 
         # NOTE: calling self.get_children() creates a circular reference--
         # it calls get_child_descriptors() internally, but that doesn't work until
@@ -53,16 +53,20 @@ class RandomizeModule(RandomizeFields, XModule):
         if self.choice is None:
             # choose one based on the system seed, or randomly if that's not available
             if num_choices > 0:
-                if self.system.seed is not None:
+                if self.system.seed is not None and 'use_randrange' not in (self.descriptor.xml_attributes or []):
                     self.choice = self.system.seed % num_choices
+                    log.debug('using seed for %s choice=%s' % (str(self.location), self.choice))
                 else:
                     self.choice = random.randrange(0, num_choices)
+                    log.debug('using randrange for %s' % str(self.location))
+            else:
+                log.debug('error in randomize: num_choices = %s' % num_choices)
 
         if self.choice is not None:
             self.child_descriptor = self.descriptor.get_children()[self.choice]
             # Now get_children() should return a list with one element
-            log.debug("children of randomize module (should be only 1): %s",
-                      self.get_children())
+            log.debug("choice=%s in %s, children of randomize module (should be only 1): %s",
+                      self.choice, str(self.location), self.get_children())
             self.child = self.get_children()[0]
         else:
             self.child_descriptor = None
@@ -78,12 +82,36 @@ class RandomizeModule(RandomizeFields, XModule):
         return [self.child_descriptor]
 
 
-    def student_view(self, context):
+    def get_html(self):
         if self.child is None:
             # raise error instead?  In fact, could complain on descriptor load...
-            return Fragment(content=u"<div>Nothing to randomize between</div>")
+            return "<div>Nothing to randomize between</div>"
 
-        return self.child.render('student_view', context)
+        if self.system.user_is_staff:
+            dishtml = self.system.render_template('randomize_control.html', {
+                    'element_id': self.location.html_id(),
+                    'is_staff': self.system.user_is_staff,
+                    'ajax_url': self.system.ajax_url,
+                    'choice': self.choice,
+                    'num_choices': len(self.descriptor.get_children()),
+                    })
+            # html = '<html><p>Welcome, staff.  Randomize loc=%s ; Choice=%s</p><br/><hr/></br/>' % (str(self.location), self.choice)
+            html = "<html>" + dishtml + self.child.get_html() + "</html>"
+            return html
+        return self.child.get_html()
+
+    def handle_ajax(self, dispatch, data):
+        if dispatch=='next':
+            self.choice = self.choice + 1
+        elif dispatch=='jump':
+            log.debug('jump, data=%s' % data)
+            self.choice = int(data['choice'])
+        num_choices = len(self.descriptor.get_children())
+        if self.choice >= num_choices:
+            self.choice = 0
+
+        result = {'ret': "choice=%s" % self.choice}
+        return json.dumps(result)
 
     def get_icon_class(self):
         return self.child.get_icon_class() if self.child else 'other'

--- a/lms/templates/randomize_control.html
+++ b/lms/templates/randomize_control.html
@@ -1,0 +1,39 @@
+% if is_staff: 
+<div id="randomize_${element_id}_control">
+    <p>
+    <input id="randomize_next" type="button" value="This is randomized module ${choice} of ${num_choices}: Go to next"/>
+    or jump to:
+    <select id="randomize_jump">
+        % for kchoice in range(num_choices):
+	    <% selected = "selected" if kchoice==choice else "" %>
+	    <option value="${kchoice}" ${selected}>${kchoice}</option>
+        % endfor
+    </select>
+    </p>
+</div>
+<hr/>
+
+<script type="text/javascript">
+do_next = function(){
+    $.get( "${ajax_url}/next", function( data ) {
+      $( "#randomize_next" ).html( data );
+      alert( "next successful" );
+      location.reload();
+    });
+}
+$('#randomize_next').click(do_next);
+
+rand_jump = function(){
+    var choice = $('#randomize_jump option:selected').text();
+    $.post( "${ajax_url}/jump", { 'choice': choice},
+      function( data ) {
+        $( "#randomize_next" ).html( data );
+        alert( "jump to " + choice + " successful" );
+        location.reload();
+      });
+}
+
+$('#randomize_jump').change(rand_jump);
+
+</script>
+% endif


### PR DESCRIPTION
randomize module which allows staff to select which specific child module to view.
Includes randomize_control.html template.  Uses AJAX for rendering children.

Does not include the code changes which would make randomize more robust, by tracking children based on location instead of index into list of children.  Using an index is not a good idea, because course staff editing the content may change the length and order of elements.  Additional error checking should be added to make sure the randomly chosen child still exists.

This version of the module was used at MIT through the Fall of 2013.  It is out-of-date with respect to changes which have happened to the xmodule semantics.

@shnayder 
