### PR TITLE
Reset, delete and rescore not working on staff debug info

### DIFF
--- a/lms/static/js/staff_debug_actions.js
+++ b/lms/static/js/staff_debug_actions.js
@@ -111,15 +111,15 @@ var StaffDebug = (function(){
 
 // Register click handlers
 $(document).ready(function() {
-    $('#staff-debug-reset').click(function() {
+    $('.staff-debug-reset').click(function() {
         StaffDebug.reset($(this).data('location'));
         return false;
     });
-    $('#staff-debug-sdelete').click(function() {
+    $('.staff-debug-sdelete').click(function() {
         StaffDebug.sdelete($(this).data('location'));
         return false;
     });
-    $('#staff-debug-rescore').click(function() {
+    $('.staff-debug-rescore').click(function() {
         StaffDebug.rescore($(this).data('location'));
         return false;
     });

--- a/lms/templates/instructor/instructor_dashboard_2/student_admin.html
+++ b/lms/templates/instructor/instructor_dashboard_2/student_admin.html
@@ -10,7 +10,7 @@
       </p>
       <br>
       <p>
-	<a href="${ section_data['spoc_gradebook_url'] }" class="progress-link"> ${_("View Gradebook")} </a>
+	<a href="${ section_data['spoc_gradebook_url'] }" class="gradebook-link"> ${_("View Gradebook")} </a>
       </p>
     <hr>
   %endif

--- a/lms/templates/staff_problem_info.html
+++ b/lms/templates/staff_problem_info.html
@@ -63,11 +63,11 @@ ${block_content}
       </div>
       <div>
         [
-        <a href="#" id="staff-debug-reset" data-location="${location.name}">${_('Reset Student Attempts')}</a>
+        <a href="#" id="staff-debug-reset" class="staff-debug-reset" data-location="${location.name}">${_('Reset Student Attempts')}</a>
         |
-        <a href="#" id="staff-debug-sdelete" data-location="${location.name}">${_('Delete Student State')}</a>
+        <a href="#" id="staff-debug-sdelete" class="staff-debug-sdelete" data-location="${location.name}">${_('Delete Student State')}</a>
         |
-        <a href="#" id="staff-debug-rescore" data-location="${location.name}">${_('Rescore Student Submission')}</a>
+        <a href="#" id="staff-debug-rescore" class="staff-debug-rescore" data-location="${location.name}">${_('Rescore Student Submission')}</a>
         
         ]
       </div>


### PR DESCRIPTION
LMS-2706

Reseting student attempts and deleting student state not working on RC.

It was working for only first parts because click events were bound with "id" of elements not with class, when we bind a click event with "id" it will only bind with first element found on the page with this id.
