### PR TITLE
Hooking the logistration page into the new HTTP endpoint for email opt in

### DIFF
--- a/common/djangoapps/user_api/urls.py
+++ b/common/djangoapps/user_api/urls.py
@@ -20,6 +20,12 @@ urlpatterns = patterns(
         r'^v1/forum_roles/(?P<name>[a-zA-Z]+)/users/$',
         user_api_views.ForumRoleUsersListView.as_view()
     ),
+
+    url(
+        r'^v1/preferences/email_opt_in/$',
+        user_api_views.UpdateEmailOptInPreference.as_view(),
+        name="preferences_email_opt_in"
+    ),
 )
 
 if settings.FEATURES.get('ENABLE_COMBINED_LOGIN_REGISTRATION'):

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1046,6 +1046,7 @@ student_account_js = [
     'js/utils/edx.utils.validate.js',
     'js/src/utility.js',
     'js/student_account/enrollment.js',
+    'js/student_account/emailoptin.js',
     'js/student_account/shoppingcart.js',
     'js/student_account/models/LoginModel.js',
     'js/student_account/models/RegisterModel.js',

--- a/lms/static/js/spec/main.js
+++ b/lms/static/js/spec/main.js
@@ -293,6 +293,10 @@
                 exports: 'edx.student.account.EnrollmentInterface',
                 deps: ['jquery', 'jquery.cookie']
             },
+            'js/student_account/emailoptin': {
+                exports: 'edx.student.account.EmailOptInInterface',
+                deps: ['jquery', 'jquery.cookie']
+            },
             'js/student_account/shoppingcart': {
                 exports: 'edx.student.account.ShoppingCartInterface',
                 deps: ['jquery', 'jquery.cookie', 'underscore']
@@ -362,6 +366,7 @@
                     'js/student_account/models/PasswordResetModel',
                     'js/student_account/models/RegisterModel',
                     'js/student_account/views/FormView',
+                    'js/student_account/emailoptin',
                     'js/student_account/enrollment',
                     'js/student_account/shoppingcart',
                 ]
@@ -383,6 +388,7 @@
         'lms/include/js/spec/student_account/register_spec.js',
         'lms/include/js/spec/student_account/password_reset_spec.js',
         'lms/include/js/spec/student_account/enrollment_spec.js',
+        'lms/include/js/spec/student_account/emailoptin_spec.js',
         'lms/include/js/spec/student_account/shoppingcart_spec.js',
         'lms/include/js/spec/student_profile/profile_spec.js'
     ]);

