### PR TITLE
Fixed change language acceptance test

### DIFF
--- a/common/test/acceptance/tests/test_lms.py
+++ b/common/test/acceptance/tests/test_lms.py
@@ -105,6 +105,8 @@ class LanguageTest(UniqueCourseTest):
         # Change language to Dummy Esperanto
         self.dashboard_page.change_language(self.test_new_lang)
 
+        self.dashboard_page.visit()
+
         changed_text = fulfill(self._changed_lang_promise)
         # We should see the dummy-language text on the page
         self.assertIn(self.current_courses_text, changed_text)


### PR DESCRIPTION
After changing the language, the dashboard automatically refreshes.

However, unless we _explicitly_ tell the tests to visit the dashboard, we run the risk of trying to look at the text on the dashboard before the page has finished refreshing.

This fix forces the test to explicitly visit the dashboard before checking for text.

@wedaly , let me know if my surmising here is actually correct?
