### PR TITLE
Skip collectstatic when running unit test suites

### DIFF
--- a/cms/envs/test.py
+++ b/cms/envs/test.py
@@ -54,6 +54,7 @@ STATICFILES_DIRS += [
     for course_dir in os.listdir(COMMON_TEST_DATA_ROOT)
     if os.path.isdir(COMMON_TEST_DATA_ROOT / course_dir)
 ]
+STATICFILES_STORAGE = None
 
 DOC_STORE_CONFIG = {
     'host': 'localhost',

--- a/common/djangoapps/static_replace/test/test_static_replace.py
+++ b/common/djangoapps/static_replace/test/test_static_replace.py
@@ -1,8 +1,8 @@
 import re
 
 from nose.tools import assert_equals, assert_true, assert_false  # pylint: disable=E0611
-from static_replace import (replace_static_urls, replace_course_urls,
-                            _url_replace_regex)
+from django.test.utils import override_settings
+from static_replace import replace_static_urls, replace_course_urls, _url_replace_regex
 from mock import patch, Mock
 from xmodule.modulestore import Location
 from xmodule.modulestore.mongo import MongoModuleStore
@@ -13,6 +13,7 @@ COURSE_ID = 'org/course/run'
 STATIC_SOURCE = '"/static/file.png"'
 
 
+@override_settings(STATICFILES_STORAGE='pipeline.storage.PipelineCachedStorage')
 def test_multi_replace():
     course_source = '"/course/file.png"'
 
@@ -26,6 +27,7 @@ def test_multi_replace():
     )
 
 
+@override_settings(STATICFILES_STORAGE='pipeline.storage.PipelineCachedStorage')
 @patch('static_replace.staticfiles_storage')
 def test_storage_url_exists(mock_storage):
     mock_storage.exists.return_value = True
@@ -36,6 +38,7 @@ def test_storage_url_exists(mock_storage):
     mock_storage.url.called_once_with('data_dir/file.png')
 
 
+@override_settings(STATICFILES_STORAGE='pipeline.storage.PipelineCachedStorage')
 @patch('static_replace.staticfiles_storage')
 def test_storage_url_not_exists(mock_storage):
     mock_storage.exists.return_value = False
@@ -46,6 +49,7 @@ def test_storage_url_not_exists(mock_storage):
     mock_storage.url.called_once_with('file.png')
 
 
+@override_settings(STATICFILES_STORAGE='pipeline.storage.PipelineCachedStorage')
 @patch('static_replace.StaticContent')
 @patch('static_replace.modulestore')
 def test_mongo_filestore(mock_modulestore, mock_static_content):

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -370,7 +370,10 @@ class TestTOC(TestCase):
             self.assertIn(toc_section, actual)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MIXED_MODULESTORE)
+@override_settings(
+    MODULESTORE=TEST_DATA_MIXED_MODULESTORE,
+    STATICFILES_STORAGE='pipeline.storage.PipelineCachedStorage'
+)
 class TestHtmlModifiers(ModuleStoreTestCase):
     """
     Tests to verify that standard modifications to the output of XModule/XBlock

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -66,6 +66,7 @@ NOSE_ARGS = [
 TEST_ROOT = path("test_root")
 # Want static files in the same dir for running on jenkins.
 STATIC_ROOT = TEST_ROOT / "staticfiles"
+STATICFILES_STORAGE = None
 
 STATUS_MESSAGE_PATH = TEST_ROOT / "status_message.json"
 

--- a/rakelib/tests.rake
+++ b/rakelib/tests.rake
@@ -70,17 +70,11 @@ TEST_TASK_DIRS = []
 
     # Per System tasks/
     desc "Run all django tests on our djangoapps for the #{system}"
-    task "test_#{system}", [:test_id] => [
-        :clean_test_files, :install_prereqs,
-        "#{system}:gather_assets:test", "fasttest_#{system}"
-    ]
+    task "test_#{system}", [:test_id] => [:clean_test_files, :install_prereqs, "fasttest_#{system}"]
 
-    # Have a way to run the tests without running collectstatic -- useful when debugging without
-    # messing with static files.
+    # Have a way to run the tests without install prereqs
     task "fasttest_#{system}", [:test_id] => [test_id_dir, report_dir, :clean_reports_dir] do |t, args|
         args.with_defaults(:test_id => nil)
-
-
 
         begin
             run_tests(system, report_dir, args.test_id)


### PR DESCRIPTION
This has been driving me crazy :)  There is no reason why the unit test suite needs to run collectstatic: since view-level tests aren't actually rendering anything in the browser, none of the static asset links will be followed.

There were a few tests in `courseware_wiki` that depended on assets being available, because:
- Django templates were being used, which included...
- A `static` tag, which called...
- `pipeline.storage.PipelineCachedStorage`, which raised
- a `ValueError` if the resource was not found.

Except for the `static_replace` Django app, all other unit tests shouldn't need `PipelineCachedStorage`.

This PR updates the unit test settings, removes the `collectstatic` step in the rake test commands, and explicitly overrides settings to install `PipelineCachedStorage` for the few tests that actually need it.

https://edx-wiki.atlassian.net/browse/TE-280

@jzoldak 
