### PR TITLE
cache user ids for users with disabled accounts

### DIFF
--- a/common/djangoapps/student/middleware.py
+++ b/common/djangoapps/student/middleware.py
@@ -4,8 +4,12 @@ disabled accounts from accessing the site.
 """
 from django.http import HttpResponseForbidden
 from django.utils.translation import ugettext as _
+from django.core.cache import cache
 from django.conf import settings
 from student.models import UserStanding
+
+# Generate UserStanding cache on startup
+UserStanding.generate_cache()
 
 class UserStandingMiddleware(object):
     """
@@ -14,24 +18,17 @@ class UserStandingMiddleware(object):
     """
     def process_request(self, request):
         user = request.user
-        try:
-            user_account = UserStanding.objects.get(user=user.id)
-            # because user is a unique field in UserStanding, there will either be
-            # one or zero user_accounts associated with a UserStanding
-        except UserStanding.DoesNotExist:
-            pass
-        else:
-            if user_account.account_status == UserStanding.ACCOUNT_DISABLED:
-                msg = _(
-                            'Your account has been disabled. If you believe '
-                            'this was done in error, please contact us at '
-                            '{link_start}{support_email}{link_end}'
-                        ).format(
-                            support_email=settings.DEFAULT_FEEDBACK_EMAIL,
-                            link_start=u'<a href="mailto:{address}?subject={subject_line}">'.format(
-                                address=settings.DEFAULT_FEEDBACK_EMAIL,
-                                subject_line=_('Disabled Account'),
-                            ),
-                            link_end=u'</a>'
-                        )
-                return HttpResponseForbidden(msg)
+        if user.id in cache.get('disabled_account_ids', []):
+            msg = _(
+                        'Your account has been disabled. If you believe '
+                        'this was done in error, please contact us at '
+                        '{link_start}{support_email}{link_end}'
+                    ).format(
+                        support_email=settings.DEFAULT_FEEDBACK_EMAIL,
+                        link_start=u'<a href="mailto:{address}?subject={subject_line}">'.format(
+                            address=settings.DEFAULT_FEEDBACK_EMAIL,
+                            subject_line=_('Disabled Account'),
+                        ),
+                        link_end=u'</a>'
+                    )
+            return HttpResponseForbidden(msg)


### PR DESCRIPTION
@ormsbee , not sure if this is the right idea. I noticed that the UserStanding table was taking up a lot of db time, which is ridiculous seeing how small of a table it is. I thought caching its relevant content might speed up our response time. 

See:
https://rpm.newrelic.com/accounts/88178/applications/3343327/databases#id=407521706
