### PR TITLE
Only display active users for the certificate report

### DIFF
--- a/lms/djangoapps/certificates/management/commands/gen_cert_report.py
+++ b/lms/djangoapps/certificates/management/commands/gen_cert_report.py
@@ -61,8 +61,8 @@ class Command(BaseCommand):
             # find students who are enrolled
             print "Looking up certificate states for {0}".format(course_id)
             enrolled_students = User.objects.filter(
-                    courseenrollment__course_id=course_id).prefetch_related(
-                            "groups").order_by('username')
+                    courseenrollment__course_id=course_id,
+                    courseenrollment__is_active=True)
             cert_data[course_id] = {'enrolled': enrolled_students.count()}
 
             tallies = GeneratedCertificate.objects.filter(

--- a/lms/djangoapps/certificates/management/commands/ungenerated_certs.py
+++ b/lms/djangoapps/certificates/management/commands/ungenerated_certs.py
@@ -84,8 +84,7 @@ class Command(BaseCommand):
 
             print "Fetching enrolled students for {0}".format(course_id)
             enrolled_students = User.objects.filter(
-                courseenrollment__course_id=course_id).prefetch_related(
-                    "groups").order_by('username')
+                courseenrollment__course_id=course_id)
 
             xq = XQueueCertInterface()
             if options['insecure']:


### PR DESCRIPTION
Also removes the unnecessary pre-fetch.
For certificate generations we will continue to generate certs for
both active and inactive users.

For the report we only display active users since it was confusing
due to the instructor dashboard only displaying active users.

@dianakhuang 
@hkim823 
