### PR TITLE
Update djpyfs

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -143,5 +143,3 @@ git+https://github.com/mitocw/django-cas.git
 
 # edX packages
 edx-submissions==0.0.8
-
--e git+https://github.com/pmitros/django-pyfs.git@36f64c0f1f458ce7b9ecb2347667b202d13a8317#egg=djpyfs

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -17,6 +17,7 @@
 -e git+https://github.com/un33k/django-ipware.git@42cb1bb1dc680a60c6452e8bb2b843c2a0382c90#egg=django-ipware
 -e git+https://github.com/appliedsec/pygeoip.git@95e69341cebf5a6a9fbf7c4f5439d458898bdc3b#egg=pygeoip
 -e git+https://github.com/jazkarta/edx-jsme.git@c5bfa5d361d6685d8c643838fc0055c25f8b7999#egg=edx-jsme
+-e git+https://github.com/pmitros/django-pyfs.git@d175715e0fe3367ec0f1ee429c242d603f6e8b10#egg=djpyfs
 
 # Our libraries:
 -e git+https://github.com/edx/XBlock.git@81a6d713c98d4914af96a0ca624ee7fa4903625e#egg=XBlock


### PR DESCRIPTION
djpyfs was creating a connection to S3 on import. This is Very Bad™, and caused devstack to break. This commit updates djpyfs so it doesn't do that anymore.

@nedbat @pmitros @jarv 
