### PR TITLE
Change most uses of html_id to just use block_id

### DIFF
--- a/common/djangoapps/xmodule_modifiers.py
+++ b/common/djangoapps/xmodule_modifiers.py
@@ -243,22 +243,22 @@ def add_staff_markup(user, has_instructor_access, block, view, frag, context):  
             log.warning("Unable to read field in Staff Debug information", exc_info=True)
             field_contents.append((name, "WARNING: Unable to read field"))
 
-    staff_context = {'fields': field_contents,
-                     'xml_attributes': getattr(block, 'xml_attributes', {}),
-                     'location': block.location,
-                     'xqa_key': block.xqa_key,
-                     'source_file': source_file,
-                     'source_url': '%s/%s/tree/master/%s' % (giturl, data_dir, source_file),
-                     'category': str(block.__class__.__name__),
-                     # Template uses element_id in js function names, so can't allow dashes
-                     'element_id': block.location.html_id().replace('-', '_'),
-                     'edit_link': edit_link,
-                     'user': user,
-                     'xqa_server': settings.FEATURES.get('USE_XQA_SERVER', 'http://xqa:server@content-qa.mitx.mit.edu/xqa'),
-                     'histogram': json.dumps(histogram),
-                     'render_histogram': render_histogram,
-                     'block_content': frag.content,
-                     'is_released': is_released,
-                     'has_instructor_access': has_instructor_access,
-                     }
+    staff_context = {
+        'fields': field_contents,
+        'xml_attributes': getattr(block, 'xml_attributes', {}),
+        'location': block.location,
+        'xqa_key': block.xqa_key,
+        'source_file': source_file,
+        'source_url': '%s/%s/tree/master/%s' % (giturl, data_dir, source_file),
+        'category': block.location.block_type,
+        'element_id': block.location.block_id,
+        'edit_link': edit_link,
+        'user': user,
+        'xqa_server': settings.FEATURES.get('USE_XQA_SERVER', 'http://xqa:server@content-qa.mitx.mit.edu/xqa'),
+        'histogram': json.dumps(histogram),
+        'render_histogram': render_histogram,
+        'block_content': frag.content,
+        'is_released': is_released,
+        'has_instructor_access': has_instructor_access,
+     }
     return wrap_fragment(frag, render_to_string("staff_problem_info.html", staff_context))

--- a/common/lib/capa/capa/capa_problem.py
+++ b/common/lib/capa/capa/capa_problem.py
@@ -114,14 +114,14 @@ class LoncapaProblem(object):
     Main class for capa Problems.
     """
 
-    def __init__(self, problem_text, id, capa_system, state=None, seed=None):
+    def __init__(self, problem_text, problem_id, capa_system, state=None, seed=None):
         """
         Initializes capa Problem.
 
         Arguments:
 
             problem_text (string): xml defining the problem.
-            id (string): identifier for this problem, often a filename (no spaces).
+            problem_id (UsageKey): identifier for this problem
             capa_system (LoncapaSystem): LoncapaSystem instance which provides OS,
                 rendering, user context, and other resources.
             state (dict): containing the following keys:
@@ -136,7 +136,7 @@ class LoncapaProblem(object):
 
         ## Initialize class variables from state
         self.do_reset()
-        self.problem_id = id
+        self.problem_id = problem_id
         self.capa_system = capa_system
 
         state = state or {}
@@ -653,7 +653,7 @@ class LoncapaProblem(object):
                     random_seed=self.seed,
                     python_path=python_path,
                     cache=self.capa_system.cache,
-                    slug=self.problem_id,
+                    slug=unicode(self.problem_id),
                     unsafely=self.capa_system.can_execute_unsafe_code(),
                 )
             except Exception as err:
@@ -778,7 +778,7 @@ class LoncapaProblem(object):
         response_id = 1
         self.responders = {}
         for response in tree.xpath('//' + "|//".join(responsetypes.registry.registered_tags())):
-            response_id_str = self.problem_id + "_" + str(response_id)
+            response_id_str = self.problem_id.block_id + "_" + str(response_id)
             # create and save ID for this response
             response.set('id', response_id_str)
             response_id += 1
@@ -794,7 +794,7 @@ class LoncapaProblem(object):
             for entry in inputfields:
                 entry.attrib['response_id'] = str(response_id)
                 entry.attrib['answer_id'] = str(answer_id)
