### PR TITLE
Refactor verify course id decorator and fixed tests.

### DIFF
--- a/lms/djangoapps/courseware/tests/test_lti_integration.py
+++ b/lms/djangoapps/courseware/tests/test_lti_integration.py
@@ -188,7 +188,7 @@ class TestLTIModuleListing(ModuleStoreTestCase):
         """tests that the draft lti module is part of the endpoint response"""
         request = mock.Mock()
         request.method = 'GET'
-        response = get_course_lti_endpoints(request, self.course.id.to_deprecated_string())
+        response = get_course_lti_endpoints(request, course_id=self.course.id.to_deprecated_string())
 
         self.assertEqual(200, response.status_code)
         self.assertEqual('application/json', response['Content-Type'])

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -463,7 +463,7 @@ class TestProgressDueDate(BaseDueDateTests):
         """ Returns the HTML for the progress page """
 
         mako_middleware_process_request(self.request)
-        return views.progress(self.request, course.id.to_deprecated_string(), self.user.id).content
+        return views.progress(self.request, course_id=course.id.to_deprecated_string(), student_id=self.user.id).content
 
 
 class TestAccordionDueDate(BaseDueDateTests):
@@ -560,11 +560,11 @@ class ProgressPageTests(ModuleStoreTestCase):
     def test_pure_ungraded_xblock(self):
         ItemFactory(category='acid', parent_location=self.vertical.location)
 
-        resp = views.progress(self.request, self.course.id.to_deprecated_string())
+        resp = views.progress(self.request, course_id=self.course.id.to_deprecated_string())
         self.assertEqual(resp.status_code, 200)
 
     def test_non_asci_grade_cutoffs(self):
-        resp = views.progress(self.request, self.course.id.to_deprecated_string())
+        resp = views.progress(self.request, course_id=self.course.id.to_deprecated_string())
         self.assertEqual(resp.status_code, 200)
 
 
@@ -581,11 +581,11 @@ class TestVerifyCourseIdDecorator(TestCase):
     def test_decorator_with_valid_course_id(self):
         mocked_view = create_autospec(views.course_about)
         view_function = views.verify_course_id(mocked_view)
-        view_function(self.request, self.valid_course_id)
+        view_function(self.request, course_id=self.valid_course_id)
         self.assertTrue(mocked_view.called)
 
     def test_decorator_with_invalid_course_id(self):
         mocked_view = create_autospec(views.course_about)
         view_function = views.verify_course_id(mocked_view)
-        self.assertRaises(Http404, view_function, self.request, self.invalid_course_id)
+        self.assertRaises(Http404, view_function, self.request, course_id=self.invalid_course_id)
         self.assertFalse(mocked_view.called)

--- a/lms/djangoapps/courseware/views.py
+++ b/lms/djangoapps/courseware/views.py
@@ -84,17 +84,18 @@ def user_groups(user):
 
 def verify_course_id(view_func):
     """
-    This decorator should only be used with views whose second argument is course_id.
+    This decorator should only be used with views whose kwargs must contain course_id.
     If course_id is not valid raise 404.
     """
 
     @wraps(view_func)
-    def _decorated(request, course_id, *args, **kwargs):
+    def _decorated(request, *args, **kwargs):
+        course_id = kwargs.get("course_id")
         try:
             SlashSeparatedCourseKey.from_deprecated_string(course_id)
         except InvalidKeyError:
             raise Http404
-        response = view_func(request, course_id, *args, **kwargs)
+        response = view_func(request, *args, **kwargs)
         return response
 
     return _decorated


### PR DESCRIPTION
Used course_id from keyword arguments this way decorator would become independent of the order of args. Fixed tests.
