### PR TITLE
Add expected whitespace to capa multiple choice response test

### DIFF
--- a/common/lib/xmodule/xmodule/tests/test_capa_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_capa_module.py
@@ -1737,7 +1737,7 @@ class TestProblemCheckTracking(unittest.TestCase):
             },
             factory.answer_key(3): {
                 'question': '',
-                'answer': u'<text>a table</text>',
+                'answer': u'\n        <text>a table</text>\n      ',
                 'response_type': 'multiplechoiceresponse',
                 'input_type': 'choicegroup',
                 'correct': False,


### PR DESCRIPTION
Reproduce this failure on current master with: 

```
nosetests -v common/lib/xmodule/xmodule/tests/test_capa_module.py:TestProblemCheckTracking.test_choice_answer_text
```

or with:

```
paver test_lib -l common/lib/xmodule/xmodule/tests/test_capa_module.py:TestProblemCheckTracking.test_choice_answer_text
```

git bisect has is breaking in [commit d6547988566751688952f2fb780070cb6f944ba](../../commit/d6547988566751688952f2fb780070cb6f944ba1)

but I can't for the life of me figure out exactly why. Also I'm not sure why it's passing in jenkins on master.
:(

@cpennington @nparlante thoughts?
