### PR TITLE
Common Djangoapps [partial commit]

### DIFF
--- a/common/djangoapps/course_groups/cohorts.py
+++ b/common/djangoapps/course_groups/cohorts.py
@@ -32,30 +32,30 @@ def local_random():
 
     return _local_random
 
-def is_course_cohorted(course_id):
+def is_course_cohorted(course_key):
     """
-    Given a course id, return a boolean for whether or not the course is
+    Given a course key, return a boolean for whether or not the course is
     cohorted.
 
     Raises:
        Http404 if the course doesn't exist.
     """
-    return courses.get_course_by_id(course_id).is_cohorted
+    return courses.get_course_by_id(course_key).is_cohorted
 
 
-def get_cohort_id(user, course_id):
+def get_cohort_id(user, course_key):
     """
-    Given a course id and a user, return the id of the cohort that user is
+    Given a course key and a user, return the id of the cohort that user is
     assigned to in that course.  If they don't have a cohort, return None.
     """
-    cohort = get_cohort(user, course_id)
+    cohort = get_cohort(user, course_key)
     return None if cohort is None else cohort.id
 
 
-def is_commentable_cohorted(course_id, commentable_id):
+def is_commentable_cohorted(course_key, commentable_id):
     """
     Args:
-        course_id: string
+        course_key: CourseKey
         commentable_id: string
 
     Returns:
@@ -64,7 +64,7 @@ def is_commentable_cohorted(course_id, commentable_id):
     Raises:
         Http404 if the course doesn't exist.
     """
-    course = courses.get_course_by_id(course_id)
+    course = courses.get_course_by_id(course_key)
 
     if not course.is_cohorted:
         # this is the easy case :)
@@ -77,18 +77,18 @@ def is_commentable_cohorted(course_id, commentable_id):
         # inline discussions are cohorted by default
         ans = True
 
-    log.debug(u"is_commentable_cohorted({0}, {1}) = {2}".format(course_id,
-                                                               commentable_id,
-                                                               ans))
+    log.debug(u"is_commentable_cohorted({0}, {1}) = {2}".format(
+        course_key, commentable_id, ans
+    ))
     return ans
 
 
-def get_cohorted_commentables(course_id):
+def get_cohorted_commentables(course_key):
     """
-    Given a course_id return a list of strings representing cohorted commentables
+    Given a course_key return a list of strings representing cohorted commentables
     """
 
-    course = courses.get_course_by_id(course_id)
+    course = courses.get_course_by_id(course_key)
 
     if not course.is_cohorted:
         # this is the easy case :)
@@ -99,34 +99,34 @@ def get_cohorted_commentables(course_id):
     return ans
 
 
-def get_cohort(user, course_id):
+def get_cohort(user, course_key):
     """
-    Given a django User and a course_id, return the user's cohort in that
+    Given a django User and a CourseKey, return the user's cohort in that
     cohort.
 
     Arguments:
         user: a Django User object.
-        course_id: string in the format 'org/course/run'
+        course_key: CourseKey
 
     Returns:
         A CourseUserGroup object if the course is cohorted and the User has a
         cohort, else None.
 
     Raises:
-       ValueError if the course_id doesn't exist.
+       ValueError if the CourseKey doesn't exist.
     """
     # First check whether the course is cohorted (users shouldn't be in a cohort
     # in non-cohorted courses, but settings can change after course starts)
     try:
-        course = courses.get_course_by_id(course_id)
+        course = courses.get_course_by_id(course_key)
     except Http404:
-        raise ValueError("Invalid course_id")
+        raise ValueError("Invalid course_key")
 
     if not course.is_cohorted:
         return None
 
     try:
-        return CourseUserGroup.objects.get(course_id=course_id,
+        return CourseUserGroup.objects.get(course_id=course_key,
                                             group_type=CourseUserGroup.COHORT,
                                             users__id=user.id)
     except CourseUserGroup.DoesNotExist:
@@ -142,72 +142,81 @@ def get_cohort(user, course_id):
         # Nowhere to put user
         log.warning("Course %s is auto-cohorted, but there are no"
                     " auto_cohort_groups specified",
-                    course_id)
+                    course_key)
         return None
 
     # Put user in a random group, creating it if needed
     group_name = local_random().choice(choices)
 
     group, created = CourseUserGroup.objects.get_or_create(
-        course_id=course_id,
+        course_id=course_key,
         group_type=CourseUserGroup.COHORT,
-        name=group_name)
+        name=group_name
+    )
 
     user.course_groups.add(group)
     return group
 
 
-def get_course_cohorts(course_id):
+def get_course_cohorts(course_key):
     """
     Get a list of all the cohorts in the given course.
 
     Arguments:
-        course_id: string in the format 'org/course/run'
+        course_key: CourseKey
 
     Returns:
         A list of CourseUserGroup objects.  Empty if there are no cohorts. Does
         not check whether the course is cohorted.
     """
-    return list(CourseUserGroup.objects.filter(course_id=course_id,
-                                               group_type=CourseUserGroup.COHORT))
+    return list(CourseUserGroup.objects.filter(
+        course_id=course_key,
+        group_type=CourseUserGroup.COHORT
+    ))
 
 ### Helpers for cohort management views
 
 
-def get_cohort_by_name(course_id, name):
+def get_cohort_by_name(course_key, name):
     """
     Return the CourseUserGroup object for the given cohort.  Raises DoesNotExist
     it isn't present.
     """
-    return CourseUserGroup.objects.get(course_id=course_id,
-                                       group_type=CourseUserGroup.COHORT,
-                                       name=name)
+    return CourseUserGroup.objects.get(
+        course_id=course_key,
+        group_type=CourseUserGroup.COHORT,
+        name=name
+    )
 
 
-def get_cohort_by_id(course_id, cohort_id):
+def get_cohort_by_id(course_key, cohort_id):
     """
     Return the CourseUserGroup object for the given cohort.  Raises DoesNotExist
-    it isn't present.  Uses the course_id for extra validation...
+    it isn't present.  Uses the course_key for extra validation...
     """
-    return CourseUserGroup.objects.get(course_id=course_id,
-                                       group_type=CourseUserGroup.COHORT,
-                                       id=cohort_id)
+    return CourseUserGroup.objects.get(
+        course_id=course_key,
+        group_type=CourseUserGroup.COHORT,
+        id=cohort_id
+    )
 
 
-def add_cohort(course_id, name):
+def add_cohort(course_key, name):
     """
     Add a cohort to a course.  Raises ValueError if a cohort of the same name already
     exists.
     """
-    log.debug("Adding cohort %s to %s", name, course_id)
-    if CourseUserGroup.objects.filter(course_id=course_id,
+    log.debug("Adding cohort %s to %s", name, course_key)
+    if CourseUserGroup.objects.filter(course_id=course_key,
                                       group_type=CourseUserGroup.COHORT,
                                       name=name).exists():
         raise ValueError("Can't create two cohorts with the same name")
 
-    return CourseUserGroup.objects.create(course_id=course_id,
-                                          group_type=CourseUserGroup.COHORT,
-                                          name=name)
+    return CourseUserGroup.objects.create(
+        course_id=course_key,
+        group_type=CourseUserGroup.COHORT,
+        name=name
+    )
 
 
 class CohortConflict(Exception):
@@ -237,9 +246,10 @@ def add_user_to_cohort(cohort, username_or_email):
     previous_cohort = None
 
     course_cohorts = CourseUserGroup.objects.filter(
-        course_id=cohort.course_id,
+        course_id=cohort.course_key,
         users__id=user.id,
-        group_type=CourseUserGroup.COHORT)
+        group_type=CourseUserGroup.COHORT
+    )
     if course_cohorts.exists():
         if course_cohorts[0] == cohort:
             raise ValueError("User {0} already present in cohort {1}".format(
@@ -253,21 +263,21 @@ def add_user_to_cohort(cohort, username_or_email):
     return (user, previous_cohort)
 
 
-def get_course_cohort_names(course_id):
+def get_course_cohort_names(course_key):
     """
     Return a list of the cohort names in a course.
     """
-    return [c.name for c in get_course_cohorts(course_id)]
+    return [c.name for c in get_course_cohorts(course_key)]
 
 
-def delete_empty_cohort(course_id, name):
+def delete_empty_cohort(course_key, name):
     """
     Remove an empty cohort.  Raise ValueError if cohort is not empty.
     """
-    cohort = get_cohort_by_name(course_id, name)
+    cohort = get_cohort_by_name(course_key, name)
     if cohort.users.exists():
         raise ValueError(
             "Can't delete non-empty cohort {0} in course {1}".format(
-                name, course_id))
+                name, course_key))
 
     cohort.delete()

--- a/common/djangoapps/course_groups/models.py
+++ b/common/djangoapps/course_groups/models.py
@@ -2,6 +2,7 @@ import logging
 
 from django.contrib.auth.models import User
 from django.db import models
+from xmodule_django.models import CourseKeyField
 
 log = logging.getLogger(__name__)
 
@@ -23,7 +24,8 @@ class CourseUserGroup(models.Model):
 
     # Note: groups associated with particular runs of a course.  E.g. Fall 2012 and Spring
     # 2013 versions of 6.00x will have separate groups.
