### PR TITLE
Update acceptance tests to use real duration of YouTube video.

### DIFF
--- a/common/djangoapps/terrain/stubs/tests/test_youtube_stub.py
+++ b/common/djangoapps/terrain/stubs/tests/test_youtube_stub.py
@@ -24,7 +24,11 @@ class StubYouTubeServiceTest(unittest.TestCase):
             self.url + 'test_youtube/OEoXaMPEzfM?v=2&alt=jsonc&callback=callback_func'
         )
 
-        self.assertEqual('callback_func({"data": {"duration": 60, "message": "I\'m youtube.", "id": "OEoXaMPEzfM"}})', response.content)
+        # YouTube metadata for video `OEoXaMPEzfM` states that duration is 116.
+        self.assertEqual(
+            'callback_func({"data": {"duration": 116, "message": "I\'m youtube.", "id": "OEoXaMPEzfM"}})',
+            response.content
+        )
 
     def test_transcript_url_equal(self):
         response = requests.get(

--- a/common/djangoapps/terrain/stubs/youtube.py
+++ b/common/djangoapps/terrain/stubs/youtube.py
@@ -98,11 +98,16 @@ class StubYouTubeHandler(StubHttpRequestHandler):
 
         # Construct the response content
         callback = self.get_params['callback']
+        youtube_metadata = json.loads(
+            requests.get(
+                "http://gdata.youtube.com/feeds/api/videos/{id}?v=2&alt=jsonc".format(id=youtube_id)
+            ).text
+        )
         data = OrderedDict({
             'data': OrderedDict({
                 'id': youtube_id,
                 'message': message,
-                'duration': 60 if youtube_id == 'OEoXaMPEzfM' else 77,
+                'duration': youtube_metadata['data']['duration'],
             })
         })
         response = "{cb}({data})".format(cb=callback, data=json.dumps(data))

--- a/lms/djangoapps/courseware/features/video.feature
+++ b/lms/djangoapps/courseware/features/video.feature
@@ -185,7 +185,10 @@ Feature: LMS.Video component
     And I select the "1.50" speed
     And I reload the page with video
     Then I see "Hi, welcome to Edx." text in the captions
-    And I see duration "1:00"
+    # The 1:56 time is the duration from metadata. 1:54 time is the duration reported
+    # by the video API once the video starts playing. The next step is correct because
+    # "1:56" is the duration in the VCR timer before the video plays.
+    And I see duration "1:56"
 
   # 15
    Scenario: Download button works correctly for non-english transcript in Youtube mode of Video component


### PR DESCRIPTION
**Description**

The YouTube stub server should actually get real duration of YouTube video, and pass that on to the video player instance on front end. If YouTube stub sever doesn't do this, then when the Play button will be clicked in the video player, the video will begin playing, and the API will report a totally different duration than was previously determined form the metadata (YouTube stub server responds with metadata information for acceptance tests).

**Reviewers**
- @polesye 
- @auraz 
