### PR TITLE
shim to update ruby/node, not python reqs

### DIFF
--- a/pavelib/assets.py
+++ b/pavelib/assets.py
@@ -190,7 +190,7 @@ def watch_assets(options):
 
 
 @task
-@needs('pavelib.prereqs.install_prereqs')
+@needs('pavelib.prereqs.install_asset_prereqs')
 @consume_args
 def update_assets(args):
     """

--- a/pavelib/prereqs.py
+++ b/pavelib/prereqs.py
@@ -151,3 +151,15 @@ def install_prereqs():
     install_ruby_prereqs()
     install_node_prereqs()
     install_python_prereqs()
+
+@task
+def install_asset_prereqs():
+    """
+    Installs Ruby and Node
+    """
+    if os.environ.get("NO_PREREQ_INSTALL", False):
+        return
+
+    install_ruby_prereqs()
+    install_node_prereqs()
+


### PR DESCRIPTION
@mulby @jarv 

I think this is the lowest risk way of letting us run paver from our existing deployment scripts.