-    course_id = models.CharField(max_length=255, db_index=True,
+    # TODO change field name to course_key
+    course_id = CourseKeyField(max_length=255, db_index=True,
                                  help_text="Which course is this group associated with?")
 
     # For now, only have group type 'cohort', but adding a type field to support

--- a/common/djangoapps/course_groups/tests/test_cohorts.py
+++ b/common/djangoapps/course_groups/tests/test_cohorts.py
@@ -9,6 +9,7 @@ from course_groups.cohorts import (get_cohort, get_course_cohorts,
                                    is_commentable_cohorted, get_cohort_by_name)
 
 from xmodule.modulestore.django import modulestore, clear_existing_modulestores
+from xmodule.modulestore.locations import SlashSeparatedCourseKey
 
 from xmodule.modulestore.tests.django_utils import mixed_store_config
 
@@ -84,13 +85,14 @@ class TestCohorts(django.test.TestCase):
         Make sure that course is reloaded every time--clear out the modulestore.
         """
         clear_existing_modulestores()
+        self.toy_course_key = SlashSeparatedCourseKey("edX", "toy", "2012_Fall")
 
     def test_get_cohort(self):
         """
         Make sure get_cohort() does the right thing when the course is cohorted
         """
-        course = modulestore().get_course("edX/toy/2012_Fall")
-        self.assertEqual(course.id, "edX/toy/2012_Fall")
+        course = modulestore().get_course(self.toy_course_key)
+        self.assertEqual(course.id, self.toy_course_key)
         self.assertFalse(course.is_cohorted)
 
         user = User.objects.create(username="test", email="a@b.com")
@@ -120,8 +122,7 @@ class TestCohorts(django.test.TestCase):
         """
         Make sure get_cohort() does the right thing when the course is auto_cohorted
         """
-        course = modulestore().get_course("edX/toy/2012_Fall")
-        self.assertEqual(course.id, "edX/toy/2012_Fall")
+        course = modulestore().get_course(self.toy_course_key)
         self.assertFalse(course.is_cohorted)
 
         user1 = User.objects.create(username="test", email="a@b.com")
@@ -168,8 +169,7 @@ class TestCohorts(django.test.TestCase):
         """
         Make sure get_cohort() randomizes properly.
         """
-        course = modulestore().get_course("edX/toy/2012_Fall")
-        self.assertEqual(course.id, "edX/toy/2012_Fall")
+        course = modulestore().get_course(self.toy_course_key)
         self.assertFalse(course.is_cohorted)
 
         groups = ["group_{0}".format(n) for n in range(5)]
@@ -194,26 +194,26 @@ class TestCohorts(django.test.TestCase):
             self.assertLess(num_users, 50)
 
     def test_get_course_cohorts(self):
-        course1_id = 'a/b/c'
-        course2_id = 'e/f/g'
+        course1_key = SlashSeparatedCourseKey('a', 'b', 'c')
+        course2_key = SlashSeparatedCourseKey('e', 'f', 'g')
 
         # add some cohorts to course 1
         cohort = CourseUserGroup.objects.create(name="TestCohort",
-                                                course_id=course1_id,
+                                                course_id=course1_key,
                                                 group_type=CourseUserGroup.COHORT)
 
         cohort = CourseUserGroup.objects.create(name="TestCohort2",
-                                                course_id=course1_id,
+                                                course_id=course1_key,
                                                 group_type=CourseUserGroup.COHORT)
 
         # second course should have no cohorts
-        self.assertEqual(get_course_cohorts(course2_id), [])
+        self.assertEqual(get_course_cohorts(course2_key), [])
 
-        cohorts = sorted([c.name for c in get_course_cohorts(course1_id)])
+        cohorts = sorted([c.name for c in get_course_cohorts(course1_key)])
         self.assertEqual(cohorts, ['TestCohort', 'TestCohort2'])
 
     def test_is_commentable_cohorted(self):
-        course = modulestore().get_course("edX/toy/2012_Fall")
+        course = modulestore().get_course(self.toy_course_key)
         self.assertFalse(course.is_cohorted)
 
         def to_id(name):

--- a/common/djangoapps/course_groups/views.py
+++ b/common/djangoapps/course_groups/views.py
@@ -33,25 +33,25 @@ def split_by_comma_and_whitespace(s):
 
 
 @ensure_csrf_cookie
-def list_cohorts(request, course_id):
+def list_cohorts(request, course_key):
     """
     Return json dump of dict:
 
     {'success': True,
      'cohorts': [{'name': name, 'id': id}, ...]}
     """
-    get_course_with_access(request.user, course_id, 'staff')
+    get_course_with_access(request.user, 'staff', course_key)
 
     all_cohorts = [{'name': c.name, 'id': c.id}
-               for c in cohorts.get_course_cohorts(course_id)]
+                   for c in cohorts.get_course_cohorts(course_key)]
 
     return json_http_response({'success': True,
-                            'cohorts': all_cohorts})
+                               'cohorts': all_cohorts})
 
 
 @ensure_csrf_cookie
 @require_POST
-def add_cohort(request, course_id):
+def add_cohort(request, course_key):
     """
     Return json of dict:
     {'success': True,
@@ -63,7 +63,7 @@ def add_cohort(request, course_id):
     {'success': False,
      'msg': error_msg} if there's an error
     """
-    get_course_with_access(request.user, course_id, 'staff')
+    get_course_with_access(request.user, 'staff', course_key)
 
     name = request.POST.get("name")
     if not name:
@@ -71,7 +71,7 @@ def add_cohort(request, course_id):
                                 'msg': "No name specified"})
 
     try:
-        cohort = cohorts.add_cohort(course_id, name)
+        cohort = cohorts.add_cohort(course_key, name)
     except ValueError as err:
         return json_http_response({'success': False,
                                 'msg': str(err)})
@@ -84,7 +84,7 @@ def add_cohort(request, course_id):
 
 
 @ensure_csrf_cookie
-def users_in_cohort(request, course_id, cohort_id):
+def users_in_cohort(request, course_key, cohort_id):
     """
     Return users in the cohort.  Show up to 100 per page, and page
     using the 'page' GET attribute in the call.  Format:
@@ -97,11 +97,11 @@ def users_in_cohort(request, course_id, cohort_id):
          'users': [{'username': ..., 'email': ..., 'name': ...}]
     }
     """
-    get_course_with_access(request.user, course_id, 'staff')
+    get_course_with_access(request.user, 'staff', course_key)
 
     # this will error if called with a non-int cohort_id.  That's ok--it
     # shoudn't happen for valid clients.
-    cohort = cohorts.get_cohort_by_id(course_id, int(cohort_id))
+    cohort = cohorts.get_cohort_by_id(course_key, int(cohort_id))
 
     paginator = Paginator(cohort.users.all(), 100)
     page = request.GET.get('page')
@@ -119,17 +119,17 @@ def users_in_cohort(request, course_id, cohort_id):
     user_info = [{'username': u.username,
                   'email': u.email,
                   'name': '{0} {1}'.format(u.first_name, u.last_name)}
-                  for u in users]
+                 for u in users]
 
     return json_http_response({'success': True,
-                            'page': page,
-                            'num_pages': paginator.num_pages,
-                            'users': user_info})
+                               'page': page,
+                               'num_pages': paginator.num_pages,
+                               'users': user_info})
 
 
 @ensure_csrf_cookie
 @require_POST
-def add_users_to_cohort(request, course_id, cohort_id):
+def add_users_to_cohort(request, course_key, cohort_id):
     """
     Return json dict of:
 
@@ -144,9 +144,9 @@ def add_users_to_cohort(request, course_id, cohort_id):
      'present': [str1, str2, ...],    # already there
      'unknown': [str1, str2, ...]}
     """
-    get_course_with_access(request.user, course_id, 'staff')
+    get_course_with_access(request.user, 'staff', course_key)
 
-    cohort = cohorts.get_cohort_by_id(course_id, cohort_id)
+    cohort = cohorts.get_cohort_by_id(course_key, cohort_id)
 
     users = request.POST.get('users', '')
     added = []
@@ -175,15 +175,15 @@ def add_users_to_cohort(request, course_id, cohort_id):
             unknown.append(username_or_email)
 
     return json_http_response({'success': True,
-                            'added': added,
-                            'changed': changed,
-                            'present': present,
-                            'unknown': unknown})
+                               'added': added,
+                               'changed': changed,
+                               'present': present,
+                               'unknown': unknown})
 
 
 @ensure_csrf_cookie
 @require_POST
-def remove_user_from_cohort(request, course_id, cohort_id):
+def remove_user_from_cohort(request, course_key, cohort_id):
     """
     Expects 'username': username in POST data.
 
