### PR TITLE
Careful identification of "dashboards"

### DIFF
--- a/docs/en_us/course_authors/source/building_course/setting_up_student_view.rst
+++ b/docs/en_us/course_authors/source/building_course/setting_up_student_view.rst
@@ -10,8 +10,9 @@ Overview
 *******************
 
 This chapter describes how you set up your course to be displayed in the course
-summary page and in a student's dashboard. The information you configure for
-your course is important for prospective and current students to understand.
+summary page and in a student's **Current Courses** dashboard. The information
+you configure for your course is important for prospective and current students
+to understand.
 
 See:
 
@@ -56,9 +57,9 @@ The Student Dashboard
 
 
 If a student registers for your course, the course is then listed on the
-dashboard, with the course image.  From the dashboard, a student can open a
-course that has started. If the course has not started, the student can see the
-start date, as explained in this chapter.
+**Current Courses** dashboard, with the course image.  From the dashboard, a
+student can open a course that has started. If the course has not started, the
+student can see the start date, as explained in this chapter.
 
 .. image:: ../Images/dashboard.png
  :alt: An image of the dashboard
@@ -70,6 +71,7 @@ start date, as explained in this chapter.
 ***********************************
 Set Important Dates for Your Course
 ***********************************
+
 You must set dates and times for enrollment and for the course.
 
 In Studio, from the **Settings** menu, select **Schedule and Details**.  
@@ -95,8 +97,8 @@ The Course Start Date
  you intend it to.  You must change the course start date to the date you want
  students to begin using the course.
 
-Students see the course start date on their dashboards and on the course summary
-page.
+Students see the course start date on their **Current Courses** dashboards and
+on the course summary page.
 
 The following example shows the course start date on the course summary page:
 
@@ -107,8 +109,8 @@ The following example shows the course start date on the course summary page:
  your edX Program Manager, to ensure the date is accurate on the course
  summary page.
 
-In the dashboard, if the course has not yet started, students see the start date
-as in the following example:
+In the dashboard, if the course has not yet started, students see the start
+date as in the following example:
 
 .. image:: ../Images/dashboard-course-to-start.png
  :alt: An image of a course that has not started in the student dashboard, with
@@ -181,7 +183,8 @@ the course end date.
  summary page.
 
 After grades and certificates are finalized, students see the course end date
-on their personal dashboards, as shown in the following examples.
+on their personal **Current Courses** dashboards, as shown in the following
+examples.
 
 * If grades and certificates are not yet finalized, students can see the course
   end date and a message:

--- a/docs/en_us/course_authors/source/getting_started/accounts.rst
+++ b/docs/en_us/course_authors/source/getting_started/accounts.rst
@@ -112,7 +112,8 @@ Reset Your Password
 
 The process to reset your password on edX.org and Edge is the same.
 
-#. On edx.org or edge.edx.org, go to your Dashboard.
+#. On edx.org or edge.edx.org, log in or click the site logo at top left to go
+   to your **Current Courses** dashboard.
 
 #. In the account information pane in the upper left corner, click **Reset Password**. 
 

--- a/docs/en_us/course_authors/source/getting_started/get_started.rst
+++ b/docs/en_us/course_authors/source/getting_started/get_started.rst
@@ -62,7 +62,7 @@ Create Your First Course
 
 When you receive notice that you can create courses, log in to Studio_.
 
-You see the following page:
+You see the following page, which is your **My Courses** dashboard:
 
 .. image:: ../Images/first_course.png
  :width: 600
@@ -98,11 +98,12 @@ The rest of this documentation describes how you now build and run your course. 
 ************************
 View Your Course on Edge
 ************************
+
 You can now view the course you just created, even though it doesn't have any content.
 
 In the Course Outline in Studio, click **View Live**. The course opens on Edge.
 
-You can also go directly to Edge_. Log in if prompted. You see the course you just created listed:
+You can also go directly to Edge_. Log in if prompted. You see the course you just created listed on your **My Courses** dashboard:
 
 .. image:: ../Images/new_course.png
  :width: 600

--- a/docs/en_us/course_authors/source/releasing_course/beta_testing.rst
+++ b/docs/en_us/course_authors/source/releasing_course/beta_testing.rst
@@ -233,9 +233,9 @@ When you add beta testers, note the following.
   cannot enroll themselves in your course. However, you can enroll the beta
   testers prior to the **Enrollment Start Date**.
 
-* If you add the beta testers after the defined start of the beta test, and they
-  are enrolled in the course, they see your course on their dashboards when they
-  log in.
+* If you add the beta testers after the defined start of the beta test, and
+  they are enrolled in the course, they see your course on their **Current
+  Courses** dashboards when they log in.
 
 * If you add beta testers before the test starts, or if they are not enrolled,
   they do not see your course on their dashboards. You can enroll the beta
