### PR TITLE
Fix incorrect parse of url in video_module.py

### DIFF
--- a/common/lib/xmodule/xmodule/tests/test_video.py
+++ b/common/lib/xmodule/xmodule/tests/test_video.py
@@ -20,7 +20,7 @@ from mock import Mock
 from . import LogicTest
 from lxml import etree
 from xmodule.modulestore import Location
-from xmodule.video_module import VideoDescriptor, create_youtube_string
+from xmodule.video_module import VideoDescriptor, create_youtube_string, get_ext
 from .test_import import DummySystem
 from xblock.field_data import DictFieldData
 from xblock.fields import ScopeIds
@@ -106,6 +106,18 @@ class VideoModuleTest(LogicTest):
              '1.25': '',
              '1.50': ''}
         )
+
+    def test_get_ext(self):
+        """Test get the file's extension in a url without query string."""
+        filename_str = 'http://www.example.com/path/video.mp4'
+        output = get_ext(filename_str)
+        self.assertEqual(output, 'mp4')
+
+    def test_get_ext_with_query_string(self):
+        """Test get the file's extension in a url with query string."""
+        filename_str = 'http://www.example.com/path/video.mp4?param1=1&p2=2'
+        output = get_ext(filename_str)
+        self.assertEqual(output, 'mp4')
 
 
 class VideoDescriptorTest(unittest.TestCase):

--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -43,6 +43,7 @@ from .video_utils import create_youtube_string
 
 from xmodule.modulestore.inheritance import InheritanceKeyValueStore
 from xblock.runtime import KvsFieldData
+from urlparse import urlparse
 
 log = logging.getLogger(__name__)
 
@@ -253,7 +254,8 @@ class VideoModule(VideoFields, XModule):
         track_url = None
         transcript_download_format = self.transcript_download_format
 
-        get_ext = lambda filename: filename.rpartition('.')[-1]
+        # Prevent incorrectly parsing urls like 'http://abc.com/path/video.mp4?xxxx'.
+        get_ext = lambda filename: urlparse(filename).path.rpartition('.')[-1]
         sources = {get_ext(src): src for src in self.html5_sources}
 
         if self.download_video:

--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -45,6 +45,12 @@ from xmodule.modulestore.inheritance import InheritanceKeyValueStore
 from xblock.runtime import KvsFieldData
 from urlparse import urlparse
 
+def get_ext(filename):
+    # Prevent incorrectly parsing urls like 'http://abc.com/path/video.mp4?xxxx'.
+    path = urlparse(filename).path
+    return path.rpartition('.')[-1]
+
+
 log = logging.getLogger(__name__)
 
 
@@ -254,8 +260,6 @@ class VideoModule(VideoFields, XModule):
         track_url = None
         transcript_download_format = self.transcript_download_format
 
-        # Prevent incorrectly parsing urls like 'http://abc.com/path/video.mp4?xxxx'.
-        get_ext = lambda filename: urlparse(filename).path.rpartition('.')[-1]
         sources = {get_ext(src): src for src in self.html5_sources}
 
         if self.download_video:


### PR DESCRIPTION
Sometimes the video url may look like 'http://abc.com/path/video.mp4?xxxx'.
(For example, the Windows Azure's media service will offer such type of url.)
The original code in video_module.py will produce 'mp4?xxxx' instead of 'mp4'
as the extension of a filename for such type of url, and therefore the video
will be non-playable. The fix here uses the built-in urlparse module to retrive
only the path component from a url and therefore the extension 'mp4' will be
correctly fetched.
