### PR TITLE
Revert ORA2 release back to 05-05-14

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -26,7 +26,7 @@
 -e git+https://github.com/edx/bok-choy.git@82b4e82d79b9d4c6d087ebbfa26ea23235728e62#egg=bok_choy
 -e git+https://github.com/edx-solutions/django-splash.git@9965a53c269666a30bb4e2b3f6037c138aef2a55#egg=django-splash
 -e git+https://github.com/edx/acid-block.git@459aff7b63db8f2c5decd1755706c1a64fb4ebb1#egg=acid-xblock
--e git+https://github.com/edx/edx-ora2.git@release-2014-05-12T12.57#egg=edx-ora2
+-e git+https://github.com/edx/edx-ora2.git@release-2014-05-05T12.00#egg=edx-ora2
 
 # Prototype XBlocks for limited roll-outs and user testing. These are not for general use.
 -e git+https://github.com/pmitros/ConceptXBlock.git@2376fde9ebdd83684b78dde77ef96361c3bd1aa0#egg=concept-xblock


### PR DESCRIPTION
Response to [TIM-572](https://edx-wiki.atlassian.net/browse/TIM-572) while we determine and fix the underlying cause.

There is a reverse migration in this PR that will delete a new table that was introduced.  We should skip this reverse migration.

@brianhw @stephensanchez 
