### PR TITLE
WIP: Verify requirements page

### DIFF
--- a/lms/djangoapps/verify_student/tests/test_views.py
+++ b/lms/djangoapps/verify_student/tests/test_views.py
@@ -14,10 +14,12 @@ import json
 import mock
 import urllib
 import decimal
+import unittest
 from mock import patch, Mock
 import pytz
 from datetime import timedelta, datetime
 
+import ddt
 from django.test.client import Client
 from django.test import TestCase
 from django.test.utils import override_settings
@@ -25,15 +27,17 @@ from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.core.exceptions import ObjectDoesNotExist
 
+from util.testing import UrlResetMixin
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, mixed_store_config
 from xmodule.modulestore.tests.factories import CourseFactory
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
-from student.tests.factories import UserFactory
+from opaque_keys.edx.locator import CourseLocator
+from student.tests.factories import UserFactory, CourseEnrollmentFactory
 from student.models import CourseEnrollment
 from course_modes.tests.factories import CourseModeFactory
 from course_modes.models import CourseMode
 from shoppingcart.models import Order, CertificateItem
-from verify_student.views import render_to_response
+from verify_student.views import render_to_response, PayAndVerifyView
 from verify_student.models import SoftwareSecurePhotoVerification
 from reverification.tests.factories import MidcourseReverificationWindowFactory
 
@@ -751,3 +755,582 @@ class TestCreateOrder(ModuleStoreTestCase):
         attempt.mark_ready()
         attempt.submit()
         attempt.approve()
