### PR TITLE
Make notifier API resilient to bad enrollments

### DIFF
--- a/lms/djangoapps/notifier_api/tests.py
+++ b/lms/djangoapps/notifier_api/tests.py
@@ -10,6 +10,7 @@ from django_comment_common.models import Role, Permission
 from lang_pref import LANGUAGE_KEY
 from notification_prefs import NOTIFICATION_PREF_KEY
 from notifier_api.views import NotifierUsersViewSet
+from opaque_keys.edx.locator import CourseLocator
 from student.models import CourseEnrollment
 from student.tests.factories import UserFactory, CourseEnrollmentFactory
 from user_api.models import UserPreference
@@ -121,7 +122,10 @@ class NotifierUsersViewSetTest(UrlResetMixin, ModuleStoreTestCase):
         self.assertEqual(result["course_info"], {})
 
     def test_course_info_non_existent_course_enrollment(self):
-        CourseEnrollmentFactory(user=self.user)
+        CourseEnrollmentFactory(
+            user=self.user,
+            course_id=CourseLocator(org="dummy", course="dummy", run="non_existent")
+        )
         result = self._get_detail()
         self.assertEqual(result["course_info"], {})
 

--- a/lms/djangoapps/notifier_api/tests.py
+++ b/lms/djangoapps/notifier_api/tests.py
@@ -120,6 +120,11 @@ class NotifierUsersViewSetTest(UrlResetMixin, ModuleStoreTestCase):
         result = self._get_detail()
         self.assertEqual(result["course_info"], {})
 
+    def test_course_info_non_existent_course_enrollment(self):
+        CourseEnrollmentFactory(user=self.user)
+        result = self._get_detail()
+        self.assertEqual(result["course_info"], {})
+
     def test_preferences(self):
         lang_pref = UserPreferenceFactory(
             user=self.user,


### PR DESCRIPTION
Previously, the user endpoint would would return 404 for any request
involving a user having an enrollment for a course that no longer
existed.

@jimabramson @nasthagiri 
