### PR TITLE
Sarina/port cohorts inst dash

### DIFF
--- a/common/djangoapps/course_groups/cohorts.py
+++ b/common/djangoapps/course_groups/cohorts.py
@@ -6,6 +6,7 @@ forums, and to the cohort admin views.
 from django.http import Http404
 import logging
 import random
+from django.utils.translation import ugettext as _
 
 from courseware import courses
 from student.models import get_user_by_username_or_email
@@ -211,7 +212,7 @@ def add_cohort(course_key, name):
     if CourseUserGroup.objects.filter(course_id=course_key,
                                       group_type=CourseUserGroup.COHORT,
                                       name=name).exists():
-        raise ValueError("Can't create two cohorts with the same name")
+        raise ValueError(_("Cohort with name {name} already exists.".format(name=name)))
 
     return CourseUserGroup.objects.create(
         course_id=course_key,
@@ -253,9 +254,9 @@ def add_user_to_cohort(cohort, username_or_email):
     )
     if course_cohorts.exists():
         if course_cohorts[0] == cohort:
-            raise ValueError("User {0} already present in cohort {1}".format(
-                user.username,
-                cohort.name))
+            raise ValueError(_("User {username} already present in cohort {cohort_name}").format(
+                username=user.username,
+                cohort_name=cohort.name))
         else:
             previous_cohort = course_cohorts[0].name
             course_cohorts[0].users.remove(user)
@@ -278,7 +279,7 @@ def delete_empty_cohort(course_key, name):
     cohort = get_cohort_by_name(course_key, name)
     if cohort.users.exists():
         raise ValueError(
-            "Can't delete non-empty cohort {0} in course {1}".format(
-                name, course_key))
+            _("Can't delete non-empty cohort {cohort_name} in course {course_name}").format(
+                cohort_name=name, course_name=course_key))
 
     cohort.delete()

--- a/common/djangoapps/course_groups/views.py
+++ b/common/djangoapps/course_groups/views.py
@@ -8,6 +8,7 @@ import json
 import logging
 import re
 
+from student.models import UserProfile
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
 from courseware.courses import get_course_with_access
 from edxmako.shortcuts import render_to_response
