### PR TITLE
fixes for status for prof ed and verified registration

### DIFF
--- a/lms/static/sass/views/_verification.scss
+++ b/lms/static/sass/views/_verification.scss
@@ -385,7 +385,6 @@
           .sts-track-value {
             background-color: $professional-color-lvl1;
           }
-
         }
       }
 
@@ -470,7 +469,14 @@
       display: inline-block;
 
       .sts-track-value {
-        background: $m-blue-l1;
+        background: $verified-color-lvl3;
+      }
+
+      &.professional-ed {
+
+        .sts-track-value {
+          background-color: $professional-color-lvl1;
+        }
       }
     }
   }

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -211,7 +211,7 @@
           <a class="instructor-info-action" href="${studio_url}">${_("View About Page in studio")}</a>
         </div>
       % endif
-      
+
       <nav>
         <a href="#" class="active">${_("Overview")}</a>
       ##  <a href="#">${_("FAQ")}</a>

--- a/lms/templates/verify_student/_verification_header.html
+++ b/lms/templates/verify_student/_verification_header.html
@@ -11,6 +11,8 @@
       <span class="sts-label">${_("You are upgrading your registration for")}</span>
     %elif reverify:
       <span class="sts-label">${_("You are re-verifying for")}</span>
+    %elif modes_dict and "professional" in modes_dict:
+      <span class="sts-label">${_("You are registering for")}</span>
     %else:
       <span class="sts-label">${_("You are registering for")}</span>
     %endif
@@ -63,6 +65,14 @@
         <span class="sts-course-number">${course_num}</span>
         <span class="sts-course-name">${course_name}.</span>
     </span>
+
+    %if modes_dict and "professional" in modes_dict:
+    <span class="sts-track professional-ed">
+      <span class="sts-track-value">
+          ${_("Professional Education")}
+      </span>
+    </span>
+    %else:
     <span class="sts-track">
       <span class="sts-track-value">
         %if upgrade:
@@ -73,6 +83,7 @@
           <span class="context">${_("Registering as: ")}</span> ${_("Verified")}
         %endif
     </span>
+    %endif
   </h2>
 </header>
 %endif


### PR DESCRIPTION
Fixes for status for prof ed and verified registration on both variants of AB test: professional ed status shows pink and says "Professional Education", verified shows green and says "Verified" for both control and A variant

@marcotuts can you review my changes?
