### PR TITLE
Fix quotation mark & apostrophe related i18n bug

### DIFF
--- a/cms/templates/settings_advanced.html
+++ b/cms/templates/settings_advanced.html
@@ -4,6 +4,7 @@
 <%!
   from django.utils.translation import ugettext as _
   from contentstore import utils
+  from django.utils.html import escapejs
 %>
 <%block name="title">${_("Advanced Settings")}</%block>
 <%block name="bodyclass">is-signedin course advanced view-settings</%block>
@@ -40,12 +41,12 @@ require(["domReady!", "jquery", "gettext", "js/models/settings/advanced", "js/vi
       var deprecatedSettingsLabel = $('.deprecated-settings-label');
       if ($this.is(':checked')) {
           wrapperDeprecatedSetting.addClass('is-set');
-          deprecatedSettingsLabel.text('${_('Hide Deprecated Settings') | h}');
+          deprecatedSettingsLabel.text('${escapejs(_('Hide Deprecated Settings'))}');
           editor.render_deprecated = true;
       }
       else {
           wrapperDeprecatedSetting.removeClass('is-set');
-          deprecatedSettingsLabel.text('${_('Show Deprecated Settings') | h}');
+          deprecatedSettingsLabel.text('${escapejs(_('Show Deprecated Settings'))}');
           editor.render_deprecated = false;
       }
 


### PR DESCRIPTION
Output HTML escaped localized text is not good, as Javascript does not handle HTML escaped strings and the escaped strings will be displayed in their raw format. So the fix in #4345 only makes the string does not break Javascript code, but cannot actually solve the problem introduced by #4282.
