### PR TITLE
Reduce captions wait time.

### DIFF
--- a/lms/djangoapps/courseware/features/video.py
+++ b/lms/djangoapps/courseware/features/video.py
@@ -438,7 +438,7 @@ def error_message_has_correct_text(_step):
 @step('I make sure captions are (.+)$')
 def set_captions_visibility_state(_step, captions_state):
     SELECTOR = '.closed .subtitles'
-    if world.is_css_not_present(SELECTOR, wait_time=30):
+    if world.is_css_not_present(SELECTOR):
         if captions_state == 'closed':
             world.css_click('.hide-subtitles')
     else:


### PR DESCRIPTION
Before executing the `@step('I make sure captions are (.+)$')` video player controls will be in stable(rendered completely) state so we don't need to wait for `30 seconds`. The default wait time is enough.
