### PR TITLE
The correct LTI keyword is "roles", not "role"

### DIFF
--- a/common/lib/xmodule/xmodule/lti_module.py
+++ b/common/lib/xmodule/xmodule/lti_module.py
@@ -116,7 +116,7 @@ class LTIModule(LTIFields, XModule):
             launch_presentation_return_url
             lti_message_type
             lti_version
-            role
+            roles
             *+ all custom parameters*
 
         These parameters should be encoded and signed by *OAuth1* together with


### PR DESCRIPTION
This is only a correction in the documentation
