### PR TITLE
Allow attaching arbitrary JavaScript functions to methods in Video player.

### DIFF
--- a/common/lib/xmodule/xmodule/js/spec/video/initialize_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/initialize_spec.js
@@ -466,7 +466,9 @@ function (Initialize) {
             it('regiter callback for videoPlayer.update method - direct function call', function () {
                 var state = {
                         methodCallbacks: {
-                            update: []
+                            videoPlayer: {
+                                update: []
+                            }
                         }
                     },
                     registerCallback = Initialize.prototype.registerCallback;

--- a/common/lib/xmodule/xmodule/js/spec/video/initialize_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/initialize_spec.js
@@ -459,18 +459,29 @@ function (Initialize) {
         });
 
         describe('Registering callbacks', function () {
-            it('regiter callback for videoPlayer.update method direct function call', function () {
+            var callback = function (t) {
+                var x = 1; return x + t;
+            };
+
+            it('regiter callback for videoPlayer.update method - direct function call', function () {
                 var state = {
                         methodCallbacks: {
                             update: []
                         }
                     },
-                    callback = function (t) {
-                        var x = 1; return x + t;
-                    },
                     registerCallback = Initialize.prototype.registerCallback;
 
-                registerCallback('videoPlayer', 'update', callback);
+                registerCallback.call(state, 'videoPlayer', 'update', callback);
+                expect(state.methodCallbacks.videoPlayer.update[0]).toBe(callback);
+            });
+
+            it('regiter callback for videoPlayer.update method - call through DOM element', function () {
+                var state;
+
+                jasmine.initializePlayer();
+                state = $('.video').data('video-player-state');
+
+                state.registerCallback('videoPlayer', 'update', callback);
                 expect(state.methodCallbacks.videoPlayer.update[0]).toBe(callback);
             });
         });

--- a/common/lib/xmodule/xmodule/js/spec/video/initialize_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/initialize_spec.js
@@ -458,6 +458,23 @@ function (Initialize) {
             });
         });
 
+        describe('Registering callbacks', function () {
+            it('regiter callback for videoPlayer.update method direct function call', function () {
+                var state = {
+                        methodCallbacks: {
+                            update: []
+                        }
+                    },
+                    callback = function (t) {
+                        var x = 1; return x + t;
+                    },
+                    registerCallback = Initialize.prototype.registerCallback;
+
+                registerCallback('videoPlayer', 'update', callback);
+                expect(state.methodCallbacks.videoPlayer.update[0]).toBe(callback);
+            });
+        });
+
         describe('isHtml5Mode', function () {
             it('returns `true` if player in `html5` mode', function () {
                 var state = {

--- a/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
+++ b/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
@@ -938,8 +938,8 @@ function (VideoPlayer, VideoStorage) {
      *     `state` object. Since the `state` object is accessible via the
      *     video DOM element data attribute "video-player-state", this function
      *     can be used by external JavaScript code on the page to synchronize
-     *     with the video player by attaching callbacks to methods which are configured
-     *     to have attached callbacks. For a list of available methods see the
+     *     with the video player by attaching callbacks to methods (which are configured
+     *     to have attached callbacks). For a list of available methods see the
      *     definition of `methodCallbacks` in `initialize()` function in this file.
      *
      * Parameters:
@@ -953,9 +953,9 @@ function (VideoPlayer, VideoStorage) {
      *
      * Returns:
      *     -1, -2, -3, -4, -5 [number]:
-     *         In case of error. For example if objName refers to a not defined object, or
-     *         if method named methodName does not support attaching of callbacks. See
-     *         function implementation for exact details.
+     *         In case of error. For example if `objName` refers to an undefined object, or
+     *         if method named `methodName` does not support attaching of callbacks. See
+     *         function implementation for case-by-case return error values.
      *     0 [number]:
      *         In case the function is successful.
      */

--- a/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
+++ b/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
@@ -77,6 +77,7 @@ function (VideoPlayer, VideoStorage) {
         setSpeed: setSpeed,
         speedToString: speedToString,
         trigger: trigger,
+        registerCallback: registerCallback,
         youtubeId: youtubeId
     },
 
@@ -497,7 +498,21 @@ function (VideoPlayer, VideoStorage) {
             id: id,
             isFullScreen: false,
             isTouch: isTouch,
-            storage: storage
+            storage: storage,
+
+            // Some methods of some objects support attaching callbacks to them.
+            // These callbacks will be executed after the method finishes running.
+            // Callbacks will be executed if the method is successful.
+            // Callbacks will be executed with parameters appropriate to each method.
+            // Not all methods will support callbacks. The following is a hierarchy
+            // of objects/methods that support attaching callbacks to them.
+            // This list can be extended by modifying objects/methods to allow for
+            // attaching of callbacks.
+            methodCallbacks: {
+                videoPlayer: {
+                    update: []
+                }
+            }
         });
 
         console.log(
@@ -912,6 +927,68 @@ function (VideoPlayer, VideoStorage) {
         tmpObj.apply(this, extraParameters);
 
         return true;
+    }
+
+    /*
+     * Function:
+     *     registerCallback
+     *
+     * Description:
+     *     Allow arbitrary JavaScript callback function be attached to methods of
+     *     `state` object. Since the `state` object is accessible via the
+     *     video DOM element data attribute "video-player-state", this function
+     *     can be used by external JavaScript code on the page to synchronize
+     *     with the video player by attaching callbacks to methods which are configured
+     *     to have attached callbacks. For a list of available methods see the
+     *     definition of `methodCallbacks` in `initialize()` function in this file.
+     *
+     * Parameters:
+     *     objName [string]:
+     *         The name of the object in the `state` object.
+     *     methodName [string]:
+     *         The name of the method in the object `state[objName]` for which the
+     *         callback should be registered.
+     *     callback [function]:
+     *         The callback function.
+     *
+     * Returns:
+     *     -1, -2, -3, -4, -5 [number]:
+     *         In case of error. For example if objName refers to a not defined object, or
+     *         if method named methodName does not support attaching of callbacks. See
+     *         function implementation for exact details.
+     *     0 [number]:
+     *         In case the function is successful.
+     */
+    function registerCallback(objName, methodName, callback) {
+        if (typeof objName !== 'string' ) {
+            console.log('[Video info]: registerCallback: parameter "objName" is not a string!');
+
+            return -1;
+        }
+        if (typeof methodName !== 'string') {
+            console.log('[Video info]: registerCallback: parameter "methodName" is not a string!');
+
+            return -2;
+        }
+        if (!$.isFunction(callback)) {
+            console.log('[Video info]: registerCallback: parameter "callback" is not a function!');
+
+            return -3;
+        }
+        if (!this.methodCallbacks[objName]) {
+            console.log('[Video info]: registerCallback: the object "' + objName + '" does not have methods which you can attach callback to!');
+
+            return -4;
+        }
+        if (!this.methodCallbacks[objName][methodName]) {
+            console.log('[Video info]: registerCallback: the method "' + methodName + '" does not support attaching callbacks to it!');
+
+            return -5;
+        }
+
+        this.methodCallbacks[objName][methodName].push(callback);
+
+        return 0;
     }
 });
 

--- a/common/lib/xmodule/xmodule/js/src/video/03_video_player.js
+++ b/common/lib/xmodule/xmodule/js/src/video/03_video_player.js
@@ -340,6 +340,13 @@ function (HTML5Video, Resizer) {
             $.each(
                 this.methodCallbacks.videoPlayer.update,
                 function (index, callback) {
+                    // We execute callbacks using `window.setTimeout` to make
+                    // sure that the `update()` function does not get
+                    // interrupted in case if `callback` function contains an
+                    // error, or if it contain blocking code. By setting the
+                    // timeout value to 0, we make sure that the `callback`
+                    // functions execute straight after `update()` finishes,
+                    // and the JS runtime is able to execute other queued code.
                     window.setTimeout(function () {
                         callback(_this.videoPlayer.currentTime);
                     }, 0);

--- a/common/lib/xmodule/xmodule/js/src/video/03_video_player.js
+++ b/common/lib/xmodule/xmodule/js/src/video/03_video_player.js
@@ -327,9 +327,25 @@ function (HTML5Video, Resizer) {
     // (currentTime) and its duration.
     // It is called at a regular interval when the video is playing.
     function update(time) {
-        this.videoPlayer.currentTime = time || this.videoPlayer.player.getCurrentTime();
+        var _this;
+
+        this.videoPlayer.currentTime = time || this.videoPlayer.player
+            .getCurrentTime();
 
         if (isFinite(this.videoPlayer.currentTime)) {
+            _this = this;
+
+            // Executed all attached callbacks to this method, passing the
+            // video's current playing time as a parameter.
+            $.each(
+                this.methodCallbacks.videoPlayer.update,
+                function (index, callback) {
+                    window.setTimeout(function () {
+                        callback(_this.videoPlayer.currentTime);
+                    }, 0);
+                }
+            );
+
             this.videoPlayer.updatePlayTime(this.videoPlayer.currentTime);
 
             // We need to pause the video if current time is smaller (or equal)


### PR DESCRIPTION
**Description**

As a result of a discussion in edx-platform dev IRC chat with [robertlight](https://github.com/robertlight), this PR was formed. The idea is that there should be an ability to synchronize page content with a video. For this it is ideal that the edX Video player exposes an API to attach function callbacks to a method in a Video instance. The Video instance is available via the video DOM element data attribute `video-player-state`.

So, to achieve synchronization, one would do something along the lines of:

```
var state = $('.video').data('video-player-state');
state.registerCallback('videoPlayer', 'update', function (currentTime) {
    // Callback function implementation details
});
```

**Reviewers**
- @nedbat 
