### PR TITLE
Anton/video player grading

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -132,6 +132,11 @@
         "readFixtures",
         "setFixtures",
         "appendSetFixtures",
-        "spyOnEvent"
+        "spyOnEvent",
+
+        // i18n
+        "gettext",
+        "ngettext",
+        "interpolate",
     ]
 }

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ These are notable changes in edx-platform.  This is a rolling list of changes,
 in roughly chronological order, most recent first.  Add your entries at or near
 the top.  Include a label indicating the component affected.
 
+Blades: Add video player grading. BLD-1020.
+
 All: refactored code to handle course_ids, module_ids, etc in a cleaner way.
 See https://github.com/edx/edx-platform/wiki/Opaque-Keys for details. 
 

--- a/cms/djangoapps/contentstore/features/video_editor.feature
+++ b/cms/djangoapps/contentstore/features/video_editor.feature
@@ -5,6 +5,7 @@ Feature: CMS Video Component Editor
   # 1
   Scenario: User can view Video metadata
     Given I have created a Video component
+    And I have enabled video grading
     And I edit the component
     Then I see the correct video settings and default values
 

--- a/cms/djangoapps/contentstore/features/video_editor.py
+++ b/cms/djangoapps/contentstore/features/video_editor.py
@@ -8,6 +8,7 @@ from nose.tools import assert_true, assert_equal, assert_in, assert_not_equal # 
 from terrain.steps import reload_the_page
 from django.conf import settings
 from common import upload_file, attach_file
+from advanced_settings import change_value
 
 TEST_ROOT = settings.COMMON_TEST_DATA_ROOT
 
@@ -150,8 +151,12 @@ def correct_video_settings(_step):
         ['Upload Handout', '', False],
         ['Video Download Allowed', 'False', False],
         ['Video File URLs', '', False],
+        ['Video Is Scored', 'False', False],
+        ['Video Is Scored When Viewed', 'False', False],
+        ['Video Percent to View', '', False],
         ['Video Start Time', '00:00:00', False],
         ['Video Stop Time', '00:00:00', False],
+        ['Weight', '1', False],
         ['YouTube ID', 'OEoXaMPEzfM', False],
         ['YouTube ID for .75x speed', '', False],
         ['YouTube ID for 1.25x speed', '', False],
@@ -306,3 +311,12 @@ def i_see_correct_langs(_step, langs):
     for lang_code, label in translations.items():
         assert_true(any([i.text == label for i in items]))
         assert_true(any([i['data-lang-code'] == lang_code for i in items]))
+
+
+@step('I have enabled video grading')
+def enable_video_grading(step):
+    url = world.browser.url
+    step.given("I select the Advanced Settings")
+    change_value(step, 'grade_videos', 'true')
+    world.visit(url)
+    world.wait_for_xmodule()

