### PR TITLE
Video: Fix download transcript behavior. 

### DIFF
--- a/cms/djangoapps/contentstore/features/video-editor.py
+++ b/cms/djangoapps/contentstore/features/video-editor.py
@@ -45,7 +45,7 @@ def correct_video_settings(_step):
         ['HTML5 Transcript', '', False],
         ['Show Transcript', 'True', False],
         ['Start Time', '00:00:00', False],
-        # ['Transcript Download Allowed', 'False', False],
+        ['Transcript Download Allowed', 'False', False],
         ['Video Download Allowed', 'False', False],
         ['Video Sources', '', False],
         ['Youtube ID', 'OEoXaMPEzfM', False],

--- a/common/lib/xmodule/xmodule/tests/test_video.py
+++ b/common/lib/xmodule/xmodule/tests/test_video.py
@@ -277,6 +277,36 @@ class VideoDescriptorImportTestCase(unittest.TestCase):
             'data': ''
         })
 
+    def test_from_xml_missing_download_track(self):
+        """
+        Ensure that attributes have the right values if they aren't
+        explicitly set in XML.
+        """
+        module_system = DummySystem(load_error_modules=True)
+        xml_data = '''
+            <video display_name="Test Video"
+                   youtube="1.0:p2Q6BrNhdh8,1.25:1EeWXzPdhSA"
+                   show_captions="true">
+              <source src="http://www.example.com/source.mp4"/>
+              <track src="http://www.example.com/track"/>
+            </video>
+        '''
+        output = VideoDescriptor.from_xml(xml_data, module_system, Mock())
+        self.assert_attributes_equal(output, {
+            'youtube_id_0_75': '',
+            'youtube_id_1_0': 'p2Q6BrNhdh8',
+            'youtube_id_1_25': '1EeWXzPdhSA',
+            'youtube_id_1_5': '',
+            'show_captions': True,
+            'start_time': datetime.timedelta(seconds=0.0),
+            'end_time': datetime.timedelta(seconds=0.0),
+            'track': 'http://www.example.com/track',
+            'download_track': True,
+            'download_video': True,
+            'html5_sources': ['http://www.example.com/source.mp4'],
+            'data': ''
+        })
+
     def test_from_xml_no_attributes(self):
         """
         Make sure settings are correct if none are explicitly set in XML.


### PR DESCRIPTION
DT - Download Transcript;
DA - Transcript Download Allowed.

The following behavior is provided:
1) Both fields are editable and always present;
2) If DA is False, "Download Transcript" button is disabled;
3) If DA is True and DT is not empty, "Download Transcript" button is enabled and link from DT field is used;
4) If DA is True and DT is empty, "Download Transcript" button is enabled and transcript file in *.srt format is used, if video has transcript.

Import is fixed to support an old style XML format: if video has XML in old format and  `track` node is available,  "Download Transcript" button will be shown and link form track will be used.

@auraz please review.
