### PR TITLE
lms/djangoapps/courseware changes for opaque keys [partial commit]

### DIFF
--- a/common/djangoapps/terrain/course_helpers.py
+++ b/common/djangoapps/terrain/course_helpers.py
@@ -43,7 +43,7 @@ def log_in(username='robot', password='test', email='robot@edx.org', name="Robot
 
 
 @world.absorb
-def register_by_course_id(course_id, username='robot', password='test', is_staff=False):
+def register_by_course_key(course_key, username='robot', password='test', is_staff=False):
     create_user(username, password)
     user = User.objects.get(username=username)
     # Note: this flag makes the user global staff - that is, an edX employee - not a course staff.
@@ -51,17 +51,17 @@ def register_by_course_id(course_id, username='robot', password='test', is_staff
     if is_staff:
         user.is_staff = True
         user.save()
-    CourseEnrollment.enroll(user, course_id)
+    CourseEnrollment.enroll(user, course_key)
 
 
 @world.absorb
-def enroll_user(user, course_id):
+def enroll_user(user, course_key):
     # Activate user
     registration = world.RegistrationFactory(user=user)
     registration.register(user)
     registration.activate()
     # Enroll them in the course
-    CourseEnrollment.enroll(user, course_id)
+    CourseEnrollment.enroll(user, course_key)
 
 
 @world.absorb

--- a/common/djangoapps/terrain/steps.py
+++ b/common/djangoapps/terrain/steps.py
@@ -21,6 +21,8 @@ from .course_helpers import *
 from .ui_helpers import *
 from nose.tools import assert_equals  # pylint: disable=E0611
 
+from xmodule.modulestore.locations import SlashSeparatedCourseKey
+
 from logging import getLogger
 logger = getLogger(__name__)
 
@@ -110,7 +112,8 @@ def i_am_not_logged_in(step):
 
 @step('I am staff for course "([^"]*)"$')
 def i_am_staff_for_course_by_id(step, course_id):
-    world.register_by_course_id(course_id, True)
+    course_key = SlashSeparatedCourseKey.from_deprecated_string(course_id)
+    world.register_by_course_key(course_key, True)
 
 
 @step(r'click (?:the|a) link (?:called|with the text) "([^"]*)"$')

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -8,12 +8,13 @@ from django.http import Http404
 from django.conf import settings
 
 from edxmako.shortcuts import render_to_string
-from xmodule.course_module import CourseDescriptor
-from xmodule.modulestore import Location, XML_MODULESTORE_TYPE, MONGO_MODULESTORE_TYPE
-from xmodule.modulestore.django import modulestore, loc_mapper
+from xmodule.modulestore import XML_MODULESTORE_TYPE
+from xmodule.modulestore.keys import CourseKey
+from xmodule.modulestore.django import modulestore
 from xmodule.contentstore.content import StaticContent
 from xmodule.modulestore.exceptions import ItemNotFoundError, InvalidLocationError
 from static_replace import replace_static_urls
+from xmodule.modulestore import MONGO_MODULESTORE_TYPE
 
 from courseware.access import has_access
 from courseware.model_data import FieldDataCache
@@ -49,15 +50,15 @@ def get_course(course_id, depth=0):
     None means infinite depth.  Default is to fetch no children.
     """
     try:
-        course_loc = CourseDescriptor.id_to_location(course_id)
-        return modulestore().get_instance(course_id, course_loc, depth=depth)
+        return modulestore().get_course(course_id, depth=depth)
     except (KeyError, ItemNotFoundError):
         raise ValueError(u"Course not found: {0}".format(course_id))
     except InvalidLocationError:
         raise ValueError(u"Invalid location: {0}".format(course_id))
 
 
-def get_course_by_id(course_id, depth=0):
+# TODO please rename this function to get_course_by_key at next opportunity!
+def get_course_by_id(course_key, depth=0):
     """
     Given a course id, return the corresponding course descriptor.
 
@@ -66,50 +67,55 @@ def get_course_by_id(course_id, depth=0):
     depth: The number of levels of children for the modulestore to cache. None means infinite depth
     """
     try:
-        course_loc = CourseDescriptor.id_to_location(course_id)
-        return modulestore().get_instance(course_id, course_loc, depth=depth)
+        course = modulestore().get_course(course_key, depth=depth)
+        if course:
+            return course
+        else:
+            raise Http404("Course not found.")
     except (KeyError, ItemNotFoundError):
         raise Http404("Course not found.")
     except InvalidLocationError:
         raise Http404("Invalid location")
 
 
-def get_course_with_access(user, course_id, action, depth=0):
+def get_course_with_access(user, action, course_key, depth=0):
     """
-    Given a course_id, look up the corresponding course descriptor,
+    Given a course_key, look up the corresponding course descriptor,
     check that the user has the access to perform the specified action
     on the course, and return the descriptor.
 
-    Raises a 404 if the course_id is invalid, or the user doesn't have access.
+    Raises a 404 if the course_key is invalid, or the user doesn't have access.
 
     depth: The number of levels of children for the modulestore to cache. None means infinite depth
     """
-    course = get_course_by_id(course_id, depth=depth)
-    if not has_access(user, course, action):
+    assert isinstance(course_key, CourseKey)
+    course = get_course_by_id(course_key, depth=depth)
+
+    if not has_access(user, action, course, course_key):
         # Deliberately return a non-specific error message to avoid
         # leaking info about access control settings
         raise Http404("Course not found.")
+
     return course
 
 
-def get_opt_course_with_access(user, course_id, action):
+def get_opt_course_with_access(user, action, course_key):
     """
-    Same as get_course_with_access, except that if course_id is None,
+    Same as get_course_with_access, except that if course_key is None,
     return None without performing any access checks.
     """
-    if course_id is None:
+    if course_key is None:
         return None
-    return get_course_with_access(user, course_id, action)
+    return get_course_with_access(user, action, course_key)
 
 
 def course_image_url(course):
-    """Try to look up the image url for the course.  If it's not found,
-    log an error and return the dead link"""
-    if course.static_asset_path or modulestore().get_modulestore_type(course.location.course_id) == XML_MODULESTORE_TYPE:
+    """ Determine whether this is an XML or Studio-backed course, and return the appropriate course_image URL """
+    if course.static_asset_path or modulestore().get_modulestore_type(course.id) == XML_MODULESTORE_TYPE:
         return '/static/' + (course.static_asset_path or getattr(course, 'data_dir', '')) + "/images/course_image.jpg"
     else:
-        loc = StaticContent.compute_location(course.location.org, course.location.course, course.course_image)
-        _path = StaticContent.get_url_path_from_location(loc)
+        loc = StaticContent.compute_location(course.location.course_key, course.course_image)
+        _path = loc.to_deprecated_string()
         return _path
 
 
@@ -158,7 +164,7 @@ def get_course_about_section(course, section_key):
     # markup. This can change without effecting this interface when we find a
     # good format for defining so many snippets of text/html.
 
-# TODO: Remove number, instructors from this list
+    # TODO: Remove number, instructors from this list
     if section_key in ['short_description', 'description', 'key_dates', 'video',
                        'course_staff_short', 'course_staff_extended',
                        'requirements', 'syllabus', 'textbook', 'faq', 'more_info',
@@ -199,7 +205,7 @@ def get_course_about_section(course, section_key):
 
         except ItemNotFoundError:
             log.warning(
-                u"Missing about section {key} in course {url}".format(key=section_key, url=course.location.url())
+                u"Missing about section {key} in course {url}".format(key=section_key, url=course.location.to_deprecated_string())
             )
             return None
     elif section_key == "title":
@@ -223,14 +229,14 @@ def get_course_info_section(request, course, section_key):
     - updates
     - guest_updates
     """
-    loc = Location(course.location.tag, course.location.org, course.location.course, 'course_info', section_key)
+    usage_key = course.id.make_usage_key('course_info', section_key)
 
     # Use an empty cache
     field_data_cache = FieldDataCache([], course.id, request.user)
     info_module = get_module(
         request.user,
         request,
-        loc,
+        usage_key,
         field_data_cache,
         course.id,
         wrap_xmodule_display=False,
@@ -279,12 +285,12 @@ def get_course_syllabus_section(course, section_key):
                 return replace_static_urls(
                     html_file.read().decode('utf-8'),
                     getattr(course, 'data_dir', None),
-                    course_id=course.location.course_id,
+                    course_id=course.id,
                     static_asset_path=course.static_asset_path,
                 )
         except ResourceNotFoundError:
             log.exception(
-                u"Missing syllabus section {key} in course {url}".format(key=section_key, url=course.location.url())
+                u"Missing syllabus section {key} in course {url}".format(key=section_key, url=course.location.to_deprecated_string())
             )
             return "! Syllabus missing !"
 
@@ -312,7 +318,7 @@ def get_courses(user, domain=None):
     Returns a list of courses available, sorted by course.number
     '''
     courses = branding.get_visible_courses()
-    courses = [c for c in courses if has_access(user, c, 'see_exists')]
+    courses = [c for c in courses if has_access(user, 'see_exists', c)]
 
     courses = sorted(courses, key=lambda course: course.number)
 
@@ -332,15 +338,14 @@ def sort_by_announcement(courses):
     return courses
 
 
-def get_cms_course_link(course):
+def get_cms_course_link(course, page='course'):
     """
     Returns a link to course_index for editing the course in cms,
     assuming that the course is actually cms-backed.
     """
-    locator = loc_mapper().translate_location(
-        course.location.course_id, course.location, False, True
-    )
-    return "//" + settings.CMS_BASE + locator.url_reverse('course/', '')
+    # This is fragile, but unfortunately the problem is that within the LMS we
+    # can't use the reverse calls from the CMS
+    return u"//{}/{}/{}".format(settings.CMS_BASE, page, unicode(course.id))
 
 
 def get_cms_block_link(block, page):
@@ -348,20 +353,20 @@ def get_cms_block_link(block, page):
     Returns a link to block_index for editing the course in cms,
     assuming that the block is actually cms-backed.
     """
-    locator = loc_mapper().translate_location(
-        block.location.course_id, block.location, False, True
-    )
-    return "//" + settings.CMS_BASE + locator.url_reverse(page, '')
+    # This is fragile, but unfortunately the problem is that within the LMS we
+    # can't use the reverse calls from the CMS
+    return u"//{}/{}/{}".format(settings.CMS_BASE, page, block.location)
 
 
-def get_studio_url(course_id, page):
+def get_studio_url(course_key, page):
     """
     Get the Studio URL of the page that is passed in.
     """
-    course = get_course_by_id(course_id)
+    assert(isinstance(course_key, CourseKey))
+    course = get_course_by_id(course_key)
     is_studio_course = course.course_edit_method == "Studio"
-    is_mongo_course = modulestore().get_modulestore_type(course_id) == MONGO_MODULESTORE_TYPE
+    is_mongo_course = modulestore().get_modulestore_type(course_key) == MONGO_MODULESTORE_TYPE
     studio_link = None
     if is_studio_course and is_mongo_course:
-        studio_link = get_cms_block_link(course, page)
+        studio_link = get_cms_course_link(course, page)
     return studio_link

--- a/lms/djangoapps/courseware/features/annotatable.py
+++ b/lms/djangoapps/courseware/features/annotatable.py
@@ -140,7 +140,7 @@ class AnnotatableSteps(object):
 
     def active_problem_selector(self, subselector):
         return 'div[data-problem-id="{}"] {}'.format(
-            world.scenario_dict['PROBLEMS'][self.active_problem].location.url(),
+            world.scenario_dict['PROBLEMS'][self.active_problem].location.to_deprecated_string(),
             subselector,
         )
 

--- a/lms/djangoapps/courseware/features/common.py
+++ b/lms/djangoapps/courseware/features/common.py
@@ -12,6 +12,7 @@ from django.core.urlresolvers import reverse
 from student.models import CourseEnrollment
 from xmodule.modulestore import Location
 from xmodule.modulestore.django import modulestore
+from xmodule.modulestore.locations import SlashSeparatedCourseKey
 from xmodule.course_module import CourseDescriptor
 from courseware.courses import get_course_by_id
 from xmodule import seq_module, vertical_module
@@ -119,16 +120,19 @@ def go_into_course(step):
 
 
 def course_id(course_num):
-    return "%s/%s/%s" % (world.scenario_dict['COURSE'].org, course_num,
-                         world.scenario_dict['COURSE'].url_name)
+    return SlashSeparatedCourseKey(
+        world.scenario_dict['COURSE'].org,
+        course_num,
+        world.scenario_dict['COURSE'].url_name
+    )
 
 
 def course_location(course_num):
-    return world.scenario_dict['COURSE'].location._replace(course=course_num)
+    return world.scenario_dict['COURSE'].location.replace(course=course_num)
 
 
 def section_location(course_num):
-    return world.scenario_dict['SECTION'].location._replace(course=course_num)
+    return world.scenario_dict['SECTION'].location.replace(course=course_num)
 
 
 def visit_scenario_item(item_key):
@@ -140,8 +144,8 @@ def visit_scenario_item(item_key):
     url = django_url(reverse(
         'jump_to',
         kwargs={
-            'course_id': world.scenario_dict['COURSE'].id,
-            'location': str(world.scenario_dict[item_key].location),
+            'course_id': world.scenario_dict['COURSE'].id.to_deprecated_string(),
+            'location': world.scenario_dict[item_key].location.to_deprecated_string(),
         }
     ))
 

--- a/lms/djangoapps/courseware/features/conditional.py
+++ b/lms/djangoapps/courseware/features/conditional.py
@@ -46,16 +46,16 @@ class ConditionalSteps(object):
 
         metadata = {
             'xml_attributes': {
-                'sources': world.scenario_dict['CONDITION_SOURCE'].location.url()
+                condition: cond_value
             }
         }
-        metadata['xml_attributes'][condition] = cond_value
 
         world.scenario_dict['CONDITIONAL'] = world.ItemFactory(
             parent_location=world.scenario_dict['WRAPPER'].location,
             category='conditional',
             display_name="Test Conditional",
-            metadata=metadata
+            metadata=metadata,
+            sources_list=[world.scenario_dict['CONDITION_SOURCE'].location],
         )
 
         world.ItemFactory(

--- a/lms/djangoapps/courseware/features/lti.py
+++ b/lms/djangoapps/courseware/features/lti.py
@@ -201,26 +201,24 @@ def i_am_registered_for_the_course(coursenum, metadata, user='Instructor'):
         metadata.update({'days_early_for_beta': 5, 'start': tomorrow})
         create_course_for_lti(coursenum, metadata)
         course_descriptor = world.scenario_dict['COURSE']
-        course_location = world.scenario_dict['COURSE'].location
 
         # create beta tester
-        user = BetaTesterFactory(course=course_location)
+        user = BetaTesterFactory(course=course_descriptor.id)
         normal_student = UserFactory()
-        instructor = InstructorFactory(course=course_location)
+        instructor = InstructorFactory(course=course_descriptor.id)
 
-        assert not has_access(normal_student, course_descriptor, 'load')
-        assert has_access(user, course_descriptor, 'load')
-        assert has_access(instructor, course_descriptor, 'load')
+        assert not has_access(normal_student, 'load', course_descriptor)
+        assert has_access(user, 'load', course_descriptor)
+        assert has_access(instructor, 'load', course_descriptor)
     else:
         metadata.update({'start': datetime.datetime(1970, 1, 1, tzinfo=UTC)})
         create_course_for_lti(coursenum, metadata)
         course_descriptor = world.scenario_dict['COURSE']
-        course_location = world.scenario_dict['COURSE'].location
-        user = InstructorFactory(course=course_location)
+        user = InstructorFactory(course=course_descriptor.id)
 
     # Enroll the user in the course and log them in
-    if has_access(user, course_descriptor, 'load'):
-        world.enroll_user(user, course_id(coursenum))
+    if has_access(user, 'load', course_descriptor):
+        world.enroll_user(user, course_descriptor.id)
 
     world.log_in(username=user.username, password='test')
 

--- a/lms/djangoapps/courseware/features/navigation.py
+++ b/lms/djangoapps/courseware/features/navigation.py
@@ -5,6 +5,7 @@ from lettuce import world, step
 from common import course_id, course_location
 from problems_setup import PROBLEM_DICT
 from nose.tools import assert_in
+from xmodule.modulestore.locations import SlashSeparatedCourseKey
 
 
 @step(u'I am viewing a course with multiple sections')
@@ -148,7 +149,7 @@ def create_course():
 
 
 def create_user_and_visit_course():
-    world.register_by_course_id('edx/999/Test_Course')
+    world.register_by_course_key(SlashSeparatedCourseKey('edx', '999', 'Test_Course'))
     world.log_in()
     world.visit('/courses/edx/999/Test_Course/courseware/')
 

--- a/lms/djangoapps/courseware/features/openended.py
+++ b/lms/djangoapps/courseware/features/openended.py
@@ -10,7 +10,7 @@ logger = getLogger(__name__)
 
 @step('I navigate to an openended question$')
 def navigate_to_an_openended_question(step):
-    world.register_by_course_id('MITx/3.091x/2012_Fall')
+    world.register_by_course_key('MITx/3.091x/2012_Fall')
     world.log_in(email='robot@edx.org', password='test')
     problem = '/courses/MITx/3.091x/2012_Fall/courseware/Week_10/Polymer_Synthesis/'
     world.browser.visit(django_url(problem))
@@ -20,7 +20,7 @@ def navigate_to_an_openended_question(step):
 
 @step('I navigate to an openended question as staff$')
 def navigate_to_an_openended_question_as_staff(step):
-    world.register_by_course_id('MITx/3.091x/2012_Fall', True)
+    world.register_by_course_key('MITx/3.091x/2012_Fall', True)
     world.log_in(email='robot@edx.org', password='test')
     problem = '/courses/MITx/3.091x/2012_Fall/courseware/Week_10/Polymer_Synthesis/'
     world.browser.visit(django_url(problem))

--- a/lms/djangoapps/courseware/features/registration.py
+++ b/lms/djangoapps/courseware/features/registration.py
@@ -7,7 +7,7 @@ from lettuce.django import django_url
 
 @step('I register for the course "([^"]*)"$')
 def i_register_for_the_course(_step, course):
-    url = django_url('courses/%s/about' % world.scenario_dict['COURSE'].id)
+    url = django_url('courses/%s/about' % world.scenario_dict['COURSE'].id.to_deprecated_string())
     world.browser.visit(url)
     world.css_click('section.intro a.register')
 

--- a/lms/djangoapps/courseware/features/video.py
+++ b/lms/djangoapps/courseware/features/video.py
@@ -195,7 +195,7 @@ def add_vertical_to_course(course_num):
 
 
 def last_vertical_location(course_num):
-    return world.scenario_dict['LAST_VERTICAL'].location._replace(course=course_num)
+    return world.scenario_dict['LAST_VERTICAL'].location.replace(course=course_num)
 
 
 def upload_file(filename, location):
@@ -204,7 +204,7 @@ def upload_file(filename, location):
     mime_type = "application/json"
 
     content_location = StaticContent.compute_location(
-        location.org, location.course, filename
+        location.course_key, filename
     )
     content = StaticContent(content_location, filename, mime_type, f.read())
     contentstore().save(content)

--- a/lms/djangoapps/courseware/grades.py
+++ b/lms/djangoapps/courseware/grades.py
@@ -23,6 +23,7 @@ from xmodule.modulestore.exceptions import ItemNotFoundError
 from xmodule.util.duedate import get_extended_due_date
 from .models import StudentModule
 from .module_render import get_module_for_descriptor
+from opaque_keys import InvalidKeyError
 
 log = logging.getLogger("edx.courseware")
 
@@ -50,9 +51,9 @@ def yield_dynamic_descriptor_descendents(descriptor, module_creator):
         yield next_descriptor
 
 
-def answer_distributions(course_id):
+def answer_distributions(course_key):
     """
-    Given a course_id, return answer distributions in the form of a dictionary
+    Given a course_key, return answer distributions in the form of a dictionary
     mapping:
 
       (problem url_name, problem display_name, problem_id) -> {dict: answer -> count}
@@ -82,67 +83,60 @@ def answer_distributions(course_id):
     # dict: { module.module_state_key : (url_name, display_name) }
     state_keys_to_problem_info = {}  # For caching, used by url_and_display_name
 
-    def url_and_display_name(module_state_key):
+    def url_and_display_name(usage_key):
         """
-        For a given module_state_key, return the problem's url and display_name.
+        For a given usage_key, return the problem's url and display_name.
         Handle modulestore access and caching. This method ignores permissions.
-        May throw an ItemNotFoundError if there is no content that corresponds
-        to this module_state_key.
+
+        Raises:
+            InvalidKeyError: if the usage_key does not parse
+            ItemNotFoundError: if there is no content that corresponds
+                to this usage_key.
         """
         problem_store = modulestore()
-        if module_state_key not in state_keys_to_problem_info:
-            problems = problem_store.get_items(module_state_key, course_id=course_id, depth=1)
-            if not problems:
-                # Likely means that the problem was deleted from the course
-                # after the student had answered. We log this suspicion where
-                # this exception is caught.
-                raise ItemNotFoundError(
-                    "Answer Distribution: Module {} not found for course {}"
-                    .format(module_state_key, course_id)
-                )
-            problem = problems[0]
+        if usage_key not in state_keys_to_problem_info:
+            problem = problem_store.get_item(usage_key)
             problem_info = (problem.url_name, problem.display_name_with_default)
-            state_keys_to_problem_info[module_state_key] = problem_info
+            state_keys_to_problem_info[usage_key] = problem_info
 
-        return state_keys_to_problem_info[module_state_key]
+        return state_keys_to_problem_info[usage_key]
 
     # Iterate through all problems submitted for this course in no particular
     # order, and build up our answer_counts dict that we will eventually return
     answer_counts = defaultdict(lambda: defaultdict(int))
-    for module in StudentModule.all_submitted_problems_read_only(course_id):
+    for module in StudentModule.all_submitted_problems_read_only(course_key):
         try:
             state_dict = json.loads(module.state) if module.state else {}
             raw_answers = state_dict.get("student_answers", {})
         except ValueError:
             log.error(
                 "Answer Distribution: Could not parse module state for " +
-                "StudentModule id={}, course={}".format(module.id, course_id)
+                "StudentModule id={}, course={}".format(module.id, course_key)
             )
             continue
 
-        # Each problem part has an ID that is derived from the
-        # module.module_state_key (with some suffix appended)
-        for problem_part_id, raw_answer in raw_answers.items():
-            # Convert whatever raw answers we have (numbers, unicode, None, etc.)
-            # to be unicode values. Note that if we get a string, it's always
-            # unicode and not str -- state comes from the json decoder, and that
-            # always returns unicode for strings.
-            answer = unicode(raw_answer)
+        try:
+            url, display_name = url_and_display_name(module.module_id.map_into_course(course_key))
+            # Each problem part has an ID that is derived from the
+            # module.module_state_key (with some suffix appended)
+            for problem_part_id, raw_answer in raw_answers.items():
+                # Convert whatever raw answers we have (numbers, unicode, None, etc.)
+                # to be unicode values. Note that if we get a string, it's always
+                # unicode and not str -- state comes from the json decoder, and that
+                # always returns unicode for strings.
+                answer = unicode(raw_answer)
+                answer_counts[(url, display_name, problem_part_id)][answer] += 1
 
-            try:
-                url, display_name = url_and_display_name(module.module_state_key)
-            except ItemNotFoundError:
-                msg = "Answer Distribution: Item {} referenced in StudentModule {} " + \
-                      "for user {} in course {} not found; " + \
-                      "This can happen if a student answered a question that " + \
-                      "was later deleted from the course. This answer will be " + \
-                      "omitted from the answer distribution CSV."
-                log.warning(
-                    msg.format(module.module_state_key, module.id, module.student_id, course_id)
-                )
-                continue
-
-            answer_counts[(url, display_name, problem_part_id)][answer] += 1
+        except (ItemNotFoundError, InvalidKeyError):
+            msg = "Answer Distribution: Item {} referenced in StudentModule {} " + \
+                  "for user {} in course {} not found; " + \
+                  "This can happen if a student answered a question that " + \
+                  "was later deleted from the course. This answer will be " + \
+                  "omitted from the answer distribution CSV."
+            log.warning(
+                msg.format(module.module_state_key, module.id, module.student_id, course_key)
+            )
+            continue
 
     return answer_counts
 
@@ -183,7 +177,9 @@ def _grade(student, request, course, keep_raw_scores):
     # Dict of item_ids -> (earned, possible) point tuples. This *only* grabs
     # scores that were registered with the submissions API, which for the moment
     # means only openassessment (edx-ora2)
-    submissions_scores = sub_api.get_scores(course.id, anonymous_id_for_user(student, course.id))
+    submissions_scores = sub_api.get_scores(
+        course.id.to_deprecated_string(), anonymous_id_for_user(student, course.id)
+    )
 
     totaled_scores = {}
     # This next complicated loop is just to collect the totaled_scores, which is
@@ -206,7 +202,7 @@ def _grade(student, request, course, keep_raw_scores):
             # API. If scores exist, we have to calculate grades for this section.
             if not should_grade_section:
                 should_grade_section = any(
-                    descriptor.location.url() in submissions_scores
+                    descriptor.location.to_deprecated_string() in submissions_scores
                     for descriptor in section['xmoduledescriptors']
                 )
 
@@ -214,7 +210,7 @@ def _grade(student, request, course, keep_raw_scores):
                 with manual_transaction():
                     should_grade_section = StudentModule.objects.filter(
                         student=student,
-                        module_state_key__in=[
+                        module_id__in=[
                             descriptor.location for descriptor in section['xmoduledescriptors']
                         ]
                     ).exists()
@@ -350,7 +346,7 @@ def _progress_summary(student, request, course):
             # This student must not have access to the course.
             return None
 
-    submissions_scores = sub_api.get_scores(course.id, anonymous_id_for_user(student, course.id))
+    submissions_scores = sub_api.get_scores(course.id.to_deprecated_string(), anonymous_id_for_user(student, course.id))
 
     chapters = []
     # Don't include chapters that aren't displayable (e.g. due to error)
@@ -427,7 +423,7 @@ def get_score(course_id, user, problem_descriptor, module_creator, scores_cache=
     if not user.is_authenticated():
         return (None, None)
 
-    location_url = problem_descriptor.location.url()
+    location_url = problem_descriptor.location.to_deprecated_string()
     if location_url in scores_cache:
         return scores_cache[location_url]
 
@@ -451,7 +447,7 @@ def get_score(course_id, user, problem_descriptor, module_creator, scores_cache=
         student_module = StudentModule.objects.get(
             student=user,
             course_id=course_id,
-            module_state_key=problem_descriptor.location
+            module_id=problem_descriptor.location
         )
     except StudentModule.DoesNotExist:
         student_module = None

--- a/lms/djangoapps/courseware/management/commands/clean_xml.py
+++ b/lms/djangoapps/courseware/management/commands/clean_xml.py
@@ -73,7 +73,7 @@ def import_with_checks(course_dir, verbose=True):
         return (False, None)
 
     course = courses[0]
-    errors = modulestore.get_item_errors(course.location)
+    errors = modulestore.get_course_errors(course.id)
     if len(errors) != 0:
         all_ok = False
         print '\n'

--- a/lms/djangoapps/courseware/management/commands/dump_course_ids.py
+++ b/lms/djangoapps/courseware/management/commands/dump_course_ids.py
@@ -24,18 +24,12 @@ class Command(BaseCommand):
     )
 
     def handle(self, *args, **options):
-        results = []
-
         try:
             name = options['modulestore']
             store = modulestore(name)
         except KeyError:
             raise CommandError("Unknown modulestore {}".format(name))
 
-        for course in store.get_courses():
-            course_id = course.location.course_id
-            results.append(course_id)
-
-        output = '\n'.join(results) + '\n'
+        output = u'\n'.join(course.id.to_deprecated_string() for course in store.get_courses()) + '\n'
 
         return output.encode('utf-8')

--- a/lms/djangoapps/courseware/management/commands/dump_course_structure.py
+++ b/lms/djangoapps/courseware/management/commands/dump_course_structure.py
@@ -25,6 +25,8 @@ from django.core.management.base import BaseCommand, CommandError
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.inheritance import own_metadata, compute_inherited_metadata
 from xblock.fields import Scope
+from opaque_keys import InvalidKeyError
+from xmodule.modulestore.locations import SlashSeparatedCourseKey
 
 FILTER_LIST = ['xml_attributes', 'checklists']
 INHERITED_FILTER_LIST = ['children', 'xml_attributes', 'checklists']
@@ -66,7 +68,11 @@ class Command(BaseCommand):
 
         # Get the course data
 
-        course_id = args[0]
+        try:
+            course_id = SlashSeparatedCourseKey.from_deprecated_string(args[0])
+        except InvalidKeyError:
+            raise CommandError("Invalid course_id")
+
         course = store.get_course(course_id)
         if course is None:
             raise CommandError("Invalid course_id")
@@ -90,12 +96,12 @@ def dump_module(module, destination=None, inherited=False, defaults=False):
 
     destination = destination if destination else {}
 
-    items = own_metadata(module).iteritems()
-    filtered_metadata = {k: v for k, v in items if k not in FILTER_LIST}
+    items = own_metadata(module)
+    filtered_metadata = {k: v for k, v in items.iteritems() if k not in FILTER_LIST}
 
-    destination[module.location.url()] = {
+    destination[module.location.to_deprecated_string()] = {
         'category': module.location.category,
-        'children': [str(child) for child in getattr(module, 'children', [])],
+        'children': [child.to_deprecated_string() for child in getattr(module, 'children', [])],
         'metadata': filtered_metadata,
     }
 
@@ -116,7 +122,7 @@ def dump_module(module, destination=None, inherited=False, defaults=False):
                 return field.values != field.default
 
         inherited_metadata = {field.name: field.read_json(module) for field in module.fields.values() if is_inherited(field)}
-        destination[module.location.url()]['inherited_metadata'] = inherited_metadata
+        destination[module.location.to_deprecated_string()]['inherited_metadata'] = inherited_metadata
 
     for child in module.get_children():
         dump_module(child, destination, inherited, defaults)

--- a/lms/djangoapps/courseware/management/commands/metadata_to_json.py
+++ b/lms/djangoapps/courseware/management/commands/metadata_to_json.py
@@ -38,7 +38,7 @@ def import_course(course_dir, verbose=True):
         return None
 
     course = courses[0]
-    errors = modulestore.get_item_errors(course.location)
+    errors = modulestore.get_course_errors(course.id)
     if len(errors) != 0:
         sys.stderr.write('ERRORs during import: {0}\n'.format('\n'.join(map(str_of_err, errors))))
 

--- a/lms/djangoapps/courseware/models.py
+++ b/lms/djangoapps/courseware/models.py
@@ -18,6 +18,8 @@ from django.db import models
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
+from xmodule_django.models import CourseKeyField, LocationKeyField
+
 
 class StudentModule(models.Model):
     """
@@ -38,12 +40,31 @@ class StudentModule(models.Model):
     # but for abtests and the like, this can be set to a shared value
     # for many instances of the module.
     # Filename for homeworks, etc.
-    module_state_key = models.CharField(max_length=255, db_index=True, db_column='module_id')
+    module_id = LocationKeyField(max_length=255, db_index=True, db_column='module_id')
     student = models.ForeignKey(User, db_index=True)
-    course_id = models.CharField(max_length=255, db_index=True)
+    # TODO: This is a lie; course_id now represents something more like a course_key.  We may
+    # or may not want to change references to this to something like course_key or course_key_field in
+    # this file.  (Certain changes would require a DB migration which is probably not what we want.)
+    # Someone should look at this and reevaluate before the final merge into master.
+    course_id = CourseKeyField(max_length=255, db_index=True)
+
+    @property
+    def module_state_key(self):
+        """
+        Returns a Location based on module_id and course_id
+        """
+        return self.course_id.make_usage_key(self.module_id.category, self.module_id.name)
+
+    @module_state_key.setter
+    def module_state_key(self, usage_key):
+        """
+        Set the module_id and course_id from the passed UsageKey
+        """
+        self.course_id = usage_key.course_key
+        self.module_id = usage_key
 
     class Meta:
-        unique_together = (('student', 'module_state_key', 'course_id'),)
+        unique_together = (('student', 'module_id', 'course_id'),)
 
     ## Internal state of the object
     state = models.TextField(null=True, blank=True)
@@ -110,7 +131,7 @@ class StudentModuleHistory(models.Model):
     max_grade = models.FloatField(null=True, blank=True)
 
     @receiver(post_save, sender=StudentModule)
-    def save_history(sender, instance, **kwargs):
+    def save_history(sender, instance, **kwargs):  # pylint: disable=no-self-argument
         if instance.module_type in StudentModuleHistory.HISTORY_SAVING_TYPES:
             history_entry = StudentModuleHistory(student_module=instance,
                                                  version=None,
@@ -133,7 +154,7 @@ class XModuleUserStateSummaryField(models.Model):
     field_name = models.CharField(max_length=64, db_index=True)
 
     # The definition id for the module
-    usage_id = models.CharField(max_length=255, db_index=True)
+    usage_id = LocationKeyField(max_length=255, db_index=True)
 
     # The value of the field. Defaults to None dumped as json
     value = models.TextField(default='null')
@@ -221,7 +242,7 @@ class OfflineComputedGrade(models.Model):
     Table of grades computed offline for a given user and course.
     """
     user = models.ForeignKey(User, db_index=True)
-    course_id = models.CharField(max_length=255, db_index=True)
+    course_id = CourseKeyField(max_length=255, db_index=True)
 
     created = models.DateTimeField(auto_now_add=True, null=True, db_index=True)
     updated = models.DateTimeField(auto_now=True, db_index=True)
@@ -244,10 +265,10 @@ class OfflineComputedGradeLog(models.Model):
         ordering = ["-created"]
         get_latest_by = "created"
 
-    course_id = models.CharField(max_length=255, db_index=True)
+    course_id = CourseKeyField(max_length=255, db_index=True)
     created = models.DateTimeField(auto_now_add=True, null=True, db_index=True)
     seconds = models.IntegerField(default=0)  	# seconds elapsed for computation
     nstudents = models.IntegerField(default=0)
 
     def __unicode__(self):
-        return "[OCGLog] %s: %s" % (self.course_id, self.created)
+        return "[OCGLog] %s: %s" % (self.course_id.to_deprecated_string(), self.created)  # pylint: disable=no-member

--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -7,6 +7,7 @@ import static_replace
 from functools import partial
 from requests.auth import HTTPBasicAuth
 from dogapi import dog_stats_api
+from opaque_keys import InvalidKeyError
 
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -21,7 +22,7 @@ from courseware.access import has_access, get_user_role
 from courseware.masquerade import setup_masquerade
 from courseware.model_data import FieldDataCache, DjangoKeyValueStore
 from lms.lib.xblock.field_data import LmsFieldData
-from lms.lib.xblock.runtime import LmsModuleSystem, unquote_slashes
+from lms.lib.xblock.runtime import LmsModuleSystem, unquote_slashes, quote_slashes
 from edxmako.shortcuts import render_to_string
 from eventtracking import tracker
 from psychometrics.psychoanalyze import make_psychometrics_data_update_handler
@@ -33,7 +34,7 @@ from xblock.exceptions import NoSuchHandlerError
 from xblock.django.request import django_to_webob_request, webob_to_django_response
 from xmodule.error_module import ErrorDescriptor, NonStaffErrorDescriptor
 from xmodule.exceptions import NotFoundError, ProcessingError
-from xmodule.modulestore import Location
+from xmodule.modulestore.locations import SlashSeparatedCourseKey
 from xmodule.modulestore.django import modulestore, ModuleI18nService
 from xmodule.modulestore.exceptions import ItemNotFoundError
 from xmodule.util.duedate import get_extended_due_date
@@ -49,15 +50,19 @@ log = logging.getLogger(__name__)
 
 
 if settings.XQUEUE_INTERFACE.get('basic_auth') is not None:
-    requests_auth = HTTPBasicAuth(*settings.XQUEUE_INTERFACE['basic_auth'])
+    REQUESTS_AUTH = HTTPBasicAuth(*settings.XQUEUE_INTERFACE['basic_auth'])
 else:
-    requests_auth = None
+    REQUESTS_AUTH = None
 
-xqueue_interface = XQueueInterface(
+XQUEUE_INTERFACE = XQueueInterface(
     settings.XQUEUE_INTERFACE['url'],
     settings.XQUEUE_INTERFACE['django_auth'],
-    requests_auth,
+    REQUESTS_AUTH,
 )
+
+# TODO basically all instances of course_id in this file *should* be changed to course_key, but
+# there's a couple tricky ones I'm too afraid to change before we merge the jellyfish branches.
+# This should be fixed after the jellyfish merge, before merge into master.
 
 
 def make_track_function(request):
@@ -127,7 +132,7 @@ def toc_for_course(user, request, course, active_chapter, active_section, field_
     return chapters
 
 
-def get_module(user, request, location, field_data_cache, course_id,
+def get_module(user, request, usage_key, field_data_cache,
                position=None, not_found_ok=False, wrap_xmodule_display=True,
                grade_bucket_type=None, depth=0,
                static_asset_path=''):
@@ -157,9 +162,8 @@ def get_module(user, request, location, field_data_cache, course_id,
     if possible.  If not possible, return None.
     """
     try:
-        location = Location(location)
-        descriptor = modulestore().get_instance(course_id, location, depth=depth)
-        return get_module_for_descriptor(user, request, descriptor, field_data_cache, course_id,
+        descriptor = modulestore().get_item(usage_key, depth=depth)
+        return get_module_for_descriptor(user, request, descriptor, field_data_cache, usage_key.course_key,
                                          position=position,
                                          wrap_xmodule_display=wrap_xmodule_display,
                                          grade_bucket_type=grade_bucket_type,
@@ -198,7 +202,7 @@ def get_module_for_descriptor(user, request, descriptor, field_data_cache, cours
     See get_module() docstring for further details.
     """
     # allow course staff to masquerade as student
-    if has_access(user, descriptor, 'staff', course_id):
+    if has_access(user, 'staff', descriptor, course_id):
         setup_masquerade(request, True)
 
     track_function = make_track_function(request)
@@ -223,7 +227,7 @@ def get_module_for_descriptor_internal(user, descriptor, field_data_cache, cours
     # Do not check access when it's a noauth request.
     if getattr(user, 'known', True):
         # Short circuit--if the user shouldn't have access, bail without doing any work
-        if not has_access(user, descriptor, 'load', course_id):
+        if not has_access(user, 'load', descriptor, course_id):
             return None
 
     student_data = KvsFieldData(DjangoKeyValueStore(field_data_cache))
@@ -234,9 +238,9 @@ def get_module_for_descriptor_internal(user, descriptor, field_data_cache, cours
         relative_xqueue_callback_url = reverse(
             'xqueue_callback',
             kwargs=dict(
-                course_id=course_id,
+                course_id=course_id.to_deprecated_string(),
                 userid=str(user.id),
-                mod_id=descriptor.location.url(),
+                mod_id=descriptor.location.to_deprecated_string(),
                 dispatch=dispatch
             ),
         )
@@ -248,7 +252,7 @@ def get_module_for_descriptor_internal(user, descriptor, field_data_cache, cours
     xqueue_default_queuename = descriptor.location.org + '-' + descriptor.location.course
 
     xqueue = {
-        'interface': xqueue_interface,
+        'interface': XQUEUE_INTERFACE,
         'construct_callback': make_xqueue_callback,
         'default_queuename': xqueue_default_queuename.replace(' ', '_'),
         'waittime': settings.XQUEUE_WAITTIME_BETWEEN_REQUESTS
@@ -312,12 +316,10 @@ def get_module_for_descriptor_internal(user, descriptor, field_data_cache, cours
 
         # Bin score into range and increment stats
         score_bucket = get_score_bucket(student_module.grade, student_module.max_grade)
-        course_id_dict = Location.parse_course_id(course_id)
 
         tags = [
-            u"org:{org}".format(**course_id_dict),
-            u"course:{course}".format(**course_id_dict),
-            u"run:{name}".format(**course_id_dict),
+            u"org:{}".format(course_id.org),
+            u"course:{}".format(course_id),
             u"score_bucket:{0}".format(score_bucket)
         ]
 
@@ -340,7 +342,11 @@ def get_module_for_descriptor_internal(user, descriptor, field_data_cache, cours
     # Wrap the output display in a single div to allow for the XModule
     # javascript to be bound correctly
     if wrap_xmodule_display is True:
-        block_wrappers.append(partial(wrap_xblock, 'LmsRuntime', extra_data={'course-id': course_id}))
+        block_wrappers.append(partial(
+            wrap_xblock, 'LmsRuntime',
+            extra_data={'course-id': course_id.to_deprecated_string()},
+            usage_id_serializer=lambda usage_id: quote_slashes(usage_id.to_deprecated_string())
+        ))
 
     # TODO (cpennington): When modules are shared between courses, the static
     # prefix is going to have to be specific to the module, not the directory
@@ -366,11 +372,11 @@ def get_module_for_descriptor_internal(user, descriptor, field_data_cache, cours
     block_wrappers.append(partial(
         replace_jump_to_id_urls,
         course_id,
-        reverse('jump_to_id', kwargs={'course_id': course_id, 'module_id': ''}),
+        reverse('jump_to_id', kwargs={'course_id': course_id.to_deprecated_string(), 'module_id': ''}),
     ))
 
     if settings.FEATURES.get('DISPLAY_DEBUG_INFO_TO_STAFF'):
-        if has_access(user, descriptor, 'staff', course_id):
+        if has_access(user, 'staff', descriptor, course_id):
             block_wrappers.append(partial(add_staff_markup, user))
 
     # These modules store data using the anonymous_student_id as a key.
@@ -385,7 +391,7 @@ def get_module_for_descriptor_internal(user, descriptor, field_data_cache, cours
     if is_pure_xblock or is_lti_module:
         anonymous_student_id = anonymous_id_for_user(user, course_id)
     else:
-        anonymous_student_id = anonymous_id_for_user(user, '')
+        anonymous_student_id = anonymous_id_for_user(user, None)
 
     system = LmsModuleSystem(
         track_function=track_function,
@@ -409,12 +415,12 @@ def get_module_for_descriptor_internal(user, descriptor, field_data_cache, cours
         ),
         replace_course_urls=partial(
             static_replace.replace_course_urls,
-            course_id=course_id
+            course_key=course_id
         ),
         replace_jump_to_id_urls=partial(
             static_replace.replace_jump_to_id_urls,
             course_id=course_id,
-            jump_to_id_base_url=reverse('jump_to_id', kwargs={'course_id': course_id, 'module_id': ''})
+            jump_to_id_base_url=reverse('jump_to_id', kwargs={'course_id': course_id.to_deprecated_string(), 'module_id': ''})
         ),
         node_path=settings.NODE_PATH,
         publish=publish,
@@ -440,13 +446,13 @@ def get_module_for_descriptor_internal(user, descriptor, field_data_cache, cours
     if settings.FEATURES.get('ENABLE_PSYCHOMETRICS'):
         system.set(
             'psychometrics_handler',  # set callback for updating PsychometricsData
-            make_psychometrics_data_update_handler(course_id, user, descriptor.location.url())
+            make_psychometrics_data_update_handler(course_id, user, descriptor.location.to_deprecated_string())
         )
 
-    system.set(u'user_is_staff', has_access(user, descriptor.location, u'staff', course_id))
+    system.set(u'user_is_staff', has_access(user, u'staff', descriptor.location, course_id))
 
     # make an ErrorDescriptor -- assuming that the descriptor's system is ok
-    if has_access(user, descriptor.location, 'staff', course_id):
+    if has_access(user, u'staff', descriptor.location, course_id):
         system.error_descriptor_class = ErrorDescriptor
     else:
         system.error_descriptor_class = NonStaffErrorDescriptor
@@ -460,15 +466,17 @@ def find_target_student_module(request, user_id, course_id, mod_id):
     """
     Retrieve target StudentModule
     """
+    course_id = SlashSeparatedCourseKey.from_deprecated_string(course_id)
+    usage_key = course_id.make_usage_key_from_deprecated_string(mod_id)
     user = User.objects.get(id=user_id)
     field_data_cache = FieldDataCache.cache_for_descriptor_descendents(
         course_id,
         user,
-        modulestore().get_instance(course_id, mod_id),
+        modulestore().get_item(usage_key),
         depth=0,
         select_for_update=True
     )
-    instance = get_module(user, request, mod_id, field_data_cache, course_id, grade_bucket_type='xqueue')
+    instance = get_module(user, request, usage_key, field_data_cache, grade_bucket_type='xqueue')
     if instance is None:
         msg = "No module {0} for user {1}--access denied?".format(mod_id, user)
         log.debug(msg)
@@ -566,11 +574,19 @@ def _invoke_xblock_handler(request, course_id, usage_id, handler, suffix, user):
     """
     Invoke an XBlock handler, either authenticated or not.
 
-    """
-    location = unquote_slashes(usage_id)
+    Arguments:
+        request (HttpRequest): the current request
+        course_id (str): A string of the form org/course/run
+        usage_id (str): A string of the form i4x://org/course/category/name@revision
+        handler (str): The name of the handler to invoke
+        suffix (str): The suffix to pass to the handler when invoked
+        user (User): The currently logged in user
 
-    # Check parameters and fail fast if there's a problem
-    if not Location.is_valid(location):
+    """
+    try:
+        course_id = SlashSeparatedCourseKey.from_deprecated_string(course_id)
+        usage_key = course_id.make_usage_key_from_deprecated_string(unquote_slashes(usage_id))
+    except InvalidKeyError:
         raise Http404("Invalid location")
 
     # Check submitted files
@@ -580,12 +596,12 @@ def _invoke_xblock_handler(request, course_id, usage_id, handler, suffix, user):
         return HttpResponse(json.dumps({'success': error_msg}))
 
     try:
-        descriptor = modulestore().get_instance(course_id, location)
+        descriptor = modulestore().get_item(usage_key)
     except ItemNotFoundError:
         log.warn(
-            "Invalid location for course id {course_id}: {location}".format(
-                course_id=course_id,
-                location=location
+            "Invalid location for course id {course_id}: {usage_key}".format(
+                course_id=usage_key.course_key,
+                usage_key=usage_key
             )
         )
         raise Http404
@@ -602,11 +618,11 @@ def _invoke_xblock_handler(request, course_id, usage_id, handler, suffix, user):
         user,
         descriptor
     )
-    instance = get_module(user, request, location, field_data_cache, course_id, grade_bucket_type='ajax')
+    instance = get_module(user, request, usage_key, field_data_cache, grade_bucket_type='ajax')
     if instance is None:
         # Either permissions just changed, or someone is trying to be clever
         # and load something they shouldn't have access to.
-        log.debug("No module %s for user %s -- access denied?", location, user)
+        log.debug("No module %s for user %s -- access denied?", usage_key, user)
         raise Http404
 
     req = django_to_webob_request(request)

--- a/lms/djangoapps/courseware/tests/__init__.py
+++ b/lms/djangoapps/courseware/tests/__init__.py
@@ -94,7 +94,7 @@ class BaseTestXmodule(ModuleStoreTestCase):
         #self.item_module = self.item_descriptor.xmodule_runtime.xmodule_instance
         #self.item_module is None at this time
 
-        self.item_url = Location(self.item_descriptor.location).url()
+        self.item_url = self.item_descriptor.location.to_deprecated_string()
 
     def setup_course(self):
         self.course = CourseFactory.create(data=self.COURSE_DATA)
@@ -139,7 +139,7 @@ class BaseTestXmodule(ModuleStoreTestCase):
         """Return item url with dispatch."""
         return reverse(
             'xblock_handler',
-            args=(self.course.id, quote_slashes(self.item_url), 'xmodule_handler', dispatch)
+            args=(self.course.id.to_deprecated_string(), quote_slashes(self.item_url), 'xmodule_handler', dispatch)
         )
 
 

--- a/lms/djangoapps/courseware/tests/factories.py
+++ b/lms/djangoapps/courseware/tests/factories.py
@@ -6,9 +6,6 @@ from factory.django import DjangoModelFactory
 # Imported to re-export
 # pylint: disable=unused-import
 from student.tests.factories import UserFactory  # Imported to re-export
-from student.tests.factories import GroupFactory  # Imported to re-export
-from student.tests.factories import CourseEnrollmentAllowedFactory  # Imported to re-export
-from student.tests.factories import RegistrationFactory  # Imported to re-export
 # pylint: enable=unused-import
 
 from student.tests.factories import UserProfileFactory as StudentUserProfileFactory
@@ -23,10 +20,11 @@ from student.roles import (
     OrgInstructorRole,
 )
 
-from xmodule.modulestore import Location
+from xmodule.modulestore.locations import SlashSeparatedCourseKey
 
 
-location = partial(Location, 'i4x', 'edX', 'test_course', 'problem')
+course_id = SlashSeparatedCourseKey(u'edX', u'test_course', u'test')
+location = partial(course_id.make_usage_key, u'problem')
 
 
 class UserProfileFactory(StudentUserProfileFactory):
@@ -41,9 +39,10 @@ class InstructorFactory(UserFactory):
     last_name = "Instructor"
 
     @factory.post_generation
+    # TODO Change this from course to course_key at next opportunity
     def course(self, create, extracted, **kwargs):
         if extracted is None:
-            raise ValueError("Must specify a course location for a course instructor user")
+            raise ValueError("Must specify a CourseKey for a course instructor user")
         CourseInstructorRole(extracted).add_users(self)
 
 
@@ -55,9 +54,10 @@ class StaffFactory(UserFactory):
     last_name = "Staff"
 
     @factory.post_generation
+    # TODO Change this from course to course_key at next opportunity
     def course(self, create, extracted, **kwargs):
         if extracted is None:
-            raise ValueError("Must specify a course location for a course staff user")
+            raise ValueError("Must specify a CourseKey for a course staff user")
         CourseStaffRole(extracted).add_users(self)
 
 
@@ -69,9 +69,10 @@ class BetaTesterFactory(UserFactory):
     last_name = "Beta-Tester"
 
     @factory.post_generation
+    # TODO Change this from course to course_key at next opportunity
     def course(self, create, extracted, **kwargs):
         if extracted is None:
-            raise ValueError("Must specify a course location for a beta-tester user")
+            raise ValueError("Must specify a CourseKey for a beta-tester user")
         CourseBetaTesterRole(extracted).add_users(self)
 
 
@@ -83,10 +84,11 @@ class OrgStaffFactory(UserFactory):
     last_name = "Org-Staff"
 
     @factory.post_generation
+    # TODO Change this from course to course_key at next opportunity
     def course(self, create, extracted, **kwargs):
         if extracted is None:
-            raise ValueError("Must specify a course location for an org-staff user")
-        OrgStaffRole(extracted).add_users(self)
+            raise ValueError("Must specify a CourseKey for an org-staff user")
+        OrgStaffRole(extracted.org).add_users(self)
 
 
 class OrgInstructorFactory(UserFactory):
@@ -97,10 +99,11 @@ class OrgInstructorFactory(UserFactory):
     last_name = "Org-Instructor"
 
     @factory.post_generation
+    # TODO Change this from course to course_key at next opportunity
     def course(self, create, extracted, **kwargs):
         if extracted is None:
-            raise ValueError("Must specify a course location for an org-instructor user")
-        OrgInstructorRole(extracted).add_users(self)
+            raise ValueError("Must specify a CourseKey for an org-instructor user")
+        OrgInstructorRole(extracted.org).add_users(self)
 
 
 class GlobalStaffFactory(UserFactory):
@@ -119,7 +122,7 @@ class StudentModuleFactory(DjangoModelFactory):
 
     module_type = "problem"
     student = factory.SubFactory(UserFactory)
-    course_id = "MITx/999/Robot_Super_Course"
+    course_id = SlashSeparatedCourseKey("MITx", "999", "Robot_Super_Course")
     state = None
     grade = None
     max_grade = None
@@ -131,7 +134,7 @@ class UserStateSummaryFactory(DjangoModelFactory):
 
     field_name = 'existing_field'
     value = json.dumps('old_value')
-    usage_id = location('usage_id').url()
+    usage_id = location('usage_id')
 
 
 class StudentPrefsFactory(DjangoModelFactory):

--- a/lms/djangoapps/courseware/tests/helpers.py
+++ b/lms/djangoapps/courseware/tests/helpers.py
@@ -130,7 +130,7 @@ class LoginEnrollmentTestCase(TestCase):
         """
         resp = self.client.post(reverse('change_enrollment'), {
             'enrollment_action': 'enroll',
-            'course_id': course.id,
+            'course_id': course.id.to_deprecated_string(),
         })
         result = resp.status_code == 200
         if verify:
@@ -142,5 +142,7 @@ class LoginEnrollmentTestCase(TestCase):
         Unenroll the currently logged-in user, and check that it worked.
         `course` is an instance of CourseDescriptor.
         """
-        check_for_post_code(self, 200, reverse('change_enrollment'), {'enrollment_action': 'unenroll',
-                                                                      'course_id': course.id})
+        check_for_post_code(self, 200, reverse('change_enrollment'), {
+            'enrollment_action': 'unenroll',
+            'course_id': course.id.to_deprecated_string()
+        })

--- a/lms/djangoapps/courseware/tests/test_about.py
+++ b/lms/djangoapps/courseware/tests/test_about.py
@@ -9,6 +9,7 @@ from .helpers import LoginEnrollmentTestCase
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from courseware.tests.modulestore_config import TEST_DATA_MIXED_MODULESTORE
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.locations import SlashSeparatedCourseKey
 
 
 @override_settings(MODULESTORE=TEST_DATA_MIXED_MODULESTORE)
@@ -22,13 +23,13 @@ class AboutTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase):
 
     def test_logged_in(self):
         self.setup_user()
-        url = reverse('about_course', args=[self.course.id])
+        url = reverse('about_course', args=[self.course.id.to_deprecated_string()])
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
         self.assertIn("OOGIE BLOOGIE", resp.content)
 
     def test_anonymous_user(self):
-        url = reverse('about_course', args=[self.course.id])
+        url = reverse('about_course', args=[self.course.id.to_deprecated_string()])
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
         self.assertIn("OOGIE BLOOGIE", resp.content)
@@ -39,7 +40,7 @@ class AboutTestCaseXML(LoginEnrollmentTestCase, ModuleStoreTestCase):
     # The following XML test course (which lives at common/test/data/2014)
     # is closed; we're testing that an about page still appears when
     # the course is already closed
-    xml_course_id = 'edX/detached_pages/2014'
+    xml_course_id = SlashSeparatedCourseKey('edX', 'detached_pages', '2014')
 
     # this text appears in that course's about page
     # common/test/data/2014/about/overview.html
@@ -48,14 +49,14 @@ class AboutTestCaseXML(LoginEnrollmentTestCase, ModuleStoreTestCase):
     @mock.patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
     def test_logged_in_xml(self):
         self.setup_user()
-        url = reverse('about_course', args=[self.xml_course_id])
+        url = reverse('about_course', args=[self.xml_course_id.to_deprecated_string()])
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
         self.assertIn(self.xml_data, resp.content)
 
     @mock.patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
     def test_anonymous_user_xml(self):
-        url = reverse('about_course', args=[self.xml_course_id])
+        url = reverse('about_course', args=[self.xml_course_id.to_deprecated_string()])
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
         self.assertIn(self.xml_data, resp.content)
@@ -82,7 +83,7 @@ class AboutWithCappedEnrollmentsTestCase(LoginEnrollmentTestCase, ModuleStoreTes
         This test will make sure that enrollment caps are enforced
         """
         self.setup_user()
-        url = reverse('about_course', args=[self.course.id])
+        url = reverse('about_course', args=[self.course.id.to_deprecated_string()])
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
         self.assertIn('<a href="#" class="register">', resp.content)

--- a/lms/djangoapps/courseware/tests/test_access.py
+++ b/lms/djangoapps/courseware/tests/test_access.py
@@ -6,11 +6,12 @@ from mock import Mock
 from django.test import TestCase
 from django.test.utils import override_settings
 
-from courseware.tests.factories import UserFactory, CourseEnrollmentAllowedFactory, StaffFactory, InstructorFactory
-from student.tests.factories import AnonymousUserFactory
+from courseware.tests.factories import UserFactory, StaffFactory, InstructorFactory
+from student.tests.factories import AnonymousUserFactory, CourseEnrollmentAllowedFactory
 from xmodule.modulestore import Location
 from courseware.tests.tests import TEST_DATA_MIXED_MODULESTORE
 import pytz
+from xmodule.modulestore.locations import SlashSeparatedCourseKey
 
 
 # pylint: disable=protected-access
@@ -21,129 +22,161 @@ class AccessTestCase(TestCase):
     """
 
     def setUp(self):
-        self.course = Location('i4x://edX/toy/course/2012_Fall')
+        course_key = SlashSeparatedCourseKey('edX', 'toy', '2012_Fall')
+        self.course = course_key.make_usage_key('course', course_key.run)
         self.anonymous_user = AnonymousUserFactory()
         self.student = UserFactory()
         self.global_staff = UserFactory(is_staff=True)
-        self.course_staff = StaffFactory(course=self.course)
-        self.course_instructor = InstructorFactory(course=self.course)
+        # TODO please change the StaffFactory and InstructorFactory parameters ASAP!
+        self.course_staff = StaffFactory(course=self.course.course_key)
+        self.course_instructor = InstructorFactory(course=self.course.course_key)
 
     def test__has_access_to_location(self):
-        self.assertFalse(access._has_access_to_location(None, self.course, 'staff', None))
+        self.assertFalse(access._has_access_to_location(
+            None, 'staff', self.course, self.course.course_key
+        ))
 
-        self.assertFalse(access._has_access_to_location(self.anonymous_user, self.course, 'staff', None))
-        self.assertFalse(access._has_access_to_location(self.anonymous_user, self.course, 'instructor', None))
+        self.assertFalse(access._has_access_to_location(
+            self.anonymous_user, 'staff', self.course, self.course.course_key
+        ))
+        self.assertFalse(access._has_access_to_location(
+            self.anonymous_user, 'instructor', self.course, self.course.course_key
+        ))
 
-        self.assertTrue(access._has_access_to_location(self.global_staff, self.course, 'staff', None))
-        self.assertTrue(access._has_access_to_location(self.global_staff, self.course, 'instructor', None))
+        self.assertTrue(access._has_access_to_location(
+            self.global_staff, 'staff', self.course, self.course.course_key
+        ))
+        self.assertTrue(access._has_access_to_location(
+            self.global_staff, 'instructor', self.course, self.course.course_key
+        ))
 
         # A user has staff access if they are in the staff group
-        self.assertTrue(access._has_access_to_location(self.course_staff, self.course, 'staff', None))
-        self.assertFalse(access._has_access_to_location(self.course_staff, self.course, 'instructor', None))
+        self.assertTrue(access._has_access_to_location(
+            self.course_staff, 'staff', self.course, self.course.course_key
+        ))
+        self.assertFalse(access._has_access_to_location(
+            self.course_staff, 'instructor', self.course, self.course.course_key
+        ))
 
         # A user has staff and instructor access if they are in the instructor group
-        self.assertTrue(access._has_access_to_location(self.course_instructor, self.course, 'staff', None))
-        self.assertTrue(access._has_access_to_location(self.course_instructor, self.course, 'instructor', None))
+        self.assertTrue(access._has_access_to_location(
+            self.course_instructor, 'staff', self.course, self.course.course_key
+        ))
+        self.assertTrue(access._has_access_to_location(
+            self.course_instructor, 'instructor', self.course, self.course.course_key
+        ))
 
         # A user does not have staff or instructor access if they are
         # not in either the staff or the the instructor group
-        self.assertFalse(access._has_access_to_location(self.student, self.course, 'staff', None))
-        self.assertFalse(access._has_access_to_location(self.student, self.course, 'instructor', None))
+        self.assertFalse(access._has_access_to_location(
+            self.student, 'staff', self.course, self.course.course_key
+        ))
+        self.assertFalse(access._has_access_to_location(
+            self.student, 'instructor', self.course, self.course.course_key
+        ))
 
     def test__has_access_string(self):
-        u = Mock(is_staff=True)
-        self.assertFalse(access._has_access_string(u, 'not_global', 'staff', None))
+        user = Mock(is_staff=True)
+        self.assertFalse(access._has_access_string(user, 'staff', 'not_global', self.course.course_key))
 
-        u._has_global_staff_access.return_value = True
-        self.assertTrue(access._has_access_string(u, 'global', 'staff', None))
+        user._has_global_staff_access.return_value = True
+        self.assertTrue(access._has_access_string(user, 'staff', 'global', self.course.course_key))
 
-        self.assertRaises(ValueError, access._has_access_string, u, 'global', 'not_staff', None)
+        self.assertRaises(ValueError, access._has_access_string, user, 'not_staff', 'global', self.course.course_key)
 
     def test__has_access_descriptor(self):
         # TODO: override DISABLE_START_DATES and test the start date branch of the method
-        u = Mock()
-        d = Mock()
-        d.start = datetime.datetime.now(pytz.utc) - datetime.timedelta(days=1)  # make sure the start time is in the past
+        user = Mock()
+        date = Mock()
+        date.start = datetime.datetime.now(pytz.utc) - datetime.timedelta(days=1)  # make sure the start time is in the past
 
         # Always returns true because DISABLE_START_DATES is set in test.py
-        self.assertTrue(access._has_access_descriptor(u, d, 'load'))
-        self.assertRaises(ValueError, access._has_access_descriptor, u, d, 'not_load_or_staff')
+        self.assertTrue(access._has_access_descriptor(user, 'load', date))
+        with self.assertRaises(ValueError):
+            access._has_access_descriptor(user, 'not_load_or_staff', date)
 
     def test__has_access_course_desc_can_enroll(self):
-        u = Mock()
+        user = Mock()
         yesterday = datetime.datetime.now(pytz.utc) - datetime.timedelta(days=1)
         tomorrow = datetime.datetime.now(pytz.utc) + datetime.timedelta(days=1)
-        c = Mock(enrollment_start=yesterday, enrollment_end=tomorrow, enrollment_domain='')
+        course = Mock(enrollment_start=yesterday, enrollment_end=tomorrow, enrollment_domain='')
 
         # User can enroll if it is between the start and end dates
-        self.assertTrue(access._has_access_course_desc(u, c, 'enroll'))
+        self.assertTrue(access._has_access_course_desc(user, 'enroll', course))
 
         # User can enroll if authenticated and specifically allowed for that course
         # even outside the open enrollment period
-        u = Mock(email='test@edx.org', is_staff=False)
-        u.is_authenticated.return_value = True
+        user = Mock(email='test@edx.org', is_staff=False)
+        user.is_authenticated.return_value = True
 
-        c = Mock(enrollment_start=tomorrow, enrollment_end=tomorrow, id='edX/test/2012_Fall', enrollment_domain='')
+        course = Mock(
+            enrollment_start=tomorrow, enrollment_end=tomorrow,
+            id=SlashSeparatedCourseKey('edX', 'test', '2012_Fall'), enrollment_domain=''
+        )
 
-        allowed = CourseEnrollmentAllowedFactory(email=u.email, course_id=c.id)
+        CourseEnrollmentAllowedFactory(email=user.email, course_id=course.id)
 
-        self.assertTrue(access._has_access_course_desc(u, c, 'enroll'))
+        self.assertTrue(access._has_access_course_desc(user, 'enroll', course))
 
         # Staff can always enroll even outside the open enrollment period
-        u = Mock(email='test@edx.org', is_staff=True)
-        u.is_authenticated.return_value = True
+        user = Mock(email='test@edx.org', is_staff=True)
+        user.is_authenticated.return_value = True
 
-        c = Mock(enrollment_start=tomorrow, enrollment_end=tomorrow, id='edX/test/Whenever', enrollment_domain='')
-        self.assertTrue(access._has_access_course_desc(u, c, 'enroll'))
+        course = Mock(
+            enrollment_start=tomorrow, enrollment_end=tomorrow,
+            id=SlashSeparatedCourseKey('edX', 'test', 'Whenever'), enrollment_domain='',
+        )
+        self.assertTrue(access._has_access_course_desc(user, 'enroll', course))
 
         # TODO:
         # Non-staff cannot enroll outside the open enrollment period if not specifically allowed
 
     def test__user_passed_as_none(self):
         """Ensure has_access handles a user being passed as null"""
-        access.has_access(None, 'global', 'staff', None)
+        access.has_access(None, 'staff', 'global', None)
+
 
 class UserRoleTestCase(TestCase):
     """
     Tests for user roles.
     """
     def setUp(self):
-        self.course = Location('i4x://edX/toy/course/2012_Fall')
+        self.course_key = SlashSeparatedCourseKey('edX', 'toy', '2012_Fall')
         self.anonymous_user = AnonymousUserFactory()
         self.student = UserFactory()
         self.global_staff = UserFactory(is_staff=True)
-        self.course_staff = StaffFactory(course=self.course)
-        self.course_instructor = InstructorFactory(course=self.course)
+        self.course_staff = StaffFactory(course=self.course_key)
+        self.course_instructor = InstructorFactory(course=self.course_key)
 
     def test_user_role_staff(self):
         """Ensure that user role is student for staff masqueraded as student."""
         self.assertEqual(
             'staff',
-            access.get_user_role(self.course_staff, self.course.course_id)
+            access.get_user_role(self.course_staff, self.course_key)
         )
         # Masquerade staff
         self.course_staff.masquerade_as_student = True
         self.assertEqual(
             'student',
-            access.get_user_role(self.course_staff, self.course.course_id)
+            access.get_user_role(self.course_staff, self.course_key)
         )
 
     def test_user_role_instructor(self):
         """Ensure that user role is student for instructor masqueraded as student."""
         self.assertEqual(
             'instructor',
-            access.get_user_role(self.course_instructor, self.course.course_id)
+            access.get_user_role(self.course_instructor, self.course_key)
         )
         # Masquerade instructor
         self.course_instructor.masquerade_as_student = True
         self.assertEqual(
             'student',
-            access.get_user_role(self.course_instructor, self.course.course_id)
+            access.get_user_role(self.course_instructor, self.course_key)
         )
 
     def test_user_role_anonymous(self):
         """Ensure that user role is student for anonymous user."""
         self.assertEqual(
             'student',
-            access.get_user_role(self.anonymous_user, self.course.course_id)
+            access.get_user_role(self.anonymous_user, self.course_key)
         )

--- a/lms/djangoapps/courseware/tests/test_course_info.py
+++ b/lms/djangoapps/courseware/tests/test_course_info.py
@@ -22,13 +22,13 @@ class CourseInfoTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase):
 
     def test_logged_in(self):
         self.setup_user()
-        url = reverse('info', args=[self.course.id])
+        url = reverse('info', args=[self.course.id.to_deprecated_string()])
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
         self.assertIn("OOGIE BLOOGIE", resp.content)
 
     def test_anonymous_user(self):
-        url = reverse('info', args=[self.course.id])
+        url = reverse('info', args=[self.course.id.to_deprecated_string()])
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
         self.assertNotIn("OOGIE BLOOGIE", resp.content)

--- a/lms/djangoapps/courseware/tests/test_courses.py
+++ b/lms/djangoapps/courseware/tests/test_courses.py
@@ -4,7 +4,6 @@ Tests for course access
 """
 import mock
 
-from django.http import Http404
 from django.test.utils import override_settings
 from student.tests.factories import UserFactory
 from xmodule.modulestore.django import get_default_store_name_for_current_request
@@ -14,16 +13,12 @@ from xmodule.tests.xml import factories as xml
 from xmodule.tests.xml import XModuleXmlImportTest
 
 from courseware.courses import (
-    get_course_by_id,
-    get_course,
-    get_cms_course_link,
-    get_cms_block_link,
-    course_image_url,
-    get_course_info_section,
-    get_course_about_section
+    get_course_by_id, get_cms_course_link, course_image_url,
+    get_course_info_section, get_course_about_section, get_course
 )
 from courseware.tests.helpers import get_request_for_user
 from courseware.tests.tests import TEST_DATA_MONGO_MODULESTORE, TEST_DATA_MIXED_MODULESTORE
+from xmodule.modulestore.locations import SlashSeparatedCourseKey
 
 
 CMS_BASE_TEST = 'testcms'
@@ -34,25 +29,29 @@ class CoursesTest(ModuleStoreTestCase):
 
     def test_get_course_by_id_invalid_chars(self):
         """
-        Test that `get_course_by_id` throws a 404, rather than
-        an exception, when faced with unexpected characters
-        (such as unicode characters, and symbols such as = and ' ')
+        Test that `get_course` throws a 404, rather than an exception,
+        when faced with unexpected characters (such as unicode characters,
+        and symbols such as = and ' ')
         """
         with self.assertRaises(Http404):
-            get_course_by_id('MITx/foobar/statistics=introduction')
-            get_course_by_id('MITx/foobar/business and management')
-            get_course_by_id('MITx/foobar/NiñøJoséMaríáßç')
+            get_course_by_id(SlashSeparatedCourseKey('MITx', 'foobar', 'business and management'))
+        with self.assertRaises(Http404):
+            get_course_by_id(SlashSeparatedCourseKey('MITx', 'foobar' 'statistics=introduction'))
+        with self.assertRaises(Http404):
+            get_course_by_id(SlashSeparatedCourseKey('MITx', 'foobar', 'NiñøJoséMaríáßç'))
 
     def test_get_course_invalid_chars(self):
         """
-        Test that `get_course` throws a ValueError, rather than
-        a 404, when faced with unexpected characters
-        (such as unicode characters, and symbols such as = and ' ')
+        Test that `get_course` throws a ValueError, rather than a 404,
+        when faced with unexpected characters (such as unicode characters,
+        and symbols such as = and ' ')
         """
         with self.assertRaises(ValueError):
-            get_course('MITx/foobar/statistics=introduction')
-            get_course('MITx/foobar/business and management')
-            get_course('MITx/foobar/NiñøJoséMaríáßç')
+            get_course(SlashSeparatedCourseKey('MITx', 'foobar', 'business and management'))
+        with self.assertRaises(ValueError):
+            get_course(SlashSeparatedCourseKey('MITx', 'foobar', 'statistics=introduction'))
+        with self.assertRaises(ValueError):
+            get_course(SlashSeparatedCourseKey('MITx', 'foobar', 'NiñøJoséMaríáßç'))
 
     @override_settings(
         MODULESTORE=TEST_DATA_MONGO_MODULESTORE, CMS_BASE=CMS_BASE_TEST
@@ -67,6 +66,7 @@ class CoursesTest(ModuleStoreTestCase):
             org='org', number='num', display_name='name'
         )
 
+        cms_url = u"//{}/course/slashes:org+num+name".format(CMS_BASE_TEST)
         self.assertEqual(cms_url, get_cms_course_link(self.course))
         self.assertEqual(cms_url, get_cms_block_link(self.course, 'course'))
 
@@ -146,10 +146,11 @@ class XmlCourseImageTestCase(XModuleXmlImportTest):
 
 class CoursesRenderTest(ModuleStoreTestCase):
     """Test methods related to rendering courses content."""
+    toy_course_key = SlashSeparatedCourseKey('edX', 'toy', '2012_Fall')
 
     @override_settings(MODULESTORE=TEST_DATA_MIXED_MODULESTORE)
     def test_get_course_info_section_render(self):
-        course = get_course_by_id('edX/toy/2012_Fall')
+        course = get_course_by_id(self.toy_course_key)
         request = get_request_for_user(UserFactory.create())
 
         # Test render works okay
@@ -167,7 +168,7 @@ class CoursesRenderTest(ModuleStoreTestCase):
     @override_settings(MODULESTORE=TEST_DATA_MIXED_MODULESTORE)
     @mock.patch('courseware.courses.get_request_for_thread')
     def test_get_course_about_section_render(self, mock_get_request):
-        course = get_course_by_id('edX/toy/2012_Fall')
+        course = get_course_by_id(self.toy_course_key)
         request = get_request_for_user(UserFactory.create())
         mock_get_request.return_value = request
 

--- a/lms/djangoapps/courseware/tests/test_draft_modulestore.py
+++ b/lms/djangoapps/courseware/tests/test_draft_modulestore.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 from django.test.utils import override_settings
 
 from xmodule.modulestore.django import modulestore
-from xmodule.modulestore import Location
+from xmodule.modulestore.locations import SlashSeparatedCourseKey
 
 from modulestore_config import TEST_DATA_DRAFT_MONGO_MODULESTORE
 
@@ -13,8 +13,7 @@ class TestDraftModuleStore(TestCase):
         store = modulestore()
 
         # fix was to allow get_items() to take the course_id parameter
-        store.get_items(Location(None, None, 'vertical', None, None),
-                        course_id='abc', depth=0)
+        store.get_items(SlashSeparatedCourseKey('a', 'b', 'c'), category='vertical')
 
         # test success is just getting through the above statement.
         # The bug was that 'course_id' argument was

--- a/lms/djangoapps/courseware/tests/test_grades.py
+++ b/lms/djangoapps/courseware/tests/test_grades.py
@@ -9,6 +9,7 @@ from courseware.tests.modulestore_config import TEST_DATA_MIXED_MODULESTORE
 from student.tests.factories import UserFactory
 from xmodule.modulestore.tests.factories import CourseFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.locations import SlashSeparatedCourseKey
 
 from courseware.grades import grade, iterate_grades_for
 
@@ -62,7 +63,7 @@ class TestGradeIteration(ModuleStoreTestCase):
         should be raised. This is a horrible crossing of abstraction boundaries
         and should be fixed, but for now we're just testing the behavior. :-("""
         with self.assertRaises(Http404):
-            gradeset_results = iterate_grades_for("I/dont/exist", [])
+            gradeset_results = iterate_grades_for(SlashSeparatedCourseKey("I", "dont", "exist"), [])
             gradeset_results.next()
 
     def test_all_empty_grades(self):

--- a/lms/djangoapps/courseware/tests/test_lti_integration.py
+++ b/lms/djangoapps/courseware/tests/test_lti_integration.py
@@ -27,7 +27,8 @@ class TestLTI(BaseTestXmodule):
         mocked_signature_after_sign = u'my_signature%3D'
         mocked_decoded_signature = u'my_signature='
 
-        context_id = self.item_descriptor.course_id
+        # TODO this course_id is actually a course_key; please change this ASAP!
+        context_id = self.item_descriptor.course_id.to_deprecated_string()
         user_id = unicode(self.item_descriptor.xmodule_runtime.anonymous_student_id)
         hostname = self.item_descriptor.xmodule_runtime.hostname
         resource_link_id = unicode(urllib.quote('{}-{}'.format(hostname, self.item_descriptor.location.html_id())))
@@ -38,10 +39,6 @@ class TestLTI(BaseTestXmodule):
             user_id=user_id
         )
 
-        lis_outcome_service_url = 'https://{host}{path}'.format(
-            host=hostname,
-            path=self.item_descriptor.xmodule_runtime.handler_url(self.item_descriptor, 'grade_handler', thirdparty=True).rstrip('/?')
-        )
         self.correct_headers = {
             u'user_id': user_id,
             u'oauth_callback': u'about:blank',

--- a/lms/djangoapps/courseware/tests/test_masquerade.py
+++ b/lms/djangoapps/courseware/tests/test_masquerade.py
@@ -12,14 +12,14 @@ import json
 
 from django.test.utils import override_settings
 from django.core.urlresolvers import reverse
-from django.contrib.auth.models import User
 
+from courseware.tests.factories import StaffFactory
 from courseware.tests.helpers import LoginEnrollmentTestCase
 from courseware.tests.modulestore_config import TEST_DATA_MIXED_MODULESTORE
-from student.roles import CourseStaffRole
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.django import modulestore, clear_existing_modulestores
 from lms.lib.xblock.runtime import quote_slashes
+from xmodule.modulestore.locations import SlashSeparatedCourseKey
 
 
 @override_settings(MODULESTORE=TEST_DATA_MIXED_MODULESTORE)
@@ -33,26 +33,19 @@ class TestStaffMasqueradeAsStudent(ModuleStoreTestCase, LoginEnrollmentTestCase)
         # Clear out the modulestores, causing them to reload
         clear_existing_modulestores()
 
-        self.graded_course = modulestore().get_course("edX/graded/2012_Fall")
+        self.graded_course = modulestore().get_course(SlashSeparatedCourseKey("edX", "graded", "2012_Fall"))
 
         # Create staff account
-        self.instructor = 'view2@test.com'
-        self.password = 'foo'
-        self.create_account('u2', self.instructor, self.password)
-        self.activate_user(self.instructor)
-
-        def make_instructor(course):
-            CourseStaffRole(course.location).add_users(User.objects.get(email=self.instructor))
-
-        make_instructor(self.graded_course)
+        self.staff = StaffFactory(course=self.graded_course.id)
 
         self.logout()
-        self.login(self.instructor, self.password)
+        # self.staff.password is the sha hash but login takes the plain text
+        self.login(self.staff.email, 'test')
         self.enroll(self.graded_course)
 
     def get_cw_section(self):
         url = reverse('courseware_section',
-                      kwargs={'course_id': self.graded_course.id,
+                      kwargs={'course_id': self.graded_course.id.to_deprecated_string(),
                               'chapter': 'GradedChapter',
                               'section': 'Homework1'})
 
@@ -64,7 +57,7 @@ class TestStaffMasqueradeAsStudent(ModuleStoreTestCase, LoginEnrollmentTestCase)
     def test_staff_debug_for_staff(self):
         resp = self.get_cw_section()
         sdebug = 'Staff Debug Info'
-
+        print resp.content
         self.assertTrue(sdebug in resp.content)
 
     def toggle_masquerade(self):
@@ -88,11 +81,11 @@ class TestStaffMasqueradeAsStudent(ModuleStoreTestCase, LoginEnrollmentTestCase)
 
     def get_problem(self):
         pun = 'H1P1'
-        problem_location = "i4x://edX/graded/problem/%s" % pun
+        problem_location = self.graded_course.id.make_usage_key("problem", pun)
 
         modx_url = reverse('xblock_handler',
-                           kwargs={'course_id': self.graded_course.id,
-                                   'usage_id': quote_slashes(problem_location),
+                           kwargs={'course_id': self.graded_course.id.to_deprecated_string(),
+                                   'usage_id': quote_slashes(problem_location.to_deprecated_string()),
                                    'handler': 'xmodule_handler',
                                    'suffix': 'problem_get'})
 

--- a/lms/djangoapps/courseware/tests/test_model_data.py
+++ b/lms/djangoapps/courseware/tests/test_model_data.py
@@ -11,12 +11,11 @@ from courseware.models import StudentModule, XModuleUserStateSummaryField
 from courseware.models import XModuleStudentInfoField, XModuleStudentPrefsField
 
 from student.tests.factories import UserFactory
-from courseware.tests.factories import StudentModuleFactory as cmfStudentModuleFactory
+from courseware.tests.factories import StudentModuleFactory as cmfStudentModuleFactory, location, course_id
 from courseware.tests.factories import UserStateSummaryFactory
 from courseware.tests.factories import StudentPrefsFactory, StudentInfoFactory
 
 from xblock.fields import Scope, BlockScope, ScopeIds
-from xmodule.modulestore import Location
 from django.test import TestCase
 from django.db import DatabaseError
 from xblock.core import KeyValueMultiSaveError
@@ -37,9 +36,6 @@ def mock_descriptor(fields=[]):
     descriptor.module_class.__name__ = 'MockProblemModule'
     return descriptor
 
-location = partial(Location, 'i4x', 'edX', 'test_course', 'problem')
-course_id = 'edX/test_course/test'
-
 # The user ids here are 1 because we make a student in the setUp functions, and
 # they get an id of 1.  There's an assertion in setUp to ensure that assumption
 # is still true.
@@ -51,7 +47,7 @@ user_info_key = partial(DjangoKeyValueStore.Key, Scope.user_info, 1, None)
 
 
 class StudentModuleFactory(cmfStudentModuleFactory):
-    module_state_key = location('usage_id').url()
+    module_state_key = location('usage_id')
     course_id = course_id
 
 
@@ -204,7 +200,7 @@ class TestMissingStudentModule(TestCase):
         student_module = StudentModule.objects.all()[0]
         self.assertEquals({'a_field': 'a_value'}, json.loads(student_module.state))
         self.assertEquals(self.user, student_module.student)
-        self.assertEquals(location('usage_id').url(), student_module.module_state_key)
+        self.assertEquals(location('usage_id'), student_module.module_state_key)
         self.assertEquals(course_id, student_module.course_id)
 
     def test_delete_field_from_missing_student_module(self):
@@ -317,12 +313,12 @@ class StorageTestBase(object):
         self.assertEquals(exception.saved_field_names[0], 'existing_field')
 
 
-class TestContentStorage(StorageTestBase, TestCase):
-    """Tests for ContentStorage"""
+class TestUserStateSummaryStorage(StorageTestBase, TestCase):
+    """Tests for UserStateSummaryStorage"""
     factory = UserStateSummaryFactory
     scope = Scope.user_state_summary
     key_factory = user_state_summary_key
-    storage_class = XModuleUserStateSummaryField
+    storage_class = factory.FACTORY_FOR
 
 
 class TestStudentPrefsStorage(OtherUserFailureTestMixin, StorageTestBase, TestCase):

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -18,11 +18,11 @@ from xblock.field_data import FieldData
 from xblock.runtime import Runtime
 from xblock.fields import ScopeIds
 from xmodule.lti_module import LTIDescriptor
-from xmodule.modulestore import Location
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import ItemFactory, CourseFactory
 from xmodule.x_module import XModuleDescriptor
+from xmodule.modulestore.locations import SlashSeparatedCourseKey
 
 from courseware import module_render as render
 from courseware.courses import get_course_with_access, course_image_url, get_course_info_section
@@ -43,9 +43,9 @@ class ModuleRenderTestCase(ModuleStoreTestCase, LoginEnrollmentTestCase):
     Tests of courseware.module_render
     """
     def setUp(self):
-        self.location = Location('i4x', 'edX', 'toy', 'chapter', 'Overview')
-        self.course_id = 'edX/toy/2012_Fall'
-        self.toy_course = modulestore().get_course(self.course_id)
+        self.course_key = SlashSeparatedCourseKey('edX', 'toy', '2012_Fall')
+        self.location = self.course_key.make_usage_key('chapter', 'Overview')
+        self.toy_course = modulestore().get_course(self.course_key)
         self.mock_user = UserFactory()
         self.mock_user.id = 1
         self.request_factory = RequestFactory()
@@ -56,7 +56,7 @@ class ModuleRenderTestCase(ModuleStoreTestCase, LoginEnrollmentTestCase):
         self.dispatch = 'score_update'
 
         # Construct a 'standard' xqueue_callback url
-        self.callback_url = reverse('xqueue_callback', kwargs=dict(course_id=self.course_id,
+        self.callback_url = reverse('xqueue_callback', kwargs=dict(course_id=self.course_key.to_deprecated_string(),
                                                                    userid=str(self.mock_user.id),
                                                                    mod_id=self.mock_module.id,
                                                                    dispatch=self.dispatch))
@@ -76,17 +76,17 @@ class ModuleRenderTestCase(ModuleStoreTestCase, LoginEnrollmentTestCase):
         mock_request = MagicMock()
         mock_request.user = self.mock_user
 
-        course = get_course_with_access(self.mock_user, self.course_id, 'load')
+        course = get_course_with_access(self.mock_user, 'load', self.course_key)
 
         field_data_cache = FieldDataCache.cache_for_descriptor_descendents(
-            self.course_id, self.mock_user, course, depth=2)
+            self.course_key, self.mock_user, course, depth=2)
 
         module = render.get_module(
             self.mock_user,
             mock_request,
-            Location('i4x', 'edX', 'toy', 'html', 'toyjumpto'),
+            self.course_key.make_usage_key('html', 'toyjumpto'),
             field_data_cache,
-            self.course_id
+            self.course_key
         )
 
         # get the rendered HTML output which should have the rewritten link
@@ -94,7 +94,7 @@ class ModuleRenderTestCase(ModuleStoreTestCase, LoginEnrollmentTestCase):
 
         # See if the url got rewritten to the target link
         # note if the URL mapping changes then this assertion will break
-        self.assertIn('/courses/' + self.course_id + '/jump_to_id/vertical_test', html)
+        self.assertIn('/courses/' + self.course_key.to_deprecated_string() + '/jump_to_id/vertical_test', html)
 
 
     def test_xqueue_callback_success(self):
@@ -113,7 +113,7 @@ class ModuleRenderTestCase(ModuleStoreTestCase, LoginEnrollmentTestCase):
             get_fake_module.return_value = self.mock_module
             # call xqueue_callback with our mocked information
             request = self.request_factory.post(self.callback_url, data)
-            render.xqueue_callback(request, self.course_id, self.mock_user.id, self.mock_module.id, self.dispatch)
+            render.xqueue_callback(request, self.course_key, self.mock_user.id, self.mock_module.id, self.dispatch)
 
         # Verify that handle ajax is called with the correct data
         request.POST['queuekey'] = fake_key
@@ -130,12 +130,12 @@ class ModuleRenderTestCase(ModuleStoreTestCase, LoginEnrollmentTestCase):
             # Test with missing xqueue data
             with self.assertRaises(Http404):
                 request = self.request_factory.post(self.callback_url, {})
-                render.xqueue_callback(request, self.course_id, self.mock_user.id, self.mock_module.id, self.dispatch)
+                render.xqueue_callback(request, self.course_key, self.mock_user.id, self.mock_module.id, self.dispatch)
 
             # Test with missing xqueue_header
             with self.assertRaises(Http404):
                 request = self.request_factory.post(self.callback_url, data)
-                render.xqueue_callback(request, self.course_id, self.mock_user.id, self.mock_module.id, self.dispatch)
+                render.xqueue_callback(request, self.course_key, self.mock_user.id, self.mock_module.id, self.dispatch)
 
     def test_get_score_bucket(self):
         self.assertEquals(render.get_score_bucket(0, 10), 'incorrect')
@@ -149,8 +149,8 @@ class ModuleRenderTestCase(ModuleStoreTestCase, LoginEnrollmentTestCase):
         dispatch_url = reverse(
             'xblock_handler',
             args=[
-                'edX/toy/2012_Fall',
-                quote_slashes('i4x://edX/toy/videosequence/Toy_Videos'),
+                self.course_key.to_deprecated_string(),
+                quote_slashes(self.course_key.make_usage_key('videosequence', 'Toy_Videos').to_deprecated_string()),
                 'xmodule_handler',
                 'goto_position'
             ]
@@ -166,9 +166,9 @@ class TestHandleXBlockCallback(ModuleStoreTestCase, LoginEnrollmentTestCase):
     """
 
     def setUp(self):
-        self.location = Location('i4x', 'edX', 'toy', 'chapter', 'Overview')
-        self.course_id = 'edX/toy/2012_Fall'
-        self.toy_course = modulestore().get_course(self.course_id)
+        self.course_key = SlashSeparatedCourseKey('edX', 'toy', '2012_Fall')
+        self.location = self.course_key.make_usage_key('chapter', 'Overview')
+        self.toy_course = modulestore().get_course(self.course_key)
         self.mock_user = UserFactory()
         self.mock_user.id = 1
         self.request_factory = RequestFactory()
@@ -179,10 +179,14 @@ class TestHandleXBlockCallback(ModuleStoreTestCase, LoginEnrollmentTestCase):
         self.dispatch = 'score_update'
 
         # Construct a 'standard' xqueue_callback url
-        self.callback_url = reverse('xqueue_callback', kwargs=dict(course_id=self.course_id,
-                                                                   userid=str(self.mock_user.id),
-                                                                   mod_id=self.mock_module.id,
-                                                                   dispatch=self.dispatch))
+        self.callback_url = reverse(
+            'xqueue_callback', kwargs={
+                'course_id': self.course_key.to_deprecated_string(),
+                'userid': str(self.mock_user.id),
+                'mod_id': self.mock_module.id,
+                'dispatch': self.dispatch
+            }
+        )
 
     def _mock_file(self, name='file', size=10):
         """Create a mock file object for testing uploads"""
@@ -201,7 +205,7 @@ class TestHandleXBlockCallback(ModuleStoreTestCase, LoginEnrollmentTestCase):
         with self.assertRaises(Http404):
             render.handle_xblock_callback(
                 request,
-                'dummy/course/id',
+                self.course_key.to_deprecated_string(),
                 'invalid Location',
                 'dummy_handler'
                 'dummy_dispatch'
@@ -216,8 +220,8 @@ class TestHandleXBlockCallback(ModuleStoreTestCase, LoginEnrollmentTestCase):
         self.assertEquals(
             render.handle_xblock_callback(
                 request,
-                'dummy/course/id',
-                quote_slashes(str(self.location)),
+                self.course_key.to_deprecated_string(),
+                quote_slashes(self.location.to_deprecated_string()),
                 'dummy_handler'
             ).content,
             json.dumps({
@@ -236,8 +240,8 @@ class TestHandleXBlockCallback(ModuleStoreTestCase, LoginEnrollmentTestCase):
         self.assertEquals(
             render.handle_xblock_callback(
                 request,
-                'dummy/course/id',
-                quote_slashes(str(self.location)),
+                self.course_key.to_deprecated_string(),
+                quote_slashes(self.location.to_deprecated_string()),
                 'dummy_handler'
             ).content,
             json.dumps({
@@ -251,8 +255,8 @@ class TestHandleXBlockCallback(ModuleStoreTestCase, LoginEnrollmentTestCase):
         request.user = self.mock_user
         response = render.handle_xblock_callback(
             request,
-            self.course_id,
-            quote_slashes(str(self.location)),
+            self.course_key.to_deprecated_string(),
+            quote_slashes(self.location.to_deprecated_string()),
             'xmodule_handler',
             'goto_position',
         )
@@ -265,7 +269,7 @@ class TestHandleXBlockCallback(ModuleStoreTestCase, LoginEnrollmentTestCase):
             render.handle_xblock_callback(
                 request,
                 'bad_course_id',
-                quote_slashes(str(self.location)),
+                quote_slashes(self.location.to_deprecated_string()),
                 'xmodule_handler',
                 'goto_position',
             )
@@ -276,8 +280,8 @@ class TestHandleXBlockCallback(ModuleStoreTestCase, LoginEnrollmentTestCase):
         with self.assertRaises(Http404):
             render.handle_xblock_callback(
                 request,
-                self.course_id,
-                quote_slashes(str(Location('i4x', 'edX', 'toy', 'chapter', 'bad_location'))),
+                self.course_key.to_deprecated_string(),
+                quote_slashes(self.course_key.make_usage_key('chapter', 'bad_location').to_deprecated_string()),
                 'xmodule_handler',
                 'goto_position',
             )
@@ -288,8 +292,8 @@ class TestHandleXBlockCallback(ModuleStoreTestCase, LoginEnrollmentTestCase):
         with self.assertRaises(Http404):
             render.handle_xblock_callback(
                 request,
-                self.course_id,
-                quote_slashes(str(self.location)),
+                self.course_key.to_deprecated_string(),
+                quote_slashes(self.location.to_deprecated_string()),
                 'xmodule_handler',
                 'bad_dispatch',
             )
@@ -300,8 +304,8 @@ class TestHandleXBlockCallback(ModuleStoreTestCase, LoginEnrollmentTestCase):
         with self.assertRaises(Http404):
             render.handle_xblock_callback(
                 request,
-                self.course_id,
-                quote_slashes(str(self.location)),
+                self.course_key.to_deprecated_string(),
+                quote_slashes(self.location.to_deprecated_string()),
                 'bad_handler',
                 'bad_dispatch',
             )
@@ -313,13 +317,13 @@ class TestTOC(TestCase):
     def setUp(self):
 
         # Toy courses should be loaded
-        self.course_name = 'edX/toy/2012_Fall'
-        self.toy_course = modulestore().get_course(self.course_name)
+        self.course_key = SlashSeparatedCourseKey('edX', 'toy', '2012_Fall')
+        self.toy_course = modulestore().get_course(self.course_key)
         self.portal_user = UserFactory()
 
     def test_toc_toy_from_chapter(self):
         chapter = 'Overview'
-        chapter_url = '%s/%s/%s' % ('/courses', self.course_name, chapter)
+        chapter_url = '%s/%s/%s' % ('/courses', self.course_key, chapter)
         factory = RequestFactory()
         request = factory.get(chapter_url)
         field_data_cache = FieldDataCache.cache_for_descriptor_descendents(
@@ -346,7 +350,7 @@ class TestTOC(TestCase):
 
     def test_toc_toy_from_section(self):
         chapter = 'Overview'
-        chapter_url = '%s/%s/%s' % ('/courses', self.course_name, chapter)
+        chapter_url = '%s/%s/%s' % ('/courses', self.course_key, chapter)
         section = 'Welcome'
         factory = RequestFactory()
         request = factory.get(chapter_url)
@@ -506,7 +510,7 @@ class TestHtmlModifiers(ModuleStoreTestCase):
 
         self.assertIn(
             '/courses/{course_id}/bar/content'.format(
-                course_id=self.course.id
+                course_id=self.course.id.to_deprecated_string()
             ),
             result_fragment.content
         )
@@ -558,11 +562,11 @@ class ViewInStudioTest(ModuleStoreTestCase):
         Define the XML backed course to use.
         Toy courses are already loaded in XML and mixed modulestores.
         """
-        course_id = 'edX/toy/2012_Fall'
-        location = Location('i4x', 'edX', 'toy', 'chapter', 'Overview')
-        descriptor = modulestore().get_instance(course_id, location)
+        course_key = SlashSeparatedCourseKey('edX', 'toy', '2012_Fall')
+        location = course_key.make_usage_key('chapter', 'Overview')
+        descriptor = modulestore().get_item(location)
 
-        self._get_module(course_id, descriptor, location)
+        self._get_module(course_key, descriptor, location)
 
 
 @override_settings(MODULESTORE=TEST_DATA_MONGO_MODULESTORE)
@@ -722,7 +726,7 @@ class TestStaffDebugInfo(ModuleStoreTestCase):
 
         StudentModuleFactory.create(
             course_id=self.course.id,
-            module_state_key=self.location,
+            module_id=self.location,
             student=UserFactory(),
             grade=1,
             max_grade=1,
@@ -761,7 +765,7 @@ class TestAnonymousStudentId(ModuleStoreTestCase, LoginEnrollmentTestCase):
 
     @patch('courseware.module_render.has_access', Mock(return_value=True))
     def _get_anonymous_id(self, course_id, xblock_class):
-        location = Location('dummy_org', 'dummy_course', 'dummy_category', 'dummy_name')
+        location = course_id.make_usage_key('dummy_category', 'dummy_name')
         descriptor = Mock(
             spec=xblock_class,
             _field_data=Mock(spec=FieldData),
@@ -796,7 +800,7 @@ class TestAnonymousStudentId(ModuleStoreTestCase, LoginEnrollmentTestCase):
                 # This value is set by observation, so that later changes to the student
                 # id computation don't break old data
                 '5afe5d9bb03796557ee2614f5c9611fb',
-                self._get_anonymous_id(course_id, descriptor_class)
+                self._get_anonymous_id(SlashSeparatedCourseKey.from_deprecated_string(course_id), descriptor_class)
             )
 
     @data(*PER_COURSE_ANONYMIZED_DESCRIPTORS)
@@ -805,14 +809,14 @@ class TestAnonymousStudentId(ModuleStoreTestCase, LoginEnrollmentTestCase):
             # This value is set by observation, so that later changes to the student
             # id computation don't break old data
             'e3b0b940318df9c14be59acb08e78af5',
-            self._get_anonymous_id('MITx/6.00x/2012_Fall', descriptor_class)
+            self._get_anonymous_id(SlashSeparatedCourseKey('MITx', '6.00x', '2012_Fall'), descriptor_class)
         )
 
         self.assertEquals(
             # This value is set by observation, so that later changes to the student
             # id computation don't break old data
             'f82b5416c9f54b5ce33989511bb5ef2e',
-            self._get_anonymous_id('MITx/6.00x/2013_Spring', descriptor_class)
+            self._get_anonymous_id(SlashSeparatedCourseKey('MITx', '6.00x', '2013_Spring'), descriptor_class)
         )
 
 
@@ -858,8 +862,8 @@ class TestModuleTrackingContext(ModuleStoreTestCase):
 
         render.handle_xblock_callback(
             self.request,
-            self.course.id,
-            quote_slashes(str(descriptor.location)),
+            self.course.id.to_deprecated_string(),
+            quote_slashes(descriptor.location.to_deprecated_string()),
             'xmodule_handler',
             'problem_check',
         )

--- a/lms/djangoapps/courseware/tests/test_navigation.py
+++ b/lms/djangoapps/courseware/tests/test_navigation.py
@@ -75,10 +75,10 @@ class TestNavigation(ModuleStoreTestCase, LoginEnrollmentTestCase):
         self.enroll(self.test_course, True)
 
         resp = self.client.get(reverse('courseware',
-                               kwargs={'course_id': self.course.id}))
+                               kwargs={'course_id': self.course.id.to_deprecated_string()}))
 
         self.assertRedirects(resp, reverse(
-            'courseware_section', kwargs={'course_id': self.course.id,
+            'courseware_section', kwargs={'course_id': self.course.id.to_deprecated_string(),
                                           'chapter': 'Overview',
                                           'section': 'Welcome'}))
 
@@ -92,16 +92,22 @@ class TestNavigation(ModuleStoreTestCase, LoginEnrollmentTestCase):
         self.enroll(self.course, True)
         self.enroll(self.test_course, True)
 
-        self.client.get(reverse('courseware_section', kwargs={'course_id': self.course.id,
-                                                              'chapter': 'Overview',
-                                                              'section': 'Welcome'}))
+        self.client.get(reverse('courseware_section', kwargs={
+            'course_id': self.course.id.to_deprecated_string(),
+            'chapter': 'Overview',
+            'section': 'Welcome',
+        }))
 
         resp = self.client.get(reverse('courseware',
-                               kwargs={'course_id': self.course.id}))
+                               kwargs={'course_id': self.course.id.to_deprecated_string()}))
 
-        self.assertRedirects(resp, reverse('courseware_chapter',
-                                           kwargs={'course_id': self.course.id,
-                                                   'chapter': 'Overview'}))
+        self.assertRedirects(resp, reverse(
+            'courseware_chapter',
+            kwargs={
+                'course_id': self.course.id.to_deprecated_string(),
+                'chapter': 'Overview'
+            }
+        ))
 
     def test_accordion_state(self):
         """
@@ -113,15 +119,19 @@ class TestNavigation(ModuleStoreTestCase, LoginEnrollmentTestCase):
         self.enroll(self.test_course, True)
 
         # Now we directly navigate to a section in a chapter other than 'Overview'.
-        check_for_get_code(self, 200, reverse('courseware_section',
-                                              kwargs={'course_id': self.course.id,
-                                                      'chapter': 'factory_chapter',
-                                                      'section': 'factory_section'}))
+        check_for_get_code(self, 200, reverse(
+            'courseware_section',
+            kwargs={
+                'course_id': self.course.id.to_deprecated_string(),
+                'chapter': 'factory_chapter',
+                'section': 'factory_section'
+            }
+        ))
 
         # And now hitting the courseware tab should redirect to 'factory_chapter'
         resp = self.client.get(reverse('courseware',
-                               kwargs={'course_id': self.course.id}))
+                               kwargs={'course_id': self.course.id.to_deprecated_string()}))
 
         self.assertRedirects(resp, reverse('courseware_chapter',
-                                           kwargs={'course_id': self.course.id,
+                                           kwargs={'course_id': self.course.id.to_deprecated_string(),
                                                    'chapter': 'factory_chapter'}))

--- a/lms/djangoapps/courseware/tests/test_split_module.py
+++ b/lms/djangoapps/courseware/tests/test_split_module.py
@@ -113,11 +113,10 @@ class SplitTestBase(ModuleStoreTestCase):
 
         resp = self.client.get(reverse(
             'courseware_section',
-            kwargs={'course_id': self.course.id,
+            kwargs={'course_id': self.course.id.to_deprecated_string(),
                     'chapter': self.chapter.url_name,
                     'section': self.sequential.url_name}
         ))
-
         content = resp.content
 
         # Assert we see the proper icon in the top display
@@ -176,15 +175,15 @@ class TestVertSplitTestVert(SplitTestBase):
             display_name="Split test vertical",
         )
         # pylint: disable=protected-access
-        c0_url = self.course.location._replace(category="vertical", name="split_test_cond0")
-        c1_url = self.course.location._replace(category="vertical", name="split_test_cond1")
+        c0_url = self.course.id.make_usage_key("vertical", "split_test_cond0")
+        c1_url = self.course.id.make_usage_key("vertical", "split_test_cond1")
 
         split_test = ItemFactory.create(
             parent_location=vert1.location,
             category="split_test",
             display_name="Split test",
             user_partition_id='0',
-            group_id_to_child={"0": c0_url.url(), "1": c1_url.url()},
+            group_id_to_child={"0": c0_url, "1": c1_url},
         )
 
         cond0vert = ItemFactory.create(
@@ -242,15 +241,15 @@ class TestSplitTestVert(SplitTestBase):
         # split_test cond 0 = vert <- {video, problem}
         # split_test cond 1 = vert <- {video, html}
         # pylint: disable=protected-access
-        c0_url = self.course.location._replace(category="vertical", name="split_test_cond0")
-        c1_url = self.course.location._replace(category="vertical", name="split_test_cond1")
+        c0_url = self.course.id.make_usage_key("vertical", "split_test_cond0")
+        c1_url = self.course.id.make_usage_key("vertical", "split_test_cond1")
 
         split_test = ItemFactory.create(
             parent_location=self.sequential.location,
             category="split_test",
             display_name="Split test",
             user_partition_id='0',
-            group_id_to_child={"0": c0_url.url(), "1": c1_url.url()},
+            group_id_to_child={"0": c0_url, "1": c1_url},
         )
 
         cond0vert = ItemFactory.create(

--- a/lms/djangoapps/courseware/tests/test_tabs.py
+++ b/lms/djangoapps/courseware/tests/test_tabs.py
@@ -15,6 +15,7 @@ from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 from courseware.tests.helpers import get_request_for_user, LoginEnrollmentTestCase
 from courseware.tests.modulestore_config import TEST_DATA_MIXED_MODULESTORE
+from xmodule.modulestore.locations import SlashSeparatedCourseKey
 
 
 @override_settings(MODULESTORE=TEST_DATA_MIXED_MODULESTORE)
@@ -27,29 +28,30 @@ class StaticTabDateTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase):
             category="static_tab", parent_location=self.course.location,
             data="OOGIE BLOOGIE", display_name="new_tab"
         )
+        self.toy_course_key = SlashSeparatedCourseKey('edX', 'toy', '2012_Fall')
 
     def test_logged_in(self):
         self.setup_user()
-        url = reverse('static_tab', args=[self.course.id, 'new_tab'])
+        url = reverse('static_tab', args=[self.course.id.to_deprecated_string(), 'new_tab'])
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
         self.assertIn("OOGIE BLOOGIE", resp.content)
 
     def test_anonymous_user(self):
-        url = reverse('static_tab', args=[self.course.id, 'new_tab'])
+        url = reverse('static_tab', args=[self.course.id.to_deprecated_string(), 'new_tab'])
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
         self.assertIn("OOGIE BLOOGIE", resp.content)
 
     @override_settings(MODULESTORE=TEST_DATA_MIXED_MODULESTORE)
     def test_get_static_tab_contents(self):
-        course = get_course_by_id('edX/toy/2012_Fall')
+        course = get_course_by_id(self.toy_course_key)
         request = get_request_for_user(UserFactory.create())
         tab = CourseTabList.get_tab_by_slug(course.tabs, 'resources')
 
         # Test render works okay
         tab_content = get_static_tab_contents(request, course, tab)
-        self.assertIn('edX/toy/2012_Fall', tab_content)
+        self.assertIn(self.toy_course_key.to_deprecated_string(), tab_content)
         self.assertIn('static_tab', tab_content)
 
         # Test when render raises an exception
@@ -66,7 +68,7 @@ class StaticTabDateTestCaseXML(LoginEnrollmentTestCase, ModuleStoreTestCase):
     # The following XML test course (which lives at common/test/data/2014)
     # is closed; we're testing that tabs still appear when
     # the course is already closed
-    xml_course_id = 'edX/detached_pages/2014'
+    xml_course_key = SlashSeparatedCourseKey('edX', 'detached_pages', '2014')
 
     # this text appears in the test course's tab
     # common/test/data/2014/tabs/8e4cce2b4aaf4ba28b1220804619e41f.html
@@ -76,14 +78,14 @@ class StaticTabDateTestCaseXML(LoginEnrollmentTestCase, ModuleStoreTestCase):
     @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
     def test_logged_in_xml(self):
         self.setup_user()
-        url = reverse('static_tab', args=[self.xml_course_id, self.xml_url])
+        url = reverse('static_tab', args=[self.xml_course_key.to_deprecated_string(), self.xml_url])
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
         self.assertIn(self.xml_data, resp.content)
 
     @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
     def test_anonymous_user_xml(self):
-        url = reverse('static_tab', args=[self.xml_course_id, self.xml_url])
+        url = reverse('static_tab', args=[self.xml_course_key.to_deprecated_string(), self.xml_url])
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
         self.assertIn(self.xml_data, resp.content)

--- a/lms/djangoapps/courseware/tests/test_video_mongo.py
+++ b/lms/djangoapps/courseware/tests/test_video_mongo.py
@@ -14,6 +14,7 @@ from xmodule.video_module import create_youtube_string
 from xmodule.tests import get_test_descriptor_system
 from xmodule.modulestore import Location
 from xmodule.video_module import VideoDescriptor
+from xmodule.modulestore.locations import SlashSeparatedCourseKey
 
 from . import BaseTestXmodule
 from .test_video_xml import SOURCE_XML
@@ -511,10 +512,11 @@ class VideoDescriptorTest(unittest.TestCase):
 
     def setUp(self):
         system = get_test_descriptor_system()
-        location = Location('i4x://org/course/video/name')
+        course_key = SlashSeparatedCourseKey('org', 'course', 'run')
+        usage_key = course_key.make_usage_key('video', 'name')
         self.descriptor = system.construct_xblock_from_class(
             VideoDescriptor,
-            scope_ids=ScopeIds(None, None, location, location),
+            scope_ids=ScopeIds(None, None, usage_key, usage_key),
             field_data=DictFieldData({}),
         )
         self.descriptor.runtime.handler_url = MagicMock()


### PR DESCRIPTION
This commit updates lms/djangoapps/courseware.

These keys are now objects with a limited interface, and the particular
internal representation is managed by the data storage layer (the
modulestore).

For the LMS, there should be no outward-facing changes to the system. The keys
are, for now, a change to internal representation only. For Studio, the new
serialized form of the keys is used in urls, to allow for further migration in
the future.

Co-Author: Andy Armstrong andya@edx.org Co-Author: Christina Roberts
christina@edx.org Co-Author: David Baumgold db@edx.org Co-Author: Diana
Huang dkh@edx.org Co-Author: Don Mitchell dmitchell@edx.org Co-Author:
Julia Hansbrough julia@edx.org Co-Author: Nimisha Asthagiri
nasthagiri@edx.org Co-Author: Sarina Canelake sarina@edx.org

[LMS-2370]
