### PR TITLE
Add possibility to remove group configurations.

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_group_configurations.py
+++ b/cms/djangoapps/contentstore/views/tests/test_group_configurations.py
@@ -22,6 +22,7 @@ GROUP_CONFIGURATION_JSON = {
 }
 
 
+# pylint: disable=no-member
 class HelperMethods(object):
     """
     Mixin that provides useful methods for Group Configuration tests.
@@ -137,7 +138,7 @@ class GroupConfigurationsBaseTestCase(object):
 
 # pylint: disable=no-member
 @skipUnless(settings.FEATURES.get('ENABLE_GROUP_CONFIGURATIONS'), 'Tests Group Configurations feature')
-class GroupConfigurationsListHandlerTestCase(CourseTestCase, GroupConfigurationsBaseTestCase):
+class GroupConfigurationsListHandlerTestCase(CourseTestCase, GroupConfigurationsBaseTestCase, HelperMethods):
     """
     Test cases for group_configurations_list_handler.
     """
@@ -233,7 +234,7 @@ class GroupConfigurationsListHandlerTestCase(CourseTestCase, GroupConfigurations
 
 # pylint: disable=no-member
 @skipUnless(settings.FEATURES.get('ENABLE_GROUP_CONFIGURATIONS'), 'Tests Group Configurations feature')
-class GroupConfigurationsDetailHandlerTestCase(CourseTestCase, GroupConfigurationsBaseTestCase):
+class GroupConfigurationsDetailHandlerTestCase(CourseTestCase, GroupConfigurationsBaseTestCase, HelperMethods):
     """
     Test cases for group_configurations_detail_handler.
     """
@@ -294,9 +295,7 @@ class GroupConfigurationsDetailHandlerTestCase(CourseTestCase, GroupConfiguratio
         """
         Edit group configuration and check its id and modified fields.
         """
-        self.course.user_partitions = [
-            UserPartition(self.ID, 'First name', 'First description', [Group(0, 'Group A'), Group(1, 'Group B'), Group(2, 'Group C')]),
-        ]
+        self._add_user_partitions()
         self.save_course()
 
         expected = {
@@ -327,6 +326,65 @@ class GroupConfigurationsDetailHandlerTestCase(CourseTestCase, GroupConfiguratio
         self.assertEqual(user_partititons[0].groups[0].name, u'New Group Name')
         self.assertEqual(user_partititons[0].groups[1].name, u'Group C')
 
+    def test_can_delete_group_configuration(self):
+        """
+        Delete group configuration and check user partitions.
+        """
+        self._add_user_partitions(count=2)
+        self.save_course()
+
+        response = self.client.delete(
+            self._url(cid=0),
+            content_type="application/json",
+            HTTP_ACCEPT="application/json",
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+        self.assertEqual(response.status_code, 204)
+        self.reload_course()
+        # Verify that user_partitions is properly updated in the course.
+        user_partititons = self.course.user_partitions
+        self.assertEqual(len(user_partititons), 1)
+        self.assertEqual(user_partititons[0].name, u'Name 1')
+
+    def test_cannot_delete_used_group_configuration(self):
+        """
+        Cannot delete group configuration if it is in use.
+        """
+        self._add_user_partitions(count=2)
+        self._create_content_experiment(cid=0)
+
+        response = self.client.delete(
+            self._url(cid=0),
+            content_type="application/json",
+            HTTP_ACCEPT="application/json",
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+        self.assertEqual(response.status_code, 400)
+        content = json.loads(response.content)
+        self.assertTrue(content['error'])
+        self.reload_course()
+        # Verify that user_partitions is still the same.
+        user_partititons = self.course.user_partitions
+        self.assertEqual(len(user_partititons), 2)
+        self.assertEqual(user_partititons[0].name, u'Name 0')
+
+    def test_cannot_delete_non_existent_group_configuration(self):
+        """
+        Cannot delete group configuration if it is doesn't exist.
+        """
+        self._add_user_partitions(count=2)
+        response = self.client.delete(
+            self._url(cid=999),
+            content_type="application/json",
+            HTTP_ACCEPT="application/json",
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+        self.assertEqual(response.status_code, 404)
+        # Verify that user_partitions is still the same.
+        user_partititons = self.course.user_partitions
+        self.assertEqual(len(user_partititons), 2)
+        self.assertEqual(user_partititons[0].name, u'Name 0')
+
 
 # pylint: disable=no-member
 @skipUnless(settings.FEATURES.get('ENABLE_GROUP_CONFIGURATIONS'), 'Tests Group Configurations feature')
@@ -335,6 +393,9 @@ class GroupConfigurationsUsageInfoTestCase(CourseTestCase, HelperMethods):
     Tests for usage information of configurations.
     """
     def setUp(self):
+        """
+        Set up group configurations and split test module.
+        """
         super(GroupConfigurationsUsageInfoTestCase, self).setUp()
 
     def test_group_configuration_not_used(self):
@@ -439,5 +500,5 @@ class GroupConfigurationsUsageInfoTestCase(CourseTestCase, HelperMethods):
             display_name='Test Content Experiment'
         )
         self.save_course()
-        actual = GroupConfiguration._get_usage_info(self.course, self.store)
+        actual = GroupConfiguration.get_usage_info(self.course, self.store)
         self.assertEqual(actual, {0: []})

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -105,7 +105,7 @@ FEATURES = {
     'ADVANCED_SECURITY': False,
 
     # Toggles Group Configuration editing functionality
-    'ENABLE_GROUP_CONFIGURATIONS': os.environ.get('FEATURE_GROUP_CONFIGURATIONS'),
+    'ENABLE_GROUP_CONFIGURATIONS': True or os.environ.get('FEATURE_GROUP_CONFIGURATIONS'),
 }
 ENABLE_JASMINE = False
 

--- a/cms/static/js/models/group_configuration.js
+++ b/cms/static/js/models/group_configuration.js
@@ -22,7 +22,8 @@ function(Backbone, _, str, gettext, GroupModel, GroupCollection) {
                     }
                 ]),
                 showGroups: false,
-                editing: false
+                editing: false,
+                usage: []
             };
         },
 

--- a/cms/static/js/spec/models/group_configuration_spec.js
+++ b/cms/static/js/spec/models/group_configuration_spec.js
@@ -9,6 +9,9 @@ define([
       this.addMatchers({
         toBeInstanceOf: function(expected) {
           return this.actual instanceof expected;
+        },
+        toBeEmpty: function() {
+            return this.actual.length === 0;
         }
       });
     });
