### PR TITLE
Convert CAPA inputtype statuses from strings to objects,

### DIFF
--- a/common/lib/capa/capa/inputtypes.py
+++ b/common/lib/capa/capa/inputtypes.py
@@ -60,7 +60,47 @@ log = logging.getLogger(__name__)
 
 #########################################################################
 
-registry = TagRegistry()
+registry = TagRegistry()  # pylint: disable=C0103
+
+
+class Status(object):
+    """
+    Problem status
+    attributes: classname, display_name
+    """
+    css_classes = {
+        # status: css class
+        'unsubmitted': 'unanswered',
+        'incomplete': 'incorrect',
+        'queued': 'processing',
+    }
+    __slots__ = ('classname', '_status', 'display_name')
+
+    def __init__(self, status, gettext_func=unicode):
+        self.classname = self.css_classes.get(status, status)
+        _ = gettext_func
+        names = {
+            'correct': _('correct'),
+            'incorrect': _('incorrect'),
+            'incomplete': _('incomplete'),
+            'unanswered': _('unanswered'),
+            'unsubmitted': _('unanswered'),
+            'queued': _('processing'),
+        }
+        self.display_name = names.get(status, unicode(status))
+        self._status = status or ''
+
+    def __str__(self):
+        return self._status
+
+    def __unicode__(self):
+        return self._status.decode('utf8')
+
+    def __repr__(self):
+        return 'Status(%r)' % self._status
+
+    def __eq__(self, other):
+        return self._status == str(other)
 
 
 class Attribute(object):
@@ -259,9 +299,7 @@ class InputTypeBase(object):
         context = {
             'id': self.input_id,
             'value': self.value,
-            'status': self.status,
-            'status_class': self.status_class,
-            'status_display': self.status_display,
+            'status': Status(self.status, self.capa_system.i18n.ugettext),
             'msg': self.msg,
             'STATIC_URL': self.capa_system.STATIC_URL,
         }
@@ -270,34 +308,6 @@ class InputTypeBase(object):
         )
         context.update(self._extra_context())
         return context
