### PR TITLE
Internal/External Studio file URLs

### DIFF
--- a/cms/djangoapps/contentstore/views/assets.py
+++ b/cms/djangoapps/contentstore/views/assets.py
@@ -8,6 +8,7 @@ from django.contrib.auth.decorators import login_required
 from django.views.decorators.http import require_http_methods
 from django_future.csrf import ensure_csrf_cookie
 from django.views.decorators.http import require_POST
+from django.conf import settings
 
 from edxmako.shortcuts import render_to_response
 from cache_toolbox.core import del_cached_content
@@ -290,10 +291,12 @@ def _get_asset_json(display_name, date, location, thumbnail_location, locked):
     Helper method for formatting the asset information to send to client.
     """
     asset_url = StaticContent.get_url_path_from_location(location)
+    external_url = settings.LMS_BASE + asset_url
     return {
         'display_name': display_name,
         'date_added': get_default_time_display(date),
         'url': asset_url,
+        'external_url': external_url,
         'portable_url': StaticContent.get_static_path_from_location(location),
         'thumbnail': StaticContent.get_url_path_from_location(thumbnail_location) if thumbnail_location is not None else None,
         'locked': locked,

--- a/cms/djangoapps/contentstore/views/tests/test_assets.py
+++ b/cms/djangoapps/contentstore/views/tests/test_assets.py
@@ -36,14 +36,20 @@ class AssetsTestCase(CourseTestCase):
 
 
 class BasicAssetsTestCase(AssetsTestCase):
+    location = Location(['i4x', 'foo', 'bar', 'asset', 'my_file_name.jpg'])
+    TEST_LMS_BASE = 'localhost:8000'
+
     def test_basic(self):
         resp = self.client.get(self.url, HTTP_ACCEPT='text/html')
         self.assertEquals(resp.status_code, 200)
 
     def test_static_url_generation(self):
-        location = Location(['i4x', 'foo', 'bar', 'asset', 'my_file_name.jpg'])
-        path = StaticContent.get_static_path_from_location(location)
+        path = StaticContent.get_static_path_from_location(self.location)
         self.assertEquals(path, '/static/my_file_name.jpg')
+
+    def test_lms_url_generation(self):
+        url = self.TEST_LMS_BASE + StaticContent.get_url_path_from_location(self.location)
+        self.assertEquals(url, 'localhost:8000/i4x/foo/bar/asset/my_file_name.jpg')
 
     def test_pdf_asset(self):
         module_store = modulestore('direct')

--- a/cms/static/js/models/asset.js
+++ b/cms/static/js/models/asset.js
@@ -8,6 +8,7 @@ define(["backbone"], function(Backbone) {
       thumbnail: "",
       date_added: "",
       url: "",
+      external_url: "",
       portable_url: "",
       locked: false
     }

--- a/cms/static/js/views/asset.js
+++ b/cms/static/js/views/asset.js
@@ -18,6 +18,7 @@ var AssetView = BaseView.extend({
       thumbnail: this.model.get('thumbnail'),
       date_added: this.model.get('date_added'),
       url: this.model.get('url'),
+      external_url: this.model.get('external_url'),
       portable_url: this.model.get('portable_url'),
       uniqueId: uniqueId
     }));

--- a/cms/static/sass/views/_assets.scss
+++ b/cms/static/sass/views/_assets.scss
@@ -304,7 +304,7 @@
             @include transition(all $tmg-f2 ease-in-out 0s);
             @extend %t-copy-sub2;
             box-shadow: none;
-            border: none;
+            border: 1px solid transparent;
             background: none;
             width: 100%;
             color: $gray-l2;

--- a/cms/templates/asset_index.html
+++ b/cms/templates/asset_index.html
@@ -156,11 +156,20 @@ require(["domReady", "jquery", "js/models/asset", "js/collections/asset",
             	<p>${_("In addition to the files you upload on this page, any files that you add to the course appear in this list. These files include your course image, textbook chapters, and files that appear on your Course Handouts sidebar.")}</p>
             </div>
             <div class="bit">
+                <h3 class="title-3">${_("File URLs")}</h3>
+                 <ul class="list-details">
+                    <li class="item-detail">${_("You use the Embed URL value to link to the file or image from a component, a course update, or a course handout.")}</li>
+                    <li class="item-detail">${_("You use the External URL value to reference the file or image from outside of your course. Do not use the External URL as a link value within your course.")}</li>
+          			<li class="item-detail">${_("You can upload new files or view, download, or delete existing files. You can lock a file so that people who are not enrolled in your course cannot access that file.")}</li>
+          			
+        		</ul>
+            </div>
+             <div class="bit">
                 <h3 class="title-3">${_("What can I do on this page?")}</h3>
                  <ul class="list-details">
-          			<li class="item-detail">${_("You can upload new files or view, download, or delete existing files. You can lock a file so that people who are not enrolled in your course cannot access that file.")}</li>
-          			<li class="item-detail">${_("Use the URL listed for a file to create a link to that file in the Course Handouts sidebar or in the body of the course.")}</li>
-        		</ul>
+                    <li class="item-detail">${_("You can upload new files or view, download, or delete existing files. You can lock a file so that people who are not enrolled in your course cannot access that file.")}</li>
+                    
+                </ul>
             </div>
         </aside>
     </section>

--- a/cms/templates/asset_index.html
+++ b/cms/templates/asset_index.html
@@ -160,7 +160,6 @@ require(["domReady", "jquery", "js/models/asset", "js/collections/asset",
                  <ul class="list-details">
                     <li class="item-detail">${_("You use the Embed URL value to link to the file or image from a component, a course update, or a course handout.")}</li>
                     <li class="item-detail">${_("You use the External URL value to reference the file or image from outside of your course. Do not use the External URL as a link value within your course.")}</li>
-          			<li class="item-detail">${_("You can upload new files or view, download, or delete existing files. You can lock a file so that people who are not enrolled in your course cannot access that file.")}</li>
           			
         		</ul>
             </div>

--- a/cms/templates/js/asset-library.underscore
+++ b/cms/templates/js/asset-library.underscore
@@ -16,7 +16,8 @@
             <th class="thumb-col"><%= gettext("Preview") %></th>
             <th class="name-col sortable-column"><span class="column-sort-link" id="js-asset-name-col"><%= gettext("Name") %></span></th>
             <th class="date-col sortable-column"><span class="column-sort-link" id="js-asset-date-col"><%= gettext("Date Added") %></span></th>
-            <th class="embed-col"><%= gettext("URL") %></th>
+            <th class="embed-col"><%= gettext("Embed URL") %></th>
+            <th class="embed-col"><%= gettext("External URL") %></th>
             <th class="actions-col"><span class="sr"><%= gettext("Actions") %></span></th>
         </tr>
         </thead>

--- a/cms/templates/js/asset.underscore
+++ b/cms/templates/js/asset.underscore
@@ -16,6 +16,9 @@
 <td class="embed-col">
     <input type="text" class="embeddable-xml-input" value="<%= portable_url %>" readonly>
 </td>
+<td class="embed-col">
+    <input type="text" class="embeddable-xml-input" value="<%= external_url %>" readonly>
+</td>
 <td class="actions-col">
     <ul class="actions-list">
         <li class="action-item action-delete">


### PR DESCRIPTION
- Changed link URL of file name to use public/LMS url
- Added toggle link to display all public URLs for instructor convenience

On page load, the page looks pretty much identical to before.

![screen shot 2014-02-12 at 11 09 14 am](https://f.cloud.github.com/assets/3364609/2152447/3792dc58-9419-11e3-9448-694fcbd69bcf.png)

When you click the new "Show external URLs" toggle link, all of the asset URL readonly text fields switch to displaying external URLs.

![screen shot 2014-02-12 at 11 09 20 am](https://f.cloud.github.com/assets/3364609/2152448/3a1214e4-9419-11e3-82ed-45bde80ad245.png)
