### PR TITLE
Adding new attribute to the xmodule_runtime to check admin privileges on users

### DIFF
--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -501,6 +501,7 @@ def get_module_system_for_user(user, field_data_cache,
         )
 
     system.set(u'user_is_staff', has_access(user, descriptor.location, u'staff', course_id))
+    system.set(u'user_is_admin', has_access(user, 'global', 'staff'))
 
     # make an ErrorDescriptor -- assuming that the descriptor's system is ok
     if has_access(user, descriptor.location, 'staff', course_id):


### PR DESCRIPTION
ORA2 will want to check if a user is a Django Admin to allow scheduling training tasks for AI classifiers. This change adds one attribute on the module_render runtime using an existing function to check admin privileges. 

@wedaly @gradyward 

@cpennington would you mind taking a quick glance at this? 
