### PR TITLE
Update django-cas Version

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -141,8 +141,9 @@ analytics-python==0.4.4
 
 git+https://github.com/mfogel/django-settings-context-processor.git
 
-# django-cas version 2.0.3 with patch to be compatible with django 1.4
-git+https://github.com/mitocw/django-cas.git
+# django-cas version 2.1.1 with patch to be compatible with django 1.4
+# support CAS 3.0
+git+https://github.com/eduStack/django-cas.git
 
 # edX packages
 edx-submissions==0.0.8


### PR DESCRIPTION
Update django-cas Version .

As the old mitx version can not support  CAS 2.0 and CAS 3.0 provided by ja-sig.org(java) 
So I open this pull.

eduStack/django-cas is a fork of https://bitbucket.org/cpcc/django-cas which use hg as version control.

cas_mapper_example:  https://github.com/eduStack/bistux_cas_mapper
