### PR TITLE
Handle OpenID errors for POST requests.

### DIFF
--- a/common/djangoapps/external_auth/views.py
+++ b/common/djangoapps/external_auth/views.py
@@ -6,6 +6,7 @@ import re
 import string       # pylint: disable=W0402
 import fnmatch
 import unicodedata
+import urllib
 
 from textwrap import dedent
 from external_auth.models import ExternalAuthMap
@@ -810,7 +811,8 @@ def provider_login(request):
                 # remember request and original path
                 request.session['openid_setup'] = {
                     'request': openid_request,
-                    'url': request.get_full_path()
+                    'url': request.get_full_path(),
+                    'post_params': request.POST,
                 }
 
                 # user failed login on previous attempt
@@ -831,6 +833,20 @@ def provider_login(request):
         openid_setup = request.session['openid_setup']
         openid_request = openid_setup['request']
         openid_request_url = openid_setup['url']
+        post_params = openid_setup['post_params']
+        # We need to preserve the parameters, and the easiest way to do this is
+        # through the URL
+        url_post_params = {
+            param: post_params[param] for param in post_params if param.startswith('openid')
+        }
+
+        encoded_params = urllib.urlencode(url_post_params)
+
+        if '?' not in openid_request_url:
+            openid_request_url = openid_request_url + '?' + encoded_params
+        else:
+            openid_request_url = openid_request_url + '&' + encoded_params
+
         del request.session['openid_setup']
 
         # don't allow invalid trust roots


### PR DESCRIPTION
@rlucioni @wedaly 

So the background on this bug is that we are _technically_ supporting POST requests coming in, but when there was an error (i.e. a mistyped password), we would lose all of the incoming information because it wasn't being encoded in the URLs. I have switched this so any POST parameters that begin with `openid.` are now being preserved in the URLs. It's not the best solution, but I think it requires the least amount of re-architecture of this code.

ECOM-441
