### PR TITLE
Content library permissions & collaboration (SOL-81)

### DIFF
--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -234,6 +234,7 @@ def xblock_view_handler(request, usage_key_string, view_name):
 
         elif view_name in (PREVIEW_VIEWS + container_views):
             is_pages_view = view_name == STUDENT_VIEW   # Only the "Pages" view uses student view in Studio
+            can_edit = has_studio_write_access(request.user, usage_key.course_key)
 
             # Determine the items to be shown as reorderable. Note that the view
             # 'reorderable_container_child_preview' is only rendered for xblocks that
@@ -266,6 +267,7 @@ def xblock_view_handler(request, usage_key_string, view_name):
             context = {
                 'is_pages_view': is_pages_view,     # This setting disables the recursive wrapping of xblocks
                 'is_unit_page': is_unit(xblock),
+                'can_edit': can_edit,
                 'root_xblock': xblock if (view_name == 'container_preview') else None,
                 'reorderable_items': reorderable_items,
                 'paging': paging,

--- a/cms/djangoapps/contentstore/views/library.py
+++ b/cms/djangoapps/contentstore/views/library.py
@@ -188,5 +188,6 @@ def library_blocks_view(library, user, response_format):
         'context_library': library,
         'component_templates': json.dumps(component_templates),
         'xblock_info': xblock_info,
-        'templates': CONTAINER_TEMPATES
+        'templates': CONTAINER_TEMPATES,
+        'lib_users_url': reverse_library_url('manage_library_users', unicode(library.location.library_key)),
     })

--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -226,6 +226,7 @@ def _studio_wrap_xblock(xblock, view, frag, context, display_name_only=False):
             'content': frag.content,
             'is_root': is_root,
             'is_reorderable': is_reorderable,
+            'can_edit': context.get('can_edit', True),
         }
         html = render_to_string('studio_xblock_wrapper.html', template_context)
         frag = wrap_fragment(frag, html)

--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -22,6 +22,7 @@ from xblock.runtime import KvsFieldData
 from xblock.django.request import webob_to_django_response, django_to_webob_request
 from xblock.exceptions import NoSuchHandlerError
 from xblock.fragment import Fragment
+from student.auth import has_studio_read_access, has_studio_write_access
 
 from lms.djangoapps.lms_xblock.field_data import LmsFieldData
 from cms.lib.xblock.field_data import CmsFieldData
@@ -124,6 +125,28 @@ class StudioUserService(object):
         return self._request.user.id
 
 
+class StudioPermissionsService(object):
+    """
+    Service that can provide information about a user's permissions.
+
+    Deprecated. To be replaced by a more general authorization service.
+
+    Only used by LibraryContentDescriptor (and library_tools.py).
+    """
+
+    def __init__(self, request):
+        super(StudioPermissionsService, self).__init__()
+        self._request = request
+
+    def can_read(self, course_key):
+        """ Does the user have read access to the given course/library? """
+        return has_studio_read_access(self._request.user, course_key)
+
+    def can_write(self, course_key):
+        """ Does the user have read access to the given course/library? """
+        return has_studio_write_access(self._request.user, course_key)
+
+
 def _preview_module_system(request, descriptor, field_data):
     """
     Returns a ModuleSystem for the specified descriptor that is specialized for
@@ -153,6 +176,7 @@ def _preview_module_system(request, descriptor, field_data):
     ]
 
     descriptor.runtime._services['user'] = StudioUserService(request)  # pylint: disable=protected-access
+    descriptor.runtime._services['studio_user_permissions'] = StudioPermissionsService(request)  # pylint: disable=protected-access
 
     return PreviewModuleSystem(
         static_url=settings.STATIC_URL,

--- a/cms/djangoapps/contentstore/views/tests/test_user.py
+++ b/cms/djangoapps/contentstore/views/tests/test_user.py
@@ -70,7 +70,7 @@ class UsersTestCase(CourseTestCase):
     def test_detail_post(self):
         resp = self.client.post(
             self.detail_url,
-            data={"role": None},
+            data={"role": ""},
         )
         self.assertEqual(resp.status_code, 204)
         # reload user from DB
@@ -218,7 +218,7 @@ class UsersTestCase(CourseTestCase):
             data={"role": "instructor"},
             HTTP_ACCEPT="application/json",
         )
-        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.status_code, 403)
         result = json.loads(resp.content)
         self.assertIn("error", result)
 
@@ -232,7 +232,7 @@ class UsersTestCase(CourseTestCase):
             data={"role": "instructor"},
             HTTP_ACCEPT="application/json",
         )
-        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.status_code, 403)
         result = json.loads(resp.content)
         self.assertIn("error", result)
 
@@ -255,7 +255,7 @@ class UsersTestCase(CourseTestCase):
         self.user.save()
 
         resp = self.client.delete(self.detail_url)
-        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.status_code, 403)
         result = json.loads(resp.content)
         self.assertIn("error", result)
         # reload user from DB

--- a/cms/djangoapps/contentstore/views/user.py
+++ b/cms/djangoapps/contentstore/views/user.py
@@ -9,11 +9,12 @@ from edxmako.shortcuts import render_to_response
 
 from xmodule.modulestore.django import modulestore
 from opaque_keys.edx.keys import CourseKey
+from opaque_keys.edx.locator import LibraryLocator
 from util.json_request import JsonResponse, expect_json
-from student.roles import CourseInstructorRole, CourseStaffRole
+from student.roles import CourseInstructorRole, CourseStaffRole, LibraryUserRole
 from course_creators.views import user_requested_access
 
-from student.auth import has_course_author_access
+from student.auth import STUDIO_EDIT_ROLES, STUDIO_VIEW_USERS, get_user_permissions
 
 from student.models import CourseEnrollment
 from django.http import HttpResponseNotFound
@@ -50,8 +51,7 @@ def course_team_handler(request, course_key_string=None, email=None):
         json: remove a particular course team member from the course team (email is required).
     """
     course_key = CourseKey.from_string(course_key_string) if course_key_string else None
-    if not has_course_author_access(request.user, course_key):
-        raise PermissionDenied()
+    # No permissions check here - each helper method does its own check.
 
     if 'application/json' in request.META.get('HTTP_ACCEPT', 'application/json'):
         return _course_team_user(request, course_key, email)
@@ -66,7 +66,8 @@ def _manage_users(request, course_key):
     This view will return all CMS users who are editors for the specified course
     """
     # check that logged in user has permissions to this item
-    if not has_course_author_access(request.user, course_key):
+    user_perms = get_user_permissions(request.user, course_key)
+    if not (user_perms & STUDIO_VIEW_USERS):
         raise PermissionDenied()
 
     course_module = modulestore().get_course(course_key)
@@ -78,7 +79,7 @@ def _manage_users(request, course_key):
         'context_course': course_module,
         'staff': staff,
         'instructors': instructors,
-        'allow_actions': has_course_author_access(request.user, course_key, role=CourseInstructorRole),
+        'allow_actions': bool(user_perms & STUDIO_EDIT_ROLES),
     })
 
 
@@ -88,17 +89,14 @@ def _course_team_user(request, course_key, email):
     Handle the add, remove, promote, demote requests ensuring the requester has authority
     """
     # check that logged in user has permissions to this item
-    if has_course_author_access(request.user, course_key, role=CourseInstructorRole):
-        # instructors have full permissions
-        pass
-    elif has_course_author_access(request.user, course_key, role=CourseStaffRole) and email == request.user.email:
-        # staff can only affect themselves
+    requester_perms = get_user_permissions(request.user, course_key)
+    permissions_error_response = JsonResponse({"error": _("Insufficient permissions")}, 403)
+    if (requester_perms & STUDIO_VIEW_USERS) or (email == request.user.email):
+        # This user has permissions to at least view the list of users or is editing themself
         pass
     else:
-        msg = {
-            "error": _("Insufficient permissions")
-        }
-        return JsonResponse(msg, 400)
+        # This user is not even allowed to know who the authorized users are.
+        return permissions_error_response
 
     try:
         user = User.objects.get(email=email)
@@ -108,7 +106,13 @@ def _course_team_user(request, course_key, email):
         }
         return JsonResponse(msg, 404)
 
-    # role hierarchy: globalstaff > "instructor" > "staff" (in a course)
+    is_library = isinstance(course_key, LibraryLocator)
+    # Ordered list of roles: can always move self to the right, but need STUDIO_EDIT_ROLES to move any user left
+    if is_library:
+        role_hierarchy = (CourseInstructorRole, CourseStaffRole, LibraryUserRole)
+    else:
+        role_hierarchy = (CourseInstructorRole, CourseStaffRole)
+
     if request.method == "GET":
         # just return info about the user
         msg = {
@@ -117,11 +121,16 @@ def _course_team_user(request, course_key, email):
             "role": None,
         }
         # what's the highest role that this user has? (How should this report global staff?)
-        for role in [CourseInstructorRole(course_key), CourseStaffRole(course_key)]:
-            if role.has_user(user):
+        for role in role_hierarchy:
+            if role(course_key).has_user(user):
                 msg["role"] = role.ROLE
                 break
         return JsonResponse(msg)
+
+    # All of the following code is for editing/promoting/deleting users.
+    # Check that the user has STUDIO_EDIT_ROLES permission or is editing themselves:
+    if not ((requester_perms & STUDIO_EDIT_ROLES) or (user.id == request.user.id)):
+        return permissions_error_response
 
     # can't modify an inactive user
     if not user.is_active:
@@ -131,60 +140,43 @@ def _course_team_user(request, course_key, email):
         return JsonResponse(msg, 400)
 
     if request.method == "DELETE":
-        try:
-            try_remove_instructor(request, course_key, user)
-        except CannotOrphanCourse as oops:
-            return JsonResponse(oops.msg, 400)
+        new_role = None
+    else:
+        # only other operation supported is to promote/demote a user by changing their role:
+        # role may be None or "" (equivalent to a DELETE request) but must be set.
+        # Check that the new role was specified:
+        if "role" in request.json or "role" in request.POST:
+            new_role = request.json.get("role", request.POST.get("role"))
+        else:
+            return JsonResponse({"error": _("No `role` specified.")}, 400)
 
