### PR TITLE
Fixing start-time and end-time related Jasmine tests.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -108,5 +108,30 @@
     //
     // The parameter "predef" should remain empty for this configuration file
     // to remain as general as possible.
-    "predef": []
+    "predef": [
+        // jQuery library.
+        "jQuery", "$",
+
+        // Underscore.js library.
+        "_",
+
+        // Jasmine library.
+        "jasmine",
+        "describe", "xdescribe",
+        "it", "xit",
+        "spyOn",
+        "beforeEach",
+        "afterEach",
+        "expect",
+        "waitsFor",
+        "runs",
+
+        // jQuery-Jasmine library.
+        "loadFixtures",
+        "appendLoadFixtures",
+        "readFixtures",
+        "setFixtures",
+        "appendSetFixtures",
+        "spyOnEvent"
+    ]
 }

--- a/common/lib/xmodule/xmodule/js/spec/helper.js
+++ b/common/lib/xmodule/xmodule/js/spec/helper.js
@@ -1,4 +1,6 @@
-(function ($, undefined) {
+(function () {
+    'use strict';
+
     var stubbedYT = {
         Player: function () {
             var Player = jasmine.createSpyObj(
@@ -150,11 +152,11 @@
                 }
             } else if (settings.url.match(/transcript\/translation\/.+$/)) {
                 return settings.success(jasmine.stubbedCaption);
-            } else if (settings.url == '/transcript/available_translations') {
+            } else if (settings.url === '/transcript/available_translations') {
                 return settings.success(['uk', 'de']);
             } else if (settings.url.match(/.+\/problem_get$/)) {
                 return settings.success({
-                    html: readFixtures('problem_content.html')
+                    html: window.readFixtures('problem_content.html')
                 });
             } else if (
                 settings.url === '/calculate' ||
@@ -163,13 +165,15 @@
                 settings.url.match(/.+\/problem_(check|reset|show|save)$/)
             ) {
                 // Do nothing.
-            } else if (settings.url == '/save_user_state') {
+                return;
+            } else if (settings.url === '/save_user_state') {
                 return {success: true};
             } else if (settings.url === 'http://www.youtube.com/iframe_api') {
                 // Stub YouTube API.
                 window.YT = stubbedYT;
 
-                // Call the callback that must be called when YouTube API is loaded. By specification.
+                // Call the callback that must be called when YouTube API is
+                // loaded. By specification.
                 window.onYouTubeIframeAPIReady();
 
                 return {success: true};
@@ -205,7 +209,7 @@
             }
         });
 
-        return this.addMatchers(imagediff.jasmine);
+        return this.addMatchers(window.imagediff.jasmine);
     });
 
     // Stub jQuery.cookie module.
@@ -244,7 +248,7 @@
         }
 
         jasmine.stubRequests();
-        state = new Video('#example');
+        state = new window.Video('#example');
 
         state.resizer = (function () {
             var methods = [
@@ -279,4 +283,4 @@
         // "video.html" contains HTML template for a YouTube video.
         return jasmine.initializePlayer('video.html', params);
     };
-}).call(this, window.jQuery);
+}).call(this);

