### PR TITLE
Tracks last edited date and user, and adds has_changes for blocks

### DIFF
--- a/cms/djangoapps/contentstore/course_info_model.py
+++ b/cms/djangoapps/contentstore/course_info_model.py
@@ -239,6 +239,6 @@ def save_course_update_items(location, course_updates, course_update_items, user
     course_updates.data = _get_html(course_update_items)
 
     # update db record
-    modulestore('direct').update_item(course_updates, user)
+    modulestore('direct').update_item(course_updates, user.id)
 
     return course_updates

--- a/cms/djangoapps/contentstore/views/tests/test_course_updates.py
+++ b/cms/djangoapps/contentstore/views/tests/test_course_updates.py
@@ -135,7 +135,7 @@ class CourseUpdateTest(CourseTestCase):
         update_content = u"Hello world!"
         update_data = u"<ol><li><h2>" + update_date + "</h2>" + update_content + "</li></ol>"
         course_updates.data = update_data
-        modulestore('direct').update_item(course_updates, self.user)
+        modulestore('direct').update_item(course_updates, self.user.id)
 
         # test getting all updates list
         course_update_url = self.create_update_url()

--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -1,7 +1,6 @@
 from xblock.fields import Scope
 
 from contentstore.utils import get_modulestore
-from cms.lib.xblock.mixin import CmsBlockMixin
 
 
 class CourseMetadata(object):
@@ -33,9 +32,6 @@ class CourseMetadata(object):
         result = {}
 
         for field in descriptor.fields.values():
-            if field.name in CmsBlockMixin.fields:
-                continue
-
             if field.scope != Scope.settings:
                 continue
 

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -33,7 +33,6 @@ from lms.envs.common import (
 from path import path
 
 from lms.lib.xblock.mixin import LmsBlockMixin
-from cms.lib.xblock.mixin import CmsBlockMixin
 from dealer.git import git
 
 ############################ FEATURE CONFIGURATION #############################
@@ -238,7 +237,7 @@ from xmodule.x_module import XModuleMixin
 
 # This should be moved into an XBlock Runtime/Application object
 # once the responsibility of XBlock creation is moved out of modulestore - cpennington
-XBLOCK_MIXINS = (LmsBlockMixin, CmsBlockMixin, InheritanceMixin, XModuleMixin)
+XBLOCK_MIXINS = (LmsBlockMixin, InheritanceMixin, XModuleMixin)
 
 # Allow any XBlock in Studio
 # You should also enable the ALLOW_ALL_ADVANCED_COMPONENTS feature flag, so that

--- a/cms/lib/xblock/mixin.py
+++ b/cms/lib/xblock/mixin.py
@@ -19,11 +19,3 @@ class DateTuple(Field):
             return None
 
         return list(value.timetuple())
-
-
-class CmsBlockMixin(XBlockMixin):
-    """
-    Mixin with fields common to all blocks in Studio
-    """
-    published_date = DateTuple(help="Date when the module was published", scope=Scope.settings)
-    published_by = Integer(help="Id of the user who published this module", scope=Scope.settings)

--- a/common/lib/xmodule/xmodule/error_module.py
+++ b/common/lib/xmodule/xmodule/error_module.py
@@ -13,6 +13,7 @@ from xmodule.x_module import XModule, XModuleDescriptor
 from xmodule.errortracker import exc_info_to_str
 from xblock.fields import String, Scope, ScopeIds
 from xblock.field_data import DictFieldData
+from xmodule.modulestore.xml_exporter import EdxJSONEncoder
 
 
 log = logging.getLogger(__name__)
@@ -121,7 +122,7 @@ class ErrorDescriptor(ErrorFields, XModuleDescriptor):
     def from_json(cls, json_data, system, location, error_msg='Error not available'):
         return cls._construct(
             system,
-            json.dumps(json_data, skipkeys=False, indent=4),
+            json.dumps(json_data, skipkeys=False, indent=4, cls=EdxJSONEncoder),
             error_msg,
             location=location
         )

--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -21,6 +21,8 @@ import re
 from bson.son import SON
 from fs.osfs import OSFS
 from path import path
+from datetime import datetime
+from pytz import UTC
 
 from importlib import import_module
 from xmodule.errortracker import null_error_tracker, exc_info_to_str
@@ -206,6 +208,23 @@ class CachingDescriptorSystem(MakoDescriptorSystem):
                     # to python values
                     metadata_to_inherit = self.cached_metadata.get(non_draft_loc.to_deprecated_string(), {})
                     inherit_metadata(module, metadata_to_inherit)
+
+                edit_info = json_data.get('edit_info')
+
+                # migrate published_by and published_date if edit_info isn't present
+                if not edit_info:
+                    module.edited_by = module.edited_on = module.published_date = None
+                    # published_date was previously stored as a list of time components instead of a datetime
+                    if metadata.get('published_date'):
+                        module.published_date = datetime(*metadata.get('published_date')[0:6]).replace(tzinfo=UTC)
+                    module.published_by = metadata.get('published_by')
+                # otherwise restore the stored editing information
+                else:
+                    module.edited_by = edit_info.get('edited_by')
+                    module.edited_on = edit_info.get('edited_on')
+                    module.published_date = edit_info.get('published_date')
+                    module.published_by = edit_info.get('published_by')
+
                 # decache any computed pending field settings
                 module.save()
                 return module
@@ -826,7 +845,7 @@ class MongoModuleStore(ModuleStoreWriteBase):
         return xmodule
 
     def create_and_save_xmodule(self, location, definition_data=None, metadata=None, system=None,
-                                fields={}):
+                                fields={}, user_id=None):
         """
         Create the new xmodule and save it. Does not return the new module because if the caller
         will insert it as a child, it's inherited metadata will completely change. The difference
@@ -837,12 +856,13 @@ class MongoModuleStore(ModuleStoreWriteBase):
         :param definition_data: can be empty. The initial definition_data for the kvs
         :param metadata: can be empty, the initial metadata for the kvs
         :param system: if you already have an xblock from the course, the xblock.runtime value
+        :param user_id: the user that created the xblock
         """
         # differs from split mongo in that I believe most of this logic should be above the persistence
         # layer but added it here to enable quick conversion. I'll need to reconcile these.
         new_object = self.create_xmodule(location, definition_data, metadata, system, fields)
         location = new_object.scope_ids.usage_id
-        self.update_item(new_object, allow_not_found=True)
+        self.update_item(new_object, allow_not_found=True, user_id=user_id)
 
         # VS[compat] cdodge: This is a hack because static_tabs also have references from the course module, so
         # if we add one then we need to also add it to the policy information (i.e. metadata)
@@ -856,7 +876,7 @@ class MongoModuleStore(ModuleStoreWriteBase):
                     url_slug=new_object.scope_ids.usage_id.name,
                 )
             )
