### PR TITLE
Fix recently added PEP8 violations

### DIFF
--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -452,6 +452,7 @@ def parse_query_params(strategy, response, *args, **kwargs):
         'is_register_2': auth_entry == AUTH_ENTRY_REGISTER_2,
     }
 
+
 # TODO (ECOM-369): Once the A/B test of the combined login/registration
 # form completes, we will be able to remove the extra login/registration
 # end-points.  HOWEVER, users who used the new forms during the A/B

--- a/common/djangoapps/user_api/api/profile.py
+++ b/common/djangoapps/user_api/api/profile.py
@@ -16,6 +16,7 @@ from user_api.helpers import intercept_errors
 
 log = logging.getLogger(__name__)
 
+
 class ProfileRequestError(Exception):
     """ The request to the API was not valid. """
     pass

--- a/common/djangoapps/user_api/tests/test_profile_api.py
+++ b/common/djangoapps/user_api/tests/test_profile_api.py
@@ -174,8 +174,6 @@ class ProfileApiTest(TestCase):
         result_obj = UserOrgTag.objects.get(user=user, org=course.id.org, key='email-optin')
         self.assertEqual(result_obj.value, expected_result)
 
-
-
     @raises(profile_api.ProfileUserNotFound)
     def test_retrieve_and_update_preference_info_no_user(self):
         preferences = profile_api.preference_info(self.USERNAME)

--- a/common/test/acceptance/pages/lms/instructor_dashboard.py
+++ b/common/test/acceptance/pages/lms/instructor_dashboard.py
@@ -13,6 +13,7 @@ class InstructorDashboardPage(CoursePage):
     Instructor dashboard, where course staff can manage a course.
     """
     url_path = "instructor"
+
     def is_browser_on_page(self):
         return self.q(css='div.instructor-dashboard-wrapper-2').present
 
@@ -31,6 +32,7 @@ class MembershipPage(PageObject):
     Membership section of the Instructor dashboard.
     """
     url = None
+
     def is_browser_on_page(self):
         return self.q(css='a[data-section=membership].active-section').present
 

--- a/scripts/all-tests.sh
+++ b/scripts/all-tests.sh
@@ -57,7 +57,7 @@ set -e
 
 # Violations thresholds for failing the build
 PYLINT_THRESHOLD=4600
-PEP8_THRESHOLD=5
+PEP8_THRESHOLD=0
 
 source $HOME/jenkins_env
 


### PR DESCRIPTION
These violations were introduced recently, _after_ we had removed all
instances of these violations. As of now, these represent the final PEP8
violations.

This PR also drops the PEP8 threshold down to zero violations (!!!), so
it will need to be merged _after_ #6045 lands.
