### PR TITLE
Fix the chinese name of chinese language in common.py

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -576,8 +576,8 @@ LANGUAGES = (
     ('tr-tr', u'Türkçe (Türkiye)'),  # Turkish (Turkey)
     ('uk', u'Українська'),  # Uknranian
     ('vi', u'Tiếng Việt'),  # Vietnamese
-    ('zh-cn', u'大陆简体'),  # Chinese (China)
-    ('zh-tw', u'台灣正體'),  # Chinese (Taiwan)
+    ('zh-cn', u'中文(简体)'),  # Chinese (China)
+    ('zh-tw', u'中文(台灣)'),  # Chinese (Taiwan)
 )
 
 LANGUAGE_DICT = dict(LANGUAGES)


### PR DESCRIPTION
The current version of chinese language's chinese name is not politically neutral.
In fact, which form of chinese (traditional or simplified) can be called "正體"(in traditional chinese) or "正体"(in simplified chinese) is not globally defined. So, using the names "台灣正體" & "大陆简体" will make the users from mainland of China very uncomfortable; and in the opposite, the names "繁体中文" & "简体中文" which are widely used in mainland of China may also make the users of taiwan very uncomfortable.
So, I change the name according to the word used by Microsoft Windows, which is more neutral.
