### PR TITLE
Tolerance expressed in percentage now computes correctly. [BLD-522]

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ These are notable changes in edx-platform.  This is a rolling list of changes,
 in roughly chronological order, most recent first.  Add your entries at or near
 the top.  Include a label indicating the component affected.
 
+Blades: Tolerance expressed in percentage now computes correctly. BLD-522.
+
 Studio: Add drag-and-drop support to the container page. STUD-1309.
 
 Common: Add extensible third-party auth module.

--- a/common/lib/capa/capa/tests/test_responsetypes.py
+++ b/common/lib/capa/capa/tests/test_responsetypes.py
@@ -20,6 +20,7 @@ from capa.responsetypes import LoncapaProblemError, \
     StudentInputError, ResponseError
 from capa.correctmap import CorrectMap
 from capa.util import convert_files_to_filenames
+from capa.util import compare_with_tolerance
 from capa.xqueue_interface import dateformat
 
 from pytz import UTC
@@ -1120,7 +1121,6 @@ class NumericalResponseTest(ResponseTest):
     # We blend the line between integration (using evaluator) and exclusively
     # unit testing the NumericalResponse (mocking out the evaluator)
     # For simple things its not worth the effort.
-
     def test_grade_range_tolerance(self):
         problem_setup = [
             # [given_asnwer, [list of correct responses], [list of incorrect responses]]
@@ -1177,9 +1177,20 @@ class NumericalResponseTest(ResponseTest):
         self.assert_multiple_grade(problem, correct_responses, incorrect_responses)
 
     def test_grade_percent_tolerance(self):
+        # Positive only range
         problem = self.build_problem(answer=4, tolerance="10%")
-        correct_responses = ["4.0", "4.3", "3.7", "4.30", "3.70"]
-        incorrect_responses = ["", "4.5", "3.5", "0"]
+        correct_responses = ["4.0", "4.00", "4.39", "3.61"]
+        incorrect_responses = ["", "4.41", "3.59", "0"]
+        self.assert_multiple_grade(problem, correct_responses, incorrect_responses)
+        # Negative only range
+        problem = self.build_problem(answer=-4, tolerance="10%")
+        correct_responses = ["-4.0", "-4.00", "-4.39", "-3.61"]
+        incorrect_responses = ["", "-4.41", "-3.59", "0"]
+        self.assert_multiple_grade(problem, correct_responses, incorrect_responses)
+        # Mixed negative/positive range
+        problem = self.build_problem(answer=1, tolerance="200%")
+        correct_responses = ["1", "1.00", "2.99", "0.99"]
+        incorrect_responses = ["", "3.01", "-1.01"]
         self.assert_multiple_grade(problem, correct_responses, incorrect_responses)
 
     def test_floats(self):

--- a/common/lib/capa/capa/tests/test_util.py
+++ b/common/lib/capa/capa/tests/test_util.py
@@ -1,0 +1,82 @@
+"""Tests capa util"""
+
+import unittest
+import textwrap
+from . import test_capa_system
+from capa.util import compare_with_tolerance
+
+
+class UtilTest(unittest.TestCase):
+    """Tests for util"""
+    def setUp(self):
+        super(UtilTest, self).setUp()
+        self.system = test_capa_system()
+
+    def test_compare_with_tolerance(self):
+        # Test default tolerance '0.001%' (it is relative)
+        result = compare_with_tolerance(100.0, 100.0)
+        self.assertTrue(result)
+        result = compare_with_tolerance(100.001, 100.0)
+        self.assertTrue(result)
+        result = compare_with_tolerance(101.0, 100.0)
+        self.assertFalse(result)
+        # Test absolute percentage tolerance
+        result = compare_with_tolerance(109.9, 100.0, '10%', False)
+        self.assertTrue(result)
+        result = compare_with_tolerance(110.1, 100.0, '10%', False)
+        self.assertFalse(result)
+        # Test relative percentage tolerance
+        result = compare_with_tolerance(111.0, 100.0, '10%', True)
+        self.assertTrue(result)
+        result = compare_with_tolerance(112.0, 100.0, '10%', True)
+        self.assertFalse(result)
+        # Test absolute tolerance (string)
+        result = compare_with_tolerance(109.9, 100.0, '10.0', False)
+        self.assertTrue(result)
+        result = compare_with_tolerance(110.1, 100.0, '10.0', False)
+        self.assertFalse(result)
+         # Test relative tolerance (string)
+        result = compare_with_tolerance(111.0, 100.0, '0.1', True)
+        self.assertTrue(result)
+        result = compare_with_tolerance(112.0, 100.0, '0.1', True)
+        self.assertFalse(result)
+        # Test absolute tolerance (float)
+        result = compare_with_tolerance(109.9, 100.0, 10.0, False)
+        self.assertTrue(result)
+        result = compare_with_tolerance(110.1, 100.0, 10.0, False)
+        self.assertFalse(result)
+         # Test relative tolerance (float)
+        result = compare_with_tolerance(111.0, 100.0, 0.1, True)
+        self.assertTrue(result)
+        result = compare_with_tolerance(112.0, 100.0, 0.1, True)
+        self.assertFalse(result)
+        ##### Infinite values #####
+        infinity = float('Inf')
+        # Test relative tolerance (float)
+        result = compare_with_tolerance(infinity, 100.0, 1.0, True)
+        self.assertFalse(result)
+        result = compare_with_tolerance(100.0, infinity, 1.0, True)
+        self.assertFalse(result)
+        result = compare_with_tolerance(infinity, infinity, 1.0, True)
+        self.assertTrue(result)
+        # Test absolute tolerance (float)
+        result = compare_with_tolerance(infinity, 100.0, 1.0, False)
+        self.assertFalse(result)
+        result = compare_with_tolerance(100.0, infinity, 1.0, False)
+        self.assertFalse(result)
+        result = compare_with_tolerance(infinity, infinity, 1.0, False)
+        self.assertTrue(result)
+        # Test relative tolerance (string)
+        result = compare_with_tolerance(infinity, 100.0, '1.0', True)
+        self.assertFalse(result)
+        result = compare_with_tolerance(100.0, infinity, '1.0', True)
+        self.assertFalse(result)
+        result = compare_with_tolerance(infinity, infinity, '1.0', True)
+        self.assertTrue(result)
+        # Test absolute tolerance (string)
+        result = compare_with_tolerance(infinity, 100.0, '1.0', False)
+        self.assertFalse(result)
+        result = compare_with_tolerance(100.0, infinity, '1.0', False)
+        self.assertFalse(result)
+        result = compare_with_tolerance(infinity, infinity, '1.0', False)
+        self.assertTrue(result)


### PR DESCRIPTION
@auraz @valera-rozuvan It fixes the issue, tested it with -100 +- 10%; 100 +- 10%; 0 +- 10%; 10 +- 100%; -10 +- 100%. I guess we should add tests.
