### PR TITLE
Annotation Tools: Adding Try-Catch for anonyous_student_id issue in staging

### DIFF
--- a/common/lib/xmodule/xmodule/imageannotation_module.py
+++ b/common/lib/xmodule/xmodule/imageannotation_module.py
@@ -108,12 +108,15 @@ class ImageAnnotationModule(AnnotatableFields, XModule):
 
         self.instructions = self._extract_instructions(xmltree)
         self.openseadragonjson = html_to_text(etree.tostring(xmltree.find('json'), encoding='unicode'))
-        self.user = ""
+        self.user_email = ""
         self.is_course_staff = False
         if self.runtime.get_user_role() in ['instructor', 'staff']:
             self.is_course_staff = True
         if self.runtime.get_real_user is not None:
-            self.user = self.runtime.get_real_user(self.runtime.anonymous_student_id).email
+            try:
+                self.user_email = self.runtime.get_real_user(self.runtime.anonymous_student_id).email
+            except:  # pylint: disable=broad-except
+                self.user_email = _("No email address found.")
 
     def _extract_instructions(self, xmltree):
         """ Removes <instructions> from the xmltree and returns them as a string, otherwise None. """
@@ -124,7 +127,7 @@ class ImageAnnotationModule(AnnotatableFields, XModule):
         context = {
             'display_name': self.display_name_with_default,
             'instructions_html': self.instructions,
-            'token': retrieve_token(self.user, self.annotation_token_secret),
+            'token': retrieve_token(self.user_email, self.annotation_token_secret),
             'tag': self.instructor_tags,
             'openseadragonjson': self.openseadragonjson,
             'annotation_storage': self.annotation_storage_url,

--- a/common/lib/xmodule/xmodule/textannotation_module.py
+++ b/common/lib/xmodule/xmodule/textannotation_module.py
@@ -107,7 +107,10 @@ class TextAnnotationModule(AnnotatableFields, XModule):
         if self.runtime.get_user_role() in ['instructor', 'staff']:
             self.is_course_staff = True
         if self.runtime.get_real_user is not None:
-            self.user_email = self.runtime.get_real_user(self.runtime.anonymous_student_id).email
+            try:
+                self.user_email = self.runtime.get_real_user(self.runtime.anonymous_student_id).email
+            except:  # pylint: disable=broad-except
+                self.user_email = _("No email address found.")
 
     def _extract_instructions(self, xmltree):
         """ Removes <instructions> from the xmltree and returns them as a string, otherwise None. """

--- a/common/lib/xmodule/xmodule/videoannotation_module.py
+++ b/common/lib/xmodule/xmodule/videoannotation_module.py
@@ -107,7 +107,10 @@ class VideoAnnotationModule(AnnotatableFields, XModule):
         if self.runtime.get_user_role() in ['instructor', 'staff']:
             self.is_course_staff = True
         if self.runtime.get_real_user is not None:
-            self.user_email = self.runtime.get_real_user(self.runtime.anonymous_student_id).email
+            try:
+                self.user_email = self.runtime.get_real_user(self.runtime.anonymous_student_id).email
+            except:  # pylint: disable=broad-except
+                self.user_email = _("No email address found.")
 
     def _extract_instructions(self, xmltree):
         """ Removes <instructions> from the xmltree and returns them as a string, otherwise None. """


### PR DESCRIPTION
@sarina I also changed the variable name from user to user_email for image annotation. Someone from edX in a previous PR asked me to change that previously and I'm assuming it was before the image annotation got added and it wasn't fixed in the image too. 

Should fix the issue in staging where `self.user_email = self.runtime.get_real_user(self.runtime.anonymous_student_id).email` threw an error where `get_real_user` returned None for some strange reason.