@@ -193,14 +193,14 @@ def remove_user_from_cohort(request, course_id, cohort_id):
     {'success': False,
      'msg': error_msg}
     """
-    get_course_with_access(request.user, course_id, 'staff')
+    get_course_with_access(request.user, 'staff', course_key)
 
     username = request.POST.get('username')
     if username is None:
         return json_http_response({'success': False,
-                                'msg': 'No username specified'})
+                                   'msg': 'No username specified'})
 
-    cohort = cohorts.get_cohort_by_id(course_id, cohort_id)
+    cohort = cohorts.get_cohort_by_id(course_key, cohort_id)
     try:
         user = User.objects.get(username=username)
         cohort.users.remove(user)
@@ -208,16 +208,18 @@ def remove_user_from_cohort(request, course_id, cohort_id):
     except User.DoesNotExist:
         log.debug('no user')
         return json_http_response({'success': False,
-                                'msg': "No user '{0}'".format(username)})
+                                   'msg': "No user '{0}'".format(username)})
 
 
-def debug_cohort_mgmt(request, course_id):
+def debug_cohort_mgmt(request, course_key):
     """
     Debugging view for dev.
     """
     # add staff check to make sure it's safe if it's accidentally deployed.
-    get_course_with_access(request.user, course_id, 'staff')
+    get_course_with_access(request.user, 'staff', course_key)
 
-    context = {'cohorts_ajax_url': reverse('cohorts',
-                                           kwargs={'course_id': course_id})}
+    context = {'cohorts_ajax_url': reverse(
+        'cohorts',
+        kwargs={'course_id': course_key.to_deprecated_string()}
+    )}
     return render_to_response('/course_groups/debug.html', context)

--- a/common/djangoapps/course_modes/models.py
+++ b/common/djangoapps/course_modes/models.py
@@ -9,6 +9,8 @@ from collections import namedtuple
 from django.utils.translation import ugettext as _
 from django.db.models import Q
 
+from xmodule_django.models import CourseKeyField
+
 Mode = namedtuple('Mode', ['slug', 'name', 'min_price', 'suggested_prices', 'currency', 'expiration_datetime'])
 
 class CourseMode(models.Model):
@@ -17,7 +19,7 @@ class CourseMode(models.Model):
 
     """
     # the course that this mode is attached to
-    course_id = models.CharField(max_length=255, db_index=True)
+    course_id = CourseKeyField(max_length=255, db_index=True)
 
     # the reference to this mode that can be used by Enrollments to generate
     # similar behavior for the same slug across courses

--- a/common/djangoapps/course_modes/tests/test_models.py
+++ b/common/djangoapps/course_modes/tests/test_models.py
@@ -8,6 +8,7 @@ Replace this with more appropriate tests for your application.
 from datetime import datetime, timedelta
 import pytz
 
+from xmodule.modulestore.locations import SlashSeparatedCourseKey
 from django.test import TestCase
 from course_modes.models import CourseMode, Mode
 
