### PR TITLE
TNL-660: Toggle single note visibility.

### DIFF
--- a/common/test/acceptance/pages/lms/edxnotes.py
+++ b/common/test/acceptance/pages/lms/edxnotes.py
@@ -212,6 +212,8 @@ class EdxNoteHighlight(NoteChild):
     """
     BODY_SELECTOR = ""
     ADDER_SELECTOR = ".annotator-adder"
+    VIEWER_SELECTOR = ".annotator-viewer"
+    EDITOR_SELECTOR = ".annotator-editor"
 
     def __init__(self, browser, element, parent_id):
         super(EdxNoteHighlight, self).__init__(browser, parent_id)
@@ -224,8 +226,8 @@ class EdxNoteHighlight(NoteChild):
         """
         Returns True if the note is visible.
         """
-        viewer_is_visible = self.q(css=self._bounded_selector(".annotator-viewer")).visible
-        editor_is_visible = self.q(css=self._bounded_selector(".annotator-editor")).visible
+        viewer_is_visible = self.q(css=self._bounded_selector(self.VIEWER_SELECTOR)).visible
+        editor_is_visible = self.q(css=self._bounded_selector(self.EDITOR_SELECTOR)).visible
         return viewer_is_visible or editor_is_visible
 
     def wait_for_adder_visibility(self):
@@ -241,7 +243,7 @@ class EdxNoteHighlight(NoteChild):
         Waiting for visibility of note viewer.
         """
         self.wait_for_element_visibility(
-            self._bounded_selector(".annotator-viewer"), "Note Viewer is visible."
+            self._bounded_selector(self.VIEWER_SELECTOR), "Note Viewer is visible."
         )
 
     def wait_for_editor_visibility(self):
@@ -249,7 +251,7 @@ class EdxNoteHighlight(NoteChild):
         Waiting for visibility of note editor.
         """
         self.wait_for_element_visibility(
-            self._bounded_selector(".annotator-editor"), "Note Editor is visible."
+            self._bounded_selector(self.EDITOR_SELECTOR), "Note Editor is visible."
         )
 
     def wait_for_notes_invisibility(self, text="Notes are hidden"):
@@ -278,9 +280,9 @@ class EdxNoteHighlight(NoteChild):
 
     def click_on_viewer(self):
         """
-        Clicks on the highlighted text.
+        Clicks on the note viewer.
         """
-        self.q(css=self._bounded_selector(".annotator-editor")).first.click()
+        self.q(css=self._bounded_selector(self.VIEWER_SELECTOR)).first.click()
         return self
 
     def show(self):

--- a/common/test/acceptance/pages/lms/edxnotes.py
+++ b/common/test/acceptance/pages/lms/edxnotes.py
@@ -120,6 +120,21 @@ class EdxNotesUnitPage(CoursePage):
     def is_browser_on_page(self):
         return self.q(css="body.courseware .edx-notes-wrapper").present
 
+    def move_mouse_to(self, selector):
+        """
+        Moves mouse to the element that matches `selector(str)`.
+        """
+        body = self.q(css=selector)[0]
+        ActionChains(self.browser).move_to_element(body).release().perform()
+        return self
+
+    def click(self, selector):
+        """
+        Clicks on the element that matches `selector(str)`.
+        """
+        self.q(css=selector).first.click()
+        return self
+
     @property
     def components(self):
         """
@@ -204,6 +219,15 @@ class EdxNoteHighlight(NoteChild):
         self.item_id = parent_id
         disable_animations(self)
 
