### PR TITLE
Remove google analytics tracking from iframes used in Drupal course abou...

### DIFF
--- a/lms/templates/courseware/mktg_course_about.html
+++ b/lms/templates/courseware/mktg_course_about.html
@@ -13,10 +13,6 @@
 <%block name="bodyclass">view-iframe-content view-partial-mktgregister</%block>
 
 
-<%block name="headextra">
-  <%include file="../google_analytics.html" />
-</%block>
-
 <%block name="js_extra">
   <script type="text/javascript">
   (function() {

--- a/lms/templates/mktg_iframe.html
+++ b/lms/templates/mktg_iframe.html
@@ -22,9 +22,9 @@
 
   <%block name="headextra"/>
 
-  % if not course:
-  <%include file="google_analytics.html" />
-  % endif
+  <!-- NOTE: if we want segment io on these iframes at some point, put
+    include file="widgets/segment-io.html"
+  here -->
 
   <!-- repeated button styles needed for IE (copied from _shame.scss) -->
   <style type="text/css" media="screen">


### PR DESCRIPTION
...t pages

This fixes two issues:
- if the course pointed to doesn't exist, GA was added to the iframe twice
- more importantly, we don't want to count these as separate views anyway--
  we just care about the about page itself.
- I also added a note about where we would put our segment.io widget if we want it
  later

LMS-2581
