### PR TITLE
Make test_export_all_courses not flaky

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/tests/test_cleanup_assets.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_cleanup_assets.py
@@ -43,8 +43,7 @@ class ExportAllCourses(ModuleStoreTestCase):
         # check that there are two assets ['example.txt', '.example.txt'] in contentstore for imported course
         all_assets, count = self.content_store.get_all_content_for_course(course.id)
         self.assertEqual(count, 2)
-        self.assertEqual(all_assets[0]['_id']['name'], u'.example.txt')
-        self.assertEqual(all_assets[1]['_id']['name'], u'example.txt')
+        self.assertEqual(set([asset['_id']['name'] for asset in all_assets]), set([u'.example.txt', u'example.txt']))
 
         # manually add redundant assets (file ".DS_Store" and filename starts with "._")
         course_filter = course.id.make_asset_key("asset", None)
@@ -59,14 +58,12 @@ class ExportAllCourses(ModuleStoreTestCase):
         # check that now course has four assets
         all_assets, count = self.content_store.get_all_content_for_course(course.id)
         self.assertEqual(count, 4)
-        self.assertEqual(all_assets[0]['_id']['name'], u'.example.txt')
-        self.assertEqual(all_assets[1]['_id']['name'], u'example.txt')
-        self.assertEqual(all_assets[2]['_id']['name'], u'._example_test.txt')
-        self.assertEqual(all_assets[3]['_id']['name'], u'.DS_Store')
-
+        self.assertEqual(
+            set([asset['_id']['name'] for asset in all_assets]),
+            set([u'.example.txt', u'example.txt', u'._example_test.txt', u'.DS_Store'])
+        )
         # now call asset_cleanup command and check that there is only two proper assets in contentstore for the course
         call_command('cleanup_assets')
         all_assets, count = self.content_store.get_all_content_for_course(course.id)
         self.assertEqual(count, 2)
-        self.assertEqual(all_assets[0]['_id']['name'], u'.example.txt')
-        self.assertEqual(all_assets[1]['_id']['name'], u'example.txt')
+        self.assertEqual(set([asset['_id']['name'] for asset in all_assets]), set([u'.example.txt', u'example.txt']))


### PR DESCRIPTION
Current implementation of the test relies on the exact order in which `xml_importer.import_static_content` would return files in `static` dir. This function uses `os.walk` for retrieving list of the files and `os.walk` does not guarantee order of files retrieved, which might make test fail for no apparent reason.

review: @andy-armstrong @cahrens @auraz  @zubair-arbi
