### PR TITLE
Turn off capa name masking

### DIFF
--- a/common/lib/capa/capa/responsetypes.py
+++ b/common/lib/capa/capa/responsetypes.py
@@ -748,7 +748,7 @@ class MultipleChoiceResponse(LoncapaResponse):
         for response in self.xml.xpath("choicegroup"):
             # Is Masking enabled? -- check for shuffle or answer-pool features
             ans_str = response.get("answer-pool")
-            if response.get("shuffle") == "true" or (ans_str is not None and ans_str != "0"):
+            if False: # Temporarily turn off masking
                 self.is_masked = True
                 self.mask_dict = {}
                 rng = random.Random(self.context["seed"])

--- a/common/lib/capa/capa/tests/test_answer_pool.py
+++ b/common/lib/capa/capa/tests/test_answer_pool.py
@@ -64,8 +64,9 @@ class CapaAnswerPoolTest(unittest.TestCase):
         self.assertIsNotNone(problem.tree.xpath('//choicegroup[@answer-pool-done="done"]'))
         # Check about masking
         response = problem.responders.values()[0]
-        self.assertTrue(hasattr(response, 'is_masked'))
-        self.assertEqual(response.unmask_order(), ['choice_3', 'choice_5', 'choice_1', 'choice_4'])
+        ### Temporarily disabling masking
+        ###self.assertTrue(hasattr(response, 'is_masked'))
+        ###self.assertEqual(response.unmask_order(), ['choice_3', 'choice_5', 'choice_1', 'choice_4'])
 
     def test_answer_pool_4_choices_1_multiplechoiceresponse_seed2(self):
         xml_str = textwrap.dedent("""
@@ -112,8 +113,8 @@ class CapaAnswerPoolTest(unittest.TestCase):
         self.assertIsNotNone(problem.tree.xpath('//choicegroup[@answer-pool-done="done"]'))
         # Check about masking
         response = problem.responders.values()[0]
-        self.assertTrue(hasattr(response, 'is_masked'))
-        self.assertEqual(response.unmask_order(), ['choice_0', 'choice_4', 'choice_3', 'choice_2'])
+        ###self.assertTrue(hasattr(response, 'is_masked'))
+        ###self.assertEqual(response.unmask_order(), ['choice_0', 'choice_4', 'choice_3', 'choice_2'])
 
     def test_no_answer_pool_4_choices_1_multiplechoiceresponse(self):
         xml_str = textwrap.dedent("""
@@ -160,7 +161,7 @@ class CapaAnswerPoolTest(unittest.TestCase):
         self.assertEquals(problem.tree.xpath('//choicegroup[@answer-pool-done="done"]'), [])
         # Check about masking
         response = problem.responders.values()[0]
-        self.assertFalse(hasattr(response, 'is_masked'))
+        ###self.assertFalse(hasattr(response, 'is_masked'))
 
     def test_0_answer_pool_4_choices_1_multiplechoiceresponse(self):
         xml_str = textwrap.dedent("""
@@ -205,7 +206,7 @@ class CapaAnswerPoolTest(unittest.TestCase):
         self.assertRegexpMatches(the_html, r"<div>\{.*'1_solution_1'.*'1_solution_2'.*\}</div>")
         self.assertEquals(problem.tree.xpath('//choicegroup[@answer-pool-done="done"]'), [])
         response = problem.responders.values()[0]
-        self.assertFalse(hasattr(response, 'is_masked'))
+        ###self.assertFalse(hasattr(response, 'is_masked'))
 
     def test_invalid_answer_pool(self):
         xml_str = textwrap.dedent("""
@@ -290,8 +291,8 @@ class CapaAnswerPoolTest(unittest.TestCase):
         self.assertRegexpMatches(the_html, r"<div>.*\[.*'correct-2'.*'wrong-1'.*'wrong-2'.*.*'wrong-3'.*'wrong-4'.*\].*</div>")
         self.assertRegexpMatches(the_html, r"<div>\{.*'1_solution_2'.*\}</div>")
         response = problem.responders.values()[0]
-        self.assertTrue(hasattr(response, 'is_masked'))
-        self.assertEqual(response.unmask_order(), ['choice_5', 'choice_0', 'choice_1', 'choice_3', 'choice_4'])
+        ###self.assertTrue(hasattr(response, 'is_masked'))
+        ###self.assertEqual(response.unmask_order(), ['choice_5', 'choice_0', 'choice_1', 'choice_3', 'choice_4'])
 
     def test_answer_pool_2_multiplechoiceresponses_seed1(self):
         xml_str = textwrap.dedent("""

--- a/common/lib/capa/capa/tests/test_shuffle.py
+++ b/common/lib/capa/capa/tests/test_shuffle.py
@@ -33,8 +33,9 @@ class CapaShuffleTest(unittest.TestCase):
         self.assertRegexpMatches(the_html, r"<div>.*\[.*'Banana'.*'Apple'.*'Chocolate'.*'Donut'.*\].*</div>")
         # Check that choice name masking is enabled and that unmasking works
         response = problem.responders.values()[0]
-        self.assertTrue(hasattr(response, 'is_masked'))
-        self.assertEqual(response.unmask_order(), ['choice_1', 'choice_0', 'choice_2', 'choice_3'])
+        ### Temporarily disabling masking
+        ###self.assertTrue(hasattr(response, 'is_masked'))
+        ###self.assertEqual(response.unmask_order(), ['choice_1', 'choice_0', 'choice_2', 'choice_3'])
         self.assertEqual(the_html, problem.get_html(), 'should be able to call get_html() twice')
         self.assertIsNotNone(problem.tree.xpath('//choicegroup[@shuffle-done="done"]'))
 
@@ -55,8 +56,8 @@ class CapaShuffleTest(unittest.TestCase):
         # B A C D
         # Check that the custom name= names come through
         response = problem.responders.values()[0]
-        self.assertTrue(hasattr(response, 'is_masked'))
-        self.assertEqual(response.unmask_order(), ['choice_0', 'choice_aaa', 'choice_1', 'choice_ddd'])
+        ###self.assertTrue(hasattr(response, 'is_masked'))
+        ###self.assertEqual(response.unmask_order(), ['choice_0', 'choice_aaa', 'choice_1', 'choice_ddd'])
         self.assertIsNotNone(problem.tree.xpath('//choicegroup[@shuffle-done="done"]'))
 
     def test_shuffle_different_seed(self):
@@ -90,8 +91,8 @@ class CapaShuffleTest(unittest.TestCase):
         the_html = problem.get_html()
         self.assertRegexpMatches(the_html, r"<div>.*\[.*'Apple'.*\].*</div>")
         response = problem.responders.values()[0]
-        self.assertEqual(response.unmask_order(), ['choice_0'])
-        self.assertEqual(response.unmask_name('mask_0'), 'choice_0')
+        ###self.assertEqual(response.unmask_order(), ['choice_0'])
+        ###self.assertEqual(response.unmask_name('mask_0'), 'choice_0')
         self.assertIsNotNone(problem.tree.xpath('//choicegroup[@shuffle-done="done"]'))
 
     def test_shuffle_6_choices(self):
@@ -275,7 +276,7 @@ class CapaShuffleTest(unittest.TestCase):
         self.assertRegexpMatches(html, r"<div>.*\[.*'Banana'.*'Apple'.*'Chocolate'.*'Donut'.*\].*</div>.*" +
                                        r"<div>.*\[.*'B'.*'A'.*'C'.*'D'.*\].*</div>")
         responses = problem.responders.values()
-        self.assertTrue(hasattr(responses[0], 'is_masked'))
-        self.assertTrue(hasattr(responses[1], 'is_masked'))
-        self.assertEqual(responses[0].unmask_order(), ['choice_1', 'choice_0', 'choice_2', 'choice_3'])
-        self.assertEqual(responses[1].unmask_order(), ['choice_1', 'choice_0', 'choice_2', 'choice_3'])
+        ###self.assertTrue(hasattr(responses[0], 'is_masked'))
+        ###self.assertTrue(hasattr(responses[1], 'is_masked'))
+        ###self.assertEqual(responses[0].unmask_order(), ['choice_1', 'choice_0', 'choice_2', 'choice_3'])
+        ###self.assertEqual(responses[1].unmask_order(), ['choice_1', 'choice_0', 'choice_2', 'choice_3'])


### PR DESCRIPTION
Temporary workaround as the un-masking is not working
on the logging data sent out to courseware_studentmodule.
Also turn off the test bits this change breaks. @sefk 
