### PR TITLE
Content libraries prototype

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_libraries.py
+++ b/cms/djangoapps/contentstore/tests/test_libraries.py
@@ -1,0 +1,274 @@
+"""
+Content library unit tests that require the CMS runtime.
+"""
+from contentstore.tests.utils import AjaxEnabledTestClient, parse_json
+from contentstore.utils import reverse_usage_url
+from fs.memoryfs import MemoryFS
+from xmodule.library_content_module import LibraryVersionReference
+from xmodule.modulestore import ModuleStoreEnum
+from xmodule.modulestore.django import modulestore
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.tests import get_test_system
+from mock import Mock
+from opaque_keys.edx.locator import CourseKey, LibraryLocator
+import ddt
+
+
+@ddt.ddt
+class TestLibraries(ModuleStoreTestCase):
+    """
+    High-level tests for libraries
+    """
+    def setUp(self):
+        user_password = super(TestLibraries, self).setUp()
+
+        self.client = AjaxEnabledTestClient()
+        self.client.login(username=self.user.username, password=user_password)
+
+        self.lib_key = self._create_library()
+        self.library = modulestore().get_library(self.lib_key)
+
+    def _create_module_system(self, course):
+        """
+        Create an xmodule system so we can use bind_for_student
+        """
+        def get_module(descriptor):
+            """Mocks module_system get_module function"""
+            module_system = get_test_system()
+            module_system.get_module = get_module
+            descriptor.bind_for_student(module_system, descriptor._field_data)  # pylint: disable=protected-access
+            return descriptor
+
+        module_system = get_test_system()
+        module_system.get_module = get_module
+        module_system.descriptor_system = course.runtime
+        course.runtime.export_fs = MemoryFS()
+        return module_system
+
+    def _create_library(self, org="org", library="lib", display_name="Test Library"):
+        """
+        Helper method used to create a library. Uses the REST API.
+        """
+        response = self.client.ajax_post('/library/', {
+            'org': org,
+            'library': library,
+            'display_name': display_name,
+        })
+        self.assertEqual(response.status_code, 200)
+        lib_info = parse_json(response)
+        lib_key = CourseKey.from_string(lib_info['library_key'])
+        self.assertIsInstance(lib_key, LibraryLocator)
+        return lib_key
+
+    def _add_library_content_block(self, course, library_key, other_settings=None):
+        """
+        Helper method to add a LibraryContent block to a course.
+        The block will be configured to select content from the library
+        specified by library_key.
+        other_settings can be a dict of Scope.settings fields to set on the block.
+        """
+        metadata = {'source_libraries': [LibraryVersionReference(library_key)]}
+        if other_settings:
+            metadata.update(other_settings)
+        return ItemFactory.create(
+            category='library_content',
+            parent_location=course.location,
+            user_id=self.user.id,
+            metadata=metadata,
+            publish_item=False,
+        )
+
+    def _refresh_children(self, lib_content_block):
+        """
+        Helper method: Uses the REST API to call the 'refresh_children' handler
+        of a LibraryContent block
+        """
+        if 'user' not in lib_content_block.runtime._services:  # pylint: disable=protected-access
+            lib_content_block.runtime._services['user'] = Mock(user_id=self.user.id)  # pylint: disable=protected-access
+        handler_url = reverse_usage_url('component_handler', lib_content_block.location, kwargs={'handler': 'refresh_children'})
+        response = self.client.ajax_post(handler_url)
+        self.assertEqual(response.status_code, 200)
+        return modulestore().get_item(lib_content_block.location)
+
+    @ddt.data(
+        (2, 1, 1),
+        (2, 2, 2),
+        (2, 20, 2),
+    )
+    @ddt.unpack
+    def test_max_items(self, num_to_create, num_to_select, num_expected):
+        """
+        Test that overriding blocks from a library in a specific course works
+        """
+        for _ in range(0, num_to_create):
+            ItemFactory.create(category="html", parent_location=self.library.location, user_id=self.user.id, publish_item=False)
+
+        with modulestore().default_store(ModuleStoreEnum.Type.split):
+            course = CourseFactory.create()
+
+        lc_block = self._add_library_content_block(course, self.lib_key, {'max_count': num_to_select})
+        self.assertEqual(len(lc_block.children), 0)
+        lc_block = self._refresh_children(lc_block)
+
+        # Now, we want to make sure that .children has the total # of potential
+        # children, and that get_child_descriptors() returns the actual children
+        # chosen for a given student.
+        # In order to be able to call get_child_descriptors(), we must first
+        # call bind_for_student:
+        lc_block.bind_for_student(self._create_module_system(course), lc_block._field_data)  # pylint: disable=protected-access
+        self.assertEqual(len(lc_block.children), num_to_create)
+        self.assertEqual(len(lc_block.get_child_descriptors()), num_expected)
+
+    def test_consistent_children(self):
+        """
+        Test that the same student will always see the same selected child block
+        """
+        # Create many blocks in the library and add them to a course:
+        for num in range(0, 8):
+            ItemFactory.create(
+                metadata={"data": "This is #{}".format(num + 1)},
+                category="html", parent_location=self.library.location, user_id=self.user.id, publish_item=False
+            )
+
+        with modulestore().default_store(ModuleStoreEnum.Type.split):
+            course = CourseFactory.create()
+            module_system = self._create_module_system(course)
+
+        lc_block = self._add_library_content_block(course, self.lib_key, {'max_count': 1})
+        lc_block_key = lc_block.location
+        lc_block = self._refresh_children(lc_block)
+
+        def get_child_of_lc_block(block):
+            """
+            Helper that gets the actual child block seen by a student.
+            We cannot use get_child_descriptors because it uses features that
+            are mocked by the test runtime.
+            """
+            block_ids = list(block._xmodule.selected_children())  # pylint: disable=protected-access
+            self.assertEqual(len(block_ids), 1)
+            for child_key in block.children:
+                if child_key.block_id == block_ids[0]:
+                    return modulestore().get_item(child_key)
+            return None
+
+        # bind the module for a student:
+        lc_block.bind_for_student(module_system, lc_block._field_data)  # pylint: disable=protected-access
+        chosen_child = get_child_of_lc_block(lc_block)
+        chosen_child_defn_id = chosen_child.definition_locator.definition_id
+
+        modulestore().update_item(lc_block, self.user.id)
+
+        # Now re-load the block and try again:
+        def check():
+            """
+            Confirm that chosen_child is still the child seen by the test student
+            """
+            for _ in range(0, 10):  # Repeat many times b/c blocks are randomized
+                lc_block = modulestore().get_item(lc_block_key)  # Reload block from the database
+                lc_block.bind_for_student(module_system, lc_block._field_data)  # pylint: disable=protected-access
+                current_child = get_child_of_lc_block(lc_block)
+                self.assertEqual(current_child.location, chosen_child.location)
+                self.assertEqual(current_child.data, chosen_child.data)
+                self.assertEqual(current_child.definition_locator.definition_id, chosen_child_defn_id)
+        check()
+
+        # Refresh the children:
+        lc_block = self._refresh_children(lc_block)
+        lc_block.bind_for_student(module_system, lc_block._field_data)  # pylint: disable=protected-access
+
+        # Now re-load the block and try yet again, in case refreshing the children changed anything:
+        check()
+
+    def test_definition_shared_with_library(self):
+        """
+        Test that the same block definition is used for the library and course[s]
+        """
+        block1 = ItemFactory.create(category="html", parent_location=self.library.location, user_id=self.user.id, publish_item=False)
+        def_id1 = block1.definition_locator.definition_id
+        block2 = ItemFactory.create(category="html", parent_location=self.library.location, user_id=self.user.id, publish_item=False)
+        def_id2 = block2.definition_locator.definition_id
+        self.assertNotEqual(def_id1, def_id2)
+
+        # Next, create a course:
+        with modulestore().default_store(ModuleStoreEnum.Type.split):
+            course = CourseFactory.create()
+
+        # Add a LibraryContent block to the course:
+        lc_block = self._add_library_content_block(course, self.lib_key)
+        lc_block = self._refresh_children(lc_block)
+        for child_key in lc_block.children:
+            child = modulestore().get_item(child_key)
+            def_id = child.definition_locator.definition_id
+            self.assertIn(def_id, (def_id1, def_id2))
+
+    def test_fields(self):
+        """
+        Test that blocks used from a library have the same field values as
+        defined by the library author.
+        """
+        data_value = "A Scope.content value"
+        name_value = "A Scope.settings value"
+        lib_block = ItemFactory.create(
+            category="html",
+            parent_location=self.library.location,
+            user_id=self.user.id,
+            publish_item=False,
+            display_name=name_value,
+            metadata={
+                "data": data_value,
+            },
+        )
+        self.assertEqual(lib_block.data, data_value)
+        self.assertEqual(lib_block.display_name, name_value)
+
+        # Next, create a course:
+        with modulestore().default_store(ModuleStoreEnum.Type.split):
+            course = CourseFactory.create()
+
+        # Add a LibraryContent block to the course:
+        lc_block = self._add_library_content_block(course, self.lib_key)
+        lc_block = self._refresh_children(lc_block)
+        course_block = modulestore().get_item(lc_block.children[0])
+
+        self.assertEqual(course_block.data, data_value)
+        self.assertEqual(course_block.display_name, name_value)
+
+    def test_block_with_children(self):
+        """
+        Test that blocks used from a library can have children.
+        """
+        data_value = "A Scope.content value"
+        name_value = "A Scope.settings value"
+        # In the library, create a vertical block with a child:
+        vert_block = ItemFactory.create(
+            category="vertical",
+            parent_location=self.library.location,
+            user_id=self.user.id,
+            publish_item=False,
+        )
+        child_block = ItemFactory.create(
+            category="html",
+            parent_location=vert_block.location,
+            user_id=self.user.id,
+            publish_item=False,
+            display_name=name_value,
+            metadata={"data": data_value, },
+        )
+        self.assertEqual(child_block.data, data_value)
+        self.assertEqual(child_block.display_name, name_value)
+
+        # Next, create a course:
+        with modulestore().default_store(ModuleStoreEnum.Type.split):
+            course = CourseFactory.create()
+
+        # Add a LibraryContent block to the course:
+        lc_block = self._add_library_content_block(course, self.lib_key)
+        lc_block = self._refresh_children(lc_block)
+        self.assertEqual(len(lc_block.children), 1)
+        course_vert_block = modulestore().get_item(lc_block.children[0])
+        self.assertEqual(len(course_vert_block.children), 1)
+        course_child_block = modulestore().get_item(course_vert_block.children[0])
+
+        self.assertEqual(course_child_block.data, data_value)
+        self.assertEqual(course_child_block.display_name, name_value)

--- a/cms/djangoapps/contentstore/tests/test_libraries.py
+++ b/cms/djangoapps/contentstore/tests/test_libraries.py
@@ -3,6 +3,7 @@ Content library unit tests that require the CMS runtime.
 """
 from contentstore.tests.utils import AjaxEnabledTestClient, parse_json
 from contentstore.utils import reverse_usage_url
+from contentstore.views.tests.test_library import LIBRARY_REST_URL
 from fs.memoryfs import MemoryFS
 from xmodule.library_content_module import LibraryVersionReference
 from xmodule.modulestore import ModuleStoreEnum
@@ -50,7 +51,7 @@ class TestLibraries(ModuleStoreTestCase):
         """
         Helper method used to create a library. Uses the REST API.
         """
-        response = self.client.ajax_post('/library/', {
+        response = self.client.ajax_post(LIBRARY_REST_URL, {
             'org': org,
             'library': library,
             'display_name': display_name,
@@ -99,7 +100,7 @@ class TestLibraries(ModuleStoreTestCase):
     @ddt.unpack
     def test_max_items(self, num_to_create, num_to_select, num_expected):
         """
-        Test that overriding blocks from a library in a specific course works
+        Test the 'max_count' property of LibraryContent blocks.
         """
         for _ in range(0, num_to_create):
             ItemFactory.create(category="html", parent_location=self.library.location, user_id=self.user.id, publish_item=False)
@@ -150,7 +151,6 @@ class TestLibraries(ModuleStoreTestCase):
             for child_key in block.children:
                 if child_key.block_id == block_ids[0]:
                     return modulestore().get_item(child_key)
-            return None
 
         # bind the module for a student:
         lc_block.bind_for_student(module_system, lc_block._field_data)  # pylint: disable=protected-access

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -293,6 +293,13 @@ def reverse_course_url(handler_name, course_key, kwargs=None):
     return reverse_url(handler_name, 'course_key_string', course_key, kwargs)
 
 
+def reverse_library_url(handler_name, library_key, kwargs=None):
+    """
+    Creates the URL for handlers that use library_keys as URL parameters.
+    """
+    return reverse_url(handler_name, 'library_key_string', library_key, kwargs)
+
+
 def reverse_usage_url(handler_name, usage_key, kwargs=None):
     """
     Creates the URL for handlers that use usage_keys as URL parameters.

--- a/cms/djangoapps/contentstore/views/__init__.py
+++ b/cms/djangoapps/contentstore/views/__init__.py
@@ -12,6 +12,7 @@ from .error import *
 from .helpers import *
 from .item import *
 from .import_export import *
