### PR TITLE
Fixed jump_to_id in problem solution.

### DIFF
--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -811,7 +811,10 @@ class CapaMixin(CapaFields):
         new_answers = dict()
         for answer_id in answers:
             try:
-                new_answer = {answer_id: self.runtime.replace_urls(answers[answer_id])}
+                answer_content = self.runtime.replace_urls(answers[answer_id])
+                if self.runtime.replace_jump_to_id_urls:
+                    answer_content = self.runtime.replace_jump_to_id_urls(answer_content)
+                new_answer = {answer_id: answer_content}
             except TypeError:
                 log.debug(u'Unable to perform URL substitution on answers[%s]: %s',
                           answer_id, answers[answer_id])

--- a/common/lib/xmodule/xmodule/tests/test_capa_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_capa_module.py
@@ -1890,3 +1890,29 @@ class TestProblemCheckTracking(unittest.TestCase):
                 'variant': ''
             }
         })
+
+    def test_get_answer_with_jump_to_id_urls(self):
+        """
+        Make sure replace_jump_to_id_urls() is called in get_answer.
+        """
+        problem_xml = textwrap.dedent("""
+        <problem>
+            <p>What is 1+4?</p>
+                <numericalresponse answer="5">
+                  <formulaequationinput />
+                </numericalresponse>
+
+                <solution>
+                <div class="detailed-solution">
+                <p>Explanation</p>
+                <a href="/jump_to_id/c0f8d54964bc44a4a1deb8ecce561ecd">here's the same link to the hint page.</a>
+                </div>
+                </solution>
+        </problem>
+        """)
+
+        data = dict()
+        problem = CapaFactory.create(showanswer='always', xml=problem_xml)
+        problem.runtime.replace_jump_to_id_urls = Mock()
+        problem.get_answer(data)
+        self.assertTrue(problem.runtime.replace_jump_to_id_urls.called)


### PR DESCRIPTION
Ticket: [TNL-729](https://openedx.atlassian.net/browse/TNL-729)

If we include jump_to_id url in problem's solution like this `<a href="/jump_to_id/c0f8d54964bc44a4a1deb8ecce561ecd">unit link</a>` then it was not replaced with complete url of that unit which results a 404 page when we click on this link.
Called `replace_jump_to_id_urls()` on problem solution to complete the url.
