### PR TITLE
Remove i18n from ux reference templates

### DIFF
--- a/cms/templates/base.html
+++ b/cms/templates/base.html
@@ -35,6 +35,8 @@
   </head>
 
   <body class="<%block name='bodyclass'></%block> hide-wip lang_${LANGUAGE_CODE}">
+  <%block name="view_notes"></%block>
+
     <a class="nav-skip" href="#content">${_("Skip to this view's content")}</a>
 
     <script type="text/javascript">
@@ -82,7 +84,7 @@
             "URI": "js/vendor/URI.min",
             "ieshim": "js/src/ie_shim",
             "tooltip_manager": "js/src/tooltip_manager",
-            
+
             // Files needed for Annotations feature
             "annotator": "js/vendor/ova/annotator-full",
             "annotator-harvardx": "js/vendor/ova/annotator-full-firebase-auth",

--- a/cms/templates/ux/reference/_note-usage.html
+++ b/cms/templates/ux/reference/_note-usage.html
@@ -1,0 +1,12 @@
+<!-- NOTE:
+
+This file is a static reference template used by the edX design and development teams while
+building new features. These files are not generally maintained or updated once a feature has
+been completed. Additionally, these templates are subject to the following:
+
+* inconsistent markup/UI with current UI
+* deletion by the edX design or development if not needed
+* not compliant with internationalization, javascript, or accessibility standards used
+  throughout the rest of the platform
+
+-->

--- a/cms/templates/ux/reference/container.html
+++ b/cms/templates/ux/reference/container.html
@@ -31,18 +31,18 @@
         </div>
 
         <nav class="nav-actions">
-            <h3 class="sr">${_("Page Actions")}</h3>
+            <h3 class="sr">Page Actions</h3>
             <ul>
 
 <!-- begin publishing changes -->
                 <li class="action-item action-view nav-item">
                     <a href="#" class="button view-button action-button">
-                        <span class="action-button-text">${_("View Published Version")}</span>
+                        <span class="action-button-text">View Published Version</span>
                     </a>
                 </li>
                 <li class="action-item action-preview nav-item">
                     <a href="#" class="button preview-button action-button">
-                        <span class="action-button-text">${_("Preview Changes")}</span>
+                        <span class="action-button-text">Preview Changes</span>
                     </a>
                 </li>
 <!-- end publishing changes -->
@@ -458,7 +458,7 @@
                 <!-- case never published, future release no staff lock -->
 
                 <div class="bit-publishing ">
-                  <h3 class="bar-mod-title pub-status"><span class="sr">${_("Publishing Status")} </span>${_("Draft (Never published)")}</h3>
+                  <h3 class="bar-mod-title pub-status"><span class="sr">Publishing Status </span>Draft (Never published)</h3>
                   <div class="wrapper-last-draft bar-mod-content">
 
                   <!-- case: unpubbed changes -->
@@ -503,7 +503,7 @@
                 <!-- case published no changes, future release no staff lock -->
 
                 <div class="bit-publishing is-published">
-                  <h3 class="bar-mod-title pub-status"><span class="sr">${_("Publishing Status")} </span>${_("Published")}</h3>
+                  <h3 class="bar-mod-title pub-status"><span class="sr">Publishing Status </span>Published</h3>
                   <div class="wrapper-last-draft bar-mod-content">
 
                   <!-- case: unpubbed changes -->
@@ -549,7 +549,7 @@
                 <!-- case unpubbed changes, future release no staff lock -->
 
                 <div class="bit-publishing is-draft">
-                  <h3 class="bar-mod-title pub-status"><span class="sr">${_("Publishing Status")} </span>${_("Draft (Unpublished changes)")}</h3>
+                  <h3 class="bar-mod-title pub-status"><span class="sr">Publishing Status </span>Draft (Unpublished changes)</h3>
                   <div class="wrapper-last-draft bar-mod-content">
 
                   <!-- case: unpubbed changes -->
@@ -595,7 +595,7 @@
                 <!-- case unpubbed changes, future release with staff lock -->
 
                 <div class="bit-publishing is-draft is-staff-only">
