### PR TITLE
GIT URL should not be a deprecated setting (TNL-396).

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/inheritance.py
+++ b/common/lib/xmodule/xmodule/modulestore/inheritance.py
@@ -66,8 +66,7 @@ class InheritanceMixin(XBlockMixin):
     giturl = String(
         display_name=_("GIT URL"),
         help=_("Enter the URL for the course data GIT repository."),
-        scope=Scope.settings,
-        deprecated=True  # Deprecated because GIT workflow users do not use Studio.
+        scope=Scope.settings
     )
     xqa_key = String(
         display_name=_("XQA Key"),


### PR DESCRIPTION
Do not deprecate giturl.
Issue: https://openedx.atlassian.net/browse/TNL-396

Acceptance criteria: 
- If feature flag ENABLE_EXPORT_GIT is off, don't show the setting at all on the Advanced Settings page. 
- If feature flag ENABLE_EXPORT_GIT is on, show the setting as a non-deprecated Advanced Setting. 

Reviewers: @auraz @tymofij 
