### PR TITLE
Fix case of y coords in Drag & Drop template

### DIFF
--- a/docs/en_us/course_authors/source/exercises_tools/drag_and_drop.rst
+++ b/docs/en_us/course_authors/source/exercises_tools/drag_and_drop.rst
@@ -1,2 +1,1 @@
 .. include:: ../../../shared/exercises_tools/drag_and_drop.rst
-

--- a/docs/en_us/shared/exercises_tools/drag_and_drop.rst
+++ b/docs/en_us/shared/exercises_tools/drag_and_drop.rst
@@ -143,8 +143,8 @@ Template for Advanced Problem
           <drag_and_drop_input img="/static/TARGET_IMAGE.png" target_outline="true" one_per_target="true" no_labels="true" label_bg_color="rgb(222, 139, 238)">
               <draggable id="1" label="LABEL 1" />
               <draggable id="2" label="LABEL 2" />
-              <target id="A" x="NUMBER" Y="NUMBER" w="X+WIDTH" h="Y+HEIGHT"/>
-              <target id="B" x="NUMBER" Y="NUMBER" w="X+WIDTH" h="Y+HEIGHT"/>
+              <target id="A" x="NUMBER" y="NUMBER" w="X+WIDTH" h="Y+HEIGHT"/>
+              <target id="B" x="NUMBER" y="NUMBER" w="X+WIDTH" h="Y+HEIGHT"/>
           </drag_and_drop_input>
           <answer type="loncapa/python">
   correct_answer = [{


### PR DESCRIPTION
Change from uppercase to lowercase “Y” (DOC-1070)
@mhoeber @lamagnifica @srpearce @JAAkana please review
