### PR TITLE
Fixed HTML tab in bulk email feature on firefox.

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/html/edit.coffee
+++ b/common/lib/xmodule/xmodule/js/src/html/edit.coffee
@@ -96,6 +96,10 @@ class @HTMLEditingDescriptor
     $currentTarget = $(e.currentTarget)
     if not $currentTarget.hasClass('current')
       $currentTarget.addClass('current')
+
+      # Initializing $mceToolbar if undefined.
+      if not @$mceToolbar?
+        @$mceToolbar = $(@element).find('table.mceToolbar')
       @$mceToolbar.toggleClass(HTMLEditingDescriptor.isInactiveClass)
       @$advancedEditorWrapper.toggleClass(HTMLEditingDescriptor.isInactiveClass)
 


### PR DESCRIPTION
LMS-2275

Clicking the HTML tab in Firefox isn't working properly for bulk email feature.
