### PR TITLE
Remove staff lock field when removing staff lock

### DIFF
--- a/cms/static/js/spec/views/pages/container_subviews_spec.js
+++ b/cms/static/js/spec/views/pages/container_subviews_spec.js
@@ -394,13 +394,13 @@ define(["jquery", "underscore", "underscore.string", "js/spec_helpers/create_sin
 
                         create_sinon.expectJsonRequest(requests, 'POST', '/xblock/locator-container', {
                             publish: 'republish',
-                            metadata: { visible_to_staff_only: isStaffOnly }
+                            metadata: { visible_to_staff_only: isStaffOnly ? true : null }
                         });
                         create_sinon.respondWithJson(requests, {
                             data: null,
                             id: "locator-container",
                             metadata: {
-                                visible_to_staff_only: isStaffOnly
+                                visible_to_staff_only: isStaffOnly ? true : null
                             }
                         });
                         create_sinon.expectJsonRequest(requests, 'GET', '/xblock/locator-container');

--- a/cms/static/js/views/pages/container_subviews.js
+++ b/cms/static/js/views/pages/container_subviews.js
@@ -174,9 +174,11 @@ define(["jquery", "underscore", "gettext", "js/views/baseview", "js/views/utils/
                 };
 
                 saveAndPublishStaffLock = function() {
+                    // Setting staff lock to null when disabled will delete the field from this xblock,
+                    // allowing it to use the inherited value instead of using false explicitly.
                     return xblockInfo.save({
                         publish: 'republish',
-                        metadata: {visible_to_staff_only: enableStaffLock}},
+                        metadata: {visible_to_staff_only: enableStaffLock ? true : null}},
                         {patch: true}
                     ).always(function() {
                         xblockInfo.set("publish", null);


### PR DESCRIPTION
This change will prevent a `false` staff lock from being inherited.

@cahrens @dan-f please review.
