### PR TITLE
Add tracking on expand of upsell message

### DIFF
--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -5,7 +5,6 @@
 
 <%!
   from django.core.urlresolvers import reverse
-  import waffle
 %>
 
 <%
@@ -31,6 +30,12 @@
         (e).preventDefault();
 
         $(this).closest('.message.is-expandable').toggleClass('is-expanded');
+
+        course = $("#upgrade-to-verified").data("course-id");
+        analytics.track('edx.bi.dashboard.upsell_copy.clicked', {
+          category: 'user-engagement',
+          label: course
+        });
     }
 
     $("#failed-verification-button-dismiss").click(function(event) {
@@ -45,15 +50,6 @@
       user = $(event.target).data("user");
       course = $(event.target).data("course-id");
       Logger.log('edx.course.enrollment.upgrade.clicked', [user, course], null);
-      % if waffle.flag_is_active(request, 'alternate_upsell_copy'):
-      analytics.track("Clicked on Alternate Upsell Copy", {
-        course: course
-      });
-      % else:
-      analytics.track("Clicked on Regular Upsell Copy", {
-        course: course
-      });
-      % endif
     });
 
     $(".email-settings").click(function(event) {

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -4,7 +4,6 @@
 <%!
   from django.core.urlresolvers import reverse
   from courseware.courses import course_image_url, get_course_about_section
-  import waffle
 %>
 
 <%
@@ -107,11 +106,7 @@
             <div class="wrapper-tip">
               <h4 class="message-title">
                 <i class="icon-caret-down ui-toggle-expansion"></i>
-                % if waffle.flag_is_active(request, 'alternate_upsell_copy'):
-                  <span class="value">${_("Document your accomplishment!")}</span>
-                % else:
                   <span class="value">${_("Challenge Yourself!")}</span>
-                % endif
               </h4>
               <p class="message-copy">${_("Take this course as an ID-verified student.")}</p>
             </div>


### PR DESCRIPTION
This adds tracking on click/expansion of the upsell message appearing on the student dashboard, as per [ECOM-292](https://openedx.atlassian.net/browse/ECOM-292). I've also ripped out some relevant Django Waffle code; I'll get the rest in a future PR.

@flowerhack and @wedaly, could you give this a once-over? I've manually tested the emission of the event.
