### PR TITLE
username and email request for lti module

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -173,3 +173,5 @@ Jason Zhu <fmyzjs@gmail.com>
 Marceau Cnudde <marceau.cnudde@gmail.com>
 Braden MacDonald <mail@bradenm.com>
 Jonathan Piacenti <kelketek@gmail.com>
+Paul Medlock-Walton <paulmw@mit.edu>
+Henry Tareque <henry.tareque@gmail.com>

--- a/common/lib/xmodule/xmodule/js/src/lti/lti.js
+++ b/common/lib/xmodule/xmodule/js/src/lti/lti.js
@@ -1,0 +1,32 @@
+(function () {
+    'use strict';
+    /**
+     * This function will process all the attributes from the DOM element passed, taking all of
+     * the configuration attributes. It uses the request-username and request-email
+     * to prompt the user to decide if they want to share their personal information
+     * with the third party application connecting through LTI.
+     * @constructor
+     * @param {jQuery} element DOM element with the lti container.
+     */
+    this.LTI = function (element) {
+        var dataAttrs = $(element).find('.lti').data(),
+            askToSendUsername = (dataAttrs.askToSendUsername === 'True'),
+            askToSendEmail = (dataAttrs.askToSendEmail === 'True');
+
+        // When the lti button is clicked, provide users the option to
+        // accept or reject sending their information to a third party
+        $(element).on('click', '.link_lti_new_window', function () {
+            if(askToSendUsername && askToSendEmail) {
+                return confirm(gettext("Click OK to have your username and e-mail address sent to a 3rd party application.\n\nClick Cancel to return to this page without sending your information."));
+            } else if (askToSendUsername) {
+                return confirm(gettext("Click OK to have your username sent to a 3rd party application.\n\nClick Cancel to return to this page without sending your information."));
+            } else if (askToSendEmail) {
+                return confirm(gettext("Click OK to have your e-mail address sent to a 3rd party application.\n\nClick Cancel to return to this page without sending your information."));
+            } else {
+                return true;
+            }
+        });
+
+    };
+
+}).call(this);

--- a/lms/djangoapps/courseware/features/lti.feature
+++ b/lms/djangoapps/courseware/features/lti.feature
@@ -137,3 +137,73 @@ Feature: LMS.LTI component
   | True               | True        |
   Then in the LTI component I do not see an provider iframe
   Then I see LTI component module title with text "LTI (EXTERNAL RESOURCE)"
+
+  #13
+  Scenario: LTI component button text is correctly displayed
+  Given the course has correct LTI credentials with registered Instructor
+  And the course has an LTI component with correct fields:
+  | button_text        |
+  | Launch Application |
+  Then I see LTI component button with text "Launch Application"
+
+  #14
+  Scenario: LTI component description is correctly displayed
+  Given the course has correct LTI credentials with registered Instructor
+  And the course has an LTI component with correct fields:
+  | description             |
+  | Application description |
+  Then I see LTI component description with text "Application description"
+
+  #15
+  Scenario: LTI component requests permission for username and is rejected
+  Given the course has correct LTI credentials with registered Instructor
+  And the course has an LTI component with correct fields:
+  | ask_to_send_username |
+  | True                 |
+  Then I view the permission alert
+  Then I reject the permission alert and do not view the LTI
+  
+  #16
+  Scenario: LTI component requests permission for username and displays LTI when accepted
+  Given the course has correct LTI credentials with registered Instructor
+  And the course has an LTI component with correct fields:
+  | ask_to_send_username |
+  | True                 |
+  Then I view the permission alert
+  Then I accept the permission alert and view the LTI
+
+  #17
+  Scenario: LTI component requests permission for email and is rejected
+  Given the course has correct LTI credentials with registered Instructor
+  And the course has an LTI component with correct fields:
+  | ask_to_send_email |
+  | True              |
+  Then I view the permission alert
+  Then I reject the permission alert and do not view the LTI
+  
+  #18
+  Scenario: LTI component requests permission for email and displays LTI when accepted
+  Given the course has correct LTI credentials with registered Instructor
+  And the course has an LTI component with correct fields:
+  | ask_to_send_email |
+  | True              |
+  Then I view the permission alert
+  Then I accept the permission alert and view the LTI
+
+  #19
+  Scenario: LTI component requests permission for email and username and is rejected
+  Given the course has correct LTI credentials with registered Instructor
+  And the course has an LTI component with correct fields:
+  | ask_to_send_email | ask_to_send_username |
+  | True              | True                 |
+  Then I view the permission alert
+  Then I reject the permission alert and do not view the LTI
+  
+  #20
+  Scenario: LTI component requests permission for email and username and displays LTI when accepted
+  Given the course has correct LTI credentials with registered Instructor
+  And the course has an LTI component with correct fields:
+  | ask_to_send_email | ask_to_send_username |
+  | True              | True                 |
+  Then I view the permission alert
+  Then I accept the permission alert and view the LTI

