### PR TITLE
Update paver bok_choy (test) commands to reflect new default vars.

### DIFF
--- a/pavelib/paver_tests/test_paver_bok_choy_cmds.py
+++ b/pavelib/paver_tests/test_paver_bok_choy_cmds.py
@@ -14,8 +14,8 @@ class TestPaverBokChoy(unittest.TestCase):
     def _expected_command(self, expected_text_append):
         if expected_text_append:
             expected_text_append = "/" + expected_text_append
-        expected_statement = ("SCREENSHOT_DIR='{repo_dir}/test_root/log' "
-                                       "HAR_DIR='{repo_dir}/test_root/log/hars' "
+        expected_statement = ("DEFAULT_STORE=None SCREENSHOT_DIR='{repo_dir}/test_root/log' "
+                                       "BOK_CHOY_HAR_DIR='{repo_dir}/test_root/log/hars' "
                                        "SELENIUM_DRIVER_LOG_DIR='{repo_dir}/test_root/log' "
                                        "nosetests {repo_dir}/common/test/acceptance/tests{exp_text} "
                                        "--with-xunit "


### PR DESCRIPTION
@clytwynec @nasthagiri 

This takes into account recent changes for how bok-choy commands are composed in paver. (Should also bring Jenkins back to green.)
