### PR TITLE
Kill DISABLE_RESET_EMAIL_TEST flag

### DIFF
--- a/cms/envs/test.py
+++ b/cms/envs/test.py
@@ -190,9 +190,6 @@ SEGMENT_IO_KEY = '***REMOVED***'
 
 FEATURES['ENABLE_SERVICE_STATUS'] = True
 
-# This is to disable a test under the common directory that will not pass when run under CMS
-FEATURES['DISABLE_RESET_EMAIL_TEST'] = True
-
 # Toggles embargo on for testing
 FEATURES['EMBARGO'] = True
 

--- a/common/djangoapps/student/tests/test_email.py
+++ b/common/djangoapps/student/tests/test_email.py
@@ -272,9 +272,7 @@ class EmailChangeConfirmationTests(EmailTestMixin, TransactionTestCase):
         self.check_confirm_email_change('email_exists.html', {})
         self.assertFailedBeforeEmailing(email_user)
 
-    @unittest.skipIf(settings.FEATURES.get('DISABLE_RESET_EMAIL_TEST', False),
-                         dedent("""Skipping Test because CMS has not provided necessary templates for email reset.
-                                If LMS tests print this message, that needs to be fixed."""))
+    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', "Test only valid in LMS")
     def test_old_email_fails(self, email_user):
         email_user.side_effect = [Exception, None]
         self.check_confirm_email_change('email_change_failed.html', {
@@ -283,9 +281,7 @@ class EmailChangeConfirmationTests(EmailTestMixin, TransactionTestCase):
         self.assertRolledBack()
         self.assertChangeEmailSent(email_user)
 
-    @unittest.skipIf(settings.FEATURES.get('DISABLE_RESET_EMAIL_TEST', False),
-                         dedent("""Skipping Test because CMS has not provided necessary templates for email reset.
-                                If LMS tests print this message, that needs to be fixed."""))
+    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', "Test only valid in LMS")
     def test_new_email_fails(self, email_user):
         email_user.side_effect = [None, Exception]
         self.check_confirm_email_change('email_change_failed.html', {
@@ -294,9 +290,7 @@ class EmailChangeConfirmationTests(EmailTestMixin, TransactionTestCase):
         self.assertRolledBack()
         self.assertChangeEmailSent(email_user)
 
-    @unittest.skipIf(settings.FEATURES.get('DISABLE_RESET_EMAIL_TEST', False),
-                         dedent("""Skipping Test because CMS has not provided necessary templates for email reset.
-                                If LMS tests print this message, that needs to be fixed."""))
+    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', "Test only valid in LMS")
     def test_successful_email_change(self, email_user):
         self.check_confirm_email_change('email_change_successful.html', {
             'old_email': self.user.email,

--- a/common/djangoapps/student/tests/test_reset_password.py
+++ b/common/djangoapps/student/tests/test_reset_password.py
@@ -15,7 +15,6 @@ from django.contrib.auth.tokens import default_token_generator
 from django.utils.http import int_to_base36
 
 from mock import Mock, patch
-from textwrap import dedent
 import ddt
 
 from student.views import password_reset, password_reset_confirm_wrapper
@@ -90,13 +89,7 @@ class ResetPasswordTests(TestCase):
 
         cache.clear()
 
-    @unittest.skipIf(
-        settings.FEATURES.get('DISABLE_RESET_EMAIL_TEST', False),
-        dedent("""
-            Skipping Test because CMS has not provided necessary templates for password reset.
-            If LMS tests print this message, that needs to be fixed.
-        """)
-    )
+    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', "Test only valid in LMS")
     @patch('django.core.mail.send_mail')
     @patch('student.views.render_to_string', Mock(side_effect=mock_render_to_string, autospec=True))
     def test_reset_password_email(self, send_email):
@@ -123,13 +116,7 @@ class ResetPasswordTests(TestCase):
         self.assertFalse(self.user.is_active)
         re.search(r'password_reset_confirm/(?P<uidb36>[0-9A-Za-z]+)-(?P<token>.+)/', msg).groupdict()
 
-    @unittest.skipIf(
-        settings.FEATURES.get('DISABLE_RESET_EMAIL_TEST', False),
-        dedent("""
-            Skipping Test because CMS has not provided necessary templates for password reset.
-            If LMS tests print this message, that needs to be fixed.
-        """)
-    )
+    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', "Test only valid in LMS")
     @patch('django.core.mail.send_mail')
     @ddt.data((False, 'http://'), (True, 'https://'))
     @ddt.unpack


### PR DESCRIPTION
We're better served by just directly testing if we're in the LMS or not.

This PR replaces #5456. @adampalay @benpatterson @feanil can you review?
