### PR TITLE
Added handling in gitlog template for missing import logs

### DIFF
--- a/lms/djangoapps/dashboard/tests/test_sysadmin.py
+++ b/lms/djangoapps/dashboard/tests/test_sysadmin.py
@@ -552,6 +552,33 @@ class TestSysAdminMongoCourseImport(SysadminBaseTestCase):
                 'course_id': 'Not/Real/Testing'}))
         self.assertEqual(404, response.status_code)
 
+    def test_gitlog_no_logs(self):
+        """
+        Make sure the template behaves well when rendered despite there not being any logs.
+        (This is for courses imported using methods other than the git_add_course command)
+        """
+
+        self._setstaff_login()
+        self._mkdir(getattr(settings, 'GIT_REPO_DIR'))
+
+        self._add_edx4edx()
+
+        # Simulate a lack of git import logs
+        import_logs = CourseImportLog.objects.all()
+        import_logs.delete()
+
+        response = self.client.get(
+            reverse('gitlogs_detail', kwargs={
+                'course_id': 'MITx/edx4edx/edx4edx'
+            })
+        )
+        self.assertIn(
+            'No git import logs have been recorded for this course.',
+            response.content
+        )
+
+        self._rm_edx4edx()
+
     def test_gitlog_courseteam_access(self):
         """
         Ensure course team users are allowed to access only their own course.

--- a/lms/templates/sysadmin_dashboard_gitlogs.html
+++ b/lms/templates/sysadmin_dashboard_gitlogs.html
@@ -97,6 +97,8 @@ textarea {
               logs = cilset[:10]
           else:
               logs = cilset[:2]
+
+          cil = None
           %>
           % for cil in logs:
               <%
@@ -114,7 +116,14 @@ textarea {
           %if course_id is not None:
               <tr>
                 <td colspan="3">
-                  <pre>${cil.import_log | h}</pre>
+                  <pre>
+                    %if cil is not None:
+                        ${cil.import_log | h}
+                    %else:
+                        ## Translators: git is a version-control system; see http://git-scm.com/about
+                        ${_('No git import logs have been recorded for this course.')}
+                    %endif
+                  </pre>
                 </td>
               </tr>
           %endif


### PR DESCRIPTION
Fixes a template error that occurs when viewing a course's detailed
git import log. The problem happens for courses imported using methods
other than the `git_add_course` command. @carsongee 