-        auth.remove_users(request.user, CourseStaffRole(course_key), user)
-        return JsonResponse()
+    old_roles = set()
+    role_added = False
+    for role_type in role_hierarchy:
+        role = role_type(course_key)
+        if role_type.ROLE == new_role:
+            if (requester_perms & STUDIO_EDIT_ROLES) or (user.id == request.user.id and old_roles):
+                # User has STUDIO_EDIT_ROLES permission or is currently a member of a higher role, and is thus demoting themself
+                auth.add_users(request.user, role, user)
+                role_added = True
+            else:
+                return permissions_error_response
+        elif role.has_user(user):
+            # Remove the user from this old role:
+            old_roles.add(role)
 
-    # all other operations require the requesting user to specify a role
-    role = request.json.get("role", request.POST.get("role"))
-    if role is None:
-        return JsonResponse({"error": _("`role` is required")}, 400)
+    if new_role and not role_added:
+        return JsonResponse({"error": _("Invalid `role` specified.")}, 400)
 
-    if role == "instructor":
-        if not has_course_author_access(request.user, course_key, role=CourseInstructorRole):
-            msg = {
-                "error": _("Only instructors may create other instructors")
-            }
+    for role in old_roles:
+        if isinstance(role, CourseInstructorRole) and role.users_with_role().count() == 1:
+            msg = {"error": _("You may not remove the last Admin. Add another Admin first.")}
             return JsonResponse(msg, 400)
-        auth.add_users(request.user, CourseInstructorRole(course_key), user)
-        # auto-enroll the course creator in the course so that "View Live" will work.
-        CourseEnrollment.enroll(user, course_key)
-    elif role == "staff":
-        # add to staff regardless (can't do after removing from instructors as will no longer
-        # be allowed)
-        auth.add_users(request.user, CourseStaffRole(course_key), user)
-        try:
-            try_remove_instructor(request, course_key, user)
-        except CannotOrphanCourse as oops:
-            return JsonResponse(oops.msg, 400)
+        auth.remove_users(request.user, role, user)
 
-        # auto-enroll the course creator in the course so that "View Live" will work.
+    if new_role and not is_library:
+        # The user may be newly added to this course.
+        # auto-enroll the user in the course so that "View Live" will work.
         CourseEnrollment.enroll(user, course_key)
 
     return JsonResponse()
-
-
-class CannotOrphanCourse(Exception):
-    """
-    Exception raised if an attempt is made to remove all responsible instructors from course.
-    """
-    def __init__(self, msg):
-        self.msg = msg
-        Exception.__init__(self)
-
-
-def try_remove_instructor(request, course_key, user):
-
-    # remove all roles in this course from this user: but fail if the user
-    # is the last instructor in the course team
-    instructors = CourseInstructorRole(course_key)
-    if instructors.has_user(user):
-        if instructors.users_with_role().count() == 1:
-            msg = {"error": _("You may not remove the last instructor from a course")}
-            raise CannotOrphanCourse(msg)
-        else:
-            auth.remove_users(request.user, instructors, user)

