### PR TITLE
Refrain from accessing country code if country is None

### DIFF
--- a/common/djangoapps/embargo/middleware.py
+++ b/common/djangoapps/embargo/middleware.py
@@ -166,7 +166,7 @@ class EmbargoMiddleware(object):
         profile_country = cache.get(cache_key)
         if profile_country is None:
             profile = getattr(user, 'profile', None)
-            if profile is not None:
+            if profile is not None and profile.country is not None:
                 profile_country = profile.country.code.upper()
             else:
                 profile_country = ""

--- a/common/djangoapps/embargo/tests/test_middleware.py
+++ b/common/djangoapps/embargo/tests/test_middleware.py
@@ -219,6 +219,7 @@ class EmbargoMiddlewareTests(ModuleStoreTestCase):
         self.assertEqual(response.status_code, 200)
 
     @ddt.data(
+        (None, False),
         ("", False),
         ("us", False),
         ("CU", True),


### PR DESCRIPTION
Proposed fix for the error we were seeing in the release relating to the embargo middleware. New accounts created after the country column was added (i.e., after January) have an empty string for `country`, but old accounts have NULL. @dianakhuang and @wedaly, could you please review this? I'll add the commit reverting the reversion of #4976 once it's available.
