### PR TITLE
Initial implementation of RestrictAccessMiddleware, to restrict the acce...

### DIFF
--- a/common/djangoapps/restrict_access/middleware.py
+++ b/common/djangoapps/restrict_access/middleware.py
@@ -1,0 +1,104 @@
+"""
+Middleware to restrict access by ip addresses, which is configurable in
+settings.
+
+Usage
+~~~~~
+
+To use, find ``MIDDLEWARE_CLASSES`` in your ``settings.py`` and add:
+
+    MIDDLEWARE_CLASSES = [
+        ...
+        'restrict_access.middleware.RestrictAccessMiddleware',
+        ...
+    ]
+
+
+To enable this feature, set 'RESTRICT_ACCESS_ALLOW' in your settings.py:
+
+  RESTRICT_ACCESS_ALLOW: tuple of ip addresses or networks allowed to access the lms.
+
+NOTE: if there is no 'RESTRICT_ACCESS_ALLOW' in settings, the feature is considered disabled. The
+middleware will allow all requests.
+
+Additionnal settings:
+
+  RESTRICT_ACCESS_DENY: tuple of ip addresses or networks that are excluded from
+  the ALLOW list. The deny rules have priority over the allow rules.
+
+  RESTRICT_ACCESS_REDIRECT_URL: External url used for http redirection when a request is denied.
+
+Examples:
+
+RESTRICT_ACCESS_ALLOW = (
+    '10.0.2.0/24', # network 10.0.2.* is allowed
+    '10.0.3.5'     # single ip address
+    )
+RESTRICT_ACCESS_DENY = (
+    '10.0.2.1/32', # 10.0.2.1 ip is deny
+    )
+RESTRICT_ACCESS_REDIRECT_URL = 'http://code.edx.org/'
+
+"""
+
+from django.http import HttpResponseRedirect, HttpResponseForbidden
+from django.conf import settings
+import ipaddr
+
+class RestrictAccessMiddleware(object):
+    """
+    Middleware class to control the access by ip addresses.
+    """
+
+    def process_request(self, request):
+
+        # authenticated users are allowed
+        if hasattr(request, "user") and request.user.is_authenticated():
+            return
+
+        allow = getattr(settings, "RESTRICT_ACCESS_ALLOW", None)
+
+        # enabled?
+        if allow:
+
+            deny = getattr(settings, "RESTRICT_ACCESS_DENY", None)
+
+            # read the ip addresses/networks settings
+            try:
+                request_addr = ipaddr.IPAddress(request.META['REMOTE_ADDR'])
+                networks_allowed = [ipaddr.IPNetwork(network) for network in allow]
+                if deny:
+                    networks_denied = [ipaddr.IPNetwork(network) for network in deny]
+            except ValueError:
+                # default policy is forbidden if we can't get the request ip
+                # or the settings are invalid (ie. bad ip address or network)
+                return self.deny_request()
+
+            # default policy is denied
+            request_is_allowed = False
+
+            # loop through the settings to check if the request is allowed
+            for network_allowed in networks_allowed:
+                if network_allowed.Contains(request_addr):
+                    request_is_allowed = True
+                    if deny:
+                        for network_denied in networks_denied:
+                            if network_denied.Contains(request_addr):
+                                request_is_allowed = False
+                                break
+                    break
+
+            if not request_is_allowed:
+                return self.deny_request()
+
+
+    def deny_request(self):
+        """
+        Deny the request. If 'RESTRICT_ACCESS_REDIRECT_URL' is defined, redirect to
+        the specified url. Otherwise, return HttpResponseForbidden.
+        """
+        url = getattr(settings, "RESTRICT_ACCESS_REDIRECT_URL", None)
+        if url:
+            return HttpResponseRedirect(url)
+
+        return HttpResponseForbidden('Access Denied')

