### PR TITLE
Render markup in inline threads on expand/collapse

### DIFF
--- a/common/static/coffee/spec/discussion/view/discussion_thread_view_inline_spec.coffee
+++ b/common/static/coffee/spec/discussion/view/discussion_thread_view_inline_spec.coffee
@@ -48,6 +48,7 @@ describe "DiscussionThreadInlineView", ->
         spyOn($, "ajax")
         # Avoid unnecessary boilerplate
         spyOn(@view.showView, "render")
+        spyOn(@view.showView, "convertMath")
         spyOn(@view, "makeWmdEditor")
         spyOn(DiscussionThreadView.prototype, "renderResponse")
 
@@ -98,5 +99,8 @@ describe "DiscussionThreadInlineView", ->
             @view.render()
             @view.expandPost()
             expect(@view.$el.find(".post-body").text()).toEqual(@thread.get("body"))
+            expect(@view.showView.convertMath).toHaveBeenCalled()
+            @view.showView.convertMath.reset()
             @view.collapsePost()
             expect(@view.$el.find(".post-body").text()).toEqual(@thread.get("abbreviatedBody"))
+            expect(@view.showView.convertMath).toHaveBeenCalled()

--- a/common/static/coffee/src/discussion/views/discussion_thread_view_inline.coffee
+++ b/common/static/coffee/src/discussion/views/discussion_thread_view_inline.coffee
@@ -46,6 +46,7 @@ if Backbone?
     expandPost: (event) =>
       @$el.addClass('expanded')
       @$el.find('.post-body').html(@model.get('body'))
+      @showView.convertMath()
       @$el.find('.expand-post').css('display', 'none')
       @$el.find('.collapse-post').css('display', 'block')
       @$el.find('.post-extended-content').show()
@@ -60,6 +61,7 @@ if Backbone?
         $('html, body').animate({scrollTop: postTop})
       @$el.removeClass('expanded')
       @$el.find('.post-body').html(@model.get('abbreviatedBody'))
+      @showView.convertMath()
       @$el.find('.expand-post').css('display', 'block')
       @$el.find('.collapse-post').css('display', 'none')
       @$el.find('.post-extended-content').hide()


### PR DESCRIPTION
This was a bug in 3af90ef.

@jimabramson @dianakhuang 
