### PR TITLE
Update (optional) Group Configuration urls to use settings.COURSE_KEY_PATTERN

### DIFF
--- a/cms/urls.py
+++ b/cms/urls.py
@@ -94,8 +94,8 @@ urlpatterns += patterns(
 
 if settings.FEATURES.get('ENABLE_GROUP_CONFIGURATIONS'):
     urlpatterns += patterns('contentstore.views',
-        url(r'^group_configurations/(?P<course_key_string>[^/]+)$', 'group_configurations_list_handler'),
-        url(r'^group_configurations/(?P<course_key_string>[^/]+)/(?P<group_configuration_id>\d+)/?$',
+        url(r'^group_configurations/{}$'.format(settings.COURSE_KEY_PATTERN), 'group_configurations_list_handler'),
+        url(r'^group_configurations/{}/(?P<group_configuration_id>\d+)/?$'.format(settings.COURSE_KEY_PATTERN),
             'group_configurations_detail_handler'),
     )
 


### PR DESCRIPTION
Brings optional Group  Configuration urls in line with others, adheres to changes introduced in https://github.com/edx/edx-platform/commit/d9dd45662ec96d465897f1e0d8e16e681d1db067

review:  @auraz, @polesye 
cc: @andy-armstrong @cahrens 
