### PR TITLE
Remove caution re grade exports + content experiments

### DIFF
--- a/docs/en_us/course_authors/source/content_experiments/content_experiments_overview.rst
+++ b/docs/en_us/course_authors/source/content_experiments/content_experiments_overview.rst
@@ -16,10 +16,6 @@ Information on analyzing events from content experiments is included in the
 
 .. _edX Researcher Guide: http://edx.readthedocs.org/projects/devdata/en/latest/internal_data_formats/tracking_logs.html#a-b-testing-events
 
-.. caution::
-  If you have graded problems within a content experiment, grade exports do not
-  work for your course. This issue is currently being addressed.
-
 For more information, see:
 
 * :ref:`Configure Your Course for Content Experiments`


### PR DESCRIPTION
Remove the Caution in docs re grade exports not working for courses that have graded content in content experiments. (TNL-42)
