### PR TITLE
Acceptance test for STUD-1311.

### DIFF
--- a/cms/djangoapps/contentstore/features/common.py
+++ b/cms/djangoapps/contentstore/features/common.py
@@ -396,6 +396,11 @@ def i_replace_w_draft(_step):
     world.css_click("a.publish-draft")
 
 
+@step(u'I click on "delete draft"$')
+def i_delete_draft(_step):
+    world.css_click("a.delete-draft")
+
+
 @step(u'I publish the unit$')
 def publish_unit(_step):
     world.select_option('visibility-select', 'public')

--- a/cms/djangoapps/contentstore/features/problem-editor.feature
+++ b/cms/djangoapps/contentstore/features/problem-editor.feature
@@ -95,6 +95,15 @@ Feature: CMS.Problem Editor
     And I delete "1" component
     Then I see no components
 
+  # This is a very specific scenario for a bug where editing a component in draft
+  # impacted the published version.
+  Scenario: Changes to draft problem do not impact published version
+    Given I have created a Blank Common Problem
+    When I publish the unit
+    And I click on "edit a draft"
+    And I change the display name to "draft"
+    And I click on "delete draft"
+    Then the problem display name is "Blank Common Problem"
 
   # Disabled 11/13/2013 after failing in master
   # The screenshot showed that the LaTeX editor had the text "hi",

--- a/cms/djangoapps/contentstore/features/problem-editor.py
+++ b/cms/djangoapps/contentstore/features/problem-editor.py
@@ -62,6 +62,11 @@ def my_display_name_change_is_persisted_on_save(step):
     verify_modified_display_name()
 
 
+@step('the problem display name is "(.*)"$')
+def verify_problem_display_name(step, name):
+    assert_equal(name.upper(), world.browser.find_by_css('.problem-header').text)
+
+
 @step('I can specify special characters in the display name')
 def i_can_modify_the_display_name_with_special_chars(_step):
     index = world.get_setting_entry_index(DISPLAY_NAME)


### PR DESCRIPTION
Acceptance test for draft/publish bug.

Note that it would make sense to have the acceptance tests for drafts and publish in their own test file. However, the only other "draft"-related test is right above this in problem-editor.feature (also using a problem to test with), and since we know we will soon need to change all these tests when we change the publishing model, I figured this is an acceptable place for now.

@cpennington @jzoldak Please review. I expect this test to fail until the release branch is merged back to master.