+    @property
+    def is_visible(self):
+        """
+        Returns True if the note is visible.
+        """
+        viewer_is_visible = self.q(css=self._bounded_selector(".annotator-viewer")).visible
+        editor_is_visible = self.q(css=self._bounded_selector(".annotator-editor")).visible
+        return viewer_is_visible or editor_is_visible
+
     def wait_for_adder_visibility(self):
         """
         Waiting for visibility of note adder button.
@@ -243,6 +267,20 @@ class EdxNoteHighlight(NoteChild):
         self.wait_for_adder_visibility()
         self.q(css=self._bounded_selector(self.ADDER_SELECTOR)).first.click()
         self.wait_for_editor_visibility()
+        return self
+
+    def click_on_highlight(self):
+        """
+        Clicks on the highlighted text.
+        """
+        ActionChains(self.browser).move_to_element(self.element).click().release().perform()
+        return self
+
+    def click_on_viewer(self):
+        """
+        Clicks on the highlighted text.
+        """
+        self.q(css=self._bounded_selector(".annotator-editor")).first.click()
         return self
 
     def show(self):

--- a/common/test/acceptance/pages/lms/edxnotes.py
+++ b/common/test/acceptance/pages/lms/edxnotes.py
@@ -160,7 +160,7 @@ class AnnotatableComponent(NoteChild):
         notes = self.q(css=self._bounded_selector(".annotator-hl"))
         return [EdxNoteHighlight(self.browser, note, self.item_id) for note in notes]
 
-    def create_note(self, selector=".annotator-hl"):
+    def create_note(self, selector=".annotate-id"):
         """
         Create the note by the selector, return a context manager that will
         show and save the note popup.

--- a/common/test/acceptance/tests/helpers.py
+++ b/common/test/acceptance/tests/helpers.py
@@ -9,6 +9,7 @@ import os
 from path import path
 from bok_choy.web_app_test import WebAppTest
 from opaque_keys.edx.locator import CourseLocator
+from bok_choy.javascript import js_defined
 
 
 def skip_if_browser(browser):
@@ -90,6 +91,7 @@ def enable_animations(page):
     enable_css_animations(page)
 
 
+@js_defined('window.jQuery')
 def disable_jquery_animations(page):
     """
     Disable jQuery animations.
@@ -97,6 +99,7 @@ def disable_jquery_animations(page):
     page.browser.execute_script("jQuery.fx.off = true;")
 
 
+@js_defined('window.jQuery')
 def enable_jquery_animations(page):
     """
     Enable jQuery animations.

--- a/common/test/acceptance/tests/lms/test_lms_edxnotes.py
+++ b/common/test/acceptance/tests/lms/test_lms_edxnotes.py
@@ -88,7 +88,7 @@ class EdxNotesTest(UniqueCourseTest):
         self.assertGreater(len(components), 0)
         index = offset
         for component in components:
-            for note in component.create_note(".annotator-hl"):
+            for note in component.create_note(".annotate-id"):
                 note.text = "TEST TEXT {}".format(index)
                 index += 1
 

--- a/common/test/acceptance/tests/lms/test_lms_edxnotes.py
+++ b/common/test/acceptance/tests/lms/test_lms_edxnotes.py
@@ -117,7 +117,7 @@ class EdxNotesTest(UniqueCourseTest):
             actual = [note.text for note in component.notes]
             expected = ["TEST TEXT {}".format(i + index) for i in xrange(len(actual))]
             index += len(actual)
-            self.assertItemsEqual(expected, actual)
+            self.assertEqual(set(expected), set(actual))
 
     def test_can_create_notes(self):
         """

--- a/common/test/acceptance/tests/lms/test_lms_edxnotes.py
+++ b/common/test/acceptance/tests/lms/test_lms_edxnotes.py
@@ -93,7 +93,7 @@ class EdxNotesDefaultInteractionsTest(EdxNotesTestMixin):
         self.assertGreater(len(components), 0)
         index = offset
         for component in components:
-            for note in component.create_note(".annotate-id"):
+            for note in component.create_note(".{}".format(self.selector)):
                 note.text = "TEST TEXT {}".format(index)
                 index += 1
 
@@ -402,7 +402,7 @@ class EdxNotesToggleSingleNoteTest(EdxNotesTestMixin):
     def setUp(self):
         super(EdxNotesToggleSingleNoteTest, self).setUp()
         self._add_notes()
-        self.note_page.visit()
+        self.note_unit_page.visit()
 
     def test_can_toggle_by_clicking_on_highlighted_text(self):
         """
@@ -414,12 +414,12 @@ class EdxNotesToggleSingleNoteTest(EdxNotesTestMixin):
         When I click outside the note
         Then I see the the note is closed
         """
-        note = self.note_page.notes[0]
+        note = self.note_unit_page.notes[0]
 
         note.click_on_highlight()
-        self.note_page.move_mouse_to('body')
+        self.note_unit_page.move_mouse_to('body')
         self.assertTrue(note.is_visible)
-        self.note_page.click('body')
+        self.note_unit_page.click('body')
         self.assertFalse(note.is_visible)
 
     def test_can_toggle_by_clicking_on_the_note(self):
@@ -432,12 +432,12 @@ class EdxNotesToggleSingleNoteTest(EdxNotesTestMixin):
         When I click outside the note
         Then I see the the note is closed
         """
