### PR TITLE
Redirected to dashboard if course mode is none.

### DIFF
--- a/lms/djangoapps/verify_student/tests/test_views.py
+++ b/lms/djangoapps/verify_student/tests/test_views.py
@@ -81,6 +81,34 @@ class TestVerifyView(TestCase):
 
 
 @override_settings(MODULESTORE=TEST_DATA_MONGO_MODULESTORE)
+class TestVerifiedView(TestCase):
+    """
+    Tests for VerifiedView.
+    """
+    def setUp(self):
+        self.user = UserFactory.create(username="abc", password="test")
+        self.client.login(username="abc", password="test")
+        self.course_id = "MITx/999.1x/Verified_Course"
+        self.course = CourseFactory.create(org='MITx', number='999.1x', display_name='Verified Course')
+
+    def test_verified_course_mode_none(self):
+        """
+        Test VerifiedView when there is no active verified mode for course.
+        """
+        url = reverse('verify_student_verified', kwargs={"course_id": self.course_id})
+
+        verify_mode = CourseMode.mode_for_course(self.course_id, "verified")
+        # Verify mode should be None.
+        self.assertEquals(verify_mode, None)
+
+        response = self.client.get(url)
+        # Status code should be 302.
+        self.assertTrue(response.status_code, 302)
+        # Location should contains dashboard.
+        self.assertIn('dashboard', response._headers.get('location')[1])
+
+
+@override_settings(MODULESTORE=TEST_DATA_MONGO_MODULESTORE)
 class TestReverifyView(TestCase):
     """
     Tests for the reverification views

--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -117,6 +117,8 @@ class VerifiedView(View):
         if CourseEnrollment.enrollment_mode_for_user(request.user, course_id) == 'verified':
             return redirect(reverse('dashboard'))
         verify_mode = CourseMode.mode_for_course(course_id, "verified")
+        if verify_mode is None:
+            return redirect(reverse('dashboard'))
         if course_id in request.session.get("donation_for_course", {}):
             chosen_price = request.session["donation_for_course"][course_id]
         else:


### PR DESCRIPTION
LMS-2617

If some one goes to verified url after expiration date passed on a verified course server gives an error because course mode is 'None' for this course after expiration.

Student redirected to dashboard.