-                  <h3 class="bar-mod-title pub-status"><span class="sr">${_("Publishing Status")} </span>${_("Draft (Unpublished changes)")}</h3>
+                  <h3 class="bar-mod-title pub-status"><span class="sr">Publishing Status </span>Draft (Unpublished changes)</h3>
                   <div class="wrapper-last-draft bar-mod-content">
 
                   <!-- case: unpubbed changes -->
@@ -641,7 +641,7 @@
                 <!-- case published no changes, release in past no staff lock -->
 
                 <div class="bit-publishing is-published">
-                  <h3 class="bar-mod-title pub-status"><span class="sr">${_("Publishing Status")} </span>${_("Published")}</h3>
+                  <h3 class="bar-mod-title pub-status"><span class="sr">Publishing Status </span>Published</h3>
                   <div class="wrapper-last-draft bar-mod-content">
 
                   <!-- case: unpubbed changes -->

--- a/cms/templates/ux/reference/container.html
+++ b/cms/templates/ux/reference/container.html
@@ -1,5 +1,9 @@
 <%inherit file="../../base.html" />
 
+<%block name="view_notes">
+    <%include file="_note-usage.html" />
+</%block>
+
 <%!
   import logging
   from util.date_utils import get_default_time_display

--- a/cms/templates/ux/reference/course-create-rerun.html
+++ b/cms/templates/ux/reference/course-create-rerun.html
@@ -19,7 +19,7 @@ TODO:
 <%! from django.utils.translation import ugettext as _ %>
 <%! from django.core.urlresolvers import reverse %>
 
-<%block name="title">[template] ${_("Create a Course Rerun of HarvardX SW12.2x T2_2014")}</%block>
+<%block name="title">[template] Create a Course Rerun of HarvardX SW12.2x T2_2014</%block>
 <%block name="bodyclass">is-signedin view-course-create view-course-create-rerun</%block>
 
 <%block name="content">
@@ -28,20 +28,20 @@ TODO:
   <div class="wrapper-mast wrapper">
     <header class="mast mast-wizard has-actions">
       <h1 class="page-header">
-        <span class="page-header-sub">${_("Create a re-run of a course")}</span>
+        <span class="page-header-sub">Create a re-run of a course</span>
       </h1>
 
       <nav class="nav-actions">
         <h3 class="sr">Page Actions</h3>
         <ul>
           <li class="nav-item">
-            <a href="" rel="external" class="button cancel-button">${_("Cancel")}</a>
+            <a href="" rel="external" class="button cancel-button">Cancel</a>
           </li>
         </ul>
       </nav>
 
       <h2 class="page-header-super course-original">
-        <span class="sr">${_("You are creating a re-run from:")}</span>
+        <span class="sr">You are creating a re-run from:</span>
         <span class="course-original-title-id">HarvardX SW12.2x T2_2014</span>
         <span class="course-original-title">China (Part 2): The Creation and End of a Centralized Empire</span>
       </h2>
@@ -55,8 +55,8 @@ TODO:
           <div class="introduction">
             <div class="copy">
               <p>
-                ${_("Provide identifying information for this re-run of the course. The original course is not affected in any way by a re-run.")}
-                <strong>${_("Note: Together, the organization, course number, and course run must uniquely identify this new course instance.")}</strong>
+                Provide identifying information for this re-run of the course. The original course is not affected in any way by a re-run.
+                <strong>Note: Together, the organization, course number, and course run must uniquely identify this new course instance.</strong>
               <p>
             </div>
           </div><!-- /introduction -->
@@ -73,44 +73,44 @@ TODO:
 
               <div class="wrapper-form">
                 <fieldset>
-                  <legend class="sr">${_("Required Information to Create a re-run of a course")}</legend>
+                  <legend class="sr">Required Information to Create a re-run of a course</legend>
 
                   <ol class="list-input">
                     <li class="field text required" id="field-course-name">
-                      <label for="rerun-course-name">${_("Course Name")}</label>
-                      <input class="rerun-course-name" id="rerun-course-name" type="text" name="rerun-course-name" aria-required="true" placeholder="${_('e.g. Introduction to Computer Science')}" />
+                      <label for="rerun-course-name">Course Name</label>
+                      <input class="rerun-course-name" id="rerun-course-name" type="text" name="rerun-course-name" aria-required="true" placeholder="e.g. Introduction to Computer Science" />
                       <span class="tip">
