### PR TITLE
Install Python prereqs before running doc and i18n tests

### DIFF
--- a/rakelib/docs.rake
+++ b/rakelib/docs.rake
@@ -46,7 +46,7 @@ end
 
 # Run documentation tests
 desc "Run documentation tests"
-task :test_docs do
+task :test_docs => :install_python_prereqs do
     # Be sure that sphinx can build docs w/o exceptions.
     test_message = "If a docs test fails, you should run '%s' and look at whole output and fix exceptions.
 (You shouldn't fix rst warnings and errors for this to pass, just get rid of exceptions.)"

--- a/rakelib/i18n.rake
+++ b/rakelib/i18n.rake
@@ -63,7 +63,7 @@ namespace :i18n do
   end
 
   desc "Run tests for the internationalization library"
-  task :test => [I18N_REPORT_DIR, :clean_reports_dir] do
+  task :test => [:install_python_prereqs, I18N_REPORT_DIR, :clean_reports_dir] do
     pythonpath_prefix = "PYTHONPATH=#{REPO_ROOT}/i18n:$PYTHONPATH"
     test_sh("i18n", "#{pythonpath_prefix} nosetests #{REPO_ROOT}/i18n/tests --with-xunit --xunit-file=#{I18N_XUNIT_REPORT}")
   end


### PR DESCRIPTION
We need to update Python dependencies before running the doc or i18n tests.  I believe this was the root cause of the failure here: https://jenkins.testeng.edx.org/job/edx-all-tests-auto-master/SHARD=1,TEST_SUITE=unit/956/console

@jbau @jzoldak 
