### PR TITLE
Install EASE and requirements

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -45,6 +45,7 @@ Markdown==2.2.1
 mongoengine==0.7.10
 networkx==1.7
 nltk==2.0.4
+nose==1.3.3
 oauthlib==0.5.1
 paramiko==1.9.0
 path.py==3.0.1

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -28,6 +28,7 @@
 -e git+https://github.com/edx/acid-block.git@459aff7b63db8f2c5decd1755706c1a64fb4ebb1#egg=acid-xblock
 -e git+https://github.com/edx/edx-ora2.git@release-2014-05-23T16.59#egg=edx-ora2
 -e git+https://github.com/edx/opaque-keys.git@1f5ab1abd8273559795b0460e74658e7cd8adc8d#egg=opaque-keys
+git+https://github.com/edx/ease.git@6eee938f98777367b414217c09a8dce05efc2d7f#egg=ease
 
 # Prototype XBlocks for limited roll-outs and user testing. These are not for general use.
 -e git+https://github.com/pmitros/ConceptXBlock.git@2376fde9ebdd83684b78dde77ef96361c3bd1aa0#egg=concept-xblock


### PR DESCRIPTION
- Add EASE to edx-platform requirements
- Install fisher and scikit-learn (EASE requirements)

I installed this branch on a sandbox and was able to get the EASE test suite to pass.  The only other thing I needed to do was add this line to `edxapp_env`:

```
export NLTK_DATA="/edx/var/ora/nltk_data"
```

@feanil  If possible, I'd like to get this merged soon because it will make deployment and testing easier.
