### PR TITLE
Revert hack for tinymce.

### DIFF
--- a/lms/templates/courseware/instructor_dashboard.html
+++ b/lms/templates/courseware/instructor_dashboard.html
@@ -17,13 +17,6 @@
 <%static:css group='style-vendor-tinymce-skin'/>
 <%static:css group='style-course'/>
 
-  <script type="text/javascript">
-    // This is a hack to get tinymce to work correctly in Firefox until the annotator tool is refactored to not include
-    // tinymce globally.
-    if(typeof window.Range.prototype === "undefined") {
-        window.Range.prototype = { };
-    }
-  </script>
   <script type="text/javascript" src="${static.url('js/vendor/flot/jquery.flot.js')}"></script>
   <script type="text/javascript" src="${static.url('js/vendor/flot/jquery.flot.axislabels.js')}"></script>
   <script type="text/javascript" src="${static.url('js/vendor/jquery-jvectormap-1.1.1/jquery-jvectormap-1.1.1.min.js')}"></script>

--- a/lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html
+++ b/lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html
@@ -25,13 +25,6 @@
   <%static:css group='style-vendor-tinymce-content'/>
   <%static:css group='style-vendor-tinymce-skin'/>
   <%static:css group='style-course'/>
-  <script type="text/javascript">
-    // This is a hack to get tinymce to work correctly in Firefox until the annotator tool is refactored to not include
-    // tinymce globally.
-    if(typeof window.Range.prototype === "undefined") {
-        window.Range.prototype = { };
-    }
-  </script>
   <script type="text/javascript" src="${static.url('js/vendor/backbone-min.js')}"></script>
   <script type="text/javascript" src="${static.url('js/vendor/mustache.js')}"></script>
   <script type="text/javascript" src="${static.url('js/vendor/flot/jquery.flot.js')}"></script>


### PR DESCRIPTION
This was needed because the globally included tinymce.js was causing
bulk email editor to not work properly. Tinymce.js is no longer
included globally so this is not longer needed.

TNL-374
