### PR TITLE
Add payment information to payment confirmation page

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1010,6 +1010,7 @@ courseware_js = (
 base_vendor_js = [
     'js/vendor/jquery.min.js',
     'js/vendor/jquery.cookie.js',
+    'js/vendor/url.min.js',
     'js/vendor/underscore-min.js',
     'js/vendor/require.js',
     'js/RequireJS-namespace-undefine.js',

--- a/lms/static/js/verify_student/pay_and_verify.js
+++ b/lms/static/js/verify_student/pay_and_verify.js
@@ -56,6 +56,11 @@ var edx = edx || {};
             'review-photos-step': {
                 fullName: el.data('full-name'),
                 platformName: el.data('platform-name')
+            },
+            'enrollment-confirmation-step': {
+                courseName: el.data('course-name'),
+                courseStartDate: el.data('course-start-date'),
+                coursewareUrl: el.data('courseware-url')
             }
         }
     }).render();

--- a/lms/static/js/verify_student/views/pay_and_verify_view.js
+++ b/lms/static/js/verify_student/views/pay_and_verify_view.js
@@ -30,18 +30,17 @@ var edx = edx || {};
             this.errorModel = obj.errorModel || {};
             this.displaySteps = obj.displaySteps || [];
 
-            // Determine which step we're starting on
-            // Depending on how the user enters the flow,
-            // this could be anywhere in the sequence of steps.
-            this.currentStepIndex = _.indexOf(
-                _.pluck( this.displaySteps, 'name' ),
-                obj.currentStep
-            );
-
             this.progressView = new edx.verify_student.ProgressView({
                 el: this.el,
                 displaySteps: this.displaySteps,
-                currentStepIndex: this.currentStepIndex
+
+                // Determine which step we're starting on
+                // Depending on how the user enters the flow,
+                // this could be anywhere in the sequence of steps.
+                currentStepIndex: _.indexOf(
+                    _.pluck( this.displaySteps, 'name' ),
+                    obj.currentStep
+                )
             });
 
             this.initializeStepViews( obj.stepInfo );
@@ -140,29 +139,21 @@ var edx = edx || {};
             // underscore template.
             // When the view is rendered, it will overwrite the existing
             // step in the DOM.
-            stepName = this.displaySteps[ this.currentStepIndex ].name;
+            stepName = this.displaySteps[ this.progressView.currentStepIndex ].name;
             stepView = this.subviews[ stepName ];
             stepView.el = stepEl;
             stepView.render();
         },
 
         nextStep: function() {
-            this.currentStepIndex = Math.min( this.currentStepIndex + 1, this.displaySteps.length - 1 );
+            this.progressView.nextStep();
             this.render();
         },
 
         goToStep: function( stepName ) {
-            var stepIndex = _.indexOf(
-                _.pluck( this.displaySteps, 'name' ),
-                stepName
-            );
-
-            if ( stepIndex >= 0 ) {
-                this.currentStepIndex = stepIndex;
-                this.render();
-            }
-        },
-
+            this.progressView.goToStep( stepName );
+            this.render();
+        }
     });
 
 })(jQuery, _, Backbone, gettext);

--- a/lms/static/js/verify_student/views/payment_confirmation_step_view.js
+++ b/lms/static/js/verify_student/views/payment_confirmation_step_view.js
@@ -3,16 +3,133 @@
  */
 var edx = edx || {};
 
