### PR TITLE
When checking permissions for wiki look at dot format role names too.

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -376,8 +376,15 @@ def create_new_course(request):
         metadata = {}
     else:
         metadata = {'display_name': display_name}
+
+    # Set a unique wiki_slug for newly created courses. To maintain active wiki_slugs for existing xml courses this
+    # cannot be changed in CourseDescriptor.
+    wiki_slug = "{0}.{1}.{2}".format(dest_location.org, dest_location.course, dest_location.name)
+    definition_data = {'wiki_slug': wiki_slug}
+
     modulestore('direct').create_and_save_xmodule(
         dest_location,
+        definition_data=definition_data,
         metadata=metadata
     )
     new_course = modulestore('direct').get_item(dest_location)

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -603,6 +603,11 @@ class CourseDescriptor(CourseFields, SequenceDescriptor):
 
             xml_object.append(textbook_xml_object)
 
+        if self.wiki_slug is not None:
+            wiki_xml_object = etree.Element('wiki')
+            wiki_xml_object.set('slug', self.wiki_slug)
+            xml_object.append(wiki_xml_object)
+
         return xml_object
 
     def has_ended(self):

--- a/common/lib/xmodule/xmodule/modulestore/mixed.py
+++ b/common/lib/xmodule/xmodule/modulestore/mixed.py
@@ -417,6 +417,17 @@ class MixedModuleStore(ModuleStoreWriteBase):
         for course in store.get_courses():
             loc_mapper().translate_location(course.location.course_id, course.location)
 
+    def get_courses_for_wiki(self, wiki_slug):
+        """
+        Return the list of courses which use this wiki_slug
+        :param wiki_slug: the course wiki root slug
+        :return: list of course locations
+        """
+        courses = []
+        for modulestore in self.modulestores.values():
+            courses.extend(modulestore.get_courses_for_wiki(wiki_slug))
+        return courses
+
 
 def _compare_stores(left, right):
     """

--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -880,8 +880,8 @@ class MongoModuleStore(ModuleStoreWriteBase):
 
     def get_courses_for_wiki(self, wiki_slug):
         """
-        Return the list of courses which use this wiki
-        :param wiki_slug: the wiki id
+        Return the list of courses which use this wiki_slug
+        :param wiki_slug: the course wiki root slug
         :return: list of course locations
         """
         courses = self.collection.find({'definition.data.wiki_slug': wiki_slug})

--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -878,6 +878,15 @@ class MongoModuleStore(ModuleStoreWriteBase):
         item_locs -= all_reachable
         return list(item_locs)
 
+    def get_courses_for_wiki(self, wiki_slug):
+        """
+        Return the list of courses which use this wiki
+        :param wiki_slug: the wiki id
+        :return: list of course locations
+        """
+        courses = self.collection.find({'definition.data.wiki_slug': wiki_slug})
+        return [Location(course['_id']) for course in courses]
+
     def _create_new_field_data(self, _category, _location, definition_data, metadata):
         """
         To instantiate a new xmodule which will be saved latter, set up the dbModel and kvs

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
@@ -1645,3 +1645,14 @@ class SplitMongoModuleStore(ModuleStoreWriteBase):
         be a json dict key.
         """
         structure['blocks'][LocMapperStore.encode_key_for_mongo(block_id)] = content
+
+    def get_courses_for_wiki(self, wiki_slug):
+        """
+        Return the list of courses which use this wiki_slug
+        :param wiki_slug: the course wiki root slug
+        :return: list of course locations
+
+        Todo: Needs to be implemented.
+        """
+        courses = []
+        return courses

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_mixed_modulestore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_mixed_modulestore.py
@@ -368,6 +368,24 @@ class TestMixedModuleStore(LocMapperSetupSansDjango):
         orphans = self.store.get_orphans(self.course_locations[self.MONGO_COURSEID], None)
         self.assertEqual(len(orphans), 0, "unexpected orphans: {}".format(orphans))
 
+    @ddt.data('direct')
+    def test_get_courses_for_wiki(self, default_ms):
+        """
+        Test the get_courses_for_wiki method
+        """
+        self.initdb(default_ms)
+        course_locations = self.store.get_courses_for_wiki('toy')
+        self.assertEqual(len(course_locations), 1)
+        self.assertIn(Location('i4x', 'edX', 'toy', 'course', '2012_Fall'), course_locations)
+
+        course_locations = self.store.get_courses_for_wiki('simple')
+        self.assertEqual(len(course_locations), 1)
+        self.assertIn(Location('i4x', 'edX', 'simple', 'course', '2012_Fall'), course_locations)
+
+        self.assertEqual(len(self.store.get_courses_for_wiki('edX.simple.2012_Fall')), 0)
+        self.assertEqual(len(self.store.get_courses_for_wiki('no_such_wiki')), 0)
+
+
 #=============================================================================================================
 # General utils for not using django settings
 #=============================================================================================================

--- a/common/lib/xmodule/xmodule/modulestore/xml.py
+++ b/common/lib/xmodule/xmodule/modulestore/xml.py
@@ -790,3 +790,12 @@ class XMLModuleStore(ModuleStoreReadBase):
         "split" for new-style split MongoDB backed courses.
         """
         return XML_MODULESTORE_TYPE
