### PR TITLE
Set the page in the correct place.

### DIFF
--- a/lms/djangoapps/staticbook/views.py
+++ b/lms/djangoapps/staticbook/views.py
@@ -101,6 +101,7 @@ def pdf_index(request, course_id, book_index, chapter=None, page=None):
         viewer_params += current_chapter['url']
         current_url = current_chapter['url']
 
+    viewer_params += '#zoom=page-fit'
     if page is not None:
         viewer_params += '&amp;page={}'.format(page)
 

--- a/lms/templates/static_pdfbook.html
+++ b/lms/templates/static_pdfbook.html
@@ -44,7 +44,7 @@ $(function(){
 <iframe
   title="${current_chapter['title']|h}"
   id="viewer-frame"
-  src="${request.path}?viewer=true${viewer_params}#zoom=page-fit"
+  src="${request.path}?viewer=true${viewer_params}"
   width="856"
   height="1108"
   frameborder="0"


### PR DESCRIPTION
fixes LMS-2562. page belongs after the hash, not in the query string.

@adampalay 
