### PR TITLE
Use monospaced font for CodeMirror editor.

### DIFF
--- a/cms/static/sass/views/_settings.scss
+++ b/cms/static/sass/views/_settings.scss
@@ -828,7 +828,7 @@
         border: 1px solid $mediumGrey;
         border-radius: 2px;
         background-color: $lightGrey;
-        font-family: 'Open Sans', sans-serif;
+        font-family: $f-monospace;
         color: $baseFontColor;
         outline: 0;
         height: auto;
@@ -838,6 +838,10 @@
         &.CodeMirror-focused {
           @include linear-gradient($paleYellow, tint($paleYellow, 90%));
           outline: 0;
+        }
+
+        .CodeMirror-sizer {
+          top: 4px; /* Vertical alignment for monospace font */
         }
 
         // editor color changes just for JSON


### PR DESCRIPTION
Cursor position gets off with non-monospaced font.
STUD-1456.

This bug does not exist for our CodeMirror usage in Problems and HTML because we already use a monospaced font there. I think the bug was introduced in our CodeMirror upgrade, and it may be particular to certain browsers (both Nimisha and I have seen it).

@marcotuts and @nasthagiri Please review.
@marcotuts is there a more attractive monospaced font?
