### PR TITLE
Non-active accounts activated on email change confirmation

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -97,6 +97,7 @@ AUDIT_LOG = logging.getLogger("audit")
 
 ReverifyInfo = namedtuple('ReverifyInfo', 'course_id course_name course_number date status display')  # pylint: disable=C0103
 
+
 def csrf_token(context):
     """A csrf token that can be included in a form."""
     csrf_token = context.get('csrf_token', '')
@@ -257,8 +258,8 @@ def get_course_enrollment_pairs(user, course_org_filter, org_filter_out_set):
             yield (course, enrollment)
         else:
             log.error("User {0} enrolled in {2} course {1}".format(
-                        user.username, enrollment.course_id, "broken" if course else "non-existent"
-                     ))
+                user.username, enrollment.course_id, "broken" if course else "non-existent"
+            ))
 
 
 def _cert_info(user, course, cert_status):
@@ -1495,35 +1496,25 @@ def auto_auth(request):
 @ensure_csrf_cookie
 def activate_account(request, key):
     """When link in activation e-mail is clicked"""
-    r = Registration.objects.filter(activation_key=key)
-    if len(r) == 1:
+    try:
+        account_activated = _do_account_activation(request.user, key)
+    except Registration.DoesNotExist:
+        return render_to_response(
+            "registration/activation_invalid.html",
+            {'csrf': csrf(request)['csrf_token']},
+        )
+    else:
         user_logged_in = request.user.is_authenticated()
-        already_active = True
-        if not r[0].user.is_active:
-            r[0].activate()
-            already_active = False
-
-        # Enroll student in any pending courses he/she may have if auto_enroll flag is set
-        student = User.objects.filter(id=r[0].user_id)
-        if student:
-            ceas = CourseEnrollmentAllowed.objects.filter(email=student[0].email)
-            for cea in ceas:
-                if cea.auto_enroll:
-                    CourseEnrollment.enroll(student[0], cea.course_id)
-
+        already_active = not account_activated
         resp = render_to_response(
             "registration/activation_complete.html",
             {
                 'user_logged_in': user_logged_in,
-                'already_active': already_active
+                'already_active': already_active,
             }
         )
         return resp
-    if len(r) == 0:
-        return render_to_response(
-            "registration/activation_invalid.html",
-            {'csrf': csrf(request)['csrf_token']}
-        )
+
     return HttpResponse(_("Unknown error. Please e-mail us to let us know how it happened."))
 
 
@@ -1728,7 +1719,8 @@ def change_email_request(request):
     context = {
         'key': pec.activation_key,
         'old_email': user.email,
-        'new_email': pec.new_email
+        'new_email': pec.new_email,
+        'needs_activation': (not user.is_active),
     }
 
     subject = render_to_string('emails/email_change_subject.txt', context)
@@ -1756,7 +1748,8 @@ def change_email_request(request):
 @transaction.commit_manually
 def confirm_email_change(request, key):
     """ User requested a new e-mail. This is called when the activation
-    link is clicked. We confirm with the old e-mail, and update
+    link is clicked. We confirm with the old e-mail, and update.
+    The user account is also activated if it hasn't been already
     """
     try:
         try:
@@ -1805,6 +1798,15 @@ def confirm_email_change(request, key):
         except Exception:
             log.warning('Unable to send confirmation email to new address', exc_info=True)
             response = render_to_response("email_change_failed.html", {'email': pec.new_email})
+            transaction.rollback()
+            return response
+
+        # Activate user who is not yet active
+        try:
+            address_context['account_activated'] = _do_account_activation(user, None)
+        except Registration.DoesNotExist:
+            log.warning('No matching Registration object for non-activated user', exc_info=True)
+            response = render_to_response("registration/activation_invalid.html", {'csrf': csrf(request)['csrf_token']})
             transaction.rollback()
             return response
 
@@ -1946,3 +1948,38 @@ def change_email_settings(request):
         track.views.server_track(request, "change-email-settings", {"receive_emails": "no", "course": course_id}, page='dashboard')
 
     return JsonResponse({"success": True})
+
+
+def _do_account_activation(user, key):
+    """
+    Activates the given user if not already activated, and auto enrolls.
+
+    True is returned if the user has been activated, false otherwise.
+    An exception is thrown if no matching Registration object is found.
+    """
+    if key is not None:
+        # If given a registration key, get registration obj with it
+        register_obj = Registration.objects.get(activation_key=key)
+    else:
+        # Otherwise, grab registration obj that matches user
+        register_obj = Registration.objects.get(user=user)
+
+    activated = False
+    if not register_obj.user.is_active:
+        register_obj.activate()
+        activated = True
+    _auto_enroll(register_obj)
+    return activated
+
+
+def _auto_enroll(register_obj):
+    """Enroll in pending courses if auto_enroll enabled"""
+    try:
+        student = User.objects.get(id=register_obj.user_id)
+    except User.DoesNotExist:
+        return
+    else:
+        ceas = CourseEnrollmentAllowed.objects.filter(email=student.email)
+        for cea in ceas:
+            if cea.auto_enroll:
+                CourseEnrollment.enroll(student, cea.course_id)

