### PR TITLE
Fix bug multiple choice with video. BLD-788.

### DIFF
--- a/common/lib/xmodule/xmodule/js/spec/capa/display_spec.coffee
+++ b/common/lib/xmodule/xmodule/js/spec/capa/display_spec.coffee
@@ -124,9 +124,15 @@ describe 'Problem', ->
         expect(@problem.bind).toHaveBeenCalled()
 
   describe 'check_fd', ->
-    xit 'should have more specs written for this functionality', ->
-      expect(false)
+    beforeEach ->
+      # Insert an input of type file outside of the problem.
+      $('.xblock-student_view').after('<input type="file" />')
+      @problem = new Problem($('.xblock-student_view'))
+      spyOn(@problem, 'check')
 
+    it 'check method is called if input of type file is not in problem', ->
+      @problem.check_fd()
+      expect(@problem.check).toHaveBeenCalled()
 
   describe 'check', ->
     beforeEach ->
@@ -509,5 +515,3 @@ describe 'Problem', ->
     xit 'serialize all answers', ->
       @problem.refreshAnswers()
       expect(@problem.answers).toEqual "input_1_1=one&input_1_2=two"
-
-

--- a/common/lib/xmodule/xmodule/js/src/capa/display.coffee
+++ b/common/lib/xmodule/xmodule/js/src/capa/display.coffee
@@ -195,7 +195,7 @@ class @Problem
   ###
   check_fd: =>
     # If there are no file inputs in the problem, we can fall back on @check
-    if $('input:file').length == 0
+    if @el.find('input:file').length == 0
       @check()
       return
 


### PR DESCRIPTION
**Jira issue**
[BLD-788](https://edx-wiki.atlassian.net/browse/BLD-788)

**Description**
Multiple choice/checkbox problems in Studio are marked "incorrect" if below video.

**Problem**
The `Video` element contains an input with type file. When the Check button was clicked for the `multiple choice` problem, the code was acting in different ways when there as a `Video` on the page and when there wasn't. This is because in the `check_fd()` method there was a selector that was looking for inputs of type file on the whole page instead of just in the current problem. When there was a `Video` on the page, the page-wide selector returned the Video's file input, and the `check_fd()` method went on believing that the `multiple choice` had a file input.

**Solution**
The correct way is to look for file inputs only in the current element.

**Reviewers**
- @ormsbee  
