### PR TITLE
Rebalance CMS acceptance test shards

### DIFF
--- a/cms/djangoapps/contentstore/features/video_editor.feature
+++ b/cms/djangoapps/contentstore/features/video_editor.feature
@@ -1,4 +1,4 @@
-@shard_3
+@shard_1
 Feature: CMS Video Component Editor
   As a course author, I want to be able to create video components
 


### PR DESCRIPTION
Shard 3 of the CMS acceptance tests was starting to take way longer than 1 and 2.
E.g. for a current build of master Shards 1, 2, 3: 26 min, 36 min, 41 min.

This moves about 8 minutes from shard 3 to shard 1.

@polesye FYI.
@clytwynec pls review.
