### PR TITLE
In user profile changing page should reposition window to top

### DIFF
--- a/common/static/coffee/src/discussion/views/discussion_user_profile_view.coffee
+++ b/common/static/coffee/src/discussion/views/discussion_user_profile_view.coffee
@@ -37,6 +37,7 @@ if Backbone?
           @numPages = response.num_pages
           @discussion.reset(response.discussion_data, {silent: false})
           history.pushState({}, "", url)
+          $("html, body").animate({ scrollTop: 0 });
         error: =>
           DiscussionUtil.discussionAlert(
             gettext("Sorry"),

--- a/common/test/acceptance/pages/lms/discussion.py
+++ b/common/test/acceptance/pages/lms/discussion.py
@@ -1,5 +1,6 @@
 from contextlib import contextmanager
 
+from bok_choy.javascript import wait_for_js
 from bok_choy.page_object import PageObject
 from bok_choy.promise import EmptyPromise, Promise
 
@@ -342,6 +343,10 @@ class DiscussionUserProfilePage(CoursePage):
             and
             self.q(css='section.user-profile div.sidebar-username').text[0] == self.username
         )
+
+    @wait_for_js
+    def is_window_on_top(self):
+        return self.browser.execute_script("return $('html, body').offset().top") == 0
 
     def get_shown_thread_ids(self):
         elems = self.q(css="article.discussion-thread")

--- a/common/test/acceptance/tests/discussion/test_discussion.py
+++ b/common/test/acceptance/tests/discussion/test_discussion.py
@@ -419,6 +419,7 @@ class DiscussionUserProfileTest(UniqueCourseTest):
         current_page = 1
         total_pages = max(num_threads - 1, 1) / self.PAGE_SIZE + 1
         all_pages = range(1, total_pages + 1)
+        return page
 
         def _check_page():
             # ensure the page being displayed as "current" is the expected one
@@ -478,6 +479,12 @@ class DiscussionUserProfileTest(UniqueCourseTest):
 
     def test_151_threads(self):
         self.check_pages(151)
+
+    def test_pagination_window_reposition(self):
+        page = self.check_pages(50)
+        page.click_next_page()
+        page.wait_for_ajax()
+        self.assertTrue(page.is_window_on_top())
 
 
 @attr('shard_1')


### PR DESCRIPTION
When we change the page using pagination in the user
profile page the data gets updated but the position
of the window remains at pagination. It should change
position of window to top.

TNL-107