-        note = self.note_page.notes[0]
+        note = self.note_unit_page.notes[0]
 
         note.show().click_on_viewer()
-        self.note_page.move_mouse_to('body')
+        self.note_unit_page.move_mouse_to('body')
         self.assertTrue(note.is_visible)
-        self.note_page.click('body')
+        self.note_unit_page.click('body')
         self.assertFalse(note.is_visible)
 
     def test_interaction_between_notes(self):
@@ -452,11 +452,11 @@ class EdxNotesToggleSingleNoteTest(EdxNotesTestMixin):
         When I click again on highlighted text in the second component
         Then I see appropriate note
         """
-        note_1 = self.note_page.notes[0]
-        note_2 = self.note_page.notes[1]
+        note_1 = self.note_unit_page.notes[0]
+        note_2 = self.note_unit_page.notes[1]
 
         note_1.click_on_highlight()
-        self.note_page.move_mouse_to('body')
+        self.note_unit_page.move_mouse_to('body')
         self.assertTrue(note_1.is_visible)
 
         note_2.click_on_highlight()

--- a/common/test/acceptance/tests/lms/test_lms_edxnotes.py
+++ b/common/test/acceptance/tests/lms/test_lms_edxnotes.py
@@ -9,16 +9,16 @@ from ...pages.lms.edxnotes import EdxNotesUnitPage, EdxNotesPage
 from ...fixtures.edxnotes import EdxNotesFixture, Note, Range
 
 
-class EdxNotesTest(UniqueCourseTest):
+class EdxNotesTestMixin(UniqueCourseTest):
     """
-    Tests for annotation inside HTML components in LMS.
+    Creates a course with initial data and contains useful helper methods.
     """
-
     def setUp(self):
         """
         Initialize pages and install a course fixture.
         """
-        super(EdxNotesTest, self).setUp()
+        super(EdxNotesTestMixin, self).setUp()
+        self.courseware_page = CoursewarePage(self.browser, self.course_id)
         self.course_nav = CourseNavPage(self.browser)
         self.note_unit_page = EdxNotesUnitPage(self.browser, self.course_id)
         self.notes_page = EdxNotesPage(self.browser, self.course_id)
@@ -84,6 +84,11 @@ class EdxNotesTest(UniqueCourseTest):
         self.edxnotes_fixture.create_notes(notes_list)
         self.edxnotes_fixture.install()
 
+
+class EdxNotesDefaultInteractionsTest(EdxNotesTestMixin):
+    """
+    Tests for creation, editing, deleting annotations inside annotatable components in LMS.
+    """
     def create_notes(self, components, offset=0):
         self.assertGreater(len(components), 0)
         index = offset
@@ -122,12 +127,12 @@ class EdxNotesTest(UniqueCourseTest):
     def test_can_create_notes(self):
         """
         Scenario: User can create notes.
-        Given I have a course with 3 annotatatble components
-        And I open the unit with 2 annotatatble components
+        Given I have a course with 3 annotatable components
+        And I open the unit with 2 annotatable components
         When I add 2 notes for the first component and 1 note for the second
         Then I see that notes were correctly created
         When I change sequential position to "2"
-        And I add note for the annotatatble component on the page
+        And I add note for the annotatable component on the page
         Then I see that note was correctly created
         When I refresh the page
         Then I see that note was correctly stored
@@ -157,7 +162,7 @@ class EdxNotesTest(UniqueCourseTest):
         """
         Scenario: User can edit notes.
         Given I have a course with 3 components with notes
-        And I open the unit with 2 annotatatble components
+        And I open the unit with 2 annotatable components
         When I change text in the notes
         Then I see that notes were correctly changed
         When I change sequential position to "2"
@@ -192,7 +197,7 @@ class EdxNotesTest(UniqueCourseTest):
         """
         Scenario: User can delete notes.
         Given I have a course with 3 components with notes
-        And I open the unit with 2 annotatatble components
+        And I open the unit with 2 annotatable components
         When I remove all notes on the page
         Then I do not see any notes on the page
         When I change sequential position to "2"
