### PR TITLE
Set REQUIRE_COURSE_EMAIL_AUTH to False

### DIFF
--- a/lms/djangoapps/instructor/tests/test_legacy_email.py
+++ b/lms/djangoapps/instructor/tests/test_legacy_email.py
@@ -96,6 +96,7 @@ class TestInstructorDashboardEmailView(ModuleStoreTestCase):
     def test_email_flag_true_xml_store(self):
         # If the enable email setting is enabled, but this is an XML backed course,
         # the email view shouldn't be available on the instructor dashboard.
+        # It doesn't matter what value of 'REQUIRE_COURSE_EMAIL_AUTH' is.
 
         # The course factory uses a MongoModuleStore backing, so patch the
         # `get_modulestore_type` method to pretend to be XML-backed.
@@ -109,7 +110,7 @@ class TestInstructorDashboardEmailView(ModuleStoreTestCase):
             response = self.client.get(self.url)
             self.assertFalse(self.email_link in response.content)
 
-    @patch.dict(settings.FEATURES, {'ENABLE_INSTRUCTOR_EMAIL': True})
+    @patch.dict(settings.FEATURES, {'ENABLE_INSTRUCTOR_EMAIL': True, 'REQUIRE_COURSE_EMAIL_AUTH': True})
     def test_send_mail_unauthorized(self):
         """ Test 'Send email' action returns an error if course is not authorized to send email. """
 
@@ -123,7 +124,7 @@ class TestInstructorDashboardEmailView(ModuleStoreTestCase):
         )
         self.assertContains(response, "Email is not enabled for this course.")
 
-    @patch.dict(settings.FEATURES, {'ENABLE_INSTRUCTOR_EMAIL': True})
+    @patch.dict(settings.FEATURES, {'ENABLE_INSTRUCTOR_EMAIL': True, 'REQUIRE_COURSE_EMAIL_AUTH': True})
     def test_send_mail_authorized(self):
         """ Test 'Send email' action when course is authorized to send email. """
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -137,7 +137,7 @@ FEATURES = {
     #   for each course via django-admin interface.
     # If False and ENABLE_INSTRUCTOR_EMAIL: Email will be turned on by default
     #   for all Mongo-backed courses.
-    'REQUIRE_COURSE_EMAIL_AUTH': True,
+    'REQUIRE_COURSE_EMAIL_AUTH': False,
 
     # Analytics experiments - shows instructor analytics tab in LMS instructor dashboard.
     # Enabling this feature depends on installation of a separate analytics server.


### PR DESCRIPTION
In production this value is True.

Changing this config file means that developers, by default, will see course email in their local dev and sandbox environments. This is important for full testing of released features. We shouldn't hide a feature we use on prod behind a feature flag locally.
