### PR TITLE
LMS: at registration, displayed country names should be sorted alphabetically.

### DIFF
--- a/lms/templates/register-shib.html
+++ b/lms/templates/register-shib.html
@@ -7,7 +7,6 @@
 
 <%! from django.core.urlresolvers import reverse %>
 <%! from django.utils import html %>
-<%! from django_countries.countries import COUNTRIES %>
 <%! from student.models import UserProfile %>
 <%! from datetime import date %>
 <%! import calendar %>

--- a/lms/templates/register.html
+++ b/lms/templates/register.html
@@ -14,6 +14,8 @@
 <%! from datetime import date %>
 <%! from third_party_auth import pipeline, provider %>
 <%! import calendar %>
+<%! from functools import cmp_to_key %>
+<%! from locale import setlocale, LC_COLLATE, strcoll %>
 
 <%block name="pagetitle">${_("Register for {platform_name}").format(platform_name=platform_name)}</%block>
 
@@ -250,7 +252,11 @@
               <label for="country">${_("Country")}</label>
               <select id="country" name="country" ${'required aria-required="true"' if settings.REGISTRATION_EXTRA_FIELDS['country'] == 'required' else ''}>
                 <option value="">--</option>
-                %for code, country_name in COUNTRIES:
+                <%!setlocale(LC_COLLATE, '')%>
+                <%!countries = [[code,unicode(name)] for (code,name) in COUNTRIES]%>
+                <%<key = lambda (code, name): cmp_to_key(strcoll)(name)%>
+                <%!sorted_countries = sorted(countries, key=key)%>
+                %for code, country_name in sorted_countries:
                 <option value="${code}">${ unicode(country_name) }</option>
                 %endfor
               </select>

--- a/lms/templates/signup_modal.html
+++ b/lms/templates/signup_modal.html
@@ -3,7 +3,6 @@
 <%namespace name='static' file='static_content.html'/>
 <%! from django.conf import settings %>
 <%! from django.core.urlresolvers import reverse %>
-<%! from django_countries.countries import COUNTRIES %>
 <%! from student.models import UserProfile %>
 <%! from datetime import date %>
 <%! import calendar %>


### PR DESCRIPTION
When settings.REGISTRATION_EXTRA_FIELDS['country'] != 'hidded', users
are asked to select their country at registration.

When the list of country names is displayed in a language other than
english, the names are not sorted in alphabetical order.

This PR fixes this and makes sure country names are displayed in
alphabetical order for any language.
