### PR TITLE
Ignore imports when computing pylint similarities

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -212,6 +212,9 @@ ignore-comments=yes
 # Ignore docstrings when computing similarities.
 ignore-docstrings=yes
 
+# Ignore imports when computing similarities.
+ignore-imports=yes
+
 
 [VARIABLES]
 


### PR DESCRIPTION
@sarina @nedbat 
