### PR TITLE
link studio startup.py to lms/startup.py

### DIFF
--- a/cms/startup.py
+++ b/cms/startup.py
@@ -1,16 +1,1 @@
-"""
-Module with code executed during Studio startup
-"""
-from django.conf import settings
-
-# Force settings to run so that the python path is modified
-settings.INSTALLED_APPS  # pylint: disable=W0104
-
-from django_startup import autostartup
-
-
-def run():
-    """
-    Executed during django startup
-    """
-    autostartup()
+../lms/startup.py


### PR DESCRIPTION
See Issue #2397

When custom themes are enabled and set, studio startup fails since it doesn't check or set theming paths (even as it may not use theming items).

This PR removes `cms/startup.py`, and links it to `lms/startup.py`.

Sort of related to PR #3094 (which enables theming configuration thru ansible).

@singingwolfboy - please review.
