### PR TITLE
Ensure no old gems are left behind between test runs.

### DIFF
--- a/jenkins/acceptance.sh
+++ b/jenkins/acceptance.sh
@@ -58,7 +58,9 @@ if [ -e $HOME/edx-rbenv_clean.tar.gz ]; then
     tar -C $HOME -xf $HOME/edx-rbenv_clean.tar.gz
 fi
 
-# Bootstrap Ruby requirements so we can run the tests
+# Ensure the Ruby environment is in a clean state and
+# bootstrap Ruby requirements so we can run the tests
+bundle clean --force
 bundle install
 
 # Reset the jenkins worker's virtualenv back to the

--- a/jenkins/acceptance.sh
+++ b/jenkins/acceptance.sh
@@ -58,10 +58,11 @@ if [ -e $HOME/edx-rbenv_clean.tar.gz ]; then
     tar -C $HOME -xf $HOME/edx-rbenv_clean.tar.gz
 fi
 
-# Ensure the Ruby environment is in a clean state and
-# bootstrap Ruby requirements so we can run the tests
-bundle clean --force
+# Bootstrap Ruby requirements so we can run the tests
 bundle install
+
+# Ensure the Ruby environment contains no stray gems
+bundle clean --force
 
 # Reset the jenkins worker's virtualenv back to the
 # state it was in when the instance was spun up.

--- a/jenkins/all-tests.sh
+++ b/jenkins/all-tests.sh
@@ -66,7 +66,9 @@ if [ -e $HOME/edx-rbenv_clean.tar.gz ]; then
     tar -C $HOME -xf $HOME/edx-rbenv_clean.tar.gz
 fi
 
-# Bootstrap Ruby requirements so we can run the tests
+# Ensure the Ruby environment is in a clean state and
+# bootstrap Ruby requirements so we can run the tests
+bundle clean --force
 bundle install
 
 # Reset the jenkins worker's virtualenv back to the

--- a/jenkins/all-tests.sh
+++ b/jenkins/all-tests.sh
@@ -66,10 +66,11 @@ if [ -e $HOME/edx-rbenv_clean.tar.gz ]; then
     tar -C $HOME -xf $HOME/edx-rbenv_clean.tar.gz
 fi
 
-# Ensure the Ruby environment is in a clean state and
-# bootstrap Ruby requirements so we can run the tests
-bundle clean --force
+# Bootstrap Ruby requirements so we can run the tests
 bundle install
+
+# Ensure the Ruby environment contains no stray gems
+bundle clean --force
 
 # Reset the jenkins worker's virtualenv back to the
 # state it was in when the instance was spun up.


### PR DESCRIPTION
The issue is thus:
1. We run a job on a jenkins-worker that includes a gem upgrade to sass 3.3. This produces deprecation warnings
*\* CC @andy-armstrong on that issue, related to #3462. I'm guessing those deprecation warnings will have to be addressed.
2. Then we run another job on the same jenkins-worker that is using the old gem (say, running on master)
*\* However, in this second run, we still get the deprecation warnings. This is because the previously-upgraded gems are still left behind in the rbenv.

@jzoldak @clytwynec Can you take a look?
