### PR TITLE
Hide group configurations from advanced settings

### DIFF
--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -14,7 +14,6 @@ class CourseMetadata(object):
     # The list of fields that wouldn't be shown in Advanced Settings.
     # Should not be used directly. Instead the filtered_list method should be used if the field needs to be filtered
     # depending on the feature flag.
-<<<<<<< HEAD
     FILTERED_LIST = [
         'xml_attributes',
         'start',
@@ -29,6 +28,7 @@ class CourseMetadata(object):
         'graded',
         'hide_from_toc',
         'pdf_textbooks',
+        'user_partitions',
         'name',  # from xblock
         'tags',  # from xblock
         'visible_to_staff_only',


### PR DESCRIPTION
@cahrens @jimabramson This is the one change to make the cohorted-courseware branch safe to merge to master.