--- a/lms/static/js/spec/student_account/access_spec.js
+++ b/lms/static/js/spec/student_account/access_spec.js
@@ -5,7 +5,8 @@ define([
     'js/student_account/views/AccessView',
     'js/student_account/views/FormView',
     'js/student_account/enrollment',
-    'js/student_account/shoppingcart'
+    'js/student_account/shoppingcart',
+    'js/student_account/emailoptin'
 ], function($, TemplateHelpers, AjaxHelpers, AccessView, FormView, EnrollmentInterface, ShoppingCartInterface) {
         describe('edx.student.account.AccessView', function() {
             'use strict';

--- a/lms/static/js/spec/student_account/emailoptin_spec.js
+++ b/lms/static/js/spec/student_account/emailoptin_spec.js
@@ -1,0 +1,28 @@
+define(['js/common_helpers/ajax_helpers', 'js/student_account/emailoptin'],
+    function( AjaxHelpers, EmailOptInInterface ) {
+        'use strict';
+
+        describe( 'edx.student.account.EmailOptInInterface', function() {
+
+            var COURSE_KEY = 'edX/DemoX/Fall',
+                EMAIL_OPT_IN = 'True',
+                EMAIL_OPT_IN_URL = '/user_api/v1/preferences/email_opt_in/';
+
+            it('Opts in for organization emails', function() {
+                // Spy on Ajax requests
+                var requests = AjaxHelpers.requests( this );
+
+                // Attempt to enroll the user
+                EmailOptInInterface.setPreference( COURSE_KEY, EMAIL_OPT_IN );
+
+                // Expect that the correct request was made to the server
+                AjaxHelpers.expectRequest(
+                    requests, 'POST', EMAIL_OPT_IN_URL, 'course_id=edX%2FDemoX%2FFall&email_opt_in=True'
+                );
+
+                // Simulate a successful response from the server
+                AjaxHelpers.respondWithJson(requests, {});
+            });
+        });
+    }
+);

--- a/lms/static/js/student_account/emailoptin.js
+++ b/lms/static/js/student_account/emailoptin.js
@@ -1,0 +1,35 @@
+var edx = edx || {};
+
+(function($) {
+    'use strict';
+
+    edx.student = edx.student || {};
+    edx.student.account = edx.student.account || {};
+
+    edx.student.account.EmailOptInInterface = {
+
+        urls: {
+            emailOptInUrl: '/user_api/v1/preferences/email_opt_in/'
+        },
+
+        headers: {
+            'X-CSRFToken': $.cookie('csrftoken')
+        },
+
+        /**
+         * Set the email opt in setting for the organization associated
+         * with this course.
+         * @param  {string} courseKey  Slash-separated course key.
+         * @param {string} emailOptIn The preference to opt in or out of organization emails.
+         */
+        setPreference: function( courseKey, emailOptIn, context ) {
+            return $.ajax({
+                url: this.urls.emailOptInUrl,
+                type: 'POST',
+                data: {course_id: courseKey, email_opt_in: emailOptIn},
+                headers: this.headers,
+                context: context
+            });
+        }
+    };
+})(jQuery);

--- a/lms/static/js/student_account/views/AccessView.js
+++ b/lms/static/js/student_account/views/AccessView.js
@@ -170,6 +170,33 @@ var edx = edx || {};
          * Once authentication has completed successfully, a user may need to:
          *
          * - Enroll in a course.
+         * - Update email opt-in preferences
+         *
+         * These actions are delegated from the authComplete function to additional
+         * functions requiring authentication.
+         *
+         */
+        authComplete: function() {
+            var emailOptIn = edx.student.account.EmailOptInInterface,
+                queryParams = this.queryParams();
+
+            // Set the email opt in preference.
+            if (!_.isUndefined(queryParams.emailOptIn) && queryParams.enrollmentAction) {
+                emailOptIn.setPreference(
+                    decodeURIComponent(queryParams.courseId),
+                    queryParams.emailOptIn,
+                    this
+                ).always(this.enrollment);
+            } else {
+                this.enrollment();
+            }
+        },
+
+        /**
+         * Designed to be invoked after authentication has completed. This function enrolls
+         * the student as requested.
+         *
+         * - Enroll in a course.
          * - Add a course to the shopping cart.
          * - Be redirected to the dashboard / track selection page / shopping cart.
          *
@@ -191,7 +218,7 @@ var edx = edx || {};
          * ?course_id: The slash-separated course ID to enroll in or add to the cart.
          *
          */
-        authComplete: function() {
+        enrollment: function() {
             var enrollment = edx.student.account.EnrollmentInterface,
                 shoppingcart = edx.student.account.ShoppingCartInterface,
                 redirectUrl = '/dashboard',
@@ -248,7 +275,8 @@ var edx = edx || {};
             return {
                 next: $.url( '?next' ),
                 enrollmentAction: $.url( '?enrollment_action' ),
-                courseId: $.url( '?course_id' )
+                courseId: $.url( '?course_id' ),
+                emailOptIn: $.url( '?email_opt_in')
             };
         },
 


### PR DESCRIPTION
Updating the Login and Registration page to accept the email_opt_in parameter, which will set an organization-wide setting for receiving emails.

Related to the ECOM-525 story, sub task ECOM-680

@rlucioni @wedaly 
