### PR TITLE
Hide deleted course updates from mobile API.

### DIFF
--- a/lms/djangoapps/mobile_api/course_info/views.py
+++ b/lms/djangoapps/mobile_api/course_info/views.py
@@ -25,7 +25,12 @@ class CourseUpdatesList(generics.ListAPIView):
         course_id = CourseKey.from_string(kwargs['course_id'])
         course = modulestore().get_course(course_id)
         course_updates_module = get_course_info_section_module(request, course, 'updates')
-        return Response(reversed(course_updates_module.items))
+
+        updates_to_show = [
+            update for update in reversed(course_updates_module.items)
+            if update.get("status") != "deleted"
+        ]
+        return Response(updates_to_show)
 
 
 class CourseHandoutsList(generics.ListAPIView):


### PR DESCRIPTION
@andy-armstrong: Another small fix for mobile (so two total for this release).
