### PR TITLE
change djfs settings not to throw an error when the app starts up

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -215,7 +215,8 @@ with open(CONFIG_ROOT / CONFIG_PREFIX + "auth.json") as auth_file:
     AUTH_TOKENS = json.load(auth_file)
 
 ############### XBlock filesystem field config ##########
-DJFS = AUTH_TOKENS.get('DJFS', None)
+if 'DJFS' in AUTH_TOKENS and AUTH_TOKENS['DJFS'] is not None:
+    DJFS = AUTH_TOKENS['DJFS']
 
 EMAIL_HOST_USER = AUTH_TOKENS.get('EMAIL_HOST_USER', EMAIL_HOST_USER)
 EMAIL_HOST_PASSWORD = AUTH_TOKENS.get('EMAIL_HOST_PASSWORD', EMAIL_HOST_PASSWORD)


### PR DESCRIPTION
@singingwolfboy  
@feanil 

Can we merge this in so that sandbox builds don't fail? 
http://jenkins.edx.org:8080/job/connect-sandbox-to-prod-clone/122/console
