### PR TITLE
Show boolean values as checkbox in Studio.

### DIFF
--- a/cms/djangoapps/contentstore/features/video_editor.py
+++ b/cms/djangoapps/contentstore/features/video_editor.py
@@ -119,7 +119,10 @@ def set_show_captions(step, setting):
 
     world.edit_component()
     world.select_editor_tab('Advanced')
-    world.browser.select('Show Transcript', setting)
+    if setting == 'True':
+        world.browser.check('Show Transcript')
+    else:
+        world.browser.uncheck('Show Transcript')
     world.save_component()
 
 
@@ -147,12 +150,12 @@ def correct_video_settings(_step):
         # advanced
         [DISPLAY_NAME, 'Video', False],
         ['Default Timed Transcript', '', False],
-        ['Download Transcript Allowed', 'False', False],
+        ['Download Transcript Allowed', 'false', False],
         ['Downloadable Transcript URL', '', False],
-        ['Show Transcript', 'True', False],
+        ['Show Transcript', 'true', False],
         ['Transcript Languages', '', False],
         ['Upload Handout', '', False],
-        ['Video Download Allowed', 'False', False],
+        ['Video Download Allowed', 'false', False],
         ['Video File URLs', '', False],
         ['Video Start Time', '00:00:00', False],
         ['Video Stop Time', '00:00:00', False],

--- a/cms/static/coffee/spec/views/metadata_edit_spec.coffee
+++ b/cms/static/coffee/spec/views/metadata_edit_spec.coffee
@@ -15,6 +15,7 @@ define ["js/models/metadata", "js/collections/metadata", "js/views/metadata", "c
       optionEntryTemplate = readFixtures('metadata-option-entry.underscore')
       listEntryTemplate = readFixtures('metadata-list-entry.underscore')
       dictEntryTemplate = readFixtures('metadata-dict-entry.underscore')
+      booleanEntryTemplate = readFixtures('metadata-boolean-entry.underscore')
 
       beforeEach ->
           setFixtures($("<script>", {id: "metadata-editor-tpl", type: "text/template"}).text(editorTemplate))
@@ -23,6 +24,7 @@ define ["js/models/metadata", "js/collections/metadata", "js/views/metadata", "c
           appendSetFixtures($("<script>", {id: "metadata-option-entry", type: "text/template"}).text(optionEntryTemplate))
           appendSetFixtures($("<script>", {id: "metadata-list-entry", type: "text/template"}).text(listEntryTemplate))
           appendSetFixtures($("<script>", {id: "metadata-dict-entry", type: "text/template"}).text(dictEntryTemplate))
+          appendSetFixtures($("<script>", {id: "metadata-boolean-entry", type: "text/template"}).text(booleanEntryTemplate))
 
       genericEntry = {
           default_value: 'default value',
@@ -112,6 +114,20 @@ define ["js/models/metadata", "js/collections/metadata", "js/views/metadata", "c
           }
       }
 
+      booleanEntry = {
+          default_value: false,
+          display_name: "True or False",
+          explicitly_set: false,
+          field_name: "boolean",
+          help: "Do you have a bike, car or roller-skates?",
+          options: [
+              {"display_name": "True", "value": true},
+              {"display_name": "False", "value": false}
+          ],
+          type: MetadataModel.BOOLEAN_TYPE,
+          value: true
+      }
+
 
       # Test for the editor that creates the individual views.
       describe "MetadataView.Editor creates editors for each field", ->
@@ -137,17 +153,18 @@ define ["js/models/metadata", "js/collections/metadata", "js/views/metadata", "c
                       },
                       listEntry,
                       timeEntry,
-                      dictEntry
+                      dictEntry,
+                      booleanEntry,
                   ]
               )
 
           it "creates child views on initialize, and sorts them alphabetically", ->
               view = new MetadataView.Editor({collection: @model})
               childModels = view.collection.models
-              expect(childModels.length).toBe(8)
+              expect(childModels.length).toBe(9)
               # Be sure to check list view as well as other input types
               childViews = view.$el.find('.setting-input, .list-settings')
-              expect(childViews.length).toBe(8)
+              expect(childViews.length).toBe(9)
 
               verifyEntry = (index, display_name, type) ->
                   expect(childModels[index].get('display_name')).toBe(display_name)
