### PR TITLE
Support and tests for adding a reset button to units

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ These are notable changes in edx-platform.  This is a rolling list of changes,
 in roughly chronological order, most recent first.  Add your entries at or near
 the top.  Include a label indicating the component affected.
 
+Common: Add configurable reset button to units
+
 LMS: Support adding cohorts from the instructor dashboard. TNL-162
 
 LMS: Support adding students to a cohort via the instructor dashboard. TNL-163

--- a/cms/djangoapps/contentstore/features/problem-editor.py
+++ b/cms/djangoapps/contentstore/features/problem-editor.py
@@ -13,6 +13,7 @@ MAXIMUM_ATTEMPTS = "Maximum Attempts"
 PROBLEM_WEIGHT = "Problem Weight"
 RANDOMIZATION = 'Randomization'
 SHOW_ANSWER = "Show Answer"
+SHOW_RESET_BUTTON = "Show Reset Button"
 TIMER_BETWEEN_ATTEMPTS = "Timer Between Attempts"
 MATLAB_API_KEY = "Matlab API key"
 
@@ -102,6 +103,7 @@ def i_see_advanced_settings_with_values(step):
             [PROBLEM_WEIGHT, "", False],
             [RANDOMIZATION, "Never", False],
             [SHOW_ANSWER, "Finished", False],
+            [SHOW_RESET_BUTTON, "False", False],
             [TIMER_BETWEEN_ATTEMPTS, "0", False],
         ])
 

--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -29,6 +29,8 @@ from xblock.fields import Scope, String, Boolean, Dict, Integer, Float
 from .fields import Timedelta, Date
 from django.utils.timezone import UTC
 from .util.duedate import get_extended_due_date
+from xmodule.capa_base_constants import RANDOMIZATION, SHOWANSWER
+from django.conf import settings
 
 log = logging.getLogger("edx.courseware")
 
