### PR TITLE
Prep marketing iframe and relevant courseware view for email opt-in

### DIFF
--- a/lms/djangoapps/courseware/views.py
+++ b/lms/djangoapps/courseware/views.py
@@ -785,10 +785,7 @@ def course_about(request, course_id):
 @cache_if_anonymous
 @ensure_valid_course_key
 def mktg_course_about(request, course_id):
-    """
-    This is the button that gets put into an iframe on the Drupal site
-    """
-
+    """This is the button that gets put into an iframe on the Drupal site."""
     course_key = SlashSeparatedCourseKey.from_deprecated_string(course_id)
 
     try:
@@ -798,8 +795,7 @@ def mktg_course_about(request, course_id):
         )
         course = get_course_with_access(request.user, permission_name, course_key)
     except (ValueError, Http404):
-        # if a course does not exist yet, display a coming
-        # soon button
+        # If a course does not exist yet, display a "Coming Soon" button
         return render_to_response(
             'courseware/mktg_coming_soon.html', {'course_id': course_key.to_deprecated_string()}
         )
@@ -817,6 +813,9 @@ def mktg_course_about(request, course_id):
                             settings.FEATURES.get('ENABLE_LMS_MIGRATION'))
     course_modes = CourseMode.modes_for_course_dict(course.id)
 
+    # Drupal will pass the organization's full name as a GET parameter
+    organization_full_name = request.GET.get('organization_full_name')
+
     context = {
         'course': course,
         'registered': registered,
@@ -824,6 +823,7 @@ def mktg_course_about(request, course_id):
         'course_target': course_target,
         'show_courseware_link': show_courseware_link,
         'course_modes': course_modes,
+        'organization_full_name': organization_full_name,
     }
 
     # The edx.org marketing site currently displays only in English.

--- a/lms/templates/courseware/mktg_course_about.html
+++ b/lms/templates/courseware/mktg_course_about.html
@@ -16,6 +16,10 @@
   <script type="text/javascript">
   (function() {
     $(".register").click(function(event) {
+      if ( !$("#email-opt-in").prop("checked") ) {
+        $("input[name='email_opt_in']").val("false");
+      }
+
       $("#class_enroll_form").submit();
       event.preventDefault();
     });
@@ -29,7 +33,9 @@
           window.top.location.href = "${reverse('dashboard')}";
         }
       } else if (xhr.status == 403) {
-        window.top.location.href = $("a.register").attr("href") || "${reverse('register_user')}?course_id=${course.id | u}&enrollment_action=enroll";
+        var email_opt_in = $("input[name='email_opt_in']").val();
+        ## Ugh.
+        window.top.location.href = $("a.register").attr("href") + email_opt_in || "${reverse('register_user')}?course_id=${course.id | u}&enrollment_action=enroll&email_opt_in=" + email_opt_in;
       } else {
         $('#register_error').html(
             (xhr.responseText ? xhr.responseText : "${_("An error occurred. Please try again later.")}")
@@ -54,7 +60,7 @@
         %elif allow_registration:
         <a class="action action-register register ${'has-option-verified' if len(course_modes) > 1 else ''}"
             %if not user.is_authenticated():
-                href="${reverse('register_user')}?course_id=${course.id | u}&enrollment_action=enroll"
+                href="${reverse('register_user')}?course_id=${course.id | u}&enrollment_action=enroll&email_opt_in="
             %endif
         >${_("Enroll in")} <strong>${course.display_number_with_default | h}</strong>
             %if len(course_modes) > 1:
@@ -71,6 +77,18 @@
             </span>
             %endif
         </a>
+
+        <p class="form-field">
+          <input id="email-opt-in" type="checkbox" name="opt-in" class="email-opt-in" value="true" checked>
+          <label for="email-opt-in">
+            ## Translators: This line appears next a checkbox which users can leave checked or uncheck in order
+            ## to indicate whether they want to receive emails from the organization offering the course.
+            ${_("I would like to receive email about other {organization_full_name} programs and offers.").format(
+              organization_full_name=organization_full_name
+            )}
+          </label>
+        </p>
+
         %else:
           <div class="action registration-closed is-disabled">${_("Enrollment Is Closed")}</div>
         %endif
@@ -83,6 +101,7 @@
       <fieldset class="enroll_fieldset">
         <input name="course_id" type="hidden" value="${course.id | h}">
         <input name="enrollment_action" type="hidden" value="enroll">
+        <input name="email_opt_in" type="hidden" value="true">
         <input type="hidden" name="csrfmiddlewaretoken" value="${ csrf_token }">
       </fieldset>
       <div class="submit">


### PR DESCRIPTION
Puts a checkbox in the iframe. The iframe uses an organization_full_name parameter sent by the courseware views and POSTs an email_opt_in parameter to the student views, preserving it on 403.

Adds tests, modifies view to receive organization full name from GET parameters
