### PR TITLE
XBlocks are something initialized before all resources (url) are loaded

### DIFF
--- a/cms/static/js/views/xblock.js
+++ b/cms/static/js/views/xblock.js
@@ -33,7 +33,7 @@ define(["jquery", "underscore", "js/views/baseview", "xblock/runtime.v1"],
                     fragmentsRendered;
 
                 fragmentsRendered = this.renderXBlockFragment(fragment, wrapper);
-                $.when(fragmentsRendered).done(function() {
+                fragmentsRendered.done(function() {
                     xblockElement = self.$('.xblock').first();
                     xblock = XBlock.initializeBlock(xblockElement);
                     self.xblock = xblock;

--- a/cms/static/js/views/xblock.js
+++ b/cms/static/js/views/xblock.js
@@ -25,18 +25,23 @@ define(["jquery", "underscore", "js/views/baseview", "xblock/runtime.v1"],
             },
 
             handleXBlockFragment: function(fragment, options) {
-                var wrapper = this.$el,
+                var self = this,
+                    wrapper = this.$el,
                     xblockElement,
                     success = options ? options.success : null,
-                    xblock;
-                this.renderXBlockFragment(fragment, wrapper);
-                xblockElement = this.$('.xblock').first();
-                xblock = XBlock.initializeBlock(xblockElement);
-                this.xblock = xblock;
-                this.xblockReady(xblock);
-                if (success) {
-                    success(xblock);
-                }
+                    xblock,
+                    fragmentsRendered;
+
+                fragmentsRendered = this.renderXBlockFragment(fragment, wrapper);
+                $.when(fragmentsRendered).done(function() {
+                    xblockElement = self.$('.xblock').first();
+                    xblock = XBlock.initializeBlock(xblockElement);
+                    self.xblock = xblock;
+                    self.xblockReady(xblock);
+                    if (success) {
+                        success(xblock);
+                    }
+                });
             },
 
             /**


### PR DESCRIPTION
I had some issues with the latest master with one of my xblock, especially when playing with the Studio edit. The xblock was initialized before my main init function was fetched and executed from the server. After some investigation, I noticed that the promise of the resources was simply not taken into account.

This PR fixes the issue. Basically, it waits that all fragment resources are loaded and rendered before trying to call the init function.

Let me know if you have any concern or modification you'd like.
