### PR TITLE
trigger change event for file field while uploading pdf

### DIFF
--- a/cms/static/coffee/spec/views/upload_spec.coffee
+++ b/cms/static/coffee/spec/views/upload_spec.coffee
@@ -64,6 +64,32 @@ define ["js/models/uploads", "js/views/uploads", "js/models/chapter", "js/spec_h
                 expect(@view.$el).toContain("#upload_error")
                 expect(@view.$(".action-upload")).toHaveClass("disabled")
 
+            it "should render an error with an invalid file type after a correct file type selected", ->
+                correctFile = {name: "fake.pdf", "type": "application/pdf"}
+                inCorrectFile = {name: "fake.png", "type": "image/png"}
+                event = {}
+                @view.render()
+
+                event.target = {"files": [correctFile]}
+                @view.selectFile(event)
+                expect(@view.$el).toContain("input[type=file]")
+                expect(@view.$el).not.toContain("#upload_error")
+                expect(@view.$(".action-upload")).not.toHaveClass("disabled")
+
+                realMethod = @model.set
+                spyOn(@model, "set").andCallFake (data) ->
+                  if data.selectedFile != undefined
+                    this.attributes.selectedFile = data.selectedFile
+                    this.changed = {}
+                  else
+                    realMethod.apply(this, arguments)
+
+                event.target = {"files": [inCorrectFile]}
+                @view.selectFile(event)
+                expect(@view.$el).toContain("input[type=file]")
+                expect(@view.$el).toContain("#upload_error")
+                expect(@view.$(".action-upload")).toHaveClass("disabled")
+
         describe "Uploads", ->
             beforeEach ->
                 @clock = sinon.useFakeTimers()

--- a/cms/static/js/views/uploads.js
+++ b/cms/static/js/views/uploads.js
@@ -61,9 +61,15 @@ define(["jquery", "underscore", "gettext", "js/views/modals/base_modal", "jquery
             },
 
             selectFile: function(e) {
+                var selectedFile = e.target.files[0] || null;
                 this.model.set({
-                    selectedFile: e.target.files[0] || null
+                    selectedFile: selectedFile
                 });
+                // This change event triggering necessary for FireFox, because the browser don't
+                // consider change of File object (file input field) as a change in model.
+                if (selectedFile && $.isEmptyObject(this.model.changed)){
+                    this.model.trigger('change');
+                }
             },
 
             upload: function(e) {


### PR DESCRIPTION
STUD-1775
@waheedahmed @symbolist @adampalay 
Make File upload modal to trigger change event when a new file is selected. Currently modal thinks that no change is made (just another File object so ignore it) when user selects a new file after selecting first time.
