### PR TITLE
Translation fix in studio: For better translation in unit.html

### DIFF
--- a/cms/templates/unit.html
+++ b/cms/templates/unit.html
@@ -165,15 +165,21 @@ require(["domReady!", "jquery", "js/models/module_info", "coffee/src/views/unit"
               <p class="publish-draft-message">${_('This is a draft of the published unit. To update the live version, you must {link_start}replace it with this draft{link_end}.').format(link_start='<a href="#" class="publish-draft">', link_end='</a>')}</p>
             </div>
             <div class="row status">
-              <p>${_("This unit is scheduled to be released to <strong>students</strong>")}
-              % if release_date is not None:
-                ${_(u"on {date}").format(date=u"<strong>{}</strong>".format(release_date))}
-              % endif
-              ${_("with the subsection {link_start}{name}{link_end}").format(
-                  name=subsection.display_name_with_default,
-                  link_start=u'<a href="{url}">'.format(url=subsection_url),
-                  link_end='</a>',
-                )}
+              <p>
+               % if release_date is not None:
+                  ${_("This unit is scheduled to be released to <strong>students</strong> on <strong>{date}</strong> with the subsection {link_start}{name}{link_end}").format(
+                      date=release_date,
+                      name=subsection.display_name_with_default,
+                      link_start=u'<a href="{url}">'.format(url=subsection_url),
+                      link_end=u'</a>',
+                  )}
+               % else:
+                  ${_("This unit is scheduled to be released to <strong>students</strong> with the subsection {link_start}{name}{link_end}").format(
+                      name=subsection.display_name_with_default,
+                      link_start=u'<a href="{url}">'.format(url=subsection_url),
+                      link_end=u'</a>',
+                  )}
+               % endif
               </p>
             </div>
             <div class="row unit-actions">


### PR DESCRIPTION
As the sentence in unit.html is splitted into three parts due to the varible release_date may be None, it breaks the integrity of a sentence.
Different language may have different word or event grammer order, so if a sentence is breaked into three parts, translators cannot adjust the word orders to create a good translation.
This fix tries to combine the sentence together so that translators can freely change the orders of sentence parts to make a good translation.
