### PR TITLE
Specify that split_test_modules support children.

### DIFF
--- a/common/lib/xmodule/xmodule/split_test_module.py
+++ b/common/lib/xmodule/xmodule/split_test_module.py
@@ -21,6 +21,8 @@ log = logging.getLogger('edx.' + __name__)
 
 class SplitTestFields(object):
     """Fields needed for split test module"""
+    has_children = True
+
     user_partition_id = Integer(
         help="Which user partition is used for this test",
         scope=Scope.content


### PR DESCRIPTION
Specify that split_test modules support children so that Studio knows how to manipulate them correctly.
