### PR TITLE
Feature/fmo/multipart email

### DIFF
--- a/common/djangoapps/mail/__init__.py
+++ b/common/djangoapps/mail/__init__.py
@@ -1,0 +1,29 @@
+from django.core.mail import get_connection
+from django.core.mail.message import EmailMultiAlternatives
+
+
+def send_mail(subject, message, from_email, recipient_list,
+              fail_silently=False, auth_user=None, auth_password=None,
+              connection=None, html_message=None):
+    """
+    Note: this method is a copy of the django.core.mail.send_mail in v 1.7,
+    which adds the html_message option.
+
+    Easy wrapper for sending a single message to a recipient list. All members
+    of the recipient list will see the other recipients in the 'To' field.
+
+    If auth_user is None, the EMAIL_HOST_USER setting is used.
+    If auth_password is None, the EMAIL_HOST_PASSWORD setting is used.
+
+    Note: The API for this method is frozen. New code wanting to extend the
+    functionality should use the EmailMessage class directly.
+    """
+    connection = connection or get_connection(username=auth_user,
+                                    password=auth_password,
+                                    fail_silently=fail_silently)
+    mail = EmailMultiAlternatives(subject, message, from_email, recipient_list,
+                                  connection=connection)
+    if html_message:
+        mail.attach_alternative(html_message, 'text/html')
+
+    return mail.send()

--- a/common/djangoapps/mail/__init__.py
+++ b/common/djangoapps/mail/__init__.py
@@ -1,3 +1,6 @@
+"""
+Port of `send_mail` from Django 1.7.
+"""
 from django.core.mail import get_connection
 from django.core.mail.message import EmailMultiAlternatives
 
@@ -19,8 +22,8 @@ def send_mail(subject, message, from_email, recipient_list,
     functionality should use the EmailMessage class directly.
     """
     connection = connection or get_connection(username=auth_user,
-                                    password=auth_password,
-                                    fail_silently=fail_silently)
+                                              password=auth_password,
+                                              fail_silently=fail_silently)
     mail = EmailMultiAlternatives(subject, message, from_email, recipient_list,
                                   connection=connection)
     if html_message:

--- a/common/djangoapps/student/forms.py
+++ b/common/djangoapps/student/forms.py
@@ -8,6 +8,7 @@ from django.contrib.auth.models import User
 from django.contrib.auth.forms import PasswordResetForm
 from django.contrib.auth.hashers import UNUSABLE_PASSWORD
 from django.contrib.auth.tokens import default_token_generator
+from django.contrib.sites.models import get_current_site
 
 from edxmako.shortcuts import render_to_string
 

--- a/common/djangoapps/student/forms.py
+++ b/common/djangoapps/student/forms.py
@@ -1,10 +1,15 @@
-"""
+﻿"""
 Utility functions for validating forms
 """
 from django import forms
+from django.template import loader
+from django.utils.http import int_to_base36
 from django.contrib.auth.models import User
 from django.contrib.auth.forms import PasswordResetForm
 from django.contrib.auth.hashers import UNUSABLE_PASSWORD
+from django.contrib.auth.tokens import default_token_generator
+
+from edxmako.shortcuts import render_to_string
 
 
 class PasswordResetFormNoActive(PasswordResetForm):
@@ -23,3 +28,41 @@ class PasswordResetFormNoActive(PasswordResetForm):
                for user in self.users_cache):
             raise forms.ValidationError(self.error_messages['unusable'])
         return email
+    def save(self, domain_override=None,
+             subject_template_name='registration/password_reset_subject.txt',
+             email_template_name='registration/password_reset_email.html',
+             html_email_template_name='registration/password_reset_email_html.html',
+             use_https=False, token_generator=default_token_generator,
+             from_email=None, request=None):
+        """
+        This is a copy from Django 1.4.5's django.contrib.auth.forms.PasswordResetForm
+        Except it adds support for multipart email
+        Generates a one-use only link for resetting password and sends to the
+        user.
+        """
+        from mail import send_mail
+        from django.conf import settings
+        for user in self.users_cache:
+            if not domain_override:
+                current_site = get_current_site(request)
+                site_name = current_site.name
+                domain = current_site.domain
+            else:
+                site_name = domain = domain_override
+            c = {
+                'email': user.email,
+                'domain': domain,
+                'site_name': site_name,
+                'uid': int_to_base36(user.id),
+                'user': user,
+                'token': token_generator.make_token(user),
+                'protocol': use_https and 'https' or 'http',
+            }
+            subject = loader.render_to_string(subject_template_name, c)
+            # Email subject *must not* contain newlines
+            subject = ''.join(subject.splitlines())
+            email = loader.render_to_string(email_template_name, c)
+            email_html = None
+            if (settings.FEATURES.get('ENABLE_MULTIPART_EMAIL')):
+                email_html = render_to_string(html_email_template_name, c)
+            send_mail(subject, email, from_email, [user.email], html_message=email_html)

--- a/common/djangoapps/student/forms.py
+++ b/common/djangoapps/student/forms.py
@@ -30,6 +30,7 @@ class PasswordResetFormNoActive(PasswordResetForm):
             raise forms.ValidationError(self.error_messages['unusable'])
         return email
 
+    # pylint: disable=W0221
     def save(self, domain_override=None,
              subject_template_name='registration/password_reset_subject.txt',
              email_template_name='registration/password_reset_email.html',

--- a/common/djangoapps/student/forms.py
+++ b/common/djangoapps/student/forms.py
@@ -28,6 +28,7 @@ class PasswordResetFormNoActive(PasswordResetForm):
                for user in self.users_cache):
             raise forms.ValidationError(self.error_messages['unusable'])
         return email
