### PR TITLE
marketing url too many slashes

### DIFF
--- a/lms/urls.py
+++ b/lms/urls.py
@@ -223,7 +223,7 @@ if settings.COURSEWARE_ENABLED:
         url(r'^courses/(?P<course_id>[^/]+/[^/]+/[^/]+)/mktg-about$',
             'courseware.views.mktg_course_about', name="mktg_about_course"),
         #View for mktg site
-        url(r'^mktg/(?P<course_id>.*)$',
+        url(r'^mktg/(?P<course_id>[^/]+/[^/]+/[^/]+)/?$',
             'courseware.views.mktg_course_about', name="mktg_about_course"),
 
         #Inside the course


### PR DESCRIPTION
@dianakhuang please review. Fixes the backtraces which look like:
May 19 19:52:47 dev-edxapp-003 [service_variant=lms][django.request][env:stage_edx] ERROR [dev-edxapp-003  6031] [base.py:215] - Internal Server Error: /mktg/edX/LOG101/2014_T2/
Traceback (most recent call last):
  File "/opt/edx/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 111, in get_response
    response = callback(request, _callback_args, *_callback_kwargs)
  File "/opt/edx/local/lib/python2.7/site-packages/newrelic-2.18.1.15/newrelic/hooks/framework_django.py", line 492, in wrapper
    return wrapped(_args, *_kwargs)
  File "/opt/edx/local/lib/python2.7/site-packages/django/utils/decorators.py", line 91, in _wrapped_view
    response = view_func(request, _args, *_kwargs)
  File "/opt/wwc/edx-platform/common/djangoapps/util/cache.py", line 51, in _decorated
    response = view_func(request, _args, *_kwargs)
  File "/opt/wwc/edx-platform/lms/djangoapps/courseware/views.py", line 618, in mktg_course_about
    course_key = SlashSeparatedCourseKey.from_deprecated_string(course_id)
  File "/opt/wwc/edx-platform/common/lib/xmodule/xmodule/modulestore/locations.py", line 76, in from_deprecated_string
    return cls._from_string(serialized)
  File "/opt/wwc/edx-platform/common/lib/xmodule/xmodule/modulestore/locations.py", line 52, in _from_string
    raise InvalidKeyError(cls, serialized)
InvalidKeyError: <class 'xmodule.modulestore.locations.SlashSeparatedCourseKey'>: edX/LOG101/2014_T2/
