### PR TITLE
path_to_location now returns 404 on orphaned items. Resolves LMS-9661.

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/search.py
+++ b/common/lib/xmodule/xmodule/modulestore/search.py
@@ -60,13 +60,13 @@ def path_to_location(modulestore, usage_key):
                 # Found it!
                 path = (next_usage, path)
                 return flatten(path)
+            elif parent is None:
+                # Orphaned item.
+                return None
 
             # otherwise, add parent locations at the end
             newpath = (next_usage, path)
             queue.append((parent, newpath))
-
-        # If we're here, there is no path
-        return None
 
     if not modulestore.has_item(usage_key):
         raise ItemNotFoundError(usage_key)


### PR DESCRIPTION
This resolves [LMS-9661](https://openedx.atlassian.net/browse/LMS-9661): AttributeError in jump_to_id.

The issue was that orphaned items could be matched, and because they are orphaned, no path to a parent course could be made. This patch should both fix the issue and provide a test to make sure it does not recur.

This is my first pull request. I have pre-emptively sent in my contributor agreement. Thanks in advance!

Internal reference: @antoviaque
