### PR TITLE
Fixed video not playing after changing speed to anything other than 1.

### DIFF
--- a/common/lib/xmodule/xmodule/js/spec/video/video_player_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_player_spec.js
@@ -496,7 +496,7 @@ function (VideoPlayer) {
                     state.speed = '2.0';
                     state.videoPlayer.onPlay();
                     expect(state.videoPlayer.setPlaybackRate)
-                        .toHaveBeenCalledWith('2.0');
+                        .toHaveBeenCalledWith('2.0', true);
                     state.videoPlayer.onPlay();
                     expect(state.videoPlayer.setPlaybackRate.calls.length)
                         .toEqual(1);


### PR DESCRIPTION
BLD-1221

On Firefox, if we change default video speed anything other than 1x, video will not play.

Ticket Link: https://openedx.atlassian.net/browse/BLD-1221
