### PR TITLE
Adding django default log handlers into logging configuration

### DIFF
--- a/common/lib/logsettings.py
+++ b/common/lib/logsettings.py
@@ -67,12 +67,22 @@ def get_logger_config(log_dir,
             'syslog_format': {'format': syslog_format},
             'raw': {'format': '%(message)s'},
         },
+        'filters': {
+            'require_debug_false': {
+                '()': 'django.utils.log.RequireDebugFalse',
+            }
+        },
         'handlers': {
             'console': {
                 'level': console_loglevel,
                 'class': 'logging.StreamHandler',
                 'formatter': 'standard',
                 'stream': sys.stderr,
+            },
+            'mail_admins': {
+                'level': 'ERROR',
+                'filters': ['require_debug_false'],
+                'class': 'django.utils.log.AdminEmailHandler'
             },
             'syslogger-remote': {
                 'level': 'INFO',
@@ -96,6 +106,11 @@ def get_logger_config(log_dir,
                 'handlers': handlers,
                 'level': 'DEBUG',
                 'propagate': False
+            },
+            'django.request': {
+                'handlers': ['mail_admins'],
+                'level': 'ERROR',
+                'propagate': True,
             },
         }
     }


### PR DESCRIPTION
This handler, filter, and logger were lost in https://github.com/edx/edx-platform/pull/3061 (and rightly so, since they were there due to a side effect).  This adds them back to the logging configuration.
