### PR TITLE
crude fix for intermittent jasmine test failures

### DIFF
--- a/common/static/coffee/spec/discussion/view/response_comment_view_spec.coffee
+++ b/common/static/coffee/spec/discussion/view/response_comment_view_spec.coffee
@@ -141,8 +141,6 @@ describe 'ResponseCommentView', ->
                 spyOn(@view, 'cancelEdit')
                 spyOn($, "ajax").andCallFake(
                     (params) =>
-                        expect(params.url._parts.path).toEqual("/courses/edX/999/test/discussion/comments/01234567/update")
-                        expect(params.data.body).toEqual(@updatedBody)
                         if @ajaxSucceed
                             params.success()
                         else
@@ -154,6 +152,8 @@ describe 'ResponseCommentView', ->
                 @ajaxSucceed = true
                 @view.update(makeEventSpy())
                 expect($.ajax).toHaveBeenCalled()
+                expect($.ajax.mostRecentCall.args[0].url._parts.path).toEqual('/courses/edX/999/test/discussion/comments/01234567/update')
+                expect($.ajax.mostRecentCall.args[0].data.body).toEqual(@updatedBody)
                 expect(@view.model.get("body")).toEqual(@updatedBody)
                 expect(@view.cancelEdit).toHaveBeenCalled()
 
@@ -162,6 +162,8 @@ describe 'ResponseCommentView', ->
                 @ajaxSucceed = false
                 @view.update(makeEventSpy())
                 expect($.ajax).toHaveBeenCalled()
+                expect($.ajax.mostRecentCall.args[0].url._parts.path).toEqual('/courses/edX/999/test/discussion/comments/01234567/update')
+                expect($.ajax.mostRecentCall.args[0].data.body).toEqual(@updatedBody)
                 expect(@view.model.get("body")).toEqual(originalBody)
                 expect(@view.cancelEdit).not.toHaveBeenCalled()
                 expect(@view.$(".edit-comment-form-errors *").length).toEqual(1)


### PR DESCRIPTION
This seeks to address an intermittent test failure that reads:

Expected '/courses/edX/999/test/discussion/forum/undefined/threads/dummy' to equal '/courses/edX/999/test/discussion/comments/01234567/update'.

The expectation itself is being used in the wrong spec context.  Strong suspicion is that the spy on the global `$` is not being properly reset outside the scope of the spec...sometimes.  [This stackoverflow answer](http://stackoverflow.com/a/17072318/3482144) to a related question suggests that there are edge cases that come into play with jasmine spies, globals, and beforeEach, all of which are elements here.

In addition, there are very similar assertions being made in other nearby specs but outside of the ajax spy, and we are not seeing the same problems in those places.

@gwprice @jzoldak  
