### PR TITLE
Define SELENIUM_DRIVER_LOG_DIR in paver bok-choy command

### DIFF
--- a/pavelib/utils/test/suites/bokchoy_suite.py
+++ b/pavelib/utils/test/suites/bokchoy_suite.py
@@ -103,6 +103,7 @@ class BokChoyTestSuite(TestSuite):
         cmd = [
             "SCREENSHOT_DIR='{}'".format(self.log_dir),
             "HAR_DIR='{}'".format(self.har_dir),
+            "SELENIUM_DRIVER_LOG_DIR='{}'".format(self.log_dir),
             "nosetests",
             test_spec,
             "--with-xunit",


### PR DESCRIPTION
@clytwynec @benmcmorran 

This should have been included in #4926
And fixes the log files that are currently being created at the base of the edx-platform dir.
