### PR TITLE
Add missing mimetypes for xblock resources

### DIFF
--- a/cms/startup.py
+++ b/cms/startup.py
@@ -14,3 +14,19 @@ def run():
     Executed during django startup
     """
     autostartup()
+
+    add_mimetypes()
+
+
+def add_mimetypes():
+    """
+    Add extra mimetypes. Used in xblock_resource.
+
+    If you add a mimetype here, be sure to also add it in lms/startup.py.
+    """
+    import mimetypes
+
+    mimetypes.add_type('application/vnd.ms-fontobject', '.eot')
+    mimetypes.add_type('application/x-font-opentype', '.otf')
+    mimetypes.add_type('application/x-font-ttf', '.ttf')
+    mimetypes.add_type('application/font-woff', '.woff')

--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -64,7 +64,6 @@ XQUEUE_INTERFACE = XQueueInterface(
 # Some brave person should make the variable names consistently someday, but the code's
 # coupled enough that it's kind of tricky--you've been warned!
 
-
 class LmsModuleRenderError(Exception):
     """
     An exception class for exceptions thrown by module_render that don't fit well elsewhere

--- a/lms/startup.py
+++ b/lms/startup.py
@@ -35,6 +35,8 @@ def run():
 def add_mimetypes():
     """
     Add extra mimetypes. Used in xblock_resource.
+
+    If you add a mimetype here, be sure to also add it in cms/startup.py.
     """
     import mimetypes
 

--- a/lms/startup.py
+++ b/lms/startup.py
@@ -20,6 +20,8 @@ def run():
     """
     autostartup()
 
+    add_mimetypes()
+
     if settings.FEATURES.get('USE_CUSTOM_THEME', False):
         enable_theme()
 
@@ -28,6 +30,18 @@ def run():
 
     if settings.FEATURES.get('ENABLE_THIRD_PARTY_AUTH', False):
         enable_third_party_auth()
+
+
+def add_mimetypes():
+    """
+    Add extra mimetypes. Used in xblock_resource.
+    """
+    import mimetypes
+
+    mimetypes.add_type('application/vnd.ms-fontobject', '.eot')
+    mimetypes.add_type('application/x-font-opentype', '.otf')
+    mimetypes.add_type('application/x-font-ttf', '.ttf')
+    mimetypes.add_type('application/font-woff', '.woff')
 
 
 def enable_theme():

--- a/lms/tests.py
+++ b/lms/tests.py
@@ -1,9 +1,24 @@
 """Tests for the lms module itself."""
 
+import mimetypes
+
 from django.test import TestCase
 
 from edxmako import add_lookup, LOOKUP
 from lms import startup
+
+
+class LmsModuleTests(TestCase):
+    """
+    Tests for lms module itself.
+    """
+
+    def test_new_mimetypes(self):
+        extensions = ['eot', 'otf', 'ttf', 'woff']
+        for extension in extensions:
+            mimetype, _ = mimetypes.guess_type('test.' + extension)
+            self.assertIsNotNone(mimetype)
+
 
 class TemplateLookupTests(TestCase):
     """


### PR DESCRIPTION
This PR is related is related to https://github.com/edx/XBlock/pull/214 . It adds the missing font mimetypes for the xblock resource rendering. Without this patch, django simply crash with a DjangoUnicodeError. The mimetype is used here:

https://github.com/aboudreault/edx-platform/blob/e011eb1ab5defc3af80e5019b43b48b32d8a6bb2/lms/djangoapps/courseware/module_render.py#L648

CC, @antoviaque, @jimabramson
