### PR TITLE
Fix a bug in Individual Due Date Extensions (IDDE).

### DIFF
--- a/lms/djangoapps/instructor/tests/test_tools.py
+++ b/lms/djangoapps/instructor/tests/test_tools.py
@@ -199,10 +199,17 @@ class TestSetDueDateExtension(ModuleStoreTestCase):
 
     def test_set_due_date_extension(self):
         extended = datetime.datetime(2013, 12, 25, 0, 0, tzinfo=utc)
-        tools.set_due_date_extension(self.course, self.week1, self.user,
-                                     extended)
+        tools.set_due_date_extension(self.course, self.week1, self.user, extended)
         self.assertEqual(self.extended_due(self.week1), extended)
         self.assertEqual(self.extended_due(self.homework), extended)
+
+    def test_set_due_date_extension_create_studentmodule(self):
+        extended = datetime.datetime(2013, 12, 25, 0, 0, tzinfo=utc)
+        user = UserFactory.create()  # No student modules for this user
+        tools.set_due_date_extension(self.course, self.week1, user, extended)
+        extended_due = functools.partial(get_extended_due, self.course, student=user)
+        self.assertEqual(extended_due(self.week1), extended)
+        self.assertEqual(extended_due(self.homework), extended)
 
     def test_reset_due_date_extension(self):
         tools.set_due_date_extension(self.course, self.week1, self.user, None)


### PR DESCRIPTION
The IDDE implementation relied on a StudentModule being created for a
particular block in order to set the extended due date on that block.
Since StudentModules seem to be created on demand whenever data is
written to an attribute with Scope.user_state, it meant that if a
homework problem hadn't yet been touched by a student it was possible
that the due date extension wouldn't take effect for that problem, even
if the due date extension was successfully set for the parent unit.

This patch fixes this problem by creating new StudentModules as
necessary in order to make sure extended due dates propogate properly to
all problems in a unit.
