### PR TITLE
fixup! Upgraded to Django 1.5

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -193,8 +193,8 @@ simplefilter('ignore')
 # List of finder classes that know how to find static files in
 # various locations.
 STATICFILES_FINDERS = (
-    'staticfiles.finders.FileSystemFinder',
-    'staticfiles.finders.AppDirectoriesFinder',
+    'django.contrib.staticfiles.finders.FileSystemFinder',
+    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
     'pipeline.finders.PipelineFinder',
 )
 
@@ -557,6 +557,7 @@ INSTALLED_APPS = (
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.sites',
+    'django.contrib.staticfiles',
     'django.contrib.messages',
     'djcelery',
     'south',
@@ -587,7 +588,6 @@ INSTALLED_APPS = (
     # For asset pipelining
     'edxmako',
     'pipeline',
-    'staticfiles',
     'static_replace',
     'require',
 

--- a/common/djangoapps/pipeline_js/views.py
+++ b/common/djangoapps/pipeline_js/views.py
@@ -4,7 +4,7 @@ Views for returning XModule JS (used by requirejs)
 import json
 from django.conf import settings
 from django.http import HttpResponse
-from staticfiles.storage import staticfiles_storage
+from django.contrib.staticfiles.storage import staticfiles_storage
 from edxmako.shortcuts import render_to_response
 
 

--- a/common/djangoapps/pipeline_mako/templates/static_content.html
+++ b/common/djangoapps/pipeline_mako/templates/static_content.html
@@ -1,5 +1,5 @@
 <%!
-from staticfiles.storage import staticfiles_storage
+from django.contrib.staticfiles.storage import staticfiles_storage
 from pipeline_mako import compressed_css, compressed_js
 from django.utils.translation import get_language_bidi
 %>

--- a/common/djangoapps/static_replace/__init__.py
+++ b/common/djangoapps/static_replace/__init__.py
@@ -1,8 +1,8 @@
 import logging
 import re
 
-from staticfiles.storage import staticfiles_storage
-from staticfiles import finders
+from django.contrib.staticfiles.storage import staticfiles_storage
+from django.contrib.staticfiles import finders
 from django.conf import settings
 
 from xmodule.modulestore.django import modulestore

--- a/common/djangoapps/terrain/browser.py
+++ b/common/djangoapps/terrain/browser.py
@@ -19,23 +19,6 @@ from json import dumps
 import xmodule.modulestore.django
 from xmodule.contentstore.django import _CONTENTSTORE
 
-# There is an import issue when using django-staticfiles with lettuce
-# Lettuce assumes that we are using django.contrib.staticfiles,
-# but the rest of the app assumes we are using django-staticfiles
-# (in particular, django-pipeline and our mako implementation)
-# To resolve this, we check whether staticfiles is installed,
-# then redirect imports for django.contrib.staticfiles
-# to use staticfiles.
-try:
-    import staticfiles
-    import staticfiles.handlers
-except ImportError:
-    pass
-else:
-    import sys
-    sys.modules['django.contrib.staticfiles'] = staticfiles
-    sys.modules['django.contrib.staticfiles.handlers'] = staticfiles.handlers
-
 LOGGER = getLogger(__name__)
 LOGGER.info("Loading the lettuce acceptance testing terrain file...")
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -893,8 +893,8 @@ simplefilter('ignore')
 # List of finder classes that know how to find static files in
 # various locations.
 STATICFILES_FINDERS = (
-    'staticfiles.finders.FileSystemFinder',
-    'staticfiles.finders.AppDirectoriesFinder',
+    'django.contrib.staticfiles.finders.FileSystemFinder',
+    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
     'pipeline.finders.PipelineFinder',
 )
 
@@ -1394,6 +1394,7 @@ INSTALLED_APPS = (
     'django.contrib.messages',
     'django.contrib.sessions',
     'django.contrib.sites',
+    'django.contrib.staticfiles',
     'djcelery',
     'south',
 
@@ -1406,7 +1407,6 @@ INSTALLED_APPS = (
     # For asset pipelining
     'edxmako',
     'pipeline',
-    'staticfiles',
     'static_replace',
 
     # Our courseware

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -7,7 +7,6 @@
 # Python libraries to install directly from github
 
 # Third-party:
--e git+https://github.com/edx/django-staticfiles.git@d89aae2a82f2b#egg=django-staticfiles
 -e git+https://github.com/edx/django-pipeline.git@88ec8a011e481918fdc9d2682d4017c835acd8be#egg=django-pipeline
 -e git+https://github.com/edx/django-wiki.git@cd0b2b31997afccde519fe5b3365e61a9edb143f#egg=django-wiki
 -e git+https://github.com/edx/django-oauth2-provider.git@0.2.7-fork-edx-2#egg=django-oauth2-provider


### PR DESCRIPTION
@cpennington This removes `django-staticfiles` in favour of the built-in `django.contrib.staticfiles` as part of our road to Django 1.7.
