### PR TITLE
LMS-11357 Split revert_to_publish: correctly revert to Published version

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/tests/test_mixed_modulestore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_mixed_modulestore.py
@@ -982,9 +982,11 @@ class TestMixedModuleStore(unittest.TestCase):
         vertical_children_num = len(vertical.children)
 
         self.store.publish(self.course.location, self.user_id)
+        self.assertFalse(self._has_changes(self.vertical_x1a))
 
         # delete leaf problem (will make parent vertical a draft)
         self.store.delete_item(self.problem_x1a_1, self.user_id)
+        self.assertTrue(self._has_changes(self.vertical_x1a))
 
         draft_parent = self.store.get_item(self.vertical_x1a)
         self.assertEqual(vertical_children_num - 1, len(draft_parent.children))
@@ -998,6 +1000,7 @@ class TestMixedModuleStore(unittest.TestCase):
         reverted_parent = self.store.get_item(self.vertical_x1a)
         self.assertEqual(vertical_children_num, len(published_parent.children))
         self.assertEqual(reverted_parent, published_parent)
+        self.assertFalse(self._has_changes(self.vertical_x1a))
 
     @ddt.data('draft', 'split')
     def test_revert_to_published_root_published(self, default_ms):

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore_bulk_operations.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore_bulk_operations.py
@@ -18,8 +18,8 @@ class TestBulkWriteMixin(unittest.TestCase):
         self.conn = self.bulk.db_connection = MagicMock(name='db_connection', spec=MongoConnection)
         self.conn.get_course_index.return_value = {'initial': 'index'}
 
-        self.course_key = CourseLocator('org', 'course', 'run-a')
-        self.course_key_b = CourseLocator('org', 'course', 'run-b')
+        self.course_key = CourseLocator('org', 'course', 'run-a', branch='test')
+        self.course_key_b = CourseLocator('org', 'course', 'run-b', branch='test')
         self.structure = {'this': 'is', 'a': 'structure', '_id': ObjectId()}
         self.index_entry = {'this': 'is', 'an': 'index'}
 


### PR DESCRIPTION
https://openedx.atlassian.net/browse/LMS-11357

@dmitchell Please review

@cpennington FYI - `version_structure` now raises an Exception if the branch is not specified.  Otherwise, we inadvertently create a new structure for the None branch.
