### PR TITLE
Logistration: Use href in marketing link if available to make A/B testing easier

### DIFF
--- a/lms/templates/courseware/mktg_course_about.html
+++ b/lms/templates/courseware/mktg_course_about.html
@@ -29,7 +29,7 @@
           window.top.location.href = "${reverse('dashboard')}";
         }
       } else if (xhr.status == 403) {
-        window.top.location.href = "${reverse('register_user')}?course_id=${course.id | u}&enrollment_action=enroll";
+        window.top.location.href = $("a.register").attr("href") || "${reverse('register_user')}?course_id=${course.id | u}&enrollment_action=enroll";
       } else {
         $('#register_error').html(
             (xhr.responseText ? xhr.responseText : "${_("An error occurred. Please try again later.")}")


### PR DESCRIPTION
We're currently hard-coding the "register user" link the JavaScript on the marketing button iframe.  For an A/B test, I'm going to need to rewrite this URL to point to the login page instead of register.

Since we're already writing the "register user" URL to the href of the register button link, I've modified the JS to prefer that href.  I can then overwrite the href using JavaScript injected by Optimizely.

@dianakhuang @rlucioni please review.
