### PR TITLE
Fix doublequoting. BLD-812.

### DIFF
--- a/common/lib/xmodule/xmodule/lti_module.py
+++ b/common/lib/xmodule/xmodule/lti_module.py
@@ -341,8 +341,8 @@ class LTIModule(LTIFields, XModule):
         """
         return "{context}:{resource_link}:{user_id}".format(
             context=urllib.quote(self.context_id),
-            resource_link=urllib.quote(self.get_resource_link_id()),
-            user_id=urllib.quote(self.get_user_id())
+            resource_link=self.get_resource_link_id(),
+            user_id=self.get_user_id()
         )
 
     def get_course(self):

--- a/lms/djangoapps/courseware/tests/test_lti_integration.py
+++ b/lms/djangoapps/courseware/tests/test_lti_integration.py
@@ -34,8 +34,8 @@ class TestLTI(BaseTestXmodule):
 
         sourcedId = "{context}:{resource_link}:{user_id}".format(
             context=urllib.quote(context_id),
-            resource_link=urllib.quote(resource_link_id),
-            user_id=urllib.quote(user_id)
+            resource_link=resource_link_id,
+            user_id=user_id
         )
 
         lis_outcome_service_url = 'https://{host}{path}'.format(


### PR DESCRIPTION
Remove double use of `urllib.quote()` in parts of `lis_result_sourcedid` parameter.

Issue: https://edx-wiki.atlassian.net/browse/BLD-812

@auraz  please review.
