### PR TITLE
Unit tests don't need assets

### DIFF
--- a/cms/envs/test.py
+++ b/cms/envs/test.py
@@ -59,6 +59,14 @@ STATICFILES_DIRS += [
     if os.path.isdir(COMMON_TEST_DATA_ROOT / course_dir)
 ]
 
+# Avoid having to run collectstatic before the unit test suite
+# If we don't add these settings, then Django templates that can't
+# find pipelined assets will raise a ValueError.
+# http://stackoverflow.com/questions/12816941/unit-testing-with-django-pipeline
+STATICFILES_STORAGE='pipeline.storage.NonPackagingPipelineStorage'
+STATIC_URL = "/static/"
+PIPELINE_ENABLED=False
+
 # Add split as another store for testing
 MODULESTORE['default']['OPTIONS']['stores'].append(
     {

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -109,6 +109,13 @@ STATICFILES_DIRS += [
     if os.path.isdir(COMMON_TEST_DATA_ROOT / course_dir)
 ]
 
+# Avoid having to run collectstatic before the unit test suite
+# If we don't add these settings, then Django templates that can't
+# find pipelined assets will raise a ValueError.
+# http://stackoverflow.com/questions/12816941/unit-testing-with-django-pipeline
+STATICFILES_STORAGE='pipeline.storage.NonPackagingPipelineStorage'
+PIPELINE_ENABLED=False
+
 update_module_store_settings(
     MODULESTORE,
     module_store_options={

--- a/pavelib/utils/test/suites/nose_suite.py
+++ b/pavelib/utils/test/suites/nose_suite.py
@@ -99,12 +99,6 @@ class SystemTestSuite(NoseTestSuite):
     def __enter__(self):
         super(SystemTestSuite, self).__enter__()
 
-        if not self.fasttest:
-            # TODO: Fix the tests so that collectstatic isn't needed ever
-            # add --skip-collect to this when the tests are fixed
-            args = [self.root, '--settings=test']
-            call_task('pavelib.assets.update_assets', args=args)
-
     @property
     def cmd(self):
         cmd = (


### PR DESCRIPTION
This has driven me crazy for the last 8 months or so: unit tests shouldn't need pipelined static assets.  The only reason we require this now is that some of our tests render Django templates, which use a static files tag, which raise a `ValueError` if the assets aren't found.

This PR fixes the issue by:
- Disabling the Django pipeline
- Using `NonPackagingPipelineStorage`, so that the Django template tag won't raise an error.
- For Studio, using `STATIC_URL` without the git commit (which otherwise causes some of the `static_replace` tests in common to fail).

This speeds up the unit test suite by about 48 seconds in Jenkins and is _significantly_ faster in devstack (since it avoids copying to an NFS-synced directory)

I've preserved the settings for the acceptance tests, since those should more closely match production.

@jzoldak @benpatterson please review.
