### PR TITLE
add max_attempts to inheritance.py (LMS-2130)

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/inheritance.py
+++ b/common/lib/xmodule/xmodule/modulestore/inheritance.py
@@ -5,7 +5,7 @@ Support for inheritance of fields down an XBlock hierarchy.
 from datetime import datetime
 from pytz import UTC
 
-from xblock.fields import Scope, Boolean, String, Float, XBlockMixin, Dict
+from xblock.fields import Scope, Boolean, String, Float, XBlockMixin, Dict, Integer
 from xblock.runtime import KeyValueStore, KvsFieldData
 
 from xmodule.fields import Date, Timedelta
@@ -78,7 +78,15 @@ class InheritanceMixin(XBlockMixin):
     use_latex_compiler = Boolean(
         help="Enable LaTeX templates?",
         default=False,
-        scope=Scope.settings)
+        scope=Scope.settings
+    )
+    max_attempts = Integer(
+        display_name="Maximum Attempts",
+        help=("Defines the number of times a student can try to answer this problem. "
+              "If the value is not set, infinite attempts are allowed."),
+        values={"min": 0}, scope=Scope.settings
+    )
+
 
 
 def compute_inherited_metadata(descriptor):

--- a/common/lib/xmodule/xmodule/tests/test_xml_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_xml_module.py
@@ -538,14 +538,14 @@ class TestXmlAttributes(XModuleXmlImportTest):
         # name)
         assert_in('attempts', seq.xml_attributes)
 
-    def test_inheritable_attribute(self):
-        # days_early_for_beta isn't a basic attribute of Sequence
-        assert_false(hasattr(SequenceDescriptor, 'days_early_for_beta'))
+    def check_inheritable_attribute(self, attribute, value):
+        # `attribute` isn't a basic attribute of Sequence
+        assert_false(hasattr(SequenceDescriptor, attribute))
 
-        # days_early_for_beta is added by InheritanceMixin
-        assert_true(hasattr(InheritanceMixin, 'days_early_for_beta'))
+        # `attribute` is added by InheritanceMixin
+        assert_true(hasattr(InheritanceMixin, attribute))
 
-        root = SequenceFactory.build(policy={'days_early_for_beta': '2'})
+        root = SequenceFactory.build(policy={attribute: str(value)})
         ProblemFactory.build(parent=root)
 
         # InheritanceMixin will be used when processing the XML
@@ -556,10 +556,14 @@ class TestXmlAttributes(XModuleXmlImportTest):
         assert_equals(seq.unmixed_class, SequenceDescriptor)
         assert_not_equals(type(seq), SequenceDescriptor)
 
-        # days_early_for_beta is added to the constructed sequence, because
+        # `attribute` is added to the constructed sequence, because
         # it's in the InheritanceMixin
-        assert_equals(2, seq.days_early_for_beta)
+        assert_equals(value, getattr(seq, attribute))
 
-        # days_early_for_beta is a known attribute, so we shouldn't include it
+        # `attribute` is a known attribute, so we shouldn't include it
         # in xml_attributes
-        assert_not_in('days_early_for_beta', seq.xml_attributes)
+        assert_not_in(attribute, seq.xml_attributes)
+
+    def test_inheritable_attributes(self):
+        self.check_inheritable_attribute('days_early_for_beta', 2)
+        self.check_inheritable_attribute('max_attempts', 5)


### PR DESCRIPTION
@symbolist 
@cpennington 

this adds `max_attempts` to inheritance.py so that xml-authored courses can set this attribute at the sequential level
