### PR TITLE
Correct typos and grammatical errors in translated strings

### DIFF
--- a/common/djangoapps/student/tests/test_login.py
+++ b/common/djangoapps/student/tests/test_login.py
@@ -413,7 +413,7 @@ class ExternalAuthShibTest(ModuleStoreTestCase):
         noshib_response = self.client.get(TARGET_URL, follow=True)
         self.assertEqual(noshib_response.redirect_chain[-1],
                          ('http://testserver/accounts/login?next={url}'.format(url=TARGET_URL), 302))
-        self.assertContains(noshib_response, ("Log into your {platform_name} Account | {platform_name}"
+        self.assertContains(noshib_response, ("Log into your {platform_name} account | {platform_name}"
                                               .format(platform_name=settings.PLATFORM_NAME)))
         self.assertEqual(noshib_response.status_code, 200)
 

--- a/lms/templates/login.html
+++ b/lms/templates/login.html
@@ -6,7 +6,7 @@
 <%! from django.utils.translation import ugettext as _ %>
 <%! from third_party_auth import provider, pipeline %>
 
-<%block name="pagetitle">${_("Log into your {platform_name} Account").format(platform_name=platform_name)}</%block>
+<%block name="pagetitle">${_("Log into your {platform_name} account").format(platform_name=platform_name)}</%block>
 
 <%block name="bodyclass">view-login</%block>
 
@@ -136,13 +136,13 @@
 
       <!-- status messages -->
       <div role="alert" class="status message">
-        <h3 class="message-title">${_("We're Sorry, {platform_name} accounts are unavailable currently").format(platform_name=platform_name)}</h3>
+        <h3 class="message-title">${_("We're sorry, {platform_name} accounts are currently unavailable.").format(platform_name=platform_name)}</h3>
       </div>
 
       <div role="alert" class="status message submission-error" tabindex="-1">
         <h3 class="message-title">${_("We couldn't log you in.")} </h3>
         <ul class="message-copy">
-          <li>${_("Your email or password is incorrect")}</li>
+          <li>${_("Your email or password is incorrect.")}</li>
         </ul>
       </div>
 
@@ -151,7 +151,7 @@
       </div>
 
       <p class="instructions sr">
-        ${_('Please provide the following information to log into your {platform_name} account. Required fields are noted by <strong class="indicator">bold text and an asterisk (*)</strong>.').format(platform_name=platform_name)}
+        ${_('Please provide the following information to log into your {platform_name} account. Required fields are denoted by <strong class="indicator">bold text and an asterisk (*)</strong>.').format(platform_name=platform_name)}
       </p>
 
       <div class="group group-form group-form-requiredinformation">

--- a/lms/templates/register.html
+++ b/lms/templates/register.html
@@ -108,7 +108,7 @@
 
       <!-- status messages -->
       <div role="alert" class="status message">
-        <h3 class="message-title">${_("We're sorry, {platform_name} enrollment is not available in your region").format(platform_name=platform_name)}</h3>
+        <h3 class="message-title">${_("We're sorry, {platform_name} enrollment is not available in your region.").format(platform_name=platform_name)}</h3>
       </div>
 
       <div role="alert" class="status message submission-error" tabindex="-1">
@@ -137,7 +137,7 @@
 
         <p class="instructions">
           ${_('Create your own {platform_name} account below').format(platform_name=platform_name)}
-          <span class="note">${_('Required fields are noted by <strong class="indicator">bold text and an asterisk (*)</strong>.')}</span>
+          <span class="note">${_('Required fields are denoted by <strong class="indicator">bold text and an asterisk (*)</strong>.')}</span>
         </p>
 
 
@@ -154,8 +154,8 @@
       % else:
 
       <p class="instructions">
-        ${_("Please complete the following fields to register for an account. ")}<br />
-        ${_('Required fields are noted by <strong class="indicator">bold text and an asterisk (*)</strong>.')}
+        ${_("Please complete the following fields to register for an account.")}<br />
+        ${_('Required fields are denoted by <strong class="indicator">bold text and an asterisk (*)</strong>.')}
       </p>
 
       % endif


### PR DESCRIPTION
@sarina, this contains corrections to translated strings appearing on the login and registration pages which I pulled out of a previous PR. I'm aware that these copy changes will break live translations of the lines I've touched. Do you have any suggestions as to how I should bring these changes in?
