### PR TITLE
Corrected NameError for invalid variable

### DIFF
--- a/lms/djangoapps/instructor/views/legacy.py
+++ b/lms/djangoapps/instructor/views/legacy.py
@@ -1817,7 +1817,7 @@ def dump_grading_context(course):
             notes = ''
             if getattr(sdesc, 'score_by_attempt', False):
                 notes = ', score by attempt!'
-            msg += "      %s (grade_format=%s, Assignment=%s%s)\n" % (s.display_name, grade_format, aname, notes)
+            msg += "      %s (grade_format=%s, Assignment=%s%s)\n" % (sdesc.display_name, grade_format, aname, notes)
     msg += "all descriptors:\n"
     msg += "length=%d\n" % len(gcontext['all_descriptors'])
     msg = '<pre>%s</pre>' % msg.replace('<', '&lt;')


### PR DESCRIPTION
It looks like `s` got refactored in cd746bf8e5127c6049950ef002c5ca9e1aebed65 but got missed here. It was in one of the super commits so not sure who should review, but simple change.

Heads up to @ichuang 