-
-    @property
-    def status_class(self):
-        """
-        Return the CSS class for the associated status.
-        """
-        statuses = {
-            'unsubmitted': 'unanswered',
-            'incomplete': 'incorrect',
-            'queued': 'processing',
-        }
-        return statuses.get(self.status, self.status)
-
-    @property
-    def status_display(self):
-        """
-        Return the human-readable and translated word for the associated status.
-        """
-        _ = self.capa_system.i18n.ugettext
-        statuses = {
-            'correct': _('correct'),
-            'incorrect': _('incorrect'),
-            'incomplete': _('incomplete'),
-            'unanswered': _('unanswered'),
-            'unsubmitted': _('unanswered'),
-            'queued': _('queued'),
-        }
-        return statuses.get(self.status, self.status)
 
     def _extra_context(self):
         """

--- a/common/lib/capa/capa/templates/annotationinput.html
+++ b/common/lib/capa/capa/templates/annotationinput.html
@@ -52,13 +52,7 @@
         <input type="hidden" class="value" name="input_${id}" id="input_${id}" value="${value|h}" />
     % endif
 
-    % if status == 'unsubmitted':
-    <span class="unanswered" style="display:inline-block;" id="status_${id}" aria-describedby="input_${id}"><span class="sr">Status: Unanswered</span></span>
-    % elif status == 'incomplete':
-    <span class="incorrect" id="status_${id}" aria-describedby="input_${id}"><span class="sr">Status: Incorrect</span></span>
-    % elif status == 'incorrect' and not has_options_value:
-    <span class="incorrect" id="status_${id}" aria-describedby="input_${id}"><span class="sr">Status: Incorrect</span></span>
-    % endif
+    <span class="status ${status.classname}" id="status_${id}" aria-describedby="input_${id}"><span class="sr">${status.display_name}</span></span>
 
     <p id="answer_${id}" class="answer answer-annotation"></p>
 </div>

--- a/common/lib/capa/capa/templates/chemicalequationinput.html
+++ b/common/lib/capa/capa/templates/chemicalequationinput.html
@@ -1,7 +1,7 @@
 <div id="chemicalequationinput_${id}" class="chemicalequationinput">
     <div class="script_placeholder" data-src="${previewer}"/>
 
-    <div class="${status_class}" id="status_${id}">
+    <div class="${status.classname}" id="status_${id}">
 
     <input type="text" name="input_${id}" id="input_${id}" aria-label="${label}" aria-describedby="answer_${id}" data-input-id="${id}" value="${value|h}"
    % if size:
@@ -11,7 +11,7 @@
 
       <p class="status" aria-describedby="input_${id}">
         ${value|h} -
-        ${status_display}
+        ${status.display_name}
       </p>
 
       <div id="input_${id}_preview" class="equation"></div>

--- a/common/lib/capa/capa/templates/choicegroup.html
+++ b/common/lib/capa/capa/templates/choicegroup.html
@@ -1,7 +1,7 @@
 <form class="choicegroup capa_inputtype" id="inputtype_${id}">
     <div class="indicator_container">
     % if input_type == 'checkbox' or not value:
-        <span class="status ${status_class if show_correctness != 'never' else 'unanswered'}"
+        <span class="status ${status.classname if show_correctness != 'never' else 'unanswered'}"
             id="status_${id}"
             aria-describedby="inputtype_${id}">
             <span class="sr">
@@ -11,7 +11,7 @@
                 %endif
                 %endfor
                 -
-                ${status_display}
+                ${status.display_name}
             </span>
         </span>
     % endif
@@ -51,7 +51,7 @@
 
             % if input_type == 'radio' and ( (isinstance(value, basestring) and (choice_id == value))  or  (not isinstance(value, basestring) and choice_id in value) ):
             % if status in ('correct', 'incorrect') and not show_correctness=='never':
-            <span class="sr status">${choice_description|h} - ${status_display}</span>
+            <span class="sr status">${choice_description|h} - ${status.display_name}</span>
             % endif
             % endif
         </label>

--- a/common/lib/capa/capa/templates/choicetext.html
+++ b/common/lib/capa/capa/templates/choicetext.html
@@ -10,7 +10,7 @@
     <div class="script_placeholder" data-src="/static/js/capa/choicetextinput.js"/>
     <div class="indicator_container">
     % if input_type == 'checkbox' or not element_checked:
-        <span class="status ${status_class}" id="status_${id}"></span>
+        <span class="status ${status.classname}" id="status_${id}"></span>
     % endif
     </div>
 

--- a/common/lib/capa/capa/templates/codeinput.html
+++ b/common/lib/capa/capa/templates/codeinput.html
@@ -17,10 +17,10 @@
 
   <div class="grader-status" tabindex="-1">
       <span id="status_${id}"
-            class="${status_class}"
+            class="${status.classname}"
             aria-describedby="input_${id}"
       >
-          <span class="status sr">${status_display}</span>
+          <span class="status sr">${status.display_name}</span>
       </span>
     % if status == 'queued':
       <span style="display:none;" class="xqueue" id="${id}">${queue_len}</span>
@@ -30,7 +30,7 @@
       <div style="display:none;" name="${hidden}" inputid="input_${id}" />
     % endif
 
-    <p class="debug">${status_display}</p>
+    <p class="debug">${status.display_name}</p>
   </div>
 
   <span id="answer_${id}"></span>

--- a/common/lib/capa/capa/templates/crystallography.html
+++ b/common/lib/capa/capa/templates/crystallography.html
@@ -9,29 +9,14 @@
     <div class="script_placeholder" data-src="/static/js/sylvester.js"></div>
     <div class="script_placeholder" data-src="/static/js/crystallography.js"></div>
 
-    % if status == 'unsubmitted':
-        <div class="unanswered" id="status_${id}">
-    % elif status == 'correct':
-        <div class="correct" id="status_${id}">
-    % elif status == 'incorrect':
-        <div class="incorrect" id="status_${id}">
-    % elif status == 'incomplete':
-        <div class="incorrect" id="status_${id}">
-    % endif
+    % if status in ['unsubmitted', 'correct', 'incorrect', 'incomplete']:
+        <div class="status ${status.classname}" id="status_${id}">
 
 
     <input type="text" name="input_${id}" aria-describedby="answer_${id}" id="input_${id}" value="${value|h}" style="display:none;"/>
 
     <p class="status" aria-describedby="input_${id}">
-        % if status == 'unsubmitted':
-        unanswered
-        % elif status == 'correct':
-        correct
-        % elif status == 'incorrect':
-        incorrect
-        % elif status == 'incomplete':
-        incomplete
-        % endif
+        ${status.display_name}
     </p>
 
     <p id="answer_${id}" class="answer"></p>

--- a/common/lib/capa/capa/templates/designprotein2dinput.html
+++ b/common/lib/capa/capa/templates/designprotein2dinput.html
@@ -2,14 +2,8 @@
     <div class="script_placeholder" data-src="/static/js/capa/protex/protex.nocache.js?raw"/>
     <div class="script_placeholder" data-src="${applet_loader}"/>
 
-    % if status == 'unsubmitted':
-    <div class="unanswered" id="status_${id}">
-    % elif status == 'correct':
-    <div class="correct" id="status_${id}">
-    % elif status == 'incorrect':
-    <div class="incorrect" id="status_${id}">
-    % elif status == 'incomplete':
-    <div class="incomplete" id="status_${id}">
+    % if status in ['unsubmitted', 'correct', 'incorrect', 'incomplete']:
+    <div class="${status.classname}" id="status_${id}">
     % endif
 
     <div id="protex_container"></div>
@@ -17,15 +11,7 @@
     <input type="hidden" name="input_${id}" id="input_${id}" aria-describedby="answer_${id}" value="${value|h}"/>
 
     <p class="status" aria-describedby="input_${id}">
-      % if status == 'unsubmitted':
-      unanswered
-      % elif status == 'correct':
-      correct
-      % elif status == 'incorrect':
-      incorrect
-      % elif status == 'incomplete':
-      incomplete
-      % endif
+    ${status.display_name}
     </p>
 
     <p id="answer_${id}" class="answer"></p>

--- a/common/lib/capa/capa/templates/drag_and_drop_input.html
+++ b/common/lib/capa/capa/templates/drag_and_drop_input.html
@@ -8,14 +8,8 @@
 
     <div class="script_placeholder" data-src="${STATIC_URL}js/capa/drag_and_drop.js"></div>
 
-    % if status == 'unsubmitted':
-        <div class="unanswered" id="status_${id}">
-    % elif status == 'correct':
-        <div class="correct" id="status_${id}">
-    % elif status == 'incorrect':
-        <div class="incorrect" id="status_${id}">
-    % elif status == 'incomplete':
-        <div class="incorrect" id="status_${id}">
+    % if status in ['unsubmitted', 'correct', 'incorrect', 'incomplete']:
+        <div class="${status.classname}" id="status_${id}">
     % endif
 
 
@@ -23,15 +17,7 @@
     style="display:none;"/>
 
     <p class="status" aria-describedby="input_${id}">
-        % if status == 'unsubmitted':
-        unanswered
-        % elif status == 'correct':
-        correct
-        % elif status == 'incorrect':
-        incorrect
-        % elif status == 'incomplete':
-        incomplete
-        % endif
+    ${status.display_name}
     </p>
 
     <p id="answer_${id}" class="answer"></p>

--- a/common/lib/capa/capa/templates/editageneinput.html
+++ b/common/lib/capa/capa/templates/editageneinput.html
@@ -2,14 +2,8 @@
     <div class="script_placeholder" data-src="/static/js/capa/genex/genex.nocache.js?raw"/>
     <div class="script_placeholder" data-src="${applet_loader}"/>
 
-    % if status == 'unsubmitted':
-    <div class="unanswered" id="status_${id}">
-    % elif status == 'correct':
-    <div class="correct" id="status_${id}">
-    % elif status == 'incorrect':
-    <div class="incorrect" id="status_${id}">
-    % elif status == 'incomplete':
-    <div class="incomplete" id="status_${id}">
+    % if status in ['unsubmitted', 'correct', 'incorrect', 'incomplete']:
+    <div class="${status.classname}" id="status_${id}">
     % endif
 
     <div id="genex_container"></div>
@@ -18,15 +12,7 @@
     <input type="hidden" name="input_${id}" aria-describedby="answer_${id}" id="input_${id}" value="${value|h}"/>
 
     <p class="status" aria-describedby="input_${id}">
-      % if status == 'unsubmitted':
-      unanswered
-      % elif status == 'correct':
-      correct
-      % elif status == 'incorrect':
-      incorrect
-      % elif status == 'incomplete':
-      incomplete
-      % endif
+    ${status.display_name}
     </p>
 
     <p id="answer_${id}" class="answer"></p>

--- a/common/lib/capa/capa/templates/editamolecule.html
+++ b/common/lib/capa/capa/templates/editamolecule.html
@@ -1,15 +1,9 @@
 <section id="editamoleculeinput_${id}" class="editamoleculeinput">
   <div class="script_placeholder" data-src="${applet_loader}"/>
 
-  % if status == 'unsubmitted':
-  <div class="unanswered" id="status_${id}">
-  % elif status == 'correct':
-  <div class="correct" id="status_${id}">
-  % elif status == 'incorrect':
-  <div class="incorrect" id="status_${id}">
-  % elif status == 'incomplete':
-  <div class="incorrect" id="status_${id}">
-  % endif
+    % if status in ['unsubmitted', 'correct', 'incorrect', 'incomplete']:
+    <div class="${status.classname}" id="status_${id}">
+    % endif
 
     <div id="applet_${id}" class="applet" data-molfile-src="${file}" style="display:block;width:500px;height:400px">
     </div>
@@ -23,15 +17,7 @@
     <p id="answer_${id}" class="answer"></p>
 
     <p class="status" aria-describedby="input_${id}">
-      % if status == 'unsubmitted':
-      unanswered
-      % elif status == 'correct':
-      correct
-      % elif status == 'incorrect':
-      incorrect
-      % elif status == 'incomplete':
-      incomplete
-      % endif
+    ${status.display_name}
     </p>
     <br/> <br/>
 

--- a/common/lib/capa/capa/templates/filesubmission.html
+++ b/common/lib/capa/capa/templates/filesubmission.html
@@ -1,14 +1,9 @@
 <section id="filesubmission_${id}" class="filesubmission">
   <div class="grader-status file">
-    % if status == 'unsubmitted':
-    <span class="unanswered" style="display:inline-block;" id="status_${id}">Unanswered</span>
-    % elif status == 'correct':
-    <span class="correct" id="status_${id}">Correct</span>
-    % elif status == 'incorrect':
-    <span class="incorrect" id="status_${id}">Incorrect</span>
-    % elif status == 'queued':
-    <span class="processing" id="status_${id}">Queued</span>
-    <span style="display:none;" class="xqueue" id="${id}" >${queue_len}</span>
+
+    <span class="${status.classname}" id="status_${id}">${status.display_name}</span>
+    % if status == 'queued':
+    <span style="display:none;" class="xqueue" id="${id}">${queue_len}</span>
     % endif
     <p class="debug">${status}</p>
 

--- a/common/lib/capa/capa/templates/formulaequationinput.html
+++ b/common/lib/capa/capa/templates/formulaequationinput.html
@@ -1,6 +1,6 @@
 <% doinline = 'style="display:inline-block;vertical-align:top"' if inline else "" %>
 <section id="formulaequationinput_${id}" class="inputtype formulaequationinput" ${doinline}>
-  <div class="${status_class}" id="status_${id}">
+  <div class="${status.classname}" id="status_${id}">
     <input type="text" name="input_${id}" id="input_${id}"
         data-input-id="${id}" value="${value|h}"
         aria-label="${label}"
@@ -20,7 +20,7 @@
               % else:
               ${label}
               %endif
-          </span> - ${status_display}
+          </span> - ${status.display_name}
       </p>
 
       <div id="input_${id}_preview" class="equation">

--- a/common/lib/capa/capa/templates/imageinput.html
+++ b/common/lib/capa/capa/templates/imageinput.html
@@ -39,38 +39,11 @@
     (new ImageInput('${id}'));
   </script>
 
-  % if status == 'unsubmitted':
       <span
-        class="unanswered"
-        style="display: inline-block;"
+        class="status ${status.classname}"
         id="status_${id}"
         aria-describedby="input_${id}"
       >
-        <span class="sr">Status: unanswered</span>
+        <span class="sr">${status.display_name}</span>
       </span>
-  % elif status == 'correct':
-      <span
-        class="correct"
-        id="status_${id}"
-        aria-describedby="input_${id}"
-      >
-        <span class="sr">Status: correct</span>
-      </span>
-  % elif status == 'incorrect':
-      <span
-        class="incorrect"
-        id="status_${id}"
-        aria-describedby="input_${id}"
-      >
-        <span class="sr">Status: incorrect</span>
-      </span>
-  % elif status == 'incomplete':
-      <span
-        class="incorrect"
-        id="status_${id}"
-        aria-describedby="input_${id}"
-      >
-        <span class="sr">Status: incorrect</span>
-      </span>
-  % endif
 </div>

--- a/common/lib/capa/capa/templates/jsinput.html
+++ b/common/lib/capa/capa/templates/jsinput.html
@@ -17,14 +17,8 @@
 
   <div class="script_placeholder" data-src="${jschannel_loader}"/>
   <div class="script_placeholder" data-src="${jsinput_loader}"/>
-  % if status == 'unsubmitted':
-  <div class="unanswered" id="status_${id}">
-  % elif status == 'correct':
-  <div class="correct" id="status_${id}">
-  % elif status == 'incorrect':
-  <div class="incorrect" id="status_${id}">
-  % elif status == 'incomplete':
-  <div class="incorrect" id="status_${id}">
+  % if status in ['unsubmitted', 'correct', 'incorrect', 'incomplete']:
+  <div class="${status.classname}" id="status_${id}">
   % endif
 
   <iframe name="iframe_${id}"
@@ -44,15 +38,7 @@
     <p id="answer_${id}" class="answer"></p>
 
     <p class="status">
-      % if status == 'unsubmitted':
-      unanswered
-      % elif status == 'correct':
-      correct
-      % elif status == 'incorrect':
-      incorrect
-      % elif status == 'incomplete':
-      incomplete
-      % endif
+    ${status.display_name}
     </p>
     <br/> <br/>
 

--- a/common/lib/capa/capa/templates/jstextline.html
+++ b/common/lib/capa/capa/templates/jstextline.html
@@ -18,23 +18,9 @@
     <textarea style="display:none" id="input_${id}_fromjs" name="input_${id}_fromjs"></textarea>
   % endif
 
-  % if status == 'unsubmitted':
-  <span class="unanswered" style="display:inline-block;" id="status_${id}" aria-describedby="input_${id}">
-    <span class="sr">Status: unanswered</span>
+  <span class="status ${status.classname}" id="status_${id}" aria-describedby="input_${id}">
+    <span class="sr">${status.display_name</span>
   </span>
-  % elif status == 'correct':
-  <span class="correct" id="status_${id}" aria-describedby="input_${id}">
-    <span class="sr">Status: correct</span>
-  </span>
-  % elif status == 'incorrect':
-  <span class="incorrect" id="status_${id}" aria-describedby="input_${id}">
-    <span class="sr">Status: incorrect</span>
-  </span>
-  % elif status == 'incomplete':
-  <span class="incorrect" id="status_${id}" aria-describedby="input_${id}">
-    <span class="sr">Status: incorrect</span>
-  </span>
-  % endif
   % if msg:
     <br/>
     <span class="debug">${msg|n}</span>

--- a/common/lib/capa/capa/templates/matlabinput.html
+++ b/common/lib/capa/capa/templates/matlabinput.html
@@ -18,10 +18,10 @@
 
   <div class="grader-status" tabindex="-1">
       <span id="status_${id}"
-            class="${status_class}"
+            class="${status.classname}"
             aria-describedby="input_${id}"
       >
-          <span class="status sr">${status_display}</span>
+          <span class="status sr">${status.display_name}</span>
       </span>
     % if status == 'queued':
       <span style="display:none;" class="xqueue" id="${id}">${queue_len}</span>
@@ -31,7 +31,7 @@
       <div style="display:none;" name="${hidden}" inputid="input_${id}" />
     % endif
 
-    <p class="debug">${status_display}</p>
+    <p class="debug">${status.display_name}</p>
   </div>
 
   <span id="answer_${id}"></span>

--- a/common/lib/capa/capa/templates/optioninput.html
+++ b/common/lib/capa/capa/templates/optioninput.html
@@ -13,10 +13,10 @@
     </select>
 
   <span id="answer_${id}"></span>  
-  <span class="status ${status_class}"
+  <span class="status ${status.classname}"
       id="status_${id}"
       aria-describedby="input_${id}">
-    <span class="sr">${value|h} - ${status_display}</span>
+    <span class="sr">${value|h} - ${status.display_name}</span>
   </span>
 
   % if msg:

--- a/common/lib/capa/capa/templates/schematicinput.html
+++ b/common/lib/capa/capa/templates/schematicinput.html
@@ -1,4 +1,4 @@
-<span>
+<div>
   <div class="script_placeholder" data-src="${setup_script}"/>
   <input type="hidden"
     class="schematic"
@@ -16,23 +16,7 @@
     />
 
   <span id="answer_${id}"></span>
-  % if status == 'unsubmitted':
-  <span class="ui-icon ui-icon-bullet" style="display:inline-block;" id="status_${id}" aria-describedby="input_${id}">
-    <span class="sr">Status: unsubmitted</span>
+  <span class="status ${status.classname}" id="status_${id}" aria-describedby="input_${id}">
+    <span class="sr">${status.display_name}</span>
   </span>
-  % elif status == 'correct':
-  <span class="ui-icon ui-icon-check" style="display:inline-block;" id="status_${id}" aria-describedby="input_${id}">
-    <span class="sr">Status: correct</span>
-  </span>
-  % elif status == 'incorrect':
-  <span class="ui-icon ui-icon-close" style="display:inline-block;" id="status_${id}" aria-describedby="input_${id}">
-    <span class="sr">Status: incorrect</span>
-  </span>
-  % elif status == 'incomplete':
-  <span class="ui-icon ui-icon-close" style="display:inline-block;" id="status_${id}" aria-describedby="input_${id}">
-    <span class="sr">Status: incomplete</span>
-  </span>
-  % endif
-
-</span>
-
+</div>

--- a/common/lib/capa/capa/templates/textline.html
+++ b/common/lib/capa/capa/templates/textline.html
@@ -8,7 +8,7 @@
     % endif
 
     % if status in ('unsubmitted', 'correct', 'incorrect', 'incomplete'):
-    <div class="${status_class} ${doinline}" id="status_${id}">
+    <div class="${status.classname} ${doinline}" id="status_${id}">
     % endif
     % if hidden:
       <div style="display:none;" name="${hidden}" inputid="input_${id}" />
@@ -38,7 +38,7 @@
         ${label}
         %endif
         -
-        ${status_display}
+        ${status.display_name}
       </p>
 
       <p id="answer_${id}" class="answer" aria-hidden="true"></p>

--- a/common/lib/capa/capa/templates/vsepr_input.html
+++ b/common/lib/capa/capa/templates/vsepr_input.html
@@ -11,14 +11,8 @@
 
     <div class="script_placeholder" data-src="/static/js/vsepr/vsepr.js"></div>
 
-    % if status == 'unsubmitted':
-    <div class="unanswered" id="status_${id}">
-    % elif status == 'correct':
-    <div class="correct" id="status_${id}">
-    % elif status == 'incorrect':
-    <div class="incorrect" id="status_${id}">
-    % elif status == 'incomplete':
-    <div class="incorrect" id="status_${id}">
+    % if status in ['unsubmitted', 'correct', 'incorrect', 'incomplete']:
+    <div class="${status.classname}" id="status_${id}">
     % endif
 
   <input type="text" name="input_${id}" id="input_${id}" aria-describedby="answer_${id}" value="${value|h}"
@@ -26,15 +20,7 @@
    />
 
       <p class="status" aria-describedby="input_${id}">
-        % if status == 'unsubmitted':
-        unanswered
-        % elif status == 'correct':
-        correct
-        % elif status == 'incorrect':
-        incorrect
-        % elif status == 'incomplete':
-        incomplete
-        % endif
+      ${status.display_name}
       </p>
 
   <p id="answer_${id}" class="answer"></p>

--- a/common/lib/capa/capa/tests/__init__.py
+++ b/common/lib/capa/capa/tests/__init__.py
@@ -7,6 +7,7 @@ import os.path
 import fs.osfs
 
 from capa.capa_problem import LoncapaProblem, LoncapaSystem
+from capa.inputtypes import Status
 from mock import Mock, MagicMock
 
 import xml.sax.saxutils as saxutils
@@ -47,6 +48,7 @@ def test_capa_system():
         render_template=tst_render_template,
         seed=0,
         STATIC_URL='/dummy-static/',
+        STATUS_CLASS=Status,
         xqueue={'interface': xqueue_interface, 'construct_callback': calledback_url, 'default_queuename': 'testqueue', 'waittime': 10},
     )
     return the_system

--- a/common/lib/capa/capa/tests/test_html_render.py
+++ b/common/lib/capa/capa/tests/test_html_render.py
@@ -153,9 +153,7 @@ class CapaHtmlRenderTest(unittest.TestCase):
         # the solution
         expected_textline_context = {
             'STATIC_URL': '/dummy-static/',
-            'status': 'unsubmitted',
-            'status_class': 'unanswered',
-            'status_display': u'unanswered',
+            'status': the_system.STATUS_CLASS('unsubmitted'),
             'label': '',
             'value': '',
             'preprocessor': None,

--- a/common/lib/capa/capa/tests/test_input_templates.py
+++ b/common/lib/capa/capa/tests/test_input_templates.py
@@ -9,7 +9,7 @@ import json
 from lxml import etree
 from mako.template import Template as MakoTemplate
 from mako import exceptions
-
+from capa.inputtypes import Status
 
 class TemplateError(Exception):
     """
