### PR TITLE
Unflag Group Configurations; Render only existing children in staff view of split_test.

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_group_configurations.py
+++ b/cms/djangoapps/contentstore/views/tests/test_group_configurations.py
@@ -7,7 +7,6 @@ from contentstore.utils import reverse_course_url, reverse_usage_url
 from contentstore.views.component import SPLIT_TEST_COMPONENT_TYPE
 from contentstore.views.course import GroupConfiguration
 from contentstore.tests.utils import CourseTestCase
-from util.testing import UrlResetMixin
 from xmodule.partitions.partitions import Group, UserPartition
 from xmodule.modulestore.tests.factories import ItemFactory
 from xmodule.split_test_module import ValidationMessage, ValidationMessageType
@@ -165,11 +164,10 @@ class GroupConfigurationsBaseTestCase(object):
 
 
 # pylint: disable=no-member
-class GroupConfigurationsListHandlerTestCase(UrlResetMixin, CourseTestCase, GroupConfigurationsBaseTestCase, HelperMethods):
+class GroupConfigurationsListHandlerTestCase(CourseTestCase, GroupConfigurationsBaseTestCase, HelperMethods):
     """
     Test cases for group_configurations_list_handler.
     """
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_GROUP_CONFIGURATIONS": True})
     def setUp(self):
         """
         Set up GroupConfigurationsListHandlerTestCase.
@@ -261,14 +259,13 @@ class GroupConfigurationsListHandlerTestCase(UrlResetMixin, CourseTestCase, Grou
 
 
 # pylint: disable=no-member
-class GroupConfigurationsDetailHandlerTestCase(UrlResetMixin, CourseTestCase, GroupConfigurationsBaseTestCase, HelperMethods):
+class GroupConfigurationsDetailHandlerTestCase(CourseTestCase, GroupConfigurationsBaseTestCase, HelperMethods):
     """
     Test cases for group_configurations_detail_handler.
     """
 
     ID = 0
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_GROUP_CONFIGURATIONS": True})
     def setUp(self):
         """
         Set up GroupConfigurationsDetailHandlerTestCase.
