### PR TITLE
Allowing email optin to work on register.

### DIFF
--- a/common/djangoapps/enrollment/views.py
+++ b/common/djangoapps/enrollment/views.py
@@ -11,58 +11,13 @@ from rest_framework.response import Response
 from rest_framework.throttling import UserRateThrottle
 from enrollment import api
 from student.models import NonExistentCourseError, CourseEnrollmentException
+from util.authentication import SessionAuthenticationAllowInactiveUser
 
 
 class EnrollmentUserThrottle(UserRateThrottle):
     """Limit the number of requests users can make to the enrollment API."""
     # TODO Limit significantly after performance testing.  # pylint: disable=fixme
     rate = '50/second'
-
-
-class SessionAuthenticationAllowInactiveUser(SessionAuthentication):
-    """Ensure that the user is logged in, but do not require the account to be active.
-
-    We use this in the special case that a user has created an account,
-    but has not yet activated it.  We still want to allow the user to
-    enroll in courses, so we remove the usual restriction
-    on session authentication that requires an active account.
-
-    You should use this authentication class ONLY for end-points that
-    it's safe for an unactived user to access.  For example,
-    we can allow a user to update his/her own enrollments without
-    activating an account.
-
-    """
-    def authenticate(self, request):
-        """Authenticate the user, requiring a logged-in account and CSRF.
-
-        This is exactly the same as the `SessionAuthentication` implementation,
-        with the `user.is_active` check removed.
-
-        Args:
-            request (HttpRequest)
-
-        Returns:
-            Tuple of `(user, token)`
-
-        Raises:
-            PermissionDenied: The CSRF token check failed.
-
-        """
-        # Get the underlying HttpRequest object
-        request = request._request  # pylint: disable=protected-access
-        user = getattr(request, 'user', None)
-
-        # Unauthenticated, CSRF validation not required
-        # This is where regular `SessionAuthentication` checks that the user is active.
-        # We have removed that check in this implementation.
-        if not user:
-            return None
-
-        self.enforce_csrf(request)
-
-        # CSRF passed with authenticated user
-        return (user, None)
 
 
 @api_view(['GET'])

--- a/common/djangoapps/user_api/tests/test_views.py
+++ b/common/djangoapps/user_api/tests/test_views.py
@@ -1528,7 +1528,7 @@ class UpdateEmailOptInTestCase(ApiTestCase):
         self.assertHttpBadRequest(response)
 
     def test_update_email_opt_in_inactive_user(self):
-        """Test that an inactive user can still update email."""
+        """Test that an inactive user can still update their email optin preference."""
         self.user.is_active = False
         self.user.save()
         # Register, which should trigger an activation email

--- a/common/djangoapps/user_api/tests/test_views.py
+++ b/common/djangoapps/user_api/tests/test_views.py
@@ -1526,3 +1526,18 @@ class UpdateEmailOptInTestCase(ApiTestCase):
 
         response = self.client.post(self.url, params)
         self.assertHttpBadRequest(response)
+
+    def test_update_email_opt_in_inactive_user(self):
+        """Test that an inactive user can still update email."""
+        self.user.is_active = False
+        self.user.save()
+        # Register, which should trigger an activation email
+        response = self.client.post(self.url, {
+            "course_id": unicode(self.course.id),
+            "email_opt_in": u"True"
+        })
+        self.assertHttpOK(response)
+        preference = UserOrgTag.objects.get(
+            user=self.user, org=self.course.id.org, key="email-optin"
+        )
+        self.assertEquals(preference.value, u"True")

--- a/common/djangoapps/user_api/views.py
+++ b/common/djangoapps/user_api/views.py
@@ -47,6 +47,52 @@ class ApiKeyHeaderPermission(permissions.BasePermission):
         )
 
 
