### PR TITLE
Pin django-cas to hash

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -141,8 +141,5 @@ analytics-python==0.4.4
 
 git+https://github.com/mfogel/django-settings-context-processor.git
 
-# django-cas version 2.0.3 with patch to be compatible with django 1.4
-git+https://github.com/mitocw/django-cas.git
-
 # edX packages
 edx-submissions==0.0.8

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -19,6 +19,7 @@
 -e git+https://github.com/appliedsec/pygeoip.git@95e69341cebf5a6a9fbf7c4f5439d458898bdc3b#egg=pygeoip
 -e git+https://github.com/jazkarta/edx-jsme.git@c5bfa5d361d6685d8c643838fc0055c25f8b7999#egg=edx-jsme
 -e git+https://github.com/pmitros/django-pyfs.git@d175715e0fe3367ec0f1ee429c242d603f6e8b10#egg=djpyfs
+git+https://github.com/mitocw/django-cas.git@60a5b8e5a62e63e0d5d224a87f0b489201a0c695#egg=django-cas
 
 # Our libraries:
 -e git+https://github.com/edx/XBlock.git@2029af2a4b524310847decfb34ef39da8a30dc4e#egg=XBlock


### PR DESCRIPTION
Per the comments in #5992 we are pinning django-cas to prevent a stealth upgrade for changes that happen in that repository.
