### PR TITLE
Put student profile third party auth behind a feature flag

### DIFF
--- a/lms/djangoapps/student_profile/views.py
+++ b/lms/djangoapps/student_profile/views.py
@@ -4,6 +4,7 @@ from django.http import (
     QueryDict, HttpResponse,
     HttpResponseBadRequest, HttpResponseServerError
 )
+from django.conf import settings
 from django_future.csrf import ensure_csrf_cookie
 from django.contrib.auth.decorators import login_required
 from django.views.decorators.http import require_http_methods
@@ -32,12 +33,14 @@ def index(request):
     """
     user = request.user
 
-    return render_to_response(
-        'student_profile/index.html', {
-            'disable_courseware_js': True,
-            'provider_user_states': pipeline.get_provider_user_states(user),
-        }
-    )
+    context = {
+        'disable_courseware_js': True
+    }
+
+    if settings.FEATURES.get('ENABLE_THIRD_PARTY_AUTH'):
+        context['provider_user_states'] = pipeline.get_provider_user_states(user)
+
+    return render_to_response('student_profile/index.html', context)
 
 
 @login_required

--- a/lms/templates/student_profile/index.html
+++ b/lms/templates/student_profile/index.html
@@ -1,5 +1,4 @@
 <%! from django.utils.translation import ugettext as _ %>
-<%! from third_party_auth import pipeline %>
 <%namespace name='static' file='/static_content.html'/>
 
 <%inherit file="../main.html" />
@@ -25,44 +24,6 @@
     </div>
 </form>
 
-<li class="controls--account">
-    <span class="title">
-        ## Translators: this section lists all the third-party authentication providers (for example, Google and LinkedIn) the user can link with or unlink from their edX account.
-        ${_("Connected Accounts")}
-    </span>
-    <span class="data">
-    <span class="third-party-auth">
-        % for state in provider_user_states:
-            <div class="auth-provider">
-                <div class="status">
-                    % if state.has_account:
-                        <i class="icon icon-link"></i> <span class="copy">${_('Linked')}</span>
-                    % else:
-                        <i class="icon icon-unlink"></i><span class="copy">${_('Not Linked')}</span>
-                    % endif
-                </div>
-                <span class="provider">${state.provider.NAME}</span>
-                <span class="control">
-                    <form
-                        action="${pipeline.get_disconnect_url(state.provider.NAME)}"
-                        method="post"
-                        name="${state.get_unlink_form_name()}">
-                        % if state.has_account:
-                            <input type="hidden" name="csrfmiddlewaretoken" value="${csrf_token}">
-
-                            <a href="#" onclick="document.${state.get_unlink_form_name()}.submit()">
-                                ## Translators: clicking on this removes the link between a user's edX account and their account with an external authentication provider (like Google or LinkedIn).
-                                ${_("Unlink")}
-                            </a>
-                        % else:
-                            <a href="${pipeline.get_login_url(state.provider.NAME, pipeline.AUTH_ENTRY_PROFILE)}">
-                                ## Translators: clicking on this creates a link between a user's edX account and their account with an external authentication provider (like Google or LinkedIn).
-                                ${_("Link")}
-                            </a>
-                        % endif
-                    </form>
-                </span>
-            </div>
-        % endfor
-    </span>
-</li>
+% if settings.FEATURES.get('ENABLE_THIRD_PARTY_AUTH'):
+    <%include file="third_party_auth.html" />
+% endif

--- a/lms/templates/student_profile/third_party_auth.html
+++ b/lms/templates/student_profile/third_party_auth.html
@@ -1,0 +1,44 @@
+<%! from django.utils.translation import ugettext as _ %>
+<%! from third_party_auth import pipeline %>
+
+<li class="controls--account">
+    <span class="title">
+        ## Translators: this section lists all the third-party authentication providers (for example, Google and LinkedIn) the user can link with or unlink from their edX account.
+        ${_("Connected Accounts")}
+    </span>
+    <span class="data">
+    <span class="third-party-auth">
+        % for state in provider_user_states:
+            <div class="auth-provider">
+                <div class="status">
+                    % if state.has_account:
+                        <i class="icon icon-link"></i> <span class="copy">${_('Linked')}</span>
+                    % else:
+                        <i class="icon icon-unlink"></i><span class="copy">${_('Not Linked')}</span>
+                    % endif
+                </div>
+                <span class="provider">${state.provider.NAME}</span>
+                <span class="control">
+                    <form
+                        action="${pipeline.get_disconnect_url(state.provider.NAME)}"
+                        method="post"
+                        name="${state.get_unlink_form_name()}">
+                        % if state.has_account:
+                            <input type="hidden" name="csrfmiddlewaretoken" value="${csrf_token}">
+
+                            <a href="#" onclick="document.${state.get_unlink_form_name()}.submit()">
+                                ## Translators: clicking on this removes the link between a user's edX account and their account with an external authentication provider (like Google or LinkedIn).
+                                ${_("Unlink")}
+                            </a>
+                        % else:
+                            <a href="${pipeline.get_login_url(state.provider.NAME, pipeline.AUTH_ENTRY_PROFILE)}">
+                                ## Translators: clicking on this creates a link between a user's edX account and their account with an external authentication provider (like Google or LinkedIn).
+                                ${_("Link")}
+                            </a>
+                        % endif
+                    </form>
+                </span>
+            </div>
+        % endfor
+    </span>
+</li>


### PR DESCRIPTION
When third party auth is disabled, the database table social auth requires might not be created.  This leads to errors on the student profile page (currently disabled in prod).

This PR adds a check for the feature flag `ENABLE_THIRD_PARTY_AUTH` so we can use the student profile page without enabling third party auth.

@stephensanchez @dianakhuang Please review.