@@ -123,9 +123,7 @@ class ChoiceGroupTemplateTest(TemplateTestCase):
         choices = [('1', 'choice 1'), ('2', 'choice 2'), ('3', 'choice 3')]
         self.context = {'id': '1',
                         'choices': choices,
-                        'status': 'correct',
-                        'status_class': 'correct',
-                        'status_display': u'correct',
+                        'status': Status('correct'),
                         'label': 'test',
                         'input_type': 'checkbox',
                         'name_array_suffix': '1',
@@ -138,7 +136,7 @@ class ChoiceGroupTemplateTest(TemplateTestCase):
         (not a particular option) is marked correct.
         """
 
-        self.context['status'] = self.context['status_class'] = self.context['status_display'] = 'correct'
+        self.context['status'] = Status('correct')
         self.context['input_type'] = 'checkbox'
         self.context['value'] = ['1', '2']
 
@@ -160,14 +158,14 @@ class ChoiceGroupTemplateTest(TemplateTestCase):
         (not a particular option) is marked incorrect.
         """
         conditions = [
-            {'status': 'incorrect', 'input_type': 'radio', 'value': '', 'status_class': 'incorrect'},
-            {'status': 'incorrect', 'input_type': 'checkbox', 'value': [], 'status_class': 'incorrect'},
-            {'status': 'incorrect', 'input_type': 'checkbox', 'value': ['2'], 'status_class': 'incorrect'},
-            {'status': 'incorrect', 'input_type': 'checkbox', 'value': ['2', '3'], 'status_class': 'incorrect'},
-            {'status': 'incomplete', 'input_type': 'radio', 'value': '', 'status_class': 'incorrect'},
-            {'status': 'incomplete', 'input_type': 'checkbox', 'value': [], 'status_class': 'incorrect'},
-            {'status': 'incomplete', 'input_type': 'checkbox', 'value': ['2'], 'status_class': 'incorrect'},
-            {'status': 'incomplete', 'input_type': 'checkbox', 'value': ['2', '3'], 'status_class': 'incorrect'}]
+            {'status': Status('incorrect'), 'input_type': 'radio', 'value': ''},
+            {'status': Status('incorrect'), 'input_type': 'checkbox', 'value': []},
+            {'status': Status('incorrect'), 'input_type': 'checkbox', 'value': ['2']},
+            {'status': Status('incorrect'), 'input_type': 'checkbox', 'value': ['2', '3']},
+            {'status': Status('incomplete'), 'input_type': 'radio', 'value': ''},
+            {'status': Status('incomplete'), 'input_type': 'checkbox', 'value': []},
+            {'status': Status('incomplete'), 'input_type': 'checkbox', 'value': ['2']},
+            {'status': Status('incomplete'), 'input_type': 'checkbox', 'value': ['2', '3']}]
 
         for test_conditions in conditions:
             self.context.update(test_conditions)
