### PR TITLE
Better test console reports; i18n XUnit results

### DIFF
--- a/i18n/config.py
+++ b/i18n/config.py
@@ -5,7 +5,7 @@ from path import path
 
 # BASE_DIR is the working directory to execute django-admin commands from.
 # Typically this should be the 'edx-platform' directory.
-BASE_DIR = path(__file__).abspath().dirname().joinpath('..').normpath()
+BASE_DIR = path(__file__).abspath().dirname().dirname()
 
 # LOCALE_DIR contains the locale files.
 # Typically this should be 'edx-platform/conf/locale'

--- a/rakelib/acceptance_test.rake
+++ b/rakelib/acceptance_test.rake
@@ -10,7 +10,11 @@ def run_acceptance_tests(system, harvest_args)
 
     report_file = File.join(ACCEPTANCE_REPORT_DIR, "#{system}.xml")
     report_args = "--with-xunit --xunit-file #{report_file}"
-    test_sh(django_admin(system, 'acceptance', 'harvest', '--debug-mode', '--verbosity 2', report_args, harvest_args))
+    cmd = django_admin(
+        system, 'acceptance', 'harvest', '--debug-mode',
+        '--verbosity 2', report_args, harvest_args
+    )
+    test_sh("#{system} acceptance tests", cmd)
 end
 
 task :setup_acceptance_db do

--- a/rakelib/docs.rake
+++ b/rakelib/docs.rake
@@ -42,4 +42,18 @@ desc "Build docs and show them in browser"
 task :doc, [:type, :quiet] =>  :builddocs do |t, args|
     Rake::Task["showdocs"].invoke(args.type, args.quiet)
 end
-# --- Develop and public documentation ---
+
+
+# Run documentation tests
+desc "Run documentation tests"
+task :test_docs do
+    # Be sure that sphinx can build docs w/o exceptions.
+    test_message = "If a docs test fails, you should run '%s' and look at whole output and fix exceptions.
+(You shouldn't fix rst warnings and errors for this to pass, just get rid of exceptions.)"
+    puts (test_message  % ["rake doc[docs,verbose]"]).colorize( :light_green )
+    test_sh('docs', 'rake builddocs')
+end
+
+
+# Add documentation tests to the main test command
+task :test => :'test_docs'

--- a/rakelib/helpers.rb
+++ b/rakelib/helpers.rb
@@ -119,11 +119,16 @@ def environments(system)
     end
 end
 
-$failed_tests = 0
+
+$failed_tests = []
 
 # Run sh on args. If TESTS_FAIL_FAST is set, then stop on the first shell failure.
 # Otherwise, a final task will be added that will fail if any tests have failed
-def test_sh(*args)
+def test_sh(name, *args)
+    puts("\n=======================================".green)
+    puts("Running #{name} tests".green)
+    puts("=======================================".green)
+
     sh(*args) do |ok, res|
         if ok
             return
@@ -132,15 +137,24 @@ def test_sh(*args)
         if ENV['TESTS_FAIL_FAST']
             fail("Test failed!")
         else
-            $failed_tests += 1
+            $failed_tests << name
         end
     end
+
+    puts("\n=======================================\n".green)
 end
 
 # Add a task after all other tasks that fails if any tests have failed
 if !ENV['TESTS_FAIL_FAST']
     task :fail_tests do
-        fail("#{$failed_tests} tests failed!") if $failed_tests > 0
+        if $failed_tests.length > 0
+            puts("=======================================".red)
+            puts("Tests failed in these test suites:".red)
+            $failed_tests.each do |test|
+                puts("* #{test}".red)
+            end
+            exit 1
+        end
     end
 
     Rake.application.top_level_tasks << :fail_tests

--- a/rakelib/i18n.rake
+++ b/rakelib/i18n.rake
@@ -1,5 +1,11 @@
 # --- Internationalization tasks
 
+I18N_REPORT_DIR = report_dir_path('i18n')
+I18N_XUNIT_REPORT = File.join(I18N_REPORT_DIR, 'nosetests.xml')
+
+directory I18N_REPORT_DIR
+
+
 namespace :i18n do
 
   desc "Extract localizable strings from sources"
@@ -57,10 +63,9 @@ namespace :i18n do
   end
 
   desc "Run tests for the internationalization library"
-  task :test do
-    test = File.join(REPO_ROOT, "i18n", "tests")
+  task :test => [I18N_REPORT_DIR, :clean_reports_dir] do
     pythonpath_prefix = "PYTHONPATH=#{REPO_ROOT}/i18n:$PYTHONPATH"
-    sh("#{pythonpath_prefix} nosetests #{test}")
+    test_sh("i18n", "#{pythonpath_prefix} nosetests #{REPO_ROOT}/i18n/tests --with-xunit --xunit-file=#{I18N_XUNIT_REPORT}")
   end
 
   # Commands for automating the process of including translations in edx-platform.
@@ -79,3 +84,7 @@ namespace :i18n do
   end
 
 end
+
+
+# Add i18n tests to the main test command
+task :test => :'i18n:test'

--- a/rakelib/js_test.rake
+++ b/rakelib/js_test.rake
@@ -40,7 +40,7 @@ def js_test_tool(env, command, do_coverage)
         cmd += " --coverage-xml #{report_dir}"
     end
 
-    test_sh(cmd)
+    test_sh("javascript", cmd)
 end
 
 # Print a list of js_test commands for


### PR DESCRIPTION
Currently, when the doc and i18n tests fail in Jenkins, it's very hard to figure out what went wrong.  You can see at the end of the console log that tests failed, but it doesn't tell you which one(s), and the traceback is buried in lots of rake output garbage.

This addresses the issue by (1) adding section headers to the console output saying which test suite is running, (2) adding a list of tests that failed to the end of the test output.

Since these kinds of failures occur _before_ running any unit tests, I think it makes more sense to have readable logs than to generate dummy XUnit reports.  However, the PR also adds xunit reports to the i18n tests, which should get picked up by Jenkins.

Changes:
- List which test suites failed
- Add section headings to test console output
- i18n tests generate XUnit reports
- Move i18n and docs test commands out of tests.rake

https://edx-wiki.atlassian.net/browse/TE-330

@jzoldak 
