### PR TITLE
TNL-784: Scroll  to note and open it

### DIFF
--- a/lms/static/js/edxnotes/plugins/scroller.js
+++ b/lms/static/js/edxnotes/plugins/scroller.js
@@ -1,0 +1,65 @@
+;(function (define, undefined) {
+'use strict';
+define(['jquery', 'underscore', 'annotator'], function ($, _, Annotator) {
+    /**
+     * Adds the Scroller Plugin which scrolls to a note with a certain id and
+     * opens it.
+     **/
+    Annotator.Plugin.Scroller = function () {
+        // Call the Annotator.Plugin constructor this sets up the element and
+        // options properties.
+        Annotator.Plugin.apply(this, arguments);
+    };
+
+    $.extend(Annotator.Plugin.Scroller.prototype, new Annotator.Plugin(), {
+        getIdFromLocationHash: function() {
+            return window.location.hash.substr(1);
+        },
+
+        pluginInit: function () {
+            _.bindAll(this, 'onNotesLoaded');
+            // If the page URL contains a hash, we could be coming from a click
+            // on an anchor in the notes page. In that case, the hash is the id
+            // of the note that has to be scrolled to and opened.
+            if (this.getIdFromLocationHash()) {
+                this.annotator.subscribe('annotationsLoaded', this.onNotesLoaded);
+            }
+        },
+
+        destroy: function () {
+            this.annotator.unsubscribe('annotationsLoaded', this.onNotesLoaded);
+        },
+
+        onNotesLoaded: function (notes) {
+            var hash = this.getIdFromLocationHash();
+            this.annotator.logger.log('Scroller', {
+                'notes:': notes,
+                'hash': hash
+            });
+            _.each(notes, function (note) {
+                var highlight, offset;
+                if (note.id === hash && note.highlights.length) {
+                    // Clear the page URL hash, it won't be needed once we've
+                    // scrolled and opened the relevant note. And it would
+                    // unnecessarily repeat the steps below if we come from
+                    // another sequential.
+                    window.location.hash = '';
+                    highlight = $(note.highlights[0]);
+                    offset = highlight.position();
+                    // Open the note
+                    this.annotator.showFrozenViewer([note], {
+                        top: offset.top + 0.5 * highlight.height(),
+                        left: offset.left + 0.5 * highlight.width()
+                    });
+                    // Scroll to highlight
+                    this.scrollIntoView(highlight);
+                }
+            }, this);
+        },
+
+        scrollIntoView: function (highlight) {
+            highlight.focus();
+        }
+    });
+});
+}).call(this, define || RequireJS.define);

