### PR TITLE
keep large answers from appearing (TNL-441)

### DIFF
--- a/common/lib/xmodule/xmodule/css/capa/display.scss
+++ b/common/lib/xmodule/xmodule/css/capa/display.scss
@@ -158,7 +158,9 @@ div.problem {
       }
       &.status {
         margin: 8px 0 0 $baseline/2;
-        text-indent: -9999px;
+        text-indent: 100%;
+        white-space: nowrap;
+        overflow: hidden;
       }
     }
 
@@ -203,7 +205,6 @@ div.problem {
         width: 20px;
         height: 20px;
         background: url('../images/incorrect-icon.png') center center no-repeat;
-        text-indent: -9999px;
       }
 
       input {


### PR DESCRIPTION
@cptvitamin @talbs 

Before:
![screen shot 2014-09-19 at 9 54 56 am](https://cloud.githubusercontent.com/assets/2748698/4336230/9ee89306-4004-11e4-99c1-8dec51c7359a.png)

After:
![screen shot 2014-09-19 at 9 55 17 am](https://cloud.githubusercontent.com/assets/2748698/4336231/a63ec468-4004-11e4-811f-102f83e89daf.png)

Test in the text input problem on this page: 
https://edge.edx.org/courses/alp/9999/adamtest/courseware/6ae0c6cb9c7747c4b0ac610e8510aa81/2d791aeac09c4e30a2db99beab9e9af5/2
