### PR TITLE
Work around for JQuery sortable bug (placeholder smaller than component).

### DIFF
--- a/cms/static/js/views/container.js
+++ b/cms/static/js/views/container.js
@@ -20,6 +20,12 @@ define(["jquery", "underscore", "js/views/xblock", "js/utils/module", "gettext",
                 reorderableContainer.sortable({
                     handle: '.drag-handle',
 
+                    start: function (event, ui) {
+                        // Necessary because of an open bug in JQuery sortable.
+                        // http://bugs.jqueryui.com/ticket/4990
+                        reorderableContainer.sortable('refreshPositions');
+                    },
+
                     stop: function (event, ui) {
                         var saving, hideSaving, removeFromParent;
 

--- a/common/test/acceptance/tests/test_studio_container.py
+++ b/common/test/acceptance/tests/test_studio_container.py
@@ -205,7 +205,6 @@ class DragAndDropTest(NestedVerticalTest):
             expected_ordering
         )
 
-    @skip("Sporadically drags outside of the Group.")
     def test_reorder_in_group(self):
         """
         Drag Group A Item 2 before Group A Item 1.


### PR DESCRIPTION
STUD-1967

@andy-armstrong Please review. The unskipped test passed 4 times for me. If it ends up failing in Jenkins, I will restore the skip.
