### PR TITLE
ispublic is in active use by Stanford.

### DIFF
--- a/lms/lib/xblock/mixin.py
+++ b/lms/lib/xblock/mixin.py
@@ -46,8 +46,7 @@ class LmsBlockMixin(XBlockMixin):
     ispublic = Boolean(
         display_name=_("Course Is Public"),
         help=_("Enter true or false. If true, the course is open to the public. If false, the course is open only to admins."),
-        scope=Scope.settings,
-        deprecated=True
+        scope=Scope.settings
     )
     visible_to_staff_only = Boolean(
         help=_("If true, can be seen only by course staff, regardless of start date."),


### PR DESCRIPTION
@mhoeber Removing "ispublic" from deprecated set.
