### PR TITLE
Fixed transcript not follow with video on seek.

### DIFF
--- a/common/lib/xmodule/xmodule/js/spec/video/video_player_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_player_spec.js
@@ -382,6 +382,26 @@ function (VideoPlayer) {
                     }, 'video didn\'t start playing', WAIT_TIMEOUT);
                 });
 
+
+                it('call runTimer in seekTo on player', function () {
+                    runs(function () {
+                        spyOn(state.videoPlayer, 'stopTimer');
+                        spyOn(state.videoPlayer, 'runTimer');
+                        state.videoPlayer.seekTo(10);
+                    });
+
+                    waitsFor(function () {
+                        return state.videoPlayer.currentTime >= 10;
+                    }, 'currentTime is less than 10 seconds', WAIT_TIMEOUT);
+
+                    runs(function () {
+                        expect(state.videoPlayer.stopTimer)
+                            .toHaveBeenCalled();
+                        expect(state.videoPlayer.runTimer)
+                            .toHaveBeenCalled();
+                    });
+                });
+
                 // as per TNL-439 this test is deemed flaky and needs to be fixed.
                 // disabled 09/18/2014
                 xit('slider event causes log update', function () {

--- a/common/lib/xmodule/xmodule/js/src/video/03_video_player.js
+++ b/common/lib/xmodule/xmodule/js/src/video/03_video_player.js
@@ -489,6 +489,11 @@ function (HTML5Video, Resizer) {
 
         this.videoPlayer.updatePlayTime(time, true);
         this.el.trigger('seek', arguments);
+
+        // the timer is stopped above; restart it.
+        if (this.videoPlayer.isPlaying()) {
+            this.videoPlayer.runTimer();
+        }
     }
 
     function runTimer() {


### PR DESCRIPTION
Ticket: [TNL-235](https://openedx.atlassian.net/browse/TNL-235)

If video player is in playing state then in `seekTo()` timer was stopped to call `update()` at regular interval of time here [03_video_player.js#L466-L467!](https://github.com/edx/edx-platform/blob/master/common/lib/xmodule/xmodule/js/src/video/03_video_player.js#L466-L467) 
but not triggering it again to call `update()` at regular interval of time.

According to my thinking this problem will occur in all browsers.
