### PR TITLE
Consider profession ed courses as paid courses.

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -968,7 +968,7 @@ class CourseEnrollment(models.Model):
         """
         paid_course = CourseMode.objects.filter(Q(course_id=self.course_id) & Q(mode_slug='honor') &
                                                 (Q(expiration_datetime__isnull=True) | Q(expiration_datetime__gte=datetime.now(pytz.UTC)))).exclude(min_price=0)
-        if paid_course:
+        if paid_course or self.mode == 'professional':
             return True
 
         return False


### PR DESCRIPTION
For professional education, we want to make sure students know that they will not get a refund after unregistering for a course. This setting controls a display toggled on the dashboard for refund text.

@flowerhack @ormsbee

ECOM-63
