### PR TITLE
Add defininition of window.location.origin in both studio and LMS

### DIFF
--- a/cms/templates/base.html
+++ b/cms/templates/base.html
@@ -1,4 +1,4 @@
-﻿## -*- coding: utf-8 -*-
+## -*- coding: utf-8 -*-
 <%! from django.utils.translation import ugettext as _ %>
 <%namespace name='static' file='static_content.html'/>
 
@@ -39,12 +39,6 @@
 
     <script type="text/javascript">
     window.baseUrl = "${settings.STATIC_URL}";
-    // Internet Explorer does not have built-in property 'window.location.origin',
-    // we need to create one here as some vendor code such as TinyMCE uses this.
-    if (!window.location.origin) {
-        window.location.origin = window.location.protocol + "//" + window.location.hostname
-                               + (window.location.port ? ':' + window.location.port : '');
-    }
     var require = {
         baseUrl: baseUrl,
         waitSeconds: 60,
@@ -86,6 +80,7 @@
             "accessibility": "js/src/accessibility_tools",
             "draggabilly": "js/vendor/draggabilly.pkgd",
             "URI": "js/vendor/URI.min",
+            "ieshim": "js/src/ie_shim",
 
             // externally hosted files
             "tender": [
@@ -239,7 +234,7 @@
         deps: ["jquery", "gettext"],
         callback: function() {
             // load other scripts on every page, after jquery loads
-            require(["js/base", "coffee/src/main", "coffee/src/logger", "datepair", "accessibility"]);
+            require(["js/base", "coffee/src/main", "coffee/src/logger", "datepair", "accessibility", "ieshim"]);
             // we need "datepair" because it dynamically modifies the page
             // when it is loaded -- yuck!
         }

--- a/common/static/js/src/ie_shim.js
+++ b/common/static/js/src/ie_shim.js
@@ -1,0 +1,16 @@
+/*
+ * This file is used for keeping compatibility with Internet Explorer.
+ * As starting with IE10, the conditional comments are not supported, this file
+ * will always be loaded whether the browser is IE or not. Therefore, the code
+ * here should not make any assumption and should always detect the execution
+ * conditions itself.
+ */
+
+// Shim name: Create the attribute of 'window.location.origin'
+// IE version: 11 or earlier, 12 or later not tested
+// Internet Explorer does not have built-in property 'window.location.origin',
+// we need to create one here as some vendor code such as TinyMCE uses this.
+if (!window.location.origin) {
+    window.location.origin = window.location.protocol + "//" + window.location.hostname
+                           + (window.location.port ? ':' + window.location.port : '');
+}

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1002,6 +1002,7 @@ PIPELINE_JS = {
             'js/query-params.js',
             'js/src/utility.js',
             'js/src/accessibility_tools.js',
+            'js/src/ie_shim.js',
         ],
         'output_filename': 'js/lms-application.js',
 


### PR DESCRIPTION
The same bug in studio was fixed in #3893, and as TinyMCE is also used in LMS, it should be also fixed in LMS.
