### PR TITLE
lms/templates updates for opaque keys [partial commit]

### DIFF
--- a/lms/templates/class_dashboard/all_section_metrics.js
+++ b/lms/templates/class_dashboard/all_section_metrics.js
@@ -6,7 +6,7 @@
 
 $(function () {
 
-  d3.json("${reverse('all_sequential_open_distrib', kwargs=dict(course_id=course_id))}", function(error, json) {
+  d3.json("${reverse('all_sequential_open_distrib', kwargs=dict(course_id=course_id.to_deprecated_string()))}", function(error, json) {
     var section, paramOpened, barGraphOpened, error;
     var i, curr_id;
     var errorMessage = gettext('Unable to retrieve data, please try again later.');
@@ -46,7 +46,7 @@ $(function () {
     }
   });
 
-  d3.json("${reverse('all_problem_grade_distribution', kwargs=dict(course_id=course_id))}", function(error, json) {
+  d3.json("${reverse('all_problem_grade_distribution', kwargs=dict(course_id=course_id.to_deprecated_string()))}", function(error, json) {
     var section, paramGrade, barGraphGrade, error;
     var i, curr_id;
     var errorMessage = gettext('Unable to retrieve data, please try again later.');

--- a/lms/templates/conditional_ajax.html
+++ b/lms/templates/conditional_ajax.html
@@ -1,7 +1,6 @@
 <div
     id="conditional_${element_id}"
     class="conditional-wrapper"
-    data-problem-id="${id}"
     data-url="${ajax_url}"
     data-depends="${depends}"
 >

--- a/lms/templates/conditional_module.html
+++ b/lms/templates/conditional_module.html
@@ -4,7 +4,7 @@ from django.core.urlresolvers import reverse
 
 def _message(reqm, message):
     return message.format(link="<a href={url}>{url_name}</a>".format(
-        url = reverse('jump_to', kwargs=dict(course_id=reqm.course_id,
+        url = reverse('jump_to', kwargs=dict(course_id=reqm.course_id.to_deprecated_string(),
                         location=reqm.location.url())),
         url_name = reqm.display_name_with_default))
 %>

--- a/lms/templates/course.html
+++ b/lms/templates/course.html
@@ -5,11 +5,11 @@ from django.core.urlresolvers import reverse
 from courseware.courses import course_image_url, get_course_about_section
 %>
 <%page args="course" />
-<article id="${course.id}" class="course">
+<article id="${course.id.to_deprecated_string()}" class="course">
   %if course.is_newish:
     <span class="status">${_("New")}</span>
   %endif
-  <a href="${reverse('about_course', args=[course.id])}">
+  <a href="${reverse('about_course', args=[course.id.to_deprecated_string()])}">
   <div class="inner-wrapper">
       <header class="course-preview">
         <hgroup>

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -2,7 +2,6 @@
 <%!
   from django.core.urlresolvers import reverse
   from courseware.courses import course_image_url, get_course_about_section
-  from courseware.access import has_access
   from django.conf import settings
   from edxmako.shortcuts import marketing_link
 
@@ -60,7 +59,7 @@
       };
       $("#add_to_cart_post").click(function(event){
         $.ajax({
-          url: "${reverse('add_course_to_cart', args=[course.id])}",
+          url: "${reverse('add_course_to_cart', args=[course.id.to_deprecated_string()])}",
           type: "POST",
           /* Rant: HAD TO USE COMPLETE B/C PROMISE.DONE FOR SOME REASON DOES NOT WORK ON THIS PAGE. */
           complete: add_course_complete_handler
@@ -83,7 +82,7 @@
       if(xhr.status == 200) {
         location.href = "${reverse('dashboard')}";
       } else if (xhr.status == 403) {
-        location.href = "${reverse('course-specific-register', args=[course.id])}?course_id=${course.id}&enrollment_action=enroll";
+        location.href = "${reverse('course-specific-register', args=[course.id.to_deprecated_string()])}?course_id=${course.id.to_deprecated_string()}&enrollment_action=enroll";
       } else if (xhr.status == 400) { //This means the user did not have permission
         $('#register_error').html("${perms_error}").css("display", "block");
       } else {
@@ -104,7 +103,7 @@
           location.href = xhr.responseText;
         }
       } else if (xhr.status == 403) {
-        location.href = "${reverse('register_user')}?course_id=${course.id}&enrollment_action=enroll";
+        location.href = "${reverse('register_user')}?course_id=${course.id.to_deprecated_string()}&enrollment_action=enroll";
       } else {
         $('#register_error').html(
             (xhr.responseText ? xhr.responseText : 'An error occurred. Please try again later.')
@@ -250,7 +249,7 @@
                     account=microsite.get_value('course_about_twitter_account', '@edxonline'),
                     url=u"http://{domain}{path}".format(
                         domain=site_domain,
-                        path=reverse('about_course', args=[course.id])
+                        path=reverse('about_course', args=[course.id.to_deprecated_string()])
                     )
                 ).replace(u" ", u"+")
                 tweet_action = u"http://twitter.com/intent/tweet?text={tweet_text}".format(tweet_text=tweet_text)
@@ -265,7 +264,7 @@
                         platform=platform_name,
                         url=u"http://{domain}{path}".format(
                             domain=site_domain,
-                            path=reverse('about_course', args=[course.id]),
+                            path=reverse('about_course', args=[course.id.to_deprecated_string()]),
                         )
                     )
                 ).replace(u" ", u"%20")
@@ -340,7 +339,7 @@
   <div style="display: none;">
     <form id="class_enroll_form" method="post" data-remote="true" action="${reverse('change_enrollment')}">
       <fieldset class="enroll_fieldset">
-        <input name="course_id" type="hidden" value="${course.id}">
+        <input name="course_id" type="hidden" value="${course.id.to_deprecated_string()}">
         <input name="enrollment_action" type="hidden" value="enroll">
       </fieldset>
       <div class="submit">

--- a/lms/templates/courseware/course_navigation.html
+++ b/lms/templates/courseware/course_navigation.html
@@ -23,7 +23,7 @@ def url_class(is_active):
 <nav class="${active_page} course-material">
   <div class="inner-wrapper">
     <ol class="course-tabs">
-      % for tab in CourseTabList.iterate_displayable(course, settings, user.is_authenticated(), has_access(user, course, 'staff')):
+      % for tab in CourseTabList.iterate_displayable(course, settings, user.is_authenticated(), has_access(user, 'staff', course, course.id)):
         <%
             tab_is_active = (tab.tab_id == active_page)
             tab_image = notification_image_for_tab(tab, user, course)

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -58,7 +58,7 @@ ${page_title_breadcrumbs(course_name())}
   % endif
 
   <script type="text/javascript">
-    var $$course_id = "${course.id}";
+    var $$course_id = "${course.id.to_deprecated_string()}";
 
     $(function(){
         $(".ui-accordion-header a, .ui-accordion-content .subtitle").each(function() {

--- a/lms/templates/courseware/gradebook.html
+++ b/lms/templates/courseware/gradebook.html
@@ -54,7 +54,7 @@
         %for student in students:
         <tr>
           <td>
-            <a href="${reverse('student_progress', kwargs=dict(course_id=course_id, student_id=student['id']))}">${student['username']}</a>
+            <a href="${reverse('student_progress', kwargs=dict(course_id=course_id.to_deprecated_string(), student_id=student['id']))}">${student['username']}</a>
           </td>
         </tr>
         %endfor

--- a/lms/templates/courseware/instructor_dashboard.html
+++ b/lms/templates/courseware/instructor_dashboard.html
@@ -34,30 +34,30 @@
 
 <style type="text/css">
 table.stat_table {
-	font-family: verdana,arial,sans-serif;
-	font-size:11px;
-	color:#333333;
-	border-width: 1px;
-	border-color: #666666;
-	border-collapse: collapse;
+    font-family: verdana,arial,sans-serif;
+    font-size:11px;
+    color:#333333;
+    border-width: 1px;
+    border-color: #666666;
+    border-collapse: collapse;
 }
 table.stat_table th {
-	border-width: 1px;
-	padding: 8px;
-	border-style: solid;
-	border-color: #666666;
-	background-color: #dedede;
+    border-width: 1px;
+    padding: 8px;
+    border-style: solid;
+    border-color: #666666;
+    background-color: #dedede;
 }
 table.stat_table td {
-	border-width: 1px;
-	padding: 8px;
-	border-style: solid;
-	border-color: #666666;
-	background-color: #ffffff;
+    border-width: 1px;
+    padding: 8px;
+    border-style: solid;
+    border-color: #666666;
+    background-color: #ffffff;
 }
 .divScroll {
-	height: 200px;
-	overflow: scroll;
+    height: 200px;
+    overflow: scroll;
 }
 
 a.selectedmode { background-color: yellow; }
@@ -126,7 +126,7 @@ function goto( mode)
         <a class="instructor-info-action beta-button" href="${ beta_dashboard_url }">${_("Try New Beta Dashboard")}</a>
       %endif
     </div>
-    
+
     <h1>${_("Instructor Dashboard")}</h1>
 
     <h2 class="navbar">[ <a href="#" onclick="goto('Grades');" class="${modeflag.get('Grades')}">Grades</a> |
@@ -147,7 +147,7 @@ function goto( mode)
           %if settings.FEATURES.get('CLASS_DASHBOARD'):
              | <a href="#" onclick="goto('Metrics');" class="${modeflag.get('Metrics')}">${_("Metrics")}</a>
           %endif
-	  ]
+      ]
     </h2>
 
     <form name="idashform" method="POST">
@@ -187,11 +187,11 @@ function goto( mode)
     % endif
 
     <p>
-    <a href="${reverse('gradebook', kwargs=dict(course_id=course.id))}" class="${'is-disabled' if disable_buttons else ''}">${_("Gradebook")}</a>
+    <a href="${reverse('gradebook', kwargs=dict(course_id=course.id.to_deprecated_string()))}" class="${'is-disabled' if disable_buttons else ''}">${_("Gradebook")}</a>
     </p>
 
     <p>
-    <a href="${reverse('grade_summary', kwargs=dict(course_id=course.id))}" class="${'is-disabled' if disable_buttons else ''}">${_("Grade summary")}</a>
+    <a href="${reverse('grade_summary', kwargs=dict(course_id=course.id.to_deprecated_string()))}" class="${'is-disabled' if disable_buttons else ''}">${_("Grade summary")}</a>
     </p>
 
     <p>
@@ -253,15 +253,13 @@ function goto( mode)
     <H2>${_("Course-specific grade adjustment")}</h2>
 
     <p>
-      ${_("Specify a particular problem in the course here by its url:")}
+      ${_("Specify a particular problem in the course here by its location:")}
       <input type="text" name="problem_for_all_students" size="60">
     </p>
     <p>
-      ${_('You may use just the "urlname" if a problem, or "modulename/urlname" if not. '
-          '(For example, if the location is <tt>i4x://university/course/problem/problemname</tt>, '
-          'then just provide the <tt>problemname</tt>. '
-          'If the location is <tt>i4x://university/course/notaproblem/someothername</tt>, then '
-          'provide <tt>notaproblem/someothername</tt>.)')}
+      ${_("You should provide the full location of a problem. A location will look like this: {location}").format(
+      location="<tt>location:edX+Open_DemoX+problem+78c98390884243b89f6023745231c525</tt>")
+      }
     </p>
     <p>
       ${_("Then select an action:")}
@@ -288,16 +286,15 @@ function goto( mode)
       <input type="submit" name="action" value="Get link to student's progress page">
     </p>
     <p>
-      ${_("Specify a particular problem in the course here by its url:")}
+      ${_("Specify a particular problem in the course here by its location:")}
       <input type="text" name="problem_for_student" size="60">
     </p>
     <p>
-      ${_('You may use just the "urlname" if a problem, or "modulename/urlname" if not. '
-          '(For example, if the location is <tt>i4x://university/course/problem/problemname</tt>, '
-          'then just provide the <tt>problemname</tt>. '
-          'If the location is <tt>i4x://university/course/notaproblem/someothername</tt>, then '
-          'provide <tt>notaproblem/someothername</tt>.)')}
+      ${_("You should provide the full location of a problem. A location will look like this: {location}").format(
+      location="<tt>location:edX+Open_DemoX+problem+78c98390884243b89f6023745231c525</tt>")
+      }
     </p>
+
     <p>
       ${_("Then select an action:")}
       <input type="submit" name="action" value="Reset student's attempts">
@@ -401,7 +398,7 @@ function goto( mode)
   %else:
   <p>${_("User requires forum administrator privileges to perform administration tasks.  See instructor.")}</p>
   %endif
-  
+
   <br />
   <h2>${_("Explanation of Roles:")}</h2>
   <p>${_("Forum Moderators: can edit or delete any post, remove misuse flags, close and re-open threads, endorse "
@@ -562,9 +559,9 @@ function goto( mode)
         <li class="item">${_("Have you sent the email to yourself first to make sure you're happy with how it's displayed, and that embedded links and images work properly?")}</li>
       </ul>
       <div class="submit-email-warning">
-	<p class="copy"><span style="color: red;"><b>${_("CAUTION!")}</b></span>
-	  ${_("Once the 'Send Email' button is clicked, your email will be queued for sending.")}
-	<b>${_("A queued email CANNOT be cancelled.")}</b></p>
+        <p class="copy"><span style="color: red;"><b>${_("CAUTION!")}</b></span>
+          ${_("Once the 'Send Email' button is clicked, your email will be queued for sending.")}
+        <b>${_("A queued email CANNOT be cancelled.")}</b></p>
       </div>
       <br />
       <input type="submit" name="action" value="Send email">
@@ -686,7 +683,7 @@ function goto( mode)
     </script>
 
     <div id="metrics"></div>
-    
+
     <h3 class="attention">${_("Loading the latest graphs for you; depending on your class size, this may take a few minutes.")}</h3>
 
     %for i in range(0,len(metrics_results['section_display_name'])):
@@ -817,16 +814,16 @@ function goto( mode)
       <h2>${datatable['title'] | h}</h2>
       <table class="stat_table">
         <tr>
-	%for hname in datatable['header']:
-	  <th>${hname | h}</th>
-	%endfor
-	</tr>
+        %for hname in datatable['header']:
+          <th>${hname | h}</th>
+        %endfor
+        </tr>
         %for row in datatable['data']:
           <tr>
-	    %for value in row:
-	      <td>${value | h}</td>
-	    %endfor
-	  </tr>
+          %for value in row:
+            <td>${value | h}</td>
+          %endfor
+          </tr>
         %endfor
       </table>
     </p>
@@ -851,8 +848,8 @@ function goto( mode)
         </tr>
       %for tasknum, instructor_task in enumerate(instructor_tasks):
         <tr id="task-progress-entry-${tasknum}" class="task-progress-entry"
-	    data-task-id="${instructor_task.task_id}"
-	    data-in-progress="true">
+            data-task-id="${instructor_task.task_id}"
+            data-in-progress="true">
           <td>${instructor_task.task_type}</td>
           <td>${instructor_task.task_input}</td>
           <td class="task-id">${instructor_task.task_id}</td>
@@ -880,16 +877,16 @@ function goto( mode)
       <h2>${course_stats['title'] | h}</h2>
       <table class="stat_table">
         <tr>
-	%for hname in course_stats['header']:
-	  <th>${hname | h}</th>
-	%endfor
-	</tr>
+        %for hname in course_stats['header']:
+          <th>${hname | h}</th>
+        %endfor
+        </tr>
         %for row in course_stats['data']:
           <tr>
-	    %for value in row:
-	      <td>${value | h}</td>
-	    %endfor
-	  </tr>
+            %for value in row:
+              <td>${value | h}</td>
+            %endfor
+          </tr>
         %endfor
       </table>
     </p>

--- a/lms/templates/courseware/mktg_coming_soon.html
+++ b/lms/templates/courseware/mktg_coming_soon.html
@@ -2,7 +2,6 @@
 <%!
   from django.core.urlresolvers import reverse
   from courseware.courses import course_image_url, get_course_about_section
-  from courseware.access import has_access
 %>
 <%namespace name='static' file='../static_content.html'/>
 

--- a/lms/templates/courseware/mktg_course_about.html
+++ b/lms/templates/courseware/mktg_course_about.html
@@ -2,7 +2,6 @@
 <%!
   from django.core.urlresolvers import reverse
   from courseware.courses import course_image_url, get_course_about_section
-  from courseware.access import has_access
 %>
 <%namespace name='static' file='../static_content.html'/>
 
@@ -34,7 +33,7 @@
           window.top.location.href = "${reverse('dashboard')}";
         }
       } else if (xhr.status == 403) {
-        window.top.location.href = "${reverse('register_user')}?course_id=${course.id}&enrollment_action=enroll";
+        window.top.location.href = "${reverse('register_user')}?course_id=${course.id.to_deprecated_string()}&enrollment_action=enroll";
       } else {
         $('#register_error').html(
             (xhr.responseText ? xhr.responseText : "${_("An error occurred. Please try again later.")}")
@@ -74,7 +73,7 @@
   <div style="display: none;">
     <form id="class_enroll_form" method="post" data-remote="true" action="${reverse('change_enrollment')}">
       <fieldset class="enroll_fieldset">
-        <input name="course_id" type="hidden" value="${course.id}">
+        <input name="course_id" type="hidden" value="${course.id.to_deprecated_string()}">
         <input name="enrollment_action" type="hidden" value="enroll">
         <input type="hidden" name="csrfmiddlewaretoken" value="${ csrf_token }">
       </fieldset>

--- a/lms/templates/courseware/progress.html
+++ b/lms/templates/courseware/progress.html
@@ -43,7 +43,7 @@ from django.conf import settings
           <a class="instructor-info-action studio-view" href="${studio_url}">${_("View Grading in studio")}</a>
         </div>
       % endif
-      
+
       <header>
         <h1>${_("Course Progress for Student '{username}' ({email})").format(username=student.username, email=student.email)}</h1>
       </header>
@@ -51,7 +51,7 @@ from django.conf import settings
       %if settings.FEATURES.get("SHOW_PROGRESS_SUCCESS_BUTTON"):
         <%
           SUCCESS_BUTTON_URL = settings.PROGRESS_SUCCESS_BUTTON_URL.format(
-            course_id=course.id, student_id=student.id)
+            course_id=course.id.to_deprecated_string(), student_id=student.id)
           nonzero_cutoffs = [cutoff for cutoff in course.grade_cutoffs.values() if cutoff > 0]
           success_cutoff = min(nonzero_cutoffs) if nonzero_cutoffs else None
         %>
@@ -83,7 +83,7 @@ from django.conf import settings
               percentageString = "{0:.0%}".format( float(earned)/total) if earned > 0 and total > 0 else ""
               %>
 
-              <h3><a href="${reverse('courseware_section', kwargs=dict(course_id=course.id, chapter=chapter['url_name'], section=section['url_name']))}">
+              <h3><a href="${reverse('courseware_section', kwargs=dict(course_id=course.id.to_deprecated_string(), chapter=chapter['url_name'], section=section['url_name']))}">
                 ${ section['display_name'] }
                 %if total > 0 or earned > 0:
                   <span class="sr">

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -23,7 +23,7 @@
 <li class="course-item">
   <article class="course ${enrollment.mode}">
     <%
-      course_target = reverse('info', args=[course.id])
+      course_target = reverse('info', args=[course.id.to_deprecated_string()])
     %>
 
     % if show_courseware_link:
@@ -91,10 +91,10 @@
 
               <ul class="actions message-actions">
                 <li class="action-item">
-                  <a class="action action-upgrade" href="${reverse('course_modes_choose', kwargs={'course_id': course.id})}?upgrade=True">
+                  <a class="action action-upgrade" href="${reverse('course_modes_choose', kwargs={'course_id': course.id.to_deprecated_string()})}?upgrade=True">
                     <img class="deco-graphic" src="${static.url('images/vcert-ribbon-s.png')}" alt="ID Verified Ribbon/Badge">
                     <span class="wrapper-copy">
-                      <span class="copy" id="upgrade-to-verified" data-course-id="${course.id}" data-user="${user.username}">${_("Upgrade to Verified Track")}</span>
+                      <span class="copy" id="upgrade-to-verified" data-course-id="${course.id.to_deprecated_string()}" data-user="${user.username}">${_("Upgrade to Verified Track")}</span>
                     </span>
                   </a>
                 </li>
@@ -113,25 +113,25 @@
 
       % if enrollment.mode != "verified":
         ## Translators: The course's name will be added to the end of this sentence.
-        <a href="#unenroll-modal" class="unenroll" rel="leanModal" data-course-id="${course.id}" data-course-number="${course.number}" onclick="document.getElementById('track-info').innerHTML='${_("Are you sure you want to unregister from")}'; document.getElementById('refund-info').innerHTML=''">
+        <a href="#unenroll-modal" class="unenroll" rel="leanModal" data-course-id="${course.id.to_deprecated_string()}" data-course-number="${course.number}" onclick="document.getElementById('track-info').innerHTML='${_("Are you sure you want to unregister from")}'; document.getElementById('refund-info').innerHTML=''">
           ${_('Unregister')}
         </a>
       % elif show_refund_option:
         ## Translators: The course's name will be added to the end of this sentence.
-        <a href="#unenroll-modal" class="unenroll" rel="leanModal" data-course-id="${course.id}" data-course-number="${course.number}" onclick="document.getElementById('track-info').innerHTML='${_("Are you sure you want to unregister from the verified {cert_name_long} track of").format(cert_name_long=cert_name_long)}';
-          document.getElementById('refund-info').innerHTML='${_("In order to request a refund for the amount you paid, you will need to send an email to {billing_email}.  Be sure to include your email and the course name.").format(billing_email=billing_email)}'">
+        <a href="#unenroll-modal" class="unenroll" rel="leanModal" data-course-id="${course.id.to_deprecated_string()}" data-course-number="${course.number}" onclick="document.getElementById('track-info').innerHTML='${_("Are you sure you want to unregister from the verified {cert_name_long} track of").format(cert_name_long=cert_name_long)}';
+        document.getElementById('refund-info').innerHTML=gettext('You will be refunded the amount you paid.')">
           ${_('Unregister')}
         </a>
       % else:
         ## Translators: The course's name will be added to the end of this sentence.
-        <a href="#unenroll-modal" class="unenroll" rel="leanModal" data-course-id="${course.id}" data-course-number="${course.number}" onclick="document.getElementById('track-info').innerHTML='${_("Are you sure you want to unregister from the verified {cert_name_long} track of").format(cert_name_long=cert_name_long)}';
+        <a href="#unenroll-modal" class="unenroll" rel="leanModal" data-course-id="${course.id.to_deprecated_string()}" data-course-number="${course.number}" onclick="document.getElementById('track-info').innerHTML='${_("Are you sure you want to unregister from the verified {cert_name_long} track of").format(cert_name_long=cert_name_long)}';
         document.getElementById('refund-info').innerHTML=gettext('The refund deadline for this course has passed, so you will not receive a refund.')">
           ${_('Unregister')}
         </a>
       % endif
 
 % if show_email_settings:
-        <a href="#email-settings-modal" class="email-settings" rel="leanModal" data-course-id="${course.id}" data-course-number="${course.number}" data-optout="${course.id in course_optouts}">${_('Email Settings')}</a>
+        <a href="#email-settings-modal" class="email-settings" rel="leanModal" data-course-id="${course.id.to_deprecated_string()}" data-course-number="${course.number}" data-optout="${course.id.to_deprecated_string() in course_optouts}">${_('Email Settings')}</a>
 % endif
 
 

--- a/lms/templates/discussion/user_profile.html
+++ b/lms/templates/discussion/user_profile.html
@@ -32,7 +32,7 @@
       </nav>
     </section>
 
-    <section class="course-content container discussion-user-threads" data-course-id="${course.id | h}" data-threads="${threads}" data-user-info="${user_info}" data-page="${page}" data-num-pages="${num_pages}"/>
+    <section class="course-content container discussion-user-threads" data-course-id="${course.id.to_deprecated_string() | h}" data-threads="${threads}" data-user-info="${user_info}" data-page="${page}" data-num-pages="${num_pages}"/>
   </div>
 </section>
 

--- a/lms/templates/help_modal.html
+++ b/lms/templates/help_modal.html
@@ -99,7 +99,7 @@
       <textarea name="details" id="feedback_form_details" aria-required="true"></textarea>
       <input name="issue_type" type="hidden">
 % if course:
-      <input name="course_id" type="hidden" value="${course.id | h}">
+      <input name="course_id" type="hidden" value="${course.id.to_deprecated_string() | h}">
 % endif
       <div class="submit">
         <input name="submit" type="submit" value="${_('Submit')}" id="feedback_submit">

--- a/lms/templates/instructor/instructor_dashboard_2/course_info.html
+++ b/lms/templates/instructor/instructor_dashboard_2/course_info.html
@@ -16,17 +16,17 @@
   <ul class="list-input">
     <li class="field text is-not-editable" id="field-course-organization">
       <label for="course-organization">${_("Organization:")}</label>
-      <b>${ section_data['course_org'] }</b>
+      <b>${ section_data['course_id'].org }</b>
     </li>
 
     <li class="field text is-not-editable" id="field-course-number">
       <label for="course-number">${_("Course Number:")}</label>
-      <b>${ section_data['course_num'] }</b>
+      <b>${ section_data['course_id'].course }</b>
     </li>
 
     <li class="field text is-not-editable" id="field-course-name">
       <label for="course-name">${_("Course Name:")}</label>
-      <b>${ section_data['course_name'] }</b>
+      <b>${ section_data['course_id'].run }</b>
     </li>
 
     <li class="field text is-not-editable" id="field-course-display-name">

--- a/lms/templates/instructor/instructor_dashboard_2/student_admin.html
+++ b/lms/templates/instructor/instructor_dashboard_2/student_admin.html
@@ -30,16 +30,13 @@
   </p>
   <br>
 
-  <p> ${_('Specify a particular problem in the course here by its url:')}
-  <input type="text" name="problem-select-single" placeholder="${_("Problem urlname")}">
+  <p> ${_('Specify a particular problem in the course here by its location:')}
+  <input type="text" name="problem-select-single" placeholder="${_("Problem location")}">
   </p>
 
   <p>
-    ${_('You may use just the "urlname" if a problem, or "modulename/urlname" if not. (For example, if the location is {location1}, then just provide the {urlname1}. If the location is {location2}, then provide {urlname2}.)').format(
-    location1="<tt>i4x://university/course/problem/problemname</tt>",
-    urlname1="<tt>problemname</tt>",
-    location2="<tt>i4x://university/course/notaproblem/someothername</tt>",
-    urlname2="<tt>notaproblem/someothername</tt>")
+    ${_("You should provide the full location of a problem. A location will look like this: {location}").format(
+    location="<tt>location:edX+Open_DemoX+problem+78c98390884243b89f6023745231c525</tt>")
     }
   </p>
 
@@ -81,15 +78,12 @@
     <div class="request-response-error"></div>
 
     <p>
-      ${_("Specify a particular problem in the course here by its url:")}
-      <input type="text" name="problem-select-all" size="60">
+      ${_("Specify a particular problem in the course here by its location:")}
+      <input type="text" name="problem-select-all" size="60" placeholder="${_("Problem location")}">
     </p>
     <p>
-      ${_('You may use just the "urlname" if a problem, or "modulename/urlname" if not. (For example, if the location is {location1}, then just provide the {urlname1}. If the location is {location2}, then provide {urlname2}.)').format(
-      location1="<tt>i4x://university/course/problem/problemname</tt>",
-      urlname1="<tt>problemname</tt>",
-      location2="<tt>i4x://university/course/notaproblem/someothername</tt>",
-      urlname2="<tt>notaproblem/someothername</tt>")
+      ${_("You should provide the full location of a problem. A location will look like this: {location}").format(
+      location="<tt>location:edX+Open_DemoX+problem+78c98390884243b89f6023745231c525</tt>")
       }
     </p>
     <p>

--- a/lms/templates/navigation.html
+++ b/lms/templates/navigation.html
@@ -20,7 +20,7 @@ from status.status import get_site_status_msg
 <%block cached="False">
 <%
 try:
-    course_id = course.id
+    course_id = course.id.to_deprecated_string()
 except:
     # can't figure out a better way to get at a possibly-defined course var
     course_id = None
@@ -104,7 +104,7 @@ site_status_msg = get_site_status_msg(course_id)
       % if not settings.FEATURES['DISABLE_LOGIN_BUTTON']:
           % if course and settings.FEATURES.get('RESTRICT_ENROLL_BY_REG_METHOD') and course.enrollment_domain:
           <li class="nav-global-04">
-            <a class="cta cta-register" href="${reverse('course-specific-register', args=[course.id])}">${_("Register Now")}</a>
+            <a class="cta cta-register" href="${reverse('course-specific-register', args=[course.id.to_deprecated_string()])}">${_("Register Now")}</a>
           </li>
           % else:
           <li class="nav-global-04">
@@ -118,7 +118,7 @@ site_status_msg = get_site_status_msg(course_id)
     <li class="nav-courseware-01">
       % if not settings.FEATURES['DISABLE_LOGIN_BUTTON']:
           % if course and settings.FEATURES.get('RESTRICT_ENROLL_BY_REG_METHOD') and course.enrollment_domain:
-          <a class="cta cta-login" href="${reverse('course-specific-login', args=[course.id])}${login_query()}">${_("Log in")}</a>
+          <a class="cta cta-login" href="${reverse('course-specific-login', args=[course.id.to_deprecated_string()])}${login_query()}">${_("Log in")}</a>
           % else:
           <a class="cta cta-login" href="/login${login_query()}">${_("Log in")}</a>
           % endif

--- a/lms/templates/notes.html
+++ b/lms/templates/notes.html
@@ -59,140 +59,138 @@
 
 <section class="container">
     <div class="notes-wrapper">
-    	<h1>${_('My Notes')}</h1>
-    	<div id="notesHolder"></div>
+        <h1>${_('My Notes')}</h1>
+        <div id="notesHolder"></div>
         <section id="catchDIV">
-        	<div class="annotationListContainer">${_('You do not have any notes.')}</div>
+            <div class="annotationListContainer">${_('You do not have any notes.')}</div>
         </section>
-    	<script>
+        <script>
 
-    	//Grab uri of the course
-    	var parts = window.location.href.split("/"), 
-    		uri = '',
-		courseid;
-	for (var index = 0; index <= 6; index += 1) uri += parts[index]+"/"; //Get the unit url
-	courseid = parts[4] + "/" + parts[5] + "/" + parts[6];
+        //Grab uri of the course
+        var parts = window.location.href.split("/"),
+            uri = '';
+        for (var index = 0; index <= 6; index += 1) uri += parts[index]+"/"; //Get the unit url
         var pagination = 100,
-		is_staff = false,
-        options = {
-        optionsAnnotator: {
-            permissions:{
-                user: {
-                    id:"${student.email}", 
-                    name:"${student.username}"
-                },
-                userString: function (user) {
-                    if (user && user.name) 
-                        return user.name;
-                    return user;
-                },
-                userId: function (user) {
-                    if (user && user.id) 
-                        return user.id;
-                    return user;
-                },
-                permissions: {
-                        'read':   [],
-                        'update': ["${student.email}"],
-                        'delete': ["${student.email}"],
-                        'admin':  ["${student.email}"]
-                },
-                showViewPermissionsCheckbox: true,
-                showEditPermissionsCheckbox: false,
-                userAuthorize: function(action, annotation, user) {
-                    var token, tokens, _i, _len;
-                    if (annotation.permissions) {
-                      tokens = annotation.permissions[action] || [];
-                      if (is_staff){
-                      	return true;
-                      }
-                      if (tokens.length === 0) {
-                        return true;
-                      }
-                      for (_i = 0, _len = tokens.length; _i < _len; _i++) {
-                        token = tokens[_i];
-                        
-                        if (this.userId(user) === token) {
+            is_staff = false,
+            options = {
+                optionsAnnotator: {
+                    permissions:{
+                        user: {
+                            id:"${student.email}",
+                            name:"${student.username}"
+                        },
+                        userString: function (user) {
+                            if (user && user.name)
+                                return user.name;
+                            return user;
+                        },
+                        userId: function (user) {
+                            if (user && user.id)
+                                return user.id;
+                            return user;
+                        },
+                        permissions: {
+                                'read':   [],
+                                'update': ["${student.email}"],
+                                'delete': ["${student.email}"],
+                                'admin':  ["${student.email}"]
+                        },
+                        showViewPermissionsCheckbox: true,
+                        showEditPermissionsCheckbox: false,
+                        userAuthorize: function(action, annotation, user) {
+                            var token, tokens, _i, _len;
+                            if (annotation.permissions) {
+                              tokens = annotation.permissions[action] || [];
+                              if (is_staff){
+                              	return true;
+                              }
+                              if (tokens.length === 0) {
+                                return true;
+                              }
+                              for (_i = 0, _len = tokens.length; _i < _len; _i++) {
+                                token = tokens[_i];
 
-                          return true;
+                                if (this.userId(user) === token) {
+
+                                  return true;
+                                }
+                              }
+
+                              return false;
+                            } else if (annotation.user) {
+                              if (user) {
+                                return this.userId(user) === this.userId(annotation.user);
+                              } else {
+                                return false;
+                              }
+                            }
+                            return true;
+                          },
+                    },
+                    auth: {
+                        tokenUrl: location.protocol+'//'+location.host+"/token?course_id=${course.id.to_deprecated_string()}"
+                    },
+                    store: {
+                        // The endpoint of the store on your server.
+                        prefix: "${storage}",
+
+                        annotationData: {},
+
+                        urls: {
+                            // These are the default URLs.
+                            create:  '/create',
+                            read:    '/read/:id',
+                            update:  '/update/:id',
+                            destroy: '/delete/:id',
+                            search:  '/search'
+                        },
+
+                        loadFromSearch:{
+                            limit:pagination,
+                            offset:0,
+                            uri:uri
                         }
-                      }
-
-                      return false;
-                    } else if (annotation.user) {
-                      if (user) {
-                        return this.userId(user) === this.userId(annotation.user);
-                      } else {
-                        return false;
-                      }
-                    }
-                    return true;
-                  },
-            },
-            auth: {
-                tokenUrl: location.protocol+'//'+location.host+"/token?course_id="+courseid
-            },
-            store: {
-                // The endpoint of the store on your server.
-                prefix: "${storage}",
-
-                annotationData: {},
-
-                urls: {
-                    // These are the default URLs.
-                    create:  '/create',
-                    read:    '/read/:id',
-                    update:  '/update/:id',
-                    destroy: '/delete/:id',
-                    search:  '/search'
+                    },
                 },
+                optionsVideoJS: {techOrder: ["html5","flash","youtube"]},
+                optionsRS: {},
+                optionsOVA: {posBigNew:'none'},
+                optionsRichText: {
+                    tinymce:{
+                        selector: "li.annotator-item textarea",
+                        plugins: "media image insertdatetime link code",
+                        menubar: false,
+                        toolbar_items_size: 'small',
+                        extended_valid_elements : "iframe[src|frameborder|style|scrolling|class|width|height|name|align|id]",
+                        toolbar: "insertfile undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image media rubric | code ",
+                    }
+                },
+            };
 
-                loadFromSearch:{
-                    limit:pagination,
-                    offset:0,
-                    uri:uri
-                }
+        tinyMCE.baseURL = "${settings.STATIC_URL}" + "js/vendor/ova";
+        var imgURLRoot = "${settings.STATIC_URL}" + "js/vendor/ova/catch/img/";
+
+        //remove old instances
+        if (Annotator._instances.length !== 0) {
+            $('#notesHolder').annotator("destroy");
+        }
+        delete ova;
+        //Load the plugin Video/Text Annotation
+        var ova = new OpenVideoAnnotation.Annotator($('#notesHolder'),options);
+
+
+        //Catch
+        var annotator = ova.annotator,
+            catchOptions = {
+                media:'text',
+                externalLink:true,
+                imageUrlRoot:imgURLRoot,
+                showMediaSelector: true,
+                showPublicPrivate: true,
+                pagination:pagination,//Number of Annotations per load in the pagination,
+                flags:is_staff
             },
-        },
-        optionsVideoJS: {techOrder: ["html5","flash","youtube"]},
-        optionsRS: {},
-        optionsOVA: {posBigNew:'none'},
-        optionsRichText: {
-            tinymce:{
-                selector: "li.annotator-item textarea",
-                plugins: "media image insertdatetime link code",
-                menubar: false,
-                toolbar_items_size: 'small',
-                extended_valid_elements : "iframe[src|frameborder|style|scrolling|class|width|height|name|align|id]",
-                toolbar: "insertfile undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image media rubric | code ",
-            }
-        },
-    };
-	
-	tinyMCE.baseURL = "${settings.STATIC_URL}" + "js/vendor/ova";
-	var imgURLRoot = "${settings.STATIC_URL}" + "js/vendor/ova/catch/img/";
-	
-	//remove old instances
-    if (Annotator._instances.length !== 0) {
-      $('#notesHolder').annotator("destroy");
-    }
-    delete ova;
-    //Load the plugin Video/Text Annotation
-    var ova = new OpenVideoAnnotation.Annotator($('#notesHolder'),options);
-    
-    
-    //Catch
-    var annotator = ova.annotator,
-        catchOptions = {
-            media:'text',
-            externalLink:true,
-            imageUrlRoot:imgURLRoot,
-            showMediaSelector: true,
-            showPublicPrivate: true,
-            pagination:pagination,//Number of Annotations per load in the pagination,
-            flags:is_staff
-        },
-        Catch = new CatchAnnotation($('#catchDIV'),catchOptions);
+            Catch = new CatchAnnotation($('#catchDIV'),catchOptions);
         </script>
     </div>
 </section>

--- a/lms/templates/peer_grading/peer_grading.html
+++ b/lms/templates/peer_grading/peer_grading.html
@@ -41,7 +41,7 @@ criteria.{end_li_tag}
                             %if problem['closed']:
                                 ${problem['problem_name']}
                             %else:
-                                <a href="#problem" data-location="${problem['location']}" class="problem-button">${problem['problem_name']}</a>
+                                <a href="#problem" data-location="${problem['location'].to_deprecated_string()}" class="problem-button">${problem['problem_name']}</a>
                             %endif
                         </td>
                         <td>

--- a/lms/templates/shoppingcart/verified_cert_receipt.html
+++ b/lms/templates/shoppingcart/verified_cert_receipt.html
@@ -1,5 +1,4 @@
 <%! from django.utils.translation import ugettext as _ %>
-<%! from django.core.urlresolvers import reverse %>
 <%! from student.views import course_from_id %>
 
 <%inherit file="../main.html" />
@@ -113,7 +112,7 @@
                     </td>
                     <td class="options">
                       %if course_has_started:
-                          <a class="action action-course" href="${reverse('course_root', kwargs={'course_id': item.course_id})}">${_("Go to Course")}</a>
+                          <a class="action action-course" href="${course_root_url}">${_("Go to Course")}</a>
                       %else:
                       %endif
                     </td>
@@ -123,7 +122,7 @@
                 <tfoot>
                   <tr class="course-actions">
                     <td colspan="3">
-                      <a class="action action-dashboard" href="${reverse('dashboard')}">${_("Go to your Dashboard")}</a>
+                      <a class="action action-dashboard" href="${dashboard_url}">${_("Go to your Dashboard")}</a>
                     </td>
                   </tr>
                 </tfoot>

--- a/lms/templates/sysadmin_dashboard_gitlogs.html
+++ b/lms/templates/sysadmin_dashboard_gitlogs.html
@@ -76,9 +76,10 @@ textarea {
 	  </thead>
 	  <tbody>
 		%for cil in cilset[:10]:
+        <% course_id_string = cil.course_id.to_deprecated_string() if cil.course_id else None %>
         <tr>
 	      <td>${cil.created}</td>
-	      <td><a href="${reverse('gitlogs')}/${cil.course_id}">${cil.course_id}</a></td>
+	      <td><a href="${reverse('gitlogs')}/${course_id_string}">${course_id_string}</a></td>
 	      <td>${cil.git_log}</td>
 		</tr>
 		%endfor
@@ -103,9 +104,10 @@ textarea {
 	  </thead>
 	  <tbody>
 		% for cil in cilset[:2]:
+        <% course_id_string = cil.course_id.to_deprecated_string() if cil.course_id else None %>
         <tr>
 	      <td>${cil.created}</td>
-	      <td><a href="${reverse('gitlogs')}/${cil.course_id}">${cil.course_id}</a></td>
+	      <td><a href="${reverse('gitlogs')}/${course_id_string}">${course_id_string}</a></td>
 	      <td>${cil.git_log}</td>
 		</tr>
 	

--- a/lms/templates/verify_student/_verification_support.html
+++ b/lms/templates/verify_student/_verification_support.html
@@ -19,7 +19,7 @@
         %else:
            <h3 class="title">${_("Change your mind?")}</h3>
           <div class="copy">
-            <p>${_("You can always {a_start} audit the course for free {a_end} without verifying.").format(a_start='<a rel="external" href="/course_modes/choose/' + course_id + '">', a_end="</a>")}</p>
+            <p>${_("You can always {a_start} audit the course for free {a_end} without verifying.").format(a_start='<a rel="external" href="{}">'.format(course_modes_choose_url), a_end="</a>")}</p>
           </div>
         %endif
       </li>
@@ -27,7 +27,7 @@
       <li class="help-item help-item-technical">
         <h3 class="title">${_("Technical Requirements")}</h3>
         <div class="copy">
-          <p>${_("Please make sure your browser is updated to the <strong>{a_start}most recent version possible{a_end}</strong>. Also, please make sure your <strong>web cam is plugged in, turned on, and allowed to function in your web browser (commonly adjustable in your browser settings).</strong>").format(a_start='<a rel="external" href="http://browsehappy.com/">', a_end="</a>")}</p>
+          <p>${_("Please make sure your browser is updated to the {a_start}most recent version possible{a_end}. Also, please make sure your <strong>web cam is plugged in, turned on, and allowed to function in your web browser (commonly adjustable in your browser settings).</strong>").format(a_start='<strong><a rel="external" href="http://browsehappy.com/">', a_end="</a></strong>")}</p>
         </div>
       </li>
     </ul>

--- a/lms/templates/verify_student/midcourse_reverify_dash.html
+++ b/lms/templates/verify_student/midcourse_reverify_dash.html
@@ -25,7 +25,9 @@
                       <h3 class="course-name">${item.course_name} (${item.course_number})</h3>
                       <p class="deadline">${_('Re-verify by {date}').format(date="<strong>" + item.date + "</strong>")}</p>
                     </div>
-		    <p class="reverify-status"><a class="btn action-primary action-reverify" href="${reverse('verify_student_midcourse_reverify', kwargs={'course_id': item.course_id})}">Re-verify for ${item.course_number}</a></p>
+                    <p class="reverify-status"><a class="btn action-primary action-reverify" href="${reverse('verify_student_midcourse_reverify', kwargs={'course_id': item.course_id.to_deprecated_string()})}">
+			${_("Re-verify for {course_number}").format(course_number=item.course_number)}
+		    </a></p>
                   </li>
                 % endfor
                 </ul>
@@ -42,7 +44,9 @@
                       <h3 class="course-name">${item.course_name} (${item.course_number})</h3>
                       <p class="deadline">${_('Re-verify by {date}').format(date="<strong>" + item.date + "</strong>")}</p>
                     </div>
-		    <p class="reverify-status"><a class="btn action-primary action-reverify" href="${reverse('verify_student_midcourse_reverify', kwargs={'course_id': item.course_id})}">Re-verify for ${item.course_number}</a></p>
+                    <p class="reverify-status"><a class="btn action-primary action-reverify" href="${reverse('verify_student_midcourse_reverify', kwargs={'course_id': item.course_id.to_deprecated_string()})}">
+			${_("Re-verify for {course_number}").format(course_number=item.course_number)}
+		    </a></p>
                   </li>
                 % endfor
                 </ul>

--- a/lms/templates/verify_student/photo_verification.html
+++ b/lms/templates/verify_student/photo_verification.html
@@ -27,7 +27,7 @@
     <div class="msg-content">
       <h3 class="title">${_("No Webcam Detected")}</h3>
       <div class="copy">
-        <p>${_("You don't seem to have a webcam connected. Double-check that your webcam is connected and working to continue registering, or select to {a_start} audit the course for free {a_end} without verifying.").format(a_start='<a rel="external" href="/course_modes/choose/' + course_id + '">', a_end="</a>")}</p>
+        <p>${_("You don't seem to have a webcam connected. Double-check that your webcam is connected and working to continue registering, or select to {a_start} audit the course for free {a_end} without verifying.").format(a_start='<a rel="external" href="{}">'.format(course_modes_choose_url), a_end="</a>")}</p>
       </div>
     </div>
   </div>
@@ -182,7 +182,7 @@
                         %if upgrade:
                           <dd class="faq-answer">${_("You can always continue to audit the course without verifying.")}</dd>
                         %else:
-                          <dd class="faq-answer">${_("You can always {a_start} audit the course for free {a_end} without verifying.").format(a_start='<a rel="external" href="/course_modes/choose/' + course_id + '">', a_end="</a>")}</dd>
+                          <dd class="faq-answer">${_("You can always {a_start} audit the course for free {a_end} without verifying.").format(a_start='<a rel="external" href="{}">'.format(course_modes_choose_url), a_end="</a>")}</dd>
                         %endif
                       </dl>
                     </div>

--- a/lms/templates/verify_student/show_requirements.html
+++ b/lms/templates/verify_student/show_requirements.html
@@ -168,12 +168,12 @@
           %if upgrade:
             <span class="help help-inline">${_("Missing something? You can always continue to audit this course instead.")}</span>
           %else:
-            <span class="help help-inline">${_("Missing something? You can always {a_start}audit this course instead{a_end}").format(a_start='<a href="/course_modes/choose/' + course_id + '">', a_end="</a>")}</span>
+            <span class="help help-inline">${_("Missing something? You can always {a_start}audit this course instead{a_end}").format(a_start='<a href="{}">'.format(course_modes_choose_url), a_end="</a>")}</span>
           %endif
 
           <ol class="wizard-steps">
             <li class="wizard-step">
-            <a class="next action-primary ${"disabled" if is_not_active else ""}" id="face_next_button" href="${reverse('verify_student_verify', kwargs={'course_id': course_id})}?upgrade=${upgrade}">${_("Go to Step 1: Take my Photo")}</a>
+            <a class="next action-primary ${"disabled" if is_not_active else ""}" id="face_next_button" href="${verify_student_url}?upgrade=${upgrade}">${_("Go to Step 1: Take my Photo")}</a>
             </li>
           </ol>
         </nav>

--- a/lms/templates/verify_student/verified.html
+++ b/lms/templates/verify_student/verified.html
@@ -12,7 +12,7 @@
 var submitToPaymentProcessing = function(event) {
     event.preventDefault();
     var xhr = $.post(
-      "/verify_student/create_order",
+      "${create_order_url}",
       {
         "course_id" : "${course_id}",
       },


### PR DESCRIPTION
This commit updates lms/templates.

These keys are now objects with a limited interface, and the particular
internal representation is managed by the data storage layer (the
modulestore).

For the LMS, there should be no outward-facing changes to the system. The keys
are, for now, a change to internal representation only. For Studio, the new
serialized form of the keys is used in urls, to allow for further migration in
the future.

Co-Author: Andy Armstrong andya@edx.org Co-Author: Christina Roberts
christina@edx.org Co-Author: David Baumgold db@edx.org Co-Author: Diana
Huang dkh@edx.org Co-Author: Don Mitchell dmitchell@edx.org Co-Author:
Julia Hansbrough julia@edx.org Co-Author: Nimisha Asthagiri
nasthagiri@edx.org Co-Author: Sarina Canelake sarina@edx.org

[LMS-2370]
