### PR TITLE
Make staff debug info code to be always LTR

### DIFF
--- a/lms/static/sass/course/courseware/_courseware.scss
+++ b/lms/static/sass/course/courseware/_courseware.scss
@@ -209,6 +209,10 @@ div.course-wrapper {
       margin-top: lh();
       line-height: lh();
       font-family: Consolas, "Lucida Console", Monaco, "Courier New", Courier, monospace;
+
+      // Debugging content is always in English, therefore it's never RTL
+      direction: ltr;
+      text-align: left;
     }
 
     div.ui-tabs {


### PR DESCRIPTION
This fixes the code/debug content **Staff Debug Info** modal in RTL setups. The change is mostly a convenience change for the course staff and not something critical.

I would say keep the staff debug info modal **untranslated** and always LTR because of: 
- It is very puzzling to translate variable names and map them back to the variables.
- The course authors in our team would would prefer English LTR variable names. 
- As a native Arabic speaker, and learned English mostly to learn and work as a programmer, I prefer the English variables.
## Before (Unfixed)

![unfixed](https://cloud.githubusercontent.com/assets/645156/4752221/d8a61d34-5aa8-11e4-8f98-fd3b1cddaf00.png)
## After (Fixed)

![fixed](https://cloud.githubusercontent.com/assets/645156/4752219/d1f7f566-5aa8-11e4-9b23-7cac13b4f6d7.png)