+
+
+@override_settings(MODULESTORE=MODULESTORE_CONFIG)
+@ddt.ddt
+class TestPayAndVerifyView(UrlResetMixin, ModuleStoreTestCase):
+    """Tests for the payment / verification flow views. """
+
+    MIN_PRICE = 12
+    USERNAME = "test_user"
+    PASSWORD = "test_password"
+
+    @patch.dict(settings.FEATURES, {'SEPARATE_VERIFICATION_FROM_PAYMENT': True})
+    def setUp(self):
+        super(TestPayAndVerifyView, self).setUp('verify_student.urls')
+        self.user = UserFactory.create(username=self.USERNAME, password=self.PASSWORD)
+        result = self.client.login(username=self.USERNAME, password=self.PASSWORD)
+        self.assertTrue(result, msg="Could not log in")
+
+    @ddt.data("verified", "professional")
+    def test_start_verification_not_verified(self, course_mode):
+        course = self._create_course(course_mode)
+        self._enroll(course.id, "honor")
+        response = self._get_page('verify_student_start_verification', course.id)
+        self._assert_displayed_mode(response, course_mode)
+        self._assert_steps_displayed(
+            response,
+            PayAndVerifyView.ALL_STEPS,
+            [PayAndVerifyView.INTRO_STEP]
+        )
+        self._assert_messaging(response, PayAndVerifyView.FIRST_TIME_VERIFY_MSG)
+        self._assert_payment_displayed(response, True)
+        self._assert_requirements_displayed(response, [
+            PayAndVerifyView.PHOTO_ID_REQ,
+            PayAndVerifyView.WEBCAM_REQ,
+            PayAndVerifyView.CREDIT_CARD_REQ,
+        ])
+
+    # TODO: do we need to be smarter about how we handle the denied case?
+    @ddt.data("expired", "denied")
+    def test_start_verification_expired_or_denied_verification(self, verification_status):
+        course = self._create_course("verified")
+        self._enroll(course.id, "verified")
+        self._set_verification_status(verification_status)
+        response = self._get_page('verify_student_start_verification', course.id)
+
+        # Expect the same content as when the user has not verified
+        self._assert_steps_displayed(
+            response,
+            PayAndVerifyView.STEPS_WITHOUT_PAYMENT,
+            [PayAndVerifyView.INTRO_STEP]
+        )
+        self._assert_messaging(response, PayAndVerifyView.FIRST_TIME_VERIFY_MSG)
+        self._assert_requirements_displayed(response, [
+            PayAndVerifyView.PHOTO_ID_REQ,
+            PayAndVerifyView.WEBCAM_REQ,
+        ])
+
+    @ddt.data(
+        ("verified", "submitted"),
+        ("verified", "approved"),
+        ("verified", "error"),
+        ("professional", "submitted")
+    )
+    @ddt.unpack
+    def test_start_verification_already_verified(self, course_mode, verification_status):
+        course = self._create_course(course_mode)
+        self._enroll(course.id, "honor")
+        self._set_verification_status(verification_status)
+        response = self._get_page('verify_student_start_verification', course.id)
+        self._assert_displayed_mode(response, course_mode)
+        self._assert_steps_displayed(
+            response,
+            PayAndVerifyView.STEPS_WITHOUT_VERIFICATION,
+            [PayAndVerifyView.INTRO_STEP]
+        )
+        self._assert_messaging(response, PayAndVerifyView.FIRST_TIME_VERIFY_MSG)
+        self._assert_payment_displayed(response, True)
+        self._assert_requirements_displayed(response, [
+            PayAndVerifyView.CREDIT_CARD_REQ,
+        ])
+
+    @ddt.data("verified", "professional")
+    def test_start_verification_already_paid(self, course_mode):
+        course = self._create_course(course_mode)
+        self._enroll(course.id, course_mode)
+        response = self._get_page('verify_student_start_verification', course.id)
+        self._assert_displayed_mode(response, course_mode)
+        self._assert_steps_displayed(
+            response,
+            PayAndVerifyView.STEPS_WITHOUT_PAYMENT,
+            [PayAndVerifyView.INTRO_STEP]
+        )
+        self._assert_messaging(response, PayAndVerifyView.FIRST_TIME_VERIFY_MSG)
+        self._assert_payment_displayed(response, False)
+        self._assert_requirements_displayed(response, [
+            PayAndVerifyView.PHOTO_ID_REQ,
+            PayAndVerifyView.WEBCAM_REQ,
+        ])
+
+    def test_start_verification_not_enrolled(self):
+        course = self._create_course("verified")
+        self._set_verification_status("submitted")
+        response = self._get_page('verify_student_start_verification', course.id)
+
+        # This shouldn't happen if the student has been auto-enrolled,
+        # but if they somehow end up on this page without enrolling,
+        # treat them as if they need to pay
+        response = self._get_page('verify_student_start_verification', course.id)
+        self._assert_steps_displayed(
+            response,
+            PayAndVerifyView.STEPS_WITHOUT_VERIFICATION,
+            [PayAndVerifyView.INTRO_STEP]
+        )
+        self._assert_payment_displayed(response, True)
+        self._assert_requirements_displayed(response, [
+            PayAndVerifyView.CREDIT_CARD_REQ,
+        ])
+
+    def test_start_verification_unenrolled(self):
+        course = self._create_course("verified")
+        self._set_verification_status("submitted")
+        self._enroll(course.id, "verified")
+        self._unenroll(course.id)
+
+        # If unenrolled, treat them like they haven't paid at all
+        # (we assume that they've gotten a refund or didn't pay initially)
+        response = self._get_page('verify_student_start_verification', course.id)
+        self._assert_steps_displayed(
+            response,
+            PayAndVerifyView.STEPS_WITHOUT_VERIFICATION,
+            [PayAndVerifyView.INTRO_STEP]
+        )
+        self._assert_payment_displayed(response, True)
+        self._assert_requirements_displayed(response, [
+            PayAndVerifyView.CREDIT_CARD_REQ,
+        ])
+
+    @ddt.data(
+        ("verified", "submitted"),
+        ("verified", "approved"),
+        ("professional", "submitted")
+    )
+    @ddt.unpack
+    def test_start_verification_already_verified_and_paid(self, course_mode, verification_status):
+        course = self._create_course(course_mode)
+        self._enroll(course.id, course_mode)
+        self._set_verification_status(verification_status)
+        response = self._get_page(
+            'verify_student_start_verification',
+            course.id,
+            expected_status_code=302
+        )
+        self._assert_redirects_to_dashboard(response)
+
+    def test_verify_now(self):
+        # We've already paid, and now we're trying to verify
+        course = self._create_course("verified")
+        self._enroll(course.id, "verified")
+        response = self._get_page('verify_student_verify_now', course.id)
+
+        self._assert_messaging(response, PayAndVerifyView.VERIFY_NOW_MSG)
+
+        # Expect that *all* steps are displayed,
+        # but we start after the payment step (because it's already completed).
+        self._assert_steps_displayed(
+            response,
+            PayAndVerifyView.ALL_STEPS,
+            [
+                PayAndVerifyView.INTRO_STEP,
+                PayAndVerifyView.MAKE_PAYMENT_STEP,
+                PayAndVerifyView.PAYMENT_CONFIRMATION_STEP,
+                PayAndVerifyView.FACE_PHOTO_STEP
+            ]
+        )
+
+        # For ease of implementation, TODO: explain
+        # These will be hidden from the user anyway since they're starting
+        # after the payment step.
+        self._assert_payment_displayed(response, True)
+        self._assert_requirements_displayed(response, [
+            PayAndVerifyView.PHOTO_ID_REQ,
+            PayAndVerifyView.WEBCAM_REQ,
+            PayAndVerifyView.CREDIT_CARD_REQ,
+        ])
+
+    def test_verify_now_already_verified(self):
+        course = self._create_course("verified")
+        self._enroll(course.id, "verified")
+        self._set_verification_status("submitted")
+
+        # Already verified, so if we somehow end up here,
+        # redirect immediately to the dashboard
+        response = self._get_page(
+            'verify_student_verify_now',
+            course.id,
+            expected_status_code=302
+        )
+        self._assert_redirects_to_dashboard(response)
+
+    @ddt.data(
+        "verify_student_verify_now",
+        "verify_student_verify_later",
+        "verify_student_payment_confirmation"
+    )
+    def test_verify_now_or_later_not_enrolled(self, page_name):
+        course = self._create_course("verified")
+        response = self._get_page(page_name, course.id, expected_status_code=302)
+        self._assert_redirects_to_start_verification(response, course.id)
+
+    @ddt.data(
+        "verify_student_verify_now",
+        "verify_student_verify_later",
+        "verify_student_payment_confirmation"
+    )
+    def test_verify_now_or_later_unenrolled(self, page_name):
+        course = self._create_course("verified")
+        self._enroll(course.id, "verified")
+        self._unenroll(course.id)
+        response = self._get_page(page_name, course.id, expected_status_code=302)
+        self._assert_redirects_to_start_verification(response, course.id)
+
+    @ddt.data(
+        "verify_student_verify_now",
+        "verify_student_verify_later",
+        "verify_student_payment_confirmation"
+    )
+    def test_verify_now_or_later_not_paid(self, page_name):
+        course = self._create_course("verified")
+        self._enroll(course.id, "honor")
+        response = self._get_page(page_name, course.id, expected_status_code=302)
+        self._assert_redirects_to_upgrade(response, course.id)
+
+    def test_verify_later(self):
+        course = self._create_course("verified")
+        self._enroll(course.id, "verified")
+        response = self._get_page("verify_student_verify_later", course.id)
+
+        self._assert_messaging(response, PayAndVerifyView.VERIFY_LATER_MSG)
+
+        # Expect that the payment steps are NOT displayed
+        self._assert_steps_displayed(
+            response,
+            PayAndVerifyView.STEPS_WITHOUT_PAYMENT,
+            [PayAndVerifyView.INTRO_STEP]
+        )
+        self._assert_payment_displayed(response, False)
+        self._assert_requirements_displayed(response, [
+            PayAndVerifyView.PHOTO_ID_REQ,
+            PayAndVerifyView.WEBCAM_REQ,
+        ])
+
+    def test_verify_later_already_verified(self):
+        course = self._create_course("verified")
+        self._enroll(course.id, "verified")
+        self._set_verification_status("submitted")
+
+        # Already verified, so if we somehow end up here,
+        # redirect immediately to the dashboard
+        response = self._get_page(
+            'verify_student_verify_later',
+            course.id,
+            expected_status_code=302
+        )
+        self._assert_redirects_to_dashboard(response)
+
+    def test_payment_confirmation(self):
+        course = self._create_course("verified")
+        self._enroll(course.id, "verified")
+        response = self._get_page('verify_student_payment_confirmation', course.id)
+
+        self._assert_messaging(response, PayAndVerifyView.PAYMENT_CONFIRMATION_MSG)
+
+        # Expect that *all* steps are displayed,
+        # but we start at the payment confirmation step
+        self._assert_steps_displayed(
+            response,
+            PayAndVerifyView.ALL_STEPS,
+            [
+                PayAndVerifyView.INTRO_STEP,
+                PayAndVerifyView.MAKE_PAYMENT_STEP,
+                PayAndVerifyView.PAYMENT_CONFIRMATION_STEP,
+            ]
+        )
+
+        # These will be hidden from the user anyway since they're starting
+        # after the payment step.  We're already including the payment
+        # steps, so it's easier to include these as well.
+        self._assert_payment_displayed(response, True)
+        self._assert_requirements_displayed(response, [
+            PayAndVerifyView.PHOTO_ID_REQ,
+            PayAndVerifyView.WEBCAM_REQ,
+            PayAndVerifyView.CREDIT_CARD_REQ,
+        ])
+
+    def test_payment_confirmation_already_verified(self):
+        course = self._create_course("verified")
+        self._enroll(course.id, "verified")
+        self._set_verification_status("submitted")
+
+        response = self._get_page('verify_student_payment_confirmation', course.id)
+
+        # Other pages would redirect to the dashboard at this point,
+        # because the user has paid and verified.  However, we want
+        # the user to see the confirmation page even if there
+        # isn't anything for them to do here except return
+        # to the dashboard.
+        self._assert_steps_displayed(
+            response,
+            PayAndVerifyView.STEPS_WITHOUT_VERIFICATION,
+            [
+                PayAndVerifyView.INTRO_STEP,
+                PayAndVerifyView.MAKE_PAYMENT_STEP,
+                PayAndVerifyView.PAYMENT_CONFIRMATION_STEP,
+            ]
+        )
+
+    @ddt.data("verified", "professional")
+    def test_upgrade(self, course_mode):
+        course = self._create_course(course_mode)
+        self._enroll(course.id, "honor")
+
+        response = self._get_page('verify_student_upgrade_and_verify', course.id)
+        self._assert_displayed_mode(response, course_mode)
+        self._assert_steps_displayed(
+            response,
+            PayAndVerifyView.ALL_STEPS,
+            [PayAndVerifyView.INTRO_STEP]
+        )
+        self._assert_messaging(response, PayAndVerifyView.UPGRADE_MSG)
+        self._assert_payment_displayed(response, True)
+        self._assert_requirements_displayed(response, [
+            PayAndVerifyView.PHOTO_ID_REQ,
+            PayAndVerifyView.WEBCAM_REQ,
+            PayAndVerifyView.CREDIT_CARD_REQ,
+        ])
+
+    def test_upgrade_already_verified(self):
+        course = self._create_course("verified")
+        self._enroll(course.id, "honor")
+        self._set_verification_status("submitted")
+
+        response = self._get_page('verify_student_upgrade_and_verify', course.id)
+        self._assert_steps_displayed(
+            response,
+            PayAndVerifyView.STEPS_WITHOUT_VERIFICATION,
+            [PayAndVerifyView.INTRO_STEP]
+        )
+        self._assert_messaging(response, PayAndVerifyView.UPGRADE_MSG)
+        self._assert_payment_displayed(response, True)
+        self._assert_requirements_displayed(response, [
+            PayAndVerifyView.CREDIT_CARD_REQ,
+        ])
+
+    def test_upgrade_already_paid(self):
+        course = self._create_course("verified")
+        self._enroll(course.id, "verified")
+
+        # If we've already paid, then the upgrade messaging
+        # won't make much sense.  Redirect them to the
+        # "verify later" page instead.
+        response = self._get_page(
+            'verify_student_upgrade_and_verify',
+            course.id,
+            expected_status_code=302
+        )
+        self._assert_redirects_to_verify_later(response, course.id)
+
+    def test_upgrade_already_verified_and_paid(self):
+        course = self._create_course("verified")
+        self._enroll(course.id, "verified")
+        self._set_verification_status("submitted")
+
+        # Already verified and paid, so redirect to the dashboard
+        response = self._get_page(
+            'verify_student_upgrade_and_verify',
+            course.id,
+            expected_status_code=302
+        )
+        self._assert_redirects_to_dashboard(response)
+
+    def test_upgrade_not_enrolled(self):
+        course = self._create_course("verified")
+        response = self._get_page(
+            'verify_student_upgrade_and_verify',
+            course.id,
+            expected_status_code=302
+        )
+        self._assert_redirects_to_start_verification(response, course.id)
+
+    def test_upgrade_unenrolled(self):
+        course = self._create_course("verified")
+        self._enroll(course.id, "verified")
+        self._unenroll(course.id)
+        response = self._get_page(
+            'verify_student_upgrade_and_verify',
+            course.id,
+            expected_status_code=302
+        )
+        self._assert_redirects_to_start_verification(response, course.id)
+
+    @ddt.data([], ["honor"], ["honor", "audit"])
+    def test_no_verified_mode_for_course(self, modes_available):
+        course = self._create_course(*modes_available)
+
+        pages = [
+            'verify_student_start_verification',
+            'verify_student_verify_now',
+            'verify_student_verify_later',
+            'verify_student_upgrade_and_verify',
+        ]
+
+        for page_name in pages:
+            response = self._get_page(
+                page_name,
+                course.id,
+                expected_status_code=404
+            )
+
+    @ddt.data(
+        "verify_student_start_verification",
+        "verify_student_verify_now",
+        "verify_student_verify_later",
+        "verify_student_upgrade_and_verify",
+    )
+    def test_require_login(self, url_name):
+        self.client.logout()
+        course = self._create_course("verified")
+        response = self._get_page(url_name, course.id, expected_status_code=302)
+
+        original_url = reverse(url_name, kwargs={'course_id': unicode(course.id)})
+        login_url = u"{login_url}?next={original_url}".format(
+            login_url=reverse('accounts_login'),
+            original_url=original_url
+        )
+        self.assertRedirects(response, login_url)
+
+    @ddt.data(
+        "verify_student_start_verification",
+        "verify_student_verify_now",
+        "verify_student_verify_later",
+        "verify_student_upgrade_and_verify",
+    )
+    def test_no_such_course(self, url_name):
+        non_existent_course = CourseLocator(course="test", org="test", run="test")
+        self._get_page(
+            url_name,
+            non_existent_course,
+            expected_status_code=404
+        )
+
+    def _create_course(self, *course_modes):
+        """Create a new course with the specified course modes. """
+        course = CourseFactory.create()
+
+        for course_mode in course_modes:
+            min_price = (self.MIN_PRICE if course_mode != "honor" else 0)
+            mode = CourseModeFactory(
+                course_id=course.id,
+                mode_slug=course_mode,
+                mode_display_name=course_mode,
+                min_price=min_price
+            )
+
+        return course
+
+    def _enroll(self, course_key, mode):
+        """Enroll the user in a course. """
+        CourseEnrollmentFactory.create(
+            user=self.user,
+            course_id=course_key,
+            mode=mode
+        )
+
+    def _unenroll(self, course_key):
+        """Unenroll the user from a course. """
+        CourseEnrollment.unenroll(self.user, course_key)
+
+    def _set_verification_status(self, status):
+        """Set the user's photo verification status. """
+        attempt = SoftwareSecurePhotoVerification.objects.create(user=self.user)
+
+        if status in ["submitted", "approved", "expired", "denied", "error"]:
+            attempt.mark_ready()
+            attempt.submit()
+
+        if status in ["approved", "expired"]:
+            attempt.approve()
+        elif status == "denied":
+            attempt.deny("Denied!")
+        elif status == "error":
+            attempt.system_error("Error!")
+
+        if status == "expired":
+            days_good_for = settings.VERIFY_STUDENT["DAYS_GOOD_FOR"]
+            attempt.created_at = datetime.now(pytz.UTC) - timedelta(days=(days_good_for + 1))
+            attempt.save()
+
+    def _get_page(self, url_name, course_key, expected_status_code=200):
+        """Retrieve one of the verification pages. """
+        url = reverse(url_name, kwargs={"course_id": unicode(course_key)})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, expected_status_code)
+        return response
+
+    def _assert_displayed_mode(self, response, expected_mode):
+        """Check whether a course mode is displayed. """
+        # DEBUG
+        response_dict = json.loads(response.content)
+        self.assertEqual(response_dict['course_mode'], expected_mode)
+
+    def _assert_steps_displayed(self, response, expected_steps, expected_completed):
+        """Check whether steps in the flow are displayed to the user. """
+        # DEBUG
+        response_dict = json.loads(response.content)
+
+        # Is the step displayed?
+        # TODO: more explanation
+        for step, displayed in response_dict['display_steps'].iteritems():
+            if step in expected_steps:
+                self.assertTrue(
+                    displayed,
+                    msg="Expected step '{step}' to be displayed".format(step=step)
+                )
+            else:
+                self.assertFalse(
+                    displayed,
+                    msg="Expected step '{step}' to be hidden".format(step=step)
+                )
+
+        # Is the step completed?
+        for step in expected_steps:
+            completed = response_dict['completed_steps'][step]
+            if step in expected_completed:
+                self.assertTrue(
+                    completed,
+                    msg="Expected step '{step}' to be complete".format(step=step)
+                )
+            else:
+                self.assertFalse(
+                    completed,
+                    msg="Expected step '{step}' to be incomplete".format(step=step)
+                )
+
+    def _assert_messaging(self, response, expected_message):
+        """Check the messaging on the page. """
+        # DEBUG
+        response_dict = json.loads(response.content)
+        self.assertEqual(response_dict['message'], expected_message)
+
+    def _assert_payment_displayed(self, response, is_displayed):
+        """Check that payment is displayed on the page. """
+        # DEBUG
+        response_dict = json.loads(response.content)
+        self.assertEqual(response_dict['show_payment'], is_displayed)
+
+    def _assert_requirements_displayed(self, response, requirements):
+        """Check that requirements are displayed on the page. """
+        # DEBUG
+        response_dict = json.loads(response.content)
+        for req, displayed in response_dict['requirements'].iteritems():
+            if req in requirements:
+                self.assertTrue(displayed, msg="Expected '{req}' requirement to be displayed".format(req=req))
+            else:
+                self.assertFalse(displayed, msg="Expected '{req}' requirement to be hidden".format(req=req))
+
+    def _assert_redirects_to_dashboard(self, response):
+        self.assertRedirects(response, reverse('dashboard'))
+
+    def _assert_redirects_to_start_verification(self, response, course_id):
+        url = reverse('verify_student_start_verification', kwargs={'course_id': unicode(course_id)})
+        self.assertRedirects(response, url)
+
+    def _assert_redirects_to_verify_later(self, response, course_id):
+        url = reverse('verify_student_verify_later', kwargs={'course_id': unicode(course_id)})
+        self.assertRedirects(response, url)
+
+    def _assert_redirects_to_upgrade(self, response, course_id):
+        url = reverse('verify_student_upgrade_and_verify', kwargs={'course_id': unicode(course_id)})
+        self.assertRedirects(response, url)

