### PR TITLE
Fixed errors in discussion XModule

### DIFF
--- a/common/static/coffee/spec/discussion/view/discussion_thread_edit_view_spec.js
+++ b/common/static/coffee/spec/discussion/view/discussion_thread_edit_view_spec.js
@@ -29,10 +29,7 @@
         testUpdate = function(view, thread) {
             spyOn($, 'ajax').andCallFake(function(params) {
                 expect(params.url.path()).toEqual(DiscussionUtil.urlFor('update_thread', 'dummy_id'));
-                if (view.isTabMode()) {
-                    // TODO remove the tabMode condition, depends on #5554 / TNL-606
-                    expect(params.data.thread_type).toBe('discussion');
-                }
+                expect(params.data.thread_type).toBe('discussion');
                 expect(params.data.commentable_id).toBe('other_topic');
                 expect(params.data.title).toBe('changed thread title');
                 params.success();
@@ -45,15 +42,12 @@
             expect($.ajax).toHaveBeenCalled();
 
             expect(thread.get('title')).toBe('changed thread title');
-            if (view.isTabMode()) {
-                // TODO remove the tabMode condition, depends on #5554 / TNL-606
-                expect(thread.get('thread_type')).toBe('discussion');
-            }
+            expect(thread.get('thread_type')).toBe('discussion');
             expect(thread.get('commentable_id')).toBe('other_topic');
             expect(thread.get('courseware_title')).toBe('Other Topic');
             expect(view.$('.edit-post-title')).toHaveValue('');
             expect(view.$('.wmd-preview p')).toHaveText('');
-        }
+        };
 
         it('can save new data correctly in tab mode', function() {
             this.createEditView();

--- a/common/static/coffee/spec/discussion/view/new_post_view_spec.coffee
+++ b/common/static/coffee/spec/discussion/view/new_post_view_spec.coffee
@@ -127,9 +127,8 @@ describe "NewPostView", ->
         view.$(".cancel").click()
         expect(eventSpy).toHaveBeenCalled()
         expect(view.$(".post-errors").html()).toEqual("");
-        if mode == "tab"
-          expect($("input[id$='post-type-question']")).toBeChecked()
-          expect($("input[id$='post-type-discussion']")).not.toBeChecked()
+        expect($("input[id$='post-type-question']")).toBeChecked()
+        expect($("input[id$='post-type-discussion']")).not.toBeChecked()
         expect(view.$(".js-post-title").val()).toEqual("");
         expect(view.$(".js-post-body textarea").val()).toEqual("");
         expect(view.$(".js-follow")).toBeChecked()

--- a/common/static/coffee/src/discussion/discussion_module_view.coffee
+++ b/common/static/coffee/src/discussion/discussion_module_view.coffee
@@ -99,13 +99,17 @@ if Backbone?
 
       @newPostForm = $('.new-post-article')
       @threadviews = @discussion.map (thread) =>
-        new DiscussionThreadView(
+        view = new DiscussionThreadView(
           el: @$("article#thread_#{thread.id}"),
           model: thread,
           mode: "inline",
           course_settings: @course_settings,
           topicId: discussionId
         )
+        thread.on "thread:thread_type_updated", ->
+          view.rerender()
+          view.expand()
+        return view
       _.each @threadviews, (dtv) -> dtv.render()
       DiscussionUtil.bulkUpdateContentInfo(window.$$annotated_content_info)
       @newPostView = new NewPostView(

--- a/common/static/coffee/src/discussion/views/discussion_thread_view.coffee
+++ b/common/static/coffee/src/discussion/views/discussion_thread_view.coffee
@@ -34,6 +34,20 @@ if Backbone?
       if @isQuestion()
         @markedAnswers = new Comments()
 
+    rerender: () ->
+      if @showView?
+        @showView.undelegateEvents()
+      @undelegateEvents()
+      @$el.empty()
+      @initialize(
+        mode: @mode
+        model: @model
+        el: @el
+        course_settings: @course_settings
+        topicId: @topicId
+      )
+      @render()
+
     renderTemplate: ->
       @template = _.template($("#thread-template").html())
       @template(@model.toJSON())

--- a/common/static/coffee/src/discussion/views/new_post_view.coffee
+++ b/common/static/coffee/src/discussion/views/new_post_view.coffee
@@ -16,9 +16,9 @@ if Backbone?
               form_id: @mode + (if @topicId then "-" + @topicId else "")
           })
           @$el.html(_.template($("#new-post-template").html(), context))
+          threadTypeTemplate = _.template($("#thread-type-template").html());
+          @addField(threadTypeTemplate({form_id: _.uniqueId("form-")}));
           if @isTabMode()
-              threadTypeTemplate = _.template($("#thread-type-template").html());
-              @addField(threadTypeTemplate({form_id: _.uniqueId("form-")}));
               @topicView = new DiscussionTopicMenuView {
                   topicId:  @topicId
                   course_settings: @course_settings


### PR DESCRIPTION
...f3725628b186fa:
1. Enabled `thread_type` selector for inline discussions
2. Fixed missing `commentable_id` (Javascript null was encoded as string 'null', not null object)

This addresses: https://openedx.atlassian.net/browse/TNL-606
