### PR TITLE
Remove multi-threading test as unnecessary and flakey

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -855,15 +855,14 @@ class MiscCourseTests(ContentStoreTestCase):
         self.assertContains(resp, unicode(asset_key))
 
     def test_prefetch_children(self):
-        # make sure we haven't done too many round trips to DB
-        # note we say 4 round trips here for:
+        # make sure we haven't done too many round trips to DB:
         # 1) the course,
         # 2 & 3) for the chapters and sequentials
         # Because we're querying from the top of the tree, we cache information needed for inheritance,
         # so we don't need to make an extra query to compute it.
         # set the branch to 'publish' in order to prevent extra lookups of draft versions
         with self.store.branch_setting(ModuleStoreEnum.Branch.published_only, self.course.id):
-            with check_mongo_calls(3, 0):
+            with check_mongo_calls(3):
                 course = self.store.get_course(self.course.id, depth=2)
 
             # make sure we pre-fetched a known sequential which should be at depth=2
@@ -875,7 +874,7 @@ class MiscCourseTests(ContentStoreTestCase):
         # Now, test with the branch set to draft. No extra round trips b/c it doesn't go deep enough to get
         # beyond direct only categories
         with self.store.branch_setting(ModuleStoreEnum.Branch.draft_preferred, self.course.id):
-            with check_mongo_calls(3, 0):
+            with check_mongo_calls(3):
                 self.store.get_course(self.course.id, depth=2)
 
     def _check_verticals(self, locations):

--- a/cms/djangoapps/contentstore/views/tests/test_course_index.py
+++ b/cms/djangoapps/contentstore/views/tests/test_course_index.py
@@ -8,20 +8,17 @@ import datetime
 from contentstore.tests.utils import CourseTestCase
 from contentstore.utils import reverse_course_url, add_instructor
 from contentstore.views.access import has_course_access
-from contentstore.views.course import course_outline_initial_state, _course_outline_json
+from contentstore.views.course import course_outline_initial_state
 from contentstore.views.item import create_xblock_info, VisibilityState
 from course_action_state.models import CourseRerunState
 from util.date_utils import get_default_time_display
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, check_mongo_calls, \
-    mongo_uses_error_check
+from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 from opaque_keys.edx.locator import CourseLocator
 from student.tests.factories import UserFactory
 from course_action_state.managers import CourseRerunUIStateManager
 from django.conf import settings
-import ddt
-import threading
 import pytz
 
 
@@ -312,28 +309,3 @@ class TestCourseOutline(CourseTestCase):
 
         self.assertEqual(_get_release_date(response), get_default_time_display(self.course.start))
         _assert_settings_link_present(response)
-
-
-@ddt.ddt
-class OutlinePerfTest(TestCourseOutline):
-    def setUp(self):
-        with modulestore().default_store(ModuleStoreEnum.Type.split):
-            super(OutlinePerfTest, self).setUp()
-
-    @ddt.data(1, 2, 4, 8)
-    def test_query_counts(self, num_threads):
-        """
-        Test that increasing threads does not increase query counts
-        """
-        def test_client():
-            with modulestore().default_store(ModuleStoreEnum.Type.split):
-                with modulestore().bulk_operations(self.course.id):
-                    course = modulestore().get_course(self.course.id, depth=0)
-                    return _course_outline_json(None, course)
-
-        per_thread = 4
-        with check_mongo_calls(per_thread * num_threads, 0):
-            outline_threads = [threading.Thread(target=test_client) for __ in xrange(num_threads)]
-            [thread.start() for thread in outline_threads]
-            # now wait until they all finish
-            [thread.join() for thread in outline_threads]

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -384,7 +384,7 @@ class TestTOC(ModuleStoreTestCase):
                             'format': '', 'due': None, 'active': False}],
                           'url_name': 'secret:magic', 'display_name': 'secret:magic'}])
 
-            with check_mongo_calls(toc_finds, 0):
+            with check_mongo_calls(toc_finds):
                 actual = render.toc_for_course(
                     self.request.user, self.request, self.toy_course, self.chapter, None, self.field_data_cache
                 )
@@ -423,7 +423,7 @@ class TestTOC(ModuleStoreTestCase):
                             'format': '', 'due': None, 'active': False}],
                           'url_name': 'secret:magic', 'display_name': 'secret:magic'}])
 
-            with check_mongo_calls(toc_finds, 0):
+            with check_mongo_calls(toc_finds):
                 actual = render.toc_for_course(self.request.user, self.request, self.toy_course, self.chapter, section, self.field_data_cache)
             for toc_section in expected:
                 self.assertIn(toc_section, actual)


### PR DESCRIPTION
also fix other users of check_mongo_calls to use None if they don't care about sends
PLAT-239

@jzoldak plz review
