### PR TITLE
locking version of requests-oauthlib to 0.4.0

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -66,6 +66,7 @@ pytz==2012h
 pysrt==0.4.7
 PyYAML==3.10
 requests==1.2.3
+requests-oauthlib==0.4.0
 scipy==0.11.0
 Shapely==1.2.16
 singledispatch==3.4.0.2


### PR DESCRIPTION
requests version 1.2.3 does not appear to be compatible with the
new version of requests-oauthlib.

We have been running with 0.4.0 for awhile in production and elsewhere including continuous integration.

requests-oathlib tries to import to_native_string in util.py:

```
File
"/root/.virtualenvs/edx-platform/local/lib/python2.7/site-packages/requests_oauthlib/oauth1_auth.py",
line 10, in <module>
    from requests.utils import to_native_string
ImportError: cannot import name to_native_string
```