--- a/common/lib/xmodule/xmodule/js/spec/video/video_control_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_control_spec.js
@@ -1,4 +1,6 @@
-(function (undefined) {
+(function (WAIT_TIMEOUT) {
+    'use strict';
+
     describe('VideoControl', function () {
         var state, oldOTBD;
 
@@ -105,14 +107,18 @@
         });
 
         describe('constructor with start-time', function () {
-            it('saved position is 0, timer slider and VCR set to start-time', function () {
-                var duration;
+            it(
+                'saved position is 0, timer slider and VCR set to start-time',
+                function ()
+            {
+                var duration, sliderEl, expectedValue;
 
                 runs(function () {
                     state = jasmine.initializePlayer({
                         start: 10,
                         savedVideoPosition: 0
                     });
+                    sliderEl = state.videoProgressSlider.slider;
                     spyOn(state.videoPlayer, 'duration').andReturn(60);
                 });
 
@@ -124,23 +130,29 @@
                 }, 'duration is set', WAIT_TIMEOUT);
 
                 runs(function () {
-                    expect($('.video-controls').find('.vidtime'))
-                        .toHaveText('0:10 / 1:00');
+                    expectedValue = $('.video-controls').find('.vidtime');
+                    expect(expectedValue).toHaveText('0:10 / 1:00');
 
-                    expect(state.videoProgressSlider.slider.slider('option', 'value')).toBe(10);
+                    expectedValue = sliderEl.slider('option', 'value');
+                    expect(expectedValue).toBe(10);
 
                     state.storage.clear();
                 });
             });
 
-            it('saved position is after start-time, timer slider and VCR set to saved position', function () {
-                var duration;
+            it(
+                'saved position is after start-time, ' +
+                'timer slider and VCR set to saved position',
+                function ()
+            {
+                var duration, sliderEl, expectedValue;
 
                 runs(function () {
                     state = jasmine.initializePlayer({
                         start: 10,
                         savedVideoPosition: 15
                     });
+                    sliderEl = state.videoProgressSlider.slider;
                     spyOn(state.videoPlayer, 'duration').andReturn(60);
                 });
 
@@ -152,23 +164,29 @@
                 }, 'duration is set', WAIT_TIMEOUT);
 
                 runs(function () {
-                    expect($('.video-controls').find('.vidtime'))
-                        .toHaveText('0:15 / 1:00');
+                    expectedValue = $('.video-controls').find('.vidtime');
+                    expect(expectedValue).toHaveText('0:15 / 1:00');
 
-                    expect(state.videoProgressSlider.slider.slider('option', 'value')).toBe(15);
+                    expectedValue = sliderEl.slider('option', 'value');
+                    expect(expectedValue).toBe(15);
 
                     state.storage.clear();
                 });
             });
 
-            it('saved position is negative, timer slider and VCR set to start-time', function () {
-                var duration;
+            it(
+                'saved position is negative, ' +
+                'timer slider and VCR set to start-time',
+                function ()
+            {
+                var duration, sliderEl, expectedValue;
 
                 runs(function () {
                     state = jasmine.initializePlayer({
                         start: 10,
                         savedVideoPosition: -15
                     });
+                    sliderEl = state.videoProgressSlider.slider;
                     spyOn(state.videoPlayer, 'duration').andReturn(60);
                 });
 
@@ -180,23 +198,29 @@
                 }, 'duration is set', WAIT_TIMEOUT);
 
                 runs(function () {
-                    expect($('.video-controls').find('.vidtime'))
-                        .toHaveText('0:10 / 1:00');
+                    expectedValue = $('.video-controls').find('.vidtime');
+                    expect(expectedValue).toHaveText('0:10 / 1:00');
 
-                    expect(state.videoProgressSlider.slider.slider('option', 'value')).toBe(10);
+                    expectedValue = sliderEl.slider('option', 'value');
+                    expect(expectedValue).toBe(10);
 
                     state.storage.clear();
                 });
             });
 
-            it('saved position is not a number, timer slider and VCR set to start-time', function () {
-                var duration;
+            it(
+                'saved position is not a number, ' +
+                'timer slider and VCR set to start-time',
+                function ()
+            {
+                var duration, sliderEl, expectedValue;
 
                 runs(function () {
                     state = jasmine.initializePlayer({
                         start: 10,
                         savedVideoPosition: 'a'
                     });
+                    sliderEl = state.videoProgressSlider.slider;
                     spyOn(state.videoPlayer, 'duration').andReturn(60);
                 });
 
@@ -208,23 +232,29 @@
                 }, 'duration is set', WAIT_TIMEOUT);
 
                 runs(function () {
-                    expect($('.video-controls').find('.vidtime'))
-                        .toHaveText('0:10 / 1:00');
+                    expectedValue = $('.video-controls').find('.vidtime');
+                    expect(expectedValue).toHaveText('0:10 / 1:00');
 
-                    expect(state.videoProgressSlider.slider.slider('option', 'value')).toBe(10);
+                    expectedValue = sliderEl.slider('option', 'value');
+                    expect(expectedValue).toBe(10);
 
                     state.storage.clear();
                 });
             });
 
-            it('saved position is greater than end-time, timer slider and VCR set to start-time', function () {
-                var duration;
+            it(
+                'saved position is greater than end-time, ' +
+                'timer slider and VCR set to start-time',
+                function ()
+            {
+                var duration, sliderEl, expectedValue;
 
                 runs(function () {
                     state = jasmine.initializePlayer({
                         start: 10,
                         savedVideoPosition: 10000
                     });
+                    sliderEl = state.videoProgressSlider.slider;
                     spyOn(state.videoPlayer, 'duration').andReturn(60);
                 });
 
@@ -236,10 +266,11 @@
                 }, 'duration is set', WAIT_TIMEOUT);
 
                 runs(function () {
-                    expect($('.video-controls').find('.vidtime'))
-                        .toHaveText('0:10 / 1:00');
+                    expectedValue = $('.video-controls').find('.vidtime');
+                    expect(expectedValue).toHaveText('0:10 / 1:00');
 
-                    expect(state.videoProgressSlider.slider.slider('option', 'value')).toBe(10);
+                    expectedValue = sliderEl.slider('option', 'value');
+                    expect(expectedValue).toBe(10);
 
                     state.storage.clear();
                 });
@@ -247,14 +278,18 @@
         });
 
         describe('constructor with end-time', function () {
-            it('saved position is 0, timer slider and VCR set to 0:00', function () {
-                var duration;
+            it(
+                'saved position is 0, timer slider and VCR set to 0:00',
+                function ()
+            {
+                var duration, sliderEl, expectedValue;
 
                 runs(function () {
                     state = jasmine.initializePlayer({
                         end: 20,
                         savedVideoPosition: 0
                     });
+                    sliderEl = state.videoProgressSlider.slider;
                     spyOn(state.videoPlayer, 'duration').andReturn(60);
                 });
 
@@ -266,23 +301,29 @@
                 }, 'duration is set', WAIT_TIMEOUT);
 
                 runs(function () {
-                    expect($('.video-controls').find('.vidtime'))
-                        .toHaveText('0:00 / 1:00');
+                    expectedValue = $('.video-controls').find('.vidtime');
+                    expect(expectedValue).toHaveText('0:00 / 1:00');
 
-                    expect(state.videoProgressSlider.slider.slider('option', 'value')).toBe(0);
+                    expectedValue = sliderEl.slider('option', 'value');
+                    expect(expectedValue).toBe(0);
 
                     state.storage.clear();
                 });
             });
 
-            it('saved position is after start-time, timer slider and VCR set to saved position', function () {
-                var duration;
+            it(
+                'saved position is after start-time, ' +
+                'timer slider and VCR set to saved position',
+                function ()
+            {
+                var duration, sliderEl, expectedValue;
 
                 runs(function () {
                     state = jasmine.initializePlayer({
                         end: 20,
                         savedVideoPosition: 15
                     });
+                    sliderEl = state.videoProgressSlider.slider;
                     spyOn(state.videoPlayer, 'duration').andReturn(60);
                 });
 
@@ -294,24 +335,29 @@
                 }, 'duration is set', WAIT_TIMEOUT);
 
                 runs(function () {
-                    expect($('.video-controls').find('.vidtime'))
-                        .toHaveText('0:15 / 1:00');
+                    expectedValue = $('.video-controls').find('.vidtime');
+                    expect(expectedValue).toHaveText('0:15 / 1:00');
 
-                    expect(state.videoProgressSlider.slider.slider('option', 'value')).toBe(15);
+                    expectedValue = sliderEl.slider('option', 'value');
+                    expect(expectedValue).toBe(15);
 
                     state.storage.clear();
                 });
             });
 
             // TODO: Fix!
-            it('saved position is negative, timer slider and VCR set to 0:00', function () {
-                var duration, c1 = 0;
+            it(
+                'saved position is negative, timer slider and VCR set to 0:00',
+                function ()
+            {
+                var duration, sliderEl, expectedValue;
 
                 runs(function () {
                     state = jasmine.initializePlayer({
                         end: 20,
                         savedVideoPosition: -15
                     });
+                    sliderEl = state.videoProgressSlider.slider;
                     spyOn(state.videoPlayer, 'duration').andReturn(60);
                 });
 
@@ -323,23 +369,29 @@
                 }, 'duration is set', WAIT_TIMEOUT);
 
                 runs(function () {
-                    expect($('.video-controls').find('.vidtime'))
-                        .toHaveText('0:00 / 1:00');
+                    expectedValue = $('.video-controls').find('.vidtime');
+                    expect(expectedValue).toHaveText('0:00 / 1:00');
 
-                    expect(true).toBe(true);
-                    expect(state.videoProgressSlider.slider.slider('option', 'value')).toBe(0);
+                    expectedValue = sliderEl.slider('option', 'value');
+                    expect(expectedValue).toBe(0);
+
                     state.storage.clear();
                 });
             });
 
-            it('saved position is not a number, timer slider and VCR set to 0:00', function () {
-                var duration;
+            it(
+                'saved position is not a number, ' +
+                'timer slider and VCR set to 0:00',
+                function ()
+            {
+                var duration, sliderEl, expectedValue;
 
                 runs(function () {
                     state = jasmine.initializePlayer({
                         end: 20,
                     savedVideoPosition: 'a'
                     });
+                    sliderEl = state.videoProgressSlider.slider;
                     spyOn(state.videoPlayer, 'duration').andReturn(60);
                 });
 
@@ -351,23 +403,30 @@
                 }, 'duration is set', WAIT_TIMEOUT);
 
                 runs(function () {
-                    expect($('.video-controls').find('.vidtime'))
-                        .toHaveText('0:00 / 1:00');
+                    expectedValue = $('.video-controls').find('.vidtime');
+                    expect(expectedValue).toHaveText('0:00 / 1:00');
 
-                    expect(state.videoProgressSlider.slider.slider('option', 'value')).toBe(0);
+                    expectedValue = sliderEl.slider('option', 'value');
+                    expect(expectedValue).toBe(0);
+
                     state.storage.clear();
                 });
             });
 
             // TODO: Fix!
-            it('saved position is greater than end-time, timer slider and VCR set to 0:00', function () {
-                var duration;
+            it(
+                'saved position is greater than end-time, ' +
+                'timer slider and VCR set to 0:00',
+                function ()
+            {
+                var duration, sliderEl, expectedValue;
 
                 runs(function () {
                     state = jasmine.initializePlayer({
                         end: 20,
                         savedVideoPosition: 10000
                     });
+                    sliderEl = state.videoProgressSlider.slider;
                     spyOn(state.videoPlayer, 'duration').andReturn(60);
                 });
 
@@ -379,18 +438,23 @@
                 }, 'duration is set', WAIT_TIMEOUT);
 
                 runs(function () {
-                    expect($('.video-controls').find('.vidtime'))
-                        .toHaveText('0:00 / 1:00');
+                    expectedValue = $('.video-controls').find('.vidtime');
+                    expect(expectedValue).toHaveText('0:00 / 1:00');
 
-                    expect(state.videoProgressSlider.slider.slider('option', 'value')).toBe(0);
+                    expectedValue = sliderEl.slider('option', 'value');
+                    expect(expectedValue).toBe(0);
+
                     state.storage.clear();
                 });
             });
         });
 
         describe('constructor with start-time and end-time', function () {
-            it('saved position is 0, timer slider and VCR set to start-time', function () {
-                var duration;
+            it(
+                'saved position is 0, timer slider and VCR set to start-time',
+                function ()
+            {
+                var duration, sliderEl, expectedValue;
 
                 runs(function () {
                     state = jasmine.initializePlayer({
@@ -398,6 +462,7 @@
                         end: 20,
                         savedVideoPosition: 0
                     });
+                    sliderEl = state.videoProgressSlider.slider;
                     spyOn(state.videoPlayer, 'duration').andReturn(60);
                 });
 
@@ -409,16 +474,22 @@
                 }, 'duration is set', WAIT_TIMEOUT);
 
                 runs(function () {
-                    expect($('.video-controls').find('.vidtime'))
-                        .toHaveText('0:10 / 1:00');
+                    expectedValue = $('.video-controls').find('.vidtime');
+                    expect(expectedValue).toHaveText('0:10 / 1:00');
 
-                    expect(state.videoProgressSlider.slider.slider('option', 'value')).toBe(10);
+                    expectedValue = sliderEl.slider('option', 'value');
+                    expect(expectedValue).toBe(10);
+
                     state.storage.clear();
                 });
             });
 
-            it('saved position is after start-time, timer slider and VCR set to saved position', function () {
-                var duration;
+            it(
+                'saved position is after start-time, ' +
+                'timer slider and VCR set to saved position',
+                function ()
+            {
+                var duration, sliderEl, expectedValue;
 
                 runs(function () {
                     state = jasmine.initializePlayer({
@@ -426,6 +497,7 @@
                         end: 20,
                         savedVideoPosition: 15
                     });
+                    sliderEl = state.videoProgressSlider.slider;
                     spyOn(state.videoPlayer, 'duration').andReturn(60);
                 });
 
@@ -437,17 +509,22 @@
                 }, 'duration is set', WAIT_TIMEOUT);
 
                 runs(function () {
-                    expect($('.video-controls').find('.vidtime'))
-                        .toHaveText('0:15 / 1:00');
+                    expectedValue = $('.video-controls').find('.vidtime');
+                    expect(expectedValue).toHaveText('0:15 / 1:00');
 
-                    expect(state.videoProgressSlider.slider.slider('option', 'value')).toBe(15);
+                    expectedValue = sliderEl.slider('option', 'value');
+                    expect(expectedValue).toBe(15);
 
                     state.storage.clear();
                 });
             });
 
-            it('saved position is negative, timer slider and VCR set to start-time', function () {
-                var duration;
+            it(
+                'saved position is negative, ' +
+                'timer slider and VCR set to start-time',
+                function ()
+            {
+                var duration, sliderEl, expectedValue;
 
                 runs(function () {
                     state = jasmine.initializePlayer({
@@ -455,6 +532,7 @@
                         end: 20,
                         savedVideoPosition: -15
                     });
+                    sliderEl = state.videoProgressSlider.slider;
                     spyOn(state.videoPlayer, 'duration').andReturn(60);
                 });
 
@@ -466,17 +544,22 @@
                 }, 'duration is set', WAIT_TIMEOUT);
 
                 runs(function () {
-                    expect($('.video-controls').find('.vidtime'))
-                        .toHaveText('0:10 / 1:00');
+                    expectedValue = $('.video-controls').find('.vidtime');
+                    expect(expectedValue).toHaveText('0:10 / 1:00');
 
-                    expect(state.videoProgressSlider.slider.slider('option', 'value')).toBe(10);
+                    expectedValue = sliderEl.slider('option', 'value');
+                    expect(expectedValue).toBe(10);
 
                     state.storage.clear();
                 });
             });
 
-            it('saved position is not a number, timer slider and VCR set to start-time', function () {
-                var duration;
+            it(
+                'saved position is not a number, ' +
+                'timer slider and VCR set to start-time',
+                function ()
+            {
+                var duration, sliderEl, expectedValue;
 
                 runs(function () {
                     state = jasmine.initializePlayer({
@@ -484,6 +567,7 @@
                         end: 20,
                         savedVideoPosition: 'a'
                     });
+                    sliderEl = state.videoProgressSlider.slider;
                     spyOn(state.videoPlayer, 'duration').andReturn(60);
                 });
 
@@ -495,17 +579,22 @@
                 }, 'duration is set', WAIT_TIMEOUT);
 
                 runs(function () {
-                    expect($('.video-controls').find('.vidtime'))
-                        .toHaveText('0:10 / 1:00');
+                    expectedValue = $('.video-controls').find('.vidtime');
+                    expect(expectedValue).toHaveText('0:10 / 1:00');
 
-                    expect(state.videoProgressSlider.slider.slider('option', 'value')).toBe(10);
+                    expectedValue = sliderEl.slider('option', 'value');
+                    expect(expectedValue).toBe(10);
 
                     state.storage.clear();
                 });
             });
 
-            it('saved position is greater than end-time, timer slider and VCR set to start-time', function () {
-                var duration;
+            it(
+                'saved position is greater than end-time, ' +
+                'timer slider and VCR set to start-time',
+                function ()
+            {
+                var duration, sliderEl, expectedValue;
 
                 runs(function () {
                     state = jasmine.initializePlayer({
@@ -513,6 +602,7 @@
                         end: 20,
                         savedVideoPosition: 10000
                     });
+                    sliderEl = state.videoProgressSlider.slider;
                     spyOn(state.videoPlayer, 'duration').andReturn(60);
                 });
 
@@ -524,10 +614,11 @@
                 }, 'duration is set', WAIT_TIMEOUT);
 
                 runs(function () {
-                    expect($('.video-controls').find('.vidtime'))
-                        .toHaveText('0:10 / 1:00');
+                    expectedValue = $('.video-controls').find('.vidtime');
+                    expect(expectedValue).toHaveText('0:10 / 1:00');
 
-                    expect(state.videoProgressSlider.slider.slider('option', 'value')).toBe(10);
+                    expectedValue = sliderEl.slider('option', 'value');
+                    expect(expectedValue).toBe(10);
 
                     state.storage.clear();
                 });
@@ -589,7 +680,9 @@
                     beforeEach(function () {
                         $('.video_control').addClass('play');
                         spyOnEvent(state.videoControl, 'pause');
-                        state.videoControl.togglePlayback(jQuery.Event('click'));
+                        state.videoControl.togglePlayback(
+                            $.Event('click')
+                        );
                     });
 
                     it('does not trigger the pause event', function () {
@@ -602,7 +695,9 @@
                     beforeEach(function () {
                         $('.video_control').addClass('pause');
                         spyOnEvent(state.videoControl, 'play');
-                        state.videoControl.togglePlayback(jQuery.Event('click'));
+                        state.videoControl.togglePlayback(
+                            $.Event('click')
+                        );
                     });
 
                     it('does not trigger the play event', function () {
@@ -749,4 +844,4 @@
             expect(controls).not.toHaveClass('is-hidden');
         });
     });
-}).call(this);
+}).call(this, window.WAIT_TIMEOUT);


### PR DESCRIPTION
**Note**

Could not reproduce the failing tests. Performed small refactoring.

**Description**

The following two tests are flaky on master:

1.) JavaScript.firefox.VideoControl constructor with start-time: saved position is 0, timer slider and VCR set to start-time (from javascript)

_Stacktrace_

```
timeout: timed out after 5000 msec waiting for duration is set
```

2.) JavaScript.firefox.VideoControl constructor with end-time: saved position is greater than end-time, timer slider and VCR set to 0:00 (from javascript) 

_Stacktrace_

```
timeout: timed out after 5000 msec waiting for duration is set
```

[ 1 ] https://jenkins.testeng.edx.org/job/edx-all-tests-auto-master/1545/SHARD=1,TEST_SUITE=unit/testReport/junit/JavaScript/firefox/VideoControl_constructor_with_start_time__saved_position_is_0__timer_slider_and_VCR_set_to_start_time/
[ 2 ] https://jenkins.testeng.edx.org/job/edx-all-tests-auto-pr/8683/SHARD=1,TEST_SUITE=unit/testReport/junit/JavaScript/firefox/VideoControl_constructor_with_end_time__saved_position_is_greater_than_end_time__timer_slider_and_VCR_set_to_0_00/

**Jira issue**

[BLD-1013](https://edx-wiki.atlassian.net/browse/BLD-1013).

**Reviewers**
- @polesye 
