### PR TITLE
Use UglifyJS to minify JavaScript in the LMS

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1211,7 +1211,7 @@ if os.path.isdir(DATA_DIR):
 
 
 PIPELINE_CSS_COMPRESSOR = None
-PIPELINE_JS_COMPRESSOR = None
+PIPELINE_JS_COMPRESSOR = "pipeline.compressors.uglifyjs.UglifyJSCompressor"
 
 STATICFILES_IGNORE_PATTERNS = (
     "sass/*",
@@ -1222,7 +1222,7 @@ STATICFILES_IGNORE_PATTERNS = (
     "common_static",
 )
 
-PIPELINE_YUI_BINARY = 'yui-compressor'
+PIPELINE_UGLIFYJS_BINARY='node_modules/.bin/uglifyjs'
 
 # Setting that will only affect the edX version of django-pipeline until our changes are merged upstream
 PIPELINE_COMPILE_INPLACE = True

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
     "name": "edx",
     "version": "0.1.0",
     "dependencies": {
-      "coffee-script": "1.6.1"
+      "coffee-script": "1.6.1",
+      "uglify-js": "2.4.15"
     }
 }


### PR DESCRIPTION
Possible short-term fix until we get RequireJS optimizer set up.

I tested this change in a sandbox and saw these improvements (compared to prod):
- lms-main_vendor: 382 KB --> 253 KB
- lms-application: 15.1 KB --> 9.7 KB
- lms-modules: 207 KB --> 134 KB
- lms-courseware: 2.3 KB --> 1.9 KB
- discussion: 28.7 KB --> 23.6 KB

For those files, that's about a 33% decrease in file size.

@andy-armstrong @polesye Thoughts?
