### PR TITLE
In inline discussion two discussion module override actions

### DIFF
--- a/common/static/coffee/src/discussion/discussion_module_view.coffee
+++ b/common/static/coffee/src/discussion/discussion_module_view.coffee
@@ -97,7 +97,7 @@ if Backbone?
       else
         @$el.append($discussion)
 
-      @newPostForm = $('.new-post-article')
+      @newPostForm = this.$el.find('.new-post-article')
       @threadviews = @discussion.map (thread) =>
         view = new DiscussionThreadView(
           el: @$("article#thread_#{thread.id}"),

--- a/common/test/acceptance/pages/lms/discussion.py
+++ b/common/test/acceptance/pages/lms/discussion.py
@@ -308,6 +308,35 @@ class InlineDiscussionPage(PageObject):
     def element_exists(self, selector):
         return self.q(css=self._discussion_selector + " " + selector).present
 
+    def is_new_post_opened(self):
+        return self._find_within(".new-post-article").visible
+
+    def click_element(self, selector):
+        self.wait_for_element_presence(
+            "{discussion} {selector}".format(discussion=self._discussion_selector, selector=selector),
+            "{selector} is visible".format(selector=selector)
+        )
+        self._find_within(selector).click()
+
+    def click_cancel_new_post(self):
+        self.click_element(".cancel")
+        EmptyPromise(
+            lambda: not self.is_new_post_opened(),
+            "New post closed"
+        ).fulfill()
+
+    def click_new_post_button(self):
+        self.click_element(".new-post-btn")
+        EmptyPromise(
+            self.is_new_post_opened,
+            "New post opened"
+        ).fulfill()
+
+    @wait_for_js
+    def _is_element_visible(self, selector):
+        query = self._find_within(selector)
+        return query.present and query.visible
+
 
 class InlineDiscussionThreadPage(DiscussionThreadPage):
     def __init__(self, browser, thread_id):


### PR DESCRIPTION
In inline discussion if we have two discussion module the
new post button open form for both discussions as well as
cancel button of one discussion call the cancel of other.
Click and button actions are now being handled inside view
of each module so that they don't disturb eachother.

TNL-776