+from .library import *
 from .preview import *
 from .public import *
 from .export_git import *

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -430,6 +430,7 @@ def course_listing(request):
     return render_to_response('index.html', {
         'courses': courses,
         'in_process_course_actions': in_process_course_actions,
+        'libraries_enabled': LIBRARIES_ENABLED,
         'libraries': [format_library_for_view(lib) for lib in libraries],
         'user': request.user,
         'request_course_creator_url': reverse('contentstore.views.request_course_creator'),

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -38,6 +38,7 @@ from contentstore.utils import (
     add_extra_panel_tab,
     remove_extra_panel_tab,
     reverse_course_url,
+    reverse_library_url,
     reverse_usage_url,
     reverse_url,
     remove_all_instructors,
@@ -56,6 +57,7 @@ from .component import (
     ADVANCED_COMPONENT_TYPES,
 )
 from contentstore.tasks import rerun_course
+from .library import LIBRARIES_ENABLED
 from .item import create_xblock_info
 from course_creators.views import get_course_creator_status, add_user_with_status_unrequested
 from contentstore import utils
@@ -341,6 +343,14 @@ def _accessible_courses_list_from_groups(request):
     return courses_list.values(), in_process_course_actions
 
 
+def _accessible_libraries_list(user):
+    """
+    List all libraries available to the logged in user by iterating through all libraries
+    """
+    # No need to worry about ErrorDescriptors - split's get_libraries() never returns them.
+    return [lib for lib in modulestore().get_libraries() if has_course_access(user, lib.location)]
+
+
 @login_required
 @ensure_csrf_cookie
 def course_listing(request):
@@ -359,6 +369,8 @@ def course_listing(request):
             # user have some old groups or there was some error getting courses from django groups
             # so fallback to iterating through all courses
             courses, in_process_course_actions = _accessible_courses_list(request)
+
+    libraries = _accessible_libraries_list(request.user) if LIBRARIES_ENABLED else []
 
     def format_course_for_view(course):
         """
@@ -393,6 +405,18 @@ def course_listing(request):
                 }) if uca.state == CourseRerunUIStateManager.State.FAILED else ''
         }
 
+    def format_library_for_view(library):
+        """
+        Return a dict of the data which the view requires for each library
+        """
+        return {
+            'display_name': library.display_name,
+            'library_key': unicode(library.location.library_key),
+            'url': reverse_library_url('library_handler', unicode(library.location.library_key)),
+            'org': library.display_org_with_default,
+            'number': library.display_number_with_default,
+        }
+
     # remove any courses in courses that are also in the in_process_course_actions list
     in_process_action_course_keys = [uca.course_key for uca in in_process_course_actions]
     courses = [
@@ -406,6 +430,7 @@ def course_listing(request):
     return render_to_response('index.html', {
         'courses': courses,
         'in_process_course_actions': in_process_course_actions,
+        'libraries': [format_library_for_view(lib) for lib in libraries],
         'user': request.user,
         'request_course_creator_url': reverse('contentstore.views.request_course_creator'),
         'course_creator_status': _get_course_creator_status(request.user),

--- a/cms/djangoapps/contentstore/views/helpers.py
+++ b/cms/djangoapps/contentstore/views/helpers.py
@@ -13,7 +13,7 @@ from django.utils.translation import ugettext as _
 from edxmako.shortcuts import render_to_string, render_to_response
 from xblock.core import XBlock
 from xmodule.modulestore.django import modulestore
-from contentstore.utils import reverse_course_url, reverse_usage_url
+from contentstore.utils import reverse_course_url, reverse_library_url, reverse_usage_url
 
 __all__ = ['edge', 'event', 'landing']
 
@@ -106,6 +106,9 @@ def xblock_studio_url(xblock, parent_xblock=None):
             url=reverse_course_url('course_handler', xblock.location.course_key),
             usage_key=urllib.quote(unicode(xblock.location))
         )
+    elif category == 'library':
+        library_key = xblock.location.course_key
+        return reverse_library_url('library_handler', library_key)
     else:
         return reverse_usage_url('container_handler', xblock.location)
 

--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -47,6 +47,7 @@ from edxmako.shortcuts import render_to_string
 from models.settings.course_grading import CourseGradingModel
 from cms.lib.xblock.runtime import handler_url, local_resource_url
 from opaque_keys.edx.keys import UsageKey, CourseKey
+from opaque_keys.edx.locator import LibraryUsageLocator
 
 __all__ = ['orphan_handler', 'xblock_handler', 'xblock_view_handler', 'xblock_outline_handler']
 
@@ -649,7 +650,9 @@ def _get_module_info(xblock, rewrite_static_links=True):
             )
 
         # Pre-cache has changes for the entire course because we'll need it for the ancestor info
-        modulestore().has_changes(modulestore().get_course(xblock.location.course_key, depth=None))
+        # Except library blocks which don't use draft/publish
+        if not isinstance(xblock.location, LibraryUsageLocator):
+            modulestore().has_changes(modulestore().get_courselike(xblock.location.course_key, depth=None))
 
         # Note that children aren't being returned until we have a use case.
         return create_xblock_info(xblock, data=data, metadata=own_metadata(xblock), include_ancestor_info=True)
@@ -690,12 +693,16 @@ def create_xblock_info(xblock, data=None, metadata=None, include_ancestor_info=F
 
         return None
 
+    is_library_block = isinstance(xblock.location, LibraryUsageLocator)
     is_xblock_unit = is_unit(xblock, parent_xblock)
-    # this should not be calculated for Sections and Subsections on Unit page
-    has_changes = modulestore().has_changes(xblock) if (is_xblock_unit or course_outline) else None
+    # this should not be calculated for Sections and Subsections on Unit page or for library blocks
+    has_changes = modulestore().has_changes(xblock) if (is_xblock_unit or course_outline) and not is_library_block else None
 
     if graders is None:
-        graders = CourseGradingModel.fetch(xblock.location.course_key).graders
+        if not is_library_block:
+            graders = CourseGradingModel.fetch(xblock.location.course_key).graders
+        else:
+            graders = []
 
     # Compute the child info first so it can be included in aggregate information for the parent
     should_visit_children = include_child_info and (course_outline and not is_xblock_unit or not course_outline)
@@ -715,7 +722,7 @@ def create_xblock_info(xblock, data=None, metadata=None, include_ancestor_info=F
         visibility_state = _compute_visibility_state(xblock, child_info, is_xblock_unit and has_changes)
     else:
         visibility_state = None
-    published = modulestore().has_published_version(xblock)
+    published = modulestore().has_published_version(xblock) if not is_library_block else None
 
     xblock_info = {
         "id": unicode(xblock.location),
@@ -723,7 +730,7 @@ def create_xblock_info(xblock, data=None, metadata=None, include_ancestor_info=F
         "category": xblock.category,
         "edited_on": get_default_time_display(xblock.subtree_edited_on) if xblock.subtree_edited_on else None,
         "published": published,
-        "published_on": get_default_time_display(xblock.published_on) if xblock.published_on else None,
+        "published_on": get_default_time_display(xblock.published_on) if published and xblock.published_on else None,
         "studio_url": xblock_studio_url(xblock, parent_xblock),
         "released_to_students": datetime.now(UTC) > xblock.start,
         "release_date": release_date,

--- a/cms/djangoapps/contentstore/views/library.py
+++ b/cms/djangoapps/contentstore/views/library.py
@@ -1,0 +1,112 @@
+"""
+Views related to content libraries.
+A content library is a structure containing XBlocks which can be re-used in the
+multiple courses.
+"""
+from __future__ import absolute_import
+
+import json
+import logging
+
+from contentstore.views.item import create_xblock_info
+from django.http import HttpResponseNotAllowed, Http404
+from django.contrib.auth.decorators import login_required
+from django.core.exceptions import PermissionDenied
+from django.conf import settings
+from django.utils.translation import ugettext as _
+from django_future.csrf import ensure_csrf_cookie
+from edxmako.shortcuts import render_to_response
+from opaque_keys.edx.keys import CourseKey
+from opaque_keys.edx.locator import LibraryLocator, LibraryUsageLocator
+from xmodule.modulestore.django import modulestore
+
+from .access import has_course_access
+from .component import get_component_templates
+from util.json_request import JsonResponse
+
+__all__ = ['library_handler']
+
+log = logging.getLogger(__name__)
+
+LIBRARIES_ENABLED = settings.FEATURES.get('ENABLE_CONTENT_LIBRARIES', False)
+
+
+@login_required
+@ensure_csrf_cookie
+def library_handler(request, library_key_string=None):
+    """
+    RESTful interface to most content library related functionality.
+    """
+    if not LIBRARIES_ENABLED:
+        raise Http404  # Should never happen because we test the feature in urls.py also
+
+    response_format = 'html'
+    if request.REQUEST.get('format', 'html') == 'json' or 'application/json' in request.META.get('HTTP_ACCEPT', 'text/html'):
+        response_format = 'json'
+
+    if library_key_string:
+        library_key = CourseKey.from_string(library_key_string)
+        if not isinstance(library_key, LibraryLocator):
+            raise Http404  # This is not a library
+        if not has_course_access(request.user, library_key):
+            raise PermissionDenied()
+
+        library = modulestore().get_library(library_key)
+        if library is None:
+            raise Http404
+
+        if request.method == 'GET':
+            return library_blocks_view(library, response_format)
+        return HttpResponseNotAllowed(['GET'])
+
+    elif request.method == 'GET':
+        # List all accessible libraries:
+        lib_info = [
+            {
+                "display_name": lib.display_name,
+                "library_key": unicode(lib.location.library_key),
+            }
+            for lib in modulestore().get_libraries()
+            if has_course_access(request.user, lib.location.library_key)
+        ]
+        return JsonResponse(lib_info)
+    else:
+        return HttpResponseNotAllowed(['GET'])
+
+
+def library_blocks_view(library, response_format):
+    """
+    The main view of a course's content library.
+    Shows all the XBlocks in the library, and allows adding/editing/deleting
+    them.
+    Can be called with response_format="json" to get a JSON-formatted list of
+    the XBlocks in the library along with library metadata.
+    """
+    children = library.children
+    if response_format == "json":
+        # The JSON response for this request is short and sweet:
+        prev_version = library.runtime.course_entry.structure['previous_version']
+        return JsonResponse({
+            "display_name": library.display_name,
+            "library_id": unicode(library.location.course_key),  # library.course_id raises UndefinedContext - fix?
+            "version": unicode(library.runtime.course_entry.course_key.version),
+            "previous_version": unicode(prev_version) if prev_version else None,
+            "blocks": [unicode(x) for x in children],
+        })
+
+    xblock_info = create_xblock_info(library, include_ancestor_info=False, graders=[])
+
+    component_templates = get_component_templates(library)
+
+    assert isinstance(library.location.library_key, LibraryLocator)
+    assert isinstance(library.location, LibraryUsageLocator)
+
+    return render_to_response('library.html', {
+        'context_library': library,
+        'action': 'view',
+        'xblock': library,
+        'xblock_locator': library.location,
+        'unit': None,
+        'component_templates': json.dumps(component_templates),
+        'xblock_info': xblock_info,
+    })

--- a/cms/djangoapps/contentstore/views/tests/test_course_index.py
+++ b/cms/djangoapps/contentstore/views/tests/test_course_index.py
@@ -6,7 +6,7 @@ import lxml
 import datetime
 
 from contentstore.tests.utils import CourseTestCase
-from contentstore.utils import reverse_course_url, add_instructor
+from contentstore.utils import reverse_course_url, reverse_library_url, add_instructor
 from contentstore.views.access import has_course_access
 from contentstore.views.course import course_outline_initial_state
 from contentstore.views.item import create_xblock_info, VisibilityState
@@ -14,7 +14,7 @@ from course_action_state.models import CourseRerunState
 from util.date_utils import get_default_time_display
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, LibraryFactory
 from opaque_keys.edx.locator import CourseLocator
 from student.tests.factories import UserFactory
 from course_action_state.managers import CourseRerunUIStateManager
@@ -60,6 +60,27 @@ class TestCourseIndex(CourseTestCase):
             self.assertEqual(outline_link.get("href"), link.get("href"))
             course_menu_link = outline_parsed.find_class('nav-course-courseware-outline')[0]
             self.assertEqual(course_menu_link.find("a").get("href"), link.get("href"))
+
+    def test_libraries_on_course_index(self):
+        """
+        Test getting the list of libraries from the course listing page
+        """
+        # Add a library:
+        lib1 = LibraryFactory.create()
+
+        index_url = '/course/'
+        index_response = self.client.get(index_url, {}, HTTP_ACCEPT='text/html')
+        parsed_html = lxml.html.fromstring(index_response.content)
+        library_link_eles = parsed_html.find_class('library-link')
+        self.assertEqual(len(library_link_eles), 1)
+        link = library_link_eles[0]
+        self.assertEqual(
+            link.get("href"),
+            reverse_library_url('library_handler', lib1.location.library_key),
+        )
+        # now test that url
+        outline_response = self.client.get(link.get("href"), {}, HTTP_ACCEPT='text/html')
+        self.assertEqual(outline_response.status_code, 200)
 
     def test_is_staff_access(self):
         """

--- a/cms/djangoapps/contentstore/views/tests/test_helpers.py
+++ b/cms/djangoapps/contentstore/views/tests/test_helpers.py
@@ -4,7 +4,7 @@ Unit tests for helpers.py.
 
 from contentstore.tests.utils import CourseTestCase
 from contentstore.views.helpers import xblock_studio_url, xblock_type_display_name
-from xmodule.modulestore.tests.factories import ItemFactory
+from xmodule.modulestore.tests.factories import ItemFactory, LibraryFactory
 from django.utils import http
 
 
@@ -49,6 +49,11 @@ class HelpersTestCase(CourseTestCase):
         video = ItemFactory.create(parent_location=child_vertical.location, category="video",
                                    display_name="My Video")
         self.assertIsNone(xblock_studio_url(video))
+
+        # Verify library URL
+        library = LibraryFactory.create()
+        expected_url = u'/library/{}'.format(unicode(library.location.library_key))
+        self.assertEqual(xblock_studio_url(library), expected_url)
 
     def test_xblock_type_display_name(self):
 

--- a/cms/djangoapps/contentstore/views/tests/test_item.py
+++ b/cms/djangoapps/contentstore/views/tests/test_item.py
@@ -24,7 +24,8 @@ from student.tests.factories import UserFactory
 from xmodule.capa_module import CapaDescriptor
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
-from xmodule.modulestore.tests.factories import ItemFactory, check_mongo_calls
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.factories import ItemFactory, LibraryFactory, check_mongo_calls
 from xmodule.x_module import STUDIO_VIEW, STUDENT_VIEW
 from xblock.exceptions import NoSuchHandlerError
 from opaque_keys.edx.keys import UsageKey, CourseKey
@@ -1380,6 +1381,51 @@ class TestXBlockInfo(ItemTest):
             self.assertEqual(xblock_info['edited_by'], 'testuser')
         else:
             self.assertIsNone(xblock_info.get('edited_by', None))
+
+
+class TestLibraryXBlockInfo(ModuleStoreTestCase):
+    """
+    Unit tests for XBlock Info for XBlocks in a content library
+    """
+    def setUp(self):
+        super(TestLibraryXBlockInfo, self).setUp()
+        user_id = self.user.id
+        self.library = LibraryFactory.create()
+        self.top_level_html = ItemFactory.create(
+            parent_location=self.library.location, category='html', user_id=user_id, publish_item=False
+        )
+        self.vertical = ItemFactory.create(
+            parent_location=self.library.location, category='vertical', user_id=user_id, publish_item=False
+        )
+        self.child_html = ItemFactory.create(
+            parent_location=self.vertical.location, category='html', display_name='Test HTML Child Block', user_id=user_id, publish_item=False
+        )
+
+    def test_lib_xblock_info(self):
+        html_block = modulestore().get_item(self.top_level_html.location)
+        xblock_info = create_xblock_info(html_block)
+        self.validate_component_xblock_info(xblock_info, html_block)
+        self.assertIsNone(xblock_info.get('child_info', None))
+
+    def test_lib_child_xblock_info(self):
+        html_block = modulestore().get_item(self.child_html.location)
+        xblock_info = create_xblock_info(html_block, include_ancestor_info=True, include_child_info=True)
+        self.validate_component_xblock_info(xblock_info, html_block)
+        self.assertIsNone(xblock_info.get('child_info', None))
+        ancestors = xblock_info['ancestor_info']['ancestors']
+        self.assertEqual(len(ancestors), 2)
+        self.assertEqual(ancestors[0]['category'], 'vertical')
+        self.assertEqual(ancestors[0]['id'], unicode(self.vertical.location))
+        self.assertEqual(ancestors[1]['category'], 'library')
+
+    def validate_component_xblock_info(self, xblock_info, original_block):
+        """
+        Validate that the xblock info is correct for the test component.
+        """
+        self.assertEqual(xblock_info['category'], original_block.category)
+        self.assertEqual(xblock_info['id'], unicode(original_block.location))
+        self.assertEqual(xblock_info['display_name'], original_block.display_name)
+        self.assertIsNone(xblock_info.get('published_on', None))
 
 
 class TestXBlockPublishingInfo(ItemTest):

--- a/cms/djangoapps/contentstore/views/tests/test_library.py
+++ b/cms/djangoapps/contentstore/views/tests/test_library.py
@@ -1,0 +1,154 @@
+"""
+Unit tests for contentstore.views.library
+
+More important high-level tests are in contentstore/tests/test_libraries.py
+"""
+from contentstore.tests.utils import AjaxEnabledTestClient, parse_json
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.factories import LibraryFactory
+from mock import patch
+from opaque_keys.edx.locator import CourseKey, LibraryLocator
+import ddt
+
+LIBRARY_REST_URL = '/library/'  # URL for GET/POST requests involving libraries
+
+
+def make_url_for_lib(key):
+    """ Get the RESTful/studio URL for testing the given library """
+    if isinstance(key, LibraryLocator):
+        key = unicode(key)
+    return LIBRARY_REST_URL + key
+
+
+@ddt.ddt
+class UnitTestLibraries(ModuleStoreTestCase):
+    """
+    Unit tests for library views
+    """
+
+    def setUp(self):
+        user_password = super(UnitTestLibraries, self).setUp()
+
+        self.client = AjaxEnabledTestClient()
+        self.client.login(username=self.user.username, password=user_password)
+
+    ######################################################
+    # Tests for /library/ - list and create libraries:
+
+    @patch("contentstore.views.library.LIBRARIES_ENABLED", False)
+    def test_with_libraries_disabled(self):
+        """
+        The library URLs should return 404 if libraries are disabled.
+        """
+        response = self.client.get_json(LIBRARY_REST_URL)
+        self.assertEqual(response.status_code, 404)
+
+    def test_list_libraries(self):
+        """
+        Test that we can GET /library/ to list all libraries visible to the current user.
+        """
+        # Create some more libraries
+        libraries = [LibraryFactory.create() for _ in range(0, 3)]
+        lib_dict = dict([(lib.location.library_key, lib) for lib in libraries])
+
+        response = self.client.get_json(LIBRARY_REST_URL)
+        self.assertEqual(response.status_code, 200)
+        lib_list = parse_json(response)
+        self.assertEqual(len(lib_list), len(libraries))
+        for entry in lib_list:
+            self.assertIn("library_key", entry)
+            self.assertIn("display_name", entry)
+            key = CourseKey.from_string(entry["library_key"])
+            self.assertIn(key, lib_dict)
+            self.assertEqual(entry["display_name"], lib_dict[key].display_name)
+            del lib_dict[key]  # To ensure no duplicates are matched
+
+    @ddt.data("delete", "put")
+    def test_bad_http_verb(self, verb):
+        """
+        We should get an error if we do weird requests to /library/
+        """
+        response = getattr(self.client, verb)(LIBRARY_REST_URL)
+        self.assertEqual(response.status_code, 405)
+
+    def test_create_library(self):
+        """ Create a library. """
+        response = self.client.ajax_post(LIBRARY_REST_URL, {
+            'org': 'org',
+            'library': 'lib',
+            'display_name': "New Library",
+        })
+        self.assertEqual(response.status_code, 200)
+        # That's all we check. More detailed tests are in contentstore.tests.test_libraries...
+
+    @ddt.data(
+        {},
+        {'org': 'org'},
+        {'library': 'lib'},
+        {'org': 'C++', 'library': 'lib', 'display_name': 'Lib with invalid characters in key'},
+        {'org': 'Org', 'library': 'Wh@t?', 'display_name': 'Lib with invalid characters in key'},
+    )
+    def test_create_library_invalid(self, data):
+        """
+        Make sure we are prevented from creating libraries with invalid keys/data
+        """
+        response = self.client.ajax_post(LIBRARY_REST_URL, data)
+        self.assertEqual(response.status_code, 400)
+
+    def test_no_duplicate_libraries(self):
+        """
+        We should not be able to create multiple libraries with the same key
+        """
+        lib = LibraryFactory.create()
+        lib_key = lib.location.library_key
+        response = self.client.ajax_post(LIBRARY_REST_URL, {
+            'org': lib_key.org,
+            'library': lib_key.library,
+            'display_name': "A Duplicate key, same as 'lib'",
+        })
+        self.assertIn('duplicate', parse_json(response)['ErrMsg'])
+        self.assertEqual(response.status_code, 400)
+
+    ######################################################
+    # Tests for /library/:lib_key/ - get a specific library as JSON or HTML editing view
+
+    def test_get_lib_info(self):
+        """
+        Test that we can get data about a library (in JSON format) using /library/:key/
+        """
+        # Create a library
+        lib_key = LibraryFactory.create().location.library_key
+        # Re-load the library from the modulestore, explicitly including version information:
+        print("\n\nLoading now:")
+        lib = self.store.get_library(lib_key, remove_version=False, remove_branch=False)
+        version = lib.location.library_key.version_guid
+        print(repr(self.store))
+        print(repr(lib.location.library_key))
+        self.assertNotEqual(version, None)
+
+        response = self.client.get_json(make_url_for_lib(lib_key))
+        self.assertEqual(response.status_code, 200)
+        info = parse_json(response)
+        self.assertEqual(info['display_name'], lib.display_name)
+        self.assertEqual(info['library_id'], unicode(lib_key))
+        self.assertEqual(info['previous_version'], None)
+        self.assertNotEqual(info['version'], None)
+        self.assertNotEqual(info['version'], '')
+        self.assertEqual(info['version'], unicode(version))
+
+    @ddt.data('library-v1:Nonexistent+library', 'course-v1:Org+Course', 'course-v1:Org+Course+Run', 'invalid')
+    def test_invalid_keys(self, key_str):
+        """
+        Check that various Nonexistent/invalid keys give 404 errors
+        """
+        response = self.client.get_json(make_url_for_lib(key_str))
+        self.assertEqual(response.status_code, 404)
+
+    def test_bad_http_verb_with_lib_key(self):
+        """
+        We should get an error if we do weird requests to /library/
+        """
+        lib = LibraryFactory.create()
+        for verb in ("post", "delete", "put"):
+            response = getattr(self.client, verb)(make_url_for_lib(lib.location.library_key))
+            self.assertEqual(response.status_code, 405)

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -728,6 +728,7 @@ ADVANCED_COMPONENT_TYPES = [
     'word_cloud',
     'graphical_slider_tool',
     'lti',
+    'library_content',
     # XBlocks from pmitros repos are prototypes. They should not be used
     # except for edX Learning Sciences experiments on edge.edx.org without
     # further work to make them robust, maintainable, finalize data formats,

--- a/cms/envs/test.py
+++ b/cms/envs/test.py
@@ -224,3 +224,6 @@ FEATURES['USE_MICROSITES'] = True
 # For consistency in user-experience, keep the value of this setting in sync with
 # the one in lms/envs/test.py
 FEATURES['ENABLE_DISCUSSION_SERVICE'] = False
+
+# Enable content libraries code for the tests
+FEATURES['ENABLE_CONTENT_LIBRARIES'] = True

--- a/cms/static/js/index.js
+++ b/cms/static/js/index.js
@@ -152,6 +152,14 @@ define(["domReady", "jquery", "underscore", "js/utils/cancel_on_escape", "js/vie
             CreateLibraryUtils.configureHandlers();
         };
 
+        var showTab = function(tab) {
+          return function(e) {
+            e.preventDefault();
+            $('.courses-tab').toggleClass('active', tab === 'courses');
+            $('.libraries-tab').toggleClass('active', tab === 'libraries');
+          }
+        };
+
         var onReady = function () {
             $('.new-course-button').bind('click', addNewCourse);
             $('.new-library-button').bind('click', addNewLibrary);
@@ -159,6 +167,8 @@ define(["domReady", "jquery", "underscore", "js/utils/cancel_on_escape", "js/vie
                 ViewUtils.reload();
             }));
             $('.action-reload').bind('click', ViewUtils.reload);
+            $('#course-index-tabs .courses-tab').bind('click', showTab('courses'));
+            $('#course-index-tabs .libraries-tab').bind('click', showTab('libraries'));
         };
 
         domReady(onReady);

--- a/cms/static/js/index.js
+++ b/cms/static/js/index.js
@@ -1,17 +1,35 @@
 define(["domReady", "jquery", "underscore", "js/utils/cancel_on_escape", "js/views/utils/create_course_utils",
-    "js/views/utils/view_utils"],
-    function (domReady, $, _, CancelOnEscape, CreateCourseUtilsFactory, ViewUtils) {
+    "js/views/utils/create_library_utils", "js/views/utils/view_utils"],
+    function (domReady, $, _, CancelOnEscape, CreateCourseUtilsFactory, CreateLibraryUtilsFactory, ViewUtils) {
         var CreateCourseUtils = CreateCourseUtilsFactory({
             name: '.new-course-name',
             org: '.new-course-org',
             number: '.new-course-number',
             run: '.new-course-run',
             save: '.new-course-save',
-            errorWrapper: '.wrap-error',
+            errorWrapper: '.create-course .wrap-error',
             errorMessage: '#course_creation_error',
-            tipError: 'span.tip-error',
-            error: '.error',
+            tipError: '.create-course span.tip-error',
+            error: '.create-course .error',
             allowUnicode: '.allow-unicode-course-id'
+        }, {
+            shown: 'is-shown',
+            showing: 'is-showing',
+            hiding: 'is-hiding',
+            disabled: 'is-disabled',
+            error: 'error'
+        });
+
+        var CreateLibraryUtils = CreateLibraryUtilsFactory({
+            name: '.new-library-name',
+            org: '.new-library-org',
+            number: '.new-library-number',
+            save: '.new-library-save',
+            errorWrapper: '.create-library .wrap-error',
+            errorMessage: '#library_creation_error',
+            tipError: '.create-library  span.tip-error',
+            error: '.create-library .error',
+            allowUnicode: '.allow-unicode-library-id'
         }, {
             shown: 'is-shown',
             showing: 'is-showing',
@@ -42,7 +60,7 @@ define(["domReady", "jquery", "underscore", "js/utils/cancel_on_escape", "js/vie
 
             analytics.track('Created a Course', course_info);
             CreateCourseUtils.createCourse(course_info, function (errorMessage) {
-                $('.wrap-error').addClass('is-shown');
+                $('.create-course .wrap-error').addClass('is-shown');
                 $('#course_creation_error').html('<p>' + errorMessage + '</p>');
                 $('.new-course-save').addClass('is-disabled');
             });
@@ -60,7 +78,7 @@ define(["domReady", "jquery", "underscore", "js/utils/cancel_on_escape", "js/vie
                 }
             );
             $('#course_creation_error').html('');
-            $('.wrap-error').removeClass('is-shown');
+            $('.create-course .wrap-error').removeClass('is-shown');
             $('.new-course-save').off('click');
         };
 
@@ -79,8 +97,64 @@ define(["domReady", "jquery", "underscore", "js/utils/cancel_on_escape", "js/vie
             CreateCourseUtils.configureHandlers();
         };
 
+        var saveNewLibrary = function (e) {
+            e.preventDefault();
+
+            if (CreateLibraryUtils.hasInvalidRequiredFields()) {
+                return;
+            }
+
+            var $newLibraryForm = $(this).closest('#create-library-form');
+            var display_name = $newLibraryForm.find('.new-library-name').val();
+            var org = $newLibraryForm.find('.new-library-org').val();
+            var number = $newLibraryForm.find('.new-library-number').val();
+
+            lib_info = {
+                org: org,
+                number: number,
+                display_name: display_name,
+            };
+
+            analytics.track('Created a Library', lib_info);
+            CreateLibraryUtils.createLibrary(lib_info, function (errorMessage) {
+                $('.create-library .wrap-error').addClass('is-shown');
+                $('#library_creation_error').html('<p>' + errorMessage + '</p>');
+                $('.new-library-save').addClass('is-disabled');
+            });
+        };
+
+        var cancelNewLibrary = function (e) {
+            e.preventDefault();
+            $('.new-library-button').removeClass('is-disabled');
+            $('.wrapper-create-library').removeClass('is-shown');
+            // Clear out existing fields and errors
+            _.each(
+                ['.new-library-name', '.new-library-org', '.new-library-number'],
+                function (field) { $(field).val(''); }
+            );
+            $('#library_creation_error').html('');
+            $('.create-library .wrap-error').removeClass('is-shown');
+            $('.new-library-save').off('click');
+        };
+
+        var addNewLibrary = function (e) {
+            e.preventDefault();
+            $('.new-library-button').addClass('is-disabled');
+            $('.new-library-save').addClass('is-disabled');
+            var $newLibrary = $('.wrapper-create-library').addClass('is-shown');
+            var $cancelButton = $newLibrary.find('.new-library-cancel');
+            var $libraryName = $('.new-library-name');
+            $libraryName.focus().select();
+            $('.new-library-save').on('click', saveNewLibrary);
+            $cancelButton.bind('click', cancelNewLibrary);
+            CancelOnEscape($cancelButton);
+
+            CreateLibraryUtils.configureHandlers();
+        };
+
         var onReady = function () {
             $('.new-course-button').bind('click', addNewCourse);
+            $('.new-library-button').bind('click', addNewLibrary);
             $('.dismiss-button').bind('click', ViewUtils.deleteNotificationHandler(function () {
                 ViewUtils.reload();
             }));

--- a/cms/static/js/spec/views/pages/course_rerun_spec.js
+++ b/cms/static/js/spec/views/pages/course_rerun_spec.js
@@ -49,12 +49,12 @@ define(["jquery", "js/common_helpers/ajax_helpers", "js/spec_helpers/view_helper
 
             describe("Field validation", function () {
                 it("returns a message for an empty string", function () {
-                    var message = CreateCourseUtils.validateRequiredField('');
+                    var message = ViewUtils.validateRequiredField('');
                     expect(message).not.toBe('');
                 });
 
                 it("does not return a message for a non empty string", function () {
-                    var message = CreateCourseUtils.validateRequiredField('edX');
+                    var message = ViewUtils.validateRequiredField('edX');
                     expect(message).toBe('');
                 });
             });

--- a/cms/static/js/views/utils/create_library_utils.js
+++ b/cms/static/js/views/utils/create_library_utils.js
@@ -1,26 +1,26 @@
 /**
- * Provides utilities for validating courses during creation, for both new courses and reruns.
+ * Provides utilities for validating libraries during creation.
  */
 define(["jquery", "underscore", "gettext", "js/views/utils/view_utils"],
     function ($, _, gettext, ViewUtils) {
         return function (selectors, classes) {
-            var validateTotalCourseItemsLength, setNewCourseFieldInErr, hasInvalidRequiredFields,
-                createCourse, validateFilledFields, configureHandlers;
+            var validateTotalKeyLength, setNewLibraryFieldInErr, hasInvalidRequiredFields,
+                createLibrary, validateFilledFields, configureHandlers;
 
             var validateRequiredField = ViewUtils.validateRequiredField;
             var validateURLItemEncoding = ViewUtils.validateURLItemEncoding;
 
-            // Ensure that org/course_num/run < 65 chars.
-            validateTotalCourseItemsLength = function () {
+            // Ensure that org/librarycode < 65 chars.
+            validateTotalKeyLength = function () {
                 var totalLength = _.reduce(
-                    [selectors.org, selectors.number, selectors.run],
+                    [selectors.org, selectors.number],
                     function (sum, ele) {
                         return sum + $(ele).val().length;
                     }, 0
                 );
                 if (totalLength > 65) {
                     $(selectors.errorWrapper).addClass(classes.shown).removeClass(classes.hiding);
-                    $(selectors.errorMessage).html('<p>' + gettext('The combined length of the organization, course number, and course run fields cannot be more than 65 characters.') + '</p>');
+                    $(selectors.errorMessage).html('<p>' + gettext('The combined length of the organization and library code fields cannot be more than 65 characters.') + '</p>');
                     $(selectors.save).addClass(classes.disabled);
                 }
                 else {
@@ -28,7 +28,7 @@ define(["jquery", "underscore", "gettext", "js/views/utils/view_utils"],
                 }
             };
 
-            setNewCourseFieldInErr = function (el, msg) {
+            setNewLibraryFieldInErr = function (el, msg) {
                 if (msg) {
                     el.addClass(classes.error);
                     el.children(selectors.tipError).addClass(classes.showing).removeClass(classes.hiding).text(msg);
@@ -47,21 +47,21 @@ define(["jquery", "underscore", "gettext", "js/views/utils/view_utils"],
             // One final check for empty values
             hasInvalidRequiredFields = function () {
                 return _.reduce(
-                    [selectors.name, selectors.org, selectors.number, selectors.run],
+                    [selectors.name, selectors.org, selectors.number],
                     function (acc, ele) {
                         var $ele = $(ele);
                         var error = validateRequiredField($ele.val());
-                        setNewCourseFieldInErr($ele.parent(), error);
+                        setNewLibraryFieldInErr($ele.parent(), error);
                         return error ? true : acc;
                     },
                     false
                 );
             };
 
-            createCourse = function (courseInfo, errorHandler) {
+            createLibrary = function (libraryInfo, errorHandler) {
                 $.postJSON(
-                    '/course/',
-                    courseInfo,
+                    '/library/',
+                    libraryInfo,
                     function (data) {
                         if (data.url !== undefined) {
                             ViewUtils.redirect(data.url);
@@ -75,7 +75,7 @@ define(["jquery", "underscore", "gettext", "js/views/utils/view_utils"],
             // Ensure that all fields are not empty
             validateFilledFields = function () {
                 return _.reduce(
-                    [selectors.org, selectors.number, selectors.run, selectors.name],
+                    [selectors.org, selectors.number, selectors.name],
                     function (acc, ele) {
                         var $ele = $(ele);
                         return $ele.val().length !== 0 ? acc : false;
@@ -87,7 +87,7 @@ define(["jquery", "underscore", "gettext", "js/views/utils/view_utils"],
             // Handle validation asynchronously
             configureHandlers = function () {
                 _.each(
-                    [selectors.org, selectors.number, selectors.run],
+                    [selectors.org, selectors.number],
                     function (ele) {
                         var $ele = $(ele);
                         $ele.on('keyup', function (event) {
@@ -98,8 +98,8 @@ define(["jquery", "underscore", "gettext", "js/views/utils/view_utils"],
                                 return;
                             }
                             var error = validateURLItemEncoding($ele.val(), $(selectors.allowUnicode).val() === 'True');
-                            setNewCourseFieldInErr($ele.parent(), error);
-                            validateTotalCourseItemsLength();
+                            setNewLibraryFieldInErr($ele.parent(), error);
+                            validateTotalKeyLength();
                             if (!validateFilledFields()) {
                                 $(selectors.save).addClass(classes.disabled);
                             }
@@ -109,8 +109,8 @@ define(["jquery", "underscore", "gettext", "js/views/utils/view_utils"],
                 var $name = $(selectors.name);
                 $name.on('keyup', function () {
                     var error = validateRequiredField($name.val());
-                    setNewCourseFieldInErr($name.parent(), error);
-                    validateTotalCourseItemsLength();
+                    setNewLibraryFieldInErr($name.parent(), error);
+                    validateTotalKeyLength();
                     if (!validateFilledFields()) {
                         $(selectors.save).addClass(classes.disabled);
                     }
@@ -118,10 +118,10 @@ define(["jquery", "underscore", "gettext", "js/views/utils/view_utils"],
             };
 
             return {
-                validateTotalCourseItemsLength: validateTotalCourseItemsLength,
-                setNewCourseFieldInErr: setNewCourseFieldInErr,
+                validateTotalKeyLength: validateTotalKeyLength,
+                setNewLibraryFieldInErr: setNewLibraryFieldInErr,
                 hasInvalidRequiredFields: hasInvalidRequiredFields,
-                createCourse: createCourse,
+                createLibrary: createLibrary,
                 validateFilledFields: validateFilledFields,
                 configureHandlers: configureHandlers
             };

--- a/cms/static/js/views/utils/view_utils.js
+++ b/cms/static/js/views/utils/view_utils.js
@@ -5,7 +5,8 @@ define(["jquery", "underscore", "gettext", "js/views/feedback_notification", "js
     function ($, _, gettext, NotificationView, PromptView) {
         var toggleExpandCollapse, showLoadingIndicator, hideLoadingIndicator, confirmThenRunOperation,
             runOperationShowingMessage, disableElementWhileRunning, getScrollOffset, setScrollOffset,
-            setScrollTop, redirect, reload, hasChangedAttributes, deleteNotificationHandler;
+            setScrollTop, redirect, reload, hasChangedAttributes, deleteNotificationHandler,
+            validateRequiredField=1, validateURLItemEncoding=2;
 
         /**
          * Toggles the expanded state of the current element.
@@ -173,6 +174,35 @@ define(["jquery", "underscore", "gettext", "js/views/feedback_notification", "js
             return false;
         };
 
+        /**
+         * Helper method for course/library creation - verifies a required field is not blank.
+         */
+        validateRequiredField = function (msg) {
+            return msg.length === 0 ? gettext('Required field.') : '';
+        };
+
+        /**
+         * Helper method for course/library creation.
+         * Check that a course (org, number, run) doesn't use any special characters
+         */
+        validateURLItemEncoding = function (item, allowUnicode) {
+            var required = validateRequiredField(item);
+            if (required) {
+                return required;
+            }
+            if (allowUnicode) {
+                if (/\s/g.test(item)) {
+                    return gettext('Please do not use any spaces in this field.');
+                }
+            }
+            else {
+                if (item !== encodeURIComponent(item)) {
+                    return gettext('Please do not use any spaces or special characters in this field.');
+                }
+            }
+            return '';
+        };
+
         return {
             'toggleExpandCollapse': toggleExpandCollapse,
             'showLoadingIndicator': showLoadingIndicator,
@@ -186,6 +216,8 @@ define(["jquery", "underscore", "gettext", "js/views/feedback_notification", "js
             'setScrollOffset': setScrollOffset,
             'redirect': redirect,
             'reload': reload,
-            'hasChangedAttributes': hasChangedAttributes
+            'hasChangedAttributes': hasChangedAttributes,
+            'validateRequiredField': validateRequiredField,
+            'validateURLItemEncoding': validateURLItemEncoding
         };
     });

--- a/cms/static/sass/elements/_forms.scss
+++ b/cms/static/sass/elements/_forms.scss
@@ -394,7 +394,6 @@ form {
 // ELEM: form wrapper
 .wrapper-create-element {
   height: 0;
-  margin-bottom: $baseline;
   opacity: 0.0;
   pointer-events: none;
   overflow: hidden;
@@ -405,6 +404,7 @@ form {
 
   &.is-shown {
     height: auto; // define a specific height for the animating version of this UI to work properly
+    margin-bottom: $baseline;
     opacity: 1.0;
     pointer-events: auto;
   }

--- a/cms/static/sass/views/_dashboard.scss
+++ b/cms/static/sass/views/_dashboard.scss
@@ -289,10 +289,42 @@
 
   // ====================
 
-  // ELEM: course listings
-  .courses {
-    margin: $baseline 0;
+  // Course/Library tabs
+  #course-index-tabs {
+    margin: 0;
+    font-size: 1.4rem;
 
+    li {
+      display: inline-block;
+      line-height: $baseline*2;
+      margin: 0 10px;
+
+      &.active, &:hover {
+        border-bottom: 4px solid $blue;
+      }
+
+      a {
+        color: $blue;
+        cursor: pointer;
+        display: inline-block;
+      }
+
+      &.active a {
+        color: $gray-d2;
+      }
+    }
+  }
+
+  // ELEM: course listings
+  .courses-tab, .libraries-tab {
+    display: none;
+
+    &.active {
+      display: block;
+    }
+  }
+
+  .courses, .libraries {
     .title {
       @extend %t-title6;
       margin-bottom: $baseline;
@@ -311,7 +343,6 @@
 	}
 
   .list-courses {
-    margin-top: $baseline;
     border-radius: 3px;
     border: 1px solid $gray-l2;
     background: $white;

--- a/cms/templates/base.html
+++ b/cms/templates/base.html
@@ -21,6 +21,8 @@
         % if context_course:
         <% ctx_loc = context_course.location %>
         ${context_course.display_name_with_default | h} |
+        % elif context_library:
+        ${context_library.display_name_with_default | h} |
         % endif
         edX Studio
     </title>

--- a/cms/templates/index.html
+++ b/cms/templates/index.html
@@ -24,6 +24,10 @@
           % if course_creator_status=='granted':
           <a href="#" class="button new-button new-course-button"><i class="icon-plus icon-inline"></i>
               ${_("New Course")}</a>
+            % if libraries_enabled:
+              <a href="#" class="button new-button new-library-button"><i class="icon-plus icon-inline"></i>
+              ${_("New Library")}</a>
+            % endif
           % elif course_creator_status=='disallowed_for_this_site' and settings.FEATURES.get('STUDIO_REQUEST_EMAIL',''):
           <a href="mailto:${settings.FEATURES.get('STUDIO_REQUEST_EMAIL','')}">${_("Email staff to create course")}</a>
           % endif
@@ -108,6 +112,56 @@
           </div>
         </form>
       </div>
+      
+        %if libraries_enabled:
+        <div class="wrapper-create-element wrapper-create-library">
+          <form class="form-create create-library library-info" id="create-library-form" name="create-library-form">
+            <div class="wrap-error">
+              <div id="library_creation_error" name="library_creation_error" class="message message-status message-status error" role="alert">
+              <p>${_("Please correct the highlighted fields below.")}</p>
+              </div>
+            </div>
+
+            <div class="wrapper-form">
+              <h3 class="title">${_("Create a New Library")}</h3>
+
+              <fieldset>
+                <legend class="sr">${_("Required Information to Create a New Library")}</legend>
+
+                <ol class="list-input">
+                  <li class="field text required" id="field-library-name">
+                    <label for="new-library-name">${_("Library Name")}</label>
+                    <input class="new-library-name" id="new-library-name" type="text" name="new-library-name" aria-required="true" placeholder="${_('e.g. Computer Science Problems')}" />
+                    <span class="tip">${_("The public display name for your library.")}</span>
+                    <span class="tip tip-error is-hiding"></span>
+                  </li>
+                  <li class="field text required" id="field-organization">
+                    <label for="new-library-org">${_("Organization")}</label>
+                    <input class="new-library-org" id="new-library-org" type="text" name="new-library-org" aria-required="true" placeholder="${_('e.g. UniversityX or OrganizationX')}" />
+                    <span class="tip">${_("The name of the organization sponsoring the library.")}  <strong>${_("Note: This is part of your library URL, so no spaces or special characters are allowed.")}</strong> ${_("This cannot be changed.")}</span>
+                    <span class="tip tip-error is-hiding"></span>
+                  </li>
+
+                  <li class="field text required" id="field-library-number">
+                    <label for="new-library-number">${_("Library Code/Number")}</label>
+                    <input class="new-library-number" id="new-library-number" type="text" name="new-library-number" aria-required="true" placeholder="${_('e.g. CSPROB')}" />
+                    <span class="tip">${_("The unique code that identifies this library.")} <strong>${_("Note: This is part of your library URL, so no spaces or special characters are allowed and it cannot be changed.")}</strong></span>
+                    <span class="tip tip-error is-hiding"></span>
+                  </li>
+                </ol>
+
+              </fieldset>
+            </div>
+
+            <div class="actions">
+              <input type="hidden" value="${allow_unicode_course_id}" class="allow-unicode-course-id" />
+              <input type="submit" value="${_('Create')}" class="action action-primary new-library-save" />
+              <input type="button" value="${_('Cancel')}" class="action action-secondary action-cancel new-library-cancel" />
+            </div>
+          </form>
+        </div>
+        % endif
+
       % endif
 
       <!-- STATE: processing courses -->

--- a/cms/templates/index.html
+++ b/cms/templates/index.html
@@ -262,8 +262,15 @@
       </div>
       %endif
 
+      %if libraries_enabled:
+      <ul id="course-index-tabs">
+        <li class="courses-tab active"><a>${_("Courses")}</a></li>
+        <li class="libraries-tab"><a>${_("Libraries")}</a></li>
+      </ul>
+      %endif
+
       %if len(courses) > 0:
-      <div class="courses">
+      <div class="courses courses-tab active">
         <ul class="list-courses">
           %for course_info in sorted(courses, key=lambda s: s['display_name'].lower() if s['display_name'] is not None else ''):
           <li class="course-item" data-course-key="${course_info['course_key'] | h}">
@@ -300,10 +307,7 @@
       </div>
 
       %else:
-      <div class="courses">
-      </div>
-
-      <div class="notice notice-incontext notice-instruction notice-instruction-nocourses list-notices">
+      <div class="notice notice-incontext notice-instruction notice-instruction-nocourses list-notices courses-tab active">
         <div class="notice-item">
           <div class="msg">
             <h3 class="title">${_("Are you staff on an existing Studio course?")}</h3>
@@ -410,14 +414,8 @@
       </div>
       % endif
 
-      %if libraries:
-      <div class="copy">
-        <h1>Content Libraries</h1>
-        <p>${_("Warning: Content Libraries are currently a beta feature, and may be subject to backwards-incompatible changes.")}</p>
-        <p>${_("Here are all of the libraries you currently have access to in Studio:")}</p>
-      </div>
-
-      <div class="courses">
+      %if len(libraries) > 0:
+      <div class="libraries libraries-tab">
         <ul class="list-courses">
           %for library_info in sorted(libraries, key=lambda s: s['display_name'].lower() if s['display_name'] is not None else ''):
           <li class="course-item">
@@ -437,6 +435,17 @@
           </li>
           %endfor
         </ul>
+      </div>
+
+      %else:
+      <div class="notice notice-incontext notice-instruction notice-instruction-nocourses list-notices libraries-tab">
+        <div class="notice-item">
+          <div class="msg">
+            <div class="copy">
+              <p>${_('You don\'t have any content libraries yet.')}</p>
+            </div>
+          </div>
+        </div>
       </div>
       %endif
 

--- a/cms/templates/index.html
+++ b/cms/templates/index.html
@@ -125,6 +125,17 @@
             <div class="wrapper-form">
               <h3 class="title">${_("Create a New Library")}</h3>
 
+              <div class="notice notice-incontext notice-workflow" style="margin-bottom: 0; margin-top: 20px;">
+                <div class="notice-item">
+                  <div class="msg">
+                    <h3>${_("Beta Feature Warning")}</h3>
+                    <div class="copy">
+                      <p>${_("Content Libraries are a beta feature and should be used for testing/development purposes only. Any libraries you create now may not be compatible with future updates!")}</p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
               <fieldset>
                 <legend class="sr">${_("Required Information to Create a New Library")}</legend>
 

--- a/cms/templates/index.html
+++ b/cms/templates/index.html
@@ -356,6 +356,36 @@
       </div>
       % endif
 
+      %if libraries:
+      <div class="copy">
+        <h1>Content Libraries</h1>
+        <p>${_("Warning: Content Libraries are currently a beta feature, and may be subject to backwards-incompatible changes.")}</p>
+        <p>${_("Here are all of the libraries you currently have access to in Studio:")}</p>
+      </div>
+
+      <div class="courses">
+        <ul class="list-courses">
+          %for library_info in sorted(libraries, key=lambda s: s['display_name'].lower() if s['display_name'] is not None else ''):
+          <li class="course-item">
+            <a class="library-link" href="${library_info['url']}">
+              <h3 class="course-title">${library_info['display_name']}</h3>
+
+              <div class="course-metadata">
+                <span class="course-org metadata-item">
+                  <span class="label">${_("Organization:")}</span> <span class="value">${library_info['org']}</span>
+                </span>
+                <span class="course-num metadata-item">
+                  <span class="label">${_("Course Number:")}</span>
+                  <span class="value">${library_info['number']}</span>
+                </span>
+              </div>
+            </a>
+          </li>
+          %endfor
+        </ul>
+      </div>
+      %endif
+
     </article>
     <aside class="content-supplementary" role="complementary">
       <div class="bit">

--- a/cms/templates/library.html
+++ b/cms/templates/library.html
@@ -1,0 +1,87 @@
+<%inherit file="base.html" />
+<%!
+import json
+
+from contentstore.views.helpers import xblock_studio_url, xblock_type_display_name
+from django.utils.translation import ugettext as _
+%>
+<%block name="title">${xblock.display_name_with_default} ${xblock_type_display_name(xblock)}</%block>
+<%block name="bodyclass">is-signedin course container view-container</%block>
+
+<%namespace name='static' file='static_content.html'/>
+
+<%!
+templates = ["basic-modal", "modal-button", "edit-xblock-modal",
+    "editor-mode-button", "upload-dialog", "image-modal",
+    "add-xblock-component", "add-xblock-component-button", "add-xblock-component-menu",
+    "add-xblock-component-menu-problem", "xblock-string-field-editor", "publish-xblock", "publish-history",
+    "unit-outline", "container-message"]
+%>
+<%block name="header_extras">
+% for template_name in templates:
+<script type="text/template" id="${template_name}-tpl">
+    <%static:include path="js/${template_name}.underscore" />
+</script>
+% endfor
+<link rel="stylesheet" type="text/css" href="${static.url('js/vendor/timepicker/jquery.timepicker.css')}" />
+</%block>
+
+<%block name="requirejs">
+    require(["js/factories/container"], function(ContainerFactory) {
+        ContainerFactory(
+            ${component_templates | n}, ${json.dumps(xblock_info) | n}, "${action}", false
+        );
+    });
+</%block>
+
+<%block name="content">
+
+
+<div class="wrapper-mast wrapper">
+    <header class="mast has-actions has-navigation has-subtitle">
+        <div class="page-header">
+            <div class="wrapper-xblock-field incontext-editor is-editable"
+                 data-field="display_name" data-field-display-name="${_("Display Name")}">
+                <h1 class="page-header-title xblock-field-value incontext-editor-value"><span class="title-value">${xblock.display_name_with_default | h}</span></h1>
+            </div>
+        </div>
+
+        <nav class="nav-actions">
+            <h3 class="sr">${_("Page Actions")}</h3>
+            <ul>
+                <li class="action-item action-edit nav-item">
+                    <a href="#" class="button button-edit action-button edit-button">
+                        <i class="icon-pencil"></i>
+                        <span class="action-button-text">${_("Edit")}</span>
+                    </a>
+                </li>
+            </ul>
+        </nav>
+    </header>
+</div>
+
+<div class="wrapper-content wrapper">
+    <div class="inner-wrapper">
+        <section class="content-area">
+
+            <article class="content-primary">
+                <div class="container-message wrapper-message"></div>
+                <section class="wrapper-xblock level-page is-hidden studio-xblock-wrapper" data-locator="${xblock_locator | h}" data-course-key="${xblock_locator.course_key | h}">
+                </section>
+                <div class="ui-loading">
+                    <p><span class="spin"><i class="icon-refresh"></i></span> <span class="copy">${_("Loading...")}</span></p>
+                </div>
+            </article>
+            <aside class="content-supplementary" role="complimentary">
+                <div class="bit">
+                    <h3 class="title-3">${_("Adding content components")}</h3>
+                    <p>${_("You can add compnents to the library. Help text here.")}</p>
+                </div>
+                <div class="bit external-help">
+                    <a href="${get_online_help_info('library')['doc_url']}" target="_blank" class="button external-help-button">${_("Learn more about content libraries")}</a>
+                </div>
+            </aside>
+        </section>
+    </div>
+</div>
+</%block>

--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -120,6 +120,43 @@
           </li>
         </ol>
       </nav>
+      % elif context_library:
+       <%
+            library_key = context_library.location.course_key
+            index_url = reverse('contentstore.views.library_handler', kwargs={'library_key_string': unicode(library_key)})
+            import_url = 'TODO'
+            export_url = 'TODO'
+      %>
+      <h2 class="info-course">
+        <span class="sr">${_("Current Library:")}</span>
+        <a class="course-link" href="${index_url}">
+          <span class="course-org">${context_library.display_org_with_default | h}</span><span class="course-number">${context_library.display_number_with_default | h}</span>
+          <span class="course-title" title="${context_library.display_name_with_default}">${context_library.display_name_with_default}</span>
+        </a>
+      </h2>
+
+      <nav class="nav-course nav-dd ui-left">
+        <h2 class="sr">${_("{course_name}'s Navigation:").format(course_name=context_library.display_name_with_default)}</h2>
+        <ol>
+
+          <li class="nav-item nav-course-tools">
+            <h3 class="title"><span class="label">${_("Tools")}</span> <i class="icon-caret-down ui-toggle-dd"></i></h3>
+
+            <div class="wrapper wrapper-nav-sub">
+              <div class="nav-sub">
+                <ul>
+                  <li class="nav-item nav-course-tools-import">
+                    <a href="${import_url}">${_("Import")}</a>
+                  </li>
+                  <li class="nav-item nav-course-tools-export">
+                    <a href="${export_url}">${_("Export")}</a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </li>
+        </ol>
+      </nav>
       % endif
     </div>
 

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -109,6 +109,12 @@ urlpatterns += patterns('',
     url(r'^i18n.js$', 'django.views.i18n.javascript_catalog', js_info_dict),
 )
 
+if settings.FEATURES.get('ENABLE_CONTENT_LIBRARIES'):
+    LIBRARY_KEY_PATTERN = r'(?P<library_key_string>library-v1:[^/+]+\+[^/+]+)'
+    urlpatterns += (
+        url(r'^library/{}?$'.format(LIBRARY_KEY_PATTERN),
+            'contentstore.views.library_handler', name='library_handler'),
+    )
 
 if settings.FEATURES.get('ENABLE_EXPORT_GIT'):
     urlpatterns += (url(r'^export_git/{}$'.format(settings.COURSE_KEY_PATTERN),

--- a/common/lib/xmodule/setup.py
+++ b/common/lib/xmodule/setup.py
@@ -12,6 +12,7 @@ XMODULES = [
     "html = xmodule.html_module:HtmlDescriptor",
     "image = xmodule.backcompat_module:TranslateCustomTagDescriptor",
     "library = xmodule.library_module:LibraryDescriptor",
+    "library_content = xmodule.library_content_module:LibraryContentDescriptor",
     "error = xmodule.error_module:ErrorDescriptor",
     "peergrading = xmodule.peer_grading_module:PeerGradingDescriptor",
     "poll_question = xmodule.poll_module:PollDescriptor",

--- a/common/lib/xmodule/setup.py
+++ b/common/lib/xmodule/setup.py
@@ -11,6 +11,7 @@ XMODULES = [
     "discuss = xmodule.backcompat_module:TranslateCustomTagDescriptor",
     "html = xmodule.html_module:HtmlDescriptor",
     "image = xmodule.backcompat_module:TranslateCustomTagDescriptor",
+    "library = xmodule.library_module:LibraryDescriptor",
     "error = xmodule.error_module:ErrorDescriptor",
     "peergrading = xmodule.peer_grading_module:PeerGradingDescriptor",
     "poll_question = xmodule.poll_module:PollDescriptor",

--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -1,0 +1,424 @@
+"""
+LibraryContent: The XBlock used to include blocks from a library in a course.
+"""
+from bson.objectid import ObjectId
+from collections import namedtuple
+from copy import copy
+import hashlib
+from .mako_module import MakoModuleDescriptor
+from opaque_keys.edx.locator import LibraryLocator
+import random
+from webob import Response
+from xblock.core import XBlock
+from xblock.fields import Scope, String, List, Integer, Boolean
+from xblock.fragment import Fragment
+from xmodule.modulestore.exceptions import ItemNotFoundError
+from xmodule.x_module import XModule, STUDENT_VIEW
+from xmodule.studio_editable import StudioEditableModule, StudioEditableDescriptor
+from .xml_module import XmlDescriptor
+from pkg_resources import resource_string
+
+# Make '_' a no-op so we can scrape strings
+_ = lambda text: text
+
+
+def enum(**enums):
+    """ enum helper in lieu of enum34 """
+    return type('Enum', (), enums)
+
+
+class LibraryVersionReference(namedtuple("LibraryVersionReference", "library_id version")):
+    """
+    A reference to a specific library, with an optional version.
+    The version is used to find out when the LibraryContentXBlock was last
+    updated with the latest content from the library.
+
+    library_id is a LibraryLocator
+    version is an ObjectId or None
+    """
+    def __new__(cls, library_id, version=None):
+        # pylint: disable=super-on-old-class
+        if not isinstance(library_id, LibraryLocator):
+            library_id = LibraryLocator.from_string(library_id)
+        if library_id.version_guid:
+            assert (version is None) or (version == library_id.version_guid)
+            if not version:
+                version = library_id.version_guid
+            library_id = library_id.for_version(None)
+        if version and not isinstance(version, ObjectId):
+            version = ObjectId(version)
+        return super(LibraryVersionReference, cls).__new__(cls, library_id, version)
+
+    @staticmethod
+    def from_json(value):
+        """
+        Implement from_json to convert from JSON
+        """
+        return LibraryVersionReference(*value)
+
+    def to_json(self):
+        """
+        Implement to_json to convert value to JSON
+        """
+        # TODO: Is there anyway for an xblock to *store* an ObjectId as
+        # part of the List() field value?
+        return [unicode(self.library_id), unicode(self.version) if self.version else None]  # pylint: disable=no-member
+
+
+class LibraryList(List):
+    """
+    Special List class for listing references to content libraries.
+    Is simply a list of LibraryVersionReference tuples.
+    """
+    def from_json(self, values):
+        """
+        Implement from_json to convert from JSON.
+
+        values might be a list of lists, or a list of strings
+        Normally the runtime gives us:
+            [[u'library-v1:ProblemX+PR0B', '5436ffec56c02c13806a4c1b'], ...]
+        But the studio editor gives us:
+            [u'library-v1:ProblemX+PR0B,5436ffec56c02c13806a4c1b', ...]
+        """
+        def parse(val):
+            """ Convert this list entry from its JSON representation """
+            if isinstance(val, unicode) or isinstance(val, str):
+                val = val.strip(' []')
+                parts = val.rsplit(',', 1)
+                val = [parts[0], parts[1] if len(parts) > 1 else None]
+            return LibraryVersionReference.from_json(val)
+        return [parse(v) for v in values]
+
+    def to_json(self, values):
+        """
+        Implement to_json to convert value to JSON
+        """
+        return [lvr.to_json() for lvr in values]
+
+
+class LibraryContentFields(object):
+    """
+    Fields for the LibraryContentModule.
+
+    Separated out for now because they need to be added to the module and the
+    descriptor.
+    """
+    source_libraries = LibraryList(
+        display_name=_("Library"),
+        help=_("Which content library to draw content from"),
+        default=[],
+        scope=Scope.settings,
+    )
+    mode = String(
+        help=_("Determines how content is drawn from the library"),
+        default="random",
+        values=[
+            {"display_name": _("Choose n at random"), "value": "random"}
+            # Future addition: Choose a new random set of n every time the student refreshes the block, for self tests
+            # Future addition: manually selected blocks
+        ],
+        scope=Scope.settings,
+    )
+    max_count = Integer(
+        display_name=_("Count"),
+        help=_("How many components to select from the library"),
+        default=1,
+        scope=Scope.settings,
+    )
+    filters = String(default="")  # TBD
+    has_score = Boolean(
+        display_name=_("Scored"),
+        help=_("Set this true if this is meant to be either a graded assignment or a practice problem."),
+        default=False,
+        scope=Scope.settings,
+    )
+    selected = List(
+        # This is a list of block_ids used to record which random/first set of matching blocks was selected per user
+        default=[],
+        scope=Scope.user_state,
+    )
+    has_children = True
+
+
+def _get_library(modulestore, library_key):
+    """
+    Given a library key like "library-v1:ProblemX+PR0B", return the
+    'library' XBlock with meta-information about the library.
+
+    Returns None on error.
+    """
+    if not isinstance(library_key, LibraryLocator):
+        library_key = LibraryLocator.from_string(library_key)
+    assert library_key.version_guid is None
+
+    # TODO: Is this too tightly coupled to split? May need to abstract this into a service
+    # provided by the CMS runtime.
+    try:
+        library = modulestore.get_library(library_key, remove_version=False)
+    except ItemNotFoundError:
+        return None
+    # We need to know the library's version so ensure it's set in library.location.library_key.version_guid
+    assert library.location.library_key.version_guid is not None
+    return library
+
+
+#pylint: disable=abstract-method
+class LibraryContentModule(LibraryContentFields, XModule, StudioEditableModule):
+    """
+    An XBlock whose children are chosen dynamically from a content library.
+    Can be used to create randomized assessments among other things.
+
+    Note: technically, all matching blocks from the content library are added
+    as children of this block, but only a subset of those children are shown to
+    any particular student.
+    """
+    def selected_children(self):
+        """
+        Returns a set() of block_ids indicating which of the possible children
+        have been selected to display to the current user.
+
+        This reads and updates the "selected" field, which has user_state scope.
+
+        Note: self.selected and the return value contain block_ids. To get
+        actual BlockUsageLocators, it is necessary to use self.children,
+        because the block_ids alone do not specify the block type.
+        """
+        if hasattr(self, "_selected_set"):
+            # Already done:
+            return self._selected_set  # pylint: disable=access-member-before-definition
+        # Determine which of our children we will show:
+        selected = set(self.selected) if self.selected else set()  # set of block_ids
+        valid_block_ids = set([c.block_id for c in self.children])  # pylint: disable=no-member
+        # Remove any selected blocks that are no longer valid:
+        selected -= (selected - valid_block_ids)
+        # If max_count has been decreased, we may have to drop some previously selected blocks:
+        while len(selected) > self.max_count:
+            selected.pop()
+        # Do we have enough blocks now?
+        num_to_add = self.max_count - len(selected)
+        if num_to_add > 0:
+            # We need to select [more] blocks to display to this user:
+            if self.mode == "random":
+                pool = valid_block_ids - selected
+                num_to_add = min(len(pool), num_to_add)
+                selected |= set(random.sample(pool, num_to_add))
+                # We now have the correct n random children to show for this user.
+            else:
+                raise NotImplementedError("Unsupported mode.")
+        # Save our selections to the user state, to ensure consistency:
+        self.selected = list(selected)  # TODO: this doesn't save from the LMS "Progress" page.
+        # Cache the results
+        self._selected_set = selected  # pylint: disable=attribute-defined-outside-init
+        return selected
+
+    def _get_selected_child_blocks(self):
+        """
+        Generator returning XBlock instances of the children selected for the
+        current user.
+        """
+        selected = self.selected_children()
+        for child_loc in self.children:  # pylint: disable=no-member
+            if child_loc.block_id in selected:
+                yield self.runtime.get_block(child_loc)
+
+    def student_view(self, context):
+        fragment = Fragment()
+        contents = []
+        child_context = {} if not context else copy(context)
+
+        for child in self._get_selected_child_blocks():
+            for displayable in child.displayable_items():
+                rendered_child = displayable.render(STUDENT_VIEW, child_context)
+                fragment.add_frag_resources(rendered_child)
+                contents.append({
+                    'id': displayable.location.to_deprecated_string(),
+                    'content': rendered_child.content
+                })
+
+        fragment.add_content(self.system.render_template('vert_module.html', {
+            'items': contents,
+            'xblock_context': context,
+        }))
+        return fragment
+
+    def author_view(self, context):
+        """
+        Renders the Studio views.
+        Normal studio view: displays library status and has an "Update" button.
+        Studio container view: displays a preview of all possible children.
+        """
+        fragment = Fragment()
+        root_xblock = context.get('root_xblock')
+        is_root = root_xblock and root_xblock.location == self.location
+
+        if is_root:
+            # User has clicked the "View" link. Show a preview of all possible children:
+            if self.children:  # pylint: disable=no-member
+                self.render_children(context, fragment, can_reorder=False, can_add=False)
+            else:
+                fragment.add_content(u'<p>{}</p>'.format(
+                    _('No matching content found in library, no library configured, or not yet loaded from library.')
+                ))
+        else:
+            # When shown on a unit page, don't show any sort of preview - just the status of this block.
+            LibraryStatus = enum(  # pylint: disable=invalid-name
+                NONE=0,  # no library configured
+                INVALID=1,  # invalid configuration or library has been deleted/corrupted
+                OK=2,  # library configured correctly and should be working fine
+            )
+            UpdateStatus = enum(  # pylint: disable=invalid-name
+                CANNOT=0,  # Cannot update - library is not set, invalid, deleted, etc.
+                NEEDED=1,  # An update is needed - prompt the user to update
+                UP_TO_DATE=2,  # No update necessary - library is up to date
+            )
+            library_names = []
+            library_status = LibraryStatus.OK
+            update_status = UpdateStatus.UP_TO_DATE
+            if self.source_libraries:
+                for library_key, version in self.source_libraries:
+                    library = _get_library(self.runtime.descriptor_runtime.modulestore, library_key)
+                    if library is None:
+                        library_status = LibraryStatus.INVALID
+                        update_status = UpdateStatus.CANNOT
+                        break
+                    library_names.append(library.display_name)
+                    latest_version = library.location.library_key.version_guid
+                    if version is None or version != latest_version:
+                        update_status = UpdateStatus.NEEDED
+                    # else library is up to date.
+            else:
+                library_status = LibraryStatus.NONE
+                update_status = UpdateStatus.CANNOT
+            fragment.add_content(self.system.render_template('library-block-author-view.html', {
+                'library_status': library_status,
+                'LibraryStatus': LibraryStatus,
+                'update_status': update_status,
+                'UpdateStatus': UpdateStatus,
+                'library_names': library_names,
+                'max_count': self.max_count,
+                'mode': self.mode,
+                'num_children': len(self.children),  # pylint: disable=no-member
+            }))
+            fragment.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/library_content_edit.js'))
+            fragment.initialize_js('LibraryContentAuthorView')
+        return fragment
+
+    def get_child_descriptors(self):
+        """
+        We override normal handling of children.
+        In this case, our goal is to prevent the LMS from expecting any grades
+        from child XBlocks. So we tell the system that we have no children.
+        This way, we can report a single consolidated grade.
+
+        Without this, the progress tab in the LMS would show an expected grade
+        from each possible child, rather than the n chosen child[ren].
+        """
+        return list(self._get_selected_child_blocks())
+
+
+@XBlock.wants('user')
+class LibraryContentDescriptor(LibraryContentFields, MakoModuleDescriptor, XmlDescriptor, StudioEditableDescriptor):
+    """
+    Descriptor class for LibraryContentModule XBlock.
+    """
+    module_class = LibraryContentModule
+    mako_template = 'widgets/metadata-edit.html'
+    js = {'coffee': [resource_string(__name__, 'js/src/vertical/edit.coffee')]}
+    js_module_name = "VerticalDescriptor"
+
+    @XBlock.handler
+    def refresh_children(self, request, suffix):  # pylint: disable=unused-argument
+        """
+        Refresh children:
+        This method is to be used when any of the libraries that this block
+        references have been updated. It will re-fetch all matching blocks from
+        the libraries, and copy them as children of this block. The children
+        will be given new block_ids, but the definition ID used should be the
+        exact same definition ID used in the library.
+
+        This method will update this block's 'source_libraries' field to store
+        the version number of the libraries used, so we easily determine if
+        this block is up to date or not.
+        """
+        user_id = self.runtime.service(self, 'user').user_id
+        new_children = []
+
+        store = self.system.modulestore
+        with store.bulk_operations(self.location.course_key):
+            # Currently, ALL children are deleted and then re-added in a way
+            # that preserves their block_ids (and thus should preserve student
+            # data, grades, analytics, etc.)
+            # Once course-level field overrides are implemented, this will
+            # change to a more conservative implementation.
+
+            # First, delete all our existing children:
+            for child in self.children:  # pylint: disable=access-member-before-definition
+                store.delete_item(child, user_id)
+            # Now add all matching children, and record the library version we use:
+            new_libraries = []
+            for library_key, old_version in self.source_libraries:  # pylint: disable=unused-variable
+                library = _get_library(self.system.modulestore, library_key)  # pylint: disable=protected-access
+                for child_key in library.children:
+                    child = store.get_item(child_key, depth=9)
+                    # We compute a block_id for each matching child block found in the library.
+                    # block_ids are unique within any branch, but are not unique per-course or globally.
+                    # We need our block_ids to be consistent when content in the library is updated, so
+                    # we compute block_id as a hash of three pieces of data:
+                    unique_data = "{}:{}:{}".format(
+                        self.location.block_id,  # Must not clash with other usages of the same library in this course
+                        unicode(library_key.for_version(None)).encode("utf-8"),  # The block ID below is only unique within a library, so we need this too
+                        child_key.block_id,  # Child block ID. Should not change even if the block is edited.
+                    )
+                    child_block_id = hashlib.sha1(unique_data).hexdigest()[:20]
+                    new_child_info = store.create_item(
+                        user_id,
+                        self.location.course_key,
+                        child_key.block_type,
+                        block_id=child_block_id,
+                        definition_locator=child.definition_locator,
+                        runtime=self.system,
+                    )
+                    new_children.append(new_child_info.location)
+                new_libraries.append(LibraryVersionReference(library_key, library.location.library_key.version_guid))
+            self.source_libraries = new_libraries
+            self.children = new_children  # pylint: disable=attribute-defined-outside-init
+            self.system.modulestore.update_item(self, user_id)
+        return Response()
+
+    def has_dynamic_children(self):
+        """
+        Inform the runtime that our children vary per-user.
+        See get_child_descriptors() above
+        """
+        return True
+
+    def get_content_titles(self):
+        """
+        Returns list of friendly titles for our selected children only; without
+        thi, all possible children's titles would be seen in the sequence bar in
+        the LMS.
+
+        This overwrites the get_content_titles method included in x_module by default.
+        """
+        titles = []
+        for child in self._xmodule.get_child_descriptors():
+            titles.extend(child.get_content_titles())
+        return titles
+
+    @classmethod
+    def definition_from_xml(cls, xml_object, system):
+        """ XML support not yet implemented. """
+        raise NotImplementedError
+
+    def definition_to_xml(self, resource_fs):
+        """ XML support not yet implemented. """
+        raise NotImplementedError
+
+    @classmethod
+    def from_xml(cls, xml_data, system, id_generator):
+        """ XML support not yet implemented. """
+        raise NotImplementedError
+
+    def export_to_xml(self, resource_fs):
+        """ XML support not yet implemented. """
+        raise NotImplementedError

--- a/common/lib/xmodule/xmodule/library_module.py
+++ b/common/lib/xmodule/xmodule/library_module.py
@@ -1,0 +1,78 @@
+"""
+'library' XBlock/XModule
+
+The "library" XBlock/XModule is the root of every content library structure
+tree. All content blocks in the library are its children. It is analagous to
+the "course" XBlock/XModule used as the root of each normal course structure
+tree.
+"""
+import logging
+
+from xmodule.vertical_module import VerticalDescriptor, VerticalModule
+
+from xblock.fields import Scope, String, List
+
+log = logging.getLogger(__name__)
+
+# Make '_' a no-op so we can scrape strings
+_ = lambda text: text
+
+
+class LibraryFields(object):
+    """
+    Fields of the "library" XBlock - see below.
+    """
+    display_name = String(
+        help=_("Enter the name of the library as it should appear in Studio."),
+        default="Library",
+        display_name=_("Library Display Name"),
+        scope=Scope.settings
+    )
+    advanced_modules = List(
+        display_name=_("Advanced Module List"),
+        help=_("Enter the names of the advanced components to use in your library."),
+        scope=Scope.settings
+    )
+    has_children = True
+
+
+class LibraryDescriptor(LibraryFields, VerticalDescriptor):
+    """
+    Descriptor for our library XBlock/XModule.
+    """
+    module_class = VerticalModule
+
+    def __init__(self, *args, **kwargs):
+        """
+        Expects the same arguments as XModuleDescriptor.__init__
+        """
+        super(LibraryDescriptor, self).__init__(*args, **kwargs)
+
+    def __unicode__(self):
+        return u"Library: {}".format(self.display_name)
+
+    def __str__(self):
+        return "Library: {}".format(self.display_name)
+
+    @property
+    def display_org_with_default(self):
+        """
+        Return a display organization if it has been specified, otherwise return the 'org' that is in the location.
+        """
+        return self.location.course_key.org
+
+    @property
+    def display_number_with_default(self):
+        """
+        Return a display course number if it has been specified, otherwise return the 'library' that is in the location
+        """
+        return self.location.course_key.library
+
+    @classmethod
+    def from_xml(cls, xml_data, system, id_generator):
+        """ XML support not yet implemented. """
+        raise NotImplementedError
+
+    def export_to_xml(self, resource_fs):
+        """ XML support not yet implemented. """
+        raise NotImplementedError

--- a/common/lib/xmodule/xmodule/modulestore/__init__.py
+++ b/common/lib/xmodule/xmodule/modulestore/__init__.py
@@ -82,6 +82,7 @@ class ModuleStoreEnum(object):
         """
         draft = 'draft-branch'
         published = 'published-branch'
+        library = 'library'
 
     class UserID(object):
         """

--- a/common/lib/xmodule/xmodule/modulestore/mixed.py
+++ b/common/lib/xmodule/xmodule/modulestore/mixed.py
@@ -13,6 +13,7 @@ from contracts import contract, new_contract
 
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey, AssetKey
+from opaque_keys.edx.locator import LibraryLocator
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
 from xmodule.assetstore import AssetMetadata
 
@@ -259,6 +260,23 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
                     courses[course_id] = course
         return courses.values()
 
+    @strip_key
+    def get_libraries(self, **kwargs):
+        '''
+        Returns a list containing the top level XModuleDescriptors of the libraries in this modulestore.
+        '''
+        libraries = {}
+        for store in self.modulestores:
+            if not hasattr(store, 'get_libraries'):
+                continue
+            # filter out ones which were fetched from earlier stores but locations may not be ==
+            for course in store.get_libraries(**kwargs):
+                course_id = self._clean_course_id_for_mapping(course.location)
+                if course_id not in libraries:
+                    # course is indeed unique. save it in result
+                    libraries[course_id] = course
+        return libraries.values()
+
     def make_course_key(self, org, course, run):
         """
         Return a valid :class:`~opaque_keys.edx.keys.CourseKey` for this modulestore
@@ -289,6 +307,31 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
             return store.get_course(course_key, depth=depth, **kwargs)
         except ItemNotFoundError:
             return None
+
+    @strip_key
+    def get_library(self, library_key, depth=0, **kwargs):
+        """
+        returns the library block associated with the given key. If no such library exists,
+        it returns None
+
+        :param library_key: must be a LibraryLocator
+        """
+        assert(isinstance(library_key, LibraryLocator))
+        store = self._get_modulestore_for_courseid(library_key)
+        if not hasattr(store, 'get_library'):
+            return None  # This key seems invalid since its modulestore doesn't support libraries
+        try:
+            return store.get_library(library_key, depth=depth, **kwargs)
+        except ItemNotFoundError:
+            return None
+
+    def get_courselike(self, key, depth=0, **kwargs):
+        """
+        Fetch a course or a library
+        """
+        if isinstance(key, LibraryLocator):
+            return self.get_library(key, depth, **kwargs)
+        return self.get_course(key, depth, **kwargs)
 
     @strip_key
     def has_course(self, course_id, ignore_case=False, **kwargs):
@@ -506,6 +549,34 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
         self.mappings[course_key] = store
 
         return course
+
+    @strip_key
+    def create_library(self, org, library, user_id, fields, **kwargs):
+        """
+        Creates and returns a new library.
+
+        Args:
+            org (str): the organization that owns the course
+            library (str): the code/number/name of the library
+            user_id: id of the user creating the course
+            fields (dict): Fields to set on the course at initialization - e.g. display_name
+            kwargs: Any optional arguments understood by a subset of modulestores to customize instantiation
+
+        Returns: a LibraryDescriptor
+        """
+        # first make sure an existing course/lib doesn't already exist in the mapping
+        lib_key = LibraryLocator(org=org, library=library)
+        if lib_key in self.mappings:
+            raise DuplicateCourseError(lib_key, lib_key)
+
+        # create the library
+        store = self._verify_modulestore_support(None, 'create_library')
+        library = store.create_library(org, library, user_id, fields, **kwargs)
+
+        # add new library to the mapping
+        self.mappings[lib_key] = store
+
+        return library
 
     @strip_key
     def clone_course(self, source_course_id, dest_course_id, user_id, fields=None, **kwargs):

--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -33,7 +33,7 @@ from importlib import import_module
 from opaque_keys.edx.keys import UsageKey, CourseKey, AssetKey
 from opaque_keys.edx.locations import Location
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
-from opaque_keys.edx.locator import CourseLocator
+from opaque_keys.edx.locator import CourseLocator, LibraryLocator
 
 from xblock.core import XBlock
 from xblock.exceptions import InvalidScopeError
@@ -871,6 +871,8 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
         otherwise, do a case sensitive search
         """
         assert(isinstance(course_key, CourseKey))
+        if isinstance(course_key, LibraryLocator):
+            return None  # Libraries require split mongo
         course_key = self.fill_in_run(course_key)
         location = course_key.make_usage_key('course', course_key.run)
         if ignore_case:

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/caching_descriptor_system.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/caching_descriptor_system.py
@@ -4,7 +4,7 @@ from contracts import contract, new_contract
 from lazy import lazy
 from xblock.runtime import KvsFieldData
 from xblock.fields import ScopeIds
-from opaque_keys.edx.locator import BlockUsageLocator, LocalId, CourseLocator, DefinitionLocator
+from opaque_keys.edx.locator import BlockUsageLocator, LocalId, CourseLocator, LibraryLocator, DefinitionLocator
 from xmodule.mako_module import MakoDescriptorSystem
 from xmodule.error_module import ErrorDescriptor
 from xmodule.errortracker import exc_info_to_str
@@ -19,6 +19,8 @@ from xmodule.modulestore.split_mongo import BlockKey, CourseEnvelope
 log = logging.getLogger(__name__)
 
 new_contract('BlockUsageLocator', BlockUsageLocator)
+new_contract('CourseLocator', CourseLocator)
+new_contract('LibraryLocator', LibraryLocator)
 new_contract('BlockKey', BlockKey)
 new_contract('CourseEnvelope', CourseEnvelope)
 
@@ -115,7 +117,7 @@ class CachingDescriptorSystem(MakoDescriptorSystem, EditInfoRuntimeMixin):
         self.modulestore.cache_block(course_key, version_guid, block_key, block)
         return block
 
-    @contract(block_key=BlockKey, course_key=CourseLocator)
+    @contract(block_key=BlockKey, course_key="CourseLocator | LibraryLocator")
     def get_module_data(self, block_key, course_key):
         """
         Get block from module_data adding it to module_data if it's not already there but is in the structure
@@ -178,8 +180,8 @@ class CachingDescriptorSystem(MakoDescriptorSystem, EditInfoRuntimeMixin):
         if definition_id is None:
             definition_id = LocalId()
 
-        block_locator = BlockUsageLocator(
-            course_key,
+        # Construct the Block Usage Locator:
+        block_locator = course_key.make_usage_key(
             block_type=block_key.type,
             block_id=block_key.id,
         )

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
@@ -65,8 +65,7 @@ from xblock.core import XBlock
 from xblock.fields import Scope, Reference, ReferenceList, ReferenceValueDict
 from xmodule.errortracker import null_error_tracker
 from opaque_keys.edx.locator import (
-    BlockUsageLocator, DefinitionLocator, CourseLocator, VersionTree,
-    LocalId,
+    BlockUsageLocator, DefinitionLocator, CourseLocator, LibraryLocator, VersionTree, LocalId,
 )
 from xmodule.modulestore.exceptions import InsufficientSpecificationError, VersionConflictError, DuplicateItemError, \
     DuplicateCourseError
@@ -190,8 +189,8 @@ class SplitBulkWriteMixin(BulkOperationsMixin):
         if course_key is None:
             return self._bulk_ops_record_type()
 
-        if not isinstance(course_key, CourseLocator):
-            raise TypeError(u'{!r} is not a CourseLocator'.format(course_key))
+        if not isinstance(course_key, (CourseLocator, LibraryLocator)):
+            raise TypeError(u'{!r} is not a CourseLocator or LibraryLocator'.format(course_key))
         # handle version_guid based retrieval locally
         if course_key.org is None or course_key.course is None or course_key.run is None:
             return self._active_bulk_ops.records[
@@ -207,8 +206,8 @@ class SplitBulkWriteMixin(BulkOperationsMixin):
         """
         Clear the record for this course
         """
-        if not isinstance(course_key, CourseLocator):
-            raise TypeError('{!r} is not a CourseLocator'.format(course_key))
+        if not isinstance(course_key, (CourseLocator, LibraryLocator)):
+            raise TypeError('{!r} is not a CourseLocator or LibraryLocator'.format(course_key))
 
         if course_key.org and course_key.course and course_key.run:
             del self._active_bulk_ops.records[course_key.replace(branch=None, version_guid=None)]
@@ -776,6 +775,26 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
         # add it in the envelope for the structure.
         return CourseEnvelope(course_key.replace(version_guid=version_guid), entry)
 
+    def _get_structures_for_branch(self, branch):
+        """
+        Internal generator for fetching lists of courses, libraries, etc.
+        """
+        matching_indexes = self.find_matching_course_indexes(branch)
+
+        # collect ids and then query for those
+        version_guids = []
+        id_version_map = {}
+        for course_index in matching_indexes:
+            version_guid = course_index['versions'][branch]
+            version_guids.append(version_guid)
+            id_version_map[version_guid] = course_index
+
+        if not version_guids:
+            return
+
+        for entry in self.find_structures_by_id(version_guids):
+            yield entry, id_version_map[entry['_id']]
+
     @autoretry_read()
     def get_courses(self, branch, **kwargs):
         '''
@@ -789,30 +808,36 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
 
         :param branch: the branch for which to return courses.
         '''
-        matching_indexes = self.find_matching_course_indexes(branch)
-
-        # collect ids and then query for those
-        version_guids = []
-        id_version_map = {}
-        for course_index in matching_indexes:
-            version_guid = course_index['versions'][branch]
-            version_guids.append(version_guid)
-            id_version_map[version_guid] = course_index
-
-        if not version_guids:
-            return []
-
-        matching_structures = self.find_structures_by_id(version_guids)
-
         # get the blocks for each course index (s/b the root)
         result = []
-        for entry in matching_structures:
-            course_info = id_version_map[entry['_id']]
+        for entry, course_info in self._get_structures_for_branch(branch):
             envelope = CourseEnvelope(
                 CourseLocator(
                     org=course_info['org'],
                     course=course_info['course'],
                     run=course_info['run'],
+                    branch=branch,
+                ),
+                entry
+            )
+            root = entry['root']
+            course_list = self._load_items(envelope, [root], 0, lazy=True, **kwargs)
+            if not isinstance(course_list[0], ErrorDescriptor):
+                result.append(course_list[0])
+        return result
+
+    def get_libraries(self, branch="library", **kwargs):
+        '''
+        Returns a list of "library" root blocks matching any given qualifiers.
+
+        TODO: better way of identifying library index entry vs. course index entry.
+        '''
+        result = []
+        for entry, course_info in self._get_structures_for_branch(branch):
+            envelope = CourseEnvelope(
+                LibraryLocator(
+                    org=course_info['org'],
+                    library=course_info['course'],
                     branch=branch,
                 ),
                 entry
@@ -844,6 +869,28 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
         root = course_entry.structure['root']
         result = self._load_items(course_entry, [root], depth, lazy=True, **kwargs)
         return result[0]
+
+    def get_library(self, library_id, depth=0, **kwargs):
+        '''
+        Gets the 'library' root block for the library identified by the locator
+        '''
+        if not isinstance(library_id, LibraryLocator):
+            # The supplied CourseKey is of the wrong type, so it can't possibly be stored in this modulestore.
+            raise ItemNotFoundError(library_id)
+
+        course_entry = self._lookup_course(library_id)
+        root = course_entry.structure['root']
+        result = self._load_items(course_entry, [root], depth, lazy=True, **kwargs)
+        return result[0]
+
+    def get_courselike(self, locator, depth=0, **kwargs):
+        """
+        Gets a course or a library.
+        """
+        if isinstance(locator, LibraryLocator):
+            return self.get_library(locator, depth, **kwargs)
+        else:
+            return self.get_course(locator, depth, **kwargs)
 
     def has_course(self, course_id, ignore_case=False, **kwargs):
         '''
@@ -1227,19 +1274,27 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
 
         new_def_data = self._serialize_fields(old_definition['block_type'], new_def_data)
         if needs_saved():
-            # Do a deep copy so that we don't corrupt the cached version of the definition
-            new_definition = copy.deepcopy(old_definition)
-            new_definition['_id'] = ObjectId()
-            new_definition['fields'] = new_def_data
-            new_definition['edit_info']['edited_by'] = user_id
-            new_definition['edit_info']['edited_on'] = datetime.datetime.now(UTC)
-            # previous version id
-            new_definition['edit_info']['previous_version'] = definition_locator.definition_id
-            new_definition['schema_version'] = self.SCHEMA_VERSION
-            self.update_definition(course_key, new_definition)
-            return DefinitionLocator(new_definition['block_type'], new_definition['_id']), True
+            definition_locator = self._update_definition_from_data(course_key, old_definition, new_def_data, user_id)
+            return definition_locator, True
         else:
             return definition_locator, False
+
+    def _update_definition_from_data(self, course_key, old_definition, new_def_data, user_id):
+        """
+        Update the persisted version of the given definition and return the
+        locator of the new definition. Does not check if data differs from the
+        previous version.
+        """
+        new_definition = copy.deepcopy(old_definition)
+        new_definition['_id'] = ObjectId()
+        new_definition['fields'] = new_def_data
+        new_definition['edit_info']['edited_by'] = user_id
+        new_definition['edit_info']['edited_on'] = datetime.datetime.now(UTC)
+        # previous version id
+        new_definition['edit_info']['previous_version'] = old_definition['_id']
+        new_definition['schema_version'] = self.SCHEMA_VERSION
+        self.update_definition(course_key, new_definition)
+        return DefinitionLocator(new_definition['block_type'], new_definition['_id'])
 
     def _generate_block_key(self, course_blocks, category):
         """
@@ -1325,7 +1380,7 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
             # persist the definition if persisted != passed
             if (definition_locator is None or isinstance(definition_locator.definition_id, LocalId)):
                 definition_locator = self.create_definition_from_data(course_key, new_def_data, block_type, user_id)
-            elif new_def_data is not None:
+            elif new_def_data:
                 definition_locator, _ = self.update_definition_from_data(course_key, definition_locator, new_def_data, user_id)
 
             # copy the structure and modify the new one
@@ -1494,6 +1549,19 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
         assert master_branch is not None
         # check course and run's uniqueness
         locator = CourseLocator(org=org, course=course, run=run, branch=master_branch)
+        return self._create_courselike(
+            locator, user_id, master_branch, fields, versions_dict,
+            search_targets, root_category, root_block_id, **kwargs
+        )
+
+    def _create_courselike(
+        self, locator, user_id, master_branch, fields=None,
+        versions_dict=None, search_targets=None, root_category='course',
+        root_block_id=None, **kwargs
+    ):
+        """
+        Internal code for creating a course or library
+        """
         index = self.get_course_index(locator)
         if index is not None:
             raise DuplicateCourseError(locator, index)
@@ -1508,20 +1576,7 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
         # if building a wholly new structure
         if versions_dict is None or master_branch not in versions_dict:
             # create new definition and structure
-            definition_id = ObjectId()
-            definition_entry = {
-                '_id': definition_id,
-                'block_type': root_category,
-                'fields': definition_fields,
-                'edit_info': {
-                    'edited_by': user_id,
-                    'edited_on': datetime.datetime.now(UTC),
-                    'previous_version': None,
-                    'original_version': definition_id,
-                },
-                'schema_version': self.SCHEMA_VERSION,
-            }
-            self.update_definition(locator, definition_entry)
+            definition_id = self.create_definition_from_data(locator, definition_fields, root_category, user_id).definition_id
 
             draft_structure = self._new_structure(
                 user_id,
@@ -1549,15 +1604,11 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
             if block_fields is not None:
                 root_block['fields'].update(self._serialize_fields(root_category, block_fields))
             if definition_fields is not None:
-                definition = copy.deepcopy(self.get_definition(locator, root_block['definition']))
-                definition['fields'].update(definition_fields)
-                definition['edit_info']['previous_version'] = definition['_id']
-                definition['edit_info']['edited_by'] = user_id
-                definition['edit_info']['edited_on'] = datetime.datetime.now(UTC)
-                definition['_id'] = ObjectId()
-                definition['schema_version'] = self.SCHEMA_VERSION
-                self.update_definition(locator, definition)
-                root_block['definition'] = definition['_id']
+                old_def = self.get_definition(locator, root_block['definition'])
+                new_fields = old_def['fields']
+                new_fields.update(definition_fields)
+                definition_id = self._update_definition_from_data(locator, old_def, new_fields, user_id).definition_id
+                root_block['definition'] = definition_id
                 root_block['edit_info']['edited_on'] = datetime.datetime.now(UTC)
                 root_block['edit_info']['edited_by'] = user_id
                 root_block['edit_info']['previous_version'] = root_block['edit_info'].get('update_version')
@@ -1574,9 +1625,9 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
             self.update_structure(locator, draft_structure)
             index_entry = {
                 '_id': ObjectId(),
-                'org': org,
-                'course': course,
-                'run': run,
+                'org': locator.org,
+                'course': locator.course,
+                'run': locator.run,
                 'edited_by': user_id,
                 'edited_on': datetime.datetime.now(UTC),
                 'versions': versions_dict,
@@ -1588,8 +1639,19 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
             self.insert_course_index(locator, index_entry)
 
             # expensive hack to persist default field values set in __init__ method (e.g., wiki_slug)
-            course = self.get_course(locator, **kwargs)
+            course = self.get_courselike(locator, **kwargs)
             return self.update_item(course, user_id, **kwargs)
+
+    def create_library(self, org, library, user_id, fields, **kwargs):
+        """
+        Create a new library. Arguments are similar to create_course().
+        """
+        kwargs["fields"] = fields
+        kwargs["master_branch"] = kwargs.get("master_branch", ModuleStoreEnum.BranchName.library)
+        kwargs["root_category"] = kwargs.get("root_category", "library")
+        kwargs["root_block_id"] = kwargs.get("root_block_id", "library")
+        locator = LibraryLocator(org=org, library=library, branch=kwargs["master_branch"])
+        return self._create_courselike(locator, user_id, **kwargs)
 
     def update_item(self, descriptor, user_id, allow_not_found=False, force=False, **kwargs):
         """
@@ -1680,14 +1742,24 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
                 if index_entry is not None:
                     self._update_search_targets(index_entry, definition_fields)
                     self._update_search_targets(index_entry, settings)
-                    course_key = CourseLocator(
-                        org=index_entry['org'],
-                        course=index_entry['course'],
-                        run=index_entry['run'],
-                        branch=course_key.branch,
-                        version_guid=new_id
-                    )
+                    if isinstance(course_key, LibraryLocator):
+                        course_key = LibraryLocator(
+                            org=index_entry['org'],
+                            library=index_entry['course'],
+                            branch=course_key.branch,
+                            version_guid=new_id
+                        )
+                    else:
+                        course_key = CourseLocator(
+                            org=index_entry['org'],
+                            course=index_entry['course'],
+                            run=index_entry['run'],
+                            branch=course_key.branch,
+                            version_guid=new_id
+                        )
                     self._update_head(course_key, index_entry, course_key.branch, new_id)
+                elif isinstance(course_key, LibraryLocator):
+                    course_key = LibraryLocator(version_guid=new_id)
                 else:
                     course_key = CourseLocator(version_guid=new_id)
 

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split_draft.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split_draft.py
@@ -9,7 +9,7 @@ from xmodule.modulestore.exceptions import InsufficientSpecificationError
 from xmodule.modulestore.draft_and_published import (
     ModuleStoreDraftAndPublished, DIRECT_ONLY_CATEGORIES, UnsupportedRevisionError
 )
-from opaque_keys.edx.locator import CourseLocator
+from opaque_keys.edx.locator import CourseLocator, LibraryLocator, LibraryUsageLocator
 from xmodule.modulestore.split_mongo import BlockKey
 from contracts import contract
 
@@ -56,6 +56,10 @@ class DraftVersioningModuleStore(SplitMongoModuleStore, ModuleStoreDraftAndPubli
     def get_course(self, course_id, depth=0, **kwargs):
         course_id = self._map_revision_to_branch(course_id)
         return super(DraftVersioningModuleStore, self).get_course(course_id, depth=depth, **kwargs)
+
+    def get_library(self, library_id, depth=0, **kwargs):
+        library_id = self._map_revision_to_branch(library_id)
+        return super(DraftVersioningModuleStore, self).get_library(library_id, depth=depth, **kwargs)
 
     def clone_course(self, source_course_id, dest_course_id, user_id, fields=None, revision=None, **kwargs):
         """
@@ -153,12 +157,17 @@ class DraftVersioningModuleStore(SplitMongoModuleStore, ModuleStoreDraftAndPubli
                 Otherwise, raises a ValueError.
         """
         with self.bulk_operations(location.course_key):
-            if revision == ModuleStoreEnum.RevisionOption.published_only:
+            if isinstance(location, LibraryUsageLocator):
+                branches_to_delete = [ModuleStoreEnum.BranchName.library]  # Libraries don't yet have draft/publish support
+            elif revision == ModuleStoreEnum.RevisionOption.published_only:
                 branches_to_delete = [ModuleStoreEnum.BranchName.published]
             elif revision == ModuleStoreEnum.RevisionOption.all:
                 branches_to_delete = [ModuleStoreEnum.BranchName.published, ModuleStoreEnum.BranchName.draft]
             elif revision is None:
-                branches_to_delete = [ModuleStoreEnum.BranchName.draft]
+                if location.course_key.branch:
+                    branches_to_delete = [location.course_key.branch]  # Delete from whatever branch is explicitly requested
+                else:
+                    branches_to_delete = [ModuleStoreEnum.BranchName.draft]  # Default
             else:
                 raise UnsupportedRevisionError(
                     [
@@ -178,18 +187,25 @@ class DraftVersioningModuleStore(SplitMongoModuleStore, ModuleStoreDraftAndPubli
         """
         Maps RevisionOptions to BranchNames, inserting them into the key
         """
+        if isinstance(key, (LibraryLocator, LibraryUsageLocator)):
+            # Libraries don't yet have draft/publish support:
+            draft_branch = ModuleStoreEnum.BranchName.library
+            published_branch = ModuleStoreEnum.BranchName.library
+        else:
+            draft_branch = ModuleStoreEnum.BranchName.draft
+            published_branch = ModuleStoreEnum.BranchName.published
 
         if revision == ModuleStoreEnum.RevisionOption.published_only:
-            return key.for_branch(ModuleStoreEnum.BranchName.published)
+            return key.for_branch(published_branch)
         elif revision == ModuleStoreEnum.RevisionOption.draft_only:
-            return key.for_branch(ModuleStoreEnum.BranchName.draft)
+            return key.for_branch(draft_branch)
         elif revision is None:
             if key.branch is not None:
                 return key
             elif self.get_branch_setting(key) == ModuleStoreEnum.Branch.draft_preferred:
-                return key.for_branch(ModuleStoreEnum.BranchName.draft)
+                return key.for_branch(draft_branch)
             else:
-                return key.for_branch(ModuleStoreEnum.BranchName.published)
+                return key.for_branch(published_branch)
         else:
             raise UnsupportedRevisionError()
 

--- a/common/lib/xmodule/xmodule/modulestore/tests/factories.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/factories.py
@@ -78,6 +78,36 @@ class CourseFactory(XModuleFactory):
             return new_course
 
 
+class LibraryFactory(XModuleFactory):
+    """
+    Factory for creating a content library
+    """
+    org = factory.Sequence(lambda n: 'org%d' % n)
+    library = factory.Sequence(lambda n: 'lib%d' % n)
+    display_name = factory.Sequence(lambda n: 'Test Library %d' % n)
+
+    # pylint: disable=unused-argument
+    @classmethod
+    def _create(cls, target_class, **kwargs):
+        """
+        Create a library with a unique name and key.
+        All class attributes (from this class and base classes) are automagically
+        passed in via **kwargs.
+        """
+        # some of the kwargst actual field values, so pop those off for use separately:
+        org = kwargs.pop('org')
+        library = kwargs.pop('library')
+        store = kwargs.pop('modulestore')
+        user_id = kwargs.pop('user_id', ModuleStoreEnum.UserID.test)
+
+        # Pass the metadata just as field=value pairs
+        kwargs.update(kwargs.pop('metadata', {}))
+        default_store_override = kwargs.pop('default_store', ModuleStoreEnum.Type.split)
+        with store.default_store(default_store_override):
+            new_library = store.create_library(org, library, user_id, fields=kwargs)
+            return new_library
+
+
 class ItemFactory(XModuleFactory):
     """
     Factory for XModule items.

--- a/common/lib/xmodule/xmodule/public/js/library_content_edit.js
+++ b/common/lib/xmodule/xmodule/public/js/library_content_edit.js
@@ -1,0 +1,24 @@
+/* JavaScript for editing operations that can be done on LibraryContentXBlock */
+window.LibraryContentAuthorView = function (runtime, element) {
+    $(element).find('.library-update-btn').on('click', function(e) {
+        e.preventDefault();
+        // Update the XBlock with the latest matching content from the library:
+        runtime.notify('save', {
+            state: 'start',
+            element: element,
+            message: gettext('Updating with latest library content…')
+        });
+        $.post(runtime.handlerUrl(element, 'refresh_children')).done(function() {
+            runtime.notify('save', {
+                state: 'end',
+                element: element
+            });
+            // runtime.refreshXBlock(element);
+            // The above does not work, because this XBlock's runtime has no reference
+            // to the page (XBlockContainerPage). Only the Vertical XBlock's runtime has
+            // a reference to the page, and we have no way of getting a reference to it.
+            // So instead we:
+            location.reload();
+        });
+    });
+};

--- a/common/lib/xmodule/xmodule/tests/test_library_content_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_library_content_module.py
@@ -1,0 +1,210 @@
+"""
+Unit tests for the classes in library_content_module.py
+"""
+from bson import ObjectId
+import ddt
+from mock import Mock, patch
+import random
+import unittest
+from collections import namedtuple
+from opaque_keys.edx.locator import LibraryLocator
+
+from xmodule.library_content_module import (
+    LibraryVersionReference, LibraryList, LibraryContentModule,
+    LibraryContentFields, LibraryContentDescriptor
+)
+
+
+@ddt.ddt
+class TestLibraryVersionReference(unittest.TestCase):
+    """ Tests for LibraryVersionReference """
+    # pylint: disable=no-member
+    # ^ because pylint currently raises no-member for any use of namedtuple
+    def test_init_from_string_without_version(self):
+        locator = LibraryLocator("TestX", "LIB")
+
+        lvr = LibraryVersionReference(unicode(locator))
+
+        self.assertEquals(lvr.library_id, locator)
+        self.assertEquals(lvr.version, locator.version)
+        self.assertIsNone(lvr.version)
+
+    def test_init_from_course_locator_without_version(self):
+        locator = LibraryLocator("TestX", "LIB")
+
+        lvr = LibraryVersionReference(locator)
+
+        self.assertEquals(lvr.library_id, locator)
+        self.assertEquals(lvr.version, locator.version)
+        self.assertIsNone(lvr.version)
+
+    def test_init_from_course_locator_and_version(self):
+        version = ObjectId()
+        locator = LibraryLocator("TestX", "LIB")
+
+        lvr = LibraryVersionReference(locator, version)
+
+        self.assertEquals(lvr.library_id, locator)
+        self.assertEquals(lvr.version, version)
+
+    def test_init_from_lib_locator_and_matching_version(self):
+        version = ObjectId()
+        locator = LibraryLocator("TestX", "LIB", version_guid=version)
+        expected_locator = locator.for_version(None)
+
+        lvr = LibraryVersionReference(locator, version)
+
+        self.assertEquals(lvr.library_id, expected_locator)
+        self.assertEquals(lvr.version, version)
+
+    def test_init_throws_if_version_mismatch(self):
+        version = ObjectId("aaaaaaaaaaaaaaaaaaaaaaaa")
+        locator = LibraryLocator("TestX", "LIB", version_guid=ObjectId("bbbbbbbbbbbbbbbbbbbbbbbb"))
+
+        with self.assertRaises(AssertionError):
+            LibraryVersionReference(locator, version)
+
+    @ddt.data(
+        ["library-v1:TestX+TEST", "abcdefabcdefabcdefabcdef"],
+    )
+    @ddt.unpack
+    def test_from_json(self, expected_locator, expected_version):
+        lvr = LibraryVersionReference.from_json([expected_locator, expected_version])
+        self.assertEquals(unicode(lvr.library_id), expected_locator)
+        self.assertEquals(lvr.version, ObjectId(expected_version))
+
+    @ddt.data(
+        ["library-v1:TestX+TEST", "abcdefabcdefabcdefabcdef"],
+        ["library-v1:TestX+TEST", None],
+    )
+    def test_json_roundtrip(self, expected):
+        result = LibraryVersionReference.from_json(expected).to_json()
+        self.assertEquals(expected, result)
+
+
+class TestLibraryList(unittest.TestCase):
+    """ Tests for LibraryList """
+    def test_json_roundtrip(self):
+        json_data = [
+            ["library-v1:TestX+TEST", "abcdefabcdefabcdefabcdef"],
+            ["library-v1:TestX+OTHER", "efabcdefabcdefabcdefabcd"],
+        ]
+
+        lib_list = LibraryList()
+
+        self.assertEquals(lib_list.to_json(lib_list.from_json(json_data)), json_data)
+
+    def test_from_json(self):
+        json_data = [
+            ["library-v1:TestX+TEST", "abcdefabcdefabcdefabcdef"],
+            ["library-v1:TestX+OTHER", "efabcdefabcdefabcdefabcd"],
+        ]
+        expected = [LibraryVersionReference.from_json(a) for a in json_data]
+
+        lib_list = LibraryList()
+
+        self.assertEquals(lib_list.from_json(json_data), expected)
+
+
+LCM = LibraryContentModule
+
+
+@patch.object(LCM, "source_libraries", LCM.source_libraries.default)
+@patch.object(LCM, "mode", LCM.mode.default)
+@patch.object(LCM, "max_count", LCM.max_count.default)
+@patch.object(LCM, "filters", LCM.filters.default)
+@patch.object(LCM, "selected", LCM.selected.default)
+@patch.object(LCM, "has_score", LCM.has_score.default)  # pylint: disable=maybe-no-member
+@patch.object(LCM, "children", [])
+class TestLibraryContentModule(unittest.TestCase):
+    """ Tests for LibraryContentModule """
+    def setUp(self):
+        # Mocking out base classes of LibraryContentModule
+        self._orig_bases = LibraryContentModule.__bases__
+        LibraryContentModule.__bases__ = (LibraryContentFields,)
+        # just making sure that tests are reproducible
+        self._orig_random_state = random.getstate()
+        random.seed(42)
+
+        # more verbose than assertTrue(a.issubset(b))
+        self.assert_is_subset = self.assertLessEqual
+
+    def tearDown(self):
+        random.setstate(self._orig_random_state)
+        LibraryContentModule.__bases__ = self._orig_bases
+
+    def _set_up_lcm(self, num_child, max_count, selected=None, mode="random"):
+        """ Create an instance of LibraryContentModule with mock children """
+        assert mode in ["random", "first"]
+        if selected is None:
+            selected = []
+
+        lcm = LibraryContentModule()
+
+        MockChildBlock = namedtuple('XBlock', "block_id")  # pylint: disable=invalid-name
+        lcm.children = [MockChildBlock(i) for i in range(num_child)]
+
+        lcm.max_count = max_count
+        lcm.selected = selected
+        lcm.mode = mode
+
+        all_block_ids = set(c.block_id for c in lcm.children)
+
+        return lcm, all_block_ids
+
+    def _assert_consistent_selection(self, selected, lcm, all_block_ids):
+        """ Helper for following tests of the 'selected' property """
+        max_elements = min(lcm.max_count, len(lcm.children))
+        self.assertEqual(len(selected), max_elements)
+        self.assertEqual(selected, set(lcm.selected))
+        self.assert_is_subset(selected, all_block_ids)
+
+    def test_selected_children_filled_from_children(self):
+        lcm, all_block_ids = self._set_up_lcm(num_child=10, max_count=5)
+
+        selection = lcm.selected_children()
+
+        self._assert_consistent_selection(selection, lcm, all_block_ids)
+
+    def test_selected_children_returns_all_from_small_pool(self):
+        lcm, all_block_ids = self._set_up_lcm(num_child=4, max_count=6)
+
+        selection = lcm.selected_children()
+
+        self._assert_consistent_selection(selection, lcm, all_block_ids)
+        self.assertEqual(selection, all_block_ids)
+
+    def test_selected_children_fixes_selected_with_invalid_ids(self):
+        lcm, all_block_ids = self._set_up_lcm(8, 5, selected=[-3, 1, 5, 9, 15])
+        old_but_valid_ids = set(lcm.selected) & all_block_ids
+
+        selection = lcm.selected_children()
+
+        self._assert_consistent_selection(selection, lcm, all_block_ids)
+        self.assert_is_subset(old_but_valid_ids, selection)
+
+    def test_selected_children_fixes_selected_with_too_many_ids(self):
+        lcm, all_block_ids = self._set_up_lcm(12, 4, selected=list(range(8)))
+        orig_selected = set(lcm.selected)
+
+        selection = lcm.selected_children()
+
+        self._assert_consistent_selection(selection, lcm, all_block_ids)
+        self.assert_is_subset(selection, set(orig_selected))
+
+    def test_calling_selected_children_multiple_times_returns_same_result(self):
+        lcm, all_block_ids = self._set_up_lcm(13, 7)
+
+        selections = [lcm.selected_children() for _ in range(10)]
+
+        for selection in selections:
+            self._assert_consistent_selection(selection, lcm, all_block_ids)
+        for sel1, sel2 in zip(selections, selections[1:]):
+            self.assertEquals(sel1, sel2)
+
+
+class TestLibraryContentDescriptor(unittest.TestCase):
+    """ Tests for LibraryContentDescriptor """
+    def test_has_dynamic_children_returns_true(self):
+        lcd = LibraryContentDescriptor(Mock(), Mock(), Mock())
+        self.assertTrue(lcd.has_dynamic_children())

--- a/lms/djangoapps/courseware/models.py
+++ b/lms/djangoapps/courseware/models.py
@@ -32,6 +32,10 @@ class StudentModule(models.Model):
     MODULE_TYPES = (('problem', 'problem'),
                     ('video', 'video'),
                     ('html', 'html'),
+                    ('course', 'course'),
+                    ('chapter', 'Section'),
+                    ('sequential', 'Subsection'),
+                    ('library_content', 'Library Content'),
                     )
     ## These three are the key for the object
     module_type = models.CharField(max_length=32, choices=MODULE_TYPES, default='problem', db_index=True)

--- a/lms/templates/library-block-author-view.html
+++ b/lms/templates/library-block-author-view.html
@@ -1,0 +1,18 @@
+<%!
+from django.utils.translation import ugettext as _
+from django.core.urlresolvers import reverse
+%>
+<div class="xblock-header-secondary">
+    % if library_status == LibraryStatus.OK:
+        <p>${_('This component will be replaced by {mode} {max_count} components from the {num_children} matching components from {lib_names}.').format(mode=mode, max_count=max_count, num_children=num_children, lib_names=', '.join(library_names))}</p>
+        % if update_status == UpdateStatus.NEEDED:
+            <p><strong>${_('This component is out of date.')}</strong> <a href="#" class="library-update-btn">↻ ${_('Update now with latest components from the library')}</a></p>
+        % elif update_status == UpdateStatus.UP_TO_DATE:
+            <p>${_(u'✓ Up to date.')}</p>
+        % endif
+    % elif library_status == LibraryStatus.NONE:
+        <p>${_('No library or filters configured. Press "Edit" to configure.')}</p>
+    % else:
+        <p>${_('Library is invalid, corrupt, or has been deleted.')}</p>
+    % endif
+</div>

--- a/lms/templates/staff_problem_info.html
+++ b/lms/templates/staff_problem_info.html
@@ -4,7 +4,7 @@
 
 ## The JS for this is defined in xqa_interface.html
 ${block_content}
-%if location.category in ['problem','video','html','combinedopenended','graphical_slider_tool']:
+%if location.category in ['problem','video','html','combinedopenended','graphical_slider_tool', 'library_content']:
 %  if edit_link:
   <div>
       <a href="${edit_link}">Edit</a>

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -30,7 +30,7 @@
 -e git+https://github.com/edx-solutions/django-splash.git@7579d052afcf474ece1239153cffe1c89935bc4f#egg=django-splash
 -e git+https://github.com/edx/acid-block.git@df1a7f0cae46567c251d507b8c72168aed8ec042#egg=acid-xblock
 -e git+https://github.com/edx/edx-ora2.git@release-2014-10-27T19.33#egg=edx-ora2
--e git+https://github.com/edx/opaque-keys.git@0.1.2#egg=opaque-keys
+-e git+https://github.com/edx/opaque-keys.git@b12401384921c075e5a4ed7aedc3bea57f56ec32#egg=opaque-keys
 -e git+https://github.com/edx/ease.git@97de68448e5495385ba043d3091f570a699d5b5f#egg=ease
 -e git+https://github.com/edx/i18n-tools.git@56f048af9b6868613c14aeae760548834c495011#egg=i18n-tools
 -e git+https://github.com/edx/edx-oauth2-provider.git@0.3.1#egg=oauth2-provider


### PR DESCRIPTION
**Background**: This is an early-stage prototype implementation of [Content Libraries](https://openedx.atlassian.net/wiki/display/SOL/Content+Libraries) ([SOL-11](https://openedx.atlassian.net/browse/SOL-11)). Once this PR is ready, it is intended to be merged so that it can be used as a common basis for further work on the feature. **It is not intended for use on production instances anytime soon**, so is disabled by default using a feature flag. Backwards-incompatible/breaking changes may be introduced in the near future.

**Discussion**: Architecture discussed extensively on [the wiki](https://openedx.atlassian.net/wiki/display/SOL/Content+Libraries) and in meetings, then the revised proposal was presented to the [Arch Council](https://openedx.atlassian.net/wiki/display/AC/Architecture+Council) on Oct. 21 and given thumbs up. [Some open questions remain](https://openedx.atlassian.net/wiki/display/SOL/10-22-2014+Architect+Council+Review+of+Content+Libraries).

**Partner information**: 3rd party-hosted open edX instance, for an edX solutions client.

**Merge deadline**: TBD

**Dependencies**: Requires edx/opaque-keys#46, which is already merged.

**Status**: Demonstrates the very basic features of libraries.

**Future**: The following will _not_ be part of this PR:
- UI/UX improvements, including pagination ([code for this is ready](https://github.com/open-craft/edx-platform/pull/9), PR coming after this one merged)
- Course-specific overrides (implementing this requires careful thought and code review so I'd like to do it separately in an upcoming pull request). **Note** that this means that at present, if you import content from a library into a course, then edit the imported blocks from the course view in studio, any such changes will be lost when synchronizing/updating with the latest content blocks from the library. ([code for this is ready](https://github.com/open-craft/edx-platform/pull/6), PR coming after this one merged)
- filtering/tagging
- Support of libraries from non-split courses
- Performance tests (can we have 1,000 problems in the library? 10,000?) - very much depends on how course overrides are implemented, so this is deferred for now
- Permissions - currently uses the same permissions system as courses. ([code for this is ready](https://github.com/open-craft/edx-platform/pull/8), PR coming after this one merged)

**Testing Instructions**:
1. Check out this branch and do `paver install_python_prereqs`
2. As 'edxapp' user, edit `~/cms.env.json` and add `"ENABLE_CONTENT_LIBRARIES": true` to the `FEATURES` object.
3. Edit `~/cms.auth.json`. Go to `MODULESTORE` > `default` > `OPTIONS` > `stores` - it should contain two or three entries. Re-order the entries so that the store with `"NAME": "split",` comes first in the `stores` list. (This makes [split](https://github.com/edx/edx-platform/wiki/Split:-the-versioning,-structure-saving-DAO) the default modulestore for any new courses.)
4. Start `paver devstack studio` and go to `localhost:8001` in your browser.
5. Log in as staff, and create a new library (a new "New library" button should appear at top right of studio home page).
6. Add some content to the library.
7. Go to studio home and go into a course or create a new course.
8. Go to Settings > Advanced Settings and add `"library_content"` to advanced_modules.
9. Go to Content > Outline. Create a new section and subsection, then edit it. Click "Advanced" and add a new "library_content" block.
10. Once the block is added, click "Edit" to edit its settings. Most are explained on the settings editor. For the "Library" setting, you must click "Add", then paste the LibraryLocator of your library. This looks like `library-v1:ProblemX+PR0B`. (It's in the URL when you go to the library in studio). Hit Save.
11. Click "Update now with latest components from the library".
12. Optional: Click "View >" to preview all the blocks found in the library.
13. Hit "Publish", then start up the LMS and go to `localhost:8000`. Browse into the course, and you should see that the block is replaced by random blocks from the library. To test the randomization, click the lowest "STAFF DEBUG INFO" link underneath the module, then click "Delete Student State", then refresh the page.
