### PR TITLE
BLD-1104: List units that use group configuration.

### DIFF
--- a/cms/static/js/models/group_configuration.js
+++ b/cms/static/js/models/group_configuration.js
@@ -22,7 +22,8 @@ function(Backbone, _, str, gettext, GroupModel, GroupCollection) {
                     }
                 ]),
                 showGroups: false,
-                editing: false
+                editing: false,
+                usage: []
             };
         },
 

--- a/cms/static/js/spec/models/group_configuration_spec.js
+++ b/cms/static/js/spec/models/group_configuration_spec.js
@@ -9,6 +9,9 @@ define([
       this.addMatchers({
         toBeInstanceOf: function(expected) {
           return this.actual instanceof expected;
+        },
+        toBeEmpty: function() {
+            return this.actual.length === 0;
         }
       });
     });
@@ -38,6 +41,10 @@ define([
                 expect(groups).toBeInstanceOf(GroupCollection);
                 expect(groups.at(0).get('name')).toBe('Group A');
                 expect(groups.at(1).get('name')).toBe('Group B');
+            });
+
+            it('should have an empty usage by default', function() {
+                expect(this.model.get('usage')).toBeEmpty();
             });
 
             it('should be able to reset itself', function() {
@@ -120,7 +127,8 @@ define([
                                 'order': 1,
                                 'name': 'Group 2'
                             }
-                        ]
+                        ],
+                        'usage': []
                     },
                     model = new GroupConfigurationModel(
                         serverModelSpec, { parse: true }

--- a/cms/static/js/spec/views/group_configuration_spec.js
+++ b/cms/static/js/spec/views/group_configuration_spec.js
@@ -28,6 +28,12 @@ define([
         inputGroupName: '.group-name',
         inputName: '.group-configuration-name-input',
         inputDescription: '.group-configuration-description-input',
+        usageCount: '.group-configuration-usage-count',
+        usage: '.group-configuration-usage',
+        usageText: '.group-configuration-usage-text',
+        usageTextAnchor: '.group-configuration-usage-text > a',
+        usageUnit: '.group-configuration-usage-unit',
+        usageUnitAnchor: '.group-configuration-usage-unit > a'
     };
 
     beforeEach(function() {
@@ -89,6 +95,7 @@ define([
             });
 
             this.collection = new GroupConfigurationCollection([ this.model ]);
+            this.collection.outlineUrl = '/outline';
             this.view = new GroupConfigurationDetails({
                 model: this.model
             });
@@ -125,6 +132,70 @@ define([
                 .toContainText('Contains 3 groups');
             expect(this.view.$(SELECTORS.description)).not.toExist();
             expect(this.view.$(SELECTORS.groupsAllocation)).not.toExist();
+        });
+
+        it('should show empty usage appropriately', function() {
+            this.model.set('showGroups', false);
+            this.view.$('.show-groups').click();
+
+            expect(this.view.$(SELECTORS.usageCount)).not.toExist();
+            expect(this.view.$(SELECTORS.usageText))
+                .toContainText('This Group Configuration is not in use. ' +
+                               'Start by adding a content experiment to any ' +
+                               'Unit via the');
+            expect(this.view.$(SELECTORS.usageTextAnchor)).toExist();
+            expect(this.view.$(SELECTORS.usageUnit)).not.toExist();
+        });
+
+        it('should hide empty usage appropriately', function() {
+            this.model.set('showGroups', true);
+            this.view.$('.hide-groups').click();
+
+            expect(this.view.$(SELECTORS.usageText)).not.toExist();
+            expect(this.view.$(SELECTORS.usageUnit)).not.toExist();
+            expect(this.view.$(SELECTORS.usageCount))
+                .toContainText('Not in Use');
+        });
+
+        it('should show non-empty usage appropriately', function() {
+            var usageUnitAnchors;
+
+            this.model.set('usage',
+                [
+                    {'label': 'label1', 'url': 'url1'},
+                    {'label': 'label2', 'url': 'url2'}
+                ]
+            );
+            this.model.set('showGroups', false);
+            this.view.$('.show-groups').click();
+
+            usageUnitAnchors = this.view.$(SELECTORS.usageUnitAnchor);
+
+            expect(this.view.$(SELECTORS.usageCount)).not.toExist();
+            expect(this.view.$(SELECTORS.usageText))
+                .toContainText('This Group Configuration is used in:');
+            expect(this.view.$(SELECTORS.usageUnit).length).toBe(2);
+            expect(usageUnitAnchors.length).toBe(2);
+            expect(usageUnitAnchors.eq(0)).toContainText('label1');
+            expect(usageUnitAnchors.eq(0).attr('href')).toBe('url1');
+            expect(usageUnitAnchors.eq(1)).toContainText('label2');
+            expect(usageUnitAnchors.eq(1).attr('href')).toBe('url2');
+        });
+
+        it('should hide non-empty usage appropriately', function() {
+            this.model.set('usage',
+                [
+                    {'label': 'label1', 'url': 'url1'},
+                    {'label': 'label2', 'url': 'url2'}
+                ]
+            );
+            this.model.set('showGroups', true);
+            this.view.$('.hide-groups').click();
+
+            expect(this.view.$(SELECTORS.usageText)).not.toExist();
+            expect(this.view.$(SELECTORS.usageUnit)).not.toExist();
+            expect(this.view.$(SELECTORS.usageCount))
+                .toContainText('Used in 2 units');
         });
     });
 
@@ -418,5 +489,3 @@ define([
         });
     });
 });
