### PR TITLE
don't export draft children of orphaned drafted (TNL-923)

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -258,6 +258,8 @@ class ImportRequiredTestCases(ContentStoreTestCase):
         # and assert that they contain the created modules
         self.assertIn(self.DRAFT_HTML + ".xml", draft_dir.listdir('html'))
         self.assertIn(self.DRAFT_VIDEO + ".xml", draft_dir.listdir('video'))
+        # and assert the child of the orphaned draft wasn't exported
+        self.assertNotIn(self.ORPHAN_DRAFT_HTML + ".xml", draft_dir.listdir('html'))
 
         # check for grading_policy.json
         filesystem = OSFS(root_dir / 'test_export/policies/2012_Fall')

--- a/cms/djangoapps/contentstore/tests/utils.py
+++ b/cms/djangoapps/contentstore/tests/utils.py
@@ -134,6 +134,8 @@ class CourseTestCase(ModuleStoreTestCase):
         self.store.update_item(self.course, self.user.id)
 
     TEST_VERTICAL = 'vertical_test'
+    ORPHAN_DRAFT_VERTICAL = 'orphan_draft_vertical'
+    ORPHAN_DRAFT_HTML = 'orphan_draft_html'
     PRIVATE_VERTICAL = 'a_private_vertical'
     PUBLISHED_VERTICAL = 'a_published_vertical'
     SEQUENTIAL = 'vertical_sequential'
@@ -157,6 +159,18 @@ class CourseTestCase(ModuleStoreTestCase):
         orphan_vertical = self.store.get_item(vertical.location)
         self.assertEqual(orphan_vertical.location.name, 'no_references')
         self.assertEqual(len(orphan_vertical.children), len(vertical.children))
+
+        # create an orphan vertical and html; we already don't try to import
+        # the orphaned vertical, but we should make sure we don't import
+        # the orphaned vertical's child html, too
+        orphan_draft_vertical = self.store.create_item(
+            self.user.id, course_id, 'vertical', self.ORPHAN_DRAFT_VERTICAL
+        )
+        orphan_draft_html = self.store.create_item(
+            self.user.id, course_id, 'html', self.ORPHAN_DRAFT_HTML
+        )
+        orphan_draft_vertical.children.append(orphan_draft_html.location)
+        self.store.update_item(orphan_draft_vertical, self.user.id)
 
         # create a Draft vertical
         vertical = self.store.get_item(course_id.make_usage_key('vertical', self.TEST_VERTICAL), depth=1)


### PR DESCRIPTION
@dmitchell 
@zubair-arbi 

Fixes an issue where the draft children of orphaned drafts were being exported

related bugs:
https://openedx.atlassian.net/browse/TNL-923
https://openedx.atlassian.net/browse/TNL-872
