### PR TITLE
IGNORABLE_404_ENDS is wrong and unused

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -260,7 +260,6 @@ SITE_ID = 1
 SITE_NAME = "localhost:8001"
 HTTPS = 'on'
 ROOT_URLCONF = 'cms.urls'
-IGNORABLE_404_ENDS = ('favicon.ico')
 
 # Email
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -521,7 +521,6 @@ SITE_ID = 1
 SITE_NAME = "edx.org"
 HTTPS = 'on'
 ROOT_URLCONF = 'lms.urls'
-IGNORABLE_404_ENDS = ('favicon.ico')
 # NOTE: Please set ALLOWED_HOSTS to some sane value, as we do not allow the default '*'
 
 # Platform Email


### PR DESCRIPTION
This setting is only used if SEND_BROKEN_LINK_EMAILS is true, which it
is not, and it is deprecated, and this value for it is wrong, since it
is used as an iterable.
