### PR TITLE
Fix lettuce tests for course outline page [STUD-1961]

### DIFF
--- a/cms/djangoapps/contentstore/features/common.py
+++ b/cms/djangoapps/contentstore/features/common.py
@@ -182,9 +182,10 @@ def create_a_course():
     assert_true(world.is_css_present(course_title_css))
 
 
-def add_section(name='My Section'):
+def add_section(name=None):
     world.css_click('.course-outline .add-button')
-    set_element_value('.xblock-field-input', name, Keys.ENTER)
+    if name is not None:
+        set_element_value('.xblock-field-input', name, Keys.ENTER)
     assert_true(world.is_css_present('.outline-item-section .xblock-field-value'))
 
 

--- a/cms/djangoapps/contentstore/features/course-outline.feature
+++ b/cms/djangoapps/contentstore/features/course-outline.feature
@@ -22,12 +22,12 @@ Feature: CMS.Course Outline
         Then I see the "Collapse All Sections" link
         And all sections are expanded
 
-    Scenario: Collapse link is not removed after last section of a course is deleted
+    Scenario: Collapse link is removed after last section of a course is deleted
         Given I have a course with 1 section
         And I navigate to the course outline page
-        When I will confirm all alerts
         And I press the "section" delete icon
-        Then I see the "Collapse All Sections" link
+        When I will confirm all alerts
+        Then I do not see the "Collapse All Sections" link
 
     Scenario: Collapsing all sections when all sections are expanded
         Given I navigate to the outline page of a course with multiple sections

--- a/cms/djangoapps/contentstore/features/course-outline.py
+++ b/cms/djangoapps/contentstore/features/course-outline.py
@@ -64,59 +64,67 @@ def nav_to_the_outline_page_of_a_course_with_multiple_sections(step):
 
 @step(u'I add a section')
 def i_add_a_section(step):
-    add_section(name='My New Section That I Just Added')
+    add_section()
 
 
-@step(u'I click the "([^"]*)" link$')
-def i_click_the_text_span(step, text):
-    span_locator = '.toggle-button-sections span'
-    assert_true(world.browser.is_element_present_by_css(span_locator))
-    # first make sure that the expand/collapse text is the one you expected
-    assert_true(world.css_has_value(span_locator, text))
-    world.css_click(span_locator)
+@step(u'I press the "section" delete icon')
+def i_press_the_section_delete_icon(step):
+    delete_locator = 'section .outline-item-section > .wrapper-xblock-header a.delete-button'
+    world.css_click(delete_locator)
 
 
-@step(u'I collapse the first section$')
-def i_collapse_a_section(step):
-    collapse_locator = 'section.outline-section a.collapse'
-    world.css_click(collapse_locator)
+@step(u'I will confirm all alerts')
+def i_confirm_all_alerts(step):
+    confirm_locator = '.prompt .nav-actions a.action-primary'
+    world.css_click(confirm_locator)
 
 
-@step(u'I expand the first section$')
-def i_expand_a_section(step):
-    expand_locator = 'section.outline-section a.expand'
-    world.css_click(expand_locator)
-
-
-@step(u'I see the "([^"]*)" link$')
-def i_see_the_span_with_text(step, text):
-    span_locator = '.toggle-button-sections span'
-    assert_true(world.css_has_value(span_locator, text))
+@step(u'I see the "([^"]*) All Sections" link$')
+def i_see_the_collapse_expand_all_span(step, text):
+    if text == "Collapse":
+        span_locator = '.toggle-button-expand-collapse .collapse-all .label'
+    elif text == "Expand":
+        span_locator = '.toggle-button-expand-collapse .expand-all .label'
     assert_true(world.css_visible(span_locator))
 
 
-@step(u'I do not see the "([^"]*)" link$')
-def i_do_not_see_the_span_with_text(step, text):
-    # Note that the span will exist on the page but not be visible
-    span_locator = '.toggle-button-sections span'
-    assert_true(world.is_css_present(span_locator))
+@step(u'I do not see the "([^"]*) All Sections" link$')
+def i_do_not_see_the_collapse_expand_all_span(step, text):
+    if text == "Collapse":
+        span_locator = '.toggle-button-expand-collapse .collapse-all .label'
+    elif text == "Expand":
+        span_locator = '.toggle-button-expand-collapse .expand-all .label'
     assert_false(world.css_visible(span_locator))
 
 
