### PR TITLE
A better check for the existence of matlabinput element.

### DIFF
--- a/common/lib/capa/capa/responsetypes.py
+++ b/common/lib/capa/capa/responsetypes.py
@@ -1879,7 +1879,7 @@ class CodeResponse(LoncapaResponse):
 
         # matlab api key can be defined in course settings. if so, add it to the grader payload
         api_key = getattr(self.capa_system, 'matlab_api_key', None)
-        if self.xml.find('matlabinput') and api_key:
+        if api_key and self.xml.find('matlabinput') is not None:
             self.payload['token'] = api_key
             self.payload['endpoint_version'] = "2"
             self.payload['requestor_id'] = self.capa_system.anonymous_student_id


### PR DESCRIPTION
It turns out that `bool(xml.find('element'))` will return false if the element is empty. In this case, we care only whether the element exists.

@nedbat 
