### PR TITLE
fix paver theming on devstack (SERVICE_VARIANT support)

### DIFF
--- a/pavelib/utils/envs.py
+++ b/pavelib/utils/envs.py
@@ -15,7 +15,7 @@ class Env(object):
     """
 
     # Root of the git repository (edx-platform)
-    REPO_ROOT = path(__file__).parent.parent.parent
+    REPO_ROOT = path(__file__).abspath().parent.parent.parent
 
     # Service variant (lms, cms, etc.) configured with an environment variable
     # We use this to determine which envs.json file to load.


### PR DESCRIPTION
For @singingwolfboy 

When running in devstack, you need to set the SERVICE_VARIANT so that
assets.py knows what environment file to use.  Recall that in devstack
we have all our settings in ../lms.env.json, not just ../env.json.  So
you need to run like this:

```
SERVICE_VARIANT=lms paver lms --settings=devstack
```

Previously you'd get this error:

```
Warning: could not find environment JSON file at 'lms.env.json'
```

Note there is no path on the file, that's the bug.  By making
self.REPO_ROOT absolute, we can walk up the tree and correctly find
the file, which is /edx/app/edxapp/lms.env.json fwiw.
