### PR TITLE
Move all lms lettuce tests into shard 1

### DIFF
--- a/lms/djangoapps/courseware/features/annotatable.feature
+++ b/lms/djangoapps/courseware/features/annotatable.feature
@@ -1,4 +1,3 @@
-@shard_2
 Feature: LMS.Annotatable Component
   As a student, I want to view an Annotatable component in the LMS
 

--- a/lms/djangoapps/courseware/features/certificates.feature
+++ b/lms/djangoapps/courseware/features/certificates.feature
@@ -1,4 +1,3 @@
-@shard_2
 Feature: LMS.Verified certificates
     As a student,
     In order to earn a verified certificate

--- a/lms/djangoapps/courseware/features/conditional.feature
+++ b/lms/djangoapps/courseware/features/conditional.feature
@@ -1,4 +1,3 @@
-@shard_2
 Feature: LMS.Conditional Module
   As a student, I want to view a Conditional component in the LMS
 

--- a/lms/djangoapps/courseware/features/events.feature
+++ b/lms/djangoapps/courseware/features/events.feature
@@ -1,4 +1,3 @@
-@shard_2
 Feature: LMS.Events
   As a researcher, I want to be able to track events in the LMS
 

--- a/lms/djangoapps/courseware/features/gst.feature
+++ b/lms/djangoapps/courseware/features/gst.feature
@@ -1,4 +1,3 @@
-@shard_2
 Feature: LMS.Graphical Slider Tool Module
   As a student, I want to view a Graphical Slider Tool Component
 

--- a/lms/djangoapps/courseware/features/help.feature
+++ b/lms/djangoapps/courseware/features/help.feature
@@ -1,4 +1,3 @@
-@shard_2
 Feature: LMS.The help module should work
   In order to get help
   As a student

--- a/lms/djangoapps/courseware/features/high-level-tabs.feature
+++ b/lms/djangoapps/courseware/features/high-level-tabs.feature
@@ -1,4 +1,3 @@
-@shard_1
 Feature: LMS.All the high level tabs should work
   In order to preview the courseware
   As a student

--- a/lms/djangoapps/courseware/features/homepage.feature
+++ b/lms/djangoapps/courseware/features/homepage.feature
@@ -1,4 +1,3 @@
-@shard_1
 Feature: LMS.Homepage for web users
   In order to get an idea what edX is about
   As a an anonymous web user

--- a/lms/djangoapps/courseware/features/login.feature
+++ b/lms/djangoapps/courseware/features/login.feature
@@ -1,4 +1,3 @@
-@shard_1
 Feature: LMS.Login in as a registered user
   As a registered user
   In order to access my content

--- a/lms/djangoapps/courseware/features/lti.feature
+++ b/lms/djangoapps/courseware/features/lti.feature
@@ -1,4 +1,4 @@
-@shard_1 @requires_stub_lti
+@requires_stub_lti
 Feature: LMS.LTI component
   As a student, I want to view LTI component in LMS.
 

--- a/lms/djangoapps/courseware/features/navigation.feature
+++ b/lms/djangoapps/courseware/features/navigation.feature
@@ -1,4 +1,3 @@
-@shard_1
 Feature: LMS.Navigate Course
     As a student in an edX course
     In order to access courseware

--- a/lms/djangoapps/courseware/features/problems.feature
+++ b/lms/djangoapps/courseware/features/problems.feature
@@ -1,4 +1,4 @@
-@shard_1 @requires_stub_xqueue
+@requires_stub_xqueue
 Feature: LMS.Answer problems
     As a student in an edX course
     In order to test my understanding of the material

--- a/lms/djangoapps/courseware/features/registration.feature
+++ b/lms/djangoapps/courseware/features/registration.feature
@@ -1,4 +1,3 @@
-@shard_1
 Feature: LMS.Register for a course
   As a registered user
   In order to access my class content

--- a/lms/djangoapps/courseware/features/signup.feature
+++ b/lms/djangoapps/courseware/features/signup.feature
@@ -1,4 +1,3 @@
-@shard_2
 Feature: LMS.Sign in
   In order to use the edX content
   As a new user

--- a/lms/djangoapps/courseware/features/staff_debug_info.feature
+++ b/lms/djangoapps/courseware/features/staff_debug_info.feature
@@ -1,4 +1,3 @@
-@shard_1
 Feature: LMS.Debug staff info links
     As a course staff in an edX course
     In order to test my understanding of the material

--- a/lms/djangoapps/courseware/features/video.feature
+++ b/lms/djangoapps/courseware/features/video.feature
@@ -1,4 +1,4 @@
-@shard_2 @requires_stub_youtube
+@requires_stub_youtube
 Feature: LMS.Video component
   As a student, I want to view course videos in LMS
 

--- a/lms/djangoapps/courseware/features/word_cloud.feature
+++ b/lms/djangoapps/courseware/features/word_cloud.feature
@@ -1,4 +1,3 @@
-@shard_2
 Feature: LMS.World Cloud component
   As a student, I want to view Word Cloud component in LMS.
 

--- a/lms/djangoapps/instructor/features/bulk_email.feature
+++ b/lms/djangoapps/instructor/features/bulk_email.feature
@@ -1,4 +1,3 @@
-@shard_2
 Feature: LMS.Instructor Dash Bulk Email
     As an instructor or course staff,
     In order to communicate with students and staff

--- a/lms/djangoapps/instructor/features/data_download.feature
+++ b/lms/djangoapps/instructor/features/data_download.feature
@@ -1,4 +1,3 @@
-@shard_2
 Feature: LMS.Instructor Dash Data Download
     As an instructor or course staff,
     In order to manage my class

--- a/scripts/all-tests.sh
+++ b/scripts/all-tests.sh
@@ -106,7 +106,7 @@ END
         ;;
 
     "lms-acceptance")
-        rake test:acceptance:lms["-v 3 --tag shard_${SHARD}"]
+        rake test:acceptance:lms["-v 3"]
         ;;
 
     "cms-acceptance")


### PR DESCRIPTION
@benpatterson

Now that we have moved the lettuce acceptance tests to bok-choy, the lms lettuce shards are only taking ~2 minutes each. 

See for example: https://jenkins.testeng.edx.org/job/edx-all-tests-auto-master/1985/testReport/

So let's collapse into shard 1 and use 1 fewer worker.
