### PR TITLE
bugfix: avoid side-effects when overriding User.default_retrieve_params

### DIFF
--- a/lms/lib/comment_client/user.py
+++ b/lms/lib/comment_client/user.py
@@ -116,7 +116,7 @@ class User(models.Model):
 
     def _retrieve(self, *args, **kwargs):
         url = self.url(action='get', params=self.attributes)
-        retrieve_params = self.default_retrieve_params
+        retrieve_params = self.default_retrieve_params.copy()
         retrieve_params.update(kwargs)
         if self.attributes.get('course_id'):
             retrieve_params['course_id'] = self.course_id.to_deprecated_string()


### PR DESCRIPTION
Since c2ebfde, cc.User was prone to intermittent KeyErrors on 'upvoted_ids' due to a class default being modified.

@gwprice 
