### PR TITLE
Make release table by PR, instead of by commit

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -425,7 +425,7 @@ def main():
     ensure_github_creds()
 
     if args.table:
-        print(generate_table(args.previous, args.current))
+        print(generate_pr_table(args.previous, args.current))
         return
 
     print("EMAIL:")

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -341,11 +341,11 @@ def generate_pr_table(start_ref, end_ref):
 @memoized
 def get_commits_not_in_prs(start_ref, end_ref):
     """
-    Return a list of commits that exist between start_ref and end_ref,
+    Return a tuple of commits that exist between start_ref and end_ref,
     but were not merged to the end_ref. If everyone is following the
-    pull request process correctly, this should return an empty list.
+    pull request process correctly, this should return an empty tuple.
     """
-    return list(Commit.iter_items(
+    return tuple(Commit.iter_items(
         repo,
         "{start}..{end}".format(start=start_ref, end=end_ref),
         first_parent=True, no_merges=True,
@@ -420,7 +420,7 @@ def main():
     )
     print("\n")
     print(generate_pr_table(args.previous, args.current))
-    commits_without_prs = list(get_commits_not_in_prs(args.previous, args.current))
+    commits_without_prs = get_commits_not_in_prs(args.previous, args.current)
     if commits_without_prs:
         num = len(commits_without_prs)
         plural = num > 1

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -126,6 +126,9 @@ def get_github_creds():
 
 
 def create_github_creds():
+    """
+    https://developer.github.com/v3/oauth_authorizations/#create-a-new-authorization
+    """
     headers = {"User-Agent": "edx-release"}
     payload = {"note": "edx-release"}
     username = raw_input("Github username: ")
@@ -163,7 +166,6 @@ def ensure_github_creds(attempts=3):
         return False
 
     # Looks like we need to create the OAuth creds
-    # https://developer.github.com/v3/oauth_authorizations/#create-a-new-authorization
     print("We need to set up OAuth authentication with Github's API. "
           "Your password will not be stored.", file=sys.stderr)
     token = None

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -155,8 +155,9 @@ def generate_table(start_ref, end_ref):
     """
     Return a string corresponding to a commit table to embed in Confluence
     """
-    header = "|| Merged By || Title || PR || JIRA || Verified? ||"
+    header = "|| Merged By || Author || Title || PR || JIRA || Verified? ||"
     pr_link = "[#{num}|https://github.com/edx/edx-platform/pull/{num}]"
+    user_link = "[@{user}|https://github.com/{user}]"
     rows = [header]
     prbe = prs_by_email(start_ref, end_ref)
     for email, pull_requests in prbe.items():
@@ -165,6 +166,7 @@ def generate_table(start_ref, end_ref):
                 pr_info = get_pr_info(pull_request)
                 title = pr_info["title"] or ""
                 body = pr_info["body"] or ""
+                author = pr_info["user"]["login"]
             except requests.exceptions.RequestException as e:
                 print(
                     "Warning: could not fetch data for #{num}: {message}".format(
@@ -174,8 +176,10 @@ def generate_table(start_ref, end_ref):
                 )
                 title = "?"
                 body = "?"
-            rows.append("| {merged_by} | {title} | {pull_request} | {jira} | {verified} |".format(
+                author = ""
+            rows.append("| {merged_by} | {author} | {title} | {pull_request} | {jira} | {verified} |".format(
                 merged_by=email if i == 0 else "",
+                author=user_link.format(user=author) if author else "",
                 title=title.replace("|", "\|"),
                 pull_request=pr_link.format(num=pull_request),
                 jira=", ".join(parse_ticket_references(body)),

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -261,9 +261,9 @@ def get_pr_info(num):
     Returns the info from the Github API
     """
     url = "https://api.github.com/repos/edx/edx-platform/pulls/{num}".format(num=num)
-    credentials = get_github_creds()
+    username, token = get_github_creds()
     headers = {
-        "Authorization": "token {}".format(credentials[1]),
+        "Authorization": "token {}".format(token),
         "User-Agent": "edx-release",
     }
     response = requests.get(url, headers=headers)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -360,10 +360,6 @@ def generate_email(start_ref, end_ref, release_date=None):
 
         Please record your notes on https://edx-wiki.atlassian.net/wiki/display/ENG/Release+Page%3A+{date}
         and add any bugs found to the Release Candidate Bugs section.
-
-        If you are a non-affiliated open-source contributor to edx-platform,
-        the edX employee who merged in your pull request will manually verify
-        your change(s), and you may disregard this message.
     """.format(
         emails=", ".join(prbe.keys()),
         date=release_date.isoformat(),

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -5,7 +5,7 @@ a release-master multitool
 from __future__ import print_function, unicode_literals
 import sys
 from path import path
-from git import Repo, Commit
+from git import Repo
 from git.refs.symbolic import SymbolicReference
 import argparse
 from datetime import date, timedelta

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -404,12 +404,24 @@ def generate_email(start_ref, end_ref, release_date=None):
     email = """
         To: {emails}
 
-        You've made changes that are about to be released. All of the commits
-        that you either authored or committed are listed below. Please verify them on
-        stage.edx.org and stage-edge.edx.org.
+        You merged at least one pull request for edx-platform that is going out
+        in this upcoming release, and you are responsible for verifying those
+        changes on the staging servers before the code is released. Please go
+        to the release page to do so:
 
-        Please record your notes on https://edx-wiki.atlassian.net/wiki/display/ENG/Release+Page%3A+{date}
-        and add any bugs found to the Release Candidate Bugs section.
+        https://edx-wiki.atlassian.net/wiki/display/ENG/Release+Page%3A+{date}
+
+        The staging servers are:
+
+        https://www.stage.edx.org
+        https://stage-edge.edx.org
+
+        Note that you are responsible for verifying any pull requests that you
+        merged, whether you wrote the code or not. (If you didn't write the code,
+        you can and should try to get the person who wrote the code to help
+        verify the changes -- but even if you can't, you're still responsible!)
+        If you find any bugs, please notify me and record the bugs on the
+        release page. Thanks!
     """.format(
         emails=", ".join(prbe.keys()),
         date=release_date.isoformat(),

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -2,17 +2,22 @@
 """
 a release-master multitool
 """
+from __future__ import print_function, unicode_literals
+import sys
 from path import path
-from git import Repo
+from git import Repo, Commit
+from git.refs.symbolic import SymbolicReference
 import argparse
 from datetime import date, timedelta
 from dateutil.parser import parse as parse_datestring
 import re
-from collections import OrderedDict
+from collections import OrderedDict, defaultdict
 import textwrap
+import requests
 
 IGNORED_EMAILS = set(("vagrant@precise32.(none)",))
 JIRA_RE = re.compile(r"\b[A-Z]{2,}-\d+\b")
+PR_BRANCH_RE = re.compile(r"remotes/origin/pr/(\d+)")
 PROJECT_ROOT = path(__file__).abspath().dirname()
 repo = Repo(PROJECT_ROOT)
 git = repo.git
@@ -36,7 +41,20 @@ def make_parser():
     parser.add_argument(
         '--table', '-t', action="store_true", default=False,
         help="only print table")
+    parser.add_argument(
+        '--commit-table', action="store_true", default=False,
+        help="Display table by commit, instead of by PR")
     return parser
+
+
+def ensure_pr_fetch():
+    # it would be nice to use the git-python API to do this, but it doesn't seem
+    # to support configurations with more than one value per key. :(
+    origin_fetches = git.config("remote.origin.fetch", get_all=True).splitlines()
+    pr_fetch = '+refs/pull/*/head:refs/remotes/origin/pr/*'
+    if pr_fetch not in origin_fetches:
+        git.config("remote.origin.fetch", pr_fetch, add=True)
+        git.fetch()
 
 
 def default_release_date():
@@ -93,24 +111,158 @@ def commits_by_email(commit_range, include_merge=False):
     return data
 
 
-def generate_table(commit_range, include_merge=False):
+class NotFoundError(Exception): pass
+
+
+def get_pr_for_commit(commit, branch="master"):
+    """
+    http://stackoverflow.com/questions/8475448/find-merge-commit-which-include-a-specific-commit
+    """
+    remote_branch = git.describe(commit, all=True, contains=True)
+    match = PR_BRANCH_RE.search(remote_branch)
+    if match:
+        pr_num = int(match.group(1))
+        return pr_num
+    # if `git describe` didn't work, we need to use `git branch` -- it's slower
+    remote_branches = git.branch(commit, all=True, contains=True).splitlines()
+    for remote_branch in remote_branches:
+        remote_branch = remote_branch.strip()
+        match = PR_BRANCH_RE.search(remote_branch)
+        if match:
+            pr_num = int(match.group(1))
+            # we have a pull request -- but is it the right one?
+            ref = SymbolicReference(repo, "refs/{}".format(remote_branch))
+            merge_base = git.merge_base(ref, branch)
+            rev = "{base}^..{branch}".format(base=merge_base, branch=remote_branch)
+            pr_commits = list(Commit.iter_items(repo, rev))
+            if commit in pr_commits:
+                # found it!
+                return pr_num
+    err = NotFoundError(
+        "Can't find pull request for commit {commit} against branch {branch}".format(
+            commit=commit, branch=branch,
+        )
+    )
+    err.commit = commit
+    raise err
+
+
+def get_merge_commit(commit, branch="master"):
+    """
+    Given a commit that was merged into the given branch, return the merge commit
+    for that event.
+
+    http://stackoverflow.com/questions/8475448/find-merge-commit-which-include-a-specific-commit
+    """
+    commit_range = "{}..{}".format(commit, branch)
+    ancestry_paths = git.rev_list(commit_range, ancestry_path=True).splitlines()
+    first_parents = git.rev_list(commit_range, first_parent=True).splitlines()
+    both = set(ancestry_paths) & set(first_parents)
+    for commit_hash in reversed(ancestry_paths):
+        if commit_hash in both:
+            return repo.commit(commit_hash)
+    raise ValueError("No merge commit for {commit} in {branch}!".format(
+        commit=commit, branch=branch,
+    ))
+
+def get_prs_for_commit_range(commit_range):
+    """
+    Returns a set of pull requests (integers) that contain all the commits
+    in the given commit range.
+    """
+    pull_requests = set()
+    for commit in Commit.iter_items(repo, commit_range):
+        # ignore merge commits
+        if len(commit.parents) > 1:
+            continue
+        pull_requests.add(get_pr_for_commit(commit))
+    return pull_requests
+
+
+def prs_by_email(commit_range):
+    """
+    Returns an ordered dictionary of {email: pr_list}
+    Email is the email address of the person who merged the pull request
+    The dictionary is alphabetically ordered by email address
+    The pull request list is ordered by merge date
+    """
+    unordered_data = defaultdict(set)
+    for pr_num in get_prs_for_commit_range(commit_range):
+        ref = "refs/remotes/origin/pr/{num}".format(num=pr_num)
+        branch = SymbolicReference(repo, ref)
+        merge = get_merge_commit(branch.commit)
+        unordered_data[merge.author.email].add((pr_num, merge))
+
+    ordered_data = OrderedDict()
+    for email in sorted(unordered_data.keys()):
+        ordered = sorted(unordered_data[email], key=lambda pair: pair[1].authored_date)
+        ordered_data[email] = [num for num, merge in ordered]
+    return ordered_data
+
+
+def generate_table_by_commit(commit_range, include_merge=False):
     """
     Return a string corresponding to a commit table to embed in Confluence
     """
-    header = u"||Author||Summary||Commit||JIRA||Verified?||"
+    header = "||Author||Summary||Commit||JIRA||Verified?||"
     commit_link = "[commit|https://github.com/edx/edx-platform/commit/{sha}]"
     rows = [header]
     cbe = commits_by_email(commit_range, include_merge)
     for email, commits in cbe.items():
         for i, commit in enumerate(commits):
-            rows.append(u"| {author} | {summary} | {commit} | {jira} | {verified} |".format(
+            rows.append("| {author} | {summary} | {commit} | {jira} | {verified} |".format(
                 author=email if i == 0 else "",
                 summary=commit.summary.replace("|", "\|"),
                 commit=commit_link.format(sha=commit.hexsha),
                 jira=", ".join(parse_ticket_references(commit.message)),
                 verified="",
             ))
-    return u"\n".join(rows)
+    return "\n".join(rows)
+
+
+def get_pr_info(num):
+    """
+    Returns the info from the Github API
+    """
+    url = "https://api.github.com/repos/edx/edx-platform/pulls/{num}".format(num=num)
+    response = requests.get(url)
+    result = response.json()
+    if not response.ok:
+        raise requests.exceptions.RequestException(result["message"])
+    return result
+
+
+def generate_table_by_pr(commit_range):
+    """
+    Return a string corresponding to a commit table to embed in Confluence
+    """
+    header = "|| Merged By || Title || PR || JIRA || Verified? ||"
+    pr_link = "[#{num}|https://github.com/edx/edx-platform/pull/{num}]"
+    rows = [header]
+    prbe = prs_by_email(commit_range)
+    for email, pull_requests in prbe.items():
+        for i, pull_request in enumerate(pull_requests):
+            try:
+                pr_info = get_pr_info(pull_request)
+                title = pr_info["title"] or ""
+                body = pr_info["body"] or ""
+            except requests.exceptions.RequestException as e:
+                print(
+                    "Warning: could not fetch data for #{num}: {message}".format(
+                        num=pull_request, message=e.message
+                    ),
+                    file=sys.stderr,
+                )
+                title = "?"
+                body = "?"
+            rows.append("| {merged_by} | {title} | {pull_request} | {jira} | {verified} |".format(
+                merged_by=email if i == 0 else "",
+                title=title.replace("|", "\|"),
+                pull_request=pr_link.format(num=pull_request),
+                jira=", ".join(parse_ticket_references(body)),
+                verified="",
+            ))
+    return "\n".join(rows)
 
 
 def generate_email(commit_range, release_date=None):
@@ -149,7 +301,10 @@ def main():
     commit_range = "{0}..{1}".format(args.previous, args.current)
 
     if args.table:
-        print(generate_table(commit_range, include_merge=args.merge))
+        if args.commit_table:
+            print(generate_table_by_commit(commit_range, include_merge=args.merge))
+        else:
+            print(generate_table_by_pr(commit_range))
         return
 
     print("EMAIL:")
@@ -161,7 +316,10 @@ def main():
         "in your release wiki page"
     )
     print("\n")
-    print(generate_table(commit_range, include_merge=args.merge).encode('UTF-8'))
+    if args.commit_table:
+        print(generate_table_by_commit(commit_range, include_merge=args.merge))
+    else:
+        print(generate_table_by_pr(commit_range))
 
 if __name__ == "__main__":
     main()

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,13 +45,16 @@ def make_parser():
 
 
 def ensure_pr_fetch():
+    remotes = git.remote().splitlines()
+    if not "edx" in remotes:
+        git.remote("add", "edx", "https://github.com/edx/edx-platform.git")
     # it would be nice to use the git-python API to do this, but it doesn't seem
     # to support configurations with more than one value per key. :(
     edx_fetches = git.config("remote.edx.fetch", get_all=True).splitlines()
     pr_fetch = '+refs/pull/*/head:refs/remotes/edx/pr/*'
     if pr_fetch not in edx_fetches:
         git.config("remote.edx.fetch", pr_fetch, add=True)
-        git.fetch()
+        git.fetch("edx")
 
 
 def default_release_date():

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -15,7 +15,6 @@ from collections import OrderedDict, defaultdict
 import textwrap
 import requests
 
-IGNORED_EMAILS = set(("vagrant@precise32.(none)",))
 JIRA_RE = re.compile(r"\b[A-Z]{2,}-\d+\b")
 PR_BRANCH_RE = re.compile(r"remotes/edx/pr/(\d+)")
 PROJECT_ROOT = path(__file__).abspath().dirname()


### PR DESCRIPTION
Rather than making a release table on a per-commit basis, its more concise to make it on a per-pull-request basis. This also ensures that core committers verify the pull requests they have merged from external committers.

@cpennington @hkim823  Can you two review this?
