### PR TITLE
Tender widget inavailability stops loading studio page

### DIFF
--- a/cms/templates/widgets/tender.html
+++ b/cms/templates/widgets/tender.html
@@ -7,6 +7,14 @@ window.Tender = {
   hide_kb: 'true',
   widgetToggles: document.getElementsByClassName('show-tender')
 }
-require(['tender']);
+// In order to avoid requirejs timeout errors should tender not be
+// available, we're not using domReady as a loader plugin here.
+// For more details, please see the note at
+// http://requirejs.org/docs/api.html#pageload
+require(['domReady'], function (domReady) {
+  domReady(function () {
+      require(['tender']);
+  });
+});
 </script>
 % endif

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -131,7 +131,7 @@ update_module_store_settings(
         'fs_root': TEST_ROOT / "data",
     },
     xml_store_options={
-        'data_dir': mkdtemp(),  # never inadvertently load all the XML courses
+        'data_dir': mkdtemp(dir=TEST_ROOT),  # never inadvertently load all the XML courses
     },
     doc_store_settings={
         'host': MONGO_HOST,


### PR DESCRIPTION
When tender_widget.js is inavailable studio page stops
loading becuase of error in the requirejs. It is
dependency in the requirejs so when it doesn't load
it cause other dependencies to stop loading.

TNL-1018
