### PR TITLE
Update Markdown to 2.6.1

### DIFF
--- a/docs/shared/requirements.txt
+++ b/docs/shared/requirements.txt
@@ -36,7 +36,7 @@ GitPython==0.3.2.RC1
 glob2==0.3
 lxml==3.3.6
 mako==0.7.3
-Markdown==2.2.1
+Markdown==2.6.1
 mock==1.0.1
 networkx==1.7
 nltk==2.0.4

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -50,7 +50,7 @@ httpretty==0.8.3
 lazy==1.1
 lxml==3.3.6
 mako==0.9.1
-Markdown==2.2.1
+Markdown==2.6.1
 --allow-external meliae
 --allow-unverified meliae
 meliae==0.4.0

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -9,7 +9,7 @@
 # Third-party:
 -e git+https://github.com/edx/django-staticfiles.git@d89aae2a82f2b#egg=django-staticfiles
 -e git+https://github.com/edx/django-pipeline.git@88ec8a011e481918fdc9d2682d4017c835acd8be#egg=django-pipeline
--e git+https://github.com/edx/django-wiki.git@cd0b2b31997afccde519fe5b3365e61a9edb143f#egg=django-wiki
+-e git+https://github.com/edx/django-wiki.git@67fe4d99b2327ae500e9da120b53d836ca9f7b6b#egg=django-wiki
 -e git+https://github.com/edx/django-oauth2-provider.git@0.2.7-fork-edx-2#egg=django-oauth2-provider
 -e git+https://github.com/clytwynec/flaky.git@clytwynec/fix-false-success-results#egg=flaky
 -e git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=mongodb_proxy


### PR DESCRIPTION
Just to keep us on the upgrade treadmill. [OSPR-79](https://openedx.atlassian.net/browse/OSPR-79)
- [Release Notes for v2.3](http://pythonhosted.org/Markdown/release-2.3.html)
- [Release Notes for v2.4](http://pythonhosted.org/Markdown/release-2.4.html)
- [Release Notes for v2.5](http://pythonhosted.org/Markdown/release-2.5.html)
- [Release Notes for v2.6](http://pythonhosted.org/Markdown/release-2.6.html)
