### PR TITLE
Text Annotation Tool: Reply/Grouping Bug Fix

### DIFF
--- a/common/static/js/vendor/ova/catch/js/catch.js
+++ b/common/static/js/vendor/ova/catch/js/catch.js
@@ -546,9 +546,11 @@ CatchAnnotation.prototype = {
             // public or is equal to the person with update access, then we leave it alone,
             // otherwise we need to clean them up (i.e. disable them).
             if (self.options.userId !== '' && self.options.userId !== value.permissions.update[0]) {
-                $.each(value.highlights, function(key1, value1){
-                    $(value1).removeClass('annotator-hl');
-                });
+                if (value.highlights !== undefined) {
+                    $.each(value.highlights, function(key1, value1){
+                        $(value1).removeClass('annotator-hl');
+                    });
+                }
             }
         });
     },
@@ -1196,11 +1198,11 @@ CatchAnnotation.prototype = {
         
         annotations.forEach(function(ann){
             var child, h, _i, _len, _ref;
-            if (ann.highlights !== null) {
+            if (ann.highlights !== undefined) {
                 _ref = ann.highlights;
                 for (_i = 0, _len = _ref.length; _i < _len; _i++) {
                     h = _ref[_i];
-                    if (!(h.parentNode !== null)) {
+                    if (!(h.parentNode !== undefined)) {
                         continue;
                     }
                     child = h.childNodes[0];

--- a/common/static/js/vendor/ova/grouping-annotator.js
+++ b/common/static/js/vendor/ova/grouping-annotator.js
@@ -145,15 +145,19 @@ Annotator.Plugin.Grouping = (function(_super) {
         $.each(lineAnnDict, function(key, val) {
             if (val.length > self.groupthreshold) {
                 val.forEach(function(anno){
-                    $.each(anno.highlights, function(key, anno) {
-                       $(anno).css("background-color", "inherit");   
-                    });
+                    if (anno.highlights !== undefined) {
+                        $.each(anno.highlights, function(key, anno) {
+                           $(anno).css("background-color", "inherit");   
+                        });
+                    }
                 });
             } else {
                 val.forEach(function(anno) {
-                    $.each(anno.highlights, function(key, anno) {
-                       $(anno).css("background-color", "rgba(255, 255, 10, .3)");   
-                    });
+                    if (anno.highlights !== undefined) {
+                        $.each(anno.highlights, function(key, anno) {
+                           $(anno).css("background-color", "rgba(255, 255, 10, .3)");   
+                        });
+                    }
                 });
             }
         });
@@ -187,14 +191,18 @@ Annotator.Plugin.Grouping = (function(_super) {
                 $(newdiv).click(function(evt){
                     if($(evt.srcElement).attr("data-selected") === '0') {
                         annotations.forEach(function(annot){
-                            $.each(annot.highlights, function(key, ann) {
-                                $(ann).css("background-color", "inherit");
-                            });
+                            if (annot.highlights !== undefined) {
+                                $.each(annot.highlights, function(key, ann) {
+                                    $(ann).css("background-color", "inherit");
+                                });
+                            }
                         });
                         self.groupedAnnotations[$(evt.srcElement).css("top").replace("px", "")].forEach(function(item) {
-                            $.each(item.highlights, function(key, ann) {
-                                $(ann).css("background-color", "rgba(255, 255, 10, 0.3)");
-                            });
+                            if (item.highlights !== undefined) {
+                                $.each(item.highlights, function(key, ann) {
+                                    $(ann).css("background-color", "rgba(255, 255, 10, 0.3)");
+                                });
+                            }
                         });
                         $(evt.srcElement).attr("data-selected", '1');
                     } else {
@@ -237,9 +245,11 @@ Annotator.Plugin.Grouping = (function(_super) {
             $(".onOffGroupButton").html("Annotation Grouping: OFF");
             $(".onOffGroupButton").addClass("buttonOff");
             this.annotator.plugins.Store.annotations.forEach(function(annot) {
-                $.each(annot.highlights, function(key, ann) {
-                $(ann).css("background-color", "");
-                });
+                if (annot.highlights !== undefined) {
+                    $.each(annot.highlights, function(key, ann) {
+                        $(ann).css("background-color", "");
+                    });
+                }
             });
             
             // deals with the HighlightTags Plug-In


### PR DESCRIPTION
This addresses the bug **[TNL-287]**.
**Note:** This is a very small but important bug fix. 4 courses are affected (PoetryX, HeroesX, Visualizing Japan, ChinaX) with a total enrollment 47,000 students. 
**Ideal Fix Deployment:** Week of Sept 15th. 

**Background:** Our backend handles "Replies" (basically annotations with a "parent id" to the annotation being replied to) but the vendor tool we are using to annotate called Annotator can't handle these as they do not have anything highlighted. When I recently added the Grouping plugin I forgot to check whether the attribute "highlight" exists within the annotation object. _So basically this bug fix is just a lot of `if (annotation.highlights !== undefined)` to make sure it doesn't crash._

**Studio Update:** None.

**LMS Update:** Things shouldn't break after creating a reply now.

**Testing:**
1. Using the following [tarball](https://www.dropbox.com/s/r684ber7z4ddqtc/2014_T4.DPRfFs.tar.gz), create a new annotation or two. 
2. Go into 'Public' and reply to the annotation using the Reply button in the table below the source text.
3. Try going to Instructor or MyNotes
    a. In the old version you should see nothing happening and the following message, basically breaking the tool:
        ![Error message](http://i.imgur.com/SGpUYcZ.png)
    b. In the new version you should be able to travel back and forth freely between all tabs after creating a reply.
