### PR TITLE
Fixed transform_url function in WikiAccessMiddleware.

### DIFF
--- a/lms/djangoapps/course_wiki/middleware.py
+++ b/lms/djangoapps/course_wiki/middleware.py
@@ -52,11 +52,10 @@ class WikiAccessMiddleware(object):
             return redirect(reverse('accounts_login'), next=request.path)
 
         if course_id:
-            # this is a /course/123/wiki request
-            my_url = request.path.replace(wiki_path, '').replace('/wiki/', '')
-            # HACK: django-wiki monkeypatches the reverse function to enable
-            # urls to be rewritten
-            reverse._transform_url = lambda url: my_url + url  # pylint: disable=W0212
+            # This is a /courses/org/name/run/wiki request
+            # HACK: django-wiki monkeypatches the django reverse function to enable urls to be rewritten
+            url_prefix = "/courses/{0}".format(course_id)
+            reverse._transform_url = lambda url: url_prefix + url  # pylint: disable=protected-access
             # Authorization Check
             # Let's see if user is enrolled or the course allows for public access
             try:

--- a/lms/djangoapps/course_wiki/tests/test_middleware.py
+++ b/lms/djangoapps/course_wiki/tests/test_middleware.py
@@ -1,0 +1,36 @@
+"""
+Tests for wiki middleware.
+"""
+
+from django.test.client import Client
+from django.test.utils import override_settings
+from wiki.models import URLPath
+
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory
+
+from courseware.tests.factories import InstructorFactory
+from courseware.tests.modulestore_config import TEST_DATA_MIXED_MODULESTORE
+from course_wiki.views import get_or_create_root
+
+
+@override_settings(MODULESTORE=TEST_DATA_MIXED_MODULESTORE)
+class TestWikiAccessMiddleware(ModuleStoreTestCase):
+    """Tests for WikiAccessMiddleware."""
+
+    def setUp(self):
+        """Test setup."""
+        self.wiki = get_or_create_root()
+
+        self.course_math101 = CourseFactory.create(org='edx', number='math101', display_name='2014', metadata={'use_unique_wiki_id': 'false'})
+        self.course_math101_instructor = InstructorFactory(course=self.course_math101.location, username='instructor', password='secret')
+        self.wiki_math101 = URLPath.create_article(self.wiki, 'math101', title='math101')
+
+        self.client = Client()
+        self.client.login(username='instructor', password='secret')
+
+    def test_url_tranform(self):
+        """Test that the correct prefix ('/courses/<course_id>') is added to the urls in the wiki."""
+        response = self.client.get('/courses/edx/math101/2014/wiki/math101/')
+        self.assertIn('/courses/edx/math101/2014/wiki/math101/_edit/', response.content)
+        self.assertIn('/courses/edx/math101/2014/wiki/math101/_settings/', response.content)


### PR DESCRIPTION
In the current implementation if the path prefix contains the
wiki_path value it gets deleted. For example if the prefix is
'/courses/edx/math101/2014' and wiki_path is '101/' the final
prefix becomes '/courses/edx/math2014'.

JIRA: LMS-2556
