### PR TITLE
Use language API to return JSON of released languages

### DIFF
--- a/lms/djangoapps/student_profile/test/test_views.py
+++ b/lms/djangoapps/student_profile/test/test_views.py
@@ -2,6 +2,7 @@
 """ Tests for student profile views. """
 
 from urllib import urlencode
+import json
 
 from mock import patch
 import ddt
@@ -76,6 +77,16 @@ class StudentProfileViewTest(UrlResetMixin, TestCase):
         mock_update_profile.side_effect = profile_api.ProfileUserNotFound
         response = self._change_name(self.FULL_NAME)
         self.assertEqual(response.status_code, 500)
+
+    @patch('student_profile.views.language_api.released_languages')
+    def test_get_released_languages(self, mock_released_languages):
+        mock_released_languages.return_value = [self.NEW_LANGUAGE]
+
+        response = self.client.get(reverse('released_languages'))
+        self.assertEqual(
+            json.loads(response.content),
+            [{'code': self.NEW_LANGUAGE.code, 'name': self.NEW_LANGUAGE.name}]
+        )
 
     @patch('student_profile.views.language_api.released_languages')
     def test_language_change(self, mock_released_languages):

--- a/lms/djangoapps/student_profile/urls.py
+++ b/lms/djangoapps/student_profile/urls.py
@@ -4,4 +4,5 @@ urlpatterns = patterns(
     'student_profile.views',
     url(r'^$', 'index', name='profile_index'),
     url(r'^language_change$', 'language_change_handler', name='language_change'),
+    url(r'^language/released$', 'get_released_languages', name='released_languages'),
 )

--- a/lms/djangoapps/student_profile/views.py
+++ b/lms/djangoapps/student_profile/views.py
@@ -1,5 +1,7 @@
 """ Views for a student's profile information. """
 
+import json
+
 from django.http import (
     QueryDict, HttpResponse,
     HttpResponseBadRequest, HttpResponseServerError
@@ -93,6 +95,31 @@ def _update_profile(request):
     # A 204 is intended to allow input for actions to take place
     # without causing a change to the user agent's active document view.
     return HttpResponse(status=204)
+
+
+@login_required
+@require_http_methods(['GET'])
+def get_released_languages(request):
+    """Convert the list of released languages to JSON.
+
+    Args:
+        request (HttpRequest)
+
+    Returns:
+        HttpResponse: 200 if successful on GET
+        HttpResponse: 302 if not logged in (redirect to login page)
+        HttpResponse: 405 if using an unsupported HTTP method
+        HttpResponse: 500 if an unexpected error occurs
+
+    Example:
+
+        GET /profile/language/released
+
+    """
+    languages = language_api.released_languages()
+    response_data = [{'code': language.code, 'name': language.name} for language in languages]
+
+    return HttpResponse(json.dumps(response_data), content_type='application/json')
 
 
 @login_required


### PR DESCRIPTION
This layers a view on top of the language API which allows us to get the list of released languages as JSON with a GET to `/profile/language/released`. @dianakhuang, FYI.