--- a/common/djangoapps/restrict_access/test.py
+++ b/common/djangoapps/restrict_access/test.py
@@ -1,0 +1,134 @@
+"""Test for restrict access"""
+
+from django.http import HttpResponseRedirect
+
+from django.utils import unittest
+from django.test.utils import override_settings
+from mock import Mock
+
+from restrict_access.middleware import RestrictAccessMiddleware
+
+class RestrictAccessTest(unittest.TestCase):
+    """
+    Test the restrict access middleware
+    """
+
+    def setUp(self):
+        """
+        Create a django test request
+        """
+        self.middleware = RestrictAccessMiddleware()
+        self.request = Mock(
+            META={'REMOTE_ADDR': '10.0.2.2'},
+        )
+
+        # probably not the best way to create an anon request
+        del self.request.user
+
+    @override_settings(RESTRICT_ACCESS_ALLOW=('10.0.2.0/24',))
+    @override_settings(RESTRICT_ACCESS_DENY=('10.0.2.2',))
+    def test_restrict_access_authenticated(self):
+        """
+        Test restrict access with a auth user (automatically allowed).
+        """
+
+        # create a request with an authenticated user
+        request = Mock(
+            META={'REMOTE_ADDR': '10.0.2.2'},
+        )
+
+        self.assertIsNone(self.middleware.process_request(request))
+
+    def test_restrict_access_disabled(self):
+        """
+        Test restrict access disabled
+        """
+
+        self.assertIsNone(self.middleware.process_request(self.request))
+
+    @override_settings(RESTRICT_ACCESS_ALLOW=('',))
+    def test_restrict_access_invalid_allow(self):
+        """
+        Test restrict access with an invalid allow settings
+        """
+
+        self.assertIsNotNone(self.middleware.process_request(self.request))
+
+    @override_settings(RESTRICT_ACCESS_ALLOW=('10.0.2.2',))
+    def test_restrict_access_with_request_ip_allow(self):
+        """
+        Test restrict access with a our request ip address in allow settings
+        """
+
+        self.assertIsNone(self.middleware.process_request(self.request))
+
+    @override_settings(RESTRICT_ACCESS_ALLOW=('192.168.4.4',))
+    def test_restrict_access_with_unknown_ip_allow(self):
+        """
+        Test restrict access with a an unknown ip address in allow settings
+        """
+
+        self.assertIsNotNone(self.middleware.process_request(self.request))
+
+    @override_settings(RESTRICT_ACCESS_DENY=('10.0.2.2',))
+    def test_restrict_access_disabled_with_deny(self):
+        """
+        Test restrict access disabled, but with deny settings
+        """
+
+        self.assertIsNone(self.middleware.process_request(self.request))
+
+    @override_settings(RESTRICT_ACCESS_ALLOW=('10.0.2.2',))
+    @override_settings(RESTRICT_ACCESS_DENY=('10.0.2.2',))
+    def test_restrict_access_with_request_ip_allow_and_deny(self):
+        """
+        Test restrict access with a our request ip address in allow and deny
+        """
+
+        self.assertIsNotNone(self.middleware.process_request(self.request))
+
+    @override_settings(RESTRICT_ACCESS_ALLOW=('10.0.2.2',))
+    @override_settings(RESTRICT_ACCESS_DENY=('',))
+    def test_restrict_access_with_request_ip_allow_and_invalid_deny(self):
+        """
+        Test restrict access with a our request ip address in allow and an invalid deny
+        """
+
+        self.assertIsNotNone(self.middleware.process_request(self.request))
+
+    @override_settings(RESTRICT_ACCESS_ALLOW=('10.0.2.0/32',))
+    def test_restrict_access_with_network_32(self):
+        """
+        Test restrict access with a our request ip address not in the allow network
+        """
+
+        self.assertIsNotNone(self.middleware.process_request(self.request))
+
+    @override_settings(RESTRICT_ACCESS_ALLOW=('10.0.2.0/24',))
+    def test_restrict_access_with_network_24(self):
+        """
+        Test restrict access with a our request ip address in the allow network
+        """
+
+        self.assertIsNone(self.middleware.process_request(self.request))
+
+    @override_settings(RESTRICT_ACCESS_ALLOW=('10.0.2.0/24',))
+    @override_settings(RESTRICT_ACCESS_DENY=('10.0.2.2/32',))
+    def test_restrict_access_with_network_24_with_deny(self):
+        """
+        Test restrict access with a our request ip address include in the allow network, but also in deny.
+        """
+
+        self.assertIsNotNone(self.middleware.process_request(self.request))
+
+    @override_settings(RESTRICT_ACCESS_REDIRECT_URL='http://code.edx.org/')
+    @override_settings(RESTRICT_ACCESS_ALLOW=('10.0.2.0/24',))
+    @override_settings(RESTRICT_ACCESS_DENY=('10.0.2.2/32',))
+    def test_restrict_access_with_network_24_with_deny_and_redirect(self):
+        """
+        Test restrict access with a our request ip address include in the allow network, but also in deny... with a redirect url.
+        """
+
+        self.assertIsInstance(
+            self.middleware.process_request(self.request),
+            HttpResponseRedirect)

--- a/common/djangoapps/restrict_access/test.py
+++ b/common/djangoapps/restrict_access/test.py
@@ -62,6 +62,21 @@ class RestrictAccessTest(unittest.TestCase):
 
         self.assertIsNone(self.middleware.process_request(self.request))
 
+    @override_settings(RESTRICT_ACCESS_ALLOW=('10.0.2.2',))
+    def test_restrict_access_with_request_ip_proxy_allow(self):
+        """
+        Test restrict access with a our request ip address in allow settings,
+        when behing a proxy.
+        """
+
+        # create a request to simulate a deployment behing a proxy
+        request = Mock(
+            META={'REMOTE_ADDR': '10.0.1.1', 'HTTP_X_FORWARDED_FOR': '10.0.2.2'},
+        )
+        del request.user
+
+        self.assertIsNone(self.middleware.process_request(request))
+
     @override_settings(RESTRICT_ACCESS_ALLOW=('192.168.4.4',))
     def test_restrict_access_with_unknown_ip_allow(self):
         """

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -75,6 +75,9 @@ xmltodict==0.4.1
 django-ratelimit-backend==0.6
 unicodecsv==0.9.4
 
+# Used for RestrictAccessMiddleware
+ipaddr==2.1.11
+
 # Used for debugging
 ipython==0.13.1
 


### PR DESCRIPTION
@antoviaque : This is a pull request for the recruitment task: Restrict access to the LMS by IP address.

This pull request adds the ability to restrict the access of the LMS by ip addresses or networks. I've added some documentation in the middleware implementation file. Tests are also implemented.

@jtauber : I've added a package in the requirements: ipaddr (http://code.google.com/p/ipaddr-py/), which is to manage ip addresses and networks. It is licensed under Apache 2. Let me know if there is any issue.

@e0d : A new package has been added in requirements for the middleware: ipaddr (http://code.google.com/p/ipaddr-py/). However, I don't think it needs any system requirement. 

Don't hesitate if you have any question or if there are any modification that I should do.

Best Regards,
Alan
