### PR TITLE
Update the reference to gsehub/xblock-mentoring#4

### DIFF
--- a/requirements/edx/edx-private.txt
+++ b/requirements/edx/edx-private.txt
@@ -1,7 +1,7 @@
 # Requirements for edx.org that aren't necessarily needed for Open edX.
 
 -e git+ssh://git@github.com/jazkarta/edX-jsdraw.git@9fcd333aaa2ac3df65dd247b601ce0b56bb10cad#egg=edx-jsdraw
--e git+https://github.com/gsehub/xblock-mentoring.git@e292496295dbb6e6d692015171a7dbaf45385321#egg=xblock-mentoring
+-e git+https://github.com/gsehub/xblock-mentoring.git@d4532e4f89aaf36b56715be2abc0f9402912794e#egg=xblock-mentoring
 
 # Prototype XBlocks from edX learning sciences limited roll-outs and user testing. 
 # Concept XBlock, in particular, is nowhere near finished and an early prototype. 


### PR DESCRIPTION
This updates the reference to the Mentoring XBlock incorporating the changes is gsehub/xblock-mentoring#4: "Port the Studio editor and remove the dataexport functionality"
