### PR TITLE
block.get_parent() and group access enforcement

### DIFF
--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -141,7 +141,8 @@ def xblock_handler(request, usage_key_string):
                     # right now can't combine output of this w/ output of _get_module_info, but worthy goal
                     return JsonResponse(CourseGradingModel.get_section_grader_type(usage_key))
                 # TODO: pass fields to _get_module_info and only return those
-                rsp = _get_module_info(_get_xblock(usage_key, request.user))
+                with modulestore().bulk_operations(usage_key.course_key):
+                    rsp = _get_module_info(_get_xblock(usage_key, request.user))
                 return JsonResponse(rsp)
             else:
                 return HttpResponse(status=406)

--- a/cms/djangoapps/contentstore/views/tests/test_item.py
+++ b/cms/djangoapps/contentstore/views/tests/test_item.py
@@ -100,9 +100,20 @@ class GetItemTest(ItemTest):
         return html, resources
 
     @ddt.data(
-        (1, 21, 23, 35, 37),
-        (2, 22, 24, 38, 39),
-        (3, 23, 25, 41, 41),
+        # chapter explanation:
+        # 1-3. get course, chapter, chapter's children,
+        # 4-7. chapter's published grandchildren, chapter's draft grandchildren, published & then draft greatgrand
+        # 8 compute chapter's parent
+        # 9 get chapter's parent
+        # 10-16. run queries 2-8 again
+        # 17-19. compute seq, vert, and problem's parents (odd since it's going down; so, it knows)
+        # 20-22. get course 3 times
+        # 23. get chapter
+        # 24. compute chapter's parent (course)
+        # 25. compute course's parent (None)
+        (1, 20, 20, 26, 26),
+        (2, 21, 21, 29, 28),
+        (3, 22, 22, 32, 30),
     )
     @ddt.unpack
     def test_get_query_count(self, branching_factor, chapter_queries, section_queries, unit_queries, problem_queries):
@@ -361,21 +372,46 @@ class TestDuplicateItem(ItemTest):
         except for location and display name.
         """
         def duplicate_and_verify(source_usage_key, parent_usage_key):
+            """ Duplicates the source, parenting to supplied parent. Then does equality check. """
             usage_key = self._duplicate_item(parent_usage_key, source_usage_key)
-            self.assertTrue(check_equality(source_usage_key, usage_key), "Duplicated item differs from original")
+            self.assertTrue(
+                check_equality(source_usage_key, usage_key, parent_usage_key),
+                "Duplicated item differs from original"
+            )
 
-        def check_equality(source_usage_key, duplicate_usage_key):
+        def check_equality(source_usage_key, duplicate_usage_key, parent_usage_key=None):
+            """
+            Gets source and duplicated items from the modulestore using supplied usage keys.
+            Then verifies that they represent equivalent items (modulo parents and other
+            known things that may differ).
+            """
             original_item = self.get_item_from_modulestore(source_usage_key)
             duplicated_item = self.get_item_from_modulestore(duplicate_usage_key)
 
             self.assertNotEqual(
-                original_item.location,
-                duplicated_item.location,
+                unicode(original_item.location),
+                unicode(duplicated_item.location),
                 "Location of duplicate should be different from original"
             )
-            # Set the location and display name to be the same so we can make sure the rest of the duplicate is equal.
+
+            # Parent will only be equal for root of duplicated structure, in the case
+            # where an item is duplicated in-place.
+            if parent_usage_key and unicode(original_item.parent) == unicode(parent_usage_key):
+                self.assertEqual(
+                    unicode(parent_usage_key), unicode(duplicated_item.parent),
+                    "Parent of duplicate should equal parent of source for root xblock when duplicated in-place"
+                )
+            else:
+                self.assertNotEqual(
+                    unicode(original_item.parent), unicode(duplicated_item.parent),
+                    "Parent duplicate should be different from source"
+                )
+
+            # Set the location, display name, and parent to be the same so we can make sure the rest of the
+            # duplicate is equal.
             duplicated_item.location = original_item.location
             duplicated_item.display_name = original_item.display_name
+            duplicated_item.parent = original_item.parent
 
             # Children will also be duplicated, so for the purposes of testing equality, we will set
             # the children to the original after recursively checking the children.

--- a/common/lib/xmodule/xmodule/modulestore/inheritance.py
+++ b/common/lib/xmodule/xmodule/modulestore/inheritance.py
@@ -57,15 +57,6 @@ class InheritanceMixin(XBlockMixin):
         default=False,
         scope=Scope.settings,
     )
-    group_access = Dict(
-        help="A dictionary that maps which groups can be shown this block. The keys "
-             "are group configuration ids and the values are a list of group IDs. "
-             "If there is no key for a group configuration or if the list of group IDs "
-             "is empty then the block is considered visible to all. Note that this "
-             "field is ignored if the block is visible_to_staff_only.",
-        default={},
-        scope=Scope.settings,
-    )
     course_edit_method = String(
         display_name=_("Course Editor"),
         help=_("Enter the method by which this course is edited (\"XML\" or \"Studio\")."),

--- a/common/lib/xmodule/xmodule/modulestore/modulestore_settings.py
+++ b/common/lib/xmodule/xmodule/modulestore/modulestore_settings.py
@@ -98,6 +98,7 @@ def update_module_store_settings(
         module_store_options=None,
         xml_store_options=None,
         default_store=None,
+        mappings=None,
 ):
     """
     Updates the settings for each store defined in the given module_store_setting settings
