### PR TITLE
Use strings instead of tuples as keys in SessionKeyValueStore.

### DIFF
--- a/cms/djangoapps/contentstore/views/session_kv_store.py
+++ b/cms/djangoapps/contentstore/views/session_kv_store.py
@@ -5,18 +5,23 @@ from __future__ import absolute_import
 
 from xblock.runtime import KeyValueStore
 
+
+def stringify(key):
+    return repr(tuple(key))
+
+
 class SessionKeyValueStore(KeyValueStore):
     def __init__(self, request):
         self._session = request.session
 
     def get(self, key):
-        return self._session[tuple(key)]
+        return self._session[stringify(key)]
 
     def set(self, key, value):
-        self._session[tuple(key)] = value
+        self._session[stringify(key)] = value
 
     def delete(self, key):
-        del self._session[tuple(key)]
+        del self._session[stringify(key)]
 
     def has(self, key):
-        return tuple(key) in self._session
+        return stringify(key) in self._session


### PR DESCRIPTION
Some Django packages expect only strings as keys in the user session,
and it is also a recommended practice in the Django manual.
