### PR TITLE
Move <HR> inside of template conditional

### DIFF
--- a/lms/templates/instructor/instructor_dashboard_2/instructor_analytics.html
+++ b/lms/templates/instructor/instructor_dashboard_2/instructor_analytics.html
@@ -52,9 +52,9 @@
        data-endpoint="${ section_data['proxy_legacy_analytics_url'] }"
        >
   </div>
-%endif
 
-<hr>
+  <hr>
+%endif
 
 <div class="profile-distribution-widget-container"
   data-title="${_("Year of Birth")}"


### PR DESCRIPTION
Otherwise, if `settings.ENABLE_INSTRUCTOR_ANALYTICS` is set to `False`,
two horizontal rules are rendered consecutively.

The `<HR>` has also been indented to align with surrounding tags.
