### PR TITLE
Disable ajax caching in IE to fix backbone fetching

### DIFF
--- a/cms/static/js/base.js
+++ b/cms/static/js/base.js
@@ -73,6 +73,11 @@ domReady(function() {
     $('a.show-tender').bind('click', smoothScrollTop);
 
     IframeUtils.iframeBinding();
+
+    // disable ajax caching in IE so that backbone fetches work
+    if ($.browser.msie) {
+        $.ajaxSetup({ cache: false });
+    }
 });
 
 function smoothScrollLink(e) {


### PR DESCRIPTION
This fixes all the IE issues that I experienced on the course outline page. @cahrens @benmcmorran 
