### PR TITLE
(WIP) Implemented Xblock Runtime User service

### DIFF
--- a/common/lib/xmodule/xmodule/html_module.py
+++ b/common/lib/xmodule/xmodule/html_module.py
@@ -67,6 +67,10 @@ class HtmlModule(HtmlFields, XModule):
     css = {'scss': [resource_string(__name__, 'css/html/display.scss')]}
 
     def get_html(self):
+        user_service = self.runtime.service(self, 'user')
+        xblock_user = user_service.get_user()
+        print xblock_user.email
+
         if self.system.anonymous_student_id:
             return self.data.replace("%%USER_ID%%", self.system.anonymous_student_id)
         return self.data

--- a/common/lib/xmodule/xmodule/modulestore/django.py
+++ b/common/lib/xmodule/xmodule/modulestore/django.py
@@ -20,6 +20,8 @@ from xmodule.util.django import get_current_request_hostname
 import xmodule.modulestore  # pylint: disable=unused-import
 from xmodule.contentstore.django import contentstore
 
+from lms.lib.xblock.models import XBlockUser
+
 # We may not always have the request_cache module available
 try:
     from request_cache.middleware import RequestCache
@@ -108,6 +110,22 @@ def clear_existing_modulestores():
     """
     global _MIXED_MODULESTORE  # pylint: disable=global-statement
     _MIXED_MODULESTORE = None
+
+
+class ModuleUserService(object):
+    """
+    Implement the XBlock runtime 'user' service.
+
+    Each instance of this runtime service takes a user and a course_id
+    and stores a XBlockUser object. It's possible to only wrap desired
+    attributes into the XBlockUser object.
+    """
+    def __init__(self, user, course_id=None):
+        self.xblock_user = XBlockUser(self, email=user.email,
+                                        full_name=user.profile.name)
+
+    def get_user(self):
+        return self.xblock_user
 
 
 class ModuleI18nService(object):

--- a/common/lib/xmodule/xmodule/tests/__init__.py
+++ b/common/lib/xmodule/xmodule/tests/__init__.py
@@ -23,7 +23,7 @@ from xmodule.modulestore.inheritance import InheritanceMixin, own_metadata
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
 from xmodule.mako_module import MakoDescriptorSystem
 from xmodule.error_module import ErrorDescriptor
-
+from xmodule.modulestore.django import ModuleI18nService, ModuleUserService
 
 MODULE_DIR = path(__file__).dirname()
 # Location of common test DATA directory
@@ -73,13 +73,14 @@ def get_test_system(course_id=SlashSeparatedCourseKey('org', 'course', 'run')):
     where `my_render_func` is a function of the form my_render_func(template, context).
 
     """
+    user = Mock(is_staff=False)
     return TestModuleSystem(
         static_url='/static',
         track_function=Mock(),
         get_module=Mock(),
         render_template=mock_render_template,
         replace_urls=str,
-        user=Mock(is_staff=False),
+        user=user,
         filestore=Mock(),
         debug=True,
         hostname="edx.org",
@@ -92,6 +93,10 @@ def get_test_system(course_id=SlashSeparatedCourseKey('org', 'course', 'run')):
         get_user_role=Mock(is_staff=False),
         descriptor_runtime=get_test_descriptor_system(),
         user_location=Mock(),
+        services={
+            'i18n': ModuleI18nService(),
+            'user': ModuleUserService(user, course_id=course_id)
+        }
     )
 
 

--- a/common/lib/xmodule/xmodule/tests/test_html_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_html_module.py
@@ -38,3 +38,11 @@ class HtmlModuleSubstitutionTestCase(unittest.TestCase):
         module = HtmlModule(self.descriptor, module_system, field_data, Mock())
         self.assertEqual(module.get_html(), sample_xml)
 
+
+    def test_xblock_user_runtime_service(self):
+        user_service = self.runtime.service(self, 'user')
+        xblock_user = user_service.get_user()
+
+        # Make sure that xblock_user exists.
+        self.assertIsNotNone(xblock_user)
+

