### PR TITLE
Fix bug affecting video transcripts in XMLModulesStore courses

### DIFF
--- a/common/lib/xmodule/xmodule/video_module/video_handlers.py
+++ b/common/lib/xmodule/xmodule/video_module/video_handlers.py
@@ -195,12 +195,21 @@ class VideoStudentViewHandlers(object):
 
         if transcript_name:
             course_location = CourseDescriptor.id_to_location(self.course_id)
-            course = self.descriptor.runtime.modulestore.get_item(course_location)
-            if course.static_asset_path:
+
+            # Get the asset path for course
+            asset_path = None
+            if hasattr(self.descriptor.runtime, 'modulestore'):
+                course = self.descriptor.runtime.modulestore.get_item(course_location)
+                asset_path = course.static_asset_path
+            else:
+                # Handle XML Courses that don't have modulestore in the runtime
+                asset_path = getattr(self.descriptor, 'data_dir', None)
+
+            if asset_path:
                 response = Response(
                     status=307,
                     location='/static/{0}/{1}'.format(
-                        course.static_asset_path,
+                        asset_path,
                         subs_filename(transcript_name, self.transcript_language)
                     )
                 )


### PR DESCRIPTION
This corrects a bug discovered on staging that was introduced by https://github.com/edx/edx-platform/pull/3213

It now checks for the presence of a modulestore in the run time and uses the data_dir to create the static path if it isn't there (the case with XMLModuleStore courses).

suggested reviewers: @auraz and @polesye since they reviewed the original transcript changes.
