### PR TITLE
Fixed studio can't handle more than 9 lines in advanced settings.

### DIFF
--- a/cms/static/sass/views/_settings.scss
+++ b/cms/static/sass/views/_settings.scss
@@ -833,7 +833,6 @@
         outline: 0;
         height: auto;
         min-height: ($baseline*2.25);
-        max-height: ($baseline*10);
 
         &.CodeMirror-focused {
           @include linear-gradient($paleYellow, tint($paleYellow, 90%));


### PR DESCRIPTION
STUD-1483

Studio can't handle more than 9 lines in advanced settings. there was a max-height attribute for CodeMirror CSS which was limiting the text input field to specific height.
