### PR TITLE
AWS settings for XBlocks to have filesystem-like storage

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -88,6 +88,12 @@ CELERY_QUEUES = {
 with open(CONFIG_ROOT / CONFIG_PREFIX + "env.json") as env_file:
     ENV_TOKENS = json.load(env_file)
 
+DJFS = {
+    'type' : 's3fs',
+    'bucket' : ENV_TOKENS.get('xblock-fs-storage-bucket', None),
+    'prefix' : ENV_TOKENS.get('xblock-fs-storage-prefix', '')
+}
+
 # STATIC_URL_BASE specifies the base url to use for static files
 STATIC_URL_BASE = ENV_TOKENS.get('STATIC_URL_BASE', None)
 if STATIC_URL_BASE:

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -111,6 +111,12 @@ if os.environ.get('QUEUE') == 'high_mem':
 with open(CONFIG_ROOT / CONFIG_PREFIX + "env.json") as env_file:
     ENV_TOKENS = json.load(env_file)
 
+DJFS = {
+    'type' : 's3fs',
+    'bucket' : ENV_TOKENS.get('xblock-fs-storage-bucket', None),
+    'prefix' : ENV_TOKENS.get('xblock-fs-storage-prefix', '')
+}
+
 # STATIC_ROOT specifies the directory where static files are
 # collected
 STATIC_ROOT_BASE = ENV_TOKENS.get('STATIC_ROOT_BASE', None)


### PR DESCRIPTION
@cpennington @jarv PR to add s3fs support to aws.py. 

I tested this on sandbox to make sure edx-platform still works. I did not test whether configuring djpyfs works. I do not have a way to test this within the next 30 minutes. The Profile block requires backports from xblock-sdk to edx-platform. The pyfs-backed recommender has an issue working on sandbox, irrespective of this patch, and I'm still figuring out how to debug on sandbox. I won't have that done in the next 30 minutes. 

However, this is zero risk for now, since I'm not deploying anything which requires the above at the same time. Old recommender and everything else works fine. 

Mind if I merge prior to cut-to-release? If it works, it will save time later as we're debugging. If it doesn't work for any reason, little harm done (will need to be cleaned up in a new patch). 

Next step would be to add the matching tokens to the JSON config file. 
