### PR TITLE
Upgrade MathJax to 2.4

### DIFF
--- a/cms/static/coffee/spec/main.coffee
+++ b/cms/static/coffee/spec/main.coffee
@@ -47,7 +47,7 @@ requirejs.config({
         "URI": "xmodule_js/common_static/js/vendor/URI.min",
         "mock-ajax": "xmodule_js/common_static/js/vendor/mock-ajax",
 
-        "mathjax": "//cdn.mathjax.org/mathjax/2.2-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&delayStartupUntil=configured",
+        "mathjax": "//cdn.mathjax.org/mathjax/2.4-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&delayStartupUntil=configured",
         "youtube": "//www.youtube.com/player_api?noext",
         "tender": "//api.tenderapp.com/tender_widget",
 

--- a/cms/static/coffee/spec/main_squire.coffee
+++ b/cms/static/coffee/spec/main_squire.coffee
@@ -41,7 +41,7 @@ requirejs.config({
         "domReady": "xmodule_js/common_static/js/vendor/domReady",
         "URI": "xmodule_js/common_static/js/vendor/URI.min",
 
-        "mathjax": "//cdn.mathjax.org/mathjax/2.2-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&delayStartupUntil=configured",
+        "mathjax": "//cdn.mathjax.org/mathjax/2.4-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&delayStartupUntil=configured",
         "youtube": "//www.youtube.com/player_api?noext",
         "tender": "//api.tenderapp.com/tender_widget.js"
 

--- a/cms/static/require-config.js
+++ b/cms/static/require-config.js
@@ -74,7 +74,7 @@ require.config({
             // so that require doesn't fall over
             "js/src/tender_fallback"
         ],
-        "mathjax": "//cdn.mathjax.org/mathjax/2.2-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&delayStartupUntil=configured",
+        "mathjax": "//cdn.mathjax.org/mathjax/2.4-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&delayStartupUntil=configured",
         "youtube": [
             // youtube URL does not end in ".js". We add "?noext" to the path so
             // that require.js adds the ".js" to the query component of the URL,

--- a/common/templates/mathjax_include.html
+++ b/common/templates/mathjax_include.html
@@ -33,4 +33,4 @@
 <!-- This must appear after all mathjax-config blocks, so it is after the imports from the other templates.
      It can't be run through static.url because MathJax uses crazy url introspection to do lazy loading of
      MathJax extension libraries -->
-<script type="text/javascript" src="https://cdn.mathjax.org/mathjax/2.2-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full"></script>
+<script type="text/javascript" src="https://cdn.mathjax.org/mathjax/2.4-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full"></script>

--- a/lms/static/js/spec/main.js
+++ b/lms/static/js/spec/main.js
@@ -43,7 +43,7 @@
             'jasmine.async': 'xmodule_js/common_static/js/vendor/jasmine.async',
             'draggabilly': 'xmodule_js/common_static/js/vendor/draggabilly.pkgd',
             'domReady': 'xmodule_js/common_static/js/vendor/domReady',
-            'mathjax': '//cdn.mathjax.org/mathjax/2.2-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&delayStartupUntil=configured',
+            'mathjax': '//cdn.mathjax.org/mathjax/2.4-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&delayStartupUntil=configured',
             'youtube': '//www.youtube.com/player_api?noext',
             'tender': '//api.tenderapp.com/tender_widget',
             'coffee/src/ajax_prefix': 'xmodule_js/common_static/coffee/src/ajax_prefix',


### PR DESCRIPTION
edx-platform is currently using MathJax 2.2 that's loaded from an S3 bucket (https://github.com/edx/edx-platform/blob/cc6e63dd222902a4cdc7ddc6655fbbddd2b16282/common/templates/mathjax_include.html). One of our clients that has built an external UI based on jquery-xblock has been experiencing weird rendering issues in IE, which we tracked down to a bug in MathJax, most probably related to https://github.com/mathjax/MathJax/issues/585. Switching to MathJax 2.4 in xblock-discussion (https://github.com/edx-solutions/xblock-discussion/pull/24) fixed the problem for us.

I am not sure what the reason for hosting MathJax on S3 is, although it makes sense to host it externally since it's a huge dependency as far as JS libraries go. There is also a vendored version at https://github.com/edx/edx-platform/tree/cfae1cdf62fb74307b88bd091cd4ba927af6b1fc/common/static/js/vendor/mathjax-MathJax-c9db6ac, but that's an old 2.0 version that only appears to be used in xmodule JS specs (https://github.com/edx/edx-platform/blob/master/common/lib/xmodule/xmodule/js/js_test.yml#L54). I would be happy to try and port the specs to use the externally hosted version and removed the vendored MathJax lib if there is interest.

Any kind of feedback would be much appreciated.
