### PR TITLE
Reformats markdown problem templates avoid extra line breaks.

### DIFF
--- a/common/lib/xmodule/xmodule/templates/problem/multiplechoice.yaml
+++ b/common/lib/xmodule/xmodule/templates/problem/multiplechoice.yaml
@@ -2,13 +2,9 @@
 metadata:
     display_name: Multiple Choice
     markdown: |
-       A multiple choice problem presents radio buttons for student input. Students can only select a single 
-       option presented. Multiple Choice questions have been the subject of many areas of research due to the early 
-       invention and adoption of bubble sheets.
+       A multiple choice problem presents radio buttons for student input. Students can only select a single option presented. Multiple Choice questions have been the subject of many areas of research due to the early invention and adoption of bubble sheets.
        
-       One of the main elements that goes into a good multiple choice question is the existence of good distractors. 
-       That is, each of the alternate responses presented to the student should be the result of a plausible mistake 
-       that a student might make.
+       One of the main elements that goes into a good multiple choice question is the existence of good distractors. That is, each of the alternate responses presented to the student should be the result of a plausible mistake that a student might make.
     
        >>What Apple device competed with the portable CD player?<<
             ( ) The iPad
@@ -17,8 +13,7 @@ metadata:
             ( ) The vegetable peeler
             
        [explanation]
-       The release of the iPod allowed consumers to carry their entire music library with them in a 
-       format that did not rely on fragile and energy-intensive spinning disks.
+       The release of the iPod allowed consumers to carry their entire music library with them in a format that did not rely on fragile and energy-intensive spinning disks.
        [explanation]
 data: |
    <problem>

--- a/common/lib/xmodule/xmodule/templates/problem/numericalresponse.yaml
+++ b/common/lib/xmodule/xmodule/templates/problem/numericalresponse.yaml
@@ -2,12 +2,9 @@
 metadata:
     display_name: Numerical Input
     markdown: |
-       A numerical input problem accepts a line of text input from the
-       student, and evaluates the input for correctness based on its
-       numerical value.
+       A numerical input problem accepts a line of text input from the student, and evaluates the input for correctness based on its numerical value.
 
-       The answer is correct if it is within a specified numerical tolerance
-       of the expected answer.
+       The answer is correct if it is within a specified numerical tolerance of the expected answer.
 
        >>Enter the numerical value of Pi:<<
        = 3.14159 +- .02
@@ -19,12 +16,9 @@ metadata:
        = 5
 
        [explanation]
-       Pi, or the the ratio between a circle's circumference to its diameter, is an irrational number 
-       known to extreme precision. It is value is approximately equal to 3.14.
+       Pi, or the the ratio between a circle's circumference to its diameter, is an irrational number known to extreme precision. It is value is approximately equal to 3.14.
 
-       Although you can get an exact value by typing 502*9 into a calculator, the result will be close to 
-       500*10, or 5,000. The grader accepts any response within 15% of the true value, 4518, so that you 
-       can use any estimation technique that you like.
+       Although you can get an exact value by typing 502*9 into a calculator, the result will be close to 500*10, or 5,000. The grader accepts any response within 15% of the true value, 4518, so that you can use any estimation technique that you like.
 
        If you look at your hand, you can count that you have five fingers.
        [explanation]

--- a/common/lib/xmodule/xmodule/templates/problem/optionresponse.yaml
+++ b/common/lib/xmodule/xmodule/templates/problem/optionresponse.yaml
@@ -2,9 +2,7 @@
 metadata:
     display_name: Dropdown
     markdown: |
-        Dropdown problems give a limited set of options for students to respond with, and present those options
-        in a format that encourages them to search for a specific answer rather than being immediately presented 
-        with options from which to recognize the correct answer.
+        Dropdown problems give a limited set of options for students to respond with, and present those options in a format that encourages them to search for a specific answer rather than being immediately presented with options from which to recognize the correct answer.
 
         The answer options and the identification of the correct answer is defined in the <b>optioninput</b> tag.
 
@@ -13,10 +11,7 @@ metadata:
         [[(Multiple Choice), Text Input, Numerical Input, External Response, Image Response]]
 
         [explanation]
-        Multiple Choice also allows students to select from a variety of pre-written responses, although the 
-        format makes it easier for students to read very long response options. Dropdowns also differ
-        slightly because students are more likely to think of an answer and then search for it rather than 
-        relying purely on recognition to answer the question.
+        Multiple Choice also allows students to select from a variety of pre-written responses, although the format makes it easier for students to read very long response options. Dropdowns also differ slightly because students are more likely to think of an answer and then search for it rather than relying purely on recognition to answer the question.
         [explanation]
 data: |
   <problem>

--- a/common/lib/xmodule/xmodule/templates/problem/string_response.yaml
+++ b/common/lib/xmodule/xmodule/templates/problem/string_response.yaml
@@ -2,12 +2,9 @@
 metadata:
     display_name: Text Input
     markdown: |
-        A text input problem accepts a line of text from the 
-        student, and evaluates the input for correctness based on an expected 
-        answer.
+        A text input problem accepts a line of text from the student, and evaluates the input for correctness based on an expected answer.
     
-        The answer is correct if it matches every character of the expected answer. This can be a problem with  
-        international spelling, dates, or anything where the format of the answer is not clear.
+        The answer is correct if it matches every character of the expected answer. This can be a problem with international spelling, dates, or anything where the format of the answer is not clear.
     
         >>Which US state has Lansing as its capital?<<
 
@@ -15,8 +12,7 @@ metadata:
         
 
         [explanation]
-        Lansing is the capital of Michigan, although it is not Michgan's largest city, 
-        or even the seat of the county in which it resides.
+        Lansing is the capital of Michigan, although it is not Michgan's largest city, or even the seat of the county in which it resides.
         [explanation]
 data: |
     <problem>
@@ -25,7 +21,8 @@ data: |
     A text input problem accepts a line of text from the
     student, and evaluates the input for correctness based on an expected
     answer.
-
+    </p>
+    <p>
     The answer is correct if it matches every character of the expected answer. This can be a problem with international spelling, dates, or anything where the format of the answer is not clear. 
     </p>
 

--- a/common/lib/xmodule/xmodule/templates/problem/string_response.yaml
+++ b/common/lib/xmodule/xmodule/templates/problem/string_response.yaml
@@ -12,7 +12,7 @@ metadata:
         
 
         [explanation]
-        Lansing is the capital of Michigan, although it is not Michgan's largest city, or even the seat of the county in which it resides.
+        Lansing is the capital of Michigan, although it is not Michigan's largest city, or even the seat of the county in which it resides.
         [explanation]
 data: |
     <problem>
@@ -33,7 +33,7 @@ data: |
         <solution>
             <div class="detailed-solution">
                 <p>Explanation</p>
-                <p>Lansing is the capital of Michigan, although it is not Michgan's largest city, or even the seat of the county in which it resides.</p>
+                <p>Lansing is the capital of Michigan, although it is not Michigan's largest city, or even the seat of the county in which it resides.</p>
             </div>
         </solution>
     </problem>


### PR DESCRIPTION
Based on the parsing rules in `common/lib/xmodule/xmodule/js/src/problem/edit.coffee` every line is formatted as a new paragraph (line 400):

```
splits[i] = splits[i].replace(/(^(?!\s*\<|$).*$)/gm, '<p>$1</p>');
```

I've simply reformatted the template files so they are consistent with their generated xml in order to avoid changing existing behavior.

@cahrens @andy-armstrong 
