### PR TITLE
Explicitly skip tests in common unless we know we're running the LMS unittest suite

### DIFF
--- a/common/djangoapps/student/tests/test_bulk_email_settings.py
+++ b/common/djangoapps/student/tests/test_bulk_email_settings.py
@@ -7,8 +7,8 @@ Course Auth is turned on.
 
 from django.test.utils import override_settings
 from django.conf import settings
-from django.core.urlresolvers import reverse, NoReverseMatch
-from unittest.case import SkipTest
+from django.core.urlresolvers import reverse
+import unittest
 
 from courseware.tests.tests import TEST_DATA_MONGO_MODULESTORE
 from student.tests.factories import UserFactory, CourseEnrollmentFactory
@@ -23,6 +23,7 @@ from mock import patch
 
 
 @override_settings(MODULESTORE=TEST_DATA_MONGO_MODULESTORE)
+@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 class TestStudentDashboardEmailView(ModuleStoreTestCase):
     """
     Check for email view displayed with flag
@@ -35,11 +36,7 @@ class TestStudentDashboardEmailView(ModuleStoreTestCase):
         CourseEnrollmentFactory.create(user=student, course_id=self.course.id)
         self.client.login(username=student.username, password="test")
 
-        try:
-            # URL for dashboard
-            self.url = reverse('dashboard')
-        except NoReverseMatch:
-            raise SkipTest("Skip this test if url cannot be found (ie running from CMS tests)")
+        self.url = reverse('dashboard')
         # URL for email settings modal
         self.email_modal_link = (
             ('<a href="#email-settings-modal" class="email-settings" rel="leanModal" '
@@ -92,6 +89,7 @@ class TestStudentDashboardEmailView(ModuleStoreTestCase):
 
 
 @override_settings(MODULESTORE=TEST_DATA_MIXED_MODULESTORE)
+@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 class TestStudentDashboardEmailViewXMLBacked(ModuleStoreTestCase):
     """
     Check for email view on student dashboard, with XML backed course.
@@ -107,11 +105,7 @@ class TestStudentDashboardEmailViewXMLBacked(ModuleStoreTestCase):
         )
         self.client.login(username=student.username, password="test")
 
