### PR TITLE
Add module display name to module related server events

### DIFF
--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -698,3 +698,63 @@ class TestAnonymousStudentId(ModuleStoreTestCase, LoginEnrollmentTestCase):
             'f82b5416c9f54b5ce33989511bb5ef2e',
             self._get_anonymous_id('MITx/6.00x/2013_Spring', descriptor_class)
         )
+
+
+@override_settings(MODULESTORE=TEST_DATA_MIXED_MODULESTORE)
+@patch('track.views.tracker')
+class TestModuleTrackingContext(ModuleStoreTestCase):
+    """
+    Ensure correct tracking information is included in events emitted during XBlock callback handling.
+    """
+
+    def setUp(self):
+        self.user = UserFactory.create()
+        self.request = RequestFactory().get('/')
+        self.request.user = self.user
+        self.request.session = {}
+        self.course = CourseFactory.create()
+
+        self.problem_xml = OptionResponseXMLFactory().build_xml(
+            question_text='The correct answer is Correct',
+            num_inputs=2,
+            weight=2,
+            options=['Correct', 'Incorrect'],
+            correct_option='Correct'
+        )
+
+    def test_context_contains_display_name(self, mock_tracker):
+        problem_display_name = u'Option Response Problem'
+        actual_display_name = self.handle_callback_and_get_display_name_from_event(mock_tracker, problem_display_name)
+        self.assertEquals(problem_display_name, actual_display_name)
+
+    def handle_callback_and_get_display_name_from_event(self, mock_tracker, problem_display_name=None):
+        """
+        Creates a fake module, invokes the callback and extracts the display name from the emitted problem_check event.
+        """
+        descriptor_kwargs = {
+            'category': 'problem',
+            'data': self.problem_xml
+        }
+        if problem_display_name:
+            descriptor_kwargs['display_name'] = problem_display_name
+
+        descriptor = ItemFactory.create(**descriptor_kwargs)
+
+        render.handle_xblock_callback(
+            self.request,
+            self.course.id,
+            quote_slashes(str(descriptor.location)),
+            'xmodule_handler',
+            'problem_check',
+        )
+
+        self.assertEquals(len(mock_tracker.send.mock_calls), 1)
+        mock_call = mock_tracker.send.mock_calls[0]
+        event = mock_call[1][0]
+
+        self.assertEquals(event['event_type'], 'problem_check')
+        return event['context']['module']['display_name']
+
+    def test_missing_display_name(self, mock_tracker):
+        actual_display_name = self.handle_callback_and_get_display_name_from_event(mock_tracker)
+        self.assertTrue(actual_display_name.startswith('problem'))


### PR DESCRIPTION
This information will likely be used frequently for analytics purposes, so we would like to denormalize here to avoid having to join with the modulestore later.

We would like this feature to make it in to the release tomorrow.

A few notes:
- Wasn't sure where the best place to put this logic is.  Very open to suggestions.
- I figured the best way to communicate what we are trying to do was to submit a diff.  I'm not attached to any of this.
- Once the approach is approved, I'll nail it down with some tests etc.

Fixes: AN-594
Reviewers: @cpennington, @rocha, @brianhw
