### PR TITLE
Fixed youtube stub server and removed unused variable.

### DIFF
--- a/common/djangoapps/terrain/stubs/tests/test_youtube_stub.py
+++ b/common/djangoapps/terrain/stubs/tests/test_youtube_stub.py
@@ -4,7 +4,7 @@ Unit test for stub YouTube implementation.
 
 import unittest
 import requests
-from ..youtube import StubYouTubeService, IFRAME_API_RESPONSE
+from ..youtube import StubYouTubeService
 
 
 class StubYouTubeServiceTest(unittest.TestCase):

--- a/common/djangoapps/terrain/stubs/youtube.py
+++ b/common/djangoapps/terrain/stubs/youtube.py
@@ -24,7 +24,7 @@ from urlparse import urlparse
 from collections import OrderedDict
 
 
-IFRAME_API_RESPONSE = requests.get('https://www.youtube.com/iframe_api').content.strip("\n")
+IFRAME_API_RESPONSE = None
 
 
 class StubYouTubeHandler(StubHttpRequestHandler):
@@ -50,6 +50,11 @@ class StubYouTubeHandler(StubHttpRequestHandler):
         """
         Handle a GET request from the client and sends response back.
         """
+
+        # Initialize only once if IFRAME_API_RESPONSE is none.
+        global IFRAME_API_RESPONSE  # pylint: disable=W0603
+        if IFRAME_API_RESPONSE is None:
+            IFRAME_API_RESPONSE = requests.get('https://www.youtube.com/iframe_api').content.strip("\n")
 
         self.log_message(
             "Youtube provider received GET request to path {}".format(self.path)


### PR DESCRIPTION
Ticket: [TNL-778](https://openedx.atlassian.net/browse/TNL-778)

If youtube is not available then on importing StubYouTubeService it raises ConnectionError exception.

This needs to be fixed because when youtube is not available and we run lettuce test in which youtube stub server is not used then it raises this exception and we can't run tests.

One of the usages of `_enroll` haven't been updated: `test_course_serializer_with_display_overrides`, fixed it too.
