### PR TITLE
fix export for openassessment drafts (PLAT-249)

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -462,6 +462,41 @@ class ImportRequiredTestCases(ContentStoreTestCase):
         )
         self.assertEqual(len(items), 1)
 
+    def test_export_course_no_xml_attributes(self):
+        """
+        Test that a module without an `xml_attributes` attr will still be
+        exported successfully
+        """
+        content_store = contentstore()
+        import_from_xml(self.store, self.user.id, TEST_DATA_DIR, ['toy'])
+        course_id = SlashSeparatedCourseKey('edX', 'toy', '2012_Fall')
+        verticals = self.store.get_items(course_id, qualifiers={'category': 'vertical'})
+        vertical = verticals[0]
+
+        # create OpenAssessmentBlock:
+        open_assessment = ItemFactory.create(
+            parent_location=vertical.location,
+            category="openassessment",
+            display_name="untitled",
+        )
+        # convert it to draft
+        draft_open_assessment = self.store.convert_to_draft(
+            open_assessment.location, self.user.id
+        )
+
+        # note that it has no `xml_attributes` attribute
+        self.assertFalse(hasattr(draft_open_assessment, "xml_attributes"))
+
+        # export should still complete successfully
+        root_dir = path(mkdtemp_clean())
+        export_to_xml(
+            self.store,
+            content_store,
+            course_id,
+            root_dir,
+            'test_no_xml_attributes'
+        )
+
 
 class MiscCourseTests(ContentStoreTestCase):
     """

--- a/common/lib/xmodule/xmodule/modulestore/xml_exporter.py
+++ b/common/lib/xmodule/xmodule/modulestore/xml_exporter.py
@@ -149,6 +149,10 @@ def export_to_xml(modulestore, contentstore, course_key, root_dir, course_dir):
                         # since export_from_xml (called by `add_xml_to_node`)
                         # exports a whole tree
 
+                        # ensure module has "xml_attributes" attr
+                        if not hasattr(draft_node.module, 'xml_attributes'):
+                            draft_node.module.xml_attributes = {}
+
                         draft_node.module.xml_attributes['parent_url'] = draft_node.parent_url
                         parent = modulestore.get_item(draft_node.parent_location)
                         index = parent.children.index(draft_node.module.location)


### PR DESCRIPTION
This addresses an issue with exporting the drafts of xblocks that don't have `xml_attributes` defined for them

@dmitchell 
@nasthagiri 

https://openedx.atlassian.net/browse/PLAT-249
