### PR TITLE
Fix wiki search query

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -1018,7 +1018,7 @@ class MongoModuleStore(ModuleStoreWriteBase):
         :param wiki_slug: the course wiki root slug
         :return: list of course locations
         """
-        courses = self.collection.find({'definition.data.wiki_slug': wiki_slug})
+        courses = self.collection.find({'_id.category': 'course', 'definition.data.wiki_slug': wiki_slug})
         # the course's run == its name. It's the only xblock for which that's necessarily true.
         return [Location._from_deprecated_son(course['_id'], course['_id']['name']) for course in courses]
 

--- a/mongo_indexes.md
+++ b/mongo_indexes.md
@@ -25,7 +25,7 @@ fs.files:
 
 Index needed thru 'category' by `_get_all_content_for_course` and others. That query also takes a sort
 which can be `uploadDate`, `display_name`, 
-# again, uploadDate may also be a freq sort.
+
 ```
 ensureIndex({'_id.tag': 1, '_id.org': 1, '_id.course': 1, '_id.category': 1})
 ```


### PR DESCRIPTION
and formatting error in a doc file.

By searching on category, we'll use the index rather than a full table scan to narrow the possible matches.

@symbolist @cpennington or @dianakhuang please review.
