### PR TITLE
Add possibility to run bok_choy tests in local env.

### DIFF
--- a/cms/envs/bok_choy.py
+++ b/cms/envs/bok_choy.py
@@ -55,3 +55,10 @@ YOUTUBE_PORT = 9080
 YOUTUBE['API'] = "127.0.0.1:{0}/get_youtube_api/".format(YOUTUBE_PORT)
 YOUTUBE['TEST_URL'] = "127.0.0.1:{0}/test_youtube/".format(YOUTUBE_PORT)
 YOUTUBE['TEXT_API']['url'] = "127.0.0.1:{0}/test_transcripts_youtube/".format(YOUTUBE_PORT)
+
+#####################################################################
+# Lastly, see if the developer has any local overrides.
+try:
+    from .private import *      # pylint: disable=F0401
+except ImportError:
+    pass

--- a/lms/envs/bok_choy.py
+++ b/lms/envs/bok_choy.py
@@ -67,3 +67,10 @@ YOUTUBE_PORT = 9080
 YOUTUBE['API'] = "127.0.0.1:{0}/get_youtube_api/".format(YOUTUBE_PORT)
 YOUTUBE['TEST_URL'] = "127.0.0.1:{0}/test_youtube/".format(YOUTUBE_PORT)
 YOUTUBE['TEXT_API']['url'] = "127.0.0.1:{0}/test_transcripts_youtube/".format(YOUTUBE_PORT)
+
+#####################################################################
+# Lastly, see if the developer has any local overrides.
+try:
+    from .private import *      # pylint: disable=F0401
+except ImportError:
+    pass


### PR DESCRIPTION
This PR will allow to run bok_choy test in native dev env w/o vagrant and virtualbox
1. Run mysqld, mongod and memcached
2. Create, if they are not exist, two private.py files in cms/envs and lms/envs and add following code to them:

In lms/envs/private.py add:

``` python
"""
My custom settings.
"""
import os
from logsettings import get_logger_config


from .common import REPO_ROOT


if os.environ['SERVICE_VARIANT'] == 'bok_choy':
    from .aws import ENV_TOKENS
    LOGGING = get_logger_config(REPO_ROOT + '/log',
                            logging_env=ENV_TOKENS['LOGGING_ENV'],
                            syslog_addr=(ENV_TOKENS['SYSLOG_SERVER'], 514),
                            local_loglevel=ENV_TOKENS.get('LOCAL_LOGLEVEL', 'INFO'),
                            debug=False,
                            dev_env=True,
                            service_variant=os.environ['SERVICE_VARIANT'])
```

In cms/envs/private.py add:

``` python
"""
My custom settings.
"""
import os
from logsettings import get_logger_config


from .common import REPO_ROOT


if os.environ['SERVICE_VARIANT'] == 'bok_choy':
    from .aws import ENV_TOKENS
    LOGGING = get_logger_config(REPO_ROOT + '/log',
                            logging_env=ENV_TOKENS['LOGGING_ENV'],
                            syslog_addr=(ENV_TOKENS['SYSLOG_SERVER'], 514),
                            debug=False,
                            dev_env=True,
                            service_variant=os.environ['SERVICE_VARIANT'])
```

then you will be able to run bok_choy tests.

@jzoldak please review
