### PR TITLE
Remove banner from instructor dashboard

### DIFF
--- a/lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html
+++ b/lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html
@@ -72,9 +72,6 @@
     </div>
 
   <h1>${_("Instructor Dashboard")}</h1>
-    <div class="wrapper-msg urgency-low msg-warning is-shown">
-        <p>${_("We've changed the look and feel of the Instructor Dashboard. During this transition time, you can still access the old Instructor Dashboard by clicking the 'Revert to Legacy Dashboard' button above.")}</p>
-    </div>
 
     %if analytics_dashboard_message:
       <div class="wrapper-msg urgency-low is-shown">


### PR DESCRIPTION
@shnayder @explorerleslie - as we discussed last week, this is to remove the banner from the instructor dashboard based on Renzo's metrics that not many are switching back to the legacy instructor dash.

![screen shot 2014-08-10 at 1 07 35 am](https://cloud.githubusercontent.com/assets/1985317/3868539/481bf8ce-204c-11e4-843a-3d2b53c4f3d7.png)
