### PR TITLE
Add course author notes for 7/16 release

### DIFF
--- a/docs/en_us/release_notes/source/07-21-2014.rst
+++ b/docs/en_us/release_notes/source/07-21-2014.rst
@@ -1,0 +1,83 @@
+###################################
+July 21, 2014
+###################################
+
+The following information reflects what is new in the edX Platform as of July 21,
+2014. See previous pages in this document for a history of changes.
+
+****************************************
+edX Release Announcements Mailing List
+****************************************
+
+These edX Course Staff Release Notes are always available and are updated with
+each release of the edX Platform on `edx.org`_ and `edX Edge`_.
+
+You can also sign up for the `edX Release Announcements mailing list`_ to get
+an email message when we have updated the edX Course Staff Release Notes.
+
+***************************************
+edX Studio
+***************************************
+
+* In open response assessments, instructors can now create assignments that allow students to upload an image file as well as write a text response. For more information, see `Creating Peer Assessments`_.
+
+* In open response assessments, instructors can now create a criterion that includes a field for comments, but no options. For more information, see `Creating Peer Assessments`_.
+
+* In some cases, deleting a unit from a subsection caused server errors. This bug has been fixed. (STUD-1962)
+
+***************************************
+edX Learning Management System
+***************************************
+   
+* The Instructor Dashboard **Analytics** tab now includes the number of students who interacted with the course by visiting pages, playing videos, contributing to discussions, submitting answers to problems, or completing other course activites. The active student count is updated each week.
+
+* Some links on the right side of the course wiki appeared to be disabled. This has been fixed. (LMS-1308)
+
+* Forum posts created by anonymous users appeared with a "by Staff" label. This bug has been fixed. (FOR-156)
+
+* When a student selected **Post anonymously to classmates** check box in the forums, the post appeared as anonymous to both students and staff. This bug has been fixed. (FOR-122)
+
+**************************
+edX Documentation
+**************************
+
+The following documentation is available:
+
+* `Building and Running an edX Course`_ 
+
+  Click **Help** in the upper-right corner of any page in the edX Studio
+  user interface to access relevant sections in this guide. You can also
+  download the entire guide as a PDF.
+
+  Recent changes include: 
+
+  * The `Running Your Course`_ section now includes a `Participating in Course Discussions`_ chapter that provides information for both students and staff. 
+
+  * The `Discussions`_ chapter has been updated to reflect changes in the UI.
+       
+* `edX Research Guide`_
+
+  Recent changes include: 
+
+  * The `Track Student Activity`_ section has been added to the `Student Data`_ chapter.
+
+* `edX Developer's Guide`_
+
+   * The link to the `Ubuntu installation instructions`_ has been updated.
+
+* `edX XBlock Documentation`_
+
+* `Installing, Configuring, and Running the edX Platform`_  
+
+**************************
+Other edX Resources
+**************************
+
+You can access the `edX Status`_ page to get an up-to-date status for all
+services on edx.org and edX Edge. The page also includes the Twitter feed for
+@edXstatus, which the edX Operations team uses to post updates.
+
+You can access the public `edX roadmap`_ for details about the currently
+planned product direction.
+
+.. include:: links.rst

--- a/docs/en_us/release_notes/source/index.rst
+++ b/docs/en_us/release_notes/source/index.rst
@@ -31,6 +31,7 @@ email message when we have updated the edX Course Staff Release Notes.
 
    read_me
    preface
+   07-21-2014
    07-10-2014
    06-25-2014
    06-17-2014

--- a/docs/en_us/release_notes/source/links.rst
+++ b/docs/en_us/release_notes/source/links.rst
@@ -80,6 +80,8 @@
 
 .. _Student Data: http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/running_course/course_student.html#student-data
 
+.. _Track Student Activity: http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/running_course/course_student.html#track-student-activity
+
 .. _Add the Beta Testers: http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/releasing_course/beta_testing.html#add-testers
 
 .. _Getting Started: http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/getting_started/index.html#getting-started-index
@@ -139,6 +141,8 @@
 .. _Components: http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/creating_content/organizing_course.html#components
 
 .. _Discussions: http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/running_course/discussions.html  
+
+.. _Participating in Course Discussions: http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/running_course/discussions_students.html
 
 .. _Guidance for Discussion Moderators: http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/running_course/discussion_guidance_moderators.html
 
@@ -210,3 +214,5 @@
 .. _Analytics: http://edx.readthedocs.org/projects/userdocs/en/latest/analytics.html
 
 .. _Opaque Keys: https://github.com/edx/edx-platform/wiki/Opaque-Keys
+
+.. _Ubuntu installation instructions: https://github.com/edx/configuration/wiki/edX-Ubuntu-12.04-64-bit-Installation


### PR DESCRIPTION
@mhoeber @lamagnifica Please review. Draft at http://draft-release-notes-7-16.readthedocs.org/en/latest/07-16-2014.html.

I didn't include the following; let me know if I should:
- https://github.com/edx/edx-platform/pull/4095 (creates an Open edX footer)
- https://github.com/edx/edx-platform/pull/4172 (e-commerce enhancements - I don't think these are externally visible yet)
- https://github.com/edx/edx-platform/pull/4353 and https://github.com/edx/edx-platform/pull/4368 (these two are specific to annotations, which I think only Harvard uses and we don't want to publicize)
