### PR TITLE
Fix for fuzzy prompt on Studio Pages

### DIFF
--- a/cms/templates/edit-tabs.html
+++ b/cms/templates/edit-tabs.html
@@ -179,5 +179,5 @@
   </a>
 </div>
 
-<div class="edit-xblock-modal"/>
+<div class="edit-xblock-modal"></div>
 </%block>


### PR DESCRIPTION
@talbs Can you give this a quick review? The prompt on the Studio Pages page was getting fuzzed out because of shorthand div syntax.
