### PR TITLE
fix click event for actual target

### DIFF
--- a/cms/static/js/views/xblock_outline.js
+++ b/cms/static/js/views/xblock_outline.js
@@ -281,7 +281,7 @@ define(["jquery", "underscore", "gettext", "js/views/baseview", "js/views/utils/
 
             handleAddEvent: function(event) {
                 var self = this,
-                    target = $(event.target),
+                    target = $(event.currentTarget),
                     category = target.data('category');
                 event.preventDefault();
                 XBlockViewUtils.addXBlock(target).done(function(locator) {

--- a/common/test/acceptance/pages/studio/overview.py
+++ b/common/test/acceptance/pages/studio/overview.py
@@ -487,11 +487,15 @@ class CourseOutlinePage(CoursePage, CourseOutlineContainer):
         """
         click_css(self, '.wrapper-mast nav.nav-actions .button-new')
 
-    def add_section_from_bottom_button(self):
+    def add_section_from_bottom_button(self, click_child_icon=False):
         """
         Clicks the button for adding a section which resides at the bottom of the screen.
         """
-        click_css(self, self.BOTTOM_ADD_SECTION_BUTTON)
+        element_css = self.BOTTOM_ADD_SECTION_BUTTON
+        if click_child_icon:
+            element_css += " .icon-plus"
+
+        click_css(self, element_css)
 
     def toggle_expand_collapse(self):
         """

--- a/common/test/acceptance/tests/studio/test_studio_outline.py
+++ b/common/test/acceptance/tests/studio/test_studio_outline.py
@@ -1005,6 +1005,19 @@ class CreateSectionsTest(CourseOutlineTest):
         self.assertEqual(len(self.course_outline_page.sections()), 1)
         self.assertTrue(self.course_outline_page.section_at(0).in_editable_form())
 
+    def test_create_new_section_from_bottom_button_plus_icon(self):
+        """
+        Scenario: Create new section from button plus icon at bottom of page
+            Given that I am on the course outline
+            When I click the plus icon in "+ Add section" button at the bottom of the page
+            Then I see a new section added to the bottom of the page
+            And the display name is in its editable form.
+        """
+        self.course_outline_page.visit()
+        self.course_outline_page.add_section_from_bottom_button(click_child_icon=True)
+        self.assertEqual(len(self.course_outline_page.sections()), 1)
+        self.assertTrue(self.course_outline_page.section_at(0).in_editable_form())
+
     def test_create_new_subsection(self):
         """
         Scenario: Create new subsection


### PR DESCRIPTION
TNL-138
@waheedahmed @symbolist @adampalay @cahrens 
Resolve the issue where when some users clicks on plus icon inside "button-new" ["New Section", "New Subsection", "New Unit"] then they see server error (KeyError: 'parent_locator').
