### PR TITLE
Removed LANGUAGE from devstack settings

### DIFF
--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -7,9 +7,6 @@ from .aws import * # pylint: disable=wildcard-import, unused-wildcard-import
 DEBUG = True
 USE_I18N = True
 TEMPLATE_DEBUG = True
-LANGUAGES = (
-    ('eo', 'Esperanto'),
-)
 # By default don't use a worker, execute tasks as if they were local functions
 CELERY_ALWAYS_EAGER = True
 


### PR DESCRIPTION
We want the devstack to use the language settings in lms/envs/common.py, rather than overriding it in lms/envs/devstack.py

This PR makes that happen.
