### PR TITLE
Return 404 instead of 500 for missing forum thread

### DIFF
--- a/common/static/coffee/src/discussion/views/discussion_thread_view.coffee
+++ b/common/static/coffee/src/discussion/views/discussion_thread_view.coffee
@@ -57,8 +57,13 @@ if Backbone?
           @responses.add(data['content']['children'])
           @renderResponseCountAndPagination(data['content']['resp_total'])
           @trigger "thread:responses:rendered"
-        error: =>
-          if firstLoad
+        error: (xhr) =>
+          if xhr.status == 404
+            DiscussionUtil.discussionAlert(
+              gettext("Sorry"),
+              gettext("The thread you selected has been deleted. Please select another thread.")
+            )
+          else if firstLoad
             DiscussionUtil.discussionAlert(
               gettext("Sorry"),
               gettext("We had some trouble loading responses. Please reload the page.")

--- a/lms/djangoapps/django_comment_client/forum/views.py
+++ b/lms/djangoapps/django_comment_client/forum/views.py
@@ -237,12 +237,17 @@ def single_thread(request, course_id, discussion_id, thread_id):
     # Currently, the front end always loads responses via AJAX, even for this
     # page; it would be a nice optimization to avoid that extra round trip to
     # the comments service.
-    thread = cc.Thread.find(thread_id).retrieve(
-        recursive=request.is_ajax(),
-        user_id=request.user.id,
-        response_skip=request.GET.get("resp_skip"),
-        response_limit=request.GET.get("resp_limit")
-    )
+    try:
+        thread = cc.Thread.find(thread_id).retrieve(
+            recursive=request.is_ajax(),
+            user_id=request.user.id,
+            response_skip=request.GET.get("resp_skip"),
+            response_limit=request.GET.get("resp_limit")
+        )
+    except cc.utils.CommentClientRequestError as e:
+        if e.status_code == 404:
+            raise Http404
+        raise
 
     if request.is_ajax():
         with newrelic.agent.FunctionTrace(nr_transaction, "get_annotated_content_infos"):


### PR DESCRIPTION
Also show a more specific error message in the front end. This change
only has an effect if using cs_comments_service commit 1d71330 or later.
