### PR TITLE
Update diff-cover to v0.4.1 and support --compare-branch

### DIFF
--- a/rakelib/tests.rake
+++ b/rakelib/tests.rake
@@ -154,7 +154,8 @@ namespace :test do
 end
 
 desc "Build the html, xml, and diff coverage reports"
-task :coverage => :report_dirs do
+task :coverage, [:compare_branch] => :report_dirs do |t, args|
+    compare_branch = args[:compare_branch] || 'origin/master'
 
     # Generate coverage for Python sources
     TEST_TASK_DIRS.each do |dir|
@@ -181,8 +182,8 @@ task :coverage => :report_dirs do
         diff_html_path = report_dir_path('diff_coverage_combined.html')
 
         # Generate the diff coverage reports (HTML and console)
-        sh("diff-cover #{xml_report_str} --html-report #{diff_html_path}")
-        sh("diff-cover #{xml_report_str}")
+        sh("diff-cover #{xml_report_str} --compare-branch=#{compare_branch} --html-report #{diff_html_path}")
+        sh("diff-cover #{xml_report_str} --compare-branch=#{compare_branch}")
         puts "\n"
     end
 end

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -19,7 +19,7 @@
 # Our libraries:
 -e git+https://github.com/edx/XBlock.git@fc5fea25c973ec66d8db63cf69a817ce624f5ef5#egg=XBlock
 -e git+https://github.com/edx/codejail.git@71f5c5616e2a73ae8cecd1ff2362774a773d3665#egg=codejail
--e git+https://github.com/edx/diff-cover.git@v0.2.9#egg=diff_cover
+-e git+https://github.com/edx/diff-cover.git@v0.4.1#egg=diff_cover
 -e git+https://github.com/edx/js-test-tool.git@v0.1.5#egg=js_test_tool
 -e git+https://github.com/edx/django-waffle.git@823a102e48#egg=django-waffle
 -e git+https://github.com/edx/event-tracking.git@0.1.0#egg=event-tracking


### PR DESCRIPTION
Recent versions of diff-cover introduced support for the --compare-branch command line argument. This patch adds support for it to `rake coverage`.

`rake coverage[rev_id]` will run diff-cover against that rev, while the default `rake coverage` behavior is unchanged.
