### PR TITLE
i18n/dummy.py cleanup

### DIFF
--- a/i18n/dummy.py
+++ b/i18n/dummy.py
@@ -23,6 +23,7 @@ generates output conf/locale/$DUMMY_LOCALE/LC_MESSAGES,
 where $DUMMY_LOCALE is the dummy_locale value set in the i18n config
 """
 
+import sys
 import os
 import polib
 


### PR DESCRIPTION
- The dummy script is missing an import, so it raises an exception when the program exits.
- The dummy script wasn't executable.
- There was another script "make_dummy.py" that was an empty file.

@sarina 
