### PR TITLE
Add more tests for the container page

### DIFF
--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -306,7 +306,7 @@ def container_handler(request, tag=None, package_id=None, branch=None, version_g
     if 'text/html' in request.META.get('HTTP_ACCEPT', 'text/html'):
         locator = BlockUsageLocator(package_id=package_id, branch=branch, version_guid=version_guid, block_id=block)
         try:
-            old_location, course, xblock, __ = _get_item_in_course(request, locator)
+            __, course, xblock, __ = _get_item_in_course(request, locator)
         except ItemNotFoundError:
             return HttpResponseBadRequest()
 

--- a/cms/djangoapps/contentstore/views/tests/test_helpers.py
+++ b/cms/djangoapps/contentstore/views/tests/test_helpers.py
@@ -12,24 +12,30 @@ class HelpersTestCase(CourseTestCase):
     Unit tests for helpers.py.
     """
     def test_xblock_studio_url(self):
+        course = self.course
+
         # Verify course URL
-        self.assertEqual(xblock_studio_url(self.course),
+        self.assertEqual(xblock_studio_url(course),
                          u'/course/MITx.999.Robot_Super_Course/branch/published/block/Robot_Super_Course')
 
         # Verify chapter URL
         chapter = ItemFactory.create(parent_location=self.course.location, category='chapter',
                                      display_name="Week 1")
         self.assertIsNone(xblock_studio_url(chapter))
+        self.assertIsNone(xblock_studio_url(chapter, course))
 
         # Verify lesson URL
         sequential = ItemFactory.create(parent_location=chapter.location, category='sequential',
                                         display_name="Lesson 1")
         self.assertIsNone(xblock_studio_url(sequential))
+        self.assertIsNone(xblock_studio_url(sequential, course))
 
         # Verify vertical URL
         vertical = ItemFactory.create(parent_location=sequential.location, category='vertical',
                                       display_name='Unit')
         self.assertEqual(xblock_studio_url(vertical),
+                         u'/unit/MITx.999.Robot_Super_Course/branch/published/block/Unit')
+        self.assertEqual(xblock_studio_url(vertical, course),
                          u'/unit/MITx.999.Robot_Super_Course/branch/published/block/Unit')
 
         # Verify child vertical URL
@@ -37,8 +43,11 @@ class HelpersTestCase(CourseTestCase):
                                             display_name='Child Vertical')
         self.assertEqual(xblock_studio_url(child_vertical),
                          u'/container/MITx.999.Robot_Super_Course/branch/published/block/Child_Vertical')
+        self.assertEqual(xblock_studio_url(child_vertical, course),
+                         u'/container/MITx.999.Robot_Super_Course/branch/published/block/Child_Vertical')
 
         # Verify video URL
         video = ItemFactory.create(parent_location=child_vertical.location, category="video",
                                    display_name="My Video")
         self.assertIsNone(xblock_studio_url(video))
+        self.assertIsNone(xblock_studio_url(video, course))

--- a/cms/static/sass/views/_unit.scss
+++ b/cms/static/sass/views/_unit.scss
@@ -1399,7 +1399,7 @@ body.unit .xblock-type-container {
 // UI: special case discussion, HTML xmodule styling
 
 body.unit .component {
-  .xmodule_DiscussionModule, .xmodule_HtmlModule {
+  .xmodule_DiscussionModule, .xmodule_HtmlModule, .xblock {
     margin-top: ($baseline*1.5);
   }
 }

--- a/common/test/acceptance/pages/xblock/acid.py
+++ b/common/test/acceptance/pages/xblock/acid.py
@@ -34,6 +34,13 @@ class AcidView(PageObject):
         selector = '{} .acid-block {} .pass'.format(self.context_selector, test_selector)
         return bool(self.q(css=selector).execute(try_interval=0.1, timeout=3))
 
+    def child_test_passed(self, test_selector):
+        """
+        Return whether a particular :class:`.AcidParentBlock` test passed.
+        """
+        selector = '{} .acid-parent-block {} .pass'.format(self.context_selector, test_selector)
+        return bool(self.q(css=selector).execute(try_interval=0.1, timeout=3))
+
     @property
     def init_fn_passed(self):
         """
@@ -47,8 +54,8 @@ class AcidView(PageObject):
         Whether the tests of children passed
         """
         return all([
-            self.test_passed('.child-counts-match'),
-            self.test_passed('.child-values-match')
+            self.child_test_passed('.child-counts-match'),
+            self.child_test_passed('.child-values-match')
         ])
 
     @property

--- a/common/test/acceptance/tests/test_lms.py
+++ b/common/test/acceptance/tests/test_lms.py
@@ -359,6 +359,19 @@ class XBlockAcidBase(UniqueCourseTest):
         self.course_info_page = CourseInfoPage(self.browser, self.course_id)
         self.tab_nav = TabNavPage(self.browser)
 
+
+    def validate_acid_block_view(self, acid_block):
+        """
+        Verify that the LMS view for the Acid Block is correct
+        """
+        self.assertTrue(acid_block.init_fn_passed)
+        self.assertTrue(acid_block.resource_url_passed)
+        self.assertTrue(acid_block.scope_passed('user_state'))
+        self.assertTrue(acid_block.scope_passed('user_state_summary'))
+        self.assertTrue(acid_block.scope_passed('preferences'))
+        self.assertTrue(acid_block.scope_passed('user_info'))
+
+
     def test_acid_block(self):
         """
         Verify that all expected acid block tests pass in the lms.
@@ -368,13 +381,7 @@ class XBlockAcidBase(UniqueCourseTest):
         self.tab_nav.go_to_tab('Courseware')
 
         acid_block = AcidView(self.browser, '.xblock-student_view[data-block-type=acid]')
-        self.assertTrue(acid_block.init_fn_passed)
-        self.assertTrue(acid_block.child_tests_passed)
-        self.assertTrue(acid_block.resource_url_passed)
-        self.assertTrue(acid_block.scope_passed('user_state'))
-        self.assertTrue(acid_block.scope_passed('user_state_summary'))
-        self.assertTrue(acid_block.scope_passed('preferences'))
-        self.assertTrue(acid_block.scope_passed('user_info'))
+        self.validate_acid_block_view(acid_block)
 
 
 class XBlockAcidNoChildTest(XBlockAcidBase):
@@ -420,7 +427,7 @@ class XBlockAcidChildTest(XBlockAcidBase):
             XBlockFixtureDesc('chapter', 'Test Section').add_children(
                 XBlockFixtureDesc('sequential', 'Test Subsection').add_children(
                     XBlockFixtureDesc('vertical', 'Test Unit').add_children(
-                        XBlockFixtureDesc('acid', 'Acid Block').add_children(
+                        XBlockFixtureDesc('acid_parent', 'Acid Parent Block').add_children(
                             XBlockFixtureDesc('acid', 'First Acid Child', metadata={'name': 'first'}),
                             XBlockFixtureDesc('acid', 'Second Acid Child', metadata={'name': 'second'}),
                             XBlockFixtureDesc('html', 'Html Child', data="<html>Contents</html>"),
@@ -429,6 +436,10 @@ class XBlockAcidChildTest(XBlockAcidBase):
                 )
             )
         ).install()
+
+    def validate_acid_block_view(self, acid_block):
+        super(XBlockAcidChildTest, self).validate_acid_block_view()
+        self.assertTrue(acid_block.child_tests_passed)
 
     # This will fail until we fix support of children in pure XBlocks
     @expectedFailure

--- a/common/test/acceptance/tests/test_studio.py
+++ b/common/test/acceptance/tests/test_studio.py
@@ -147,6 +147,17 @@ class XBlockAcidBase(WebAppTest):
 
         self.auth_page.visit()
 
+    def validate_acid_block_preview(self, acid_block):
+        """
+        Validate the Acid Block's preview
+        """
+        self.assertTrue(acid_block.init_fn_passed)
+        self.assertTrue(acid_block.resource_url_passed)
+        self.assertTrue(acid_block.scope_passed('user_state'))
+        self.assertTrue(acid_block.scope_passed('user_state_summary'))
+        self.assertTrue(acid_block.scope_passed('preferences'))
+        self.assertTrue(acid_block.scope_passed('user_info'))
+
     def test_acid_block_preview(self):
         """
         Verify that all expected acid block tests pass in studio preview
@@ -155,22 +166,13 @@ class XBlockAcidBase(WebAppTest):
         self.outline.visit()
         subsection = self.outline.section('Test Section').subsection('Test Subsection')
         unit = subsection.toggle_expand().unit('Test Unit').go_to()
-        container = unit.components[0].go_to_container()
 
-        acid_block = AcidView(self.browser, container.xblocks[0].preview_selector)
-        self.assertTrue(acid_block.init_fn_passed)
-        self.assertTrue(acid_block.child_tests_passed)
-        self.assertTrue(acid_block.resource_url_passed)
-        self.assertTrue(acid_block.scope_passed('user_state'))
-        self.assertTrue(acid_block.scope_passed('user_state_summary'))
-        self.assertTrue(acid_block.scope_passed('preferences'))
-        self.assertTrue(acid_block.scope_passed('user_info'))
+        acid_block = AcidView(self.browser, unit.components[0].preview_selector)
+        self.validate_acid_block_preview(acid_block)
 
-    # This will fail until we support editing on the container page
-    @expectedFailure
     def test_acid_block_editor(self):
         """
-        Verify that all expected acid block tests pass in studio preview
+        Verify that all expected acid block tests pass in studio editor
         """
 
         self.outline.visit()
@@ -181,7 +183,6 @@ class XBlockAcidBase(WebAppTest):
 
         acid_block = AcidView(self.browser, unit.components[0].edit().editor_selector)
         self.assertTrue(acid_block.init_fn_passed)
-        self.assertTrue(acid_block.child_tests_passed)
         self.assertTrue(acid_block.resource_url_passed)
         self.assertTrue(acid_block.scope_passed('content'))
         self.assertTrue(acid_block.scope_passed('settings'))
@@ -213,7 +214,36 @@ class XBlockAcidNoChildTest(XBlockAcidBase):
         ).install()
 
 
-class XBlockAcidChildTest(XBlockAcidBase):
+class XBlockAcidParentBase(XBlockAcidBase):
+    """
+    Base class for tests that verify that parent XBlock integration is working correctly
+    """
+    __test__ = False
+
+    def validate_acid_block_preview(self, acid_block):
+        super(XBlockAcidParentBase, self).validate_acid_block_preview(acid_block)
+        self.assertTrue(acid_block.child_tests_passed)
+
+    def test_acid_block_preview(self):
+        """
+        Verify that all expected acid block tests pass in studio preview
+        """
+
+        self.outline.visit()
+        subsection = self.outline.section('Test Section').subsection('Test Subsection')
+        unit = subsection.toggle_expand().unit('Test Unit').go_to()
+        container = unit.components[0].go_to_container()
+
+        acid_block = AcidView(self.browser, container.xblocks[0].preview_selector)
+        self.validate_acid_block_preview(acid_block)
+
+    # This will fail until the container page supports editing
+    @expectedFailure
+    def test_acid_block_editor(self):
+        super(XBlockAcidParentBase, self).test_acid_block_editor()
+
+
+class XBlockAcidEmptyParentTest(XBlockAcidParentBase):
     """
     Tests of an AcidBlock with children
     """
@@ -232,7 +262,34 @@ class XBlockAcidChildTest(XBlockAcidBase):
             XBlockFixtureDesc('chapter', 'Test Section').add_children(
                 XBlockFixtureDesc('sequential', 'Test Subsection').add_children(
                     XBlockFixtureDesc('vertical', 'Test Unit').add_children(
-                        XBlockFixtureDesc('acid', 'Acid Block').add_children(
+                        XBlockFixtureDesc('acid_parent', 'Acid Parent Block').add_children(
+                        )
+                    )
+                )
+            )
+        ).install()
+
+
+class XBlockAcidChildTest(XBlockAcidParentBase):
+    """
+    Tests of an AcidBlock with children
+    """
+    __test__ = True
+
+    def setup_fixtures(self):
+
+        course_fix = CourseFixture(
+            self.course_info['org'],
+            self.course_info['number'],
+            self.course_info['run'],
+            self.course_info['display_name']
+        )
+
+        course_fix.add_children(
+            XBlockFixtureDesc('chapter', 'Test Section').add_children(
+                XBlockFixtureDesc('sequential', 'Test Subsection').add_children(
+                    XBlockFixtureDesc('vertical', 'Test Unit').add_children(
+                        XBlockFixtureDesc('acid_parent', 'Acid Parent Block').add_children(
                             XBlockFixtureDesc('acid', 'First Acid Child', metadata={'name': 'first'}),
                             XBlockFixtureDesc('acid', 'Second Acid Child', metadata={'name': 'second'}),
                             XBlockFixtureDesc('html', 'Html Child', data="<html>Contents</html>"),

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -25,4 +25,4 @@
 -e git+https://github.com/edx/event-tracking.git@f0211d702d#egg=event-tracking
 -e git+https://github.com/edx/bok-choy.git@62de7b576a08f36cde5b030c52bccb1a2f3f8df1#egg=bok_choy
 -e git+https://github.com/edx-solutions/django-splash.git@9965a53c269666a30bb4e2b3f6037c138aef2a55#egg=django-splash
--e git+https://github.com/edx/acid-block.git@bf61f0fcd5916a9236bb5681c98374a48a13a74c#egg=acid-xblock
+-e git+https://github.com/edx/acid-block.git@459aff7b63db8f2c5decd1755706c1a64fb4ebb1#egg=acid-xblock


### PR DESCRIPTION
I've added a few more tests for the container page:
- added tests for `get_studio_url` when passing a course parameter
- added new Bok Choy tests for Acid XBlock that test container and non-container versions

I've also added a styling fix from Marco that gives XBlocks the appropriate spacing in Studio.

@cahrens @cpennington please review.
