### PR TITLE
Improves the way LMS serves /favicon.ico

### DIFF
--- a/lms/urls.py
+++ b/lms/urls.py
@@ -5,6 +5,8 @@ from django.conf.urls.static import static
 
 import django.contrib.auth.views
 
+from microsite_configuration import microsite
+
 # Uncomment the next two lines to enable the admin:
 if settings.DEBUG or settings.FEATURES.get('ENABLE_DJANGO_ADMIN_SITE'):
     admin.autodiscover()
@@ -106,6 +108,14 @@ urlpatterns += (
         {'template': '404.html'}, name="404"),
 )
 
+# Favicon
+favicon_path = microsite.get_value('favicon_path', settings.FAVICON_PATH)
+urlpatterns += ((
+    r'^favicon\.ico$',
+    'django.views.generic.simple.redirect_to',
+    {'url':  settings.STATIC_URL + favicon_path}
+),)
+
 # Semi-static views only used by edX, not by themes
 if not settings.FEATURES["USE_CUSTOM_THEME"]:
     urlpatterns += (
@@ -125,10 +135,7 @@ if not settings.FEATURES["USE_CUSTOM_THEME"]:
 
         # Press releases
         url(r'^press/([_a-zA-Z0-9-]+)$', 'static_template_view.views.render_press_release', name='press_release'),
-
-        # Favicon
-        (r'^favicon\.ico$', 'django.views.generic.simple.redirect_to', {'url': '/static/images/favicon.ico'}),
-    )
+)
 
 # Only enable URLs for those marketing links actually enabled in the
 # settings. Disable URLs by marking them as None.


### PR DESCRIPTION
In the original code, the pattern for /favicon.ico is added to the
list of URL patterns only when no theme is enabled. This means that,
when /favicon.ico is requested on themed edX, one gets a 404 error.

This is a pity because there is already a FAVICON_PATH setting which
contains the path to the favicon and which already points to the
theme's one when a theme is enabled.

So this PR improves the way /favicon.ico is served in several ways:
1. The instruction adding the pattern to the list is moved outside of the
   if not settings.FEATURES["USE_CUSTOM_THEME"] block, so that the pattern
   gets added independently of whether a custom theme is enabled or not.
2. The redirection makes use of settings.STATIC_URL, instead of the
   hard-coded '/static' used in the original code.
3. The microsites configuration is taken into account, so that if a
   microsite provides its own favicon.ico, it will be that file which will be
   returned. This is inspired by lms/templates/main.html.
4. The redirection uses the FAVICON_PATH setting. This setting is
   theme-sensitive, so when a custom theme is enabled, FAVICON_PATH is
   modified to point to the theme's favicon rather than to edX's one.
   So the redirection now benefits from this already implemented behaviour.