-
-

--- a/cms/static/js/views/group_configuration_details.js
+++ b/cms/static/js/views/group_configuration_details.js
@@ -1,7 +1,7 @@
 define([
-    'js/views/baseview', 'underscore', 'gettext'
+    'js/views/baseview', 'underscore', 'gettext', 'underscore.string'
 ],
-function(BaseView, _, gettext) {
+function(BaseView, _, gettext, str) {
     'use strict';
     var GroupConfigurationDetails = BaseView.extend({
         tagName: 'div',
@@ -30,6 +30,8 @@ function(BaseView, _, gettext) {
         render: function() {
             var attrs = $.extend({}, this.model.attributes, {
                 groupsCountMessage: this.getGroupsCountTitle(),
+                usageCountMessage: this.getUsageCountTitle(),
+                outlineAnchorMessage: this.getOutlineAnchorMessage(),
                 index: this.model.collection.indexOf(this.model)
             });
 
@@ -64,6 +66,44 @@ function(BaseView, _, gettext) {
                 );
 
             return interpolate(message, { count: count }, true);
+        },
+
+        getUsageCountTitle: function () {
+            var count = this.model.get('usage').length, message;
+
+            if (count === 0) {
+                message = gettext('Not in Use');
+            } else {
+                message = ngettext(
+                    /*
+                        Translators: 'count' is number of units that the group
+                        configuration is used in.
+                    */
+                    'Used in %(count)s unit', 'Used in %(count)s units',
+                    count
+                );
+            }
+
+            return interpolate(message, { count: count }, true);
+        },
+
+        getOutlineAnchorMessage: function () {
+            var message = gettext(
+                    /*
+                        Translators: 'outlineAnchor' is an anchor pointing to
+                        the course outline page.
+                    */
+                    'This Group Configuration is not in use. Start by adding a content experiment to any Unit via the %(outlineAnchor)s.'
+                ),
+                anchor = str.sprintf(
+                    '<a href="%(url)s" title="%(text)s">%(text)s</a>',
+                    {
+                            url: this.model.collection.outlineUrl,
+                            text: gettext('Course Outline')
+                    }
+                );
+
+            return str.sprintf(message, {outlineAnchor: anchor});
         }
     });
 

--- a/cms/static/sass/views/_group-configuration.scss
+++ b/cms/static/sass/views/_group-configuration.scss
@@ -42,142 +42,164 @@
       outline: none;
 
       .group-configuration-details {
-        padding: $baseline ($baseline*1.5);
+        .wrapper-group-configuration {
+          padding: $baseline ($baseline*1.5);
 
-        .group-configuration-header {
-          margin-bottom: 0;
-          border-bottom: 0;
-        }
-
-        .group-configuration-title {
-          @extend %t-title;
-          @include font-size(22);
-          @include line-height(22);
-          overflow: hidden;
-          text-overflow: ellipsis;
-          margin-right: ($baseline*14);
-          font-weight: bold;
-
-          .group-toggle {
-            display: inline-block;
-            padding-left: $baseline;
-            color: $black;
-
-            &:hover, &:focus {
-              color: $blue;
-            }
-          }
-        }
-
-        .group-configuration-info {
-          @extend %t-copy-sub1;
-          color: $gray-l1;
-          margin-left: $baseline;
-
-          &.group-configuration-info-inline {
-            display: table;
-            width: 70%;
-            margin: ($baseline/4) 0 ($baseline/2) $baseline;
-
-            li {
-              @include box-sizing(border-box);
-              display: table-cell;
-              margin-right: 1%;
-            }
+          .group-configuration-header {
+            margin-bottom: 0;
+            border-bottom: 0;
           }
 
-          &.group-configuration-info-block {
-            li {
-              padding: ($baseline/4) 0;
-            }
-          }
-
-          .group-configuration-label {
-            text-transform: uppercase;
-          }
-
-          .group-configuration-description {
+          .group-configuration-title {
+            @extend %t-title;
+            @include font-size(22);
+            @include line-height(22);
             overflow: hidden;
             text-overflow: ellipsis;
-          }
-        }
+            margin-right: ($baseline*14);
+            font-weight: bold;
 
-        .ui-toggle-expansion {
-          @include transition(rotate .15s ease-in-out .25s);
-          @include font-size(21);
-          display: inline-block;
-          width: ($baseline*0.75);
-          vertical-align: baseline;
-          margin-left: -$baseline;
-        }
+            .group-toggle {
+              display: inline-block;
+              padding-left: $baseline;
+              color: $black;
 
-        &.is-selectable {
-          cursor: pointer;
-
-          &:hover {
-            color: $blue;
-
-            .ui-toggle-expansion {
-              color: $blue;
+              &:hover, &:focus {
+                color: $blue;
+              }
             }
           }
-        }
 
-        .groups {
-          margin-left: $baseline;
-          margin-bottom: ($baseline*0.75);
+          .group-configuration-info {
+            @extend %t-copy-sub1;
+            color: $gray-l1;
+            margin-left: $baseline;
 
-          .group {
-            @extend %t-copy-sub2;
-            @include font-size(18);
-            @include line-height(16);
-            padding: ($baseline/7) 0 ($baseline/4);
-            border-top: 1px solid $gray-l4;
-            white-space: nowrap;
+            &.group-configuration-info-inline {
+              display: table;
+              width: 70%;
+              margin: ($baseline/4) 0 ($baseline/2) $baseline;
 
-            &:first-child {
-              border-top: none;
+              li {
+                @include box-sizing(border-box);
+                display: table-cell;
+                margin-right: 1%;
+
+                &.group-configuration-usage-count {
+                  font-style: italic;
+                }
+              }
             }
 
-            .group-name {
+            &.group-configuration-info-block {
+              li {
+                padding: ($baseline/4) 0;
+              }
+            }
+
+            .group-configuration-label {
+              text-transform: uppercase;
+            }
+
+            .group-configuration-description {
               overflow: hidden;
               text-overflow: ellipsis;
-              display: inline-block;
-              vertical-align: middle;
-              width: 75%;
-              margin-right: 5%;
             }
+          }
 
-            .group-allocation {
+          .ui-toggle-expansion {
+            @include transition(rotate .15s ease-in-out .25s);
+            @include font-size(21);
+            display: inline-block;
+            width: ($baseline*0.75);
+            vertical-align: baseline;
+            margin-left: -$baseline;
+          }
+
+          &.is-selectable {
+            cursor: pointer;
+
+            &:hover {
+              color: $blue;
+
+              .ui-toggle-expansion {
+                color: $blue;
+              }
+            }
+          }
+
+          .groups {
+            margin-left: $baseline;
+            margin-bottom: ($baseline*0.75);
+
+            .group {
+              @extend %t-copy-sub2;
+              @include font-size(18);
+              @include line-height(16);
+              padding: ($baseline/7) 0 ($baseline/4);
+              border-top: 1px solid $gray-l4;
+              white-space: nowrap;
+
+              &:first-child {
+                border-top: none;
+              }
+
+              .group-name {
+                overflow: hidden;
+                text-overflow: ellipsis;
+                display: inline-block;
+                vertical-align: middle;
+                width: 75%;
+                margin-right: 5%;
+              }
+
+              .group-allocation {
+                display: inline-block;
+                vertical-align: middle;
+                width: 20%;
+                color: $gray-l1;
+                text-align: right;
+              }
+            }
+          }
+
+          .actions {
+            @include transition(opacity .15s .25s ease-in-out);
+            opacity: 0.0;
+            position: absolute;
+            top: $baseline;
+            right: $baseline;
+
+            .action {
               display: inline-block;
-              vertical-align: middle;
-              width: 20%;
-              color: $gray-l1;
-              text-align: right;
+              margin-right: ($baseline/4);
+
+              .edit {
+                @include blue-button;
+                @extend %t-action4;
+              }
             }
           }
         }
 
-        .actions {
-          @include transition(opacity .15s .25s ease-in-out);
-          opacity: 0.0;
-          position: absolute;
-          top: $baseline;
-          right: $baseline;
+        .wrapper-group-configuration-usages {
+          @include font-size(14);
+          background-color: #f8f8f8;
+          box-shadow: 0 2px 2px 0 $shadow inset;
+          padding: $baseline ($baseline*1.5) $baseline ($baseline*2.5);
 
-          .action {
-            display: inline-block;
-            margin-right: ($baseline/4);
+          .group-configuration-usage {
+            color: $gray-l1;
+            margin-left: $baseline;
 
-            .edit {
-              @include blue-button;
-              @extend %t-action4;
+            .group-configuration-usage-unit {
+              padding: ($baseline/4) 0;
             }
           }
         }
       }
 
-      &:hover .actions {
+      &:hover .wrapper-group-configuration .actions {
         opacity: 1.0;
       }
     }

--- a/cms/templates/group_configurations.html
+++ b/cms/templates/group_configurations.html
@@ -26,6 +26,7 @@ function(doc, GroupConfigurationCollection, GroupConfigurationsPage) {
     var collection = new GroupConfigurationCollection(${json.dumps(configurations)}, { parse: true });
 
     collection.url = "${group_configuration_url}";
+    collection.outlineUrl = "${course_outline_url}";
     new GroupConfigurationsPage({
         el: $('#content'),
         collection: collection

--- a/cms/templates/js/group-configuration-details.underscore
+++ b/cms/templates/js/group-configuration-details.underscore
@@ -23,19 +23,22 @@
         <li class="group-configuration-groups-count">
             <%= groupsCountMessage %>
         </li>
+        <li class="group-configuration-usage-count">
+            <%= usageCountMessage %>
+        </li>
       <% } %>
     </ol>
 
     <% if(showGroups) { %>
       <% allocation = Math.floor(100 / groups.length) %>
-        <ol class="groups groups-<%= index %>">
-          <% groups.each(function(group, groupIndex) { %>
-            <li class="group group-<%= groupIndex %>"
-              ><span class="group-name"><%= group.get('name') %></span
-              ><span class="group-allocation"><%= allocation %>%</span
-            ></li>
-          <% }) %>
-        </ol>
+      <ol class="groups groups-<%= index %>">
+        <% groups.each(function(group, groupIndex) { %>
+          <li class="group group-<%= groupIndex %>">
+            <span class="group-name"><%= group.get('name') %></span>
+            <span class="group-allocation"><%= allocation %>%</span>
+          </li>
+        <% }) %>
+      </ol>
     <% } %>
     <ul class="actions group-configuration-actions">
         <li class="action action-edit">
@@ -43,3 +46,21 @@
         </li>
     </ul>
 </div>
+<% if(showGroups) { %>
+  <div class="wrapper-group-configuration-usages">
+    <% if (!_.isEmpty(usage)) { %>
+      <h4 class="group-configuration-usage-text"><%= gettext('This Group Configuration is used in:') %></h4>
+      <ol class="group-configuration-usage">
+        <% _.each(usage, function(unit) { %>
+          <li class="group-configuration-usage-unit">
+            <a href=<%= unit.url %> ><%= unit.label %></a>
+          </li>
+        <% }) %>
+      </ol>
+    <% } else { %>
+      <p class="group-configuration-usage-text">
+        <%= outlineAnchorMessage %>
+      </p>
+    <% } %>
+  </div>
+<% } %>

--- a/common/test/acceptance/fixtures/course.py
+++ b/common/test/acceptance/fixtures/course.py
@@ -99,6 +99,7 @@ class XBlockFixtureDesc(object):
         self.grader_type = grader_type
         self.publish = publish
         self.children = []
+        self.locator = None
 
     def add_children(self, *args):
         """
@@ -137,11 +138,12 @@ class XBlockFixtureDesc(object):
                 metadata={2},
                 grader_type={3},
                 publish={4},
-                children={5}
+                children={5},
+                locator={6},
             >
         """).strip().format(
             self.category, self.data, self.metadata,
-            self.grader_type, self.publish, self.children
+            self.grader_type, self.publish, self.children, self.locator
         )
 
 
@@ -199,7 +201,7 @@ class CourseFixture(StudioApiFixture):
 
         self._updates = []
         self._handouts = []
-        self._children = []
+        self.children = []
         self._assets = []
         self._advanced_settings = {}
 
@@ -216,7 +218,7 @@ class CourseFixture(StudioApiFixture):
 
         Returns the course fixture to allow chaining.
         """
-        self._children.extend(args)
+        self.children.extend(args)
         return self
 
     def add_update(self, update):
@@ -257,7 +259,7 @@ class CourseFixture(StudioApiFixture):
         self._configure_course()
         self._upload_assets()
         self._add_advanced_settings()
-        self._create_xblock_children(self._course_location, self._children)
+        self._create_xblock_children(self._course_location, self.children)
 
         return self
 
@@ -362,7 +364,7 @@ class CourseFixture(StudioApiFixture):
         # Construct HTML with each of the handout links
         handouts_li = [
             '<li><a href="/static/{handout}">Example Handout</a></li>'.format(handout=handout)
-             for handout in self._handouts
+            for handout in self._handouts
         ]
         handouts_html = '<ol class="treeview-handoutsnav">{}</ol>'.format("".join(handouts_li))
 
@@ -446,12 +448,31 @@ class CourseFixture(StudioApiFixture):
         Recursively create XBlock children.
         """
         for desc in xblock_descriptions:
-            loc = self._create_xblock(parent_loc, desc)
+            loc = self.create_xblock(parent_loc, desc)
             self._create_xblock_children(loc, desc.children)
 
         self._publish_xblock(parent_loc)
 
-    def _create_xblock(self, parent_loc, xblock_desc):
+    def get_nested_xblocks(self, category=None):
+        """
+        Return a list of nested XBlocks for the course that can be filtered by
+        category.
+        """
+        xblocks = self._get_nested_xblocks(self)
+        if category:
+            xblocks = filter(lambda x: x.category == category, xblocks)
+        return xblocks
+
+    def _get_nested_xblocks(self, xblock_descriptor):
+        """
+        Return a list of nested XBlocks for the course.
+        """
+        xblocks = list(xblock_descriptor.children)
+        for child in xblock_descriptor.children:
+            xblocks.extend(self._get_nested_xblocks(child))
+        return xblocks
+
+    def create_xblock(self, parent_loc, xblock_desc):
         """
         Create an XBlock with `parent_loc` (the location of the parent block)
         and `xblock_desc` (an `XBlockFixtureDesc` instance).
@@ -477,6 +498,7 @@ class CourseFixture(StudioApiFixture):
 
         try:
             loc = response.json().get('locator')
+            xblock_desc.locator = loc
 
         except ValueError:
             raise CourseFixtureError("Could not decode JSON from '{0}'".format(response.content))

--- a/common/test/acceptance/pages/studio/overview.py
+++ b/common/test/acceptance/pages/studio/overview.py
@@ -89,6 +89,9 @@ class CourseOutlineUnit(CourseOutlineChild):
         """
         return UnitPage(self.browser, self.locator).visit()
 
+    def is_browser_on_page(self):
+        return self.q(css=self.BODY_SELECTOR).present
+
 
 class CourseOutlineSubsection(CourseOutlineChild, CourseOutlineContainer):
     """
@@ -197,4 +200,3 @@ class CourseOutlinePage(CoursePage, CourseOutlineContainer):
         Open release date edit modal of first section in course outline
         """
         self.q(css='div.section-published-date a.edit-release-date').first.click()
-

--- a/common/test/acceptance/pages/studio/settings_group_configurations.py
+++ b/common/test/acceptance/pages/studio/settings_group_configurations.py
@@ -15,6 +15,7 @@ class GroupConfigurationsPage(CoursePage):
     def is_browser_on_page(self):
         return self.q(css='body.view-group-configurations').present
 
+    @property
     def group_configurations(self):
         """
         Return list of the group configurations for the course.
@@ -68,6 +69,20 @@ class GroupConfiguration(object):
         """
         return self.find_css(css).first.text[0]
 
+    def click_outline_anchor(self):
+        """
+        Click on the `Course Outline` link.
+        """
+        css = 'p.group-configuration-usage-text a'
+        self.find_css(css).first.click()
+
+    def click_unit_anchor(self, index=0):
+        """
+        Click on the link to the unit.
+        """
+        css = 'li.group-configuration-usage-unit a'
+        self.find_css(css).nth(index).click()
+
     def edit(self):
         """
         Open editing view for the group configuration.
@@ -113,6 +128,14 @@ class GroupConfiguration(object):
         Return validation message.
         """
         return self.get_text('.message-status.error')
+
+    @property
+    def usages(self):
+        """
+        Return list of usages.
+        """
+        css = '.group-configuration-usage-unit'
+        return self.find_css(css).text
 
     @property
     def name(self):

--- a/common/test/acceptance/pages/studio/unit.py
+++ b/common/test/acceptance/pages/studio/unit.py
@@ -14,6 +14,8 @@ class UnitPage(PageObject):
     Unit page in Studio
     """
 
+    NAME_SELECTOR = '#unit-display-name-input'
+
     def __init__(self, browser, unit_locator):
         super(UnitPage, self).__init__(browser)
         self.unit_locator = unit_locator
@@ -37,6 +39,10 @@ class UnitPage(PageObject):
             self.q(css='body.view-unit').present and
             Promise(_is_finished_loading, 'Finished rendering the xblocks in the unit.').fulfill()
         )
+
+    @property
+    def name(self):
+        return self.q(css=self.NAME_SELECTOR).attrs('value')[0]
 
     @property
     def components(self):
@@ -86,6 +92,7 @@ COMPONENT_BUTTONS = {
     'advanced_tab': '.editor-tabs li.inner_tab_wrap:nth-child(2) > a',
     'save_settings': '.action-save',
 }
+
 
 class Component(PageObject):
     """


### PR DESCRIPTION
**Ticket:** [BLD-1104](https://openedx.atlassian.net/browse/BLD-1104)

**Acceptance criteria:** 
- In collapsed view of group configurations: 
  - Show number of units that use this group configuration.
- In expanded view of group configurations: 
  - Show list of units that contain experiments that use the group configuration
  - Each item in the list of units should be hyperlinked. When the link is clicked, the unit containing the experiment that uses the group configuration should be opened. 
  - If no content experiments use this group configuration, show link to Course Outline to use the group configuration. 

**sandbox:** http://studio.jmclaus.m.sandbox.edx.org/

@andy-armstrong , @cahrens , @frrrances , @mhoeber , @explorerleslie please review.
