### PR TITLE
CodeMirror should use monospace fonts.

### DIFF
--- a/cms/static/sass/elements/_forms.scss
+++ b/cms/static/sass/elements/_forms.scss
@@ -442,6 +442,7 @@ code {
 .CodeMirror {
   @extend %t-copy-sub1;
   background: #fff;
+  font-family: $f-monospace;
 }
 
 .text-editor {


### PR DESCRIPTION
TNL-197

Reviewed in https://github.com/edx/edx-platform/pull/5124.
