### PR TITLE
Increase the test SQLite DB timeout. TE-397

### DIFF
--- a/cms/envs/acceptance.py
+++ b/cms/envs/acceptance.py
@@ -67,7 +67,10 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
         'NAME': TEST_ROOT / "db" / "test_edx.db",
-        'TEST_NAME': TEST_ROOT / "db" / "test_edx.db"
+        'TEST_NAME': TEST_ROOT / "db" / "test_edx.db",
+        'OPTIONS': {
+            'timeout': 30,
+        },
     }
 }
 

--- a/lms/envs/acceptance.py
+++ b/lms/envs/acceptance.py
@@ -58,6 +58,9 @@ DATABASES = {
         'ENGINE': 'django.db.backends.sqlite3',
         'NAME': TEST_ROOT / "db" / "test_edx.db",
         'TEST_NAME': TEST_ROOT / "db" / "test_edx.db",
+        'OPTIONS': {
+            'timeout': 30,
+        },
     }
 }
 


### PR DESCRIPTION
See notes in TE-397 for examples of failures on jenkins, and https://docs.djangoproject.com/en/dev/ref/databases/#database-is-locked-errors for timeout info.

@clytwynec @benpatterson 
