### PR TITLE
Add Staff Graded Assignments XBlock to edx-platform

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -614,6 +614,7 @@ MAX_FAILED_LOGIN_ATTEMPTS_LOCKOUT_PERIOD_SECS = 15 * 60
 OPTIONAL_APPS = (
     'edx_jsdraw',
     'mentoring',
+    'edx_sga',
 
     # edx-ora2
     'submissions',
@@ -656,6 +657,7 @@ ADVANCED_COMPONENT_TYPES = [
     'word_cloud',
     'graphical_slider_tool',
     'lti',
+    'edx_sga',
     # XBlocks from pmitros repos are prototypes. They should not be used
     # except for edX Learning Sciences experiments on edge.edx.org without
     # further work to make them robust, maintainable, finalize data formats,

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1633,6 +1633,7 @@ ALL_LANGUAGES = (
 OPTIONAL_APPS = (
     'edx_jsdraw',
     'mentoring',
+    'edx_sga',
 
     # edx-ora2
     'submissions',

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -31,3 +31,6 @@
 -e git+https://github.com/edx/opaque-keys.git@454bd984d9539550c6290020e92ee2d6094038d0#egg=opaque-keys
 -e git+https://github.com/edx/ease.git@97de68448e5495385ba043d3091f570a699d5b5f#egg=ease
 -e git+https://github.com/edx/i18n-tools.git@f5303e82dff368c7595884d9325aeea1d802da25#egg=i18n-tools
+
+# Third Party XBlocks
+-e git+https://github.com/mitodl/edx-sga@7e308cf676b6f41493d9cf7864296bc1c089b36b#egg=edx-sga


### PR DESCRIPTION
This adds the PyPi version of SGA (https://github.com/mitodl/edx-sga) to requirements and optional apps. I wasn't sure whether to add it to the github requirements or here.  It seemed cleaner to use the PyPi version.

@pdpinch @ichuang @nedbat @cpennington
