### PR TITLE
When s3fs cannot be accessed replaced with osfs

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -215,14 +215,7 @@ with open(CONFIG_ROOT / CONFIG_PREFIX + "auth.json") as auth_file:
     AUTH_TOKENS = json.load(auth_file)
 
 ############### XBlock filesystem field config ##########
-if 'XBLOCK_FS_STORAGE_BUCKET' in ENV_TOKENS:
-    DJFS = {
-        'type' : 's3fs',
-        'bucket' : ENV_TOKENS.get('XBLOCK_FS_STORAGE_BUCKET', None),
-        'prefix' : ENV_TOKENS.get('XBLOCK_FS_STORAGE_PREFIX', '/xblock-storage/'),
-        'aws_access_key_id' : AUTH_TOKENS.get('AWS_ACCESS_KEY_ID', None),
-        'aws_secret_access_key' : AUTH_TOKENS.get('AWS_SECRET_ACCESS_KEY', None)
-    }
+DJFS = AUTH_TOKENS.get('DJFS', None)
 
 EMAIL_HOST_USER = AUTH_TOKENS.get('EMAIL_HOST_USER', EMAIL_HOST_USER)
 EMAIL_HOST_PASSWORD = AUTH_TOKENS.get('EMAIL_HOST_PASSWORD', EMAIL_HOST_PASSWORD)

--- a/cms/envs/bok_choy.auth.json
+++ b/cms/envs/bok_choy.auth.json
@@ -89,6 +89,13 @@
         "url": "http://localhost:18060/",
         "username": "lms"
     },
+    "DJFS": {
+            "type": "s3fs",
+            "bucket": "test",
+            "prefix": "test",
+            "aws_access_key_id": "test",
+            "aws_secret_access_key": "test"
+    },
     "SECRET_KEY": "",
     "XQUEUE_INTERFACE": {
         "basic_auth": [

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -300,14 +300,7 @@ with open(CONFIG_ROOT / CONFIG_PREFIX + "auth.json") as auth_file:
     AUTH_TOKENS = json.load(auth_file)
 
 ############### XBlock filesystem field config ##########
-if 'XBLOCK_FS_STORAGE_BUCKET' in ENV_TOKENS:
-    DJFS = {
-        'type' : 's3fs',
-        'bucket' : ENV_TOKENS.get('XBLOCK_FS_STORAGE_BUCKET', None),
-        'prefix' : ENV_TOKENS.get('XBLOCK_FS_STORAGE_PREFIX', '/xblock-storage/'),
-        'aws_access_key_id' : AUTH_TOKENS.get('AWS_ACCESS_KEY_ID', None),
-        'aws_secret_access_key' : AUTH_TOKENS.get('AWS_SECRET_ACCESS_KEY', None)
-    }
+DJFS = AUTH_TOKENS.get('DJFS', None)
 
 ############### Module Store Items ##########
 HOSTNAME_MODULESTORE_DEFAULT_MAPPINGS = ENV_TOKENS.get('HOSTNAME_MODULESTORE_DEFAULT_MAPPINGS', {})

--- a/lms/envs/bok_choy.auth.json
+++ b/lms/envs/bok_choy.auth.json
@@ -109,6 +109,13 @@
             "SOCIAL_AUTH_FACEBOOK_SECRET": "test"
         }
     },
+    "DJFS": {
+            "type": "s3fs",
+            "bucket": "test",
+            "prefix": "test",
+            "aws_access_key_id": "test",
+            "aws_secret_access_key": "test"
+    },
     "XQUEUE_INTERFACE": {
         "basic_auth": [
             "edx",


### PR DESCRIPTION
add var XBLOCK_FS_USE_S3_STORAGE ,default to be set True
When aws s3 service cannot be accessed or poor network,webmaster can replace s3fs with osfs

Review ticket:  https://openedx.atlassian.net/browse/OSPR-50
