### PR TITLE
Temporarily disable studio acid block tests that are failing

### DIFF
--- a/common/test/acceptance/tests/test_studio.py
+++ b/common/test/acceptance/tests/test_studio.py
@@ -189,6 +189,7 @@ class XBlockAcidBase(WebAppTest):
         self.assertTrue(acid_block.scope_passed('settings'))
 
 
+@skip('Temporarily diabling because it is failing in Jenkins. TE-369')
 class XBlockAcidNoChildTest(XBlockAcidBase):
     """
     Tests of an AcidBlock with no children


### PR DESCRIPTION
@andy-armstrong @cpennington 

I'll merge this now and will work on it with @andy-armstrong this afternoon.
