### PR TITLE
Click on posts I'm following should load threads

### DIFF
--- a/common/static/coffee/spec/discussion/view/discussion_thread_list_view_spec.coffee
+++ b/common/static/coffee/spec/discussion/view/discussion_thread_list_view_spec.coffee
@@ -549,6 +549,7 @@ describe "DiscussionThreadListView", ->
             ,
             "Following"
           )
+          expect($.ajax.mostRecentCall.args[0].data.group_id).toBeUndefined();
 
         it "should get threads for the selected leaf", ->
           testSelectionRequest(

--- a/common/static/coffee/src/discussion/views/discussion_thread_list_view.coffee
+++ b/common/static/coffee/src/discussion/views/discussion_thread_list_view.coffee
@@ -188,7 +188,6 @@ if Backbone?
             options.group_id = @group_id
         when 'followed'
           options.user_id = window.user.id
-          options.group_id = "all"
         when 'commentables'
           options.commentable_ids = @discussionIds
           if @group_id


### PR DESCRIPTION
When as course moderator when we click on posts
I'm followng from sidebar dropdown it gives error
that threads cannot be loaded. It should show all
the threads the user is following.

TNL-469