@@ -18,7 +19,7 @@ class CourseModeModelTest(TestCase):
     """
 
     def setUp(self):
-        self.course_id = 'TestCourse'
+        self.course_key = SlashSeparatedCourseKey('Test', 'TestCourse', 'TestCourseRun')
         CourseMode.objects.all().delete()
 
     def create_mode(self, mode_slug, mode_name, min_price=0, suggested_prices='', currency='usd'):
@@ -26,7 +27,7 @@ class CourseModeModelTest(TestCase):
         Create a new course mode
         """
         return CourseMode.objects.get_or_create(
-            course_id=self.course_id,
+            course_id=self.course_key,
             mode_display_name=mode_name,
             mode_slug=mode_slug,
             min_price=min_price,
@@ -39,7 +40,7 @@ class CourseModeModelTest(TestCase):
         If we can't find any modes, we should get back the default mode
         """
         # shouldn't be able to find a corresponding course
-        modes = CourseMode.modes_for_course(self.course_id)
+        modes = CourseMode.modes_for_course(self.course_key)
         self.assertEqual([CourseMode.DEFAULT_MODE], modes)
 
     def test_nodes_for_course_single(self):
@@ -48,13 +49,13 @@ class CourseModeModelTest(TestCase):
         """
 
         self.create_mode('verified', 'Verified Certificate')
-        modes = CourseMode.modes_for_course(self.course_id)
+        modes = CourseMode.modes_for_course(self.course_key)
         mode = Mode(u'verified', u'Verified Certificate', 0, '', 'usd', None)
         self.assertEqual([mode], modes)
 
-        modes_dict = CourseMode.modes_for_course_dict(self.course_id)
+        modes_dict = CourseMode.modes_for_course_dict(self.course_key)
         self.assertEqual(modes_dict['verified'], mode)
-        self.assertEqual(CourseMode.mode_for_course(self.course_id, 'verified'),
+        self.assertEqual(CourseMode.mode_for_course(self.course_key, 'verified'),
                          mode)
 
     def test_modes_for_course_multiple(self):
@@ -67,18 +68,18 @@ class CourseModeModelTest(TestCase):
         for mode in set_modes:
             self.create_mode(mode.slug, mode.name, mode.min_price, mode.suggested_prices)
 
-        modes = CourseMode.modes_for_course(self.course_id)
+        modes = CourseMode.modes_for_course(self.course_key)
         self.assertEqual(modes, set_modes)
-        self.assertEqual(mode1, CourseMode.mode_for_course(self.course_id, u'honor'))
-        self.assertEqual(mode2, CourseMode.mode_for_course(self.course_id, u'verified'))
-        self.assertIsNone(CourseMode.mode_for_course(self.course_id, 'DNE'))
+        self.assertEqual(mode1, CourseMode.mode_for_course(self.course_key, u'honor'))
+        self.assertEqual(mode2, CourseMode.mode_for_course(self.course_key, u'verified'))
+        self.assertIsNone(CourseMode.mode_for_course(self.course_key, 'DNE'))
 
     def test_min_course_price_for_currency(self):
         """
         Get the min course price for a course according to currency
         """
         # no modes, should get 0
-        self.assertEqual(0, CourseMode.min_course_price_for_currency(self.course_id, 'usd'))
+        self.assertEqual(0, CourseMode.min_course_price_for_currency(self.course_key, 'usd'))
 
         # create some modes
         mode1 = Mode(u'honor', u'Honor Code Certificate', 10, '', 'usd', None)
@@ -88,27 +89,27 @@ class CourseModeModelTest(TestCase):
         for mode in set_modes:
             self.create_mode(mode.slug, mode.name, mode.min_price, mode.suggested_prices, mode.currency)
 
-        self.assertEqual(10, CourseMode.min_course_price_for_currency(self.course_id, 'usd'))
-        self.assertEqual(80, CourseMode.min_course_price_for_currency(self.course_id, 'cny'))
+        self.assertEqual(10, CourseMode.min_course_price_for_currency(self.course_key, 'usd'))
+        self.assertEqual(80, CourseMode.min_course_price_for_currency(self.course_key, 'cny'))
 
     def test_modes_for_course_expired(self):
         expired_mode, _status = self.create_mode('verified', 'Verified Certificate')
         expired_mode.expiration_datetime = datetime.now(pytz.UTC) + timedelta(days=-1)
         expired_mode.save()
-        modes = CourseMode.modes_for_course(self.course_id)
+        modes = CourseMode.modes_for_course(self.course_key)
         self.assertEqual([CourseMode.DEFAULT_MODE], modes)
 
         mode1 = Mode(u'honor', u'Honor Code Certificate', 0, '', 'usd', None)
         self.create_mode(mode1.slug, mode1.name, mode1.min_price, mode1.suggested_prices)
-        modes = CourseMode.modes_for_course(self.course_id)
+        modes = CourseMode.modes_for_course(self.course_key)
         self.assertEqual([mode1], modes)
 
         expiration_datetime = datetime.now(pytz.UTC) + timedelta(days=1)
         expired_mode.expiration_datetime = expiration_datetime
         expired_mode.save()
         expired_mode_value = Mode(u'verified', u'Verified Certificate', 0, '', 'usd', expiration_datetime)
-        modes = CourseMode.modes_for_course(self.course_id)
+        modes = CourseMode.modes_for_course(self.course_key)
         self.assertEqual([expired_mode_value, mode1], modes)
 
-        modes = CourseMode.modes_for_course('second_test_course')
+        modes = CourseMode.modes_for_course(SlashSeparatedCourseKey('TestOrg', 'TestCourse', 'TestRun'))
         self.assertEqual([CourseMode.DEFAULT_MODE], modes)

--- a/common/djangoapps/course_modes/views.py
+++ b/common/djangoapps/course_modes/views.py
@@ -20,6 +20,7 @@ from courseware.access import has_access
 from student.models import CourseEnrollment
 from student.views import course_from_id
 from verify_student.models import SoftwareSecurePhotoVerification
+from xmodule.modulestore.locations import SlashSeparatedCourseKey
 
 
 class ChooseModeView(View):
@@ -35,7 +36,9 @@ class ChooseModeView(View):
     def get(self, request, course_id, error=None):
         """ Displays the course mode choice page """
 
-        enrollment_mode = CourseEnrollment.enrollment_mode_for_user(request.user, course_id)
+        course_key = SlashSeparatedCourseKey.from_deprecated_string(course_id)
+
+        enrollment_mode = CourseEnrollment.enrollment_mode_for_user(request.user, course_key)
         upgrade = request.GET.get('upgrade', False)
         request.session['attempting_upgrade'] = upgrade
 
@@ -47,13 +50,13 @@ class ChooseModeView(View):
         if enrollment_mode is not None and upgrade is False:
             return redirect(reverse('dashboard'))
 
-        modes = CourseMode.modes_for_course_dict(course_id)
+        modes = CourseMode.modes_for_course_dict(course_key)
         donation_for_course = request.session.get("donation_for_course", {})
-        chosen_price = donation_for_course.get(course_id, None)
+        chosen_price = donation_for_course.get(course_key, None)
 
-        course = course_from_id(course_id)
+        course = course_from_id(course_key)
         context = {
-            "course_id": course_id,
+            "course_modes_choose_url": reverse("course_modes_choose", kwargs={'course_id': course_key.to_deprecated_string()}),
             "modes": modes,
             "course_name": course.display_name_with_default,
             "course_org": course.display_org_with_default,
@@ -72,25 +75,26 @@ class ChooseModeView(View):
     @method_decorator(login_required)
     def post(self, request, course_id):
         """ Takes the form submission from the page and parses it """
+        course_key = SlashSeparatedCourseKey.from_deprecated_string(course_id)
         user = request.user
 
         # This is a bit redundant with logic in student.views.change_enrollement,
         # but I don't really have the time to refactor it more nicely and test.
-        course = course_from_id(course_id)
-        if not has_access(user, course, 'enroll'):
+        course = course_from_id(course_key)
+        if not has_access(user, 'enroll', course):
             error_msg = _("Enrollment is closed")
-            return self.get(request, course_id, error=error_msg)
+            return self.get(request, course_key, error=error_msg)
 
         upgrade = request.GET.get('upgrade', False)
 
         requested_mode = self.get_requested_mode(request.POST)
 
-        allowed_modes = CourseMode.modes_for_course_dict(course_id)
+        allowed_modes = CourseMode.modes_for_course_dict(course_key)
         if requested_mode not in allowed_modes:
             return HttpResponseBadRequest(_("Enrollment mode not supported"))
 
         if requested_mode in ("audit", "honor"):
-            CourseEnrollment.enroll(user, course_id, requested_mode)
+            CourseEnrollment.enroll(user, course_key, requested_mode)
             return redirect('dashboard')
 
         mode_info = allowed_modes[requested_mode]
@@ -104,25 +108,25 @@ class ChooseModeView(View):
                 amount_value = decimal.Decimal(amount).quantize(decimal.Decimal('.01'), rounding=decimal.ROUND_DOWN)
             except decimal.InvalidOperation:
                 error_msg = _("Invalid amount selected.")
-                return self.get(request, course_id, error=error_msg)
+                return self.get(request, course_key, error=error_msg)
 
             # Check for minimum pricing
             if amount_value < mode_info.min_price:
                 error_msg = _("No selected price or selected price is too low.")
-                return self.get(request, course_id, error=error_msg)
+                return self.get(request, course_key, error=error_msg)
 
             donation_for_course = request.session.get("donation_for_course", {})
-            donation_for_course[course_id] = amount_value
+            donation_for_course[course_key] = amount_value
             request.session["donation_for_course"] = donation_for_course
             if SoftwareSecurePhotoVerification.user_has_valid_or_pending(request.user):
                 return redirect(
                     reverse('verify_student_verified',
-                            kwargs={'course_id': course_id}) + "?upgrade={}".format(upgrade)
+                            kwargs={'course_id': course_key.to_deprecated_string()}) + "?upgrade={}".format(upgrade)
                 )
 
             return redirect(
                 reverse('verify_student_show_requirements',
-                        kwargs={'course_id': course_id}) + "?upgrade={}".format(upgrade))
+                        kwargs={'course_id': course_key.to_deprecated_string()}) + "?upgrade={}".format(upgrade))
 
     def get_requested_mode(self, request_dict):
         """

--- a/common/djangoapps/django_comment_common/models.py
+++ b/common/djangoapps/django_comment_common/models.py
@@ -9,7 +9,8 @@ from django.utils.translation import ugettext_noop
 from student.models import CourseEnrollment
 
 from xmodule.modulestore.django import modulestore
-from xmodule.course_module import CourseDescriptor
+from xmodule.modulestore.exceptions import ItemNotFoundError
+from xmodule_django.models import CourseKeyField, NoneToEmptyManager
 
 FORUM_ROLE_ADMINISTRATOR = ugettext_noop('Administrator')
 FORUM_ROLE_MODERATOR = ugettext_noop('Moderator')
@@ -48,16 +49,20 @@ def assign_default_role(course_id, user):
 
 
 class Role(models.Model):
+
+    objects = NoneToEmptyManager()
+
     name = models.CharField(max_length=30, null=False, blank=False)
     users = models.ManyToManyField(User, related_name="roles")
-    course_id = models.CharField(max_length=255, blank=True, db_index=True)
+    course_id = CourseKeyField(max_length=255, blank=True, db_index=True)
 
     class Meta:
         # use existing table that was originally created from django_comment_client app
         db_table = 'django_comment_client_role'
 
     def __unicode__(self):
-        return self.name + " for " + (self.course_id if self.course_id else "all courses")
+        # pylint: disable=no-member
+        return self.name + " for " + (self.course_id.to_deprecated_string() if self.course_id else "all courses")
 
     def inherit_permissions(self, role):   # TODO the name of this method is a little bit confusing,
                                          # since it's one-off and doesn't handle inheritance later
@@ -71,8 +76,9 @@ class Role(models.Model):
         self.permissions.add(Permission.objects.get_or_create(name=permission)[0])
 
     def has_permission(self, permission):
-        course_loc = CourseDescriptor.id_to_location(self.course_id)
-        course = modulestore().get_instance(self.course_id, course_loc)
+        course = modulestore().get_course(self.course_id)
+        if course is None:
+            raise ItemNotFoundError(self.course_id)
         if self.name == FORUM_ROLE_STUDENT and \
            (permission.startswith('edit') or permission.startswith('update') or permission.startswith('create')) and \
            (not course.forum_posts_allowed):

--- a/common/djangoapps/django_comment_common/tests.py
+++ b/common/djangoapps/django_comment_common/tests.py
@@ -1,5 +1,6 @@
 from django.test import TestCase
 
+from xmodule.modulestore.locations import SlashSeparatedCourseKey
 from django_comment_common.models import Role
 from student.models import CourseEnrollment, User
 
@@ -21,13 +22,13 @@ class RoleAssignmentTest(TestCase):
             "hacky",
             "hacky@fake.edx.org"
         )
-        self.course_id = "edX/Fake101/2012"
-        CourseEnrollment.enroll(self.staff_user, self.course_id)
-        CourseEnrollment.enroll(self.student_user, self.course_id)
+        self.course_key = SlashSeparatedCourseKey("edX", "Fake101", "2012")
+        CourseEnrollment.enroll(self.staff_user, self.course_key)
+        CourseEnrollment.enroll(self.student_user, self.course_key)
 
     def test_enrollment_auto_role_creation(self):
         student_role = Role.objects.get(
-            course_id=self.course_id,
+            course_id=self.course_key,
             name="Student"
         )
 

--- a/common/djangoapps/django_comment_common/utils.py
+++ b/common/djangoapps/django_comment_common/utils.py
@@ -10,27 +10,27 @@ _MODERATOR_ROLE_PERMISSIONS = ["edit_content", "delete_thread", "openclose_threa
 _ADMINISTRATOR_ROLE_PERMISSIONS = ["manage_moderator"]
 
 
-def _save_forum_role(course_id, name):
+def _save_forum_role(course_key, name):
     """
