### PR TITLE
Misuse of 'gettext' in mako templates

### DIFF
--- a/cms/templates/settings_advanced.html
+++ b/cms/templates/settings_advanced.html
@@ -40,12 +40,12 @@ require(["domReady!", "jquery", "gettext", "js/models/settings/advanced", "js/vi
       var deprecatedSettingsLabel = $('.deprecated-settings-label');
       if ($this.is(':checked')) {
           wrapperDeprecatedSetting.addClass('is-set');
-          deprecatedSettingsLabel.text(gettext('Hide Deprecated Settings'));
+          deprecatedSettingsLabel.text('${_('Hide Deprecated Settings')}');
           editor.render_deprecated = true;
       }
       else {
           wrapperDeprecatedSetting.removeClass('is-set');
-          deprecatedSettingsLabel.text(gettext('Show Deprecated Settings'));
+          deprecatedSettingsLabel.text('${_('Show Deprecated Settings')}');
           editor.render_deprecated = false;
       }
 


### PR DESCRIPTION
To translate strings in mako templates, the pattern of `${_()}` should be used instead of `gettext` even if the strings to be translated is located in a `script` block.
