### PR TITLE
Fix diff branch paver option to take value

### DIFF
--- a/pavelib/tests.py
+++ b/pavelib/tests.py
@@ -159,7 +159,7 @@ def test(options):
 @task
 @needs('pavelib.prereqs.install_prereqs')
 @cmdopts([
-    ("compare_branch", "b", "Branch to compare against, defaults to origin/master"),
+    ("compare_branch=", "b", "Branch to compare against, defaults to origin/master"),
 ])
 def coverage(options):
     """


### PR DESCRIPTION
The compare branch option paver coverage takes was a boolean but needed to take a value. One character fix.
