### PR TITLE
Acceptance tests (lettuce): hardcode sleeps to fix flakiness

### DIFF
--- a/lms/djangoapps/courseware/features/change_enrollment.py
+++ b/lms/djangoapps/courseware/features/change_enrollment.py
@@ -6,6 +6,8 @@ from opaque_keys.edx.locations import SlashSeparatedCourseKey
 from logging import getLogger
 logger = getLogger(__name__)
 
+import time
+
 
 @step(u'the course "([^"]*)" has all enrollment modes$')
 def add_enrollment_modes_to_course(_step, course):
@@ -43,6 +45,7 @@ def honor_code_upgrade(_step):
     """ Simulates choosing the honor code mode on the upgrade page """
     honor_code_link = world.browser.find_by_css('.title-expand')
     honor_code_link.click()
+    time.sleep(1)
     honor_code_checkbox = world.browser.find_by_css('#honor-code')
     honor_code_checkbox.click()
     upgrade_button = world.browser.find_by_name("certificate_mode")

--- a/lms/djangoapps/courseware/features/registration.py
+++ b/lms/djangoapps/courseware/features/registration.py
@@ -3,6 +3,7 @@
 
 from lettuce import world, step
 from lettuce.django import django_url
+import time
 
 
 @step('I register for the course "([^"]*)"$')
@@ -18,8 +19,13 @@ def i_register_to_audit_the_course(_step):
     url = django_url('courses/%s/about' % world.scenario_dict['COURSE'].id.to_deprecated_string())
     world.browser.visit(url)
     world.css_click('section.intro a.register')
+    # the below button has a race condition. When the page first loads
+    # some animation needs to complete before this button is in a stable
+    # position. TODO: implement this without a sleep.
+    time.sleep(2)
     audit_button = world.browser.find_by_name("audit_mode")
     audit_button.click()
+    time.sleep(1)
     assert world.is_css_present('section.container.dashboard')
 
 


### PR DESCRIPTION
This is a quick fix (because the long fix was taking far too long
due to animation). The truer fix is to port these tests to bok-choy.
