### PR TITLE
Don't fetch the course just to find out if the user has access to it.

### DIFF
--- a/lms/djangoapps/courseware/tests/test_access.py
+++ b/lms/djangoapps/courseware/tests/test_access.py
@@ -32,47 +32,47 @@ class AccessTestCase(TestCase):
         self.course_instructor = InstructorFactory(course=self.course.course_key)
 
     def test__has_access_to_location(self):
-        self.assertFalse(access._has_access_to_location(
-            None, 'staff', self.course, self.course.course_key
+        self.assertFalse(access._has_access_to_course(
+            None, 'staff', self.course.course_key
         ))
 
-        self.assertFalse(access._has_access_to_location(
-            self.anonymous_user, 'staff', self.course, self.course.course_key
+        self.assertFalse(access._has_access_to_course(
+            self.anonymous_user, 'staff', self.course.course_key
         ))
-        self.assertFalse(access._has_access_to_location(
-            self.anonymous_user, 'instructor', self.course, self.course.course_key
+        self.assertFalse(access._has_access_to_course(
+            self.anonymous_user, 'instructor', self.course.course_key
         ))
 
-        self.assertTrue(access._has_access_to_location(
-            self.global_staff, 'staff', self.course, self.course.course_key
+        self.assertTrue(access._has_access_to_course(
+            self.global_staff, 'staff', self.course.course_key
         ))
-        self.assertTrue(access._has_access_to_location(
-            self.global_staff, 'instructor', self.course, self.course.course_key
+        self.assertTrue(access._has_access_to_course(
+            self.global_staff, 'instructor', self.course.course_key
         ))
 
         # A user has staff access if they are in the staff group
-        self.assertTrue(access._has_access_to_location(
-            self.course_staff, 'staff', self.course, self.course.course_key
+        self.assertTrue(access._has_access_to_course(
+            self.course_staff, 'staff', self.course.course_key
         ))
-        self.assertFalse(access._has_access_to_location(
-            self.course_staff, 'instructor', self.course, self.course.course_key
+        self.assertFalse(access._has_access_to_course(
+            self.course_staff, 'instructor', self.course.course_key
         ))
 
         # A user has staff and instructor access if they are in the instructor group
-        self.assertTrue(access._has_access_to_location(
-            self.course_instructor, 'staff', self.course, self.course.course_key
+        self.assertTrue(access._has_access_to_course(
+            self.course_instructor, 'staff', self.course.course_key
         ))
-        self.assertTrue(access._has_access_to_location(
-            self.course_instructor, 'instructor', self.course, self.course.course_key
+        self.assertTrue(access._has_access_to_course(
+            self.course_instructor, 'instructor', self.course.course_key
         ))
 
         # A user does not have staff or instructor access if they are
         # not in either the staff or the the instructor group
-        self.assertFalse(access._has_access_to_location(
-            self.student, 'staff', self.course, self.course.course_key
+        self.assertFalse(access._has_access_to_course(
+            self.student, 'staff', self.course.course_key
         ))
-        self.assertFalse(access._has_access_to_location(
-            self.student, 'instructor', self.course, self.course.course_key
+        self.assertFalse(access._has_access_to_course(
+            self.student, 'instructor', self.course.course_key
         ))
 
     def test__has_access_string(self):


### PR DESCRIPTION
@cpennington @sarina same pr but w/o pulling other changes in. To not fetch course just to see if the user has staff or instructor access and to clean up some signatures which had unnecessary args.
