### PR TITLE
WL-98

### DIFF
--- a/lms/djangoapps/instructor/enrollment.py
+++ b/lms/djangoapps/instructor/enrollment.py
@@ -331,6 +331,10 @@ def send_mail_to_student(student, param_dict):
             'emails/remove_beta_tester_email_subject.txt',
             'emails/remove_beta_tester_email_message.txt'
         ),
+        'account_creation_and_enrollment': (
+            'emails/enroll_email_enrolledsubject.txt',
+            'emails/account_creation_and_enroll_emailMessage.txt'
+        ),
     }
 
     subject_template, message_template = email_template_dict.get(message_type, (None, None))

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -9,6 +9,7 @@ import requests
 import datetime
 import ddt
 import random
+import io
 from urllib import quote
 from django.test import TestCase
 from nose.tools import raises
@@ -40,6 +41,7 @@ from courseware.models import StudentModule
 # modules which are mocked in test cases.
 import instructor_task.api
 import instructor.views.api
+from instructor.views.api import generate_unique_password
 from instructor.views.api import _split_input_list, common_exceptions_400
 from instructor_task.api_helper import AlreadyRunningError
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
@@ -48,6 +50,8 @@ from shoppingcart.models import (
     PaidCourseRegistration, Coupon, Invoice, CourseRegistrationCode
 )
 from course_modes.models import CourseMode
+from django.core.files.uploadedfile import SimpleUploadedFile
+from student.models import NonExistentCourseError
 
 from .test_tools import msk_from_problem_urlname
 from ..views.tools import get_extended_due
@@ -283,6 +287,242 @@ class TestInstructorAPIDenyLevels(ModuleStoreTestCase, LoginEnrollmentTestCase):
                 200,
                 "Instructor should be allowed to access endpoint " + endpoint
             )
