### PR TITLE
make embargo template theme-able

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -33,6 +33,7 @@ from django.views.decorators.http import require_POST, require_GET
 from ratelimitbackend.exceptions import RateLimitException
 
 from edxmako.shortcuts import render_to_response, render_to_string
+from mako.exceptions import TopLevelLookupException
 
 from course_modes.models import CourseMode
 from student.models import (
@@ -147,12 +148,14 @@ def embargo(_request):
     Render the embargo page.
 
     Explains to the user why they are not able to access a particular embargoed course.
+    Tries to use the themed version, but fall back to the default if not found.
     """
-    if settings.FEATURES["USE_CUSTOM_THEME"]:
-        template="static_templates/theme-embargo.html"
-    else:
-        template="static_templates/embargo.html"
-    return render_to_response(template)
+    try:
+        if settings.FEATURES["USE_CUSTOM_THEME"]:
+            return render_to_response("static_templates/theme-embargo.html")
+    except TopLevelLookupException:
+        pass
+    return render_to_response("static_templates/embargo.html")
 
 
 def press(request):

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -148,7 +148,11 @@ def embargo(_request):
 
     Explains to the user why they are not able to access a particular embargoed course.
     """
-    return render_to_response('static_templates/embargo.html')
+    if settings.FEATURES["USE_CUSTOM_THEME"]:
+        template="static_templates/theme-embargo.html"
+    else:
+        template="static_templates/embargo.html"
+    return render_to_response(template)
 
 
 def press(request):


### PR DESCRIPTION
Use "Stanford-style" theming to enable you to put your own embargo notice up.

@flowerhack: this is a tiny change to enable us so put up our own themed embargo message.  We are pulling in the same change to our own instance and deploying tomorrow (see PR #2833).  Indeed you can see what our themed version looks like in the screenshot attached to that PR.

Note that you probably think that this is a pretty ugly way to do theming and overrides.  It is, sorry about that.  When we did our original pass at theming edX, nearly a year ago now (!) we weren't able to get a cleaner way working.  You'd think that you could just use template search precedence so that one template would override the others, but it's complicated by edX using two templating systems, and templates including each other.  This should get cleaned up.  In the meantime, this change is consistent with how we do it elsewhere.

Thanks.
