### PR TITLE
Preserve the contribution amount specified on the track selection page.

### DIFF
--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -483,6 +483,12 @@ class PayAndVerifyView(View):
             else ""
         )
 
+        # If the user set a contribution amount on another page,
+        # use that amount to pre-fill the price selection form.
+        contribution_amount = request.session.get(
+            'donation_for_course', {}
+        ).get(unicode(course_key), '')
+
         # Render the top-level page
         context = {
             'user_full_name': full_name,
@@ -493,6 +499,7 @@ class PayAndVerifyView(View):
             'current_step': current_step,
             'disable_courseware_js': True,
             'display_steps': display_steps,
+            'contribution_amount': contribution_amount,
             'is_active': request.user.is_active,
             'messages': self._messages(
                 message,

--- a/lms/static/js/verify_student/pay_and_verify.js
+++ b/lms/static/js/verify_student/pay_and_verify.js
@@ -48,6 +48,7 @@ var edx = edx || {};
                 courseKey: el.data('course-key'),
                 minPrice: el.data('course-mode-min-price'),
                 suggestedPrices: (el.data('course-mode-suggested-prices') || "").split(","),
+                contributionAmount: el.data('contribution-amount'),
                 currency: el.data('course-mode-currency'),
                 purchaseEndpoint: el.data('purchase-endpoint')
             },

--- a/lms/static/js/verify_student/views/make_payment_step_view.js
+++ b/lms/static/js/verify_student/views/make_payment_step_view.js
@@ -17,6 +17,12 @@ var edx = edx || {};
                 requirements: this.stepData.requirements
             }).render();
 
+            // Update the contribution amount with the amount the user
+            // selected in a previous screen.
+            if ( this.stepData.contributionAmount ) {
+                this.selectPaymentAmount( this.stepData.contributionAmount );
+            }
+
             // Enable the payment button once an amount is chosen
             $( "input[name='contribution']" ).on( 'click', _.bind( this.enablePaymentButton, this ) );
 
@@ -105,6 +111,31 @@ var edx = edx || {};
             } else {
                 return contributionInput.val();
             }
+        },
+
+        selectPaymentAmount: function( amount ) {
+            var amountFloat = parseFloat( amount ),
+                foundPrice;
+
+            // Check if we have a suggested price that matches the amount
+            foundPrice = _.find(
+                this.stepData.suggestedPrices,
+                function( price ) {
+                    return parseFloat( price ) === amountFloat;
+                }
+            );
+
+            // If we've found an option for the price, select it.
+            if ( foundPrice ) {
+                $( '#contribution-' + foundPrice, this.el ).prop( 'checked', true );
+            } else {
+                // Otherwise, enter the value into the text box
+                $( '#contribution-other-amt', this.el ).val( amount );
+                $( '#contribution-other', this.el ).prop( 'checked', true );
+            }
+
+            // In either case, enable the payment button
+            this.enablePaymentButton();
         }
 
     });

--- a/lms/templates/verify_student/pay_and_verify.html
+++ b/lms/templates/verify_student/pay_and_verify.html
@@ -65,6 +65,7 @@ from verify_student.views import PayAndVerifyView
       data-course-mode-min-price='${course_mode.min_price}'
       data-course-mode-suggested-prices='${course_mode.suggested_prices}'
       data-course-mode-currency='${course_mode.currency}'
+      data-contribution-amount='${contribution_amount}'
       data-purchase-endpoint='${purchase_endpoint}'
       data-display-steps='${json.dumps(display_steps)}'
       data-current-step='${current_step}'


### PR DESCRIPTION
Preserve the contribution amount specified on the track selection page once the user reaches the new "make payment" page.

The amount is already being stored as a session variable.  I've passed that variable along to the template; if provided, the BackBone view for the payment page will select the price automatically.

Reviewers: @rlucioni @dianakhuang 
