### PR TITLE
Add ADDL_INSTALLED_APPS to studio for parity with lms

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -168,6 +168,10 @@ ENV_FEATURES = ENV_TOKENS.get('FEATURES', ENV_TOKENS.get('MITX_FEATURES', {}))
 for feature, value in ENV_FEATURES.items():
     FEATURES[feature] = value
 
+# Additional installed apps
+for app in ENV_TOKENS.get('ADDL_INSTALLED_APPS', []):
+    INSTALLED_APPS += (app,)
+
 WIKI_ENABLED = ENV_TOKENS.get('WIKI_ENABLED', WIKI_ENABLED)
 
 LOGGING = get_logger_config(LOG_DIR,


### PR DESCRIPTION
Simple change to allow adding additional django apps to be added to studio like what is available on lms. 
@e0d @jarv @jbau
