### PR TITLE
splash-screen: Add ability to redirect to a splash screen URL

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,8 @@ LMS:  If the course start date is kept at the default studio value (Jan 1, 2030)
 and advertised_start is not set, the start date is not displayed in the
 /courses tile view, the course about page, or the dashboard
 
+LMS: Add ability to redirect to a splash screen.
+
 Blades: Add role parameter to LTI. BLD-583.
 
 Blades: Bugfix "In Firefox YouTube video with start time plays from 00:00:00".

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -687,6 +687,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.messages.middleware.MessageMiddleware',
     'track.middleware.TrackMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
+    'splash.middleware.SplashMiddleware',
 
     'course_wiki.course_nav.Middleware',
 
@@ -1095,6 +1096,9 @@ INSTALLED_APPS = (
     'django_comment_client',
     'django_comment_common',
     'notes',
+
+    # Splash screen
+    'splash',
 
     # Monitoring
     'datadog',

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -22,3 +22,4 @@
 -e git+https://github.com/edx/django-waffle.git@823a102e48#egg=django-waffle
 -e git+https://github.com/edx/event-tracking.git@f0211d702d#egg=event-tracking
 -e git+https://github.com/edx/bok-choy.git@v0.1.0#egg=bok_choy
+-e git+https://github.com/edx-solutions/django-splash.git@15bf143b15714e22fc451ff1b0f8a7a2a9483172#egg=django-splash


### PR DESCRIPTION
Checks for the presence of a cookie with specific values when activated,
and redirect the user to a configurable URL when it is not found, or not
with an accepted value.

To be used to display a splash screen to users upon the first visit.
It's the responsability of the splash page at the redirected URL to set
the proper cookie value before sending users back to the LMS.
