### PR TITLE
Fix bug in inline discussion post creation

### DIFF
--- a/common/static/coffee/src/discussion/discussion_module_view.coffee
+++ b/common/static/coffee/src/discussion/discussion_module_view.coffee
@@ -107,7 +107,8 @@ if Backbone?
       @newPostView = new NewPostView(
         el: @newPostForm,
         collection: @discussion,
-        course_settings: @course_settings
+        course_settings: @course_settings,
+        topicId: discussionId
       )
       @newPostView.render()
       @discussion.on "add", @addThread

--- a/common/static/coffee/src/discussion/views/new_post_view.coffee
+++ b/common/static/coffee/src/discussion/views/new_post_view.coffee
@@ -7,6 +7,7 @@ if Backbone?
               throw new Error("invalid mode: " + @mode)
           @course_settings = options.course_settings
           @maxNameWidth = 100
+          @topicId = options.topicId
 
       render: () ->
           if @mode is "tab"


### PR DESCRIPTION
Commit 994ccd1 contained a bug that caused new posts created via the
courseware interface to not get posted to the correct topic. They would
appear to work but would actually be posted to the "undefined" topic.
This has now been fixed.

JIRA: FOR-154

@adampalay 
