### PR TITLE
Install edx-submissions from PyPi instead of from edx-ora2

### DIFF
--- a/lms/djangoapps/courseware/grades.py
+++ b/lms/djangoapps/courseware/grades.py
@@ -15,7 +15,6 @@ from dogapi import dog_stats_api
 from courseware import courses
 from courseware.model_data import FieldDataCache
 from student.models import anonymous_id_for_user
-from submissions import api as sub_api
 from xmodule import graders
 from xmodule.graders import Score
 from xmodule.modulestore.django import modulestore
@@ -23,6 +22,7 @@ from xmodule.modulestore.exceptions import ItemNotFoundError
 from xmodule.util.duedate import get_extended_due_date
 from .models import StudentModule
 from .module_render import get_module_for_descriptor
+from submissions import api as sub_api  # installed from the edx-submissions repository
 from opaque_keys import InvalidKeyError
 
 log = logging.getLogger("edx.courseware")

--- a/lms/djangoapps/instructor/enrollment.py
+++ b/lms/djangoapps/instructor/enrollment.py
@@ -14,9 +14,7 @@ from student.models import CourseEnrollment, CourseEnrollmentAllowed
 from courseware.models import StudentModule
 from edxmako.shortcuts import render_to_string
 
-# Submissions is a Django app that is currently installed
-# from the edx-ora2 repo, although it will likely move in the future.
-from submissions import api as sub_api
+from submissions import api as sub_api  # installed from the edx-submissions repository
 from student.models import anonymous_id_for_user
 
 from microsite_configuration import microsite

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -52,9 +52,7 @@ import analytics.distributions
 import analytics.csvs
 import csv
 
-# Submissions is a Django app that is currently installed
-# from the edx-ora2 repo, although it will likely move in the future.
-from submissions import api as sub_api
+from submissions import api as sub_api # installed from the edx-submissions repository
 
 from bulk_email.models import CourseEmail
 

--- a/lms/djangoapps/instructor/views/legacy.py
+++ b/lms/djangoapps/instructor/views/legacy.py
@@ -36,9 +36,7 @@ from xmodule.html_module import HtmlDescriptor
 from opaque_keys import InvalidKeyError
 from lms.lib.xblock.runtime import quote_slashes
 
-# Submissions is a Django app that is currently installed
-# from the edx-ora2 repo, although it will likely move in the future.
-from submissions import api as sub_api
+from submissions import api as sub_api  # installed from the edx-submissions repository
 
 from bulk_email.models import CourseEmail, CourseAuthorization
 from courseware import grades

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -130,3 +130,6 @@ git+https://github.com/mfogel/django-settings-context-processor.git
 
 # django-cas version 2.0.3 with patch to be compatible with django 1.4
 git+https://github.com/mitocw/django-cas.git
+
+# edX packages
+edx-submissions==0.0.2

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -26,6 +26,6 @@
 -e git+https://github.com/edx/bok-choy.git@82b4e82d79b9d4c6d087ebbfa26ea23235728e62#egg=bok_choy
 -e git+https://github.com/edx-solutions/django-splash.git@9965a53c269666a30bb4e2b3f6037c138aef2a55#egg=django-splash
 -e git+https://github.com/edx/acid-block.git@459aff7b63db8f2c5decd1755706c1a64fb4ebb1#egg=acid-xblock
--e git+https://github.com/edx/edx-ora2.git@release-2014-06-02T15.45#egg=edx-ora2
+-e git+https://github.com/edx/edx-ora2.git@14b03246e95c999888396202d514d7b251b46c78#egg=edx-ora2
 -e git+https://github.com/edx/opaque-keys.git@91b7ec93cfb57c6739332e85805296626b4fb1db#egg=opaque-keys
 git+https://github.com/edx/ease.git@a990b25ed4238acb1b15ee6f027465db3a10960e#egg=ease


### PR DESCRIPTION
Companion PR to https://github.com/edx/edx-ora2/pull/411 in the edx-ora2 repo.
This installs the `submissions` app from PyPi instead of through edx-ora2.

Once the edx-ora2 PR gets merged, I'll update the edx-ora2 commit in the edx-platform reqs (before merging this PR).

@ormsbee @singingwolfboy 
