### PR TITLE
Fix source editor for the case of no CodeMirror editor.

### DIFF
--- a/cms/templates/widgets/source-edit.html
+++ b/cms/templates/widgets/source-edit.html
@@ -123,7 +123,16 @@ require(["jquery", "jquery.leanModal", "codemirror/stex"], function($) {
               if (xml.length == 0) {
                   alert('Conversion failed!  error:' + data.message);
               } else {
-                  el.closest('.component').find('.CodeMirror-wrap')[0].CodeMirror.setValue(xml);
+                  // If a parent CodeMirror editor is open (LaTeX problem being edited), set the text
+                  // there. Otherwise, set the text in the active TinyMCE Editor for the case
+                  // of an HTML component being edited.
+                  var parentCodemirrorEditor = el.closest('.component').find('.CodeMirror-wrap');
+                  if (parentCodemirrorEditor.length > 0) {
+                      parentCodemirrorEditor[0].CodeMirror.setValue(xml);
+                  }
+                  else if (window.tinyMCE !== undefined && window.tinyMCE.activeEditor !== undefined) {
+                      window.tinyMCE.activeEditor.setContent(xml);
+                  }
                   save_hls(el);
               }
           },


### PR DESCRIPTION
In the HTML component, there is no longer a tabbed CodeMirror Editor. STUD-1516.

There are no tests for this. I had previously written a smoke test for the high level source editor for LaTeX problems, but it has been disabled because the test did not pass reliably.

In problem-editor.feature:

Disabled 11/13/2013 after failing in master
  # The screenshot showed that the LaTeX editor had the text "hi",
  # but Selenium timed out waiting for the text to appear.
  # It also caused later tests to fail with "UnexpectedAlertPresent"
  #
  # This feature will work in Firefox only when Firefox is the active window
  # IE will not interact with the high level source in sauce labs
  #@skip_internetexplorer
  #Scenario: High Level source is persisted for LaTeX problem (bug STUD-280)
  #  Given I have created a LaTeX Problem
  #  When I edit and compile the High Level Source
  #  Then my change to the High Level Source is persisted
  #  And when I view the High Level Source I see my changes
