### PR TITLE
Simplify bok choy environments to inherit pipeline settings from common.

### DIFF
--- a/cms/envs/bok_choy.py
+++ b/cms/envs/bok_choy.py
@@ -40,7 +40,6 @@ update_module_store_settings(
 
 # Enable django-pipeline and staticfiles
 STATIC_ROOT = (TEST_ROOT / "staticfiles").abspath()
-PIPELINE = True
 
 # Silence noisy logs
 import logging

--- a/lms/envs/bok_choy.py
+++ b/lms/envs/bok_choy.py
@@ -49,7 +49,6 @@ OPEN_ENDED_GRADING_INTERFACE['url'] = 'http://localhost:8041/'
 
 # Enable django-pipeline and staticfiles
 STATIC_ROOT = (TEST_ROOT / "staticfiles").abspath()
-PIPELINE = True
 
 # Silence noisy logs
 import logging


### PR DESCRIPTION
This may also help with some (bot not all) of the flaky tests. Certain assets aren't being rendered currently.
