### PR TITLE
Fixes potential 'too many open files error' when running all servers.

### DIFF
--- a/pavelib/servers.py
+++ b/pavelib/servers.py
@@ -119,9 +119,9 @@ def run_all_servers(options):
 
     if not fast:
         for system in ['lms', 'studio']:
-            args = [system, '--settings={}'.format(settings), '--skip-collect', '--watch']
+            args = [system, '--settings={}'.format(settings), '--skip-collect']
             call_task('pavelib.assets.update_assets', args=args)
-
+        call_task('pavelib.assets.watch_assets', options={'background': True})
     run_multi_processes([
         django_cmd('lms', settings, 'runserver', '--traceback', '--pythonpath=.', "0.0.0.0:{}".format(DEFAULT_PORT['lms'])),
         django_cmd('studio', settings, 'runserver', '--traceback', '--pythonpath=.', "0.0.0.0:{}".format(DEFAULT_PORT['studio'])),


### PR DESCRIPTION
Related to https://groups.google.com/forum/#!topic/edx-code/p8N8WteHRHI

@singingwolfboy I think the problem is that there were two watchdog threads starting if you were to run `paver run_all_servers`. I couldn't reproduce the error, but it seems like that's where the problem lies.
