### PR TITLE
In user profile changing page should reposition window to top

### DIFF
--- a/common/static/coffee/src/discussion/views/discussion_user_profile_view.coffee
+++ b/common/static/coffee/src/discussion/views/discussion_user_profile_view.coffee
@@ -37,6 +37,7 @@ if Backbone?
           @numPages = response.num_pages
           @discussion.reset(response.discussion_data, {silent: false})
           history.pushState({}, "", url)
+          $("html, body").animate({ scrollTop: @$el.offset().top });
         error: =>
           DiscussionUtil.discussionAlert(
             gettext("Sorry"),


### PR DESCRIPTION
When we change the page using pagination in the user
profile page the data gets updated but the position
of the window remains at pagination. It should change
position of window to top.

TNL-107
