### PR TITLE
Improve stability of test_studio_outline tests.

### DIFF
--- a/common/test/acceptance/pages/studio/container.py
+++ b/common/test/acceptance/pages/studio/container.py
@@ -55,6 +55,15 @@ class ContainerPage(PageObject):
             Promise(_is_finished_loading, 'Finished rendering the xblock wrappers.').fulfill()
         )
 
+    def wait_for_component_menu(self):
+        """
+        Waits until the menu bar of components is present on the page.
+        """
+        EmptyPromise(
+            lambda: self.q(css='div.add-xblock-component').present,
+            'Wait for the menu of components to be present'
+        ).fulfill()
+
     @property
     def xblocks(self):
         """

--- a/common/test/acceptance/pages/studio/overview.py
+++ b/common/test/acceptance/pages/studio/overview.py
@@ -345,7 +345,7 @@ class CourseOutlinePage(CoursePage, CourseOutlineContainer):
     BOTTOM_ADD_SECTION_BUTTON = '.outline > .add-section .button-new'
 
     def is_browser_on_page(self):
-        return self.q(css='body.view-outline').present
+        return self.q(css='body.view-outline').present and self.q(css='div.ui-loading.is-hidden').present
 
     def view_live(self):
         """

--- a/common/test/acceptance/pages/studio/utils.py
+++ b/common/test/acceptance/pages/studio/utils.py
@@ -69,6 +69,7 @@ def add_discussion(page, menu_index=0):
     menu_index specifies which instance of the menus should be used (based on vertical
     placement within the page).
     """
+    page.wait_for_component_menu()
     click_css(page, 'a>span.large-discussion-icon', menu_index)
 
 
@@ -80,6 +81,7 @@ def add_advanced_component(page, menu_index, name):
     placement within the page).
     """
     # Click on the Advanced icon.
+    page.wait_for_component_menu()
     click_css(page, 'a>span.large-advanced-icon', menu_index, require_notification=False)
 
     # This does an animation to hide the first level of buttons


### PR DESCRIPTION
STUD-2084

@jzoldak and @dan-f please review

In addition to checking for the "add components" buttons to be present for STUD-2084, this includes a fix for a case with the "Loading" indicator still showing on the course overview page--

  File "/usr/lib/python2.7/unittest/case.py", line 327, in run
    testMethod()
  File "/home/jenkins/workspace/edx-all-tests-auto-pr/SHARD/2/TEST_SUITE/bok-choy/common/test/acceptance/tests/test_studio_outline.py", line 196, in test_unreleased_unpublished_changes_unlocked
    self.FUTURE_UNPUBLISHED_WARNING
  File "/home/jenkins/workspace/edx-all-tests-auto-pr/SHARD/2/TEST_SUITE/bok-choy/common/test/acceptance/tests/test_studio_outline.py", line 218, in _verify_unit_warning
    self._ensure_unit_present(unit_state)
  File "/home/jenkins/workspace/edx-all-tests-auto-pr/SHARD/2/TEST_SUITE/bok-choy/common/test/acceptance/tests/test_studio_outline.py", line 243, in _ensure_unit_present
    subsection = self.course_outline_page.section(name).subsection(name)
  File "/home/jenkins/edx-venv/src/bok-choy/bok_choy/page_object.py", line 64, in wrapper
    return method(self, _args, *_kwargs)
  File "/home/jenkins/workspace/edx-all-tests-auto-pr/SHARD/2/TEST_SUITE/bok-choy/common/test/acceptance/pages/studio/overview.py", line 361, in section
    return self.child(title)
  File "/home/jenkins/workspace/edx-all-tests-auto-pr/SHARD/2/TEST_SUITE/bok-choy/common/test/acceptance/pages/studio/overview.py", line 158, in child
    ).attrs('data-locator')[0]
