### PR TITLE
make embargo template theme-able -- Stanford Branch

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -162,7 +162,11 @@ def embargo(_request):
 
     Explains to the user why they are not able to access a particular embargoed course.
     """
-    return render_to_response('static_templates/embargo.html')
+    if settings.FEATURES["USE_CUSTOM_THEME"]:
+        template="static_templates/theme-embargo.html"
+    else:
+        template="static_templates/embargo.html"
+    return render_to_response(template)
 
 
 def press(request):


### PR DESCRIPTION
Use "Stanford-style" theming to enable you to put your own embargo notice up.

I will submit this same change in a separate PR to master.  The change to the Stanford theme has already been committed to master there.  

@caesar2164 -- can you review please?

![screen shot 2014-03-05 at 3 09 43 pm](https://f.cloud.github.com/assets/621565/2340050/64115de0-a4bd-11e3-8e12-95e230867842.png)
