### PR TITLE
Use local storage instead of S3 for uploads in devstack.

### DIFF
--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -4,6 +4,10 @@ Specific overrides to the base prod settings to make development easier.
 
 from .aws import * # pylint: disable=wildcard-import, unused-wildcard-import
 
+# Don't use S3 in devstack, fall back to filesystem
+del DEFAULT_FILE_STORAGE
+MEDIA_ROOT = "/edx/app/edxapp/media"
+
 DEBUG = True
 USE_I18N = True
 TEMPLATE_DEBUG = DEBUG

--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -6,7 +6,7 @@ from .aws import * # pylint: disable=wildcard-import, unused-wildcard-import
 
 # Don't use S3 in devstack, fall back to filesystem
 del DEFAULT_FILE_STORAGE
-MEDIA_ROOT = "/edx/app/edxapp/media"
+MEDIA_ROOT = "/edx/var/edxapp/uploads"
 
 DEBUG = True
 USE_I18N = True

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -6,7 +6,7 @@ from .aws import * # pylint: disable=wildcard-import, unused-wildcard-import
 
 # Don't use S3 in devstack, fall back to filesystem
 del DEFAULT_FILE_STORAGE
-MEDIA_ROOT = "/edx/app/edxapp/media"
+MEDIA_ROOT = "/edx/var/edxapp/uploads"
 
 
 DEBUG = True

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -4,6 +4,11 @@ Specific overrides to the base prod settings to make development easier.
 
 from .aws import * # pylint: disable=wildcard-import, unused-wildcard-import
 
+# Don't use S3 in devstack, fall back to filesystem
+del DEFAULT_FILE_STORAGE
+MEDIA_ROOT = "/edx/app/edxapp/media"
+
+
 DEBUG = True
 USE_I18N = True
 TEMPLATE_DEBUG = True


### PR DESCRIPTION
In doing some development in the devstack using the file storage API, I noticed it is configured by default to use S3, which doesn't really work for common development.  This pull request modified the devstack configuration only to use a local file storage for uploads.
