### PR TITLE
jquery.immediateDescendents cannot be loaded until jQuery is loaded.

### DIFF
--- a/cms/templates/base.html
+++ b/cms/templates/base.html
@@ -217,6 +217,9 @@
             "tooltip_manager": {
                 deps: ["jquery", "underscore"]
             },
+            "jquery.immediateDescendents": {
+                deps: ["jquery"]
+            },
             "xblock/core": {
                 exports: "XBlock",
                 deps: ["jquery", "jquery.immediateDescendents"]


### PR DESCRIPTION
STUD-1999

@jzoldak please review. This is based on the error log you put in the JIRA ticket.
