### PR TITLE
Quiet some noisy loggers for lettuce acceptance tests

### DIFF
--- a/cms/envs/acceptance.py
+++ b/cms/envs/acceptance.py
@@ -19,11 +19,20 @@ import logging
 logging.basicConfig(filename=TEST_ROOT / "log" / "cms_acceptance.log", level=logging.ERROR)
 
 import os
-from random import choice, randint
 
 
 def seed():
     return os.getppid()
+
+# Suppress error message "Cannot determine primary key of logged in user"
+# from track.middleware that gets triggered when using an auto_auth workflow
+# This is an ERROR level warning so we need to set the threshold at CRITICAL
+logging.getLogger('track.middleware').setLevel(logging.CRITICAL)
+
+# Suppress warning message "Cannot find corresponding link for name: <foo>"
+# from edxmako.shortcuts. We have no appropriate pages in the platform to
+# use, so these are not set up for TOS and PRIVACY
+logging.getLogger('edxmako.shortcuts').setLevel(logging.ERROR)
 
 DOC_STORE_CONFIG = {
     'host': 'localhost',

--- a/lms/envs/acceptance.py
+++ b/lms/envs/acceptance.py
@@ -27,6 +27,11 @@ import string
 def seed():
     return os.getppid()
 
+# Suppress error message "Cannot determine primary key of logged in user"
+# from track.middleware that gets triggered when using an auto_auth workflow
+# This is an ERROR level warning so we need to set the threshold at CRITICAL
+logging.getLogger('track.middleware').setLevel(logging.CRITICAL)
+
 # Use the mongo store for acceptance tests
 DOC_STORE_CONFIG = {
     'host': 'localhost',


### PR DESCRIPTION
This will suppress some of the log messages that are clogging up the logs and confusing people who are troubleshooting actual errors:
- Cannot determine primary key of logged in user
- Cannot find corresponding link for name: TOS
- Cannot find corresponding link for name: PRIVACY