-    Save and Update 'course_id' for all roles which are already created to keep course_id same
-    as actual passed course id
+    Save and Update 'course_key' for all roles which are already created to keep course_id same
+    as actual passed course key
     """
-    role, created = Role.objects.get_or_create(name=name, course_id=course_id)
+    role, created = Role.objects.get_or_create(name=name, course_id=course_key)
     if created is False:
-        role.course_id = course_id
+        role.course_id = course_key
         role.save()
 
     return role
 
 
-def seed_permissions_roles(course_id):
+def seed_permissions_roles(course_key):
     """
     Create and assign permissions for forum roles
     """
-    administrator_role = _save_forum_role(course_id, "Administrator")
-    moderator_role = _save_forum_role(course_id, "Moderator")
-    community_ta_role = _save_forum_role(course_id, "Community TA")
-    student_role = _save_forum_role(course_id, "Student")
+    administrator_role = _save_forum_role(course_key, "Administrator")
+    moderator_role = _save_forum_role(course_key, "Moderator")
+    community_ta_role = _save_forum_role(course_key, "Community TA")
+    student_role = _save_forum_role(course_key, "Student")
 
     for per in _STUDENT_ROLE_PERMISSIONS:
         student_role.add_permission(per)

--- a/common/djangoapps/embargo/models.py
+++ b/common/djangoapps/embargo/models.py
@@ -13,14 +13,17 @@ file and check it in at the same time as your model changes. To do that,
 from django.db import models
 
 from config_models.models import ConfigurationModel
+from xmodule_django.models import CourseKeyField, NoneToEmptyManager
 
 
 class EmbargoedCourse(models.Model):
     """
     Enable course embargo on a course-by-course basis.
     """
+    objects = NoneToEmptyManager()
+
     # The course to embargo
-    course_id = models.CharField(max_length=255, db_index=True, unique=True)
+    course_id = CourseKeyField(max_length=255, db_index=True, unique=True)
 
     # Whether or not to embargo
     embargoed = models.BooleanField(default=False)
@@ -42,7 +45,8 @@ class EmbargoedCourse(models.Model):
         not_em = "Not "
         if self.embargoed:
             not_em = ""
-        return u"Course '{}' is {}Embargoed".format(self.course_id, not_em)
+        # pylint: disable=no-member
+        return u"Course '{}' is {}Embargoed".format(self.course_id.to_deprecated_string(), not_em)
 
 
 class EmbargoedState(ConfigurationModel):

--- a/common/djangoapps/embargo/tests/test_forms.py
+++ b/common/djangoapps/embargo/tests/test_forms.py
@@ -22,8 +22,8 @@ class EmbargoCourseFormTest(ModuleStoreTestCase):
 
     def setUp(self):
         self.course = CourseFactory.create()
-        self.true_form_data = {'course_id': self.course.id, 'embargoed': True}
-        self.false_form_data = {'course_id': self.course.id, 'embargoed': False}
+        self.true_form_data = {'course_id': self.course.id.to_deprecated_string(), 'embargoed': True}
+        self.false_form_data = {'course_id': self.course.id.to_deprecated_string(), 'embargoed': False}
 
     def test_embargo_course(self):
         self.assertFalse(EmbargoedCourse.is_embargoed(self.course.id))
@@ -62,7 +62,7 @@ class EmbargoCourseFormTest(ModuleStoreTestCase):
 
     def test_form_typo(self):
         # Munge course id
-        bad_id = self.course.id + '_typo'
+        bad_id = self.course.id.to_deprecated_string() + '_typo'
 
         form_data = {'course_id': bad_id, 'embargoed': True}
         form = EmbargoedCourseForm(data=form_data)
@@ -79,7 +79,7 @@ class EmbargoCourseFormTest(ModuleStoreTestCase):
 
     def test_invalid_location(self):
         # Munge course id
-        bad_id = self.course.id.split('/')[-1]
+        bad_id = self.course.id.to_deprecated_string().split('/')[-1]
 
         form_data = {'course_id': bad_id, 'embargoed': True}
         form = EmbargoedCourseForm(data=form_data)

--- a/common/djangoapps/embargo/tests/test_middleware.py
+++ b/common/djangoapps/embargo/tests/test_middleware.py
@@ -32,8 +32,8 @@ class EmbargoMiddlewareTests(TestCase):
         self.embargo_course.save()
         self.regular_course = CourseFactory.create(org="Regular")
         self.regular_course.save()
-        self.embargoed_page = '/courses/' + self.embargo_course.id + '/info'
-        self.regular_page = '/courses/' + self.regular_course.id + '/info'
+        self.embargoed_page = '/courses/' + self.embargo_course.id.to_deprecated_string() + '/info'
+        self.regular_page = '/courses/' + self.regular_course.id.to_deprecated_string() + '/info'
         EmbargoedCourse(course_id=self.embargo_course.id, embargoed=True).save()
         EmbargoedState(
             embargoed_countries="cu, ir, Sy, SD",

--- a/common/djangoapps/embargo/tests/test_models.py
+++ b/common/djangoapps/embargo/tests/test_models.py
@@ -1,13 +1,14 @@
 """Test of models for embargo middleware app"""
 from django.test import TestCase
 
+from xmodule.modulestore.locations import SlashSeparatedCourseKey
 from embargo.models import EmbargoedCourse, EmbargoedState, IPFilter
 
 
 class EmbargoModelsTest(TestCase):
     """Test each of the 3 models in embargo.models"""
     def test_course_embargo(self):
-        course_id = 'abc/123/doremi'
+        course_id = SlashSeparatedCourseKey('abc', '123', 'doremi')
         # Test that course is not authorized by default
         self.assertFalse(EmbargoedCourse.is_embargoed(course_id))
 

--- a/common/djangoapps/external_auth/views.py
+++ b/common/djangoapps/external_auth/views.py
@@ -576,9 +576,8 @@ def course_specific_login(request, course_id):
        Dispatcher function for selecting the specific login method
        required by the course
     """
-    try:
-        course = course_from_id(course_id)
-    except ItemNotFoundError:
+    course = student.views.course_from_id(course_id)
+    if not course:
         # couldn't find the course, will just return vanilla signin page
         return _redirect_with_get_querydict('signin_user', request.GET)
 
@@ -595,9 +594,9 @@ def course_specific_register(request, course_id):
         Dispatcher function for selecting the specific registration method
         required by the course
     """
-    try:
-        course = course_from_id(course_id)
-    except ItemNotFoundError:
+    course = student.views.course_from_id(course_id)
+
+    if not course:
         # couldn't find the course, will just return vanilla registration page
         return _redirect_with_get_querydict('register_user', request.GET)
 
@@ -934,9 +933,3 @@ def provider_xrds(request):
     # custom XRDS header necessary for discovery process
     response['X-XRDS-Location'] = get_xrds_url('xrds', request)
     return response
-
-
-def course_from_id(course_id):
-    """Return the CourseDescriptor corresponding to this course_id"""
-    course_loc = CourseDescriptor.id_to_location(course_id)
-    return modulestore().get_instance(course_id, course_loc)

--- a/common/djangoapps/heartbeat/views.py
+++ b/common/djangoapps/heartbeat/views.py
@@ -13,6 +13,6 @@ def heartbeat(request):
     """
     output = {
         'date': datetime.now(UTC).isoformat(),
-        'courses': [course.location.url() for course in modulestore().get_courses()],
+        'courses': [course.location.to_deprecated_string() for course in modulestore().get_courses()],
     }
     return HttpResponse(json.dumps(output, indent=4))

--- a/common/djangoapps/reverification/models.py
+++ b/common/djangoapps/reverification/models.py
@@ -7,6 +7,7 @@ import pytz
 from django.core.exceptions import ValidationError
 from django.db import models
 from util.validate_on_save import ValidateOnSaveMixin
+from xmodule_django.models import CourseKeyField
 
 
 class MidcourseReverificationWindow(ValidateOnSaveMixin, models.Model):
@@ -17,7 +18,7 @@ class MidcourseReverificationWindow(ValidateOnSaveMixin, models.Model):
     overlapping time ranges.  This is enforced by this class's clean() method.
     """
     # the course that this window is attached to
-    course_id = models.CharField(max_length=255, db_index=True)
+    course_id = CourseKeyField(max_length=255, db_index=True)
     start_date = models.DateTimeField(default=None, null=True, blank=True)
     end_date = models.DateTimeField(default=None, null=True, blank=True)
 

--- a/common/djangoapps/reverification/tests/factories.py
+++ b/common/djangoapps/reverification/tests/factories.py
@@ -5,6 +5,7 @@ from reverification.models import MidcourseReverificationWindow
 from factory.django import DjangoModelFactory
 import pytz
 from datetime import timedelta, datetime
+from xmodule.modulestore.locations import SlashSeparatedCourseKey
 
 
 # Factories don't have __init__ methods, and are self documenting
@@ -13,7 +14,7 @@ class MidcourseReverificationWindowFactory(DjangoModelFactory):
     """ Creates a generic MidcourseReverificationWindow. """
     FACTORY_FOR = MidcourseReverificationWindow
 
-    course_id = u'MITx/999/Robot_Super_Course'
+    course_id = SlashSeparatedCourseKey.from_deprecated_string(u'MITx/999/Robot_Super_Course')
     # By default this factory creates a window that is currently open
     start_date = datetime.now(pytz.UTC) - timedelta(days=100)
     end_date = datetime.now(pytz.UTC) + timedelta(days=100)

--- a/common/djangoapps/static_replace/__init__.py
+++ b/common/djangoapps/static_replace/__init__.py
@@ -72,7 +72,7 @@ def replace_jump_to_id_urls(text, course_id, jump_to_id_base_url):
     return re.sub(_url_replace_regex('/jump_to_id/'), replace_jump_to_id_url, text)
 
 
-def replace_course_urls(text, course_id):
+def replace_course_urls(text, course_key):
     """
     Replace /course/$stuff urls with /courses/$course_id/$stuff urls
 
