### PR TITLE
Upon fail-over check, change asset metadata document to new format.

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -1483,6 +1483,16 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
             # Not found, so create.
             course_assets = {'course_id': unicode(course_key), 'assets': {}}
             course_assets['assets']['_id'] = self.asset_collection.insert(course_assets)
+        elif isinstance(course_assets['assets'], list):
+            # This record is in the old course assets format.
+            # Ensure that no data exists before updating the format.
+            assert(len(course_assets['assets']), 0)
+            # Update the format to a dict.
+            self.asset_collection.update(
+                {'_id': course_assets['_id']},
+                {'$set': {'assets': {}}}
+            )
+            course_assets['assets'] = {'_id': course_assets['_id']}
         else:
             course_assets['assets']['_id'] = course_assets['_id']
 


### PR DESCRIPTION
Explanation:
Although the modulestore asset metadata system is not yet in use by any other systems, a fail-over occurs upon static asset request which checks the system to see if an asset's metadata is present. That check assumes that the value of the 'assets' key of the Mongo document is a dict. Before PR #6166, this 'assets' key's value was a list. It also wasn't being used - all the asset metadata items were being added to the main document in a list keyed by its asset type, currently "asset" and "video" (not "assets").

PR #6166 has cleaned up the format by saving asset metadata in an "assets" dict. This change migrates the "assets" list to an empty "assets" dict. Again, the "assets" list in the old format shouldn't have any metadata in the list at all - so there should be no actual data to migrate from that old "assets" list.
