### PR TITLE
Upgrade jsdraw input to latest version.

### DIFF
--- a/requirements/edx/edx-private.txt
+++ b/requirements/edx/edx-private.txt
@@ -1,4 +1,4 @@
 # Requirements for edx.org that aren't necessarily needed for Open edX.
 
--e git+ssh://git@github.com/jazkarta/edX-jsdraw.git@df9d048e331a642193e5aa2e03650fb84a9d715f#egg=edx-jsdraw
+-e git+ssh://git@github.com/jazkarta/edX-jsdraw.git@4d1497c034ed2afb55228b62e5ac99a0f023e5ef#egg=edx-jsdraw
 -e git+https://github.com/gsehub/xblock-mentoring.git@adcb490a96a98c142124c6abbb2bdf8feb511baf#egg=xblock-mentoring


### PR DESCRIPTION
Uses JSDraw's API for grading answers instead of trying to compare SMILES strings.  As it turns out, the SMILES strings generated by JSDraw are not normalized, so it can output different SMILES strings for the same molecule depending on how the student drew it.  JSDraw has its own API for comparing molecules which should solve this problem.
