### PR TITLE
Remove Django Waffle

### DIFF
--- a/common/djangoapps/embargo/tests/test_middleware.py
+++ b/common/djangoapps/embargo/tests/test_middleware.py
@@ -260,12 +260,12 @@ class EmbargoMiddlewareTests(ModuleStoreTestCase):
         profile.save()
 
         # Warm the cache
-        with self.assertNumQueries(18):
+        with self.assertNumQueries(14):
             self.client.get(self.embargoed_page)
 
         # Access the page multiple times, but expect that we hit
         # the database to check the user's profile only once
-        with self.assertNumQueries(12):
+        with self.assertNumQueries(8):
             self.client.get(self.embargoed_page)
 
     def test_embargo_profile_country_db_null(self):

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -837,14 +837,6 @@ JASMINE_TEST_DIRECTORY = PROJECT_ROOT + '/static/coffee'
 # Ignore deprecation warnings (so we don't clutter Jenkins builds/production)
 simplefilter('ignore')
 
-################################# Waffle ###################################
-
-# Name prepended to cookies set by Waffle
-WAFFLE_COOKIE = "waffle_flag_%s"
-
-# Two weeks (in sec)
-WAFFLE_MAX_AGE = 1209600
-
 ################################# Middleware ###################################
 # List of finder classes that know how to find static files in
 # various locations.
@@ -909,9 +901,6 @@ MIDDLEWARE_CLASSES = (
     'ratelimitbackend.middleware.RateLimitMiddleware',
     # needs to run after locale middleware (or anything that modifies the request context)
     'edxmako.middleware.MakoMiddleware',
-
-    # For A/B testing
-    'waffle.middleware.WaffleMiddleware',
 
     # for expiring inactive sessions
     'session_inactivity_timeout.middleware.SessionInactivityTimeout',
@@ -1330,9 +1319,6 @@ INSTALLED_APPS = (
 
     # Foldit integration
     'foldit',
-
-    # For A/B testing
-    'waffle',
 
     # For testing
     'django.contrib.admin',  # only used in DEBUG mode

--- a/lms/templates/courseware/course_navigation.html
+++ b/lms/templates/courseware/course_navigation.html
@@ -18,7 +18,6 @@ def url_class(is_active):
 <%! from django.core.urlresolvers import reverse %>
 <%! from django.utils.translation import ugettext as _ %>
 <%! from courseware.views import notification_image_for_tab %>
-<% import waffle %>
 
 % if disable_tabs is UNDEFINED or not disable_tabs:
 <nav class="${active_page} course-material">
@@ -29,11 +28,7 @@ def url_class(is_active):
             tab_is_active = (tab.tab_id == active_page) or (tab.tab_id == default_tab)
             tab_image = notification_image_for_tab(tab, user, course)
         %>
-        % if waffle.flag_is_active(request, 'visual_treatment'):
-          <li class="${"prominent" if tab.name in ("Courseware", "Course Content") else ""}">
-        % else:
           <li>
-        % endif
              <a href="${tab.link_func(course, reverse) | h}" class="${url_class(tab_is_active)}">
                  ${_(tab.name) | h}
                  % if tab_is_active:

--- a/lms/templates/courseware/welcome-back.html
+++ b/lms/templates/courseware/welcome-back.html
@@ -1,6 +1,5 @@
 <%!
 from django.utils.translation import ugettext as _ 
-import waffle
 %>
 
 <h2>${chapter_module.display_name_with_default}</h2>

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -64,8 +64,6 @@ urlpatterns = ('',  # nopep8
 
     url(r'^lang_pref/', include('lang_pref.urls')),
 
-    url(r'^', include('waffle.urls')),
-
     url(r'^i18n/', include('django.conf.urls.i18n')),
 
     url(r'^embargo$', 'student.views.embargo', name="embargo"),

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -22,7 +22,6 @@
 -e git+https://github.com/edx/codejail.git@71f5c5616e2a73ae8cecd1ff2362774a773d3665#egg=codejail
 -e git+https://github.com/edx/diff-cover.git@v0.5.0#egg=diff_cover
 -e git+https://github.com/edx/js-test-tool.git@v0.1.5#egg=js_test_tool
--e git+https://github.com/edx/django-waffle.git@823a102e48#egg=django-waffle
 -e git+https://github.com/edx/event-tracking.git@0.1.0#egg=event-tracking
 -e git+https://github.com/edx/edx-analytics-data-api-client.git@0.1.0#egg=edx-analytics-data-api-client
 -e git+https://github.com/edx/bok-choy.git@2e6eab960a97fe41778292fe8e1b2f0b69a1be2d#egg=bok_choy


### PR DESCRIPTION
Paired with changes made in #5184, this removes all vestiges of Django Waffle from our codebase. @stephensanchez and @wedaly, could you please review this?

@feanil, I'll draft an email to send to edx-code before we merge this. How should we go about deleting the tables created by Waffle?
