### PR TITLE
CMS fail to collectstatic when USE_CUSTOM_THEME

### DIFF
--- a/cms/startup.py
+++ b/cms/startup.py
@@ -21,6 +21,9 @@ def run():
 
     add_mimetypes()
 
+    if settings.FEATURES.get('USE_CUSTOM_THEME', False):
+        enable_theme()
+
 
 def add_mimetypes():
     """
@@ -34,3 +37,34 @@ def add_mimetypes():
     mimetypes.add_type('application/x-font-opentype', '.otf')
     mimetypes.add_type('application/x-font-ttf', '.ttf')
     mimetypes.add_type('application/font-woff', '.woff')
+
+
+def enable_theme():
+    """
+    Enable the settings for a custom theme, whose files should be stored
+    in ENV_ROOT/themes/THEME_NAME (e.g., edx_all/themes/stanford).
+    At this moment this is actually just a fix for collectstatic,
+    (see https://openedx.atlassian.net/browse/TNL-726),
+    but can be improved with a full theming option also for Studio
+    in the future (see lms.startup)
+    """
+    # Workaround for setting THEME_NAME to an empty
+    # string which is the default due to this ansible
+    # bug: https://github.com/ansible/ansible/issues/4812
+    if settings.THEME_NAME == "":
+        settings.THEME_NAME = None
+        return
+
+    assert settings.FEATURES['USE_CUSTOM_THEME']
+    settings.FAVICON_PATH = 'themes/{name}/images/favicon.ico'.format(
+        name=settings.THEME_NAME
+    )
+
+    # Calculate the location of the theme's files
+    theme_root = settings.ENV_ROOT / "themes" / settings.THEME_NAME
+
+    # Namespace the theme's static files to 'themes/<theme_name>' to
+    # avoid collisions with default edX static files
+    settings.STATICFILES_DIRS.append(
+        (u'themes/{}'.format(settings.THEME_NAME), theme_root / 'static')
+    )

--- a/cms/tests/__init__.py
+++ b/cms/tests/__init__.py
@@ -1,0 +1,4 @@
+"""
+Module for test in cms folder
+All cms/test/* are already included in paver test
+"""

--- a/cms/tests/test_startup.py
+++ b/cms/tests/test_startup.py
@@ -1,0 +1,47 @@
+"""
+Test cms startup
+"""
+
+from django.conf import settings
+
+from django.test import TestCase
+from django.test.utils import override_settings
+
+from mock import patch
+from cms.startup import run, enable_theme
+
+
+class StartupTestCase(TestCase):
+    """
+    Test cms startup
+    """
+
+    def setUp(self):
+        super(StartupTestCase, self).setUp()
+
+    @patch.dict("django.conf.settings.FEATURES", {"USE_CUSTOM_THEME": True})
+    @override_settings(THEME_NAME="bar")
+    def test_run_with_theme(self):
+        self.assertEqual(settings.FEATURES["USE_CUSTOM_THEME"], True)
+        with patch('cms.startup.enable_theme') as mock_enable_theme:
+            run()
+            self.assertTrue(mock_enable_theme.called)
+
+    @patch.dict("django.conf.settings.FEATURES", {"USE_CUSTOM_THEME": False})
+    def test_run_without_theme(self):
+        self.assertEqual(settings.FEATURES["USE_CUSTOM_THEME"], False)
+        with patch('cms.startup.enable_theme') as mock_enable_theme:
+            run()
+            self.assertFalse(mock_enable_theme.called)
+
+    @patch.dict("django.conf.settings.FEATURES", {"USE_CUSTOM_THEME": True})
+    @override_settings(THEME_NAME="bar")
+    @override_settings(FAVICON_PATH="images/favicon.ico")
+    def test_enable_theme(self):
+        enable_theme()
+        self.assertEqual(
+            settings.FAVICON_PATH,
+            'themes/bar/images/favicon.ico'
+        )
+        exp_path = (u'themes/bar', settings.ENV_ROOT / "themes/bar/static")
+        self.assertIn(exp_path, settings.STATICFILES_DIRS)

--- a/pavelib/utils/test/suites/nose_suite.py
+++ b/pavelib/utils/test/suites/nose_suite.py
@@ -137,6 +137,9 @@ class SystemTestSuite(NoseTestSuite):
 
         if self.root == 'lms':
             default_test_id += " {system}/tests.py".format(system=self.root)
+        
+        if self.root == 'cms':
+            default_test_id += " {system}/tests/*".format(system=self.root)
 
         return default_test_id
 


### PR DESCRIPTION
This is a PR to fix https://openedx.atlassian.net/browse/TNL-726.
See also this workaround https://github.com/open-craft/edx-platform/commit/8c9436ca75825731b2bb90b8273bd4844c7e2f61 (I can't found a PR ) and the available discussion https://groups.google.com/forum/#!msg/edx-code/6H0MPfWB3CU/5-3pNoYbOMEJ

I made the workaround similar to what already happen in lms.startup
