### PR TITLE
Fix test_combined_open_ended.py - test_iframe

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -139,3 +139,4 @@ Raees Chachar <raees.chachar@arbisoft.com>
 Muhammad Ammar <muhammad.ammar@arbisoft.com>
 William Desloge <william.desloge@ionis-group.com>
 Marco Re <mrc.re@tiscali.it>
+Ray Hooker <ray.hooker@gmail.com>

--- a/common/lib/xmodule/xmodule/tests/test_combined_open_ended.py
+++ b/common/lib/xmodule/xmodule/tests/test_combined_open_ended.py
@@ -1369,7 +1369,7 @@ class OpenEndedModuleUtilTest(unittest.TestCase):
     embed_dirty = u'<embed height="200" id="cats" onhover="eval()" src="http://example.com/lolcats.swf" width="200"/>'
     embed_clean = u'<embed width="200" height="200" id="cats" src="http://example.com/lolcats.swf">'
     iframe_dirty = u'<iframe class="cats" height="200" onerror="eval()" src="http://example.com/lolcats" width="200"/>'
-    iframe_clean = u'<iframe height="200" class="cats" width="200" src="http://example.com/lolcats"></iframe>'
+    iframe_clean = u'<iframe class="cats" width="200" height="200" src="http://example.com/lolcats"></iframe>'
 
     text = u'I am a \u201c\xfcber student\u201d'
     text_lessthan_noencd = u'This used to be broken < by the other parser. 3>5'


### PR DESCRIPTION
The test was designed to verify that the sanitize_html method would properly remove "evil tags" from html. The test compares an iframe snippet before and after.  The sanitize actually but the test was failing due to an incorrect test string.  The string were functionally equivalent but the fields were reordered.  The test was fixed by setting the iframe_clean string to the iframe_dirty string minus the offending - onerror="eval()" - tag.  Once the fields were in the same order the strings matched and the test passes.
