### PR TITLE
Prevent bad sequential titles

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/sequence/display.coffee
+++ b/common/lib/xmodule/xmodule/js/src/sequence/display.coffee
@@ -21,7 +21,9 @@ class @Sequence
 
   updatePageTitle: ->
     # update the page title to include the current section
-    document.title = @link_for(@position).data('title') + @base_page_title
+    position_link = @link_for(@position)
+    if position_link and position_link.data('title')
+        document.title = position_link.data('title') + @base_page_title
     
   hookUpProgressEvent: ->
     $('.problems-wrapper').bind 'progressChanged', @updateProgress


### PR DESCRIPTION
Don't try to set the title if we don't have anything in the sequential.

Currently, the [tests](https://github.com/edx/edx-platform/blob/master/common/lib/xmodule/xmodule/js/spec/sequence/display_spec.coffee) for sequentials are not working, so I didn't write one for this PR.

LMS-2168
