### PR TITLE
Correct 3rd party auth login page message and styling

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -883,13 +883,16 @@ def login_user(request, error=""):  # pylint: disable-msg=too-many-statements,un
             AUDIT_LOG.warning(
                 u'Login failed - user with username {username} has no social auth with backend_name {backend_name}'.format(
                     username=username, backend_name=backend_name))
-            return JsonResponse({
-                "success": False,
-                # Translators: provider_name is the name of an external, third-party user authentication service (like
-                # Google or LinkedIn).
-                "value": _('There is no {platform_name} account associated with your {provider_name} account. Please use your {platform_name} credentials or pick another provider.').format(
-                    platform_name=settings.PLATFORM_NAME, provider_name=requested_provider.NAME)
-            })  # TODO: this should be a status code 401  # pylint: disable=fixme
+            return HttpResponseBadRequest(
+                _("<p>You've successfully logged into your {provider_name} account, but this account "
+               "isn't linked with an {platform_name} account yet. Use your {platform_name} username and "
+               "password to log into {platform_name} below, and then link your {platform_name} account with "
+               "{provider_name} from your dashboard.</p><p>If you don't have an {platform_name} account yet, click "
+               "<strong>Register Now</strong> at the top of the page.</p>").format(
+                    platform_name=settings.PLATFORM_NAME, provider_name=requested_provider.NAME),
+                content_type= "text/plain",
+                status=401
+            )
 
     else:
 

--- a/lms/static/sass/multicourse/_account.scss
+++ b/lms/static/sass/multicourse/_account.scss
@@ -610,6 +610,14 @@
         display: block;
       }
     }
+
+    .third-party-signin.message {
+      display: none;
+
+      &.is-shown {
+        display: block;
+      }
+    }
   }
 }
 

--- a/lms/templates/login.html
+++ b/lms/templates/login.html
@@ -46,8 +46,10 @@
         toggleSubmitButton(false);
       });
 
-      $('#login-form').on('ajax:error', function() {
+      $('#login-form').on('ajax:error', function(event, request, status_string) {
         toggleSubmitButton(true);
+        $('.third-party-signin.message').addClass('is-shown').focus();
+        $('.third-party-signin.message .instructions').html(request.responseText);
       });
 
       $('#login-form').on('ajax:success', function(event, json, xhr) {
@@ -74,6 +76,7 @@
         } else {
           toggleSubmitButton(true);
           $('.message.submission-error').addClass('is-shown').focus();
+          debugger;
           $('.message.submission-error .message-copy').html(json.value);
         }
       });
@@ -134,18 +137,22 @@
 
       <!-- status messages -->
       <div role="alert" class="status message">
-        <h3 class="message-title">${_("We're Sorry, {platform_name} accounts are unavailable currently").format(platform_name=platform_name)}</h3>
+        <h3 class="message-title">${_("We're sorry, {platform_name} accounts are currently unavailable.").format(platform_name=platform_name)}</h3>
       </div>
 
       <div role="alert" class="status message submission-error" tabindex="-1">
-        <h3 class="message-title">${_("The following errors occurred while logging you in:")} </h3>
+        <h3 class="message-title">${_("We couldn't log you in.")} </h3>
         <ul class="message-copy">
           <li>${_("Your email or password is incorrect")}</li>
         </ul>
       </div>
 
+      <div role="alert" class="third-party-signin message" tabindex="-1">
+        <p class="instructions"> </p>
+      </div>
+
       <p class="instructions sr">
-        ${_('Please provide the following information to log into your {platform_name} account. Required fields are noted by <strong class="indicator">bold text and an asterisk (*)</strong>.').format(platform_name=platform_name)}
+        ${_('Please provide the following information to log into your {platform_name} account. Required fields are denoted by <strong class="indicator">bold text and an asterisk (*)</strong>.').format(platform_name=platform_name)}
       </p>
 
       <div class="group group-form group-form-requiredinformation">

--- a/lms/templates/register.html
+++ b/lms/templates/register.html
@@ -137,7 +137,7 @@
 
         <p class="instructions">
           ${_('Create your own {platform_name} account below').format(platform_name=platform_name)}
-          <span class="note">${_('Required fields are noted by <strong class="indicator">bold text and an asterisk (*)</strong>.')}</span>
+          <span class="note">${_('Required fields are denoted by <strong class="indicator">bold text and an asterisk (*)</strong>.')}</span>
         </p>
 
 
@@ -146,7 +146,7 @@
         <p class="instructions">
           ## Translators: selected_provider is the name of an external, third-party user authentication service (like Google or LinkedIn).
           ${_("You've successfully signed in with {selected_provider}.").format(selected_provider='<strong>%s</strong>' % selected_provider)}<br />
-          ${_("Finish your account registration below to start learning.")}
+          ${_("We just need a little more information before you start learning with edX.")}
         </p>
 
         % endif
@@ -155,7 +155,7 @@
 
       <p class="instructions">
         ${_("Please complete the following fields to register for an account. ")}<br />
-        ${_('Required fields are noted by <strong class="indicator">bold text and an asterisk (*)</strong>.')}
+        ${_('Required fields are denoted by <strong class="indicator">bold text and an asterisk (*)</strong>.')}
       </p>
 
       % endif


### PR DESCRIPTION
This addresses [ECOM-219](https://openedx.atlassian.net/browse/ECOM-219). @stephensanchez and @dianakhuang, could you please give this a look?

@sarina, the string returned by `HttpResponseBadRequest` includes HTML tags, specifically <p> and <strong>. I'm aware that our i18n guidelines discourage this, but I did it at @griffresch's suggestion as an alternative to writing complicated code to add the line break and bolding retroactively. Since Griff has asked for these copy changes to be in this week's release, and knowing that we would create a story to clean this up for next week, would you be okay with taking this approach for now? Can you think of a better way to implement this?