+class SessionAuthenticationAllowInactiveUser(authentication.SessionAuthentication):
+    """Ensure that the user is logged in, but do not require the account to be active.
+
+    We use this in the special case that a user has created an account,
+    but has not yet activated it.  We still want to allow the user to
+    enroll in courses, so we remove the usual restriction
+    on session authentication that requires an active account.
+
+    You should use this authentication class ONLY for end-points that
+    it's safe for an un-activated user to access.  For example,
+    we can allow a user to update his/her own enrollments without
+    activating an account.
+
+    """
+    def authenticate(self, request):
+        """Authenticate the user, requiring a logged-in account and CSRF.
+
+        This is exactly the same as the `SessionAuthentication` implementation,
+        with the `user.is_active` check removed.
+
+        Args:
+            request (HttpRequest)
+
+        Returns:
+            Tuple of `(user, token)`
+
+        Raises:
+            PermissionDenied: The CSRF token check failed.
+
+        """
+        # Get the underlying HttpRequest object
+        request = request._request  # pylint: disable=protected-access
+        user = getattr(request, 'user', None)
+
+        # Unauthenticated, CSRF validation not required
+        # This is where regular `SessionAuthentication` checks that the user is active.
+        # We have removed that check in this implementation.
+        if not user:
+            return None
+
+        self.enforce_csrf(request)
+
+        # CSRF passed with authenticated user
+        return (user, None)
+
+
 class LoginSessionView(APIView):
     """HTTP end-points for logging in users. """
 
@@ -842,7 +888,7 @@ class PreferenceUsersListView(generics.ListAPIView):
 
 class UpdateEmailOptInPreference(APIView):
     """View for updating the email opt in preference. """
-    authentication_classes = (authentication.SessionAuthentication,)
+    authentication_classes = (SessionAuthenticationAllowInactiveUser,)
 
     @method_decorator(require_post_params(["course_id", "email_opt_in"]))
     @method_decorator(ensure_csrf_cookie)

--- a/common/djangoapps/util/authentication.py
+++ b/common/djangoapps/util/authentication.py
@@ -1,0 +1,48 @@
+""" Common Authentication Handlers used across projects. """
+from rest_framework import authentication
+
+
+class SessionAuthenticationAllowInactiveUser(authentication.SessionAuthentication):
+    """Ensure that the user is logged in, but do not require the account to be active.
+
+    We use this in the special case that a user has created an account,
+    but has not yet activated it.  We still want to allow the user to
+    enroll in courses, so we remove the usual restriction
+    on session authentication that requires an active account.
+
+    You should use this authentication class ONLY for end-points that
+    it's safe for an un-activated user to access.  For example,
+    we can allow a user to update his/her own enrollments without
+    activating an account.
+
+    """
+    def authenticate(self, request):
+        """Authenticate the user, requiring a logged-in account and CSRF.
+
+        This is exactly the same as the `SessionAuthentication` implementation,
+        with the `user.is_active` check removed.
+
+        Args:
+            request (HttpRequest)
+
+        Returns:
+            Tuple of `(user, token)`
+
+        Raises:
+            PermissionDenied: The CSRF token check failed.
+
+        """
+        # Get the underlying HttpRequest object
+        request = request._request  # pylint: disable=protected-access
+        user = getattr(request, 'user', None)
+
+        # Unauthenticated, CSRF validation not required
+        # This is where regular `SessionAuthentication` checks that the user is active.
+        # We have removed that check in this implementation.
+        if not user:
+            return None
+
+        self.enforce_csrf(request)
+
+        # CSRF passed with authenticated user
+        return (user, None)


### PR DESCRIPTION
Fix for defect ECOM-715

Registering and setting email opt in was not working. This is because the user was inactive, which requires a special authentication handler.

Note that the handler in here is copied from the Enrollment API. I'm not certain what I'd like to do about this. In the short term, I think this is a reasonable approach, because I do not want either API to rely on each other.  In the future, we should consider what other common utilities we need, and potentially abstract a separate project that these can rely on. 

@rlucioni @wedaly 
