### PR TITLE
capa custom response support for decimal grades

### DIFF
--- a/common/lib/capa/capa/tests/test_correctmap.py
+++ b/common/lib/capa/capa/tests/test_correctmap.py
@@ -85,7 +85,7 @@ class CorrectMapTest(unittest.TestCase):
         self.cmap.set(
             answer_id='1_2_1',
             correctness='correct',
-            npoints=5
+            npoints=5.3
         )
 
         self.cmap.set(
@@ -116,7 +116,7 @@ class CorrectMapTest(unittest.TestCase):
         # If points assigned --> npoints
         # If no points assigned and correct --> 1 point
         # If no points assigned and incorrect --> 0 points
-        self.assertEqual(self.cmap.get_npoints('1_2_1'), 5)
+        self.assertEqual(self.cmap.get_npoints('1_2_1'), 5.3)
         self.assertEqual(self.cmap.get_npoints('2_2_1'), 1)
         self.assertEqual(self.cmap.get_npoints('3_2_1'), 5)
         self.assertEqual(self.cmap.get_npoints('4_2_1'), 0)


### PR DESCRIPTION
@nedbat please forward to someone(s) for review whenever convenient

This adds support for partial (decimal) grades to custom python-graded responses.  Basically, in the dict returned by the grading function (specified by python), I've added an additional, _optional_ key `grade_decimal`, that will specify the partial credit for that response (instead of binary 0 or max).  The `ok` key still controls "correctness" in `CorrectMap`, which shows up in the UI as controlling the "checkmark" versus "x" displayed to the student.  This partial credit functionality for the score of a response was surprisingly not present before.

The particular use case we have is that our compilers course has a programming component that's done via a downloaded VM.  Students can run a grading script on the VM, get a hash, and then copy and paste this hash into a custom-graded response with a textbox to get a score.  Since the score can any integer [0, 63], we needed to be able to specify partial credit.

@jinpa as FYI.
