### PR TITLE
Added history for email and username changes to userprofile model

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -26,7 +26,7 @@ from django.utils import timezone
 from django.contrib.auth.models import User
 from django.contrib.auth.hashers import make_password
 from django.contrib.auth.signals import user_logged_in, user_logged_out
-from django.db import models, IntegrityError
+from django.db import models, IntegrityError, transaction
 from django.db.models import Count
 from django.dispatch import receiver, Signal
 from django.core.exceptions import ObjectDoesNotExist
@@ -276,6 +276,59 @@ class UserProfile(models.Model):
         self.set_meta(meta)
         self.save()
 
+    @transaction.commit_on_success
+    def update_name(self, new_name):
+        """Update the user's name, storing the old name in the history.
+
+        Implicitly saves the model.
+        If the new name is not the same as the old name, do nothing.
+
+        Arguments:
+            new_name (unicode): The new full name for the user.
+
+        Returns:
+            None
+
+        """
+        if self.name == new_name:
+            return
+
+        if self.name:
+            meta = self.get_meta()
+            if 'old_names' not in meta:
+                meta['old_names'] = []
+            meta['old_names'].append([self.name, u"", datetime.now(UTC).isoformat()])
+            self.set_meta(meta)
+
+        self.name = new_name
+        self.save()
+
+    @transaction.commit_on_success
+    def update_email(self, new_email):
+        """Update the user's email and save the change in the history.
+
+        Implicitly saves the model.
+        If the new email is the same as the old email, do not update the history.
+
+        Arguments:
+            new_email (unicode): The new email for the user.
+
+        Returns:
+            None
+        """
+        if self.user.email == new_email:
+            return
+
+        meta = self.get_meta()
+        if 'old_emails' not in meta:
+            meta['old_emails'] = []
+        meta['old_emails'].append([self.user.email, datetime.now(UTC).isoformat()])
+        self.set_meta(meta)
+        self.save()
+
+        self.user.email = new_email
+        self.user.save()
+
 
 class UserSignupSource(models.Model):
     """
@@ -341,7 +394,17 @@ class PendingEmailChange(models.Model):
     activation_key = models.CharField(('activation key'), max_length=32, unique=True, db_index=True)
 
     def request_change(self, email):
-        """ TODO """
+        """Request a change to a user's email.
+
+        Implicitly saves the pending email change record.
+
+        Arguments:
+            email (unicode): The proposed new email for the user.
+
+        Returns:
+            unicode: The activation code to confirm the change.
+
+        """
         self.new_email = email
         self.activation_key = uuid.uuid4().hex
         self.save()

--- a/common/djangoapps/user_api/api/profile.py
+++ b/common/djangoapps/user_api/api/profile.py
@@ -4,7 +4,7 @@ Profile information includes a student's demographic information and preferences
 but does NOT include basic account information such as username/password.
 
 """
-from user_api.models import User, UserProfile
+from user_api.models import UserProfile
 
 
 class ProfileRequestError(Exception):
@@ -17,7 +17,9 @@ class ProfileInternalError(Exception):
     """ An error occurred in an API call. """
     pass
 
+
 FULL_NAME_MAX_LENGTH = 255
+
 
 def profile_info(username):
     """Retrieve a user's profile information
@@ -44,7 +46,7 @@ def profile_info(username):
         'email': profile.user.email,
         'full_name': profile.name,
     }
-    
+
     return profile_dict
 
 
@@ -68,15 +70,12 @@ def update_profile(username, full_name=None):
         profile = UserProfile.objects.get(user__username=username)
     except UserProfile.DoesNotExist:
         raise ProfileRequestError("TODO")
-    
+
     if full_name is not None:
         if len(full_name) > FULL_NAME_MAX_LENGTH:
             raise ProfileRequestError("TODO")
         else:
-            profile.name = full_name
-
-    # Assumption: Django won't save if nothing has changed.
-    profile.save()
+            profile.update_name(full_name)
 
 
 def preference_info(username, preference_name):

--- a/common/djangoapps/user_api/tests/test_profile_api.py
+++ b/common/djangoapps/user_api/tests/test_profile_api.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 """ Tests for the profile API. """
 
-
 from django.test import TestCase
 import ddt
+from dateutil.parser import parse as parse_datetime
 from user_api.api import account as account_api
 from user_api.api import profile as profile_api
+from user_api.models import UserProfile
 
 
 @ddt.ddt
@@ -49,3 +50,43 @@ class ProfileApiTest(TestCase):
     def test_retrieve_profile_no_user(self):
         profile = profile_api.profile_info("does not exist")
         self.assertIs(profile, None)
+
+    def test_record_name_change_history(self):
+        account_api.create_account(self.USERNAME, self.PASSWORD, self.EMAIL)
+
+        # Change the name once
+        # Since the original name was an empty string, expect that the list
+        # of old names is empty
+        profile_api.update_profile(self.USERNAME, full_name="new name")
+        meta = UserProfile.objects.get(user__username=self.USERNAME).get_meta()
+        self.assertEqual(meta, {})
+
+        # Change the name again and expect the new name is stored in the history
+        profile_api.update_profile(self.USERNAME, full_name="another new name")
+        meta = UserProfile.objects.get(user__username=self.USERNAME).get_meta()
+
+        self.assertEqual(len(meta['old_names']), 1)
+        name, rationale, timestamp = meta['old_names'][0]
+        self.assertEqual(name, "new name")
+        self.assertEqual(rationale, u"")
+        self._assert_is_datetime(timestamp)
+
+        # Change the name a third time and expect both names are stored in the history
+        profile_api.update_profile(self.USERNAME, full_name="yet another new name")
+        meta = UserProfile.objects.get(user__username=self.USERNAME).get_meta()
+
+        self.assertEqual(len(meta['old_names']), 2)
+        name, rationale, timestamp = meta['old_names'][1]
+        self.assertEqual(name, "another new name")
+        self.assertEqual(rationale, u"")
+        self._assert_is_datetime(timestamp)
+
+    def _assert_is_datetime(self, timestamp):
+        if not timestamp:
+            return False
+        try:
+            parse_datetime(timestamp)
+        except ValueError:
+            return False
+        else:
+            return True


### PR DESCRIPTION
Mainly for backwards compatibility with the current behavior of the `UserProfile.meta` field.

@rlucioni 
