### PR TITLE
forums: add UX for username search results.

### DIFF
--- a/common/static/coffee/src/discussion/utils.coffee
+++ b/common/static/coffee/src/discussion/utils.coffee
@@ -73,6 +73,7 @@ class @DiscussionUtil
       downvote_comment        : "/courses/#{$$course_id}/discussion/comments/#{param}/downvote"
       undo_vote_for_comment   : "/courses/#{$$course_id}/discussion/comments/#{param}/unvote"
       upload                  : "/courses/#{$$course_id}/discussion/upload"
+      users                   : "/courses/#{$$course_id}/discussion/users"
       search                  : "/courses/#{$$course_id}/discussion/forum/search"
       retrieve_discussion     : "/courses/#{$$course_id}/discussion/forum/#{param}/inline"
       retrieve_single_thread  : "/courses/#{$$course_id}/discussion/forum/#{param}/threads/#{param1}"

--- a/common/test/acceptance/pages/lms/discussion.py
+++ b/common/test/acceptance/pages/lms/discussion.py
@@ -351,13 +351,13 @@ class DiscussionTabHomePage(CoursePage, DiscussionPageMixin):
     def is_browser_on_page(self):
         return self.q(css=".discussion-body section.home-header").present
 
-    def perform_search(self):
+    def perform_search(self, text="dummy"):
         self.q(css=".discussion-body .sidebar .search").first.click()
         EmptyPromise(
             lambda: self.q(css=".discussion-body .sidebar .search.is-open").present,
             "waiting for search input to be available"
         ).fulfill()
-        self.q(css="#search-discussions").fill("dummy" + chr(10))
+        self.q(css="#search-discussions").fill(text + chr(10))
         EmptyPromise(
             self.is_ajax_finished,
             "waiting for server to return result"
@@ -365,6 +365,9 @@ class DiscussionTabHomePage(CoursePage, DiscussionPageMixin):
 
     def get_search_alert_messages(self):
         return self.q(css=self.ALERT_SELECTOR + " .message").text
+
+    def get_search_alert_links(self):
+        return self.q(css=self.ALERT_SELECTOR + " .link-jump")
 
     def dismiss_alert_message(self, text):
         """

--- a/lms/static/sass/discussion/_discussion-developer.scss
+++ b/lms/static/sass/discussion/_discussion-developer.scss
@@ -70,11 +70,12 @@ body.discussion {
         @include transition(none);
         @extend %t-weight5;
         padding: ($baseline/4) ($baseline/2);
+        color: $white;
 
         // reseting poorly globally scoped hover/focus state for this control
         &:hover, &:focus {
-          color: $link-color;
-          text-decoration: underline;
+          color: $white;
+          text-decoration: none;
         }
       }
     }


### PR DESCRIPTION
JIRA: FOR-627

@gwprice @marcotuts 

@marcotuts re: our chat earlier, see screengrabs below.   I made the x icon white, however the horizontal position was deliberately set up by @talbs to align well with items in the thread list, so wanted to reconfirm before messing around with that.

@lou-wang note in addition to story as scoped, threw in a trivial fix to formally tell the user that no threads matched their search, this resolved some confusion and seems generally polite, but the design isn't considered long-term.  

![screen shot 2014-06-17 at 4 00 54 pm](https://cloud.githubusercontent.com/assets/1349368/3305802/71bcedb2-f65a-11e3-90be-57f94ec43038.png)

![screen shot 2014-06-17 at 4 01 26 pm](https://cloud.githubusercontent.com/assets/1349368/3305805/7bf412ec-f65a-11e3-9b3d-486dd9848f61.png)

![screen shot 2014-06-17 at 4 01 12 pm](https://cloud.githubusercontent.com/assets/1349368/3305806/8666f578-f65a-11e3-9aab-039d7b5e0a09.png)
