### PR TITLE
Fixed urlpatterns regex for support views in dashboard app.

### DIFF
--- a/lms/urls.py
+++ b/lms/urls.py
@@ -99,7 +99,7 @@ if settings.FEATURES["ENABLE_SYSADMIN_DASHBOARD"]:
     )
 
 urlpatterns += (
-    url(r'support/', include('dashboard.support_urls')),
+    url(r'^support/', include('dashboard.support_urls')),
 )
 
 #Semi-static views (these need to be rendered and have the login bar, but don't change)


### PR DESCRIPTION
Currently urls ending in 'support' show the support page.

LMS-6634
