### PR TITLE
Make wiki links not look inactive

### DIFF
--- a/lms/static/sass/course/wiki/_wiki.scss
+++ b/lms/static/sass/course/wiki/_wiki.scss
@@ -277,6 +277,7 @@ section.wiki {
         a {
           color: $link-color;
           font-weight: bold;
+          background-color: $gray-l4;
 
           .icon-view,
           .icon-home {
@@ -301,20 +302,17 @@ section.wiki {
             background-position: -25px -99px;
           }
 
-          &:hover, &:focus {
-            background: none;
-          }
         }
       }
     }
 
     a {
       display: block;
-      padding: 2px 4px;
+      padding: 2px 8px;
       border-radius: 3px;
       font-size: 0.9em;
       line-height: 25px;
-      color: #8f8f8f;
+      color: $link-color;
 
       .icon {
         float: left;


### PR DESCRIPTION
@frrrances not sure if `link-color-d1` is the most correct color for "active" links, but it looks appropriately different from the base color.

fixes LMS-1308
