### PR TITLE
WL-109 Courseware Logo Link

### DIFF
--- a/lms/djangoapps/branding/views.py
+++ b/lms/djangoapps/branding/views.py
@@ -47,7 +47,9 @@ def index(request):
         if microsite.get_value(
                 'ALWAYS_REDIRECT_HOMEPAGE_TO_DASHBOARD_FOR_AUTHENTICATED_USER',
                 settings.FEATURES.get('ALWAYS_REDIRECT_HOMEPAGE_TO_DASHBOARD_FOR_AUTHENTICATED_USER', True)
-        ) or get_course_enrollments(request.user):
+        ) or (get_course_enrollments(request.user) and microsite.get_value(
+                'REDIRECT_HOMEPAGE_TO_DASHBOARD_IF_ENROLLED_IN_COURSES',
+                settings.FEATURES.get('REDIRECT_HOMEPAGE_TO_DASHBOARD_IF_ENROLLED_IN_COURSES', True))):
 
             return redirect(reverse('dashboard'))
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -273,6 +273,11 @@ FEATURES = {
     # False to not redirect the user
     'ALWAYS_REDIRECT_HOMEPAGE_TO_DASHBOARD_FOR_AUTHENTICATED_USER': True,
 
+    # When a logged in user goes to the homepage ('/') should the user be
+    # redirected to the dashboard if he's enrolled in any courses. Set to False to
+    # stay at the homepage.
+    'REDIRECT_HOMEPAGE_TO_DASHBOARD_IF_ENROLLED_IN_COURSES': True,
+
     # Expose Mobile REST API. Note that if you use this, you must also set
     # ENABLE_OAUTH2_PROVIDER to True
     'ENABLE_MOBILE_REST_API': False,


### PR DESCRIPTION
@chrisndodge @griffresch @afzaledx  Kindly look into the change set.

we found the feature flag 'ALWAYS_REDIRECT_HOMEPAGE_TO_DASHBOARD_FOR_AUTHENTICATED_USER' which defaults to True.

We have added a new feature flag: 'REDIRECT_HOMEPAGE_TO_DASHBOARD_IF_ENROLLED_IN_COURSES' again with the default value True.

To fulfil the requirements of this story, the site would have to run with both flags set to False.

Thanks
