### PR TITLE
(WIP) Video Captions

### DIFF
--- a/cms/djangoapps/contentstore/features/video.py
+++ b/cms/djangoapps/contentstore/features/video.py
@@ -5,7 +5,8 @@ from selenium.webdriver.common.keys import Keys
 from xmodule.modulestore.django import modulestore
 
 VIDEO_BUTTONS = {
-    'CC': '.hide-subtitles',
+    'CC': '.hide-closed-captions',
+    'transcripts': '.hide-captions',
     'volume': '.volume',
     'play': '.video_control.play',
     'pause': '.video_control.pause',
@@ -114,7 +115,7 @@ def i_edit_the_component(_step):
 
 @step('I have (hidden|toggled) captions$')
 def hide_or_show_captions(step, shown):
-    button_css = 'a.hide-subtitles'
+    button_css = 'a.hide-captions'
     if shown == 'hidden':
         world.css_click(button_css)
     if shown == 'toggled':
@@ -167,13 +168,13 @@ def the_youtube_video_is_shown(_step):
 @step('Make sure captions are (.+)$')
 def set_captions_visibility_state(_step, captions_state):
     SELECTOR = '.closed .subtitles'
-    world.wait_for_visible('.hide-subtitles')
+    world.wait_for_visible('.hide-captions')
     if captions_state == 'closed':
         if world.is_css_not_present(SELECTOR):
-            world.css_find('.hide-subtitles').click()
+            world.css_find('.hide-captions').click()
     else:
         if world.is_css_present(SELECTOR):
-            world.css_find('.hide-subtitles').click()
+            world.css_find('.hide-captions').click()
 
 
 @step('I hover over button "([^"]*)"$')

--- a/cms/templates/ux/reference/container.html
+++ b/cms/templates/ux/reference/container.html
@@ -153,7 +153,7 @@
                                                                         </section>
                                                                         <a href="#" tabindex="0" class="hide-captions" role="button" aria-disabled="false"
                                                                               title="Turn off transcripts">
-                                                                          <i class="icon-caret-right" aria-hidden="true"></i>
+                                                                          <i class="fa fa-caret-right" aria-hidden="true"></i>
                                                                         </a>
 
                                                                         <div class="video-player-post"></div>

--- a/cms/templates/ux/reference/container.html
+++ b/cms/templates/ux/reference/container.html
@@ -137,7 +137,7 @@
 
                                                             <h2>Video</h2>
 
-                                                            <div id="video_i4x-AndyA-ABT101-video-72b5a0d74e8c4ed4a4d4e6bf67837c09" class="video closed is-initialized" data-streams="1.00:OEoXaMPEzfM" data-save-state-url="/preview/xblock/i4x:;_;_AndyA;_ABT101;_video;_72b5a0d74e8c4ed4a4d4e6bf67837c09/handler/xmodule_handler/save_user_state" data-caption-data-dir="None" data-show-captions="true" data-general-speed="1.0" data-speed="null" data-start="0.0" data-end="0.0" data-caption-asset-path="/c4x/AndyA/ABT101/asset/subs_" data-autoplay="False" data-yt-test-timeout="1500" data-yt-test-url="https://gdata.youtube.com/feeds/api/videos/" data-autohide-html5="False" tabindex="-1">
+                                                            <div id="video_i4x-AndyA-ABT101-video-72b5a0d74e8c4ed4a4d4e6bf67837c09" class="video closed is-initialized" data-streams="1.00:OEoXaMPEzfM" data-save-state-url="/preview/xblock/i4x:;_;_AndyA;_ABT101;_video;_72b5a0d74e8c4ed4a4d4e6bf67837c09/handler/xmodule_handler/save_user_state" data-caption-data-dir="None" data-show-captions="true" data-show-closed-captions="true" data-general-speed="1.0" data-speed="null" data-start="0.0" data-end="0.0" data-caption-asset-path="/c4x/AndyA/ABT101/asset/subs_" data-autoplay="False" data-yt-test-timeout="1500" data-yt-test-url="https://gdata.youtube.com/feeds/api/videos/" data-autohide-html5="False" tabindex="-1">
                                                                 <div class="focus_grabber first" tabindex="-1"></div>
 
                                                                 <div class="tc-wrapper">
@@ -151,7 +151,15 @@
                                                                             <iframe id="i4x-AndyA-ABT101-video-72b5a0d74e8c4ed4a4d4e6bf67837c09" frameborder="0" allowfullscreen="1" title="YouTube video player" width="640" height="360" src="https://www.youtube.com/embed/OEoXaMPEzfM?controls=0&amp;wmode=transparent&amp;rel=0&amp;showinfo=0&amp;enablejsapi=1&amp;modestbranding=1&amp;html5=1&amp;origin=http%3A%2F%2Flocalhost%3A8001" style="height: 411.75px; width: 732px; top: -22.875px; left: 0px;"></iframe>
                                                                             <h3 class="hidden">ERROR: No playable video sources found!</h3>
                                                                         </section>
+                                                                        <a href="#" tabindex="0" class="hide-captions" role="button" aria-disabled="false"
+                                                                              title="Turn off transcripts">
+                                                                          <i class="icon-caret-right" aria-hidden="true"></i>
+                                                                        </a>
+
                                                                         <div class="video-player-post"></div>
+                                                                        <section class="closed-caption">
+                                                                            <p class="text"></p>
+                                                                        </section>
                                                                         <section class="video-controls" style="">
                                                                             <div class="slider ui-slider ui-slider-horizontal ui-widget ui-widget-content ui-corner-all" title="Video position" aria-disabled="false" tabindex="-1" style=""><div class="ui-slider-range ui-widget-header ui-slider-range-min" style="width: 0%;"></div><a class="ui-slider-handle ui-state-default ui-corner-all" href="#" role="slider" title="Video position" aria-disabled="false" aria-valuetext="0 seconds" style="left: 0%;"></a></div>
                                                                             <div>
@@ -176,7 +184,7 @@
                                                                                     <a href="#" class="add-fullscreen" title="Fill browser" role="button" aria-disabled="false">Fill browser</a>
                                                                                     <a href="#" class="quality_control" title="HD off" role="button" aria-disabled="false" style="display: inline;">HD off</a>
 
-                                                                                    <a href="#" class="hide-subtitles" title="Turn on captions" role="button" aria-disabled="false" style="display: none;">Turn on captions</a>
+                                                                                    <a href="#" class="hide-closed-captions" title="Turn on captions" role="button" aria-disabled="false" style="display: none;">Turn on captions</a>
                                                                                 </div>
                                                                             </div>
                                                                         </section>

--- a/common/djangoapps/track/shim.py
+++ b/common/djangoapps/track/shim.py
@@ -76,6 +76,8 @@ NAME_TO_EVENT_TYPE_MAP = {
     'edx.video.loaded': 'load_video',
     'edx.video.transcript.shown': 'show_transcript',
     'edx.video.transcript.hidden': 'hide_transcript',
+    'edx.video.closedcaptions.shown': 'show_closed_captions',
+    'edx.video.closedcaptions.hidden': 'hide_closed_captions',
 }
 
 

--- a/common/djangoapps/track/views/tests/test_segmentio.py
+++ b/common/djangoapps/track/views/tests/test_segmentio.py
@@ -315,6 +315,8 @@ class SegmentIOTrackingTestCase(EventTrackingTestCase):
         ('edx.video.loaded', 'load_video'),
         ('edx.video.transcript.shown', 'show_transcript'),
         ('edx.video.transcript.hidden', 'hide_transcript'),
+        ('edx.video.closedcaptions.shown', 'show_closed_captions'),
+        ('edx.video.closedcaptions.hidden', 'hide_closed_captions'),
     )
     @unpack
     def test_video_event(self, name, event_type):

