### PR TITLE
Use deprecated course_key when calling the analytics API.

### DIFF
--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -285,7 +285,7 @@ def _update_active_students(course_key, section_data):
 
     try:
         client = RestClient(base_url=base_url, auth_token=auth_token)
-        course = Course(client, course_key)
+        course = Course(client, course_key.to_deprecated_string())
 
         section_data['active_student_count'] = course.recent_active_user_count['count']
 


### PR DESCRIPTION
Previously it was serializing the course_key directly, which is not
interpreted correctly by the API.