-@step(u'all sections are expanded$')
-def all_sections_are_expanded(step):
+@step(u'I click the "([^"]*) All Sections" link$')
+def i_click_the_collapse_expand_all_span(step, text):
+    if text == "Collapse":
+        span_locator = '.toggle-button-expand-collapse .collapse-all .label'
+    elif text == "Expand":
+        span_locator = '.toggle-button-expand-collapse .expand-all .label'
+    assert_true(world.browser.is_element_present_by_css(span_locator))
+    world.css_click(span_locator)
+
+
+@step(u'I ([^"]*) the first section$')
+def i_collapse_expand_a_section(step, text):
+    if text == "collapse":
+        locator = 'section .outline-item-section .ui-toggle-expansion'
+    elif text == "expand":
+        locator = 'section .outline-item-section .ui-toggle-expansion'
+    world.css_click(locator)
+
+
+@step(u'all sections are ([^"]*)$')
+def all_sections_are_collapsed_or_expanded(step, text):
     subsection_locator = 'div.subsection-list'
     subsections = world.css_find(subsection_locator)
     for index in range(len(subsections)):
-        assert_true(world.css_visible(subsection_locator, index=index))
-
-
-@step(u'all sections are collapsed$')
-def all_sections_are_collapsed(step):
-    subsection_locator = 'div.subsection-list'
-    subsections = world.css_find(subsection_locator)
-    for index in range(len(subsections)):
-        assert_false(world.css_visible(subsection_locator, index=index))
+        if text == "collapsed":
+            assert_false(world.css_visible(subsection_locator, index=index))
+        elif text == "expanded":
+            assert_true(world.css_visible(subsection_locator, index=index))
 
 
 @step(u"I change an assignment's grading status")

--- a/cms/static/js/views/pages/course_outline.js
+++ b/cms/static/js/views/pages/course_outline.js
@@ -17,9 +17,21 @@ define(["jquery", "underscore", "gettext", "js/views/pages/base_page", "js/views
                 this.$('.add-button').click(function(event) {
                     self.outlineView.handleAddEvent(event);
                 });
+                this.model.on('change', this.setCollapseExpandVisibility, this);
+            },
+
+            setCollapseExpandVisibility: function() {
+                var has_content = this.hasContent(),
+                    collapseExpandButton = $('.toggle-button-expand-collapse');
+                if (has_content) {
+                    collapseExpandButton.show();
+                } else {
+                    collapseExpandButton.hide();
+                }
             },
 
             renderPage: function() {
+                this.setCollapseExpandVisibility();
                 this.outlineView = new CourseOutlineView({
                     el: this.$('.course-outline'),
                     model: this.model,

--- a/cms/templates/course_outline.html
+++ b/cms/templates/course_outline.html
@@ -46,7 +46,7 @@ from contentstore.utils import reverse_usage_url
             <h3 class="sr">${_("Page Actions")}</h3>
             <ul>
                 <li class="nav-item">
-                    <a href="#" class="toggle-button toggle-button-expand-collapse collapse-all">
+                    <a href="#" class="toggle-button toggle-button-expand-collapse collapse-all is-hidden">
                         <span class="collapse-all"><i class="icon-arrow-up"></i> <span class="label">${_("Collapse All Sections")}</span></span>
                         <span class="expand-all"><i class="icon-arrow-down"></i> <span class="label">${_("Expand All Sections")}</span></span>
                     </a>


### PR DESCRIPTION
This PR updates the lettuce tests for the course outline feature. Currently all scenarios are passing except for `Collapse link appears after creating first section of a course`, which is failing because `add_section` in `cms/djangoapps/contentstore/features/common.py` is not working properly (currently trying to fix this).

Edit: All tests are now passing. The exception being thrown by `add_section` happened when trying to fill in the section name. Since the course outline story does not require the section to be named, the test no longer initiates this behavior.

@andy-armstrong 
