### PR TITLE
Remove course ID from title in course about page

### DIFF
--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -119,7 +119,7 @@
   <script src="${static.url('js/course_info.js')}"></script>
 </%block>
 
-<%block name="pagetitle">${_("About {course.display_number_with_default}").format(course=course) | h}</%block>
+<%block name="pagetitle">${get_course_about_section(course, "title")}</%block>
 
 <section class="course-info">
   <header class="course-profile">
@@ -128,7 +128,7 @@
       <section class="intro">
         <hgroup>
           <h1>
-            ${course.display_number_with_default | h}: ${get_course_about_section(course, "title")}
+            ${get_course_about_section(course, "title")}
             % if not self.theme_enabled():
               <a href="#">${get_course_about_section(course, "university")}</a>
             % endif


### PR DESCRIPTION
Having the course ID as course title doesn’t make a lot of sense (SEO, user comprehension, etc.)
It’s also in contradiction with the `og:title` property.

As for the `<h1>` title, the course ID is redundant with the "Course number" in the sidebar right below it:

![screen shot 2014-06-20 at 3 38 36 pm](https://cloud.githubusercontent.com/assets/166147/3340678/5e44e384-f880-11e3-8238-d45fc6ee448f.png)