@@ -122,6 +123,9 @@ def update_module_store_settings(
                 mixed_stores.insert(0, store)
                 return
         raise Exception("Could not find setting for requested default store: {}".format(default_store))
+
+    if mappings and 'mappings' in module_store_setting['default']['OPTIONS']:
+        module_store_setting['default']['OPTIONS']['mappings'] = mappings
 
 
 def get_mixed_stores(mixed_setting):

--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -31,7 +31,7 @@ from sortedcontainers import SortedListWithKey
 
 from importlib import import_module
 from opaque_keys.edx.keys import UsageKey, CourseKey, AssetKey
-from opaque_keys.edx.locations import Location
+from opaque_keys.edx.locations import Location, BlockUsageLocator
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
 from opaque_keys.edx.locator import CourseLocator, LibraryLocator
 
@@ -56,6 +56,7 @@ log = logging.getLogger(__name__)
 new_contract('CourseKey', CourseKey)
 new_contract('AssetKey', AssetKey)
 new_contract('AssetMetadata', AssetMetadata)
+new_contract('BlockUsageLocator', BlockUsageLocator)
 
 # sort order that returns DRAFT items first
 SORT_REVISION_FAVOR_DRAFT = ('_id.revision', pymongo.DESCENDING)
@@ -93,12 +94,13 @@ class MongoKeyValueStore(InheritanceKeyValueStore):
     A KeyValueStore that maps keyed data access to one of the 3 data areas
     known to the MongoModuleStore (data, children, and metadata)
     """
-    def __init__(self, data, children, metadata):
+    def __init__(self, data, parent, children, metadata):
         super(MongoKeyValueStore, self).__init__()
         if not isinstance(data, dict):
             self._data = {'data': data}
         else:
             self._data = data
+        self._parent = parent
         self._children = children
         self._metadata = metadata
 
@@ -106,7 +108,7 @@ class MongoKeyValueStore(InheritanceKeyValueStore):
         if key.scope == Scope.children:
             return self._children
         elif key.scope == Scope.parent:
-            return None
+            return self._parent
         elif key.scope == Scope.settings:
             return self._metadata[key.field_name]
         elif key.scope == Scope.content:
@@ -216,15 +218,35 @@ class CachingDescriptorSystem(MakoDescriptorSystem, EditInfoRuntimeMixin):
                     self._convert_reference_to_key(childloc)
                     for childloc in definition.get('children', [])
                 ]
+
+                parent = None
+                if self.cached_metadata is not None:
+                    # fish the parent out of here if it's available
+                    parent_url = self.cached_metadata.get(unicode(location), {}).get('parent', {}).get(
+                        ModuleStoreEnum.Branch.published_only if location.revision is None
+                        else ModuleStoreEnum.Branch.draft_preferred
+                    )
+                    if parent_url:
+                        parent = BlockUsageLocator.from_string(parent_url)
+                if not parent and category != 'course':
+                    # try looking it up just-in-time (but not if we're working with a root node (course).
+                    parent = self.modulestore.get_parent_location(
+                        as_published(location),
+                        ModuleStoreEnum.RevisionOption.published_only if location.revision is None
+                        else ModuleStoreEnum.RevisionOption.draft_preferred
+                    )
+
                 data = definition.get('data', {})
                 if isinstance(data, basestring):
                     data = {'data': data}
+
                 mixed_class = self.mixologist.mix(class_)
                 if data:  # empty or None means no work
                     data = self._convert_reference_fields_to_keys(mixed_class, location.course_key, data)
                 metadata = self._convert_reference_fields_to_keys(mixed_class, location.course_key, metadata)
                 kvs = MongoKeyValueStore(
                     data,
+                    parent,
                     children,
                     metadata,
                 )
@@ -432,6 +454,32 @@ class MongoBulkOpsMixin(BulkOperationsMixin):
         )
 
 
+class ParentLocationCache(dict):
+    """
+    Dict-based object augmented with a more cache-like interface, for internal use.
+    """
+    # pylint: disable=missing-docstring
+
+    @contract(key=unicode)
+    def has(self, key):
+        return key in self
+
+    @contract(key=unicode, value="BlockUsageLocator | None")
+    def set(self, key, value):
+        self[key] = value
+
+    @contract(key=unicode)
+    def delete(self, key):
+        if key in self:
+            del self[key]
+
+    @contract(value="BlockUsageLocator")
+    def delete_by_value(self, value):
+        keys_to_delete = [k for k, v in self.iteritems() if v == value]
+        for key in keys_to_delete:
+            del self[key]
+
+
 class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, MongoBulkOpsMixin):
     """
     A Mongodb backed ModuleStore
@@ -565,6 +613,16 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
             return location.replace(revision=MongoRevisionKey.draft)
         return location.replace(revision=MongoRevisionKey.published)
 
+    def _get_parent_cache(self, branch):
+        """
+        Provides a reference to one of the two branch-specific
+        ParentLocationCaches associated with the current request (if any).
+        """
+        if self.request_cache is not None:
+            return self.request_cache.data.setdefault('parent-location-{}'.format(branch), ParentLocationCache())
+        else:
+            return ParentLocationCache()
+
     def _compute_metadata_inheritance_tree(self, course_id):
         '''
         TODO (cdodge) This method can be deleted when the 'split module store' work has been completed
@@ -633,7 +691,13 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
                     _compute_inherited_metadata(child)
                 else:
                     # this is likely a leaf node, so let's record what metadata we need to inherit
-                    metadata_to_inherit[child] = my_metadata
+                    metadata_to_inherit[child] = my_metadata.copy()
+                # WARNING: 'parent' is not part of inherited metadata, but
+                # we're piggybacking on this recursive traversal to grab
+                # and cache the child's parent, as a performance optimization.
+                # The 'parent' key will be popped out of the dictionary during
+                # CachingDescriptorSystem.load_item
+                metadata_to_inherit[child].setdefault('parent', {})[self.get_branch_setting()] = url
 
         if root is not None:
             _compute_inherited_metadata(root)
@@ -728,12 +792,18 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
         data = {}
         to_process = list(items)
         course_key = self.fill_in_run(course_key)
+        parent_cache = self._get_parent_cache(self.get_branch_setting())
+
         while to_process and depth is None or depth >= 0:
             children = []
             for item in to_process:
                 self._clean_item_data(item)
-                children.extend(item.get('definition', {}).get('children', []))
-                data[Location._from_deprecated_son(item['location'], course_key.run)] = item
+                item_location = Location._from_deprecated_son(item['location'], course_key.run)
+                item_children = item.get('definition', {}).get('children', [])
+                children.extend(item_children)
+                for item_child in item_children:
+                    parent_cache.set(item_child, item_location)
+                data[item_location] = item
 
             if depth == 0:
                 break
@@ -1238,6 +1308,13 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
             if xblock.has_children:
                 children = self._serialize_scope(xblock, Scope.children)
                 payload.update({'definition.children': children['children']})
+
+                # Remove all old pointers to me, then add my current children back
+                parent_cache = self._get_parent_cache(self.get_branch_setting())
+                parent_cache.delete_by_value(xblock.location)
+                for child in xblock.children:
+                    parent_cache.set(unicode(child), xblock.location)
+
             self._update_single_item(xblock.scope_ids.usage_id, payload, allow_not_found=allow_not_found)
 
             # update subtree edited info for ancestors
@@ -1330,6 +1407,10 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
         assert revision == ModuleStoreEnum.RevisionOption.published_only \
             or revision == ModuleStoreEnum.RevisionOption.draft_preferred
 
+        parent_cache = self._get_parent_cache(self.get_branch_setting())
+        if parent_cache.has(unicode(location)):
+            return parent_cache.get(unicode(location))
+
         # create a query with tag, org, course, and the children field set to the given location
         query = self._course_key_to_son(location.course_key)
         query['definition.children'] = unicode(location)
@@ -1338,30 +1419,35 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
         if revision == ModuleStoreEnum.RevisionOption.published_only:
             query['_id.revision'] = MongoRevisionKey.published
 
-        # query the collection, sorting by DRAFT first
-        parents = self.collection.find(query, {'_id': True}, sort=[SORT_REVISION_FAVOR_DRAFT])
+        def cache_and_return(parent_loc):  # pylint:disable=missing-docstring
+            parent_cache.set(unicode(location), parent_loc)
+            return parent_loc
 
-        if parents.count() == 0:
+        # query the collection, sorting by DRAFT first
+        parents = list(
+            self.collection.find(query, {'_id': True}, sort=[SORT_REVISION_FAVOR_DRAFT])
+        )
+        if len(parents) == 0:
             # no parents were found
-            return None
+            return cache_and_return(None)
 
         if revision == ModuleStoreEnum.RevisionOption.published_only:
-            if parents.count() > 1:
+            if len(parents) > 1:
                 non_orphan_parents = self._get_non_orphan_parents(location, parents, revision)
                 if len(non_orphan_parents) == 0:
                     # no actual parent found
-                    return None
+                    return cache_and_return(None)
 
                 if len(non_orphan_parents) > 1:
                     # should never have multiple PUBLISHED parents
                     raise ReferentialIntegrityError(
-                        u"{} parents claim {}".format(parents.count(), location)
+                        u"{} parents claim {}".format(len(parents), location)
                     )
                 else:
-                    return non_orphan_parents[0]
+                    return cache_and_return(non_orphan_parents[0].replace(run=location.course_key.run))
             else:
                 # return the single PUBLISHED parent
-                return Location._from_deprecated_son(parents[0]['_id'], location.course_key.run)
+                return cache_and_return(Location._from_deprecated_son(parents[0]['_id'], location.course_key.run))
         else:
             # there could be 2 different parents if
             #   (1) the draft item was moved or
@@ -1377,11 +1463,11 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
             # since we sorted by SORT_REVISION_FAVOR_DRAFT, the 0'th parent is the one we want
             if published_parents > 1:
                 non_orphan_parents = self._get_non_orphan_parents(location, all_parents, revision)
-                return non_orphan_parents[0]
+                return cache_and_return(non_orphan_parents[0].replace(run=location.course_key.run))
 
             found_id = all_parents[0]['_id']
             # don't disclose revision outside modulestore
-            return Location._from_deprecated_son(found_id, location.course_key.run)
+            return cache_and_return(Location._from_deprecated_son(found_id, location.course_key.run))
 
     def get_parent_location(self, location, revision=ModuleStoreEnum.RevisionOption.published_only, **kwargs):
         '''
@@ -1400,7 +1486,7 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
         '''
         parent = self._get_raw_parent_location(location, revision)
         if parent:
-            return as_published(parent)
+            return parent
         return None
 
     def get_modulestore_type(self, course_key=None):
@@ -1454,6 +1540,7 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
         """
         kvs = MongoKeyValueStore(
             definition_data,
+            None,
             [],
             metadata,
         )

--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -468,11 +468,6 @@ class ParentLocationCache(dict):
     def set(self, key, value):
         self[key] = value
 
-    @contract(key=unicode)
-    def delete(self, key):
-        if key in self:
-            del self[key]
-
     @contract(value="BlockUsageLocator")
     def delete_by_value(self, value):
         keys_to_delete = [k for k, v in self.iteritems() if v == value]

--- a/common/lib/xmodule/xmodule/modulestore/mongo/draft.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/draft.py
@@ -627,6 +627,9 @@ class DraftModuleStore(MongoModuleStore):
 
         Raises:
             ItemNotFoundError: if any of the draft subtree nodes aren't found
+
+        Returns:
+            The newly published xblock
         """
         # NOTE: cannot easily use self._breadth_first b/c need to get pub'd and draft as pairs
         # (could do it by having 2 breadth first scans, the first to just get all published children

--- a/common/lib/xmodule/xmodule/modulestore/tests/factories.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/factories.py
@@ -209,25 +209,17 @@ class ItemFactory(XModuleFactory):
             # replace the display name with an optional parameter passed in from the caller
             if display_name is not None:
                 metadata['display_name'] = display_name
-            runtime = parent.runtime if parent else None
-            store.create_item(
+
+            module = store.create_child(
                 user_id,
-                location.course_key,
+                parent.location,
                 location.block_type,
                 block_id=location.block_id,
                 metadata=metadata,
                 definition_data=data,
-                runtime=runtime
+                runtime=parent.runtime,
+                fields=kwargs,
             )
-
-            module = store.get_item(location)
-
-            for attr, val in kwargs.items():
-                setattr(module, attr, val)
-            # Save the attributes we just set
-            module.save()
-
-            store.update_item(module, user_id)
 
             # VS[compat] cdodge: This is a hack because static_tabs also have references from the course module, so
             # if we add one then we need to also add it to the policy information (i.e. metadata)
@@ -247,12 +239,15 @@ class ItemFactory(XModuleFactory):
                 parent.children.append(location)
                 store.update_item(parent, user_id)
                 if publish_item:
-                    store.publish(parent.location, user_id)
+                    published_parent = store.publish(parent.location, user_id)
+                    # module is last child of parent
+                    return published_parent.get_children()[-1]
+                else:
+                    return store.get_item(location)
             elif publish_item:
-                store.publish(location, user_id)
-
-        # return the published item
-        return store.get_item(location)
+                return store.publish(location, user_id)
+            else:
+                return module
 
 
 @contextmanager

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_mixed_modulestore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_mixed_modulestore.py
@@ -358,12 +358,12 @@ class TestMixedModuleStore(CourseComparisonTest):
             self.store.has_item(self.fake_location, revision=ModuleStoreEnum.RevisionOption.draft_preferred)
 
     # draft queries:
-    #   problem: find draft item, find all items pertinent to inheritance computation
+    #   problem: find draft item, find all items pertinent to inheritance computation, find parent
     #   non-existent problem: find draft, find published
     # split:
     #   problem: active_versions, structure
     #   non-existent problem: ditto
-    @ddt.data(('draft', [2, 2], 0), ('split', [2, 2], 0))
+    @ddt.data(('draft', [3, 2], 0), ('split', [2, 2], 0))
     @ddt.unpack
     def test_get_item(self, default_ms, max_find, max_send):
         self.initdb(default_ms)
@@ -388,10 +388,10 @@ class TestMixedModuleStore(CourseComparisonTest):
             self.store.get_item(self.fake_location, revision=ModuleStoreEnum.RevisionOption.draft_preferred)
 
     # Draft:
-    #    wildcard query, 6! load pertinent items for inheritance calls, course root fetch (why)
+    #    wildcard query, 6! load pertinent items for inheritance calls, load parents, course root fetch (why)
     # Split:
     #    active_versions (with regex), structure, and spurious active_versions refetch
-    @ddt.data(('draft', 8, 0), ('split', 3, 0))
+    @ddt.data(('draft', 14, 0), ('split', 3, 0))
     @ddt.unpack
     def test_get_items(self, default_ms, max_find, max_send):
         self.initdb(default_ms)
@@ -405,7 +405,6 @@ class TestMixedModuleStore(CourseComparisonTest):
 
         course_locn = self.course_locations[self.MONGO_COURSEID]
         with check_mongo_calls(max_find, max_send):
-            # NOTE: use get_course if you just want the course. get_items is expensive
             modules = self.store.get_items(course_locn.course_key, qualifiers={'category': 'problem'})
         self.assertEqual(len(modules), 6)
 
@@ -416,12 +415,11 @@ class TestMixedModuleStore(CourseComparisonTest):
                 revision=ModuleStoreEnum.RevisionOption.draft_preferred
             )
 
-    # draft: get draft, count parents, get parents, count & get grandparents, count & get greatgrand,
-    #        count & get next ancestor (chapter's parent), count non-existent next ancestor, get inheritance
+    # draft: get draft, get ancestors up to course (2-6), compute inheritance
     #    sends: update problem and then each ancestor up to course (edit info)
     # split: active_versions, definitions (calculator field), structures
     #  2 sends to update index & structure (note, it would also be definition if a content field changed)
-    @ddt.data(('draft', 11, 5), ('split', 3, 2))
+    @ddt.data(('draft', 7, 5), ('split', 3, 2))
     @ddt.unpack
     def test_update_item(self, default_ms, max_find, max_send):
         """
@@ -881,9 +879,9 @@ class TestMixedModuleStore(CourseComparisonTest):
 
     # notice this doesn't test getting a public item via draft_preferred which draft would have 2 hits (split
     # still only 2)
-    # Draft: count via definition.children query, then fetch via that query
+    # Draft: get_parent
     # Split: active_versions, structure
-    @ddt.data(('draft', 2, 0), ('split', 2, 0))
+    @ddt.data(('draft', 1, 0), ('split', 2, 0))
     @ddt.unpack
     def test_get_parent_locations(self, default_ms, max_find, max_send):
         """
@@ -982,20 +980,12 @@ class TestMixedModuleStore(CourseComparisonTest):
     # Draft:
     #   Problem path:
     #    1. Get problem
-    #    2-3. count matches definition.children called 2x?
-    #    4. get parent via definition.children query
-    #    5-7. 2 counts and 1 get grandparent via definition.children
-    #    8-10. ditto for great-grandparent
-    #    11-13. ditto for next ancestor
-    #    14. fail count query looking for parent of course (unnecessary)
-    #    15. get course record direct query (not via definition.children) (already fetched in 13)
-    #    16. get items for inheritance computation
-    #    17. get vertical (parent of problem)
-    #    18. get items for inheritance computation (why? caching should handle)
-    #    19-20. get vertical_x1b (? why? this is the only ref in trace) & items for inheritance computation
-    #   Chapter path: get chapter, count parents 2x, get parents, count non-existent grandparents
+    #    2-6. get parent and rest of ancestors up to course
+    #    7-8. get sequential, compute inheritance
+    #    8-9. get vertical, compute inheritance
+    #    10-11. get other vertical_x1b (why?) and compute inheritance
     # Split: active_versions & structure
-    @ddt.data(('draft', [20, 5], 0), ('split', [2, 2], 0))
+    @ddt.data(('draft', [12, 3], 0), ('split', [2, 2], 0))
     @ddt.unpack
     def test_path_to_location(self, default_ms, num_finds, num_sends):
         """

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_mongo.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_mongo.py
@@ -710,15 +710,16 @@ class TestMongoKeyValueStore(object):
     def setUp(self):
         self.data = {'foo': 'foo_value'}
         self.course_id = SlashSeparatedCourseKey('org', 'course', 'run')
+        self.parent = self.course_id.make_usage_key('parent', 'p')
         self.children = [self.course_id.make_usage_key('child', 'a'), self.course_id.make_usage_key('child', 'b')]
         self.metadata = {'meta': 'meta_val'}
-        self.kvs = MongoKeyValueStore(self.data, self.children, self.metadata)
+        self.kvs = MongoKeyValueStore(self.data, self.parent, self.children, self.metadata)
 
     def test_read(self):
         assert_equals(self.data['foo'], self.kvs.get(KeyValueStore.Key(Scope.content, None, None, 'foo')))
+        assert_equals(self.parent, self.kvs.get(KeyValueStore.Key(Scope.parent, None, None, 'parent')))
         assert_equals(self.children, self.kvs.get(KeyValueStore.Key(Scope.children, None, None, 'children')))
         assert_equals(self.metadata['meta'], self.kvs.get(KeyValueStore.Key(Scope.settings, None, None, 'meta')))
-        assert_equals(None, self.kvs.get(KeyValueStore.Key(Scope.parent, None, None, 'parent')))
 
     def test_read_invalid_scope(self):
         for scope in (Scope.preferences, Scope.user_info, Scope.user_state):
@@ -728,7 +729,7 @@ class TestMongoKeyValueStore(object):
             assert_false(self.kvs.has(key))
 
     def test_read_non_dict_data(self):
-        self.kvs = MongoKeyValueStore('xml_data', self.children, self.metadata)
+        self.kvs = MongoKeyValueStore('xml_data', self.parent, self.children, self.metadata)
         assert_equals('xml_data', self.kvs.get(KeyValueStore.Key(Scope.content, None, None, 'data')))
 
     def _check_write(self, key, value):
@@ -739,9 +740,10 @@ class TestMongoKeyValueStore(object):
         yield (self._check_write, KeyValueStore.Key(Scope.content, None, None, 'foo'), 'new_data')
         yield (self._check_write, KeyValueStore.Key(Scope.children, None, None, 'children'), [])
         yield (self._check_write, KeyValueStore.Key(Scope.settings, None, None, 'meta'), 'new_settings')
+        # write Scope.parent raises InvalidScope, which is covered in test_write_invalid_scope
 
     def test_write_non_dict_data(self):
-        self.kvs = MongoKeyValueStore('xml_data', self.children, self.metadata)
+        self.kvs = MongoKeyValueStore('xml_data', self.parent, self.children, self.metadata)
         self._check_write(KeyValueStore.Key(Scope.content, None, None, 'data'), 'new_data')
 
     def test_write_invalid_scope(self):

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_xml.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_xml.py
@@ -31,7 +31,7 @@ class TestXMLModuleStore(unittest.TestCase):
     Test around the XML modulestore
     """
     def test_xml_modulestore_type(self):
-        store = XMLModuleStore(DATA_DIR, course_dirs=['toy', 'simple'])
+        store = XMLModuleStore(DATA_DIR, course_dirs=[])
         self.assertEqual(store.get_modulestore_type(), ModuleStoreEnum.Type.xml)
 
     def test_unicode_chars_in_xml_content(self):

--- a/common/lib/xmodule/xmodule/modulestore/xml.py
+++ b/common/lib/xmodule/xmodule/modulestore/xml.py
@@ -54,7 +54,7 @@ def clean_out_mako_templating(xml_string):
 
 class ImportSystem(XMLParsingSystem, MakoDescriptorSystem):
     def __init__(self, xmlstore, course_id, course_dir,
-                 error_tracker, parent_tracker,
+                 error_tracker,
                  load_error_modules=True, **kwargs):
         """
         A class that handles loading from xml.  Does some munging to ensure that
@@ -211,7 +211,8 @@ class ImportSystem(XMLParsingSystem, MakoDescriptorSystem):
 
             if descriptor.has_children:
                 for child in descriptor.get_children():
-                    parent_tracker.add_parent(child.scope_ids.usage_id, descriptor.scope_ids.usage_id)
+                    child.parent = descriptor.location
+                    child.save()
 
             # After setting up the descriptor, save any changes that we have
             # made to attributes on the descriptor to the underlying KeyValueStore.
@@ -283,7 +284,9 @@ def _convert_reference_fields_to_keys(xblock):  # pylint: disable=invalid-name
     for field in xblock.fields.itervalues():
         if field.is_set_on(xblock):
             field_value = getattr(xblock, field.name)
-            if isinstance(field, Reference):
+            if field_value is None:
+                setattr(xblock, field.name, None)
+            elif isinstance(field, Reference):
                 setattr(xblock, field.name, _make_usage_key(course_key, field_value))
             elif isinstance(field, ReferenceList):
                 setattr(xblock, field.name, [_make_usage_key(course_key, ele) for ele in field_value])
@@ -329,41 +332,6 @@ def create_block_from_xml(xml_data, system, id_generator):
     return xblock
 
 
-class ParentTracker(object):
-    """A simple class to factor out the logic for tracking location parent pointers."""
-    def __init__(self):
-        """
-        Init
-        """
-        # location -> parent.  Not using defaultdict because we care about the empty case.
-        self._parents = dict()
-
-    def add_parent(self, child, parent):
-        """
-        Add a parent of child location to the set of parents.  Duplicate calls have no effect.
-
-        child and parent must be :class:`.Location` instances.
-        """
-        self._parents[child] = parent
-
-    def is_known(self, child):
-        """
-        returns True iff child has some parents.
-        """
-        return child in self._parents
-
-    def make_known(self, location):
-        """Tell the parent tracker about an object, without registering any
-        parents for it.  Used for the top level course descriptor locations."""
-        self._parents.setdefault(location, None)
-
-    def parent(self, child):
-        """
-        Return the parent of this child.  If not is_known(child), will throw a KeyError
-        """
-        return self._parents[child]
-
-
 class XMLModuleStore(ModuleStoreReadBase):
     """
     An XML backed ModuleStore
@@ -402,8 +370,6 @@ class XMLModuleStore(ModuleStoreReadBase):
             module_path, _, class_name = default_class.rpartition('.')
             class_ = getattr(import_module(module_path), class_name)
             self.default_class = class_
-
-        self.parent_trackers = defaultdict(ParentTracker)
 
         # All field data will be stored in an inheriting field data.
         self.field_data = inheriting_field_data(kvs=DictKeyValueStore())
@@ -451,7 +417,7 @@ class XMLModuleStore(ModuleStoreReadBase):
         else:
             self.courses[course_dir] = course_descriptor
             self._course_errors[course_descriptor.id] = errorlog
-            self.parent_trackers[course_descriptor.id].make_known(course_descriptor.scope_ids.usage_id)
+            course_descriptor.parent = None
 
     def __unicode__(self):
         '''
@@ -563,7 +529,6 @@ class XMLModuleStore(ModuleStoreReadBase):
                 course_id=course_id,
                 course_dir=course_dir,
                 error_tracker=tracker,
-                parent_tracker=self.parent_trackers[course_id],
                 load_error_modules=self.load_error_modules,
                 get_policy=get_policy,
                 mixins=self.xblock_mixins,
@@ -807,10 +772,8 @@ class XMLModuleStore(ModuleStoreReadBase):
         '''Find the location that is the parent of this location in this
         course.  Needed for path_to_location().
         '''
-        if not self.parent_trackers[location.course_key].is_known(location):
-            raise ItemNotFoundError("{0} not in {1}".format(location, location.course_key))
-
-        return self.parent_trackers[location.course_key].parent(location)
+        block = self.get_item(location, 0)
+        return block.parent
 
     def get_modulestore_type(self, course_key=None):
         """

--- a/common/lib/xmodule/xmodule/modulestore/xml_importer.py
+++ b/common/lib/xmodule/xmodule/modulestore/xml_importer.py
@@ -27,7 +27,7 @@ from path import path
 import json
 import re
 
-from .xml import XMLModuleStore, ImportSystem, ParentTracker
+from .xml import XMLModuleStore, ImportSystem
 from xblock.runtime import KvsFieldData, DictKeyValueStore
 from xmodule.x_module import XModuleDescriptor
 from opaque_keys.edx.keys import UsageKey
@@ -423,9 +423,13 @@ def _import_module_and_update_references(
 
     fields = {}
     for field_name, field in module.fields.iteritems():
-        if field.is_set_on(module):
+        if field.scope != Scope.parent and field.is_set_on(module):
             if isinstance(field, Reference):
-                fields[field_name] = _convert_reference_fields_to_new_namespace(field.read_from(module))
+                value = field.read_from(module)
+                if value is None:
+                    fields[field_name] = None
+                else:
+                    fields[field_name] = _convert_reference_fields_to_new_namespace(field.read_from(module))
             elif isinstance(field, ReferenceList):
                 references = field.read_from(module)
                 fields[field_name] = [_convert_reference_fields_to_new_namespace(reference) for reference in references]
@@ -490,7 +494,6 @@ def _import_course_draft(
         course_id=source_course_id,
         course_dir=draft_course_dir,
         error_tracker=errorlog.tracker,
-        parent_tracker=ParentTracker(),
         load_error_modules=False,
         mixins=xml_module_store.xblock_mixins,
         field_data=KvsFieldData(kvs=DictKeyValueStore()),

--- a/common/lib/xmodule/xmodule/partitions/partitions.py
+++ b/common/lib/xmodule/xmodule/partitions/partitions.py
@@ -10,7 +10,21 @@ from stevedore.extension import ExtensionManager
 
 class UserPartitionError(Exception):
     """
-    An error was found regarding user partitions.
+    Base Exception for when an error was found regarding user partitions.
+    """
+    pass
+
+
+class NoSuchUserPartitionError(UserPartitionError):
+    """
+    Exception to be raised when looking up a UserPartition by its ID fails.
+    """
+    pass
+
+
+class NoSuchUserPartitionGroupError(UserPartitionError):
+    """
+    Exception to be raised when looking up a UserPartition Group by its ID fails.
     """
     pass
 
@@ -171,9 +185,14 @@ class UserPartition(namedtuple("UserPartition", "id name description groups sche
 
     def get_group(self, group_id):
         """
-        Returns the group with the specified id.
+        Returns the group with the specified id.  Raises NoSuchUserPartitionGroupError if not found.
         """
-        for group in self.groups:    # pylint: disable=no-member
+        # pylint: disable=no-member
+
+        for group in self.groups:
             if group.id == group_id:
                 return group
-        return None
+
+        raise NoSuchUserPartitionGroupError(
+            "could not find a Group with ID [{}] in UserPartition [{}]".format(group_id, self.id)
+        )

--- a/common/lib/xmodule/xmodule/partitions/tests/test_partitions.py
+++ b/common/lib/xmodule/xmodule/partitions/tests/test_partitions.py
@@ -7,7 +7,9 @@ from unittest import TestCase
 from mock import Mock
 
 from stevedore.extension import Extension, ExtensionManager
-from xmodule.partitions.partitions import Group, UserPartition, UserPartitionError, USER_PARTITION_SCHEME_NAMESPACE
+from xmodule.partitions.partitions import (
+    Group, UserPartition, UserPartitionError, NoSuchUserPartitionGroupError, USER_PARTITION_SCHEME_NAMESPACE
+)
 from xmodule.partitions.partitions_service import PartitionService
 from xmodule.tests import get_test_system
 
@@ -258,6 +260,23 @@ class TestUserPartition(PartitionTestCase):
         }
         user_partition = UserPartition.from_json(jsonified)
         self.assertNotIn("programmer", user_partition.to_json())
+
+    def test_get_group(self):
+        """
+        UserPartition.get_group correctly returns the group referenced by the
+        `group_id` parameter, or raises NoSuchUserPartitionGroupError when
+        the lookup fails.
+        """
+        self.assertEqual(
+            self.user_partition.get_group(self.TEST_GROUPS[0].id),  # pylint: disable=no-member
+            self.TEST_GROUPS[0]
+        )
+        self.assertEqual(
+            self.user_partition.get_group(self.TEST_GROUPS[1].id),  # pylint: disable=no-member
+            self.TEST_GROUPS[1]
+        )
+        with self.assertRaises(NoSuchUserPartitionGroupError):
+            self.user_partition.get_group(3)
 
 
 class StaticPartitionService(PartitionService):

--- a/common/lib/xmodule/xmodule/tests/test_conditional.py
+++ b/common/lib/xmodule/xmodule/tests/test_conditional.py
@@ -30,7 +30,6 @@ class DummySystem(ImportSystem):
             course_id=SlashSeparatedCourseKey(ORG, COURSE, 'test_run'),
             course_dir='test_dir',
             error_tracker=Mock(),
-            parent_tracker=Mock(),
             load_error_modules=load_error_modules,
         )
 

--- a/common/lib/xmodule/xmodule/tests/test_course_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_course_module.py
@@ -36,14 +36,12 @@ class DummySystem(ImportSystem):
         course_id = SlashSeparatedCourseKey(ORG, COURSE, 'test_run')
         course_dir = "test_dir"
         error_tracker = Mock()
-        parent_tracker = Mock()
 
         super(DummySystem, self).__init__(
             xmlstore=xmlstore,
             course_id=course_id,
             course_dir=course_dir,
             error_tracker=error_tracker,
-            parent_tracker=parent_tracker,
             load_error_modules=load_error_modules,
             field_data=KvsFieldData(DictKeyValueStore()),
         )

--- a/common/lib/xmodule/xmodule/tests/test_import.py
+++ b/common/lib/xmodule/xmodule/tests/test_import.py
@@ -39,14 +39,12 @@ class DummySystem(ImportSystem):
         course_id = SlashSeparatedCourseKey(ORG, COURSE, 'test_run')
         course_dir = "test_dir"
         error_tracker = Mock()
-        parent_tracker = Mock()
 
         super(DummySystem, self).__init__(
             xmlstore=xmlstore,
             course_id=course_id,
             course_dir=course_dir,
             error_tracker=error_tracker,
-            parent_tracker=parent_tracker,
             load_error_modules=load_error_modules,
             mixins=(InheritanceMixin, XModuleMixin),
             field_data=KvsFieldData(DictKeyValueStore()),

--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -835,7 +835,8 @@ class XModuleDescriptor(XModuleMixin, HTMLSnippet, ResourceTemplates, XBlock):
 
     # =============================== BUILTIN METHODS ==========================
     def __eq__(self, other):
-        return (self.scope_ids == other.scope_ids and
+        return (hasattr(other, 'scope_ids') and
+                self.scope_ids == other.scope_ids and
                 self.fields.keys() == other.fields.keys() and
                 all(getattr(self, field.name) == getattr(other, field.name)
                     for field in self.fields.values()))

--- a/lms/djangoapps/courseware/access.py
+++ b/lms/djangoapps/courseware/access.py
@@ -15,6 +15,7 @@ from xmodule.error_module import ErrorDescriptor
 from xmodule.x_module import XModule
 
 from xblock.core import XBlock
+from xmodule.partitions.partitions import NoSuchUserPartitionError, NoSuchUserPartitionGroupError
 
 from external_auth.models import ExternalAuthMap
 from courseware.masquerade import is_masquerading_as_student
@@ -265,6 +266,71 @@ def _has_access_error_desc(user, action, descriptor, course_key):
     return _dispatch(checkers, action, user, descriptor)
 
 
+def _has_group_access(descriptor, user, course_key):
+    """
+    This function returns a boolean indicating whether or not `user` has
+    sufficient group memberships to "load" a block (the `descriptor`)
+    """
+    if len(descriptor.user_partitions) == 0:
+        # short circuit the process, since there are no defined user partitions
+        return True
+
+    # use merged_group_access which takes group access on the block's
+    # parents / ancestors into account
+    merged_access = descriptor.merged_group_access
+    # check for False in merged_access, which indicates that at least one
+    # partition's group list excludes all students.
+    if False in merged_access.values():
+        log.warning("Group access check excludes all students, access will be denied.", exc_info=True)
+        return False
+
+    # resolve the partition IDs in group_access to actual
+    # partition objects, skipping those which contain empty group directives.
+    # if a referenced partition could not be found, access will be denied.
+    try:
+        partitions = [
+            descriptor._get_user_partition(partition_id)  # pylint:disable=protected-access
+            for partition_id, group_ids in merged_access.items()
+            if group_ids is not None
+        ]
+    except NoSuchUserPartitionError:
+        log.warning("Error looking up user partition, access will be denied.", exc_info=True)
+        return False
+
+    # next resolve the group IDs specified within each partition
+    partition_groups = []
+    try:
+        for partition in partitions:
+            groups = [
+                partition.get_group(group_id)
+                for group_id in merged_access[partition.id]
+            ]
+            if groups:
+                partition_groups.append((partition, groups))
+    except NoSuchUserPartitionGroupError:
+        log.warning("Error looking up referenced user partition group, access will be denied.", exc_info=True)
+        return False
+
+    # look up the user's group for each partition
+    user_groups = {}
+    for partition, groups in partition_groups:
+        user_groups[partition.id] = partition.scheme.get_group_for_user(
+            course_key,
+            user,
+            partition,
+        )
+
+    # finally: check that the user has a satisfactory group assignment
+    # for each partition.
+    if not all(
+        user_groups.get(partition.id) in groups for partition, groups in partition_groups
+    ):
+        return False
+
+    # all checks passed.
+    return True
+
+
 def _has_access_descriptor(user, action, descriptor, course_key=None):
     """
     Check if user has access to this descriptor.
@@ -286,6 +352,12 @@ def _has_access_descriptor(user, action, descriptor, course_key=None):
         """
         if descriptor.visible_to_staff_only and not _has_staff_access_to_descriptor(user, descriptor, course_key):
             return False
+
+        # enforce group access
+        if not _has_group_access(descriptor, user, course_key):
+            # if group_access check failed, deny access unless the requestor is staff,
+            # in which case immediately grant access.
+            return _has_staff_access_to_descriptor(user, descriptor, course_key)
 
         # If start dates are off, can always load
         if settings.FEATURES['DISABLE_START_DATES'] and not is_masquerading_as_student(user):

--- a/lms/djangoapps/courseware/tests/test_access.py
+++ b/lms/djangoapps/courseware/tests/test_access.py
@@ -105,7 +105,7 @@ class AccessTestCase(TestCase):
     def test__has_access_descriptor(self):
         # TODO: override DISABLE_START_DATES and test the start date branch of the method
         user = Mock()
-        descriptor = Mock()
+        descriptor = Mock(user_partitions=[])
 
         # Always returns true because DISABLE_START_DATES is set in test.py
         self.assertTrue(access._has_access_descriptor(user, 'load', descriptor))
@@ -118,7 +118,7 @@ class AccessTestCase(TestCase):
         """
         Tests that "visible_to_staff_only" overrides start date.
         """
-        mock_unit = Mock()
+        mock_unit = Mock(user_partitions=[])
         mock_unit._class_tags = {}  # Needed for detached check in _has_access_descriptor
 
         def verify_access(student_should_have_access):

--- a/lms/djangoapps/courseware/tests/test_group_access.py
+++ b/lms/djangoapps/courseware/tests/test_group_access.py
@@ -1,0 +1,384 @@
+"""
+This module defines tests for courseware.access that are specific to group
+access control rules.
+"""
+
+import ddt
+from stevedore.extension import Extension, ExtensionManager
+
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.partitions.partitions import Group, UserPartition, USER_PARTITION_SCHEME_NAMESPACE
+from xmodule.modulestore.django import modulestore
+
+import courseware.access as access
+from courseware.tests.factories import StaffFactory, UserFactory
+
+
+class MemoryUserPartitionScheme(object):
+    """
+    In-memory partition scheme for testing.
+    """
+    name = "memory"
+
+    def __init__(self):
+        self.current_group = {}
+
+    def set_group_for_user(self, user, user_partition, group):
+        """
+        Link this user to this group in this partition, in memory.
+        """
+        self.current_group.setdefault(user.id, {})[user_partition.id] = group
+
+    def get_group_for_user(self, course_id, user, user_partition, track_function=None):  # pylint: disable=unused-argument
+        """
+        Fetch the group to which this user is linked in this partition, or None.
+        """
+        return self.current_group.get(user.id, {}).get(user_partition.id)
+
+
+def resolve_attrs(test_method):
+    """
+    Helper function used with ddt.  It allows passing strings to test methods
+    via @ddt.data, which are the names of instance attributes on `self`, and
+    replaces them with the resolved values of those attributes in the method
+    call.
+    """
+    def _wrapper(self, *args):  # pylint: disable=missing-docstring
+        new_args = [getattr(self, arg) for arg in args]
+        return test_method(self, *new_args)
+    return _wrapper
+
+
+@ddt.ddt
+class GroupAccessTestCase(ModuleStoreTestCase):
+    """
+    Tests to ensure that has_access() correctly enforces the visibility
+    restrictions specified in the `group_access` field of XBlocks.
+    """
+    # pylint: disable=no-member
+
+    def set_user_group(self, user, partition, group):
+        """
+        Internal DRY / shorthand.
+        """
+        partition.scheme.set_group_for_user(user, partition, group)
+
+    def set_group_access(self, block, access_dict):
+        """
+        DRY helper.
+        """
+        block.group_access = access_dict
+        modulestore().update_item(block, 1)
+
+    def setUp(self):
+
+        UserPartition.scheme_extensions = ExtensionManager.make_test_instance(
+            [
+                Extension(
+                    "memory",
+                    USER_PARTITION_SCHEME_NAMESPACE,
+                    MemoryUserPartitionScheme(),
+                    None
+                ),
+            ],
+            namespace=USER_PARTITION_SCHEME_NAMESPACE
+        )
+
+        self.cat_group = Group(10, 'cats')
+        self.dog_group = Group(20, 'dogs')
+        self.worm_group = Group(30, 'worms')
+        self.animal_partition = UserPartition(
+            0,
+            'Pet Partition',
+            'which animal are you?',
+            [self.cat_group, self.dog_group, self.worm_group],
+            scheme=UserPartition.get_scheme("memory"),
+        )
+
+        self.red_group = Group(1000, 'red')
+        self.blue_group = Group(2000, 'blue')
+        self.gray_group = Group(3000, 'gray')
+        self.color_partition = UserPartition(
+            100,
+            'Color Partition',
+            'what color are you?',
+            [self.red_group, self.blue_group, self.gray_group],
+            scheme=UserPartition.get_scheme("memory"),
+        )
+
+        self.course = CourseFactory.create(
+            user_partitions=[self.animal_partition, self.color_partition],
+        )
+        self.chapter = ItemFactory.create(category='chapter', parent=self.course)
+        self.section = ItemFactory.create(category='sequential', parent=self.chapter)
+        self.vertical = ItemFactory.create(category='vertical', parent=self.section)
+        self.component = ItemFactory.create(category='problem', parent=self.vertical)
+
+        self.red_cat = UserFactory()  # student in red and cat groups
+        self.set_user_group(self.red_cat, self.animal_partition, self.cat_group)
+        self.set_user_group(self.red_cat, self.color_partition, self.red_group)
+
+        self.blue_dog = UserFactory()  # student in blue and dog groups
+        self.set_user_group(self.blue_dog, self.animal_partition, self.dog_group)
+        self.set_user_group(self.blue_dog, self.color_partition, self.blue_group)
+
+        self.white_mouse = UserFactory()  # student in no group
+
+        self.gray_worm = UserFactory()  # student in deleted group
+        self.set_user_group(self.gray_worm, self.animal_partition, self.worm_group)
+        self.set_user_group(self.gray_worm, self.color_partition, self.gray_group)
+        # delete the gray/worm groups from the partitions now so we can test scenarios
+        # for user whose group is missing.
+        self.animal_partition.groups.pop()
+        self.color_partition.groups.pop()
+
+        # add a staff user, whose access will be unconditional in spite of group access.
+        self.staff = StaffFactory.create(course_key=self.course.id)
+
+    # avoid repeatedly declaring the same sequence for ddt in all the test cases.
+    PARENT_CHILD_PAIRS = (
+        ('chapter', 'chapter'),
+        ('chapter', 'section'),
+        ('chapter', 'vertical'),
+        ('chapter', 'component'),
+        ('section', 'section'),
+        ('section', 'vertical'),
+        ('section', 'component'),
+        ('vertical', 'vertical'),
+        ('vertical', 'component'),
+    )
+
+    def tearDown(self):
+        """
+        Clear out the stevedore extension points on UserPartition to avoid
+        side-effects in other tests.
+        """
+        UserPartition.scheme_extensions = None
+
+    def check_access(self, user, block, is_accessible):
+        """
+        DRY helper.
+        """
+        self.assertIs(
+            access.has_access(user, 'load', block, self.course.id),
+            is_accessible
+        )
+
+    def ensure_staff_access(self, block):
+        """
+        Another DRY helper.
+        """
+        self.assertTrue(access.has_access(self.staff, 'load', block, self.course.id))
+
+    # NOTE: in all the tests that follow, `block_specified` and
+    # `block_accessed` designate the place where group_access rules are
+    # specified, and where access is being checked in the test, respectively.
+
+    @ddt.data(*PARENT_CHILD_PAIRS)
+    @ddt.unpack
+    @resolve_attrs
+    def test_has_access_single_partition_single_group(self, block_specified, block_accessed):
+        """
+        Access checks are correctly enforced on the block when a single group
+        is specified for a single partition.
+        """
+        self.set_group_access(
+            block_specified,
+            {self.animal_partition.id: [self.cat_group.id]},
+        )
+        self.check_access(self.red_cat, block_accessed, True)
+        self.check_access(self.blue_dog, block_accessed, False)
+        self.check_access(self.white_mouse, block_accessed, False)
+        self.check_access(self.gray_worm, block_accessed, False)
+        self.ensure_staff_access(block_accessed)
+
+    @ddt.data(*PARENT_CHILD_PAIRS)
+    @ddt.unpack
+    @resolve_attrs
+    def test_has_access_single_partition_two_groups(self, block_specified, block_accessed):
+        """
+        Access checks are correctly enforced on the block when multiple groups
+        are specified for a single partition.
+        """
+        self.set_group_access(
+            block_specified,
+            {self.animal_partition.id: [self.cat_group.id, self.dog_group.id]},
+        )
+        self.check_access(self.red_cat, block_accessed, True)
+        self.check_access(self.blue_dog, block_accessed, True)
+        self.check_access(self.white_mouse, block_accessed, False)
+        self.check_access(self.gray_worm, block_accessed, False)
+        self.ensure_staff_access(block_accessed)
+
+    @ddt.data(*PARENT_CHILD_PAIRS)
+    @ddt.unpack
+    @resolve_attrs
+    def test_has_access_single_partition_disjoint_groups(self, block_specified, block_accessed):
+        """
+        When the parent's and child's group specifications do not intersect,
+        access is denied to the child regardless of the user's groups.
+        """
+        if block_specified == block_accessed:
+            # this test isn't valid unless block_accessed is a descendant of
+            # block_specified.
+            return
+
+        self.set_group_access(
+            block_specified,
+            {self.animal_partition.id: [self.dog_group.id]},
+        )
+        self.set_group_access(
+            block_accessed,
+            {self.animal_partition.id: [self.cat_group.id]},
+        )
+        self.check_access(self.red_cat, block_accessed, False)
+        self.check_access(self.blue_dog, block_accessed, False)
+        self.check_access(self.white_mouse, block_accessed, False)
+        self.check_access(self.gray_worm, block_accessed, False)
+        self.ensure_staff_access(block_accessed)
+
+    @ddt.data(*PARENT_CHILD_PAIRS)
+    @ddt.unpack
+    @resolve_attrs
+    def test_has_access_single_empty_partition(self, block_specified, block_accessed):
+        """
+        No group access checks are enforced on the block when group_access
+        declares a partition but does not specify any groups.
+        """
+        self.set_group_access(block_specified, {self.animal_partition.id: []})
+        self.check_access(self.red_cat, block_accessed, True)
+        self.check_access(self.blue_dog, block_accessed, True)
+        self.check_access(self.white_mouse, block_accessed, True)
+        self.check_access(self.gray_worm, block_accessed, True)
+        self.ensure_staff_access(block_accessed)
+
+    @ddt.data(*PARENT_CHILD_PAIRS)
+    @ddt.unpack
+    @resolve_attrs
+    def test_has_access_empty_dict(self, block_specified, block_accessed):
+        """
+        No group access checks are enforced on the block when group_access is an
+        empty dictionary.
+        """
+        self.set_group_access(block_specified, {})
+        self.check_access(self.red_cat, block_accessed, True)
+        self.check_access(self.blue_dog, block_accessed, True)
+        self.check_access(self.white_mouse, block_accessed, True)
+        self.check_access(self.gray_worm, block_accessed, True)
+        self.ensure_staff_access(block_accessed)
+
+    @ddt.data(*PARENT_CHILD_PAIRS)
+    @ddt.unpack
+    @resolve_attrs
+    def test_has_access_none(self, block_specified, block_accessed):
+        """
+        No group access checks are enforced on the block when group_access is None.
+        """
+        self.set_group_access(block_specified, None)
+        self.check_access(self.red_cat, block_accessed, True)
+        self.check_access(self.blue_dog, block_accessed, True)
+        self.check_access(self.white_mouse, block_accessed, True)
+        self.check_access(self.gray_worm, block_accessed, True)
+        self.ensure_staff_access(block_accessed)
+
+    @ddt.data(*PARENT_CHILD_PAIRS)
+    @ddt.unpack
+    @resolve_attrs
+    def test_has_access_single_partition_group_none(self, block_specified, block_accessed):
+        """
+        No group access checks are enforced on the block when group_access
+        specifies a partition but its value is None.
+        """
+        self.set_group_access(block_specified, {self.animal_partition.id: None})
+        self.check_access(self.red_cat, block_accessed, True)
+        self.check_access(self.blue_dog, block_accessed, True)
+        self.check_access(self.white_mouse, block_accessed, True)
+        self.check_access(self.gray_worm, block_accessed, True)
+        self.ensure_staff_access(block_accessed)
+
+    @ddt.data(*PARENT_CHILD_PAIRS)
+    @ddt.unpack
+    @resolve_attrs
+    def test_has_access_single_partition_group_empty_list(self, block_specified, block_accessed):
+        """
+        No group access checks are enforced on the block when group_access
+        specifies a partition but its value is an empty list.
+        """
+        self.set_group_access(block_specified, {self.animal_partition.id: []})
+        self.check_access(self.red_cat, block_accessed, True)
+        self.check_access(self.blue_dog, block_accessed, True)
+        self.check_access(self.white_mouse, block_accessed, True)
+        self.check_access(self.gray_worm, block_accessed, True)
+        self.ensure_staff_access(block_accessed)
+
+    @ddt.data(*PARENT_CHILD_PAIRS)
+    @ddt.unpack
+    @resolve_attrs
+    def test_has_access_nonexistent_nonempty_partition(self, block_specified, block_accessed):
+        """
+        Access will be denied to the block when group_access specifies a
+        nonempty partition that does not exist in course.user_partitions.
+        """
+        self.set_group_access(block_specified, {9: [99]})
+        self.check_access(self.red_cat, block_accessed, False)
+        self.check_access(self.blue_dog, block_accessed, False)
+        self.check_access(self.white_mouse, block_accessed, False)
+        self.check_access(self.gray_worm, block_accessed, False)
+        self.ensure_staff_access(block_accessed)
+
+    @ddt.data(*PARENT_CHILD_PAIRS)
+    @ddt.unpack
+    @resolve_attrs
+    def test_has_access_nonexistent_group(self, block_specified, block_accessed):
+        """
+        Access will be denied to the block when group_access contains a group
+        id that does not exist in its referenced partition.
+        """
+        self.set_group_access(block_specified, {self.animal_partition.id: [99]})
+        self.check_access(self.red_cat, block_accessed, False)
+        self.check_access(self.blue_dog, block_accessed, False)
+        self.check_access(self.white_mouse, block_accessed, False)
+        self.check_access(self.gray_worm, block_accessed, False)
+        self.ensure_staff_access(block_accessed)
+
+    @ddt.data(*PARENT_CHILD_PAIRS)
+    @ddt.unpack
+    @resolve_attrs
+    def test_multiple_partitions(self, block_specified, block_accessed):
+        """
+        Group access restrictions are correctly enforced when multiple partition
+        / group rules are defined.
+        """
+        self.set_group_access(
+            block_specified,
+            {
+                self.animal_partition.id: [self.cat_group.id],
+                self.color_partition.id: [self.red_group.id],
+            },
+        )
+        self.check_access(self.red_cat, block_accessed, True)
+        self.check_access(self.blue_dog, block_accessed, False)
+        self.check_access(self.white_mouse, block_accessed, False)
+        self.check_access(self.gray_worm, block_accessed, False)
+        self.ensure_staff_access(block_accessed)
+
+    @ddt.data(*PARENT_CHILD_PAIRS)
+    @ddt.unpack
+    @resolve_attrs
+    def test_multiple_partitions_deny_access(self, block_specified, block_accessed):
+        """
+        Group access restrictions correctly deny access even when some (but not
+        all) group_access rules are satisfied.
+        """
+        self.set_group_access(
+            block_specified,
+            {
+                self.animal_partition.id: [self.cat_group.id],
+                self.color_partition.id: [self.blue_group.id],
+            },
+        )
+        self.check_access(self.red_cat, block_accessed, False)
+        self.check_access(self.blue_dog, block_accessed, False)
+        self.check_access(self.gray_worm, block_accessed, False)
+        self.ensure_staff_access(block_accessed)

--- a/lms/djangoapps/courseware/tests/test_lti_integration.py
+++ b/lms/djangoapps/courseware/tests/test_lti_integration.py
@@ -163,7 +163,7 @@ class TestLTIModuleListing(ModuleStoreTestCase):
             parent_location=self.section2.location,
             display_name="lti draft",
             category="lti",
-            location=self.course.id.make_usage_key('lti', 'lti_published'),
+            location=self.course.id.make_usage_key('lti', 'lti_draft'),
             publish_item=False,
         )
 
@@ -199,7 +199,7 @@ class TestLTIModuleListing(ModuleStoreTestCase):
             "lti_1_1_result_service_xml_endpoint": self.expected_handler_url('grade_handler'),
             "lti_2_0_result_service_json_endpoint":
             self.expected_handler_url('lti_2_0_result_rest_handler') + "/user/{anon_user_id}",
-            "display_name": self.lti_draft.display_name
+            "display_name": self.lti_published.display_name,
         }
         self.assertEqual([expected], json.loads(response.content))
 

--- a/lms/djangoapps/courseware/tests/test_submitting_problems.py
+++ b/lms/djangoapps/courseware/tests/test_submitting_problems.py
@@ -1159,11 +1159,11 @@ class TestConditionalContent(TestSubmittingProblems):
         vertical_0, vertical_1 = self.split_setup(user_partition_group)
 
         # Group 0 will have 2 problems in the section, worth a total of 4 points.
-        self.add_dropdown_to_section(vertical_0.location, 'H2P1', 1).location.html_id()
-        self.add_dropdown_to_section(vertical_0.location, 'H2P2', 3).location.html_id()
+        self.add_dropdown_to_section(vertical_0.location, 'H2P1_GROUP0', 1).location.html_id()
+        self.add_dropdown_to_section(vertical_0.location, 'H2P2_GROUP0', 3).location.html_id()
 
         # Group 1 will have 1 problem in the section, worth a total of 1 point.
-        self.add_dropdown_to_section(vertical_1.location, 'H2P1', 1).location.html_id()
+        self.add_dropdown_to_section(vertical_1.location, 'H2P1_GROUP1', 1).location.html_id()
 
         # Submit answers for problem in Section 1, which is visible to all students.
         self.submit_question_answer('H1P1', {'2_1': 'Correct', '2_2': 'Incorrect'})
@@ -1175,8 +1175,8 @@ class TestConditionalContent(TestSubmittingProblems):
         """
         self.split_different_problems_setup(self.user_partition_group_0)
 
-        self.submit_question_answer('H2P1', {'2_1': 'Correct'})
-        self.submit_question_answer('H2P2', {'2_1': 'Correct', '2_2': 'Incorrect', '2_3': 'Correct'})
+        self.submit_question_answer('H2P1_GROUP0', {'2_1': 'Correct'})
+        self.submit_question_answer('H2P2_GROUP0', {'2_1': 'Correct', '2_2': 'Incorrect', '2_3': 'Correct'})
 
         self.assertEqual(self.score_for_hw('homework1'), [1.0])
         self.assertEqual(self.score_for_hw('homework2'), [1.0, 2.0])
@@ -1194,7 +1194,7 @@ class TestConditionalContent(TestSubmittingProblems):
         """
         self.split_different_problems_setup(self.user_partition_group_1)
 
-        self.submit_question_answer('H2P1', {'2_1': 'Correct'})
+        self.submit_question_answer('H2P1_GROUP1', {'2_1': 'Correct'})
 
         self.assertEqual(self.score_for_hw('homework1'), [1.0])
         self.assertEqual(self.score_for_hw('homework2'), [1.0])
@@ -1219,7 +1219,7 @@ class TestConditionalContent(TestSubmittingProblems):
         [_, vertical_1] = self.split_setup(user_partition_group)
 
         # Group 1 will have 1 problem in the section, worth a total of 1 point.
-        self.add_dropdown_to_section(vertical_1.location, 'H2P1', 1).location.html_id()
+        self.add_dropdown_to_section(vertical_1.location, 'H2P1_GROUP1', 1).location.html_id()
 
         self.submit_question_answer('H1P1', {'2_1': 'Correct'})
 
@@ -1244,7 +1244,7 @@ class TestConditionalContent(TestSubmittingProblems):
         """
         self.split_one_group_no_problems_setup(self.user_partition_group_1)
 
-        self.submit_question_answer('H2P1', {'2_1': 'Correct'})
+        self.submit_question_answer('H2P1_GROUP1', {'2_1': 'Correct'})
 
         self.assertEqual(self.score_for_hw('homework1'), [1.0])
         self.assertEqual(self.score_for_hw('homework2'), [1.0])

--- a/lms/djangoapps/instructor/tests/test_tools.py
+++ b/lms/djangoapps/instructor/tests/test_tools.py
@@ -119,7 +119,8 @@ class TestFindUnit(ModuleStoreTestCase):
         Test finding a nested unit.
         """
         url = self.homework.location.to_deprecated_string()
-        self.assertEqual(tools.find_unit(self.course, url), self.homework)
+        found_unit = tools.find_unit(self.course, url)
+        self.assertEqual(found_unit.location, self.homework.location)
 
     def test_find_unit_notfound(self):
         """

--- a/lms/lib/xblock/mixin.py
+++ b/lms/lib/xblock/mixin.py
@@ -1,12 +1,26 @@
 """
 Namespace that defines fields common to all blocks used in the LMS
 """
+from lazy import lazy
+
 from xblock.fields import Boolean, Scope, String, XBlockMixin, Dict
 from xblock.validation import ValidationMessage
 from xmodule.modulestore.inheritance import UserPartitionList
+from xmodule.partitions.partitions import NoSuchUserPartitionError, NoSuchUserPartitionGroupError
 
 # Make '_' a no-op so we can scrape strings
 _ = lambda text: text
+
+
+class GroupAccessDict(Dict):
+    """Special Dict class for serializing the group_access field"""
+    def from_json(self, access_dict):
+        if access_dict is not None:
+            return {int(k): access_dict[k] for k in access_dict}
+
+    def to_json(self, access_dict):
+        if access_dict is not None:
+            return {unicode(k): access_dict[k] for k in access_dict}
 
 
 class LmsBlockMixin(XBlockMixin):
@@ -55,15 +69,55 @@ class LmsBlockMixin(XBlockMixin):
         default=False,
         scope=Scope.settings,
     )
