### PR TITLE
Save language preference on account creation

### DIFF
--- a/common/djangoapps/student/tests/test_create_account.py
+++ b/common/djangoapps/student/tests/test_create_account.py
@@ -1,0 +1,43 @@
+"Tests for account creation"
+
+import ddt
+from django.contrib.auth.models import User
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+from django.test.utils import override_settings
+import mock
+
+from user_api.models import UserPreference
+from lang_pref import LANGUAGE_KEY
+
+
+@ddt.ddt
+class TestCreateAccount(TestCase):
+    "Tests for account creation"
+
+    def setUp(self):
+        self.username = "test_user"
+        self.url = reverse("create_account")
+        self.params = {
+            "username": self.username,
+            "email": "test@example.org",
+            "password": "testpass",
+            "name": "Test User",
+            "honor_code": "true",
+            "terms_of_service": "true",
+        }
+
+    @ddt.data("en", "eo")
+    def test_default_lang_pref_saved(self, lang):
+        with mock.patch("django.conf.settings.LANGUAGE_CODE", lang):
+            response = self.client.post(self.url, self.params)
+            self.assertEqual(response.status_code, 200)
+            user = User.objects.get(username=self.username)
+            self.assertEqual(UserPreference.get_preference(user, LANGUAGE_KEY), lang)
+
+    @ddt.data("en", "eo")
+    def test_header_lang_pref_saved(self, lang):
+        response = self.client.post(self.url, self.params, HTTP_ACCEPT_LANGUAGE=lang)
+        self.assertEqual(response.status_code, 200)
+        user = User.objects.get(username=self.username)
+        self.assertEqual(UserPreference.get_preference(user, LANGUAGE_KEY), lang)

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -27,7 +27,7 @@ from django.http import (HttpResponse, HttpResponseBadRequest, HttpResponseForbi
 from django.shortcuts import redirect
 from django_future.csrf import ensure_csrf_cookie
 from django.utils.http import cookie_date, base36_to_int
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, get_language
 from django.views.decorators.http import require_POST, require_GET
 
 from ratelimitbackend.exceptions import RateLimitException
@@ -1000,6 +1000,9 @@ def _do_create_account(post_vars):
         profile.save()
     except Exception:
         log.exception("UserProfile creation failed for user {id}.".format(id=user.id))
+
+    UserPreference.set_preference(user, LANGUAGE_KEY, get_language())
+
     return (user, profile, registration)
 
 


### PR DESCRIPTION
This is necessary to allow non-browser-based services (e.g. notifier)
to know a user's preferred language even if the user has not explicitly
selected one.

@jimabramson @dianakhuang @flowerhack 