@@ -258,9 +258,7 @@ To add multiple beta testers:
 
 #. View the live version of your course.
 
-#. Click **Instructor**, and then click **Try New Beta Dashboard**.
-
-#. Click **Membership**. 
+#. Click **Instructor**, and then click **Membership**. 
 
 #. In the **Batch Beta Tester Addition** section of the page, enter one or more
    addresses or usernames separated by commas or line feeds (the Enter key). You
@@ -293,9 +291,7 @@ To add a single beta tester:
 
 #. View the live version of your course.
 
-#. Click **Instructor** then **Try New Beta Dashboard**.
-
-#. Click **Membership**.
+#. Click **Instructor** then **Membership**.
 
 #. In the **Administration List Management** section, use the drop-down list to
    select **Beta Testers**.

--- a/docs/en_us/course_authors/source/releasing_course/course_launching.rst
+++ b/docs/en_us/course_authors/source/releasing_course/course_launching.rst
@@ -112,8 +112,8 @@ recipients by selecting one of these predefined groups:
   Email messages are not sent to enrolled students in these circumstances:
 
   * Students can opt not to receive email messages through the **Email
-    Settings** link, which is present on the edX dashboard for each course.
-    Email messages are not sent to these students.
+    Settings** link, which is present for each course on the **Current
+    Courses** dashboard. Email messages are not sent to these students.
 
   * Email is not sent to students who have not replied to an account activation
     email message.

--- a/docs/en_us/course_authors/source/running_course/course_enrollment.rst
+++ b/docs/en_us/course_authors/source/running_course/course_enrollment.rst
@@ -61,11 +61,12 @@ explicitly enroll students.
 When you enroll people in a course you have these options:
 
 * **Auto Enroll**. When you choose this option, the people who you enroll do
-  not need to complete an explicit course enrollment step. Of the list of
-  email addresses that you supply, those that correspond to a registered user
-  account are immediately enrolled in the course, and your course displays on the dashboards on log in. Email addresses on the list
-  that do not match a registered user account are enrolled as soon as that
-  account is registered and activated.
+  not need to complete an explicit course enrollment step. Of the list of email
+  addresses that you supply, those that correspond to a registered user account
+  are immediately enrolled in the course, and your course displays on the
+  **Current Courses** dashboard for those users on log in. Email addresses on
+  the list that do not match a registered user account are enrolled as soon as
+  that account is registered and activated.
 
   If you do not select **Auto Enroll**, the people who you enroll must also actively locate your course and enroll themselves in it. These students see the course on their dashboards after they have done so.
 
@@ -165,6 +166,6 @@ To unenroll students, you supply the email addresses of enrolled students.
 .. note:: The **Auto Enroll** option has no effect when you click **Unenroll**.
 
 5. Click **Unenroll**. The course is no longer listed on the students'
-   dashboards, and the students can no longer contribute to discussions or the
-   wiki or access the courseware.
+   **Current Courses** dashboards, and the students can no longer contribute to
+   discussions or the wiki or access the courseware.
 

--- a/docs/en_us/course_authors/source/running_course/discussions.rst
+++ b/docs/en_us/course_authors/source/running_course/discussions.rst
@@ -354,7 +354,8 @@ responses, and comments. Messages that include spoilers or solutions, or that
 contain inappropriate or off-topic material, should be edited quickly to remove
 text, images, or links.
 
-#. Log in to the course with your discussion administrator username.
+#. Log in to the site and then select the course on your **Current Courses**
+   dashboard.
 
 #. Click the **Edit** button below the post or response or the pencil icon for
    the comment.
@@ -373,7 +374,8 @@ Discussion moderators, community TAs, and discussion admins can delete the
 content of posts, responses, and comments. Posts that include spam or abusive
 language may need to be deleted, rather than edited.
 
-#. Log in to the course with your discussion administrator username.
+#. Log in to the site and then select the course on your **Current Courses**
+   dashboard.
 
 #. Click the **Delete** button below the post or response or the "X" icon for
    the comment.


### PR DESCRIPTION
@mhoeber , this is just cleanup. This came out of the issue that Alison Kuryla's course team had finding "dashboard" in the docs. The JIRA item in the name is for any changes for course re-run to the "My Courses" dashboard, and pointed at 2. There aren't any visible changes, so I spent a half hour going through and identifying the various dashboards in text for Alison instead. And found a couple missed "New Beta Instructor Dashboard" references too -- yuck!
