### PR TITLE
Fixed empty display name with original value

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -179,9 +179,11 @@ Henry Tareque <henry.tareque@gmail.com>
 Eugeny Kolpakov <eugeny.kolpakov@gmail.com>
 Omar Al-Ithawi <oithawi@qrf.org>
 Louis Pilfold <louis@lpil.uk>
+Syed Hassan Raza <hassan.raza@arbisoft.com>
 Akiva Leffert <akiva@edx.org>
 Mike Bifulco <mbifulco@aquent.com>
 Jim Zheng <jimzheng@stanford.edu>
 Afzal Wali <afzaledx@edx.org>
 Julien Romagnoli <julien.romagnoli@fbmx.net>
 Wenjie Wu <wuwenjie718@gmail.com>
+

--- a/cms/djangoapps/contentstore/features/component.feature
+++ b/cms/djangoapps/contentstore/features/component.feature
@@ -115,18 +115,3 @@ Feature: CMS.Component Adding
         And I see a Problem component with display name "Duplicate of 'Blank Common Problem'" in position "1"
         And I see a Problem component with display name "Multiple Choice" in position "2"
 
-    Scenario: I can set the display name of a component
-        Given I am in Studio editing a new unit
-        When I add a "Text" "HTML" component
-        Then I see the display name is "Text"
-        When I change the display name to "I'm the Cuddliest!"
-        Then I see the display name is "I'm the Cuddliest!"
-
-    Scenario: If a component has no display name, the category is displayed
-        Given I am in Studio editing a new unit
-        When I add a "Blank Advanced Problem" "Advanced Problem" component
-        Then I see the display name is "Blank Advanced Problem"
-        When I change the display name to ""
-        Then I see the display name is "Blank Advanced Problem"
-        When I unset the display name
-        Then I see the display name is "Blank Advanced Problem"

--- a/cms/djangoapps/contentstore/features/component.feature
+++ b/cms/djangoapps/contentstore/features/component.feature
@@ -127,6 +127,6 @@ Feature: CMS.Component Adding
         When I add a "Blank Advanced Problem" "Advanced Problem" component
         Then I see the display name is "Blank Advanced Problem"
         When I change the display name to ""
-        Then I see the display name is "problem"
+        Then I see the display name is "Blank Advanced Problem"
         When I unset the display name
         Then I see the display name is "Blank Advanced Problem"

