### PR TITLE
Consistently wrap the DataDog API to prevent logged errors & missing stats data

### DIFF
--- a/common/djangoapps/monitoring/signals.py
+++ b/common/djangoapps/monitoring/signals.py
@@ -10,7 +10,7 @@ the recorded metrics.
 from django.db.models.signals import post_save, post_delete, m2m_changed, post_init
 from django.dispatch import receiver
 
-from dogapi import dog_stats_api
+import dogstats_wrapper as dog_stats_api
 
 
 def _database_tags(action, sender, kwargs):

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -17,7 +17,7 @@ import logging
 from pytz import UTC
 import uuid
 from collections import defaultdict
-from dogapi import dog_stats_api
+import dogstats_wrapper as dog_stats_api
 from django.db.models import Q
 import pytz
 

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -78,7 +78,7 @@ from lang_pref import LANGUAGE_KEY
 
 import track.views
 
-from dogapi import dog_stats_api
+import dogstats_wrapper as dog_stats_api
 
 from util.db import commit_on_success_with_read_committed
 from util.json_request import JsonResponse

--- a/common/djangoapps/util/views.py
+++ b/common/djangoapps/util/views.py
@@ -9,7 +9,7 @@ from django.views.decorators.csrf import requires_csrf_token
 from django.views.defaults import server_error
 from django.http import (Http404, HttpResponse, HttpResponseNotAllowed,
                          HttpResponseServerError)
-from dogapi import dog_stats_api
+import dogstats_wrapper as dog_stats_api
 from edxmako.shortcuts import render_to_response
 import zendesk
 from microsite_configuration import microsite

--- a/common/lib/capa/capa/responsetypes.py
+++ b/common/lib/capa/capa/responsetypes.py
@@ -33,7 +33,7 @@ from sys import float_info
 from collections import namedtuple
 from shapely.geometry import Point, MultiPoint
 
-from dogapi import dog_stats_api
+import dogstats_wrapper as dog_stats_api
 
 # specific library imports
 from calc import evaluator, UndefinedVariable

--- a/common/lib/capa/capa/xqueue_interface.py
+++ b/common/lib/capa/capa/xqueue_interface.py
@@ -5,7 +5,7 @@ import hashlib
 import json
 import logging
 import requests
-from dogapi import dog_stats_api
+import dogstats_wrapper as dog_stats_api
 
 
 log = logging.getLogger(__name__)

--- a/common/lib/dogstats/dogstats_wrapper/__init__.py
+++ b/common/lib/dogstats/dogstats_wrapper/__init__.py
@@ -1,0 +1,1 @@
+from .wrapper import increment, histogram, timer

--- a/common/lib/dogstats/dogstats_wrapper/wrapper.py
+++ b/common/lib/dogstats/dogstats_wrapper/wrapper.py
@@ -1,0 +1,47 @@
+"""
+Wrapper for dog_stats_api, ensuring tags are valid.
+See: http://help.datadoghq.com/customer/portal/questions/908720-api-guidelines
+"""
+from dogapi import dog_stats_api
+
+
+def _clean_tags(tags):
+    """
+    Helper method that does the actual cleaning of tags for sending to statsd.
+    1. Handles any type of tag - a plain string, UTF-8 binary, or a unicode
+       string, and converts it to UTF-8 encoded bytestring needed by statsd.
+    2. Escape pipe character - used by statsd as a field separator.
+    3. Trim to 200 characters (DataDog API limitation)
+    """
+    def clean(tagstr):
+        if isinstance(tagstr, str):
+            return tagstr.replace('|', '_')[:200]
+        return unicode(tagstr).replace('|', '_')[:200].encode("utf-8")
+    return [clean(t) for t in tags]
+
+
+def increment(metric_name, *args, **kwargs):
+    """
+    Wrapper around dog_stats_api.increment that cleans any tags used.
+    """
+    if "tags" in kwargs:
+        kwargs["tags"] = _clean_tags(kwargs["tags"])
+    dog_stats_api.increment(metric_name, *args, **kwargs)
+
+
+def histogram(metric_name, *args, **kwargs):
+    """
+    Wrapper around dog_stats_api.histogram that cleans any tags used.
+    """
+    if "tags" in kwargs:
+        kwargs["tags"] = _clean_tags(kwargs["tags"])
+    dog_stats_api.histogram(metric_name, *args, **kwargs)
+
+
+def timer(metric_name, *args, **kwargs):
+    """
+    Wrapper around dog_stats_api.timer that cleans any tags used.
+    """
+    if "tags" in kwargs:
+        kwargs["tags"] = _clean_tags(kwargs["tags"])
+    return dog_stats_api.timer(metric_name, *args, **kwargs)

