### PR TITLE
Fixed full screen functionality for image module in HTMLModule.

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/html/display.coffee
+++ b/common/lib/xmodule/xmodule/js/src/html/display.coffee
@@ -6,6 +6,8 @@ class @HTMLModule
     Collapsible.setCollapsibles(@el)
     if MathJax?
 	    MathJax.Hub.Queue ["Typeset", MathJax.Hub, @el[0]]
+    if setupFullScreenModal?
+      setupFullScreenModal()
 
   $: (selector) ->
     $(selector, @el)

--- a/common/lib/xmodule/xmodule/js/src/html/imageModal.js
+++ b/common/lib/xmodule/xmodule/js/src/html/imageModal.js
@@ -1,6 +1,7 @@
-$(function() {
+var setupFullScreenModal = function() {
   
-  // Set up on page load
+  // Setup full screen image modal.
+  // Executed from HTMLModule in display.js.
   $("a.modal-content").each(function() {
     var smallImageObject = $(this).children();
     var largeImageSRC = $(this).attr('href');
@@ -106,4 +107,4 @@ $(function() {
       $(".wrapper-modal-image .image-content .image-controls .modal-ui-icon").toggleClass('is-disabled');
     }
   });
-});
+};


### PR DESCRIPTION
TNL-265

Full screen functionality was not working when user navigate to image module by using navigation bar or next button.

Actually the script which was loading the full screen image modal was executed only on page load.

Ticket: https://openedx.atlassian.net/browse/TNL-265
