### PR TITLE
Setting up another data czar

### DIFF
--- a/docs/en_us/data/source/internal_data_formats/change_log.rst
+++ b/docs/en_us/data/source/internal_data_formats/change_log.rst
@@ -14,6 +14,9 @@ October-December 2014
 
    * - Date
      - Change
+   * - 10/28/14
+     - Added best practices for passphrases to the
+       :ref:`Getting_Credentials_Data_Czar` chapter.
    * - 10/23/14
      - Added examples of the format used to identify course components to the
        :ref:`Student_Info` and :ref:`Tracking Logs` chapters.

--- a/docs/en_us/data/source/internal_data_formats/credentials.rst
+++ b/docs/en_us/data/source/internal_data_formats/credentials.rst
@@ -41,11 +41,16 @@ GNU Privacy Guard (GnuPG or GPG). Essentially, you install a cryptographic
 application on your local computer and then supply your email address and a
 secret passphrase (a password).
 
-.. important:: The email address that you supply when you create your keys 
- must be your official email address at your edX partner institution. After you
- specify the passphrase, be sure to take any steps necessary to assure that you
- can use it in the future. To minimize security risks, GPG does not provide a
- mechanism for supplying you with a reminder hint.
+.. important:: 
+
+ * The email address that you supply when you create your keys must be your
+   official email address at your edX partner institution.
+
+ * After you specify the passphrase, be sure to take any steps necessary to
+   assure that you can use it in the future. To minimize security risks, GPG
+   does not provide a mechanism for supplying you with a reminder hint.
+
+ * Do not reveal your passphrase to anyone else.
 
 The result is the public key that you send to edX to use in encrypting data
 files for your institution, and the private key which you keep secret and use
@@ -88,7 +93,10 @@ Create Keys: Windows
 #. Optionally, click **Make a Backup Copy of Your Key Pair** to store both of
    the keys on a removable data storage device.
 
-.. important:: Do not reveal your passphrase, or share your private key, with anyone else.
+.. important:: Do not reveal your passphrase, or share your private key, with 
+ anyone else. If you need another person to be able to transfer and decrypt
+ files, work with edX to set her or him up as an additional data czar. Data
+ czars must create and use their own passphrases.
 
 .. _Gpg4win: http://gpg4win.org/
 
@@ -187,7 +195,8 @@ credentials.csv file. Open the decrypted credentials.csv file to see that it
 contains your email address, your Access Key, and your Secret Key.
 
  .. image:: ../Images/AWS_Credentials.png
-  :alt: A csv file, open in Notepad, with the Access Key value and the Secret Key value underlined
+  :alt: A csv file, open in Notepad, with the Access Key value and the Secret 
+        Key value underlined
 
 .. _Access Amazon S3:
 

--- a/docs/en_us/data/source/internal_data_formats/data_czar.rst
+++ b/docs/en_us/data/source/internal_data_formats/data_czar.rst
@@ -8,8 +8,15 @@ A data czar is the single representative at a partner institution who has the
 credentials to download and decrypt edX data packages. The data czar is
 responsible for transferring data securely to researchers and other interested
 parties after it is received. Due to the sensitivity of this data, the
-responsibility for these activities is restricted to one individual. At each
-partner institution, the data czar is the primary point of contact for
+responsibility for these activities is restricted to one individual. 
+
+.. important:: As a best practice for working with student data, edX strongly 
+ recommends a single data czar at each partner institution. However, if an
+ additional individual is given this responsibility at your institution, be
+ sure to work with edX to set up individual credentials for that additional
+ data czar.
+
+At each partner institution, the data czar is the primary point of contact for
 information about edX data.
 
 * :ref:`Skills_Experience_Data_Czar`
@@ -23,11 +30,13 @@ making a secure transfer of the data to the research team. Typically, the data
 team includes members in the following roles (or a data czar with these skill
 sets):
 
-* Database administrators work with the SQL and NoSQL data files and write queries on the data.
+* Database administrators work with the SQL and NoSQL data files and write
+  queries on the data.
 
 * Statisticians and data analysts mine the data.
 
-* Educational researchers pose questions and interpret the results of queries on the data.
+* Educational researchers pose questions and interpret the results of queries
+  on the data.
 
 See :ref:`Skills_Experience_Contributors`.
 
@@ -137,7 +146,8 @@ Technical Skills
   join, and aggregate data from different data sources, handle JSON
   serialization, and Unicode specificities.
 
-- Experience with data mining and data aggregation across a rich, varied data set.
+- Experience with data mining and data aggregation across a rich, varied data
+  set.
 
 - Ability to write parsing scripts that properly handle JSON serialization and
   Unicode.


### PR DESCRIPTION
@shnayder  @mhoeber @WatsonEmily @stroilova : now that it is possible to add a second data czar, best practice remains to have just one at a site, but to add a second data czar rather than have them share a single passphrase (we just don't want all partners to add lots of people all over)
