### PR TITLE
On import, ignore the attempt to create dir

### DIFF
--- a/cms/djangoapps/contentstore/views/import_export.py
+++ b/cms/djangoapps/contentstore/views/import_export.py
@@ -214,7 +214,10 @@ def import_handler(request, course_key_string):
 
                     if dirpath != course_dir:
                         for fname in os.listdir(dirpath):
-                            shutil.move(dirpath / fname, course_dir)
+                            try:
+                                shutil.move(dirpath / fname, course_dir)
+                            except shutil.Error:  # directory already exists
+                                pass
 
                     _module_store, course_items = import_from_xml(
                         modulestore(),


### PR DESCRIPTION
which exists. Occurs when course includes a subdir w/ same
name as the course's root dir which occurred when there
was a manifest.sh file.

@ormsbee plz review
