### PR TITLE
Fixes devstack settings to work with new version of debug toolbar

### DIFF
--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -54,7 +54,8 @@ DEBUG_TOOLBAR_PANELS = (
 )
 
 DEBUG_TOOLBAR_CONFIG = {
-    'INTERCEPT_REDIRECTS': False
+    'INTERCEPT_REDIRECTS': False,
+    'SHOW_TOOLBAR_CALLBACK': 'check_debug.should_show_debug_toolbar',
 }
 
 # To see stacktraces for MongoDB queries, set this to True.

--- a/common/lib/check_debug.py
+++ b/common/lib/check_debug.py
@@ -1,0 +1,14 @@
+"""
+Function to check debug status.
+"""
+import os
+
+def should_show_debug_toolbar(request):
+    """
+    Return True/False to determine whether to show the Django
+    Debug Toolbar.
+
+    If HIDE_TOOLBAR is set in the process environment, the
+    toolbar will be hidden.
+    """
+    return not bool(os.getenv('HIDE_TOOLBAR', ''))

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -53,7 +53,7 @@ DEBUG_TOOLBAR_PANELS = (
 
 DEBUG_TOOLBAR_CONFIG = {
     'INTERCEPT_REDIRECTS': False,
-    'SHOW_TOOLBAR_CALLBACK': lambda _: True,
+    'SHOW_TOOLBAR_CALLBACK': 'check_debug.should_show_debug_toolbar',
 }
 
 ########################### PIPELINE #################################


### PR DESCRIPTION
@singingwolfboy 
Your recent PR to upgrade the debug toolbar broke devstack because the `SHOW_TOOLBAR_CALLBACK` setting now expects a string rather than a function.
