### PR TITLE
Added back in component header visual separation from component renderin...

### DIFF
--- a/cms/static/sass/views/_unit.scss
+++ b/cms/static/sass/views/_unit.scss
@@ -877,10 +877,10 @@ body.unit {
     .wrapper-component-action-header {
       @include box-sizing(border-box);
       position: absolute;
-      width: 100%;
-      padding: $baseline/4 $baseline/2;
       top: 0;
       left: 0;
+      padding: $baseline/4 $baseline/2;
+      width: 100%;
       border-bottom: 1px solid $gray-l4;
       background-color: $gray-l6;
     }
@@ -892,7 +892,7 @@ body.unit {
       max-width: 60%;
       color: $gray-l1;
       text-overflow: ellipsis;
-      white-space: nowrap; 
+      white-space: nowrap;
       font-weight: 300;
     }
 

--- a/cms/static/sass/views/_unit.scss
+++ b/cms/static/sass/views/_unit.scss
@@ -881,6 +881,8 @@ body.unit {
       padding: $baseline/4 $baseline/2;
       top: 0;
       left: 0;
+      border-bottom: 1px solid $gray-l4;
+      background-color: $gray-l6;
     }
 
     .component-header {


### PR DESCRIPTION
...g block, making clear the display name for each component is not rendered to students

Image included for ease of review - 
![image](https://f.cloud.github.com/assets/2023680/2082921/a7744c9a-8df8-11e3-964a-384d5c235f2a.png)
