### PR TITLE
Studio: FIX - Outline Item Title Truncation

### DIFF
--- a/cms/static/sass/elements/_forms.scss
+++ b/cms/static/sass/elements/_forms.scss
@@ -362,7 +362,6 @@ form {
 
   .incontext-editor-value,
   .incontext-editor-action-wrapper {
-    @extend %cont-truncated;
     display: inline-block;
     vertical-align: middle;
     max-width: 80%;

--- a/cms/static/sass/elements/_tender-widget.scss
+++ b/cms/static/sass/elements/_tender-widget.scss
@@ -210,7 +210,7 @@
 
 .widget-layout dl#brain_buster_captcha dd #captcha_answer {
   display: block;
-  width: 97%%;
+  width: 97%;
 }
 
 .widget-layout .form-actions .btn-post_topic {

--- a/cms/static/sass/views/_container.scss
+++ b/cms/static/sass/views/_container.scss
@@ -25,6 +25,10 @@
 
         .is-editable {
 
+          .incontext-editor-value {
+            @extend %cont-truncated;
+          }
+
           // TOOD: abstract this out into a Sass placeholder
           .incontext-editor-input {
             @include transition(box-shadow $tmg-f1 ease-in-out 0, color $tmg-f1 ease-in-out 0);

--- a/cms/static/sass/views/_outline.scss
+++ b/cms/static/sass/views/_outline.scss
@@ -290,6 +290,10 @@
       .section-header {
         @extend %outline-item-header;
 
+        .incontext-editor-value {
+          white-space: nowrap;
+        }
+
         .incontext-editor-input {
           @extend %t-strong;
           @extend %t-title5;
@@ -378,6 +382,10 @@
       // header
       .subsection-header {
         @extend %outline-item-header;
+
+        .incontext-editor-value {
+          white-space: nowrap;
+        }
 
         .incontext-editor-input {
           @extend %t-title6;


### PR DESCRIPTION
This work starts to resolve TNL-189 (https://openedx.atlassian.net/browse/TNL-189) and involves the following steps:
- removing CSS-based solution for truncating outline section/subsection titles (due to Chrome bug)
- moving to a JavaScript-based truncation solution for outline view only
- non-related syntax fix to Sass widget
