### PR TITLE
Fix syntax-related PEP8 issues

### DIFF
--- a/common/djangoapps/django_comment_common/models.py
+++ b/common/djangoapps/django_comment_common/models.py
@@ -67,8 +67,11 @@ class Role(models.Model):
     def inherit_permissions(self, role):   # TODO the name of this method is a little bit confusing,
                                          # since it's one-off and doesn't handle inheritance later
         if role.course_id and role.course_id != self.course_id:
-            logging.warning("%s cannot inherit permissions from %s due to course_id inconsistency",
-                            self, role)
+            logging.warning(
+                "%s cannot inherit permissions from %s due to course_id inconsistency",
+                self,
+                role,
+            )
         for per in role.permissions.all():
             self.add_permission(per)
 

--- a/docs/en_us/developers/source/conf.py
+++ b/docs/en_us/developers/source/conf.py
@@ -4,8 +4,9 @@
 # pylint: disable=W0212
 # pylint: disable=W0613
 
-import sys, os
+import os
 from path import path
+import sys
 
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 

--- a/docs/en_us/platform_api/source/conf.py
+++ b/docs/en_us/platform_api/source/conf.py
@@ -4,8 +4,9 @@
 # pylint: disable=W0212
 # pylint: disable=W0613
 
-import sys, os
+import os
 from path import path
+import sys
 
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 

--- a/docs/shared/conf.py
+++ b/docs/shared/conf.py
@@ -21,7 +21,8 @@
 #
 # -----------------------------------------------------------------------------
 
-import sys, os
+import os
+import sys
 
 BASEDIR = os.path.dirname(os.path.abspath(__file__))
 

--- a/lms/djangoapps/django_comment_client/base/tests.py
+++ b/lms/djangoapps/django_comment_client/base/tests.py
@@ -1036,8 +1036,8 @@ class UsersEndpointTestCase(ModuleStoreTestCase, MockRequestSetupMixin):
         response = self.make_request(username="other")
         self.assertEqual(response.status_code, 404)
         content = json.loads(response.content)
-        self.assertTrue(content.has_key("errors"))
-        self.assertFalse(content.has_key("users"))
+        self.assertIn("errors", content)
+        self.assertNotIn("users", content)
 
     @patch('lms.lib.comment_client.utils.requests.request')
     def test_requires_matched_user_has_forum_content(self, mock_request):

--- a/lms/djangoapps/django_comment_client/utils.py
+++ b/lms/djangoapps/django_comment_client/utils.py
@@ -123,7 +123,7 @@ def _filter_unstarted_categories(category_map):
 def _sort_map_entries(category_map, sort_alpha):
     things = []
     for title, entry in category_map["entries"].items():
-        if entry["sort_key"] == None and sort_alpha:
+        if entry["sort_key"] is None and sort_alpha:
             entry["sort_key"] = title
         things.append((title, entry))
     for title, category in category_map["subcategories"].items():

--- a/lms/djangoapps/instructor/views/tools.py
+++ b/lms/djangoapps/instructor/views/tools.py
@@ -59,7 +59,7 @@ def bulk_email_is_enabled_for_course(course_id):
     3. Bulk email is enabled for the course.
     """
 
-    bulk_email_enabled_globally = (settings.FEATURES['ENABLE_INSTRUCTOR_EMAIL'] == True)
+    bulk_email_enabled_globally = (settings.FEATURES['ENABLE_INSTRUCTOR_EMAIL'] is True)
     is_studio_course = (modulestore().get_modulestore_type(course_id) != ModuleStoreEnum.Type.xml)
     bulk_email_enabled_for_course = CourseAuthorization.instructor_email_enabled(course_id)
 

--- a/scripts/all-tests.sh
+++ b/scripts/all-tests.sh
@@ -57,7 +57,7 @@ set -e
 
 # Violations thresholds for failing the build
 PYLINT_THRESHOLD=4600
-PEP8_THRESHOLD=15
+PEP8_THRESHOLD=10
 
 source $HOME/jenkins_env
 


### PR DESCRIPTION
This changeset resolves 8 PEP8 issues: It addresses the following
syntax-related PEP8 violations:
- E401 multiple imports on one line
- E502 the backslash is redundant between brackets
- W601 .has_key() is deprecated, use 'in'
- E711 comparison to None should be 'if cond is None:'
- E712 comparison to True should be 'if cond is True:' or 'if cond:'

I'll lower the violation threshold after #5925 is merged.
