### PR TITLE
Verified Receipt page layout fixes

### DIFF
--- a/lms/templates/shoppingcart/verified_cert_receipt.html
+++ b/lms/templates/shoppingcart/verified_cert_receipt.html
@@ -13,23 +13,21 @@
 % endif
 
 <div class="container">
-  <section class="wrapper cart-list">
+  <section class="wrapper">
 
     <header class="page-header">
       <h2 class="title">
-        <span class="sts-label">${_("You are now registered for: ")}</span>
 
         <span class="wrapper-sts">
-          <span class="sts-course">
-            <span class="sts-course-org">${course_org}</span>
-            <span class="sts-course-number">${course_num}</span>
-            <span class="sts-course-name">${course_name}</span>
-          </span>
+          <span class="sts-label">${_("You are now registered for: ")}</span>
+          <span class="sts-course-org">${course_org}</span>
+          <span class="sts-course-number">${course_num}</span>
+          <span class="sts-course-name">${course_name}</span>
+        </span>
 
-          <span class="sts-track">
-            <span class="sts-track-value">
-              <span class="context">${_("Registered as: ")}</span> ${_("ID Verified")}
-            </span>
+        <span class="sts-track">
+          <span class="sts-track-value">
+            <span class="context">${_("Registered as: ")}</span> ${_("ID Verified")}
           </span>
         </span>
       </h2>


### PR DESCRIPTION
Reorg of the receipt page header to match rest of the flow; removed cart-list class from receipt page wrapper.

@dianakhuang and @jbau can you confirm that this change will not affect the edX verified certificate and Stanford shopping cart? 

@talbs can you review my FED work?