+
     def save(self, domain_override=None,
              subject_template_name='registration/password_reset_subject.txt',
              email_template_name='registration/password_reset_email.html',
@@ -49,7 +50,7 @@ class PasswordResetFormNoActive(PasswordResetForm):
                 domain = current_site.domain
             else:
                 site_name = domain = domain_override
-            c = {
+            context = {
                 'email': user.email,
                 'domain': domain,
                 'site_name': site_name,
@@ -58,11 +59,11 @@ class PasswordResetFormNoActive(PasswordResetForm):
                 'token': token_generator.make_token(user),
                 'protocol': use_https and 'https' or 'http',
             }
-            subject = loader.render_to_string(subject_template_name, c)
+            subject = loader.render_to_string(subject_template_name, context)
             # Email subject *must not* contain newlines
             subject = ''.join(subject.splitlines())
-            email = loader.render_to_string(email_template_name, c)
+            email = loader.render_to_string(email_template_name, context)
             email_html = None
             if (settings.FEATURES.get('ENABLE_MULTIPART_EMAIL')):
-                email_html = render_to_string(html_email_template_name, c)
+                email_html = render_to_string(html_email_template_name, context)
             send_mail(subject, email, from_email, [user.email], html_message=email_html)

--- a/common/djangoapps/student/tests/test_create_account.py
+++ b/common/djangoapps/student/tests/test_create_account.py
@@ -71,7 +71,7 @@ class TestCreateAccount(TestCase):
         request.user = AnonymousUser()
 
         mako_middleware_process_request(request)
-        with mock.patch('django.contrib.auth.models.User.email_user') as mock_send_mail:
+        with mock.patch('student.views.send_mail') as mock_send_mail:
             student.views.create_account(request)
 
         # check that send_mail is called

--- a/common/djangoapps/student/tests/test_email.py
+++ b/common/djangoapps/student/tests/test_email.py
@@ -115,7 +115,7 @@ class ReactivationEmailTests(EmailTestMixin, TestCase):
         self.assertReactivateEmailSent(send_mail)
         self.assertFalse(response_data['success'])
 
-    def test_reactivation_for_unregistered_user(self, send_mail):
+    def test_reactivation_for_unregistered_user(self, __):
         """
         Test that trying to send a reactivation email to an unregistered
         user fails without throwing a 500 error.

--- a/common/djangoapps/student/tests/test_reset_password.py
+++ b/common/djangoapps/student/tests/test_reset_password.py
@@ -1,4 +1,4 @@
-"""
+﻿"""
 Test the various password reset flows
 """
 import json
@@ -90,7 +90,7 @@ class ResetPasswordTests(TestCase):
         cache.clear()
 
     @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', "Test only valid in LMS")
-    @patch('django.core.mail.send_mail')
+    @patch('mail.send_mail')
     @patch('student.views.render_to_string', Mock(side_effect=mock_render_to_string, autospec=True))
     def test_reset_password_email(self, send_email):
         """Tests contents of reset password email, and that user is not active"""

--- a/common/djangoapps/student/tests/test_reset_password.py
+++ b/common/djangoapps/student/tests/test_reset_password.py
@@ -117,7 +117,7 @@ class ResetPasswordTests(TestCase):
         re.search(r'password_reset_confirm/(?P<uidb36>[0-9A-Za-z]+)-(?P<token>.+)/', msg).groupdict()
 
     @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', "Test only valid in LMS")
-    @patch('django.core.mail.send_mail')
+    @patch('mail.send_mail')
     @ddt.data((False, 'http://'), (True, 'https://'))
     @ddt.unpack
     def test_reset_password_email_https(self, is_secure, protocol, send_email):

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1929,12 +1929,12 @@ def reactivation_email_for_user(user):
     message = render_to_string('emails/activation_email.txt', context)
     message_html = None
     if (settings.FEATURES.get('ENABLE_MULTIPART_EMAIL')):
-        message_html = render_to_string('emails/html/activation_email.html', d)
+        message_html = render_to_string('emails/html/activation_email.html', context)
 
     from_address = microsite.get_value(
-            'email_from_address',
-            settings.DEFAULT_FROM_EMAIL
-        )
+        'email_from_address',
+        settings.DEFAULT_FROM_EMAIL
+    )
 
     try:
         send_mail(subject, message, from_address, [user.email], html_message=message_html)

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1931,7 +1931,7 @@ def reactivation_email_for_user(user):
     if (settings.FEATURES.get('ENABLE_MULTIPART_EMAIL')):
         message_html = render_to_string('emails/html/activation_email.html', d)
 
-    from_address = MicrositeConfiguration.get_microsite_configuration_value(
+    from_address = microsite.get_value(
             'email_from_address',
             settings.DEFAULT_FROM_EMAIL
         )
@@ -2062,7 +2062,7 @@ def confirm_email_change(request, key):  # pylint: disable=unused-argument
         message_html = None
         if (settings.FEATURES.get('ENABLE_MULTIPART_EMAIL')):
             message_html = render_to_string('emails/html/confirm_email_change.html', address_context)
-        from_address = MicrositeConfiguration.get_microsite_configuration_value(
+        from_address = microsite.get_value(
             'email_from_address',
             settings.DEFAULT_FROM_EMAIL
         )

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1,4 +1,4 @@
-"""
+﻿"""
 Student Views
 """
 import datetime
@@ -17,7 +17,7 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.auth.views import password_reset_confirm
 from django.contrib import messages
 from django.core.context_processors import csrf
-from django.core.mail import send_mail
+from mail import send_mail
 from django.core.urlresolvers import reverse
 from django.core.validators import validate_email, validate_slug, ValidationError
 from django.db import IntegrityError, transaction
@@ -1577,6 +1577,9 @@ def create_account(request, post_override=None):  # pylint: disable-msg=too-many
     # Email subject *must not* contain newlines
     subject = ''.join(subject.splitlines())
     message = render_to_string('emails/activation_email.txt', context)
+    message_html = None
+    if (settings.FEATURES.get('ENABLE_MULTIPART_EMAIL')):
+        message_html = render_to_string('emails/html/activation_email.html', context)
 
     # don't send email if we are doing load testing or random user generation for some reason
     # or external auth with bypass activated
@@ -1596,7 +1599,7 @@ def create_account(request, post_override=None):  # pylint: disable-msg=too-many
                            '-' * 80 + '\n\n' + message)
                 send_mail(subject, message, from_address, [dest_addr], fail_silently=False)
             else:
-                user.email_user(subject, message, from_address)
+                send_mail(subject, message, from_address, [user.email], html_message=message_html)
         except Exception:  # pylint: disable=broad-except
             log.error('Unable to send activation email to user from "{from_address}"'.format(from_address=from_address), exc_info=True)
             js['value'] = _('Could not send activation e-mail.')
@@ -1924,9 +1927,17 @@ def reactivation_email_for_user(user):
     subject = render_to_string('emails/activation_email_subject.txt', context)
     subject = ''.join(subject.splitlines())
     message = render_to_string('emails/activation_email.txt', context)
+    message_html = None
+    if (settings.FEATURES.get('ENABLE_MULTIPART_EMAIL')):
+        message_html = render_to_string('emails/html/activation_email.html', d)
+
+    from_address = MicrositeConfiguration.get_microsite_configuration_value(
+            'email_from_address',
+            settings.DEFAULT_FROM_EMAIL
+        )
 
     try:
-        user.email_user(subject, message, settings.DEFAULT_FROM_EMAIL)
+        send_mail(subject, message, from_address, [user.email], html_message=message_html)
     except Exception:  # pylint: disable=broad-except
         log.error('Unable to send reactivation email from "{from_address}"'.format(from_address=settings.DEFAULT_FROM_EMAIL), exc_info=True)
         return JsonResponse({
@@ -1997,13 +2008,16 @@ def change_email_request(request):
     subject = ''.join(subject.splitlines())
 
     message = render_to_string('emails/email_change.txt', context)
+    message_html = None
+    if (settings.FEATURES.get('ENABLE_MULTIPART_EMAIL')):
+        message_html = render_to_string('emails/html/email_change.html', context)
 
     from_address = microsite.get_value(
         'email_from_address',
         settings.DEFAULT_FROM_EMAIL
     )
     try:
-        send_mail(subject, message, from_address, [pec.new_email])
+        send_mail(subject, message, from_address, [pec.new_email], html_message=message_html)
     except Exception:  # pylint: disable=broad-except
         log.error('Unable to send email activation link to user from "{from_address}"'.format(from_address=from_address), exc_info=True)
         return JsonResponse({
@@ -2045,6 +2059,13 @@ def confirm_email_change(request, key):  # pylint: disable=unused-argument
         message = render_to_string('emails/confirm_email_change.txt', address_context)
         u_prof = UserProfile.objects.get(user=user)
         meta = u_prof.get_meta()
+        message_html = None
+        if (settings.FEATURES.get('ENABLE_MULTIPART_EMAIL')):
+            message_html = render_to_string('emails/html/confirm_email_change.html', address_context)
+        from_address = MicrositeConfiguration.get_microsite_configuration_value(
+            'email_from_address',
+            settings.DEFAULT_FROM_EMAIL
+        )
         if 'old_emails' not in meta:
             meta['old_emails'] = []
         meta['old_emails'].append([user.email, datetime.datetime.now(UTC).isoformat()])
@@ -2052,7 +2073,7 @@ def confirm_email_change(request, key):  # pylint: disable=unused-argument
         u_prof.save()
         # Send it to the old email...
         try:
-            user.email_user(subject, message, settings.DEFAULT_FROM_EMAIL)
+            send_mail(subject, message, from_address, [user.email], html_message=message_html)
         except Exception:    # pylint: disable=broad-except
             log.warning('Unable to send confirmation email to old address', exc_info=True)
             response = render_to_response("email_change_failed.html", {'email': user.email})
@@ -2064,7 +2085,7 @@ def confirm_email_change(request, key):  # pylint: disable=unused-argument
         pec.delete()
         # And send it to the new email...
         try:
-            user.email_user(subject, message, settings.DEFAULT_FROM_EMAIL)
+            send_mail(subject, message, from_address, [user.email], html_message=message_html)
         except Exception:  # pylint: disable=broad-except
             log.warning('Unable to send confirmation email to new address', exc_info=True)
             response = render_to_response("email_change_failed.html", {'email': pec.new_email})

--- a/lms/djangoapps/instructor/enrollment.py
+++ b/lms/djangoapps/instructor/enrollment.py
@@ -339,7 +339,8 @@ def send_mail_to_student(student, param_dict):
         ),
         'account_creation_and_enrollment': (
             'emails/enroll_email_enrolledsubject.txt',
-            'emails/account_creation_and_enroll_emailMessage.txt'
+            'emails/account_creation_and_enroll_emailMessage.txt',
+            'emails/html/account_creation_and_enroll_emailMessage.html'
         ),
     }
 

--- a/lms/djangoapps/instructor/enrollment.py
+++ b/lms/djangoapps/instructor/enrollment.py
@@ -348,6 +348,7 @@ def send_mail_to_student(student, param_dict):
         subject = render_to_string(subject_template, param_dict)
         message = render_to_string(message_template, param_dict)
 
+    message_html = None
     if (settings.FEATURES.get('ENABLE_MULTIPART_EMAIL')):
         message_html = render_to_string(html_template, param_dict)
 

--- a/lms/djangoapps/instructor/enrollment.py
+++ b/lms/djangoapps/instructor/enrollment.py
@@ -8,7 +8,7 @@ import json
 from django.contrib.auth.models import User
 from django.conf import settings
 from django.core.urlresolvers import reverse
-from django.core.mail import send_mail
+from mail import send_mail
 
 from student.models import CourseEnrollment, CourseEnrollmentAllowed
 from courseware.models import StudentModule
@@ -309,27 +309,33 @@ def send_mail_to_student(student, param_dict):
     email_template_dict = {
         'allowed_enroll': (
             'emails/enroll_email_allowedsubject.txt',
-            'emails/enroll_email_allowedmessage.txt'
+            'emails/enroll_email_allowedmessage.txt',
+            'emails/html/enroll_email_allowedmessage.html'
         ),
         'enrolled_enroll': (
             'emails/enroll_email_enrolledsubject.txt',
-            'emails/enroll_email_enrolledmessage.txt'
+            'emails/enroll_email_enrolledmessage.txt',
+            'emails/html/enroll_email_enrolledmessage.html'
         ),
         'allowed_unenroll': (
             'emails/unenroll_email_subject.txt',
-            'emails/unenroll_email_allowedmessage.txt'
+            'emails/unenroll_email_allowedmessage.txt',
+            'emails/html/unenroll_email_allowedmessage.html'
         ),
         'enrolled_unenroll': (
             'emails/unenroll_email_subject.txt',
-            'emails/unenroll_email_enrolledmessage.txt'
+            'emails/unenroll_email_enrolledmessage.txt',
+            'emails/html/unenroll_email_enrolledmessage.html'
         ),
         'add_beta_tester': (
             'emails/add_beta_tester_email_subject.txt',
-            'emails/add_beta_tester_email_message.txt'
+            'emails/add_beta_tester_email_message.txt',
+            'emails/html/add_beta_tester_email_message.html'
         ),
         'remove_beta_tester': (
             'emails/remove_beta_tester_email_subject.txt',
-            'emails/remove_beta_tester_email_message.txt'
+            'emails/remove_beta_tester_email_message.txt',
+            'emails/html/remove_beta_tester_email_message.html'
         ),
         'account_creation_and_enrollment': (
             'emails/enroll_email_enrolledsubject.txt',
@@ -337,10 +343,13 @@ def send_mail_to_student(student, param_dict):
         ),
     }
 
-    subject_template, message_template = email_template_dict.get(message_type, (None, None))
+    subject_template, message_template, html_template = email_template_dict.get(message_type, (None, None, None))
     if subject_template is not None and message_template is not None:
         subject = render_to_string(subject_template, param_dict)
         message = render_to_string(message_template, param_dict)
+
+    if (settings.FEATURES.get('ENABLE_MULTIPART_EMAIL')):
+        message_html = render_to_string(html_template, param_dict)
 
     if subject and message:
         # Remove leading and trailing whitespace from body
@@ -353,7 +362,8 @@ def send_mail_to_student(student, param_dict):
             settings.DEFAULT_FROM_EMAIL
         )
 
-        send_mail(subject, message, from_address, [student], fail_silently=False)
+        send_mail(subject, message, from_address, [student], fail_silently=False, html_message=message_html)
+
 
 
 def uses_shib(course):

--- a/lms/djangoapps/instructor/views/legacy.py
+++ b/lms/djangoapps/instructor/views/legacy.py
@@ -1678,6 +1678,7 @@ def send_mail_to_student(student, param_dict):
         subject = render_to_string(subject_template, param_dict)
         message = render_to_string(message_template, param_dict)
 
+    message_html = None
     if (settings.FEATURES.get('ENABLE_MULTIPART_EMAIL')):
         message_html = render_to_string(html_template, param_dict)
 

--- a/lms/djangoapps/instructor/views/legacy.py
+++ b/lms/djangoapps/instructor/views/legacy.py
@@ -24,7 +24,7 @@ from django.http import HttpResponse
 from django_future.csrf import ensure_csrf_cookie
 from django.views.decorators.cache import cache_control
 from django.core.urlresolvers import reverse
-from django.core.mail import send_mail
+from mail import send_mail
 from django.utils import timezone
 
 from xmodule_modifiers import wrap_xblock, request_token
@@ -1667,16 +1667,19 @@ def send_mail_to_student(student, param_dict):
     message_type = param_dict['message']
 
     email_template_dict = {
-        'allowed_enroll': ('emails/enroll_email_allowedsubject.txt', 'emails/enroll_email_allowedmessage.txt'),
-        'enrolled_enroll': ('emails/enroll_email_enrolledsubject.txt', 'emails/enroll_email_enrolledmessage.txt'),
-        'allowed_unenroll': ('emails/unenroll_email_subject.txt', 'emails/unenroll_email_allowedmessage.txt'),
-        'enrolled_unenroll': ('emails/unenroll_email_subject.txt', 'emails/unenroll_email_enrolledmessage.txt'),
+        'allowed_enroll': ('emails/enroll_email_allowedsubject.txt', 'emails/enroll_email_allowedmessage.txt', 'emails/html/enroll_email_allowedmessage.html'),
+        'enrolled_enroll': ('emails/enroll_email_enrolledsubject.txt', 'emails/enroll_email_enrolledmessage.txt', 'emails/html/enroll_email_enrolledmessage.html'),
+        'allowed_unenroll': ('emails/unenroll_email_subject.txt', 'emails/unenroll_email_allowedmessage.txt', 'emails/html/unenroll_email_allowedmessage.html'),
+        'enrolled_unenroll': ('emails/unenroll_email_subject.txt', 'emails/unenroll_email_enrolledmessage.txt', 'emails/html/unenroll_email_enrolledmessage.html'),
     }
 
-    subject_template, message_template = email_template_dict.get(message_type, (None, None))
+    subject_template, message_template, html_template = email_template_dict.get(message_type, (None, None, None))
     if subject_template is not None and message_template is not None:
         subject = render_to_string(subject_template, param_dict)
         message = render_to_string(message_template, param_dict)
+
+    if (settings.FEATURES.get('ENABLE_MULTIPART_EMAIL')):
+        message_html = render_to_string(html_template, param_dict)
 
     if subject and message:
         # Remove leading and trailing whitespace from body
@@ -1689,7 +1692,7 @@ def send_mail_to_student(student, param_dict):
             settings.DEFAULT_FROM_EMAIL
         )
 
-        send_mail(subject, message, from_address, [student], fail_silently=False)
+        send_mail(subject, message, from_address, [student], fail_silently=False, html_message=message_html)
 
         return True
     else:

--- a/lms/djangoapps/shoppingcart/models.py
+++ b/lms/djangoapps/shoppingcart/models.py
@@ -22,7 +22,7 @@ from django.db.models import Sum
 from django.core.urlresolvers import reverse
 from model_utils.managers import InheritanceManager
 from model_utils.models import TimeStampedModel
-from django.core.mail.message import EmailMessage
+from django.core.mail.message import EmailMultiAlternatives
 
 from xmodule.modulestore.django import modulestore
 
@@ -314,7 +314,7 @@ class Order(models.Model):
                         'payment_email_signature': microsite.get_value('payment_email_signature'),
                     }
                 )
-                email = EmailMessage(
+                email = EmailMultiAlternatives(
                     subject=subject,
                     body=message,
                     from_email=from_address,
@@ -325,6 +325,25 @@ class Order(models.Model):
                 # the single seat is simple text
                 if is_order_type_business:
                     email.content_subtype = "html"
+                elif (settings.FEATURES.get('ENABLE_MULTIPART_EMAIL')):
+                    message_html = render_to_string(
+                        'emails/html/order_confirmation_email.html',
+                        {
+                            'order': self,
+                            'recipient_name': recipient[0],
+                            'recipient_type': recipient[2],
+                            'site_name': site_name,
+                            'order_items': orderitems,
+                            'course_names': ", ".join([course_info[0] for course_info in courses_info]),
+                            'dashboard_url': dashboard_url,
+                            'order_placed_by': '{username} ({email})'.format(username=self.user.username, email=getattr(self.user, 'email')),  # pylint: disable=E1101
+                            'has_billing_info': settings.FEATURES['STORE_BILLING_INFO'],
+                            'platform_name': microsite.get_value('platform_name', settings.PLATFORM_NAME),
+                            'payment_support_email': microsite.get_value('payment_support_email', settings.PAYMENT_SUPPORT_EMAIL),
+                            'payment_email_signature': microsite.get_value('payment_email_signature'),
+                        }
+                    )
+                    email.attach_alternative(message_html, 'text/html')
 
                 if csv_file:
                     email.attach(u'RegistrationCodesRedemptionUrls.csv', csv_file.getvalue(), 'text/csv')

--- a/lms/djangoapps/shoppingcart/tests/test_models.py
+++ b/lms/djangoapps/shoppingcart/tests/test_models.py
@@ -191,7 +191,7 @@ class OrderTest(ModuleStoreTestCase):
     def test_purchase_item_email_smtp_failure(self, error_logger):
         cart = Order.get_cart_for_user(user=self.user)
         CertificateItem.add_to_order(cart, self.course_key, self.cost, 'honor')
-        with patch('shoppingcart.models.EmailMessage.send', side_effect=smtplib.SMTPException):
+        with patch('shoppingcart.models.EmailMultiAlternatives.send', side_effect=smtplib.SMTPException):
             cart.purchase()
             self.assertTrue(error_logger.called)
 

--- a/lms/templates/emails/html/account_creation_and_enroll_emailMessage.html
+++ b/lms/templates/emails/html/account_creation_and_enroll_emailMessage.html
@@ -1,0 +1,30 @@
+<%! from microsite_configuration.middleware import microsite %>
+<%! from django.utils.translation import ugettext as _ %>
+<%inherit file="one_call_to_action.html" />
+
+<%block name="title">
+  ${_("Welcome to {course_name}").format(course_name=course.display_name_with_default)}
+</%block>
+
+<%block name="msg_header">
+  ${_("Welcome to {course_name}").format(course_name=course.display_name_with_default)}
+  <br/>
+</%block>
+
+<%block name="msg_content" >
+  ${_("To get started, please visit https://{site_name}. The login information for your account follows.").format(site_name=site_name)}
+  <br/>
+</%block>
+
+<%block name="msg_content_2" >
+  ${_("email: {email}").format(email=email_address)}
+  ${_("password: {password}").format(password=password)}
+  <br/>
+  ${_("It is recommended that you change your password.")}
+  <br/>
+</%block>
+
+<%block name="call_to_action_href">https://${ site }% endif</%block>
+
+<%block name="call_to_action_label">${_("Go to {site_name}").format(site_name=site_name)}</%block>
+

--- a/lms/templates/emails/html/activation_email.html
+++ b/lms/templates/emails/html/activation_email.html
@@ -1,0 +1,27 @@
+<%! from microsite_configuration.middleware import microsite %>
+<%! from django.utils.translation import ugettext as _ %>
+<%inherit file="one_call_to_action.html" />
+
+<%block name="title">
+${_("Account activation")}
+</%block>
+
+<%block name="msg_header">
+${_("Thank you for signing up for {platform_name}!").format(
+    platform_name=microsite.get_value(
+        'platform_name',
+        settings.PLATFORM_NAME
+    )
+  )
+}
+<br/>
+</%block>
+
+<%block name="msg_content" >
+${_("To activate your account, use the button below.")}
+<br/>
+</%block>
+
+<%block name="call_to_action_href">http://${ site }/activate/${ key }</%block>
+
+<%block name="call_to_action_label">${_("Activate my account")}</%block>

--- a/lms/templates/emails/html/add_beta_tester_email_message.html
+++ b/lms/templates/emails/html/add_beta_tester_email_message.html
@@ -1,0 +1,28 @@
+<%! from django.core.urlresolvers import reverse %>
+<%! from django.utils.translation import ugettext as _ %>
+<%inherit file="one_call_to_action.html" />
+
+<%block name="title">
+${_("Beta tester")}
+</%block>
+
+<%block name="msg_header">
+${_("Dear {full_name}").format(full_name=full_name)}
+</%block>
+
+<%block name="msg_content" >
+${_("You have been invited to be a beta tester for {course_name} at {site_name} by a "
+  "member of the course staff.").format(
+    course_name=course.display_name_with_default,
+    site_name=site_name
+  )}
+<br/>
+</%block>
+
+% if course_about_url is not None:
+<%block name="call_to_action_href">${course_about_url}</%block>
+<%block name="call_to_action_label">${_("Join the course")}</%block>
+% else:
+<%block name="call_to_action_href">${site_name}</%block>
+<%block name="call_to_action_label">${_("Enroll in the course")}</%block>
+% endif

--- a/lms/templates/emails/html/add_beta_tester_email_message.html
+++ b/lms/templates/emails/html/add_beta_tester_email_message.html
@@ -19,10 +19,17 @@ ${_("You have been invited to be a beta tester for {course_name} at {site_name} 
 <br/>
 </%block>
 
+<%block name="call_to_action_href">
 % if course_about_url is not None:
-<%block name="call_to_action_href">${course_about_url}</%block>
-<%block name="call_to_action_label">${_("Join the course")}</%block>
+  ${course_about_url}
 % else:
-<%block name="call_to_action_href">${site_name}</%block>
-<%block name="call_to_action_label">${_("Enroll in the course")}</%block>
+  ${site_name}
 % endif
+</%block>
+<%block name="call_to_action_label">
+% if course_about_url is not None:
+  ${_("Join the course")}
+% else:
+  ${_("Enroll in the course")}
+% endif
+</%block>

--- a/lms/templates/emails/html/confirm_email_change.html
+++ b/lms/templates/emails/html/confirm_email_change.html
@@ -1,0 +1,36 @@
+<%! from django.core.urlresolvers import reverse %>
+<%! from django.utils.translation import ugettext as _ %>
+<%namespace file="../../main.html" import="stanford_theme_enabled" />
+## Again, ugly hack that needs to be changed
+<%inherit file="one_content_box.html" />
+
+<%block name="title">
+${_("Email change")}
+</%block>
+
+<%block name="msg_header">
+${_("Email change")}
+<br/>
+</%block>
+
+<%block name="msg_content" >
+${_("This is to confirm that you changed the e-mail associated with "
+      "{platform_name} from {old_email} to {new_email}. If you "
+      "did not make this request, please contact us immediately. Contact "
+      "information is listed at:").format(platform_name=settings.PLATFORM_NAME, old_email=old_email, new_email=new_email)}
+<br/>
+<br/>
+% if stanford_theme_enabled():
+ ${settings.CONTACT_EMAIL}
+ % else:
+   % if is_secure:
+    https://${ site }${reverse('contact')}
+  % else:
+    http://${ site }${reverse('contact')}
+  % endif
+% endif
+<br/>
+<br/>
+${_("We keep a log of old e-mails, so if this request was unintentional, we "
+    "can investigate.")}
+</%block>

--- a/lms/templates/emails/html/email_change.html
+++ b/lms/templates/emails/html/email_change.html
@@ -29,11 +29,13 @@ ${_("We received a request to change the e-mail associated with your "
 
 </%block>
 
+<%block name="call_to_action_href">
 % if is_secure:
-<%block name="call_to_action_href">https://${ site }/email_confirm/${ key }</%block>
+https://${ site }/email_confirm/${ key }
 % else:
-<%block name="call_to_action_href">http://${ site }/email_confirm/${ key }</%block>
+http://${ site }/email_confirm/${ key }
 % endif
+</%block>
 
 <%block name="call_to_action_label">${_("Confirm change")}</%block>
 

--- a/lms/templates/emails/html/email_change.html
+++ b/lms/templates/emails/html/email_change.html
@@ -1,0 +1,41 @@
+<%! from django.utils.translation import ugettext as _ %>
+<%! from microsite_configuration.middleware import microsite %>
+
+<%namespace file="../../main.html" import="stanford_theme_enabled" />
+<%inherit file="one_call_to_action.html" />
+
+<%block name="title">
+  ${_("Request to change email")}
+</%block>
+
+<%block name="msg_header">
+  ${_("Email change")}
+<br/>
+</%block>
+
+<%block name="msg_content" >
+${_("We received a request to change the e-mail associated with your "
+    "{platform_name} account from {old_email} to {new_email}. "
+    "If this is correct, please confirm your new e-mail address using "
+    "the button below:").format(
+      platform_name=microsite.get_value(
+          'platform_name',
+          settings.PLATFORM_NAME
+      ),
+      old_email=old_email,
+      new_email=new_email
+    )
+  }
+
+</%block>
+
+% if is_secure:
+<%block name="call_to_action_href">https://${ site }/email_confirm/${ key }</%block>
+% else:
+<%block name="call_to_action_href">http://${ site }/email_confirm/${ key }</%block>
+% endif
+
+<%block name="call_to_action_label">${_("Confirm change")}</%block>
+
+
+

--- a/lms/templates/emails/html/enroll_email_allowedmessage.html
+++ b/lms/templates/emails/html/enroll_email_allowedmessage.html
@@ -1,0 +1,45 @@
+<%inherit file="one_content_box.html" />
+<%! from django.utils.translation import ugettext as _ %>
+
+<%block name="msg_header">
+  ${_("Dear student,")}
+</%block>
+
+<%block name="msg_content" >
+  ${_("You have been invited to join {course_name} at {site_name} by a "
+    "member of the course staff.").format(
+      course_name=course.display_name_with_default,
+      site_name=site_name
+    )}
+  <br/>
+% if is_shib_course:
+% if auto_enroll:
+
+${_("To access the course visit {course_url} and login.").format(course_url=course_url)}
+% elif course_about_url is not None:
+
+${_("To access the course visit {course_about_url} and register for the course.").format(
+    course_about_url=course_about_url)}
+% endif
+% else:
+
+${_("To finish your registration, please visit {registration_url} and fill "
+  "out the registration form making sure to use {email_address} in the E-mail field.").format(
+    registration_url=registration_url,
+    email_address=email_address
+  )}
+% if auto_enroll:
+${_("Once you have registered and activated your account, you will see "
+  "{course_name} listed on your dashboard.").format(
+    course_name=course.display_name_with_default
+  )}
+% elif course_about_url is not None:
+${_("Once you have registered and activated your account, visit {course_about_url} "
+  "to join the course.").format(course_about_url=course_about_url)}
+% else:
+${_("You can then enroll in {course_name}.").format(course_name=course.display_name_with_default)}
+% endif
+% endif
+</%block>
+
+

--- a/lms/templates/emails/html/enroll_email_enrolledmessage.html
+++ b/lms/templates/emails/html/enroll_email_enrolledmessage.html
@@ -1,0 +1,26 @@
+<%inherit file="one_call_to_action.html" />
+<%! from django.utils.translation import ugettext as _ %>
+
+<%block name="title"></%block>
+
+<%block name="msg_header">
+  ${_("Dear {full_name}").format(full_name=full_name)}
+  <br/>
+</%block>
+
+<%block name="msg_content" >
+  ${_("You have been enrolled in {course_name} at {site_name} by a member "
+    "of the course staff. The course should now appear on your {site_name} "
+    "dashboard.").format(
+      course_name=course.display_name_with_default,
+      site_name=site_name
+    )}
+  <br/>
+  ${_("To start accessing course materials, please visit {course_url} or use the button below.").format(
+      course_url=course_url
+    )}
+</%block>
+
+<%block name="call_to_action_href">${ course_url }</%block>
+
+<%block name="call_to_action_label">${_("Take me there")}</%block>

--- a/lms/templates/emails/html/footer_content.html
+++ b/lms/templates/emails/html/footer_content.html
@@ -1,0 +1,15 @@
+<%! from microsite_configuration.middleware import microsite %>
+<em>Copyright © 2013 edX, All rights reserved.</em><br>
+<br>
+<br>
+  <b>Our mailing address is:</b><br>
+  edX<br>
+  11 Cambridge Center, Suite 101<br>
+  Cambridge, MA, USA 02142<br>
+<br>
+<br>
+This email was automatically sent from ${microsite.get_value(
+        'platform_name',
+        settings.PLATFORM_NAME
+    )
+  }. <br>

--- a/lms/templates/emails/html/header_content.html
+++ b/lms/templates/emails/html/header_content.html
@@ -1,0 +1,3 @@
+<a href='http://edx.org' title='' class='' target='_self' style='word-wrap: break-word !important;'>
+<img align='left' alt='edX' src='http://courses.edx.org/static/images/bulk_email/edXHeaderImage.jpg' width='564.0000152587891' style='max-width: 600px;padding-bottom: 0;display: inline !important;vertical-align: bottom;border: 0;line-height: 100%;outline: none;text-decoration: none;height: auto !important;' class='mcnImage'>
+</a>

--- a/lms/templates/emails/html/mc_base.html
+++ b/lms/templates/emails/html/mc_base.html
@@ -1,0 +1,216 @@
+<%! from microsite_configuration.middleware import microsite %>
+<%! from django.utils.translation import ugettext as _ %>
+<!DOCTYPE html PUBLIC '-//W3C//DTD XHTML 1.0 Transitional//EN' 'http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd'>
+<html xmlns:fb='http://www.facebook.com/2008/fbml' xmlns:og='http://opengraph.org/schema/'> <head>
+<meta property='og:title' content='Update from {course_title}'/>
+<meta property='fb:page_id' content='43929265776' />
+        <meta http-equiv='Content-Type' content='text/html; charset=UTF-8'>
+        <title><%block name="title">${_("Message from edX")}</%block></title>
+                    </head>
+        <body leftmargin='0' marginwidth='0' topmargin='0' marginheight='0' offset='0' style='margin: 0;padding: 0;background-color: #ffffff;'>
+        <center>
+            <table align='center' border='0' cellpadding='0' cellspacing='0' height='100%' width='100%' id='bodyTable' style='border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;margin: 0;padding: 0;background-color: #ffffff;height: 100% !important;width: 100% !important;'>
+                <tr>
+                   <td align='center' valign='top' id='bodyCell' style='border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;margin: 0;padding: 0;border-top: 0;height: 100% !important;width: 100% !important;'>
+                        <!-- BEGIN TEMPLATE // -->
+                        <table border='0' cellpadding='0' cellspacing='0' width='100%' style='border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;'>
+                            <tr>
+                                <td align='center' valign='top' style='border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;'>
+                                    <!-- BEGIN PREHEADER // -->
+                                    <table border='0' cellpadding='0' cellspacing='0' width='100%' id='templatePreheader' style='border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;background-color: #fcfcfc;border-top: 0;border-bottom: 0;'>
+                                        <tr>
+                                        	<td align='center' valign='top' style='border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;'>
+                                                <table border='0' cellpadding='0' cellspacing='0' width='600' class='templateContainer' style='border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;'>
+                                                    <tr>
+                                                        <td valign='top' class='preheaderContainer' style='padding-top: 9px;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;'><table border='0' cellpadding='0' cellspacing='0' width='100%' class='mcnTextBlock' style='border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;'>
+    <tbody class='mcnTextBlockOuter'>
+        <tr>
+            <td valign='top' class='mcnTextBlockInner' style='border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;'>
+
+                <table align='left' border='0' cellpadding='0' cellspacing='0' width='366' class='mcnTextContentContainer' style='border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;'>
+                    <tbody><tr>
+
+                        <td valign='top' class='mcnTextContent' style='padding-top: 9px;padding-left: 18px;padding-bottom: 9px;padding-right: 0;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;color: #606060;font-family: Helvetica;font-size: 11px;line-height: 125%;text-align: left;'>
+
+                            <br>
+
+                        </td>
+                    </tr>
+                </tbody></table>
+
+            </td>
+        </tr>
+    </tbody>
+</table></td>
+                                                    </tr>
+                                                </table>
+                                            </td>
+                                        </tr>
+                                    </table>
+                                    <!-- // END PREHEADER -->
+                                </td>
+                            </tr>
+                            <tr>
+                                <td align='center' valign='top' style='border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;'>
+                                    <!-- BEGIN HEADER // -->
+                                    <table border='0' cellpadding='0' cellspacing='0' width='100%' id='templateHeader' style='border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;background-color: #fcfcfc;border-top: 0;border-bottom: 0;'>
+                                        <tr>
+                                            <td align='center' valign='top' style='border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;'>
+                                                <table border='0' cellpadding='0' cellspacing='0' width='600' class='templateContainer' style='border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;'>
+                                                    <tr>
+                                                        <td valign='top' class='headerContainer' style='padding-top: 10px;padding-right: 18px;padding-bottom: 10px;padding-left: 18px;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;'><table border='0' cellpadding='0' cellspacing='0' width='100%' class='mcnImageBlock' style='border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;'>
+    <tbody class='mcnImageBlockOuter'>
+            <tr>
+                <td valign='top' style='padding: 9px;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;' class='mcnImageBlockInner'>
+                    <table align='left' width='100%' border='0' cellpadding='0' cellspacing='0' class='mcnImageContentContainer' style='border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;'>
+                        <tbody><tr>
+                            <td class='mcnImageContent' valign='top' style='padding-right: 9px;padding-left: 9px;padding-top: 0;padding-bottom: 0;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;'>
+
+                                    <%include file="/${microsite.get_template_path('emails/html/header_content.html')}" />
+
+                            </td>
+                        </tr>
+                    </tbody></table>
+                </td>
+            </tr>
+    </tbody>
+</table><table border='0' cellpadding='0' cellspacing='0' width='100%' class='mcnTextBlock' style='border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;'>
+    <tbody class='mcnTextBlockOuter'>
+        <tr>
+            <td valign='top' class='mcnTextBlockInner' style='border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;'>
+
+                <table align='left' border='0' cellpadding='0' cellspacing='0' width='599' class='mcnTextContentContainer' style='border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;'>
+                    <tbody><tr>
+
+                        <td valign='top' class='mcnTextContent' style='padding-top: 9px;padding-right: 18px;padding-bottom: 9px;padding-left: 18px;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;color: #606060;font-family: Helvetica;font-size: 15px;line-height: 150%;text-align: left;'>
+
+                            <div style='text-align: right;'>
+	<span style='font-size:11px;'><span style='color:#00a0e3;'>${_("Connect with edX:")}</span></span> &nbsp;<a href='http://facebook.com/edxonline' target='_blank' style='color: #6DC6DD;font-weight: normal;text-decoration: underline;word-wrap: break-word !important;'><img align='none' height='16' src='http://courses.edx.org/static/images/bulk_email/FacebookIcon.png' style='width: 16px;height: 16px;border: 0;line-height: 100%;outline: none;text-decoration: none;' width='16'></a>&nbsp;&nbsp;<a href='http://twitter.com/edxonline' target='_blank' style='color: #6DC6DD;font-weight: normal;text-decoration: underline;word-wrap: break-word !important;'><img align='none' height='16' src='http://courses.edx.org/static/images/bulk_email/TwitterIcon.png' style='width: 16px;height: 16px;border: 0;line-height: 100%;outline: none;text-decoration: none;' width='16'></a>&nbsp;&nbsp;<a href='https://plus.google.com/108235383044095082735' target='_blank' style='color: #6DC6DD;font-weight: normal;text-decoration: underline;word-wrap: break-word !important;'><img align='none' height='16' src='http://courses.edx.org/static/images/bulk_email/GooglePlusIcon.png' style='width: 16px;height: 16px;border: 0;line-height: 100%;outline: none;text-decoration: none;' width='16'></a>&nbsp;&nbsp;<a href='http://www.meetup.com/edX-Communities/' target='_blank' style='color: #6DC6DD;font-weight: normal;text-decoration: underline;word-wrap: break-word !important;'><img align='none' height='16' src='http://courses.edx.org/static/images/bulk_email/MeetupIcon.png' style='width: 16px;height: 16px;border: 0;line-height: 100%;outline: none;text-decoration: none;' width='16'></a></div>
+
+                        </td>
+                    </tr>
+                </tbody></table>
+
+            </td>
+        </tr>
+    </tbody>
+</table></td>
+                                                    </tr>
+                                                </table>
+                                            </td>
+                                        </tr>
+                                    </table>
+                                    <!-- // END HEADER -->
+                                </td>
+                            </tr>
+                            <tr>
+                                <td align='center' valign='top' style='border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;'>
+                                    <!-- BEGIN BODY // -->
+                                    <table border='0' cellpadding='0' cellspacing='0' width='100%' id='templateBody' style='border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;background-color: #fcfcfc;border-top: 0;border-bottom: 0;'>
+                                        <tr>
+                                            <td align='center' valign='top' style='border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;'>
+                                                <table border='0' cellpadding='0' cellspacing='0' width='600' class='templateContainer' style='border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;'>
+                                                    <tr>
+                                                        <td valign='top' class='bodyContainer' style='padding-top: 10px;padding-right: 18px;padding-bottom: 10px;padding-left: 18px;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;'><table border='0' cellpadding='0' cellspacing='0' width='100%' class='mcnTextBlock' style='border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;'>
+    <tbody class='mcnTextBlockOuter'>
+        <tr>
+            <td valign='top' class='mcnTextBlockInner' style='border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;'>
+
+                <table align='left' border='0' cellpadding='0' cellspacing='0' width='600' class='mcnTextContentContainer' style='border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;'>
+                    <tbody><tr>
+
+                        <td valign='top' class='mcnTextContent' style='padding-top: 9px;padding-right: 18px;padding-bottom: 9px;padding-left: 18px;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;color: #606060;font-family: Helvetica;font-size: 14px;line-height: 150%;text-align: left;'>
+
+                        <%block name="content_table"></%block>
+
+                        </td>
+                    </tr>
+                </tbody></table>
+
+            </td>
+        </tr>
+    </tbody>
+</table><table border='0' cellpadding='0' cellspacing='0' width='100%' class='mcnDividerBlock' style='border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;'>
+    <tbody class='mcnDividerBlockOuter'>
+        <tr>
+            <td class='mcnDividerBlockInner' style='padding: 18px 18px 3px;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;'>
+                <table class='mcnDividerContent' border='0' cellpadding='0' cellspacing='0' width='100%' style='border-top-width: 1px;border-top-style: solid;border-top-color: #666666;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;'>
+                    <tbody><tr>
+                        <td style='border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;'>
+                            <span></span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+        </tr>
+    </tbody>
+</table><table border='0' cellpadding='0' cellspacing='0' width='100%' class='mcnTextBlock' style='border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;'>
+    <tbody class='mcnTextBlockOuter'>
+        <tr>
+            <td valign='top' class='mcnTextBlockInner' style='border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;'>
+
+                <table align='left' border='0' cellpadding='0' cellspacing='0' width='600' class='mcnTextContentContainer' style='border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;'>
+                    <tbody><tr>
+
+                        <td valign='top' class='mcnTextContent' style='padding-top: 9px;padding-right: 18px;padding-bottom: 9px;padding-left: 18px;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;color: #606060;font-family: Helvetica;font-size: 14px;line-height: 150%;text-align: left;'>
+
+                            <div style='text-align: right;'>
+	<a href='http://facebook.com/edxonline' target='_blank' style='color: #2f73bc;font-weight: normal;text-decoration: underline;word-wrap: break-word !important;'><img align='none' height='16' src='http://courses.edx.org/static/images/bulk_email/FacebookIcon.png' style='width: 16px;height: 16px;border: 0;line-height: 100%;outline: none;text-decoration: none;' width='16'></a>&nbsp;&nbsp;<a href='http://twitter.com/edxonline' target='_blank' style='color: #2f73bc;font-weight: normal;text-decoration: underline;word-wrap: break-word !important;'><img align='none' height='16' src='http://courses.edx.org/static/images/bulk_email/TwitterIcon.png' style='width: 16px;height: 16px;border: 0;line-height: 100%;outline: none;text-decoration: none;' width='16'></a>&nbsp;&nbsp;<a href='https://plus.google.com/108235383044095082735' target='_blank' style='color: #2f73bc;font-weight: normal;text-decoration: underline;word-wrap: break-word !important;'><img align='none' height='16' src='http://courses.edx.org/static/images/bulk_email/GooglePlusIcon.png' style='width: 16px;height: 16px;border: 0;line-height: 100%;outline: none;text-decoration: none;' width='16'></a>&nbsp; &nbsp;<a href='http://www.meetup.com/edX-Communities/' target='_blank' style='color: #2f73bc;font-weight: normal;text-decoration: underline;word-wrap: break-word !important;'><img align='none' height='16' src='http://courses.edx.org/static/images/bulk_email/MeetupIcon.png' style='width: 16px;height: 16px;border: 0;line-height: 100%;outline: none;text-decoration: none;' width='16'></a></div>
+
+                        </td>
+                    </tr>
+                </tbody></table>
+
+            </td>
+        </tr>
+    </tbody>
+</table></td>
+                                                    </tr>
+                                                </table>
+                                            </td>
+                                        </tr>
+                                    </table>
+                                    <!-- // END BODY -->
+                                </td>
+                            </tr>
+                            <tr>
+                                <td align='center' valign='top' style='border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;'>
+                                    <!-- BEGIN FOOTER // -->
+                                    <table border='0' cellpadding='0' cellspacing='0' width='100%' id='templateFooter' style='border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;background-color: #006ba4;border-top: 0;border-bottom: 0;'>
+                                        <tr>
+                                            <td align='center' valign='top' style='border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;'>
+                                                <table border='0' cellpadding='0' cellspacing='0' width='600' class='templateContainer' style='border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;'>
+                                                    <tr>
+                                                        <td valign='top' class='footerContainer' style='padding-top: 10px;padding-right: 18px;padding-bottom: 10px;padding-left: 18px;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;'><table border='0' cellpadding='0' cellspacing='0' width='100%' class='mcnTextBlock' style='border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;'>
+    <tbody class='mcnTextBlockOuter'>
+        <tr>
+            <td valign='top' class='mcnTextBlockInner' style='border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;'>
+
+                <table align='left' border='0' cellpadding='0' cellspacing='0' width='600' class='mcnTextContentContainer' style='border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;'>
+                    <tbody><tr>
+
+                        <td valign='top' class='mcnTextContent' style='padding-top: 9px;padding-right: 18px;padding-bottom: 9px;padding-left: 18px;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;color: #f2f2f2;font-family: Helvetica;font-size: 11px;line-height: 125%;text-align: left;'>
+                            <%include file="/${microsite.get_template_path('emails/html/footer_content.html')}" />
+                        </td>
+                    </tr>
+                </tbody></table>
+
+            </td>
+        </tr>
+    </tbody>
+</table></td>
+                                                    </tr>
+                                                </table>
+                                            </td>
+                                        </tr>
+                                    </table>
+                                    <!-- // END FOOTER -->
+                                </td>
+                            </tr>
+                        </table>
+                        <!-- // END TEMPLATE -->
+                    </td>
+                </tr>
+            </table>
+        </center>
+    </body>    </body> </html>

--- a/lms/templates/emails/html/one_call_to_action.html
+++ b/lms/templates/emails/html/one_call_to_action.html
@@ -1,0 +1,31 @@
+<%! from django.utils.translation import ugettext as _ %>
+<%inherit file="mc_base.html" />
+
+<%block name="title"></%block>
+
+<%block name="content_table">
+
+  <tr>
+    <td valign="top" class="mcnTextContent" style="padding-top: 18px;padding-right: 18px;padding-bottom: 9px;padding-left: 18px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;color: #606060;font-family: Helvetica;font-size: 15px;line-height: 150%;text-align: left;">
+
+      <h3 style="margin: 0;padding: 0;display: block;font-family: Helvetica;font-size: 18px;font-style: normal;font-weight: bold;line-height: 125%;letter-spacing: -.5px;text-align: left;color: #606060;">
+        <%block name="msg_header">${_("Message")}</%block>
+      </h3>
+      <br />
+      <%block name="msg_content" >${_("This message was generated automatically.")}</%block>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" valign="top" class="bottomShim" style="mso-table-lspace: 0pt;mso-table-rspace: 0pt;padding-top: 18px;padding-right: 18px;padding-bottom: 38px;padding-left: 18px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;color: #606060;font-family: Helvetica;font-size: 15px;line-height: 150%">
+      <table border="0" cellpadding="0" cellspacing="0" width="260" class="emailButton" style="border-collapse: separate;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;background-color: #2C9AB7;border-radius: 4px;">
+        <tr>
+          <td align="center" valign="middle" class="buttonContent" style="mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;color: #FFFFFF;font-family: Helvetica;font-size: 18px;font-weight: bold;line-height: 100%;padding: 15px;text-align: center;">
+            <a href="<%block name="call_to_action_href" >#</%block>" target="_blank" style="word-wrap: break-word;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;color: #FFFFFF;display: block;text-decoration: none;"><%block name="call_to_action_label">${_("Action")}</%block></a>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+
+
+</%block>

--- a/lms/templates/emails/html/one_content_box.html
+++ b/lms/templates/emails/html/one_content_box.html
@@ -1,0 +1,20 @@
+<%! from django.utils.translation import ugettext as _ %>
+<%inherit file="mc_base.html" />
+
+<%block name="title"></%block>
+
+<%block name="content_table">
+
+  <tr>
+    <td valign="top" class="mcnTextContent" style="padding-top: 9px;padding-right: 18px;padding-bottom: 9px;padding-left: 18px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;color: #606060;font-family: Helvetica;font-size: 15px;line-height: 150%;text-align: left;">
+
+      <h3><span style="font-family:arial,helvetica neue,helvetica,sans-serif"><%block name="msg_header">${_("Message")}</%block></span></h3>
+
+      <p><%block name="msg_content" >${_("This message was generated automatically.")}</%block></p>
+
+      <p><%block name="msg_content_2" ></%block></p>
+
+    </td>
+  </tr>
+
+</%block>

--- a/lms/templates/emails/html/order_confirmation_email.html
+++ b/lms/templates/emails/html/order_confirmation_email.html
@@ -1,0 +1,47 @@
+<%inherit file='one_content_box.html' />
+<%! from django.utils.translation import ugettext as _ %>
+
+<%block name="title">Pago exitoso </%block>
+
+<%block name="msg_header">
+${_("Hi {name}").format(name=order.user.profile.name)}
+</%block>
+
+<%block name="msg_content" >
+${_("Your payment was successful. You will see the charge below on your next credit or debit card statement.")}
+<br/>
+${_("The charge will show up on your statement under the company name {merchant_name}.").format(merchant_name=settings.CC_MERCHANT_NAME)}
+<br/>
+% if marketing_link('FAQ'):
+${_("If you have billing questions, please read the FAQ ({faq_url}) or contact {billing_email}.").format(billing_email=settings.PAYMENT_SUPPORT_EMAIL, faq_url=marketing_link('FAQ'))}
+% else:
+${_("If you have billing questions, please contact {billing_email}.").format(billing_email=settings.PAYMENT_SUPPORT_EMAIL)}
+% endif
+<br/>
+${_("-The {platform_name} Team").format(platform_name=settings.PLATFORM_NAME)}
+<br/>
+${_("Your order number is: {order_number}").format(order_number=order.id)}
+<br/>
+${_("The items in your order are:")}
+<br/>
+${_("Quantity - Description - Price")}
+%for order_item in order_items:
+    ${order_item.qty} - ${order_item.line_desc} - ${"$" if order_item.currency == 'usd' else ""}${order_item.line_cost}
+    <br/>
+%endfor
+<br/>
+${_("Total billed to credit/debit card: {currency_symbol}{total_cost}").format(total_cost=order.total_cost, currency_symbol=("$" if order.currency == 'usd' else ""))}
+<br/>
+% if has_billing_info:
+${order.bill_to_cardtype} ${_("#:")} ${order.bill_to_ccnum}<br/>
+${order.bill_to_first} ${order.bill_to_last}<br/>
+${order.bill_to_street1}<br/>
+${order.bill_to_street2}<br/>
+${order.bill_to_city}, ${order.bill_to_state} ${order.bill_to_postalcode}<br/>
+${order.bill_to_country.upper()}<br/>
+% endif
+<br/>
+%for order_item in order_items:
+    ${order_item.additional_instruction_text}<br/>
+%endfor
+</%block>

--- a/lms/templates/emails/html/order_confirmation_email.html
+++ b/lms/templates/emails/html/order_confirmation_email.html
@@ -1,7 +1,7 @@
 <%inherit file='one_content_box.html' />
 <%! from django.utils.translation import ugettext as _ %>
 
-<%block name="title">Pago exitoso </%block>
+<%block name="title">${_("Your payment was successful")}</%block>
 
 <%block name="msg_header">
 ${_("Hi {name}").format(name=order.user.profile.name)}
@@ -9,39 +9,48 @@ ${_("Hi {name}").format(name=order.user.profile.name)}
 
 <%block name="msg_content" >
 ${_("Your payment was successful. You will see the charge below on your next credit or debit card statement.")}
-<br/>
 ${_("The charge will show up on your statement under the company name {merchant_name}.").format(merchant_name=settings.CC_MERCHANT_NAME)}
-<br/>
 % if marketing_link('FAQ'):
-${_("If you have billing questions, please read the FAQ ({faq_url}) or contact {billing_email}.").format(billing_email=settings.PAYMENT_SUPPORT_EMAIL, faq_url=marketing_link('FAQ'))}
+${_("If you have billing questions, please read the FAQ ({faq_url}) or contact {billing_email}.").format(billing_email=payment_support_email, faq_url=marketing_link('FAQ'))}
 % else:
-${_("If you have billing questions, please contact {billing_email}.").format(billing_email=settings.PAYMENT_SUPPORT_EMAIL)}
+${_("If you have billing questions, please contact {billing_email}.").format(billing_email=payment_support_email)}
 % endif
 <br/>
-${_("-The {platform_name} Team").format(platform_name=settings.PLATFORM_NAME)}
+
+${_("Warm regards,")}
+% if payment_email_signature:
+${payment_email_signature}
+% else:
+${_("The {platform_name} Team").format(platform_name=platform_name)}
+%endif
 <br/>
+
 ${_("Your order number is: {order_number}").format(order_number=order.id)}
 <br/>
+
 ${_("The items in your order are:")}
 <br/>
+
 ${_("Quantity - Description - Price")}
 %for order_item in order_items:
     ${order_item.qty} - ${order_item.line_desc} - ${"$" if order_item.currency == 'usd' else ""}${order_item.line_cost}
-    <br/>
 %endfor
 <br/>
+
 ${_("Total billed to credit/debit card: {currency_symbol}{total_cost}").format(total_cost=order.total_cost, currency_symbol=("$" if order.currency == 'usd' else ""))}
 <br/>
+
 % if has_billing_info:
-${order.bill_to_cardtype} ${_("#:")} ${order.bill_to_ccnum}<br/>
-${order.bill_to_first} ${order.bill_to_last}<br/>
-${order.bill_to_street1}<br/>
-${order.bill_to_street2}<br/>
-${order.bill_to_city}, ${order.bill_to_state} ${order.bill_to_postalcode}<br/>
-${order.bill_to_country.upper()}<br/>
+${order.bill_to_cardtype} ${_("#:")} ${order.bill_to_ccnum}
+${order.bill_to_first} ${order.bill_to_last}
+${order.bill_to_street1}
+${order.bill_to_street2}
+${order.bill_to_city}, ${order.bill_to_state} ${order.bill_to_postalcode}
+${order.bill_to_country.upper()}
 % endif
 <br/>
+
 %for order_item in order_items:
-    ${order_item.additional_instruction_text}<br/>
+    ${order_item.additional_instruction_text}
 %endfor
 </%block>

--- a/lms/templates/emails/html/remove_beta_tester_email_message.html
+++ b/lms/templates/emails/html/remove_beta_tester_email_message.html
@@ -1,0 +1,21 @@
+<%! from django.utils.translation import ugettext as _ %>
+<%inherit file="one_content_box.html" />
+
+<%block name="msg_header">
+  ${_("Dear {full_name}").format(full_name=full_name)}
+  <br/>
+</%block>
+
+<%block name="msg_content" >
+${_("You have been removed as a beta tester for {course_name} at {site_name} by a "
+  "member of the course staff. The course will remain on your dashboard, but "
+  "you will no longer be part of the beta testing group.").format(
+    course_name=course.display_name_with_default,
+    site_name=site_name
+  )}
+</%block>
+
+<%block name="msg_content_2" >
+  ${_("Your other courses have not been affected.")}
+  <br/>
+</%block>

--- a/lms/templates/emails/html/unenroll_email_allowedmessage.html
+++ b/lms/templates/emails/html/unenroll_email_allowedmessage.html
@@ -1,0 +1,15 @@
+<%inherit file="one_content_box.html" />
+<%! from django.utils.translation import ugettext as _ %>
+
+<%block name="title">Retiro del curso | eduNEXT</%block>
+
+<%block name="msg_header">
+  ${_("Dear student,")}
+  <br/>
+</%block>
+
+<%block name="msg_content" >
+${_("You have been un-enrolled from course {course_name} by a member "
+    "of the course staff. Please disregard the invitation "
+    "previously sent.").format(course_name=course.display_name_with_default)}
+</%block>

--- a/lms/templates/emails/html/unenroll_email_enrolledmessage.html
+++ b/lms/templates/emails/html/unenroll_email_enrolledmessage.html
@@ -1,0 +1,20 @@
+<%inherit file="one_content_box.html" />
+<%! from django.utils.translation import ugettext as _ %>
+
+<%block name="msg_header">
+  ${_("Dear {full_name},").format(full_name=full_name)}
+  <br/>
+</%block>
+
+<%block name="msg_content" >
+${_("You have been un-enrolled in {course_name} at {site_name} by a member "
+    "of the course staff. The course will no longer appear on your "
+    "{site_name} dashboard.").format(
+    	course_name=course.display_name_with_default, site_name=site_name
+    )}
+</%block>
+
+<%block name="msg_content_2" >
+  ${_("Your other courses have not been affected.")}
+  <br/>
+</%block>

--- a/lms/templates/registration/password_reset_email_html.html
+++ b/lms/templates/registration/password_reset_email_html.html
@@ -1,6 +1,7 @@
 <%!
     from django.core.urlresolvers import reverse
     from microsite_configuration.middleware import microsite
+    from django.utils.translation import ugettext as _
 %>
 <%inherit file="/emails/html/one_call_to_action.html" />
 

--- a/lms/templates/registration/password_reset_email_html.html
+++ b/lms/templates/registration/password_reset_email_html.html
@@ -1,0 +1,26 @@
+<%!
+    from django.core.urlresolvers import reverse
+    from microsite_configuration.middleware import microsite
+%>
+<%inherit file="/emails/html/one_call_to_action.html" />
+
+<%block name="title">
+  ${_("Request to change password")}
+</%block>
+
+<%block name="msg_header">
+  ${_("Password reset")}
+<br/>
+</%block>
+
+<%block name="msg_content" >
+${_("You're receiving this e-mail because you requested a password reset for your user account at edx.org.")}
+<br />
+${_("If you didn't request this change, you can disregard this email - we have not yet reset your password.")}
+</%block>
+
+<%block name="call_to_action_href">http://${ domain }${reverse('student.views.password_reset_confirm_wrapper', kwargs={'uidb36': uid, 'token': token})}</%block>
+
+<%block name="call_to_action_label">${_("Change my password")}</%block>
+
+


### PR DESCRIPTION
Add in support for multipart emails (html) in the automatic messages that respond to user actions. Eg: account creation, password change, ...

This PR:
- Adds a new send_mail function with the support for html
- Adds all the required templates to render the html messages (the base template is the one from the bulk_email app which ultimately is the one from the mailchimp templates)
- replaces the user.email_user function with the aforementioned send_mail
- Overrides the save method in class PasswordResetFormNoActive to use the new send_mail
