### PR TITLE
Fixed CC button in internet explorer.

### DIFF
--- a/lms/templates/video.html
+++ b/lms/templates/video.html
@@ -85,8 +85,7 @@
                       <a href="#" class="quality-control is-hidden" title="${_('HD off')}" role="button" aria-disabled="false">${_('HD off')}</a>
 
                       <div class="lang menu-container">
-                        <a href="#" class="hide-subtitles" title="${_('Turn off captions')}" role="button" aria-
-                        disabled="false">${_('Turn off captions')}</a>
+                        <a href="#" class="hide-subtitles" title="${_('Turn off captions')}" role="button" aria-disabled="false">${_('Turn off captions')}</a>
                       </div>
                   </div>
               </div>


### PR DESCRIPTION
Ticket: [TNL-617](https://openedx.atlassian.net/browse/TNL-617)

Html fixed for cc button, there was a line break b/w `aria- 
disabled="false"` which creates a disabled attribute for element.
