### PR TITLE
Upgrade django-wiki to most current PyPI version

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1440,7 +1440,7 @@ INSTALLED_APPS = (
 
     # For the wiki
     'wiki',  # The new django-wiki from benjaoming
-    'django_notify',
+    'django_nyt',
     'course_wiki',  # Our customizations
     'mptt',
     'sekizai',

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -26,6 +26,7 @@ django-mako==0.1.5pre
 django-model-utils==1.4.0
 django-masquerade==0.1.6
 django-mptt==0.5.5
+django-nyt>=0.9.4
 django-openid-auth==0.4
 django-robots==0.9.1
 django-sekizai==0.6.1

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -9,7 +9,7 @@
 # Third-party:
 -e git+https://github.com/edx/django-staticfiles.git@d89aae2a82f2b#egg=django-staticfiles
 -e git+https://github.com/edx/django-pipeline.git@88ec8a011e481918fdc9d2682d4017c835acd8be#egg=django-pipeline
--e git+https://github.com/edx/django-wiki.git@cd0b2b31997afccde519fe5b3365e61a9edb143f#egg=django-wiki
+-e git+https://github.com/edx/django-wiki.git@b7be37edf716ff915c6fa86567bff55c7a86500e#egg=django-wiki
 -e git+https://github.com/edx/django-oauth2-provider.git@0.2.7-fork-edx-2#egg=django-oauth2-provider
 -e git+https://github.com/edx/MongoDBProxy.git@efe14679c9263ab491916ed960f5930127e05faf#egg=mongodb_proxy
 -e git+https://github.com/gabrielfalcao/lettuce.git@cccc3978ad2df82a78b6f9648fe2e9baddd22f88#egg=lettuce

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -9,7 +9,7 @@
 # Third-party:
 -e git+https://github.com/edx/django-staticfiles.git@d89aae2a82f2b#egg=django-staticfiles
 -e git+https://github.com/edx/django-pipeline.git@88ec8a011e481918fdc9d2682d4017c835acd8be#egg=django-pipeline
--e git+https://github.com/edx/django-wiki.git@b7be37edf716ff915c6fa86567bff55c7a86500e#egg=django-wiki
+-e git+https://github.com/edx/django-wiki.git@01cb9ac39987966dde5596fc6f28547eae7233d0#egg=django-wiki
 -e git+https://github.com/edx/django-oauth2-provider.git@0.2.7-fork-edx-2#egg=django-oauth2-provider
 -e git+https://github.com/edx/MongoDBProxy.git@efe14679c9263ab491916ed960f5930127e05faf#egg=mongodb_proxy
 -e git+https://github.com/gabrielfalcao/lettuce.git@cccc3978ad2df82a78b6f9648fe2e9baddd22f88#egg=lettuce


### PR DESCRIPTION
We made 4 changes into our fork:

https://github.com/edx/django-wiki/pull/1 : was definitely fixed upstream (discussed in the PR comments)

https://github.com/edx/django-wiki/pull/2 & https://github.com/edx/django-wiki/pull/3 were the same PRs (against different branches) using ugettext_lazy rather than gettext for translations. Upstream does **not** use this. So we need to figure out if we need the lazy translations, and why.

https://github.com/edx/django-wiki/pull/4 is not present upstream but I think worthy of submitting an upstream PR.

So overall it looks like perhaps we can't use the Py PI version of wiki until at least the fix from PR 4 is present upstream.

So, I updated the django-wiki fork instead, given that we want the changes introduced in the 3rd and 4th PR to the repo.

Here is my method: I reset edx/django-wiki master to upstream master. I then made a new branch, https://github.com/edx/django-wiki/tree/rc/2014-11-21, off of the old release branch (https://github.com/edx/django-wiki/tree/edx_release) and then rebased it atop edx/django-wiki master.

Doing a compare, you can see that the rc/2014-11-21 branch contains the django-wiki master branch plus two commits: https://github.com/edx/django-wiki/compare/edx:master...rc/2014-11-21

I think this is the safer way to go, until we can submit patches upstream. We should do manual testing and try to merge this as soon as possible.