--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -474,6 +474,7 @@ module_runtime_attr = partial(ProxyAttribute, 'xmodule_runtime')  # pylint: disa
 
 
 @XBlock.needs("i18n")
+@XBlock.needs("user")
 class XModule(XModuleMixin, HTMLSnippet, XBlock):  # pylint: disable=abstract-method
     """ Implements a generic learning module.
 

--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -34,7 +34,7 @@ from xblock.django.request import django_to_webob_request, webob_to_django_respo
 from xmodule.error_module import ErrorDescriptor, NonStaffErrorDescriptor
 from xmodule.exceptions import NotFoundError, ProcessingError
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
-from xmodule.modulestore.django import modulestore, ModuleI18nService
+from xmodule.modulestore.django import modulestore, ModuleI18nService, ModuleUserService
 from xmodule.modulestore.exceptions import ItemNotFoundError
 from xmodule.util.duedate import get_extended_due_date
 from xmodule_modifiers import replace_course_urls, replace_jump_to_id_urls, replace_static_urls, add_staff_markup, wrap_xblock
@@ -496,6 +496,7 @@ def get_module_system_for_user(user, field_data_cache,
         get_real_user=user_by_anonymous_id,
         services={
             'i18n': ModuleI18nService(),
+            'user': ModuleUserService(user, course_id=course_id)
         },
         get_user_role=lambda: get_user_role(user, course_id),
         descriptor_runtime=descriptor.runtime,

--- a/lms/lib/xblock/models.py
+++ b/lms/lib/xblock/models.py
@@ -1,0 +1,60 @@
+"""
+Implement interfaces for representing runtime objects in XBlock.
+
+Do not persist along with the xblock. Just a representation of runtime object.
+"""
+
+class XBlockModel(object):
+    """
+    Interface to represent an xblock model.
+
+    By providing an interface, workbench can dynamically define the 
+    attributes for each XBlockModel object that is bound to an xblock
+
+    This Model allows a very flexible transfer of workbench objects 
+    to the given XBlock instance.
+    """
+
+    def __init__(self, parent, **kwargs):
+        """
+        Constructor for XBlockUser takes in kwargs of attr and vals to rep
+        the object. The parent in the xblock to which this model will be 
+        bound.
+        """
+        self.parent = parent
+
+        for attr, val in kwargs.iteritems():
+            self.add_attribute(attr, val)
+
+    def add_attr(self, attr, value):
+        """
+        Sets a new attribute attr_name of value to the XBlock Model instance 
+        """
+        setattr(self, attr, value)
+    
+
+class XBlockUser(XBlockModel):
+    """
+    XBlock's user model representation during runtime. 
+
+    XBlock provides a set of predefined attributes as instance variables.
+        - email
+        - full_name
+        - user_name
+        - anon_id
+        - is_instructor
+
+    Runtimes are not required to conform to this standard and can always
+    use kwargs and att_attr to patch attributes dynamically
+    """
+    def __init__(self, parent, email="", full_name="", user_name="", anon_id="", is_instructor=False, **kwargs):
+
+        # Set standardized attributes
+        self.email = email
+        self.full_name = full_name
+        self.user_name = user_name
+        self.anon_id = anon_id
+        self.is_instructor = is_instructor
+        
+        # Set all dynamic attributes
+        super(XBlockUser, self).__init__(parent, **kwargs)


### PR DESCRIPTION
@jbau @cpennington 

This commit introduces a new Xblock Runtime service: ModuleUserService in
common/lib/xmodule/xmodule/modulestore/django.py

With this new service, it is now possible to store user models as
XBlockUser objects and store desired attributes in them.

Xblocks can now call self.runtime.service(self, 'user') to access the user
service and call get_user() to receive the XBlockUser object of the current
user.

*\* This PR is to open up a conversation about this feature
*\* XblockUser has not yet landed in xblock/master, and is currently patched in
lms/lib/xblock for this PR
