### PR TITLE
Annotation Tools: Load Tinymce in student_view

### DIFF
--- a/common/lib/xmodule/xmodule/imageannotation_module.py
+++ b/common/lib/xmodule/xmodule/imageannotation_module.py
@@ -9,6 +9,7 @@ from xmodule.raw_module import RawDescriptor
 from xblock.core import Scope, String
 from xmodule.annotator_mixin import get_instructions, html_to_text
 from xmodule.annotator_token import retrieve_token
+from xblock.fragment import Fragment
 
 import textwrap
 
@@ -94,7 +95,7 @@ class ImageAnnotationModule(AnnotatableFields, XModule):
         """ Removes <instructions> from the xmltree and returns them as a string, otherwise None. """
         return get_instructions(xmltree)
 
-    def get_html(self):
+    def student_view(self, context):
         """ Renders parameters to template. """
         context = {
             'display_name': self.display_name_with_default,
@@ -105,7 +106,10 @@ class ImageAnnotationModule(AnnotatableFields, XModule):
             'openseadragonjson': self.openseadragonjson,
         }
 
-        return self.system.render_template('imageannotation.html', context)
+        fragment = Fragment(self.system.render_template('imageannotation.html', context))
+        fragment.add_javascript_url("/static/js/vendor/tinymce/js/tinymce/tinymce.full.min.js")
+        fragment.add_javascript_url("/static/js/vendor/tinymce/js/tinymce/jquery.tinymce.min.js")
+        return fragment
 
 
 class ImageAnnotationDescriptor(AnnotatableFields, RawDescriptor):  # pylint: disable=abstract-method

--- a/common/lib/xmodule/xmodule/tests/test_imageannotation.py
+++ b/common/lib/xmodule/xmodule/tests/test_imageannotation.py
@@ -69,10 +69,10 @@ class ImageAnnotationModuleTestCase(unittest.TestCase):
         actual = self.mod._extract_instructions(xmltree)  # pylint: disable=protected-access
         self.assertIsNone(actual)
 
-    def test_get_html(self):
+    def test_student_view(self):
         """
         Tests the function that passes in all the information in the context that will be used in templates/textannotation.html
         """
-        context = self.mod.get_html()
+        context = self.mod.student_view({}).content
         for key in ['display_name', 'instructions_html', 'annotation_storage', 'token', 'tag', 'openseadragonjson']:
             self.assertIn(key, context)

--- a/common/lib/xmodule/xmodule/tests/test_textannotation.py
+++ b/common/lib/xmodule/xmodule/tests/test_textannotation.py
@@ -54,10 +54,10 @@ class TextAnnotationModuleTestCase(unittest.TestCase):
         actual = self.mod._extract_instructions(xmltree)  # pylint: disable=W0212
         self.assertIsNone(actual)
 
-    def test_get_html(self):
+    def test_student_view(self):
         """
         Tests the function that passes in all the information in the context that will be used in templates/textannotation.html
         """
-        context = self.mod.get_html()
+        context = self.mod.student_view({}).content
         for key in ['display_name', 'tag', 'source', 'instructions_html', 'content_html', 'annotation_storage', 'token']:
             self.assertIn(key, context)

--- a/common/lib/xmodule/xmodule/tests/test_videoannotation.py
+++ b/common/lib/xmodule/xmodule/tests/test_videoannotation.py
@@ -62,10 +62,10 @@ class VideoAnnotationModuleTestCase(unittest.TestCase):
         self.assertEqual(expectedyoutube, result2)
         self.assertEqual(expectednotyoutube, result1)
 
-    def test_get_html(self):
+    def test_student_view(self):
         """
         Tests to make sure variables passed in truly exist within the html once it is all rendered.
         """
-        context = self.mod.get_html()
+        context = self.mod.student_view({}).content
         for key in ['display_name', 'instructions_html', 'sourceUrl', 'typeSource', 'poster', 'annotation_storage']:
             self.assertIn(key, context)

--- a/common/lib/xmodule/xmodule/textannotation_module.py
+++ b/common/lib/xmodule/xmodule/textannotation_module.py
@@ -8,7 +8,7 @@ from xmodule.raw_module import RawDescriptor
 from xblock.core import Scope, String
 from xmodule.annotator_mixin import get_instructions
 from xmodule.annotator_token import retrieve_token
-
+from xblock.fragment import Fragment
 import textwrap
 
 # Make '_' a no-op so we can scrape strings
@@ -73,7 +73,7 @@ class TextAnnotationModule(AnnotatableFields, XModule):
         """ Removes <instructions> from the xmltree and returns them as a string, otherwise None. """
         return get_instructions(xmltree)
 
-    def get_html(self):
+    def student_view(self, context):
         """ Renders parameters to template. """
         context = {
             'course_key': self.runtime.course_id,
@@ -85,7 +85,10 @@ class TextAnnotationModule(AnnotatableFields, XModule):
             'annotation_storage': self.annotation_storage_url,
             'token': retrieve_token(self.user_email, self.annotation_token_secret),
         }
-        return self.system.render_template('textannotation.html', context)
+        fragment = Fragment(self.system.render_template('textannotation.html', context))
+        fragment.add_javascript_url("/static/js/vendor/tinymce/js/tinymce/tinymce.full.min.js")
+        fragment.add_javascript_url("/static/js/vendor/tinymce/js/tinymce/jquery.tinymce.min.js")
+        return fragment
 
 
 class TextAnnotationDescriptor(AnnotatableFields, RawDescriptor):

