### PR TITLE
Fixed CodeMirror editor view height in studio.

### DIFF
--- a/cms/static/sass/elements/_modal-window.scss
+++ b/cms/static/sass/elements/_modal-window.scss
@@ -222,6 +222,10 @@
       height: 365px;
     }
 
+    .CodeMirror-advanced {
+      height: 435px;
+    }
+
     .wrapper-comp-settings {
 
       .list-input {

--- a/common/lib/xmodule/xmodule/js/src/combinedopenended/edit.coffee
+++ b/common/lib/xmodule/xmodule/js/src/combinedopenended/edit.coffee
@@ -62,6 +62,7 @@ Write a persuasive essay to a newspaper reflecting your views on censorship in l
       $(@element.find('.xml-box')).hide()
     else
       @createXMLEditor()
+      @xml_editor.display.wrapper.className += " CodeMirror-advanced";
 
     @alertTaskRubricModification()
 
@@ -92,6 +93,7 @@ Write a persuasive essay to a newspaper reflecting your views on censorship in l
       @toggleCheatsheetVisibility()
     if @confirmConversionToXml()
       @createXMLEditor(OpenEndedMarkdownEditingDescriptor.markdownToXml(@markdown_editor.getValue()))
+      @xml_editor.display.wrapper.className += " CodeMirror-advanced";
       # Need to refresh to get line numbers to display properly (and put cursor position to 0)
       @xml_editor.setCursor(0)
       @xml_editor.refresh()

--- a/common/lib/xmodule/xmodule/js/src/problem/edit.coffee
+++ b/common/lib/xmodule/xmodule/js/src/problem/edit.coffee
@@ -25,6 +25,7 @@ class @MarkdownEditingDescriptor extends XModule.Descriptor
       $(@element.find('.xml-box')).hide()
     else
       @createXMLEditor()
+      @xml_editor.display.wrapper.className += " CodeMirror-advanced";
 
   ###
   Creates the XML Editor and sets it as the current editor. If text is passed in,
@@ -53,6 +54,7 @@ class @MarkdownEditingDescriptor extends XModule.Descriptor
       @toggleCheatsheetVisibility()
     if @confirmConversionToXml()
       @createXMLEditor(MarkdownEditingDescriptor.markdownToXml(@markdown_editor.getValue()))
+      @xml_editor.display.wrapper.className += " CodeMirror-advanced";
       # Need to refresh to get line numbers to display properly (and put cursor position to 0)
       @xml_editor.setCursor(0)
       @xml_editor.refresh()


### PR DESCRIPTION
[TNL-920](https://openedx.atlassian.net/browse/TNL-920)

`.CodeMirror` height was less than `.modal-content` height, because of this CodeMirror view was getting cut off, fixed by equalising the height.

[Sandbox Studio Link](http://studio.waheedahmed.m.sandbox.edx.org/)
