### PR TITLE
Fix incorrect max upload file size on forums

### DIFF
--- a/lms/djangoapps/django_comment_client/base/views.py
+++ b/lms/djangoapps/django_comment_client/base/views.py
@@ -568,7 +568,7 @@ def upload(request, course_id):  # ajax upload file to a question or answer
         size = file_storage.size(new_file_name)
         if size > cc_settings.MAX_UPLOAD_FILE_SIZE:
             file_storage.delete(new_file_name)
-            msg = _("maximum upload file size is %(file_size)sK") % \
+            msg = _("Maximum upload file size is %(file_size)s bytes.") % \
                 {'file_size': cc_settings.MAX_UPLOAD_FILE_SIZE}
             raise exceptions.PermissionDenied(msg)
 


### PR DESCRIPTION
The file size is calculated and displayed as a number of bytes, but was
being incorrectly labeled as 'K' [0].

The size is now correctly labeled as "bytes" and the sentence now begins
with a leading captial letter.

Impact: This has been broken on master since 2012 [1].

[0] https://github.com/edx/edx-platform/blob/master/lms/djangoapps/django_comment_client/settings.py#L4
[1] https://github.com/edx/edx-platform/commit/5d90366917c6e81513e26ea4cb8305df0f3e6d97
