### PR TITLE
Make YouTube mocked server serve YouTube API

### DIFF
--- a/cms/djangoapps/contentstore/features/video.feature
+++ b/cms/djangoapps/contentstore/features/video.feature
@@ -3,16 +3,31 @@ Feature: CMS Video Component
   As a course author, I want to be able to view my created videos in Studio
 
   # 1
+  Scenario: YouTube stub server proxies YouTube API correctly
+    Given youtube stub server proxies YouTube API
+    Given I have created a Video component
+    Then I can see video button "play"
+    And I click video button "play"
+    Then I can see video button "pause"
+
+  # 2
+  Scenario: YouTube stub server can block YouTube API
+    Given youtube stub server blocks YouTube API
+    Given I have created a Video component
+    Given We explicitly wait for YouTube API to not load
+    Then I do not see video button "play"
+
+  # 3
   Scenario: Autoplay is disabled in Studio
     Given I have created a Video component
     Then when I view the video it does not have autoplay enabled
 
-  # 2
+  # 4
   Scenario: Creating a video takes a single click
     Given I have clicked the new unit button
     Then creating a video takes a single click
 
-  # 3
+  # 5
   # Sauce Labs cannot delete cookies
   @skip_sauce
   Scenario: Captions are hidden correctly
@@ -20,14 +35,14 @@ Feature: CMS Video Component
     And I have hidden captions
     Then when I view the video it does not show the captions
 
-  # 4
+  # 6
   # Sauce Labs cannot delete cookies
   @skip_sauce
   Scenario: Captions are shown correctly
     Given I have created a Video component with subtitles
     Then when I view the video it does show the captions
 
-  # 5
+  # 7
   # Sauce Labs cannot delete cookies
   @skip_sauce
   Scenario: Captions are toggled correctly
@@ -35,13 +50,13 @@ Feature: CMS Video Component
     And I have toggled captions
     Then when I view the video it does show the captions
 
-  # 6
+  # 8
   Scenario: Video data is shown correctly
     Given I have created a video with only XML data
     And I reload the page
     Then the correct Youtube video is shown
 
-  # 7
+  # 9
   # Disabled 11/26 due to flakiness in master.
   # Enabled back on 11/29.
   Scenario: When enter key is pressed on a caption shows an outline around it
@@ -51,7 +66,7 @@ Feature: CMS Video Component
     Then I press "enter" button on caption line with data-index "0"
     And I see caption line with data-index "0" has class "focused"
 
-  # 8
+  # 10
   Scenario: When start and end times are specified, a range on slider is shown
     Given I have created a Video component with subtitles
     And Make sure captions are closed
@@ -63,7 +78,7 @@ Feature: CMS Video Component
     And I click video button "play"
     Then I see a range on slider
 
-  # 12
+  # 11
   # Disabled 2/19/14 after intermittent failures in master
   #Scenario: Check that position is stored on page refresh, position within start-end range
   #  Given I have created a Video component with subtitles
@@ -81,7 +96,7 @@ Feature: CMS Video Component
   #  And I click video button "play"
   #  Then I see video starts playing from "0:16" position
 
-  # 13
+  # 12
 # Disabled 2/18/14 after intermittent failures in master
 #  Scenario: Check that position is stored on page refresh, position before start-end range
 #    Given I have created a Video component with subtitles
@@ -99,7 +114,7 @@ Feature: CMS Video Component
 #    And I click video button "play"
 #    Then I see video starts playing from "0:12" position
 
-  # 14
+  # 13
 # Disabled 2/18/14 after intermittent failures in master
 #  Scenario: Check that position is stored on page refresh, position after start-end range
 #    Given I have created a Video component with subtitles

