### PR TITLE
Fix exception on Internet Explorer when adding first transcript language

### DIFF
--- a/cms/static/js/views/video/translations_editor.js
+++ b/cms/static/js/views/video/translations_editor.js
@@ -47,6 +47,13 @@ function($, _, AbstractEditor, FileUpload, UploadDialog) {
                     var dropdown = $(element).clone();
 
                     _.each(values, function(value, key) {
+                        // Note: IE may raise an exception if key is an empty string,
+                        // while other browsers return null as excepted. So coerce it
+                        // into null for browser consistency.
+                        if (key === "") {
+                            key = null;
+                        }
+
                         var option = dropdown[0].options.namedItem(key);
 
                         if (option) {


### PR DESCRIPTION
Internet Explorer throws an "Invalid argument" exception when uses an empty string as the parameter in `namedItem` method.
As other browsers returns `null` when the parameter is an empty string, it is safe to first test whether the parameter is an empty string, and if not then the original code is executed.
