### PR TITLE
(WIP) Fix jump_to_id links returning 404 for private units in preview

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -151,3 +151,4 @@ Steven Burch <stv@stanford.edu>
 Waqas Khalid <wkhalid@edx.org>
 Muhammad Ammar <mammar@edx.org>
 Abdallah Nassif <abdoosh00@gmail.com>
+Ivan Mirić <imiric@gmail.com>

--- a/common/lib/xmodule/xmodule/modulestore/search.py
+++ b/common/lib/xmodule/xmodule/modulestore/search.py
@@ -24,6 +24,10 @@ def path_to_location(modulestore, usage_key):
     If the section is a sequential or vertical, position will be the children index
     of this location under that sequence.
     '''
+    if not modulestore.has_item(usage_key):
+        raise ItemNotFoundError(usage_key)
+
+    usage_key = usage_key.replace(revision=None)
 
     def flatten(xs):
         '''Convert lisp-style (a, (b, (c, ()))) list into a python list.
@@ -71,9 +75,6 @@ def path_to_location(modulestore, usage_key):
 
         # If we're here, there is no path
         return None
-
-    if not modulestore.has_item(usage_key):
-        raise ItemNotFoundError(usage_key)
 
     path = find_path_to_course()
     if path is None:


### PR DESCRIPTION
Hi,

this fixes an issue with resolving `jump_to_id` links to private units in LMS preview mode.

To reproduce:
1. Create a new private unit (in Studio).
2. Link to it from a public unit with `/jump_to_id/<unit ID>`.
3. View the course in preview mode and click on the `jump_to_id` link.

Before:
- The link would return 404.

After:
- The link will resolve and redirect to the private unit properly.

~~I wasn't able to add tests for this, as I'm not sure how to create private/draft units in the XML notation. I read through the [documentation](http://edx.readthedocs.org/en/latest/course_data_formats/course_xml.html), but specifying neither `"ispublic": "false"` nor a future start date in the course policy file seemed to reproduce the 404 in the `TestJumpTo` tests. So I could use some help with adding a test case for this.~~ Added test case in 15dfd2f.

Thanks!

Internal edX bugtracker reference: STUD-150
cc: @antoviaque

P.S.: This is my first time contributing, so let me know if I messed something up. :) I marked it as WIP because I wanted to get your feedback on if this is the right approach, but otherwise this fix is functional.
P.P.S: I've already sent the signed Contributor Agreement.
