### PR TITLE
Four Unicode fixes in discussion

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -177,3 +177,4 @@ Alasdair Swan <aswan@edx.org>
 Paul Medlock-Walton <paulmw@mit.edu>
 Henry Tareque <henry.tareque@gmail.com>
 Eugeny Kolpakov <eugeny.kolpakov@gmail.com>
+Omar Al-Ithawi <oithawi@qrf.org>

--- a/lms/lib/comment_client/thread.py
+++ b/lms/lib/comment_client/thread.py
@@ -90,9 +90,9 @@ class Thread(models.Model):
     @classmethod
     def url_for_threads(cls, params={}):
         if params.get('commentable_id'):
-            return "{prefix}/{commentable_id}/threads".format(prefix=settings.PREFIX, commentable_id=params['commentable_id'])
+            return u"{prefix}/{commentable_id}/threads".format(prefix=settings.PREFIX, commentable_id=params['commentable_id'])
         else:
-            return "{prefix}/threads".format(prefix=settings.PREFIX)
+            return u"{prefix}/threads".format(prefix=settings.PREFIX)
 
     @classmethod
     def url_for_search_threads(cls, params={}):

--- a/lms/lib/comment_client/utils.py
+++ b/lms/lib/comment_client/utils.py
@@ -40,8 +40,8 @@ def request_timer(request_id, method, url, tags=None):
     duration = end - start
 
     log.info(
-        "comment_client_request_log: request_id={request_id}, method={method}, "
-        "url={url}, duration={duration}".format(
+        u"comment_client_request_log: request_id={request_id}, method={method}, "
+        u"url={url}, duration={duration}".format(
             request_id=request_id,
             method=method,
             url=url,


### PR DESCRIPTION
While I've been working on edx/edx-platform#5309 and had roughly the following environment changes:
- `LANGAUGE: 'ar'`
- `PLATFORM_NAME: 'إدراك'` (Arabic/Unicode name)
- RTL layout (should be irrelevant)
- Possibly other Arabic/Unicode values all over the site

I've posted an Arabic thread, and it threw unicode encoding exceptions. Which I have solved by just adding `u` in front of four strings.
