### PR TITLE
Disable sending activation email also when doing external_auth and setti...

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1316,8 +1316,13 @@ def create_account(request, post_override=None):  # pylint: disable-msg=too-many
     subject = ''.join(subject.splitlines())
     message = render_to_string('emails/activation_email.txt', context)
 
-    # don't send email if we are doing load testing or random user generation for some reason
-    if not (settings.FEATURES.get('AUTOMATIC_AUTH_FOR_TESTING')):
+    # don't send email if we are doing load testing or random user generation for some reason 
+    # or external auth with bypass activated
+    send_email = (
+        not settings.FEATURES.get('AUTOMATIC_AUTH_FOR_TESTING') and
+        not (DoExternalAuth and settings.FEATURES.get('BYPASS_ACTIVATION_EMAIL_FOR_EXTAUTH'))
+    )
+    if send_email:
         from_address = microsite.get_value(
             'email_from_address',
             settings.DEFAULT_FROM_EMAIL


### PR DESCRIPTION
...ng BYPASS_ACTIVATION_EMAIL_FOR_EXTAUTH=True

Sorry for this....it was a previous PR with some discussions, but wrong branch and I was forced to clean my master branch
