### PR TITLE
Added trailing slashes

### DIFF
--- a/common/djangoapps/course_modes/urls.py
+++ b/common/djangoapps/course_modes/urls.py
@@ -5,5 +5,5 @@ from course_modes import views
 
 urlpatterns = patterns(
     '',
-    url(r'^choose/(?P<course_id>[^/]+/[^/]+/[^/]+)$', views.ChooseModeView.as_view(), name="course_modes_choose"),
+    url(r'^choose/(?P<course_id>[^/]+/[^/]+/[^/]+)/$', views.ChooseModeView.as_view(), name="course_modes_choose"),
 )

--- a/lms/djangoapps/courseware/features/certificates.py
+++ b/lms/djangoapps/courseware/features/certificates.py
@@ -281,7 +281,7 @@ def see_that_i_am_on_the_verified_track(step):
 
 @step(u'I leave the flow and return$')
 def leave_the_flow_and_return(step):
-    world.visit('verify_student/verified/edx/999/Certificates')
+    world.visit('verify_student/verified/edx/999/Certificates/')
 
 
 @step(u'I am at the verified page$')

--- a/lms/djangoapps/verify_student/urls.py
+++ b/lms/djangoapps/verify_student/urls.py
@@ -5,19 +5,19 @@ from verify_student import views
 urlpatterns = patterns(
     '',
     url(
-        r'^show_requirements/(?P<course_id>[^/]+/[^/]+/[^/]+)$',
+        r'^show_requirements/(?P<course_id>[^/]+/[^/]+/[^/]+)/$',
         views.show_requirements,
         name="verify_student_show_requirements"
     ),
 
     url(
-        r'^verify/(?P<course_id>[^/]+/[^/]+/[^/]+)$',
+        r'^verify/(?P<course_id>[^/]+/[^/]+/[^/]+)/$',
         views.VerifyView.as_view(),  # pylint: disable=E1120
         name="verify_student_verify"
     ),
 
     url(
-        r'^verified/(?P<course_id>[^/]+/[^/]+/[^/]+)$',
+        r'^verified/(?P<course_id>[^/]+/[^/]+/[^/]+)/$',
         views.VerifiedView.as_view(),
         name="verify_student_verified"
     ),
@@ -41,7 +41,7 @@ urlpatterns = patterns(
     ),
 
     url(
-        r'^midcourse_reverify/(?P<course_id>[^/]+/[^/]+/[^/]+)$',
+        r'^midcourse_reverify/(?P<course_id>[^/]+/[^/]+/[^/]+)/$',
         views.MidCourseReverifyView.as_view(),  # pylint: disable=E1120
         name="verify_student_midcourse_reverify"
     ),


### PR DESCRIPTION
Added trailing slashes otherwise the course_id regex sometimes eats up get parameters.

LMS-2738

Example error:

```
Internal Server Error: /course_modes/choose/BUx/SABR101x/2T2014?upgrade=True
Traceback (most recent call last):
  File "/opt/edx/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 111, in get_response
    response = callback(request, *callback_args, **callback_kwargs)
  File "/opt/edx/local/lib/python2.7/site-packages/newrelic-2.18.1.15/newrelic/hooks/framework_django.py", line 492, in wrapper
    return wrapped(*args, **kwargs)
  File "/opt/edx/local/lib/python2.7/site-packages/django/views/generic/base.py", line 48, in view
    return self.dispatch(request, *args, **kwargs)
  File "/opt/edx/local/lib/python2.7/site-packages/newrelic-2.18.1.15/newrelic/hooks/framework_django.py", line 829, in wrapper
    return wrapped(*args, **kwargs)
  File "/opt/edx/local/lib/python2.7/site-packages/django/views/generic/base.py", line 69, in dispatch
    return handler(request, *args, **kwargs)
  File "/opt/edx/local/lib/python2.7/site-packages/django/utils/decorators.py", line 25, in _wrapper
    return bound_func(*args, **kwargs)
  File "/opt/edx/local/lib/python2.7/site-packages/django/contrib/auth/decorators.py", line 20, in _wrapped_view
    return view_func(request, *args, **kwargs)
  File "/opt/edx/local/lib/python2.7/site-packages/django/utils/decorators.py", line 21, in bound_func
    return func(self, *args2, **kwargs2)
  File "/opt/wwc/edx-platform/common/djangoapps/course_modes/views.py", line 54, in get
    course = course_from_id(course_id)
  File "/opt/wwc/edx-platform/common/djangoapps/student/views.py", line 132, in course_from_id
    course_loc = CourseDescriptor.id_to_location(course_id)
  File "/opt/wwc/edx-platform/common/lib/xmodule/xmodule/course_module.py", line 830, in id_to_location
    return Location(course_id_dict)
  File "/opt/wwc/edx-platform/common/lib/xmodule/xmodule/modulestore/__init__.py", line 214, in __new__
    check_dict(kwargs)
  File "/opt/wwc/edx-platform/common/lib/xmodule/xmodule/modulestore/__init__.py", line 179, in check_dict
    check_list(list_)
  File "/opt/wwc/edx-platform/common/lib/xmodule/xmodule/modulestore/__init__.py", line 186, in check_list
    _check_location_part(list_[4], INVALID_CHARS_NAME)
  File "/opt/wwc/edx-platform/common/lib/xmodule/xmodule/modulestore/__init__.py", line 59, in _check_location_part
    raise InvalidLocationError("Invalid characters in {!r}.".format(val))
InvalidLocationError: Invalid characters in u'2T2014?upgrade=True'.
```
