### PR TITLE
Implemented Keyword Substitution feature

### DIFF
--- a/cms/startup.py
+++ b/cms/startup.py
@@ -7,7 +7,7 @@ from django.conf import settings
 settings.INSTALLED_APPS  # pylint: disable=W0104
 
 from django_startup import autostartup
-
+from util import keyword_substitution
 
 def run():
     """
@@ -17,6 +17,9 @@ def run():
 
     add_mimetypes()
 
+    # Supply keyword-substitution mapping for CMS
+    # Currently no substitution for CMS
+    keyword_substitution.KEYWORD_FUNCTION_MAP = {}
 
 def add_mimetypes():
     """

--- a/cms/static/js/views/course_info_update.js
+++ b/cms/static/js/views/course_info_update.js
@@ -1,6 +1,6 @@
 define(["js/views/baseview", "codemirror", "js/models/course_update",
-    "js/views/feedback_prompt", "js/views/feedback_notification", "js/views/course_info_helper", "js/utils/modal"],
-    function(BaseView, CodeMirror, CourseUpdateModel, PromptView, NotificationView, CourseInfoHelper, ModalUtils) {
+    "js/views/feedback_prompt", "js/views/feedback_notification", "js/views/course_info_helper", "js/utils/modal", "js/views/utils/view_utils"],
+    function(BaseView, CodeMirror, CourseUpdateModel, PromptView, NotificationView, CourseInfoHelper, ModalUtils, viewUtils) {
 
     var CourseInfoUpdateView = BaseView.extend({
         // collection is CourseUpdateCollection
@@ -73,6 +73,11 @@ define(["js/views/baseview", "codemirror", "js/models/course_update",
 
         onSave: function(event) {
             event.preventDefault();
+            validation = viewUtils.keywordValidator.validate_string(this.$codeMirror.getValue());
+            if (!validation.is_valid) {
+                alert(gettext("There are invalid keywords in your email. Please check the following keywords and try again:") + "\n" + validation.invalid_keywords);
+                return;
+            }
             var targetModel = this.eventModel(event);
             targetModel.set({ date : this.dateEntry(event).val(), content : this.$codeMirror.getValue() });
             // push change to display, hide the editor, submit the change

--- a/cms/static/js/views/utils/view_utils.js
+++ b/cms/static/js/views/utils/view_utils.js
@@ -5,7 +5,7 @@ define(["jquery", "underscore", "gettext", "js/views/feedback_notification", "js
     function ($, _, gettext, NotificationView, PromptView) {
         var toggleExpandCollapse, showLoadingIndicator, hideLoadingIndicator, confirmThenRunOperation,
             runOperationShowingMessage, disableElementWhileRunning, getScrollOffset, setScrollOffset,
-            setScrollTop, redirect, hasChangedAttributes;
+            setScrollTop, redirect, hasChangedAttributes, keywordValidator;
 
         /**
          * Toggles the expanded state of the current element.
@@ -151,6 +151,34 @@ define(["jquery", "underscore", "gettext", "js/views/feedback_notification", "js
             return false;
         };
 
+            var i = 0;
+        keywordValidator = (function () {
+            var regexp = /%%+[^%]+%%/g;
+            var keywords = ['%%USER_ID%%', '%%USER_FULLNAME%%', '%%COURSE_DISPLAY_NAME%%', '%%COURSE_END_DATE%%'];
+            var validate = function (string) {
+                var found_keywords = string.match(regexp);
+                var invalid_keywords = [];
+                var num_found = found_keywords.length;
+                var curr_keyword;
+
+                for (var i = 0; i < num_found; i++) {
+                    curr_keyword = found_keywords[i];
+                    if ($.inArray(curr_keyword, keywords) == -1) {
+                        invalid_keywords.push(curr_keyword);
+                    }
+                }
+
+                return {
+                    'is_valid': invalid_keywords.length == 0? true : false,
+                    'invalid_keywords': invalid_keywords,
+                }
+
+            };
+            return {
+                'validate_string': validate,
+            };
+        }());
+
         return {
             'toggleExpandCollapse': toggleExpandCollapse,
             'showLoadingIndicator': showLoadingIndicator,
@@ -162,6 +190,7 @@ define(["jquery", "underscore", "gettext", "js/views/feedback_notification", "js
             'getScrollOffset': getScrollOffset,
             'setScrollOffset': setScrollOffset,
             'redirect': redirect,
-            'hasChangedAttributes': hasChangedAttributes
+            'hasChangedAttributes': hasChangedAttributes,
+            'keywordValidator': keywordValidator,
         };
     });

--- a/cms/static/js/views/utils/view_utils.js
+++ b/cms/static/js/views/utils/view_utils.js
@@ -156,7 +156,8 @@ define(["jquery", "underscore", "gettext", "js/views/feedback_notification", "js
             var regexp = /%%+[^%]+%%/g;
             var keywords = ['%%USER_ID%%', '%%USER_FULLNAME%%', '%%COURSE_DISPLAY_NAME%%', '%%COURSE_END_DATE%%'];
             var validate = function (string) {
-                var found_keywords = string.match(regexp);
+                var regex_match = string.match(regexp);
+                var found_keywords = regex_match == null ? [] : regex_match
                 var invalid_keywords = [];
                 var num_found = found_keywords.length;
                 var curr_keyword;

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -97,8 +97,11 @@ def anonymous_id_for_user(user, course_id, save=True):
     hasher = hashlib.md5()
     hasher.update(settings.SECRET_KEY)
     hasher.update(unicode(user.id))
+
+    # Since course_id consists of course name strings, convert to utf-8 before hashing
     if course_id:
-        hasher.update(course_id.to_deprecated_string())
+        hasher.update(course_id.to_deprecated_string().encode('utf-8'))
+
     digest = hasher.hexdigest()
 
     if not hasattr(user, '_anonymous_id'):

--- a/common/djangoapps/student/tests/tests.py
+++ b/common/djangoapps/student/tests/tests.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """
 This file demonstrates writing tests using the unittest module. These will pass
 when you run "manage.py test".
@@ -265,6 +267,7 @@ class DashboardTest(TestCase):
         )
 
         self.assertFalse(enrollment.refundable())
+
 
 class EnrollInCourseTest(TestCase):
     """Tests enrolling and unenrolling in courses."""
@@ -636,3 +639,18 @@ class AnonymousLookupTable(TestCase):
         real_user = user_by_anonymous_id(anonymous_id)
         self.assertEqual(self.user, real_user)
         self.assertEqual(anonymous_id, anonymous_id_for_user(self.user, self.course.id, save=False))
+
+    def test_non_ascii_anon_id(self):
+        """
+        Test that anonymous_id_for_user doesn't fail with course ids that contain
+        non-ascii characters
+        """
+        non_ascii_course = CourseFactory.create(
+            org=self.COURSE_ORG,
+            display_name=u"세원",
+            number=self.COURSE_SLUG
+        )
+        enrollment = CourseEnrollment.enroll(self.user, self.course.id)
+        # This shouldn't throw error
+        anon_id = anonymous_id_for_user(self.user, self.course.id)
+

--- a/common/djangoapps/util/keyword_substitution.py
+++ b/common/djangoapps/util/keyword_substitution.py
@@ -1,0 +1,66 @@
+from django.contrib.auth.models import User
+from xmodule.modulestore.django import modulestore
+
+"""
+keyword_substitution.py
+
+Contains utility functions to help substitute keywords in a text body with
+the appropriate user / course data.
+
+Supported:
+    LMS:
+        - %%USER_ID%% => anonymous user id
+        - %%USER_FULLNAME%% => User's full name
+        - %%COURSE_DISPLAY_NAME%% => display name of the course
+        - %%COURSE_END_DATE%% => end date of the course
+
+Usage:
+    KEYWORD_FUNCTION_MAP must be supplied in startup.py, so that it lives
+    above other modules in the dependency tree and acts like a global var.
+    Then we can call substitute_keywords_with_data where substitution is
+    needed. Currently called in:
+        - LMS: Announcements + Bulk emails
+        - CMS: Not called
+"""
+
+KEYWORD_FUNCTION_MAP = {}
+
+def add_keyword_function_map(mapping):
+    """
+    Attaches the given keyword-function map to the existing one
+    """
+    KEYWORD_FUNCTION_MAP.update(mapping)
+
+def add_keyword_function_pair(keyword, func):
+    """
+    Attach one keyword, func pair to the map
+    """
+    KEYWORD_FUNCTION_MAP[keyword] = func
+
+def substitute_keywords_with_data(string, user_id=None, course_id=None):
+    """
+    Iterates through all keywords that must be substituted and replaces
+    them by calling the corresponding functions stored in KEYWORD_FUNCTION_MAP.
+
+    Function stored in KEYWORD_FUNCTION_MAP must return a string to replace with.
+    Also, functions imported from other modules must be wrapped around in a
+    new function if they don't take in user_id and course_id. This is to simplify
+    the forloop below, and eliminate the possibility of unnecessarily piling up
+    if elif else statements when the keyword pool grows.
+    """
+
+    # Do not proceed without parameters: Compatibility check with existing tests
+    # That do not supply these parameters
+    if user_id is None or course_id is None:
+        return string
+
+    # Memoize user objects
+    user = User.objects.get(id=user_id)
+    course = modulestore().get_course(course_id, depth=0)
+
+    for key, func in KEYWORD_FUNCTION_MAP.iteritems():
+        if key in string:
+            substitutor = func(user, course)
+            string = string.replace(key, substitutor)
+
+    return string

--- a/common/djangoapps/util/tests/test_keyword_sub_utils.py
+++ b/common/djangoapps/util/tests/test_keyword_sub_utils.py
@@ -1,0 +1,101 @@
+"""
+Tests for keyword_substitution.py
+"""
+
+from django.test import TestCase
+from student.tests.factories import UserFactory
+from xmodule.modulestore.tests.factories import CourseFactory
+
+from student.models import anonymous_id_for_user
+from util.date_utils import get_default_time_display
+from util import keyword_substitution as Ks
+
+class KeywordSubTest(TestCase):
+
+    def setUp(self):
+        self.user = UserFactory.create(
+            email="testuser@edx.org",
+            username="testuser",
+            profile__name="Test User"
+        )
+        self.course = CourseFactory.create(
+            org='edx',
+            course='999',
+            display_name='test_course'
+        )
+
+        # Mimic monkeypatching done in startup.py
+        Ks.KEYWORD_FUNCTION_MAP = self.get_keyword_function_map()
+
+    def get_keyword_function_map(self):
+        def user_id_sub(user, course):
+            # Don't include course_id for compatibility 
+            return anonymous_id_for_user(user, None)
+
+        def user_fullname_sub(user, course=None):
+            return user.profile.name
+
+        def course_display_name_sub(user, course):
+            return course.display_name
+
+        def course_end_date_sub(user, course):
+            return get_default_time_display(course.end)
+
+        return {
+            '%%USER_ID%%': user_id_sub,
+            '%%USER_FULLNAME%%': user_fullname_sub,
+            '%%COURSE_DISPLAY_NAME%%': course_display_name_sub,
+            '%%COURSE_END_DATE%%': course_end_date_sub
+        }
+
+    def test_course_name_sub(self):
+        test_string = 'Course Display Name: %%COURSE_DISPLAY_NAME%%'
+        course_name = self.course.display_name
+        result = Ks.substitute_keywords_with_data(test_string, self.user.id, self.course.id)
+
+        self.assertIn(course_name, result)
+        self.assertNotIn('%%COURSE_DISPLAY_NAME%%', result)
+
+    def test_anonymous_id_sub(self):
+        test_string = "This is the test string. sub this: %%USER_ID%% into anon_id"
+        anon_id = anonymous_id_for_user(self.user, None)
+        result = Ks.substitute_keywords_with_data(test_string, self.user.id, self.course.id)
+
+        self.assertIn("this: " + anon_id + " into", result)
+        self.assertNotIn("%%USER_ID%%", result)
+
+    def test_name_sub(self):
+        test_string = "This is the test string. subthis:  %%USER_FULLNAME%% into user name"
+        user_name = self.user.profile.name
+        result = Ks.substitute_keywords_with_data(test_string, self.user.id, self.course.id)
+
+        self.assertNotIn('%%USER_FULLNAME', result)
+        self.assertIn(user_name, result)
+
+    def test_anonymous_id_sub_html(self):
+        """
+        Test that sub-ing works in html tags as well
+        """
+        test_string = "<some tag>%%USER_ID%%</some tag>"
+        anon_id = anonymous_id_for_user(self.user, None)
+        result = Ks.substitute_keywords_with_data(test_string, self.user.id, self.course.id)
+
+        self.assertEquals(result, "<some tag>" + anon_id + "</some tag>")
+
+    def test_illegal_subtag(self):
+        """
+        Test that sub-ing doesn't ocurr with illegal tags
+        """
+        test_string = "%%user_id%%"
+        result = Ks.substitute_keywords_with_data(test_string, self.user.id, self.course.id)
+
+        self.assertEquals(test_string, result)
+
+    def test_should_not_sub(self):
+        """
+        Test that sub-ing doesn't work without subtags
+        """
+        test_string = "this string has no subtags"
+        result = Ks.substitute_keywords_with_data(test_string, self.user.id, self.course.id)
+
+        self.assertEquals(test_string, result)

--- a/lms/djangoapps/bulk_email/models.py
+++ b/lms/djangoapps/bulk_email/models.py
@@ -20,6 +20,7 @@ from html_to_text import html_to_text
 from mail_utils import wrap_message
 
 from xmodule_django.models import CourseKeyField
+from util.keyword_substitution import substitute_keywords_with_data
 
 log = logging.getLogger(__name__)
 
@@ -186,15 +187,20 @@ class CourseEmailTemplate(models.Model):
         Such encoding is left to the email code, which will use the value
         of settings.DEFAULT_CHARSET to encode the message.
         """
+
+        # Substitute
+        if 'user_id' in context and 'course_id' in context:
+            message_body = substitute_keywords_with_data(message_body, context['user_id'], context['course_id'])
+
         # If we wanted to support substitution, we'd call:
         # format_string = format_string.replace(COURSE_EMAIL_MESSAGE_BODY_TAG, message_body)
         result = format_string.format(**context)
         # Note that the body tag in the template will now have been
         # "formatted", so we need to do the same to the tag being
         # searched for.
+
         message_body_tag = COURSE_EMAIL_MESSAGE_BODY_TAG.format()
         result = result.replace(message_body_tag, message_body, 1)
-
         # finally, return the result, after wrapping long lines and without converting to an encoded byte array.
         return wrap_message(result)
 

--- a/lms/djangoapps/bulk_email/tasks.py
+++ b/lms/djangoapps/bulk_email/tasks.py
@@ -459,6 +459,8 @@ def _send_course_email(entry_id, email_id, to_list, global_email_context, subtas
             email = current_recipient['email']
             email_context['email'] = email
             email_context['name'] = current_recipient['profile__name']
+            email_context['user_id'] = current_recipient['pk']
+            email_context['course_id'] = course_email.course_id
 
             # Construct message content using templates and context:
             plaintext_msg = course_email_template.render_plaintext(course_email.text_message, email_context)

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -16,6 +16,7 @@ from xmodule.modulestore.exceptions import ItemNotFoundError
 from static_replace import replace_static_urls
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.x_module import STUDENT_VIEW
+from util.keyword_substitution import substitute_keywords_with_data
 
 from courseware.access import has_access
 from courseware.model_data import FieldDataCache
@@ -250,6 +251,7 @@ def get_course_info_section(request, course, section_key):
     if info_module is not None:
         try:
             html = info_module.render(STUDENT_VIEW).content
+            html = substitute_keywords_with_data(html, request.user.id, course.id)
         except Exception:  # pylint: disable=broad-except
             html = render_to_string('courseware/error-message.html', None)
             log.exception(

--- a/lms/static/coffee/src/instructor_dashboard/send_email.coffee
+++ b/lms/static/coffee/src/instructor_dashboard/send_email.coffee
@@ -46,7 +46,7 @@ class SendEmail
         # Validation for keyword substitution
         validation = KeywordValidator().validate_string @$emailEditor.save()['data']
         if not validation.is_valid
-          alert gettext(gettext("There are invalid keywords in your email. Please check the following keywords and try again: \n") + validation.invalid_keywords)
+          alert gettext(gettext("There are invalid keywords in your email. Please check the following keywords and try again:") +"\n"+ validation.invalid_keywords)
           return
         
         success_message = gettext("Your email was successfully queued for sending.")

--- a/lms/static/coffee/src/instructor_dashboard/send_email.coffee
+++ b/lms/static/coffee/src/instructor_dashboard/send_email.coffee
@@ -13,6 +13,7 @@ PendingInstructorTasks = -> window.InstructorDashboard.util.PendingInstructorTas
 create_task_list_table = -> window.InstructorDashboard.util.create_task_list_table.apply this, arguments
 create_email_content_table = -> window.InstructorDashboard.util.create_email_content_table.apply this, arguments
 create_email_message_views = -> window.InstructorDashboard.util.create_email_message_views.apply this, arguments
+KeywordValidator = -> window.InstructorDashboard.util.KeywordValidator
 
 class SendEmail
   constructor: (@$container) ->
@@ -42,6 +43,12 @@ class SendEmail
         alert gettext("Your message cannot be blank.")
 
       else
+        # Validation for keyword substitution
+        validation = KeywordValidator().validate_string @$emailEditor.save()['data']
+        if not validation.is_valid
+          alert gettext(gettext("There are invalid keywords in your email. Please check the following keywords and try again: \n") + validation.invalid_keywords)
+          return
+        
         success_message = gettext("Your email was successfully queued for sending.")
         send_to = @$send_to.val().toLowerCase()
         if send_to == "myself"

--- a/lms/static/coffee/src/instructor_dashboard/util.coffee
+++ b/lms/static/coffee/src/instructor_dashboard/util.coffee
@@ -280,6 +280,30 @@ class PendingInstructorTasks
       error: std_ajax_err => console.error "Error finding pending instructor tasks to display"
     ### /Pending Instructor Tasks Section ####
 
+class KeywordValidator
+
+    @keyword_regex = /%%+[^%]+%%/g
+    @keywords = ['%%USER_ID%%', '%%USER_FULLNAME%%', '%%COURSE_DISPLAY_NAME%%', '%%COURSE_END_DATE%%']
+
+    @validate_string: (string) =>
+      found_keywords = string.match(@keyword_regex)
+      invalid_keywords = []
+      is_valid = true
+      keywords = @keywords
+
+      for found_keyword in found_keywords
+        do (found_keyword) ->
+          if found_keyword not in keywords
+            invalid_keywords.push found_keyword
+      
+      if invalid_keywords.length != 0
+        is_valid = false
+      
+      return {
+        is_valid: is_valid,
+        invalid_keywords: invalid_keywords
+      }
+
 # export for use
 # create parent namespaces if they do not already exist.
 # abort if underscore can not be found.
@@ -294,3 +318,4 @@ if _?
     create_email_content_table: create_email_content_table
     create_email_message_views: create_email_message_views
     PendingInstructorTasks: PendingInstructorTasks
+    KeywordValidator: KeywordValidator

--- a/lms/static/coffee/src/instructor_dashboard/util.coffee
+++ b/lms/static/coffee/src/instructor_dashboard/util.coffee
@@ -286,7 +286,8 @@ class KeywordValidator
     @keywords = ['%%USER_ID%%', '%%USER_FULLNAME%%', '%%COURSE_DISPLAY_NAME%%', '%%COURSE_END_DATE%%']
 
     @validate_string: (string) =>
-      found_keywords = string.match(@keyword_regex)
+      regex_match = string.match(@keyword_regex)
+      found_keywords = if regex_match == null then [] else regex_match
       invalid_keywords = []
       is_valid = true
       keywords = @keywords


### PR DESCRIPTION
@jrbl @jinpa 

![screen shot 2014-07-18 at 4 02 35 pm](https://cloud.githubusercontent.com/assets/3598201/3632888/a5fc93d8-0ecf-11e4-8154-69c818781e70.png)
![screen shot 2014-07-18 at 4 02 11 pm](https://cloud.githubusercontent.com/assets/3598201/3632889/a5fca044-0ecf-11e4-9238-d42c842bf8c3.png)

With this commit, instructors can include keywords in their bulk emails and
announcments that will be automatically substituted to the corresponding value
in the database. This commit introduces: %%USER_ID%% => anonymous_user_id and
%%USER_FULLNAME%% => user profile name.

This substitution in done by common/djangoapps/util/keyword_substitution.py. It
has a map between keywords and functions that will be called on the original
string (html document), and replace each keyword with the return value of the
function. In order to add more keyword substitutions, we can just add
"%%keywords%%" and their function mappings to the map in the future.

In the future, we can use this module to introduce keyword substitution feature
in other places.

*\* Since this feature deals with anonymous user ids, it's dependent on: 
https://github.com/edx/edx-platform/pull/4485
