### PR TITLE
Fix saving error of video editor with non-english translations

### DIFF
--- a/cms/templates/widgets/tabs-aggregator.html
+++ b/cms/templates/widgets/tabs-aggregator.html
@@ -5,7 +5,7 @@
         <span class="component-name"></span>
         <ul class="${'editor-tabs' if (len(tabs) != 1) else 'editor-single-tab-name' }">
         % for tab in tabs:
-            <li class="inner_tab_wrap"><a href="#tab-${html_id}-${loop.index}" class="tab ${'current' if tab.get('current', False) else ''}">${_(tab['name'])}</a></li>
+            <li class="inner_tab_wrap"><a href="#tab-${html_id}-${loop.index}" class="tab ${'current' if tab.get('current', False) else ''}" data-tab_name="${tab['name']}">${_(tab['name'])}</a></li>
         % endfor
         </ul>
       </div>

--- a/common/lib/xmodule/xmodule/js/fixtures/tabs-edit.html
+++ b/common/lib/xmodule/xmodule/js/fixtures/tabs-edit.html
@@ -11,9 +11,9 @@
                             <div class="wrapper-comp-editor" id="editor-tab-id" data-html_id='test_id'>
                                 <div class="edit-header">
                                     <ul class="editor-tabs">
-                                        <li  class="inner_tab_wrap"><a href="#tab-0" class="tab">Tab 0 Editor</a></li>
-                                        <li  class="inner_tab_wrap"><a href="#tab-1" class="tab">Tab 1 Transcripts</a></li>
-                                        <li  class="inner_tab_wrap" id="settings"><a href="#tab-2" class="tab">Tab 2 Settings</a></li>
+                                        <li  class="inner_tab_wrap"><a href="#tab-0" class="tab" data-tab_name="Tab 0 Editor">(Tab 0 Editor)</a></li>
+                                        <li  class="inner_tab_wrap"><a href="#tab-1" class="tab" data-tab_name="Tab 1 Transcripts">(Tab 1 Transcripts)</a></li>
+                                        <li  class="inner_tab_wrap" id="settings"><a href="#tab-2" class="tab" data-tab_name="Tab 2 Settings">(Tab 2 Settings)</a></li>
                                     </ul>
                                 </div>
                                 <div class="tabs-wrapper">

--- a/common/lib/xmodule/xmodule/js/src/tabs/tabs-aggregator.coffee
+++ b/common/lib/xmodule/xmodule/js/src/tabs/tabs-aggregator.coffee
@@ -32,7 +32,7 @@ class @TabsEditingDescriptor
 
       @$tabs.each( (index, value) ->
         if $(value).hasClass('current')
-          previousTab = $(value).html()
+          previousTab = $(value).data('tab_name')
       )
 
       # init and save data from previous tab
@@ -42,7 +42,7 @@ class @TabsEditingDescriptor
       # (to be implemented when there is a use case for this functionality)
 
       # call onswitch
-      onSwitchFunction = TabsEditingDescriptor.Model.modules[@html_id].tabSwitch[$currentTarget.text()]
+      onSwitchFunction = TabsEditingDescriptor.Model.modules[@html_id].tabSwitch[$currentTarget.data('tab_name')]
       onSwitchFunction() if $.isFunction(onSwitchFunction)
 
       @$tabs.removeClass('current')
@@ -59,7 +59,7 @@ class @TabsEditingDescriptor
 
   save: ->
     @element.off('click', '.editor-tabs .tab', @onSwitchEditor)
-    current_tab = @$tabs.filter('.current').html()
+    current_tab = @$tabs.filter('.current').data('tab_name')
     data: TabsEditingDescriptor.Model.getValue(@html_id, current_tab)
 
   setMetadataEditor : (metadataEditor) ->


### PR DESCRIPTION
Currently the code in `tabs-aggregator.coffee` uses the display name of a tab as the key to index the current tab. When a non-english translation is applied, the javascript code will get localized names instead of the original english names, which causes the `getValue` function fails as it cannot reference the correct tab.
Here I use the `data-tab_name` attribute to store the original english tab name, so it can be later used as the index key.
