### PR TITLE
Supply loading_timeout attribute for jsinput tag.

### DIFF
--- a/common/lib/capa/capa/inputtypes.py
+++ b/common/lib/capa/capa/inputtypes.py
@@ -585,8 +585,10 @@ class JSInput(InputTypeBase):
                                              #   set state
             Attribute('width', "400"),       # iframe width
             Attribute('height', "300"),      # iframe height
-            Attribute('sop', None)           # SOP will be relaxed only if this
-                                             # attribute is set to false.
+            Attribute('sop', None),           # SOP will be relaxed only if this
+                                              # attribute is set to false.
+            Attribute('loading_timeout', None)  # Timeout that is used when
+                                                # loading JS application.
         ]
 
     def _extra_context(self):

--- a/common/lib/capa/capa/templates/jsinput.html
+++ b/common/lib/capa/capa/templates/jsinput.html
@@ -15,6 +15,9 @@
     % if sop:
     data-sop="${sop}"
     % endif
+    % if loading_timeout:
+    data-loading-timeout="${loading_timeout}"
+    % endif
     data-processed="false"
     >
 

--- a/common/static/js/capa/src/jsinput.js
+++ b/common/static/js/capa/src/jsinput.js
@@ -32,7 +32,7 @@ var JSInput = (function ($, undefined) {
 
     /*      END     Utils                                   */
 
-    var loadingTimeout = 300;
+    var loadingTimeout = getLoadingTimeout();
 
     function jsinputConstructor(elem) {
         // Define an class that will be instantiated for each jsinput element
@@ -207,13 +207,17 @@ var JSInput = (function ($, undefined) {
     }
 
     function getLoadingTimeout() {
-        var allSections = $('section.jsinput'), timeout;
+        var allSections = $('section.jsinput'), t,
+            timeout = 300; // Default value
+
         allSections.each(function(index, value) {
-            timeout = $(value).attr("data-loading-timeout");
-            if (timeout && isFinite(timeout)) {
-                loadingTimeout = Math.max(loadingTimeout, timeout);
+            t = $(value).attr("data-loading-timeout");
+            if (t && isFinite(t)) {
+                timeout = Math.max(t, timeout);
             }
         });
+
+        return timeout;
     }
 
     // This is ugly, but without a timeout pages with multiple/heavy jsinputs
@@ -221,7 +225,6 @@ var JSInput = (function ($, undefined) {
     // 300 ms is arbitrary but this has functioned with the only application 
     // that has ever used JSInput, jsVGL. Something more sturdy should be put in
     // place.
-    getLoadingTimeout();
     if ($.isReady) {
         setTimeout(walkDOM, loadingTimeout);
     } else {

--- a/common/static/js/capa/src/jsinput.js
+++ b/common/static/js/capa/src/jsinput.js
@@ -32,6 +32,7 @@ var JSInput = (function ($, undefined) {
 
     /*      END     Utils                                   */
 
+    var loadingTimeout = 300;
 
     function jsinputConstructor(elem) {
         // Define an class that will be instantiated for each jsinput element
@@ -205,15 +206,26 @@ var JSInput = (function ($, undefined) {
         });
     }
 
+    function getLoadingTimeout() {
+        var allSections = $('section.jsinput'), timeout;
+        allSections.each(function(index, value) {
+            timeout = $(value).attr("data-loading-timeout");
+            if (timeout && isFinite(timeout)) {
+                loadingTimeout = Math.max(loadingTimeout, timeout);
+            }
+        });
+    }
+
     // This is ugly, but without a timeout pages with multiple/heavy jsinputs
     // don't load properly.
     // 300 ms is arbitrary but this has functioned with the only application 
     // that has ever used JSInput, jsVGL. Something more sturdy should be put in
     // place.
+    getLoadingTimeout();
     if ($.isReady) {
-        setTimeout(walkDOM, 300);
+        setTimeout(walkDOM, loadingTimeout);
     } else {
-        $(document).ready(setTimeout(walkDOM, 300));
+        $(document).ready(setTimeout(walkDOM, loadingTimeout));
     }
 
     return {

--- a/docs/en_us/developers/source/extending_platform/javascript.rst
+++ b/docs/en_us/developers/source/extending_platform/javascript.rst
@@ -313,3 +313,9 @@ The following table describes the attributes of the ``jsinput`` element.
      - The same-origin policy (SOP), meaning that all elements have the same
        protocol, host, and port. To bypass the SOP, set to ``true``.
      - false
+   * - loading_timeout
+     - Timeout (in ms) that lets a heavy JS application load before JSInput is
+       initialized. If multiple JSInput have the above parameter set and are
+       included in a page, the largest value will be retained.
+     - 300
+


### PR DESCRIPTION
This is an attempt to address a request from MITx regarding the loading timeout in JSInput. The default value of 300 ms doesn't work with these very heavy GWT TEALSim applications in 8.01r. This PR lets an author choose this timeout from the XML, as an attribute of the jsinput tag. If multiple JSInput have this attribute set and are included in a page, the largest value will be retained. The only issue I know of is that pressing on the Check button before the timeout has elapsed will result in a JS error thrown in `check_save_waitfor` with the corresponding alert: `Could not grade your answer. The submission was aborted.`. This is known and deemed acceptable by the developer that issued the request.

@carsongee @pdpinch @terman  @stvstnfrd @jinpa @Lyla-Fischer Please have a look.