-        try:
-            # URL for dashboard
-            self.url = reverse('dashboard')
-        except NoReverseMatch:
-            raise SkipTest("Skip this test if url cannot be found (ie running from CMS tests)")
+        self.url = reverse('dashboard')
 
         # URL for email settings modal
         self.email_modal_link = (

--- a/common/djangoapps/student/tests/test_change_name.py
+++ b/common/djangoapps/student/tests/test_change_name.py
@@ -3,15 +3,17 @@ Unit tests for change_name view of student.
 """
 import json
 
-from django.core.urlresolvers import reverse, NoReverseMatch
+from django.conf import settings
+from django.core.urlresolvers import reverse
 from django.test.client import Client
 from django.test import TestCase
 
 from student.tests.factories import UserFactory
 from student.models import UserProfile
-from unittest.case import SkipTest
+import unittest
 
 
+@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 class TestChangeName(TestCase):
     """
     Check the change_name view of student.
@@ -22,14 +24,14 @@ class TestChangeName(TestCase):
 
     def test_change_name_get_request(self):
         """Get requests are not allowed in this view."""
-        change_name_url = self.get_url()
+        change_name_url = reverse('change_name')
         resp = self.client.get(change_name_url)
         self.assertEquals(resp.status_code, 405)
 
     def test_change_name_post_request(self):
         """Name will be changed when provided with proper data."""
         self.client.login(username=self.student.username, password='test')
-        change_name_url = self.get_url()
+        change_name_url = reverse('change_name')
         resp = self.client.post(change_name_url, {
             'new_name': 'waqas',
             'rationale': 'change identity'
@@ -44,7 +46,7 @@ class TestChangeName(TestCase):
     def test_change_name_without_name(self):
         """Empty string for name is not allowed in this view."""
         self.client.login(username=self.student.username, password='test')
-        change_name_url = self.get_url()
+        change_name_url = reverse('change_name')
         resp = self.client.post(change_name_url, {
             'new_name': '',
             'rationale': 'change identity'
@@ -54,17 +56,9 @@ class TestChangeName(TestCase):
 
     def test_unauthenticated(self):
         """Unauthenticated user is not allowed to call this view."""
-        change_name_url = self.get_url()
+        change_name_url = reverse('change_name')
         resp = self.client.post(change_name_url, {
             'new_name': 'waqas',
             'rationale': 'change identity'
         })
         self.assertEquals(resp.status_code, 404)
-
-    def get_url(self):
-        """Get the url of change_name view."""
-        try:
-            change_name_url = reverse('change_name')
-            return change_name_url
-        except NoReverseMatch:
-            raise SkipTest("Skip this test if url cannot be found (ie running from CMS tests)")

--- a/common/djangoapps/student/tests/tests.py
+++ b/common/djangoapps/student/tests/tests.py
@@ -153,15 +153,13 @@ class DashboardTest(TestCase):
         )
         self.client = Client()
 
+    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
     def check_verification_status_on(self, mode, value):
         """
         Check that the css class and the status message are in the dashboard html.
         """
         CourseEnrollment.enroll(self.user, self.course.location.course_key, mode=mode)
-        try:
-            response = self.client.get(reverse('dashboard'))
-        except NoReverseMatch:
-            raise SkipTest("Skip this test if url cannot be found (ie running from CMS tests)")
+        response = self.client.get(reverse('dashboard'))
         self.assertContains(response, "class=\"course {0}\"".format(mode))
         self.assertContains(response, value)
 
@@ -175,15 +173,13 @@ class DashboardTest(TestCase):
         self.check_verification_status_on('honor', 'You\'re enrolled as an honor code student')
         self.check_verification_status_on('audit', 'You\'re auditing this course')
 
+    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
     def check_verification_status_off(self, mode, value):
         """
         Check that the css class and the status message are not in the dashboard html.
         """
         CourseEnrollment.enroll(self.user, self.course.location.course_key, mode=mode)
-        try:
-            response = self.client.get(reverse('dashboard'))
-        except NoReverseMatch:
-            raise SkipTest("Skip this test if url cannot be found (ie running from CMS tests)")
+        response = self.client.get(reverse('dashboard'))
         self.assertNotContains(response, "class=\"course {0}\"".format(mode))
         self.assertNotContains(response, value)
 
@@ -230,7 +226,6 @@ class DashboardTest(TestCase):
         verified_mode.expiration_datetime = datetime.now(pytz.UTC) - timedelta(days=1)
         verified_mode.save()
         self.assertFalse(enrollment.refundable())
-
 
 
 class EnrollInCourseTest(TestCase):

--- a/common/djangoapps/track/tests/test_logs.py
+++ b/common/djangoapps/track/tests/test_logs.py
@@ -1,13 +1,15 @@
-"""Tests for student tracking"""
+"""Tests that tracking data are successfully logged"""
 import mock
+import unittest
 
 from django.test import TestCase
 from django.core.urlresolvers import reverse, NoReverseMatch
+from django.conf import settings
 from track.models import TrackingLog
 from track.views import user_track
-from nose.plugins.skip import SkipTest
 
 
+@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 class TrackingTest(TestCase):
     """
     Tests that tracking logs correctly handle events
@@ -24,10 +26,7 @@ class TrackingTest(TestCase):
         ]
         with mock.patch.dict('django.conf.settings.FEATURES', {'ENABLE_SQL_TRACKING_LOGS': True}):
             for request_params in requests:
-                try:  # because /event maps to two different views in lms and cms, we're only going to test lms here
-                    response = self.client.post(reverse(user_track), request_params)
-                except NoReverseMatch:
-                    raise SkipTest()
+                response = self.client.post(reverse(user_track), request_params)
                 self.assertEqual(response.status_code, 200)
                 self.assertEqual(response.content, 'success')
                 tracking_logs = TrackingLog.objects.order_by('-dtcreated')
@@ -47,10 +46,7 @@ class TrackingTest(TestCase):
         ]
         with mock.patch.dict('django.conf.settings.FEATURES', {'ENABLE_SQL_TRACKING_LOGS': True}):
             for request_params in requests:
-                try:  # because /event maps to two different views in lms and cms, we're only going to test lms here
-                    response = self.client.get(reverse(user_track), request_params)
-                except NoReverseMatch:
-                    raise SkipTest()
+                response = self.client.get(reverse(user_track), request_params)
                 self.assertEqual(response.status_code, 200)
                 self.assertEqual(response.content, 'success')
                 tracking_logs = TrackingLog.objects.order_by('-dtcreated')

--- a/common/djangoapps/track/tests/test_logs.py
+++ b/common/djangoapps/track/tests/test_logs.py
@@ -9,6 +9,7 @@ from track.models import TrackingLog
 from track.views import user_track
 
 
+@unittest.skip("TODO: these tests were not being run before, and now that they are they're failing")
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 class TrackingTest(TestCase):
     """


### PR DESCRIPTION
...in

@jzoldak @sarina 
removed `try ... except`s for ReverseMatchErrors when running tests in common that were only meant to be run in LMS. This way if the url naming scheme changes, we won't accidentally skip over these tests.
