### PR TITLE
Text Annotation Tool: Safari Colored Highlights Bug Fix

### DIFF
--- a/common/static/js/vendor/ova/tags-annotator.js
+++ b/common/static/js/vendor/ova/tags-annotator.js
@@ -1035,9 +1035,17 @@ Annotator.Plugin.HighlightTags = (function(_super) {
                     if(anns.tags[index].indexOf("flagged-") == -1){
                         if (typeof this.colors[anns.tags[index]] != "undefined") {
                             var finalcolor = this.colors[anns.tags[index]];
-                            $(annotations[annNum]).css("background","rgba("+finalcolor.red+","+finalcolor.green+","+finalcolor.blue+",0.3");
+                            $(annotations[annNum]).css(
+                                "background", 
+                                // last value, 0.3 is the standard highlight opacity for annotator
+                                "rgba(" + finalcolor.red + ", " + finalcolor.green + ", " + finalcolor.blue + ", 0.3)"
+                            );
                         }else{
-                            $(annotations[annNum]).css("background","");
+                            $(annotations[annNum]).css(
+                                "background", 
+                                // returns the value to the inherited value without the above
+                                ""
+                            );
                         }
                     }
                 }


### PR DESCRIPTION
**Background:** Forgot to close a set of Parentheses and it is causing CSS inconsistencies between Safari and the rest of the browsers.

**Studio Updates:** None.

**LMS Updates:** Literally added a parenthesis. It will now allow tagging to change the color of the highlighted annotations in Safari.

**Testing:** Set up the text annotation component in Advanced Settings under "advanced_modules." Add the component to a Unit and head over to the LMS and add an annotation. Make sure to add a tag with a color (defaults to "imagery" being red and "parallelism" being blue). Before if you did that in Safari, it would stay yellow. 
