### PR TITLE
Make the strings in "Advanced Settings" page localizable

### DIFF
--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -45,8 +45,8 @@ class CourseMetadata(object):
 
             result[field.name] = {
                 'value': field.read_json(descriptor),
-                'display_name': field.display_name,
-                'help': field.help,
+                'display_name': _(field.display_name),
+                'help': _(field.help),
                 'deprecated': field.runtime_options.get('deprecated', False)
             }
 


### PR DESCRIPTION
The fields should be translated before render into html templates.
