### PR TITLE
Html escaped from display name in xblock.

### DIFF
--- a/cms/djangoapps/contentstore/features/course-outline.feature
+++ b/cms/djangoapps/contentstore/features/course-outline.feature
@@ -25,7 +25,7 @@ Feature: CMS.Course Outline
     Scenario: Collapse link is removed after last section of a course is deleted
         Given I have a course with 1 section
         And I navigate to the course outline page
-        And I press the "section" delete icon
+        And I press the section delete icon
         When I will confirm all alerts
         Then I do not see the "Collapse All Sections" link
 

--- a/cms/djangoapps/contentstore/features/course-outline.py
+++ b/cms/djangoapps/contentstore/features/course-outline.py
@@ -67,7 +67,7 @@ def i_add_a_section(step):
     add_section()
 
 
-@step(u'I press the "section" delete icon')
+@step(u'I press the section delete icon')
 def i_press_the_section_delete_icon(step):
     delete_locator = 'section .outline-section > .section-header a.delete-button'
     world.css_click(delete_locator)

--- a/cms/djangoapps/contentstore/features/problem-editor.feature
+++ b/cms/djangoapps/contentstore/features/problem-editor.feature
@@ -30,6 +30,12 @@ Feature: CMS.Problem Editor
     Then I can revert the display name to unset
     And my display name is unset on save
 
+  Scenario: User can specify html in display name and it will be escaped
+    Given I have created a Blank Common Problem
+    When I edit and select Settings
+    Then I can specify html in the display name and save
+    And the problem display name is "<script>alert('test')</script>"
+
   # IE will not click the revert button properly
   @skip_internetexplorer
   Scenario: User can select values in a Select

--- a/cms/djangoapps/contentstore/features/problem-editor.py
+++ b/cms/djangoapps/contentstore/features/problem-editor.py
@@ -133,6 +133,18 @@ def i_can_modify_the_display_name_with_special_chars(_step):
     verify_modified_display_name_with_special_chars()
 
 
+@step('I can specify html in the display name and save')
+def i_can_modify_the_display_name_with_html(_step):
+    """
+    If alert appear on save then UnexpectedAlertPresentException
+    will occur and test will fail.
+    """
+    index = world.get_setting_entry_index(DISPLAY_NAME)
+    world.set_field_value(index, "<script>alert('test')</script>")
+    verify_modified_display_name_with_html()
+    world.save_component()
+
+
 @step('my special characters and persisted on save')
 def special_chars_persisted_on_save(step):
     world.save_component_and_reopen(step)
@@ -348,6 +360,10 @@ def verify_modified_display_name():
 
 def verify_modified_display_name_with_special_chars():
     world.verify_setting_entry(world.get_setting_entry(DISPLAY_NAME), DISPLAY_NAME, "updated ' \" &", True)
+
+
+def verify_modified_display_name_with_html():
+    world.verify_setting_entry(world.get_setting_entry(DISPLAY_NAME), DISPLAY_NAME, "<script>alert('test')</script>", True)
 
 
 def verify_unset_display_name():

--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -231,7 +231,7 @@ class XModuleMixin(XBlockMixin):
         name = self.display_name
         if name is None:
             name = self.url_name.replace('_', ' ')
-        return name
+        return name.replace('<', '&lt;').replace('>', '&gt;')
 
     @property
     def xblock_kvs(self):


### PR DESCRIPTION
LMS-11194

You can set the Display Name on any xblock, and it will render the raw text, not escaped. This allows any HTML tags, including script injection.
