### PR TITLE
Add donation button to the enrollment success message

### DIFF
--- a/common/djangoapps/config_models/decorators.py
+++ b/common/djangoapps/config_models/decorators.py
@@ -1,0 +1,26 @@
+"""Decorators for model-based configuration. """
+from functools import wraps
+from django.http import HttpResponseNotFound
+
+
+def require_config(config_model):
+    """View decorator that enables/disables a view based on configuration.
+
+    Arguments:
+        config_model (ConfigurationModel subclass): The class of the configuration
+            model to check.
+
+    Returns:
+        HttpResponse: 404 if the configuration model is disabled,
+            otherwise returns the response from the decorated view.
+
+    """
+    def _decorator(func):
+        @wraps(func)
+        def _inner(*args, **kwargs):
+            if not config_model.current().enabled:
+                return HttpResponseNotFound()
+            else:
+                return func(*args, **kwargs)
+        return _inner
+    return _decorator

--- a/common/djangoapps/course_modes/models.py
+++ b/common/djangoapps/course_modes/models.py
@@ -59,6 +59,9 @@ class CourseMode(models.Model):
     DEFAULT_MODE = Mode('honor', _('Honor Code Certificate'), 0, '', 'usd', None, None)
     DEFAULT_MODE_SLUG = 'honor'
 
+    # Modes that allow a student to pursue a verified certificate
+    VERIFIED_MODES = ["verified", "professional"]
+
     class Meta:
         """ meta attributes of this model """
         unique_together = ('course_id', 'mode_slug', 'currency')
@@ -126,6 +129,22 @@ class CourseMode(models.Model):
         professional_mode = modes_dict.get('professional', None)
         # we prefer professional over verify
         return professional_mode if professional_mode else verified_mode
+
+    @classmethod
+    def has_verified_mode(cls, course_mode_dict):
+        """Check whether the modes for a course allow a student to pursue a verfied certificate.
+
+        Args:
+            course_mode_dict (dictionary mapping course mode slugs to Modes)
+
+        Returns:
+            bool: True iff the course modes contain a verified track.
+
+        """
+        for mode in cls.VERIFIED_MODES:
+            if mode in course_mode_dict:
+                return True
+        return False
 
     @classmethod
     def min_course_price_for_verified_for_currency(cls, course_id, currency):

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -412,7 +412,7 @@ def register_user(request, extra_context=None):
     return render_to_response('register.html', context)
 
 
-def complete_course_mode_info(course_id, enrollment):
+def complete_course_mode_info(course_id, enrollment, modes=None):
     """
     We would like to compute some more information from the given course modes
     and the user's current enrollment
@@ -421,7 +421,9 @@ def complete_course_mode_info(course_id, enrollment):
         - whether to show the course upsell information
         - numbers of days until they can't upsell anymore
     """
-    modes = CourseMode.modes_for_course_dict(course_id)
+    if modes is None:
+        modes = CourseMode.modes_for_course_dict(course_id)
+
     mode_info = {'show_upsell': False, 'days_for_upsell': None}
     # we want to know if the user is already verified and if verified is an
     # option
@@ -472,9 +474,17 @@ def dashboard(request):
     # enrollments, because it could have been a data push snafu.
     course_enrollment_pairs = list(get_course_enrollment_pairs(user, course_org_filter, org_filter_out_set))
 
-    # Check to see if the student has recently enrolled in a course. If so, display a notification message confirming
-    # the enrollment.
-    enrollment_message = _create_recent_enrollment_message(course_enrollment_pairs)
+    # Retrieve the course modes for each course
+    course_modes_by_course = {
+        course.id: CourseMode.modes_for_course_dict(course.id)
+        for course, __ in course_enrollment_pairs
+    }
+
+    # Check to see if the student has recently enrolled in a course.
+    # If so, display a notification message confirming the enrollment.
+    enrollment_message = _create_recent_enrollment_message(
+        course_enrollment_pairs, course_modes_by_course
+    )
 
     course_optouts = Optout.objects.filter(user=user).values_list('course_id', flat=True)
 
@@ -496,8 +506,21 @@ def dashboard(request):
     show_courseware_links_for = frozenset(course.id for course, _enrollment in course_enrollment_pairs
                                           if has_access(request.user, 'load', course))
 
