### PR TITLE
Rollback Django Debug Toolbar from 1.0.1 to 0.9.4

### DIFF
--- a/cms/envs/dev.py
+++ b/cms/envs/dev.py
@@ -160,7 +160,7 @@ DEBUG_TOOLBAR_PANELS = (
     #  Django=1.3.1/1.4 where requests to views get duplicated (your method gets
     #  hit twice). So you can uncomment when you need to diagnose performance
     #  problems, but you shouldn't leave it on.
-    #  'debug_toolbar.panels.profiling.ProfilingPanel',
+    #  'debug_toolbar.panels.profiling.ProfilingDebugPanel',
 )
 
 DEBUG_TOOLBAR_CONFIG = {

--- a/cms/envs/dev_dbperf.py
+++ b/cms/envs/dev_dbperf.py
@@ -9,21 +9,21 @@ This configuration is to turn on the Django Toolbar stats for DB access stats, f
 from .dev import *
 
 DEBUG_TOOLBAR_PANELS = (
-    'debug_toolbar.panels.versions.VersionsPanel',
-    'debug_toolbar.panels.timer.TimerPanel',
-    'debug_toolbar.panels.settings.SettingsPanel',
-    'debug_toolbar.panels.headers.HeadersPanel',
-    'debug_toolbar.panels.request.RequestPanel',
-    'debug_toolbar.panels.sql.SQLPanel',
-    'debug_toolbar.panels.signals.SignalsPanel',
-    'debug_toolbar.panels.logging.LoggingPanel',
-    'debug_toolbar_mongo.panel.MongoDebugPanel',
+    'debug_toolbar.panels.version.VersionDebugPanel',
+    'debug_toolbar.panels.timer.TimerDebugPanel',
+    'debug_toolbar.panels.settings_vars.SettingsVarsDebugPanel',
+    'debug_toolbar.panels.headers.HeaderDebugPanel',
+    'debug_toolbar.panels.request_vars.RequestVarsDebugPanel',
+    'debug_toolbar.panels.sql.SQLDebugPanel',
+    'debug_toolbar.panels.signals.SignalDebugPanel',
+    'debug_toolbar.panels.logger.LoggingPanel',
+    'debug_toolbar_mongo.panel.MongoDebugPanel'
 
     #  Enabling the profiler has a weird bug as of django-debug-toolbar==0.9.4 and
     #  Django=1.3.1/1.4 where requests to views get duplicated (your method gets
     #  hit twice). So you can uncomment when you need to diagnose performance
     #  problems, but you shouldn't leave it on.
-    #  'debug_toolbar.panels.profiling.ProfilingPanel',
+    #  'debug_toolbar.panels.profiling.ProfilingDebugPanel',
 )
 
 # To see stacktraces for MongoDB queries, set this to True.

--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -37,14 +37,14 @@ MIDDLEWARE_CLASSES += ('debug_toolbar.middleware.DebugToolbarMiddleware',)
 INTERNAL_IPS = ('127.0.0.1',)
 
 DEBUG_TOOLBAR_PANELS = (
-    'debug_toolbar.panels.versions.VersionsPanel',
-    'debug_toolbar.panels.timer.TimerPanel',
-    'debug_toolbar.panels.settings.SettingsPanel',
-    'debug_toolbar.panels.headers.HeadersPanel',
-    'debug_toolbar.panels.request.RequestPanel',
-    'debug_toolbar.panels.sql.SQLPanel',
-    'debug_toolbar.panels.signals.SignalsPanel',
-    'debug_toolbar.panels.logging.LoggingPanel',
+    'debug_toolbar.panels.version.VersionDebugPanel',
+    'debug_toolbar.panels.timer.TimerDebugPanel',
+    'debug_toolbar.panels.settings_vars.SettingsVarsDebugPanel',
+    'debug_toolbar.panels.headers.HeaderDebugPanel',
+    'debug_toolbar.panels.request_vars.RequestVarsDebugPanel',
+    'debug_toolbar.panels.sql.SQLDebugPanel',
+    'debug_toolbar.panels.signals.SignalDebugPanel',
+    'debug_toolbar.panels.logger.LoggingPanel',
 
     #  Enabling the profiler has a weird bug as of django-debug-toolbar==0.9.4 and
     #  Django=1.3.1/1.4 where requests to views get duplicated (your method gets

--- a/lms/envs/content.py
+++ b/lms/envs/content.py
@@ -19,19 +19,18 @@ INSTALLED_APPS += ('debug_toolbar',)
 MIDDLEWARE_CLASSES += ('debug_toolbar.middleware.DebugToolbarMiddleware',)
 
 DEBUG_TOOLBAR_PANELS = (
-   'debug_toolbar.panels.versions.VersionsPanel',
-   'debug_toolbar.panels.timer.TimerPanel',
-   'debug_toolbar.panels.settings.SettingsPanel',
-   'debug_toolbar.panels.headers.HeadersPanel',
-   'debug_toolbar.panels.request.RequestPanel',
-   'debug_toolbar.panels.sql.SQLPanel',
-   'debug_toolbar.panels.signals.SignalsPanel',
-   'debug_toolbar.panels.logging.LoggingPanel',
+   'debug_toolbar.panels.version.VersionDebugPanel',
+   'debug_toolbar.panels.timer.TimerDebugPanel',
+   'debug_toolbar.panels.settings_vars.SettingsVarsDebugPanel',
+   'debug_toolbar.panels.headers.HeaderDebugPanel',
+   'debug_toolbar.panels.request_vars.RequestVarsDebugPanel',
+   'debug_toolbar.panels.sql.SQLDebugPanel',
+   'debug_toolbar.panels.signals.SignalDebugPanel',
+   'debug_toolbar.panels.logger.LoggingPanel',
 
 #  Enabling the profiler has a weird bug as of django-debug-toolbar==0.9.4 and
 #  Django=1.3.1/1.4 where requests to views get duplicated (your method gets
 #  hit twice). So you can uncomment when you need to diagnose performance
 #  problems, but you shouldn't leave it on.
-#  'debug_toolbar.panels.profiling.ProfilingPanel',
+#  'debug_toolbar.panels.profiling.ProfilingDebugPanel',
 )
-

--- a/lms/envs/dev.py
+++ b/lms/envs/dev.py
@@ -230,7 +230,7 @@ DEBUG_TOOLBAR_PANELS = (
 #  Django=1.3.1/1.4 where requests to views get duplicated (your method gets
 #  hit twice). So you can uncomment when you need to diagnose performance
 #  problems, but you shouldn't leave it on.
-#  'debug_toolbar.panels.profiling.ProfilingPanel',
+#  'debug_toolbar.panels.profiling.ProfilingDebugPanel',
 )
 
 DEBUG_TOOLBAR_CONFIG = {

--- a/lms/envs/devplus.py
+++ b/lms/envs/devplus.py
@@ -57,20 +57,20 @@ MIDDLEWARE_CLASSES += ('debug_toolbar.middleware.DebugToolbarMiddleware',)
 INTERNAL_IPS = ('127.0.0.1',)
 
 DEBUG_TOOLBAR_PANELS = (
-   'debug_toolbar.panels.versions.VersionsPanel',
-   'debug_toolbar.panels.timer.TimerPanel',
-   'debug_toolbar.panels.settings.SettingsPanel',
-   'debug_toolbar.panels.headers.HeadersPanel',
-   'debug_toolbar.panels.request.RequestPanel',
-   'debug_toolbar.panels.sql.SQLPanel',
-   'debug_toolbar.panels.signals.SignalsPanel',
-   'debug_toolbar.panels.logging.LoggingPanel',
+   'debug_toolbar.panels.version.VersionDebugPanel',
+   'debug_toolbar.panels.timer.TimerDebugPanel',
+   'debug_toolbar.panels.settings_vars.SettingsVarsDebugPanel',
+   'debug_toolbar.panels.headers.HeaderDebugPanel',
+   'debug_toolbar.panels.request_vars.RequestVarsDebugPanel',
+   'debug_toolbar.panels.sql.SQLDebugPanel',
+   'debug_toolbar.panels.signals.SignalDebugPanel',
+   'debug_toolbar.panels.logger.LoggingPanel',
 
 #  Enabling the profiler has a weird bug as of django-debug-toolbar==0.9.4 and
 #  Django=1.3.1/1.4 where requests to views get duplicated (your method gets
 #  hit twice). So you can uncomment when you need to diagnose performance
 #  problems, but you shouldn't leave it on.
-  'debug_toolbar.panels.profiling.ProfilingPanel',
+  'debug_toolbar.panels.profiling.ProfilingDebugPanel',
 )
 
 #PIPELINE = True

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -35,20 +35,20 @@ MIDDLEWARE_CLASSES += ('django_comment_client.utils.QueryCountDebugMiddleware',
 INTERNAL_IPS = ('127.0.0.1',)
 
 DEBUG_TOOLBAR_PANELS = (
-    'debug_toolbar.panels.versions.VersionsPanel',
-    'debug_toolbar.panels.timer.TimerPanel',
-    'debug_toolbar.panels.settings.SettingsPanel',
-    'debug_toolbar.panels.headers.HeadersPanel',
-    'debug_toolbar.panels.request.RequestPanel',
-    'debug_toolbar.panels.sql.SQLPanel',
-    'debug_toolbar.panels.signals.SignalsPanel',
-    'debug_toolbar.panels.logging.LoggingPanel',
+    'debug_toolbar.panels.version.VersionDebugPanel',
+    'debug_toolbar.panels.timer.TimerDebugPanel',
+    'debug_toolbar.panels.settings_vars.SettingsVarsDebugPanel',
+    'debug_toolbar.panels.headers.HeaderDebugPanel',
+    'debug_toolbar.panels.request_vars.RequestVarsDebugPanel',
+    'debug_toolbar.panels.sql.SQLDebugPanel',
+    'debug_toolbar.panels.signals.SignalDebugPanel',
+    'debug_toolbar.panels.logger.LoggingPanel',
 
-#  Enabling the profiler has a weird bug as of django-debug-toolbar==0.9.4 and
-#  Django=1.3.1/1.4 where requests to views get duplicated (your method gets
-#  hit twice). So you can uncomment when you need to diagnose performance
-#  problems, but you shouldn't leave it on.
-#  'debug_toolbar.panels.profiling.ProfilingPanel',
+    #  Enabling the profiler has a weird bug as of django-debug-toolbar==0.9.4 and
+    #  Django=1.3.1/1.4 where requests to views get duplicated (your method gets
+    #  hit twice). So you can uncomment when you need to diagnose performance
+    #  problems, but you shouldn't leave it on.
+    #  'debug_toolbar.panels.profiling.ProfilingPanel',
 )
 
 DEBUG_TOOLBAR_CONFIG = {

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -93,12 +93,20 @@ sphinx_rtd_theme==0.1.5
 Babel==1.3
 transifex-client==0.10
 
+# We've tried several times to update the debug toolbar to version 1.0.1,
+# and had problems each time, resulting in us rolling back to 0.9.4. Before
+# submitting another pull request to do this update, check the following:
+# * https://github.com/django-debug-toolbar/django-debug-toolbar/issues/535 should be resolved
+# * Studio and CMS should both run correctly, both directly and via devstack
+# * Check the Javascript console to be sure there are no Javascript errors
+#   related to the Django debug toolbar
+django_debug_toolbar==0.9.4
+django-debug-toolbar-mongo
+
 # Used for testing
 coverage==3.7
 ddt==0.6.0
 django-crum==0.5
-django-debug-toolbar-mongo
-django_debug_toolbar==1.0.1
 django_nose==1.1
 factory_boy==2.2.1
 freezegun==0.1.11


### PR DESCRIPTION
Due to issues with require.js and the latest version of the toolbar.
Also included a note in the requirements file explaining the situation, and what
needs to happen before this can be upgrade properly.

Conflicts:
    lms/envs/dev.py
