### PR TITLE
Integrate third party auth into the combined login/registration page.

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -92,6 +92,7 @@ from util.password_policy_validators import (
     validate_password_dictionary
 )
 
+import third_party_auth
 from third_party_auth import pipeline, provider
 from xmodule.error_module import ErrorDescriptor
 from shoppingcart.models import CourseRegistrationCode
@@ -406,7 +407,7 @@ def register_user(request, extra_context=None):
 
     # If third-party auth is enabled, prepopulate the form with data from the
     # selected provider.
-    if microsite.get_value('ENABLE_THIRD_PARTY_AUTH', settings.FEATURES.get('ENABLE_THIRD_PARTY_AUTH')) and pipeline.running(request):
+    if third_party_auth.is_enabled() and pipeline.running(request):
         running_pipeline = pipeline.get(request)
         current_provider = provider.Registry.get_by_backend_name(running_pipeline.get('backend'))
         overrides = current_provider.get_register_form_data(running_pipeline.get('kwargs'))
@@ -619,7 +620,7 @@ def dashboard(request):
         'provider_states': [],
     }
 
-    if microsite.get_value('ENABLE_THIRD_PARTY_AUTH', settings.FEATURES.get('ENABLE_THIRD_PARTY_AUTH')):
+    if third_party_auth.is_enabled():
         context['duplicate_provider'] = pipeline.get_duplicate_provider(messages.get_messages(request))
         context['provider_user_states'] = pipeline.get_provider_user_states(user)
 
@@ -911,7 +912,7 @@ def login_user(request, error=""):  # pylint: disable-msg=too-many-statements,un
     redirect_url = None
     response = None
     running_pipeline = None
-    third_party_auth_requested = microsite.get_value('ENABLE_THIRD_PARTY_AUTH', settings.FEATURES.get('ENABLE_THIRD_PARTY_AUTH')) and pipeline.running(request)
+    third_party_auth_requested = third_party_auth.is_enabled() and pipeline.running(request)
     third_party_auth_successful = False
     trumped_by_first_party_auth = bool(request.POST.get('email')) or bool(request.POST.get('password'))
     user = None
@@ -933,7 +934,7 @@ def login_user(request, error=""):  # pylint: disable-msg=too-many-statements,un
             AUDIT_LOG.warning(
                 u'Login failed - user with username {username} has no social auth with backend_name {backend_name}'.format(
                     username=username, backend_name=backend_name))
