### PR TITLE
Sjang92/enroll email squashed

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -155,6 +155,6 @@ Johnny Brown <johnnybrown7@gmail.com>
 Ben McMorran <bmcmorran@edx.org>
 Mat Peterson <mpeterson@edx.org>
 Tim Babych <tim.babych@gmail.com>
-Brandon DeRosier <btd@cheesekeg.com>
-Daniel Li <swli@edx.org>
+Se Won Jang <swjang@stanford.edu>
+Brandon DeRosier <btd@cheesekeg.com>Daniel Li <swli@edx.org>
 Daniel Friedman <dfriedman@edx.org>

--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -42,6 +42,8 @@ class CourseDetailsTestCase(CourseTestCase):
         self.assertIsNone(details.syllabus, "syllabus somehow initialized" + str(details.syllabus))
         self.assertIsNone(details.intro_video, "intro_video somehow initialized" + str(details.intro_video))
         self.assertIsNone(details.effort, "effort somehow initialized" + str(details.effort))
+        self.assertFalse(details.enable_enrollment_email, "Enrollment Email should be initialized as false")
+        self.assertTrue(details.enable_default_enrollment_email, "Default Template option for enrollment email should be initialized as true")
 
     def test_encoder(self):
         details = CourseDetails.fetch(self.course.id)

--- a/cms/djangoapps/models/settings/course_details.py
+++ b/cms/djangoapps/models/settings/course_details.py
@@ -24,6 +24,8 @@ class CourseDetails(object):
         self.syllabus = None  # a pdf file asset
         self.short_description = ""
         self.overview = ""  # html to render as the overview
+        self.pre_enrollment_email = ""  # html to render as the pre-enrollment email
+        self.post_enrollment_email = ""  # html to render as the post-enrollment email
         self.intro_video = None  # a video pointer
         self.effort = None  # int hours/week
         self.course_image_name = ""
@@ -59,6 +61,18 @@ class CourseDetails(object):
         temploc = course_key.make_usage_key('about', 'overview')
         try:
             course_details.overview = modulestore().get_item(temploc).data
+        except ItemNotFoundError:
+            pass
+
+        temploc = course_key.make_usage_key('about', 'pre_enrollment_email')
+        try:
+            course.pre_enrollment_email = get_modulestore(temploc).get_item(temploc).data
+        except ItemNotFoundError:
+            pass
+
+        temploc = course_key.make_usage_key('about', 'post_enrollment_email')
+        try:
+            course.post_enrollment_email = get_modulestore(temploc).get_item(temploc).data
         except ItemNotFoundError:
             pass
 
@@ -155,7 +169,7 @@ class CourseDetails(object):
 
         # NOTE: below auto writes to the db w/o verifying that any of the fields actually changed
         # to make faster, could compare against db or could have client send over a list of which fields changed.
-        for about_type in ['syllabus', 'overview', 'effort', 'short_description']:
+        for about_type in ['syllabus', 'overview', 'effort', 'short_description', 'pre_enrollment_email', 'post_enrollment_email']:
             cls.update_about_item(course_key, about_type, jsondict[about_type], descriptor, user)
 
         recomposed_video_tag = CourseDetails.recompose_video_tag(jsondict['intro_video'])

