### PR TITLE
Instructors can view previously sent email content

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ These are notable changes in edx-platform.  This is a rolling list of changes,
 in roughly chronological order, most recent first.  Add your entries at or near
 the top.  Include a label indicating the component affected.
 
+LMS: Instructors can request and see content of previous bulk emails sent in the instructor dashboard. 
+
 Studio: New advanced setting "invitation_only" for courses. This setting overrides the enrollment start/end dates
   if set. LMS-2670
 

--- a/lms/djangoapps/instructor/tests/utils.py
+++ b/lms/djangoapps/instructor/tests/utils.py
@@ -1,0 +1,84 @@
+"""
+Utilities for instructor unit tests
+"""
+import datetime
+import json
+import random
+from django.utils.timezone import utc
+from util.date_utils import get_default_time_display
+
+
+class FakeInfo(object):
+    """Parent class for faking objects used in tests"""
+    FEATURES = []
+
+    def __init__(self):
+        for feature in self.FEATURES:
+            setattr(self, feature, u'expected')
+
+    def to_dict(self):
+        """ Returns a dict representation of the object """
+        return {key: getattr(self, key) for key in self.FEATURES}
+
+
+class FakeContentTask(FakeInfo):
+    """ Fake task info needed for email content list """
+    FEATURES = [
+        'task_input',
+        'task_output',
+    ]
+
+    def __init__(self, email_id, num_sent, sent_to):
+        super(FakeContentTask, self).__init__()
+        self.task_input = {'email_id': email_id, 'to_option': sent_to}
+        self.task_input = json.dumps(self.task_input)
+        self.task_output = {'total': num_sent}
+        self.task_output = json.dumps(self.task_output)
+
+    def make_invalid_input(self):
+        """Corrupt the task input field to test errors"""
+        self.task_input = "THIS IS INVALID JSON"
+
+
+class FakeEmail(FakeInfo):
+    """ Corresponding fake email for a fake task """
+    FEATURES = [
+        'subject',
+        'html_message',
+        'id',
+        'created',
+    ]
+
+    def __init__(self, email_id):
+        super(FakeEmail, self).__init__()
+        self.id = unicode(email_id)
+        # Select a random data for create field
+        year = random.choice(range(1950, 2000))
+        month = random.choice(range(1, 12))
+        day = random.choice(range(1, 28))
+        hour = random.choice(range(0, 23))
+        minute = random.choice(range(0, 59))
+        self.created = datetime.datetime(year, month, day, hour, minute, tzinfo=utc)
+
+
+class FakeEmailInfo(FakeInfo):
+    """ Fake email information object """
+    FEATURES = [
+        u'created',
+        u'sent_to',
+        u'email',
+        u'number_sent'
+    ]
+
+    EMAIL_FEATURES = [
+        u'subject',
+        u'html_message',
+        u'id'
+    ]
+
+    def __init__(self, fake_email, num_sent):
+        super(FakeEmailInfo, self).__init__()
+        self.created = get_default_time_display(fake_email.created)
+        self.number_sent = num_sent
+        fake_email_dict = fake_email.to_dict()
+        self.email = {feature: fake_email_dict[feature] for feature in self.EMAIL_FEATURES}

--- a/lms/djangoapps/instructor/views/api_urls.py
+++ b/lms/djangoapps/instructor/views/api_urls.py
@@ -31,6 +31,8 @@ urlpatterns = patterns('',  # nopep8
         'instructor.views.api.list_instructor_tasks', name="list_instructor_tasks"),
     url(r'^list_background_email_tasks$',
         'instructor.views.api.list_background_email_tasks', name="list_background_email_tasks"),
+    url(r'^list_email_content$',
+        'instructor.views.api.list_email_content', name="list_email_content"),
     url(r'^list_forum_members$',
         'instructor.views.api.list_forum_members', name="list_forum_members"),
     url(r'^update_forum_role_membership$',

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -92,7 +92,6 @@ def instructor_dashboard_2(request, course_id):
     if course_mode_has_price:
         sections.append(_section_e_commerce(course_key, access))
 
-
     studio_url = None
     if is_studio_course:
         studio_url = get_cms_course_link(course)
@@ -277,6 +276,9 @@ def _section_send_email(course_key, access, course):
         ),
         'email_background_tasks_url': reverse(
             'list_background_email_tasks', kwargs={'course_id': course_key.to_deprecated_string()}
+        ),
+        'email_content_history_url': reverse(
+            'list_email_content', kwargs={'course_id': course_key.to_deprecated_string()}
         ),
     }
     return section_data

