### PR TITLE
Add placeholders for text input on Extensions dash feature

### DIFF
--- a/lms/templates/instructor/instructor_dashboard_2/extensions.html
+++ b/lms/templates/instructor/instructor_dashboard_2/extensions.html
@@ -12,7 +12,7 @@
   <p>
     ${_("Specify the {platform_name} email address or username of a student "
         "here:").format(platform_name=settings.PLATFORM_NAME)}
-    <input type="text" name="student">
+    <input type="text" name="student" placeholder="${_("Student Email or Username")}">
   </p>
   <p>
     ${_("Choose the graded unit:")}
@@ -67,7 +67,7 @@
   <p>
     ${_("Specify the {platform_name} email address or username of a student "
         "here:").format(platform_name=settings.PLATFORM_NAME)}
-    <input type="text" name="student">
+    <input type="text" name="student" placeholder="${_("Student Email or Username")}">
     <input type="button" name="show-student-extensions" 
            value="${_("List date extensions for student")}"
            data-endpoint="${section_data['show_student_extensions_url']}">
@@ -90,7 +90,7 @@
   <p>
     ${_("Specify the {platform_name} email address or username of a student "
         "here:").format(platform_name=settings.PLATFORM_NAME)}
-    <input type="text" name="student">
+    <input type="text" name="student" placeholder="${_("Student Email or Username")}">
   </p>
   <p>
     ${_("Choose the graded unit:")}


### PR DESCRIPTION
I noticed this while reviewing the recent PRs from @bradenmacdonald. This PR adds in placeholders on the text input fields which increases accessibility:
![screen shot 2014-08-20 at 12 02 30 pm](https://cloud.githubusercontent.com/assets/1985317/3983917/a3b51f50-2883-11e4-8fb9-b808166d746a.png)

The text and styling is the same as other places on the instructor dashboard:
![screen shot 2014-08-20 at 12 02 42 pm](https://cloud.githubusercontent.com/assets/1985317/3983922/ae184012-2883-11e4-99b6-be16196e67d7.png)

@bradenmacdonald  and @carsongee would you mind taking a look?
