### PR TITLE
FIX - LMS: Calculator Toggle Label Display

### DIFF
--- a/lms/static/sass/course/layout/_calculator.scss
+++ b/lms/static/sass/course/layout/_calculator.scss
@@ -12,6 +12,7 @@ div.calc-main {
   }
 
   a.calc {
+    @include text-hide();
     background: url("../images/calc-icon.png") rgba(#111, .9) no-repeat center;
     border-bottom: 0;
     border-radius: 3px 3px 0 0;


### PR DESCRIPTION
This work visually hides the calculator toggle label, which is not needed in the visual UI, but is still valuable from semantic and accessibility perspectives.

@frrrances included some screenshots of the display issue the label causes here - https://github.com/edx/edx-platform/pull/5998#issuecomment-65661543
