### PR TITLE
Removing ipython from edx dependencies

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -76,9 +76,6 @@ xmltodict==0.4.1
 django-ratelimit-backend==0.6
 unicodecsv==0.9.4
 
-# Used for debugging
-ipython==0.13.1
-
 # Used for development operation
 watchdog==0.6.0
 


### PR DESCRIPTION
Ipython is not strictly required to run edx-platform. It can be setup as part of Vagrant provision scripts, or manually by each developer as required in specific cases.
