### PR TITLE
Inline discussion XModule fix

### DIFF
--- a/common/static/coffee/spec/discussion/view/new_post_view_spec.coffee
+++ b/common/static/coffee/spec/discussion/view/new_post_view_spec.coffee
@@ -127,9 +127,8 @@ describe "NewPostView", ->
         view.$(".cancel").click()
         expect(eventSpy).toHaveBeenCalled()
         expect(view.$(".post-errors").html()).toEqual("");
-        if mode == "tab"
-          expect($("input[id$='post-type-question']")).toBeChecked()
-          expect($("input[id$='post-type-discussion']")).not.toBeChecked()
+        expect($("input[id$='post-type-question']")).toBeChecked()
+        expect($("input[id$='post-type-discussion']")).not.toBeChecked()
         expect(view.$(".js-post-title").val()).toEqual("");
         expect(view.$(".js-post-body textarea").val()).toEqual("");
         expect(view.$(".js-follow")).toBeChecked()

--- a/common/static/coffee/src/discussion/views/discussion_thread_edit_view.js
+++ b/common/static/coffee/src/discussion/views/discussion_thread_edit_view.js
@@ -28,9 +28,9 @@
                 this.template = _.template($('#thread-edit-template').html());
                 this.$el.html(this.template(this.model.toJSON())).appendTo(this.container);
                 this.submitBtn = this.$('.post-update');
+                threadTypeTemplate = _.template($("#thread-type-template").html());
+                this.addField(threadTypeTemplate({form_id: formId}));
                 if (this.isTabMode()) {
-                    threadTypeTemplate = _.template($("#thread-type-template").html());
-                    this.addField(threadTypeTemplate({form_id: formId}));
                     this.$("#" + formId + "-post-type-" + this.threadType).attr('checked', true);
                     this.topicView = new DiscussionTopicMenuView({
                         topicId: this.topicId,
@@ -57,6 +57,16 @@
                     body = this.$('.edit-post-body textarea').val(),
                     commentableId = this.isTabMode() ? this.topicView.getCurrentTopicId() : null;
 
+                var post_data = {
+                    title: title,
+                    thread_type: threadType,
+                    body: body
+                };
+
+                if (this.isTabMode()){
+                    post_data.commentable_id = commentableId;
+                }
+
                 return DiscussionUtil.safeAjax({
                     $elem: this.submitBtn,
                     $loading: this.submitBtn,
@@ -64,12 +74,7 @@
                     type: 'POST',
                     dataType: 'json',
                     async: false, // @TODO when the rest of the stuff below is made to work properly..
-                    data: {
-                        title: title,
-                        thread_type: threadType,
-                        body: body,
-                        commentable_id: commentableId
-                    },
+                    data: post_data,
                     error: DiscussionUtil.formErrorHandler(this.$('.post-errors')),
                     success: function() {
                         var newAttrs = {

--- a/common/static/coffee/src/discussion/views/new_post_view.coffee
+++ b/common/static/coffee/src/discussion/views/new_post_view.coffee
@@ -16,9 +16,9 @@ if Backbone?
               form_id: @mode + (if @topicId then "-" + @topicId else "")
           })
           @$el.html(_.template($("#new-post-template").html(), context))
+          threadTypeTemplate = _.template($("#thread-type-template").html());
+          @addField(threadTypeTemplate({form_id: _.uniqueId("form-")}));
           if @isTabMode()
-              threadTypeTemplate = _.template($("#thread-type-template").html());
-              @addField(threadTypeTemplate({form_id: _.uniqueId("form-")}));
               @topicView = new DiscussionTopicMenuView {
                   topicId:  @topicId
                   course_settings: @course_settings


### PR DESCRIPTION
Looks like
- Talked to @jmclaus on https://github.com/edx/edx-platform/pull/5308 - by the time of posting he couldn't reproduce the bug.
- Affected components: LMS
- Affected users: all users at all courses using inline discussion XModule
- Test instructions: 
  *\* Create course + section + subsection + unit
  *\* Put a discussion into unit (make sure you don't use discussion XBlock, this patch fixes ordinary discussion XModule)
  *\* Log in to studio, enroll for a course, go to unit with discussion.
  *\* Try creating a new post: without this patch there should be no discussion/question selector, submitting a post should fail.
  *\* When patch is applied there should be discussion/question selector and submitting a post should create a post of desired type.
  *\* Try editing the post: without this patch update should fail (probably with message `Topic does not exist`)
  *\* When patch is applied edit should succed (including changing post type)
- Partner information: 3rd party-hosted open edX instance, for an edX solutions client.
- Merge deadline: Oct 31 (soft requirement to minimize code drift, we maintain it on the client fork in the meantime), however, due to scope and potential severity it might make sense to do it faster.
