### PR TITLE
Add acceptance test for blocked YouTueb API with HTML5 sources

### DIFF
--- a/lms/djangoapps/courseware/features/video.feature
+++ b/lms/djangoapps/courseware/features/video.feature
@@ -14,13 +14,13 @@ Feature: LMS Video component
 #    And I click video button "play"
 #    Then I see video starts playing from "0:10" position
 
-  # 2
+  # 1
   Scenario: Video component is fully rendered in the LMS in HTML5 mode
     Given the course has a Video component in "HTML5" mode
     When the video has rendered in "HTML5" mode
     And all sources are correct
 
-  # 3
+  # 2
   @skip_firefox
   Scenario: Autoplay is disabled in LMS for a Video component
     Given the course has a Video component in "HTML5" mode
@@ -40,24 +40,32 @@ Feature: LMS Video component
     When the video has rendered in "HTML5" mode
 
   # 5
+  Scenario: Video component is not rendered in the LMS in Youtube mode with HTML5 sources when YouTube API is blocked
+    Given youtube server is up and response time is 2 seconds
+    And youtube stub server blocks YouTube API
+    And the course has a Video component in "Youtube_HTML5" mode
+    And I wait "3" seconds
+    Then the video has rendered in "HTML5" mode
+
+  # 6
   Scenario: Video component is rendered in the LMS in Youtube mode without HTML5 sources
     Given youtube server is up and response time is 2 seconds
     And the course has a Video component in "Youtube" mode
     When the video has rendered in "Youtube" mode
 
-  # 6
+  # 7
   Scenario: Video component is rendered in the LMS in Youtube mode with HTML5 sources that doesn't supported by browser
     Given youtube server is up and response time is 2 seconds
     And the course has a Video component in "Youtube_HTML5_Unsupported_Video" mode
     When the video has rendered in "Youtube" mode
 
-  # 7
+  # 8
   Scenario: Video component is rendered in the LMS in HTML5 mode with HTML5 sources that doesn't supported by browser
     Given the course has a Video component in "HTML5_Unsupported_Video" mode
     Then error message is shown
     And error message has correct text
 
-  # 8
+  # 9
   Scenario: Multiple videos in sequentials all load and work, switching between sequentials
     Given I am registered for the course "test_course"
     And it has a video "A" in "Youtube" mode in position "1" of sequential
@@ -79,7 +87,7 @@ Feature: LMS Video component
     When I open video "A"
     Then video "A" should start playing at speed "2.0"
 
-  # 9
+  # 10
   Scenario: Video component stores speed correctly when each video is in separate sequence
     Given I am registered for the course "test_course"
     And it has a video "A" in "Youtube" mode in position "1" of sequential
@@ -101,7 +109,7 @@ Feature: LMS Video component
     When I open video "C"
     Then video "C" should start playing at speed "1.0"
 
-  # 10
+  # 11
    Scenario: Language menu works correctly in Video component
      Given I am registered for the course "test_course"
      And I have a "chinese_transcripts.srt" transcript file in assets
@@ -116,7 +124,7 @@ Feature: LMS Video component
      And I select language with code "en"
      And I see "Hi, welcome to Edx." text in the captions
 
-  # 10
+  # 12
   Scenario: CC button works correctly w/o english transcript in HTML5 mode of Video component
     Given I am registered for the course "test_course"
     And I have a "chinese_transcripts.srt" transcript file in assets
@@ -126,7 +134,7 @@ Feature: LMS Video component
     And I make sure captions are opened
     Then I see "好 各位同学" text in the captions
 
-  # 11
+  # 13
   Scenario: CC button works correctly only w/ english transcript in HTML5 mode of Video component
     Given I am registered for the course "test_course"
     And I have a "subs_OEoXaMPEzfM.srt.sjson" transcript file in assets
@@ -136,7 +144,7 @@ Feature: LMS Video component
     And I make sure captions are opened
     Then I see "Hi, welcome to Edx." text in the captions
 
-  # 12
+  # 14
   Scenario: CC button works correctly w/o english transcript in Youtube mode of Video component
     Given I am registered for the course "test_course"
     And I have a "chinese_transcripts.srt" transcript file in assets
@@ -146,7 +154,7 @@ Feature: LMS Video component
     And I make sure captions are opened
     Then I see "好 各位同学" text in the captions
 
-  # 13
+  # 15
   Scenario: CC button works correctly if transcripts and sub fields are empty, but transcript file exists in assets (Youtube mode of Video component)
     Given I am registered for the course "test_course"
     And I have a "subs_OEoXaMPEzfM.srt.sjson" transcript file in assets
@@ -154,12 +162,12 @@ Feature: LMS Video component
     And I make sure captions are opened
     Then I see "Hi, welcome to Edx." text in the captions
 
-  # 14
+  # 16
   Scenario: CC button is hidden if no translations
     Given the course has a Video component in "Youtube" mode
     Then button "CC" is hidden
 
-  # 15
+  # 17
   Scenario: Video is aligned correctly if transcript is visible in fullscreen mode
     Given I am registered for the course "test_course"
     And I have a "subs_OEoXaMPEzfM.srt.sjson" transcript file in assets
