### PR TITLE
Wait for scripts defined in common xmodule code to execute.

### DIFF
--- a/cms/templates/container.html
+++ b/cms/templates/container.html
@@ -32,19 +32,18 @@ main_xblock_info = {
 <script type='text/javascript'>
     require(["domReady!", "jquery", "js/models/xblock_info", "js/views/pages/container",
         "js/collections/component_template", "xmodule", "coffee/src/main", "xblock/cms.runtime.v1"],
-            function(doc, $, XBlockInfo, ContainerPage, ComponentTemplates) {
-                var view, mainXBlockInfo;
-
+            function(doc, $, XBlockInfo, ContainerPage, ComponentTemplates, xmoduleLoader) {
                 var templates = new ComponentTemplates(${component_templates | n}, {parse: true});
+                var mainXBlockInfo = new XBlockInfo(${json.dumps(main_xblock_info) | n});
 
-                mainXBlockInfo = new XBlockInfo(${json.dumps(main_xblock_info) | n});
-
-                view = new ContainerPage({
-                    el: $('#content'),
-                    model: mainXBlockInfo,
-                    templates: templates
+                xmoduleLoader.done(function () {
+                    var view = new ContainerPage({
+                        el: $('#content'),
+                        model: mainXBlockInfo,
+                        templates: templates
+                    });
+                    view.render();
                 });
-                view.render();
             });
 </script>
 

--- a/cms/templates/edit-tabs.html
+++ b/cms/templates/edit-tabs.html
@@ -21,16 +21,18 @@
 <script type='text/javascript'>
     require(["js/models/explicit_url", "coffee/src/views/tabs",
         "xmodule", "coffee/src/main", "xblock/cms.runtime.v1"],
-            function (TabsModel, TabsEditView) {
-                var model = new TabsModel({
-                    id: "${context_course.location}",
-                    explicit_url: "${reverse('contentstore.views.tabs_handler', kwargs={'course_key_string': context_course.id})}"
-                });
+            function (TabsModel, TabsEditView, xmoduleLoader) {
+                xmoduleLoader.done(function () {
+                    var model = new TabsModel({
+                        id: "${context_course.location}",
+                        explicit_url: "${reverse('contentstore.views.tabs_handler', kwargs={'course_key_string': context_course.id})}"
+                    });
 
-                new TabsEditView({
-                    el: $('.tab-list'),
-                    model: model,
-                    mast: $('.wrapper-mast')
+                    new TabsEditView({
+                        el: $('.tab-list'),
+                        model: model,
+                        mast: $('.wrapper-mast')
+                    });
                 });
             });
   </script>

--- a/cms/templates/unit.html
+++ b/cms/templates/unit.html
@@ -21,25 +21,27 @@ from django.utils.translation import ugettext as _
 <%block name="jsextra">
   <script type='text/javascript'>
 require(["domReady!", "jquery", "js/models/module_info", "coffee/src/views/unit", "js/collections/component_template",
-    "jquery.ui", "xmodule", "coffee/src/main", "xblock/cms.runtime.v1"],
-    function(doc, $, ModuleModel, UnitEditView, ComponentTemplates) {
+    "xmodule", "jquery.ui", "coffee/src/main", "xblock/cms.runtime.v1"],
+    function(doc, $, ModuleModel, UnitEditView, ComponentTemplates, xmoduleLoader) {
   window.unit_location_analytics = '${unit_usage_key}';
 
   var templates = new ComponentTemplates(${component_templates | n}, {parse: true});
 
-  new UnitEditView({
-    el: $('.main-wrapper'),
-    view: 'unit',
-    model: new ModuleModel({
-      id: '${unit_usage_key}',
-      state: '${unit_state}'
-    }),
-    templates: templates
-  });
+  xmoduleLoader.done(function () {
+      new UnitEditView({
+        el: $('.main-wrapper'),
+        view: 'unit',
+        model: new ModuleModel({
+          id: '${unit_usage_key}',
+          state: '${unit_state}'
+        }),
+        templates: templates
+      });
 
-  $('.new-component-template').each(function(){
-      $emptyEditor = $(this).find('.empty');
-      $(this).prepend($emptyEditor);
+      $('.new-component-template').each(function(){
+          $emptyEditor = $(this).find('.empty');
+          $(this).prepend($emptyEditor);
+      });
   });
 });
   </script>

--- a/common/djangoapps/pipeline_js/templates/xmodule.js
+++ b/common/djangoapps/pipeline_js/templates/xmodule.js
@@ -21,8 +21,17 @@ define(["jquery", "underscore", "mathjax", "codemirror", "tinymce",
 
     var urls = ${urls};
     var head = $("head");
-    $.each(urls, function(i, url) {
+    var deferred = $.Deferred();
+    var numResources = urls.length;
+    $.each(urls, function (i, url) {
         head.append($("<script/>", {src: url}));
+        // Wait for all the scripts to execute.
+        require([url], function () {
+            if (i === numResources - 1) {
+               deferred.resolve();
+            }
+        });
     });
-    return window.XModule;
+
+    return deferred.promise();
 });


### PR DESCRIPTION
STUD-1792

@cpennington @andy-armstrong What do you think of this approach? I can't reproduce the bug locally to confirm that it fixes it... When I run locally, the Promise is resolved before the JS in container.html and unit.html executes.

@singingwolfboy Adding you in case you are interested or know of a better way to dynamically add JS dependencies. Ideally, we'd like to say that "xmodule" depends on all these individual scripts being loaded and executed.
