### PR TITLE
Fix bad interaction between pluggable InputTypes and Microsites

### DIFF
--- a/common/djangoapps/edxmako/paths.py
+++ b/common/djangoapps/edxmako/paths.py
@@ -15,11 +15,14 @@ class DynamicTemplateLookup(TemplateLookup):
     A specialization of the standard mako `TemplateLookup` class which allows
     for adding directories progressively.
     """
-    def add_directory(self, directory):
+    def add_directory(self, directory, prepend=False):
         """
         Add a new directory to the template lookup path.
         """
-        self.directories.append(os.path.normpath(directory))
+        if prepend:
+            self.directories.insert(0, os.path.normpath(directory))
+        else:
+            self.directories.append(os.path.normpath(directory))
 
 
 def clear_lookups(namespace):
@@ -29,7 +32,7 @@ def clear_lookups(namespace):
     if namespace in LOOKUP:
         del LOOKUP[namespace]
 
-def add_lookup(namespace, directory, package=None):
+def add_lookup(namespace, directory, package=None, prepend=False):
     """
     Adds a new mako template lookup directory to the given namespace.
 
@@ -48,7 +51,7 @@ def add_lookup(namespace, directory, package=None):
         )
     if package:
         directory = pkg_resources.resource_filename(package, directory)
-    templates.add_directory(directory)
+    templates.add_directory(directory, prepend=prepend)
 
 
 def lookup_template(namespace, name):

--- a/lms/startup.py
+++ b/lms/startup.py
@@ -52,8 +52,7 @@ def enable_theme():
 
     # Include the theme's templates in the template search paths
     settings.TEMPLATE_DIRS.insert(0, theme_root / 'templates')
-    settings.MAKO_TEMPLATES['main'].insert(0, theme_root / 'templates')
-    edxmako.startup.run()
+    edxmako.paths.add_lookup('main', theme_root / 'templates', prepend=True)
 
     # Namespace the theme's static files to 'themes/<theme_name>' to
     # avoid collisions with default edX static files
@@ -98,8 +97,7 @@ def enable_microsites():
     # if we have any valid microsites defined, let's wire in the Mako and STATIC_FILES search paths
     if microsite_config_dict:
         settings.TEMPLATE_DIRS.append(microsites_root)
-        settings.MAKO_TEMPLATES['main'].append(microsites_root)
-        edxmako.startup.run()
+        edxmako.paths.add_lookup('main', microsites_root)
 
         settings.STATICFILES_DIRS.insert(0, microsites_root)
 


### PR DESCRIPTION
Pluggable InputTypes use edxmako.paths.add_lookup to inject new mako template
directories. Those were getting clobbered by microsites
(and by theming), which were completely rebuilding the mako template lookup
list from scratch.

This commit switches those two features to use the same add_lookup function as
pluggable InputTypes.

[LMS-2489]
