### PR TITLE
Remove webcam capture approval button (checkmark)

### DIFF
--- a/lms/static/js/verify_student/views/webcam_photo_view.js
+++ b/lms/static/js/verify_student/views/webcam_photo_view.js
@@ -241,7 +241,6 @@
             // Install event handlers
             $( "#webcam_reset_button", this.el ).on( 'click', _.bind( this.reset, this ) );
             $( "#webcam_capture_button", this.el ).on( 'click', _.bind( this.capture, this ) );
-            $( "#webcam_approve_button", this.el ).on( 'click', _.bind( this.approve, this ) );
 
             return this;
         },
@@ -255,7 +254,6 @@
 
             // Go back to the initial button state
             $( "#webcam_reset_button", this.el ).hide();
-            $( "#webcam_approve_button", this.el ).removeClass( "approved" ).hide();
             $( "#webcam_capture_button", this.el ).show();
         },
 
@@ -263,23 +261,17 @@
             // Take a snapshot of the video
             var success = this.backend.snapshot();
 
-            // Show the reset and approve buttons
             if ( success ) {
+                // Hide the capture button, and show the reset button
                 $( "#webcam_capture_button", this.el ).hide();
                 $( "#webcam_reset_button", this.el ).show();
-                $( "#webcam_approve_button", this.el ).show();
+
+                // Save the data to the model
+                this.model.set( this.modelAttribute, this.backend.getImageData() );
+
+                // Enable the submit button
+                $( this.submitButton ).removeClass( "is-disabled" );
             }
-        },
-
-        approve: function() {
-            // Save the data to the model
-            this.model.set( this.modelAttribute, this.backend.getImageData() );
-
-            // Make the "approve" button green
-            $( "#webcam_approve_button" ).addClass( "approved" );
-
-            // Enable the submit button
-            $( this.submitButton ).removeClass( "is-disabled" );
         },
 
         chooseVideoCaptureBackend: function() {
@@ -298,7 +290,6 @@
             // Hide the buttons
             $( "#webcam_capture_button", this.el ).hide();
             $( "#webcam_reset_button", this.el ).hide();
-            $( "#webcam_approve_button", this.el ).hide();
 
             // Show the error message
             this.errorModel.set({

--- a/lms/static/sass/views/_verification.scss
+++ b/lms/static/sass/views/_verification.scss
@@ -732,8 +732,8 @@
           left: ($baseline/2);
         }
 
-        // control - take/do
-        .control-do {
+        // control - take/do, retake
+        .control-do, .control-retake {
           left: 45%;
         }
 
@@ -2183,8 +2183,8 @@
             left: ($baseline/2);
           }
 
-          // control - take/do
-          .control-do {
+          // control - take/do, retake
+          .control-do, .control-retake {
             left: 45%;
           }
 

--- a/lms/templates/verify_student/face_photo_step.underscore
+++ b/lms/templates/verify_student/face_photo_step.underscore
@@ -18,7 +18,6 @@
               <li class="help-item"><%- gettext( "Be sure your entire face is inside the frame" ) %></li>
               <li class="help-item"><%- gettext( "Can we match the photo you took with the one on your ID?" ) %></li>
               <li class="help-item"><%- gettext( "Once in position, use the camera button" ) %> <span class="example">(<i class="icon-camera"></i>)</span> <%- gettext( "to capture your picture" ) %></li>
-              <li class="help-item"><%- gettext( "Use the checkmark button" ) %> <span class="example">(<i class="icon-ok"></i>)</span> <%- gettext( "once you are happy with the photo" ) %></li>
             </ul>
           </div>
         </div>

--- a/lms/templates/verify_student/id_photo_step.underscore
+++ b/lms/templates/verify_student/id_photo_step.underscore
@@ -20,7 +20,6 @@
               <li class="help-item"><%- gettext( "Try to keep your fingers at the edge to avoid covering important information" ) %></li>
               <li class="help-item"><%- gettext( "Acceptable IDs include drivers licenses, passports, or other goverment-issued IDs that include your name and photo" ) %></li>
               <li class="help-item"><%- gettext( "Once in position, use the camera button ") %> <span class="example">(<i class="icon-camera"></i>)</span> <%- gettext( "to capture your ID" ) %></li>
-              <li class="help-item"><%- gettext( "Use the checkmark button" ) %> <span class="example">(<i class="icon-ok"></i>)</span> <%- gettext( "once you are happy with the photo" ) %></li>
             </ul>
           </div>
         </div>

--- a/lms/templates/verify_student/webcam_photo.underscore
+++ b/lms/templates/verify_student/webcam_photo.underscore
@@ -9,7 +9,7 @@
 
 <div class="controls photo-controls">
   <ul class="list-controls">
-    <li class="control control-redo" id="webcam_reset_button" style="display: none;">
+    <li class="control control-retake" id="webcam_reset_button" style="display: none;">
       <a class="action action-redo">
         <i class="icon-undo"></i> <span class="sr"><%- gettext( "Retake" ) %></span>
       </a>
@@ -18,12 +18,6 @@
     <li class="control control-do" id="webcam_capture_button">
       <a class="action action-do">
         <i class="icon-camera"></i> <span class="sr"><%- gettext( "Take photo" ) %></span>
-      </a>
-    </li>
-
-    <li class="control control-approve" id="webcam_approve_button" style="display: none;">
-      <a class="action action-approve">
-        <i class="icon-ok"></i> <span class="sr"><%- gettext( "Looks good" ) %></span>
       </a>
     </li>
   </ul>


### PR DESCRIPTION
As per @andywaldrop's request, this removes the webcam capture approval button (i.e., the checkmark) from the webcam photo view. Capturing a photo now automatically saves the data to the verification model and enables the submit button.

@wedaly and @AlasdairSwan, could you review this when you're able?

I noticed while removing the checkmark that the breadcrumb at the top of the page doesn't update as the user proceeds through the verification flow. This behavior is present in master, so this branch hasn't introduced a regression. I think resolving this issue is separate from the removal of the checkmark, so a fix isn't included in this PR.
