### PR TITLE
username and email request for lti module

### DIFF
--- a/common/lib/xmodule/xmodule/css/lti/lti.scss
+++ b/common/lib/xmodule/xmodule/css/lti/lti.scss
@@ -34,6 +34,10 @@ div.lti {
         }
     }
 
+    div.ltiTextBox {
+        width: 280px;
+    }
+
     form.ltiLaunchForm {
         display: none;
     }

--- a/common/lib/xmodule/xmodule/lti_module.py
+++ b/common/lib/xmodule/xmodule/lti_module.py
@@ -191,6 +191,35 @@ class LTIFields(object):
         default=False,
         scope=Scope.settings
     )
+    """
+        Users will be presented with a message indicating that their e-mail/username would be sent to a third 
+        party application. When "Open in new Page" is not selected, the tool automatically appears without any user action.
+    """
+    request_username = Boolean(
+        display_name=_("Request user's username"),
+        help=_(
+            "Requesting user's username will only work if 'Open in a new page' is set to True"
+        ),
+        default=False,
+        scope=Scope.settings
+    )
+    request_email = Boolean(
+        display_name=_("Request user's email"),
+        help=_(
+            "Requesting user's email will only work if 'Open in a new page' is set to True"
+        ),
+        default=False,
+        scope=Scope.settings
+    )
+
+    text_box = String(
+        display_name=_("LTI Application Information"),
+        help=_(
+            "Provide a description of the third party application. If requesting username and/or email, use this text box to inform users "
+            "that their username and/or email will be forwarded to a third party application."),
+        default="",
+        scope=Scope.settings
+    )
 
 
 class LTIModule(LTIFields, LTI20ModuleMixin, XModule):
@@ -317,6 +346,7 @@ class LTIModule(LTIFields, LTI20ModuleMixin, XModule):
 
         # parsing custom parameters to dict
         custom_parameters = {}
+
         for custom_parameter in self.custom_parameters:
             try:
                 param_name, param_value = [p.strip() for p in custom_parameter.split('=', 1)]
@@ -370,6 +400,10 @@ class LTIModule(LTIFields, LTI20ModuleMixin, XModule):
             'weight': self.weight,
             'module_score': self.module_score,
             'comment': sanitized_comment,
+            'text_box': self.text_box,
+            'request_username': self.request_username,
+            'request_email': self.request_email,
+
         }
 
     def get_html(self):
@@ -514,6 +548,26 @@ class LTIModule(LTIFields, LTI20ModuleMixin, XModule):
         if self.has_score:
             body.update({
                 u'lis_outcome_service_url': self.get_outcome_service_url()
+            })
+
+        self.user_email = ""
+        self.user_username = ""
+
+        # Username and email can't be sent in studio mode, because the user object is not defined.
+        # To test functionality test in LMS
+        
+        if self.runtime.get_real_user is not None:
+            real_user_object = self.runtime.get_real_user(self.runtime.anonymous_student_id)
+            self.user_email = real_user_object.email
+            self.user_username  = real_user_object.username
+
+        if self.request_username and self.user_username and self.open_in_a_new_page:
+            body.update({
+                u'lis_person_sourcedid': self.user_username
+            })
+        if self.request_email and self.user_email and self.open_in_a_new_page:
+            body.update({
+                u'lis_person_contact_email_primary': self.user_email
             })
 
         # Appending custom parameter for signing.

--- a/lms/djangoapps/courseware/tests/test_lti_integration.py
+++ b/lms/djangoapps/courseware/tests/test_lti_integration.py
@@ -89,6 +89,9 @@ class TestLTI(BaseTestXmodule):
             'module_score': None,
             'comment': u'',
             'weight': 1.0,
+            'request_username': self.item_descriptor.request_username,
+            'request_email': self.item_descriptor.request_email,
+            'text_box': self.item_descriptor.text_box,
         }
 
         def mocked_sign(self, *args, **kwargs):

--- a/lms/templates/lti.html
+++ b/lms/templates/lti.html
@@ -26,6 +26,9 @@
 % if launch_url and launch_url !=  'http://www.example.com' and not hide_launch:
     % if open_in_a_new_page:
         <div class="wrapper-lti-link">
+            <div class="ltiTextBox">
+                <span>${text_box}</span>
+            </div>
             <p class="lti-link external"><a target="_blank" class="link_lti_new_window" href="${form_url}">
                 ${_('View resource in a new window')}
                  <i class="icon-external-link"></i>
@@ -43,7 +46,7 @@
     <h3 class="error_message">
         ${_('Please provide launch_url. Click "Edit", and fill in the required fields.')}
     </h3>
-%endif
+% endif
 
 % if has_score and comment:
     <h4 class="problem-feedback-label">${_("Feedback on your work from the grader:")}</h4>


### PR DESCRIPTION
Necessary for MIT course starting early October. Please merge as soon as possible to facilitate feature testing.

added username and email functionality, so that username and email can be passed to the lti third party app