@@ -63,9 +65,9 @@ class Randomization(String):
     """
     def from_json(self, value):
         if value in ("", "true"):
-            return "always"
+            return RANDOMIZATION.ALWAYS
         elif value == "false":
-            return "per_student"
+            return RANDOMIZATION.PER_STUDENT
         return value
 
     to_json = from_json
@@ -103,15 +105,15 @@ class CapaFields(object):
     max_attempts = Integer(
         display_name=_("Maximum Attempts"),
         help=_("Defines the number of times a student can try to answer this problem. "
-              "If the value is not set, infinite attempts are allowed."),
+               "If the value is not set, infinite attempts are allowed."),
         values={"min": 0}, scope=Scope.settings
     )
     due = Date(help=_("Date that this problem is due by"), scope=Scope.settings)
     extended_due = Date(
         help=_("Date that this problem is due by for a particular student. This "
-             "can be set by an instructor, and will override the global due "
-             "date if it is set to a date that is later than the global due "
-             "date."),
+               "can be set by an instructor, and will override the global due "
+               "date if it is set to a date that is later than the global due "
+               "date."),
         default=None,
         scope=Scope.user_state,
     )
@@ -122,36 +124,45 @@ class CapaFields(object):
     showanswer = String(
         display_name=_("Show Answer"),
         help=_("Defines when to show the answer to the problem. "
-              "A default value can be set in Advanced Settings."),
+               "A default value can be set in Advanced Settings."),
         scope=Scope.settings,
-        default="finished",
+        default=SHOWANSWER.FINISHED,
         values=[
-            {"display_name": _("Always"), "value": "always"},
-            {"display_name": _("Answered"), "value": "answered"},
-            {"display_name": _("Attempted"), "value": "attempted"},
-            {"display_name": _("Closed"), "value": "closed"},
-            {"display_name": _("Finished"), "value": "finished"},
-            {"display_name": _("Correct or Past Due"), "value": "correct_or_past_due"},
-            {"display_name": _("Past Due"), "value": "past_due"},
-            {"display_name": _("Never"), "value": "never"}]
+            {"display_name": _("Always"), "value": SHOWANSWER.ALWAYS},
+            {"display_name": _("Answered"), "value": SHOWANSWER.ANSWERED},
+            {"display_name": _("Attempted"), "value": SHOWANSWER.ATTEMPTED},
+            {"display_name": _("Closed"), "value": SHOWANSWER.CLOSED},
+            {"display_name": _("Finished"), "value": SHOWANSWER.FINISHED},
+            {"display_name": _("Correct or Past Due"), "value": SHOWANSWER.CORRECT_OR_PAST_DUE},
+            {"display_name": _("Past Due"), "value": SHOWANSWER.PAST_DUE},
+            {"display_name": _("Never"), "value": SHOWANSWER.NEVER}]
     )
     force_save_button = Boolean(
         help=_("Whether to force the save button to appear on the page"),
         scope=Scope.settings,
         default=False
     )
+    reset_key = "DEFAULT_SHOW_RESET_BUTTON"
+    default_reset_button = getattr(settings, reset_key) if hasattr(settings, reset_key) else False
+    show_reset_button = Boolean(
+        display_name=_("Show Reset Button"),
+        help=_("Determines whether a 'Reset' button is shown so the user may reset their answer. "
+               "A default value can be set in Advanced Settings."),
+        scope=Scope.settings,
+        default=default_reset_button
+    )
     rerandomize = Randomization(
         display_name=_("Randomization"),
         help=_("Defines how often inputs are randomized when a student loads the problem. "
-             "This setting only applies to problems that can have randomly generated numeric values. "
-             "A default value can be set in Advanced Settings."),
-        default="never",
+               "This setting only applies to problems that can have randomly generated numeric values. "
+               "A default value can be set in Advanced Settings."),
+        default=RANDOMIZATION.NEVER,
         scope=Scope.settings,
         values=[
-            {"display_name": _("Always"), "value": "always"},
-            {"display_name": _("On Reset"), "value": "onreset"},
-            {"display_name": _("Never"), "value": "never"},
-            {"display_name": _("Per Student"), "value": "per_student"}
+            {"display_name": _("Always"), "value": RANDOMIZATION.ALWAYS},
+            {"display_name": _("On Reset"), "value": RANDOMIZATION.ONRESET},
+            {"display_name": _("Never"), "value": RANDOMIZATION.NEVER},
+            {"display_name": _("Per Student"), "value": RANDOMIZATION.PER_STUDENT}
         ]
     )
     data = String(help=_("XML data for the problem"), scope=Scope.content, default="<problem></problem>")
@@ -170,7 +181,7 @@ class CapaFields(object):
     weight = Float(
         display_name=_("Problem Weight"),
         help=_("Defines the number of points each problem is worth. "
-              "If the value is not set, each response field in the problem is worth one point."),
+               "If the value is not set, each response field in the problem is worth one point."),
         values={"min": 0, "step": .1},
         scope=Scope.settings
     )
@@ -254,7 +265,7 @@ class CapaMixin(CapaFields):
                     tb=cgi.escape(
                         u''.join(['Traceback (most recent call last):\n'] +
                         traceback.format_tb(sys.exc_info()[2])))
-                    )
+                )
                 # create a dummy problem with error message instead of failing
                 problem_text = (u'<problem><text><span class="inline-error">'
                                 u'Problem {url} has an error:</span>{msg}</text></problem>'.format(
@@ -274,9 +285,9 @@ class CapaMixin(CapaFields):
         """
         Choose a new seed.
         """
-        if self.rerandomize == 'never':
+        if self.rerandomize == RANDOMIZATION.NEVER:
             self.seed = 1
-        elif self.rerandomize == "per_student" and hasattr(self.runtime, 'seed'):
+        elif self.rerandomize == RANDOMIZATION.PER_STUDENT and hasattr(self.runtime, 'seed'):
             # see comment on randomization_bin
             self.seed = randomization_bin(self.runtime.seed, unicode(self.location).encode('utf-8'))
         else:
@@ -446,7 +457,7 @@ class CapaMixin(CapaFields):
         """
         Return True/False to indicate whether to show the "Check" button.
         """
-        submitted_without_reset = (self.is_submitted() and self.rerandomize == "always")
+        submitted_without_reset = (self.is_submitted() and self.rerandomize == RANDOMIZATION.ALWAYS)
 
         # If the problem is closed (past due / too many attempts)
         # then we do NOT show the "check" button
@@ -463,19 +474,20 @@ class CapaMixin(CapaFields):
         """
         is_survey_question = (self.max_attempts == 0)
 
