### PR TITLE
Update XBlock to latest version

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -17,7 +17,7 @@
 -e git+https://github.com/appliedsec/pygeoip.git@95e69341cebf5a6a9fbf7c4f5439d458898bdc3b#egg=pygeoip
 
 # Our libraries:
--e git+https://github.com/edx/XBlock.git@6dd8a9223cae34184ba5e2e1a186f36c4df1e080#egg=XBlock
+-e git+https://github.com/edx/XBlock.git@6ec7edd6c44c7d2f1583df077cbf3e0f621ae984#egg=XBlock
 -e git+https://github.com/edx/codejail.git@e3d98f9455#egg=codejail
 -e git+https://github.com/edx/diff-cover.git@v0.2.9#egg=diff_cover
 -e git+https://github.com/edx/js-test-tool.git@v0.1.5#egg=js_test_tool


### PR DESCRIPTION
Update XBlock to the latest version.  The changes are:
1) Move parts of the repo into XBlock-sdk (2d1a7c21604bdcd60152b5c6ae586d9a3b0c4a45)
2) Add a DateTime field (c7ef611727d89887a258c5d4774a6efbda36cb13 and 2ac249d5af0cd42adf766bfb1c6858354bbcccd9)

The peer assessment XBlock depends on (2).  Updating XBlock now is a preventative measure to avoid Jenkins build failures.  Once edx-tim gets installed, it stays installed, and the runtime will try to load it.  This means that any branch using an earlier version of XBlock will fail in Jenkins.

@nedbat @jzoldak 
