### PR TITLE
Pinned version of sure library

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -69,6 +69,7 @@ Shapely==1.2.16
 singledispatch==3.4.0.2
 sorl-thumbnail==11.12
 South==0.7.6
+sure==1.2.3
 sympy==0.7.1
 xmltodict==0.4.1
 django-ratelimit-backend==0.6


### PR DESCRIPTION
The `sure` library (a dependency of `lettuce`) released a new version on 2/2 that failed on installation with the error message:

```
OError: [Errno 2] No such file or directory: '/home/jenkins/edx-venv/build/sure/readme.rst'
```

This PR pins the version to `1.2.3`, which still works.
