### PR TITLE
Wait for ajax to complete when editing components in Studio acceptance tests

### DIFF
--- a/cms/djangoapps/contentstore/features/component_settings_editor_helpers.py
+++ b/cms/djangoapps/contentstore/features/component_settings_editor_helpers.py
@@ -122,6 +122,7 @@ def ensure_settings_visible():
 def edit_component():
     world.wait_for(lambda _driver: world.css_visible('a.edit-button'))
     world.css_click('a.edit-button')
+    world.wait_for_ajax_complete()
 
 
 @world.absorb


### PR DESCRIPTION
Tests need to wait for ajax calls to complete when after pressing the edit button.
See cms/static/coffee/src/views/module_edit.coffee

@zubair-arbi @andy-armstrong 
