### PR TITLE
Wording for batch beta email add with autoenroll (LMS-2551)

### DIFF
--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -342,7 +342,7 @@ def bulk_beta_modify_access(request, course_id):
 
     email_params = {}
     if email_students:
-        email_params = get_email_params(course, auto_enroll=False)
+        email_params = get_email_params(course, auto_enroll=auto_enroll)
 
     for identifier in identifiers:
         try:

--- a/lms/templates/emails/add_beta_tester_email_message.txt
+++ b/lms/templates/emails/add_beta_tester_email_message.txt
@@ -8,7 +8,11 @@ ${_("You have been invited to be a beta tester for {course_name} at {site_name} 
 		site_name=site_name
 	)}
 
-% if course_about_url is not None:
+% if auto_enroll:
+${_("To start accessing course materials, please visit {course_url}").format(
+		course_url=course_url
+	)}
+% elif course_about_url is not None:
 ${_("Visit {course_about_url} to join the course and begin the beta test.").format(course_about_url=course_about_url)}
 % else:
 ${_("Visit {site_name} to enroll in the course and begin the beta test.").format(site_name=site_name)}


### PR DESCRIPTION
@lamagnifica @adampalay tiny change to bulk beta addition email (conditional wording for 'auto_enroll' copied out of the Enrollment email)

https://edx-wiki.atlassian.net/browse/LMS-2551
