### PR TITLE
Disable range requests in pdf.js (Not to be merged)

### DIFF
--- a/lms/djangoapps/staticbook/views.py
+++ b/lms/djangoapps/staticbook/views.py
@@ -106,7 +106,7 @@ def pdf_index(request, course_id, book_index, chapter=None, page=None):
         viewer_params += current_chapter['url']
         current_url = current_chapter['url']
 
-    viewer_params += '#zoom=page-fit'
+    viewer_params += '#zoom=page-fit&disableRange=true'
     if page is not None:
         viewer_params += '&amp;page={}'.format(page)
 

--- a/lms/templates/static_pdfbook.html
+++ b/lms/templates/static_pdfbook.html
@@ -18,7 +18,7 @@ $(function(){
     e.preventDefault();
     var url = $(this).attr('rel');
     $('#viewer-frame').attr({
-        'src': 'https://courses.edx.org${request.path}?viewer=true&file=' + url + '#zoom=page-fit',
+        'src': 'https://courses.edx.org${request.path}?viewer=true&file=' + url + '#zoom=page-fit&disableRange=true',
         'title': $(this).text()
         });
     $('#viewer-frame').focus();

--- a/lms/templates/static_pdfbook.html
+++ b/lms/templates/static_pdfbook.html
@@ -18,7 +18,7 @@ $(function(){
     e.preventDefault();
     var url = $(this).attr('rel');
     $('#viewer-frame').attr({
-        'src': '${request.path}?viewer=true&file=' + url + '#zoom=page-fit',
+        'src': 'https://courses.edx.org${request.path}?viewer=true&file=' + url + '#zoom=page-fit',
         'title': $(this).text()
         });
     $('#viewer-frame').focus();
@@ -44,7 +44,7 @@ $(function(){
 <iframe
   title="${current_chapter['title']|h}"
   id="viewer-frame"
-  src="${request.path}?viewer=true${viewer_params}"
+  src="https://courses.edx.org${request.path}?viewer=true${viewer_params}"
   width="856"
   height="1108"
   frameborder="0"


### PR DESCRIPTION
https://openedx.atlassian.net/browse/TNL-488

The first commit causes the pdfviewer to be loaded from courses.edx.org instead of from the current host. To test
1. Import a course into devstack while keeping the same id as on courses.edx.org.
2. Checkout first commit.
3. Try to replicate the issue.

To test the fix:
1. Checkout 2nd commit.
2. In Chrome goto Settings > Show advanced settings > Clear browsing data and delete 'Cached images and files' from the last month.
3. Try to replicate the issue.
