### PR TITLE
Set initial video quality to large instead of default to avoid automatic switch to HD when iframe resizes. [BLD 981]

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ These are notable changes in edx-platform.  This is a rolling list of changes,
 in roughly chronological order, most recent first.  Add your entries at or near
 the top.  Include a label indicating the component affected.
 
+Blades: Set initial video quality to large instead of default to avoid automatic switch to HD when iframe resizes. BLD-981.
+
 Blades: Add an upload button for authors to provide students with an option to
 download a handout associated with a video (of arbitrary file format). BLD-1000.
 

--- a/common/lib/xmodule/xmodule/js/spec/video/video_quality_control_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_quality_control_spec.js
@@ -57,6 +57,12 @@
                     .toEqual(1);
             });
 
+            it('initializes with a quality equal to large', function () {
+                videoPlayer.onPlay();
+
+                expect(player.setPlaybackQuality).toHaveBeenCalledWith('large');
+            });
+
             it('shows the quality control on play if HD is available',
                function () {
                 videoPlayer.onPlay();

--- a/common/lib/xmodule/xmodule/js/src/video/05_video_quality_control.js
+++ b/common/lib/xmodule/xmodule/js/src/video/05_video_quality_control.js
@@ -104,6 +104,12 @@ function () {
         if (this.config.availableHDQualities.length > 0) {
             this.trigger('videoQualityControl.showQualityControl');
         }
+        // On initialization, force the video quality to be 'large' instead of
+        // 'default'. Otherwise, the player will sometimes switch to HD
+        // automatically, for example when the iframe resizes itself.
+        this.trigger('videoPlayer.handlePlaybackQualityChange',
+            this.videoQualityControl.quality
+        );
     }
 
     function onQualityChange(value) {


### PR DESCRIPTION
@polesye @valera-rozuvan Please review.
