### PR TITLE
Fixed 500 error on views with incomplete course id in url.

### DIFF
--- a/lms/djangoapps/courseware/tests/test_lti_integration.py
+++ b/lms/djangoapps/courseware/tests/test_lti_integration.py
@@ -178,11 +178,10 @@ class TestLTIModuleListing(ModuleStoreTestCase):
 
     def test_lti_rest_bad_course(self):
         """Tests what happens when the lti listing rest endpoint gets a bad course_id"""
-        bad_ids = [u"sf", u"dne/dne/dne", u"fo/ey/\u5305"]
-        request = mock.Mock()
-        request.method = 'GET'
+        bad_ids = [u"sf", u"dne/dne/dne", u"fo/ey/\\u5305"]
         for bad_course_id in bad_ids:
-            response = get_course_lti_endpoints(request, bad_course_id)
+            lti_rest_endpoints_url = 'courses/{}/lti_rest_endpoints/'.format(bad_course_id)
+            response = self.client.get(lti_rest_endpoints_url)
             self.assertEqual(404, response.status_code)
 
     def test_lti_rest_listing(self):

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -5,7 +5,7 @@ Tests courseware views.py
 import unittest
 from datetime import datetime
 
-from mock import MagicMock, patch
+from mock import MagicMock, patch, create_autospec
 from pytz import UTC
 
 from django.test import TestCase
@@ -150,6 +150,10 @@ class ViewsTestCase(TestCase):
 
     def test_invalid_course_id(self):
         response = self.client.get('/courses/MITx/3.091X/')
+        self.assertEqual(response.status_code, 404)
+
+    def test_incomplete_course_id(self):
+        response = self.client.get('/courses/MITx/')
         self.assertEqual(response.status_code, 404)
 
     def test_index_invalid_position(self):
@@ -562,3 +566,26 @@ class ProgressPageTests(ModuleStoreTestCase):
     def test_non_asci_grade_cutoffs(self):
         resp = views.progress(self.request, self.course.id.to_deprecated_string())
         self.assertEqual(resp.status_code, 200)
+
+
+class TestVerifyCourseIdDecorator(TestCase):
+    """
+    Tests for the verify_course_id decorator.
+    """
+
+    def setUp(self):
+        self.request = RequestFactory().get("foo")
+        self.valid_course_id = "edX/test/1"
+        self.invalid_course_id = "edX/"
+
+    def test_decorator_with_valid_course_id(self):
+        mocked_view = create_autospec(views.course_about)
+        view_function = views.verify_course_id(mocked_view)
+        view_function(self.request, self.valid_course_id)
+        self.assertTrue(mocked_view.called)
+
+    def test_decorator_with_invalid_course_id(self):
+        mocked_view = create_autospec(views.course_about)
+        view_function = views.verify_course_id(mocked_view)
+        self.assertRaises(Http404, view_function, self.request, self.invalid_course_id)
+        self.assertFalse(mocked_view.called)


### PR DESCRIPTION
LMS-11217

Added try except in views to catch InvalidKeyError and raised Http404 when an incomplete course id is in url.

Added unit test.
