### PR TITLE
Update OpenID dialog text

### DIFF
--- a/lms/templates/provider_login.html
+++ b/lms/templates/provider_login.html
@@ -41,7 +41,7 @@
 %if error:
       <div id="login_error" class="modal-form-error" style="display: block;">${_("Email or password is incorrect.")}</div>
 %endif
-      <p>${_("Please note that we will be sending your user name, email, and full name to this third party site.")}</p>
+      <p>${_("Your username, email, and full name will be sent to {destination}, where the collection and use of this information will be governed by their terms of service and privacy policy.").format(destination=return_to)}</p>
       <label>${_("E-mail")}</label>
       <input type="text" name="email" placeholder="${_('E-mail')}" tabindex="1" autofocus="autofocus" />
       <label>${_("Password")}</label>


### PR DESCRIPTION
We want to indicate more clearly that the information that we transmit
to the third party is governed by their terms of service and privacy
policy.

@jimabramson 