-    course_modes = {course.id: complete_course_mode_info(course.id, enrollment) for course, enrollment in course_enrollment_pairs}
-    cert_statuses = {course.id: cert_info(request.user, course) for course, _enrollment in course_enrollment_pairs}
+    # Construct a dictionary of course mode information
+    # used to render the course list.  We re-use the course modes dict
+    # we loaded earlier to avoid hitting the database.
+    course_mode_info = {
+        course.id: complete_course_mode_info(
+            course.id, enrollment,
+            modes=course_modes_by_course[course.id]
+        )
+        for course, enrollment in course_enrollment_pairs
+    }
+
+    cert_statuses = {
+        course.id: cert_info(request.user, course)
+        for course, _enrollment in course_enrollment_pairs
+    }
 
     # only show email settings for Mongo course and when bulk email is turned on
     show_email_settings_for = frozenset(
@@ -567,7 +590,7 @@ def dashboard(request):
         'staff_access': staff_access,
         'errored_courses': errored_courses,
         'show_courseware_links_for': show_courseware_links_for,
-        'all_course_modes': course_modes,
+        'all_course_modes': course_mode_info,
         'cert_statuses': cert_statuses,
         'show_email_settings_for': show_email_settings_for,
         'reverifications': reverifications,
@@ -595,23 +618,35 @@ def dashboard(request):
     return render_to_response('dashboard.html', context)
 
 
-def _create_recent_enrollment_message(course_enrollment_pairs):
+def _create_recent_enrollment_message(course_enrollment_pairs, course_modes):
     """Builds a recent course enrollment message
 
     Constructs a new message template based on any recent course enrollments for the student.
 
     Args:
         course_enrollment_pairs (list): A list of tuples containing courses, and the associated enrollment information.
+        course_modes (dict): Mapping of course ID's to course mode dictionaries.
 
     Returns:
         A string representing the HTML message output from the message template.
+        None if there are no recently enrolled courses.
 
     """
-    recent_course_enrollment_pairs = _get_recently_enrolled_courses(course_enrollment_pairs)
-    if recent_course_enrollment_pairs:
+    recently_enrolled_courses = _get_recently_enrolled_courses(course_enrollment_pairs)
+
+    if recently_enrolled_courses:
+        messages = [
+            {
+                "course_id": course.id,
+                "course_name": course.display_name,
+                "allow_donation": not CourseMode.has_verified_mode(course_modes[course.id])
+            }
+            for course in recently_enrolled_courses
+        ]
+
         return render_to_string(
             'enrollment/course_enrollment_message.html',
-            {'recent_course_enrollment_pairs': recent_course_enrollment_pairs,}
+            {'course_enrollment_messages': messages}
         )
 
 
@@ -624,14 +659,14 @@ def _get_recently_enrolled_courses(course_enrollment_pairs):
         course_enrollment_pairs (list): A list of tuples containing courses, and the associated enrollment information.
 
     Returns:
-        A list of tuples for the course and enrollment.
+        A list of courses
 
     """
     seconds = DashboardConfiguration.current().recent_enrollment_time_delta
     sorted_list = sorted(course_enrollment_pairs, key=lambda created: created[1].created, reverse=True)
     time_delta = (datetime.datetime.now(UTC) - datetime.timedelta(seconds=seconds))
     return [
-        (course, enrollment) for course, enrollment in sorted_list
+        course for course, enrollment in sorted_list
         # If the enrollment has no created date, we are explicitly excluding the course
         # from the list of recent enrollments.
         if enrollment.is_active and enrollment.created > time_delta

--- a/lms/djangoapps/shoppingcart/admin.py
+++ b/lms/djangoapps/shoppingcart/admin.py
@@ -2,7 +2,9 @@
 Allows django admin site to add PaidCourseRegistrationAnnotations
 """
 from ratelimitbackend import admin
-from shoppingcart.models import PaidCourseRegistrationAnnotation, Coupon
+from shoppingcart.models import (
+    PaidCourseRegistrationAnnotation, Coupon, DonationConfiguration
+)
 
 
 class SoftDeleteCouponAdmin(admin.ModelAdmin):
@@ -49,3 +51,4 @@ class SoftDeleteCouponAdmin(admin.ModelAdmin):
 
 admin.site.register(PaidCourseRegistrationAnnotation)
 admin.site.register(Coupon, SoftDeleteCouponAdmin)
+admin.site.register(DonationConfiguration)

--- a/lms/djangoapps/shoppingcart/migrations/0019_auto__add_donationconfiguration.py
+++ b/lms/djangoapps/shoppingcart/migrations/0019_auto__add_donationconfiguration.py
@@ -1,0 +1,199 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'DonationConfiguration'
+        db.create_table('shoppingcart_donationconfiguration', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('change_date', self.gf('django.db.models.fields.DateTimeField')(auto_now_add=True, blank=True)),
+            ('changed_by', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['auth.User'], null=True, on_delete=models.PROTECT)),
+            ('enabled', self.gf('django.db.models.fields.BooleanField')(default=False)),
+        ))
+        db.send_create_signal('shoppingcart', ['DonationConfiguration'])
+
+
+    def backwards(self, orm):
+        # Deleting model 'DonationConfiguration'
+        db.delete_table('shoppingcart_donationconfiguration')
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'shoppingcart.certificateitem': {
+            'Meta': {'object_name': 'CertificateItem', '_ormbases': ['shoppingcart.OrderItem']},
+            'course_enrollment': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['student.CourseEnrollment']"}),
+            'course_id': ('xmodule_django.models.CourseKeyField', [], {'max_length': '128', 'db_index': 'True'}),
+            'mode': ('django.db.models.fields.SlugField', [], {'max_length': '50'}),
+            'orderitem_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['shoppingcart.OrderItem']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'shoppingcart.coupon': {
+            'Meta': {'object_name': 'Coupon'},
+            'code': ('django.db.models.fields.CharField', [], {'max_length': '32', 'db_index': 'True'}),
+            'course_id': ('xmodule_django.models.CourseKeyField', [], {'max_length': '255'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(2014, 10, 3, 0, 0)'}),
+            'created_by': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'percentage_discount': ('django.db.models.fields.IntegerField', [], {'default': '0'})
+        },
+        'shoppingcart.couponredemption': {
+            'Meta': {'object_name': 'CouponRedemption'},
+            'coupon': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['shoppingcart.Coupon']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'order': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['shoppingcart.Order']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"})
+        },
+        'shoppingcart.courseregistrationcode': {
+            'Meta': {'object_name': 'CourseRegistrationCode'},
+            'code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '32', 'db_index': 'True'}),
+            'course_id': ('xmodule_django.models.CourseKeyField', [], {'max_length': '255', 'db_index': 'True'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(2014, 10, 3, 0, 0)'}),
+            'created_by': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'created_by_user'", 'to': "orm['auth.User']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'invoice': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['shoppingcart.Invoice']", 'null': 'True'}),
+            'order': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'purchase_order'", 'null': 'True', 'to': "orm['shoppingcart.Order']"})
+        },
+        'shoppingcart.donation': {
+            'Meta': {'object_name': 'Donation', '_ormbases': ['shoppingcart.OrderItem']},
+            'course_id': ('xmodule_django.models.CourseKeyField', [], {'max_length': '255', 'db_index': 'True'}),
+            'donation_type': ('django.db.models.fields.CharField', [], {'default': "'general'", 'max_length': '32'}),
+            'orderitem_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['shoppingcart.OrderItem']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'shoppingcart.donationconfiguration': {
+            'Meta': {'object_name': 'DonationConfiguration'},
+            'change_date': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'changed_by': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']", 'null': 'True', 'on_delete': 'models.PROTECT'}),
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'shoppingcart.invoice': {
+            'Meta': {'object_name': 'Invoice'},
+            'address_line_1': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'address_line_2': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True'}),
+            'address_line_3': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True'}),
+            'company_contact_email': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'company_contact_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'company_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'country': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True'}),
+            'course_id': ('xmodule_django.models.CourseKeyField', [], {'max_length': '255', 'db_index': 'True'}),
+            'customer_reference_number': ('django.db.models.fields.CharField', [], {'max_length': '63', 'null': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'internal_reference': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True'}),
+            'is_valid': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'recipient_email': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'recipient_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True'}),
+            'total_amount': ('django.db.models.fields.FloatField', [], {}),
+            'zip': ('django.db.models.fields.CharField', [], {'max_length': '15', 'null': 'True'})
+        },
+        'shoppingcart.order': {
+            'Meta': {'object_name': 'Order'},
+            'bill_to_cardtype': ('django.db.models.fields.CharField', [], {'max_length': '32', 'blank': 'True'}),
+            'bill_to_ccnum': ('django.db.models.fields.CharField', [], {'max_length': '8', 'blank': 'True'}),
+            'bill_to_city': ('django.db.models.fields.CharField', [], {'max_length': '64', 'blank': 'True'}),
+            'bill_to_country': ('django.db.models.fields.CharField', [], {'max_length': '64', 'blank': 'True'}),
+            'bill_to_first': ('django.db.models.fields.CharField', [], {'max_length': '64', 'blank': 'True'}),
+            'bill_to_last': ('django.db.models.fields.CharField', [], {'max_length': '64', 'blank': 'True'}),
+            'bill_to_postalcode': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'bill_to_state': ('django.db.models.fields.CharField', [], {'max_length': '8', 'blank': 'True'}),
+            'bill_to_street1': ('django.db.models.fields.CharField', [], {'max_length': '128', 'blank': 'True'}),
+            'bill_to_street2': ('django.db.models.fields.CharField', [], {'max_length': '128', 'blank': 'True'}),
+            'currency': ('django.db.models.fields.CharField', [], {'default': "'usd'", 'max_length': '8'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'processor_reply_dump': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'purchase_time': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'refunded_time': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'cart'", 'max_length': '32'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"})
+        },
+        'shoppingcart.orderitem': {
+            'Meta': {'object_name': 'OrderItem'},
+            'currency': ('django.db.models.fields.CharField', [], {'default': "'usd'", 'max_length': '8'}),
+            'fulfilled_time': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'line_desc': ('django.db.models.fields.CharField', [], {'default': "'Misc. Item'", 'max_length': '1024'}),
+            'list_price': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '30', 'decimal_places': '2'}),
+            'order': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['shoppingcart.Order']"}),
+            'qty': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'refund_requested_time': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'db_index': 'True'}),
+            'report_comments': ('django.db.models.fields.TextField', [], {'default': "''"}),
+            'service_fee': ('django.db.models.fields.DecimalField', [], {'default': '0.0', 'max_digits': '30', 'decimal_places': '2'}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'cart'", 'max_length': '32', 'db_index': 'True'}),
+            'unit_cost': ('django.db.models.fields.DecimalField', [], {'default': '0.0', 'max_digits': '30', 'decimal_places': '2'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"})
+        },
+        'shoppingcart.paidcourseregistration': {
+            'Meta': {'object_name': 'PaidCourseRegistration', '_ormbases': ['shoppingcart.OrderItem']},
+            'course_id': ('xmodule_django.models.CourseKeyField', [], {'max_length': '128', 'db_index': 'True'}),
+            'mode': ('django.db.models.fields.SlugField', [], {'default': "'honor'", 'max_length': '50'}),
+            'orderitem_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['shoppingcart.OrderItem']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'shoppingcart.paidcourseregistrationannotation': {
+            'Meta': {'object_name': 'PaidCourseRegistrationAnnotation'},
+            'annotation': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'course_id': ('xmodule_django.models.CourseKeyField', [], {'unique': 'True', 'max_length': '128', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'shoppingcart.registrationcoderedemption': {
+            'Meta': {'object_name': 'RegistrationCodeRedemption'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'order': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['shoppingcart.Order']", 'null': 'True'}),
+            'redeemed_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(2014, 10, 3, 0, 0)', 'null': 'True'}),
+            'redeemed_by': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"}),
+            'registration_code': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['shoppingcart.CourseRegistrationCode']"})
+        },
+        'student.courseenrollment': {
+            'Meta': {'ordering': "('user', 'course_id')", 'unique_together': "(('user', 'course_id'),)", 'object_name': 'CourseEnrollment'},
+            'course_id': ('xmodule_django.models.CourseKeyField', [], {'max_length': '255', 'db_index': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'null': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'mode': ('django.db.models.fields.CharField', [], {'default': "'honor'", 'max_length': '100'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"})
+        }
+    }
+
+    complete_apps = ['shoppingcart']

--- a/lms/djangoapps/shoppingcart/models.py
+++ b/lms/djangoapps/shoppingcart/models.py
@@ -22,6 +22,7 @@ from model_utils.managers import InheritanceManager
 
 from xmodule.modulestore.django import modulestore
 
+from config_models.models import ConfigurationModel
 from course_modes.models import CourseMode
 from edxmako.shortcuts import render_to_string
 from student.models import CourseEnrollment, UNENROLL_DONE
@@ -870,6 +871,11 @@ class CertificateItem(OrderItem):
                 unit_cost__gt=(CourseMode.min_course_price_for_verified_for_currency(course_id, 'usd')))).count()
 
 
+class DonationConfiguration(ConfigurationModel):
+    """Configure whether donations are enabled on the site."""
+    pass
+
+
 class Donation(OrderItem):
     """A donation made by a user.
 
@@ -984,7 +990,7 @@ class Donation(OrderItem):
             course_id (CourseKey)
 
         Raises:
-            InvalidCartItem: The course ID is not valid.
+            CourseDoesNotExistException: The course ID is not valid.
 
         Returns:
             unicode
@@ -998,7 +1004,7 @@ class Donation(OrderItem):
                 err = _(
                     u"Could not find a course with the ID '{course_id}'"
                 ).format(course_id=course_id)
-                raise InvalidCartItem(err)
+                raise CourseDoesNotExistException(err)
 
             return _(u"Donation for {course}").format(course=course.display_name)
 

--- a/lms/djangoapps/shoppingcart/urls.py
+++ b/lms/djangoapps/shoppingcart/urls.py
@@ -4,6 +4,7 @@ from django.conf import settings
 urlpatterns = patterns('shoppingcart.views',  # nopep8
     url(r'^postpay_callback/$', 'postpay_callback'),  # Both the ~accept and ~reject callback pages are handled here
     url(r'^receipt/(?P<ordernum>[0-9]*)/$', 'show_receipt'),
+    url(r'^donation/$', 'donate', name='donation'),
     url(r'^csv_report/$', 'csv_report', name='payment_csv_report'),
 )
 

--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -241,11 +241,12 @@ def create_order(request):
     )
 
     params = get_signed_purchase_params(
-        cart, callback_url=callback_url
+        cart,
+        callback_url=callback_url,
+        extra_data=[unicode(course_id)]
     )
 
     params['success'] = True
-    params['merchant_defined_data1'] = unicode(course_id)
     return HttpResponse(json.dumps(params), content_type="text/json")
 
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1024,6 +1024,7 @@ main_vendor_js = base_vendor_js + [
     'js/vendor/URI.min.js',
 ]
 
+dashboard_js = sorted(rooted_glob(PROJECT_ROOT / 'static', 'js/dashboard/**/*.js'))
 discussion_js = sorted(rooted_glob(COMMON_ROOT / 'static', 'coffee/src/discussion/**/*.js'))
 staff_grading_js = sorted(rooted_glob(PROJECT_ROOT / 'static', 'coffee/src/staff_grading/**/*.js'))
 open_ended_js = sorted(rooted_glob(PROJECT_ROOT / 'static', 'coffee/src/open_ended/**/*.js'))
@@ -1172,6 +1173,10 @@ PIPELINE_JS = {
     'instructor_dash': {
         'source_filenames': instructor_dash_js,
         'output_filename': 'js/instructor_dash.js',
+    },
+    'dashboard': {
+        'source_filenames': dashboard_js,
+        'output_filename': 'js/dashboard.js'
     },
     'student_account': {
         'source_filenames': student_account_js,

--- a/lms/static/js/dashboard/donation.js
+++ b/lms/static/js/dashboard/donation.js
@@ -1,0 +1,243 @@
+var edx = edx || {};
+
+(function($) {
+    'use strict';
+
+    edx.dashboard = edx.dashboard || {};
+    edx.dashboard.donation = {};
+
+    /**
+     * View for making donations for a course.
+     * @constructor
+     * @param {Object} params
+     * @param {Object} params.el - The container element.
+     * @param {string} params.course - The ID of the course for the donation.
+     */
+    edx.dashboard.donation.DonationView = function(params) {
+        /**
+         * Dynamically configure a form, which the client can submit
+         * to the payment processor.
+         * @param {Object} form - The form to modify.
+         * @param {string} method - The HTTP method used to submit the form.
+         * @param {string} url - The URL where the form data will be submitted.
+         * @param {Object} params - Form data, included as hidden inputs.
+         */
+        var configureForm = function(form, method, url, params) {
+            $("input", form).remove();
+            form.attr("action", url);
+            form.attr("method", method);
+            _.each(params, function(value, key) {
+                $("<input>").attr({
+                    type: "hidden",
+                    name: key,
+                    value: value
+                }).appendTo(form);
+            });
+        };
+
+        /**
+        * Fire an analytics event indicating that the user
+        * is about to be sent to the external payment processor.
+        *
+        * @param {string} course - The course ID for the donation.
+        */
+        var firePaymentAnalyticsEvent = function(course) {
+            analytics.track(
+                "edx.bi.user.payment_processor.visited",
+                {
+                    category: "donations",
+                    label: course
+                }
+            );
+        };
+
+        /**
+        * Add a donation to the user's cart.
+        *
+        * @param {string} amount - The amount of the donation (e.g. "23.45")
+        * @param {string} course - The ID of the course.
+        * @returns {Object} The promise from the AJAX call to the server,
+        *     which resolves with a data object of the form
+        *     { payment_url: <string>, payment_params: <Object> }
+        */
+        var addDonationToCart = function(amount, course) {
+            return $.ajax({
+                url: "/shoppingcart/donation/",
+                type: "POST",
+                data: {
+                    amount: amount,
+                    course_id: course
+                }
+            });
+        };
+
+        var view = {
+            /**
+            * Initialize the view.
+            *
+            * @param {Object} params
+            * @param {JQuery selector} params.el - The container element.
+            * @param {string} params.course - The ID of the course for the donation.
+            * @returns {DonationView}
+            */
+            initialize: function(params) {
+                this.$el = params.el;
+                this.course = params.course;
+                _.bindAll(view,
+                    'render', 'donate', 'startPayment',
+                    'validate', 'startPayment',
+                    'displayServerError', 'submitPaymentForm'
+                );
+                return this;
+            },
+
+            /**
+            * Render the form for making a donation for a course.
+            *
+            * @returns {DonationView}
+            */
+            render: function() {
+                var html = _.template($("#donation-tpl").html(), {});
+                this.$el.html(html);
+                this.$amount = $("input[name=\"amount\"]", this.$el);
+                this.$submit = $("input[type=\"submit\"]", this.$el);
+                this.$errorMsg = $(".payment-form", this.$el);
+                this.$paymentForm = $(".payment-form", this.$el);
+                this.$submit.click(this.donate);
+                return this;
+            },
+
+            /**
+            * Handle a click event on the "donate" button.
+            * This will contact the LMS server to add the donation
+            * to the user's cart, then send the user to the
+            * external payment processor.
+            *
+            * @param {Object} event - The click event.
+            */
+            donate: function(event) {
+                // Prevent form submission
+                if (event) {
+                    event.preventDefault();
+                }
+
+                // Immediately disable the submit button to prevent duplicate submissions
+                this.$submit.addClass("disabled");
+
+                if (this.validate()) {
+                    var amount = this.$amount.val();
+                    addDonationToCart(amount, this.course)
+                        .done(this.startPayment)
+                        .fail(this.displayServerError);
+                }
+                else {
+                    // If an error occurred, allow the user to resubmit
+                    this.$submit.removeClass("disabled");
+                }
+            },
+
+            /**
+            * Send signed payment parameters to the external
+            * payment processor.
+            *
+            * @param {Object} data - The signed payment data received from the LMS server.
+            * @param {string} data.payment_url - The URL of the external payment processor.
+            * @param {Object} data.payment_data - Parameters to send to the external payment processor.
+            */
+            startPayment: function(data) {
+                configureForm(
+                    this.$paymentForm,
+                    'post',
+                    data.payment_url,
+                    data.payment_params
+                );
+                firePaymentAnalyticsEvent(this.course);
+                this.submitPaymentForm(this.$paymentForm);
+            },
+
+            /**
+            * Validate the donation amount and mark any validation errors.
+            *
+            * @returns {boolean} True iff the form is valid.
+            */
+            validate: function() {
+                var amount = this.$amount.val();
+                var isValid = this.validateAmount(amount);
+
+                if (isValid) {
+                    this.$amount.removeClass('validation-error');
+                    this.$errorMsg.text("");
+                }
+
+                else {
+                    this.$amount.addClass('validation-error');
+                    this.$errorMsg.text(
+                        gettext("Please enter a valid donation amount.")
+                    );
+                }
+
+                return isValid;
+            },
+
+            /**
+            * Validate that the given amount is a valid currency string.
+            *
+            * @param {string} amount
+            * @returns {boolean} True iff the amount is valid.
+            */
+            validateAmount: function(amount) {
+                var amountRegex = /^\d+.\d{2}$|^\d+$/i;
+                if (!amountRegex.test(amount)) {
+                    return false;
+                }
+
+                if (parseFloat(amount) < 0.01) {
+                    return false;
+                }
+
+                return true;
+            },
+
+            /**
+            * Display an error message when we receive an error from the LMS server.
+            */
+            displayServerError: function() {
+                // Display the error message
+                this.$errorMsg.text(gettext("Your donation could not be submitted."));
+
+                // Re-enable the submit button to allow the user to retry
+                this.$submit.removeClass("disabled");
+            },
+
+            /**
+            * Submit the payment from to the external payment processor.
+            * This is a separate function so we can easily stub it out in tests.
+            *
+            * @param {Object} form - The dynamically constructed payment form.
+            */
+            submitPaymentForm: function(form) {
+                form.submit();
+            },
+        };
+
+        view.initialize(params);
+        return view;
+    };
+
+    $(document).ready(function() {
+        // There may be multiple donation forms on the page
+        // (one for each newly enrolled course).
+        // For each one, create a new donation view to handle
+        // that form, and parameterize it based on the
+        // "data-course" attribute (the course ID).
+        $(".donate-container").each(function() {
+            var container = $(this);
+            var course = container.data("course");
+            var view = new edx.dashboard.donation.DonationView({
+                el: container,
+                course: course
+            }).render();
+        });
+    });
+
+})(jQuery);

--- a/lms/static/js/fixtures/donation.underscore
+++ b/lms/static/js/fixtures/donation.underscore
@@ -1,0 +1,1 @@
+../../../templates/dashboard/donation.underscore

--- a/lms/static/js/spec/dashboard/donation.js
+++ b/lms/static/js/spec/dashboard/donation.js
@@ -1,0 +1,170 @@
+define(['js/common_helpers/template_helpers', 'js/common_helpers/ajax_helpers', 'js/dashboard/donation'],
+    function(TemplateHelpers, AjaxHelpers) {
+        'use strict';
+
+        describe("edx.dashboard.donation.DonationView", function() {
+
+            var PAYMENT_URL = "https://fake.processor.com/pay/";
+            var PAYMENT_PARAMS = {
+                orderId: "test-order",
+                signature: "abcd1234"
+            };
+            var AMOUNT = "45.67";
+            var COURSE_ID = "edx/DemoX/Demo";
+
+            var view = null;
+            var requests = null;
+
+            beforeEach(function() {
+                setFixtures("<div></div>");
+                TemplateHelpers.installTemplate('templates/dashboard/donation');
+
+                view = new edx.dashboard.donation.DonationView({
+                    el: $("#jasmine-fixtures"),
+                    course: COURSE_ID
+                }).render();
+
+                // Stub out the actual submission of the payment form
+                // (which would cause the page to reload)
+                // This function gets passed the dynamically constructed
+                // form with signed payment parameters from the LMS server,
+                // so we can verify that the form is constructed correctly.
+                spyOn(view, 'submitPaymentForm').andCallFake(function() {});
+
+                // Stub the analytics event tracker
+                window.analytics = jasmine.createSpyObj('analytics', ['track']);
+            });
+
+            it("processes a donation for a course", function() {
+                // Spy on AJAX requests
+                requests = AjaxHelpers.requests(this);
+
+                // Enter a donation amount and proceed to the payment page
+                view.$amount.val(AMOUNT);
+                view.donate();
+
+                // Verify that the client contacts the server to create
+                // the donation item in the shopping cart and receive
+                // the signed payment params.
+                AjaxHelpers.expectRequest(
+                    requests, "POST", "/shoppingcart/donation/",
+                    $.param({ amount: AMOUNT, course_id: COURSE_ID })
+                );
+
+                // Simulate a response from the server containing the signed
+                // parameters to send to the payment processor
+                AjaxHelpers.respondWithJson(requests, {
+                    payment_url: PAYMENT_URL,
+                    payment_params: PAYMENT_PARAMS,
+                });
+
+                // Verify that the payment form has the payment parameters
+                // sent by the LMS server, and that it's targeted at the
+                // correct payment URL.
+                // We stub out the actual submission of the form to avoid
+                // leaving the current page during the test.
+                expect(view.submitPaymentForm).toHaveBeenCalled();
+                var form = view.submitPaymentForm.mostRecentCall.args[0];
+                expect(form.serialize()).toEqual($.param(PAYMENT_PARAMS));
+                expect(form.attr('method')).toEqual("post");
+                expect(form.attr('action')).toEqual(PAYMENT_URL);
+            });
+
+            it("validates the donation amount", function() {
+                var assertValidAmount = function(amount, isValid) {
+                    expect(view.validateAmount(amount)).toBe(isValid);
+                };
+                assertValidAmount("", false);
+                assertValidAmount("  ", false);
+                assertValidAmount("abc", false);
+                assertValidAmount("14.", false);
+                assertValidAmount(".1", false);
+                assertValidAmount("-1", false);
+                assertValidAmount("-1.00", false);
+                assertValidAmount("-", false);
+                assertValidAmount("0", false);
+                assertValidAmount("0.00", false);
+                assertValidAmount("00.00", false);
+                assertValidAmount("3", true);
+                assertValidAmount("12.34", true);
+                assertValidAmount("278", true);
+                assertValidAmount("278.91", true);
+                assertValidAmount("0.14", true);
+            });
+
+            it("displays validation errors", function() {
+                // Attempt to submit an invalid donation amount
+                view.$amount.val("");
+                view.donate();
+
+                // Verify that the amount field is marked as having a validation error
+                expect(view.$amount).toHaveClass("validation-error");
+
+                // Verify that the error message appears
+                expect(view.$errorMsg.text()).toEqual("Please enter a valid donation amount.");
+
+                // Expect that the submit button is re-enabled to allow users to submit again
+                expect(view.$submit).not.toHaveClass("disabled");
+
+                // Try again, this time submitting a valid amount
+                view.$amount.val(AMOUNT);
+                view.donate();
+
+                // Expect that the errors are cleared
+                expect(view.$errorMsg.text()).toEqual("");
+
+                // Expect that the submit button is disabled
+                expect(view.$submit).toHaveClass("disabled");
+            });
+
+            it("displays an error when the server cannot be contacted", function() {
+                // Spy on AJAX requests
+                requests = AjaxHelpers.requests(this);
+
+                // Simulate an error from the LMS servers
+                view.donate();
+                AjaxHelpers.respondWithError(requests);
+
+                // Expect that the error is displayed
+                expect(view.$errorMsg.text()).toEqual("Your donation could not be submitted.");
+
+                // Verify that the submit button is re-enabled
+                // so users can try again.
+                expect(view.$submit).not.toHaveClass("disabled");
+            });
+
+            it("disables the submit button once the user donates", function() {
+                // Before we submit, the button should be enabled
+                expect(view.$submit).not.toHaveClass("disabled");
+
+                // Simulate starting a donation
+                // Since we're not simulating the AJAX response, this will block
+                // in the state just after the user kicks off the donation process.
+                view.donate();
+
+                // Verify that the submit button is disabled
+                expect(view.$submit).toHaveClass("disabled");
+            });
+
+            it("sends an analytics event when the user submits a donation", function() {
+                // Simulate the submission to the payment processor
+                // We skip the intermediary steps here by passing in
+                // the payment url and parameters,
+                // which the view would ordinarily retrieve from the LMS server.
+                view.startPayment({
+                    payment_url: PAYMENT_URL,
+                    payment_params: PAYMENT_PARAMS
+                });
+
+                // Verify that the analytics event was fired
+                expect(window.analytics.track).toHaveBeenCalledWith(
+                    "edx.bi.user.payment_processor.visited",
+                    {
+                        category: "donations",
+                        label: COURSE_ID
+                    }
+                );
+            });
+        });
+    }
+);

--- a/lms/static/js/spec/main.js
+++ b/lms/static/js/spec/main.js
@@ -219,6 +219,10 @@
                 exports: 'js/staff_debug_actions',
                 deps: ['gettext']
             },
+            'js/dashboard/donation.js': {
+                exports: 'js/dashboard/donation',
+                deps: ['jquery', 'underscore', 'gettext']
+            },
             // Backbone classes loaded explicitly until they are converted to use RequireJS
             'js/models/cohort': {
                 exports: 'CohortModel',
@@ -255,7 +259,8 @@
         'lms/include/js/spec/views/cohorts_spec.js',
         'lms/include/js/spec/photocapture_spec.js',
         'lms/include/js/spec/staff_debug_actions_spec.js',
-        'lms/include/js/spec/views/notification_spec.js'
+        'lms/include/js/spec/views/notification_spec.js',
+        'lms/include/js/spec/dashboard/donation.js',
     ]);
 
 }).call(this, requirejs, define);

--- a/lms/static/js_test.yml
+++ b/lms/static/js_test.yml
@@ -71,6 +71,7 @@ spec_paths:
 #
 fixture_paths:
     - templates/instructor/instructor_dashboard_2
+    - templates/dashboard
 
 requirejs:
   paths:

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -20,7 +20,16 @@
 <%block name="bodyclass">view-dashboard is-authenticated</%block>
 <%block name="nav_skip">#my-courses</%block>
 
+<%block name="header_extras">
+% for template_name in ["donation"]:
+<script type="text/template" id="${template_name}-tpl">
+  <%static:include path="dashboard/${template_name}.underscore" />
+</script>
+% endfor
+</%block>
+
 <%block name="js_extra">
+  <%static:js group='dashboard'/>
   <script type="text/javascript">
   (function() {
 

--- a/lms/templates/dashboard/donation.underscore
+++ b/lms/templates/dashboard/donation.underscore
@@ -1,0 +1,6 @@
+<form class="donate-form">
+    <input type="text" name="amount" value="25.00" />
+    <input type="submit" name="Donate" value="<%- gettext('Donate') %>" />
+    <div class="donation-error-msg" />
+</form>
+<form class="payment-form"></form>

--- a/lms/templates/enrollment/course_enrollment_message.html
+++ b/lms/templates/enrollment/course_enrollment_message.html
@@ -1,11 +1,15 @@
 <%! from django.utils.translation import ugettext as _ %>
-% for course, enrollment in recent_course_enrollment_pairs:
+% for course_msg in course_enrollment_messages:
     <div class="wrapper-msg urgency-high">
         <div class="msg">
             <div class="msg-content">
                 <h2 class="sr">${_("Enrollment Successful")}</h2>
                 <div class="copy">
-                    <p>${_("You have successfully enrolled in {enrolled_course}.").format(enrolled_course=course.display_name)}</p>
+                    <p>${_("You have successfully enrolled in {enrolled_course}.").format(enrolled_course=course_msg["course_name"])}</p>
+
+                    % if course_msg["allow_donation"]:
+                    <div class="donate-container" data-course="${ course_msg['course_id'] }" />
+                    % endif
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Changes:
- Add donation end-point
- Make donations configurable
- Added donation button to dashboard
- Generalize merchant defined data for payment processor

Notes:
- To enable this, you need to use model-based configuration.  Enable `DonationConfiguration` and `DashboardConfiguration` (enrollment message timeout) in Django admin.
- This PR includes client-side validation and introduces a new client-side analytics event `edx.bi.user.payment_processor.visited` fired when the user clicks the "donate" button, right before we send them to the external payment processor.
- This PR does NOT include any style changes.

Reviewers: @dianakhuang @stephensanchez @AlasdairSwan 
FYI: @andy-armstrong @chrisndodge 

[ECOM-445](https://openedx.atlassian.net/browse/ECOM-445)
