### PR TITLE
Updated so is submission prevented by JS due to errors it scrolls to the...

### DIFF
--- a/lms/static/js/student_account/views/FormView.js
+++ b/lms/static/js/student_account/views/FormView.js
@@ -179,6 +179,11 @@ var edx = edx || {};
             $msg.html( html.join('') );
 
             this.element.show( this.$errors );
+
+            // Scroll to error messages
+            $('html,body').animate({
+                scrollTop: this.$errors.offset().top
+            },'slow');
         },
 
         submitForm: function( event ) {


### PR DESCRIPTION
... error messages @rlucioni @wedaly Updated so if JS validation prevents form submission it scrolls up to show the error messages. Without this on mobile it is not obvious what is happening.
