### PR TITLE
Logistration: Remove extra viewport meta tag

### DIFF
--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -10,7 +10,6 @@
 %>
 <head dir="${dir_rtl}">
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     % if responsive:
     <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
@AlasdairSwan Good catch!  When I cherry-picked the commit from the other branch, it added the conditional `meta` tag, but left the existing meta tag.
