### PR TITLE
Display error page templates, for testing purposes

### DIFF
--- a/lms/urls.py
+++ b/lms/urls.py
@@ -499,3 +499,9 @@ if settings.DEBUG:
 #Custom error pages
 handler404 = 'static_template_view.views.render_404'
 handler500 = 'static_template_view.views.render_500'
+
+# display error page templates, for testing purposes
+urlpatterns += (
+    url(r'404', handler404),
+    url(r'500', handler500),
+)


### PR DESCRIPTION
This commit allows us to test the server error template by visiting `/500`. This
way, we can catch errors in our error templates, instead of having infinitely
recursing errors.

Reviewers: @feanil @rocha 
