### PR TITLE
Fixed InvalidKeyError in course handler in studio.

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -1488,6 +1488,12 @@ class ContentStoreTest(ContentStoreTestCase):
         course_module = self.store.get_course(course_key)
         self.assertEquals(course_module.wiki_slug, 'MITx.111.2013_Spring')
 
+    def test_course_handler_with_invalid_course_key_string(self):
+        """Test viewing the course overview page with invalid course id"""
+
+        response = self.client.get_html('/course/edX/test')
+        self.assertEquals(response.status_code, 404)
+
 
 class MetadataSaveTestCase(ContentStoreTestCase):
     """Test that metadata is correctly cached and decached."""

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -12,7 +12,7 @@ from django.conf import settings
 from django.views.decorators.http import require_http_methods
 from django.core.exceptions import PermissionDenied
 from django.core.urlresolvers import reverse
-from django.http import HttpResponseBadRequest, HttpResponseNotFound, HttpResponse
+from django.http import HttpResponseBadRequest, HttpResponseNotFound, HttpResponse, Http404
 from util.json_request import JsonResponse, JsonResponseBadRequest
 from util.date_utils import get_default_time_display
 from edxmako.shortcuts import render_to_response
@@ -208,28 +208,31 @@ def course_handler(request, course_key_string=None):
     DELETE
         json: delete this branch from this course (leaving off /branch/draft would imply delete the course)
     """
-    response_format = request.REQUEST.get('format', 'html')
-    if response_format == 'json' or 'application/json' in request.META.get('HTTP_ACCEPT', 'application/json'):
-        if request.method == 'GET':
-            course_module = _get_course_module(CourseKey.from_string(course_key_string), request.user, depth=None)
-            return JsonResponse(_course_outline_json(request, course_module))
-        elif request.method == 'POST':  # not sure if this is only post. If one will have ids, it goes after access
-            return _create_or_rerun_course(request)
-        elif not has_course_access(request.user, CourseKey.from_string(course_key_string)):
-            raise PermissionDenied()
-        elif request.method == 'PUT':
-            raise NotImplementedError()
-        elif request.method == 'DELETE':
-            raise NotImplementedError()
+    try:
+        response_format = request.REQUEST.get('format', 'html')
+        if response_format == 'json' or 'application/json' in request.META.get('HTTP_ACCEPT', 'application/json'):
+            if request.method == 'GET':
+                course_module = _get_course_module(CourseKey.from_string(course_key_string), request.user, depth=None)
+                return JsonResponse(_course_outline_json(request, course_module))
+            elif request.method == 'POST':  # not sure if this is only post. If one will have ids, it goes after access
+                return _create_or_rerun_course(request)
+            elif not has_course_access(request.user, CourseKey.from_string(course_key_string)):
+                raise PermissionDenied()
+            elif request.method == 'PUT':
+                raise NotImplementedError()
+            elif request.method == 'DELETE':
+                raise NotImplementedError()
+            else:
+                return HttpResponseBadRequest()
+        elif request.method == 'GET':  # assume html
+            if course_key_string is None:
+                return course_listing(request)
+            else:
+                return course_index(request, CourseKey.from_string(course_key_string))
         else:
-            return HttpResponseBadRequest()
-    elif request.method == 'GET':  # assume html
-        if course_key_string is None:
-            return course_listing(request)
-        else:
-            return course_index(request, CourseKey.from_string(course_key_string))
-    else:
-        return HttpResponseNotFound()
+            return HttpResponseNotFound()
+    except InvalidKeyError:
+        raise Http404
 
 
 @login_required

--- a/common/djangoapps/external_auth/tests/test_ssl.py
+++ b/common/djangoapps/external_auth/tests/test_ssl.py
@@ -200,24 +200,17 @@ class SSLClientTest(ModuleStoreTestCase):
         This tests to make sure when immediate signup is on that
         the user doesn't get presented with the registration page.
         """
-        # Expect an InvalidKeyError from course page as we don't have anything else built
-        with self.assertRaisesRegexp(
-                InvalidKeyError,
-                "<class 'opaque_keys.edx.keys.CourseKey'>: None"
-        ):
-            self.client.get(
-                reverse('signup'), follow=True,
-                SSL_CLIENT_S_DN=self.AUTH_DN.format(self.USER_NAME, self.USER_EMAIL)
-            )
+        response = self.client.get(
+            reverse('signup'), follow=True,
+            SSL_CLIENT_S_DN=self.AUTH_DN.format(self.USER_NAME, self.USER_EMAIL)
+        )
+        self.assertEqual(response.status_code, 404)
         # assert that we are logged in
         self.assertIn(SESSION_KEY, self.client.session)
 
         # Now that we are logged in, make sure we don't see the registration page
-        with self.assertRaisesRegexp(
-                InvalidKeyError,
-                "<class 'opaque_keys.edx.keys.CourseKey'>: None"
-        ):
-            self.client.get(reverse('signup'), follow=True)
+        response = self.client.get(reverse('signup'), follow=True)
+        self.assertEqual(response.status_code, 404)
 
     @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
     @override_settings(FEATURES=FEATURES_WITH_SSL_AUTH_IMMEDIATE_SIGNUP)


### PR DESCRIPTION
LMS-11141

Implemented try except on `CourseKey.from_string()` in course handler to fix `InvalidKeyError`.

Added test for invalid `course_key_string`.
