### PR TITLE
Make LinkedIn auth provider request email by default.

### DIFF
--- a/common/djangoapps/third_party_auth/provider.py
+++ b/common/djangoapps/third_party_auth/provider.py
@@ -139,6 +139,9 @@ class LinkedInOauth2(BaseProvider):
     SETTINGS = {
         'SOCIAL_AUTH_LINKEDIN_OAUTH2_KEY': None,
         'SOCIAL_AUTH_LINKEDIN_OAUTH2_SECRET': None,
+        'SOCIAL_AUTH_LINKEDIN_OAUTH2_SCOPE': None,
+        'SOCIAL_AUTH_LINKEDIN_OAUTH2_FIELD_SELECTORS': None,
+        'SOCIAL_AUTH_LINKEDIN_OAUTH2_EXTRA_DATA': None,
     }
 
     @classmethod


### PR DESCRIPTION
This change updates the default settings of the LinkedIn third party auth
provider to request the email field to be included in the OAuth2 data.

This is useful so that the email field gets pre-populated when registering
via the 'Sign in with LinkedIn' button on the registration page.
