### PR TITLE
Removing unused import

### DIFF
--- a/common/test/acceptance/pages/xblock/utils.py
+++ b/common/test/acceptance/pages/xblock/utils.py
@@ -2,8 +2,6 @@
 Utility methods useful for XBlock page tests.
 """
 from bok_choy.promise import Promise
-from selenium.webdriver.common.action_chains import ActionChains
-
 
 def wait_for_xblock_initialization(page, xblock_css):
     """


### PR DESCRIPTION
Removed unused ActionChains import as part of the plan to remove ActionChains from bokchoy test
