### PR TITLE
forum secondary post action labels

### DIFF
--- a/common/static/coffee/src/discussion/content.coffee
+++ b/common/static/coffee/src/discussion/content.coffee
@@ -108,6 +108,11 @@ if Backbone?
       @get("abuse_flaggers").pop(window.user.get('id'))
       @trigger "change", @
 
+    isFlagged: ->
+      user = DiscussionUtil.getUser()
+      flaggers = @get("abuse_flaggers")
+      (user and user.id in flaggers) or (DiscussionUtil.isFlagModerator and flaggers.length > 0)
+
     incrementVote: (increment) ->
       newVotes = _.clone(@get("votes"))
       newVotes.up_count = newVotes.up_count + increment

--- a/common/static/coffee/src/discussion/views/discussion_content_view.coffee
+++ b/common/static/coffee/src/discussion/views/discussion_content_view.coffee
@@ -111,6 +111,7 @@ if Backbone?
 
       pinned: (pinned) ->
         @updateButtonState(".action-pin", pinned)
+        @$(".post-label-pinned").toggle(pinned)
 
       abuse_flaggers: (abuse_flaggers) ->
         flagged = (
@@ -118,10 +119,11 @@ if Backbone?
           (DiscussionUtil.isFlagModerator and abuse_flaggers.length > 0)
         )
         @updateButtonState(".action-report", flagged)
+        @$(".post-label-reported").toggle(flagged)
 
       closed: (closed) ->
         @updateButtonState(".action-close", closed)
-        @$(".post-status-closed").toggle(closed)
+        @$(".post-label-closed").toggle(closed)
     })
 
     showSecondaryActions: (event) =>
@@ -242,3 +244,21 @@ if Backbone?
         {url: @model.urlFor("close"), type: "POST", data: updates, $elem: $(event.currentTarget)},
         msg
       )
+
+    getAuthorDisplay: ->
+      _.template($("#post-user-display-template").html())(
+        username: @model.get('username') || null
+        user_url: @model.get('user_url')
+        is_community_ta: @model.get('community_ta_authored')
+        is_staff: @model.get('staff_authored')
+      )
+
+    getEndorserDisplay: ->
+      endorsement = @model.get('endorsement')
+      if endorsement and endorsement.username
+        _.template($("#post-user-display-template").html())(
+          username: endorsement.username
+          user_url: DiscussionUtil.urlFor('user_profile', endorsement.user_id)
+          is_community_ta: DiscussionUtil.isTA(endorsement.user_id)
+          is_staff: DiscussionUtil.isStaff(endorsement.user_id)
+        )

--- a/common/static/coffee/src/discussion/views/discussion_thread_show_view.coffee
+++ b/common/static/coffee/src/discussion/views/discussion_thread_show_view.coffee
@@ -10,6 +10,8 @@ if Backbone?
       @template = _.template($("#thread-show-template").html())
       context = @model.toJSON()
       context.mode = @mode
+      context.flagged = @model.isFlagged()
+      context.author_display = @getAuthorDisplay()
       @template(context)
 
     render: ->

--- a/common/static/coffee/src/discussion/views/response_comment_show_view.coffee
+++ b/common/static/coffee/src/discussion/views/response_comment_show_view.coffee
@@ -4,12 +4,10 @@ if Backbone?
 
     render: ->
       @template = _.template($("#response-comment-show-template").html())
-      params = @model.toJSON()
+      @$el.html(@template(_.extend({author_display: @getAuthorDisplay()}, @model.attributes)))
 
-      @$el.html(@template(params))
       @delegateEvents()
       @renderAttrs()
-      @markAsStaff()
       @$el.find(".timeago").timeago()
       @convertMath()
       @addReplyLink()
@@ -26,12 +24,6 @@ if Backbone?
       body = @$el.find(".response-body")
       body.html DiscussionUtil.postMathJaxProcessor DiscussionUtil.markdownWithHighlight body.text()
       MathJax.Hub.Queue ["Typeset", MathJax.Hub, body[0]]
-
-    markAsStaff: ->
-      if DiscussionUtil.isStaff(@model.get("user_id"))
-        @$el.find("a.profile-link").after('<span class="staff-label">' + gettext('staff') + '</span>')
-      else if DiscussionUtil.isTA(@model.get("user_id"))
-        @$el.find("a.profile-link").after('<span class="community-ta-label">' + gettext('Community TA') + '</span>')
 
     _delete: (event) =>
         @trigger "comment:_delete", event

--- a/common/static/coffee/src/discussion/views/thread_response_show_view.coffee
+++ b/common/static/coffee/src/discussion/views/thread_response_show_view.coffee
@@ -6,7 +6,13 @@ if Backbone?
 
     renderTemplate: ->
         @template = _.template($("#thread-response-show-template").html())
