### PR TITLE
reverting the upgrade

### DIFF
--- a/requirements/edx/post.txt
+++ b/requirements/edx/post.txt
@@ -5,4 +5,4 @@
 #   * One of @e0d, @jarv, or @feanil - to check system requirements
 
 # This must be installed after distribute has been updated.
-MySQL-python==1.2.5
+MySQL-python==1.2.4


### PR DESCRIPTION
An error was discovered in a single instance sandbox when running bulk-email tasks:

```
AttributeError: {'exc_message': "'Connection' object has no attribute 'get_autocommit'", 'exc_type': 'AttributeError'}
```

Rolling the library back fixed the issue.

@singingwolfboy @sarina 
