### PR TITLE
Fix split_test xblock so that it can render in Studio

### DIFF
--- a/cms/djangoapps/contentstore/features/component.py
+++ b/cms/djangoapps/contentstore/features/component.py
@@ -48,7 +48,7 @@ def add_a_multi_step_component(step, is_advanced, category):
 def see_a_multi_step_component(step, category):
 
     # Wait for all components to finish rendering
-    selector = 'li.component div.xblock-student_view'
+    selector = 'li.component div.xblock-studio_preview_view'
     world.wait_for(lambda _: len(world.css_find(selector)) == len(step.hashes))
 
     for idx, step_hash in enumerate(step.hashes):
@@ -77,7 +77,7 @@ def see_a_problem_component(step, category):
     assert_true(world.is_css_present(component_css),
                 'No problem was added to the unit.')
 
-    problem_css = 'li.component div.xblock-student_view'
+    problem_css = 'li.component div.xblock-studio_preview_view'
     actual_text = world.css_text(problem_css)
     assert_in(category.upper(), actual_text)
 

--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -233,7 +233,7 @@ def xblock_view_handler(request, package_id, view_name, tag=None, branch=None, v
             context = {
                 'container_view': is_container_view,
                 'read_only': is_read_only_view,
-                'root_xblock': component
+                'root_xblock': component,
             }
 
             fragment = get_preview_fragment(request, component, context)

--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -135,7 +135,7 @@ def _preview_module_system(request, descriptor):
         course_id=course_id,
         anonymous_student_id='student',
 
-        # Set up functions to modify the fragment produced by student_view
+        # Set up functions to modify the fragment produced by studio_preview_view
         wrappers=wrappers,
         error_descriptor_class=ErrorDescriptor,
         # get_user_role accepts a location or a CourseLocator.
@@ -169,7 +169,7 @@ def _studio_wrap_xblock(xblock, view, frag, context, display_name_only=False):
     Wraps the results of rendering an XBlock view in a div which adds a header and Studio action buttons.
     """
     # Only add the Studio wrapper when on the container page. The unit page will remain as is for now.
-    if context.get('container_view', None) and view == 'student_view':
+    if context.get('container_view', None) and view == 'studio_preview_view':
         locator = loc_mapper().translate_location(xblock.course_id, xblock.location)
         template_context = {
             'xblock_context': context,
@@ -190,14 +190,14 @@ def _studio_wrap_xblock(xblock, view, frag, context, display_name_only=False):
 
 def get_preview_fragment(request, descriptor, context):
     """
-    Returns the HTML returned by the XModule's student_view,
+    Returns the HTML returned by the XModule's studio_preview_view,
     specified by the descriptor and idx.
     """
     module = _load_preview_module(request, descriptor)
 
     try:
-        fragment = module.render("student_view", context)
+        fragment = module.render("studio_preview_view", context)
     except Exception as exc:                          # pylint: disable=W0703
-        log.warning("Unable to render student_view for %r", module, exc_info=True)
+        log.warning("Unable to render studio_preview_view for %r", module, exc_info=True)
         fragment = Fragment(render_to_string('html_error.html', {'message': str(exc)}))
     return fragment

--- a/cms/djangoapps/contentstore/views/tests/test_item.py
+++ b/cms/djangoapps/contentstore/views/tests/test_item.py
@@ -22,7 +22,7 @@ from xmodule.modulestore.django import loc_mapper
 from xmodule.modulestore.locator import BlockUsageLocator
 from xmodule.modulestore.exceptions import ItemNotFoundError
 from xmodule.modulestore import Location
-
+from xmodule.tests.xml import factories as xml
 
 class ItemTest(CourseTestCase):
     """ Base test class for create, save, and delete """
@@ -156,6 +156,19 @@ class GetItem(ItemTest):
             (r'"/container/MITx.999.Robot_Super_Course/branch/published/block/wrapper.{3}" class="action-button">\s*'
              '<span class="action-button-text">View</span>')
         )
+
+    def test_split_test(self):
+        root_locator = self._create_vertical()
+        resp = self.create_xblock(category='split_test', parent_locator=root_locator)
+        self.assertEqual(resp.status_code, 200)
+        split_test_locator = self.response_locator(resp)
+        resp = self.create_xblock(parent_locator=split_test_locator, category='html', boilerplate='announcement.yaml')
+        self.assertEqual(resp.status_code, 200)
+        resp = self.create_xblock(parent_locator=split_test_locator, category='html', boilerplate='zooming_image.yaml')
+        self.assertEqual(resp.status_code, 200)
+        html, __ = self._get_container_preview(split_test_locator)
+        self.assertIn('Announcement', html)
+        self.assertIn('Zooming', html)
 
 
 class DeleteItem(ItemTest):

--- a/cms/lib/xblock/mixin.py
+++ b/cms/lib/xblock/mixin.py
@@ -3,8 +3,10 @@ Mixin defining common Studio functionality
 """
 
 import datetime
+import functools
 
 from xblock.fields import Scope, Field, Integer, XBlockMixin
+from xblock.runtime import NoSuchViewError
 
 
 class DateTuple(Field):
@@ -27,3 +29,25 @@ class CmsBlockMixin(XBlockMixin):
     """
     published_date = DateTuple(help="Date when the module was published", scope=Scope.settings)
     published_by = Integer(help="Id of the user who published this module", scope=Scope.settings)
+
+    def studio_preview_view(self, context):
+        """
+        Renders Studio's preview of a component when rendering an xblock and its children.
+        The default implementation just renders the student view.
+        """
+        view_function = self.get_view_function('student_view')
+        return view_function(context)
+
+    # TODO this shared function should be moved into xblock itself and reused by xblock/runtime.py.
+    def get_view_function(self, view_name):
+        """
+        Returns the view function for the specified view name. If the requested view doesn't exist,
+        the fallback view is used instead.
+        """
+        view_fn = getattr(self, view_name, None)
+        if view_fn is None:
+            view_fn = getattr(self, "fallback_view", None)
+            if view_fn is None:
+                raise NoSuchViewError(self, view_name)
+            view_fn = functools.partial(view_fn, view_name)
+        return view_fn

--- a/cms/static/coffee/src/views/module_edit.coffee
+++ b/cms/static/coffee/src/views/module_edit.coffee
@@ -22,7 +22,7 @@ define ["jquery", "underscore", "gettext", "xblock/runtime.v1",
     $moduleEditor: => @$componentEditor().find('.module-editor')
 
     loadDisplay: ->
-      XBlock.initializeBlock(@$el.find('.xblock-student_view'))
+      XBlock.initializeBlock(@$el.find('.xblock-studio_preview_view'))
 
     loadEdit: ->
       @module = XBlock.initializeBlock(@$el.find('.xblock-studio_view'))

--- a/cms/static/sass/elements/_xmodules.scss
+++ b/cms/static/sass/elements/_xmodules.scss
@@ -1,8 +1,8 @@
 // studio - elements - xmodules & xblocks
 // ====================
 
-// general - display mode (xblock-student_view or xmodule_display)
-.xmodule_display, .xblock-student_view {
+// general - display mode (xblock-student_view, xblock_studio_preview_view or xmodule_display)
+.xmodule_display, .xblock-student_view, .xblock_studio_preview_view {
 
   // font styling
   i, em {
@@ -16,7 +16,7 @@
 .xmodule_VideoModule {
 
   // display mode
-  &.xblock-student_view {
+  &.xblock-student_view, &.xblock_studio_preview_view {
 
     // full screen
     .video-controls .add-fullscreen {

--- a/cms/static/sass/views/_static-pages.scss
+++ b/cms/static/sass/views/_static-pages.scss
@@ -183,16 +183,16 @@
     border-left: 1px solid $mediumGrey;
     border-right: 1px solid $mediumGrey;
 
-    .xblock-student_view {
+    .xblock-studio_preview_view {
       display: none;
     }
   }
 
-  .new .xblock-student_view {
+  .new .xblock-studio_preview_view {
     background: $yellow;
   }
 
-  .xblock-student_view {
+  .xblock-studio_preview_view {
     @include transition(background-color $tmg-s3 linear 0s);
     padding: 20px 20px 22px;
     font-size: 24px;

--- a/cms/static/sass/views/_unit.scss
+++ b/cms/static/sass/views/_unit.scss
@@ -433,7 +433,7 @@ body.course.unit,.view-unit {
       }
     }
 
-    .xblock-student_view {
+    .xblock-studio_preview_view {
       padding: 2*$baseline $baseline $baseline;
       overflow-x: auto;
 

--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -1018,7 +1018,7 @@ class DescriptorSystem(ConfigurableFragmentWrapper, Runtime):  # pylint: disable
         return result
 
     def render(self, block, view_name, context=None):
-        if view_name == 'student_view':
+        if view_name in ('studio_preview_view', 'student_view'):
             assert block.xmodule_runtime is not None
             if isinstance(block, (XModule, XModuleDescriptor)):
                 to_render = block._xmodule

--- a/common/test/acceptance/pages/studio/container.py
+++ b/common/test/acceptance/pages/studio/container.py
@@ -71,4 +71,4 @@ class XBlockWrapper(PageObject):
 
     @property
     def preview_selector(self):
-        return self._bounded_selector('.xblock-student_view')
+        return self._bounded_selector('.xblock-studio_preview_view')

--- a/common/test/acceptance/pages/studio/unit.py
+++ b/common/test/acceptance/pages/studio/unit.py
@@ -26,7 +26,7 @@ class UnitPage(PageObject):
 
     def is_browser_on_page(self):
         # Wait until all components have been loaded
-        number_of_leaf_xblocks = len(self.q(css='{} .xblock-student_view'.format(Component.BODY_SELECTOR)))
+        number_of_leaf_xblocks = len(self.q(css='{} .xblock-studio_preview_view'.format(Component.BODY_SELECTOR)))
         number_of_container_xblocks = len(self.q(css='{} .wrapper-xblock'.format(Component.BODY_SELECTOR)))
         return (
             self.is_css_present('body.view-unit') and
@@ -91,7 +91,7 @@ class Component(PageObject):
 
     @property
     def preview_selector(self):
-        return self._bounded_selector('.xblock-student_view')
+        return self._bounded_selector('.xblock-studio_preview_view')
 
     def edit(self):
         self.css_click(self._bounded_selector('.edit-button'))


### PR DESCRIPTION
This change addresses STUD-1403 where split_test modules could not render in Studio. It changes Studio to pass a new 'runtime-type' of 'studio' when rendering an xblock. In split_test, this will then cause all of the children to be rendered, rather than just the one that matches the conditional.

Note: I had to bulletproof the code in split_test in case the user partitions are not available. I understand that this might not be the best long term solution, but hopefully this is tolerable for this week's release.

@dianakhuang @cpennington Please review.
