### PR TITLE
Fix UnicodeError with anonymous student IDs

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -100,7 +100,7 @@ def anonymous_id_for_user(user, course_id, save=True):
     hasher.update(settings.SECRET_KEY)
     hasher.update(unicode(user.id))
     if course_id:
-        hasher.update(course_id.to_deprecated_string())
+        hasher.update(course_id.to_deprecated_string().encode('utf-8'))
     digest = hasher.hexdigest()
 
     if not hasattr(user, '_anonymous_id'):

--- a/common/djangoapps/student/tests/tests.py
+++ b/common/djangoapps/student/tests/tests.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 This file demonstrates writing tests using the unittest module. These will pass
 when you run "manage.py test".
@@ -736,3 +737,11 @@ class AnonymousLookupTable(TestCase):
         real_user = user_by_anonymous_id(anonymous_id)
         self.assertEqual(self.user, real_user)
         self.assertEqual(anonymous_id, anonymous_id_for_user(self.user, self.course.id, save=False))
+
+    def test_roundtrip_with_unicode_course_id(self):
+        course2 = CourseFactory.create(org=self.COURSE_ORG, display_name=u"Omega Course Ω", number=self.COURSE_SLUG)
+        CourseEnrollment.enroll(self.user, course2.id)
+        anonymous_id = anonymous_id_for_user(self.user, course2.id)
+        real_user = user_by_anonymous_id(anonymous_id)
+        self.assertEqual(self.user, real_user)
+        self.assertEqual(anonymous_id, anonymous_id_for_user(self.user, course2.id, save=False))


### PR DESCRIPTION
**Background**: Course IDs are allowed to contain unicode characters, but `anonymous_id_for_user(user, course_id)` currently throws a `UnicodeError` exception if it is given a course ID with non-ASCII characters. This pull request fixes the issue and adds a new test covering this case.

**Discussion**: Myself, @antoviaque, @mattdrayer have discussed this after we became aware of this due to test failures caused by this issue on the solutions fork.

**Affects**: `common` code, known to cause test failures in LMS under certain conditions, and likely would cause real-world errors in the LMS as well, for any courses with unicode characters in their course ID.

**How to reproduce**: Run the included test case without the fix to `models.py`

**Urgency**: Low-Moderate - Unknown if it is affecting any real installations.

**Authorship**: This is a contribution from OpenCraft.

Related comment: At some point in the future, I assume, we will want to get rid of `to_deprecated_string`, in which case this line will become `hasher.update(unicode(course_id).encode('utf-8'))`. That change could even be made now, but it changes how anonymous IDs are calculated, resulting in new hash values that won't match any previously generated hash values / anonymous IDs. Although previously generated anonymous IDs always get stored in a database and such a change is thus totally backwards compatible, there are a couple of unit tests and a runtime warning that are explicitly designed to catch such changes in how the digest is calculated. So for now I've stuck with the most clearly backwards-compatible route.