@@ -159,8 +176,9 @@ define ["js/models/metadata", "js/collections/metadata", "js/views/metadata", "c
               verifyEntry(3, 'New Dict', '')
               verifyEntry(4, 'Show Answer', 'select-one')
               verifyEntry(5, 'Time', 'text')
-              verifyEntry(6, 'Unknown', 'text')
-              verifyEntry(7, 'Weight', 'number')
+              verifyEntry(6, 'True or False', 'checkbox')
+              verifyEntry(7, 'Unknown', 'text')
+              verifyEntry(8, 'Weight', 'number')
 
           it "returns its display name", ->
               view = new MetadataView.Editor({collection: @model})
@@ -232,7 +250,7 @@ define ["js/models/metadata", "js/collections/metadata", "js/views/metadata", "c
           it "uses a text input type", ->
               assertInputType(@view, 'text')
 
-          it "returns the intial value upon initialization", ->
+          it "returns the initial value upon initialization", ->
               assertValueInView(@view, 'Word cloud')
 
           it "can update its value in the view", ->
@@ -606,3 +624,24 @@ define ["js/models/metadata", "js/collections/metadata", "js/views/metadata", "c
           @el.find('input.input-key').last().val('third setting')
           @el.find('input.input-key').last().trigger('input')
           expect(@el.find('.create-setting')).not.toHaveClass('is-disabled')
+
+      describe "MetadataView.Boolean is an option input type with clear functionality", ->
+          beforeEach ->
+              model = new MetadataModel(booleanEntry)
+              @view = new MetadataView.Boolean({model: model})
+
+          it "uses a checkbox input type", ->
+              assertInputType(@view, 'checkbox')
+
+          it "returns the initial value upon initialization", ->
+              assertValueInView(@view, true)
+
+          it "can update its value in the view", ->
+              assertCanUpdateView(@view, true)
+              assertCanUpdateView(@view, false)
+
+          it "has a clear method to revert to the model default", ->
+              assertClear(@view, false)
+
+          it "has an update model method", ->
+              assertUpdateModel(@view, null, true)

--- a/cms/static/js/models/metadata.js
+++ b/cms/static/js/models/metadata.js
@@ -102,6 +102,7 @@ define(["backbone"], function(Backbone) {
         }
     });
 
+    Metadata.BOOLEAN_TYPE = "Boolean";
     Metadata.SELECT_TYPE = "Select";
     Metadata.INTEGER_TYPE = "Integer";
     Metadata.FLOAT_TYPE = "Float";

--- a/cms/static/js/views/metadata.js
+++ b/cms/static/js/views/metadata.js
@@ -549,5 +549,24 @@ function(BaseView, _, MetadataModel, AbstractEditor, FileUpload, UploadDialog, V
         }
     });
 
+    Metadata.Boolean = AbstractEditor.extend({
+
+        events : {
+            "change .input" : "updateModel",
+            "click .setting-clear" : "clear"
+        },
+
+        templateName: "metadata-boolean-entry",
+
+        getValueFromEditor: function () {
+            return this.$el.find('#' + this.uniqueId).is(':checked');
+        },
+
+        setValueInEditor: function (value) {
+            this.$el.find('#' + this.uniqueId).prop('checked', value);
+        }
+    });
+
+
     return Metadata;
 });

--- a/cms/static/sass/views/_unit.scss
+++ b/cms/static/sass/views/_unit.scss
@@ -537,6 +537,11 @@ body.course.unit,
         }
       }
 
+      input[type="checkbox"] {
+        width: 1em;
+        height: 1em;
+      }
+
       select {
         //box-shadow: 0 1px 2px $shadow-l1 inset;
 
@@ -723,6 +728,15 @@ body.course.unit,
           &:hover {
             color: $blue;
           }
+        }
+      }
+
+      .metadata-boolean {
+        .wrapper-setting-input {
+          display: inline-block;
+          text-align: center;
+          vertical-align: middle;
+          width: 45%;
         }
       }
     }

--- a/cms/templates/js/metadata-boolean-entry.underscore
+++ b/cms/templates/js/metadata-boolean-entry.underscore
@@ -1,0 +1,10 @@
+<div class="wrapper-comp-setting metadata-boolean">
+    <label class="label setting-label" for="<%= uniqueId %>"><%= model.get('display_name') %></label>
+    <div class="wrapper-setting-input">
+        <input class="input setting-input" type="checkbox" id="<%= uniqueId %>" value='<%= model.get("value") %>'/>
+    </div>
+    <button class="action setting-clear inactive" type="button" name="setting-clear" value="<%= gettext("Clear") %>" data-tooltip="<%= gettext("Clear") %>">
+        <i class="icon-undo"></i><span class="sr">"<%= gettext("Clear Value") %>"</span>
+    </button>
+</div>
+<span class="tip setting-help"><%= model.get('help') %></span>

--- a/cms/templates/js/metadata-boolean-entry.underscore
+++ b/cms/templates/js/metadata-boolean-entry.underscore
@@ -1,7 +1,7 @@
 <div class="wrapper-comp-setting metadata-boolean">
     <label class="label setting-label" for="<%= uniqueId %>"><%= model.get('display_name') %></label>
     <div class="wrapper-setting-input">
