### PR TITLE
Add method to clear mako template lookups

### DIFF
--- a/common/djangoapps/edxmako/__init__.py
+++ b/common/djangoapps/edxmako/__init__.py
@@ -13,4 +13,4 @@
 #   limitations under the License.
 LOOKUP = {}
 
-from .paths import add_lookup, lookup_template
+from .paths import add_lookup, lookup_template, clear_lookups

--- a/common/djangoapps/edxmako/paths.py
+++ b/common/djangoapps/edxmako/paths.py
@@ -22,6 +22,13 @@ class DynamicTemplateLookup(TemplateLookup):
         self.directories.append(os.path.normpath(directory))
 
 
+def clear_lookups(namespace):
+    """
+    Remove mako template lookups for the given namespace.
+    """
+    if namespace in LOOKUP:
+        del LOOKUP[namespace]
+
 def add_lookup(namespace, directory, package=None):
     """
     Adds a new mako template lookup directory to the given namespace.

--- a/common/djangoapps/edxmako/startup.py
+++ b/common/djangoapps/edxmako/startup.py
@@ -2,7 +2,7 @@
 Initialize the mako template lookup
 """
 from django.conf import settings
-from . import add_lookup
+from . import add_lookup, clear_lookups
 
 
 def run():
@@ -14,5 +14,6 @@ def run():
     """
     template_locations = settings.MAKO_TEMPLATES
     for namespace, directories in template_locations.items():
+        clear_lookups(namespace)
         for directory in directories:
             add_lookup(namespace, directory)


### PR DESCRIPTION
Warning: this is a quick and (really) dirty fix.

`edxmako.startup.run()` is called twice: 
- first by `django_startup` (`common/lib/django_startup.py`)
- then by `lms.startup.run()`

When using custom theming, the theme template path is prepended to the `MAKO_TEMPLATES` settings variables in `lms.startup`. Unfortunately, at this point `edxmako.startup.run()` has already been executed so the theme template path will not be at the top of the lookup table (so mako template overrides will never get picked up).

Here’s the really quick fix I came up with, I’m aware that there should be a better way to do this (stop calling `edxmako.startup.run()` in `django_startup`?). I haven’t really had time to delve more into details. Let me know if you can think of a better way to fix this, I’ll update the PR accordingly.
