### PR TITLE
This should enable logging of codejail on prod

### DIFF
--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -221,6 +221,8 @@ LOGGING = get_logger_config(LOG_DIR,
                             debug=False,
                             service_variant=SERVICE_VARIANT)
 
+LOGGING['loggers'].setdefault('codejail.jail_code', {})['level'] = 'DEBUG'
+
 COURSE_LISTINGS = ENV_TOKENS.get('COURSE_LISTINGS', {})
 SUBDOMAIN_BRANDING = ENV_TOKENS.get('SUBDOMAIN_BRANDING', {})
 VIRTUAL_UNIVERSITIES = ENV_TOKENS.get('VIRTUAL_UNIVERSITIES', [])


### PR DESCRIPTION
I wasn't sure exactly where to put this, but aws.py seems like the most expedient place.

@nedbat @e0d 