-(function( $ ) {
+(function( $, _, gettext ) {
     'use strict';
 
     edx.verify_student = edx.verify_student || {};
 
-    // The "Verify Later" button goes directly to the dashboard,
-    // The "Verify Now" button reloads this page with the "skip-first-step"
-    // flag set.  This allows the user to navigate back to the confirmation
-    // if he/she wants to.
-    // For this reason, we don't need any custom click handlers here.
-    edx.verify_student.PaymentConfirmationStepView = edx.verify_student.StepView.extend({});
+    edx.verify_student.PaymentConfirmationStepView = edx.verify_student.StepView.extend({
 
-})( jQuery );
+        /**
+         * Retrieve receipt information from the shopping cart.
+         *
+         * We make this request from JavaScript to encapsulate
+         * the verification Django app from the shopping cart app.
+         *
+         * This method checks the query string param
+         * ?payment-order-num, which can be set by the shopping cart
+         * before redirecting to the payment confirmation page.
+         * This step then reads the param and requests receipt information
+         * from the shopping cart.  At no point does the "verify student"
+         * Django app interact directly with the shopping cart.
+         *
+         * @param  {object} templateContext The original template context.
+         * @return {object} A JQuery promise that resolves with the modified
+         *                    template context.
+         */
+        updateContext: function( templateContext ) {
+            var view = this;
+            return $.Deferred(
+                function( defer ) {
+                    var paymentOrderNum = $.url( '?payment-order-num' );
+                    if ( paymentOrderNum ) {
+                        // If there is a payment order number, try to retrieve
+                        // the receipt information from the shopping cart.
+                        view.getReceiptData( paymentOrderNum ).done(
+                            function( data ) {
+                                // Add the receipt info to the template context
+                                _.extend( templateContext, { receipt: this.receiptContext( data ) } );
+                                defer.resolveWith( view, [ templateContext ]);
+                            }
+                        ).fail(function() {
+                            // Display an error
+                            // This can occur if the user does not have access to the receipt
+                            // or the order number is invalid.
+                            defer.rejectWith(
+                                this,
+                                [
+                                    gettext( "Error" ),
+                                    gettext( "Could not retrieve payment information" )
+                                ]
+                            );
+                        });
+                    } else {
+                        // If no payment order is provided, return the original context
+                        // The template is responsible for displaying a default state.
+                        _.extend( templateContext, { receipt: null } );
+                        defer.resolveWith( view, [ templateContext ]);
+                    }
+                }
+            ).promise();
+        },
+
+        /**
+         * The "Verify Later" button goes directly to the dashboard,
+         * The "Verify Now" button reloads this page with the "skip-first-step"
+         * flag set.  This allows the user to navigate back to the confirmation
+         * if he/she wants to.
+         * For this reason, we don't need any custom click handlers here.
+         */
+        postRender: function() {},
+
+        /**
+         * Retrieve receipt data from the shoppingcart.
+         * @param  {int} paymentOrderNum The order number of the payment.
+         * @return {object}                 JQuery Promise.
+         */
+        getReceiptData: function( paymentOrderNum ) {
+            return $.ajax({
+                url: _.sprintf( '/shoppingcart/receipt/%s/', paymentOrderNum ),
+                type: 'GET',
+                dataType: 'json',
+                context: this
+            });
+        },
+
+        /**
+         * Construct the template context from data received
+         * from the shopping cart receipt.
+         *
+         * @param  {object} data Receipt data received from the server
+         * @return {object}      Receipt template context.
+         */
+        receiptContext: function( data ) {
+            var view = this,
+                receiptContext;
+
+            receiptContext = {
+                orderNum: data.orderNum,
+                currency: data.currency,
+                purchasedDatetime: data.purchase_datetime,
+                totalCost: view.formatMoney( data.total_cost ),
+                isRefunded: data.status === "refunded",
+                billedTo: {
+                    firstName: data.billed_to.first_name,
+                    lastName: data.billed_to.last_name,
+                    city: data.billed_to.city,
+                    state: data.billed_to.state,
+                    postalCode: data.billed_to.postal_code,
+                    country: data.billed_to.country
+                },
+                items: []
+            };
+
+            receiptContext.items = _.map(
+                data.items,
+                function( item ) {
+                    return {
+                        lineDescription: item.line_desc,
+                        cost: view.formatMoney( item.line_cost )
+                    };
+                }
+            );
+
+            return receiptContext;
+        },
+
+        formatMoney: function( moneyStr ) {
+            return Number( moneyStr ).toFixed(2);
+        }
+    });
+
+})( jQuery, _, gettext );

--- a/lms/static/js/verify_student/views/progress_view.js
+++ b/lms/static/js/verify_student/views/progress_view.js
@@ -18,6 +18,24 @@
             this.currentStepIndex = obj.currentStepIndex || 0;
         },
 
