### PR TITLE
Temporary fix for runtime.resources_fs error

### DIFF
--- a/lms/lib/xblock/runtime.py
+++ b/lms/lib/xblock/runtime.py
@@ -196,3 +196,11 @@ class LmsModuleSystem(LmsHandlerUrls, ModuleSystem):  # pylint: disable=abstract
         )
         services['fs'] = xblock.reference.plugins.FSService()
         super(LmsModuleSystem, self).__init__(**kwargs)
+
+    # backward compatibility fix for callers not knowing this is a ModuleSystem v DescriptorSystem
+    @property
+    def resources_fs(self):
+        """
+        Return what would be the resources_fs on a DescriptorSystem
+        """
+        return getattr(self, 'filestore', None)


### PR DESCRIPTION
@stephensanchez @adampalay fix for TNL-644

@cpennington I assume you'll figure out the correct way to fix this. I'm wondering if the caller which is trying to construct an LmsModuleSystem should check whether descriptor.runtime is already that.
