### PR TITLE
Make reverse matching robust to errored courses

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -189,9 +189,9 @@ def _accessible_courses_list_from_groups(request):
         course_key = course_access.course_id
         if course_key not in courses_list:
             course = modulestore('direct').get_course(course_key)
-            if course is None:
-                raise ItemNotFoundError(course_key)
-            courses_list[course_key] = course
+            if course is not None:
+                # ignore deleted or errored courses
+                courses_list[course_key] = course
 
     return courses_list.values()
 

--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -208,7 +208,7 @@ class CachingDescriptorSystem(MakoDescriptorSystem):
                 module.save()
                 return module
             except:
-                log.warning("Failed to load descriptor", exc_info=True)
+                log.warning("Failed to load descriptor from %s", json_data, exc_info=True)
                 return ErrorDescriptor.from_json(
                     json_data,
                     self,


### PR DESCRIPTION
@cpennington fixes the problem we had on edge and makes the reverse matching actually useful

I reproduced the problem by adding a tab of type "wiko" to a course and then put in this patch.
