### PR TITLE
Add matplotlib to the sandbox requirements.

### DIFF
--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -9,3 +9,4 @@ networkx==1.7
 sympy==0.7.1
 pyparsing==2.0.1
 nltk==2.0.4
+matplotlib==1.3.1


### PR DESCRIPTION
Used by MITx/6.341x

Review: @nedbat @carsongee 
FYI: @shnayder 