-        if self.rerandomize in ["always", "onreset"]:
+        # If the problem is closed (and not a survey question with max_attempts==0),
+        # then do NOT show the reset button.
+        if (self.closed() and not is_survey_question):
+            return False
 
-            # If the problem is closed (and not a survey question with max_attempts==0),
-            # then do NOT show the reset button.
-            # If the problem hasn't been submitted yet, then do NOT show
-            # the reset button.
-            if (self.closed() and not is_survey_question) or not self.is_submitted():
+        # Button only shows up for randomized problems if the question has been submitted
+        if self.rerandomize in [RANDOMIZATION.ALWAYS, RANDOMIZATION.ONRESET] and self.is_submitted():
+            return True
+        else:
+            # Do NOT show the button if the problem is correct
+            if self.is_correct():
                 return False
             else:
-                return True
-        # Only randomized problems need a "reset" button
-        else:
-            return False
+                return self.show_reset_button
 
     def should_show_save_button(self):
         """
@@ -489,7 +501,7 @@ class CapaMixin(CapaFields):
             return not self.closed()
         else:
             is_survey_question = (self.max_attempts == 0)
-            needs_reset = self.is_submitted() and self.rerandomize == "always"
+            needs_reset = self.is_submitted() and self.rerandomize == RANDOMIZATION.ALWAYS
 
             # If the student has unlimited attempts, and their answers
             # are not randomized, then we do not need a save button
@@ -503,7 +515,7 @@ class CapaMixin(CapaFields):
             # In those cases. the if statement below is false,
             # and the save button can still be displayed.
             #
-            if self.max_attempts is None and self.rerandomize != "always":
+            if self.max_attempts is None and self.rerandomize != RANDOMIZATION.ALWAYS:
                 return False
 
             # If the problem is closed (and not a survey question with max_attempts==0),
@@ -697,28 +709,28 @@ class CapaMixin(CapaFields):
         """
         if self.showanswer == '':
             return False
-        elif self.showanswer == "never":
+        elif self.showanswer == SHOWANSWER.NEVER:
             return False
         elif self.runtime.user_is_staff:
             # This is after the 'never' check because admins can see the answer
             # unless the problem explicitly prevents it
             return True
-        elif self.showanswer == 'attempted':
+        elif self.showanswer == SHOWANSWER.ATTEMPTED:
             return self.attempts > 0
-        elif self.showanswer == 'answered':
+        elif self.showanswer == SHOWANSWER.ANSWERED:
             # NOTE: this is slightly different from 'attempted' -- resetting the problems
             # makes lcp.done False, but leaves attempts unchanged.
             return self.lcp.done
-        elif self.showanswer == 'closed':
+        elif self.showanswer == SHOWANSWER.CLOSED:
             return self.closed()
-        elif self.showanswer == 'finished':
+        elif self.showanswer == SHOWANSWER.FINISHED:
             return self.closed() or self.is_correct()
 
-        elif self.showanswer == 'correct_or_past_due':
+        elif self.showanswer == SHOWANSWER.CORRECT_OR_PAST_DUE:
             return self.is_correct() or self.is_past_due()
-        elif self.showanswer == 'past_due':
+        elif self.showanswer == SHOWANSWER.PAST_DUE:
             return self.is_past_due()
-        elif self.showanswer == 'always':
+        elif self.showanswer == SHOWANSWER.ALWAYS:
             return True
 
         return False
@@ -952,7 +964,7 @@ class CapaMixin(CapaFields):
             raise NotFoundError(_("Problem is closed."))
 
         # Problem submitted. Student should reset before checking again
-        if self.done and self.rerandomize == "always":
+        if self.done and self.rerandomize == RANDOMIZATION.ALWAYS:
             event_info['failure'] = 'unreset'
             self.track_function_unmask('problem_check_fail', event_info)
             if dog_stats_api:
@@ -1206,7 +1218,7 @@ class CapaMixin(CapaFields):
             # was presented to the user, with values interpolated etc, but that can be done
             # later if necessary.
             variant = ''
-            if self.rerandomize != 'never':
+            if self.rerandomize != RANDOMIZATION.NEVER:
                 variant = self.seed
 
             is_correct = correct_map.is_correct(input_id)
@@ -1333,7 +1345,7 @@ class CapaMixin(CapaFields):
 
         # Problem submitted. Student should reset before saving
         # again.
