### PR TITLE
change PaidCourseRegistration.contained_in_order

### DIFF
--- a/lms/djangoapps/shoppingcart/models.py
+++ b/lms/djangoapps/shoppingcart/models.py
@@ -478,8 +478,11 @@ class PaidCourseRegistration(OrderItem):
         """
         Is the course defined by course_id contained in the order?
         """
-        return course_id in [item.paidcourseregistration.course_id
-                             for item in order.orderitem_set.all().select_subclasses("paidcourseregistration")]
+        return course_id in [
+            item.course_id
+            for item in order.orderitem_set.all().select_subclasses("paidcourseregistration")
+            if isinstance(item, cls)
+        ]
 
     @classmethod
     def get_total_amount_of_purchased_item(cls, course_key):

--- a/lms/djangoapps/shoppingcart/tests/test_models.py
+++ b/lms/djangoapps/shoppingcart/tests/test_models.py
@@ -337,6 +337,16 @@ class PaidCourseRegistrationTest(ModuleStoreTestCase):
             reg1.purchased_callback()
         self.assertFalse(CourseEnrollment.is_enrolled(self.user, self.course_key))
 
+    def test_user_cart_has_both_items(self):
+        """
+        This test exists b/c having both CertificateItem and PaidCourseRegistration in an order used to break
+        PaidCourseRegistration.contained_in_order
+        """
+        cart = Order.get_cart_for_user(self.user)
+        CertificateItem.add_to_order(cart, self.course_key, self.cost, 'honor')
+        PaidCourseRegistration.add_to_order(self.cart, self.course_key)
+        self.assertTrue(PaidCourseRegistration.contained_in_order(cart, self.course_key))
+
 
 @override_settings(MODULESTORE=TEST_DATA_MONGO_MODULESTORE)
 class CertificateItemTest(ModuleStoreTestCase):


### PR DESCRIPTION
now handles cases where the order has both a PaidCourseRegistration
and a CertificateItem

@chrisndodge @cdodge 
