### PR TITLE
Make OAuth token login endpoint CSRF exempt

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1114,6 +1114,7 @@ def login_user(request, error=""):  # pylint: disable-msg=too-many-statements,un
     })  # TODO: this should be status code 400  # pylint: disable=fixme
 
 
+@csrf_exempt
 @require_POST
 @social_utils.strategy("social:complete")
 def login_oauth_token(request, backend):


### PR DESCRIPTION
@aleffert @nasthagiri 

@ormsbee I'd like to get this into the release if possible so we can unblock app testing
