### PR TITLE
Add endpoint to log in with OAuth access token

### DIFF
--- a/common/djangoapps/student/tests/test_login.py
+++ b/common/djangoapps/student/tests/test_login.py
@@ -12,8 +12,14 @@ from django.conf import settings
 from django.core.cache import cache
 from django.core.urlresolvers import reverse, NoReverseMatch
 from django.http import HttpResponseBadRequest, HttpResponse
+import httpretty
+from social.apps.django_app.default.models import UserSocialAuth
 from student.tests.factories import UserFactory, RegistrationFactory, UserProfileFactory
-from student.views import _parse_course_id_from_string, _get_course_enrollment_domain
+from student.views import (
+    _parse_course_id_from_string,
+    _get_course_enrollment_domain,
+    login_oauth_token,
+)
 
 from xmodule.modulestore.tests.factories import CourseFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, mixed_store_config
@@ -430,3 +436,89 @@ class ExternalAuthShibTest(ModuleStoreTestCase):
         self.assertEqual(shib_response.redirect_chain[-2],
                          ('http://testserver{url}'.format(url=TARGET_URL_SHIB), 302))
         self.assertEqual(shib_response.status_code, 200)
+
+
+@httpretty.activate
+class LoginOAuthTokenMixin(object):
+    """
+    Mixin with tests for the login_oauth_token view. A TestCase that includes
+    this must define the following:
+
+    BACKEND: The name of the backend from python-social-auth
+    USER_URL: The URL of the endpoint that the backend retrieves user data from
+    UID_FIELD: The field in the user data that the backend uses as the user id
+    """
+
+    def setUp(self):
+        self.client = Client()
+        self.url = reverse(login_oauth_token, kwargs={"backend": self.BACKEND})
+        self.social_uid = "social_uid"
+        self.user = UserFactory()
+        UserSocialAuth.objects.create(user=self.user, provider=self.BACKEND, uid=self.social_uid)
+
+    def _setup_user_response(self, success):
+        """
+        Register a mock response for the third party user information endpoint;
+        success indicates whether the response status code should be 200 or 400
+        """
+        if success:
+            status = 200
+            body = json.dumps({self.UID_FIELD: self.social_uid})
+        else:
+            status = 400
+            body = json.dumps({})
+        httpretty.register_uri(
+            httpretty.GET,
+            self.USER_URL,
+            body=body,
+            status=status,
+            content_type="application/json"
+        )
+
+    def _assert_error(self, response, status_code, error):
+        """Assert that the given response was a 400 with the given error code"""
+        self.assertEqual(response.status_code, status_code)
+        self.assertEqual(json.loads(response.content), {"error": error})
+        self.assertNotIn("partial_pipeline", self.client.session)
+
+    def test_success(self):
+        self._setup_user_response(success=True)
+        response = self.client.post(self.url, {"access_token": "dummy"})
+        self.assertEqual(response.status_code, 204)
+
+    def test_invalid_token(self):
+        self._setup_user_response(success=False)
+        response = self.client.post(self.url, {"access_token": "dummy"})
+        self._assert_error(response, 401, "invalid_token")
+
+    def test_missing_token(self):
+        response = self.client.post(self.url)
+        self._assert_error(response, 400, "invalid_request")
+
+    def test_unlinked_user(self):
+        UserSocialAuth.objects.all().delete()
+        self._setup_user_response(success=True)
+        response = self.client.post(self.url, {"access_token": "dummy"})
+        self._assert_error(response, 401, "invalid_token")
+
+    def test_get_method(self):
+        response = self.client.get(self.url, {"access_token": "dummy"})
+        self.assertEqual(response.status_code, 405)
+
+
+# This is necessary because cms does not implement third party auth
+@unittest.skipUnless(settings.FEATURES.get("ENABLE_THIRD_PARTY_AUTH"), "third party auth not enabled")
+class LoginOAuthTokenTestFacebook(LoginOAuthTokenMixin, TestCase):
+    """Tests login_oauth_token with the Facebook backend"""
+    BACKEND = "facebook"
+    USER_URL = "https://graph.facebook.com/me"
+    UID_FIELD = "id"
+
+
+# This is necessary because cms does not implement third party auth
+@unittest.skipUnless(settings.FEATURES.get("ENABLE_THIRD_PARTY_AUTH"), "third party auth not enabled")
+class LoginOAuthTokenTestGoogle(LoginOAuthTokenMixin, TestCase):
+    """Tests login_oauth_token with the Google backend"""
+    BACKEND = "google-oauth2"
+    USER_URL = "https://www.googleapis.com/oauth2/v1/userinfo"
+    UID_FIELD = "email"

--- a/common/djangoapps/third_party_auth/settings.py
+++ b/common/djangoapps/third_party_auth/settings.py
@@ -111,7 +111,7 @@ def _set_global_settings(django_settings):
         'social.pipeline.social_auth.auth_allowed',
         'social.pipeline.social_auth.social_user',
         'social.pipeline.user.get_username',
-        'third_party_auth.pipeline.redirect_to_supplementary_form',
+        'third_party_auth.pipeline.ensure_user_information',
         'social.pipeline.user.create_user',
         'social.pipeline.social_auth.associate_user',
         'social.pipeline.social_auth.load_extra_data',

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -534,6 +534,7 @@ if settings.FEATURES.get('AUTOMATIC_AUTH_FOR_TESTING'):
 if settings.FEATURES.get('ENABLE_THIRD_PARTY_AUTH'):
     urlpatterns += (
         url(r'', include('third_party_auth.urls')),
+        url(r'^login_oauth_token/(?P<backend>[^/]+)/$', 'student.views.login_oauth_token'),
     )
 
 # If enabled, expose the URLs for the new dashboard, account, and profile pages

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -44,6 +44,7 @@ git+https://github.com/pmitros/pyfs.git@96e1922348bfe6d99201b9512a9ed946c87b7e0b
 GitPython==0.3.2.RC1
 glob2==0.3
 gunicorn==0.17.4
+httpretty==0.8.3
 lazy==1.1
 lxml==3.3.6
 mako==0.9.1


### PR DESCRIPTION
@aleffert @rlucioni 

FYI @nasthagiri @dianakhuang @johncox-google

I dislike the fact that we have to poke the session to pass information to the pipeline. I'm wondering if we should change parse_query_params to not require auth_entry to be set in the session (and instead pass is_api as a kwarg to the pipeline), but I haven't fully thought through the ramifications of that change. I'm also not at all tied to the format of the responses from the new endpoint. If you can think of something better, let me know.
