### PR TITLE
Change shopping cart status once sent to Cybersource (ECOM-218)

### DIFF
--- a/lms/djangoapps/shoppingcart/tests/test_models.py
+++ b/lms/djangoapps/shoppingcart/tests/test_models.py
@@ -102,6 +102,38 @@ class OrderTest(ModuleStoreTestCase):
         self.assertEquals(cart.orderitem_set.count(), len(course_costs))
         self.assertEquals(cart.total_cost, sum(cost for _course, cost in course_costs))
 
+    def test_start_purchase(self):
+        # Start the purchase, which will mark the cart as "paying"
+        cart = Order.get_cart_for_user(user=self.user)
+        CertificateItem.add_to_order(cart, self.course_key, self.cost, 'honor', currency='usd')
+        cart.start_purchase()
+        self.assertEqual(cart.status, 'paying')
+        for item in cart.orderitem_set.all():
+            self.assertEqual(item.status, 'paying')
+
+        # Starting the purchase should be idempotent
+        cart.start_purchase()
+        self.assertEqual(cart.status, 'paying')
+        for item in cart.orderitem_set.all():
+            self.assertEqual(item.status, 'paying')
+
+        # If we retrieve the cart for the user, we should get a different order
+        next_cart = Order.get_cart_for_user(user=self.user)
+        self.assertNotEqual(cart, next_cart)
+        self.assertEqual(next_cart.status, 'cart')
+
+        # Complete the first purchase
+        cart.purchase()
+        self.assertEqual(cart.status, 'purchased')
+        for item in cart.orderitem_set.all():
+            self.assertEqual(item.status, 'purchased')
+
+        # Starting the purchase again should be a no-op
+        cart.start_purchase()
+        self.assertEqual(cart.status, 'purchased')
+        for item in cart.orderitem_set.all():
+            self.assertEqual(item.status, 'purchased')
+
     def test_purchase(self):
         # This test is for testing the subclassing functionality of OrderItem, but in
         # order to do this, we end up testing the specific functionality of

--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -227,6 +227,15 @@ def create_order(request):
     enrollment_mode = current_mode.slug
     CertificateItem.add_to_order(cart, course_id, amount, enrollment_mode)
 
+    # Change the order's status so that we don't accidentally modify it later.
+    # We need to do this to ensure that the parameters we send to the payment system
+    # match what we store in the database.
+    # (Ordinarily we would do this client-side when the user submits the form, but since
+    # the JavaScript on this page does that immediately, we make the change here instead.
+    # This avoids a second AJAX call and some additional complication of the JavaScript.)
+    # If a user later re-enters the verification / payment flow, she will create a new order.
+    cart.start_purchase()
+
     callback_url = request.build_absolute_uri(
         reverse("shoppingcart.views.postpay_callback")
     )


### PR DESCRIPTION
Set order status to "paying" before redirecting to the external payment processor.  This ensures that a user does not modify an order once we have sent it to CyberSource, avoiding the error some users have reported: "Sorry! Due to an error your purchase was charged for a different amount than the order total!"

Open questions (need input from product / doc):
- Are the implications of this change (potential for duplicate orders in the DB, resetting the user's cart if they restart the payment flow after getting to CyberSource) acceptable?  (Waiting on input from product).
- Do we need text in the UI warning users that once they click on "Checkout", they can't go back and change their order?  If so, how can we succinctly explain this to users?  @srpearce 

Suggested reviewers: @dianakhuang @jbau 

@stroilova This change implies that there could be multiple orders for a particular user, but only one order with status "cart" or "payment" (aborted orders would have status "paying").  I'm not sure if this will affect the audit script you're using.

[ECOM-218](https://openedx.atlassian.net/browse/ECOM-218)
