### PR TITLE
Refactor default_store logic in paver test_bokchoy

### DIFF
--- a/pavelib/bok_choy.py
+++ b/pavelib/bok_choy.py
@@ -52,7 +52,7 @@ def test_bokchoy(options):
     opts = {
         'test_spec': getattr(options, 'test_spec', None),
         'fasttest': getattr(options, 'fasttest', False),
-        'default_store': getattr(options, 'default_store', None),
+        'default_store': getattr(options, 'default_store', 'split'),
         'verbosity': getattr(options, 'verbosity', 2),
         'extra_args': getattr(options, 'extra_args', ''),
         'test_dir': 'tests',
@@ -78,8 +78,8 @@ def perf_report_bokchoy(options):
     opts = {
         'test_spec': getattr(options, 'test_spec', None),
         'fasttest': getattr(options, 'fasttest', False),
+        'default_store': getattr(options, 'default_store', 'split'),
         'imports_dir': getattr(options, 'imports_dir', None),
-        'default_store': getattr(options, 'default_store', None),
         'verbosity': getattr(options, 'verbosity', 2),
         'test_dir': 'performance',
         'ptests': True,
@@ -90,22 +90,15 @@ def perf_report_bokchoy(options):
 def run_bokchoy(**opts):
     """
     Runs BokChoyTestSuite with the given options.
-    If a default store is not specified, runs the test suite for 'split' as the default store.
     """
-    if opts['default_store'] not in ['draft', 'split']:
-        msg = colorize(
-            'red',
-            'No modulestore specified, running tests for split.'
+    test_suite = BokChoyTestSuite('bok-choy', **opts)
+    msg = colorize(
+        'green',
+        'Running tests using {default_store} modulestore.'.format(
+            default_store=test_suite.default_store)
         )
-        print(msg)
-        stores = ['split']
-    else:
-        stores = [opts['default_store']]
-
-    for store in stores:
-        opts['default_store'] = store
-        test_suite = BokChoyTestSuite('bok-choy', **opts)
-        test_suite.run()
+    print(msg)
+    test_suite.run()
 
 
 @task

--- a/pavelib/paver_tests/test_paver_bok_choy_cmds.py
+++ b/pavelib/paver_tests/test_paver_bok_choy_cmds.py
@@ -40,7 +40,7 @@ class TestPaverBokChoyCmd(unittest.TestCase):
         self.request.test_spec = "test_foo.py:FooTest.test_bar"
         self.assertEqual(self.request.cmd, self._expected_command(self.request.test_spec))
 
-    def test_default_bokchoy_with_split_default_store(self):
+    def test_default_bokchoy_with_draft_default_store(self):
         self.request.test_spec = "test_foo.py"
         self.request.default_store = "draft"
         self.assertEqual(self.request.cmd, self._expected_command(self.request.test_spec, "draft"))

--- a/pavelib/paver_tests/test_paver_bok_choy_cmds.py
+++ b/pavelib/paver_tests/test_paver_bok_choy_cmds.py
@@ -6,26 +6,23 @@ from pavelib.utils.test.suites.bokchoy_suite import BokChoyTestSuite
 REPO_DIR = os.getcwd()
 
 
-class TestPaverBokChoy(unittest.TestCase):
+class TestPaverBokChoyCmd(unittest.TestCase):
 
     def setUp(self):
         self.request = BokChoyTestSuite('')
 
-    def _expected_command(self, expected_text_append):
+    def _expected_command(self, expected_text_append, expected_default_store=None):
         if expected_text_append:
             expected_text_append = "/" + expected_text_append
-        expected_statement = (
-            "DEFAULT_STORE=None SCREENSHOT_DIR='{repo_dir}/test_root/log' "
-            "BOK_CHOY_HAR_DIR='{repo_dir}/test_root/log/hars' "
-            "SELENIUM_DRIVER_LOG_DIR='{repo_dir}/test_root/log' "
-            "nosetests {repo_dir}/common/test/acceptance/tests{exp_text} "
-            "--with-xunit "
-            "--xunit-file={repo_dir}/reports/bok_choy/xunit.xml "
-            "--verbosity=2 ".format(
-                repo_dir=REPO_DIR,
-                exp_text=expected_text_append,
-            )
-        )
+        expected_statement = ("DEFAULT_STORE={default_store} SCREENSHOT_DIR='{repo_dir}/test_root/log' "
+                                       "BOK_CHOY_HAR_DIR='{repo_dir}/test_root/log/hars' "
+                                       "SELENIUM_DRIVER_LOG_DIR='{repo_dir}/test_root/log' "
+                                       "nosetests {repo_dir}/common/test/acceptance/tests{exp_text} "
+                                       "--with-xunit "
+                                       "--xunit-file={repo_dir}/reports/bok_choy/xunit.xml "
+                                       "--verbosity=2 ".format(default_store=expected_default_store,
+                                                               repo_dir=REPO_DIR,
+                                                               exp_text=expected_text_append))
         return expected_statement
 
     def test_default_bokchoy(self):
@@ -43,5 +40,13 @@ class TestPaverBokChoy(unittest.TestCase):
         self.request.test_spec = "test_foo.py:FooTest.test_bar"
         self.assertEqual(self.request.cmd, self._expected_command(self.request.test_spec))
 
+    def test_default_bokchoy_with_split_default_store(self):
+        self.request.test_spec = "test_foo.py"
+        self.request.default_store = "draft"
+        self.assertEqual(self.request.cmd, self._expected_command(self.request.test_spec, "draft"))
 
-    # TODO: Test when bok_choy test file is in a subdir
+    def test_default_bokchoy_with_invalid_default_store(self):
+        # the cmd will dumbly compose whatever we pass in for the default_store
+        self.request.test_spec = "test_foo.py"
+        self.request.default_store = "invalid"
+        self.assertEqual(self.request.cmd, self._expected_command(self.request.test_spec, "invalid"))

--- a/pavelib/utils/test/suites/bokchoy_suite.py
+++ b/pavelib/utils/test/suites/bokchoy_suite.py
@@ -18,6 +18,14 @@ __test__ = False  # do not collect
 class BokChoyTestSuite(TestSuite):
     """
     TestSuite for running Bok Choy tests
+    Properties (below is a subset):
+      test_dir - parent directory for tests
+      log_dir - directory for test output
+      report_dir - directory for reports (e.g., coverage) related to test execution
+      xunit_report - directory for xunit-style output (xml)
+      fasttest - when set, skip various set-up tasks (e.g., DB migrations)
+      test_spec - when set, specifies test files, classes, cases, etc. See platform doc.
+      default_store - modulestore to use when running tests (split or draft)
     """
     def __init__(self, *args, **kwargs):
         super(BokChoyTestSuite, self).__init__(*args, **kwargs)

--- a/pavelib/utils/test/suites/bokchoy_suite.py
+++ b/pavelib/utils/test/suites/bokchoy_suite.py
@@ -28,7 +28,7 @@ class BokChoyTestSuite(TestSuite):
         self.cache = Env.BOK_CHOY_CACHE
         self.fasttest = kwargs.get('fasttest', False)
         self.test_spec = kwargs.get('test_spec', None)
-        self.default_store = kwargs.get('default_store')
+        self.default_store = kwargs.get('default_store', None)
         self.verbosity = kwargs.get('verbosity', 2)
         self.extra_args = kwargs.get('extra_args', '')
         self.ptests = kwargs.get('ptests', False)


### PR DESCRIPTION
@clytwynec @nasthagiri 

Hey guys I refactored this. In part, it makes it easier to test. But, I still need to sort out mocking the run_bokchoy wherein I can examine the test suite object but avoid actually running the script.

That said, could you please take a look at the 'production' code as well. Any feedback?

Thanks!
