### PR TITLE
Added a script for automatically starting and suspending a vagrant image

### DIFF
--- a/scripts/vagrant_monitor.py
+++ b/scripts/vagrant_monitor.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+"""
+Automatically start and stop your vagrant instance.
+
+Copy vagrantmonitor.plist to ~/Library/LaunchAgents/ and edit it to point to
+the path to this script. Then reboot or "launchctl load ~/Library/LaunchAgents/vagrantmonitor.plist"
+On logout, this script will suspend the vagrant instance.
+
+In order for vagrant to add shared folders without prompting for a password,
+add this to /etc/sudoers
+
+Cmnd_Alias VAGRANT_EXPORTS_ADD = /usr/bin/su root -c echo '*' >> /etc/exports
+Cmnd_Alias VAGRANT_NFSD = /sbin/nfsd restart
+Cmnd_Alias VAGRANT_EXPORTS_REMOVE = /usr/bin/sed -e /*/ d -ibak /etc/exports
+%staff ALL=(root) NOPASSWD: VAGRANT_EXPORTS_ADD, VAGRANT_NFSD, VAGRANT_EXPORTS_REMOVE
+
+"""
+import subprocess
+import signal
+import os
+import os.path
+import time
+import sys
+
+
+def vagrant_up():
+    subprocess.call(['vagrant', 'up'])
+
+def vagrant_suspend(signum, frame):
+    subprocess.call(['vagrant', 'suspend'])
+    sys.exit()
+
+def wait():
+    signal.signal(signal.SIGTERM, vagrant_suspend)
+    try:
+        signal.pause()
+    except KeyboardInterrupt:
+        vagrant_suspend(None, None)
+
+
+if __name__ == '__main__':
+    fname = os.path.abspath(__file__)
+    parent = os.path.dirname(os.path.dirname(os.path.dirname(fname)))
+    os.chdir(parent)
+
+    vagrant_up()
+
+    wait()

--- a/scripts/vagrant_monitor.py
+++ b/scripts/vagrant_monitor.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python
 """
-Automatically start and stop your vagrant instance.
+Automatically start and stop your vagrant instance on OS X (tested on 10.9).
 
-Copy vagrantmonitor.plist to ~/Library/LaunchAgents/ and edit it to point to
-the path to this script. Then reboot or "launchctl load ~/Library/LaunchAgents/vagrantmonitor.plist"
+
+Copy vagrantmonitor.plist to ~/Library/LaunchAgents/ and replace PATH_TO to
+the absolute path to the edx-platform parent directory.
+Then reboot or "launchctl load ~/Library/LaunchAgents/vagrantmonitor.plist"
 On logout, this script will suspend the vagrant instance.
 
 In order for vagrant to add shared folders without prompting for a password,

--- a/scripts/vagrantmonitor.plist
+++ b/scripts/vagrantmonitor.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>vagrant-sleep</string>
+  <key>ProgramArguments</key>
+  <array>
+	<string>PATH_TO/edx-platform/scripts/vagrant_monitor.py</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+</dict>
+</plist>


### PR DESCRIPTION
Copy (and edit) vagrantmonitor.plist to ~/Library/LaunchAgents/
Add the commented section of vagrant_monitor.py to /etc/sudoers

`vagrant up` will run on login, and `vagrant suspend` will run on logout.

@jzoldak @singingwolfboy 
