### PR TITLE
Remove user_partitions from advanced settings

### DIFF
--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -2,6 +2,7 @@ from xblock.fields import Scope
 from xmodule.modulestore.django import modulestore
 from django.utils.translation import ugettext as _
 
+
 class CourseMetadata(object):
     '''
     For CRUD operations on metadata fields which do not have specific editors
@@ -23,6 +24,7 @@ class CourseMetadata(object):
                      'graded',
                      'hide_from_toc',
                      'pdf_textbooks',
+                     'user_partitions',
                      'name',  # from xblock
                      'tags',  # from xblock
                      'video_speed_optimizations',

--- a/common/test/acceptance/fixtures/course.py
+++ b/common/test/acceptance/fixtures/course.py
@@ -499,15 +499,21 @@ class CourseFixture(StudioApiFixture):
         """
         Publish the xblock at `locator`.
         """
+        self._update_xblock(locator, {'publish': 'make_public'})
+
+    def _update_xblock(self, locator, data):
+        """
+        Update the xblock at `locator`.
+        """
         # Create the new XBlock
         response = self.session.put(
             "{}/xblock/{}".format(STUDIO_BASE_URL, locator),
-            data=json.dumps({'publish': 'make_public'}),
+            data=json.dumps(data),
             headers=self.headers,
         )
 
         if not response.ok:
-            msg = "Could not publish {}.  Status was {}".format(locator, response.status_code)
+            msg = "Could not update {} with data {}.  Status was {}".format(locator, data, response.status_code)
             raise CourseFixtureError(msg)
 
     def _encode_post_dict(self, post_dict):

--- a/common/test/acceptance/pages/studio/container.py
+++ b/common/test/acceptance/pages/studio/container.py
@@ -143,6 +143,7 @@ class ContainerPage(PageObject):
         Note that this does an ajax call.
         """
         self.q(css='.add-missing-groups-button').first.click()
+        self.wait_for_page()
 
     def missing_groups_button_present(self):
         """


### PR DESCRIPTION
**Ticket:** [BLD-1091](https://openedx.atlassian.net/browse/BLD-1091)
- Add user_partitions to filter list (list of settings NOT shown in Advanced Settings).
- Advanced settings page should no longer list have the user_partitions setting. 

**sandbox:** http://studio.auraz.m.sandbox.edx.org/

@andy-armstrong , @cahrens , @mhoeber , @explorerleslie please review.
