### PR TITLE
create draft request gets already created version if it exists

### DIFF
--- a/cms/djangoapps/contentstore/views/helpers.py
+++ b/cms/djangoapps/contentstore/views/helpers.py
@@ -4,7 +4,6 @@ from django.http import HttpResponse
 from django.shortcuts import redirect
 from edxmako.shortcuts import render_to_string, render_to_response
 from xmodule.modulestore.django import loc_mapper, modulestore
-from xmodule.modulestore.exceptions import DuplicateItemError, ItemNotFoundError
 
 __all__ = ['edge', 'event', 'landing']
 
@@ -37,24 +36,20 @@ def render_from_lms(template_name, dictionary, context=None, namespace='main'):
     return render_to_string(template_name, dictionary, context, namespace="lms." + namespace)
 
 
-def _xmodule_recurse(item, action, ignore_exception=None):
+def _xmodule_recurse(item, action, ignore_exception=()):
     """
     Recursively apply provided action on item and its children
 
-    ignore_duplicate_exception (str): A optional argument; when set to a certain value then ignores the corresponding
-        exception raised while xmodule recursion
+    ignore_exception (Exception Object): A optional argument; when passed ignores the corresponding
+        exception raised during xmodule recursion,
     """
     for child in item.get_children():
         _xmodule_recurse(child, action, ignore_exception)
 
-    if ignore_exception in ['ItemNotFoundError', 'DuplicateItemError']:
-        # In case of valid provided exception; ignore it and continue recursion
-        try:
-            return action(item)
-        except (ItemNotFoundError, DuplicateItemError):
-            return
-
-    action(item)
+    try:
+        return action(item)
+    except ignore_exception:
+        return
 
 
 def get_parent_xblock(xblock):

--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -21,7 +21,7 @@ from xblock.fragment import Fragment
 
 import xmodule
 from xmodule.modulestore.django import modulestore, loc_mapper
-from xmodule.modulestore.exceptions import ItemNotFoundError, InvalidLocationError
+from xmodule.modulestore.exceptions import ItemNotFoundError, InvalidLocationError, DuplicateItemError
 from xmodule.modulestore.inheritance import own_metadata
 from xmodule.modulestore.locator import BlockUsageLocator
 from xmodule.modulestore import Location