+
+
+@override_settings(MODULESTORE=TEST_DATA_MIXED_MODULESTORE)
+@patch.dict(settings.FEATURES, {'ALLOW_AUTOMATED_SIGNUPS': True})
+class TestInstructorAPIBulkAccountCreationAndEnrollment(ModuleStoreTestCase, LoginEnrollmentTestCase):
+    """
+    Test Bulk account creation and enrollment from csv file
+    """
+    def setUp(self):
+        self.request = RequestFactory().request()
+        self.course = CourseFactory.create()
+        self.instructor = InstructorFactory(course_key=self.course.id)
+        self.client.login(username=self.instructor.username, password='test')
+        self.url = reverse('register_and_enroll_students', kwargs={'course_id': self.course.id.to_deprecated_string()})
+
+        self.not_enrolled_student = UserFactory(
+            username='NotEnrolledStudent',
+            email='nonenrolled@test.com',
+            first_name='NotEnrolled',
+            last_name='Student'
+        )
+
+    @patch('instructor.views.api.log.info')
+    def test_account_creation_and_enrollment_with_csv(self, info_log):
+        """
+        Happy path test to create a single new user
+        """
+        csv_content = "test_student@example.com,test_student_1,tester1,USA"
+        uploaded_file = SimpleUploadedFile("temp.csv", csv_content)
+        response = self.client.post(self.url, {'students_list': uploaded_file})
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content)
+        self.assertEquals(len(data['row_errors']), 0)
+        self.assertEquals(len(data['warnings']), 0)
+        self.assertEquals(len(data['general_errors']), 0)
+
+        # test the log for email that's send to new created user.
+        info_log.assert_called_with('email sent to new created user at test_student@example.com')
+
+    @patch('instructor.views.api.log.info')
+    def test_account_creation_and_enrollment_with_csv_with_blank_lines(self, info_log):
+        """
+        Happy path test to create a single new user
+        """
+        csv_content = "\ntest_student@example.com,test_student_1,tester1,USA\n\n"
+        uploaded_file = SimpleUploadedFile("temp.csv", csv_content)
+        response = self.client.post(self.url, {'students_list': uploaded_file})
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content)
+        self.assertEquals(len(data['row_errors']), 0)
+        self.assertEquals(len(data['warnings']), 0)
+        self.assertEquals(len(data['general_errors']), 0)
+
+        # test the log for email that's send to new created user.
+        info_log.assert_called_with('email sent to new created user at test_student@example.com')
+
+    @patch('instructor.views.api.log.info')
+    def test_email_and_username_already_exist(self, info_log):
+        """
+        If the email address and username already exists
+        and the user is enrolled in the course, do nothing (including no email gets sent out)
+        """
+        csv_content = "test_student@example.com,test_student_1,tester1,USA\n" \
+                      "test_student@example.com,test_student_1,tester2,US"
+        uploaded_file = SimpleUploadedFile("temp.csv", csv_content)
+        response = self.client.post(self.url, {'students_list': uploaded_file})
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content)
+        self.assertEquals(len(data['row_errors']), 0)
+        self.assertEquals(len(data['warnings']), 0)
+        self.assertEquals(len(data['general_errors']), 0)
+
+        # test the log for email that's send to new created user.
+        info_log.assert_called_with("user already exists with username '{username}' and email '{email}'".format(username='test_student_1', email='test_student@example.com'))
+
+    def test_bad_file_upload_type(self):
+        """
+        Try uploading some non-CSV file and verify that it is rejected
+        """
+        uploaded_file = SimpleUploadedFile("temp.jpg", io.BytesIO(b"some initial binary data: \x00\x01").read())
+        response = self.client.post(self.url, {'students_list': uploaded_file})
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content)
+        self.assertNotEquals(len(data['general_errors']), 0)
+        self.assertEquals(data['general_errors'][0]['response'], 'Could not read uploaded file.')
+
+    def test_insufficient_data(self):
+        """
+        Try uploading a CSV file which does not have the exact four columns of data
+        """
+        csv_content = "test_student@example.com,test_student_1\n"
+        uploaded_file = SimpleUploadedFile("temp.csv", csv_content)
+        response = self.client.post(self.url, {'students_list': uploaded_file})
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content)
+        self.assertEquals(len(data['row_errors']), 0)
+        self.assertEquals(len(data['warnings']), 0)
+        self.assertEquals(len(data['general_errors']), 1)
+        self.assertEquals(data['general_errors'][0]['response'], 'Data in row #1 must have exactly four columns: email, username, full name, and country')
+
+    def test_invalid_email_in_csv(self):
+        """
+        Test failure case of a poorly formatted email field
+        """
+        csv_content = "test_student.example.com,test_student_1,tester1,USA"
+
+        uploaded_file = SimpleUploadedFile("temp.csv", csv_content)
+        response = self.client.post(self.url, {'students_list': uploaded_file})
+        data = json.loads(response.content)
+        self.assertEqual(response.status_code, 200)
+        self.assertNotEquals(len(data['row_errors']), 0)
+        self.assertEquals(len(data['warnings']), 0)
+        self.assertEquals(len(data['general_errors']), 0)
+        self.assertEquals(data['row_errors'][0]['response'], 'Invalid email {0}.'.format('test_student.example.com'))
+
+    @patch('instructor.views.api.log.info')
+    def test_csv_user_exist_and_not_enrolled(self, info_log):
+        """
+        If the email address and username already exists
+        and the user is not enrolled in the course, enrolled him/her and iterate to next one.
+        """
+        csv_content = "nonenrolled@test.com,NotEnrolledStudent,tester1,USA"
+
+        uploaded_file = SimpleUploadedFile("temp.csv", csv_content)
+        response = self.client.post(self.url, {'students_list': uploaded_file})
+        self.assertEqual(response.status_code, 200)
+        info_log.assert_called_with('user {username} enrolled in the course {course}'.format(username='NotEnrolledStudent', course=self.course.id))
+
+    def test_user_with_already_existing_email_in_csv(self):
+        """
+        If the email address already exists, but the username is different,
+        assume it is the correct user and just register the user in the course.
+        """
+        csv_content = "test_student@example.com,test_student_1,tester1,USA\n" \
+                      "test_student@example.com,test_student_2,tester2,US"
+
+        uploaded_file = SimpleUploadedFile("temp.csv", csv_content)
+        response = self.client.post(self.url, {'students_list': uploaded_file})
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content)
+        warning_message = 'An account with email {email} exists but the provided username {username} ' \
+                          'is different. Enrolling anyway with {email}.'.format(email='test_student@example.com', username='test_student_2')
+        self.assertNotEquals(len(data['warnings']), 0)
+        self.assertEquals(data['warnings'][0]['response'], warning_message)
+        user = User.objects.get(email='test_student@example.com')
+        self.assertTrue(CourseEnrollment.is_enrolled(user, self.course.id))
+
+    def test_user_with_already_existing_username_in_csv(self):
+        """
+        If the username already exists (but not the email),
+        assume it is a different user and fail to create the new account.
+        """
+        csv_content = "test_student1@example.com,test_student_1,tester1,USA\n" \
+                      "test_student2@example.com,test_student_1,tester2,US"
+
+        uploaded_file = SimpleUploadedFile("temp.csv", csv_content)
+
+        response = self.client.post(self.url, {'students_list': uploaded_file})
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content)
+        self.assertNotEquals(len(data['row_errors']), 0)
+        self.assertEquals(data['row_errors'][0]['response'], 'Username {user} already exists.'.format(user='test_student_1'))
+
+    def test_csv_file_not_attached(self):
+        """
+        Test when the user does not attach a file
+        """
+        csv_content = "test_student1@example.com,test_student_1,tester1,USA\n" \
+                      "test_student2@example.com,test_student_1,tester2,US"
+
+        uploaded_file = SimpleUploadedFile("temp.csv", csv_content)
+
+        response = self.client.post(self.url, {'file_not_found': uploaded_file})
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content)
+        self.assertNotEquals(len(data['general_errors']), 0)
+        self.assertEquals(data['general_errors'][0]['response'], 'File is not attached.')
+
+    def test_raising_exception_in_auto_registration_and_enrollment_case(self):
+        """
+        Test that exceptions are handled well
+        """
+        csv_content = "test_student1@example.com,test_student_1,tester1,USA\n" \
+                      "test_student2@example.com,test_student_1,tester2,US"
+
+        uploaded_file = SimpleUploadedFile("temp.csv", csv_content)
+        with patch('instructor.views.api.create_and_enroll_user') as mock:
+            mock.side_effect = NonExistentCourseError()
+            response = self.client.post(self.url, {'students_list': uploaded_file})
+
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content)
+        self.assertNotEquals(len(data['row_errors']), 0)
+        self.assertEquals(data['row_errors'][0]['response'], 'NonExistentCourseError')
+
+    def test_generate_unique_password(self):
+        """
+        generate_unique_password should generate a unique password string that excludes certain characters.
+        """
+        password = generate_unique_password([], 12)
+        self.assertEquals(len(password), 12)
+        for letter in password:
+            self.assertNotIn(letter, 'aAeEiIoOuU1l')
+
+    def test_users_created_and_enrolled_successfully_if_others_fail(self):
+
+        csv_content = "test_student1@example.com,test_student_1,tester1,USA\n" \
+                      "test_student3@example.com,test_student_1,tester3,CA\n" \
+                      "test_student2@example.com,test_student_2,tester2,USA"
+
+        uploaded_file = SimpleUploadedFile("temp.csv", csv_content)
+        response = self.client.post(self.url, {'students_list': uploaded_file})
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content)
+        self.assertNotEquals(len(data['row_errors']), 0)
+        self.assertEquals(data['row_errors'][0]['response'], 'Username {user} already exists.'.format(user='test_student_1'))
+        self.assertTrue(User.objects.filter(username='test_student_1', email='test_student1@example.com').exists())
+        self.assertTrue(User.objects.filter(username='test_student_2', email='test_student2@example.com').exists())
+        self.assertFalse(User.objects.filter(email='test_student3@example.com').exists())
+
+    @patch.object(instructor.views.api, 'generate_random_string',
+                  Mock(side_effect=['first', 'first', 'second']))
+    def test_generate_unique_password_no_reuse(self):
+        """
+        generate_unique_password should generate a unique password string that hasn't been generated before.
+        """
+        generated_password = ['first']
+        password = generate_unique_password(generated_password, 12)
+        self.assertNotEquals(password, 'first')
+
+    @patch.dict(settings.FEATURES, {'ALLOW_AUTOMATED_SIGNUPS': False})
+    def test_allow_automated_signups_flag_not_set(self):
+        csv_content = "test_student1@example.com,test_student_1,tester1,USA"
+        uploaded_file = SimpleUploadedFile("temp.csv", csv_content)
+        response = self.client.post(self.url, {'students_list': uploaded_file})
+        self.assertEquals(response.status_code, 403)
 
 
 @ddt.ddt

