### PR TITLE
Adding an additional check to avoid donations showing up for microsites.

### DIFF
--- a/common/djangoapps/course_modes/models.py
+++ b/common/djangoapps/course_modes/models.py
@@ -164,6 +164,25 @@ class CourseMode(models.Model):
         return 0
 
     @classmethod
+    def has_payment_options(cls, course_id):
+        """Determines if there is any mode that has payment options
+
+        Check the dict of course modes and see if any of them have a minimum price or
+        suggested prices. Returns True if any course mode has a payment option.
+
+        Args:
+            course_mode_dict (dict): Dictionary mapping course mode slugs to Modes
+
+        Returns:
+            True if any course mode has a payment option.
+
+        """
+        for mode in cls.modes_for_course(course_id):
+            if mode.min_price > 0 or mode.suggested_prices != '':
+                return True
+        return False
+
+    @classmethod
     def min_course_price_for_currency(cls, course_id, currency):
         """
         Returns the minimum price of the course in the appropriate currency over all the course's

--- a/common/djangoapps/course_modes/tests/test_models.py
+++ b/common/djangoapps/course_modes/tests/test_models.py
@@ -127,3 +127,22 @@ class CourseModeModelTest(TestCase):
         mode = CourseMode.verified_mode_for_course(self.course_key)
 
         self.assertEqual(mode.slug, 'professional')
+
+    def test_course_has_payment_options(self):
+        # Has no payment options.
+        honor, _ = self.create_mode('honor', 'Honor')
+        self.assertFalse(CourseMode.has_payment_options(self.course_key))
+
+        # Now we do have a payment option.
+        verified, _ = self.create_mode('verified', 'Verified', min_price=5)
+        self.assertTrue(CourseMode.has_payment_options(self.course_key))
+
+        # Unset verified's minimum price.
+        verified.min_price = 0
+        verified.save()
+        self.assertFalse(CourseMode.has_payment_options(self.course_key))
+
+        # Finally, give the honor mode payment options
+        honor.suggested_prices = '5, 10, 15'
+        honor.save()
+        self.assertTrue(CourseMode.has_payment_options(self.course_key))

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -697,7 +697,10 @@ def _allow_donation(course_modes, course_id):
         True if the course is allowing donations.
 
     """
-    return DonationConfiguration.current().enabled and not CourseMode.has_verified_mode(course_modes[course_id])
+    donations_enabled = DonationConfiguration.current().enabled
+    is_verified_mode = CourseMode.has_verified_mode(course_modes[course_id])
+    is_microsite = microsite.is_request_in_microsite()
+    return  donations_enabled and not is_verified_mode and not is_microsite
 
 
 def try_change_enrollment(request):

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -699,8 +699,8 @@ def _allow_donation(course_modes, course_id):
     """
     donations_enabled = DonationConfiguration.current().enabled
     is_verified_mode = CourseMode.has_verified_mode(course_modes[course_id])
-    is_microsite = microsite.is_request_in_microsite()
-    return donations_enabled and not is_verified_mode and not is_microsite
+    has_payment_option = CourseMode.has_payment_options(course_id)
+    return donations_enabled and not is_verified_mode and not has_payment_option
 
 
 def try_change_enrollment(request):

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -700,7 +700,7 @@ def _allow_donation(course_modes, course_id):
     donations_enabled = DonationConfiguration.current().enabled
     is_verified_mode = CourseMode.has_verified_mode(course_modes[course_id])
     is_microsite = microsite.is_request_in_microsite()
-    return  donations_enabled and not is_verified_mode and not is_microsite
+    return donations_enabled and not is_verified_mode and not is_microsite
 
 
 def try_change_enrollment(request):


### PR DESCRIPTION
Donations are showing up for people newly enrolled on microsites (including for professional ed courses). The prof ed  courses on the microsites are course_mode "honor", but more importantly, we do not want to request donations on any microsites.

So this solution is straight forward. Adding a check when displaying the donations button to avoid displaying it for microsites. 

@andywaldrop @griffresch @wedaly @chrisndodge 

Verifying locally.
