### PR TITLE
Ignore extra fields while parsing video_xml

### DIFF
--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -765,7 +765,7 @@ class VideoDescriptor(VideoFields, TabsEditingDescriptor, EmptyDataRawDescriptor
                 else:
                 # We export values with json.dumps (well, except for Strings, but
                 # for about a month we did it for Strings also).
-                    if hasattr(cls, attr) is False:
+                    if attr not in cls.fields:
                         # Don't set attributes which are not in VideoDescriptor
                         continue
                     value = deserialize_field(cls.fields[attr], value)

--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -758,6 +758,11 @@ class VideoDescriptor(VideoFields, TabsEditingDescriptor, EmptyDataRawDescriptor
                     # If the user has specified html5 sources, make sure we don't use the default video
                     if youtube_id != '' or 'html5_sources' in field_data:
                         field_data['youtube_id_{0}'.format(normalized_speed.replace('.', '_'))] = youtube_id
+            elif attr not in cls.fields:
+                # Don't set attributes which are not in VideoDescriptor
+                # Note: This is a workaround. Export should be patched so that it does not include
+                # fields not in cls.fields"
+                continue
             else:
                 #  Convert XML attrs into Python values.
                 if attr in conversions:
@@ -765,9 +770,6 @@ class VideoDescriptor(VideoFields, TabsEditingDescriptor, EmptyDataRawDescriptor
                 else:
                 # We export values with json.dumps (well, except for Strings, but
                 # for about a month we did it for Strings also).
-                    if attr not in cls.fields:
-                        # Don't set attributes which are not in VideoDescriptor
-                        continue
                     value = deserialize_field(cls.fields[attr], value)
                 field_data[attr] = value
 

--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -765,6 +765,9 @@ class VideoDescriptor(VideoFields, TabsEditingDescriptor, EmptyDataRawDescriptor
                 else:
                 # We export values with json.dumps (well, except for Strings, but
                 # for about a month we did it for Strings also).
+                    if hasattr(cls, attr) is False:
+                        # Don't set attributes which are not in VideoDescriptor
+                        continue
                     value = deserialize_field(cls.fields[attr], value)
                 field_data[attr] = value
 


### PR DESCRIPTION
STUD-1361
@waheedahmed @symbolist @adampalay 
Ignore extra fields other than VideoDescriptor have while parsing video_xml so that video component creates successfully.
