### PR TITLE
Fix some links to different installation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,14 @@ Installation
 
 Please refer to the following wiki pages in our [configuration repo](https://github.com/edx/configuration) to install edX:
 
-* [edX Developer Stack](https://github.com/edx/configuration/wiki/edX-Developer-Stack) 
+* [edX Developer Stack using Vagrant/Virtualbox](https://github.com/edx/configuration/wiki/edX-Developer-Stack)
 <br/>These instructions are for developers who want to contribute or make changes to the edX source code.
-* [edX Production Stack](https://github.com/edx/configuration/wiki/edX-Production-Stack) 
-<br/>Using Vagrant/Virtualbox this will setup all edX services on a single server in a production like configuration.
-* [edX Ubuntu 12.04 installation](https://github.com/edx/configuration/wiki/edX-Ubuntu-12.04-Installation) 
-<br/>This will install edX on an existing Ubuntu 12.04 server.
+* [edX Production Stack using Vagrant/Virtualbox](https://github.com/edx/configuration/wiki/edx-Production-stack--installation-using-Vagrant-Virtualbox) 
+<br/>This will setup all edX services in the [edX Production Stack](https://github.com/edx/configuration/wiki/edX-Production-Stack) on a single server, using Vagrant/Virtualbox.
+* [edX Production Stack on Ubuntu 12.04, from scratch](https://github.com/edx/configuration/wiki/edX-Ubuntu-12.04-Installation) 
+<br/>This will setup all edX services in the [edX Production Stack](https://github.com/edx/configuration/wiki/edX-Production-Stack) on a single Ubuntu 12.04 server, from scratch.
+* [edX Production Stack on a single AWS server using pre-installed image](https://github.com/edx/configuration/wiki/Single-AWS-server-installation-using-Amazon-Machine-Image)
+<br/>This will setup all edX services in the [edX Production Stack](https://github.com/edx/configuration/wiki/edX-Production-Stack) on a single Amazon Web Services server, using an Amazon Machine Image.
 
 
 License

--- a/docs/en_us/release_notes/source/02-19-2014.rst
+++ b/docs/en_us/release_notes/source/02-19-2014.rst
@@ -4,7 +4,7 @@ February 19, 2014
 
 You can now access the public edX roadmap_ for details about the currently planned product direction.
 
-.. _roadmap: https://edx-wiki.atlassian.net/wiki/display/OPENPROD/OpenEdX+Public+Product+Roadmap
+.. _roadmap: https://edx-wiki.atlassian.net/wiki/display/OPENPROD/Open+EdX+Public+Product+Roadmap
 
 
 Course staff documentation, *Building a Course with edX Studio*, is available online_. You can also download the new guide as a PDF from the edX Studio user interface.


### PR DESCRIPTION
 In conjunction with changes to edx and edx/configuration  wikis, this hopefully clarifies all the different installation instructions. It is important to mark all production stack installations as such, as there is a wiki page that then explains how to manage the production stack (i.e. three ways to install: Vagrant, Scratch Ubuntu and AWS/AMI, but one way to manage)
