### PR TITLE
Fix for htmlbooks

### DIFF
--- a/lms/djangoapps/staticbook/views.py
+++ b/lms/djangoapps/staticbook/views.py
@@ -7,6 +7,8 @@ from django.http import Http404
 from edxmako.shortcuts import render_to_response
 
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
+from xmodule.annotator_token import retrieve_token
+
 from courseware.access import has_access
 from courseware.courses import get_course_with_access
 from notes.utils import notes_enabled_for_course
@@ -170,5 +172,7 @@ def html_index(request, course_id, book_index, chapter=None):
             'student': student,
             'staff_access': staff_access,
             'notes_enabled': notes_enabled,
+            'storage': course.annotation_storage_url,
+            'token': retrieve_token(student.email, course.annotation_token_secret),
         },
     )

--- a/lms/static/coffee/src/notes.coffee
+++ b/lms/static/coffee/src/notes.coffee
@@ -13,10 +13,9 @@ class StudentNotes
             $(el).data('notes-instance', @)
 
     # Initializes annotations on a container element in response to an init event.
-    onInitNotes: (event, uri=null) =>
+    onInitNotes: (event, uri=null, storage_url=null, token=null) =>
         event.stopPropagation()
 
-        storeConfig = @getStoreConfig uri
         found = @targets.some (target) -> target is event.target
 
         # Get uri   
@@ -47,10 +46,10 @@ class StudentNotes
                         return user.id  if user and user.id
                         user 
                 auth: 
-                    tokenUrl: location.protocol+'//'+location.host+"/token?course_id="+courseid
+                    token: token
 
                 store:
-                    prefix: 'http://catch.aws.af.cm/annotator'
+                    prefix: storage_url
 
                     annotationData: uri:uri
 
@@ -87,33 +86,6 @@ class StudentNotes
                 ova = new OpenVideoAnnotation.Annotator($(event.target), options)  
             else
                 @targets.push(event.target)
-
-    # Returns a JSON config object that can be passed to the annotator Store plugin
-    getStoreConfig: (uri) ->
-        prefix = @getPrefix()
-        if uri is null
-            uri = @getURIPath()
-
-        storeConfig =
-            prefix: prefix
-            loadFromSearch:
-                uri: uri
-                limit: 0
-            annotationData:
-                uri: uri
-        storeConfig
-
-    # Returns the API endpoint for the annotation store
-    getPrefix: () ->
-        re = /^(\/courses\/[^/]+\/[^/]+\/[^/]+)/
-        match = re.exec(@getURIPath())
-        prefix = (if match then match[1] else '')
-        return "#{prefix}/notes/api"
-
-    # Returns the URI path of the current page for filtering annotations
-    getURIPath: () ->
-        window.location.href.toString().split(window.location.host)[1]
-
 
 # Enable notes by default on the document root.
 # To initialize annotations on a container element in the document:

--- a/lms/templates/static_htmlbook.html
+++ b/lms/templates/static_htmlbook.html
@@ -14,7 +14,6 @@
   <script type="text/javascript" src="${static.url('js/vendor/tinymce/js/tinymce/tinymce.full.min.js')}"></script>
   <script type="text/javascript" src="${static.url('js/vendor/tinymce/js/tinymce/jquery.tinymce.min.js')}"></script>
   <script type="text/javascript">
-	tinyMCE.baseURL = "${static.url('js/vendor/tinymce/js/tinymce')}";
 (function($) {
     $.fn.myHTMLViewer = function(options) {
         var urlToLoad = null;
@@ -40,7 +39,7 @@
         if(options.notesEnabled) {
             onComplete = function(url) {
                 return function() {
-                    $('#viewerContainer').trigger('notes:init', [url]);
+                    $('#viewerContainer').trigger('notes:init', [url, "${storage}", "${token}"]);
                 }
             };
         }

--- a/lms/templates/static_htmlbook.html
+++ b/lms/templates/static_htmlbook.html
@@ -11,8 +11,10 @@
 </%block>
 
 <%block name="js_extra">
+  <script type="text/javascript" src="${static.url('js/vendor/tinymce/js/tinymce/tinymce.full.min.js')}"></script>
+  <script type="text/javascript" src="${static.url('js/vendor/tinymce/js/tinymce/jquery.tinymce.min.js')}"></script>
   <script type="text/javascript">
-	tinyMCE.baseURL = "${settings.STATIC_URL}" + "js/vendor/ova";
+	tinyMCE.baseURL = "${static.url('js/vendor/tinymce/js/tinymce')}";
 (function($) {
     $.fn.myHTMLViewer = function(options) {
         var urlToLoad = null;


### PR DESCRIPTION
Htmlbooks were not updated in https://github.com/edx/edx-platform/pull/3744/files. This PR makes the relevant changes:
1. Adds tinymce.js to the template since it is no longer being included globally.
2. Tokens are no longer fetched via get calls but included in the template in other places where the annotation tool is used and the url to fetch them has been removed (see above PR). So fixes it for this case.
3. Passes storage_url as a token. At the moment there is a hardcoded value which is no longer in service.
4. Right now the tinymce editor is not working in the annotation popup.

Fixes for the first three are needed for the htmlbooks to be at least browsable/readable. Still trying to figure out the cause of 4 but want to get these fixes in for now.

We will verify this on stage manually for now. Tests are in progress.
