### PR TITLE
cms aws.py: enable ADDL_INSTALLED_APPS for xblocks

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -164,6 +164,10 @@ LANGUAGES = ENV_TOKENS.get('LANGUAGES', LANGUAGES)
 LANGUAGE_CODE = ENV_TOKENS.get('LANGUAGE_CODE', LANGUAGE_CODE)
 USE_I18N = ENV_TOKENS.get('USE_I18N', USE_I18N)
 
+# Additional installed apps
+for app in ENV_TOKENS.get('ADDL_INSTALLED_APPS', []):
+    INSTALLED_APPS += (app,)
+
 ENV_FEATURES = ENV_TOKENS.get('FEATURES', ENV_TOKENS.get('MITX_FEATURES', {}))
 for feature, value in ENV_FEATURES.items():
     FEATURES[feature] = value


### PR DESCRIPTION
This was something that I got stuck on on last week's hackathon.  @jarv or @e0d or @feanil to review.

Add the hook to the aws config so that adding ADDL_INSTALLED_APPS to the
dict will get picked up by the app.  This is already present in
lms/envs/aws.py, just moving this into cms/envs/aws.py to match.

I believe this will be needed to use xblocks in production with CMS.

Also helpful for devstack.  This could be configured in devstack in
private.py, but I prefer editing the cms.env.json directly, as that's
required for other things, like theming.  I don't use a private.py
anymore.
