### PR TITLE
Introducing JSHint.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,112 @@
+// --------------------------------------------------------------------
+// JSHint Configuration
+// --------------------------------------------------------------------
+//
+// http://www.jshint.com/
+// http://jshint.com/docs/options/
+{
+    // == Enforcing Options ===============================================
+    "bitwise"         : false,     // Prohibits the use of bitwise operators such as ^ (XOR), | (OR) and others. Bitwise operators are very rare in JavaScript programs and quite often & is simply a mistyped &&.
+    "camelcase"       : false,     // Allows you to force all variable names to use either camelCase style or UPPER_CASE with underscores.
+    "curly"           : true,      // Requires you to always put curly braces around blocks in loops and conditionals. JavaScript allows you to omit curly braces when the block consists of only one statement
+    "eqeqeq"          : true,      // Prohibits the use of == and != in favor of === and !==.
+    "es3"             : false,     // Tells JSHint that your code needs to adhere to ECMAScript 3 specification. Use this option if you need your program to be executable in older browsers—such as Internet Explorer 6/7/8/9.
+    "forin"           : true,      // Requires all for in loops to filter object's items.
+    "freeze"          : true,      // Prohibits overwriting prototypes of native objects such as Array, Date and so on.
+    "immed"           : true,      // Prohibits the use of immediate function invocations without wrapping them in parentheses.
+    // "indent"       : 4,         // Enforces specific tab width for your code. Has no effect when "white" option is not used.
+    "latedef"         : "nofunc",  // Prohibits the use of a variable before it was defined. Setting this option to "nofunc" will allow function declarations to be ignored.
+    "newcap"          : true,      // Requires you to capitalize names of constructor functions.
+    "noarg"           : true,      // Prohibits the use of arguments.caller and arguments.callee.
+    "noempty"         : true,      // Warns when you have an empty block in your code.
+    "nonbsp"          : true,      // Warns about "non-breaking whitespace" characters.
+    "nonew"           : true,      // Prohibits the use of constructor functions for side-effects.
+    "plusplus"        : false,     // Prohibits the use of unary increment and decrement operators.
+    "quotmark"        : "single",  // Enforces the consistency of quotation marks used throughout your code. It accepts three values: true, "single", and "double".
+    "undef"           : true,      // Prohibits the use of explicitly undeclared variables.
+    "unused"          : true,      // Warns when you define and never use your variables.
+    "strict"          : true,      // Requires all functions to run in ECMAScript 5's strict mode.
+    "trailing"        : true,      // Makes it an error to leave a trailing whitespace in your code.
+    "maxlen"          : 80,        // Lets you set the maximum length of a line.
+    //"maxparams"     : 4,         // Lets you set the max number of formal parameters allowed per function.
+    //"maxdepth"      : 4,         // Lets you control how nested do you want your blocks to be.
+    //"maxstatements" : 4,         // Lets you set the max number of statements allowed per function.
+    //"maxcomplexity" : 4,         // Lets you control cyclomatic complexity throughout your code.
+
+
+    // == Relaxing Options ================================================
+    "asi"           : false,       // Suppresses warnings about missing semicolons.
+    "boss"          : false,       // Suppresses warnings about the use of assignments in cases where comparisons are expected.
+    "debug"         : false,       // Suppresses warnings about the debugger statements in your code.
+    "eqnull"        : false,       // Suppresses warnings about == null comparisons.
+    "esnext"        : false,       // Tells JSHint that your code uses ECMAScript 6 specific syntax.
+    "evil"          : false,       // Suppresses warnings about the use of eval.
+    "expr"          : false,       // Suppresses warnings about the use of expressions where normally you would expect to see assignments or function calls.
+    "funcscope"     : false,       // Suppresses warnings about declaring variables inside of control structures while accessing them later from the outside.
+    "gcl"           : false,       // Makes JSHint compatible with Google Closure Compiler.
+    "globalstrict"  : false,       // Suppresses warnings about the use of global strict mode.
+    "iterator"      : false,       // Suppresses warnings about the __iterator__ property.
+    "lastsemic"     : false,       // Suppresses warnings about missing semicolons, but only when the semicolon is omitted for the last statement in a one-line block.
+    "laxbreak"      : false,       // Suppresses most of the warnings about possibly unsafe line breaks in your code.
+    "laxcomma"      : false,       // Suppresses warnings about comma-first coding style.
+    "loopfunc"      : false,       // Suppresses warnings about functions inside of loops.
+    "maxerr"        : 100,         // Set the maximum amount of warnings JSHint will produce before giving up.
+    "moz"           : false,       // Tells JSHint that your code uses Mozilla JavaScript extensions.
+    "notypeof"      : false,       // Suppresses warnings about invalid typeof operator values.
+    "proto"         : false,       // Suppresses warnings about the __proto__ property.
+    "scripturl"     : false,       // Suppresses warnings about the use of script-targeted URLs—such as javascript:...
+    "smarttabs"     : false,       // Suppresses warnings about mixed tabs and spaces when the latter are used for alignment only.
+    "shadow"        : false,       // Suppresses warnings about variable shadowing i.e. declaring a variable that had been already declared somewhere in the outer scope.
+    "sub"           : false,       // Suppresses warnings about using [] notation when it can be expressed in dot notation.
+    "supernew"      : false,       // Suppresses warnings about "weird" constructions like new function () { ... } and new Object;.
+    "validthis"     : true,       // Suppresses warnings about possible strict violations when the code is running in strict mode and you use this in a non-constructor function.
+    "noyield"       : false,       // Suppresses warnings about generator functions with no yield statement in them.
+
+
+    // == Environments ====================================================
+    //
+    // These options pre-define global variables that are exposed by
+    // popular JavaScript libraries and runtime environments—such as
+    // browser or node.js.
+    "browser"       : true,        // Defines globals exposed by modern browsers: all the way from good old document and navigator to the HTML5 FileReader and other new developments in the browser world.
+    "devel"         : true,        // Defines globals that are usually used for logging poor-man's debugging: console, alert, etc.
+    // The rest should remain `false`. Please see explanation for the "predef" parameter below.
+    "couch"         : false,       // Defines globals exposed by CouchDB.
+    "dojo"          : false,       // Defines globals exposed by the Dojo Toolkit
+    "jquery"        : false,        // Defines globals exposed by the jQuery JavaScript library.
+    "mootools"      : false,       // Defines globals exposed by the MooTools JavaScript framework.
+    "node"          : false,       // Defines globals available when your code is running inside of the Node runtime environment.
+    "nonstandard"   : false,       // Defines non-standard but widely adopted globals such as escape and unescape.
+    "phantom"       : false,        // Defines globals available when your core is running inside of the PhantomJS runtime environment.
+    "prototypejs"   : false,       // Defines globals exposed by the Prototype JavaScript framework.
+    "rhino"         : false,       // Defines globals available when your code is running inside of the Rhino runtime environment.
+    "worker"        : false,       // Defines globals available when your code is running inside of a Web Worker.
+    "wsh"           : false,       // Defines globals available when your code is running as a script for the Windows Script Host.
+    "yui"           : false,       // Defines globals exposed by the YUI JavaScript framework.
+
+
+    // == JSLint Legacy ===================================================
+    //
+    // These options are legacy from JSLint. Aside from bug fixes they will
+    // not be improved in any way and might be removed at any point.
+    // "nomen"         : false,    // Disallows the use of dangling _ in variables.
+    // "onevar"        : false,    // Allows only one var statement per function.
+    // "passfail"      : false,    // Makes JSHint stop on the first error or warning.
+    // "white"         : false,    // make JSHint check your source code against Douglas Crockford's JavaScript coding style.
+
+
+    // == Undocumented Options ============================================
+    //
+    // If you are using some global variable, for example `define`, or `$`, please
+    // make it available within your JS file by passing it to the wrapper anonymous
+    // function like so:
+    //
+    // (function (define, $) {
+    //     'use strict';
+    //     // Your content goes here which uses `define`, and `$`.
+    // }).call(this, window.define, window.jQuery);
+    //
+    // The parameter "predef" should remain empty for this configuration file
+    // to remain as general as possible.
+    "predef": []
+}


