### PR TITLE
Added alt attribute in image map input problem.

### DIFF
--- a/common/lib/xmodule/xmodule/templates/problem/imageresponse.yaml
+++ b/common/lib/xmodule/xmodule/templates/problem/imageresponse.yaml
@@ -11,7 +11,7 @@ data: |
     </p>
     <p>Which animal shown below is a kitten?</p>
     <imageresponse>
-      <imageinput src="https://studio.edx.org/c4x/edX/DemoX/asset/Dog-and-Cat.jpg" width="640" height="400" rectangle="(385,98)-(600,337)"/>
+      <imageinput src="https://studio.edx.org/c4x/edX/DemoX/asset/Dog-and-Cat.jpg" width="640" height="400" rectangle="(385,98)-(600,337)" alt="Two animals side by side. On the left, a brown furry animal with floppy ears and a large dark nose, on the right, a smaller furry animal with pointy ears and a small pink nose."/>
     </imageresponse>
     <solution>
       <div class="detailed-solution">

--- a/common/templates/course_modes/_contribution.html
+++ b/common/templates/course_modes/_contribution.html
@@ -14,7 +14,7 @@
     <ul class="field-group field-group-other">
       <li class="contribution-option contribution-option-other1">
         <input type="radio" id="contribution-other" name="contribution" value="" ${'checked' if (chosen_price and chosen_price not in suggested_prices) else ''} />
-        <label for=" contribution-other"><span class="sr">Other</span></label>
+        <label for="contribution-other"><span class="sr">Other</span></label>
       </li>
 
       <li class="contribution-option contribution-option-other2">


### PR DESCRIPTION
Tickets: [TNL-822](https://openedx.atlassian.net/browse/TNL-822), [TNL-825](https://openedx.atlassian.net/browse/TNL-825)

Without ALT attribute image map input problem type is completely inaccessible. It's important that we include one in the example to demonstrate it to course team.

Space removed from `for` attribute.
