### PR TITLE
Calculate has_changes only Section/Subsection only on Outline page

### DIFF
--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -595,9 +595,6 @@ def _get_module_info(xblock, rewrite_static_links=True):
             course_id=xblock.location.course_key
         )
 
-    # Pre-cache has changes for the entire course because we'll need it for the ancestor info
-    modulestore().has_changes(modulestore().get_course(xblock.location.course_key, depth=None))
-
     # Note that children aren't being returned until we have a use case.
     return create_xblock_info(xblock, data=data, metadata=own_metadata(xblock), include_ancestor_info=True)
 
@@ -638,7 +635,8 @@ def create_xblock_info(xblock, data=None, metadata=None, include_ancestor_info=F
         return None
 
     is_xblock_unit = is_unit(xblock, parent_xblock)
-    has_changes = modulestore().has_changes(xblock)
+    # this should not be calculated for Sections and Subsections on Unit page
+    has_changes = modulestore().has_changes(xblock) if (is_xblock_unit or course_outline) else None
 
     if graders is None:
         graders = CourseGradingModel.fetch(xblock.location.course_key).graders

--- a/cms/djangoapps/contentstore/views/tests/test_item.py
+++ b/cms/djangoapps/contentstore/views/tests/test_item.py
@@ -100,9 +100,9 @@ class GetItemTest(ItemTest):
         return html, resources
 
     @ddt.data(
-        (1, 21, 23, 35, 37),
-        (2, 22, 24, 38, 39),
-        (3, 23, 25, 41, 41),
+        (1, 14, 16, 30, 30),
+        (2, 15, 17, 39, 32),
+        (3, 16, 18, 52, 34),
     )
     @ddt.unpack
     def test_get_query_count(self, branching_factor, chapter_queries, section_queries, unit_queries, problem_queries):

--- a/common/lib/xmodule/xmodule/modulestore/mongo/draft.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/draft.py
@@ -590,7 +590,6 @@ class DraftModuleStore(MongoModuleStore):
         _internal([root_usage.to_deprecated_son() for root_usage in root_usages])
         self.collection.remove({'_id': {'$in': to_be_deleted}}, safe=self.collection.safe)
 
-    @MongoModuleStore.memoize_request_cache
     def has_changes(self, xblock):
         """
         Check if the subtree rooted at xblock has any drafts and thus may possibly have changes


### PR DESCRIPTION
This fixes a bit of overhead introduced in https://github.com/edx/edx-platform/pull/5020
`@memoize_request_cache` still improves the result by couple of queries.

@cahrens @polesye @olmar 

Number of queries for `test_get_query_count(branching_factor, chapter_queries, section_queries, unit_queries, problem_queries)`

Previously:

```
(1, 21, 23, 35, 37),
(2, 22, 24, 38, 39),
(3, 23, 25, 41, 41),
```

without memoize:

```
(1, 14, 16, 28, 30),
(2, 15, 17, 39, 32),
(3, 16, 18, 52, 34),
```

with memoize:

```
(1, 14, 16, 28, 30),
(2, 15, 17, 35, 32),
(3, 16, 18, 46, 34),
```

I propose we leave memoize in, unless RAM usage becomes an issue.
