### PR TITLE
Clean up references to answer distribution-like things

### DIFF
--- a/common/lib/capa/capa/inputtypes.py
+++ b/common/lib/capa/capa/inputtypes.py
@@ -804,9 +804,15 @@ class MatlabInput(CodeInput):
         # the graded response takes precedence
         if 'queue_msg' in self.input_state and self.status in ['queued', 'incomplete', 'unsubmitted']:
             attributes = bleach.ALLOWED_ATTRIBUTES.copy()
-            attributes.update({'*': ['class', 'style', 'id'], 'audio': ['controls', 'autobuffer', 'autoplay', 'src']})
+            # Yuck! but bleach does not offer the option of passing in allowed_protocols,
+            # and matlab uses data urls for images
+            if u'data' not in bleach.BleachSanitizer.allowed_protocols:
+                bleach.BleachSanitizer.allowed_protocols.append(u'data')
+            attributes.update({'*': ['class', 'style', 'id'],
+                    'audio': ['controls', 'autobuffer', 'autoplay', 'src'],
+                    'img': ['src', 'width', 'height', 'class']})
             self.queue_msg = bleach.clean(self.input_state['queue_msg'],
-                    tags=bleach.ALLOWED_TAGS + ['div', 'p', 'audio', 'pre'],
+                    tags=bleach.ALLOWED_TAGS + ['div', 'p', 'audio', 'pre', 'img'],
                     styles=['white-space'],
                     attributes=attributes
                     )

--- a/common/lib/capa/capa/tests/test_inputtypes.py
+++ b/common/lib/capa/capa/tests/test_inputtypes.py
@@ -665,7 +665,8 @@ class MatlabTest(unittest.TestCase):
     Zero or more ELSEIF parts can be used as well as nested <strong>if</strong>'s.
     The expression is usually of the form expr rop expr where 
     rop is ==, <, >, <=, >=, or ~=.
- 
+    <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAjAAAAGkCAIAAACgj==" />
+
     Example
        if I == J
          A(I,J) = 2;
@@ -692,7 +693,7 @@ class MatlabTest(unittest.TestCase):
         the_input = self.input_class(test_capa_system(), elt, state)
         context = the_input._get_render_context()  # pylint: disable=W0212
         self.maxDiff = None
-        expected = u'\n<div class="matlabResponse"><div class="commandWindowOutput" style="white-space: pre;"> <strong>if</strong> Conditionally execute statements.\nThe general form of the <strong>if</strong> statement is\n\n   <strong>if</strong> expression\n     statements\n   ELSEIF expression\n     statements\n   ELSE\n     statements\n   END\n\nThe statements are executed if the real part of the expression \nhas all non-zero elements. The ELSE and ELSEIF parts are optional.\nZero or more ELSEIF parts can be used as well as nested <strong>if</strong>\'s.\nThe expression is usually of the form expr rop expr where \nrop is ==, &lt;, &gt;, &lt;=, &gt;=, or ~=.\n\nExample\n   if I == J\n     A(I,J) = 2;\n   elseif abs(I-J) == 1\n     A(I,J) = -1;\n   else\n     A(I,J) = 0;\n   end\n\nSee also <a>relop</a>, <a>else</a>, <a>elseif</a>, <a>end</a>, <a>for</a>, <a>while</a>, <a>switch</a>.\n\nReference page in Help browser\n   <a>doc if</a>\n\n</div><ul></ul></div>\n'
+        expected = u'\n<div class="matlabResponse"><div class="commandWindowOutput" style="white-space: pre;"> <strong>if</strong> Conditionally execute statements.\nThe general form of the <strong>if</strong> statement is\n\n   <strong>if</strong> expression\n     statements\n   ELSEIF expression\n     statements\n   ELSE\n     statements\n   END\n\nThe statements are executed if the real part of the expression \nhas all non-zero elements. The ELSE and ELSEIF parts are optional.\nZero or more ELSEIF parts can be used as well as nested <strong>if</strong>\'s.\nThe expression is usually of the form expr rop expr where \nrop is ==, &lt;, &gt;, &lt;=, &gt;=, or ~=.\n<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAjAAAAGkCAIAAACgj==">\n\nExample\n   if I == J\n     A(I,J) = 2;\n   elseif abs(I-J) == 1\n     A(I,J) = -1;\n   else\n     A(I,J) = 0;\n   end\n\nSee also <a>relop</a>, <a>else</a>, <a>elseif</a>, <a>end</a>, <a>for</a>, <a>while</a>, <a>switch</a>.\n\nReference page in Help browser\n   <a>doc if</a>\n\n</div><ul></ul></div>\n'
 
         self.assertEqual(context['queue_msg'], expected)
 

