### PR TITLE
Annotation Tools: Give staff/instructors full permissions (bug fix)

### DIFF
--- a/common/lib/xmodule/xmodule/imageannotation_module.py
+++ b/common/lib/xmodule/xmodule/imageannotation_module.py
@@ -109,6 +109,9 @@ class ImageAnnotationModule(AnnotatableFields, XModule):
         self.instructions = self._extract_instructions(xmltree)
         self.openseadragonjson = html_to_text(etree.tostring(xmltree.find('json'), encoding='unicode'))
         self.user = ""
+        self.is_course_staff = False
+        if self.runtime.get_user_role() in ['instructor', 'staff']:
+            self.is_course_staff = True
         if self.runtime.get_real_user is not None:
             self.user = self.runtime.get_real_user(self.runtime.anonymous_student_id).email
 
@@ -128,10 +131,15 @@ class ImageAnnotationModule(AnnotatableFields, XModule):
             'default_tab': self.default_tab,
             'instructor_email': self.instructor_email,
             'annotation_mode': self.annotation_mode,
+            'is_course_staff': self.is_course_staff,
         }
         fragment = Fragment(self.system.render_template('imageannotation.html', context))
-        fragment.add_javascript_url(self.runtime.STATIC_URL + "js/vendor/tinymce/js/tinymce/tinymce.full.min.js")
-        fragment.add_javascript_url(self.runtime.STATIC_URL + "js/vendor/tinymce/js/tinymce/jquery.tinymce.min.js")
+
+        # TinyMCE already exists in Studio so we should not load the files again
+        # get_real_user always returns "None" in Studio since its runtimes contains no anonymous ids
+        if self.runtime.get_real_user is not None:
+            fragment.add_javascript_url(self.runtime.STATIC_URL + "js/vendor/tinymce/js/tinymce/tinymce.full.min.js")
+            fragment.add_javascript_url(self.runtime.STATIC_URL + "js/vendor/tinymce/js/tinymce/jquery.tinymce.min.js")
         return fragment
 
 

--- a/common/lib/xmodule/xmodule/tests/test_imageannotation.py
+++ b/common/lib/xmodule/xmodule/tests/test_imageannotation.py
@@ -46,9 +46,23 @@ class ImageAnnotationModuleTestCase(unittest.TestCase):
         """
             Makes sure that the Module is declared and mocked with the sample xml above.
         """
+        # return anything except None to test LMS
+        def test_real_user(useless):
+            useless_user = Mock(email='fake@fake.com', id=useless)
+            return useless_user
+
+        # test to make sure that role is checked in LMS
+        def test_user_role():
+            return 'staff'
+
+        self.system = get_test_system()
+        self.system.get_real_user = test_real_user
+        self.system.get_user_role = test_user_role
+        self.system.anonymous_student_id = None
+
         self.mod = ImageAnnotationModule(
             Mock(),
-            get_test_system(),
+            self.system,
             DictFieldData({'data': self.sample_xml}),
             ScopeIds(None, None, None, None)
         )
@@ -74,5 +88,5 @@ class ImageAnnotationModuleTestCase(unittest.TestCase):
         Tests the function that passes in all the information in the context that will be used in templates/textannotation.html
         """
         context = self.mod.student_view({}).content
-        for key in ['display_name', 'instructions_html', 'annotation_storage', 'token', 'tag', 'openseadragonjson']:
+        for key in ['display_name', 'instructions_html', 'annotation_storage', 'token', 'tag', 'openseadragonjson', 'default_tab', 'instructor_email', 'annotation_mode', 'is_course_staff']:
             self.assertIn(key, context)

--- a/common/lib/xmodule/xmodule/tests/test_textannotation.py
+++ b/common/lib/xmodule/xmodule/tests/test_textannotation.py
@@ -31,9 +31,23 @@ class TextAnnotationModuleTestCase(unittest.TestCase):
         """
             Makes sure that the Module is declared and mocked with the sample xml above.
         """
+        # return anything except None to test LMS
+        def test_real_user(useless):
+            useless_user = Mock(email='fake@fake.com', id=useless)
+            return useless_user
+
+        # test to make sure that role is checked in LMS
+        def test_user_role():
+            return 'staff'
+
+        self.system = get_test_system()
+        self.system.get_real_user = test_real_user
+        self.system.get_user_role = test_user_role
+        self.system.anonymous_student_id = None
+
         self.mod = TextAnnotationModule(
             Mock(),
-            get_test_system(),
+            self.system,
             DictFieldData({'data': self.sample_xml}),
             ScopeIds(None, None, None, None)
         )
@@ -59,5 +73,5 @@ class TextAnnotationModuleTestCase(unittest.TestCase):
         Tests the function that passes in all the information in the context that will be used in templates/textannotation.html
         """
         context = self.mod.student_view({}).content
