### PR TITLE
utilities section and caption update utility

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_utilities.py
+++ b/cms/djangoapps/contentstore/tests/test_utilities.py
@@ -1,0 +1,125 @@
+""" Unit tests for utility methods in views.py. """
+from contentstore.utils import get_modulestore
+from contentstore.views.utility import expand_utility_action_url
+from xmodule.modulestore.tests.factories import CourseFactory
+from xmodule.modulestore.django import loc_mapper
+
+import json
+from .utils import CourseTestCase
+
+
+class UtilitiesTestCase(CourseTestCase):
+    """ Test for utility get and put methods. """
+    def setUp(self):
+        """ Creates the test course. """
+        super(UtilitiesTestCase, self).setUp()
+        self.course = CourseFactory.create(org='mitX', number='333', display_name='Utilities Course')
+        self.location = loc_mapper().translate_location(self.course.location.course_id, self.course.location, False, True)
+        self.utilities_url = self.location.url_reverse('utility/', '')
+
+    def get_persisted_utilities(self):
+        """ Returns the utilities as persisted in the modulestore. """
+        modulestore = get_modulestore(self.course.location)
+        return modulestore.get_item(self.course.location).utilities
+
+    def compare_utilities(self, persisted, request):
+        """
+        Handles url expansion as possible difference and descends into guts
+        """
+        self.assertEqual(persisted['short_description'], request['short_description'])
+        expanded_utility = expand_utility_action_url(self.course, persisted)
+        for pers, req in zip(expanded_utility['items'], request['items']):
+            self.assertEqual(pers['short_description'], req['short_description'])
+            self.assertEqual(pers['long_description'], req['long_description'])
+            self.assertEqual(pers['action_url'], req['action_url'])
+            self.assertEqual(pers['action_text'], req['action_text'])
+            self.assertEqual(pers['action_external'], req['action_external'])
+
+    def test_get_utilities(self):
+        """ Tests the get utilities method and URL expansion. """
+        response = self.client.get(self.utilities_url)
+        self.assertContains(response, "Bulk Operations")
+        # Verify expansion of action URL happened.
+        self.assertContains(response, 'captions/mitX.333.Utilities_Course')
+        # Verify persisted utility does NOT have expanded URL.
+        utility_0 = self.get_persisted_utilities()[0]
+        self.assertEqual('UtilitiesVideoCaptions', get_action_url(utility_0, 0))
+        payload = response.content
+
+        # Now delete the utilities from the course and verify they get repopulated (for courses
+        # created before utilities were introduced).
+        self.course.utilities = None
+        # Save the changed `utilities` to the underlying KeyValueStore before updating the modulestore
+        self.course.save()
+        modulestore = get_modulestore(self.course.location)
+        modulestore.update_item(self.course, self.user.id)
+        self.assertEqual(self.get_persisted_utilities(), None)
+        response = self.client.get(self.utilities_url)
+        self.assertEqual(payload, response.content)
+
+    def test_get_utilities_html(self):
+        """ Tests getting the HTML template for the utilities page). """
+        response = self.client.get(self.utilities_url, HTTP_ACCEPT='text/html')
+        self.assertContains(response, "What are course utilities?")
+        # The HTML generated will define the handler URL (for use by the Backbone model).
+        self.assertContains(response, self.utilities_url)
+
+    def test_update_utilities_no_index(self):
+        """ No utility index, should return all of them. """
+        returned_utilities = json.loads(self.client.get(self.utilities_url).content)
+        # Verify that persisted utilities do not have expanded action URLs.
+        # compare_utilities will verify that returned_utilities DO have expanded action URLs.
+        pers = self.get_persisted_utilities()
+        self.assertEqual('UtilitiesVideoCaptions', get_first_item(pers[0]).get('action_url'))
+        for pay, resp in zip(pers, returned_utilities):
+            self.compare_utilities(pay, resp)
+
+    def test_utilities_post_unsupported(self):
+        """ Delete operation is not supported. """
+        update_url = self.location.url_reverse('utility/', '100')
+        response = self.client.post(update_url)
+        print response.status_code
+        self.assertEqual(response.status_code, 405)
+
+    def test_utilities_put_unsupported(self):
+        """ Delete operation is not supported. """
+        update_url = self.location.url_reverse('utility/', '100')
+        response = self.client.put(update_url)
+        self.assertEqual(response.status_code, 405)
+
+    def test_utilities_delete_unsupported(self):
+        """ Delete operation is not supported. """
+        update_url = self.location.url_reverse('utility/', '100')
+        response = self.client.delete(update_url)
+        self.assertEqual(response.status_code, 405)
+
+    def test_expand_utility_action_url(self):
+        """
+        Tests the method to expand utility action url.
+        """
+
+        def test_expansion(utility, index, stored, expanded):
+            """
+            Tests that the expected expanded value is returned for the item at the given index.
+
+            Also verifies that the original utility is not modified.
+            """
+            self.assertEqual(get_action_url(utility, index), stored)
+            expanded_utility = expand_utility_action_url(self.course, utility)
+            self.assertEqual(get_action_url(expanded_utility, index), expanded)
+            # Verify no side effect in the original list.
+            self.assertEqual(get_action_url(utility, index), stored)
+
+        test_expansion(self.course.utilities[0], 0, 'UtilitiesVideoCaptions', '/utilities/captions/mitX.333.Utilities_Course/branch/draft/block/Utilities_Course')
+
+
+def get_first_item(utility):
+    """ Returns the first item from the utility. """
+    return utility['items'][0]
+
+
+def get_action_url(utility, index):
+    """
+    Returns the action_url for the item at the specified index in the given utility.
+    """
+    return utility['items'][index]['action_url']

--- a/cms/djangoapps/contentstore/views/__init__.py
+++ b/cms/djangoapps/contentstore/views/__init__.py
@@ -6,6 +6,8 @@
 # All files below declare exports with __all__
 from .assets import *
 from .checklist import *
+from .utility import *
+from .utilities.captions import *
 from .component import *
 from .course import *
 from .error import *

