### PR TITLE
fix capa textline to properly use inline if specified when using math preprocessor

### DIFF
--- a/common/lib/capa/capa/templates/textline.html
+++ b/common/lib/capa/capa/templates/textline.html
@@ -3,7 +3,7 @@
 <section id="inputtype_${id}" class="${'text-input-dynamath' if do_math else ''} capa_inputtype ${doinline} textline" >
 
     % if preprocessor is not None:
-    <div class="text-input-dynamath_data" data-preprocessor="${preprocessor['class_name']}"/>
+    <div class="text-input-dynamath_data ${doinline}" data-preprocessor="${preprocessor['class_name']}"/>
     <div class="script_placeholder" data-src="${preprocessor['script_src']}"/>
     % endif
 

--- a/common/lib/capa/capa/tests/test_input_templates.py
+++ b/common/lib/capa/capa/tests/test_input_templates.py
@@ -431,7 +431,7 @@ class TextlineTemplateTest(TemplateTestCase):
                                         'script_src': 'test_script'}
         xml = self.render_to_xml(self.context)
 
-        xpath = "//div[@class='text-input-dynamath_data' and @data-preprocessor='test_class']"
+        xpath = "//div[@class='text-input-dynamath_data ' and @data-preprocessor='test_class']"
         self.assert_has_xpath(xml, xpath, self.context)
 
         xpath = "//div[@class='script_placeholder' and @data-src='test_script']"

--- a/common/lib/capa/capa/tests/test_input_templates.py
+++ b/common/lib/capa/capa/tests/test_input_templates.py
@@ -431,10 +431,19 @@ class TextlineTemplateTest(TemplateTestCase):
                                         'script_src': 'test_script'}
         xml = self.render_to_xml(self.context)
 
-        xpath = "//div[@class='text-input-dynamath_data ' and @data-preprocessor='test_class']"
+        xpath = "//div[contains(@class, 'text-input-dynamath_data') and @data-preprocessor='test_class']"
         self.assert_has_xpath(xml, xpath, self.context)
 
         xpath = "//div[@class='script_placeholder' and @data-src='test_script']"
+        self.assert_has_xpath(xml, xpath, self.context)
+
+    def test_do_inline_and_preprocessor(self):
+        self.context['preprocessor'] = {'class_name': 'test_class',
+                                        'script_src': 'test_script'}
+        self.context['inline'] = True
+        xml = self.render_to_xml(self.context)
+
+        xpath = "//div[contains(@class, 'text-input-dynamath_data inline') and @data-preprocessor='test_class']"
         self.assert_has_xpath(xml, xpath, self.context)
 
     def test_do_inline(self):


### PR DESCRIPTION
When using the dynamic math javascript preprocessor feature, textline does not honor the "inline" flag, because of a div which is fixed to be `display:block`. 

This PR fixes that bug, using the same approach as previously employed (https://github.com/edx/edx-platform/pull/845).

1 line, 12 character fix.

@chrisndodge ?
