### PR TITLE
Use the CDN-friendly URLs for the Powered-By logos

### DIFF
--- a/lms/templates/footer.html
+++ b/lms/templates/footer.html
@@ -65,11 +65,11 @@
       <p>
         <a href="http://openedx.org/">
           ## standard powered-by logo
-          <img src="https://s3.amazonaws.com/files.edx.org/openedx-logos/edx-openedx-logo-tag.png" alt="Powered by Open edX" width="150" height="50" />
+          <img src="https://files.edx.org/openedx-logos/edx-openedx-logo-tag.png" alt="Powered by Open edX" width="150" height="50" />
           ## greyscale logo for dark background
-          ## <img src="https://s3.amazonaws.com/files.edx.org/openedx-logos/edx-openedx-logo-tag-light.png" alt="Powered by Open edX" width="150" height="50" />
+          ## <img src="https://files.edx.org/openedx-logos/edx-openedx-logo-tag-light.png" alt="Powered by Open edX" width="150" height="50" />
           ## greyscale logo for light background
-          ## <img src="https://s3.amazonaws.com/files.edx.org/openedx-logos/edx-openedx-logo-tag-dark.png" alt="Powered by Open edX" width="150" height="50" />
+          ## <img src="https://files.edx.org/openedx-logos/edx-openedx-logo-tag-dark.png" alt="Powered by Open edX" width="150" height="50" />
         </a>
       </p>
     </div>


### PR DESCRIPTION
John Jarvis updated the wiki page to use better URLs: https://github.com/edx/edx-platform/wiki/Powered-by-Open-edX-Logos.  This updates the footer to use those URLs.