@@ -387,3 +392,76 @@ class EdxNotesPageTest(UniqueCourseTest):
         item.go_to_unit()
         self.courseware_page.wait_for_page()
         self.assertIn(text, self.courseware_page.xblock_component_html_content())
+
+
+class EdxNotesToggleSingleNoteTest(EdxNotesTestMixin):
+    """
+    Tests for toggling single annotation.
+    """
+
+    def setUp(self):
+        super(EdxNotesToggleSingleNoteTest, self).setUp()
+        self._add_notes()
+        self.note_page.visit()
+
+    def test_can_toggle_by_clicking_on_highlighted_text(self):
+        """
+        Scenario: User can toggle a single note by clicking on highlighted text.
+        Given I have a course with components with notes
+        When I click on highlighted text
+        And I move mouse out of the note
+        Then I see that the note is still shown
+        When I click outside the note
+        Then I see the the note is closed
+        """
+        note = self.note_page.notes[0]
+
+        note.click_on_highlight()
+        self.note_page.move_mouse_to('body')
+        self.assertTrue(note.is_visible)
+        self.note_page.click('body')
+        self.assertFalse(note.is_visible)
+
+    def test_can_toggle_by_clicking_on_the_note(self):
+        """
+        Scenario: User can toggle a single note by clicking on the note.
+        Given I have a course with components with notes
+        When I click on the note
+        And I move mouse out of the note
+        Then I see that the note is still shown
+        When I click outside the note
+        Then I see the the note is closed
+        """
+        note = self.note_page.notes[0]
+
+        note.show().click_on_viewer()
+        self.note_page.move_mouse_to('body')
+        self.assertTrue(note.is_visible)
+        self.note_page.click('body')
+        self.assertFalse(note.is_visible)
+
+    def test_interaction_between_notes(self):
+        """
+        Scenario: Interactions between notes works well.
+        Given I have a course with components with notes
+        When I click on highlighted text in the first component
+        And I move mouse out of the note
+        Then I see that the note is still shown
+        When I click on highlighted text in the second component
+        Then I do not see any notes
+        When I click again on highlighted text in the second component
+        Then I see appropriate note
+        """
+        note_1 = self.note_page.notes[0]
+        note_2 = self.note_page.notes[1]
+
+        note_1.click_on_highlight()
+        self.note_page.move_mouse_to('body')
+        self.assertTrue(note_1.is_visible)
+
+        note_2.click_on_highlight()
+        self.assertFalse(note_1.is_visible)
+        self.assertFalse(note_2.is_visible)
+
+        note_2.click_on_highlight()
+        self.assertTrue(note_2.is_visible)

