### PR TITLE
Course admin should be able to de-admin dicussion admins

### DIFF
--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -1495,10 +1495,6 @@ def update_forum_role_membership(request, course_id):
         ))
 
     user = get_student_from_identifier(unique_student_identifier)
-    target_is_instructor = has_access(user, 'instructor', course)
-    # cannot revoke instructor
-    if target_is_instructor and action == 'revoke' and rolename == FORUM_ROLE_ADMINISTRATOR:
-        return HttpResponseBadRequest("Cannot revoke instructor forum admin privileges.")
 
     try:
         update_forum_role(course_id, user, rolename, action)


### PR DESCRIPTION
As a global staff or course staff once you added yourself
in the discussion admins you cannot revoke it back unless
you remove yourself as course staff. Any of the course staff
member should be able to remove others from discussion admins
whether they are course staff or not.

TNL-315
