### PR TITLE
Video: update acceptance test.

### DIFF
--- a/cms/djangoapps/contentstore/features/component_settings_editor_helpers.py
+++ b/cms/djangoapps/contentstore/features/component_settings_editor_helpers.py
@@ -214,7 +214,7 @@ def get_setting_entry(label):
 @world.absorb
 def get_setting_entry_index(label):
     def get_index():
-        settings = world.css_find('.wrapper-comp-setting')
+        settings = world.css_find('.metadata_edit .wrapper-comp-setting')
         for index, setting in enumerate(settings):
             if setting.find_by_css('.setting-label')[0].value == label:
                 return index
@@ -232,6 +232,6 @@ def set_field_value(index, value):
     Instead we will find the element, set its value, then hit the Tab key
     to get to the next field.
     """
-    elem = world.css_find('div.wrapper-comp-setting input.setting-input')[index]
+    elem = world.css_find('.metadata_edit div.wrapper-comp-setting input.setting-input')[index]
     elem.value = value
     elem.type(Keys.TAB)

--- a/cms/djangoapps/contentstore/features/problem-editor.py
+++ b/cms/djangoapps/contentstore/features/problem-editor.py
@@ -142,7 +142,7 @@ def set_the_weight_to_abc(step, bad_weight):
 
 @step('if I set the max attempts to "(.*)", it will persist as a valid integer$')
 def set_the_max_attempts(step, max_attempts_set):
-    # on firefox with selenium, the behaviour is different.
+    # on firefox with selenium, the behavior is different.
     # eg 2.34 displays as 2.34 and is persisted as 2
     index = world.get_setting_entry_index(MAXIMUM_ATTEMPTS)
     world.set_field_value(index, max_attempts_set)

--- a/cms/djangoapps/contentstore/features/video-editor.feature
+++ b/cms/djangoapps/contentstore/features/video-editor.feature
@@ -12,6 +12,7 @@ Feature: CMS Video Component Editor
   Scenario: User can modify Video display name
     Given I have created a Video component
     And I edit the component
+    And I open tab "Advanced"
     Then I can modify the display name
     And my video display name change is persisted on save
 


### PR DESCRIPTION
Added more specific selector to find elements just in Settings/Advanced tab (Video player has 2 tabs).

Possible issue: if element is hidden, `value` will return `None`.

@auraz please review.