@@ -313,7 +313,7 @@ def _save_item(request, usage_loc, item_location, data=None, children=None, meta
             _xmodule_recurse(
                 existing_item,
                 lambda i: modulestore().unpublish(i.location),
-                ignore_exception='ItemNotFoundError'
+                ignore_exception=ItemNotFoundError
             )
         elif publish == 'create_draft':
             # This recursively clones the existing item location to a draft location (the draft is
@@ -321,7 +321,7 @@ def _save_item(request, usage_loc, item_location, data=None, children=None, meta
             _xmodule_recurse(
                 existing_item,
                 lambda i: modulestore().convert_to_draft(i.location),
-                ignore_exception='DuplicateItemError'
+                ignore_exception=DuplicateItemError
             )
 
     if data:

--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -21,7 +21,7 @@ from xblock.fragment import Fragment
 
 import xmodule
 from xmodule.modulestore.django import modulestore, loc_mapper
-from xmodule.modulestore.exceptions import ItemNotFoundError, InvalidLocationError
+from xmodule.modulestore.exceptions import ItemNotFoundError, InvalidLocationError, DuplicateItemError
 from xmodule.modulestore.inheritance import own_metadata
 from xmodule.modulestore.locator import BlockUsageLocator
 from xmodule.modulestore import Location
@@ -314,7 +314,11 @@ def _save_item(request, usage_loc, item_location, data=None, children=None, meta
         elif publish == 'create_draft':
             # This recursively clones the existing item location to a draft location (the draft is
             # implicit, because modulestore is a Draft modulestore)
-            _xmodule_recurse(existing_item, lambda i: modulestore().convert_to_draft(i.location))
+            try:
+                _xmodule_recurse(existing_item, lambda i: modulestore().convert_to_draft(i.location))
+            except DuplicateItemError:
+                # Since there is already a draft version of this module so no need to create another
+                pass
 
     if data:
         # TODO Allow any scope.content fields not just "data" (exactly like the get below this)

--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -21,7 +21,7 @@ from xblock.fragment import Fragment
 
 import xmodule
 from xmodule.modulestore.django import modulestore, loc_mapper
-from xmodule.modulestore.exceptions import ItemNotFoundError, InvalidLocationError, DuplicateItemError
+from xmodule.modulestore.exceptions import ItemNotFoundError, InvalidLocationError
 from xmodule.modulestore.inheritance import own_metadata
 from xmodule.modulestore.locator import BlockUsageLocator
 from xmodule.modulestore import Location
@@ -310,15 +310,19 @@ def _save_item(request, usage_loc, item_location, data=None, children=None, meta
 
     if publish:
         if publish == 'make_private':
-            _xmodule_recurse(existing_item, lambda i: modulestore().unpublish(i.location))
+            _xmodule_recurse(
+                existing_item,
+                lambda i: modulestore().unpublish(i.location),
+                ignore_exception='ItemNotFoundError'
+            )
         elif publish == 'create_draft':
             # This recursively clones the existing item location to a draft location (the draft is
             # implicit, because modulestore is a Draft modulestore)
-            try:
-                _xmodule_recurse(existing_item, lambda i: modulestore().convert_to_draft(i.location))
-            except DuplicateItemError:
-                # Since there is already a draft version of this module so no need to create another
-                pass
+            _xmodule_recurse(
+                existing_item,
+                lambda i: modulestore().convert_to_draft(i.location),
+                ignore_exception='DuplicateItemError'
+            )
 
     if data:
         # TODO Allow any scope.content fields not just "data" (exactly like the get below this)

--- a/cms/djangoapps/contentstore/views/tests/test_item.py
+++ b/cms/djangoapps/contentstore/views/tests/test_item.py
@@ -632,6 +632,39 @@ class TestEditItem(ItemTest):
         draft = self.get_item_from_modulestore(self.problem_locator, True)
         self.assertEqual(draft.due, datetime(2077, 10, 10, 4, 0, tzinfo=UTC))
 
+    def test_create_draft_with_multiple_requests(self):
+        """
+        Create a draft request returns already created version if it exists.
+        """
+        # Make problem public.
+        self.client.ajax_post(
+            self.problem_update_url,
+            data={'publish': 'make_public'}
+        )
+        self.assertIsNotNone(self.get_item_from_modulestore(self.problem_locator, False))
+        # Now make it draft, which means both versions will exist.
+        self.client.ajax_post(
+            self.problem_update_url,
+            data={
+                'publish': 'create_draft'
+            }
+        )
+        self.assertIsNotNone(self.get_item_from_modulestore(self.problem_locator, False))
+        draft_1 = self.get_item_from_modulestore(self.problem_locator, True)
+        self.assertIsNotNone(draft_1)
+
+        # Now check that when a user sends request to create a draft when there is already a draft version then
+        # user gets that already created draft instead of getting DuplicateItemError exception.
+        self.client.ajax_post(
+            self.problem_update_url,
+            data={
+                'publish': 'create_draft'
+            }
+        )
+        draft_2 = self.get_item_from_modulestore(self.problem_locator, True)
+        self.assertIsNotNone(draft_2)
+        self.assertEqual(draft_1, draft_2)
+
     def test_published_and_draft_contents_with_update(self):
         """ Create a draft and publish it then modify the draft and check that published content is not modified """
 


### PR DESCRIPTION
STUD-1616
@waheedahmed @symbolist @adampalay 
Fix showing DuplicateItemError for multiple requests for "create a draft" by returning already created draft version
