### PR TITLE
Remove deprecated Jenkins script paths.

### DIFF
--- a/jenkins/acceptance.sh
+++ b/jenkins/acceptance.sh
@@ -1,1 +1,0 @@
-../scripts/acceptance-tests.sh

--- a/jenkins/all-tests.sh
+++ b/jenkins/all-tests.sh
@@ -1,1 +1,0 @@
-../scripts/all-tests.sh


### PR DESCRIPTION
These now exist under scripts/ and we have the infrastructure in place on Jenkins to support either path.

@singingwolfboy @jzoldak for review
