### PR TITLE
Fix instructor dashboard editor

### DIFF
--- a/common/static/css/vendor/ova/richText-annotator.css
+++ b/common/static/css/vendor/ova/richText-annotator.css
@@ -16,7 +16,7 @@
 	font-style: italic;
 }
 
-.mce-container {
+.courseware .mce-container {
 	z-index:3000000000!important; /*To fix full-screen problems*/
 }
 


### PR DESCRIPTION
Adds a css selector to ova richText annotator file to limit tinymce editor changes to the courseware pages - fix for instructor dashboard email editor.
