### PR TITLE
Fixed 500ing CSV reports

### DIFF
--- a/lms/djangoapps/shoppingcart/models.py
+++ b/lms/djangoapps/shoppingcart/models.py
@@ -602,7 +602,7 @@ class CertificateItem(OrderItem):
         etc
         """
         query = use_read_replica_if_available(
-            CertificateItem.objects.filter(course_id=course_id, mode='verified', status=status).aggregate(Sum(field_to_aggregate)))[field_to_aggregate + '__sum']
+            CertificateItem.objects.filter(course_id=course_id, mode='verified', status=status)).aggregate(Sum(field_to_aggregate))[field_to_aggregate + '__sum']
         if query is None:
             return Decimal(0.00)
         else:
@@ -615,4 +615,4 @@ class CertificateItem(OrderItem):
                 course_id=course_id,
                 mode='verified',
                 status='purchased',
-                unit_cost__gt=(CourseMode.min_course_price_for_verified_for_currency(course_id, 'usd'))).count())
+                unit_cost__gt=(CourseMode.min_course_price_for_verified_for_currency(course_id, 'usd')))).count()


### PR DESCRIPTION
The more query-intensive CSV reports use the function use_read_replica_if_available to force them to use the read replica if they can.

Some misplaced parenthesis resulted in this function being called on ints and dicts instead of queries, causing 500's on download attempts.

This issue was not evident on sandbox/devstack/stage, but the use_read_replica_if_available function was added after load testing on dev, which is probably why it wasn't caught on dev.  Sorry :(