-        <input class="input setting-input" type="checkbox" id="<%= uniqueId %>" value='<%= model.get("value") %>'/>
+        <input class="input setting-input" type="checkbox" id="<%= uniqueId %>" value='<%= model.get("value") %>' name="<%= model.get('display_name') %>"/>
     </div>
     <button class="action setting-clear inactive" type="button" name="setting-clear" value="<%= gettext("Clear") %>" data-tooltip="<%= gettext("Clear") %>">
         <i class="icon-undo"></i><span class="sr">"<%= gettext("Clear Value") %>"</span>

--- a/cms/templates/widgets/metadata-edit.html
+++ b/cms/templates/widgets/metadata-edit.html
@@ -12,7 +12,7 @@
 <script id="metadata-editor-tpl" type="text/template">
     <%static:include path="js/metadata-editor.underscore" />
 </script>
-% for template_name in ["metadata-number-entry", "metadata-string-entry", "metadata-option-entry", "metadata-list-entry", "metadata-dict-entry", "metadata-file-uploader-entry", "metadata-file-uploader-item"]:
+% for template_name in ["metadata-number-entry", "metadata-string-entry", "metadata-option-entry", "metadata-list-entry", "metadata-dict-entry", "metadata-file-uploader-entry", "metadata-file-uploader-item", "metadata-boolean-entry"]:
     <script id="${template_name}" type="text/template">
         <%static:include path="js/${template_name}.underscore" />
     </script>

--- a/cms/templates/widgets/tabs/metadata-edit-tab.html
+++ b/cms/templates/widgets/tabs/metadata-edit-tab.html
@@ -8,7 +8,7 @@
     <%static:include path="js/metadata-editor.underscore" />
 </script>
 
-% for template_name in ["metadata-number-entry", "metadata-string-entry", "metadata-option-entry", "metadata-list-entry", "metadata-dict-entry", "metadata-file-uploader-entry", "metadata-file-uploader-item"]:
+% for template_name in ["metadata-number-entry", "metadata-string-entry", "metadata-option-entry", "metadata-list-entry", "metadata-dict-entry", "metadata-file-uploader-entry", "metadata-file-uploader-item", "metadata-boolean-entry"]:
     <script id="${template_name}" type="text/template">
         <%static:include path="js/${template_name}.underscore" />
     </script>

--- a/common/lib/xmodule/xmodule/tests/test_xml_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_xml_module.py
@@ -224,7 +224,7 @@ class EditableMetadataFieldsTest(unittest.TestCase):
         self.assert_field_values(
             editable_fields, 'boolean_select', TestFields.boolean_select,
             explicitly_set=False, value=None, default_value=None,
-            type='Select', options=[{'display_name': "True", "value": True}, {'display_name': "False", "value": False}]
+            type='Boolean', options=[{'display_name': "True", "value": True}, {'display_name': "False", "value": False}]
         )
 
         # Test for float

--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -16,10 +16,10 @@ from webob import Response
 from webob.multidict import MultiDict
 
 from xblock.core import XBlock
-from xblock.fields import Scope, Integer, Float, List, XBlockMixin, String, Dict
+from xblock.fields import Scope, Integer, Float, List, XBlockMixin, String, Dict, Boolean
+from xmodule.fields import RelativeTime
 from xblock.fragment import Fragment
 from xblock.runtime import Runtime, IdReader
-from xmodule.fields import RelativeTime
 
 from xmodule.errortracker import exc_info_to_str
 from xmodule.modulestore.exceptions import ItemNotFoundError
@@ -872,8 +872,11 @@ class XModuleDescriptor(XModuleMixin, HTMLSnippet, ResourceTemplates, XBlock):
         editor_type = "Generic"
         values = field.values
         if isinstance(values, (tuple, list)) and len(values) > 0:
-            editor_type = "Select"
             values = [jsonify_value(field, json_choice) for json_choice in values]
+            if isinstance(field, Boolean):
+                editor_type = "Boolean"
+            else:
+                editor_type = "Select"
         elif isinstance(field, Integer):
             editor_type = "Integer"
         elif isinstance(field, Float):


### PR DESCRIPTION
**Ticket:** [BLD-666](https://edx-wiki.atlassian.net/browse/BLD-666)
Boolean values as a setting are quite common, and right now, we display those as a drop down with the options of True and False. It would make much more sense to display them as a checkbox.

**Sandbox:** http://studio.polesye.m.sandbox.edx.org/

@cahrens, @talbs please review.
