### PR TITLE
Bugfix: anon_user_id from non-ascii course_id

### DIFF
--- a/common/djangoapps/student/tests/tests.py
+++ b/common/djangoapps/student/tests/tests.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 This file demonstrates writing tests using the unittest module. These will pass
 when you run "manage.py test".
@@ -621,3 +622,25 @@ class AnonymousLookupTable(TestCase):
         real_user = user_by_anonymous_id(anonymous_id)
         self.assertEqual(self.user, real_user)
         self.assertEqual(anonymous_id, anonymous_id_for_user(self.user, self.course.id, save=False))
+
+    def test_non_ascii_anon_id(self):
+        """
+        Test that anonymous_id_for_user doesn't fail with course ids that contain
+        non-ascii characters
+        """
+        non_ascii_course = CourseFactory.create(
+            org=self.COURSE_ORG,
+            display_name = u"세원",
+            number=self.COURSE_SLUG
+        )
+        enrollment = CourseEnrollment.enroll(self.user, self.course.id)
+        did_raise = False
+
+        # assert that no Unicode Error is raised
+        try:
+            anon_id = anonymous_id_for_user(self.user, self.course.id)
+        except (UnicodeDecodeError, UnicodeEncodeError):
+            did_raise = True
+
+        self.assertFalse(did_raise)
+


### PR DESCRIPTION
Jira: LMS-11110
https://openedx.atlassian.net/browse/LMS-11110

@jbau @jrbl

Previously, anonymous_user_ids were calculated without correctly encoding
course_ids. This worked with courses that have names that only have ascii code
characters in them. However, this approach fails with course ids with non-ascii
characters.

The problem is, if we switch the method entirely from ascii to utf-8, there
will be compatibility issues with the pre-computed anon_user_ids in the
database (It is lazily instantiated and stored). This case, we would have to
write a script to switch records in the database manually.

So this commit solves this problem by first checking if the course id contains
non-ascii characters and encodes it as utf-8 only if it does. This way, we can
keep all the anon_ids that we have computed and kept in the db.
