### PR TITLE
Skip generation of 'eo' files in i18n test suite

### DIFF
--- a/i18n/tests/test_generate.py
+++ b/i18n/tests/test_generate.py
@@ -40,7 +40,8 @@ class TestGenerate(TestCase):
         self.assertTrue(os.path.exists(filename))
         os.remove(filename)
 
-    @patch.object(CONFIGURATION, 'locales', ['eo'])
+    # Patch dummy_locales to not have esperanto present
+    @patch.object(CONFIGURATION, 'dummy_locales', ['fake2'])
     def test_main(self):
         """
         Runs generate.main() which should merge source files,


### PR DESCRIPTION
This PR disables the `test_generate` tests within the `rake i18n:test` suite.

@nedbat or @cpennington -- this is a request from a few engineers, that we don't run the extract, dummy, and generate tasks as part of `rake test`. I agree - I think we should run those tasks as part of Jenkins automation along with transifex pushes and pulls.

Edit: I changed it so we simply skip the generation of `'eo'` files.
