### PR TITLE
Make overriding branch settings thread-safe LMS-11125

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/__init__.py
+++ b/common/lib/xmodule/xmodule/modulestore/__init__.py
@@ -548,18 +548,6 @@ class ModuleStoreReadBase(ModuleStoreRead):
             raise ValueError(u"Cannot set default store to type {}".format(store_type))
         yield
 
-    @contextmanager
-    def branch_setting(self, branch_setting, course_id=None):
-        """
-        A context manager for temporarily setting a store's branch value
-        """
-        previous_branch_setting_func = getattr(self, 'branch_setting_func', None)
-        try:
-            self.branch_setting_func = lambda: branch_setting
-            yield
-        finally:
-            self.branch_setting_func = previous_branch_setting_func
-
 
 class ModuleStoreWriteBase(ModuleStoreReadBase, ModuleStoreWrite):
     '''

--- a/common/lib/xmodule/xmodule/modulestore/draft_and_published.py
+++ b/common/lib/xmodule/xmodule/modulestore/draft_and_published.py
@@ -2,10 +2,64 @@
 This module provides an abstraction for Module Stores that support Draft and Published branches.
 """
 
+import threading
 from abc import ABCMeta, abstractmethod
+from contextlib import contextmanager
 from . import ModuleStoreEnum
 
-class ModuleStoreDraftAndPublished(object):
+
+class BranchSettingMixin(object):
+    """
+    A mixin to manage a module store's branch setting.
+    The order of override is (from higher precedence to lower):
+       1. thread-specific setting temporarily set using the branch_setting contextmanager
+       2. the return value of the branch_setting_func passed into this mixin's init method
+       3. the default branch setting being ModuleStoreEnum.Branch.published_only
+    """
+
+    def __init__(self, *args, **kwargs):
+        """
+        :param branch_setting_func: a function that returns the default branch setting for this object.
+            If not specified, ModuleStoreEnum.Branch.published_only is used as the default setting.
+        """
+        super(BranchSettingMixin, self).__init__(*args, **kwargs)
+        self.default_branch_setting_func = kwargs.pop(
+            'branch_setting_func',
+            lambda: ModuleStoreEnum.Branch.published_only
+        )
+
+        # cache the branch setting on a local thread to support a multi-threaded environment
+        self.thread_cache = threading.local()
+
+    @contextmanager
+    def branch_setting(self, branch_setting, course_id=None):  # pylint: disable=unused-argument
+        """
+        A context manager for temporarily setting a store's branch value on the current thread.
+        """
+        previous_thread_branch_setting = getattr(self.thread_cache, 'branch_setting', None)
+        try:
+            self.thread_cache.branch_setting = branch_setting
+            yield
+        finally:
+            self.thread_cache.branch_setting = previous_thread_branch_setting
+
+    def get_branch_setting(self, course_id=None):  # pylint: disable=unused-argument
+        """
+        Returns the current branch_setting on the store.
+
+        Returns the thread-local setting, if set.
+        Otherwise, returns the default value of the setting function set during the store's initialization.
+        """
+        # first check the thread-local cache
+        thread_local_branch_setting = getattr(self.thread_cache, 'branch_setting', None)
+        if thread_local_branch_setting:
+            return thread_local_branch_setting
+        else:
+            # return the default value
+            return self.default_branch_setting_func()
+
+
+class ModuleStoreDraftAndPublished(BranchSettingMixin):
     """
     A mixin for a read-write database backend that supports two branches, Draft and Published, with
     options to prefer Draft and fallback to Published.
@@ -14,7 +68,6 @@ class ModuleStoreDraftAndPublished(object):
 
     def __init__(self, *args, **kwargs):
         super(ModuleStoreDraftAndPublished, self).__init__(*args, **kwargs)
-        self.branch_setting_func = kwargs.pop('branch_setting_func', lambda: ModuleStoreEnum.Branch.published_only)
 
     @abstractmethod
     def delete_item(self, location, user_id, revision=None, **kwargs):

--- a/common/lib/xmodule/xmodule/modulestore/mixed.py
+++ b/common/lib/xmodule/xmodule/modulestore/mixed.py
@@ -142,7 +142,7 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
         store = self._get_modulestore_for_courseid(usage_key.course_key)
         return store.get_item(usage_key, depth, **kwargs)
 
-    def get_items(self, course_key, settings=None, content=None, **kwargs):
+    def get_items(self, course_key, **kwargs):
         """
         Returns:
             list of XModuleDescriptor instances for the matching items within the course with
@@ -153,11 +153,12 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
 
         Args:
             course_key (CourseKey): the course identifier
-            settings (dict): fields to look for which have settings scope. Follows same syntax
-                and rules as kwargs below
-            content (dict): fields to look for which have content scope. Follows same syntax and
-                rules as kwargs below.
-            kwargs (key=value): what to look for within the course.
+            kwargs:
+                settings (dict): fields to look for which have settings scope. Follows same syntax
+                    and rules as kwargs below
+                content (dict): fields to look for which have content scope. Follows same syntax and
+                    rules as kwargs below.
+            additional kwargs (key=value): what to look for within the course.
                 Common qualifiers are ``category`` or any field name. if the target field is a list,
                 then it searches for the given value in the list not list equivalence.
                 Substring matching pass a regex object.
@@ -170,7 +171,7 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
             raise Exception("Must pass in a course_key when calling get_items()")
 
         store = self._get_modulestore_for_courseid(course_key)
-        return store.get_items(course_key, settings=settings, content=content, **kwargs)
+        return store.get_items(course_key, **kwargs)
 
     def get_courses(self):
         '''
