### PR TITLE
Course teams can turn off Chinese Caching from studio (BLD-1207)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ These are notable changes in edx-platform.  This is a rolling list of changes,
 in roughly chronological order, most recent first.  Add your entries at or near
 the top.  Include a label indicating the component affected.
 
+Blades: Course teams can turn off Chinese Caching from Studio. BLD-1207
+
 LMS: Instructors can request and see content of previous bulk emails sent in the instructor dashboard.
 
 Studio: New course outline and unit/container pages with revised publishing model. STUD-1790 (part 1)

--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -27,7 +27,6 @@ class CourseMetadata(object):
                      'user_partitions',
                      'name',  # from xblock
                      'tags',  # from xblock
-                     'video_speed_optimizations',
                      'visible_to_staff_only'
     ]
 

--- a/common/lib/xmodule/xmodule/modulestore/inheritance.py
+++ b/common/lib/xmodule/xmodule/modulestore/inheritance.py
@@ -148,7 +148,8 @@ class InheritanceMixin(XBlockMixin):
         scope=Scope.settings
     )
     video_speed_optimizations = Boolean(
-        help="Enable Video CDN.",
+        display_name=_("Enable video caching system"),
+        help=_("Enter true or false. If true then video caching system (CDN) will be used for HTML5 videos. Currently it only makes a difference for China."),
         default=True,
         scope=Scope.settings
     )


### PR DESCRIPTION
Allow turning off Chinese CDN from Studio.
**Issue**: [BLD-1207](https://openedx.atlassian.net/browse/BLD-1207)

Please review: @tymofij 