--- a/cms/static/js/models/settings/course_details.js
+++ b/cms/static/js/models/settings/course_details.js
@@ -5,17 +5,18 @@ var CourseDetails = Backbone.Model.extend({
         org : '',
         course_id: '',
         run: '',
-        start_date: null,	// maps to 'start'
-        end_date: null,		// maps to 'end'
+        start_date: null,   // maps to 'start'
+        end_date: null,     // maps to 'end'
         enrollment_start: null,
         enrollment_end: null,
         syllabus: null,
         short_description: "",
         overview: "",
         intro_video: null,
-        effort: null,	// an int or null,
+        effort: null,   // an int or null,
         course_image_name: '', // the filename
-        course_image_asset_path: '' // the full URL (/c4x/org/course/num/asset/filename)
+        course_image_asset_path: '', // the full URL (/c4x/org/course/num/asset/filename)
+        enable_enrollment_email: false
     },
 
     // When init'g from html script, ensure you pass {parse: true} as an option (2nd arg to reset)

--- a/cms/static/js/views/settings/main.js
+++ b/cms/static/js/views/settings/main.js
@@ -13,6 +13,7 @@ var DetailsView = ValidatingView.extend({
         'click .remove-course-introduction-video' : "removeVideo",
         'focus #course-overview' : "codeMirrorize",
         'click #enable-enrollment-email' : "toggleEnrollmentEmails",
+        'click #enable-default-enrollment-email' : "toggleDefaultEnrollmentEmails",
         'focus #pre-enrollment-email' : "codeMirrorize",
         'focus #post-enrollment-email' : "codeMirrorize",
         'mouseover #timezone' : "updateTime",
@@ -43,6 +44,21 @@ var DetailsView = ValidatingView.extend({
         this.listenTo(this.model, 'invalid', this.handleValidationError);
         this.listenTo(this.model, 'change', this.showNotificationBar);
         this.selectorToField = _.invert(this.fieldToSelectorMap);
+
+        /* Memoize html elements for enrollment emails */
+
+        this.pre_enrollment_email_elem = this.$el.find('#' + this.fieldToSelectorMap['pre_enrollment_email']);
+        this.pre_enrollment_email_subject_elem = this.$el.find('#' + this.fieldToSelectorMap['pre_enrollment_email_subject']);
+        this.pre_enrollment_email_field = this.$el.find('#field-pre-enrollment-email');
+        this.pre_enrollment_email_subject_field = this.$el.find('#field-pre-enrollment-email-subject');
+
+        this.post_enrollment_email_elem = this.$el.find('#' + this.fieldToSelectorMap['post_enrollment_email']);
+        this.post_enrollment_email_subject_elem = this.$el.find('#' + this.fieldToSelectorMap['post_enrollment_email_subject']);
+        this.post_enrollment_email_field = this.$el.find('#field-post-enrollment-email');
+        this.post_enrollment_email_subject_field = this.$el.find('#field-post-enrollment-email-subject');
+
+        this.enable_enrollment_email_box = this.$el.find('#' + this.fieldToSelectorMap['enable_enrollment_email'])[0];
+        this.enable_default_enrollment_email_box = this.$el.find('#' + this.fieldToSelectorMap['enable_default_enrollment_email'])[0];
     },
 
     render: function() {
@@ -54,11 +70,30 @@ var DetailsView = ValidatingView.extend({
         this.$el.find('#' + this.fieldToSelectorMap['overview']).val(this.model.get('overview'));
         this.codeMirrorize(null, $('#course-overview')[0]);
 
-        this.$el.find('#' + this.fieldToSelectorMap['pre_enrollment_email']).val(this.model.get('pre_enrollment_email'));
+        this.pre_enrollment_email_subject_elem.val(this.model.get('pre_enrollment_email_subject'));
+        this.post_enrollment_email_subject_elem.val(this.model.get('post_enrollment_email_subject'));
+
+        this.pre_enrollment_email_elem.val(this.model.get('pre_enrollment_email'));
         this.codeMirrorize(null, $('#pre-enrollment-email')[0]);
 
-        this.$el.find('#' + this.fieldToSelectorMap['post_enrollment_email']).val(this.model.get('post_enrollment_email'));
+        this.post_enrollment_email_elem.val(this.model.get('post_enrollment_email'));
         this.codeMirrorize(null, $('#post-enrollment-email')[0]);
+
+        this.enable_enrollment_email_box.checked = this.model.get('enable_enrollment_email');
+
+        this.enable_default_enrollment_email_box.checked = this.model.get('enable_default_enrollment_email');
+
+        if (this.model.get('enable_enrollment_email')) {
+            this.pre_enrollment_email_field.show();
+            this.post_enrollment_email_field.show();
+            this.pre_enrollment_email_subject_field.show();
+            this.post_enrollment_email_subject_field.show();
+        } else {
+            this.pre_enrollment_email_field.hide();
+            this.post_enrollment_email_field.hide();
+            this.pre_enrollment_email_subject_field.hide();
+            this.post_enrollment_email_subject_field.hide();
+        }
 
         this.$el.find('#' + this.fieldToSelectorMap['short_description']).val(this.model.get('short_description'));
 
@@ -88,7 +123,11 @@ var DetailsView = ValidatingView.extend({
         'short_description' : 'course-short-description',
         'intro_video' : 'course-introduction-video',
         'effort' : "course-effort",
-        'course_image_asset_path': 'course-image-url'
+        'course_image_asset_path': 'course-image-url',
+        'enable_enrollment_email': 'enable-enrollment-email',
+        'pre_enrollment_email_subject' :'pre-enrollment-email-subject',
+        'post_enrollment_email_subject':'post-enrollment-email-subject',
+        'enable_default_enrollment_email':'enable-default-enrollment-email'
     },
 
     updateTime : function(e) {
@@ -163,6 +202,12 @@ var DetailsView = ValidatingView.extend({
         case 'course-effort':
             this.setField(event);
             break;
+        case 'pre-enrollment-email-subject':
+            this.setField(event);
+            break; 
+        case 'post-enrollment-email-subject':
+            this.setField(event);
+            break;
         case 'course-short-description':
             this.setField(event);
             break;
@@ -198,13 +243,36 @@ var DetailsView = ValidatingView.extend({
     },
 
     toggleEnrollmentEmails: function(event) {
-        var isChecked = this.$el.find("#enable-enrollment-email").is(':checked');
+        var isChecked = this.enable_enrollment_email_box.checked;
+
         if(isChecked) {
-            this.$el.find('#field-pre-enrollment-email').show();
-            this.$el.find('#field-post-enrollment-email').show();
+            this.pre_enrollment_email_field.show();
+            this.post_enrollment_email_field.show();
+            this.pre_enrollment_email_subject_field.show();
+            this.post_enrollment_email_subject_field.show();
+
         } else {
-            this.$el.find('#field-pre-enrollment-email').hide();
-            this.$el.find('#field-post-enrollment-email').hide();
+            this.pre_enrollment_email_field.hide();
+            this.post_enrollment_email_field.hide();
+            this.pre_enrollment_email_subject_field.hide();
+            this.post_enrollment_email_subject_field.hide();
+
+            /* If enrollment email sending option is turned off, default email option should be turned off as well. */
+            this.enable_default_enrollment_email_box.checked = false;
+            this.setAndValidate(this.selectorToField['enable-default-enrollment-email'], false);
+        }
+
+        var field = this.selectorToField['enable-enrollment-email'];
+        if (this.model.get(field) != isChecked) {
+            this.setAndValidate(field, isChecked);
+        }
+    },
+
+    toggleDefaultEnrollmentEmails: function(event) {
+        var isChecked = this.enable_default_enrollment_email_box.checked;
+        var field = this.selectorToField['enable-default-enrollment-email'];
+        if (this.model.get(field) != isChecked) {
+            this.setAndValidate(field, isChecked);
         }
     },
 

--- a/cms/static/js/views/settings/main.js
+++ b/cms/static/js/views/settings/main.js
@@ -12,6 +12,9 @@ var DetailsView = ValidatingView.extend({
         "change textarea" : "updateModel",
         'click .remove-course-introduction-video' : "removeVideo",
         'focus #course-overview' : "codeMirrorize",
+        'click #enable-enrollment-email' : "toggleEnrollmentEmails",
+        'focus #pre-enrollment-email' : "codeMirrorize",
+        'focus #post-enrollment-email' : "codeMirrorize",
         'mouseover #timezone' : "updateTime",
         // would love to move to a general superclass, but event hashes don't inherit in backbone :-(
         'focus :input' : "inputFocus",
@@ -51,6 +54,12 @@ var DetailsView = ValidatingView.extend({
         this.$el.find('#' + this.fieldToSelectorMap['overview']).val(this.model.get('overview'));
         this.codeMirrorize(null, $('#course-overview')[0]);
 
+        this.$el.find('#' + this.fieldToSelectorMap['pre_enrollment_email']).val(this.model.get('pre_enrollment_email'));
+        this.codeMirrorize(null, $('#pre-enrollment-email')[0]);
+
+        this.$el.find('#' + this.fieldToSelectorMap['post_enrollment_email']).val(this.model.get('post_enrollment_email'));
+        this.codeMirrorize(null, $('#post-enrollment-email')[0]);
+
         this.$el.find('#' + this.fieldToSelectorMap['short_description']).val(this.model.get('short_description'));
 
         this.$el.find('.current-course-introduction-video iframe').attr('src', this.model.videosourceSample());
@@ -74,6 +83,8 @@ var DetailsView = ValidatingView.extend({
         'enrollment_start' : 'enrollment-start',
         'enrollment_end' : 'enrollment-end',
         'overview' : 'course-overview',
+        'pre_enrollment_email' : 'pre-enrollment-email',
+        'post_enrollment_email' : 'post-enrollment-email',
         'short_description' : 'course-short-description',
         'intro_video' : 'course-introduction-video',
         'effort' : "course-effort",
@@ -185,6 +196,18 @@ var DetailsView = ValidatingView.extend({
             this.$el.find('.remove-course-introduction-video').hide();
         }
     },
+
+    toggleEnrollmentEmails: function(event) {
+        var isChecked = this.$el.find("#enable-enrollment-email").is(':checked');
+        if(isChecked) {
+            this.$el.find('#field-pre-enrollment-email').show();
+            this.$el.find('#field-post-enrollment-email').show();
+        } else {
+            this.$el.find('#field-pre-enrollment-email').hide();
+            this.$el.find('#field-post-enrollment-email').hide();
+        }
+    },
+
     codeMirrors : {},
     codeMirrorize: function (e, forcedTarget) {
         var thisTarget;

--- a/cms/static/sass/views/_settings.scss
+++ b/cms/static/sass/views/_settings.scss
@@ -202,6 +202,26 @@
             display: inline-block;
           }
         }
+
+        .list-actions {
+          //box-shadow: inset 0 1px 1px $shadow-l1;
+          //border-top: 1px solid $gray-l2;
+          padding-top:  ($baseline/2);
+          //background: $gray-l5;
+
+          .action-primary {
+            @include blue-button();
+            @extend %t-action3;
+            font-weight: 600;
+
+            [class^="icon-"] {
+              @extend %t-icon5;
+              display: inline-block;
+              vertical-align: middle;
+              margin-top: -3px;
+            }
+          }
+        }
       }
 
       .field-group {
@@ -395,6 +415,32 @@
     #field-course-overview {
 
       #course-overview {
+        height: ($baseline*20);
+      }
+
+      //adds back in CodeMirror border removed due to Unit page styling of component editors
+      .CodeMirror {
+        border: 1px solid $gray-l2;
+      }
+    }
+
+    // specific fields - pre-enrollment email
+    #field-pre-enrollment-email {
+
+      #pre-enrollment-email {
+        height: ($baseline*20);
+      }
+
+      //adds back in CodeMirror border removed due to Unit page styling of component editors
+      .CodeMirror {
+        border: 1px solid $gray-l2;
+      }
+    }
+
+    // specific fields - post-enrollment email
+    #field-post-enrollment-email {
+
+      #post-enrollment-email {
         height: ($baseline*20);
       }
 

--- a/cms/static/sass/views/_settings.scss
+++ b/cms/static/sass/views/_settings.scss
@@ -204,11 +204,8 @@
         }
 
         .list-actions {
-          //box-shadow: inset 0 1px 1px $shadow-l1;
-          //border-top: 1px solid $gray-l2;
           padding-top:  ($baseline/2);
-          //background: $gray-l5;
-
+  
           .action-primary {
             @include blue-button();
             @extend %t-action3;

--- a/cms/templates/settings.html
+++ b/cms/templates/settings.html
@@ -205,7 +205,7 @@ require(["domReady!", "jquery", "js/models/settings/course_details", "js/views/s
               <ol class="list-input">
                 % if short_description_editable:
                 <li class="field text" id="field-course-short-description">
-                  <label for="course-overview">${_("Course Short Description")}</label>
+                  <label for="course-short-description">${_("Course Short Description")}</label>
                   <textarea class="text" id="course-short-description"></textarea>
                   <span class="tip tip-stacked">${_("Appears on the course catalog page when students roll over the course name. Limit to ~150 characters")}</span>
                 </li>
@@ -224,6 +224,38 @@ require(["domReady!", "jquery", "js/models/settings/course_details", "js/views/s
                   <span class="tip tip-stacked">${overview_text()}</span>
                 </li>
                 % endif
+
+                <li class="field text" id="field-enable-enrollment-email">
+                  <input type="checkbox" id="enable-enrollment-email"/>
+                  <label for="enable-enrollment-email">${_("Enable enrollment emails")}</label>
+                </li>
+
+                <li class="field text" id="field-pre-enrollment-email">
+                  <label for="pre-enrollment-email">${_("Email sent to students who enroll before the course starts")}</label>
+                  <textarea class="tinymce text-editor" id="pre-enrollment-email"></textarea>
+                  <span class="tip tip-stacked">${_("This email will be sent to any student who enrolls in the course before its start date")}</span>
+                  <ul class="list-actions">
+                    <li class="action-item">
+                      <a title="${_('Send me a copy of this via email')}"
+                          href="" class="action action-primary">
+                          ${_("Send me a test email")}</a>
+                    </li>
+                  </ul>
+                </li>
+
+                <li class="field text" id="field-post-enrollment-email">
+                  <label for="post-enrollment-email">${_("Email sent to students who enroll after the course starts")}</label>
+                  <textarea class="tinymce text-editor" id="post-enrollment-email"></textarea>
+                  <span class="tip tip-stacked">${_("This email will be sent to any student who enrolls in the course after its start date")}</span>
+                  <ul class="list-actions">
+                    <li class="action-item">
+                      <a title="${_('Send me a copy of this via email')}"
+                          href="" class="action action-primary">
+                          ${_("Send me a test email")}</a>
+                    </li>
+                  </ul>
+                </li>
+
 
                 <li class="field image" id="field-course-image">
                   <label>${_("Course Image")}</label>

--- a/cms/templates/settings.html
+++ b/cms/templates/settings.html
@@ -226,8 +226,19 @@ require(["domReady!", "jquery", "js/models/settings/course_details", "js/views/s
                 % endif
 
                 <li class="field text" id="field-enable-enrollment-email">
+                  <label for="course-email">${_("Course Enrollment Email")}</label>
                   <input type="checkbox" id="enable-enrollment-email"/>
                   <label for="enable-enrollment-email">${_("Enable enrollment emails")}</label>
+                </li>
+
+                <li class="field text" id="field-enable-default-enrollment-email">
+                  <input type="checkbox" id="enable-default-enrollment-email"/>
+                  <label for="enable-enrollment-email">${_("Use default enrollment emails")}</label>
+                </li>
+
+                <li class="field text" id="field-pre-enrollment-email-subject">
+                  <label for="pre-enrollment-email-subject">${_("Subject of the Email sent to students who enroll before the course starts")}</label>
+                  <textarea class = 'text' id="pre-enrollment-email-subject"></textarea>
                 </li>
 
                 <li class="field text" id="field-pre-enrollment-email">
@@ -241,6 +252,10 @@ require(["domReady!", "jquery", "js/models/settings/course_details", "js/views/s
                           ${_("Send me a test email")}</a>
                     </li>
                   </ul>
+                </li>
+                <li class="field text" id="field-post-enrollment-email-subject">
+                  <label for="post-enrollment-email-subject">${_("Subject of the Email sent to students who enroll after the course starts")}</label>
+                  <textarea class = 'text' id="post-enrollment-email-subject"></textarea>
                 </li>
 
                 <li class="field text" id="field-post-enrollment-email">

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -760,6 +760,9 @@ class CourseEnrollment(models.Model):
                may include "audit", "verified_id", etc. Please don't use it
                until we have these mapped out.
 
+        'should_send_email' is a boolean that specifies if a course enrollment 
+        email should be sent to the given user. 
+
         It is expected that this method is called from a method which has already
         verified the user authentication and access.
         """

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -686,6 +686,7 @@ def notify_enrollment_by_email(course, user, request):
 
             else:
 
+                # If not default, use the default emailing template
                 course_url = reverse('info', args=(course.id.to_deprecated_string(),))
                 context = {
                     'course':course,

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -8,6 +8,8 @@ import uuid
 import time
 from collections import defaultdict
 from pytz import UTC
+from pytz import timezone
+import json
 
 from django.conf import settings
 from django.contrib.auth import logout, authenticate, login
@@ -57,7 +59,7 @@ from xmodule.modulestore import ModuleStoreEnum
 
 from collections import namedtuple
 
-from courseware.courses import get_courses, sort_by_announcement
+from courseware.courses import get_courses, sort_by_announcement, get_course_about_section
 from courseware.access import has_access
 
 from django_comment_common.models import Role
@@ -632,7 +634,11 @@ def change_enrollment(request):
 
         current_mode = available_modes[0]
         CourseEnrollment.enroll(user, course.id, mode=current_mode.slug)
-
+        
+        # notify the user of the enrollment via email
+        enrollment_email_result = json.loads(notify_enrollment_by_email(course, user, request).content)
+        if ('is_success' in enrollment_email_result and not enrollment_email_result['is_success']):
+            return HttpResponseBadRequest(_(enrollment_email_result['error']))
         return HttpResponse()
 
     elif action == "add_to_cart":
@@ -655,6 +661,51 @@ def change_enrollment(request):
         return HttpResponse()
     else:
         return HttpResponseBadRequest(_("Enrollment action is invalid"))
+
+def notify_enrollment_by_email(course, user, request):
+    """
+    Updates the user about the course enrollment by email.
+
+    If the Course has already started, use post_enrollment_email
+    If the Course has not yet started, use pre_enrollment_email
+    """
+
+    if (not (settings.FEATURES.get('AUTOMATIC_AUTH_FOR_TESTING')) and course.enable_enrollment_email):
+        from_address = microsite.get_value('email_from_address', settings.DEFAULT_FROM_EMAIL)
+
+        try:
+            if (not course.enable_default_enrollment_email):
+
+                # Check if the course has already started and set subject & message accordingly
+                if (course.has_started):
+                    subject = get_course_about_section(course, 'post_enrollment_email_subject')
+                    message = get_course_about_section(course, 'post_enrollment_email')
+                else:
+                    subject = get_course_about_section(course, 'pre_enrollment_email_subject')
+                    message = get_course_about_section(course, 'pre_enrollment_email')
+
+            else:
+
+                course_url = reverse('info', args=(course.id.to_deprecated_string(),))
+                context = {
+                    'course':course,
+                    'full_name':user.profile.name,
+                    'site_name': microsite.get_value('SITE_NAME', settings.SITE_NAME),
+                    'course_url':request.build_absolute_uri(course_url),
+                }
+                subject = render_to_string('emails/enroll_email_enrolledsubject.txt', context)
+                message = render_to_string('emails/enroll_email_enrolledmessage.txt', context)
+
+            subject = ''.join(subject.splitlines())
+
+            user.email_user(subject, message, from_address)
+        except Exception:
+            log.error('unable to send course enrollment verification email to user from "{from_address}"'.format(
+                        from_address=from_address), exc_info = True)
+            return JsonResponse({"is_success": False, "error": _("Could not send enrollment email to the user"),})
+        return JsonResponse({"is_success": True, "subject": subject, "message": message})
+    else:
+        return JsonResponse({"email_did_fire": False})
 
 
 def _parse_course_id_from_string(input_str):

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -169,6 +169,8 @@ class CourseFields(object):
                              default=[], scope=Scope.content)
 
     wiki_slug = String(help="Slug that points to the wiki for this course", scope=Scope.content)
+    enable_enrollment_email = Boolean(help="Whether to send notification email upon enrollment or not", default=False, scope=Scope.settings)
+    enable_default_enrollment_email = Boolean(help="Whether to use default enrollment email for enrollment notification", default=True, scope=Scope.settings)
     enrollment_start = Date(help="Date that enrollment for this class is opened", scope=Scope.settings)
     enrollment_end = Date(help="Date that enrollment for this class is closed", scope=Scope.settings)
     start = Date(help="Start time when this module is visible",

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -161,6 +161,10 @@ def get_course_about_section(course, section_key):
     - faq
     - more_info
     - ocw_links
+    - pre_enrollment_email
+    - post_enrollment_email
+    - pre_enrollment_email_subject
+    - post_enrollment_email_subject
     """
 
     # Many of these are stored as html files instead of some semantic
@@ -172,7 +176,9 @@ def get_course_about_section(course, section_key):
                        'course_staff_short', 'course_staff_extended',
                        'requirements', 'syllabus', 'textbook', 'faq', 'more_info',
                        'number', 'instructors', 'overview',
-                       'effort', 'end_date', 'prerequisites', 'ocw_links']:
+                       'effort', 'end_date', 'prerequisites', 'ocw_links', 
+                       'pre_enrollment_email', 'post_enrollment_email', 
+                       'pre_enrollment_email_subject', 'post_enrollment_email_subject']:
 
         try:
 


### PR DESCRIPTION
@jrbl @nparlante 

Enrollment Email Feature

From Jane's feature description:

"Students are sometimes confused by the fact that they don't get an email to let them know when they've enrolled in a course.  This feature would have the system send an introductory email that will confirm enrollment.  There will be variants of that email for when they enroll: eg. before the start date or not."
