### PR TITLE
Fix Firefox YouTube default Flash mode

### DIFF
--- a/common/lib/xmodule/xmodule/js/spec/video/video_player_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_player_spec.js
@@ -183,6 +183,25 @@ function (VideoPlayer) {
             });
         });
 
+        describe('onReady YouTube', function () {
+            beforeEach(function () {
+                state = jasmine.initializePlayerYouTube();
+
+                state.videoEl = $('video, iframe');
+            });
+
+            it('multiple speeds and flash mode, change back to html5 mode', function () {
+                var playbackRates = state.videoPlayer.player.getAvailablePlaybackRates();
+
+                state.currentPlayerMode = 'flash';
+
+                state.videoPlayer.onReady();
+
+                expect(playbackRates.length).toBe(4);
+                expect(state.currentPlayerMode).toBe('html5');
+            });
+        });
+
         describe('onStateChange', function () {
             describe('when the video is unstarted', function () {
                 beforeEach(function () {

--- a/common/lib/xmodule/xmodule/js/src/video/03_video_player.js
+++ b/common/lib/xmodule/xmodule/js/src/video/03_video_player.js
@@ -559,7 +559,7 @@ function (HTML5Video, Resizer) {
         );
 
         if (
-            this.currentPlayerMode === 'html5' &&
+            (this.currentPlayerMode === 'html5' || availablePlaybackRates.length > 1) &&
             this.videoType === 'youtube'
         ) {
             if (availablePlaybackRates.length === 1 && !this.isTouch) {
@@ -573,6 +573,8 @@ function (HTML5Video, Resizer) {
 
                 _restartUsingFlash(this);
             } else if (availablePlaybackRates.length > 1) {
+                this.currentPlayerMode = 'html5';
+
                 // We need to synchronize available frame rates with the ones
                 // that the user specified.
 


### PR DESCRIPTION
**Description**

Video speeds .5, 1.50 and 2.0  not available in Firefox

The only video speed available in live courses is 1.0 in Firefox. I was able to reproduce in the following courses when using Firefox. The issue does not occur in Chrome.

https://courses.edx.org/courses/DelftX/AE1110x/1T2014/courseware/669e9115be17498a9fa0cc5cee0cb78f/3ca3d5812aef405a8aaa1f296d4985aa/

https://courses.edx.org/courses/DelftX/AE1110x/1T2014/courseware/669e9115be17498a9fa0cc5cee0cb78f/3ca3d5812aef405a8aaa1f296d4985aa/

**Jira issue**

[BLD-895](https://edx-wiki.atlassian.net/browse/BLD-895)

**Debug information**

In a fresh state, the Firefox browser does not have a cookie stored that tells it to play YouTube videos in HTML5 mode. This cookie can be set on the [YouTube HTML5 page](http://www.youtube.com/html5) by requesting the HTML5 player.

After requesting the HTML5 mode, going back to the edX video, and refreshing the page, we see that the HTML5 player loads, but that there is still 1 speed in the speeds dialog. Why is this happening?

Code flow:
1. Request HTML5 player for YouTube ID.
2. For some reason Flash player loads (even though we specify `html5 = 1` in the `playerVars` settings array).
3. The YouTube API reports that we have only 1 speed available.
4. The codes thinks that we should switch to Flash player because there is only one speed available. This check was put in place back when the Firefox native HTML5 player did not support multiple speeds. Back then it was decided that if the native API reported only one speed, then we should switch back to Flash mode.
5. After switching to Flash mode, the internal variable `currentPlayerMode` is set to `flash`.
6. THE INTERESTING PART! The second time the API loads up, it is magically in HTML5 player mode! However, since the variable `currentPlayerMode` is set to `flash`, the code doesn't know to update the speed menu, even though the API reports us that we have multiple speeds available.

**Solution**

In code, when we query available speeds from the API, if we get back multiple speeds, we disregard the `currentPlayerMode` if it is set to `flash`. We can only be in `html5` mode - Flash doesn't support multiple speeds. In this case, we set `currentPlayerMode` back to `html5`.

**Reviewers**
- @polesye 
