### PR TITLE
Update opaque-keys library to use block_id for html_id for new keys.

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -423,36 +423,37 @@ def course_index(request, course_key):
     """
     # A depth of None implies the whole course. The course outline needs this in order to compute has_changes.
     # A unit may not have a draft version, but one of its components could, and hence the unit itself has changes.
-    course_module = _get_course_module(course_key, request.user, depth=None)
-    lms_link = get_lms_link_for_item(course_module.location)
-    sections = course_module.get_children()
-    course_structure = _course_outline_json(request, course_module)
-    locator_to_show = request.REQUEST.get('show', None)
-    course_release_date = get_default_time_display(course_module.start) if course_module.start != DEFAULT_START_DATE else _("Unscheduled")
-    settings_url = reverse_course_url('settings_handler', course_key)
+    with modulestore().bulk_write_operations(course_key):
+        course_module = _get_course_module(course_key, request.user, depth=None)
+        lms_link = get_lms_link_for_item(course_module.location)
+        sections = course_module.get_children()
+        course_structure = _course_outline_json(request, course_module)
+        locator_to_show = request.REQUEST.get('show', None)
+        course_release_date = get_default_time_display(course_module.start) if course_module.start != DEFAULT_START_DATE else _("Unscheduled")
+        settings_url = reverse_course_url('settings_handler', course_key)
 
-    try:
-        current_action = CourseRerunState.objects.find_first(course_key=course_key, should_display=True)
-    except (ItemNotFoundError, CourseActionStateItemNotFoundError):
-        current_action = None
+        try:
+            current_action = CourseRerunState.objects.find_first(course_key=course_key, should_display=True)
+        except (ItemNotFoundError, CourseActionStateItemNotFoundError):
+            current_action = None
 
-    return render_to_response('course_outline.html', {
-        'context_course': course_module,
-        'lms_link': lms_link,
-        'sections': sections,
-        'course_structure': course_structure,
-        'initial_state': course_outline_initial_state(locator_to_show, course_structure) if locator_to_show else None,
-        'course_graders': json.dumps(
-            CourseGradingModel.fetch(course_key).graders
-        ),
-        'rerun_notification_id': current_action.id if current_action else None,
-        'course_release_date': course_release_date,
-        'settings_url': settings_url,
-        'notification_dismiss_url':
-            reverse_course_url('course_notifications_handler', current_action.course_key, kwargs={
-                'action_state_id': current_action.id,
-            }) if current_action else None,
-    })
+        return render_to_response('course_outline.html', {
+            'context_course': course_module,
+            'lms_link': lms_link,
+            'sections': sections,
+            'course_structure': course_structure,
+            'initial_state': course_outline_initial_state(locator_to_show, course_structure) if locator_to_show else None,
+            'course_graders': json.dumps(
+                CourseGradingModel.fetch(course_key).graders
+            ),
+            'rerun_notification_id': current_action.id if current_action else None,
+            'course_release_date': course_release_date,
+            'settings_url': settings_url,
+            'notification_dismiss_url':
+                reverse_course_url('course_notifications_handler', current_action.course_key, kwargs={
+                    'action_state_id': current_action.id,
+                }) if current_action else None,
+        })
 
 
 def course_outline_initial_state(locator_to_show, course_structure):

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/caching_descriptor_system.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/caching_descriptor_system.py
@@ -75,25 +75,29 @@ class CachingDescriptorSystem(MakoDescriptorSystem):
         else:
             block_id = usage_key
 
+        if isinstance(usage_key, BlockUsageLocator):
+            # trust the passed in key to know the caller's expectations of which fields are filled in.
+            # particularly useful for strip_keys so may go away when we're version aware
+            course_key = usage_key.course_key
+        else:
+            course_info = course_entry_override or self.course_entry
+            course_key = CourseLocator(
+                version_guid=course_info['structure']['_id'],
+                org=course_info.get('org'),
+                course=course_info.get('course'),
+                run=course_info.get('run'),
+                branch=course_info.get('branch'),
+            )
         json_data = self.module_data.get(block_id)
         if json_data is None:
             # deeper than initial descendant fetch or doesn't exist
-            course_info = course_entry_override or self.course_entry
-            course_key = CourseLocator(
-                course_info.get('org'), course_info.get('course'), course_info.get('run'), course_info.get('branch'),
-                course_info['structure']['_id']
-            )
             self.modulestore.cache_items(self, [block_id], course_key, lazy=self.lazy)
             json_data = self.module_data.get(block_id)
             if json_data is None:
                 raise ItemNotFoundError(block_id)
 
         class_ = self.load_block_type(json_data.get('category'))
-        new_item = self.xblock_from_json(class_, block_id, json_data, course_entry_override, **kwargs)
-        if isinstance(usage_key, BlockUsageLocator):
-            # trust the passed in key to know the caller's expectations of which fields are filled in.
-            # particularly useful for strip_keys so may go away when we're version aware
-            new_item.location = usage_key
+        new_item = self.xblock_from_json(class_, course_key, block_id, json_data, course_entry_override, **kwargs)
         return new_item
 
     # xblock's runtime does not always pass enough contextual information to figure out
@@ -107,7 +111,7 @@ class CachingDescriptorSystem(MakoDescriptorSystem):
     # low; thus, the course_entry is most likely correct. If the thread is looking at > 1 named container
     # pointing to the same structure, the access is likely to be chunky enough that the last known container
     # is the intended one when not given a course_entry_override; thus, the caching of the last branch/course id.
-    def xblock_from_json(self, class_, block_id, json_data, course_entry_override=None, **kwargs):
+    def xblock_from_json(self, class_, course_key, block_id, json_data, course_entry_override=None, **kwargs):
         if course_entry_override is None:
             course_entry_override = self.course_entry
         else:
@@ -124,15 +128,8 @@ class CachingDescriptorSystem(MakoDescriptorSystem):
         if block_id is None:
             block_id = LocalId()
 
-        block_course_key = CourseLocator(
-            version_guid=course_entry_override['structure']['_id'],
-            org=course_entry_override.get('org'),
-            course=course_entry_override.get('course'),
-            run=course_entry_override.get('run'),
-            branch=course_entry_override.get('branch'),
-        )
         block_locator = BlockUsageLocator(
-            block_course_key,
+            course_key,
             block_type=json_data.get('category'),
             block_id=block_id,
         )

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
@@ -1255,7 +1255,7 @@ class SplitMongoModuleStore(ModuleStoreWriteBase):
                     if field_name in fields:
                         json_data['_inherited_settings'][field_name] = fields[field_name]
 
-        new_block = runtime.xblock_from_json(xblock_class, block_id, json_data, **kwargs)
+        new_block = runtime.xblock_from_json(xblock_class, course_key, block_id, json_data, **kwargs)
         for field_name, value in fields.iteritems():
             setattr(new_block, field_name, value)
 

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -29,6 +29,6 @@
 -e git+https://github.com/edx-solutions/django-splash.git@7579d052afcf474ece1239153cffe1c89935bc4f#egg=django-splash
 -e git+https://github.com/edx/acid-block.git@459aff7b63db8f2c5decd1755706c1a64fb4ebb1#egg=acid-xblock
 -e git+https://github.com/edx/edx-ora2.git@release-2014-08-08T13.47#egg=edx-ora2
--e git+https://github.com/edx/opaque-keys.git@454bd984d9539550c6290020e92ee2d6094038d0#egg=opaque-keys
+-e git+https://github.com/edx/opaque-keys.git@7152bcd9be8afb4accee9aa5d9d3c67d575f3e4e#egg=opaque-keys
 -e git+https://github.com/edx/ease.git@97de68448e5495385ba043d3091f570a699d5b5f#egg=ease
 -e git+https://github.com/edx/i18n-tools.git@0d7847f9dfa2281640527b4dc51f5854f950f9b7#egg=i18n-tools


### PR DESCRIPTION
Catch more places where get_children was giving us version aware references.
LMS-11237

oh, and added a bulk ops call so use ?w=1

@cpennington @nasthagiri 
