### PR TITLE
log stop_video event

### DIFF
--- a/common/lib/xmodule/xmodule/js/spec/video/video_player_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_player_spec.js
@@ -335,6 +335,7 @@ function (VideoPlayer) {
 
                     state.videoEl = $('video, iframe');
 
+                    spyOn(state.videoPlayer, 'log').andCallThrough();
                     spyOn(state.videoControl, 'pause').andCallThrough();
                     spyOn($.fn, 'trigger').andCallThrough();
 
@@ -349,6 +350,15 @@ function (VideoPlayer) {
 
                 it('pause the video caption', function () {
                     expect($.fn.trigger).toHaveBeenCalledWith('ended', {});
+                });
+
+                it('log stop_video event', function () {
+                    expect(state.videoPlayer.log).toHaveBeenCalledWith(
+                        'stop_video',
+                        {
+                            currentTime: state.videoPlayer.currentTime
+                        }
+                    );
                 });
             });
         });

--- a/common/lib/xmodule/xmodule/js/src/video/03_video_player.js
+++ b/common/lib/xmodule/xmodule/js/src/video/03_video_player.js
@@ -506,6 +506,12 @@ function (HTML5Video, Resizer) {
 
     function onEnded() {
         var time = this.videoPlayer.duration();
+        this.videoPlayer.log(
+            'stop_video',
+            {
+                currentTime: this.videoPlayer.currentTime
+            }
+        );
 
         this.trigger('videoControl.pause', null);
         this.trigger('videoProgressSlider.notifyThroughHandleEnd', {


### PR DESCRIPTION
In this PR, I propose to log the stop_video event, and not log a pause_video event if the video is already ended.
