### PR TITLE
Ensure system language is released in dark lang middleware

### DIFF
--- a/common/djangoapps/dark_lang/middleware.py
+++ b/common/djangoapps/dark_lang/middleware.py
@@ -10,6 +10,7 @@ in the user's session.
 This middleware must be placed before the LocaleMiddleware, but after
 the SessionMiddleware.
 """
+from django.conf import settings
 
 from django.utils.translation.trans_real import parse_accept_lang_header
 
@@ -33,6 +34,7 @@ def dark_parse_accept_lang_header(accept):
     for lang, priority in browser_langs:
         lang = CHINESE_LANGUAGE_CODE_MAP.get(lang.lower(), lang)
         django_langs.append((lang, priority))
+
     return django_langs
 
 # If django 1.7 or higher is used, the right-side can be updated with new-style codes.
@@ -65,7 +67,10 @@ class DarkLangMiddleware(object):
         """
         Current list of released languages
         """
-        return DarkLangConfig.current().released_languages_list
+        language_options = DarkLangConfig.current().released_languages_list
+        if settings.LANGUAGE_CODE not in language_options:
+            language_options.append(settings.LANGUAGE_CODE)
+        return language_options
 
     def process_request(self, request):
         """

--- a/common/djangoapps/dark_lang/tests.py
+++ b/common/djangoapps/dark_lang/tests.py
@@ -93,6 +93,12 @@ class DarkLangMiddlewareTests(TestCase):
             self.process_request(accept='rel;q=1.0, unrel;q=0.5')
         )
 
+    def test_accept_with_syslang(self):
+        self.assertAcceptEquals(
+            'en;q=1.0, rel;q=0.8',
+            self.process_request(accept='en;q=1.0, rel;q=0.8, unrel;q=0.5')
+        )
+
     def test_accept_multiple_released_langs(self):
         DarkLangConfig(
             released_languages=('rel, unrel'),


### PR DESCRIPTION
LMS-2644

@adampalay this is the change that should be made; it mirrors logic in `common/djangoapps/student/views.py:523`
