### PR TITLE
Adds longerusername to support usernames longer than 30 characters

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -712,8 +712,8 @@ INSTALLED_APPS = (
     'openedx.core.djangoapps.user_api',
     'django_openid_auth',
 
-    # External auth
-    'longerusername',
+    # Allow longer usernames and passwords
+    'longerusernameandemail',
 
     'embargo',
 

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -712,6 +712,9 @@ INSTALLED_APPS = (
     'openedx.core.djangoapps.user_api',
     'django_openid_auth',
 
+    # External auth
+    'longerusername',
+
     'embargo',
 
     # Monitoring signals

--- a/common/djangoapps/student/forms.py
+++ b/common/djangoapps/student/forms.py
@@ -114,7 +114,7 @@ class AccountCreationForm(forms.Form):
         }
     )
     email = forms.EmailField(
-        max_length=75,  # Limit per RFCs is 254, but User's email field in django 1.4 only takes 75
+        max_length=255,
         error_messages={
             "required": _EMAIL_INVALID_MSG,
             "invalid": _EMAIL_INVALID_MSG,

--- a/common/djangoapps/student/forms.py
+++ b/common/djangoapps/student/forms.py
@@ -105,7 +105,7 @@ class AccountCreationForm(forms.Form):
     # TODO: Resolve repetition
     username = forms.SlugField(
         min_length=2,
-        max_length=30,
+        max_length=255,
         error_messages={
             "required": _USERNAME_TOO_SHORT_MSG,
             "invalid": _("Username should only consist of A-Z and 0-9, with no spaces."),

--- a/common/djangoapps/student/tests/test_create_account.py
+++ b/common/djangoapps/student/tests/test_create_account.py
@@ -321,8 +321,8 @@ class TestCreateAccountValidation(TestCase):
             assert_email_error("A properly formatted e-mail is required")
 
         # Too long
-        params["email"] = "this_email_address_has_76_characters_in_it_so_it_is_unacceptable@example.com"
-        assert_email_error("Email cannot be more than 75 characters long")
+        params["email"] = "{}@example.com".format('a' * 244)
+        assert_email_error("Email cannot be more than 255 characters long")
 
         # Invalid
         params["email"] = "not_an_email_address"

--- a/common/djangoapps/student/tests/test_create_account.py
+++ b/common/djangoapps/student/tests/test_create_account.py
@@ -294,8 +294,8 @@ class TestCreateAccountValidation(TestCase):
             assert_username_error("Username must be minimum of two characters long")
 
         # Too long
-        params["username"] = "this_username_has_31_characters"
-        assert_username_error("Username cannot be more than 30 characters long")
+        params["username"] = 'a' * 256
+        assert_username_error("Username cannot be more than 255 characters long")
 
         # Invalid
         params["username"] = "invalid username"

--- a/common/djangoapps/student/tests/test_long_username_email.py
+++ b/common/djangoapps/student/tests/test_long_username_email.py
@@ -20,10 +20,10 @@ class TestLongUsernameEmail(TestCase):
 
     def test_long_username(self):
         """
-        Test username cannot be more than 30 characters long.
+        Test username cannot be more than 255 characters long.
         """
 
-        self.url_params['username'] = 'username' * 4
+        self.url_params['username'] = 'a' * 256
         response = self.client.post(self.url, self.url_params)
 
         # Status code should be 400.
@@ -32,7 +32,7 @@ class TestLongUsernameEmail(TestCase):
         obj = json.loads(response.content)
         self.assertEqual(
             obj['value'],
-            "Username cannot be more than 30 characters long",
+            "Username cannot be more than 255 characters long",
         )
 
     def test_long_email(self):

--- a/common/djangoapps/student/tests/test_long_username_email.py
+++ b/common/djangoapps/student/tests/test_long_username_email.py
@@ -37,10 +37,10 @@ class TestLongUsernameEmail(TestCase):
 
     def test_long_email(self):
         """
-        Test email cannot be more than 75 characters long.
+        Test email cannot be more than 255 characters long.
         """
 
-        self.url_params['email'] = '{0}@bar.com'.format('foo_bar' * 15)
+        self.url_params['email'] = '{0}@bar.com'.format('a' * 248)
         response = self.client.post(self.url, self.url_params)
 
         # Status code should be 400.
@@ -49,5 +49,5 @@ class TestLongUsernameEmail(TestCase):
         obj = json.loads(response.content)
         self.assertEqual(
             obj['value'],
-            "Email cannot be more than 75 characters long",
+            "Email cannot be more than 255 characters long",
         )

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1544,7 +1544,9 @@ INSTALLED_APPS = (
     # External auth (OpenID, shib)
     'external_auth',
     'django_openid_auth',
-    'longerusername',
+
+    # Allow longer usernames and passwords
+    'longerusernameandemail',
 
     # OAuth2 Provider
     'provider',

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1544,6 +1544,7 @@ INSTALLED_APPS = (
     # External auth (OpenID, shib)
     'external_auth',
     'django_openid_auth',
+    'longerusername',
 
     # OAuth2 Provider
     'provider',

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -47,6 +47,7 @@ glob2==0.3
 gunicorn==0.17.4
 httpretty==0.8.3
 lazy==1.1
+longerusername==0.4
 lxml==3.3.6
 mako==0.9.1
 Markdown==2.2.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -47,7 +47,7 @@ glob2==0.3
 gunicorn==0.17.4
 httpretty==0.8.3
 lazy==1.1
-longerusername==0.4
+django-longerusernameandemail==0.5.6
 lxml==3.3.6
 mako==0.9.1
 Markdown==2.2.1


### PR DESCRIPTION
External auth providers often have usernames longer than 30
characters, and adding this django app extends that to 255 with a
patch and schema migration.  This change should not affect the
username length limitations for internal user accounts.

I was wondering if @jbau had come across this yet as it just bit us
with CAS usernames much longer than 30 characters. This is mostly
an ops change and DB migration, so maybe @e0d or @jarv  might
want to take a look.

I also would understand if due to the somewhat hacky nature of
longerusername that you guys may not want this, and I'm open
to other suggestions.
