### PR TITLE
Make new-style chinese language codes works for translation

### DIFF
--- a/common/djangoapps/dark_lang/middleware.py
+++ b/common/djangoapps/dark_lang/middleware.py
@@ -16,6 +16,42 @@ from django.utils.translation.trans_real import parse_accept_lang_header
 from dark_lang.models import DarkLangConfig
 
 
+def dark_parse_accept_lang_header(accept):
+    '''
+    The use of 'zh-cn' for 'Simplified Chinese' and 'zh-tw' for 'Traditional Chinese'
+    are now deprecated, as discussed here: https://code.djangoproject.com/ticket/18419.
+    The new language codes 'zh-hans' and 'zh-hant' are now used since django 1.7.
+    Although majority of browsers still use the old language codes, some new browsers
+    such as IE11 in Windows 8.1 start to use the new ones, which makes the current
+    chinese translations of edX don't work properly under these browsers.
+    This function can keep compatibility between the old and new language codes. If one
+    day edX uses django 1.7 or higher, this function can be modified to support the old
+    language codes until there are no browsers use them.
+    '''
+    browser_langs = parse_accept_lang_header(accept)
+    django_langs = []
+    for lang, priority in browser_langs:
+        lang = CHINESE_LANGUAGE_CODE_MAP.get(lang.lower(), lang)
+        django_langs.append((lang, priority))
+    return django_langs
+
+# If django 1.7 or higher is used, the right-side can be updated with new-style codes.
+CHINESE_LANGUAGE_CODE_MAP = {
+    # The following are the new-style language codes for chinese language
+    'zh-hans': 'zh-CN',     # Chinese (Simplified),
+    'zh-hans-cn': 'zh-CN',  # Chinese (Simplified, China)
+    'zh-hans-sg': 'zh-CN',  # Chinese (Simplified, Singapore)
+    'zh-hant': 'zh-TW',     # Chinese (Traditional)
+    'zh-hant-hk': 'zh-TW',  # Chinese (Traditional, Hongkong)
+    'zh-hant-mo': 'zh-TW',  # Chinese (Traditional, Macau)
+    'zh-hant-tw': 'zh-TW',  # Chinese (Traditional, Taiwan)
+    # The following are the old-style language codes that django does not recognize
+    'zh-hk': 'zh-TW',       # Chinese (Traditional, Hongkong)
+    'zh-mo': 'zh-TW',       # Chinese (Traditional, Macau)
+    'zh-sg': 'zh-CN',       # Chinese (Simplified, Singapore)
+}
+
+
 class DarkLangMiddleware(object):
     """
     Middleware for dark-launching languages.
@@ -65,7 +101,7 @@ class DarkLangMiddleware(object):
         new_accept = ", ".join(
             self._format_accept_value(lang, priority)
             for lang, priority
-            in parse_accept_lang_header(accept)
+            in dark_parse_accept_lang_header(accept)
             if self._is_released(lang)
         )
 

--- a/common/djangoapps/dark_lang/tests.py
+++ b/common/djangoapps/dark_lang/tests.py
@@ -208,3 +208,15 @@ class DarkLangMiddlewareTests(TestCase):
             'rel',
             self.process_request(preview_lang='unrel', django_language='rel')
         )
+
+    def test_accept_chinese_language_codes(self):
+        DarkLangConfig(
+            released_languages=('zh-cn, zh-tw'),
+            changed_by=self.user,
+            enabled=True
+        ).save()
+
+        self.assertAcceptEquals(
+            'zh-CN;q=1.0, zh-TW;q=0.5, zh-TW;q=0.3',
+            self.process_request(accept='zh-Hans;q=1.0, zh-Hant-TW;q=0.5, zh-hk;q=0.3')
+        )


### PR DESCRIPTION
The old-style chinese language codes used in django 1.4 series are now deprecated, as discussed here: `https://code.djangoproject.com/ticket/18419`.
Although majority of browsers still use the old-style language codes, some new browsers such as IE11 in Windows 8.1 start to use the new-style names instead of old-style ones which makes the current chinese translations of edX can't work properly under these browsers.
As there is no easy way for edX to change a higher version of django, I think we could do some mapping here so that the users who use IE11 in Windows 8.1 or other browsers that use the new-style names can view correct translations.
Also, this fix will make users who use one of the language codes: `zh-hk`, `zh-sg` and `zh-mo` can see the correct translations.
