### PR TITLE
Fixed bok choy flaky test for studio.

### DIFF
--- a/common/test/acceptance/pages/studio/container.py
+++ b/common/test/acceptance/pages/studio/container.py
@@ -247,6 +247,9 @@ class ContainerPage(PageObject):
         Note that this does an ajax call.
         """
         self.q(css='.add-missing-groups-button').first.click()
+        self.wait_for_ajax()
+
+        # Wait until all xblocks rendered.
         self.wait_for_page()
 
     def missing_groups_button_present(self):


### PR DESCRIPTION
TNL-284

On ajax call `wait_for_page()` was used instead of `wait_for_ajax()` in `add_missing_groups()`
