### PR TITLE
Dan f/display name validation

### DIFF
--- a/cms/static/js/views/xblock_string_field_editor.js
+++ b/cms/static/js/views/xblock_string_field_editor.js
@@ -68,11 +68,20 @@ define(["jquery", "gettext", "js/views/baseview"],
                 this.getInput().addClass('is-hidden');
             },
 
+            cancelInput: function() {
+                this.getInput().val(this.model.get(this.fieldName));
+                this.hideInput();
+            },
+
             updateField: function() {
                 var xblockInfo = this.model,
-                    newValue = this.getInput().val(),
-                    requestData = this.createUpdateRequestData(newValue),
-                    fieldName = this.fieldName;
+                    newValue = this.getInput().val().trim(),
+                    oldValue = xblockInfo.get(this.fieldName),
+                    requestData = this.createUpdateRequestData(newValue);
+                if (newValue === '' || newValue === oldValue) {
+                    this.cancelInput();
+                    return;
+                }
                 this.runOperationShowingMessage(gettext('Saving&hellip;'),
                     function() {
                         return xblockInfo.save(requestData);
@@ -92,8 +101,7 @@ define(["jquery", "gettext", "js/views/baseview"],
 
             handleKeyUp: function(event) {
                 if (event.keyCode === 27) {   // Revert the changes if the user hits escape
-                    this.getInput().val(this.model.get(this.fieldName));
-                    this.hideInput();
+                    this.cancelInput();
                 }
             }
         });


### PR DESCRIPTION
This PR primarily fixes a bug in the Backbone xblock string field editor view which allowed users to enter the empty string as a valid field name, resulting in a broken UI. It more generally handles whitespace issues by trimming input before attempting to save it.

Please let me know if I'm following best practices. For example, in `updateField`, is it OK to return from the if, or would it  be better to wrap the `this.runOperationShowingMessage` in an else? How about the one-time-use `oldValue`?

@cahrens @andy-armstrong 
