### PR TITLE
Fix failing video tests due to wrong IFRAME_API_RESPONSE 

### DIFF
--- a/common/djangoapps/terrain/stubs/tests/test_youtube_stub.py
+++ b/common/djangoapps/terrain/stubs/tests/test_youtube_stub.py
@@ -4,7 +4,7 @@ Unit test for stub YouTube implementation.
 
 import unittest
 import requests
-from ..youtube import StubYouTubeService
+from ..youtube import StubYouTubeService, IFRAME_API_RESPONSE
 
 
 class StubYouTubeServiceTest(unittest.TestCase):
@@ -74,3 +74,16 @@ class StubYouTubeServiceTest(unittest.TestCase):
 
         # ensure that server config dict is empty after successful reset
         self.assertEqual(self.server.config, {})
+
+
+    def test_iframe_response_is_up_to_date(self):
+        """
+        Check if IFRAME_API_RESPONSE is up-to-date.
+
+        This should prevent issues with IFRAME_API_RESPONSE hard-coding, 
+        when hard-coded version is different from actual.
+        """
+        self.assertEqual(
+            IFRAME_API_RESPONSE,
+            requests.get('https://www.youtube.com/iframe_api').content.strip("\n")
+        )

--- a/common/djangoapps/terrain/stubs/youtube.py
+++ b/common/djangoapps/terrain/stubs/youtube.py
@@ -20,13 +20,20 @@ from .http import StubHttpRequestHandler, StubHttpService
 import json
 import time
 import requests
+import textwrap
 from urlparse import urlparse
 from collections import OrderedDict
 
 
-# Unless we find a better way, we will get the response from iframe api
-# once per suite run, instead of using hardcoded response, to avoid issues.
-IFRAME_API_RESPONSE = requests.get('http://www.youtube.com/iframe_api').text
+IFRAME_API_RESPONSE = textwrap.dedent(
+    "if (!window['YT']) {var YT = {loading: 0,loaded: 0};}if (!window['YTConfig']) {var YTConfig"
+    " = {'host': 'http://www.youtube.com'};}if (!YT.loading) {YT.loading = 1;(function(){var l ="
+    " [];YT.ready = function(f) {if (YT.loaded) {f();} else {l.push(f);}};window.onYTReady ="
+    " function() {YT.loaded = 1;for (var i = 0; i < l.length; i++) {try {l[i]();} catch (e) "
+    "{}}};YT.setConfig = function(c) {for (var k in c) {if (c.hasOwnProperty(k)) {YTConfig[k]"
+    " = c[k];}}};var a = document.createElement('script');a.id = 'www-widgetapi-script';a.src"
+    " = 'https:' + '//s.ytimg.com/yts/jsbin/www-widgetapi-vflT-xPmY/www-widgetapi.js';a.async"
+    " = true;var b = document.getElementsByTagName('script')[0];b.parentNode.insertBefore(a, b);})();}")
 
 
 class StubYouTubeHandler(StubHttpRequestHandler):

--- a/common/test/acceptance/tests/video/test_video_handout.py
+++ b/common/test/acceptance/tests/video/test_video_handout.py
@@ -3,11 +3,9 @@
 """
 Acceptance tests for CMS Video Handout.
 """
-from unittest import skip
 from .test_studio_video_module import CMSVideoBaseTest
 
 
-@skip('Failing in master in wait_for_video_component_render BLD-1194')
 class VideoHandoutTest(CMSVideoBaseTest):
     """
     CMS Video Handout Test Class


### PR DESCRIPTION
This fixes https://openedx.atlassian.net/browse/BLD-1194. 
The issue is due to change in http://www.youtube.com/iframe_api response javascript. We were using the hardcoded response due to which video player is not initializing. Similar to https://github.com/edx/edx-platform/pull/4691 but IFRAME_API_RESPONSE is hardcoded. It seems to make handout tests work fine.

Reviewers @polesye  @muhammad-ammar 
