### PR TITLE
only display browser warning for <= IE8 (LMS-2732)

### DIFF
--- a/lms/templates/navigation.html
+++ b/lms/templates/navigation.html
@@ -129,7 +129,7 @@ site_status_msg = get_site_status_msg(course_id)
   </nav>
 </header>
 % if course:
-<!--[if IE]>
+<!--[if lte IE 8]>
 <div class="ie-banner" aria-hidden="true">${_('<strong>Warning:</strong> Your browser is not fully supported. We strongly recommend using {chrome_link_start}Chrome{chrome_link_end} or {ff_link_start}Firefox{ff_link_end}.').format(chrome_link_start='<a href="https://www.google.com/intl/en/chrome/browser/" target="_blank">', chrome_link_end='</a>', ff_link_start='<a href="http://www.mozilla.org/en-US/firefox/new/" target="_blank">', ff_link_end='</a>')}</div>
 <![endif]-->
 % endif


### PR DESCRIPTION
@talbs 
@symbolist 

Per product, only display this warning for browsers we actually don't support (i.e. IE <= 8)

https://edx-wiki.atlassian.net/browse/LMS-2732
