### PR TITLE
Fix for BLD-993

### DIFF
--- a/common/lib/xmodule/xmodule/js/spec/capa/display_spec.coffee
+++ b/common/lib/xmodule/xmodule/js/spec/capa/display_spec.coffee
@@ -255,6 +255,20 @@ describe 'Problem', ->
         expect($('.show .show-label')).toHaveText 'Hide Answer'
         expect(window.SR.readElts).toHaveBeenCalled()
 
+      it 'toggle the show answer button, answers are strings', ->
+        spyOn($, 'postWithPrefix').andCallFake (url, callback) -> callback(answers: '1_1': 'One', '1_2': 'Two')
+        @problem.show()
+        expect($('.show .show-label')).toHaveText 'Hide Answer'
+        expect(window.SR.readElts).toHaveBeenCalledWith ['<p>Answer: One</p>', '<p>Answer: Two</p>']
+
+      it 'toggle the show answer button, answers are elements', ->
+        answer1 = '<div><span class="detailed-solution">one</span></div>'
+        answer2 = '<div><span class="detailed-solution">two</span></div>'
+        spyOn($, 'postWithPrefix').andCallFake (url, callback) -> callback(answers: '1_1': answer1, '1_2': answer2)
+        @problem.show()
+        expect($('.show .show-label')).toHaveText 'Hide Answer'
+        expect(window.SR.readElts).toHaveBeenCalledWith [jasmine.any(jQuery), jasmine.any(jQuery)]
+
       it 'add the showed class to element', ->
         spyOn($, 'postWithPrefix').andCallFake (url, callback) -> callback(answers: {})
         @problem.show()

--- a/common/lib/xmodule/xmodule/js/src/capa/display.coffee
+++ b/common/lib/xmodule/xmodule/js/src/capa/display.coffee
@@ -342,7 +342,18 @@ class @Problem
             answer = @$("#answer_#{key}, #solution_#{key}")
             answer.html(value)
             Collapsible.setCollapsibles(answer)
-            solution = $(value).find('.detailed-solution')
+
+            # Sometimes, `value` is just a string containing a MathJax formula.
+            # If this is the case, jQuery will throw an error in some corner cases
+            # because of an incorrect selector. We setup a try..catch so that
+            # the script doesn't break in such cases.
+            #
+            # We will fallback to the second `if statement` below, if an
+            # error is thrown by jQuery.
+            try
+                solution = $(value).find('.detailed-solution')
+            catch e
+                solution = {}
             if solution.length
               answer_text.push(solution)
             else


### PR DESCRIPTION
**Description**

In certain cases jQuery errors when it is passed an invalid selector. A fix for this is to silently catch these errors.

**Jira issue**

[BLD-993](https://edx-wiki.atlassian.net/browse/BLD-993)

**Reviewers**

@davestgermain - Please review, since you have last changed this file in the place where it fails.