--- a/cms/djangoapps/contentstore/features/video.py
+++ b/cms/djangoapps/contentstore/features/video.py
@@ -21,11 +21,27 @@ SELECTORS = {
 DELAY = 0.5
 
 
+@step('youtube stub server (.*) YouTube API')
+def configure_youtube_api(_step, action):
+    action=action.strip()
+    if action == 'proxies':
+        world.youtube.config['youtube_api_blocked'] = False
+    elif action == 'blocks':
+        world.youtube.config['youtube_api_blocked'] = True
+    else:
+        raise ValueError('Parameter `action` should be one of "proxies" or "blocks".')
+
+
+@step('We explicitly wait for YouTube API to not load$')
+def wait_for_youtube_api_fail(_step):
+    world.wait(3)
+
+
 @step('I have created a Video component$')
-def i_created_a_video_component(step):
+def i_created_a_video_component(_step):
     world.create_course_with_unit()
     world.create_component_instance(
-        step=step,
+        step=_step,
         category='video',
     )
 
@@ -77,6 +93,8 @@ def i_have_uploaded_subtitles(_step, sub_id):
 
 @step('when I view the (.*) it does not have autoplay enabled$')
 def does_not_autoplay(_step, video_type):
+    world.wait(DELAY)
+    world.wait_for_ajax_complete()
     actual = world.css_find('.%s' % video_type)[0]['data-autoplay']
     expected = [u'False', u'false', False]
     assert actual in expected
@@ -198,6 +216,20 @@ def see_a_range_slider_with_proper_range(_step):
     world.wait_for_visible(VIDEO_BUTTONS['pause'])
 
     assert world.css_visible(".slider-range")
+
+
+@step('I (.*) see video button "([^"]*)"$')
+def do_not_see_or_not_button_video(_step, action, button_type):
+    world.wait(DELAY)
+    world.wait_for_ajax_complete()
+    action=action.strip()
+    button = button_type.strip()
+    if action == 'do not':
+        assert not world.is_css_present(VIDEO_BUTTONS[button])
+    elif action == 'can':
+        assert world.css_visible(VIDEO_BUTTONS[button])
+    else:
+        raise ValueError('Parameter `action` should be one of "do not" or "can".')
 
 
 @step('I click video button "([^"]*)"$')

--- a/cms/envs/acceptance.py
+++ b/cms/envs/acceptance.py
@@ -119,6 +119,6 @@ except ImportError:
     pass
 
 # Point the URL used to test YouTube availability to our stub YouTube server
-YOUTUBE['API'] = 'youtube.com/iframe_api'
+YOUTUBE['API'] = "127.0.0.1:{0}/get_youtube_api/".format(YOUTUBE_PORT)
 YOUTUBE['TEST_URL'] = "127.0.0.1:{0}/test_youtube/".format(YOUTUBE_PORT)
 YOUTUBE['TEXT_API']['url'] = "127.0.0.1:{0}/test_transcripts_youtube/".format(YOUTUBE_PORT)

--- a/common/djangoapps/terrain/stubs/youtube.py
+++ b/common/djangoapps/terrain/stubs/youtube.py
@@ -20,6 +20,7 @@ To start this stub server on its own from Vagrant:
 from .http import StubHttpRequestHandler, StubHttpService
 import json
 import time
+import requests
 from urlparse import urlparse
 from collections import OrderedDict
 
@@ -74,6 +75,13 @@ class StubYouTubeHandler(StubHttpRequestHandler):
             youtube_id = params.path.split('/').pop()
 
             self._send_video_response(youtube_id, "I'm youtube.")
+
+        elif 'get_youtube_api' in self.path:
+            if self.server.config.get('youtube_api_blocked'):
+                self.send_response(404, content='', headers={'Content-type': 'text/plain'})
+            else:
+                response = requests.get('http://www.youtube.com/iframe_api')
+                self.send_response(200, content=response.text, headers={'Content-type': 'text/html'})
 
         else:
             self.send_response(


### PR DESCRIPTION
**Description**

1.) Making YouTube mock server serve YouTube API.
2.) Adding ability to block YouTube API from YouTube mock server.
3.) Adding acceptance tests that check YouTube mock server for availability of YouTube API, and for it's ability to block YouTube API.

**Jira issue**

Part of [BLD-939](https://edx-wiki.atlassian.net/browse/BLD-939).

**Reviewers**
- @olmar 
