### PR TITLE
Fix discussion error popup on http request abort

### DIFF
--- a/common/static/coffee/src/discussion/views/discussion_thread_view.coffee
+++ b/common/static/coffee/src/discussion/views/discussion_thread_view.coffee
@@ -120,7 +120,9 @@ if Backbone?
           )
           @trigger "thread:responses:rendered"
           @loadedResponses = true
-        error: (xhr) =>
+        error: (xhr, textStatus) =>
+          return if textStatus == 'abort'
+
           if xhr.status == 404
             DiscussionUtil.discussionAlert(
               gettext("Sorry"),


### PR DESCRIPTION
In the Discussion Tab, if we click quickly to select items in the thread list, we'll get this error:

![http_request_abort_issue](https://cloud.githubusercontent.com/assets/532356/4188180/36bf26ba-3770-11e4-8aa9-cdfddd1f38f8.png)

This is due to the fact that the http request is _aborted_, which is normal since we are trying to access another thread without waiting that the current one has finished its loading. The current code interpret this as an error... but it is not. This PR proposes a simple fix for those cases.

@gwprice @jimabramson 
