### PR TITLE
Endorsement username shouldn't be broken

### DIFF
--- a/common/static/coffee/spec/discussion/view/thread_response_show_view_spec.coffee
+++ b/common/static/coffee/spec/discussion/view/thread_response_show_view_spec.coffee
@@ -45,6 +45,7 @@ describe "ThreadResponseShowView", ->
     it "renders endorsement correctly for a marked answer in a question thread", ->
         endorsement = {
           "username": "test_endorser",
+          "user_id": "test_id",
           "time": new Date().toISOString()
         }
         @thread.set("thread_type", "question")
@@ -56,6 +57,7 @@ describe "ThreadResponseShowView", ->
         expect(@view.$(".posted-details").text().replace(/\s+/g, " ")).toMatch(
           "marked as answer less than a minute ago by " + endorsement.username
         )
+        expect(@view.$(".posted-details > a").attr('href')).toEqual("/courses/edX/999/test/discussion/forum/users/test_id")
 
     it "renders anonymous endorsement correctly for a marked answer in a question thread", ->
         endorsement = {
@@ -74,6 +76,7 @@ describe "ThreadResponseShowView", ->
     it "renders endorsement correctly for an endorsed response in a discussion thread", ->
         endorsement = {
           "username": "test_endorser",
+          "user_id": "test_id",
           "time": new Date().toISOString()
         }
         @thread.set("thread_type", "discussion")
@@ -85,6 +88,7 @@ describe "ThreadResponseShowView", ->
         expect(@view.$(".posted-details").text().replace(/\s+/g, " ")).toMatch(
           "endorsed less than a minute ago by " + endorsement.username
         )
+        expect(@view.$(".posted-details > a").attr('href')).toEqual("/courses/edX/999/test/discussion/forum/users/test_id")
 
     it "renders anonymous endorsement correctly for an endorsed response in a discussion thread", ->
         endorsement = {

--- a/common/static/coffee/src/discussion/views/discussion_content_view.coffee
+++ b/common/static/coffee/src/discussion/views/discussion_content_view.coffee
@@ -194,7 +194,7 @@ if Backbone?
       url = @model.urlFor("endorse")
       updates =
         endorsed: is_endorsing
-        endorsement: if is_endorsing then {username: DiscussionUtil.getUser().get("username"), time: new Date().toISOString()} else null
+        endorsement: if is_endorsing then {username: DiscussionUtil.getUser().get("username"), user_id: DiscussionUtil.getUser().id, time: new Date().toISOString()} else null
       if @model.get('thread').get('thread_type') == 'question'
         if is_endorsing
           msg = gettext("We had some trouble marking this response as an answer.  Please try again.")


### PR DESCRIPTION
If we endourse the answer of the question in discussion
the username link that is created is broken whereas it
should point to the userprofile.

TNL-188
