### PR TITLE
Puts course listings in a sane order

### DIFF
--- a/common/djangoapps/student/tests/test_course_listing.py
+++ b/common/djangoapps/student/tests/test_course_listing.py
@@ -88,6 +88,7 @@ class TestCourseListing(ModuleStoreTestCase):
             courses_list = list(get_course_enrollment_pairs(self.student, None, []))
             self.assertEqual(courses_list, [])
 
+    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
     def test_course_listing_errored_deleted_courses(self):
         """
         Create good courses, courses that won't load, and deleted courses which still have

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1,13 +1,13 @@
 """
 Student Views
 """
-import datetime
 import logging
 import re
 import uuid
 import time
 import json
 from collections import defaultdict
+from datetime import datetime
 from pytz import UTC
 
 from django.conf import settings
@@ -42,6 +42,7 @@ from edxmako.shortcuts import render_to_response, render_to_string
 from mako.exceptions import TopLevelLookupException
 
 from course_modes.models import CourseMode
+
 from student.models import (
     Registration, UserProfile, PendingNameChange,
     PendingEmailChange, CourseEnrollment, unique_id_for_user,
@@ -64,6 +65,7 @@ from collections import namedtuple
 
 from courseware.courses import get_courses, sort_by_announcement
 from courseware.access import has_access
+from courseware.models import course_modified_times
 
 from django_comment_common.models import Role
 
@@ -226,7 +228,7 @@ def single_course_reverification_info(user, course, enrollment):  # pylint: disa
         ReverifyInfo: (course_id, course_name, course_number, date, status)
         OR, None: None if there is no re-verification info for this enrollment
     """
-    window = MidcourseReverificationWindow.get_window(course.id, datetime.datetime.now(UTC))
+    window = MidcourseReverificationWindow.get_window(course.id, datetime.now(UTC))
 
     # If there's no window OR the user is not verified, we don't get reverification info
     if (not window) or (enrollment.mode != "verified"):
@@ -244,6 +246,8 @@ def get_course_enrollment_pairs(user, course_org_filter, org_filter_out_set):
     Get the relevant set of (Course, CourseEnrollment) pairs to be displayed on
     a student's dashboard.
     """
+    pairs = []
+
     for enrollment in CourseEnrollment.enrollments_for_user(user):
         course = modulestore().get_course(enrollment.course_id)
         if course and not isinstance(course, ErrorDescriptor):
@@ -257,12 +261,18 @@ def get_course_enrollment_pairs(user, course_org_filter, org_filter_out_set):
             elif course.location.org in org_filter_out_set:
                 continue
 
-            yield (course, enrollment)
+            pairs.append((course, enrollment))
         else:
             log.error("User {0} enrolled in {2} course {1}".format(
                 user.username, enrollment.course_id, "broken" if course else "non-existent"
             ))
 
+    ## Sort pairs in order of courseware access. If I am actively using a course, it should bubble up to the top.
+    modified_times_map = course_modified_times(user, [p[0].scope_ids.usage_id for p in pairs])
+    def key_function(x):
+        return modified_times_map.get(unicode(x[0].scope_ids.usage_id), datetime.min)
+    pairs.sort(key=key_function, reverse=True)
+    return pairs
 
 def _cert_info(user, course, cert_status):
     """
@@ -429,7 +439,7 @@ def complete_course_mode_info(course_id, enrollment):
         mode_info['show_upsell'] = True
         # if there is an expiration date, find out how long from now it is
         if modes['verified'].expiration_datetime:
-            today = datetime.datetime.now(UTC).date()
+            today = datetime.now(UTC).date()
             mode_info['days_for_upsell'] = (modes['verified'].expiration_datetime.date() - today).days
 
     return mode_info
@@ -1167,7 +1177,7 @@ def disable_account_ajax(request):
             context['message'] = _("Unexpected account status")
             return JsonResponse(context, status=400)
         user_account.changed_by = request.user
-        user_account.standing_last_changed_at = datetime.datetime.now(UTC)
+        user_account.standing_last_changed_at = datetime.now(UTC)
         user_account.save()
 
     return JsonResponse(context)
@@ -1552,7 +1562,7 @@ def create_account(request, post_override=None):  # pylint: disable-msg=too-many
 
     if do_external_auth:
         eamap.user = new_user
-        eamap.dtsignup = datetime.datetime.now(UTC)
+        eamap.dtsignup = datetime.now(UTC)
         eamap.save()
         AUDIT_LOG.info("User registered with external_auth %s", post_vars['username'])
         AUDIT_LOG.info('Updated ExternalAuthMap for %s to be %s', post_vars['username'], eamap)
@@ -1980,7 +1990,7 @@ def confirm_email_change(request, key):  # pylint: disable=unused-argument
         meta = u_prof.get_meta()
         if 'old_emails' not in meta:
             meta['old_emails'] = []
-        meta['old_emails'].append([user.email, datetime.datetime.now(UTC).isoformat()])
+        meta['old_emails'].append([user.email, datetime.now(UTC).isoformat()])
         u_prof.set_meta(meta)
         u_prof.save()
         # Send it to the old email...
@@ -2100,7 +2110,7 @@ def accept_name_change_by_id(uid):
     meta = u_prof.get_meta()
     if 'old_names' not in meta:
         meta['old_names'] = []
-    meta['old_names'].append([u_prof.name, pnc.rationale, datetime.datetime.now(UTC).isoformat()])
+    meta['old_names'].append([u_prof.name, pnc.rationale, datetime.now(UTC).isoformat()])
     u_prof.set_meta(meta)
 
     u_prof.name = pnc.new_name