@@ -38,6 +41,10 @@ define([
                 expect(groups).toBeInstanceOf(GroupCollection);
                 expect(groups.at(0).get('name')).toBe('Group A');
                 expect(groups.at(1).get('name')).toBe('Group B');
+            });
+
+            it('should have an empty usage by default', function() {
+                expect(this.model.get('usage')).toBeEmpty();
             });
 
             it('should be able to reset itself', function() {
@@ -120,7 +127,8 @@ define([
                                 'order': 1,
                                 'name': 'Group 2'
                             }
-                        ]
+                        ],
+                        'usage': []
                     },
                     model = new GroupConfigurationModel(
                         serverModelSpec, { parse: true }

--- a/cms/static/js/spec/views/group_configuration_spec.js
+++ b/cms/static/js/spec/views/group_configuration_spec.js
@@ -28,6 +28,12 @@ define([
         inputGroupName: '.group-name',
         inputName: '.group-configuration-name-input',
         inputDescription: '.group-configuration-description-input',
+        usageCount: '.group-configuration-usage-count',
+        usage: '.group-configuration-usage',
+        usageText: '.group-configuration-usage-text',
+        usageTextAnchor: '.group-configuration-usage-text > a',
+        usageUnit: '.group-configuration-usage-unit',
+        usageUnitAnchor: '.group-configuration-usage-unit > a'
     };
 
     beforeEach(function() {
@@ -89,6 +95,7 @@ define([
             });
 
             this.collection = new GroupConfigurationCollection([ this.model ]);
+            this.collection.outlineUrl = '/outline';
             this.view = new GroupConfigurationDetails({
                 model: this.model
             });
@@ -125,6 +132,70 @@ define([
                 .toContainText('Contains 3 groups');
             expect(this.view.$(SELECTORS.description)).not.toExist();
             expect(this.view.$(SELECTORS.groupsAllocation)).not.toExist();
+        });
+
+        it('should show empty usage appropriately', function() {
+            this.model.set('showGroups', false);
+            this.view.$('.show-groups').click();
+
+            expect(this.view.$(SELECTORS.usageCount)).not.toExist();
+            expect(this.view.$(SELECTORS.usageText))
+                .toContainText('This Group Configuration is not in use. ' +
+                               'Start by adding a content experiment to any ' +
+                               'Unit via the');
+            expect(this.view.$(SELECTORS.usageTextAnchor)).toExist();
+            expect(this.view.$(SELECTORS.usageUnit)).not.toExist();
+        });
+
+        it('should hide empty usage appropriately', function() {
+            this.model.set('showGroups', true);
+            this.view.$('.hide-groups').click();
+
+            expect(this.view.$(SELECTORS.usageText)).not.toExist();
+            expect(this.view.$(SELECTORS.usageUnit)).not.toExist();
+            expect(this.view.$(SELECTORS.usageCount))
+                .toContainText('Not in Use');
+        });
+
+        it('should show non-empty usage appropriately', function() {
+            var usageUnitAnchors;
+
+            this.model.set('usage',
+                [
+                    {'label': 'label1', 'url': 'url1'},
+                    {'label': 'label2', 'url': 'url2'}
+                ]
+            );
+            this.model.set('showGroups', false);
+            this.view.$('.show-groups').click();
+
+            usageUnitAnchors = this.view.$(SELECTORS.usageUnitAnchor);
+
+            expect(this.view.$(SELECTORS.usageCount)).not.toExist();
+            expect(this.view.$(SELECTORS.usageText))
+                .toContainText('This Group Configuration is used in:');
+            expect(this.view.$(SELECTORS.usageUnit).length).toBe(2);
+            expect(usageUnitAnchors.length).toBe(2);
+            expect(usageUnitAnchors.eq(0)).toContainText('label1');
+            expect(usageUnitAnchors.eq(0).attr('href')).toBe('url1');
+            expect(usageUnitAnchors.eq(1)).toContainText('label2');
+            expect(usageUnitAnchors.eq(1).attr('href')).toBe('url2');
+        });
+
+        it('should hide non-empty usage appropriately', function() {
+            this.model.set('usage',
+                [
+                    {'label': 'label1', 'url': 'url1'},
+                    {'label': 'label2', 'url': 'url2'}
+                ]
+            );
+            this.model.set('showGroups', true);
+            this.view.$('.hide-groups').click();
+
+            expect(this.view.$(SELECTORS.usageText)).not.toExist();
+            expect(this.view.$(SELECTORS.usageUnit)).not.toExist();
+            expect(this.view.$(SELECTORS.usageCount))
+                .toContainText('Used in 2 units');
         });
     });
 
@@ -418,5 +489,3 @@ define([
         });
     });
 });
-
-

