### PR TITLE
Temporarily disable masking

### DIFF
--- a/common/lib/capa/capa/responsetypes.py
+++ b/common/lib/capa/capa/responsetypes.py
@@ -780,19 +780,7 @@ class MultipleChoiceResponse(LoncapaResponse):
         for response in self.xml.xpath("choicegroup"):
             # Is Masking enabled? -- check for shuffle or answer-pool features
             ans_str = response.get("answer-pool")
-            if response.get("shuffle") == "true" or (ans_str is not None and ans_str != "0"):
-                self._has_mask = True  # pylint: disable=W0201
-                self._mask_dict = {}   # pylint: disable=W0201
-                # We do not want the random mask names to be the same
-                # for all responses in a problem (sharing the one seed),
-                # like mask_2 in view-source turns out to always be the correct choice.
-                # But it must be repeatable and a function of the seed.
-                # Therefore we add the _1 number from the .id to the seed.
-                seed_delta = int(self.id[self.id.rindex("_") + 1:])
-                rng = random.Random(self.context["seed"] + seed_delta)
-                # e.g. mask_ids = [3, 1, 0, 2]
-                mask_ids = range(len(response))
-                rng.shuffle(mask_ids)
+            # Masking (self._has_mask) is off, to be re-enabled with a future PR.
             rtype = response.get('type')
             if rtype not in ["MultipleChoice"]:
                 # force choicegroup to be MultipleChoice if not valid
@@ -853,11 +841,11 @@ class MultipleChoiceResponse(LoncapaResponse):
         """
         Returns a list of the choice names in the order displayed to the user,
         using the regular (non-masked) names.
-        Fails with LoncapaProblemError if called on a response that is not masking.
         """
+        # With masking disabled, this computation remains interesting to see
+        # the displayed order, even though there is no unmasking.
         choices = self.xml.xpath('choicegroup/choice')
-        # We let the unmask_name() raise the error for us if this response is not masking.
-        return [self.unmask_name(choice.get("name")) for choice in choices]
+        return [choice.get("name") for choice in choices]
 
     def do_shuffle(self, tree, problem):
         """

--- a/common/lib/capa/capa/tests/test_answer_pool.py
+++ b/common/lib/capa/capa/tests/test_answer_pool.py
@@ -59,7 +59,7 @@ class CapaAnswerPoolTest(unittest.TestCase):
         self.assertEqual(the_html, problem.get_html(), 'should be able to call get_html() twice')
         # Check about masking
         response = problem.responders.values()[0]
-        self.assertTrue(response.has_mask())
+        self.assertFalse(response.has_mask())
         self.assertTrue(response.has_answerpool())
         self.assertEqual(response.unmask_order(), ['choice_3', 'choice_5', 'choice_1', 'choice_4'])
 
@@ -71,7 +71,7 @@ class CapaAnswerPoolTest(unittest.TestCase):
         self.assertRegexpMatches(the_html, r"<div>\{.*'1_solution_1'.*\}</div>")
         # Check about masking
         response = problem.responders.values()[0]
-        self.assertTrue(hasattr(response, 'has_mask'))
+        self.assertFalse(response.has_mask())
         self.assertTrue(hasattr(response, 'has_answerpool'))
         self.assertEqual(response.unmask_order(), ['choice_0', 'choice_4', 'choice_3', 'choice_2'])
 
@@ -280,7 +280,7 @@ class CapaAnswerPoolTest(unittest.TestCase):
         self.assertRegexpMatches(the_html, r"<div>.*\[.*'correct-2'.*'wrong-1'.*'wrong-2'.*.*'wrong-3'.*'wrong-4'.*\].*</div>")
         self.assertRegexpMatches(the_html, r"<div>\{.*'1_solution_2'.*\}</div>")
         response = problem.responders.values()[0]
-        self.assertTrue(response.has_mask())
+        self.assertFalse(response.has_mask())
         self.assertEqual(response.unmask_order(), ['choice_5', 'choice_0', 'choice_1', 'choice_3', 'choice_4'])
 
     def test_answer_pool_2_multiplechoiceresponses_seed1(self):

--- a/common/lib/capa/capa/tests/test_shuffle.py
+++ b/common/lib/capa/capa/tests/test_shuffle.py
@@ -34,7 +34,7 @@ class CapaShuffleTest(unittest.TestCase):
         self.assertRegexpMatches(the_html, r"<div>.*\[.*'Banana'.*'Apple'.*'Chocolate'.*'Donut'.*\].*</div>")
         # Check that choice name masking is enabled and that unmasking works
         response = problem.responders.values()[0]
-        self.assertTrue(response.has_mask())
+        self.assertFalse(response.has_mask())
         self.assertEqual(response.unmask_order(), ['choice_1', 'choice_0', 'choice_2', 'choice_3'])
         self.assertEqual(the_html, problem.get_html(), 'should be able to call get_html() twice')
 
@@ -55,7 +55,7 @@ class CapaShuffleTest(unittest.TestCase):
         # B A C D
         # Check that the custom name= names come through
         response = problem.responders.values()[0]
-        self.assertTrue(response.has_mask())
+        self.assertFalse(response.has_mask())
         self.assertTrue(response.has_shuffle())
         self.assertEqual(response.unmask_order(), ['choice_0', 'choice_aaa', 'choice_1', 'choice_ddd'])
 
@@ -90,10 +90,9 @@ class CapaShuffleTest(unittest.TestCase):
         the_html = problem.get_html()
         self.assertRegexpMatches(the_html, r"<div>.*\[.*'Apple'.*\].*</div>")
         response = problem.responders.values()[0]
-        self.assertTrue(response.has_mask())
+        self.assertFalse(response.has_mask())
         self.assertTrue(response.has_shuffle())
         self.assertEqual(response.unmask_order(), ['choice_0'])
-        self.assertEqual(response.unmask_name('mask_0'), 'choice_0')
 
     def test_shuffle_6_choices(self):
         xml_str = textwrap.dedent("""