--- a/lms/djangoapps/instructor/views/api_urls.py
+++ b/lms/djangoapps/instructor/views/api_urls.py
@@ -7,6 +7,8 @@ from django.conf.urls import patterns, url
 urlpatterns = patterns('',  # nopep8
     url(r'^students_update_enrollment$',
         'instructor.views.api.students_update_enrollment', name="students_update_enrollment"),
+    url(r'^register_and_enroll_students$',
+        'instructor.views.api.register_and_enroll_students', name="register_and_enroll_students"),
     url(r'^list_course_role_members$',
         'instructor.views.api.list_course_role_members', name="list_course_role_members"),
     url(r'^modify_access$',

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -250,6 +250,7 @@ def _section_membership(course, access):
         'access': access,
         'enroll_button_url': reverse('students_update_enrollment', kwargs={'course_id': course_key.to_deprecated_string()}),
         'unenroll_button_url': reverse('students_update_enrollment', kwargs={'course_id': course_key.to_deprecated_string()}),
+        'upload_student_csv_button_url': reverse('register_and_enroll_students', kwargs={'course_id': course_key.to_deprecated_string()}),
         'modify_beta_testers_button_url': reverse('bulk_beta_modify_access', kwargs={'course_id': course_key.to_deprecated_string()}),
         'list_course_role_members_url': reverse('list_course_role_members', kwargs={'course_id': course_key.to_deprecated_string()}),
         'modify_access_url': reverse('modify_access', kwargs={'course_id': course_key.to_deprecated_string()}),

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -287,6 +287,11 @@ FEATURES = {
 
     # Enable the new dashboard, account, and profile pages
     'ENABLE_NEW_DASHBOARD': False,
+
+    # Show a section in the membership tab of the instructor dashboard
+    # to allow an upload of a CSV file that contains a list of new accounts to create
+    # and register for course.
+    'ALLOW_AUTOMATED_SIGNUPS': False,
 }
 
 # Ignore static asset files on import which match this pattern

--- a/lms/static/sass/base/_variables.scss
+++ b/lms/static/sass/base/_variables.scss
@@ -143,6 +143,7 @@ $light-gray: #ddd;
 // used by descriptor css
 $lightGrey: #edf1f5;
 $darkGrey: #8891a1;
+$lightGrey1: #ccc;
 $blue-d1: shade($blue,20%);
 $blue-d2: shade($blue,40%);
 $blue-d4: shade($blue,80%);

--- a/lms/static/sass/course/instructor/_instructor_2.scss
+++ b/lms/static/sass/course/instructor/_instructor_2.scss
@@ -684,6 +684,52 @@ section.instructor-dashboard-content-2 {
       }
     }
   }