-                        ${_("The public display name for the new course. (This name is often the same as the original course name.)")}
+                        The public display name for the new course. (This name is often the same as the original course name.)
                       </span>
                       <span class="tip tip-error is-hidden"></span>
                     </li>
                     <li class="field text required" id="field-organization">
-                      <label for="rerun-course-org">${_("Organization")}</label>
-                      <input class="rerun-course-org" id="rerun-course-org" type="text" name="rerun-course-org" aria-required="true" placeholder="${_('e.g. UniversityX or OrganizationX')}" />
+                      <label for="rerun-course-org">Organization</label>
+                      <input class="rerun-course-org" id="rerun-course-org" type="text" name="rerun-course-org" aria-required="true" placeholder="e.g. UniversityX or OrganizationX" />
                       <span class="tip">
-                        ${_("The name of the organization sponsoring the new course. (This name is often the same as the original organization name.)")}
-                        <strong class="tip-note" class="tip-note">${_("Note: No spaces or special characters are allowed.")}</strong>
+                        The name of the organization sponsoring the new course. (This name is often the same as the original organization name.)
+                        <strong class="tip-note" class="tip-note">Note: No spaces or special characters are allowed.</strong>
                       </span>
                       <span class="tip tip-error is-hidden"></span>
                     </li>
 
                     <li class="row">
                       <div class="column field text required" id="field-course-number">
-                        <label for="rerun-course-number">${_("Course Number")}</label>
-                        <input class="rerun-course-number" id="rerun-course-number" type="text" name="rerun-course-number" aria-required="true" placeholder="${_('e.g. CS101')}" />
+                        <label for="rerun-course-number">Course Number</label>
+                        <input class="rerun-course-number" id="rerun-course-number" type="text" name="rerun-course-number" aria-required="true" placeholder="e.g. CS101" />
                         <span class="tip">
-                          ${_("The unique number that identifies the new course within the organization.  (This number is often the same as the original course number.)")}
-                          <strong class="tip-note" class="tip-note">${_("Note: No spaces or special characters are allowed.")}</strong>
+                          The unique number that identifies the new course within the organization.  (This number is often the same as the original course number.)
+                          <strong class="tip-note" class="tip-note">Note: No spaces or special characters are allowed.</strong>
                         </span>
                         <span class="tip tip-error is-hidden"></span>
                       </div>
 
                       <div class="column field text required" id="field-course-run">
-                        <label for="rerun-course-run">${_("Course Run")}</label>
-                        <input class="rerun-course-run" id="rerun-course-run" type="text" name="rerun-course-run" aria-required="true"placeholder="${_('e.g. 2014_T1')}" />
+                        <label for="rerun-course-run">Course Run</label>
+                        <input class="rerun-course-run" id="rerun-course-run" type="text" name="rerun-course-run" aria-required="true"placeholder="e.g. 2014_T1" />
                         <span class="tip">
-                          ${_("The term in which the new course will run. (This value is often different than the original course run value.)")}
-                          <strong class="tip-note" class="tip-note">${_("Note: No spaces or special characters are allowed.")}</strong>
+                          The term in which the new course will run. (This value is often different than the original course run value.)
+                          <strong class="tip-note" class="tip-note">Note: No spaces or special characters are allowed.</strong>
                         </span>
                         <span class="tip tip-error is-hidden"></span>
                       </div>
@@ -122,8 +122,8 @@ TODO:
               </div>
 
               <div class="actions">
-                <button type="submit" class="action action-primary rerun-course-save is-disabled">${_('Create Re-run')}</button>
-                <button type="button" class="action action-secondary action-cancel rerun-course-cancel">${_('Cancel')}</button>
+                <button type="submit" class="action action-primary rerun-course-save is-disabled">Create Re-run</button>
+                <button type="button" class="action action-secondary action-cancel rerun-course-cancel">Cancel</button>
               </div>
             </form>
           </div><!-- /rerun-course -->
@@ -136,50 +136,50 @@ TODO:
               <div class="wrapper-error is-shown">
                 <!-- NOTE: this element's contents should be only included when they are needed and not kept in the DOM for all states -->
                 <div id="course_rerun_error" name="course_rerun_error" class="message message-status error" role="alert">
