### PR TITLE
Only allow users who turned 13 before this year began to opt in.

### DIFF
--- a/common/djangoapps/user_api/api/profile.py
+++ b/common/djangoapps/user_api/api/profile.py
@@ -191,7 +191,7 @@ def update_email_opt_in(username, org, optin):
     profile = UserProfile.objects.get(user=user)
     of_age = (
         profile.year_of_birth is None or  # If year of birth is not set, we assume user is of age.
-        datetime.datetime.now(UTC).year - profile.year_of_birth >=  # pylint: disable=maybe-no-member
+        datetime.datetime.now(UTC).year - profile.year_of_birth >  # pylint: disable=maybe-no-member
         getattr(settings, 'EMAIL_OPTIN_MINIMUM_AGE', 13)
     )
 

--- a/common/djangoapps/user_api/tests/test_profile_api.py
+++ b/common/djangoapps/user_api/tests/test_profile_api.py
@@ -105,8 +105,11 @@ class ProfileApiTest(TestCase):
         # Check that a 32-year old can opt-out
         (32, False, u"False"),
 
-        # Check that someone 13 years old can opt-in
-        (13, True, u"True"),
+        # Check that someone 14 years old can opt-in
+        (14, True, u"True"),
+
+        # Check that someone 13 years old cannot opt-in (must have turned 13 before this year)
+        (13, True, u"False"),
 
         # Check that someone 12 years old cannot opt-in
         (12, True, u"False")


### PR DESCRIPTION
This is a fix for defect ECOM-719.  We only track the year someone was born, not the month / day. We'll be safe by only allowing those users who turned 13 before this year began to opt in for organization emails, to avoid someone at 12 years, 1 month, to get included in the acceptable group. 

Example:
Born December 2nd, 2002.  Current Date January 3rd, 2015. Turns 13 on December 2nd, 2015, but is granted access 11 months early.
Now we run the risk of someone being 13 years old having to wait 11 months to opt in for emails (reversing the example)

@rlucioni @wedaly @griffresch 
