### PR TITLE
Add test in import code to make sure two overlapping courses aren't imported

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/import.py
+++ b/cms/djangoapps/contentstore/management/commands/import.py
@@ -53,5 +53,5 @@ class Command(BaseCommand):
         for module in course_items:
             course_id = module.location.course_id
             if not are_permissions_roles_seeded(course_id):
-                self.stdout.write('Seeding forum roles for course {0}'.format(course_id))
+                self.stdout.write('Seeding forum roles for course {0}\n'.format(course_id))
                 seed_permissions_roles(course_id)

--- a/cms/djangoapps/contentstore/management/commands/tests/test_import.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_import.py
@@ -23,7 +23,7 @@ class TestImport(ModuleStoreTestCase):
     """
 
     COURSE_ID = ['EDx', '0.00x', '2013_Spring', ]
-    DIFF_TERM = ['EDx', '0.00x', '2014_Spring', ]
+    DIFF_RUN = ['EDx', '0.00x', '2014_Spring', ]
 
     def setUp(self):
         """
@@ -43,14 +43,14 @@ class TestImport(ModuleStoreTestCase):
         with open(os.path.join(self.good_dir, "course", "{0[2]}.xml".format(self.COURSE_ID)), "w+") as f:
             f.write('<course></course>')
 
-        # Create term changed course xml
+        # Create run changed course xml
         self.dupe_dir = tempfile.mkdtemp(dir=self.content_dir)
         os.makedirs(os.path.join(self.dupe_dir, "course"))
         with open(os.path.join(self.dupe_dir, "course.xml"), "w+") as f:
             f.write('<course url_name="{0[2]}" org="{0[0]}" '
-                    'course="{0[1]}"/>'.format(self.DIFF_TERM))
+                    'course="{0[1]}"/>'.format(self.DIFF_RUN))
 
-        with open(os.path.join(self.dupe_dir, "course", "{0[2]}.xml".format(self.DIFF_TERM)), "w+") as f:
+        with open(os.path.join(self.dupe_dir, "course", "{0[2]}.xml".format(self.DIFF_RUN)), "w+") as f:
             f.write('<course></course>')
 
     def test_forum_seed(self):
@@ -63,8 +63,9 @@ class TestImport(ModuleStoreTestCase):
 
     def test_duplicate_with_url(self):
         """
-        Check to make sure an import doesn't import courses that will
-        create find one duplicates
+        Check to make sure an import doesn't import courses that have the
+        same org and course, but they have different runs in order to
+        prevent modulestore "findone" exceptions on deletion
         """
         # Load up base course and verify it is available
         call_command('import', self.content_dir, self.good_dir)
@@ -73,4 +74,4 @@ class TestImport(ModuleStoreTestCase):
 
         # Now load up duped course and verify it doesn't load
         call_command('import', self.content_dir, self.dupe_dir)
-        self.assertIsNone(store.get_course('/'.join(self.DIFF_TERM)))
+        self.assertIsNone(store.get_course('/'.join(self.DIFF_RUN)))

--- a/common/lib/xmodule/xmodule/modulestore/xml_importer.py
+++ b/common/lib/xmodule/xmodule/modulestore/xml_importer.py
@@ -176,6 +176,31 @@ def import_from_xml(
                 if module.scope_ids.block_type == 'course':
                     course_data_path = path(data_dir) / module.data_dir
                     course_location = module.location
+                    course_prefix = u'{0.org}/{0.course}'.format(course_location)
+
+                    # Check to see if a course with the same
+                    # pseudo_course_id, but different term exists in
+                    # the passed store to avoid broken courses
+                    courses = store.get_courses()
+                    bad_term = False
+                    for course in courses:
+                        if course.location.course_id.startswith(course_prefix):
+                            log.debug('Import is overwriting existing course')
+                            # Importing over existing course, check
+                            # that terms match or fail
+                            if course.location.name != module.location.name:
+                                log.error(
+                                    'A course with ID %s exists, and this '
+                                    'course has the same organization and '
+                                    'course number, but a different term that '
+                                    'is fully identified as %s.',
+                                    course.location.course_id,
+                                    module.location.course_id
+                                )
+                                bad_term = True
+                    if bad_term:
+                        # Skip this course, but keep trying to import courses
+                        continue
 
                     log.debug('======> IMPORTING course to location {loc}'.format(
                         loc=course_location

--- a/common/lib/xmodule/xmodule/modulestore/xml_importer.py
+++ b/common/lib/xmodule/xmodule/modulestore/xml_importer.py
@@ -179,15 +179,15 @@ def import_from_xml(
                     course_prefix = u'{0.org}/{0.course}'.format(course_location)
 
                     # Check to see if a course with the same
-                    # pseudo_course_id, but different term exists in
+                    # pseudo_course_id, but different run exists in
                     # the passed store to avoid broken courses
                     courses = store.get_courses()
-                    bad_term = False
+                    bad_run = False
                     for course in courses:
                         if course.location.course_id.startswith(course_prefix):
                             log.debug('Import is overwriting existing course')
                             # Importing over existing course, check
-                            # that terms match or fail
+                            # that runs match or fail
                             if course.location.name != module.location.name:
                                 log.error(
                                     'A course with ID %s exists, and this '
@@ -197,8 +197,9 @@ def import_from_xml(
                                     course.location.course_id,
                                     module.location.course_id
                                 )
-                                bad_term = True
-                    if bad_term:
+                                bad_run = True
+                                break
+                    if bad_run:
                         # Skip this course, but keep trying to import courses
                         continue
 


### PR DESCRIPTION
We have been having an issue where the course term changes and gets imported via the command line. This completes successfully and creates two courses that have overlapping items in the modulestore. This results in major problems when one course is deleted as it fires errors with findone finding more than one location as well as deleting portions of both courses when one is partially deleted.  

This code corrects this by logging an error when the bad import occurs and skipping the import that would cause the bad modulestore state to occur.  This is already a condition that is checked for in studio, but this enforces it at the import level so that it can't occur via the management command or other possible xml import entry points either.

FYI to @pdpinch and @ichuang

@sarina not sure on reviewers