--- a/lms/static/coffee/src/instructor_dashboard/data_download.coffee
+++ b/lms/static/coffee/src/instructor_dashboard/data_download.coffee
@@ -171,7 +171,7 @@ class ReportDownloads
     columns = [
       id: 'link'
       field: 'link'
-      name: gettext('File Name (Newest First)')
+      name: gettext('File Name')
       toolTip: gettext("Links are generated on demand and expire within 5 minutes due to the sensitive nature of student information.")
       sortable: false
       minWidth: 150

--- a/lms/templates/courseware/instructor_dashboard.html
+++ b/lms/templates/courseware/instructor_dashboard.html
@@ -207,7 +207,9 @@ function goto( mode)
     </p>
 
     <p>
+  %if not settings.FEATURES.get('ENABLE_ASYNC_ANSWER_DISTRIBUTION'):
     <input type="submit" name="action" value="Download CSV of answer distributions" class="${'is-disabled' if disable_buttons else ''}">
+  %endif
     <input type="submit" name="action" value="Dump description of graded assignments configuration">
     </p>
     <hr width="40%" style="align:left">
@@ -639,7 +641,7 @@ function goto( mode)
   <br/>
   %if analytics_results.get("ProblemGradeDistribution"):
     <p>
-      ${_("Answer distribution for problems")}
+      ${_("Score distribution for problems")}
       (${analytics_results["ProblemGradeDistribution"]['time']})
     </p>
     <div>

--- a/lms/templates/instructor/instructor_dashboard_2/analytics.html
+++ b/lms/templates/instructor/instructor_dashboard_2/analytics.html
@@ -18,7 +18,7 @@
 <script type="text/template" id="grade-distributions-widget-template">
   <div class="grade-distributions-widget">
     <div class="header">
-      <h2 class="title"> ${_("Grade Distribution")} </h2>
+      <h2 class="title"> ${_("Score Distribution")} </h2>
       <p>${_("The chart below displays the score distribution for each standard problem in your class, specified by the problem's url name.")}
 	${_("Scores are shown without weighting applied, so if your problem contains 2 questions, it will display as having a total of 2 points.")}</p>
       <br />

--- a/lms/templates/instructor/instructor_dashboard_2/data_download.html
+++ b/lms/templates/instructor/instructor_dashboard_2/data_download.html
@@ -6,25 +6,25 @@
   <h2>${_("Data Download")}</h2>
   <div class="request-response-error msg msg-error copy" id="data-request-response-error"></div>
 
-  <p>${_("The following button generates a CSV file of all students enrolled in this course, along with profile information such as email address and username.")}</p>
+  <p>${_("Click to generate a CSV file of all students enrolled in this course, along with profile information such as email address and username:")}</p>
 
   <p><input type="button" name="list-profiles-csv" value="${_("Download profile information as a CSV")}" data-endpoint="${ section_data['get_students_features_url'] }" data-csv="true"></p>
 
   % if not disable_buttons:
-    <p>${_("For smaller courses, profile information for enrolled students can be listed directly on this page:")}</p>
+    <p>${_("For smaller courses, click to list profile information for enrolled students directly on this page:")}</p>
     <p><input type="button" name="list-profiles" value="${_("List enrolled students' profile information")}" data-endpoint="${ section_data['get_students_features_url'] }"></p>
   %endif
   <div class="data-display-table" id="data-student-profiles-table"></div>
   
 
   <br>
-  <p>${_("The following button displays the grading configuration for the course. The grading configuration is the breakdown of graded subsections of the course (such as exams and problem sets), and can be changed on the 'Grading' page (under 'Settings') in Studio.")}</p>
+  <p>${_("Click to display the grading configuration for the course. The grading configuration is the breakdown of graded subsections of the course (such as exams and problem sets), and can be changed on the 'Grading' page (under 'Settings') in Studio.")}</p>
   <p><input type="button" name="dump-gradeconf" value="${_("Grading Configuration")}" data-endpoint="${ section_data['get_grading_config_url'] }"></p>
 
   <div class="data-display-text" id="data-grade-config-text"></div>
   <br>
 
-  <p>${_("Download a CSV of anonymized student IDs by clicking this button.")}</p>
+  <p>${_("Click to download a CSV of anonymized student IDs:")}</p>
   <p><input type="button" name="list-anon-ids" value="${_("Get Student Anonymized IDs CSV")}" data-csv="true" class="csv" data-endpoint="${ section_data['get_anon_ids_url'] }" class="${'is-disabled' if disable_buttons else ''}"></p>
 </div>
 
@@ -34,7 +34,7 @@
     <h2> ${_("Reports")}</h2>
 
   %if settings.FEATURES.get('ALLOW_COURSE_STAFF_GRADE_DOWNLOADS') or section_data['access']['admin']:
-    <p>${_("The following button will generate a CSV grade report for all currently enrolled students.  Generated reports appear in a table below and can be downloaded.")}</p>
+    <p>${_("Click to generate a CSV grade report for all currently enrolled students.  Links to generated reports appear in a table below when report generation is complete.")}</p>
 
     <p>${_("For large courses, generating this report may take several hours. Please be patient and do not click the button multiple times. Clicking the button multiple times will significantly slow the grade generation process.")}</p>
 
@@ -49,10 +49,15 @@
 
     <p><b>${_("Reports Available for Download")}</b></p>
     <p>
-      ${_("Grade reports listed below are generated each time the <b>Generate Grade Report</b> button is clicked. A link to each grade report remains available on this page, identified by the UTC date and time of generation. Grade reports are not deleted, so you will always be able to access previously generated reports from this page.")}
-      ## Translators: "these rules" in this sentence references a detailed description of the grading reports that will appear in a table that contains a mix of different types of reports.  This sentence intends to indicate that the description of the grading report does not apply to the other reports that may appear in the table.
-      ${_("Other reports may appear in the table for which these rules will not necessarily apply.")}
+      ${_("The grade reports listed below are generated each time the <b>Generate Grade Report</b> button is clicked. A link to each grade report remains available on this page, identified by the UTC date and time of generation. Grade reports are not deleted, so you will always be able to access previously generated reports from this page.")}
     </p>
+
+  %if settings.FEATURES.get('ENABLE_ASYNC_ANSWER_DISTRIBUTION'):
+    <p>
+      ${_("The answer distribution report listed below is generated periodically by an automated background process. The report is cumulative, so answers submitted after the process starts are included in a subsequent report. The report is generated several times per day.")}
+    </p>
+  %endif
+
     ## Translators: a table of URL links to report files appears after this sentence.
     <p>${_("<b>Note</b>: To keep student data secure, you cannot save or email these links for direct access. Copies of links expire within 5 minutes.")}</p><br>
 


### PR DESCRIPTION
In the near future an answer distribution report will be displayed in the
data download reports table.  In order to avoid confusion, we need to clean
up several misleading labels and remove a redundant feature.

Note that the redundant feature is surrounded by a feature flag so that it
can be disabled once the report goes live in the table.

Fixes: AN-694
Reviewers: @sarina, @rocha, @lamagnifica
FYI: @stroilova, @brianhw
