### PR TITLE
Add more granular pageview tracking, update Segment.io snippet

### DIFF
--- a/lms/templates/widgets/segment-io.html
+++ b/lms/templates/widgets/segment-io.html
@@ -13,10 +13,7 @@
   // Get current page URL and pull out the path
   path = window.location.href.split("/")[3]
   // Match on the current path and fire the appropriate pageview event
-  if (path == "") {
-    // Home page viewed (path empty)
-    window.analytics.page("Home");
-  } else if (path == "register") {
+  if (path == "register") {
     // Registration page viewed
     window.analytics.page("Registration");
   } else if (path == "login") {
@@ -25,12 +22,6 @@
   } else if (path == "dashboard") {
     // Dashboard viewed
     window.analytics.page("Dashboard");
-  } else if (path == "course-list") {
-    // Course listing page viewed
-    window.analytics.page("Course Listing");
-  } else if (path == "course") {
-    // Course about page viewed
-    window.analytics.page("Course About");
   } else {
     // This event serves as a catch-all, firing when any other page is viewed
     window.analytics.page("Other");

--- a/lms/templates/widgets/segment-io.html
+++ b/lms/templates/widgets/segment-io.html
@@ -6,23 +6,33 @@
 <% active_flags = " + ".join(waffle.get_flags(request)) %>
 
 <script type="text/javascript">
+  // Asynchronously load Segment.io's analytics.js library
   window.analytics||(window.analytics=[]),window.analytics.methods=["identify","track","trackLink","trackForm","trackClick","trackSubmit","page","pageview","ab","alias","ready","group","on","once","off"],window.analytics.factory=function(t){return function(){var a=Array.prototype.slice.call(arguments);return a.unshift(t),window.analytics.push(a),window.analytics}};for(var i=0;i<window.analytics.methods.length;i++){var method=window.analytics.methods[i];window.analytics[method]=window.analytics.factory(method)}window.analytics.load=function(t){var a=document.createElement("script");a.type="text/javascript",a.async=!0,a.src=("https:"===document.location.protocol?"https://":"http://")+"d2dq2ahtl5zl1z.cloudfront.net/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(a,n)},window.analytics.SNIPPET_VERSION="2.0.8",
   window.analytics.load("${ settings.SEGMENT_IO_LMS_KEY }");
 
-  path = window.location.href.split("/").slice(3)[0]
+  // Get current page URL and pull out the path
+  path = window.location.href.split("/")[3]
+  // Match on the current path and fire the appropriate pageview event
   if (path == "") {
+    // Home page viewed (path empty)
     window.analytics.page("Home");
   } else if (path == "register") {
+    // Registration page viewed
     window.analytics.page("Registration");
   } else if (path == "login") {
+    // Login page viewed
     window.analytics.page("Login");
   } else if (path == "dashboard") {
+    // Dashboard viewed
     window.analytics.page("Dashboard");
   } else if (path == "course-list") {
+    // Course listing page viewed
     window.analytics.page("Course Listing");
   } else if (path == "course") {
+    // Course about page viewed
     window.analytics.page("Course About");
   } else {
+    // This event serves as a catch-all, firing when any other page is viewed
     window.analytics.page("Other");
   }
 
@@ -32,6 +42,7 @@
       "Registered"      : true,
       email             : "${ user.email }",
       username          : "${ user.username }",
+      // Count the number of courses in which the user is currently enrolled
       "Enrollment Count": ${ sum(1 for course in user.courseenrollment_set.values() if course['is_active'] == True) },
       "Active Flags"    : "${ active_flags }",
     });

--- a/lms/templates/widgets/segment-io.html
+++ b/lms/templates/widgets/segment-io.html
@@ -6,15 +6,34 @@
 <% active_flags = " + ".join(waffle.get_flags(request)) %>
 
 <script type="text/javascript">
-  var analytics=analytics||[];analytics.load=function(e){var t=document.createElement("script");t.type="text/javascript",t.async=!0,t.src=("https:"===document.location.protocol?"https://":"http://")+"d2dq2ahtl5zl1z.cloudfront.net/analytics.js/v1/"+e+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n);var r=function(e){return function(){analytics.push([e].concat(Array.prototype.slice.call(arguments,0)))}},i=["identify","track","trackLink","trackForm","trackClick","trackSubmit","pageview","ab","alias","ready"];for(var s=0;s<i.length;s++)analytics[i[s]]=r(i[s])};
-  analytics.load("${ settings.SEGMENT_IO_LMS_KEY }");
+  window.analytics||(window.analytics=[]),window.analytics.methods=["identify","track","trackLink","trackForm","trackClick","trackSubmit","page","pageview","ab","alias","ready","group","on","once","off"],window.analytics.factory=function(t){return function(){var a=Array.prototype.slice.call(arguments);return a.unshift(t),window.analytics.push(a),window.analytics}};for(var i=0;i<window.analytics.methods.length;i++){var method=window.analytics.methods[i];window.analytics[method]=window.analytics.factory(method)}window.analytics.load=function(t){var a=document.createElement("script");a.type="text/javascript",a.async=!0,a.src=("https:"===document.location.protocol?"https://":"http://")+"d2dq2ahtl5zl1z.cloudfront.net/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(a,n)},window.analytics.SNIPPET_VERSION="2.0.8",
+  window.analytics.load("${ settings.SEGMENT_IO_LMS_KEY }");
+
+  path = window.location.href.split("/").slice(3)[0]
+  if (path == "") {
+    window.analytics.page("Home");
+  } else if (path == "register") {
+    window.analytics.page("Registration");
+  } else if (path == "login") {
+    window.analytics.page("Login");
+  } else if (path == "dashboard") {
+    window.analytics.page("Dashboard");
+  } else if (path == "course-list") {
+    window.analytics.page("Course Listing");
+  } else if (path == "course") {
+    window.analytics.page("Course About");
+  } else {
+    window.analytics.page("Other");
+  }
 
   % if user.is_authenticated():
 
     analytics.identify("${ user.id }", {
-      email          : "${ user.email }",
-      username       : "${ user.username }",
-      "Active Flags" : "${ active_flags }",
+      "Registered"      : true,
+      email             : "${ user.email }",
+      username          : "${ user.username }",
+      "Enrollment Count": ${ sum(1 for course in user.courseenrollment_set.values() if course['is_active'] == True) },
+      "Active Flags"    : "${ active_flags }",
     });
 
   % endif


### PR DESCRIPTION
This PR addresses the majority of requests for analytics improvements proposed [here](https://edx-wiki.atlassian.net/wiki/display/PROD/Course+%28Discovery%29%5E2) (bottom of the page, Phase 1, part F).

More specifically, this adds support for using Segment.io to explicitly track views of the home, registration, login, dashboard, course listing, and course about pages; another pageview event serves as a catch-all, firing when any other page is viewed. This PR also adds two new user superproperties: one tracking whether a user is registered (always true for authenticated users - @marcotuts noted that this condition is appropriate for the analysis he wants to perform in Mixpanel), and the other tracking a user's current enrollment count. In order to achieve this, I had to update the Segment.io tracking snippet we've been using.

My approach here sends named "Page" events to Segment.io, which then routes these to Mixpanel as "Viewed [Name] Page" events. For example, if Segment.io receives a page event named "Registration," Mixpanel will be sent an event named "Viewed Registration Page." Once this is merged in, I'll turn off the auto-generated "Loaded a Page" events which are currently being sent to Mixpanel by Segment.io; the "Viewed Other Page" event, which contains the URL of the viewed page as a property, will take its place.

@sarina and @dianakhuang, could you please help me review this?

@shnayder, FYI.
