### PR TITLE
Fix XML parser with empty HTML5 attributes.

### DIFF
--- a/common/lib/capa/capa/responsetypes.py
+++ b/common/lib/capa/capa/responsetypes.py
@@ -14,6 +14,7 @@ import cgi
 import inspect
 import json
 import logging
+import html5lib
 import numbers
 import numpy
 import os
@@ -1761,17 +1762,22 @@ class CodeResponse(LoncapaResponse):
                           " tags: 'correct', 'score', 'msg'")
                 return fail
 
-        # Next, we need to check that the contents of the external grader message
-        #   is safe for the LMS.
+        # Next, we need to check that the contents of the external grader message is safe for the LMS.
         # 1) Make sure that the message is valid XML (proper opening/closing tags)
-        # 2) TODO: Is the message actually HTML?
+        # 2) If it is not valid XML, make sure it is valid HTML. Note: html5lib parser will try to repair any broken HTML
+        # For example: <aaa></bbb> will become <aaa/>.
         msg = score_result['msg']
+
         try:
             etree.fromstring(msg)
         except etree.XMLSyntaxError as _err:
-            log.error("Unable to parse external grader message as valid"
+            # If `html` contains attrs with no values, like `controls` in <audio controls src='smth'/>,
+            # XML parser will raise exception, so wee fallback to html5parser, which will set empty "" values for such attrs.
+            parsed = html5lib.parseFragment(msg, treebuilder='lxml', namespaceHTMLElements=False)
+            if not parsed:
+                log.error("Unable to parse external grader message as valid"
                       " XML: score_msg['msg']=%s", msg)
-            return fail
+                return fail
 
         return (True, score_result['correct'], score_result['score'], msg)
 


### PR DESCRIPTION
Fix for BLD-827 (https://edx-wiki.atlassian.net/browse/BLD-827) : "Audio Playback of MatLab-generated file not working"

@adampalay please review and test manually.
