### PR TITLE
fixup! Change improper calls to convert strings to SSCKeys

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/check_course.py
+++ b/cms/djangoapps/contentstore/management/commands/check_course.py
@@ -11,7 +11,7 @@ class Command(BaseCommand):
         if len(args) != 1:
             raise CommandError("check_course requires one argument: <course_id>")
 
-        course_key = SlashSeparatedCourseKey.from_deprecated_string(args[0])
+        course_key = CourseKey.from_string(args[0])
 
         store = modulestore()
 

--- a/cms/djangoapps/contentstore/management/commands/clone_course.py
+++ b/cms/djangoapps/contentstore/management/commands/clone_course.py
@@ -23,8 +23,8 @@ class Command(BaseCommand):
         if len(args) != 2:
             raise CommandError("clone requires 2 arguments: <source-course_id> <dest-course_id>")
 
-        source_course_id = SlashSeparatedCourseKey.from_deprecated_string(args[0])
-        dest_course_id = SlashSeparatedCourseKey.from_deprecated_string(args[1])
+        source_course_id = CourseKey.from_string(args[0])
+        dest_course_id = CourseKey.from_string(args[1])
 
         mstore = modulestore('direct')
         cstore = contentstore()

--- a/cms/djangoapps/contentstore/management/commands/delete_course.py
+++ b/cms/djangoapps/contentstore/management/commands/delete_course.py
@@ -14,7 +14,7 @@ class Command(BaseCommand):
         if len(args) != 1 and len(args) != 2:
             raise CommandError("delete_course requires one or more arguments: <course_id> |commit|")
 
-        course_id = SlashSeparatedCourseKey.from_deprecated_string(args[0])
+        course_id = CourseKey.from_string(args[0])
 
         commit = False
         if len(args) == 2:

--- a/cms/djangoapps/contentstore/management/commands/export.py
+++ b/cms/djangoapps/contentstore/management/commands/export.py
@@ -22,7 +22,7 @@ class Command(BaseCommand):
         if len(args) != 2:
             raise CommandError("export requires two arguments: <course id> <output path>")
 
-        course_id = SlashSeparatedCourseKey.from_deprecated_string(args[0])
+        course_id = CourseKey.from_string(args[0])
         output_path = args[1]
 
         print("Exporting course id = {0} to {1}".format(course_id, output_path))

--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -1616,7 +1616,7 @@ class ContentStoreTest(ModuleStoreTestCase):
         self.assertEquals(course_module.wiki_slug, 'toy')
 
         # But change the wiki_slug if it is a different course.
-        target_course_id = SlashSeparatedCourseKey.from_deprecated_string('MITx/999/2013_Spring')
+        target_course_id = CourseKey.from_string('MITx/999/2013_Spring')
         course_data = {
             'org': target_course_id.org,
             'number': target_course_id.course,

--- a/cms/djangoapps/contentstore/views/export_git.py
+++ b/cms/djangoapps/contentstore/views/export_git.py
@@ -25,7 +25,7 @@ def export_git(request, course_key_string):
     """
     This method serves up the 'Export to Git' page
     """
-    course_key = SlashSeparatedCourseKey.from_deprecated_string(course_key_string)
+    course_key = CourseKey.from_string(course_key_string)
     if not has_course_access(request.user, course_key):
         raise PermissionDenied()
 

--- a/cms/djangoapps/contentstore/views/tests/test_access.py
+++ b/cms/djangoapps/contentstore/views/tests/test_access.py
@@ -20,7 +20,7 @@ class RolesTest(TestCase):
         self.global_admin = AdminFactory()
         self.instructor = User.objects.create_user('testinstructor', 'testinstructor+courses@edx.org', 'foo')
         self.staff = User.objects.create_user('teststaff', 'teststaff+courses@edx.org', 'foo')
-        self.course_key = SlashSeparatedCourseKey('mitX', '101', 'test')
+        self.course_key = CourseKey.from_string('slashes:mitX/101/test')
 
     def test_get_user_role_instructor(self):
         """

--- a/cms/djangoapps/contentstore/views/tests/test_course_updates.py
+++ b/cms/djangoapps/contentstore/views/tests/test_course_updates.py
@@ -237,7 +237,7 @@ class CourseUpdateTest(CourseTestCase):
         Test that a user can successfully post on course updates and handouts of a course
         whose location in not in loc_mapper
         """
-        course_key = SlashSeparatedCourseKey.from_deprecated_string('slashes:Org1/Course_1/Run_1')
+        course_key = CourseKey.from_string('slashes:Org1/Course_1/Run_1')
         course_update_url = self.create_update_url(course_key=course_key)
 
         # create a course via the view handler


### PR DESCRIPTION
This commit reverts the cms-related conversions of CourseKey to SlashSeparatedCourseKey, since the cms doesn't use SSCKeys
