### PR TITLE
Tweak to old header styles to fix login button

### DIFF
--- a/lms/static/sass/shared/_header.scss
+++ b/lms/static/sass/shared/_header.scss
@@ -283,7 +283,7 @@ header.global {
     margin-top: ($baseline/4);
     list-style: none;
 
-    div {
+    li, div {
       display: inline-block;
 
       .cta {


### PR DESCRIPTION
@AlasdairSwan 
@talbs Quick look!

The old login button lost the cta button-style. This should fix it before the RC is cut today.

Attn: @nasthagiri  I'd like to get this in before an RC is cut, or cherry-pick it on.
