### PR TITLE
Fix convert_to_draft to correctly return a draft

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_container.py
+++ b/cms/djangoapps/contentstore/views/tests/test_container.py
@@ -56,7 +56,6 @@ class ContainerViewTestCase(CourseTestCase):
             parent_location=published_xblock_with_child.location,
             category="html", display_name="Child HTML"
         )
-        draft_xblock_with_child = modulestore('draft').convert_to_draft(published_xblock_with_child.location)
         branch_name = "MITx.999.Robot_Super_Course/branch/draft/block"
         self._test_html_content(
             published_xblock_with_child,
@@ -73,6 +72,11 @@ class ContainerViewTestCase(CourseTestCase):
                 r'<a href="#" class="navigation-link navigation-current">Wrapper</a>'
             ).format(branch_name=branch_name)
         )
+
+        # Now make the unit and its children into a draft and validate the container again
+        modulestore('draft').convert_to_draft(self.vertical.location)
+        modulestore('draft').convert_to_draft(self.child_vertical.location)
+        draft_xblock_with_child = modulestore('draft').convert_to_draft(published_xblock_with_child.location)
         self._test_html_content(
             draft_xblock_with_child,
             branch_name=branch_name,

--- a/common/lib/xmodule/xmodule/modulestore/mongo/draft.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/draft.py
@@ -154,7 +154,7 @@ class DraftModuleStore(MongoModuleStore):
         self.refresh_cached_metadata_inheritance_tree(draft_location)
         self.fire_updated_modulestore_signal(get_course_id_no_run(draft_location), draft_location)
 
-        return self._load_items([original])[0]
+        return wrap_draft(self._load_items([original])[0])
 
     def update_item(self, xblock, user=None, allow_not_found=False):
         """


### PR DESCRIPTION
I've changed convert_to_draft to call wrap_draft on the item it returns, so that Studio will understand it to be a draft.
