### PR TITLE
Adding an XBlock to display School Yourself lessons, to be used in AlgebraX and GeometryX

### DIFF
--- a/requirements/edx/edx-private.txt
+++ b/requirements/edx/edx-private.txt
@@ -17,3 +17,7 @@
 # It is an R&D prototype, intended for roll-out one location in one course. 
 # It should not be used without learning sciences support in the current state. 
 -e git+https://github.com/pmitros/RecommenderXBlock.git@b4f3596d095d88bb4540f0d04ab81836d84edc98#egg=recommender-xblock
+
+# This repository contains schoolyourself-xblock, which is used in
+# edX's "AlgebraX" and "GeometryX" courses.
+-e git+https://github.com/schoolyourself/schoolyourself-xblock.git@ae028c3c185d1abf93823f7a5d946a8e66b8e7d9#egg=schoolyourself-xblock


### PR DESCRIPTION
Hi edX team,
This PR contains a single change to one of the requirements files, which points to XBlocks that we'll be using for the upcoming AlgebraX and GeometryX courses (https://www.edx.org/school/schoolyourself). We've been up to the edX office a couple of times to talk to the team about it (but mostly I've been pestering @nedbat). We're on track to launch all of our content in Q1 2015, but we've finished up the XBlock part of our work early in the hope of testing on Edge sooner rather than later.

These XBlocks essentially display iframes and send data back and forth between edX and School Yourself. In many ways they are like LTI components, although there are some slight differences that made us go with this route rather than using the built-in LTI XModule. For more info, there's a short summary and screenshots in the README of https://github.com/schoolyourself/schoolyourself-xblock.

I have sandbox production stack running with this change. See here for an example, and feel free to mess around with it: http://edx.schoolyourself.org/courses/SchoolYourself/AlgebraX/2015_T1/courseware/6980e6d535d145d9bea927be4b2388a3/1369f4827e8946dc992ad044e23fdeff/   (log in with "staff@example.com" / "edx").

There are two things I'm not too sure about:
- One issue I have run into is that the Progress tab never seems to get updated in this demo (it works just fine on devstack when I run locally). Looking at the logs, I suspect that I don't have my prod stack configured properly, as I get a bunch of HTTP 500s being thrown by XQueue whenever the XBlock publishes a grade event. I've posted some gory details here: https://groups.google.com/forum/#!topic/edx-code/QP-MOSfu-pw
- In order to get this to work on this sandbox, I had to set `ALLOW_ALL_ADVANCED_COMPONENTS` to `True` in `cms/envs/common.py`. I'm not sure how this is configured on edx.org, but I assume (based on the comments in that file) that it's `False` in production on edx.org and that there is some other place that contains a pre-approved list of XBlocks that are allowed. Since we plan to run this on edx.org, do I need to update another place in the code to enable this in production?
