### PR TITLE
Automatically log in users who access third party login after trying to register for a course

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -813,6 +813,11 @@ class CourseEnrollment(models.Model):
                may include "audit", "verified_id", etc. Please don't use it
                until we have these mapped out.
 
+        Exceptions that can be raised: NonExistentCourseError,
+        EnrollmentClosedError, CourseFullError, AlreadyEnrolledError.  All these
+        are subclasses of CourseEnrollmentException if you want to catch all of
+        them in the same way.
+
         It is expected that this method is called from a method which has already
         verified the user authentication.
 

--- a/common/djangoapps/student/roles.py
+++ b/common/djangoapps/student/roles.py
@@ -7,6 +7,7 @@ from abc import ABCMeta, abstractmethod
 
 from django.contrib.auth.models import User
 
+from student.models import CourseAccessRole
 from xmodule_django.models import CourseKeyField
 
 
@@ -15,7 +16,6 @@ class RoleCache(object):
     A cache of the CourseAccessRoles held by a particular user
     """
     def __init__(self, user):
-        from student.models import CourseAccessRole
         self._roles = set(
             CourseAccessRole.objects.filter(user=user).all()
         )
@@ -140,7 +140,6 @@ class RoleBase(AccessRole):
         """
         Remove the supplied django users from this role.
         """
-        from student.models import CourseAccessRole
         entries = CourseAccessRole.objects.filter(
             user__in=users, role=self._role_name, org=self.org, course_id=self.course_key
         )
@@ -177,7 +176,6 @@ class CourseRole(RoleBase):
 
     @classmethod
     def course_group_already_exists(self, course_key):
-        from student.models import CourseAccessRole
         return CourseAccessRole.objects.filter(org=course_key.org, course_id=course_key).exists()
 
 
@@ -271,7 +269,6 @@ class UserBasedRole(object):
         """
         Grant this object's user the object's role for the supplied courses
         """
-        from student.models import CourseAccessRole
         if self.user.is_authenticated and self.user.is_active:
             for course_key in course_keys:
                 entry = CourseAccessRole(user=self.user, role=self.role, course_id=course_key, org=course_key.org)
@@ -285,7 +282,6 @@ class UserBasedRole(object):
         """
         Remove the supplied courses from this user's configured role.
         """
-        from student.models import CourseAccessRole
         entries = CourseAccessRole.objects.filter(user=self.user, role=self.role, course_id__in=course_keys)
         entries.delete()
         if hasattr(self.user, '_roles'):
@@ -300,5 +296,4 @@ class UserBasedRole(object):
         * course_id
         * role (will be self.role--thus uninteresting)
         """
-        from student.models import CourseAccessRole
         return CourseAccessRole.objects.filter(role=self.role, user=self.user)

--- a/common/djangoapps/student/roles.py
+++ b/common/djangoapps/student/roles.py
@@ -6,7 +6,7 @@ adding users, removing users, and listing members
 from abc import ABCMeta, abstractmethod
 
 from django.contrib.auth.models import User
-from student.models import CourseAccessRole
+
 from xmodule_django.models import CourseKeyField
 
 
@@ -15,6 +15,7 @@ class RoleCache(object):
     A cache of the CourseAccessRoles held by a particular user
     """
     def __init__(self, user):
+        from student.models import CourseAccessRole
         self._roles = set(
             CourseAccessRole.objects.filter(user=user).all()
         )
@@ -127,6 +128,7 @@ class RoleBase(AccessRole):
         """
         # silently ignores anonymous and inactive users so that any that are
         # legit get updated.
+        from student.models import CourseAccessRole
         for user in users:
             if user.is_authenticated and user.is_active and not self.has_user(user):
                 entry = CourseAccessRole(user=user, role=self._role_name, course_id=self.course_key, org=self.org)
@@ -138,6 +140,7 @@ class RoleBase(AccessRole):
         """
         Remove the supplied django users from this role.
         """
+        from student.models import CourseAccessRole
         entries = CourseAccessRole.objects.filter(
             user__in=users, role=self._role_name, org=self.org, course_id=self.course_key
         )
