### PR TITLE
Add dev command to run in native envs.

### DIFF
--- a/docs/en_us/developers/source/pavelib.rst
+++ b/docs/en_us/developers/source/pavelib.rst
@@ -140,7 +140,12 @@ Run Servers
 
     **run_celery**: runs celery for specified system
 
-     *--settings=* Environment settings e.g. aws, dev
+     *--settings=* Environment settings e.g. aws, dev both for LMS and Studio
+
+     *--settings_lms=* Override django settings for LMS e.g. cms.dev
+
+     *--settings_cms=* Override django settings for Studio
+
 
 ::
 


### PR DESCRIPTION
I have some issues with paver, local Mac OS dev env.

1) when i do
 paver run_all_servers --settings=dev --worker_settings=celery
Ctrl-C
and 
paver run_all_servers --settings=dev --worker_settings=celery
second time
I got 

```
0 errors found
Django version 1.4.8, using settings 'cms.envs.dev'
Development server is running at http://0.0.0.0:8001/
Quit the server with CONTROL-C.
Error: [Errno 48] Address already in use
0 errors found
Django version 1.4.8, using settings 'lms.envs.dev'
Development server is running at http://0.0.0.0:8000/
Quit the server with CONTROL-C.
Error: [Errno 48] Address already in use
```

2) If in one terminal window I do
 paver studio --settings=dev
and in second terminal window I do
 paver lms --settings=cms.dev
In 1st terminal process is aborted with next message:

```
0 errors found
Django version 1.4.8, using settings 'cms.envs.dev'
Development server is running at http://0.0.0.0:8001/
Quit the server with CONTROL-C.
  overwrite lms/static/sass/application-extend1.css
  overwrite lms/static/sass/application-extend2.css
  overwrite lms/static/sass/application.css
  overwrite lms/static/sass/course.css
    CHANGED: /Users/kry/mitx_all/edx-platform/lms/static/sass/application-extend1.scss
sass --style compressed --cache-location /tmp/sass-cache --load-path ./common/static/sass --update -E utf-8 */static
Processes ending
```

And vice versa.

@singingwolfboy please review.
