### PR TITLE
RelativeTime: incorrect value after XML serialization.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ These are notable changes in edx-platform.  This is a rolling list of changes,
 in roughly chronological order, most recent first.  Add your entries at or near
 the top.  Include a label indicating the component affected.
 
+Blades: Fix bug with incorrect RelativeTime value after XML serialization. BLD-1060
+
 LMS: Update bulk email implementation to lessen load on the database
 by consolidating chunked queries for recipients into a single query.
 

--- a/common/lib/xmodule/xmodule/js/spec/time_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/time_spec.js
@@ -3,6 +3,13 @@
 
     describe('Time', function () {
         describe('format', function () {
+            describe('with NAN', function () {
+                it('return a correct time format', function () {
+                    expect(Time.format('string')).toEqual('0:00');
+                    expect(Time.format(void(0))).toEqual('0:00');
+                });
+            });
+
             describe('with duration more than or equal to 1 hour', function () {
                 it('return a correct time format', function () {
                     expect(Time.format(3600)).toEqual('1:00:00');

--- a/common/lib/xmodule/xmodule/js/src/time.js
+++ b/common/lib/xmodule/xmodule/js/src/time.js
@@ -12,6 +12,10 @@
     function format(time, formatFull) {
         var hours, minutes, seconds;
 
+        if (!_.isFinite(time)) {
+            time = 0;
+        }
+
         seconds = Math.floor(time);
         minutes = Math.floor(seconds / 60);
         hours = Math.floor(minutes / 60);


### PR DESCRIPTION
Sorry for the mess.
Lines that were changed in:
`common/lib/xmodule/xmodule/js/spec/time_spec.js` lines 6-11.
`common/lib/xmodule/xmodule/js/src/time.js` lines 15-17.

@auraz please review.
