### PR TITLE
Adding new metadata service for determining preview mode

### DIFF
--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -21,7 +21,7 @@ from courseware.access import has_access, get_user_role
 from courseware.masquerade import setup_masquerade
 from courseware.model_data import FieldDataCache, DjangoKeyValueStore
 from lms.lib.xblock.field_data import LmsFieldData
-from lms.lib.xblock.runtime import LmsModuleSystem, unquote_slashes
+from lms.lib.xblock.runtime import LmsModuleSystem, unquote_slashes, LmsMetadataService
 from edxmako.shortcuts import render_to_string
 from eventtracking import tracker
 from psychometrics.psychoanalyze import make_psychometrics_data_update_handler
@@ -486,6 +486,7 @@ def get_module_system_for_user(user, field_data_cache,
         get_real_user=user_by_anonymous_id,
         services={
             'i18n': ModuleI18nService(),
+            'metadata': LmsMetadataService(),
         },
         get_user_role=lambda: get_user_role(user, course_id),
         descriptor_runtime=descriptor.runtime,

--- a/lms/lib/xblock/runtime.py
+++ b/lms/lib/xblock/runtime.py
@@ -8,6 +8,7 @@ from django.core.urlresolvers import reverse
 from django.conf import settings
 from user_api import user_service
 from xmodule.modulestore.django import modulestore
+from xmodule.modulestore.mongo.draft import DraftModuleStore
 from xmodule.x_module import ModuleSystem
 from xmodule.partitions.partitions_service import PartitionService
 
@@ -179,6 +180,18 @@ class UserTagsService(object):
 
         return user_service.set_course_tag(self._get_current_user(),
                                            self.runtime.course_id, key, value)
+
+
+class LmsMetadataService(object):
+    """
+    Implement the XBlock runtime "Metadata" service.
+
+    Allows the retrieval of LMS specific metadata. Exposes methods specific to
+    the LMS configuration and requests.
+    """
+    def is_preview_enabled(self):
+        module_store = modulestore()
+        return isinstance(module_store, DraftModuleStore)
 
 
 class LmsModuleSystem(LmsHandlerUrls, ModuleSystem):  # pylint: disable=abstract-method

--- a/lms/lib/xblock/test/test_metadata_service.py
+++ b/lms/lib/xblock/test/test_metadata_service.py
@@ -1,0 +1,20 @@
+from django.conf import settings
+from django.test.utils import override_settings
+from lms.lib.xblock.runtime import LmsMetadataService
+from xmodule.modulestore.tests.django_utils import draft_mongo_store_config, ModuleStoreTestCase
+
+TEST_MODULESTORE = draft_mongo_store_config(settings.TEST_ROOT / "data")
+
+@override_settings(MODULESTORE=TEST_MODULESTORE)
+class TestPreviewLmsMetadataService(ModuleStoreTestCase):
+
+    def test_preview_enabled(self):
+        service = LmsMetadataService()
+        self.assertTrue(service.is_preview_enabled())
+
+
+class TestProdLmsMetadataService(ModuleStoreTestCase):
+
+    def test_preview_not_enabled(self):
+        service = LmsMetadataService()
+        self.assertFalse(service.is_preview_enabled())

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -26,7 +26,7 @@
 -e git+https://github.com/edx/bok-choy.git@82b4e82d79b9d4c6d087ebbfa26ea23235728e62#egg=bok_choy
 -e git+https://github.com/edx-solutions/django-splash.git@9965a53c269666a30bb4e2b3f6037c138aef2a55#egg=django-splash
 -e git+https://github.com/edx/acid-block.git@459aff7b63db8f2c5decd1755706c1a64fb4ebb1#egg=acid-xblock
--e git+https://github.com/edx/edx-ora2.git@release-2014-04-27T20.17#egg=edx-ora2
+-e git+https://github.com/edx/edx-ora2.git@5d7d10724174d29acae49fddad41e8b6ccca15ab#egg=edx-ora2
 
 # Prototype XBlocks for limited roll-outs and user testing. These are not for general use.
 -e git+https://github.com/pmitros/ConceptXBlock.git@2376fde9ebdd83684b78dde77ef96361c3bd1aa0#egg=concept-xblock


### PR DESCRIPTION
Allows any XBlock requesting the metadata service to pull this in and determine if it is in Preview Mode or not. 

Not sure if I want to check in the hash for ORA2 or not; should not necessarily matter.

Related code on ORA2 side is on PR: 
https://github.com/edx/edx-ora2/pull/301

@wedaly @cpennington @ormsbee 
