### PR TITLE
decode uri component before redirect for safe redirect

### DIFF
--- a/common/djangoapps/terrain/steps.py
+++ b/common/djangoapps/terrain/steps.py
@@ -81,7 +81,9 @@ def click_the_link_with_the_text_group1(step, linktext):
 
 @step('I should see that the path is "([^"]*)"$')
 def i_should_see_that_the_path_is(step, path):
-    assert world.url_equals(path)
+    assert world.url_equals(path), (
+        "path should be {!r} but is {!r}".format(path, world.browser.url)
+    )
 
 
 @step(u'the page title should be "([^"]*)"$')

--- a/lms/djangoapps/courseware/features/login.feature
+++ b/lms/djangoapps/courseware/features/login.feature
@@ -46,3 +46,13 @@ Feature: LMS.Login in as a registered user
     And I visit the url "/login?next=http://www.google.com/"
     When I submit my credentials on the login form
     Then I should be on the dashboard page
+
+    Scenario: Login with a redirect with parameters
+    Given I am an edX user
+    And I am not logged in
+    And I visit the url "/debug/show_parameters?foo=hello&bar=world"
+    And I should see that the path is "/accounts/login?next=/debug/show_parameters%3Ffoo%3Dhello%26bar%3Dworld"
+    When I submit my credentials on the login form
+    And I wait for "2" seconds
+    Then I should see "foo: u'hello'" somewhere on the page
+    And I should see "bar: u'world'" somewhere on the page

--- a/lms/djangoapps/debug/views.py
+++ b/lms/djangoapps/debug/views.py
@@ -3,14 +3,14 @@
 import pprint
 import traceback
 
-from django.http import Http404
+from django.http import Http404, HttpResponse
 from django.contrib.auth.decorators import login_required
+from django.utils.html import escape
+
 from django_future.csrf import ensure_csrf_cookie
 from edxmako.shortcuts import render_to_response
 
 from codejail.safe_exec import safe_exec
-
-from util.json_request import JsonResponse
 
 
 @login_required
@@ -36,9 +36,10 @@ def run_python(request):
 
 @login_required
 def show_parameters(request):
-    """A page that shows what GET parameters were on the URL."""
-    params = {
-        'get': dict(request.GET),
-        'post': dict(request.POST),
-    }
-    return JsonResponse(params)
+    """A page that shows what parameters were on the URL and post."""
+    html = []
+    for name, value in sorted(request.GET.items()):
+        html.append(escape("GET {}: {!r}".format(name, value)))
+    for name, value in sorted(request.POST.items()):
+        html.append(escape("POST {}: {!r}".format(name, value)))
+    return HttpResponse("\n".join("<p>{}</p>".format(h) for h in html))

--- a/lms/djangoapps/debug/views.py
+++ b/lms/djangoapps/debug/views.py
@@ -10,6 +10,9 @@ from edxmako.shortcuts import render_to_response
 
 from codejail.safe_exec import safe_exec
 
+from util.json_request import JsonResponse
+
+
 @login_required
 @ensure_csrf_cookie
 def run_python(request):
@@ -29,3 +32,13 @@ def run_python(request):
         else:
             c['results'] = pprint.pformat(g)
     return render_to_response("debug/run_python_form.html", c)
+
+
+@login_required
+def show_parameters(request):
+    """A page that shows what GET parameters were on the URL."""
+    params = {
+        'get': dict(request.GET),
+        'post': dict(request.POST),
+    }
+    return JsonResponse(params)

--- a/lms/templates/login.html
+++ b/lms/templates/login.html
@@ -51,7 +51,7 @@
       $('#login-form').on('ajax:success', function(event, json, xhr) {
         if(json.success) {
           var u=decodeURI(window.location.search);
-          next=u.split("next=")[1];
+          next=decodeURIComponent(u.split("next=")[1]);
           if (next && !isExternal(next)) {
             location.href=next;
           }  else if(json.redirect_url){

--- a/lms/templates/login.html
+++ b/lms/templates/login.html
@@ -54,8 +54,8 @@
           var next = u.split("next=")[1];
           if (next != undefined) {
             // if next is undefined, decodeURI returns "undefined" causing a bad redirect.
-            next = decodeURI(next); 
-	  }		
+            next = decodeURIComponent(next);
+          }
           if (next && !isExternal(next)) {
             location.href=next;
           }  else if(json.redirect_url){

--- a/lms/templates/login.html
+++ b/lms/templates/login.html
@@ -51,7 +51,11 @@
       $('#login-form').on('ajax:success', function(event, json, xhr) {
         if(json.success) {
           var u=decodeURI(window.location.search);
-          var next=decodeURIComponent(u.split("next=")[1]);
+          var next = u.split("next=")[1];
+          if (next != undefined) {
+            // if next is undefined, decodeURI returns "undefined" causing a bad redirect.
+            next = decodeURI(next); 
+	  }		
           if (next && !isExternal(next)) {
             location.href=next;
           }  else if(json.redirect_url){

--- a/lms/templates/login.html
+++ b/lms/templates/login.html
@@ -51,7 +51,7 @@
       $('#login-form').on('ajax:success', function(event, json, xhr) {
         if(json.success) {
           var u=decodeURI(window.location.search);
-          next=decodeURIComponent(u.split("next=")[1]);
+          var next=decodeURIComponent(u.split("next=")[1]);
           if (next && !isExternal(next)) {
             location.href=next;
           }  else if(json.redirect_url){

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -478,11 +478,11 @@ urlpatterns += (
 
 if settings.FEATURES.get('ENABLE_DEBUG_RUN_PYTHON'):
     urlpatterns += (
-        url(r'^debug/run_python', 'debug.views.run_python'),
+        url(r'^debug/run_python$', 'debug.views.run_python'),
     )
 
 urlpatterns += (
-    url(r'^debug/show_parameters', 'debug.views.show_parameters'),
+    url(r'^debug/show_parameters$', 'debug.views.show_parameters'),
 )
 
 # Crowdsourced hinting instructor manager.

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -481,6 +481,10 @@ if settings.FEATURES.get('ENABLE_DEBUG_RUN_PYTHON'):
         url(r'^debug/run_python', 'debug.views.run_python'),
     )
 
+urlpatterns += (
+    url(r'^debug/show_parameters', 'debug.views.show_parameters'),
+)
+
 # Crowdsourced hinting instructor manager.
 if settings.FEATURES.get('ENABLE_HINTER_INSTRUCTOR_VIEW'):
     urlpatterns += (


### PR DESCRIPTION
Decoding URI component before redirecting will allow for redirection with all the get parameters along with the previous url. Currently, if a url with get parameter is redirected to, it results in a 404. 

@version101
