### PR TITLE
Pylint: ignore TODO comments

### DIFF
--- a/pavelib/quality.py
+++ b/pavelib/quality.py
@@ -30,7 +30,9 @@ def run_pylint(options):
         # This makes the folder if it doesn't already exist.
         report_dir = (Env.REPORT_DIR / system).makedirs_p()
 
-        flags = '-E' if errors else ''
+        flags = ["--disable=fixme"]
+        if errors:
+            flags.append("--errors-only")
 
         apps = [system]
 
@@ -51,7 +53,7 @@ def run_pylint(options):
             "{pythonpath_prefix} pylint {flags} -f parseable {apps} | "
             "tee {report_dir}/pylint.report".format(
                 pythonpath_prefix=pythonpath_prefix,
-                flags=flags,
+                flags=" ".join(flags),
                 apps=apps_list,
                 report_dir=report_dir
             )

--- a/pavelib/quality.py
+++ b/pavelib/quality.py
@@ -30,7 +30,7 @@ def run_pylint(options):
         # This makes the folder if it doesn't already exist.
         report_dir = (Env.REPORT_DIR / system).makedirs_p()
 
-        flags = ["--disable=fixme"]
+        flags = []
         if errors:
             flags.append("--errors-only")
 
@@ -180,12 +180,15 @@ def run_quality(options):
 
     try:
         sh(
-            "{pythonpath_prefix} diff-quality --violations=pylint {pylint_reports} {percentage_string} "
-            "--html-report {dquality_dir}/diff_quality_pylint.html".format(
+            "{pythonpath_prefix} diff-quality --violations=pylint "
+            "{pylint_reports} {percentage_string} "
+            "--html-report {dquality_dir}/diff_quality_pylint.html "
+            "--options='{pylint_options}'".format(
                 pythonpath_prefix=pythonpath_prefix,
                 pylint_reports=pylint_reports,
                 percentage_string=percentage_string,
-                dquality_dir=dquality_dir
+                dquality_dir=dquality_dir,
+                pylint_options="--disable=fixme",
             )
         )
     except BuildFailure, error_message:

--- a/pylintrc
+++ b/pylintrc
@@ -41,8 +41,7 @@ disable=
 # W0142: Used * or ** magic
 # R0921: Abstract class not referenced
 # R0922: Abstract class is only referenced 1 times
-# W0511: TODO comments
-    I0011,C0301,W0141,W0142,R0921,R0922,W0511,
+    I0011,C0301,W0141,W0142,R0921,R0922,
 
 # Django makes classes that trigger these
 # W0232: Class has no __init__ method

--- a/pylintrc
+++ b/pylintrc
@@ -41,7 +41,8 @@ disable=
 # W0142: Used * or ** magic
 # R0921: Abstract class not referenced
 # R0922: Abstract class is only referenced 1 times
-    I0011,C0301,W0141,W0142,R0921,R0922,
+# W0511: TODO comments
+    I0011,C0301,W0141,W0142,R0921,R0922,W0511,
 
 # Django makes classes that trigger these
 # W0232: Class has no __init__ method


### PR DESCRIPTION
`TODO` comments are currently flagged by pylint, which causes them to break the build on Jenkins. We have many TODO comments already in the codebase, and it isn't practical to stop working to fix them all. We also don't want to just delete them: they contain valuable information. However, anytime that code is touched, diff-quality flags the TODO and fails the build.

It would be nice if there were a way to have `diff-quality` report on these TODO comments, but more as a warning, and not have them fail the build. However, I don't know how to do that, so this is the next best solution. TODO comments and similar can always be caught by humans in code review.
