### PR TITLE
Add width and height to look right in all browsers

### DIFF
--- a/lms/templates/footer.html
+++ b/lms/templates/footer.html
@@ -65,11 +65,11 @@
       <p>
         <a href="http://openedx.org/">
           ## standard powered-by logo
-          <img src="https://s3.amazonaws.com/files.edx.org/openedx-logos/edx-openedx-logo-tag.png" alt="Powered by Open edX" />
+          <img src="https://s3.amazonaws.com/files.edx.org/openedx-logos/edx-openedx-logo-tag.png" alt="Powered by Open edX" width="150" height="50" />
           ## greyscale logo for dark background
-          ## <img src="https://s3.amazonaws.com/files.edx.org/openedx-logos/edx-openedx-logo-tag-light.png" alt="Powered by Open edX" />
+          ## <img src="https://s3.amazonaws.com/files.edx.org/openedx-logos/edx-openedx-logo-tag-light.png" alt="Powered by Open edX" width="150" height="50" />
           ## greyscale logo for light background
-          ## <img src="https://s3.amazonaws.com/files.edx.org/openedx-logos/edx-openedx-logo-tag-dark.png" alt="Powered by Open edX" />
+          ## <img src="https://s3.amazonaws.com/files.edx.org/openedx-logos/edx-openedx-logo-tag-dark.png" alt="Powered by Open edX" width="150" height="50" />
         </a>
       </p>
     </div>


### PR DESCRIPTION
Bertrand asked for retina-scaled logos, so I replaced the S3 images with 2x-scaled versions.  To look right, we need the width and height, which is a good practice anyway.
