### PR TITLE
Avoid unnecessary calls to get_parent_xblock in _course_outline_json

### DIFF
--- a/cms/djangoapps/contentstore/views/helpers.py
+++ b/cms/djangoapps/contentstore/views/helpers.py
@@ -55,19 +55,20 @@ def get_parent_xblock(xblock):
     return modulestore().get_item(parent_location)
 
 
-def is_unit(xblock):
+def is_unit(xblock, parent_xblock=None):
     """
     Returns true if the specified xblock is a vertical that is treated as a unit.
     A unit is a vertical that is a direct child of a sequential (aka a subsection).
     """
     if xblock.category == 'vertical':
-        parent_xblock = get_parent_xblock(xblock)
+        if parent_xblock is None:
+            parent_xblock = get_parent_xblock(xblock)
         parent_category = parent_xblock.category if parent_xblock else None
         return parent_category == 'sequential'
     return False
 
 
-def xblock_has_own_studio_page(xblock):
+def xblock_has_own_studio_page(xblock, parent_xblock=None):
     """
     Returns true if the specified xblock has an associated Studio page. Most xblocks do
     not have their own page but are instead shown on the page of their parent. There
@@ -80,21 +81,22 @@ def xblock_has_own_studio_page(xblock):
     """
     category = xblock.category
 
-    if is_unit(xblock):
+    if is_unit(xblock, parent_xblock):
         return True
     elif category == 'vertical':
-        parent_xblock = get_parent_xblock(xblock)
+        if parent_xblock is None:
+            parent_xblock = get_parent_xblock(xblock)
         return is_unit(parent_xblock) if parent_xblock else False
 
     # All other xblocks with children have their own page
     return xblock.has_children
 
 
-def xblock_studio_url(xblock):
+def xblock_studio_url(xblock, parent_xblock=None):
     """
     Returns the Studio editing URL for the specified xblock.
     """
-    if not xblock_has_own_studio_page(xblock):
+    if not xblock_has_own_studio_page(xblock, parent_xblock):
         return None
     category = xblock.category
     if category == 'course':

--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -623,10 +623,7 @@ def create_xblock_info(xblock, data=None, metadata=None, include_ancestor_info=F
 
         return None
 
-    if parent_xblock:
-        is_xblock_unit = parent_xblock.category == 'sequential' and xblock.category == 'vertical'
-    else:
-        is_xblock_unit = is_unit(xblock)
+    is_xblock_unit = is_unit(xblock, parent_xblock)
     is_unit_with_changes = is_xblock_unit and modulestore().has_changes(xblock.location)
 
     # Compute the child info first so it can be included in aggregate information for the parent
@@ -652,7 +649,7 @@ def create_xblock_info(xblock, data=None, metadata=None, include_ancestor_info=F
         "edited_on": get_default_time_display(xblock.subtree_edited_on) if xblock.subtree_edited_on else None,
         "published": published,
         "published_on": get_default_time_display(xblock.published_date) if xblock.published_date else None,
-        'studio_url': xblock_studio_url(xblock),
+        'studio_url': xblock_studio_url(xblock, parent_xblock),
         "released_to_students": datetime.now(UTC) > xblock.start,
         "release_date": release_date,
         "visibility_state": _compute_visibility_state(xblock, child_info, is_unit_with_changes) if not xblock.category == 'course' else None,


### PR DESCRIPTION
When calculating _course_outline_json's `xblock_studio_url(xblock)` we hit Mongo database often, but mostly because methods used in `xblock_studio_url` (`xblock_has_own_studio_page`, `is_unit`) are calling `get_parent_xblock` a lot. This change tries to reuse information about parent_xblock when possible.

Reduces rendering time for Justice course from 5.5 to 3.2 seconds for me.

review: @cahrens @dan-f