--- a/lms/djangoapps/instructor/views/instructor_task_helpers.py
+++ b/lms/djangoapps/instructor/views/instructor_task_helpers.py
@@ -1,0 +1,113 @@
+"""
+A collection of helper utility functions for working with instructor
+tasks.
+"""
+import json
+import logging
+from util.date_utils import get_default_time_display
+from bulk_email.models import CourseEmail
+from django.utils.translation import ugettext as _
+from instructor_task.views import get_task_completion_info
+
+log = logging.getLogger(__name__)
+
+
+def email_error_information():
+    """
+    Returns email information marked as None, used in event email
+    cannot be loaded
+    """
+    expected_info = [
+        'created',
+        'sent_to',
+        'email',
+        'number_sent'
+    ]
+    return {info: None for info in expected_info}
+
+
+def extract_email_features(email_task):
+    """
+    From the given task, extract email content information
+
+    Expects that the given task has the following attributes:
+    * task_input (dict containing email_id and to_option)
+    * task_output (optional, dict containing total emails sent)
+
+    With this information, gets the corresponding email object from the
+    bulk emails table, and loads up a dict containing the following:
+    * created, the time the email was sent displayed in default time display
+    * sent_to, the group the email was delivered to
+    * email, dict containing the subject, id, and html_message of an email
+    * number_sent, int number of emails sent
+    If task_input cannot be loaded, then the email cannot be loaded
+    and None is returned for these fields.
+    """
+    # Load the task input info to get email id
+    try:
+        task_input_information = json.loads(email_task.task_input)
+    except ValueError:
+        log.error("Could not parse task input as valid json; task input: %s", email_task.task_input)
+        return email_error_information()
+
+    email = CourseEmail.objects.get(id=task_input_information['email_id'])
+
+    creation_time = get_default_time_display(email.created)
+    email_feature_dict = {'created': creation_time, 'sent_to': task_input_information['to_option']}
+    features = ['subject', 'html_message', 'id']
+    email_info = {feature: unicode(getattr(email, feature)) for feature in features}
+
+    # Pass along email as an object with the information we desire
+    email_feature_dict['email'] = email_info
+
+    number_sent = None
+    if hasattr(email_task, 'task_output') and email_task.task_output is not None:
+        try:
+            task_output = json.loads(email_task.task_output)
+        except ValueError:
+            log.error("Could not parse task output as valid json; task output: %s", email_task.task_output)
+        else:
+            if 'total' in task_output:
+                number_sent = int(task_output['total'])
+    email_feature_dict['number_sent'] = number_sent
+
+    return email_feature_dict
+
+
+def extract_task_features(task):
+    """
+    Convert task to dict for json rendering.
+    Expects tasks have the following features:
+    * task_type (str, type of task)
+    * task_input (dict, input(s) to the task)
+    * task_id (str, celery id of the task)
+    * requester (str, username who submitted the task)
+    * task_state (str, state of task eg PROGRESS, COMPLETED)
+    * created (datetime, when the task was completed)
+    * task_output (optional)
+    """
+    # Pull out information from the task
+    features = ['task_type', 'task_input', 'task_id', 'requester', 'task_state']
+    task_feature_dict = {feature: str(getattr(task, feature)) for feature in features}
+    # Some information (created, duration, status, task message) require additional formatting
+    task_feature_dict['created'] = task.created.isoformat()
+
+    # Get duration info, if known
+    duration_sec = 'unknown'
+    if hasattr(task, 'task_output') and task.task_output is not None:
+        try:
+            task_output = json.loads(task.task_output)
+        except ValueError:
+            log.error("Could not parse task output as valid json; task output: %s", task.task_output)
+        else:
+            if 'duration_ms' in task_output:
+                duration_sec = int(task_output['duration_ms'] / 1000.0)
+    task_feature_dict['duration_sec'] = duration_sec
+
+    # Get progress status message & success information
+    success, task_message = get_task_completion_info(task)
+    status = _("Complete") if success else _("Incomplete")
+    task_feature_dict['status'] = status
+    task_feature_dict['task_message'] = task_message
+
+    return task_feature_dict

