### PR TITLE
Fix test page definition for course group configurations page

### DIFF
--- a/common/test/acceptance/pages/studio/settings_group_configurations.py
+++ b/common/test/acceptance/pages/studio/settings_group_configurations.py
@@ -1,7 +1,7 @@
 """
 Course Group Configurations page.
 """
-
+from bok_choy.promise import EmptyPromise
 from .course_page import CoursePage
 from .utils import confirm_prompt
 
@@ -14,7 +14,20 @@ class GroupConfigurationsPage(CoursePage):
     url_path = "group_configurations"
 
     def is_browser_on_page(self):
-        return self.q(css='body.view-group-configurations').present
+        """
+        Verify that the browser is on the page and it is not still loading.
+        """
+        EmptyPromise(
+            lambda: self.q(css='body.view-group-configurations').present,
+            'On the group configuration page'
+        ).fulfill()
+
+        EmptyPromise(
+            lambda: not self.q(css='span.spin').visible,
+            'Group Configurations are finished loading'
+        ).fulfill()
+
+        return True
 
     @property
     def group_configurations(self):


### PR DESCRIPTION
This was causing intermittent failures when it was trying to parse the groups but the page wasn't finished loading yet.   TNL-685

@zubair-arbi @cahrens 
