### PR TITLE
Lazy loading of CourseMode model's internationalization.

### DIFF
--- a/common/djangoapps/course_modes/models.py
+++ b/common/djangoapps/course_modes/models.py
@@ -6,7 +6,7 @@ from datetime import datetime
 
 from django.db import models
 from collections import namedtuple
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 from django.db.models import Q
 
 from xmodule_django.models import CourseKeyField


### PR DESCRIPTION
The use of `ugettext` here instead of `ugettext_lazy` can cause cyclical imports if this module is loaded earlier than expected. Per the Django documentation:
https://docs.djangoproject.com/en/dev/topics/i18n/translation/#lazy-translation

And yes, this merge request is happening because it happened to us and left a very cryptic 'cannot import name' error. :)
- Partner information: 3rd party-hosted open edX instance
- Merge deadline: would be nice to have it merged by Nov 3rd to minimize code drift, but not an edX partner so no hard requirement
