### PR TITLE
Add OAuth2 backend

### DIFF
--- a/common/djangoapps/oauth2_provider/README.md
+++ b/common/djangoapps/oauth2_provider/README.md
@@ -1,0 +1,19 @@
+edX OAuth2 Provider
+===================
+OAuth2 provider for edX Platform.
+
+
+Instructions
+------------
+
+OAuth2 client must be registered to obtain their client_id and
+client_secret. The registration can be done using the /admin web
+interface, by adding new entries to the OAuth2 Clients table.
+
+Apart from the two basic OAuth2 client types (public and
+confidential), this provider as a notion of a trusted client. Such
+clients to not require user approval for accessing user resources, and
+will not show up the approval page during the sing-in process.
+
+To make a client trusted after it has been created, add it to the
+OAuth2-provider TrustedModel tables using the /admin web interface.

--- a/common/djangoapps/oauth2_provider/__init__.py
+++ b/common/djangoapps/oauth2_provider/__init__.py
@@ -1,0 +1,4 @@
+"""
+OAuth2 provider based on `django-oauth2-provider` with
+customizations for the edx-platform.
+"""

--- a/common/djangoapps/oauth2_provider/admin.py
+++ b/common/djangoapps/oauth2_provider/admin.py
@@ -1,0 +1,14 @@
+"""
+OAuth2 provider Django admin interface
+"""
+from django.contrib import admin
+
+from oauth2_provider.models import TrustedClient
+
+
+class TrustedClientAdmin(admin.ModelAdmin):
+    "Django admin configuration for `TrustedClient` model"
+    list_display = ('client',)
+
+
+admin.site.register(TrustedClient, TrustedClientAdmin)

--- a/common/djangoapps/oauth2_provider/backends.py
+++ b/common/djangoapps/oauth2_provider/backends.py
@@ -1,0 +1,24 @@
+"""
+OAuth2 provider `django-oauth2-provider` authentication backends
+"""
+
+from oauth2_provider.forms import PublicPasswordGrantForm
+
+
+class PublicPasswordBackend(object):
+    """
+    Simple client authentication wrapper backends that delegates to
+    `oauth2_provider.forms.PublicPasswordGrantForm`
+    """
+
+    def authenticate(self, request=None):
+        "Returns client if correctly authenticated. Otherwise returns None"
+        if request is None:
+            return None
+
+        form = PublicPasswordGrantForm(request.REQUEST)
+
+        if form.is_valid():
+            return form.cleaned_data.get('client')
+
+        return None

--- a/common/djangoapps/oauth2_provider/forms.py
+++ b/common/djangoapps/oauth2_provider/forms.py
@@ -1,0 +1,71 @@
+"""
+OAuth2 provider customized `django-oauth2-provider` forms
+"""
+
+from django.contrib.auth import authenticate
+from django.contrib.auth.models import User
+
+import provider.oauth2.forms
+import provider.constants
+from provider.forms import OAuthValidationError
+from provider.oauth2.models import Client
+
+
+# The forms in this module are required to use email as a secondary
+# identifier when authenticating via OAuth2, since the specification
+# only uses the `username` parameter. An alternative approach is to
+# write a backend like `django.contrib.auth.backends.ModelBackend`
+# and add it to `AUTHENTICATION_BACKENDS` in the Django settings.
+
+
+class PasswordGrantForm(provider.oauth2.forms.PasswordGrantForm):
+    """
+    Forms that validates the user email to be used as secondary user
+    identifier during authentication.
+
+    """
+
+    def clean(self):
+        data = self.cleaned_data  # pylint: disable=no-member
+        username = data.get('username')
+        password = data.get('password')
+
+        user = authenticate(username=username, password=password)
+
+        # If the username was not found try the user using username as
+        # the email address. It is valid because the edx-platform has
+        # a unique constraint placed on the email field.
+        if user is None:
+            try:
+                user_obj = User.objects.get(email=username)
+                user = authenticate(username=user_obj.username, password=password)
+            except User.DoesNotExist:
+                user = None
+
+        if user is None or not user.is_active:
+            raise OAuthValidationError({'error': 'invalid_grant'})
+
+        data['user'] = user
+        return data
+
+
+class PublicPasswordGrantForm(PasswordGrantForm,
+                              provider.oauth2.forms.PublicPasswordGrantForm):
+    """
+    Form wrapper to ensure the the customized PasswordGrantForm is used
+    during client authentication.
+
+    """
+    def clean(self):
+        data = super(PublicPasswordGrantForm, self).clean()
+
+        try:
+            client = Client.objects.get(client_id=data.get('client_id'))
+        except Client.DoesNotExist:
+            raise OAuthValidationError({'error': 'invalid_client'})
+
+        if client.client_type != provider.constants.PUBLIC:
+            raise OAuthValidationError({'error': 'invalid_client'})
+
+        data['client'] = client
+        return data

