### PR TITLE
Set marketing site logged in cookie from third party auth.

### DIFF
--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -1,0 +1,42 @@
+"""Helpers for the student app. """
+import time
+from django.utils.http import cookie_date
+from django.conf import settings
+
+
+def set_logged_in_cookie(request, response):
+    """Set a cookie indicating that the user is logged in.
+
+    Some installations have an external marketing site configured
+    that displays a different UI when the user is logged in
+    (e.g. a link to the student dashboard instead of to the login page)
+
+    Arguments:
+        request (HttpRequest): The request to the view, used to calculate
+            the cookie's expiration date based on the session expiration date.
+        response (HttpResponse): The response on which the cookie will be set.
+
+    Returns:
+        HttpResponse
+
+    """
+    if request.session.get_expire_at_browser_close():
+        max_age = None
+        expires = None
+    else:
+        max_age = request.session.get_expiry_age()
+        expires_time = time.time() + max_age
+        expires = cookie_date(expires_time)
+
+    response.set_cookie(
+        settings.EDXMKTG_COOKIE_NAME, 'true', max_age=max_age,
+        expires=expires, domain=settings.SESSION_COOKIE_DOMAIN,
+        path='/', secure=None, httponly=None,
+    )
+
+    return response
+
+
+def is_logged_in_cookie_set(request):
+    """Check whether the request has the logged in cookie set. """
+    return settings.EDXMKTG_COOKIE_NAME in request.COOKIES

--- a/common/djangoapps/third_party_auth/settings.py
+++ b/common/djangoapps/third_party_auth/settings.py
@@ -116,6 +116,7 @@ def _set_global_settings(django_settings):
         'social.pipeline.social_auth.associate_user',
         'social.pipeline.social_auth.load_extra_data',
         'social.pipeline.user.user_details',
+        'third_party_auth.pipeline.set_logged_in_cookie',
         'third_party_auth.pipeline.login_analytics',
         'third_party_auth.pipeline.change_enrollment',
     )

--- a/common/djangoapps/third_party_auth/tests/specs/base.py
+++ b/common/djangoapps/third_party_auth/tests/specs/base.py
@@ -394,6 +394,19 @@ class IntegrationTest(testutil.TestCase, test.TestCase):
         """Gets a user by email, using the given strategy."""
         return strategy.storage.user.user_model().objects.get(email=email)
 
+    def assert_logged_in_cookie_redirect(self, response):
+        """Verify that the user was redirected in order to set the logged in cookie. """
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response["Location"],
+            pipeline.get_complete_url(self.PROVIDER_CLASS.BACKEND_CLASS.name)
+        )
+        self.assertEqual(response.cookies[django_settings.EDXMKTG_COOKIE_NAME].value, 'true')
+
+    def set_logged_in_cookie(self, request):
+        """Simulate setting the marketing site cookie on the request. """
+        request.COOKIES[django_settings.EDXMKTG_COOKIE_NAME] = 'true'
+
     # Actual tests, executed once per child.
 
     def test_canceling_authentication_redirects_to_login_when_auth_entry_login(self):
@@ -430,6 +443,16 @@ class IntegrationTest(testutil.TestCase, test.TestCase):
         self.assert_dashboard_response_looks_correct(student_views.dashboard(request), request.user, linked=False)
         self.assert_social_auth_does_not_exist_for_user(request.user, strategy)
 
+        # We should be redirected back to the complete page, setting
+        # the "logged in" cookie for the marketing site.
+        self.assert_logged_in_cookie_redirect(actions.do_complete(
+            request.social_strategy, social_views._do_login, request.user, None,  # pylint: disable-msg=protected-access
+            redirect_field_name=auth.REDIRECT_FIELD_NAME
+        ))
+
+        # Set the cookie and try again
+        self.set_logged_in_cookie(request)
+
         # Fire off the auth pipeline to link.
         self.assert_redirect_to_dashboard_looks_correct(actions.do_complete(
             request.social_strategy, social_views._do_login, request.user, None,  # pylint: disable-msg=protected-access
@@ -448,6 +471,9 @@ class IntegrationTest(testutil.TestCase, test.TestCase):
         user = self.create_user_models_for_existing_account(
             strategy, 'user@example.com', 'password', self.get_username())
         self.assert_social_auth_exists_for_user(user, strategy)
+
+        # We're already logged in, so simulate that the cookie is set correctly
+        self.set_logged_in_cookie(request)
 
         # Instrument the pipeline to get to the dashboard with the full
         # expected state.
@@ -561,6 +587,17 @@ class IntegrationTest(testutil.TestCase, test.TestCase):
         # redirects to /auth/complete. In the browser ajax handlers will
         # redirect the user to the dashboard; we invoke it manually here.
         self.assert_json_success_response_looks_correct(student_views.login_user(strategy.request))
+
+        # We should be redirected back to the complete page, setting
+        # the "logged in" cookie for the marketing site.
+        self.assert_logged_in_cookie_redirect(actions.do_complete(
+            request.social_strategy, social_views._do_login, request.user, None,  # pylint: disable-msg=protected-access
+            redirect_field_name=auth.REDIRECT_FIELD_NAME
+        ))
+
+        # Set the cookie and try again
+        self.set_logged_in_cookie(request)
+
         self.assert_redirect_to_dashboard_looks_correct(
             actions.do_complete(strategy, social_views._do_login, user=user))
         self.assert_dashboard_response_looks_correct(student_views.dashboard(request), user)
@@ -651,6 +688,16 @@ class IntegrationTest(testutil.TestCase, test.TestCase):
         # At this point the user object exists, but there is no associated
         # social auth.
         self.assert_social_auth_does_not_exist_for_user(created_user, strategy)
+
+        # We should be redirected back to the complete page, setting
+        # the "logged in" cookie for the marketing site.
+        self.assert_logged_in_cookie_redirect(actions.do_complete(
+            request.social_strategy, social_views._do_login, request.user, None,  # pylint: disable-msg=protected-access
+            redirect_field_name=auth.REDIRECT_FIELD_NAME
+        ))
+
+        # Set the cookie and try again
+        self.set_logged_in_cookie(request)
 
         # Pick the pipeline back up. This will create the account association
         # and send the user to the dashboard, where the association will be


### PR DESCRIPTION
[ECOM-550](https://openedx.atlassian.net/browse/ECOM-550): 3rd Part Auth - Header - Log In and Registration button showing after successful login

I'm going to run through the full 3rd party auth manual test plan on Monday, including edge cases like the user deleting just the logged in cookie at various points in the pipeline.  But I think this is far enough along to go into code review.

Reviewers: @dianakhuang @rlucioni 
FYI: @stephensanchez enjoy your vacation!
