### PR TITLE
Update django-countries to 2.1.2, override country name for Taiwan

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -31,7 +31,7 @@ from django.db.models import Count
 from django.dispatch import receiver, Signal
 from django.core.exceptions import ObjectDoesNotExist
 from django.utils.translation import ugettext_noop
-from django_countries import CountryField
+from django_countries.fields import CountryField
 from config_models.models import ConfigurationModel
 from track import contexts
 from eventtracking import tracker

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -27,14 +27,13 @@ Longer TODO:
 import sys
 import os
 import imp
-import json
 
 from path import path
 from warnings import simplefilter
+from django.utils.translation import ugettext_lazy as _
 
 from .discussionsettings import *
 from xmodule.modulestore.modulestore_settings import update_module_store_settings
-
 from lms.lib.xblock.mixin import LmsBlockMixin
 
 ################################### FEATURES ###################################
@@ -1838,3 +1837,9 @@ AUTO_REGISTRATION_AB_TEST_EXCLUDE_COURSES = set([
 # REGISTRATION CODES DISPLAY INFORMATION SUBTITUTIONS IN THE INVOICE ATTACHMENT
 INVOICE_CORP_ADDRESS = "Please place your corporate address\nin this configuration"
 INVOICE_PAYMENT_INSTRUCTIONS = "This is where you can\nput directions on how people\nbuying registration codes"
+
+# Country code overrides
+# Used by django-countries
+COUNTRIES_OVERRIDE = {
+    "TW": _("Taiwan"),
+}

--- a/lms/templates/register-shib.html
+++ b/lms/templates/register-shib.html
@@ -7,7 +7,7 @@
 
 <%! from django.core.urlresolvers import reverse %>
 <%! from django.utils import html %>
-<%! from django_countries.countries import COUNTRIES %>
+<%! from django_countries import countries %>
 <%! from student.models import UserProfile %>
 <%! from datetime import date %>
 <%! import calendar %>

--- a/lms/templates/register.html
+++ b/lms/templates/register.html
@@ -8,7 +8,7 @@
 
 <%! from django.core.urlresolvers import reverse %>
 <%! from django.utils import html %>
-<%! from django_countries.countries import COUNTRIES %>
+<%! from django_countries import countries %>
 <%! from django.utils.translation import ugettext as _ %>
 <%! from student.models import UserProfile %>
 <%! from datetime import date %>
@@ -254,7 +254,7 @@
               <label for="country">${_("Country")}</label>
               <select id="country" name="country" ${'required aria-required="true"' if settings.REGISTRATION_EXTRA_FIELDS['country'] == 'required' else ''}>
                 <option value="">--</option>
-                %for code, country_name in COUNTRIES:
+                %for code, country_name in sorted(countries.countries, key=lambda (__, name): unicode(name)):
                 <option value="${code}">${ unicode(country_name) }</option>
                 %endfor
               </select>

--- a/lms/templates/signup_modal.html
+++ b/lms/templates/signup_modal.html
@@ -3,7 +3,7 @@
 <%namespace name='static' file='static_content.html'/>
 <%! from django.conf import settings %>
 <%! from django.core.urlresolvers import reverse %>
-<%! from django_countries.countries import COUNTRIES %>
+<%! from django_countries import countries %>
 <%! from student.models import UserProfile %>
 <%! from datetime import date %>
 <%! import calendar %>

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -16,7 +16,7 @@ defusedxml==0.4.1
 distribute>=0.6.28, <0.7
 django-babel-underscore==0.1.0
 django-celery==3.0.17
-django-countries==1.5
+django-countries==2.1.2
 django-extensions==1.2.5
 django-filter==0.6.0
 django-followit==0.0.3


### PR DESCRIPTION
[ECOM-475](https://openedx.atlassian.net/browse/ECOM-475)
- Update django-countries to 2.1.2 to get setting that allows us to override country names.
- Override the country name for Taiwan

Reviewers: @dianakhuang @stephensanchez 
FYI: @jbau @chrisndodge 
