### PR TITLE
Annotation Tool: Removed color bug from Flagging and HighlightTags plugins

### DIFF
--- a/common/static/js/vendor/ova/tags-annotator.js
+++ b/common/static/js/vendor/ova/tags-annotator.js
@@ -1032,12 +1032,13 @@ Annotator.Plugin.HighlightTags = (function(_super) {
             if (typeof anns.tags != "undefined" && this.colors !== {}) {
                 
                 for(var index = 0; index < anns.tags.length; ++index){
-                    
-                    if (typeof this.colors[anns.tags[index]] != "undefined") {
-                        var finalcolor = this.colors[anns.tags[index]];
-                        $(annotations[annNum]).css("background","rgba("+finalcolor.red+","+finalcolor.green+","+finalcolor.blue+",0.3");
-                    }else{
-                        $(annotations[annNum]).css("background","");
+                    if(anns.tags[index].indexOf("flagged-") == -1){
+                        if (typeof this.colors[anns.tags[index]] != "undefined") {
+                            var finalcolor = this.colors[anns.tags[index]];
+                            $(annotations[annNum]).css("background","rgba("+finalcolor.red+","+finalcolor.green+","+finalcolor.blue+",0.3");
+                        }else{
+                            $(annotations[annNum]).css("background","");
+                        }
                     }
                 }
                 


### PR DESCRIPTION
**Background:** Flagging and HighlightTags are plugins for Annotator (the open-source project that is the basis for our annotation tool). They are completely independent of each other, which may create unintended consequences when used together.

**Goal:** Currently, if you select a tag that changes the color of the highlight and then "flag" the annotation, it will remove the coloring because they are tag-based. This PR adds one line of code (line no. 1035, an `if` statement) that checks to make sure that flagging tags are NOT taken into account when selecting the color of the annotation highlight.

**Studio Updates:** None.

**LMS Updates:** Now, the color of the annotation highlight is the LAST non-flagging tag in the annotation tool. When someone flags an annotation it SHOULD NOT affect the color the annotation used to be.

*_Testing: *_ Initiate the annotation components using Advanced Settings to add advanced modules, annotation storage url, and secret token. Create a new unit and add a text annotation component. In the LMS, highlight any part of the text and add a colored tag (it comes prepopulated with "imagery" as red and "parallelism" as blue). Save. Hover over the annotation and a viewer should come up. A flag on the upper left-hand corner should be there to "flag" the annotation as offensive. Now in the old version if you were to click on that flag and refresh the page, the annotation should be back to yellow instead of the color of the last tag, because you've added a flagging tag. In this PR, it should remain the color you chose in the last nonflagging tag. 