--- a/common/djangoapps/oauth2_provider/migrations/0001_initial.py
+++ b/common/djangoapps/oauth2_provider/migrations/0001_initial.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'TrustedClient'
+        db.create_table('oauth2_provider_trustedclient', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('client', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['oauth2.Client'])),
+        ))
+        db.send_create_signal('oauth2_provider', ['TrustedClient'])
+
+
+    def backwards(self, orm):
+        # Deleting model 'TrustedClient'
+        db.delete_table('oauth2_provider_trustedclient')
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'oauth2.client': {
+            'Meta': {'object_name': 'Client'},
+            'client_id': ('django.db.models.fields.CharField', [], {'default': "'599bed4d027ee6e573d6'", 'max_length': '255'}),
+            'client_secret': ('django.db.models.fields.CharField', [], {'default': "'92c7e99d5b7bb6b4d7cf20ba26d01fa7ae48eed2'", 'max_length': '255'}),
+            'client_type': ('django.db.models.fields.IntegerField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'redirect_uri': ('django.db.models.fields.URLField', [], {'max_length': '200'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'oauth2_client'", 'null': 'True', 'to': "orm['auth.User']"})
+        },
+        'oauth2_provider.trustedclient': {
+            'Meta': {'object_name': 'TrustedClient'},
+            'client': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['oauth2.Client']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        }
+    }
+
+    complete_apps = ['oauth2_provider']

--- a/common/djangoapps/oauth2_provider/models.py
+++ b/common/djangoapps/oauth2_provider/models.py
@@ -1,0 +1,18 @@
+"""
+Custom OAuth2 modes
+"""
+
+from django.db import models
+
+from provider.oauth2.models import Client
+
+
+class TrustedClient(models.Model):
+    """
+    By default `django-oauth2-provider` shows a consent form to the
+    user after his credentials has been validated. Trusted clients
+    bypass the user consent and redirect to the OAuth2 client
+    directly.
+
+    """
+    client = models.ForeignKey(Client)

