### PR TITLE
Update UserCourseTag model to have modified and created timestamps.

### DIFF
--- a/common/djangoapps/user_api/migrations/0004_auto__add_field_usercoursetag_created__add_field_usercoursetag_modifie.py
+++ b/common/djangoapps/user_api/migrations/0004_auto__add_field_usercoursetag_created__add_field_usercoursetag_modifie.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+from contextlib import contextmanager
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    @contextmanager
+    def lock_table(self, table_name):
+        """ Context manager for locking a table (MySQL only) """
+        # Lock tables only under MySQL (it isn't supported for SQLLite)
+        is_mysql = (db.backend_name == 'mysql')
+
+        # Before the block executes, lock the specified table
+        if is_mysql:
+            db.execute("LOCK TABLE {table} WRITE".format(table=table_name))
+
+        # Execute the block
+        yield
+
+        # Add a deferred statement to unlock tables
+        # This will ensure that tables stay locked until
+        # all deferred SQL executes
+        # (for example, creating foreign key constraints and adding indices)
+        if is_mysql:
+            db.add_deferred_sql("UNLOCK TABLES")
+
+    def forwards(self, orm):
+
+        with self.lock_table('user_api_usercoursetag'):
+            # Adding field 'UserCourseTag.created'
+            db.add_column('user_api_usercoursetag', 'created',
+                          self.gf('model_utils.fields.AutoCreatedField')(default=datetime.datetime.now),
+                          keep_default=False)
+
+            # Adding field 'UserCourseTag.modified'
+            db.add_column('user_api_usercoursetag', 'modified',
+                          self.gf('model_utils.fields.AutoLastModifiedField')(default=datetime.datetime.now),
+                          keep_default=False)
+
+            # Changing field 'UserCourseTag.course_id'
+            db.alter_column('user_api_usercoursetag', 'course_id', self.gf('xmodule_django.models.CourseKeyField')(max_length=255))
+
+    def backwards(self, orm):
+        # Deleting field 'UserCourseTag.created'
+        db.delete_column('user_api_usercoursetag', 'created')
+
+        # Deleting field 'UserCourseTag.modified'
+        db.delete_column('user_api_usercoursetag', 'modified')
+
+        # Changing field 'UserCourseTag.course_id'
+        db.alter_column('user_api_usercoursetag', 'course_id', self.gf('django.db.models.fields.CharField')(max_length=255))
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'user_api.usercoursetag': {
+            'Meta': {'unique_together': "(('user', 'course_id', 'key'),)", 'object_name': 'UserCourseTag'},
+            'course_id': ('xmodule_django.models.CourseKeyField', [], {'max_length': '255', 'db_index': 'True'}),
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'+'", 'to': "orm['auth.User']"}),
+            'value': ('django.db.models.fields.TextField', [], {})
+        },
+        'user_api.userpreference': {
+            'Meta': {'unique_together': "(('user', 'key'),)", 'object_name': 'UserPreference'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'preferences'", 'to': "orm['auth.User']"}),
+            'value': ('django.db.models.fields.TextField', [], {})
+        }
+    }
+
+    complete_apps = ['user_api']

--- a/common/djangoapps/user_api/models.py
+++ b/common/djangoapps/user_api/models.py
@@ -1,6 +1,7 @@
 from django.contrib.auth.models import User
 from django.core.validators import RegexValidator
 from django.db import models
+from model_utils.models import TimeStampedModel
 
 from xmodule_django.models import CourseKeyField
 
@@ -47,7 +48,7 @@ class UserPreference(models.Model):
             return default
 
 
-class UserCourseTag(models.Model):
+class UserCourseTag(TimeStampedModel):
     """
     Per-course user tags, to be used by various things that want to store tags about
     the user.  Added initially to store assignment to experimental groups.

--- a/common/djangoapps/user_api/tests/test_models.py
+++ b/common/djangoapps/user_api/tests/test_models.py
@@ -1,7 +1,8 @@
 from django.db import IntegrityError
 from django.test import TestCase
+from xmodule.modulestore.tests.factories import CourseFactory
 from student.tests.factories import UserFactory
-from user_api.tests.factories import UserPreferenceFactory
+from user_api.tests.factories import UserPreferenceFactory, UserCourseTagFactory
 from user_api.models import UserPreference
 
 
@@ -19,14 +20,41 @@ class UserPreferenceModelTest(TestCase):
 
     def test_arbitrary_values(self):
         user = UserFactory.create()
-        UserPreferenceFactory.create(user=user, key="testkey0", value="")
-        UserPreferenceFactory.create(user=user, key="testkey1", value="This is some English text!")
-        UserPreferenceFactory.create(user=user, key="testkey2", value="{'some': 'json'}")
-        UserPreferenceFactory.create(
+        self._create_and_assert(user=user, key="testkey0", value="")
+        self._create_and_assert(user=user, key="testkey1", value="This is some English text!")
+        self._create_and_assert(user=user, key="testkey2", value="{'some': 'json'}")
+        self._create_and_assert(
             user=user,
             key="testkey3",
             value="\xe8\xbf\x99\xe6\x98\xaf\xe4\xb8\xad\xe5\x9b\xbd\xe6\x96\x87\xe5\xad\x97'"
         )
+
+    def _create_and_assert(self, user, key, value):
+        """Create a new preference and assert the values. """
+        preference = UserPreferenceFactory.create(user=user, key=key, value=value)
+        self.assertEqual(preference.user, user)
+        self.assertEqual(preference.key, key)
+        self.assertEqual(preference.value, value)
+        return preference
+
+    def test_create_user_tags(self):
+        """Create user preference tags and confirm properties are set accordingly. """
+        user = UserFactory.create()
+        course = CourseFactory.create()
+        tag = UserCourseTagFactory.create(user=user, course_id=course.id, key="testkey", value="foobar")
+        self.assertEquals(tag.user, user)
+        self.assertEquals(tag.course_id, course.id)
+        self.assertEquals(tag.key, "testkey")
+        self.assertEquals(tag.value, "foobar")
+        self.assertIsNotNone(tag.created)
+        self.assertIsNotNone(tag.modified)
+
+        # Modify the tag and save it. Check if the modified timestamp is updated.
+        original_modified = tag.modified
+        tag.value = "barfoo"
+        tag.save()
+        self.assertEquals(tag.value, "barfoo")
+        self.assertNotEqual(original_modified, tag.modified)
 
     def test_get_set_preference(self):
         # Checks that you can set a preference and get that preference later


### PR DESCRIPTION
This is for ECOM-525, sub-task ECOM-682 to update the UserCourseTag model to have a modified and created timestamp. Added tests to ensure they are updated as expected with interactions for the models. Cleaned up another test in the file while I was in there. 

@rlucioni @wedaly @dianakhuang 

Re: UserCourseTag model @shnayder I was curious if there was a specific desire to use this model for the "Email Opt-In" setting versus creating a new UserOrgTag Model.  As I understand it, we want to use theUserCourseTag model so we could audit which course a user enrolled in when they decided to opt in/out of emails.  Otherwise, I just wanted to check to see if it's possible we want a UserOrgTag Model instead, which links a user preference to an organization. 
