### PR TITLE
`xmodule.x_module` -> `xmodule.modulestore`

### DIFF
--- a/docs/en_us/developers/source/xblocks.rst
+++ b/docs/en_us/developers/source/xblocks.rst
@@ -99,12 +99,12 @@ To enable an XBlock for testing in your devstack (https://github.com/edx/configu
 
     #.  In ``edx-platform/lms/envs/common.py``, uncomment::
 
-        # from xmodule.x_module import prefer_xmodules
+        # from xmodule.modulestore import prefer_xmodules
         # XBLOCK_SELECT_FUNCTION = prefer_xmodules
 
     #.  In ``edx-platform/cms/envs/common.py``, uncomment::
 
-        # from xmodule.x_module import prefer_xmodules
+        # from xmodule.modulestore import prefer_xmodules
         # XBLOCK_SELECT_FUNCTION = prefer_xmodules
 
     #.  In ``edx-platform/cms/envs/common.py``, change::


### PR DESCRIPTION
Changing  `xmodule.x_module` to `xmodule.modulestore`
