### PR TITLE
ECOM-757: Fix reference error with emailOptIn variable

### DIFF
--- a/lms/templates/courseware/mktg_course_about.html
+++ b/lms/templates/courseware/mktg_course_about.html
@@ -58,7 +58,7 @@
         }
 
         ## Ugh.
-        window.top.location.href = $("a.register").attr("href") || "${reverse('register_user')}?course_id=${course.id | u}&enrollment_action=enroll&email_opt_in=" + email_opt_in;
+        window.top.location.href = $("a.register").attr("href") || "${reverse('register_user')}?course_id=${course.id | u}&enrollment_action=enroll&email_opt_in=" + emailOptIn;
       } else {
         $('#register_error').html(
             (xhr.responseText ? xhr.responseText : "${_("An error occurred. Please try again later.")}")


### PR DESCRIPTION
[ECOM-757](https://openedx.atlassian.net/browse/ECOM-757): Uncaught ReferenceError: email_opt_in is not defined

I introduced this bug when resolving merge conflicts by hand.  Unfortunately, this is in the marketing iframe JavaScript, which is currently impossible to unit test.  I have manually verified the fix in devstack (reproduced the issue before, made this change, then the issue was fixed).

Reviewers: @rlucioni @stephensanchez 
FYI: @clintonb 
