### PR TITLE
Add logging of search quality information

### DIFF
--- a/docs/en_us/data/source/internal_data_formats/discussion_data.rst
+++ b/docs/en_us/data/source/internal_data_formats/discussion_data.rst
@@ -18,6 +18,8 @@ The primary collection that holds all of the discussion posts written by users i
 
 A sample of the field/value pairs that are in the mongo file, and descriptions of the attributes that these two types of objects share and that are specific to each type, follow.
 
+In addition to these collections, events are also emitted to track specific user activities. See :ref:`forum_events`.
+
 *********
 Samples
 *********

--- a/docs/en_us/data/source/internal_data_formats/event_list.rst
+++ b/docs/en_us/data/source/internal_data_formats/event_list.rst
@@ -38,6 +38,8 @@ Event List
      - :ref:`enrollment` and :ref:`instructor_enrollment`
    * - ``edx.course.enrollment.deactivated`` 
      - :ref:`enrollment` and :ref:`instructor_enrollment`
+   * - ``edx.forum.searched``
+     - :ref:`forum_events`
    * - ``get_anon_ids``
      - :ref:`Instructor_Event_Types`
    * - ``get_student_progress_page``

--- a/docs/en_us/data/source/internal_data_formats/tracking_logs.rst
+++ b/docs/en_us/data/source/internal_data_formats/tracking_logs.rst
@@ -292,6 +292,8 @@ outside the Instructor Dashboard.
 
 * :ref:`AB_Event_Types`
 
+* :ref:`forum_events`
+
 The descriptions that follow include what each event represents, the system
 component it originates from, the history of any changes made to the event over
 time, and any additional member fields that the ``context`` and ``event`` fields contain.
@@ -1761,6 +1763,33 @@ the child module that was shown to the student.
    * - ``child-id``
      - string
      - ID of the module that displays to the student. 
+
+.. _forum_events:
+
+==========================
+Forum Events
+==========================
+
+``edx.forum.searched``
+----------------------------------
+
+After a user executes a text search in the navigation sidebar of the Discussion tab of a course, the server emits an ``edx.forum.text_search`` event.
+
+**Component**: Discussion Tab
+
+**Event Source**: Server
+
+**History**: Added 16 May 2014.
+
+``event`` **Fields**:
+
++---------------------+---------------+---------------------------------------------------------------------+
+| Field               | Type          | Details                                                             |
++=====================+===============+=====================================================================+
+| ``query``           | string        | The text entered into the search box by the user.                   |
++---------------------+---------------+---------------------------------------------------------------------+
+| ``total_results``   | integer       | The total number of results matching the query.                     |
++---------------------+---------------+---------------------------------------------------------------------+
 
 .. _Instructor_Event_Types:
 


### PR DESCRIPTION
For now, this only includes course id, search terms, and result count.
Information is logged both to the standard logger for near-term analysis
and the event tracker for the longer term. Result count logging requires
commit 02466b1 of cs_comments_service (otherwise it will be null).

@jimabramson 
