### PR TITLE
Use default locale to OpenID profile claims.

### DIFF
--- a/lms/djangoapps/oauth2_handler/handlers.py
+++ b/lms/djangoapps/oauth2_handler/handlers.py
@@ -1,5 +1,7 @@
 """ Handlers for OpenID Connect provider. """
 
+from django.conf import settings
+
 import branding
 from courseware.access import has_access
 from student.models import anonymous_id_for_user
@@ -51,6 +53,11 @@ class ProfileHandler(object):
         """
 
         language = UserPreference.get_preference(data['user'], LANGUAGE_KEY)
+
+        # If the user has no language specified, return the default one.
+        if not language:
+            language = getattr(settings, 'LANGUAGE_CODE')
+
         return language
 
 

--- a/lms/djangoapps/oauth2_handler/tests.py
+++ b/lms/djangoapps/oauth2_handler/tests.py
@@ -1,4 +1,5 @@
 # pylint: disable=missing-docstring
+from django.conf import settings
 from django.test.utils import override_settings
 from django.test import TestCase
 
@@ -52,12 +53,13 @@ class IDTokenTest(BaseTestMixin, IDTokenTestCase):
 
         self.assertEqual(claim_name, user_name)
 
+    @override_settings(LANGUAGE_CODE='en')
     def test_user_without_locale_claim(self):
         scopes, claims = self.get_new_id_token_values('openid profile')
         self.assertIn('profile', scopes)
-        self.assertNotIn('locale', claims)
+        self.assertEqual(claims['locale'], 'en')
 
-    def test_user_wit_locale_claim(self):
+    def test_user_with_locale_claim(self):
         language = 'en'
         UserPreference.set_preference(self.user, LANGUAGE_KEY, language)
         scopes, claims = self.get_new_id_token_values('openid profile')


### PR DESCRIPTION
If the user has not selected a default locale, then return the default one.
