### PR TITLE
Updating the marketing iframe, courseware views, and student views for email opt-in

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -102,6 +102,7 @@ from third_party_auth import pipeline, provider
 from student.helpers import auth_pipeline_urls, set_logged_in_cookie
 from xmodule.error_module import ErrorDescriptor
 from shoppingcart.models import CourseRegistrationCode
+from user_api.api import profile as profile_api
 
 import analytics
 from eventtracking import tracker
@@ -739,6 +740,12 @@ def try_change_enrollment(request):
             log.exception("Exception automatically enrolling after login: %s", exc)
 
 
+def _update_email_opt_in(request, username, org):
+    """Helper function used to hit the profile API if email opt-in is enabled."""
+    email_opt_in = request.POST.get('email_opt_in') == 'true'
+    profile_api.update_email_opt_in(username, org, email_opt_in)
+
+
 @require_POST
 @commit_on_success_with_read_committed
 def change_enrollment(request, check_access=True):
@@ -803,6 +810,10 @@ def change_enrollment(request, check_access=True):
             log.warning("User {0} tried to enroll in non-existent course {1}"
                         .format(user.username, course_id))
             return HttpResponseBadRequest(_("Course id is invalid"))
+
+        # Record the user's email opt-in preference
+        if settings.FEATURES.get('ENABLE_MKTG_EMAIL_OPT_IN'):
+            _update_email_opt_in(request, user.username, course_id.org)
 
         available_modes = CourseMode.modes_for_course_dict(course_id)
 

--- a/common/djangoapps/util/cache.py
+++ b/common/djangoapps/util/cache.py
@@ -43,17 +43,13 @@ def cache_if_anonymous(*get_parameters):
     @cache_if_anonymous()
     def myView(request):
     """
-
     def decorator(view_func):
-        """The outer wrapper, used to allow the decorator to take optional
-        arguments.
-        """
+        """The outer wrapper, used to allow the decorator to take optional arguments."""
         @wraps(view_func)
         def wrapper(request, *args, **kwargs):
             """The inner wrapper, which wraps the view function."""
             if not request.user.is_authenticated():
-                #Use the cache
-                # same view accessed through different domain names may
+                # Use the cache. The same view accessed through different domain names may
                 # return different things, so include the domain name in the key.
                 domain = str(request.META.get('HTTP_HOST')) + '.'
                 cache_key = domain + "cache_if_anonymous." + get_language() + '.' + request.path
@@ -70,7 +66,7 @@ def cache_if_anonymous(*get_parameters):
                 return response
 
             else:
-                #Don't use the cache
+                # Don't use the cache.
                 return view_func(request, *args, **kwargs)
 
         return wrapper

--- a/lms/djangoapps/branding/views.py
+++ b/lms/djangoapps/branding/views.py
@@ -33,7 +33,7 @@ def get_course_enrollments(user):
 
 
 @ensure_csrf_cookie
-@cache_if_anonymous
+@cache_if_anonymous()
 def index(request):
     '''
     Redirects to main page -- info page if user authenticated, or marketing if not
@@ -81,7 +81,7 @@ def index(request):
 
 
 @ensure_csrf_cookie
-@cache_if_anonymous
+@cache_if_anonymous()
 def courses(request):
     """
     Render the "find courses" page. If the marketing site is enabled, redirect

--- a/lms/djangoapps/static_template_view/views.py
+++ b/lms/djangoapps/static_template_view/views.py
@@ -30,7 +30,7 @@ def index(request, template):
 
 
 @ensure_csrf_cookie
-@cache_if_anonymous
+@cache_if_anonymous()
 def render(request, template):
     """
     This view function renders the template sent without checking that it
@@ -43,7 +43,7 @@ def render(request, template):
 
 
 @ensure_csrf_cookie
-@cache_if_anonymous
+@cache_if_anonymous()
 def render_press_release(request, slug):
     """
     Render a press release given a slug.  Similar to the "render" function above,

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -283,6 +283,9 @@ FEATURES = {
     # Enable the combined login/registration form
     'ENABLE_COMBINED_LOGIN_REGISTRATION': False,
 
+    # Enable organizational email opt-in
+    'ENABLE_MKTG_EMAIL_OPT_IN': False,
+
     # Show a section in the membership tab of the instructor dashboard
     # to allow an upload of a CSV file that contains a list of new accounts to create
     # and register for course.

--- a/lms/templates/courseware/mktg_course_about.html
+++ b/lms/templates/courseware/mktg_course_about.html
@@ -16,6 +16,14 @@
   <script type="text/javascript">
   (function() {
     $(".register").click(function(event) {
+      if ( !$("#email-opt-in").prop("checked") ) {
+        $("input[name='email_opt_in']").val("false");
+      }
+
+      var email_opt_in = $("input[name='email_opt_in']").val(),
+        current_href = $("a.register").attr("href");
+      $("a.register").attr("href", current_href + "&email_opt_in=" + email_opt_in)
+
       $("#class_enroll_form").submit();
       event.preventDefault();
     });
@@ -29,7 +37,9 @@
           window.top.location.href = "${reverse('dashboard')}";
         }
       } else if (xhr.status == 403) {
-        window.top.location.href = $("a.register").attr("href") || "${reverse('register_user')}?course_id=${course.id | u}&enrollment_action=enroll";
+        var email_opt_in = $("input[name='email_opt_in']").val();
+        ## Ugh.
+        window.top.location.href = $("a.register").attr("href") || "${reverse('register_user')}?course_id=${course.id | u}&enrollment_action=enroll&email_opt_in=" + email_opt_in;
       } else {
         $('#register_error').html(
             (xhr.responseText ? xhr.responseText : "${_("An error occurred. Please try again later.")}")
@@ -71,6 +81,23 @@
             </span>
             %endif
         </a>
+
+        % if settings.FEATURES.get('ENABLE_MKTG_EMAIL_OPT_IN'):
+          ## We only display the email opt-in checkbox if we've been given a valid full name (i.e., not None)
+          % if organization_full_name:
+            <p class="form-field">
+              <input id="email-opt-in" type="checkbox" name="opt-in" class="email-opt-in" value="true" checked>
+              <label for="email-opt-in">
+                ## Translators: This line appears next a checkbox which users can leave checked or uncheck in order
+                ## to indicate whether they want to receive emails from the organization offering the course.
+                ${_("I would like to receive email about other {organization_full_name} programs and offers.").format(
+                  organization_full_name=organization_full_name
+                )}
+              </label>
+            </p>
+          % endif
+        % endif
+
         %else:
           <div class="action registration-closed is-disabled">${_("Enrollment Is Closed")}</div>
         %endif
@@ -83,6 +110,7 @@
       <fieldset class="enroll_fieldset">
         <input name="course_id" type="hidden" value="${course.id | h}">
         <input name="enrollment_action" type="hidden" value="enroll">
+        <input name="email_opt_in" type="hidden" value="true">
         <input type="hidden" name="csrfmiddlewaretoken" value="${ csrf_token }">
       </fieldset>
       <div class="submit">


### PR DESCRIPTION
Feature flagged where necessary. This puts a checkbox in the marketing iframe. The iframe uses an `organization_full_name` parameter forwarded from Drupal by the courseware views and POSTs an `email_opt_in` parameter to the student views, preserving it on 403.

Related to the ECOM-525 story, subtasks ECOM-681 and ECOM-686.

@stephensanchez and @wedaly, could you please review this when you're able? @AlasdairSwan, FYI.
