### PR TITLE
Annotation Tools Reverting commit @3bfb633 and updating openseadragon.js for latest build

### DIFF
--- a/common/lib/xmodule/xmodule/annotator_mixin.py
+++ b/common/lib/xmodule/xmodule/annotator_mixin.py
@@ -6,10 +6,6 @@ from lxml import etree
 from urlparse import urlparse
 from os.path import splitext, basename
 from HTMLParser import HTMLParser
-from xblock.core import Scope, String
-
-# Make '_' a no-op so we can scrape strings
-_ = lambda text: text
 
 def get_instructions(xmltree):
     """ Removes <instructions> from the xmltree and returns them as a string, otherwise None. """
@@ -56,37 +52,3 @@ def html_to_text(html):
     htmlstripper = MLStripper()
     htmlstripper.feed(html)
     return htmlstripper.get_data()
-
-
-class CommonAnnotatorMixin(object):
-    annotation_storage_url = String(
-        help=_("Location of Annotation backend"),
-        scope=Scope.settings,
-        default="http://your_annotation_storage.com",
-        display_name=_("Url for Annotation Storage")
-    )
-    annotation_token_secret = String(
-        help=_("Secret string for annotation storage"),
-        scope=Scope.settings,
-        default="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-        display_name=_("Secret Token String for Annotation")
-    )
-    default_tab = String(
-        display_name=_("Default Annotations Tab"),
-        help=_("Select which tab will be the default in the annotations table: myNotes, Instructor, or Public."),
-        scope=Scope.settings,
-        default="myNotes",
-    )
-    # currently only supports one instructor, will build functionality for multiple later
-    instructor_email = String(
-        display_name=_("Email for 'Instructor' Annotations"),
-        help=_("Email of the user that will be attached to all annotations that will be found in 'Instructor' tab."),
-        scope=Scope.settings,
-        default="",
-    )
-    annotation_mode = String(
-        display_name=_("Mode for Annotation Tool"),
-        help=_("Type in number corresponding to following modes:  'instructor' or 'everyone'"),
-        scope=Scope.settings,
-        default="everyone",
-    )

--- a/common/lib/xmodule/xmodule/imageannotation_module.py
+++ b/common/lib/xmodule/xmodule/imageannotation_module.py
@@ -7,7 +7,7 @@ from pkg_resources import resource_string
 from xmodule.x_module import XModule
 from xmodule.raw_module import RawDescriptor
 from xblock.core import Scope, String
-from xmodule.annotator_mixin import CommonAnnotatorMixin, get_instructions, html_to_text
+from xmodule.annotator_mixin import get_instructions, html_to_text
 from xmodule.annotator_token import retrieve_token
 from xblock.fragment import Fragment
 
@@ -51,9 +51,40 @@ class AnnotatableFields(object):
         scope=Scope.settings,
         default='professor:green,teachingAssistant:blue',
     )
+    annotation_storage_url = String(
+        help=_("Location of Annotation backend"),
+        scope=Scope.settings,
+        default="http://your_annotation_storage.com",
+        display_name=_("Url for Annotation Storage")
+    )
+    annotation_token_secret = String(
+        help=_("Secret string for annotation storage"),
+        scope=Scope.settings,
+        default="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+        display_name=_("Secret Token String for Annotation")
+    )
+    default_tab = String(
+        display_name=_("Default Annotations Tab"),
+        help=_("Select which tab will be the default in the annotations table: myNotes, Instructor, or Public."),
+        scope=Scope.settings,
+        default="myNotes",
+    )
+    # currently only supports one instructor, will build functionality for multiple later
+    instructor_email = String(
+        display_name=_("Email for 'Instructor' Annotations"),
+        help=_("Email of the user that will be attached to all annotations that will be found in 'Instructor' tab."),
+        scope=Scope.settings,
+        default="",
+    )
+    annotation_mode = String(
+        display_name=_("Mode for Annotation Tool"),
+        help=_("Type in number corresponding to following modes:  'instructor' or 'everyone'"),
+        scope=Scope.settings,
+        default="everyone",
+    )
 
 
-class ImageAnnotationModule(AnnotatableFields, CommonAnnotatorMixin, XModule):
+class ImageAnnotationModule(AnnotatableFields, XModule):
     '''Image Annotation Module'''
     js = {
         'coffee': [

--- a/common/lib/xmodule/xmodule/textannotation_module.py
+++ b/common/lib/xmodule/xmodule/textannotation_module.py
@@ -6,7 +6,7 @@ from pkg_resources import resource_string
 from xmodule.x_module import XModule
 from xmodule.raw_module import RawDescriptor
 from xblock.core import Scope, String
-from xmodule.annotator_mixin import CommonAnnotatorMixin, get_instructions
+from xmodule.annotator_mixin import get_instructions
 from xmodule.annotator_token import retrieve_token
 from xblock.fragment import Fragment
 import textwrap
@@ -53,9 +53,40 @@ class AnnotatableFields(object):
         scope=Scope.settings,
         default='',
     )
+    annotation_storage_url = String(
+        help=_("Location of Annotation backend"),
+        scope=Scope.settings,
+        default="http://your_annotation_storage.com",
+        display_name=_("Url for Annotation Storage")
+    )
+    annotation_token_secret = String(
+        help=_("Secret string for annotation storage"),
+        scope=Scope.settings,
+        default="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+        display_name=_("Secret Token String for Annotation")
+    )
+    default_tab = String(
+        display_name=_("Default Annotations Tab"),
+        help=_("Select which tab will be the default in the annotations table: myNotes, Instructor, or Public."),
+        scope=Scope.settings,
+        default="myNotes",
+    )
+    # currently only supports one instructor, will build functionality for multiple later
+    instructor_email = String(
+        display_name=_("Email for 'Instructor' Annotations"),
+        help=_("Email of the user that will be attached to all annotations that will be found in 'Instructor' tab."),
+        scope=Scope.settings,
+        default="",
+    )
+    annotation_mode = String(
+        display_name=_("Mode for Annotation Tool"),
+        help=_("Type in number corresponding to following modes:  'instructor' or 'everyone'"),
+        scope=Scope.settings,
+        default="everyone",
+    )
 
 
-class TextAnnotationModule(AnnotatableFields, CommonAnnotatorMixin, XModule):
+class TextAnnotationModule(AnnotatableFields, XModule):
     ''' Text Annotation Module '''
     js = {'coffee': [],
           'js': []}

--- a/common/lib/xmodule/xmodule/videoannotation_module.py
+++ b/common/lib/xmodule/xmodule/videoannotation_module.py
@@ -7,7 +7,7 @@ from pkg_resources import resource_string
 from xmodule.x_module import XModule
 from xmodule.raw_module import RawDescriptor
 from xblock.core import Scope, String
-from xmodule.annotator_mixin import CommonAnnotatorMixin, get_instructions, get_extension
+from xmodule.annotator_mixin import get_instructions, get_extension
 from xmodule.annotator_token import retrieve_token
 from xblock.fragment import Fragment
 
@@ -45,9 +45,40 @@ class AnnotatableFields(object):
         scope=Scope.settings,
         default=""
     )
