### PR TITLE
Discussion thread response show dual vote count

### DIFF
--- a/common/static/coffee/src/discussion/views/discussion_content_view.coffee
+++ b/common/static/coffee/src/discussion/views/discussion_content_view.coffee
@@ -138,6 +138,8 @@ if Backbone?
       closed: (closed) ->
         @updateButtonState(".action-close", closed)
         @$(".post-label-closed").toggleClass("is-hidden", not closed)
+        @$(".action-vote").toggle(not closed)
+        @$(".display-vote").toggle(closed)
     })
 
     toggleSecondaryActions: (event) =>

--- a/common/static/coffee/src/discussion/views/discussion_thread_view.coffee
+++ b/common/static/coffee/src/discussion/views/discussion_thread_view.coffee
@@ -79,7 +79,6 @@ if Backbone?
         @$('.comment-form').closest('li').toggle(not closed)
         @$(".action-vote").toggle(not closed)
         @$(".display-vote").toggle(closed)
-#        @$(".display-vote").toggle(closed)
         @renderAddResponseButton()
     })
 
@@ -260,6 +259,7 @@ if Backbone?
       comment = new Comment(body: body, created_at: (new Date()).toISOString(), username: window.user.get("username"), votes: { up_count: 0 }, abuse_flaggers:[], endorsed: false, user_id: window.user.get("id"))
       comment.set('thread', @model.get('thread'))
       @renderResponseToList(comment, ".js-response-list")
+      @renderAttrs()
       @model.addComment()
       @renderAddResponseButton()
 

--- a/common/test/acceptance/pages/lms/discussion.py
+++ b/common/test/acceptance/pages/lms/discussion.py
@@ -264,6 +264,10 @@ class DiscussionTabSingleThreadPage(CoursePage):
     def __getattr__(self, name):
         return getattr(self.thread_page, name)
 
+    def close_open_thread(self):
+        with self.thread_page._secondary_action_menu_open(".forum-thread-main-wrapper"):
+            self._find_within(".forum-thread-main-wrapper .action-close").first.click()
+
 
 class InlineDiscussionPage(PageObject):
     url = None


### PR DESCRIPTION
When the responses of the thread is loaded it shows
dual vote count one with simple text and one with
button whereas only text should be shown when thread
is closed and only button when thread is open.

TNL-1016