+        nextStep: function() {
+            this.currentStepIndex = Math.min(
+                this.currentStepIndex + 1,
+                this.displaySteps.length - 1
+            );
+        },
+
+        goToStep: function( stepName ) {
+            var stepIndex = _.indexOf(
+                _.pluck( this.displaySteps, 'name' ),
+                stepName
+            );
+
+            if ( stepIndex >= 0 ) {
+                this.currentStepIndex = stepIndex;
+            }
+        },
+
         render: function() {
             var renderedHtml, context;
 

--- a/lms/static/js/verify_student/views/step_view.js
+++ b/lms/static/js/verify_student/views/step_view.js
@@ -64,10 +64,10 @@
             this.postRender();
         },
 
-        handleError: function() {
+        handleError: function( errorTitle, errorMsg ) {
             this.errorModel.set({
-                errorTitle: gettext( "Error" ),
-                errorMsg: gettext( "An unexpected error occurred.  Please reload the page to try again." ),
+                errorTitle: errorTitle || gettext( "Error" ),
+                errorMsg: errorMsg || gettext( "An unexpected error occurred.  Please reload the page to try again." ),
                 shown: true
             });
         },

--- a/lms/templates/verify_student/enrollment_confirmation_step.underscore
+++ b/lms/templates/verify_student/enrollment_confirmation_step.underscore
@@ -1,1 +1,50 @@
-<p>Enrollment confirmation!</p>
+<div class="wrapper-content-main">
+  <article class="content-main">
+    <h3 class="title"><%- gettext( "Congratulations!  You are now enrolled in the verified track." ) %></h3>
+    <div class="instruction">
+      <p><%- gettext( "You are now enrolled as a verified student!  Your enrollment details are below.") %></p>
+    </div>
+
+    <ul class="list-info">
+      <li class="info-item course-info">
+        <h4 class="title">
+          <%- gettext( "You are enrolled in " ) %> :
+        </h4>
+        <div class="wrapper-report">
+          <table class="report report-course">
+            <caption class="sr"><%- gettext( "A list of courses you have just enrolled in as a verified student" ) %></caption>
+            <thead>
+              <tr>
+                <th scope="col" ><%- gettext( "Course" ) %></th>
+                <th scope="col" ><%- gettext( "Status" ) %></th>
+                <th scope="col" ><span class="sr"><%- gettext( "Options" ) %></span></th>
+              </tr>
+            </thead>
+
+            <tbody>
+              <tr>
+                <td><%- courseName %></td>
+                <td>
+                   <%- _.sprintf( gettext( "Starts: %(start)s" ), { start: courseStartDate } ) %>
+                </td>
+                <td class="options">
+                <% if ( coursewareUrl ) { %>
+                      <a class="action action-course" href="<%- coursewareUrl %>"><%- gettext( "Go to Course" ) %></a>
+                <% } %>
+                </td>
+              </tr>
+            </tbody>
+            <tfoot>
+              <tr class="course-actions">
+                <td colspan="3">
+                  <a class="action action-dashboard" href="/dashboard"><%- gettext("Go to your dashboard") %></a>
+                </td>
+              </tr>
+            </tfoot>
+          </table>
+        </div>
+
+      </li>
+    </ul>
+  </article>
+</div>

--- a/lms/templates/verify_student/payment_confirmation_step.underscore
+++ b/lms/templates/verify_student/payment_confirmation_step.underscore
@@ -5,47 +5,80 @@
       <p><%- gettext( "You are now enrolled as a verified student!  Your enrollment details are below.") %></p>
     </div>
 
+    <% if ( receipt ) { %>
     <ul class="list-info">
-      <li class="info-item course-info">
-        <h4 class="title">
-          <%- gettext( "You are enrolled in " ) %> :
-        </h4>
+      <li class="info-item payment-info">
+        <h4 class="title"><%- gettext( "Payment Details" ) %></h4>
+
+        <div class="copy">
+          <p><%- gettext( "Please print this page for your records; it serves as your receipt. You will also receive an email with the same information." ) %></p>
+        </div>
+
         <div class="wrapper-report">
-          <table class="report report-course">
-            <caption class="sr"><%- gettext( "A list of courses you have just enrolled in as a verified student" ) %></caption>
+          <table class="report report-receipt">
             <thead>
               <tr>
-                <th scope="col" ><%- gettext( "Course" ) %></th>
-                <th scope="col" ><%- gettext( "Status" ) %></th>
-                <th scope="col" ><span class="sr"><%- gettext( "Options" ) %></span></th>
+                <th scope="col" ><%- gettext( "Order No." ) %></th>
+                <th scope="col" ><%- gettext( "Description" ) %></th>
+                <th scope="col" ><%- gettext( "Date" ) %></th>
+                <th scope="col" ><%- gettext( "Description" ) %></th>
               </tr>
             </thead>
 
             <tbody>
-              <tr>
-                <td><%- courseName %></td>
-                <td>
-                   <%- _.sprintf( gettext( "Starts: %(start)s" ), { start: courseStartDate } ) %>
-                </td>
-                <td class="options">
-                <% if ( coursewareUrl ) { %>
-                      <a class="action action-course" href="<%- coursewareUrl %>"><%- gettext( "Go to Course" ) %></a>
+              <% for ( var i = 0; i < receipt.items.length; i++ ) { %>
+                <% if ( receipt.isRefunded ) { %>
+                  <td><del><%- receipt.orderNum %></del></td>
+                  <td><del><%- receipt.items[i].lineDescription %></del></td>
+                  <td><del><%- receipt.purchasedDatetime %></del></td>
+                  <td><del><%- receipt.items[i].cost %> ($<%- receipt.currency.toUpperCase() %>)</del></td>
+                <% } else { %>
+                  <tr>
+                    <td><%- receipt.orderNum %></td>
+                    <td><%- receipt.items[i].lineDescription %></td>
+                    <td><%- receipt.purchasedDatetime %></td>
+                    <td><%- receipt.items[i].cost %> ($<%- receipt.currency.toUpperCase() %>)</td>
+                  </tr>
                 <% } %>
-                </td>
-              </tr>
+              <% } %>
             </tbody>
+
             <tfoot>
-              <tr class="course-actions">
-                <td colspan="3">
-                  <a class="action action-dashboard" href="/dashboard"><%- gettext("Go to your dashboard") %></a>
+              <tr>
+                <th scope="row" class="total-label" colspan="1"><%- gettext( "Total" ) %></th>
+                <td claass="total-value" colspan="3">
+                  <span class="value-amount"><%- receipt.totalCost %></span>
+                   <span class="value-currency">(<%- receipt.currency.toUpperCase() %>)</span>
                 </td>
               </tr>
             </tfoot>
           </table>
+
+          <% if ( receipt.isRefunded ) { %>
+          <div class="msg msg-refunds">
+            <h4 class="title sr"><%- gettext( "Please Note" ) %>: </h4>
+            <div class="copy">
+              <p><%- gettext( "Items with strikethough have been refunded." ) %></p>
+            </div>
+          </div>
+          <% } %>
         </div>
 
+        <div class="copy">
+          <p><%- gettext( "Billed To" ) %>:
+              <span class="name-first"><%- receipt.billedTo.firstName %></span>
+              <span class="name-last"><%- receipt.billedTo.lastName %></span>
+              (<span class="address-city"><%- receipt.billedTo.city %></span>,
+              <span class="address-state"><%- receipt.billedTo.state %></span>
+              <span class="address-postalcode"><%- receipt.billedTo.postalCode %></span>
+              <span class="address-country"><%- receipt.billedTo.country.toUpperCase() %></span>)
+          </p>
+        </div>
       </li>
     </ul>
+    <% } else { %>
+        <p><%- gettext( "No receipt available." ) %></p>
+    <% } %>
 
     <% if ( nextStepTitle ) { %>
     <nav class="nav-wizard is-ready">


### PR DESCRIPTION
- Add JSON end-point for shoppingcart receipt information
- Add enrollment confirmation page
- Fix progress update
- Add order info to the payment confirmation page.

I tried as much as possible to isolate `verify_student` from `shoppingcart`.  The step responsible for payment information uses a querystring param to find the order number; this will need to be set from the post pay callback redirect.  This step then queries the shopping cart to retrieve a JSON representation of the receipt, which it uses to render the page.

@rlucioni This also fixes the issue with the progress steps not being updated that you noticed yesterday.

Reviewers: @stephensanchez @rlucioni 
FYI: @dianakhuang @chrisndodge 