-                  <p>${_("A course already has that organization, course number, and course run. Change one or more of these values to give the new course a unique URL.")}</p>
+                  <p>A course already has that organization, course number, and course run. Change one or more of these values to give the new course a unique URL.</p>
                 </div>
               </div>
 
               <div class="wrapper-form">
                 <fieldset>
-                  <legend class="sr">${_("Required Information to Create a re-run of a course")}</legend>
+                  <legend class="sr">Required Information to Create a re-run of a course</legend>
 
                   <ol class="list-input">
                     <li class="field text required error" id="field-course-name">
-                      <label for="rerun-course-name">${_("Course Name")}</label>
-                      <input class="rerun-course-name" id="rerun-course-name" type="text" name="rerun-course-name" aria-required="true" placeholder="${_('e.g. Introduction to Computer Science')}" />
+                      <label for="rerun-course-name">Course Name</label>
+                      <input class="rerun-course-name" id="rerun-course-name" type="text" name="rerun-course-name" aria-required="true" placeholder="e.g. Introduction to Computer Science" />
                       <span class="tip">
-                        ${_("The public display name for the new course. (This name is often the same as the original course name.)")}
+                        The public display name for the new course. (This name is often the same as the original course name.)
                       </span>
                       <span class="tip tip-error is-hiding"></span>
                     </li>
                     <li class="field text required error" id="field-organization">
-                      <label for="rerun-course-org">${_("Organization")}</label>
-                      <input class="rerun-course-org" id="rerun-course-org" type="text" name="rerun-course-org" aria-required="true" placeholder="${_('e.g. UniversityX or OrganizationX')}" />
+                      <label for="rerun-course-org">Organization</label>
+                      <input class="rerun-course-org" id="rerun-course-org" type="text" name="rerun-course-org" aria-required="true" placeholder="e.g. UniversityX or OrganizationX" />
                       <span class="tip">
-                        ${_("The name of the organization sponsoring the new course. (This name is often the same as the original organization name.)")}
-                        <strong class="tip-note" class="tip-note">${_("Note: No spaces or special characters are allowed.")}</strong>
+                        The name of the organization sponsoring the new course. (This name is often the same as the original organization name.)
+                        <strong class="tip-note" class="tip-note">Note: No spaces or special characters are allowed.</strong>
                       </span>
                       <span class="tip tip-error is-hiding"></span>
                     </li>
 
                     <li class="row">
                       <div class="column field text required error" id="field-course-number">
-                        <label for="rerun-course-number">${_("Course Number")}</label>
-                        <input class="rerun-course-number" id="rerun-course-number" type="text" name="rerun-course-number" aria-required="true" placeholder="${_('e.g. CS101')}" />
+                        <label for="rerun-course-number">Course Number</label>
+                        <input class="rerun-course-number" id="rerun-course-number" type="text" name="rerun-course-number" aria-required="true" placeholder="e.g. CS101" />
                         <span class="tip">
-                          ${_("The unique number that identifies the new course within the organization.  (This number is often the same as the original course number.)")}
-                          <strong class="tip-note" class="tip-note">${_("Note: No spaces or special characters are allowed.")}</strong>
+                          The unique number that identifies the new course within the organization.  (This number is often the same as the original course number.)
+                          <strong class="tip-note" class="tip-note">Note: No spaces or special characters are allowed.</strong>
                         </span>
                         <span class="tip tip-error is-hiding"></span>
                       </div>
 
                       <div class="column field text required error" id="field-course-run">
-                        <label for="rerun-course-run">${_("Course Run")}</label>
-                        <input class="rerun-course-run" id="rerun-course-run" type="text" name="rerun-course-run" aria-required="true"placeholder="${_('e.g. 2014_T1')}" />
+                        <label for="rerun-course-run">Course Run</label>
+                        <input class="rerun-course-run" id="rerun-course-run" type="text" name="rerun-course-run" aria-required="true"placeholder="e.g. 2014_T1" />
                         <span class="tip">
