### PR TITLE
Parse urls with query params for ^/static

### DIFF
--- a/common/djangoapps/static_replace/test/test_static_replace.py
+++ b/common/djangoapps/static_replace/test/test_static_replace.py
@@ -95,13 +95,15 @@ def test_raw_static_check():
 @patch('static_replace.modulestore')
 def test_static_url_with_query(mock_modulestore, mock_storage):
     """
-    Make sure urls with query have the parameter section unaltered
+    Make sure that for urls with query params:
+     query params that contain "^/static/" are converted to full location urls
+     query params that do not contain "^/static/" are left unchanged
     """
     mock_storage.exists.return_value = False
     mock_modulestore.return_value = Mock(MongoModuleStore)
 
-    pre_text = 'EMBED src ="/static/LAlec04_controller.swf?csConfigFile=/c4x/org/course/asset/LAlec04_config.xml"'
-    post_text = 'EMBED src ="/c4x/org/course/asset/LAlec04_controller.swf?csConfigFile=/c4x/org/course/asset/LAlec04_config.xml"'
+    pre_text = 'EMBED src ="/static/LAlec04_controller.swf?csConfigFile=/static/LAlec04_config.xml&name1=value1&name2=value2"'
+    post_text = 'EMBED src ="/c4x/org/course/asset/LAlec04_controller.swf?csConfigFile=%2Fc4x%2Forg%2Fcourse%2Fasset%2FLAlec04_config.xml&name1=value1&name2=value2"'
     assert_equals(post_text, replace_static_urls(pre_text, DATA_DIRECTORY, COURSE_KEY))
 
 

--- a/common/lib/xmodule/xmodule/contentstore/content.py
+++ b/common/lib/xmodule/xmodule/contentstore/content.py
@@ -7,7 +7,8 @@ XASSET_THUMBNAIL_TAIL_NAME = '.jpg'
 import os
 import logging
 import StringIO
-from urlparse import urlparse, urlunparse
+from urlparse import urlparse, urlunparse, parse_qsl
+from urllib import urlencode
 
 from xmodule.modulestore.locations import AssetLocation, SlashSeparatedCourseKey
 from .django import contentstore
@@ -123,8 +124,22 @@ class StaticContent(object):
         loc = StaticContent.compute_location(course_id, orig_path)
         loc_url = loc.to_deprecated_string()
 
+        # parse the query params for "^/static/" and replace with the location url
+        orig_query = parse_qsl(query)
+        new_query_list = []
+        for query_name, query_value in orig_query:
+            if query_value.startswith("/static/"):
+                new_query = StaticContent.compute_location(
+                    course_id,
+                    query_value[len('/static/'):],
+                )
+                new_query_url = new_query.to_deprecated_string()
+                new_query_list.append((query_name, new_query_url))
+            else:
+                new_query_list.append((query_name, query_value))
+
         # Reconstruct with new path
-        return urlunparse((scheme, netloc, loc_url, params, query, fragment))
+        return urlunparse((scheme, netloc, loc_url, params, urlencode(new_query_list), fragment))
 
     def stream_data(self):
         yield self._data


### PR DESCRIPTION
  Query params with a value that starts with /static should have their values converted to the full location.
  Query params with a value that does not start with /static should be left unchanged.
