### PR TITLE
Stanford-only: fix anonymous access with the grade me button

### DIFF
--- a/common/lib/xmodule/xmodule/templates/html/grade_me.yaml
+++ b/common/lib/xmodule/xmodule/templates/html/grade_me.yaml
@@ -2,31 +2,33 @@
 metadata:
     display_name: (Grade Me!)  Button
 data: |
-      <p>By clicking the button below, you assert that you have completed the course in its entirety.</p>
-      
-      <!-- <form action=/request_certificate method=POST>
-        <input type=hidden name=student_id value=103 />
-        <input type=hidden name=course_id value="OpenEdX/200/Stanford_Sandbox" />
-        <input type=submit name="hoo" />
-      </form> -->
-      
-      <input type=button value="Yes, I Agree." id="User_Verify_Button" style="margin-bottom: 20px;" />
+      <p id="verify_button_by_clicking_msg">By clicking the button below, you assert that you have completed the course in its entirety.</p>
+
+      <p><input type=button value="Yes, I Agree." id="User_Verify_Button" style="margin-bottom: 20px;" /></p>
       <p class="verify-button-success-text" style="font-weight: bold; color: #008200;"></p>
       
       <script type="text/javascript">
         var success_message = "Your grading and certification request has been received, <br />if you have passed, your certificate should be available in the next 20 minutes.";
-        document.getElementById('User_Verify_Button').addEventListener("click",
-        function(event) {
-          (function(event) {
-            var linkcontents = $('a.user-link').contents();
-            $.ajax({
-              type:     'POST',
-              url:      '/request_certificate',
-              data:     {'course_id': $$course_id},
-              success:  function(data) {
-                $('.verify-button-success-text').html(success_message);
-              }
+        var failure_message = "We're sorry; users who haven't created accounts and registered for the course may not receive Statements of Accomplishment.";
+
+        // for actual value of username, use scraped_username.split(':')[1].trim(); to get actual value
+        var scraped_username = $('li.primary a.user-link').text();
+        if (scraped_username) {
+            document.getElementById('User_Verify_Button').addEventListener("click",
+            function(event) {
+              (function(event) {
+                $.ajax({
+                  type:     'POST',
+                  url:      '/request_certificate',
+                  data:     {'course_id': $$course_id},
+                  success:  function(data) {
+                    $('.verify-button-success-text').html(success_message);
+                  }
+                });
+              }).call(document.getElementById('User_Verify_Button'), event);
             });
-          }).call(document.getElementById('User_Verify_Button'), event);
-        });
+        } else {
+            $('#verify_button_by_clicking_msg').html(failure_message);
+            $('#User_Verify_Button').remove();
+        };
       </script>


### PR DESCRIPTION
Deny self-service certificates for anonymous users

Bugfix for the following condition:
When anonymous (e.g., non-registered) access is enabled for a course, and that course also uses the /request_certificate endpoint (e.g., via the "Grade Me" button), anonymous users could request to be graded and given certificates.

As a matter of policy, Stanford doesn't want to give certificates to anonymous students.

This will probably need to be tested on stage before merge.

@jbau plz
