### PR TITLE
Paver: Soften npm registry configuration settings

### DIFF
--- a/pavelib/prereqs.py
+++ b/pavelib/prereqs.py
@@ -102,9 +102,11 @@ def ruby_prereqs_installation():
 
 def node_prereqs_installation():
     """
-    Installs Node prerequisites
+    Configures npm and installs Node prerequisites
     """
-    sh("npm config set registry {}".format(NPM_REGISTRY))
+    sh("test `npm config get registry` = \"{reg}\" || "
+       "(echo setting registry; npm config set registry"
+       " {reg})".format(reg=NPM_REGISTRY))
     sh('npm install')
 
 


### PR DESCRIPTION
If paver is being run by a user that is not the same as the user
that installed npm on the guest machine, then paver install_prereqs fails
with the following error:

  ---> pavelib.prereqs.install_node_prereqs
  npm config set registry http://registry.npmjs.org/
  npm ERR! Error: EPERM, chown '/home/jenkins/.npmrc'
  npm ERR!  { [Error: EPERM, chown '/home/jenkins/.npmrc'] errno: 50, code: 'EPERM', path: '/home/jenkins/.npmrc' }
  npm ERR!
  npm ERR! Please try running this command again as root/Administrator.

  npm ERR! System Linux 3.2.0-23-generic
  npm ERR! command "/usr/bin/node" "/usr/bin/npm" "config" "set" "registry" "http://registry.npmjs.org/"
  npm ERR! cwd /home/jenkins/shallow-clone
  npm ERR! node -v v0.10.30
  npm ERR! npm -v 1.4.21
  npm ERR! path /home/jenkins/.npmrc
  npm ERR! code EPERM
  npm ERR! errno 50
  npm ERR! stack Error: EPERM, chown '/home/jenkins/.npmrc'
  npm ERR!
  npm ERR! Additional logging details can be found in:
  npm ERR!     /home/jenkins/shallow-clone/npm-debug.log
  npm ERR! not ok code 0

  Captured Task Output:

---

  ---> pavelib.prereqs.install_prereqs
  ---> pavelib.prereqs.install_ruby_prereqs
  ---> pavelib.prereqs.install_node_prereqs
  npm config set registry http://registry.npmjs.org/

  Build failed running pavelib.prereqs.install_prereqs: Subprocess return code: 50

This change is a workaround. Unfortunately most of the above output will still
be printed to console, but the exception is otherwise handled and npm install is
successful.
