### PR TITLE
Remove tooltip manager to get tests working in CMS again.

### DIFF
--- a/cms/templates/base.html
+++ b/cms/templates/base.html
@@ -81,7 +81,6 @@
             "draggabilly": "js/vendor/draggabilly.pkgd",
             "URI": "js/vendor/URI.min",
             "ieshim": "js/src/ie_shim",
-            "tooltip_manager": "coffee/src/discussion/tooltip_manager",
 
             // externally hosted files
             "tender": [
@@ -235,7 +234,7 @@
         deps: ["jquery", "gettext"],
         callback: function() {
             // load other scripts on every page, after jquery loads
-            require(["js/base", "coffee/src/main", "coffee/src/logger", "datepair", "accessibility", "ieshim", "tooltip_manager"]);
+            require(["js/base", "coffee/src/main", "coffee/src/logger", "datepair", "accessibility", "ieshim"]);
             // we need "datepair" because it dynamically modifies the page
             // when it is loaded -- yuck!
         }


### PR DESCRIPTION
My theory is that the discussion module tooltip_manager is not getting bundled into the "xmodule" JS. It would work locally if the non-bundled file can be found.

To fix this, we should really move the toolitp_manager to the correct location. In the short term, I think it is OK to just remove the dependency. Tooltips won't work, but they didn't for large parts of CMS before Anton's PR anyway.

@polesye here is a pointer to how we bundle JS in common package for use by RequireJS in CMS (since it is not used in LMS nor in common in general). Take a look at /edx-platform/common/djangoapps/pipeline_js/urls.py and /edx-platform/common/djangoapps/pipeline_js/templates/xmodule.js and /edx-platform/common/djangoapps/pipeline_js/views.py
