### PR TITLE
Break out course key fields into event context

### DIFF
--- a/common/djangoapps/track/tests/test_contexts.py
+++ b/common/djangoapps/track/tests/test_contexts.py
@@ -7,18 +7,26 @@ from track import contexts
 
 class TestContexts(TestCase):
 
-    COURSE_ID = 'test/course_name/course_run'
     ORG_ID = 'test'
+    COURSE = 'course_name'
+    RUN = 'course_run'
+    COURSE_ID = '/'.join((ORG_ID, COURSE, RUN))
+    COURSE_KEY = 'course-v1:' + '+'.join((ORG_ID, COURSE, RUN))
 
     def test_course_id_from_url(self):
         self.assert_parses_course_id_from_url('http://foo.bar.com/courses/{course_id}/more/stuff')
 
-    def assert_parses_course_id_from_url(self, format_string):
+    def assert_parses_course_id_from_url(self, format_string, course_id=COURSE_ID):
         self.assertEquals(
-            contexts.course_context_from_url(format_string.format(course_id=self.COURSE_ID)),
+            contexts.course_context_from_url(format_string.format(course_id=course_id)),
             {
-                'course_id': self.COURSE_ID,
-                'org_id': self.ORG_ID
+                'course_id': course_id,
+                'org_id': self.ORG_ID,
+                'course_key': {
+                    'org': self.ORG_ID,
+                    'course': self.COURSE,
+                    'run': self.RUN
+                },
             }
         )
 
@@ -42,3 +50,9 @@ class TestContexts(TestCase):
 
     def test_no_url(self):
         self.assert_empty_context_for_url(None)
+
+    def test_course_v1(self):
+        self.assert_parses_course_id_from_url('http://foo.bar.com/courses/{course_id}/other/stuff', course_id=self.COURSE_KEY)
+
+    def test_course_v1_later_in_url(self):
+        self.assert_parses_course_id_from_url('http://foo.bar.com/x/y/z/courses/{course_id}/other/stuff', course_id=self.COURSE_KEY)

--- a/common/djangoapps/track/tests/test_middleware.py
+++ b/common/djangoapps/track/tests/test_middleware.py
@@ -92,6 +92,11 @@ class TrackMiddlewareTestCase(TestCase):
         expected_context_subset = {
             'course_id': 'test_org/test_course/test_run',
             'org_id': 'test_org',
+            'course_key': {
+                'org': 'test_org',
+                'course': 'test_course',
+                'run': 'test_run'
+            }
         }
         self.assert_dict_subset(captured_context, expected_context_subset)
 

--- a/common/djangoapps/track/views/tests/test_views.py
+++ b/common/djangoapps/track/views/tests/test_views.py
@@ -54,6 +54,11 @@ class TestTrackViews(TestCase):
             'context': {
                 'course_id': 'foo/bar/baz',
                 'org_id': 'foo',
+                'course_key': {
+                    'org': 'foo',
+                    'course': 'bar',
+                    'run': 'baz'
+                }
             },
         }
         self.mock_tracker.send.assert_called_once_with(expected_event)
@@ -85,6 +90,11 @@ class TestTrackViews(TestCase):
                     'course_id': 'foo/bar/baz',
                     'org_id': 'foo',
                     'user_id': '',
+                    'course_key': {
+                        'org': 'foo',
+                        'course': 'bar',
+                        'run': 'baz'
+                    },
                     'path': u'/event'
                 },
             }
@@ -136,6 +146,11 @@ class TestTrackViews(TestCase):
                     'user_id': '',
                     'course_id': u'foo/bar/baz',
                     'org_id': 'foo',
+                    'course_key': {
+                        'org': 'foo',
+                        'course': 'bar',
+                        'run': 'baz'
+                    },
                     'path': u'/courses/foo/bar/baz/xmod/'
                 },
             }
@@ -169,6 +184,11 @@ class TestTrackViews(TestCase):
                     'user_id': '',
                     'course_id': u'foo/bar/baz',
                     'org_id': 'foo',
+                    'course_key': {
+                        'org': 'foo',
+                        'course': 'bar',
+                        'run': 'baz'
+                    },
                     'path': u'/courses/foo/bar/baz/xmod/'
                 },
             }


### PR DESCRIPTION
Event log consumers parsing events may not have the opaque-keys library available in the execution environment they are using to analyze the tracking logs and/or may not even be python based. In order to simplify the analysis, and hopefully prevent string parsing of the identifier, we split out the various fields of the course key and store them alongside the serialized key in the context.

Reviewers: @rocha @brianhw @cpennington
