### PR TITLE
Ammar ben/bok choy shard 3

### DIFF
--- a/common/test/acceptance/tests/base_studio_test.py
+++ b/common/test/acceptance/tests/base_studio_test.py
@@ -4,6 +4,7 @@ from .helpers import UniqueCourseTest
 from ..pages.studio.overview import CourseOutlinePage
 from ..pages.studio.utils import verify_ordering
 
+
 class StudioCourseTest(UniqueCourseTest):
     """
     Base class for all Studio course tests.

--- a/common/test/acceptance/tests/test_studio_acid_xblock.py
+++ b/common/test/acceptance/tests/test_studio_acid_xblock.py
@@ -2,7 +2,6 @@
 Acceptance tests for Studio related to the acid xblock.
 """
 from unittest import skip
-from nose.plugins.attrib import attr
 from bok_choy.web_app_test import WebAppTest
 
 from ..pages.studio.auto_auth import AutoAuthPage
@@ -11,7 +10,6 @@ from ..pages.xblock.acid import AcidView
 from ..fixtures.course import CourseFixture, XBlockFixtureDesc
 
 
-@attr('shard_1')
 class XBlockAcidBase(WebAppTest):
     """
     Base class for tests that verify that XBlock integration is working correctly
@@ -120,7 +118,6 @@ class XBlockAcidNoChildTest(XBlockAcidBase):
         self.user = course_fix.user
 
 
-@attr('shard_1')
 class XBlockAcidParentBase(XBlockAcidBase):
     """
     Base class for tests that verify that parent XBlock integration is working correctly
@@ -174,7 +171,6 @@ class XBlockAcidEmptyParentTest(XBlockAcidParentBase):
         self.user = course_fix.user
 
 
-@attr('shard_1')
 class XBlockAcidChildTest(XBlockAcidParentBase):
     """
     Tests of an AcidBlock with children

--- a/common/test/acceptance/tests/test_studio_bad_data.py
+++ b/common/test/acceptance/tests/test_studio_bad_data.py
@@ -1,10 +1,8 @@
-from nose.plugins.attrib import attr
 from .base_studio_test import ContainerBase
 from ..fixtures.course import XBlockFixtureDesc
 from ..pages.studio.utils import verify_ordering
 
 
-@attr('shard_1')
 class BadComponentTest(ContainerBase):
     """
     Tests that components with bad content do not break the Unit page.
@@ -42,7 +40,6 @@ class BadComponentTest(ContainerBase):
         verify_ordering(self, unit, [{"": ["Unit HTML", "Unit Problem"]}])
 
 
-@attr('shard_1')
 class CopiedFromLmsBadContentTest(BadComponentTest):
     """
     Tests that components with HTML copied from the LMS (LmsRuntime) do not break the Unit page.
@@ -63,7 +60,6 @@ class CopiedFromLmsBadContentTest(BadComponentTest):
             """
 
 
-@attr('shard_1')
 class CopiedFromStudioBadContentTest(BadComponentTest):
     """
     Tests that components with HTML copied from the Studio (containing "ui-sortable" class) do not break the Unit page.
@@ -91,7 +87,6 @@ class CopiedFromStudioBadContentTest(BadComponentTest):
             """
 
 
-@attr('shard_1')
 class JSErrorBadContentTest(BadComponentTest):
     """
     Tests that components that throw JS errors do not break the Unit page.

--- a/common/test/acceptance/tests/test_studio_container.py
+++ b/common/test/acceptance/tests/test_studio_container.py
@@ -289,6 +289,7 @@ class EditContainerTest(NestedVerticalTest):
         self.modify_display_name_and_verify(container)
 
 
+@attr('shard_1')
 class UnitPublishingTest(ContainerBase):
     """
     Tests of the publishing control and related widgets on the Unit page.

--- a/common/test/acceptance/tests/test_studio_general.py
+++ b/common/test/acceptance/tests/test_studio_general.py
@@ -4,7 +4,6 @@ Acceptance tests for Studio.
 
 from unittest import skip
 from bok_choy.web_app_test import WebAppTest
-from nose.plugins.attrib import attr
 
 from ..pages.studio.asset_index import AssetIndexPage
 from ..pages.studio.auto_auth import AutoAuthPage
@@ -28,7 +27,6 @@ from ..fixtures.course import XBlockFixtureDesc
 from .base_studio_test import StudioCourseTest
 
 