-                          ${_("The term in which the new course will run. (This value is often different than the original course run value.)")}
-                          <strong class="tip-note" class="tip-note">${_("Note: No spaces or special characters are allowed.")}</strong>
+                          The term in which the new course will run. (This value is often different than the original course run value.)
+                          <strong class="tip-note" class="tip-note">Note: No spaces or special characters are allowed.</strong>
                         </span>
                         <span class="tip tip-error is-hiding"></span>
                       </div>
@@ -192,8 +192,8 @@ TODO:
               </div>
 
               <div class="actions">
-                <button type="submit" class="action action-primary rerun-course-save is-disabled">${_('Create Re-run')}</button>
-                <button type="button" class="action action-secondary action-cancel rerun-course-cancel">${_('Cancel and Return to Dashboard')}</button>
+                <button type="submit" class="action action-primary rerun-course-save is-disabled">Create Re-run</button>
+                <button type="button" class="action action-secondary action-cancel rerun-course-cancel">Cancel and Return to Dashboard</button>
               </div>
             </form>
           </div><!-- /rerun-course -->
@@ -206,50 +206,50 @@ TODO:
               <div class="wrapper-error is-shown">
                 <!-- NOTE: this element's contents should be only included when they are needed and not kept in the DOM for all states -->
                 <div id="course_rerun_error" name="course_rerun_error" class="message message-status error" role="alert">
-                  <p>${_("Please correct the highlighted fields below.")}</p>
+                  <p>Please correct the highlighted fields below.</p>
                 </div>
               </div>
 
               <div class="wrapper-form">
                 <fieldset>
-                  <legend class="sr">${_("Required Information to Create a re-run of a course")}</legend>
+                  <legend class="sr">Required Information to Create a re-run of a course</legend>
 
                   <ol class="list-input">
                     <li class="field text required error" id="field-course-name">
-                      <label for="rerun-course-name">${_("Course Name")}</label>
-                      <input class="rerun-course-name" id="rerun-course-name" type="text" name="rerun-course-name" aria-required="true" placeholder="${_('e.g. Introduction to Computer Science')}" />
+                      <label for="rerun-course-name">Course Name</label>
+                      <input class="rerun-course-name" id="rerun-course-name" type="text" name="rerun-course-name" aria-required="true" placeholder="e.g. Introduction to Computer Science" />
                       <span class="tip">
-                        ${_("The public display name for the new course. (This name is often the same as the original course name.)")}
+                        The public display name for the new course. (This name is often the same as the original course name.)
                       </span>
                       <span class="tip tip-error is-showing">Required field.</span>
                     </li>
                     <li class="field text required error" id="field-organization">
-                      <label for="rerun-course-org">${_("Organization")}</label>
-                      <input class="rerun-course-org" id="rerun-course-org" type="text" name="rerun-course-org" aria-required="true" placeholder="${_('e.g. UniversityX or OrganizationX')}" />
+                      <label for="rerun-course-org">Organization</label>
+                      <input class="rerun-course-org" id="rerun-course-org" type="text" name="rerun-course-org" aria-required="true" placeholder="e.g. UniversityX or OrganizationX" />
                       <span class="tip">
-                        ${_("The name of the organization sponsoring the new course. (This name is often the same as the original organization name.)")}
-                        <strong class="tip-note">${_("Note: No spaces or special characters are allowed.")}</strong>
+                        The name of the organization sponsoring the new course. (This name is often the same as the original organization name.)
+                        <strong class="tip-note">Note: No spaces or special characters are allowed.</strong>
                       </span>
                       <span class="tip tip-error is-showing">Please do not use any spaces or special characters in this field.</span>
                     </li>
 
                     <li class="row">
                       <div class="column field text required error" id="field-course-number">
-                        <label for="rerun-course-number">${_("Course Number")}</label>
-                        <input class="rerun-course-number" id="rerun-course-number" type="text" name="rerun-course-number" aria-required="true" placeholder="${_('e.g. CS101')}" />
+                        <label for="rerun-course-number">Course Number</label>
+                        <input class="rerun-course-number" id="rerun-course-number" type="text" name="rerun-course-number" aria-required="true" placeholder="e.g. CS101" />
                         <span class="tip">