-    group_access = Dict(
-        help="A dictionary that maps which groups can be shown this block. The keys "
-             "are group configuration ids and the values are a list of group IDs. "
-             "If there is no key for a group configuration or if the list of group IDs "
-             "is empty then the block is considered visible to all. Note that this "
-             "field is ignored if the block is visible_to_staff_only.",
+
+    group_access = GroupAccessDict(
+        help=_(
+            "A dictionary that maps which groups can be shown this block. The keys "
+            "are group configuration ids and the values are a list of group IDs. "
+            "If there is no key for a group configuration or if the set of group IDs "
+            "is empty then the block is considered visible to all. Note that this "
+            "field is ignored if the block is visible_to_staff_only."
+        ),
         default={},
         scope=Scope.settings,
     )
+
+    @lazy
+    def merged_group_access(self):
+        """
+        This computes access to a block's group_access rules in the context of its position
+        within the courseware structure, in the form of a lazily-computed attribute.
+        Each block's group_access rule is merged recursively with its parent's, guaranteeing
+        that any rule in a parent block will be enforced on descendants, even if a descendant
+        also defined its own access rules.  The return value is always a dict, with the same
+        structure as that of the group_access field.
+
+        When merging access rules results in a case where all groups are denied access in a
+        user partition (which effectively denies access to that block for all students),
+        the special value False will be returned for that user partition key.
+        """
+        parent = self.get_parent()
+        if not parent:
+            return self.group_access or {}
+
+        merged_access = parent.merged_group_access.copy()
+        if self.group_access is not None:
+            for partition_id, group_ids in self.group_access.items():
+                if group_ids:  # skip if the "local" group_access for this partition is None or empty.
+                    if partition_id in merged_access:
+                        if merged_access[partition_id] is False:
+                            # special case - means somewhere up the hierarchy, merged access rules have eliminated
+                            # all group_ids from this partition, so there's no possible intersection.
+                            continue
+                        # otherwise, if the parent defines group access rules for this partition,
+                        # intersect with the local ones.
+                        merged_access[partition_id] = list(
+                            set(merged_access[partition_id]).intersection(group_ids)
+                        ) or False
+                    else:
+                        # add the group access rules for this partition to the merged set of rules.
+                        merged_access[partition_id] = group_ids
+        return merged_access
 
     # Specified here so we can see what the value set at the course-level is.
     user_partitions = UserPartitionList(
@@ -74,29 +128,14 @@ class LmsBlockMixin(XBlockMixin):
 
     def _get_user_partition(self, user_partition_id):
         """
-        Returns the user partition with the specified id, or None if there is no such partition.
+        Returns the user partition with the specified id.  Raises
+        `NoSuchUserPartitionError` if the lookup fails.
         """
         for user_partition in self.user_partitions:
             if user_partition.id == user_partition_id:
                 return user_partition
 
-        return None
-
-    def is_visible_to_group(self, user_partition, group):
-        """
-        Returns true if this xblock should be shown to a user in the specified user partition group.
-        This method returns true if one of the following is true:
-         - the xblock has no group_access dictionary specified
-         - if the dictionary has no key for the user partition's id
-         - if the value for the user partition's id is an empty list
-         - if the value for the user partition's id contains the specified group's id
-        """
-        if not self.group_access:
-            return True
-        group_ids = self.group_access.get(user_partition.id, [])
-        if len(group_ids) == 0:
-            return True
-        return group.id in group_ids
+        raise NoSuchUserPartitionError("could not find a UserPartition with ID [{}]".format(user_partition_id))
 
     def validate(self):
         """
@@ -105,8 +144,9 @@ class LmsBlockMixin(XBlockMixin):
         _ = self.runtime.service(self, "i18n").ugettext  # pylint: disable=redefined-outer-name
         validation = super(LmsBlockMixin, self).validate()
         for user_partition_id, group_ids in self.group_access.iteritems():
-            user_partition = self._get_user_partition(user_partition_id)
-            if not user_partition:
+            try:
+                user_partition = self._get_user_partition(user_partition_id)
+            except NoSuchUserPartitionError:
                 validation.add(
                     ValidationMessage(
                         ValidationMessage.ERROR,
@@ -115,8 +155,9 @@ class LmsBlockMixin(XBlockMixin):
                 )
             else:
                 for group_id in group_ids:
-                    group = user_partition.get_group(group_id)
-                    if not group:
+                    try:
+                        user_partition.get_group(group_id)
+                    except NoSuchUserPartitionGroupError:
                         validation.add(
                             ValidationMessage(
                                 ValidationMessage.ERROR,

--- a/lms/lib/xblock/test/test_mixin.py
+++ b/lms/lib/xblock/test/test_mixin.py
@@ -1,8 +1,12 @@
 """
 Tests of the LMS XBlock Mixin
 """
+import ddt
+from django.conf import settings
 
 from xblock.validation import ValidationMessage
+from xmodule.modulestore import ModuleStoreEnum
+from xmodule.modulestore.modulestore_settings import update_module_store_settings
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.partitions.partitions import Group, UserPartition
@@ -13,9 +17,11 @@ class LmsXBlockMixinTestCase(ModuleStoreTestCase):
     Base class for XBlock mixin tests cases. A simple course with a single user partition is created
     in setUp for all subclasses to use.
     """
-
-    def setUp(self):
-        super(LmsXBlockMixinTestCase, self).setUp()
+    def build_course(self):
+        """
+        Build up a course tree with a UserPartition.
+        """
+        # pylint: disable=attribute-defined-outside-init
         self.user_partition = UserPartition(
             0,
             'first_partition',
@@ -31,13 +37,16 @@ class LmsXBlockMixinTestCase(ModuleStoreTestCase):
         self.section = ItemFactory.create(parent=self.course, category='chapter', display_name='Test Section')
         self.subsection = ItemFactory.create(parent=self.section, category='sequential', display_name='Test Subsection')
         self.vertical = ItemFactory.create(parent=self.subsection, category='vertical', display_name='Test Unit')
-        self.video = ItemFactory.create(parent=self.subsection, category='video', display_name='Test Video')
+        self.video = ItemFactory.create(parent=self.vertical, category='video', display_name='Test Video 1')
 
 
 class XBlockValidationTest(LmsXBlockMixinTestCase):
     """
     Unit tests for XBlock validation
     """
+    def setUp(self):
+        super(XBlockValidationTest, self).setUp()
+        self.build_course()
 
     def verify_validation_message(self, message, expected_message, expected_message_type):
         """
@@ -92,6 +101,9 @@ class XBlockGroupAccessTest(LmsXBlockMixinTestCase):
     """
     Unit tests for XBlock group access.
     """
+    def setUp(self):
+        super(XBlockGroupAccessTest, self).setUp()
+        self.build_course()
 
     def test_is_visible_to_group(self):
         """
@@ -121,3 +133,92 @@ class XBlockGroupAccessTest(LmsXBlockMixinTestCase):
         self.video.group_access[self.user_partition.id] = [self.group2.id, 999]    # pylint: disable=no-member
         self.assertFalse(self.video.is_visible_to_group(self.user_partition, self.group1))
         self.assertTrue(self.video.is_visible_to_group(self.user_partition, self.group2))
+
+
+@ddt.ddt
+class XBlockGetParentTest(LmsXBlockMixinTestCase):
+    """
+    Test that XBlock.get_parent returns correct results with each modulestore
+    backend.
+    """
+    def _pre_setup(self):
+        # load the one xml course into the xml store
+        update_module_store_settings(
+            settings.MODULESTORE,
+            mappings={'edX/toy/2012_Fall': ModuleStoreEnum.Type.xml},
+            xml_store_options={
+                'data_dir': settings.COMMON_TEST_DATA_ROOT  # where toy course lives
+            },
+        )
+        super(XBlockGetParentTest, self)._pre_setup()
+
+    @ddt.data(ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split, ModuleStoreEnum.Type.xml)
+    def test_parents(self, modulestore_type):
+        with self.store.default_store(modulestore_type):
+
+            # setting up our own local course tree here, since it needs to be
+            # created with the correct modulestore type.
+
+            if modulestore_type == 'xml':
+                course_key = self.store.make_course_key('edX', 'toy', '2012_Fall')
+            else:
+                course_key = self.create_toy_course('edX', 'toy', '2012_Fall_copy')
+            course = self.store.get_course(course_key)
+
+            self.assertIsNone(course.get_parent())
+
+            def recurse(parent):
+                """
+                Descend the course tree and ensure the result of get_parent()
+                is the expected one.
+                """
+                visited = []
+                for child in parent.get_children():
+                    self.assertEqual(parent.location, child.get_parent().location)
+                    visited.append(child)
+                    visited += recurse(child)
+                return visited
+
+            visited = recurse(course)
+            self.assertEqual(len(visited), 28)
+
+    @ddt.data(ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split)
+    def test_parents_draft_content(self, modulestore_type):
+        # move the video to the new vertical
+        with self.store.default_store(modulestore_type):
+            self.build_course()
+            new_vertical = ItemFactory.create(parent=self.subsection, category='vertical', display_name='New Test Unit')
+            child_to_move_location = self.video.location.for_branch(None)
+            new_parent_location = new_vertical.location.for_branch(None)
+            old_parent_location = self.vertical.location.for_branch(None)
+
+            with self.store.branch_setting(ModuleStoreEnum.Branch.draft_preferred):
+                self.assertIsNone(self.course.get_parent())
+
+                with self.store.bulk_operations(self.course.id):
+                    user_id = ModuleStoreEnum.UserID.test
+
+                    old_parent = self.store.get_item(old_parent_location)
+                    old_parent.children.remove(child_to_move_location)
+                    self.store.update_item(old_parent, user_id)
+
+                    new_parent = self.store.get_item(new_parent_location)
+                    new_parent.children.append(child_to_move_location)
+                    self.store.update_item(new_parent, user_id)
+
+                    # re-fetch video from draft store
+                    video = self.store.get_item(child_to_move_location)
+
+                    self.assertEqual(
+                        new_parent_location,
+                        video.get_parent().location
+                    )
+            with self.store.branch_setting(ModuleStoreEnum.Branch.published_only):
+                # re-fetch video from published store
+                video = self.store.get_item(child_to_move_location)
+                self.assertEqual(
+                    old_parent_location,
+                    video.get_parent().location.for_branch(None)
+                )
+
+

--- a/lms/lib/xblock/test/test_mixin.py
+++ b/lms/lib/xblock/test/test_mixin.py
@@ -97,44 +97,6 @@ class XBlockValidationTest(LmsXBlockMixinTestCase):
         )
 
 
-class XBlockGroupAccessTest(LmsXBlockMixinTestCase):
-    """
-    Unit tests for XBlock group access.
-    """
-    def setUp(self):
-        super(XBlockGroupAccessTest, self).setUp()
-        self.build_course()
-
-    def test_is_visible_to_group(self):
-        """
-        Test the behavior of is_visible_to_group.
-        """
-        # All groups are visible for an unrestricted xblock
-        self.assertTrue(self.video.is_visible_to_group(self.user_partition, self.group1))
-        self.assertTrue(self.video.is_visible_to_group(self.user_partition, self.group2))
-
-        # Verify that all groups are visible if the set of group ids is empty
-        self.video.group_access[self.user_partition.id] = []    # pylint: disable=no-member
-        self.assertTrue(self.video.is_visible_to_group(self.user_partition, self.group1))
-        self.assertTrue(self.video.is_visible_to_group(self.user_partition, self.group2))
-
-        # Verify that only specified groups are visible
-        self.video.group_access[self.user_partition.id] = [self.group1.id]    # pylint: disable=no-member
-        self.assertTrue(self.video.is_visible_to_group(self.user_partition, self.group1))
-        self.assertFalse(self.video.is_visible_to_group(self.user_partition, self.group2))
-
-        # Verify that having an invalid user partition does not affect group visibility of other partitions
-        self.video.group_access[999] = [self.group1.id]
-        self.assertTrue(self.video.is_visible_to_group(self.user_partition, self.group1))
-        self.assertFalse(self.video.is_visible_to_group(self.user_partition, self.group2))
-
-        # Verify that group access is still correct even with invalid group ids
-        self.video.group_access.clear()
-        self.video.group_access[self.user_partition.id] = [self.group2.id, 999]    # pylint: disable=no-member
-        self.assertFalse(self.video.is_visible_to_group(self.user_partition, self.group1))
-        self.assertTrue(self.video.is_visible_to_group(self.user_partition, self.group2))
-
-
 @ddt.ddt
 class XBlockGetParentTest(LmsXBlockMixinTestCase):
     """
@@ -222,3 +184,140 @@ class XBlockGetParentTest(LmsXBlockMixinTestCase):
                 )
 
 
+class RenamedTuple(tuple):  # pylint: disable=incomplete-protocol
+    """
+    This class is only used to allow overriding __name__ on the tuples passed
+    through ddt, in order to have the generated test names make sense.
+    """
+    pass
+
+
+def ddt_named(parent, child):
+    """
+    Helper to get more readable dynamically-generated test names from ddt.
+    """
+    args = RenamedTuple([parent, child])
+    setattr(args, '__name__', 'parent_{}_child_{}'.format(parent, child))
+    return args
+
+
+@ddt.ddt
+class XBlockMergedGroupAccessTest(LmsXBlockMixinTestCase):
+    """
+    Test that XBlock.merged_group_access is computed correctly according to
+    our access control rules.
+    """
+
+    PARTITION_1 = 1
+    PARTITION_1_GROUP_1 = 11
+    PARTITION_1_GROUP_2 = 12
+
+    PARTITION_2 = 2
+    PARTITION_2_GROUP_1 = 21
+    PARTITION_2_GROUP_2 = 22
+
+    PARENT_CHILD_PAIRS = (
+        ddt_named('section', 'subsection'),
+        ddt_named('section', 'vertical'),
+        ddt_named('section', 'video'),
+        ddt_named('subsection', 'vertical'),
+        ddt_named('subsection', 'video'),
+    )
+
+    def setUp(self):
+        super(XBlockMergedGroupAccessTest, self).setUp()
+        self.build_course()
+
+    def set_group_access(self, block, access_dict):
+        """
+        DRY helper.
+        """
+        block.group_access = access_dict
+        block.runtime.modulestore.update_item(block, 1)
+
+    @ddt.data(*PARENT_CHILD_PAIRS)
+    @ddt.unpack
+    def test_intersecting_groups(self, parent, child):
+        """
+        When merging group_access on a block, the resulting group IDs for each
+        partition is the intersection of the group IDs defined for that
+        partition across all ancestor blocks (including this one).
+        """
+        parent_block = getattr(self, parent)
+        child_block = getattr(self, child)
+
+        self.set_group_access(parent_block, {self.PARTITION_1: [self.PARTITION_1_GROUP_1, self.PARTITION_1_GROUP_2]})
+        self.set_group_access(child_block, {self.PARTITION_1: [self.PARTITION_1_GROUP_2]})
+
+        self.assertEqual(
+            parent_block.merged_group_access,
+            {self.PARTITION_1: [self.PARTITION_1_GROUP_1, self.PARTITION_1_GROUP_2]},
+        )
+        self.assertEqual(
+            child_block.merged_group_access,
+            {self.PARTITION_1: [self.PARTITION_1_GROUP_2]},
+        )
+
+    @ddt.data(*PARENT_CHILD_PAIRS)
+    @ddt.unpack
+    def test_disjoint_groups(self, parent, child):
+        """
+        When merging group_access on a block, if the intersection of group IDs
+        for a partition is empty, the merged value for that partition is False.
+        """
+        parent_block = getattr(self, parent)
+        child_block = getattr(self, child)
+
+        self.set_group_access(parent_block, {self.PARTITION_1: [self.PARTITION_1_GROUP_1]})
+        self.set_group_access(child_block, {self.PARTITION_1: [self.PARTITION_1_GROUP_2]})
+
+        self.assertEqual(
+            parent_block.merged_group_access,
+            {self.PARTITION_1: [self.PARTITION_1_GROUP_1]},
+        )
+        self.assertEqual(
+            child_block.merged_group_access,
+            {self.PARTITION_1: False},
+        )
+
+    def test_disjoint_groups_no_override(self):
+        """
+        Special case of the above test - ensures that `False` propagates down
+        to the block being queried even if blocks further down in the hierarchy
+        try to override it.
+        """
+        self.set_group_access(self.section, {self.PARTITION_1: [self.PARTITION_1_GROUP_1]})
+        self.set_group_access(self.subsection, {self.PARTITION_1: [self.PARTITION_1_GROUP_2]})
+        self.set_group_access(self.vertical, {self.PARTITION_1: [self.PARTITION_1_GROUP_1, self.PARTITION_1_GROUP_2]})
+
+        self.assertEqual(
+            self.vertical.merged_group_access,
+            {self.PARTITION_1: False},
+        )
+        self.assertEqual(
+            self.video.merged_group_access,
+            {self.PARTITION_1: False},
+        )
+
+    @ddt.data(*PARENT_CHILD_PAIRS)
+    @ddt.unpack
+    def test_union_partitions(self, parent, child):
+        """
+        When merging group_access on a block, the result's keys (partitions)
+        are the union of all partitions specified across all ancestor blocks
+        (including this one).
+        """
+        parent_block = getattr(self, parent)
+        child_block = getattr(self, child)
+
+        self.set_group_access(parent_block, {self.PARTITION_1: [self.PARTITION_1_GROUP_1]})
+        self.set_group_access(child_block, {self.PARTITION_2: [self.PARTITION_1_GROUP_2]})
+
+        self.assertEqual(
+            parent_block.merged_group_access,
+            {self.PARTITION_1: [self.PARTITION_1_GROUP_1]},
+        )
+        self.assertEqual(
+            child_block.merged_group_access,
+            {self.PARTITION_1: [self.PARTITION_1_GROUP_1], self.PARTITION_2: [self.PARTITION_1_GROUP_2]},
+        )

--- a/openedx/core/djangoapps/course_groups/partition_scheme.py
+++ b/openedx/core/djangoapps/course_groups/partition_scheme.py
@@ -3,6 +3,8 @@ Provides a UserPartition driver for cohorts.
 """
 import logging
 
+from xmodule.partitions.partitions import NoSuchUserPartitionGroupError
+
 from .cohorts import get_cohort, get_partition_group_id_for_cohort
 
 log = logging.getLogger(__name__)
@@ -56,8 +58,9 @@ class CohortPartitionScheme(object):
             # fail silently
             return None
 
-        group = user_partition.get_group(group_id)
-        if group is None:
+        try:
+            return user_partition.get_group(group_id)
+        except NoSuchUserPartitionGroupError:
             # if we have a match but the group doesn't exist in the partition,
             # it means the mapping is invalid.  the previous state of the
             # partition configuration may have been modified.
@@ -67,9 +70,8 @@ class CohortPartitionScheme(object):
                     "requested_partition_id": user_partition.id,
                     "requested_group_id": group_id,
                     "cohort_id": cohort.id,
-                }
+                },
+                exc_info=True
             )
             # fail silently
             return None
