### PR TITLE
Restricting registration to whitelisted email domains

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1121,6 +1121,16 @@ def create_account(request, post_override=None):
         js['field'] = 'email'
         return JsonResponse(js, status=400)
 
+    if settings.FEATURES.get('RESTRICT_USER_EMAIL_DOMAINS', False):
+        for domain in settings.FEATURES.get('ALLOWED_USER_EMAIL_DOMAINS', []):
+            domain_pattern = r"^{0}$".format(re.escape(domain).replace('\\*', '.+?'))
+            if re.match(domain_pattern, post_vars['email'].split("@")[1]):
+                break
+        else:
+            js['value'] = _("Valid e-mail in an allowed domain is required.").format(field=a)
+            js['field'] = 'email'
+            return JsonResponse(js, status=400)
+
     try:
         validate_slug(post_vars['username'])
     except ValidationError:

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -224,6 +224,14 @@ FEATURES = {
 
     # Toggle embargo functionality
     'EMBARGO': False,
+
+    # Turn on to enable restricting user registraion to e-mails in domains
+    # that are given in ALLOWED_USER_EMAIL_DOMAINS
+    'RESTRICT_USER_EMAIL_DOMAINS': False,
+
+    # The list of domains in which users can have their e-mails.
+    # * can be used as wildcard. By default filled with e-mails used in tests.
+    'ALLOWED_USER_EMAIL_DOMAINS': ["example.com", "*.example.com", "*.edx.org", "bar.com"]
 }
 
 # Used for A/B testing


### PR DESCRIPTION
This pull request modified common.djangoapps.student.create_account to restrict registrations to users which have e-mails in proper domains (those can be wildcarded) only when registering from website and not admin panel, Of course relevant settings are added to lms/env/common.py and tests are written and passing.

This is a recruitment task given by @antoviaque and as per his instructions I'm asking for a review.

Let me know if I can explain, clarify or fix anything.

Cheers, Chris.
