### PR TITLE
Serve ORA2 JavaScript i18n strings

### DIFF
--- a/cms/urls.py
+++ b/cms/urls.py
@@ -94,8 +94,8 @@ urlpatterns += patterns(
 
 js_info_dict = {
     'domain': 'djangojs',
-    # No packages needed, we get LOCALE_PATHS anyway.
-    'packages': (),
+    # We need to explicitly include external Django apps that are not in LOCALE_PATHS.
+    'packages': ('openassessment',),
 }
 
 urlpatterns += patterns('',

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -81,8 +81,8 @@ urlpatterns += (
 
 js_info_dict = {
     'domain': 'djangojs',
-    # No packages needed, we get LOCALE_PATHS anyway.
-    'packages': (),
+    # We need to explicitly include external Django apps that are not in LOCALE_PATHS.
+    'packages': ('openassessment',),
 }
 
 urlpatterns += (


### PR DESCRIPTION
Allow the LMS and Studio to serve JavaScript translation strings for ORA2.  @nedbat please review.
