### PR TITLE
Make TinyMCE more tolerant about HTML elements

### DIFF
--- a/cms/djangoapps/contentstore/features/html-editor.feature
+++ b/cms/djangoapps/contentstore/features/html-editor.feature
@@ -47,6 +47,26 @@ Feature: CMS.HTML Editor
       --></style>
       """
 
+  Scenario: TinyMCE and CodeMirror preserve span tags
+    Given I have created a Blank HTML Page
+    When I edit the page
+    And type "<span>Test</span>" in the code editor and press OK
+    And I save the page
+    Then the page text contains:
+      """
+      <span>Test</span>
+      """
+
+  Scenario: TinyMCE and CodeMirror preserve math tags
+    Given I have created a Blank HTML Page
+    When I edit the page
+    And type "<math><msup><mi>x</mi><mn>2</mn></msup></math>" in the code editor and press OK
+    And I save the page
+    Then the page text contains:
+      """
+      <math><msup><mi>x</mi><mn>2</mn></msup></math>
+      """
+
   Scenario: TinyMCE toolbar buttons are as expected
     Given I have created a Blank HTML Page
     When I edit the page
@@ -57,7 +77,7 @@ Feature: CMS.HTML Editor
     When I edit the page
     And type "<img src="/static/image.jpg">" in the code editor and press OK
     Then the src link is rewritten to "c4x/MITx/999/asset/image.jpg"
-    And the code editor displays "<p><img src="/static/image.jpg" alt="" /></p>"
+    And the code editor displays "<p><img src="/static/image.jpg" /></p>"
 
   Scenario: Code format toolbar button wraps text with code tags
     Given I have created a Blank HTML Page

--- a/common/lib/xmodule/xmodule/js/src/html/edit.coffee
+++ b/common/lib/xmodule/xmodule/js/src/html/edit.coffee
@@ -53,7 +53,6 @@ class @HTMLEditingDescriptor
       valid_children : "+body[style]",
 
       # Allow any elements to be used, e.g. link, script, math
-      verify_html: false,
       valid_elements: "*[*]",
       extended_valid_elements: "*[*]",
       invalid_elements: "",

--- a/common/lib/xmodule/xmodule/js/src/html/edit.coffee
+++ b/common/lib/xmodule/xmodule/js/src/html/edit.coffee
@@ -48,8 +48,16 @@ class @HTMLEditingDescriptor
       height: '400px',
       menubar: false,
       statusbar: false,
+
       # Necessary to avoid stripping of style tags.
       valid_children : "+body[style]",
+
+      # Allow any elements to be used, e.g. link, script, math
+      verify_html: false,
+      valid_elements: "*[*]",
+      extended_valid_elements: "*[*]",
+      invalid_elements: "",
+
       setup: @setupTinyMCE,
       # Cannot get access to tinyMCE Editor instance (for focusing) until after it is rendered.
       # The tinyMCE callback passes in the editor as a parameter.


### PR DESCRIPTION
STUD-1565

This change improves TinyMCE's handling of some HTML elements (e.g. span tags, math tags etc) but doesn't completely solve the issues our users are reporting: 

http://help.edge.edx.org/discussions/problems/4718-help-me-understand-what-studio-strips-from-my-code

In particular, TinyMCE will still rewrite the user's HTML, losing whitespace, comments etc. It also loses <link> tags which strictly speaking aren't allowed outside the head tag, but for some reason seems to be used as a workaround in most browsers. I tried all of the TinyMCE options I could find, but I think I've hit the limit now.

@cahrens Let me know whether you think this is a net win, or whether it doesn't get us far enough. Either way, we still need your changes, I believe.

@nasthagiri Could you also review this when you have a chance.