--- a/common/test/acceptance/pages/lms/dashboard.py
+++ b/common/test/acceptance/pages/lms/dashboard.py
@@ -20,8 +20,8 @@ class DashboardPage(PageObject):
         return self.q(css='section.my-courses').present
 
     @property
-    def current_courses_text(self):
-        text_items = self.q(css='section#my-courses').text
+    def courses_text(self):
+        text_items = self.q(css='section#my-courses span.my-courses-title-label').text
         if len(text_items) > 0:
             return text_items[0]
         else:

--- a/common/test/acceptance/tests/test_lms.py
+++ b/common/test/acceptance/tests/test_lms.py
@@ -77,10 +77,10 @@ class LanguageTest(UniqueCourseTest):
         self.dashboard_page = DashboardPage(self.browser)
 
         self.test_new_lang = 'eo'
-        # This string is unicode for "ÇÜRRÉNT ÇØÜRSÉS", which should appear in our Dummy Esperanto page
+        # This string is unicode for "ÇØÜRSÉS", which should appear in our Dummy Esperanto page
         # We store the string this way because Selenium seems to try and read in strings from
         # the HTML in this format. Ideally we could just store the raw ÇÜRRÉNT ÇØÜRSÉS string here
-        self.current_courses_text = u'\xc7\xdcRR\xc9NT \xc7\xd6\xdcRS\xc9S'
+        self.courses_text = u'\xc7\xd6\xdcRS\xc9S'
 
         self.username = "test"
         self.password = "testpass"
@@ -92,10 +92,10 @@ class LanguageTest(UniqueCourseTest):
         # Change language to Dummy Esperanto
         self.dashboard_page.change_language(self.test_new_lang)
 
-        changed_text = self.dashboard_page.current_courses_text
+        changed_text = self.dashboard_page.courses_text
 
         # We should see the dummy-language text on the page
-        self.assertIn(self.current_courses_text, changed_text)
+        self.assertIn(self.courses_text, changed_text)
 
     def test_language_persists(self):
         auto_auth_page = AutoAuthPage(self.browser, username=self.username, password=self.password, email=self.email, course_id=self.course_id)
@@ -113,10 +113,10 @@ class LanguageTest(UniqueCourseTest):
 
         self.dashboard_page.visit()
 
-        changed_text = self.dashboard_page.current_courses_text
+        changed_text = self.dashboard_page.courses_text
 
         # We should see the dummy-language text on the page
-        self.assertIn(self.current_courses_text, changed_text)
+        self.assertIn(self.courses_text, changed_text)
 
 
 class HighLevelTabTest(UniqueCourseTest):

--- a/lms/djangoapps/courseware/models.py
+++ b/lms/djangoapps/courseware/models.py
@@ -93,6 +93,12 @@ class StudentModule(models.Model):
         return unicode(repr(self))
 
 
+def course_modified_times(user, ids):
+    ''' Returns the times when a given studentmodule was last modified.
+    '''
+    results = StudentModule.objects.filter(student=user, module_state_key__in=ids).values_list('module_state_key', 'modified')
+    return dict(results)
+
 class StudentModuleHistory(models.Model):
     """Keeps a complete history of state changes for a given XModule for a given
     Student. Right now, we restrict this to problems so that the table doesn't

--- a/lms/static/sass/multicourse/_dashboard.scss
+++ b/lms/static/sass/multicourse/_dashboard.scss
@@ -308,6 +308,28 @@
       margin-bottom: 30px;
     }
 
+    // my courses title
+    .my-courses-title {
+      @include clearfix();
+    }
+
+    .my-courses-title-label {
+      display: inline-block;
+      vertical-align: middle;
+      width: flex-grid(6, 9);
+    }
+
+    .my-courses-title-description {
+      @extend %t-title7;
+      display: inline-block;
+      vertical-align: middle;
+      width: flex-grid(3, 9);
+      text-transform: lowercase;
+      text-align: right;
+      letter-spacing: 0;
+      color: $lighter-base-font-color;
+    }
+
     .empty-dashboard-message {
       padding: 60px 0px;
       text-align: center;

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -291,7 +291,7 @@
 
   <section class="my-courses" id="my-courses">
     <header>
-      <h2>${_("Current Courses")}</h2>
+      <div style="display:flex"><h2>${_("Courses")} </h2><div style="flex-grow:1"></div><div style="font-size: 13px; color: #646464;">${_("ordered by recent activity")}</div></div>
     </header>
 
     % if len(course_enrollment_pairs) > 0:

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -291,7 +291,10 @@
 
   <section class="my-courses" id="my-courses">
     <header>
-      <div style="display:flex"><h2>${_("Courses")} </h2><div style="flex-grow:1"></div><div style="font-size: 13px; color: #646464;">${_("ordered by recent activity")}</div></div>
+      <h2 class="my-courses-title">
+        <span class="my-courses-title-label">${_("Courses")}</span>
+        <span class="my-courses-title-description">${_("ordered by recent activity")}</span>
+      </h2>
     </header>
 
     % if len(course_enrollment_pairs) > 0:


### PR DESCRIPTION
@cpennington @nedbat Right now, if I go to edx.org, and look at the courses I'm taking, I have to scroll through 6 pages of things I signed up for but never touched. This is a supremely bad user experience. I'm sure I did a ton of things wrong, but this code applies a heuristic where courses are ordered on the page in roughly the order in which I last visited them (defined as "clicked around in courseware a little bit"). Recent courses are on top. Old courses are on bottom. I can go to courses I'm active in quickly and immediately. 
