### PR TITLE
FIX - LMS: Courseware Content Background Color/Height in IE

### DIFF
--- a/lms/static/sass/ie.scss
+++ b/lms/static/sass/ie.scss
@@ -184,10 +184,13 @@
   }
 
   .course-wrapper {
-    clear: both !important;
+    @include clearfix();
   }
 }
 
+// ====================
+
+// CASE: IE9
 .lte9 {
 
   .ie-banner {


### PR DESCRIPTION
This work resolves IE9 (and IE 6-8 in general) display issue where courseware content layout/background display was broken.