@@ -174,6 +177,7 @@ class CourseRole(RoleBase):
 
     @classmethod
     def course_group_already_exists(self, course_key):
+        from student.models import CourseAccessRole
         return CourseAccessRole.objects.filter(org=course_key.org, course_id=course_key).exists()
 
 
@@ -267,6 +271,7 @@ class UserBasedRole(object):
         """
         Grant this object's user the object's role for the supplied courses
         """
+        from student.models import CourseAccessRole
         if self.user.is_authenticated and self.user.is_active:
             for course_key in course_keys:
                 entry = CourseAccessRole(user=self.user, role=self.role, course_id=course_key, org=course_key.org)
@@ -280,6 +285,7 @@ class UserBasedRole(object):
         """
         Remove the supplied courses from this user's configured role.
         """
+        from student.models import CourseAccessRole
         entries = CourseAccessRole.objects.filter(user=self.user, role=self.role, course_id__in=course_keys)
         entries.delete()
         if hasattr(self.user, '_roles'):
@@ -294,4 +300,5 @@ class UserBasedRole(object):
         * course_id
         * role (will be self.role--thus uninteresting)
         """
+        from student.models import CourseAccessRole
         return CourseAccessRole.objects.filter(role=self.role, user=self.user)

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -669,6 +669,18 @@ def change_enrollment(request, auto_register=False):
     if 'course_id' not in request.POST:
         return HttpResponseBadRequest(_("Course id not specified"))
 
+    try:
+        course_id = SlashSeparatedCourseKey.from_deprecated_string(request.POST.get("course_id"))
+    except InvalidKeyError:
+        log.warning(
+            "User {username} tried to {action} with invalid course id: {course_id}".format(
+                username=user.username,
+                action=action,
+                course_id=request.POST.get("course_id")
+            )
+        )
+        return HttpResponseBadRequest(_("Invalid course id"))
+
     # Ensure the user is authenticated
     if not user.is_authenticated():
         return HttpResponseForbidden()
@@ -721,7 +733,7 @@ def change_enrollment(request, auto_register=False):
                 # for no such model to exist, even though we've set the enrollment type
                 # to "honor".
                 try:
-                    CourseEnrollment.enroll(user, course.id, mode=current_mode.slug)
+                    CourseEnrollment.enroll(user, course_id, mode=current_mode.slug)
                 except Exception:
                     return HttpResponseBadRequest(_("Could not enroll"))
 
@@ -757,7 +769,7 @@ def change_enrollment(request, auto_register=False):
                 )
 
             try:
-                CourseEnrollment.enroll(user, course.id, mode=current_mode.slug)
+                CourseEnrollment.enroll(user, course_id, mode=current_mode.slug)
             except Exception:
                 return HttpResponseBadRequest(_("Could not enroll"))
 

--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -399,3 +399,10 @@ def login_analytics(*args, **kwargs):
                 }
             }
         )
+
+@partial.partial
+def change_enrollment(*args, **kwargs):
+    try:
+        CourseEnrollment.enroll(user, 'foo')
+    except:
+        pass

--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -69,8 +69,10 @@ from social.apps.django_app.default import models
 from social.exceptions import AuthException
 from social.pipeline import partial
 
-from student.models import CourseEnrollment
+from student.models import CourseEnrollment, CourseEnrollmentException
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
+
+from logging import getLogger
 
 from . import provider
 
@@ -86,6 +88,8 @@ _AUTH_ENTRY_CHOICES = frozenset([
 ])
 _DEFAULT_RANDOM_PASSWORD_LENGTH = 12
 _PASSWORD_CHARSET = string.letters + string.digits
+
+logger = getLogger(__name__)
 
 
 class AuthEntryError(AuthException):
@@ -404,7 +408,7 @@ def login_analytics(*args, **kwargs):
             }
         )
 
-@partial.partial
+#@partial.partial
 def change_enrollment(*args, **kwargs):
     """
     If the user accessed the third party auth flow after trying to register for
@@ -418,5 +422,7 @@ def change_enrollment(*args, **kwargs):
                     kwargs['strategy'].session_get('registration_course_id')
                 )
             )
