### PR TITLE
Make assets:coffee a dependency of i18n:extract

### DIFF
--- a/rakelib/i18n.rake
+++ b/rakelib/i18n.rake
@@ -3,7 +3,7 @@
 namespace :i18n do
 
   desc "Extract localizable strings from sources"
-  task :extract => "i18n:validate:gettext" do
+  task :extract => ["i18n:validate:gettext", "assets:coffee"] do
     sh(File.join(REPO_ROOT, "i18n", "extract.py"))
   end
 


### PR DESCRIPTION
Extraction is done on the compiled .js files, so coffee compilation
should be done before extracting strings.

@nedbat 