-
-        return group

--- a/openedx/core/djangoapps/user_api/partition_schemes.py
+++ b/openedx/core/djangoapps/user_api/partition_schemes.py
@@ -1,11 +1,13 @@
 """
 Provides partition support to the user service.
 """
-
+import logging
 import random
 import api.course_tag as course_tag_api
 
-from xmodule.partitions.partitions import UserPartitionError
+from xmodule.partitions.partitions import UserPartitionError, NoSuchUserPartitionGroupError
+
+log = logging.getLogger(__name__)
 
 
 class RandomUserPartitionScheme(object):
@@ -22,7 +24,23 @@ class RandomUserPartitionScheme(object):
         """
         partition_key = cls._key_for_partition(user_partition)
         group_id = course_tag_api.get_course_tag(user, course_id, partition_key)
-        group = user_partition.get_group(int(group_id)) if not group_id is None else None
+
+        group = None
+        if group_id is not None:
+            # attempt to look up the presently assigned group
+            try:
+                group = user_partition.get_group(int(group_id))
+            except NoSuchUserPartitionGroupError:
+                # jsa: we can turn off warnings here if this is an expected case.
+                log.warn(
+                    "group not found in RandomUserPartitionScheme: %r",
+                    {
+                        "requested_partition_id": user_partition.id,
+                        "requested_group_id": group_id,
+                    },
+                    exc_info=True
+                )
+
         if group is None:
             if not user_partition.groups:
                 raise UserPartitionError('Cannot assign user to an empty user partition')


### PR DESCRIPTION
@cpennington @dmitchell @andy-armstrong   I'm rebuilding the commits on my branch for ease of review.  The first implements the plumbing necessary for get_parent() to work.

Questions:
- smuggling `parent_url` inside the `cached_metadata` seems to work - but only some of the time.  Therefore an (extremely naive) just-in-time lookup is added as a fallback.  Sadly it seems `load_item` executes multiple times for the same block during the same modulestore lifecycle, therefore we have multiple objects in memory for the same block, but different identities (as evidenced by the need in tests to compare equality by blocks' locations instead of the blocks themselves).  Is this by design?  If not, is there any realistic way to address it without a major effort?  I don't yet feel comfortable enough making changes to this code to guess.
- I suspect that I should be testing get_parent with each modulestore implementation, is that right?
- Are the tests for get_parent (for any given modulestore) exhaustive enough?
