### PR TITLE
To support UNICODE xblock.location

### DIFF
--- a/cms/djangoapps/contentstore/views/helpers.py
+++ b/cms/djangoapps/contentstore/views/helpers.py
@@ -110,7 +110,7 @@ def xblock_studio_url(xblock, parent_xblock=None):
     elif category in ('chapter', 'sequential'):
         return u'{url}?show={usage_key}'.format(
             url=reverse_course_url('course_handler', xblock.location.course_key),
-            usage_key=urllib.quote(unicode(xblock.location))
+            usage_key=urllib.quote(unicode(xblock.location).encode('utf8'))
         )
     elif category == 'library':
         library_key = xblock.location.course_key

--- a/cms/djangoapps/contentstore/views/tests/test_helpers.py
+++ b/cms/djangoapps/contentstore/views/tests/test_helpers.py
@@ -5,6 +5,8 @@ Unit tests for helpers.py.
 from contentstore.tests.utils import CourseTestCase
 from contentstore.views.helpers import xblock_studio_url, xblock_type_display_name
 from xmodule.modulestore.tests.factories import ItemFactory, LibraryFactory
+from xmodule.modulestore.xml import XMLModuleStore
+from xmodule.tests import DATA_DIR
 from django.utils import http
 
 
@@ -54,6 +56,17 @@ class HelpersTestCase(CourseTestCase):
         library = LibraryFactory.create()
         expected_url = u'/library/{}'.format(unicode(library.location.library_key))
         self.assertEqual(xblock_studio_url(library), expected_url)
+
+    def test_unicode_xblock_studio_url(self):
+
+        #import unicode course
+        modulestore = XMLModuleStore(DATA_DIR, course_dirs=['2014_Uni'])
+        courses = modulestore.get_courses()
+        course = courses[0]
+
+        # Verify course URL
+        course_url = http.urlquote('/course/{}'.format(course.id))
+        self.assertEqual(xblock_studio_url(course), course_url)
 
     def test_xblock_type_display_name(self):
 


### PR DESCRIPTION
Ticket: [OSPR-269](https://openedx.atlassian.net/browse/OSPR-269)

When people use unicode course org name(e.g Chinese) ,urllib.quote cannot format unicode char like:

``` shell
>>> import urllib
>>> loc = 'i4x://创联/7302478/chapter/4ab413b41ad9447db41668bed03f149f'
>>> urllib.quote(loc)
'i4x%3A//%E5%88%9B%E8%81%94/7302478/chapter/4ab413b41ad9447db41668bed03f149f'
>>> urllib.quote(unicode(loc))
Traceback (most recent call last):
  File "<console>", line 1, in <module>
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe5 in position 6: ordinal not in range(128)
>>> 
```

so I open this pull
@sarina @nedbat @singingwolfboy
