### PR TITLE
enable  sysadmin dashboard in devstack

### DIFF
--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -30,7 +30,7 @@ for pkg_name in ['track.contexts', 'track.middleware', 'dd.dogapi']:
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 FEATURES['ENABLE_INSTRUCTOR_EMAIL'] = True     # Enable email for all Studio courses
 FEATURES['REQUIRE_COURSE_EMAIL_AUTH'] = False  # Give all courses email (don't require django-admin perms)
-
+FEATURES['ENABLE_SYSADMIN_DASHBOARD'] = True   # sysadmin dashboard, to see what courses are loaded, to delete & load courses
 
 ########################## ANALYTICS TESTING ########################
 


### PR DESCRIPTION
Enable  sysadmin dashboard in devstack, to see what courses are loaded, to delete & load courses
