### PR TITLE
Fix link in account activation email

### DIFF
--- a/lms/templates/emails/activation_email.txt
+++ b/lms/templates/emails/activation_email.txt
@@ -18,7 +18,7 @@ ${_("Activation ensures that you can register for {platform_name} courses and"
       " If you require assistance, please use our web form at"
       " {contact_us} or email {info_address}.").format(
              platform_name=settings.PLATFORM_NAME,
-             contact_us=settings.MKTG_URL_LINK_MAP['CONTACT'],
+             contact_us='https://www.edx.org/contact-us',
              info_address=settings.CONTACT_EMAIL
       )}
 


### PR DESCRIPTION
@dianakhuang @flowerhack -- is this URL present anywhere programmatically? I'd really love to not have to code this in directly, but `settings.MKTG_URL_LINK_MAP` apparently is not something we actually use and I don't know what else it could be.

@hkim823 fyi this needs to go into the release candidate.
