### PR TITLE
Ndupoux/fixing registration page

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -161,3 +161,4 @@ Daniel Friedman <dfriedman@edx.org>
 Asad Iqbal <aiqbal@edx.org>
 Peter Pinch <pdpinch@mit.edu>
 Muhammad Shoaib <mshoaib@edx.org>
+Nicholas Dupoux <njdupoux1994@gmail.com>

--- a/cms/templates/register.html
+++ b/cms/templates/register.html
@@ -31,9 +31,9 @@
               <input id="email" type="email" name="email" placeholder="e.g. jane.doe@gmail.com" />
             </li>
 
-            <li class="field text required" id="field-password">
-              <label for="password">${_("Password")}</label>
-              <input id="password" type="password" name="password" />
+            <li class="field text required" id="field-name">
+              <label for="name">${_("Full Name")}</label>
+              <input id="name" type="text" name="name" placeholder="e.g. Jane Doe" />
             </li>
 
             <li class="field text required" id="field-username">
@@ -42,9 +42,9 @@
               <span class="tip tip-stacked">${_("This will be used in public discussions with your courses and in our edX101 support forums")}</span>
             </li>
 
-            <li class="field text required" id="field-name">
-              <label for="name">${_("Full Name")}</label>
-              <input id="name" type="text" name="name" placeholder="e.g. Jane Doe" />
+            <li class="field text required" id="field-password">
+              <label for="password">${_("Password")}</label>
+              <input id="password" type="password" name="password" />
             </li>
 
             <li class="field-group">

--- a/common/djangoapps/student/tests/test_password_policy.py
+++ b/common/djangoapps/student/tests/test_password_policy.py
@@ -236,3 +236,39 @@ class TestPasswordPolicy(TestCase):
         self.assertEqual(response.status_code, 200)
         obj = json.loads(response.content)
         self.assertTrue(obj['success'])
+
+
+class TestUsernamePasswordNonmatch(TestCase):
+    """
+    Test that registration username and password fields differ
+    """
+    def setUp(self):
+        super(TestUsernamePasswordNonmatch, self).setUp()
+        self.url = reverse('create_account')
+
+        self.url_params = {
+            'username': 'username',
+            'email': 'foo_bar@bar.com',
+            'name': 'username',
+            'terms_of_service': 'true',
+            'honor_code': 'true',
+        }
+
+    def test_with_username_password_match(self):
+        self.url_params['username'] = "foobar"
+        self.url_params['password'] = "foobar"
+        response = self.client.post(self.url, self.url_params)
+        self.assertEquals(response.status_code, 400)
+        obj = json.loads(response.content)
+        self.assertEqual(
+            obj['value'],
+            "Username and password fields cannot match",
+        )
+
+    def test_with_username_password_nonmatch(self):
+        self.url_params['username'] = "foobar"
+        self.url_params['password'] = "nonmatch"
+        response = self.client.post(self.url, self.url_params)
+        self.assertEquals(response.status_code, 200)
+        obj = json.loads(response.content)
+        self.assertTrue(obj['success'])

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1275,6 +1275,14 @@ def create_account(request, post_override=None):  # pylint: disable-msg=too-many
                 extended_profile = {}
             extended_profile[field] = post_vars[field]
 
+    # Make sure that password and username fields do not match
+    username = post_vars['username']
+    password = post_vars['password']
+    if username == password:
+        js['value'] = _("Username and password fields cannot match")
+        js['field'] = 'username'
+        return JsonResponse(js, status=400)
+
     # Ok, looks like everything is legit.  Create the account.
     try:
         with transaction.commit_on_success():

--- a/lms/templates/register.html
+++ b/lms/templates/register.html
@@ -167,6 +167,17 @@
             <input class="" id="email" type="email" name="email" value="${email}" placeholder="${_('example: username@domain.com')}" required aria-required="true" />
           </li>
 
+          <li class="field required text" id="field-name">
+            <label for="name">${_('Full Name')}</label>
+            <input id="name" type="text" name="name" value="${name}" placeholder="${_('example: Jane Doe')}" required aria-required="true" aria-describedby="name-tip" />
+            <span class="tip tip-input" id="name-tip">${_("Needed for any certificates you may earn")}</span>
+          </li>
+          <li class="field required text" id="field-username">
+            <label for="username">${_('Public Username')}</label>
+            <input id="username" type="text" name="username" value="${username}" placeholder="${_('example: JaneDoe')}" required aria-required="true" aria-describedby="username-tip"/>
+            <span class="tip tip-input" id="username-tip">${_('Will be shown in any discussions or forums you participate in')} <strong>(${_('cannot be changed later')})</strong></span>
+          </li>
+
           % if settings.FEATURES.get('ENABLE_THIRD_PARTY_AUTH') and running_pipeline:
 
           <li class="is-disabled field optional password" id="field-password" hidden>
@@ -182,17 +193,6 @@
           </li>
 
           % endif
-
-          <li class="field required text" id="field-username">
-            <label for="username">${_('Public Username')}</label>
-            <input id="username" type="text" name="username" value="${username}" placeholder="${_('example: JaneDoe')}" required aria-required="true" aria-describedby="username-tip"/>
-            <span class="tip tip-input" id="username-tip">${_('Will be shown in any discussions or forums you participate in')} <strong>(${_('cannot be changed later')})</strong></span>
-          </li>
-          <li class="field required text" id="field-name">
-            <label for="name">${_('Full Name')}</label>
-            <input id="name" type="text" name="name" value="${name}" placeholder="${_('example: Jane Doe')}" required aria-required="true" aria-describedby="name-tip" />
-            <span class="tip tip-input" id="name-tip">${_("Needed for any certificates you may earn")}</span>
-          </li>
         </ol>
 
         % else:


### PR DESCRIPTION
I've edited the user registration page in order to prevent new users from using their password as their public username. 
With the current registration page layout, many users erroneously set their password as their public username, since the username field is directly below the password field. 
To fix this issue, the existing username and real name form fields have been moved above the password field and a password confirmation field has been added. Two simple validations have been added to the create_account handler to make sure that the password and password confirmation fields match and that the password field and username fields do not match when a user submits the registration form. I've also edited existing tests to now incorporate the added password confirmation field. 
@jrbl @jinpa @sarina 