@@ -170,13 +178,13 @@ Feature: LMS Video component
     And I click video button "fullscreen"
     Then I see video aligned correctly with enabled transcript
 
-  # 16
+  # 18
   Scenario: Video is aligned correctly if transcript is hidden in fullscreen mode
     Given the course has a Video component in "Youtube" mode
     And I click video button "fullscreen"
     Then I see video aligned correctly without enabled transcript
 
-  # 17
+  # 19
   Scenario: Video is aligned correctly on transcript toggle in fullscreen mode
     Given I am registered for the course "test_course"
     And I have a "subs_OEoXaMPEzfM.srt.sjson" transcript file in assets
@@ -189,7 +197,7 @@ Feature: LMS Video component
     And I click video button "CC"
     Then I see video aligned correctly without enabled transcript
 
-  # 18
+  # 20
   Scenario: Download Transcript button works correctly in Video component
     Given I am registered for the course "test_course"
     And I have a "subs_OEoXaMPEzfM.srt.sjson" transcript file in assets
@@ -227,7 +235,7 @@ Feature: LMS Video component
 #    Then I see "Hi, welcome to Edx." text in the captions
 #    And I see duration "1:00"
 
-  # 20
+  # 21
    Scenario: Download button works correctly for non-english transcript in Youtube mode of Video component
      Given I am registered for the course "test_course"
      And I have a "chinese_transcripts.srt" transcript file in assets
@@ -240,7 +248,7 @@ Feature: LMS Video component
      And I see "好 各位同学" text in the captions
      Then I can download transcript in "srt" format that has text "好 各位同学"
 
-  # 21
+  # 22
    Scenario: Download button works correctly for non-english transcript in HTML5 mode of Video component
      Given I am registered for the course "test_course"
      And I have a "chinese_transcripts.srt" transcript file in assets
@@ -253,7 +261,7 @@ Feature: LMS Video component
      And I see "好 各位同学" text in the captions
      Then I can download transcript in "srt" format that has text "好 各位同学"
 
-  # 22
+  # 23
   Scenario: Download button works correctly w/o english transcript in HTML5 mode of Video component
     Given I am registered for the course "test_course"
     And I have a "chinese_transcripts.srt" transcript file in assets
@@ -263,7 +271,7 @@ Feature: LMS Video component
     And I see "好 各位同学" text in the captions
     Then I can download transcript in "srt" format that has text "好 各位同学"
 
-  # 23
+  # 24
   Scenario: Download button works correctly w/o english transcript in Youtube mode of Video component
     Given I am registered for the course "test_course"
     And I have a "chinese_transcripts.srt" transcript file in assets
@@ -273,7 +281,7 @@ Feature: LMS Video component
     And I see "好 各位同学" text in the captions
     Then I can download transcript in "srt" format that has text "好 各位同学"
 
-  # 24
+  # 25
   Scenario: Verify that each video in each sub-section includes a transcript for non-Youtube countries.
     Given youtube server is up and response time is 2 seconds
     And I am registered for the course "test_course"

--- a/lms/djangoapps/courseware/features/video.py
+++ b/lms/djangoapps/courseware/features/video.py
@@ -280,11 +280,6 @@ def configure_youtube_api(_step, action):
         raise ValueError('Parameter `action` should be one of "proxies" or "blocks".')
 
 
-@step('We explicitly wait for YouTube API to not load$')
-def wait_for_youtube_api_fail(_step):
-    world.wait(3)
-
-
 @step('when I view the (.*) it does not have autoplay enabled$')
 def does_not_autoplay(_step, video_type):
     actual = world.css_find('.%s' % video_type)[0]['data-autoplay']

--- a/lms/djangoapps/courseware/features/video.py
+++ b/lms/djangoapps/courseware/features/video.py
@@ -269,6 +269,22 @@ def parse_time_str(time_str):
     return time_obj.tm_min * 60 + time_obj.tm_sec
 
 
+@step('youtube stub server (.*) YouTube API')
+def configure_youtube_api(_step, action):
+    action=action.strip()
+    if action == 'proxies':
+        world.youtube.config['youtube_api_blocked'] = False
+    elif action == 'blocks':
+        world.youtube.config['youtube_api_blocked'] = True
+    else:
+        raise ValueError('Parameter `action` should be one of "proxies" or "blocks".')
+
+
+@step('We explicitly wait for YouTube API to not load$')
+def wait_for_youtube_api_fail(_step):
+    world.wait(3)
+
+
 @step('when I view the (.*) it does not have autoplay enabled$')
 def does_not_autoplay(_step, video_type):
     actual = world.css_find('.%s' % video_type)[0]['data-autoplay']
@@ -543,4 +559,3 @@ def shows_captions(_step, show_captions):
         assert world.is_css_present('div.video.closed')
     else:
         assert world.is_css_not_present('div.video.closed')
-


### PR DESCRIPTION
**Description**

When the video has both YouTube IDs and HTML5 sources, and the YouTube API is blocked, then HTML5 sources should be used.

**Jira issue**

[BLD-965](https://edx-wiki.atlassian.net/browse/BLD-965).

**Reviewers**
- @polesye 
