### PR TITLE
Allow xblocks to be added as advanced problem types

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ These are notable changes in edx-platform.  This is a rolling list of changes,
 in roughly chronological order, most recent first.  Add your entries at or near
 the top.  Include a label indicating the component affected.
 
+Studio: Move Peer Assessment into advanced problems menu.
+
 Blades: Add context-aware video index. BLD-933
 
 Blades: Fix bug with incorrect link format and redirection. BLD-1049

--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -140,7 +140,7 @@ class ContentStoreToyCourseTest(ModuleStoreTestCase):
         self.check_components_on_page(
             ADVANCED_COMPONENT_TYPES,
             ['Word cloud', 'Annotation', 'Text Annotation', 'Video Annotation', 'Image Annotation',
-             'Open Response Assessment', 'Peer Grading Interface', 'openassessment', 'split_test'],
+             'Open Response Assessment', 'Peer Grading Interface', 'split_test'],
         )
 
     def test_advanced_components_require_two_clicks(self):

--- a/cms/static/coffee/spec/main.coffee
+++ b/cms/static/coffee/spec/main.coffee
@@ -212,6 +212,7 @@ define([
     "js/spec/video/transcripts/videolist_spec", "js/spec/video/transcripts/message_manager_spec",
     "js/spec/video/transcripts/file_uploader_spec",
 
+    "js/spec/models/component_template_spec",
     "js/spec/models/explicit_url_spec",
 
     "js/spec/utils/drag_and_drop_spec",

--- a/cms/static/js/models/component_template.js
+++ b/cms/static/js/models/component_template.js
@@ -13,19 +13,31 @@ define(["backbone"], function (Backbone) {
             templates: []
         },
         parse: function (response) {
+            // Returns true only for templates that both have no boilerplate and are of
+            // the overall type of the menu. This allows other component types to be added
+            // and they will get sorted alphabetically rather than just at the top.
+            // e.g. The ORA openassessment xblock is listed as an advanced problem.
+            var isPrimaryBlankTemplate = function(template) {
+                return !template.boilerplate_name && template.category === response.type;
+            };
+
             this.type = response.type;
             this.templates = response.templates;
             this.display_name = response.display_name;
 
             // Sort the templates.
             this.templates.sort(function (a, b) {
-                // The entry without a boilerplate always goes first
-                if (!a.boilerplate_name || (a.display_name < b.display_name)) {
+                // The blank problem for the current type goes first
+                if (isPrimaryBlankTemplate(a)) {
+                    return -1;
+                } else if (isPrimaryBlankTemplate(b)) {
+                    return 1;
+                } else if (a.display_name > b.display_name) {
+                    return 1;
+                } else if (a.display_name < b.display_name) {
                     return -1;
                 }
-                else {
-                    return (a.display_name > b.display_name) ? 1 : 0;
-                }
+                return 0;
             });
         }
     });

--- a/cms/static/js/spec/models/component_template_spec.js
+++ b/cms/static/js/spec/models/component_template_spec.js
@@ -1,0 +1,79 @@
+define(["js/models/component_template"],
+    function (ComponentTemplate) {
+
+        describe("ComponentTemplates", function() {
+            var mockTemplateJSON = {
+                "templates": [
+                    {
+                        "category": "problem",
+                        "boilerplate_name": "formularesponse.yaml",
+                        "display_name": "Math Expression Input"
+                    }, {
+                        "category": "problem",
+                        "boilerplate_name": null,
+                        "display_name": "Blank Advanced Problem"
+                    }, {
+                        "category": "problem",
+                        "boilerplate_name": "checkboxes.yaml",
+                        "display_name": "Checkboxes"
+                    }, {
+                        "category": "problem",
+                        "boilerplate_name": "multiple_choice.yaml",
+                        "display_name": "Multiple Choice"
+                    }, {
+                        "category": "problem",
+                        "boilerplate_name": "drag_and_drop.yaml",
+                        "display_name": "Drag and Drop"
+                    }, {
+                        "category": "problem",
+                        "boilerplate_name": "problem_with_hint.yaml",
+                        "display_name": "Problem with Adaptive Hint"
+                    }, {
+                        "category": "problem",
+                        "boilerplate_name": "imageresponse.yaml",
+                        "display_name": "Image Mapped Input"
+                    }, {
+                        "category": "openassessment",
+                        "boilerplate_name": null,
+                        "display_name": "Peer Assessment"
+                    }, {
+                        "category": "problem",
+                        "boilerplate_name": "an_easy_problem.yaml",
+                        "display_name": "An Easy Problem"
+                    }, {
+                        "category": "word_cloud",
+                        "boilerplate_name": null,
+                        "display_name": "Word Cloud"
+                    }, { // duplicate display name to verify sort behavior
+                        "category": "word_cloud",
+                        "boilerplate_name": "alternate_word_cloud.yaml",
+                        "display_name": "Word Cloud"
+                    }],
+                "type": "problem"
+            };
+
+            it('orders templates correctly', function () {
+                var lastTemplate = null,
+                    firstComparison = true,
+                    componentTemplate = new ComponentTemplate(),
+                    template, templateName, i;
+                componentTemplate.parse(mockTemplateJSON);
+                for (i=0; i < componentTemplate.templates.length; i++) {
+                    template = componentTemplate.templates[i];
+                    templateName = template['display_name'];
+                    if (lastTemplate) {
+                        if (!firstComparison || lastTemplate['boilerplate_name']) {
+                            expect(lastTemplate['display_name'] < templateName).toBeTruthy();
+                        }
+                        firstComparison = false;
+                    } else {
+                        // If the first template is blank, make sure that it has the correct category
+                        if (!template['boilerplate_name']) {
+                            expect(template['category']).toBe('problem');
+                        }
+                        lastTemplate = template;
+                    }
+                }
+            });
+        });
+    });


### PR DESCRIPTION
This change allows Studio to add xblocks as advanced problems instead of advanced components, if desired. This feature is being first used to support Peer Assessment as a built-in advanced problem.