-        for key in ['display_name', 'tag', 'source', 'instructions_html', 'content_html', 'annotation_storage', 'token']:
+        for key in ['display_name', 'tag', 'source', 'instructions_html', 'content_html', 'annotation_storage', 'token', 'diacritic_marks', 'default_tab', 'annotation_mode', 'is_course_staff']:
             self.assertIn(key, context)

--- a/common/lib/xmodule/xmodule/tests/test_videoannotation.py
+++ b/common/lib/xmodule/xmodule/tests/test_videoannotation.py
@@ -27,9 +27,23 @@ class VideoAnnotationModuleTestCase(unittest.TestCase):
         """
         Makes sure that the Video Annotation Module is created.
         """
+        # return anything except None to test LMS
+        def test_real_user(useless):
+            useless_user = Mock(email='fake@fake.com', id=useless)
+            return useless_user
+
+        # test to make sure that role is checked in LMS
+        def test_user_role():
+            return 'staff'
+
+        self.system = get_test_system()
+        self.system.get_real_user = test_real_user
+        self.system.get_user_role = test_user_role
+        self.system.anonymous_student_id = None
+
         self.mod = VideoAnnotationModule(
             Mock(),
-            get_test_system(),
+            self.system,
             DictFieldData({'data': self.sample_xml, 'sourceUrl': self.sample_sourceurl}),
             ScopeIds(None, None, None, None)
         )
