### PR TITLE
Use /tmp/mako_lms and /tmp/mako_cms for compiled mako templates.

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -130,8 +130,8 @@ GEOIP_PATH = REPO_ROOT / "common/static/data/geoip/GeoIP.dat"
 
 ############################# WEB CONFIGURATION #############################
 # This is where we stick our compiled template files.
-from tempdir import mkdtemp_clean
-MAKO_MODULE_DIR = mkdtemp_clean('mako')
+import tempfile
+MAKO_MODULE_DIR = os.path.join(tempfile.gettempdir(), 'mako_cms')
 MAKO_TEMPLATES = {}
 MAKO_TEMPLATES['main'] = [
     PROJECT_ROOT / 'templates',

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -310,8 +310,8 @@ OPENID_PROVIDER_TRUSTED_ROOTS = ['cs50.net', '*.cs50.net']
 ################################## EDX WEB #####################################
 # This is where we stick our compiled template files. Most of the app uses Mako
 # templates
-from tempdir import mkdtemp_clean
-MAKO_MODULE_DIR = mkdtemp_clean('mako')
+import tempfile
+MAKO_MODULE_DIR = os.path.join(tempfile.gettempdir(), 'mako_lms')
 MAKO_TEMPLATES = {}
 MAKO_TEMPLATES['main'] = [PROJECT_ROOT / 'templates',
                           COMMON_ROOT / 'templates',


### PR DESCRIPTION
Currently a new temp directory is created for every process via
mkdtemp_clean() which cleans it on process exit.

However, this is not compatible with using --preload option of
gunicorn. With this option the tmp directory is created on gunicorn
start and is shared by all the workers. But when a worker exits it
deletes the directory. And so on the next requent the tmp directory
needs to be recreated and the templates need to be recompiled.

LMS-6507