--- a/common/lib/dogstats/setup.py
+++ b/common/lib/dogstats/setup.py
@@ -1,0 +1,10 @@
+from setuptools import setup
+
+setup(
+    name="dogstats_wrapper",
+    version="0.1",
+    packages=["dogstats_wrapper"],
+    install_requires=[
+        "dogapi",
+    ],
+)

--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -12,7 +12,7 @@ import sys
 
 # We don't want to force a dependency on datadog, so make the import conditional
 try:
-    from dogapi import dog_stats_api
+    import dogstats_wrapper as dog_stats_api
 except ImportError:
     # pylint: disable=invalid-name
     dog_stats_api = None

--- a/common/lib/xmodule/xmodule/open_ended_grading_classes/controller_query_service.py
+++ b/common/lib/xmodule/xmodule/open_ended_grading_classes/controller_query_service.py
@@ -1,4 +1,4 @@
-from dogapi import dog_stats_api
+import dogstats_wrapper as dog_stats_api
 
 import logging
 from .grading_service_module import GradingService

--- a/common/lib/xmodule/xmodule/open_ended_grading_classes/grading_service_module.py
+++ b/common/lib/xmodule/xmodule/open_ended_grading_classes/grading_service_module.py
@@ -2,7 +2,7 @@
 import json
 import logging
 import requests
-from dogapi import dog_stats_api
+import dogstats_wrapper as dog_stats_api
 from requests.exceptions import RequestException, ConnectionError, HTTPError
 
 from .combined_open_ended_rubric import CombinedOpenEndedRubric, RubricParsingError

--- a/common/lib/xmodule/xmodule/open_ended_grading_classes/peer_grading_service.py
+++ b/common/lib/xmodule/xmodule/open_ended_grading_classes/peer_grading_service.py
@@ -1,5 +1,5 @@
 import logging
-from dogapi import dog_stats_api
+import dogstats_wrapper as dog_stats_api
 
 from .grading_service_module import GradingService
 from opaque_keys.edx.keys import UsageKey

--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -25,7 +25,7 @@ from xmodule.errortracker import exc_info_to_str
 from xmodule.modulestore.exceptions import ItemNotFoundError
 from opaque_keys.edx.keys import UsageKey
 from xmodule.exceptions import UndefinedContext
-from dogapi import dog_stats_api
+import dogstats_wrapper as dog_stats_api
 
 
 log = logging.getLogger(__name__)

--- a/lms/djangoapps/bulk_email/tasks.py
+++ b/lms/djangoapps/bulk_email/tasks.py
@@ -7,7 +7,7 @@ import random
 import json
 from time import sleep
 
