### PR TITLE
Mobile events, updates to video events

### DIFF
--- a/docs/en_us/data/source/internal_data_formats/change_log.rst
+++ b/docs/en_us/data/source/internal_data_formats/change_log.rst
@@ -14,6 +14,9 @@ October-December 2014
 
    * - Date
      - Change
+   * - 10/16/14
+     - Updated video events with new fields relating to mobile device use in
+       the :ref:`Tracking Logs` chapter.
    * - 10/07/14
      - Added new student and instructor events relating to cohort use to the
        :ref:`Tracking Logs` chapter.
@@ -84,7 +87,7 @@ April-June 2014
    * - 
      - Updated the ``seek_video`` event in the :ref:`Tracking Logs` chapter.
    * - 06/23/14
-     - Added a :ref:`Preface` with resources for course teams, developers,
+     - Added a `Preface`_ with resources for course teams, developers,
        researchers, and students.
    * - 05/23/14
      - Added descriptions of the enrollment upgrade events to the
@@ -154,3 +157,4 @@ January-March 2014
    * - 02/14/14
      - Added the ``seek_video`` and ``speed_change_video`` event types to the :ref:`Tracking Logs` chapter.
 
+.. _Preface: http://edx.readthedocs.org/projects/devdata/en/latest/preface.html

--- a/docs/en_us/data/source/internal_data_formats/discussion_data.rst
+++ b/docs/en_us/data/source/internal_data_formats/discussion_data.rst
@@ -114,7 +114,7 @@ more readable is produced.
     ],
     "up_count": 1
   }
-}
+ }
 
 ----------------------------------------
 Comment Document Example
@@ -197,7 +197,7 @@ When pretty printed, this comment looks like this:
   "created_at": {
     "$date": 1390759901966
   }
-}
+ }
 
 *****************
 Shared Fields


### PR DESCRIPTION
@stroilova , @mulby , @nasthagiri , @gwprice , @lou-wang , @mhoeber here is a framework that we can work from to get initial documentation out with the release. Notes:
- I am not sure that the same additional context fields that I see for the v.0 play_video (Olga shared with me) event also apply to all of the other video events.
- the event field names for the new edx.app.browser.launched event in Olga's spreadsheet are very rough