--- a/lms/djangoapps/verify_student/urls.py
+++ b/lms/djangoapps/verify_student/urls.py
@@ -1,6 +1,7 @@
 from django.conf.urls import patterns, url
 
 from verify_student import views
+from verify_student.views import PayAndVerifyView
 
 from django.conf import settings
 
@@ -82,3 +83,79 @@ urlpatterns = patterns(
         name="verify_student_toggle_failed_banner_off"
     ),
 )
+
+
+if settings.FEATURES.get("SEPARATE_VERIFICATION_FROM_PAYMENT"):
+
+    urlpatterns += patterns(
+        '',
+
+        # The user is starting the verification / payment process,
+        # most likely after enrolling in a course and selecting
+        # a "verified" track.
+        url(
+            r'^start-verification/{course}/$'.format(course=settings.COURSE_ID_PATTERN),
+            views.PayAndVerifyView.as_view(),
+            name="verify_student_start_verification",
+            kwargs={
+                'message': PayAndVerifyView.FIRST_TIME_VERIFY_MSG
+            }
+        ),
+
+        # The user is enrolled in a non-paid mode and wants to upgrade.
+        # This is the same as the "start verification" flow,
+        # except with slight messaging changes.
+        url(
+            r'^upgrade/{course}/$'.format(course=settings.COURSE_ID_PATTERN),
+            views.PayAndVerifyView.as_view(),
+            name="verify_student_upgrade_and_verify",
+            kwargs={
+                'message': PayAndVerifyView.UPGRADE_MSG
+            }
+        ),
+
+        # The user has paid and still needs to verify.
+        # Since the user has "just paid", we display *all* steps
+        # including payment.  The user resumes the flow
+        # from the verification step.
+        # Note that if the user has already verified, this will redirect
+        # to the dashboard.
+        url(
+            r'^verify-now/{course}/$'.format(course=settings.COURSE_ID_PATTERN),
+            views.PayAndVerifyView.as_view(),
+            name="verify_student_verify_now",
+            kwargs={
+                'always_show_payment': True,
+                'current_step': PayAndVerifyView.FACE_PHOTO_STEP,
+                'message': PayAndVerifyView.VERIFY_NOW_MSG
+            }
+        ),
+
+        # The user has paid and still needs to verify,
+        # but the user is NOT arriving directly from the payment flow.
+        # This is equivalent to starting a new flow
+        # with the payment steps and requirements hidden
+        # (since the user already paid).
+        url(
+            r'^verify-later/{course}/$'.format(course=settings.COURSE_ID_PATTERN),
+            views.PayAndVerifyView.as_view(),
+            name="verify_student_verify_later",
+            kwargs={
+                'message': PayAndVerifyView.VERIFY_LATER_MSG
+            }
+        ),
+
+        # The user is returning to the flow after paying.
+        # This usually occurs after a redirect from the shopping cart
+        # once the order has been fulfilled.
+        url(
+            r'^payment-confirmation/{course}/$'.format(course=settings.COURSE_ID_PATTERN),
+            views.PayAndVerifyView.as_view(),
+            name="verify_student_payment_confirmation",
+            kwargs={
+                'always_show_payment': True,
+                'current_step': PayAndVerifyView.PAYMENT_CONFIRMATION_STEP,
+                'message': PayAndVerifyView.PAYMENT_CONFIRMATION_MSG
+            }
+        ),
+    )

