### PR TITLE
Pyfilesystem fix for AWS

### DIFF
--- a/docs/shared/requirements.txt
+++ b/docs/shared/requirements.txt
@@ -28,7 +28,10 @@ django-method-override==0.1.0
 djangorestframework==2.3.5
 django==1.4.5
 feedparser==5.1.3
-fs==0.4.0
+# Master pyfs has a bug working with VPC auth. This is a fix. We should switch
+# back to master when and if this fix is merged back.
+# fs==0.4.0
+git+https://github.com/pmitros/pyfs.git@96e1922348bfe6d99201b9512a9ed946c87b7e0b
 GitPython==0.3.2.RC1
 glob2==0.3
 lxml==3.0.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -37,7 +37,10 @@ djangorestframework==2.3.5
 django==1.4.14
 feedparser==5.1.3
 firebase-token-generator==1.3.2
-fs==0.4.0
+# Master pyfs has a bug working with VPC auth. This is a fix. We should switch
+# back to master when and if this fix is merged back.
+# fs==0.4.0
+git+https://github.com/pmitros/pyfs.git@96e1922348bfe6d99201b9512a9ed946c87b7e0b
 GitPython==0.3.2.RC1
 glob2==0.3
 gunicorn==0.17.4


### PR DESCRIPTION
pyfs expects AWS access/secret keys. This prevents it from working with VPC auth in prod. This removes the expectation. See: 

  https://github.com/pmitros/pyfs/commit/96e1922348bfe6d99201b9512a9ed946c87b7e0b

Same fix for pyfs latest worked without issues on sandbox. Imports/exports have a version dependency on pyfs-0.4.0, so test failed. I am waiting on tests to run and on sandbox provisioning to see if this is ready to go. 
