### PR TITLE
Remove default message from conditional module

### DIFF
--- a/common/lib/xmodule/xmodule/conditional_module.py
+++ b/common/lib/xmodule/xmodule/conditional_module.py
@@ -154,7 +154,8 @@ class ConditionalModule(ConditionalFields, XModule):
         an AJAX call.
         """
         if not self.is_condition_satisfied():
-            defmsg = "{link} must be attempted before this will become visible."
+            # a message attribute can be added to the <conditional> tag...
+            defmsg = ""
             message = self.descriptor.xml_attributes.get('message', defmsg)
             context = {'module': self,
                        'message': message}


### PR DESCRIPTION
A message can be added in the XML <conditional> tag, ex: 

```
<conditional sources="i4x://THE/COURSE/TRIPLE/######" message="This message is editable in the corresponding conditional file for the vertical" correct="True">
    <html url_name="######"/>
    <problem url_name="######"/>
</conditional>
```

Example of where the message appears, and where the other message is ugly:

![screen shot 2014-05-07 at 2 07 37 pm](https://cloud.githubusercontent.com/assets/3364609/2908803/bfa2d64e-d62b-11e3-80d1-6c2cef829758.png)
