### PR TITLE
Mark strings that were causing test failures as unicode

### DIFF
--- a/lms/djangoapps/bulk_email/forms.py
+++ b/lms/djangoapps/bulk_email/forms.py
@@ -64,7 +64,7 @@ class CourseAuthorizationAdminForm(forms.ModelForm):  # pylint: disable=R0924
             get_course_by_id(course_id, depth=1)
         except Exception as exc:
             msg = 'Error encountered ({0})'.format(str(exc).capitalize())
-            msg += ' --- Entered course id was: "{0}". '.format(course_id)
+            msg += u' --- Entered course id was: "{0}". '.format(course_id)
             msg += 'Please recheck that you have supplied a course id in the format: ORG/COURSE/RUN'
             raise forms.ValidationError(msg)
 

--- a/lms/djangoapps/bulk_email/tests/test_forms.py
+++ b/lms/djangoapps/bulk_email/tests/test_forms.py
@@ -84,7 +84,7 @@ class CourseAuthorizationFormTest(ModuleStoreTestCase):
         self.assertFalse(form.is_valid())
 
         msg = u'Error encountered (Course not found.)'
-        msg += ' --- Entered course id was: "{0}". '.format(bad_id)
+        msg += u' --- Entered course id was: "{0}". '.format(bad_id)
         msg += 'Please recheck that you have supplied a course id in the format: ORG/COURSE/RUN'
         self.assertEquals(msg, form._errors['course_id'][0])  # pylint: disable=protected-access
 
@@ -102,7 +102,7 @@ class CourseAuthorizationFormTest(ModuleStoreTestCase):
         self.assertFalse(form.is_valid())
 
         msg = u'Error encountered (Need more than 1 value to unpack)'
-        msg += ' --- Entered course id was: "{0}". '.format(bad_id)
+        msg += u' --- Entered course id was: "{0}". '.format(bad_id)
         msg += 'Please recheck that you have supplied a course id in the format: ORG/COURSE/RUN'
         self.assertEquals(msg, form._errors['course_id'][0])  # pylint: disable=protected-access
 
@@ -126,7 +126,7 @@ class CourseAuthorizationXMLFormTest(ModuleStoreTestCase):
         self.assertFalse(form.is_valid())
 
         msg = u"Course Email feature is only available for courses authored in Studio. "
-        msg += '"{0}" appears to be an XML backed course.'.format(course_id)
+        msg += u'"{0}" appears to be an XML backed course.'.format(course_id)
         self.assertEquals(msg, form._errors['course_id'][0])  # pylint: disable=protected-access
 
         with self.assertRaisesRegexp(ValueError, "The CourseAuthorization could not be created because the data didn't validate."):


### PR DESCRIPTION
@sarina @feanil 
This is needed for tests to pass when the release branch is merged into master.