--- a/common/lib/xmodule/xmodule/videoannotation_module.py
+++ b/common/lib/xmodule/xmodule/videoannotation_module.py
@@ -9,6 +9,7 @@ from xmodule.raw_module import RawDescriptor
 from xblock.core import Scope, String
 from xmodule.annotator_mixin import get_instructions, get_extension
 from xmodule.annotator_token import retrieve_token
+from xblock.fragment import Fragment
 
 import textwrap
 
@@ -72,7 +73,7 @@ class VideoAnnotationModule(AnnotatableFields, XModule):
         ''' get the extension of a given url '''
         return get_extension(src_url)
 
-    def get_html(self):
+    def student_view(self, context):
         """ Renders parameters to template. """
         extension = self._get_extension(self.sourceurl)
 
@@ -87,8 +88,10 @@ class VideoAnnotationModule(AnnotatableFields, XModule):
             'annotation_storage': self.annotation_storage_url,
             'token': retrieve_token(self.user_email, self.annotation_token_secret),
         }
-
-        return self.system.render_template('videoannotation.html', context)
+        fragment = Fragment(self.system.render_template('videoannotation.html', context))
+        fragment.add_javascript_url("/static/js/vendor/tinymce/js/tinymce/tinymce.full.min.js")
+        fragment.add_javascript_url("/static/js/vendor/tinymce/js/tinymce/jquery.tinymce.min.js")
+        return fragment
 
 
 class VideoAnnotationDescriptor(AnnotatableFields, RawDescriptor):

--- a/lms/templates/imageannotation.html
+++ b/lms/templates/imageannotation.html
@@ -31,8 +31,6 @@
                 <%namespace name='static' file='/static_content.html'/>
                 ${static.css(group='style-vendor-tinymce-content', raw=True)}
                 ${static.css(group='style-vendor-tinymce-skin', raw=True)}
-                <script type="text/javascript" src="${static.url('js/vendor/tinymce/js/tinymce/tinymce.full.min.js', raw=True)}" />
-                <script type="text/javascript" src="${static.url('js/vendor/tinymce/js/tinymce/jquery.tinymce.min.js', raw=True)}" />
             </div> 
 			<div id="catchDIV">
                 ## Translators: Notes below refer to annotations. They wil later be put under a "Notes" section.
@@ -180,7 +178,6 @@
         optionsOSDA:{},
 
     };
-    tinymce.baseURL = "${settings.STATIC_URL}" + "js/vendor/tinymce/js/tinymce";
     var imgURLRoot = "${settings.STATIC_URL}" + "js/vendor/ova/catch/img/";
 	
     if (typeof Annotator != 'undefined'){

--- a/lms/templates/textannotation.html
+++ b/lms/templates/textannotation.html
@@ -2,8 +2,6 @@
 <%namespace name='static' file='/static_content.html'/>
 ${static.css(group='style-vendor-tinymce-content', raw=True)}
 ${static.css(group='style-vendor-tinymce-skin', raw=True)}
-<script type="text/javascript" src="${static.url('js/vendor/tinymce/js/tinymce/tinymce.full.min.js', raw=True)}" />
-<script type="text/javascript" src="${static.url('js/vendor/tinymce/js/tinymce/jquery.tinymce.min.js', raw=True)}" />
 
 <div class="annotatable-wrapper">
     <div class="annotatable-header">
@@ -167,7 +165,6 @@ ${static.css(group='style-vendor-tinymce-skin', raw=True)}
     };
 
     var imgURLRoot = "${settings.STATIC_URL}" + "js/vendor/ova/catch/img/";
-    tinymce.baseURL = "${settings.STATIC_URL}" + "js/vendor/tinymce/js/tinymce";
 
     //remove old instances
     if (Annotator._instances.length !== 0) {

--- a/lms/templates/videoannotation.html
+++ b/lms/templates/videoannotation.html
@@ -2,9 +2,6 @@
 <%namespace name='static' file='/static_content.html'/>
 ${static.css(group='style-vendor-tinymce-content', raw=True)}
 ${static.css(group='style-vendor-tinymce-skin', raw=True)}
-<script type="text/javascript" src="${static.url('js/vendor/tinymce/js/tinymce/tinymce.full.min.js', raw=True)}" />
-<script type="text/javascript" src="${static.url('js/vendor/tinymce/js/tinymce/jquery.tinymce.min.js', raw=True)}" />
-
 
 <div class="annotatable-wrapper">
 	<div class="annotatable-header">
@@ -168,7 +165,6 @@ ${static.css(group='style-vendor-tinymce-skin', raw=True)}
     };
 
 	var imgURLRoot = "${settings.STATIC_URL}" + "js/vendor/ova/catch/img/";
-	tinymce.baseURL = "${settings.STATIC_URL}" + "js/vendor/tinymce/js/tinymce";
 
 	//remove old instances
     if (Annotator._instances.length !== 0) {


### PR DESCRIPTION
**Background:** This is a follow-up to PR #3831. According to @cpennington and @singingwolfboy there was a race condition with TinyMCE in the annotation tools which could be fixed by loading them via student_view from the XBlock API.

*_Goal of PR: *_ This PR focuses solely on that fix. It includes both changes to the modules in xmodule as well as to the test files to verify the fix.

**CMS Updates:** None.

**LMS Updates:** Changes to the way TinyMCE loads.

**Testing Notes:** Everything seems to be working in the local environment but the issue always seems to be on staging.
