### PR TITLE
Changing Student Anon ID Dump to return Course Specific IDs.

### DIFF
--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -1279,18 +1279,21 @@ class TestInstructorAPILevelsDataDump(ModuleStoreTestCase, LoginEnrollmentTestCa
             self.assertEqual(student_json['username'], student.username)
             self.assertEqual(student_json['email'], student.email)
 
+    @patch.object(instructor.views.api, 'anonymous_id_for_user', Mock(return_value='42'))
+    @patch.object(instructor.views.api, 'unique_id_for_user', Mock(return_value='41'))
     def test_get_anon_ids(self):
         """
         Test the CSV output for the anonymized user ids.
         """
         url = reverse('get_anon_ids', kwargs={'course_id': self.course.id})
-        with patch('instructor.views.api.unique_id_for_user') as mock_unique:
-            mock_unique.return_value = '42'
-            response = self.client.get(url, {})
+        response = self.client.get(url, {})
         self.assertEqual(response['Content-Type'], 'text/csv')
         body = response.content.replace('\r', '')
-        self.assertTrue(body.startswith('"User ID","Anonymized user ID"\n"2","42"\n'))
-        self.assertTrue(body.endswith('"7","42"\n'))
+        self.assertTrue(body.startswith(
+            '"User ID","Anonymized user ID","Course Specific Anonymized user ID"'
+            '\n"2","41","42"\n'
+        ))
+        self.assertTrue(body.endswith('"7","41","42"\n'))
 
     def test_list_report_downloads(self):
         url = reverse('list_report_downloads', kwargs={'course_id': self.course.id})

--- a/lms/djangoapps/instructor/tests/test_legacy_anon_csv.py
+++ b/lms/djangoapps/instructor/tests/test_legacy_anon_csv.py
@@ -17,11 +17,12 @@ from django.core.urlresolvers import reverse
 
 from courseware.tests.helpers import LoginEnrollmentTestCase
 from courseware.tests.modulestore_config import TEST_DATA_MIXED_MODULESTORE
+import instructor.views.legacy
 from student.roles import CourseStaffRole
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.django import modulestore, clear_existing_modulestores
 
-from mock import patch
+from mock import Mock, patch
 
 
 @override_settings(MODULESTORE=TEST_DATA_MIXED_MODULESTORE)
@@ -50,14 +51,17 @@ class TestInstructorDashboardAnonCSV(ModuleStoreTestCase, LoginEnrollmentTestCas
         self.login(self.instructor, self.password)
         self.enroll(self.toy)
 
+    @patch.object(instructor.views.legacy, 'anonymous_id_for_user', Mock(return_value='42'))
+    @patch.object(instructor.views.legacy, 'unique_id_for_user', Mock(return_value='41'))
     def test_download_anon_csv(self):
         course = self.toy
         url = reverse('instructor_dashboard_legacy', kwargs={'course_id': course.id})
-
-        with patch('instructor.views.legacy.unique_id_for_user') as mock_unique:
-            mock_unique.return_value = 42
-            response = self.client.post(url, {'action': 'Download CSV of all student anonymized IDs'})
+        response = self.client.post(url, {'action': 'Download CSV of all student anonymized IDs'})
 
         self.assertEqual(response['Content-Type'], 'text/csv')
         body = response.content.replace('\r', '')
-        self.assertEqual(body, '"User ID","Anonymized user ID"\n"2","42"\n')
+        self.assertEqual(
+            body,
+            ('"User ID","Anonymized user ID","Course Specific Anonymized user ID"'
+             '\n"2","41","42"\n')
+        )

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -33,7 +33,7 @@ from django_comment_common.models import (
 )
 
 from courseware.models import StudentModule
-from student.models import unique_id_for_user, CourseEnrollment
+from student.models import CourseEnrollment, unique_id_for_user, anonymous_id_for_user
 import instructor_task.api
 from instructor_task.api_helper import AlreadyRunningError
 from instructor_task.views import get_task_completion_info
@@ -619,8 +619,8 @@ def get_anon_ids(request, course_id):  # pylint: disable=W0613
     students = User.objects.filter(
         courseenrollment__course_id=course_id,
     ).order_by('id')
-    header = ['User ID', 'Anonymized user ID']
-    rows = [[s.id, unique_id_for_user(s)] for s in students]
+    header = ['User ID', 'Anonymized user ID', 'Course Specific Anonymized user ID']
+    rows = [[s.id, unique_id_for_user(s), anonymous_id_for_user(s, course_id)] for s in students]
     return csv_response(course_id.replace('/', '-') + '-anon-ids.csv', header, rows)
 
 

--- a/lms/djangoapps/instructor/views/legacy.py
+++ b/lms/djangoapps/instructor/views/legacy.py
@@ -36,7 +36,6 @@ from xmodule.html_module import HtmlDescriptor
 # Submissions is a Django app that is currently installed
 # from the edx-ora2 repo, although it will likely move in the future.
 from submissions import api as sub_api
-from student.models import anonymous_id_for_user
 
 from bulk_email.models import CourseEmail, CourseAuthorization
 from courseware import grades
@@ -64,7 +63,12 @@ from instructor_task.views import get_task_completion_info
 from edxmako.shortcuts import render_to_response, render_to_string
 from class_dashboard import dashboard_data
 from psychometrics import psychoanalyze
-from student.models import CourseEnrollment, CourseEnrollmentAllowed, unique_id_for_user
+from student.models import (
+    CourseEnrollment,
+    CourseEnrollmentAllowed,
+    unique_id_for_user,
+    anonymous_id_for_user
+)
 from student.views import course_from_id
 import track.views
 from xblock.field_data import DictFieldData
@@ -634,8 +638,8 @@ def instructor_dashboard(request, course_id):
             courseenrollment__course_id=course_id,
         ).order_by('id')
 
-        datatable = {'header': ['User ID', 'Anonymized user ID']}
-        datatable['data'] = [[s.id, unique_id_for_user(s)] for s in students]
+        datatable = {'header': ['User ID', 'Anonymized user ID', 'Course Specific Anonymized user ID']}
+        datatable['data'] = [[s.id, unique_id_for_user(s), anonymous_id_for_user(s, course_id)] for s in students]
         return return_csv(course_id.replace('/', '-') + '-anon-ids.csv', datatable)
 
     #----------------------------------------


### PR DESCRIPTION
Tests verified, manually tested.

@cpennington  Regarding our conversation this morning around the CSV action to pull anonymous user IDs, this PR would change the CSV to include the course-specific IDs. 

@Lyla-Fischer This change alters the contract of what is returned by this instructor dashboard action, is there any risk of impacting staff / instructors who may rely on the old Anonymous IDs? 

@wedaly 
