### PR TITLE
Fixed UnicodeEncodeError in student`s migrations

### DIFF
--- a/common/djangoapps/student/migrations/0035_access_roles.py
+++ b/common/djangoapps/student/migrations/0035_access_roles.py
@@ -145,10 +145,10 @@ class Migration(DataMigration):
         if self.mongostore is not None:
             course_son = bson.son.SON([
                 ('_id.tag', 'i4x'),
-                ('_id.org', re.compile(r'^{}$'.format(downcased_ssck.org), re.IGNORECASE)),
-                ('_id.course', re.compile(r'^{}$'.format(downcased_ssck.course), re.IGNORECASE)),
+                ('_id.org', re.compile(ur'^{}$'.format(downcased_ssck.org), re.IGNORECASE | re.UNICODE)),
+                ('_id.course', re.compile(ur'^{}$'.format(downcased_ssck.course), re.IGNORECASE | re.UNICODE)),
                 ('_id.category', 'course'),
-                ('_id.name', re.compile(r'^{}$'.format(downcased_ssck.run), re.IGNORECASE)),
+                ('_id.name', re.compile(ur'^{}$'.format(downcased_ssck.run), re.IGNORECASE | re.UNICODE)),
             ])
             entry = self.mongostore.collection.find_one(course_son)
             if entry:

--- a/common/djangoapps/student/migrations/0036_access_roles_orgless.py
+++ b/common/djangoapps/student/migrations/0036_access_roles_orgless.py
@@ -112,10 +112,10 @@ class Migration(DataMigration):
         if self.mongostore is not None:
             course_son = bson.son.SON([
                 ('_id.tag', 'i4x'),
-                ('_id.org', re.compile(r'^{}$'.format(downcased_ssck.org), re.IGNORECASE)),
-                ('_id.course', re.compile(r'^{}$'.format(downcased_ssck.course), re.IGNORECASE)),
+                ('_id.org', re.compile(ur'^{}$'.format(downcased_ssck.org), re.IGNORECASE | re.UNICODE)),
+                ('_id.course', re.compile(ur'^{}$'.format(downcased_ssck.course), re.IGNORECASE | re.UNICODE)),
                 ('_id.category', 'course'),
-                ('_id.name', re.compile(r'^{}$'.format(downcased_ssck.run), re.IGNORECASE)),
+                ('_id.name', re.compile(ur'^{}$'.format(downcased_ssck.run), re.IGNORECASE | re.UNICODE)),
             ])
             entry = self.mongostore.collection.find_one(course_son)
             if entry:


### PR DESCRIPTION
I've been migrating my old DB (haven't migrated since Apr) and got the error bellow. The same error occurs in `0036_access_roles_orgless`
This PR fixed it for me.

```
Running migrations for student:
 - Migrating forwards to 0041_add_dashboard_config.
 > student:0034_auto__add_courseaccessrole
 > student:0035_access_roles
 - Migration 'student:0035_access_roles' is marked for no-dry-run.
 ! Error found during real run of migration! Aborting.

 ! Since you have a database that does not support running
 ! schema-altering statements in transactions, we have had
 ! to leave it in an interim state between migrations.

! You *might* be able to recover with:   (migration cannot be dry-run; cannot discover commands)
 ! The South developers regret this has happened, and would
 ! like to gently persuade you to consider a slightly
 ! easier-to-deal-with DBMS (one that supports DDL transactions)
 ! NOTE: The error which caused the migration to fail is further up.
Error in migration: student:0035_access_roles
Traceback (most recent call last):
  File "./manage.py", line 99, in <module>
    execute_from_command_line([sys.argv[0]] + django_args)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 443,                            in execute_from_command_line
    utility.execute()
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 382,                            in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/management/base.py", line 196, in r                           un_from_argv
    self.execute(*args, **options.__dict__)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/management/base.py", line 232, in e                           xecute
    output = self.handle(*args, **options)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/management/base.py", line 371, in h                           andle
    return self.handle_noargs(**options)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/south/management/commands/syncdb.py", line 99,                            in handle_noargs
    management.call_command('migrate', **options)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 150,                            in call_command
    return klass.execute(*args, **defaults)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/management/base.py", line 232, in e                           xecute
    output = self.handle(*args, **options)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/south/management/commands/migrate.py", line 108                           , in handle
    ignore_ghosts = ignore_ghosts,
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/south/migration/__init__.py", line 213, in migr                           ate_app
    success = migrator.migrate_many(target, workplan, database)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/south/migration/migrators.py", line 235, in mig                           rate_many
    result = migrator.__class__.migrate_many(migrator, target, migrations, database)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/south/migration/migrators.py", line 310, in mig                           rate_many
    result = self.migrate(migration, database)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/south/migration/migrators.py", line 133, in mig                           rate
    result = self.run(migration)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/south/migration/migrators.py", line 107, in run
    return self.run_migration(migration)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/south/migration/migrators.py", line 81, in run_                           migration
    migration_function()
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/south/migration/migrators.py", line 57, in <lam                           bda>
    return (lambda: direction(orm))
  File "/edx/app/edxapp/edx-platform/common/djangoapps/student/migrations/0035_access_roles.py", line 90, in forwards
    correct_course_key = self._map_downcased_ssck(course_key)
  File "/edx/app/edxapp/edx-platform/common/djangoapps/student/migrations/0035_access_roles.py", line 148, in _map_dow                           ncased_ssck
    ('_id.org', re.compile(r'^{}$'.format(downcased_ssck.org), re.IGNORECASE)),
UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-7: ordinal not in range(128)
```
