### PR TITLE
for tests change the default xml data dir 

### DIFF
--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -131,7 +131,7 @@ update_module_store_settings(
         'fs_root': TEST_ROOT / "data",
     },
     xml_store_options={
-        'data_dir': mkdtemp(),  # never inadvertently load all the XML courses
+        'data_dir': mkdtemp(dir=TEST_ROOT),  # never inadvertently load all the XML courses
     },
     doc_store_settings={
         'host': MONGO_HOST,


### PR DESCRIPTION
to a place where it will get cleaned up

As currently coded (sorry about this, blame me), all jenkins workers are now writing to temp dirs under /tmp which could be growing without cleanup.

This way it would instead of being created under /tmp, be created under test_root, which will get cleaned up before the next build when the git clean gets executed.
