### PR TITLE
Upgrade edx-platform to version of xblock from https://github.com/edx/XBlock/pull/240.

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -20,7 +20,7 @@
 -e git+https://github.com/pmitros/django-pyfs.git@d175715e0fe3367ec0f1ee429c242d603f6e8b10#egg=djpyfs
 
 # Our libraries:
--e git+https://github.com/edx/XBlock.git@246811773c67a84fdb17614a8e9f7ec7b1890574#egg=XBlock
+-e git+https://github.com/edx/XBlock.git@e3e4c3cff6ffb8c4819cad7a2c761fca3c5731fe#egg=XBlock
 -e git+https://github.com/edx/codejail.git@66dd5a45e5072666ff9a70c768576e9ffd1daa4b#egg=codejail
 -e git+https://github.com/edx/diff-cover.git@9a44ae21369662a7d06bfc5111875fc0d119e03b#egg=diff_cover
 -e git+https://github.com/edx/js-test-tool.git@v0.1.5#egg=js_test_tool


### PR DESCRIPTION
@lukedmor Would it be possible for you to look at these test failures? When I include your commit (https://github.com/edx/XBlock/pull/240) in edx-platform, some unit tests are failing.

I am in the process of merging a change to XBlock, and I will need to include it in edx-platform.

FYI: @nedbat 