@@ -519,7 +520,7 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
         A context manager for temporarily setting the branch value for the given course' store
         to the given branch_setting.  If course_id is None, the default store is used.
         """
-        store = self._get_modulestore_for_courseid(course_id)
+        store = self._verify_modulestore_support(course_id, 'branch_setting')
         with store.branch_setting(branch_setting, course_id):
             yield
 

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_xml.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_xml.py
@@ -107,3 +107,19 @@ class TestXMLModuleStore(unittest.TestCase):
             SlashSeparatedCourseKey('edX', 'toy', '2012_Fall'),
             locator_key_fields=SlashSeparatedCourseKey.KEY_FIELDS
         )
+
+    def test_branch_setting(self):
+        """
+        Test the branch setting context manager
+        """
+        store = XMLModuleStore(DATA_DIR, course_dirs=['toy'])
+        course_key = store.get_courses()[0]
+
+        # XML store allows published_only branch setting
+        with store.branch_setting(ModuleStoreEnum.Branch.published_only, course_key):
+            store.get_item(course_key.location)
+
+        # XML store does NOT allow draft_preferred branch setting
+        with self.assertRaises(ValueError):
+            with store.branch_setting(ModuleStoreEnum.Branch.draft_preferred, course_key):
+                pass

--- a/common/lib/xmodule/xmodule/modulestore/xml.py
+++ b/common/lib/xmodule/xmodule/modulestore/xml.py
@@ -13,6 +13,7 @@ from fs.osfs import OSFS
 from importlib import import_module
 from lxml import etree
 from path import path
+from contextlib import contextmanager
 
 from xmodule.error_module import ErrorDescriptor
 from xmodule.errortracker import make_error_tracker, exc_info_to_str
@@ -408,9 +409,6 @@ class XMLModuleStore(ModuleStoreReadBase):
         self.field_data = inheriting_field_data(kvs=DictKeyValueStore())
 
         self.i18n_service = i18n_service
-
-        # The XML Module Store is a read-only store and only handles published content
-        self.branch_setting_func = lambda: ModuleStoreEnum.RevisionOption.published_only
 
         # If we are specifically asked for missing courses, that should
         # be an error.  If we are asked for "all" courses, find the ones
@@ -826,3 +824,11 @@ class XMLModuleStore(ModuleStoreReadBase):
         """
         return {ModuleStoreEnum.Type.xml: True}
 
+    @contextmanager
+    def branch_setting(self, branch_setting, course_id=None):  # pylint: disable=unused-argument
+        """
+        A context manager for temporarily setting the branch value for the store to the given branch_setting.
+        """
+        if branch_setting != ModuleStoreEnum.Branch.published_only:
+            raise ValueError(u"Cannot set branch setting to {} on a ReadOnly store".format(branch_setting))
+        yield

--- a/common/lib/xmodule/xmodule/modulestore/xml_importer.py
+++ b/common/lib/xmodule/xmodule/modulestore/xml_importer.py
@@ -162,8 +162,8 @@ def import_from_xml(
     # method on XmlModuleStore.
     course_items = []
 
-    with store.branch_setting(ModuleStoreEnum.Branch.draft_preferred):
-        for course_key in xml_module_store.modules.keys():
+    for course_key in xml_module_store.modules.keys():
+        with store.branch_setting(ModuleStoreEnum.Branch.draft_preferred, course_key):
 
             if target_course_id is not None:
                 dest_course_id = target_course_id


### PR DESCRIPTION
https://openedx.atlassian.net/browse/LMS-11125

_Note_: As described in the ticket, this is an actual issue in Studio. When exporting a course, we temporarily set the branch_setting to `published_only`. This could potentially collide with other requests that are active at the same time (they would not see Draft content).

@cpennington @dmitchell @sarina  Please review.

Updating the Split Modulestore to use the new branch_setting implementation is a separate PR: https://github.com/edx/edx-platform/pull/4514
