### PR TITLE
Fix start-time functionality in the video player.

### DIFF
--- a/common/lib/xmodule/xmodule/js/spec/video/general_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/general_spec.js
@@ -221,7 +221,7 @@
                 expect(state.videoPlayer.play).toHaveBeenCalled();
             });
 
-            it('when cued, onEnded resets start and end time only the second time', function () {
+            it('even when cued, onEnded does not resets start and end time', function () {
                 state.videoPlayer.skipOnEndedStartEndReset = true;
                 state.videoPlayer.onEnded();
                 expect(state.videoPlayer.startTime).toBe(10);
@@ -229,8 +229,8 @@
 
                 state.videoPlayer.skipOnEndedStartEndReset = undefined;
                 state.videoPlayer.onEnded();
-                expect(state.videoPlayer.startTime).toBe(0);
-                expect(state.videoPlayer.endTime).toBe(null);
+                expect(state.videoPlayer.startTime).toBe(10);
+                expect(state.videoPlayer.endTime).toBe(30);
             });
         });
 

--- a/common/lib/xmodule/xmodule/js/spec/video/video_player_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_player_spec.js
@@ -562,6 +562,7 @@ function (VideoPlayer) {
                 runs(function () {
                     var htmlStr;
 
+                    state.videoPlayer.goToStartTime = false;
                     state.videoPlayer.updatePlayTime(60);
 
                     htmlStr = $('.vidtime').html();
@@ -589,6 +590,7 @@ function (VideoPlayer) {
                 }, 'Video is fully loaded.', WAIT_TIMEOUT);
 
                 runs(function () {
+                    state.videoPlayer.goToStartTime = false;
                     state.videoPlayer.updatePlayTime(60);
 
                     expect(state.videoCaption.updatePlayTime)
@@ -606,6 +608,7 @@ function (VideoPlayer) {
                 }, 'Video is fully loaded.', WAIT_TIMEOUT);
 
                 runs(function () {
+                    state.videoPlayer.goToStartTime = false;
                     state.videoPlayer.updatePlayTime(60);
 
                     expect(state.videoProgressSlider.updatePlayTime)
@@ -677,35 +680,39 @@ function (VideoPlayer) {
 
         describe('updatePlayTime with invalid endTime', function () {
             beforeEach(function () {
-                state = jasmine.initializePlayer(
-                    {
-                        end: 100000
-                    }
-                );
+                state = {
+                    videoPlayer: {
+                        duration: function () {
+                            // The video will be 60 seconds long.
+                            return 60;
+                        },
+                        goToStartTime: true,
+                        startTime: undefined,
+                        endTime: undefined,
+                        player: {
+                            seekTo: function () {}
+                        }
+                    },
+                    config: {
+                        savedVideoPosition: 0,
+                        startTime: 0,
 
-                state.videoEl = $('video, iframe');
-
-                spyOn(state.videoPlayer, 'updatePlayTime').andCallThrough();
+                        // We are setting the end-time to 10000 seconds. The
+                        // video will be less than this, the code will reset
+                        // the end time to `null` - i.e. to the end of the video.
+                        // This is the expected behavior we will test for.
+                        endTime: 10000
+                    },
+                    currentPlayerMode: 'html5',
+                    trigger: function () {},
+                    browserIsFirefox: false
+                };
             });
 
             it('invalid endTime is reset to null', function () {
-                var duration;
+                VideoPlayer.prototype.updatePlayTime.call(state, 0);
 
-                state.videoPlayer.updatePlayTime.reset();
-                state.videoPlayer.play();
-
-                waitsFor(
-                    function () {
-                        return state.videoPlayer.isPlaying() &&
-                            state.videoPlayer.initialSeekToStartTime === false;
-                    },
-                    'updatePlayTime was invoked and duration is set',
-                    WAIT_TIMEOUT
-                );
-
-                runs(function () {
-                    expect(state.videoPlayer.endTime).toBe(null);
-                });
+                expect(state.videoPlayer.endTime).toBe(null);
             });
         });
 

--- a/common/lib/xmodule/xmodule/js/src/video/03_video_player.js
+++ b/common/lib/xmodule/xmodule/js/src/video/03_video_player.js
@@ -305,10 +305,10 @@ function (HTML5Video, Resizer) {
             this.videoPlayer.updatePlayTime(this.videoPlayer.currentTime);
 
             // We need to pause the video if current time is smaller (or equal)
-            // than end time. Also, we must make sure that this is only done
+            // than end-time. Also, we must make sure that this is only done
             // once per video playing from start to end.
             if (
-                this.videoPlayer.stopAtEndTime === true &&
+                this.videoPlayer.stopAtEndTime &&
                 this.videoPlayer.endTime !== null &&
                 this.videoPlayer.endTime <= this.videoPlayer.currentTime
             ) {
@@ -648,7 +648,7 @@ function (HTML5Video, Resizer) {
             savedVideoPosition = this.config.savedVideoPosition,
             youTubeId, startTime, endTime;
 
-        if (duration > 0 && videoPlayer.goToStartTime === true) {
+        if (duration > 0 && videoPlayer.goToStartTime) {
             videoPlayer.goToStartTime = false;
 
             videoPlayer.startTime = this.config.startTime;
@@ -716,14 +716,14 @@ function (HTML5Video, Resizer) {
 
             if (time > 0) {
                 // After a bug came up (BLD-708: "In Firefox YouTube video with
-                // start time plays from 00:00:00") the video refused to play
-                // from start time, and only played from the beginning.
+                // start-time plays from 00:00:00") the video refused to play
+                // from start-time, and only played from the beginning.
                 //
                 // It turned out that for some reason if Firefox you couldn't
                 // seek beyond some amount of time before the video loaded.
                 // Very strange, but in Chrome there is no such bug.
                 //
-                // HTML5 video sources play fine from start time in both Chrome
+                // HTML5 video sources play fine from start-time in both Chrome
                 // and Firefox.
                 if (this.browserIsFirefox && this.videoType === 'youtube') {
                     if (this.currentPlayerMode === 'flash') {
@@ -734,7 +734,7 @@ function (HTML5Video, Resizer) {
 
                     // When we will call cueVideoById() for some strange reason
                     // an ENDED event will be fired. It really does no damage
-                    // except for the fact that the end time is reset to null.
+                    // except for the fact that the end-time is reset to null.
                     // We do not want this.
                     //
                     // The flag `skipOnEndedStartEndReset` will notify the
@@ -808,7 +808,7 @@ function (HTML5Video, Resizer) {
         // Sometimes the YouTube API doesn't finish instantiating all of it's
         // methods, but the execution point arrives here.
         //
-        // This happens when you have start and end times set, and click "Edit"
+        // This happens when you have start-time and end-time set, and click "Edit"
         // in Studio, and then "Save". The Video editor dialog closes, the
         // video reloads, but the start-end range is not visible.
         if (this.videoPlayer.player.getDuration) {

--- a/common/lib/xmodule/xmodule/js/src/video/03_video_player.js
+++ b/common/lib/xmodule/xmodule/js/src/video/03_video_player.js
@@ -410,7 +410,7 @@ function (HTML5Video, Resizer) {
         );
 
         // After the user seeks, the video will start playing from
-        // the seeked to point, and stop playing at the end.
+        // the sought point, and stop playing at the end.
         this.videoPlayer.goToStartTime = false;
         if (newTime > this.videoPlayer.endTime || this.videoPlayer.endTime === null) {
             this.videoPlayer.stopAtEndTime = false;
@@ -738,9 +738,8 @@ function (HTML5Video, Resizer) {
                     // We do not want this.
                     //
                     // The flag `skipOnEndedStartEndReset` will notify the
-                    // onEnded() callback for the ENDED event that just this
-                    // once there is no need in resetting the start and end
-                    // times
+                    // onEnded() callback for the ENDED event that there
+                    // is no need in resetting the start-time and end-time.
                     videoPlayer.skipOnEndedStartEndReset = true;
 
                     videoPlayer.seekToTimeOnCued = time;

--- a/common/lib/xmodule/xmodule/js/src/video/06_video_progress_slider.js
+++ b/common/lib/xmodule/xmodule/js/src/video/06_video_progress_slider.js
@@ -101,7 +101,7 @@ function () {
     }
 
     // Rebuild the slider start-end range (if it doesn't take up the
-    // whole slider). Remember that endTime === null means the end time
+    // whole slider). Remember that endTime === null means the end-time
     // is set to the end of video by default.
     function updateStartEndTimeRegion(params) {
         var isFlashMode = this.currentPlayerMode === 'flash',

--- a/common/lib/xmodule/xmodule/js/src/video/06_video_progress_slider.js
+++ b/common/lib/xmodule/xmodule/js/src/video/06_video_progress_slider.js
@@ -180,6 +180,10 @@ function () {
     function onSlide(event, ui) {
         this.videoProgressSlider.frozen = true;
 
+        // Remember the seek to value so that we don't repeat ourselves on the
+        // 'stop' slider event.
+        this.videoProgressSlider.lastSeekValue = ui.value;
+
         this.trigger(
             'videoPlayer.onSlideSeek',
             {'type': 'onSlideSeek', 'time': ui.value}
@@ -196,10 +200,16 @@ function () {
 
         this.videoProgressSlider.frozen = true;
 
-        this.trigger(
-            'videoPlayer.onSlideSeek',
-            {'type': 'onSlideSeek', 'time': ui.value}
-        );
+        // Only perform a seek if we haven't made a seek for the new slider value.
+        // This is necessary so that if the user only clicks on the slider, without
+        // dragging it, then only one seek is made, even when a 'slide' and a 'stop'
+        // events are triggered on the slider.
+        if (this.videoProgressSlider.lastSeekValue !== ui.value) {
+            this.trigger(
+                'videoPlayer.onSlideSeek',
+                {'type': 'onSlideSeek', 'time': ui.value}
+            );
+        }
 
         // ARIA
         this.videoProgressSlider.handle.attr(
@@ -216,8 +226,8 @@ function () {
             duration = Math.floor(params.duration);
 
         if (
-            (this.videoProgressSlider.slider) &&
-            (!this.videoProgressSlider.frozen)
+            this.videoProgressSlider.slider &&
+            !this.videoProgressSlider.frozen
         ) {
             this.videoProgressSlider.slider
                 .slider('option', 'max', duration)


### PR DESCRIPTION
**Description**

When there is a start-time:
- Initially, the video starts playing from the start-time.
- Whenever the player resets for any reason (such as reaching the end of the video), it will reset to start-time instead of 00:00:00.
- It should not be the case that any time the user presses play, it start playing from start-time.

**Jira Issue**

[BLD-659](https://edx-wiki.atlassian.net/browse/BLD-659)

**Reviewers**
- @jmclaus 
- @wedaly 
