### PR TITLE
Add ENABLE_DISCUSSION_EMAIL_DIGEST feature

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -86,6 +86,7 @@ from bulk_email.models import Optout, CourseAuthorization
 import shoppingcart
 from openedx.core.djangoapps.user_api.models import UserPreference
 from lang_pref import LANGUAGE_KEY
+from notification_prefs.views import enable_notifications
 
 import track.views
 
@@ -1588,6 +1589,12 @@ def create_account(request, post_override=None):  # pylint: disable-msg=too-many
         return JsonResponse({'success': False, 'value': exc.message, 'field': exc.field}, status=400)
 
     (user, profile, registration) = ret
+
+    if settings.FEATURES.get('ENABLE_DISCUSSION_EMAIL_DIGEST'):
+        try:
+            enable_notifications(user)
+        except Exception:
+            log.exception("Enable discussion notifications failed for user {id}.".format(id=user.id))
 
     dog_stats_api.increment("common.student.account_created")
 

--- a/lms/djangoapps/notification_prefs/views.py
+++ b/lms/djangoapps/notification_prefs/views.py
@@ -90,6 +90,31 @@ class UsernameCipher(object):
         return UsernameCipher._remove_padding(decrypted)
 
 
+def enable_notifications(user):
+    """
+    Enable notifications for a user.
+    Currently only used for daily forum digests.
+    """
+    UserPreference.objects.get_or_create(
+        user=user,
+        key=NOTIFICATION_PREF_KEY,
+        defaults={
+            "value": UsernameCipher.encrypt(user.username)
+        }
+    )
+
+
+def disable_notifications(user):
+    """
+    Disable notifications for a user.
+    Currently only used for daily forum digests.
+    """
+    UserPreference.objects.filter(
+        user=user,
+        key=NOTIFICATION_PREF_KEY
+    ).delete()
+
+
 @require_POST
 def ajax_enable(request):
     """
@@ -103,13 +128,7 @@ def ajax_enable(request):
     if not request.user.is_authenticated():
         raise PermissionDenied
 
-    UserPreference.objects.get_or_create(
-        user=request.user,
-        key=NOTIFICATION_PREF_KEY,
-        defaults={
-            "value": UsernameCipher.encrypt(request.user.username)
-        }
-    )
+    enable_notifications(request.user)
 
     return HttpResponse(status=204)
 
@@ -125,10 +144,7 @@ def ajax_disable(request):
     if not request.user.is_authenticated():
         raise PermissionDenied
 
-    UserPreference.objects.filter(
-        user=request.user,
-        key=NOTIFICATION_PREF_KEY
-    ).delete()
+    disable_notifications(request.user)
 
     return HttpResponse(status=204)
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -103,6 +103,13 @@ FEATURES = {
     # this should remain off in production until digest notifications are online.
     'ENABLE_DISCUSSION_HOME_PANEL': False,
 
+    # Set this to True if you want the discussion digest emails enabled automatically for new users.
+    # This will be set on all new account registrations.
+    # It is not recommended to enable this feature if ENABLE_DISCUSSION_HOME_PANEL is not enabled, since
+    # subscribers who receive digests in that case will only be able to unsubscribe via links embedded
+    # in their emails, and they will have no way to resubscribe.
+    'ENABLE_DISCUSSION_EMAIL_DIGEST': False,
+
     'ENABLE_PSYCHOMETRICS': False,  # real-time psychometrics (eg item response theory analysis in instructor dashboard)
 
     'ENABLE_DJANGO_ADMIN_SITE': True,  # set true to enable django's admin site, even on prod (e.g. for course ops)


### PR DESCRIPTION
This PR adds a simple feature to enable discussion emails digest by default for all users. On account creation, if 
 ENABLE_DISCUSSION_EMAIL_DIGEST is set to True in settings, the process will set the notification_pref accordingly.

Question: I wonder if the setting name shouldn't be more generic for notifications. Is that setting used for anything else than discussion digest?

 @jimabramson @antoviaque
