### PR TITLE
Increase randomness of course name in testcase

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/tests/test_mixed_modulestore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_mixed_modulestore.py
@@ -1720,7 +1720,7 @@ class TestMixedModuleStore(unittest.TestCase):
 
         # verify store used for creating a course
         try:
-            course = self.store.create_course("org", "course{}".format(uuid4().hex[:3]), "run", self.user_id)
+            course = self.store.create_course("org", "course{}".format(uuid4().hex[:5]), "run", self.user_id)
             self.assertEquals(course.system.modulestore.get_modulestore_type(), store_type)
         except NotImplementedError:
             self.assertEquals(store_type, ModuleStoreEnum.Type.xml)


### PR DESCRIPTION
@benpatterson or @clytwynec pls review.
Grepping through the code, it seems that a lot of our tests use 5 hex digits, so I increased it to be the same.

@nasthagiri FYI. This test [failed intermittently](https://ci.solanolabs.com/reports/963416), it seems the root cause was that 3 hex digits wasn't of sufficient random uniqueness.
