### PR TITLE
Update boto to 2.30.0

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -8,7 +8,7 @@ beautifulsoup4==4.1.3
 beautifulsoup==3.2.1
 bleach==1.4
 html5lib==0.999
-boto==2.13.3
+boto==2.30.0
 celery==3.0.19
 dealer==0.2.3
 distribute>=0.6.28, <0.7

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -27,7 +27,7 @@
 -e git+https://github.com/edx/bok-choy.git@821d3b0ac742c204a93d802a8732be024a0bce22#egg=bok_choy
 -e git+https://github.com/edx-solutions/django-splash.git@9965a53c269666a30bb4e2b3f6037c138aef2a55#egg=django-splash
 -e git+https://github.com/edx/acid-block.git@459aff7b63db8f2c5decd1755706c1a64fb4ebb1#egg=acid-xblock
--e git+https://github.com/edx/edx-ora2.git@release-2014-07-28T12.09#egg=edx-ora2
+-e git+https://github.com/singingwolfboy/edx-ora2.git@db/update-boto#egg=edx-ora2
 -e git+https://github.com/edx/opaque-keys.git@454bd984d9539550c6290020e92ee2d6094038d0#egg=opaque-keys
 -e git+https://github.com/edx/ease.git@97de68448e5495385ba043d3091f570a699d5b5f#egg=ease
 -e git+https://github.com/edx/i18n-tools.git@f5303e82dff368c7595884d9325aeea1d802da25#egg=i18n-tools


### PR DESCRIPTION
Just to keep us on the upgrade treadmill. Looks like the configuration repo is already on boto 2.29.1.
