### PR TITLE
Add email opt in to old login and register pages

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -364,8 +364,10 @@ def signin_user(request):
         return redirect(reverse('dashboard'))
 
     course_id = request.GET.get('course_id')
+    email_opt_in = request.GET.get('email_opt_in')
     context = {
         'course_id': course_id,
+        'email_opt_in': email_opt_in,
         'enrollment_action': request.GET.get('enrollment_action'),
         # Bool injected into JS to submit form if we're inside a running third-
         # party auth pipeline; distinct from the actual instance of the running
@@ -394,9 +396,11 @@ def register_user(request, extra_context=None):
         return external_auth.views.redirect_with_get('root', request.GET)
 
     course_id = request.GET.get('course_id')
+    email_opt_in = request.GET.get('email_opt_in')
 
     context = {
         'course_id': course_id,
+        'email_opt_in': email_opt_in,
         'email': '',
         'enrollment_action': request.GET.get('enrollment_action'),
         'name': '',

--- a/lms/templates/login.html
+++ b/lms/templates/login.html
@@ -198,6 +198,10 @@
       <input type="hidden" name="course_id" value="${course_id | h}" />
 % endif
 
+% if email_opt_in:
+      <input type="hidden" name="email_opt_in" value="${email_opt_in | h}" />
+% endif
+
       <div class="form-actions">
         <button name="submit" type="submit" id="submit" class="action action-primary action-update login-button"></button>
       </div>

--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -158,8 +158,12 @@
 </html>
 
 <%def name="login_query()">${
-  u"?course_id={0}&enrollment_action={1}".format(
+  u"?course_id={0}&enrollment_action={1}{email_opt_in}".format(
     urlquote_plus(course_id),
-    urlquote_plus(enrollment_action)
+    urlquote_plus(enrollment_action),
+    email_opt_in=(
+      u"&email_opt_in=" + urlquote_plus(email_opt_in)
+      if email_opt_in else ""
+    )
   ) if course_id and enrollment_action else ""
 }</%def>

--- a/lms/templates/register.html
+++ b/lms/templates/register.html
@@ -361,6 +361,10 @@
       <input type="hidden" name="course_id" value="${course_id | h}" />
 % endif
 
+% if email_opt_in:
+      <input type="hidden" name="email_opt_in" value="${email_opt_in | h }" />
+% endif
+
       <div class="form-actions">
         <button name="submit" type="submit" id="submit" class="action action-primary action-update register-button">${_('Register')} <span class="orn-plus">+</span> ${_('Create My Account')}</button>
       </div>


### PR DESCRIPTION
Add support for email-opt in pref to the old login/register pages.
Reviewers: @rlucioni @dianakhuang 
