### PR TITLE
FIX - LMS: Dashboard Course Image Dimensions

### DIFF
--- a/lms/static/sass/multicourse/_dashboard.scss
+++ b/lms/static/sass/multicourse/_dashboard.scss
@@ -390,6 +390,7 @@
 
         img {
           width: 100%;
+          min-height: 100%;
         }
       }
 


### PR DESCRIPTION
resolving display issue where older/smaller courses images wouldn't fill the designated area on the student dashboard.
