### PR TITLE
Do not generate CSS source maps in production

### DIFF
--- a/common/static/js/vendor/ova/annotator-full.js
+++ b/common/static/js/vendor/ova/annotator-full.js
@@ -3371,5 +3371,3 @@ Annotator.prototype.setupPlugins = function(config, options) {
 /*
 //
 */
-
-//@ sourceMappingURL=annotator-full.map

--- a/pavelib/assets.py
+++ b/pavelib/assets.py
@@ -132,7 +132,7 @@ def compile_sass(debug=False):
     """
     sh(cmd(
         'sass', '' if debug else '--style compressed',
-        "--sourcemap",
+        "--sourcemap" if debug else '',
         "--cache-location {cache}".format(cache=SASS_CACHE_PATH),
         "--load-path", " ".join(SASS_LOAD_PATHS + THEME_SASS_PATHS),
         "--update", "-E", "utf-8", " ".join(SASS_UPDATE_DIRS + THEME_SASS_PATHS),


### PR DESCRIPTION
[TNL-271](https://openedx.atlassian.net/browse/TNL-271) eliminate broken links to .map files

These are for development environment only, and we did not distribute them to production servers. So this change only removes reference to never-existing files, making debug console output a bit cleaner in production.

@talbs @cahrens @andy-armstrong @polesye @olmar 
