### PR TITLE
Certs: pass course name on queue

### DIFF
--- a/lms/djangoapps/certificates/queue.py
+++ b/lms/djangoapps/certificates/queue.py
@@ -175,6 +175,7 @@ class XQueueCertInterface(object):
             self.request.user = student
             self.request.session = {}
 
+            course_name = course.display_name or course_id
             is_whitelisted = self.whitelist.filter(user=student, course_id=course_id, whitelist=True).exists()
             grade = grades.grade(student, self.request, course)
             enrollment_mode = CourseEnrollment.enrollment_mode_for_user(student, course_id)
@@ -220,6 +221,7 @@ class XQueueCertInterface(object):
                         'action': 'create',
                         'username': student.username,
                         'course_id': course_id,
+                        'course_name': course_name,
                         'name': profile.name,
                         'grade': grade['grade'],
                         'template_pdf': template_pdf,


### PR DESCRIPTION
Stanford had a problem a few times that certificate requests had
different values for the course display name and the course name printed
on the certificate and verification pages because of human error. This
passes the course display name on the queue to the certificate requests,
so that at least one place where the course name is reproduced (the
certificate agent's settings.py) can be eliminated.

@jarv or @dianakhuang please. This won't do anything for people who aren't using our branch of certificates, but I'm finally starting to get movement on bringing that stuff to y'all, and anyway I don't think this patch will hurt anything.
