### PR TITLE
allow STUDENT_FILEUPLOAD_MAX_SIZE to be configured in aws.py

### DIFF
--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -337,6 +337,9 @@ BROKER_URL = "{0}://{1}:{2}@{3}/{4}".format(CELERY_BROKER_TRANSPORT,
                                             CELERY_BROKER_HOSTNAME,
                                             CELERY_BROKER_VHOST)
 
+# upload limits
+STUDENT_FILEUPLOAD_MAX_SIZE = ENV_TOKENS.get("STUDENT_FILEUPLOAD_MAX_SIZE", STUDENT_FILEUPLOAD_MAX_SIZE)
+
 # Event tracking
 TRACKING_BACKENDS.update(AUTH_TOKENS.get("TRACKING_BACKENDS", {}))
 


### PR DESCRIPTION
This is needed in residential use cases, where the file upload size may need to be larger than the default 4M.
