### PR TITLE
Add static fallback method for video transcripts

### DIFF
--- a/lms/djangoapps/courseware/tests/test_video_handlers.py
+++ b/lms/djangoapps/courseware/tests/test_video_handlers.py
@@ -226,7 +226,7 @@ class TestTranscriptDownloadDispatch(TestVideo):
     DATA = """
         <video show_captions="true"
         display_name="A Name"
-        sub='blahblah'
+        sub='OEoXaMPEzfM'
         >
             <source src="example.mp4"/>
             <source src="example.webm"/>
@@ -278,23 +278,6 @@ class TestTranscriptDownloadDispatch(TestVideo):
         self.assertEqual(response.body, 'Subs!')
         self.assertEqual(response.headers['Content-Type'], 'application/x-subrip; charset=utf-8')
         self.assertEqual(response.headers['Content-Disposition'], 'attachment; filename="塞.srt"')
-
-    def test_download_static_transcript(self):
-        """
-        Set course static_asset_path and ensure we get redirected to that path
-        if it isn't found in the contentstore
-        """
-        self.course.static_asset_path = 'dummy/static'
-        self.course.save()
-        store = editable_modulestore()
-        store.update_item(self.course, 'blahblah')
-        request = Request.blank('/download')
-        response = self.item.transcript(request=request, dispatch='download')
-        self.assertEqual(response.status, '307 Temporary Redirect')
-        self.assertIn(
-            ('Location', '/static/dummy/static/subs_blahblah.srt.sjson'),
-            response.headerlist
-        )
 
 
 class TestTranscriptTranslationGetDispatch(TestVideo):
@@ -429,7 +412,7 @@ class TestTranscriptTranslationGetDispatch(TestVideo):
         self.course.static_asset_path = 'dummy/static'
         self.course.save()
         store = editable_modulestore()
-        store.update_item(self.course, 'blahblah')
+        store.update_item(self.course, 'OEoXaMPEzfM')
 
         # Test youtube style en
         request = Request.blank('/translation/en?videoId=12345')
@@ -441,23 +424,20 @@ class TestTranscriptTranslationGetDispatch(TestVideo):
         )
 
         # Test HTML5 video style
-        self.item.sub = 'blahblah'
+        self.item.sub = 'OEoXaMPEzfM'
         request = Request.blank('/translation/en')
         response = self.item.transcript(request=request, dispatch='translation/en')
         self.assertEqual(response.status, '307 Temporary Redirect')
         self.assertIn(
-            ('Location', '/static/dummy/static/subs_blahblah.srt.sjson'),
+            ('Location', '/static/dummy/static/subs_OEoXaMPEzfM.srt.sjson'),
             response.headerlist
         )
 
-        # Test different language
+        # Test different language to ensure we are just ignoring it since we can't
+        # translate with static fallback
         request = Request.blank('/translation/uk')
         response = self.item.transcript(request=request, dispatch='translation/uk')
-        self.assertEqual(response.status, '307 Temporary Redirect')
-        self.assertIn(
-            ('Location', '/static/dummy/static/uk_subs_blahblah.srt.sjson'),
-            response.headerlist
-        )
+        self.assertEqual(response.status, '404 Not Found')
 
 
 class TestStudioTranscriptTranslationGetDispatch(TestVideo):

--- a/lms/djangoapps/courseware/tests/test_video_handlers.py
+++ b/lms/djangoapps/courseware/tests/test_video_handlers.py
@@ -10,8 +10,9 @@ from datetime import timedelta
 from webob import Request
 
 from xmodule.contentstore.content import StaticContent
-from xmodule.modulestore import Location
 from xmodule.contentstore.django import contentstore
+from xmodule.modulestore import Location
+from xmodule.modulestore.django import editable_modulestore
 from . import BaseTestXmodule
 from .test_video_xml import SOURCE_XML
 from cache_toolbox.core import del_cached_content
@@ -225,6 +226,7 @@ class TestTranscriptDownloadDispatch(TestVideo):
     DATA = """
         <video show_captions="true"
         display_name="A Name"
+        sub='blahblah'
         >
             <source src="example.mp4"/>
             <source src="example.webm"/>
@@ -276,6 +278,23 @@ class TestTranscriptDownloadDispatch(TestVideo):
         self.assertEqual(response.body, 'Subs!')
         self.assertEqual(response.headers['Content-Type'], 'application/x-subrip; charset=utf-8')
         self.assertEqual(response.headers['Content-Disposition'], 'attachment; filename="塞.srt"')
+
+    def test_download_static_transcript(self):
+        """
+        Set course static_asset_path and ensure we get redirected to that path
+        if it isn't found in the contentstore
+        """
+        self.course.static_asset_path = 'dummy/static'
+        self.course.save()
+        store = editable_modulestore()
+        store.update_item(self.course, 'blahblah')
+        request = Request.blank('/download')
+        response = self.item.transcript(request=request, dispatch='download')
+        self.assertEqual(response.status, '307 Temporary Redirect')
+        self.assertIn(
+            ('Location', '/static/dummy/static/subs_blahblah.srt.sjson'),
+            response.headerlist
+        )
 
 
 class TestTranscriptTranslationGetDispatch(TestVideo):
@@ -401,6 +420,44 @@ class TestTranscriptTranslationGetDispatch(TestVideo):
         request = Request.blank('/translation/uk')
         response = self.item.transcript(request=request, dispatch='translation/uk')
         self.assertDictEqual(json.loads(response.body), subs)
+
+    def test_translation_static_transcript(self):
+        """
+        Set course static_asset_path and ensure we get redirected to that path
+        if it isn't found in the contentstore
+        """
+        self.course.static_asset_path = 'dummy/static'
+        self.course.save()
+        store = editable_modulestore()
+        store.update_item(self.course, 'blahblah')
+
+        # Test youtube style en
+        request = Request.blank('/translation/en?videoId=12345')
+        response = self.item.transcript(request=request, dispatch='translation/en')
+        self.assertEqual(response.status, '307 Temporary Redirect')
+        self.assertIn(
+            ('Location', '/static/dummy/static/subs_12345.srt.sjson'),
+            response.headerlist
+        )
+
+        # Test HTML5 video style
+        self.item.sub = 'blahblah'
+        request = Request.blank('/translation/en')
+        response = self.item.transcript(request=request, dispatch='translation/en')
+        self.assertEqual(response.status, '307 Temporary Redirect')
+        self.assertIn(
+            ('Location', '/static/dummy/static/subs_blahblah.srt.sjson'),
+            response.headerlist
+        )
+
+        # Test different language
+        request = Request.blank('/translation/uk')
+        response = self.item.transcript(request=request, dispatch='translation/uk')
+        self.assertEqual(response.status, '307 Temporary Redirect')
+        self.assertIn(
+            ('Location', '/static/dummy/static/uk_subs_blahblah.srt.sjson'),
+            response.headerlist
+        )
 
 
 class TestStudioTranscriptTranslationGetDispatch(TestVideo):


### PR DESCRIPTION
Courses that are imported with the --nostatic flag do not show transcripts/captions properly even if those captions are stored inside their static folder.  This adds a last resort method of redirecting to the static asset path of the course if the transcript can't be found inside the contentstore and the course has the static_asset_path field set.

One thing I thought was strange is that value of static_asset_path didn't seem to be inherited down even though it is inheritance.py and is available on the module but set with the default value instead of the value at the course descriptor, so I had to get the course descriptor to retrieve the proper value. If there is a better method, I would be interested in changing to it instead.

This is only my second journey into xmodules/modulestore @sarina so I'm still not sure on reviewers.

Heads up to @pdpinch and @ichuang
