### PR TITLE
Making the django main template navigation course aware.

### DIFF
--- a/lms/templates/main_django.html
+++ b/lms/templates/main_django.html
@@ -31,11 +31,13 @@
 
 <body class="{% block bodyclass %}{% endblock %} lang_{{LANGUAGE_CODE}}">
   <a class="nav-skip" href="{% block nav_skip %}#content{% endblock %}">{% trans "Skip to this view's content" %}</a>
-  {% if ENABLE_NEW_EDX_HEADER %}
-    {% include "navigation.html" %}
-  {% else %}
-    {% include "original_navigation.html" %}
-  {% endif %}
+  {% with course=request.course %}
+    {% if ENABLE_NEW_EDX_HEADER %}
+      {% include "navigation.html" %}
+    {% else %}
+      {% include "original_navigation.html" %}
+    {% endif %}
+  {% endwith %}
   <div class="content-wrapper" id="content">
     {% block body %}{% endblock %}
     {% block bodyextra %}{% endblock %}


### PR DESCRIPTION
@wedaly @talbs @griffresch @sarina 
https://openedx.atlassian.net/browse/ECOM-221
This is a quick fix for the Wiki page, but more so, all Django template headers that are supposed to be course aware.

The defect indicated we'd want the header styles to stay consistent within courseware, but the django templates were not passing the course variable through to the navigation.html template context. This fix will do that, update the course info in the header, and keep the old styling.

![image](https://cloud.githubusercontent.com/assets/235752/4373155/8f589f0c-432a-11e4-9f21-f888269c09a8.png)
