### PR TITLE
Removing dot in scenario names

### DIFF
--- a/lms/djangoapps/courseware/features/lti.feature
+++ b/lms/djangoapps/courseware/features/lti.feature
@@ -79,7 +79,7 @@ Feature: LMS.LTI component
   And I see graph with total progress "5%"
 
   #9
-  Scenario: Graded LTI component in LMS is correctly works with LTI2.0 PUT callback
+  Scenario: Graded LTI component in LMS is correctly works with LTI2v0 PUT callback
   Given the course has correct LTI credentials with registered Instructor
   And the course has an LTI component with correct fields:
   | open_in_a_new_page | weight | is_graded | has_score |
@@ -98,7 +98,7 @@ Feature: LMS.LTI component
   Then I see LTI component feedback with text "This is awesome."
 
   #10
-  Scenario: Graded LTI component in LMS is correctly works with LTI2.0 PUT delete callback
+  Scenario: Graded LTI component in LMS is correctly works with LTI2v0 PUT delete callback
   Given the course has correct LTI credentials with registered Instructor
   And the course has an LTI component with correct fields:
   | open_in_a_new_page | weight | is_graded | has_score |


### PR DESCRIPTION
Test EngineeringTE-444
LTI test results are not rolling up properly because of "." in scenario names

https://edx-wiki.atlassian.net/browse/TE-444