--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -12,7 +12,10 @@ from edxmako.shortcuts import render_to_response
 
 from django.conf import settings
 from django.core.urlresolvers import reverse
-from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseRedirect
+from django.http import (
+    HttpResponse, HttpResponseBadRequest,
+    HttpResponseRedirect, Http404
+)
 from django.shortcuts import redirect
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
@@ -165,6 +168,458 @@ class VerifiedView(View):
             "modes_dict": modes_dict,
         }
         return render_to_response('verify_student/verified.html', context)
+
+
+class PayAndVerifyView(View):
+    """View for the "verify and pay" flow.
+
+    This view is somewhat complicated, because the user
+    can enter it from a number of different places:
+
+    * From the "choose your track" page.
+    * After completing payment.
+    * From the dashboard in order to complete verification.
+    * From the dashboard in order to upgrade to a verified track.
+
+    The page will display different steps and requirements
+    depending on:
+
+    * Whether the user has submitted a photo verification recently.
+    * Whether the user has paid for the course.
+    * How the user reached the page (mostly affects messaging)
+
+    We are also super-paranoid about how users reach this page.
+    If they somehow aren't enrolled, or the course doesn't exist,
+    or they've unenrolled, or they've already paid/verified,
+    ... then we try to redirect them to the page with the
+    most appropriate messaging (including the dashboard).
+
+    Note that this page does NOT handle re-verification
+    (photo verification that was denied or had an error);
+    that is handled by the "reverify" view.
+
+    """
+
+    # Step definitions
+    #
+    # These represent the numbered steps a user sees in
+    # the verify / payment flow.
+    #
+    # Steps can either be:
+    # - displayed or hidden
+    # - complete or incomplete
+    #
+    # For example, when a user enters the verification/payment
+    # flow for the first time, the user will see steps
+    # for both payment and verification.  As the user
+    # completes these steps (for example, submitting a photo)
+    # the steps will be marked "complete".
+    #
+    # If a user has already verified for another course,
+    # then the verification steps will be hidden,
+    # since the user has already completed them.
+    #
+    # If a user re-enters the flow from another application
+    # (for example, after completing payment through
+    # a third-party payment processor), then the user
+    # will resume the flow at an intermediate step.
+    #
+    INTRO_STEP = 'intro'
+    MAKE_PAYMENT_STEP = 'make-payment'
+    PAYMENT_CONFIRMATION_STEP = 'payment-confirmation'
+    FACE_PHOTO_STEP = 'face-photo'
+    ID_PHOTO_STEP = 'id-photo'
+    REVIEW_PHOTOS_STEP = 'review-photos'
+    ENROLLMENT_CONFIRMATION_STEP = 'enrollment-confirmation'
+
+    ALL_STEPS = [
+        INTRO_STEP,
+        MAKE_PAYMENT_STEP,
+        PAYMENT_CONFIRMATION_STEP,
+        FACE_PHOTO_STEP,
+        ID_PHOTO_STEP,
+        REVIEW_PHOTOS_STEP,
+        ENROLLMENT_CONFIRMATION_STEP
+    ]
+
+    PAYMENT_STEPS = [
+        MAKE_PAYMENT_STEP,
+        PAYMENT_CONFIRMATION_STEP
+    ]
+
+    VERIFICATION_STEPS = [
+        FACE_PHOTO_STEP,
+        ID_PHOTO_STEP,
+        REVIEW_PHOTOS_STEP,
+        ENROLLMENT_CONFIRMATION_STEP
+    ]
+
+    STEPS_WITHOUT_PAYMENT = [
+        step for step in ALL_STEPS
+        if step not in PAYMENT_STEPS
+    ]
+
+    STEPS_WITHOUT_VERIFICATION = [
+        step for step in ALL_STEPS
+        if step not in VERIFICATION_STEPS
+    ]
+
+    # Messages
+    #
+    # Depending on how the user entered reached the page,
+    # we will display different text messaging.
+    # For example, we show users who are upgrading
+    # slightly different copy than users who are verifying
+    # for the first time.
+    #
+    FIRST_TIME_VERIFY_MSG = 'first-time-verify'
+    VERIFY_NOW_MSG = 'verify-now'
+    VERIFY_LATER_MSG = 'verify-later'
+    UPGRADE_MSG = 'upgrade'
+    PAYMENT_CONFIRMATION_MSG = 'payment-confirmation'
+
+    MESSAGES = {
+        FIRST_TIME_VERIFY_MSG: 'first-time-verify',
+        VERIFY_NOW_MSG: 'verify-now',
+        VERIFY_LATER_MSG: 'verify-later',
+        UPGRADE_MSG: 'upgrade',
+        PAYMENT_CONFIRMATION_MSG: 'payment-confirmation'
+    }
+
+    # Requirements
+    #
+    # These explain to the user what he or she
+    # will need to successfully pay and/or verify.
+    #
+    # These are determined by the steps displayed
+    # to the user; for example, if the user does not
+    # need to complete the verification steps,
+    # then the photo ID and webcam requirements are hidden.
+    #
+    PHOTO_ID_REQ = "photo-id-required"
+    WEBCAM_REQ = "webcam-required"
+    CREDIT_CARD_REQ = "credit-card-required"
+
+    STEP_REQUIREMENTS = {
+        ID_PHOTO_STEP: [PHOTO_ID_REQ, WEBCAM_REQ],
+        FACE_PHOTO_STEP: [WEBCAM_REQ],
+        MAKE_PAYMENT_STEP: [CREDIT_CARD_REQ],
+    }
+
+    @method_decorator(login_required)
+    def get(
+        self, request, course_id,
+        always_show_payment=False,
+        current_step=INTRO_STEP,
+        message=FIRST_TIME_VERIFY_MSG
+    ):
+        """Render the pay/verify requirements page.
+
+        Arguments:
+            request (HttpRequest): The request object.
+            course_id (unicode): The ID of the course the user is trying
+                to enroll in.
+
+        Keyword Arguments:
+            always_show_payment (bool): If True, show the payment steps
+                even if the user has already paid.  This is useful
+                for users returning to the flow after paying.
+            current_step (string): The current step in the flow.
+            message (string): The messaging to display.
+
+        Returns:
+            HttpResponse
+
+        Raises:
+            Http404: The course does not exist or does not
+                have a verified mode.
+
+        """
+        # Parse the course key
+        # The URL regex should guarantee that the key format is valid.
+        course_key = CourseKey.from_string(course_id)
+
+        # Verify that the course exists and has a verified mode
+        if modulestore().has_course(course_key) is None:
+            raise Http404
+
+        # Verify that the course has a verified mode
+        if CourseMode.verified_mode_for_course(course_key) is None:
+            raise Http404
+
+        # Check whether the user has verified, paid, and enrolled.
+        # A user is considered "paid" if he or she has an enrollment
+        # with a paid course mode (such as "verified").
+        # For this reason, every paid user is enrolled, but not
+        # every enrolled user is paid.
+        already_verified = self._check_already_verified(request.user)
+        already_paid, is_enrolled = self._check_enrollment(request.user, course_key)
+
+        # Redirect the user to a more appropriate page if the
+        # messaging won't make sense based on the user's
+        # enrollment / payment / verification status.
+        redirect_response = self._redirect_if_necessary(
+            message,
+            already_verified,
+            already_paid,
+            is_enrolled,
+            course_key
+        )
+        if redirect_response is not None:
+            return redirect_response
+
+        display_steps = self._display_steps(
+            always_show_payment,
+            already_verified,
+            already_paid
+        )
+
+        completed_steps = self._completed_steps(display_steps, current_step)
+
+        # Determine the requirements (e.g. webcam, credit card)
+        # based on the steps the user needs to complete.
+        requirements = self._requirements(display_steps)
+
+        # DEBUG: generate a JSON object describing what we'll pass to the template
+        description = json.dumps({
+            'course_key': unicode(course_key),
+            'course_mode': self._verified_course_mode(course_key),
+            'display_steps': self._steps_dict(display_steps),
+            'completed_steps': self._steps_dict(completed_steps),
+            'requirements': requirements,
+            'show_payment': requirements[self.CREDIT_CARD_REQ],
+            'message': message
+        }, indent=4)
+        return HttpResponse(description, content_type="text/plain")
+
+    def _redirect_if_necessary(
+        self,
+        message,
+        already_verified,
+        already_paid,
+        is_enrolled,
+        course_key
+    ):
+        """Redirect the user to a more appropriate page if necessary.
+
+        In some cases, a user may visit this page with
+        verification / enrollment / payment state that
+        we don't anticipate.  For example, a user may unenroll
+        from the course after paying for it, then visit the
+        "verify now" page to complete verification.
+
+        When this happens, we try to redirect the user to
+        the most appropriate page.
+
+        Arguments:
+
+            message (string): The messaging of the page.  Should be a key
+                in `MESSAGES`.
+
+            already_verified (bool): Whether the user has submitted
+                a verification request recently.
+
+            already_paid (bool): Whether the user is enrolled in a paid
+                course mode.
+
+            is_enrolled (bool): Whether the user has an active enrollment
+                in the course.
+
+            course_key (CourseKey): The key for the course.
+
+        Returns:
+            HttpResponse or None
+
+        """
+        url = None
+        course_kwargs = {'course_id': unicode(course_key)}
+
+        if already_verified and already_paid:
+            # If they've already paid and verified, there's nothing else to do,
+            # so redirect them to the dashboard.
+            if message != self.PAYMENT_CONFIRMATION_MSG:
+                url = reverse('dashboard')
+        elif message in [self.VERIFY_NOW_MSG, self.VERIFY_LATER_MSG, self.PAYMENT_CONFIRMATION_MSG]:
+            if is_enrolled:
+                # If the user is already enrolled but hasn't yet paid,
+                # then the "upgrade" messaging is more appropriate.
+                if not already_paid:
+                    url = reverse('verify_student_upgrade_and_verify', kwargs=course_kwargs)
+            else:
+                # If the user is NOT enrolled, then send him/her
+                # to the first time verification page.
+                url = reverse('verify_student_start_verification', kwargs=course_kwargs)
+        elif message == self.UPGRADE_MSG:
+            if is_enrolled:
+                # If upgrading and we've paid but haven't verified,
+                # then the "verify later" messaging makes more sense.
+                if already_paid:
+                    url = reverse('verify_student_verify_later', kwargs=course_kwargs)
+            else:
+                url = reverse('verify_student_start_verification', kwargs=course_kwargs)
+
+        # Redirect if necessary, otherwise implicitly return None
+        if url is not None:
+            return redirect(url)
+
+    def _display_steps(self, always_show_payment, already_verified, already_paid):
+        """Determine which steps to display to the user.
+
+        Includes all steps by default, but removes steps
+        if the user has already completed them.
+
+        Arguments:
+            always_show_payment (bool): If True, display the payment steps
+                even if the user has already paid.
+
+            already_verified (bool): Whether the user has submitted
+                a verification request recently.
+
+            already_paid (bool): Whether the user is enrolled in a paid
+                course mode.
+
+        Returns:
+            list
+
+        """
+        display_steps = self.ALL_STEPS
+        remove_steps = set()
+
+        if already_verified:
+            remove_steps |= set(self.VERIFICATION_STEPS)
+
+        if already_paid and not always_show_payment:
+            remove_steps |= set(self.PAYMENT_STEPS)
+
+        return [
+            step for step in display_steps
+            if step not in remove_steps
+        ]
+
+    def _completed_steps(self, display_steps, current_step):
+        """Determine which steps the user has completed.
+
+        Every step before and including the current step
+        is marked "completed".
+
+        Arguments:
+            display_steps (list): List of steps displayed.
+            current_step (string): The name of the step the user is
+                currently on.
+
+        Returns:
+            list
+
+        """
+        completed_steps = []
+        for step in display_steps:
+            completed_steps.append(step)
+            if step == current_step:
+                break
+        return completed_steps
+
+    def _steps_dict(self, include_steps):
+        """Return a dictionary of steps.
+
+        Each key in the dictionary is a step.
+        The value is True if the step is
+        in `step_list` and False otherwise.
+
+        This is a more convenient representation
+        for templates.
+
+        Arguments:
+            step_list (list): The list of steps to include.
+
+        Returns:
+            dict
+
+        """
+        include_steps_set = set(include_steps)
+        return {
+            step_name: (step_name in include_steps_set)
+            for step_name in self.ALL_STEPS
+        }
+
+    def _requirements(self, display_steps):
+        """Determine which requirements to show the user.
+
+        For example, if the user needs to submit a photo
+        verification, tell the user that she will need
+        a photo ID and a webcam.
+
+        Arguments:
+            display_steps (list): The steps to display to the user.
+
+        Returns:
+            dict: Keys are requirement names, values are booleans
+                indicating whether to show the requirement.
+
+        """
+        all_requirements = {
+            self.PHOTO_ID_REQ: False,
+            self.WEBCAM_REQ: False,
+            self.CREDIT_CARD_REQ: False
+        }
+
+        for step, step_requirements in self.STEP_REQUIREMENTS.iteritems():
+            if step in display_steps:
+                for requirement in step_requirements:
+                    all_requirements[requirement] = True
+
+        return all_requirements
+
+    def _verified_course_mode(self, course_key):
+        """Check whether the course has a verified mode.
+
+        Arguments:
+            course_key (CourseKey): The key for the course to check.
+
+        Returns:
+            bool
+
+        """
+        mode = CourseMode.verified_mode_for_course(course_key)
+        if mode is not None:
+            return mode.slug
+
+    def _check_already_verified(self, user):
+        """Check whether the user has a valid or pending verification.
+
+        Note that this includes cases in which the user's verification
+        has not been accepted (either because it hasn't been processed,
+        or there was an error).
+
+        This should return True if the user has done their part:
+        submitted photos within the expiration period.
+
+        """
+        return SoftwareSecurePhotoVerification.user_has_valid_or_pending(user)
+
+    def _check_enrollment(self, user, course_key):
+        """Check whether the user has an active enrollment and has paid.
+
+        If a user is enrolled in a paid course mode, we assume
+        that the user has paid.
+
+        Arguments:
+            user (User): The user to check.
+            course_key (CourseKey): The key of the course to check.
+
+        Returns:
+            Tuple `(has_paid, is_active)` indicating whether the user
+            has paid and whether the user has an active account.
+
+        """
+        enrollment_mode, is_active = CourseEnrollment.enrollment_mode_for_user(user, course_key)
+        has_paid = False
+
+        if enrollment_mode is not None and is_active:
+            all_modes = CourseMode.modes_for_course_dict(course_key)
+            course_mode = all_modes.get(enrollment_mode)
+            has_paid = (course_mode and course_mode.min_price > 0)
+
+        return (has_paid, bool(is_active))
 
 
 @require_POST


### PR DESCRIPTION
- WIP implementation of the "verify requirements" page.
- The views return JSON objects with template context; the templates aren't actually rendered yet.
- The tests verify the template context, but this is encapsulated in helper methods.  Once I add template rendering, it should be easy to rewrite those methods to verify the actual content of the page.

@dianakhuang When you get a chance, could you take a look at this?  Looking for feedback on the URL structure and view logic, in particular if I'm missing any states we're going to need.
