### PR TITLE
Use analytics.identify instead of the old utility function

### DIFF
--- a/common/static/js/src/utility.js
+++ b/common/static/js/src/utility.js
@@ -40,10 +40,3 @@ window.rewriteStaticLinks = function(content, from, to) {
     var regex = new RegExp("(https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}([-a-zA-Z0-9@:%_\+.~#?&//=]*))?"+fromRe, 'g');
     return content.replace(regex, replacer);
 };
-
-window.identifyUser = function(userID, email, username) {
-    analytics.identify(userID, {
-        email: email,
-        username: username
-    });    
-};

--- a/lms/templates/widgets/segment-io.html
+++ b/lms/templates/widgets/segment-io.html
@@ -7,7 +7,10 @@
   analytics.page();
 
   % if user.is_authenticated():
-    window.identifyUser("${user.id}", "${user.email}", "${user.username}");
+    analytics.identify("${user.id}", {
+      email: "${user.email}",
+      username: "${user.username}"
+    });
   % endif
 </script>
 <!-- end Segment.io -->


### PR DESCRIPTION
During the course of the release, I noticed `Uncaught TypeError: undefined is not a function` errors being thrown in the LMS on prod. I'm not sure how long this error has been around, but it's due to the fact that the utility function used to help Segment/GA identify users is loaded (in main.html) after Segment needs it. For reasons I don't fully understand, Segment has continued to function normally in spite of this error, successfully identifying users.

This fix resolves the error and also removes the old utility function. It's left over from back when we used to do more in the JS with Segment. Given where we stand now, it doesn't make much sense to abstract this piece of logic out of the Segment template.

@dianakhuang and @wedaly, could you take a quick look at this?
