### PR TITLE
Transparent bg on flat outline button

### DIFF
--- a/common/static/sass/_mixins.scss
+++ b/common/static/sass/_mixins.scss
@@ -231,6 +231,7 @@
   border-radius: ($baseline/4);
   border: 1px solid $blue-l2;
   padding: 1px ($baseline/2) 2px ($baseline/2);
+  background-color: transparent;
   color: $blue-l2;
 
   &:hover, &:focus {


### PR DESCRIPTION
explicitly set transparent background on flat outline button to prevent browser defaults
@polesye This should fix the button state you found on Textbooks and Group Configurations.

@talbs @polesye can you review?
