### PR TITLE
Discussion: Add cohorted_threads_privacy cohort setting 

### DIFF
--- a/common/djangoapps/course_groups/cohorts.py
+++ b/common/djangoapps/course_groups/cohorts.py
@@ -45,6 +45,16 @@ def is_course_cohorted(course_key):
     return courses.get_course_by_id(course_key).is_cohorted
 
 
+def get_cohorted_threads_privacy(course_key):
+    """
+    Given a course key, return the cohorted threads privacy setting.
+
+    Raises:
+       Http404 if the course doesn't exist.
+    """
+    return courses.get_course_by_id(course_key).cohorted_threads_privacy
+
+
 def get_cohort_id(user, course_key):
     """
     Given a course key and a user, return the id of the cohort that user is

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -816,6 +816,18 @@ class CourseDescriptor(CourseFields, SequenceDescriptor):
         return set(config.get("cohorted_discussions", []))
 
     @property
+    def cohorted_threads_privacy(self):
+        """
+        Return whether the course cohorted threads pricacy. If the privacy is set to 'cohort-only',
+        a user that is not in a cohort will only see threads that are not cohorted.
+        """
+        config = self.cohort_config
+        if config is None:
+            return 'public'
+
+        return config.get("cohorted_threads_privacy", 'public')
+
+    @property
     def is_newish(self):
         """
         Returns if the course has been flagged as new. If

--- a/lms/djangoapps/django_comment_client/forum/views.py
+++ b/lms/djangoapps/django_comment_client/forum/views.py
@@ -12,8 +12,9 @@ import newrelic.agent
 
 from edxmako.shortcuts import render_to_response
 from courseware.courses import get_course_with_access
-from course_groups.cohorts import (is_course_cohorted, get_cohort_id, is_commentable_cohorted,
-                                   get_cohorted_commentables, get_course_cohorts, get_cohort_by_id)
+from course_groups.cohorts import (is_course_cohorted, get_cohorted_threads_privacy, get_cohort_id,
+                                   is_commentable_cohorted, get_cohorted_commentables,
+                                   get_course_cohorts, get_cohort_by_id)
 from courseware.access import has_access
 
 from django_comment_client.permissions import cached_has_permission
@@ -97,6 +98,8 @@ def get_threads(request, course_key, discussion_id=None, per_page=THREADS_PER_PA
     if not group_id:
         if not cached_has_permission(request.user, "see_all_cohorts", course_key):
             group_id = get_cohort_id(request.user, course_key)
+            if not group_id and get_cohorted_threads_privacy(course_key) == 'cohort-only':
+                default_query_params['exclude_groups'] = True
 
     if group_id:
         default_query_params["group_id"] = group_id


### PR DESCRIPTION
This PR adds **cohorted_threads_privacy** cohort setting: a user that is not in any cohort will only see non-cohorted threads.

This is a need for a client. By default, for a cohorted course, if a user that is **not** in a cohort group accesses the discussion tab, he will see all threads, even those that have been posted in a cohort. The  **cohorted_threads_privacy**  setting allow you to change that behavior. If you set it to 'cohort-only', a user not in a cohort will only see non-cohorted threads.

```
{
    "cohorted_threads_privacy": "cohort-only",
    "cohorted": true
}
```

There is no test for this feature. I have not found where I could add a simple test for this purpose. Where the get_threads functions is tested?

@jimabramson @gwprice 