@@ -190,16 +188,16 @@ class ChoiceGroupTemplateTest(TemplateTestCase):
         (not a particular option) is marked unanswered.
         """
         conditions = [
-            {'status': 'unsubmitted', 'input_type': 'radio', 'value': '', 'status_class': 'unanswered'},
-            {'status': 'unsubmitted', 'input_type': 'radio', 'value': [], 'status_class': 'unanswered'},
-            {'status': 'unsubmitted', 'input_type': 'checkbox', 'value': [], 'status_class': 'unanswered'},
+            {'status': Status('unsubmitted'), 'input_type': 'radio', 'value': ''},
+            {'status': Status('unsubmitted'), 'input_type': 'radio', 'value': []},
+            {'status': Status('unsubmitted'), 'input_type': 'checkbox', 'value': []},
             {'input_type': 'radio', 'value': ''},
             {'input_type': 'radio', 'value': []},
             {'input_type': 'checkbox', 'value': []},
             {'input_type': 'checkbox', 'value': ['1']},
             {'input_type': 'checkbox', 'value': ['1', '2']}]
 
-        self.context['status'] = self.context['status_class'] = 'unanswered'
+        self.context['status'] = Status('unanswered')
 
         for test_conditions in conditions:
             self.context.update(test_conditions)
@@ -225,7 +223,7 @@ class ChoiceGroupTemplateTest(TemplateTestCase):
             {'input_type': 'radio', 'value': '2'},
             {'input_type': 'radio', 'value': ['2']}]
 
-        self.context['status'] = 'correct'
+        self.context['status'] = Status('correct')
 
         for test_conditions in conditions:
             self.context.update(test_conditions)
@@ -246,7 +244,7 @@ class ChoiceGroupTemplateTest(TemplateTestCase):
             {'input_type': 'radio', 'value': '2'},
             {'input_type': 'radio', 'value': ['2']}]
 
-        self.context['status'] = self.context['status_class'] = 'incorrect'
+        self.context['status'] = Status('incorrect')
 
         for test_conditions in conditions:
             self.context.update(test_conditions)
@@ -270,16 +268,16 @@ class ChoiceGroupTemplateTest(TemplateTestCase):
         """
 
         conditions = [
-            {'input_type': 'radio', 'status': 'correct', 'value': '', 'status_class': 'correct'},
-            {'input_type': 'radio', 'status': 'correct', 'value': '2', 'status_class': 'correct'},
-            {'input_type': 'radio', 'status': 'correct', 'value': ['2'], 'status_class': 'correct'},
-            {'input_type': 'radio', 'status': 'incorrect', 'value': '2', 'status_class': 'incorrect'},
-            {'input_type': 'radio', 'status': 'incorrect', 'value': [], 'status_class': 'incorrect'},
-            {'input_type': 'radio', 'status': 'incorrect', 'value': ['2'], 'status_class': 'incorrect'},
-            {'input_type': 'checkbox', 'status': 'correct', 'value': [], 'status_class': 'correct'},
-            {'input_type': 'checkbox', 'status': 'correct', 'value': ['2'], 'status_class': 'correct'},
-            {'input_type': 'checkbox', 'status': 'incorrect', 'value': [], 'status_class': 'incorrect'},
-            {'input_type': 'checkbox', 'status': 'incorrect', 'value': ['2'], 'status_class': 'incorrect'}]
+            {'input_type': 'radio', 'status': Status('correct'), 'value': ''},
+            {'input_type': 'radio', 'status': Status('correct'), 'value': '2'},
+            {'input_type': 'radio', 'status': Status('correct'), 'value': ['2']},
+            {'input_type': 'radio', 'status': Status('incorrect'), 'value': '2'},
+            {'input_type': 'radio', 'status': Status('incorrect'), 'value': []},
+            {'input_type': 'radio', 'status': Status('incorrect'), 'value': ['2']},
+            {'input_type': 'checkbox', 'status': Status('correct'), 'value': []},
+            {'input_type': 'checkbox', 'status': Status('correct'), 'value': ['2']},
+            {'input_type': 'checkbox', 'status': Status('incorrect'), 'value': []},
+            {'input_type': 'checkbox', 'status': Status('incorrect'), 'value': ['2']}]
 
         self.context['show_correctness'] = 'never'
         self.context['submitted_message'] = 'Test message'