--- a/common/djangoapps/oauth2_provider/tests.py
+++ b/common/djangoapps/oauth2_provider/tests.py
@@ -1,0 +1,237 @@
+"""OAuth2 provider tests"""
+
+# pylint: disable=missing-docstring
+
+import json
+import os.path
+import unittest
+import urlparse
+
+from django.conf import settings
+from django.core.urlresolvers import reverse
+from django.http import QueryDict
+from django.test import TestCase
+
+import provider.oauth2.models
+import provider.oauth2.views
+from provider.constants import PUBLIC, CONFIDENTIAL
+from factory.django import DjangoModelFactory
+from ddt import ddt, data
+
+from student.tests.factories import UserFactory
+
+import oauth2_provider.views
+import oauth2_provider.models
+
+
+ENABLE_OAUTH2 = settings.FEATURES.get('ENABLE_OAUTH2_PROVIDER')
+
+USERNAME = 'some_username'
+EMAIL = 'test@example.com'
+PASSWORD = 'some_password'
+
+CLIENT_ID = 'some_client_id'
+CLIENT_SECRET = 'some_client_secret'
+
+CLIENT_URL = 'http://example.com'
+CLIENT_REDIRECT_URI = 'http://example.com/application'
+
+
+# Data to generate login tests. Missing fields default to the values
+# in the module variables above. 'success' defaults to False.
+# 'client_secret' is not used unless specified.
+CUSTOM_PASSWORD_GRANT_TEST_DATA = [
+    {
+        'success': True
+    },
+    {
+        'username': EMAIL,
+        'success': True
+    },
+    {
+        'password': PASSWORD + '_bad',
+    },
+    {
+        'username': USERNAME + '_bad',
+    },
+    {
+        'client_id': CLIENT_ID + '_bad'
+    },
+    {
+        'username': EMAIL,
+        'password': PASSWORD + '_bad',
+    },
+    {
+        'client_secret': CLIENT_SECRET,
+        'success': True
+    },
+    {
+        'client_type': CONFIDENTIAL,
+        'client_secret': CLIENT_SECRET,
+        'success': True
+    },
+    {
+        'client_secret': CLIENT_SECRET + '_bad',
+        'success': True  # public clients should ignore the client_secret field
+    },
+    {
+        'client_type': CONFIDENTIAL,
+        'client_secret': CLIENT_SECRET + '_bad',
+    },
+]
+
+
+class ClientFactory(DjangoModelFactory):
+    FACTORY_FOR = provider.oauth2.models.Client
+
+    url = CLIENT_URL
+    redirect_uri = CLIENT_REDIRECT_URI
+
+
+class TrustedClientFactory(DjangoModelFactory):
+    FACTORY_FOR = oauth2_provider.models.TrustedClient
+
+
+@ddt
+class AccessTokenTest(TestCase):
+    def setUp(self):
+        self.url = reverse('oauth2:access_token')
+        self.user = UserFactory.create(
+            username=USERNAME,
+            email=EMAIL,
+            password=PASSWORD,
+        )
+
+    @data(*CUSTOM_PASSWORD_GRANT_TEST_DATA)
+    @unittest.skipUnless(ENABLE_OAUTH2, "ENABLE_OAUTH2_PROVIDER not enabled")
+    def test_custom_password_grants(self, test_data):
+        ClientFactory.create(
+            client_id=CLIENT_ID,
+            client_secret=CLIENT_SECRET,
+            client_type=test_data.get('client_type', PUBLIC)
+        )
+
+        values = {
+            'grant_type': 'password',
+            'client_id': test_data.get('client_id', CLIENT_ID),
+            'username': test_data.get('username', USERNAME),
+            'password': test_data.get('password', PASSWORD),
+        }
+
+        client_secret = test_data.get('client_secret')
+        if client_secret:
+            values.update({'client_secret': client_secret})
+
+        response = self.client.post(self.url, values)
+
+        if test_data.get('success', False):
+            self.assertEqual(200, response.status_code)
+            self.assertIn('access_token', json.loads(response.content))
+        else:
+            self.assertEqual(400, response.status_code)
+
+
+class ClientBaseTest(TestCase):
+    def setUp(self):
+        self.user = UserFactory.create(
+            username=USERNAME,
+            password=PASSWORD,
+        )
+        self.auth_client = ClientFactory.create(
+            client_id=CLIENT_ID,
+            client_secret=CLIENT_SECRET,
+            client_type=CONFIDENTIAL
+        )
+        self.payload = {
+            'client_id': CLIENT_ID,
+            'response_type': 'code',
+            'state': 'some_state',
+            'redirect_uri': CLIENT_REDIRECT_URI
+        }
+
+    def set_scope(self, scope):
+        if scope is None and 'scope' in self.payload:
+            del self.payload['scope']
+        else:
+            self.payload['scope'] = scope
+
+    def use_trusted_client(self):
+        client = TrustedClientFactory.create(client=self.auth_client)
+        return client
+
+    def login_and_authorize(self):
+        self.client.login(username=USERNAME, password=PASSWORD)
+        self.client.get(reverse('oauth2:capture'), self.payload)
+        response = self.client.get(reverse('oauth2:authorize'), self.payload)
+
+        return response
+
+
+class TrustedClientTest(ClientBaseTest):
+    @unittest.skipUnless(ENABLE_OAUTH2, "ENABLE_OAUTH2_PROVIDER not enabled")
+    def test_untrusted_client(self):
+        response = self.login_and_authorize()
+
+        form_action = 'action="{}"'.format(path(reverse("oauth2:authorize")))
+
+        # Check that the consent form is presented
+        self.assertContains(response, form_action, status_code=200)
+
+    @unittest.skipUnless(ENABLE_OAUTH2, "ENABLE_OAUTH2_PROVIDER not enabled")
+    def test_trusted_client(self):
+        self.use_trusted_client()
+
+        response = self.login_and_authorize()
+        self.assertEqual(302, response.status_code)
+        self.assertEqual(reverse('oauth2:redirect'), path(response['Location']))
+
+
+class ClientScopeTest(ClientBaseTest):
+    def get_access_token_response(self):
+        response = self.login_and_authorize()
+        self.assertEqual(302, response.status_code)
+        self.assertEqual(reverse('oauth2:redirect'), path(response['Location']))
+
+        response = self.client.get(reverse('oauth2:redirect'))
+
+        query = QueryDict(urlparse.urlparse(response['Location']).query)
+        code = query['code']
+
+        response = self.client.post(reverse('oauth2:access_token'), {
+            'grant_type': 'authorization_code',
+            'client_id': CLIENT_ID,
+            'client_secret': CLIENT_SECRET,
+            'code': code,
+        })
+
+        return response
+
+    @unittest.skipUnless(ENABLE_OAUTH2, "ENABLE_OAUTH2_PROVIDER not enabled")
+    def test_username_scope(self):
+        self.use_trusted_client()
+        self.set_scope('preferred_username')
+
+        response = self.get_access_token_response()
+
+        self.assertEqual(200, response.status_code)
+
+        values = json.loads(response.content)
+        self.assertEqual(values.get('preferred_username'), USERNAME)
+        self.assertIn('preferred_username', values.get('scope'))
+
+    @unittest.skipUnless(ENABLE_OAUTH2, "ENABLE_OAUTH2_PROVIDER not enabled")
+    def test_no_scope(self):
+        self.use_trusted_client()
+
+        response = self.get_access_token_response()
+
+        self.assertEqual(200, response.status_code)
+
+        values = json.loads(response.content)
+        self.assertNotIn('preferred_username', values)
+        self.assertNotIn('preferred_username', values.get('scope'))
+
+
+def path(url):
+    """Get and normalize the path on a URL"""
+    return os.path.normpath(urlparse.urlparse(url).path)

