### PR TITLE
Making the header width fixed until we have responsive design.

### DIFF
--- a/lms/static/sass/shared/_header.scss
+++ b/lms/static/sass/shared/_header.scss
@@ -334,8 +334,7 @@ header.global-new {
 
   nav {
     @include clearfix();
-    max-width: grid-width(12);
-    min-width: 760px;
+    width: grid-width(12);
     height: ($baseline*2);
     margin: 0 auto;
     padding: 18px ($baseline/2) 0;


### PR DESCRIPTION
@AlasdairSwan @ndubbaka 

FYI @talbs this is due to the following behavior being seen:
![image](https://cloud.githubusercontent.com/assets/235752/4595403/2506fcee-5099-11e4-9f78-ee63572a3df0.png)

This was styling that existed in the old header. Probably was a problem then too, but the bigger fonts and buttons probably just makes it stand out more now. 

FYI @benpatterson we'll probably want this in before we push to prod. 
