### PR TITLE
Change bok-choy coverage XML filename

### DIFF
--- a/common/test/acceptance/.coveragerc
+++ b/common/test/acceptance/.coveragerc
@@ -12,4 +12,4 @@ title = Bok Choy Test Coverage Report
 directory = reports/bok_choy/cover
 
 [xml]
-output = reports/bok_choy/coverage.xml
+output = reports/bok_choy/acceptance_coverage.xml


### PR DESCRIPTION
Change name of bok-choy XML coverage report to avoid combining it with the unit test coverage reports.

@jzoldak 
