### PR TITLE
Bump django 1.4 minor version to 1.4.12 to pick up patches

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -33,7 +33,7 @@ django-storages==1.1.5
 django-threaded-multihost==1.4-1
 django-method-override==0.1.0
 djangorestframework==2.3.5
-django==1.4.8
+django==1.4.12
 feedparser==5.1.3
 fs==0.4.0
 GitPython==0.3.2.RC1


### PR DESCRIPTION
@e0d @cpennington 

https://docs.djangoproject.com/en/1.4/releases/1.4.11/  is main reason why.
