### PR TITLE
Annotation Tools: Thumbnail check breaks tool on creation

### DIFF
--- a/common/static/js/vendor/ova/OpenSeaDragonAnnotation.js
+++ b/common/static/js/vendor/ova/OpenSeaDragonAnnotation.js
@@ -577,13 +577,19 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             var isRP = (typeof rp!='undefined');
             var isSource = false;
             
-            // Double checks that the image being displayed matches the annotations 
-            var source = this.viewer.source;
-            var tilesUrl = typeof source.tilesUrl!='undefined'?source.tilesUrl:'';
-            var functionUrl = typeof source.getTileUrl!='undefined'?source.getTileUrl:'';
-            var compareUrl = tilesUrl!=''?tilesUrl:('' + functionUrl).replace(/\s+/g, ' ');
-            if(isContainer) isSource = (an.target.src == compareUrl);
-            
+            // Though it would be better to store server ids of images in the annotation that
+            // would require changing annotations that were already made, instead we check if
+            // the id is a substring of the thumbnail, which according to OpenSeaDragon API should be the case.
+            var sourceId = this.viewer.source['@id'];
+
+            // code runs on annotation creation before thumbnail is created
+            var targetThumb = an.target ? an.target.thumb : false;
+            if (isContainer) {
+                // reason why this is okay is that we are trying to ascertain that the annotation
+                // is related to the image drawn. If thumbnail attribute is empty it means the annotation
+                // was just created and should still be considered an annotation of this image.
+                isSource = targetThumb ? (targetThumb.indexOf(sourceId) !== -1) : true;
+            }            
             return (isOpenSeaDragon && isContainer && isImage && isRP && isSource);
         },
         
@@ -841,13 +847,13 @@ Annotator.Plugin.OpenSeaDragon = (function(_super) {
         // Makes sure OSD exists and that annotation is an image annotation
         // with a position in the OSD instance
         var isOpenSeaDragon = (typeof annotator.osda != 'undefined');
-        var isContainer = (typeof an.target!='undefined' && an.target.container==this.viewer.id );
+        var isContainer = (typeof an.target!='undefined' && an.target.container==osda.viewer.id );
         var isImage = (typeof an.media!='undefined' && an.media=='image');
         var isRP = (typeof rp!='undefined');
         var isSource = false;
         
         // Double checks that the image being displayed matches the annotations 
-        var source = this.viewer.source;
+        var source = osda.viewer.source;
         var tilesUrl = typeof source.tilesUrl!='undefined'?source.tilesUrl:'';
         var functionUrl = typeof source.getTileUrl!='undefined'?source.getTileUrl:'';
         var compareUrl = tilesUrl!=''?tilesUrl:('' + functionUrl).replace(/\s+/g, ' ');


### PR DESCRIPTION
**Affected Courses:**  3 courses are affected (Visualizing Japan, ChinaX, HeroesX) with a total enrollment of ~35,000 students.
**Ideal Fix Deployment:** Ideally, today. Otherwise as soon as possible. 

**Background:** After the code release earlier today (9/25) I received messages from course instructors and students that they could not make image annotations. Checking the console I noticed the issue was caused by the bug fix I made that was released earlier today. During testing I had neglected to realize that the code actually broke annotation creation. No annotations can be created due to "thumbnails" being saved only after a user hits "Save" instead of before. 

**Studio Changes:** None.

**LMS Changes:** Users should now be able to create annotations

**Testing:**
1. Install the [tarball](https://www.dropbox.com/s/r684ber7z4ddqtc/2014_T4.DPRfFs.tar.gz) as usual.
2. Try to make an annotation. It failed on creation before. Now it does not. 
    a. The previous error was an AttributeError trying to find "thumb" of undefined, which is because the function runs on annotations that have not yet been saved. "thumb" is attached only during the saving process. This mitigates that.
