### PR TITLE
Reverted lettuce to v1.35

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -10,7 +10,7 @@
 -e git+https://github.com/edx/django-staticfiles.git@d89aae2a82f2b#egg=django-staticfiles
 -e git+https://github.com/edx/django-pipeline.git@88ec8a011e481918fdc9d2682d4017c835acd8be#egg=django-pipeline
 -e git+https://github.com/edx/django-wiki.git@41815e2ef1b0323f92900f8e60711b0f0c37766b#egg=django-wiki
--e git+https://github.com/gabrielfalcao/lettuce.git@cccc3978ad2df82a78b6f9648fe2e9baddd22f88#egg=lettuce
+-e git+https://github.com/gabrielfalcao/lettuce.git@5632b6b79a87881abf7647c8a0fce023a9df3af0#egg=lettuce
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev
 -e git+https://github.com/eventbrite/zendesk.git@d53fe0e81b623f084e91776bcf6369f8b7b63879#egg=zendesk
 


### PR DESCRIPTION
Whilst following installation instructions for installing on existing 12.04 server, I came across this error:

```
IOError: [Errno 2] No such file or directory: u'/home/ralph/.virtualenvs/test/build/sure/readme.rst'

---------------------------------------- 
Cleaning up...
Command python setup.py egg_info failed with error code 1 in /home/ralph/.virtualenvs/test/build/sure
Storing debug log for failure in /home/ralph/.pip/pip.log
```

The issue stemmed from the lettuce package. Versions 2.x+ produce an error due to a missing file (readme.rst), I downgraded the version and installation worked.
