### PR TITLE
Update django-nose version

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -120,7 +120,7 @@ chrono==1.0.2
 coverage==3.7
 ddt==0.8.0
 django-crum==0.5
-django_nose==1.2
+django_nose==1.3
 factory_boy==2.2.1
 freezegun==0.1.11
 mock==1.0.1


### PR DESCRIPTION
Reason:
- keep up with latest
- enable ability to run under profiler. Requires this fix: https://github.com/django-nose/django-nose/issues/121
- also, this adds django 1.6 and 1.7 support (for when we get there, hopefully soon?)
