### PR TITLE
Fixed HD button in firefox.

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/video/05_video_quality_control.js
+++ b/common/lib/xmodule/xmodule/js/src/video/05_video_quality_control.js
@@ -64,9 +64,9 @@ function () {
         state.videoQualityControl.el.on('click',
             state.videoQualityControl.toggleQuality
         );
-        state.el.on('play', _.once(function () {
-            state.videoQualityControl.fetchAvailableQualities();
-        }));
+        state.el.on('play', _.once(
+            state.videoQualityControl.fetchAvailableQualities
+        ));
     }
 
     // ***************************************************************


### PR DESCRIPTION
Ticket: [TNL-536](https://openedx.atlassian.net/browse/TNL-536)

HD button was not appearing in firefox, binding format for `fetchAvailableQualities()` on play was not working in firefox.
