### PR TITLE
show a friendly message for an empty course rather than an error page

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -151,3 +151,4 @@ Steven Burch <stv@stanford.edu>
 Waqas Khalid <wkhalid@edx.org>
 Muhammad Ammar <mammar@edx.org>
 Abdallah Nassif <abdoosh00@gmail.com>
+Johnny Brown <johnnybrown7@gmail.com>

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore.py
@@ -506,6 +506,42 @@ class SplitModuleTest(unittest.TestCase):
                 return element
 
 
+class TestHasChildrenAtDepth(SplitModuleTest):
+    """Test the has_children_at_depth method of XModuleMixin. """
+
+    def test_has_children_at_depth(self):
+        course_locator = CourseLocator(
+            org='testx', offering='GreekHero', branch='draft'
+        )
+        block_locator = BlockUsageLocator(
+            course_locator, 'course', 'head12345'
+        )
+        block = modulestore().get_item(block_locator)
+
+        self.assertRaises(
+            ValueError, block.has_children_at_depth, -1,
+        )
+        self.assertTrue(block.has_children_at_depth(0))
+        self.assertTrue(block.has_children_at_depth(1))
+        self.assertFalse(block.has_children_at_depth(2))
+
+        ch1 = modulestore().get_item(
+            BlockUsageLocator(course_locator, 'chapter', block_id='chapter1')
+        )
+        self.assertFalse(ch1.has_children_at_depth(0))
+
+        ch2 = modulestore().get_item(
+            BlockUsageLocator(course_locator, 'chapter', block_id='chapter2')
+        )
+        self.assertFalse(ch2.has_children_at_depth(0))
+
+        ch3 = modulestore().get_item(
+            BlockUsageLocator(course_locator, 'chapter', block_id='chapter3')
+        )
+        self.assertTrue(ch3.has_children_at_depth(0))
+        self.assertFalse(ch3.has_children_at_depth(1))
+
+
 class SplitModuleCourseTests(SplitModuleTest):
     '''
     Course CRUD operation tests

--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -209,6 +209,29 @@ class XModuleMixin(XBlockMixin):
                 result[field.name] = field.read_json(self)
         return result
 
+    def has_children_at_depth(self, depth):
+        """
+        Returns true if self has children at the given depth. depth==0 returns
+        false if self is a leaf, true otherwise.
+
+                           SELF
+                            |
+                     [child at depth 0]
+                     /           \
+                 [depth 1]    [depth 1]
+                 /       \
+           [depth 2]   [depth 2]
+
+        So the example above would return True for `has_children_at_depth(2)`, and False
+        for depth > 2
+        """
+        if depth < 0:
+            raise ValueError("negative depth argument is invalid")
+        elif depth == 0:
+            return bool(self.get_children())
+        else:
+            return any(child.has_children_at_depth(depth - 1) for child in self.get_children())
+
     def get_content_titles(self):
         """
         Returns list of content titles for all of self's children.

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -145,7 +145,7 @@ class ViewsTestCase(TestCase):
         mock_module.position = 3
         mock_module.get_display_items.return_value = []
         self.assertRaises(Http404, views.redirect_to_course_position,
-                          mock_module)
+                          mock_module, views.CONTENT_DEPTH)
 
     def test_registered_for_course(self):
         self.assertFalse(views.registered_for_course('Basketweaving', None))

--- a/lms/djangoapps/courseware/views.py
+++ b/lms/djangoapps/courseware/views.py
@@ -52,6 +52,7 @@ log = logging.getLogger("edx.courseware")
 
 template_imports = {'urllib': urllib}
 
+CONTENT_DEPTH = 2
 
 def user_groups(user):
     """
@@ -113,17 +114,36 @@ def render_accordion(request, course, chapter, section, field_data_cache):
     return render_to_string('courseware/accordion.html', context)
 
 
-def get_current_child(xmodule):
+def get_current_child(xmodule, min_depth=None):
     """
     Get the xmodule.position's display item of an xmodule that has a position and
-    children.  If xmodule has no position or is out of bounds, return the first child.
+    children.  If xmodule has no position or is out of bounds, return the first
+    child with children extending down to content_depth.
+
+    For example, if chapter_one has no position set, with two child sections,
+    section-A having no children and section-B having a discussion unit,
+    `get_current_child(chapter, min_depth=1)`  will return section-B.
+
     Returns None only if there are no children at all.
     """
+    def _get_default_child_module(child_modules):
+        """Returns the first child of xmodule, subject to min_depth."""
+        if not child_modules:
+            default_child = None
+        elif not min_depth > 0:
+            default_child = child_modules[0]
+        else:
+            content_children = [child for child in child_modules if
+                                child.has_children_at_depth(min_depth - 1)]
+            default_child = content_children[0] if content_children else None
+
+        return default_child
+
     if not hasattr(xmodule, 'position'):
         return None
 
     if xmodule.position is None:
-        pos = 0
+        return _get_default_child_module(xmodule.get_display_items())
     else:
         # position is 1-indexed.
         pos = xmodule.position - 1
@@ -132,14 +152,15 @@ def get_current_child(xmodule):
     if 0 <= pos < len(children):
         child = children[pos]
     elif len(children) > 0:
-        # Something is wrong.  Default to first child
-        child = children[0]
+        # module has a set position, but the position is out of range.
+        # return default child.
+        child = _get_default_child_module(children)
     else:
         child = None
     return child
 
 
-def redirect_to_course_position(course_module):
+def redirect_to_course_position(course_module, content_depth):
     """
     Return a redirect to the user's current place in the course.
 
@@ -153,7 +174,7 @@ def redirect_to_course_position(course_module):
 
     """
     urlargs = {'course_id': course_module.id.to_deprecated_string()}
-    chapter = get_current_child(course_module)
+    chapter = get_current_child(course_module, min_depth=content_depth)
     if chapter is None:
         # oops.  Something bad has happened.
         raise Http404("No chapter found when loading current position in course")
@@ -163,7 +184,7 @@ def redirect_to_course_position(course_module):
         return redirect(reverse('courseware_chapter', kwargs=urlargs))
 
     # Relying on default of returning first child
-    section = get_current_child(chapter)
+    section = get_current_child(chapter, min_depth=content_depth - 1)
     if section is None:
         raise Http404("No section found when loading current position in course")
 
@@ -266,9 +287,6 @@ def index(request, course_id, chapter=None, section=None,
 
         studio_url = get_studio_url(course_key, 'course')
 
-        if chapter is None:
-            return redirect_to_course_position(course_module)
-
         context = {
             'csrf': csrf(request)['csrf_token'],
             'accordion': render_accordion(request, course, chapter, section, field_data_cache),
@@ -282,6 +300,15 @@ def index(request, course_id, chapter=None, section=None,
             'xqa_server': settings.FEATURES.get('USE_XQA_SERVER', 'http://xqa:server@content-qa.mitx.mit.edu/xqa'),
             'reverifications': fetch_reverify_banner_info(request, course_key),
         }
+
+        has_content = course.has_children_at_depth(CONTENT_DEPTH)
+        if not has_content:
+            # Show empty courseware for a course with no units
+            return render_to_response('courseware/courseware.html', context)
+        elif chapter is None:
+            # passing CONTENT_DEPTH avoids returning 404 for a course with an
+            # empty first section and a second section with content
+            return redirect_to_course_position(course_module, CONTENT_DEPTH)
 
         # Only show the chat if it's enabled by the course and in the
         # settings.

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -195,7 +195,11 @@ ${fragment.foot_html()}
 
       <div id="accordion" style="display: none">
         <nav aria-label="${_('Course Navigation')}">
-          ${accordion}
+          % if accordion.strip():
+            ${accordion}
+          % else:
+            <div class="chapter">${_("No content has been added to this course")}</div>
+          % endif
         </nav>
       </div>
     </div>


### PR DESCRIPTION
See also the [trello discussion](https://trello.com/c/fVzRPOd1/2-forum-autoprovisioning-fails-for-new-user) and [possibly related commit](https://github.com/edx/edx-platform/pull/2957).

Changes LMS so that when a course has no content, i.e. no units have been added by the instructor in studio, we show a message indicating that the course has no content. This is a change from the previous behavior showing various 404/500 responses depending on whether sections/subsections were present.

To verify the fix, I did the following steps:
- Created a new account in studio
- activated account in same browser session
- Created a course
- Clicked "view live"
- Clicked "Discussions"
- Added a section in studio
- Clicked "view live" -> "discussions"
- Added a subsection in studio
- Clicked "view live" -> "discussions"
- Added a unit to the subsection, set the unit to public, did not add a component to the unit
- Clicked "view live" -> "discussions"
- Added a component to the unit
- Clicked "view live" -> "discussions"
- Logged out, logged back in, returned to course
- Clicked "view live" -> "discussions"

@antoviaque