@@ -315,9 +313,9 @@ class ChoiceGroupTemplateTest(TemplateTestCase):
         """
 
         conditions = [
-            {'input_type': 'radio', 'status': 'unsubmitted', 'value': ''},
-            {'input_type': 'radio', 'status': 'unsubmitted', 'value': []},
-            {'input_type': 'checkbox', 'status': 'unsubmitted', 'value': []},
+            {'input_type': 'radio', 'status': Status('unsubmitted'), 'value': ''},
+            {'input_type': 'radio', 'status': Status('unsubmitted'), 'value': []},
+            {'input_type': 'checkbox', 'status': Status('unsubmitted'), 'value': []},
 
             # These tests expose bug #365
             # When the bug is fixed, uncomment these cases.
@@ -354,9 +352,7 @@ class TextlineTemplateTest(TemplateTestCase):
 
     def setUp(self):
         self.context = {'id': '1',
-                        'status': 'correct',
-                        'status_class': 'correct',
-                        'status_display': u'correct',
+                        'status': Status('correct'),
                         'label': 'test',
                         'value': '3',
                         'preprocessor': None,
@@ -383,9 +379,7 @@ class TextlineTemplateTest(TemplateTestCase):
                  ('incomplete', 'incorrect', 'incomplete')]
 
         for (context_status, div_class, status_mark) in cases:
-            self.context['status'] = context_status
-            self.context['status_class'] = div_class
-            self.context['status_display'] = status_mark
+            self.context['status'] = Status(context_status)
             xml = self.render_to_xml(self.context)
 
             # Expect that we get a <div> with correct class
@@ -461,8 +455,7 @@ class TextlineTemplateTest(TemplateTestCase):
         self.context['inline'] = True
 
         for (context_status, div_class) in cases:
-            self.context['status'] = context_status
-            self.context['status_class'] = div_class
+            self.context['status'] = Status(context_status)
             xml = self.render_to_xml(self.context)
 
             # Expect that we get a <div> with correct class
@@ -487,9 +480,7 @@ class FormulaEquationInputTemplateTest(TemplateTestCase):
         self.context = {
             'id': 2,
             'value': 'PREFILLED_VALUE',
-            'status': 'unsubmitted',
-            'status_class': 'unanswered',
-            'status_display': u'unsubmitted',
+            'status': Status('unsubmitted'),
             'label': 'test',
             'previewer': 'file.js',
             'reported_status': 'REPORTED_STATUS',
@@ -525,9 +516,7 @@ class AnnotationInputTemplateTest(TemplateTestCase):
                         'options': [],
                         'has_options_value': False,
                         'debug': False,
-                        'status': 'unsubmitted',
-                        'status_class': 'unanswered',
-                        'status_display': u'unsubmitted',
+                        'status': Status('unsubmitted'),
                         'return_to_annotation': False,
                         'msg': '<p>This is a test message</p>', }
         super(AnnotationInputTemplateTest, self).setUp()
@@ -587,16 +576,16 @@ class AnnotationInputTemplateTest(TemplateTestCase):
                       ('incorrect', 'incorrect')]
 
         for (input_status, expected_css_class) in test_cases:
-            self.context['status'] = input_status
+            self.context['status'] = Status(input_status)
             xml = self.render_to_xml(self.context)
 
-            xpath = "//span[@class='{0}']".format(expected_css_class)
+            xpath = "//span[@class='status {0}']".format(expected_css_class)
             self.assert_has_xpath(xml, xpath, self.context)
 
         # If individual options are being marked, then expect
         # just the option to be marked incorrect, not the whole problem
         self.context['has_options_value'] = True
-        self.context['status'] = 'incorrect'
+        self.context['status'] = Status('incorrect')
         xpath = "//span[@class='incorrect']"
         xml = self.render_to_xml(self.context)
         self.assert_no_xpath(xml, xpath, self.context)
@@ -687,9 +676,7 @@ class OptionInputTemplateTest(TemplateTestCase):
         self.context = {
             'id': 2,
             'options': [],
-            'status': 'unsubmitted',
-            'status_class': 'unanswered',
-            'status_display': u'unanswered',
+            'status': Status('unsubmitted'),
             'label': 'test',
             'value': 0
         }
@@ -729,8 +716,7 @@ class OptionInputTemplateTest(TemplateTestCase):
                       ('incomplete', 'status incorrect')]
 
         for (input_status, expected_css_class) in test_cases:
-            self.context['status'] = input_status
-            self.context['status_class'] = expected_css_class.split(' ')[1]
+            self.context['status'] = Status(input_status)
             xml = self.render_to_xml(self.context)
 
             xpath = "//span[@class='{0}']".format(expected_css_class)
@@ -753,7 +739,7 @@ class DragAndDropTemplateTest(TemplateTestCase):
         self.context = {'id': 2,
                         'drag_and_drop_json': '',
                         'value': 0,
-                        'status': 'unsubmitted',
+                        'status': Status('unsubmitted'),
                         'msg': ''}
         super(DragAndDropTemplateTest, self).setUp()
 
@@ -767,7 +753,7 @@ class DragAndDropTemplateTest(TemplateTestCase):
                       ('incomplete', 'incorrect', 'incomplete')]
 
         for (input_status, expected_css_class, expected_text) in test_cases:
-            self.context['status'] = input_status
+            self.context['status'] = Status(input_status)
             xml = self.render_to_xml(self.context)
 
             # Expect a <div> with the status
@@ -814,9 +800,7 @@ class ChoiceTextGroupTemplateTest(TemplateTestCase):
                    {'tail_text': '', 'type': 'textinput', 'value': '', 'contents': 'choiceinput_1_textinput_0'}])]
         self.context = {'id': '1',
                         'choices': choices,
-                        'status': 'correct',
-                        'status_class': 'correct',
-                        'status_display': u'correct',
+                        'status': Status('correct'),
                         'input_type': 'radio',
                         'label': 'choicetext label',
                         'value': self.VALUE_DICT}
@@ -829,7 +813,7 @@ class ChoiceTextGroupTemplateTest(TemplateTestCase):
         Section is used for checkbox, so inputting text does not deselect
         """
         input_tags = ('radio', 'checkbox')
