### PR TITLE
Remove references to /tmp in tests

### DIFF
--- a/cms/envs/test.py
+++ b/cms/envs/test.py
@@ -138,7 +138,7 @@ CACHES = {
 
     'mongo_metadata_inheritance': {
         'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
-        'LOCATION': '/var/tmp/mongo_metadata_inheritance',
+        'LOCATION': os.path.join(tempfile.gettempdir(), 'mongo_metadata_inheritance'),
         'TIMEOUT': 300,
         'KEY_FUNCTION': 'util.memcache.safe_key',
     },

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_modulestore_settings.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_modulestore_settings.py
@@ -3,13 +3,14 @@ Tests for testing the modulestore settings migration code.
 """
 import copy
 import ddt
+from tempfile import mkdtemp
+
 from unittest import TestCase
 from xmodule.modulestore.modulestore_settings import (
     convert_module_store_setting_if_needed,
     update_module_store_settings,
     get_mixed_stores,
 )
-
 
 @ddt.ddt
 class ModuleStoreSettingsMigration(TestCase):
@@ -35,7 +36,7 @@ class ModuleStoreSettingsMigration(TestCase):
                 "collection": "modulestore",
                 "db": "edxapp",
                 "default_class": "xmodule.hidden_module.HiddenDescriptor",
-                "fs_root": "/edx/var/edxapp/data",
+                "fs_root": mkdtemp(),
                 "host": "localhost",
                 "password": "password",
                 "port": 27017,

--- a/lms/envs/bok_choy.env.json
+++ b/lms/envs/bok_choy.env.json
@@ -75,11 +75,6 @@
     },
     "FEEDBACK_SUBMISSION_EMAIL": "",
     "GITHUB_REPO_ROOT": "** OVERRIDDEN **",
-    "GRADES_DOWNLOAD": {
-        "BUCKET": "edx-grades",
-        "ROOT_PATH": "/tmp/edx-s3/grades",
-        "STORAGE_TYPE": "localfs"
-    },
     "LMS_BASE": "localhost:8003",
     "LOCAL_LOGLEVEL": "INFO",
     "LOGGING_ENV": "sandbox",

--- a/lms/envs/bok_choy.py
+++ b/lms/envs/bok_choy.py
@@ -4,7 +4,7 @@ Settings for bok choy tests
 
 import os
 from path import path
-
+from tempfile import mkdtemp
 
 CONFIG_ROOT = path(__file__).abspath().dirname()  # pylint: disable=E1120
 TEST_ROOT = CONFIG_ROOT.dirname().dirname() / "test_root"
@@ -41,6 +41,13 @@ update_module_store_settings(
     },
     default_store=os.environ.get('DEFAULT_STORE', 'draft'),
 )
+
+###################### Grade Downloads ######################
+GRADES_DOWNLOAD = {
+    'STORAGE_TYPE': 'localfs',
+    'BUCKET': 'edx-grades',
+    'ROOT_PATH': os.path.join(mkdtemp(), 'edx-s3', 'grades'),
+}
 
 # Configure the LMS to use our stub XQueue implementation
 XQUEUE_INTERFACE['url'] = 'http://localhost:8040'

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -178,7 +178,7 @@ CACHES = {
 
     'mongo_metadata_inheritance': {
         'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
-        'LOCATION': '/var/tmp/mongo_metadata_inheritance',
+        'LOCATION': os.path.join(tempfile.gettempdir(), 'mongo_metadata_inheritance'),
         'TIMEOUT': 300,
         'KEY_FUNCTION': 'util.memcache.safe_key',
     },

--- a/pavelib/assets.py
+++ b/pavelib/assets.py
@@ -8,6 +8,7 @@ from watchdog.observers import Observer
 from watchdog.events import PatternMatchingEventHandler
 import glob
 import traceback
+import os
 from .utils.envs import Env
 from .utils.cmd import cmd, django_cmd
 
@@ -16,7 +17,15 @@ from .utils.cmd import cmd, django_cmd
 COFFEE_DIRS = ['lms', 'cms', 'common']
 SASS_LOAD_PATHS = ['./common/static/sass']
 SASS_UPDATE_DIRS = ['*/static']
-SASS_CACHE_PATH = '/tmp/sass-cache'
+
+# If running at Solano labs, multiple builds could be running on the
+# same VM, so do not hard code the path to /tmp.
+# Instead use the thread-safe temp dir.
+if os.getenv('TDDIUM'):
+    SASS_CACHE_PATH = os.path.join(os.getenv('TDDIUM_TMPDIR'), 'sass-cache')
+else:
+    SASS_CACHE_PATH = '/tmp/sass-cache'
+
 
 THEME_COFFEE_PATHS = []
 THEME_SASS_PATHS = []


### PR DESCRIPTION
This is to make progress towards supporting Solano or other CIs (e.g. jenkins running concurrent jobs per worker).

Including:
- Change path for mongo_metadata_inheritance to use unique temp dir
- Update SASS_CACHE_PATH with thread-safe temp dir
- Remove hard coded directory reference for grades download tests
- Remove hard coded directory reference for direct mongo test

@benpatterson @clytwynec @muhammad-ammar 
