### PR TITLE
Return HttpResponseServerError for exceptions in xqueue_callback.

### DIFF
--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -106,7 +106,7 @@ class ModuleRenderTestCase(ModuleStoreTestCase, LoginEnrollmentTestCase):
         """
         fake_key = 'fake key'
         xqueue_header = json.dumps({'lms_key': fake_key})
-        data = {
+        post_data = {
             'xqueue_header': xqueue_header,
             'xqueue_body': 'hello world',
         }
@@ -115,15 +115,19 @@ class ModuleRenderTestCase(ModuleStoreTestCase, LoginEnrollmentTestCase):
         with patch('courseware.module_render.find_target_student_module') as get_fake_module:
             get_fake_module.return_value = self.mock_module
             # call xqueue_callback with our mocked information
-            request = self.request_factory.post(self.callback_url, data)
-            render.xqueue_callback(request, self.course_id, self.mock_user.id, self.mock_module.id, self.dispatch)
+            request = self.request_factory.post(self.callback_url, post_data)
+            response = render.xqueue_callback(request, self.course_id, self.mock_user.id, self.mock_module.id, self.dispatch)
+            self.assertEqual(response.status_code, 200)
 
         # Verify that handle ajax is called with the correct data
         request.POST['queuekey'] = fake_key
         self.mock_module.handle_ajax.assert_called_once_with(self.dispatch, request.POST)
 
     def test_xqueue_callback_missing_header_info(self):
-        data = {
+        """
+        Test xqueue_callback when header info is missing or incomplete.
+        """
+        post_data = {
             'xqueue_header': '{}',
             'xqueue_body': 'hello world',
         }
@@ -137,8 +141,27 @@ class ModuleRenderTestCase(ModuleStoreTestCase, LoginEnrollmentTestCase):
 
             # Test with missing xqueue_header
             with self.assertRaises(Http404):
-                request = self.request_factory.post(self.callback_url, data)
+                request = self.request_factory.post(self.callback_url, post_data)
                 render.xqueue_callback(request, self.course_id, self.mock_user.id, self.mock_module.id, self.dispatch)
+
+    def test_xqueue_callback_save_error(self):
+        """
+        Test xqueue_callback when module.handle_ajax() or module.save() raises an exception.
+        """
+        fake_key = 'fake key'
+        xqueue_header = json.dumps({'lms_key': fake_key})
+        post_data = {
+            'xqueue_header': xqueue_header,
+            'xqueue_body': 'hello world',
+        }
+
+        with patch('courseware.module_render.find_target_student_module') as get_fake_module:
+            self.mock_module.save = MagicMock(side_effect=Exception)
+            get_fake_module.return_value = self.mock_module
+            # call xqueue_callback with our mocked information
+            request = self.request_factory.post(self.callback_url, post_data)
+            response = render.xqueue_callback(request, self.course_id, self.mock_user.id, self.mock_module.id, self.dispatch)
+            self.assertEqual(response.status_code, 500)
 
     def test_get_score_bucket(self):
         self.assertEquals(render.get_score_bucket(0, 10), 'incorrect')


### PR DESCRIPTION
Uncaught exceptions also result in a `HttpResponseServerError` but this is cleaner.

LMS-2619
