### PR TITLE
Bulk-email now have links in respective to settings.HTTPS

### DIFF
--- a/lms/djangoapps/bulk_email/tasks.py
+++ b/lms/djangoapps/bulk_email/tasks.py
@@ -140,16 +140,18 @@ def _get_course_email_context(course):
     """
     course_id = course.id.to_deprecated_string()
     course_title = course.display_name
-    course_url = 'https://{}{}'.format(
+    scheme = "https" if settings.HTTPS == "on" else "http"
+    course_url = '{}://{}{}'.format(
+        scheme,
         settings.SITE_NAME,
         reverse('course_root', kwargs={'course_id': course_id})
     )
-    image_url = 'https://{}{}'.format(settings.SITE_NAME, course_image_url(course))
+    image_url = '{}://{}{}'.format(scheme, settings.SITE_NAME, course_image_url(course))
     email_context = {
         'course_title': course_title,
         'course_url': course_url,
         'course_image_url': image_url,
-        'account_settings_url': 'https://{}{}'.format(settings.SITE_NAME, reverse('dashboard')),
+        'account_settings_url': '{}://{}{}'.format(scheme, settings.SITE_NAME, reverse('dashboard')),
         'platform_name': settings.PLATFORM_NAME,
     }
     return email_context

--- a/lms/djangoapps/bulk_email/tasks.py
+++ b/lms/djangoapps/bulk_email/tasks.py
@@ -140,18 +140,18 @@ def _get_course_email_context(course):
     """
     course_id = course.id.to_deprecated_string()
     course_title = course.display_name
-    scheme = "https" if settings.HTTPS == "on" else "http"
+    protocol = "https" if settings.HTTPS == "on" else "http"
     course_url = '{}://{}{}'.format(
-        scheme,
+        protocol,
         settings.SITE_NAME,
         reverse('course_root', kwargs={'course_id': course_id})
     )
-    image_url = '{}://{}{}'.format(scheme, settings.SITE_NAME, course_image_url(course))
+    image_url = '{}://{}{}'.format(protocol, settings.SITE_NAME, course_image_url(course))
     email_context = {
         'course_title': course_title,
         'course_url': course_url,
         'course_image_url': image_url,
-        'account_settings_url': '{}://{}{}'.format(scheme, settings.SITE_NAME, reverse('dashboard')),
+        'account_settings_url': '{}://{}{}'.format(protocol, settings.SITE_NAME, reverse('dashboard')),
         'platform_name': settings.PLATFORM_NAME,
     }
     return email_context


### PR DESCRIPTION
Bulk emails always have links on https version of course, dashboard and course image.

Well, this PR fixed it. Easy-cheezey.

I understand, there are no tests here. But I just cannot figure out, how test this one. If someone could help me to write tests for that...
