### PR TITLE
Update selenium and splinter versions

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -123,8 +123,8 @@ pep8==1.4.5
 pylint==0.28
 python-subunit==0.0.16
 rednose==0.3
-selenium==2.39.0
-splinter==0.5.4
+selenium==2.42.1
+splinter==0.6.0
 testtools==0.9.34
 flaky==0.2.0
 


### PR DESCRIPTION
@muhammad-ammar 
I was thinking we should be up to date on selenium and splinter. 
Looks like the bok-choy tests are having a problem. I tried updating at the bok-choy package level and all its test pass, so I'm thinking the issue is with one of our helper methods.
If you have time, can you please look into this. Feel free to push this branch. Thx.
