### PR TITLE
Speed up test for closed caption state

### DIFF
--- a/cms/djangoapps/contentstore/features/video.py
+++ b/cms/djangoapps/contentstore/features/video.py
@@ -166,7 +166,7 @@ def set_captions_visibility_state(_step, captions_state):
     SELECTOR = '.closed .subtitles'
     world.wait_for_visible('.hide-subtitles')
     if captions_state == 'closed':
-        if not world.is_css_present(SELECTOR):
+        if world.is_css_not_present(SELECTOR):
             world.css_find('.hide-subtitles').click()
     else:
         if world.is_css_present(SELECTOR):


### PR DESCRIPTION
@polesye @muhammad-ammar 

This will speed up the tests in the case that the captions should be closed.
E.g. CMS Video Component : When start and end times are specified, a range on slider is shown, step: And Make sure captions are closed

Here is the report from the last test build of master: https://jenkins.testeng.edx.org/job/edx-all-tests-auto-master/lastCompletedBuild/SHARD=3,TEST_SUITE=cms-acceptance/testReport/(root)/CMS%20Video%20Component%20_%20When%20start%20and%20end%20times%20are%20specified,%20a%20range%20on%20slider%20is%20shown/
