### PR TITLE
Image Annotation Tool: Border and tag-based coloring

### DIFF
--- a/common/static/css/vendor/ova/richText-annotator.css
+++ b/common/static/css/vendor/ova/richText-annotator.css
@@ -47,3 +47,8 @@ div.mce-tinymce.mce-container.mce-panel {
 	background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH3QkBBB07nraNoQAAAhZJREFUKM+NkstrE1EUxr+5c08ykztpJtVoazHBF8FgQQzonyBKEZS6FrQKLl0EXBRT0ZULJSs3oii4TyHgu90IlTaL6qouWlv7Ck1N0BSnmZk714WbPHz07M4534+Pw3eAHdTY8A9+Nd9/bshU1DpnO4HXjh2ZY2J9/OSTxHTrnP8PvJYf+BDQ6qEDaQBB43jrTusUFy4oPjsYWYzF+VS91nxLYfdhKgONaQT3W/KMxr1XY5e+qj86f8zsKYYsZ6AvjWFzA8ORHkAnwN8So7evzL/8pzMAXL/Hq8mMv1up371T7Z+/c3n9cKeuDS6Xy6dN07zLuZ56Onk2Ed2/ANJsnE/PQMpgyffle+kYzwazB1+3waVS6X48Hr9BRPB9H57nYXplFKeSt8D1Hriug9XKF0x+Lmw+ys8m2m42DOOn4zhQSsGyLOi6jqONm9isbmFVFlDbaGKx8QaB1rvdlbNhGLAsC0IIGIYBIQSy2ROQ0oOp7wOPraHXEugRvDtnzjmi0SiICEIIEBGklAB9B6cmbG0AUnrY5m73h+m6DsYYTNMEYwxEBMY0hGNVhHkcZigBO9qHlDHS7cwYg23bAIBQKAQigud7IH0XwtxDoHwEIQ9SLKx0wa7rPiaivYyxESklXNeFBg0mjyNQTQSuATMSm6ipuYt//eVcLhdeXl5+UKlUlur1upqamVAv3j3/VCyOD3VqfwF6uLp3q+vMcgAAAABJRU5ErkJggg==');
 	background-repeat: no-repeat;
 }
+
+/* Fixes conflicting design between tinymce css and annotator css */
+.mce-ico.mce-i-resize {
+	font-family: 'tinymce';
+}

--- a/common/static/js/vendor/ova/OpenSeaDragonAnnotation.js
+++ b/common/static/js/vendor/ova/OpenSeaDragonAnnotation.js
@@ -231,7 +231,11 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                 var span = document.createElement('span');
                 var rectPosition = an.rangePosition;
                 span.className = "annotator-hl";
-                span.style.border = '2px solid rgba(0,0,0,0.5)';
+                
+                // outline and border below create a double line one black and one white
+                // so to be able to differentiate when selecting dark or light images
+                span.style.border = '2px solid rgb(255, 255, 255)';
+                span.style.outline = '2px solid rgb(0, 0, 0)';
                 span.style.background = 'rgba(0,0,0,0)';
                 
                 // Adds listening items for the viewer and editor
@@ -305,7 +309,12 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                 viewer.innerTracker.setTracking(false);
                 this.rect = document.createElement('div');
                 this.rect.style.background = 'rgba(0,0,0,0)';
-                this.rect.style.border = '2px solid rgba(0,0,0,0.5)';
+                
+                // outline and border below create a double line one black and one white
+                // so to be able to differentiate when selecting dark or light images
+                this.rect.style.border = '2px solid rgb(255, 255, 255)';
+                this.rect.style.outline = '2px solid rgb(0, 0, 0)';
+                
                 this.rect.style.position = 'absolute';
                 this.rect.className = 'DrawingRect';
                 // set the initial position

