### PR TITLE
Increases precision of percentages shown in 'Total' bar on progress page

### DIFF
--- a/common/lib/xmodule/xmodule/graders.py
+++ b/common/lib/xmodule/xmodule/graders.py
@@ -183,7 +183,7 @@ class WeightedSubsectionsGrader(CourseGrader):
             subgrade_result = subgrader.grade(grade_sheet, generate_random_scores)
 
             weighted_percent = subgrade_result['percent'] * weight
-            section_detail = u"{0} = {1:.1%} of a possible {2:.0%}".format(category, weighted_percent, weight)
+            section_detail = u"{0} = {1:.2%} of a possible {2:.2%}".format(category, weighted_percent, weight)
 
             total_percent += weighted_percent
             section_breakdown += subgrade_result['section_breakdown']


### PR DESCRIPTION
The percentages shown currently can be confusing. For example, if the true weight
of a category is 0.76925% and the student scores 100% in it, they will see '0.8%
out of a possible 1.0%'. Increasing the precision to 2 decimal places changes it
to '0.77% of a possible 0.77%'.

LMS-2205
