### PR TITLE
xblock-brightcove: XBlock - Brightcove video player -- DO NOT MERGE, FOR EARLY REVIEW

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -24,3 +24,4 @@
 -e git+https://github.com/edx/bok-choy.git@62de7b576a08f36cde5b030c52bccb1a2f3f8df1#egg=bok_choy
 -e git+https://github.com/edx-solutions/django-splash.git@9965a53c269666a30bb4e2b3f6037c138aef2a55#egg=django-splash
 -e git+https://github.com/edx/acid-block.git@bf61f0fcd5916a9236bb5681c98374a48a13a74c#egg=acid-xblock
+-e git+https://github.com/edx-solutions/xblock-brightcove.git@8c1d123e221fb1df6dab221c8eb7a7ea7d507e74#egg=xblock-brightcove


### PR DESCRIPTION
Adds basic support for the Brightcove video player, through the following XBlock:

https://github.com/edx-solutions/xblock-brightcove
