### PR TITLE
Improve certificates test time

### DIFF
--- a/lms/djangoapps/courseware/features/certificates.py
+++ b/lms/djangoapps/courseware/features/certificates.py
@@ -261,7 +261,7 @@ def see_upsell_link_on_my_dashboard(step):
 @step(u'I do not see the upsell link on my dashboard')
 def see_upsell_link_on_my_dashboard(step):
     course_link_css = UPSELL_LINK_CSS
-    assert not world.is_css_present(course_link_css)
+    assert world.is_css_not_present(course_link_css)
 
 
 @step(u'I select the upsell link on my dashboard')


### PR DESCRIPTION
This will speedup the step `And I do not see the upsell link on my dashboard`

Please verify from jenkins test report. Below is the result of last build of master. 
https://jenkins.testeng.edx.org/job/edx-all-tests-auto-master/SHARD=2,TEST_SUITE=lms-acceptance/lastCompletedBuild/testReport/LMS/Verified%20certificates%20_%20Verified%20courses%20display%20correctly%20on%20dashboard/