-        self.context['status'] = 'correct'
+        self.context['status'] = Status('correct')
         xpath = "//section[@id='forinput1_choiceinput_0bc']"
 
         self.context['value'] = {}
@@ -842,7 +826,7 @@ class ChoiceTextGroupTemplateTest(TemplateTestCase):
         """Test conditions under which the entire problem
         (not a particular option) is marked correct"""
 
-        self.context['status'] = 'correct'
+        self.context['status'] = Status('correct')
         self.context['input_type'] = 'checkbox'
         self.context['value'] = self.VALUE_DICT
 
@@ -863,14 +847,14 @@ class ChoiceTextGroupTemplateTest(TemplateTestCase):
         (not a particular option) is marked incorrect"""
         grouping_tags = {'radio': 'label', 'checkbox': 'section'}
         conditions = [
-            {'status': 'incorrect', 'status_class': 'incorrect', 'input_type': 'radio', 'value': {}},
-            {'status': 'incorrect', 'status_class': 'incorrect', 'input_type': 'checkbox', 'value': self.WRONG_CHOICE_CHECKBOX},
-            {'status': 'incorrect', 'status_class': 'incorrect', 'input_type': 'checkbox', 'value': self.BOTH_CHOICE_CHECKBOX},
-            {'status': 'incorrect', 'status_class': 'incorrect', 'input_type': 'checkbox', 'value': self.VALUE_DICT},
-            {'status': 'incomplete', 'status_class': 'incorrect', 'input_type': 'radio', 'value': {}},
-            {'status': 'incomplete', 'status_class': 'incorrect', 'input_type': 'checkbox', 'value': self.WRONG_CHOICE_CHECKBOX},
-            {'status': 'incomplete', 'status_class': 'incorrect', 'input_type': 'checkbox', 'value': self.BOTH_CHOICE_CHECKBOX},
-            {'status': 'incomplete', 'status_class': 'incorrect', 'input_type': 'checkbox', 'value': self.VALUE_DICT}]
+            {'status': Status('incorrect'), 'input_type': 'radio', 'value': {}},
+            {'status': Status('incorrect'), 'input_type': 'checkbox', 'value': self.WRONG_CHOICE_CHECKBOX},
+            {'status': Status('incorrect'), 'input_type': 'checkbox', 'value': self.BOTH_CHOICE_CHECKBOX},
+            {'status': Status('incorrect'), 'input_type': 'checkbox', 'value': self.VALUE_DICT},
+            {'status': Status('incomplete'), 'input_type': 'radio', 'value': {}},
+            {'status': Status('incomplete'), 'input_type': 'checkbox', 'value': self.WRONG_CHOICE_CHECKBOX},
+            {'status': Status('incomplete'), 'input_type': 'checkbox', 'value': self.BOTH_CHOICE_CHECKBOX},
+            {'status': Status('incomplete'), 'input_type': 'checkbox', 'value': self.VALUE_DICT}]
 
         for test_conditions in conditions:
             self.context.update(test_conditions)
@@ -894,15 +878,14 @@ class ChoiceTextGroupTemplateTest(TemplateTestCase):
         grouping_tags = {'radio': 'label', 'checkbox': 'section'}
 
         conditions = [
-            {'status': 'unsubmitted', 'input_type': 'radio', 'value': {}},
-            {'status': 'unsubmitted', 'input_type': 'radio', 'value': self.EMPTY_DICT},
-            {'status': 'unsubmitted', 'input_type': 'checkbox', 'value': {}},
-            {'status': 'unsubmitted', 'input_type': 'checkbox', 'value': self.EMPTY_DICT},
-            {'status': 'unsubmitted', 'input_type': 'checkbox', 'value': self.VALUE_DICT},
-            {'status': 'unsubmitted', 'input_type': 'checkbox', 'value': self.BOTH_CHOICE_CHECKBOX}]
+            {'status': Status('unsubmitted'), 'input_type': 'radio', 'value': {}},
+            {'status': Status('unsubmitted'), 'input_type': 'radio', 'value': self.EMPTY_DICT},
+            {'status': Status('unsubmitted'), 'input_type': 'checkbox', 'value': {}},
+            {'status': Status('unsubmitted'), 'input_type': 'checkbox', 'value': self.EMPTY_DICT},
+            {'status': Status('unsubmitted'), 'input_type': 'checkbox', 'value': self.VALUE_DICT},
+            {'status': Status('unsubmitted'), 'input_type': 'checkbox', 'value': self.BOTH_CHOICE_CHECKBOX}]
 
-        self.context['status'] = 'unanswered'
-        self.context['status_class'] = 'unanswered'
+        self.context['status'] = Status('unanswered')
 
         for test_conditions in conditions:
             self.context.update(test_conditions)

--- a/common/lib/capa/capa/tests/test_inputtypes.py
+++ b/common/lib/capa/capa/tests/test_inputtypes.py
@@ -56,9 +56,7 @@ class OptionInputTest(unittest.TestCase):
             'STATIC_URL': '/dummy-static/',
             'value': 'Down',
             'options': [('Up', 'Up'), ('Down', 'Down'), ('Don\'t know', 'Don\'t know')],
-            'status': 'answered',
-            'status_class': 'answered',
-            'status_display': 'answered',
+            'status': inputtypes.Status('answered'),
             'label': '',
             'msg': '',
             'inline': False,
@@ -118,9 +116,7 @@ class ChoiceGroupTest(unittest.TestCase):
             'STATIC_URL': '/dummy-static/',
             'id': 'sky_input',
             'value': 'foil3',
-            'status': 'answered',
-            'status_class': 'answered',
-            'status_display': 'answered',
+            'status': inputtypes.Status('answered'),
             'label': '',
             'msg': '',
             'input_type': expected_input_type,
@@ -158,10 +154,10 @@ class JavascriptInputTest(unittest.TestCase):
         display_file = "my_files/hi.js"
 
         xml_str = """<javascriptinput id="prob_1_2" params="{params}" problem_state="{ps}"
-                                      display_class="{dc}" display_file="{df}"/>""".format(
-                                          params=params,
-                                          ps=quote_attr(problem_state),
-                                          dc=display_class, df=display_file)
+                                    display_class="{dc}" display_file="{df}"/>""".format(
+            params=params,
+            ps=quote_attr(problem_state),
+            dc=display_class, df=display_file)
 
         element = etree.fromstring(xml_str)
 
