### PR TITLE
Studio: FIX - Course Rerun Outline Notification Icon Display

### DIFF
--- a/cms/templates/course_outline.html
+++ b/cms/templates/course_outline.html
@@ -40,7 +40,7 @@ from contentstore.utils import reverse_usage_url
   %if notification_dismiss_url is not None:
   <div class="wrapper wrapper-alert wrapper-alert-announcement is-shown">
     <div class="alert announcement has-actions">
-      <i class="alert-symbol icon-bullhorn"></i>
+      <i class="feedback-symbol icon-bullhorn"></i>
 
       <div class="copy">
         <h2 class="title title-3">${_("This course was created as a re-run. Some manual configuration is needed.")}</h2>

--- a/cms/templates/js/mock/mock-course-rerun-notification.underscore
+++ b/cms/templates/js/mock/mock-course-rerun-notification.underscore
@@ -1,7 +1,7 @@
 <div id="page-alert">
     <div class="wrapper wrapper-alert wrapper-alert-announcement is-shown">
         <div class="alert announcement has-actions">
-            <i class="alert-symbol icon-bullhorn"></i>
+            <i class="feedback-symbol icon-bullhorn"></i>
 
             <div class="copy">
                 <h2 class="title title-3">This course was created as a re-run. Some manual configuration is needed.</h2>


### PR DESCRIPTION
This work resolves a post-course rerun outline UI alert icon display issue ([UX-1054](https://openedx.atlassian.net/browse/UX-1054)).
