### PR TITLE
Create new API endpoint for email optin

### DIFF
--- a/common/djangoapps/user_api/tests/test_profile_api.py
+++ b/common/djangoapps/user_api/tests/test_profile_api.py
@@ -1,14 +1,18 @@
 # -*- coding: utf-8 -*-
 """ Tests for the profile API. """
+from django.contrib.auth.models import User
 
 from django.test import TestCase
 import ddt
+from django.test.utils import override_settings
 from nose.tools import raises
 from dateutil.parser import parse as parse_datetime
+from xmodule.modulestore.tests.factories import CourseFactory
+import datetime
 
 from user_api.api import account as account_api
 from user_api.api import profile as profile_api
-from user_api.models import UserProfile
+from user_api.models import UserProfile, UserOrgTag
 
 
 @ddt.ddt
@@ -93,6 +97,84 @@ class ProfileApiTest(TestCase):
 
         preferences = profile_api.preference_info(self.USERNAME)
         self.assertEqual(preferences['preference_key'], 'preference_value')
+
+    @ddt.data(
+        # Check that a 27 year old can opt-in
+        (27, True, u"True"),
+
+        # Check that a 32-year old can opt-out
+        (32, False, u"False"),
+
+        # Check that someone 13 years old can opt-in
+        (13, True, u"True"),
+
+        # Check that someone 12 years old cannot opt-in
+        (12, True, u"False")
+    )
+    @ddt.unpack
+    @override_settings(EMAIL_OPTIN_MINIMUM_AGE=13)
+    def test_update_email_optin(self, age, option, expected_result):
+        # Create the course and account.
+        course = CourseFactory.create()
+        account_api.create_account(self.USERNAME, self.PASSWORD, self.EMAIL)
+
+        # Set year of birth
+        user = User.objects.get(username=self.USERNAME)
+        profile = UserProfile.objects.get(user=user)
+        year_of_birth = datetime.datetime.now().year - age  # pylint: disable=maybe-no-member
+        profile.year_of_birth = year_of_birth
+        profile.save()
+
+        profile_api.update_email_opt_in(self.USERNAME, course.id.org, option)
+        result_obj = UserOrgTag.objects.get(user=user, org=course.id.org, key='email-optin')
+        self.assertEqual(result_obj.value, expected_result)
+
+    def test_update_email_optin_no_age_set(self):
+        # Test that the API still works if no age is specified.
+        # Create the course and account.
+        course = CourseFactory.create()
+        account_api.create_account(self.USERNAME, self.PASSWORD, self.EMAIL)
+
+        user = User.objects.get(username=self.USERNAME)
+
+        profile_api.update_email_opt_in(self.USERNAME, course.id.org, True)
+        result_obj = UserOrgTag.objects.get(user=user, org=course.id.org, key='email-optin')
+        self.assertEqual(result_obj.value, u"True")
+
+    @ddt.data(
+        # Check that a 27 year old can opt-in, then out.
+        (27, True, False, u"False"),
+
+        # Check that a 32-year old can opt-out, then in.
+        (32, False, True, u"True"),
+
+        # Check that someone 13 years old can opt-in, then out.
+        (13, True, False, u"False"),
+
+        # Check that someone 12 years old cannot opt-in, then explicitly out.
+        (12, True, False, u"False")
+    )
+    @ddt.unpack
+    @override_settings(EMAIL_OPTIN_MINIMUM_AGE=13)
+    def test_change_email_optin(self, age, option, second_option, expected_result):
+        # Create the course and account.
+        course = CourseFactory.create()
+        account_api.create_account(self.USERNAME, self.PASSWORD, self.EMAIL)
+
+        # Set year of birth
+        user = User.objects.get(username=self.USERNAME)
+        profile = UserProfile.objects.get(user=user)
+        year_of_birth = datetime.datetime.now().year - age  # pylint: disable=maybe-no-member
+        profile.year_of_birth = year_of_birth
+        profile.save()
+
+        profile_api.update_email_opt_in(self.USERNAME, course.id.org, option)
+        profile_api.update_email_opt_in(self.USERNAME, course.id.org, second_option)
+
+        result_obj = UserOrgTag.objects.get(user=user, org=course.id.org, key='email-optin')
+        self.assertEqual(result_obj.value, expected_result)
+
+
 
     @raises(profile_api.ProfileUserNotFound)
     def test_retrieve_and_update_preference_info_no_user(self):

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1365,6 +1365,10 @@ BULK_EMAIL_LOG_SENT_EMAILS = False
 # parallel, and what the SES rate is.
 BULK_EMAIL_RETRY_DELAY_BETWEEN_SENDS = 0.02
 
+############################# Email Opt In ####################################
+
+# Minimum age for organization-wide email opt in
+EMAIL_OPTIN_MINIMUM_AGE = 13
 
 ############################## Video ##########################################
 


### PR DESCRIPTION
Creating a new Email Opt-In Endpoint in the profile API for ECOM-525, sub task ECOM-685. This hooks into the new User Org Tag model. 

@dianakhuang @rlucioni
