### PR TITLE
edX Solutions Team: Cast grade weight to float

### DIFF
--- a/lms/djangoapps/courseware/grades.py
+++ b/lms/djangoapps/courseware/grades.py
@@ -474,6 +474,7 @@ def get_score(course_id, user, problem_descriptor, module_creator, scores_cache=
     # Now we re-weight the problem, if specified
     weight = problem_descriptor.weight
     if weight is not None:
+        weight = float(weight)
         if total == 0:
             log.exception("Cannot reweight a problem with zero total points. Problem: " + str(student_module))
             return (correct, total)


### PR DESCRIPTION
Discovered in assisting an edx/solutions customer. Some xblocks publish weight as a non-numeric value, so if we are to use it to weight the grade for the problem, it needs to be cast as float in order to calculate the weight correctly.

Certainly seems like something that could be addressed by the xblock developer, but if we want to encourage more xblock development, it is probably good to be more resilient.
