### PR TITLE
Test PR 3769 (Improves the way LMS serves /favicon.ico)

### DIFF
--- a/common/test/templates/theme-footer.html
+++ b/common/test/templates/theme-footer.html
@@ -1,0 +1,1 @@
+# intentionally left blank

--- a/common/test/templates/theme-google-analytics.html
+++ b/common/test/templates/theme-google-analytics.html
@@ -1,0 +1,1 @@
+# intentionally left blank

--- a/common/test/templates/theme-head-extra.html
+++ b/common/test/templates/theme-head-extra.html
@@ -1,0 +1,1 @@
+# intentionally left blank

--- a/common/test/templates/theme-header.html
+++ b/common/test/templates/theme-header.html
@@ -1,0 +1,1 @@
+# intentionally left blank

--- a/lms/djangoapps/courseware/tests/test_favicon.py
+++ b/lms/djangoapps/courseware/tests/test_favicon.py
@@ -1,0 +1,57 @@
+from django.conf import settings
+from django.core.urlresolvers import clear_url_caches, resolve
+
+from django.test import TestCase
+from django.test.utils import override_settings
+
+from mock import patch
+
+import sys
+
+
+class FaviconTestCase(TestCase):
+
+    def setUp(self):
+        super(FaviconTestCase, self).setUp()
+
+    def test_favicon_redirect(self):
+        resp = self.client.get("/favicon.ico")
+        self.assertEqual(resp.status_code, 301)
+        self.assertRedirects(
+            resp,
+            "/static/images/favicon.ico",
+            status_code=301, target_status_code=404  # @@@ how to avoid 404?
+        )
+
+    @override_settings(FAVICON_PATH="images/foo.ico")
+    def test_favicon_redirect_with_favicon_path_setting(self):
+
+        # for some reason I had to put this inline rather than just using
+        # the UrlResetMixin
+
+        urlconf = settings.ROOT_URLCONF
+        if urlconf in sys.modules:
+            reload(sys.modules[urlconf])
+        clear_url_caches()
+        resolve("/")
+
+        resp = self.client.get("/favicon.ico")
+        self.assertEqual(resp.status_code, 301)
+        self.assertRedirects(
+            resp,
+            "/static/images/foo.ico",
+            status_code=301, target_status_code=404  # @@@ how to avoid 404?
+        )
+
+    @patch.dict("django.conf.settings.FEATURES", {"USE_CUSTOM_THEME": True})
+    @override_settings(THEME_NAME="bar")
+    def test_favicon_redirect_with_theme(self):
+        self.assertEqual(settings.FEATURES["USE_CUSTOM_THEME"], True)
+
+        resp = self.client.get("/favicon.ico")
+        self.assertEqual(resp.status_code, 301)
+        self.assertRedirects(
+            resp,
+            "/static/images/foo.ico",
+            status_code=301, target_status_code=404  # @@@ how to avoid 404?
+        )

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -318,6 +318,12 @@ MICROSITE_CONFIGURATION = {
 MICROSITE_ROOT_DIR = COMMON_ROOT / 'test' / 'test_microsites'
 FEATURES['USE_MICROSITES'] = True
 
+# add extra template directory for test-only templates
+MAKO_TEMPLATES['main'].extend([
+    COMMON_ROOT / 'test' / 'templates'
+])
+
+
 ######### LinkedIn ########
 LINKEDIN_API['COMPANY_ID'] = '0000000'
 


### PR DESCRIPTION
Because this might need a little discussion, I'm making a separate pull request for these tests for #3769 

In particular:
1. is this the best way to have dummy theme templates? (required to test the case where `USE_CUSTOM_THEME` is `True`)
2. is there any way to avoid a 404 on the redirects? It doesn't prevent the tests from doing their job, but it would be nice if the code on redirect was 200 (the issue is that, in testing, `/static/` doesn't serve up static media.