--- a/cms/djangoapps/contentstore/views/tests/test_captions.py
+++ b/cms/djangoapps/contentstore/views/tests/test_captions.py
@@ -1,0 +1,268 @@
+"""Tests for items views."""
+
+import json
+from uuid import uuid4
+import copy
+import textwrap
+from pymongo import MongoClient
+
+from django.test.utils import override_settings
+from django.conf import settings
+
+from xmodule.video_module import transcripts_utils
+from contentstore.tests.utils import CourseTestCase
+from cache_toolbox.core import del_cached_content
+from xmodule.modulestore.django import modulestore
+from xmodule.contentstore.django import contentstore, _CONTENTSTORE
+from xmodule.contentstore.content import StaticContent
+from xmodule.exceptions import NotFoundError
+from xmodule.modulestore.django import loc_mapper
+from xmodule.modulestore.locator import BlockUsageLocator
+
+from contentstore.tests.modulestore_config import TEST_MODULESTORE
+TEST_DATA_CONTENTSTORE = copy.deepcopy(settings.CONTENTSTORE)
+TEST_DATA_CONTENTSTORE['DOC_STORE_CONFIG']['db'] = 'test_xcontent_%s' % uuid4().hex
+
+
+@override_settings(CONTENTSTORE=TEST_DATA_CONTENTSTORE, MODULESTORE=TEST_MODULESTORE)
+class Basetranscripts(CourseTestCase):
+    """Base test class for transcripts tests."""
+
+    org = 'MITx'
+    number = '999'
+
+    def clear_subs_content(self):
+        """Remove, if transcripts content exists."""
+        for youtube_id in self.get_youtube_ids().values():
+            filename = 'subs_{0}.srt.sjson'.format(youtube_id)
+            content_location = StaticContent.compute_location(
+                self.org, self.number, filename)
+            try:
+                content = contentstore().find(content_location)
+                contentstore().delete(content.get_id())
+            except NotFoundError:
+                pass
+
+    def setUp(self):
+        """Create initial data."""
+        super(Basetranscripts, self).setUp()
+        self.location = loc_mapper().translate_location(
+            self.course.location.course_id, self.course.location, False, True
+        )
+        self.captions_url = self.location.url_reverse('utilities/captions/', '')
+        self.unicode_locator = unicode(self.location)
+
+        # Add video module
+        data = {
+            'parent_locator': self.unicode_locator,
+            'category': 'video',
+            'type': 'video'
+        }
+        resp = self.client.ajax_post('/xblock', data)
+        self.item_locator, self.item_location = self._get_locator(resp)
+        self.assertEqual(resp.status_code, 200)
+
+        self.item = modulestore().get_item(self.item_location)
+        # hI10vDNYz4M - valid Youtube ID with transcripts.
+        # JMD_ifUUfsU, AKqURZnYqpk, DYpADpL7jAY - valid Youtube IDs without transcripts.
+        self.item.data = '<video youtube="0.75:JMD_ifUUfsU,1.0:hI10vDNYz4M,1.25:AKqURZnYqpk,1.50:DYpADpL7jAY" />'
+        modulestore().update_item(self.item, self.user.id)
+
+        self.item = modulestore().get_item(self.item_location)
+        # Remove all transcripts for current module.
+        self.clear_subs_content()
+
+    def _get_locator(self, resp):
+        """ Returns the locator and old-style location (as a string) from the response returned by a create operation. """
+        locator = json.loads(resp.content).get('locator')
+        return locator, loc_mapper().translate_locator_to_location(BlockUsageLocator(locator)).url()
+
+    def get_youtube_ids(self):
+        """Return youtube speeds and ids."""
+        item = modulestore().get_item(self.item_location)
+
+        return {
+            0.75: item.youtube_id_0_75,
+            1: item.youtube_id_1_0,
+            1.25: item.youtube_id_1_25,
+            1.5: item.youtube_id_1_5
+        }
+
+    def tearDown(self):
+        MongoClient().drop_database(TEST_DATA_CONTENTSTORE['DOC_STORE_CONFIG']['db'])
+        _CONTENTSTORE.clear()
+
+
+class TestCheckcaptions(Basetranscripts):
+    """Tests for '/utilities/captions' url."""
+
+    def save_subs_to_store(self, subs, subs_id):
+        """Save transcripts into `StaticContent`."""
+        filedata = json.dumps(subs, indent=2)
+        mime_type = 'application/json'
+        filename = 'subs_{0}.srt.sjson'.format(subs_id)
+
+        content_location = StaticContent.compute_location(
+            self.org, self.number, filename)
+        content = StaticContent(content_location, filename, mime_type, filedata)
+        contentstore().save(content)
+        del_cached_content(content_location)
+        return content_location
+
+    def test_success_download_nonyoutube(self):
+        subs_id = str(uuid4())
+        self.item.data = textwrap.dedent("""
+            <video youtube="" sub="{}">
+                <source src="http://www.quirksmode.org/html5/videos/big_buck_bunny.mp4"/>
+                <source src="http://www.quirksmode.org/html5/videos/big_buck_bunny.webm"/>
+                <source src="http://www.quirksmode.org/html5/videos/big_buck_bunny.ogv"/>
+            </video>
+        """.format(subs_id))
+        modulestore().update_item(self.item, self.user.id)
+
+        subs = {
+            'start': [100, 200, 240],
+            'end': [200, 240, 380],
+            'text': [
+                'subs #1',
+                'subs #2',
+                'subs #3'
+            ]
+        }
+        self.save_subs_to_store(subs, subs_id)
+
+        link = self.captions_url
+        data = {
+            'video': json.dumps({'location': self.item_location}),
+            'action': 'get'
+        }
+        resp = self.client.post(link, data, HTTP_ACCEPT='application/json')
+        self.assertEqual(resp.status_code, 200)
+        self.assertDictEqual(
+            json.loads(resp.content),
+            {
+                u'status': True,
+                u'location': self.item_location,
+                u'command': u'use_existing',
+                u'current_item_subs': subs_id,
+                u'html5_equal': False,
+                u'html5_local': [],
+                u'is_youtube_mode': False,
+                u'status': u'Success',
+                u'subs': u'',
+                u'youtube_diff': True,
+                u'youtube_local': False,
+                u'youtube_server': False
+            }
+        )
+
+        transcripts_utils.remove_subs_from_store(subs_id, self.item)
+
+    def test_check_youtube(self):
+        self.item.data = '<video youtube="1:JMD_ifUUfsU" />'
+        modulestore().update_item(self.item, self.user.id)
+
+        subs = {
+            'start': [100, 200, 240],
+            'end': [200, 240, 380],
+            'text': [
+                'subs #1',
+                'subs #2',
+                'subs #3'
+            ]
+        }
+        self.save_subs_to_store(subs, 'JMD_ifUUfsU')
+        link = self.captions_url
+        data = {
+            'video': json.dumps({'location': self.item_location}),
+            'action': 'get'
+        }
+        resp = self.client.post(link, data, HTTP_ACCEPT='application/json')
+        self.assertEqual(resp.status_code, 200)
+        self.assertDictEqual(
+            json.loads(resp.content),
+            {
+                u'command': u'found',
+                u'current_item_subs': None,
+                u'html5_equal': False,
+                u'html5_local': [],
+                u'is_youtube_mode': True,
+                u'status': u'Success',
+                u'subs': u'JMD_ifUUfsU',
+                u'youtube_diff': True,
+                u'youtube_local': True,
+                u'youtube_server': False,
+                u'location': self.item_location
+            }
+        )
+
+    def test_fail_data_without_id(self):
+        link = self.captions_url
+        data = {
+            'video': '',
+            'action': ''
+        }
+        resp = self.client.post(link, data, HTTP_ACCEPT='application/json')
+        print resp.content
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(json.loads(resp.content).get('message'), "Invalid location.")
+
+    def test_fail_data_with_bad_locator(self):
+        # Test for raising `InvalidLocationError` exception.
+        link = self.captions_url
+        data = {
+            'video': json.dumps({'location': ''}),
+            'action': 'get'
+        }
+        resp = self.client.post(link, data)
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(json.loads(resp.content).get('message'), "Can't find item by locator.")
+
+        # Test for raising `ItemNotFoundError` exception.
+        data = {
+            'video': json.dumps({'location': '{0}_{1}'.format(self.item_location, 'BAD_LOCATION')}),
+            'action': 'get'
+        }
+        resp = self.client.post(link, data)
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(json.loads(resp.content).get('message'), "Can't find item by locator.")
+
+    def test_fail_for_non_video_module(self):
+        # Not video module: setup
+        data = {
+            'parent_locator': self.unicode_locator,
+            'category': 'not_video',
+            'type': 'not_video'
+        }
+        resp = self.client.ajax_post('/xblock', data)
+        item_locator, item_location = self._get_locator(resp)
+        subs_id = str(uuid4())
+        item = modulestore().get_item(item_location)
+        item.data = textwrap.dedent("""
+            <not_video youtube="" sub="{}">
+                <source src="http://www.quirksmode.org/html5/videos/big_buck_bunny.mp4"/>
+                <source src="http://www.quirksmode.org/html5/videos/big_buck_bunny.webm"/>
+                <source src="http://www.quirksmode.org/html5/videos/big_buck_bunny.ogv"/>
+            </videoalpha>
+        """.format(subs_id))
+        modulestore().update_item(item, self.user.id)
+
+        subs = {
+            'start': [100, 200, 240],
+            'end': [200, 240, 380],
+            'text': [
+                'subs #1',
+                'subs #2',
+                'subs #3'
+            ]
+        }
+        self.save_subs_to_store(subs, subs_id)
+
+        link = self.captions_url
+        data = {
+            'video': json.dumps({'location': item_location}),
+            'action': 'get'
+        }
+        resp = self.client.post(link, data)
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(json.loads(resp.content).get('message'), 'Transcripts are supported only for "video" modules.')

