### PR TITLE
Adding ability to give an attribute callback for CAS

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -191,6 +191,14 @@ if FEATURES.get('AUTH_USE_CAS'):
     )
     INSTALLED_APPS += ('django_cas',)
     MIDDLEWARE_CLASSES += ('django_cas.middleware.CASMiddleware',)
+    CAS_ATTRIBUTE_CALLBACK = ENV_TOKENS.get('CAS_ATTRIBUTE_CALLBACK', None)
+    if CAS_ATTRIBUTE_CALLBACK:
+        import importlib
+        CAS_USER_DETAILS_RESOLVER = getattr(
+            importlib.import_module(CAS_ATTRIBUTE_CALLBACK['module']),
+            CAS_ATTRIBUTE_CALLBACK['function']
+        )
+
 
 ################ SECURE AUTH ITEMS ###############################
 # Secret things: passwords, access keys, etc.

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -268,6 +268,14 @@ if FEATURES.get('AUTH_USE_CAS'):
     )
     INSTALLED_APPS += ('django_cas',)
     MIDDLEWARE_CLASSES += ('django_cas.middleware.CASMiddleware',)
+    CAS_ATTRIBUTE_CALLBACK = ENV_TOKENS.get('CAS_ATTRIBUTE_CALLBACK', None)
+    if CAS_ATTRIBUTE_CALLBACK:
+        import importlib
+        CAS_USER_DETAILS_RESOLVER = getattr(
+            importlib.import_module(CAS_ATTRIBUTE_CALLBACK['module']),
+            CAS_ATTRIBUTE_CALLBACK['function']
+        )
+
 
 HOSTNAME_MODULESTORE_DEFAULT_MAPPINGS = ENV_TOKENS.get('HOSTNAME_MODULESTORE_DEFAULT_MAPPINGS',{})
 


### PR DESCRIPTION
This allows you to specify a template module and function to use attributes from CAS and add them to the django user models. Unfortunately CAS doesn't specify any one particular way to define attributes or what attributes are used like Shibboleth does, so the django-cas app requires a callable function to get things like the first name, email address etc. This PR creates the option to pass that function in with the json configs.

@sarina and @e0d since you looked at the last CAS change.  I plan on having a PR to add these to edx/configuration with an update to the wiki page shortly too.
