### PR TITLE
Updating ora2 requirements

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -26,7 +26,7 @@
 -e git+https://github.com/edx/bok-choy.git@25a47b3bf87c503fc4996e52addac83b42ec6f38#egg=bok_choy
 -e git+https://github.com/edx-solutions/django-splash.git@9965a53c269666a30bb4e2b3f6037c138aef2a55#egg=django-splash
 -e git+https://github.com/edx/acid-block.git@459aff7b63db8f2c5decd1755706c1a64fb4ebb1#egg=acid-xblock
--e git+https://github.com/edx/edx-ora2.git@87fd72f9927cd37e553d7f68cfaf80d6c574eb55#egg=edx-ora2
+-e git+https://github.com/edx/edx-ora2.git@26fc1126c5ba322a04b1094c5e6481e2fd36dab3#egg=edx-ora2
 
 # Prototype XBlocks for limited roll-outs and user testing. These are not for general use. 
 -e git+https://github.com/pmitros/ConceptXBlock.git@2376fde9ebdd83684b78dde77ef96361c3bd1aa0#egg=concept-xblock


### PR DESCRIPTION
Changing the ora2 requirements to point at the release hash. 
@wedaly 
@feanil Note that the name of the egg is still 'edx-ora2', versus 'ora2'.  This is what the line says on platform release now, does this need to change, or should it stay the same? 
