### PR TITLE
Fix for Codemirror overflowing Multiple Choice modal

### DIFF
--- a/cms/static/sass/elements/_modal-window.scss
+++ b/cms/static/sass/elements/_modal-window.scss
@@ -179,10 +179,6 @@
       height: 365px;
     }
 
-    &.modal-type-problem .CodeMirror {
-      height: 435px;
-    }
-
     .wrapper-comp-settings {
 
       .list-input {


### PR DESCRIPTION
Resizing codemirror to fit with the toolbar when editing Studio problem components (Multiple Choice). @andy-armstrong can you review?
