### PR TITLE
fix for an internal server error reported by splunk

### DIFF
--- a/lms/templates/static_templates/server-error.html
+++ b/lms/templates/static_templates/server-error.html
@@ -4,7 +4,7 @@
 <section class="outside-app">
   <h1>
     ${_(u"There has been a 500 error on the {platform_name} servers").format(
-        platform_name=u"<em>{}</em>".format(platform_name=settings.PLATFORM_NAME)
+        platform_name=u"<em>{platform_name}</em>".format(platform_name=settings.PLATFORM_NAME)
     )}
   </h1>
   <p>


### PR DESCRIPTION
```

pr 22 20:14:35 prod-edxapp-009
[service_variant=lms][django.request][env:prod_edx] ERROR
[prod-edxapp-009  29543] [base.py:215] - Internal Server Error:
/courses/IMFx/OL14.01/2T2014/discussion/53564e81dfc11c02150003c6
Traceback (most recent call last):
  File
"/opt/edx/local/lib/python2.7/site-packages/django/core/handlers/base.py",
line 111, in get_response
    response = callback(request, *callback_args, **callback_kwargs)
  File
"/opt/edx/local/lib/python2.7/site-packages/newrelic-2.18.1.15/newrelic/hooks/framework_django.py",
line 492, in wrapper
    return wrapped(*args, **kwargs)
  File
"/opt/wwc/edx-platform/lms/djangoapps/static_template_view/views.py",
line 69, in render_500
    return
HttpResponseServerError(render_to_string('static_templates/server-error.html',
{}))
  File "/opt/wwc/edx-platform/common/djangoapps/edxmako/shortcuts.py",
line 104, in render_to_string
    return template.render_unicode(**context_dictionary)
  File "/opt/edx/local/lib/python2.7/site-packages/mako/template.py",
line 452, in render_unicode
    as_unicode=True)
  File
"/opt/edx/local/lib/python2.7/site-packages/newrelic-2.18.1.15/newrelic/hooks/template_mako.py",
line 25, in __call__
    return self.__wrapped(template, *args, **kwargs)
  File "/opt/edx/local/lib/python2.7/site-packages/mako/runtime.py",
line 807, in _render
    **_kwargs_for_callable(callable_, data))
  File "/opt/edx/local/lib/python2.7/site-packages/mako/runtime.py",
line 839, in _render_context
    _exec_template(inherit, lclcontext, args=args, kwargs=kwargs)
  File "/opt/edx/local/lib/python2.7/site-packages/mako/runtime.py",
line 865, in _exec_template
    callable_(context, *args, **kwargs)
  File "/tmp/tmpv1orA2mako/main.html.py", line 253, in render_body
    __M_writer(filters.decode.utf8(self.body()))
  File "/tmp/tmpv1orA2mako/static_templates/server-error.html.py", line
40, in render_body
    platform_name=u"<em>{}</em>".format(platform_name=settings.PLATFORM_NAME)
IndexError: tuple index out of range

```