@@ -67,5 +81,5 @@ class VideoAnnotationModuleTestCase(unittest.TestCase):
         Tests to make sure variables passed in truly exist within the html once it is all rendered.
         """
         context = self.mod.student_view({}).content
-        for key in ['display_name', 'instructions_html', 'sourceUrl', 'typeSource', 'poster', 'annotation_storage']:
+        for key in ['display_name', 'instructions_html', 'sourceUrl', 'typeSource', 'poster', 'annotation_storage', 'default_tab', 'instructor_email', 'annotation_mode', "is_course_staff"]:
             self.assertIn(key, context)

--- a/common/lib/xmodule/xmodule/textannotation_module.py
+++ b/common/lib/xmodule/xmodule/textannotation_module.py
@@ -103,6 +103,9 @@ class TextAnnotationModule(AnnotatableFields, XModule):
         self.instructions = self._extract_instructions(xmltree)
         self.content = etree.tostring(xmltree, encoding='unicode')
         self.user_email = ""
+        self.is_course_staff = False
+        if self.runtime.get_user_role() in ['instructor', 'staff']:
+            self.is_course_staff = True
         if self.runtime.get_real_user is not None:
             self.user_email = self.runtime.get_real_user(self.runtime.anonymous_student_id).email
 
@@ -125,10 +128,15 @@ class TextAnnotationModule(AnnotatableFields, XModule):
             'default_tab': self.default_tab,
             'instructor_email': self.instructor_email,
             'annotation_mode': self.annotation_mode,
+            'is_course_staff': self.is_course_staff,
         }
         fragment = Fragment(self.system.render_template('textannotation.html', context))
-        fragment.add_javascript_url(self.runtime.STATIC_URL + "js/vendor/tinymce/js/tinymce/tinymce.full.min.js")
-        fragment.add_javascript_url(self.runtime.STATIC_URL + "js/vendor/tinymce/js/tinymce/jquery.tinymce.min.js")
+
+        # TinyMCE already exists in Studio so we should not load the files again
+        # get_real_user always returns "None" in Studio since its runtimes contains no anonymous ids
+        if self.runtime.get_real_user is not None:
+            fragment.add_javascript_url(self.runtime.STATIC_URL + "js/vendor/tinymce/js/tinymce/tinymce.full.min.js")
+            fragment.add_javascript_url(self.runtime.STATIC_URL + "js/vendor/tinymce/js/tinymce/jquery.tinymce.min.js")
         return fragment
 
 

--- a/common/lib/xmodule/xmodule/videoannotation_module.py
+++ b/common/lib/xmodule/xmodule/videoannotation_module.py
@@ -103,6 +103,9 @@ class VideoAnnotationModule(AnnotatableFields, XModule):
         self.instructions = self._extract_instructions(xmltree)
         self.content = etree.tostring(xmltree, encoding='unicode')
         self.user_email = ""
+        self.is_course_staff = False
+        if self.runtime.get_user_role() in ['instructor', 'staff']:
+            self.is_course_staff = True
         if self.runtime.get_real_user is not None:
             self.user_email = self.runtime.get_real_user(self.runtime.anonymous_student_id).email
 
@@ -131,10 +134,15 @@ class VideoAnnotationModule(AnnotatableFields, XModule):
             'default_tab': self.default_tab,
             'instructor_email': self.instructor_email,
             'annotation_mode': self.annotation_mode,
+            'is_course_staff': self.is_course_staff,
         }
         fragment = Fragment(self.system.render_template('videoannotation.html', context))
-        fragment.add_javascript_url(self.runtime.STATIC_URL + "js/vendor/tinymce/js/tinymce/tinymce.full.min.js")
-        fragment.add_javascript_url(self.runtime.STATIC_URL + "js/vendor/tinymce/js/tinymce/jquery.tinymce.min.js")
+
+        # TinyMCE already exists in Studio so we should not load the files again
+        # get_real_user always returns "None" in Studio since its runtimes contains no anonymous ids
+        if self.runtime.get_real_user is not None:
+            fragment.add_javascript_url(self.runtime.STATIC_URL + "js/vendor/tinymce/js/tinymce/tinymce.full.min.js")
+            fragment.add_javascript_url(self.runtime.STATIC_URL + "js/vendor/tinymce/js/tinymce/jquery.tinymce.min.js")
         return fragment
 
 

--- a/lms/templates/imageannotation.html
+++ b/lms/templates/imageannotation.html
@@ -72,7 +72,7 @@
     var unit_id = $('#sequence-list').find('.active').attr("data-element");
         uri += unit_id;
     var pagination = 100,
-     is_staff = ('${user.email}'=='${instructor_email}'),
+     is_staff = '${is_course_staff}' === 'True',
         options = {
         optionsAnnotator: {
             permissions:{

--- a/lms/templates/textannotation.html
+++ b/lms/templates/textannotation.html
@@ -61,7 +61,7 @@ ${static.css(group='style-xmodule-annotations', raw=True)}
     var unit_id = $('#sequence-list').find('.active').attr("data-element");
     uri += unit_id;
     var pagination = 100,
-        is_staff = !('${user.is_staff}'=='False'),
+        is_staff = '${is_course_staff}' === 'True',
         options = {
         optionsAnnotator: {
             permissions:{

--- a/lms/templates/videoannotation.html
+++ b/lms/templates/videoannotation.html
@@ -64,7 +64,7 @@ ${static.css(group='style-xmodule-annotations', raw=True)}
 	var unit_id = $('#sequence-list').find('.active').attr("data-element");
     uri += unit_id;
 	var pagination = 100,
-	 is_staff = !('${user.is_staff}'=='False'),
+	 is_staff = '${is_course_staff}' === 'True',
         options = {
         optionsAnnotator: {
             permissions:{


### PR DESCRIPTION
This addresses the bug **[TNL-288]**.
**Affected Courses:**  4 courses are affected (PoetryX, HeroesX, Visualizing Japan, ChinaX) with a total enrollment 47,000 students. 
**Ideal Fix Deployment:** Week of Sept 15th. 

**Note:** In order to facilitate moderation for annotations, staff and instructors need to have write/read/delete/update access to students' annotations. Normally I do it myself, but 4 courses will be starting up that need some self-moderation since I can't do it all on my own.

**Background:** This was supposed to be done by my predecessor but he misunderstood the user attribute `is_staff` which is meant for Django admins, not course admins. Having found the way to get roles, I've updated the way that the staff variable is found for all three tools.

**Studio Update:** None.

**LMS Update:** Instructors and Course Staff should have access to students' annotations.

**Testing:** 
1. Load the course using this [tarball](https://www.dropbox.com/s/r684ber7z4ddqtc/2014_T4.DPRfFs.tar.gz).
2. Create three accounts: a student, a course staff, and an instructor.
3. As a student create a text, video, and image annotation.
4. As a course staff and then instructor, try to edit/delete the annotation that the student created.
   a) Before you got the pop-up but no option to edit.
       ![Before permissions](http://i.imgur.com/qVIpw9c.png)
   b) Now you should see the edit/delete options pop up.
       ![After permissions](http://i.imgur.com/MF3pSJx.png)
