### PR TITLE
fixing long names on outline, unit, container

### DIFF
--- a/cms/static/sass/elements/_forms.scss
+++ b/cms/static/sass/elements/_forms.scss
@@ -334,7 +334,10 @@ form[class^="create-"] {
 
   .incontext-editor-value,
   .incontext-editor-action-wrapper {
+    @extend %cont-truncated;
     display: inline-block;
+    vertical-align: middle;
+    max-width: 80%;
   }
 
   .incontext-editor-open-action {

--- a/cms/static/sass/views/_outline.scss
+++ b/cms/static/sass/views/_outline.scss
@@ -15,11 +15,6 @@
       vertical-align: top;
     }
 
-    .incontext-editor-value {
-      max-width: 80%;
-      margin-right: ($baseline/10);
-    }
-
     .incontext-editor-open-action {
       @include transition(opacity $tmg-f1 ease-in-out 0);
       opacity: 0.0;


### PR DESCRIPTION
Prevent wrapping and edit button moving to a new line on long names on outline, unit, container.

@talbs @cahrens Can you review?
