### PR TITLE
Fixed analytics counts on instructor dashboard.

### DIFF
--- a/lms/djangoapps/instructor_analytics/distributions.py
+++ b/lms/djangoapps/instructor_analytics/distributions.py
@@ -123,6 +123,7 @@ def profile_distribution(course_id, feature):
             """ Get the count of enrolled students matching the feature value. """
             return CourseEnrollment.objects.filter(
                 course_id=course_id,
+                is_active=True,
                 **get_filter(feature, value)
             ).count()
 
@@ -141,7 +142,8 @@ def profile_distribution(course_id, feature):
     elif feature in _OPEN_CHOICE_FEATURES:
         prd.type = 'OPEN_CHOICE'
         profiles = UserProfile.objects.filter(
-            user__courseenrollment__course_id=course_id
+            user__courseenrollment__course_id=course_id,
+            user__courseenrollment__is_active=True
         )
         query_distribution = profiles.values(
             feature).annotate(Count(feature)).order_by()

--- a/lms/djangoapps/instructor_analytics/tests/test_distributions.py
+++ b/lms/djangoapps/instructor_analytics/tests/test_distributions.py
@@ -17,6 +17,7 @@ class TestAnalyticsDistributions(TestCase):
 
         self.users = [UserFactory(
             profile__gender=['m', 'f', 'o'][i % 3],
+            profile__level_of_education=['a', 'hs', 'el'][i % 3],
             profile__year_of_birth=i + 1930
         ) for i in xrange(30)]
 
@@ -48,6 +49,26 @@ class TestAnalyticsDistributions(TestCase):
         self.assertEqual(distribution.choices_display_names, None)
         self.assertNotIn('no_data', distribution.data)
         self.assertEqual(distribution.data[1930], 1)
+
+    def test_gender_count(self):
+        course_enrollments = CourseEnrollment.objects.filter(
+            course_id=self.course_id, user__profile__gender='m'
+        )
+        distribution = profile_distribution(self.course_id, "gender")
+        self.assertEqual(distribution.data['m'], len(course_enrollments))
+        course_enrollments[0].deactivate()
+        distribution = profile_distribution(self.course_id, "gender")
+        self.assertEqual(distribution.data['m'], len(course_enrollments) - 1)
+
+    def test_level_of_education_count(self):
+        course_enrollments = CourseEnrollment.objects.filter(
+            course_id=self.course_id, user__profile__level_of_education='hs'
+        )
+        distribution = profile_distribution(self.course_id, "level_of_education")
+        self.assertEqual(distribution.data['hs'], len(course_enrollments))
+        course_enrollments[0].deactivate()
+        distribution = profile_distribution(self.course_id, "level_of_education")
+        self.assertEqual(distribution.data['hs'], len(course_enrollments) - 1)
 
 
 class TestAnalyticsDistributionsNoData(TestCase):


### PR DESCRIPTION
LMS-11228

On instructor dashboard analytics the breakdown by gender and education numbers are calculated against the number of users ever enrolled in the course instead of the number of users currently enrolled in the course.
Fixed by adding filter for only active course enrolments. Added couple of unit tests.
