### PR TITLE
Remove autoplay for video in course about page

### DIFF
--- a/cms/djangoapps/models/settings/course_details.py
+++ b/cms/djangoapps/models/settings/course_details.py
@@ -182,7 +182,7 @@ class CourseDetails(object):
         result = None
         if video_key:
             result = '<iframe width="560" height="315" src="//www.youtube.com/embed/' + \
-                video_key + '?autoplay=1&rel=0" frameborder="0" allowfullscreen=""></iframe>'
+                video_key + '?rel=0" frameborder="0" allowfullscreen=""></iframe>'
         return result
 
 


### PR DESCRIPTION
The iframe was generated with `autoplay=1`, which, sometimes, would cause the video to play in the background.

This is a quick fix, it won’t fix the existing courses as the `<iframe>` is stored in the database. To do so, you’ll have to edit the `"about/video.html"` file manually.
