### PR TITLE
Fix split test unicode issues

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -1291,7 +1291,7 @@ class GroupConfiguration(object):
                 course.location.course_key.make_usage_key(unit.location.block_type, unit.location.name)
             )
             usage_info[split_test.user_partition_id].append({
-                'label': '{} / {}'.format(unit.display_name, split_test.display_name),
+                'label': u'{} / {}'.format(unit.display_name, split_test.display_name),
                 'url': unit_url,
                 'validation': split_test.general_validation_message,
             })

--- a/lms/templates/split_test_author_view.html
+++ b/lms/templates/split_test_author_view.html
@@ -19,7 +19,7 @@ show_link = group_configuration_url is not None
         <p>
             <span class="message-text">
                 ${_("This content experiment uses group configuration '{group_configuration_name}'.").format(
-                    group_configuration_name="<a href='{}'>{}</a>".format(group_configuration_url, user_partition.name) if show_link else user_partition.name
+                    group_configuration_name=u"<a href='{}'>{}</a>".format(group_configuration_url, user_partition.name) if show_link else user_partition.name
                 )}
             </span>
         </p>


### PR DESCRIPTION
Unicode error would happen when unit name contained non-ascii characters.
