### PR TITLE
Adding additonal path to search for git information on sysadmin dashboard

### DIFF
--- a/lms/djangoapps/dashboard/git_import.py
+++ b/lms/djangoapps/dashboard/git_import.py
@@ -21,7 +21,7 @@ from xmodule.modulestore import Location
 
 log = logging.getLogger(__name__)
 
-GIT_REPO_DIR = getattr(settings, 'GIT_REPO_DIR', '/opt/edx/course_repos')
+GIT_REPO_DIR = getattr(settings, 'GIT_REPO_DIR', '/edx/var/app/edxapp/course_repos')
 GIT_IMPORT_STATIC = getattr(settings, 'GIT_IMPORT_STATIC', True)
 
 

--- a/lms/djangoapps/dashboard/tests/test_sysadmin.py
+++ b/lms/djangoapps/dashboard/tests/test_sysadmin.py
@@ -4,6 +4,7 @@ Provide tests for sysadmin dashboard feature in sysadmin.py
 
 import glob
 import os
+import re
 import shutil
 import unittest
 
@@ -453,6 +454,31 @@ class TestSysAdminMongoCourseImport(SysadminBaseTestCase):
         self._rm_edx4edx()
         course = def_ms.get_course('MITx/edx4edx/edx4edx')
         self.assertIsNone(course)
+
+    def test_course_info(self):
+        """
+        Check to make sure we are getting git info for courses
+        """
+        # Regex of first 3 columns of course information table row for
+        # test course loaded from git. Would not have sha1 if
+        # git_info_for_course failed.
+        table_re = re.compile(r"""
+            <tr>\s+
+            <td>edX\sAuthor\sCourse</td>\s+  # expected test git course name
+            <td>MITx/edx4edx/edx4edx</td>\s+  # expected test git course_id
+            <td>[a-fA-F\d]{40}</td>  # git sha1 hash
+        """, re.VERBOSE)
+
+        self._setstaff_login()
+        self._mkdir(getattr(settings, 'GIT_REPO_DIR'))
+
+        # Make sure we don't have any git hashes on the page
+        response = self.client.get(reverse('sysadmin_courses'))
+        self.assertNotRegexpMatches(response.content, table_re)
+
+        # Now add the course and make sure it does match
+        response = self._add_edx4edx()
+        self.assertRegexpMatches(response.content, table_re)
 
     def test_gitlogs(self):
         """


### PR DESCRIPTION
When viewing the sysadmin dashboard courses tag, we also search the git
repository directory in addition to the DATA_DIR to try and find
the course git repo to get hash, last commit, and last editor information
for each loaded course if available.

Suggested reviewers: @singingwolfboy and @cpennington since you did the original Sysadmin Dashboard review.
Heads up to @sarina.
