### PR TITLE
Add DEFAULT_FILE_STORAGE configuration.

### DIFF
--- a/cms/envs/test.py
+++ b/cms/envs/test.py
@@ -19,7 +19,8 @@ from warnings import filterwarnings, simplefilter
 from uuid import uuid4
 
 # import settings from LMS for consistent behavior with CMS
-from lms.envs.test import (WIKI_ENABLED, PLATFORM_NAME, SITE_NAME)
+# pylint: disable=unused-import
+from lms.envs.test import (WIKI_ENABLED, PLATFORM_NAME, SITE_NAME, DEFAULT_FILE_STORAGE, MEDIA_ROOT, MEDIA_URL)
 
 # mongo connection settings
 MONGO_PORT_NUM = int(os.environ.get('EDXAPP_TEST_MONGO_PORT', '27017'))

--- a/common/djangoapps/util/file.py
+++ b/common/djangoapps/util/file.py
@@ -70,7 +70,8 @@ def store_uploaded_file(
         stored_file_name = base_storage_filename + file_extension
 
         file_storage = DefaultStorage()
-        file_storage.save(stored_file_name, uploaded_file)
+        # If a file already exists with the supplied name, file_storage will make the filename unique.
+        stored_file_name = file_storage.save(stored_file_name, uploaded_file)
 
         if validator:
             try:


### PR DESCRIPTION
Tests in common are run with both CMS and LMS configuration (with different env files). Previously only the LMS configuration file was updated (see https://github.com/edx/edx-platform/blob/master/lms/envs/test.py#L273).

@dan-f and @jzoldak 

Jay, should there be a common test file configuration that both LMS and CMS test.py files can start from?
