### PR TITLE
Analytics should use user.id not anon id

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -986,7 +986,7 @@ def login_user(request, error=""):  # pylint: disable-msg=too-many-statements,un
     # Track the user's sign in
     if settings.FEATURES.get('SEGMENT_IO_LMS') and hasattr(settings, 'SEGMENT_IO_LMS_KEY'):
         tracking_context = tracker.get_tracker().resolve_context()
-        analytics.identify(anonymous_id_for_user(user, None), {
+        analytics.identify(user.id, {
             'email': email,
             'username': username,
         })
@@ -1461,7 +1461,7 @@ def create_account(request, post_override=None):  # pylint: disable-msg=too-many
     # Track the user's registration
     if settings.FEATURES.get('SEGMENT_IO_LMS') and hasattr(settings, 'SEGMENT_IO_LMS_KEY'):
         tracking_context = tracker.get_tracker().resolve_context()
-        analytics.identify(anonymous_id_for_user(user, None), {
+        analytics.identify(user.id, {
             email: email,
             username: username,
         })


### PR DESCRIPTION
@flowerhack, feel free to take over ownership of this one. :+1: from me on the changes.

@hkim823, we'd like to get this into the release if possible. If deployed as is, the RC would degrade our internal analytics.
