### PR TITLE
Do event tracking for major forum events.

### DIFF
--- a/common/djangoapps/student/tests/factories.py
+++ b/common/djangoapps/student/tests/factories.py
@@ -2,7 +2,7 @@
 from student.models import (User, UserProfile, Registration,
                             CourseEnrollmentAllowed, CourseEnrollment,
                             PendingEmailChange, UserStanding,
-                            )
+                            CourseAccessRole)
 from course_modes.models import CourseMode
 from django.contrib.auth.models import Group, AnonymousUser
 from datetime import datetime
@@ -111,6 +111,14 @@ class CourseEnrollmentFactory(DjangoModelFactory):
 
     user = factory.SubFactory(UserFactory)
     course_id = SlashSeparatedCourseKey('edX', 'toy', '2012_Fall')
+
+
+class CourseAccessRoleFactory(DjangoModelFactory):
+    FACTORY_FOR = CourseAccessRole
+
+    user = factory.SubFactory(UserFactory)
+    course_id = SlashSeparatedCourseKey('edX', 'toy', '2012_Fall')
+    role = 'TestRole'
 
 
 class CourseEnrollmentAllowedFactory(DjangoModelFactory):

--- a/common/test/acceptance/fixtures/discussion.py
+++ b/common/test/acceptance/fixtures/discussion.py
@@ -44,7 +44,7 @@ class Thread(ContentFactory):
 
 
 class Comment(ContentFactory):
-    thread_id = None
+    thread_id = "dummy thread"
     depth = 0
     type = "comment"
     body = "dummy comment body"

--- a/lms/djangoapps/django_comment_client/utils.py
+++ b/lms/djangoapps/django_comment_client/utils.py
@@ -383,11 +383,12 @@ def extend_content(content):
     return merge_dict(content, content_info)
 
 
-def add_courseware_context(content_list, course, user):
+def add_courseware_context(content_list, course, user, id_map=None):
     """
     Decorates `content_list` with courseware metadata.
     """
-    id_map = get_discussion_id_map(course, user)
+    if id_map is None:
+        id_map = get_discussion_id_map(course, user)
 
     for content in content_list:
         commentable_id = content['commentable_id']


### PR DESCRIPTION
This PR is intended to supersede #4840 . Please close that one and continue the discussion here.

This PR is a WIP because the specification provided at https://openedx.atlassian.net/wiki/pages/viewpage.action?spaceKey=AN&title=Forum+Events has left me with a few questions, and I'm not sure that this implementation conforms entirely to the vision of what was stated. Most of it has been implemented.

The tests are also currently failing because tests which test the comment functionality did not anticipate the thread ID needing to be accessed, but these events now require it, so those tests will need patching to permit this. I also added a few new tests which will need similar fixing. But I'd rather start getting feedback now.

A few issues:
1. How would one get the category id and name? I'm not really sure what these are to begin with, as I don't see them as fields on the comments.
2. How would one get the origin? It doesn't seem like there's a sane way to do that at the moment. Would there need to be modification to the existing views to post the enum value we want? Would there be any values other than 'courseware' and 'forum'?
3. Some of the keys in the spec appear oddly inconsistent, though I may be missing something. For example: 'discussion.id' vs 'category_id'.

Feedback would be appreciated. Thank you.
- Partner information: 3rd party-hosted open edX instance, for an edX solutions client (so will need to get some sort of solution merged in)
- Merge deadline: Oct 22nd (soft requirement to minimize code drift, we maintain it on the client fork in the meantime)

Ping @sarina 
