### PR TITLE
Fix for XBlock/Studio/time bug

### DIFF
--- a/cms/lib/xblock/mixin.py
+++ b/cms/lib/xblock/mixin.py
@@ -3,6 +3,8 @@ Mixin defining common Studio functionality
 """
 
 import datetime
+import dateutil.parser
+import warnings
 
 from xblock.fields import Scope, Field, Integer, XBlockMixin
 
@@ -15,8 +17,21 @@ class DateTuple(Field):
         return datetime.datetime(*value[0:6])
 
     def to_json(self, value):
-        if value is None:
+        if not value:
+            if value != None:
+                warnings.warn("If time is not set, use Python None", RuntimeWarning)
             return None
+
+        # By runtime specification, this should never happen.  Since
+        # it did happen, we want an appropriate sanity-check, by:
+        #   http://en.wikipedia.org/wiki/Robustness_principle
+        #
+        # We could see this issue on export/import of an
+        # AnimationXBlock.  TODO: Figure out whether this is
+        # happening, and if so, why this happened (6/18/14).
+        if isinstance(value, basestring): 
+            value = dateutil.parser.parse(value)
+            warnings.warn("Date should be a datetime object, not a string.", RuntimeWarning) 
 
         return list(value.timetuple())
 


### PR DESCRIPTION
@dmitchell @cpennington I was using XBlocks in Studio, and getting funny import/export errors with XML content. This fixes it. I do not understand the code path around this basically at all. The fix was purely mechanical -- I saw strings going in and matching exceptions, so I made it handle strings. I'd appreciate a more detailed look-over to see if this is sane. 
