### PR TITLE
(WIP) Ex-60 All students using registration codes from that purchase to be unable to access course material

### DIFF
--- a/lms/djangoapps/courseware/views.py
+++ b/lms/djangoapps/courseware/views.py
@@ -46,6 +46,7 @@ from xmodule.modulestore.search import path_to_location
 from xmodule.tabs import CourseTabList, StaffGradingTab, PeerGradingTab, OpenEndedGradingTab
 from xmodule.x_module import STUDENT_VIEW
 import shoppingcart
+from shoppingcart.models import CourseRegistrationCode
 from opaque_keys import InvalidKeyError
 
 from microsite_configuration import microsite
@@ -290,6 +291,14 @@ def index(request, course_id, chapter=None, section=None,
     course_key = SlashSeparatedCourseKey.from_deprecated_string(course_id)
 
     user = User.objects.prefetch_related("groups").get(id=request.user.id)
+
+    # Redirecting to dashboard if the course is blocked due to un payment.
+    redeemed_registration_codes = CourseRegistrationCode.objects.filter(course_id=course_key, registrationcoderedemption__redeemed_by=request.user)
+    for redeemed_registration in redeemed_registration_codes:
+        if not getattr(redeemed_registration.invoice, 'is_valid'):
+            log.warning(u'User %s cannot access the course %s because payment has not yet been received', user, course_key.to_deprecated_string())
+            return redirect(reverse('dashboard'))
+
     request.user = user  # keep just one instance of User
     course = get_course_with_access(user, 'load', course_key, depth=2)
     staff_access = has_access(user, 'staff', course)

--- a/lms/static/sass/multicourse/_dashboard.scss
+++ b/lms/static/sass/multicourse/_dashboard.scss
@@ -1085,4 +1085,61 @@
       @extend %t-copy;
     }
   }
-}
+   p.course-block{
+    border-style: solid;
+    border-color: #E3DC86;
+    padding: 5px;
+    border-width: 1px;
+    background: #FDFBE4;
+
+  }
+  .enter-course-blocked{
+
+    @include box-sizing(border-box);
+    display: block;
+    float: left;
+    font: normal 15px/1.6rem $sans-serif;
+    letter-spacing: 0;
+    padding: 6px 32px 7px;
+    text-align: center;
+    margin-top: 16px;
+    opacity:0.5;
+    background:#808080;
+    border:0;
+    color:white;
+    box-shadow:none;
+    &.archived {
+            @include button(simple, $button-archive-color);
+            font: normal 15px/1.6rem $sans-serif;
+            padding: 6px 32px 7px;
+
+            &:hover, &:focus {
+              text-decoration: none;
+            }
+          }
+  }
+  a.disable-look{
+    color: #808080;
+  }
+  a.disable-look-unregister{
+    color: #808080;
+    float: right;
+    display: block;
+    font-style: italic;
+    color: $lighter-base-font-color;
+    text-decoration: underline;
+    font-size: .8em;
+    margin-top: 32px;
+
+  }
+  a.disable-look-settings{
+    @extend a.disable-look-unregister;
+      margin-right: 10px;
+    }
+
+  }
+  a.fade-cover{
+    @extend .cover;
+    opacity: 0.5;
+  }
+

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -303,7 +303,8 @@
             <% course_mode_info = all_course_modes.get(course.id) %>
             <% show_refund_option = (course.id in show_refund_option_for) %>
             <% is_paid_course = (course.id in enrolled_courses_either_paid) %>
-            <%include file='dashboard/_dashboard_course_listing.html' args="course=course, enrollment=enrollment, show_courseware_link=show_courseware_link, cert_status=cert_status, show_email_settings=show_email_settings, course_mode_info=course_mode_info, show_refund_option = show_refund_option, is_paid_course = is_paid_course" />
+            <% is_course_blocked = (course.id in block_courses) %>
+            <%include file='dashboard/_dashboard_course_listing.html' args="course=course, enrollment=enrollment, show_courseware_link=show_courseware_link, cert_status=cert_status, show_email_settings=show_email_settings, course_mode_info=course_mode_info, show_refund_option = show_refund_option, is_paid_course = is_paid_course, is_course_blocked = is_course_blocked" />
       % endfor
 
       </ul>
@@ -518,3 +519,13 @@
     </form>
   </div>
 </section>
+
+<script>
+    $(function() {
+        $("#unregister_block_course").click( function(event) {
+            $("#unenroll_course_id").val( $(event.target).data("course-id") );
+            $("#unenroll_course_number").text( $(event.target).data("course-number") );
+        });
+    });
+</script>
+

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -1,4 +1,4 @@
-<%page args="course, enrollment, show_courseware_link, cert_status, show_email_settings, course_mode_info, show_refund_option, is_paid_course" />
+<%page args="course, enrollment, show_courseware_link, cert_status, show_email_settings, course_mode_info, show_refund_option, is_paid_course, is_course_blocked" />
 
 <%! from django.utils.translation import ugettext as _ %>
 <%!
