### PR TITLE
Revert "Update opaque-keys library to use block_id for html_id for new k...

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -423,37 +423,36 @@ def course_index(request, course_key):
     """
     # A depth of None implies the whole course. The course outline needs this in order to compute has_changes.
     # A unit may not have a draft version, but one of its components could, and hence the unit itself has changes.
-    with modulestore().bulk_write_operations(course_key):
-        course_module = _get_course_module(course_key, request.user, depth=None)
-        lms_link = get_lms_link_for_item(course_module.location)
-        sections = course_module.get_children()
-        course_structure = _course_outline_json(request, course_module)
-        locator_to_show = request.REQUEST.get('show', None)
-        course_release_date = get_default_time_display(course_module.start) if course_module.start != DEFAULT_START_DATE else _("Unscheduled")
-        settings_url = reverse_course_url('settings_handler', course_key)
+    course_module = _get_course_module(course_key, request.user, depth=None)
+    lms_link = get_lms_link_for_item(course_module.location)
+    sections = course_module.get_children()
+    course_structure = _course_outline_json(request, course_module)
+    locator_to_show = request.REQUEST.get('show', None)
+    course_release_date = get_default_time_display(course_module.start) if course_module.start != DEFAULT_START_DATE else _("Unscheduled")
+    settings_url = reverse_course_url('settings_handler', course_key)
 
-        try:
-            current_action = CourseRerunState.objects.find_first(course_key=course_key, should_display=True)
-        except (ItemNotFoundError, CourseActionStateItemNotFoundError):
-            current_action = None
+    try:
+        current_action = CourseRerunState.objects.find_first(course_key=course_key, should_display=True)
+    except (ItemNotFoundError, CourseActionStateItemNotFoundError):
+        current_action = None
 
-        return render_to_response('course_outline.html', {
-            'context_course': course_module,
-            'lms_link': lms_link,
-            'sections': sections,
-            'course_structure': course_structure,
-            'initial_state': course_outline_initial_state(locator_to_show, course_structure) if locator_to_show else None,
-            'course_graders': json.dumps(
-                CourseGradingModel.fetch(course_key).graders
-            ),
-            'rerun_notification_id': current_action.id if current_action else None,
-            'course_release_date': course_release_date,
-            'settings_url': settings_url,
-            'notification_dismiss_url':
-                reverse_course_url('course_notifications_handler', current_action.course_key, kwargs={
-                    'action_state_id': current_action.id,
-                }) if current_action else None,
-        })
+    return render_to_response('course_outline.html', {
+        'context_course': course_module,
+        'lms_link': lms_link,
+        'sections': sections,
+        'course_structure': course_structure,
+        'initial_state': course_outline_initial_state(locator_to_show, course_structure) if locator_to_show else None,
+        'course_graders': json.dumps(
+            CourseGradingModel.fetch(course_key).graders
+        ),
+        'rerun_notification_id': current_action.id if current_action else None,
+        'course_release_date': course_release_date,
+        'settings_url': settings_url,
+        'notification_dismiss_url':
+            reverse_course_url('course_notifications_handler', current_action.course_key, kwargs={
+                'action_state_id': current_action.id,
+            }) if current_action else None,
+    })
 
 
 def course_outline_initial_state(locator_to_show, course_structure):

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
@@ -1258,7 +1258,7 @@ class SplitMongoModuleStore(ModuleStoreWriteBase):
                     if field_name in fields:
                         json_data['_inherited_settings'][field_name] = fields[field_name]
 
-        new_block = runtime.xblock_from_json(xblock_class, course_key, block_id, json_data, **kwargs)
+        new_block = runtime.xblock_from_json(xblock_class, block_id, json_data, **kwargs)
         for field_name, value in fields.iteritems():
             setattr(new_block, field_name, value)
 

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -29,6 +29,6 @@
 -e git+https://github.com/edx-solutions/django-splash.git@7579d052afcf474ece1239153cffe1c89935bc4f#egg=django-splash
 -e git+https://github.com/edx/acid-block.git@459aff7b63db8f2c5decd1755706c1a64fb4ebb1#egg=acid-xblock
 -e git+https://github.com/edx/edx-ora2.git@release-2014-08-08T13.47#egg=edx-ora2
--e git+https://github.com/edx/opaque-keys.git@7152bcd9be8afb4accee9aa5d9d3c67d575f3e4e#egg=opaque-keys
+-e git+https://github.com/edx/opaque-keys.git@454bd984d9539550c6290020e92ee2d6094038d0#egg=opaque-keys
 -e git+https://github.com/edx/ease.git@97de68448e5495385ba043d3091f570a699d5b5f#egg=ease
 -e git+https://github.com/edx/i18n-tools.git@0d7847f9dfa2281640527b4dc51f5854f950f9b7#egg=i18n-tools


### PR DESCRIPTION
Reverts edx/edx-platform#4960
install_prereqs is now failing with:

```
pip install -q --exists-action w -r requirements/edx/github.txt
[...]
  Could not find a tag or branch '7152bcd9be8afb4accee9aa5d9d3c67d575f3e4e', assuming commit.
fatal: Could not parse object '7152bcd9be8afb4accee9aa5d9d3c67d575f3e4e'.
Command /usr/bin/git reset --hard -q 7152bcd9be8afb4accee9aa5d9d3c67d575f3e4e failed with error code 128 in /edx/app/edxapp/venvs/edxapp/src/opaque-keys
Storing debug log for failure in /edx/app/edxapp/.pip/pip.log
```