-from dogapi import dog_stats_api
+import dogstats_wrapper as dog_stats_api
 from smtplib import SMTPServerDisconnected, SMTPDataError, SMTPConnectError, SMTPException
 from boto.ses.exceptions import (
     SESAddressNotVerifiedError,
@@ -690,7 +690,7 @@ def _submit_for_retry(entry_id, email_id, to_list, global_email_context, current
 
 def _statsd_tag(course_title):
     """
-    Calculate the tag we will use for DataDog.
+    Prefix the tag we will use for DataDog.
+    The tag also gets modified by our dogstats_wrapper code.
     """
-    tag = u"course_email:{0}".format(course_title).encode('utf-8')
-    return tag[:200]
+    return u"course_email:{0}".format(course_title)

--- a/lms/djangoapps/certificates/views.py
+++ b/lms/djangoapps/certificates/views.py
@@ -1,5 +1,5 @@
 """URL handlers related to certificate handling by LMS"""
-from dogapi import dog_stats_api
+import dogstats_wrapper as dog_stats_api
 import json
 import logging
 

--- a/lms/djangoapps/courseware/grades.py
+++ b/lms/djangoapps/courseware/grades.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from django.db import transaction
 from django.test.client import RequestFactory
 
-from dogapi import dog_stats_api
+import dogstats_wrapper as dog_stats_api
 
 from courseware import courses
 from courseware.model_data import FieldDataCache
@@ -522,7 +522,7 @@ def iterate_grades_for(course_id, students):
     request = RequestFactory().get('/')
 
     for student in students:
-        with dog_stats_api.timer('lms.grades.iterate_grades_for', tags=['action:{}'.format(course_id)]):
+        with dog_stats_api.timer('lms.grades.iterate_grades_for', tags=[u'action:{}'.format(course_id)]):
             try:
                 request.user = student
                 # Grading calls problem rendering, which calls masquerading,

--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -7,7 +7,7 @@ import xblock.reference.plugins
 
 from functools import partial
 from requests.auth import HTTPBasicAuth
-from dogapi import dog_stats_api
+import dogstats_wrapper as dog_stats_api
 from opaque_keys import InvalidKeyError
 
 from django.conf import settings

--- a/lms/djangoapps/instructor_task/subtasks.py
+++ b/lms/djangoapps/instructor_task/subtasks.py
@@ -10,7 +10,7 @@ from contextlib import contextmanager
 
 from celery.utils.log import get_task_logger
 from celery.states import SUCCESS, READY_STATES, RETRY
-from dogapi import dog_stats_api
+import dogstats_wrapper as dog_stats_api
 
 from django.db import transaction, DatabaseError
 from django.core.cache import cache
@@ -393,7 +393,7 @@ def check_subtask_is_valid(entry_id, current_task_id, new_subtask_status):
         format_str = "Unexpected task_id '{}': unable to find subtasks of instructor task '{}': rejecting task {}"
         msg = format_str.format(current_task_id, entry, new_subtask_status)
         TASK_LOG.warning(msg)
-        dog_stats_api.increment('instructor_task.subtask.duplicate.nosubtasks', tags=[_statsd_tag(entry.course_id)])
+        dog_stats_api.increment('instructor_task.subtask.duplicate.nosubtasks', tags=[entry.course_id])
         raise DuplicateTaskException(msg)
 
     # Confirm that the InstructorTask knows about this particular subtask.
@@ -403,7 +403,7 @@ def check_subtask_is_valid(entry_id, current_task_id, new_subtask_status):
         format_str = "Unexpected task_id '{}': unable to find status for subtask of instructor task '{}': rejecting task {}"
         msg = format_str.format(current_task_id, entry, new_subtask_status)
         TASK_LOG.warning(msg)
-        dog_stats_api.increment('instructor_task.subtask.duplicate.unknown', tags=[_statsd_tag(entry.course_id)])
+        dog_stats_api.increment('instructor_task.subtask.duplicate.unknown', tags=[entry.course_id])
         raise DuplicateTaskException(msg)
 
     # Confirm that the InstructorTask doesn't think that this subtask has already been
@@ -414,7 +414,7 @@ def check_subtask_is_valid(entry_id, current_task_id, new_subtask_status):
         format_str = "Unexpected task_id '{}': already completed - status {} for subtask of instructor task '{}': rejecting task {}"
         msg = format_str.format(current_task_id, subtask_status, entry, new_subtask_status)
         TASK_LOG.warning(msg)
-        dog_stats_api.increment('instructor_task.subtask.duplicate.completed', tags=[_statsd_tag(entry.course_id)])
+        dog_stats_api.increment('instructor_task.subtask.duplicate.completed', tags=[entry.course_id])
         raise DuplicateTaskException(msg)
 
     # Confirm that the InstructorTask doesn't think that this subtask is already being
@@ -428,7 +428,7 @@ def check_subtask_is_valid(entry_id, current_task_id, new_subtask_status):
             format_str = "Unexpected task_id '{}': already retried - status {} for subtask of instructor task '{}': rejecting task {}"
             msg = format_str.format(current_task_id, subtask_status, entry, new_subtask_status)
             TASK_LOG.warning(msg)
-            dog_stats_api.increment('instructor_task.subtask.duplicate.retried', tags=[_statsd_tag(entry.course_id)])
+            dog_stats_api.increment('instructor_task.subtask.duplicate.retried', tags=[entry.course_id])
             raise DuplicateTaskException(msg)
 
     # Now we are ready to start working on this.  Try to lock it.
@@ -438,7 +438,7 @@ def check_subtask_is_valid(entry_id, current_task_id, new_subtask_status):
         format_str = "Unexpected task_id '{}': already being executed - for subtask of instructor task '{}'"
         msg = format_str.format(current_task_id, entry)
         TASK_LOG.warning(msg)
-        dog_stats_api.increment('instructor_task.subtask.duplicate.locked', tags=[_statsd_tag(entry.course_id)])
+        dog_stats_api.increment('instructor_task.subtask.duplicate.locked', tags=[entry.course_id])
         raise DuplicateTaskException(msg)
 
 
@@ -570,11 +570,3 @@ def _update_subtask_status(entry_id, current_task_id, new_subtask_status):
     else:
         TASK_LOG.debug("about to commit....")
         transaction.commit()
-
-
-def _statsd_tag(course_id):
-    """
-    Calculate the tag we will use for DataDog.
-    """
-    tag = unicode(course_id).encode('utf-8')
-    return tag[:200]

--- a/lms/djangoapps/instructor_task/tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tasks_helper.py
@@ -13,7 +13,7 @@ from celery.utils.log import get_task_logger
 from celery.states import SUCCESS, FAILURE
 from django.contrib.auth.models import User
 from django.db import transaction, reset_queries
-from dogapi import dog_stats_api
+import dogstats_wrapper as dog_stats_api
 from pytz import UTC
 
 from xmodule.modulestore.django import modulestore
@@ -198,7 +198,7 @@ def run_main_task(entry_id, task_fcn, action_name):
         raise ValueError(message)
 
     # Now do the work:
-    with dog_stats_api.timer('instructor_tasks.time.overall', tags=['action:{name}'.format(name=action_name)]):
+    with dog_stats_api.timer('instructor_tasks.time.overall', tags=[u'action:{name}'.format(name=action_name)]):
         task_progress = task_fcn(entry_id, course_id, task_input, action_name)
 
     # Release any queries that the connection has been hanging onto:

--- a/lms/djangoapps/open_ended_grading/staff_grading_service.py
+++ b/lms/djangoapps/open_ended_grading/staff_grading_service.py
@@ -19,7 +19,7 @@ from edxmako.shortcuts import render_to_string
 from student.models import unique_id_for_user
 
 from open_ended_grading.utils import does_location_exist
-from dogapi import dog_stats_api
+import dogstats_wrapper as dog_stats_api
 
 log = logging.getLogger(__name__)
 

--- a/lms/lib/comment_client/utils.py
+++ b/lms/lib/comment_client/utils.py
@@ -1,5 +1,5 @@
 from contextlib import contextmanager
-from dogapi import dog_stats_api
+import dogstats_wrapper as dog_stats_api
 import logging
 import requests
 from django.conf import settings

--- a/requirements/edx/local.txt
+++ b/requirements/edx/local.txt
@@ -3,6 +3,7 @@
 -e common/lib/calc
 -e common/lib/capa
 -e common/lib/chem
+-e common/lib/dogstats
 -e common/lib/safe_lxml
 -e common/lib/sandbox-packages
 -e common/lib/symmath


### PR DESCRIPTION
**Background**: While working on #5386, I noticed these warnings in the logs:

```
   UnicodeEncodeError: 'ascii' codec can't encode character u'\u03a9' in position 61: ordinal not in range(128)
   stevedore.extension: DEBUG: found extension EntryPoint.parse('course-v1 = opaque_keys.edx.locator:CourseLocator')
   dd.dogapi: ERROR: couldnt submit statsd point
   Traceback (most recent call last):
     File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/dogapi/stats/statsd.py", line 29, in add_point
       self.socket_sendto(payload, self.address)
   UnicodeEncodeError: 'ascii' codec can't encode character u'\u03a9' in position 65: ordinal not in range(128)
```

**Discussion**: Apparently dog_stats_api cannot handle non-ASCII tags. In some parts of the codebase, such as `edx-platform/lms/djangoapps/bulk_email/tasks.py`, all calls to `dog_stats_api` are wrapped with `_statsd_tag()` which prevents these UnicodeErrors. But elsewhere in the codebase, `dog_stats_api` methods called with tags that are unicode strings, potentially causing UnicodeErrors and resulting in statistics being under-reported, should the tags contain any non-ASCII characters.

To fix this, I refactored the code so that _all_ calls to the DataDog API are wrapped. At the same time I added a couple other checks/cleanups to the wrapper method to ensure stats reporting is as robust as possible:
- Trim the tags to 200 characters while they are unicode strings, _then_ encode them as UTF-8. Doing it vice-versa as the previous `_statsd_tag()` method did can result in splitting multi-byte characters and thus corrupt strings.
- Replace `|` character if present, as statsd uses it as a field separator

I considered making this an upstream patch to the dogapi package but the simplest approach I found would break backwards compatibility, and not doing so would require a larger change (adding the `six` package etc.) as they support Python 2.7 and 3.x. Changing edx-platform is simpler.

**Affects**: Unknkown. Not likely to affect too many courses/instances at this time.

**How to reproduce**: Reverse the one-line fix to student/models.py made in #5386, then run the test that was part of that PR. Check over the detailed test failure log output. You will see the logged warnings quoted above.

**Urgency**: Low. Just a warning in the logs and at worst result in missing stats data.

**Authorship**: This is a contribution from OpenCraft.

**Partner information**: 3rd party-hosted open edX instance, for an edX solutions client (so will need to get some sort of solution merged in)

**Merge deadline**: Mon October 20 (soft requirement to minimize code drift, we may maintain it on the client fork in the meantime)
