### PR TITLE
Will/bok choy test robustness

### DIFF
--- a/common/test/acceptance/pages/studio/unit.py
+++ b/common/test/acceptance/pages/studio/unit.py
@@ -4,7 +4,7 @@ Unit page in Studio
 
 from bok_choy.page_object import PageObject
 from bok_choy.query import SubQuery
-from bok_choy.promise import EmptyPromise, fulfill
+from bok_choy.promise import Promise, EmptyPromise, fulfill
 
 from . import BASE_URL
 
@@ -27,12 +27,17 @@ class UnitPage(PageObject):
         return self.is_css_present('body.view-unit')
 
     def component(self, title):
-        return Component(
-            self.browser,
-            self.q(css=Component.BODY_SELECTOR).filter(
+        return Component(self.browser, self._locator(title))
+
+    def _locator(self, title):
+        def _check_func():
+            locators = self.q(css=Component.BODY_SELECTOR).filter(
                 SubQuery(css=Component.NAME_SELECTOR).filter(text=title)
-            )[0]['data-locator']
-        )
+            ).map(lambda el: el['data-locator']).results
+
+            return (len(locators) > 0, locators[0])
+
+        return fulfill(Promise(_check_func, "Found data locator for component"))
 
 
 class Component(PageObject):

--- a/common/test/acceptance/tests/test_lms.py
+++ b/common/test/acceptance/tests/test_lms.py
@@ -69,6 +69,23 @@ class RegistrationTest(UniqueCourseTest):
         course_names = dashboard.available_courses
         self.assertIn(self.course_info['display_name'], course_names)
 
+    def assert_course_available(self, course_id):
+        # Occassionally this does not show up immediately,
+        # so we wait and try reloading the page
+        def _check_course_available():
+            available = self.find_courses_page.course_id_list
+            if course_id in available:
+                return True
+            else:
+                self.find_courses_page.visit()
+                return False
+
+        return fulfill(EmptyPromise(
+            _check_course_available,
+            "Found course {course_id} in the list of available courses".format(course_id=course_id),
+            try_limit=3, try_interval=2
+        ))
+
 
 class LanguageTest(UniqueCourseTest):
     """


### PR DESCRIPTION
Fixes for some failures in the bok-choy test suite I've observed locally:
- Add page reload retry for finding course fixture on the "find courses" page.  The logs indicate that the course was successfully created; the screenshots confirm that other courses were available.  This suggests that there is a race condition between course creation (in Studio) and course availability (in the LMS).  My solution here is to reload the page up to 3 times if the course isn't found, retriggering a query to Mongo.
- Protect Acid XBlock tests from `StaleElement` exceptions (by using `map` instead of accessing Selenium elements directly)
- Allow Acid XBlock test to retry if it can't find any component locators, likely because the JavaScript hasn't finished updating the page.

@jzoldak 
