### PR TITLE
Fix embargo middleware with tests

### DIFF
--- a/common/djangoapps/embargo/middleware.py
+++ b/common/djangoapps/embargo/middleware.py
@@ -166,7 +166,7 @@ class EmbargoMiddleware(object):
         profile_country = cache.get(cache_key)
         if profile_country is None:
             profile = getattr(user, 'profile', None)
-            if profile is not None and profile.country is not None:
+            if profile is not None and profile.country.code is not None:
                 profile_country = profile.country.code.upper()
             else:
                 profile_country = ""


### PR DESCRIPTION
This includes the fix that @rlucioni merged to the RC yesterday (https://github.com/edx/edx-platform/commit/12d5c9b281245a1cf7fab462deaa1b09489548b0).

It adds a test case validating the fix.  See the comment for a detailed explanation of why this was so hard to validate :)

Since this includes the exact same change as in the RC, I don't anticipate merge conflicts when release is merged back into master.

@rlucioni @dianakhuang please review.