### PR DESCRIPTION
**Description**

I want to propose the following guidelines to all future JavaScript code changes.

1.) All authors that write and submit JavaScript code (as a pull request, or a separate commit) should run JSHint against the code. The configuration file `.jshintrc` (to be used by all developers) will be placed in the `edx-platfoirm` root. When `jshint` runs, it first checks for `.jshintrc` file in the same directory as the source file, and then travels up the source tree, until it either finds a `.jshintrc` file or (if no `.jshintrc` file is found) uses built-in defaults. Our aim that all developers run JSHint with a standard configuration file, and that there are no hard-errors (see NOTE at the end) reported by JSHint.

2.) When in doubt about JSHint errors/warnings - use the latest JSHint from [http://www.jshint.com/install/](http://www.jshint.com/install/).

3.) All new JavaScript files should use the following template:

```
(function (globalVar1, globalVar2, ...) {
    'use strict';
    // Your code goes here. In this code you can use globalVar1 etc.
    // and not get an "used before defined" JSHint error. Also, being
    // explicit about what is global is a good way to go!
}).call(this, window.fullNameGlobalVar1, window.fullNameGlobalVar2, ...);
```

4.) All existing JavaScript files that are modified should be updated so that they pass against JSHint using the edx-platform `.jshintrc` file, and rewritten to use the wrapper anonymous function template from above.

**NOTE**: I believe that only JSHint warnings should be disregarded of the type "unused variable", when that unused variable is a function parameter that can't be removed. For example:

```
(function ($) {
    'use strict';

    var test = ['a', 'b', 'c'];

    $.each(test, function (index, value) {
        console.log(value);
    });
}).call(this, window.jQuery);
```

In this case JSHint will give a warning about `index` not being used. It is safe to disregard these kind of warning.

**Special thanks** to @jmclaus for providing his original `.jshintrc` file! It was modified a bit.

**Motivation**

Often, JSHint will catch silly errors right in the editor. You will see that you have coded something wrong without having to start up Studio or LMS and checking your changes in the browser. We all know the pain of waiting for the system to start up only to find that you have let a little JavaScript syntax error slip by.

Also, for a long time we are without a JavaScript standard and guidelines. I think with the introduction of JSHint, JavaScript code in edX will start to be formalized and standardized.

**Reviewers**

I want to hear the thoughts about this PR from all JavaScript developers at edX who are interested in improving the quality of JavaScript code at edX. Especially from:
- @singingwolfboy 
- @cahrens 
- @polesye 
- @jmclaus 
