### PR TITLE
Final text review

### DIFF
--- a/common/djangoapps/user_api/tests/test_views.py
+++ b/common/djangoapps/user_api/tests/test_views.py
@@ -1345,7 +1345,9 @@ class RegistrationViewTest(ApiTestCase):
         self.assertEqual(response.status_code, 409)
         self.assertEqual(
             response.content,
-            "It looks like {} belongs to an existing account.".format(self.EMAIL)
+            "It looks like {} belongs to an existing account. Try again with a different email address.".format(
+                self.EMAIL
+            )
         )
 
     def test_register_duplicate_username(self):
@@ -1370,7 +1372,9 @@ class RegistrationViewTest(ApiTestCase):
         self.assertEqual(response.status_code, 409)
         self.assertEqual(
             response.content,
-            "It looks like {} belongs to an existing account.".format(self.USERNAME)
+            "It looks like {} belongs to an existing account. Try again with a different email address and username.".format(
+                self.USERNAME
+            )
         )
 
     def test_register_duplicate_username_and_email(self):
@@ -1395,7 +1399,7 @@ class RegistrationViewTest(ApiTestCase):
         self.assertEqual(response.status_code, 409)
         self.assertEqual(
             response.content,
-            "It looks like {} and {} belong to an existing account.".format(
+            "It looks like {} and {} belong to an existing account. Try again with a different email address and username.".format(
                 self.EMAIL, self.USERNAME
             )
         )

--- a/common/djangoapps/user_api/views.py
+++ b/common/djangoapps/user_api/views.py
@@ -280,19 +280,19 @@ class RegistrationView(APIView):
                 # account using both an email address and a username associated with an
                 # existing account.
                 error_msg = _(
-                    u"It looks like {email_address} and {username} belong to an existing account."
+                    u"It looks like {email_address} and {username} belong to an existing account. Try again with a different email address and username."
                 ).format(email_address=email, username=username)
             elif 'email' in conflicts:
                 # Translators: This message is shown to users who attempt to create a new
                 # account using an email address associated with an existing account.
                 error_msg = _(
-                    u"It looks like {email_address} belongs to an existing account."
+                    u"It looks like {email_address} belongs to an existing account. Try again with a different email address."
                 ).format(email_address=email)
             else:
                 # Translators: This message is shown to users who attempt to create a new
                 # account using a username associated with an existing account.
                 error_msg = _(
-                    u"It looks like {username} belongs to an existing account."
+                    u"It looks like {username} belongs to an existing account. Try again with a different username."
                 ).format(username=username)
 
             return HttpResponse(
@@ -504,14 +504,20 @@ class RegistrationView(APIView):
         # Translators: "Terms of Service" is a legal document users must agree to
         # in order to register a new account.
         label = _(
-            u"I agree to the {terms_of_service}"
-        ).format(terms_of_service=terms_link)
+            u"I agree to the {platform_name} {terms_of_service}."
+        ).format(
+            platform_name=settings.PLATFORM_NAME,
+            terms_of_service=terms_link
+        )
 
         # Translators: "Terms of Service" is a legal document users must agree to
         # in order to register a new account.
         error_msg = _(
-            u"You must agree to the {terms_of_service}"
-        ).format(terms_of_service=terms_link)
+            u"You must agree to the {platform_name} {terms_of_service}."
+        ).format(
+            platform_name=settings.PLATFORM_NAME,
+            terms_of_service=terms_link
+        )
 
         form_desc.add_field(
             "honor_code",
@@ -535,11 +541,21 @@ class RegistrationView(APIView):
 
         # Translators: "Terms of service" is a legal document users must agree to
         # in order to register a new account.
-        label = _(u"I agree to the {terms_of_service}").format(terms_of_service=terms_link)
+        label = _(
+            u"I agree to the {platform_name} {terms_of_service}."
+        ).format(
+            platform_name=settings.PLATFORM_NAME,
+            terms_of_service=terms_link
+        )
 
         # Translators: "Terms of service" is a legal document users must agree to
         # in order to register a new account.
-        error_msg = _("You must agree to the {terms_of_service}").format(terms_of_service=terms_link)
+        error_msg = _(
+            u"You must agree to the {platform_name} {terms_of_service}."
+        ).format(
+            platform_name=settings.PLATFORM_NAME,
+            terms_of_service=terms_link
+        )
 
         form_desc.add_field(
             "terms_of_service",

--- a/common/static/js/spec/edx.utils.validate_spec.js
+++ b/common/static/js/spec/edx.utils.validate_spec.js
@@ -9,9 +9,10 @@ describe('edx.utils.validate', function () {
         VALID_STRING = 'xsy_is_awesome',
         SHORT_STRING = 'x',
         LONG_STRING = 'xsy_is_way_too_awesome',
-        REQUIRED_ERROR_FRAGMENT = 'required',
+        EMAIL_ERROR_FRAGMENT = 'formatted',
         MIN_ERROR_FRAGMENT = 'least',
         MAX_ERROR_FRAGMENT = 'up to',
+        REQUIRED_ERROR_FRAGMENT = 'empty',
         CUSTOM_MESSAGE = 'custom message';
 
     var createFixture = function( type, name, required, minlength, maxlength, value ) {
@@ -117,11 +118,11 @@ describe('edx.utils.validate', function () {
         createFixture('email', 'email', false, MIN_LENGTH, MAX_LENGTH, 'localpart');
 
         // Verify optional field behavior
-        expectInvalid('invalid');
+        expectInvalid(EMAIL_ERROR_FRAGMENT);
 
         // Verify required field behavior
         field.prop('required', false);
-        expectInvalid('invalid');
+        expectInvalid(EMAIL_ERROR_FRAGMENT);
     });
 
     it('succeeds if an email field is provided a valid address', function () {

--- a/common/static/js/utils/edx.utils.validate.js
+++ b/common/static/js/utils/edx.utils.validate.js
@@ -18,10 +18,10 @@ var edx = edx || {};
             validate: {
 
                 msg: {
-                    email: '<li><%- gettext("The email address you\'ve provided is invalid.") %></li>',
-                    min: '<li><%- _.sprintf(gettext("%(field)s must have at least %(count)d characters"), context) %></li>',
-                    max: '<li><%- _.sprintf(gettext("%(field)s can only contain up to %(count)d characters"), context) %></li>',
-                    required: '<li><%- _.sprintf(gettext("%(field)s is required"), context) %></li>',
+                    email: '<li><%- gettext("The email address you\'ve provided isn\'t formatted correctly.") %></li>',
+                    min: '<li><%- _.sprintf(gettext("%(field)s must have at least %(count)d characters."), context) %></li>',
+                    max: '<li><%- _.sprintf(gettext("%(field)s can only contain up to %(count)d characters."), context) %></li>',
+                    required: '<li><%- _.sprintf(gettext("The %(field)s field cannot be empty."), context) %></li>',
                     custom: '<li><%= content %></li>'
                 },
 
@@ -73,12 +73,6 @@ var edx = edx || {};
                         var max = $el.attr('maxlength') || false;
 
                         return ( !!max ) ? max >= $el.val().length : true;
-                    },
-
-                    capitalizeFirstLetter: function( str ) {
-                        str = str.replace('_', ' ');
-
-                        return str.charAt(0).toUpperCase() + str.slice(1);
                     }
                 },
 
@@ -121,16 +115,21 @@ var edx = edx || {};
                     }
                 },
 
+                getLabel: function( id ) {
+                    // Extract the field label, remove the asterisk (if it appears) and any extra whitespace
+                    return $("label[for=" + id + "]").text().split("*")[0].trim();
+                },
+
                 getMessage: function( $el, tests ) {
                     var txt = [],
                         tpl,
-                        name,
+                        label,
                         obj,
                         customMsg;
 
                     _.each( tests, function( value, key ) {
                         if ( !value ) {
-                            name = $el.attr('name');
+                            label = _fn.validate.getLabel( $el.attr('id') );
                             customMsg = $el.data('errormsg-' + key) || false;
 
                             // If the field has a custom error msg attached, use it
@@ -147,7 +146,7 @@ var edx = edx || {};
                                     // We pass the context object to the template so that
                                     // we can perform variable interpolation using sprintf
                                     context: {
-                                        field: _fn.validate.str.capitalizeFirstLetter( name )
+                                        field: label
                                     }
                                 };
 

--- a/lms/templates/student_account/access.underscore
+++ b/lms/templates/student_account/access.underscore
@@ -5,7 +5,7 @@
 
 <section id="form-load-fail" class="form-type hidden" aria-hidden="true">
     <div class="status submission-error">
-        <p class="message-copy"><%- gettext("Apologies, we appear to be experiencing technical difficulties. Please try again later.") %></p>
+        <p class="message-copy"><%- gettext("Sorry, we're having some technical problems. Wait a few minutes and try again.") %></p>
     </div>
 </section>
 

--- a/lms/templates/student_account/register.underscore
+++ b/lms/templates/student_account/register.underscore
@@ -18,7 +18,7 @@
 
 <form id="register" autocomplete="off">
     <div class="status submission-error hidden" aria-hidden="true">
-        <h4 class="message-title"><%- gettext("An error occurred in your registration.") %></h4>
+        <h4 class="message-title"><%- gettext("We couldn't complete your registration.") %></h4>
         <ul class="message-copy"></ul>
     </div>
 


### PR DESCRIPTION
@AlasdairSwan and @wedaly, these are copy changes suggested by @srpearce. I've also modified the field validation utility to use the field's `label` in error messages instead of the field's `name`; the `name` is used primarily for styling, isn't i18n'd, and isn't necessarily consistent with the field `label`.
