### PR TITLE
Added minimal pyinvoke example (paver replacement)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -139,3 +139,4 @@ Raees Chachar <raees.chachar@arbisoft.com>
 Muhammad Ammar <muhammad.ammar@arbisoft.com>
 William Desloge <william.desloge@ionis-group.com>
 Marco Re <mrc.re@tiscali.it>
+Andreas Dewes <andreas.dewes@gmail.com>

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -1,0 +1,8 @@
+from __future__ import print_function
+from invoke import Collection
+
+ns = Collection()
+
+from .quality import tasks as quality_tasks
+
+ns.add_collection(quality_tasks,"quality")

--- a/tasks/quality.py
+++ b/tasks/quality.py
@@ -1,0 +1,25 @@
+"""
+Run quality checkers on the code
+"""
+from __future__ import print_function
+
+import sys
+import argparse
+from invoke import Collection,task
+
+def run_pylint(system):
+    print("running pylint on: %s" % system)
+
+pylint = Collection("pylint")
+
+for system in ('lms','cms','common'):
+
+    @task(name = system)
+    def pylint_system(system = system):
+        return run_pylint(system)
+
+    pylint.add_task(pylint_system,name = system)
+
+tasks = Collection("quality")
+tasks.add_collection(pylint)
+


### PR DESCRIPTION
I'm at the PyCon sprint working on migrating all tasks in **rakelib** to Python to eliminate the **rake** dependency. We currently use _paver_ but it seems that it's not very well suited for defining hierarchical and interdependent tasks, so we decided looking at alternative solutions. I built a minimal example using **pyinvoke** (https://github.com/pyinvoke/invoke) which demonstrates how to define and run tasks there.

After installing pyinvoke (pip install invoke ; I didn't add it to requirements.txt since I couldn't locate it), you can get a list of all the tasks like this:

```
#run in edx-platform
invoke --list

#this should print:
Available tasks:

  quality.pylint.cms
  quality.pylint.common
  quality.pylint.lms
```

You can run individual tasks like you would in rake (except that you replace ":" with "."):

```
#Runs pylint on all systems (cms,lms,common):
invoke quality.pylint.all

#Runs pylint on cms with arg foo = 'bar'
invoke quality.pylint.cms --foo=bar
```

This is just a minimal example I want to put up for discussion, so please provide some feedback. Maybe the people working on the **paver** tasks can also comment on the difficulties they encountered so far, so that we can construct a more complete example in **pyinvoke** and see if it's a better fit.