-@attr('shard_1')
 class LoggedOutTest(WebAppTest):
     """
     Smoke test for pages in Studio that are visible when logged out.
@@ -48,7 +46,6 @@ class LoggedOutTest(WebAppTest):
             page.visit()
 
 
-@attr('shard_1')
 class LoggedInPagesTest(WebAppTest):
     """
     Tests that verify the pages in Studio that you can get to when logged
@@ -68,7 +65,6 @@ class LoggedInPagesTest(WebAppTest):
         self.dashboard_page.visit()
 
 
-@attr('shard_1')
 class CoursePagesTest(StudioCourseTest):
     """
     Tests that verify the pages in Studio that you can get to when logged
@@ -113,7 +109,6 @@ class CoursePagesTest(StudioCourseTest):
             page.visit()
 
 
-@attr('shard_1')
 class DiscussionPreviewTest(StudioCourseTest):
     """
     Tests that Inline Discussions are rendered with a custom preview in Studio

--- a/common/test/acceptance/tests/test_studio_outline.py
+++ b/common/test/acceptance/tests/test_studio_outline.py
@@ -1,8 +1,6 @@
 """
 Acceptance tests for studio related to the outline page.
 """
-from nose.plugins.attrib import attr
-
 from datetime import datetime, timedelta
 import itertools
 from pytz import UTC
@@ -69,7 +67,6 @@ class CourseOutlineTest(StudioCourseTest):
         verify_ordering(self, outline_page, expected_ordering)
 
 
-@attr('shard_2')
 class CourseOutlineDragAndDropTest(CourseOutlineTest):
     """
     Tests of drag and drop within the outline page.
@@ -124,7 +121,6 @@ class CourseOutlineDragAndDropTest(CourseOutlineTest):
         self.drag_and_verify(self.seq_1_vert_2_handle, self.chap_1_seq_2_handle, expected_ordering, course_outline_page)
 
 
-@attr('shard_2')
 class WarningMessagesTest(CourseOutlineTest):
     """
     Feature: Warning messages on sections, subsections, and units
@@ -329,7 +325,6 @@ class WarningMessagesTest(CourseOutlineTest):
             unit.toggle_staff_lock()
 
 
-@attr('shard_2')
 class EditingSectionsTest(CourseOutlineTest):
     """
     Feature: Editing Release date, Due date and grading type.
@@ -477,7 +472,6 @@ class EditingSectionsTest(CourseOutlineTest):
         self.assertIn(release_text, self.course_outline_page.section_at(0).subsection_at(0).release_date)
 
 
-@attr('shard_2')
 class StaffLockTest(CourseOutlineTest):
     """
     Feature: Sections, subsections, and units can be locked and unlocked from the course outline.
@@ -859,7 +853,6 @@ class StaffLockTest(CourseOutlineTest):
         self._remove_staff_lock_and_verify_warning(subsection, False)
 
 
-@attr('shard_2')
 class EditNamesTest(CourseOutlineTest):
     """
     Feature: Click-to-edit section/subsection names
@@ -975,7 +968,6 @@ class EditNamesTest(CourseOutlineTest):
         self.assertTrue(self.course_outline_page.section_at(0).is_collapsed)
 
 
-@attr('shard_2')
 class CreateSectionsTest(CourseOutlineTest):
     """
     Feature: Create new sections/subsections/units
@@ -1049,7 +1041,6 @@ class CreateSectionsTest(CourseOutlineTest):
         self.assertTrue(unit_page.is_inline_editing_display_name())
 
 
-@attr('shard_2')
 class DeleteContentTest(CourseOutlineTest):
     """
     Feature: Deleting sections/subsections/units
@@ -1161,7 +1152,6 @@ class DeleteContentTest(CourseOutlineTest):
         self.assertTrue(self.course_outline_page.has_no_content_message)
 
 
-@attr('shard_2')
 class ExpandCollapseMultipleSectionsTest(CourseOutlineTest):
     """
     Feature: Courses with multiple sections can expand and collapse all sections.
@@ -1293,7 +1283,6 @@ class ExpandCollapseMultipleSectionsTest(CourseOutlineTest):
         self.verify_all_sections(collapsed=False)
 
 
-@attr('shard_2')
 class ExpandCollapseSingleSectionTest(CourseOutlineTest):
     """
     Feature: Courses with a single section can expand and collapse all sections.
@@ -1333,7 +1322,6 @@ class ExpandCollapseSingleSectionTest(CourseOutlineTest):
         self.assertFalse(self.course_outline_page.section_at(0).subsection_at(1).is_collapsed)
 
 
-@attr('shard_2')
 class ExpandCollapseEmptyTest(CourseOutlineTest):
     """
     Feature: Courses with no sections initially can expand and collapse all sections after addition.
