### PR TITLE
Make create_item return the xblock as obtained from get_item.

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -1015,7 +1015,8 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
         xblock = self.create_xmodule(location, **kwargs)
         self.update_item(xblock, user_id, allow_not_found=True)
 
-        return xblock
+        # Retrieve the item from the store so that it has edit info attributes
+        return self.get_item(xblock.location)
 
     def create_child(self, user_id, parent_usage_key, block_type, block_id=None, **kwargs):
         """

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_mixed_modulestore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_mixed_modulestore.py
@@ -430,10 +430,13 @@ class TestMixedModuleStore(unittest.TestCase):
         self.assertEqual(parent, self.course_locations[self.XML_COURSEID1])
 
     def verify_get_parent_locations_results(self, expected_results):
+        def branch_agnostic(location):
+            return location if location is None else location.for_branch(None)
+
         for child_location, parent_location, revision in expected_results:
             self.assertEqual(
-                parent_location,
-                self.store.get_parent_location(child_location, revision=revision)
+                branch_agnostic(parent_location),
+                branch_agnostic(self.store.get_parent_location(child_location, revision=revision))
             )
 
     @ddt.data('draft', 'split')

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_publish.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_publish.py
@@ -19,7 +19,7 @@ class TestPublish(SplitWMongoCourseBoostrapper):
         # There are 12 created items and 7 parent updates
         # create course: finds: 1 to verify uniqueness, 1 to find parents
         # sends: 1 to create course, 1 to create overview
-        with check_mongo_calls(self.draft_mongo, 6, 2):
+        with check_mongo_calls(self.draft_mongo, 7, 2):
             super(TestPublish, self)._create_course(split=False)  # 2 inserts (course and overview)
 
         # with bulk will delay all inheritance computations which won't be added into the mongo_calls
@@ -62,7 +62,7 @@ class TestPublish(SplitWMongoCourseBoostrapper):
                     'vertical', 'Vert2',
                     split=False
                 )
-            with check_mongo_calls(self.draft_mongo, 2, 2):
+            with check_mongo_calls(self.draft_mongo, 4, 2):
                 # 2 finds b/c looking for non-existent parents
                 self._create_item('static_tab', 'staticuno', "<p>tab</p>", {'display_name': 'Tab uno'}, None, None, split=False)
                 self._create_item('course_info', 'updates', "<ol><li><h2>Sep 22</h2><p>test</p></li></ol>", {}, None, None, split=False)


### PR DESCRIPTION
Needed so that all editing info fields will be populated. We had made this change on the bulk publishing branch (before the code was moved from mixed modulestore into the individual modulestores).

Note that this is also consistent with the implementation in split.py. @nasthagiri and @cpennington please review.

As to the test_mixed_modulestore change, here is an e-mail from @nasthagiri describing the issue:

---

The problem is that the implementation of .replace is different between SlashSeparatedCourseKey and CourseLocator.  If you look at the _key member in the 2 locations, you'll see the underlying key object that is used.

The old implementation in SlashSeparatedCourseKey had overridden all attributes, including "branch" when .replace was called.  However, the new implementation in CourseLocator keeps the attribute values, including "branch".

So it seems one would NOT run into this issue if they happened to have used a SlashSeparatedCourseKey.

The location variable in create_item in base.py happens to be a SlashSeparatedCourseKey.  But when you changed it to return the return value of get_item, it happened to load the xblock, which creates a CourseLocator.

In the end, I believe the test in test_mixed_modulestore needs to be updated to be branch_agnostic.

@cpennington , here's another case of a hard-to-debug issue having to do with comparison of Key objects - one having a Branch specified and the other not.  It just happened to work before since SlashSeparatedCourseKeys implemented .replace differently (only capturing the org/course/run from the previous object).
