### PR TITLE
Course start time displayed based on timezones

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_course_start.py
+++ b/cms/djangoapps/contentstore/tests/test_course_start.py
@@ -13,15 +13,6 @@ NOW = datetime.strptime('2013-01-01T01:00:00', '%Y-%m-%dT%H:%M:00').replace(tzin
 
 class CMSCourseStartTimeTests(unittest.TestCase):
     """ Test that course start time is returned correctly """
-    def setUp(self):
-        datetime_patcher = patch.object(
-            xmodule.course_module, 'datetime',
-            Mock(wraps=datetime)
-        )
-        mocked_datetime = datetime_patcher.start()
-        mocked_datetime.now.return_value = NOW
-        self.addCleanup(datetime_patcher.stop)
-
     start_times = [
         # start time, expected return in UTC
         ('2012-12-02T12:00', 'Dec 02, 2012'),
@@ -30,10 +21,8 @@ class CMSCourseStartTimeTests(unittest.TestCase):
         ('2014-07-31T18:00', 'Jul 31, 2014'),
     ]
 
-    @patch('xmodule.course_module.datetime.now')
-    def test_cms_start_date(self, gmtime_mock):
+    def test_cms_start_date(self):
         """ Test start date text in cms, should just convert to date format"""
-        gmtime_mock.return_value = NOW
         for times in self.start_times:
             course = get_dummy_course(start=times[0])
             self.assertEqual(course.start_date_text, times[1])

--- a/cms/djangoapps/contentstore/tests/test_course_start.py
+++ b/cms/djangoapps/contentstore/tests/test_course_start.py
@@ -1,0 +1,39 @@
+"""
+Tests displaying course start time in CMS
+"""
+import unittest
+from datetime import datetime, timedelta
+import xmodule.course_module
+from mock import Mock, patch
+from django.utils.timezone import UTC
+from xmodule.tests.test_course_module import get_dummy_course
+
+NOW = datetime.strptime('2013-01-01T01:00:00', '%Y-%m-%dT%H:%M:00').replace(tzinfo=UTC())
+
+
+class CMSCourseStartTimeTests(unittest.TestCase):
+    """ Test that course start time is returned correctly """
+    def setUp(self):
+        datetime_patcher = patch.object(
+            xmodule.course_module, 'datetime',
+            Mock(wraps=datetime)
+        )
+        mocked_datetime = datetime_patcher.start()
+        mocked_datetime.now.return_value = NOW
+        self.addCleanup(datetime_patcher.stop)
+
+    start_times = [
+        # start time, expected return in UTC
+        ('2012-12-02T12:00', 'Dec 02, 2012'),
+        ('2014-01-01T3:00', 'Jan 01, 2014'),
+        ('2014-07-31T3:00', 'Jul 31, 2014'),
+        ('2014-07-31T18:00', 'Jul 31, 2014'),
+    ]
+
+    @patch('xmodule.course_module.datetime.now')
+    def test_cms_start_date(self, gmtime_mock):
+        """ Test start date text in cms, should just convert to date format"""
+        gmtime_mock.return_value = NOW
+        for times in self.start_times:
+            course = get_dummy_course(start=times[0])
+            self.assertEqual(course.start_date_text, times[1])

--- a/common/djangoapps/util/date_utils.py
+++ b/common/djangoapps/util/date_utils.py
@@ -34,7 +34,16 @@ def get_default_time_display(dtime):
     return (localized + timezone).strip()
 
 def set_time_zone(dtime, tz):
-    """Sets the given date time object to the given timezone"""
+    """
+    Sets the given date time object to the given timezone
+
+    Args:
+        dtime (datetime object) - the datetime object to be edited
+        tz (string) - the timezone to set the datetime object, expressed as a
+        pytz timezone string. Example: US/Pacific
+
+    If an unknown timezone is given, defaults to UTC
+    """
     try:
         to_tz = timezone(tz)
     except UnknownTimeZoneError:

--- a/common/djangoapps/util/date_utils.py
+++ b/common/djangoapps/util/date_utils.py
@@ -33,6 +33,13 @@ def get_default_time_display(dtime):
     localized = strftime_localized(dtime, "DATE_TIME")
     return (localized + timezone).strip()
 
+def set_time_zone(dtime, tz):
+    """Sets the given date time object to the given timezone"""
+    try:
+        to_tz = timezone(tz)
+    except UnknownTimeZoneError:
+        to_tz = UTC
+    return to_tz.normalize(dtime.astimezone(to_tz))
 
 def get_time_display(dtime, format_string=None, coerce_tz=None):
     """
@@ -49,11 +56,7 @@ def get_time_display(dtime, format_string=None, coerce_tz=None):
     format_string should be a unicode string that is a valid argument for datetime's strftime method.
     """
     if dtime is not None and dtime.tzinfo is not None and coerce_tz:
-        try:
-            to_tz = timezone(coerce_tz)
-        except UnknownTimeZoneError:
-            to_tz = UTC
-        dtime = to_tz.normalize(dtime.astimezone(to_tz))
+        dtime = set_time_zone(dtime, coerce_tz)
     if dtime is None or format_string is None:
         return get_default_time_display(dtime)
     try:
@@ -79,7 +82,7 @@ DEFAULT_TIME_FORMAT = "%I:%M:%S %p"
 DEFAULT_DATE_TIME_FORMAT = "%b %d, %Y at %H:%M"
 
 
-def strftime_localized(dtime, format):      # pylint: disable=redefined-builtin
+def strftime_localized(dtime, format, coerce_tz=None):      # pylint: disable=redefined-builtin
     """
     Format a datetime, just like the built-in strftime, but with localized words.
 
@@ -103,10 +106,15 @@ def strftime_localized(dtime, format):      # pylint: disable=redefined-builtin
         format (str): The format string to use, as specified by
             :ref:`datetime.strftime`.
 
+        coerce_tz (pytz timezone string): The timezone to use.
+
     Returns:
         A unicode string with the formatted datetime.
 
     """
+    # First convert date time convert to given time zone, if one given
+    if coerce_tz is not None:
+        dtime = set_time_zone(dtime, coerce_tz)
 
     if format == "SHORT_DATE":
         format = "%x"

--- a/common/lib/xmodule/xmodule/modulestore/django.py
+++ b/common/lib/xmodule/xmodule/modulestore/django.py
@@ -137,7 +137,7 @@ class ModuleI18nService(object):
         # right there.  If you are reading this comment after April 1, 2014,
         # then Cale was a liar.
         from util.date_utils import strftime_localized
-        kwargs['coerce_tz'] = settings.TIME_ZONE_DISPLAYED_FOR_DEADLINES
+        kwargs['coerce_tz'] = getattr(settings, 'TIME_ZONE_DISPLAYED_FOR_DEADLINES', None)
         return strftime_localized(*args, **kwargs)
 
 

--- a/common/lib/xmodule/xmodule/modulestore/django.py
+++ b/common/lib/xmodule/xmodule/modulestore/django.py
@@ -137,6 +137,7 @@ class ModuleI18nService(object):
         # right there.  If you are reading this comment after April 1, 2014,
         # then Cale was a liar.
         from util.date_utils import strftime_localized
+        kwargs['coerce_tz'] = settings.TIME_ZONE_DISPLAYED_FOR_DEADLINES
         return strftime_localized(*args, **kwargs)
 
 

--- a/common/lib/xmodule/xmodule/tests/test_course_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_course_module.py
@@ -282,6 +282,7 @@ class IsNewCourseTestCase(unittest.TestCase):
         descriptor = get_dummy_course(start='2012-12-31T12:00')
         assert(descriptor.is_newish is True)
 
+
     # def test_end_date_text(self):
     #     # No end date set, returns empty string.
     #     d = get_dummy_course('2012-12-02T12:00')

--- a/common/lib/xmodule/xmodule/tests/test_course_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_course_module.py
@@ -11,7 +11,6 @@ import xmodule.course_module
 from xmodule.modulestore.xml import ImportSystem, XMLModuleStore
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
 from django.utils.timezone import UTC
-from xmodule.modulestore.django import ModuleI18nService
 
 
 ORG = 'test_org'
@@ -38,7 +37,6 @@ class DummySystem(ImportSystem):
         course_dir = "test_dir"
         error_tracker = Mock()
         parent_tracker = Mock()
-        services = {'i18n': ModuleI18nService()}
 
         super(DummySystem, self).__init__(
             xmlstore=xmlstore,
@@ -48,7 +46,6 @@ class DummySystem(ImportSystem):
             parent_tracker=parent_tracker,
             load_error_modules=load_error_modules,
             field_data=KvsFieldData(DictKeyValueStore()),
-            services=services,
         )
 
 

--- a/common/lib/xmodule/xmodule/tests/test_course_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_course_module.py
@@ -187,68 +187,68 @@ class IsNewCourseTestCase(unittest.TestCase):
             print "Comparing %s to %s" % (a, b)
             assertion(a_score, b_score)
 
-    start_advertised_settings = [
-        # start, advertised, result, is_still_default
-        ('2012-12-02T12:00', None, 'Dec 02, 2012', False),
-        ('2012-12-02T12:00', '2011-11-01T12:00', 'Nov 01, 2011', False),
-        ('2012-12-02T12:00', 'Spring 2012', 'Spring 2012', False),
-        ('2012-12-02T12:00', 'November, 2011', 'November, 2011', False),
-        (xmodule.course_module.CourseFields.start.default, None, 'TBD', True),
-        (xmodule.course_module.CourseFields.start.default, 'January 2014', 'January 2014', False),
-    ]
+    # start_advertised_settings = [
+    #     # start, advertised, result, is_still_default
+    #     ('2012-12-02T12:00', None, 'Dec 02, 2012', False),
+    #     ('2012-12-02T12:00', '2011-11-01T12:00', 'Nov 01, 2011', False),
+    #     ('2012-12-02T12:00', 'Spring 2012', 'Spring 2012', False),
+    #     ('2012-12-02T12:00', 'November, 2011', 'November, 2011', False),
+    #     (xmodule.course_module.CourseFields.start.default, None, 'TBD', True),
+    #     (xmodule.course_module.CourseFields.start.default, 'January 2014', 'January 2014', False),
+    # ]
+    #
+    # @patch('xmodule.course_module.datetime.now')
+    # def test_start_date_text(self, gmtime_mock):
+    #     gmtime_mock.return_value = NOW
+    #     for s in self.start_advertised_settings:
+    #         d = get_dummy_course(start=s[0], advertised_start=s[1])
+    #         print "Checking start=%s advertised=%s" % (s[0], s[1])
+    #         self.assertEqual(d.start_date_text, s[2])
+    #
+    # def test_start_date_is_default(self):
+    #     for s in self.start_advertised_settings:
+    #         d = get_dummy_course(start=s[0], advertised_start=s[1])
+    #         self.assertEqual(d.start_date_is_still_default, s[3])
 
-    @patch('xmodule.course_module.datetime.now')
-    def test_start_date_text(self, gmtime_mock):
-        gmtime_mock.return_value = NOW
-        for s in self.start_advertised_settings:
-            d = get_dummy_course(start=s[0], advertised_start=s[1])
-            print "Checking start=%s advertised=%s" % (s[0], s[1])
-            self.assertEqual(d.start_date_text, s[2])
-
-    def test_start_date_is_default(self):
-        for s in self.start_advertised_settings:
-            d = get_dummy_course(start=s[0], advertised_start=s[1])
-            self.assertEqual(d.start_date_is_still_default, s[3])
-
-    pacific_timezone_start_settings = [
-        # Start time in UTC, advertised in UTC, result in US/Pacific, is_still_default
-        ('2014-07-10T12:00', None, 'Jul 10, 2014', False),
-        ('2014-07-11T04:30', None, 'Jul 10, 2014', False),
-        ('2020-08-18T09:00', None, 'Aug 18, 2020', False),
-    ]
-
-    @patch('django.conf.settings.TIME_ZONE_DISPLAYED_FOR_DEADLINES', new="US/Pacific")
-    def test_start_date_text_pacific_timezone(self):
-        for s in self.pacific_timezone_start_settings:
-            d = get_dummy_course(start=s[0], advertised_start=s[1])
-            self.assertEqual(d.start_date_text, s[2])
-
-    eastern_timezone_start_settings = [
-        # Start time in UTC, advertised in UTC, result in US/Eastern, is_still_default,
-        ('2014-07-25T03:00', None, 'Jul 24, 2014', False),
-        ('2020-10-10T14:00', None, 'Oct 10, 2020', False),
-        ('2020-12-25T05:00', None, 'Dec 25, 2020', False),
-    ]
-
-    @patch('django.conf.settings.TIME_ZONE_DISPLAYED_FOR_DEADLINES', new="US/Eastern")
-    def test_start_date_text_eastern_timezone(self):
-        for s in self.eastern_timezone_start_settings:
-            d = get_dummy_course(start=s[0], advertised_start=s[1])
-            self.assertEqual(d.start_date_text, s[2])
-
-    australia_timezone_start_settings = [
-        # Start time in UTC, advertised in UTC, result in Australia/Sydney, is_still_default,
-        ('2014-07-25T03:00', None, 'Jul 25, 2014', False),
-        ('2020-10-10T14:00', None, 'Oct 11, 2020', False),
-        ('2020-12-25T18:00', None, 'Dec 26, 2020', False),
-        ('2020-12-25T12:00', None, 'Dec 25, 2020', False),
-    ]
-
-    @patch('django.conf.settings.TIME_ZONE_DISPLAYED_FOR_DEADLINES', new="Australia/Sydney")
-    def test_start_date_text_australia_timezone(self):
-        for s in self.australia_timezone_start_settings:
-            d = get_dummy_course(start=s[0], advertised_start=s[1])
-            self.assertEqual(d.start_date_text, s[2])
+    # pacific_timezone_start_settings = [
+    #     # Start time in UTC, advertised in UTC, result in US/Pacific, is_still_default
+    #     ('2014-07-10T12:00', None, 'Jul 10, 2014', False),
+    #     ('2014-07-11T04:30', None, 'Jul 10, 2014', False),
+    #     ('2020-08-18T09:00', None, 'Aug 18, 2020', False),
+    # ]
+    #
+    # @patch('django.conf.settings.TIME_ZONE_DISPLAYED_FOR_DEADLINES', new="US/Pacific")
+    # def test_start_date_text_pacific_timezone(self):
+    #     for s in self.pacific_timezone_start_settings:
+    #         d = get_dummy_course(start=s[0], advertised_start=s[1])
+    #         self.assertEqual(d.start_date_text, s[2])
+    #
+    # eastern_timezone_start_settings = [
+    #     # Start time in UTC, advertised in UTC, result in US/Eastern, is_still_default,
+    #     ('2014-07-25T03:00', None, 'Jul 24, 2014', False),
+    #     ('2020-10-10T14:00', None, 'Oct 10, 2020', False),
+    #     ('2020-12-25T05:00', None, 'Dec 25, 2020', False),
+    # ]
+    #
+    # @patch('django.conf.settings.TIME_ZONE_DISPLAYED_FOR_DEADLINES', new="US/Eastern")
+    # def test_start_date_text_eastern_timezone(self):
+    #     for s in self.eastern_timezone_start_settings:
+    #         d = get_dummy_course(start=s[0], advertised_start=s[1])
+    #         self.assertEqual(d.start_date_text, s[2])
+    #
+    # australia_timezone_start_settings = [
+    #     # Start time in UTC, advertised in UTC, result in Australia/Sydney, is_still_default,
+    #     ('2014-07-25T03:00', None, 'Jul 25, 2014', False),
+    #     ('2020-10-10T14:00', None, 'Oct 11, 2020', False),
+    #     ('2020-12-25T18:00', None, 'Dec 26, 2020', False),
+    #     ('2020-12-25T12:00', None, 'Dec 25, 2020', False),
+    # ]
+    #
+    # @patch('django.conf.settings.TIME_ZONE_DISPLAYED_FOR_DEADLINES', new="Australia/Sydney")
+    # def test_start_date_text_australia_timezone(self):
+    #     for s in self.australia_timezone_start_settings:
+    #         d = get_dummy_course(start=s[0], advertised_start=s[1])
+    #         self.assertEqual(d.start_date_text, s[2])
 
     def test_display_organization(self):
         descriptor = get_dummy_course(start='2012-12-02T12:00', is_new=True)

--- a/common/lib/xmodule/xmodule/tests/test_course_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_course_module.py
@@ -11,6 +11,7 @@ import xmodule.course_module
 from xmodule.modulestore.xml import ImportSystem, XMLModuleStore
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
 from django.utils.timezone import UTC
+from xmodule.modulestore.django import ModuleI18nService
 
 
 ORG = 'test_org'
@@ -37,6 +38,7 @@ class DummySystem(ImportSystem):
         course_dir = "test_dir"
         error_tracker = Mock()
         parent_tracker = Mock()
+        services = {'i18n': ModuleI18nService()}
 
         super(DummySystem, self).__init__(
             xmlstore=xmlstore,
@@ -46,6 +48,7 @@ class DummySystem(ImportSystem):
             parent_tracker=parent_tracker,
             load_error_modules=load_error_modules,
             field_data=KvsFieldData(DictKeyValueStore()),
+            services=services,
         )
 
 

--- a/common/lib/xmodule/xmodule/tests/test_course_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_course_module.py
@@ -187,69 +187,6 @@ class IsNewCourseTestCase(unittest.TestCase):
             print "Comparing %s to %s" % (a, b)
             assertion(a_score, b_score)
 
-    # start_advertised_settings = [
-    #     # start, advertised, result, is_still_default
-    #     ('2012-12-02T12:00', None, 'Dec 02, 2012', False),
-    #     ('2012-12-02T12:00', '2011-11-01T12:00', 'Nov 01, 2011', False),
-    #     ('2012-12-02T12:00', 'Spring 2012', 'Spring 2012', False),
-    #     ('2012-12-02T12:00', 'November, 2011', 'November, 2011', False),
-    #     (xmodule.course_module.CourseFields.start.default, None, 'TBD', True),
-    #     (xmodule.course_module.CourseFields.start.default, 'January 2014', 'January 2014', False),
-    # ]
-    #
-    # @patch('xmodule.course_module.datetime.now')
-    # def test_start_date_text(self, gmtime_mock):
-    #     gmtime_mock.return_value = NOW
-    #     for s in self.start_advertised_settings:
-    #         d = get_dummy_course(start=s[0], advertised_start=s[1])
-    #         print "Checking start=%s advertised=%s" % (s[0], s[1])
-    #         self.assertEqual(d.start_date_text, s[2])
-    #
-    # def test_start_date_is_default(self):
-    #     for s in self.start_advertised_settings:
-    #         d = get_dummy_course(start=s[0], advertised_start=s[1])
-    #         self.assertEqual(d.start_date_is_still_default, s[3])
-
-    # pacific_timezone_start_settings = [
-    #     # Start time in UTC, advertised in UTC, result in US/Pacific, is_still_default
-    #     ('2014-07-10T12:00', None, 'Jul 10, 2014', False),
-    #     ('2014-07-11T04:30', None, 'Jul 10, 2014', False),
-    #     ('2020-08-18T09:00', None, 'Aug 18, 2020', False),
-    # ]
-    #
-    # @patch('django.conf.settings.TIME_ZONE_DISPLAYED_FOR_DEADLINES', new="US/Pacific")
-    # def test_start_date_text_pacific_timezone(self):
-    #     for s in self.pacific_timezone_start_settings:
-    #         d = get_dummy_course(start=s[0], advertised_start=s[1])
-    #         self.assertEqual(d.start_date_text, s[2])
-    #
-    # eastern_timezone_start_settings = [
-    #     # Start time in UTC, advertised in UTC, result in US/Eastern, is_still_default,
-    #     ('2014-07-25T03:00', None, 'Jul 24, 2014', False),
-    #     ('2020-10-10T14:00', None, 'Oct 10, 2020', False),
-    #     ('2020-12-25T05:00', None, 'Dec 25, 2020', False),
-    # ]
-    #
-    # @patch('django.conf.settings.TIME_ZONE_DISPLAYED_FOR_DEADLINES', new="US/Eastern")
-    # def test_start_date_text_eastern_timezone(self):
-    #     for s in self.eastern_timezone_start_settings:
-    #         d = get_dummy_course(start=s[0], advertised_start=s[1])
-    #         self.assertEqual(d.start_date_text, s[2])
-    #
-    # australia_timezone_start_settings = [
-    #     # Start time in UTC, advertised in UTC, result in Australia/Sydney, is_still_default,
-    #     ('2014-07-25T03:00', None, 'Jul 25, 2014', False),
-    #     ('2020-10-10T14:00', None, 'Oct 11, 2020', False),
-    #     ('2020-12-25T18:00', None, 'Dec 26, 2020', False),
-    #     ('2020-12-25T12:00', None, 'Dec 25, 2020', False),
-    # ]
-    #
-    # @patch('django.conf.settings.TIME_ZONE_DISPLAYED_FOR_DEADLINES', new="Australia/Sydney")
-    # def test_start_date_text_australia_timezone(self):
-    #     for s in self.australia_timezone_start_settings:
-    #         d = get_dummy_course(start=s[0], advertised_start=s[1])
-    #         self.assertEqual(d.start_date_text, s[2])
-
     def test_display_organization(self):
         descriptor = get_dummy_course(start='2012-12-02T12:00', is_new=True)
         self.assertNotEqual(descriptor.location.org, descriptor.display_org_with_default)
@@ -281,15 +218,6 @@ class IsNewCourseTestCase(unittest.TestCase):
 
         descriptor = get_dummy_course(start='2012-12-31T12:00')
         assert(descriptor.is_newish is True)
-
-
-    # def test_end_date_text(self):
-    #     # No end date set, returns empty string.
-    #     d = get_dummy_course('2012-12-02T12:00')
-    #     self.assertEqual('', d.end_date_text)
-    #
-    #     d = get_dummy_course('2012-12-02T12:00', end='2014-9-04T12:00')
-    #     self.assertEqual('Sep 04, 2014', d.end_date_text)
 
 
 class DiscussionTopicsTestCase(unittest.TestCase):

--- a/common/lib/xmodule/xmodule/tests/test_course_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_course_module.py
@@ -282,13 +282,13 @@ class IsNewCourseTestCase(unittest.TestCase):
         descriptor = get_dummy_course(start='2012-12-31T12:00')
         assert(descriptor.is_newish is True)
 
-    def test_end_date_text(self):
-        # No end date set, returns empty string.
-        d = get_dummy_course('2012-12-02T12:00')
-        self.assertEqual('', d.end_date_text)
-
-        d = get_dummy_course('2012-12-02T12:00', end='2014-9-04T12:00')
-        self.assertEqual('Sep 04, 2014', d.end_date_text)
+    # def test_end_date_text(self):
+    #     # No end date set, returns empty string.
+    #     d = get_dummy_course('2012-12-02T12:00')
+    #     self.assertEqual('', d.end_date_text)
+    #
+    #     d = get_dummy_course('2012-12-02T12:00', end='2014-9-04T12:00')
+    #     self.assertEqual('Sep 04, 2014', d.end_date_text)
 
 
 class DiscussionTopicsTestCase(unittest.TestCase):

--- a/lms/djangoapps/courseware/tests/test_course_start_time.py
+++ b/lms/djangoapps/courseware/tests/test_course_start_time.py
@@ -1,0 +1,85 @@
+"""
+Tests displaying of course start time
+"""
+import unittest
+from datetime import datetime, timedelta
+import xmodule.course_module
+from mock import Mock, patch
+from django.utils.timezone import UTC
+from xmodule.tests.test_course_module import get_dummy_course
+
+NOW = datetime.strptime('2013-01-01T01:00:00', '%Y-%m-%dT%H:%M:00').replace(tzinfo=UTC())
+
+class CourseStartTimeTests(unittest.TestCase):
+
+    def setUp(self):
+        datetime_patcher = patch.object(
+            xmodule.course_module, 'datetime',
+            Mock(wraps=datetime)
+        )
+        mocked_datetime = datetime_patcher.start()
+        mocked_datetime.now.return_value = NOW
+        self.addCleanup(datetime_patcher.stop)
+
+    start_advertised_settings = [
+        # start, advertised, result, is_still_default
+        ('2012-12-02T12:00', None, 'Dec 02, 2012', False),
+        ('2012-12-02T12:00', '2011-11-01T12:00', 'Nov 01, 2011', False),
+        ('2012-12-02T12:00', 'Spring 2012', 'Spring 2012', False),
+        ('2012-12-02T12:00', 'November, 2011', 'November, 2011', False),
+        (xmodule.course_module.CourseFields.start.default, None, 'TBD', True),
+        (xmodule.course_module.CourseFields.start.default, 'January 2014', 'January 2014', False),
+    ]
+
+    @patch('xmodule.course_module.datetime.now')
+    def test_start_date_text(self, gmtime_mock):
+        gmtime_mock.return_value = NOW
+        for s in self.start_advertised_settings:
+            d = get_dummy_course(start=s[0], advertised_start=s[1])
+            print "Checking start=%s advertised=%s" % (s[0], s[1])
+            self.assertEqual(d.start_date_text, s[2])
+
+    def test_start_date_is_default(self):
+        for s in self.start_advertised_settings:
+            d = get_dummy_course(start=s[0], advertised_start=s[1])
+            self.assertEqual(d.start_date_is_still_default, s[3])
+
+    pacific_timezone_start_settings = [
+        # Start time in UTC, advertised in UTC, result in US/Pacific, is_still_default
+        ('2014-07-10T12:00', None, 'Jul 10, 2014', False),
+        ('2014-07-11T04:30', None, 'Jul 10, 2014', False),
+        ('2020-08-18T09:00', None, 'Aug 18, 2020', False),
+    ]
+
+    @patch('django.conf.settings.TIME_ZONE_DISPLAYED_FOR_DEADLINES', new="US/Pacific")
+    def test_start_date_text_pacific_timezone(self):
+        for s in self.pacific_timezone_start_settings:
+            d = get_dummy_course(start=s[0], advertised_start=s[1])
+            self.assertEqual(d.start_date_text, s[2])
+
+    eastern_timezone_start_settings = [
+        # Start time in UTC, advertised in UTC, result in US/Eastern, is_still_default,
+        ('2014-07-25T03:00', None, 'Jul 24, 2014', False),
+        ('2020-10-10T14:00', None, 'Oct 10, 2020', False),
+        ('2020-12-25T05:00', None, 'Dec 25, 2020', False),
+    ]
+
+    @patch('django.conf.settings.TIME_ZONE_DISPLAYED_FOR_DEADLINES', new="US/Eastern")
+    def test_start_date_text_eastern_timezone(self):
+        for s in self.eastern_timezone_start_settings:
+            d = get_dummy_course(start=s[0], advertised_start=s[1])
+            self.assertEqual(d.start_date_text, s[2])
+
+    australia_timezone_start_settings = [
+        # Start time in UTC, advertised in UTC, result in Australia/Sydney, is_still_default,
+        ('2014-07-25T03:00', None, 'Jul 25, 2014', False),
+        ('2020-10-10T14:00', None, 'Oct 11, 2020', False),
+        ('2020-12-25T18:00', None, 'Dec 26, 2020', False),
+        ('2020-12-25T12:00', None, 'Dec 25, 2020', False),
+    ]
+
+    @patch('django.conf.settings.TIME_ZONE_DISPLAYED_FOR_DEADLINES', new="Australia/Sydney")
+    def test_start_date_text_australia_timezone(self):
+        for s in self.australia_timezone_start_settings:
+            d = get_dummy_course(start=s[0], advertised_start=s[1])
+            self.assertEqual(d.start_date_text, s[2])

--- a/lms/djangoapps/courseware/tests/test_course_times.py
+++ b/lms/djangoapps/courseware/tests/test_course_times.py
@@ -1,5 +1,5 @@
 """
-Tests displaying of course start time
+Tests displaying of course start time for LMS
 """
 import unittest
 from datetime import datetime, timedelta
@@ -10,7 +10,8 @@ from xmodule.tests.test_course_module import get_dummy_course
 
 NOW = datetime.strptime('2013-01-01T01:00:00', '%Y-%m-%dT%H:%M:00').replace(tzinfo=UTC())
 
-class CourseTimeTests(unittest.TestCase):
+
+class LMSCourseTimeTests(unittest.TestCase):
     """ Ensure course start and end times are returned correctly """
     def setUp(self):
         datetime_patcher = patch.object(

--- a/lms/djangoapps/courseware/tests/test_course_times.py
+++ b/lms/djangoapps/courseware/tests/test_course_times.py
@@ -13,14 +13,6 @@ NOW = datetime.strptime('2013-01-01T01:00:00', '%Y-%m-%dT%H:%M:00').replace(tzin
 
 class LMSCourseTimeTests(unittest.TestCase):
     """ Ensure course start and end times are returned correctly """
-    def setUp(self):
-        datetime_patcher = patch.object(
-            xmodule.course_module, 'datetime',
-            Mock(wraps=datetime)
-        )
-        mocked_datetime = datetime_patcher.start()
-        mocked_datetime.now.return_value = NOW
-        self.addCleanup(datetime_patcher.stop)
 
     start_advertised_settings = [
         # start, advertised, result, is_still_default
@@ -32,10 +24,8 @@ class LMSCourseTimeTests(unittest.TestCase):
         (xmodule.course_module.CourseFields.start.default, 'January 2014', 'January 2014', False),
     ]
 
-    @patch('xmodule.course_module.datetime.now')
-    def test_start_date_text(self, gmtime_mock):
+    def test_start_date_text(self):
         """ Test start date returned correctly default (UTC) TZ """
-        gmtime_mock.return_value = NOW
         for s in self.start_advertised_settings:
             d = get_dummy_course(start=s[0], advertised_start=s[1])
             print "Checking start=%s advertised=%s" % (s[0], s[1])

--- a/lms/djangoapps/courseware/tests/test_course_times.py
+++ b/lms/djangoapps/courseware/tests/test_course_times.py
@@ -11,7 +11,7 @@ from xmodule.tests.test_course_module import get_dummy_course
 NOW = datetime.strptime('2013-01-01T01:00:00', '%Y-%m-%dT%H:%M:00').replace(tzinfo=UTC())
 
 class CourseTimeTests(unittest.TestCase):
-
+    """ Ensure course start and end times are returned correctly """
     def setUp(self):
         datetime_patcher = patch.object(
             xmodule.course_module, 'datetime',
@@ -33,6 +33,7 @@ class CourseTimeTests(unittest.TestCase):
 
     @patch('xmodule.course_module.datetime.now')
     def test_start_date_text(self, gmtime_mock):
+        """ Test start date returned correctly default (UTC) TZ """
         gmtime_mock.return_value = NOW
         for s in self.start_advertised_settings:
             d = get_dummy_course(start=s[0], advertised_start=s[1])
@@ -40,6 +41,7 @@ class CourseTimeTests(unittest.TestCase):
             self.assertEqual(d.start_date_text, s[2])
 
     def test_start_date_is_default(self):
+        """ Test use of default start date """
         for s in self.start_advertised_settings:
             d = get_dummy_course(start=s[0], advertised_start=s[1])
             self.assertEqual(d.start_date_is_still_default, s[3])
@@ -53,6 +55,7 @@ class CourseTimeTests(unittest.TestCase):
 
     @patch('django.conf.settings.TIME_ZONE_DISPLAYED_FOR_DEADLINES', new="US/Pacific")
     def test_start_date_text_pacific_timezone(self):
+        """ Test use of set timezone, US/Pacific """
         for s in self.pacific_timezone_start_settings:
             d = get_dummy_course(start=s[0], advertised_start=s[1])
             self.assertEqual(d.start_date_text, s[2])
@@ -66,6 +69,7 @@ class CourseTimeTests(unittest.TestCase):
 
     @patch('django.conf.settings.TIME_ZONE_DISPLAYED_FOR_DEADLINES', new="US/Eastern")
     def test_start_date_text_eastern_timezone(self):
+        """ Test use of set timezone, US/Eastern """
         for s in self.eastern_timezone_start_settings:
             d = get_dummy_course(start=s[0], advertised_start=s[1])
             self.assertEqual(d.start_date_text, s[2])
@@ -80,6 +84,7 @@ class CourseTimeTests(unittest.TestCase):
 
     @patch('django.conf.settings.TIME_ZONE_DISPLAYED_FOR_DEADLINES', new="Australia/Sydney")
     def test_start_date_text_australia_timezone(self):
+        """ Test use of set timezone, international """
         for s in self.australia_timezone_start_settings:
             d = get_dummy_course(start=s[0], advertised_start=s[1])
             self.assertEqual(d.start_date_text, s[2])

--- a/lms/djangoapps/courseware/tests/test_course_times.py
+++ b/lms/djangoapps/courseware/tests/test_course_times.py
@@ -10,7 +10,7 @@ from xmodule.tests.test_course_module import get_dummy_course
 
 NOW = datetime.strptime('2013-01-01T01:00:00', '%Y-%m-%dT%H:%M:00').replace(tzinfo=UTC())
 
-class CourseStartTimeTests(unittest.TestCase):
+class CourseTimeTests(unittest.TestCase):
 
     def setUp(self):
         datetime_patcher = patch.object(
@@ -83,3 +83,11 @@ class CourseStartTimeTests(unittest.TestCase):
         for s in self.australia_timezone_start_settings:
             d = get_dummy_course(start=s[0], advertised_start=s[1])
             self.assertEqual(d.start_date_text, s[2])
+
+    def test_end_date_text(self):
+        # No end date set, returns empty string.
+        d = get_dummy_course('2012-12-02T12:00')
+        self.assertEqual('', d.end_date_text)
+
+        d = get_dummy_course('2012-12-02T12:00', end='2014-9-04T12:00')
+        self.assertEqual('Sep 04, 2014', d.end_date_text)

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -211,7 +211,7 @@
           <a class="instructor-info-action" href="${studio_url}">${_("View About Page in studio")}</a>
         </div>
       % endif
-      
+
       <nav>
         <a href="#" class="active">${_("Overview")}</a>
       ##  <a href="#">${_("FAQ")}</a>


### PR DESCRIPTION
Currently, course start times are displayed solely in UTC time. This can be confusing for instructors,
since they might schedule the start time in their timezone only to another date advertised due to
the conversion to UTC.

To fix this discrepancy, I've edited the text that is returned when a course's start date is requested
to be displayed based on timezone settings. This is done by updating the strftime_localized function in
date_utils to also take in a timezone; thus, this function may now be used elsewhere when a date displayed
in an appropriate timezone is desired.

This is a fix for the issue logged here: https://openedx.atlassian.net/browse/LOC-61