@@ -1371,7 +1359,6 @@ class ExpandCollapseEmptyTest(CourseOutlineTest):
         self.assertFalse(self.course_outline_page.section_at(0).is_collapsed)
 
 
-@attr('shard_2')
 class DefaultStatesEmptyTest(CourseOutlineTest):
     """
     Feature: Misc course outline default states/actions when starting with an empty course
@@ -1396,7 +1383,6 @@ class DefaultStatesEmptyTest(CourseOutlineTest):
         self.assertTrue(self.course_outline_page.bottom_add_section_button.is_present())
 
 
-@attr('shard_2')
 class DefaultStatesContentTest(CourseOutlineTest):
     """
     Feature: Misc course outline default states/actions when starting with a course with content
@@ -1421,7 +1407,6 @@ class DefaultStatesContentTest(CourseOutlineTest):
         self.assertEqual(courseware.xblock_component_type(2), 'discussion')
 
 
-@attr('shard_2')
 class UnitNavigationTest(CourseOutlineTest):
     """
     Feature: Navigate to units
@@ -1442,7 +1427,6 @@ class UnitNavigationTest(CourseOutlineTest):
         self.assertTrue(unit.is_browser_on_page)
 
 
-@attr('shard_1')
 class PublishSectionTest(CourseOutlineTest):
     """
     Feature: Publish sections.

--- a/common/test/acceptance/tests/test_studio_rerun.py
+++ b/common/test/acceptance/tests/test_studio_rerun.py
@@ -3,7 +3,6 @@ Acceptance tests for Studio related to course reruns.
 """
 
 import random
-from nose.plugins.attrib import attr
 from bok_choy.promise import EmptyPromise
 
 from ..pages.studio.index import DashboardPage
@@ -15,7 +14,6 @@ from ..fixtures.course import XBlockFixtureDesc
 from .base_studio_test import StudioCourseTest
 
 
-@attr('shard_2')
 class CourseRerunTest(StudioCourseTest):
     """
     Feature: Courses can be rerun

--- a/common/test/acceptance/tests/video/test_studio_video_editor.py
+++ b/common/test/acceptance/tests/video/test_studio_video_editor.py
@@ -3,10 +3,11 @@
 """
 Acceptance tests for CMS Video Editor.
 """
-
+from nose.plugins.attrib import attr
 from .test_studio_video_module import CMSVideoBaseTest
 
 
+@attr('shard_2')
 class VideoEditorTest(CMSVideoBaseTest):
     """
     CMS Video Editor Test Class

--- a/common/test/acceptance/tests/video/test_studio_video_module.py
+++ b/common/test/acceptance/tests/video/test_studio_video_module.py
@@ -12,7 +12,6 @@ from ...fixtures.course import CourseFixture, XBlockFixtureDesc
 from ..helpers import UniqueCourseTest, is_youtube_available, YouTubeStubConfig
 
 
-@attr('shard_2')
 @skipIf(is_youtube_available() is False, 'YouTube is not available!')
 class CMSVideoBaseTest(UniqueCourseTest):
     """
@@ -125,6 +124,7 @@ class CMSVideoBaseTest(UniqueCourseTest):
         self.unit_page.xblocks[1].save_settings()
 
 
+@attr('shard_2')
 class CMSVideoTest(CMSVideoBaseTest):
     """
     CMS Video Test Class

--- a/common/test/acceptance/tests/video/test_studio_video_transcript.py
+++ b/common/test/acceptance/tests/video/test_studio_video_transcript.py
@@ -18,10 +18,11 @@ front-end validation will not pass.
                   one stored on YouTube
     t_not_exist - this file does not exist on YouTube; it exists locally
 """
-
+from nose.plugins.attrib import attr
 from .test_studio_video_module import CMSVideoBaseTest
 
 
+@attr('shard_2')
 class VideoTranscriptTest(CMSVideoBaseTest):
     """
     CMS Video Transcript Test Class


### PR DESCRIPTION
@jzoldak @clytwynec @muhammad-ammar 

This would replace #4986, effectively de-coupling the all-tests.sh change in #4988 from the shard organization. That way, we can still cherry pick _only_ the all-tests.sh change as needed on older PRs that are being tested.
