### PR TITLE
update gunicorn app

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -39,7 +39,7 @@ firebase-token-generator==1.3.2
 fs==0.4.0
 GitPython==0.3.2.RC1
 glob2==0.3
-gunicorn==0.17.4
+gunicorn==19.1.0
 lazy==1.1
 lxml==3.0.1
 mako==0.9.1


### PR DESCRIPTION
gunicorn (0.17.4) terminates the process on timeout without giving time to cleanup (in case of worker timeout on importing large course data folder is not cleaned) while new version (19.1.0) gives worker time to cleanup of timeout.
relates to: PLAT-82
