### PR TITLE
Allow one group in a group configuration (BLD-1223)

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -1134,8 +1134,8 @@ class GroupConfiguration(object):
         """
         if not self.configuration.get("name"):
             raise GroupConfigurationsValidationError(_("must have name of the configuration"))
-        if len(self.configuration.get('groups', [])) < 2:
-            raise GroupConfigurationsValidationError(_("must have at least two groups"))
+        if len(self.configuration.get('groups', [])) < 1:
+            raise GroupConfigurationsValidationError(_("must have at least one group"))
 
     def generate_id(self, used_ids):
         """

--- a/cms/djangoapps/contentstore/views/tests/test_group_configurations.py
+++ b/cms/djangoapps/contentstore/views/tests/test_group_configurations.py
@@ -121,13 +121,11 @@ class GroupConfigurationsBaseTestCase(object):
                     {u'name': u'Group B'},
                 ],
             },
-            # must have at least two groups
+            # must have at least one group
             {
                 u'name': u'Test name',
                 u'description': u'Test description',
-                u'groups': [
-                    {u'name': u'Group A'},
-                ],
+                u'groups': [],
             },
             # an empty json
             {},

--- a/cms/static/js/models/group_configuration.js
+++ b/cms/static/js/models/group_configuration.js
@@ -80,14 +80,14 @@ function(Backbone, _, str, gettext, GroupModel, GroupCollection) {
         validate: function(attrs) {
             if (!_.str.trim(attrs.name)) {
                 return {
-                    message: gettext('Group Configuration name is required'),
+                    message: gettext('Group Configuration name is required.'),
                     attributes: {name: true}
                 };
             }
 
-            if (attrs.groups.length < 2) {
+            if (attrs.groups.length < 1) {
                 return {
-                    message: gettext('There must be at least two groups'),
+                    message: gettext('There must be at least one group.'),
                     attributes: { groups: true }
                 };
             } else {
@@ -100,7 +100,7 @@ function(Backbone, _, str, gettext, GroupModel, GroupCollection) {
                 });
                 if (!_.isEmpty(invalidGroups)) {
                     return {
-                        message: gettext('All groups must have a name'),
+                        message: gettext('All groups must have a name.'),
                         attributes: { groups: invalidGroups }
                     };
                 }

--- a/cms/static/js/spec/models/group_configuration_spec.js
+++ b/cms/static/js/spec/models/group_configuration_spec.js
@@ -183,15 +183,14 @@ define([
                 expect(model.isValid()).toBeTruthy();
             });
 
-            it('requires at least two groups', function() {
+            it('requires at least one group', function() {
                 var group1 = new GroupModel({ name: 'Group A' }),
-                    group2 = new GroupModel({ name: 'Group B' }),
                     model = new GroupConfigurationModel({ name: 'foo' });
 
-                model.get('groups').reset([group1]);
+                model.get('groups').reset([]);
                 expect(model.isValid()).toBeFalsy();
 
-                model.get('groups').add(group2);
+                model.get('groups').add(group1);
                 expect(model.isValid()).toBeTruthy();
             });
 


### PR DESCRIPTION
Allow one group in a group configuration (instead of requiring two)

Issue: [BLD-1223](https://openedx.atlassian.net/browse/BLD-1223)

**Acceptance criteria:**
- remove the restriction that a group configuration must have 2 groups.
- still validate to make sure at least one group is present

**Sandbox:** http://studio.olmar.m.sandbox.edx.org/

**Reviewers:** @tymofij @cahrens @explorerleslie 