-        @template(@model.toJSON())
+        context = _.extend({
+            author_display: @getAuthorDisplay(),
+            endorser_display: @getEndorserDisplay()
+          },
+          @model.attributes
+        )
+        @template(context)
 
     render: ->
       @$el.html(@renderTemplate())
@@ -14,21 +20,12 @@ if Backbone?
       @renderAttrs()
       @$el.find(".posted-details .timeago").timeago()
       @convertMath()
-      @markAsStaff()
       @
 
     convertMath: ->
       element = @$(".response-body")
       element.html DiscussionUtil.postMathJaxProcessor DiscussionUtil.markdownWithHighlight element.text()
       MathJax.Hub.Queue ["Typeset", MathJax.Hub, element[0]]
-
-    markAsStaff: ->
-      if DiscussionUtil.isStaff(@model.get("user_id"))
-        @$el.addClass("staff")
-        @$el.prepend('<span class="staff-banner">' + gettext('staff') + '</span>')
-      else if DiscussionUtil.isTA(@model.get("user_id"))
-        @$el.addClass("community-ta")
-        @$el.prepend('<span class="community-ta-banner">' + gettext('Community TA') + '</span>')
 
     edit: (event) ->
         @trigger "response:edit", event

--- a/lms/static/sass/application-extend2.scss.mako
+++ b/lms/static/sass/application-extend2.scss.mako
@@ -57,6 +57,7 @@
 @import "discussion/views/profile";
 @import "discussion/elements/actions";
 @import "discussion/elements/editor";
+@import "discussion/elements/labels";
 @import "discussion/elements/navigation";
 @import "discussion/views/response";
 @import 'discussion/utilities/developer';

