### PR TITLE
Stanford: Certs merge bug fix

### DIFF
--- a/lms/djangoapps/certificates/queue.py
+++ b/lms/djangoapps/certificates/queue.py
@@ -194,7 +194,7 @@ class XQueueCertInterface(object):
                 cert_mode = GeneratedCertificate.MODES.honor
             else:
                 # honor code and audit students
-                template_pdf = "certificate-template-{0}-{1}.pdf".format(**course_id_dict)
+                template_pdf = "certificate-template-{org}-{course}.pdf".format(**course_id_dict)
             if forced_grade:
                 grade['grade'] = forced_grade
 


### PR DESCRIPTION
Stanford-only materiál. DNM to master. @sefk FYI, @gbruhns please confirm fix against CME.

There was a bug in last week's merge that broke the interaction between the LMS and the certificate agent; this patch fixes it. If it is deployed everywhere, it should tidy up all the cert troubles we've seen this week. Note that while this is a patch against -platform, it is a very small one, on an out-of-the-way part of the system, and I would feel okay doing an OOB deploy everywhere.

Current instance installation CME is by hand, not ansible.
