### PR TITLE
prevent the LMS/CMS from being renderable in an iframe

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -193,7 +193,12 @@ MIDDLEWARE_CLASSES = (
 
     # for expiring inactive sessions
     'session_inactivity_timeout.middleware.SessionInactivityTimeout',
+
+    # use Django built in clickjacking protection
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
 )
+
+X_FRAME_OPTIONS = 'DENY'
 
 ############# XBlock Configuration ##########
 

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -198,8 +198,6 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 )
 
-X_FRAME_OPTIONS = 'DENY'
-
 ############# XBlock Configuration ##########
 
 # This should be moved into an XBlock Runtime/Application object

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -729,8 +729,6 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 )
 
-X_FRAME_OPTIONS = 'DENY'
-
 ############################### Pipeline #######################################
 
 STATICFILES_STORAGE = 'pipeline.storage.PipelineCachedStorage'

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -724,7 +724,12 @@ MIDDLEWARE_CLASSES = (
 
     # for expiring inactive sessions
     'session_inactivity_timeout.middleware.SessionInactivityTimeout',
+
+    # use Django built in clickjacking protection
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
 )
+
+X_FRAME_OPTIONS = 'DENY'
 
 ############################### Pipeline #######################################
 


### PR DESCRIPTION
@dianakhuang @ormsbee not sure who to ask here

I can't think of an automated test for this. Basically, this just makes sure that someone can't embed the LMS/CMS in an iframe.
