### PR TITLE
Updating to newer scipy library.

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -67,7 +67,7 @@ pysrt==0.4.7
 PyYAML==3.10
 requests==2.3.0
 requests-oauthlib==0.4.1
-scipy==0.11.0
+scipy==0.12.0
 Shapely==1.2.16
 singledispatch==3.4.0.2
 sorl-thumbnail==11.12


### PR DESCRIPTION
We have a course Author that would like to use some of the additional features provided in scipy version 0.12.0.
@jtauber, this shouldn't provide any additional Licensing issues.
@jarv, are you and the other members of your team okay with this?
