### PR TITLE
Reset the jenkins python virtualenv before test runs.

### DIFF
--- a/jenkins/acceptance.sh
+++ b/jenkins/acceptance.sh
@@ -54,6 +54,13 @@ git fetch origin master:refs/remotes/origin/master
 # Bootstrap Ruby requirements so we can run the tests
 bundle install
 
+# Reset the jenkins worker's virtualenv back to the
+# state it was in when the instance was spun up.
+if [ -e $HOME/edx-venv_clean.tar.gz ]; then
+    rm -rf $HOME/edx-venv
+    tar -C $HOME -xf $HOME/edx-venv_clean.tar.gz
+fi
+
 # Activate the Python virtualenv
 source $HOME/edx-venv/bin/activate
 

--- a/jenkins/all-tests.sh
+++ b/jenkins/all-tests.sh
@@ -62,6 +62,13 @@ git fetch origin master:refs/remotes/origin/master
 # Bootstrap Ruby requirements so we can run the tests
 bundle install
 
+# Reset the jenkins worker's virtualenv back to the
+# state it was in when the instance was spun up.
+if [ -e $HOME/edx-venv_clean.tar.gz ]; then
+    rm -rf $HOME/edx-venv
+    tar -C $HOME -xf $HOME/edx-venv_clean.tar.gz
+fi
+
 # Activate the Python virtualenv
 source $HOME/edx-venv/bin/activate
 


### PR DESCRIPTION
This goes with [configuration/pull/1049](https://github.com/edx/configuration/pull/1049), though they can be merged independently.

@singingwolfboy @rlucioni This should fix the virtualenv (lack of) isolation issue. :joy_cat: 
