### PR TITLE
Modified cohorts module to support the new workgroup type

### DIFF
--- a/common/djangoapps/course_groups/models.py
+++ b/common/djangoapps/course_groups/models.py
@@ -14,7 +14,7 @@ class CourseUserGroup(models.Model):
     course, and cohorts are used to split up the forums by group.
     """
     class Meta:
-        unique_together = (('name', 'course_id'), )
+        unique_together = (('name', 'course_id', 'group_type'), )
 
     name = models.CharField(max_length=255,
                             help_text=("What is the name of this group?  "
@@ -29,6 +29,8 @@ class CourseUserGroup(models.Model):
 
     # For now, only have group type 'cohort', but adding a type field to support
     # things like 'question_discussion', 'friends', 'off-line-class', etc
+    ANY = 'any'
     COHORT = 'cohort'
-    GROUP_TYPE_CHOICES = ((COHORT, 'Cohort'),)
+    WORKGROUP = 'workgroup'
+    GROUP_TYPE_CHOICES = ((COHORT, 'Cohort'), (WORKGROUP, 'Workgroup'))
     group_type = models.CharField(max_length=20, choices=GROUP_TYPE_CHOICES)

--- a/common/djangoapps/course_groups/views.py
+++ b/common/djangoapps/course_groups/views.py
@@ -217,8 +217,7 @@ def remove_user_from_cohort(request, course_key_string, cohort_id):
 
     cohort = cohorts.get_cohort_by_id(course_key, cohort_id)
     try:
-        user = User.objects.get(username=username)
-        cohort.users.remove(user)
+        cohorts.remove_user_from_cohort(cohort, username)
         return json_http_response({'success': True})
     except User.DoesNotExist:
         log.debug('no user')

--- a/common/static/coffee/src/discussion/views/new_post_view.coffee
+++ b/common/static/coffee/src/discussion/views/new_post_view.coffee
@@ -60,13 +60,16 @@ if Backbone?
 
       getOptionsHTML: () ->
           # cohort options?
-          if @course_settings.get("is_cohorted") and DiscussionUtil.isStaff()
-              user_cohort_id = $("#discussion-container").data("user-cohort-id")
-              cohort_options = _.map @course_settings.get("cohorts"), (cohort) ->
+          if @course_settings.get("is_cohorted")
+              user_cohort_ids = $("#discussion-container").data("user-cohort-ids")
+              user_cohort_id = if user_cohort_ids then user_cohort_ids.split(',')[0] else null
+              cohorts = @course_settings.get("cohorts")
+              cohort_options = _.map cohorts, (cohort) ->
                   {value: cohort.id, text: cohort.name, selected: cohort.id==user_cohort_id}
           else
               cohort_options = null
           context = _.clone(@course_settings.attributes)
+          context.user_is_staff = DiscussionUtil.isStaff()
           context.cohort_options = cohort_options
           _.template($("#new-post-options-template").html(), context)
 

--- a/lms/djangoapps/django_comment_client/base/views.py
+++ b/lms/djangoapps/django_comment_client/base/views.py
@@ -18,7 +18,8 @@ from opaque_keys.edx.locations import SlashSeparatedCourseKey
 
 from courseware.access import has_access
 from courseware.courses import get_course_with_access, get_course_by_id
-from course_groups.cohorts import get_cohort_id, is_commentable_cohorted
+from course_groups.models import CourseUserGroup
+from course_groups.cohorts import get_cohort, get_cohort_id, is_commentable_cohorted
 import django_comment_client.settings as cc_settings
 from django_comment_client.utils import (
     add_courseware_context,
@@ -108,17 +109,19 @@ def create_thread(request, course_id, commentable_id):
 
     # Cohort the thread if the commentable is cohorted.
     if is_commentable_cohorted(course_id, commentable_id):
-        user_group_id = get_cohort_id(user, course_id)
+        user_cohorts = get_cohort(user, course_id,
+                                  group_type=CourseUserGroup.ANY, allow_multiple=True)
+        user_group_ids = [cohort.id for cohort in user_cohorts]
 
+        # Not sure of the proper behavior here, currently selecting the first cohort..
+        group_id = post.get('group_id', user_group_ids[0] if user_group_ids else None)
         # TODO (vshnayder): once we have more than just cohorts, we'll want to
         # change this to a single get_group_for_user_and_commentable function
         # that can do different things depending on the commentable_id
-        if cached_has_permission(request.user, "see_all_cohorts", course_id):
-            # admins can optionally choose what group to post as
-            group_id = post.get('group_id', user_group_id)
-        else:
+        if group_id and group_id not in user_group_ids and \
+           not cached_has_permission(request.user, "see_all_cohorts", course_id):
             # regular users always post with their own id.
-            group_id = user_group_id
+            group_id = user_group_ids[0] if user_group_ids else None
 
         if group_id:
             thread.group_id = group_id

--- a/lms/templates/discussion/_underscore_templates.html
+++ b/lms/templates/discussion/_underscore_templates.html
@@ -444,7 +444,9 @@
             ## Translators: This labels the selector for which group of students can view a post
             ${_("Make visible to:")}
             <select class="group-filter-select new-post-group" name="group_id">
+                ${'<% if (user_is_staff) { %>'}
                 <option value="">${_("All Groups")}</option>
+                ${'<% } %>'}
                 ${'<% _.each(cohort_options, function(opt) { %>'}
                     <option value="${'<%= opt.value %>'}" ${'<% if (opt.selected) { %>selected<% } %>'}>${'<%- opt.text %>'}</option>
                 ${'<% }); %>'}

--- a/lms/templates/discussion/index.html
+++ b/lms/templates/discussion/index.html
@@ -34,7 +34,7 @@
          data-content-info="${annotated_content_info}"
          data-sort-preference="${sort_preference}"
          data-flag-moderator="${flag_moderator}"
-         data-user-cohort-id="${user_cohort}"
+         data-user-cohort-ids="${user_cohorts}"
          data-course-settings="${course_settings}">
     <div class="discussion-body">
         <div class="forum-nav"></div>


### PR DESCRIPTION
This PR contains the addition of a new cohort type: workgroup. This type can be used to create various cohorts. To give you more context, this is used to create group projects between students, so they can also have a private/cohorted discussion in the unit.  Some detials:
- The current behavior of edx cohorts has not changed. It remains the same as before. All functions are using the CourseUserGroup.COHORT type as default.
- If we want to interact with a different type of cohort, we need to specify it with group_type=CourseUserGroup.WORKGROUP with the needed function.
- A user can now be in multiple cohort, ONLY if we specified it explicitly with the allow_multiple parameter of the add_user_to_cohort function. This shouldn't be used with the normal COHORT type, but might be for other types.
- The get_cohort() behave the same as before and will return only one user cohort. If you need to get multiple cohorts, you have to use this function with allow_multiple=True.
- In get_cohort(), auto_cohort is only supported for normal course cohort. (type COHORT).
- A new function is available: remove_user_from_cohort(), which is also used in views.py 
- We can use the type CourseUserGroup.ANY where appropriate to get cohorts of all types and not only from a specific type.

cc @antoviaque @jimabramson @gwprice @chrisndodge 

Let me know if you have any comments.
