### PR TITLE
external_auth: handle request.META values as str, not unicode

### DIFF
--- a/common/djangoapps/external_auth/views.py
+++ b/common/djangoapps/external_auth/views.py
@@ -137,7 +137,7 @@ def _external_login_or_signup(request,
     try:
         eamap = ExternalAuthMap.objects.get(external_id=external_id,
                                             external_domain=external_domain)
-        log.debug('Found eamap=%s', eamap)
+        log.debug(u'Found eamap=%s', eamap)
     except ExternalAuthMap.DoesNotExist:
         # go render form for creating edX user
         eamap = ExternalAuthMap(external_id=external_id,
@@ -146,7 +146,7 @@ def _external_login_or_signup(request,
         eamap.external_email = email
         eamap.external_name = fullname
         eamap.internal_password = generate_password()
-        log.debug('Created eamap=%s', eamap)
+        log.debug(u'Created eamap=%s', eamap)
         eamap.save()
 
     log.info(u"External_Auth login_or_signup for %s : %s : %s : %s", external_domain, external_id, email, fullname)
@@ -166,7 +166,7 @@ def _external_login_or_signup(request,
                     eamap.user = link_user
                     eamap.save()
                     internal_user = link_user
-                    log.info('SHIB: Linking existing account for %s', eamap.external_id)
+                    log.info(u'SHIB: Linking existing account for %s', eamap.external_id)
                     # now pass through to log in
                 else:
                     # otherwise, there must have been an error, b/c we've already linked a user with these external
@@ -177,10 +177,10 @@ def _external_login_or_signup(request,
                                            % getattr(settings, 'TECH_SUPPORT_EMAIL', 'techsupport@class.stanford.edu')))
                     return default_render_failure(request, failure_msg)
             except User.DoesNotExist:
-                log.info('SHIB: No user for %s yet, doing signup', eamap.external_email)
+                log.info(u'SHIB: No user for %s yet, doing signup', eamap.external_email)
                 return _signup(request, eamap, retfun)
         else:
-            log.info('No user for %s yet. doing signup', eamap.external_email)
+            log.info(u'No user for %s yet. doing signup', eamap.external_email)
             return _signup(request, eamap, retfun)
 
     # We trust shib's authentication, so no need to authenticate using the password again
@@ -194,25 +194,25 @@ def _external_login_or_signup(request,
             auth_backend = 'django.contrib.auth.backends.ModelBackend'
         user.backend = auth_backend
         if settings.FEATURES['SQUELCH_PII_IN_LOGS']:
-            AUDIT_LOG.info('Linked user.id: {0} logged in via Shibboleth'.format(user.id))
+            AUDIT_LOG.info(u'Linked user.id: {0} logged in via Shibboleth'.format(user.id))
         else:
-            AUDIT_LOG.info('Linked user "{0}" logged in via Shibboleth'.format(user.email))
+            AUDIT_LOG.info(u'Linked user "{0}" logged in via Shibboleth'.format(user.email))
     elif uses_certs:
         # Certificates are trusted, so just link the user and log the action
         user = internal_user
         user.backend = 'django.contrib.auth.backends.ModelBackend'
         if settings.FEATURES['SQUELCH_PII_IN_LOGS']:
-            AUDIT_LOG.info('Linked user_id {0} logged in via SSL certificate'.format(user.id))
+            AUDIT_LOG.info(u'Linked user_id {0} logged in via SSL certificate'.format(user.id))
         else:
-            AUDIT_LOG.info('Linked user "{0}" logged in via SSL certificate'.format(user.email))
+            AUDIT_LOG.info(u'Linked user "{0}" logged in via SSL certificate'.format(user.email))
     else:
         user = authenticate(username=uname, password=eamap.internal_password, request=request)
     if user is None:
         # we want to log the failure, but don't want to log the password attempted:
         if settings.FEATURES['SQUELCH_PII_IN_LOGS']:
-            AUDIT_LOG.warning('External Auth Login failed')
+            AUDIT_LOG.warning(u'External Auth Login failed')
         else:
-            AUDIT_LOG.warning('External Auth Login failed for "{0}"'.format(uname))
+            AUDIT_LOG.warning(u'External Auth Login failed for "{0}"'.format(uname))
         return _signup(request, eamap, retfun)
 
     if not user.is_active:
@@ -222,14 +222,14 @@ def _external_login_or_signup(request,
             user.is_active = True
             user.save()
             if settings.FEATURES['SQUELCH_PII_IN_LOGS']:
-                AUDIT_LOG.info('Activating user {0} due to external auth'.format(user.id))
+                AUDIT_LOG.info(u'Activating user {0} due to external auth'.format(user.id))
             else:
-                AUDIT_LOG.info('Activating user "{0}" due to external auth'.format(uname))
+                AUDIT_LOG.info(u'Activating user "{0}" due to external auth'.format(uname))
         else:
             if settings.FEATURES['SQUELCH_PII_IN_LOGS']:
-                AUDIT_LOG.warning('User {0} is not active after external login'.format(user.id))
+                AUDIT_LOG.warning(u'User {0} is not active after external login'.format(user.id))
             else:
-                AUDIT_LOG.warning('User "{0}" is not active after external login'.format(uname))
+                AUDIT_LOG.warning(u'User "{0}" is not active after external login'.format(uname))
             # TODO: improve error page
             msg = 'Account not yet activated: please look for link in your email'
             return default_render_failure(request, msg)
@@ -246,9 +246,9 @@ def _external_login_or_signup(request,
     else:
         student.views.try_change_enrollment(request)
     if settings.FEATURES['SQUELCH_PII_IN_LOGS']:
-        AUDIT_LOG.info("Login success - user.id: {0}".format(user.id))
+        AUDIT_LOG.info(u"Login success - user.id: {0}".format(user.id))
     else:
-        AUDIT_LOG.info("Login success - {0} ({1})".format(user.username, user.email))
+        AUDIT_LOG.info(u"Login success - {0} ({1})".format(user.username, user.email))
     if retfun is None:
         return redirect('/')
     return retfun()
@@ -292,7 +292,7 @@ def _signup(request, eamap, retfun=None):
         post_vars = dict(username=username,
                          honor_code=u'true',
                          terms_of_service=u'true')
-        log.info('doing immediate signup for %s, params=%s', username, post_vars)
+        log.info(u'doing immediate signup for %s, params=%s', username, post_vars)
         student.views.create_account(request, post_vars)
         # should check return content for successful completion before
         if retfun is not None:
@@ -331,7 +331,7 @@ def _signup(request, eamap, retfun=None):
     except ValidationError:
         context['ask_for_email'] = True
 
-    log.info('EXTAUTH: Doing signup for %s', eamap.external_id)
+    log.info(u'EXTAUTH: Doing signup for %s', eamap.external_id)
 
     return student.views.register_user(request, extra_context=context)
 
@@ -508,14 +508,14 @@ def shib_login(request):
         """))
 
     if not request.META.get('REMOTE_USER'):
-        log.error("SHIB: no REMOTE_USER found in request.META")
+        log.error(u"SHIB: no REMOTE_USER found in request.META")
         return default_render_failure(request, shib_error_msg)
     elif not request.META.get('Shib-Identity-Provider'):
-        log.error("SHIB: no Shib-Identity-Provider in request.META")
+        log.error(u"SHIB: no Shib-Identity-Provider in request.META")
         return default_render_failure(request, shib_error_msg)
     else:
         # If we get here, the user has authenticated properly
-        shib = {attr: request.META.get(attr, '')
+        shib = {attr: request.META.get(attr, '').decode('utf-8')
                 for attr in ['REMOTE_USER', 'givenName', 'sn', 'mail', 'Shib-Identity-Provider', 'displayName']}
 
         # Clean up first name, last name, and email address
@@ -525,7 +525,7 @@ def shib_login(request):
         shib['givenName'] = shib['givenName'].split(";")[0].strip().capitalize()
 
     # TODO: should we be logging creds here, at info level?
-    log.info("SHIB creds returned: %r", shib)
+    log.info(u"SHIB creds returned: %r", shib)
 
     fullname = shib['displayName'] if shib['displayName'] else u'%s %s' % (shib['givenName'], shib['sn'])
 


### PR DESCRIPTION
@nedbat @marcore

This is the more systematic shib changes we talked about on https://github.com/edx/edx-platform/pull/5034
Basically, it fixes the test cases for `request.META` to generate `str`s with unicode points instead of `unicode`.  And it converts values read from `request.META` to `unicode` as soon as possible.

@marcore do you want to see if these changes also solve your issues?