-                          ${_("The unique number that identifies the new course within the organization.  (This number is often the same as the original course number.)")}
-                          <strong class="tip-note">${_("Note: No spaces or special characters are allowed.")}</strong>
+                          The unique number that identifies the new course within the organization.  (This number is often the same as the original course number.)
+                          <strong class="tip-note">Note: No spaces or special characters are allowed.</strong>
                         </span>
                         <span class="tip tip-error is-showing">Please do not use any spaces or special characters in this field.</span>
                       </div>
 
                       <div class="column field text required error" id="field-course-run">
-                        <label for="rerun-course-run">${_("Course Run")}</label>
-                        <input class="rerun-course-run" id="rerun-course-run" type="text" name="rerun-course-run" aria-required="true"placeholder="${_('e.g. 2014_T1')}" />
+                        <label for="rerun-course-run">Course Run</label>
+                        <input class="rerun-course-run" id="rerun-course-run" type="text" name="rerun-course-run" aria-required="true"placeholder="e.g. 2014_T1" />
                         <span class="tip">
-                          ${_("The term in which the new course will run. (This value is often different than the original course run value.)")}
-                          <strong class="tip-note">${_("Note: No spaces or special characters are allowed.")}</strong>
+                          The term in which the new course will run. (This value is often different than the original course run value.)
+                          <strong class="tip-note">Note: No spaces or special characters are allowed.</strong>
                         </span>
                         <span class="tip tip-error is-showing">Required field.</span>
                       </div>
@@ -262,8 +262,8 @@ TODO:
               </div>
 
               <div class="actions">
-                <button type="submit" class="action action-primary rerun-course-save is-disabled">${_('Create Re-run')}</button>
-                <button type="button" class="action action-secondary action-cancel rerun-course-cancel">${_('Cancel and Return to Dashboard')}</button>
+                <button type="submit" class="action action-primary rerun-course-save is-disabled">Create Re-run</button>
+                <button type="button" class="action action-secondary action-cancel rerun-course-cancel">Cancel and Return to Dashboard</button>
               </div>
             </form>
           </div><!-- /rerun-course -->
@@ -278,44 +278,44 @@ TODO:
 
               <div class="wrapper-form">
                 <fieldset>
-                  <legend class="sr">${_("Required Information to Create a re-run of a course")}</legend>
+                  <legend class="sr">Required Information to Create a re-run of a course</legend>
 
                   <ol class="list-input">
                     <li class="field text required" id="field-course-name">
-                      <label for="rerun-course-name">${_("Course Name")}</label>
-                      <input class="rerun-course-name" id="rerun-course-name" type="text" name="rerun-course-name" aria-required="true" placeholder="${_('e.g. Introduction to Computer Science')}" />
+                      <label for="rerun-course-name">Course Name</label>
+                      <input class="rerun-course-name" id="rerun-course-name" type="text" name="rerun-course-name" aria-required="true" placeholder="e.g. Introduction to Computer Science" />
                       <span class="tip">
-                        ${_("The public display name for the new course. (This name is often the same as the original course name.)")}
+                        The public display name for the new course. (This name is often the same as the original course name.)
                       </span>
                       <span class="tip tip-error is-hiding"></span>
                     </li>
                     <li class="field text required" id="field-organization">
-                      <label for="rerun-course-org">${_("Organization")}</label>
-                      <input class="rerun-course-org" id="rerun-course-org" type="text" name="rerun-course-org" aria-required="true" placeholder="${_('e.g. UniversityX or OrganizationX')}" />
+                      <label for="rerun-course-org">Organization</label>
+                      <input class="rerun-course-org" id="rerun-course-org" type="text" name="rerun-course-org" aria-required="true" placeholder="e.g. UniversityX or OrganizationX" />
                       <span class="tip">
-                        ${_("The name of the organization sponsoring the new course. (This name is often the same as the original organization name.)")}
-                        <strong class="tip-note">${_("Note: No spaces or special characters are allowed.")}</strong>
+                        The name of the organization sponsoring the new course. (This name is often the same as the original organization name.)
+                        <strong class="tip-note">Note: No spaces or special characters are allowed.</strong>
                       </span>
                       <span class="tip tip-error is-hiding"></span>
                     </li>
 
                     <li class="row">
                       <div class="column field text required" id="field-course-number">
