### PR TITLE
Added feature setting to disable histograms in Staff Debug Info panel.

### DIFF
--- a/common/djangoapps/xmodule_modifiers.py
+++ b/common/djangoapps/xmodule_modifiers.py
@@ -147,7 +147,7 @@ def grade_histogram(module_id):
     return grades
 
 
-def add_histogram(user, block, view, frag, context):  # pylint: disable=unused-argument
+def add_staff_debug_info(user, block, view, frag, context):  # pylint: disable=unused-argument
     """
     Updates the supplied module with a new get_html function that wraps
     the output of the old get_html function with additional information

--- a/common/djangoapps/xmodule_modifiers.py
+++ b/common/djangoapps/xmodule_modifiers.py
@@ -126,8 +126,12 @@ def replace_static_urls(data_dir, block, view, frag, context, course_id=None, st
 
 
 def grade_histogram(module_id):
-    ''' Print out a histogram of grades on a given problem.
-        Part of staff member debug info.
+    '''
+    Print out a histogram of grades on a given problem in staff member debug info.
+
+    Warning: If a student has just looked at an xmodule and not attempted
+    it, their grade is None. Since there will always be at least one such student
+    this function almost always returns [].
     '''
     from django.db import connection
     cursor = connection.cursor()
@@ -161,7 +165,7 @@ def add_staff_debug_info(user, block, view, frag, context):  # pylint: disable=u
         return frag
 
     block_id = block.id
-    if block.has_score:
+    if block.has_score and settings.FEATURES.get('DISPLAY_HISTOGRAMS_TO_STAFF'):
         histogram = grade_histogram(block_id)
         render_histogram = len(histogram) > 0
     else:

--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -38,7 +38,7 @@ from xmodule.modulestore import Location
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError
 from xmodule.util.duedate import get_extended_due_date
-from xmodule_modifiers import replace_course_urls, replace_jump_to_id_urls, replace_static_urls, add_histogram, wrap_xblock
+from xmodule_modifiers import replace_course_urls, replace_jump_to_id_urls, replace_static_urls, add_staff_debug_info, wrap_xblock
 from xmodule.lti_module import LTIModule
 from xmodule.x_module import XModuleDescriptor
 
@@ -368,9 +368,9 @@ def get_module_for_descriptor_internal(user, descriptor, field_data_cache, cours
         reverse('jump_to_id', kwargs={'course_id': course_id, 'module_id': ''}),
     ))
 
-    if settings.FEATURES.get('DISPLAY_HISTOGRAMS_TO_STAFF'):
+    if settings.FEATURES.get('DISPLAY_DEBUG_INFO_TO_STAFF'):
         if has_access(user, descriptor, 'staff', course_id):
-            block_wrappers.append(partial(add_histogram, user))
+            block_wrappers.append(partial(add_staff_debug_info, user))
 
     # These modules store data using the anonymous_student_id as a key.
     # To prevent loss of data, we will continue to provide old modules with

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -55,7 +55,9 @@ DISCUSSION_SETTINGS = {
 FEATURES = {
     'SAMPLE': False,
     'USE_DJANGO_PIPELINE': True,
-    'DISPLAY_HISTOGRAMS_TO_STAFF': True,
+
+    'DISPLAY_DEBUG_INFO_TO_STAFF': True,
+
     'REROUTE_ACTIVATION_EMAIL': False,  # nonempty string = address for all activation emails
     'DEBUG_LEVEL': 0,  # 0 = lowest level, least verbose, 255 = max level, most verbose
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -57,6 +57,7 @@ FEATURES = {
     'USE_DJANGO_PIPELINE': True,
 
     'DISPLAY_DEBUG_INFO_TO_STAFF': True,
+    'DISPLAY_HISTOGRAMS_TO_STAFF': False,  # For large courses this slows down courseware access for staff.
 
     'REROUTE_ACTIVATION_EMAIL': False,  # nonempty string = address for all activation emails
     'DEBUG_LEVEL': 0,  # 0 = lowest level, least verbose, 255 = max level, most verbose


### PR DESCRIPTION
Generating histograms requires scanning the courseware_studentmodule table on
each view. This can make staff access to courseware very slow on large courses.

LMS-1199
