### PR TITLE
Improve handling of bad JSON from comments service

### DIFF
--- a/lms/lib/comment_client/utils.py
+++ b/lms/lib/comment_client/utils.py
@@ -104,7 +104,15 @@ def perform_request(method, url, data_or_params=None, raw=False,
         if raw:
             return response.text
         else:
-            data = response.json()
+            try:
+                data = response.json()
+            except ValueError:
+                raise CommentClientError(
+                    u"Comments service returned invalid JSON for request {request_id}; first 100 characters: '{content}'".format(
+                        request_id=request_id,
+                        content=response.text[:100]
+                    )
+                )
             if paged_results:
                 dog_stats_api.histogram(
                     'comment_client.request.paged.result_count',


### PR DESCRIPTION
Instead of allowing the JSONDecodeError to escape, raise an error
indicating the request id to allow for further investigation.

@jimabramson 