@@ -173,9 +169,7 @@ class JavascriptInputTest(unittest.TestCase):
         expected = {
             'STATIC_URL': '/dummy-static/',
             'id': 'prob_1_2',
-            'status': 'unanswered',
-            'status_class': 'unanswered',
-            'status_display': u'unanswered',
+            'status': inputtypes.Status('unanswered'),
             # 'label': '',
             'msg': '',
             'value': '3',
@@ -208,9 +202,7 @@ class TextLineTest(unittest.TestCase):
             'STATIC_URL': '/dummy-static/',
             'id': 'prob_1_2',
             'value': 'BumbleBee',
-            'status': 'unanswered',
-            'status_class': 'unanswered',
-            'status_display': u'unanswered',
+            'status': inputtypes.Status('unanswered'),
             'label': 'testing 123',
             'size': size,
             'msg': '',
@@ -242,9 +234,7 @@ class TextLineTest(unittest.TestCase):
             'STATIC_URL': '/dummy-static/',
             'id': 'prob_1_2',
             'value': 'BumbleBee',
-            'status': 'unanswered',
-            'status_class': 'unanswered',
-            'status_display': u'unanswered',
+            'status': inputtypes.Status('unanswered'),
             'label': '',
             'size': size,
             'msg': '',
@@ -288,9 +278,7 @@ class TextLineTest(unittest.TestCase):
                 'STATIC_URL': '/dummy-static/',
                 'id': 'prob_1_2',
                 'value': 'BumbleBee',
-                'status': 'unanswered',
-                'status_class': 'unanswered',
-                'status_display': u'unanswered',
+                'status': inputtypes.Status('unanswered'),
                 'label': '',
                 'size': size,
                 'msg': '',
@@ -331,9 +319,7 @@ class FileSubmissionTest(unittest.TestCase):
         expected = {
             'STATIC_URL': '/dummy-static/',
             'id': 'prob_1_2',
-            'status': 'queued',
-            'status_class': 'processing',
-            'status_display': u'queued',
+            'status': inputtypes.Status('queued'),
             'label': '',
             'msg': the_input.submitted_msg,
             'value': 'BumbleBee.py',
@@ -383,9 +369,7 @@ class CodeInputTest(unittest.TestCase):
             'STATIC_URL': '/dummy-static/',
             'id': 'prob_1_2',
             'value': 'print "good evening"',
-            'status': 'queued',
-            'status_class': 'processing',
-            'status_display': u'queued',
+            'status': inputtypes.Status('queued'),
             # 'label': '',
             'msg': the_input.submitted_msg,
             'mode': mode,
@@ -439,9 +423,7 @@ class MatlabTest(unittest.TestCase):
             'STATIC_URL': '/dummy-static/',
             'id': 'prob_1_2',
             'value': 'print "good evening"',
-            'status': 'queued',
-            'status_class': 'processing',
-            'status_display': u'queued',
+            'status': inputtypes.Status('queued'),
             # 'label': '',
             'msg': self.the_input.submitted_msg,
             'mode': self.mode,
@@ -472,9 +454,7 @@ class MatlabTest(unittest.TestCase):
             'STATIC_URL': '/dummy-static/',
             'id': 'prob_1_2',
             'value': 'print "good evening"',
-            'status': 'queued',
-            'status_class': 'processing',
-            'status_display': u'queued',
+            'status': inputtypes.Status('queued'),
             # 'label': '',
             'msg': the_input.submitted_msg,
             'mode': self.mode,
@@ -505,9 +485,7 @@ class MatlabTest(unittest.TestCase):
                 'STATIC_URL': '/dummy-static/',
                 'id': 'prob_1_2',
                 'value': 'print "good evening"',
-                'status': status,
-                'status_class': status,
-                'status_display': unicode(status),
+                'status': inputtypes.Status(status),
                 # 'label': '',
                 'msg': '',
                 'mode': self.mode,
@@ -537,9 +515,7 @@ class MatlabTest(unittest.TestCase):
             'STATIC_URL': '/dummy-static/',
             'id': 'prob_1_2',
             'value': 'print "good evening"',
-            'status': 'queued',
-            'status_class': 'processing',
-            'status_display': u'queued',
+            'status': inputtypes.Status('queued'),
             # 'label': '',
             'msg': the_input.submitted_msg,
             'mode': self.mode,
@@ -617,7 +593,7 @@ class MatlabTest(unittest.TestCase):
         output = self.the_input.get_html()
         self.assertEqual(
             etree.tostring(output),
-            """<div>{\'status\': \'queued\', \'button_enabled\': True, \'linenumbers\': \'true\', \'rows\': \'10\', \'queue_len\': \'3\', \'mode\': \'\', \'cols\': \'80\', \'value\': \'print "good evening"\', \'status_class\': \'processing\', \'queue_msg\': \'\', \'STATIC_URL\': \'/dummy-static/\', \'msg\': u\'Submitted. As soon as a response is returned, this message will be replaced by that feedback.\', \'matlab_editor_js\': \'/dummy-static/js/vendor/CodeMirror/octave.js\', \'hidden\': \'\', \'status_display\': u\'queued\', \'id\': \'prob_1_2\', \'tabsize\': 4}</div>"""
+            """<div>{\'status\': Status(\'queued\'), \'button_enabled\': True, \'rows\': \'10\', \'queue_len\': \'3\', \'mode\': \'\', \'cols\': \'80\', \'STATIC_URL\': \'/dummy-static/\', \'linenumbers\': \'true\', \'queue_msg\': \'\', \'value\': \'print "good evening"\', \'msg\': u\'Submitted. As soon as a response is returned, this message will be replaced by that feedback.\', \'matlab_editor_js\': \'/dummy-static/js/vendor/CodeMirror/octave.js\', \'hidden\': \'\', \'id\': \'prob_1_2\', \'tabsize\': 4}</div>"""
         )
 
         # test html, that is correct HTML5 html, but is not parsable by XML parser.
@@ -735,9 +711,7 @@ class SchematicTest(unittest.TestCase):
             'STATIC_URL': '/dummy-static/',
             'id': 'prob_1_2',
             'value': value,
-            'status': 'unsubmitted',
-            'status_class': 'unanswered',
-            'status_display': u'unanswered',
+            'status': inputtypes.Status('unsubmitted'),
             'label': '',
             'msg': '',
             'initial_value': initial_value,
@@ -781,9 +755,7 @@ class ImageInputTest(unittest.TestCase):
             'STATIC_URL': '/dummy-static/',
             'id': 'prob_1_2',
             'value': value,
-            'status': 'unsubmitted',
-            'status_class': 'unanswered',
-            'status_display': u'unanswered',
+            'status': inputtypes.Status('unsubmitted'),
             'label': '',
             'width': width,
             'height': height,
@@ -838,9 +810,7 @@ class CrystallographyTest(unittest.TestCase):
             'STATIC_URL': '/dummy-static/',
             'id': 'prob_1_2',
             'value': value,
-            'status': 'unsubmitted',
-            'status_class': 'unanswered',
-            'status_display': u'unanswered',
+            'status': inputtypes.Status('unsubmitted'),
             # 'label': '',
             'msg': '',
             'width': width,
@@ -882,9 +852,7 @@ class VseprTest(unittest.TestCase):
             'STATIC_URL': '/dummy-static/',
             'id': 'prob_1_2',
             'value': value,
-            'status': 'unsubmitted',
-            'status_class': 'unanswered',
-            'status_display': u'unanswered',
+            'status': inputtypes.Status('unsubmitted'),
             'msg': '',
             'width': width,
             'height': height,
@@ -916,9 +884,7 @@ class ChemicalEquationTest(unittest.TestCase):
             'STATIC_URL': '/dummy-static/',
             'id': 'prob_1_2',
             'value': 'H2OYeah',
-            'status': 'unanswered',
-            'status_class': 'unanswered',
-            'status_display': 'unanswered',
+            'status': inputtypes.Status('unanswered'),
             'label': '',
             'msg': '',
             'size': self.size,
@@ -1006,9 +972,7 @@ class FormulaEquationTest(unittest.TestCase):
             'STATIC_URL': '/dummy-static/',
             'id': 'prob_1_2',
             'value': 'x^2+1/2',
-            'status': 'unanswered',
-            'status_class': 'unanswered',
-            'status_display': u'unanswered',
+            'status': inputtypes.Status('unanswered'),
             'label': '',
             'msg': '',
             'size': self.size,
@@ -1115,20 +1079,20 @@ class DragAndDropTest(unittest.TestCase):
                         "target_outline": "false",
                         "base_image": "/dummy-static/images/about_1.png",
                         "draggables": [
-{"can_reuse": "", "label": "Label 1", "id": "1", "icon": "", "target_fields": []},
-{"can_reuse": "", "label": "cc", "id": "name_with_icon", "icon": "/dummy-static/images/cc.jpg", "target_fields": []},
-{"can_reuse": "", "label": "arrow-left", "id": "with_icon", "icon": "/dummy-static/images/arrow-left.png", "can_reuse": "", "target_fields": []},
-{"can_reuse": "", "label": "Label2", "id": "5", "icon": "", "can_reuse": "", "target_fields": []},
-{"can_reuse": "", "label": "Mute", "id": "2", "icon": "/dummy-static/images/mute.png", "can_reuse": "", "target_fields": []},
-{"can_reuse": "", "label": "spinner", "id": "name_label_icon3", "icon": "/dummy-static/images/spinner.gif", "can_reuse": "", "target_fields": []},
-{"can_reuse": "", "label": "Star", "id": "name4", "icon": "/dummy-static/images/volume.png", "can_reuse": "", "target_fields": []},
-{"can_reuse": "", "label": "Label3", "id": "7", "icon": "", "can_reuse": "", "target_fields": []}],
+                            {"can_reuse": "", "label": "Label 1", "id": "1", "icon": "", "target_fields": []},
+                            {"can_reuse": "", "label": "cc", "id": "name_with_icon", "icon": "/dummy-static/images/cc.jpg", "target_fields": []},
+                            {"can_reuse": "", "label": "arrow-left", "id": "with_icon", "icon": "/dummy-static/images/arrow-left.png", "target_fields": []},
+                            {"can_reuse": "", "label": "Label2", "id": "5", "icon": "", "target_fields": []},
+                            {"can_reuse": "", "label": "Mute", "id": "2", "icon": "/dummy-static/images/mute.png", "target_fields": []},
+                            {"can_reuse": "", "label": "spinner", "id": "name_label_icon3", "icon": "/dummy-static/images/spinner.gif", "target_fields": []},
+                            {"can_reuse": "", "label": "Star", "id": "name4", "icon": "/dummy-static/images/volume.png", "target_fields": []},
+                            {"can_reuse": "", "label": "Label3", "id": "7", "icon": "", "target_fields": []}],
                         "one_per_target": "True",
                         "targets": [
-                {"y": "90", "x": "210", "id": "t1", "w": "90", "h": "90"},
-                {"y": "160", "x": "370", "id": "t2", "w": "90", "h": "90"}
-                                    ]
-                    }
+                            {"y": "90", "x": "210", "id": "t1", "w": "90", "h": "90"},
+                            {"y": "160", "x": "370", "id": "t2", "w": "90", "h": "90"}
+                        ]
+        }
 
         the_input = lookup_tag('drag_and_drop_input')(test_capa_system(), element, state)
 
