### PR TITLE
Add Solano Labs tddium artifacts to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ cover_html/
 reports/
 jscover.log
 jscover.log.*
+.tddium*
 
 ### Installation artifacts
 *.egg-info


### PR DESCRIPTION
@jzoldak this replaces https://github.com/benpatterson/edx-platform/pull/19 which had not yet been merged on the downstream fork
