### PR TITLE
Video: Add highlighting of start/end time field when clicking into it.

### DIFF
--- a/cms/static/js/views/metadata.js
+++ b/cms/static/js/views/metadata.js
@@ -320,12 +320,14 @@ function(BaseView, _, MetadataModel, AbstractEditor, VideoList) {
 
     Metadata.RelativeTime = AbstractEditor.extend({
 
-        defaultValue : '00:00:00',
+        defaultValue: '00:00:00',
         // By default max value of RelativeTime field on Backend is 23:59:59,
         // that is 86399 seconds.
-        maxTimeInSeconds : 86399,
+        maxTimeInSeconds: 86399,
 
-        events : {
+        events: {
+            "focus input" : "addSelection",
+            "mouseup input" : "mouseUpHandler",
             "change input" : "updateModel",
             "keypress .setting-input" : "showClearButton"  ,
             "click .setting-clear" : "clear"
@@ -333,7 +335,7 @@ function(BaseView, _, MetadataModel, AbstractEditor, VideoList) {
 
         templateName: "metadata-string-entry",
 
-        getValueFromEditor : function () {
+        getValueFromEditor: function () {
             var $input = this.$el.find('#' + this.uniqueId);
 
             return $input.val();
@@ -384,18 +386,28 @@ function(BaseView, _, MetadataModel, AbstractEditor, VideoList) {
             ].join(':');
         },
 
-        setValueInEditor : function (value) {
+        setValueInEditor: function (value) {
             if (!value) {
                 value = this.defaultValue;
             }
 
             this.$el.find('input').val(value);
+        },
+
+        addSelection: function (event) {
+            $(event.currentTarget).select();
+        },
+
+        mouseUpHandler: function (event) {
+            // Prevents default behavior to make works selection in WebKit
+            // browsers
+            event.preventDefault();
         }
     });
 
     Metadata.Dict = AbstractEditor.extend({
 
-        events : {
+        events: {
             "click .setting-clear" : "clear",
             "keypress .setting-input" : "showClearButton",
             "change input" : "updateModel",


### PR DESCRIPTION
[BLD-581](https://edx-wiki.atlassian.net/browse/BLD-581)

**Description**
When clicking into the start/end time field, the entire 00:00:00 string should be highlighted so that when the user starts typing, she is (by default) typing in an empty text field.

Studio -> Video -> Editor -> Advanced tab

@jmclaus 
