### PR TITLE
Do not save an xblock after rendering the Studio view.

### DIFF
--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -225,7 +225,6 @@ def xblock_view_handler(request, usage_key_string, view_name):
                 log.debug("unable to render studio_view for %r", xblock, exc_info=True)
                 fragment = Fragment(render_to_string('html_error.html', {'message': str(exc)}))
 
-            store.update_item(xblock, request.user.id)
         elif view_name in (PREVIEW_VIEWS + container_views):
             is_pages_view = view_name == STUDENT_VIEW   # Only the "Pages" view uses student view in Studio
 

--- a/common/test/acceptance/pages/studio/html_component_editor.py
+++ b/common/test/acceptance/pages/studio/html_component_editor.py
@@ -1,6 +1,5 @@
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.action_chains import ActionChains
-from utils import click_css
 from component_editor import ComponentEditorView
 
 
@@ -8,13 +7,25 @@ class HtmlComponentEditorView(ComponentEditorView):
     """
     Represents the rendered view of an HTML component editor.
     """
-
     def set_content_and_save(self, content):
         """
-        Types content into the html component.
+        Types content into the html component and presses Save.
+        """
+        self.set_content(content)
+        self.save()
+
+    def set_content_and_cancel(self, content):
+        """
+        Types content into the html component and presses Cancel to abort the change.
+        """
+        self.set_content(content)
+        self.cancel()
+
+    def set_content(self, content):
+        """
+        Types content into the html component, leaving the component open.
         """
         self.q(css='.edit-xblock-modal .editor-modes .editor-button').click()
         editor = self.q(css=self._bounded_selector('.html-editor .mce-edit-area'))[0]
         ActionChains(self.browser).click(editor).\
             send_keys([Keys.CONTROL, 'a']).key_up(Keys.CONTROL).send_keys(content).perform()
-        click_css(self, 'a.action-save')

--- a/common/test/acceptance/tests/studio/test_studio_acid_xblock.py
+++ b/common/test/acceptance/tests/studio/test_studio_acid_xblock.py
@@ -86,8 +86,6 @@ class XBlockAcidBase(WebAppTest):
         acid_block = AcidView(self.browser, unit.xblocks[0].edit().editor_selector)
         self.assertTrue(acid_block.init_fn_passed)
         self.assertTrue(acid_block.resource_url_passed)
-        self.assertTrue(acid_block.scope_passed('content'))
-        self.assertTrue(acid_block.scope_passed('settings'))
 
 
 class XBlockAcidNoChildTest(XBlockAcidBase):

--- a/common/test/acceptance/tests/studio/test_studio_container.py
+++ b/common/test/acceptance/tests/studio/test_studio_container.py
@@ -605,6 +605,27 @@ class UnitPublishingTest(ContainerBase):
         self._view_published_version(unit)
         self.assertTrue(modified_content in self.courseware.xblock_component_html_content(0))
 
+    def test_cancel_does_not_create_draft(self):
+        """
+        Scenario: Editing a component and then canceling does not create a draft version (TNL-399)
+            Given I have a published unit with no unpublished changes
+            When I go to the unit page in Studio
+            And edit the content of an HTML component and then press cancel
+            Then the content does not change
+            And the title in the Publish information box is "Published and Live"
+            And when I reload the page
+            Then the title in the Publish information box is "Published and Live"
+        """
+        unit = self.go_to_unit_page()
+        component = unit.xblocks[1]
+        component.edit()
+        HtmlComponentEditorView(self.browser, component.locator).set_content_and_cancel("modified content")
+        self.assertEqual(component.student_content, "Body of HTML Unit.")
+        self._verify_publish_title(unit, self.PUBLISHED_LIVE_STATUS)
+        self.browser.refresh()
+        unit.wait_for_page()
+        self._verify_publish_title(unit, self.PUBLISHED_LIVE_STATUS)
+
     def test_delete_child_in_published_unit(self):
         """
         Scenario: A published unit can be published again after deleting a child


### PR DESCRIPTION
TNL-399

After extended conversations with @explorerleslie , @cpennington , and @dmitchell , Leslie decided that we should remove the save call after rendering the Studio view. This fixes TNL-399 (which, interestingly, was not an issue for split modulestore).

Note that there is still a chance that the "Published" vs "Unpublished Changes" status will get out of date, if an xblock is doing AJAX callbacks. The xblock ajax handler in component.py also does a call to update_item. As far as I know, this only impacts the acid xblock, which is not used by any courses. We have no mechanism at this point to know that the client side needs to re-fetch data in this case.

Note also that clicking "Save" on the Studio view editor will always create a draft version in the old draft modulestore, even if there are no actual changes (this is not true for split modulestore). I have created a story to make the behavior consistent, https://openedx.atlassian.net/browse/TNL-632.

@andy-armstrong and @zubair-arbi Please review.