--- a/lms/djangoapps/courseware/tests/test_lti_integration.py
+++ b/lms/djangoapps/courseware/tests/test_lti_integration.py
@@ -89,6 +89,10 @@ class TestLTI(BaseTestXmodule):
             'module_score': None,
             'comment': u'',
             'weight': 1.0,
+            'ask_to_send_username': self.item_descriptor.ask_to_send_username,
+            'ask_to_send_email': self.item_descriptor.ask_to_send_email,
+            'description': self.item_descriptor.description,
+            'button_text': self.item_descriptor.button_text,
         }
 
         def mocked_sign(self, *args, **kwargs):

--- a/lms/templates/lti.html
+++ b/lms/templates/lti.html
@@ -21,13 +21,18 @@
 <div
     id="${element_id}"
     class="${element_class}"
+    data-ask-to-send-username="${ask_to_send_username}"
+    data-ask-to-send-email="${ask_to_send_email}"
 >
 
 % if launch_url and launch_url !=  'http://www.example.com' and not hide_launch:
     % if open_in_a_new_page:
         <div class="wrapper-lti-link">
+            % if description:
+                <div class="lti-description">${description}</div>
+            % endif
             <p class="lti-link external"><a target="_blank" class="link_lti_new_window" href="${form_url}">
-                ${_('View resource in a new window')}
+                ${button_text or _('View resource in a new window')}
                  <i class="icon-external-link"></i>
             </a></p>
         </div>
@@ -43,7 +48,7 @@
     <h3 class="error_message">
         ${_('Please provide launch_url. Click "Edit", and fill in the required fields.')}
     </h3>
-%endif
+% endif
 
 % if has_score and comment:
     <h4 class="problem-feedback-label">${_("Feedback on your work from the grader:")}</h4>


### PR DESCRIPTION
allow username and email can be passed to a lti third party app
ask user permission when lti button is clicked
allow course editor to customize text on lti launch button

Testing notes: Course tarball is here https://openedx.atlassian.net/secure/attachment/11799/2014_T1.tPB9cH.tar.gz

**Instructions for manual testing:**

Import the course in studio attached to the pull request. Go to the only unit that there is.

**Testing Username/Email**

In the settings for the LTI module, you will see that "Request user's username" is true. If you click the button, a confirmation dialog will appear informing the user that their username would go to a third party app. If you click ok, you will be transferred to a random third party LTI site I found online. You can use the network tab in your Chrome dev tools to see that the username is passed in with the property "lis_person_sourcedid" of the request headers. Repeat for requesting the email ("lis_person_contact_email_primary"), and for requesting both the username and email.

If neither username or e-mail is selected to be requested, the confirmation dialog does not appear.

**Testing button text**

You'll see that I've entered new button text for this demo. If you edit the button text in the settings to be empty, you will see that the button's text is what it has been in previous versions of the code 'View resource in a new window'

**Testing application description**

You'll see that I've already entered fake text for an application description. You can edit it from the settings.
