### PR TITLE
Video: Revert Download transcript button behavior.

### DIFF
--- a/cms/djangoapps/contentstore/features/video-editor.py
+++ b/cms/djangoapps/contentstore/features/video-editor.py
@@ -40,11 +40,12 @@ def correct_video_settings(_step):
 
         # advanced
         ['Display Name', 'Video', False],
+        ['Download Transcript', '', False],
         ['End Time', '00:00:00', False],
         ['HTML5 Transcript', '', False],
         ['Show Transcript', 'True', False],
         ['Start Time', '00:00:00', False],
-        ['Transcript Download Allowed', 'False', False],
+        # ['Transcript Download Allowed', 'False', False],
         ['Video Download Allowed', 'False', False],
         ['Video Sources', '', False],
         ['Youtube ID', 'OEoXaMPEzfM', False],

--- a/common/lib/xmodule/xmodule/tests/test_video.py
+++ b/common/lib/xmodule/xmodule/tests/test_video.py
@@ -384,7 +384,7 @@ class VideoDescriptorImportTestCase(unittest.TestCase):
             'start_time': datetime.timedelta(seconds=1),
             'end_time': datetime.timedelta(seconds=60),
             'track': 'http://www.example.com/track',
-            'download_track': True,
+            # 'download_track': True,
             'html5_sources': ['http://www.example.com/source.mp4'],
             'data': '',
         })
@@ -414,7 +414,7 @@ class VideoDescriptorImportTestCase(unittest.TestCase):
             'start_time': datetime.timedelta(seconds=1),
             'end_time': datetime.timedelta(seconds=60),
             'track': 'http://www.example.com/track',
-            'download_track': True,
+            # 'download_track': True,
             'html5_sources': ['http://www.example.com/source.mp4'],
             'data': ''
         })
@@ -444,7 +444,7 @@ class VideoDescriptorImportTestCase(unittest.TestCase):
             'start_time': datetime.timedelta(seconds=1),
             'end_time': datetime.timedelta(seconds=60),
             'track': 'http://www.example.com/track',
-            'download_track': True,
+            # 'download_track': True,
             'html5_sources': ['http://www.example.com/source.mp4'],
             'data': ''
         })

