### PR TITLE
Fixed wiki merge url regex.

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -469,6 +469,7 @@ LMS_MIGRATION_ALLOWED_IPS = []
 # too many inadvertent side effects :-(
 COURSE_KEY_PATTERN = r'(?P<course_key_string>[^/+]+(/|\+)[^/+]+(/|\+)[^/]+)'
 COURSE_ID_PATTERN = COURSE_KEY_PATTERN.replace('course_key_string', 'course_id')
+COURSE_KEY_REGEX = COURSE_KEY_PATTERN.replace('P<course_key_string>', ':')
 
 USAGE_KEY_PATTERN = r'(?P<usage_key_string>(?:i4x://?[^/]+/[^/]+/[^/]+/[^@]+(?:@[^/]+)?)|(?:[^/]+))'
 ASSET_KEY_PATTERN = r'(?P<asset_key_string>(?:/?c4x(:/)?/[^/]+/[^/]+/[^/]+/[^@]+(?:@[^/]+)?)|(?:[^/]+))'

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -188,7 +188,7 @@ if settings.WIKI_ENABLED:
         # never be returned by a reverse() so they come after the other url patterns
         url(r'^courses/{}/course_wiki/?$'.format(settings.COURSE_ID_PATTERN),
             'course_wiki.views.course_wiki_redirect', name="course_wiki"),
-        url(r'^courses/{}/wiki/'.format(settings.COURSE_ID_PATTERN), include(wiki_pattern())),
+        url(r'^courses/{}/wiki/'.format(settings.COURSE_KEY_REGEX), include(wiki_pattern())),
     )
 
 if settings.COURSEWARE_ENABLED:


### PR DESCRIPTION
TNL-413

By using this `settings.COURSE_ID_PATTERN` in wiki url, it passes `course_id` as keyword argument to wiki `merge()`.

Ticket: https://openedx.atlassian.net/browse/TNL-413
