### PR TITLE
Don't hardcode https protocol in password reset email.

### DIFF
--- a/lms/templates/registration/password_reset_email.html
+++ b/lms/templates/registration/password_reset_email.html
@@ -3,7 +3,7 @@
 
 {% trans "Please go to the following page and choose a new password:" %}
 {% block reset_link %}
-https://{{domain}}{% url 'student.views.password_reset_confirm_wrapper' uidb36=uid token=token %}
+http{% if is_secure %}s{% endif %}://{{domain}}{% url 'student.views.password_reset_confirm_wrapper' uidb36=uid token=token %}
 {% endblock %}
 
 {% trans "If you didn't request this change, you can disregard this email - we have not yet reset your password." %}


### PR DESCRIPTION
Use http or https, depending on the value of `is_secure`.
This is similar to how links in some other email templates work.