-            return HttpResponseBadRequest(
+            return HttpResponse(
                 _("You've successfully logged into your {provider_name} account, but this account isn't linked with an {platform_name} account yet.").format(
                     platform_name=settings.PLATFORM_NAME, provider_name=requested_provider.NAME
                 )
@@ -1344,7 +1345,7 @@ def create_account(request, post_override=None):  # pylint: disable-msg=too-many
         getattr(settings, 'REGISTRATION_EXTRA_FIELDS', {})
     )
 
-    if microsite.get_value('ENABLE_THIRD_PARTY_AUTH', settings.FEATURES.get('ENABLE_THIRD_PARTY_AUTH')) and pipeline.running(request):
+    if third_party_auth.is_enabled() and pipeline.running(request):
         post_vars = dict(post_vars.items())
         post_vars.update({'password': pipeline.make_random_password()})
 
@@ -1524,7 +1525,7 @@ def create_account(request, post_override=None):  # pylint: disable-msg=too-many
 
         # If the user is registering via 3rd party auth, track which provider they use
         provider_name = None
-        if settings.FEATURES.get('ENABLE_THIRD_PARTY_AUTH') and pipeline.running(request):
+        if third_party_auth.is_enabled() and pipeline.running(request):
             running_pipeline = pipeline.get(request)
             current_provider = provider.Registry.get_by_backend_name(running_pipeline.get('backend'))
             provider_name = current_provider.NAME
@@ -1615,7 +1616,7 @@ def create_account(request, post_override=None):  # pylint: disable-msg=too-many
     redirect_url = try_change_enrollment(request)
 
     # Resume the third-party-auth pipeline if necessary.
-    if microsite.get_value('ENABLE_THIRD_PARTY_AUTH', settings.FEATURES.get('ENABLE_THIRD_PARTY_AUTH')) and pipeline.running(request):
+    if third_party_auth.is_enabled() and pipeline.running(request):
         running_pipeline = pipeline.get(request)
         redirect_url = pipeline.get_complete_url(running_pipeline['backend'])
 

--- a/common/djangoapps/third_party_auth/__init__.py
+++ b/common/djangoapps/third_party_auth/__init__.py
@@ -1,0 +1,15 @@
+"""Third party authentication. """
+
+from microsite_configuration import microsite
+
+
+def is_enabled():
+    """Check whether third party authentication has been enabled. """
+
+    # We do this imports internally to avoid initializing settings prematurely
+    from django.conf import settings
+
+    return microsite.get_value(
+        "ENABLE_THIRD_PARTY_AUTH",
+        settings.FEATURES.get("ENABLE_THIRD_PARTY_AUTH")
+    )

--- a/common/djangoapps/third_party_auth/tests/testutil.py
+++ b/common/djangoapps/third_party_auth/tests/testutil.py
@@ -4,7 +4,9 @@ Utilities for writing third_party_auth tests.
 Used by Django and non-Django tests; must not have Django deps.
 """
 
+from contextlib import contextmanager
 import unittest
+import mock
 
 from third_party_auth import provider
 
@@ -37,3 +39,81 @@ class TestCase(unittest.TestCase):
         provider.Registry._reset()
         provider.Registry.configure_once(self._original_providers)
         super(TestCase, self).tearDown()
+
+
+@contextmanager
+def simulate_running_pipeline(pipeline_target, backend, email=None, fullname=None, username=None):
+    """Simulate that a pipeline is currently running.
+
+    You can use this context manager to test packages that rely on third party auth.
+
+    This uses `mock.patch` to override some calls in `third_party_auth.pipeline`,
+    so you will need to provide the "target" module *as it is imported*
+    in the software under test.  For example, if `foo/bar.py` does this:
+
+    >>> from third_party_auth import pipeline
+
+    then you will need to do something like this:
+
+    >>> with simulate_running_pipeline("foo.bar.pipeline", "google-oauth2"):
+    >>>    bar.do_something_with_the_pipeline()
+
+    If, on the other hand, `foo/bar.py` had done this:
+
+    >>> import third_party_auth
+
+    then you would use the target "foo.bar.third_party_auth.pipeline" instead.
+
+    Arguments:
+
+        pipeline_target (string): The path to `third_party_auth.pipeline` as it is imported
+            in the software under test.
+
+        backend (string): The name of the backend currently running, for example "google-oauth2".
+            Note that this is NOT the same as the name of the *provider*.  See the Python
+            social auth documentation for the names of the backends.
+
+    Keyword Arguments:
+        email (string): If provided, simulate that the current provider has
+            included the user's email address (useful for filling in the registration form).
+
+        fullname (string): If provided, simulate that the current provider has
+            included the user's full name (useful for filling in the registration form).
+
+        username (string): If provided, simulate that the pipeline has provided
+            this suggested username.  This is something that the `third_party_auth`
+            app generates itself and should be available by the time the user
+            is authenticating with a third-party provider.
+
+    Returns:
+        None
+
+    """
+    pipeline_data = {
+        "backend": backend,
+        "kwargs": {
+            "details": {}
+        }
+    }
+    if email is not None:
+        pipeline_data["kwargs"]["details"]["email"] = email
+    if fullname is not None:
+        pipeline_data["kwargs"]["details"]["fullname"] = fullname
+    if username is not None:
+        pipeline_data["kwargs"]["username"] = username
+
+    pipeline_get = mock.patch("{pipeline}.get".format(pipeline=pipeline_target), spec=True)
+    pipeline_running = mock.patch("{pipeline}.running".format(pipeline=pipeline_target), spec=True)
+
+    mock_get = pipeline_get.start()
+    mock_running = pipeline_running.start()
+
+    mock_get.return_value = pipeline_data
+    mock_running.return_value = True
+
+    try:
+        yield
+
+    finally:
+        pipeline_get.stop()
+        pipeline_running.stop()

--- a/lms/djangoapps/student_profile/views.py
+++ b/lms/djangoapps/student_profile/views.py
@@ -13,7 +13,7 @@ from django.contrib.auth.decorators import login_required
 from edxmako.shortcuts import render_to_response
 from user_api.api import profile as profile_api
 from lang_pref import LANGUAGE_KEY, api as language_api
-from third_party_auth import pipeline
+import third_party_auth
 
 
 @login_required
@@ -60,8 +60,8 @@ def _get_profile(request):
         'disable_courseware_js': True
     }
 
-    if settings.FEATURES.get('ENABLE_THIRD_PARTY_AUTH'):
-        context['provider_user_states'] = pipeline.get_provider_user_states(user)
+    if third_party_auth.is_enabled():
+        context['provider_user_states'] = third_party_auth.pipeline.get_provider_user_states(user)
 
     return render_to_response('student_profile/index.html', context)
 

--- a/lms/static/js/student_account/accessApp.js
+++ b/lms/static/js/student_account/accessApp.js
@@ -7,7 +7,7 @@ var edx = edx || {};
     edx.student.account = edx.student.account || {};
 
     return new edx.student.account.AccessView({
-        mode: $('#login-and-registration-container').data('initial-mode') || 'login',
-        thirdPartyAuth: $('#login-and-registration-container').data('third-party-auth-providers') || false
+        mode: $('#login-and-registration-container').data('initial-mode'),
+        thirdPartyAuth: $('#login-and-registration-container').data('third-party-auth')
     });
 })(jQuery);

--- a/lms/static/js/student_account/views/AccessView.js
+++ b/lms/static/js/student_account/views/AccessView.js
@@ -26,7 +26,13 @@ var edx = edx || {};
 
         initialize: function( obj ) {
             this.tpl = $(this.tpl).html();
-            this.activeForm = obj.mode;
+            this.activeForm = obj.mode || 'login';
+            this.thirdPartyAuth = obj.thirdPartyAuth || {
+                currentProvider: null,
+                providers: []
+            };
+            console.log(obj);
+
             this.render();
         },
 
@@ -48,12 +54,12 @@ var edx = edx || {};
 
         loadForm: function( type ) {
             if ( type === 'login' ) {
-                this.subview.login =  new edx.student.account.LoginView();
+                this.subview.login =  new edx.student.account.LoginView( this.thirdPartyAuth );
 
                 // Listen for 'password-help' event to toggle sub-views
                 this.listenTo( this.subview.login, 'password-help', this.resetPassword );
             } else if ( type === 'register' ) {
-                this.subview.register = new edx.student.account.RegisterView();
+                this.subview.register = new edx.student.account.RegisterView( this.thirdPartyAuth );
             } else if ( type === 'reset' ) {
                 this.subview.passwordHelp = new edx.student.account.PasswordResetView();
             }

--- a/lms/static/js/student_account/views/RegisterView.js
+++ b/lms/static/js/student_account/views/RegisterView.js
@@ -16,15 +16,19 @@ var edx = edx || {};
         fieldTpl: $('#form_field-tpl').html(),
 
         events: {
-            'click .js-register': 'submitForm'
+            'click .js-register': 'submitForm',
+            'click .login-provider': 'thirdPartyAuth'
         },
 
         errors: [],
 
         $form: {},
 
-        initialize: function() {
+        initialize: function( thirdPartyAuthInfo ) {
             this.tpl = $(this.tpl).html();
+
+            this.providers = thirdPartyAuthInfo.providers || [];
+            this.currentProvider = thirdPartyAuthInfo.currentProvider || "";
             this.getInitialData();
         },
 
@@ -33,7 +37,9 @@ var edx = edx || {};
             var fields = html || '';
 
             $(this.el).html( _.template( this.tpl, {
-                fields: fields
+                fields: fields,
+                currentProvider: this.currentProvider,
+                providers: this.providers
             }));
 
             this.postRender();
@@ -81,8 +87,10 @@ var edx = edx || {};
                 i,
                 len = data.length,
                 fieldTpl = this.fieldTpl;
-console.log('buildForm ', data);
             for ( i=0; i<len; i++ ) {
+                // "default" is reserved in JavaScript
+                data[i].value = data[i]["default"];
+
                 html.push( _.template( fieldTpl, $.extend( data[i], {
                     form: 'register'
                 }) ) );
@@ -139,6 +147,16 @@ console.log(this.model);
             } else {
                 console.log('here are the errors ', this.errors);
                 this.toggleErrorMsg( true );
+            }
+        },
+
+        thirdPartyAuth: function( event ) {
+            var providerUrl = $(event.target).data("provider-url") || "";
+            if (providerUrl) {
+                window.location.href = providerUrl;
+            } else {
+                // TODO -- error handling here
+                console.log("No URL available for third party auth provider");
             }
         },
 

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -1,5 +1,6 @@
 <%! from django.utils.translation import ugettext as _ %>
 <%! from django.template import RequestContext %>
+<%! import third_party_auth %>
 <%! from third_party_auth import pipeline %>
 <%! from microsite_configuration import microsite %>
 
@@ -95,7 +96,7 @@
         <%include file='dashboard/_dashboard_info_language.html' />
         %endif
 
-        % if microsite.get_value('ENABLE_THIRD_PARTY_AUTH', settings.FEATURES.get('ENABLE_THIRD_PARTY_AUTH')):
+        % if third_party_auth.is_enabled():
         <li class="controls--account">
           <span class="title">
             ## Translators: this section lists all the third-party authentication providers (for example, Google and LinkedIn) the user can link with or unlink from their edX account.

--- a/lms/templates/login.html
+++ b/lms/templates/login.html
@@ -4,6 +4,7 @@
 
 <%! from django.core.urlresolvers import reverse %>
 <%! from django.utils.translation import ugettext as _ %>
+<%! import third_party_auth %>
 <%! from third_party_auth import provider, pipeline %>
 
 <%block name="pagetitle">${_("Log into your {platform_name} Account").format(platform_name=platform_name)}</%block>
@@ -48,8 +49,16 @@
 
       $('#login-form').on('ajax:error', function(event, request, status_string) {
         toggleSubmitButton(true);
-        $('.third-party-signin.message').addClass('is-shown').focus();
-        $('.third-party-signin.message .instructions').html(request.responseText);
+
+        if (request.status === 401) {
+          $('.message.submission-error').removeClass('is-shown');
+          $('.third-party-signin.message').addClass('is-shown').focus();
+          $('.third-party-signin.message .instructions').html(request.responseText);
+        } else {
+          $('.third-party-signin.message').removeClass('is-shown');
+          $('.message.submission-error').addClass('is-shown').focus();
+          $('.message.submission-error').html(gettext("Your request could not be completed.  Please try again."));
+        }
       });
 
       $('#login-form').on('ajax:success', function(event, json, xhr) {
@@ -194,7 +203,7 @@
       </div>
     </form>
 
-    % if microsite.get_value('ENABLE_THIRD_PARTY_AUTH', settings.FEATURES.get('ENABLE_THIRD_PARTY_AUTH')):
+    % if third_party_auth.is_enabled():
 
       <span class="deco-divider">
         ## Developers: this is a sentence fragment, which is usually frowned upon.  The design of the pags uses this fragment to provide an "else" clause underneath a number of choices.  It's OK to leave it.

--- a/lms/templates/register.html
+++ b/lms/templates/register.html
@@ -12,6 +12,7 @@
 <%! from django.utils.translation import ugettext as _ %>
 <%! from student.models import UserProfile %>
 <%! from datetime import date %>
+<%! import third_party_auth %>
 <%! from third_party_auth import pipeline, provider %>
 <%! import calendar %>
 
@@ -116,7 +117,7 @@
         <ul class="message-copy"> </ul>
       </div>
 
-      % if microsite.get_value('ENABLE_THIRD_PARTY_AUTH', settings.FEATURES.get('ENABLE_THIRD_PARTY_AUTH')):
+      % if third_party_auth.is_enabled():
 
         % if not running_pipeline:
 
@@ -182,7 +183,7 @@
             <span class="tip tip-input" id="username-tip">${_('Will be shown in any discussions or forums you participate in')} <strong>(${_('cannot be changed later')})</strong></span>
           </li>
 
-          % if settings.FEATURES.get('ENABLE_THIRD_PARTY_AUTH') and running_pipeline:
+          % if third_party_auth.is_enabled() and running_pipeline:
 
           <li class="is-disabled field optional password" id="field-password" hidden>
             <label for="password">${_('Password')}</label>

--- a/lms/templates/student_account/form_field.underscore
+++ b/lms/templates/student_account/form_field.underscore
@@ -27,6 +27,7 @@
             <% if ( restrictions.min_length ) { %> minlength="<%= restrictions.min_length %>"<% } %>
             <% if ( restrictions.max_length ) { %> maxlength="<%= restrictions.max_length %>"<% } %>
             <% if ( required ) { %> required<% } %>
+            value="<%- value %>"
         />
     <% } %>
 

--- a/lms/templates/student_account/login.underscore
+++ b/lms/templates/student_account/login.underscore
@@ -5,6 +5,22 @@
             <p>Email or password is incorrent. <a href="#">Forgot password?</a></p>
         </div>
     </div>
+    <div class="already-authenticated-msg hidden">
+        <% if (currentProvider) { %>
+            <p class="instructions">
+            You've successfully logged into <%- currentProvider %>, but you need to link
+            your account.  Please click "I am a returning user" to create
+            an EdX account.
+            </p>
+        <% } %>
+    </div>
     <%= fields %>
     <button class="action action-primary action-update js-login">Log in</button>
 </form>
+<% for (var i=0; i < providers.length; i++) {
+    var provider = providers[i];
+%>
+    <button type="submit"class="button button-primary button-<%- provider.name %> login-provider" data-provider-url="<%- provider.loginUrl %>">
+        <span class="icon <%- provider.iconClass %>"></span>Sign in with <%- provider.name %>
+    </button>
+<% } %>

--- a/lms/templates/student_account/login_and_register.html
+++ b/lms/templates/student_account/login_and_register.html
@@ -19,34 +19,10 @@
 % endfor
 </%block>
 
-
-## TODO: Use JavaScript to populate this div with
-## the actual registration/login forms (loaded asynchronously from the user API)
-## The URLS for the forms are:
-## - GET /user_api/v1/registration/
-## - GET /user_api/v1/login_session/
-##
-## You can post back to those URLs with JSON-serialized
-## data from the form fields in order to complete the registration
-## or login.
-##
-## Also TODO: we need to figure out how to enroll students in
-## a course if they got here from a course about page.
-##
-## third_party_auth_providers is a JSON-serialized list of
-## dictionaries of the form:
-## {
-##      "name": "Facebook",
-##      "icon_class": "facebook-icon",
-##      "login_url": "http://api.facebook.com/auth"
-## }
-##
-## Note that this list may be empty.
-##
 <div class="section-bkg-wrapper">
     <div id="login-and-registration-container"
         class="login-register"
         data-initial-mode="${initial_mode}"
-        data-third-party-auth-providers="${third_party_auth_providers}"
+        data-third-party-auth='${third_party_auth}'
     />
 </div>

--- a/lms/templates/student_account/register.underscore
+++ b/lms/templates/student_account/register.underscore
@@ -1,3 +1,18 @@
+<% if (currentProvider) { %>
+    <p class="instructions">
+      You've successfully signed in with <strong><%- currentProvider %></strong>.<br />
+      We just need a little more information before you start learning with edX.
+    </p>
+<% } else {
+    for (var i=0; i < providers.length; i++) {
+        var provider = providers[i];
+%>
+    <button type="submit"class="button button-primary button-<%- provider.name %> login-provider" data-provider-url="<%- provider.registerUrl %>">
+        <span class="icon <%- provider.iconClass %>"></span>Sign up with <%- provider.name %>
+    </button>
+<% }
+} %>
+
 <form id="register" autocomplete="off">
     <div class="error-msg hidden">
         <h4>An error occured in your registration.</h4>

--- a/lms/templates/student_profile/index.html
+++ b/lms/templates/student_profile/index.html
@@ -1,4 +1,5 @@
 <%! from django.utils.translation import ugettext as _ %>
+<%! import third_party_auth %>
 <%namespace name='static' file='/static_content.html'/>
 
 <%inherit file="../main.html" />
@@ -25,6 +26,6 @@
 
 <div id="profile-container"></div>
 
-% if settings.FEATURES.get('ENABLE_THIRD_PARTY_AUTH'):
+% if third_party_auth.is_enabled():
     <%include file="third_party_auth.html" />
 % endif


### PR DESCRIPTION
Changes:
- Change third party auth login failure code to a 401, to detect authentication success with no linked account.
- If already authenticated, redirect immediately to the dashboard.
- Use "Location" header correctly for 302 redirects from student views.
- Add utility functions for simulating a running third-party auth pipeline.
- Add a utility function for checking whether third party auth is enabled.

Not yet implemented (mostly to avoid merge conflicts with the other JS work):
- i18n for JavaScript templates
- Proper error messaging in JS
- Default values in registration form if shared by the third party auth provider (Python handles this, but the JS doesn't yet display it)
- JS tests

Reviewers: @stephensanchez @dianakhuang 
FYI: @rlucioni @AlasdairSwan 
