### PR TITLE
Example of inheritance field that does not work for descriptor.

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/inheritance.py
+++ b/common/lib/xmodule/xmodule/modulestore/inheritance.py
@@ -86,6 +86,12 @@ class InheritanceMixin(XBlockMixin):
               "If the value is not set, infinite attempts are allowed."),
         values={"min": 0}, scope=Scope.settings
     )
+    grade_videos = Boolean(
+        help="pass",
+        display_name='Grade videos',
+        scope=Scope.settings,
+        default=False
+    )
 
 
 

--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -137,7 +137,7 @@ class VideoModule(VideoFields, VideoStudentViewHandlers, XModule):
 
         # OrderedDict for easy testing of rendered context in tests
         sorted_languages = OrderedDict(sorted(languages.items(), key=itemgetter(1)))
-
+        assert self.grade_videos is True
         return self.system.render_template('video.html', {
             'ajax_url': self.system.ajax_url + '/save_user_state',
             'autoplay': settings.FEATURES.get('AUTOPLAY_VIDEOS', False),
@@ -253,6 +253,8 @@ class VideoDescriptor(VideoFields, VideoStudioViewHandlers, TabsEditingDescripto
         editable_fields['transcripts']['type'] = 'VideoTranslations'
         editable_fields['transcripts']['urlRoot'] = self.runtime.handler_url(self, 'studio_transcript', 'translation').rstrip('/?')
         editable_fields['handout']['type'] = 'FileUploader'
+
+        assert self.grade_videos is True
 
         return editable_fields
 

--- a/common/lib/xmodule/xmodule/video_module/video_xfields.py
+++ b/common/lib/xmodule/xmodule/video_module/video_xfields.py
@@ -151,3 +151,9 @@ class VideoFields(object):
         display_name=_("Upload Handout"),
         scope=Scope.settings,
     )
+    grade_videos = Boolean(
+        help="pass",
+        display_name='Grade videos',
+        scope=Scope.settings,
+        default=False
+    )


### PR DESCRIPTION
Do not merge

@cpennington this is example we've talked about.
1. Set in course settings "grade_videos" to true
2. Add video to a course
3. Press edit -> Exception will arise 
