### PR TITLE
Fix bug that prevented account association during registration

### DIFF
--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -350,7 +350,7 @@ def redirect_to_supplementary_form(strategy, details, response, uid, is_dashboar
 
     user_inactive = user and not user.is_active
     user_unset = user is None
-    dispatch_to_login = (is_login and user_unset) or user_inactive
+    dispatch_to_login = is_login and (user_unset or user_inactive)
 
     if is_dashboard:
         return


### PR DESCRIPTION
@nedbat: A tiny bugfix I'd like to merge tomorrow.

Previously, when resuming the pipeline in the register case, dispatch_to_login was True because user_inactive was True. dispatch_to_login may be True iff is_login is True; otherwise, during new account registration we'd redirect to /login rather than resuming the pipeline. This looked almost correct in the UI, but because the rest of the pipeline failed to execute, the association between the user's edX account and their third-party account was never created.

Also fixed buggy test that failed to catch this case.

@psimakov, @jbau, @jzoldak: Just FYI -- nothing for you to do.
