### PR TITLE
splash-url-exclusion: Exclude '/heartbeat' from redirect

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -22,5 +22,5 @@
 -e git+https://github.com/edx/django-waffle.git@823a102e48#egg=django-waffle
 -e git+https://github.com/edx/event-tracking.git@f0211d702d#egg=event-tracking
 -e git+https://github.com/edx/bok-choy.git@62de7b576a08f36cde5b030c52bccb1a2f3f8df1#egg=bok_choy
--e git+https://github.com/edx-solutions/django-splash.git@15bf143b15714e22fc451ff1b0f8a7a2a9483172#egg=django-splash
+-e git+https://github.com/edx-solutions/django-splash.git@9965a53c269666a30bb4e2b3f6037c138aef2a55#egg=django-splash
 -e git+https://github.com/edx/acid-block.git@bf61f0fcd5916a9236bb5681c98374a48a13a74c#egg=acid-xblock


### PR DESCRIPTION
Update the dependency to load this commit: https://github.com/edx-solutions/django-splash/commit/6e8bd685214aebe78d0cfdf5572e27c5f1bc357a

Which allows to prevent `/heartbeat` from being redirected, which is necessary on production servers as the ELB can't set a cookie or be logged in.
