### PR TITLE
(WIP) RTL Sass compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,10 +73,14 @@ lms/static/sass/*.css.map
 lms/static/sass/application.scss
 lms/static/sass/application-extend1.scss
 lms/static/sass/application-extend2.scss
+lms/static/sass/base/_variables.scss
 lms/static/sass/course.scss
 cms/static/css/
 cms/static/sass/*.css
 cms/static/sass/*.css.map
+
+###Generated RTL assets
+sass-rtl
 
 ### Logging artifacts
 log/

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -297,6 +297,9 @@ FEATURES = {
 
     # Enable the new dashboard, account, and profile pages
     'ENABLE_NEW_DASHBOARD': False,
+
+    # Enable RTL compilation and layout switching based on the user's preferred language
+    'ENABLE_RTL': False,
 }
 
 # Ignore static asset files on import which match this pattern

--- a/lms/static/sass/base/_variables.scss.mako
+++ b/lms/static/sass/base/_variables.scss.mako
@@ -2,7 +2,11 @@
 
 // setting the layout to handle right to left languages
 // false= lang direction left to right (eg. english); true = rtl (eg. arabic)
-$rtl: false;
+% if env.get("RTL", False):
+  $rtl: true;
+%else:
+  $rtl: false;
+%endif
 
 
 // base


### PR DESCRIPTION
Hi @nedbat and @frrrances,

I'm trying in this PR to load the correct layout direction (RTL or LTR) for the users based on their language preference. This is based on @frrrances RTL work #2682. See my [original comment](https://github.com/edx/edx-platform/pull/5309#issuecomment-56484498) for more info.

**Done:**
- Compile two versions of the Sass into two directories `sass` and `sass-rtl`.
- `ENABLE_RTL` feature to turn on and off the compilation. This should save compilation time for LTR only platforms setups.

**TODO's:**
- Create a new Pipeline finder to load the correct compiled CSS files

Please tell me what do you think?
