### PR TITLE
When fill_in_run() fails, handle failure instead of exception.

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/tests/test_mongo.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_mongo.py
@@ -29,7 +29,7 @@ from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.mongo import MongoKeyValueStore
 from xmodule.modulestore.draft import DraftModuleStore
 from opaque_keys.edx.locations import SlashSeparatedCourseKey, AssetLocation
-from opaque_keys.edx.locator import LibraryLocator
+from opaque_keys.edx.locator import LibraryLocator, CourseLocator
 from opaque_keys.edx.keys import UsageKey
 from xmodule.modulestore.xml_exporter import export_to_xml
 from xmodule.modulestore.xml_importer import import_from_xml, perform_xlint
@@ -42,6 +42,8 @@ from xmodule.x_module import XModuleMixin
 from xmodule.modulestore.mongo.base import as_draft
 from xmodule.modulestore.tests.mongo_connection import MONGO_PORT_NUM, MONGO_HOST
 from xmodule.modulestore.edit_info import EditInfoMixin
+from xmodule.modulestore.exceptions import ItemNotFoundError
+
 
 log = logging.getLogger(__name__)
 
@@ -700,6 +702,11 @@ class TestMongoModuleStoreWithNoAssetCollection(TestMongoModuleStore):
         course = courses[0]
         # Confirm that no specified asset collection name means empty asset metadata.
         self.assertEquals(self.draft_store.get_all_asset_metadata(course.id, 'asset'), [])
+
+    def test_no_asset_invalid_key(self):
+        course_key = CourseLocator(org="edx3", course="test_course", run=None, deprecated=True)
+        # Confirm that invalid course key raises ItemNotFoundError
+        self.assertRaises(ItemNotFoundError, lambda: self.draft_store.get_all_asset_metadata(course_key, 'asset')[:1])
 
 
 class TestMongoKeyValueStore(object):


### PR DESCRIPTION
@dmitchell  This PR is in response to some unhandled exceptions I've seen on production. Here's one:

```
Dec  1 03:35:28 ip-10-2-10-161 [service_variant=lms][django.request][env:prod-edx-edxapp] ERROR [ip-10-2-10-161  29105] [base.py:213] - Internal Server Error: /c4x/mitx/6.00.2x/asset/6002x_additional_resources.pdf
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 87, in get_response
    response = middleware_method(request)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/newrelic-2.18.1.15/newrelic/hooks/framework_django.py", line 221, in wrapper
    return wrapped(*args, **kwargs)
  File "/edx/app/edxapp/edx-platform/common/djangoapps/contentserver/middleware.py", line 46, in process_request
    content = AssetManager.find(loc, as_stream=True)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/assetstore/assetmgr.py", line 54, in find
    content_md = modulestore().find_asset_metadata(asset_key)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/modulestore/mixed.py", line 87, in inner
    retval = func(field_decorator=strip_key_collection, *args, **kwargs)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/modulestore/mixed.py", line 342, in find_asset_metadata
    return store.find_asset_metadata(asset_key, **kwargs)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/modulestore/__init__.py", line 332, in find_asset_metadata
    course_assets, asset_idx = self._find_course_asset(asset_key)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/modulestore/__init__.py", line 301, in _find_course_asset
    course_assets = self._find_course_assets(asset_key.course_key)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/modulestore/mongo/base.py", line 1476, in _find_course_assets
    {'course_id': unicode(course_key)},
  File "/edx/app/edxapp/venvs/edxapp/src/opaque-keys/opaque_keys/__init__.py", line 165, in __unicode__
    return self._to_deprecated_string()
  File "/edx/app/edxapp/venvs/edxapp/src/opaque-keys/opaque_keys/edx/locator.py", line 370, in _to_deprecated_string
    return u'/'.join([self.org, self.course, self.run])
TypeError: sequence item 2: expected string or Unicode, NoneType found
```

@cpennington  Also review.

Should I create a new CourseFactory that doesn't fill in a run to test?
