### PR TITLE
Fix Studio to gracefully handle xblock JavaScript errors

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -22,12 +22,12 @@
     "nonbsp"          : true,      // Warns about "non-breaking whitespace" characters.
     "nonew"           : true,      // Prohibits the use of constructor functions for side-effects.
     "plusplus"        : false,     // Prohibits the use of unary increment and decrement operators.
-    "quotmark"        : "single",  // Enforces the consistency of quotation marks used throughout your code. It accepts three values: true, "single", and "double".
+    "quotmark"        : false,     // Enforces the consistency of quotation marks used throughout your code. It accepts three values: true, "single", and "double".
     "undef"           : true,      // Prohibits the use of explicitly undeclared variables.
     "unused"          : true,      // Warns when you define and never use your variables.
     "strict"          : true,      // Requires all functions to run in ECMAScript 5's strict mode.
     "trailing"        : true,      // Makes it an error to leave a trailing whitespace in your code.
-    "maxlen"          : 80,        // Lets you set the maximum length of a line.
+    "maxlen"          : 120,       // Lets you set the maximum length of a line.
     //"maxparams"     : 4,         // Lets you set the max number of formal parameters allowed per function.
     //"maxdepth"      : 4,         // Lets you control how nested do you want your blocks to be.
     //"maxstatements" : 4,         // Lets you set the max number of statements allowed per function.
@@ -59,7 +59,7 @@
     "shadow"        : false,       // Suppresses warnings about variable shadowing i.e. declaring a variable that had been already declared somewhere in the outer scope.
     "sub"           : false,       // Suppresses warnings about using [] notation when it can be expressed in dot notation.
     "supernew"      : false,       // Suppresses warnings about "weird" constructions like new function () { ... } and new Object;.
-    "validthis"     : true,       // Suppresses warnings about possible strict violations when the code is running in strict mode and you use this in a non-constructor function.
+    "validthis"     : true,        // Suppresses warnings about possible strict violations when the code is running in strict mode and you use this in a non-constructor function.
     "noyield"       : false,       // Suppresses warnings about generator functions with no yield statement in them.
 
 
@@ -73,11 +73,11 @@
     // The rest should remain `false`. Please see explanation for the "predef" parameter below.
     "couch"         : false,       // Defines globals exposed by CouchDB.
     "dojo"          : false,       // Defines globals exposed by the Dojo Toolkit
-    "jquery"        : false,        // Defines globals exposed by the jQuery JavaScript library.
+    "jquery"        : false,       // Defines globals exposed by the jQuery JavaScript library.
     "mootools"      : false,       // Defines globals exposed by the MooTools JavaScript framework.
     "node"          : false,       // Defines globals available when your code is running inside of the Node runtime environment.
     "nonstandard"   : false,       // Defines non-standard but widely adopted globals such as escape and unescape.
-    "phantom"       : false,        // Defines globals available when your core is running inside of the PhantomJS runtime environment.
+    "phantom"       : false,       // Defines globals available when your core is running inside of the PhantomJS runtime environment.
     "prototypejs"   : false,       // Defines globals exposed by the Prototype JavaScript framework.
     "rhino"         : false,       // Defines globals available when your code is running inside of the Rhino runtime environment.
     "worker"        : false,       // Defines globals available when your code is running inside of a Web Worker.

--- a/cms/static/js/spec/views/modals/edit_xblock_spec.js
+++ b/cms/static/js/spec/views/modals/edit_xblock_spec.js
@@ -71,8 +71,8 @@ define(["jquery", "underscore", "js/spec_helpers/create_sinon", "js/spec_helpers
                             refreshed = true;
                         };
                     modal = showModal(requests, mockXBlockEditorHtml, { refresh: refresh });
-                    modal.runtime.notify('save', { state: 'start' });
-                    modal.runtime.notify('save', { state: 'end' });
+                    modal.editorView.notifyRuntime('save', { state: 'start' });
+                    modal.editorView.notifyRuntime('save', { state: 'end' });
                     expect(edit_helpers.isShowingModal(modal)).toBeFalsy();
                     expect(refreshed).toBeTruthy();
                 });
