### PR TITLE
Fix track selection header copy

### DIFF
--- a/lms/djangoapps/verify_student/tests/test_views.py
+++ b/lms/djangoapps/verify_student/tests/test_views.py
@@ -186,12 +186,12 @@ class TestVerifyView(ModuleStoreTestCase):
         response = self.client.get(url)
         self.assertEquals(response.status_code, 302)
 
-    def test_valid_course_registration_text(self):
+    def test_valid_course_enrollment_text(self):
         url = reverse('verify_student_verify',
                       kwargs={"course_id": unicode(self.course_key)})
         response = self.client.get(url)
 
-        self.assertIn("You are now enrolled in the audit track", response.content)
+        self.assertIn("You are now enrolled in", response.content)
 
     def test_valid_course_upgrade_text(self):
         url = reverse('verify_student_verify',

--- a/lms/templates/verify_student/_verification_header.html
+++ b/lms/templates/verify_student/_verification_header.html
@@ -3,18 +3,37 @@
 <header class="page-header">
     <h2 class="title">
         <span class="wrapper-sts">
+            <% organization = '<span class="sts-course-org">' + course_org + '</span>' %>
+            <% course_name = '<span class="sts-course-number">' + course_num + '</span> <span class="sts-course-name">' + 'course_name' + '</span>' %>
             % if upgrade:
-                <span class="sts-label">${_("You are upgrading your enrollment for")}</span>
+                <span class="sts-label">
+                    ${_("You are upgrading your enrollment for {organization}'s {course_name}").format(
+                        organization=organization,
+                        course_name=course_name
+                    )}
+                </span>
             % elif reverify:
-                <span class="sts-label">${_("You are re-verifying for")}</span>
+                <span class="sts-label">
+                    ${_("You are re-verifying for {organization}'s {course_name}").format(
+                        organization=organization,
+                        course_name=course_name
+                    )}
+                </span>
             % elif modes_dict and "professional" in modes_dict:
-                <span class="sts-label">${_("You are registering for")}</span>
+                <span class="sts-label">
+                    ${_("You are enrolling in {organization}'s {course_name}").format(
+                        organization=organization,
+                        course_name=course_name
+                    )}
+                </span>
             % else:
-                <span class="sts-label">${_("Congrats! You are now enrolled in the audit track")}</span>
+                <span class="sts-label">
+                    ${_("Congrats! You are now enrolled in {organization}'s {course_name}").format(
+                        organization=organization,
+                        course_name=course_name
+                    )}
+                </span>
             % endif
-                <span class="sts-course-org">${course_org}'s</span>
-                <span class="sts-course-number">${course_num}</span>
-                <span class="sts-course-name">${course_name}</span>
         </span>
 
         % if modes_dict and "professional" in modes_dict:
@@ -27,11 +46,20 @@
             <span class="sts-track">
                 <span class="sts-track-value">
                     % if upgrade:
-                        <span class="context">${_("Upgrading to:")}</span> ${_("Verified")}
+                        ${_("{span_start}Upgrading to:{span_end} Verified").format(
+                            span_start='<span class="context">',
+                            span_end='</span>'
+                        )}
                     % elif reverify:
-                        <span class="context">${_("Re-verifying for:")}</span> ${_("Verified")}
+                        ${_("{span_start}Re-verifying for:{span_end} Verified").format(
+                            span_start='<span class="context">',
+                            span_end='</span>'
+                        )}
                     % else:
-                        <span class="context">${_("Registering as: ")}</span> ${_("Verified")}
+                        ${_("{span_start}Enrolling as:{span_end} Verified").format(
+                            span_start='<span class="context">',
+                            span_end='</span>'
+                        )}
                     % endif
                 </span>
             </span>


### PR DESCRIPTION
@AlasdairSwan and @dianakhuang, I noticed a pretty visible error in the copy displayed in the header on the track selection page. Currently, after enrolling in, for example, FooX's Course 6, it reads "Congrats! You are now enrolled in the audit track FooX's Course 6" [sic]. This should instead read something like "Congrats! You are now enrolled in FooX's Course 6." (Excluding mention of any enrollment track in this copy is also more consistent with the rest of the page, since track selection is meant to occur on this page, not before it; "Now choose your course track" is displayed immediately below this line.)

I'm not sure if this issue is urgent enough to warrant a PR against the RC, but Griff suggested that we should fix it quickly, if possible; this change is also very low risk.

@dan-f, FYI. 
