### PR TITLE
Flowerhack/conditional module rendering

### DIFF
--- a/common/lib/xmodule/xmodule/conditional_module.py
+++ b/common/lib/xmodule/xmodule/conditional_module.py
@@ -197,7 +197,10 @@ class ConditionalDescriptor(ConditionalFields, SequenceDescriptor):
         # substitution can be done.
         if not self.sources_list:
             if 'sources' in self.xml_attributes and isinstance(self.xml_attributes['sources'], basestring):
-                self.sources_list = ConditionalDescriptor.parse_sources(self.xml_attributes)
+                self.sources_list = [
+                    self.location.course_key.make_usage_key_from_deprecated_string(item)
+                    for item in ConditionalDescriptor.parse_sources(self.xml_attributes)
+                ]
 
     @staticmethod
     def parse_sources(xml_element):

--- a/common/lib/xmodule/xmodule/tests/test_conditional.py
+++ b/common/lib/xmodule/xmodule/tests/test_conditional.py
@@ -253,3 +253,45 @@ class ConditionalModuleXmlTest(unittest.TestCase):
         print "post-attempt ajax: ", ajax
         html = ajax['html']
         self.assertTrue(any(['This is a secret' in item for item in html]))
+
+    def test_conditional_module_with_empty_sources_list(self):
+        """
+        If a ConditionalDescriptor is initialized with an empty sources_list, we assert that the sources_list is set
+        via generating UsageKeys from the values in xml_attributes['sources']
+        """
+        dummy_system = Mock()
+        dummy_location = Location("edX", "conditional_test", "test_run", "conditional", "SampleConditional", None)
+        dummy_scope_ids = ScopeIds(None, None, dummy_location, dummy_location)
+        dummy_field_data = DictFieldData({
+            'data': '<conditional/>',
+            'xml_attributes': {'sources': 'i4x://HarvardX/ER22x/poll_question/T15_poll'},
+            'children': None,
+        })
+        conditional = ConditionalDescriptor(
+            dummy_system,
+            dummy_field_data,
+            dummy_scope_ids,
+        )
+        self.assertEqual(
+            conditional.sources_list[0],
+            conditional.location.course_key.make_usage_key_from_deprecated_string(conditional.xml_attributes['sources'])
+        )
+
+    def test_conditional_module_parse_sources(self):
+        dummy_system = Mock()
+        dummy_location = Location("edX", "conditional_test", "test_run", "conditional", "SampleConditional", None)
+        dummy_scope_ids = ScopeIds(None, None, dummy_location, dummy_location)
+        dummy_field_data = DictFieldData({
+            'data': '<conditional/>',
+            'xml_attributes': {'sources': 'i4x://HarvardX/ER22x/poll_question/T15_poll;i4x://HarvardX/ER22x/poll_question/T16_poll'},
+            'children': None,
+        })
+        conditional = ConditionalDescriptor(
+            dummy_system,
+            dummy_field_data,
+            dummy_scope_ids,
+        )
+        self.assertEqual(
+            conditional.parse_sources(conditional.xml_attributes),
+            ['i4x://HarvardX/ER22x/poll_question/T15_poll', 'i4x://HarvardX/ER22x/poll_question/T16_poll']
+        )


### PR DESCRIPTION
This fixes the conditional modules that were breaking rendering of courseware, import/export, etc on stage.

There is no automated test.  Don and I worked to munge my local MongoDB datastore such that it would replicate the failures we see on Stage, and verified that these commits fix the failure.  If we need more thorough testing, I'll need Cale's help :)
