### PR TITLE
Fix paver python prereq paths

### DIFF
--- a/pavelib/prereqs.py
+++ b/pavelib/prereqs.py
@@ -13,6 +13,8 @@ PREREQS_MD5_DIR = os.getenv('PREREQ_CACHE_DIR', Env.REPO_ROOT / '.prereqs_cache'
 NPM_REGISTRY = "http://registry.npmjs.org/"
 PYTHON_REQ_FILES = [
     'requirements/edx/pre.txt',
+    'requirements/edx/github.txt',
+    'requirements/edx/local.txt',
     'requirements/edx/base.txt',
     'requirements/edx/post.txt',
 ]

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -4,8 +4,6 @@
 #   * @jtauber - to check licensing
 #   * One of @e0d, @jarv, or @feanil - to check system requirements
 
--r repo.txt
-
 beautifulsoup4==4.1.3
 beautifulsoup==3.2.1
 bleach==1.4

--- a/requirements/edx/repo.txt
+++ b/requirements/edx/repo.txt
@@ -1,2 +1,0 @@
--r github.txt
--r local.txt


### PR DESCRIPTION
Currently paver can't detect if something changed in `requirements/edx/github.txt`,    `requirements/edx/local.txt`. Added these file paths in `pavelib/prereqs.py` so that correct prereqs are installed. Also deleted `requirements/edx/repo.txt` as it looks like that now no one is using it.