--- a/common/djangoapps/oauth2_provider/urls.py
+++ b/common/djangoapps/oauth2_provider/urls.py
@@ -1,0 +1,18 @@
+"""
+OAuth2 provider urls
+"""
+
+from django.contrib.auth.decorators import login_required
+from django.views.decorators.csrf import csrf_exempt
+from django.conf.urls import patterns, url
+
+from oauth2_provider.views import Authorize, Redirect, Capture, AccessTokenView
+
+
+urlpatterns = patterns(
+    '',
+    url('^authorize/?$', login_required(Capture.as_view()), name='capture'),
+    url('^authorize/confirm/?$', login_required(Authorize.as_view()), name='authorize'),
+    url('^redirect/?$', login_required(Redirect.as_view()), name='redirect'),
+    url('^access_token/?$', csrf_exempt(AccessTokenView.as_view()), name='access_token'),
+)

--- a/common/djangoapps/oauth2_provider/views.py
+++ b/common/djangoapps/oauth2_provider/views.py
@@ -1,0 +1,64 @@
+"""
+Customized django-oauth2-provider views
+"""
+
+from django.conf import settings
+
+import provider.oauth2.views
+import provider.oauth2.forms
+from provider import scope
+from provider.oauth2.views import OAuthError
+from provider.oauth2.views import Capture, Redirect  # pylint: disable=unused-import
+
+from oauth2_provider.forms import PasswordGrantForm
+from oauth2_provider.models import TrustedClient
+from oauth2_provider.backends import PublicPasswordBackend
+
+
+# pylint: disable=abstract-method
+class Authorize(provider.oauth2.views.Authorize):
+    """
+    edX customized authorization view:
+      - Introduces trusted clients, which do not require user consent.
+    """
+    def get_authorization_form(self, request, client, data, client_data):
+        # Check if the client is trusted. If so, bypass user
+        # authorization by filling the data in the form.
+        trusted = TrustedClient.objects.filter(client=client).exists()
+        if trusted:
+            scope_names = scope.to_names(client_data['scope'])
+            data = {'authorize': [u'Authorize'], 'scope': scope_names}
+
+        form = provider.oauth2.forms.AuthorizationForm(data)
+        return form
+
+
+# pylint: disable=abstract-method
+class AccessTokenView(provider.oauth2.views.AccessTokenView):
+    """
+    edX customized access token view:
+      - Allows usage of email as main identifier when requesting a
+        password grant.
+      - Return username along access token if requested in the scope.
+    """
+
+    # add custom authentication provider
+    authentication = (provider.oauth2.views.AccessTokenView.authentication +
+                      (PublicPasswordBackend, ))
+
+    def get_password_grant(self, _request, data, client):
+        # Use customize form to allow use of user email during authentication
+        form = PasswordGrantForm(data, client=client)
+        if not form.is_valid():
+            raise OAuthError(form.errors)
+        return form.cleaned_data
+
+    # pylint: disable=super-on-old-class
+    def access_token_response_data(self, access_token):
+        # Include username along the access token response if requested in the scope.
+        response_data = super(AccessTokenView, self).access_token_response_data(access_token)
+
+        if scope.check(settings.OAUTH_USERNAME_SCOPE, access_token.scope):
+            response_data.update({'preferred_username': access_token.user.username})
+
+        return response_data

