### PR TITLE
Validate student profile name field, use Backbone.js on the profile page

### DIFF
--- a/lms/djangoapps/student_profile/test/test_views.py
+++ b/lms/djangoapps/student_profile/test/test_views.py
@@ -68,7 +68,7 @@ class StudentProfileViewTest(UrlResetMixin, TestCase):
 
     @ddt.data(
         ('get', 'profile_index'),
-        ('put', 'name_change')
+        ('put', 'profile_index')
     )
     @ddt.unpack
     def test_require_login(self, method, url_name):
@@ -82,12 +82,11 @@ class StudentProfileViewTest(UrlResetMixin, TestCase):
         self.assertIn('accounts/login?next=', response.redirect_chain[0][0])
 
     @ddt.data(
-        ('get', 'profile_index'),
-        ('put', 'name_change')
+        (['get', 'put'], 'profile_index'),
     )
     @ddt.unpack
-    def test_require_http_method(self, correct_method, url_name):
-        wrong_methods = {'get', 'put', 'post', 'head', 'options', 'delete'} - {correct_method}
+    def test_require_http_method(self, correct_methods, url_name):
+        wrong_methods = {'get', 'put', 'post', 'head', 'options', 'delete'} - set(correct_methods)
         url = reverse(url_name)
 
         for method in wrong_methods:
@@ -104,10 +103,10 @@ class StudentProfileViewTest(UrlResetMixin, TestCase):
         data = {}
         if new_name is not None:
             # We can't pass a Unicode object to urlencode, so we encode the Unicode object
-            data['new_name'] = new_name.encode('utf-8')
+            data['fullName'] = new_name.encode('utf-8')
 
         return self.client.put(
-            path=reverse('name_change'),
+            path=reverse('profile_index'),
             data=urlencode(data),
             content_type= 'application/x-www-form-urlencoded'
         )

--- a/lms/djangoapps/student_profile/urls.py
+++ b/lms/djangoapps/student_profile/urls.py
@@ -3,5 +3,4 @@ from django.conf.urls import patterns, url
 urlpatterns = patterns(
     'student_profile.views',
     url(r'^$', 'index', name='profile_index'),
-    url(r'^name_change$', 'name_change_handler', name='name_change'),
 )

