### PR TITLE
Disable sending activation email also when doing external_auth and setting BYPASS_ACTIVATION_EMAIL_FOR_EXTAUTH=True

### DIFF
--- a/common/djangoapps/student/tests/test_create_account.py
+++ b/common/djangoapps/student/tests/test_create_account.py
@@ -1,19 +1,26 @@
 "Tests for account creation"
 
 import ddt
+import unittest
 from django.contrib.auth.models import User
+from django.test.client import RequestFactory
+from django.conf import settings
 from django.core.urlresolvers import reverse
-from django.db.transaction import rollback
+from django.contrib.auth.models import AnonymousUser
+from django.utils.importlib import import_module
 from django.test import TestCase, TransactionTestCase
-from django.test.utils import override_settings
+
 import mock
 
 from user_api.models import UserPreference
 from lang_pref import LANGUAGE_KEY
 
+from edxmako.tests import mako_middleware_process_request
+from external_auth.models import ExternalAuthMap
 import student
 
 TEST_CS_URL = 'https://comments.service.test:123/'
+
 
 @ddt.ddt
 class TestCreateAccount(TestCase):
@@ -22,6 +29,7 @@ class TestCreateAccount(TestCase):
     def setUp(self):
         self.username = "test_user"
         self.url = reverse("create_account")
+        self.request_factory = RequestFactory()
         self.params = {
             "username": self.username,
             "email": "test@example.org",
@@ -45,6 +53,50 @@ class TestCreateAccount(TestCase):
         self.assertEqual(response.status_code, 200)
         user = User.objects.get(username=self.username)
         self.assertEqual(UserPreference.get_preference(user, LANGUAGE_KEY), lang)
+
+    def base_extauth_bypass_sending_activation_email(self, bypass_activation_email_for_extauth_setting):
+        """
+        Tests user creation without sending activation email when
+        doing external auth
+        """
+
+        request = self.request_factory.post(self.url, self.params)
+        # now indicate we are doing ext_auth by setting 'ExternalAuthMap' in the session.
+        request.session = import_module(settings.SESSION_ENGINE).SessionStore()  # empty session
+        extauth = ExternalAuthMap(external_id='withmap@stanford.edu',
+                                  external_email='withmap@stanford.edu',
+                                  internal_password=self.params['password'],
+                                  external_domain='shib:https://idp.stanford.edu/')
+        request.session['ExternalAuthMap'] = extauth
+        request.user = AnonymousUser()
+
+        mako_middleware_process_request(request)
+        with mock.patch('django.contrib.auth.models.User.email_user') as mock_send_mail:
+            student.views.create_account(request)
+
+        # check that send_mail is called
+        if bypass_activation_email_for_extauth_setting:
+            self.assertFalse(mock_send_mail.called)
+        else:
+            self.assertTrue(mock_send_mail.called)
+
+    @unittest.skipUnless(settings.FEATURES.get('AUTH_USE_SHIB'), "AUTH_USE_SHIB not set")
+    @mock.patch.dict(settings.FEATURES, {'BYPASS_ACTIVATION_EMAIL_FOR_EXTAUTH': True, 'AUTOMATIC_AUTH_FOR_TESTING': False})
+    def test_extauth_bypass_sending_activation_email_with_bypass(self):
+        """
+        Tests user creation without sending activation email when
+        settings.FEATURES['BYPASS_ACTIVATION_EMAIL_FOR_EXTAUTH']=True and doing external auth
+        """
+        self.base_extauth_bypass_sending_activation_email(True)
+
+    @unittest.skipUnless(settings.FEATURES.get('AUTH_USE_SHIB'), "AUTH_USE_SHIB not set")
+    @mock.patch.dict(settings.FEATURES, {'BYPASS_ACTIVATION_EMAIL_FOR_EXTAUTH': False, 'AUTOMATIC_AUTH_FOR_TESTING': False})
+    def test_extauth_bypass_sending_activation_email_without_bypass(self):
+        """
+        Tests user creation without sending activation email when
+        settings.FEATURES['BYPASS_ACTIVATION_EMAIL_FOR_EXTAUTH']=False and doing external auth
+        """
+        self.base_extauth_bypass_sending_activation_email(False)
 
 
 @mock.patch.dict("student.models.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1512,7 +1512,12 @@ def create_account(request, post_override=None):  # pylint: disable-msg=too-many
     message = render_to_string('emails/activation_email.txt', context)
 
     # don't send email if we are doing load testing or random user generation for some reason
-    if not (settings.FEATURES.get('AUTOMATIC_AUTH_FOR_TESTING')):
+    # or external auth with bypass activated
+    send_email = (
+        not settings.FEATURES.get('AUTOMATIC_AUTH_FOR_TESTING') and
+        not (do_external_auth and settings.FEATURES.get('BYPASS_ACTIVATION_EMAIL_FOR_EXTAUTH'))
+    )
+    if send_email:
         from_address = microsite.get_value(
             'email_from_address',
             settings.DEFAULT_FROM_EMAIL


### PR DESCRIPTION
See #4256
