### PR TITLE
add find_fixme task

### DIFF
--- a/docs/en_us/internal/testing.md
+++ b/docs/en_us/internal/testing.md
@@ -404,6 +404,10 @@ More specific options are below.
 
 		paver run_quality --percentage=100
 
+* Note that 'fixme' violations are not counted with run_quality. To see all 'TODO' lines, use:
+
+		paver find_fixme --system=lms
+`system` is an optional argument here. It defaults to `cms,lms,common`.
 
 
 ## Testing using queue servers

--- a/scripts/all-tests.sh
+++ b/scripts/all-tests.sh
@@ -107,6 +107,7 @@ SHARD=${SHARD:="all"}
 case "$TEST_SUITE" in
 
     "quality")
+        paver find_fixme > fixme.log || { cat fixme.log; EXIT=1; }
         paver run_pep8 -l $PEP8_THRESHOLD > pep8.log || { cat pep8.log; EXIT=1; }
         paver run_pylint -l $PYLINT_THRESHOLD > pylint.log || { cat pylint.log; EXIT=1; }
         # Run quality task. Pass in the 'fail-under' percentage to diff-quality


### PR DESCRIPTION
With the changes from https://github.com/edx/edx-platform/pull/6122, we will no longer be finding fixmes with `run_quality` or `run_pylint`.  This change adds a way of finding only fixmes.  I've added it to the all-tests.sh script in the quality shard, so that jenkins builds will find the fixmes (writing them to their own log) without failing the builds.
