### PR TITLE
bok-choy: Fix flakiness in date-picker steps under studio tests

### DIFF
--- a/common/test/acceptance/pages/studio/overview.py
+++ b/common/test/acceptance/pages/studio/overview.py
@@ -614,6 +614,7 @@ class CourseOutlineModal(object):
         for i in xrange(abs(date_diff)):
             self.page.q(css=selector).click()
         self.page.q(css="a.ui-state-default").nth(day - 1).click()  # set day
+        self.page.wait_for_element_invisibility("#ui-datepicker-div", "datepicker should be closed")
         EmptyPromise(
             lambda: getattr(self, property_name) == u'{m}/{d}/{y}'.format(m=month, d=day, y=year),
             "{} is updated in modal.".format(property_name)


### PR DESCRIPTION
These were failing on Solano builds because the save button was clicked
before the datepicker was done its work. (The EmptyPromise was still satisfied
because the input field value had been updated, but the datepicker widget
caused issues about 3/4 of the time.)
