### PR TITLE
Changes for Help Modal to work on Stanford Site

### DIFF
--- a/lms/static/sass/base/_base.scss
+++ b/lms/static/sass/base/_base.scss
@@ -225,7 +225,7 @@ mark {
 .help-tab {
   @include transform(rotate(-90deg));
   @include transform-origin(0 0);
-  top: 50%;
+  top: 250px;
   left: 0;
   position: fixed;
   z-index: 99;
@@ -244,7 +244,7 @@ mark {
 
     &:hover, &:focus {
       color: #fff;
-      background: #1D9DD9;
+      background: $link-color;
     }
   }
 }
@@ -273,13 +273,24 @@ mark {
 
     &:hover, &:focus {
       color: #fff;
-      background: #1D9DD9;
+      background: $link-color;
     }
   }
 }
 
-#feedback_form textarea[name="details"] {
-  height: 150px;
+#feedback_form {
+  input, textarea {
+    font: normal 1em/1.4em $sans-serif;
+  }
+  textarea[name="details"] {
+    height: 150px;
+  }
+}
+
+#feedback_success_wrapper {
+  p {
+    padding: 0 20px 20px 20px;
+  }
 }
 
 // ====================

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -68,6 +68,9 @@ urlpatterns = ('',  # nopep8
     url(r'^i18n/', include('django.conf.urls.i18n')),
 
     url(r'^embargo$', 'student.views.embargo', name="embargo"),
+    
+    # Feedback Form endpoint
+    url(r'^submit_feedback$', 'util.views.submit_feedback'),
 )
 
 # if settings.FEATURES.get("MULTIPLE_ENROLLMENT_ROLES"):
@@ -122,9 +125,6 @@ if not settings.FEATURES["USE_CUSTOM_THEME"]:
 
         # Favicon
         (r'^favicon\.ico$', 'django.views.generic.simple.redirect_to', {'url': '/static/images/favicon.ico'}),
-
-        url(r'^submit_feedback$', 'util.views.submit_feedback'),
-
     )
 
 # Only enable URLs for those marketing links actually enabled in the


### PR DESCRIPTION
- moved zendesk outside of theme condition
- improved help modal styling

Before:
![screen shot 2014-05-05 at 11 30 07 am](https://cloud.githubusercontent.com/assets/3364609/2882577/4320661e-d490-11e3-9d43-62a5b9725adb.png)

After:
![screen shot 2014-05-05 at 11 29 06 am](https://cloud.githubusercontent.com/assets/3364609/2882579/47ae3d64-d490-11e3-9747-fbb0da66c3b1.png)
