### PR TITLE
Conditional module changes to support Locator/Location conversion.

### DIFF
--- a/common/lib/xmodule/xmodule/tests/test_export.py
+++ b/common/lib/xmodule/xmodule/tests/test_export.py
@@ -78,6 +78,7 @@ class RoundTripTestCase(unittest.TestCase):
         "toy",
         "simple",
         "conditional_and_poll",
+        "conditional",
         "self_assessment",
         "graphic_slider_tool",
         "test_exam_registration",

--- a/common/test/data/conditional/conditional/condone.xml
+++ b/common/test/data/conditional/conditional/condone.xml
@@ -1,3 +1,4 @@
-        <conditional condition="require_attempted" required="problem/choiceprob">
-            <html url_name="secret_page" />
-        </conditional>
+<conditional correct="True" sources="i4x://edX/cond_test/problem/choiceprob">
+    <html>Conditionally shown page</html>
+    <show sources="i4x://edX/cond_test/html/congrats; i4x://edX/cond_test/html/secret_page"/>
+</conditional>

--- a/common/test/data/conditional/course.xml
+++ b/common/test/data/conditional/course.xml
@@ -1,8 +1,16 @@
-<course name="Conditional Course" org="edX" course="cond_test" graceperiod="1 day 5 hours 59 minutes 59 seconds" slug="2012_Fall" start="2015-07-17T12:00">
-  <chapter name="Problems with Condition">
-      <sequential>
-        <problem url_name="choiceprob" />
-	  <conditional url_name="condone"/>
-      </sequential>
-  </chapter>
+<course name="Conditional Course" org="edX" course="cond_test" graceperiod="1 day 5 hours 59 minutes 59 seconds"
+        slug="2012_Fall" start="2012-07-17T12:00">
+    <chapter name="Problems with Condition">
+        <!-- In order for the conditional to reference modules via "show",
+             they must be defined elsewhere in the course. Therefore, add them to a
+             non-released sequential. -->
+        <sequential start="2080-07-17T12:00">
+            <html url_name="congrats"/>
+            <html url_name="secret_page"/>
+        </sequential>
+        <sequential>
+            <problem url_name="choiceprob"/>
+            <conditional url_name="condone"/>
+        </sequential>
+    </chapter>
 </course>

--- a/common/test/data/conditional/html/congrats.xml
+++ b/common/test/data/conditional/html/congrats.xml
@@ -1,0 +1,3 @@
+<html display_name="Congrats">
+<p>Congrats-- you answered the problem correctly!</p>
+</html>


### PR DESCRIPTION
In order for MixedModulestore to convert between Locations and Locators, fields storing locations need to declare that they have References.

This change should be backwards-compatible, as the format that is exported has not changed. The only difference is how the data is stored internally in the xblock.

@dmitchell @singingwolfboy @ichuang Please review.
