### PR TITLE
Flip order of register and login options in the access view

### DIFF
--- a/lms/templates/student_account/access.underscore
+++ b/lms/templates/student_account/access.underscore
@@ -5,18 +5,18 @@
 
 <section class="form-type">
     <h2>
-        <input type="radio" name="form" id="register-option" value="register" class="form-toggle" <% if ( mode === 'register' ) { %>checked<% } %> >
-        <label for="register-option" class="form-label"><%- gettext("I am a new user") %></label>
-    </h2>
-    <div id="register-form" class="form-wrapper <% if ( mode !== 'register' ) { %>hidden" aria-hidden="true<% } %>"></div>
-</section>
-
-<section class="form-type">
-    <h2>
         <input type="radio" name="form" id="login-option" value="login" class="form-toggle" <% if ( mode === 'login' ) { %>checked<% } %>>
         <label for="login-option" class="form-label"><%- gettext("I am a returning user") %></label>
     </h2>
     <div id="login-form" class="form-wrapper <% if ( mode !== 'login' ) { %>hidden" aria-hidden="true<% } %>"></div>
+</section>
+
+<section class="form-type">
+    <h2>
+        <input type="radio" name="form" id="register-option" value="register" class="form-toggle" <% if ( mode === 'register' ) { %>checked<% } %> >
+        <label for="register-option" class="form-label"><%- gettext("I am a new user") %></label>
+    </h2>
+    <div id="register-form" class="form-wrapper <% if ( mode !== 'register' ) { %>hidden" aria-hidden="true<% } %>"></div>
 </section>
 
 <div id="password-reset-wrapper"></div>


### PR DESCRIPTION
This is a suggestion from @griffresch and I, for your consideration @andywaldrop. Impetus is that the login option is difficult to find when a user lands on the registration form, since the login radio button is all the way at the bottom of the page. Since the login form is short, putting it above the registration option doesn't push the registration option all the way down to the bottom of the page. This makes it easier to switch between the forms quickly by keeping both options visible on screen.

This is how the registration page would appear:
![](http://i.imgur.com/A5oesf4.png)
This is how the login page would appear:
![](http://i.imgur.com/5gl2nc0.png)

@AlasdairSwan, FYI.