--- a/lms/static/js/edxnotes/views/notes_factory.js
+++ b/lms/static/js/edxnotes/views/notes_factory.js
@@ -1,9 +1,10 @@
 ;(function (define, undefined) {
 'use strict';
 define([
-     'jquery', 'underscore', 'annotator', 'js/edxnotes/utils/logger', 'js/edxnotes/views/shim'
+     'jquery', 'underscore', 'annotator', 'js/edxnotes/utils/logger',
+     'js/edxnotes/views/shim', 'js/edxnotes/plugins/scroller'
 ], function ($, _, Annotator, Logger) {
-    var plugins = ['Auth', 'Store'],
+    var plugins = ['Auth', 'Store', 'Scroller'],
         getOptions, setupPlugins, updateHeaders, getAnnotator;
 
     /**

--- a/lms/static/js/spec/edxnotes/custom_matchers.js
+++ b/lms/static/js/spec/edxnotes/custom_matchers.js
@@ -26,7 +26,7 @@ define(['jquery'], function($) {
 
             toBeFocused: function () {
                 return $(this.actual)[0] === $(this.actual)[0].ownerDocument.activeElement;
-            },
+            }
         });
     };
 });

--- a/lms/static/js/spec/edxnotes/plugins/scroller_spec.js
+++ b/lms/static/js/spec/edxnotes/plugins/scroller_spec.js
@@ -1,0 +1,94 @@
+define([
+    'jquery', 'underscore', 'annotator', 'js/edxnotes/views/notes_factory',
+    'js/spec/edxnotes/custom_matchers'
+], function($, _, Annotator, NotesFactory, customMatchers) {
+    'use strict';
+    describe('EdxNotes Scroll Plugin', function() {
+        var annotators, highlights;
+
+        function checkAnnotatorIsFrozen(annotator) {
+            expect(annotator.isFrozen).toBe(true);
+            expect(annotator.onHighlightMouseover).not.toHaveBeenCalled();
+            expect(annotator.startViewerHideTimer).not.toHaveBeenCalled();
+        }
+
+        function checkAnnotatorIsUnfrozen(annotator) {
+            expect(annotator.isFrozen).toBe(false);
+            expect(annotator.onHighlightMouseover).toHaveBeenCalled();
+            expect(annotator.startViewerHideTimer).toHaveBeenCalled();
+        }
+
+        beforeEach(function() {
+            customMatchers(this);
+            loadFixtures('js/fixtures/edxnotes/edxnotes_wrapper.html');
+            annotators = [
+                NotesFactory.factory($('div#edx-notes-wrapper-123').get(0), {
+                    endpoint: 'http://example.com/'
+                }),
+                NotesFactory.factory($('div#edx-notes-wrapper-456').get(0), {
+                    endpoint: 'http://example.com/'
+                })
+            ];
+
+            highlights = _.map(annotators, function(annotator) {
+                spyOn(annotator, 'onHighlightClick').andCallThrough();
+                spyOn(annotator, 'onHighlightMouseover').andCallThrough();
+                spyOn(annotator, 'startViewerHideTimer').andCallThrough();
+                return $('<span></span>', {
+                    'class': 'annotator-hl',
+                    'tabindex': -1,
+                    'text': 'some content'
+                }).appendTo(annotator.element);
+            });
+
+            spyOn(annotators[0].plugins.Scroller, 'getIdFromLocationHash').andReturn('abc123');
+            spyOn($.fn, 'unbind').andCallThrough();
+        });
+
+        afterEach(function () {
+            _.invoke(Annotator._instances, 'destroy');
+        });
+
+        it('should scroll to a note, open it and freeze the annotator if its id is part of the url hash', function() {
+            annotators[0].plugins.Scroller.onNotesLoaded([{
+                id: 'abc123',
+                highlights: [highlights[0]]
+            }]);
+            annotators[0].onHighlightMouseover.reset();
+            expect(highlights[0]).toBeFocused();
+            highlights[0].mouseover();
+            highlights[0].mouseout();
+            checkAnnotatorIsFrozen(annotators[0]);
+        });
+
+        it('should not do anything if the url hash contains a wrong id', function() {
+            annotators[0].plugins.Scroller.onNotesLoaded([{
+                id: 'def456',
+                highlights: [highlights[0]]
+            }]);
+            expect(highlights[0]).not.toBeFocused();
+            highlights[0].mouseover();
+            highlights[0].mouseout();
+            checkAnnotatorIsUnfrozen(annotators[0]);
+        });
+
+        it('should not do anything if the url hash contains an empty id', function() {
+            annotators[0].plugins.Scroller.onNotesLoaded([{
+                id: '',
+                highlights: [highlights[0]]
+            }]);
+            expect(highlights[0]).not.toBeFocused();
+            highlights[0].mouseover();
+            highlights[0].mouseout();
+            checkAnnotatorIsUnfrozen(annotators[0]);
+        });
+
+        it('should unbind onNotesLoaded on destruction', function() {
+            annotators[0].plugins.Scroller.destroy();
+            expect($.fn.unbind).toHaveBeenCalledWith(
+                'annotationsLoaded',
+                annotators[0].plugins.Scroller.onNotesLoaded
+            );
+        });
+    });
+});

--- a/lms/static/js/spec/edxnotes/views/shim_spec.js
+++ b/lms/static/js/spec/edxnotes/views/shim_spec.js
@@ -42,6 +42,7 @@ define([
                 spyOn(annotator, 'onHighlightMouseover').andCallThrough();
                 spyOn(annotator, 'startViewerHideTimer').andCallThrough();
             });
+            spyOn($.fn, 'off').andCallThrough();
         });
 
         afterEach(function () {
@@ -111,6 +112,14 @@ define([
 
             // Check that second one doesn't have a bound click.edxnotes:freeze
             checkClickEventsNotBound('edxnotes:freeze' + annotators[1].uid);
+        });
+
+        it('should unbind onNotesLoaded on destruction', function() {
+            annotators[0].destroy();
+            expect($.fn.off).toHaveBeenCalledWith(
+                'click',
+                annotators[0].onNoteClick
+            );
         });
     });
 });

--- a/lms/static/js/spec/main.js
+++ b/lms/static/js/spec/main.js
@@ -433,7 +433,8 @@
         'lms/include/js/spec/edxnotes/views/visibility_decorator_spec.js',
         'lms/include/js/spec/edxnotes/views/toggle_notes_factory_spec.js',
         'lms/include/js/spec/edxnotes/models/tab_spec.js',
-        'lms/include/js/spec/edxnotes/models/note_spec.js'
+        'lms/include/js/spec/edxnotes/models/note_spec.js',
+        'lms/include/js/spec/edxnotes/plugins/scroller_spec.js'
     ]);
 
 }).call(this, requirejs, define);

--- a/lms/static/require-config-lms.js
+++ b/lms/static/require-config-lms.js
@@ -143,10 +143,7 @@
             // End of needed by OVA
         },
         map: {
-          "js/edxnotes/views/notes_factory": {
-              "annotator": "annotator_1.2.9"
-          },
-          "js/edxnotes/views/shim": {
+          "js/edxnotes/*": {
               "annotator": "annotator_1.2.9"
           }
         }

--- a/lms/templates/edxnotes/note-item.underscore
+++ b/lms/templates/edxnotes/note-item.underscore
@@ -29,7 +29,7 @@
         <% } else if (quote) { %>
             <h3 class="reference-title"><%- gettext("Noted in:") %></h3>
         <% } %>
-        <a class="reference-meta reference-unit-link" href="<%= unit.url %>"><%- unit.display_name %></a>
+        <a class="reference-meta reference-unit-link" href="<%= unit.url %>#<%= id %>"><%- unit.display_name %></a>
         <h3 class="reference-title"><%- gettext("Last Edited:") %></h3>
         <span class="reference-meta reference-updated-date"><%- updated %></span>
     </div>


### PR DESCRIPTION
**Ticket:** https://openedx.atlassian.net/browse/TNL-784

**Acceptance criteria:**
When the unit is opened from a link from the View All Notes view, the note that was clicked from should be scrolled into view and should be opened for viewing on the unit. To close the note, you can click outside of the note pop-up. Orphaned notes shouldn't have this behavior.

**Sandbox:** http://jmclaus.m.sandbox.edx.org

@polesye @tymofij @explorerleslie Please review.