-        except:
+        except CourseEnrollmentException:
             pass
+        except Exception, e:
+            logger.exception(e)

--- a/common/djangoapps/third_party_auth/settings.py
+++ b/common/djangoapps/third_party_auth/settings.py
@@ -110,6 +110,7 @@ def _set_global_settings(django_settings):
         'social.pipeline.social_auth.load_extra_data',
         'social.pipeline.user.user_details',
         'third_party_auth.pipeline.login_analytics',
+        'third_party_auth.pipeline.change_enrollment',
     )
 
     # We let the user specify their email address during signup.

--- a/lms/djangoapps/courseware/access.py
+++ b/lms/djangoapps/courseware/access.py
@@ -21,6 +21,7 @@ from student.roles import (
     GlobalStaff, CourseStaffRole, CourseInstructorRole,
     OrgStaffRole, OrgInstructorRole, CourseBetaTesterRole
 )
+from student.models import CourseEnrollment, CourseEnrollmentAllowed
 from opaque_keys.edx.keys import CourseKey, UsageKey
 DEBUG_ACCESS = False
 
@@ -123,7 +124,6 @@ def _has_access_course_desc(user, action, course):
         """
         Can this user access the forums in this course?
         """
-        from student.models import CourseEnrollment
         return (
             can_load() and
             (
@@ -148,7 +148,6 @@ def _has_access_course_desc(user, action, course):
         """
 
         # if using registration method to restrict (say shibboleth)
-        from student.models import CourseEnrollmentAllowed
         if settings.FEATURES.get('RESTRICT_ENROLL_BY_REG_METHOD') and course.enrollment_domain:
             if user is not None and user.is_authenticated() and \
                 ExternalAuthMap.objects.filter(user=user, external_domain=course.enrollment_domain):

--- a/lms/djangoapps/courseware/access.py
+++ b/lms/djangoapps/courseware/access.py
@@ -14,11 +14,9 @@ from xmodule.x_module import XModule
 
 from xblock.core import XBlock
 
-from student.models import CourseEnrollmentAllowed
 from external_auth.models import ExternalAuthMap
 from courseware.masquerade import is_masquerading_as_student
 from django.utils.timezone import UTC
-from student.models import CourseEnrollment
 from student.roles import (
     GlobalStaff, CourseStaffRole, CourseInstructorRole,
     OrgStaffRole, OrgInstructorRole, CourseBetaTesterRole
@@ -125,6 +123,7 @@ def _has_access_course_desc(user, action, course):
         """
         Can this user access the forums in this course?
         """
+        from student.models import CourseEnrollment
         return (
             can_load() and
             (
@@ -149,6 +148,7 @@ def _has_access_course_desc(user, action, course):
         """
 
         # if using registration method to restrict (say shibboleth)
+        from student.models import CourseEnrollmentAllowed
         if settings.FEATURES.get('RESTRICT_ENROLL_BY_REG_METHOD') and course.enrollment_domain:
             if user is not None and user.is_authenticated() and \
                 ExternalAuthMap.objects.filter(user=user, external_domain=course.enrollment_domain):

--- a/lms/djangoapps/courseware/tests/helpers.py
+++ b/lms/djangoapps/courseware/tests/helpers.py
@@ -116,6 +116,7 @@ class LoginEnrollmentTestCase(TestCase):
         resp = self.client.post(reverse('change_enrollment'), {
             'enrollment_action': 'enroll',
             'course_id': course.id.to_deprecated_string(),
+            'check_access': True,
         })
         result = resp.status_code == 200
         if verify:


### PR DESCRIPTION
This PR refactors `change_enrollment` and `enroll` so that `change_enrollment` handles only validation we'd expect in a view ("is the user logged in before trying to access this view", "is this user in the auto-register A/B test", etc), and the `enroll` method handles more "server"-y concerns (is the class already full, does the class exist, etc).

That way, the third party login flow can simply call `enroll` directly without worrying about skipping over any important checks, since we don't really have access to views midway through the third party login flow.
