### PR TITLE
Remove unecessary call to getUserMedia

### DIFF
--- a/lms/static/js/verify_student/photocapture.js
+++ b/lms/static/js/verify_student/photocapture.js
@@ -213,11 +213,6 @@ function initSnapshotHandler(names, hasHtml5CameraSupport) {
     navigator.getUserMedia({video: true}, function(stream) {
       video[0].src = window.URL.createObjectURL(stream);
       localMediaStream = stream;
-
-      // We do this in a recursive call on success because Firefox seems to
-      // simply eat the request if you stack up two on top of each other before
-      // the user has a chance to approve the first one.
-      initSnapshotHandler(names, hasHtml5CameraSupport);
     }, onVideoFail);
   }
   else {


### PR DESCRIPTION
Hi,

I tested it on Firefox 28.0 and Google Chrome 33.0.1750.152.
