### PR TITLE
Fix for empty imsx_messageIdentifier

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -168,3 +168,4 @@ Juanan Pereira <juanan.pereira@ehu.es>
 Clinton Blackburn <cblackburn@edx.org>
 Dennis Jen <djen@edx.org>
 Filippo Valsorda <hi@filippo.io>
+Ivica Ceraj <ceraj@mit.edu>

--- a/common/lib/xmodule/xmodule/lti_module.py
+++ b/common/lib/xmodule/xmodule/lti_module.py
@@ -694,7 +694,7 @@ oauth_consumer_key="", oauth_signature="frVp4JuvT1mVXlxktiAUjQ7%2F1cw%3D"'}
         parser = etree.XMLParser(ns_clean=True, recover=True, encoding='utf-8')
         root = etree.fromstring(data, parser=parser)
 
-        imsx_messageIdentifier = root.xpath("//def:imsx_messageIdentifier", namespaces=namespaces)[0].text
+        imsx_messageIdentifier = root.xpath("//def:imsx_messageIdentifier", namespaces=namespaces)[0].text or ''
         sourcedId = root.xpath("//def:sourcedId", namespaces=namespaces)[0].text
         score = root.xpath("//def:textString", namespaces=namespaces)[0].text
         action = root.xpath("//def:imsx_POXBody", namespaces=namespaces)[0].getchildren()[0].tag.replace('{'+lti_spec_namespace+'}', '')


### PR DESCRIPTION
XML parser dereferences <imsx_messageIdentifier/> text value as None. This value is later escaped using SAX escape function without checking if value is a string, thus module throws following exception:
...
 File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/lti_module.py", line 667, in grade_handler
    'imsx_messageIdentifier': escape(imsx_messageIdentifier),
  File "/usr/lib/python2.7/xml/sax/saxutils.py", line 39, in escape
    data = data.replace("&", "&amp;")
AttributeError: 'NoneType' object has no attribute 'replace'
...

This patch ensures value for imsx_messageIdentifier returned from parse_grade_xml_body() is an empty string.
