### PR TITLE
Show a success button at the top of the Progress page

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -243,6 +243,10 @@ FEATURES = {
 
     # Turn off Advanced Security by default
     'ADVANCED_SECURITY': False,
+
+    # Show a "Download your certificate" on the Progress page if the lowest
+    # nonzero grade cutoff is met
+    'SHOW_PROGRESS_SUCCESS_BUTTON': False,
 }
 
 # Used for A/B testing
@@ -1282,6 +1286,11 @@ GRADES_DOWNLOAD = {
     'BUCKET': 'edx-grades',
     'ROOT_PATH': '/tmp/edx-s3/grades',
 }
+
+######################## PROGRESS SUCCESS BUTTON ##############################
+# The course id will be appended to the following url
+PROGRESS_SUCCESS_BUTTON_URL = 'http://<domain>/<path>/'
+PROGRESS_SUCCESS_BUTTON_TEXT = "Download your certificate"
 
 #### PASSWORD POLICY SETTINGS #####
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1288,9 +1288,9 @@ GRADES_DOWNLOAD = {
 }
 
 ######################## PROGRESS SUCCESS BUTTON ##############################
-# The course id will be appended to the following url
-PROGRESS_SUCCESS_BUTTON_URL = 'http://<domain>/<path>/'
-PROGRESS_SUCCESS_BUTTON_TEXT = "Download your certificate"
+# The following fields are available in the URL: {course_id} {student_id}
+PROGRESS_SUCCESS_BUTTON_URL = 'http://<domain>/<path>/{course_id}'
+PROGRESS_SUCCESS_BUTTON_TEXT_OVERRIDE = None
 
 #### PASSWORD POLICY SETTINGS #####
 

--- a/lms/static/sass/course/_profile.scss
+++ b/lms/static/sass/course/_profile.scss
@@ -148,6 +148,24 @@
       }
     }
 
+    #course-success {
+      margin-bottom: 30px;
+      text-align: center;
+      > a {
+        @include button(simple, $button-color);
+        @include box-sizing(border-box);
+        border-radius: 3px;
+        font: normal 15px/1.6rem $sans-serif;
+        letter-spacing: 0;
+        padding: 5px 18px 6px;
+        text-align: center;
+
+        &:hover, &:focus {
+          text-decoration: none;
+        }
+      }
+    }
+
     #grade-detail-graph {
       min-height: 400px;
       width: 100%;

--- a/lms/templates/courseware/progress.html
+++ b/lms/templates/courseware/progress.html
@@ -48,6 +48,20 @@ from django.conf import settings
         <h1>${_("Course Progress for Student '{username}' ({email})").format(username=student.username, email=student.email)}</h1>
       </header>
 
+      %if settings.FEATURES['SHOW_PROGRESS_SUCCESS_BUTTON']:
+        <%
+          nonzero_cutoffs = [cutoff for cutoff in course.grade_cutoffs.values() if cutoff > 0]
+          success_cutoff = min(nonzero_cutoffs) if nonzero_cutoffs else None
+        %>
+        %if success_cutoff and grade_summary['percent'] > success_cutoff:
+          <div id="course-success">
+            <a href="${settings.PROGRESS_SUCCESS_BUTTON_URL}${course.id}">
+              ${settings.PROGRESS_SUCCESS_BUTTON_TEXT}
+            </a>
+          </div>
+        %endif
+      %endif
+
       %if not course.disable_progress_graph:
         <div id="grade-detail-graph" aria-hidden="true"></div>
       %endif

--- a/lms/templates/courseware/progress.html
+++ b/lms/templates/courseware/progress.html
@@ -48,15 +48,17 @@ from django.conf import settings
         <h1>${_("Course Progress for Student '{username}' ({email})").format(username=student.username, email=student.email)}</h1>
       </header>
 
-      %if settings.FEATURES['SHOW_PROGRESS_SUCCESS_BUTTON']:
+      %if settings.FEATURES.get("SHOW_PROGRESS_SUCCESS_BUTTON"):
         <%
+          SUCCESS_BUTTON_URL = settings.PROGRESS_SUCCESS_BUTTON_URL.format(
+            course_id=course.id, student_id=student.id)
           nonzero_cutoffs = [cutoff for cutoff in course.grade_cutoffs.values() if cutoff > 0]
           success_cutoff = min(nonzero_cutoffs) if nonzero_cutoffs else None
         %>
         %if success_cutoff and grade_summary['percent'] > success_cutoff:
           <div id="course-success">
-            <a href="${settings.PROGRESS_SUCCESS_BUTTON_URL}${course.id}">
-              ${settings.PROGRESS_SUCCESS_BUTTON_TEXT}
+            <a href="${SUCCESS_BUTTON_URL}">
+              ${settings.PROGRESS_SUCCESS_BUTTON_TEXT_OVERRIDE or _("Download your certificate")}
             </a>
           </div>
         %endif


### PR DESCRIPTION
### Add SHOW_PROGRESS_SUCCESS_BUTTON feature

This will show a button at the top of `lms/templates/courseware/progress.html` if the lowest nonzero grade cutoff has been reached.

Introduce two settings:
- `PROGRESS_SUCCESS_BUTTON_URL` is the href of that button (the course id is appended)
- `PROGRESS_SUCCESS_BUTTON_TEXT` is the text, defaults to "_Download your certificate_"

The change is pretty minimal. However, feedback on settings naming/placement and testing would be welcome.

_This is a test task for recruiting purposes_ - @antoviaque