-                entry.attrib['id'] = "%s_%i_%i" % (self.problem_id, response_id, answer_id)
+                entry.attrib['id'] = u"%s_%i_%i" % (self.problem_id.block_id, response_id, answer_id)
                 answer_id = answer_id + 1
 
             # instantiate capa Response
@@ -819,5 +819,5 @@ class LoncapaProblem(object):
         # TODO: We should make the namespaces consistent and unique (e.g. %s_problem_%i).
         solution_id = 1
         for solution in tree.findall('.//solution'):
-            solution.attrib['id'] = "%s_solution_%i" % (self.problem_id, solution_id)
+            solution.attrib['id'] = "%s_solution_%i" % (self.problem_id.block_id, solution_id)
             solution_id += 1

--- a/common/lib/capa/capa/tests/__init__.py
+++ b/common/lib/capa/capa/tests/__init__.py
@@ -5,6 +5,7 @@ import os
 import os.path
 
 import fs.osfs
+from opaque_keys.edx.locator import CourseLocator, BlockUsageLocator
 
 from capa.capa_problem import LoncapaProblem, LoncapaSystem
 from capa.inputtypes import Status
@@ -56,7 +57,10 @@ def test_capa_system():
 
 def new_loncapa_problem(xml, capa_system=None, seed=723):
     """Construct a `LoncapaProblem` suitable for unit tests."""
-    return LoncapaProblem(xml, id='1', seed=seed, capa_system=capa_system or test_capa_system())
+    return LoncapaProblem(
+        xml, problem_id=BlockUsageLocator(CourseLocator('org', 'course', 'run'), 'problem', '1'),
+        seed=seed, capa_system=capa_system or test_capa_system()
+    )
 
 
 def load_fixture(relpath):

--- a/common/lib/capa/capa/tests/test_responsetypes.py
+++ b/common/lib/capa/capa/tests/test_responsetypes.py
@@ -20,7 +20,6 @@ from capa.responsetypes import LoncapaProblemError, \
     StudentInputError, ResponseError
 from capa.correctmap import CorrectMap
 from capa.util import convert_files_to_filenames
-from capa.util import compare_with_tolerance
 from capa.xqueue_interface import dateformat
 
 from pytz import UTC

--- a/common/lib/xmodule/xmodule/annotatable_module.py
+++ b/common/lib/xmodule/xmodule/annotatable_module.py
@@ -64,7 +64,7 @@ class AnnotatableModule(AnnotatableFields, XModule):
 
         self.instructions = self._extract_instructions(xmltree)
         self.content = etree.tostring(xmltree, encoding='unicode')
-        self.element_id = self.location.html_id()
+        self.element_id = self.location.block_id
         self.highlight_colors = ['yellow', 'orange', 'purple', 'blue', 'green']
 
     def _get_annotation_class_attr(self, index, el):

