### PR TITLE
ORA2 release-2014-06-30T13.39

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -26,7 +26,7 @@
 -e git+https://github.com/edx/bok-choy.git@82b4e82d79b9d4c6d087ebbfa26ea23235728e62#egg=bok_choy
 -e git+https://github.com/edx-solutions/django-splash.git@9965a53c269666a30bb4e2b3f6037c138aef2a55#egg=django-splash
 -e git+https://github.com/edx/acid-block.git@459aff7b63db8f2c5decd1755706c1a64fb4ebb1#egg=acid-xblock
--e git+https://github.com/edx/edx-ora2.git@release-2014-06-23T13.19#egg=edx-ora2
+-e git+https://github.com/edx/edx-ora2.git@release-2014-06-30T13.39#egg=edx-ora2
 -e git+https://github.com/edx/opaque-keys.git@5929789900b3d0a354ce7274bde74edfd0430f03#egg=opaque-keys
--e git+https://github.com/edx/ease.git@97de68448e5495385ba043d3091f570a699d5b5f#egg=ease
+-e git+https://github.com/edx/ease.git@f9f47fb6b5c7c8b6c3360efa72eb56561e1a03b0#egg=ease
 -e git+https://github.com/edx/i18n-tools.git@f5303e82dff368c7595884d9325aeea1d802da25#egg=i18n-tools


### PR DESCRIPTION
Also bumps EASE to bump NLTK to version 2.0.4 (from 2.0.3).  This should resolve a version conflict with edx-platform.

@stephensanchez I don't think we need any other changes this week (settings, etc.), right?
