### PR TITLE
Avoid requesting unnecessary thread responses

### DIFF
--- a/lms/djangoapps/django_comment_client/forum/views.py
+++ b/lms/djangoapps/django_comment_client/forum/views.py
@@ -239,8 +239,11 @@ def single_thread(request, course_id, discussion_id, thread_id):
     cc_user = cc.User.from_django_user(request.user)
     user_info = cc_user.to_dict()
 
+    # Currently, the front end always loads responses via AJAX, even for this
+    # page; it would be a nice optimization to avoid that extra round trip to
+    # the comments service.
     thread = cc.Thread.find(thread_id).retrieve(
-        recursive=True,
+        recursive=request.is_ajax(),
         user_id=request.user.id,
         response_skip=request.GET.get("resp_skip"),
         response_limit=request.GET.get("resp_limit")


### PR DESCRIPTION
The front-end code for rendering a thread always makes an AJAX request
for the resopnses, regardless of how the thread was accessed (directly
by URL or by selecting it from the thread list). Previously, when
a user accessed a thread directly by URL, the LMS would initially
request the thread from the comments service with responses, but that
response data was never actually used. Now, the responses are not
fetched with that initial query.

@jimabramson
