### PR TITLE
Upgrade `requests` module

### DIFF
--- a/common/djangoapps/terrain/stubs/lti.py
+++ b/common/djangoapps/terrain/stubs/lti.py
@@ -256,7 +256,7 @@ class StubLtiHandler(StubHttpRequestHandler):
         sha1 = hashlib.sha1()
         sha1.update(body)
         oauth_body_hash = unicode(base64.b64encode(sha1.digest()))  # pylint: disable=too-many-function-args
-        params = client.get_oauth_params()
+        params = client.get_oauth_params(None)
         params.append((u'oauth_body_hash', oauth_body_hash))
         mock_request = mock.Mock(
             uri=unicode(urllib.unquote(url)),

--- a/common/lib/xmodule/xmodule/lti_2_util.py
+++ b/common/lib/xmodule/xmodule/lti_2_util.py
@@ -106,7 +106,7 @@ class LTI20ModuleMixin(object):
         log.debug("[LTI] oauth_body_hash = {}".format(oauth_body_hash))
         client_key, client_secret = self.get_client_key_secret()
         client = Client(client_key, client_secret)
-        params = client.get_oauth_params()
+        params = client.get_oauth_params(None)
         params.append((u'oauth_body_hash', oauth_body_hash))
         mock_request = mock.Mock(
             uri=unicode(urllib.unquote(request.url)),

--- a/docs/shared/requirements.txt
+++ b/docs/shared/requirements.txt
@@ -50,7 +50,7 @@ python-memcached==1.48
 python-openid==2.2.5
 pytz==2012h
 PyYAML==3.10
-requests==1.2.3
+requests==2.3.0
 Shapely==1.2.16
 sorl-thumbnail==11.12
 South==0.7.6

--- a/docs/shared/requirements.txt
+++ b/docs/shared/requirements.txt
@@ -37,7 +37,7 @@ Markdown==2.2.1
 mock==1.0.1
 networkx==1.7
 nltk==2.0.4
-oauthlib==0.5.1
+oauthlib==0.6.3
 paramiko==1.9.0
 path.py==3.0.1
 Pillow==1.7.8

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -65,7 +65,7 @@ python-social-auth==0.1.23
 pytz==2012h
 pysrt==0.4.7
 PyYAML==3.10
-requests==1.2.3
+requests==2.3.0
 requests-oauthlib==0.4.0
 scipy==0.11.0
 Shapely==1.2.16

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -47,7 +47,7 @@ mongoengine==0.7.10
 networkx==1.7
 nltk==2.0.4
 nose==1.3.3
-oauthlib==0.5.1
+oauthlib==0.6.3
 paramiko==1.9.0
 path.py==3.0.1
 Pillow==1.7.8

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -66,7 +66,7 @@ pytz==2012h
 pysrt==0.4.7
 PyYAML==3.10
 requests==2.3.0
-requests-oauthlib==0.4.0
+requests-oauthlib==0.4.1
 scipy==0.11.0
 Shapely==1.2.16
 singledispatch==3.4.0.2


### PR DESCRIPTION
Looks like fairly minor changes: http://docs.python-requests.org/en/latest/api/#migrating-to-2-x

However, we also want to upgrade `requests-oauthlib`, which requires upgrading `oauthlib`.
