### PR TITLE
Fix dashboard template around final grade status

### DIFF
--- a/lms/templates/dashboard/_dashboard_certificate_information.html
+++ b/lms/templates/dashboard/_dashboard_certificate_information.html
@@ -24,11 +24,8 @@ else:
 %>
 <div class="message message-status ${status_css_class} is-shown">
 
-% if cert_status['status'] == 'processing' and not course.may_certify():
+% if cert_status['status'] == 'processing':
       <p class="message-copy">${_("Final course details are being wrapped up at this time. Your final standing will be available shortly.")}</p>
-% elif course.may_certify() and cert_status['status'] == 'processing':
-      <!-- Certification is allowed but no cert requested, or cert unearned -->
-      <!-- <p class="message-copy">${_("Your final standing is unrequested or unavailable at this time.")}</p> -->
 % elif cert_status['status'] in ('generating', 'ready', 'notpassing', 'restricted'):
       <p class="message-copy">${_("Your final grade:")}
       <span class="grade-value">${"{0:.0f}%".format(float(cert_status['grade'])*100)}</span>.


### PR DESCRIPTION
- ae8847cd6e73 checked in buggy conditional in the dashboard templates that caused an empty 'details being wrapped up' box to display regardless of whether it was true.
- Simplify conditional so that we care only whether output of the view's _cert_info() says 'processing', which should be the value computed when either no cert status exists or when the certs are, in fact processing.  This should mean that the "details being wrapped up" message is displayed when certs haven't run and the grade box is displayed the rest of the time.

@adampalay and @dianakhuang please.

The thing that makes this more complicated to understand than first impressions is that the cert_status values 'processing', 'ready', etc. are only loosely related to the the user's actual certificate status. This value is actually computed by common/djangoapps/student/views.py:290:_cert_info(), which longs for cleanup.
