### PR TITLE
Make emails in lms translatable

### DIFF
--- a/conf/locale/babel_mako.cfg
+++ b/conf/locale/babel_mako.cfg
@@ -9,3 +9,5 @@ input_encoding = utf-8
 input_encoding = utf-8
 [mako: cms/templates/emails/**.txt]
 input_encoding = utf-8
+[mako: lms/templates/emails/**.txt]
+input_encoding = utf-8

--- a/lms/templates/emails/confirm_email_change.txt
+++ b/lms/templates/emails/confirm_email_change.txt
@@ -1,19 +1,20 @@
 <%! from django.core.urlresolvers import reverse %>
+<%! from django.utils.translation import ugettext as _ %>
 <%namespace file="../main.html" import="stanford_theme_enabled" />
 ## Again, ugly hack that needs to be changed
 ## TODO: this probably needs better formatting to look nice in an
 ##       email client (Mako leaves awkward whitespace)
 % if stanford_theme_enabled():
-  This is to confirm that you changed the e-mail associated with
-  ${settings.PLATFORM_NAME} from ${old_email} to ${new_email}. If you
-  did not make this request, please contact us at
+  ${_("This is to confirm that you changed the e-mail associated with "
+      "{platform_name} from {old_email} to {new_email}. If you "
+      "did not make this request, please contact us at").format(platform_name=settings.PLATFORM_NAME, old_email=old_email, new_email=new_email)}
 
   ${settings.CONTACT_EMAIL}
 % else:
-  This is to confirm that you changed the e-mail associated with
-  ${settings.PLATFORM_NAME} from ${old_email} to ${new_email}. If you
-  did not make this request, please contact us immediately. Contact
-  information is listed at:
+  ${_("This is to confirm that you changed the e-mail associated with "
+      "{platform_name} from {old_email} to {new_email}. If you "
+      "did not make this request, please contact us immediately. Contact "
+      "information is listed at:").format(platform_name=settings.PLATFORM_NAME, old_email=old_email, new_email=new_email)}
 
   % if is_secure:
     https://${ site }${reverse('contact')}
@@ -22,5 +23,5 @@
   % endif
 % endif
 
-We keep a log of old e-mails, so if this request was unintentional, we
-can investigate.
+${_("We keep a log of old e-mails, so if this request was unintentional, we "
+    "can investigate.")}

--- a/lms/templates/emails/email_change.txt
+++ b/lms/templates/emails/email_change.txt
@@ -1,8 +1,9 @@
+<%! from django.utils.translation import ugettext as _ %>
 <%namespace file="../main.html" import="stanford_theme_enabled" />
-We received a request to change the e-mail associated with your
-${settings.PLATFORM_NAME} account from ${old_email} to ${new_email}.
-If this is correct, please confirm your new e-mail address by
-visiting:
+${_("We received a request to change the e-mail associated with your "
+    "{platform_name} account from {old_email} to {new_email}. "
+    "If this is correct, please confirm your new e-mail address by "
+    "visiting:").format(platform_name=settings.PLATFORM_NAME, old_email=old_email, new_email=new_email)}
 
 % if is_secure:
  https://${ site }/email_confirm/${ key }
@@ -12,13 +13,13 @@ visiting:
 
 ## TODO: fix this ugly hack
 % if stanford_theme_enabled():
-  If you didn't request this, you don't need to do anything; you won't
-  receive any more email from us. Please do not reply to this e-mail;
-  if you require assistance, check the about section of the
-  ${settings.PLATFORM_NAME} Courses web site.
+  ${_("If you didn't request this, you don't need to do anything; you won't "
+      "receive any more email from us. Please do not reply to this e-mail; "
+      "if you require assistance, check the about section of the "
+      "{platform_name} Courses web site.").format(platform_name=settings.PLATFORM_NAME)}
 % else:
-  If you didn't request this, you don't need to do anything; you won't
-  receive any more email from us. Please do not reply to this e-mail;
-  if you require assistance, check the help section of the
-  ${settings.PLATFORM_NAME} web site.
+  ${_("If you didn't request this, you don't need to do anything; you won't "
+      "receive any more email from us. Please do not reply to this e-mail; "
+      "if you require assistance, check the help section of the "
+      "{platform_name} web site.").format(platform_name=settings.PLATFORM_NAME)}
 % endif

--- a/lms/templates/emails/email_change_subject.txt
+++ b/lms/templates/emails/email_change_subject.txt
@@ -1,1 +1,2 @@
-Request to change ${settings.PLATFORM_NAME} account e-mail
+<%! from django.utils.translation import ugettext as _ %>
+${_("Request to change {platform_name} account e-mail").format(platform_name=settings.PLATFORM_NAME)}

--- a/lms/templates/emails/reject_name_change.txt
+++ b/lms/templates/emails/reject_name_change.txt
@@ -1,14 +1,15 @@
+<%! from django.utils.translation import ugettext as _ %>
 <%namespace file="../main.html" import="stanford_theme_enabled" />
 (Not currently used)
 
 ## TODO: fix this ugly hack
 % if stanford_theme_enabled():
-  We are sorry. Our course staff did not approve your request to change
-  your name from ${old_name} to ${new_name}. If you need further
-  assistance, please e-mail the tech support at
+  ${_("We are sorry. Our course staff did not approve your request to change "
+      "your name from {old_name} to {new_name}. If you need further "
+      "assistance, please e-mail the tech support at").format(old_name=old_name, new_name=new_name)}
   ${settings.TECH_SUPPORT_EMAIL}.
 % else:
-  We are sorry. Our course staff did not approve your request to change
-  your name from ${old_name} to ${new_name}. If you need further
-  assistance, please e-mail the course staff at ta@edx.org.
+  ${_("We are sorry. Our course staff did not approve your request to change "
+      "your name from {old_name} to {new_name}. If you need further "
+      "assistance, please e-mail the course staff at ta@edx.org.").format(old_name=old_name, new_name=new_name)}
 % endif


### PR DESCRIPTION
The translatable strings of email texts in lms/templates/emails are not extracted by `rake i18n:generate` because the `conf/locale/babel_mako.cfg` does not include them.
And several emails in lms are not translatable because they do not use ugettext.
