### PR TITLE
ensure SERVICE_VARIANT set; pass theme to coffeescript;

### DIFF
--- a/pavelib/assets.py
+++ b/pavelib/assets.py
@@ -128,12 +128,11 @@ def compile_sass(debug=False):
     """
     Compile Sass to CSS.
     """
-    theme_paths = THEME_SASS_PATHS
     sh(cmd(
         'sass', '' if debug else '--style compressed',
         "--cache-location {cache}".format(cache=SASS_CACHE_PATH),
-        "--load-path", " ".join(SASS_LOAD_PATHS + theme_paths),
-        "--update", "-E", "utf-8", " ".join(SASS_UPDATE_DIRS + theme_paths)
+        "--load-path", " ".join(SASS_LOAD_PATHS + THEME_SASS_PATHS),
+        "--update", "-E", "utf-8", " ".join(SASS_UPDATE_DIRS + THEME_SASS_PATHS)
     ))
 
 

--- a/pavelib/assets.py
+++ b/pavelib/assets.py
@@ -11,10 +11,23 @@ import traceback
 from .utils.envs import Env
 from .utils.cmd import cmd, django_cmd
 
+# setup baseline paths
+
 COFFEE_DIRS = ['lms', 'cms', 'common']
 SASS_LOAD_PATHS = ['./common/static/sass']
 SASS_UPDATE_DIRS = ['*/static']
 SASS_CACHE_PATH = '/tmp/sass-cache'
+
+THEME_COFFEE_PATHS = []
+THEME_SASS_PATHS = []
+
+edxapp_env = Env()
+if edxapp_env.feature_flags.get('USE_CUSTOM_THEME', False):
+    theme_name = edxapp_env.env_tokens.get('THEME_NAME', '')
+    parent_dir = path(edxapp_env.REPO_ROOT).abspath().parent
+    theme_root = parent_dir / "themes" / theme_name
+    THEME_COFFEE_PATHS = [theme_root]
+    THEME_SASS_PATHS = [theme_root / "static" / "sass"]
 
 
 class CoffeeScriptWatcher(PatternMatchingEventHandler):
@@ -54,7 +67,7 @@ class SassWatcher(PatternMatchingEventHandler):
         """
         register files with observer
         """
-        for dirname in SASS_LOAD_PATHS + SASS_UPDATE_DIRS + theme_sass_paths():
+        for dirname in SASS_LOAD_PATHS + SASS_UPDATE_DIRS + THEME_SASS_PATHS:
             paths = []
             if '*' in dirname:
                 paths.extend(glob.glob(dirname))
@@ -92,27 +105,11 @@ class XModuleSassWatcher(SassWatcher):
             traceback.print_exc()
 
 
-def theme_sass_paths():
-    """
-    Return the a list of paths to the theme's sass assets,
-    or an empty list if no theme is configured.
-    """
-    edxapp_env = Env()
-
-    if edxapp_env.feature_flags.get('USE_CUSTOM_THEME', False):
-        theme_name = edxapp_env.env_tokens.get('THEME_NAME', '')
-        parent_dir = path(edxapp_env.REPO_ROOT).abspath().parent
-        theme_root = parent_dir / "themes" / theme_name
-        return [theme_root / "static" / "sass"]
-    else:
-        return []
-
-
 def coffeescript_files():
     """
     return find command for paths containing coffee files
     """
-    dirs = " ".join([Env.REPO_ROOT / coffee_dir for coffee_dir in COFFEE_DIRS])
+    dirs = " ".join(THEME_COFFEE_PATHS + [Env.REPO_ROOT / coffee_dir for coffee_dir in COFFEE_DIRS])
     return cmd('find', dirs, '-type f', '-name \"*.coffee\"')
 
 
@@ -131,7 +128,7 @@ def compile_sass(debug=False):
     """
     Compile Sass to CSS.
     """
