### PR TITLE
New post should show category/subcategory breadcrumb when created.

### DIFF
--- a/lms/djangoapps/django_comment_client/forum/views.py
+++ b/lms/djangoapps/django_comment_client/forum/views.py
@@ -145,8 +145,11 @@ def inline_discussion(request, course_id, discussion_id):
     with newrelic.agent.FunctionTrace(nr_transaction, "get_metadata_for_threads"):
         annotated_content_info = utils.get_metadata_for_threads(course_key, threads, request.user, user_info)
     is_staff = cached_has_permission(request.user, 'openclose_thread', course.id)
+    threads = [utils.prepare_content(thread, course_key, is_staff) for thread in threads]
+    with newrelic.agent.FunctionTrace(nr_transaction, "add_courseware_context"):
+        add_courseware_context(threads, course)
     return utils.JsonResponse({
-        'discussion_data': [utils.prepare_content(thread, course_key, is_staff) for thread in threads],
+        'discussion_data': threads,
         'user_info': user_info,
         'annotated_content_info': annotated_content_info,
         'page': query_params['page'],


### PR DESCRIPTION
When the new post is created under the subcategory and it appear
after the creation, it doesn't have the link of category/subcategory
after thread body. When we reload the page the link appears. Link
should appear after creation.

TNL-404
