### PR TITLE
Update django-wiki

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -9,7 +9,7 @@
 # Third-party:
 -e git+https://github.com/edx/django-staticfiles.git@d89aae2a82f2b#egg=django-staticfiles
 -e git+https://github.com/edx/django-pipeline.git@88ec8a011e481918fdc9d2682d4017c835acd8be#egg=django-pipeline
--e git+https://github.com/edx/django-wiki.git@cd0b2b31997afccde519fe5b3365e61a9edb143f#egg=django-wiki
+-e git+https://github.com/edx/django-wiki.git@1fc65727450a751eb6d9ce3064438badb5145fab#egg=django-wiki
 -e git+https://github.com/gabrielfalcao/lettuce.git@cccc3978ad2df82a78b6f9648fe2e9baddd22f88#egg=lettuce
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev
 -e git+https://github.com/eventbrite/zendesk.git@d53fe0e81b623f084e91776bcf6369f8b7b63879#egg=zendesk


### PR DESCRIPTION
**This pull request needs manual testing!!**

Because edx forked the `django-wiki` project, we've fallen behind. I've taken the [`edx_release` branch in our fork](https://github.com/edx/django-wiki/tree/edx_release) and rebased it on top of the [`master` branch of the upstream version](https://github.com/benjaoming/django-wiki/tree/master) and created a new branch called [`edx_release_rebase`](https://github.com/edx/django-wiki/tree/edx_release_rebase). This pull request proposes switching from our `edx_release` branch to this new `edx_release_rebase` branch for edx-platform. ([The comparison is too large for github to show](https://github.com/edx/django-wiki/compare/edx_release...edx_release_rebase) -- to view it on the command line, check out the repo and run `git diff edx_release..edx_release_rebase`.)

According to @rocha, there aren't tests for the wiki, so we'll need to test with new and existing data before actually merging this.

See also: http://django-wiki.readthedocs.org/en/latest/release_notes.html
