### PR TITLE
Fix for TNL-147

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -176,3 +176,4 @@ Jonathan Piacenti <kelketek@gmail.com>
 Alasdair Swan <aswan@edx.org>
 Paul Medlock-Walton <paulmw@mit.edu>
 Henry Tareque <henry.tareque@gmail.com>
+Eugeny Kolpakov <eugeny.kolpakov@gmail.com>

--- a/cms/djangoapps/contentstore/features/html-editor.feature
+++ b/cms/djangoapps/contentstore/features/html-editor.feature
@@ -105,6 +105,14 @@ Feature: CMS.HTML Editor
       <li>zzzz<ol>
       """
 
+  Scenario: Font selection dropdown contains Default font and tinyMCE builtin fonts
+    Given I have created a Blank HTML Page
+    When I edit the page
+    And I click font selection dropdown
+    Then I should see a list of available fonts
+    And "Default" option sets "'Open Sans', Verdana, Arial, Helvetica, sans-serif" font family
+    And all standard tinyMCE fonts should be available
+
 # Skipping in master due to brittleness JZ 05/22/2014
 #  Scenario: Can switch from Visual Editor to Raw
 #    Given I have created a Blank HTML Page

--- a/common/lib/xmodule/xmodule/js/src/html/edit.coffee
+++ b/common/lib/xmodule/xmodule/js/src/html/edit.coffee
@@ -1,5 +1,30 @@
 class @HTMLEditingDescriptor
 
+  # custom fonts are prepended to font selection dropdown
+  CUSTOM_FONTS = "Default='Open Sans', Verdana, Arial, Helvetica, sans-serif;"
+
+  # list of standard tinyMCE fonts: http://www.tinymce.com/wiki.php/Configuration:font_formats
+  STANDARD_FONTS = "Andale Mono=andale mono,times;"+
+    "Arial=arial,helvetica,sans-serif;"+
+    "Arial Black=arial black,avant garde;"+
+    "Book Antiqua=book antiqua,palatino;"+
+    "Comic Sans MS=comic sans ms,sans-serif;"+
+    "Courier New=courier new,courier;"+
+    "Georgia=georgia,palatino;"+
+    "Helvetica=helvetica;"+
+    "Impact=impact,chicago;"+
+    "Symbol=symbol;"+
+    "Tahoma=tahoma,arial,helvetica,sans-serif;"+
+    "Terminal=terminal,monaco;"+
+    "Times New Roman=times new roman,times;"+
+    "Trebuchet MS=trebuchet ms,geneva;"+
+    "Verdana=verdana,geneva;"+
+    "Webdings=webdings;"+
+    "Wingdings=wingdings,zapf dingbats"
+
+  _getFonts = () ->
+    CUSTOM_FONTS + STANDARD_FONTS
+
   constructor: (element) ->
     @element = element
     @base_asset_url = @element.find("#editor-tab").data('base-asset-url')
@@ -35,6 +60,7 @@ class @HTMLEditingDescriptor
       tinyMCE.suffix = ".min"
       @tiny_mce_textarea = $(".tiny-mce", @element).tinymce({
         script_url : "#{baseUrl}/js/vendor/tinymce/js/tinymce/tinymce.full.min.js",
+        font_formats : _getFonts(),
         theme : "modern",
         skin: 'studio-tmce4',
         schema: "html5",

--- a/common/static/css/tinymce-studio-content.css
+++ b/common/static/css/tinymce-studio-content.css
@@ -2,6 +2,10 @@
 .mce-content-body {
     padding: 10px;
     background-color: #fff;
+    /* keep font-family in sync with CUSTOM_FONTS constant in Html editor XModule
+     * (edx-platform/common/lib/xmodule/xmodule/js/src/html/edit.coffee)
+     * and with acceptance tests in cms/djangoapps/contentstore/features/html-editor.feature
+     */
     font-family: 'Open Sans', Verdana, Arial, Helvetica, sans-serif;
     font-size: 16px;
     line-height: 1.6;


### PR DESCRIPTION
This pull request fixes https://openedx.atlassian.net/browse/TNL-147

The reason behind the issue was the fact that default text editor font set in tinymce-studio-content.css was not among the list of fonts tinyMCE use out of the box.

The solution is twofold:
1. Prepended font-family from tinymce-studio-content.css to font selection dropdown.
2. Added a button to clear font-family style only - useful to keep styling in resulting html minimal.

Unfortunately, such non-functional customizations are very hard to test. There were some analogous modifications already, and I was unable to locate any tests for them. 

So, if there exists some kind of mechanism for testing such modifications, I would be grateful for any guidance and will do my best to use it.
