### PR TITLE
TNL-281: reduce amount of JS in marketing iframe

### DIFF
--- a/lms/templates/courseware/mktg_course_about.html
+++ b/lms/templates/courseware/mktg_course_about.html
@@ -52,7 +52,13 @@
             <div class="action is-registered">${_("You Are Enrolled")}</div>
           %endif
         %elif allow_registration:
-        <a class="action action-register register ${'has-option-verified' if len(course_modes) > 1 else ''}" href="#">${_("Enroll in")} <strong>${course.display_number_with_default | h}</strong>
+        <a class="action action-register register ${'has-option-verified' if len(course_modes) > 1 else ''}"
+            %if user.is_authenticated():
+                href="${reverse('about_course', args=[course.id.to_deprecated_string()])}"
+            %else:
+                href="${reverse('register_user')}?course_id=${course.id | u}&enrollment_action=enroll"
+            %endif
+        >${_("Enroll in")} <strong>${course.display_number_with_default | h}</strong>
             %if len(course_modes) > 1:
             <span class="track">
             ## Translators: This is the second line on a button users can click.  The first line is "Enroll in COURSE_NAME"

--- a/lms/templates/mktg_iframe.html
+++ b/lms/templates/mktg_iframe.html
@@ -13,8 +13,7 @@
 
   <%static:css group='style-vendor'/>
   <%static:css group='style-app'/>
-
-  <%static:js group='main_vendor'/>
+  <%static:js group='base_vendor'/>
 
   <!--[if lt IE 9]>
     <script src="${static.url('js/html5shiv.js')}"></script>


### PR DESCRIPTION
It probably makes sense to not send lms-main_vendor.js for this view since it's 1MB and dramatically slows down the first page render. 

Acceptance criteria:
- Allow the bit of LMS that displays the registration button on the marketing site to load without the whole LMS javascript coming along with it.

Tested registration with:
- marketing site: https://dev.edx.org/course/edx/edx-demox-1-demox-4116?lms=http://tymofij.m.sandbox.edx.org (please enable loading remote iframe content by clicking on the shield icon in the location bar)
- LMS: http://tymofij.m.sandbox.edx.org

JS size decreased from 960k to 100k
Also adds clickable link on the button for those who like to open links in new tabs.
- Register-and-enrolд for anonymous users
- Course about page (with big Enroll button) for registered users
