### PR TITLE
Advanced settings discussion category ids should be unique.

### DIFF
--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -260,7 +260,7 @@ class CourseFields(object):
     )
     discussion_topics = Dict(
         display_name=_("Discussion Topic Mapping"),
-        help=_("Enter discussion categories in the following format: \"CategoryName\": {\"id\": \"i4x-InstitutionName-CourseNumber-course-CourseRun\"}. For example, one discussion category may be \"Lydian Mode\": {\"id\": \"i4x-UniversityX-MUS101-course-2014_T1\"}."),
+        help=_("Enter discussion categories in the following format: \"CategoryName\": {\"id\": \"i4x-InstitutionName-CourseNumber-course-CourseRun\"}. For example, one discussion category may be \"Lydian Mode\": {\"id\": \"i4x-UniversityX-MUS101-course-2014_T1\"}. The \"id\" value for each category must be unique."),
         scope=Scope.settings
     )
     discussion_sort_alpha = Boolean(


### PR DESCRIPTION
If the ids in the adnvaced setting discussion category are
not unique then threads under categories with different name
will come in every category with same id. Ids should be unique
inorder to differentiate between different categories.

TNL-752
