### PR TITLE
Ensure all user-facing cohort-related strings are internationalized

### DIFF
--- a/lms/templates/instructor/instructor_dashboard_2/cohort-editor.underscore
+++ b/lms/templates/instructor/instructor_dashboard_2/cohort-editor.underscore
@@ -3,11 +3,7 @@
         <span class="title-value"><%- cohort.get('name') %></span>
         <span class="group-count"><%-
             interpolate(
-                ngettext(
-                    '(contains 1 student)',
-                    '(contains %(student_count)s students)',
-                    cohort.get('user_count')
-                ),
+                ngettext('(contains %(student_count)s student)', '(contains %(student_count)s students)', cohort.get('user_count')),
                 { student_count: cohort.get('user_count') },
                 true
             )


### PR DESCRIPTION
TNL-55

I've done a run-through of all our various cohort UIs to verify that we are in fact translating user-facing strings.

The only problem I found was in the cohort editor, and seems to be caused by a bug in the translation scraper which doesn't handle newlines too well.
@explorerleslie There's also a question about the student profile CSV - see below.

Places I've checked (did I miss anything?):
- Studio
  - Advanced Settings - translated
- LMS
  - Instructor Dashboard
    - Cohort management UI - translated
    - Data download - @explorerleslie should the header row of the student profile CSV be translated? That column is currently translated for the in-page profile info display, but are not for the CSV. For reference, it looks like the grade report header row is not translated either.
  - Forums
    - the cohort selector is translated for thread filtering and when posting new threads
    - "this post is visible to..." is translated

@cahrens @andy-armstrong please review