--- a/lms/static/coffee/src/instructor_dashboard/send_email.coffee
+++ b/lms/static/coffee/src/instructor_dashboard/send_email.coffee
@@ -11,6 +11,8 @@ plantTimeout = -> window.InstructorDashboard.util.plantTimeout.apply this, argum
 std_ajax_err = -> window.InstructorDashboard.util.std_ajax_err.apply this, arguments
 PendingInstructorTasks = -> window.InstructorDashboard.util.PendingInstructorTasks
 create_task_list_table = -> window.InstructorDashboard.util.create_task_list_table.apply this, arguments
+create_email_content_table = -> window.InstructorDashboard.util.create_email_content_table.apply this, arguments
+create_email_message_views = -> window.InstructorDashboard.util.create_email_message_views.apply this, arguments
 
 class SendEmail
   constructor: (@$container) ->
@@ -21,9 +23,14 @@ class SendEmail
     @$btn_send = @$container.find("input[name='send']'")
     @$task_response = @$container.find(".request-response")
     @$request_response_error = @$container.find(".request-response-error")
+    @$content_request_response_error = @$container.find(".content-request-response-error")
     @$history_request_response_error = @$container.find(".history-request-response-error")
     @$btn_task_history_email = @$container.find("input[name='task-history-email']'")
+    @$btn_task_history_email_content = @$container.find("input[name='task-history-email-content']'")
     @$table_task_history_email = @$container.find(".task-history-email-table")
+    @$table_email_content_history = @$container.find(".content-history-email-table")
+    @$email_content_table_inner = @$container.find(".content-history-table-inner")
+    @$email_messages_wrapper = @$container.find(".email-messages-wrapper")
 
     # attach click handlers
 
@@ -83,9 +90,25 @@ class SendEmail
           else
             @$history_request_response_error.text gettext("There is no email history for this course.")
             # Enable the msg-warning css display
-            $(".msg-warning").css({"display":"block"})
+            @$history_request_response_error.css({"display":"block"})
         error: std_ajax_err =>
           @$history_request_response_error.text gettext("There was an error obtaining email task history for this course.")
+
+    # List content history for emails sent
+    @$btn_task_history_email_content.click =>
+      url = @$btn_task_history_email_content.data 'endpoint'
+      $.ajax
+        dataType: 'json'
+        url : url
+        success: (data) =>
+          if data.emails.length
+            create_email_content_table @$table_email_content_history, @$email_content_table_inner, data.emails
+            create_email_message_views @$email_messages_wrapper, data.emails
+          else
+            @$content_request_response_error.text gettext("There is no email history for this course.")
+            @$content_request_response_error.css({"display":"block"})
+        error: std_ajax_err =>
+          @$content_request_response_error.text gettext("There was an error obtaining email content history for this course.")
 
   fail_with_error: (msg) ->
     console.warn msg

--- a/lms/static/js/toggle_login_modal.js
+++ b/lms/static/js/toggle_login_modal.js
@@ -17,7 +17,7 @@
         closeButton: null,
         position: 'fixed'
       }
-      
+
       if ($("#lean_overlay").length == 0) {
         var overlay = $("<div id='lean_overlay'></div>");
         $("body").append(overlay);
@@ -52,6 +52,11 @@
             close_modal(modal_id, e);
           });
 
+          // To enable closing of email modal when copy button hit
+          $(o.copyEmailButton).click(function(e) {
+            close_modal(modal_id, e);
+          });
+
           var modal_height = $(modal_id).outerHeight();
           var modal_width = $(modal_id).outerWidth();
 
@@ -59,17 +64,28 @@
           $('#lean_overlay').fadeTo(200,o.overlay);
 
           $('iframe', modal_id).attr('src', $('iframe', modal_id).data('src'));
-          $(modal_id).css({
-            'display' : 'block',
-            'position' : o.position,
-            'opacity' : 0,
-            'z-index': 11000,
-            'left' : 50 + '%',
-            'margin-left' : -(modal_width/2) + "px",
-            'top' : o.top + "px"
-          })
+          if ($(modal_id).hasClass("email-modal")){
+            $(modal_id).css({
+              'width' : 80 + '%',
+              'height' : 80 + '%',
+              'position' : o.position,
+              'opacity' : 0,
+              'z-index' : 11000,
+              'left' : 10 + '%',
+              'top' : 10 + '%'
+            })
+          } else {
+            $(modal_id).css({
+              'position' : o.position,
+              'opacity' : 0,
+              'z-index': 11000,
+              'left' : 50 + '%',
+              'margin-left' : -(modal_width/2) + "px",
+              'top' : o.top + "px"
+            })
+        }
 
