### PR TITLE
Update test_group_configuration_validation on single group allowed

### DIFF
--- a/common/test/acceptance/tests/test_studio_split_test.py
+++ b/common/test/acceptance/tests/test_studio_split_test.py
@@ -644,9 +644,9 @@ class GroupConfigurationsTest(ContainerBase, SplitTestMixin):
         When I set a name
         And I delete the name of one of the groups and try to save
         Then I see error message "All groups must have a name"
-        When I delete the group without name and try to save
-        Then I see error message "Please add at least two groups."
-        When I add new group and try to save
+        When I delete all the groups and try to save
+        Then I see error message "There must be at least one group."
+        When I add a group and try to save
         Then I see the group configuration is saved successfully
         """
         def try_to_save_and_verify_error_message(message):
@@ -670,7 +670,9 @@ class GroupConfigurationsTest(ContainerBase, SplitTestMixin):
         config.name = "Name of the Group Configuration"
         config.groups[1].name = ''
         try_to_save_and_verify_error_message("All groups must have a name.")
-        config.groups[1].remove()
+        config.groups[0].remove()
+        config.groups[0].remove()
+        try_to_save_and_verify_error_message("There must be at least one group.")
         config.add_group()
 
         # Save the configuration
@@ -680,7 +682,7 @@ class GroupConfigurationsTest(ContainerBase, SplitTestMixin):
             config,
             name="Name of the Group Configuration",
             description="Description of the group configuration.",
-            groups=["Group A", "Group B"]
+            groups=["Group A"]
         )
 
     def test_group_configuration_empty_usage(self):


### PR DESCRIPTION
We no longer have requirement of at least two groups in Group Configuration, since https://github.com/edx/edx-platform/pull/4920

One unchanged test slipped through, and has to be corrected.

@olmar @auraz 