--- a/lms/static/sass/discussion/_discussion.scss
+++ b/lms/static/sass/discussion/_discussion.scss
@@ -94,7 +94,7 @@ body.discussion {
     }
 
     h1 {
-      margin-bottom: ($baseline/2);
+      margin-bottom: ($baseline/4);
       font-size: 28px;
       font-weight: 700;
       letter-spacing: 0;
@@ -103,18 +103,14 @@ body.discussion {
 
     .posted-details {
       font-size: 12px;
-      font-style: italic;
       color: #888;
 
       .username {
-        display: block;
-        font-size: 16px;
         font-weight: 700;
       }
 
       .timeago, .top-post-status {
         color: inherit;
-        font-style: italic;
       }
     }
 
@@ -244,30 +240,6 @@ body.discussion {
 
   .posted-details {
     font-size: 11px;
-  }
-
-  .staff-label {
-    margin-left: ($baseline/4);
-    padding: 0 ($baseline/5);
-    border-radius: 2px;
-    background: #009FE2;
-    font-size: 9px;
-    font-weight: 700;
-    font-style: normal;
-    color: white;
-    text-transform: uppercase;
-  }
-
-  .community-ta-label{
-    margin-left: ($baseline/10);
-    padding: 0 ($baseline/5);
-    border-radius: 2px;
-    background: $forum-color-community-ta;
-    font-size: 9px;
-    font-weight: 700;
-    font-style: normal;
-    color: white;
-    text-transform: uppercase;
   }
 
   .main-article.new {

--- a/lms/static/sass/discussion/_mixins.scss
+++ b/lms/static/sass/discussion/_mixins.scss
@@ -114,3 +114,39 @@
   white-space: nowrap;
   text-overflow: ellipsis;
 }
+
+@mixin forum-post-label($color) {
+  @extend %t-weight4;
+  @include font-size(9);
+  display: inline;
+  margin-top: ($baseline/4);
+  border: 1px solid;
+  border-radius: 3px;
+  padding: 1px 6px;
+  text-transform: uppercase;
+  white-space: nowrap;
+
+  border-color: $color;
+  color: $color;
+
+  .icon {
+    margin-right: ($baseline/5);
+  }
+
+  &:last-child {
+    margin-right: 0;
+  }
+}
+
+@mixin forum-user-label($color) {
+  margin-left: ($baseline/4);
+  padding: 0 ($baseline/5);
+  border-radius: 2px;
+  background: $color;
+  font-size: 9px;
+  font-weight: 700;
+  font-style: normal;
+  color: white;
+  text-transform: uppercase;
+  vertical-align: middle;
+}

--- a/lms/static/sass/discussion/elements/_labels.scss
+++ b/lms/static/sass/discussion/elements/_labels.scss
@@ -1,0 +1,43 @@
+// discussion - elements - labels
+// ====================
+
+body.discussion, .discussion-module {
+
+  .post-labels {
+    display: inline;
+    margin-left: 8px;
+  }
+
+  .post-label-pinned {
+    @include forum-post-label($forum-color-pinned);
+  }
+
+  .post-label-following {
+    @include forum-post-label($forum-color-following);
+  }
+
+  .post-label-reported {
+    @include forum-post-label($forum-color-reported);
+  }
+
+  .post-label-closed {
+    @include forum-post-label($forum-color-closed);
+  }
+
+  .post-label-by-staff {
+    @include forum-post-label($forum-color-staff);
+  }
+
+  .post-label-by-community-ta {
+    @include forum-post-label($forum-color-community-ta);
+  }
+
+  .user-label-staff {
+    @include forum-user-label($forum-color-staff);
+  }
+
+  .user-label-community-ta {
+    @include forum-user-label($forum-color-community-ta);
+  }
+
+}

--- a/lms/static/sass/discussion/elements/_navigation.scss
+++ b/lms/static/sass/discussion/elements/_navigation.scss
@@ -231,51 +231,6 @@
   display: block;
 }
 
-%forum-nav-thread-label {
-  @extend %t-weight4;
-  @include font-size(9);
-  display: inline;
-  margin-top: ($baseline/4);
-  padding: 1px 6px;
-  border: 1px solid;
-  border-radius: 3px;
-  text-transform: uppercase;
-  white-space: nowrap;
-
-  &:last-child {
-    margin-right: 0;
-  }
-
-  .icon {
-    margin-right: ($baseline/5);
-  }
-
-}
-
-.forum-nav-thread-label-pinned {
-  @extend %forum-nav-thread-label;
-  border-color: $forum-color-pinned;
-  color: $forum-color-pinned;
-}
-
-.forum-nav-thread-label-following {
-  @extend %forum-nav-thread-label;
-  border-color: $forum-color-following;
-  color: $forum-color-following;
-}
-
-.forum-nav-thread-label-staff {
-  @extend %forum-nav-thread-label;
-  border-color: $forum-color-staff;
-  color: $forum-color-staff;
-}
-
-.forum-nav-thread-label-community-ta {
-  @extend %forum-nav-thread-label;
-  border-color: $forum-color-community-ta;
-  color: $forum-color-community-ta;
-}
-
 %forum-nav-thread-wrapper-2-content {
   @include font-size(11);
   display: inline-block;

--- a/lms/static/sass/discussion/utilities/_variables.scss
+++ b/lms/static/sass/discussion/utilities/_variables.scss
@@ -1,5 +1,7 @@
 $forum-color-active-thread: tint($blue, 85%);
 $forum-color-pinned: $pink;
+$forum-color-reported: $pink;
+$forum-color-closed: $black;
 $forum-color-following: $blue;
 $forum-color-staff: $blue;
 $forum-color-community-ta: $green-d1;

--- a/lms/static/sass/discussion/views/_thread.scss
+++ b/lms/static/sass/discussion/views/_thread.scss
@@ -31,6 +31,10 @@ body.discussion, .discussion-module {
   // response layout
   .discussion-response {
 
+    .username {
+      font-weight: 700;
+    }
+
     .response-header {
       display: inline-block;
       width: flex-grid(8,12);
@@ -98,3 +102,4 @@ body.discussion, .discussion-thread.expanded {
     box-shadow: 0 1px 3px $shadow;
   }
 }
+

--- a/lms/templates/discussion/_underscore_templates.html
+++ b/lms/templates/discussion/_underscore_templates.html
@@ -50,23 +50,20 @@
 
           <h1>${'<%- title %>'}</h1>
           <p class="posted-details">
-              ${"<% if (obj.username) { %>"}
-              <a href="${'<%- user_url %>'}" class="username">${'<%- username %>'}</a>
-              ${"<% } else { %>"}
-              ${_('anonymous') | h}
-              ${"<% } %>"}
               ## This part is incredibly gross but necessary to combine i18n in
               ## mako with logic in underscore.
               ## Translators: post_type describes the kind of post this is
               ## (e.g. "question" or "discussion"); time_ago is how much time
               ## has passed since the post was created (e.g. "4 hours ago")
-              ${"{post_type} posted {time_ago}".format(
+              ${"{post_type} posted {time_ago} by {author}".format(
                   post_type="<%- thread_type %>",
-                  time_ago="<span class='timeago' title='<%- created_at %>'><%- created_at %></span>"
+                  time_ago="<span class='timeago' title='<%- created_at %>'><%- created_at %></span>",
+                  author="<%= author_display %>"
               )}
-
-              <span class="post-status-closed top-post-status" style="display: none">
-                ${_("&bull; This thread is closed.")}
+              <span class="post-labels">
+                  <span class="post-label-pinned"><i class="icon icon-pushpin"></i>${_("Pinned")}</span>
+                  <span class="post-label-reported"><i class="icon icon-flag"></i>${_("Reported")}</span>
+                  <span class="post-label-closed"><i class="icon icon-lock"></i>${_("Closed")}</span>
               </span>
           </p>
       </header>
@@ -138,20 +135,19 @@
 
 <script aria-hidden="true" type="text/template" id="thread-response-show-template">
     <header class="response-header response-local">
-        ${"<% if (obj.username) { %>"}
-        <a href="${'<%- user_url %>'}" class="posted-by">${'<%- username %>'}</a>
-        ${"<% } else { %>"}
-        <span class="anonymous"><em>${_('anonymous')}</em></span>
-        ${"<% } %>"}
+        ${'<%= author_display %>'}
         <p class="posted-details">
             <span class="timeago" title="${'<%= created_at %>'}">${'<%= created_at %>'}</span>
+            <span class="post-labels">
+                <span class="post-label-reported"><i class="icon icon-flag"></i>${_("Reported")}</span>
+            </span>
             <%
             js_block = u"""
                 interpolate(
                     endorsement.username ? "{user_fmt_str}" : "{anon_fmt_str}",
                     {{
                         'time_ago': '<span class="timeago" title="' + endorsement.time + '">' + endorsement.time + '</span>',
-                        'user': endorsement.username
+                        'user': endorser_display
                     }},
                     true
                 )""".format(
@@ -208,20 +204,18 @@
     js_block = u"""
       interpolate(
         '{}',
-        {{'time_ago': '<span class=\"timeago\" title=\"' + created_at + '\">' + created_at + '</span>'}},
+        {{'time_ago': '<span class=\"timeago\" title=\"' + created_at + '\">' + created_at + '</span>', 'author': author_display}},
         true
         )""".format(
                ## Translators: 'timeago' is a placeholder for a fuzzy, relative timestamp (see: https://github.com/rmm5t/jquery-timeago)
-               escapejs(_('posted %(time_ago)s by'))
+               escapejs(_('posted %(time_ago)s by %(author)s'))
              )
            %>
     <p class="posted-details">
     ${'<%='}${js_block}${'%>'}
-    ${"<% if (obj.username) { %>"}
-    <a href="${'<%- user_url %>'}" class="profile-link">${'<%- username %>'}</a>
-    ${"<% } else { %>"}
-    ${_('anonymous')}
-    ${"<% } %>"}
+      <span class="post-labels">
+        <span class="post-label-reported"><i class="icon icon-flag"></i>${_("Reported")}</span>
+      </span>
     </p>
   </div>
 </script>
@@ -270,16 +264,16 @@
         js_block = u"""
         var labels = "";
         if (pinned) {{
-            labels += '<li class="forum-nav-thread-label-pinned"><i class="icon icon-pushpin"></i>{pinned_text}</li> ';
+            labels += '<li class="post-label-pinned"><i class="icon icon-pushpin"></i>{pinned_text}</li> ';
         }}
         if (typeof(subscribed) != "undefined" && subscribed) {{
-            labels += '<li class="forum-nav-thread-label-following"><i class="icon icon-star"></i>{following_text}</li> ';
+            labels += '<li class="post-label-following"><i class="icon icon-star"></i>{following_text}</li> ';
         }}
         if (staff_authored) {{
-            labels += '<li class="forum-nav-thread-label-staff"><i class="icon icon-user"></i>{staff_text}</li> ';
+            labels += '<li class="post-label-by-staff"><i class="icon icon-user"></i>{staff_text}</li> ';
         }}
         if (community_ta_authored) {{
-            labels += '<li class="forum-nav-thread-label-community-ta"><i class="icon icon-user"></i>{community_ta_text}</li> ';
+            labels += '<li class="post-label-by-community-ta"><i class="icon icon-user"></i>{community_ta_text}</li> ';
         }}
         if (labels != "") {{
             print('<ul class="forum-nav-thread-labels">' + labels + '</ul>');
@@ -624,4 +618,17 @@ ${secondaryAction("delete", "remove", _("Delete"))}
         </li>
         ${"<% _.each(primaryActions, function(action) { print(_.template($('#forum-action-' + action).html(), {})) }) %>"}
     </ul>
+</script>
+
+<script aria-hidden="true" type="text/template" id="post-user-display-template">
+    ${"<% if (username) { %>"}
+    <a href="${'<%- user_url %>'}" class="username">${'<%- username %>'}</a>
+        ${"<% if (is_community_ta) { %>"}
+        <span class="user-label-community-ta">${_("Community TA")}</span>
+        ${"<% } else if (is_staff) { %>"}
+        <span class="user-label-staff">${_("Staff")}</span>
+        ${"<% } %>"}
+    ${"<% } else { %>"}
+    ${_('anonymous') | h}
+    ${"<% } %>"}
 </script>


### PR DESCRIPTION
@gwprice @talbs

still needs tests, but figured i'd share -
wonder if y'all think this is a fine way to factor/reuse styles (see .forum-post-label-\* stuff and the new mixin)

making some layout inferences based on the post action cleanup wiki.  did not extend these changes into thread responses / comments, just the main thread header.
