### PR TITLE
Fix the title of edit modals from the unit page.

### DIFF
--- a/cms/static/js/spec/views/pages/container_spec.js
+++ b/cms/static/js/spec/views/pages/container_spec.js
@@ -87,14 +87,13 @@ define(["jquery", "underscore", "js/spec_helpers/create_sinon", "js/spec_helpers
                 });
 
                 it('can edit itself', function() {
-                    var editButtons, modalElement,
+                    var editButtons,
                         updatedTitle = 'Updated Test Container';
                     renderContainerPage(mockContainerXBlockHtml, this);
 
                     // Click the root edit button
                     editButtons = containerPage.$('.nav-actions .edit-button');
                     editButtons.first().click();
-                    modalElement = edit_helpers.getModalElement();
 
                     // Expect a request to be made to show the studio view for the container
                     expect(lastRequest().url).toBe(
@@ -107,7 +106,7 @@ define(["jquery", "underscore", "js/spec_helpers/create_sinon", "js/spec_helpers
                     expect(edit_helpers.isShowingModal()).toBeTruthy();
 
                     // Expect the correct title to be shown
-                    expect(modalElement.find('.modal-window-title').text()).toBe('Editing: Test Container');
+                    expect(edit_helpers.getModalTitle()).toBe('Editing: Test Container');
 
                     // Press the save button and respond with a success message to the save
                     edit_helpers.pressModalButton('.action-save');

--- a/cms/static/js/spec/views/unit_spec.js
+++ b/cms/static/js/spec/views/unit_spec.js
@@ -211,7 +211,11 @@ define(["jquery", "underscore", "jasmine", "coffee/src/views/unit", "js/models/m
                         html: mockXBlockEditorHtml,
                         resources: []
                     });
+
+                    // Expect that a modal is shown with the correct title
                     expect(edit_helpers.isShowingModal()).toBeTruthy();
+                    expect(edit_helpers.getModalTitle()).toBe('Editing: Test Child Container');
+
                 });
             });
 

--- a/cms/static/js/spec_helpers/modal_helpers.js
+++ b/cms/static/js/spec_helpers/modal_helpers.js
@@ -27,6 +27,11 @@ define(["jquery", "js/spec_helpers/view_helpers"],
             return modalElement;
         };
 
+        getModalTitle = function(modal) {
+            var modalElement = getModalElement(modal);
+            return modalElement.find('.modal-window-title').text();
+        };
+
         isShowingModal = function(modal) {
             var modalElement = getModalElement(modal);
             return modalElement.length > 0;
@@ -58,6 +63,7 @@ define(["jquery", "js/spec_helpers/view_helpers"],
 
         return $.extend(view_helpers, {
             'getModalElement': getModalElement,
+            'getModalTitle': getModalTitle,
             'installModalTemplates': installModalTemplates,
             'isShowingModal': isShowingModal,
             'hideModalIfShowing': hideModalIfShowing,

--- a/cms/static/js/views/modals/edit_xblock.js
+++ b/cms/static/js/views/modals/edit_xblock.js
@@ -181,6 +181,10 @@ define(["jquery", "underscore", "gettext", "js/views/modals/base_modal",
                 if (xblockWrapperElement.length > 0) {
                     xblockElement = xblockWrapperElement.find('.xblock');
                     displayName = xblockWrapperElement.find('.xblock-header .header-details').text().trim();
+                    // If not found, try looking for the old unit page style rendering
+                    if (!displayName) {
+                        displayName = this.xblockElement.find('.component-header').text().trim();
+                    }
                     xblockInfo = new XBlockInfo({
                         id: xblockWrapperElement.data('locator'),
                         courseKey: xblockWrapperElement.data('course-key'),


### PR DESCRIPTION
The last bug fix I made for the editing containers story introduced this new bug. I somehow lost the logic for getting a display name for an xblock rendered on the unit page. I've reintroduced the logic and written a unit test to verify that the correct title is shown.

@cahrens Please review.
