### PR TITLE
Studio: FIX - Unit/Container Sidebar Content Wrapping

### DIFF
--- a/cms/static/sass/views/_container.scss
+++ b/cms/static/sass/views/_container.scss
@@ -150,6 +150,10 @@
         .user {
           @extend %t-strong;
         }
+
+        .user {
+          @extend %cont-text-wrap;
+        }
       }
 
       .wrapper-release {
@@ -225,6 +229,10 @@
         .user {
           @extend %t-strong;
         }
+
+        .user {
+          @extend %cont-text-wrap;
+        }
       }
     }
 
@@ -236,8 +244,10 @@
       .wrapper-unit-id {
 
         .unit-id-value {
+          @extend %cont-text-wrap;
           @extend %t-copy-sub1;
           display: inline-block;
+          width: 100%;
         }
 
         .tip {
@@ -264,6 +274,10 @@
           .subsection-header {
             margin-bottom: ($baseline/2);
           }
+        }
+
+        .item-title {
+          @extend %cont-text-wrap;
         }
 
         .item-title a {

--- a/common/static/sass/_mixins.scss
+++ b/common/static/sass/_mixins.scss
@@ -365,9 +365,6 @@
 
 // extends - content - wrapping
 %cont-text-wrap {
-  text-wrap: wrap;
-  white-space: pre-wrap;
-  white-space: -moz-pre-wrap;
   word-wrap: break-word;
 }
 


### PR DESCRIPTION
This work resolves issues with user and unit IDs extending past the unit/container sidebar UI's width (STUD-2113) and also updates the Sass placeholder used to rely on modern CSS specs/properties.

https://openedx.atlassian.net/browse/STUD-2113
