### PR TITLE
Stop page extending out of viewport width by 40px

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -178,3 +178,4 @@ Paul Medlock-Walton <paulmw@mit.edu>
 Henry Tareque <henry.tareque@gmail.com>
 Eugeny Kolpakov <eugeny.kolpakov@gmail.com>
 Omar Al-Ithawi <oithawi@qrf.org>
+Louis Pilfold <louis@lpil.uk>

--- a/lms/static/sass/base/_base.scss
+++ b/lms/static/sass/base/_base.scss
@@ -107,7 +107,7 @@ a:focus {
 
 .container {
   @include clearfix;
-  box-sizing: border-box;
+  @include box-sizing(border-box);
   margin: 0 auto 0;
   padding: 0px 30px;
   max-width: grid-width(12);

--- a/lms/static/sass/base/_base.scss
+++ b/lms/static/sass/base/_base.scss
@@ -107,6 +107,7 @@ a:focus {
 
 .container {
   @include clearfix;
+  box-sizing: border-box;
   margin: 0 auto 0;
   padding: 0px 30px;
   max-width: grid-width(12);

--- a/lms/static/sass/shared/_footer.scss
+++ b/lms/static/sass/shared/_footer.scss
@@ -8,7 +8,7 @@
 
   footer {
     @include clearfix();
-    box-sizing: border-box;
+    @include box-sizing(border-box);
     max-width: grid-width(12);
     min-width: 760px;
     width: flex-grid(12);

--- a/lms/static/sass/shared/_footer.scss
+++ b/lms/static/sass/shared/_footer.scss
@@ -8,6 +8,7 @@
 
   footer {
     @include clearfix();
+    box-sizing: border-box;
     max-width: grid-width(12);
     min-width: 760px;
     width: flex-grid(12);


### PR DESCRIPTION
Currently the `.container` and `.wrapper-footer` elements are set to `width: 100%`, and also have horizontal padding added to them. This results in a total width of greater than the full width of the viewport; This causing the browser to scroll horizonally into empty space, regardless of how wide the viewport is.

I had added the `box-sizing: border-box` to these classes in order to resolve this.

Cheers,
Louis

P.S. I've emailed my contributor agreement to Jennifer. :paperclip: 
