### PR TITLE
Do not show middle-click href in marketing iframe for logged in users

### DIFF
--- a/lms/templates/courseware/mktg_course_about.html
+++ b/lms/templates/courseware/mktg_course_about.html
@@ -53,9 +53,7 @@
           %endif
         %elif allow_registration:
         <a class="action action-register register ${'has-option-verified' if len(course_modes) > 1 else ''}"
-            %if user.is_authenticated():
-                href="${reverse('about_course', args=[course.id.to_deprecated_string()])}"
-            %else:
+            %if not user.is_authenticated():
                 href="${reverse('register_user')}?course_id=${course.id | u}&enrollment_action=enroll"
             %endif
         >${_("Enroll in")} <strong>${course.display_number_with_default | h}</strong>


### PR DESCRIPTION
https://github.com/edx/edx-platform/pull/5657/ beside of reducing JS size in marketing iframe added real middle-clickable hrefs on "Enrol" button.

For anonymous users it pointed to registration-for-a-course page
For logged in users it pointed to course-about-page.

Left-clicking was not affected, as it was handled javascriptically.

Issue I just found was that courses which did not yet start instead of About display "page not found".
This patch removes added link for authorized users, avoiding possible confusion and experience worse than it was before TNL-281.

@explorerleslie @cahrens @auraz @martynjames 
