### PR TITLE
Fix exception-related PEP8 issues

### DIFF
--- a/common/lib/sandbox-packages/loncapa/loncapa_check.py
+++ b/common/lib/sandbox-packages/loncapa/loncapa_check.py
@@ -29,7 +29,12 @@ def lc_choose(index, *args):
         pass
     if len(args):
         return args[0]
-    raise Exception, "loncapa_check.lc_choose error, index=%s, args=%s" % (index, args)
+    raise Exception(
+        "loncapa_check.lc_choose error, index={index}, args={args}".format(
+            index=index,
+            args=args,
+        )
+    )
 
 deg2rad = math.pi / 180.0
 rad2deg = 180.0 / math.pi

--- a/common/lib/xmodule/xmodule/capa_module.py
+++ b/common/lib/xmodule/xmodule/capa_module.py
@@ -88,11 +88,11 @@ class CapaModule(CapaMixin, XModule):
 
         except NotFoundError as err:
             _, _, traceback_obj = sys.exc_info()  # pylint: disable=redefined-outer-name
-            raise ProcessingError, (not_found_error_message, err), traceback_obj
+            raise ProcessingError(not_found_error_message), None, traceback_obj
 
         except Exception as err:
             _, _, traceback_obj = sys.exc_info()  # pylint: disable=redefined-outer-name
-            raise ProcessingError, (generic_error_message, err), traceback_obj
+            raise ProcessingError(generic_error_message), None, traceback_obj
 
         after = self.get_progress()
 

--- a/scripts/all-tests.sh
+++ b/scripts/all-tests.sh
@@ -57,7 +57,7 @@ set -e
 
 # Violations thresholds for failing the build
 PYLINT_THRESHOLD=4600
-PEP8_THRESHOLD=10
+PEP8_THRESHOLD=5
 
 source $HOME/jenkins_env
 


### PR DESCRIPTION
This changeset resolves 3 PEP8 issues: It addresses the following
exception-related PEP8 violation:
- W602 deprecated form of raising exception