@@ -81,6 +81,8 @@ def replace_course_urls(text, course_id):
 
     returns: text with the links replaced
     """
+
+    course_id = course_key.to_deprecated_string()
 
     def replace_course_url(match):
         quote = match.group('quote')

--- a/common/djangoapps/static_replace/test/test_static_replace.py
+++ b/common/djangoapps/static_replace/test/test_static_replace.py
@@ -4,12 +4,13 @@ from nose.tools import assert_equals, assert_true, assert_false  # pylint: disab
 from static_replace import (replace_static_urls, replace_course_urls,
                             _url_replace_regex)
 from mock import patch, Mock
-from xmodule.modulestore import Location
+
+from xmodule.modulestore.locations import SlashSeparatedCourseKey
 from xmodule.modulestore.mongo import MongoModuleStore
 from xmodule.modulestore.xml import XMLModuleStore
 
 DATA_DIRECTORY = 'data_dir'
-COURSE_ID = 'org/course/run'
+COURSE_KEY = SlashSeparatedCourseKey('org', 'course', 'run')
 STATIC_SOURCE = '"/static/file.png"'
 
 
@@ -21,8 +22,8 @@ def test_multi_replace():
         replace_static_urls(replace_static_urls(STATIC_SOURCE, DATA_DIRECTORY), DATA_DIRECTORY)
     )
     assert_equals(
-        replace_course_urls(course_source, COURSE_ID),
-        replace_course_urls(replace_course_urls(course_source, COURSE_ID), COURSE_ID)
+        replace_course_urls(course_source, COURSE_KEY),
+        replace_course_urls(replace_course_urls(course_source, COURSE_KEY), COURSE_KEY)
     )
 
 
@@ -59,10 +60,10 @@ def test_mongo_filestore(mock_modulestore, mock_static_content):
     # Namespace => content url
     assert_equals(
         '"' + mock_static_content.convert_legacy_static_url_with_course_id.return_value + '"',
-        replace_static_urls(STATIC_SOURCE, DATA_DIRECTORY, course_id=COURSE_ID)
+        replace_static_urls(STATIC_SOURCE, DATA_DIRECTORY, course_id=COURSE_KEY)
     )
 
-    mock_static_content.convert_legacy_static_url_with_course_id.assert_called_once_with('file.png', COURSE_ID)
+    mock_static_content.convert_legacy_static_url_with_course_id.assert_called_once_with('file.png', COURSE_KEY)
 
 
 @patch('static_replace.settings')
@@ -101,7 +102,7 @@ def test_static_url_with_query(mock_modulestore, mock_storage):
 
     pre_text = 'EMBED src ="/static/LAlec04_controller.swf?csConfigFile=/c4x/org/course/asset/LAlec04_config.xml"'
     post_text = 'EMBED src ="/c4x/org/course/asset/LAlec04_controller.swf?csConfigFile=/c4x/org/course/asset/LAlec04_config.xml"'
-    assert_equals(post_text, replace_static_urls(pre_text, DATA_DIRECTORY, COURSE_ID))
+    assert_equals(post_text, replace_static_urls(pre_text, DATA_DIRECTORY, COURSE_KEY))
 
 
 def test_regex():

--- a/common/djangoapps/student/auth.py
+++ b/common/djangoapps/student/auth.py
@@ -35,7 +35,7 @@ def has_access(user, role):
         return True
     # if not, then check inferred permissions
     if (isinstance(role, (CourseStaffRole, CourseBetaTesterRole)) and
-            CourseInstructorRole(role.location).has_user(user)):
+            CourseInstructorRole(role.course_key).has_user(user)):
         return True
     return False
 
@@ -81,6 +81,6 @@ def _check_caller_authority(caller, role):
     if isinstance(role, (GlobalStaff, CourseCreatorRole)):
         raise PermissionDenied
     elif isinstance(role, CourseRole):  # instructors can change the roles w/in their course
-        if not has_access(caller, CourseInstructorRole(role.location)):
+        if not has_access(caller, CourseInstructorRole(role.course_key)):
             raise PermissionDenied
 

--- a/common/djangoapps/student/management/commands/anonymized_id_mapping.py
+++ b/common/djangoapps/student/management/commands/anonymized_id_mapping.py
@@ -59,7 +59,7 @@ class Command(BaseCommand):
                 for student in students:
                     csv_writer.writerow((
                         student.id,
-                        anonymous_id_for_user(student, ''),
+                        anonymous_id_for_user(student, None),
                         anonymous_id_for_user(student, course_id)
                     ))
         except IOError:

--- a/common/djangoapps/student/migrations/0034_auto__add_courseaccessrole.py
+++ b/common/djangoapps/student/migrations/0034_auto__add_courseaccessrole.py
@@ -1,0 +1,189 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'CourseAccessRole'
+        db.create_table('student_courseaccessrole', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('user', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['auth.User'])),
+            ('org', self.gf('django.db.models.fields.CharField')(db_index=True, max_length=64, blank=True)),
+            ('course_id', self.gf('xmodule_django.models.CourseKeyField')(db_index=True, max_length=255, blank=True)),
+            ('role', self.gf('django.db.models.fields.CharField')(max_length=64, db_index=True)),
+        ))
+        db.send_create_signal('student', ['CourseAccessRole'])
+
+        # Adding unique constraint on 'CourseAccessRole', fields ['user', 'org', 'course_id', 'role']
+        db.create_unique('student_courseaccessrole', ['user_id', 'org', 'course_id', 'role'])
+
+
+        # Changing field 'AnonymousUserId.course_id'
+        db.alter_column('student_anonymoususerid', 'course_id', self.gf('xmodule_django.models.CourseKeyField')(max_length=255))
+
+        # Changing field 'CourseEnrollment.course_id'
+        db.alter_column('student_courseenrollment', 'course_id', self.gf('xmodule_django.models.CourseKeyField')(max_length=255))
+
+        # Changing field 'CourseEnrollmentAllowed.course_id'
+        db.alter_column('student_courseenrollmentallowed', 'course_id', self.gf('xmodule_django.models.CourseKeyField')(max_length=255))
+
+    def backwards(self, orm):
+        # Removing unique constraint on 'CourseAccessRole', fields ['user', 'org', 'course_id', 'role']
+        db.delete_unique('student_courseaccessrole', ['user_id', 'org', 'course_id', 'role'])
+
+        # Deleting model 'CourseAccessRole'
+        db.delete_table('student_courseaccessrole')
+
+
+        # Changing field 'AnonymousUserId.course_id'
+        db.alter_column('student_anonymoususerid', 'course_id', self.gf('django.db.models.fields.CharField')(max_length=255))
+
+        # Changing field 'CourseEnrollment.course_id'
+        db.alter_column('student_courseenrollment', 'course_id', self.gf('django.db.models.fields.CharField')(max_length=255))
+
+        # Changing field 'CourseEnrollmentAllowed.course_id'
+        db.alter_column('student_courseenrollmentallowed', 'course_id', self.gf('django.db.models.fields.CharField')(max_length=255))
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'student.anonymoususerid': {
+            'Meta': {'object_name': 'AnonymousUserId'},
+            'anonymous_user_id': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '32'}),
+            'course_id': ('xmodule_django.models.CourseKeyField', [], {'db_index': 'True', 'max_length': '255', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"})
+        },
+        'student.courseaccessrole': {
+            'Meta': {'unique_together': "(('user', 'org', 'course_id', 'role'),)", 'object_name': 'CourseAccessRole'},
+            'course_id': ('xmodule_django.models.CourseKeyField', [], {'db_index': 'True', 'max_length': '255', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'org': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '64', 'blank': 'True'}),
+            'role': ('django.db.models.fields.CharField', [], {'max_length': '64', 'db_index': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"})
+        },
+        'student.courseenrollment': {
+            'Meta': {'ordering': "('user', 'course_id')", 'unique_together': "(('user', 'course_id'),)", 'object_name': 'CourseEnrollment'},
+            'course_id': ('xmodule_django.models.CourseKeyField', [], {'max_length': '255', 'db_index': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'null': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'mode': ('django.db.models.fields.CharField', [], {'default': "'honor'", 'max_length': '100'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"})
+        },
+        'student.courseenrollmentallowed': {
+            'Meta': {'unique_together': "(('email', 'course_id'),)", 'object_name': 'CourseEnrollmentAllowed'},
+            'auto_enroll': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'course_id': ('xmodule_django.models.CourseKeyField', [], {'max_length': '255', 'db_index': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'null': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'email': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'student.loginfailures': {
+            'Meta': {'object_name': 'LoginFailures'},
+            'failure_count': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'lockout_until': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"})
+        },
+        'student.passwordhistory': {
+            'Meta': {'object_name': 'PasswordHistory'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'time_set': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"})
+        },
+        'student.pendingemailchange': {
+            'Meta': {'object_name': 'PendingEmailChange'},
+            'activation_key': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '32', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'new_email': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '255', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['auth.User']", 'unique': 'True'})
+        },
+        'student.pendingnamechange': {
+            'Meta': {'object_name': 'PendingNameChange'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'new_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'rationale': ('django.db.models.fields.CharField', [], {'max_length': '1024', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['auth.User']", 'unique': 'True'})
+        },
+        'student.registration': {
+            'Meta': {'object_name': 'Registration', 'db_table': "'auth_registration'"},
+            'activation_key': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '32', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']", 'unique': 'True'})
+        },
+        'student.userprofile': {
+            'Meta': {'object_name': 'UserProfile', 'db_table': "'auth_userprofile'"},
+            'allow_certificate': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'city': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'country': ('django_countries.fields.CountryField', [], {'max_length': '2', 'null': 'True', 'blank': 'True'}),
+            'courseware': ('django.db.models.fields.CharField', [], {'default': "'course.xml'", 'max_length': '255', 'blank': 'True'}),
+            'gender': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '6', 'null': 'True', 'blank': 'True'}),
+            'goals': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '255', 'blank': 'True'}),
+            'level_of_education': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '6', 'null': 'True', 'blank': 'True'}),
+            'location': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '255', 'blank': 'True'}),
+            'mailing_address': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'meta': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '255', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'profile'", 'unique': 'True', 'to': "orm['auth.User']"}),
+            'year_of_birth': ('django.db.models.fields.IntegerField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'})
+        },
+        'student.userstanding': {
+            'Meta': {'object_name': 'UserStanding'},
+            'account_status': ('django.db.models.fields.CharField', [], {'max_length': '31', 'blank': 'True'}),
+            'changed_by': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']", 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'standing_last_changed_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'standing'", 'unique': 'True', 'to': "orm['auth.User']"})
+        },
+        'student.usertestgroup': {
+            'Meta': {'object_name': 'UserTestGroup'},
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '32', 'db_index': 'True'}),
+            'users': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.User']", 'db_index': 'True', 'symmetrical': 'False'})
+        }
+    }
+
+    complete_apps = ['student']

--- a/common/djangoapps/student/tests/test_authz.py
+++ b/common/djangoapps/student/tests/test_authz.py
@@ -5,12 +5,12 @@ import mock
 
 from django.test import TestCase
 from django.contrib.auth.models import User, AnonymousUser
-from xmodule.modulestore import Location
 from django.core.exceptions import PermissionDenied
 
 from student.roles import CourseInstructorRole, CourseStaffRole, CourseCreatorRole
 from student.tests.factories import AdminFactory
 from student.auth import has_access, add_users, remove_users
+from xmodule.modulestore.locations import SlashSeparatedCourseKey
 
 
 class CreatorGroupTest(TestCase):
@@ -137,54 +137,54 @@ class CourseGroupTest(TestCase):
         self.global_admin = AdminFactory()
         self.creator = User.objects.create_user('testcreator', 'testcreator+courses@edx.org', 'foo')
         self.staff = User.objects.create_user('teststaff', 'teststaff+courses@edx.org', 'foo')
-        self.location = Location('i4x', 'mitX', '101', 'course', 'test')
+        self.course_key = SlashSeparatedCourseKey('mitX', '101', 'test')
 
     def test_add_user_to_course_group(self):
         """
         Tests adding user to course group (happy path).
         """
         # Create groups for a new course (and assign instructor role to the creator).
-        self.assertFalse(has_access(self.creator, CourseInstructorRole(self.location)))
-        add_users(self.global_admin, CourseInstructorRole(self.location), self.creator)
-        add_users(self.global_admin, CourseStaffRole(self.location), self.creator)
-        self.assertTrue(has_access(self.creator, CourseInstructorRole(self.location)))
+        self.assertFalse(has_access(self.creator, CourseInstructorRole(self.course_key)))
+        add_users(self.global_admin, CourseInstructorRole(self.course_key), self.creator)
+        add_users(self.global_admin, CourseStaffRole(self.course_key), self.creator)
+        self.assertTrue(has_access(self.creator, CourseInstructorRole(self.course_key)))
 
         # Add another user to the staff role.
-        self.assertFalse(has_access(self.staff, CourseStaffRole(self.location)))
-        add_users(self.creator, CourseStaffRole(self.location), self.staff)
-        self.assertTrue(has_access(self.staff, CourseStaffRole(self.location)))
+        self.assertFalse(has_access(self.staff, CourseStaffRole(self.course_key)))
+        add_users(self.creator, CourseStaffRole(self.course_key), self.staff)
+        self.assertTrue(has_access(self.staff, CourseStaffRole(self.course_key)))
 
     def test_add_user_to_course_group_permission_denied(self):
         """
         Verifies PermissionDenied if caller of add_user_to_course_group is not instructor role.
         """
-        add_users(self.global_admin, CourseInstructorRole(self.location), self.creator)
-        add_users(self.global_admin, CourseStaffRole(self.location), self.creator)
+        add_users(self.global_admin, CourseInstructorRole(self.course_key), self.creator)
+        add_users(self.global_admin, CourseStaffRole(self.course_key), self.creator)
         with self.assertRaises(PermissionDenied):
-            add_users(self.staff, CourseStaffRole(self.location), self.staff)
+            add_users(self.staff, CourseStaffRole(self.course_key), self.staff)
 
     def test_remove_user_from_course_group(self):
         """
         Tests removing user from course group (happy path).
         """
-        add_users(self.global_admin, CourseInstructorRole(self.location), self.creator)
-        add_users(self.global_admin, CourseStaffRole(self.location), self.creator)
+        add_users(self.global_admin, CourseInstructorRole(self.course_key), self.creator)
+        add_users(self.global_admin, CourseStaffRole(self.course_key), self.creator)
 
-        add_users(self.creator, CourseStaffRole(self.location), self.staff)
-        self.assertTrue(has_access(self.staff, CourseStaffRole(self.location)))
+        add_users(self.creator, CourseStaffRole(self.course_key), self.staff)
+        self.assertTrue(has_access(self.staff, CourseStaffRole(self.course_key)))
 
-        remove_users(self.creator, CourseStaffRole(self.location), self.staff)
-        self.assertFalse(has_access(self.staff, CourseStaffRole(self.location)))
+        remove_users(self.creator, CourseStaffRole(self.course_key), self.staff)
+        self.assertFalse(has_access(self.staff, CourseStaffRole(self.course_key)))
 
-        remove_users(self.creator, CourseInstructorRole(self.location), self.creator)
-        self.assertFalse(has_access(self.creator, CourseInstructorRole(self.location)))
+        remove_users(self.creator, CourseInstructorRole(self.course_key), self.creator)
+        self.assertFalse(has_access(self.creator, CourseInstructorRole(self.course_key)))
 
     def test_remove_user_from_course_group_permission_denied(self):
         """
         Verifies PermissionDenied if caller of remove_user_from_course_group is not instructor role.
         """
-        add_users(self.global_admin, CourseInstructorRole(self.location), self.creator)
+        add_users(self.global_admin, CourseInstructorRole(self.course_key), self.creator)
         another_staff = User.objects.create_user('another', 'teststaff+anothercourses@edx.org', 'foo')
-        add_users(self.global_admin, CourseStaffRole(self.location), self.creator, self.staff, another_staff)
+        add_users(self.global_admin, CourseStaffRole(self.course_key), self.creator, self.staff, another_staff)
         with self.assertRaises(PermissionDenied):
-            remove_users(self.staff, CourseStaffRole(self.location), another_staff)
+            remove_users(self.staff, CourseStaffRole(self.course_key), another_staff)

--- a/common/djangoapps/student/tests/test_bulk_email_settings.py
+++ b/common/djangoapps/student/tests/test_bulk_email_settings.py
@@ -15,6 +15,7 @@ from student.tests.factories import UserFactory, CourseEnrollmentFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 from courseware.tests.modulestore_config import TEST_DATA_MIXED_MODULESTORE
+from xmodule.modulestore.locations import SlashSeparatedCourseKey
 
 from bulk_email.models import CourseAuthorization
 
@@ -100,7 +101,10 @@ class TestStudentDashboardEmailViewXMLBacked(ModuleStoreTestCase):
 
         # Create student account
         student = UserFactory.create()
-        CourseEnrollmentFactory.create(user=student, course_id=self.course_name)
+        CourseEnrollmentFactory.create(
+            user=student,
+            course_id=SlashSeparatedCourseKey.from_deprecated_string(self.course_name)
+        )
         self.client.login(username=student.username, password="test")
 
         try:

--- a/common/djangoapps/student/tests/test_login.py
+++ b/common/djangoapps/student/tests/test_login.py
@@ -20,6 +20,7 @@ from xmodule.modulestore.inheritance import own_metadata
 from xmodule.modulestore.django import editable_modulestore
 
 from external_auth.models import ExternalAuthMap
+from xmodule.modulestore.locations import SlashSeparatedCourseKey
 
 TEST_DATA_MIXED_MODULESTORE = mixed_store_config(settings.COMMON_TEST_DATA_ROOT, {})
 
@@ -275,7 +276,10 @@ class UtilFnTest(TestCase):
         COURSE_ID = u'org/num/run'                                # pylint: disable=C0103
         COURSE_URL = u'/courses/{}/otherstuff'.format(COURSE_ID)  # pylint: disable=C0103
         NON_COURSE_URL = u'/blahblah'                             # pylint: disable=C0103
-        self.assertEqual(_parse_course_id_from_string(COURSE_URL), COURSE_ID)
+        self.assertEqual(
+            _parse_course_id_from_string(COURSE_URL),
+            SlashSeparatedCourseKey.from_deprecated_string(COURSE_ID)
+        )
         self.assertIsNone(_parse_course_id_from_string(NON_COURSE_URL))
 
 
@@ -320,7 +324,7 @@ class ExternalAuthShibTest(ModuleStoreTestCase):
         """
         Tests the _get_course_enrollment_domain utility function
         """
-        self.assertIsNone(_get_course_enrollment_domain("I/DONT/EXIST"))
+        self.assertIsNone(_get_course_enrollment_domain(SlashSeparatedCourseKey("I", "DONT", "EXIST")))
         self.assertIsNone(_get_course_enrollment_domain(self.course.id))
         self.assertEqual(self.shib_course.enrollment_domain, _get_course_enrollment_domain(self.shib_course.id))
 
@@ -340,7 +344,7 @@ class ExternalAuthShibTest(ModuleStoreTestCase):
         Tests the redirects when visiting course-specific URL with @login_required.
         Should vary by course depending on its enrollment_domain
         """
