### PR TITLE
Properly get lazily translated exception message

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_export_git.py
+++ b/cms/djangoapps/contentstore/tests/test_export_git.py
@@ -76,6 +76,16 @@ class TestExportGit(CourseTestCase):
         response = self.client.get('{}?action=push'.format(self.test_url))
         self.assertIn('Export Failed:', response.content)
 
+    def test_exception_translation(self):
+        """
+        Regression test for making sure errors are properly stringified
+        """
+        self.course_module.giturl = 'foobar'
+        get_modulestore(self.course_module.location).update_item(self.course_module)
+
+        response = self.client.get('{}?action=push'.format(self.test_url))
+        self.assertNotIn('django.utils.functional.__proxy__', response.content)
+
     def test_course_export_success(self):
         """
         Test successful course export response.

--- a/cms/djangoapps/contentstore/views/export_git.py
+++ b/cms/djangoapps/contentstore/views/export_git.py
@@ -45,7 +45,7 @@ def export_git(request, org, course, name):
                 msg = _('Course successfully exported to git repository')
             except git_export_utils.GitExportError as ex:
                 failed = True
-                msg = str(ex)
+                msg = unicode(ex)
 
     return render_to_response('export_git.html', {
         'context_course': course_module,


### PR DESCRIPTION
User's were getting the classic `django.utils.functional.__proxy__` as error message output which is a lot less helpful than what the actually error message was saying. I've corrected it and added a regression test for catching it if it comes up again.

@sarina
