### PR TITLE
Tmporarily disable bulk operations b/c old mongo

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -423,7 +423,7 @@ def course_index(request, course_key):
     """
     # A depth of None implies the whole course. The course outline needs this in order to compute has_changes.
     # A unit may not have a draft version, but one of its components could, and hence the unit itself has changes.
-    with modulestore().bulk_operations(course_key):
+    with modulestore().bulk_temp_noop_operations(course_key):  # FIXME
         course_module = _get_course_module(course_key, request.user, depth=None)
         lms_link = get_lms_link_for_item(course_module.location)
         sections = course_module.get_children()

--- a/common/lib/xmodule/xmodule/modulestore/__init__.py
+++ b/common/lib/xmodule/xmodule/modulestore/__init__.py
@@ -566,6 +566,14 @@ class ModuleStoreReadBase(ModuleStoreRead):
         finally:
             self._end_bulk_operation(course_id)
 
+    @contextmanager
+    def bulk_temp_noop_operations(self, course_id):
+        """
+        A hotfix noop b/c old mongo does not properly handle nested bulk operations and does unnecessary work
+        if the bulk operation only reads data. Replace with bulk_operations once fixed (or don't merge to master)
+        """
+        yield
+
     def _begin_bulk_operation(self, course_id):
         """
         Begin a bulk write operation on course_id.

--- a/common/lib/xmodule/xmodule/modulestore/search.py
+++ b/common/lib/xmodule/xmodule/modulestore/search.py
@@ -68,7 +68,8 @@ def path_to_location(modulestore, usage_key):
             newpath = (next_usage, path)
             queue.append((parent, newpath))
 
-    with modulestore.bulk_operations(usage_key.course_key):
+    # FIXME replace with bulk_operations once it's fixed for old mongo
+    with modulestore.bulk_temp_noop_operations(usage_key.course_key):
         if not modulestore.has_item(usage_key):
             raise ItemNotFoundError(usage_key)
 

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_mixed_modulestore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_mixed_modulestore.py
@@ -715,7 +715,7 @@ class TestMixedModuleStore(unittest.TestCase):
     # TODO: LMS-11220: Document why draft find count is [19, 6]
     # TODO: LMS-11220: Document why split find count is [2, 2]
 #     @ddt.data(('draft', [19, 6], 0), ('split', [2, 2], 0))
-    @ddt.data(('draft', [18, 6], 0), ('split', [16, 2], 0))  # FIXME, replace w/ above when bulk reenabled
+    @ddt.data(('draft', [18, 5], 0), ('split', [16, 6], 0))  # FIXME, replace w/ above when bulk reenabled
     @ddt.unpack
     def test_path_to_location(self, default_ms, num_finds, num_sends):
         """

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_mixed_modulestore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_mixed_modulestore.py
@@ -714,7 +714,8 @@ class TestMixedModuleStore(unittest.TestCase):
     # TODO: LMS-11220: Document why draft send count is 5
     # TODO: LMS-11220: Document why draft find count is [19, 6]
     # TODO: LMS-11220: Document why split find count is [2, 2]
-    @ddt.data(('draft', [19, 6], 0), ('split', [2, 2], 0))
+#     @ddt.data(('draft', [19, 6], 0), ('split', [2, 2], 0))
+    @ddt.data(('draft', [18, 6], 0), ('split', [16, 2], 0))  # FIXME, replace w/ above when bulk reenabled
     @ddt.unpack
     def test_path_to_location(self, default_ms, num_finds, num_sends):
         """

--- a/lms/djangoapps/courseware/model_data.py
+++ b/lms/djangoapps/courseware/model_data.py
@@ -110,7 +110,8 @@ class FieldDataCache(object):
 
             return descriptors
 
-        with modulestore().bulk_operations(descriptor.location.course_key):
+        # FIXME
+        with modulestore().bulk_temp_noop_operations(descriptor.location.course_key):
             descriptors = get_child_descriptors(descriptor, depth, descriptor_filter)
 
         return FieldDataCache(descriptors, course_id, user, select_for_update)

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -335,7 +335,7 @@ class TestTOC(ModuleStoreTestCase):
 
     # TODO: LMS-11220: Document why split find count is 9
     # TODO: LMS-11220: Document why mongo find count is 4
-    @ddt.data((ModuleStoreEnum.Type.mongo, 4, 0), (ModuleStoreEnum.Type.split, 9, 0))
+    @ddt.data((ModuleStoreEnum.Type.mongo, 3, 0), (ModuleStoreEnum.Type.split, 21, 0))
     @ddt.unpack
     def test_toc_toy_from_chapter(self, default_ms, num_finds, num_sends):
         with self.store.default_store(default_ms):
@@ -364,7 +364,7 @@ class TestTOC(ModuleStoreTestCase):
 
     # TODO: LMS-11220: Document why split find count is 9
     # TODO: LMS-11220: Document why mongo find count is 4
-    @ddt.data((ModuleStoreEnum.Type.mongo, 4, 0), (ModuleStoreEnum.Type.split, 9, 0))
+    @ddt.data((ModuleStoreEnum.Type.mongo, 3, 0), (ModuleStoreEnum.Type.split, 21, 0))
     @ddt.unpack
     def test_toc_toy_from_section(self, default_ms, num_finds, num_sends):
         with self.store.default_store(default_ms):


### PR DESCRIPTION
does too much work on exit and doesn't handle nesting

@cpennington @hkim823 review and deploy or just deploy as soon as tests complete
