### PR TITLE
Fix description for LTI passports field.

### DIFF
--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -161,7 +161,7 @@ class TextbookList(List):
 class CourseFields(object):
     lti_passports = List(
         display_name=_("LTI Passports"),
-        help=_("Enter the passports for course LTI tools in the following format: \"id\":\"client_key:client_secret\"."),
+        help=_("Enter the passports for course LTI tools in the following format: \"id:client_key:client_secret\"."),
         scope=Scope.settings
     )
     textbooks = TextbookList(help="List of pairs of (title, url) for textbooks used in this course",


### PR DESCRIPTION
Fixes typo introduced here:
https://github.com/edx/edx-platform/commit/a4b172d9d873ad827f13f1b348a215078b3b693c#diff-bd98b26adfa6feaab2df7f29f515f11aR165

@cahrens please review
