### PR TITLE
Linkify contributor process graph

### DIFF
--- a/docs/en_us/developers/source/process/overview.rst
+++ b/docs/en_us/developers/source/process/overview.rst
@@ -45,6 +45,7 @@ Overview
 .. image:: pr-process.png
    :align: center
    :alt: A visualization of the pull request process
+   :target: ../_images/pr-process.png
 
 If you are a :doc:`contributor <contributor>` submitting a pull request, expect that it will
 take a few weeks before it can be merged. The earlier you can start talking


### PR DESCRIPTION
Because it's too small to read on RTD. @sarina, @mhoeber, can you two review?