+    annotation_storage_url = String(
+        help=_("Location of Annotation backend"),
+        scope=Scope.settings,
+        default="http://your_annotation_storage.com",
+        display_name=_("Url for Annotation Storage")
+    )
+    annotation_token_secret = String(
+        help=_("Secret string for annotation storage"),
+        scope=Scope.settings,
+        default="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+        display_name=_("Secret Token String for Annotation")
+    )
+    default_tab = String(
+        display_name=_("Default Annotations Tab"),
+        help=_("Select which tab will be the default in the annotations table: myNotes, Instructor, or Public."),
+        scope=Scope.settings,
+        default="myNotes",
+    )
+    # currently only supports one instructor, will build functionality for multiple later
+    instructor_email = String(
+        display_name=_("Email for 'Instructor' Annotations"),
+        help=_("Email of the user that will be attached to all annotations that will be found in 'Instructor' tab."),
+        scope=Scope.settings,
+        default="",
+    )
+    annotation_mode = String(
+        display_name=_("Mode for Annotation Tool"),
+        help=_("Type in number corresponding to following modes:  'instructor' or 'everyone'"),
+        scope=Scope.settings,
+        default="everyone",
+    )
 
 
-class VideoAnnotationModule(AnnotatableFields, CommonAnnotatorMixin, XModule):
+class VideoAnnotationModule(AnnotatableFields, XModule):
     '''Video Annotation Module'''
     js = {
         'coffee': [

--- a/common/static/js/vendor/ova/openseadragon.js
+++ b/common/static/js/vendor/ova/openseadragon.js
@@ -7872,14 +7872,14 @@ $.extend( $.IIIF1_1TileSource.prototype, $.TileSource.prototype, {
             uri;
 
         if ( level_width < this.tile_width && level_height < this.tile_height ){
-            iiif_size = level_width + "," + level_height;
+            iiif_size = level_width + ",";
             iiif_region = 'full';
         } else {
             iiif_tile_x = x * iiif_tile_size_width;
             iiif_tile_y = y * iiif_tile_size_height;
             iiif_tile_w = Math.min( iiif_tile_size_width, this.width - iiif_tile_x );
             iiif_tile_h = Math.min( iiif_tile_size_height, this.height - iiif_tile_y );
-            iiif_size = Math.ceil(iiif_tile_w * scale) + "," +  Math.ceil(iiif_tile_h * scale);
+            iiif_size = Math.ceil(iiif_tile_w * scale) + ",";
             iiif_region = [ iiif_tile_x, iiif_tile_y, iiif_tile_w, iiif_tile_h ].join(',');
         }
         uri = [ this['@id'], iiif_region, iiif_size, IIIF_ROTATION, IIIF_QUALITY ].join('/');


### PR DESCRIPTION
Urgent Fix to merged PR #3969 

Issue: Tried to accomplish an issue raised by @auraz  where I should factor out variables for the annotation tools. Basically `textannotation_module.py`, `imageannotation_module.py`, and `videoannotation_module.py` each had instances of `annotation_storage_url`, `annotation_mode`, etc. I tried to compile them all into `annotator_mixin.py`. Thought it had worked and pushed the fixes but it turns out that if you go to studio you get the following message anytime I hit "Edit" for image, text and annotation components in studio:
![studio error](http://i.imgur.com/uqQVLlc.png)

Basically those 4 files got reverted to how they were before commit 3bfb633.

It was made known to us less than an hour ago that the file openseadragon.js we were using was using a different api call then the server so this is a 2-line change to make it work while we upgrade. 
