### PR TITLE
Sanchez/fix django header tests

### DIFF
--- a/common/djangoapps/edxmako/shortcuts.py
+++ b/common/djangoapps/edxmako/shortcuts.py
@@ -77,6 +77,32 @@ def marketing_link_context_processor(request):
     )
 
 
+def header_footer_context_processor(request):
+    """
+    A django context processor to pass feature flags through to all Django
+    Templates that are related to the display of the header and footer in
+    the edX platform.
+    """
+    # TODO: ECOM-136 Remove this processor with the corresponding header and footer feature flags.
+    return dict(
+        [
+            ("ENABLE_NEW_EDX_HEADER", settings.FEATURES.get("ENABLE_NEW_EDX_HEADER", False)),
+            ("ENABLE_NEW_EDX_FOOTER", settings.FEATURES.get("ENABLE_NEW_EDX_FOOTER", False))
+        ]
+    )
+
+
+def open_source_footer_context_processor(request):
+    """
+    Checks the site name to determine whether to use the edX.org footer or the Open Source Footer.
+    """
+    return dict(
+        [
+            ("IS_EDX_DOMAIN", settings.FEATURES.get('IS_EDX_DOMAIN', False))
+        ]
+    )
+
+
 def render_to_string(template_name, dictionary, context=None, namespace='main'):
 
     # see if there is an override template defined in the microsite

--- a/common/djangoapps/edxmako/tests.py
+++ b/common/djangoapps/edxmako/tests.py
@@ -1,6 +1,7 @@
 
 from mock import patch, Mock
 import unittest
+import ddt
 
 from django.conf import settings
 from django.http import HttpResponse
@@ -10,11 +11,16 @@ from django.test.client import RequestFactory
 from django.core.urlresolvers import reverse
 import edxmako.middleware
 from edxmako import add_lookup, LOOKUP
-from edxmako.shortcuts import marketing_link, render_to_string
+from edxmako.shortcuts import (
+    marketing_link,
+    render_to_string,
+    header_footer_context_processor,
+    open_source_footer_context_processor
+)
 from student.tests.factories import UserFactory
 from util.testing import UrlResetMixin
 
-
+@ddt.ddt
 class ShortcutsTests(UrlResetMixin, TestCase):
     """
     Test the edxmako shortcuts file
@@ -33,6 +39,26 @@ class ShortcutsTests(UrlResetMixin, TestCase):
             expected_link = reverse('login')
             link = marketing_link('ABOUT')
             self.assertEquals(link, expected_link)
+
+    @ddt.data((True, True), (False, False), (False, True), (True, False))
+    @ddt.unpack
+    def test_header_and_footer(self, header_setting, footer_setting):
+        with patch.dict('django.conf.settings.FEATURES', {
+            'ENABLE_NEW_EDX_HEADER': header_setting,
+            'ENABLE_NEW_EDX_FOOTER': footer_setting,
+        }):
+            result = header_footer_context_processor({})
+            self.assertEquals(footer_setting, result.get('ENABLE_NEW_EDX_FOOTER'))
+            self.assertEquals(header_setting, result.get('ENABLE_NEW_EDX_HEADER'))
+
+    @ddt.data(True, False)
+    @ddt.unpack
+    def test_edx_footer(self, expected_result):
+        with patch.dict('django.conf.settings.FEATURES', {
+            'IS_EDX_DOMAIN': expected_result
+        }):
+            result = open_source_footer_context_processor({})
+            self.assertEquals(expected_result, result.get('IS_EDX_DOMAIN'))
 
 
 class AddLookupTests(TestCase):

--- a/common/djangoapps/edxmako/tests.py
+++ b/common/djangoapps/edxmako/tests.py
@@ -51,9 +51,9 @@ class ShortcutsTests(UrlResetMixin, TestCase):
             self.assertEquals(footer_setting, result.get('ENABLE_NEW_EDX_FOOTER'))
             self.assertEquals(header_setting, result.get('ENABLE_NEW_EDX_HEADER'))
 
-    @ddt.data(True, False)
+    @ddt.data((True, None), (False, None))
     @ddt.unpack
-    def test_edx_footer(self, expected_result):
+    def test_edx_footer(self, expected_result, _):
         with patch.dict('django.conf.settings.FEATURES', {
             'IS_EDX_DOMAIN': expected_result
         }):

--- a/lms/djangoapps/courseware/tests/test_footer.py
+++ b/lms/djangoapps/courseware/tests/test_footer.py
@@ -3,35 +3,35 @@ Tests related to the basic footer-switching based off SITE_NAME to ensure
 edx.org uses an edx footer but other instances use an Open edX footer.
 """
 