+  // Auto Enroll Csv Section
+  .auto_enroll_csv {
+    .results {
+
+    }
+    .enrollment_signup_button {
+      margin-right: ($baseline/4);
+    }
+    // Custom File upload
+    .customBrowseBtn {
+      margin: ($baseline/2) 0;
+      display: inline-block;
+      .file-browse {
+        position:relative;
+        overflow:hidden;
+        display: inline;
+        margin-left: -5px;
+        span.browse{
+          @include button(simple, $blue);
+          padding: 6px ($baseline/2);
+          font-size: 12px;
+          border-radius: 0 3px 3px 0;
+          margin-right: ($baseline);
+        }
+        input.file_field {
+          position:absolute;
+          top:0;
+          right:0;
+          margin:0;
+          padding:0;
+          cursor:pointer;
+          opacity:0;
+          filter:alpha(opacity=0);
+        }
+      }
+      & > span, & input[disabled]{
+        vertical-align: middle;
+      }
+      input[disabled] {
+        cursor: not-allowed;
+        border: 1px solid $lightGrey1;
+        border-radius: 4px 0 0 4px;
+        padding: 6px 6px 5px;
+      }
+    }
+  }
 
   .enroll-option {
     margin: ($baseline/2) 0;

--- a/lms/templates/emails/account_creation_and_enroll_emailMessage.txt
+++ b/lms/templates/emails/account_creation_and_enroll_emailMessage.txt
@@ -1,0 +1,14 @@
+<%! from django.utils.translation import ugettext as _ %>
+
+${_("Welcome to {course_name}").format(course_name=course.display_name_with_default)}
+
+${_("To get started, please visit https://{site_name}. The login information for your account follows.").format(site_name=site_name)}
+
+${_("email: {email}").format(email=email_address)}
+${_("password: {password}").format(password=password)}
+
+${_("It is recommended that you change your password.")}
+
+${_("Sincerely yours,")}
+
+${_("The {course_name} Team").format(course_name=course.display_name_with_default)}

--- a/lms/templates/instructor/instructor_dashboard_2/membership.html
+++ b/lms/templates/instructor/instructor_dashboard_2/membership.html
@@ -1,5 +1,6 @@
 <%! from django.utils.translation import ugettext as _ %>
 <%page args="section_data"/>
+<%! from microsite_configuration import microsite %>
 
 <script type="text/template" id="member-list-widget-template">
   <div class="member-list-widget">
@@ -67,6 +68,30 @@
   <div class="request-response"></div>
   <div class="request-response-error"></div>
 </div>
+
+%if microsite.get_value('ALLOW_AUTOMATED_SIGNUPS', settings.FEATURES.get('ALLOW_AUTOMATED_SIGNUPS', False)):
+  <hr class="divider" />
+
+  <div class="auto_enroll auto_enroll_csv">
+    <h2> ${_("Register/Enroll Students")} </h2>
+    <p>
+    ${_("To register and enroll a list of users in this course, choose a CSV file that contains the following columns in this exact order: email, username, name, and country. Please include one student per row and do not include any headers, footers, or blank lines.")}
+    </p>
+    <form id="student-auto-enroll-form" method="post" action="${ section_data['upload_student_csv_button_url'] }" enctype="multipart/form-data">
+      <div class="customBrowseBtn">
+        <input disabled="disabled" id="browseFile" placeholder="choose file" />
+        <div class="file-browse btn btn-primary">
+            <span class="browse"> Browse </span>
+            <input class="file_field" id="browseBtn" name="students_list" type="file" accept=".csv"/>
+        </div>
+      </div>
+      <button type="submit" name="enrollment_signup_button">${_("Upload CSV")}</button>
+
+      <input type="hidden" name="csrfmiddlewaretoken" value="${ csrf_token }">
+    </form>
+    <div class="results"></div>
+  </div>
+%endif
 
 <hr class="divider" />
 
@@ -245,5 +270,6 @@
             }
         });
         </script>
+
     </%block>
 % endif


### PR DESCRIPTION
fix typo and add more security on API

fix some bugs and typos

address PR feedback

be sure to send emails when accounts already exist

PR feedback

fix multiple uploads

pep8 fixes

pep8 fix

pylint fixes

fix url mapping

WL-98
- Complete code coverage
- Update code for error and warning messages.
- improve code as per some suggestions

updated the UI of the auto_enroll feature

fixed the errors

PR feedback

add test

add back file filtering

add some more error handling of input

remove unneeded coffeescript code

pylint fixes

add pep8 space

WL-98
- Updated and added test cases.
- Updated membership coffee file for errors display handling.
- fixed minor text issues.

allow for blank lines and add a test

add blank line (pep8)
