### PR TITLE
Translate string iff non-empty

### DIFF
--- a/cms/djangoapps/contentstore/views/checklist.py
+++ b/cms/djangoapps/contentstore/views/checklist.py
@@ -136,7 +136,7 @@ def localize_checklist_text(checklist):
     # Localize checklist items
     for item in checklist.get('items'):
         item['short_description'] = ugettext(item['short_description'])
-        item['long_description'] = ugettext(item['long_description'])
+        item['long_description'] = ugettext(item['long_description']) if item['long_description'] != '' else u''
         item['action_text'] = ugettext(item['action_text']) if item['action_text'] != "" else u""
 
     return checklist


### PR DESCRIPTION
This resolves an issue where a checklist's long_description being empty
caused gettext to dump PO file headers.

I had originally made this change to the Stanford-Online/edx-platform
repository a few weeks ago [0] to address a failing test on our fork.
I didn't take the time to diagnose the root issue; I just fixed it for
the single case.

After stumbling across the issue elsewhere, @kluo 
followed through and tracked down the cause of the behavior. It turns
out that `gettext`, by default, translates the empty string into PO file
headers; this is apparently a feature, not a bug [1].

This behavior seems counterintuitive; for our use, it seems that
translating an empty string should simply return an empty string. We
already program defensively around this in platform code [2], but it'd be
convenient to resolve this with a centralized solution, instead of a
patchwork of fixes.

[0] 4b88f54aa658db952e899222ff5ede4a1c1beb18
[1] http://stackoverflow.com/questions/18459387/translation-of-empty-string-shows-po-header
[2] https://github.com/edx/edx-platform/blob/master/cms/djangoapps/contentstore/views/checklist.py#L140
