### PR TITLE
Inline underscore templates; add pre render step

### DIFF
--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -25,8 +25,6 @@ from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext as _, ugettext_lazy
 from django.contrib.auth.decorators import login_required
 
-from staticfiles.storage import staticfiles_storage
-
 from openedx.core.djangoapps.user_api.api import profile as profile_api
 
 from course_modes.models import CourseMode
@@ -270,31 +268,31 @@ class PayAndVerifyView(View):
     STEP_INFO = {
         INTRO_STEP: Step(
             title=ugettext_lazy("Intro"),
-            template_name="verify_student/intro_step.underscore"
+            template_name="intro_step"
         ),
         MAKE_PAYMENT_STEP: Step(
             title=ugettext_lazy("Make Payment"),
-            template_name="verify_student/make_payment_step.underscore"
+            template_name="make_payment_step"
         ),
         PAYMENT_CONFIRMATION_STEP: Step(
             title=ugettext_lazy("Payment Confirmation"),
-            template_name="verify_student/payment_confirmation_step.underscore"
+            template_name="payment_confirmation_step"
         ),
         FACE_PHOTO_STEP: Step(
             title=ugettext_lazy("Take Face Photo"),
-            template_name="verify_student/face_photo_step.underscore"
+            template_name="face_photo_step"
         ),
         ID_PHOTO_STEP: Step(
             title=ugettext_lazy("ID Photo"),
-            template_name="verify_student/id_photo_step.underscore"
+            template_name="id_photo_step"
         ),
         REVIEW_PHOTOS_STEP: Step(
             title=ugettext_lazy("Review Photos"),
-            template_name="verify_student/review_photos_step.underscore"
+            template_name="review_photos_step"
         ),
         ENROLLMENT_CONFIRMATION_STEP: Step(
             title=ugettext_lazy("Enrollment Confirmation"),
-            template_name="verify_student/enrollment_confirmation_step.underscore"
+            template_name="enrollment_confirmation_step"
         ),
     }
 
@@ -607,33 +605,11 @@ class PayAndVerifyView(View):
             {
                 'name': step,
                 'title': unicode(self.STEP_INFO[step].title),
-                'templateUrl': self._template_url(self.STEP_INFO[step].template_name)
+                'templateName': self.STEP_INFO[step].template_name
             }
             for step in display_steps
             if step not in remove_steps
         ]
-
-    def _template_url(self, template_name):
-        """Determine the path to a template.
-
-        This uses staticfiles, so the path will include MD5
-        hashes when used in production.  This is really important,
-        because otherwise the JavaScript won't be able to find
-        the templates!
-
-        Arguments:
-            template_name (str): The name of the template, relative
-                to the "static/templates" directory.
-
-        Returns:
-            string
-
-        """
-        template_path = u"templates/{name}".format(name=template_name)
-        return (
-            staticfiles_storage.url(template_path)
-            if template_name is not None else ""
-        )
 
     def _requirements(self, display_steps):
         """Determine which requirements to show the user.

--- a/lms/static/js/verify_student/views/pay_and_verify_view.js
+++ b/lms/static/js/verify_student/views/pay_and_verify_view.js
@@ -96,7 +96,7 @@ var edx = edx || {};
 
                     subviewConfig = {
                         errorModel: this.errorModel,
-                        templateUrl: this.displaySteps[i].templateUrl,
+                        templateName: this.displaySteps[i].templateName,
                         nextStepNum: (i + 2), // Next index, starting from 1
                         nextStepTitle: nextStepTitle,
                         stepData: stepData

--- a/lms/templates/verify_student/pay_and_verify.html
+++ b/lms/templates/verify_student/pay_and_verify.html
@@ -9,7 +9,13 @@ from verify_student.views import PayAndVerifyView
 <%block name="bodyclass">register verification-process step-requirements</%block>
 <%block name="pagetitle">${messages.page_title}</%block>
 <%block name="header_extras">
-    % for template_name in ["progress", "requirements", "webcam_photo", "error"]:
+    <%
+      template_names = (
+          ["progress", "requirements", "webcam_photo", "error"] +
+          [step['templateName'] for step in display_steps]
+      )
+    %>
+    % for template_name in template_names:
         <script type="text/template" id="${template_name}-tpl">
             <%static:include path="verify_student/${template_name}.underscore" />
         </script>


### PR DESCRIPTION
I ran the numbers, and the underscore templates total about 16K (the total page size is ~250K, including these).   For this reason, I've inlined the templates into the DOM -- when RequireJS optimizer is enabled in the LMS, these will be loaded asynchronously (and cached!).  This simplifies the `StepView` considerably, and it avoids an extra round-trip to render each step.

In a separate PR, I'm going to need to modify the context of the template based on an AJAX request, so I've added a `preRender` method that allows this.

Reviewers: @AlasdairSwan @stephensanchez 
