### PR TITLE
Disable discussion service setting for lettuce tests

### DIFF
--- a/cms/djangoapps/contentstore/features/pages.py
+++ b/cms/djangoapps/contentstore/features/pages.py
@@ -98,25 +98,25 @@ def _verify_page_names(first, second):
 
 @step(u'the built-in pages are in the default order$')
 def built_in_pages_in_default_order(step):
-    expected_pages = ['Courseware', 'Course Info', 'Discussion', 'Wiki', 'Progress']
+    expected_pages = ['Courseware', 'Course Info', 'Wiki', 'Progress']
     see_pages_in_expected_order(expected_pages)
 
 
 @step(u'the built-in pages are switched$')
 def built_in_pages_switched(step):
-    expected_pages = ['Courseware', 'Course Info', 'Wiki', 'Progress', 'Discussion']
+    expected_pages = ['Courseware', 'Course Info', 'Progress', 'Wiki']
     see_pages_in_expected_order(expected_pages)
 
 
 @step(u'the pages are in the default order$')
 def pages_in_default_order(step):
-    expected_pages = ['Courseware', 'Course Info', 'Discussion', 'Wiki', 'Progress', 'First', 'Empty']
+    expected_pages = ['Courseware', 'Course Info', 'Wiki', 'Progress', 'First', 'Empty']
     see_pages_in_expected_order(expected_pages)
 
 
 @step(u'the pages are switched$$')
 def pages_are_switched(step):
-    expected_pages = ['Courseware', 'Course Info', 'Wiki', 'Progress', 'First', 'Empty', 'Discussion']
+    expected_pages = ['Courseware', 'Course Info', 'Progress', 'First', 'Empty', 'Wiki']
     see_pages_in_expected_order(expected_pages)
 
 

--- a/cms/envs/acceptance.py
+++ b/cms/envs/acceptance.py
@@ -98,9 +98,12 @@ STATICFILES_FINDERS += ('pipeline.finders.PipelineFinder', )
 # Use the auto_auth workflow for creating users and logging them in
 FEATURES['AUTOMATIC_AUTH_FOR_TESTING'] = True
 
-# For consistency in user-experience, keep the value of this setting in sync with
-# the one in lms/envs/acceptance.py
-FEATURES['ENABLE_DISCUSSION_SERVICE'] = True
+# Forums are disabled in test.py to speed up unit tests, but we do not have
+# per-test control for lettuce acceptance tests.
+# If you are writing an acceptance test that needs the discussion service enabled,
+# do not write it in lettuce, but instead write it using bok-choy.
+# DO NOT CHANGE THIS SETTING HERE.
+FEATURES['ENABLE_DISCUSSION_SERVICE'] = False
 
 # HACK
 # Setting this flag to false causes imports to not load correctly in the lettuce python files

--- a/lms/envs/acceptance.py
+++ b/lms/envs/acceptance.py
@@ -98,10 +98,11 @@ STATICFILES_FINDERS += ('pipeline.finders.PipelineFinder', )
 BULK_EMAIL_DEFAULT_FROM_EMAIL = "test@test.org"
 
 # Forums are disabled in test.py to speed up unit tests, but we do not have
-# per-test control for acceptance tests
-# For consistency in user-experience, keep the value of this setting in sync with
-# the one in cms/envs/acceptance.py
-FEATURES['ENABLE_DISCUSSION_SERVICE'] = True
+# per-test control for lettuce acceptance tests.
+# If you are writing an acceptance test that needs the discussion service enabled,
+# do not write it in lettuce, but instead write it using bok-choy.
+# DO NOT CHANGE THIS SETTING HERE.
+FEATURES['ENABLE_DISCUSSION_SERVICE'] = False
 
 # Use the auto_auth workflow for creating users and logging them in
 FEATURES['AUTOMATIC_AUTH_FOR_TESTING'] = True


### PR DESCRIPTION
@nasthagiri 

Enabling the discussion service integration has other implications - every time a user is created or logs into lms or studio it tries and fails to update a corresponding user record on the cs_comments_service side. This is causing the tests to use extra resources, and clogging up the logs (which is causing confusion for people troubleshooting actual errors). 

I'd like to turn it off and make sure it stays off for lettuce tests.
