### PR TITLE
SymbolicResponse i18n.

### DIFF
--- a/common/lib/capa/capa/responsetypes.py
+++ b/common/lib/capa/capa/responsetypes.py
@@ -1778,9 +1778,14 @@ class SymbolicResponse(CustomResponse):
                 debug=self.context.get('debug'),
             )
         except Exception as err:
-            log.error("oops in symbolicresponse (cfn) error %s", err)
+            log.error("oops in SymbolicResponse (cfn) error %s", err)
             log.error(traceback.format_exc())
-            raise Exception("oops in symbolicresponse (cfn) error %s", err)
+            _ = self.capa_system.i18n.ugettext
+            # Translators: 'SymbolicResponse' is a problem type and should not be translated.
+            msg = _(u"oops in SymbolicResponse (cfn) error {error_msg}").format(
+                error_msg=err,
+            )
+            raise Exception(msg)
         self.context['messages'][0] = self.clean_message_html(ret['msg'])
         self.context['correct'] = ['correct' if ret['ok'] else 'incorrect'] * len(idset)
 


### PR DESCRIPTION
Ticket [BLD-721](https://edx-wiki.atlassian.net/browse/BLD-721)

Result for SymbolicResponse:

```
#. Translators: 'SymbolicResponse' is a problem type and should not be
#. translated.
#: common/lib/capa/capa/responsetypes.py:1786
msgid "oops in SymbolicResponse (cfn) error"
msgstr ""
```

@olmar please review.
