### PR TITLE
Include edited/published_by for container page only

### DIFF
--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -198,7 +198,7 @@ def container_handler(request, usage_key_string):
 
         # Fetch the XBlock info for use by the container page. Note that it includes information
         # about the block's ancestors and siblings for use by the Unit Outline.
-        xblock_info = create_xblock_info(xblock, include_ancestor_info=is_unit_page)
+        xblock_info = create_xblock_info(xblock, include_ancestor_info=is_unit_page, include_edited_by=True, include_published_by=True)
 
         # Create the link for preview.
         preview_lms_base = settings.FEATURES.get('PREVIEW_LMS_BASE')

--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -656,6 +656,8 @@ def create_xblock_info(xblock, data=None, metadata=None, include_ancestor_info=F
         xblock_info['ancestor_info'] = _create_xblock_ancestor_info(xblock)
     if child_info:
         xblock_info['child_info'] = child_info
+    # Currently, 'edited_by' and 'published_by' are only used by the container page.  Only compute them when asked to do
+    # so, since safe_get_username() is expensive.
     if include_edited_by:
         xblock_info['edited_by'] = safe_get_username(xblock.subtree_edited_by)
     if include_published_by:

--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -586,7 +586,7 @@ def _get_module_info(xblock, rewrite_static_links=True):
 
 
 def create_xblock_info(xblock, data=None, metadata=None, include_ancestor_info=False, include_child_info=False,
-                       include_children_predicate=NEVER):
+                       include_edited_by=False, include_published_by=False, include_children_predicate=NEVER):
     """
     Creates the information needed for client-side XBlockInfo.
 
@@ -639,10 +639,8 @@ def create_xblock_info(xblock, data=None, metadata=None, include_ancestor_info=F
         "display_name": xblock.display_name_with_default,
         "category": xblock.category,
         "edited_on": get_default_time_display(xblock.subtree_edited_on) if xblock.subtree_edited_on else None,
-        "edited_by": safe_get_username(xblock.subtree_edited_by),
         "published": published,
         "published_on": get_default_time_display(xblock.published_date) if xblock.published_date else None,
-        "published_by": safe_get_username(xblock.published_by),
         'studio_url': xblock_studio_url(xblock),
         "released_to_students": datetime.now(UTC) > xblock.start,
         "release_date": release_date,
@@ -658,6 +656,10 @@ def create_xblock_info(xblock, data=None, metadata=None, include_ancestor_info=F
         xblock_info['ancestor_info'] = _create_xblock_ancestor_info(xblock)
     if child_info:
         xblock_info['child_info'] = child_info
+    if include_edited_by:
+        xblock_info['edited_by'] = safe_get_username(xblock.subtree_edited_by)
+    if include_published_by:
+        xblock_info['published_by'] = safe_get_username(xblock.published_by)
     # On the unit page only, add 'has_changes' to indicate when there are changes that can be discarded.
     # We don't add it in general because it is an expensive operation.
     if is_xblock_unit:

--- a/cms/djangoapps/contentstore/views/tests/test_item.py
+++ b/cms/djangoapps/contentstore/views/tests/test_item.py
@@ -1142,6 +1142,7 @@ class TestXBlockInfo(ItemTest):
         xblock_info = create_xblock_info(
             vertical,
             include_child_info=True,
+            include_edited_by=True,
             include_children_predicate=ALWAYS,
             include_ancestor_info=True
         )
@@ -1176,7 +1177,6 @@ class TestXBlockInfo(ItemTest):
         self.assertEqual(xblock_info['id'], 'i4x://MITx/999/chapter/Week_1')
         self.assertEqual(xblock_info['display_name'], 'Week 1')
         self.assertTrue(xblock_info['published'])
-        self.assertEqual(xblock_info['edited_by'], 'testuser')
 
         # Finally, validate the entire response for consistency
         self.validate_xblock_info_consistency(xblock_info, has_child_info=has_child_info)
@@ -1189,7 +1189,6 @@ class TestXBlockInfo(ItemTest):
         self.assertEqual(xblock_info['id'], 'i4x://MITx/999/sequential/Lesson_1')
         self.assertEqual(xblock_info['display_name'], 'Lesson 1')
         self.assertTrue(xblock_info['published'])
-        self.assertEqual(xblock_info['edited_by'], 'testuser')
 
         # Finally, validate the entire response for consistency
         self.validate_xblock_info_consistency(xblock_info, has_child_info=has_child_info)
@@ -1214,7 +1213,7 @@ class TestXBlockInfo(ItemTest):
         self.validate_course_xblock_info(ancestors[2], has_child_info=False)
 
         # Finally, validate the entire response for consistency
-        self.validate_xblock_info_consistency(xblock_info, has_child_info=True, has_ancestor_info=True)
+        self.validate_xblock_info_consistency(xblock_info, has_child_info=True, has_ancestor_info=True, has_edited_by=True)
 
     def validate_component_xblock_info(self, xblock_info):
         """
@@ -1224,12 +1223,11 @@ class TestXBlockInfo(ItemTest):
         self.assertEqual(xblock_info['id'], 'i4x://MITx/999/video/My_Video')
         self.assertEqual(xblock_info['display_name'], 'My Video')
         self.assertTrue(xblock_info['published'])
-        self.assertEqual(xblock_info['edited_by'], 'testuser')
 
         # Finally, validate the entire response for consistency
         self.validate_xblock_info_consistency(xblock_info)
 
-    def validate_xblock_info_consistency(self, xblock_info, has_ancestor_info=False, has_child_info=False):
+    def validate_xblock_info_consistency(self, xblock_info, has_ancestor_info=False, has_child_info=False, has_edited_by=False):
         """
         Validate that the xblock info is internally consistent.
         """
@@ -1237,7 +1235,6 @@ class TestXBlockInfo(ItemTest):
         self.assertIsNotNone(xblock_info['id'])
         self.assertIsNotNone(xblock_info['category'])
         self.assertTrue(xblock_info['published'])
-        self.assertEqual(xblock_info['edited_by'], 'testuser')
         if has_ancestor_info:
             self.assertIsNotNone(xblock_info.get('ancestor_info', None))
             ancestors = xblock_info['ancestor_info']['ancestors']
@@ -1258,6 +1255,10 @@ class TestXBlockInfo(ItemTest):
                     )
         else:
             self.assertIsNone(xblock_info.get('child_info', None))
+        if has_edited_by:
+            self.assertEqual(xblock_info['edited_by'], 'testuser')
+        else:
+            self.assertIsNone(xblock_info.get('edited_by', None))
 
 
 class TestXBlockPublishingInfo(ItemTest):


### PR DESCRIPTION
Speeds up the load-time of the course outline page.

Only computes `'edited_by'` and `'published_by'` when we're generating xblock info for a unit page.

@cahrens 
