### PR TITLE
Fixes check for Image Annotation Tool to include ID from image server and fix scrolling bug

### DIFF
--- a/common/lib/xmodule/xmodule/imageannotation_module.py
+++ b/common/lib/xmodule/xmodule/imageannotation_module.py
@@ -115,7 +115,7 @@ class ImageAnnotationModule(AnnotatableFields, XModule):
         if self.runtime.get_real_user is not None:
             try:
                 self.user_email = self.runtime.get_real_user(self.runtime.anonymous_student_id).email
-            except:  # pylint: disable=broad-except
+            except Exception:  # pylint: disable=broad-except
                 self.user_email = _("No email address found.")
 
     def _extract_instructions(self, xmltree):

--- a/common/lib/xmodule/xmodule/textannotation_module.py
+++ b/common/lib/xmodule/xmodule/textannotation_module.py
@@ -109,7 +109,7 @@ class TextAnnotationModule(AnnotatableFields, XModule):
         if self.runtime.get_real_user is not None:
             try:
                 self.user_email = self.runtime.get_real_user(self.runtime.anonymous_student_id).email
-            except:  # pylint: disable=broad-except
+            except Exception:  # pylint: disable=broad-except
                 self.user_email = _("No email address found.")
 
     def _extract_instructions(self, xmltree):

--- a/common/lib/xmodule/xmodule/videoannotation_module.py
+++ b/common/lib/xmodule/xmodule/videoannotation_module.py
@@ -109,7 +109,7 @@ class VideoAnnotationModule(AnnotatableFields, XModule):
         if self.runtime.get_real_user is not None:
             try:
                 self.user_email = self.runtime.get_real_user(self.runtime.anonymous_student_id).email
-            except:  # pylint: disable=broad-except
+            except Exception:  # pylint: disable=broad-except
                 self.user_email = _("No email address found.")
 
     def _extract_instructions(self, xmltree):

--- a/common/static/js/vendor/ova/OpenSeaDragonAnnotation.js
+++ b/common/static/js/vendor/ova/OpenSeaDragonAnnotation.js
@@ -577,13 +577,12 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             var isRP = (typeof rp!='undefined');
             var isSource = false;
             
-            // Double checks that the image being displayed matches the annotations 
-            var source = this.viewer.source;
-            var tilesUrl = typeof source.tilesUrl!='undefined'?source.tilesUrl:'';
-            var functionUrl = typeof source.getTileUrl!='undefined'?source.getTileUrl:'';
-            var compareUrl = tilesUrl!=''?tilesUrl:('' + functionUrl).replace(/\s+/g, ' ');
-            if(isContainer) isSource = (an.target.src == compareUrl);
-            
+            // Though it would be better to store server ids of images in the annotation that
+            // would require changing annotations that were already made, instead we check if
+            // the id is a substring of the thumbnail, which according to OpenSeaDragon API should be the case.
+            var sourceId = this.viewer.source['@id'];
+            var targetThumb = an.target.thumb;
+            if (isContainer) isSource = (targetThumb.indexOf(sourceId) !== -1);            
             return (isOpenSeaDragon && isContainer && isImage && isRP && isSource);
         },
         

--- a/common/static/js/vendor/ova/OpenSeaDragonAnnotation.js
+++ b/common/static/js/vendor/ova/OpenSeaDragonAnnotation.js
@@ -582,7 +582,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             // the id is a substring of the thumbnail, which according to OpenSeaDragon API should be the case.
             var sourceId = this.viewer.source['@id'];
             var targetThumb = an.target.thumb;
-            if (isContainer) isSource = (targetThumb.indexOf(sourceId) !== -1);            
+            if (isContainer) {
+                isSource = (targetThumb.indexOf(sourceId) !== -1);
+            }            
             return (isOpenSeaDragon && isContainer && isImage && isRP && isSource);
         },
         

--- a/common/static/js/vendor/ova/catch/js/catch.js
+++ b/common/static/js/vendor/ova/catch/js/catch.js
@@ -874,7 +874,9 @@ CatchAnnotation.prototype = {
             var an = allannotations[item];
             // Makes sure that all images are set to transparent in case one was
             // previously selected.
-            an.highlights[0].style.background = "rgba(0, 0, 0, 0)";
+            if (an.highlights) {
+               an.highlights[0].style.background = "rgba(0, 0, 0, 0)";
+            }
             if (typeof an.id !== 'undefined' && an.id === osdaId) { // this is the annotation
                 var bounds = new OpenSeadragon.Rect(an.bounds.x, an.bounds.y, an.bounds.width, an.bounds.height);
                 osda.viewer.viewport.fitBounds(bounds, false);
@@ -883,7 +885,9 @@ CatchAnnotation.prototype = {
                                         'slow');
                 // signifies a selected annotation once OSD has zoomed in on the
                 // appropriate area, it turns the background a bit yellow
-                an.highlights[0].style.background = "rgba(255, 255, 10, 0.2)";
+                if (an.highlights !== undefined) {
+                    an.highlights[0].style.background = "rgba(255, 255, 10, 0.2)";
+                }
             }
         }
     },
@@ -912,7 +916,7 @@ CatchAnnotation.prototype = {
                             startOffset = hasRanges?an.ranges[0].startOffset:'',
                             endOffset = hasRanges?an.ranges[0].endOffset:'';
 
-                        if (typeof startOffset !== 'undefined' && typeof endOffset !== 'undefined') { 
+                        if (typeof startOffset !== 'undefined' && typeof endOffset !== 'undefined' && typeof an.highlights) { 
 
                             $(an.highlights).parent().find('.annotator-hl').removeClass('api'); 
                             // change the color


### PR DESCRIPTION
This addresses the bug **[TNL-443]**.
**Affected Courses:**  1 course is affected (Visualizing Japan) with a total enrollment of ~10,000 students.
**Ideal Fix Deployment:** Week of Sept 29th

**Background:** As explained in TNL-443, it was notified early this morning that when users clicked on the thumbnails within the tables they were not able to scroll back up and be zoomed/panned to the proper locations. After a little more fiddling around it was discovered that the issue affected every item after the first "failure." This code changes the way that you verify that the thumbnail/annotation are from the image currently being shown on the same page. It checks that the thumbnail contains the substring of the id as per OpenSeaDragon's API. 

**Studio Changes:** None.

**LMS Changes:** 1) Removed old way of checking (not sure why that method was chosen by my predecessor, but it seems like a super bad idea) if annotation referred to the image on the current page. 2) Added the fix @sarina asked me to make at the end of the las PR related to the release candidate this week. 3) Added a few more checks for annotation.highlights attribute that sometimes does not get made (i.e. replies). These are not code-breaking but the code is now more correct than it used to be and that's always a plus.

**Testing:**
1. Create a sandbox instance WITHOUT this fix/PR
2. Install the [tarball](https://www.dropbox.com/s/r684ber7z4ddqtc/2014_T4.DPRfFs.tar.gz) as usual.
3. Make a few random image annotations.
4. This part is a little tricky: you need to simulate the current bug by changing the annotation.target.src attribute so that it breaks, please ask me to do it for you or talk you through it as you do. 
5. Try clicking the thumbnail and you should not see anything happen. This breaks any annotations below the one you broke as well.
6. Switch to this PR branch and try #5 again and you should see it move up and zoom/pan to the correct location
