### PR TITLE
fix location revision error for multi parent draft

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -1306,7 +1306,7 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
             ancestor_loc = parent_loc
             while ancestor_loc is not None:
                 current_loc = ancestor_loc
-                ancestor_loc = self._get_raw_parent_location(current_loc, revision)
+                ancestor_loc = self._get_raw_parent_location(as_published(current_loc), revision)
                 if ancestor_loc is None:
                     bulk_record.dirty = True
                     # The parent is an orphan, so remove all the children including


### PR DESCRIPTION
PLAT-332
@adampalay @dmitchell 
Fix problem where a component has multiple parents (of which all other parents except original parent could be orphans) and when user tires to export the course with draft version of that component then "get_parent_location" method raises "AssertionError" for location revision of that component.
