### PR TITLE
Instructor Dash: Display message when no tasks running 

### DIFF
--- a/lms/static/coffee/src/instructor_dashboard/util.coffee
+++ b/lms/static/coffee/src/instructor_dashboard/util.coffee
@@ -268,7 +268,9 @@ class PendingInstructorTasks
   ### Pending Instructor Tasks Section ####
   constructor: (@$section) ->
     # Currently running tasks
+    @$running_tasks_section = find_and_assert @$section, ".running-tasks-section"
     @$table_running_tasks = find_and_assert @$section, ".running-tasks-table"
+    @$no_tasks_message = find_and_assert @$section, ".no-pending-tasks-message"
 
     # start polling for task list
     # if the list is in the DOM
@@ -287,8 +289,14 @@ class PendingInstructorTasks
       success: (data) =>
         if data.tasks.length
           create_task_list_table @$table_running_tasks, data.tasks
+          @$no_tasks_message.hide()
+          @$running_tasks_section.show()
         else
           console.log "No pending instructor tasks to display"
+          @$running_tasks_section.hide()
+          @$no_tasks_message.empty()
+          @$no_tasks_message.append $('<p>').text gettext("No tasks currently running.")
+          @$no_tasks_message.show()
       error: std_ajax_err => console.error "Error finding pending instructor tasks to display"
     ### /Pending Instructor Tasks Section ####
 

--- a/lms/static/sass/course/instructor/_instructor_2.scss
+++ b/lms/static/sass/course/instructor/_instructor_2.scss
@@ -224,6 +224,18 @@ section.instructor-dashboard-content-2 {
     .basic-data {
       padding: 6px;
     }
+
+    .running-tasks-section {
+      display: none;
+    }
+
+    .no-pending-tasks-message {
+      display: none;
+      p {
+        color: #a2a2a2;
+        font-style: italic;
+      }
+    }
   }
 }
 

--- a/lms/templates/instructor/instructor_dashboard_2/course_info.html
+++ b/lms/templates/instructor/instructor_dashboard_2/course_info.html
@@ -76,10 +76,13 @@
   <div class="running-tasks-container action-type-container">
     <hr>
     <h2> ${_("Pending Instructor Tasks")} </h2>
-    <p>${_("The status for any active tasks appears in a table below.")} </p>
-    <br />
+    <div class="running-tasks-section">
+      <p>${_("The status for any active tasks appears in a table below.")} </p>
+      <br />
 
-    <div class="running-tasks-table" data-endpoint="${ section_data['list_instructor_tasks_url'] }"></div>
+      <div class="running-tasks-table" data-endpoint="${ section_data['list_instructor_tasks_url'] }"></div>
+    </div>
+    <div class="no-pending-tasks-message"></div>
   </div>
 
 %endif

--- a/lms/templates/instructor/instructor_dashboard_2/data_download.html
+++ b/lms/templates/instructor/instructor_dashboard_2/data_download.html
@@ -69,8 +69,11 @@
   <div class="running-tasks-container action-type-container">
     <hr>
     <h2> ${_("Pending Instructor Tasks")} </h2>
-    <p>${_("The status for any active tasks appears in a table below.")} </p>
-    <br />
-    <div class="running-tasks-table" data-endpoint="${ section_data['list_instructor_tasks_url'] }"></div>
+    <div class="running-tasks-section">
+      <p>${_("The status for any active tasks appears in a table below.")} </p>
+      <br />
+      <div class="running-tasks-table" data-endpoint="${ section_data['list_instructor_tasks_url'] }"></div>
+    </div>
+    <div class="no-pending-tasks-message"></div>
   </div>
 %endif

--- a/lms/templates/instructor/instructor_dashboard_2/send_email.html
+++ b/lms/templates/instructor/instructor_dashboard_2/send_email.html
@@ -59,10 +59,13 @@
   <div class="running-tasks-container action-type-container">
     <hr>
     <h2> ${_("Pending Instructor Tasks")} </h2>
-    <p>${_("Email actions run in the background. The status for any active tasks - including email tasks - appears in a table below.")} </p>
-    <br />
+    <div class="running-tasks-section">
+      <p>${_("Email actions run in the background. The status for any active tasks - including email tasks - appears in a table below.")} </p>
+      <br />
 
-    <div class="running-tasks-table" data-endpoint="${ section_data['list_instructor_tasks_url'] }"></div>
+      <div class="running-tasks-table" data-endpoint="${ section_data['list_instructor_tasks_url'] }"></div>
+    </div>
+    <div class="no-pending-tasks-message"></div>
   </div>
 
 

--- a/lms/templates/instructor/instructor_dashboard_2/student_admin.html
+++ b/lms/templates/instructor/instructor_dashboard_2/student_admin.html
@@ -117,10 +117,13 @@
   <div class="running-tasks-container action-type-container">
     <hr>
     <h2> ${_("Pending Instructor Tasks")} </h2>
-    <p>${_("The status for any active tasks appears in a table below.")} </p>
-    <br />
+    <div class="running-tasks-section">
+      <p>${_("The status for any active tasks appears in a table below.")} </p>
+      <br />
 
-    <div class="running-tasks-table" data-endpoint="${ section_data['list_instructor_tasks_url'] }"></div>
+      <div class="running-tasks-table" data-endpoint="${ section_data['list_instructor_tasks_url'] }"></div>
+    </div>
+    <div class="no-pending-tasks-message"></div>
   </div>
 
 %endif


### PR DESCRIPTION
This commit adds a message to the instructor dashboard that is displayed when
no instructor tasks are currently running. This message is displayed where the
instructor pending tasks table would normally be placed, and is replaced
with the table when there are running tasks.
