### PR TITLE
only redirect to dashboard if user has course enrollments, otherwise rem...

### DIFF
--- a/lms/djangoapps/branding/views.py
+++ b/lms/djangoapps/branding/views.py
@@ -3,14 +3,33 @@ from django.core.urlresolvers import reverse
 from django.http import Http404
 from django.shortcuts import redirect
 from django_future.csrf import ensure_csrf_cookie
-from edxmako.shortcuts import render_to_response
 
 import student.views
+from student.models import CourseEnrollment
+
 import courseware.views
 
 from microsite_configuration import microsite
 from edxmako.shortcuts import marketing_link
 from util.cache import cache_if_anonymous
+
+
+def get_course_enrollments(user):
+    """
+    Returns the course enrollments for the passed in user within the context of a microsite, that
+    is filtered by course_org_filter
+    """
+    enrollments = CourseEnrollment.enrollments_for_user(user)
+    microsite_org = microsite.get_value('course_org_filter')
+    if microsite_org:
+        site_enrollments = [
+            enrollment for enrollment in enrollments if enrollment.course_id.org == microsite_org
+        ]
+    else:
+        site_enrollments = [
+            enrollment for enrollment in enrollments
+        ]
+    return site_enrollments
 
 
 @ensure_csrf_cookie
@@ -21,7 +40,15 @@ def index(request):
     '''
 
     if settings.COURSEWARE_ENABLED and request.user.is_authenticated():
-        return redirect(reverse('dashboard'))
+        # For microsites, only redirect to dashboard if user has
+        # courses in his/her dashboard. Otherwise UX is a bit cryptic.
+        # In this case, we want to have the user stay on a course catalog
+        # page to make it easier to browse for courses (and register)
+        if microsite.get_value('ALWAYS_REDIRECT_HOMEPAGE_TO_DASHBOARD_FOR_AUTHENTICATED_USER', \
+            settings.FEATURES.get('ALWAYS_REDIRECT_HOMEPAGE_TO_DASHBOARD_FOR_AUTHENTICATED_USER', True)) or \
+            get_course_enrollments(request.user):
+
+            return redirect(reverse('dashboard'))
 
     if settings.FEATURES.get('AUTH_USE_CERTIFICATES'):
         from external_auth.views import ssl_login
@@ -51,7 +78,6 @@ def index(request):
     #  we do not expect this case to be reached in cases where
     #  marketing and edge are enabled
     return student.views.index(request, user=request.user)
-
 
 
 @ensure_csrf_cookie

--- a/lms/djangoapps/courseware/tests/test_microsites.py
+++ b/lms/djangoapps/courseware/tests/test_microsites.py
@@ -5,7 +5,6 @@ from django.core.urlresolvers import reverse
 from django.test.utils import override_settings
 
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
-
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 
 from helpers import LoginEnrollmentTestCase
@@ -44,17 +43,13 @@ class TestMicrosites(ModuleStoreTestCase, LoginEnrollmentTestCase):
 
         self.course_outside_microsite = CourseFactory.create(display_name='Robot_Course_Outside_Microsite', org='FooX')
 
-    def create_student_accounts(self):
-        """
-        Build out the test accounts we'll use in these tests
-        """
+    def setup_users(self):
         # Create student accounts and activate them.
         for i in range(len(self.STUDENT_INFO)):
             email, password = self.STUDENT_INFO[i]
             username = 'u{0}'.format(i)
             self.create_account(username, email, password)
             self.activate_user(email)
-
 
     @override_settings(SITE_NAME=MICROSITE_TEST_HOSTNAME)
     def test_microsite_anonymous_homepage_content(self):
@@ -89,7 +84,6 @@ class TestMicrosites(ModuleStoreTestCase, LoginEnrollmentTestCase):
         # assert that the edX partners tag line is not in the HTML
         self.assertNotContains(resp, 'Explore free courses from')
 
-
     def test_not_microsite_anonymous_homepage_content(self):
         """
         Make sure we see the right content on the homepage if we are not in a microsite
@@ -114,16 +108,39 @@ class TestMicrosites(ModuleStoreTestCase, LoginEnrollmentTestCase):
         # assert that footer template has been properly overriden on homepage
         self.assertNotContains(resp, 'This is a Test Microsite footer')
 
+    def test_no_redirect_on_homepage_when_no_enrollments(self):
+        """
+        Verify that a user going to homepage will not redirect if he/she has no course enrollments
+        """
+        self.setup_users()
+
+        email, password = self.STUDENT_INFO[0]
+        self.login(email, password)
+        resp = self.client.get(reverse('root'), HTTP_HOST=MICROSITE_TEST_HOSTNAME)
+        self.assertEquals(resp.status_code, 200)
+
+    def test_redirect_on_homepage_when_has_enrollments(self):
+        """
+        Verify that a user going to homepage will redirect to dashboard if he/she has
+        a course enrollment
+        """
+        self.setup_users()
+
+        email, password = self.STUDENT_INFO[0]
+        self.login(email, password)
+        self.enroll(self.course, True)
+
+        resp = self.client.get(reverse('root'), HTTP_HOST=MICROSITE_TEST_HOSTNAME)
+        self.assertEquals(resp.status_code, 302)
 
     def test_microsite_course_enrollment(self):
         """
         Enroll user in a course scoped in a Microsite and one course outside of a Microsite
         and make sure that they are only visible in the right Dashboards
         """
+        self.setup_users()
 
-        self.create_student_accounts()
-
-        email, password = self.STUDENT_INFO[0]
+        email, password = self.STUDENT_INFO[1]
         self.login(email, password)
         self.enroll(self.course, True)
         self.enroll(self.course_outside_microsite, True)

--- a/lms/djangoapps/courseware/tests/test_navigation.py
+++ b/lms/djangoapps/courseware/tests/test_navigation.py
@@ -59,7 +59,6 @@ class TestNavigation(ModuleStoreTestCase, LoginEnrollmentTestCase):
                                           display_name='progress_tab',
                                           default_tab = 'progress')
 
-
         # Create student accounts and activate them.
         for i in range(len(self.STUDENT_INFO)):
             email, password = self.STUDENT_INFO[i]

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -279,6 +279,11 @@ FEATURES = {
     # when the styles appropriately match the edX.org website.
     'ENABLE_NEW_EDX_HEADER': False,
 
+    # When a logged in user goes to the homepage ('/') should the user be
+    # redirected to the dashboard - this is default Open edX behavior. Set to
+    # False to not redirect the user
+    'ALWAYS_REDIRECT_HOMEPAGE_TO_DASHBOARD_FOR_AUTHENTICATED_USER': True,
+
 }
 
 # Ignore static asset files on import which match this pattern

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -330,7 +330,8 @@ MICROSITE_CONFIGURATION = {
         "show_homepage_promo_video": False,
         "course_index_overlay_text": "This is a Test Microsite Overlay Text.",
         "course_index_overlay_logo_file": "test_microsite/images/header-logo.png",
-        "homepage_overlay_html": "<h1>This is a Test Microsite Overlay HTML</h1>"
+        "homepage_overlay_html": "<h1>This is a Test Microsite Overlay HTML</h1>",
+        "ALWAYS_REDIRECT_HOMEPAGE_TO_DASHBOARD_FOR_AUTHENTICATED_USER": False,
     },
     "default": {
         "university": "default_university",


### PR DESCRIPTION
...ain on the course catalog page (aka homepage or root)

We got some UX feedback on our white label sites where it is a poor experience for logged in users to be redirected to their dashboard when they have no enrolled courses. It is felt that it is confusing to the end-user what he/she should do after that redirect.