+from mock import patch
+
 from django.test import TestCase
 from django.test.utils import override_settings
 
 
 class TestFooter(TestCase):
 
-    @override_settings(SITE_NAME="edx.org")
     def test_edx_footer(self):
         """
         Verify that the homepage, when accessed at edx.org, has the edX footer
         """
+        with patch.dict('django.conf.settings.FEATURES', {"IS_EDX_DOMAIN": True}):
+            resp = self.client.get('/')
+            self.assertEqual(resp.status_code, 200)
 
-        resp = self.client.get('/')
-        self.assertEqual(resp.status_code, 200)
+            # assert that footer template has been properly overridden on homepage
+            # test the top-level element class; which is less likely to change than copy.
+            self.assertContains(resp, 'edx-footer')
 
-        # assert that footer template has been properly overridden on homepage
-        # test the top-level element class; which is less likely to change than copy.
-        self.assertContains(resp, 'edx-footer')
-
-    @override_settings(SITE_NAME="example.com")
     def test_openedx_footer(self):
         """
         Verify that the homepage, when accessed at something other than
         edx.org, has the Open edX footer
         """
+        with patch.dict('django.conf.settings.FEATURES', {"IS_EDX_DOMAIN": False}):
+            resp = self.client.get('/')
+            self.assertEqual(resp.status_code, 200)
 
-        resp = self.client.get('/')
-        self.assertEqual(resp.status_code, 200)
-
-        # assert that footer template has been properly overridden on homepage
-        # test the top-level element class; which is less likely to change than copy.
-        self.assertContains(resp, 'wrapper-footer')
+            # assert that footer template has been properly overridden on homepage
+            # test the top-level element class; which is less likely to change than copy.
+            self.assertContains(resp, 'wrapper-footer')

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -367,6 +367,12 @@ TEMPLATE_CONTEXT_PROCESSORS = (
     # Hack to get required link URLs to password reset templates
     'edxmako.shortcuts.marketing_link_context_processor',
 
+    # Allows the open edX footer to be leveraged in Django Templates.
+    'edxmako.shortcuts.open_source_footer_context_processor',
+
+    # TODO: Used for header and footer feature flags. Remove as part of ECOM-136
+    'edxmako.shortcuts.header_footer_context_processor',
+
     # Shoppingcart processor (detects if request.user has a cart)
     'shoppingcart.context_processor.user_has_cart_context_processor',
 )

--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -83,7 +83,7 @@
 
     google_analytics_file = microsite.get_template_path('google_analytics.html')
 
-    if getattr(settings, 'SITE_NAME', '').endswith('edx.org') and not is_microsite():
+    if settings.FEATURES['IS_EDX_DOMAIN'] and not is_microsite():
         if settings.FEATURES.get('ENABLE_NEW_EDX_FOOTER', False):
             footer_file = microsite.get_template_path('edx_footer.html')
         else:

--- a/lms/templates/main_django.html
+++ b/lms/templates/main_django.html
@@ -31,13 +31,24 @@
 
 <body class="{% block bodyclass %}{% endblock %} lang_{{LANGUAGE_CODE}}">
   <a class="nav-skip" href="{% block nav_skip %}#content{% endblock %}">{% trans "Skip to this view's content" %}</a>
-  {% include "navigation.html" %}
+  {% if ENABLE_NEW_EDX_HEADER %}
+    {% include "navigation.html" %}
+  {% else %}
+    {% include "original_navigation.html" %}
+  {% endif %}
   <div class="content-wrapper" id="content">
     {% block body %}{% endblock %}
     {% block bodyextra %}{% endblock %}
   </div>
-
-  {% include "edx_footer.html" %}
+  {% if IS_EDX_DOMAIN %}
+    {% if ENABLE_NEW_EDX_FOOTER %}
+        {% include "edx_footer.html" %}
+    {% else %}
+        {% include "original_edx_footer.html" %}
+    {% endif %}
+  {% else %}
+    {% include "footer.html" %}
+  {% endif %}
 
   {% compressed_js 'application' %}
   {% compressed_js 'module-js' %}


### PR DESCRIPTION
Cleaning up syntax for new DDT test and adding back changes from https://github.com/edx/edx-platform/pull/5024 

Ensuring DDT decorator syntax has explicit tuples. 

@dianakhuang @flowerhack @rlucioni The only change in this vs. PR 5024 is test_edx_footer()

@jzoldak 
