### PR TITLE
Correcting "make html" errors

### DIFF
--- a/docs/en_us/course_authors/source/exercises_tools/problem_with_hint.rst
+++ b/docs/en_us/course_authors/source/exercises_tools/problem_with_hint.rst
@@ -57,7 +57,7 @@ To create the above problem:
 	    </text>
     </problem>
 
-.. _Drag and Drop Problem XML:
+.. _Problem with Adaptive Hint XML:
 
 *********************************
 Problem with Adaptive Hint XML

--- a/docs/en_us/course_authors/source/exercises_tools/vitalsource.rst
+++ b/docs/en_us/course_authors/source/exercises_tools/vitalsource.rst
@@ -10,7 +10,7 @@ The VitalSource Bookshelf e-reader tool provides your students with easy access 
    :width: 500
    :alt: VitalSource e-book with highlighted note
 
-For more information about Vital Source and its features, visit the `VitalSource Bookshelf support site <https://support.vitalsource.com/hc/en-us>`_.
+For more information about Vital Source and its features, visit the `VitalSource Bookshelf support site <https://support.vitalsource.com>`_.
 
 .. note:: Before you add a VitalSource Bookshelf e-reader to your course, you must work with Vital Source to make sure the content you need already exists in the Vital Source inventory. If the content is not yet available, Vital Source works with the publisher of the e-book to create an e-book that meets the VitalSource Bookshelf specifications. **This process can take up to four months.** The following steps assume that the e-book you want is already part of the Vital Source inventory.
 

--- a/docs/en_us/course_authors/source/releasing_course/beta_testing.rst
+++ b/docs/en_us/course_authors/source/releasing_course/beta_testing.rst
@@ -194,9 +194,9 @@ When you add beta testers, note the following.
 
 .. _Add_Testers_Bulk:
 
---------------------------
+================================
 Add Multiple Beta Testers
---------------------------
+================================
 
 If you have a number of beta testers that you want to add, you can use the "batch
 add" option to add them all at once, rather than individually. With this
@@ -229,9 +229,9 @@ testers**.
 
 .. note:: The **Auto Enroll** option has no effect when you click **Remove beta testers**. The user's role as a beta tester is removed; course enrollment is not affected.
 
------------------------------
+================================
 Add Beta Testers Individually
------------------------------
+================================
 
 To add a single beta tester:
 


### PR DESCRIPTION
@mhoeber @srpearce I made an html version of the course-authors guide this morning and got some errors. 

.../course_authors/source/exercises_tools/problem_with_hint.rst:64: WARNING: duplicate label drag and drop problem xml, other instance in .../course_authors/source/exercises_tools/drag_and_drop.rst
.../course_authors/source/exercises_tools/vitalsource.rst:5: WARNING: Duplicate explicit target name: "vitalsource bookshelf support site".
.../course_authors/source/releasing_course/beta_testing.rst:198: SEVERE: Title level inconsistent: (2 of these)

I made these changes to correct them. 
