### PR TITLE
Force get_content_titles to be a module attribute

### DIFF
--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -861,6 +861,7 @@ class XModuleDescriptor(XModuleMixin, HTMLSnippet, ResourceTemplates, XBlock):
     max_score = module_attr('max_score')
     student_view = module_attr('student_view')
     get_child_descriptors = module_attr('get_child_descriptors')
+    get_content_titles = module_attr('get_content_titles')
     xmodule_handler = module_attr('xmodule_handler')
 
     # ~~~~~~~~~~~~~~~ XBlock API Wrappers ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
We were running into issues where we were trying to call get_content_titles on descriptors, and we only want them on modules.

@cpennington @flowerhack 
