### PR TITLE
Add EDX_ORA2 config for non-XBlock analytics event routing.

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1517,3 +1517,10 @@ for app_name in OPTIONAL_APPS:
 # Stub for third_party_auth options.
 # See common/djangoapps/third_party_auth/settings.py for configuration details.
 THIRD_PARTY_AUTH = {}
+
+# ORA2
+EDX_ORA2 = {
+    # Temp hack to log events from non-XBlock parts of ORA2 until it can
+    # switch over to using the event tracking API.
+    "EVENT_LOGGER": "track.tracker.send"
+}


### PR DESCRIPTION
This PR is being done in lieu of #3118.

@wedaly, @stephensanchez, @mulby, @rocha: If this is merged, the event generated in https://github.com/edx/edx-ora2/pull/235 will be put into the analytics pipeline, capturing when a student's openassessment workflow is complete and they receive a score. If this isn't, then edx-ora2 still creates that event, but it just goes to info level logging and doesn't touch event tracking. As mentioned in the other PR, this information is also captured in the database.
