### PR TITLE
Correct unresolved ugettext_lazy error strings in git_export command

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/git_export.py
+++ b/cms/djangoapps/contentstore/management/commands/git_export.py
@@ -62,7 +62,7 @@ class Command(BaseCommand):
             try:
                 course_key = SlashSeparatedCourseKey.from_deprecated_string(args[0])
             except InvalidKeyError:
-                raise CommandError(GitExportError.BAD_COURSE)
+                raise CommandError(_(GitExportError.BAD_COURSE))
 
         try:
             git_export_utils.export_to_git(
@@ -72,4 +72,4 @@ class Command(BaseCommand):
                 options.get('rdir', None)
             )
         except git_export_utils.GitExportError as ex:
-            raise CommandError(str(ex))
+            raise CommandError(_(ex.message))

--- a/cms/djangoapps/contentstore/management/commands/tests/test_git_export.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_git_export.py
@@ -80,6 +80,34 @@ class TestGitExport(CourseTestCase):
                              stderr=StringIO.StringIO())
         self.assertEqual(ex.exception.code, 1)
 
+    def test_error_output(self):
+        """
+        Verify that error output is actually resolved as the correct string
+        """
+        output = StringIO.StringIO()
+        with self.assertRaises(SystemExit):
+            with self.assertRaisesRegexp(CommandError, GitExportError.BAD_COURSE):
+                call_command(
+                    'git_export', 'foo/bar:baz', 'silly',
+                    stdout=output, stderr=output
+                )
+        self.assertIn('Bad course location provided', output.getvalue())
+        output.close()
+
+        output = StringIO.StringIO()
+        with self.assertRaises(SystemExit):
+            with self.assertRaisesRegexp(CommandError, GitExportError.URL_BAD):
+                call_command(
+                    'git_export', 'foo/bar/baz', 'silly',
+                    stdout=output, stderr=output
+                )
+        self.assertIn(
+            'Non writable git url provided. Expecting something like:'
+            ' git@github.com:mitocw/edx4edx_lite.git',
+            output.getvalue()
+        )
+        output.close()
+
     def test_bad_git_url(self):
         """
         Test several bad URLs for validation


### PR DESCRIPTION
**Background**: Error messages like `Error: <django.utils.functional.__proxy__ object at 0x79a8710>` aren't terribly helpful.  This should resolve those strings to the correct error message.

**Studio**: Small command bug fix

**LMS**: None

**Testing**: running `python manage.py cms --settings=aws git_export silly foo/bar:baz` should produce the error message: `Error: Bad course location provided` instead of `Error: <django.utils.functional.__proxy__ object at ...`
