### PR TITLE
Remove course name from page H1, and slightly improve sequence navigation

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/sequence/display.coffee
+++ b/common/lib/xmodule/xmodule/js/src/sequence/display.coffee
@@ -73,19 +73,19 @@ class @Sequence
     @$('.sequence-nav-buttons a').unbind('click')
 
     if @contents.length == 0
-      @$('.sequence-nav-buttons .prev a').addClass('disabled')
-      @$('.sequence-nav-buttons .next a').addClass('disabled')
+      @$('.sequence-nav-buttons .prev a').addClass('disabled').attr('aria-hidden', 'true')
+      @$('.sequence-nav-buttons .next a').addClass('disabled').attr('aria-hidden', 'true')
       return
 
     if @position == 1
-      @$('.sequence-nav-buttons .prev a').addClass('disabled')
+      @$('.sequence-nav-buttons .prev a').addClass('disabled').attr('aria-hidden', 'true')
     else
-      @$('.sequence-nav-buttons .prev a').removeClass('disabled').click(@previous)
+      @$('.sequence-nav-buttons .prev a').removeClass('disabled').attr('aria-hidden', 'false').click(@previous)
 
     if @position == @contents.length
-      @$('.sequence-nav-buttons .next a').addClass('disabled')
+      @$('.sequence-nav-buttons .next a').addClass('disabled').attr('aria-hidden', 'true')
     else
-      @$('.sequence-nav-buttons .next a').removeClass('disabled').click(@next)
+      @$('.sequence-nav-buttons .next a').removeClass('disabled').attr('aria-hidden', 'false').click(@next)
 
   render: (new_position) ->
     if @position != new_position
@@ -113,8 +113,6 @@ class @Sequence
 
       sequence_links = @content_container.find('a.seqnav')
       sequence_links.click @goto
-      # Focus on the first available xblock.
-      @content_container.find('.vert .xblock :first').focus()
     @$("a.active").blur()
 
   goto: (event) =>

--- a/common/lib/xmodule/xmodule/seq_module.py
+++ b/common/lib/xmodule/xmodule/seq_module.py
@@ -89,7 +89,6 @@ class SequenceModule(SequenceFields, XModule):
             fragment.add_frag_resources(rendered_child)
 
             titles = child.get_content_titles()
-            print titles
             childinfo = {
                 'content': rendered_child.content,
                 'title': "\n".join(titles),

--- a/common/templates/xblock_wrapper.html
+++ b/common/templates/xblock_wrapper.html
@@ -1,3 +1,3 @@
-<div class="${' '.join(classes)}" ${data_attributes} tabindex="0">
+<div class="${' '.join(classes)}" ${data_attributes}>
     ${content}
 </div>

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -19,7 +19,7 @@ ${page_title_breadcrumbs(course_name())}
 <%static:css group='style-course-vendor'/>
 <%static:css group='style-course'/>
 
-<%block name="nav_skip">#course-content</%block>
+<%block name="nav_skip">${"#seq_content" if section_title else "#course-content"}</%block>
 
 <%include file="../discussion/_js_head_dependencies.html" />
 
@@ -182,7 +182,7 @@ ${fragment.foot_html()}
 
 % if accordion:
   <%include file="/dashboard/_dashboard_prompt_midcourse_reverify.html" />
- <%include file="/courseware/course_navigation.html" args="active_page='courseware'" />
+  <%include file="/courseware/course_navigation.html" args="active_page='courseware'" />
 % endif
 
 <div class="container">

--- a/lms/templates/navigation.html
+++ b/lms/templates/navigation.html
@@ -36,33 +36,21 @@ site_status_msg = get_site_status_msg(course_id)
 % endif
 </%block>
 
-
-% if course:
-  <header class="global slim" aria-label="${_('Global Navigation')}">
-% else:
-  <header class="global" aria-label="${_('Global Navigation')}">
-% endif
-  <nav>
-
-  <h1 class="logo">
-    <a href="${marketing_link('ROOT')}">
-      <%block name="navigation_logo">
-          <img src="${static.url(branding.get_logo_url())}" alt="
-          % if course:
-          ${course.display_org_with_default | h}: ${course.display_number_with_default | h} ${course.display_name_with_default | h} @
-          % endif
-          ${platform_name()}
-          " />
-      </%block>
-    </a>
-  </h1>
+  <header class="global ${"slim" if course else ""}" aria-label="${_('Global Navigation')}">
+    <nav>
+    <h1 class="logo">
+      <a href="${marketing_link('ROOT')}">
+        <%block name="navigation_logo">
+            <img src="${static.url(branding.get_logo_url())}" alt="${platform_name()}"/>
+        </%block>
+      </a>
+    </h1>
 
     % if course:
-      <h2><span class="provider">${course.display_org_with_default | h}:</span> ${course.display_number_with_default | h} ${course.display_name_with_default}</h2>
+    <h2><span class="provider">${course.display_org_with_default | h}:</span> ${course.display_number_with_default | h} ${course.display_name_with_default}</h2>
     % endif
 
     % if user.is_authenticated():
-
     <ol class="left nav-global authenticated">
       <%block name="navigation_global_links_authenticated">
         % if settings.FEATURES.get('COURSES_ARE_BROWSABLE'):


### PR DESCRIPTION
This is nominally for LMS-1923 (and others) but there already was an H1 on the page. These are just minor tweaks.

To me, the header in navigation.html looks fine, except that the H1 contains an image. But since the image has an alt attribute, screen readers should have no problem knowing what's going on.

Thoughts, @frrrances ?
