### PR TITLE
Add paver option to specify js-test-tool port

### DIFF
--- a/pavelib/js_test.py
+++ b/pavelib/js_test.py
@@ -18,12 +18,14 @@ __test__ = False  # do not collect
     ("suite=", "s", "Test suite to run"),
     ("mode=", "m", "dev or run"),
     ("coverage", "c", "Run test under coverage"),
+    ("port=", "p", "Port to run test server on (dev mode only)"),
 ])
 def test_js(options):
     """
     Run the JavaScript tests
     """
     mode = getattr(options, 'mode', 'run')
+    port = None
 
     if mode == 'run':
         suite = getattr(options, 'suite', 'all')
@@ -31,6 +33,7 @@ def test_js(options):
     elif mode == 'dev':
         suite = getattr(options, 'suite', None)
         coverage = False
+        port = getattr(options, 'port')
     else:
         sys.stderr.write("Invalid mode. Please choose 'dev' or 'run'.")
         return
@@ -43,7 +46,7 @@ def test_js(options):
         )
         return
 
-    test_suite = JsTestSuite(suite, mode=mode, with_coverage=coverage)
+    test_suite = JsTestSuite(suite, mode=mode, with_coverage=coverage, port=port)
     test_suite.run()
 
 
@@ -63,6 +66,7 @@ def test_js_run(options):
 @task
 @cmdopts([
     ("suite=", "s", "Test suite to run"),
+    ("port=", "p", "Port to run test server on"),
 ])
 def test_js_dev(options):
     """

--- a/pavelib/utils/test/suites/js_suite.py
+++ b/pavelib/utils/test/suites/js_suite.py
@@ -17,6 +17,7 @@ class JsTestSuite(TestSuite):
         super(JsTestSuite, self).__init__(*args, **kwargs)
         self.run_under_coverage = kwargs.get('with_coverage', True)
         self.mode = kwargs.get('mode', 'run')
+        self.port = kwargs.get('port')
 
         try:
             self.test_id = (Env.JS_TEST_ID_FILES[Env.JS_TEST_ID_KEYS.index(self.root)])
@@ -52,6 +53,9 @@ class JsTestSuite(TestSuite):
                 xunit_report=self.xunit_report,
             )
         )
+
+        if self.port:
+            cmd += " -p {port}".format(port=self.port)
 
         if self.run_under_coverage:
             cmd += " --coverage-xml {report_dir}".format(

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -24,7 +24,7 @@ git+https://github.com/pmitros/django-pyfs.git@d175715e0fe3367ec0f1ee429c242d603
 git+https://github.com/edx/XBlock.git@2029af2a4b524310847decfb34ef39da8a30dc4e#egg=XBlock
 git+https://github.com/edx/codejail.git@66dd5a45e5072666ff9a70c768576e9ffd1daa4b#egg=codejail
 git+https://github.com/edx/diff-cover.git@v0.7.2#egg=diff_cover
-git+https://github.com/edx/js-test-tool.git@v0.1.5#egg=js_test_tool
+git+https://github.com/edx/js-test-tool.git@v0.1.6#egg=js_test_tool
 git+https://github.com/edx/event-tracking.git@0.1.0#egg=event-tracking
 git+https://github.com/edx/bok-choy.git@4a259e3548a19e41cc39433caf68ea58d10a27ba#egg=bok_choy
 git+https://github.com/edx-solutions/django-splash.git@7579d052afcf474ece1239153cffe1c89935bc4f#egg=django-splash


### PR DESCRIPTION
This includes an upgrade to a newer version of js-test-tool that accepts
an option to specify the port number.

@wedaly 