@@ -279,9 +278,8 @@ class CapaShuffleTest(unittest.TestCase):
                                        r"<div>.*\[.*'C'.*'A'.*'D'.*'B'.*\].*</div>")
         # Look at the responses in their authored order
         responses = sorted(problem.responders.values(), key=lambda resp: int(resp.id[resp.id.rindex('_') + 1:]))
-        self.assertTrue(responses[0].has_mask())
+        self.assertFalse(responses[0].has_mask())
         self.assertTrue(responses[0].has_shuffle())
-        self.assertTrue(hasattr(responses[1], 'has_mask'))
         self.assertTrue(responses[1].has_shuffle())
         self.assertEqual(responses[0].unmask_order(), ['choice_1', 'choice_0', 'choice_2', 'choice_3'])
         self.assertEqual(responses[1].unmask_order(), ['choice_2', 'choice_0', 'choice_3', 'choice_1'])

--- a/common/lib/capa/capa/tests/test_targeted_feedback.py
+++ b/common/lib/capa/capa/tests/test_targeted_feedback.py
@@ -586,7 +586,7 @@ class CapaTargetedFeedbackTest(unittest.TestCase):
     def test_targeted_feedback_multiple_answer_2(self):
         problem = new_loncapa_problem(load_fixture('targeted_feedback_multiple.xml'))
         problem.done = True
-        problem.student_answers = {'1_2_1': 'choice_0', '1_3_1': 'mask_1'}  # Q1 wrong, Q2 correct
+        problem.student_answers = {'1_2_1': 'choice_0', '1_3_1': 'choice_2'}  # Q1 wrong, Q2 correct
         the_html = problem.get_html()
         without_new_lines = the_html.replace("\n", "")
         # Q1 has feedback1 and Q2 has feedbackC

--- a/common/lib/xmodule/xmodule/tests/test_capa_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_capa_module.py
@@ -1454,17 +1454,17 @@ class CapaModuleTest(unittest.TestCase):
         """
         module = CapaFactory.create(xml=self.common_shuffle_xml)
         with patch.object(module.runtime, 'track_function') as mock_track_function:
-            get_request_dict = {CapaFactory.input_key(): 'mask_1'}  # the correct choice
+            get_request_dict = {CapaFactory.input_key(): 'choice_3'}  # the correct choice
             module.check_problem(get_request_dict)
             mock_call = mock_track_function.mock_calls[0]
             event_info = mock_call[1][1]
-            # 'answers' key modified to use unmasked name
             self.assertEqual(event_info['answers'][CapaFactory.answer_key()], 'choice_3')
             # 'permutation' key added to record how problem was shown
             self.assertEquals(event_info['permutation'][CapaFactory.answer_key()],
                               ('shuffle', ['choice_3', 'choice_1', 'choice_2', 'choice_0']))
             self.assertEquals(event_info['success'], 'correct')
 
+    @unittest.skip("masking temporarily disabled")
     def test_save_unmask(self):
         """On problem save, unmasked data should appear on track_function."""
         module = CapaFactory.create(xml=self.common_shuffle_xml)
@@ -1476,6 +1476,7 @@ class CapaModuleTest(unittest.TestCase):
             self.assertEquals(event_info['answers'][CapaFactory.answer_key()], 'choice_2')
             self.assertIsNotNone(event_info['permutation'][CapaFactory.answer_key()])
 
+    @unittest.skip("masking temporarily disabled")
     def test_reset_unmask(self):
         """On problem reset, unmask names should appear track_function."""
         module = CapaFactory.create(xml=self.common_shuffle_xml)
@@ -1490,6 +1491,7 @@ class CapaModuleTest(unittest.TestCase):
             self.assertEquals(event_info['old_state']['student_answers'][CapaFactory.answer_key()], 'choice_2')
             self.assertIsNotNone(event_info['permutation'][CapaFactory.answer_key()])
 
+    @unittest.skip("masking temporarily disabled")
     def test_rescore_unmask(self):
         """On problem rescore, unmasked names should appear on track_function."""
         module = CapaFactory.create(xml=self.common_shuffle_xml)
@@ -1520,12 +1522,10 @@ class CapaModuleTest(unittest.TestCase):
         """)
         module = CapaFactory.create(xml=xml)
         with patch.object(module.runtime, 'track_function') as mock_track_function:
-            get_request_dict = {CapaFactory.input_key(): 'mask_0'}
+            get_request_dict = {CapaFactory.input_key(): 'choice_2'}  # mask_X form when masking enabled
             module.check_problem(get_request_dict)
             mock_call = mock_track_function.mock_calls[0]
             event_info = mock_call[1][1]
-            print event_info
-            # 'answers' key modified to use unmasked name
             self.assertEqual(event_info['answers'][CapaFactory.answer_key()], 'choice_2')
             # 'permutation' key added to record how problem was shown
             self.assertEquals(event_info['permutation'][CapaFactory.answer_key()],


### PR DESCRIPTION
Temporarily disable capa name masking

There is a bug I need to fix when a student re-visits a problem that they
had solved previously without masking enabled, their old state does not
load correclty.

It's simplest to turn off masking now, and re-enable it with the whole fix.

Masking only applies when problems use the new shuffle="true" or answer-pool features,
probably not used outside of Stanford yet. If a problem with masking is saved by a student,
then this change will prevent that problem from loading for that student,
so idealy make this change when no masked problems have been used.

Masked problems otherwise work as documented with
this change, they just will not use masking internally.

The change here is a small deletion to remove the masking=True logic, and more
lengthy changes to remove the tests of masking.
