### PR TITLE
allow capa problems access to anonymous_student_id

### DIFF
--- a/common/lib/capa/capa/capa_problem.py
+++ b/common/lib/capa/capa/capa_problem.py
@@ -620,6 +620,7 @@ class LoncapaProblem(object):
         """
         context = {}
         context['seed'] = self.seed
+        context['anonymous_student_id'] = self.capa_system.anonymous_student_id
         all_code = ''
 
         python_path = []

--- a/common/lib/capa/capa/tests/test_html_render.py
+++ b/common/lib/capa/capa/tests/test_html_render.py
@@ -73,6 +73,24 @@ class CapaHtmlRenderTest(unittest.TestCase):
         span_element = rendered_html.find('span')
         self.assertEqual(span_element.text, 'Test text')
 
+    def test_anonymous_student_id(self):
+        # make sure anonymous_student_id is rendered properly as a context variable
+        xml_str = textwrap.dedent("""
+            <problem>
+            <span>Welcome $anonymous_student_id</span>
+            </problem>
+        """)
+
+        # Create the problem
+        problem = new_loncapa_problem(xml_str)
+
+        # Render the HTML
+        rendered_html = etree.XML(problem.get_html())
+
+        # Expect that the anonymous_student_id was converted to "student"
+        span_element = rendered_html.find('span')
+        self.assertEqual(span_element.text, 'Welcome student')
+
     def test_render_script(self):
         # Generate some XML with a <script> tag
         xml_str = textwrap.dedent("""


### PR DESCRIPTION
An upcoming MITx course will be using jsinput to embed custom response assessments from an external server.  That server needs to know the anonymous id of the student doing the assessment.  

This PR allows capa problems access to the `aonymous_student_id`, via the usual capa context variable substitution method, i.e. `$anonymous_student_id`.  This is analogous to how the HTML module makes a substitution for `%%USER_ID%%`, but consistent with capa problem semantics.

Unit test provided.

@chrisndodge ?
