### PR TITLE
Remove unicode character inserted into video_xfields

### DIFF
--- a/common/lib/xmodule/xmodule/video_module/video_xfields.py
+++ b/common/lib/xmodule/xmodule/video_module/video_xfields.py
@@ -79,7 +79,7 @@ class VideoFields(object):
         default=False
     )
     html5_sources = List(
-        help="The URL or URLs where you’ve posted non-YouTube versions of the video. Each URL must end in .mpeg, .mp4, .ogg, or .webm and cannot be a YouTube URL. Students will be able to view the first listed video that's compatible with the student's computer. To allow students to download these videos, set Video Download Allowed to True.",
+        help="The URL or URLs where you've posted non-YouTube versions of the video. Each URL must end in .mpeg, .mp4, .ogg, or .webm and cannot be a YouTube URL. Students will be able to view the first listed video that's compatible with the student's computer. To allow students to download these videos, set Video Download Allowed to True.",
         display_name="Video File URLs",
         scope=Scope.settings,
     )


### PR DESCRIPTION
Fixes unicode character added with https://github.com/edx/edx-platform/commit/c1ef41fe6af55afa2c460ff2b4952401df6ab575#diff-828847f33fdd8417f882876864fcf359R82

Fixes this error:

```
File "/Users/sarina/edx_all/edx-platform/common/lib/xmodule/xmodule/video_module/video_xfields.py", line 82
SyntaxError: Non-ASCII character '\xe2' in file /Users/sarina/edx_all/edx-platform/common/lib/xmodule/xmodule/video_module/video_xfields.py on line 82, but no encoding declared; see http://www.python.org/peps/pep-0263.html for details
```
