### PR TITLE
Adding ability to capture auto screenshots on demand

### DIFF
--- a/lms/djangoapps/courseware/features/video.py
+++ b/lms/djangoapps/courseware/features/video.py
@@ -629,4 +629,3 @@ def click_on_the_caption(_step, index, expected_time):
     find_caption_line_by_data_index(int(index)).click()
     actual_time = elapsed_time()
     assert int(expected_time) == actual_time
-

--- a/rakelib/tests.rake
+++ b/rakelib/tests.rake
@@ -51,9 +51,10 @@ def run_tests(system, report_dir, test_id=nil, stop_on_failure=true)
 end
 
 task :clean_test_files do
-    desc "Clean fixture files used by tests and .pyc files"
+    desc "Clean fixture files used by tests, .pyc files, and automatic screenshots"
     sh("git clean -fqdx test_root/logs test_root/data test_root/staticfiles test_root/uploads")
     sh("find . -type f -name \"*.pyc\" -delete")
+    sh("rm -rf test_root/log/auto_screenshots/*")
 end
 
 task :clean_reports_dir => REPORT_DIR do


### PR DESCRIPTION
**Description**

Using the steps:

```
Given I enable capturing of screenshots before and after each step
Given I disable capturing of screenshots before and after each step
```

You can turn on capturing of screenshots and turn it off. They will be saved to directory:

```
{TEST_ROOT}/log/auto_screenshots
```

This directory is not tracked by git.

Each screenshot will be named with the following name:

```
{scenario number}__{step number}__{step function name}__{"before"|"after"}
```

Upon subsequent launches of a test, if screenshots are enabled, new screenshots will overwrite the old screenshots.

Also you can use the function

```
world.capture_screenshot(image_name)
```

anywhere you want, without turning on auto screenshots for the step.

Also you can use the decorator

```
@capture_screenshot_before_after
```

to add screenshot before and after a function execution (it can be any function, not just a step function).

**Reviewers**
- @polesye 
- @auraz 