--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -311,7 +311,7 @@ class CapaMixin(CapaFields):
 
         return LoncapaProblem(
             problem_text=text,
-            id=self.location.html_id(),
+            problem_id=self.location,
             state=state,
             seed=self.seed,
             capa_system=capa_system,

--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -389,7 +389,7 @@ class CapaMixin(CapaFields):
         """
         progress = self.get_progress()
         return self.runtime.render_template('problem_ajax.html', {
-            'element_id': self.location.html_id(),
+            'element_id': self.location.block_id,
             'id': self.location.to_deprecated_string(),
             'ajax_url': self.runtime.ajax_url,
             'progress_status': Progress.to_js_status_str(progress),
@@ -632,7 +632,7 @@ class CapaMixin(CapaFields):
 
         if encapsulate:
             html = u'<div id="problem_{id}" class="problem" data-url="{ajax_url}">'.format(
-                id=self.location.html_id(), ajax_url=self.runtime.ajax_url
+                id=self.location.block_id, ajax_url=self.runtime.ajax_url
             ) + html + "</div>"
 
         # Now do all the substitutions which the LMS module_render normally does, but
@@ -971,8 +971,8 @@ class CapaMixin(CapaFields):
 
         # Wait time between resets: check if is too soon for submission.
         if self.last_submission_time is not None and self.submission_wait_seconds != 0:
-             # pylint: disable=maybe-no-member
-             # pylint is unable to verify that .total_seconds() exists
+            # pylint: disable=maybe-no-member
+            # pylint is unable to verify that .total_seconds() exists
             if (current_time - self.last_submission_time).total_seconds() < self.submission_wait_seconds:
                 remaining_secs = int(self.submission_wait_seconds - (current_time - self.last_submission_time).total_seconds())
                 msg = _(u'You must wait at least {wait_secs} between submissions. {remaining_secs} remaining.').format(
@@ -1188,7 +1188,7 @@ class CapaMixin(CapaFields):
                 log.warning('Input id %s is not mapped to an input type.', input_id)
 
             answer_response = None
-            for response, responder in self.lcp.responders.iteritems():
+            for responder in self.lcp.responders.itervalues():
                 if input_id in responder.answer_ids:
                     answer_response = responder
 

--- a/common/lib/xmodule/xmodule/conditional_module.py
+++ b/common/lib/xmodule/xmodule/conditional_module.py
@@ -138,11 +138,13 @@ class ConditionalModule(ConditionalFields, XModule):
 
     def get_html(self):
         # Calculate html ids of dependencies
-        self.required_html_ids = [descriptor.location.html_id() for
-                                  descriptor in self.descriptor.get_required_module_descriptors()]
+        self.required_html_ids = [
+            descriptor.location.block_id for
+            descriptor in self.descriptor.get_required_module_descriptors()
+        ]
 
         return self.system.render_template('conditional_ajax.html', {
-            'element_id': self.location.html_id(),
+            'element_id': self.location.block_id,
             'ajax_url': self.system.ajax_url,
             'depends': ';'.join(self.required_html_ids)
         })

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -586,7 +586,7 @@ class CourseDescriptor(CourseFields, SequenceDescriptor):
         self.set_grading_policy(self.grading_policy)
 
         if self.discussion_topics == {}:
-            self.discussion_topics = {_('General'): {'id': self.location.html_id()}}
+            self.discussion_topics = {_('General'): {'id': unicode(self.id)}}
 
         if not getattr(self, "tabs", []):
             CourseTabList.initialize_default(self)

--- a/common/lib/xmodule/xmodule/editing_module.py
+++ b/common/lib/xmodule/xmodule/editing_module.py
@@ -54,7 +54,7 @@ class TabsEditingDescriptor(EditingFields, MakoModuleDescriptor):
         _context = super(TabsEditingDescriptor, self).get_context()
         _context.update({
             'tabs': self.tabs,
-            'html_id': self.location.html_id(),  # element_id
+            'html_id': self.location.block_id,  # element_id
             'data': self.data,
         })
         return _context

--- a/common/lib/xmodule/xmodule/gst_module.py
+++ b/common/lib/xmodule/xmodule/gst_module.py
@@ -107,7 +107,7 @@ class GraphicalSliderToolModule(GraphicalSliderToolFields, XModule):
         """ Renders parameters to template. """
 
         # these 3 will be used in class methods
-        self.html_id = self.location.html_id()
+        self.html_id = self.location.block_id
         self.html_class = self.location.category
 
         self.configuration_json = self.build_configuration_json()

--- a/common/lib/xmodule/xmodule/lti_module.py
+++ b/common/lib/xmodule/xmodule/lti_module.py
@@ -360,7 +360,7 @@ class LTIModule(LTIFields, LTI20ModuleMixin, XModule):
 
             # These parameters do not participate in OAuth signing.
             'launch_url': self.launch_url.strip(),
-            'element_id': self.location.html_id(),
+            'element_id': self.location.block_id,
             'element_class': self.category,
             'open_in_a_new_page': self.open_in_a_new_page,
             'display_name': self.display_name,

--- a/common/lib/xmodule/xmodule/poll_module.py
+++ b/common/lib/xmodule/xmodule/poll_module.py
@@ -94,11 +94,11 @@ class PollModule(PollFields, XModule):
     def get_html(self):
         """Renders parameters to template."""
         params = {
-                  'element_id': self.location.html_id(),
-                  'element_class': self.location.category,
-                  'ajax_url': self.system.ajax_url,
-                  'configuration_json': self.dump_poll(),
-                  }
+            'element_id': self.location.block_id,
+            'element_class': self.location.category,
+            'ajax_url': self.system.ajax_url,
+            'configuration_json': self.dump_poll(),
+        }
         self.content = self.system.render_template('poll.html', params)
         return self.content
 

--- a/common/lib/xmodule/xmodule/seq_module.py
+++ b/common/lib/xmodule/xmodule/seq_module.py
@@ -110,7 +110,7 @@ class SequenceModule(SequenceFields, XModule):
             contents.append(childinfo)
 
         params = {'items': contents,
-                  'element_id': self.location.html_id(),
+                  'element_id': self.location.block_id,
                   'item_id': self.location.to_deprecated_string(),
                   'position': self.position,
                   'tag': self.location.category,

--- a/common/lib/xmodule/xmodule/tests/test_conditional.py
+++ b/common/lib/xmodule/xmodule/tests/test_conditional.py
@@ -133,8 +133,8 @@ class ConditionalModuleBasicTest(unittest.TestCase):
         html = modules['cond_module'].render(STUDENT_VIEW).content
         expected = modules['cond_module'].xmodule_runtime.render_template('conditional_ajax.html', {
             'ajax_url': modules['cond_module'].xmodule_runtime.ajax_url,
-            'element_id': u'i4x-edX-conditional_test-conditional-SampleConditional',
-            'depends': u'i4x-edX-conditional_test-problem-SampleProblem',
+            'element_id': 'SampleConditional',
+            'depends': 'SampleProblem',
         })
         self.assertEquals(expected, html)
 
@@ -228,8 +228,8 @@ class ConditionalModuleXmlTest(unittest.TestCase):
             {
                 # Test ajax url is just usage-id / handler_name
                 'ajax_url': '{}/xmodule_handler'.format(location.to_deprecated_string()),
-                'element_id': u'i4x-HarvardX-ER22x-conditional-condone',
-                'depends': u'i4x-HarvardX-ER22x-problem-choiceprob'
+                'element_id': 'condone',
+                'depends': 'choiceprob'
             }
         )
         self.assertEqual(html, html_expect)

--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -162,7 +162,7 @@ class VideoModule(VideoFields, VideoStudentViewHandlers, XModule):
             'display_name': self.display_name_with_default,
             'end': self.end_time.total_seconds(),
             'handout': self.handout,
-            'id': self.location.html_id(),
+            'id': self.location.block_id,
             'show_captions': json.dumps(self.show_captions),
             'download_video_link': download_video_link,
             'sources': json.dumps(sources),

--- a/common/lib/xmodule/xmodule/word_cloud_module.py
+++ b/common/lib/xmodule/xmodule/word_cloud_module.py
@@ -232,7 +232,7 @@ class WordCloudModule(WordCloudFields, XModule):
     def get_html(self):
         """Template rendering."""
         context = {
-            'element_id': self.location.html_id(),
+            'element_id': self.location.block_id,
             'element_class': self.location.category,
             'ajax_url': self.system.ajax_url,
             'num_inputs': self.num_inputs,

--- a/lms/djangoapps/courseware/tests/test_lti_integration.py
+++ b/lms/djangoapps/courseware/tests/test_lti_integration.py
@@ -79,7 +79,7 @@ class TestLTI(BaseTestXmodule):
             'display_name': self.item_descriptor.display_name,
             'input_fields': self.correct_headers,
             'element_class': self.item_descriptor.category,
-            'element_id': self.item_descriptor.location.html_id(),
+            'element_id': self.item_descriptor.location.block_id,
             'launch_url': 'http://www.example.com',  # default value
             'open_in_a_new_page': True,
             'form_url': self.item_descriptor.xmodule_runtime.handler_url(self.item_descriptor,

--- a/lms/djangoapps/courseware/tests/test_video_mongo.py
+++ b/lms/djangoapps/courseware/tests/test_video_mongo.py
@@ -35,7 +35,7 @@ class TestVideoYouTube(TestVideo):
             'data_dir': getattr(self, 'data_dir', None),
             'display_name': u'A Name',
             'end': 3610.0,
-            'id': self.item_descriptor.location.html_id(),
+            'id': self.item_descriptor.location.block_id,
             'show_captions': 'true',
             'handout': None,
             'download_video_link': u'example.mp4',
@@ -101,7 +101,7 @@ class TestVideoNonYouTube(TestVideo):
             'display_name': u'A Name',
             'download_video_link': u'example.mp4',
             'end': 3610.0,
-            'id': self.item_descriptor.location.html_id(),
+            'id': self.item_descriptor.location.block_id,
             'sources': sources,
             'speed': 'null',
             'general_speed': 1.0,
@@ -247,7 +247,7 @@ class TestGetHtmlMethod(BaseTestXmodule):
                 'ajax_url': self.item_descriptor.xmodule_runtime.ajax_url + '/save_user_state',
                 'track': track_url if data['expected_track_url'] == u'a_sub_file.srt.sjson' else data['expected_track_url'],
                 'sub': data['sub'],
-                'id': self.item_descriptor.location.html_id(),
+                'id': self.item_descriptor.location.block_id,
             })
             self.assertEqual(
                 context,
@@ -356,7 +356,7 @@ class TestGetHtmlMethod(BaseTestXmodule):
                     self.item_descriptor, 'transcript', 'available_translations'
                 ).rstrip('/?'),
                 'ajax_url': self.item_descriptor.xmodule_runtime.ajax_url + '/save_user_state',
-                'id': self.item_descriptor.location.html_id(),
+                'id': self.item_descriptor.location.block_id,
             })
             expected_context.update(data['result'])
 
@@ -456,7 +456,7 @@ class TestGetHtmlMethod(BaseTestXmodule):
                     self.item_descriptor, 'transcript', 'available_translations'
                 ).rstrip('/?'),
                 'ajax_url': self.item_descriptor.xmodule_runtime.ajax_url + '/save_user_state',
-                'id': self.item_descriptor.location.html_id(),
+                'id': self.item_descriptor.location.block_id,
             })
             expected_context.update(data['result'])
 

--- a/lms/djangoapps/courseware/tests/test_word_cloud.py
+++ b/lms/djangoapps/courseware/tests/test_word_cloud.py
@@ -248,7 +248,7 @@ class TestWordCloud(BaseTestXmodule):
         expected_context = {
             'ajax_url': self.item_descriptor.xmodule_runtime.ajax_url,
             'element_class': self.item_descriptor.location.category,
-            'element_id': self.item_descriptor.location.html_id(),
+            'element_id': self.item_descriptor.location.block_id,
             'num_inputs': 5,  # default value
             'submitted': False  # default value
         }

--- a/lms/templates/courseware/xqa_interface.html
+++ b/lms/templates/courseware/xqa_interface.html
@@ -5,90 +5,90 @@
 <script type="text/javascript">
 
 function setup_debug(element_id, edit_link, staff_context){
-	$('#' + element_id + '_trig').leanModal(); 
-	$('#' + element_id + '_xqa_log').leanModal();		
-	$('#' + element_id + '_xqa_form').submit(function () {sendlog(element_id, edit_link, staff_context);});
+    $('#' + element_id + '_trig').leanModal(); 
+    $('#' + element_id + '_xqa_log').leanModal();
+    $('#' + element_id + '_xqa_form').submit(function () {sendlog(element_id, edit_link, staff_context);});
 
-	$("#" + element_id + "_history_trig").leanModal();
-	
-	$('#' + element_id + '_history_form').submit(
-		function () {
-			var username = $("#" + element_id + "_history_student_username").val();
-			var location = $("#" + element_id + "_history_location").val();
+    $("#" + element_id + "_history_trig").leanModal();
+    
+    $('#' + element_id + '_history_form').submit(
+        function () {
+            var username = $("#" + element_id + "_history_student_username").val();
+            var location = $("#" + element_id + "_history_location").val();
 
-			// This is a ridiculous way to get the course_id, but I'm not sure
-			// how to do it sensibly from within the staff debug code. 
-			// staff_problem_info.html is rendered through a wrapper to get_html
-			// that's injected by the code that adds the histogram -- it's all 
-			// kinda bizarre, and it remains awkward to simply ask "what course
-			// is this problem being shown in the context of."
-			var path_parts = window.location.pathname.split('/');
-			var course_id = path_parts[2] + "/" + path_parts[3] + "/" + path_parts[4];
-			$("#" + element_id + "_history_text").load('/courses/' + course_id + 
-				"/submission_history/" + username + "/" + location);
-			return false;
-		}
-	);
+            // This is a ridiculous way to get the course_id, but I'm not sure
+            // how to do it sensibly from within the staff debug code. 
+            // staff_problem_info.html is rendered through a wrapper to get_html
+            // that's injected by the code that adds the histogram -- it's all 
+            // kinda bizarre, and it remains awkward to simply ask "what course
+            // is this problem being shown in the context of."
+            var path_parts = window.location.pathname.split('/');
+            var course_id = path_parts[2] + "/" + path_parts[3] + "/" + path_parts[4];
+            $("#" + element_id + "_history_text").load('/courses/' + course_id + 
+                "/submission_history/" + username + "/" + location);
+            return false;
+        }
+    );
 }
 
 function sendlog(element_id, edit_link, staff_context){
 
-	var xqaLog = {
-			authkey: staff_context.xqa_key,
-			location: staff_context.location,
-			category : staff_context.category,
-			'username' : staff_context.user.username,
-			'return' : 'query',
-			format : 'html',
-			email : staff_context.user.email,
-			tag:$('#' + element_id + '_xqa_tag').val(),
-			entry: $('#' + element_id + '_xqa_entry').val()
-		};
-			
-	$.ajax({
-		url: '${xqa_server}/log',
-		type: 'GET',
-		contentType: 'application/json',
-		data: JSON.stringify(xqaLog),
-		crossDomain: true,
-		dataType: 'jsonp',
-		beforeSend: function (xhr) { 
-			xhr.setRequestHeader ("Authorization", "Basic eHFhOmFnYXJ3YWw="); },
-		timeout : 1000,
-		success: function(result) {
-				$('#' + element_id + '_xqa_log_data').html(result);
-		},
-		error: function() {
-			alert('Error: cannot connect to XQA server');
-			console.log('error!');
-		}
-	});
-	return false;
+    var xqaLog = {
+            authkey: staff_context.xqa_key,
+            location: staff_context.location,
+            category : staff_context.category,
+            'username' : staff_context.user.username,
+            'return' : 'query',
+            format : 'html',
+            email : staff_context.user.email,
+            tag:$('#' + element_id + '_xqa_tag').val(),
+            entry: $('#' + element_id + '_xqa_entry').val()
+        };
+            
+    $.ajax({
+        url: '${xqa_server}/log',
+        type: 'GET',
+        contentType: 'application/json',
+        data: JSON.stringify(xqaLog),
+        crossDomain: true,
+        dataType: 'jsonp',
+        beforeSend: function (xhr) { 
+            xhr.setRequestHeader ("Authorization", "Basic eHFhOmFnYXJ3YWw="); },
+        timeout : 1000,
+        success: function(result) {
+                $('#' + element_id + '_xqa_log_data').html(result);
+        },
+        error: function() {
+            alert('Error: cannot connect to XQA server');
+            console.log('error!');
+        }
+    });
+    return false;
 };
 
 function getlog(element_id, staff_context){
 
-	var xqaQuery = {
-		authkey: staff_context.xqa_key,
-		location: staff_context.location,
-		format: 'html'
-	};
+    var xqaQuery = {
+        authkey: staff_context.xqa_key,
+        location: staff_context.location,
+        format: 'html'
+    };
 
-	$.ajax({
-		url: '${xqa_server}/query',
-		type: 'GET',
-		contentType: 'application/json',
-		data: JSON.stringify(xqaQuery),
-		crossDomain: true,
-		dataType: 'jsonp',
-		timeout : 1000,
-		success: function(result) {
-			$('#' + element_id + '_xqa_log_data').html(result);
-		},
-		error: function() {
-			alert('Error: cannot connect to XQA server');
-		}
-	});
+    $.ajax({
+        url: '${xqa_server}/query',
+        type: 'GET',
+        contentType: 'application/json',
+        data: JSON.stringify(xqaQuery),
+        crossDomain: true,
+        dataType: 'jsonp',
+        timeout : 1000,
+        success: function(result) {
+            $('#' + element_id + '_xqa_log_data').html(result);
+        },
+        error: function() {
+            alert('Error: cannot connect to XQA server');
+        }
+    });
 
 
 };


### PR DESCRIPTION
Discussion forum and lti still use html id which may or may not work
for non-deprecated keys.
LMS-11236

Replaces https://github.com/edx/edx-platform/pull/4917