@@ -84,7 +84,7 @@ define(["jquery", "underscore", "js/spec_helpers/create_sinon", "js/spec_helpers
                             refreshed = true;
                         };
                     modal = showModal(requests, mockXBlockEditorHtml, { refresh: refresh });
-                    modal.runtime.notify('cancel');
+                    modal.editorView.notifyRuntime('cancel');
                     expect(edit_helpers.isShowingModal(modal)).toBeFalsy();
                     expect(refreshed).toBeFalsy();
                 });

--- a/cms/static/js/views/modals/edit_xblock.js
+++ b/cms/static/js/views/modals/edit_xblock.js
@@ -65,15 +65,10 @@ define(["jquery", "underscore", "gettext", "js/views/modals/base_modal", "js/vie
 
             onDisplayXBlock: function() {
                 var editorView = this.editorView,
-                    title = this.getTitle(),
-                    xblock = editorView.xblock,
-                    runtime = xblock.runtime;
+                    title = this.getTitle();
 
                 // Notify the runtime that the modal has been shown
-                if (runtime) {
-                    this.runtime = runtime;
-                    runtime.notify('modal-shown', this);
-                }
+                editorView.notifyRuntime('modal-shown', this);
 
                 // Update the modal's header
                 if (editorView.hasCustomTabs()) {
@@ -93,7 +88,7 @@ define(["jquery", "underscore", "gettext", "js/views/modals/base_modal", "js/vie
                 // If the xblock is not using custom buttons then choose which buttons to show
                 if (!editorView.hasCustomButtons()) {
                     // If the xblock does not support save then disable the save button
-                    if (!xblock.save) {
+                    if (!editorView.xblock.save) {
                         this.disableSave();
                     }
                     this.getActionBar().show();
@@ -175,9 +170,7 @@ define(["jquery", "underscore", "gettext", "js/views/modals/base_modal", "js/vie
                 BaseModal.prototype.hide.call(this);
 
                 // Notify the runtime that the modal has been hidden
-                if (this.runtime) {
-                    this.runtime.notify('modal-hidden');
-                }
+                this.editorView.notifyRuntime('modal-hidden');
             },
 
             findXBlockInfo: function(xblockWrapperElement, defaultXBlockInfo) {

--- a/cms/static/js/views/xblock.js
+++ b/cms/static/js/views/xblock.js
@@ -29,34 +29,58 @@ define(["jquery", "underscore", "js/views/baseview", "xblock/runtime.v1"],
                 var self = this,
                     wrapper = this.$el,
                     xblockElement,
-                    success = options ? options.success : null,
+                    successCallback = options ? options.success || options.done : null,
+                    errorCallback = options ? options.error || options.done : null,
                     xblock,
                     fragmentsRendered;
 
                 fragmentsRendered = this.renderXBlockFragment(fragment, wrapper);
-                fragmentsRendered.done(function() {
+                fragmentsRendered.always(function() {
                     xblockElement = self.$('.xblock').first();
-                    xblock = XBlock.initializeBlock(xblockElement);
-                    self.xblock = xblock;
-                    self.xblockReady(xblock);
-                    if (success) {
-                        success(xblock);
+                    try {
+                        xblock = XBlock.initializeBlock(xblockElement);
+                        self.xblock = xblock;
+                        self.xblockReady(xblock);
+                        if (successCallback) {
+                            successCallback(xblock);
+                        }
+                    } catch (e) {
+                        console.error(e.stack);
+                        // Add 'xblock-initialization-failed' class to every xblock
+                        self.$('.xblock').addClass('xblock-initialization-failed');
+
+                        // If the xblock was rendered but failed then still call xblockReady to allow
+                        // drag-and-drop to be initialized.
+                        if (xblockElement) {
+                            self.xblockReady(null);
+                        }
+                        if (errorCallback) {
+                            errorCallback();
+                        }
                     }
                 });
             },
 
             /**
-             * This method is called upon successful rendering of an xblock.
+             * Sends a notification event to the runtime, if one is available. Note that the runtime
+             * is only available once the xblock has been rendered and successfully initialized.
+             * @param eventName The name of the event to be fired.
+             * @param data The data to be passed to any listener's of the event.
              */
-            xblockReady: function(xblock) {
-                // Do nothing
+            notifyRuntime: function(eventName, data) {
+                var runtime = this.xblock && this.xblock.runtime;
+                if (runtime) {
+                    runtime.notify(eventName, data);
+                }
             },
 
             /**
-             * Returns true if the specified xblock has children.
+             * This method is called upon successful rendering of an xblock. Note that the xblock
+             * may have thrown JavaScript errors after rendering in which case the xblock parameter
+             * will be null.
              */
-            hasChildXBlocks: function() {
-                return this.$('.wrapper-xblock').length > 0;
+            xblockReady: function(xblock) {
+                // Do nothing
             },
 
             /**
@@ -77,9 +101,16 @@ define(["jquery", "underscore", "js/views/baseview", "xblock/runtime.v1"],
                 }
 
                 // Render the HTML first as the scripts might depend upon it, and then
-                // asynchronously add the resources to the page.
-                this.updateHtml(element, html);
-                return this.addXBlockFragmentResources(resources);
+                // asynchronously add the resources to the page. Any errors that are thrown
+                // by included scripts are logged to the console but are then ignored assuming
+                // that at least the rendered HTML will be in place.
+                try {
+                    this.updateHtml(element, html);
+                    return this.addXBlockFragmentResources(resources);
+                } catch(e) {
+                    console.error(e.stack);
+                    return $.Deferred().resolve();
+                }
             },
 
             /**
@@ -106,7 +137,7 @@ define(["jquery", "underscore", "js/views/baseview", "xblock/runtime.v1"],
                 numResources = resources.length;
                 deferred = $.Deferred();
                 applyResource = function(index) {
-                    var hash, resource, head, value, promise;
+                    var hash, resource, value, promise;
                     if (index >= numResources) {
                         deferred.resolve();
                         return;

--- a/cms/templates/js/mock/mock-bad-javascript-container-xblock.underscore
+++ b/cms/templates/js/mock/mock-bad-javascript-container-xblock.underscore
@@ -1,0 +1,54 @@
+<header class="xblock-header">
+    <div class="xblock-header-primary">
+        <div class="header-details">
+            <span class="xblock-display-name">Test Container</span>
+        </div>
+        <div class="header-actions">
+            <ul class="actions-list">
+            </ul>
+        </div>
+    </div>
+</header>
+<article class="xblock-render">
+    <div class="xblock" data-locator="locator-container"
+         data-init="MockXBlock" data-runtime-class="StudioRuntime" data-runtime-version="1">
+        <ol class="reorderable-container">
+            <li class="studio-xblock-wrapper is-draggable" data-locator="locator-broken-javascript">
+                <section class="wrapper-xblock level-element">
+                    <header class="xblock-header">
+                        <div class="xblock-header-primary">
+                            <div class="header-actions">
+                                <ul class="actions-list">
+                                    <li class="action-item action-edit">
+                                        <a href="#" class="edit-button action-button"></a>
+                                    </li>
+                                    <li class="action-item action-duplicate">
+                                        <a href="#" class="duplicate-button action-button"></a>
+                                    </li>
+                                    <li class="action-item action-delete">
+                                        <a href="#" class="delete-button action-button"></a>
+                                    </li>
+                                    <li class="action-item action-drag">
+                                        <span data-tooltip="Drag to reorder" class="drag-handle action"></span>
+                                    </li>
+                                </ul>
+                            </div>
+                        </div>
+                    </header>
+
+                    <article class="xblock-render">
+                        <div class="xblock xblock-student_view xmodule_display xmodule_HtmlModule"
+                             data-runtime-class="PreviewRuntime" data-init="XBlockToXModuleShim"
+                             data-request-token="5efb4488272611e48053080027880ca6" data-runtime-version="1"
+                             data-usage-id="i4x:;_;_edX;_mock"
+                             data-type="HTMLModule" data-block-type="html">
+                            <script type="text/javascript">
+                            noSuchVariable.noSuchFunction();
+                            </script>
+                        </div>
+                    </article>
+                </section>
+            </li>
+        </ol>
+    </div>
+</article>

--- a/cms/templates/js/mock/mock-bad-xblock-container-xblock.underscore
+++ b/cms/templates/js/mock/mock-bad-xblock-container-xblock.underscore
@@ -1,0 +1,51 @@
+<header class="xblock-header">
+    <div class="xblock-header-primary">
+        <div class="header-details">
+            <span class="xblock-display-name">Test Container</span>
+        </div>
+        <div class="header-actions">
+            <ul class="actions-list">
+            </ul>
+        </div>
+    </div>
+</header>
+<article class="xblock-render">
+    <div class="xblock" data-locator="locator-container"
+         data-init="MockXBlock" data-runtime-class="StudioRuntime" data-runtime-version="1">
+        <ol class="reorderable-container">
+            <li class="studio-xblock-wrapper is-draggable" data-locator="locator-broken-javascript">
+                <section class="wrapper-xblock level-element">
+                    <header class="xblock-header">
+                        <div class="xblock-header-primary">
+                            <div class="header-actions">
+                                <ul class="actions-list">
+                                    <li class="action-item action-edit">
+                                        <a href="#" class="edit-button action-button"></a>
+                                    </li>
+                                    <li class="action-item action-duplicate">
+                                        <a href="#" class="duplicate-button action-button"></a>
+                                    </li>
+                                    <li class="action-item action-delete">
+                                        <a href="#" class="delete-button action-button"></a>
+                                    </li>
+                                    <li class="action-item action-drag">
+                                        <span data-tooltip="Drag to reorder" class="drag-handle action"></span>
+                                    </li>
+                                </ul>
+                            </div>
+                        </div>
+                    </header>
+
+                    <article class="xblock-render">
+                        <div class="xblock xblock-student_view xmodule_display xmodule_HtmlModule"
+                             data-runtime-class="InvalidRuntime" data-init="XBlockToXModuleShim"
+                             data-request-token="5efb4488272611e48053080027880ca6" data-runtime-version="1"
+                             data-usage-id="i4x:;_;_edX;_mock"
+                             data-type="HTMLModule" data-block-type="html">
+                        </div>
+                    </article>
+                </section>
+            </li>
+        </ol>
+    </div>
+</article>

--- a/cms/templates/js/mock/mock-container-xblock.underscore
+++ b/cms/templates/js/mock/mock-container-xblock.underscore
@@ -14,7 +14,7 @@
          data-init="MockXBlock" data-runtime-class="StudioRuntime" data-runtime-version="1">
         <ol class="reorderable-container">
             <li class="studio-xblock-wrapper is-draggable" data-locator="locator-group-A">
-                <section class="wrapper-xblock level-nesting" data-locator="locator-group-A">
+                <section class="wrapper-xblock level-nesting">
                     <header class="xblock-header">
                         <div class="xblock-header-primary">
                             <div class="header-details">
@@ -38,8 +38,7 @@
                         <div class="xblock" data-request-token="page-render-token">
                             <ol class="reorderable-container">
                                 <li class="studio-xblock-wrapper is-draggable" data-locator="locator-component-A1">
-                                    <section class="wrapper-xblock level-element"
-                                             data-locator="locator-component-A1">
+                                    <section class="wrapper-xblock level-element">
                                         <header class="xblock-header">
                                             <div class="xblock-header-primary">
                                                 <div class="header-actions">
@@ -64,9 +63,7 @@
                                     </section>
                                 </li>
                                 <li class="studio-xblock-wrapper is-draggable" data-locator="locator-component-A2">
-                                    <section class="wrapper-xblock level-element"
-                                             data-locator="locator-component-A2">
-
+                                    <section class="wrapper-xblock level-element">
                                         <header class="xblock-header">
                                             <div class="header-actions">
                                                 <div class="xblock-header-primary">
@@ -91,8 +88,7 @@
                                     </section>
                                 </li>
                                 <li class="studio-xblock-wrapper is-draggable" data-locator="locator-component-A3">
-                                    <section class="wrapper-xblock level-element"
-                                             data-locator="locator-component-A3">
+                                    <section class="wrapper-xblock level-element">
                                         <header class="xblock-header">
                                             <div class="xblock-header-primary">
                                                 <div class="header-actions">
@@ -123,7 +119,7 @@
                 </section>
             </li>
             <li class="studio-xblock-wrapper is-draggable" data-locator="locator-group-B">
-                <section class="wrapper-xblock level-nesting" data-locator="locator-group-B">
+                <section class="wrapper-xblock level-nesting">
                     <header class="xblock-header">
                         <div class="xblock-header-primary">
                             <div class="header-details">
@@ -147,9 +143,7 @@
                         <div class="xblock" data-request-token="page-render-token">
                             <ol class="reorderable-container">
                                 <li class="studio-xblock-wrapper is-draggable" data-locator="locator-component-B1">
-                                    <section class="wrapper-xblock level-element"
-                                             data-locator="locator-component-B1">
-
+                                    <section class="wrapper-xblock level-element">
                                         <header class="xblock-header">
                                             <div class="xblock-header-primary">
                                                 <div class="header-actions">
@@ -174,9 +168,7 @@
                                     </section>
                                 </li>
                                 <li class="studio-xblock-wrapper is-draggable" data-locator="locator-component-B2">
-                                    <section class="wrapper-xblock level-element"
-                                             data-locator="locator-component-B2">
-
+                                    <section class="wrapper-xblock level-element">
                                         <header class="xblock-header">
                                             <div class="xblock-header-primary">
                                                 <div class="header-actions">
@@ -201,9 +193,7 @@
                                     </section>
                                 </li>
                                 <li class="studio-xblock-wrapper is-draggable" data-locator="locator-component-B3">
-                                    <section class="wrapper-xblock level-element"
-                                             data-locator="locator-component-B3">
-
+                                    <section class="wrapper-xblock level-element">
                                         <header class="xblock-header">
                                             <div class="xblock-header-primary">
                                                 <div class="header-actions">

--- a/cms/templates/js/mock/mock-xmodule-editor-with-custom-tabs.underscore
+++ b/cms/templates/js/mock/mock-xmodule-editor-with-custom-tabs.underscore
@@ -1,11 +1,17 @@
-<div class="xblock xblock-studio_view xmodule_edit xmodule_WrapperDescriptor" data-runtime-class="StudioRuntime" data-init="XBlockToXModuleShim" data-runtime-version="1" data-usage-id="i4x:;_;_AndyA;_ABT101;_wrapper;_wrapper_l1_poll" data-type="VerticalDescriptor" tabindex="0">
+<div class="xblock xblock-studio_view xmodule_edit xmodule_WrapperDescriptor" data-runtime-class="StudioRuntime"
+     data-init="XBlockToXModuleShim" data-runtime-version="1" data-usage-id="i4x:;_;_edX;_mock"
+     data-type="VerticalDescriptor" tabindex="0">
     <div class="wrapper-comp-editor is-active" id="editor-tab" data-base-asset-url="/c4x/AndyA/ABT101/asset/">
 <section class="editor-with-tabs">
      <div class="edit-header">
         <span class="component-name"></span>
         <ul class="editor-tabs">
-            <li class="inner_tab_wrap"><a href="#tab-i4x-testCourse-video-84c6bf5dc2a24bc7996771eb7a1a4ad1-0" class="tab current">Basic</a></li>
-            <li class="inner_tab_wrap"><a href="#tab-i4x-testCourse-video-84c6bf5dc2a24bc7996771eb7a1a4ad1-1" class="tab">Advanced</a></li>
+            <li class="inner_tab_wrap">
+                <a href="#tab-i4x-testCourse-video-84c6bf5dc2a24bc7996771eb7a1a4ad1-0" class="tab current">Basic</a>
+            </li>
+            <li class="inner_tab_wrap">
+                <a href="#tab-i4x-testCourse-video-84c6bf5dc2a24bc7996771eb7a1a4ad1-1" class="tab">Advanced</a>
+            </li>
         </ul>
       </div>
       <div class="tabs-wrapper">

--- a/cms/templates/js/mock/mock-xmodule-editor.underscore
+++ b/cms/templates/js/mock/mock-xmodule-editor.underscore
@@ -1,4 +1,6 @@
-<div class="xblock xblock-studio_view xmodule_edit xmodule_WrapperDescriptor" data-runtime-class="StudioRuntime" data-init="XBlockToXModuleShim" data-runtime-version="1" data-usage-id="i4x:;_;_AndyA;_ABT101;_wrapper;_wrapper_l1_poll" data-type="MockDescriptor" tabindex="0">
+<div class="xblock xblock-studio_view xmodule_edit xmodule_WrapperDescriptor" data-runtime-class="StudioRuntime"
+     data-init="XBlockToXModuleShim" data-runtime-version="1" data-usage-id="i4x:;_;_edX;_mock"
+     data-type="MockDescriptor" tabindex="0">
     <div class="wrapper-comp-editor is-active" id="editor-tab" data-base-asset-url="/c4x/AndyA/ABT101/asset/">
     </div>
     <section class="sequence-edit">
@@ -24,7 +26,8 @@
 
         </script>
 
-        <div class="wrapper-comp-settings metadata_edit" id="settings-tab" data-metadata='{&#34;display_name&#34;: {&#34;default_value&#34;: null, &#34;explicitly_set&#34;: true, &#34;display_name&#34;: &#34;Display Name&#34;, &#34;help&#34;: &#34;This name appears in the horizontal navigation at the top of the page.&#34;, &#34;type&#34;: &#34;Generic&#34;, &#34;value&#34;: &#34;Poll Question&#34;, &#34;field_name&#34;: &#34;display_name&#34;, &#34;options&#34;: []}, &#34;due&#34;: {&#34;default_value&#34;: null, &#34;explicitly_set&#34;: false, &#34;display_name&#34;: &#34;due&#34;, &#34;help&#34;: &#34;Date that this problem is due by&#34;, &#34;type&#34;: &#34;Generic&#34;, &#34;value&#34;: null, &#34;field_name&#34;: &#34;due&#34;, &#34;options&#34;: []}}'/>
+        <div class="wrapper-comp-settings metadata_edit" id="settings-tab"
+             data-metadata='{&#34;display_name&#34;: {&#34;default_value&#34;: null, &#34;explicitly_set&#34;: true, &#34;display_name&#34;: &#34;Display Name&#34;, &#34;help&#34;: &#34;This name appears in the horizontal navigation at the top of the page.&#34;, &#34;type&#34;: &#34;Generic&#34;, &#34;value&#34;: &#34;Poll Question&#34;, &#34;field_name&#34;: &#34;display_name&#34;, &#34;options&#34;: []}, &#34;due&#34;: {&#34;default_value&#34;: null, &#34;explicitly_set&#34;: false, &#34;display_name&#34;: &#34;due&#34;, &#34;help&#34;: &#34;Date that this problem is due by&#34;, &#34;type&#34;: &#34;Generic&#34;, &#34;value&#34;: null, &#34;field_name&#34;: &#34;due&#34;, &#34;options&#34;: []}}'/>
         <textarea data-metadata-name="custom_field">Custom Value</textarea>
     </section>
 </div>

--- a/common/test/acceptance/tests/test_studio_bad_data.py
+++ b/common/test/acceptance/tests/test_studio_bad_data.py
@@ -95,8 +95,7 @@ class JSErrorBadContentTest(BadComponentTest):
     """
     Tests that components that throw JS errors do not break the Unit page.
     """
-    # TODO: ENABLE TEST WITH ANDY'S PR
-    __test__ = False
+    __test__ = True
 
     def get_bad_html_content(self):
         """


### PR DESCRIPTION
TNL-46

I've changed Studio to catch JavaScript errors when rendering xblocks, log the error, but to then continue as normal. This means that the user is still able to interact with the xblock to delete, duplicate etc. This seems reasonable as the xblock is only rendered as a WYSIWYG representation so if it isn't fully interactive that shouldn't be a big problem.
