### PR TITLE
Mock out the underlying segment-io call.

### DIFF
--- a/common/djangoapps/third_party_auth/tests/specs/base.py
+++ b/common/djangoapps/third_party_auth/tests/specs/base.py
@@ -424,6 +424,7 @@ class IntegrationTest(testutil.TestCase, test.TestCase):
         request, strategy = self.get_request_and_strategy(
             auth_entry=pipeline.AUTH_ENTRY_LOGIN, redirect_uri='social:complete')
         strategy.backend.auth_complete = mock.MagicMock(return_value=self.fake_auth_complete(strategy))
+        pipeline.analytics.track = mock.MagicMock()
         request.user = self.create_user_models_for_existing_account(
             strategy, 'user@example.com', 'password', self.get_username(), skip_social_auth=True)
 
@@ -558,6 +559,7 @@ class IntegrationTest(testutil.TestCase, test.TestCase):
         request, strategy = self.get_request_and_strategy(
             auth_entry=pipeline.AUTH_ENTRY_LOGIN, redirect_uri='social:complete')
         strategy.backend.auth_complete = mock.MagicMock(return_value=self.fake_auth_complete(strategy))
+        pipeline.analytics.track = mock.MagicMock()
         user = self.create_user_models_for_existing_account(
             strategy, 'user@example.com', 'password', self.get_username())
         self.assert_social_auth_exists_for_user(user, strategy)

--- a/lms/djangoapps/shoppingcart/tests/test_models.py
+++ b/lms/djangoapps/shoppingcart/tests/test_models.py
@@ -3,6 +3,7 @@ Tests for the Shopping Cart Models
 """
 from decimal import Decimal
 import datetime
+import os
 
 import smtplib
 from boto.exception import BotoServerError  # this is a super-class of SESError and catches connection errors
@@ -233,7 +234,10 @@ class OrderTest(ModuleStoreTestCase):
         item = CertificateItem.add_to_order(cart, self.course_key, self.cost, 'honor')
         # course enrollment object should be created but still inactive
         self.assertFalse(CourseEnrollment.is_enrolled(self.user, self.course_key))
-        cart.purchase()
+        # the analytics client pipes output to stderr when using the default client
+        devnull = open(os.devnull, 'w')
+        with patch('sys.stderr', devnull):
+            cart.purchase()
         self.assertTrue(CourseEnrollment.is_enrolled(self.user, self.course_key))
 
         # test e-mail sending

--- a/lms/djangoapps/shoppingcart/tests/test_models.py
+++ b/lms/djangoapps/shoppingcart/tests/test_models.py
@@ -3,7 +3,7 @@ Tests for the Shopping Cart Models
 """
 from decimal import Decimal
 import datetime
-import os
+import sys
 
 import smtplib
 from boto.exception import BotoServerError  # this is a super-class of SESError and catches connection errors
@@ -235,8 +235,7 @@ class OrderTest(ModuleStoreTestCase):
         # course enrollment object should be created but still inactive
         self.assertFalse(CourseEnrollment.is_enrolled(self.user, self.course_key))
         # the analytics client pipes output to stderr when using the default client
-        devnull = open(os.devnull, 'w')
-        with patch('sys.stderr', devnull):
+        with patch('sys.stderr', sys.stdout.write):
             cart.purchase()
         self.assertTrue(CourseEnrollment.is_enrolled(self.user, self.course_key))
 


### PR DESCRIPTION
TE-532

@rlucioni @jzoldak This should reduce some noise. The calls to segment-io weren't actually taking place because they would fail to initialize anyway.
