### PR TITLE
mentoring-opaque-keys: Adds support for opaque keys

### DIFF
--- a/requirements/edx/edx-private.txt
+++ b/requirements/edx/edx-private.txt
@@ -1,4 +1,4 @@
 # Requirements for edx.org that aren't necessarily needed for Open edX.
 
 -e git+ssh://git@github.com/jazkarta/edX-jsdraw.git@9fcd333aaa2ac3df65dd247b601ce0b56bb10cad#egg=edx-jsdraw
--e git+https://github.com/gsehub/xblock-mentoring.git@43aa3202456b4c8674673474b81c51d8895d403d#egg=xblock-mentoring
+-e git+https://github.com/gsehub/xblock-mentoring.git@b779446e9f51b9a1576d514cc14166907316a106#egg=xblock-mentoring


### PR DESCRIPTION
Updates commit hash to add support for opaque keys in mentoring. Inspired from https://github.com/edx/edx-ora2/pull/330

@cpennington @dianakhuang Want to review? See https://github.com/gsehub/xblock-mentoring/pull/2 for the relevant commits.
