### PR TITLE
Fix getting attribute from local thread.

### DIFF
--- a/common/djangoapps/edxmako/shortcuts.py
+++ b/common/djangoapps/edxmako/shortcuts.py
@@ -92,7 +92,7 @@ def render_to_string(template_name, dictionary, context=None, namespace='main'):
     context_instance['marketing_link'] = marketing_link
 
     # In various testing contexts, there might not be a current request context.
-    if edxmako.middleware.REQUEST_CONTEXT.context is not None:
+    if getattr(edxmako.middleware.REQUEST_CONTEXT, "context", None) is not None:
         for d in edxmako.middleware.REQUEST_CONTEXT.context:
             context_dictionary.update(d)
     for d in context_instance:

--- a/common/djangoapps/edxmako/shortcuts.py
+++ b/common/djangoapps/edxmako/shortcuts.py
@@ -92,7 +92,7 @@ def render_to_string(template_name, dictionary, context=None, namespace='main'):
     context_instance['marketing_link'] = marketing_link
 
     # In various testing contexts, there might not be a current request context.
-    if getattr(edxmako.middleware.REQUEST_CONTEXT, "context", None) is not None:
+    if getattr(edxmako.middleware.REQUEST_CONTEXT, "context", None):
         for d in edxmako.middleware.REQUEST_CONTEXT.context:
             context_dictionary.update(d)
     for d in context_instance:

--- a/common/djangoapps/edxmako/template.py
+++ b/common/djangoapps/edxmako/template.py
@@ -48,7 +48,7 @@ class Template(MakoTemplate):
         context_dictionary = {}
 
         # In various testing contexts, there might not be a current request context.
-        if getattr(edxmako.middleware.REQUEST_CONTEXT, "context", None) is not None:
+        if getattr(edxmako.middleware.REQUEST_CONTEXT, "context", None):
             for d in edxmako.middleware.REQUEST_CONTEXT.context:
                 context_dictionary.update(d)
         for d in context_instance:

--- a/common/djangoapps/edxmako/template.py
+++ b/common/djangoapps/edxmako/template.py
@@ -48,7 +48,7 @@ class Template(MakoTemplate):
         context_dictionary = {}
 
         # In various testing contexts, there might not be a current request context.
-        if edxmako.middleware.REQUEST_CONTEXT.context is not None:
+        if getattr(edxmako.middleware.REQUEST_CONTEXT, "context", None) is not None:
             for d in edxmako.middleware.REQUEST_CONTEXT.context:
                 context_dictionary.update(d)
         for d in context_instance:

--- a/common/djangoapps/edxmako/tests.py
+++ b/common/djangoapps/edxmako/tests.py
@@ -1,5 +1,8 @@
 
 from mock import patch, Mock
+import unittest
+
+from django.conf import settings
 from django.http import HttpResponse
 from django.test import TestCase
 from django.test.utils import override_settings
@@ -7,7 +10,7 @@ from django.test.client import RequestFactory
 from django.core.urlresolvers import reverse
 import edxmako.middleware
 from edxmako import add_lookup, LOOKUP
-from edxmako.shortcuts import marketing_link
+from edxmako.shortcuts import marketing_link, render_to_string
 from student.tests.factories import UserFactory
 from util.testing import UrlResetMixin
 
@@ -70,6 +73,18 @@ class MakoMiddlewareTest(TestCase):
         self.middleware.process_response(self.request, self.response)
         # requestcontext should be None.
         self.assertIsNone(edxmako.middleware.REQUEST_CONTEXT.context)
+
+    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+    def test_render_to_string_when_no_global_context(self):
+        """
+        Test render_to_string() when makomiddleware has not initialized
+        the threadlocal REQUEST_CONTEXT.context.
+        """
+
+        if hasattr(edxmako.middleware.REQUEST_CONTEXT, "context"):
+            del edxmako.middleware.REQUEST_CONTEXT.context
+        self.assertIn("this module is temporarily unavailable", render_to_string("courseware/error-message.html", None))
+
 
 
 def mako_middleware_process_request(request):

--- a/common/djangoapps/edxmako/tests.py
+++ b/common/djangoapps/edxmako/tests.py
@@ -80,11 +80,11 @@ class MakoMiddlewareTest(TestCase):
         Test render_to_string() when makomiddleware has not initialized
         the threadlocal REQUEST_CONTEXT.context.
         """
-
-        if hasattr(edxmako.middleware.REQUEST_CONTEXT, "context"):
-            del edxmako.middleware.REQUEST_CONTEXT.context
-        self.assertIn("this module is temporarily unavailable", render_to_string("courseware/error-message.html", None))
-
+        context_copy = edxmako.middleware.REQUEST_CONTEXT.copy()
+        if hasattr(context_copy, "context"):
+            del context_copy.context
+        with patch.dict(edxmako.middleware.REQUEST_CONTEXT, context_copy):
+            self.assertIn("this module is temporarily unavailable", render_to_string("courseware/error-message.html", None))
 
 
 def mako_middleware_process_request(request):

--- a/common/djangoapps/edxmako/tests.py
+++ b/common/djangoapps/edxmako/tests.py
@@ -75,16 +75,24 @@ class MakoMiddlewareTest(TestCase):
         self.assertIsNone(edxmako.middleware.REQUEST_CONTEXT.context)
 
     @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
-    def test_render_to_string_when_no_global_context(self):
+    @patch("edxmako.middleware.REQUEST_CONTEXT")
+    def test_render_to_string_when_no_global_context_lms(self, context_mock):
         """
         Test render_to_string() when makomiddleware has not initialized
-        the threadlocal REQUEST_CONTEXT.context.
+        the threadlocal REQUEST_CONTEXT.context. This is meant to run in LMS.
         """
-        context_copy = edxmako.middleware.REQUEST_CONTEXT.copy()
-        if hasattr(context_copy, "context"):
-            del context_copy.context
-        with patch.dict(edxmako.middleware.REQUEST_CONTEXT, context_copy):
-            self.assertIn("this module is temporarily unavailable", render_to_string("courseware/error-message.html", None))
+        del context_mock.context
+        self.assertIn("this module is temporarily unavailable", render_to_string("courseware/error-message.html", None))
+
+    @unittest.skipUnless(settings.ROOT_URLCONF == 'cms.urls', 'Test only valid in cms')
+    @patch("edxmako.middleware.REQUEST_CONTEXT")
+    def test_render_to_string_when_no_global_context_cms(self, context_mock):
+        """
+        Test render_to_string() when makomiddleware has not initialized
+        the threadlocal REQUEST_CONTEXT.context. This is meant to run in CMS.
+        """
+        del context_mock.context
+        self.assertIn("We're having trouble rendering your component", render_to_string("html_error.html", None))
 
 
 def mako_middleware_process_request(request):


### PR DESCRIPTION
When using thread-locals, we have to check whether the attribute of the thread local is set before using it.
Todo so always use hasattr or getattr.
