### PR TITLE
Fixed links for units loaded via ajax.

### DIFF
--- a/common/test/acceptance/pages/lms/staff_view.py
+++ b/common/test/acceptance/pages/lms/staff_view.py
@@ -38,6 +38,13 @@ class StaffPage(PageObject):
         self.q(css='input.check').first.click()
         self.wait_for_ajax()
 
+    def load_problem_via_ajax(self):
+        """
+        Load problem via ajax by clicking next.
+        """
+        self.q(css="li.next").click()
+        self.wait_for_ajax()
+
 
 class StaffDebugPage(PageObject):
     """
@@ -56,7 +63,7 @@ class StaffDebugPage(PageObject):
         """
         if user:
             self.q(css='input[id^=sd_fu_]').first.fill(user)
-        self.q(css='section.staff-modal a#staff-debug-reset').click()
+        self.q(css='section.staff-modal a.staff-debug-reset').click()
 
     def delete_state(self, user=None):
         """
@@ -64,7 +71,7 @@ class StaffDebugPage(PageObject):
         """
         if user:
             self.q(css='input[id^=sd_fu_]').fill(user)
-        self.q(css='section.staff-modal a#staff-debug-sdelete').click()
+        self.q(css='section.staff-modal a.staff-debug-sdelete').click()
 
     def rescore(self, user=None):
         """
@@ -73,7 +80,7 @@ class StaffDebugPage(PageObject):
         """
         if user:
             self.q(css='input[id^=sd_fu_]').first.fill(user)
-        self.q(css='section.staff-modal a#staff-debug-rescore').click()
+        self.q(css='section.staff-modal a.staff-debug-rescore').click()
 
     @property
     def idash_msg(self):

--- a/common/test/acceptance/tests/test_staff_view.py
+++ b/common/test/acceptance/tests/test_staff_view.py
@@ -43,7 +43,8 @@ class StaffDebugTest(UniqueCourseTest):
         course_fix.add_children(
             XBlockFixtureDesc('chapter', 'Test Section').add_children(
                 XBlockFixtureDesc('sequential', 'Test Subsection').add_children(
-                    XBlockFixtureDesc('problem', 'Test Problem 1', data=problem_data)
+                    XBlockFixtureDesc('problem', 'Test Problem 1', data=problem_data),
+                    XBlockFixtureDesc('problem', 'Test Problem 2', data=problem_data)
                 )
             )
         ).install()
@@ -149,3 +150,47 @@ class StaffDebugTest(UniqueCourseTest):
         msg = staff_debug_page.idash_msg[0]
         self.assertEqual(u'Failed to delete student state. '
                          'User does not exist.', msg)
+
+    def test_reset_attempts_for_problem_loaded_via_ajax(self):
+        """
+        Successfully reset the student attempts for problem loaded via ajax.
+        """
+        staff_page = self._goto_staff_page()
+        staff_page.load_problem_via_ajax()
+        staff_page.answer_problem()
+
+        staff_debug_page = staff_page.open_staff_debug_info()
+        staff_debug_page.reset_attempts()
+        msg = staff_debug_page.idash_msg[0]
+        self.assertEqual(u'Successfully reset the attempts '
+                         'for user {}'.format(self.USERNAME), msg)
+
+    def test_rescore_state_for_problem_loaded_via_ajax(self):
+        """
+        Rescore the student for problem loaded via ajax.
+        """
+        staff_page = self._goto_staff_page()
+        staff_page.load_problem_via_ajax()
+        staff_page.answer_problem()
+
+        staff_debug_page = staff_page.open_staff_debug_info()
+        staff_debug_page.rescore()
+        msg = staff_debug_page.idash_msg[0]
+        # Since we aren't running celery stuff, this will fail badly
+        # for now, but is worth excercising that bad of a response
+        self.assertEqual(u'Failed to rescore problem. '
+                         'Unknown Error Occurred.', msg)
+
+    def test_student_state_delete_for_problem_loaded_via_ajax(self):
+        """
+        Successfully delete the student state for problem loaded via ajax.
+        """
+        staff_page = self._goto_staff_page()
+        staff_page.load_problem_via_ajax()
+        staff_page.answer_problem()
+
+        staff_debug_page = staff_page.open_staff_debug_info()
+        staff_debug_page.delete_state()
+        msg = staff_debug_page.idash_msg[0]
+        self.assertEqual(u'Successfully deleted student state '
+                         'for user {}'.format(self.USERNAME), msg)

--- a/lms/static/js/staff_debug_actions.js
+++ b/lms/static/js/staff_debug_actions.js
@@ -114,15 +114,16 @@ var StaffDebug = (function(){
 
 // Register click handlers
 $(document).ready(function() {
-    $('.staff-debug-reset').click(function() {
+    var $courseContent = $('.course-content');
+    $courseContent.on("click", '.staff-debug-reset', function() {
         StaffDebug.reset($(this).parent().data('location-name'), $(this).parent().data('location'));
         return false;
     });
-    $('.staff-debug-sdelete').click(function() {
+    $courseContent.on("click", '.staff-debug-sdelete', function() {
         StaffDebug.sdelete($(this).parent().data('location-name'), $(this).parent().data('location'));
         return false;
     });
-    $('.staff-debug-rescore').click(function() {
+    $courseContent.on("click", '.staff-debug-rescore', function() {
         StaffDebug.rescore($(this).parent().data('location-name'), $(this).parent().data('location'));
         return false;
     });

--- a/lms/templates/staff_problem_info.html
+++ b/lms/templates/staff_problem_info.html
@@ -63,12 +63,12 @@ ${block_content}
       </div>
       <div data-location="${location.to_deprecated_string()}" data-location-name="${location.name}">
         [
-        <a href="#" id="staff-debug-reset" class="staff-debug-reset">${_('Reset Student Attempts')}</a>
+        <a href="#" class="staff-debug-reset">${_('Reset Student Attempts')}</a>
         % if has_instructor_access:
         |
-        <a href="#" id="staff-debug-sdelete" class="staff-debug-sdelete">${_('Delete Student State')}</a>
+        <a href="#" class="staff-debug-sdelete">${_('Delete Student State')}</a>
         |
-        <a href="#" id="staff-debug-rescore" class="staff-debug-rescore">${_('Rescore Student Submission')}</a>
+        <a href="#" class="staff-debug-rescore">${_('Rescore Student Submission')}</a>
         % endif
         ]
       </div>


### PR DESCRIPTION
LMS-2711

The click handlers were setup in such a way that they did not bind to links in units loaded via ajax.