--- a/cms/static/coffee/spec/main.coffee
+++ b/cms/static/coffee/spec/main.coffee
@@ -256,6 +256,7 @@ define([
     "js/spec/views/pages/course_outline_spec",
     "js/spec/views/pages/course_rerun_spec",
     "js/spec/views/pages/index_spec",
+    "js/spec/views/pages/library_users_spec",
 
     "js/spec/views/modals/base_modal_spec",
     "js/spec/views/modals/edit_xblock_spec",

--- a/cms/static/js/factories/library.js
+++ b/cms/static/js/factories/library.js
@@ -11,7 +11,8 @@ function($, _, XBlockInfo, PagedContainerPage, LibraryContainerView, ComponentTe
             model: new XBlockInfo(XBlockInfoJson, {parse: true}),
             templates: new ComponentTemplates(componentTemplates, {parse: true}),
             action: 'view',
-            viewClass: LibraryContainerView
+            viewClass: LibraryContainerView,
+            canEdit: true
         };
 
         xmoduleLoader.done(function () {

--- a/cms/static/js/factories/manage_users.js
+++ b/cms/static/js/factories/manage_users.js
@@ -32,7 +32,7 @@ define(['jquery', 'underscore', 'gettext', 'js/views/feedback_prompt'], function
                 msg = new PromptView.Warning({
                     title: gettext('Already a course team member'),
                     message: _.template(
-                        gettext("{email} is already on the “{course}” team. If you're trying to add a new member, please double-check the email address you provided."), {
+                        gettext("{email} is already on the {course} team. Recheck the email address if you want to add a new member."), {
                             email: email,
                             course: course.escape('name')
                         }, {interpolate: /\{(.+?)\}/g}

--- a/cms/static/js/factories/manage_users_lib.js
+++ b/cms/static/js/factories/manage_users_lib.js
@@ -67,7 +67,7 @@ function($, _, gettext, PromptView, ViewUtils) {
                 msg = new PromptView.Warning({
                     title: gettext('Already a library team member'),
                     message: _.template(
-                        gettext("{email} is already on the “{course}” team. If you're trying to add a new member, please double-check the email address you provided."), {
+                        gettext("{email} is already on the {course} team. Recheck the email address if you want to add a new member."), {
                             email: email,
                             course: libraryName
                         }, {interpolate: /\{(.+?)\}/g}

--- a/cms/static/js/factories/manage_users_lib.js
+++ b/cms/static/js/factories/manage_users_lib.js
@@ -1,0 +1,159 @@
+/*
+    Code for editing users and assigning roles within a library context.
+*/
+define(['jquery', 'underscore', 'gettext', 'js/views/feedback_prompt', 'js/views/utils/view_utils'],
+function($, _, gettext, PromptView, ViewUtils) {
+    'use strict';
+    return function (libraryName, allUserEmails, tplUserURL) {
+        var unknownErrorMessage = gettext('Unknown'),
+            $createUserForm = $('#create-user-form'),
+            $createUserFormWrapper = $createUserForm.closest('.wrapper-create-user'),
+            $cancelButton;
+
+        // Our helper method that calls the RESTful API to add/remove/change user roles:
+        var changeRole = function(email, newRole, opts) {
+            var url = tplUserURL.replace('@@EMAIL@@', email);
+            var errMessage = opts.errMessage || gettext("There was an error changing the user's role");
+            var onSuccess = opts.onSuccess || function(data){ ViewUtils.reload(); };
+            var onError = opts.onError || function(){};
+            $.ajax({
+                url: url,
+                type: newRole ? 'POST' : 'DELETE',
+                dataType: 'json',
+                contentType: 'application/json',
+                notifyOnError: false,
+                data: JSON.stringify({role: newRole}),
+                success: onSuccess,
+                error: function(jqXHR, textStatus, errorThrown) {
+                    var message, prompt;
+                    try {
+                        message = JSON.parse(jqXHR.responseText).error || unknownErrorMessage;
+                    } catch (e) {
+                        message = unknownErrorMessage;
+                    }
+                    prompt = new PromptView.Error({
+                        title: errMessage,
+                        message: message,
+                        actions: {
+                            primary: { text: gettext('OK'), click: function(view) { view.hide(); onError(); } }
+                        }
+                    });
+                    prompt.show();
+                }
+            });
+        };
+
+        $createUserForm.bind('submit', function(event) {
+            event.preventDefault();
+            var email = $('#user-email-input').val().trim();
+            var msg;
+
+            if(!email) {
+                msg = new PromptView.Error({
+                    title: gettext('A valid email address is required'),
+                    message: gettext('You must enter a valid email address in order to add an instructor'),
+                    actions: {
+                        primary: {
+                            text: gettext('Return and add email address'),
+                            click: function(view) { view.hide(); $('#user-email-input').focus(); }
+                        }
+                    }
+                });
+                msg.show();
+                return;
+            }
+
+            if(_.contains(allUserEmails, email)) {
+                msg = new PromptView.Warning({
+                    title: gettext('Already a library team member'),
+                    message: _.template(
+                        gettext("{email} is already on the “{course}” team. If you're trying to add a new member, please double-check the email address you provided."), {
+                            email: email,
+                            course: libraryName
+                        }, {interpolate: /\{(.+?)\}/g}
+                    ),
+                    actions: {
+                        primary: {
+                            text: gettext('Return to team listing'),
+                            click: function(view) { view.hide(); $('#user-email-input').focus(); }
+                        }
+                    }
+                });
+                msg.show();
+                return;
+            }
+
+            // Use the REST API to create the user, giving them a role of "library_user" for now:
+            changeRole(
+                $('#user-email-input').val().trim(),
+                'library_user',
+                {
+                    errMessage: gettext('Error adding user'),
+                    onError: function() { $('#user-email-input').focus(); }
+                }
+            );
+        });
+
+        $cancelButton = $createUserForm.find('.action-cancel');
+        $cancelButton.on('click', function(event) {
+            event.preventDefault();
+            $('.create-user-button').toggleClass('is-disabled');
+            $createUserFormWrapper.toggleClass('is-shown');
+            $('#user-email-input').val('');
+        });
+
+        $('.create-user-button').on('click', function(event) {
+            event.preventDefault();
+            $('.create-user-button').toggleClass('is-disabled');
+            $createUserFormWrapper.toggleClass('is-shown');
+            $createUserForm.find('#user-email-input').focus();
+        });
+
+        $('body').on('keyup', function(event) {
+            if(event.which == jQuery.ui.keyCode.ESCAPE && $createUserFormWrapper.is('.is-shown')) {
+                $cancelButton.click();
+            }
+        });
+
+        $('.remove-user').click(function() {
+            var email = $(this).closest('li[data-email]').data('email'),
+                msg = new PromptView.Warning({
+                    title: gettext('Are you sure?'),
+                    message: _.template(gettext('Are you sure you want to delete {email} from the library “{library}”?'), {email: email, library: libraryName}, {interpolate: /\{(.+?)\}/g}),
+                    actions: {
+                        primary: {
+                            text: gettext('Delete'),
+                            click: function(view) {
+                                // User the REST API to delete the user:
+                                changeRole(email, null, { errMessage: gettext('Error removing user') });
+                            }
+                        },
+                        secondary: {
+                            text: gettext('Cancel'),
+                            click: function(view) { view.hide(); }
+                        }
+                    }
+            });
+            msg.show();
+        });
+
+        $('.user-actions .make-instructor').click(function(event) {
+            event.preventDefault();
+            var email = $(this).closest('li[data-email]').data('email');
+            changeRole(email, 'instructor', {});
+        });
+
+        $('.user-actions .make-staff').click(function(event) {
+            event.preventDefault();
+            var email = $(this).closest('li[data-email]').data('email');
+            changeRole(email, 'staff', {});
+        });
+
+        $('.user-actions .make-user').click(function(event) {
+            event.preventDefault();
+            var email = $(this).closest('li[data-email]').data('email');
+            changeRole(email, 'library_user', {});
+        });
+
+    };
+});

--- a/cms/static/js/spec/views/modals/edit_xblock_spec.js
+++ b/cms/static/js/spec/views/modals/edit_xblock_spec.js
@@ -49,7 +49,7 @@ define(["jquery", "underscore", "js/common_helpers/ajax_helpers", "js/spec_helpe
                     var requests = AjaxHelpers.requests(this);
                     modal = showModal(requests, mockXBlockEditorHtml);
                     expect(modal.$('.action-save')).not.toBeVisible();
-                    expect(modal.$('.action-cancel').text()).toBe('OK');
+                    expect(modal.$('.action-cancel').text()).toBe('Close');
                 });
 
                 it('shows the correct title', function() {

--- a/cms/static/js/spec/views/pages/library_users_spec.js
+++ b/cms/static/js/spec/views/pages/library_users_spec.js
@@ -1,0 +1,78 @@
+define([
+    "jquery", "js/common_helpers/ajax_helpers", "js/spec_helpers/view_helpers",
+    "js/factories/manage_users_lib", "js/views/utils/view_utils"
+],
+function ($, AjaxHelpers, ViewHelpers, ManageUsersFactory, ViewUtils) {
+    "use strict";
+    describe("Library Instructor Access Page", function () {
+        var mockHTML = readFixtures('mock/mock-manage-users-lib.underscore');
+
+        beforeEach(function () {
+            ViewHelpers.installMockAnalytics();
+            appendSetFixtures(mockHTML);
+            ManageUsersFactory(
+                "Mock Library",
+                ["honor@example.com", "audit@example.com", "staff@example.com"],
+                "dummy_change_role_url"
+            );
+        });
+
+        afterEach(function () {
+            ViewHelpers.removeMockAnalytics();
+        });
+
+        it("can give a user permission to use the library", function () {
+            var requests = AjaxHelpers.requests(this);
+            var reloadSpy = spyOn(ViewUtils, 'reload');
+            $('.create-user-button').click();
+            expect($('.wrapper-create-user')).toHaveClass('is-shown');
+            $('.user-email-input').val('other@example.com');
+            $('.form-create.create-user .action-primary').click();
+            AjaxHelpers.expectJsonRequest(requests, 'POST', 'dummy_change_role_url', {role: 'library_user'});
+            AjaxHelpers.respondWithJson(requests, {'result': 'ok'});
+            expect(reloadSpy).toHaveBeenCalled();
+        });
+
+        it("can cancel adding a user to the library", function () {
+            $('.create-user-button').click();
+            $('.form-create.create-user .action-secondary').click();
+            expect($('.wrapper-create-user')).not.toHaveClass('is-shown');
+        });
+
+        it("displays an error when the required field is blank", function () {
+            var requests = AjaxHelpers.requests(this);
+            $('.create-user-button').click();
+            $('.user-email-input').val('');
+            var errorPromptSelector = '.wrapper-prompt.is-shown .prompt.error';
+            expect($(errorPromptSelector).length).toEqual(0);
+            $('.form-create.create-user .action-primary').click();
+            expect($(errorPromptSelector).length).toEqual(1);
+            expect($(errorPromptSelector)).toContainText('You must enter a valid email address');
+            expect(requests.length).toEqual(0);
+        });
+
+        it("displays an error when the user has already been added", function () {
+            var requests = AjaxHelpers.requests(this);
+            $('.create-user-button').click();
+            $('.user-email-input').val('honor@example.com');
+            var warningPromptSelector = '.wrapper-prompt.is-shown .prompt.warning';
+            expect($(warningPromptSelector).length).toEqual(0);
+            $('.form-create.create-user .action-primary').click();
+            expect($(warningPromptSelector).length).toEqual(1);
+            expect($(warningPromptSelector)).toContainText('Already a library team member');
+            expect(requests.length).toEqual(0);
+        });
+
+
+        it("can remove a user's permission to access the library", function () {
+            var requests = AjaxHelpers.requests(this);
+            var reloadSpy = spyOn(ViewUtils, 'reload');
+            $('.user-item[data-email="honor@example.com"] .action-delete .delete').click();
+            expect($('.wrapper-prompt.is-shown .prompt.warning').length).toEqual(1);
+            $('.wrapper-prompt.is-shown .action-primary').click();
+            AjaxHelpers.expectJsonRequest(requests, 'DELETE', 'dummy_change_role_url', {role: null});
+            AjaxHelpers.respondWithJson(requests, {'result': 'ok'});
+            expect(reloadSpy).toHaveBeenCalled();
+        });
+    });
+});

--- a/cms/static/js/views/modals/edit_xblock.js
+++ b/cms/static/js/views/modals/edit_xblock.js
@@ -65,7 +65,8 @@ define(["jquery", "underscore", "gettext", "js/views/modals/base_modal", "js/vie
 
             onDisplayXBlock: function() {
                 var editorView = this.editorView,
-                    title = this.getTitle();
+                    title = this.getTitle(),
+                    readOnlyView = (this.editOptions && this.editOptions.readOnlyView) || !editorView.xblock.save;
 
                 // Notify the runtime that the modal has been shown
                 editorView.notifyRuntime('modal-shown', this);
@@ -88,7 +89,7 @@ define(["jquery", "underscore", "gettext", "js/views/modals/base_modal", "js/vie
                 // If the xblock is not using custom buttons then choose which buttons to show
                 if (!editorView.hasCustomButtons()) {
                     // If the xblock does not support save then disable the save button
-                    if (!editorView.xblock.save) {
+                    if (readOnlyView) {
                         this.disableSave();
                     }
                     this.getActionBar().show();
@@ -101,8 +102,8 @@ define(["jquery", "underscore", "gettext", "js/views/modals/base_modal", "js/vie
             disableSave: function() {
                 var saveButton = this.getActionButton('save'),
                     cancelButton = this.getActionButton('cancel');
-                saveButton.hide();
-                cancelButton.text(gettext('OK'));
+                saveButton.parent().hide();
+                cancelButton.text(gettext('Close'));
                 cancelButton.addClass('action-primary');
             },
 

--- a/cms/static/js/views/paged_container.js
+++ b/cms/static/js/views/paged_container.js
@@ -53,7 +53,6 @@ define(["jquery", "underscore", "js/views/container", "js/utils/module", "gettex
                         self.handleXBlockFragment(fragment, options);
                         self.processPaging({ requested_page: options.page_number });
                         self.page.renderAddXBlockComponents();
-                        self.page.updateBlockActions();
                     }
                 });
             },

--- a/cms/static/js/views/paged_container.js
+++ b/cms/static/js/views/paged_container.js
@@ -52,7 +52,8 @@ define(["jquery", "underscore", "js/views/container", "js/utils/module", "gettex
                     success: function(fragment) {
                         self.handleXBlockFragment(fragment, options);
                         self.processPaging({ requested_page: options.page_number });
-                        self.page.renderAddXBlockComponents()
+                        self.page.renderAddXBlockComponents();
+                        self.page.updateBlockActions();
                     }
                 });
             },

--- a/cms/static/js/views/pages/container.js
+++ b/cms/static/js/views/pages/container.js
@@ -140,7 +140,6 @@ define(["jquery", "underscore", "gettext", "js/views/pages/base_page", "js/views
 
             onXBlockRefresh: function(xblockView, block_added) {
                 this.xblockView.refresh(block_added);
-                this.updateBlockActions();
                 // Update publish and last modified information from the server.
                 this.model.fetch();
             },
@@ -161,12 +160,6 @@ define(["jquery", "underscore", "gettext", "js/views/pages/base_page", "js/views
                 }
             },
 
-            updateBlockActions: function() {
-                if (!this.options.canEdit) {
-                    this.xblockView.$el.find('.action-duplicate, .action-delete, .action-drag').remove();
-                }
-            },
-
             editXBlock: function(event) {
                 var xblockElement = this.findXBlockElement(event.target),
                     self = this,
@@ -174,6 +167,7 @@ define(["jquery", "underscore", "gettext", "js/views/pages/base_page", "js/views
                 event.preventDefault();
 
                 modal.edit(xblockElement, this.model, {
+                    readOnlyView: !this.options.canEdit,
                     refresh: function() {
                         self.refreshXBlock(xblockElement, false);
                     }

--- a/cms/static/js/views/pages/container.js
+++ b/cms/static/js/views/pages/container.js
@@ -20,7 +20,8 @@ define(["jquery", "underscore", "gettext", "js/views/pages/base_page", "js/views
             },
 
             options: {
-                collapsedClass: 'is-collapsed'
+                collapsedClass: 'is-collapsed',
+                canEdit: true // If not specified, assume user has permission to make changes
             },
 
             view: 'container_preview',
@@ -113,9 +114,8 @@ define(["jquery", "underscore", "gettext", "js/views/pages/base_page", "js/views
                         // Notify the runtime that the page has been successfully shown
                         xblockView.notifyRuntime('page-shown', self);
 
-                        // Render the add buttons. Paged containers should do this on their own.
                         if (self.components_on_init) {
-                            // Render the add buttons
+                            // Render the add buttons. Paged containers should do this on their own.
                             self.renderAddXBlockComponents();
                         }
 
@@ -140,20 +140,31 @@ define(["jquery", "underscore", "gettext", "js/views/pages/base_page", "js/views
 
             onXBlockRefresh: function(xblockView, block_added) {
                 this.xblockView.refresh(block_added);
+                this.updateBlockActions();
                 // Update publish and last modified information from the server.
                 this.model.fetch();
             },
 
             renderAddXBlockComponents: function() {
                 var self = this;
-                this.$('.add-xblock-component').each(function(index, element) {
-                    var component = new AddXBlockComponent({
-                        el: element,
-                        createComponent: _.bind(self.createComponent, self),
-                        collection: self.options.templates
+                if (self.options.canEdit) {
+                    this.$('.add-xblock-component').each(function(index, element) {
+                        var component = new AddXBlockComponent({
+                            el: element,
+                            createComponent: _.bind(self.createComponent, self),
+                            collection: self.options.templates
+                        });
+                        component.render();
                     });
-                    component.render();
-                });
+                } else {
+                    this.$('.add-xblock-component').remove();
+                }
+            },
+
+            updateBlockActions: function() {
+                if (!this.options.canEdit) {
+                    this.xblockView.$el.find('.action-duplicate, .action-delete, .action-drag').remove();
+                }
             },
 
             editXBlock: function(event) {

--- a/cms/static/sass/views/_dashboard.scss
+++ b/cms/static/sass/views/_dashboard.scss
@@ -495,25 +495,20 @@
       .metadata-item {
         display: inline-block;
 
-        &:after {
+        & + .metadata-item:before {
           content: "/";
           margin-left: ($baseline/10);
           margin-right: ($baseline/10);
           color: $gray-l4;
         }
 
-        &:last-child {
-
-          &:after {
-            content: "";
-            margin-left: 0;
-            margin-right: 0;
-          }
-        }
-
         .label {
           @extend %cont-text-sr;
         }
+      }
+
+      .extra-metadata {
+        margin-left: ($baseline/10);
       }
     }
 

--- a/cms/static/sass/views/_users.scss
+++ b/cms/static/sass/views/_users.scss
@@ -116,11 +116,16 @@
         &.flag-role-admin {
           background: $pink;
         }
+
+        &.flag-role-user {
+          background: $yellow-d1;
+          .msg-you { color: $yellow-l1; }
+        }
       }
 
       // ELEM: item - metadata
       .item-metadata {
-        width: flex-grid(5, 9);
+        width: flex-grid(4, 9);
         @include margin-right(flex-gutter());
 
         .user-username, .user-email {
@@ -143,7 +148,7 @@
 
       // ELEM: item - actions
       .item-actions {
-        width: flex-grid(4, 9);
+        width: flex-grid(5, 9);
         position: static; // nasty reset needed due to base.scss
         text-align: right;
 
@@ -153,12 +158,34 @@
         }
 
         .action-role {
-          width: flex-grid(3, 4);
+          width: flex-grid(7, 8);
           margin-right: flex-gutter();
+
+          .add-admin-role {
+            @include blue-button;
+            @include transition(all .15s);
+            @extend %t-action2;
+            @extend %t-strong;
+            display: inline-block;
+            padding: ($baseline/5) $baseline;
+          }
+
+          .remove-admin-role {
+            @include grey-button;
+            @include transition(all .15s);
+            @extend %t-action2;
+            @extend %t-strong;
+            display: inline-block;
+            padding: ($baseline/5) $baseline;
+          }
+          .notoggleforyou {
+            @extend %t-copy-sub1;
+            color: $gray-l2;
+          }
         }
 
         .action-delete {
-          width: flex-grid(1, 4);
+          width: flex-grid(1, 8);
 
           // STATE: disabled
           &.is-disabled {
@@ -177,33 +204,6 @@
           margin-right: 0;
           float: none;
           color: inherit;
-        }
-
-        // ELEM: admin role controls
-        .toggle-admin-role {
-
-          &.add-admin-role {
-            @include blue-button;
-            @include transition(all .15s);
-            @extend %t-action2;
-            @extend %t-strong;
-            display: inline-block;
-            padding: ($baseline/5) $baseline;
-          }
-
-          &.remove-admin-role {
-            @include grey-button;
-            @include transition(all .15s);
-            @extend %t-action2;
-            @extend %t-strong;
-            display: inline-block;
-            padding: ($baseline/5) $baseline;
-          }
-        }
-
-        .notoggleforyou {
-          @extend %t-copy-sub1;
-          color: $gray-l2;
         }
       }
 

--- a/cms/templates/container.html
+++ b/cms/templates/container.html
@@ -33,7 +33,8 @@ from django.utils.translation import ugettext as _
             ${component_templates | n}, ${json.dumps(xblock_info) | n},
             "${action}",
             {
-                isUnitPage: ${json.dumps(is_unit_page)}
+                isUnitPage: ${json.dumps(is_unit_page)},
+                canEdit: true
             }
         );
     });

--- a/cms/templates/index.html
+++ b/cms/templates/index.html
@@ -456,6 +456,9 @@
                   <span class="label">${_("Course Number:")}</span>
                   <span class="value">${library_info['number']}</span>
                 </span>
+                % if not library_info["can_edit"]:
+                  <span class="extra-metadata">${_("(Read-only)")}</span>
+                % endif
               </div>
             </a>
           </li>

--- a/cms/templates/js/mock/mock-manage-users-lib.underscore
+++ b/cms/templates/js/mock/mock-manage-users-lib.underscore
@@ -1,0 +1,146 @@
+<div class="wrapper-mast wrapper">
+  <header class="mast has-actions has-subtitle">
+    <h1 class="page-header">
+      <small class="subtitle">Settings</small>
+      <span class="sr">&gt; </span>Instructor Access
+    </h1>
+
+    <nav class="nav-actions">
+      <h3 class="sr">Page Actions</h3>
+      <ul>
+        <li class="nav-item">
+          <a href="#" class="button new-button create-user-button"><i class="icon-plus"></i> Add Instructor</a>
+        </li>
+      </ul>
+    </nav>
+  </header>
+</div>
+
+<div class="wrapper-content wrapper">
+  <section class="content">
+    <article class="content-primary" role="main">
+      <div class="wrapper-create-element animate wrapper-create-user">
+        <form class="form-create create-user" id="create-user-form" name="create-user-form">
+          <div class="wrapper-form">
+            <h3 class="title">Grant Instructor Access to This Library</h3>
+
+            <fieldset class="form-fields">
+              <legend class="sr">New Instructor Information</legend>
+
+                <ol class="list-input">
+                  <li class="field text required create-user-email">
+                    <label for="user-email-input">User's Email Address</label>
+                    <input id="user-email-input" class="user-email-input" name="user-email" type="text" placeholder="example: username@domain.com" value="">
+                    <span class="tip tip-stacked">Please provide the email address of the instructor you'd like to add</span>
+                  </li>
+                </ol>
+            </fieldset>
+          </div>
+
+          <div class="actions">
+            <button class="action action-primary" type="submit">Add User</button>
+            <button class="action action-secondary action-cancel">Cancel</button>
+          </div>
+        </form>
+      </div>
+
+      <ol class="user-list">
+
+        <li class="user-item" data-email="honor@example.com">
+
+          <span class="wrapper-ui-badge">
+            <span class="flag flag-role flag-role-staff is-hanging">
+              <span class="label sr">Current Role:</span>
+              <span class="value">
+                Staff
+              </span>
+            </span>
+          </span>
+
+          <div class="item-metadata">
+            <h3 class="user-name">
+              <span class="user-username">honor</span>
+              <span class="user-email">
+                <a class="action action-email" href="mailto:honor@example.com" title="send an email message to honor@example.com">honor@example.com</a>
+              </span>
+            </h3>
+          </div>
+
+          <ul class="item-actions user-actions">
+              <li class="action action-role">
+                <a href="#" class="make-instructor admin-role add-admin-role">Add Admin Access</span></a>
+                <a href="#" class="make-user admin-role remove-admin-role">Remove Staff Access</span></a>
+              </li>
+            <li class="action action-delete ">
+                <a href="#" class="delete remove-user action-icon" data-tooltip="Remove this user"><i class="icon-trash"></i><span class="sr">Delete the user, honor</span></a>
+            </li>
+          </ul>
+
+        </li>
+
+        <li class="user-item" data-email="audit@example.com">
+
+          <span class="wrapper-ui-badge">
+            <span class="flag flag-role flag-role-admin is-hanging">
+              <span class="label sr">Current Role:</span>
+              <span class="value">
+                Admin
+              </span>
+            </span>
+          </span>
+
+          <div class="item-metadata">
+            <h3 class="user-name">
+              <span class="user-username">audit</span>
+              <span class="user-email">
+                <a class="action action-email" href="mailto:audit@example.com" title="send an email message to audit@example.com">audit@example.com</a>
+              </span>
+            </h3>
+          </div>
+
+          <ul class="item-actions user-actions">
+                <li class="action action-role">
+                  <a href="#" class="make-staff admin-role remove-admin-role">Remove Admin Access</span></a>
+                </li>
+            <li class="action action-delete ">
+                <a href="#" class="delete remove-user action-icon" data-tooltip="Remove this user"><i class="icon-trash"></i><span class="sr">Delete the user, audit</span></a>
+            </li>
+          </ul>
+
+        </li>
+
+        <li class="user-item" data-email="staff@example.com">
+
+          <span class="wrapper-ui-badge">
+            <span class="flag flag-role flag-role-user is-hanging">
+              <span class="label sr">Current Role:</span>
+              <span class="value">
+                User
+              </span>
+            </span>
+          </span>
+
+          <div class="item-metadata">
+            <h3 class="user-name">
+              <span class="user-username">staff</span>
+              <span class="user-email">
+                <a class="action action-email" href="mailto:staff@example.com" title="send an email message to staff@example.com">staff@example.com</a>
+              </span>
+            </h3>
+          </div>
+
+          <ul class="item-actions user-actions">
+              <li class="action action-role">
+                <a href="#" class="make-staff admin-role add-admin-role">Add Staff Access</span></a>
+              </li>
+            <li class="action action-delete ">
+                <a href="#" class="delete remove-user action-icon" data-tooltip="Remove this user"><i class="icon-trash"></i><span class="sr">Delete the user, staff</span></a>
+            </li>
+          </ul>
+
+        </li>
+      </ol>
+
+    </article>
+  </section>
+</div>

--- a/cms/templates/js/system-feedback.underscore
+++ b/cms/templates/js/system-feedback.underscore
@@ -4,6 +4,7 @@
      id="<%= type %>-<%= intent %>"
      aria-hidden="<% if(obj.shown) { %>false<% } else { %>true<% } %>"
      aria-labelledby="<%= type %>-<%= intent %>-title"
+     tabindex="-1"
      <% if (obj.message) { %>aria-describedby="<%= type %>-<%= intent %>-description" <% } %>
      <% if (obj.actions) { %>role="dialog"<% } %>
   >

--- a/cms/templates/library.html
+++ b/cms/templates/library.html
@@ -22,10 +22,12 @@ from django.utils.translation import ugettext as _
 <%block name="requirejs">
     require(["js/factories/library"], function(LibraryFactory) {
         LibraryFactory(
-            ${component_templates | n}, ${json.dumps(xblock_info) | n},
+            ${component_templates | n},
+            ${json.dumps(xblock_info) | n},
             {
                 isUnitPage: false,
-                page_size: 10
+                page_size: 10,
+                canEdit: ${"true" if can_edit else "false"}
             }
         );
     });
@@ -65,10 +67,12 @@ from django.utils.translation import ugettext as _
                         </p>
                     </div>
                 </div>
+                % if can_edit:
                 <div class="bit">
                     <h3 class="title-3">${_("Adding content components")}</h3>
                     <p>${_("You can add components to the library. Help text here.")}</p>
                 </div>
+                % endif
                 <div class="bit external-help">
                     <a href="${get_online_help_info('library')['doc_url']}" target="_blank" class="button external-help-button">${_("Learn more about content libraries")}</a>
                 </div>

--- a/cms/templates/manage_users_lib.html
+++ b/cms/templates/manage_users_lib.html
@@ -44,7 +44,7 @@
                   <li class="field text required create-user-email">
                     <label for="user-email-input">${_("User's Email Address")}</label>
                     <input id="user-email-input" class="user-email-input" name="user-email" type="text" placeholder="${_('example: username@domain.com')}" value="">
-                    <span class="tip tip-stacked">${_("Please provide the email address of the user you'd like to add")}</span>
+                    <span class="tip tip-stacked">${_("Provide the email address of the user you want to add")}</span>
                   </li>
                 </ol>
             </fieldset>
@@ -99,7 +99,7 @@
                 </li>
               % else:
                 <li class="action action-role">
-                  <span class="admin-role notoggleforyou">${_("Promote another member to Admin to remove admin rights")}</span>
+                  <span class="admin-role notoggleforyou">${_("Promote another member to Admin to remove your admin rights")}</span>
                 </li>
               % endif
             % elif is_staff:
@@ -133,7 +133,7 @@
         <div class="msg">
           <h3 class="title">${_('Add More Users to This Library')}</h3>
           <div class="copy">
-            <p>${_('Adding team members makes content authoring collaborative. Users must be signed up for Studio and have an active account. ')}</p>
+            <p>${_('Grant other members of your course team access to this library. New library users must have an active {studio_name} account.').format(studio_name=settings.STUDIO_SHORT_NAME)}</p>
           </div>
         </div>
 
@@ -149,22 +149,11 @@
     <aside class="content-supplementary" role="complimentary">
       <div class="bit">
         <h3 class="title-3">${_("Library Access Roles")}</h3>
-        <p>${_("Library staff are content co-authors. They have full writing and editing privileges on all content in the library.")}</p>
-        <p>${_("Admins are library team members who can also add and remove other team members.")}</p>
-        <p>${_("Library users cannot edit content in the library, but can view the content and are able to reference or use library elements in their own courses.")}</p>
+        <p>${_("There are three access roles for libraries: User, Staff, and Admin.")}</p>
+        <p>${_("Users can view library content and can reference or use library components in their courses, but they cannot edit the contents of a library.")}</p>
+        <p>${_("Staff are content co-authors. They have full editing privileges on the contents of a library.")}</p>
+        <p>${_("Admins have full editing privileges and can also add and remove other team members. There must be at least one user with Admin privileges in a library.")}</p>
       </div>
-
-      <div class="bit">
-        <h3 class="title-3">${_("Organization-Wide Access")}</h3>
-        <p>${_("Users who have been granted admin, staff, or user access at the organization level may not be listed here but will still have access to this library.")}</p>
-      </div>
-
-      % if allow_actions:
-      <div class="bit">
-        <h3 class="title-3">${_("Transferring Ownership")}</h3>
-        <p>${_("Every library must have an Admin. If you're the Admin and you want transfer ownership of the library, click Add admin access to make another user the Admin, then ask that user to remove you from the library admin list.")}</p>
-      </div>
-      % endif
     </aside>
   </section>
 </div>

--- a/cms/templates/manage_users_lib.html
+++ b/cms/templates/manage_users_lib.html
@@ -1,0 +1,181 @@
+<%! import json %>
+<%! from django.utils.translation import ugettext as _ %>
+<%! from django.core.urlresolvers import reverse %>
+<%inherit file="base.html" />
+<%def name="online_help_token()"><% return "team" %></%def>
+<%block name="title">${_("Library User Access")}</%block>
+<%block name="bodyclass">is-signedin course users view-team</%block>
+
+<%block name="content">
+
+<div class="wrapper-mast wrapper">
+  <header class="mast has-actions has-subtitle">
+    <h1 class="page-header">
+      <small class="subtitle">${_("Settings")}</small>
+      <span class="sr">&gt; </span>${_("User Access")}
+    </h1>
+
+    <nav class="nav-actions">
+      <h3 class="sr">${_("Page Actions")}</h3>
+      <ul>
+        %if allow_actions:
+        <li class="nav-item">
+          <a href="#" class="button new-button create-user-button"><i class="icon-plus"></i> ${_("New Team Member")}</a>
+        </li>
+        %endif
+      </ul>
+    </nav>
+  </header>
+</div>
+
+<div class="wrapper-content wrapper">
+  <section class="content">
+    <article class="content-primary" role="main">
+      %if allow_actions:
+      <div class="wrapper-create-element animate wrapper-create-user">
+        <form class="form-create create-user" id="create-user-form" name="create-user-form">
+          <div class="wrapper-form">
+            <h3 class="title">${_("Grant Access to This Library")}</h3>
+
+            <fieldset class="form-fields">
+              <legend class="sr">${_("New Team Member Information")}</legend>
+
+                <ol class="list-input">
+                  <li class="field text required create-user-email">
+                    <label for="user-email-input">${_("User's Email Address")}</label>
+                    <input id="user-email-input" class="user-email-input" name="user-email" type="text" placeholder="${_('example: username@domain.com')}" value="">
+                    <span class="tip tip-stacked">${_("Please provide the email address of the user you'd like to add")}</span>
+                  </li>
+                </ol>
+            </fieldset>
+          </div>
+
+          <div class="actions">
+            <button class="action action-primary" type="submit">${_("Add User")}</button>
+            <button class="action action-secondary action-cancel">${_("Cancel")}</button>
+          </div>
+        </form>
+      </div>
+      %endif
+
+      <ol class="user-list">
+        % for user in all_users:
+          <%
+          is_instructor = user in instructors
+          is_staff = user in staff
+          role_id = 'admin' if is_instructor else ('staff' if is_staff else 'user')
+          role_desc = _("Admin") if is_instructor else (_("Staff") if is_staff else _("User"))
+          %>
+
+        <li class="user-item" data-email="${user.email}">
+
+          <span class="wrapper-ui-badge">
+            <span class="flag flag-role flag-role-${role_id} is-hanging">
+              <span class="label sr">${_("Current Role:")}</span>
+              <span class="value">
+                ${role_desc}
+                % if request.user.id == user.id:
+                    <span class="msg-you">${_("You!")}</span>
+                % endif
+              </span>
+            </span>
+          </span>
+
+          <div class="item-metadata">
+            <h3 class="user-name">
+              <span class="user-username">${user.username}</span>
+              <span class="user-email">
+                <a class="action action-email" href="mailto:${user.email}" title="${_("send an email message to {email}").format(email=user.email)}">${user.email}</a>
+              </span>
+            </h3>
+          </div>
+
+          % if allow_actions:
+          <ul class="item-actions user-actions">
+            % if is_instructor:
+              % if len(instructors) > 1:
+                <li class="action action-role">
+                  <a href="#" class="make-staff admin-role remove-admin-role">${_("Remove Admin Access")}</span></a>
+                </li>
+              % else:
+                <li class="action action-role">
+                  <span class="admin-role notoggleforyou">${_("Promote another member to Admin to remove admin rights")}</span>
+                </li>
+              % endif
+            % elif is_staff:
+              <li class="action action-role">
+                <a href="#" class="make-instructor admin-role add-admin-role">${_("Add Admin Access")}</span></a>
+                <a href="#" class="make-user admin-role remove-admin-role">${_("Remove Staff Access")}</span></a>
+              </li>
+            % else:
+              <li class="action action-role">
+                <a href="#" class="make-staff admin-role add-admin-role">${_("Add Staff Access")}</span></a>
+              </li>
+            % endif
+            <li class="action action-delete ${"is-disabled" if request.user.id == user.id and is_instructor and len(instructors) == 1 else ""}">
+                <a href="#" class="delete remove-user action-icon" data-tooltip="${_("Remove this user")}"><i class="icon-trash"></i><span class="sr">${_("Delete the user, {username}").format(username=user.username)}</span></a>
+            </li>
+          </ul>
+          % elif request.user.id == user.id:
+          <ul class="item-actions user-actions">
+            <li class="action action-delete">
+                <a href="#" class="delete remove-user action-icon" data-tooltip="${_("Remove me")}"><i class="icon-trash"></i><span class="sr">${_("Remove me from this library")}</span></a>
+            </li>
+          </ul>
+          % endif
+
+        </li>
+        % endfor
+      </ol>
+
+      % if allow_actions and len(all_users) == 1:
+      <div class="notice notice-incontext notice-create has-actions">
+        <div class="msg">
+          <h3 class="title">${_('Add More Users to This Library')}</h3>
+          <div class="copy">
+            <p>${_('Adding team members makes content authoring collaborative. Users must be signed up for Studio and have an active account. ')}</p>
+          </div>
+        </div>
+
+        <ul class="list-actions">
+          <li class="action-item">
+            <a href="#" class="action action-primary button new-button create-user-button"><i class="icon-plus icon-inline"></i> ${_('Add a New User')}</a>
+          </li>
+        </ul>
+      </div>
+      %endif
+    </article>
+
+    <aside class="content-supplementary" role="complimentary">
+      <div class="bit">
+        <h3 class="title-3">${_("Library Access Roles")}</h3>
+        <p>${_("Library staff are content co-authors. They have full writing and editing privileges on all content in the library.")}</p>
+        <p>${_("Admins are library team members who can also add and remove other team members.")}</p>
+        <p>${_("Library users cannot edit content in the library, but can view the content and are able to reference or use library elements in their own courses.")}</p>
+      </div>
+
+      <div class="bit">
+        <h3 class="title-3">${_("Organization-Wide Access")}</h3>
+        <p>${_("Users who have been granted admin, staff, or user access at the organization level may not be listed here but will still have access to this library.")}</p>
+      </div>
+
+      % if allow_actions:
+      <div class="bit">
+        <h3 class="title-3">${_("Transferring Ownership")}</h3>
+        <p>${_("Every library must have an Admin. If you're the Admin and you want transfer ownership of the library, click Add admin access to make another user the Admin, then ask that user to remove you from the library admin list.")}</p>
+      </div>
+      % endif
+    </aside>
+  </section>
+</div>
+</%block>
+
+<%block name="requirejs">
+  require(["js/factories/manage_users_lib"], function(ManageUsersFactory) {
+      ManageUsersFactory(
+        "${context_library.display_name_with_default | h}",
+        ${json.dumps([user.email for user in all_users])},
+        "${reverse('contentstore.views.course_team_handler', kwargs={'course_key_string': library_key, 'email': '@@EMAIL@@'})}"
+      );
+  });
+</%block>

--- a/cms/templates/studio_xblock_wrapper.html
+++ b/cms/templates/studio_xblock_wrapper.html
@@ -55,29 +55,37 @@ messages = json.dumps(xblock.validate().to_json())
         <div class="header-actions">
             <ul class="actions-list">
                 % if not is_root:
-                    % if not show_inline:
-                        <li class="action-item action-edit">
+                    % if can_edit:
+                        % if not show_inline:
+                            <li class="action-item action-edit">
+                                <a href="#" class="edit-button action-button">
+                                    <i class="icon-pencil"></i>
+                                    <span class="action-button-text">${_("Edit")}</span>
+                                </a>
+                            </li>
+                            <li class="action-item action-duplicate">
+                                <a href="#" data-tooltip="${_("Duplicate")}" class="duplicate-button action-button">
+                                <i class="icon-copy"></i>
+                                <span class="sr">${_("Duplicate")}</span>
+                                </a>
+                            </li>
+                        % endif
+                        <li class="action-item action-delete">
+                            <a href="#" data-tooltip="${_("Delete")}" class="delete-button action-button">
+                            <i class="icon-trash"></i>
+                            <span class="sr">${_("Delete")}</span>
+                            </a>
+                        </li>
+                        % if is_reorderable:
+                            <li class="action-item action-drag">
+                                <span data-tooltip="${_('Drag to reorder')}" class="drag-handle action"></span>
+                            </li>
+                        % endif
+                    % elif not show_inline:
+                        <li class="action-item action-edit action-edit-view-only">
                             <a href="#" class="edit-button action-button">
-                                <i class="icon-pencil"></i>
-                                <span class="action-button-text">${_("Edit")}</span>
+                                <span class="action-button-text">${_("Details")}</span>
                             </a>
-                        </li>
-                        <li class="action-item action-duplicate">
-                            <a href="#" data-tooltip="${_("Duplicate")}" class="duplicate-button action-button">
-                            <i class="icon-copy"></i>
-                            <span class="sr">${_("Duplicate")}</span>
-                            </a>
-                        </li>
-                    % endif
-                    <li class="action-item action-delete">
-                        <a href="#" data-tooltip="${_("Delete")}" class="delete-button action-button">
-                        <i class="icon-trash"></i>
-                        <span class="sr">${_("Delete")}</span>
-                        </a>
-                    </li>
-                    % if is_reorderable:
-                        <li class="action-item action-drag">
-                            <span data-tooltip="${_('Drag to reorder')}" class="drag-handle action"></span>
                         </li>
                     % endif
                 % endif

--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -39,7 +39,7 @@
       </h2>
 
       <nav class="nav-course nav-dd ui-left">
-        <h2 class="sr">${_("{course_name}'s Navigation:").format(course_name=context_course.display_name_with_default)}</h2>
+        <h2 class="sr">${_("Navigation for {course_name}").format(course_name=context_course.display_name_with_default)}</h2>
         <ol>
           <li class="nav-item nav-course-courseware">
             <h3 class="title"><span class="label"><span class="label-prefix sr">${_("Course")} </span>${_("Content")}</span> <i class="icon-caret-down ui-toggle-dd"></i></h3>
@@ -120,6 +120,38 @@
                     <a href="${reverse('export_git', kwargs=dict(course_key_string=unicode(course_key)))}">${_("Export to Git")}</a>
                   </li>
                   % endif
+                </ul>
+              </div>
+            </div>
+          </li>
+        </ol>
+      </nav>
+      % elif context_library:
+       <%
+            library_key = context_library.location.course_key
+            index_url = reverse('contentstore.views.library_handler', kwargs={'library_key_string': unicode(library_key)})
+      %>
+      <h2 class="info-course">
+        <span class="sr">${_("Current Library:")}</span>
+        <a class="course-link" href="${index_url}">
+          <span class="course-org">${context_library.display_org_with_default | h}</span><span class="course-number">${context_library.display_number_with_default | h}</span>
+          <span class="course-title" title="${context_library.display_name_with_default}">${context_library.display_name_with_default}</span>
+        </a>
+      </h2>
+
+      <nav class="nav-course nav-dd ui-left">
+        <h2 class="sr">${_("Navigation for {course_name}").format(course_name=context_library.display_name_with_default)}</h2>
+        <ol>
+
+          <li class="nav-item nav-library-settings">
+            <h3 class="title"><span class="label"><span class="label-prefix sr">${_("Library")} </span>${_("Settings")}</span> <i class="icon-caret-down ui-toggle-dd"></i></h3>
+
+            <div class="wrapper wrapper-nav-sub">
+              <div class="nav-sub">
+                <ul>
+                  <li class="nav-item nav-library-settings-team">
+                    <a href="${lib_users_url}">${_("User Access")}</a>
+                  </li>
                 </ul>
               </div>
             </div>

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -120,6 +120,8 @@ if settings.FEATURES.get('ENABLE_CONTENT_LIBRARIES'):
     urlpatterns += (
         url(r'^library/{}?$'.format(LIBRARY_KEY_PATTERN),
             'contentstore.views.library_handler', name='library_handler'),
+        url(r'^library/{}/team/$'.format(LIBRARY_KEY_PATTERN),
+            'contentstore.views.manage_library_users', name='manage_library_users'),
     )
 
 if settings.FEATURES.get('ENABLE_EXPORT_GIT'):

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -5,6 +5,11 @@ from django.conf.urls import patterns, include, url
 from ratelimitbackend import admin
 admin.autodiscover()
 
+# Pattern to match a course key or a library key
+COURSELIKE_KEY_PATTERN = r'(?P<course_key_string>({}|{}))'.format(r'[^/]+/[^/]+/[^/]+', r'[^/:]+:[^/+]+\+[^/+]+(\+[^/]+)?')
+# Pattern to match a library key only
+LIBRARY_KEY_PATTERN = r'(?P<library_key_string>library-v1:[^/+]+\+[^/+]+)'
+
 urlpatterns = patterns('',  # nopep8
 
     url(r'^transcripts/upload$', 'contentstore.views.upload_transcripts', name='upload_transcripts'),
@@ -66,7 +71,7 @@ urlpatterns += patterns(
     url(r'^signin$', 'login_page', name='login'),
     url(r'^request_course_creator$', 'request_course_creator'),
 
-    url(r'^course_team/{}/(?P<email>.+)?$'.format(settings.COURSE_KEY_PATTERN), 'course_team_handler'),
+    url(r'^course_team/{}/(?P<email>.+)?$'.format(COURSELIKE_KEY_PATTERN), 'course_team_handler'),
     url(r'^course_info/{}$'.format(settings.COURSE_KEY_PATTERN), 'course_info_handler'),
     url(
         r'^course_info_update/{}/(?P<provided_id>\d+)?$'.format(settings.COURSE_KEY_PATTERN),
@@ -112,7 +117,6 @@ urlpatterns += patterns(
 )
 
 if settings.FEATURES.get('ENABLE_CONTENT_LIBRARIES'):
-    LIBRARY_KEY_PATTERN = r'(?P<library_key_string>library-v1:[^/+]+\+[^/+]+)'
     urlpatterns += (
         url(r'^library/{}?$'.format(LIBRARY_KEY_PATTERN),
             'contentstore.views.library_handler', name='library_handler'),

--- a/common/djangoapps/student/roles.py
+++ b/common/djangoapps/student/roles.py
@@ -219,6 +219,17 @@ class CourseBetaTesterRole(CourseRole):
         super(CourseBetaTesterRole, self).__init__(self.ROLE, *args, **kwargs)
 
 
+class LibraryUserRole(CourseRole):
+    """
+    A user who can view a library and import content from it, but not edit it.
+    Used in Studio only.
+    """
+    ROLE = 'library_user'
+
+    def __init__(self, *args, **kwargs):
+        super(LibraryUserRole, self).__init__(self.ROLE, *args, **kwargs)
+
+
 class OrgStaffRole(OrgRole):
     """An organization staff member"""
     def __init__(self, *args, **kwargs):
@@ -229,6 +240,17 @@ class OrgInstructorRole(OrgRole):
     """An organization instructor"""
     def __init__(self, *args, **kwargs):
         super(OrgInstructorRole, self).__init__('instructor', *args, **kwargs)
+
+
+class OrgLibraryUserRole(OrgRole):
+    """
+    A user who can view any libraries in an org and import content from them, but not edit them.
+    Used in Studio only.
+    """
+    ROLE = LibraryUserRole.ROLE
+
+    def __init__(self, *args, **kwargs):
+        super(OrgLibraryUserRole, self).__init__(self.ROLE, *args, **kwargs)
 
 
 class CourseCreatorRole(RoleBase):

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1746,6 +1746,7 @@ def auto_auth(request):
     * `staff`: Set to "true" to make the user global staff.
     * `course_id`: Enroll the student in the course with `course_id`
     * `roles`: Comma-separated list of roles to grant the student in the course with `course_id`
+    * `no_login`: Define this to create the user but not login
 
     If username, email, or password are not provided, use
     randomly generated credentials.
@@ -1765,6 +1766,7 @@ def auto_auth(request):
     if course_id:
         course_key = CourseLocator.from_string(course_id)
     role_names = [v.strip() for v in request.GET.get('roles', '').split(',') if v.strip()]
+    login_when_done = 'no_login' not in request.GET
 
     # Get or create the user object
     post_data = {
@@ -1808,14 +1810,16 @@ def auto_auth(request):
         user.roles.add(role)
 
     # Log in as the user
-    user = authenticate(username=username, password=password)
-    login(request, user)
+    if login_when_done:
+        user = authenticate(username=username, password=password)
+        login(request, user)
 
     create_comments_service_user(user)
 
     # Provide the user with a valid CSRF token
     # then return a 200 response
-    success_msg = u"Logged in user {0} ({1}) with password {2} and user_id {3}".format(
+    success_msg = u"{} user {} ({}) with password {} and user_id {}".format(
+        u"Logged in" if login_when_done else "Created",
         username, email, password, user.id
     )
     response = HttpResponse(success_msg)

--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -279,6 +279,7 @@ class LibraryContentModule(LibraryContentFields, XModule, StudioEditableModule):
 
 @XBlock.wants('user')
 @XBlock.wants('library_tools')  # Only needed in studio
+@XBlock.wants('studio_user_permissions')  # Only available in studio
 class LibraryContentDescriptor(LibraryContentFields, MakoModuleDescriptor, XmlDescriptor, StudioEditableDescriptor):
     """
     Descriptor class for LibraryContentModule XBlock.
@@ -307,8 +308,9 @@ class LibraryContentDescriptor(LibraryContentFields, MakoModuleDescriptor, XmlDe
         """
         lib_tools = self.runtime.service(self, 'library_tools')
         user_service = self.runtime.service(self, 'user')
+        user_perms = self.runtime.service(self, 'studio_user_permissions')
         user_id = user_service.user_id if user_service else None  # May be None when creating bok choy test fixtures
-        lib_tools.update_children(self, user_id, update_db)
+        lib_tools.update_children(self, user_id, user_perms, update_db)
         return Response()
 
     def validate(self):

--- a/common/test/acceptance/pages/studio/auto_auth.py
+++ b/common/test/acceptance/pages/studio/auto_auth.py
@@ -15,7 +15,7 @@ class AutoAuthPage(PageObject):
     this url will create a user and log them in.
     """
 
-    def __init__(self, browser, username=None, email=None, password=None, staff=None, course_id=None, roles=None):
+    def __init__(self, browser, username=None, email=None, password=None, staff=None, course_id=None, roles=None, no_login=None):
         """
         Auto-auth is an end-point for HTTP GET requests.
         By default, it will create accounts with random user credentials,
@@ -51,6 +51,9 @@ class AutoAuthPage(PageObject):
         if roles is not None:
             self._params['roles'] = roles
 
+        if no_login:
+            self._params['no_login'] = True
+
     @property
     def url(self):
         """
@@ -66,7 +69,7 @@ class AutoAuthPage(PageObject):
 
     def is_browser_on_page(self):
         message = self.q(css='BODY').text[0]
-        match = re.search(r'Logged in user ([^$]+) with password ([^$]+) and user_id ([^$]+)$', message)
+        match = re.search(r'(Logged in|Created) user ([^$]+) with password ([^$]+) and user_id ([^$]+)$', message)
         return True if match else False
 
     def get_user_id(self):

--- a/common/test/acceptance/pages/studio/users.py
+++ b/common/test/acceptance/pages/studio/users.py
@@ -1,0 +1,189 @@
+"""
+Page classes to test either the Course Team page or the Library Team page.
+"""
+from bok_choy.promise import EmptyPromise
+from bok_choy.page_object import PageObject
+from ...tests.helpers import disable_animations
+from . import BASE_URL
+
+
+def wait_for_ajax_or_reload(browser):
+    """
+    Wait for all ajax requests to finish, OR for the page to reload.
+    Normal wait_for_ajax() chokes on occasion if the pages reloads,
+    giving "WebDriverException: Message: u'jQuery is not defined'"
+    """
+    def _is_ajax_finished():
+        """ Wait for jQuery to finish all AJAX calls, if it is present. """
+        return browser.execute_script("return typeof(jQuery) == 'undefined' || jQuery.active == 0")
+
+    EmptyPromise(_is_ajax_finished, "Finished waiting for ajax requests.").fulfill()
+
+
+class UsersPage(PageObject):
+    """
+    Base class for either the Course Team page or the Library Team page
+    """
+
+    def __init__(self, browser, locator):
+        super(UsersPage, self).__init__(browser)
+        self.locator = locator
+
+    @property
+    def url(self):
+        """
+        URL to this page - override in subclass
+        """
+        raise NotImplementedError
+
+    def is_browser_on_page(self):
+        """
+        Returns True iff the browser has loaded the page.
+        """
+        return self.q(css='body.view-team').present
+
+    @property
+    def users(self):
+        """
+        Return a list of users listed on this page.
+        """
+        return self.q(css='.user-list .user-item').map(lambda el: UserWrapper(self.browser, el.get_attribute('data-email'))).results
+
+    @property
+    def has_add_button(self):
+        """
+        Is the "New Team Member" button present?
+        """
+        return self.q(css='.create-user-button').present
+
+    def click_add_button(self):
+        """
+        Click on the "New Team Member" button
+        """
+        self.q(css='.create-user-button').click()
+
+    @property
+    def new_user_form_visible(self):
+        """ Is the new user form visible? """
+        return self.q(css='.form-create.create-user .user-email-input').visible
+
+    def set_new_user_email(self, email):
+        """ Set the value of the "New User Email Address" field. """
+        self.q(css='.form-create.create-user .user-email-input').fill(email)
+
+    def click_submit_new_user_form(self):
+        """ Submit the "New User" form """
+        self.q(css='.form-create.create-user .action-primary').click()
+        wait_for_ajax_or_reload(self.browser)
+
+
+class LibraryUsersPage(UsersPage):
+    """
+    Library Team page in Studio
+    """
+
+    @property
+    def url(self):
+        """
+        URL to the "User Access" page for the given library.
+        """
+        return "{}/library/{}/team/".format(BASE_URL, unicode(self.locator))
+
+
+class UserWrapper(PageObject):
+    """
+    A PageObject representing a wrapper around a user listed on the course/library team page.
+    """
+    url = None
+    COMPONENT_BUTTONS = {
+        'basic_tab': '.editor-tabs li.inner_tab_wrap:nth-child(1) > a',
+        'advanced_tab': '.editor-tabs li.inner_tab_wrap:nth-child(2) > a',
+        'save_settings': '.action-save',
+    }
+
+    def __init__(self, browser, email):
+        super(UserWrapper, self).__init__(browser)
+        self.email = email
+        self.selector = '.user-list .user-item[data-email="{}"]'.format(self.email)
+
+    def is_browser_on_page(self):
+        """
+        Sanity check that our wrapper element is on the page.
+        """
+        return self.q(css=self.selector).present
+
+    def _bounded_selector(self, selector):
+        """
+        Return `selector`, but limited to this particular user entry's context
+        """
+        return '{} {}'.format(self.selector, selector)
+
+    @property
+    def name(self):
+        """ Get this user's username, as displayed. """
+        return self.q(css=self._bounded_selector('.user-username')).text[0]
+
+    @property
+    def role_label(self):
+        """ Get this user's role, as displayed. """
+        return self.q(css=self._bounded_selector('.flag-role .value')).text[0]
+
+    @property
+    def is_current_user(self):
+        """ Does the UI indicate that this is the current user? """
+        return self.q(css=self._bounded_selector('.flag-role .msg-you')).present
+
+    @property
+    def can_promote(self):
+        """ Can this user be promoted to a more powerful role? """
+        return self.q(css=self._bounded_selector('.add-admin-role')).present
+
+    @property
+    def promote_button_text(self):
+        """ What does the promote user button say? """
+        return self.q(css=self._bounded_selector('.add-admin-role')).text[0]
+
+    def click_promote(self):
+        """ Click on the button to promote this user to the more powerful role """
+        self.q(css=self._bounded_selector('.add-admin-role')).click()
+        wait_for_ajax_or_reload(self.browser)
+
+    @property
+    def can_demote(self):
+        """ Can this user be demoted to a less powerful role? """
+        return self.q(css=self._bounded_selector('.remove-admin-role')).present
+
+    @property
+    def demote_button_text(self):
+        """ What does the demote user button say? """
+        return self.q(css=self._bounded_selector('.remove-admin-role')).text[0]
+
+    def click_demote(self):
+        """ Click on the button to demote this user to the less powerful role """
+        self.q(css=self._bounded_selector('.remove-admin-role')).click()
+        wait_for_ajax_or_reload(self.browser)
+
+    @property
+    def can_delete(self):
+        """ Can this user be deleted? """
+        return self.q(css=self._bounded_selector('.action-delete:not(.is-disabled) .remove-user')).present
+
+    def click_delete(self):
+        """ Click the button to delete this user. """
+        disable_animations(self)
+        self.q(css=self._bounded_selector('.remove-user')).click()
+        # We can't use confirm_prompt because its wait_for_ajax is flaky when the page is expected to reload.
+        self.wait_for_element_visibility('.prompt', 'Prompt is visible')
+        self.wait_for_element_visibility('.prompt .action-primary', 'Confirmation button is visible')
+        self.q(css='.prompt .action-primary').click()
+        wait_for_ajax_or_reload(self.browser)
+
+    @property
+    def has_no_change_warning(self):
+        """ Does this have a warning in place of the promote/demote buttons? """
+        return self.q(css=self._bounded_selector('.notoggleforyou')).present
+
+    @property
+    def no_change_warning_text(self):
+        """ Text of the warning seen in place of the promote/demote buttons. """
+        return self.q(css=self._bounded_selector('.notoggleforyou')).text[0]

--- a/common/test/acceptance/tests/studio/test_studio_library.py
+++ b/common/test/acceptance/tests/studio/test_studio_library.py
@@ -5,8 +5,10 @@ from ddt import ddt, data
 
 from .base_studio_test import StudioLibraryTest
 from ...fixtures.course import XBlockFixtureDesc
+from ...pages.studio.auto_auth import AutoAuthPage
 from ...pages.studio.utils import add_component
 from ...pages.studio.library import LibraryPage
+from ...pages.studio.users import LibraryUsersPage
 
 
 @ddt
@@ -306,3 +308,138 @@ class LibraryNavigationTest(StudioLibraryTest):
         self.assertEqual(self.lib_page.xblocks[0].name, '1')
         self.assertEqual(self.lib_page.xblocks[-1].name, '11')
         self.assertEqual(self.lib_page.get_page_number(), '1')
+
+
+class LibraryUsersPageTest(StudioLibraryTest):
+    """
+    Test the functionality of the library "Instructor Access" page.
+    """
+    def setUp(self):
+        super(LibraryUsersPageTest, self).setUp()
+
+        # Create a second user for use in these tests:
+        AutoAuthPage(self.browser, username="second", email="second@example.com", no_login=True).visit()
+
+        self.page = LibraryUsersPage(self.browser, self.library_key)
+        self.page.visit()
+
+    def _expect_refresh(self):
+        """
+        Wait for the page to reload.
+        """
+        self.page = LibraryUsersPage(self.browser, self.library_key).wait_for_page()
+
+    def test_user_management(self):
+        """
+        Scenario: Ensure that we can edit the permissions of users.
+        Given I have a library in Studio where I am the only admin
+        assigned (which is the default for a newly-created library)
+        And I navigate to Library "Instructor Access" Page in Studio
+        Then there should be one user listed (myself), and I must
+        not be able to remove myself or my instructor privilege.
+
+        When I click Add Intructor
+        Then I see a form to complete
+        When I complete the form and submit it
+        Then I can see the new user is listed as a "User" of the library
+
+        When I click to Add Staff permissions to the new user
+        Then I can see the new user has staff permissions and that I am now
+        able to promote them to an Admin or remove their staff permissions.
+
+        When I click to Add Admin permissions to the new user
+        Then I can see the new user has admin permissions and that I can now
+        remove Admin permissions from either user.
+        """
+        def check_is_only_admin(user):
+            """
+            Ensure user is an admin user and cannot be removed.
+            (There must always be at least one admin user.)
+            """
+            self.assertIn("admin", user.role_label.lower())
+            self.assertFalse(user.can_promote)
+            self.assertFalse(user.can_demote)
+            self.assertFalse(user.can_delete)
+            self.assertTrue(user.has_no_change_warning)
+            self.assertIn("Promote another member to Admin to remove admin rights", user.no_change_warning_text)
+
+        self.assertEqual(len(self.page.users), 1)
+        user = self.page.users[0]
+        self.assertTrue(user.is_current_user)
+        check_is_only_admin(user)
+
+        # Add a new user:
+
+        self.assertTrue(self.page.has_add_button)
+        self.assertFalse(self.page.new_user_form_visible)
+        self.page.click_add_button()
+        self.assertTrue(self.page.new_user_form_visible)
+        self.page.set_new_user_email('second@example.com')
+        self.page.click_submit_new_user_form()
+
+        # Check the new user's listing:
+
+        def get_two_users():
+            """
+            Expect two users to be listed, one being me, and another user.
+            Returns me, them
+            """
+            users = self.page.users
+            self.assertEqual(len(users), 2)
+            self.assertEqual(len([u for u in users if u.is_current_user]), 1)
+            if users[0].is_current_user:
+                return users[0], users[1]
+            else:
+                return users[1], users[0]
+
+        self._expect_refresh()
+        user_me, them = get_two_users()
+        check_is_only_admin(user_me)
+
+        self.assertIn("user", them.role_label.lower())
+        self.assertTrue(them.can_promote)
+        self.assertIn("Add Staff Access", them.promote_button_text)
+        self.assertFalse(them.can_demote)
+        self.assertTrue(them.can_delete)
+        self.assertFalse(them.has_no_change_warning)
+
+        # Add Staff permissions to the new user:
+
+        them.click_promote()
+        self._expect_refresh()
+        user_me, them = get_two_users()
+        check_is_only_admin(user_me)
+
+        self.assertIn("staff", them.role_label.lower())
+        self.assertTrue(them.can_promote)
+        self.assertIn("Add Admin Access", them.promote_button_text)
+        self.assertTrue(them.can_demote)
+        self.assertIn("Remove Staff Access", them.demote_button_text)
+        self.assertTrue(them.can_delete)
+        self.assertFalse(them.has_no_change_warning)
+
+        # Add Admin permissions to the new user:
+
+        them.click_promote()
+        self._expect_refresh()
+        user_me, them = get_two_users()
+        self.assertIn("admin", user_me.role_label.lower())
+        self.assertFalse(user_me.can_promote)
+        self.assertTrue(user_me.can_demote)
+        self.assertTrue(user_me.can_delete)
+        self.assertFalse(user_me.has_no_change_warning)
+
+        self.assertIn("admin", them.role_label.lower())
+        self.assertFalse(them.can_promote)
+        self.assertTrue(them.can_demote)
+        self.assertIn("Remove Admin Access", them.demote_button_text)
+        self.assertTrue(them.can_delete)
+        self.assertFalse(them.has_no_change_warning)
+
+        # Delete the new user:
+
+        them.click_delete()
+        self._expect_refresh()
+        self.assertEqual(len(self.page.users), 1)
+        user = self.page.users[0]
+        self.assertTrue(user.is_current_user)

--- a/common/test/acceptance/tests/studio/test_studio_library.py
+++ b/common/test/acceptance/tests/studio/test_studio_library.py
@@ -361,7 +361,7 @@ class LibraryUsersPageTest(StudioLibraryTest):
             self.assertFalse(user.can_demote)
             self.assertFalse(user.can_delete)
             self.assertTrue(user.has_no_change_warning)
-            self.assertIn("Promote another member to Admin to remove admin rights", user.no_change_warning_text)
+            self.assertIn("Promote another member to Admin to remove your admin rights", user.no_change_warning_text)
 
         self.assertEqual(len(self.page.users), 1)
         user = self.page.users[0]

--- a/common/test/acceptance/tests/studio/test_studio_library_container.py
+++ b/common/test/acceptance/tests/studio/test_studio_library_container.py
@@ -2,8 +2,11 @@
 Acceptance tests for Library Content in LMS
 """
 import ddt
-from .base_studio_test import StudioLibraryTest, ContainerBase
+from .base_studio_test import StudioLibraryTest
+from ...fixtures.course import CourseFixture
+from ..helpers import UniqueCourseTest
 from ...pages.studio.library import StudioLibraryContentXBlockEditModal, StudioLibraryContainerXBlockWrapper
+from ...pages.studio.overview import CourseOutlinePage
 from ...fixtures.course import XBlockFixtureDesc
 
 SECTION_NAME = 'Test Section'
@@ -12,7 +15,7 @@ UNIT_NAME = 'Test Unit'
 
 
 @ddt.ddt
-class StudioLibraryContainerTest(ContainerBase, StudioLibraryTest):
+class StudioLibraryContainerTest(StudioLibraryTest, UniqueCourseTest):
     """
     Test Library Content block in LMS
     """
@@ -21,6 +24,12 @@ class StudioLibraryContainerTest(ContainerBase, StudioLibraryTest):
         Install library with some content and a course using fixtures
         """
         super(StudioLibraryContainerTest, self).setUp()
+        # Also create a course:
+        self.course_fixture = CourseFixture(self.course_info['org'], self.course_info['number'], self.course_info['run'], self.course_info['display_name'])
+        self.populate_course_fixture(self.course_fixture)
+        self.course_fixture.install()
+        self.outline = CourseOutlinePage(self.browser, self.course_info['org'], self.course_info['number'], self.course_info['run'])
+
         self.outline.visit()
         subsection = self.outline.section(SECTION_NAME).subsection(SUBSECTION_NAME)
         self.unit_page = subsection.toggle_expand().unit(UNIT_NAME).go_to()


### PR DESCRIPTION
**Title**: Content library permissions & collaboration (SOL-81)

**Background**: This PR adds a new page to studio where the user can manage who else has permission to access a content library. This PR also introduces a **new read-only role** used only for libraries.

**Jira tickets**: [SOL-81](https://openedx.atlassian.net/browse/SOL-81)

**Discussions**: Various offline discussions and the internal PRs below.

**Dependencies**: None - all dependencies are already merged to the feature branch.

**Sandbox URL**: CMS http://sandbox4.opencraft.com:18010/ - LMS http://sandbox4.opencraft.com/

**Internal code reviews PRs** https://github.com/open-craft/edx-platform/pull/8 https://github.com/open-craft/edx-platform/pull/11

**Partner information**: 3rd party-hosted open edX instance, for an edX solutions client.

**Author concerns**: Studio's roles ("Instructor", "Staff") are vague (is there any documentation in the code?) and with a third role in the mix ("User"), it was unclear which roles were allowed to do what, so I added the concept of permissions (EDIT_ROLES, VIEW_USERS, EDIT_CONTENT, VIEW_CONTENT) defined via roles... Would like feedback on this approach.
