### PR TITLE
fix capa textline display to leave "inline" alone upon status change

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/capa/display.coffee
+++ b/common/lib/xmodule/xmodule/js/src/capa/display.coffee
@@ -444,7 +444,7 @@ class @Problem
         $p = $(element).find('p.status')
         `// Translators: the word unanswered here is about answering a problem the student must solve.`
         $p.text gettext("unanswered")
-        $p.parent().removeClass().addClass "unanswered"
+        $p.parent().removeClass("correct incorrect").addClass "unanswered"
 
   inputtypeSetupMethods:
 


### PR DESCRIPTION
When a user starts entering something into a capa textline input element, the status is changed from whatever it was before to being "unanswered".  If the textline was an inline display element, this property was improperly erased, destroying the formatting of problems where textline inputs are carefully placed to be inline, whenever users begin input.

This PR fixes that error by erasing only the two relevant class attributes (see https://github.com/edx/edx-platform/blob/master/common/lib/capa/capa/templates/textline.html#L11), instead of removing all class attributes.    

one line change in `display.coffee`, 19 characters.

@chrisndodge ?
