### PR TITLE
i18n: Make translation works for video editor tabs

### DIFF
--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -44,6 +44,7 @@ def get_ext(filename):
 
 
 log = logging.getLogger(__name__)
+_ = lambda text: text
 
 
 class VideoModule(VideoFields, VideoStudentViewHandlers, XModule):
@@ -177,12 +178,12 @@ class VideoDescriptor(VideoFields, VideoStudioViewHandlers, TabsEditingDescripto
 
     tabs = [
         {
-            'name': "Basic",
+            'name': _("Basic"),
             'template': "video/transcripts.html",
             'current': True
         },
         {
-            'name': "Advanced",
+            'name': _("Advanced"),
             'template': "tabs/metadata-edit-tab.html"
         }
     ]
@@ -358,7 +359,7 @@ class VideoDescriptor(VideoFields, VideoStudioViewHandlers, TabsEditingDescripto
         _ = self.runtime.service(self, "i18n").ugettext
         video_url.update({
             'help': _('The URL for your video. This can be a YouTube URL or a link to an .mp4, .ogg, or .webm video file hosted elsewhere on the Internet.'),
-            'display_name': 'Default Video URL',
+            'display_name': _('Default Video URL'),
             'field_name': 'video_url',
             'type': 'VideoList',
             'default_value': [get_youtube_link(youtube_id_1_0['default_value'])]

--- a/common/lib/xmodule/xmodule/video_module/video_xfields.py
+++ b/common/lib/xmodule/xmodule/video_module/video_xfields.py
@@ -14,51 +14,52 @@ _ = lambda text: text
 class VideoFields(object):
     """Fields for `VideoModule` and `VideoDescriptor`."""
     display_name = String(
-        display_name="Component Display Name", help="The name students see. This name appears in the course ribbon and as a header for the video.",
+        help=_("The name students see. This name appears in the course ribbon and as a header for the video."),
+        display_name=_("Component Display Name"),
         default="Video",
         scope=Scope.settings
     )
 
     saved_video_position = RelativeTime(
-        help="Current position in the video.",
+        help=_("Current position in the video."),
         scope=Scope.user_state,
         default=datetime.timedelta(seconds=0)
     )
     # TODO: This should be moved to Scope.content, but this will
     # require data migration to support the old video module.
     youtube_id_1_0 = String(
-        help="Optional, for older browsers: the YouTube ID for the normal speed video.",
-        display_name="YouTube ID",
+        help=_("Optional, for older browsers: the YouTube ID for the normal speed video."),
+        display_name=_("YouTube ID"),
         scope=Scope.settings,
         default="OEoXaMPEzfM"
     )
     youtube_id_0_75 = String(
-        help="Optional, for older browsers: the YouTube ID for the .75x speed video.",
-        display_name="YouTube ID for .75x speed",
+        help=_("Optional, for older browsers: the YouTube ID for the .75x speed video."),
+        display_name=_("YouTube ID for .75x speed"),
         scope=Scope.settings,
         default=""
     )
     youtube_id_1_25 = String(
-        help="Optional, for older browsers: the YouTube ID for the 1.25x speed video.",
-        display_name="YouTube ID for 1.25x speed",
+        help=_("Optional, for older browsers: the YouTube ID for the 1.25x speed video."),
+        display_name=_("YouTube ID for 1.25x speed"),
         scope=Scope.settings,
         default=""
     )
     youtube_id_1_5 = String(
-        help="Optional, for older browsers: the YouTube ID for the 1.5x speed video.",
-        display_name="YouTube ID for 1.5x speed",
+        help=_("Optional, for older browsers: the YouTube ID for the 1.5x speed video."),
+        display_name=_("YouTube ID for 1.5x speed"),
         scope=Scope.settings,
         default=""
     )
     start_time = RelativeTime(  # datetime.timedelta object
-        help="Time you want the video to start if you don't want the entire video to play. Formatted as HH:MM:SS. The maximum value is 23:59:59.",
-        display_name="Video Start Time",
+        help=_("Time you want the video to start if you don't want the entire video to play. Formatted as HH:MM:SS. The maximum value is 23:59:59."),
+        display_name=_("Video Start Time"),
         scope=Scope.settings,
         default=datetime.timedelta(seconds=0)
     )
     end_time = RelativeTime(  # datetime.timedelta object
-        help="Time you want the video to stop if you don't want the entire video to play. Formatted as HH:MM:SS. The maximum value is 23:59:59.",
-        display_name="Video Stop Time",
+        help=_("Time you want the video to stop if you don't want the entire video to play. Formatted as HH:MM:SS. The maximum value is 23:59:59."),
+        display_name=_("Video Stop Time"),
         scope=Scope.settings,
         default=datetime.timedelta(seconds=0)
     )
@@ -67,61 +68,61 @@ class VideoFields(object):
     # `source` is deprecated field and should not be used in future.
     # `download_video` is used instead.
     source = String(
-        help="The external URL to download the video.",
-        display_name="Download Video",
+        help=_("The external URL to download the video."),
+        display_name=_("Download Video"),
         scope=Scope.settings,
         default=""
     )
     download_video = Boolean(
-        help="Allow students to download versions of this video in different formats if they cannot use the edX video player or do not have access to YouTube. You must add at least one non-YouTube URL in the Video File URLs field.",
-        display_name="Video Download Allowed",
+        help=_("Allow students to download versions of this video in different formats if they cannot use the edX video player or do not have access to YouTube. You must add at least one non-YouTube URL in the Video File URLs field."),
+        display_name=_("Video Download Allowed"),
         scope=Scope.settings,
         default=False
     )
     html5_sources = List(
-        help="The URL or URLs where you've posted non-YouTube versions of the video. Each URL must end in .mpeg, .mp4, .ogg, or .webm and cannot be a YouTube URL. Students will be able to view the first listed video that's compatible with the student's computer. To allow students to download these videos, set Video Download Allowed to True.",
-        display_name="Video File URLs",
+        help=_("The URL or URLs where you've posted non-YouTube versions of the video. Each URL must end in .mpeg, .mp4, .ogg, or .webm and cannot be a YouTube URL. Students will be able to view the first listed video that's compatible with the student's computer. To allow students to download these videos, set Video Download Allowed to True."),
+        display_name=_("Video File URLs"),
         scope=Scope.settings,
     )
     track = String(
-        help="By default, students can download an .srt or .txt transcript when you set Download Transcript Allowed to True. If you want to provide a downloadable transcript in a different format, we recommend that you upload a handout by using the Upload a Handout field. If this isn't possible, you can post a transcript file on the Files & Uploads page or on the Internet, and then add the URL for the transcript here. Students see a link to download that transcript below the video.",
-        display_name="Downloadable Transcript URL",
+        help=_("By default, students can download an .srt or .txt transcript when you set Download Transcript Allowed to True. If you want to provide a downloadable transcript in a different format, we recommend that you upload a handout by using the Upload a Handout field. If this isn't possible, you can post a transcript file on the Files & Uploads page or on the Internet, and then add the URL for the transcript here. Students see a link to download that transcript below the video."),
+        display_name=_("Downloadable Transcript URL"),
         scope=Scope.settings,
         default=''
     )
     download_track = Boolean(
-        help="Allow students to download the timed transcript. A link to download the file appears below the video. By default, the transcript is an .srt or .txt file. If you want to provide the transcript for download in a different format, upload a file by using the Upload Handout field.",
-        display_name="Download Transcript Allowed",
+        help=_("Allow students to download the timed transcript. A link to download the file appears below the video. By default, the transcript is an .srt or .txt file. If you want to provide the transcript for download in a different format, upload a file by using the Upload Handout field."),
+        display_name=_("Download Transcript Allowed"),
         scope=Scope.settings,
         default=False
     )
     sub = String(
-        help="The default transcript for the video, from the Default Timed Transcript field on the Basic tab. This transcript should be in English. You don't have to change this setting.",
-        display_name="Default Timed Transcript",
+        help=_("The default transcript for the video, from the Default Timed Transcript field on the Basic tab. This transcript should be in English. You don't have to change this setting."),
+        display_name=_("Default Timed Transcript"),
         scope=Scope.settings,
         default=""
     )
     show_captions = Boolean(
-        help="Specify whether the transcripts appear with the video by default.",
-        display_name="Show Transcript",
+        help=_("Specify whether the transcripts appear with the video by default."),
+        display_name=_("Show Transcript"),
         scope=Scope.settings,
         default=True
     )
     # Data format: {'de': 'german_translation', 'uk': 'ukrainian_translation'}
     transcripts = Dict(
-        help="Add transcripts in different languages. Click below to specify a language and upload an .srt transcript file for that language.",
-        display_name="Transcript Languages",
+        help=_("Add transcripts in different languages. Click below to specify a language and upload an .srt transcript file for that language."),
+        display_name=_("Transcript Languages"),
         scope=Scope.settings,
         default={}
     )
     transcript_language = String(
-        help="Preferred language for transcript.",
-        display_name="Preferred language for transcript",
+        help=_("Preferred language for transcript."),
+        display_name=_("Preferred language for transcript"),
         scope=Scope.preferences,
         default="en"
     )
     transcript_download_format = String(
-        help="Transcript file format to download by user.",
+        help=_("Transcript file format to download by user."),
         scope=Scope.preferences,
         values=[
             # Translators: This is a type of file used for captioning in the video player.
@@ -131,22 +132,22 @@ class VideoFields(object):
         default='srt',
     )
     speed = Float(
-        help="The last speed that the user specified for the video.",
+        help=_("The last speed that the user specified for the video."),
         scope=Scope.user_state,
     )
     global_speed = Float(
-        help="The default speed for the video.",
+        help=_("The default speed for the video."),
         scope=Scope.preferences,
         default=1.0
     )
     youtube_is_available = Boolean(
-        help="Specify whether YouTube is available for the user.",
+        help=_("Specify whether YouTube is available for the user."),
         scope=Scope.user_info,
         default=True
     )
 
     handout = String(
-        help="Upload a handout to accompany this video. Students can download the handout by clicking Download Handout under the video.",
-        display_name="Upload Handout",
+        help=_("Upload a handout to accompany this video. Students can download the handout by clicking Download Handout under the video."),
+        display_name=_("Upload Handout"),
         scope=Scope.settings,
     )

--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -788,11 +788,14 @@ class XModuleDescriptor(XModuleMixin, HTMLSnippet, ResourceTemplates, XBlock):
             if field.scope != Scope.settings or field in self.non_editable_metadata_fields:
                 continue
 
+            def get_text(value):
+                return self.runtime.service(self, "i18n").ugettext(value) if value is not None else None
+
             # gets the 'default_value' and 'explicitly_set' attrs
             metadata_fields[field.name] = self.runtime.get_field_provenance(self, field)
             metadata_fields[field.name]['field_name'] = field.name
-            metadata_fields[field.name]['display_name'] = field.display_name
-            metadata_fields[field.name]['help'] = field.help
+            metadata_fields[field.name]['display_name'] = get_text(field.display_name)
+            metadata_fields[field.name]['help'] = get_text(field.help)
             metadata_fields[field.name]['value'] = field.read_json(self)
 
             # We support the following editors:

--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -778,6 +778,13 @@ class XModuleDescriptor(XModuleMixin, HTMLSnippet, ResourceTemplates, XBlock):
                 json_choice = field.to_json(json_choice)
             return json_choice
 
+        def get_text(value):
+            """Localize a text value that might be None."""
+            if value is None:
+                return None
+            else:
+                return self.runtime.service(self, "i18n").ugettext(value)
+
         metadata_fields = {}
 
         # Only use the fields from this class, not mixins
@@ -787,9 +794,6 @@ class XModuleDescriptor(XModuleMixin, HTMLSnippet, ResourceTemplates, XBlock):
 
             if field.scope != Scope.settings or field in self.non_editable_metadata_fields:
                 continue
-
-            def get_text(value):
-                return self.runtime.service(self, "i18n").ugettext(value) if value is not None else None
 
             # gets the 'default_value' and 'explicitly_set' attrs
             metadata_fields[field.name] = self.runtime.get_field_provenance(self, field)


### PR DESCRIPTION
Now the display_name & help strings in video editor tabs can be extracted and translated.
