### PR TITLE
(WIP) Fix studio errors with Unicode course location values

### DIFF
--- a/cms/djangoapps/contentstore/views/helpers.py
+++ b/cms/djangoapps/contentstore/views/helpers.py
@@ -104,7 +104,7 @@ def xblock_studio_url(xblock, parent_xblock=None):
     elif category in ('chapter', 'sequential'):
         return u'{url}?show={usage_key}'.format(
             url=reverse_course_url('course_handler', xblock.location.course_key),
-            usage_key=urllib.quote(unicode(xblock.location))
+            usage_key=urllib.quote(unicode(xblock.location).encode('utf-8'))
         )
     else:
         return reverse_usage_url('container_handler', xblock.location)

--- a/common/lib/xmodule/xmodule/modulestore/tests/factories.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/factories.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pprint
 import pymongo.message
 
@@ -44,9 +45,9 @@ class CourseFactory(XModuleFactory):
     """
     Factory for XModule courses.
     """
-    org = factory.Sequence(lambda n: 'org.%d' % n)
-    number = factory.Sequence(lambda n: 'course_%d' % n)
-    display_name = factory.Sequence(lambda n: 'Run %d' % n)
+    org = factory.Sequence(lambda n: u'org.عربي_.%d' % n)
+    number = factory.Sequence(lambda n: u'course._عربي_%d' % n)
+    display_name = factory.Sequence(lambda n: u'Run عربي %d' % n)
 
     # pylint: disable=unused-argument
     @classmethod

--- a/common/lib/xmodule/xmodule/modulestore/tests/factories.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/factories.py
@@ -45,9 +45,9 @@ class CourseFactory(XModuleFactory):
     """
     Factory for XModule courses.
     """
-    org = factory.Sequence(lambda n: u'org.عربي_.%d' % n)
-    number = factory.Sequence(lambda n: u'course._عربي_%d' % n)
-    display_name = factory.Sequence(lambda n: u'Run عربي %d' % n)
+    org = factory.Sequence(lambda n: 'org.%d' % n)
+    number = factory.Sequence(lambda n: 'course_%d' % n)
+    display_name = factory.Sequence(lambda n: 'Run %d' % n)
 
     # pylint: disable=unused-argument
     @classmethod

--- a/common/lib/xmodule/xmodule/modulestore/tests/factories.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/factories.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import pprint
 import pymongo.message
 

--- a/common/lib/xmodule/xmodule/modulestore/tests/factories.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/factories.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pprint
 import pymongo.message
 
@@ -44,9 +45,9 @@ class CourseFactory(XModuleFactory):
     """
     Factory for XModule courses.
     """
-    org = factory.Sequence(lambda n: 'org.%d' % n)
-    number = factory.Sequence(lambda n: 'course_%d' % n)
-    display_name = factory.Sequence(lambda n: 'Run %d' % n)
+    org = factory.Sequence(lambda n: 'org.عربي.%d' % n)
+    number = factory.Sequence(lambda n: 'course_عربي_%d' % n)
+    display_name = factory.Sequence(lambda n: 'Run عربي %d' % n)
 
     # pylint: disable=unused-argument
     @classmethod


### PR DESCRIPTION
In the CMS, when opening a course that has an Arabic/Unicode value in it's components the exception bellow happens.
To fix it I've made the following:
- Added Arabic course values by default to all courses
- Fixed the issue by encoding the value before sending it to `urllib`
## Todo
- Make sure the test update actually detects the problem
- Make sure to fix all the raised exceptions because of this test change

---

```
Nov  2 12:15:37 ip-172-31-7-111 [service_variant=cms][root][env:sandbox] ERROR [ip-172-31-7-111  19754] [exceptions.py:9] - Uncaught exception from <class 'django.core.handlers.wsgi.WSGIHandler'>
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 109, in get_response
    response = callback(request, *callback_args, **callback_kwargs)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/contrib/auth/decorators.py", line 20, in _wrapped_view
    return view_func(request, *args, **kwargs)
  File "/edx/app/edxapp/edx-platform/cms/djangoapps/contentstore/views/course.py", line 233, in course_handler
    return course_index(request, CourseKey.from_string(course_key_string))
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/contrib/auth/decorators.py", line 20, in _wrapped_view
    return view_func(request, *args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/utils/decorators.py", line 91, in _wrapped_view
    response = view_func(request, *args, **kwargs)
  File "/edx/app/edxapp/edx-platform/cms/djangoapps/contentstore/views/course.py", line 436, in course_index
    course_structure = _course_outline_json(request, course_module)
  File "/edx/app/edxapp/edx-platform/cms/djangoapps/contentstore/views/course.py", line 272, in _course_outline_json
    include_children_predicate=lambda xblock: not xblock.category == 'vertical'
  File "/edx/app/edxapp/edx-platform/cms/djangoapps/contentstore/views/item.py", line 707, in create_xblock_info
    include_children_predicate=include_children_predicate,
  File "/edx/app/edxapp/edx-platform/cms/djangoapps/contentstore/views/item.py", line 891, in _create_xblock_child_info
    ) for child in xblock.get_children()
  File "/edx/app/edxapp/edx-platform/cms/djangoapps/contentstore/views/item.py", line 707, in create_xblock_info
    include_children_predicate=include_children_predicate,
  File "/edx/app/edxapp/edx-platform/cms/djangoapps/contentstore/views/item.py", line 891, in _create_xblock_child_info
    ) for child in xblock.get_children()
  File "/edx/app/edxapp/edx-platform/cms/djangoapps/contentstore/views/item.py", line 727, in create_xblock_info
    "studio_url": xblock_studio_url(xblock, parent_xblock),
  File "/edx/app/edxapp/edx-platform/cms/djangoapps/contentstore/views/helpers.py", line 107, in xblock_studio_url
    usage_key=urllib.quote(unicode(xblock.location))
  File "/usr/lib/python2.7/urllib.py", line 1268, in quote
    return ''.join(map(quoter, s))
KeyError: u'\u0625'
```
