### PR TITLE
ChoiceGroup  i18n.

### DIFF
--- a/common/lib/capa/capa/templates/choicetext.html
+++ b/common/lib/capa/capa/templates/choicetext.html
@@ -1,3 +1,4 @@
+<%! from django.utils.translation import ugettext as _ %>
 <% element_checked = False %>
 % for choice_id, _ in choices:
     <%choice_id = choice_id %>
@@ -62,7 +63,7 @@
     </fieldset>
         <input class= "choicetextvalue" type="hidden"  name="input_${id}{}" id="input_${id}" value="${value|h}" />
     % if show_correctness == "never" and (value or status not in ['unsubmitted']):
-    <div class="capa_alert">${submitted_message}</div>
+    <div class="capa_alert">${_(submitted_message)}</div>
     %endif
     % if msg:
     <span class="message">${msg|n}</span>


### PR DESCRIPTION
@sarina please review.

```
#. Translators: 'ChoiceGroup' is an input type and should not be translated.
#: common/lib/capa/capa/inputtypes.py:451
#, python-brace-format
msgid "ChoiceGroup: unexpected tag {tag_name}"
msgstr ""

#: common/lib/capa/capa/inputtypes.py:462
msgid "Answer received."
msgstr ""

#. Translators: '<choice>' is a tag name and should not be translated.
#: common/lib/capa/capa/inputtypes.py:488
#, python-brace-format
msgid "Expected a <choice> tag; got {given_tag} instead"
msgstr ""
```
