### PR TITLE
Bok choy tests should not all run as global staff

### DIFF
--- a/common/test/acceptance/tests/test_studio_acid_xblock.py
+++ b/common/test/acceptance/tests/test_studio_acid_xblock.py
@@ -32,7 +32,6 @@ class XBlockAcidBase(WebAppTest):
             'display_name': 'Test Course ' + self.unique_id
         }
 
-        self.auth_page = AutoAuthPage(self.browser, staff=True)
         self.outline = CourseOutlinePage(
             self.browser,
             self.course_info['org'],
@@ -44,6 +43,13 @@ class XBlockAcidBase(WebAppTest):
 
         self.setup_fixtures()
 
+        self.auth_page = AutoAuthPage(
+            self.browser,
+            staff=False,
+            username=self.user.get('username'),
+            email=self.user.get('email'),
+            password=self.user.get('password')
+        )
         self.auth_page.visit()
 
     def validate_acid_block_preview(self, acid_block):
@@ -112,6 +118,8 @@ class XBlockAcidNoChildTest(XBlockAcidBase):
             )
         ).install()
 
+        self.user = course_fix.user
+
 
 class XBlockAcidParentBase(XBlockAcidBase):
     """
@@ -167,6 +175,8 @@ class XBlockAcidEmptyParentTest(XBlockAcidParentBase):
             )
         ).install()
 
+        self.user = course_fix.user
+
 
 class XBlockAcidChildTest(XBlockAcidParentBase):
     """
@@ -196,6 +206,9 @@ class XBlockAcidChildTest(XBlockAcidParentBase):
                 )
             )
         ).install()
+
+        self.user = course_fix.user
+
 
     @skip('This will fail until we fix support of children in pure XBlocks')
     def test_acid_block_preview(self):

--- a/common/test/acceptance/tests/test_studio_container.py
+++ b/common/test/acceptance/tests/test_studio_container.py
@@ -25,7 +25,6 @@ class ContainerBase(UniqueCourseTest):
         # Ensure that the superclass sets up
         super(ContainerBase, self).setUp()
 
-        self.auth_page = AutoAuthPage(self.browser, staff=True)
         self.outline = CourseOutlinePage(
             self.browser,
             self.course_info['org'],
@@ -58,6 +57,13 @@ class ContainerBase(UniqueCourseTest):
 
         self.setup_fixtures()
 
+        self.auth_page = AutoAuthPage(
+            self.browser,
+            staff=False,
+            username=self.user.get('username'),
+            email=self.user.get('email'),
+            password=self.user.get('password')
+        )
         self.auth_page.visit()
 
     def setup_fixtures(self):
@@ -87,6 +93,8 @@ class ContainerBase(UniqueCourseTest):
                 )
             )
         ).install()
+
+        self.user = course_fix.user
 
     def go_to_container_page(self, make_draft=False):
         unit = self.go_to_unit_page(make_draft)

--- a/common/test/acceptance/tests/test_studio_general.py
+++ b/common/test/acceptance/tests/test_studio_general.py
@@ -77,14 +77,26 @@ class CoursePagesTest(UniqueCourseTest):
         """
         super(CoursePagesTest, self).setUp()
 
-        CourseFixture(
+        course_fix = CourseFixture(
             self.course_info['org'],
             self.course_info['number'],
             self.course_info['run'],
             self.course_info['display_name']
-        ).install()
+        )
 
-        self.auth_page = AutoAuthPage(self.browser, staff=True)
+        course_fix.install()
+
+        # Log in as the user that created the course, and also make it
+        # so that they are no longer global staff.
+        # They will have been given instructor access to the course
+        # and enrolled in it when they created it.
+        self.auth_page = AutoAuthPage(
+            self.browser,
+            staff=False,
+            username=course_fix.user.get('username'),
+            email=course_fix.user.get('email'),
+            password=course_fix.user.get('password')
+        )
 
         self.pages = [
             clz(self.browser, self.course_info['org'], self.course_info['number'], self.course_info['run'])
@@ -116,7 +128,8 @@ class DiscussionPreviewTest(UniqueCourseTest):
 
     def setUp(self):
         super(DiscussionPreviewTest, self).setUp()
-        CourseFixture(**self.course_info).add_children(
+
+        course_fix = CourseFixture(**self.course_info).add_children(
             XBlockFixtureDesc("chapter", "Test Section").add_children(
                 XBlockFixtureDesc("sequential", "Test Subsection").add_children(
                     XBlockFixtureDesc("vertical", "Test Unit").add_children(
@@ -127,9 +140,19 @@ class DiscussionPreviewTest(UniqueCourseTest):
                     )
                 )
             )
-        ).install()
+        )
 
-        AutoAuthPage(self.browser, staff=True).visit()
+        course_fix.install()
+
+        self.auth_page = AutoAuthPage(
+            self.browser,
+            staff=False,
+            username=course_fix.user.get('username'),
+            email=course_fix.user.get('email'),
+            password=course_fix.user.get('password')
+        )
+        self.auth_page.visit()
+
         cop = CourseOutlinePage(
             self.browser,
             self.course_info['org'],


### PR DESCRIPTION
Currently the tests were creating one user to set up the course fixture, and then another, global staff, user to test the functionality.
This is sub-optimal as it's creating unnecessary users and more importantly testing everything as global staff which is not the primary use case.
