### PR TITLE
bugfix: allow multiple choice questions to display hints

### DIFF
--- a/common/lib/capa/capa/templates/choicegroup.html
+++ b/common/lib/capa/capa/templates/choicegroup.html
@@ -62,4 +62,7 @@
     % if show_correctness == "never" and (value or status not in ['unsubmitted']):
     <div class="capa_alert">${submitted_message}</div>
     %endif
+    % if msg:
+    <span class="message">${msg|n}</span>
+    % endif
 </form>

--- a/common/lib/capa/capa/templates/choicetext.html
+++ b/common/lib/capa/capa/templates/choicetext.html
@@ -64,5 +64,8 @@
     % if show_correctness == "never" and (value or status not in ['unsubmitted']):
     <div class="capa_alert">${submitted_message}</div>
     %endif
+    % if msg:
+    <span class="message">${msg|n}</span>
+    % endif
 </form>
 </section>


### PR DESCRIPTION
This is needed for hints to be able to be displayed, for multiple choice questions.

Both HarvardX and MITx would like to be able to use the adaptive hints system to provide hints for multiple choice questions.  Examples of adaptive hints provided using hintfn are given in the demo latex2edx course (https://edge.edx.org/courses/MITx/MIT.latex2edx/2014_Spring/about), but this currently does not work for multiple choice questions; it works for customresponse and optionresponse, in contrast.

See analogous change in #687

See also request for this feature here:  http://help.edge.edx.org/discussions/questions/727-how-to-enable-adaptive-hints-for-multiple-choice-questions

@sarina, @pmitros  (and maybe @ormsbee?)
