### PR TITLE
workaround for custom_tag being broken

### DIFF
--- a/common/lib/xmodule/xmodule/template_module.py
+++ b/common/lib/xmodule/xmodule/template_module.py
@@ -55,7 +55,10 @@ class CustomTagDescriptor(RawDescriptor):
         # cdodge: look up the template as a module
         template_loc = self.location.replace(category='custom_tag_template', name=template_name)
 
-        template_module = system.load_item(template_loc)
+        try:
+            template_module = system.load_item(template_loc)
+        except:
+            template_module = system.load_item(template_loc.for_branch('draft'))
         template_module_data = template_module.data
         template = Template(template_module_data)
         return template.render(**params)


### PR DESCRIPTION
The `<customtag>` construct is supported within edX XML (see http://edx.readthedocs.org/projects/devdata/en/latest/course_data_formats/course_xml.html?highlight=custom_tag#customtag), and has been used on edx.org, but is currently broken for several MITx courses.

The problem is that the custom_tag/*.xml files are being loaded by XML import as being "revision='draft'", instead of "revision=null".  For example:

```
> db.modulestore.find({"_id.course":"2.01r","_id.category":"custom_tag_template"})
{ "_id" : { "tag" : "i4x", "org" : "MITx", "course" : "2.01r", "category" : 
               "custom_tag_template", "name" : "boardnotes", "revision" : "draft" }, 
 "definition" : { "data" ...
```

The proper fix is to figure out the xml importer, and make it import with the right revision.  In particular, "_id.revision" is the mongo key id corresponding to what is called the "branch" in the mongo modulestore code, and this ought to have been null instead of "draft".  But all that code is mucked up with split mongo and jazz.

This PR works around the problem by making the template_module (which handles `<customtag>`) search for the module within the "draft" branch, as a fallback, if it is not found in the default way.   This is pretty safe, as a patch, because it only affects that single module, and also, authoring of custom tags is not supported in Studio, and thus this only affects courses authoring XML directly, and these courses are not putting the customtag template definitions deliberately in the draft directory.

This fix has been tested with the residential MITx deployment, and is in production use at MIT.

Note that edX-platform has no tests (as far as I see) for `<customtag>`, despite this feature being documented, and also being used in MITx courses on edX.  This PR, being a temporary workaround, also comes with no unit tests.  I admit the `except` clause could have been more explicit, and only catch the ItemNotFound error.   Perhaps some kind soul could fix this, if the patch gets used by edX.

To test it by hand, do something like this:
1. create the file `custom_tags/under_construction` (no .xml suffix) with this content:
   
   `<html display_name="Under Construction">`
   `<div id="unique_seed" style="display:none">${unique_seed}</div>`
   `<h2>This section is not quite ready yet&#8230;</h2>`
      `<center>`
           `<img src="http://anticap.files.wordpress.com/2011/03/bridge-to-nowhere.jpg?w=614&h=446" width="80%"/>`
      `</center>`
      `<p style="text-align:right">&#8230;please check back later!</p>`
   `</html>`
2. add a sequential like this:
   
   ```
   <sequential display_name="Board Notes W1" url_name="W1_F14_bn">
       <customtag impl="under_construction" unique_seed="201408311540" display_name="Under Construction W1_F14_bn"/>
   </sequential>
   ```

When you visit the sequential you should see a page like this:

![image](https://cloud.githubusercontent.com/assets/1590761/4128305/b224108e-3308-11e4-9aae-3d7dd0ca92d3.png)
