### PR TITLE
Removed extraneous title block that was replacing the breadcrumbs

### DIFF
--- a/lms/templates/courseware/info.html
+++ b/lms/templates/courseware/info.html
@@ -1,17 +1,15 @@
 <%! from django.utils.translation import ugettext as _ %>
 <%! from courseware.courses import get_course_info_section %>
 
-<%inherit file="/main.html" />
-<%namespace name='static' file='/static_content.html'/>
+<%inherit file="../main.html" />
+<%namespace name='static' file='../static_content.html'/>
 
-<%block name="pagetitle">${__("{course_number} Course Info").format(course_number=course.display_number_with_default)}</%block>
+<%block name="pagetitle">${_("{course_number} Course Info").format(course_number=course.display_number_with_default)}</%block>
 
 <%block name="headextra">
 <%static:css group='style-course-vendor'/>
 <%static:css group='style-course'/>
 </%block>
-
-<%block name="title"><title>${_("{course_number} Course Info").format(course_number=course.display_number_with_default)}</title></%block>
 
 <%include file="/dashboard/_dashboard_prompt_midcourse_reverify.html" />
 

--- a/lms/templates/verify_student/midcourse_photo_reverification.html
+++ b/lms/templates/verify_student/midcourse_photo_reverification.html
@@ -4,7 +4,7 @@
 <%namespace name='static' file='/static_content.html'/>
 
 <%block name="bodyclass">midcourse-reverification-process is-not-verified step-photos register</%block>
-<%block name="title"><title>${_("Re-Verify")}</title></%block>
+<%block name="pagetitle">${_("Re-Verify")}</%block>
 
 <%block name="js_extra">
 <script src="${static.url('js/vendor/responsive-carousel/responsive-carousel.js')}"></script>

--- a/lms/templates/verify_student/midcourse_reverification_confirmation.html
+++ b/lms/templates/verify_student/midcourse_reverification_confirmation.html
@@ -5,7 +5,7 @@
 <%namespace name='static' file='/static_content.html'/>
 
 <%block name="bodyclass">register verification-process is-not-verified step-confirmation</%block>
-<%block name="title"><title>${_("Re-Verification Submission Confirmation")}</title></%block>
+<%block name="pagetitle">${_("Re-Verification Submission Confirmation")}</%block>
 
 <%block name="content">
 

--- a/lms/templates/verify_student/midcourse_reverify_dash.html
+++ b/lms/templates/verify_student/midcourse_reverify_dash.html
@@ -2,11 +2,7 @@
 <%! from django.core.urlresolvers import reverse %>
 <%inherit file="../main.html" />
 <%block name="bodyclass">midcourse-reverification-process step-dash register</%block>
-<%block name="title">
-  <title>
-      ${_("Reverification Status")}
-  </title>
-</%block>
+<%block name="pagetitle">${_("Reverification Status")}</%block>
 
 <%block name="content">
 <div class="container">

--- a/lms/templates/verify_student/reverification_window_expired.html
+++ b/lms/templates/verify_student/reverification_window_expired.html
@@ -5,7 +5,7 @@
 <%namespace name='static' file='/static_content.html'/>
 
 <%block name="bodyclass">register verification-process is-not-verified step-confirmation</%block>
-<%block name="title"><title>${_("Re-Verification Failed")}</title></%block>
+<%block name="pagetitle">${_("Re-Verification Failed")}</%block>
 
 <%block name="js_extra">
 <script src="${static.url('js/vendor/responsive-carousel/responsive-carousel.js')}"></script>


### PR DESCRIPTION
This fixes a problem on the course info page and removes the remaining title blocks from a few pages. 

@nedbat @adampalay 
