### PR TITLE
fixes help copy for annotation settings

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/inheritance.py
+++ b/common/lib/xmodule/xmodule/modulestore/inheritance.py
@@ -75,13 +75,13 @@ class InheritanceMixin(XBlockMixin):
         deprecated=True
     )
     annotation_storage_url = String(
-        help=_("Enter the secret string for annotation storage. The textannotation, videoannotation, and imageannotation advanced modules require this string."),
+        help=_("Enter the location of the annotation storage server. The textannotation, videoannotation, and imageannotation advanced modules require this setting."),
         scope=Scope.settings,
         default="http://your_annotation_storage.com",
         display_name=_("URL for Annotation Storage")
     )
     annotation_token_secret = String(
-        help=_("Enter the location of the annotation storage server. The textannotation, videoannotation, and imageannotation advanced modules require this setting."),
+        help=_("Enter the secret string for annotation storage. The textannotation, videoannotation, and imageannotation advanced modules require this string."),
         scope=Scope.settings,
         default="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
         display_name=_("Secret Token String for Annotation")


### PR DESCRIPTION
@sarina , the strings for the storage url and the token secret were mixed up with each other
@lduarte1991, FYI
