### PR TITLE
Add the ability to view templates in a browser in development mode

### DIFF
--- a/cms/djangoapps/contentstore/views/dev.py
+++ b/cms/djangoapps/contentstore/views/dev.py
@@ -5,8 +5,24 @@ in a 404 error.
 """
 # pylint: disable=W0613
 from edxmako.shortcuts import render_to_response
+from mako.exceptions import TopLevelLookupException
+from django.http import HttpResponseNotFound
 
 
 def dev_mode(request):
     "Sample static view"
     return render_to_response("dev/dev_mode.html")
+
+
+def dev_show_template(request, template):
+    """
+    Shows the specified template as an HTML page.
+    e.g. /template/ux/reference/container.html shows the template under ux/reference/container.html
+
+    Note: dynamic parameters can also be passed to the page.
+    e.g. /template/ux/reference/container.html?name=Foo
+    """
+    try:
+        return render_to_response(template, request.GET.dict())
+    except TopLevelLookupException:
+        return HttpResponseNotFound("Couldn't find template {tpl}".format(tpl=template))

--- a/cms/urls_dev.py
+++ b/cms/urls_dev.py
@@ -7,4 +7,5 @@ from django.conf.urls import url
 
 urlpatterns = (
     url(r'^dev_mode$', 'contentstore.views.dev.dev_mode', name='dev_mode'),
+    url(r'^template/(?P<template>.+)$', 'contentstore.views.dev.dev_show_template'),
 )


### PR DESCRIPTION
This adds a simple mechanism to view any template file directly in a browser. The intention is that we can use this to build up reference HTML files which illustrate common UX patterns. We can then view the resulting pages without having to have a working implementation.

In development mode, the URL is /template followed by the path to the template file. For example, you can view the 404 page at:

```
/template/404.html
```

You can also supply string parameters to the template by specifying them as query parameters in the URL.

e.g.  /template/my_template?name=Foo