--- a/lms/static/js/edxnotes/views/shim.js
+++ b/lms/static/js/edxnotes/views/shim.js
@@ -4,6 +4,25 @@
         var _t = Annotator._t;
 
         /**
+         * We currently run JQuery 1.7.2 in Jasmine tests and LMS.
+         * AnnotatorJS 1.2.9. uses two calls to addBack (in the two functions
+         * 'isAnnotator' and 'onHighlightMouseover') which was only defined in
+         * JQuery 1.8.0. In LMS, it works without throwing an error because
+         * JQuery.UI 1.10.0 adds support to jQuery<1.8 by augmenting '$.fn' with
+         * that missing function. It is not the case for all Jasmine unit tests,
+         * so we add it here if necessary.
+         **/
+        if (!$.fn.addBack) {
+            $.fn.addBack = function(selector) {
+                return this.add(selector === null ?
+                        this.prevObject : this.prevObject.filter(selector)
+                );
+            };
+        }
+
+        Annotator.frozenSrc = null;
+
+        /**
          * Modifies Annotator.highlightRange to add a "tabindex=0" attribute
          * to the <span class="annotator-hl"> markup that encloses the note.
          * These are then focusable via the TAB key.
@@ -14,6 +33,25 @@
                 return results;
             },
             Annotator.prototype.highlightRange
+        );
+
+        /**
+         * Modifies Annotator.destroy to unbind click.edxnotes:freeze from the
+         * document and reset isFrozen to default value, false.
+         **/
+        Annotator.prototype.destroy = _.compose(
+            Annotator.prototype.destroy,
+            function () {
+                // We are destroying the instance that has the popup visible, revert to default,
+                // unfreeze all instances and set their isFrozen to false
+                if (this === Annotator.frozenSrc) {
+                    _.invoke(Annotator._instances, 'unfreeze');
+                } else {
+                    // Unfreeze only this instance and unbound associated 'click.edxnotes:freeze' handler
+                    $(document).off('click.edxnotes:freeze'+this.uid);
+                    this.isFrozen = false;
+                }
+            }
         );
 
         /**
@@ -35,5 +73,61 @@
               '</span>',
             '</li>'
         ].join('');
+
+        $.extend(true, Annotator.prototype, {
+            events: {
+                '.annotator-hl click': 'onHighlightClick',
+                '.annotator-viewer click': 'onNoteClick'
+            },
+
+            isFrozen: false,
+            uid: _.uniqueId(),
+
+            onHighlightClick: function (event) {
+                Annotator.Util.preventEventDefault(event);
+
+                if (!this.isFrozen) {
+                    event.stopPropagation();
+                    this.onHighlightMouseover.call(this, event);
+                }
+                Annotator.frozenSrc = this;
+                _.invoke(Annotator._instances, 'freeze');
+            },
+
+            onNoteClick: function (event) {
+                event.stopPropagation();
+                Annotator.Util.preventEventDefault(event);
+                if (!$(event.target).is('.annotator-delete')) {
+                    Annotator.frozenSrc = this;
+                    _.invoke(Annotator._instances, 'freeze');
+                }
+            },
+
+            freeze: function() {
+                if (!this.isFrozen) {
+                    // Remove default events
+                    this.removeEvents();
+                    this.viewer.element.unbind('mouseover mouseout');
+                    this.uid = _.uniqueId();
+                    $(document).on('click.edxnotes:freeze'+this.uid, this.unfreeze.bind(this));
+                    this.isFrozen = true;
+                }
+            },
+
+            unfreeze: function() {
+                if (this.isFrozen) {
+                    // Add default events
+                    this.addEvents();
+                    this.viewer.element.bind({
+                        'mouseover': this.clearViewerHideTimer,
+                        'mouseout':  this.startViewerHideTimer
+                    });
+                    this.viewer.hide();
+                    $(document).off('click.edxnotes:freeze'+this.uid);
+                    this.isFrozen = false;
+                    Annotator.frozenSrc = null;
+                }
+            }
+        });
     });
 }).call(this, define || RequireJS.define, jQuery, _);

--- a/lms/static/js/fixtures/edxnotes/edxnotes.html
+++ b/lms/static/js/fixtures/edxnotes/edxnotes.html
@@ -1,3 +1,6 @@
 <div id="edx-notes-wrapper-123" class="edx-notes-wrapper">
     Annotate it!
 </div>
+<div id="edx-notes-wrapper-456" class="edx-notes-wrapper">
+    Annotate it!
+</div>

--- a/lms/static/js/spec/edxnotes/shim_spec.js
+++ b/lms/static/js/spec/edxnotes/shim_spec.js
@@ -1,0 +1,111 @@
+define(['jquery', 'underscore', 'js/edxnotes/notes', 'jasmine-jquery'],
+    function($, _, Notes) {
+        'use strict';
+
+        describe('Test Shim', function() {
+            var annotators = [], highlights = [];
+
+            function checkAnnotatorIsFrozen(annotator) {
+                expect(annotator.isFrozen).toBe(true);
+                expect(annotator.onHighlightMouseover).not.toHaveBeenCalled();
+                expect(annotator.startViewerHideTimer).not.toHaveBeenCalled();
+            }
+
+            function checkAnnotatorIsUnfrozen(annotator) {
+                expect(annotator.isFrozen).toBe(false);
+                expect(annotator.onHighlightMouseover).toHaveBeenCalled();
+                expect(annotator.startViewerHideTimer).toHaveBeenCalled();
+            }
+
+            function checkClickEventsNotBound(namespace) {
+                var events = $._data(document, 'events').click;
+
+                _.each(events, function(event) {
+                    expect(event.namespace.indexOf(namespace)).toBeGreaterThan(-1);
+                });
+            }
+
+            beforeEach(function() {
+                loadFixtures('js/fixtures/edxnotes/edxnotes.html');
+                highlights = [];
+                annotators = [
+                    Notes.factory($('div#edx-notes-wrapper-123').get(0), {}),
+                    Notes.factory($('div#edx-notes-wrapper-456').get(0), {})
+                ];
+                _.each(annotators, function(annotator, index) {
+                    highlights.push($('<span class="annotator-hl" />').appendTo(annotators[index].element));
+                    spyOn(annotator, 'onHighlightClick').andCallThrough();
+                    spyOn(annotator, 'onHighlightMouseover').andCallThrough();
+                    spyOn(annotator, 'startViewerHideTimer').andCallThrough();
+                });
+            });
+
+            it('Test that clicking a highlight freezes mouseover and mouseout in all highlighted text', function() {
+                _.each(annotators, function(annotator) {
+                    expect(annotator.isFrozen).toBe(false);
+                });
+                highlights[0].click();
+                // Click is attached to the onHighlightClick event handler which
+                // in turn calls onHighlightMouseover.
+                // To test if onHighlightMouseover is called or not on
+                // mouseover, we'll have to reset onHighlightMouseover.
+                expect(annotators[0].onHighlightClick).toHaveBeenCalled();
+                expect(annotators[0].onHighlightMouseover).toHaveBeenCalled();
+                annotators[0].onHighlightMouseover.reset();
+
+                // Check that both instances of annotator are frozen
+                _.invoke(highlights, 'mouseover');
+                _.invoke(highlights, 'mouseout');
+                _.each(annotators, function(annotator) {
+                    checkAnnotatorIsFrozen(annotator);
+                });
+            });
+
+            it('Test that clicking twice reverts to default behavior', function() {
+                highlights[0].click();
+                $(document).click();
+                annotators[0].onHighlightMouseover.reset();
+
+                // Check that both instances of annotator are unfrozen
+                _.invoke(highlights, 'mouseover');
+                _.invoke(highlights, 'mouseout');
+                _.each(annotators, function(annotator) {
+                    checkAnnotatorIsUnfrozen(annotator);
+                });
+            });
+
+            it('Test that destroying an instance with an open viewer sets all other instances' +
+               'to unfrozen and unbinds document click.edxnotes:freeze event handlers', function() {
+                // Freeze all instances
+                highlights[0].click();
+                // Destroy first instance
+                annotators[0].destroy();
+
+                // Check that all click.edxnotes:freeze are unbound
+                checkClickEventsNotBound('edxnotes:freeze');
+
+                // Check that the remaining instance is unfrozen
+                highlights[1].mouseover();
+                highlights[1].mouseout();
+                checkAnnotatorIsUnfrozen(annotators[1]);
+            });
+
+            it('Test that destroying an instance with an closed viewer only unfreezes that instance' +
+               'and unbinds one document click.edxnotes:freeze event handlers', function() {
+                // Freeze all instances
+                highlights[0].click();
+                annotators[0].onHighlightMouseover.reset();
+                // Destroy second instance
+                annotators[1].destroy();
+
+                // Check that the first instance is frozen
+                highlights[0].mouseover();
+                highlights[0].mouseout();
+                checkAnnotatorIsFrozen(annotators[0]);
+
+                // Check that second one doesn't have a bound click.edxnotes:freeze
+                checkClickEventsNotBound('edxnotes:freeze'+annotators[1].uid);
+            });
+        });
+    }
+);

--- a/lms/static/js/spec/main.js
+++ b/lms/static/js/spec/main.js
@@ -396,6 +396,9 @@
         'lms/include/js/spec/edxnotes/notes_spec.js',
         'lms/include/js/spec/edxnotes/utils/logger_spec.js',
         'lms/include/js/spec/edxnotes/views/notes_page_spec.js'
+        'lms/include/js/spec/edxnotes/logger_spec.js',
+        'lms/include/js/spec/edxnotes/notes_spec.js',
+        'lms/include/js/spec/edxnotes/shim_spec.js'
     ]);
 
 }).call(this, requirejs, define);


### PR DESCRIPTION
**[Jira ticket - TNL-660](https://openedx.atlassian.net/browse/TNL-660)**

**Acceptance Criteria:**
As a student, if I can already see my markup, I want to show or hide a note on the unit I'm viewing.
- When you hover over a markup, the note associated with that markup should be shown.
- When you click on a markup, that note should stay open until the note is closed.

**[Sandbox](http://polesye.m.sandbox.edx.org)**

@explorerleslie FYI.
@tymofij @olmar Please review.