@@ -31,9 +31,15 @@
     %>
 
     % if show_courseware_link:
-      <a href="${course_target}" class="cover">
+      % if not is_course_blocked:
+        <a href="${course_target}" class="cover">
         <img src="${course_image_url(course)}" alt="${_('{course_number} {course_name} Cover Image').format(course_number=course.number, course_name=course.display_name_with_default) |h}" />
       </a>
+        % else:
+        <a class="fade-cover">
+        <img src="${course_image_url(course)}" alt="${_('{course_number} {course_name} Cover Image').format(course_number=course.number, course_name=course.display_name_with_default) |h}" />
+      </a>
+        % endif
     % else:
       <div class="cover">
         <img src="${course_image_url(course)}" alt="${_('{course_number} {course_name} Cover Image').format(course_number=course.number, course_name=course.display_name_with_default) | h}" />
@@ -80,7 +86,11 @@
         <h2 class="university">${get_course_about_section(course, 'university')}</h2>
         <h3>
           % if show_courseware_link:
+             % if not is_course_blocked:
             <a href="${course_target}">${course.display_number_with_default | h} ${course.display_name_with_default}</a>
+            % else:
+            <a class="disable-look">${course.display_number_with_default | h} ${course.display_name_with_default}</a>
+            % endif
           % else:
             <span>${course.display_number_with_default | h} ${course.display_name_with_default}</span>
           % endif
@@ -91,7 +101,7 @@
       <%include file='_dashboard_certificate_information.html' args='cert_status=cert_status,course=course, enrollment=enrollment'/>
       % endif
 
-      % if course_mode_info['show_upsell']:
+      % if course_mode_info['show_upsell'] and not is_course_blocked:
         <div class="message message-upsell has-actions is-expandable is-shown">
 
             <div class="wrapper-tip">
@@ -122,48 +132,101 @@
             </div>
         </div>
       %endif
+      % if is_course_blocked:
+        <p id="block-course-msg" class="course-block">
+            ${_('You can no longer access this course because payment has not yet been received. you can <a href="#">contact the account holder</a> to request payment, or you can')}
+            <a id="unregister_block_course" rel="leanModal" data-course-id="${course.id.to_deprecated_string()}" data-course-number="${course.number}" href="#unenroll-modal" > ${_('unregister')} </a>
+            ${_('for this course.')}
+        </p>
+      %endif
 
       % if show_courseware_link:
         % if course.has_ended():
+         % if not is_course_blocked:
           <a href="${course_target}" class="enter-course archived">${_('View Archived Course')}</a>
         % else:
+          <a class="enter-course-blocked archived">${_('View Archived Course')}</a>
+        % endif
+        % else:
+        % if not is_course_blocked:
           <a href="${course_target}" class="enter-course">${_('View Course')}</a>
+        % else:
+          <a class="enter-course-blocked">${_('View Course')}</a>
+        % endif
         % endif
       % endif
 
       % if is_paid_course and show_refund_option:
         ## Translators: The course's name will be added to the end of this sentence.
+        % if not is_course_blocked:
         <a href="#unenroll-modal" class="unenroll" rel="leanModal" data-course-id="${course.id.to_deprecated_string()}" data-course-number="${course.number}" onclick="document.getElementById('track-info').innerHTML='${_("Are you sure you want to unregister from the purchased course")}';
         document.getElementById('refund-info').innerHTML=gettext('You will be refunded the amount you paid.')">
           ${_('Unregister')}
         </a>
+        % else:
+        <a class="disable-look-unregister" data-course-id="${course.id.to_deprecated_string()}" data-course-number="${course.number}" onclick="document.getElementById('track-info').innerHTML='${_("Are you sure you want to unregister from the purchased course")}';
+        document.getElementById('refund-info').innerHTML=gettext('You will be refunded the amount you paid.')">
+          ${_('Unregister')}
+        </a>
+        % endif
       % elif is_paid_course and not show_refund_option:
         ## Translators: The course's name will be added to the end of this sentence.
+        % if not is_course_blocked:
         <a href="#unenroll-modal" class="unenroll" rel="leanModal" data-course-id="${course.id.to_deprecated_string()}" data-course-number="${course.number}" onclick="document.getElementById('track-info').innerHTML='${_("Are you sure you want to unregister from the purchased course")}';
         document.getElementById('refund-info').innerHTML=gettext('You will not be refunded the amount you paid.')">
           ${_('Unregister')}
         </a>
