### PR TITLE
fix wiki hide button not working in firefox (STUD-1581)

### DIFF
--- a/cms/static/coffee/src/views/tabs.coffee
+++ b/cms/static/coffee/src/views/tabs.coffee
@@ -31,7 +31,7 @@ define ["jquery", "jquery.ui", "backbone", "js/views/feedback_prompt", "js/views
       )
 
     toggleVisibilityOfTab: (event, ui) =>
-      checkbox_element = event.srcElement
+      checkbox_element = event.target
       tab_element = $(checkbox_element).parents(".course-tab")[0]
 
       saving = new NotificationView.Mini({title: gettext("Saving&hellip;")})


### PR DESCRIPTION
`srcElement` is apparently only supported by [IE](http://www.quirksmode.org/js/events_properties.html)

@zubair-arbi 
@andy-armstrong 
