### PR TITLE
Name full-screen-image setup function and call it

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/html/imageModal.js
+++ b/common/lib/xmodule/xmodule/js/src/html/imageModal.js
@@ -1,6 +1,4 @@
-$(function() {
-  
-  // Set up on page load
+function setupFullScreenImage() {
   $("a.modal-content").each(function() {
     var smallImageObject = $(this).children();
     var largeImageSRC = $(this).attr('href');
@@ -106,4 +104,4 @@ $(function() {
       $(".wrapper-modal-image .image-content .image-controls .modal-ui-icon").toggleClass('is-disabled');
     }
   });
-});
+}

--- a/common/lib/xmodule/xmodule/templates/html/image_modal.yaml
+++ b/common/lib/xmodule/xmodule/templates/html/image_modal.yaml
@@ -5,3 +5,8 @@ data: |
         <h2>Full Screen Image</h2>
         <p>Use the full screen image tool to allow students to open the image in the full screen, zoom in on the image, and drag the image within the screen.</p>
         <a href="http://static.class.stanford.edu/stanford-hills-big.jpg" class="modal-content"><img alt="The Stanford Hills" src="http://static.class.stanford.edu/stanford-hills-small.jpg" /></a>
+        <script type="text/javascript">
+            $(function () {
+                setupFullScreenImage();
+            });
+        </script>


### PR DESCRIPTION
Fix bug in fullscreen image where JS doesn't load when you switch unit tabs in LMS.