+
+    def get_courses_for_wiki(self, wiki_slug):
+        """
+        Return the list of courses which use this wiki_slug
+        :param wiki_slug: the course wiki root slug
+        :return: list of course locations
+        """
+        courses = self.get_courses()
+        return [course.location for course in courses if (course.wiki_slug == wiki_slug)]

--- a/common/lib/xmodule/xmodule/modulestore/xml_importer.py
+++ b/common/lib/xmodule/xmodule/modulestore/xml_importer.py
@@ -514,11 +514,20 @@ def remap_namespace(module, target_location_namespace):
                         chapter['url'], target_location_namespace
                     )
 
-        # if there is a wiki_slug which is the same as the original location
-        # (aka default value), then remap that so the wiki doesn't point to
-        # the old Wiki.
-        if module.wiki_slug == original_location.course:
-            module.wiki_slug = target_location_namespace.course
+        # Original wiki_slugs had value location.course. To make them unique this was changed to 'org.course.name'.
+        # If the wiki_slug is equal to either of these default values then remap that so that the wiki does not point
+        # to the old wiki.
+        original_unique_wiki_slug = '{0}.{1}.{2}'.format(
+            original_location.org,
+            original_location.course,
+            original_location.name
+        )
+        if module.wiki_slug == original_unique_wiki_slug or module.wiki_slug == original_location.course:
+            module.wiki_slug = '{0}.{1}.{2}'.format(
+                target_location_namespace.org,
+                target_location_namespace.course,
+                target_location_namespace.name,
+            )
 
         module.save()
 

--- a/common/test/data/two_toys/course/TT_2012_Fall.xml
+++ b/common/test/data/two_toys/course/TT_2012_Fall.xml
@@ -1,3 +1,4 @@
 <course display_name="Toy Course" graceperiod="2 days 5 hours 59 minutes 59 seconds" start="2015-07-17T12:00">
   <chapter url_name="Overview"/>
+  <wiki slug="edX.toy.TT_2012_Fall"/>
 </course>

--- a/lms/djangoapps/course_wiki/utils.py
+++ b/lms/djangoapps/course_wiki/utils.py
@@ -3,7 +3,8 @@ Utility functions for course_wiki.
 """
 
 from django.core.exceptions import ObjectDoesNotExist
-
+from xmodule import modulestore
+import courseware
 
 def user_is_article_course_staff(user, article):
     """
@@ -20,24 +21,24 @@ def user_is_article_course_staff(user, article):
     so this will return True.
     """
 
-    course_slug = article_course_wiki_root_slug(article)
+    wiki_slug = article_course_wiki_root_slug(article)
 
-    if course_slug is None:
+    if wiki_slug is None:
         return False
-
-    user_groups = user.groups.all()
 
     # The wiki expects article slugs to contain at least one non-digit so if
     # the course number is just a number the course wiki root slug is set to
     # be '<course_number>_'. This means slug '202_' can belong to either
     # course numbered '202_' or '202' and so we need to consider both.
 
-    if user_is_staff_on_course_number(user_groups, course_slug):
+    courses = modulestore.django.modulestore().get_courses_for_wiki(wiki_slug)
+    if any(courseware.access.has_access(user, course, 'staff', course.course_id) for course in courses):
         return True
 
-    if (course_slug.endswith('_') and slug_is_numerical(course_slug[:-1]) and
-            user_is_staff_on_course_number(user_groups, course_slug[:-1])):
-        return True
+    if (wiki_slug.endswith('_') and slug_is_numerical(wiki_slug[:-1])):
+        courses = modulestore.django.modulestore().get_courses_for_wiki(wiki_slug[:-1])
+        if any(courseware.access.has_access(user, course, 'staff', course.course_id) for course in courses):
+            return True
 
     return False
 
@@ -62,28 +63,6 @@ def course_wiki_slug(course):
         slug = slug + "_"
 
     return slug
-
-
-def user_is_staff_on_course_number(user_groups, course_number):
-    """Returns whether the groups contain a staff group for the course number"""
-
-    # Course groups have format 'instructor_<course_id>' and 'staff_<course_id>' where
-    # course_id = org/course_number/run. So check if user's groups contain a group
-    # whose name starts with 'instructor_' or 'staff_' and contains '/course_number/'.
-    course_number_fragment = '/{0}/'.format(course_number)
-    if [group for group in user_groups if (group.name.startswith(('instructor_', 'staff_')) and
-                                           course_number_fragment in group.name)]:
-        return True
-
-    # Old course groups had format 'instructor_<course_number>' and 'staff_<course_number>'
-    # Check if user's groups contain either of these.
-    old_instructor_group_name = 'instructor_{0}'.format(course_number)
-    old_staff_group_name = 'staff_{0}'.format(course_number)
-    if [group for group in user_groups if (group.name == old_instructor_group_name or
-                                           group.name == old_staff_group_name)]:
-        return True
-
-    return False
 
 
 def article_course_wiki_root_slug(article):


### PR DESCRIPTION
CourseRole names have a new format (type_org.number.run). Previously
when checking if a user was staff for a course wiki only type_org/number/run
and type_number format role names were checked. Now type.org.number.run
format names are also checked.

LMS-2136
