### PR TITLE
XBlock argument passing support

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -685,6 +685,7 @@ ADVANCED_COMPONENT_TYPES = [
     'done',  # Lets students mark things as done. See https://github.com/pmitros/DoneXBlock
     'audio',  # Embed an audio file. See https://github.com/pmitros/AudioXBlock
     'recommender',  # Crowdsourced recommender. Prototype by dli&pmitros. Intended for roll-out in one place in one course.
+    'profile', # Prototype user profile XBlock. Used to test XBlock parameter passing. See https://github.com/pmitros/ProfileXBlock
     'split_test',
     'combinedopenended',
     'peergrading',

--- a/common/djangoapps/xmodule_modifiers.py
+++ b/common/djangoapps/xmodule_modifiers.py
@@ -101,6 +101,13 @@ def wrap_xblock(runtime_class, block, view, frag, context, usage_id_serializer, 
                                      for key, value in data.iteritems()),
     }
 
+    if hasattr(frag, 'json_init_args') and frag.json_init_args is not None:
+        template_context['js_init_parameters'] = json.dumps(frag.json_init_args)
+        template_context['js_pass_parameters'] = True
+    else:
+        template_context['js_init_parameters'] = ""
+        template_context['js_pass_parameters'] = False
+
     return wrap_fragment(frag, render_to_string('xblock_wrapper.html', template_context))
 
 

--- a/common/static/coffee/src/xblock/core.coffee
+++ b/common/static/coffee/src/xblock/core.coffee
@@ -18,7 +18,14 @@
     if runtime? and version? and initFnName?
       runtime = new window[runtime]["v#{version}"]
       initFn = window[initFnName]
-      block = initFn(runtime, element) ? {}
+      if initFn.length > 2
+        initargs = $(".xblock_json_init_args", element)
+        if initargs.length == 0
+          console.log("Warning: XBlock expects data parameters")
+        data = JSON.parse(initargs.text())
+        block = initFn(runtime, element, data) ? {}
+      else
+        block = initFn(runtime, element) ? {}
       block.runtime = runtime
     else
       elementTag = $('<div>').append($element.clone()).html();

--- a/common/templates/xblock_wrapper.html
+++ b/common/templates/xblock_wrapper.html
@@ -1,3 +1,8 @@
 <div class="${' '.join(classes)}" ${data_attributes}>
+% if js_pass_parameters:
+  <script type="json/xblock-args" class="xblock_json_init_args">
+    ${js_init_parameters}
+  </script>
+% endif
     ${content}
 </div>

--- a/requirements/edx/edx-private.txt
+++ b/requirements/edx/edx-private.txt
@@ -5,11 +5,14 @@
 
 # Prototype XBlocks from edX learning sciences limited roll-outs and user testing. 
 # Concept XBlock, in particular, is nowhere near finished and an early prototype. 
+# Profile XBlock is there so we can play with XBlock arguments in the platform, but isn't ready for use outside of
+# edX.
 
 -e git+https://github.com/pmitros/ConceptXBlock.git@2376fde9ebdd83684b78dde77ef96361c3bd1aa0#egg=concept-xblock
 -e git+https://github.com/pmitros/DoneXBlock.git@1ce0ac14d9f3df3083b951262ec82e84b58d16d1#egg=done-xblock
 -e git+https://github.com/pmitros/AudioXBlock.git@1fbf19cc21613aead62799469e1593adb037fdd9#egg=audio-xblock
 -e git+https://github.com/pmitros/AnimationXBlock.git@d2b551bb8f49a138088e10298576102164145b87#egg=animation-xblock
+-e git+https://github.com/pmitros/ProfileXBlock.git@1ede6341c96c7d4a8e5942e7085e859de762f128#egg=profile-xblock
 
 # This XBlock shows a list of recommendations. 
 # It is an R&D prototype, intended for roll-out one location in one course. 


### PR DESCRIPTION
@nedbat Quick review? 

This is a port of https://github.com/edx/xblock-sdk/pull/18/files

It adds a minimal XBlock (ProfileXBlock) which is helpful for manual testing of this functionality, and when we finish it, pyfs. That block is not production-ready, but I'd also like to give a demo of this XBlock internally, and this gets it onto edge.edx.org, killing two birds with one stone. 
