### PR TITLE
Fix multiple videos on page

### DIFF
--- a/lms/djangoapps/courseware/features/video.feature
+++ b/lms/djangoapps/courseware/features/video.feature
@@ -14,48 +14,70 @@ Feature: LMS Video component
 #    And I click video button "play"
 #    Then I see video starts playing from "0:10" position
 
-  # 2
+  # 1
   Scenario: Video component is fully rendered in the LMS in HTML5 mode
     Given the course has a Video component in "HTML5" mode
     When the video has rendered in "HTML5" mode
     And all sources are correct
 
-  # 3
+  # 2
   @skip_firefox
   Scenario: Autoplay is disabled in LMS for a Video component
     Given the course has a Video component in "HTML5" mode
     Then when I view the video it does not have autoplay enabled
 
-  # 4
+  # 3
   # Youtube testing
   Scenario: Video component is fully rendered in the LMS in Youtube mode with HTML5 sources
     Given youtube server is up and response time is 0.4 seconds
     And the course has a Video component in "Youtube_HTML5" mode
     When the video has rendered in "Youtube" mode
 
-  # 5
+  # 4
   Scenario: Video component is not rendered in the LMS in Youtube mode with HTML5 sources
     Given youtube server is up and response time is 2 seconds
     And the course has a Video component in "Youtube_HTML5" mode
     When the video has rendered in "HTML5" mode
 
-  # 6
+  # 5
   Scenario: Video component is rendered in the LMS in Youtube mode without HTML5 sources
     Given youtube server is up and response time is 2 seconds
     And the course has a Video component in "Youtube" mode
     When the video has rendered in "Youtube" mode
 
-  # 7
+  # 6
   Scenario: Video component is rendered in the LMS in Youtube mode with HTML5 sources that doesn't supported by browser
     Given youtube server is up and response time is 2 seconds
     And the course has a Video component in "Youtube_HTML5_Unsupported_Video" mode
     When the video has rendered in "Youtube" mode
 
-  # 8
+  # 7
   Scenario: Video component is rendered in the LMS in HTML5 mode with HTML5 sources that doesn't supported by browser
     Given the course has a Video component in "HTML5_Unsupported_Video" mode
     Then error message is shown
     And error message has correct text
+
+  # 8
+  Scenario: Multiple videos in sequentials all load and work, switching between sequentials
+    Given I am registered for the course "test_course"
+    And it has a video "A" in "Youtube" mode in position "1" of sequential
+    And a video "B" in "HTML5" mode in position "1" of sequential
+    And a video "C" in "Youtube" mode in position "1" of sequential
+    And a video "D" in "Youtube" mode in position "1" of sequential
+    And a video "E" in "Youtube" mode in position "2" of sequential
+    And a video "F" in "Youtube" mode in position "2" of sequential
+    And a video "G" in "Youtube" mode in position "2" of sequential
+    And I open the section with videos
+    Then video "A" should start playing at speed "1.0"
+    And I select the "2.0" speed on video "B"
+    And I select the "2.0" speed on video "C"
+    And I select the "2.0" speed on video "D"
+    When I open video "E"
+    Then video "E" should start playing at speed "2.0"
+    And I select the "1.0" speed on video "F"
+    And I select the "1.0" speed on video "G"
+    When I open video "A"
+    Then video "A" should start playing at speed "2.0"
 
   # 9
   Scenario: Video component stores speed correctly when each video is in separate sequence
@@ -205,7 +227,7 @@ Feature: LMS Video component
 #    Then I see "Hi, welcome to Edx." text in the captions
 #    And I see duration "1:00"
 
-  # 21
+  # 20
    Scenario: Download button works correctly for non-english transcript in Youtube mode of Video component
      Given I am registered for the course "test_course"
      And I have a "chinese_transcripts.srt" transcript file in assets
@@ -218,7 +240,7 @@ Feature: LMS Video component
      And I see "好 各位同学" text in the captions
      Then I can download transcript in "srt" format that has text "好 各位同学"
 
-  # 22
+  # 21
    Scenario: Download button works correctly for non-english transcript in HTML5 mode of Video component
      Given I am registered for the course "test_course"
      And I have a "chinese_transcripts.srt" transcript file in assets
@@ -231,7 +253,7 @@ Feature: LMS Video component
      And I see "好 各位同学" text in the captions
      Then I can download transcript in "srt" format that has text "好 各位同学"
 
-  # 23
+  # 22
   Scenario: Download button works correctly w/o english transcript in HTML5 mode of Video component
     Given I am registered for the course "test_course"
     And I have a "chinese_transcripts.srt" transcript file in assets
@@ -241,7 +263,7 @@ Feature: LMS Video component
     And I see "好 各位同学" text in the captions
     Then I can download transcript in "srt" format that has text "好 各位同学"
 
-  # 24
+  # 23
   Scenario: Download button works correctly w/o english transcript in Youtube mode of Video component
     Given I am registered for the course "test_course"
     And I have a "chinese_transcripts.srt" transcript file in assets
@@ -251,7 +273,7 @@ Feature: LMS Video component
     And I see "好 各位同学" text in the captions
     Then I can download transcript in "srt" format that has text "好 各位同学"
 
-  # 25
+  # 24
   Scenario: Verify that each video in each sub-section includes a transcript for non-Youtube countries.
     Given youtube server is up and response time is 2 seconds
     And I am registered for the course "test_course"


### PR DESCRIPTION
**Description**

If there are several videos on page, make sure that the global onYouTubeIframeAPIReady function is properly setup so that all callbacks are trigerred when the YouTube API loads.

**Jira issue**

[BLD-972](https://edx-wiki.atlassian.net/browse/BLD-972)

**Reviewers**
- @rocha 
