### PR TITLE
Do not print exception message below stacktrace

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -154,3 +154,4 @@ Abdallah Nassif <abdoosh00@gmail.com>
 Johnny Brown <johnnybrown7@gmail.com>
 Ben McMorran <bmcmorran@edx.org>
 Mat Peterson <mpeterson@edx.org>
+Tim Babych <tim.babych@gmail.com>

--- a/common/lib/capa/capa/inputtypes.py
+++ b/common/lib/capa/capa/inputtypes.py
@@ -221,7 +221,7 @@ class InputTypeBase(object):
         self.status = state.get('status', 'unanswered')
 
         try:
-            # Pre-parse and propcess all the declared requirements.
+            # Pre-parse and process all the declared requirements.
             self.process_requirements()
 
             # Call subclass "constructor" -- means they don't have to worry about calling

--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -249,7 +249,11 @@ class CapaMixin(CapaFields):
                 # e.g. in the CMS
                 msg = u'<p>{msg}</p>'.format(msg=cgi.escape(msg))
                 msg += u'<p><pre>{tb}</pre></p>'.format(
-                    tb=cgi.escape(traceback.format_exc()))
+                    # just the traceback, no message - it is already present above
+                    tb=cgi.escape(
+                        u''.join(['Traceback (most recent call last):\n'] +
+                        traceback.format_tb(sys.exc_info()[2])))
+                    )
                 # create a dummy problem with error message instead of failing
                 problem_text = (u'<problem><text><span class="inline-error">'
                                 u'Problem {url} has an error:</span>{msg}</text></problem>'.format(


### PR DESCRIPTION
0dbcf06280d8c79ca40c48f6d5f6a1ed521b0b8a introduced localized error messages when XML for ChoiceGroup is not right. We display them on top of the page, above the traceback. However, the traceback itself contains the message one more time, and this time unicode characters are not displayed as is, but presented as \uXXXX entities. Since that behavior seems to be intrinsic for traceback.format_exc() and we do not need the message there anyway, the patch hides it from display.

without patch:
![without-fix](https://cloud.githubusercontent.com/assets/123786/3306076/7082ea0c-f65d-11e3-9900-a14eaf41450a.png)

with patch:
![with-fix](https://cloud.githubusercontent.com/assets/123786/3306077/708499ec-f65d-11e3-8abf-330ae54330d8.png)

unicode traceback output example:

``` python
# -*- coding: utf-8 -*-

import sys
import traceback

try:
    raise Exception, u"мсж", sys.exc_info()[2]
except Exception as err:
    # just the traceback
    print ''.join(['Traceback (most recent call last):\n']+traceback.format_tb(sys.exc_info()[2]))
    print
    # traceback and message, \uXXXX
    print traceback.format_exc()
```

pls review: @nedbat, @sarina, @polesye, @auraz, @olmar 