-            self.update_item(course)
+            self.update_item(course, user_id=user_id)
 
         return new_object
 
@@ -888,7 +908,7 @@ class MongoModuleStore(ModuleStoreWriteBase):
         if result['n'] == 0:
             raise ItemNotFoundError(location)
 
-    def update_item(self, xblock, user_id=None, allow_not_found=False, force=False):
+    def update_item(self, xblock, user_id=None, allow_not_found=False, force=False, isPublish=False):
         """
         Update the persisted version of xblock to reflect its current values.
 
@@ -902,7 +922,16 @@ class MongoModuleStore(ModuleStoreWriteBase):
             payload = {
                 'definition.data': definition_data,
                 'metadata': self._convert_reference_fields_to_strings(xblock, own_metadata(xblock)),
+                'edit_info': {
+                    'edited_on': datetime.now(UTC),
+                    'edited_by': user_id,
+                }
             }
+
+            if isPublish:
+                payload['edit_info']['published_date'] = datetime.now(UTC)
+                payload['edit_info']['published_by'] = user_id
+
             if xblock.has_children:
                 children = self._convert_reference_fields_to_strings(xblock, {'children': xblock.children})
                 payload.update({'definition.children': children['children']})

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
@@ -371,6 +371,20 @@ class SplitMongoModuleStore(ModuleStoreWriteBase):
 
         return self._get_block_from_structure(course_structure, usage_key.block_id) is not None
 
+    def has_changes(self, usage_key):
+        """
+        Checks if the given block has unpublished changes
+        :param usage_key: the block to check
+        :return: True if the draft and published versions differ
+        """
+        draft = self.get_item(usage_key.for_branch("draft"))
+        try:
+            published = self.get_item(usage_key.for_branch("published"))
+        except ItemNotFoundError:
+            return True
+
+        return draft.update_version != published.update_version
+
     def get_item(self, usage_key, depth=0):
         """
         depth (int): An argument that some module stores may use to prefetch


### PR DESCRIPTION
The `user_id` passed into `_update_single_item()` will always be None, so `edited_by` will always be None, but @nasthagiri will fix that in her work. STUD-1724

@cahrens @andy-armstrong @dmitchell 
