### PR TITLE
Fixed intermittent failure in XQueue stub unit test

### DIFF
--- a/common/djangoapps/terrain/stubs/xqueue.py
+++ b/common/djangoapps/terrain/stubs/xqueue.py
@@ -13,7 +13,7 @@ from .http import StubHttpRequestHandler, StubHttpService, require_params
 import json
 import copy
 from requests import post
-import threading
+from threading import Timer
 
 
 class StubXQueueHandler(StubHttpRequestHandler):
@@ -70,10 +70,8 @@ class StubXQueueHandler(StubHttpRequestHandler):
                     callback_url, xqueue_header, self.post_dict['xqueue_body']
                 )
 
-                threading.Timer(
-                    self.server.config.get('response_delay', self.DEFAULT_RESPONSE_DELAY),
-                    delayed_grade_func
-                ).start()
+                delay = self.server.config.get('response_delay', self.DEFAULT_RESPONSE_DELAY)
+                Timer(delay, delayed_grade_func).start()
 
         # If we get a request that's not to the grading submission
         # URL, return an error


### PR DESCRIPTION
The XQueue stub test would occasionally fail, because:
1) The test patched a POST request triggered by a timer.
2) The test set the timer delay to 0.
3) The test would wait for POST to be called.

Very rarely, the timer would take too long to fire, and the test would fail.  This fixes the test by replacing the `Timer.start()` call with a fake timer implementation that fires immediately.

@flowerhack 