--- a/lms/djangoapps/student_profile/views.py
+++ b/lms/djangoapps/student_profile/views.py
@@ -7,28 +7,47 @@ from django.http import (
 from django.conf import settings
 from django_future.csrf import ensure_csrf_cookie
 from django.contrib.auth.decorators import login_required
-from django.views.decorators.http import require_http_methods
 from edxmako.shortcuts import render_to_response
 from user_api.api import profile as profile_api
 from third_party_auth import pipeline
 
 
 @login_required
-@require_http_methods(['GET'])
 def index(request):
-    """Render the profile info page.
+    """View or modify the student's profile.
+
+    GET: Retrieve the user's profile information.
+    PUT: Update the user's profile information.  Currently the only accept param is "fullName".
 
     Args:
         request (HttpRequest)
 
     Returns:
-        HttpResponse: 200 if successful
+        HttpResponse: 200 if successful on GET
+        HttpResponse: 204 if successful on PUT
         HttpResponse: 302 if not logged in (redirect to login page)
+        HttpResponse: 400 if the updated information is invalid
         HttpResponse: 405 if using an unsupported HTTP method
+        HttpResponse: 500 if an unexpected error occurs.
 
-    Example usage:
+    """
+    if request.method == "GET":
+        return _get_profile(request)
+    elif request.method == "PUT":
+        return _update_profile(request)
+    else:
+        return HttpResponse(status=405)
 
-        GET /profile
+
+def _get_profile(request):
+    """Retrieve the user's profile information, including an HTML form
+    that students can use to update the information.
+
+    Args:
+        request (HttpRequest)
+
+    Returns:
+        HttpResponse
 
     """
     user = request.user
@@ -43,34 +62,24 @@ def index(request):
     return render_to_response('student_profile/index.html', context)
 
 
-@login_required
-@require_http_methods(['PUT'])
 @ensure_csrf_cookie
-def name_change_handler(request):
-    """Change the user's name.
+def _update_profile(request):
+    """Update a user's profile information.
 
     Args:
         request (HttpRequest)
 
     Returns:
-        HttpResponse: 204 if successful
-        HttpResponse: 302 if not logged in (redirect to login page)
-        HttpResponse: 400 if the provided name is invalid
-        HttpResponse: 405 if using an unsupported HTTP method
-        HttpResponse: 500 if an unexpected error occurs.
-
-    Example usage:
-
-        PUT /profile/name_change
+        HttpResponse
 
     """
     put = QueryDict(request.body)
 
     username = request.user.username
-    new_name = put.get('new_name')
+    new_name = put.get('fullName')
 
     if new_name is None:
-        return HttpResponseBadRequest("Missing param 'new_name'")
+        return HttpResponseBadRequest("Missing param 'fullName'")
 
     try:
         profile_api.update_profile(username, full_name=new_name)

--- a/lms/static/js/fixtures/student_profile/profile.underscore
+++ b/lms/static/js/fixtures/student_profile/profile.underscore
@@ -1,0 +1,1 @@
+../../../../templates/student_profile/profile.underscore

--- a/lms/static/js/spec/student_profile/profile.js
+++ b/lms/static/js/spec/student_profile/profile.js
@@ -1,0 +1,107 @@
+describe("edx.student.ProfileModel", function() {
+
+    var profile = null;
+
+    beforeEach(function() {
+        profile = new edx.student.profile.ProfileModel();
+    });
+
+    it("validates the full name field", function() {
+        // Full name cannot be blank
+        profile.set('fullName', '');
+        var errors = profile.validate(profile.attributes);
+        expect(errors).toEqual({
+            fullName: "Full name cannot be blank"
+        });
+
+        // Fill in the name and expect that the model is valid
+        profile.set('fullName', 'Bob');
+        errors = profile.validate(profile.attributes);
+        expect(errors).toBe(undefined);
+    });
+
+});
+
+describe("edx.student.ProfileView", function() {
+    var view = null;
+    var ajaxSuccess = true;
+
+    var updateProfile = function(fields) {
+        var fakeEvent = {preventDefault: function() {}};
+        view.model.set(fields);
+        view.submit(fakeEvent);
+    };
+
+    var assertAjax = function(url, method, data) {
+        expect($.ajax).toHaveBeenCalled();
+        var ajaxArgs = $.ajax.mostRecentCall.args[0];
+        expect(ajaxArgs.url).toEqual(url);
+        expect(ajaxArgs.type).toEqual(method);
+        expect(ajaxArgs.data).toEqual(data)
+        expect(ajaxArgs.headers.hasOwnProperty('X-CSRFToken')).toBe(true);
+    };
+
+    var assertSubmitStatus = function(success, expectedStatus) {
+        if (!success) {
+            expect(view.$submitStatus).toHaveClass('error');
+        }
+        else {
+            expect(view.$submitStatus).not.toHaveClass('error');
+        }
+        expect(view.$submitStatus.text()).toEqual(expectedStatus);
+    };
+
+    var assertValidationError = function(expectedError) {
+        if (expectedError === null) {
+            expect(view.$nameStatus).not.toHaveClass('validation-error');
+            expect(view.$nameStatus.text()).toEqual('');
+        }
+        else {
+            expect(view.$nameStatus).toHaveClass('validation-error');
+            expect(view.$nameStatus.text()).toEqual(expectedError);
+        }
+    };
+
+    beforeEach(function() {
+        var fixture = readFixtures('js/fixtures/student_profile/profile.underscore');
+        setFixtures('<div id="profile-tpl">' + fixture + '</div>');
+
+        view = new edx.student.profile.ProfileView().render();
+
+        // Stub AJAX calls to return success / failure
+        spyOn($, 'ajax').andCallFake(function() {
+            return $.Deferred(function(defer) {
+                if (ajaxSuccess) { defer.resolve(); }
+                else { defer.reject(); }
+            }).promise();
+        });
+    });
+
+    it("updates the student profile", function() {
+        updateProfile({ fullName: 'John Smith' });
+        assertAjax('/', 'PUT', { fullName: 'John Smith' });
+        assertSubmitStatus(true, "Saved");
+    });
+
+    it("displays validation errors", function() {
+        // Blank name should display a validation error
+        updateProfile({ fullName: '' });
+        assertValidationError("Full name cannot be blank");
+
+        // If we fix the problem and resubmit, the error should go away
+        updateProfile({ fullName: 'John Smith' });
+        assertValidationError(null);
+    });
+
+    it("displays an error if the sync fails", function() {
+        // If we get an error status on the AJAX request, display an error
+        ajaxSuccess = false;
+        updateProfile({ fullName: 'John Smith' });
+        assertSubmitStatus(false, 'The data could not be saved.');
+
+        // If we try again and succeed, the error should go away
+        ajaxSuccess = true;
+        updateProfile({ fullName: 'John Smith' });
+        assertSubmitStatus(true, 'Saved');
+    });
+});

--- a/lms/static/js_test.yml
+++ b/lms/static/js_test.yml
@@ -46,6 +46,8 @@ lib_paths:
     - xmodule_js/src/capa/
     - xmodule_js/src/video/
     - xmodule_js/src/xmodule.js
+    - xmodule_js/common_static/js/vendor/underscore-min.js
+    - xmodule_js/common_static/js/vendor/backbone-min.js
 
 # Paths to source JavaScript files
 src_paths:

--- a/lms/templates/student_profile/index.html
+++ b/lms/templates/student_profile/index.html
@@ -6,23 +6,24 @@
 <%block name="pagetitle">${_("Student Profile")}</%block>
 
 <%block name="js_extra">
+    <script type="text/javascript" src="${static.url('js/vendor/underscore-min.js')}"></script>
+    <script type="text/javascript" src="${static.url('js/vendor/backbone-min.js')}"></script>
     <%static:js group='student_profile'/>
+</%block>
+
+<%block name="header_extras">
+% for template_name in ["profile"]:
+<script type="text/template" id="${template_name}-tpl">
+  <%static:include path="student_profile/${template_name}.underscore" />
+</script>
+% endfor
 </%block>
 
 <h1>Student Profile</h1>
 
 <p>This is a placeholder for the student's profile page.</p>
 
-<form id="name-change-form">
-    <input type="hidden" name="csrfmiddlewaretoken" value="${csrf_token}">
-
-    <label for="new-name">${_('Full Name')}</label>
-    <input id="new-name" type="text" name="new-name" value="" placeholder="Xsy" />
-
-    <div class="submit-button">
-        <input type="submit" id="name-change-submit" value="${_('Change My Name')}">
-    </div>
-</form>
+<div id="profile-container" />
 
 % if settings.FEATURES.get('ENABLE_THIRD_PARTY_AUTH'):
     <%include file="third_party_auth.html" />

--- a/lms/templates/student_profile/profile.underscore
+++ b/lms/templates/student_profile/profile.underscore
@@ -1,0 +1,9 @@
+<form id="profile-form">
+    <label for="profile-name"><%- gettext('Full Name') %></label>
+    <input id="profile-name" type="text" name="profile-name" value="" placeholder="Xsy" />
+    <div id="profile-name-status" />
+    <div class="submit-button">
+        <input type="submit" id="profile-submit" value="<%- gettext('Update Profile') %>">
+    </div>
+    <div id="submit-status" />
+</form>


### PR DESCRIPTION
Changes:
- Validate student profile name field.
- Use Backbone for student profile JS.
- Use the same HTTP endpoint for both reading and updating profile info.

Reviewers: @AlasdairSwan @rlucioni 
FYI: @andy-armstrong 

[ECOM-409](https://openedx.atlassian.net/browse/ECOM-409)
