### PR TITLE
mentoring: Allow partial answers when dependency isn't enforced

### DIFF
--- a/requirements/edx/edx-private.txt
+++ b/requirements/edx/edx-private.txt
@@ -1,7 +1,7 @@
 # Requirements for edx.org that aren't necessarily needed for Open edX.
 
 -e git+ssh://git@github.com/jazkarta/edX-jsdraw.git@9fcd333aaa2ac3df65dd247b601ce0b56bb10cad#egg=edx-jsdraw
--e git+https://github.com/gsehub/xblock-mentoring.git@d4532e4f89aaf36b56715be2abc0f9402912794e#egg=xblock-mentoring
+-e git+https://github.com/gsehub/xblock-mentoring.git@4d1cce78dc232d5da6ffd73817b5c490e87a6eee#egg=xblock-mentoring
 
 # Prototype XBlocks from edX learning sciences limited roll-outs and user testing. 
 # Concept XBlock, in particular, is nowhere near finished and an early prototype. 


### PR DESCRIPTION
@sarina This is a small update of the mentoring XBlock for the Harvard GSE1.1x course. The change has been requested by the course content team, to be more permissive with content entered the students and always accept answers (green checkmark) on questions for which dependencies aren't enforced.

The diff: https://github.com/gsehub/xblock-mentoring/compare/d4532e4f89aaf36b56715be2abc0f9402912794e...4d1cce78dc232d5da6ffd73817b5c490e87a6eee