--- a/common/static/js/vendor/ova/OpenSeaDragonAnnotation.js
+++ b/common/static/js/vendor/ova/OpenSeaDragonAnnotation.js
@@ -1035,6 +1035,10 @@ OpenSeadragonAnnotation = function (element, options) {
     function reloadEditor(){
         tinymce.EditorManager.execCommand('mceRemoveEditor',true, "annotator-field-0");
         tinymce.EditorManager.execCommand('mceAddEditor',true, "annotator-field-0");
+        
+        // if person hits into/out of fullscreen before closing the editor should close itself
+        // ideally we would want to keep it open and reposition, this would make a great TODO in the future
+        annotator.editor.hide();
     }
 
     var self = this;

--- a/common/static/js/vendor/ova/OpenSeaDragonAnnotation.js
+++ b/common/static/js/vendor/ova/OpenSeaDragonAnnotation.js
@@ -1053,6 +1053,14 @@ OpenSeadragonAnnotation = function (element, options) {
     document.addEventListener("msfullscreenchange", function () {
         reloadEditor();
     }, false);
+
+    // for some reason the above doesn't work when person hits ESC to exit full screen...
+    $(document).keyup(function(e) {
+        // esc key reloads editor as well
+        if (e.keyCode == 27) { 
+            reloadEditor();
+        }   
+    });
     
     this.options = options;
 

--- a/common/static/js/vendor/ova/OpenSeaDragonAnnotation.js
+++ b/common/static/js/vendor/ova/OpenSeaDragonAnnotation.js
@@ -187,7 +187,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             }
             
             // if the colored highlights by tags plugin it is notified to colorize
-               annotator.publish('colorizeHighlight', [an]);
+            annotator.publish('externalCallToHighlightTags', [an]);
         },
         
         /**

--- a/common/static/js/vendor/ova/catch/js/catch.js
+++ b/common/static/js/vendor/ova/catch/js/catch.js
@@ -1012,7 +1012,6 @@ CatchAnnotation.prototype = {
             // Set vertical editor
             this.annotator.editor.resetOrientation();
             this.annotator.editor.invertY();
-            this.annotator.editor.element.find('.annotator-widget').css('min-width', replyElem.css('width'));
 
             // set parent 
             var parentValue = $(this.annotator.editor.element).find(".reply-item span.parent-annotation");

--- a/common/static/js/vendor/ova/catch/js/catch.js
+++ b/common/static/js/vendor/ova/catch/js/catch.js
@@ -504,6 +504,13 @@ CatchAnnotation.prototype = {
         
         // Search Button
         el.on("click", ".searchbox .search-icon", onSearchButtonClick);
+        // Search should also run when user hits ENTER
+        $('input[name=search]').keyup(function(e) {
+            // ENTER == 13
+            if(e.which == 13) {
+                onSearchButtonClick();
+            }
+        });
 
         // Clear Search Button
         el.on("click", ".searchbox .clear-search-icon", onClearSearchButtonClick);

--- a/common/static/js/vendor/ova/catch/js/catch.js
+++ b/common/static/js/vendor/ova/catch/js/catch.js
@@ -1001,6 +1001,9 @@ CatchAnnotation.prototype = {
             var positionAnnotator = videojs.findPosition(wrapper[0]);
             var positionAdder = {};
 
+            // the following addition to display makes sure the editor shows up
+            // after opening TinyMCE/editor within the image source
+            positionAdder.display = "block";
             positionAdder.left = positionLeft.left - positionAnnotator.left;
             positionAdder.top = positionLeft.top + 20 - positionAnnotator.top;
 
@@ -1010,6 +1013,7 @@ CatchAnnotation.prototype = {
             this.annotator.onAdderClick();
             
             // Set vertical editor
+            $(this.annotator.editor.element).css(positionAdder);
             this.annotator.editor.resetOrientation();
             this.annotator.editor.invertY();
 

--- a/common/static/js/vendor/ova/reply-annotator.js
+++ b/common/static/js/vendor/ova/reply-annotator.js
@@ -64,14 +64,24 @@ Annotator.Plugin.Reply = (function(_super) {
 	
 	// New JSON for the database
 	Reply.prototype.pluginSubmit = function(field, annotation) {
-		var replyItem = $(this.annotator.editor.element).find(".reply-item span.parent-annotation"),
-			parent = replyItem.html()!=''?replyItem.html():'0';
-                console.log(parent);
-                console.log(replyItem.html());
-		if (parent!='0') annotation.media = 'comment';
-		annotation.parent = parent;//set 0, because it is not a reply
-		console.log(annotation.parent);
-                return annotation.parent;
+		// since each annotation has their own reply item, this "find" is element specific
+		var replyItem = $(this.annotator.editor.element).find(".reply-item span.parent-annotation");
+		// checks to see if the current annotation is a reply by checking parent numbers
+		var parent = replyItem.html() !== '' ? replyItem.html() : '0';
+		// if the parent number is not empty or zero, we know that this is a comment
+		if (parent !== '0') {
+			annotation.media = 'comment';
+		}
+
+		// apparently some browsers continue adding <font> tags here for nonreplies
+		// this will check and set to 0 (nonreply) if it fails
+		if (parseInt(parent, 10) === NaN){
+			parent = '0';
+		}
+		
+		// set 0, because it is not a reply
+		annotation.parent = parent;
+		return annotation.parent;
 	};
 	
 

--- a/common/static/js/vendor/ova/richText-annotator.js
+++ b/common/static/js/vendor/ova/richText-annotator.js
@@ -93,6 +93,17 @@ Annotator.Plugin.RichText = (function(_super) {
                 // set the modification in the textarea of annotator
                 $(editor.element).find('textarea')[0].value = tinymce.activeEditor.getContent();
             });
+
+            // creates a function called whenever editor is resized
+            ed.on('init', function(mceInstance) {
+
+                // get win means this event activates when window is resized
+                tinymce.dom.Event.bind(ed.getWin(), 'resize', function(e){
+
+                    // mceInstance.target gets the editor, its id is used to retrieved iframe
+                    $("#"+mceInstance.target.id+"_ifr").css('min-width', '400px');
+                });
+            });
             // new button to add Rubrics of the url https://gteavirtual.org/rubric
             ed.addButton('rubric', {
                 icon: 'rubric',

--- a/common/static/js/vendor/ova/tags-annotator.js
+++ b/common/static/js/vendor/ova/tags-annotator.js
@@ -293,6 +293,8 @@ $.TokenList = function (input, url_or_data, settings) {
                 case KEY.COMMA:
                   if(selected_dropdown_item) {
                     add_token($(selected_dropdown_item).data("tokeninput"));
+                    // this allows for tags to be color-coded based on instructor set-up
+                    annotator.publish("colorEditorTags")
                     hidden_input.change();
                     return false;
                   } else{
@@ -903,6 +905,7 @@ Annotator.Plugin.HighlightTags = (function(_super) {
         this.colorize = __bind(this.colorize, this);
         this.updateField = __bind(this.updateField, this);
         this.externalCall = __bind(this.externalCall, this);
+        this.colorizeEditorTags = __bind(this.colorizeEditorTags, this);
 
         this.options = options;
         _ref = HighlightTags.__super__.constructor.apply(this, arguments);
@@ -954,7 +957,7 @@ Annotator.Plugin.HighlightTags = (function(_super) {
         this.annotator.subscribe('flaggedAnnotation', this.updateViewer);
         this.annotator.subscribe('annotationCreated', function(){setTimeout(function(){self.colorize()}, 1000)});
         this.annotator.subscribe('externalCallToHighlightTags', function(){setTimeout(function(){self.externalCall()}, 1000)});
-
+        this.annotator.subscribe('colorEditorTags', this.colorizeEditorTags);
     };
     
     HighlightTags.prototype.getHighlightTags = function(){

--- a/common/static/js/vendor/ova/tags-annotator.js
+++ b/common/static/js/vendor/ova/tags-annotator.js
@@ -1028,22 +1028,24 @@ Annotator.Plugin.HighlightTags = (function(_super) {
         return getColorValues(item)
     }
     
-    HighlightTags.prototype.colorize = function(){
+    HighlightTags.prototype.colorize = function() {
         
         var annotations = Array.prototype.slice.call($(".annotator-hl"));
-        for (annNum = 0; annNum < annotations.length; ++annNum){
+        for (annNum = 0; annNum < annotations.length; ++annNum) {
             var anns = $.data(annotations[annNum],"annotation");
-            if (typeof anns.tags != "undefined" && anns.tags.length == 0) {
+            if (typeof anns.tags !== "undefined" && anns.tags.length == 0) {
+                
                 // image annotations should not change the background of the highlight
                 // only the border so as not to block the image behind it.
                 if (anns.media !== "image") {
-                    $(annotations[annNum]).css("background-color","");
+                    $(annotations[annNum]).css("background-color", "");
                 } else {
                     $(annotations[annNum]).css("border", "2px solid rgb(255, 255, 255)");
                     $(annotations[annNum]).css("outline", "2px solid rgb(0, 0, 0)");
                 }
             }
-            if (typeof anns.tags != "undefined" && this.colors !== {}) {
+
+            if (typeof anns.tags !== "undefined" && this.colors !== {}) {
                 
                 for (var index = 0; index < anns.tags.length; ++index) {
                     if (anns.tags[index].indexOf("flagged-") == -1) {
@@ -1079,7 +1081,7 @@ Annotator.Plugin.HighlightTags = (function(_super) {
                 
             } else {
                 // if there are no tags or predefined colors, keep the background at default
-                if (anns.media !== "image"){
+                if (anns.media !== "image") {
                    $(annotations[annNum]).css("background","");
                 }
             }
@@ -1088,34 +1090,41 @@ Annotator.Plugin.HighlightTags = (function(_super) {
         this.annotator.publish('colorizeCompleted');
     }
     
-    HighlightTags.prototype.updateField = function(field, annotation){
-            
-    
-            if(this.isFirstTime){
-                var tags = this.options.tag.split(",");
-        var tokensavailable = [];
-                tags.forEach (function(tagnames){
-            lonename = tagnames.split(":");
-            
-            tokensavailable.push({'id': lonename[0], 'name':lonename[0]});
-        });
-                $("#tag-input").tokenInput(tokensavailable);
-                this.isFirstTime = false;
-            }
-            $('#token-input-tag-input').attr('placeholder','Add tags...');
-            $('#tag-input').tokenInput('clear');            
-            if (typeof annotation.tags != "undefined") {
-                for (tagnum = 0; tagnum < annotation.tags.length; tagnum++){
-                    var n = annotation.tags[tagnum];
-                        if (typeof this.annotator.plugins["HighlightTags"] != 'undefined') {
-                            if (annotation.tags[tagnum].indexOf("flagged-")==-1){
-                                $('#tag-input').tokenInput('add',{'id':n,'name':n});
-                            }
-                        } else{
-                            $('#tag-input').tokenInput('add',{'id':n,'name':n});
-                        }
+    HighlightTags.prototype.updateField = function(field, annotation) {
+        // the first time that this plug in runs, the predetermined instructor tags are
+        // added and stored for the dropdown list
+        if(this.isFirstTime) {
+            var tags = this.options.tag.split(",");
+            var tokensavailable = [];
+
+            // tags are given the structure that the dropdown/token function requires
+            tags.forEach (function(tagnames) {
+                lonename = tagnames.split(":");
+                tokensavailable.push({'id': lonename[0], 'name': lonename[0]});
+            });
+
+            // they are then added to the appropriate input for tags in annotator
+            $("#tag-input").tokenInput(tokensavailable);
+            this.isFirstTime = false;
+        }
+
+        $('#token-input-tag-input').attr('placeholder', 'Add tags...');
+        $('#tag-input').tokenInput('clear');            
+        
+        // loops through the tags already in the annotation and "add" them to this annotation
+        if (typeof annotation.tags !== "undefined") {
+            for (tagnum = 0; tagnum < annotation.tags.length; tagnum++) {
+                var n = annotation.tags[tagnum];
+                if (typeof this.annotator.plugins["HighlightTags"] !== 'undefined') {
+                    // if there are flags, we must ignore them
+                    if (annotation.tags[tagnum].indexOf("flagged-") == -1) {
+                        $('#tag-input').tokenInput('add',{'id':n,'name':n});
+                    }
+                } else {
+                    $('#tag-input').tokenInput('add', {'id': n, 'name': n});
                 }
             }
+        }
         this.colorizeEditorTags();
     }
 
@@ -1142,7 +1151,7 @@ Annotator.Plugin.HighlightTags = (function(_super) {
         });    
     }
     
-    //The following function is run when a person hits submit.
+    // The following function is run when a person hits submit.
     HighlightTags.prototype.pluginSubmit = function(field, annotation) {
         var tokens = Array.prototype.slice.call($(".token-input-input-token").parent().find('.token-input-token'));
         var arr = [];
@@ -1153,16 +1162,21 @@ Annotator.Plugin.HighlightTags = (function(_super) {
         annotation.tags = arr;
     }
 
-    //The following allows you to edit the annotation popup when the viewer has already
-    //hit submit and is just viewing the annotation.
+    // The following allows you to edit the annotation popup when the viewer has already
+    // hit submit and is just viewing the annotation.
     HighlightTags.prototype.updateViewer = function(field, annotation) {
         if (typeof annotation.tags != "undefined") {
+            
+            // if there are no tags, the space for tags in the pop up is removed and function ends
             if (annotation.tags.length == 0) {
                 $(field).remove();
                 return;
             }
+
+            // otherwise we prepare to loop through them
             var nonFlagTags = true;
             var tokenList = "<ul class=\"token-input-list\">";
+
             for (tagnum = 0; tagnum < annotation.tags.length; ++tagnum){
                 if (typeof this.annotator.plugins["Flagging"] !== 'undefined') {
                     // once again we ingore flags
@@ -1190,18 +1204,20 @@ Annotator.Plugin.HighlightTags = (function(_super) {
             }
             tokenList += "</ul>";
             $(field).append(tokenList);
+
+            // the field for tags is removed also if all the tags ended up being flags
             if (nonFlagTags) {
                 $(field).remove();
             }
             
-        } else{
+        } else {
             $(field).remove();
         }
         this.annotator.publish("finishedDrawingTags");
     }
     
-    //The following will call the colorize function during an external call and then return
-    //an event signaling completion.
+    // The following will call the colorize function during an external call and then return
+    // an event signaling completion.
     HighlightTags.prototype.externalCall = function() {
         this.colorize();
         this.annotator.publish('finishedExternalCallToHighlightTags');


### PR DESCRIPTION
This addresses the Feature Request **[TNL-596]**.
**Affected Courses:**  4 courses are affected (PoetryX, HeroesX, Visualizing Japan, ChinaX) with a total enrollment 47,000 students. 
**Ideal Fix Deployment:** Week of November 2nd.

**Background:** This is the last feature request for the Annotation tools before a feature lock to work on reorganizing the code, creating proper and adequate documentation and testing. There is now a working document for testing the tools in a live setting found [here](https://docs.google.com/document/d/10BcGZRlOHTyBiBsk6OreUXzkU3m8Ju2K6hGic6Lw-9k/edit#). 

**Studio Changes:** None.

**LMS Changes:** Note the [feature request](https://openedx.atlassian.net/browse/TNL-596). Here are screenshots of things you should now see:
1. In the Image Annotation Tool, you should see a white and black border around selections now. This is to help in black/white images where the dark border might fade into the background.
![Double borders](http://i.imgur.com/Oy5CA1K.jpg)
2. In the Image Annotation Tool, if you put in a tag you should now see the border change to the appropriate color (it takes a second to wait for a response from the annotation server) and it changes the tag to the same color:
![colored borders and tags](http://i.imgur.com/LLYPsNz.jpg)
3. 2 minor CSS changes which will be noted in line comments within the code changes. One to add the missing icon for resizing the text box:
![resize image](http://i.imgur.com/LPHZv4q.png)
And the other one is to make the reply box the same size as the box when you create an annotation, i.e. shorter as it usually goes off the page:
![resize reply editor](http://i.imgur.com/odkDO57.png)
4. These will be noted in the code as well, 2 small oversights causing issues: First, even though TinyMCE is now loaded if you enter and exit full screen mode in the image annotation, apparently hitting ESC is a different call, so I've extended TinyMCE to be reloaded if a user hits escape. Second, our backend developer noted that users would sometimes hit errors when trying to create annotations within text that included <font> tags. I've created a basic stupid check to make sure I'm sending the right information. He's creating a fix on his end to double the stupid check to make sure it doesn't happen even if it slips through a crack from my end.

**Testing:**
1. Install the [tarball](https://www.dropbox.com/s/r684ber7z4ddqtc/2014_T4.DPRfFs.tar.gz) as usual.
2. In the image annotation tool create an annotation. It should contain a black/white double border.
3. Add a predeterminted tag (it should autocomplete if you start typing either "teachingAssistant" or "professor") and it should change the color of the border as well as the tag in the viewer that pops up if you scroll over it.
4. Refresh the page to make sure it still works and is being saved on the backend
5. Hit the reply button. Note that the resize image and the width of the box are as shown in the images above.
6. Open up the image in fullscreen mode (there's a button next to the "Annotate" button). Once there hit escape or select "Exit fullscreen". Try creating an annotation and see if you can type into the editor. Before once you were out of fullscreen mode and tried to create an annotation it would not allow anything to be typed into the editor. Now it should work as intended.
