### PR TITLE
Make i18n:generate more flexible

### DIFF
--- a/i18n/generate.py
+++ b/i18n/generate.py
@@ -13,7 +13,11 @@ languages to generate.
 
 """
 
-import os, sys, logging
+import argparse
+import logging
+import os
+import sys
+
 from polib import pofile
 
 from i18n.config import BASE_DIR, CONFIGURATION
@@ -100,11 +104,16 @@ def validate_files(dir, files_to_merge):
             raise Exception("I18N: Cannot generate because file not found: {0}".format(pathname))
 
 
-def main():
+def main(argv=None):
     logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
+    parser = argparse.ArgumentParser(description="Generate merged and compiled message files.")
+    parser.add_argument("--strict", action='store_true', help="Complain about missing files.")
+
+    args = parser.parse_args(argv or [])
+
     for locale in CONFIGURATION.translated_locales:
-        merge_files(locale)
+        merge_files(locale, fail_if_missing=args.strict)
     # Dummy text is not required. Don't raise exception if files are missing.
     merge_files(CONFIGURATION.dummy_locale, fail_if_missing=False)
 
@@ -113,4 +122,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    main(sys.argv[1:])

--- a/rakelib/i18n.rake
+++ b/rakelib/i18n.rake
@@ -15,7 +15,14 @@ namespace :i18n do
 
   desc "Compile localizable strings from sources, extracting strings first."
   task :generate => "i18n:extract" do
-    sh(File.join(REPO_ROOT, "i18n", "generate.py"))
+    cmd = File.join(REPO_ROOT, "i18n", "generate.py")
+    sh("#{cmd}")
+  end
+
+  desc "Compile localizable strings from sources, extracting strings first, and complain if files are missing."
+  task :generate_strict => "i18n:extract" do
+    cmd = File.join(REPO_ROOT, "i18n", "generate.py")
+    sh("#{cmd} --strict")
   end
 
   desc "Simulate international translation by generating dummy strings corresponding to source strings."
@@ -72,7 +79,7 @@ namespace :i18n do
   # Will eventually be run by jenkins.
   namespace :robot do
     desc "Pull source strings, generate po and mo files, and validate"
-    task :pull => ["i18n:transifex:pull", "i18n:extract", "i18n:dummy", "i18n:generate"] do
+    task :pull => ["i18n:transifex:pull", "i18n:extract", "i18n:dummy", "i18n:generate_strict"] do
       sh('git clean -fdX conf/locale')
       Rake::Task["i18n:test"].invoke
       sh('git add conf/locale')


### PR DESCRIPTION
Now normal i18n:generate doesn't care about missing files, and
i18n:generate_strict does.  The robot task calls the strict version.

There may well be a better way to make the two tasks, but my Ruby+Rake
skillz are weak, and it's all going away soon.
