### PR TITLE
Redirect most studio access through draft modulestore

### DIFF
--- a/cms/djangoapps/contentstore/features/video.py
+++ b/cms/djangoapps/contentstore/features/video.py
@@ -154,7 +154,8 @@ def xml_only_video(step):
     world.ItemFactory.create(
         parent_location=parent_location,
         category='video',
-        data='<video youtube="1.00:%s"></video>' % youtube_id
+        data='<video youtube="1.00:%s"></video>' % youtube_id,
+        modulestore=store,
     )
 
 

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -14,7 +14,6 @@ from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError
 from xmodule.modulestore.locations import SlashSeparatedCourseKey, Location
 from xmodule.modulestore.store_utilities import delete_course
-from xmodule.modulestore.draft import DIRECT_ONLY_CATEGORIES
 from student.roles import CourseInstructorRole, CourseStaffRole
 
 
@@ -52,15 +51,10 @@ def delete_course_and_groups(course_id, commit=False):
 
 def get_modulestore(category_or_location):
     """
-    Returns the correct modulestore to use for modifying the specified location
+    This function no longer does anything more than just calling `modulestore()`. It used
+    to select 'direct' v 'draft' based on the category.
     """
-    if isinstance(category_or_location, Location):
-        category_or_location = category_or_location.category
-
-    if category_or_location in DIRECT_ONLY_CATEGORIES:
-        return modulestore('direct')
-    else:
-        return modulestore()
+    return modulestore()
 
 
 def get_lms_link_for_item(location, preview=False):

--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 import json
 import logging
-from collections import defaultdict
 
 from django.http import HttpResponseBadRequest, Http404
 from django.contrib.auth.decorators import login_required

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -53,7 +53,6 @@ from django_comment_common.utils import seed_permissions_roles
 from student.models import CourseEnrollment
 from student.roles import CourseRole, UserBasedRole
 
-from xmodule.html_module import AboutDescriptor
 from xmodule.modulestore.keys import CourseKey
 from course_creators.views import get_course_creator_status, add_user_with_status_unrequested
 from contentstore import utils

--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -381,8 +381,7 @@ def _save_item(request, usage_key, data=None, children=None, metadata=None, null
             # interface for publishing. However, as of now, only the DraftMongoModulestore
             # does, so we have to check for the attribute explicitly.
             store = get_modulestore(block.location)
-            if hasattr(store, 'publish'):
-                store.publish(block.location, request.user.id)
+            store.publish(block.location, request.user.id)
 
         _xmodule_recurse(
             existing_item,


### PR DESCRIPTION
rather than have caller figure out whether to call draft or direct.
Fixes get_children to always find draft children in studio.
STUD-1662

@cahrens @nasthagiri please confirm and review. Nimisha, this begins your story
