### PR TITLE
Wrap JSInput Python code in CDATA section

### DIFF
--- a/common/lib/xmodule/xmodule/templates/problem/jsinput_response.yaml
+++ b/common/lib/xmodule/xmodule/templates/problem/jsinput_response.yaml
@@ -5,6 +5,7 @@ metadata:
 data: |
       <problem display_name="webGLDemo">
       <script type="loncapa/python">
+      <![CDATA[
       import json
       def vglcfn(e, ans):
         '''
@@ -22,6 +23,7 @@ data: |
         selectedObjects = state["selectedObjects"]
         return selectedObjects["cylinder"] and not selectedObjects["cube"]
         '''
+      ]]>
       </script>
       <p>
       The shapes below can be selected (yellow) or unselected (cyan).


### PR DESCRIPTION
Python code can commonly contain characters that are invalid XML, such
as '<' and '>'. This has proven to be a pain point for instructors
implementing custom Python grading functions for their JSInput problems
(see sample code below).

This change creates a more robust template from which to make
modifications.

``` python
# This is an XML syntax error, when not inside a CDATA block.
if i < 0:
    print('negative')
```