+        % else:
+        <a class="disable-look-unregister" data-course-id="${course.id.to_deprecated_string()}" data-course-number="${course.number}" onclick="document.getElementById('track-info').innerHTML='${_("Are you sure you want to unregister from the purchased course")}';
+        document.getElementById('refund-info').innerHTML=gettext('You will not be refunded the amount you paid.')">
+          ${_('Unregister')}
+        </a>
+        % endif
       % elif enrollment.mode != "verified":
         ## Translators: The course's name will be added to the end of this sentence.
+        % if not is_course_blocked:
         <a href="#unenroll-modal" class="unenroll" rel="leanModal" data-course-id="${course.id.to_deprecated_string()}" data-course-number="${course.number}" onclick="document.getElementById('track-info').innerHTML='${_("Are you sure you want to unregister from")}'; document.getElementById('refund-info').innerHTML=''">
           ${_('Unregister')}
         </a>
+        % else:
+        <a class="disable-look-unregister" data-course-id="${course.id.to_deprecated_string()}" data-course-number="${course.number}" onclick="document.getElementById('track-info').innerHTML='${_("Are you sure you want to unregister from")}'; document.getElementById('refund-info').innerHTML=''">
+          ${_('Unregister')}
+        </a>
+        % endif
       % elif show_refund_option:
         ## Translators: The course's name will be added to the end of this sentence.
+        % if not is_course_blocked:
         <a href="#unenroll-modal" class="unenroll" rel="leanModal" data-course-id="${course.id.to_deprecated_string()}" data-course-number="${course.number}" onclick="document.getElementById('track-info').innerHTML='${_("Are you sure you want to unregister from the verified {cert_name_long} track of").format(cert_name_long=cert_name_long)}';
         document.getElementById('refund-info').innerHTML=gettext('You will be refunded the amount you paid.')">
           ${_('Unregister')}
         </a>
+        % else:
+        <a class="disable-look-unregister" data-course-id="${course.id.to_deprecated_string()}" data-course-number="${course.number}" onclick="document.getElementById('track-info').innerHTML='${_("Are you sure you want to unregister from the verified {cert_name_long} track of").format(cert_name_long=cert_name_long)}';
+        document.getElementById('refund-info').innerHTML=gettext('You will be refunded the amount you paid.')">
+          ${_('Unregister')}
+        </a>
+        % endif
       % else:
         ## Translators: The course's name will be added to the end of this sentence.
+        % if not is_course_blocked:
         <a href="#unenroll-modal" class="unenroll" rel="leanModal" data-course-id="${course.id.to_deprecated_string()}" data-course-number="${course.number}" onclick="document.getElementById('track-info').innerHTML='${_("Are you sure you want to unregister from the verified {cert_name_long} track of").format(cert_name_long=cert_name_long)}';
         document.getElementById('refund-info').innerHTML=gettext('The refund deadline for this course has passed, so you will not receive a refund.')">
           ${_('Unregister')}
         </a>
+        % else:
+        <a class="disable-look-unregister" data-course-id="${course.id.to_deprecated_string()}" data-course-number="${course.number}" onclick="document.getElementById('track-info').innerHTML='${_("Are you sure you want to unregister from the verified {cert_name_long} track of").format(cert_name_long=cert_name_long)}';
+        document.getElementById('refund-info').innerHTML=gettext('The refund deadline for this course has passed, so you will not receive a refund.')">
+          ${_('Unregister')}
+        </a>
+        % endif
       % endif
 
 % if show_email_settings:
+        % if not is_course_blocked:
         <a href="#email-settings-modal" class="email-settings" rel="leanModal" data-course-id="${course.id.to_deprecated_string()}" data-course-number="${course.number}" data-optout="${course.id.to_deprecated_string() in course_optouts}">${_('Email Settings')}</a>
+        % else:
+        <a class="disable-look-settings" data-course-id="${course.id.to_deprecated_string()}" data-course-number="${course.number}" data-optout="${course.id.to_deprecated_string() in course_optouts}">${_('Email Settings')}</a>
+        % endif
 % endif
 
 
@@ -171,3 +234,13 @@
   </section>
 </article>
 </li>
+ <script>
+           $( document ).ready(function() {
+
+               if("${is_course_blocked}" == "True"){
+                   $( "#unregister_block_course" ).click(function() {
+                       $('.disable-look-unregister').click();
+                   });
+               }
+           });
+ </script>


### PR DESCRIPTION
@cdodge I am just sharing my understanding for this task as there are some statements on wiki page: https://edx-wiki.atlassian.net/wiki/display/UX/White+label%3A+Payment+due that are creating confusions. 
In this PR, I am implementing the scenario -> If a third-party is responsible for payment. 

@cdodge If students try to access the course via a direct link to course material then it is not possible to show the content that they saw last, and redirecting them from the "you were last in"  landing page with a modal popup. So I in case of direct access to course i am redirecting the user to dashboard. 

Kindly share your feedback & suggestions. 
(Note: Some questions were asked related to EX-60 on JIRA)

Thanks.