--- a/common/lib/xmodule/xmodule/css/video/display.scss
+++ b/common/lib/xmodule/xmodule/css/video/display.scss
@@ -1,9 +1,36 @@
+
 & {
     margin-bottom: 30px;
 }
 
 .is-hidden {
   display: none;
+}
+
+.video-header {
+  display: inline-block;
+}
+
+.problem-progress {
+  display: inline-block;
+  padding-left: 5px;
+  color: #666;
+  font-weight: 100;
+  font-size: em(16);
+}
+
+h4.problem-feedback-label {
+  font-weight: 100;
+  font-size: em(16);
+  font-family: "Source Sans", "Open Sans", Verdana, Geneva, sans-serif, sans-serif;
+}
+
+div.problem-feedback {
+  margin: 15px 0;
+
+  &.is-error .problem-feedback-message{
+    color: darken($error-red, 11%);
+  }
 }
 
 div.video {
@@ -16,7 +43,16 @@ div.video {
   outline: none;
 
   &:focus, &:active, &:hover {
-    border: 0;
+    border: none;
+    outline: none;
+  }
+
+  &.is-scored {
+    @include animation(gradeSuccess 2s cubic-bezier(0,0,0,1));
+  }
+
+  &.is-error {
+    @include animation(gradeError 2s cubic-bezier(0,0,0,1));
   }
 
   &.is-initialized {

--- a/common/lib/xmodule/xmodule/js/fixtures/video.html
+++ b/common/lib/xmodule/xmodule/js/fixtures/video.html
@@ -1,6 +1,7 @@
 <div class="course-content">
   <div id="video_example">
     <div id="example">
+      <div class="problem-progress">1.0 points possible</div>
       <div
         id="video_id"
         class="video closed"
@@ -65,8 +66,18 @@
 
           <ol class="subtitles"><li></li></ol>
         </div>
-
         <div class="focus_grabber last"></div>
+        <ul class="wrapper-downloads">
+          <li class="video-sources video-download-button">
+              <a href="#">Download video</a>
+          </li>
+          <li class="video-tracks video-download-button">
+            <a href="#" class="external-track">Download transcript</a>
+          </li>
+          <li class="video-handout video-download-button">
+            <a href="#" target="_blank">Download Handout</a>
+          </li>
+        </ul>
       </div>
     </div>
   </div>

--- a/common/lib/xmodule/xmodule/js/fixtures/video_all.html
+++ b/common/lib/xmodule/xmodule/js/fixtures/video_all.html
@@ -1,6 +1,7 @@
 <div class="course-content">
   <div id="video_example">
     <div id="example">
+      <div class="problem-progress">1.0 points possible</div>
       <div
         id="video_id"
         class="video closed"
@@ -72,6 +73,9 @@
         <div class="focus_grabber last"></div>
 
         <ul class="wrapper-downloads">
+          <li class="video-sources video-download-button">
+            <a href="#">Download video</a>
+          </li>
           <li class="video-tracks">
             <div class="a11y-menu-container">
                 <a class="a11y-menu-button" href="#" title=".srt">.srt</a>
@@ -85,8 +89,10 @@
                 </ol>
             </div>
           </li>
+          <li class="video-handout video-download-button">
+            <a href="#" target="_blank">Download Handout</a>
+          </li>
         </ul>
-
       </div>
     </div>
   </div>

--- a/common/lib/xmodule/xmodule/js/fixtures/video_html5.html
+++ b/common/lib/xmodule/xmodule/js/fixtures/video_html5.html
@@ -1,6 +1,7 @@
 <div class="course-content">
   <div id="video_example">
     <div id="example">
+      <div class="problem-progress">1.0 points possible</div>
       <div
         id="video_id"
         class="video closed"
@@ -25,7 +26,6 @@
         data-autohide-html5="True"
       >
         <div class="focus_grabber first"></div>
-
         <div class="tc-wrapper">
           <article class="video-wrapper">
             <span tabindex="0" class="spinner" aria-hidden="false" aria-label="${_('Loading video player')}"></span>
@@ -35,11 +35,20 @@
             </section>
             <section class="video-controls is-hidden"></section>
           </article>
-
           <ol class="subtitles"><li></li></ol>
         </div>
-
         <div class="focus_grabber last"></div>
+        <ul class="wrapper-downloads">
+          <li class="video-sources video-download-button">
+              <a href="#">Download video</a>
+          </li>
+          <li class="video-tracks video-download-button">
+            <a href="#" class="external-track">Download transcript</a>
+          </li>
+          <li class="video-handout video-download-button">
+            <a href="#" target="_blank">Download Handout</a>
+          </li>
+        </ul>
       </div>
     </div>
   </div>

--- a/common/lib/xmodule/xmodule/js/fixtures/video_no_captions.html
+++ b/common/lib/xmodule/xmodule/js/fixtures/video_no_captions.html
@@ -1,6 +1,7 @@
 <div class="course-content">
   <div id="video_example">
     <div id="example">
+      <div class="problem-progress">1.0 points possible</div>
       <div
         id="video_id"
         class="video closed"
@@ -33,8 +34,18 @@
             <section class="video-controls is-hidden"></section>
           </article>
         </div>
-
         <div class="focus_grabber last"></div>
+        <ul class="wrapper-downloads">
+          <li class="video-sources video-download-button">
+              <a href="#">Download video</a>
+          </li>
+          <li class="video-tracks video-download-button">
+            <a href="#" class="external-track">Download transcript</a>
+          </li>
+          <li class="video-handout video-download-button">
+            <a href="#" target="_blank">Download Handout</a>
+          </li>
+        </ul>
       </div>
     </div>
   </div>

--- a/common/lib/xmodule/xmodule/js/fixtures/video_yt_multiple.html
+++ b/common/lib/xmodule/xmodule/js/fixtures/video_yt_multiple.html
@@ -1,6 +1,7 @@
 <div class="course-content">
   <div id="video_example1">
     <div id="example1">
+      <div class="problem-progress">1.0 points possible</div>
       <div
         id="video_id1"
         class="video closed"
@@ -74,6 +75,7 @@
 <div class="course-content">
   <div id="video_example2">
     <div id="example2">
+      <div class="problem-progress">1.0 posits possible</div>
       <div
         id="video_id2"
         class="video"
@@ -139,6 +141,7 @@
 <div class="course-content">
   <div id="video_example3">
     <div id="example3">
+      <div class="problem-progress">1.0 posits possible</div>
       <div
         id="video_id3"
         class="video"

--- a/common/lib/xmodule/xmodule/js/spec/helper.js
+++ b/common/lib/xmodule/xmodule/js/spec/helper.js
@@ -168,6 +168,8 @@
                 return;
             } else if (settings.url === '/save_user_state') {
                 return {success: true};
+            } else if (settings.url === '/grade_url') {
+                return '0.5';
             } else if (settings.url === 'http://www.youtube.com/iframe_api') {
                 // Stub YouTube API.
                 window.YT = stubbedYT;

--- a/common/lib/xmodule/xmodule/js/spec/time_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/time_spec.js
@@ -3,6 +3,13 @@
 
     describe('Time', function () {
         describe('format', function () {
+            describe('with NAN', function () {
+                it('return a correct time format', function () {
+                    expect(Time.format('string')).toEqual('0:00');
+                    expect(Time.format(void(0))).toEqual('0:00');
+                });
+            });
+
             describe('with duration more than or equal to 1 hour', function () {
                 it('return a correct time format', function () {
                     expect(Time.format(3600)).toEqual('1:00:00');

--- a/common/lib/xmodule/xmodule/js/spec/video/grader_collection_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/grader_collection_spec.js
@@ -1,0 +1,56 @@
+(function (require) {
+'use strict';
+require(
+['video/10_grader_collection.js'],
+function (GraderCollection) {
+describe('VideoGraderCollection', function () {
+    var state, graderCollection;
+
+    beforeEach(function () {
+        state = {
+            el: $('.video'),
+            videoPlayer: {
+                duration: jasmine.createSpy().andReturn(100)
+            },
+            config: {
+                hasScore: true,
+                graders: {
+                    scored_on_end: {isScored: false, graderValue: true},
+                    scored_on_percent: {isScored: false, graderValue: 1}
+                }
+            }
+        };
+    });
+
+    it('returns list of available graders on initialization', function () {
+        var list = new GraderCollection(state.el, state);
+
+        expect(list.length).toBe(2);
+    });
+
+    it('returns an empty list if module is not scoreable', function () {
+        var list;
+
+        state.config.hasScore = false;
+        list = new GraderCollection(state.el, state);
+        expect(list.length).toBe(0);
+    });
+
+    it('returns just a list of available graders', function () {
+        var list;
+
+        state.config.graders['bad_grader'] = function(){};
+        list = new GraderCollection(state.el, state);
+        expect(list.length).toBe(2);
+    });
+
+    it('returns just a list of unscored graders', function () {
+        var list;
+
+        state.config.graders.scored_on_end.isScored = true;
+        list = new GraderCollection(state.el, state);
+        expect(list.length).toBe(1);
+    });
+});
+});
+}(RequireJS.require));

--- a/common/lib/xmodule/xmodule/js/spec/video/grader_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/grader_spec.js
@@ -128,6 +128,7 @@ describe('VideoGrader', function () {
 
     describe('BasicGrader', function () {
         beforeEach(function () {
+            jasmine.Clock.useMock();
             state.config.graders['basic_grader'] = {
                 isScored: false,
                 graderValue: true,
@@ -141,11 +142,15 @@ describe('VideoGrader', function () {
 
         it('updates status message when done on play', function () {
             state.el.trigger('play');
+            jasmine.Clock.tick(10);
             expect($('.problem-feedback').text()).toBe(SUCCESS_MESSAGE);
         });
 
         it('updates status message when done on video download', function () {
             state.el.find('.video-download-button').trigger('click');
+            jasmine.Clock.tick(10);
+            expect($('.problem-feedback').text()).not.toBe(SUCCESS_MESSAGE);
+            jasmine.Clock.tick(25);
             expect($('.problem-feedback').text()).toBe(SUCCESS_MESSAGE);
         });
     });
@@ -160,6 +165,7 @@ describe('VideoGrader', function () {
         it('updates status message when done on video download', function () {
             new Grader(state, i18n);
             state.el.find('.video-download-button').trigger('click');
+            jasmine.Clock.tick(25);
             expect($('.problem-feedback').text()).toBe(SUCCESS_MESSAGE);
         });
 
@@ -290,7 +296,7 @@ describe('VideoGrader', function () {
         });
 
         it('shows success message if duration is less than 20s', function () {
-            state.videoPlayer.duration.andReturn(1);
+            state.videoPlayer.duration.andReturn(2);
             state.config.graders.scored_on_percent.graderValue = 50;
             new Grader(state, i18n);
             state.el.trigger('play');
@@ -302,7 +308,7 @@ describe('VideoGrader', function () {
 
             expect($('.problem-feedback').text()).toBe(SUCCESS_MESSAGE);
             expect(state.videoGrader).assertState({
-                'scored_on_percent': createStateList(3, 1)
+                'scored_on_percent': createStateList(2, 1)
             });
         });
 

--- a/common/lib/xmodule/xmodule/js/spec/video/grader_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/grader_spec.js
@@ -1,0 +1,433 @@
+(function (require) {
+'use strict';
+require(
+['video/11_grader.js', 'video/00_i18n.js', 'video/00_abstract_grader.js'],
+function (Grader, i18n, AbstractGrader) {
+describe('VideoGrader', function () {
+    var SCORED_TEXT = '(0.5 / 1.0 points)',
+        POSSIBLE_SCORES = '1.0 points possible',
+        SUCCESS_MESSAGE = 'You\'ve received credit for viewing this video.',
+        ERROR_MESSAGE = [
+            'An error occurred. ',
+            'Please refresh the page and try viewing the video again.'
+        ].join(''),
+        state;
+
+    beforeEach(function () {
+        loadFixtures('video.html');
+        state = {
+            el: $('.video'),
+            progressElement: $('.problem-progress'),
+            statusElement: $('.problem-feedback'),
+            videoPlayer: {
+                duration: jasmine.createSpy().andReturn(100)
+            },
+            storage: {
+                setItem: jasmine.createSpy(),
+                getItem: jasmine.createSpy(),
+            },
+            config: {
+                hasScore: true,
+                startTime: 0,
+                endTime: null,
+                maxScore: '1.0',
+                score: null,
+                gradeUrl: '/grade_url',
+                graders: {
+                    scored_on_end: {
+                        isScored: false,
+                        graderValue: true,
+                        saveState: false
+                    },
+                    scored_on_percent: {
+                        isScored: false,
+                        graderValue: 2,
+                        saveState: true
+                    }
+                }
+            },
+            isFlashMode: jasmine.createSpy().andReturn(false)
+        };
+    });
+
+    describe('initialize', function () {
+        it('Score is shown if module is graded.', function () {
+            state.config.score = '0.5';
+            new Grader(state, i18n);
+            expect(state.progressElement.text()).toBe(SCORED_TEXT);
+        });
+
+        it('Score is hidden if module does not graded.', function () {
+            new Grader(state, i18n);
+            expect(state.progressElement.text()).toBe(POSSIBLE_SCORES);
+        });
+
+        it('Score is hidden if incorrect score was retrieved.', function () {
+            state.config.score = 'a0.5a';
+            new Grader(state, i18n);
+            expect(state.progressElement.text()).toBe(POSSIBLE_SCORES);
+        });
+    });
+
+    describe('getGraders', function () {
+        it('returns collection with graders', function () {
+            var getGraders = Grader.prototype.getGraders;
+
+            new Grader(state, i18n);
+            expect(getGraders(state.el, state).length).toBe(2);
+        });
+    });
+
+    describe('Status bar', function () {
+        beforeEach(function () {
+            state.config.graders.scored_on_percent.isScored = true;
+            jasmine.Clock.useMock();
+        });
+
+        it('shows success message', function () {
+            new Grader(state, i18n);
+
+            expect(state.progressElement.text()).toBe(POSSIBLE_SCORES);
+            expect($('.problem-feedback').length).toBe(0);
+
+            jasmine.stubRequests();
+            state.el.trigger('play');
+            jasmine.Clock.tick(10);
+            state.el.trigger('ended');
+
+            expect(state.progressElement.text()).toBe(SCORED_TEXT);
+            expect($('.problem-feedback').text()).toBe(SUCCESS_MESSAGE);
+            expect(state.storage.setItem).toHaveBeenCalledWith(
+                'score', '0.5', true
+            );
+        });
+
+        it('shows error message', function () {
+            runs(function () {
+                new Grader(state, i18n);
+
+                expect(state.progressElement.text()).toBe(POSSIBLE_SCORES);
+                expect($('.problem-feedback').length).toBe(0);
+
+                state.el.trigger('play');
+                jasmine.Clock.tick(10);
+                state.el.trigger('ended');
+            });
+
+            waitsFor(function () {
+                return $('.problem-feedback').length;
+            }, 'Respond from server does not received.', WAIT_TIMEOUT);
+
+            runs(function () {
+                expect(state.progressElement.text()).toBe(POSSIBLE_SCORES);
+                expect($('.problem-feedback').text()).toBe(ERROR_MESSAGE);
+                expect(state.storage.setItem).not.toHaveBeenCalled();
+            });
+        });
+    });
+
+    describe('BasicGrader', function () {
+        beforeEach(function () {
+            state.config.graders['basic_grader'] = {
+                isScored: false,
+                graderValue: true,
+                saveState: false
+            };
+            state.config.graders.scored_on_percent.isScored = true;
+            state.config.graders.scored_on_end.isScored = true;
+            jasmine.stubRequests();
+            new Grader(state, i18n);
+        });
+
+        it('updates status message when done on play', function () {
+            state.el.trigger('play');
+            expect($('.problem-feedback').text()).toBe(SUCCESS_MESSAGE);
+        });
+
+        it('updates status message when done on video download', function () {
+            state.el.find('.video-download-button').trigger('click');
+            expect($('.problem-feedback').text()).toBe(SUCCESS_MESSAGE);
+        });
+    });
+
+    describe('GradeOnEnd', function () {
+        beforeEach(function () {
+            jasmine.Clock.useMock();
+            state.config.graders.scored_on_percent.isScored = true;
+            jasmine.stubRequests();
+        });
+
+        it('updates status message when done on video download', function () {
+            new Grader(state, i18n);
+            state.el.find('.video-download-button').trigger('click');
+            expect($('.problem-feedback').text()).toBe(SUCCESS_MESSAGE);
+        });
+
+        describe('ended', function () {
+            beforeEach(function () {
+                new Grader(state, i18n);
+            });
+
+            it('updates status message when done', function () {
+                state.el.trigger('play');
+                jasmine.Clock.tick(10);
+                state.el.trigger('ended');
+                expect($('.problem-feedback').text()).toBe(SUCCESS_MESSAGE);
+            });
+
+            it('updates just once', function () {
+                state.el.trigger('play');
+                jasmine.Clock.tick(10);
+                state.el.trigger('ended');
+                state.el.trigger('ended');
+                state.el.trigger('ended');
+                expect(state.storage.setItem.calls.length).toBe(1);
+            });
+
+            it('updates status message when seek to the end', function () {
+                state.el.trigger('play');
+                jasmine.Clock.tick(2);
+                state.el.trigger('seek', [100]);
+                jasmine.Clock.tick(10);
+                expect(state.storage.setItem.calls.length).toBe(1);
+            });
+        });
+
+        describe('endTime', function () {
+            beforeEach(function () {
+                state.config.startTime = 10;
+                state.config.endTime = 20;
+                new Grader(state, i18n);
+            });
+
+            it('updates status message when done', function () {
+                state.el.trigger('play');
+                jasmine.Clock.tick(10);
+                state.el.trigger('endTime');
+                expect($('.problem-feedback').text()).toBe(SUCCESS_MESSAGE);
+            });
+
+            it('updates just once', function () {
+                state.el.trigger('play');
+                jasmine.Clock.tick(10);
+                state.el.trigger('endTime');
+                state.el.trigger('endTime');
+                state.el.trigger('endTime');
+                expect(state.storage.setItem.calls.length).toBe(1);
+            });
+
+            it('updates status message when seek to the end', function () {
+                state.el.trigger('play');
+                jasmine.Clock.tick(2);
+                state.el.trigger('seek', [20.5]);
+                jasmine.Clock.tick(10);
+                expect(state.storage.setItem.calls.length).toBe(1);
+            });
+        });
+    });
+
+    describe('GradeOnPercent', function () {
+        beforeEach(function () {
+            state.config.graders.scored_on_end.isScored = true;
+            jasmine.stubRequests();
+            spyOn(_, 'throttle').andCallFake(function(f){ return f; }) ;
+            jasmine.Clock.useMock();
+            this.addMatchers({
+                assertState: function (expected) {
+                    var actual = this.actual.getStates();
+                    return this.env.equals_(actual, expected);
+                }
+            });
+        });
+
+        var createStateList = function (len, val) {
+            return $.map(_.range(len), function () {
+                return val;
+            });
+        }
+
+        it('shows success message', function () {
+            new Grader(state, i18n);
+            state.el.trigger('play');
+            jasmine.Clock.tick(10);
+            expect($('.problem-feedback').length).toBe(0);
+            state.el.trigger('progress', [0.9]);
+            expect($('.problem-feedback').length).toBe(0);
+            state.el.trigger('progress', [1.1]);
+            expect($('.problem-feedback').length).toBe(0);
+            state.el.trigger('progress', [1.5]);
+            expect($('.problem-feedback').length).toBe(0);
+            state.el.trigger('progress', [2.1]);
+            expect($('.problem-feedback').text()).toBe(SUCCESS_MESSAGE);
+            expect(state.videoGrader).assertState({
+                'scored_on_percent': createStateList(3, 1)
+            });
+        });
+
+        it('shows success message if percent equal 100', function () {
+            state.config.graders.scored_on_percent.graderValue = 100;
+            new Grader(state, i18n);
+            state.el.trigger('play');
+            jasmine.Clock.tick(10);
+
+            $.each(_.range(202), function(index, val) {
+                state.el.trigger('progress', [0.5 * index]);
+            });
+
+            expect($('.problem-feedback').text()).toBe(SUCCESS_MESSAGE);
+            expect(state.videoGrader).assertState({
+                'scored_on_percent': createStateList(101, 1)
+            });
+        });
+
+        it('shows success message immediately if percent equal 0', function () {
+            state.config.graders.scored_on_percent.graderValue = 0;
+            new Grader(state, i18n);
+            expect($('.problem-feedback').text()).toBe(SUCCESS_MESSAGE);
+            expect(state.videoGrader).assertState({
+                'scored_on_percent': []
+            });
+        });
+
+        it('shows success message if duration is less than 20s', function () {
+            state.videoPlayer.duration.andReturn(1);
+            state.config.graders.scored_on_percent.graderValue = 50;
+            new Grader(state, i18n);
+            state.el.trigger('play');
+            jasmine.Clock.tick(10);
+
+            for (var i = 0, k = 0; i <= 5; i++, k += 0.2) {
+                state.el.trigger('progress', [k]);
+            }
+
+            expect($('.problem-feedback').text()).toBe(SUCCESS_MESSAGE);
+            expect(state.videoGrader).assertState({
+                'scored_on_percent': createStateList(3, 1)
+            });
+        });
+
+    });
+
+    describe('getStartEndTimes', function () {
+        var config = {
+                'scored_on_end': {
+                    isScored: false
+                }
+            }, grader;
+
+        beforeEach(function () {
+            spyOn(AbstractGrader.prototype, 'getGrader');
+            spyOn(AbstractGrader.prototype, 'sendGradeOnSuccess');
+        });
+
+        describe('startTime', function () {
+            it('returns initial value', function () {
+                var actual;
+
+                state.config.startTime = 10;
+                this.grader = new AbstractGrader(state.el, state, config);
+                actual = this.grader.getStartEndTimes();
+                expect(actual).toEqual({
+                    start: 10,
+                    end: 100,
+                    size: 90,
+                    duration: 100
+                });
+            });
+
+            it('returns 0 if it is bigger than duration', function () {
+                var actual;
+
+                state.config.startTime = 100;
+                this.grader = new AbstractGrader(state.el, state, config);
+                actual = this.grader.getStartEndTimes();
+                expect(actual).toEqual({
+                    start: 0,
+                    end: 100,
+                    size: 100,
+                    duration: 100
+                });
+            });
+
+            it('returns correct values in flash mode', function () {
+                var actual;
+
+                state.config.startTime = 10;
+                state.speed = 2;
+                state.isFlashMode.andReturn(true);
+                this.grader = new AbstractGrader(state.el, state, config);
+                actual = this.grader.getStartEndTimes();
+                expect(actual).toEqual({
+                    start: 5,
+                    end: 50,
+                    size: 45,
+                    duration: 100
+                });
+            });
+        });
+
+        describe('endTime', function () {
+            it('returns initial value', function () {
+                var actual;
+
+                state.config.endTime = 20;
+                this.grader = new AbstractGrader(state.el, state, config);
+                actual = this.grader.getStartEndTimes();
+                expect(actual).toEqual({
+                    start: 0,
+                    end: 20,
+                    size: 20,
+                    duration: 100
+                });
+            });
+
+            it('returns duration if it is bigger than duration', function () {
+                var actual;
+
+                state.config.endTime = 100;
+                this.grader = new AbstractGrader(state.el, state, config);
+                actual = this.grader.getStartEndTimes();
+                expect(actual).toEqual({
+                    start: 0,
+                    end: 100,
+                    size: 100,
+                    duration: 100
+                });
+            });
+
+            it('returns duration if it is less than start time', function () {
+                var actual;
+
+                state.config.startTime = 50;
+                state.config.endTime = 40;
+                this.grader = new AbstractGrader(state.el, state, config);
+                actual = this.grader.getStartEndTimes();
+                expect(actual).toEqual({
+                    start: 50,
+                    end: 100,
+                    size: 50,
+                    duration: 100
+                });
+            });
+
+            it('returns correct values in flash mode', function () {
+                var actual;
+
+                state.config.endTime = 10;
+                state.speed = 2;
+                state.isFlashMode.andReturn(true);
+                this.grader = new AbstractGrader(state.el, state, config);
+                actual = this.grader.getStartEndTimes()
+
+                expect(actual).toEqual({
+                    start: 0,
+                    end: 5,
+                    size: 5,
+                    duration: 100
+                });
+            });
+        });
+    });
+});
+});
+}(RequireJS.require));

--- a/common/lib/xmodule/xmodule/js/spec/video/initialize_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/initialize_spec.js
@@ -158,6 +158,7 @@ function (Initialize) {
                     url: state.config.saveStateUrl,
                     type: 'POST',
                     async: asyncVal,
+                    notifyOnError : false,
                     dataType: 'json',
                     data: ajaxData
                 });

--- a/common/lib/xmodule/xmodule/js/src/time.js
+++ b/common/lib/xmodule/xmodule/js/src/time.js
@@ -12,6 +12,10 @@
     function format(time, formatFull) {
         var hours, minutes, seconds;
 
+        if (!isFinite(time)) {
+            time = 0;
+        }
+
         seconds = Math.floor(time);
         minutes = Math.floor(seconds / 60);
         hours = Math.floor(minutes / 60);

--- a/common/lib/xmodule/xmodule/js/src/time.js
+++ b/common/lib/xmodule/xmodule/js/src/time.js
@@ -12,7 +12,7 @@
     function format(time, formatFull) {
         var hours, minutes, seconds;
 
-        if (!isFinite(time)) {
+        if (!_.isFinite(time)) {
             time = 0;
         }
 

--- a/common/lib/xmodule/xmodule/js/src/video/00_abstract_grader.js
+++ b/common/lib/xmodule/xmodule/js/src/video/00_abstract_grader.js
@@ -5,6 +5,34 @@ define(
 [],
 function() {
     /**
+     * Creates a new object with the specified prototype object and properties.
+     * @param {Object} o The object which should be the prototype of the
+     * newly-created object.
+     * @private
+     * @throws {TypeError, Error}
+     * @return {Object}
+     */
+    var inherit = Object.create || (function () {
+        var F = function () {};
+
+        return function (o) {
+            if (arguments.length > 1) {
+                throw Error('Second argument not supported');
+            }
+            if (_.isNull(o) || _.isUndefined(o)) {
+                throw Error('Cannot set a null [[Prototype]]');
+            }
+            if (!_.isObject(o)) {
+                throw TypeError('Argument must be an object');
+            }
+
+            F.prototype = o;
+
+            return new F();
+        };
+    })();
+
+    /**
      * AbstractGrader module.
      * @exports video/00_abstract_grader.js
      * @constructor
@@ -31,13 +59,14 @@ function() {
                 }
             };
 
-        // inherit
-        var F = function () {};
-        F.prototype = Parent.prototype;
-        Child.prototype = new F();
+        // Inherit methods and properties from the Parent prototype.
+        Child.prototype = inherit(Parent.prototype);
         Child.constructor = Parent;
+        // Provide access to parent's methods and properties
         Child.__super__ = Parent.prototype;
 
+        // Extends inherited methods and properties by methods/properties
+        // passed as argument.
         if (protoProps) {
             $.extend(Child.prototype, protoProps);
         }
@@ -102,7 +131,8 @@ function() {
         },
 
         /**
-         * Decorates provided grader to send grade results on succeeded scoring.
+         * Decorates provided grader so that it sends grade results on
+         * successful scoring.
          * @param {jquery Promise} grader Grader function.
          */
         sendGradeOnSuccess: function (grader) {

--- a/common/lib/xmodule/xmodule/js/src/video/00_abstract_grader.js
+++ b/common/lib/xmodule/xmodule/js/src/video/00_abstract_grader.js
@@ -1,0 +1,160 @@
+(function (define) {
+'use strict';
+define(
+'video/00_abstract_grader.js',
+[],
+function() {
+    /**
+     * AbstractGrader module.
+     * @exports video/00_abstract_grader.js
+     * @constructor
+     * @param {Object} state The object containing the state of the video
+     * player.
+     * @return {jquery Promise}
+     */
+    var AbstractGrader = function () {
+        return this.initialize.apply(this, arguments);
+    };
+
+    /**
+     * Returns new constructor that inherits form the current constructor.
+     * @static
+     * @param {Object} protoProps The object containing which will be added to
+     * the prototype.
+     * @return {Object}
+     */
+    AbstractGrader.extend = function (protoProps) {
+        var Parent = this,
+            Child = function () {
+                if ($.isFunction(this.initialize)) {
+                    return this.initialize.apply(this, arguments);
+                }
+            };
+
+        // inherit
+        var F = function () {};
+        F.prototype = Parent.prototype;
+        Child.prototype = new F();
+        Child.constructor = Parent;
+        Child.__super__ = Parent.prototype;
+
+        if (protoProps) {
+            $.extend(Child.prototype, protoProps);
+        }
+
+        return Child;
+    };
+
+    AbstractGrader.prototype = {
+        /** Grader name on backend */
+        name: '',
+        range: {},
+
+        /** Initializes the module. */
+        initialize: function (element, state, config) {
+            this.element = element;
+            this.state = state;
+            this.config = config;
+            this.storage = this.state.storage;
+            this.url = this.state.config.gradeUrl;
+            this.grader = this.getGrader(this.element, this.state, this.config);
+            this.promise = this.sendGradeOnSuccess(this.grader);
+        },
+
+        /** Returns grader name. */
+        getName: function () {
+            return this.name;
+        },
+
+        /**
+         * Factory method that returns instance of needed Grader.
+         * @return {jquery Promise}
+         * @example:
+         *   var dfd = $.Deferred();
+         *   this.element.on('play', dfd.resolve);
+         *   return dfd.promise();
+         */
+        getGrader: function (element, state, config) {
+            throw new Error('Please implement logic of the `getGrader` method.');
+        },
+
+        /**
+         * Sends results of grading to the server.
+         * @return {jquery Promise}
+         */
+        sendGrade: function () {
+            return $.ajaxWithPrefix({
+                url: this.url,
+                data: {
+                    'graderName': this.getName()
+                },
+                type: 'POST',
+                notifyOnError: false
+            });
+        },
+
+        /**
+         * Returns promise for the grader.
+         * @return {jquery Promise}
+         */
+        getPromise: function () {
+            return this.promise;
+        },
+
+        /**
+         * Decorates provided grader to send grade results on succeeded scoring.
+         * @param {jquery Promise} grader Grader function.
+         */
+        sendGradeOnSuccess: function (grader) {
+            return grader.pipe(this.sendGrade.bind(this));
+        },
+
+        /**
+         * Returns current grader progress object.
+         * @return {Object} The object with key equals grader name and
+         * value equals current state of the grader.
+         */
+        getState: function () {
+            return null;
+        },
+
+        /**
+         * Returns start/end times for the video.
+         * @return {Object} Contains start, end times and size of the interval.
+         */
+        getStartEndTimes: function () {
+            var startTime = this.state.config.startTime,
+                endTime = this.state.config.endTime,
+                duration = this.state.videoPlayer.duration();
+
+            if (this.range && duration === this.range.duration) {
+                return this.range;
+            }
+
+            if (startTime >= duration) {
+                startTime = 0;
+            }
+
+            if (endTime <= startTime || endTime >= duration) {
+                endTime = duration;
+            }
+
+            if (this.state.isFlashMode()) {
+                startTime /= Number(this.state.speed);
+                endTime /= Number(this.state.speed);
+            }
+
+            this.range = {
+                start: startTime,
+                end: endTime,
+                size: endTime - startTime,
+                duration: duration
+            };
+
+            return this.range;
+        }
+    };
+
+    return AbstractGrader;
+});
+}(RequireJS.define));

--- a/common/lib/xmodule/xmodule/js/src/video/00_i18n.js
+++ b/common/lib/xmodule/xmodule/js/src/video/00_i18n.js
@@ -26,6 +26,10 @@ function() {
         'Very loud': gettext('Very loud'),
         // Translators: Volume level equals 100%.
         'Maximum': gettext('Maximum')
+        // Translators: "points" is the student's achieved score, and "total_points" is the maximum number of points achievable.
+        '(%(points)s / %(total_points)s points)': gettext('(%(points)s / %(total_points)s points)'),
+        'You\'ve received credit for viewing this video.': gettext('You\'ve received credit for viewing this video.'),
+        GRADER_ERROR: gettext('An error occurred. Please refresh the page and try viewing the video again.')
     };
 });
 }(RequireJS.define));

--- a/common/lib/xmodule/xmodule/js/src/video/00_i18n.js
+++ b/common/lib/xmodule/xmodule/js/src/video/00_i18n.js
@@ -25,7 +25,7 @@ function() {
         // Translators: Volume level in range ]80,99]%
         'Very loud': gettext('Very loud'),
         // Translators: Volume level equals 100%.
-        'Maximum': gettext('Maximum')
+        'Maximum': gettext('Maximum'),
         // Translators: "points" is the student's achieved score, and "total_points" is the maximum number of points achievable.
         '(%(points)s / %(total_points)s points)': gettext('(%(points)s / %(total_points)s points)'),
         'You\'ve received credit for viewing this video.': gettext('You\'ve received credit for viewing this video.'),

--- a/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
+++ b/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
@@ -419,6 +419,10 @@ function (VideoPlayer, VideoStorage, i18n) {
                         }
 
                         return value;
+                     },
+                    'score': function (value) {
+
+                        return storage.getItem('score', true) || value;
                      }
                 },
                 config = {};
@@ -480,6 +484,8 @@ function (VideoPlayer, VideoStorage, i18n) {
     function initialize(element) {
         var self = this,
             el = $(element).find('.video'),
+            progressElement = $(element).find('.problem-progress'),
+            statusElement = $(element).find('.problem-feedback'),
             container = el.find('.video-wrapper'),
             id = el.attr('id').replace(/video_/, ''),
             __dfd__ = $.Deferred(),
@@ -493,6 +499,8 @@ function (VideoPlayer, VideoStorage, i18n) {
         $.extend(this, {
             __dfd__: __dfd__,
             el: el,
+            progressElement: progressElement,
+            statusElement: statusElement,
             container: container,
             id: id,
             isFullScreen: false,
@@ -773,11 +781,18 @@ function (VideoPlayer, VideoStorage, i18n) {
     }
 
     function saveState(async, data) {
+        var state;
 
         if (!($.isPlainObject(data))) {
             data = {
                 saved_video_position: this.videoPlayer.currentTime
             };
+        }
+
+        if (this.videoGrader) {
+            state = JSON.stringify(this.videoGrader.getStates());
+            data['cumulative_score'] = state;
+            this.storage.setItem('cumulative_score', state, true);
         }
 
         if (data.speed) {
@@ -793,6 +808,7 @@ function (VideoPlayer, VideoStorage, i18n) {
         $.ajax({
             url: this.config.saveStateUrl,
             type: 'POST',
+            notifyOnError: false,
             async: async ? true : false,
             dataType: 'json',
             data: data,

--- a/common/lib/xmodule/xmodule/js/src/video/03_video_player.js
+++ b/common/lib/xmodule/xmodule/js/src/video/03_video_player.js
@@ -330,7 +330,7 @@ function (HTML5Video, Resizer) {
     function update(time) {
         this.videoPlayer.currentTime = time || this.videoPlayer.player.getCurrentTime();
 
-        if (isFinite(this.videoPlayer.currentTime)) {
+        if (_.isFinite(this.videoPlayer.currentTime)) {
             this.el.trigger('progress', [this.videoPlayer.currentTime]);
             this.videoPlayer.updatePlayTime(this.videoPlayer.currentTime);
 
@@ -459,7 +459,7 @@ function (HTML5Video, Resizer) {
     function seekTo(time, silent) {
         var duration = this.videoPlayer.duration();
 
-        if ((typeof time !== 'number') || (time > duration) || (time < 0)) {
+        if (!_.isNumber(time) || time > duration || time < 0) {
             return false;
         }
 

--- a/common/lib/xmodule/xmodule/js/src/video/03_video_player.js
+++ b/common/lib/xmodule/xmodule/js/src/video/03_video_player.js
@@ -15,6 +15,7 @@ function (HTML5Video, Resizer) {
             return dfd.promise();
         },
         methodsDict = {
+            destroy: destroy,
             duration: duration,
             handlePlaybackQualityChange: handlePlaybackQualityChange,
 
@@ -330,6 +331,7 @@ function (HTML5Video, Resizer) {
         this.videoPlayer.currentTime = time || this.videoPlayer.player.getCurrentTime();
 
         if (isFinite(this.videoPlayer.currentTime)) {
+            this.el.trigger('progress', [this.videoPlayer.currentTime]);
             this.videoPlayer.updatePlayTime(this.videoPlayer.currentTime);
 
             // We need to pause the video if current time is smaller (or equal)
@@ -341,9 +343,11 @@ function (HTML5Video, Resizer) {
                 this.videoPlayer.endTime <= this.videoPlayer.currentTime
             ) {
                 this.videoPlayer.stopAtEndTime = false;
-
                 this.videoPlayer.pause();
-
+                this.el.trigger('endTime', [
+                    this.videoPlayer.currentTime,
+                    this.videoPlayer.endTime
+                ]);
                 this.trigger('videoProgressSlider.notifyThroughHandleEnd', {
                     end: true
                 });
@@ -452,7 +456,7 @@ function (HTML5Video, Resizer) {
         );
     }
 
-    function seekTo(time) {
+    function seekTo(time, silent) {
         var duration = this.videoPlayer.duration();
 
         if ((typeof time !== 'number') || (time > duration) || (time < 0)) {
@@ -486,7 +490,9 @@ function (HTML5Video, Resizer) {
         }
 
         this.videoPlayer.updatePlayTime(time, true);
-        this.el.trigger('seek', arguments);
+        if (!silent) {
+            this.el.trigger('seek', arguments);
+        }
     }
 
     function runTimer() {
@@ -675,7 +681,7 @@ function (HTML5Video, Resizer) {
             time = this.videoPlayer.figureOutStartingTime(duration);
 
         if (time > 0 && this.videoPlayer.goToStartTime) {
-            this.videoPlayer.seekTo(time);
+            this.videoPlayer.seekTo(time, true);
         }
 
         this.el.trigger('ready', arguments);
@@ -922,6 +928,13 @@ function (HTML5Video, Resizer) {
 
     function onVolumeChange(volume) {
         this.videoPlayer.player.setVolume(volume);
+    }
+
+    function destroy() {
+        this.videoPlayer.stopTimer();
+        if (this.isYoutubeType()){
+            this.videoPlayer.player.destroy();
+        }
     }
 });
 

--- a/common/lib/xmodule/xmodule/js/src/video/10_grader_collection.js
+++ b/common/lib/xmodule/xmodule/js/src/video/10_grader_collection.js
@@ -1,0 +1,194 @@
+(function (define) {
+'use strict';
+define(
+'video/10_grader_collection.js',
+['video/00_abstract_grader.js'],
+function (AbstractGrader) {
+    /**
+     * GraderCollection module.
+     * @exports video/10_grader_collection.js
+     * @constructor
+     * @param {Object} state The object containing the state of the video
+     * player.
+     * @return {jquery Promise}
+     */
+    var GraderCollection = function (element, state) {
+        if (!(this instanceof GraderCollection)) {
+            return new GraderCollection(element, state);
+        }
+
+        var hasScore = state.config.hasScore,
+            graders = state.config.graders,
+            conversions = {
+                'basic_grader': 'BasicGrader',
+                'scored_on_end': 'GradeOnEnd',
+                'scored_on_percent': 'GradeOnPercent'
+            };
+
+        return (!hasScore) ? [] : $.map(graders, function (config, name) {
+            var graderName = conversions[name],
+                Grader = GraderCollection[graderName];
+
+            if (Grader && !config.isScored) {
+                return new Grader(element, state, config);
+            }
+        });
+    };
+
+    /** Write graders below this line **/
+
+    GraderCollection.BasicGrader = AbstractGrader.extend({
+        name: 'basic_grader',
+
+        getGrader: function (element) {
+            var downloadButton =  this.state.el.find('.video-download-button'),
+                dfd = $.Deferred();
+
+            element.on('play', dfd.resolve);
+            downloadButton.on('click', dfd.resolve);
+
+            return dfd.promise();
+        }
+    });
+
+    GraderCollection.GradeOnEnd = AbstractGrader.extend({
+        name: 'scored_on_end',
+
+        getGrader: function (element) {
+            var downloadButton =  this.state.el.find('.video-download-button');
+
+            this.dfd = $.Deferred();
+            element.on('play', _.once(this.onPlayHandler.bind(this)));
+            downloadButton.on('click', this.dfd.resolve);
+
+            return this.dfd.promise();
+        },
+
+        onPlayHandler: function (event, time) {
+            setTimeout(function () {
+                var range = this.getStartEndTimes(),
+                    size = range.size,
+                    duration = range.duration,
+                    eventName = (size === duration) ? 'ended' : 'endTime';
+
+                this.element.on(eventName, this.dfd.resolve);
+                this.element.on('seek', this.onSeekHandler.bind(this));
+            }.bind(this), 0);
+        },
+
+        onSeekHandler: function (event, time) {
+            setTimeout(function () {
+                var range = this.getStartEndTimes();
+
+                if (Math.floor(time) === range.end) {
+                    this.dfd.resolve();
+                }
+            }.bind(this), 0);
+        }
+    });
+
+    GraderCollection.GradeOnPercent = AbstractGrader.extend({
+        name: 'scored_on_percent',
+        size: 100,
+
+        getGrader: function (element, state, config) {
+            this.dfd = $.Deferred();
+            this.coef = 1;
+            this.graderValue = this.config.graderValue + 1;
+
+            if (this.config.graderValue === 0) {
+                this.dfd.resolve();
+            } else {
+                element.on('play', _.once(this.onPlayHandler.bind(this)));
+            }
+
+            return this.dfd.promise();
+        },
+
+        getProgress: function (timeline) {
+            return _.compact(timeline).length * this.coef;
+        },
+
+        createTimeline: function () {
+            return [];
+        },
+
+        getStoredLocally: function () {
+            var cumulative = this.storage.getItem('cumulative_score', true),
+                value = null;
+
+            try {
+                value = JSON.parse(cumulative)[this.getName()];
+            } catch (ex) { }
+
+            return value;
+        },
+
+        getTimeline: function (size) {
+            var current = this.timeline,
+                storedOnServer = this.config.graderState,
+                storedLocally = this.getStoredLocally(),
+                timeline = current || storedLocally || storedOnServer || [];
+
+            if (!size) {
+                size = this.size;
+            }
+
+            return timeline.length && size === this.size ?
+                timeline :
+                this.createTimeline();
+        },
+
+        onPlayHandler: function (event) {
+            setTimeout(function () {
+                var interval, waitTime;
+
+                this.range = this.getStartEndTimes();
+                interval = 1000 * this.range.size;
+                // event `progress` triggers with interval 200 ms.
+                waitTime = Math.max(interval/this.size, 200);
+
+                // We're going to receive 1-2 events `progress` for each
+                // timeline position for the small videos to be more precise and
+                // to avoid some issues with invoking of timers.
+                if (waitTime <= 500) {
+                    this.size = interval / 500;
+                    this.coef = 100 / this.size;
+                }
+
+                this.timeline = this.getTimeline(this.size);
+
+                this.element.on(
+                    'progress',
+                    _.throttle(
+                        this.onProgressHandler.bind(this), waitTime,
+                        { leading: true, trailing: true }
+                    )
+                );
+            }.bind(this), 0);
+        },
+
+        onProgressHandler: function (event, time) {
+            var seconds = Math.floor(time);
+
+            if (this.range.start <= seconds && seconds <= this.range.end) {
+                var position = Math.floor(
+                    (time - this.range.start) * this.size / this.range.size
+                );
+
+                this.timeline[position] = 1;
+                if (this.getProgress(this.timeline) >= this.graderValue) {
+                    this.dfd.resolve();
+                }
+            }
+        },
+
+        getState: function () {
+            return this.getTimeline();
+        }
+    });
+
+    return GraderCollection;
+});
+
+}(window.RequireJS.define));

--- a/common/lib/xmodule/xmodule/js/src/video/11_grader.js
+++ b/common/lib/xmodule/xmodule/js/src/video/11_grader.js
@@ -41,7 +41,7 @@ function(GraderCollection) {
             this.statusMsgElement = this.statusElement
                                         .find('.problem-feedback-message');
 
-            if (this.score && isFinite(this.score)) {
+            if (this.score && _.isFinite(this.score)) {
                 this.setScore(this.score);
                 this.updateStatusText(
                     this.i18n['You\'ve received credit for viewing this video.']
@@ -148,7 +148,7 @@ function(GraderCollection) {
          * @param {jquery XHR} jqXHR
          */
         onSuccess: function (response) {
-            if (isFinite(response)) {
+            if (_.isFinite(response)) {
                 this.setScore(response);
                 this.el.addClass('is-scored');
                 this.updateStatusText(

--- a/common/lib/xmodule/xmodule/js/src/video/11_grader.js
+++ b/common/lib/xmodule/xmodule/js/src/video/11_grader.js
@@ -154,6 +154,9 @@ function(GraderCollection) {
                 this.updateStatusText(
                     this.i18n['You\'ve received credit for viewing this video.']
                 );
+                Logger.log('video_scored', {
+                    score: response
+                });
             }
         },
 

--- a/common/lib/xmodule/xmodule/js/src/video/11_grader.js
+++ b/common/lib/xmodule/xmodule/js/src/video/11_grader.js
@@ -1,0 +1,195 @@
+(function (define) {
+'use strict';
+define(
+'video/11_grader.js',
+['video/10_grader_collection.js'],
+function(GraderCollection) {
+    /**
+     * Grader module.
+     * @exports video/11_grader.js
+     * @constructor
+     * @param {Object} state The object containing the state of the video
+     * player.
+     * @param {Object} i18n Object with translations.
+     * @return {jquery Promise}
+     */
+    var Grader = function (state, i18n) {
+        if (!(this instanceof Grader)) {
+            return new Grader(state, i18n);
+        }
+
+        this.state = state;
+        this.state.videoGrader = this;
+        this.initialize(state, i18n);
+
+        return $.Deferred().resolve().promise();
+    };
+
+    Grader.prototype = {
+        gradersForSave: [],
+
+        /** Initializes the module. */
+        initialize: function (state, i18n) {
+            this.state = state;
+            this.i18n = i18n;
+            this.el = this.state.el;
+            this.maxScore = this.state.config.maxScore;
+            this.score = this.state.config.score;
+            this.url = this.state.config.gradeUrl;
+            this.progressElement = this.state.progressElement;
+            this.statusElement = this.state.statusElement;
+            this.statusMsgElement = this.statusElement
+                                        .find('.problem-feedback-message');
+
+            if (this.score && isFinite(this.score)) {
+                this.setScore(this.score);
+                this.updateStatusText(
+                    this.i18n['You\'ve received credit for viewing this video.']
+                );
+            } else {
+                this.graders = this.getGraders(this.el, this.state);
+                $.when.apply(this, this.getPromises(this.graders))
+                    .done(this.onSuccess.bind(this))
+                    .fail(this.onError.bind(this));
+            }
+        },
+
+        /**
+         * Factory method that returns instance of needed Grader.
+         * @return {jquery Promise}
+         * @example:
+         *   var dfd = $.Deferred();
+         *   this.el.on('play', dfd.resolve);
+         *   return dfd.promise();
+         */
+        getGraders: function (element, state) {
+            return new GraderCollection(element, state);
+        },
+
+        /**
+         * Returns list of grader promises.
+         * @return {Array} List of promises.
+         */
+        getPromises: function (graders) {
+            return $.map(graders, function (grader) {
+                return grader.getPromise();
+            });
+        },
+
+        /**
+         * Updates scores on the front-end.
+         * @param {Number|String} points Score achieved by the student.
+         * @param {Number|String} totalPoints Maximum number of points
+         * achievable.
+         */
+        updateScores: function (points, totalPoints) {
+            var msg = interpolate(
+                    this.i18n['(%(points)s / %(total_points)s points)'],
+                    {
+                        'points': Number(points).toFixed(1),
+                        'total_points': Number(totalPoints).toFixed(1)
+                    }, true
+                );
+
+            this.progressElement.text(msg);
+        },
+
+        /**
+         * Creates status element and inserts it to the DOM.
+         * @param {String} message Status message.
+         */
+        createStatusElement: function (message) {
+            this.statusElement = $([
+                '<div class="problem-feedback video-feedback">',
+                    message ? message : '',
+                '</div>'
+            ].join(''));
+
+            this.statusMsgElement = this.statusElement
+                                        .find('.problem-feedback-message');
+            this.el.after(this.statusElement);
+        },
+
+        /**
+         * Updates status message by the text passed as argument.
+         * @param {String} text Text of status message.
+         * @param {String} type The type of the message: error or success.
+         */
+        updateStatusText: function (text, type) {
+            if (text) {
+                if (this.statusElement.length) {
+                    this.statusMsgElement.text(text);
+                } else {
+                    this.createStatusElement(text);
+                }
+
+                if (type === 'error') {
+                    this.statusElement.addClass('is-error');
+                } else {
+                    this.statusElement.removeClass('is-error');
+                }
+            }
+        },
+
+        /**
+         * Updates current score for the module.
+         * @param {Number|String} points Score achieved by the student.
+         */
+        setScore: function (points) {
+            this.score = points;
+            this.state.storage.setItem('score', this.score, true);
+            this.updateScores(this.score, this.maxScore);
+        },
+
+        /**
+         * Handles success response from the server after sending grade results.
+         * @param {Object} response Data returned from the server.
+         * @param {String} textStatus String describing the status.
+         * @param {jquery XHR} jqXHR
+         */
+        onSuccess: function (response) {
+            if (isFinite(response)) {
+                this.setScore(response);
+                this.el.addClass('is-scored');
+                this.updateStatusText(
+                    this.i18n['You\'ve received credit for viewing this video.']
+                );
+            }
+        },
+
+        /**
+         * Handles failed response from the server after sending grade results.
+         * @param {jquery XHR} jqXHR
+         * @param {String} textStatus String describing the type of error that
+         * occurred and an optional exception object, if one occurred.
+         * @param {String} errorThrown Textual portion of the HTTP status.
+         */
+        onError: function () {
+            var msg = this.i18n.GRADER_ERROR;
+
+            this.updateStatusText(msg, 'error');
+            this.el.addClass('is-error');
+        },
+
+        getStates: function () {
+            var states = {};
+
+            if (this.graders.length) {
+                if (!this.gradersForSave.length) {
+                    this.gradersForSave = this.graders.filter(function (grader) {
+                        return grader.config.saveState;
+                    });
+                }
+
+                $.each(this.gradersForSave, function(index, grader) {
+                    states[grader.getName()] = grader.getState();
+                });
+            }
+
+            return states;
+        }
+    };
+
+    return Grader;
+});
+}(RequireJS.define));

--- a/common/lib/xmodule/xmodule/js/src/video/12_main.js
+++ b/common/lib/xmodule/xmodule/js/src/video/12_main.js
@@ -43,7 +43,8 @@
             'video/06_video_progress_slider.js',
             'video/07_video_volume_control.js',
             'video/08_video_speed_control.js',
-            'video/09_video_caption.js'
+            'video/09_video_caption.js',
+            'video/11_grader.js'
         ],
         function (
             initialize,
@@ -54,7 +55,8 @@
             VideoProgressSlider,
             VideoVolumeControl,
             VideoSpeedControl,
-            VideoCaption
+            VideoCaption,
+            VideoGrader
         ) {
             var youtubeXhr = null,
                 oldVideo = window.Video;
@@ -68,6 +70,7 @@
                 if (previousState && previousState.videoPlayer) {
                     previousState.saveState(true);
                     $(window).off('unload', previousState.saveState);
+                    previousState.videoPlayer.destroy();
                 }
 
                 state = {};
@@ -87,7 +90,8 @@
                     VideoProgressSlider,
                     VideoVolumeControl,
                     VideoSpeedControl,
-                    VideoCaption
+                    VideoCaption,
+                    VideoGrader
                 ];
 
                 state.youtubeXhr = youtubeXhr;

--- a/common/lib/xmodule/xmodule/modulestore/inheritance.py
+++ b/common/lib/xmodule/xmodule/modulestore/inheritance.py
@@ -86,6 +86,11 @@ class InheritanceMixin(XBlockMixin):
               "If the value is not set, infinite attempts are allowed."),
         values={"min": 0}, scope=Scope.settings
     )
+    grade_videos = Boolean(
+        help="Whether videos in the course are gradeable",
+        default=False,
+        scope=Scope.settings
+    )
 
 
 

--- a/common/lib/xmodule/xmodule/static_content.py
+++ b/common/lib/xmodule/xmodule/static_content.py
@@ -99,6 +99,7 @@ def _write_styles(selector, output_root, classes):
     module_styles_lines.append("@import 'bourbon/bourbon';")
     module_styles_lines.append("@import 'bourbon/addons/button';")
     module_styles_lines.append("@import 'assets/anims';")
+    module_styles_lines.append("@import 'assets/xmodule';")
     for class_, fragment_names in css_imports.items():
         module_styles_lines.append("""{selector}.xmodule_{class_} {{""".format(
             class_=class_, selector=selector

--- a/common/lib/xmodule/xmodule/tests/test_video.py
+++ b/common/lib/xmodule/xmodule/tests/test_video.py
@@ -491,6 +491,30 @@ class VideoDescriptorImportTestCase(unittest.TestCase):
             'data': ''
         })
 
+    def test_from_xml_graded_video(self):
+        """
+        Test graded video import.
+        """
+        module_system = DummySystem(load_error_modules=True)
+        xml_data = '''
+            <video display_name="Test Video"
+                    youtube="1.0:p2Q6BrNhdh8"
+                    has_score="true"
+                    scored_on_end="true"
+                    weight="10.0"
+                    scored_on_percent="5">
+            </video>
+        '''
+        output = VideoDescriptor.from_xml(xml_data, module_system, Mock())
+        expected_attrs = {
+            'youtube_id_1_0': 'p2Q6BrNhdh8',
+            'has_score': True,
+            'scored_on_end': True,
+            'weight': 10.0,
+            'scored_on_percent': 5,
+        }
+        self.assert_attributes_equal(output, expected_attrs)
+
 
 class VideoExportTestCase(unittest.TestCase):
     """
@@ -575,3 +599,23 @@ class VideoExportTestCase(unittest.TestCase):
         expected = '<video url_name="SampleProblem1"/>\n'
 
         self.assertEquals(expected, etree.tostring(xml, pretty_print=True))
+
+    def test_graded_video_export_to_xml(self):
+        """Test for graded video export."""
+        module_system = DummySystem(load_error_modules=True)
+        location = Location(["i4x", "edX", "video", "default", "SampleProblem1"])
+        desc = VideoDescriptor(module_system, DictFieldData({}), ScopeIds(None, None, location, location))
+
+        desc.youtube_id_1_0 = 'p2Q6BrNhdh8'
+        desc.grade_videos = True
+        desc.has_score = True
+        desc.scored_on_end = True
+        desc.weight = 10.0
+        desc.scored_on_percent = 5
+
+        xml = desc.definition_to_xml(None)  # We don't use the `resource_fs` parameter
+        expected = etree.fromstring('''\
+         <video url_name="SampleProblem1" has_score="true" scored_on_end="true" weight="10.0" scored_on_percent="5" grade_videos="true" youtube="1.00:p2Q6BrNhdh8" />
+        ''')
+
+        self.assertXmlEqual(expected, xml)

--- a/common/lib/xmodule/xmodule/tests/test_video.py
+++ b/common/lib/xmodule/xmodule/tests/test_video.py
@@ -603,8 +603,7 @@ class VideoExportTestCase(unittest.TestCase):
     def test_graded_video_export_to_xml(self):
         """Test for graded video export."""
         module_system = DummySystem(load_error_modules=True)
-        location = Location(["i4x", "edX", "video", "default", "SampleProblem1"])
-        desc = VideoDescriptor(module_system, DictFieldData({}), ScopeIds(None, None, location, location))
+        desc = VideoDescriptor(module_system, DictFieldData({}), ScopeIds(None, None, self.location, self.location))
 
         desc.youtube_id_1_0 = 'p2Q6BrNhdh8'
         desc.grade_videos = True

--- a/common/lib/xmodule/xmodule/video_module/video_handlers.py
+++ b/common/lib/xmodule/xmodule/video_module/video_handlers.py
@@ -338,6 +338,13 @@ class VideoStudentViewHandlers(object):
         # At this point all graders have scored, so we should update score in database, but only if
         # a) self.max_score() is True, that means that module is score-able,
         # b) `module_score` not equals to `max_score`.
+
+        # We do not update score if module_score is already equal to max_score.
+        # If it is already equal to max_score, then student has already scored 100% for this video.
+        # After that teacher can change graders settings, so video score can be updated again.
+        # But when student had already scored 100% and if graders then were reset, we do not allow to rewrite student score.
+        # It means that if student got his grade, we do not take his grade away from him.
+
         if self.max_score() and self.module_score != self.max_score():
             try:
                 self.update_score(self.max_score())

--- a/common/lib/xmodule/xmodule/video_module/video_handlers.py
+++ b/common/lib/xmodule/xmodule/video_module/video_handlers.py
@@ -251,8 +251,8 @@ class VideoStudentViewHandlers(object):
 
             try:
                 transcript = self.translation(request.GET.get('videoId', None))
-            except NotFoundError as ex:
-                log.info(ex.message)
+            except NotFoundError as exc:
+                log.info(exc.message)
                 # Try to return static URL redirection as last resort
                 # if no translation is required
                 return self.get_static_transcript(request)
@@ -260,8 +260,8 @@ class VideoStudentViewHandlers(object):
                 TranscriptException,
                 UnicodeDecodeError,
                 TranscriptsGenerationException
-            ) as ex:
-                log.info(ex.message)
+            ) as exc:
+                log.info(exc.message)
                 response = Response(status=404)
             else:
                 response = Response(transcript, headerlist=[('Content-Language', language)])

--- a/common/lib/xmodule/xmodule/video_module/video_handlers.py
+++ b/common/lib/xmodule/xmodule/video_module/video_handlers.py
@@ -328,7 +328,7 @@ class VideoStudentViewHandlers(object):
 
         # If we came here, then current grader 'grade_name' has just scored.
         # Here we check if all other graders have already been scored.
-        # If they are not scored, then mark that current grader has scored and return.
+        # If they are not scored, then mark current grader as scored and return.
         if not all(
             [values['isScored'] for name, values in self.cumulative_score.items() if name != grader_name]
         ):

--- a/common/lib/xmodule/xmodule/video_module/video_handlers.py
+++ b/common/lib/xmodule/xmodule/video_module/video_handlers.py
@@ -48,15 +48,22 @@ class VideoStudentViewHandlers(object):
         ]
 
         conversions = {
-            'cumulative_score': self.cumulative_score_save_action,
+
             'speed': json.loads,
             'saved_video_position': RelativeTime.isotime_to_timedelta,
             'youtube_is_available': json.loads,
         }
 
+        save_actions = {
+            'cumulative_score': self.cumulative_score_save_action
+        }
+
         if dispatch == 'save_user_state':
             for key in data:
                 if hasattr(self, key) and key in accepted_keys:
+                    if key in save_actions:
+                        save_actions[key](data[key])
+                        continue
                     if key in conversions:
                         value = conversions[key](data[key])
                     else:

--- a/common/lib/xmodule/xmodule/video_module/video_handlers.py
+++ b/common/lib/xmodule/xmodule/video_module/video_handlers.py
@@ -343,12 +343,12 @@ class VideoStudentViewHandlers(object):
                 self.update_score(self.max_score())
                 self.cumulative_score[grader_name]['isScored'] = True
                 log.debug(u"Graded video reached max score.")
-            except NotImplementedError:
-                if getattr(self.system, 'is_author_mode', False):
+            except NotImplementedError:  # get_real_user is not a function: Studio or tests case.
+                if getattr(self.system, 'is_author_mode', False):  # Studio, just mimic LMS behaviour for end user.
                     return Response(json.dumps(self.module_score), status=200)
                 else:
                     return Response(status=501)
-            except AssertionError:
+            except AssertionError:  # No anon_user_id or real_user. Look at docs for self.update_score()
                 log.debug(u"No real user exists for graded video.")
                 return Response(status=500)
 

--- a/common/lib/xmodule/xmodule/video_module/video_scoring.py
+++ b/common/lib/xmodule/xmodule/video_module/video_scoring.py
@@ -1,0 +1,145 @@
+"""
+Contani methods for scoring video.
+"""
+import logging
+
+
+log = logging.getLogger(__name__)
+
+
+class VideoScoringMixin(object):
+    """
+    Contain method for scoring video
+    """
+    @property
+    def really_has_score(self):
+        return self.has_score and self.grade_videos
+
+    def max_score(self):
+        return self.weight if self.really_has_score else None
+
+    def update_score(self, score):
+        """
+        Save grade to database.
+        """
+        anon_user_id = self.runtime.anonymous_student_id
+        assert anon_user_id is not None
+
+        if callable(self.system.get_real_user):  # We are in LMS not in Studio, in Studio it is None.
+            real_user = self.system.get_real_user(anon_user_id)
+        else:
+            raise NotImplementedError
+
+        assert real_user is not None  # We can't save to database, as we do not have real user id.
+
+        self.system.publish(
+            self,
+            'grade',
+            {
+                'value': score,
+                'max_value': self.max_score(),
+                'user_id': real_user.id,
+            }
+        )
+
+        self.module_score = score
+        log.debug("[Video]: Grade is saved.")
+
+    @property
+    def non_default_graders(self):
+        """
+        Returns active graders from possible graders.
+
+        Returns:
+            dict of next format: { grader_name: grader_value }
+        """
+        return {name: getattr(self, name) for name in self.fields.keys() if name.startswith('scored') and getattr(self, name)}
+
+    @property
+    def all_graders(self):
+        """
+        Returns a list of allowed graders for the component.
+        """
+        return ['basic_grader'] + self.non_default_graders.keys()
+
+    @property
+    def active_graders(self):
+        """
+        Return list of graders that are currently enabled
+        """
+        return self.non_default_graders.keys() if self.non_default_graders else ['basic_grader']
+
+    def graders(self):
+        """
+        Fields that start with 'scored' are counted as possible graders.
+
+        If grader was added or removed, or it's value was changed update self.cumulative_score.
+
+        Returns:
+            dumped dict of next format:
+                {
+                    grader_name: {
+                        isScored: bool, was grader succeed
+                        saveState: bool, does grade store it's intermediate state in database,
+                        graderState: intermediate state of grader,
+                        graderValue: value of grader, depends of Xfiled type of grader
+                    }
+                }
+        """
+
+        # which graders save state
+        save_state = ['scored_on_percent']
+
+        if self.module_score and self.module_score == self.max_score():  # module have been scored
+            return {}
+
+        if self.non_default_graders:
+            graders_updated = sorted(self.cumulative_score) != sorted(self.non_default_graders)
+            graders_values_changed = False
+
+            # Check if values of graders were updated.
+            if not graders_updated:
+                for grader_name, grader_dict in self.cumulative_score.items():
+                    if grader_dict['graderValue'] != self.non_default_graders[grader_name]:
+                        graders_values_changed = True
+                        break
+
+            if graders_updated or graders_values_changed:
+                self.cumulative_score = {
+                    grader_name: {
+                        'isScored': self.cumulative_score.get(grader_name, {}).get('isScored', False),
+                        'saveState': grader_name in save_state,
+                        'graderValue': grader_value,
+                        'graderState': self.cumulative_score.get(grader_name, {}).get('graderState', None)
+                    }
+                    for grader_name, grader_value in self.non_default_graders.items()
+                }
+
+        else:
+            grader_name = 'basic_grader'
+            self.cumulative_score = {
+                grader_name: {
+                    'isScored': self.cumulative_score.get(grader_name, {}).get('isScored', False),
+                    'saveState': False,
+                    'graderValue': True,
+                    'graderState': None,
+                }
+            }
+
+        return self.cumulative_score
+
+    def cumulative_score_save_action(self, values):
+        """
+        Stores state for grader
+
+        Stores state for grader in copy of cumulative_score to update it in database later.
+
+        Values is dict of grader_name: grader_value
+        """
+        cumulative_score = dict(self.cumulative_score)
+
+        for grader_name, status in values.items():
+            if grader_name in self.active_graders:
+                cumulative_score[grader_name]['graderState'] = status
+
+        return cumulative_score

--- a/common/lib/xmodule/xmodule/video_module/video_scoring.py
+++ b/common/lib/xmodule/xmodule/video_module/video_scoring.py
@@ -88,7 +88,7 @@ class VideoScoringMixin(object):
                 {
                     grader_name: {
                         isScored: bool, was grader succeed
-                        saveState: bool, does grade store it's intermediate state in database,
+                        saveState: bool, does grade store its intermediate state in database,
                         graderState: intermediate state of grader,
                         graderValue: value of grader, depends of Xfield type of grader
                     }

--- a/common/lib/xmodule/xmodule/video_module/video_scoring.py
+++ b/common/lib/xmodule/xmodule/video_module/video_scoring.py
@@ -1,7 +1,6 @@
 """
 Contains methods for scoring video.
 """
-
 import json
 
 

--- a/common/lib/xmodule/xmodule/video_module/video_scoring.py
+++ b/common/lib/xmodule/xmodule/video_module/video_scoring.py
@@ -1,5 +1,5 @@
 """
-Contani methods for scoring video.
+Contains methods for scoring video.
 """
 
 import json

--- a/common/lib/xmodule/xmodule/video_module/video_scoring.py
+++ b/common/lib/xmodule/xmodule/video_module/video_scoring.py
@@ -90,7 +90,7 @@ class VideoScoringMixin(object):
                         isScored: bool, was grader succeed
                         saveState: bool, does grade store it's intermediate state in database,
                         graderState: intermediate state of grader,
-                        graderValue: value of grader, depends of Xfiled type of grader
+                        graderValue: value of grader, depends of Xfield type of grader
                     }
                 }
         """

--- a/common/lib/xmodule/xmodule/video_module/video_scoring.py
+++ b/common/lib/xmodule/xmodule/video_module/video_scoring.py
@@ -1,21 +1,30 @@
 """
 Contani methods for scoring video.
 """
-import logging
 
-
-log = logging.getLogger(__name__)
+import json
 
 
 class VideoScoringMixin(object):
     """
-    Contain method for scoring video
+    Contains methods for scoring video.
     """
     @property
     def really_has_score(self):
+        """
+        Determine if video is graded and cousre has graded videos.
+
+        Return True if video has not only numerical score
+        but course marked as it has gradeable videos.
+        """
         return self.has_score and self.grade_videos
 
     def max_score(self):
+        """
+        Get maximum score possible in this module.
+
+        Return the max score if video is gradeable, None if not.
+        """
         return self.weight if self.really_has_score else None
 
     def update_score(self, score):
@@ -43,7 +52,6 @@ class VideoScoringMixin(object):
         )
 
         self.module_score = score
-        log.debug("[Video]: Grade is saved.")
 
     @property
     def non_default_graders(self):
@@ -130,7 +138,7 @@ class VideoScoringMixin(object):
 
     def cumulative_score_save_action(self, values):
         """
-        Stores state for grader
+        Stores state for grader.
 
         Stores state for grader in copy of cumulative_score to update it in database later.
 
@@ -138,7 +146,7 @@ class VideoScoringMixin(object):
         """
         cumulative_score = dict(self.cumulative_score)
 
-        for grader_name, status in values.items():
+        for grader_name, status in json.loads(values).items():
             if grader_name in self.active_graders:
                 cumulative_score[grader_name]['graderState'] = status
 

--- a/common/lib/xmodule/xmodule/video_module/video_scoring.py
+++ b/common/lib/xmodule/xmodule/video_module/video_scoring.py
@@ -139,16 +139,8 @@ class VideoScoringMixin(object):
 
     def cumulative_score_save_action(self, values):
         """
-        Stores state for grader.
-
-        Stores state for grader in copy of cumulative_score to update it in database later.
-
-        Values is dict of grader_name: grader_value
+        Update state of grader in self.cumulative_score
         """
-        cumulative_score = dict(self.cumulative_score)
-
         for grader_name, status in json.loads(values).items():
             if grader_name in self.active_graders:
-                cumulative_score[grader_name]['graderState'] = status
-
-        return cumulative_score
+                self.cumulative_score[grader_name]['graderState'] = status

--- a/common/lib/xmodule/xmodule/video_module/video_scoring.py
+++ b/common/lib/xmodule/xmodule/video_module/video_scoring.py
@@ -84,7 +84,7 @@ class VideoScoringMixin(object):
         If grader was added or removed, or it's value was changed update self.cumulative_score.
 
         Returns:
-            dumped dict of next format:
+            dumped dict with the following format:
                 {
                     grader_name: {
                         isScored: bool, was grader successful,

--- a/common/lib/xmodule/xmodule/video_module/video_scoring.py
+++ b/common/lib/xmodule/xmodule/video_module/video_scoring.py
@@ -87,7 +87,7 @@ class VideoScoringMixin(object):
             dumped dict of next format:
                 {
                     grader_name: {
-                        isScored: bool, was grader succeed
+                        isScored: bool, was grader successful,
                         saveState: bool, does grade store its intermediate state in database,
                         graderState: intermediate state of grader,
                         graderValue: value of grader, depends of Xfield type of grader

--- a/common/lib/xmodule/xmodule/video_module/video_scoring.py
+++ b/common/lib/xmodule/xmodule/video_module/video_scoring.py
@@ -81,7 +81,7 @@ class VideoScoringMixin(object):
         """
         Fields that start with 'scored' are counted as possible graders.
 
-        If grader was added or removed, or it's value was changed update self.cumulative_score.
+        If grader was added or removed, or its value was changed, update self.cumulative_score.
 
         Returns:
             dumped dict with the following format:

--- a/common/lib/xmodule/xmodule/video_module/video_scoring.py
+++ b/common/lib/xmodule/xmodule/video_module/video_scoring.py
@@ -58,6 +58,8 @@ class VideoScoringMixin(object):
         """
         Returns active graders from possible graders.
 
+        Fields that start with 'scored' are counted as possible graders.
+
         Returns:
             dict of next format: { grader_name: grader_value }
         """

--- a/common/lib/xmodule/xmodule/video_module/video_scoring.py
+++ b/common/lib/xmodule/xmodule/video_module/video_scoring.py
@@ -12,7 +12,7 @@ class VideoScoringMixin(object):
     @property
     def really_has_score(self):
         """
-        Determine if video is graded and cousre has graded videos.
+        Determine if video is graded and course has graded videos.
 
         Return True if video has numerical score AND course has marked it as gradeable.
         """

--- a/common/lib/xmodule/xmodule/video_module/video_scoring.py
+++ b/common/lib/xmodule/xmodule/video_module/video_scoring.py
@@ -14,8 +14,7 @@ class VideoScoringMixin(object):
         """
         Determine if video is graded and cousre has graded videos.
 
-        Return True if video has not only numerical score
-        but course marked as it has gradeable videos.
+        Return True if video has numerical score AND course has marked it as gradeable.
         """
         return self.has_score and self.grade_videos
 

--- a/common/lib/xmodule/xmodule/video_module/video_utils.py
+++ b/common/lib/xmodule/xmodule/video_module/video_utils.py
@@ -1,6 +1,7 @@
 """
 Module containts utils specific for video_module but not for transcripts.
 """
+from xmodule.modulestore import Location
 
 
 def create_youtube_string(module):
@@ -23,3 +24,29 @@ def create_youtube_string(module):
         in zip(youtube_speeds, youtube_ids)
         if pair[1]
     ])
+
+
+def get_course_for_item(module):
+    '''
+    cdodge: for a given Xmodule, return the course that it belongs to
+    NOTE: This makes a lot of assumptions about the format of the course location
+    Also we have to assert that this module maps to only one course item - it'll throw an
+    assert if not
+    '''
+    item_loc = Location(module.location)
+
+    # @hack! We need to find the course location however, we don't
+    # know the 'name' parameter in this context, so we have
+    # to assume there's only one item in this query even though we are not specifying a name
+    course_search_location = Location('i4x', item_loc.org, item_loc.course, 'course', None)
+    courses = module.runtime.modulestore.get_items(course_search_location)
+
+    # make sure we found exactly one match on this above course search
+    found_cnt = len(courses)
+    if found_cnt == 0:
+        raise BaseException('Could not find course at {0}'.format(course_search_location))
+
+    if found_cnt > 1:
+        raise BaseException('Found more than one course at {0}. There should only be one!!! Dump = {1}'.format(course_search_location, courses))
+
+    return courses[0]

--- a/common/lib/xmodule/xmodule/video_module/video_utils.py
+++ b/common/lib/xmodule/xmodule/video_module/video_utils.py
@@ -1,5 +1,5 @@
 """
-Module containts utils specific for video_module but not for transcripts.
+Module contains utils specific for video_module but not for transcripts.
 """
 
 
@@ -27,7 +27,7 @@ def create_youtube_string(module):
 
 def get_course_for_item(module):
     '''
-    Get course for item
+    Get course for item.
 
     This is workaround and can be removed as soos as
     ihneritance will work for video descriptor.

--- a/common/lib/xmodule/xmodule/video_module/video_utils.py
+++ b/common/lib/xmodule/xmodule/video_module/video_utils.py
@@ -1,7 +1,6 @@
 """
 Module containts utils specific for video_module but not for transcripts.
 """
-from xmodule.modulestore import Location
 
 
 def create_youtube_string(module):
@@ -28,25 +27,6 @@ def create_youtube_string(module):
 
 def get_course_for_item(module):
     '''
-    cdodge: for a given Xmodule, return the course that it belongs to
-    NOTE: This makes a lot of assumptions about the format of the course location
-    Also we have to assert that this module maps to only one course item - it'll throw an
-    assert if not
+    Get course for item
     '''
-    item_loc = Location(module.location)
-
-    # @hack! We need to find the course location however, we don't
-    # know the 'name' parameter in this context, so we have
-    # to assume there's only one item in this query even though we are not specifying a name
-    course_search_location = Location('i4x', item_loc.org, item_loc.course, 'course', None)
-    courses = module.runtime.modulestore.get_items(course_search_location)
-
-    # make sure we found exactly one match on this above course search
-    found_cnt = len(courses)
-    if found_cnt == 0:
-        raise BaseException('Could not find course at {0}'.format(course_search_location))
-
-    if found_cnt > 1:
-        raise BaseException('Found more than one course at {0}. There should only be one!!! Dump = {1}'.format(course_search_location, courses))
-
-    return courses[0]
+    return module.runtime.modulestore.get_course(module.location.course_key, depth=0)

--- a/common/lib/xmodule/xmodule/video_module/video_utils.py
+++ b/common/lib/xmodule/xmodule/video_module/video_utils.py
@@ -28,5 +28,8 @@ def create_youtube_string(module):
 def get_course_for_item(module):
     '''
     Get course for item
+
+    This is workaround and can be removed as soos as
+    ihneritance will work for video descriptor.
     '''
     return module.runtime.modulestore.get_course(module.location.course_key, depth=0)

--- a/common/lib/xmodule/xmodule/video_module/video_utils.py
+++ b/common/lib/xmodule/xmodule/video_module/video_utils.py
@@ -29,7 +29,7 @@ def get_course_for_item(module):
     '''
     Get course for item.
 
-    This is workaround and can be removed as soos as
-    ihneritance will work for video descriptor.
+    This is workaround and can be removed as soon as
+    inheritance will work for video descriptor.
     '''
     return module.runtime.modulestore.get_course(module.location.course_key, depth=0)

--- a/common/lib/xmodule/xmodule/video_module/video_xfields.py
+++ b/common/lib/xmodule/xmodule/video_module/video_xfields.py
@@ -3,7 +3,7 @@ XFields for video module.
 """
 import datetime
 
-from xblock.fields import Scope, String, Float, Boolean, List, Dict
+from xblock.fields import Scope, String, Float, Integer, Boolean, List, Dict
 
 from xmodule.fields import RelativeTime
 
@@ -150,4 +150,60 @@ class VideoFields(object):
         help=_("Upload a handout to accompany this video. Students can download the handout by clicking Download Handout under the video."),
         display_name=_("Upload Handout"),
         scope=Scope.settings,
+    )
+
+    has_score = Boolean(
+        help="Select True if students receive a numerical score for viewing or interacting with the video.",
+        display_name="Video Is Scored",
+        scope=Scope.settings,
+        default=False,
+    )
+
+    scored_on_end = Boolean(
+        help="Select True if students receive a score for viewing the video.",
+        display_name="Video Is Scored When Viewed",
+        scope=Scope.settings,
+        default=False,
+    )
+
+    scored_on_percent = Integer(
+        help=(
+            "The minimum percentage of the video that students must watch to receive credit. "
+            "Enter a number between 1 and 100, without a percent sign. "
+            "Partial credit is not possible."
+        ),
+        display_name="Video Percent to View",
+        values={"min": 0, "max": 100},
+        scope=Scope.settings,
+    )
+
+    module_score = Float(
+        help="The score kept in the xblock KVS -- duplicate of the published score in django DB",
+        default=None,
+        scope=Scope.user_state
+    )
+
+    weight = Float(
+        display_name="Weight",
+        help=(
+            "The number of points that students receive "
+            "if they view the required video. To use this setting, "
+            "you must set Video Is Scored to True."
+        ),
+        default=1.0,
+        scope=Scope.settings,
+        values={"min": 0},
+    )
+
+    cumulative_score = Dict(
+        help="Accumulates results from particular graders.",
+        display_name="Cumulative scores.",
+        scope=Scope.user_state,
+        default={}
+    )
+
+    grade_videos = Boolean(
+        help="Whether videos in the course are gradeable",
+        default=False,
+        scope=Scope.settings
     )

--- a/common/lib/xmodule/xmodule/video_module/video_xfields.py
+++ b/common/lib/xmodule/xmodule/video_module/video_xfields.py
@@ -153,57 +153,57 @@ class VideoFields(object):
     )
 
     has_score = Boolean(
-        help="Select True if students receive a numerical score for viewing or interacting with the video.",
-        display_name="Video Is Scored",
+        help=_("Select True if students receive a numerical score for viewing or interacting with the video."),
+        display_name=_("Video Is Scored"),
         scope=Scope.settings,
         default=False,
     )
 
     scored_on_end = Boolean(
-        help="Select True if students receive a score for viewing the video.",
-        display_name="Video Is Scored When Viewed",
+        help=_("Select True if students receive a score for viewing the video."),
+        display_name=_("Video Is Scored When Viewed"),
         scope=Scope.settings,
         default=False,
     )
 
     scored_on_percent = Integer(
-        help=(
+        help=_(
             "The minimum percentage of the video that students must watch to receive credit. "
             "Enter a number between 1 and 100, without a percent sign. "
             "Partial credit is not possible."
         ),
-        display_name="Video Percent to View",
+        display_name=_("Video Percent to View"),
         values={"min": 0, "max": 100},
         scope=Scope.settings,
     )
 
     module_score = Float(
-        help="The score kept in the xblock KVS -- duplicate of the published score in django DB",
+        help=_("The score kept in the xblock KVS -- duplicate of the published score in django DB"),
         default=None,
         scope=Scope.user_state
     )
 
     weight = Float(
-        display_name="Weight",
-        help=(
+        help=_(
             "The number of points that students receive "
             "if they view the required video. To use this setting, "
             "you must set Video Is Scored to True."
         ),
+        display_name=_("Weight"),
         default=1.0,
         scope=Scope.settings,
         values={"min": 0},
     )
 
     cumulative_score = Dict(
-        help="Accumulates results from particular graders.",
-        display_name="Cumulative scores.",
+        help=_("Accumulates results from particular graders."),
+        display_name=_("Cumulative scores."),
         scope=Scope.user_state,
         default={}
     )
 
     grade_videos = Boolean(
-        help="Whether videos in the course are gradeable",
+        help=_("Whether videos in the course are gradeable"),
         default=False,
         scope=Scope.settings
     )

--- a/common/static/sass/assets/_xmodule.scss
+++ b/common/static/sass/assets/_xmodule.scss
@@ -1,0 +1,22 @@
+
+// These animations are used in Video Module
+@include keyframes(gradeSuccess) {
+  0% {
+    background: $green;
+  }
+
+  100% {
+    background: #f3f3f3;
+  }
+}
+
+@include keyframes(gradeError) {
+  0% {
+    background: darken($error-red, 11%);
+  }
+
+  100% {
+    background: #f3f3f3;
+  }
+}
+// ============================================

--- a/common/test/acceptance/pages/lms/video/video_grade_mixin.py
+++ b/common/test/acceptance/pages/lms/video/video_grade_mixin.py
@@ -2,10 +2,7 @@
 Video player in the courseware.
 """
 
-from selenium.webdriver.common.action_chains import ActionChains
-from bok_choy.page_object import PageObject
-from bok_choy.promise import EmptyPromise, Promise
-from bok_choy.javascript import wait_for_js, js_defined
+from bok_choy.promise import EmptyPromise
 
 
 SELECTORS = {
@@ -59,7 +56,7 @@ class VideoGradeMixin(object):
 
         """
         selector = self.get_element_selector(video_display_name, SELECTORS['progress'])
-        return self.q(css=selector).visible
+        return self.q(css=selector).present
 
     def progress_message_text(self, video_display_name=None):
         """
@@ -83,6 +80,8 @@ class VideoGradeMixin(object):
             video_display_name (str or None): Display name of a Video.
 
         """
+        selector = self.get_element_selector(video_display_name, SELECTORS['status'])
+
         def _check_message():
             """
             Event occurred promise check.
@@ -91,6 +90,6 @@ class VideoGradeMixin(object):
                 bool: is event occurred.
 
             """
-            return self.q(css=SELECTORS['status']).present
+            return self.q(css=selector).present
 
         EmptyPromise(_check_message, 'Message is shown', timeout=200).fulfill()

--- a/common/test/acceptance/pages/lms/video/video_grade_mixin.py
+++ b/common/test/acceptance/pages/lms/video/video_grade_mixin.py
@@ -1,0 +1,96 @@
+"""
+Video player in the courseware.
+"""
+
+from selenium.webdriver.common.action_chains import ActionChains
+from bok_choy.page_object import PageObject
+from bok_choy.promise import EmptyPromise, Promise
+from bok_choy.javascript import wait_for_js, js_defined
+
+
+SELECTORS = {
+    'status': '.video-feedback',
+    'progress': '.video-progress',
+}
+
+
+class VideoGradeMixin(object):
+    """
+    Video player in the courseware.
+    """
+
+    def is_status_message_shown(self, video_display_name=None):
+        """
+        Checks if video player status message shown.
+
+        Arguments:
+            video_display_name (str or None): Display name of a Video.
+
+        Returns:
+            bool: Tells about status message visibility.
+
+        """
+        selector = self.get_element_selector(video_display_name, SELECTORS['status'])
+        return self.q(css=selector).present
+
+    def status_message_text(self, video_display_name=None):
+        """
+        Extract video player status message text.
+
+        Arguments:
+            video_display_name (str or None): Display name of a Video.
+
+        Returns:
+            str: Status message text.
+
+        """
+        selector = self.get_element_selector(video_display_name, SELECTORS['status'])
+        return self.q(css=selector).text[0]
+
+    def is_progress_message_shown(self, video_display_name=None):
+        """
+        Checks if video player progress message shown.
+
+        Arguments:
+            video_display_name (str or None): Display name of a Video.
+
+        Returns:
+            bool: Tells about progress message visibility.
+
+        """
+        selector = self.get_element_selector(video_display_name, SELECTORS['progress'])
+        return self.q(css=selector).visible
+
+    def progress_message_text(self, video_display_name=None):
+        """
+        Extract video player progress message text.
+
+        Arguments:
+            video_display_name (str or None): Display name of a Video.
+
+        Returns:
+            str: Status message text.
+
+        """
+        selector = self.get_element_selector(video_display_name, SELECTORS['progress'])
+        return self.q(css=selector).text[0]
+
+    def wait_for_status_message(self, video_display_name=None):
+        """
+        Wait until status message occurs.
+
+        Arguments:
+            video_display_name (str or None): Display name of a Video.
+
+        """
+        def _check_message():
+            """
+            Event occurred promise check.
+
+            Returns:
+                bool: is event occurred.
+
+            """
+            return self.q(css=SELECTORS['status']).present
+
+        EmptyPromise(_check_message, 'Message is shown', timeout=200).fulfill()

--- a/common/test/acceptance/tests/video/test_video_grading.py
+++ b/common/test/acceptance/tests/video/test_video_grading.py
@@ -1,0 +1,421 @@
+# -*- coding: utf-8 -*-
+"""
+Acceptance tests for Video grading functionality.
+"""
+from ...pages.lms.progress import ProgressPage
+from .test_video_module import VideoBaseTest
+
+
+class VideoGradedTest(VideoBaseTest):
+    """ Test Video Player """
+
+    def setUp(self):
+        super(VideoGradedTest, self).setUp()
+        self.progress_page = ProgressPage(self.browser, self.course_id)
+
+    def _assert_video_is_not_scored(self, weight=1.0):
+        self.assertEquals(self.video.progress_message_text(), '({} points possible)'.format(weight))
+        self.assertFalse(self.video.is_status_message_shown())
+
+    def _assert_video_is_scored_successfully(self, weight=1.0):
+        self.assertEquals(self.video.progress_message_text(), '({} / {} points)'.format(weight, weight))
+        self.assertEquals(self.video.status_message_text(), 'You\'ve received credit for viewing this video.')
+
+    def _assert_video_is_graded_successfully(self, weight=1.0):
+        self.tab_nav.go_to_tab('Progress')
+        actual_scores = self.progress_page.scores('Test Chapter', 'Test Section')
+        self.assertEqual(actual_scores, [(int(weight), int(weight))])
+
+
+class YouTubeVideoGradedTest(VideoGradedTest):
+    """ Test YouTube Video Player """
+
+    def setUp(self):
+        super(YouTubeVideoGradedTest, self).setUp()
+
+    def test_video_is_scored_by_percent_to_view(self):
+        """
+        Scenario: Video Percent to View
+        Given the course has a Video component in "Youtube" mode:
+        |has_score|scored_on_percent|
+        |True     |1%               |
+        And I see progress message is "1.0 points possible"
+        And I do not see status message
+        And I click video button "play"
+        Then I see status and progress messages are visible
+        And I see progress message is "(1.0 / 1.0 points)"
+        And I see status message is "You've received credit for viewing this video."
+        When I open progress page
+        Then I see current scores are "1/1"
+        """
+        data = {'has_score': True, 'scored_on_percent': 1, 'grade_videos': True}
+        self.metadata = self.metadata_for_mode('youtube', additional_data=data)
+        self.navigate_to_video()
+        self._assert_video_is_not_scored()
+        self.video.click_player_button('play')
+        self.video.wait_for_status_message()
+        self._assert_video_is_scored_successfully()
+        self._assert_video_is_graded_successfully()
+
+    def test_video_basic_grader_on_play(self):
+        """
+        Scenario: Video Basic Grader is scored when a user clicks play button
+        Given the course has a Video component in "Youtube" mode:
+        |has_score|
+        |True     |
+        And I see progress message is "1.0 points possible"
+        And I do not see status message
+        And I click video button "play"
+        Then I see status and progress messages are visible
+        And I see progress message is "(1.0 / 1.0 points)"
+        And I see status message is "You've received credit for viewing this video."
+        When I open progress page
+        Then I see current scores are "1/1"
+        """
+        data = {'has_score': True, 'grade_videos': True}
+        self.metadata = self.metadata_for_mode('youtube', additional_data=data)
+        self.navigate_to_video()
+        self._assert_video_is_not_scored()
+        self.video.click_player_button('play')
+        self.video.wait_for_status_message()
+        self._assert_video_is_scored_successfully()
+        self._assert_video_is_graded_successfully()
+
+    def test_video_basic_grader_on_download_video_button(self):
+        """
+        Scenario: Video Basic Grader is scored when a user clicks download video button
+        Given the course has a Video component in "Youtube" mode:
+        |has_score|track|
+        |True     |#    |
+        And I see progress message is "1.0 points possible"
+        And I do not see status message
+        And I click video button "Download Video"
+        Then I see status and progress messages are visible
+        And I see progress message is "(1.0 / 1.0 points)"
+        And I see status message is "You've received credit for viewing this video."
+        When I open progress page
+        Then I see current scores are "1/1"
+        """
+        data = {
+            'has_score': True,
+            'grade_videos': True,
+            'track': '#',
+        }
+        self.metadata = self.metadata_for_mode('youtube', additional_data=data)
+        self.navigate_to_video()
+        self._assert_video_is_not_scored()
+        self.video.click_player_button('download_video')
+        self.video.wait_for_status_message()
+        self._assert_video_is_scored_successfully()
+        self._assert_video_is_graded_successfully()
+
+    def test_video_is_scored_by_on_end_and_click_download_video_button(self):
+        """
+        Scenario: Video Is Scored When Viewed is scored when a user clicks play
+        buttonVideo component is scored by percent viewed
+        Given the course has a Video component in "Youtube" mode:
+        |has_score|scored_on_end|weight|track|
+        |True     |True         |15    |#    |
+        And I see progress message is "15.0 points possible"
+        And I do not see status message
+        And I click video button "play"
+        And I click video button "Download Video"
+        Then I see status and progress messages are visible
+        And I see progress message is "(15.0 / 15.0 points)"
+        And I see status message is "You've received credit for viewing this video."
+        When I open progress page
+        Then I see current scores are "15/15"
+        """
+        data = {
+            'has_score': True,
+            'scored_on_end': True,
+            'weight': 15.0,
+            'grade_videos': True,
+            'track': '#',
+        }
+        self.metadata = self.metadata_for_mode('youtube', additional_data=data)
+        self.navigate_to_video()
+        self._assert_video_is_not_scored(weight=15.0)
+        self.video.click_player_button('play')
+        self.video.click_player_button('download_video')
+        self.video.wait_for_status_message()
+        self._assert_video_is_scored_successfully(weight=15.0)
+        self._assert_video_is_graded_successfully(weight=15.0)
+
+
+class Html5VideoGradedTest(VideoGradedTest):
+    """ Test Html5 Video Player """
+
+    def setUp(self):
+        super(Html5VideoGradedTest, self).setUp()
+
+    def test_video_is_scored_by_on_end(self):
+        """
+        Scenario: Video Is Scored When Viewed is scored by percent viewed
+        Given the course has a Video component in "Html5" mode:
+        |has_score|scored_on_end|weight|
+        |True     |True         |15    |
+        And I see progress message is "15.0 points possible"
+        And I do not see status message
+        And I click video button "play"
+        Then I see status and progress messages are visible
+        And I see progress message is "(15.0 / 15.0 points)"
+        And I see status message is "You've received credit for viewing this video."
+        When I open progress page
+        Then I see current scores are "15/15"
+        """
+        data = {
+            'has_score': True,
+            'scored_on_end': True,
+            'weight': 15.0,
+            'grade_videos': True,
+        }
+        self.metadata = self.metadata_for_mode('html5', additional_data=data)
+        self.navigate_to_video()
+        self._assert_video_is_not_scored(weight=15.0)
+        self.video.click_player_button('play')
+
+        # Play the video until the end.
+        self.video.wait_for_state('finished')
+        self.video.wait_for_status_message()
+
+        self._assert_video_is_scored_successfully(weight=15.0)
+        self._assert_video_is_graded_successfully(weight=15.0)
+
+    def test_video_is_scored_when_all_graders_are_enabled(self):
+        """
+        Scenario: Video component is scored well if both graders are enabled
+        Given the course has a Video component in "Html5" mode:
+        |has_score|scored_on_end|scored_on_percent|
+        |True     |True         |20%              |
+        And I click video button "play"
+        And the video is playing up to "0:02" seconds
+        And I click video button "pause"
+        And I see progress message is still "1.0 points possible"
+        And I still do not see status message
+        Then I reload the page
+        And I click video button "play"
+        And the video is playing up to the end
+        Then I see status and progress messages are visible
+        And I see progress message is "(1.0 / 1.0 points)"
+        And I see status message is "You've received credit for viewing this video."
+        When I open progress page
+        Then I see current scores are "1/1"
+        """
+        data = {
+            'has_score': True,
+            'scored_on_end': True,
+            'scored_on_percent': 40,
+            'grade_videos': True,
+        }
+        self.metadata = self.metadata_for_mode('html5', additional_data=data)
+        self.navigate_to_video()
+
+        self.video.click_player_button('play')
+        self.video.wait_for_position('0:03')
+        # Video total time is 5 sec.
+        # So 100 * 3/5 = 60% of video is played and it means that
+        # `scored_on_percent` grader is passed. So, we pause the video and
+        # verify that status and progress messages are still the same.
+        self.video.click_player_button('pause')
+        self._assert_video_is_not_scored()
+
+        # Reloads the page and waits for content loading.
+        self.browser.refresh()
+        self.video.wait_for_page()
+
+        self.video.click_player_button('play')
+
+        # Play the video until the end.
+        self.video.wait_for_state('finished')
+        self.video.wait_for_status_message()
+
+        self._assert_video_is_scored_successfully()
+        self._assert_video_is_graded_successfully()
+
+    def test_video_score_messages_are_saved_between_seq_switch(self):
+        """
+        Same as test_video_is_scored_by_on_end,
+        but after that navigate to other position of sequential and back,
+        and same message should still appear.
+        """
+        data = {'has_score': True, 'scored_on_end': True, 'grade_videos': True}
+        a_metadata = self.metadata_for_mode('html5', additional_data=data)
+        b_metadata = self.metadata_for_mode('html5')
+
+        self.verticals = [
+            [{'display_name': 'A', 'metadata': a_metadata}],
+            [{'display_name': 'B', 'metadata': b_metadata}],
+        ]
+
+        # open the section with videos (open video "A")
+        self.navigate_to_video()
+        self._assert_video_is_not_scored()
+        self.video.click_player_button('play')
+
+        # Play the video until the end.
+        self.video.wait_for_state('finished')
+
+        self._assert_video_is_scored_successfully()
+
+        self.course_nav.go_to_sequential('B')
+        self.course_nav.go_to_sequential('A')
+
+        self._assert_video_is_scored_successfully()
+
+
+class VideoGradedWithStartEndTimesTest(VideoGradedTest):
+    """ Test Video Player with start-end times"""
+
+    def setUp(self):
+        super(VideoGradedWithStartEndTimesTest, self).setUp()
+
+    def test_video_is_scored_by_percent_to_view(self):
+        """
+        Scenario: Video Percent to View with start-end times
+        Given the course has a Video component in "Youtube" mode:
+        |has_score|scored_on_percent|start_time|end_time|
+        |True     |50%              |0:10      |0:20    |
+        And I see progress message is "1.0 points possible"
+        And I do not see status message
+        And I click video button "play"
+        Then I see status and progress messages are visible
+        And I see progress message is "(1.0 / 1.0 points)"
+        And I see status message is "You've received credit for viewing this video."
+        When I open progress page
+        Then I see current scores are "1/1"
+        """
+        data = {
+            'has_score': True,
+            'scored_on_percent': 50,
+            'grade_videos': True,
+            'start_time': '00:00:10',
+            'end_time': '00:00:20',
+        }
+        self.metadata = self.metadata_for_mode('youtube', additional_data=data)
+        self.navigate_to_video()
+        self._assert_video_is_not_scored()
+        self.video.click_player_button('play')
+        self.video.wait_for_status_message()
+        self._assert_video_is_scored_successfully()
+        self._assert_video_is_graded_successfully()
+
+    def test_video_is_not_scored_by_percent_to_view_out_of_range(self):
+        """
+        Scenario: Video Percent to View: positions out of the range is not counted
+        Given the course has a Video component in "Youtube" mode:
+        |has_score|scored_on_percent|end_time|
+        |True     |50%              |0:02    |
+        And I see progress message is "1.0 points possible"
+        And I do not see status message
+        And I seek video to "0:03" position
+        And I click video button "play"
+        Then I see status and progress messages are visible
+        And I see progress message is "(1.0 / 1.0 points)"
+        And I see status message is "You've received credit for viewing this video."
+        When I open progress page
+        Then I see current scores are "1/1"
+        """
+        data = {
+            'has_score': True,
+            'scored_on_percent': 50,
+            'grade_videos': True,
+            'end_time': '00:00:02',
+        }
+        self.metadata = self.metadata_for_mode('html5', additional_data=data)
+        self.navigate_to_video()
+        self._assert_video_is_not_scored()
+        self.video.seek('0:03')
+        self.video.click_player_button('play')
+        self.video.wait_for_state('finished')
+        self._assert_video_is_not_scored()
+
+    def test_video_is_scored_by_on_end(self):
+        """
+        Scenario: Video Is Scored When Viewed with start-end times
+        Given the course has a Video component in "Youtube" mode:
+        |has_score|scored_on_end|weight|
+        |True     |True         |15    |
+        And I see progress message is "15.0 points possible"
+        And I do not see status message
+        And I click video button "play"
+        Then I see status and progress messages are visible
+        And I see progress message is "(15.0 / 15.0 points)"
+        And I see status message is "You've received credit for viewing this video."
+        When I open progress page
+        Then I see current scores are "15/15"
+        """
+        data = {
+            'has_score': True,
+            'scored_on_end': True,
+            'grade_videos': True,
+            'weight': 15.0,
+            'start_time': '00:00:10',
+            'end_time': '00:00:20',
+        }
+        self.metadata = self.metadata_for_mode('youtube', additional_data=data)
+        self.navigate_to_video()
+        self._assert_video_is_not_scored(weight=15.0)
+        self.video.click_player_button('play')
+
+        # Play the video until the end.
+        self.video.wait_for_state('pause')
+        self.video.wait_for_status_message()
+
+        self._assert_video_is_scored_successfully(weight=15.0)
+        self._assert_video_is_graded_successfully(weight=15.0)
+
+    def test_video_is_scored_by_percent_with_stored_position(self):
+        """
+        Scenario: Video Percent to View stores progress
+        Given the course has a Video component in "Youtube" mode:
+        |has_score|scored_on_percent|start_time|end_time|
+        |True     |50%              |0:10      |0:20    |
+        And I click video button "play"
+        And the video is playing up to "0:13" seconds
+        And I click video button "pause"
+        And I see progress message is still "1.0 points possible"
+        And I still do not see status message
+        Then I reload the page
+        And I see the video position is "0:13"
+        And I click video button "play"
+        And the video is playing up to the position "0:15"
+        Then I see status and progress messages are visible
+        And I see progress message is "(1.0 / 1.0 points)"
+        And I see status message is "You've received credit for viewing this video."
+        When I open progress page
+        Then I see current scores are "1/1"
+        """
+        data = {
+            'has_score': True,
+            'scored_on_percent': 50,
+            'grade_videos': True,
+            'start_time': '00:00:10',
+            'end_time': '00:00:20',
+        }
+        self.metadata = self.metadata_for_mode('youtube', additional_data=data)
+        self.navigate_to_video()
+
+        self.video.click_player_button('play')
+        self.video.wait_for_position('0:13')
+        # Video total time is 5 sec.
+        # So 100 * 3/5 = 60% of video is played and it means that
+        # `scored_on_percent` grader is passed. So, we pause the video and
+        # verify that status and progress messages are still the same.
+        self.video.click_player_button('pause')
+        self._assert_video_is_not_scored()
+
+        # Reloads the page and waits for content loading.
+        self.browser.refresh()
+        self.video.wait_for_page()
+
+        self.assertEquals(self.video.position(), '0:13')
+        self.video.click_player_button('play')
+
+        # Play the video until the end.
+        self.video.wait_for_position('0:15')
+        self.video.click_player_button('pause')
+        self.video.wait_for_status_message()
+
+        self._assert_video_is_scored_successfully()
+        self._assert_video_is_graded_successfully()

--- a/common/test/acceptance/tests/video/test_video_module.py
+++ b/common/test/acceptance/tests/video/test_video_module.py
@@ -3,7 +3,6 @@
 """
 Acceptance tests for Video.
 """
-
 import json
 import requests
 from ..helpers import UniqueCourseTest
@@ -133,7 +132,6 @@ class VideoBaseTest(UniqueCourseTest):
     def _navigate_to_courseware_video(self):
         """ Register for the course and navigate to the video unit """
         AutoAuthPage(self.browser, course_id=self.course_id).visit()
-
         self.course_info_page.visit()
         self.tab_nav.go_to_tab('Courseware')
 

--- a/lms/djangoapps/courseware/tests/test_video_handlers.py
+++ b/lms/djangoapps/courseware/tests/test_video_handlers.py
@@ -845,3 +845,34 @@ class TestVideoGradeHandler(TestVideo):
         response = self.item.grade_handler(request=request, dispatch='')
         self.assertFalse(self.item.cumulative_score['scored_on_percent']['isScored'])
         self.assertEqual(response.status_code, 501)  # NotImplemented
+
+    def test_handle_ajax_graded(self):
+        expected_graders_before = {
+            'scored_on_end': {
+                'isScored': False, 'graderValue': True,
+                'graderState': None, 'saveState': False,
+            },
+            'scored_on_percent': {
+                'isScored': False, 'graderValue': 75,
+                'graderState': None, 'saveState': True,
+            },
+        }
+        self.assertEqual(self.item_descriptor.cumulative_score, expected_graders_before)
+        
+        graders = {
+            'cumulative_score':
+            '{"scored_on_percent": true}'
+        }
+        self.item_descriptor.handle_ajax('save_user_state', graders)
+        
+        expected_graders_after = {
+           'scored_on_end': {
+                'isScored': False, 'graderValue': True,
+                'graderState': None, 'saveState': False,
+            },
+            'scored_on_percent': {
+                'isScored': False, 'graderValue': 75,
+                'graderState': True, 'saveState': True,
+            },
+        }
+        self.assertEqual(self.item_descriptor.cumulative_score, expected_graders_after)

--- a/lms/djangoapps/courseware/tests/test_video_handlers.py
+++ b/lms/djangoapps/courseware/tests/test_video_handlers.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Video xmodule tests in mongo."""
 
-from mock import patch
+from mock import patch, Mock
 import os
 import tempfile
 import textwrap
@@ -774,3 +774,74 @@ class TestGetTranscript(TestVideo):
 
         with self.assertRaises(KeyError):
             self.item.get_transcript()
+
+
+class TestVideoGradeHandler(TestVideo):
+    """
+    Test video grade handler.
+    """
+
+    DATA = """
+        <video show_captions="true"
+        display_name="A Name"
+        has_score="True"
+        scored_on_end="True"
+        scored_on_percent="75"
+        >
+            <source src="example.mp4"/>
+            <source src="example.webm"/>
+        </video>
+    """
+
+    MODEL_DATA = {
+        'data': DATA
+    }
+
+    def setUp(self):
+        super(TestVideoGradeHandler, self).setUp()
+        self.item_descriptor.render('student_view')
+        self.item = self.item_descriptor.xmodule_runtime.xmodule_instance
+
+    def test_no_grader_name(self):
+        # no grader name in graders
+        request = Request.blank('')
+        response = self.item.grade_handler(request=request, dispatch='')
+        self.assertEqual(response.status, '400 Bad Request')
+
+    def test_unknown_grader_name(self):
+        request = Request.blank('', POST={'graderName': 'unknown_grader'})
+        response = self.item.grade_handler(request=request, dispatch='')
+        self.assertEqual(response.status, '400 Bad Request')
+
+    def test_grader(self):
+        self.item.runtime.get_real_user = Mock()
+        self.item.runtime.publish = Mock()
+
+        first_grader = 'scored_on_end'
+        self.assertFalse(self.item.cumulative_score[first_grader]['isScored'])
+        request = Request.blank('', POST={'graderName': first_grader})
+        response = self.item.grade_handler(request=request, dispatch='')
+        self.assertTrue(self.item.cumulative_score[first_grader]['isScored'])
+        self.assertEqual(response.status_code, 200)
+
+        second_grader = 'scored_on_percent'
+        self.assertFalse(self.item.cumulative_score[second_grader]['isScored'])
+        request = Request.blank('', POST={'graderName': second_grader})
+        response = self.item.grade_handler(request=request, dispatch='')
+        self.assertTrue(self.item.cumulative_score[second_grader]['isScored'])
+        self.assertEqual(response.status_code, 200)
+
+    def test_no_real_user(self):
+        self.item.runtime.get_real_user = Mock(return_value=None)
+        self.item.cumulative_score['scored_on_end']['isScored'] = True
+        request = Request.blank('', POST={'graderName': 'scored_on_percent'})
+        response = self.item.grade_handler(request=request, dispatch='')
+        self.assertEqual(response.status_code, 500)
+
+    def test_grader_in_studio(self):
+        self.item.runtime.get_real_user = None
+        self.item.cumulative_score['scored_on_end']['isScored'] = True
+        request = Request.blank('', POST={'graderName': 'scored_on_percent'})
+        response = self.item.grade_handler(request=request, dispatch='')
+        self.assertFalse(self.item.cumulative_score['scored_on_percent']['isScored'])
+        self.assertEqual(response.status_code, 501)  # NotImplemented

--- a/lms/djangoapps/courseware/tests/test_video_handlers.py
+++ b/lms/djangoapps/courseware/tests/test_video_handlers.py
@@ -787,6 +787,7 @@ class TestVideoGradeHandler(TestVideo):
         has_score="True"
         scored_on_end="True"
         scored_on_percent="75"
+        grade_videos="True"
         >
             <source src="example.mp4"/>
             <source src="example.webm"/>

--- a/lms/djangoapps/courseware/tests/test_video_handlers.py
+++ b/lms/djangoapps/courseware/tests/test_video_handlers.py
@@ -858,15 +858,15 @@ class TestVideoGradeHandler(TestVideo):
             },
         }
         self.assertEqual(self.item_descriptor.cumulative_score, expected_graders_before)
-        
+
         graders = {
             'cumulative_score':
             '{"scored_on_percent": true}'
         }
         self.item_descriptor.handle_ajax('save_user_state', graders)
-        
+
         expected_graders_after = {
-           'scored_on_end': {
+            'scored_on_end': {
                 'isScored': False, 'graderValue': True,
                 'graderState': None, 'saveState': False,
             },

--- a/lms/djangoapps/courseware/tests/test_video_mongo.py
+++ b/lms/djangoapps/courseware/tests/test_video_mongo.py
@@ -21,7 +21,21 @@ from .test_video_xml import SOURCE_XML
 from .test_video_handlers import TestVideo
 
 
-class TestVideoYouTube(TestVideo):
+class VideoHTMLRenderMixin(object):
+
+    def grading_part_of_context(self):
+        return {
+            'grade_url': self.item_descriptor.xmodule_runtime.handler_url(
+                self.item_descriptor, 'grade_handler'
+            ).rstrip('/?'),
+            'has_score': json.dumps(self.item_descriptor.has_score),
+            'max_score': json.dumps(self.item_descriptor.max_score()),
+            'module_score': json.dumps(self.item_descriptor.module_score if self.item_descriptor.module_score else None),
+            'graders': json.dumps(self.item_descriptor.graders()),
+        }
+
+
+class TestVideoYouTube(TestVideo, VideoHTMLRenderMixin):
     METADATA = {}
 
     def test_video_constructor(self):
@@ -66,13 +80,15 @@ class TestVideoYouTube(TestVideo):
             ).rstrip('/?'),
         }
 
+        expected_context.update(self.grading_part_of_context())
+
         self.assertEqual(
             context,
             self.item_descriptor.xmodule_runtime.render_template('video.html', expected_context),
         )
 
 
-class TestVideoNonYouTube(TestVideo):
+class TestVideoNonYouTube(TestVideo, VideoHTMLRenderMixin):
     """Integration tests: web client + mongo."""
     DATA = """
         <video show_captions="true"
@@ -133,14 +149,14 @@ class TestVideoNonYouTube(TestVideo):
                 self.item_descriptor, 'transcript', 'available_translations'
             ).rstrip('/?')
         }
-
+        expected_context.update(self.grading_part_of_context())
         self.assertEqual(
             context,
             self.item_descriptor.xmodule_runtime.render_template('video.html', expected_context),
         )
 
 
-class TestGetHtmlMethod(BaseTestXmodule):
+class TestGetHtmlMethod(BaseTestXmodule, VideoHTMLRenderMixin):
     '''
     Make sure that `get_html` works correctly.
     '''
@@ -244,6 +260,7 @@ class TestGetHtmlMethod(BaseTestXmodule):
 
             context = self.item_descriptor.render('student_view').content
 
+            expected_context.update(self.grading_part_of_context())
             expected_context.update({
                 'transcript_download_format': None if self.item_descriptor.track and self.item_descriptor.download_track else 'srt',
                 'transcript_languages': '{"en": "English"}' if not data['transcripts'] else json.dumps({"uk": u'Українська'}),
@@ -350,6 +367,8 @@ class TestGetHtmlMethod(BaseTestXmodule):
             'transcript_languages': '{"en": "English"}',
         }
 
+
+
         for data in cases:
             DATA = SOURCE_XML.format(
                 download_video=data['download_video'],
@@ -359,6 +378,7 @@ class TestGetHtmlMethod(BaseTestXmodule):
             self.initialize_module(data=DATA)
             context = self.item_descriptor.render('student_view').content
 
+            expected_context.update(self.grading_part_of_context())
             expected_context.update({
                 'transcript_translation_url': self.item_descriptor.xmodule_runtime.handler_url(
                     self.item_descriptor, 'transcript', 'translation'
@@ -475,6 +495,11 @@ class TestVideoDescriptorInitialization(BaseTestXmodule):
                 },
                 'transcripts': {},
                 'handout': {},
+                'grade_videos': {},
+                'has_score': {},
+                'scored_on_end': {},
+                'scored_on_percent': {},
+                'weight': {},
             }
         ):
             metadata = {
@@ -521,7 +546,8 @@ class VideoDescriptorTest(unittest.TestCase):
         )
         self.descriptor.runtime.handler_url = MagicMock()
 
-    def test_get_context(self):
+    @patch('xmodule.video_module.video_module.get_course_for_item')
+    def test_get_context(self, mock_get_course):
         """"
         Test get_context.
 

--- a/lms/djangoapps/courseware/tests/test_video_scoring.py
+++ b/lms/djangoapps/courseware/tests/test_video_scoring.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Video xmodule tests in mongo."""
 from mock import Mock
+import json
 
 from . import BaseTestXmodule
 from .test_video_xml import SOURCE_XML
@@ -96,3 +97,31 @@ class TestVideoScoring(BaseTestXmodule):
         self.item = self.item_descriptor.xmodule_runtime.xmodule_instance
         self.item.module_score = 1
         self.assertEqual(self.item.graders(), {})
+
+    def test_cumulative_score_save_action(self):
+        metadata = {
+            'has_score': True,
+            'grade_videos': True,
+            'scored_on_end': True,
+        }
+        self.initialize_module(metadata=metadata)
+        self.item_descriptor.render('student_view')
+        self.item = self.item_descriptor.xmodule_runtime.xmodule_instance
+
+        expected_grader_before = {
+            'scored_on_end': {
+                'isScored': False, 'graderValue': True,
+                'graderState': None, 'saveState': False,
+            },
+        }
+        self.assertDictEqual(self.item.graders(), expected_grader_before)
+
+        new_grader_state = json.dumps({'scored_on_end': True})
+        output = self.item.cumulative_score_save_action(new_grader_state)
+        expected_grader_after = {
+            'scored_on_end': {
+                'isScored': False, 'graderValue': True,
+                'graderState': True, 'saveState': False,
+            },
+        }
+        self.assertDictEqual(output, expected_grader_after)

--- a/lms/djangoapps/courseware/tests/test_video_scoring.py
+++ b/lms/djangoapps/courseware/tests/test_video_scoring.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+"""Video xmodule tests in mongo."""
+from mock import Mock
+
+from . import BaseTestXmodule
+from .test_video_xml import SOURCE_XML
+
+
+class TestVideoScoring(BaseTestXmodule):
+
+    CATEGORY = "video"
+    DATA = SOURCE_XML
+    METADATA = {}
+
+    def setUp(self):
+        self.setup_course()
+
+    def test_maxscore(self):
+        self.initialize_module()
+        self.item_descriptor.render('student_view')
+        self.item = self.item_descriptor.xmodule_runtime.xmodule_instance
+        self.assertEqual(self.item.max_score(), None)
+
+    def test_update_score(self):
+        self.initialize_module()
+        self.initialize_module()
+        self.item_descriptor.render('student_view')
+        self.item = self.item_descriptor.xmodule_runtime.xmodule_instance
+
+        with self.assertRaises(NotImplementedError):
+            self.item.update_score(0.5)
+
+        self.item.runtime.get_real_user = Mock()
+        self.item.runtime.publish = Mock()
+        self.item.update_score(0.5)
+
+        self.assertEqual(self.item.module_score, 0.5)
+
+    def test_basic_grader(self):
+        """
+        Test if no grader selected.
+
+        Basic grader must be enabled.
+        """
+        metadata = {
+            'has_score': True,
+            'grade_videos': True,
+        }
+        self.initialize_module(metadata=metadata)
+        self.item_descriptor.render('student_view')
+        self.item = self.item_descriptor.xmodule_runtime.xmodule_instance
+
+        self.assertEqual(self.item.max_score(), self.item.weight)
+
+        expected_basic_grader = {
+            'basic_grader': {
+                'graderState': None,
+                'saveState': False,
+                'isScored': False,
+                'graderValue': True,
+            }
+        }
+
+        self.assertDictEqual(self.item.graders(), expected_basic_grader)
+
+    def test_graders(self):
+        metadata = {
+            'has_score': True,
+            'scored_on_end': True,
+            'scored_on_percent': 75,
+            'grade_videos': True,
+        }
+        self.initialize_module(metadata=metadata)
+        self.item_descriptor.render('student_view')
+        self.item = self.item_descriptor.xmodule_runtime.xmodule_instance
+        expected_graders = {
+            'scored_on_end': {
+                'isScored': False, 'graderValue': True,
+                'graderState': None, 'saveState': False,
+            },
+            'scored_on_percent': {
+                'isScored': False, 'graderValue': 75,
+                'graderState': None, 'saveState': True,
+            },
+        }
+        self.assertEqual(self.item.max_score(), self.item.weight)
+        self.assertDictEqual(self.item.graders(), expected_graders)
+
+    def test_scored_module(self):
+        metadata = {
+            'has_score': True,
+            'grade_videos': True,
+        }
+        self.initialize_module(metadata=metadata)
+        self.item_descriptor.render('student_view')
+        self.item = self.item_descriptor.xmodule_runtime.xmodule_instance
+        self.item.module_score = 1
+        self.assertEqual(self.item.graders(), {})

--- a/lms/djangoapps/courseware/tests/test_video_scoring.py
+++ b/lms/djangoapps/courseware/tests/test_video_scoring.py
@@ -117,11 +117,11 @@ class TestVideoScoring(BaseTestXmodule):
         self.assertDictEqual(self.item.graders(), expected_grader_before)
 
         new_grader_state = json.dumps({'scored_on_end': True})
-        output = self.item.cumulative_score_save_action(new_grader_state)
+        self.item.cumulative_score_save_action(new_grader_state)
         expected_grader_after = {
             'scored_on_end': {
                 'isScored': False, 'graderValue': True,
                 'graderState': True, 'saveState': False,
             },
         }
-        self.assertDictEqual(output, expected_grader_after)
+        self.assertDictEqual(self.item_descriptor.cumulative_score, expected_grader_after)

--- a/lms/templates/video.html
+++ b/lms/templates/video.html
@@ -1,7 +1,23 @@
 <%! from django.utils.translation import ugettext as _ %>
+<%! import json %>
 
 % if display_name is not UNDEFINED and display_name is not None:
-    <h2>${display_name}</h2>
+    <h2 class="video-header">${display_name}</h2>
+% endif
+
+% if has_score and max_score is not 'null':
+    <div class="problem-progress video-progress">
+        % if module_score is not 'null':
+            ## Translators: "points" is the student's achieved score, and "total_points" is the maximum number of points achievable.
+            (${_("{points} / {total_points} points").format(
+              points=module_score,
+              total_points=max_score
+            )})
+        % else:
+            ## Translators: "total_points" is the maximum number of points achievable
+            (${_("{total_points} points possible").format(total_points=max_score)})
+        % endif
+    </div>
 % endif
 
 <div
@@ -33,6 +49,11 @@
     data-yt-test-url="${yt_test_url}"
     data-transcript-translation-url="${transcript_translation_url}"
     data-transcript-available-translations-url="${transcript_available_translations_url}"
+    data-grade-url = "${grade_url}"
+    data-max-score = "${max_score}"
+    data-score = "${module_score}"
+    data-has-score = "${has_score}"
+    data-graders= '${graders}'
 
     ## For now, the option "data-autohide-html5" is hard coded. This option
     ## either enables or disables autohiding of controls and captions on mouse
@@ -146,3 +167,7 @@
     % endif
   </ul>
 </div>
+
+% if module_score is not 'null':
+  <div class="problem-feedback video-feedback">${_('You\'ve received credit for viewing this video.')}</div>
+% endif


### PR DESCRIPTION
**Ticket:** [BLD-1020](https://edx-wiki.atlassian.net/browse/BLD-1020)

**Description:**
This PR adds video player grading functionality.
To enable the functionality go to `advanced setting` find `video_grades` field and set it as `true`, then you can find new fields in the video player editor (`Advanced` tab):
A studio editor with a text box and two dropdowns. 
First dropdown defines whether students are graded for watching the video. Watching any portion of the video or downloading the video counts if neither of the other two options are selected. 
Text box (with validation for a percentage) allows author to select the percentage of video watched.
Dropdown allows author to select whether the student must reach the end. Downloading the video counts as reaching the end.

@jmclaus  - javascript part 
@srpearce - documentation, labels
@marcotuts - UI, UX
@rocha - logging
@muhammad-ammar - bok-choy tests

@sarina please review python part.

**Sandbox**:
http://studio.polesye.m.sandbox.edx.org/
