### PR TITLE
Fix old analytics api call for Split modulestore.

### DIFF
--- a/common/lib/xmodule/xmodule/tests/test_progress.py
+++ b/common/lib/xmodule/xmodule/tests/test_progress.py
@@ -23,12 +23,12 @@ class ProgressTest(unittest.TestCase):
 
     def test_create_object(self):
         # These should work:
-        p = Progress(0, 2)
-        p = Progress(1, 2)
-        p = Progress(2, 2)
+        prg1 = Progress(0, 2)  # pylint: disable=W0612
+        prg2 = Progress(1, 2)  # pylint: disable=W0612
+        prg3 = Progress(2, 2)  # pylint: disable=W0612
 
-        p = Progress(2.5, 5.0)
-        p = Progress(3.7, 12.3333)
+        prg4 = Progress(2.5, 5.0)  # pylint: disable=W0612
+        prg5 = Progress(3.7, 12.3333)  # pylint: disable=W0612
 
         # These shouldn't
         self.assertRaises(ValueError, Progress, 0, 0)
@@ -44,10 +44,10 @@ class ProgressTest(unittest.TestCase):
         self.assertEqual((0, 2), Progress(-2, 2).frac())
 
     def test_frac(self):
-        p = Progress(1, 2)
-        (a, b) = p.frac()
-        self.assertEqual(a, 1)
-        self.assertEqual(b, 2)
+        prg = Progress(1, 2)
+        (a_mem, b_mem) = prg.frac()
+        self.assertEqual(a_mem, 1)
+        self.assertEqual(b_mem, 2)
 
     def test_percent(self):
         self.assertEqual(self.not_started.percent(), 0)
@@ -98,38 +98,38 @@ class ProgressTest(unittest.TestCase):
     def test_to_js_detail_str(self):
         '''Test the Progress.to_js_detail_str() method'''
         f = Progress.to_js_detail_str
-        for p in (self.not_started, self.half_done, self.done):
-            self.assertEqual(f(p), str(p))
+        for prg in (self.not_started, self.half_done, self.done):
+            self.assertEqual(f(prg), str(prg))
         # But None should be encoded as 0
         self.assertEqual(f(None), "0")
 
     def test_add(self):
         '''Test the Progress.add_counts() method'''
-        p = Progress(0, 2)
-        p2 = Progress(1, 3)
-        p3 = Progress(2, 5)
-        pNone = None
+        prg1 = Progress(0, 2)
+        prg2 = Progress(1, 3)
+        prg3 = Progress(2, 5)
+        prg_none = None
         add = lambda a, b: Progress.add_counts(a, b).frac()
 
-        self.assertEqual(add(p, p), (0, 4))
-        self.assertEqual(add(p, p2), (1, 5))
-        self.assertEqual(add(p2, p3), (3, 8))
+        self.assertEqual(add(prg1, prg1), (0, 4))
+        self.assertEqual(add(prg1, prg2), (1, 5))
+        self.assertEqual(add(prg2, prg3), (3, 8))
 
-        self.assertEqual(add(p2, pNone), p2.frac())
-        self.assertEqual(add(pNone, p2), p2.frac())
+        self.assertEqual(add(prg2, prg_none), prg2.frac())
+        self.assertEqual(add(prg_none, prg2), prg2.frac())
 
     def test_equality(self):
         '''Test that comparing Progress objects for equality
         works correctly.'''
-        p = Progress(1, 2)
-        p2 = Progress(2, 4)
-        p3 = Progress(1, 2)
-        self.assertTrue(p == p3)
-        self.assertFalse(p == p2)
+        prg1 = Progress(1, 2)
+        prg2 = Progress(2, 4)
+        prg3 = Progress(1, 2)
+        self.assertTrue(prg1 == prg3)
+        self.assertFalse(prg1 == prg2)
 
         # Check != while we're at it
-        self.assertTrue(p != p2)
-        self.assertFalse(p != p3)
+        self.assertTrue(prg1 != prg2)
+        self.assertFalse(prg1 != prg3)
 
 
 class ModuleProgressTest(unittest.TestCase):
@@ -137,6 +137,6 @@ class ModuleProgressTest(unittest.TestCase):
     '''
     def test_xmodule_default(self):
         '''Make sure default get_progress exists, returns None'''
-        xm = x_module.XModule(Mock(), get_test_system(), DictFieldData({'location': 'a://b/c/d/e'}), Mock())
-        p = xm.get_progress()
-        self.assertEqual(p, None)
+        xmod = x_module.XModule(Mock(), get_test_system(), DictFieldData({'location': 'a://b/c/d/e'}), Mock())
+        prg = xmod.get_progress()
+        self.assertEqual(prg, None)

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -1697,7 +1697,7 @@ def send_email(request, course_id):
         course_id,
         request.user,
         send_to,
-        subject,message,
+        subject, message,
         template_name=template_name,
         from_addr=from_addr
     )
@@ -1800,7 +1800,7 @@ def proxy_legacy_analytics(request, course_id):
     url = "{}get?aname={}&course_id={}&apikey={}".format(
         settings.ANALYTICS_SERVER_URL,
         analytics_name,
-        urllib.quote(course_id.to_deprecated_string()),
+        urllib.quote(unicode(course_id)),
         settings.ANALYTICS_API_KEY,
     )
 

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -25,6 +25,7 @@ from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseForbid
 from django.utils.html import strip_tags
 import string  # pylint: disable=W0402
 import random
+import urllib
 from util.json_request import JsonResponse
 from instructor.views.instructor_task_helpers import extract_email_features, extract_task_features
 
@@ -1791,13 +1792,15 @@ def proxy_legacy_analytics(request, course_id):
     analytics_name = request.GET.get('aname')
 
     # abort if misconfigured
-    if not (hasattr(settings, 'ANALYTICS_SERVER_URL') and hasattr(settings, 'ANALYTICS_API_KEY')):
+    if not (hasattr(settings, 'ANALYTICS_SERVER_URL') and
+            hasattr(settings, 'ANALYTICS_API_KEY') and
+            settings.ANALYTICS_SERVER_URL and settings.ANALYTICS_API_KEY):
         return HttpResponse("Analytics service not configured.", status=501)
 
     url = "{}get?aname={}&course_id={}&apikey={}".format(
         settings.ANALYTICS_SERVER_URL,
         analytics_name,
-        course_id.to_deprecated_string(),
+        urllib.quote(course_id.to_deprecated_string()),
         settings.ANALYTICS_API_KEY,
     )
 

--- a/lms/djangoapps/instructor/views/legacy.py
+++ b/lms/djangoapps/instructor/views/legacy.py
@@ -11,6 +11,7 @@ import logging
 import os
 import re
 import requests
+import urllib
 
 from collections import defaultdict, OrderedDict
 from markupsafe import escape
@@ -910,7 +911,7 @@ def instructor_dashboard(request, course_id):
         """
         url = settings.ANALYTICS_SERVER_URL + \
             u"get?aname={}&course_id={}&apikey={}".format(
-                analytics_name, course_key.to_deprecated_string(), settings.ANALYTICS_API_KEY
+                analytics_name, urllib.quote(unicode(course_key)), settings.ANALYTICS_API_KEY
             )
         try:
             res = requests.get(url)


### PR DESCRIPTION
@cpennington @dmitchell 

I wasn't able to test the encoding due to no old analytics server available for testing. But I did test the empty strings.
