### PR TITLE
Fix: inadvertent scroll when loading the instructor's extensions tab

### DIFF
--- a/lms/static/coffee/src/instructor_dashboard/extensions.coffee
+++ b/lms/static/coffee/src/instructor_dashboard/extensions.coffee
@@ -70,7 +70,7 @@ class Extensions
       @clear_display()
       @$grid_table.text 'Loading...'
 
-      @$url_input = @$section.find("#view-extensions select[name='url']")
+      @$url_input = @$section.find("#view-granted-extensions select[name='url']")
       url = @$show_unit_extensions.data 'endpoint'
       send_data =
         url: @$url_input.val()
@@ -78,7 +78,7 @@ class Extensions
         dataType: 'json'
         url: url
         data: send_data
-        error: (xhr) => @fail_with_error "view-extensions", "Error getting due dates", xhr
+        error: (xhr) => @fail_with_error "view-granted-extensions", "Error getting due dates", xhr
         success: (data) => @display_grid data
 
     @$show_student_extensions.click =>
@@ -86,14 +86,14 @@ class Extensions
       @$grid_table.text 'Loading...'
 
       url = @$show_student_extensions.data 'endpoint'
-      @$student_input = @$section.find("#view-extensions input[name='student']")
+      @$student_input = @$section.find("#view-granted-extensions input[name='student']")
       send_data =
         student: @$student_input.val()
       $.ajax
         dataType: 'json'
         url: url
         data: send_data
-        error: (xhr) => @fail_with_error "view-extensions", "Error getting due dates", xhr
+        error: (xhr) => @fail_with_error "view-granted-extensions", "Error getting due dates", xhr
         success: (data) => @display_grid data
       
   # handler for when the section title is clicked.

--- a/lms/templates/instructor/instructor_dashboard_2/extensions.html
+++ b/lms/templates/instructor/instructor_dashboard_2/extensions.html
@@ -39,7 +39,7 @@
   </p>
 </div>
 <hr/>
-<div id="view-extensions">
+<div id="view-granted-extensions">
   <h2>${_("Viewing granted extensions")}</h2>
   <p>
     ${_("Here you can see what extensions have been granted on particular "


### PR DESCRIPTION
This minor commit fixes an annoying UI bug with the individual due date extensions, [mentioned](https://github.com/edx/edx-platform/pull/4868#issuecomment-52525852) to me by @sarina in #4868. Whenever an instructor clicked on the "Extensions" tab, the browser would scroll down. This was due to a div having id "view-extensions", conflicting with the tabs script which sets location.hash to "view-[current tab name]" in order to track the current tab.

This was done for OpenCraft ( cc @antoviaque ) and falls under their organization contributor agreement.
