### PR TITLE
courseware/views.py index function position value integer error correction and test

### DIFF
--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -80,13 +80,13 @@ class ViewsTestCase(TestCase):
     Tests for views.py methods.
     """
     def setUp(self):
-        course = CourseFactory()
-        chapter = ItemFactory(category='chapter', parent_location=course.location)  # pylint: disable=no-member
-        section = ItemFactory(category='sequential', parent_location=chapter.location, due=datetime(2013, 9, 18, 11, 30, 00))
-        vertical = ItemFactory(category='vertical', parent_location=section.location)
-        self.component = ItemFactory(category='problem', parent_location=vertical.location)
+        self.course = CourseFactory()
+        self.chapter = ItemFactory(category='chapter', parent_location=self.course.location)  # pylint: disable=no-member
+        self.section = ItemFactory(category='sequential', parent_location=self.chapter.location, due=datetime(2013, 9, 18, 11, 30, 00))
+        self.vertical = ItemFactory(category='vertical', parent_location=self.section.location)
+        self.component = ItemFactory(category='problem', parent_location=self.vertical.location)
 
-        self.course_key = course.id
+        self.course_key = self.course.id
         self.user = User.objects.create(username='dummy', password='123456',
                                         email='test@mit.edu')
         self.date = datetime(2013, 1, 22, tzinfo=UTC)
@@ -146,6 +146,17 @@ class ViewsTestCase(TestCase):
         mock_module.get_display_items.return_value = []
         self.assertRaises(Http404, views.redirect_to_course_position,
                           mock_module, views.CONTENT_DEPTH)
+
+    def test_index_invalid_position(self):
+        request_url = '/'.join([
+            '/courses',
+            self.course.id.to_deprecated_string(),
+            self.chapter.location.name,
+            self.section.location.name,
+            'f'
+        ])
+        response = self.client.get(request_url)
+        self.assertEqual(response.status_code, 404)
 
     def test_registered_for_course(self):
         self.assertFalse(views.registered_for_course('Basketweaving', None))

--- a/lms/djangoapps/courseware/views.py
+++ b/lms/djangoapps/courseware/views.py
@@ -354,6 +354,13 @@ def index(request, course_id, chapter=None, section=None,
             section_field_data_cache = FieldDataCache.cache_for_descriptor_descendents(
                 course_key, user, section_descriptor, depth=None)
 
+            # Verify that position a string is in fact an int
+            if position is not None:
+                try:
+                    int(position)
+                except ValueError:
+                    raise Http404("Position {} is not an integer!".format(position))
+
             section_module = get_module_for_descriptor(
                 request.user,
                 request,


### PR DESCRIPTION
@adampalay @sarina 

https://edx-wiki.atlassian.net/browse/LMS-2488

The unicode input now correctly results in a 404 error instead of a 500 error.
