### PR TITLE
Tender widget inavailability stops loading studio page

### DIFF
--- a/cms/templates/widgets/tender.html
+++ b/cms/templates/widgets/tender.html
@@ -7,6 +7,10 @@ window.Tender = {
   hide_kb: 'true',
   widgetToggles: document.getElementsByClassName('show-tender')
 }
-require(['tender']);
+require(['domReady'], function (domReady) {
+  domReady(function () {
+      require(['tender']);
+  });
+});
 </script>
 % endif


### PR DESCRIPTION
When tender_widget.js is inavailable studio page stops
loading becuase of error in the requirejs. It is
dependency in the requirejs so when it doesn't load
it cause other dependencies to stop loading.

TNL-1018
