### PR TITLE
Fixes git export to support repositories with dots in their name and cleans export repo

### DIFF
--- a/cms/djangoapps/contentstore/git_export_utils.py
+++ b/cms/djangoapps/contentstore/git_export_utils.py
@@ -126,7 +126,7 @@ def export_to_git(course_id, repo, user='', rdir=None):
 
     # export course as xml before commiting and pushing
     root_dir = os.path.dirname(rdirp)
-    course_dir = os.path.splitext(os.path.basename(rdirp))[0]
+    course_dir = os.path.basename(rdirp).rsplit('.git', 1)[0]
     try:
         export_to_xml(modulestore(), contentstore(), course_id,
                       root_dir, course_dir)

--- a/cms/djangoapps/contentstore/git_export_utils.py
+++ b/cms/djangoapps/contentstore/git_export_utils.py
@@ -111,6 +111,7 @@ def export_to_git(course_id, repo, user='', rdir=None):
             ['git', 'fetch', 'origin'],
             ['git', 'reset', '--hard', 'origin/{0}'.format(branch)],
             ['git', 'pull'],
+            ['git', 'clean', '-d', '-f'],
         ]
     else:
         cmds = [['git', 'clone', repo]]


### PR DESCRIPTION
First commit: 
Currently the export to git will cut off the "extension" of the repository name and export the courseware to the wrong directory. This corrects this behavior and adds a regression test to validate the fix.

Second commit:
If something is deleted in the remote repo for a course and it is exported from Studio the deleted items get added back in.  This corrects that behavior to clean the repo before exporting the course.