@@ -129,7 +130,7 @@ def users_in_cohort(request, course_key_string, cohort_id):
 
     user_info = [{'username': u.username,
                   'email': u.email,
-                  'name': '{0} {1}'.format(u.first_name, u.last_name)}
+                  'name': UserProfile.objects.get(user=u).name}
                  for u in users]
 
     return json_http_response({'success': True,
@@ -237,6 +238,6 @@ def debug_cohort_mgmt(request, course_key_string):
 
     context = {'cohorts_ajax_url': reverse(
         'cohorts',
-        kwargs={'course_key': course_key.to_deprecated_string()}
+        kwargs={'course_key_string': course_key.to_deprecated_string()}
     )}
     return render_to_response('/course_groups/debug.html', context)

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -71,11 +71,14 @@ def instructor_dashboard_2(request, course_id):
         _section_analytics(course_key, access),
     ]
 
-    #check if there is corresponding entry in the CourseMode Table related to the Instructor Dashboard course
+    # check if there is corresponding entry in the CourseMode Table related to the Instructor Dashboard course
     course_honor_mode = CourseMode.mode_for_course(course_key, 'honor')
     course_mode_has_price = False
     if course_honor_mode and course_honor_mode.min_price > 0:
         course_mode_has_price = True
+
+    if course.is_cohorted:
+        sections.append(_section_cohorts(course_key, access))
 
     if (settings.FEATURES.get('INDIVIDUAL_DUE_DATES') and access['instructor']):
         sections.insert(3, _section_extensions(course))
@@ -126,6 +129,17 @@ section_key will be used as a css attribute, javascript tie-in, and template imp
 section_display_name will be used to generate link titles in the nav bar.
 """  # pylint: disable=W0105
 
+
+def _section_cohorts(course_key, access):
+    """ Provide data for the cohorts feature on instructor dashboard section """
+    section_data = {
+        'section_key': 'cohorts',
+        'section_display_name': _('Cohorts'),
+        'access': access,
+        'course_id': course_key,
+        'cohorts_ajax_url': reverse('cohorts', kwargs={'course_key_string': course_key.to_deprecated_string()}),
+    }
+    return section_data
 
 def _section_e_commerce(course_key, access):
     """ Provide data for the corresponding dashboard section """

--- a/lms/static/coffee/src/instructor_dashboard/cohorts.js
+++ b/lms/static/coffee/src/instructor_dashboard/cohorts.js
@@ -1,0 +1,339 @@
+/*
+Cohorts Section
+*/
+// TODO this file needs to be fully i18n'd
+// structure stolen from http://briancray.com/posts/javascript-module-pattern
+
+var CohortManager = (function ($) {
+    // private variables and functions
+
+    // using jQuery
+    function getCookie(name) {
+        var cookieValue = null;
+        if (document.cookie && document.cookie != '') {
+            var cookies = document.cookie.split(';');
+            for (var i = 0; i < cookies.length; i++) {
+                var cookie = $.trim(cookies[i]);
+                // Does this cookie string begin with the name we want?
+                if (cookie.substring(0, name.length + 1) == (name + '=')) {
+                    cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+                    break;
+                }
+            }
+        }
+        return cookieValue;
+    }
+    var csrftoken = getCookie('csrftoken');
+    
+    function csrfSafeMethod(method) {
+        // these HTTP methods do not require CSRF protection
+        return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));
+    }  
+    $.ajaxSetup({
+        crossDomain: false, // obviates need for sameOrigin test
+        beforeSend: function(xhr, settings) {
+            if (!csrfSafeMethod(settings.type)) {
+                xhr.setRequestHeader("X-CSRFToken", csrftoken);
+            }
+        }
+    });
+
+    // constructor
+    var module = function () {
+        var el = $(".cohort-manager");
+        // localized jquery
+        var $$ = function (selector) {
+            return $(selector, el)
+        }
+        var state_init = "init";
+        var state_summary = "summary";
+        var state_detail = "detail";
+        var state = state_init;
+        
+        var url = el.data('ajax_url');
+        var self = this;
+
+        // Pull out the relevant parts of the html
+        // global stuff
+        var errors = $$(".cohort-errors");
+
+        // cohort summary display
+        var summary = $$(".cohort-summary");
+        var cohorts = $$(".cohorts");
+        var show_cohorts_button = $$(".controls .show-cohorts");
+        var add_cohort_input = $$(".cohort-name");
+        var add_cohort_button = $$(".add-cohort");
+        
+        // single cohort user display
+        var detail = $$(".cohort-detail");
+        var detail_header = $(".cohort-header", detail);
+        var detail_users = $$(".cohort-users");
+        var detail_page_num = $$(".cohort-page-num");
+        var users_area = $$(".cohort-users-area");
+        var add_members_button = $$(".add-cohort-members");
+        var op_results = $$(".cohort-op-results");
+        var cohort_id = null;
+        var cohort_title = null;
+        var detail_url = null;
+        var page = null;
+
+        // *********** Summary view methods
+
+        function show_cohort(item) {
+            // item is a li that has a data-href link to the cohort base url
+            var el = $(this);
+            cohort_title = el.text();
+            detail_url = el.data('href');
+            cohort_id = el.data('id');
+            state = state_detail;
+            render();
+            return false;
+        }
+
+        function add_to_cohorts_list(item) {
+            var li = $('<li><a href="#"></a></li>');
+            $("a", li).text(item.name)
+                .data('href', url + '/' + item.id)
+                .addClass('link')
+                .click(show_cohort);
+            cohorts.append(li);
+        };
+
+        function log_error(msg) {
+            errors.empty();
+            errors.append($("<span />").text(msg).addClass("error"));
+        };
+        
+        function load_cohorts(response) {
+            cohorts.empty();
+            if (response && response.success) { 
+                response.cohorts.forEach(add_to_cohorts_list);
+            } else {
+                log_error(response.msg || "There was an error loading cohorts");
+            }
+            summary.show();
+        };
+
+
+        function added_cohort(response) {
+            if (response && response.success) {
+                add_to_cohorts_list(response.cohort);
+            } else {
+                log_error(response.msg || "There was an error adding a cohort");
+            }                
+        }
+
+        // *********** Detail view methods
+
+        function remove_user_from_cohort(username, cohort_id, row) {
+            var delete_url = detail_url + '/delete';
+            var data = {'username': username}
+            $.post(delete_url, data).done(function() {row.remove()})
+                .fail(function(jqXHR, status, error) {
+                    log_error('Error removing user ' + username + 
+                              ' from cohort. ' + status + ' ' + error);
+                });
+        }
+
+        function add_to_users_list(item) {
+            var tr = $('<tr><td class="name"></td><td class="username"></td>' + 
+                       '<td class="email"></td>' + 
+                       '<td class="remove"></td></tr>');
+            var current_cohort_id = cohort_id;
+
+            $(".name", tr).text(item.name);
+            $(".username", tr).text(item.username);
+            $(".email", tr).text(item.email);
+
+            $(".remove", tr).html('<a href="#"> <i class="icon-remove-sign"></i> ' + gettext('Remove') + '</a>')
+                .click(function() { 
+                    remove_user_from_cohort(item.username, current_cohort_id, tr);
+                    return false;
+                });
+            
+            detail_users.append(tr);
+        };
+
+
+        function show_users(response) {
+            if (response && response.success && response.users.length > 0) { 
+		// TODO this should use Slickgrid
+		detail_users.html("<tr><th>" + gettext('Name') + "</th><th>" + gettext("Username") + "</th><th>" + gettext("Email") + "</th></tr>");
+                response.users.forEach(add_to_users_list);
+		p_page_text = gettext("Page <%= cur_page_num %> of <%= total_num_pages %>");
+		page_text = _.template(p_page_text, {
+		    cur_page_num: response.page,
+		    total_num_pages: response.num_pages
+		});
+                detail_page_num.html("<em>" + page_text + "</em>");
+            } else if (response.users.length == 0) {
+		// TODO bug: there seems to be a bug where there are no users registered for this cohort,
+		// but the users from another cohort display -- along with this message!
+		// Further debugging needed.
+		p_no_users_text = gettext("There are no users registered for cohort <%= cohort_name %>.");
+		no_users_text = _.template(p_no_users_text, {
+		    cohort_name: cohort_title
+		});
+		detail_users.html("<em>" + no_users_text + "</em>");
+	    } else {
+		p_error_text = gettext("There was an error loading users for cohort <%= cohort_name %>");
+		error_text = _.template(p_error_text, {
+		    cohort_name: cohort_title
+		});
+                log_error(response.msg || error_text);
+	    }
+	    detail.show();
+            op_results.empty();
+        }
+            
+
+        function added_users(response) {
+            op_results.empty();
+            if (response && response.success) {
+                function add_to_list(text, color) {
+                    op_results.append($("<li/>").text(text).css("color", color));
+                }
+                response.added.forEach(
+                    function(item) {
+                        add_to_list(
+                            "Added: " + item.name + ", " + item.username + ", " + item.email,
+                            "green"
+                        );
+                    }
+                );
+                response.changed.forEach(
+                    function(item) {
+                        add_to_list(
+                            "Moved from cohort " + item.previous_cohort + ": " + item.name + ", " + item.username + ", " + item.email,
+                            "purple"
+                        )
+                    }
+                );
+                response.present.forEach(
+                    function(item) {
+                        add_to_list("Already present: " + item, "black");
+                    }
+                );
+                response.unknown.forEach(
+                    function(item) {
+                        add_to_list("Unknown user: " + item, "red")
+                    }
+                );
+                users_area.val('')
+            } else {
+                log_error(response.msg || "There was an error adding users");
+            }                
+        }
+
+        // ******* Rendering
+
+            
+        function render() {
+            // Load and render the right thing based on the state
+             
+            // start with both divs hidden
+            summary.hide();
+            detail.hide();
+            // and clear out the errors
+            errors.empty();
+            if (state == state_summary) {
+                $.ajax(url).done(load_cohorts).fail(function() {
+                    log_error("Error trying to load cohorts");
+                });
+            } else if (state == state_detail) {
+		p_header_text = gettext("Members of <%= cohort_name %>");
+		header_text = _.template(p_header_text, {
+		    cohort_name: cohort_title
+		});
+                detail_header.text(header_text);
+                $.ajax(detail_url).done(show_users).fail(function() {
+                    log_error("Error trying to load users in cohort");
+                });
+            }
+        }
+
+        show_cohorts_button.click(function() { 
+            state = state_summary;
+            render();
+            return false;
+        });
+        
+        add_cohort_input.change(function() {
+            if (!$(this).val()) {
+                add_cohort_button.removeClass('button').addClass('button-disabled');
+            } else {
+                add_cohort_button.removeClass('button-disabled').addClass('button');
+            }
+        });
+
+        add_cohort_button.click(function() { 
+            var add_url = url + '/add';
+            data = {'name': add_cohort_input.val()}
+            $.post(add_url, data).done(added_cohort);
+	    // Clear input field
+	    add_cohort_input.val('');
+            return false;
+        });
+
+        add_members_button.click(function() { 
+            var add_url = detail_url + '/add';
+            data = {'users': users_area.val()}
+            $.post(add_url, data).done(added_users);
+            return false;
+        });
+
+
+    };
+
+    // prototype
+    module.prototype = {
+        constructor: module,
+    };
+
+    // return module
+    return module;
+})(jQuery);
+
+//$(window).load(function () {
+//    var my_module = new CohortManager();
+//})
+
+(function() {
+  var Cohorts, plantTimeout, std_ajax_err;
+
+  plantTimeout = function() {
+    return window.InstructorDashboard.util.plantTimeout.apply(this, arguments);
+  };
+
+  std_ajax_err = function() {
+    return window.InstructorDashboard.util.std_ajax_err.apply(this, arguments);
+  };
+
+  Cohorts = (function() {
+    function Cohorts($section) {
+      this.$section = $section;
+      this.$section.data('wrapper', this);
+      this.cohort_manager = new CohortManager();
+    }
+
+    Cohorts.prototype.onClickTitle = function() {
+	// TODO click the show_cohorts_button here
+    };
+
+    return Cohorts;
+
+  })();
+
+  if (typeof _ !== "undefined" && _ !== null) {
+    _.defaults(window, {
+      InstructorDashboard: {}
+    });
+    _.defaults(window.InstructorDashboard, {
+      sections: {}
+    });
+    _.defaults(window.InstructorDashboard.sections, {
+      Cohorts: Cohorts
+    });
+  }
+
+}).call(this);

--- a/lms/static/coffee/src/instructor_dashboard/instructor_dashboard.coffee
+++ b/lms/static/coffee/src/instructor_dashboard/instructor_dashboard.coffee
@@ -165,6 +165,9 @@ setup_instructor_dashboard_sections = (idash_content) ->
     constructor: window.InstructorDashboard.sections.Extensions
     $element: idash_content.find ".#{CSS_IDASH_SECTION}#extensions"
   ,
+    constructor: window.InstructorDashboard.sections.Cohorts
+    $element: idash_content.find ".#{CSS_IDASH_SECTION}#cohorts"
+  ,
     constructor: window.InstructorDashboard.sections.Email
     $element: idash_content.find ".#{CSS_IDASH_SECTION}#send_email"
   ,

--- a/lms/static/sass/course/instructor/_instructor_2.scss
+++ b/lms/static/sass/course/instructor/_instructor_2.scss
@@ -589,6 +589,50 @@ section.instructor-dashboard-content-2 {
 }
 
 
+.instructor-dashboard-wrapper-2 section.idash-section#cohorts {
+  .cohort-manager {
+    .cohort-errors {
+        margin: 0;
+    	padding-bottom: ($baseline);
+	color: $error-red;
+    }
+  }
+
+  .cohort-detail {
+    textarea {
+      margin-top: 0.2em;
+      height: auto;
+      width: 90%;
+    }
+
+    input {
+      margin-right: 5px;
+    }
+
+    table {
+      width: 100%;
+    }
+
+    th {
+      padding: 5px;
+    }
+
+    .remove {
+      color: $lighter-base-font-color;
+      cursor: pointer;
+
+      &:hover, &:focus {
+        color: $alert-color;
+      }
+    }
+
+    .cohort-page-num {
+      position: absolute;
+      right: 15px;
+    }
+  }
+}
+
 .instructor-dashboard-wrapper-2 section.idash-section#metrics {
 
   .metrics-container, .metrics-header-container {

--- a/lms/templates/instructor/instructor_dashboard_2/cohorts.html
+++ b/lms/templates/instructor/instructor_dashboard_2/cohorts.html
@@ -1,0 +1,54 @@
+<%! from django.utils.translation import ugettext as _ %>
+<%page args="section_data"/>
+## TODO jeez this is ugly as sin and the workflow makes no sense
+## TODO styles should be specified in CSS, not in a weird combo of here + js
+## TODO you shouldn't have to click the "Show Cohorts" button on entering this page;
+## it should be 'clicked' for you (or the page should just render the info without
+## needing the click). I'm not good enough at JS to know the best way here.
+
+## Developer: Use the cohorts.js in lms/static/coffee/src/instructor_dashboard/
+<div class="cohort-manager" data-ajax_url="${ section_data['cohorts_ajax_url'] }">
+  <h2>${_("Manage Cohort Groups")}</h2>
+
+  <div class="controls" style="padding-top:15px">
+    <input type="button" name="show-cohorts" class="button show-cohorts" value="${_("Show Cohorts")}" data-endpoint="#">
+  </div>
+
+  <div class="cohort-errors">
+  </div>
+
+  <div class="cohort-summary" style="display:none">
+    <h3>${_("All Cohorts")}</h3>
+    <ul class="cohorts">
+    </ul>
+
+    <p>
+      <input type="text" name="cohort-name" class="cohort-name" placeholder="${_('Cohort Name')}"/>
+
+      <input type="button" name="add-cohort" class="button add-cohort" value="${_("Add New Cohort")}" data-endpoint="#">
+    </p>
+
+  </div>
+
+  <div class="cohort-detail" style="display:none">
+    <h2 class="cohort-header"></h2>
+    <p>
+      <table class="cohort-users"></table>
+      <span class="cohort-page-num"></span>
+    </p>
+
+    <p>
+      <label for="cohort-users-area">
+	## This text is identical to others used on the instructor dashboard, so be careful in changing.
+	${_("Enter email addresses and/or usernames separated by new lines or commas.")}
+      </label>
+      <textarea rows="6" cols="50" class="cohort-users-area" placeholder="${_("Email Addresses/Usernames")}" spellcheck="false"></textarea>
+    </p>
+    <div>
+      <input type="button" name="add-cohort-members" class="button add-cohort-members" value="${_("Add Cohort Members")}" data-endpoint="#">
+    </div>
+
+    <p><ul class="cohort-op-results"></ul></p>
+
+  </div>
+</div>

--- a/lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html
+++ b/lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html
@@ -38,7 +38,6 @@
   <script type="text/javascript" src="${static.url('js/vendor/flot/jquery.flot.axislabels.js')}"></script>
   <script type="text/javascript" src="${static.url('js/vendor/jquery-jvectormap-1.1.1/jquery-jvectormap-1.1.1.min.js')}"></script>
   <script type="text/javascript" src="${static.url('js/vendor/jquery-jvectormap-1.1.1/jquery-jvectormap-world-mill-en.js')}"></script>
-  <script type="text/javascript" src="${static.url('js/course_groups/cohorts.js')}"></script>
   <script type="text/javascript" src="${static.url('js/vendor/jquery.event.drag-2.2.js')}"></script>
   <script type="text/javascript" src="${static.url('js/vendor/jquery.event.drop-2.2.js')}"></script>
   <script type="text/javascript" src="${static.url('js/vendor/slick.core.js')}"></script>


### PR DESCRIPTION
Port the existing Cohorts functionality to the new instructor dashboard and a fair number of improvements:
- Student name now shows up instead of being blank in user table
- Better UX
  - CSS rules
  - divs instead of uls
  - button stylings match rest of instructor dashboard
  - Text (on buttons, and labels) match rest of instructor dashboard
  - Better spacing (divs around elements, etc)
- First pass i18n (lots more still needed)

To do this I made copies of the existing code so that the "legacy" functionality is uninterrupted.

You can view this on my sandbox: http://sarina.m.sandbox.edx.org/ Log in as the default staff user. The demo course is set up to use cohorts, and you can compare and contrast the new dash implementation with the legacy dash.

Necessary future work
- improved UX
- remove feature off of Legacy dashboard & outdated code out of the codebase
- i18n
- Added lots of `TODOs` within the code that need to be addressed, particularly, on visiting the "Cohorts" page the information should be immediately displayed, not gated behind an additional button (yuck!). My Javascript isn't good enough to figure out the best way to fix this.
- API level unit testing; javascript testing
