### PR TITLE
Fix typo in studio's email text

### DIFF
--- a/cms/templates/emails/course_creator_admin_subject.txt
+++ b/cms/templates/emails/course_creator_admin_subject.txt
@@ -1,2 +1,2 @@
 <%! from django.utils.translation import ugettext as _ %>
-${_("{email} has requested Studio course creator privileges on edge".format(email=user_email))}
+${_("{email} has requested Studio course creator privileges on edge").format(email=user_email)}

--- a/cms/templates/emails/course_creator_admin_user_pending.txt
+++ b/cms/templates/emails/course_creator_admin_user_pending.txt
@@ -1,5 +1,5 @@
 <%! from django.utils.translation import ugettext as _ %>
-${_("User '{user}' with e-mail {email} has requested Studio course creator privileges on edge.".format(user=user_name, email=user_email))}
+${_("User '{user}' with e-mail {email} has requested Studio course creator privileges on edge.").format(user=user_name, email=user_email)}
 ${_("To grant or deny this request, use the course creator admin table.")}
 
 % if is_secure:


### PR DESCRIPTION
The right parenthesis should appear before the method '.format', not after.
