### PR TITLE
Remove redundant pageview segment.io events (ECOM-619)

### DIFF
--- a/lms/templates/widgets/segment-io.html
+++ b/lms/templates/widgets/segment-io.html
@@ -9,37 +9,6 @@
   % if user.is_authenticated():
     window.identifyUser("${user.id}", "${user.email}", "${user.username}");
   % endif
-
-  // Get current page URL
-  var url = window.location.href
-  // Match on the current url and fire the appropriate pageview event
-  if (url.indexOf("/register") > -1) {
-    // Registration page viewed
-    analytics.track("edx.bi.page.register.viewed", {
-      category: "pageview",
-      noninteraction: 1
-    });
-  } else if (url.indexOf("/login") > -1) {
-    // Login page viewed
-    analytics.track("edx.bi.page.login.viewed", {
-      category: "pageview",
-      noninteraction: 1
-    });
-  } else if (url.indexOf("/dashboard") > -1) {
-    // Dashboard viewed
-    analytics.track("edx.bi.page.dashboard.viewed", {
-      category: "pageview",
-      noninteraction: 1
-    });
-  } else {
-    // This event serves as a catch-all, firing when any other page is viewed
-    analytics.track("edx.bi.page.other.viewed", {
-      category: "pageview",
-      url: location.host + location.pathname + location.search,
-      noninteraction: 1
-    });
-  }
-
 </script>
 <!-- end Segment.io -->
 % else:


### PR DESCRIPTION
[ECOM-619](https://openedx.atlassian.net/browse/ECOM-619)

Background:
- These pageview events were originally included as a workaround for MixPanel, which we're no longer using.
- On Oct 9, segment.io made a change to its API so that the "noninteraction" flag we are setting stopped working.  This resulted in a bounce rate of 0% in Google Analytics.

This PR removes the redundant events, which should improve page performance as well as fixing the bounce rate issue.

Reviewers: @rlucioni @stephensanchez 
