### PR TITLE
Pin coffee-script version to 1.6.1.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
     "name": "edx",
     "version": "0.1.0",
     "dependencies": {
-      "coffee-script": "1.6.X"
+      "coffee-script": "1.6.1"
     }
 }


### PR DESCRIPTION
@jzoldak @clytwynec this resolves the js tests problem I encountered this morning. It turns out that, with 1.6.X, our jenkins-workers were just continuing to use coffee-script 1.6.1. However, on a brand-new machine (i.e., with no npm packages installed), the js will be built with coffee-script 1.6.3, and a handful of tests break.

@gwprice @jimabramson the affected file containing the tests that fail using coffee-script 1.6.3 is common/static/coffee/spec/discussion/view/discussion_thread_view_spec.js if you wanted to take a look for yourselves. You could reproduce in devstack by changing this packages.json file to specifically 1.6.3, for example.
