### PR TITLE
Make course_id a required arg to split.create_course

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/tests/test_migrate_to_split.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_migrate_to_split.py
@@ -10,7 +10,7 @@ from contentstore.management.commands.migrate_to_split import Command
 from contentstore.tests.modulestore_config import TEST_MODULESTORE
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
-from xmodule.modulestore.django import modulestore, loc_mapper
+from xmodule.modulestore.django import modulestore, loc_mapper, clear_existing_modulestores
 from xmodule.modulestore.locator import CourseLocator
 # pylint: disable=E1101
 
@@ -56,6 +56,8 @@ class TestMigrateToSplit(ModuleStoreTestCase):
         password = 'foo'
         self.user = User.objects.create_user(uname, email, password)
         self.course = CourseFactory()
+        self.addCleanup(ModuleStoreTestCase.drop_mongo_collections, 'split')
+        self.addCleanup(clear_existing_modulestores)
 
     def test_user_email(self):
         call_command(

--- a/common/lib/xmodule/xmodule/modulestore/django.py
+++ b/common/lib/xmodule/xmodule/modulestore/django.py
@@ -184,7 +184,7 @@ def editable_modulestore(name='default'):
 
     # At this point, we either have the ability to create
     # items in the store, or we do not.
-    if hasattr(store, 'create_xmodule'):
+    if hasattr(store, 'create_course'):
         return store
 
     else:

--- a/common/lib/xmodule/xmodule/modulestore/exceptions.py
+++ b/common/lib/xmodule/xmodule/modulestore/exceptions.py
@@ -46,3 +46,16 @@ class VersionConflictError(Exception):
         super(VersionConflictError, self).__init__()
         self.requestedLocation = requestedLocation
         self.currentHeadVersionGuid = currentHeadVersionGuid
+
+
+class DuplicateCourseError(Exception):
+    """
+    An attempt to create a course whose id duplicates an existing course's
+    """
+    def __init__(self, course_id, existing_entry):
+        """
+        existing_entry will have the who, when, and other properties of the existing entry
+        """
+        super(DuplicateCourseError, self).__init__()
+        self.course_id = course_id
+        self.existing_entry = existing_entry

--- a/common/lib/xmodule/xmodule/modulestore/mixed.py
+++ b/common/lib/xmodule/xmodule/modulestore/mixed.py
@@ -282,7 +282,6 @@ class MixedModuleStore(ModuleStoreWriteBase):
         :param fields: a dict of xblock field name - value pairs for the course module.
         :param metadata: the old way of setting fields by knowing which ones are scope.settings v scope.content
         :param definition_data: the complement to metadata which is also a subset of fields
-        :param id_root: the split-mongo course_id starting value (see split.create_course)
         :param pretty_id: a field split.create_course uses and may quit using
         :returns: course xblock
         """
@@ -290,22 +289,19 @@ class MixedModuleStore(ModuleStoreWriteBase):
         if not hasattr(store, 'create_course'):
             raise NotImplementedError(u"Cannot create a course on store %s" % store_name)
         if store.get_modulestore_type(course_id) == SPLIT_MONGO_MODULESTORE_TYPE:
-            id_root = kwargs.get('id_root')
             try:
                 course_dict = Location.parse_course_id(course_id)
                 org = course_dict['org']
-                if id_root is None:
-                    id_root = "{org}.{course}.{name}".format(**course_dict)
+                course_id = "{org}.{course}.{name}".format(**course_dict)
             except ValueError:
                 org = None
-                if id_root is None:
-                    id_root = course_id
+
             org = kwargs.pop('org', org)
-            pretty_id = kwargs.pop('pretty_id', id_root)
+            pretty_id = kwargs.pop('pretty_id', course_id)
             fields = kwargs.pop('fields', {})
             fields.update(kwargs.pop('metadata', {}))
             fields.update(kwargs.pop('definition_data', {}))
-            course = store.create_course(org, pretty_id, user_id, id_root=id_root, fields=fields, **kwargs)
+            course = store.create_course(course_id, org, pretty_id, user_id, fields=fields, **kwargs)
         else:  # assume mongo
             course = store.create_course(course_id, **kwargs)
 

--- a/common/lib/xmodule/xmodule/modulestore/split_migrator.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_migrator.py
@@ -47,8 +47,8 @@ class SplitMigrator(object):
         original_course = self.direct_modulestore.get_item(course_location)
         new_course_root_locator = self.loc_mapper.translate_location(old_course_id, course_location)
         new_course = self.split_modulestore.create_course(
-            course_location.org, original_course.display_name,
-            user.id, id_root=new_package_id,
+            new_package_id, course_location.org, original_course.display_name,
+            user.id,
             fields=self._get_json_fields_translate_children(original_course, old_course_id, True),
             root_block_id=new_course_root_locator.block_id,
             master_branch=new_course_root_locator.branch

--- a/common/lib/xmodule/xmodule/modulestore/tests/django_utils.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/django_utils.py
@@ -209,20 +209,24 @@ class ModuleStoreTestCase(TestCase):
         return updated_course
 
     @staticmethod
-    def drop_mongo_collections():
+    def drop_mongo_collections(store_name='default'):
         """
         If using a Mongo-backed modulestore & contentstore, drop the collections.
         """
 
         # This will return the mongo-backed modulestore
         # even if we're using a mixed modulestore
-        store = editable_modulestore()
+        store = editable_modulestore(store_name)
         if hasattr(store, 'collection'):
             connection = store.collection.database.connection
             store.collection.drop()
             connection.close()
         elif hasattr(store, 'close_all_connections'):
             store.close_all_connections()
+        elif hasattr(store, 'db'):
+            connection = store.db.connection
+            connection.drop_database(store.db.name)
+            connection.close()
 
         if contentstore().fs_files:
             db = contentstore().fs_files.database

--- a/common/lib/xmodule/xmodule/modulestore/tests/persistent_factories.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/persistent_factories.py
@@ -33,15 +33,16 @@ class PersistentCourseFactory(SplitFactory):
 
     # pylint: disable=W0613
     @classmethod
-    def _create(cls, target_class, org='testX', prettyid='999', user_id='test_user',
-                master_branch='draft', id_root=None, **kwargs):
+    def _create(cls, target_class, course_id='testX.999', org='testX', prettyid='999', user_id='test_user',
+                master_branch='draft', **kwargs):
 
         modulestore = kwargs.pop('modulestore')
         root_block_id = kwargs.pop('root_block_id', 'course')
         # Write the data to the mongo datastore
         new_course = modulestore.create_course(
-            org, prettyid, user_id, fields=kwargs, id_root=id_root or prettyid,
-            master_branch=master_branch, root_block_id=root_block_id)
+            course_id, org, prettyid, user_id, fields=kwargs,
+            master_branch=master_branch, root_block_id=root_block_id
+        )
 
         return new_course
 

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_orphan.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_orphan.py
@@ -114,7 +114,7 @@ class TestOrphan(unittest.TestCase):
         fields.update(data)
         # split requires the course to be created separately from creating items
         self.split_mongo.create_course(
-            'test_org', 'my course', self.userid, self.split_package_id, fields=fields, root_block_id='runid'
+            self.split_package_id, 'test_org', 'my course', self.userid, fields=fields, root_block_id='runid'
         )
         self.course_location = Location('i4x', 'test_org', 'test_course', 'course', 'runid')
         self.old_mongo.create_and_save_xmodule(self.course_location, data, metadata)


### PR DESCRIPTION
and remove code which made it unique. Instead raise exception on dupe.
STUD-1359

I added a bunch of calls to dropping the dbs and closing connections too. (was getting duplicate course errors as db contents bled over from one test to another)

@singingwolfboy @andy-armstrong Please review. This builds on and will conflict w/ https://github.com/edx/edx-platform/pull/2842 (conflict b/c it touches same lines)