@@ -420,12 +417,11 @@ class GroupConfigurationsDetailHandlerTestCase(UrlResetMixin, CourseTestCase, Gr
 
 
 # pylint: disable=no-member
-class GroupConfigurationsUsageInfoTestCase(UrlResetMixin, CourseTestCase, HelperMethods):
+class GroupConfigurationsUsageInfoTestCase(CourseTestCase, HelperMethods):
     """
     Tests for usage information of configurations.
     """
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_GROUP_CONFIGURATIONS": True})
     def setUp(self):
         super(GroupConfigurationsUsageInfoTestCase, self).setUp()
 
@@ -542,7 +538,6 @@ class GroupConfigurationsValidationTestCase(CourseTestCase, HelperMethods):
     """
     Tests for validation in Group Configurations.
     """
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_GROUP_CONFIGURATIONS": True})
     def setUp(self):
         super(GroupConfigurationsValidationTestCase, self).setUp()
 

--- a/cms/djangoapps/contentstore/views/tests/test_item.py
+++ b/cms/djangoapps/contentstore/views/tests/test_item.py
@@ -180,7 +180,6 @@ class GetItem(ItemTest):
         self.assertIn('Zooming', html)
 
 
-    @skipUnless(os.environ.get('FEATURE_GROUP_CONFIGURATIONS'), 'Tests Group Configurations feature')
     def test_split_test_edited(self):
         """
         Test that rename of a group changes display name of child vertical.
@@ -194,7 +193,7 @@ class GetItem(ItemTest):
         resp = self.create_xblock(category='split_test', parent_usage_key=root_usage_key)
         split_test_usage_key = self.response_usage_key(resp)
         self.client.ajax_post(
-            reverse_usage_url("xblock_handler", split_test_usage_key), 
+            reverse_usage_url("xblock_handler", split_test_usage_key),
             data={'metadata': {'user_partition_id': str(0)}}
         )
         html, __ = self._get_container_preview(split_test_usage_key)

--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -24,6 +24,7 @@ class CourseMetadata(object):
                      'graded',
                      'hide_from_toc',
                      'pdf_textbooks',
+                     'user_partitions',
                      'name',  # from xblock
                      'tags',  # from xblock
                      'visible_to_staff_only'

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -104,9 +104,6 @@ FEATURES = {
     # Turn off Advanced Security by default
     'ADVANCED_SECURITY': False,
 
-    # Toggles Group Configuration editing functionality
-    'ENABLE_GROUP_CONFIGURATIONS': os.environ.get('FEATURE_GROUP_CONFIGURATIONS'),
-
     # Modulestore to use for new courses
     'DEFAULT_STORE_FOR_NEW_COURSE': 'mongo',
 }

--- a/cms/static/js/spec/views/group_configuration_spec.js
+++ b/cms/static/js/spec/views/group_configuration_spec.js
@@ -381,7 +381,7 @@ define([
             this.view.$('form').submit();
             // See error message
             expect(this.view.$(SELECTORS.errorMessage)).toContainText(
-                'Group Configuration name is required'
+                'Group Configuration name is required.'
             );
             // No request
             expect(requests.length).toBe(0);

--- a/cms/templates/settings.html
+++ b/cms/templates/settings.html
@@ -330,7 +330,7 @@ require(["domReady!", "jquery", "js/models/settings/course_details", "js/views/s
             <li class="nav-item"><a href="${grading_config_url}">${_("Grading")}</a></li>
             <li class="nav-item"><a href="${course_team_url}">${_("Course Team")}</a></li>
             <li class="nav-item"><a href="${advanced_config_url}">${_("Advanced Settings")}</a></li>
-          % if settings.FEATURES.get('ENABLE_GROUP_CONFIGURATIONS') and "split_test" in context_course.advanced_modules:
+          % if "split_test" in context_course.advanced_modules:
             <li class="nav-item"><a href="${utils.reverse_course_url('group_configurations_list_handler', context_course.id)}">${_("Group Configurations")}</a></li>
           % endif
           </ul>

--- a/cms/templates/settings_advanced.html
+++ b/cms/templates/settings_advanced.html
@@ -126,7 +126,7 @@ require(["domReady!", "jquery", "gettext", "js/models/settings/advanced", "js/vi
             <li class="nav-item"><a href="${details_url}">${_("Details &amp; Schedule")}</a></li>
             <li class="nav-item"><a href="${grading_url}">${_("Grading")}</a></li>
             <li class="nav-item"><a href="${course_team_url}">${_("Course Team")}</a></li>
-          % if settings.FEATURES.get('ENABLE_GROUP_CONFIGURATIONS') and "split_test" in context_course.advanced_modules:
+          % if "split_test" in context_course.advanced_modules:
             <li class="nav-item"><a href="${utils.reverse_course_url('group_configurations_list_handler', context_course.id)}">${_("Group Configurations")}</a></li>
           % endif
           </ul>

--- a/cms/templates/settings_graders.html
+++ b/cms/templates/settings_graders.html
@@ -148,7 +148,7 @@ require(["domReady!", "jquery", "js/views/settings/grading", "js/models/settings
             <li class="nav-item"><a href="${detailed_settings_url}">${_("Details &amp; Schedule")}</a></li>
             <li class="nav-item"><a href="${course_team_url}">${_("Course Team")}</a></li>
             <li class="nav-item"><a href="${advanced_settings_url}">${_("Advanced Settings")}</a></li>
-          % if settings.FEATURES.get('ENABLE_GROUP_CONFIGURATIONS') and "split_test" in context_course.advanced_modules:
+          % if "split_test" in context_course.advanced_modules:
             <li class="nav-item"><a href="${utils.reverse_course_url('group_configurations_list_handler', context_course.id)}">${_("Group Configurations")}</a></li>
           % endif
           </ul>

--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -84,7 +84,7 @@
                   <li class="nav-item nav-course-settings-advanced">
                     <a href="${advanced_settings_url}">${_("Advanced Settings")}</a>
                   </li>
-                  % if settings.FEATURES.get('ENABLE_GROUP_CONFIGURATIONS') and "split_test" in context_course.advanced_modules:
+                  % if "split_test" in context_course.advanced_modules:
                   <li class="nav-item nav-course-settings-group-configurations">
                     <a href="${reverse('contentstore.views.group_configurations_list_handler', kwargs={'course_key_string': unicode(course_key)})}">${_("Group Configurations")}</a>
                   </li>

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -91,14 +91,10 @@ urlpatterns += patterns(
     url(r'^settings/advanced/{}$'.format(settings.COURSE_KEY_PATTERN), 'advanced_settings_handler'),
     url(r'^textbooks/{}$'.format(settings.COURSE_KEY_PATTERN), 'textbooks_list_handler'),
     url(r'^textbooks/{}/(?P<textbook_id>\d[^/]*)$'.format(settings.COURSE_KEY_PATTERN), 'textbooks_detail_handler'),
+    url(r'^group_configurations/{}$'.format(settings.COURSE_KEY_PATTERN), 'group_configurations_list_handler'),
+    url(r'^group_configurations/{}/(?P<group_configuration_id>\d+)/?$'.format(settings.COURSE_KEY_PATTERN),
+        'group_configurations_detail_handler'),
 )
-
-if settings.FEATURES.get('ENABLE_GROUP_CONFIGURATIONS'):
-    urlpatterns += patterns('contentstore.views',
-        url(r'^group_configurations/{}$'.format(settings.COURSE_KEY_PATTERN), 'group_configurations_list_handler'),
-        url(r'^group_configurations/{}/(?P<group_configuration_id>\d+)/?$'.format(settings.COURSE_KEY_PATTERN),
-            'group_configurations_detail_handler'),
-    )
 
 js_info_dict = {
     'domain': 'djangojs',

--- a/common/lib/xmodule/xmodule/split_test_module.py
+++ b/common/lib/xmodule/xmodule/split_test_module.py
@@ -6,6 +6,7 @@ import logging
 import json
 from webob import Response
 from uuid import uuid4
+from operator import itemgetter
 
 from xmodule.progress import Progress
 from xmodule.seq_module import SequenceDescriptor
@@ -235,24 +236,41 @@ class SplitTestModule(SplitTestFields, XModule, StudioEditableModule):
         Render the staff view for a split test module.
         """
         fragment = Fragment()
-        contents = []
+        active_contents = []
+        inactive_contents = []
 
-        for group_id in self.group_id_to_child:
-            child_location = self.group_id_to_child[group_id]
+        for child_location in self.children:  # pylint: disable=no-member
             child_descriptor = self.get_child_descriptor_by_location(child_location)
             child = self.system.get_module(child_descriptor)
             rendered_child = child.render(STUDENT_VIEW, context)
             fragment.add_frag_resources(rendered_child)
+            group_name, updated_group_id = self.get_data_for_vertical(child)
 
-            contents.append({
-                'group_id': group_id,
+            if updated_group_id is None:  # inactive group
+                group_name = child.display_name
+                updated_group_id = [g_id for g_id, loc in self.group_id_to_child.items() if loc == child_location][0]
+                inactive_contents.append({
+                    'group_name': _(u'{group_name} (inactive)').format(group_name=group_name),
+                    'id': child.location.to_deprecated_string(),
+                    'content': rendered_child.content,
+                    'group_id': updated_group_id,
+                })
+                continue
+
+            active_contents.append({
+                'group_name': group_name,
                 'id': child.location.to_deprecated_string(),
-                'content': rendered_child.content
+                'content': rendered_child.content,
+                'group_id': updated_group_id,
             })
+
+        # Sort active and inactive contents by group name.
+        sorted_active_contents = sorted(active_contents, key=itemgetter('group_name'))
+        sorted_inactive_contents = sorted(inactive_contents, key=itemgetter('group_name'))
 
         # Use the new template
         fragment.add_content(self.system.render_template('split_test_staff_view.html', {
-            'items': contents,
+            'items': sorted_active_contents + sorted_inactive_contents,
         }))
         fragment.add_css('.split-test-child { display: none; }')
         fragment.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/split_test_staff.js'))

--- a/lms/templates/split_test_author_view.html
+++ b/lms/templates/split_test_author_view.html
@@ -5,7 +5,7 @@
 split_test = context.get('split_test')
 user_partition = split_test.descriptor.get_selected_partition()
 messages = split_test.descriptor.validation_messages()
-show_link = settings.FEATURES.get('ENABLE_GROUP_CONFIGURATIONS') and group_configuration_url is not None
+show_link = group_configuration_url is not None
 %>
 
 % if is_root and not is_configured:

--- a/lms/templates/split_test_staff_view.html
+++ b/lms/templates/split_test_staff_view.html
@@ -4,7 +4,7 @@
     <select class="split-test-select">
         % for idx, item in enumerate(items):
         ## Translators: The 'Group' here refers to the group of users that has been sorted into group_id
-        <option value="${item['group_id']}">${_("Group {group_id}").format(group_id=item['group_id'])}</option>
+        <option value="${item['group_id']}">${item['group_name']}</option>
         %endfor
     </select>
 


### PR DESCRIPTION
This fixes 
-  [BLD-1224](https://openedx.atlassian.net/browse/BLD-1224) Error split test rendering in LMS
- [BLD-1229](https://openedx.atlassian.net/browse/BLD-1229)  Do not hide Group Configuration editor behind feature flag

Root cause for BLD-1224 is that group_id_to_child contains deleted groups.
Other solution is to clean group_id_to_child of split_test when group was deleted from group configuration page. But this will affect publishing. So this solution was implemented but skipped.

@tymofij @cahrens please review.

Also this provides fix for https://openedx.atlassian.net/browse/BLD-1249.
