### PR TITLE
Refactor changed lang test

### DIFF
--- a/common/test/acceptance/pages/lms/logout.py
+++ b/common/test/acceptance/pages/lms/logout.py
@@ -1,0 +1,14 @@
+from bok_choy.page_object import PageObject
+from . import BASE_URL
+
+
+class LogoutPage(PageObject):
+    """
+    Logout from the LMS by directly going to the logout URL.
+    """
+    def is_browser_on_page(self):
+        return True
+
+    @property
+    def url(self):
+        return BASE_URL + "/logout"

--- a/common/test/acceptance/tests/test_language.py
+++ b/common/test/acceptance/tests/test_language.py
@@ -1,0 +1,46 @@
+from bok_choy.web_app_test import WebAppTest
+from bok_choy.promise import fulfill, Promise
+
+from .helpers import UniqueCourseTest
+from ..pages.lms.dashboard import DashboardPage
+from ..pages.lms.logout import LogoutPage
+from ..pages.studio.auto_auth import AutoAuthPage
+
+
+class LanguageTest(UniqueCourseTest):
+    """
+    Tests that the change language functionality on the dashboard works.
+    """
+
+    def setUp(self):
+        """
+        Visit the dashboard page.
+        """
+        super(LanguageTest, self).setUp()
+
+        # Log in and visit the dashboard page
+        self.auto_auth = AutoAuthPage(
+            self.browser, course_id=self.course_id, username=self.unique_id[0:10]
+        ).visit()
+        self.dashboard_page = DashboardPage(self.browser).visit()
+
+    def test_change_lang(self):
+        # By default, should not be using the dummy language
+        self.assertFalse(self.dashboard_page.is_dummy_lang)
+
+        # Change language to Dummy Esperanto
+        self.dashboard_page.change_language('eo')
+        self.assertTrue(self.dashboard_page.is_dummy_lang)
+
+    def test_language_persists(self):
+
+        # Change language to Dummy Esperanto
+        self.dashboard_page.change_language('eo')
+
+        # Log out and log back in
+        LogoutPage(self.browser).visit()
+        self.auto_auth.visit()
+
+        # Return to the dashboard and verify that we still see the dummy language
+        self.dashboard_page.visit()
+        self.assertTrue(self.dashboard_page.is_dummy_lang)

--- a/common/test/acceptance/tests/test_lms.py
+++ b/common/test/acceptance/tests/test_lms.py
@@ -70,66 +70,6 @@ class RegistrationTest(UniqueCourseTest):
         self.assertIn(self.course_info['display_name'], course_names)
 
 
-class LanguageTest(UniqueCourseTest):
-    """
-    Tests that the change language functionality on the dashboard works
-    """
-
-    @property
-    def _changed_lang_promise(self):
-        def _check_func():
-            text = self.dashboard_page.current_courses_text
-            return (len(text) > 0, text)
-        return Promise(_check_func, "language changed")
-
-    def setUp(self):
-        """
-        Initiailize dashboard page
-        """
-        super(LanguageTest, self).setUp()
-        self.dashboard_page = DashboardPage(self.browser)
-
-        self.test_new_lang = 'eo'
-        # This string is unicode for "ÇÜRRÉNT ÇØÜRSÉS", which should appear in our Dummy Esperanto page
-        # We store the string this way because Selenium seems to try and read in strings from
-        # the HTML in this format. Ideally we could just store the raw ÇÜRRÉNT ÇØÜRSÉS string here
-        self.current_courses_text = u'\xc7\xdcRR\xc9NT \xc7\xd6\xdcRS\xc9S'
-
-        self.username = "test"
-        self.password = "testpass"
-        self.email = "test@example.com"
-
-    def test_change_lang(self):
-        AutoAuthPage(self.browser, course_id=self.course_id).visit()
-        self.dashboard_page.visit()
-        # Change language to Dummy Esperanto
-        self.dashboard_page.change_language(self.test_new_lang)
-
-        changed_text = fulfill(self._changed_lang_promise)
-        # We should see the dummy-language text on the page
-        self.assertIn(self.current_courses_text, changed_text)
-
-    def test_language_persists(self):
-        auto_auth_page = AutoAuthPage(self.browser, username=self.username, password=self.password, email=self.email, course_id=self.course_id)
-        auto_auth_page.visit()
-
-        self.dashboard_page.visit()
-        # Change language to Dummy Esperanto
-        self.dashboard_page.change_language(self.test_new_lang)
-
-        # destroy session
-        self.browser._cookie_manager.delete()
-
-        # log back in
-        auto_auth_page.visit()
-
-        self.dashboard_page.visit()
-
-        changed_text = fulfill(self._changed_lang_promise)
-        # We should see the dummy-language text on the page
-        self.assertIn(self.current_courses_text, changed_text)
-
-
 class HighLevelTabTest(UniqueCourseTest):
     """
     Tests that verify each of the high-level tabs available within a course.


### PR DESCRIPTION
- Move DOM interactions for checking the language out of the test and into the dashboard page object.
- Use a stronger assertion for checking that the language changed (not just that we were able to find the title)
- Log out instead of deleting cookies.
- Moved language tests into a separate module.

@flowerhack 
