### PR TITLE
Check if user is anonymous before calling PSYCHOMETRICS

### DIFF
--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -512,8 +512,7 @@ def get_module_system_for_user(user, field_data_cache,
             position = None
 
     system.set('position', position)
-
-    if settings.FEATURES.get('ENABLE_PSYCHOMETRICS'):
+    if settings.FEATURES.get('ENABLE_PSYCHOMETRICS') and user.is_authenticated():
         system.set(
             'psychometrics_handler',  # set callback for updating PsychometricsData
             make_psychometrics_data_update_handler(course_id, user, descriptor.location)

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -998,3 +998,14 @@ class TestRebindModule(TestSubmittingProblems):
         self.assertEqual(module.system.anonymous_student_id, anonymous_id_for_user(user2, self.course.id))
         self.assertEqual(module.scope_ids.user_id, user2.id)
         self.assertEqual(module.descriptor.scope_ids.user_id, user2.id)
+
+    @patch('courseware.module_render.make_psychometrics_data_update_handler')
+    @patch.dict(settings.FEATURES, {'ENABLE_PSYCHOMETRICS': True})
+    def test_psychometrics_anonymous(self, psycho_handler):
+        """
+        Make sure that noauth modules with anonymous users don't have
+        the psychometrics callback bound.
+        """
+        module = self.get_module_for_user(self.anon_user)
+        module.system.rebind_noauth_module_to_user(module, self.anon_user)
+        self.assertFalse(psycho_handler.called)


### PR DESCRIPTION
LTI grade callbacks for example, come in with an anonymous user.  This causes a
stack trace in the psychometrics app that leads to the LTI service
getting a 404 when trying to grade.  This adds a check before that callback gets registered.
