### PR TITLE
Annotation Tools: Turn off Private/Public option and add missing css group to MyNotes

### DIFF
--- a/common/static/js/vendor/ova/catch/js/catch.js
+++ b/common/static/js/vendor/ova/catch/js/catch.js
@@ -1124,9 +1124,15 @@ CatchAnnotation.prototype = {
         // checks to make sure that Grouping is redone when switching tags in text annotations
         if (this.options.media === 'text') {
             if (this.current_tab ==='public') {
-                this.annotator.plugins.Grouping.useGrouping = 0;
+                // this is to check if user is is MyNotes instead of the annotation component
+                if (typeof this.annotator.plugins.Grouping !== 'undefined') {
+                    this.annotator.plugins.Grouping.useGrouping = 0;
+                }
             } else {
-                this.annotator.plugins.Grouping.useGrouping = 1;
+                // this is to check if user is is MyNotes instead of the annotation component
+                if (typeof this.annotator.plugins.Grouping !== 'undefined'){
+                    this.annotator.plugins.Grouping.useGrouping = 1;
+                }
             }
             this.annotator.publish("changedTabsInCatch");
         }
@@ -1156,7 +1162,10 @@ CatchAnnotation.prototype = {
         var searchtype = searchtype || "";
         var searchInput = searchInput || ""; 
         this.clean = true;
-        this._clearAnnotator();
+
+        // the following cannot run in notes for there are no highlights
+        if($("#notesHolder").length === 0)
+            this._clearAnnotator();
         
         var annotator = this.annotator;
         var loadFromSearch = annotator.plugins.Store.options.loadFromSearch;

--- a/common/static/js/vendor/ova/catch/js/catch.js
+++ b/common/static/js/vendor/ova/catch/js/catch.js
@@ -1123,17 +1123,10 @@ CatchAnnotation.prototype = {
         
         // checks to make sure that Grouping is redone when switching tags in text annotations
         if (this.options.media === 'text') {
-            if (this.current_tab ==='public') {
+            if (typeof this.annotator.plugins.Grouping !== 'undefined') {
                 // this is to check if user is is MyNotes instead of the annotation component
-                if (typeof this.annotator.plugins.Grouping !== 'undefined') {
-                    this.annotator.plugins.Grouping.useGrouping = 0;
-                }
-            } else {
-                // this is to check if user is is MyNotes instead of the annotation component
-                if (typeof this.annotator.plugins.Grouping !== 'undefined'){
-                    this.annotator.plugins.Grouping.useGrouping = 1;
-                }
-            }
+                this.annotator.plugins.Grouping.useGrouping = this.current_tab === 'public' ? 0 : 1;
+            } 
             this.annotator.publish("changedTabsInCatch");
         }
         // Change userid and refresh
@@ -1164,8 +1157,9 @@ CatchAnnotation.prototype = {
         this.clean = true;
 
         // the following cannot run in notes for there are no highlights
-        if($("#notesHolder").length === 0)
+        if ($("#notesHolder").length === 0) {
             this._clearAnnotator();
+        }
         
         var annotator = this.annotator;
         var loadFromSearch = annotator.plugins.Store.options.loadFromSearch;

--- a/lms/templates/imageannotation.html
+++ b/lms/templates/imageannotation.html
@@ -96,7 +96,7 @@
                         'delete': ["${user.email}"],
                         'admin':  ["${user.email}"]
                 },
-                showViewPermissionsCheckbox: true,
+                showViewPermissionsCheckbox: false,
                 showEditPermissionsCheckbox: false,
                 userAuthorize: function(action, annotation, user) {
                     var token, tokens, _i, _len;

--- a/lms/templates/notes.html
+++ b/lms/templates/notes.html
@@ -3,6 +3,7 @@
 <%namespace name='static' file='static_content.html'/>
 ${static.css(group='style-vendor-tinymce-content', raw=True)}
 ${static.css(group='style-vendor-tinymce-skin', raw=True)}
+${static.css(group='style-xmodule-annotations', raw=True)}
 <script type="text/javascript" src="${static.url('js/vendor/tinymce/js/tinymce/tinymce.full.min.js', raw=True)}"></script>
  <script type="text/javascript" src="${static.url('js/vendor/tinymce/js/tinymce/jquery.tinymce.min.js', raw=True)}" ></script>
 <%inherit file="main.html" />

--- a/lms/templates/textannotation.html
+++ b/lms/templates/textannotation.html
@@ -85,7 +85,7 @@ ${static.css(group='style-xmodule-annotations', raw=True)}
                         'delete': ["${user.email}"],
                         'admin':  ["${user.email}"]
                 },
-                showViewPermissionsCheckbox: true,
+                showViewPermissionsCheckbox: false,
                 showEditPermissionsCheckbox: false,
                 userAuthorize: function(action, annotation, user) {
                     var token, tokens, _i, _len;

--- a/lms/templates/videoannotation.html
+++ b/lms/templates/videoannotation.html
@@ -88,7 +88,7 @@ ${static.css(group='style-xmodule-annotations', raw=True)}
                         'delete': ["${user.email}"],
                         'admin':  ["${user.email}"]
                 },
-                showViewPermissionsCheckbox: true,
+                showViewPermissionsCheckbox: false,
                 showEditPermissionsCheckbox: false,
                 userAuthorize: function(action, annotation, user) {
                     var token, tokens, _i, _len;


### PR DESCRIPTION
**Background:** With the last push for the annotation tool I moved css files into a group so they would only be loaded in the templates used for the components instead of everywhere in the LMS or CMS. I missed out on MyNotes. We are also running into some issues in our annotation server backend so we are disabling the options to make things Private or Public (got the okay for the courses going live in a week). Everything will now default to public since the point of the courses is to share annotations.

**Studio Updates:** None.

**LMS Updates:** Added the css group to one file and then turned the Permissions checkbox from `true` to `false`. Added check to make sure grouping exists so that "My Notes" works as intended.

**Testing**: What MyNotes looked like before: 
![Broken MyNotes Page](http://i.imgur.com/tTa9l34.png)

What it should look like (once you make annotations):
![Fixed MyNotes Page](http://i.imgur.com/pbZQbID.png)

What the editor looked like before:
![With the Permissions](http://i.imgur.com/uM00CLO.png)
What the editor should look like now:
![Without the Permissions](http://i.imgur.com/fBZwvVI.png)

The following [tarball](https://www.dropbox.com/s/phc0b08e6grtcdm/20014_T4.u1SV2n.tar.gz) contains units with the annotation tools (text, video, image). It also contains a new tab above that says "My Notes". From now on, any annotations made in text, video, or images will appear in the "My Notes" tab as a way to amalgamate the notes. To test the above, go into any (as many as you want) unit and add a comment. Check to see that the permissions button now is _not_ available. Then go to My Notes and see that your notes appear there. 