@@ -1137,9 +1101,7 @@ class DragAndDropTest(unittest.TestCase):
             'STATIC_URL': '/dummy-static/',
             'id': 'prob_1_2',
             'value': value,
-            'status': 'unsubmitted',
-            'status_class': 'unanswered',
-            'status_display': u'unanswered',
+            'status': inputtypes.Status('unsubmitted'),
             # 'label': '',
             'msg': '',
             'drag_and_drop_json': json.dumps(user_input)
@@ -1191,10 +1153,7 @@ class AnnotationInputTest(unittest.TestCase):
         expected = {
             'STATIC_URL': '/dummy-static/',
             'id': 'annotation_input',
-            'value': value,
-            'status': 'answered',
-            'status_class': 'answered',
-            'status_display': 'answered',
+            'status': inputtypes.Status('answered'),
             # 'label': '',
             'msg': '',
             'title': 'foo',
@@ -1254,9 +1213,7 @@ class TestChoiceText(unittest.TestCase):
         state = {
             'value': '{}',
             'id': 'choicetext_input',
-            'status': 'answered',
-            'status_class': 'answered',
-            'status_display': u'answered',
+            'status': inputtypes.Status('answered'),
         }
 
         first_input = self.build_choice_element('numtolerance_input', 'choiceinput_0_textinput_0', 'false', '')
@@ -1312,3 +1269,63 @@ class TestChoiceText(unittest.TestCase):
         """
         with self.assertRaisesRegexp(Exception, "Error in xml"):
             self.check_group('checkboxtextgroup', 'invalid', 'checkbox')
+
+
+class TestStatus(unittest.TestCase):
+    """
+    Tests for Status class
+    """
+    def test_str(self):
+        """
+        Test stringifing Status objects
+        """
+        statobj = inputtypes.Status('test')
+        self.assertEqual(str(statobj), 'test')
+        self.assertEqual(unicode(statobj), u'test')
+
+    def test_classes(self):
+        """
+        Test that css classnames are correct
+        """
+        css_classes = [
+            ('unsubmitted', 'unanswered'),
+            ('incomplete', 'incorrect'),
+            ('queued', 'processing'),
+            ('correct', 'correct'),
+            ('test', 'test'),
+        ]
+        for status, classname in css_classes:
+            statobj = inputtypes.Status(status)
+            self.assertEqual(statobj.classname, classname)
+
+    def test_display_names(self):
+        """
+        Test that display names are correct
+        """
+        names = [
+            ('correct', u'correct'),
+            ('incorrect', u'incorrect'),
+            ('incomplete', u'incomplete'),
+            ('unanswered', u'unanswered'),
+            ('unsubmitted', u'unanswered'),
+            ('queued', u'processing'),
+            ('dave', u'dave'),
+        ]
+        for status, display_name in names:
+            statobj = inputtypes.Status(status)
+            self.assertEqual(statobj.display_name, display_name)
+
+    def test_translated_names(self):
+        """
+        Test that display names are "translated"
+        """
+        func = lambda t: t.upper()
+        # status is in the mapping
+        statobj = inputtypes.Status('queued', func)
+        self.assertEqual(statobj.display_name, u'PROCESSING')
+
+        # status is not in the mapping
+        statobj = inputtypes.Status('test', func)
+        self.assertEqual(statobj.display_name, u'test')
+        self.assertEqual(str(statobj), 'test')
+        self.assertEqual(statobj.classname, 'test')

--- a/common/lib/xmodule/xmodule/js/src/html/display.coffee
+++ b/common/lib/xmodule/xmodule/js/src/html/display.coffee
@@ -4,7 +4,8 @@ class @HTMLModule
     @el = $(@element)
     JavascriptLoader.executeModuleScripts(@el)
     Collapsible.setCollapsibles(@el)
-    MathJax.Hub.Queue ["Typeset", MathJax.Hub, @el[0]]
+    if MathJax?
+	    MathJax.Hub.Queue ["Typeset", MathJax.Hub, @el[0]]
 
   $: (selector) ->
     $(selector, @el)


### PR DESCRIPTION
in order to simplify css class management and internationalization of status strings (potentially) displayed to the user.

@cpennington @nedbat Does this approach seem reasonable?
