### PR TITLE
Fixed instructor dashboard tooltip far away issue.

### DIFF
--- a/lms/static/sass/course/instructor/_instructor_2.scss
+++ b/lms/static/sass/course/instructor/_instructor_2.scss
@@ -744,7 +744,7 @@ section.instructor-dashboard-content-2 {
       display: none;
       position: absolute;
       top: 15px;
-      right: 0;
+      left: ($baseline*10);
       padding: ($baseline/2);
       width: 50%;
       background-color: $light-gray;


### PR DESCRIPTION
Ticket: [TNL-558](https://openedx.atlassian.net/browse/TNL-558)

On Membership page of Instructor Dashboard, tooltips appear far away from the associated controls.

Sandbox Link For Testing: [Instructor Dashboard Membership Page](http://waheedahmed.m.sandbox.edx.org/courses/edX/DemoX/Demo_Course/instructor#view-membership)
