### PR TITLE
Fix a unicode error in CyberSource2

### DIFF
--- a/lms/djangoapps/shoppingcart/processors/CyberSource2.py
+++ b/lms/djangoapps/shoppingcart/processors/CyberSource2.py
@@ -101,7 +101,7 @@ def processor_hash(value):
 
     """
     secret_key = get_processor_config().get('SECRET_KEY', '')
-    hash_obj = hmac.new(secret_key, value, sha256)
+    hash_obj = hmac.new(secret_key.encode('utf-8'), value.encode('utf-8'), sha256)
     return binascii.b2a_base64(hash_obj.digest())[:-1]  # last character is a '\n', which we don't want
 
 


### PR DESCRIPTION
This is the same fix that @dianakhuang made to the original CC implementation in this commit: https://github.com/edx/edx-platform/commit/3b668522

@dianakhuang @stephensanchez Please review.  I think we will need to hotfix this and will coordinate with ops.

[ECOM-291](https://openedx.atlassian.net/browse/ECOM-291)