--- a/common/lib/xmodule/xmodule/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module.py
@@ -119,7 +119,7 @@ class VideoFields(object):
     # `track` is deprecated field and should not be used in future.
     # `download_track` is used instead.
     track = String(
-        help="The external URL to download the timed transcript track.",
+        help="The external URL to download the timed transcript track. This appears as a link beneath the video.",
         display_name="Download Transcript",
         scope=Scope.settings,
         default=''
@@ -215,11 +215,14 @@ class VideoModule(VideoFields, XModule):
             elif self.html5_sources:
                 sources['main'] = self.html5_sources[0]
 
-        if self.download_track:
-            if self.track:
-                track_url = self.track
-            elif self.sub:
-                track_url = self.runtime.handler_url(self, 'download_transcript')
+        # Commented due to the reason described in BLD-811.
+        # if self.download_track:
+        #     if self.track:
+        #         track_url = self.track
+        #     elif self.sub:
+        #         track_url = self.runtime.handler_url(self, 'download_transcript')
+
+        track_url = self.track
 
         return self.system.render_template('video.html', {
             'ajax_url': self.system.ajax_url + '/save_user_state',
@@ -312,10 +315,16 @@ class VideoDescriptor(VideoFields, TabsEditingDescriptor, EmptyDataRawDescriptor
 
     def __init__(self, *args, **kwargs):
         '''
+        Mostly handles backward compatibility issues.
+
+        Track was deprecated field, but functionality was reverted,
+        this is commented out because might be used in future.
+        ###
         `track` is deprecated field.
         If `track` field exists show `track` field on front-end as not-editable
         but clearable. Dropdown `download_track` is a new field and it has value
         True.
+        ###
 
         `source` is deprecated field.
         a) If `source` exists and `source` is not `html5_sources`: show `source`
@@ -335,12 +344,13 @@ class VideoDescriptor(VideoFields, TabsEditingDescriptor, EmptyDataRawDescriptor
 
         editable_fields = self.editable_metadata_fields
 
-        self.track_visible = False
-        if self.track:
-            self.track_visible = True
-            download_track = editable_fields['download_track']
-            if not download_track['explicitly_set']:
-                self.download_track = True
+        # Commented due to the reason described in BLD-811.
+        # self.track_visible = False
+        # if self.track:
+        #     self.track_visible = True
+        #     download_track = editable_fields['download_track']
+        #     if not download_track['explicitly_set']:
+        #         self.download_track = True
 
         self.source_visible = False
         if self.source:
@@ -359,11 +369,15 @@ class VideoDescriptor(VideoFields, TabsEditingDescriptor, EmptyDataRawDescriptor
     def editable_metadata_fields(self):
         editable_fields = super(VideoDescriptor, self).editable_metadata_fields
 
-        if hasattr(self, 'track_visible'):
-            if self.track_visible:
-                editable_fields['track']['non_editable'] = True
-            else:
-                editable_fields.pop('track')
+        # Commented due to the reason described in BLD-811.
+        # if hasattr(self, 'track_visible'):
+        #     if self.track_visible:
+        #         editable_fields['track']['non_editable'] = True
+        #     else:
+        #         editable_fields.pop('track')
+
+        if 'download_track' in editable_fields:
+            editable_fields.pop('download_track')
 
         if hasattr(self, 'source_visible'):
             if self.source_visible:

--- a/lms/djangoapps/courseware/tests/test_video_mongo.py
+++ b/lms/djangoapps/courseware/tests/test_video_mongo.py
@@ -5,6 +5,7 @@ from mock import patch, PropertyMock
 import os
 import tempfile
 import textwrap
+import unittest
 from functools import partial
 
 from xmodule.contentstore.content import StaticContent
@@ -70,7 +71,7 @@ class TestVideoYouTube(TestVideo):
             'general_speed': 1.0,
             'start': 3603.0,
             'sub': u'a_sub_file.srt.sjson',
-            'track': None,
+            'track': '',
             'youtube_streams': _create_youtube_string(self.item_module),
             'autoplay': settings.FEATURES.get('AUTOPLAY_VIDEOS', False),
             'yt_test_timeout': 1500,
@@ -125,7 +126,7 @@ class TestVideoNonYouTube(TestVideo):
             'general_speed': 1.0,
             'start': 3603.0,
             'sub': u'a_sub_file.srt.sjson',
-            'track': None,
+            'track': '',
             'youtube_streams': '1.00:OEoXaMPEzfM',
             'autoplay': settings.FEATURES.get('AUTOPLAY_VIDEOS', True),
             'yt_test_timeout': 1500,
@@ -205,7 +206,7 @@ class TestGetHtmlMethod(BaseTestXmodule):
             'sub': u'a_sub_file.srt.sjson',
             'speed': 'null',
             'general_speed': 1.0,
-            'track': None,
+            'track': u'http://www.example.com/track',
             'youtube_streams': '1.00:OEoXaMPEzfM',
             'autoplay': settings.FEATURES.get('AUTOPLAY_VIDEOS', True),
             'yt_test_timeout': 1500,
@@ -220,13 +221,14 @@ class TestGetHtmlMethod(BaseTestXmodule):
             )
 
             self.initialize_module(data=DATA)
-            track_url = self.item_descriptor.xmodule_runtime.handler_url(self.item_module, 'download_transcript')
+            # track_url = self.item_descriptor.xmodule_runtime.handler_url(self.item_module, 'download_transcript')
 
             context = self.item_module.render('student_view').content
 
             expected_context.update({
                 'ajax_url': self.item_descriptor.xmodule_runtime.ajax_url + '/save_user_state',
-                'track': track_url if data['expected_track_url'] == u'a_sub_file.srt.sjson' else data['expected_track_url'],
+                # 'track': track_url if data['expected_track_url'] == u'a_sub_file.srt.sjson' else data['expected_track_url'],
+                'track': u'http://www.example.com/track' if data['track'] else '',
                 'sub': data['sub'],
                 'id': self.item_module.location.html_id(),
             })
@@ -309,7 +311,7 @@ class TestGetHtmlMethod(BaseTestXmodule):
             'general_speed': 1.0,
             'start': 3603.0,
             'sub': u'a_sub_file.srt.sjson',
-            'track': None,
+            'track': '',
             'youtube_streams': '1.00:OEoXaMPEzfM',
             'autoplay': settings.FEATURES.get('AUTOPLAY_VIDEOS', True),
             'yt_test_timeout': 1500,
@@ -447,6 +449,7 @@ class TestVideoDescriptorInitialization(BaseTestXmodule):
         self.assertNotIn('source', fields)
         self.assertFalse(self.item_module.download_video)
 
+    @unittest.skip('Skipped due to the reason described in BLD-811')
     def test_track_is_not_empty(self):
         metatdata = {
             'track': 'http://example.org/track',
@@ -460,6 +463,7 @@ class TestVideoDescriptorInitialization(BaseTestXmodule):
         self.assertTrue(self.item_module.download_track)
         self.assertTrue(self.item_module.track_visible)
 
+    @unittest.skip('Skipped due to the reason described in BLD-811')
     @patch('xmodule.x_module.XModuleDescriptor.editable_metadata_fields', new_callable=PropertyMock)
     def test_download_track_is_explicitly_set(self, mock_editable_fields):
         mock_editable_fields.return_value = {
@@ -510,7 +514,7 @@ class TestVideoDescriptorInitialization(BaseTestXmodule):
         self.assertFalse(self.item_module.download_track)
         self.assertTrue(self.item_module.track_visible)
 
-
+    @unittest.skip('Skipped due to the reason described in BLD-811')
     def test_track_is_empty(self):
         metatdata = {
             'track': '',


### PR DESCRIPTION
Reverts the behavior of `Download Transcript` button that was added in https://github.com/edx/edx-platform/pull/2149 .
Ticket: [BLD-811](https://edx-wiki.atlassian.net/browse/BLD-811)
Some code is commented out because might be used in future.

@valera-rozuvan please review.
