### PR TITLE
Fix filter with new opaque key, allowing user to set COURSE_LISTING as o...

### DIFF
--- a/lms/djangoapps/branding/__init__.py
+++ b/lms/djangoapps/branding/__init__.py
@@ -2,8 +2,8 @@ from xmodule.modulestore.django import modulestore
 from xmodule.course_module import CourseDescriptor
 from django.conf import settings
 
+from opaque_keys.edx.locations import SlashSeparatedCourseKey
 from microsite_configuration import microsite
-
 
 def get_visible_courses():
     """
@@ -22,7 +22,7 @@ def get_visible_courses():
 
     # this is legacy format which is outside of the microsite feature -- also handle dev case, which should not filter
     if hasattr(settings, 'COURSE_LISTINGS') and subdomain in settings.COURSE_LISTINGS and not settings.DEBUG:
-        filtered_visible_ids = frozenset(settings.COURSE_LISTINGS[subdomain])
+        filtered_visible_ids = frozenset([SlashSeparatedCourseKey.from_deprecated_string(c) for c in settings.COURSE_LISTINGS[subdomain]])
 
     filtered_by_org = microsite.get_value('course_org_filter')
 


### PR DESCRIPTION
...ld way path

Alllow settings as: 
COURSE_LISTINGS = {
    'default': ['BerkeleyX/CS169.1x/2012_Fall',
                'BerkeleyX/CS188.1x/2012_Fall',
                'HarvardX/CS50x/2012',
                'HarvardX/PH207x/2012_Fall',
                'MITx/3.091x/2012_Fall',
                'MITx/6.002x/2012_Fall',
                'MITx/6.00x/2012_Fall'],
    'berkeley': ['BerkeleyX/CS169/fa12',
                 'BerkeleyX/CS188/fa12'],
    'harvard': ['HarvardX/CS50x/2012H'],
    'mit': ['MITx/3.091/MIT_2012_Fall'],
    'sjsu': ['MITx/6.002x-EE98/2012_Fall_SJSU'],
}

and filter course correctly with new opaque key