--- a/common/djangoapps/oauth2_provider/views.py
+++ b/common/djangoapps/oauth2_provider/views.py
@@ -47,7 +47,7 @@ class AccessTokenView(provider.oauth2.views.AccessTokenView):
                       (PublicPasswordBackend, ))
 
     def get_password_grant(self, _request, data, client):
-        # Use customize form to allow use of user email during authentication
+        # Use customized form to allow use of user email during authentication
         form = PasswordGrantForm(data, client=client)
         if not form.is_valid():
             raise OAuthError(form.errors)

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -324,6 +324,7 @@ OAUTH_DEFAULT_SCOPE = 0
 OAUTH_USERNAME_SCOPE = 1
 
 # Define OAuth scopes. Required by django-oauth2-provider.
+# The default scope value is OAUTH_SCOPES[0][0]
 OAUTH_SCOPES = (
     (OAUTH_DEFAULT_SCOPE, 'default'),
     (OAUTH_USERNAME_SCOPE, 'preferred_username'),

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -117,6 +117,9 @@ FEATURES = {
     # with Shib.  Feature was requested by Stanford's office of general counsel
     'SHIB_DISABLE_TOS': False,
 
+    # Toggles OAuth2 authentication provider
+    'ENABLE_OAUTH2_PROVIDER': False,
+
     # Can be turned off if course lists need to be hidden. Effects views and templates.
     'COURSES_ARE_BROWSABLE': True,
 
@@ -314,6 +317,17 @@ STATUS_MESSAGE_PATH = ENV_ROOT / "status_message.json"
 
 ############################ OpenID Provider  ##################################
 OPENID_PROVIDER_TRUSTED_ROOTS = ['cs50.net', '*.cs50.net']
+
+############################## OAUTH2 SCOPES  ##################################
+# Use bit-shifting so that scopes can be easily combined and checked.
+OAUTH_DEFAULT_SCOPE = 0
+OAUTH_USERNAME_SCOPE = 1
+
+# Define OAuth scopes. Required by django-oauth2-provider.
+OAUTH_SCOPES = (
+    (OAUTH_DEFAULT_SCOPE, 'default'),
+    (OAUTH_USERNAME_SCOPE, 'preferred_username'),
+)
 
 ################################## EDX WEB #####################################
 # This is where we stick our compiled template files. Most of the app uses Mako
@@ -1289,6 +1303,11 @@ INSTALLED_APPS = (
     # External auth (OpenID, shib)
     'external_auth',
     'django_openid_auth',
+
+    # OAuth2 Provider
+    'provider',
+    'provider.oauth2',
+    'oauth2_provider',
 
     # For the wiki
     'wiki',  # The new django-wiki from benjaoming

--- a/lms/envs/dev.py
+++ b/lms/envs/dev.py
@@ -204,6 +204,9 @@ OPENID_USE_AS_ADMIN_LOGIN = False
 
 OPENID_PROVIDER_TRUSTED_ROOTS = ['*']
 
+############################## OAUTH2 Provider ################################
+FEATURES['ENABLE_OAUTH2_PROVIDER'] = True
+
 ######################## MIT Certificates SSL Auth ############################
 
 FEATURES['AUTH_USE_CERTIFICATES'] = False

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -203,6 +203,9 @@ simplefilter('ignore')  # Change to "default" to see the first instance of each 
 ######### Third-party auth ##########
 FEATURES['ENABLE_THIRD_PARTY_AUTH'] = True
 
+############################## OAUTH2 Provider ################################
+FEATURES['ENABLE_OAUTH2_PROVIDER'] = True
+
 ################################## OPENID #####################################
 FEATURES['AUTH_USE_OPENID'] = True
 FEATURES['AUTH_USE_OPENID_PROVIDER'] = True

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -203,9 +203,6 @@ simplefilter('ignore')  # Change to "default" to see the first instance of each 
 ######### Third-party auth ##########
 FEATURES['ENABLE_THIRD_PARTY_AUTH'] = True
 
-############################## OAUTH2 Provider ################################
-FEATURES['ENABLE_OAUTH2_PROVIDER'] = True
-
 ################################## OPENID #####################################
 FEATURES['AUTH_USE_OPENID'] = True
 FEATURES['AUTH_USE_OPENID_PROVIDER'] = True

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -451,6 +451,12 @@ if settings.FEATURES.get('AUTH_USE_OPENID_PROVIDER'):
         url(r'^openid/provider/xrds/$', 'external_auth.views.provider_xrds', name='openid-provider-xrds')
     )
 
+if settings.FEATURES.get('ENABLE_OAUTH2_PROVIDER'):
+    urlpatterns += (
+        url(r'^oauth2/', include('oauth2_provider.urls', namespace='oauth2')),
+    )
+
+
 if settings.FEATURES.get('ENABLE_LMS_MIGRATION'):
     urlpatterns += (
         url(r'^migrate/modules$', 'lms_migration.migrate.manage_modulestores'),

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -10,6 +10,7 @@
 -e git+https://github.com/edx/django-staticfiles.git@d89aae2a82f2b#egg=django-staticfiles
 -e git+https://github.com/edx/django-pipeline.git@88ec8a011e481918fdc9d2682d4017c835acd8be#egg=django-pipeline
 -e git+https://github.com/edx/django-wiki.git@cd0b2b31997afccde519fe5b3365e61a9edb143f#egg=django-wiki
+-e git+https://github.com/edx/django-oauth2-provider.git@0250c1c0fad965d95723a69967e21b5529b37611#egg=django-oauth2-provider
 -e git+https://github.com/gabrielfalcao/lettuce.git@cccc3978ad2df82a78b6f9648fe2e9baddd22f88#egg=lettuce
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev
 -e git+https://github.com/eventbrite/zendesk.git@d53fe0e81b623f084e91776bcf6369f8b7b63879#egg=zendesk


### PR DESCRIPTION
The backend is customized to support the following features:
- Email can be used as a user identifier in the OAuth2 username field.
- Trusted clients do not require the user consent and redirect automatically.
