### PR TITLE
Update mako to 1.0.1

### DIFF
--- a/docs/shared/requirements.txt
+++ b/docs/shared/requirements.txt
@@ -15,7 +15,6 @@ django-filter==0.6.0
 django-followit==0.0.3
 django-keyedcache==1.4-6
 django-kombu==0.9.4
-django-mako==0.1.5pre
 django-masquerade==0.1.6
 django-mptt==0.5.5
 django-openid-auth==0.4

--- a/docs/shared/requirements.txt
+++ b/docs/shared/requirements.txt
@@ -35,7 +35,7 @@ git+https://github.com/pmitros/pyfs.git@96e1922348bfe6d99201b9512a9ed946c87b7e0b
 GitPython==0.3.2.RC1
 glob2==0.3
 lxml==3.3.6
-mako==0.7.3
+mako==1.0.1
 Markdown==2.2.1
 mock==1.0.1
 networkx==1.7

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -22,7 +22,6 @@ django-filter==0.6.0
 django-followit==0.0.3
 django-keyedcache==1.4-6
 django-kombu==0.9.4
-django-mako==0.1.5pre
 django-model-utils==1.4.0
 django-masquerade==0.1.6
 django-mptt==0.5.5

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -49,7 +49,7 @@ gunicorn==0.17.4
 httpretty==0.8.3
 lazy==1.1
 lxml==3.3.6
-mako==0.9.1
+mako==1.0.1
 Markdown==2.2.1
 --allow-external meliae
 --allow-unverified meliae


### PR DESCRIPTION
Just to keep us on the upgrade treadmill. Changelog is here: http://docs.makotemplates.org/en/latest/changelog.html#id1

The risk of this pull request is that we use Mako for nearly all of our templates. We should have automated tests that cover all of our pages, and if there's a failure with Mako, it would probably result in a render failure that the automated tests would catch (as opposed to a subtly different output). However, our automated tests probably don't cover every permutation of every set of template variables that could be passed to Mako, and there is the small change of subtly different output, so it would be a good idea to have the manual test team take a spin through the CMS and LMS as part of the testing process for this PR, to be sure that nothing is obviously broken.