--- a/cms/static/js/spec_helpers/create_sinon.js
+++ b/cms/static/js/spec_helpers/create_sinon.js
@@ -1,5 +1,5 @@
 define(["sinon", "underscore"], function(sinon, _) {
-    var fakeServer, fakeRequests, respondWithJson, respondWithError;
+    var fakeServer, fakeRequests, expectJsonRequest, respondWithJson, respondWithError, respondToDelete;
 
     /* These utility methods are used by Jasmine tests to create a mock server or
      * get reference to mock requests. In either case, the cleanup (restore) is done with
@@ -45,6 +45,17 @@ define(["sinon", "underscore"], function(sinon, _) {
         return requests;
     };
 
+    expectJsonRequest = function(requests, method, url, jsonRequest, requestIndex) {
+        var request;
+        if (_.isUndefined(requestIndex)) {
+            requestIndex = requests.length - 1;
+        }
+        request = requests[requestIndex];
+        expect(request.url).toEqual(url);
+        expect(request.method).toEqual(method);
+        expect(JSON.parse(request.requestBody)).toEqual(jsonRequest);
+    };
+
     respondWithJson = function(requests, jsonResponse, requestIndex) {
         if (_.isUndefined(requestIndex)) {
             requestIndex = requests.length - 1;
@@ -63,10 +74,20 @@ define(["sinon", "underscore"], function(sinon, _) {
             JSON.stringify({ }));
     };
 
+    respondToDelete = function(requests, requestIndex) {
+        if (_.isUndefined(requestIndex)) {
+            requestIndex = requests.length - 1;
+        }
+        requests[requestIndex].respond(204,
+            { "Content-Type": "application/json" });
+    };
+
     return {
         "server": fakeServer,
         "requests": fakeRequests,
+        "expectJsonRequest": expectJsonRequest,
         "respondWithJson": respondWithJson,
-        "respondWithError": respondWithError
+        "respondWithError": respondWithError,
+        "respondToDelete": respondToDelete
     };
 });

--- a/cms/static/js/spec_helpers/view_helpers.js
+++ b/cms/static/js/spec_helpers/view_helpers.js
@@ -1,19 +1,22 @@
 /**
  * Provides helper methods for invoking Studio modal windows in Jasmine tests.
  */
-define(["jquery", "js/views/feedback_notification", "js/spec_helpers/create_sinon"],
-    function($, NotificationView, create_sinon) {
-        var installTemplate, installTemplates, installViewTemplates, createNotificationSpy,
-            verifyNotificationShowing, verifyNotificationHidden;
+define(['jquery', 'js/views/feedback_notification', 'js/views/feedback_prompt'],
+    function($, NotificationView, Prompt) {
+        'use strict';
+        var installTemplate, installTemplates, installViewTemplates, createFeedbackSpy, verifyFeedbackShowing,
+            verifyFeedbackHidden, createNotificationSpy, verifyNotificationShowing,
+            verifyNotificationHidden, createPromptSpy, confirmPrompt, verifyPromptShowing,
+            verifyPromptHidden;
 
         installTemplate = function(templateName, isFirst) {
             var template = readFixtures(templateName + '.underscore'),
                 templateId = templateName + '-tpl';
 
             if (isFirst) {
-                setFixtures($("<script>", { id: templateId, type: "text/template" }).text(template));
+                setFixtures($('<script>', { id: templateId, type: 'text/template' }).text(template));
             } else {
-                appendSetFixtures($("<script>", { id: templateId, type: "text/template" }).text(template));
+                appendSetFixtures($('<script>', { id: templateId, type: 'text/template' }).text(template));
             }
         };
 
@@ -35,22 +38,56 @@ define(["jquery", "js/views/feedback_notification", "js/spec_helpers/create_sino
             appendSetFixtures('<div id="page-notification"></div>');
         };
 
-        createNotificationSpy = function(type) {
-            var notificationSpy = spyOnConstructor(NotificationView, type || "Mini", ["show", "hide"]);
-            notificationSpy.show.andReturn(notificationSpy);
-            return notificationSpy;
+        createFeedbackSpy = function(type, intent) {
+            var feedbackSpy = spyOnConstructor(type, intent, ['show', 'hide']);
+            feedbackSpy.show.andReturn(feedbackSpy);
+            return feedbackSpy;
         };
 
-        verifyNotificationShowing = function(notificationSpy, text) {
-            expect(notificationSpy.constructor).toHaveBeenCalled();
-            expect(notificationSpy.show).toHaveBeenCalled();
-            expect(notificationSpy.hide).not.toHaveBeenCalled();
-            var options = notificationSpy.constructor.mostRecentCall.args[0];
+        verifyFeedbackShowing = function(feedbackSpy, text) {
+            var options;
+            expect(feedbackSpy.constructor).toHaveBeenCalled();
+            expect(feedbackSpy.show).toHaveBeenCalled();
+            expect(feedbackSpy.hide).not.toHaveBeenCalled();
+            options = feedbackSpy.constructor.mostRecentCall.args[0];
             expect(options.title).toMatch(text);
         };
 
+        verifyFeedbackHidden = function(feedbackSpy) {
+            expect(feedbackSpy.hide).toHaveBeenCalled();
+        };
+
+        createNotificationSpy = function(type) {
+            return createFeedbackSpy(NotificationView, type || 'Mini');
+        };
+
+        verifyNotificationShowing = function(notificationSpy, text) {
+            verifyFeedbackShowing.apply(this, arguments);
+        };
+
         verifyNotificationHidden = function(notificationSpy) {
-            expect(notificationSpy.hide).toHaveBeenCalled();
+            verifyFeedbackHidden.apply(this, arguments);
+        };
+
+        createPromptSpy = function(type) {
+            return createFeedbackSpy(Prompt, type || 'Warning');
+        };
+
+        confirmPrompt = function(promptSpy, pressSecondaryButton) {
+            expect(promptSpy.constructor).toHaveBeenCalled();
+            if (pressSecondaryButton) {
+                promptSpy.constructor.mostRecentCall.args[0].actions.secondary.click(promptSpy);
+            } else {
+                promptSpy.constructor.mostRecentCall.args[0].actions.primary.click(promptSpy);
+            }
+        };
+
+        verifyPromptShowing = function(promptSpy, text) {
+            verifyFeedbackShowing.apply(this, arguments);
+        };
+
+        verifyPromptHidden = function(promptSpy) {
+            verifyFeedbackHidden.apply(this, arguments);
         };
 
         return {
@@ -59,6 +96,10 @@ define(["jquery", "js/views/feedback_notification", "js/spec_helpers/create_sino
             'installViewTemplates': installViewTemplates,
             'createNotificationSpy': createNotificationSpy,
             'verifyNotificationShowing': verifyNotificationShowing,
-            'verifyNotificationHidden': verifyNotificationHidden
+            'verifyNotificationHidden': verifyNotificationHidden,
+            'confirmPrompt': confirmPrompt,
+            'createPromptSpy': createPromptSpy,
+            'verifyPromptShowing': verifyPromptShowing,
+            'verifyPromptHidden': verifyPromptHidden
         };
     });

--- a/cms/static/js/views/group_configuration_details.js
+++ b/cms/static/js/views/group_configuration_details.js
@@ -1,7 +1,7 @@
 define([
-    'js/views/baseview', 'underscore', 'gettext'
+    'js/views/baseview', 'underscore', 'gettext', 'underscore.string'
 ],
-function(BaseView, _, gettext) {
+function(BaseView, _, gettext, str) {
     'use strict';
     var GroupConfigurationDetails = BaseView.extend({
         tagName: 'div',
@@ -30,6 +30,8 @@ function(BaseView, _, gettext) {
         render: function() {
             var attrs = $.extend({}, this.model.attributes, {
                 groupsCountMessage: this.getGroupsCountTitle(),
+                usageCountMessage: this.getUsageCountTitle(),
+                outlineAnchorMessage: this.getOutlineAnchorMessage(),
                 index: this.model.collection.indexOf(this.model)
             });
 
@@ -64,6 +66,44 @@ function(BaseView, _, gettext) {
                 );
 
             return interpolate(message, { count: count }, true);
+        },
+
+        getUsageCountTitle: function () {
+            var count = this.model.get('usage').length, message;
+
+            if (count === 0) {
+                message = gettext('Not in Use');
+            } else {
+                message = ngettext(
+                    /*
+                        Translators: 'count' is number of units that the group
+                        configuration is used in.
+                    */
+                    'Used in %(count)s unit', 'Used in %(count)s units',
+                    count
+                );
+            }
+
+            return interpolate(message, { count: count }, true);
+        },
+
+        getOutlineAnchorMessage: function () {
+            var message = gettext(
+                    /*
+                        Translators: 'outlineAnchor' is an anchor pointing to
+                        the course outline page.
+                    */
+                    'This Group Configuration is not in use. Start by adding a content experiment to any Unit via the %(outlineAnchor)s.'
+                ),
+                anchor = str.sprintf(
+                    '<a href="%(url)s" title="%(text)s">%(text)s</a>',
+                    {
+                            url: this.model.collection.outlineUrl,
+                            text: gettext('Course Outline')
+                    }
+                );
+
+            return str.sprintf(message, {outlineAnchor: anchor});
         }
     });
 

--- a/cms/static/js/views/group_configuration_edit.js
+++ b/cms/static/js/views/group_configuration_edit.js
@@ -42,6 +42,7 @@ function(BaseView, _, $, gettext, GroupEdit) {
                 uniqueId: _.uniqueId(),
                 name: this.model.escape('name'),
                 description: this.model.escape('description'),
+                usage: this.model.get('usage'),
                 isNew: this.model.isNew(),
                 error: this.model.validationError
             }));

--- a/cms/static/js/views/group_configuration_edit.js
+++ b/cms/static/js/views/group_configuration_edit.js
@@ -47,7 +47,6 @@ function(BaseView, _, $, gettext, GroupEdit) {
                 error: this.model.validationError
             }));
             this.addAll();
-
             return this;
         },
 

--- a/cms/static/js/views/group_configuration_item.js
+++ b/cms/static/js/views/group_configuration_item.js
@@ -10,6 +10,9 @@ define([
         attributes: {
             'tabindex': -1
         },
+        events: {
+            'click .delete': 'deleteConfiguration'
+        },
 
         className: function () {
             var index = this.model.collection.indexOf(this.model);
@@ -24,6 +27,24 @@ define([
         initialize: function() {
             this.listenTo(this.model, 'change:editing', this.render);
             this.listenTo(this.model, 'remove', this.remove);
+        },
+
+        deleteConfiguration: function(event) {
+            if(event && event.preventDefault) { event.preventDefault(); }
+            var self = this;
+            this.confirmThenRunOperation(
+                gettext('Delete this Group Configuration?'),
+                gettext('Deleting this Group Configuration is permanent and cannot be undone.'),
+                gettext('Delete'),
+                function() {
+                    return self.runOperationShowingMessage(
+                        gettext('Deleting') + '&hellip;',
+                        function () {
+                            return self.model.destroy({ wait: true });
+                        }
+                    );
+                }
+            );
         },
 
         render: function() {

--- a/cms/static/js/views/group_configurations_list.js
+++ b/cms/static/js/views/group_configurations_list.js
@@ -14,6 +14,7 @@ define([
         initialize: function() {
             this.emptyTemplate = this.loadTemplate('no-group-configurations');
             this.listenTo(this.collection, 'add', this.addNewItemView);
+            this.listenTo(this.collection, 'remove', this.handleDestory);
         },
 
         render: function() {
@@ -57,6 +58,12 @@ define([
         addOne: function(event) {
             if(event && event.preventDefault) { event.preventDefault(); }
             this.collection.add([{ editing: true }]);
+        },
+
+        handleDestory: function () {
+            if(this.collection.length === 0) {
+                this.$el.html(this.emptyTemplate());
+            }
         }
     });
 

--- a/cms/static/js/views/pages/group_configurations.js
+++ b/cms/static/js/views/pages/group_configurations.js
@@ -1,6 +1,6 @@
 define([
     'jquery', 'underscore', 'gettext', 'js/views/baseview',
-    'js/views/group_configurations_list'
+    'js/views/group_configurations_list', 'tooltip_manager'
 ],
 function ($, _, gettext, BaseView, GroupConfigurationsList) {
     'use strict';

--- a/cms/static/sass/views/_group-configuration.scss
+++ b/cms/static/sass/views/_group-configuration.scss
@@ -42,142 +42,164 @@
       outline: none;
 
       .group-configuration-details {
-        padding: $baseline ($baseline*1.5);
+        .wrapper-group-configuration {
+          padding: $baseline ($baseline*1.5);
 
-        .group-configuration-header {
-          margin-bottom: 0;
-          border-bottom: 0;
-        }
-
-        .group-configuration-title {
-          @extend %t-title;
-          @include font-size(22);
-          @include line-height(22);
-          overflow: hidden;
-          text-overflow: ellipsis;
-          margin-right: ($baseline*14);
-          font-weight: bold;
-
-          .group-toggle {
-            display: inline-block;
-            padding-left: $baseline;
-            color: $black;
-
-            &:hover, &:focus {
-              color: $blue;
-            }
-          }
-        }
-
-        .group-configuration-info {
-          @extend %t-copy-sub1;
-          color: $gray-l1;
-          margin-left: $baseline;
-
-          &.group-configuration-info-inline {
-            display: table;
-            width: 70%;
-            margin: ($baseline/4) 0 ($baseline/2) $baseline;
-
-            li {
-              @include box-sizing(border-box);
-              display: table-cell;
-              margin-right: 1%;
-            }
+          .group-configuration-header {
+            margin-bottom: 0;
+            border-bottom: 0;
           }
 
-          &.group-configuration-info-block {
-            li {
-              padding: ($baseline/4) 0;
-            }
-          }
-
-          .group-configuration-label {
-            text-transform: uppercase;
-          }
-
-          .group-configuration-description {
+          .group-configuration-title {
+            @extend %t-title;
+            @include font-size(22);
+            @include line-height(22);
             overflow: hidden;
             text-overflow: ellipsis;
-          }
-        }
+            margin-right: ($baseline*14);
+            font-weight: bold;
 
-        .ui-toggle-expansion {
-          @include transition(rotate .15s ease-in-out .25s);
-          @include font-size(21);
-          display: inline-block;
-          width: ($baseline*0.75);
-          vertical-align: baseline;
-          margin-left: -$baseline;
-        }
+            .group-toggle {
+              display: inline-block;
+              padding-left: $baseline;
+              color: $black;
 
-        &.is-selectable {
-          cursor: pointer;
-
-          &:hover {
-            color: $blue;
-
-            .ui-toggle-expansion {
-              color: $blue;
+              &:hover, &:focus {
+                color: $blue;
+              }
             }
           }
-        }
 
-        .groups {
-          margin-left: $baseline;
-          margin-bottom: ($baseline*0.75);
+          .group-configuration-info {
+            @extend %t-copy-sub1;
+            color: $gray-l1;
+            margin-left: $baseline;
 
-          .group {
-            @extend %t-copy-sub2;
-            @include font-size(18);
-            @include line-height(16);
-            padding: ($baseline/7) 0 ($baseline/4);
-            border-top: 1px solid $gray-l4;
-            white-space: nowrap;
+            &.group-configuration-info-inline {
+              display: table;
+              width: 70%;
+              margin: ($baseline/4) 0 ($baseline/2) $baseline;
 
-            &:first-child {
-              border-top: none;
+              li {
+                @include box-sizing(border-box);
+                display: table-cell;
+                margin-right: 1%;
+
+                &.group-configuration-usage-count {
+                  font-style: italic;
+                }
+              }
             }
 
-            .group-name {
+            &.group-configuration-info-block {
+              li {
+                padding: ($baseline/4) 0;
+              }
+            }
+
+            .group-configuration-label {
+              text-transform: uppercase;
+            }
+
+            .group-configuration-description {
               overflow: hidden;
               text-overflow: ellipsis;
-              display: inline-block;
-              vertical-align: middle;
-              width: 75%;
-              margin-right: 5%;
             }
+          }
 
-            .group-allocation {
+          .ui-toggle-expansion {
+            @include transition(rotate .15s ease-in-out .25s);
+            @include font-size(21);
+            display: inline-block;
+            width: ($baseline*0.75);
+            vertical-align: baseline;
+            margin-left: -$baseline;
+          }
+
+          &.is-selectable {
+            cursor: pointer;
+
+            &:hover {
+              color: $blue;
+
+              .ui-toggle-expansion {
+                color: $blue;
+              }
+            }
+          }
+
+          .groups {
+            margin-left: $baseline;
+            margin-bottom: ($baseline*0.75);
+
+            .group {
+              @extend %t-copy-sub2;
+              @include font-size(18);
+              @include line-height(16);
+              padding: ($baseline/7) 0 ($baseline/4);
+              border-top: 1px solid $gray-l4;
+              white-space: nowrap;
+
+              &:first-child {
+                border-top: none;
+              }
+
+              .group-name {
+                overflow: hidden;
+                text-overflow: ellipsis;
+                display: inline-block;
+                vertical-align: middle;
+                width: 75%;
+                margin-right: 5%;
+              }
+
+              .group-allocation {
+                display: inline-block;
+                vertical-align: middle;
+                width: 20%;
+                color: $gray-l1;
+                text-align: right;
+              }
+            }
+          }
+
+          .actions {
+            @include transition(opacity .15s .25s ease-in-out);
+            opacity: 0.0;
+            position: absolute;
+            top: $baseline;
+            right: $baseline;
+
+            .action {
               display: inline-block;
-              vertical-align: middle;
-              width: 20%;
-              color: $gray-l1;
-              text-align: right;
+              margin-right: ($baseline/4);
+
+              .edit {
+                @include blue-button;
+                @extend %t-action4;
+              }
             }
           }
         }
 
-        .actions {
-          @include transition(opacity .15s .25s ease-in-out);
-          opacity: 0.0;
-          position: absolute;
-          top: $baseline;
-          right: $baseline;
+        .wrapper-group-configuration-usages {
+          @include font-size(14);
+          background-color: #f8f8f8;
+          box-shadow: 0 2px 2px 0 $shadow inset;
+          padding: $baseline ($baseline*1.5) $baseline ($baseline*2.5);
 
-          .action {
-            display: inline-block;
-            margin-right: ($baseline/4);
+          .group-configuration-usage {
+            color: $gray-l1;
+            margin-left: $baseline;
 
-            .edit {
-              @include blue-button;
-              @extend %t-action4;
+            .group-configuration-usage-unit {
+              padding: ($baseline/4) 0;
             }
           }
         }
       }
 
-      &:hover .actions {
+      &:hover .wrapper-group-configuration .actions {
         opacity: 1.0;
       }
     }

--- a/cms/static/sass/views/_group-configuration.scss
+++ b/cms/static/sass/views/_group-configuration.scss
@@ -172,11 +172,21 @@
 
             .action {
               display: inline-block;
+              vertical-align: middle;
               margin-right: ($baseline/4);
 
               .edit {
                 @include blue-button;
                 @extend %t-action4;
+              }
+
+              .delete {
+                @extend %ui-btn-non;
+
+                &.is-disabled {
+                  background-color: $gray-l3;
+                  color: $gray-l6;
+                }
               }
             }
           }
@@ -199,255 +209,264 @@
         }
       }
 
-      &:hover .wrapper-group-configuration .actions {
-        opacity: 1.0;
-      }
-    }
+      .group-configuration-edit {
+        @include box-sizing(border-box);
+        border-radius: 2px;
+        width: 100%;
+        background: $white;
 
-    .group-configuration-edit {
-      @include box-sizing(border-box);
-      border-radius: 2px;
-      width: 100%;
-      background: $white;
+        .wrapper-form {
+          padding: $baseline ($baseline*1.5);
+        }
 
-      .wrapper-form {
-        padding: $baseline ($baseline*1.5);
-      }
+        .tip {
+          @extend %t-copy-sub2;
+          @include transition(color, 0.15s, ease-in-out);
+          display: block;
+          margin-top: ($baseline/4);
+          color: $gray-l3;
+        }
 
-      .tip {
-        @extend %t-copy-sub2;
-        @include transition(color, 0.15s, ease-in-out);
-        display: block;
-        margin-top: ($baseline/4);
-        color: $gray-l3;
-      }
+        .is-focused .tip{
+          color: $gray;
+        }
 
-      .is-focused .tip{
-        color: $gray;
-      }
+        .actions {
+          box-shadow: inset 0 1px 2px $shadow;
+          border-top: 1px solid $gray-l1;
+          padding: ($baseline*0.75) $baseline;
+          background: $gray-l6;
 
-      .actions {
-        box-shadow: inset 0 1px 2px $shadow;
-        border-top: 1px solid $gray-l1;
-        padding: ($baseline*0.75) $baseline;
-        background: $gray-l6;
+          .action {
+            margin-right: ($baseline/4);
 
-        .action {
-          margin-right: ($baseline/4);
+            &:last-child {
+              margin-right: 0;
+            }
+          }
 
-          &:last-child {
-            margin-right: 0;
+          // add a group is below with groups styling
+          .action-primary {
+            @include blue-button;
+            @extend %t-action2;
+            @include transition(all .15s);
+            display: inline-block;
+            padding: ($baseline/5) $baseline;
+            font-weight: 600;
+            text-transform: uppercase;
+          }
+
+          .action-secondary {
+            @include grey-button;
+            @extend %t-action2;
+            @include transition(all .15s);
+            display: inline-block;
+            padding: ($baseline/5) $baseline;
+            font-weight: 600;
+            text-transform: uppercase;
+          }
+
+          .wrapper-delete-button {
+            float: right;
+            padding: ($baseline/4) ($baseline/2);
+
+            .is-disabled {
+              color: $gray-l3;
+            }
           }
         }
 
-        // add a group is below with groups styling
-        .action-primary {
-          @include blue-button;
-          @extend %t-action2;
-          @include transition(all .15s);
-          display: inline-block;
-          padding: ($baseline/5) $baseline;
-          font-weight: 600;
-          text-transform: uppercase;
-        }
+        .copy {
+          @extend %t-copy-sub2;
+          margin: ($baseline) 0 ($baseline/2) 0;
+          color: $gray;
 
-        .action-secondary {
-          @include grey-button;
-          @extend %t-action2;
-          @include transition(all .15s);
-          display: inline-block;
-          padding: ($baseline/5) $baseline;
-          font-weight: 600;
-          text-transform: uppercase;
-        }
-      }
-
-      .copy {
-        @extend %t-copy-sub2;
-        margin: ($baseline) 0 ($baseline/2) 0;
-        color: $gray;
-
-        strong {
-          font-weight: 600;
-        }
-      }
-
-      .groups-fields,
-      .group-configuration-fields {
-        @extend %cont-no-list;
-
-        .field {
-          margin: 0 0 ($baseline*0.75) 0;
-
-          &:last-child {
-            margin-bottom: 0;
+          strong {
+            font-weight: 600;
           }
+        }
 
-          &.required {
+        .groups-fields,
+        .group-configuration-fields {
+          @extend %cont-no-list;
 
-            label {
-              font-weight: 600;
+          .field {
+            margin: 0 0 ($baseline*0.75) 0;
+
+            &:last-child {
+              margin-bottom: 0;
             }
 
-            label:after {
+            &.required {
+
+              label {
+                font-weight: 600;
+              }
+
+              label:after {
+                margin-left: ($baseline/4);
+                content: "*";
+              }
+            }
+
+            label, input, textarea {
+              display: block;
+            }
+
+            textarea {
+              resize: vertical;
+            }
+
+            label {
+              @extend %t-copy-sub1;
+              @include transition(color, 0.15s, ease-in-out);
+              margin: 0 0 ($baseline/4) 0;
+
+              &.is-focused {
+                color: $blue;
+              }
+            }
+
+            //this section is borrowed from _account.scss - we should clean up and unify later
+            input, textarea {
+              @extend %t-copy-base;
+              height: 100%;
+              width: 100%;
+              padding: ($baseline/2);
+
+              &.long {
+                width: 100%;
+              }
+
+              &.short {
+                width: 25%;
+              }
+
+              ::-webkit-input-placeholder {
+                 color: $gray-l4;
+              }
+
+              :-moz-placeholder {
+                 color: $gray-l3;
+              }
+
+              ::-moz-placeholder {
+                 color: $gray-l3;
+              }
+
+              :-ms-input-placeholder {
+                 color: $gray-l3;
+              }
+
+              &:focus {
+                + .tip {
+                  color: $gray;
+                }
+              }
+            }
+
+            &.error {
+                label {
+                  color: $red;
+                }
+
+                input {
+                  border-color: $red;
+                }
+            }
+
+            &.add-group-configuration-name label {
+              @extend %t-title5;
+              display: inline-block;
+              width: 50%;
+              padding-right: 5%;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              vertical-align: bottom;
+            }
+
+            .group-configuration-id {
+              display: inline-block;
+              width: 45%;
+              text-align: right;
+              vertical-align: top;
+              color: $gray-l1;
+
+              .group-configuration-value {
+                font-weight: 600;
+                white-space: nowrap;
+                margin-left: ($baseline*0.5);
+              }
+            }
+
+            &.group-allocation {
+              color: $gray-l1;
+            }
+          }
+
+          label.required {
+            font-weight: 600;
+
+            &:after {
               margin-left: ($baseline/4);
               content: "*";
             }
           }
 
-          label, input, textarea {
-            display: block;
-          }
+          .field-group {
+            @include clearfix();
+            margin: 0 0 ($baseline/2) 0;
+            padding: ($baseline/4) 0 0 0;
 
-          textarea {
-            resize: vertical;
-          }
-
-          label {
-            @extend %t-copy-sub1;
-            @include transition(color, 0.15s, ease-in-out);
-            margin: 0 0 ($baseline/4) 0;
-
-            &.is-focused {
-              color: $blue;
-            }
-          }
-
-          //this section is borrowed from _account.scss - we should clean up and unify later
-          input, textarea {
-            @extend %t-copy-base;
-            height: 100%;
-            width: 100%;
-            padding: ($baseline/2);
-
-            &.long {
-              width: 100%;
+            .group-allocation,
+            .field {
+              display: inline-block;
+              vertical-align: middle;
+              margin: 0 3% 0 0;
             }
 
-            &.short {
-              width: 25%;
+            .group-allocation {
+              max-width: 10%;
+              min-width: 5%;
+              color: $gray-l1;
             }
 
-            ::-webkit-input-placeholder {
-               color: $gray-l4;
-            }
+            .field {
+              position: relative;
 
-            :-moz-placeholder {
-               color: $gray-l3;
-            }
-
-            ::-moz-placeholder {
-               color: $gray-l3;
-            }
-
-            :-ms-input-placeholder {
-               color: $gray-l3;
-            }
-
-            &:focus {
-              + .tip {
-                color: $gray;
-              }
-            }
-          }
-
-          &.error {
-              label {
-                color: $red;
+              &.long {
+                width: 80%;
               }
 
-              input {
-                border-color: $red;
+              &.short {
+                width: 10%;
               }
-          }
-
-          &.add-group-configuration-name label {
-            @extend %t-title5;
-            display: inline-block;
-            width: 50%;
-            padding-right: 5%;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            vertical-align: bottom;
-          }
-
-          .group-configuration-id {
-            display: inline-block;
-            width: 45%;
-            text-align: right;
-            vertical-align: top;
-            color: $gray-l1;
-
-            .group-configuration-value {
-              font-weight: 600;
-              white-space: nowrap;
-              margin-left: ($baseline*0.5);
             }
-          }
 
-          &.group-allocation {
-            color: $gray-l1;
+            .action-close {
+              @include transition(color 0.25s ease-in-out);
+              @include font-size(22);
+              display: inline-block;
+              border: 0;
+              padding: 0;
+              background: transparent;
+              color: $blue-l3;
+              vertical-align: middle;
+
+              &:hover {
+                color: $blue;
+              }
+            }
           }
         }
 
-        label.required {
-          font-weight: 600;
-
-          &:after {
-            margin-left: ($baseline/4);
-            content: "*";
-          }
-        }
-
-        .field-group {
-          @include clearfix();
-          margin: 0 0 ($baseline/2) 0;
-          padding: ($baseline/4) 0 0 0;
-
-          .group-allocation,
-          .field {
-            display: inline-block;
-            vertical-align: middle;
-            margin: 0 3% 0 0;
-          }
-
-          .group-allocation {
-            max-width: 10%;
-            min-width: 5%;
-            color: $gray-l1;
-          }
-
-          .field {
-            position: relative;
-
-            &.long {
-              width: 80%;
-            }
-
-            &.short {
-              width: 10%;
-            }
-          }
-
-          .action-close {
-            @include transition(color 0.25s ease-in-out);
-            @include font-size(22);
-            display: inline-block;
-            border: 0;
-            padding: 0;
-            background: transparent;
-            color: $blue-l3;
-            vertical-align: middle;
-
-            &:hover {
-              color: $blue;
-            }
-          }
+        .group-configuration-fields {
+          margin-bottom: $baseline;
         }
       }
 
-      .group-configuration-fields {
-        margin-bottom: $baseline;
+      &:hover .wrapper-group-configuration .actions {
+        opacity: 1.0;
       }
 
       .action-add-group {

--- a/cms/templates/base.html
+++ b/cms/templates/base.html
@@ -81,6 +81,7 @@
             "draggabilly": "js/vendor/draggabilly.pkgd",
             "URI": "js/vendor/URI.min",
             "ieshim": "js/src/ie_shim",
+            "tooltip_manager": "coffee/src/discussion/tooltip_manager",
 
             // externally hosted files
             "tender": [

--- a/cms/templates/group_configurations.html
+++ b/cms/templates/group_configurations.html
@@ -72,11 +72,13 @@ function(doc, GroupConfigurationCollection, GroupConfigurationsPage) {
       <aside class="content-supplementary" role="complimentary">
       <div class="bit">
         <h3 class="title-3">${_("What can I do on this page?")}</h3>
-        <p>${_("You can create and edit group configurations.")}</p>
+        <p>${_("You can create, edit, and delete group configurations.")}</p>
 
-        <p>${_("A group configuration defines how many groups of students are in an experiment. When you create a content experiment, you select the group configuration to use.")}</p>
+        <p>${_("A group configuration defines how many groups of students are in an experiment. When you create an experiment, you select the group configuration to use.")}</p>
 
-        <p>${_("Click {em_start}New Group Configuration{em_end} to add a new configuration. To edit an existing configuration, hover over its box and click {em_start}Edit{em_end}.").format(em_start='<strong>', em_end="</strong>")}</p>
+        <p>${_("Click {em_start}New Group Configuration{em_end} to add a new configuration. To edit a configuration, hover over its box and click {em_start}Edit{em_end}.").format(em_start='<strong>', em_end="</strong>")}</p>
+
+        <p>${_("You can delete a group configuration only if it is not in use in an experiment. To delete a configuration, hover over its box and click the delete icon.")}</p>
 
         <p><a href="${get_online_help_info(online_help_token())['doc_url']}" target="_blank">${_("Learn More")}</a></p>
       </div>

--- a/cms/templates/group_configurations.html
+++ b/cms/templates/group_configurations.html
@@ -26,6 +26,7 @@ function(doc, GroupConfigurationCollection, GroupConfigurationsPage) {
     var collection = new GroupConfigurationCollection(${json.dumps(configurations)}, { parse: true });
 
     collection.url = "${group_configuration_url}";
+    collection.outlineUrl = "${course_outline_url}";
     new GroupConfigurationsPage({
         el: $('#content'),
         collection: collection

--- a/cms/templates/js/group-configuration-details.underscore
+++ b/cms/templates/js/group-configuration-details.underscore
@@ -44,14 +44,15 @@
         <li class="action action-edit">
             <button class="edit"><%= gettext("Edit") %></button>
         </li>
-        <% deleteBtnClassName = _.isEmpty(usage) ? '' : 'is-disabled' %>
         <% if (_.isEmpty(usage)) { %>
             <li class="action action-delete wrapper-delete-button">
-        <% } else { %>
-            <li class="action action-delete wrapper-delete-button" title="<%= gettext('Cannot delete when used by experiment') %>" data-tooltip="<%= gettext('Cannot delete when used by experiment') %>">
-        <% } %>
-                <button class="delete action-icon <%= deleteBtnClassName %>"><i class="icon-trash"></i><span><%= gettext("Delete") %></span></button>
+                <button class="delete action-icon"><i class="icon-trash"></i><span><%= gettext("Delete") %></span></button>
             </li>
+        <% } else { %>
+            <li class="action action-delete wrapper-delete-button" data-tooltip="<%= gettext('Cannot delete when used by experiment') %>">
+                <button class="delete action-icon is-disabled"><i class="icon-trash"></i><span><%= gettext("Delete") %></span></button>
+            </li>
+        <% } %>
     </ul>
 </div>
 <% if(showGroups) { %>

--- a/cms/templates/js/group-configuration-details.underscore
+++ b/cms/templates/js/group-configuration-details.underscore
@@ -23,19 +23,22 @@
         <li class="group-configuration-groups-count">
             <%= groupsCountMessage %>
         </li>
+        <li class="group-configuration-usage-count">
+            <%= usageCountMessage %>
+        </li>
       <% } %>
     </ol>
 
     <% if(showGroups) { %>
       <% allocation = Math.floor(100 / groups.length) %>
-        <ol class="groups groups-<%= index %>">
-          <% groups.each(function(group, groupIndex) { %>
-            <li class="group group-<%= groupIndex %>"
-              ><span class="group-name"><%= group.get('name') %></span
-              ><span class="group-allocation"><%= allocation %>%</span
-            ></li>
-          <% }) %>
-        </ol>
+      <ol class="groups groups-<%= index %>">
+        <% groups.each(function(group, groupIndex) { %>
+          <li class="group group-<%= groupIndex %>">
+            <span class="group-name"><%= group.get('name') %></span>
+            <span class="group-allocation"><%= allocation %>%</span>
+          </li>
+        <% }) %>
+      </ol>
     <% } %>
     <ul class="actions group-configuration-actions">
         <li class="action action-edit">
@@ -43,3 +46,21 @@
         </li>
     </ul>
 </div>
+<% if(showGroups) { %>
+  <div class="wrapper-group-configuration-usages">
+    <% if (!_.isEmpty(usage)) { %>
+      <h4 class="group-configuration-usage-text"><%= gettext('This Group Configuration is used in:') %></h4>
+      <ol class="group-configuration-usage">
+        <% _.each(usage, function(unit) { %>
+          <li class="group-configuration-usage-unit">
+            <a href=<%= unit.url %> ><%= unit.label %></a>
+          </li>
+        <% }) %>
+      </ol>
+    <% } else { %>
+      <p class="group-configuration-usage-text">
+        <%= outlineAnchorMessage %>
+      </p>
+    <% } %>
+  </div>
+<% } %>

--- a/cms/templates/js/group-configuration-details.underscore
+++ b/cms/templates/js/group-configuration-details.underscore
@@ -44,6 +44,14 @@
         <li class="action action-edit">
             <button class="edit"><%= gettext("Edit") %></button>
         </li>
+        <% deleteBtnClassName = _.isEmpty(usage) ? '' : 'is-disabled' %>
+        <% if (_.isEmpty(usage)) { %>
+            <li class="action action-delete wrapper-delete-button">
+        <% } else { %>
+            <li class="action action-delete wrapper-delete-button" title="<%= gettext('Cannot delete when used by experiment') %>" data-tooltip="<%= gettext('Cannot delete when used by experiment') %>">
+        <% } %>
+                <button class="delete action-icon <%= deleteBtnClassName %>"><i class="icon-trash"></i><span><%= gettext("Delete") %></span></button>
+            </li>
     </ul>
 </div>
 <% if(showGroups) { %>

--- a/cms/templates/js/group-configuration-edit.underscore
+++ b/cms/templates/js/group-configuration-edit.underscore
@@ -36,5 +36,13 @@
     <div class="actions">
         <button class="action action-primary" type="submit"><% if (isNew) { print(gettext("Create")) } else { print(gettext("Save")) } %></button>
         <button class="action action-secondary action-cancel"><%= gettext("Cancel") %></button>
+        <% deleteBtnClassName = _.isEmpty(usage) ? '' : 'is-disabled' %>
+        <% if (_.isEmpty(usage)) { %>
+            <span class="wrapper-delete-button">
+        <% } else { %>
+            <span class="wrapper-delete-button" title="<%= gettext('Cannot delete when used by experiment') %>">
+        <% } %>
+                <a class="button action-delete delete <%= deleteBtnClassName %>" href="#"><%= gettext("Delete") %></a>
+            </span>
     </div>
 </form>

--- a/cms/templates/js/group-configuration-edit.underscore
+++ b/cms/templates/js/group-configuration-edit.underscore
@@ -36,13 +36,15 @@
     <div class="actions">
         <button class="action action-primary" type="submit"><% if (isNew) { print(gettext("Create")) } else { print(gettext("Save")) } %></button>
         <button class="action action-secondary action-cancel"><%= gettext("Cancel") %></button>
-        <% deleteBtnClassName = _.isEmpty(usage) ? '' : 'is-disabled' %>
         <% if (_.isEmpty(usage)) { %>
             <span class="wrapper-delete-button">
-        <% } else { %>
-            <span class="wrapper-delete-button" title="<%= gettext('Cannot delete when used by experiment') %>">
-        <% } %>
-                <a class="button action-delete delete <%= deleteBtnClassName %>" href="#"><%= gettext("Delete") %></a>
+                <a class="button action-delete delete" href="#"><%= gettext("Delete") %></a>
             </span>
+        <% } else { %>
+            <span class="wrapper-delete-button" data-tooltip="<%= gettext('Cannot delete when used by experiment') %>">
+                <a class="button action-delete delete is-disabled" href="#"><%= gettext("Delete") %></a>
+            </span>
+        <% } %>
+
     </div>
 </form>

--- a/common/test/acceptance/fixtures/course.py
+++ b/common/test/acceptance/fixtures/course.py
@@ -99,6 +99,7 @@ class XBlockFixtureDesc(object):
         self.grader_type = grader_type
         self.publish = publish
         self.children = []
+        self.locator = None
 
     def add_children(self, *args):
         """
@@ -137,11 +138,12 @@ class XBlockFixtureDesc(object):
                 metadata={2},
                 grader_type={3},
                 publish={4},
-                children={5}
+                children={5},
+                locator={6},
             >
         """).strip().format(
             self.category, self.data, self.metadata,
-            self.grader_type, self.publish, self.children
+            self.grader_type, self.publish, self.children, self.locator
         )
 
 
@@ -199,7 +201,7 @@ class CourseFixture(StudioApiFixture):
 
         self._updates = []
         self._handouts = []
-        self._children = []
+        self.children = []
         self._assets = []
         self._advanced_settings = {}
 
@@ -216,7 +218,7 @@ class CourseFixture(StudioApiFixture):
 
         Returns the course fixture to allow chaining.
         """
-        self._children.extend(args)
+        self.children.extend(args)
         return self
 
     def add_update(self, update):
@@ -257,7 +259,7 @@ class CourseFixture(StudioApiFixture):
         self._configure_course()
         self._upload_assets()
         self._add_advanced_settings()
-        self._create_xblock_children(self._course_location, self._children)
+        self._create_xblock_children(self._course_location, self.children)
 
         return self
 
@@ -362,7 +364,7 @@ class CourseFixture(StudioApiFixture):
         # Construct HTML with each of the handout links
         handouts_li = [
             '<li><a href="/static/{handout}">Example Handout</a></li>'.format(handout=handout)
-             for handout in self._handouts
+            for handout in self._handouts
         ]
         handouts_html = '<ol class="treeview-handoutsnav">{}</ol>'.format("".join(handouts_li))
 
@@ -446,12 +448,31 @@ class CourseFixture(StudioApiFixture):
         Recursively create XBlock children.
         """
         for desc in xblock_descriptions:
-            loc = self._create_xblock(parent_loc, desc)
+            loc = self.create_xblock(parent_loc, desc)
             self._create_xblock_children(loc, desc.children)
 
         self._publish_xblock(parent_loc)
 
-    def _create_xblock(self, parent_loc, xblock_desc):
+    def get_nested_xblocks(self, category=None):
+        """
+        Return a list of nested XBlocks for the course that can be filtered by
+        category.
+        """
+        xblocks = self._get_nested_xblocks(self)
+        if category:
+            xblocks = filter(lambda x: x.category == category, xblocks)
+        return xblocks
+
+    def _get_nested_xblocks(self, xblock_descriptor):
+        """
+        Return a list of nested XBlocks for the course.
+        """
+        xblocks = list(xblock_descriptor.children)
+        for child in xblock_descriptor.children:
+            xblocks.extend(self._get_nested_xblocks(child))
+        return xblocks
+
+    def create_xblock(self, parent_loc, xblock_desc):
         """
         Create an XBlock with `parent_loc` (the location of the parent block)
         and `xblock_desc` (an `XBlockFixtureDesc` instance).
@@ -477,6 +498,7 @@ class CourseFixture(StudioApiFixture):
 
         try:
             loc = response.json().get('locator')
+            xblock_desc.locator = loc
 
         except ValueError:
             raise CourseFixtureError("Could not decode JSON from '{0}'".format(response.content))

--- a/common/test/acceptance/fixtures/course.py
+++ b/common/test/acceptance/fixtures/course.py
@@ -499,7 +499,6 @@ class CourseFixture(StudioApiFixture):
         try:
             loc = response.json().get('locator')
             xblock_desc.locator = loc
-
         except ValueError:
             raise CourseFixtureError("Could not decode JSON from '{0}'".format(response.content))
 

--- a/common/test/acceptance/pages/studio/overview.py
+++ b/common/test/acceptance/pages/studio/overview.py
@@ -89,6 +89,9 @@ class CourseOutlineUnit(CourseOutlineChild):
         """
         return UnitPage(self.browser, self.locator).visit()
 
+    def is_browser_on_page(self):
+        return self.q(css=self.BODY_SELECTOR).present
+
 
 class CourseOutlineSubsection(CourseOutlineChild, CourseOutlineContainer):
     """
@@ -197,4 +200,3 @@ class CourseOutlinePage(CoursePage, CourseOutlineContainer):
         Open release date edit modal of first section in course outline
         """
         self.q(css='div.section-published-date a.edit-release-date').first.click()
-

--- a/common/test/acceptance/pages/studio/settings_group_configurations.py
+++ b/common/test/acceptance/pages/studio/settings_group_configurations.py
@@ -3,6 +3,7 @@ Course Group Configurations page.
 """
 
 from .course_page import CoursePage
+from .utils import confirm_prompt
 
 
 class GroupConfigurationsPage(CoursePage):
@@ -53,15 +54,13 @@ class GroupConfiguration(object):
         """
         Expand/collapse group configuration.
         """
-        css = 'a.group-toggle'
-        self.find_css(css).first.click()
+        self.find_css('a.group-toggle').first.click()
 
     def add_group(self):
         """
         Add new group.
         """
-        css = 'button.action-add-group'
-        self.find_css(css).first.click()
+        self.find_css('button.action-add-group').first.click()
 
     def get_text(self, css):
         """
@@ -73,37 +72,42 @@ class GroupConfiguration(object):
         """
         Click on the `Course Outline` link.
         """
-        css = 'p.group-configuration-usage-text a'
-        self.find_css(css).first.click()
+        self.find_css('p.group-configuration-usage-text a').first.click()
 
     def click_unit_anchor(self, index=0):
         """
         Click on the link to the unit.
         """
-        css = 'li.group-configuration-usage-unit a'
-        self.find_css(css).nth(index).click()
+        self.find_css('li.group-configuration-usage-unit a').nth(index).click()
 
     def edit(self):
         """
         Open editing view for the group configuration.
         """
-        css = '.action-edit .edit'
-        self.find_css(css).first.click()
+        self.find_css('.action-edit .edit').first.click()
+
+    def delete_is_disabled(self):
+        return self.find_css('.actions .delete.is-disabled').present
+
+    def delete(self):
+        """
+        Delete the group configuration.
+        """
+        self.find_css('.actions .delete').first.click()
+        confirm_prompt(self.page)
 
     def save(self):
         """
         Save group configuration.
         """
-        css = '.action-primary'
-        self.find_css(css).first.click()
+        self.find_css('.action-primary').first.click()
         self.page.wait_for_ajax()
 
     def cancel(self):
         """
         Cancel group configuration.
         """
-        css = '.action-secondary'
-        self.find_css(css).first.click()
+        self.find_css('.action-secondary').first.click()
 
     @property
     def mode(self):
@@ -149,8 +153,7 @@ class GroupConfiguration(object):
         """
         Set group configuration name.
         """
-        css = '.group-configuration-name-input'
-        self.find_css(css).first.fill(value)
+        self.find_css('.group-configuration-name-input').first.fill(value)
 
     @property
     def description(self):
@@ -164,20 +167,24 @@ class GroupConfiguration(object):
         """
         Set group configuration description.
         """
-        css = '.group-configuration-description-input'
-        self.find_css(css).first.fill(value)
+        self.find_css('.group-configuration-description-input').first.fill(value)
 
     @property
     def groups(self):
         """
         Return list of groups.
         """
-        css = '.group'
-
         def group_selector(group_index):
             return self.get_selector('.group-{} '.format(group_index))
 
-        return [Group(self.page, group_selector(index)) for index, element in enumerate(self.find_css(css))]
+        return [Group(self.page, group_selector(index)) for index, element in enumerate(self.find_css('.group'))]
+
+    @property
+    def delete_note(self):
+        """
+        Return delete note for the group configuration.
+        """
+        return self.find_css('.wrapper-delete-button').first.attrs('title')[0]
 
     def __repr__(self):
         return "<{}:{}>".format(self.__class__.__name__, self.name)

--- a/common/test/acceptance/pages/studio/settings_group_configurations.py
+++ b/common/test/acceptance/pages/studio/settings_group_configurations.py
@@ -15,6 +15,7 @@ class GroupConfigurationsPage(CoursePage):
     def is_browser_on_page(self):
         return self.q(css='body.view-group-configurations').present
 
+    @property
     def group_configurations(self):
         """
         Return list of the group configurations for the course.
@@ -68,6 +69,20 @@ class GroupConfiguration(object):
         """
         return self.find_css(css).first.text[0]
 
+    def click_outline_anchor(self):
+        """
+        Click on the `Course Outline` link.
+        """
+        css = 'p.group-configuration-usage-text a'
+        self.find_css(css).first.click()
+
+    def click_unit_anchor(self, index=0):
+        """
+        Click on the link to the unit.
+        """
+        css = 'li.group-configuration-usage-unit a'
+        self.find_css(css).nth(index).click()
+
     def edit(self):
         """
         Open editing view for the group configuration.
@@ -113,6 +128,14 @@ class GroupConfiguration(object):
         Return validation message.
         """
         return self.get_text('.message-status.error')
+
+    @property
+    def usages(self):
+        """
+        Return list of usages.
+        """
+        css = '.group-configuration-usage-unit'
+        return self.find_css(css).text
 
     @property
     def name(self):

--- a/common/test/acceptance/pages/studio/unit.py
+++ b/common/test/acceptance/pages/studio/unit.py
@@ -14,6 +14,8 @@ class UnitPage(PageObject):
     Unit page in Studio
     """
 
+    NAME_SELECTOR = '#unit-display-name-input'
+
     def __init__(self, browser, unit_locator):
         super(UnitPage, self).__init__(browser)
         self.unit_locator = unit_locator
@@ -37,6 +39,10 @@ class UnitPage(PageObject):
             self.q(css='body.view-unit').present and
             Promise(_is_finished_loading, 'Finished rendering the xblocks in the unit.').fulfill()
         )
+
+    @property
+    def name(self):
+        return self.q(css=self.NAME_SELECTOR).attrs('value')[0]
 
     @property
     def components(self):
@@ -86,6 +92,7 @@ COMPONENT_BUTTONS = {
     'advanced_tab': '.editor-tabs li.inner_tab_wrap:nth-child(2) > a',
     'save_settings': '.action-save',
 }
+
 
 class Component(PageObject):
     """

--- a/common/test/acceptance/pages/studio/utils.py
+++ b/common/test/acceptance/pages/studio/utils.py
@@ -111,3 +111,14 @@ def get_codemirror_value(page, index=0, find_prefix="$"):
         return {find_prefix}('div.CodeMirror:eq({index})').get(0).CodeMirror.getValue();
         """.format(index=index, find_prefix=find_prefix)
     )
+
+
+def confirm_prompt(page, cancel=False):
+    """
+    Ensures that a modal prompt and confirmation button are visible, then clicks the button. The prompt is canceled iff
+    cancel is True.
+    """
+    page.wait_for_element_visibility('.prompt', 'Prompt is visible')
+    confirmation_button_css = '.prompt .action-' + ('secondary' if cancel else 'primary')
+    page.wait_for_element_visibility(confirmation_button_css, 'Confirmation button is visible')
+    click_css(page, confirmation_button_css, require_notification=(not cancel))

--- a/common/test/acceptance/tests/test_studio_split_test.py
+++ b/common/test/acceptance/tests/test_studio_split_test.py
@@ -175,7 +175,7 @@ class SplitTest(ContainerBase, SplitTestMixin):
         self.verify_groups(container, ['alpha'], [], verify_missing_groups_not_present=False)
 
 
-@skipUnless(os.environ.get('FEATURE_GROUP_CONFIGURATIONS'), 'Tests Group Configurations feature')
+#@skipUnless(os.environ.get('FEATURE_GROUP_CONFIGURATIONS'), 'Tests Group Configurations feature')
 class SettingsMenuTest(StudioCourseTest):
     """
     Tests that Setting menu is rendered correctly in Studio
@@ -223,7 +223,7 @@ class SettingsMenuTest(StudioCourseTest):
         self.assertFalse(self.advanced_settings.q(css=link_css).present)
 
 
-@skipUnless(os.environ.get('FEATURE_GROUP_CONFIGURATIONS'), 'Tests Group Configurations feature')
+#@skipUnless(os.environ.get('FEATURE_GROUP_CONFIGURATIONS'), 'Tests Group Configurations feature')
 class GroupConfigurationsTest(ContainerBase, SplitTestMixin):
     """
     Tests that Group Configurations page works correctly with previously

--- a/common/test/acceptance/tests/test_studio_split_test.py
+++ b/common/test/acceptance/tests/test_studio_split_test.py
@@ -648,6 +648,7 @@ class GroupConfigurationsTest(ContainerBase, SplitTestMixin):
         usage = config.usages[0]
         config.click_unit_anchor()
 
+        unit = UnitPage(self.browser, vertical.locator)
         # Waiting for the page load and verify that we've landed on the unit page
         EmptyPromise(
             lambda: unit.is_browser_on_page(), "loaded page {!r}".format(unit),
@@ -655,3 +656,71 @@ class GroupConfigurationsTest(ContainerBase, SplitTestMixin):
         ).fulfill()
 
         self.assertIn(unit.name, usage)
+
+    def test_can_delete_unused_group_configuration(self):
+        """
+        Scenario: Ensure that the user can delete unused group configuration.
+        Given I have a course with 2 group configurations
+        And I go to the Group Configuration page
+        When I delete the Group Configuration with name "Configuration 1"
+        Then I see that there is one Group Configuration
+        When I edit the Group Configuration with name "Configuration 2"
+        And I delete the Group Configuration with name "Configuration 2"
+        Then I see that the are no Group Configurations
+        """
+        self.course_fixture._update_xblock(self.course_fixture._course_location, {
+            "metadata": {
+                u"user_partitions": [
+                    UserPartition(0, 'Configuration 1', 'Description of the group configuration.', [Group("0", 'Group 0'), Group("1", 'Group 1')]).to_json(),
+                    UserPartition(1, 'Configuration 2', 'Second group configuration.', [Group("0", 'Alpha'), Group("1", 'Beta'), Group("2", 'Gamma')]).to_json()
+                ],
+            },
+        })
+        self.page.visit()
+
+        self.assertEqual(len(self.page.group_configurations), 2)
+        config = self.page.group_configurations[1]
+        # Delete first group configuration via detail view
+        config.delete()
+        self.assertEqual(len(self.page.group_configurations), 1)
+
+        config = self.page.group_configurations[0]
+        config.edit()
+        self.assertFalse(config.delete_is_disabled())
+        # Delete first group configuration via edit view
+        config.delete()
+        self.assertEqual(len(self.page.group_configurations), 0)
+
+    def test_cannot_delete_used_group_configuration(self):
+        """
+        Scenario: Ensure that the user cannot delete unused group configuration.
+        Given I have a course with group configuration that is used in the Content Experiment
+        When I go to the Group Configuration page
+        Then I do not see delete button and I see a note about that
+        When I edit the Group Configuration
+        Then I do not see delete button and I see the note about that
+        """
+        # Create a new group configurations
+        self.course_fixture._update_xblock(self.course_fixture._course_location, {
+            "metadata": {
+                u"user_partitions": [
+                    UserPartition(0, "Name", "Description.", [Group("0", "Group A"), Group("1", "Group B")]).to_json()
+                ],
+            },
+        })
+
+        vertical = self.course_fixture.get_nested_xblocks(category="vertical")[0]
+        self.course_fixture.create_xblock(
+            vertical.locator,
+            XBlockFixtureDesc('split_test', 'Test Content Experiment', metadata={'user_partition_id': 0})
+        )
+        # Go to the Group Configuration Page and click unit anchor
+        self.page.visit()
+
+        config = self.page.group_configurations[0]
+        self.assertTrue(config.delete_is_disabled())
+        self.assertIn('Cannot delete when used by experiment', config.delete_note)
+
+        config.edit()
+        self.assertTrue(config.delete_is_disabled())
+        self.assertIn('Cannot delete when used by experiment', config.delete_note)


### PR DESCRIPTION
**Ticket**: [BLD-1049](https://openedx.atlassian.net/browse/BLD-1049)

**Acceptance criteria:**
- If any content experiments are using the Group Configuration, delete should be unavailable (provide some text inline that says that groups are in use and cannot be deleted).
- If no content experiments are using the Group Configuration, a delete link should appear that deletes the context experiment. \* 
- This is irreversible, so throw a similar “Delete this Group Configuration?” modal message to let the user confirm the delete. 

**sandbox:** http://studio.polesye.m.sandbox.edx.org/

@andy-armstrong , @cahrens , @frrrances , @mhoeber please review.
