### PR TITLE
Fixing calculator hint to display correct definition of the constant T

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -159,4 +159,5 @@ Brandon DeRosier <btd@cheesekeg.com>
 Daniel Li <swli@edx.org>
 Daniel Friedman <dfriedman@edx.org>
 Asad Iqbal <aiqbal@edx.org>
+Peter Pinch <pdpinch@mit.edu>
 Muhammad Shoaib <mshoaib@edx.org>

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -331,7 +331,7 @@ ${fragment.foot_html()}
                               <tr>
                                 <td>T</td>
                                 <td>=</td>
-                                <td>${_("freezing point of water in degrees Kelvin")}</td>
+                                <td>${_("Typical room temperature: 298.15 (Kelvin), same as 25C/77F")}</td>
                               </tr>
                               <tr>
                                 <td>q</td>


### PR DESCRIPTION
Documentation and code comments for the calculator indicate that the constant T is room temperature in Kelvin, but the HTML hint that users see defines it as the freezing point of water. According to @wdickson from 3.091x, room temperature is more useful for solving chemistry problems. 

This contribution is covered by the agreement with MIT. I've added myself to the AUTHORS file. 

FYI @carsongee
