### PR TITLE
Annotation Tool: Fixed TinyMCE issue when changing units

### DIFF
--- a/common/static/js/vendor/ova/richText-annotator.js
+++ b/common/static/js/vendor/ova/richText-annotator.js
@@ -130,10 +130,11 @@ Annotator.Plugin.RichText = (function(_super) {
             });
         };
 
-        // makes sure that tinymce is not initiated by checking if editors exist
-        if(tinymce.editors.length === 0) {
-            tinymce.init(this.options.tinymce);
+        // makes sure that if tinymce exists already that this removes/destroys previous version
+        if (tinymce.editors.length > 0) {
+            tinymce.remove("li.annotator-item textarea");  
         }
+        tinymce.init(this.options.tinymce);
     };
     
     /**


### PR DESCRIPTION
This addresses the bug **[TNL-293]**.
**Affected Courses:**  4 courses are affected (PoetryX, HeroesX, Visualizing Japan, ChinaX) with a total enrollment 47,000 students. 
**Ideal Fix Deployment:** Week of Sept 15th, could replace PR #5148

**Background:** Because the pages are loaded dynamically there is a particular bug that happens with TinyMCE. Originally I had fixed the bug where two competing TinyMCE initializations were interfering with each other by adding a condition to test if an editor already existed. The problem with that is that because of the dynamic loading aspect of units, the HTML containing the TinyMCE instance was deleted and could later not be found. A much better solution is below where if there exists a version of TinyMCE, i remove it and then call for it to be initialized after. 

**Studio Update:** None.

**LMS Update:** Users should be able to switch from unit to unit and not lose RichText editing tools.

**Testing:** 
1. Load the course using this [tarball](https://www.dropbox.com/s/r684ber7z4ddqtc/2014_T4.DPRfFs.tar.gz).
2. Create an annotation in two text sources within the same subsection (but in different units)
3. After you make the first one and hit the second unit using the ribbon navigation at the top you should see that the TinyMCE editor failed to load and you should see the following:
![TinyMCE fails to load]()
4. Now you should be able to go freely back and forth and create annotations. 
![TinyMCE loads normally]()
