### PR TITLE
Lower logging level in grading condition from exception to info

### DIFF
--- a/lms/djangoapps/courseware/grades.py
+++ b/lms/djangoapps/courseware/grades.py
@@ -259,7 +259,7 @@ def _grade(student, request, course, keep_raw_scores):
             if graded_total.possible > 0:
                 format_scores.append(graded_total)
             else:
-                log.exception("Unable to grade a section with a total possible score of zero. " +
+                log.info("Unable to grade a section with a total possible score of zero. " +
                               str(section_descriptor.location))
 
         totaled_scores[section_format] = format_scores


### PR DESCRIPTION
addresses part of LMS-2907

@symbolist 
@ormsbee 

This is causing devops a headache every time they run certificates. This isn't a proper exception, so thought we'd lower the logging down to info. We may not even need the logging at all.
