### PR TITLE
Fix a url processing error in 02_html5_video.js

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/video/02_html5_video.js
+++ b/common/lib/xmodule/xmodule/js/src/video/02_html5_video.js
@@ -186,16 +186,16 @@ function () {
             // Create HTML markup for individual sources of the HTML5 <video>
             // element.
             $.each(sourceStr, function (videoType, videoSource) {
-                if (
-                    (_this.config.videoSources[videoType]) &&
-                    (_this.config.videoSources[videoType].length)
-                ) {
+                var url = _this.config.videoSources[videoType];
+                if (url && url.length) {
                     sourceStr[videoType] =
                         '<source ' +
-                            'src="' + _this.config.videoSources[videoType] +
+                            'src="' + url +
                             // Following hack allows to open the same video twice
                             // https://code.google.com/p/chromium/issues/detail?id=31014
-                            '?' + (new Date()).getTime() +
+                            // Check whether the url already has a '?' inside, and if so,
+                            // use '&' instead of '?' to prevent breaking the url's integrity.
+                            (url.indexOf('?') == -1 ? '?' : '&') + (new Date()).getTime() +
                             '" ' + 'type="video/' + videoType + '" ' +
                         '/> ';
                 }


### PR DESCRIPTION
As the code in this .js will break the url's integrity when there is already a query string inside the video source's url and cause the url to be invalid in some cases (for example, when working with a url from Windows Azure's Media Service, the appended '?' will cause the url being invalid).
I modified the code by first checking whether the url has already had a query string, and if so, then use '&' instead of '?' to prevent the breaking, and it works for the url from Windows Azure's Media Service.
