### PR TITLE
Remove client side parsing of module_id

### DIFF
--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -77,6 +77,7 @@ from .tools import (
     set_due_date_extension,
     strip_if_string,
     bulk_email_is_enabled_for_course,
+    add_block_ids,
 )
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
 from opaque_keys import InvalidKeyError
@@ -1545,8 +1546,11 @@ def proxy_legacy_analytics(request, course_id):
         return HttpResponse("Error requesting from analytics server.", status=500)
 
     if res.status_code is 200:
+        payload = json.loads(res.content)
+        add_block_ids(payload)
+        content = json.dumps(payload)
         # return the successful request content
-        return HttpResponse(res.content, content_type="application/json")
+        return HttpResponse(content, content_type="application/json")
     elif res.status_code is 404:
         # forward the 404 and content
         return HttpResponse(res.content, content_type="application/json", status=404)

--- a/lms/djangoapps/instructor/views/legacy.py
+++ b/lms/djangoapps/instructor/views/legacy.py
@@ -51,7 +51,7 @@ from django_comment_common.models import (
 )
 from django_comment_client.utils import has_forum_access
 from instructor.offline_gradecalc import student_grades, offline_grades_available
-from instructor.views.tools import strip_if_string, bulk_email_is_enabled_for_course
+from instructor.views.tools import strip_if_string, bulk_email_is_enabled_for_course, add_block_ids
 from instructor_task.api import (
     get_running_instructor_tasks,
     get_instructor_task_history,
@@ -921,7 +921,9 @@ def instructor_dashboard(request, course_id):
         if res.status_code == codes.OK:
             # WARNING: do not use req.json because the preloaded json doesn't
             # preserve the order of the original record (hence OrderedDict).
-            return json.loads(res.content, object_pairs_hook=OrderedDict)
+            payload = json.loads(res.content, object_pairs_hook=OrderedDict)
+            add_block_ids(payload)
+            return payload
         else:
             log.error("Error fetching %s, code: %s, msg: %s",
                       url, res.status_code, res.content)

--- a/lms/djangoapps/instructor/views/tools.py
+++ b/lms/djangoapps/instructor/views/tools.py
@@ -14,6 +14,7 @@ from courseware.models import StudentModule
 from xmodule.fields import Date
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
+from opaque_keys.edx.keys import UsageKey
 
 from bulk_email.models import CourseAuthorization
 
@@ -309,3 +310,13 @@ def dump_student_extensions(course, student):
         "title": _("Due date extensions for {0} {1} ({2})").format(
             student.first_name, student.last_name, student.username),
         "data": data}
+
+
+def add_block_ids(payload):
+    """
+    rather than manually parsing block_ids from module_ids on the client, pass the block_ids explicitly in the payload
+    """
+    if 'data' in payload:
+        for ele in payload['data']:
+            if 'module_id' in ele:
+                ele['block_id'] = UsageKey.from_string(ele['module_id']).block_id

--- a/lms/static/coffee/src/instructor_dashboard/instructor_analytics.coffee
+++ b/lms/static/coffee/src/instructor_dashboard/instructor_analytics.coffee
@@ -120,9 +120,8 @@ class GradeDistributionDisplay
 
         # populate selector
         @$problem_selector.empty()
-        for {module_id, grade_info} in data.data
-          I4X_PROBLEM = /i4x:\/\/.*\/.*\/problem\/(.*)/
-          label = (I4X_PROBLEM.exec module_id)?[1]
+        for {module_id, block_id, grade_info} in data.data
+          label = block_id
           label ?= module_id
 
           @$problem_selector.append $ '<option/>',

--- a/lms/templates/courseware/instructor_dashboard.html
+++ b/lms/templates/courseware/instructor_dashboard.html
@@ -665,7 +665,7 @@ function goto( mode)
         </tr>
       %for row in analytics_results['ProblemGradeDistribution']['data']:
         <tr>
-          <td>${row['module_id'].split('/')[-1]}</td>
+          <td>${row['block_id']}</td>
           <td>${max(grade_record['max_grade'] for grade_record in row["grade_info"])}
           %for grade_record in row["grade_info"]:
           <td>


### PR DESCRIPTION
in analytics dashboard.
LMS-11209

@rocha I'm not sure how to test this and thought you could review it and test it. We can't have any code manually parse module ids.
