### PR TITLE
show video controls for all youtube videos

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
+++ b/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
@@ -756,7 +756,7 @@ function (VideoPlayer, VideoStorage, i18n) {
         try {
             return this.metadata[this.youtubeId()].duration;
         } catch (err) {
-            return this.metadata[this.youtubeId('1.0')].duration;
+            return _.result(this.metadata[this.youtubeId('1.0')], 'duration') || 0;
         }
     }
 

--- a/common/test/acceptance/pages/studio/video/video.py
+++ b/common/test/acceptance/pages/studio/video/video.py
@@ -118,7 +118,19 @@ class VideoComponentPage(VideoPage):
             self._wait_for(lambda: self.q(css=CLASS_SELECTORS['video_init']).present, 'Video Player Initialized')
             self._wait_for(lambda: not self.q(css=CLASS_SELECTORS['video_spinner']).visible,
                            'Video Buffering Completed')
-            self._wait_for(lambda: self.q(css=CLASS_SELECTORS['video_controls']).visible, 'Player Controls are Visible')
+            self._wait_for(self.is_controls_visible, 'Player Controls are Visible')
+
+    @wait_for_js
+    def is_controls_visible(self):
+        """
+        Get current visibility sate of all video controls.
+
+        Returns:
+            bool: True means video controls are visible for all videos, False means video controls are not visible
+            for one or more videos
+
+        """
+        return self.q(css=CLASS_SELECTORS['video_controls']).visible
 
     def click_button(self, button_name, index=0):
         """

--- a/common/test/acceptance/tests/video/test_studio_video_module.py
+++ b/common/test/acceptance/tests/video/test_studio_video_module.py
@@ -95,12 +95,14 @@ class CMSVideoBaseTest(UniqueCourseTest):
         self._install_course_fixture()
         self._navigate_to_course_unit_page()
 
-    def edit_component(self):
+    def edit_component(self, xblock_index=1):
         """
         Open component Edit Dialog for first component on page.
+
+        Arguments:
+            xblock_index: number starting from 1 (0th entry is the unit page itself)
         """
-        # The 0th entry is the unit page itself.
-        self.unit_page.xblocks[1].edit()
+        self.unit_page.xblocks[xblock_index].edit()
 
     def open_advanced_tab(self):
         """
@@ -224,6 +226,27 @@ class CMSVideoTest(CMSVideoBaseTest):
         self.video.hide_captions()
 
         self.assertFalse(self.video.is_captions_visible())
+
+    def test_video_controls_shown_correctly(self):
+        """
+        Scenario: Video controls for all videos show correctly
+        Given I have created two Video components
+        And first is private video
+        When I reload the page
+        Then video controls for all videos are visible
+        """
+        self._create_course_unit(youtube_stub_config={'youtube_api_private_video': True})
+        self.video.create_video()
+
+        # change id of first default video
+        self.edit_component(1)
+        self.open_advanced_tab()
+        self.video.set_field_value('YouTube ID', 'sampleid123')
+        self.save_unit_settings()
+
+        # again open unit page and check that video controls show for both videos
+        self._navigate_to_course_unit_page()
+        self.assertTrue(self.video.is_controls_visible())
 
     def test_captions_shown_correctly(self):
         """


### PR DESCRIPTION
TNL-184
@waheedahmed @symbolist @adampalay 
fix: Video controls of all videos after a private video do not show
