### PR TITLE
add infinity symbol to calc preview

### DIFF
--- a/common/lib/calc/calc/preview.py
+++ b/common/lib/calc/calc/preview.py
@@ -119,6 +119,9 @@ def enrich_varname(varname):
     # add hbar for QM
     greek.append('hbar')
 
+    # add infinity
+    greek.append('infty')
+
     if varname in greek:
         return ur"\{letter}".format(letter=varname)
     else:


### PR DESCRIPTION
formulaequationinput should accept the standard infinity notation of asciimath, `infty`.

This PR fixes this issue.

See analogous fix for hbar: https://github.com/edx/edx-platform/pull/888
