### PR TITLE
Logistration: Use a 403 status to indicate that the user does not have a linked account

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -952,7 +952,7 @@ def login_user(request, error=""):  # pylint: disable-msg=too-many-statements,un
                     platform_name=settings.PLATFORM_NAME
                 ),
                 content_type="text/plain",
-                status=401
+                status=403
             )
 
     else:

--- a/common/djangoapps/third_party_auth/tests/specs/base.py
+++ b/common/djangoapps/third_party_auth/tests/specs/base.py
@@ -220,7 +220,7 @@ class IntegrationTest(testutil.TestCase, test.TestCase):
 
     def assert_json_failure_response_is_missing_social_auth(self, response):
         """Asserts failure on /login for missing social auth looks right."""
-        self.assertEqual(401, response.status_code)
+        self.assertEqual(403, response.status_code)
         self.assertIn("successfully logged into your %s account, but this account isn't linked" % self.PROVIDER_CLASS.NAME, response.content)
 
     def assert_json_failure_response_is_username_collision(self, response):

--- a/common/djangoapps/user_api/tests/test_helpers.py
+++ b/common/djangoapps/user_api/tests/test_helpers.py
@@ -144,14 +144,14 @@ class StudentViewShimTest(TestCase):
         self.assertNotIn("enrollment_action", self.captured_request.POST)
         self.assertNotIn("course_id", self.captured_request.POST)
 
-    @ddt.data(True, False)
-    def test_preserve_401_status(self, check_logged_in):
+    def test_third_party_auth_login_failure(self):
         view = self._shimmed_view(
-            HttpResponse(status=401),
-            check_logged_in=check_logged_in
+            HttpResponse(status=403),
+            check_logged_in=True
         )
         response = view(HttpRequest())
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.content, "third-party-auth")
 
     def test_non_json_response(self):
         view = self._shimmed_view(HttpResponse(content="Not a JSON dict"))

--- a/common/djangoapps/user_api/views.py
+++ b/common/djangoapps/user_api/views.py
@@ -117,9 +117,10 @@ class LoginSessionView(APIView):
         Returns:
             HttpResponse: 200 on success
             HttpResponse: 400 if the request is not valid.
-            HttpResponse: 401 if the user successfully authenticated with a third-party
-                provider but does not have a linked account.
             HttpResponse: 403 if authentication failed.
+                403 with content "third-party-auth" if the user
+                has successfully authenticated with a third party provider
+                but does not have a linked account.
             HttpResponse: 302 if redirecting to another page.
 
         Example Usage:

--- a/lms/static/js/student_account/views/LoginView.js
+++ b/lms/static/js/student_account/views/LoginView.js
@@ -83,13 +83,13 @@ var edx = edx || {};
         saveError: function( error ) {
             console.log(error.status, ' error: ', error.responseText);
 
-            /* If we've gotten a 401 error, it means that we've successfully
+            /* If we've gotten a 403 error, it means that we've successfully
              * authenticated with a third-party provider, but we haven't
              * linked the account to an EdX account.  In this case,
              * we need to prompt the user to enter a little more information
              * to complete the registration process.
-             */
-            if (error.status === 401 && this.currentProvider) {
+            */
+            if (error.status === 403 && error.responseText === "third-party-auth" && this.currentProvider) {
                 this.$alreadyAuthenticatedMsg.removeClass("hidden");
             }
             else {

--- a/lms/templates/login.html
+++ b/lms/templates/login.html
@@ -50,7 +50,7 @@
       $('#login-form').on('ajax:error', function(event, request, status_string) {
         toggleSubmitButton(true);
 
-        if (request.status === 401) {
+        if (request.status === 403) {
           $('.message.submission-error').removeClass('is-shown');
           $('.third-party-signin.message').addClass('is-shown').focus();
           $('.third-party-signin.message .instructions').html(request.responseText);


### PR DESCRIPTION
It turns out that if you use a 401 and basic auth is enabled, the browser will prompt the user for basic auth credentials.  I tried a few approaches for fixing this, but in the end it was easiest and safest to send a 403 status instead.

@rlucioni please review