--- a/cms/static/js/views/abstract_editor.js
+++ b/cms/static/js/views/abstract_editor.js
@@ -69,7 +69,14 @@ define(["js/views/baseview", "underscore"], function(BaseView, _) {
             if (!this.template) return;
 
             this.setValueInEditor(this.model.getDisplayValue());
-
+            
+            if (this.model.get('display_name').indexOf('Display Name') >= 0 ) {
+            	if ($.trim(this.model.getDisplayValue()) == '' && this.$el.find("input:eq(0)").is(":focus") == false) {
+            		var original_value = $.trim(this.model.original_value || '');
+            		original_value != '' ? this.model.setValue(original_value) : this.clear();
+            		}
+            	}
+            
             if (this.model.isExplicitlySet()) {
                 this.showClearButton();
             }

--- a/common/test/acceptance/tests/studio/test_studio_container.py
+++ b/common/test/acceptance/tests/studio/test_studio_container.py
@@ -288,18 +288,18 @@ class EditContainerTest(NestedVerticalTest):
         """
         container = self.go_to_nested_container_page()
         self.modify_display_name_and_verify(container)
-        
+
     def test_display_name_with_empty_string(self):
         """
-        Test the Display Name if it is empty then it will filled with 
+        Test the Display Name if it is empty then it will filled with
         original value
         """
         unit = self.go_to_unit_page()
         component = unit.xblocks[1]
         empty_string = '  '
         self.modify_display_name_and_verify(component, modified_name=empty_string, original_value=component.name)
-        
-    
+
+
 @attr('shard_1')
 class UnitPublishingTest(ContainerBase):
     """

--- a/common/test/acceptance/tests/studio/test_studio_container.py
+++ b/common/test/acceptance/tests/studio/test_studio_container.py
@@ -8,7 +8,7 @@ from nose.plugins.attrib import attr
 from ...fixtures.course import XBlockFixtureDesc
 from ...pages.studio.component_editor import ComponentEditorView
 from ...pages.studio.html_component_editor import HtmlComponentEditorView
-from ...pages.studio.utils import add_discussion, drag
+from ...pages.studio.utils import add_discussion, drag, click_css
 from ...pages.lms.courseware import CoursewarePage
 from ...pages.lms.staff_view import StaffPage
 
@@ -298,6 +298,45 @@ class EditContainerTest(NestedVerticalTest):
         component = unit.xblocks[1]
         empty_string = '  '
         self.modify_display_name_and_verify(component, modified_name=empty_string, original_value=component.name)
+
+    def test_set_display_name(self):
+        """
+        Scenario: I can set the display name of a component
+        Given I am in Studio editing a new unit
+        When I add a "Discussion" component
+        Then I see the display name is "Discussion"
+        When I change the display name to "I'm the Cuddliest!"
+        Then I see the display name is "I'm the Cuddliest!"
+        """
+        unit = self.go_to_unit_page()
+        add_discussion(unit)
+        component = unit.xblocks[2]
+        self.assertEqual(component.name, "Discussion")
+        test_string = "I'm the Cuddliest!"
+        self.modify_display_name_and_verify(component, test_string)
+
+    def test_component_displayed_with_no_display_name(self):
+        """
+        Scenario: If a component has no display name, the category is displayed
+        Given I am in Studio editing a new unit
+        When I add a "Discussion" component
+        Then I see the display name is "Discussion"
+        When I change the display name to ""
+        Then I see the display name is "Discussion"
+        When I unset the display name
+        Then I see the display name is "Discussion"
+        """
+        unit = self.go_to_unit_page()
+        add_discussion(unit)
+        component = unit.xblocks[2]
+        self.assertEqual(component.name, "Discussion")
+        empty_string = ""
+        self.modify_display_name_and_verify(component, modified_name=empty_string, original_value="discussion")
+        component.edit()
+        component_editor = ComponentEditorView(self.browser, component.locator)
+        click_css(component_editor, 'button.setting-clear', require_notification=False)
+        component_editor.save()
+        self.assertEqual(component.name, "Discussion")
 
 
 @attr('shard_1')

--- a/common/test/acceptance/tests/studio/test_studio_container.py
+++ b/common/test/acceptance/tests/studio/test_studio_container.py
@@ -262,15 +262,16 @@ class EditContainerTest(NestedVerticalTest):
     Tests of editing a container.
     """
 
-    def modify_display_name_and_verify(self, component):
+    def modify_display_name_and_verify(self, component, modified_name='modified', original_value=None):
         """
         Helper method for changing a display name.
         """
-        modified_name = 'modified'
         self.assertNotEqual(component.name, modified_name)
         component.edit()
         component_editor = ComponentEditorView(self.browser, component.locator)
         component_editor.set_field_value_and_save('Display Name', modified_name)
+        if original_value:
+            modified_name = original_value
         self.assertEqual(component.name, modified_name)
 
     def test_edit_container_on_unit_page(self):
@@ -287,8 +288,18 @@ class EditContainerTest(NestedVerticalTest):
         """
         container = self.go_to_nested_container_page()
         self.modify_display_name_and_verify(container)
-
-
+        
+    def test_display_name_with_empty_string(self):
+        """
+        Test the Display Name if it is empty then it will filled with 
+        original value
+        """
+        unit = self.go_to_unit_page()
+        component = unit.xblocks[1]
+        empty_string = '  '
+        self.modify_display_name_and_verify(component, modified_name=empty_string, original_value=component.name)
+        
+    
 @attr('shard_1')
 class UnitPublishingTest(ContainerBase):
     """


### PR DESCRIPTION
TNL-344

Fix display name of unit if it is left empty then filled it with original value. Added bok-choy test.