-          $(modal_id).fadeTo(200,1);
+          $(modal_id).show().fadeTo(200,1);
           $(modal_id).find(".notice").hide().html("");
           var notice = $(this).data('notice')
           if(notice !== undefined) {

--- a/lms/static/sass/course/instructor/_email.scss
+++ b/lms/static/sass/course/instructor/_email.scss
@@ -20,9 +20,67 @@
   margin-top: 10px;
   line-height: 1.3;
 
-  ul { 
+  ul {
     margin-top: 0;
     margin-bottom: 10px;
   }
 }
 
+.email-background{
+  .content-history-email-table {
+    display: none;
+  }
+
+  .email-content-wrapper {
+    min-height: 100%;
+    background: #f5f5f5;
+
+    hr {
+      width: 90%;
+      margin-left: 5%;
+      margin-top: 0;
+    }
+  }
+
+  .message-bold em {
+    font-weight: bold;
+    font-style: normal;
+  }
+
+  .email-content-header {
+    padding: 20px 5%;
+
+    h2 {
+      text-align: left;
+      padding-top: 10px;
+      margin: 0;
+    }
+
+    input {
+      margin-top: 15px;
+      float: right;
+    }
+  }
+
+  .email-content-message {
+     padding: 5px 5% 40px 5%;
+  }
+
+  .email-modal {
+    overflow: auto;
+    color: $black;
+  }
+
+  .email-content-cell {
+    p {
+      padding: 15px;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      overflow: hidden;
+    }
+
+    a:hover {
+      font-weight: bold;
+    }
+  }
+}

--- a/lms/templates/instructor/instructor_dashboard_2/send_email.html
+++ b/lms/templates/instructor/instructor_dashboard_2/send_email.html
@@ -69,12 +69,27 @@
 <hr>
 
 <div class="vert-left email-background" id="section-task-history">
-    <h2> ${_("Email Task History")} </h2>
+  <h2> ${_("Email Task History")} </h2>
+  <div>
+    <p>${_("To see the content of all previously sent emails, click this button:")}</p>
+    <br/>
+    <input type="button" name="task-history-email-content" value="${_("Sent Email History")}" data-endpoint="${ section_data['email_content_history_url'] }" >
+    <div class="content-request-response-error msg msg-warning copy"></div>
+    <p>
+    <div class="content-history-email-table">
+      <p><em>${_("To read an email, click its subject.")}</em></p>
+      <br/>
+      <div class="content-history-table-inner"></div>
+    </div>
+    <div class="email-messages-wrapper"></div>
+  </div>
+  <div>
     <p>${_("To see the status for all bulk email tasks ever submitted for this course, click on this button:")}</p>
     <br/>
-  <input type="button" name="task-history-email" value="${_("Show Email Task History")}" data-endpoint="${ section_data['email_background_tasks_url'] }" >
-  <div class="history-request-response-error msg msg-warning copy"></div>
-  <div class="task-history-email-table"></div>
+    <input type="button" name="task-history-email" value="${_("Show Email Task History")}" data-endpoint="${ section_data['email_background_tasks_url'] }" >
+    <div class="history-request-response-error msg msg-warning copy"></div>
+    <div class="task-history-email-table"></div>
+  </div>
 </div>
 %endif
 


### PR DESCRIPTION
Previously on the send email page of the instructor dashboard, instructors could only view task information about emails they've sent for their course in the past.
In addition to this, I've now added the ability to see the content of all previously sent emails. A "show email content history" button has been added to the page. When clicked, a table displaying the subject line, number of emails sent, and date/time of submission for each previously sent email is created. An instructor can then click on any subject line to see the content of that email, displayed in a modal window that appears on the page. The window is also equipped with a "copy email body to editor" button, which copies the emails contents to the tinyMCE editor, so that an instructor can easily resend an email that they've sent in the past.

This PR addresses some aspects of this ticket: https://openedx.atlassian.net/browse/LMS-10345
