### PR TITLE
This fixes a few accessibility problems with drag and drop

### DIFF
--- a/common/lib/capa/capa/templates/drag_and_drop_input.html
+++ b/common/lib/capa/capa/templates/drag_and_drop_input.html
@@ -1,4 +1,4 @@
-<section id="inputtype_${id}" class="capa_inputtype" >
+<div id="inputtype_${id}" class="capa_inputtype" role="application">
     <div class="drag_and_drop_problem_div" id="drag_and_drop_div_${id}"
      data-plain-id="${id}">
     </div>
@@ -29,4 +29,4 @@
     % if status in ['unsubmitted', 'correct', 'incorrect', 'incomplete']:
         </div>
     % endif
-</section>
+</div>

--- a/common/lib/capa/capa/templates/drag_and_drop_input.html
+++ b/common/lib/capa/capa/templates/drag_and_drop_input.html
@@ -1,4 +1,4 @@
-<div id="inputtype_${id}" class="capa_inputtype" role="application">
+<div id="inputtype_${id}" class="capa_inputtype">
     <div class="drag_and_drop_problem_div" id="drag_and_drop_div_${id}"
      data-plain-id="${id}">
     </div>

--- a/common/static/js/capa/drag_and_drop/base_image.js
+++ b/common/static/js/capa/drag_and_drop/base_image.js
@@ -17,7 +17,7 @@ define([], function () {
             '></div>'
         );
 
-        state.baseImageEl = $('<img alt="drop target" />');
+        state.baseImageEl = $('<img alt="drop target image" />');
 
         state.baseImageEl.attr('src', state.config.baseImage);
         state.baseImageEl.load(function () {

--- a/common/static/js/capa/drag_and_drop/base_image.js
+++ b/common/static/js/capa/drag_and_drop/base_image.js
@@ -17,7 +17,7 @@ define([], function () {
             '></div>'
         );
 
-        state.baseImageEl = $('<img />');
+        state.baseImageEl = $('<img alt="drop target" />');
 
         state.baseImageEl.attr('src', state.config.baseImage);
         state.baseImageEl.load(function () {

--- a/common/static/js/capa/drag_and_drop/base_image.js
+++ b/common/static/js/capa/drag_and_drop/base_image.js
@@ -17,7 +17,9 @@ define([], function () {
             '></div>'
         );
 
-        state.baseImageEl = $('<img alt="drop target image" />');
+        state.baseImageEl = $('<img />', {
+                alt: gettext("Drop target image")
+            });
 
         state.baseImageEl.attr('src', state.config.baseImage);
         state.baseImageEl.load(function () {

--- a/common/static/js/capa/drag_and_drop/draggable_events.js
+++ b/common/static/js/capa/drag_and_drop/draggable_events.js
@@ -63,7 +63,6 @@ return {
                 });
                 this.iconEl.appendTo(this.state.baseImageEl.parent());
 
-
                 if (this.labelEl !== null) {
                     if (this.isOriginal === true) {
                         this.labelEl.detach();
@@ -83,9 +82,10 @@ return {
                 if (this.isOriginal === true) {
                     this.state.numDraggablesInSlider -= 1;
                 }
-                SR.readText(gettext('dragging out of slider'));
+                // SR: global "screen reader" object in accessibility_tools.js
+                window.SR.readText(gettext('dragging out of slider'));
             } else {
-                SR.readText(gettext('dragging'));
+                window.SR.readText(gettext('dragging'));
             }
 
             this.zIndex = 1000;
@@ -107,9 +107,9 @@ return {
 
             this.checkLandingElement();
             if (this.inContainer === true) {
-                SR.readText(gettext('dropped in slider'));
+                window.SR.readText(gettext('dropped in slider'));
             } else {
-                SR.readText(gettext('dropped on target'));
+                window.SR.readText(gettext('dropped on target'));
             }
             this.toggleTargets(false);
         }

--- a/common/static/js/capa/drag_and_drop/draggable_events.js
+++ b/common/static/js/capa/drag_and_drop/draggable_events.js
@@ -28,6 +28,7 @@ return {
             if (this.numDraggablesOnMe > 0) {
                 return;
             }
+            this.containerEl.attr('aria-grabbed', 'true');
 
             // If this draggable is just being dragged out of the
             // container, we must perform some additional tasks.
@@ -62,6 +63,7 @@ return {
                     'top': event.pageY - this.state.baseImageEl.offset().top - this.iconHeight * 0.5
                 });
                 this.iconEl.appendTo(this.state.baseImageEl.parent());
+
 
                 if (this.labelEl !== null) {
                     if (this.isOriginal === true) {
@@ -98,6 +100,7 @@ return {
     'mouseUp': function () {
         if (this.mousePressed === true) {
             this.state.currentMovingDraggable = null;
+            this.containerEl.attr('aria-grabbed', 'false');
 
             this.checkLandingElement();
         }

--- a/common/static/js/capa/drag_and_drop/draggable_events.js
+++ b/common/static/js/capa/drag_and_drop/draggable_events.js
@@ -28,7 +28,6 @@ return {
             if (this.numDraggablesOnMe > 0) {
                 return;
             }
-            this.containerEl.attr('aria-grabbed', 'true');
 
             // If this draggable is just being dragged out of the
             // container, we must perform some additional tasks.
@@ -84,6 +83,9 @@ return {
                 if (this.isOriginal === true) {
                     this.state.numDraggablesInSlider -= 1;
                 }
+                SR.readText(gettext('dragging out of slider'));
+            } else {
+                SR.readText(gettext('dragging'));
             }
 
             this.zIndex = 1000;
@@ -91,7 +93,8 @@ return {
             if (this.labelEl !== null) {
                 this.labelEl.css('z-index', '1000');
             }
-
+            this.iconEl.attr('aria-grabbed', 'true').focus();
+            this.toggleTargets(true);
             this.mousePressed = true;
             this.state.currentMovingDraggable = this;
         }
@@ -100,9 +103,15 @@ return {
     'mouseUp': function () {
         if (this.mousePressed === true) {
             this.state.currentMovingDraggable = null;
-            this.containerEl.attr('aria-grabbed', 'false');
+            this.iconEl.attr('aria-grabbed', 'false');
 
             this.checkLandingElement();
+            if (this.inContainer === true) {
+                SR.readText(gettext('dropped in slider'));
+            } else {
+                SR.readText(gettext('dropped on target'));
+            }
+            this.toggleTargets(false);
         }
     },
 

--- a/common/static/js/capa/drag_and_drop/draggable_logic.js
+++ b/common/static/js/capa/drag_and_drop/draggable_logic.js
@@ -236,6 +236,17 @@ return {
         return false;
     },
 
+    'toggleTargets': function (onoff) {
+        var c1, target, effect;
+        effect = (onoff ? 'move' : undefined);
+        this.state.baseImageEl.attr('aria-dropeffect', effect);
+
+        for (c1 = 0; c1 < this.state.targets.length; c1 += 1) {
+            target = this.state.targets[c1];
+            target.targetEl.attr('aria-dropeffect', effect);
+        }
+    },
+
     'snapToTarget': function (target) {
         var offset;
 

--- a/common/static/js/capa/drag_and_drop/draggable_logic.js
+++ b/common/static/js/capa/drag_and_drop/draggable_logic.js
@@ -236,15 +236,13 @@ return {
         return false;
     },
 
-    'toggleTargets': function (onoff) {
-        var c1, target, effect;
-        effect = (onoff ? 'move' : undefined);
+    'toggleTargets': function (isEnabled) {
+        var effect = (isEnabled ? 'move' : undefined);
         this.state.baseImageEl.attr('aria-dropeffect', effect);
 
-        for (c1 = 0; c1 < this.state.targets.length; c1 += 1) {
-            target = this.state.targets[c1];
+        $.each(this.state.targets, function (target) {
             target.targetEl.attr('aria-dropeffect', effect);
-        }
+        });
     },
 
     'snapToTarget': function (target) {

--- a/common/static/js/capa/drag_and_drop/draggables.js
+++ b/common/static/js/capa/drag_and_drop/draggables.js
@@ -153,8 +153,6 @@ define(['js/capa/drag_and_drop/draggable_events', 'js/capa/drag_and_drop/draggab
             'mouseDown': draggableEvents.mouseDown,
             'mouseUp': draggableEvents.mouseUp,
             'mouseMove': draggableEvents.mouseMove,
-            'keydown': draggableEvents.keyDown,
-            'keyup': draggableEvents.keyDown,
 
             'checkLandingElement': draggableLogic.checkLandingElement,
             'checkIfOnTarget': draggableLogic.checkIfOnTarget,
@@ -162,6 +160,7 @@ define(['js/capa/drag_and_drop/draggable_events', 'js/capa/drag_and_drop/draggab
             'correctZIndexes': draggableLogic.correctZIndexes,
             'moveBackToSlider': draggableLogic.moveBackToSlider,
             'moveDraggableTo': draggableLogic.moveDraggableTo,
+            'toggleTargets': draggableLogic.toggleTargets,
 
             'makeDraggableCopy': makeDraggableCopy,
 
@@ -183,9 +182,9 @@ define(['js/capa/drag_and_drop/draggable_events', 'js/capa/drag_and_drop/draggab
                     'border-right: 1px solid #CCC; ' +
                     'text-align: center; ' +
                     'position: relative; ' +
-                    'cursor: pointer; ' +
+                    'cursor: move; ' +
                 '" ' +
-                'tabindex="0" aria-grabbed="false" role="listitem"></div>'
+                'role="listitem"></div>'
         );
 
         draggableObj.containerEl.appendTo(state.sliderEl);
@@ -240,6 +239,7 @@ define(['js/capa/drag_and_drop/draggable_events', 'js/capa/drag_and_drop/draggab
                                 'position: absolute; ' +
                                 'color: black; ' +
                                 'font-size: 0.95em; ' +
+                                'cursor: move; ' +
                             '" ' +
                         '>' +
                             obj.label +
@@ -279,7 +279,9 @@ define(['js/capa/drag_and_drop/draggable_events', 'js/capa/drag_and_drop/draggab
                             'position: absolute; ' +
                             'color: black; ' +
                             'font-size: 0.95em; ' +
+                            'cursor: move; ' +
                         '" ' +
+                        'tabindex="0" aria-grabbed="false" role="listitem"' +
                     '>' +
                         obj.label +
                     '</div>'

--- a/common/static/js/capa/drag_and_drop/draggables.js
+++ b/common/static/js/capa/drag_and_drop/draggables.js
@@ -64,7 +64,7 @@ define(['js/capa/drag_and_drop/draggable_events', 'js/capa/drag_and_drop/draggab
                                 'color: black; ' +
                                 'font-size: 0.95em; ' +
                             '" ' +
-                        '>' +
+                        'role="label">' +
                             draggableObj.originalConfigObj.label +
                         '</div>'
                     );
@@ -153,6 +153,8 @@ define(['js/capa/drag_and_drop/draggable_events', 'js/capa/drag_and_drop/draggab
             'mouseDown': draggableEvents.mouseDown,
             'mouseUp': draggableEvents.mouseUp,
             'mouseMove': draggableEvents.mouseMove,
+            'keydown': draggableEvents.keyDown,
+            'keyup': draggableEvents.keyDown,
 
             'checkLandingElement': draggableLogic.checkLandingElement,
             'checkIfOnTarget': draggableLogic.checkIfOnTarget,
@@ -181,8 +183,9 @@ define(['js/capa/drag_and_drop/draggable_events', 'js/capa/drag_and_drop/draggab
                     'border-right: 1px solid #CCC; ' +
                     'text-align: center; ' +
                     'position: relative; ' +
+                    'cursor: pointer; ' +
                 '" ' +
-                '></div>'
+                'tabindex="0" aria-grabbed="false" role="listitem"></div>'
         );
 
         draggableObj.containerEl.appendTo(state.sliderEl);

--- a/common/static/js/capa/drag_and_drop/targets.js
+++ b/common/static/js/capa/drag_and_drop/targets.js
@@ -86,9 +86,8 @@ define([], function () {
                     'left: ' + obj.x + 'px; ' +
                     borderCss +
                 '" ' +
-            '></div>'
+            'aria-dropeffect=""></div>'
         );
-
         if (fromTargetField === true) {
             targetEl.appendTo(draggableObj.iconEl);
         } else {
@@ -115,9 +114,8 @@ define([], function () {
                         'background-color: white; ' +
                         'font-size: 0.95em; ' +
                         'color: #009fe2; ' +
-                        'cursor: pointer; ' +
                     '" ' +
-                'aria-dropeffect="move">0</div>'
+                '>0</div>'
             );
         } else {
             numTextEl = null;

--- a/common/static/js/capa/drag_and_drop/targets.js
+++ b/common/static/js/capa/drag_and_drop/targets.js
@@ -117,7 +117,7 @@ define([], function () {
                         'color: #009fe2; ' +
                         'cursor: pointer; ' +
                     '" ' +
-                '>0</div>'
+                'aria-dropeffect="move">0</div>'
             );
         } else {
             numTextEl = null;


### PR DESCRIPTION
LMS-1940
LMS-1904
LMS-1699

There's not a lot we can do to make a drag and drop interface accessible, if it relies on the user's ability to see something particular about the drop target. I've added the appropriate ARIA properties to the draggables and drop target and enabled some keyboard navigation, but it isn't enough. You're supposed to allow the user to move draggables around the screen with the keyboard; I'm not sure if it's worth putting in that effort if the user still needs to be able to see where to drag the element.

@talbs what do you think?
