### PR TITLE
Add 'roles' endpoint to user_api

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -148,3 +148,4 @@ Sébastien Hinderer <Sebastien.Hinderer@inria.fr>
 Kristin Stephens <ksteph@cs.berkeley.edu>
 Ben Patterson <bpatterson@edx.org>
 Luis Duarte <lduarte1991@gmail.com>
+Steven Burch <stv@stanford.edu>

--- a/common/djangoapps/user_api/urls.py
+++ b/common/djangoapps/user_api/urls.py
@@ -14,4 +14,8 @@ urlpatterns = patterns(
         r'^v1/preferences/(?P<pref_key>{})/users/$'.format(UserPreference.KEY_REGEX),
         user_api_views.PreferenceUsersListView.as_view()
     ),
+    url(
+        r'^v1/forum_roles/(?P<name>[a-zA-Z]+)/users/$',
+        user_api_views.ForumRoleUsersListView.as_view()
+    ),
 )


### PR DESCRIPTION
This PR extends the `user_api` by creating a new endpoint for
querying forum roles.

@jbau 
