### PR TITLE
Pass group_id when getting user thread and comment counts.

### DIFF
--- a/lms/djangoapps/django_comment_client/forum/views.py
+++ b/lms/djangoapps/django_comment_client/forum/views.py
@@ -325,8 +325,6 @@ def user_profile(request, course_id, user_id):
     #TODO: Allow sorting?
     course = get_course_with_access(request.user, 'load_forum', course_key)
     try:
-        profiled_user = cc.User(id=user_id, course_id=course_key)
-
         query_params = {
             'page': request.GET.get('page', 1),
             'per_page': THREADS_PER_PAGE,   # more than threads_per_page to show more activities
@@ -338,6 +336,9 @@ def user_profile(request, course_id, user_id):
             return HttpResponseBadRequest("Invalid group_id")
         if group_id is not None:
             query_params['group_id'] = group_id
+            profiled_user = cc.User(id=user_id, course_id=course_key, group_id=group_id)
+        else:
+            profiled_user = cc.User(id=user_id, course_id=course_key)
 
         threads, page, num_pages = profiled_user.active_threads(query_params)
         query_params['page'] = page

--- a/lms/lib/comment_client/user.py
+++ b/lms/lib/comment_client/user.py
@@ -8,7 +8,7 @@ class User(models.Model):
 
     accessible_fields = ['username', 'follower_ids', 'upvoted_ids', 'downvoted_ids',
                          'id', 'external_id', 'subscribed_user_ids', 'children', 'course_id',
-                         'subscribed_thread_ids', 'subscribed_commentable_ids',
+                         'group_id', 'subscribed_thread_ids', 'subscribed_commentable_ids',
                          'subscribed_course_ids', 'threads_count', 'comments_count',
                          'default_sort_key'
                         ]
@@ -120,6 +120,8 @@ class User(models.Model):
         retrieve_params.update(kwargs)
         if self.attributes.get('course_id'):
             retrieve_params['course_id'] = self.course_id.to_deprecated_string()
+        if self.attributes.get('group_id'):
+            retrieve_params['group_id'] = self.group_id
         try:
             response = perform_request(
                 'get',


### PR DESCRIPTION
TNL-543

Related cs_comments PR is https://github.com/edx/cs_comments_service/pull/122

@jimabramson @dan-f Please review.

Can use my sandbox to test--
http://cahrens.m.sandbox.edx.org/courses/christina/foo/bar/discussion/forum

This course has the following users and posts:
1) staff@example.com has moderator access. staff has started 3 discussions-- one to general (not cohorted), one to Verified Group, one to Honor Group. staff has also commented on two posts-- one written by honor to everyone, and one written by honor just to Honor Group cohort.

2) honor@example.com is in Honor Group. honor has created 2 posts, 1 to everyone and 1 to Honor Group. honor has also commented on both of those posts.

3) verified@example is in Verified Group. verified has created 2 posts, 1 to everyone and 1 to Verified Group.
