### PR TITLE
in Studio, render compact placeholders for inline discussions.

### DIFF
--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -82,6 +82,10 @@ class PreviewModuleSystem(ModuleSystem):  # pylint: disable=abstract-method
     """
     An XModule ModuleSystem for use in Studio previews
     """
+    # xmodules can check for this attribute during rendering to determine if
+    # they are being rendered for preview (i.e. in Studio)
+    is_author_mode = True
+
     def handler_url(self, block, handler_name, suffix='', query='', thirdparty=False):
         return reverse('preview_handler', kwargs={
             'usage_id': quote_slashes(unicode(block.scope_ids.usage_id).encode('utf-8')),

--- a/cms/static/sass/views/_unit.scss
+++ b/cms/static/sass/views/_unit.scss
@@ -1389,6 +1389,10 @@ body.unit .component {
   .xmodule_DiscussionModule, .xmodule_HtmlModule, .xblock {
     margin-top: ($baseline*1.5);
   }
+  .discussion-preview {
+    font-style: italic;
+    color: $mediumGrey;
+  }
 }
 
 body.unit .component.editing {

--- a/common/lib/xmodule/xmodule/discussion_module.py
+++ b/common/lib/xmodule/xmodule/discussion_module.py
@@ -50,7 +50,11 @@ class DiscussionModule(DiscussionFields, XModule):
         context = {
             'discussion_id': self.discussion_id,
         }
-        return self.system.render_template('discussion/_discussion_module.html', context)
+        if getattr(self.system, 'is_author_mode', False):
+            template = 'discussion/_discussion_module_studio.html'
+        else:
+            template = 'discussion/_discussion_module.html'
+        return self.system.render_template(template, context)
 
 
 class DiscussionDescriptor(DiscussionFields, MetadataOnlyEditingDescriptor, RawDescriptor):

--- a/common/test/acceptance/tests/test_studio.py
+++ b/common/test/acceptance/tests/test_studio.py
@@ -112,6 +112,45 @@ class CoursePagesTest(UniqueCourseTest):
             page.visit()
 
 
+class DiscussionPreviewTest(UniqueCourseTest):
+    """
+    Tests that Inline Discussions are rendered with a custom preview in Studio
+    """
+
+    def setUp(self):
+        super(DiscussionPreviewTest, self).setUp()
+        CourseFixture(**self.course_info).add_children(
+            XBlockFixtureDesc("chapter", "Test Section").add_children(
+                XBlockFixtureDesc("sequential", "Test Subsection").add_children(
+                    XBlockFixtureDesc("vertical", "Test Unit").add_children(
+                        XBlockFixtureDesc(
+                            "discussion",
+                            "Test Discussion",
+                        )
+                    )
+                )
+            )
+        ).install()
+
+        AutoAuthPage(self.browser, staff=True).visit()
+        cop = CourseOutlinePage(
+                self.browser,
+                self.course_info['org'],
+                self.course_info['number'],
+                self.course_info['run']
+                )
+        cop.visit()
+        self.unit = cop.section('Test Section').subsection('Test Subsection').toggle_expand().unit('Test Unit')
+        self.unit.go_to()
+
+    def test_is_preview(self):
+        """
+        Ensure that the preview version of the discussion is rendered.
+        """
+        self.assertTrue(self.unit.q(css=".discussion-preview").present)
+        self.assertFalse(self.unit.q(css=".discussion-show").present)
+
+
 class XBlockAcidBase(WebAppTest):
     """
     Base class for tests that verify that XBlock integration is working correctly

--- a/lms/templates/discussion/_discussion_module_studio.html
+++ b/lms/templates/discussion/_discussion_module_studio.html
@@ -1,0 +1,10 @@
+<%! from django.utils.translation import ugettext as _ %>
+
+<div class="discussion-module" data-discussion-id="${discussion_id | h}">
+    <p>
+        <span class="discussion-preview">
+            <span class="icon icon-comment"/>
+            ${_("To view live discussions, click Preview or View Live in Unit Settings.")}
+        </span>
+    </p>
+</div>


### PR DESCRIPTION
JIRA: FOR-429

This introduces an alternate rendering of DiscussionModules specifically for Studio.  No overt support for conditional rendering previously existed so a rudimentary mechanism was added.  Test coverage for Studio is provided by this PR; LMS-side coverage is implemented in PR #3183 which is not yet merged as of this moment, i'll rebase before merging this one.

@gwprice @marcotuts 
@dmitchell @auraz @cpennington 
