### PR TITLE
Improved support for multiple organization names

### DIFF
--- a/lms/templates/courseware/mktg_course_about.html
+++ b/lms/templates/courseware/mktg_course_about.html
@@ -93,17 +93,11 @@
         </a>
 
         % if settings.FEATURES.get('ENABLE_MKTG_EMAIL_OPT_IN'):
-          ## We only display the email opt-in checkbox if we've been given a valid full name (i.e., not None)
-          % if organization_full_name:
+          ## We only display the email opt-in checkbox if we've been given one or more organization names.
+          % if checkbox_label:
             <p class="form-field">
               <input id="email-opt-in" type="checkbox" name="opt-in" class="email-opt-in" value="true" checked>
-              <label for="email-opt-in" class="register-emails">
-                ## Translators: This line appears next a checkbox which users can leave checked or uncheck in order
-                ## to indicate whether they want to receive emails from the organization offering the course.
-                ${_("I would like to receive email about other {organization_full_name} programs and offers.").format(
-                  organization_full_name=organization_full_name
-                )}
-              </label>
+              <label for="email-opt-in" class="register-emails">${checkbox_label}</label>
             </p>
           % endif
         % endif


### PR DESCRIPTION
Updates copy used in the email opt-in checkbox label, constructs i18n'd strings within the view instead of passing through a separate context variable, and alleviates unipain.

From #6152. @clintonb FYI.
