### PR TITLE
Remove outline:none to assist keyboard navigation

### DIFF
--- a/common/lib/xmodule/xmodule/css/sequence/display.scss
+++ b/common/lib/xmodule/xmodule/css/sequence/display.scss
@@ -105,12 +105,11 @@ nav.sequence-nav {
         padding: 0;
         position: relative;
         @include transition(none);
-        outline: 0;
 
-        &:focus {
+/*        &:focus {
           outline: 0;
         }
-
+*/
         &:hover, &:focus {
           background-color: #fff;
           background-repeat: no-repeat;
@@ -278,12 +277,11 @@ nav.sequence-nav {
           width: 40px;
           text-indent: -9999px;
           @include transition(all .2s $ease-in-out-quad 0s);
-          outline: 0;
 
-          &:focus {
+/*          &:focus {
             outline: 0;
           }
-
+*/
           &:hover {
             opacity: 0.5;
           }
@@ -354,7 +352,6 @@ nav.sequence-bottom {
           padding: lh(.5) 4px;
           text-indent: -9999px;
           @include transition(all .2s $ease-in-out-quad 0s);
-          outline: 0;
 
           &:hover {
             opacity: 0.5;
@@ -365,10 +362,10 @@ nav.sequence-bottom {
             opacity: 0.4;
           }
 
-          &:focus {
+/*          &:focus {
             outline: 0;
           }
-        }
+*/        }
       }
 
       &.prev {
@@ -399,10 +396,10 @@ nav.sequence-bottom {
 
 .xmodule_SequenceModule nav.sequence-bottom ul li.next a,
 .xmodule_SequenceModule nav.sequence-bottom ul li.prev a {
-  outline: 0;
 
-  &:focus {
+/*  &:focus {
     outline: 0;
   }
+*/
 }
 

--- a/common/lib/xmodule/xmodule/css/video/display.scss
+++ b/common/lib/xmodule/xmodule/css/video/display.scss
@@ -15,7 +15,6 @@ div.video {
   border-radius: 5px;
 
   &:focus, &:active, &:hover {
-    outline: 0;
     border: 0;
   }
 
@@ -193,7 +192,6 @@ div.video {
           background-color: #444;
           color: #fff;
           text-decoration: none;
-          outline: 0;
         }
 
         &:active,
@@ -254,7 +252,6 @@ div.video {
 
           &:focus, &:hover {
             background-color: lighten($pink, 10%);
-            outline: 0;
           }
         }
       }
@@ -549,7 +546,6 @@ div.video {
             background-color: #F44;
             color: #0ff;
             text-decoration: none;
-            outline: 0;
           }
         }
 
@@ -610,7 +606,6 @@ div.video {
       margin-bottom: 8px;
       padding: 0;
       line-height: lh();
-      outline: 0;
 
       &.current {
         color: #333;

--- a/lms/static/sass/course/_gradebook.scss
+++ b/lms/static/sass/course/_gradebook.scss
@@ -24,7 +24,6 @@ div.gradebook-wrapper {
     	font-family: $sans-serif;
     	font-size: 11px;
     	box-shadow: 0 1px 4px rgba(0, 0, 0, .12) inset;
-    	outline: none;
     	@include transition(border-color .15s linear 0s);
 
     	&::-webkit-input-placeholder,

--- a/lms/static/sass/course/base/_base.scss
+++ b/lms/static/sass/course/base/_base.scss
@@ -75,7 +75,6 @@ input[type="password"] {
   &:focus {
     border-color: lighten($link-color, 20%);
     box-shadow: 0 0 6px 0 rgba($blue, 0.4), inset 0 0 4px 0 rgba(0,0,0, 0.15);
-    outline: none;
   }
 }
 

--- a/lms/static/sass/course/layout/_calculator.scss
+++ b/lms/static/sass/course/layout/_calculator.scss
@@ -102,7 +102,6 @@ div.calc-main {
           width: 100%;
 
           &:focus {
-            outline: none;
             border: none;
           }
         }

--- a/lms/static/sass/course/wiki/_wiki.scss
+++ b/lms/static/sass/course/wiki/_wiki.scss
@@ -105,7 +105,6 @@ section.wiki {
       box-shadow: 0 1px 4px rgba(0, 0, 0, 0.12) inset;
       font-family: $sans-serif;
       font-size: 12px;
-      outline: none;
       @include transition(border-color .1s linear 0s);
 
       &:-webkit-input-placholder {

--- a/lms/static/sass/shared/_forms.scss
+++ b/lms/static/sass/shared/_forms.scss
@@ -33,7 +33,6 @@ input[type="tel"] {
   &:focus {
     border-color: darken($button-archive-color, 50%);
     box-shadow: 0 0 6px 0 darken($button-archive-color, 50%), inset 0 0 4px 0 rgba(0,0,0, 0.15);
-    outline: none;
   }
 }
 


### PR DESCRIPTION
I've commented out a few of the :focus declarations, in case we want to add something more specific there.

[this site](http://www.outlinenone.com) unequivocally recommends removing `outline: none`...

@frrrances @caesar2164 
