### PR TITLE
Make sure temporary course directory uses safe characters.

### DIFF
--- a/lms/djangoapps/courseware/management/commands/export_course.py
+++ b/lms/djangoapps/courseware/management/commands/export_course.py
@@ -83,10 +83,11 @@ def export_course_to_directory(course_key, root_dir):
         raise CommandError("Invalid course_id")
 
     # The safest characters are A-Z, a-z, 0-9, <underscore>, <period> and <hyphen>.
-    # We represent the first four with \w, but generalize to all unicode alphanumerics.
+    # We represent the first four with \w.  
+    # TODO: Once we support courses with unicode characters, we will need to revisit this.
     replacement_char = u'-'
     course_dir = replacement_char.join([course.id.org, course.id.course, course.id.run])
-    course_dir = re.sub(r'[^\w\.\-]', replacement_char, course_dir, flags=re.UNICODE)
+    course_dir = re.sub(r'[^\w\.\-]', replacement_char, course_dir)
 
     export_to_xml(store, None, course.id, root_dir, course_dir)
 


### PR DESCRIPTION
Code to convert course_ids to filenames is handled outside the opaque keys library.  

Here is one relatively insignificant place, but one that is needed to support export for researchers.  Hopefully this matches the general we want to take in the LMS and analytics.  @nasthagiri @cpennington @clintonb 
