### PR TITLE
Warn users if the visual editor will modify their code, and offer to switch to the raw editor.

### DIFF
--- a/cms/djangoapps/contentstore/features/html-editor.feature
+++ b/cms/djangoapps/contentstore/features/html-editor.feature
@@ -34,17 +34,15 @@ Feature: CMS.HTML Editor
     Then the href link is rewritten to "c4x/MITx/999/asset/image.jpg"
     And the link is shown as "/static/image.jpg" in the Link Plugin
 
-  Scenario: TinyMCE and CodeMirror preserve style tags
+  Scenario: TinyMCE and CodeMirror strip style tags
     Given I have created a Blank HTML Page
     When I edit the page
     And type "<p class='title'>pages</p><style><!-- .title { color: red; } --></style>" in the code editor and press OK
     And I save the page
     Then the page text contains:
       """
-      <p class="title">pages</p>
-      <style><!--
-      .title { color: red; }
-      --></style>
+<p></p>
+<p>pages</p>
       """
 
   Scenario: TinyMCE and CodeMirror preserve span tags
@@ -118,15 +116,24 @@ Feature: CMS.HTML Editor
 #      fancy html
 #      """
 
-# Skipping in master due to brittleness JZ 05/22/2014
-#  Scenario: Can switch from Raw Editor to Visual
-#    Given I have created a raw HTML component
-#    And I edit the component and select the Visual Editor
-#    And I save the page
-#    When I edit the page
-#    And type "less fancy html" in the code editor and press OK
-#    And I save the page
-#    Then the page text contains:
-#      """
-#      less fancy html
-#      """
+=======
+  Scenario: Can switch from Raw Editor to Visual
+    Given I have created a raw HTML component
+    And I edit the component and select the Visual Editor
+    And I save the page
+    When I edit the page
+    And type "less fancy html" in the code editor and press OK
+    And I save the page
+    Then the page text contains:
+      """
+      less fancy html
+      """
+
+  Scenario: Visual Editor warns when data will be lost
+    Given I have created a raw HTML component
+    When I edit the page
+    And type "<div class='notallowed'>hello</div>" into the Raw Editor
+    And select the Visual Editor
+    And I save the page
+    When I edit the page
+>>>>>>> Add test for html editor warning.

--- a/common/lib/xmodule/xmodule/js/src/html/edit.coffee
+++ b/common/lib/xmodule/xmodule/js/src/html/edit.coffee
@@ -63,7 +63,7 @@ class @HTMLEditingDescriptor
         
         # Necessary to avoid stripping of style tags.
         valid_children : "+body[style]",
-        valid_elements: "h1,h2,h3,h4,p[id|style],div[id|style],span[id|style],img[src|style|alt|width|height],br,hr,a[*],strong/b,cite,mark,address,i/em,code,ul,ol,li,blockquote"
+        valid_elements: "h1,h2,h3,h4,p[id|style|class],div[id|style|class],span[id|style],section[id|style|class],img[src|style|alt|width|height],br,hr,a[*],strong/b,cite,mark,address,i/em,code,ul,ol,li,blockquote"
         extended_valid_elements: "link,math,maction,maligngroup,malingmark,menclose,merror,mfenced,mfrac,mglyph,mi,mlabeldtr,mlongdiv,mmultiscripts,mn,mo,mover,mpadded,mphantom,mroot,mrow,ms,mscarries,mscarry,msgroup,mstack,msline,mspace,msqrt,msrow,mstyle,msub,msup,msubsup,mtable,mtd,mtext,mtr,munder,munderover"        
         invalid_elements: "script,style",
         setup: @setupTinyMCE,


### PR DESCRIPTION
**WIP**

There aren't any tests yet, but I wanted to see what people thought about this approach. Currently, the confirmation is a javascript confirm dialog. Should it be a modal -- if so, where can I find that? What should the messaging be? Now, it's just a feeble: _Visual editing may cause data loss. Click cancel for raw editor._

The problem I'm running into now is that tinymce is adding a `\ufffd` character surrounded by a hidden span. I don't know why, but it seems related to the `valid_elements` setting...

@cahrens @nasthagiri @andy-armstrong 
