### PR TITLE
Do not print exception message below stacktrace

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -154,3 +154,4 @@ Abdallah Nassif <abdoosh00@gmail.com>
 Johnny Brown <johnnybrown7@gmail.com>
 Ben McMorran <bmcmorran@edx.org>
 Mat Peterson <mpeterson@edx.org>
+Tim Babych <tim.babych@gmail.com>

--- a/common/lib/capa/capa/inputtypes.py
+++ b/common/lib/capa/capa/inputtypes.py
@@ -221,7 +221,7 @@ class InputTypeBase(object):
         self.status = state.get('status', 'unanswered')
 
         try:
-            # Pre-parse and propcess all the declared requirements.
+            # Pre-parse and process all the declared requirements.
             self.process_requirements()
 
             # Call subclass "constructor" -- means they don't have to worry about calling

--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -249,7 +249,9 @@ class CapaMixin(CapaFields):
                 # e.g. in the CMS
                 msg = u'<p>{msg}</p>'.format(msg=cgi.escape(msg))
                 msg += u'<p><pre>{tb}</pre></p>'.format(
-                    tb=cgi.escape(traceback.format_exc()))
+                    # just the traceback
+                    tb=cgi.escape(''.join(['Traceback (most recent call last):\n'] +
+                        traceback.format_tb(sys.exc_info()[2]))))
                 # create a dummy problem with error message instead of failing
                 problem_text = (u'<problem><text><span class="inline-error">'
                                 u'Problem {url} has an error:</span>{msg}</text></problem>'.format(

--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -249,8 +249,9 @@ class CapaMixin(CapaFields):
                 # e.g. in the CMS
                 msg = u'<p>{msg}</p>'.format(msg=cgi.escape(msg))
                 msg += u'<p><pre>{tb}</pre></p>'.format(
-                    # just the traceback
-                    tb=cgi.escape(''.join(['Traceback (most recent call last):\n'] +
+                    # just the traceback, no message - it is already present above
+                    tb=cgi.escape(
+                        u''.join(['Traceback (most recent call last):\n'] +
                         traceback.format_tb(sys.exc_info()[2]))))
                 # create a dummy problem with error message instead of failing
                 problem_text = (u'<problem><text><span class="inline-error">'


### PR DESCRIPTION
because it prints Unicode characters escaped, and we have already formatted the message above. 

also a typo fix.

please review: @sarina, @polesye, @auraz, @olmar 
