### PR TITLE
Skip brittle HTML editor lettuce test

### DIFF
--- a/cms/djangoapps/contentstore/features/html-editor.feature
+++ b/cms/djangoapps/contentstore/features/html-editor.feature
@@ -105,26 +105,28 @@ Feature: CMS.HTML Editor
       <li>zzzz<ol>
       """
 
-  Scenario: Can switch from Visual Editor to Raw
-    Given I have created a Blank HTML Page
-    When I edit the component and select the Raw Editor
-    And I save the page
-    When I edit the page
-    And type "fancy html" into the Raw Editor
-    And I save the page
-    Then the page text contains:
-      """
-      fancy html
-      """
+# Skipping in master due to brittleness JZ 05/22/2014
+#  Scenario: Can switch from Visual Editor to Raw
+#    Given I have created a Blank HTML Page
+#    When I edit the component and select the Raw Editor
+#    And I save the page
+#    When I edit the page
+#    And type "fancy html" into the Raw Editor
+#    And I save the page
+#    Then the page text contains:
+#      """
+#      fancy html
+#      """
 
-  Scenario: Can switch from Raw Editor to Visual
-    Given I have created a raw HTML component
-    And I edit the component and select the Visual Editor
-    And I save the page
-    When I edit the page
-    And type "less fancy html" in the code editor and press OK
-    And I save the page
-    Then the page text contains:
-      """
-      less fancy html
-      """
+# Skipping in master due to brittleness JZ 05/22/2014
+#  Scenario: Can switch from Raw Editor to Visual
+#    Given I have created a raw HTML component
+#    And I edit the component and select the Visual Editor
+#    And I save the page
+#    When I edit the page
+#    And type "less fancy html" in the code editor and press OK
+#    And I save the page
+#    Then the page text contains:
+#      """
+#      less fancy html
+#      """


### PR DESCRIPTION
See [this recent jenkins run](https://jenkins.testeng.edx.org/job/edx-all-tests-auto-pr/10650/SHARD=2,TEST_SUITE=cms-acceptance/testReport/junit/CMS/HTML%20Editor%20_%20Can%20switch%20from%20Raw%20Editor%20to%20Visual/And_I_edit_the_component_and_select_the_Visual_Editor/) for an example intermittent failure.

To fix these tests:
- Don't use world.browser.select, but instead use our wrapped methods, e.g. css_click
- In cms/djangoapps/contentstore/features/component_settings_editor_helpers.py, wait for ajax to finish rendering in edit_component_and_select_settings or maybe it should be in ensure_settings_visible

@cahrens @zubair-arbi 
