### PR TITLE
optionally using environment variable for edx-platform hash

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -14,7 +14,6 @@ from logsettings import get_logger_config
 import os
 
 from path import path
-from dealer.git import git
 from xmodule.modulestore.modulestore_settings import convert_module_store_setting_if_needed
 
 # SERVICE_VARIANT specifies name of the variant used, which decides what JSON
@@ -95,7 +94,7 @@ if STATIC_URL_BASE:
     STATIC_URL = STATIC_URL_BASE.encode('ascii')
     if not STATIC_URL.endswith("/"):
         STATIC_URL += "/"
-    STATIC_URL += git.revision + "/"
+    STATIC_URL += EDX_PLATFORM_REVISION + "/"
 
 # GITHUB_REPO_ROOT is the base directory
 # for course data
@@ -106,7 +105,7 @@ GITHUB_REPO_ROOT = ENV_TOKENS.get('GITHUB_REPO_ROOT', GITHUB_REPO_ROOT)
 
 STATIC_ROOT_BASE = ENV_TOKENS.get('STATIC_ROOT_BASE', None)
 if STATIC_ROOT_BASE:
-    STATIC_ROOT = path(STATIC_ROOT_BASE) / git.revision
+    STATIC_ROOT = path(STATIC_ROOT_BASE) / EDX_PLATFORM_REVISION
 
 EMAIL_BACKEND = ENV_TOKENS.get('EMAIL_BACKEND', EMAIL_BACKEND)
 EMAIL_FILE_PATH = ENV_TOKENS.get('EMAIL_FILE_PATH', None)

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -290,9 +290,14 @@ SERVER_EMAIL = 'devops@example.com'
 ADMINS = ()
 MANAGERS = ADMINS
 
+EDX_PLATFORM_REVISION = os.environ.get('EDX_PLATFORM_REVISION')
+
+if not EDX_PLATFORM_REVISION:
+    EDX_PLATFORM_REVISION = git.revision
+
 # Static content
-STATIC_URL = '/static/' + git.revision + "/"
-STATIC_ROOT = ENV_ROOT / "staticfiles" / git.revision
+STATIC_URL = '/static/' + EDX_PLATFORM_REVISION + "/"
+STATIC_ROOT = ENV_ROOT / "staticfiles" / EDX_PLATFORM_REVISION
 
 STATICFILES_DIRS = [
     COMMON_ROOT / "static",

--- a/cms/envs/yaml_config.py
+++ b/cms/envs/yaml_config.py
@@ -22,7 +22,6 @@ from util.config_parse import convert_tokens
 import os
 
 from path import path
-from dealer.git import git
 from xmodule.modulestore.modulestore_settings import convert_module_store_setting_if_needed
 
 # https://stackoverflow.com/questions/2890146/how-to-force-pyyaml-to-load-strings-as-unicode-objects
@@ -171,10 +170,10 @@ if STATIC_URL_BASE:
     STATIC_URL = STATIC_URL_BASE.encode('ascii')
     if not STATIC_URL.endswith("/"):
         STATIC_URL += "/"
-    STATIC_URL += git.revision + "/"
+    STATIC_URL += EDX_PLATFORM_REVISION + "/"
 
 if STATIC_ROOT_BASE:
-    STATIC_ROOT = path(STATIC_ROOT_BASE) / git.revision
+    STATIC_ROOT = path(STATIC_ROOT_BASE) / EDX_PLATFORM_REVISION
 
 
 # Cache used for location mapping -- called many times with the same key/value

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -33,6 +33,7 @@ from warnings import simplefilter
 from django.utils.translation import ugettext_lazy as _
 
 from .discussionsettings import *
+from dealer.git import git
 from xmodule.modulestore.modulestore_settings import update_module_store_settings
 from lms.djangoapps.lms_xblock.mixin import LmsBlockMixin
 
@@ -683,6 +684,11 @@ PRESS_EMAIL = 'press@example.com'
 FINANCE_EMAIL = ''
 ADMINS = ()
 MANAGERS = ADMINS
+
+EDX_PLATFORM_REVISION = os.environ.get('EDX_PLATFORM_REVISION')
+
+if not EDX_PLATFORM_REVISION:
+    EDX_PLATFORM_REVISION = git.revision
 
 # Static content
 STATIC_URL = '/static/'

--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -6,7 +6,6 @@
 <%
     # set doc language direction
     from django.utils.translation import get_language_bidi
-    from dealer.git import git
     dir_rtl = 'rtl' if get_language_bidi() else 'ltr'
 %>
 <head dir="${dir_rtl}">
@@ -81,7 +80,7 @@
         ## Using what amounts to a random number in the Development environment for cache-busting
         var urlArgs = "bust=" + (new Date()).getTime();
     % else:
-        var urlArgs = "v=${git.revision}";
+        var urlArgs = "v=${settings.EDX_PLATFORM_REVISION}";
     % endif
       require.config({
           baseUrl: baseUrl,


### PR DESCRIPTION
@feanil @wedaly 
The reason for this change is that so we have the option of overriding git ref with an environment variable for situations where we aren't deploying with a checked out version of the code
