### PR TITLE
Fix for bulk email not working in Firefox

### DIFF
--- a/lms/templates/courseware/instructor_dashboard.html
+++ b/lms/templates/courseware/instructor_dashboard.html
@@ -17,6 +17,13 @@
 <%static:css group='style-vendor-tinymce-skin'/>
 <%static:css group='style-course'/>
 
+  <script type="text/javascript">
+    // This is a hack to get tinymce to work correctly in Firefox until the annotator tool is refactored to not include
+    // tinymce globally.
+    if(typeof window.Range.prototype === "undefined") {
+        window.Range.prototype = { };
+    }
+  </script>
   <script type="text/javascript" src="${static.url('js/vendor/flot/jquery.flot.js')}"></script>
   <script type="text/javascript" src="${static.url('js/vendor/flot/jquery.flot.axislabels.js')}"></script>
   <script type="text/javascript" src="${static.url('js/vendor/jquery-jvectormap-1.1.1/jquery-jvectormap-1.1.1.min.js')}"></script>

--- a/lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html
+++ b/lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html
@@ -25,6 +25,13 @@
   <%static:css group='style-vendor-tinymce-content'/>
   <%static:css group='style-vendor-tinymce-skin'/>
   <%static:css group='style-course'/>
+  <script type="text/javascript">
+    // This is a hack to get tinymce to work correctly in Firefox until the annotator tool is refactored to not include
+    // tinymce globally.
+    if(typeof window.Range.prototype === "undefined") {
+        window.Range.prototype = { };
+    }
+  </script>
   <script type="text/javascript" src="${static.url('js/vendor/underscore-min.js')}"></script>
   <script type="text/javascript" src="${static.url('js/vendor/mustache.js')}"></script>
   <script type="text/javascript" src="${static.url('js/vendor/flot/jquery.flot.js')}"></script>


### PR DESCRIPTION
A hack to get instructor email to work in Firefox while the video annotator tool is refactored to not bundle its own tinymce globally.

This should be reverted when this PR gets merged in: https://github.com/edx/edx-platform/pull/3529
It does not look like that is going to happen soon hence the need for this hack.
