### PR TITLE
Show error page templates on Studio

### DIFF
--- a/cms/urls.py
+++ b/cms/urls.py
@@ -140,3 +140,9 @@ if settings.DEBUG:
 # pylint: disable=C0103
 handler404 = 'contentstore.views.render_404'
 handler500 = 'contentstore.views.render_500'
+
+# display error page templates, for testing purposes
+urlpatterns += (
+    url(r'404', handler404),
+    url(r'500', handler500),
+)


### PR DESCRIPTION
This allows you to go to `/500` on Studio and see the 500 error page (and the same thing for `/404` with 404 errors). We already have this for the LMS, so it should exist on Studio too.
