### PR TITLE
Allowing new styles on White Label about pages.

### DIFF
--- a/lms/djangoapps/courseware/views.py
+++ b/lms/djangoapps/courseware/views.py
@@ -748,6 +748,9 @@ def course_about(request, course_id):
         'invitation_only': invitation_only,
         'active_reg_button': active_reg_button,
         'is_shib_course': is_shib_course,
+         # We do not want to display the internal courseware header, which is used when the course is found in the
+         # context. This value is therefor explicitly set to render the appropriate header.
+        'disable_courseware_header': True,
     })
 
 

--- a/lms/templates/navigation.html
+++ b/lms/templates/navigation.html
@@ -36,7 +36,7 @@ site_status_msg = get_site_status_msg(course_id)
 % endif
 </%block>
 
-<header class="${"global slim" if course else "global-new"}" aria-label="Main" role="banner">
+<header class="${"global slim" if course and not disable_courseware_header else "global-new"}" aria-label="Main" role="banner">
   <nav aria-label="Main">
     <h1 class="logo" itemscope="" itemtype="http://schema.org/Organization">
       <a href="${marketing_link('ROOT')}" title="Home page" itemprop="url">
@@ -46,7 +46,7 @@ site_status_msg = get_site_status_msg(course_id)
       </a>
     </h1>
 
-    % if course:
+    % if course and not disable_courseware_header:
     <h2><span class="provider">${course.display_org_with_default | h}:</span> ${course.display_number_with_default | h} ${course.display_name_with_default}</h2>
     % endif
 


### PR DESCRIPTION
Lesser of two evils; adding a new attribute in the context of the about page to make sure it inherits the styles of the front pages in the LMS, rather than the courseware header. 

See https://openedx.atlassian.net/browse/ECOM-390 for more details. 

With the new header enabled, it will now appear as such:
![image](https://cloud.githubusercontent.com/assets/235752/4411120/1aea08f4-44ec-11e4-9b01-3031f8a271f3.png)

@wedaly @rlucioni 
