### PR TITLE
Update EASE in edx-platform requirements

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -28,7 +28,7 @@
 -e git+https://github.com/edx/acid-block.git@459aff7b63db8f2c5decd1755706c1a64fb4ebb1#egg=acid-xblock
 -e git+https://github.com/edx/edx-ora2.git@release-2014-05-23T16.59#egg=edx-ora2
 -e git+https://github.com/edx/opaque-keys.git@91b7ec93cfb57c6739332e85805296626b4fb1db#egg=opaque-keys
-git+https://github.com/edx/ease.git@6eee938f98777367b414217c09a8dce05efc2d7f#egg=ease
+git+https://github.com/edx/ease.git@ea5770eaba4ce129cb5db8a41662435649ba6d4c#egg=ease
 
 # Prototype XBlocks for limited roll-outs and user testing. These are not for general use.
 -e git+https://github.com/pmitros/ConceptXBlock.git@2376fde9ebdd83684b78dde77ef96361c3bd1aa0#egg=concept-xblock


### PR DESCRIPTION
Currently, the EASE repository installs the NLTK corpus in its `setup.py`.  We're already installing NLTK using the Ansible scripts, so this wastes disk space.

This change removes the NLTK corpus from the EASE repository.  It also includes a minor change to error message logging.

Full changes:
https://github.com/edx/ease/compare/6eee938f98777367b414217c09a8dce05efc2d7f...ea5770eaba4ce129cb5db8a41662435649ba6d4c

Note that this change will NOT affect ORA1 installations, since those use the version of EASE installed for the `ora` user.  This change will only affect ORA2 AI grading.

@singingwolfboy