--- a/cms/djangoapps/contentstore/views/transcripts_ajax.py
+++ b/cms/djangoapps/contentstore/views/transcripts_ajax.py
@@ -224,6 +224,16 @@ def check_transcripts(request):
     except TranscriptsRequestValidationException as e:
         return error_response(transcripts_presence, e.message)
 
+    transcripts_presence = get_transcripts_presence(videos, item, transcripts_presence)
+    return JsonResponse(transcripts_presence)
+
+
+def get_transcripts_presence(videos, item, transcripts_presence):
+    """ fills in the transcripts_presence dictionary after for a given component
+    with its list of videos.
+
+    Returns transcripts_presence: dictionary containing the status of the video
+    """
     transcripts_presence['status'] = 'Success'
 
     filename = 'subs_{0}.srt.sjson'.format(item.sub)
@@ -292,8 +302,7 @@ def check_transcripts(request):
         'command': command,
         'subs': subs_to_use,
     })
-    return JsonResponse(transcripts_presence)
-
+    return transcripts_presence
 
 def _transcripts_logic(transcripts_presence, videos):
     """
@@ -384,7 +393,7 @@ def choose_transcripts(request):
     if item.sub != html5_id:  # update sub value
         item.sub = html5_id
         item.save_with_metadata(request.user)
-    response = {'status': 'Success',  'subs': item.sub}
+    response = {'status': 'Success', 'subs': item.sub}
     return JsonResponse(response)
 
 
@@ -415,7 +424,7 @@ def replace_transcripts(request):
 
     item.sub = youtube_id
     item.save_with_metadata(request.user)
-    response = {'status': 'Success',  'subs': item.sub}
+    response = {'status': 'Success', 'subs': item.sub}
     return JsonResponse(response)
 
 

--- a/cms/djangoapps/contentstore/views/utilities/captions.py
+++ b/cms/djangoapps/contentstore/views/utilities/captions.py
@@ -1,0 +1,270 @@
+
+
+"""
+Views related to operations on course objects
+"""
+import json
+import logging
+import os
+
+from django_future.csrf import ensure_csrf_cookie
+from django.conf import settings
+from django.contrib.auth.decorators import login_required
+from django.core.exceptions import PermissionDenied
+from django.http import HttpResponseBadRequest, HttpResponseNotFound
+from django.utils.translation import ugettext as _
+
+from edxmako.shortcuts import render_to_response
+from models.settings.course_grading import CourseGradingModel
+from util.json_request import JsonResponse
+from xmodule.modulestore.django import modulestore, loc_mapper
+from xmodule.modulestore.exceptions import ItemNotFoundError, InvalidLocationError, InsufficientSpecificationError
+from xmodule.modulestore.locator import BlockUsageLocator
+from xmodule.video_module.transcripts_utils import (
+                                    GetTranscriptsFromYouTubeException,
+                                    TranscriptsRequestValidationException,
+                                    download_youtube_subs)
+
+from ..access import has_course_access
+from ..transcripts_ajax import get_transcripts_presence
+
+
+log = logging.getLogger(__name__)
+
+__all__ = ['utility_captions_handler']
+
+
+def _get_locator_and_course(package_id, branch, version_guid, block_id, user, depth=0):
+    """
+    Internal method used to calculate and return the locator and course module
+    for the view functions in this file.
+    """
+    locator = BlockUsageLocator(package_id=package_id, branch=branch, version_guid=version_guid, block_id=block_id)
+    if not has_course_access(user, locator):
+        raise PermissionDenied()
+    course_location = loc_mapper().translate_locator_to_location(locator)
+    course_module = modulestore().get_item(course_location, depth=depth)
+    return locator, course_module
+
+
+# pylint: disable=unused-argument
+@login_required
+def utility_captions_handler(request, tag=None, package_id=None, branch=None, version_guid=None, block=None, utilities_index=None):
+    """
+    The restful handler for captions requests in the utilities area.
+    It provides the list of course videos as well as their status. It also lets
+    the user update the captions by pulling the latest version from YouTube.
+
+    GET
+        html: return page containing a list of videos in the course
+    POST
+        json: get the status of the captions of a given video, or update the captions
+        of a given video by copying the version of the captions hosted in youtube.
+    """
+    response_format = request.REQUEST.get('format', 'html')
+    if response_format == 'json' or 'application/json' in request.META.get('HTTP_ACCEPT', 'application/json'):
+        if request.method == 'POST':
+            if request.POST.get('action') == 'update':
+                try:
+                    locations = _validate_captions_data_update(request)
+                except TranscriptsRequestValidationException as e:
+                    return error_response(e.message)
+                return json_update_videos(request, locations)
+            else:
+                try:
+                    data, item = _validate_captions_data_get(request)
+                except TranscriptsRequestValidationException as e:
+                    return error_response(e.message)
+                return json_get_video_status(data, item)
+        else:
+            return HttpResponseBadRequest()
+    elif request.method == 'GET':  # assume html
+        return captions_index(request, package_id, branch, version_guid, block)
+    else:
+        return HttpResponseNotFound()
+
+
+@login_required
+@ensure_csrf_cookie
+def json_update_videos(request, locations):
+    """
+    Display an editable course overview.
+
+    org, course, name: Attributes of the Location for the item to edit
+    """
+    results = []
+    for key in locations:
+        try:
+            #update transcripts
+            item = modulestore().get_item(key)
+            download_youtube_subs({1.0: item.youtube_id_1_0}, item, settings)
+            item.sub = item.youtube_id_1_0
+            item.save_with_metadata(request.user)
+
+            #get new status
+            transcripts_presence = {
+                'html5_local': [],
+                'html5_equal': False,
+                'is_youtube_mode': False,
+                'youtube_local': False,
+                'youtube_server': False,
+                'youtube_diff': True,
+                'current_item_subs': None,
+                'status': 'Error',
+            }
+            videos = {'youtube': item.youtube_id_1_0}
+            html5 = {}
+            for url in item.html5_sources:
+                name = os.path.splitext(url.split('/')[-1])[0]
+                html5[name] = 'html5'
+            videos['html5'] = html5
+            captions_dict = get_transcripts_presence(videos, item, transcripts_presence)
+            captions_dict.update({'location': key})
+            results.append(captions_dict)
+
+        except GetTranscriptsFromYouTubeException as e:
+            log.debug(e)
+            results.append({'location': key, 'command': e})
+
+    return JsonResponse(results)
+
+
+@login_required
+@ensure_csrf_cookie
+def captions_index(request, package_id, branch, version_guid, block):
+    """
+    Display a list of course videos as well as their status (up to date, or out of date)
+
+    org, course, name: Attributes of the Location for the item to edit
+    """
+    locator, course = _get_locator_and_course(
+        package_id, branch, version_guid, block, request.user, depth=3
+    )
+
+    return render_to_response('captions.html',
+        {
+            'videos': get_videos(course),
+            'context_course': course,
+            'new_unit_category': 'vertical',
+            'course_graders': json.dumps(CourseGradingModel.fetch(locator).graders),
+            'locator': locator,
+        }
+    )
+
+
+def error_response(message, response=None, status_code=400):
+    """
+    Simplify similar actions: log message and return JsonResponse with message included in response.
+
+    By default return 400 (Bad Request) Response.
+    """
+    if response is None:
+        response = {}
+    log.debug(message)
+    response['message'] = message
+    return JsonResponse(response, status_code)
+
+
+def _validate_captions_data_get(request):
+    """
+    Happens on the 'get' action. Validates, that request contains all proper data for transcripts processing.
+
+    Returns touple of two elements:
+        data: dict, loaded json from request,
+        item: video item from storage
+
+    Raises `TranscriptsRequestValidationException` if validation is unsuccessful
+    or `PermissionDenied` if user has no access.
+    """
+    try:
+        data = json.loads(request.POST.get('video', '{}'))
+    except ValueError:
+        raise TranscriptsRequestValidationException(_("Invalid location."))
+
+    if not data:
+        raise TranscriptsRequestValidationException(_('Incoming video data is empty.'))
+
+    try:
+        location = data.get('location')
+        item = modulestore().get_item(location)
+    except (ItemNotFoundError, InvalidLocationError, InsufficientSpecificationError):
+        raise TranscriptsRequestValidationException(_("Can't find item by locator."))
+
+    if item.category != 'video':
+        raise TranscriptsRequestValidationException(_('Transcripts are supported only for "video" modules.'))
+
+    return data, item
+
+
+def _validate_captions_data_update(request):
+    """
+    Happens on the 'update' action. Validates, that request contains all proper data for transcripts processing.
+
+    Returns data: dict, loaded json from request
+
+    Raises `TranscriptsRequestValidationException` if validation is unsuccessful
+    or `PermissionDenied` if user has no access.
+    """
+    try:
+        data = json.loads(request.POST.get('update_array', '[]'))
+    except ValueError:
+        raise TranscriptsRequestValidationException(_("Invalid locations."))
+
+    if not data:
+        raise TranscriptsRequestValidationException(_('Incoming update_array data is empty.'))
+
+    for location in data:
+        try:
+            item = modulestore().get_item(location)
+        except (ItemNotFoundError, InvalidLocationError, InsufficientSpecificationError):
+            raise TranscriptsRequestValidationException(_("Can't find item by locator."))
+
+        if item.category != 'video':
+            raise TranscriptsRequestValidationException(_('Transcripts are supported only for "video" modules.'))
+
+    return data
+
+
+def json_get_video_status(video_meta, item):
+    """
+    Fetches the status of a given video
+
+    Returns: status True if the captions are up to date, and False if the captions are out of date
+    """
+    transcripts_presence = {
+        'html5_local': [],
+        'html5_equal': False,
+        'is_youtube_mode': False,
+        'youtube_local': False,
+        'youtube_server': False,
+        'youtube_diff': True,
+        'current_item_subs': None,
+        'status': 'Error',
+    }
+
+    videos = {'youtube': item.youtube_id_1_0}
+    html5 = {}
+    for url in item.html5_sources:
+        name = os.path.splitext(url.split('/')[-1])[0]
+        html5[name] = 'html5'
+    videos['html5'] = html5
+    transcripts_presence = get_transcripts_presence(videos, item, transcripts_presence)
+    # video_meta['status'] = transcripts_presence['status'] == 'Success' and (transcripts_presence['command'] == 'found' or transcripts_presence['command'] == 'use_existing')
+    video_meta.update(transcripts_presence)
+    return JsonResponse(video_meta)
+
+
+def get_videos(course):
+    """
+    Fetches the list of course videos
+
+    Returns: A list of tuples representing (name, location) of each video
+    """
+    video_list = []
+    for section in course.get_children():
+        for subsection in section.get_children():
+            for unit in subsection.get_children():
+                for component in unit.get_children():
+                    if component.location.category == 'video':
+                        video_list.append({'name': component.display_name_with_default, 'location': str(component.location)})
+    return video_list

--- a/cms/djangoapps/contentstore/views/utility.py
+++ b/cms/djangoapps/contentstore/views/utility.py
@@ -1,0 +1,99 @@
+import copy
+
+from util.json_request import JsonResponse
+from django.contrib.auth.decorators import login_required
+from django.views.decorators.http import require_http_methods
+from django_future.csrf import ensure_csrf_cookie
+from edxmako.shortcuts import render_to_response
+from django.http import HttpResponseNotFound
+from django.core.exceptions import PermissionDenied
+from xmodule.modulestore.django import loc_mapper
+
+from ..utils import get_modulestore
+from .access import has_course_access
+from xmodule.course_module import CourseDescriptor
+from xmodule.modulestore.locator import BlockUsageLocator
+
+__all__ = ['utility_handler']
+
+
+# pylint: disable=unused-argument
+@require_http_methods(("GET"))
+@login_required
+@ensure_csrf_cookie
+def utility_handler(request, tag=None, package_id=None, branch=None, version_guid=None, block=None, utilities_index=None):
+    """
+    The restful handler for utilities.
+
+    GET
+        html: return html page for all utilities
+        json: return json representing all utilities.
+    """
+    location = BlockUsageLocator(package_id=package_id, branch=branch, version_guid=version_guid, block_id=block)
+    if not has_course_access(request.user, location):
+        raise PermissionDenied()
+
+    old_location = loc_mapper().translate_locator_to_location(location)
+
+    modulestore = get_modulestore(old_location)
+    course_module = modulestore.get_item(old_location)
+
+    json_request = 'application/json' in request.META.get('HTTP_ACCEPT', 'application/json')
+    if request.method == 'GET':
+        # If course was created before utilities were introduced, copy them over
+        # from the template.
+        if not course_module.utilities:
+            course_module.utilities = CourseDescriptor.utilities.default
+            modulestore.update_item(course_module, request.user.id)
+
+        expanded_utilities = expand_all_action_urls(course_module)
+        if json_request:
+            return JsonResponse(expanded_utilities)
+        else:
+            handler_url = location.url_reverse('utility/', '')
+            return render_to_response('utility.html',
+                                      {
+                                          'handler_url': handler_url,
+                                          # context_course is used by analytics
+                                          'context_course': course_module,
+                                          'utilities': expanded_utilities
+                                      })
+    else:
+        # return HttpResponseNotFound()
+        raise NotImplementedError()
+
+
+def expand_all_action_urls(course_module):
+    """
+    Gets the utilities out of the course module and expands their action urls.
+
+    Returns a copy of the utilities with modified urls, without modifying the persisted version
+    of the utilities.
+    """
+    expanded_utilities = []
+    for utility in course_module.utilities:
+        expanded_utilities.append(expand_utility_action_url(course_module, utility))
+    return expanded_utilities
+
+
+def expand_utility_action_url(course_module, utility):
+    """
+    Expands the action URLs for a given utility and returns the modified version.
+
+    The method does a copy of the input utility and does not modify the input argument.
+    """
+    expanded_utility = copy.deepcopy(utility)
+
+    urlconf_map = {
+        "UtilitiesVideoCaptions": "utilities/captions",
+    }
+
+    for item in expanded_utility.get('items'):
+        action_url = item.get('action_url')
+        if action_url in urlconf_map:
+            url_prefix = urlconf_map[action_url]
+            ctx_loc = course_module.location
+            location = loc_mapper().translate_location(ctx_loc.course_id, ctx_loc, False, True)
+            item['action_url'] = location.url_reverse(url_prefix, '')
+
+    return expanded_utility

--- a/cms/static/js/collections/utility.js
+++ b/cms/static/js/collections/utility.js
@@ -1,0 +1,23 @@
+define(["backbone", "underscore", "js/models/utility"],
+        function(Backbone, _, UtilityModel) {
+    var UtilityCollection = Backbone.Collection.extend({
+        model : UtilityModel,
+
+        parse: function(response) {
+            _.each(response,
+                function( element, idx ) {
+                    element.id = idx;
+                });
+
+            return response;
+        },
+
+        // Disable caching so the browser back button will work (utilities have links to other
+        // places within Studio).
+        fetch: function (options) {
+            options.cache = false;
+            return Backbone.Collection.prototype.fetch.call(this, options);
+        }
+    });
+    return UtilityCollection;
+});

--- a/cms/static/js/models/utility.js
+++ b/cms/static/js/models/utility.js
@@ -1,0 +1,5 @@
+define(["backbone"], function(Backbone) {
+    var Utility = Backbone.Model.extend({
+    });
+    return Utility;
+});

--- a/cms/static/js/views/utility.js
+++ b/cms/static/js/views/utility.js
@@ -1,0 +1,93 @@
+define(["js/views/baseview", "underscore", "jquery"], function(BaseView, _, $) {
+    var UtilityView = BaseView.extend({
+        // takes CMS.Models.Utilities as model
+
+        events : {
+            'click .course-utility .utility-title' : "toggleUtility",
+            'click .course-checkutilitylist .task input' : "toggleTask",
+            'click a[rel="external"]' : "popup"
+        },
+
+        initialize : function() {
+            var self = this;
+            this.template = _.template($("#utility-tpl").text());
+            this.collection.fetch({
+                reset: true,
+                complete: function() {
+                    self.render();
+                }
+            });
+        },
+
+        render: function() {
+            // catch potential outside call before template loaded
+            if (!this.template) return this;
+
+            this.$el.empty();
+
+            var self = this;
+            _.each(this.collection.models,
+                function(utility, index) {
+                    self.$el.append(self.renderTemplate(utility, index));
+                });
+
+            return this;
+        },
+
+        renderTemplate: function (utility, index) {
+            var utilityItems = utility.attributes['items'];
+            var itemsChecked = 0;
+            _.each(utilityItems,
+                function(utility) {
+                    if (utility['is_checked']) {
+                        itemsChecked +=1;
+                    }
+                });
+            var percentChecked = Math.round((itemsChecked/utilityItems.length)*100);
+            return this.template({
+                utilityIndex : index,
+                utilityShortDescription : utility.attributes['short_description'],
+                items: utilityItems,
+                itemsChecked: itemsChecked,
+                percentChecked: percentChecked});
+        },
+
+        toggleUtility : function(e) {
+            e.preventDefault();
+            $(e.target).closest('.course-utility').toggleClass('is-collapsed');
+        },
+
+        toggleTask : function (e) {
+            var self = this;
+
+            var completed = 'is-completed';
+            var $checkbox = $(e.target);
+            var $task = $checkbox.closest('.task');
+            $task.toggleClass(completed);
+
+            var utility_index = $checkbox.data('utility');
+            var task_index = $checkbox.data('task');
+            var model = this.collection.at(utility_index);
+            model.attributes.items[task_index].is_checked = $task.hasClass(completed);
+
+            model.save({},
+                {
+                    success : function() {
+                        var updatedTemplate = self.renderTemplate(model, utility_index);
+                        self.$el.find('#course-utility'+utility_index).first().replaceWith(updatedTemplate);
+
+                        analytics.track('Toggled a Utility Task', {
+                            'course': course_location_analytics,
+                            'task': model.attributes.items[task_index].short_description,
+                            'state': model.attributes.items[task_index].is_checked
+                        });
+                    }
+                });
+        },
+        popup: function(e) {
+            e.preventDefault();
+            window.open($(e.target).attr('href'));
+        }
+    });
+    return UtilityView;
+});

--- a/cms/static/sass/elements/_header.scss
+++ b/cms/static/sass/elements/_header.scss
@@ -363,10 +363,12 @@ body.course.advanced .nav-course-settings-advanced,
 body.course.import .nav-course-tools .title,
 body.course.export .nav-course-tools .title,
 body.course.checklists .nav-course-tools .title,
+body.course.utilities .nav-course-tools .title,
 
 body.course.import .nav-course-tools-import,
 body.course.export .nav-course-tools-export,
 body.course.checklists .nav-course-tools-checklists,
+body.course.utilities .nav-course-tools-utilities,
 
 {
   color: $blue;

--- a/cms/static/sass/style-app-extend1.scss
+++ b/cms/static/sass/style-app-extend1.scss
@@ -45,6 +45,8 @@
 @import 'views/container';
 @import 'views/users';
 @import 'views/checklists';
+@import 'views/utilities';
+@import 'views/captions';
 @import 'views/textbooks';
 @import 'views/export-git';
 

--- a/cms/static/sass/views/_captions.scss
+++ b/cms/static/sass/views/_captions.scss
@@ -1,0 +1,150 @@
+// studio - views - course subsection
+// ====================
+
+.view-captions {
+
+  .main-wrapper {
+    margin-top: ($baseline*2);
+
+    .list-actions {
+      padding:  ($baseline/2);
+      background: $gray-l5;
+
+      .action-primary {
+        @include blue-button();
+        @extend %t-action3;
+        font-weight: 600;
+
+        [class^="icon-"] {
+          @extend %t-icon5;
+          display: inline-block;
+          vertical-align: middle;
+          margin-top: -3px;
+        }
+      }
+    }
+  }
+
+  .subsection-body {
+    padding: 32px 40px;
+    @include clearfix;
+
+    > div {
+      margin-bottom: 40px;
+    }
+    .selectall-label {
+      font-weight: normal;
+    }
+
+    input {
+      font-size: 14px;
+      margin-right: 10px;
+    }
+  }
+
+  .sortable-unit-list {
+    .green {
+      background: $green-l5;
+    }
+
+    .red {
+      background: $red-l5;
+    }
+
+    .yellow {
+      background: $yellow-l5;
+    }
+
+    .courseware-unit {
+      @include font-size(13);
+      @include clearfix();
+      margin: -1px 0 0 0;
+
+      .section-item {
+        @include transition(background $tmg-avg ease-in-out 0);
+        @include font-size(13);
+        position: relative;
+        display: block;
+        padding: 6px 8px 8px;
+        margin: 0;
+        font-weight: normal;
+
+        .green {
+          color: $green;
+        }
+
+        .red {
+          color: $red;
+        }
+
+        .yellow {
+          background: $yellow;
+        }
+
+        &:hover {
+          background: $blue-l5;
+          .popup {
+            display: block;
+          }
+        }
+
+        .popup {
+          position: absolute;
+          height: 25px;
+          top: 3px;
+          width: 100px;
+          background: rgba(255,255,255, .75);
+          border: 1px solid #aaa;
+          border-radius: 3px;
+          padding: 2px 5px;
+          right: 25px;
+          display: none;
+
+          #platform, #local, #remote {
+            padding-right: 8px;
+          }
+        }
+      }
+    }
+
+    .actions-list {
+      display: inline-block;
+      margin-bottom: 0;
+    }
+
+    .actions-item {
+      @include font-size(13);
+      display: inline-block;
+      padding: 0 4px;
+      vertical-align: middle;
+
+      .action {
+        min-width: ($baseline*.75);
+        color: $gray-l2;
+
+        &:hover,
+        &.is-set {
+          color: $blue;
+          visibility: visible;
+        }
+      }
+    }
+  }
+
+  // UI: DnD - specific elems/cases - units
+  .courseware-unit {
+
+    .draggable-drop-indicator-before {
+      top: 0;
+    }
+
+    .draggable-drop-indicator-after {
+      bottom: 0;
+    }
+  }
+
+  // UI: DnD - specific elems/cases - empty parents initial drop indicator
+  .draggable-drop-indicator-initial {
+    display: none;
+  }
+}

--- a/cms/static/sass/views/_utilities.scss
+++ b/cms/static/sass/views/_utilities.scss
@@ -1,0 +1,345 @@
+// Studio - Course Settings
+// ====================
+
+.view-utilities {
+
+  .content-primary, .content-supplementary {
+    @include box-sizing(border-box);
+    float: left;
+  }
+
+  .content-primary {
+    width: flex-grid(9, 12);
+    margin-right: flex-gutter();
+  }
+
+  // utilities - general
+  .course-utility {
+    @extend %ui-window;
+    margin: 0 0 ($baseline*2) 0;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+
+    // visual status
+    .viz-utility-status {
+      @extend %cont-text-hide;
+      @include size(100%,($baseline/4));
+      position: relative;
+      display: block;
+      margin: 0;
+      background: $gray-l4;
+
+      .viz-utility-status-value {
+        @include transition(width $tmg-s2 ease-in-out .25s);
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 0%;
+        height: ($baseline/4);
+        background: $green;
+
+        .int {
+          @extend %cont-text-sr;
+        }
+      }
+    }
+    // <span class="viz viz-utility-status"><span class="viz value viz-utility-status-value"><span class="int">0</span>% of utility completed</span></span>
+
+    // header/title
+    header {
+      @include clearfix();
+      box-shadow: inset 0 -1px 1px $shadow-l1;
+      margin-bottom: 0;
+      border-bottom: 1px solid $gray-l3;
+      padding: $baseline ($baseline*1.5);
+
+      .utility-title {
+        @include transition(color $tmg-f2 ease-in-out 0s);
+        width: flex-grid(6, 9);
+        margin: 0 flex-gutter() 0 0;
+        float: left;
+
+        .ui-toggle-expansion {
+          @include transition(all $tmg-f2 ease-in-out 0s);
+          @include font-size(21);
+          display: inline-block;
+          vertical-align: middle;
+          margin-right: ($baseline/2);
+          color: $gray-l4;
+        }
+
+        &.is-selectable {
+          cursor: pointer;
+
+          &:hover {
+            color: $blue;
+
+            .ui-toggle-expansion {
+              color: $blue;
+            }
+          }
+        }
+      }
+
+      .utility-status {
+        @extend %t-copy-sub1;
+        width: flex-grid(3, 9);
+        float: right;
+        margin-top: ($baseline/2);
+        text-align: right;
+        color: $gray-l2;
+
+
+        .icon-ok {
+          @include font-size(20);
+          display: inline-block;
+          margin-left: ($baseline/2);
+          color: $gray-l4;
+        }
+
+        .status-count {
+          @extend %t-copy-base;
+          margin-left: ($baseline/4);
+          margin-right: ($baseline/4);
+          color: $gray-d3;
+          font-weight: 600;
+        }
+
+        .status-amount {
+          @extend %t-copy-base;
+          margin-left: ($baseline/4);
+          color: $gray-d3;
+          font-weight: 600;
+        }
+      }
+    }
+
+    // utility actions
+    .course-utility-actions {
+      @include clearfix();
+      @include transition(border $tmg-f2 ease-in-out .25s);
+      box-shadow: inset 0 1px 1px $shadow-l1;
+      border-top: 1px solid $gray-l2;
+      padding: $baseline ($baseline*1.5);
+      background: $gray-l4;
+
+      .action-primary {
+        @include green-button();
+        float: left;
+
+        .icon-add {
+          @include font-size(12);
+          display: inline-block;
+          vertical-align: middle;
+          margin-right: ($baseline/4);
+        }
+      }
+
+      .action-secondary {
+        @include grey-button();
+        @extend %t-action3;
+        font-weight: 400;
+        float: right;
+
+        .icon-delete {
+          @include font-size(12);
+          display: inline-block;
+          vertical-align: middle;
+          margin-right: ($baseline/4);
+        }
+      }
+    }
+
+    // state - collapsed
+    &.is-collapsed {
+
+      header {
+        box-shadow: none;
+
+        .utility-title {
+
+          .ui-toggle-expansion {
+            @include transform(rotate(-90deg));
+            @include transform-origin(50% 50%);
+          }
+        }
+      }
+
+      .list-tasks {
+        height: 0;
+      }
+    }
+
+    // state - completed
+    &.is-completed {
+
+      .viz-utility-status {
+
+        .viz-utility-status-value {
+          width: 100%;
+        }
+      }
+
+      header {
+
+        .utility-title, .icon-caret-down {
+          color: $green;
+        }
+
+        .utility-status {
+
+          .status-count, .status-amount, .icon-ok {
+            color: $green;
+          }
+        }
+      }
+    }
+
+    // state - not available
+    .is-not-available {
+
+    }
+  }
+
+  // list of tasks
+  .list-tasks {
+    height: auto;
+    overflow: hidden;
+
+    .task {
+      @include transition(background $tmg-f2 ease-in-out 0s, border $tmg-f3 ease-in-out 0s);
+      @include clearfix();
+      position: relative;
+      border-top: 1px solid $white;
+      border-bottom: 1px solid $gray-l5;
+      padding: $baseline ($baseline*1.5);
+      background: $white;
+      opacity: 1.0;
+
+
+      &:last-child {
+        margin-bottom: 0;
+        border-bottom: none;
+      }
+
+      .task-input {
+        display: inline-block;
+        vertical-align: text-top;
+        float: left;
+        margin: ($baseline/2) flex-gutter() 0 0;
+      }
+
+      .task-details {
+        display: inline-block;
+        vertical-align: text-top;
+        float: left;
+        width: flex-grid(6,9);
+        font-weight: 500;
+
+        .task-name {
+          @include transition(color $tmg-f2 ease-in-out 0s);
+          vertical-align: baseline;
+          cursor: pointer;
+          margin-bottom: 0;
+        }
+
+        .task-description {
+          @extend %t-copy-sub1;
+          @include transition(color $tmg-f2 ease-in-out 0s);
+          color: $gray-l2;
+        }
+
+        .task-support {
+          @extend %t-copy-sub2;
+          @include transition(opacity $tmg-f2 ease-in-out 0s);
+          opacity: 0.0;
+          pointer-events: none;
+        }
+      }
+
+      .task-actions {
+        @include transition(opacity $tmg-f2 ease-in-out 0.25s);
+        @include clearfix();
+        display: inline-block;
+        vertical-align: middle;
+        float: right;
+        width: flex-grid(2,9);
+        margin: ($baseline/2) 0 0 flex-gutter();
+        opacity: 0.0;
+        pointer-events: none;
+        text-align: right;
+
+        .action-primary {
+          @include blue-button;
+          @extend %t-action4;
+          font-weight: 600;
+          text-align: center;
+        }
+
+        .action-secondary {
+          @extend %t-action4;
+          margin-top: ($baseline/2);
+        }
+      }
+
+      // state - hover
+      &:hover {
+        background: $blue-l5;
+        border-bottom-color: $blue-l4;
+        border-top-color: $blue-l4;
+        opacity: 1.0;
+
+        .task-details {
+
+          .task-support {
+            opacity: 1.0;
+            pointer-events: auto;
+          }
+        }
+
+        .task-actions {
+          opacity: 1.0;
+          pointer-events: auto;
+        }
+      }
+
+
+      // state - completed
+      &.is-completed {
+        background: $gray-l6;
+        border-top-color: $gray-l5;
+        border-bottom-color: $gray-l5;
+
+        .task-name {
+          color: $gray-l2;
+        }
+
+        .task-actions {
+
+          .action-primary {
+            @include grey-button;
+            @extend %t-action4;
+            font-weight: 600;
+            text-align: center;
+          }
+        }
+
+        &:hover {
+          background: $gray-l5;
+          border-bottom-color: $gray-l4;
+          border-top-color: $gray-l4;
+
+          .task-details {
+            opacity:1.0;
+          }
+        }
+      }
+    }
+  }
+
+  .content-supplementary {
+    width: flex-grid(3, 12);
+  }
+}

--- a/cms/templates/captions.html
+++ b/cms/templates/captions.html
@@ -1,0 +1,180 @@
+<%inherit file="base.html" />
+<%!
+  from django.utils.translation import ugettext as _
+%>
+<%block name="title">${_("Update Video Captions")}</%block>
+<%block name="bodyclass">is-signedin course view-captions</%block>
+
+
+<%namespace name="components" file="widgets/components.html" />
+<%namespace name='static' file='static_content.html'/>
+
+<%block name="content">
+<div class="main-wrapper">
+  <div class="inner-wrapper">
+    <div class="main-column">
+      <form id="update-components" action="#" method="post">
+      <input type="hidden" name="csrfmiddlewaretoken" value="${csrf_token}"/>
+      <ul class="list-actions">
+        <li class="action-item">
+          <a title="Update captions for the selected components" href="#" class="update-button action-primary action">Update</a>
+        </li>
+      </ul>
+
+      <article class="subsection-body window" data-locator="${locator}">
+        <div class="wrapper-dnd">
+          <label class="selectall-label">
+            <input type="checkbox" id="selectall"/>
+            Select all
+          </label>
+            <div class="sortable-unit-list">
+              <ol class="sortable-unit-list">
+                ${components.enum_components(unit_components=videos)}
+              </ol>
+            </div>
+        </div>
+      </article>
+      </form>
+    </div>
+  </div>
+</div>
+</%block>
+
+<%block name="jsextra">
+<link rel="stylesheet" type="text/css" href="${static.url('js/vendor/timepicker/jquery.timepicker.css')}" />
+
+<script type="text/javascript">
+require(["domReady!", "jquery"],
+  function(doc, $) {
+    $('#selectall').click(function () {
+      $('.selectedId').prop('checked', isChecked('selectall'));
+    });
+
+    $('.update-button').on('click',function() {
+      var selected = new Array();
+      $('input:checkbox.selectedId:checked').each(function() {
+         selected.push($(this).attr('name'));
+      });
+
+      // changed the checked icons to spinners
+      $.each(selected, function(idx, elem){
+        $('li.courseware-unit[data-locator="' + elem + '"]').removeClass('green red yellow');
+        v = $('li.courseware-unit[data-locator="' + elem + '"] div.item-actions');
+        v.html('<i class="icon-spinner icon-spin icon-large"></i>');
+      });
+
+      $.ajax({
+        url: '${request.get_full_path()}',
+        type: 'post',
+        dataType: 'json',
+        data: {
+                csrfmiddlewaretoken: '${csrf_token}',
+                action: 'update',
+                update_array: JSON.stringify(selected)
+              },
+        success: function (data) {
+          $.each(data, function(index, val){
+            handleResponse(val);
+          });
+        }
+      });
+    });
+
+    $('li.courseware-unit').each(function(i, el) {
+      var video = {};
+      video.location = $(this).attr('data-locator');
+      $.ajax({
+        url: '${ request.get_full_path()}',
+        type: 'post',
+        dataType: 'json',
+        data: {
+                csrfmiddlewaretoken: '${csrf_token}',
+                action: 'get',
+                video: JSON.stringify(video)
+              },
+        success: function (data) {
+            handleResponse(data);
+        }
+      });
+    });
+
+});
+
+function handleResponse(data) {
+  var icon, to_class;
+  if (data.command == 'found' || data.command == 'choose') {
+    icon ='<i class="icon-ok-sign green icon-large"></i>';
+    to_class = 'green';
+  } else if (data.command == 'replace' || data.command == 'import') {
+    icon ='<i class="icon-time yellow icon-large"></i>';
+    to_class = 'yellow';
+  } else {
+    icon ='<i class="icon-exclamation-sign red icon-large"></i>';
+    to_class = 'red';
+  }
+
+  if(data.is_youtube_mode) {
+    $('li.courseware-unit[data-locator="' + data.location + '"] .popup #platform').removeClass().addClass('icon-youtube icon-large');
+    youtube_local = $('li.courseware-unit[data-locator="' + data.location + '"] .popup #local');
+    if (data.youtube_local) {
+      youtube_local.removeClass().addClass('icon-thumbs-up icon-large');
+    } else {
+      youtube_local.removeClass().addClass('icon-thumbs-down icon-large');
+    }
+
+    youtube_server = $('li.courseware-unit[data-locator="' + data.location + '"] .popup #remote');
+    if (data.youtube_server) {
+      youtube_server.removeClass().addClass('icon-thumbs-up icon-large');
+    } else {
+      youtube_server.removeClass().addClass('icon-thumbs-down icon-large');
+    }
+
+    youtube_diff = $('li.courseware-unit[data-locator="' + data.location + '"] .popup #sync');
+    if (!data.youtube_diff) {
+      youtube_diff.removeClass().addClass('icon-thumbs-up icon-large');
+    } else {
+      youtube_diff.removeClass().addClass('icon-thumbs-down icon-large');
+    }
+  } else {
+    $('li.courseware-unit[data-locator="' + data.location + '"] .popup #platform').removeClass().addClass('icon-cloud icon-large');
+
+    html5_local = $('li.courseware-unit[data-locator="' + data.location + '"] .popup #local');
+    if (data.html5_local.length > 0) {
+      html5_local.removeClass().addClass('icon-thumbs-up icon-large');
+    } else {
+      html5_local.removeClass().addClass('icon-thumbs-down icon-large');
+    }
+
+    html5_server = $('li.courseware-unit[data-locator="' + data.location + '"] .popup #remote');
+    html5_server.removeClass().addClass('icon-thumbs-down icon-large');
+
+    html5_diff= $('li.courseware-unit[data-locator="' + data.location + '"] .popup #sync');
+    html5_diff.removeClass().addClass('icon-thumbs-down icon-large');
+
+  }
+  $('li.courseware-unit[data-locator="' + data.location + '"]').removeClass('red yellow green').addClass(to_class);
+  v = $('li.courseware-unit[data-locator="' + data.location + '"] div.item-actions');
+  v.html(icon);
+}
+function isChecked(checkboxId) {
+  var id = '#' + checkboxId;
+  return $(id).is(':checked');
+}
+
+function resetSelectAll() {
+  // if all checkbox are selected, check the selectall checkbox
+  // and viceversa
+  if ($('.selectedId').length == $('.selectedId:checked').length) {
+    $('#selectall').attr('checked', 'checked');
+  } else {
+    $('#selectall').removeAttr('checked');
+  }
+
+  if ($('.selectedId:checked').length > 0) {
+    $('#edit').attr('disabled', false);
+  } else {
+    $('#edit').attr('disabled', true);
+  }
+}
+</script>
+</%block>

--- a/cms/templates/js/utility.underscore
+++ b/cms/templates/js/utility.underscore
@@ -1,0 +1,52 @@
+<% var allChecked = itemsChecked == items.length; %>
+<section
+    <% if (allChecked) { %>
+    class="course-utility is-completed"
+    <% } else { %>
+    class="course-utility"
+    <% } %>
+    id="<%= 'course-uility' + utilityIndex %>">
+    <span class="viz viz-utility-status"><span class="viz value viz-utility-status-value" style="width: <%= percentChecked %>%;">
+        <%= _.template(gettext("{number}% of utilities completed"), {number: '<span class="int">' + percentChecked + '</span>'}, {interpolate: /\{(.+?)\}/g}) %>
+    </span></span>
+    <header>
+        <h3 class="utility-title title-2 is-selectable" title="Collapse/Expand this utility">
+            <i class="icon-caret-down ui-toggle-expansion"></i>
+            <%= utilityShortDescription %></h3>
+    </header>
+
+    <ul class="list list-tasks">
+        <% var taskIndex = 0; %>
+        <% _.each(items, function(item) { %>
+            <% var checked = item['is_checked']; %>
+            <li
+            <% if (checked) { %>
+            class="task is-completed"
+            <% } else { %>
+            class="task"
+            <% } %>
+            >
+                <% var taskId = 'course-utility' + utilityIndex + '-task' + taskIndex; %>
+
+                <label class="task-details" for="<%= taskId %>">
+                    <h4 class="task-name title title-3"><%= item['short_description'] %></h4>
+                    <p class="task-description"><%= item['long_description'] %></p>
+                </label>
+
+                <% if (item['action_text'] !== '' && item['action_url'] !== '') { %>
+                <ul class="list-actions task-actions">
+                    <li class="action-item">
+                        <a href="<%= item['action_url'] %>" class="action action-primary"
+                        <% if (item['action_external']) { %>
+                        rel="external" title="<%= gettext("This link will open in a new browser window/tab") %>"
+                        <% } %>
+                        ><%= item['action_text'] %></a>
+                    </li>
+                </ul>
+                <% } %>
+            </li>
+
+        <% taskIndex+=1; }) %>
+
+    </ul>
+</section>

--- a/cms/templates/utility.html
+++ b/cms/templates/utility.html
@@ -1,0 +1,77 @@
+<%inherit file="base.html" />
+<%!
+  from django.core.urlresolvers import reverse
+  from django.utils.translation import ugettext as _
+%>
+<%block name="title">Course Utilities</%block>
+<%block name="bodyclass">is-signedin course view-utilities</%block>
+
+<%namespace name='static' file='static_content.html'/>
+
+<%block name="header_extras">
+% for template_name in ["utility"]:
+  <script type="text/template" id="${template_name}-tpl">
+    <%static:include path="js/${template_name}.underscore" />
+  </script>
+% endfor
+</%block>
+
+<%block name="jsextra">
+<script type="text/javascript">
+require(["domReady!", "jquery", "js/collections/utility", "js/views/utility"],
+        function(doc, $, UtilityCollection, UtilityView) {
+    var utilityCollection = new UtilityCollection();
+    utilityCollection.url = "${handler_url}";
+
+    var editor = new UtilityView({
+        el: $('.course-utilities'),
+        collection: utilityCollection
+    });
+    utilityCollection.fetch({reset: true});
+});
+</script>
+</%block>
+
+
+<%block name="content">
+<div class="wrapper-mast wrapper">
+  <header class="mast has-actions has-subtitle">
+    <h1 class="page-header">
+      <small class="subtitle">${_("Tools")}</small>
+      <span class="sr">&gt; </span>${_("Course Utilities")}
+    </h1>
+  </header>
+</div>
+
+<div class="wrapper-content wrapper">
+  <section class="content">
+    <article class="content-primary" role="main">
+      <form id="course-utilities" class="course-utilities" method="post" action="">
+        <h2 class="title title-3 sr">${_("Current Utilities")}</h2>
+      </form>
+    </article>
+
+    <aside class="content-supplementary" role="complimentary">
+      <div class="bit">
+        <h3 class="title title-3">${_("What are course utilities?")}</h3>
+        <p>
+          ${_("The utilities section provides a gateway to self-service tasks or  bulk operations to course instructors. The utilities are meant to provide services that makes it easier for the instructors to manage their courses.")}
+        </p>
+      </div>
+
+      <div class="bit">
+        <h3 class="title title-3">Studio utilities</h3>
+        <nav class="nav-page utilities-current">
+          <ol>
+            % for utility in utilities:
+            <li class="nav-item">
+              <a rel="view" href="${'#course-utilities' + str(loop.index)}">${utility['short_description']}</a>
+            </li>
+            % endfor
+          </ol>
+        </nav>
+      </div>
+    </aside>
+  </section>
+</div>
+</%block>

--- a/cms/templates/widgets/components.html
+++ b/cms/templates/widgets/components.html
@@ -1,0 +1,33 @@
+<!--
+This def will enumerate through a passed in components and list all them all.
+-->
+<%def name="enum_components(unit_components, actions=True, selected=None, sortable=True)">
+  % for component in unit_components:
+
+  <li class="courseware-unit unit is-draggable" data-locator=${component['location']}>
+
+    <%include file="_ui-dnd-indicator-before.html" />
+
+    <label class="section-item">
+
+      <input type="checkbox" class="selectedId" name=${component['location']} value="" onclick="resetSelectAll();" />
+      <span class="component-name">${component['name']}</span>
+
+      <div class="popup">
+        <i class="icon-youtube icon-large" id="platform"></i>
+        <i class="icon-thumbs-up icon-large" id="local"></i>
+        <i class="icon-thumbs-up icon-large" id="remote"></i>
+        <i class="icon-thumbs-up icon-large" id="sync"></i>
+      </div>
+
+      <div class="item-actions">
+        <i class="icon-spinner icon-spin icon-large"></i>
+      </div>
+
+    </label>
+
+    <%include file="_ui-dnd-indicator-after.html" />
+  </li>
+  % endfor
+</%def>
+

--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -18,6 +18,7 @@
             location = loc_mapper().translate_location(ctx_loc.course_id, ctx_loc, False, True)
             index_url = location.url_reverse('course')
             checklists_url = location.url_reverse('checklists')
+            utilities_url = location.url_reverse('utility')
             course_team_url = location.url_reverse('course_team')
             assets_url = location.url_reverse('assets')
             textbooks_url = location.url_reverse('textbooks')
@@ -103,6 +104,9 @@
                   </li>
                   <li class="nav-item nav-course-tools-export">
                     <a href="${export_url}">${_("Export")}</a>
+                  </li>
+                  <li class="nav-item nav-course-tools-utilities">
+                    <a href="${utilities_url}">${_("Utilities")}</a>
                   </li>
                   % if settings.FEATURES.get('ENABLE_EXPORT_GIT') and context_course.giturl:
                   <li class="nav-item nav-course-tools-export-git">

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -79,6 +79,9 @@ urlpatterns += patterns(
     url(r'(?ix)^unit($|/){}$'.format(parsers.URL_RE_SOURCE), 'unit_handler'),
     url(r'(?ix)^container($|/){}$'.format(parsers.URL_RE_SOURCE), 'container_handler'),
     url(r'(?ix)^checklists/{}(/)?(?P<checklist_index>\d+)?$'.format(parsers.URL_RE_SOURCE), 'checklists_handler'),
+    url(r'(?ix)^utility/{}(/)?(?P<utilities_index>\d+)?$'.format(parsers.URL_RE_SOURCE), 'utility_handler'),
+    url(r'(?ix)^utilities/captions/{}(/)?(?P<utilities_index>\d+)?$'.format(parsers.URL_RE_SOURCE), 'utility_captions_handler'),
+
     url(r'(?ix)^orphan/{}$'.format(parsers.URL_RE_SOURCE), 'orphan_handler'),
     url(r'(?ix)^assets/{}(/)?(?P<asset_id>.+)?$'.format(parsers.URL_RE_SOURCE), 'assets_handler'),
     url(r'(?ix)^import/{}$'.format(parsers.URL_RE_SOURCE), 'import_handler'),

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -358,6 +358,17 @@ class CourseFields(object):
                                       "action_text": "Edit Course Schedule &amp; Details",
                                       "action_external": False}]}
         ])
+
+    utilities = List(scope=Scope.settings,
+                     default=[
+                         {"short_description": "Bulk Operations",
+                          "items": [
+                              {"short_description": "Get all captions from YouTube",
+                               "long_description": "This utility will attempt to get or update captions for all videos in the course from YouTube. Please allow it a couple of minutes to run.",
+                               "action_url": "UtilitiesVideoCaptions",
+                               "action_text": "Check Captions",
+                               "action_external": False}]}
+                     ])
     info_sidebar_name = String(scope=Scope.settings, default='Course Handouts')
     show_timezone = Boolean(
         help="True if timezones should be shown on dates in the courseware. Deprecated in favor of due_date_display_format.",


### PR DESCRIPTION
@jbau please take a look.

This is the first draft of the new utilities page (Tools > Utilities) and includes an "update captions" utility. The utility shows all the videos in the course to the user, with an icon indicating whether Studio has the same copy of the video captions as youtube. User can then use the utility to replace caption files with those from youtube.

The functionality to update a single video currently exists in studio. The key idea here is that when professors want to update many videos, they would be able to do it quickly in bulk (rather than updating each video individually).

I'm looking for feedback on both functionality and look and feel of the new pages. Code is still in development and is missing unit tests and needs some clean up.