-        if self.done and self.rerandomize == "always":
+        if self.done and self.rerandomize == RANDOMIZATION.ALWAYS:
             event_info['failure'] = 'done'
             self.track_function_unmask('save_problem_fail', event_info)
             return {
@@ -1357,7 +1369,7 @@ class CapaMixin(CapaFields):
     def reset_problem(self, _data):
         """
         Changes problem state to unfinished -- removes student answers,
-        and causes problem to rerender itself.
+        Causes problem to rerender itself if randomization is enabled.
 
         Returns a dictionary of the form:
           {'success': True/False,
@@ -1380,7 +1392,7 @@ class CapaMixin(CapaFields):
                 'error': _("Problem is closed."),
             }
 
-        if not self.done:
+        if not self.is_submitted():
             event_info['failure'] = 'not_done'
             self.track_function_unmask('reset_problem_fail', event_info)
             return {
@@ -1389,7 +1401,7 @@ class CapaMixin(CapaFields):
                 'error': _("Refresh the page and make an attempt before resetting."),
             }
 
-        if self.rerandomize in ["always", "onreset"]:
+        if self.is_submitted() and self.rerandomize in [RANDOMIZATION.ALWAYS, RANDOMIZATION.ONRESET]:
             # Reset random number generator seed.
             self.choose_new_seed()
 

--- a/common/lib/xmodule/xmodule/capa_base_constants.py
+++ b/common/lib/xmodule/xmodule/capa_base_constants.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+"""
+Constants for capa_base problems
+"""
+
+
+class SHOWANSWER:
+    """
+    Constants for when to show answer
+    """
+    ALWAYS = "always"
+    ANSWERED = "answered"
+    ATTEMPTED = "attempted"
+    CLOSED = "closed"
+    FINISHED = "finished"
+    CORRECT_OR_PAST_DUE = "correct_or_past_due"
+    PAST_DUE = "past_due"
+    NEVER = "never"
+
+
+class RANDOMIZATION:
+    """
+    Constants for problem randomization
+    """
+    ALWAYS = "always"
+    ONRESET = "onreset"
+    NEVER = "never"
+    PER_STUDENT = "per_student"

--- a/common/lib/xmodule/xmodule/modulestore/inheritance.py
+++ b/common/lib/xmodule/xmodule/modulestore/inheritance.py
@@ -1,15 +1,16 @@
 """
 Support for inheritance of fields down an XBlock hierarchy.
 """
+from __future__ import absolute_import
 
 from datetime import datetime
 from pytz import UTC
-
 from xmodule.partitions.partitions import UserPartition
 from xblock.fields import Scope, Boolean, String, Float, XBlockMixin, Dict, Integer, List
 from xblock.runtime import KeyValueStore, KvsFieldData
-
 from xmodule.fields import Date, Timedelta
+from django.conf import settings
+
 
 # Make '_' a no-op so we can scrape strings
 _ = lambda text: text
@@ -151,6 +152,16 @@ class InheritanceMixin(XBlockMixin):
         help=_("Enter true or false. If true, video caching will be used for HTML5 videos."),
         default=True,
         scope=Scope.settings
+    )
+
+    reset_key = "DEFAULT_SHOW_RESET_BUTTON"
+    default_reset_button = getattr(settings, reset_key) if hasattr(settings, reset_key) else False
+    show_reset_button = Boolean(
+        display_name=_("Show Reset Button for Problems"),
+        help=_("Enter true or false. If true, problems default to displaying a 'Reset' button. This value may be "
+               "overriden in each problem's settings. Existing problems whose reset setting have not been changed are affected."),
+        scope=Scope.settings,
+        default=default_reset_button
     )
 
 

--- a/lms/djangoapps/courseware/features/problems.feature
+++ b/lms/djangoapps/courseware/features/problems.feature
@@ -72,37 +72,77 @@ Feature: LMS.Answer problems
 
 
     Scenario: I can reset a problem
-        Given I am viewing a "<ProblemType>" problem
+        Given I am viewing a randomization "<Randomization>" "<ProblemType>" problem with reset button on
         And I answer a "<ProblemType>" problem "<Correctness>ly"
         When I reset the problem
         Then my "<ProblemType>" answer is marked "unanswered"
         And The "<ProblemType>" problem displays a "blank" answer
 
         Examples:
-        | ProblemType       | Correctness   |
-        | drop down         | correct       |
-        | drop down         | incorrect     |
-        | multiple choice   | correct       |
-        | multiple choice   | incorrect     |
-        | checkbox          | correct       |
-        | checkbox          | incorrect     |
-        | radio             | correct       |
-        | radio             | incorrect     |
-        | string            | correct       |
-        | string            | incorrect     |
-        | numerical         | correct       |
-        | numerical         | incorrect     |
-        | formula           | correct       |
-        | formula           | incorrect     |
-        | script            | correct       |
-        | script            | incorrect     |
-        | radio_text        | correct       |
-        | radio_text        | incorrect     |
-        | checkbox_text     | correct       |
-        | checkbox_text     | incorrect     |
-        | image             | correct       |
-        | image             | incorrect     |
+        | ProblemType       | Correctness   | Randomization |
+        | drop down         | correct       | always        |
+        | drop down         | incorrect     | always        |
+        | multiple choice   | correct       | always        |
+        | multiple choice   | incorrect     | always        |
+        | checkbox          | correct       | always        |
+        | checkbox          | incorrect     | always        |
+        | radio             | correct       | always        |
+        | radio             | incorrect     | always        |
+        | string            | correct       | always        |
+        | string            | incorrect     | always        |
+        | numerical         | correct       | always        |
+        | numerical         | incorrect     | always        |
+        | formula           | correct       | always        |
+        | formula           | incorrect     | always        |
+        | script            | correct       | always        |
+        | script            | incorrect     | always        |
+        | radio_text        | correct       | always        |
+        | radio_text        | incorrect     | always        |
+        | checkbox_text     | correct       | always        |
+        | checkbox_text     | incorrect     | always        |
+        | image             | correct       | always        |
+        | image             | incorrect     | always        |
 
+    Scenario: I can reset a non-randomized problem that I answer incorrectly
+        Given I am viewing a randomization "<Randomization>" "<ProblemType>" problem with reset button on
+        And I answer a "<ProblemType>" problem "<Correctness>ly"
+        When I reset the problem
+        Then my "<ProblemType>" answer is marked "unanswered"
+        And The "<ProblemType>" problem displays a "blank" answer
+
+        Examples:
+        | ProblemType       | Correctness   | Randomization   |
+        | drop down         | incorrect     | never           |
+        | drop down         | incorrect     | never           |
+        | multiple choice   | incorrect     | never           |
+        | checkbox          | incorrect     | never           |
+        | radio             | incorrect     | never           |
+        | string            | incorrect     | never           |
+        | numerical         | incorrect     | never           |
+        | formula           | incorrect     | never           |
+        | script            | incorrect     | never           |
+        | radio_text        | incorrect     | never           |
+        | checkbox_text     | incorrect     | never           |
+        | image             | incorrect     | never           |
+
+    Scenario: The reset button doesn't show up
+        Given I am viewing a randomization "<Randomization>" "<ProblemType>" problem with reset button on
+        And I answer a "<ProblemType>" problem "<Correctness>ly"
+        Then The "Reset" button does not appear
+
+        Examples:
+        | ProblemType       | Correctness   | Randomization   |
+        | drop down         | correct       | never           |
+        | multiple choice   | correct       | never           |
+        | checkbox          | correct       | never           |
+        | radio             | correct       | never           |
+        | string            | correct       | never           |
+        | numerical         | correct       | never           |
+        | formula           | correct       | never           |
+        | script            | correct       | never           |
+        | radio_text        | correct       | never           |
+        | checkbox_text     | correct       | never           |
+        | image             | correct       | never           |
 
     Scenario: I can answer a problem with one attempt correctly and not reset
         Given I am viewing a "multiple choice" problem with "1" attempt
@@ -114,6 +154,12 @@ Feature: LMS.Answer problems
         Then I should see "You have used 0 of 3 submissions" somewhere in the page
         When I answer a "multiple choice" problem "correctly"
         Then The "Reset" button does appear
+
+    Scenario: I can answer a problem with multiple attempts correctly but cannot reset because randomization is off
+        Given I am viewing a randomization "never" "multiple choice" problem with "3" attempts with reset
+        Then I should see "You have used 0 of 3 submissions" somewhere in the page
+        When I answer a "multiple choice" problem "correctly"
+        Then The "Reset" button does not appear
 
     Scenario: I can view how many attempts I have left on a problem
         Given I am viewing a "multiple choice" problem with "3" attempts
@@ -164,6 +210,34 @@ Feature: LMS.Answer problems
         | script            | incorrect     | 2 points possible   | 2 points possible  |
         | image             | correct       | 1/1 point           | 1 point possible   |
         | image             | incorrect     | 1 point possible    | 1 point possible   |
+
+    Scenario: I can see my score on a problem when I answer it and after I reset it
+        Given I am viewing a "<ProblemType>" problem with randomization "<Randomization>" with reset button on
+        When I answer a "<ProblemType>" problem "<Correctness>ly"
+        Then I should see a score of "<Score>"
+        When I reset the problem
+        Then I should see a score of "<Points Possible>"
+
+        Examples:
+        | ProblemType       | Correctness   | Score               | Points Possible    | Randomization |
+        | drop down         | correct       | 1/1 point           | 1 point possible   | never         |
+        | drop down         | incorrect     | 1 point possible    | 1 point possible   | never         |
+        | multiple choice   | correct       | 1/1 point           | 1 point possible   | never         |
+        | multiple choice   | incorrect     | 1 point possible    | 1 point possible   | never         |
+        | checkbox          | correct       | 1/1 point           | 1 point possible   | never         |
+        | checkbox          | incorrect     | 1 point possible    | 1 point possible   | never         |
+        | radio             | correct       | 1/1 point           | 1 point possible   | never         |
+        | radio             | incorrect     | 1 point possible    | 1 point possible   | never         |
+        | string            | correct       | 1/1 point           | 1 point possible   | never         |
+        | string            | incorrect     | 1 point possible    | 1 point possible   | never         |
+        | numerical         | correct       | 1/1 point           | 1 point possible   | never         |
+        | numerical         | incorrect     | 1 point possible    | 1 point possible   | never         |
+        | formula           | correct       | 1/1 point           | 1 point possible   | never         |
+        | formula           | incorrect     | 1 point possible    | 1 point possible   | never         |
+        | script            | correct       | 2/2 points          | 2 points possible  | never         |
+        | script            | incorrect     | 2 points possible   | 2 points possible  | never         |
+        | image             | correct       | 1/1 point           | 1 point possible   | never         |
+        | image             | incorrect     | 1 point possible    | 1 point possible   | never         |
 
     Scenario: I can see my score on a problem to which I submit a blank answer
         Given I am viewing a "<ProblemType>" problem

--- a/lms/djangoapps/courseware/features/problems.py
+++ b/lms/djangoapps/courseware/features/problems.py
@@ -26,6 +26,13 @@ def view_problem_with_attempts(step, problem_type, attempts):
     _view_problem(step, problem_type, {'max_attempts': attempts})
 
 
+@step(u'I am viewing a randomization "([^"]*)" "([^"]*)" problem with "([^"]*)" attempts with reset')
+def view_problem_attempts_reset(step, randomization, problem_type, attempts, ):
+    _view_problem(step, problem_type, {'max_attempts': attempts,
+                                       'rerandomize': randomization,
+                                       'show_reset_button': True})
+
+
 @step(u'I am viewing a "([^"]*)" that shows the answer "([^"]*)"')
 def view_problem_with_show_answer(step, problem_type, answer):
     _view_problem(step, problem_type, {'showanswer': answer})
@@ -34,6 +41,11 @@ def view_problem_with_show_answer(step, problem_type, answer):
 @step(u'I am viewing a "([^"]*)" problem')
 def view_problem(step, problem_type):
     _view_problem(step, problem_type)
+
+
+@step(u'I am viewing a randomization "([^"]*)" "([^"]*)" problem with reset button on')
+def view_random_reset_problem(step, randomization, problem_type):
+    _view_problem(step, problem_type, {'rerandomize': randomization, 'show_reset_button': True})
 
 
 @step(u'External graders respond "([^"]*)"')


### PR DESCRIPTION
Users may want to start anew when answering a question. This commit decouples reset from randomization while still preserving backward compatibility. Users can clear their input.
Instructors can set course-wide and problem-specific settings for reset button display.
