### PR TITLE
Fix to allow usernames with '-', '+', '.' in Mobile API urls.

### DIFF
--- a/lms/djangoapps/mobile_api/users/urls.py
+++ b/lms/djangoapps/mobile_api/users/urls.py
@@ -6,9 +6,9 @@ from rest_framework.urlpatterns import format_suffix_patterns
 from .views import UserDetail, UserCourseEnrollmentsList
 
 urlpatterns = patterns('mobile_api.users.views',
-    url(r'^(?P<username>\w+)$', UserDetail.as_view(), name='user-detail'),
+    url(r'^(?P<username>[\w.+-]+)$', UserDetail.as_view(), name='user-detail'),
     url(
-        r'^(?P<username>\w+)/course_enrollments/$',
+        r'^(?P<username>[\w.+-]+)/course_enrollments/$',
         UserCourseEnrollmentsList.as_view(),
         name='courseenrollment-detail'
     ),


### PR DESCRIPTION
@andy-armstrong: Fix to allow usernames with '-', '+', '.' in Mobile API urls.
