### PR TITLE
Bugfix: New Tab name being initialized as null

### DIFF
--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -429,6 +429,7 @@ def _create_item(request):
     # if we add one then we need to also add it to the policy information (i.e. metadata)
     # we should remove this once we can break this reference from the course to static tabs
     if category == 'static_tab':
+        display_name = display_name or _("Empty") # Prevent name being None
         course = store.get_course(dest_usage_key.course_key)
         course.tabs.append(
             StaticTab(

--- a/cms/djangoapps/contentstore/views/tests/test_item.py
+++ b/cms/djangoapps/contentstore/views/tests/test_item.py
@@ -248,6 +248,17 @@ class TestCreateItem(ItemTest):
         obj = self.get_item_from_modulestore(usage_key)
         self.assertEqual(obj.start, datetime(2030, 1, 1, tzinfo=UTC))
 
+    def test_static_tabs_initialization(self):
+        """
+        Test that static tab display names are not being initialized as None.
+        """
+        # Add a new static tab with no explicit name
+        resp = self.create_xblock(category='static_tab')
+        usage_key = self.response_usage_key(resp)
+
+        # Check that its name is not None
+        new_tab = self.get_item_from_modulestore(usage_key)
+        self.assertEquals(new_tab.display_name, 'Empty') 
 
 class TestDuplicateItem(ItemTest):
     """


### PR DESCRIPTION
@nedbat @jrbl

STUD-2000 

In Studio, when the course administrator creates a new tab, its name was being
initialized as null in the mongo database. This caused students in LMS to get a
server error when trying to access the course page, since LMS was trying to
process the null tabname for translation, etc. Now tabname is initialized as
'Empty', which is how it was being done in the frontend.
