### PR TITLE
Speed up test by fixing negative assertion

### DIFF
--- a/cms/djangoapps/contentstore/features/section.py
+++ b/cms/djangoapps/contentstore/features/section.py
@@ -73,7 +73,7 @@ def i_click_on_section_name_in_modal(_step):
 
 @step('I see no form for editing section name in modal$')
 def edit_section_name_form_not_exist(_step):
-    assert not world.is_css_present('.modal-window .section-name input')
+    assert world.is_css_not_present('.modal-window .section-name input')
 
 
 @step('I see the complete section name with a quote in the editor$')


### PR DESCRIPTION
@zubair-arbi @muhammad-ammar 

We should either do it this way, or if we want to use assert not world.is_css_present, then pass in a timeout (something less than the 30 seconds that is_css_present defaults to).

This will speed up the test: CMS.Create Section : Section name not clickable on editing release date
step: Then I see no form for editing section name in modal

You can verify in the test report on jenkins. E.g. this is it in the most recent build of master: https://jenkins.testeng.edx.org/job/edx-all-tests-auto-master/lastCompletedBuild/SHARD=2,TEST_SUITE=cms-acceptance/testReport/CMS/Create%20Section%20_%20Section%20name%20not%20clickable%20on%20editing%20release%20date/
