### PR TITLE
Bug/import

### DIFF
--- a/cms/djangoapps/contentstore/views/import_export.py
+++ b/cms/djangoapps/contentstore/views/import_export.py
@@ -210,17 +210,15 @@ def import_handler(request, course_key_string):
                             status=415
                         )
 
-                    logging.debug('found course.xml at {0}'.format(dirpath))
+                    dirpath = os.path.relpath(dirpath, data_root)
 
-                    if dirpath != course_dir:
-                        for fname in os.listdir(dirpath):
-                            shutil.move(dirpath / fname, course_dir)
+                    logging.debug('found course.xml at {0}'.format(dirpath))
 
                     _module_store, course_items = import_from_xml(
                         modulestore(),
                         request.user.id,
                         settings.GITHUB_REPO_ROOT,
-                        [course_subdir],
+                        [dirpath],
                         load_error_modules=False,
                         static_content_store=contentstore(),
                         target_course_id=course_key,

--- a/cms/djangoapps/contentstore/views/tests/test_import_export.py
+++ b/cms/djangoapps/contentstore/views/tests/test_import_export.py
@@ -45,11 +45,13 @@ class ImportTestCase(CourseTestCase):
         # Create tar test files -----------------------------------------------
         # OK course:
         good_dir = tempfile.mkdtemp(dir=self.content_dir)
-        os.makedirs(os.path.join(good_dir, "course"))
-        with open(os.path.join(good_dir, "course.xml"), "w+") as f:
+        # test course being deeper down than top of tar file
+        embedded_dir = os.path.join(good_dir, "grandparent", "parent")
+        os.makedirs(os.path.join(embedded_dir, "course"))
+        with open(os.path.join(embedded_dir, "course.xml"), "w+") as f:
             f.write('<course url_name="2013_Spring" org="EDx" course="0.00x"/>')
 
-        with open(os.path.join(good_dir, "course", "2013_Spring.xml"), "w+") as f:
+        with open(os.path.join(embedded_dir, "course", "2013_Spring.xml"), "w+") as f:
             f.write('<course></course>')
 
         self.good_tar = os.path.join(self.content_dir, "good.tar.gz")


### PR DESCRIPTION
Publish was breaking if the were children references to non-existent items. Because import uses publish, this was breaking imports of some courses.

Import was breaking if a tar.gz had a directory in it w/ the same name as the root dir which occurred importing some MITx courses with manifest files.

@ormsbee @cpennington plz review
