### PR TITLE
Fix cleanup .pyc file command in rake test

### DIFF
--- a/rakelib/tests.rake
+++ b/rakelib/tests.rake
@@ -59,7 +59,7 @@ end
 task :clean_test_files do
     desc "Clean fixture files used by tests and .pyc files"
     sh("git clean -fqdx test_root/logs test_root/data test_root/staticfiles test_root/uploads")
-    sh("find . -type f -name *.pyc -delete")
+    sh("find . -type f -name \"*.pyc\" -delete")
 end
 
 task :clean_reports_dir => REPORT_DIR do


### PR DESCRIPTION
When Python files were pre-compiled at the top level of the edx-platform repo, `rake test` would fail with this error:

```
find . -type f -name *.pyc -delete
find: paths must precede expression: setup.pyc
```

The issue was that the shell was expanding `*.pyc` instead of using it as a wildcard match in the find.  This PR fixes the issue by quoting `*.pyc` to prevent shell expansion.

@jzoldak 
