### PR TITLE
Add JQuery timepicker CSS to the unit and container templates

### DIFF
--- a/cms/templates/container.html
+++ b/cms/templates/container.html
@@ -22,6 +22,7 @@ from django.utils.translation import ugettext as _
 </%block>
 
 <%block name="jsextra">
+<link rel="stylesheet" type="text/css" href="${static.url('js/vendor/timepicker/jquery.timepicker.css')}" />
 <%
 main_xblock_info = {
     'id': str(xblock_locator),

--- a/cms/templates/unit.html
+++ b/cms/templates/unit.html
@@ -19,6 +19,7 @@ from django.utils.translation import ugettext as _
 </%block>
 
 <%block name="jsextra">
+  <link rel="stylesheet" type="text/css" href="${static.url('js/vendor/timepicker/jquery.timepicker.css')}" />
   <script type='text/javascript'>
 require(["domReady!", "jquery", "js/models/module_info", "coffee/src/views/unit", "js/collections/component_template",
     "xmodule", "jquery.ui", "coffee/src/main", "xblock/cms.runtime.v1"],


### PR DESCRIPTION
Studio loads [JQuery timepicker](http://jonthornton.github.io/jquery-timepicker/) JS on the unit page, but not the CSS stylesheet.  I'm planning on using the timepicker in ORA2's XBlock editing view, so I need the stylesheet to be available.

This is not ideal, since ORA2 needs to make additional assumptions about what dependencies are available in Studio.  @cpennington This is a case where it would be really helpful for the XBlock runtime to manage client-side dependencies.

@andy-armstrong and @frrrances please review.
