### PR TITLE
Studio: FIX - Staff Only coloring only Status Message icons

### DIFF
--- a/cms/static/sass/elements/_modules.scss
+++ b/cms/static/sass/elements/_modules.scss
@@ -389,7 +389,7 @@ $outline-indent-width: $baseline;
     > .subsection-status,
     > .unit-status {
 
-      .icon {
+      .status-message .icon {
         color: $color-staff-only;
       }
     }


### PR DESCRIPTION
This quick fix scopes staff only color to .status-message icons
