### PR TITLE
Make TinyMCE's HTML source code editor work under Internet Explorer

### DIFF
--- a/cms/templates/base.html
+++ b/cms/templates/base.html
@@ -1,4 +1,4 @@
-## -*- coding: utf-8 -*-
+﻿## -*- coding: utf-8 -*-
 <%! from django.utils.translation import ugettext as _ %>
 <%namespace name='static' file='static_content.html'/>
 
@@ -39,6 +39,12 @@
 
     <script type="text/javascript">
     window.baseUrl = "${settings.STATIC_URL}";
+    // Internet Explorer does not have built-in property 'window.location.origin',
+    // we need to create one here as some vendor code such as TinyMCE uses this.
+    if (!window.location.origin) {
+        window.location.origin = window.location.protocol + "//" + window.location.hostname
+                               + (window.location.port ? ':' + window.location.port : '');
+    }
     var require = {
         baseUrl: baseUrl,
         waitSeconds: 60,


### PR DESCRIPTION
As TinyMCE's CodeMirror plug-in uses 'window.location.origin' which is not supported by Internet Explorer, the HTML source code editor does not work under Internet Explorer.
We need to create one in order to make these vendor codes work under Internet Explorer.
