### PR TITLE
course_specific_reg/login for OpaqueKeys

### DIFF
--- a/common/djangoapps/external_auth/tests/test_shib.py
+++ b/common/djangoapps/external_auth/tests/test_shib.py
@@ -402,8 +402,8 @@ class ShibSPTest(ModuleStoreTestCase):
                                                     '?course_id=MITx/999/course/Robot_Super_Course' +
                                                     '&enrollment_action=enroll')
 
-            login_response = course_specific_login(login_request, SlashSeparatedCourseKey('MITx', '999', 'Robot_Super_Course'))
-            reg_response = course_specific_register(login_request, SlashSeparatedCourseKey('MITx', '999', 'Robot_Super_Course'))
+            login_response = course_specific_login(login_request, 'MITx/999/Robot_Super_Course')
+            reg_response = course_specific_register(login_request, 'MITx/999/Robot_Super_Course')
 
             if "shib" in domain:
                 self.assertIsInstance(login_response, HttpResponseRedirect)
@@ -437,8 +437,8 @@ class ShibSPTest(ModuleStoreTestCase):
                                                     '?course_id=DNE/DNE/DNE/Robot_Super_Course' +
                                                     '&enrollment_action=enroll')
 
-            login_response = course_specific_login(login_request, SlashSeparatedCourseKey('DNE', 'DNE', 'DNE'))
-            reg_response = course_specific_register(login_request, SlashSeparatedCourseKey('DNE', 'DNE', 'DNE'))
+            login_response = course_specific_login(login_request, 'DNE/DNE/DNE')
+            reg_response = course_specific_register(login_request, 'DNE/DNE/DNE')
 
             self.assertIsInstance(login_response, HttpResponseRedirect)
             self.assertEqual(login_response['Location'],

--- a/common/djangoapps/external_auth/views.py
+++ b/common/djangoapps/external_auth/views.py
@@ -48,6 +48,7 @@ import student.views
 from xmodule.modulestore.django import modulestore
 from xmodule.course_module import CourseDescriptor
 from xmodule.modulestore.exceptions import ItemNotFoundError
+from opaque_keys.edx.locations import SlashSeparatedCourseKey
 
 log = logging.getLogger("edx.external_auth")
 AUDIT_LOG = logging.getLogger("audit")
@@ -588,7 +589,8 @@ def course_specific_login(request, course_id):
        Dispatcher function for selecting the specific login method
        required by the course
     """
-    course = modulestore().get_course(course_id)
+    course_key = SlashSeparatedCourseKey.from_deprecated_string(course_id)
+    course = modulestore().get_course(course_key)
     if not course:
         # couldn't find the course, will just return vanilla signin page
         return redirect_with_get('signin_user', request.GET)
@@ -606,7 +608,8 @@ def course_specific_register(request, course_id):
         Dispatcher function for selecting the specific registration method
         required by the course
     """
-    course = modulestore().get_course(course_id)
+    course_key = SlashSeparatedCourseKey.from_deprecated_string(course_id)
+    course = modulestore().get_course(course_key)
 
     if not course:
         # couldn't find the course, will just return vanilla registration page

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -708,7 +708,7 @@ def accounts_login(request):
     if redirect_to:
         course_id = _parse_course_id_from_string(redirect_to)
         if course_id and _get_course_enrollment_domain(course_id):
-            return external_auth.views.course_specific_login(request, course_id)
+            return external_auth.views.course_specific_login(request, course_id.to_deprecated_string())
 
     context = {
         'pipeline_running': 'false',


### PR DESCRIPTION
This is to push a hotfix we made back upstream to edx master.

@singingwolfboy please assign code reviewers

The `course_id` argument to both `course_specific_register` and `course_specific_login` need to be strings, not `SlashSeparatedCourseKey`s, because both those functions can be involved via URL dispatch.  From lms/urls.py:

```
    urlpatterns += (
        url(r'^course_specific_login/(?P<course_id>[^/]+/[^/]+/[^/]+)/$',
            'external_auth.views.course_specific_login', name='course-specific-login'),
        url(r'^course_specific_register/(?P<course_id>[^/]+/[^/]+/[^/]+)/$',
            'external_auth.views.course_specific_register', name='course-specific-register'),

    )
```