-                        <label for="rerun-course-number">${_("Course Number")}</label>
-                        <input class="rerun-course-number" id="rerun-course-number" type="text" name="rerun-course-number" aria-required="true" placeholder="${_('e.g. CS101')}" />
+                        <label for="rerun-course-number">Course Number</label>
+                        <input class="rerun-course-number" id="rerun-course-number" type="text" name="rerun-course-number" aria-required="true" placeholder="e.g. CS101" />
                         <span class="tip">
-                          ${_("The unique number that identifies the new course within the organization.  (This number is often the same as the original course number.)")}
-                          <strong class="tip-note">${_("Note: No spaces or special characters are allowed.")}</strong>
+                          The unique number that identifies the new course within the organization.  (This number is often the same as the original course number.)
+                          <strong class="tip-note">Note: No spaces or special characters are allowed.</strong>
                         </span>
                         <span class="tip tip-error is-hiding"></span>
                       </div>
 
                       <div class="column field text required" id="field-course-run">
-                        <label for="rerun-course-run">${_("Course Run")}</label>
-                        <input class="rerun-course-run" id="rerun-course-run" type="text" name="rerun-course-run" aria-required="true"placeholder="${_('e.g. 2014_T1')}" />
+                        <label for="rerun-course-run">Course Run</label>
+                        <input class="rerun-course-run" id="rerun-course-run" type="text" name="rerun-course-run" aria-required="true"placeholder="e.g. 2014_T1" />
                         <span class="tip">
-                          ${_("The term in which the new course will run. (This value is often different than the original course run value.)")}
-                          <strong class="tip-note">${_("Note: No spaces or special characters are allowed.")}</strong>
+                          The term in which the new course will run. (This value is often different than the original course run value.)
+                          <strong class="tip-note">Note: No spaces or special characters are allowed.</strong>
                         </span>
                         <span class="tip tip-error is-hiding"></span>
                       </div>
@@ -329,7 +329,7 @@ TODO:
               <div class="actions">
                 <button type="submit" class="action action-primary rerun-course-save is-disabled is-processing">
                   <i class="icon icon-refresh icon-spin"></i>
-                  ${_('Processing Re-run Request')}
+                  Processing Re-run Request
                 </button>
               </div>
             </form>
@@ -339,23 +339,23 @@ TODO:
 
         <aside class="content-supplementary" role="complimentary">
           <div class="bit">
-            <h3 class="title-3">${_("When will my course re-run start?")}</h3>
+            <h3 class="title-3">When will my course re-run start?</h3>
             <ul class="list-details">
-              <li class="item-detail">${_("Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Sed posuere consectetur est at lobortis. Maecenas faucibus mollis interdum.")}</li>
+              <li class="item-detail">Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Sed posuere consectetur est at lobortis. Maecenas faucibus mollis interdum.</li>
             </ul>
           </div>
 
           <div class="bit">
-            <h3 class="title-3">${_("What transfers from the original course?")}</h3>
+            <h3 class="title-3">What transfers from the original course?</h3>
             <ul class="list-details">
-              <li class="item-detail">${_("Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Sed posuere consectetur est at lobortis. Maecenas faucibus mollis interdum.")}</li>
+              <li class="item-detail">Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Sed posuere consectetur est at lobortis. Maecenas faucibus mollis interdum.</li>
             </ul>
           </div>
 
           <div class="bit">
-            <h3 class="title-3">${_("What does not transfer from the original course?")}</h3>
+            <h3 class="title-3">What does not transfer from the original course?</h3>
             <ul class="list-details">
-              <li class="item-detail">${_("Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Sed posuere consectetur est at lobortis. Maecenas faucibus mollis interdum.")}</li>
+              <li class="item-detail">Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Sed posuere consectetur est at lobortis. Maecenas faucibus mollis interdum.</li>
             </ul>
           </div>
         </aside><!-- /content-supplementary -->

--- a/cms/templates/ux/reference/course-create-rerun.html
+++ b/cms/templates/ux/reference/course-create-rerun.html
@@ -1,20 +1,8 @@
-<!--
-
-DESIGN/UI NOTES:
-
-* create-course and new-course prefixed classes have been changed to use rerun-courses plus generic form-create class
-* changed form <input /> elements to <button> elements
-
-- - -
-
-TODO:
-
-* sync up styling of stateful classes
-* need to add support for allow_unicode_course_id in real view's template
-
- -->
-
 <%inherit file="../../base.html" />
