### PR TITLE
Upgrade scipy, lxml, boto, edx-ora2

### DIFF
--- a/docs/shared/requirements.txt
+++ b/docs/shared/requirements.txt
@@ -34,7 +34,7 @@ feedparser==5.1.3
 git+https://github.com/pmitros/pyfs.git@96e1922348bfe6d99201b9512a9ed946c87b7e0b
 GitPython==0.3.2.RC1
 glob2==0.3
-lxml==3.0.1
+lxml==3.3.6
 mako==0.7.3
 Markdown==2.2.1
 mock==1.0.1

--- a/requirements/edx-sandbox/post.txt
+++ b/requirements/edx-sandbox/post.txt
@@ -5,5 +5,5 @@
 #   * One of @e0d, @jarv, or @feanil - to check system requirements
 
 # Packages to install in the Python sandbox for secured execution.
-scipy==0.11.0
-lxml==3.0.1
+scipy==0.14.0
+lxml==3.3.6

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -8,7 +8,7 @@ beautifulsoup4==4.1.3
 beautifulsoup==3.2.1
 bleach==1.4
 html5lib==0.999
-boto==2.13.3
+boto==2.32.1
 celery==3.0.19
 cssselect==0.9.1
 dealer==0.2.3
@@ -45,7 +45,7 @@ GitPython==0.3.2.RC1
 glob2==0.3
 gunicorn==0.17.4
 lazy==1.1
-lxml==3.0.1
+lxml==3.3.6
 mako==0.9.1
 Markdown==2.2.1
 mongoengine==0.7.10
@@ -72,7 +72,7 @@ pysrt==0.4.7
 PyYAML==3.10
 requests==2.3.0
 requests-oauthlib==0.4.1
-scipy==0.11.0
+scipy==0.14.0
 Shapely==1.2.16
 singledispatch==3.4.0.2
 sorl-thumbnail==11.12

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -142,6 +142,6 @@ git+https://github.com/mfogel/django-settings-context-processor.git
 git+https://github.com/mitocw/django-cas.git
 
 # edX packages
-edx-submissions==0.0.7
+edx-submissions==0.0.8
 
 -e git+https://github.com/pmitros/django-pyfs.git@36f64c0f1f458ce7b9ecb2347667b202d13a8317#egg=djpyfs

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -27,7 +27,7 @@
 -e git+https://github.com/edx/bok-choy.git@4a259e3548a19e41cc39433caf68ea58d10a27ba#egg=bok_choy
 -e git+https://github.com/edx-solutions/django-splash.git@7579d052afcf474ece1239153cffe1c89935bc4f#egg=django-splash
 -e git+https://github.com/edx/acid-block.git@459aff7b63db8f2c5decd1755706c1a64fb4ebb1#egg=acid-xblock
--e git+https://github.com/edx/edx-ora2.git@release-2014-09-12T14.26#egg=edx-ora2
+-e git+https://github.com/edx/edx-ora2.git@release-2014-09-18T16.00#egg=edx-ora2
 -e git+https://github.com/edx/opaque-keys.git@d45d0bd8d64c69531be69178b9505b5d38806ce0#egg=opaque-keys
 -e git+https://github.com/edx/ease.git@97de68448e5495385ba043d3091f570a699d5b5f#egg=ease
 -e git+https://github.com/edx/i18n-tools.git@56f048af9b6868613c14aeae760548834c495011#egg=i18n-tools


### PR DESCRIPTION
These dependencies were upgraded in #4582, #3665, and #4275, but those upgrades were reverted by #4626 because of Jenkins issues. Now that Jenkins is working better, I'm resubmitting a new PR for these upgrades.
