### PR TITLE
Fixes firefox image hidden overflow bug.

### DIFF
--- a/common/lib/xmodule/xmodule/css/html/display.scss
+++ b/common/lib/xmodule/xmodule/css/html/display.scss
@@ -266,8 +266,8 @@ th {
       .image-content .image-wrapper {
         top: 0 !important;
         left: 0 !important;
-        width: auto !important;
-        height: auto !important;
+        width: 100% !important;
+        height: 100% !important;
         
         img {
           top: 0 !important;


### PR DESCRIPTION
There is currently a small bug with the Zoom Image feature in firefox. This fixes it. 

Before (image gets cut off at bottom when in fill screen modal mode):
![screen shot 2014-05-01 at 11 35 08 am](https://cloud.githubusercontent.com/assets/3364609/2855664/74bd0cec-d15f-11e3-90c4-f7f324189a71.png)

After (fixed):
![screen shot 2014-05-01 at 11 35 33 am](https://cloud.githubusercontent.com/assets/3364609/2855667/7e4157e6-d15f-11e3-9416-f6f988d15ea9.png)
