### PR TITLE
Positive filtering which steps can be skipped.

### DIFF
--- a/lms/djangoapps/verify_student/tests/test_views.py
+++ b/lms/djangoapps/verify_student/tests/test_views.py
@@ -1241,6 +1241,30 @@ class TestPayAndVerifyView(UrlResetMixin, ModuleStoreTestCase):
             PayAndVerifyView.FACE_PHOTO_STEP,
         )
 
+    def test_payment_cannot_skip(self):
+        """
+         Simple test to verify that certain steps cannot be skipped. This test sets up
+         a scenario where the user should be on the MAKE_PAYMENT_STEP, but is trying to
+         skip it. Despite setting the parameter, the current step should still be
+         MAKE_PAYMENT_STEP.
+        """
+        course = self._create_course("verified")
+        response = self._get_page(
+            'verify_student_start_flow',
+            course.id,
+            skip_first_step=True
+        )
+
+        self._assert_messaging(response, PayAndVerifyView.FIRST_TIME_VERIFY_MSG)
+
+        # Expect that *all* steps are displayed,
+        # but we start on the first verify step
+        self._assert_steps_displayed(
+            response,
+            PayAndVerifyView.PAYMENT_STEPS + PayAndVerifyView.VERIFICATION_STEPS,
+            PayAndVerifyView.MAKE_PAYMENT_STEP,
+        )
+
     def test_payment_confirmation_already_verified(self):
         course = self._create_course("verified")
         self._enroll(course.id, "verified")

--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -259,6 +259,12 @@ class PayAndVerifyView(View):
         ENROLLMENT_CONFIRMATION_STEP
     ]
 
+    # These are steps that can be skipped, since there are no barring requirements.
+    SKIP_STEPS = [
+        INTRO_STEP,
+        PAYMENT_CONFIRMATION_STEP
+    ]
+
     Step = namedtuple(
         'Step',
         [
@@ -458,7 +464,8 @@ class PayAndVerifyView(View):
         # Allow the caller to skip the first page
         # This is useful if we want the user to be able to
         # use the "back" button to return to the previous step.
-        if request.GET.get('skip-first-step'):
+        # This parameter should only work for known skip-able steps
+        if request.GET.get('skip-first-step') and current_step in self.SKIP_STEPS:
             display_step_names = [step['name'] for step in display_steps]
             current_step_idx = display_step_names.index(current_step)
             if (current_step_idx + 1) < len(display_steps):


### PR DESCRIPTION
@wedaly @dianakhuang 

We should only allow certain steps to be skipped. I had noticed that you could put the skip parameter on the payment step and get to payment confirmation. 

This uses a positive filter to check which step you are trying to skip.

Test added to ensure you cannot skip the payment step (tests already exist for the positive steps)
