### PR TITLE
Fix typo of release note

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -134,3 +134,4 @@ Avinash Sajjanshetty <avinashsajjan@gmail.com>
 David Glance <david.glance@gmail.com>
 Nimisha Asthagiri <nasthagiri@edx.org>
 Martyn James <mjames@edx.org>
+Xaver Y.R. Chen <yrchen@atcity.org>

--- a/docs/en_us/release_notes/source/02-26-2014.rst
+++ b/docs/en_us/release_notes/source/02-26-2014.rst
@@ -4,7 +4,7 @@ February 26, 2014
 
 You can now access the public edX roadmap_ for details about the currently planned product direction.
 
-.. _roadmap: https://edx-wiki.atlassian.net/wiki/display/OPENPROD/OpenEdX+Public+Product+Roadmap
+.. _roadmap: https://edx-wiki.atlassian.net/wiki/display/OPENPROD/Open+EdX+Public+Product+Roadmap
 
 
 Course staff documentation, *Building a Course with edX Studio*, is available online_. You can also download the guide as a PDF from the edX Studio user interface.


### PR DESCRIPTION
The original URL of roadmap has a typo. This PR just fixed it.
