### PR TITLE
removing syslog_addr

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -179,7 +179,6 @@ WIKI_ENABLED = ENV_TOKENS.get('WIKI_ENABLED', WIKI_ENABLED)
 
 LOGGING = get_logger_config(LOG_DIR,
                             logging_env=ENV_TOKENS['LOGGING_ENV'],
-                            syslog_addr=(ENV_TOKENS['SYSLOG_SERVER'], 514),
                             debug=False,
                             service_variant=SERVICE_VARIANT)
 

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -223,7 +223,6 @@ local_loglevel = ENV_TOKENS.get('LOCAL_LOGLEVEL', 'INFO')
 
 LOGGING = get_logger_config(LOG_DIR,
                             logging_env=ENV_TOKENS['LOGGING_ENV'],
-                            syslog_addr=(ENV_TOKENS['SYSLOG_SERVER'], 514),
                             local_loglevel=local_loglevel,
                             debug=False,
                             service_variant=SERVICE_VARIANT)


### PR DESCRIPTION
This is not currently being used in production and will not
be used moving forward since logs are remoted using splunk
