### PR TITLE
(WIP) initial experiment for enabling accordion control for lms navigation.

### DIFF
--- a/lms/static/coffee/fixtures/accordion.html
+++ b/lms/static/coffee/fixtures/accordion.html
@@ -1,6 +1,6 @@
 <div class="course-wrapper">
   <header id="open_close_accordion">
-    <a href="#">close</a>
+    <a href="#"><span class="sr">collapse navigation sidebar</span></a>
   </header>
   <div id="accordion"></div>
 </div>

--- a/lms/static/sass/course/base/_extends.scss
+++ b/lms/static/sass/course/base/_extends.scss
@@ -141,17 +141,13 @@ h1.top-header {
     position: relative;
 
     a {
-      background: #f6f6f6 url('../images/slide-left-icon.png') center center no-repeat;
-      border: 1px solid #D3D3D3;
-      border-radius: 3px 0 0 3px;
-      height: 16px;
-      padding: 6px;
-      position: absolute;
-      right: -1px;
-      text-indent: -9999px;
-      top: 12px;
-      width: 16px;
       z-index: 99;
+      display: block;
+      padding: 6px;
+      height: 24px;
+      border-top-left-radius: 5px;
+      border-bottom: 1px solid $light-gray;
+      background: #efefef url('../images/slide-left-icon.png') center center no-repeat;
 
       &:hover, &:focus {
         background-color: white;

--- a/lms/static/sass/course/courseware/_sidebar.scss
+++ b/lms/static/sass/course/courseware/_sidebar.scss
@@ -5,7 +5,7 @@
   border-right: 1px solid $border-color-2;
 
   #open_close_accordion {
-    display: none;
+    display: block;
   }
 
   header {

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -190,7 +190,7 @@ ${fragment.foot_html()}
 % if accordion:
     <div class="course-index" role="navigation">
       <header id="open_close_accordion">
-        <a href="#">${_("close")}</a>
+       <a href="#"><span class="sr">${_("collapse navigation sidebar")}</span></a>
       </header>
 
       <div id="accordion" style="display: none">

--- a/lms/templates/staticbook.html
+++ b/lms/templates/staticbook.html
@@ -72,7 +72,7 @@ $("#open_close_accordion a").click(function(){
 
     <section aria-label="${_('Textbook Navigation')}" class="book-sidebar">
       <header id="open_close_accordion">
-        <a href="#">close</a>
+        <a href="#"><span class="sr">collapse navigation sidebar</span></a>
       </header>
 
       <ul id="booknav" class="treeview-booknav">


### PR DESCRIPTION
Initial changes to enabling the navigation accordion control, presuming no configuration or settings necessary to merge this into the platform for now. 

1.) IN PROGRESS - Expose collapsible navigation control
2.) Add in breadcrumb navigation above Unit page sequential allowing for clearer presence/location especially if user has navigation collapsed.
3.) When user clicks subsection in navigation sidebar, default (eventually) to collapsing sidebar once breadcrumb is in place. 
4.) Visual cleanup to existing sequential bar and iconography used for accordion controls.

https://www.dropbox.com/s/oihhfxcan6qwe3e/Screenshot%202014-03-07%2005.17.15.png

via Hackathon 6. https://github.com/edx/edx-platform/wiki/Hackathon-Six%3A-New-Digs
