### PR TITLE
fix tracking log entry key child-id -> child_id

### DIFF
--- a/common/lib/xmodule/xmodule/split_test_module.py
+++ b/common/lib/xmodule/xmodule/split_test_module.py
@@ -359,7 +359,7 @@ class SplitTestModule(SplitTestFields, XModule, StudioEditableModule):
         Record in the tracking logs which child was rendered
         """
         # TODO: use publish instead, when publish is wired to the tracking logs
-        self.system.track_function('xblock.split_test.child_render', {'child-id': self.child.scope_ids.usage_id.to_deprecated_string()})
+        self.system.track_function('xblock.split_test.child_render', {'child_id': self.child.scope_ids.usage_id.to_deprecated_string()})
         return Response()
 
     def get_icon_class(self):

--- a/docs/en_us/data/source/internal_data_formats/tracking_logs.rst
+++ b/docs/en_us/data/source/internal_data_formats/tracking_logs.rst
@@ -2166,7 +2166,7 @@ the child module that was shown to the student.
    * - Field
      - Type
      - Details
-   * - ``child-id``
+   * - ``child_id``
      - string
      - ID of the module that displays to the student. 
 


### PR DESCRIPTION
tracking log entry keys cannot have a dash in them; this breaks imports into the analytics databases being used by Harvard and MIT, for example.

Fix child-id -> child_id in `common/lib/xmodule/xmodule/split_test_module.py`
