### PR TITLE
Watch for asset changes.

### DIFF
--- a/pavelib/__init__.py
+++ b/pavelib/__init__.py
@@ -1,1 +1,5 @@
+"""
+paver commands
+"""
 __all__ = ["assets", "servers", "docs", "prereqs"]
+from . import assets, servers, docs, prereqs

--- a/pavelib/servers.py
+++ b/pavelib/servers.py
@@ -27,7 +27,7 @@ def run_server(system, settings=None, port=None, skip_assets=False):
 
     if not skip_assets:
         # Local dev settings use staticfiles to serve assets, so we can skip the collecstatic step
-        args = [system, '--settings={}'.format(settings), '--skip-collect']
+        args = [system, '--settings={}'.format(settings), '--skip-collect', '--watch']
         call_task('pavelib.assets.update_assets', args=args)
 
     if port is None:
@@ -119,7 +119,7 @@ def run_all_servers(options):
 
     if not fast:
         for system in ['lms', 'studio']:
-            args = [system, '--settings={}'.format(settings), '--skip-collect']
+            args = [system, '--settings={}'.format(settings), '--skip-collect', '--watch']
             call_task('pavelib.assets.update_assets', args=args)
 
     run_multi_processes([

--- a/pavelib/utils/cmd.py
+++ b/pavelib/utils/cmd.py
@@ -2,6 +2,7 @@
 Helper functions for constructing shell commands.
 """
 
+
 def cmd(*args):
     """
     Concatenate the arguments into a space-separated shell command.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -77,7 +77,7 @@ django-ratelimit-backend==0.6
 unicodecsv==0.9.4
 
 # Used for development operation
-watchdog==0.6.0
+watchdog==0.7.1
 
 # Metrics gathering and monitoring
 dogapi==1.2.1


### PR DESCRIPTION
This paver command creates a watchdog that monitors changes to the coffeescript and sass files. It's enabled by default.

If you use devstack and do your editing in the host OS, the monitor won't see your changes (inotify doesn't work across the NFS link). But you can run `paver watch_assets` in the host OS. On OS X, you'll have to upgrade sass (`sudo gem install sass`), and `pip install paver psutil watchdog`.

@singingwolfboy @cpennington @wedaly 
