### PR TITLE
MA-104 Studio backend for video_upload

### DIFF
--- a/cms/djangoapps/contentstore/tests/utils.py
+++ b/cms/djangoapps/contentstore/tests/utils.py
@@ -88,7 +88,7 @@ class CourseTestCase(ModuleStoreTestCase):
         """
         nonstaff, password = self.create_non_staff_user()
 
-        client = Client()
+        client = AjaxEnabledTestClient()
         if authenticate:
             client.login(username=nonstaff.username, password=password)
             nonstaff.is_authenticated = True

--- a/cms/djangoapps/contentstore/views/__init__.py
+++ b/cms/djangoapps/contentstore/views/__init__.py
@@ -17,6 +17,7 @@ from .public import *
 from .export_git import *
 from .user import *
 from .tabs import *
+from .videos import *
 from .transcripts_ajax import *
 try:
     from .dev import *

--- a/cms/djangoapps/contentstore/views/tests/test_videos.py
+++ b/cms/djangoapps/contentstore/views/tests/test_videos.py
@@ -1,0 +1,103 @@
+"""
+Unit tests for video-related REST APIs.
+"""
+# pylint: disable=attribute-defined-outside-init
+import json
+import datetime
+import dateutil.parser
+
+from mock import patch
+from unittest import skip
+from django.test.utils import override_settings
+
+from contentstore.tests.utils import CourseTestCase
+from contentstore.utils import reverse_course_url
+from contentstore.views.videos import UploadStatus
+
+
+@patch.dict("django.conf.settings.FEATURES", {'ENABLE_VIDEO_UPLOAD_PIPELINE': True})
+class VideoUploadTestCase(CourseTestCase):
+    """
+    Test cases for the video upload page
+    """
+    def setUp(self):
+        super(VideoUploadTestCase, self).setUp()
+        self.url = reverse_course_url('videos_handler', self.course.id)
+
+    def test_video_pipeline_not_configured_error(self):
+        response = self.client.ajax_post(
+            self.url
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_non_staff_user(self):
+        client, __ = self.create_non_staff_authed_user_client()
+        response = client.ajax_post(
+            self.url
+        )
+        self.assertEqual(response.status_code, 403)
+
+    @patch('boto.s3.connection.S3Connection')
+    @patch('boto.s3.key.Key')
+    def setup_and_post_video_uploads(self, s3_key=None, s3_connection=None):  # pylint: disable=unused-argument
+        """
+        Sets up the course to enable video uploads, posts video files, and returns the response.
+        """
+        self.institute_name = 'TestUniversity'
+        self.files = [
+            {'file_name': 'file1'},
+            {'file_name': 'file2'},
+        ]
+        self.course.video_upload_pipeline = {
+            'Institute_Name': self.institute_name,
+            'Access_Token': 'xxx',
+        }
+        self.store.update_item(self.course, self.user.id)
+        response = self.client.ajax_post(
+            self.url,
+            data={'files': self.files}
+        )
+        self.assertEqual(response.status_code, 200)
+        return response
+
+    def find_in_list(self, value, list_of_dicts, key='file_name'):
+        """
+        Finds the element in a list of dictionary items whose value of the given key corresponds to the given value.
+        """
+        return next(el for el in list_of_dicts if el[key] == value)
+
+    def test_success_mock_storage_service(self):
+        response = self.setup_and_post_video_uploads()
+        for expected_file in self.files:
+            self.assertIn(expected_file['file_name'], response.content)
+
+    @skip("disable testing with live servers, but can enable locally with real values")
+    @override_settings(AWS_ACCESS_KEY_ID="PUT_IN_TEST_ACCESS_KEY_ID_HERE")
+    @override_settings(AWS_SECRET_ACCESS_KEY="PUT_IN_TEST_SECRET_ACCESS_KEY_HERE")
+    @override_settings(VIDEO_UPLOAD_PIPELINE={'BUCKET': 'edx-sandbox-test', 'ROOT_PATH': ''})
+    @patch('contentstore.views.videos.KEY_EXPIRATION_IN_SECONDS', 60)
+    def test_success_test_storage_service(self):
+        response = self.setup_and_post_video_uploads()
+        returned_files = json.loads(response.content)['files']
+        for expected_file in self.files:
+            file_name = expected_file['file_name']
+            returned_file = self.find_in_list(file_name, returned_files)
+            self.assertRegexpMatches(
+                returned_file['upload-url'],
+                'https://edx-sandbox-test.s3.amazonaws.com/{}/.*{}.*'.format(self.institute_name, file_name),
+            )
+
+    def test_video_index(self):
+        self.setup_and_post_video_uploads()
+        response = self.client.get_json(self.url)
+        videos = json.loads(response.content)['videos']
+        for expected_file in self.files:
+            file_name = expected_file['file_name']
+            video = self.find_in_list(file_name, videos)
+
+            # status
+            self.assertEquals(video['status'], UploadStatus.uploading)
+
+            # upload date
+            upload_date = dateutil.parser.parse(video['date_uploaded'])
+            self.assertEquals(upload_date.date(), datetime.datetime.now().date())

--- a/cms/djangoapps/contentstore/views/tests/test_videos.py
+++ b/cms/djangoapps/contentstore/views/tests/test_videos.py
@@ -5,6 +5,7 @@ Unit tests for video-related REST APIs.
 import json
 import datetime
 import dateutil.parser
+from pytz import UTC
 
 from mock import patch
 from unittest import skip
@@ -49,8 +50,8 @@ class VideoUploadTestCase(CourseTestCase):
             {'file_name': 'file2'},
         ]
         self.course.video_upload_pipeline = {
-            'Institute_Name': self.institute_name,
-            'Access_Token': 'xxx',
+            'institute_name': self.institute_name,
+            'access_token': 'xxx',
         }
         self.store.update_item(self.course, self.user.id)
         response = self.client.ajax_post(
@@ -100,4 +101,4 @@ class VideoUploadTestCase(CourseTestCase):
 
             # upload date
             upload_date = dateutil.parser.parse(video['date_uploaded'])
-            self.assertEquals(upload_date.date(), datetime.datetime.now().date())
+            self.assertEquals(upload_date.date(), datetime.datetime.now(UTC).date())

--- a/cms/djangoapps/contentstore/views/videos.py
+++ b/cms/djangoapps/contentstore/views/videos.py
@@ -44,14 +44,14 @@ class UploadStatus(object):
 
 @expect_json
 @login_required
-@require_http_methods(("GET", "POST", "PUT"))
+@require_http_methods(("GET", "POST", "PATCH"))
 def videos_handler(request, course_key_string):
     """
     The restful handler for video uploads.
 
     GET
         json: return json representing the videos that have been uploaded and their statuses