--- a/lms/templates/email_change_successful.html
+++ b/lms/templates/email_change_successful.html
@@ -6,12 +6,23 @@
 <section class="container activation">
 
   <section class="message">
-    <h1 class="valid">${_("E-mail change successful!")}</h1>
-    <hr class="horizontal-divider">
+    % if account_activated:
+      <h1 class="valid">${_("E-mail change successful, account activated!")}</h1>
+      <hr class="horizontal-divider">
 
-    <p>${_('You should see your new email in your {link_start}dashboard{link_end}.').format(
-        link_start='<a href="{url}">'.format(url=reverse('dashboard')),
-        link_end='</a>',
-      )}</p>
+      <p>
+        ${_('Thanks for activating your account. Visit your {link_start}dashboard{link_end} '
+        'to see your courses.').format( link_start='<a href="{url}">'.format(url=reverse('dashboard')),
+        link_end='</a>')}
+      </p>
+    % else:
+      <h1 class="valid">${_("E-mail change successful!")}</h1>
+      <hr class="horizontal-divider">
+
+      <p>${_('You should see your new email in your {link_start}dashboard{link_end}.').format(
+          link_start='<a href="{url}">'.format(url=reverse('dashboard')),
+          link_end='</a>',
+        )}</p>
+    % endif
   </section>
 </section>

--- a/lms/templates/emails/email_change.txt
+++ b/lms/templates/emails/email_change.txt
@@ -1,9 +1,14 @@
 <%! from django.utils.translation import ugettext as _ %>
 <%namespace file="../main.html" import="stanford_theme_enabled" />
 ${_("We received a request to change the e-mail associated with your "
-    "{platform_name} account from {old_email} to {new_email}. "
-    "If this is correct, please confirm your new e-mail address by "
-    "visiting:").format(platform_name=settings.PLATFORM_NAME, old_email=old_email, new_email=new_email)}
+    "{platform_name} account from {old_email} to {new_email}."
+    ).format(platform_name=settings.PLATFORM_NAME, old_email=old_email, new_email=new_email)}
+% if needs_activation:
+${_("If this is correct, please confirm your new e-mail address and activate "
+      "your account by visiting:")}
+% else:
+${_("If this is correct, please confirm your new e-mail address by visiting:")}
+% endif
 
 % if is_secure:
  https://${ site }/email_confirm/${ key }

--- a/lms/templates/registration/activate_account_notice.html
+++ b/lms/templates/registration/activate_account_notice.html
@@ -1,3 +1,6 @@
 <%! from django.utils.translation import ugettext as _ %>
 <h2>${_("Thanks For Registering!")}</h2>
-<p class='activation-message'>${_("Your account is not active yet. An activation link has been sent to {email}, along with instructions for activating your account.").format(email="<strong>{}</strong>".format(email))}</p>
+<p class='activation-message'>${_("Your account is not active yet. An activation link has been sent to {email}, along with instructions for activating your account. "
+    "If you don't see it within a couple of minutes, check your Spam filter. Also make sure that there aren't any typos in your email address - "
+    "if there are, click {link_start}here{link_end} to change your email address.").format(email="<strong>{}</strong>".format(email),
+    link_start='<a href="#change_email" rel="leanModal" class="edit-email">', link_end='</a>')}</p>


### PR DESCRIPTION
Previously, when a newly registered user mistyped their email address, they would be left unable to activate their account because even after changing their email address to the correct one, they had no way of reaching the account activation email that was sent to the incorrect address. Users would have to contact course ops to have their accounts activated.
To remedy this, account activation and the confirmation of a new email address has been combined for non-active account. The text displayed on the dashboard for newly registered but non-active accounts has also been changed to be less misleading, and to encourage users to check their email addresses and correct them if necessary.
![email-and-account-confirmation-msg](https://cloud.githubusercontent.com/assets/4758600/3650481/abd314f4-111c-11e4-8046-3156a78c78d6.png)

![screen shot 2014-07-22 at 10 23 58 am](https://cloud.githubusercontent.com/assets/4758600/3661895/004d420e-11c5-11e4-9db6-923230a7133d.png)