-        TARGET_URL = reverse('courseware', args=[self.course.id])            # pylint: disable=C0103
+        TARGET_URL = reverse('courseware', args=[self.course.id.to_deprecated_string()])            # pylint: disable=C0103
         noshib_response = self.client.get(TARGET_URL, follow=True)
         self.assertEqual(noshib_response.redirect_chain[-1],
                          ('http://testserver/accounts/login?next={url}'.format(url=TARGET_URL), 302))
@@ -348,7 +352,7 @@ class ExternalAuthShibTest(ModuleStoreTestCase):
                                               .format(platform_name=settings.PLATFORM_NAME)))
         self.assertEqual(noshib_response.status_code, 200)
 
-        TARGET_URL_SHIB = reverse('courseware', args=[self.shib_course.id])  # pylint: disable=C0103
+        TARGET_URL_SHIB = reverse('courseware', args=[self.shib_course.id.to_deprecated_string()])  # pylint: disable=C0103
         shib_response = self.client.get(**{'path': TARGET_URL_SHIB,
                                            'follow': True,
                                            'REMOTE_USER': self.extauth.external_id,

--- a/common/djangoapps/student/tests/test_userstanding.py
+++ b/common/djangoapps/student/tests/test_userstanding.py
@@ -53,7 +53,7 @@ class UserStandingTest(TestCase):
         try:
             self.some_url = reverse('dashboard')
         except NoReverseMatch:
-            self.some_url = '/course'
+            self.some_url = '/course/'
 
         # since it's only possible to disable accounts from lms, we're going
         # to skip tests for cms

--- a/common/djangoapps/track/contexts.py
+++ b/common/djangoapps/track/contexts.py
@@ -1,7 +1,8 @@
 """Generates common contexts"""
 import logging
 
-from xmodule.course_module import CourseDescriptor
+from xmodule.modulestore.locations import SlashSeparatedCourseKey
+from opaque_keys import InvalidKeyError
 from util.request import COURSE_REGEX
 
 log = logging.getLogger(__name__)
@@ -9,15 +10,24 @@ log = logging.getLogger(__name__)
 
 def course_context_from_url(url):
     """
-    Extracts the course_id from the given `url` and passes it on to
+    Extracts the course_context from the given `url` and passes it on to
     `course_context_from_course_id()`.
     """
     url = url or ''
 
     match = COURSE_REGEX.match(url)
-    course_id = ''
+    course_id = None
     if match:
-        course_id = match.group('course_id') or ''
+        course_id_string = match.group('course_id')
+        try:
+            course_id = SlashSeparatedCourseKey.from_deprecated_string(course_id_string)
+        except InvalidKeyError:
+            log.warning(
+                'unable to parse course_id "{course_id}"'.format(
+                    course_id=course_id_string
+                ),
+                exc_info=True
+            )
 
     return course_context_from_course_id(course_id)
 
@@ -34,23 +44,12 @@ def course_context_from_course_id(course_id):
         }
 
     """
+    if course_id is None:
+        return {'course_id': '', 'org_id': ''}
 
-    course_id = course_id or ''
-    context = {
-        'course_id': course_id,
-        'org_id': ''
+    # TODO: Make this accept any CourseKey, and serialize it using .to_string
+    assert(isinstance(course_id, SlashSeparatedCourseKey))
+    return {
+        'course_id': course_id.to_deprecated_string(),
+        'org_id': course_id.org,
     }
-
-    if course_id:
-        try:
-            location = CourseDescriptor.id_to_location(course_id)
-            context['org_id'] = location.org
-        except ValueError:
-            log.warning(
-                'Unable to parse course_id "{course_id}"'.format(
-                    course_id=course_id
-                ),
-                exc_info=True
-            )
-
-    return context

--- a/common/djangoapps/user_api/middleware.py
+++ b/common/djangoapps/user_api/middleware.py
@@ -5,6 +5,7 @@ Adds user's tags to tracking event context.
 from track.contexts import COURSE_REGEX
 from eventtracking import tracker
 from user_api.models import UserCourseTag
+from xmodule.modulestore.locations import SlashSeparatedCourseKey
 
 
 class UserTagsEventContextMiddleware(object):
@@ -19,6 +20,7 @@ class UserTagsEventContextMiddleware(object):
         course_id = None
         if match:
             course_id = match.group('course_id')
+            course_key = SlashSeparatedCourseKey.from_deprecated_string(course_id)
 
         context = {}
 
@@ -29,7 +31,7 @@ class UserTagsEventContextMiddleware(object):
                 context['course_user_tags'] = dict(
                     UserCourseTag.objects.filter(
                         user=request.user.pk,
-                        course_id=course_id
+                        course_id=course_key,
                     ).values_list('key', 'value')
                 )
             else:

--- a/common/djangoapps/user_api/models.py
+++ b/common/djangoapps/user_api/models.py
@@ -2,6 +2,8 @@ from django.contrib.auth.models import User
 from django.core.validators import RegexValidator
 from django.db import models
 
+from xmodule_django.models import CourseKeyField
+
 
 class UserPreference(models.Model):
     """A user's preference, stored as generic text to be processed by client"""
@@ -44,7 +46,7 @@ class UserCourseTag(models.Model):
     """
     user = models.ForeignKey(User, db_index=True, related_name="+")
     key = models.CharField(max_length=255, db_index=True)
-    course_id = models.CharField(max_length=255, db_index=True)
+    course_id = CourseKeyField(max_length=255, db_index=True)
     value = models.TextField()
 
     class Meta:  # pylint: disable=missing-docstring

--- a/common/djangoapps/user_api/tests/factories.py
+++ b/common/djangoapps/user_api/tests/factories.py
@@ -3,6 +3,7 @@ from factory.django import DjangoModelFactory
 from factory import SubFactory
 from student.tests.factories import UserFactory
 from user_api.models import UserPreference, UserCourseTag
+from xmodule.modulestore.locations import SlashSeparatedCourseKey
 
 # Factories don't have __init__ methods, and are self documenting
 # pylint: disable=W0232, C0111
@@ -18,6 +19,6 @@ class UserCourseTagFactory(DjangoModelFactory):
     FACTORY_FOR = UserCourseTag
 
     user = SubFactory(UserFactory)
-    course_id = 'org/course/run'
+    course_id = SlashSeparatedCourseKey('org', 'course', 'run')
     key = None
     value = None

--- a/common/djangoapps/user_api/tests/test_user_service.py
+++ b/common/djangoapps/user_api/tests/test_user_service.py
@@ -5,6 +5,7 @@ from django.test import TestCase
 
 from student.tests.factories import UserFactory
 from user_api import user_service
+from xmodule.modulestore.locations import SlashSeparatedCourseKey
 
 
 class TestUserService(TestCase):
@@ -13,7 +14,7 @@ class TestUserService(TestCase):
     """
     def setUp(self):
         self.user = UserFactory.create()
-        self.course_id = 'test_org/test_course_number/test_run'
+        self.course_id = SlashSeparatedCourseKey('test_org', 'test_course_number', 'test_run')
         self.test_key = 'test_key'
 
     def test_get_set_course_tag(self):

--- a/common/djangoapps/util/request.py
+++ b/common/djangoapps/util/request.py
@@ -3,6 +3,7 @@ import re
 
 from django.conf import settings
 from microsite_configuration import microsite
+from xmodule.modulestore.locations import SlashSeparatedCourseKey
 
 COURSE_REGEX = re.compile(r'^.*?/courses/(?P<course_id>[^/]+/[^/]+/[^/]+)')
 
@@ -26,11 +27,17 @@ def course_id_from_url(url):
     """
     Extracts the course_id from the given `url`.
     """
-    url = url or ''
+    if not url:
+        return None
 
     match = COURSE_REGEX.match(url)
-    course_id = ''
-    if match:
-        course_id = match.group('course_id') or ''
 
-    return course_id
+    if match is None:
+        return None
+
+    course_id = match.group('course_id')
+
+    if course_id is None:
+        return None
+
+    return SlashSeparatedCourseKey.from_deprecated_string(course_id)


### PR DESCRIPTION
This commit adds base classes for CourseKeys and UsageKeys, and Location and
SlashSeparatedCourseKey implementations of both.

These keys are now objects with a limited interface, and the particular
internal representation is managed by the data storage layer (the
modulestore).

For the LMS, there should be no outward-facing changes to the system. The keys
are, for now, a change to internal representation only. For Studio, the new
serialized form of the keys is used in urls, to allow for further migration in
the future.

Co-Author: Andy Armstrong andya@edx.org Co-Author: Christina Roberts
christina@edx.org Co-Author: David Baumgold db@edx.org Co-Author: Diana
Huang dkh@edx.org Co-Author: Don Mitchell dmitchell@edx.org Co-Author:
Julia Hansbrough julia@edx.org Co-Author: Nimisha Asthagiri
nasthagiri@edx.org Co-Author: Sarina Canelake sarina@edx.org

[LMS-2370]