-    PUT or POST
+    PATCH or POST
         json: upload a set of videos
     """
     # The feature flag should be enabled

--- a/cms/djangoapps/contentstore/views/videos.py
+++ b/cms/djangoapps/contentstore/views/videos.py
@@ -1,0 +1,192 @@
+"""
+Views related to the video upload feature
+"""
+
+from boto import s3
+from pytz import UTC
+from uuid import uuid4
+from datetime import datetime
+
+from django.conf import settings
+from django.contrib.auth.decorators import login_required
+from django.core.exceptions import PermissionDenied
+from django.http import HttpResponseNotFound
+from django.views.decorators.http import require_http_methods
+from opaque_keys.edx.keys import CourseKey
+from edxmako.shortcuts import render_to_response
+
+from xmodule.modulestore.django import modulestore
+from xmodule.assetstore import AssetMetadata
+from util.json_request import expect_json, JsonResponse
+from .access import has_course_access
+
+__all__ = ['videos_handler']
+
+
+# String constant used in asset keys to identify video assets.
+VIDEO_ASSET_TYPE = 'video'
+
+# Default expiration, in seconds, of one-time URLs used for uploading videos.
+KEY_EXPIRATION_IN_SECONDS = 3600
+
+
+class UploadStatus(object):
+    """
+    Constant values for the various statuses of video uploads
+    """
+    uploading = 'Uploading'
+    valid_file = "File Valid"
+    invalid_file = "File Invalid"
+    in_progress = "In Progress"
+    complete = "Complete"
+
+
+@expect_json
+@login_required
+@require_http_methods(("GET", "POST", "PUT"))
+def videos_handler(request, course_key_string):
+    """
+    The restful handler for video uploads.
+
+    GET
+        json: return json representing the videos that have been uploaded and their statuses
+    PUT or POST
+        json: upload a set of videos
+    """
+    # The feature flag should be enabled
+    assert settings.FEATURES['ENABLE_VIDEO_UPLOAD_PIPELINE']
+
+    course_key = CourseKey.from_string(course_key_string)
+
+    # For now, assume all studio users that have access to the course can upload videos.
+    # In the future, we plan to add a new org-level role for video uploaders.
+    if not has_course_access(request.user, course_key):
+        raise PermissionDenied()
+
+    # Check whether the video upload feature is configured for this course
+    course = modulestore().get_course(course_key)
+    if not course.video_pipeline_configured:
+        return JsonResponse({"error": "Course not configured properly for video upload."}, status=400)
+
+    if 'application/json' in request.META.get('HTTP_ACCEPT', 'application/json'):
+        if request.method == 'GET':
+            return videos_index_json(course)
+        else:
+            return videos_post(course, request)
+
+    return HttpResponseNotFound()
+
+
+def videos_index_json(course):
+    """
+    Returns a JSON in the following format: {
+        videos: [
+           {
+              edx_video_id: xxx,
+              file_name: xxx,
+              date_uploaded: xxx,
+              status: xxx,
+           },
+           ...
+        ]
+    }
+    """
+    videos = []
+    for metadata in modulestore().get_all_asset_metadata(course.id, VIDEO_ASSET_TYPE):
+        videos.append({
+            'edx_video_id': metadata.asset_id.path,
+            'file_name': metadata.fields['file_name'],
+            'date_uploaded': metadata.fields['upload_timestamp'],  # TODO PLAT-278 use created_on field instead
+            'status': metadata.fields['status'],
+        })
+    return JsonResponse({'videos': videos}, status=200)
+
+
+def videos_post(course, request):
+    """
+    Input (JSON): {
+        files: [
+            { file_name: xxx },
+            ...
+        ]
+    }
+    Returns (JSON): {
+        files: [
+            { file-name: xxx, upload-url: xxx },
+            ...
+        ]
+    }
+    """
+    bucket = storage_service_bucket()
+    institute_name = course.video_upload_pipeline['Institute_Name']
+
+    video_files = request.json['files']
+    for video_file in video_files:
+        file_name = video_file['file_name']
+
+        # 1. generate edx_video_id
+        edx_video_id = generate_edx_video_id(institute_name)
+
+        # 2. generate key for uploading file
+        key = storage_service_key(
+            bucket,
+            folder_name=institute_name,
+            file_name=edx_video_id,
+        )
+
+        # 3. set meta data for the file
+        for metadata_name, value in [
+            ('institute', course.video_upload_pipeline['Institute_Name']),
+            ('institute_token', course.video_upload_pipeline['Access_Token']),
+            ('user_supplied_file_name', file_name),
+            ('course_org', course.org),
+            ('course_number', course.number),
+            ('course_run', course.location.run),
+        ]:
+            key.set_metadata(metadata_name, value)
+
+        # 4. generate URL
+        video_file['upload-url'] = key.generate_url(KEY_EXPIRATION_IN_SECONDS, 'PUT')
+
+        # 5. persist edx_video_id
+        video_meta_data = AssetMetadata(
+            course.id.make_asset_key(VIDEO_ASSET_TYPE, edx_video_id),
+            fields={
+                'file_name': file_name,
+                'upload_timestamp': datetime.now(UTC),
+                'status': UploadStatus.uploading
+            }
+        )
+        modulestore().save_asset_metadata(video_meta_data, request.user.id)
+
+    return JsonResponse({'files': video_files}, status=200)
+
+
+def generate_edx_video_id(institute_name):
+    """
+    Generates and returns an edx-video-id to uniquely identify a new logical video.
+    """
+    return "{}-{}".format(institute_name, uuid4())
+
+
+def storage_service_bucket():
+    """
+    Returns a bucket in a cloud-based storage service for video uploads.
+    """
+    conn = s3.connection.S3Connection(
+        settings.AWS_ACCESS_KEY_ID,
+        settings.AWS_SECRET_ACCESS_KEY
+    )
+    return conn.get_bucket(settings.VIDEO_UPLOAD_PIPELINE['BUCKET'])
+
+
+def storage_service_key(bucket, folder_name, file_name):
+    """
+    Returns a key to the given file in the given folder in the given bucket for video uploads.
+    """
+    key_name = "{}/{}/{}".format(
+        settings.VIDEO_UPLOAD_PIPELINE['ROOT_PATH'],
+        folder_name,
+        file_name
+    )
+    return s3.key.Key(bucket, key_name)

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -107,6 +107,9 @@ FEATURES = {
 
     # Modulestore to use for new courses
     'DEFAULT_STORE_FOR_NEW_COURSE': None,
+
+    # Turn off Video Upload Pipeline through Studio, by default
+    'ENABLE_VIDEO_UPLOAD_PIPELINE': False,
 }
 ENABLE_JASMINE = False
 
@@ -548,6 +551,15 @@ YOUTUBE = {
         },
     },
 }
+
+############################# VIDEO UPLOAD PIPELINE #############################
+
+VIDEO_UPLOAD_PIPELINE = {
+    'BUCKET': 'edx-raw-videos',
+    'ROOT_PATH': '',
+}
+AWS_ACCESS_KEY_ID = ""
+AWS_SECRET_ACCESS_KEY = ""
 
 ############################ APPS #####################################
 

--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -30,19 +30,17 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 LMS_BASE = "localhost:8000"
 FEATURES['PREVIEW_LMS_BASE'] = "preview." + LMS_BASE
 
-############################# ADVANCED COMPONENTS #############################
+############################# FEATURE FLAGS #############################
 
-# Make it easier to test advanced components in local dev
+# Make it easier to test features in local dev
 FEATURES['ALLOW_ALL_ADVANCED_COMPONENTS'] = True
+FEATURES['ENABLE_VIDEO_UPLOAD_PIPELINE'] = True
+FEATURES['ALLOW_COURSE_RERUNS'] = True
 
 ################################# CELERY ######################################
 
 # By default don't use a worker, execute tasks as if they were local functions
 CELERY_ALWAYS_EAGER = True
-
-################################ COURSE RERUNS ################################
-
-FEATURES['ALLOW_COURSE_RERUNS'] = True
 
 ################################ DEBUG TOOLBAR ################################
 INSTALLED_APPS += ('debug_toolbar', 'debug_toolbar_mongo')

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -91,6 +91,7 @@ urlpatterns += patterns(
     url(r'^settings/advanced/{}$'.format(settings.COURSE_KEY_PATTERN), 'advanced_settings_handler'),
     url(r'^textbooks/{}$'.format(settings.COURSE_KEY_PATTERN), 'textbooks_list_handler'),
     url(r'^textbooks/{}/(?P<textbook_id>\d[^/]*)$'.format(settings.COURSE_KEY_PATTERN), 'textbooks_detail_handler'),
+    url(r'^videos/{}$'.format(settings.COURSE_KEY_PATTERN), 'videos_handler'),
     url(r'^group_configurations/{}$'.format(settings.COURSE_KEY_PATTERN), 'group_configurations_list_handler'),
     url(r'^group_configurations/{}/(?P<group_configuration_id>\d+)/?$'.format(settings.COURSE_KEY_PATTERN),
         'group_configurations_detail_handler'),
@@ -108,7 +109,6 @@ urlpatterns += patterns('',
     # Serve catalog of localized strings to be rendered by Javascript
     url(r'^i18n.js$', 'django.views.i18n.javascript_catalog', js_info_dict),
 )
-
 
 if settings.FEATURES.get('ENABLE_EXPORT_GIT'):
     urlpatterns += (url(r'^export_git/{}$'.format(settings.COURSE_KEY_PATTERN),

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -1106,6 +1106,6 @@ class CourseDescriptor(CourseFields, SequenceDescriptor):
         """
         return (
             self.video_upload_pipeline is not None and
-            'Institute_Name' in self.video_upload_pipeline and
-            'Access_Token' in self.video_upload_pipeline
+            'institute_name' in self.video_upload_pipeline and
+            'access_token' in self.video_upload_pipeline
         )

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -285,7 +285,11 @@ class CourseFields(object):
         default=False,
         scope=Scope.settings
     )
-
+    video_upload_pipeline = Dict(
+        display_name=_("Video Upload Pipeline"),
+        help=_("Enter settings for the video upload pipeline, including the institute name and the secret token."),
+        scope=Scope.settings
+    )
     no_grade = Boolean(
         display_name=_("Course Not Graded"),
         help=_("Enter true or false. If true, the course will not be graded."),
@@ -1094,3 +1098,14 @@ class CourseDescriptor(CourseFields, SequenceDescriptor):
             return self.display_organization
 
         return self.org
+
+    @property
+    def video_pipeline_configured(self):
+        """
+        Returns whether the video pipeline advanced setting is configured for this course.
+        """
+        return (
+            self.video_upload_pipeline is not None and
+            'Institute_Name' in self.video_upload_pipeline and
+            'Access_Token' in self.video_upload_pipeline
+        )


### PR DESCRIPTION
https://openedx.atlassian.net/browse/MA-104
Advanced Setting for "Video Upload Pipeline".
Feature Flag for "ENABLE_VIDEO_UPLOAD_PIPELINE".
Use AssetMetaData store to persist video upload information.

@andy-armstrong @gwprice I have created this new PR to reflect only the initial backend studio support of our feature.  Please review again.  
