### PR TITLE
Test that TemplateLookup dirs are not cleared during lms startup

### DIFF
--- a/lms/tests.py
+++ b/lms/tests.py
@@ -1,0 +1,23 @@
+"""Tests for the lms module itself."""
+
+from django.test import TestCase
+
+from edxmako import add_lookup, LOOKUP
+from lms import startup
+
+class TemplateLookupTests(TestCase):
+    """
+    Tests for TemplateLookup.
+    """
+
+    def test_add_lookup_to_main(self):
+        """Test that any template directories added are not cleared when microsites are enabled."""
+
+        add_lookup('main', 'external_module', __name__)
+        directories = LOOKUP['main'].directories
+        self.assertEqual(len([dir for dir in directories if 'external_module' in dir]), 1)
+
+        # This should not clear the directories list
+        startup.enable_microsites()
+        directories = LOOKUP['main'].directories
+        self.assertEqual(len([dir for dir in directories if 'external_module' in dir]), 1)

--- a/rakelib/tests.rake
+++ b/rakelib/tests.rake
@@ -33,6 +33,10 @@ def run_tests(system, report_dir, test_id=nil, stop_on_failure=true)
         default_test_id += " #{system}/lib/*"
     end
 
+    if system == :lms
+        default_test_id += " #{system}/tests.py"
+    end
+
     if test_id.nil?
         test_id = default_test_id
 


### PR DESCRIPTION
LMS-2502

Already reviewed on https://github.com/edx/edx-platform/pull/3185
