### PR TITLE
Bugfix certificates request queue HTML flattening

### DIFF
--- a/lms/djangoapps/certificates/queue.py
+++ b/lms/djangoapps/certificates/queue.py
@@ -15,7 +15,7 @@ from verify_student.models import SoftwareSecurePhotoVerification
 import json
 import random
 import logging
-import lxml
+import lxml.html
 from lxml.etree import XMLSyntaxError, ParserError
 
 


### PR DESCRIPTION
@singingwolfboy I'm not certain if you're the right person; please redirect if you're not.

Sometimes the course name comes in with HTML in it. The stripping out of that HTML is currently broken, throwing an attribute error; this change fixes it.

@jbau and @caesar2164, we'll want to cherry pick it into our release branch and not wait.