+
+<%block name="view_notes">
+  <%include file="_note-usage.html" />
+</%block>
 
 <%! from django.utils.translation import ugettext as _ %>
 <%! from django.core.urlresolvers import reverse %>

--- a/cms/templates/ux/reference/index.html
+++ b/cms/templates/ux/reference/index.html
@@ -1,4 +1,9 @@
 <%inherit file="../../base.html" />
+
+<%block name="view_notes">
+  <%include file="_note-usage.html" />
+</%block>
+
 <%block name="title">UX Style Reference</%block>
 <%block name="bodyclass">is-signedin course uploads view-container</%block>
 

--- a/cms/templates/ux/reference/modal_bulkpublish-section.html
+++ b/cms/templates/ux/reference/modal_bulkpublish-section.html
@@ -5,16 +5,16 @@
     <div style="top: 5%; left: 30%;" class="modal-window confirm modal-med modal-type-confirm">
         <div class="bulkpublish-section-modal">
             <div class="modal-header">
-                <h2 class="title modal-window-title">${_("Publish [section name]")}</h2>
+                <h2 class="title modal-window-title">Publish [section name]</h2>
             </div>
 
             <div class="modal-content">
                 <div class="message modal-introduction">
-                    <p>${_("Publish all unpublished changes for this section?")}</p>
+                    <p>Publish all unpublished changes for this section?</p>
                 </div>
 
                 <div class="modal-section bulkpublish-included">
-                    <h3 class="modal-section-title">${_("The following will be published:")}</h3>
+                    <h3 class="modal-section-title">The following will be published:</h3>
                     <div class="modal-section-content">
                         <div class="outline outline-simple outline-bulkpublish">
                             <ol class="list-subsections">

--- a/cms/templates/ux/reference/modal_bulkpublish-subsection.html
+++ b/cms/templates/ux/reference/modal_bulkpublish-subsection.html
@@ -5,16 +5,16 @@
     <div style="top: 5%; left: 30%;" class="modal-window confirm modal-med modal-type-confirm">
         <div class="bulkpublish-subsection-modal">
             <div class="modal-header">
-                <h2 class="title modal-window-title">${_("Publish [subsection name]")}</h2>
+                <h2 class="title modal-window-title">Publish [subsection name]</h2>
             </div>
 
             <div class="modal-content">
                 <div class="message modal-introduction">
-                    <p>${_("Publish all unpublished changes for this subsection?")}</p>
+                    <p>Publish all unpublished changes for this subsection?</p>
                 </div>
 
                 <div class="modal-section bulkpublish-included">
-                    <h3 class="modal-section-title">${_("The following will be published:")}</h3>
+                    <h3 class="modal-section-title">The following will be published:</h3>
                     <div class="modal-section-content">
                         <div class="outline outline-simple outline-bulkpublish">
                             <ol class="list-units">

--- a/cms/templates/ux/reference/modal_bulkpublish-unit.html
+++ b/cms/templates/ux/reference/modal_bulkpublish-unit.html
@@ -5,12 +5,12 @@
     <div style="top: 5%; left: 30%;" class="modal-window confirm modal-med modal-type-confirm">
         <div class="bulkpublish-unit-modal">
             <div class="modal-header">
-                <h2 class="title modal-window-title">${_("Publish [unit name]")}</h2>
+                <h2 class="title modal-window-title">Publish [unit name]</h2>
             </div>
 
             <div class="modal-content">
                 <div class="message modal-introduction">
-                    <p>${_("Publish all unpublished changes for this unit?")}</p>
+                    <p>Publish all unpublished changes for this unit?</p>
                 </div>
             </div>
 

--- a/cms/templates/ux/reference/outline.html
+++ b/cms/templates/ux/reference/outline.html
@@ -1,4 +1,9 @@
 <%inherit file="../../base.html" />
+
+<%block name="view_notes">
+  <%include file="_note-usage.html" />
+</%block>
+
 <%!
 from django.core.urlresolvers import reverse
 %>


### PR DESCRIPTION
@talbs @frrrances UX reference templates shouldn't have i18n (neither should JS test fixtures).
