### PR TITLE
Don't show cohort information when disabled

### DIFF
--- a/common/test/acceptance/tests/discussion/helpers.py
+++ b/common/test/acceptance/tests/discussion/helpers.py
@@ -30,6 +30,7 @@ class BaseDiscussionMixin(object):
             thread_fixture.addResponse(Response(id=str(i), body=str(i)))
         thread_fixture.push()
         self.setup_thread_page(thread_id)
+        return thread_id
 
 
 class CohortTestMixin(object):
@@ -46,7 +47,19 @@ class CohortTestMixin(object):
                 u"cohort_config": {
                     "auto_cohort_groups": auto_cohort_groups or [],
                     "cohorted_discussions": [],
-                    "cohorted": True
+                    "cohorted": True,
+                },
+            },
+        })
+
+    def disable_cohorting(self, course_fixture):
+        """
+        Disables cohorting for the current course fixture.
+        """
+        course_fixture._update_xblock(course_fixture._course_location, {
+            "metadata": {
+                u"cohort_config": {
+                    "cohorted": False
                 },
             },
         })

--- a/common/test/acceptance/tests/discussion/test_cohorts.py
+++ b/common/test/acceptance/tests/discussion/test_cohorts.py
@@ -73,6 +73,7 @@ class DiscussionTabSingleThreadTest(UniqueCourseTest):
         self.thread_page = DiscussionTabSingleThreadPage(self.browser, self.course_id, thread_id)  # pylint:disable=W0201
         self.thread_page.visit()
 
+    # pylint:disable=W0613
     def refresh_thread_page(self, thread_id):
         self.browser.refresh()
         self.thread_page.wait_for_page()

--- a/lms/djangoapps/django_comment_client/utils.py
+++ b/lms/djangoapps/django_comment_client/utils.py
@@ -394,7 +394,6 @@ def prepare_content(content, course_key, is_staff=False):
     @TODO: not all response pre-processing steps are currently integrated into
     this function.
     """
-
     fields = [
         'id', 'title', 'body', 'course_id', 'anonymous', 'anonymous_to_peers',
         'endorsed', 'parent_id', 'thread_id', 'votes', 'closed', 'created_at',


### PR DESCRIPTION
TNL-552

@cahrens and I decided that it would be cleaner to have the server return responses as if cohorting had never been enabled, rather than to teach the front end how to ignore the cohort fields.

Reviewers: @cahrens @jimabramson 
