### PR TITLE
fix bug where uploading a transcript against a HTML5 video which contains a period in the video filename causes the transcript filename to be improperly constructed

### DIFF
--- a/cms/djangoapps/contentstore/features/transcripts.feature
+++ b/cms/djangoapps/contentstore/features/transcripts.feature
@@ -677,3 +677,19 @@ Feature: CMS.Transcripts
         And I edit the component
         Then I see status message "not found"
 
+    #36 Uploading subtitles for file with periods in it should properly set the transcript name and keep the periods
+    Scenario: File name and name of subs are different
+        Given I have created a Video component
+        And I edit the component
+
+        And I enter a "video_name_1.1.2.mp4" source to field number 1
+        And I see status message "not found"
+        And I upload the transcripts file "test_transcripts.srt"
+        Then I see status message "uploaded_successfully"
+        And I see value "video_name_1.1.2" in the field "HTML5 Transcript"
+
+        And I save changes
+        Then when I view the video it does show the captions
+
+        And I edit the component
+        Then I see status message "found"

--- a/cms/djangoapps/contentstore/tests/test_transcripts_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_transcripts_utils.py
@@ -213,6 +213,19 @@ class TestDownloadYoutubeSubs(ModuleStoreTestCase):
 
         self.clear_subs_content(good_youtube_subs)
 
+    def test_subs_for_html5_vid_with_periods(self):
+        """
+        This is to verify a fix whereby subtitle files uploaded against
+        a HTML5 video that contains periods in the name causes
+        incorrect subs name parsing
+        """
+        html5_ids = transcripts_utils.get_html5_ids(['foo.mp4', 'foo.1.bar.mp4', 'foo/bar/baz.1.4.mp4', 'foo'])
+        self.assertEqual(4, len(html5_ids))
+        self.assertEqual(html5_ids[0], 'foo')
+        self.assertEqual(html5_ids[1], 'foo.1.bar')
+        self.assertEqual(html5_ids[2], 'baz.1.4')
+        self.assertEqual(html5_ids[3], 'foo')
+
     def test_fail_downloading_subs(self):
 
         # Disabled 11/14/13

--- a/cms/djangoapps/contentstore/transcripts_utils.py
+++ b/cms/djangoapps/contentstore/transcripts_utils.py
@@ -307,6 +307,15 @@ def copy_or_rename_transcript(new_name, old_name, item, delete_old=False, user=N
         remove_subs_from_store(old_name, item)
 
 
+def get_html5_ids(html5_sources):
+    """
+    Helper method to parse out an HTML5 source into the ideas
+    NOTE: This assumes that '/' are not in the filename
+    """
+    html5_ids = [x.split('/')[-1].rsplit('.', 1)[0] for x in html5_sources]
+    return html5_ids
+
+
 def manage_video_subtitles_save(old_item, new_item, user):
     """
     Does some specific things, that can be done only on save.
@@ -326,8 +335,7 @@ def manage_video_subtitles_save(old_item, new_item, user):
     """
 
     # 1.
-    # assume '.' and '/' are not in filenames
-    html5_ids = [x.split('/')[-1].split('.')[0] for x in new_item.html5_sources]
+    html5_ids = get_html5_ids(new_item.html5_sources)
     possible_video_id_list = [new_item.youtube_id_1_0] + html5_ids
     sub_name = new_item.sub
     for video_id in possible_video_id_list:


### PR DESCRIPTION
@Lyla-Fischer can you review?
