### PR TITLE
Enforce pylint violation when using old event tracker.

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -230,7 +230,7 @@ additional-builtins=
 [IMPORTS]
 
 # Deprecated modules which should not be used, separated by a comma
-deprecated-modules=regsub,string,TERMIOS,Bastion,rexec
+deprecated-modules=regsub,string,TERMIOS,Bastion,rexec,track.views
 
 # Create a graph of every (i.e. internal and external) dependencies in the
 # given file (report RP0402 must not be disabled)


### PR DESCRIPTION
This is a deprecated use and we need to be sure others don't adopt it.