--- a/common/lib/xmodule/xmodule/css/video/display.scss
+++ b/common/lib/xmodule/xmodule/css/video/display.scss
@@ -1,5 +1,5 @@
 & {
-    margin-bottom: ($baseline*1.5);
+  margin-bottom: ($baseline*1.5);
 }
 
 .is-hidden {
@@ -43,7 +43,7 @@ div.video {
     margin: 0;
     padding: 0;
 
-    .video-download-button{
+    .video-download-button {
       display: inline-block;
       vertical-align: top;
       margin: ($baseline*0.75) ($baseline/2) 0 0;
@@ -51,7 +51,7 @@ div.video {
       > a {
         @include transition(all $tmg-f2 ease-in-out 0s);
         @include font-size(14);
-        line-height : 14px;
+        line-height: 14px;
         float: left;
         border-radius: 3px;
         background-color: $very-light-text;
@@ -81,9 +81,36 @@ div.video {
     background-color: black;
     position: relative;
 
+    section.closed-caption {
+      bottom: 0;
+      left: 0;
+      position: absolute;
+      width: 100%;
+
+      .text {
+        color: white;
+        font-weight: 700;
+        box-sizing: border-box;
+        cursor: pointer;
+        text-align: center;
+
+        // Let Draggabilly do correct containment
+        min-height: 25px;
+        padding: 8px 16px 80px;
+        margin-bottom: 0;
+
+        // Stroke around the text
+        text-shadow: 0 0 5px #000,
+        -1px -1px 1px #000,
+        1px -1px 1px #000,
+        -1px 1px 1px #000,
+        1px 1px 1px #000;
+      }
+    }
+
     div.video-player-pre, div.video-player-post {
-       height: 50px;
-       background-color: black;
+      height: 50px;
+      background-color: black;
     }
 
     .spinner {
@@ -96,7 +123,7 @@ div.video {
       padding: 30px;
       border-radius: 25%;
 
-      &:after{
+      &:after {
         @include animation(rotateCW 3s infinite linear);
         content: '';
         display: block;
@@ -119,7 +146,7 @@ div.video {
       padding: 30px;
       border-radius: 25%;
 
-      &:after{
+      &:after {
         content: '';
         display: block;
         width: 0px;
@@ -275,7 +302,7 @@ div.video {
           a {
             @extend %video-button;
             background-image: url('../images/vcr.png');
-            background-position: 15px 15px ;
+            background-position: 15px 15px;
             background-repeat: no-repeat;
             border-left: none;
             box-shadow: 1px 0 0 #555;
@@ -322,7 +349,7 @@ div.video {
         div.volume > a,
         a.add-fullscreen,
         a.quality-control,
-        a.hide-subtitles {
+        a.hide-closed-captions {
           // overflow is used to bypass Firefox CSS :focus outline bug
           // http://johndoesdesign.com/blog/2012/css/firefox-and-its-css-focus-outline-bug/
           &:focus {
@@ -361,7 +388,7 @@ div.video {
 
             li {
               @extend %ui-fake-link;
-              box-shadow:  0 1px 0 #555;
+              box-shadow: 0 1px 0 #555;
               border-bottom: 1px solid $black;
               color: $white;
 
@@ -381,7 +408,7 @@ div.video {
                 }
               }
 
-              &.is-active{
+              &.is-active {
                 a {
                   font-weight: bold;
                 }
@@ -403,7 +430,7 @@ div.video {
             }
           }
 
-          .menu{
+          .menu {
             width: 131px;
 
             @media (max-width: 1120px) {
@@ -536,7 +563,6 @@ div.video {
           width: 30px;
         }
 
-
         a.quality-control {
           @extend %video-button;
           background: url(../images/hd.png) center no-repeat;
@@ -557,7 +583,7 @@ div.video {
         }
 
         div.lang {
-          & > a.hide-subtitles {
+          & > a.hide-closed-captions {
             @extend %video-button;
             @include transition(none);
             box-shadow: inset 1px 0 0 #555;
@@ -605,11 +631,12 @@ div.video {
     font-size: 14px;
     list-style: none;
     visibility: visible;
+    position: relative;
 
     li {
       @extend %ui-fake-link;
       border: 0;
-      color: rgb(29,157,217);
+      color: rgb(29, 157, 217);
       margin-bottom: 8px;
       padding: 0;
       line-height: lh();
@@ -634,11 +661,23 @@ div.video {
     }
   }
 
+  a.hide-captions {
+    position: absolute;
+    right: -8px;
+    top: 50%;
+    cursor: pointer;
+    z-index: 999;
+
+    i {
+      font-style: normal;
+      color: inherit;
+    }
+  }
+
   &.closed {
 
     article.video-wrapper {
-      width: flex-grid(9,9);
-
+      width: flex-grid(9, 9);
       background-color: inherit;
     }
 
@@ -651,7 +690,7 @@ div.video {
     }
 
     article.video-wrapper div.video-player-pre, article.video-wrapper div.video-player-post {
-        height: 0;
+      height: 0;
     }
 
     article.video-wrapper section.video-player {
@@ -661,26 +700,35 @@ div.video {
     }
 
     ol.subtitles {
-        width: 0;
-        height: 0;
+      width: 0;
+      height: 0;
     }
 
     ol.subtitles.html5 {
-        @extend %ui-depth0;
-        background-color: rgba(243, 243, 243, 0.8);
-        height: 100%;
-        position: absolute;
-        right: 0;
-        bottom: 0;
-        top: 0;
-        width: 275px;
-        padding: 0 $baseline;
-        display: none;
+      @extend %ui-depth0;
+      background-color: rgba(243, 243, 243, 0.8);
+      height: 100%;
+      position: absolute;
+      right: 0;
+      bottom: 0;
+      top: 0;
+      width: 275px;
+      padding: 0 $baseline;
+      display: none;
+    }
+
+    a.hide-captions {
+      i:before {
+        content: "\f0d9"; // Overriding `.icon-caret-right` to make it `.icon-caret-left`
+      }
     }
   }
 
   &.video-fullscreen {
     @extend %ui-depth4;
+    $captionsWidthOpen: 24%;
+    $captionsButtonWidth: 0.4%;
+
     background: rgba(#000, .95);
     border: 0;
     bottom: 0;
@@ -694,20 +742,44 @@ div.video {
     vertical-align: middle;
     border-radius: 0;
 
+    a.hide-captions {
+      right: $captionsWidthOpen + $captionsButtonWidth;
+
+      &, i {
+        color: white;
+      }
+    }
+
+    article.video-wrapper section.closed-caption {
+      width: 100% - ($captionsWidthOpen + $captionsButtonWidth);
+
+      .text {
+        font-size: 1.3em;
+      }
+    }
+
     &.closed {
       div.tc-wrapper {
         article.video-wrapper {
           width: 100%;
         }
       }
+
+      a.hide-captions {
+        right: $captionsButtonWidth;
+      }
+
+      article.video-wrapper section.closed-caption {
+        width: 100%;
+      }
     }
 
     article.video-wrapper div.video-player-pre, article.video-wrapper div.video-player-post {
-        height: 0;
+      height: 0;
     }
 
     article.video-wrapper {
-        position: static;
+      position: static;
     }
 
     article.video-wrapper section.video-player {
@@ -729,7 +801,7 @@ div.video {
         vertical-align: middle;
         margin-right: 0;
 
-        object, iframe, video{
+        object, iframe, video {
           position: absolute;
           width: auto;
           height: auto;
@@ -741,7 +813,7 @@ div.video {
         bottom: 0;
         left: 0;
         position: absolute;
-        width: 100%; 
+        width: 100%;
       }
     }
 
@@ -767,7 +839,7 @@ div.video {
   &.is-touch {
     div.tc-wrapper {
       article.video-wrapper {
-        object, iframe, video{
+        object, iframe, video {
           width: 100%;
           height: 100%;
         }

--- a/common/lib/xmodule/xmodule/css/video/display.scss
+++ b/common/lib/xmodule/xmodule/css/video/display.scss
@@ -719,7 +719,7 @@ div.video {
 
     a.hide-captions {
       i:before {
-        content: "\f0d9"; // Overriding `.icon-caret-right` to make it `.icon-caret-left`
+        content: "\f0d9"; // Overriding `.fa-caret-right` to make it `.fa-caret-left`
       }
     }
   }

--- a/common/lib/xmodule/xmodule/js/fixtures/video.html
+++ b/common/lib/xmodule/xmodule/js/fixtures/video.html
@@ -34,7 +34,7 @@
             </section>
             <a href="#" tabindex="0" class="hide-captions" role="button" aria-disabled="false"
                   title="${_('Turn off transcripts')}">
-              <i class="icon-caret-right" aria-hidden="true"></i>
+              <i class="fa fa-caret-right" aria-hidden="true"></i>
             </a>
             <div class="video-player-post"></div>
             <section class="closed-caption">

--- a/common/lib/xmodule/xmodule/js/fixtures/video.html
+++ b/common/lib/xmodule/xmodule/js/fixtures/video.html
@@ -6,6 +6,7 @@
         class="video closed"
         data-streams="0.5:7tqY6eQzVhE,1.0:cogebirgzzM,1.5:abcdefghijkl"
         data-show-captions="true"
+        data-show-closed-captions="true"
         data-save-state-url="/save_user_state"
         data-speed="1.5"
         data-start=""
@@ -31,7 +32,14 @@
             <section class="video-player">
               <iframe id="id"></iframe>
             </section>
+            <a href="#" tabindex="0" class="hide-captions" role="button" aria-disabled="false"
+                  title="${_('Turn off transcripts')}">
+              <i class="icon-caret-right" aria-hidden="true"></i>
+            </a>
             <div class="video-player-post"></div>
+            <section class="closed-caption">
+                <p class="text"></p>
+            </section>
             <section class="video-controls is-hidden">
               <div class="slider"></div>
               <div>

--- a/common/lib/xmodule/xmodule/js/fixtures/video_all.html
+++ b/common/lib/xmodule/xmodule/js/fixtures/video_all.html
@@ -5,6 +5,7 @@
         id="video_id"
         class="video closed"
         data-show-captions="true"
+        data-show-closed-captions="true"
         data-save-state-url="/save_user_state"
         data-speed="1.5"
         data-start=""
@@ -32,7 +33,14 @@
             <section class="video-player">
               <div id="id"></div>
             </section>
+            <a href="#" tabindex="0" class="hide-captions" role="button" aria-disabled="false"
+                  title="${_('Turn off transcripts')}">
+              <i class="icon-caret-right" aria-hidden="true"></i>
+            </a>
             <div class="video-player-post"></div>
+            <section class="closed-caption">
+                <p class="text"></p>
+            </section>
             <section class="video-controls is-hidden">
               <div class="slider"></div>
               <div>

--- a/common/lib/xmodule/xmodule/js/fixtures/video_all.html
+++ b/common/lib/xmodule/xmodule/js/fixtures/video_all.html
@@ -35,7 +35,7 @@
             </section>
             <a href="#" tabindex="0" class="hide-captions" role="button" aria-disabled="false"
                   title="${_('Turn off transcripts')}">
-              <i class="icon-caret-right" aria-hidden="true"></i>
+              <i class="fa fa-caret-right" aria-hidden="true"></i>
             </a>
             <div class="video-player-post"></div>
             <section class="closed-caption">

--- a/common/lib/xmodule/xmodule/js/fixtures/video_html5.html
+++ b/common/lib/xmodule/xmodule/js/fixtures/video_html5.html
@@ -5,6 +5,7 @@
         id="video_id"
         class="video closed"
         data-show-captions="true"
+        data-show-closed-captions="true"
         data-save-state-url="/save_user_state"
         data-speed="1.5"
         data-start=""

--- a/common/lib/xmodule/xmodule/js/fixtures/video_no_captions.html
+++ b/common/lib/xmodule/xmodule/js/fixtures/video_no_captions.html
@@ -6,6 +6,7 @@
         class="video closed"
         data-streams="0.5:7tqY6eQzVhE,1.0:cogebirgzzM,1.5:abcdefghijkl"
         data-show-captions="false"
+        data-show-closed-captions="false"
         data-save-state-url="/save_user_state"
         data-speed="1.5"
         data-start=""

--- a/common/lib/xmodule/xmodule/js/fixtures/video_yt_multiple.html
+++ b/common/lib/xmodule/xmodule/js/fixtures/video_yt_multiple.html
@@ -34,7 +34,7 @@
             </section>
             <a href="#" tabindex="0" class="hide-captions" role="button" aria-disabled="false"
                   title="${_('Turn off transcripts')}">
-              <i class="icon-caret-right" aria-hidden="true"></i>
+              <i class="fa fa-caret-right" aria-hidden="true"></i>
             </a>
             <div class="video-player-post"></div>
             <section class="closed-caption">
@@ -109,7 +109,7 @@
             </section>
             <a href="#" tabindex="0" class="hide-captions" role="button" aria-disabled="false"
                   title="${_('Turn off transcripts')}">
-              <i class="icon-caret-right" aria-hidden="true"></i>
+              <i class="fa fa-caret-right" aria-hidden="true"></i>
             </a>
             <div class="video-player-post"></div>
             <section class="closed-caption">
@@ -182,7 +182,7 @@
             </section>
             <a href="#" tabindex="0" class="hide-captions" role="button" aria-disabled="false"
                   title="${_('Turn off transcripts')}">
-              <i class="icon-caret-right" aria-hidden="true"></i>
+              <i class="fa fa-caret-right" aria-hidden="true"></i>
             </a>
             <div class="video-player-post"></div>
             <section class="closed-caption">

--- a/common/lib/xmodule/xmodule/js/fixtures/video_yt_multiple.html
+++ b/common/lib/xmodule/xmodule/js/fixtures/video_yt_multiple.html
@@ -6,6 +6,7 @@
         class="video closed"
         data-streams="0.5:7tqY6eQzVhE,1.0:cogebirgzzM,1.5:abcdefghijkl"
         data-show-captions="true"
+        data-show-closed-captions="true"
         data-save-state-url="/save_user_state"
         data-speed="1.5"
         data-start=""
@@ -31,7 +32,14 @@
             <section class="video-player">
               <iframe id="id1"></iframe>
             </section>
+            <a href="#" tabindex="0" class="hide-captions" role="button" aria-disabled="false"
+                  title="${_('Turn off transcripts')}">
+              <i class="icon-caret-right" aria-hidden="true"></i>
+            </a>
             <div class="video-player-post"></div>
+            <section class="closed-caption">
+                <p class="text"></p>
+            </section>
             <section class="video-controls is-hidden">
               <div class="slider"></div>
               <div>
@@ -56,7 +64,7 @@
                   <a href="#" class="add-fullscreen" title="Fill browser" role="button" aria-disabled="false">Fill Browser</a>
                   <a href="#" class="quality-control is-hidden" title="HD off" role="button" aria-disabled="false">HD off</a>
                   <div class="lang menu-container">
-                    <a href="#" class="hide-subtitles" title="Turn off captions" role="button" aria-disabled="false">Captions</a>
+                    <a href="#" class="hide-closed-captions" title="Turn off captions" role="button" aria-disabled="false">Captions</a>
                   </div>
                 </div>
               </div>
@@ -79,6 +87,7 @@
         class="video"
         data-streams="0.75:7tqY6eQzVhE,1.0:cogebirgzzM"
         data-show-captions="true"
+        data-show-closed-captions="true"
         data-speed="1.0"
         data-start=""
         data-end=""
@@ -98,7 +107,14 @@
             <section class="video-player">
               <iframe id="id2"></iframe>
             </section>
+            <a href="#" tabindex="0" class="hide-captions" role="button" aria-disabled="false"
+                  title="${_('Turn off transcripts')}">
+              <i class="icon-caret-right" aria-hidden="true"></i>
+            </a>
             <div class="video-player-post"></div>
+            <section class="closed-caption">
+                <p class="text"></p>
+            </section>
             <section class="video-controls">
               <div class="slider"></div>
               <div>
@@ -123,7 +139,7 @@
                   <a href="#" class="add-fullscreen" title="Fill browser">Fill Browser</a>
                   <a href="#" class="quality-control is-hidden" title="HD">HD</a>
                   <div class="lang menu-container">
-                    <a href="#" class="hide-subtitles" title="Turn off captions" role="button" aria-disabled="false">Captions</a>
+                    <a href="#" class="hide-closed-captions" title="Turn off captions" role="button" aria-disabled="false">Captions</a>
                   </div>
                 </div>
               </div>
@@ -144,6 +160,7 @@
         class="video"
         data-streams="0.75:7tqY6eQzVhE,1.0:cogebirgzzM"
         data-show-captions="true"
+        data-show-closed-captions="true"
         data-speed="1.0"
         data-start=""
         data-end=""
@@ -163,7 +180,14 @@
             <section class="video-player">
               <iframe id="id3"></iframe>
             </section>
+            <a href="#" tabindex="0" class="hide-captions" role="button" aria-disabled="false"
+                  title="${_('Turn off transcripts')}">
+              <i class="icon-caret-right" aria-hidden="true"></i>
+            </a>
             <div class="video-player-post"></div>
+            <section class="closed-caption">
+                <p class="text"></p>
+            </section>
             <section class="video-controls">
               <div class="slider"></div>
               <div>
@@ -188,7 +212,7 @@
                   <a href="#" class="add-fullscreen" title="Fill browser">Fill Browser</a>
                   <a href="#" class="quality-control is-hidden" title="HD">HD</a>
                   <div class="lang menu-container">
-                    <a href="#" class="hide-subtitles" title="Turn off captions" role="button" aria-disabled="false">Captions</a>
+                    <a href="#" class="hide-closed-captions" title="Turn off captions" role="button" aria-disabled="false">Captions</a>
                   </div>
                 </div>
               </div>

--- a/common/lib/xmodule/xmodule/js/js_test.yml
+++ b/common/lib/xmodule/xmodule/js/js_test.yml
@@ -59,6 +59,7 @@ lib_paths:
     - common_static/js/src/utility.js
     - public/js/split_test_staff.js
     - common_static/js/src/accessibility_tools.js
+    - common_static/js/vendor/draggabilly.pkgd.js
 
 # Paths to spec (test) JavaScript files
 spec_paths:

--- a/common/lib/xmodule/xmodule/js/spec/video/video_caption_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_caption_spec.js
@@ -593,7 +593,7 @@
             it(msg, function () {
                 spyOn(Caption, 'fetchAvailableTranslations');
                 $.ajax.andCallFake(function (settings) {
-//                    settings.error([]);
+                    settings.error([]);
                 });
 
                 state.config.transcriptLanguages = {};

--- a/common/lib/xmodule/xmodule/js/spec/video/video_caption_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_caption_spec.js
@@ -36,15 +36,15 @@
 
                 it('add caption control to video player', function () {
                     state = jasmine.initializePlayer();
-                    expect($('.video')).toContain('a.hide-subtitles');
+                    expect($('.video')).toContain('a.hide-captions');
                 });
 
                 it('add ARIA attributes to caption control', function () {
                     state = jasmine.initializePlayer();
-                    var captionControl = $('a.hide-subtitles');
+                    var captionControl = $('a.hide-captions');
                     expect(captionControl).toHaveAttrs({
                         'role': 'button',
-                        'title': 'Turn off captions',
+                        'title': 'Turn off transcripts',
                         'aria-disabled': 'false'
                     });
                 });
@@ -123,7 +123,7 @@
 
                 it('bind the hide caption button', function () {
                     state = jasmine.initializePlayer();
-                    expect($('.hide-subtitles')).toHandle('click');
+                    expect($('.hide-captions')).toHandle('click');
                 });
 
                 it('bind the mouse movement', function () {
@@ -371,7 +371,7 @@
                 });
 
                 it('captions panel is not shown', function () {
-                    expect(state.videoCaption.hideSubtitlesEl).toBeHidden();
+                    expect(state.videoCaption.hideCaptionsEl).toBeHidden();
                 });
             });
         });
@@ -593,7 +593,7 @@
             it(msg, function () {
                 spyOn(Caption, 'fetchAvailableTranslations');
                 $.ajax.andCallFake(function (settings) {
-                    settings.error([]);
+//                    settings.error([]);
                 });
 
                 state.config.transcriptLanguages = {};
@@ -604,7 +604,7 @@
                 expect(Caption.fetchAvailableTranslations).not.toHaveBeenCalled();
                 expect(Caption.hideCaptions.mostRecentCall.args)
                     .toEqual([true, false]);
-                expect(Caption.hideSubtitlesEl).toBeHidden();
+                expect(Caption.hideCaptionsEl).toBeHidden();
             });
 
             msg = 'on error: fetch available translations if there are ' +
@@ -696,7 +696,7 @@
 
                 expect($.ajaxWithPrefix).toHaveBeenCalled();
                 expect(Caption.hideCaptions).toHaveBeenCalledWith(true, false);
-                expect(Caption.hideSubtitlesEl).toBeHidden();
+                expect(Caption.hideCaptionsEl).toBeHidden();
             });
         });
 
@@ -897,7 +897,7 @@
                             controlHeight, shouldBeHeight;
 
                         state.captionsHidden = true;
-                        state.videoCaption.setSubtitlesHeight();
+                        state.videoCaption.setCaptionsHeight();
 
                         realHeight = parseInt(
                             $('.subtitles').css('maxHeight'), 10
@@ -1046,7 +1046,7 @@
             describe('when the caption is visible', function () {
                 beforeEach(function () {
                     state.el.removeClass('closed');
-                    state.videoCaption.toggle(jQuery.Event('click'));
+                    state.videoCaption.toggleCaptions(jQuery.Event('click'));
                 });
 
                 it('log the hide_transcript event', function () {
@@ -1063,15 +1063,15 @@
                 });
 
                 it('changes ARIA attribute of caption control', function () {
-                    expect($('a.hide-subtitles'))
-                        .toHaveAttr('title', 'Turn on captions');
+                    expect($('a.hide-captions'))
+                        .toHaveAttr('title', 'Turn on transcripts');
                 });
             });
 
             describe('when the caption is hidden', function () {
                 beforeEach(function () {
                     state.el.addClass('closed');
-                    state.videoCaption.toggle(jQuery.Event('click'));
+                    state.videoCaption.toggleCaptions(jQuery.Event('click'));
                     jasmine.Clock.useMock();
                 });
 
@@ -1089,12 +1089,12 @@
                 });
 
                 it('changes ARIA attribute of caption control', function () {
-                    expect($('a.hide-subtitles'))
-                        .toHaveAttr('title', 'Turn off captions');
+                    expect($('a.hide-captions'))
+                        .toHaveAttr('title', 'Turn off transcripts');
                 });
 
                 // Test turned off due to flakiness (11/25/13)
-                xit('scroll the caption', function () {
+                it('scroll the caption', function () {
                     // After transcripts are shown, and the video plays for a
                     // bit.
                     jasmine.Clock.tick(1000);

--- a/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
+++ b/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
@@ -254,6 +254,32 @@ function (VideoPlayer, VideoStorage, i18n) {
         }
     }
 
+    // function _configureClosedCaptions(state)
+    //     Configure displaying of closed captions.
+    //
+    //     Option
+    //         this.config.showClosedCaptions = true | false
+    //
+    //     Defines whether or not closed captions are shown on first viewing.
+    //
+    //     Option
+    //          this.hide_closed_captions = true | false
+    //
+    //     represents the user's choice of having the closed captions shown or
+    //     hidden. This choice is stored in cookies.
+    function _configureClosedCaptions(state) {
+        if (state.config.showClosedCaptions) {
+            state.hide_closed_captions = ($.cookie('hide_closed_captions') === 'true');
+        } else {
+            state.hide_closed_captions = true;
+
+            $.cookie('hide_closed_captions', state.hide_closed_captions, {
+                expires: 3650,
+                path: '/'
+            });
+        }
+    }
+
     // function _parseYouTubeIDs(state)
     //     The function parse YouTube stream ID's.
     //     @return
@@ -299,6 +325,7 @@ function (VideoPlayer, VideoStorage, i18n) {
         if (!state.config.sub || !state.config.sub.length) {
             state.config.sub = '';
             state.config.showCaptions = false;
+            state.config.showClosedCaptions = false;
         }
         state.setSpeed(state.speed);
 
@@ -317,6 +344,7 @@ function (VideoPlayer, VideoStorage, i18n) {
 
     function _setConfigurations(state) {
         _configureCaptions(state);
+        _configureClosedCaptions(state);
         state.setPlayerMode(state.config.mode);
         // Possible value are: 'visible', 'hiding', and 'invisible'.
         state.controlState = 'visible';
@@ -357,6 +385,7 @@ function (VideoPlayer, VideoStorage, i18n) {
                 // Conversions used to pre-process some configuration data.
                 conversions = {
                     'showCaptions': isBoolean,
+                    'showClosedCaptions': isBoolean,
                     'autoplay': isBoolean,
                     'autohideHtml5': isBoolean,
                     'savedVideoPosition': function (value) {

--- a/common/lib/xmodule/xmodule/js/src/video/03_video_player.js
+++ b/common/lib/xmodule/xmodule/js/src/video/03_video_player.js
@@ -938,7 +938,7 @@ function (HTML5Video, Resizer) {
             logInfo.code = 'html5';
         }
 
-        Logger.log(eventName, logInfo);
+                Logger.log(eventName, logInfo);
     }
 
     function onVolumeChange(volume) {

--- a/common/lib/xmodule/xmodule/js/src/video/04_video_control.js
+++ b/common/lib/xmodule/xmodule/js/src/video/04_video_control.js
@@ -260,9 +260,13 @@ function () {
     }
 
     /** Toggle fullscreen mode. */
+    // Also change the transcript toggle icon color
     function toggleFullScreen() {
         var fullScreenClassNameEl = this.el.add(document.documentElement),
-            win = $(window), text;
+            win = $(window),
+            $transcriptIcon = this.el.find('span.transcript-toggle i'),
+            $transcriptIconParent = $transcriptIcon.parent(),
+            text;
 
         if (this.videoControl.fullScreenState) {
             this.videoControl.fullScreenState = this.isFullScreen = false;

--- a/common/lib/xmodule/xmodule/js/src/video/08_video_speed_control.js
+++ b/common/lib/xmodule/xmodule/js/src/video/08_video_speed_control.js
@@ -222,7 +222,7 @@ function (Iterator) {
             if (!this.speedLinks.list.is(':focus')) {
                 this.closeMenu();
             }
-                    
+
             return false;
         },
 
@@ -250,7 +250,7 @@ function (Iterator) {
             // We do not stop propagation and default behavior on a TAB
             // keypress.
             return event.keyCode === KEY.TAB;
-        },
+        },
 
         /**
          * Keydown event handler for speed links.
@@ -318,7 +318,7 @@ function (Iterator) {
             }
 
             return true;
-        }
+        }
     };
 
     return SpeedControl;

--- a/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
@@ -47,11 +47,11 @@ function (Sjson, AsyncProcess) {
             this.loaded = false;
             this.container = state.el.find('.lang');
 
-            this.hideCaptionsEl = state.el.find('a.hide-captions');
-            this.subtitlesEl = state.el.find('ol.subtitles');
+            this.hideCaptionsEl = state.el.find('.hide-captions');
+            this.subtitlesEl = state.el.find('.subtitles');
 
-            this.hideClosedCaptionsEl = state.el.find('a.hide-closed-captions');
-            this.closedCaptionsEl = state.el.find('section.closed-caption');
+            this.hideClosedCaptionsEl = state.el.find('.hide-closed-captions');
+            this.closedCaptionsEl = state.el.find('.closed-caption');
 
             if (_.keys(languages).length) {
                 this.renderLanguageMenu(languages);

--- a/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
@@ -843,7 +843,8 @@ function (Sjson, AsyncProcess) {
         * @param {jquery Event} event
         *
         */
-        toggleCaptions: function () {
+        toggleCaptions: function (e) {
+            e.preventDefault();
             var hide_captions = !this.state.el.hasClass('closed');
             this.hideCaptions(hide_captions);
         },

--- a/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
@@ -1,4 +1,4 @@
-(function (define) {
+(function (define, Draggabilly) {
 
 // VideoCaption module.
 define(
@@ -10,6 +10,9 @@ function (Sjson, AsyncProcess) {
      *
      * @type {function}
      * @access public
+     *
+     *
+     * TODO: How to include Draggabilly correctly?
      *
      * @param {object} state - The object containing the state of the video
      *     player. All other modules, their parameters, public variables, etc.
@@ -31,6 +34,7 @@ function (Sjson, AsyncProcess) {
         return $.Deferred().resolve().promise();
     };
 
+    // TODO: Make the difference clear between captions and transcripts
     VideoCaption.prototype = {
         /**
         * @desc Initiate rendering of elements, and set their initial configuration.
@@ -41,20 +45,28 @@ function (Sjson, AsyncProcess) {
                 languages = this.state.config.transcriptLanguages;
 
             this.loaded = false;
-            this.subtitlesEl = state.el.find('ol.subtitles');
             this.container = state.el.find('.lang');
-            this.hideSubtitlesEl = state.el.find('a.hide-subtitles');
+
+            this.hideCaptionsEl = state.el.find('a.hide-captions');
+            this.subtitlesEl = state.el.find('ol.subtitles');
+
+            this.hideClosedCaptionsEl = state.el.find('a.hide-closed-captions');
+            this.closedCaptionsEl = state.el.find('section.closed-caption');
 
             if (_.keys(languages).length) {
                 this.renderLanguageMenu(languages);
 
                 if (!this.fetchCaption()) {
                     this.hideCaptions(true);
-                    this.hideSubtitlesEl.hide();
+                    this.hideClosedCaptions(true);
+                    this.hideClosedCaptionsEl.hide();
+                    this.hideCaptionsEl.hide();
                 }
             } else {
                 this.hideCaptions(true, false);
-                this.hideSubtitlesEl.hide();
+                this.hideClosedCaptions(true, false);
+                this.hideClosedCaptionsEl.hide();
+                this.hideCaptionsEl.hide();
             }
         },
 
@@ -72,7 +84,7 @@ function (Sjson, AsyncProcess) {
                 ].join(' ');
 
             // Change context to VideoCaption of event handlers using `bind`.
-            this.hideSubtitlesEl.on('click', this.toggle.bind(this));
+            this.hideClosedCaptionsEl.on('click', this.toggleClosedCaptions.bind(this));
             this.subtitlesEl
                 .on({
                     mouseenter: this.onMouseEnter.bind(this),
@@ -128,6 +140,16 @@ function (Sjson, AsyncProcess) {
             if ((state.videoType === 'html5') && (state.config.autohideHtml5)) {
                 this.subtitlesEl.on('scroll', state.videoControl.showControls);
             }
+
+            // Make the captions draggable
+            new Draggabilly(this.closedCaptionsEl.find('.text').get(0), {
+                axis: 'y',
+                containment: state.el.find('.video-wrapper').get(0)
+            });
+
+            // Bind the captions toggle icon
+            this.hideCaptionsEl
+                .on('click', this.toggleCaptions.bind(this));
         },
 
         /**
@@ -214,8 +236,10 @@ function (Sjson, AsyncProcess) {
 
             if (this.loaded) {
                 this.hideCaptions(false);
+                this.hideClosedCaptions(false);
             } else {
                 this.hideCaptions(state.hide_captions, false);
+                this.hideClosedCaptions(state.hide_closed_captions, false);
             }
 
             if (this.fetchXHR && this.fetchXHR.abort) {
@@ -281,7 +305,9 @@ function (Sjson, AsyncProcess) {
                         self.fetchAvailableTranslations();
                     } else {
                         self.hideCaptions(true, false);
-                        self.hideSubtitlesEl.hide();
+                        self.hideClosedCaptions(true, false);
+                        self.hideClosedCaptionsEl.hide();
+                        self.hideCaptionsEl.hide();
                     }
                 }
             });
@@ -319,7 +345,9 @@ function (Sjson, AsyncProcess) {
                 },
                 error: function (jqXHR, textStatus, errorThrown) {
                     self.hideCaptions(true, false);
-                    self.hideSubtitlesEl.hide();
+                    self.hideClosedCaptions(true, false);
+                    self.hideClosedCaptionsEl.hide();
+                    self.hideCaptionsEl.hide();
                 }
             });
         },
@@ -676,6 +704,12 @@ function (Sjson, AsyncProcess) {
                         .find("li[data-index='" + newIndex + "']")
                         .addClass('current');
 
+
+                    var captions = this.sjson.getCaptions();
+                    this.closedCaptionsEl
+                        .find('.text')
+                        .text(captions[newIndex]);
+
                     this.currentIndex = newIndex;
                     this.scrollCaption();
                 }
@@ -743,33 +777,90 @@ function (Sjson, AsyncProcess) {
         },
 
         /**
-        * @desc Shows/Hides captions on click `CC` button
+        * @desc Shows/Hides closed captions on click `CC` button
         *
         * @param {jquery Event} event
         *
         */
-        toggle: function (event) {
+        toggleClosedCaptions: function (event) {
             event.preventDefault();
 
-            if (this.state.el.hasClass('closed')) {
-                this.hideCaptions(false);
+            var hide_closed_captions = this.closedCaptionsEl.is(':visible');
+            this.hideClosedCaptions(hide_closed_captions);
+        },
+
+        /**
+        * @desc Shows/Hides closed captions and updates the cookie.
+        *
+        * @param {boolean} hide_closed_captions if `true` hides the caption,
+        *     otherwise - show.
+        *
+        * @param {boolean} update_cookie Flag to update or not the cookie.
+        *
+        */
+        hideClosedCaptions: function (hide_closed_captions, update_cookie) {
+            var hideClosedCaptionsEl = this.hideClosedCaptionsEl,
+                state = this.state,
+                type, text;
+
+            if (typeof update_cookie === 'undefined') {
+                update_cookie = true;
+            }
+
+            if (hide_closed_captions) {
+                type = 'hide_closed_captions';
+                state.closedCaptionsHidden = true;
+                this.closedCaptionsEl.fadeOut(0);
+                text = gettext('Turn on closed captions');
             } else {
-                this.hideCaptions(true);
+                type = 'show_closed_captions';
+                state.closedCaptionsHidden = false;
+                this.closedCaptionsEl.fadeIn(0);
+                text = gettext('Turn off closed captions');
+            }
+
+            hideClosedCaptionsEl
+                .attr('title', text)
+                .text(gettext(text));
+
+            if (state.videoPlayer) {
+                state.videoPlayer.log(type, {
+                    currentTime: state.videoPlayer.currentTime
+                });
+            }
+
+            if (update_cookie) {
+                $.cookie('hide_closed_captions', hide_closed_captions, {
+                    expires: 3650,
+                    path: '/'
+                });
             }
         },
 
         /**
-        * @desc Shows/Hides captions and updates the cookie.
+        * @desc Shows/Hides captions on click `arrow` button
         *
-        * @param {boolean} hide_captions if `true` hides the caption,
-        *     otherwise - show.
-        * @param {boolean} update_cookie Flag to update or not the cookie.
+        * @param {jquery Event} event
         *
         */
+        toggleCaptions: function () {
+            var hide_captions = !this.state.el.hasClass('closed');
+            this.hideCaptions(hide_captions);
+        },
+
+        /**
+        * @desc Shows/Hides the captions and updates the cookie.
+        *
+        * @param {boolean} hide_captions if `true` hides the transcript,
+        *     otherwise - show.
+        *
+        * @param {boolean} update_cookie Flag to update or not the cookie.        *
+        */
         hideCaptions: function (hide_captions, update_cookie) {
-            var hideSubtitlesEl = this.hideSubtitlesEl,
-                state = this.state,
-                type, text;
+            var  hideClosedCaptionsEl = this.hideClosedCaptionsEl,
+                 state = this.state,
+                 type, text;
+
 
             if (typeof update_cookie === 'undefined') {
                 update_cookie = true;
@@ -779,18 +870,19 @@ function (Sjson, AsyncProcess) {
                 type = 'hide_transcript';
                 state.captionsHidden = true;
                 state.el.addClass('closed');
-                text = gettext('Turn on captions');
+                text = gettext('Turn on transcripts');
             } else {
                 type = 'show_transcript';
                 state.captionsHidden = false;
                 state.el.removeClass('closed');
                 this.scrollCaption();
-                text = gettext('Turn off captions');
+                text = gettext('Turn off transcripts');
             }
 
-            hideSubtitlesEl
+
+            this.hideCaptionsEl
                 .attr('title', text)
-                .text(gettext(text));
+                .attr('aria-label', gettext(text));
 
             if (state.videoPlayer) {
                 state.videoPlayer.log(type, {
@@ -807,6 +899,7 @@ function (Sjson, AsyncProcess) {
             }
 
             this.setSubtitlesHeight();
+
             if (update_cookie) {
                 $.cookie('hide_captions', hide_captions, {
                     expires: 3650,
@@ -833,7 +926,7 @@ function (Sjson, AsyncProcess) {
 
         /**
         * @desc Sets the height of the caption container element.
-        *
+        * TODO: Make the difference clear between captions and transcripts i.e. shouldn't this be just `caption` instead of `subtitle`.
         */
         setSubtitlesHeight: function () {
             var height = 0,
@@ -860,4 +953,4 @@ function (Sjson, AsyncProcess) {
     return VideoCaption;
 });
 
-}(RequireJS.define));
+}(RequireJS.define, Draggabilly));

--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -82,6 +82,7 @@ class VideoModule(VideoFields, VideoTranscriptsMixin, VideoStudentViewHandlers, 
     XML source example:
 
         <video show_captions="true"
+               show_closed_captions="true"
             youtube="0.75:jNCf2gIqpeE,1.0:ZwkTiUPN0mg,1.25:rsq9auxASqI,1.50:kMyNdzVHHgg"
             url_name="lecture_21_3" display_name="S19V3: Vacancies"
         >
@@ -98,6 +99,7 @@ class VideoModule(VideoFields, VideoTranscriptsMixin, VideoStudentViewHandlers, 
     module = __name__.replace('.video_module', '', 2)
     js = {
         'js': [
+            resource_string(module, 'js/common_static/js/vendor/draggabilly.pkgd.js'),
             resource_string(module, 'js/src/video/00_component.js'),
             resource_string(module, 'js/src/video/00_video_storage.js'),
             resource_string(module, 'js/src/video/00_resizer.js'),
@@ -241,6 +243,7 @@ class VideoModule(VideoFields, VideoTranscriptsMixin, VideoStudentViewHandlers, 
             'handout': self.handout,
             'id': self.location.html_id(),
             'show_captions': json.dumps(self.show_captions),
+            'show_closed_captions': json.dumps(self.show_closed_captions),
             'download_video_link': download_video_link,
             'sources': json.dumps(sources),
             'speed': json.dumps(self.speed),
@@ -433,6 +436,7 @@ class VideoDescriptor(VideoFields, VideoTranscriptsMixin, VideoStudioViewHandler
         attrs = {
             'display_name': self.display_name,
             'show_captions': json.dumps(self.show_captions),
+            'show_closed_captions': json.dumps(self.show_closed_captions),
             'start_time': self.start_time,
             'end_time': self.end_time,
             'sub': self.sub,

--- a/common/lib/xmodule/xmodule/video_module/video_xfields.py
+++ b/common/lib/xmodule/xmodule/video_module/video_xfields.py
@@ -108,6 +108,12 @@ class VideoFields(object):
         scope=Scope.settings,
         default=True
     )
+    show_closed_captions = Boolean(
+        help=_("Specify whether the closed captions appear with the video by default."),
+        display_name=_("Show Closed Captions"),
+        scope=Scope.settings,
+        default=True
+    )
     # Data format: {'de': 'german_translation', 'uk': 'ukrainian_translation'}
     transcripts = Dict(
         help=_("Add transcripts in different languages. Click below to specify a language and upload an .srt transcript file for that language."),

--- a/common/test/acceptance/pages/lms/video/video.py
+++ b/common/test/acceptance/pages/lms/video/video.py
@@ -13,7 +13,8 @@ import logging
 log = logging.getLogger('VideoPage')
 
 VIDEO_BUTTONS = {
-    'CC': '.hide-subtitles',
+    'CC': '.hide-closed-captions',
+    'transcripts': '.hide-captions',
     'volume': '.volume',
     'play': '.video_control.play',
     'pause': '.video_control.pause',
@@ -282,13 +283,13 @@ class VideoPage(PageObject):
         states = {True: 'Shown', False: 'Hidden'}
         state = states[captions_new_state]
 
-        # Make sure that the CC button is there
-        EmptyPromise(lambda: self.is_button_shown('CC'),
-                     "CC button is shown").fulfill()
+        # Make sure that the transcripts button is there
+        EmptyPromise(lambda: self.is_button_shown('transcripts'),
+                     "transcripts button is shown").fulfill()
 
         # toggle captions visibility state if needed
         if self.is_captions_visible() != captions_new_state:
-            self.click_player_button('CC')
+            self.click_player_button('transcripts')
 
             # Verify that captions state is toggled/changed
             EmptyPromise(lambda: self.is_captions_visible() == captions_new_state,
@@ -511,8 +512,8 @@ class VideoPage(PageObject):
         """
         self.wait_for_ajax()
 
-        # mouse over to CC button
-        cc_button_selector = self.get_element_selector(VIDEO_BUTTONS["CC"])
+        # mouse over to transcripts button
+        cc_button_selector = self.get_element_selector(VIDEO_BUTTONS["transcripts"])
         element_to_hover_over = self.q(css=cc_button_selector).results[0]
         ActionChains(self.browser).move_to_element(element_to_hover_over).perform()
 

--- a/lms/djangoapps/courseware/features/video.py
+++ b/lms/djangoapps/courseware/features/video.py
@@ -39,7 +39,8 @@ HTML5_SOURCES_INCORRECT = [
 ]
 
 VIDEO_BUTTONS = {
-    'CC': '.hide-subtitles',
+    'CC': '.hide-closed-captions',
+    'transcripts': '.hide-captions',
     'volume': '.volume',
     'play': '.video_control.play',
     'pause': '.video_control.pause',
@@ -441,10 +442,10 @@ def set_captions_visibility_state(_step, captions_state):
     SELECTOR = '.closed .subtitles'
     if world.is_css_not_present(SELECTOR):
         if captions_state == 'closed':
-            world.css_click('.hide-subtitles')
+            world.css_click('.hide-captions')
     else:
         if captions_state != 'closed':
-            world.css_click('.hide-subtitles')
+            world.css_click('.hide-captions')
 
 
 @step('I see video menu "([^"]*)" with correct items$')
@@ -491,7 +492,7 @@ def select_language(_step, code):
         code=code
     )
 
-    world.css_find(VIDEO_BUTTONS["CC"])[0].mouse_over()
+    world.css_find(VIDEO_BUTTONS["transcripts"])[0].mouse_over()
     world.wait_for_present('.lang.open')
     world.css_click(selector)
 

--- a/lms/templates/video.html
+++ b/lms/templates/video.html
@@ -63,7 +63,7 @@
 
           <a href="#" tabindex="0" class="hide-captions" role="button" aria-disabled="false"
                 title="${_('Turn off transcripts')}">
-            <i class="icon-caret-right" aria-hidden="true"></i>
+            <i class="fa fa-caret-right" aria-hidden="true"></i>
           </a>
 
           <div class="video-player-post"></div>

--- a/lms/templates/video.html
+++ b/lms/templates/video.html
@@ -17,6 +17,7 @@
     data-save-state-url="${ajax_url}"
     data-caption-data-dir="${data_dir}"
     data-show-captions="${show_captions}"
+    data-show-closed-captions="${show_closed_captions}"
     data-general-speed="${general_speed}"
     data-speed="${speed}"
     data-saved-video-position="${saved_video_position}"
@@ -59,7 +60,16 @@
               <div id="${id}"></div>
               <h3 class="hidden">${_('No playable video sources found.')}</h3>
           </section>
+
+          <a href="#" tabindex="0" class="hide-captions" role="button" aria-disabled="false"
+                title="${_('Turn off transcripts')}">
+            <i class="icon-caret-right" aria-hidden="true"></i>
+          </a>
+
           <div class="video-player-post"></div>
+          <section class="closed-caption">
+              <p class="text"></p>
+          </section>
           <section class="video-controls is-hidden">
               <div class="slider" title="${_('Video position')}"></div>
               <div>
@@ -85,7 +95,7 @@
                       <a href="#" class="quality-control is-hidden" title="${_('HD off')}" role="button" aria-disabled="false">${_('HD off')}</a>
 
                       <div class="lang menu-container">
-                        <a href="#" class="hide-subtitles" title="${_('Turn off captions')}" role="button" aria-disabled="false">${_('Turn off captions')}</a>
+                        <a href="#" class="hide-closed-captions" title="${_('Turn off captions')}" role="button" aria-disabled="false">${_('Turn off captions')}</a>
                       </div>
                   </div>
               </div>


### PR DESCRIPTION
This from the hackathon.
## TODO's
- [x] Good look
- [x] Adapts to the both the video and the screen size
- [x] Allows user to view both transcript and closed captions
- [x] User can re-position the closed captions (vertically)
- [x] Totally removed the side-bar, we should both
- [x] Saves the user preference on cookies
- [x] Not configurable ~~in django-settings~~ in Studio
- [x] In code todo's?
- [x] Repositioning closed captions while video is playing is not smooth
- [x] Unclean code
- [x] Use [dragabilly](https://github.com/desandro/draggabilly) library instead of jQuery UI, for moving the closed captions (if we keep the feature)
- [ ] UX review
- [ ] Fix automated tests
## Good to Do
- [ ] Include Draggabilly correctly I've got `script error` while trying to include it using AMD style
- [ ] Make the difference clearer between captions and transcripts
- [ ] Still an xmodule
- [ ] Rebase?
## Screenshots

**Captions Only**
![image](https://cloud.githubusercontent.com/assets/645156/5489569/2b19a21a-86d3-11e4-9bd5-2b2a304a6932.png)

**Captions and Transcripts**
![image](https://cloud.githubusercontent.com/assets/645156/5489575/39604e78-86d3-11e4-8908-deff55827a6b.png)

**None**
![image](https://cloud.githubusercontent.com/assets/645156/5489581/3fba1cae-86d3-11e4-9755-36e3481972f4.png)
## Too-long don't read stuff on the wiki

https://openedx.atlassian.net/wiki/display/A11Y/Media
