### PR TITLE
Fix flaky acceptance test.

### DIFF
--- a/cms/djangoapps/contentstore/features/upload.py
+++ b/cms/djangoapps/contentstore/features/upload.py
@@ -26,8 +26,7 @@ def go_to_uploads(_step):
 
 @step(u'I upload the( test)? file "([^"]*)"$')
 def upload_file(_step, is_test_file, file_name):
-    upload_css = 'a.upload-button'
-    world.css_click(upload_css)
+    world.click_link('Upload New File')
 
     if not is_test_file:
         _write_test_file(file_name, "test file")


### PR DESCRIPTION
BLD-969 @polesye  please review. 

Reason for the fix:
There are two buttons in Studio course assets when there are no files in assets: in the middle of the page and in the right upper corner.
When running acceptance tests for a whole feature file, manual testing shows, that button in the middle is not clickable.
That's why css was changed to use button in right upper corner.
