### PR TITLE
Change 'Course Name' to 'Course Run' in "Schedule & Details" page

### DIFF
--- a/cms/templates/settings.html
+++ b/cms/templates/settings.html
@@ -83,7 +83,7 @@ require(["domReady!", "jquery", "js/models/settings/course_details", "js/views/s
             </li>
 
             <li class="field text is-not-editable" id="field-course-name">
-              <label for="course-name">${_("Course Name")}</label>
+              <label for="course-name">${_("Course Run")}</label>
               <input title="${_('This field is disabled: this information cannot be changed.')}" type="text"
                 class="long" id="course-name" readonly />
             </li>


### PR DESCRIPTION
The code behind uses course run to fill this field, so maybe the filed's name should be changed as well? 

As shown in issue #4010.

@singingwolfboy @nedbat
