### PR TITLE
fixing layout/style of disabled register button

### DIFF
--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -135,9 +135,8 @@
             <a href="${course_target}">
           %endif
 
-          <span class="register disabled">
-            ${_("You are registered for this course {course.display_number_with_default}").format(course=course) | h}
-          </span>
+          <span class="register disabled">${_("You are registered for this course")}</span>
+          
           %if show_courseware_link:
             <strong>${_("View Courseware")}</strong>
             </a>


### PR DESCRIPTION
Here's a tiny fix to improve the course about page for logged in users that I just noticed.

Before:
![before](https://f.cloud.github.com/assets/3364609/2069960/0ea8442c-8d16-11e3-937a-7d65abeda505.png)

After:
![after](https://f.cloud.github.com/assets/3364609/2069966/1259ef6c-8d16-11e3-973f-b2f5bf7ee130.png)
