### PR TITLE
Adam/fix alter xblock student state

### DIFF
--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -1745,9 +1745,26 @@ class TestInstructorAPIHelpers(TestCase):
         self.assertEqual(_split_input_list(scary_unistuff), [scary_unistuff])
 
     def test_msk_from_problem_urlname(self):
-        args = ('MITx/6.002x/2013_Spring', 'L2Node1')
-        output = 'i4x://MITx/6.002x/problem/L2Node1'
-        self.assertEqual(_msk_from_problem_urlname(*args), output)
+        course_id = 'RobotU/Robots101/3001_Spring'
+        capa_urlname = 'capa_urlname'
+        capa_urlname_xml = 'capa_urlname.xml'
+        xblock_urlname = 'notaproblem/someothername'
+        xblock_urlname_xml = 'notaproblem/someothername.xml'
+
+        capa_msk = 'i4x://RobotU/Robots101/problem/capa_urlname'
+        xblock_msk = 'i4x://RobotU/Robots101/notaproblem/someothername'
+
+        for urlname in [capa_urlname, capa_urlname_xml]:
+            self.assertEqual(
+                _msk_from_problem_urlname(course_id, urlname),
+                capa_msk
+            )
+
+        for urlname in [xblock_urlname, xblock_urlname_xml]:
+            self.assertEqual(
+                _msk_from_problem_urlname(course_id, urlname),
+                xblock_msk
+            )
 
     @raises(ValueError)
     def test_msk_from_problem_urlname_error(self):

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -1252,9 +1252,9 @@ def _msk_from_problem_urlname(course_id, urlname):
         urlname = urlname[:-4]
 
     # Combined open ended problems also have state that can be deleted.  However,
-    # appending "problem" will only allow capa problems to be reset.
-    # Get around this for combinedopenended problems.
-    if "combinedopenended" not in urlname:
+    # prepending "problem" will only allow capa problems to be reset.
+    # Get around this for xblock problems.
+    if "/" not in urlname:
         urlname = "problem/" + urlname
 
     parts = Location.parse_course_id(course_id)


### PR DESCRIPTION
@wedaly @symbolist 

Fixes an error where the new instructor dash incorrectly parses module identifiers.

Compare with https://github.com/edx/edx-platform/blob/adam/fix-alter-xblock-student-state/lms/djangoapps/instructor/views/legacy.py#L156-L177
