### PR TITLE
Fix help modal css selector

### DIFF
--- a/lms/templates/help_modal.html
+++ b/lms/templates/help_modal.html
@@ -149,7 +149,7 @@
 <script type="text/javascript">
 (function() {
     var onModalClose = function() {
-            $(".help-modal .close-modal").off("click");
+            $("#help-modal .close-modal").off("click");
             $("#lean_overlay").off("click");
             $("#help-modal").attr("aria-hidden", "true");
             $('area,input,select,textarea,button').removeAttr('tabindex');


### PR DESCRIPTION
This PR is a simple fix for an apparent typo for removing the click event handler for the close button on the help modal. The css selector was incorrect so the click event was not being removed.
@antoviaque thanks!
