### PR TITLE
Create configuration so new ORA can know where to log non-XBlock events to

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1518,6 +1518,6 @@ for app_name in OPTIONAL_APPS:
 # See common/djangoapps/third_party_auth/settings.py for configuration details.
 THIRD_PARTY_AUTH = {}
 
-EDX_TIM = {
+EDX_ORA2 = {
     "EVENT_LOGGER": "track.tracker.send"
 }

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1517,3 +1517,7 @@ for app_name in OPTIONAL_APPS:
 # Stub for third_party_auth options.
 # See common/djangoapps/third_party_auth/settings.py for configuration details.
 THIRD_PARTY_AUTH = {}
+
+EDX_TIM = {
+    "EVENT_LOGGER": "track.tracker.send"
+}

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -26,7 +26,7 @@
 -e git+https://github.com/edx/bok-choy.git@25a47b3bf87c503fc4996e52addac83b42ec6f38#egg=bok_choy
 -e git+https://github.com/edx-solutions/django-splash.git@9965a53c269666a30bb4e2b3f6037c138aef2a55#egg=django-splash
 -e git+https://github.com/edx/acid-block.git@459aff7b63db8f2c5decd1755706c1a64fb4ebb1#egg=acid-xblock
--e git+https://github.com/edx/edx-ora2.git@87fd72f9927cd37e553d7f68cfaf80d6c574eb55#egg=edx-ora2
+-e git+https://github.com/edx/edx-ora2.git@395d162d45cf13ea3058a39053a1e9f5d8400a37#egg=edx-ora2
 
-# Prototype XBlocks for limited roll-outs and user testing. These are not for general use. 
+# Prototype XBlocks for limited roll-outs and user testing. These are not for general use.
 -e git+https://github.com/pmitros/ConceptXBlock.git@2376fde9ebdd83684b78dde77ef96361c3bd1aa0#egg=concept-xblock

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -26,7 +26,7 @@
 -e git+https://github.com/edx/bok-choy.git@25a47b3bf87c503fc4996e52addac83b42ec6f38#egg=bok_choy
 -e git+https://github.com/edx-solutions/django-splash.git@9965a53c269666a30bb4e2b3f6037c138aef2a55#egg=django-splash
 -e git+https://github.com/edx/acid-block.git@459aff7b63db8f2c5decd1755706c1a64fb4ebb1#egg=acid-xblock
--e git+https://github.com/edx/edx-ora2.git@395d162d45cf13ea3058a39053a1e9f5d8400a37#egg=edx-ora2
+-e git+https://github.com/edx/edx-ora2.git@d59288cb8973be5c9179ae74591437f1b768c907#egg=edx-ora2
 
 # Prototype XBlocks for limited roll-outs and user testing. These are not for general use.
 -e git+https://github.com/pmitros/ConceptXBlock.git@2376fde9ebdd83684b78dde77ef96361c3bd1aa0#egg=concept-xblock


### PR DESCRIPTION
@wedaly, @stephensanchez: This is the last bit of TIM-260, and is necessary for event information to go through for scoring (our only non-XBlock tracking event).

@rocha, @mulby: As discussed, the event lacks a lot of the normal fields. An example:

``` python
{
    'points_possible': 8L,
    'points_earned': 8L,
    'event_type': 'openassessment.workflow.score',
    'submission_uuid': u'977f453e-b6f1-11e3-a909-080027880ca6'
}
```

I'm working this weekend but out starting on Monday, so either @wedaly or @stephensanchez will need to shepherd this through if there are other changes.
