### PR TITLE
Redirect to show_reqs for prof ed

### DIFF
--- a/common/djangoapps/course_modes/views.py
+++ b/common/djangoapps/course_modes/views.py
@@ -41,12 +41,26 @@ class ChooseModeView(View):
         request.session['attempting_upgrade'] = upgrade
 
         # Inactive users always need to re-register
-        # verified users do not need to register or upgrade
+        # verified and professional users do not need to register or upgrade
         # registered users who are not trying to upgrade do not need to re-register
-        if is_active and (upgrade is False or enrollment_mode == 'verified'):
+        if is_active and (upgrade is False or enrollment_mode == 'verified' or enrollment_mode == 'professional'):
             return redirect(reverse('dashboard'))
 
         modes = CourseMode.modes_for_course_dict(course_key)
+
+        # We assume that, if 'professional' is one of the modes, it is the *only* mode.
+        # If we offer more modes alongside 'professional' in the future, this will need to route
+        # to the usual "choose your track" page.
+        if "professional" in modes:
+            return redirect(
+                reverse(
+                    'verify_student_show_requirements',
+                    kwargs={'course_id': course_key.to_deprecated_string()}
+                )
+            )
+
+
+
         donation_for_course = request.session.get("donation_for_course", {})
         chosen_price = donation_for_course.get(course_key, None)
 

--- a/lms/djangoapps/courseware/views.py
+++ b/lms/djangoapps/courseware/views.py
@@ -708,7 +708,7 @@ def mktg_course_about(request, course_id):
 
     show_courseware_link = (has_access(request.user, 'load', course) or
                             settings.FEATURES.get('ENABLE_LMS_MIGRATION'))
-    course_modes = CourseMode.modes_for_course(course.id)
+    course_modes = CourseMode.modes_for_course_dict(course.id)
 
     return render_to_response('courseware/mktg_course_about.html', {
         'course': course,

--- a/lms/templates/courseware/mktg_course_about.html
+++ b/lms/templates/courseware/mktg_course_about.html
@@ -55,7 +55,15 @@
         <a class="action action-register register ${'has-option-verified' if len(course_modes) > 1 else ''}" href="#">${_("Register for")} <strong>${course.display_number_with_default | h}</strong>
             %if len(course_modes) > 1:
             <span class="track">
-            and choose your student track
+            ## Translators: This is the second line on a button users can click.  The first line is "Register for COURSE_NAME"
+            ## The "choose your student track" means users can select between taking the course as an auditor, as a verified student, etc
+            ${_("and choose your student track")}
+            </span>
+            %elif "professional" in course_modes:
+            <span class="track">
+            ## Translators: This is the second line on a button users can click.  The first line is "Register for COURSE_NAME"
+            ## 'Verification' here refers to verifying one's identity in order to receive a verified certificate.
+            ${_("and proceed to verification")}
             </span>
             %endif
         </a>


### PR DESCRIPTION
- Changes registration button text for professional ed courses
- Professional ed courses do not see "choose your track" page; go straight to verification flow

ECOM-40