-    theme_paths = theme_sass_paths()
+    theme_paths = THEME_SASS_PATHS
     sh(cmd(
         'sass', '' if debug else '--style compressed',
         "--cache-location {cache}".format(cache=SASS_CACHE_PATH),

--- a/pavelib/utils/envs.py
+++ b/pavelib/utils/envs.py
@@ -21,6 +21,16 @@ class Env(object):
     # We use this to determine which envs.json file to load.
     SERVICE_VARIANT = os.environ.get('SERVICE_VARIANT', None)
 
+    # If service variant not configured in env, then pass the correct
+    # environment for lms / cms
+    if not SERVICE_VARIANT:  # this will intentionally catch "";
+         args = sys.argv[1:]
+         if 'lms' in args:
+             SERVICE_VARIANT = 'lms'
+         elif any(i in args for i in ('cms', 'studio')):
+             SERVICE_VARIANT = 'cms'
+
+
     @lazy
     def env_tokens(self):
         """

--- a/pavelib/utils/envs.py
+++ b/pavelib/utils/envs.py
@@ -24,12 +24,10 @@ class Env(object):
     # If service variant not configured in env, then pass the correct
     # environment for lms / cms
     if not SERVICE_VARIANT:  # this will intentionally catch "";
-         args = sys.argv[1:]
-         if 'lms' in args:
-             SERVICE_VARIANT = 'lms'
-         elif any(i in args for i in ('cms', 'studio')):
-             SERVICE_VARIANT = 'cms'
-
+        if any(i in sys.argv[1:] for i in ('cms', 'studio')):
+            SERVICE_VARIANT = 'cms'
+        else:
+            SERVICE_VARIANT = 'lms'
 
     @lazy
     def env_tokens(self):


### PR DESCRIPTION
This enables theming with paver (PR #3075), mirroring similar changes as for rake in PR #2387.

In particular, when the following are set:

```
edxapp_theme_name: stanford
edxapp_theme_source_repo: https://{{ COMMON_GIT_MIRROR }}/{{ THEME_ACCT }}/edx-theme.git
edxapp_theme_version: master
edxapp_use_custom_theme: true  # false to disable & use std. theme
```

then:

```
paver devstack lms
```

will correctly read and pass the paths to both `coffee`  and `sass`.

Alternately, the process described in the comment of https://gist.github.com/yarko/8818633  is another way to test this - set the above four theme settings in `build-version.yml`, then run `vagrant provision`.

A way to run this on vagrant fullstack is to use `build-version.yml`, as above, and either include it in, or symlink it to `/edx/app/edx_ansible/server-vars.yml`  (it shows up as `/vagrant/build-version.yml`), and then using `update edx-platform some-version`.

_Note: currently you will need to completely remove `edx-platform` in order to clone one from a different repository (since `git remotes` is not managed thru `update`)._
#### This PR corrects two deficiencies:
-  no SERVICE_VARIANT set: 
  - prevents tasks from reading the appropriate `/edx/app/edxapp` `*.env.json` file;
  - FIX (`pavelib/utils/env.py`):
    - parse command line args for one of 'lms' or 'cms' or 'studio', and set `SERVICE_VARIANT` appropriately;
-  `coffeescript` path not update with theme (once vars read from `*.env.json`):
  - FIX (`pavelib/assets.py`):
    - add theme path, when appropriate, to the search path for `coffee`;
#### Dubious code:

Please review the following aspects:
- `env.py`:  class variables set at class level (not instantiation level), because of current use, e.g. `Env.REPO_ROOT`
  - if the use case exists of a single command line instance of paver, with multiple tasks then this could confound proper operation;
  - I rather prefer having `None` base class attributes, and setting them in `__init__()`, since this would ensure proper operation.   I did not follow this path because it would have meant more code changes (no `Env.REPO_ROOT` anywhere), and would add instantiation of the class.   I prefer consensus on the approach first (so took the path closer to the current code).
- `assets.py`:
  - for no particularly good reason, `THEME_COFFEE_PATHS` and `THEME_SASS_PATHS` set at module level (not w/in function);  not sure I like this.
### Goal

My goal and intent is to have `Vagrantfile` and `update` both honor `build-version.yml` files as extra-vars. At that point, a developer's _Getting Started_ guide to Open edX will be an easier thing to write.  This will simplify getting started, and maintaining edx instances, since common configurations will not require "deep" repository involvement.  `Build-version.yml` is consistent with and distinct from `server-vars.yml` (server configuration and settings).

This goal will involve a PR in the configuration repository (w.i.p.) to update the various `Vagrantfile` instances, and the `update` script template.

Would you please review, @jzoldak & @singingwolfboy
