### PR TITLE
Allow extra fields returned from comments service

### DIFF
--- a/lms/lib/comment_client/comment.py
+++ b/lms/lib/comment_client/comment.py
@@ -59,7 +59,7 @@ class Comment(models.Model):
             metric_tags=self._metric_tags,
             metric_action='comment.abuse.flagged'
         )
-        voteable.update_attributes(request)
+        voteable._update_attributes(request)
 
     def unFlagAbuse(self, user, voteable, removeAll):
         if voteable.type == 'thread':
@@ -80,7 +80,7 @@ class Comment(models.Model):
             metric_tags=self._metric_tags,
             metric_action='comment.abuse.unflagged'
         )
-        voteable.update_attributes(request)
+        voteable._update_attributes(request)
 
 
 def _url_for_thread_comments(thread_id):

--- a/lms/lib/comment_client/models.py
+++ b/lms/lib/comment_client/models.py
@@ -1,4 +1,9 @@
+import logging
+
 from .utils import extract, perform_request, CommentClientRequestError
+
+
+log = logging.getLogger(__name__)
 
 
 class Model(object):
@@ -70,7 +75,7 @@ class Model(object):
             metric_tags=self._metric_tags,
             metric_action='model.retrieve'
         )
-        self.update_attributes(**response)
+        self._update_attributes(**response)
 
     @property
     def _metric_tags(self):
@@ -93,12 +98,17 @@ class Model(object):
     def find(cls, id):
         return cls(id=id)
 
-    def update_attributes(self, *args, **kwargs):
+    def _update_attributes(self, *args, **kwargs):
         for k, v in kwargs.items():
             if k in self.accessible_fields:
                 self.__setattr__(k, v)
             else:
-                raise AttributeError("Field {0} does not exist".format(k))
+                log.warning(
+                    "Unexpected field {field_name} in model {model_name}".format(
+                        field_name=k,
+                        model_name=self.__class__.__name__
+                    )
+                )
 
     def updatable_attributes(self):
         return extract(self.attributes, self.updatable_fields)
@@ -135,14 +145,14 @@ class Model(object):
                 metric_action='model.insert'
             )
         self.retrieved = True
-        self.update_attributes(**response)
+        self._update_attributes(**response)
         self.after_save(self)
 
     def delete(self):
         url = self.url(action='delete', params=self.attributes)
         response = perform_request('delete', url, metric_tags=self._metric_tags, metric_action='model.delete')
         self.retrieved = True
-        self.update_attributes(**response)
+        self._update_attributes(**response)
 
     @classmethod
     def url_with_id(cls, params={}):

--- a/lms/lib/comment_client/thread.py
+++ b/lms/lib/comment_client/thread.py
@@ -98,7 +98,7 @@ class Thread(models.Model):
             metric_action='model.retrieve',
             metric_tags=self._metric_tags
         )
-        self.update_attributes(**response)
+        self._update_attributes(**response)
 
     def flagAbuse(self, user, voteable):
         if voteable.type == 'thread':
@@ -115,7 +115,7 @@ class Thread(models.Model):
             metric_action='thread.abuse.flagged',
             metric_tags=self._metric_tags
         )
-        voteable.update_attributes(request)
+        voteable._update_attributes(request)
 
     def unFlagAbuse(self, user, voteable, removeAll):
         if voteable.type == 'thread':
@@ -136,7 +136,7 @@ class Thread(models.Model):
             metric_tags=self._metric_tags,
             metric_action='thread.abuse.unflagged'
         )
-        voteable.update_attributes(request)
+        voteable._update_attributes(request)
 
     def pin(self, user, thread_id):
         url = _url_for_pin_thread(thread_id)
@@ -148,7 +148,7 @@ class Thread(models.Model):
             metric_tags=self._metric_tags,
             metric_action='thread.pin'
         )
-        self.update_attributes(request)
+        self._update_attributes(request)
 
     def un_pin(self, user, thread_id):
         url = _url_for_un_pin_thread(thread_id)
@@ -160,7 +160,7 @@ class Thread(models.Model):
             metric_tags=self._metric_tags,
             metric_action='thread.unpin'
         )
-        self.update_attributes(request)
+        self._update_attributes(request)
 
 
 def _url_for_flag_abuse_thread(thread_id):

--- a/lms/lib/comment_client/user.py
+++ b/lms/lib/comment_client/user.py
@@ -64,7 +64,7 @@ class User(models.Model):
             metric_action='user.vote',
             metric_tags=self._metric_tags + ['target.type:{}'.format(voteable.type)],
         )
-        voteable.update_attributes(request)
+        voteable._update_attributes(request)
 
     def unvote(self, voteable):
         if voteable.type == 'thread':
@@ -81,7 +81,7 @@ class User(models.Model):
             metric_action='user.unvote',
             metric_tags=self._metric_tags + ['target.type:{}'.format(voteable.type)],
         )
-        voteable.update_attributes(request)
+        voteable._update_attributes(request)
 
     def active_threads(self, query_params={}):
         if not self.course_id:
@@ -142,7 +142,7 @@ class User(models.Model):
                 )
             else:
                 raise
-        self.update_attributes(**response)
+        self._update_attributes(**response)
 
 
 def _url_for_vote_comment(comment_id):


### PR DESCRIPTION
Previously, an error was raised if the comments service returned data
including an unexpected field, which unnecessarily complicated the
release path for new features, since the list of allowed fields would
need to be modified before cs_comments_service could be modified, and
only then could edx-platform take advantage of the new CS feature. We
still log a warning if an unexpected field is returned, so we will
still be able to tell if the CS returns a corrupt response.
