### PR TITLE
Replace "edX Studio" with "{studio_name}"

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -41,7 +41,7 @@ from dealer.git import git
 from xmodule.modulestore.edit_info import EditInfoMixin
 
 ############################ FEATURE CONFIGURATION #############################
-
+STUDIO_NAME = "{platform_name} Studio".format(platform_name=PLATFORM_NAME)
 FEATURES = {
     'USE_DJANGO_PIPELINE': True,
 

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -45,6 +45,8 @@ STUDIO_SHORT_NAME = "Studio"
 STUDIO_NAME = "{platform_name} {short_name}".format(
     platform_name=PLATFORM_NAME, short_name=STUDIO_SHORT_NAME,
 )
+# Note that if you redefine STUDIO_SHORT_NAME in another settings file,
+# you'll also need to redefine STUDIO_NAME -- it won't automatically inherit.
 FEATURES = {
     'USE_DJANGO_PIPELINE': True,
 

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -41,7 +41,10 @@ from dealer.git import git
 from xmodule.modulestore.edit_info import EditInfoMixin
 
 ############################ FEATURE CONFIGURATION #############################
-STUDIO_NAME = "{platform_name} Studio".format(platform_name=PLATFORM_NAME)
+STUDIO_SHORT_NAME = "Studio"
+STUDIO_NAME = "{platform_name} {short_name}".format(
+    platform_name=PLATFORM_NAME, short_name=STUDIO_SHORT_NAME,
+)
 FEATURES = {
     'USE_DJANGO_PIPELINE': True,
 

--- a/cms/static/js/sock.js
+++ b/cms/static/js/sock.js
@@ -3,12 +3,22 @@ require(["domReady", "jquery", "jquery.smoothScroll"],
         var toggleSock = function (e) {
             e.preventDefault();
 
-            var $btnLabel = $(this).find('.copy');
+            var $btnShowSockLabel = $(this).find('.copy-show');
+            var $btnHideSockLabel = $(this).find('.copy-hide');
             var $sock = $('.wrapper-sock');
             var $sockContent = $sock.find('.wrapper-inner');
 
-            $sock.toggleClass('is-shown');
-            $sockContent.toggle('fast');
+            if ($sock.hasClass('is-shown')) {
+                $sock.removeClass('is-shown');
+                $sockContent.hide('fast');
+                $btnHideSockLabel.removeClass("is-shown").addClass("is-hidden");
+                $btnShowSockLabel.removeClass("is-hidden").addClass("is-shown");
+            } else {
+                $sock.addClass('is-shown');
+                $sockContent.show('fast');
+                $btnHideSockLabel.removeClass("is-hidden").addClass("is-shown");
+                $btnShowSockLabel.removeClass("is-shown").addClass("is-hidden");
+            }
 
             $.smoothScroll({
                 offset: -200,
@@ -17,12 +27,6 @@ require(["domReady", "jquery", "jquery.smoothScroll"],
                 scrollElement: null,
                 scrollTarget: $sock
             });
-
-            if ($sock.hasClass('is-shown')) {
-                $btnLabel.text(gettext('Hide Studio Help'));
-            } else {
-                $btnLabel.text(gettext('Looking for Help with Studio?'));
-            }
         };
 
         domReady(function () {

--- a/cms/templates/500.html
+++ b/cms/templates/500.html
@@ -1,6 +1,6 @@
 <%! from django.utils.translation import ugettext as _ %>
 <%inherit file="base.html" />
-<%block name="title">${_("{studio_name} Server Error").format(studio_name=settings.STUDIO_NAME)}</%block>
+<%block name="title">${_("{studio_name} Server Error").format(studio_name=settings.STUDIO_SHORT_NAME)}</%block>
 <%block name="bodyclass">view-util util-500</%block>
 
 <%block name="content">
@@ -9,13 +9,13 @@
     <header>
       <h1 class="title title-1">
         ${_("The {studio_name} servers encountered an error").format(
-          studio_name="<em>{studio_name}</em>".format(studio_name=settings.STUDIO_NAME)
+          studio_name="<em>{studio_name}</em>".format(studio_name=settings.STUDIO_SHORT_NAME)
         )}
       </h1>
     </header>
     <article class="content-primary" role="main">
       <p>
-        ${_("An error occurred in {studio_name} and the page could not be loaded. Please try again in a few moments.").format(studio_name=settings.STUDIO_NAME)}
+        ${_("An error occurred in {studio_name} and the page could not be loaded. Please try again in a few moments.").format(studio_name=settings.STUDIO_SHORT_NAME)}
         ${_("We've logged the error and our staff is currently working to resolve this error as soon as possible.")}
         ${_('If the problem persists, please email us at {email_link}.').format(
               email_link=u'<a href="mailto:{email_address}">{email_address}</a>'.format(

--- a/cms/templates/500.html
+++ b/cms/templates/500.html
@@ -1,17 +1,21 @@
 <%! from django.utils.translation import ugettext as _ %>
 <%inherit file="base.html" />
-<%block name="title">${_("Studio Server Error")}</%block>
+<%block name="title">${_("{studio_name} Server Error").format(studio_name=settings.STUDIO_NAME)}</%block>
 <%block name="bodyclass">view-util util-500</%block>
 
 <%block name="content">
 <div class="wrapper-content wrapper">
   <section class="content">
     <header>
-      <h1 class="title title-1">${_("The <em>Studio</em> servers encountered an error")}</h1>
+      <h1 class="title title-1">
+        ${_("The {studio_name} servers encountered an error").format(
+          studio_name="<em>{studio_name}</em>".format(studio_name=settings.STUDIO_NAME)
+        )}
+      </h1>
     </header>
     <article class="content-primary" role="main">
       <p>
-        ${_("An error occurred in Studio and the page could not be loaded. Please try again in a few moments.")}
+        ${_("An error occurred in {studio_name} and the page could not be loaded. Please try again in a few moments.").format(studio_name=settings.STUDIO_NAME)}
         ${_("We've logged the error and our staff is currently working to resolve this error as soon as possible.")}
         ${_('If the problem persists, please email us at {email_link}.').format(
               email_link=u'<a href="mailto:{email_address}">{email_address}</a>'.format(

--- a/cms/templates/activation_active.html
+++ b/cms/templates/activation_active.html
@@ -5,7 +5,7 @@
 <div class="wrapper-mast wrapper sr">
   <header class="mast">
     <h1 class="page-header">
-      ${_("{studio_name} Account Activation").format(studio_name=settings.STUDIO_NAME)}
+      ${_("{studio_name} Account Activation").format(studio_name=settings.STUDIO_SHORT_NAME)}
     </h1>
   </header>
 </div>
@@ -26,7 +26,7 @@
       <ul class="list-actions">
         <li class="action-item">
           <a href="/signin" class="action-primary action-signin">
-            ${_("Sign into {studio_name}").format(platform_name=settings.STUDIO_NAME)}
+            ${_("Sign into {studio_name}").format(platform_name=settings.STUDIO_SHORT_NAME)}
           </a>
         </li>
       </ul>

--- a/cms/templates/activation_active.html
+++ b/cms/templates/activation_active.html
@@ -4,7 +4,9 @@
 <%block name="content">
 <div class="wrapper-mast wrapper sr">
   <header class="mast">
-    <h1 class="page-header">${_("Studio Account Activation")}</h1>
+    <h1 class="page-header">
+      ${_("{studio_name} Account Activation").format(studio_name=settings.STUDIO_NAME)}
+    </h1>
   </header>
 </div>
 
@@ -17,13 +19,15 @@
       <div class="msg">
         <h2 class="title">${_("Your account is already active")}</h2>
         <div class="copy">
-          <p>${_("This account, set up using {0}, has already been activated. Please sign in to start working within edX Studio.".format(user.email))}</p>
+          <p>${_("This account, set up using {email}, has already been activated. Please sign in to start working within {studio_name}.".format(email=user.email, studio_name=settings.STUDIO_NAME))}</p>
         </div>
       </div>
 
       <ul class="list-actions">
         <li class="action-item">
-          <a href="/signin" class="action-primary action-signin">${_("Sign into Studio")}</a>
+          <a href="/signin" class="action-primary action-signin">
+            ${_("Sign into {studio_name}").format(platform_name=settings.STUDIO_NAME)}
+          </a>
         </li>
       </ul>
     </div>

--- a/cms/templates/activation_complete.html
+++ b/cms/templates/activation_complete.html
@@ -4,7 +4,7 @@
 <%block name="content">
 <div class="wrapper-mast wrapper sr">
   <header class="mast">
-    <h1 class="page-header">${_("Studio Account Activation")}</h1>
+    <h1 class="page-header">${_("{studio_name} Account Activation").format(studio_name=settings.STUDIO_NAME)}</h1>
   </header>
 </div>
 
@@ -17,13 +17,15 @@
       <div class="msg">
         <h1 class="title">${_("Your account activation is complete!")}</h1>
         <div class="copy">
-          <p>${_("Thank you for activating your account. You may now sign in and start using edX Studio to author courses.")}</p>
+          <p>${_("Thank you for activating your account. You may now sign in and start using {studio_name} to author courses.").format(studio_name=settings.STUDIO_NAME)}</p>
         </div>
       </div>
 
       <ul class="list-actions">
         <li class="action-item">
-          <a href="/signin" class="action-primary action-signin">${_("Sign into Studio")}</a>
+          <a href="/signin" class="action-primary action-signin">
+            ${_("Sign into {studio_name}").format(studio_name=settings.STUDIO_NAME)}
+          </a>
         </li>
       </ul>
     </div>

--- a/cms/templates/activation_complete.html
+++ b/cms/templates/activation_complete.html
@@ -4,7 +4,7 @@
 <%block name="content">
 <div class="wrapper-mast wrapper sr">
   <header class="mast">
-    <h1 class="page-header">${_("{studio_name} Account Activation").format(studio_name=settings.STUDIO_NAME)}</h1>
+    <h1 class="page-header">${_("{studio_name} Account Activation").format(studio_name=settings.STUDIO_SHORT_NAME)}</h1>
   </header>
 </div>
 
@@ -24,7 +24,7 @@
       <ul class="list-actions">
         <li class="action-item">
           <a href="/signin" class="action-primary action-signin">
-            ${_("Sign into {studio_name}").format(studio_name=settings.STUDIO_NAME)}
+            ${_("Sign into {studio_name}").format(studio_name=settings.STUDIO_SHORT_NAME)}
           </a>
         </li>
       </ul>

--- a/cms/templates/activation_invalid.html
+++ b/cms/templates/activation_invalid.html
@@ -4,7 +4,7 @@
 <%block name="content">
 <div class="wrapper-mast wrapper sr">
   <header class="mast">
-    <h1 class="page-header">${_("Studio Account Activation")}</h1>
+    <h1 class="page-header">${_("{studio_name} Account Activation").format(studio_name=settings.STUDIO_NAME)}</h1>
   </header>
 </div>
 
@@ -18,7 +18,8 @@
         <h1 class="title">${_("Your account activation is invalid")}</h1>
         <div class="copy">
           <p>${_("We're sorry. Something went wrong with your activation. Check to make sure the URL you went to was correct — e-mail programs will sometimes split it into two lines.")}</p>
-          <p>${_("If you still have issues, contact edX Support. In the meantime, you can also return to {link_start}the Studio homepage.{link_end}").format(
+          <p>${_("If you still have issues, contact {platform_name} Support. In the meantime, you can also return to {link_start}the {studio_name} homepage.{link_end}").format(
+              platform_name=settings.PLATFORM_NAME, studio_name=settings.STUDIO_NAME,
               link_start='<a href="/">', link_end="</a>"
             )}</p>
         </div>

--- a/cms/templates/activation_invalid.html
+++ b/cms/templates/activation_invalid.html
@@ -4,7 +4,7 @@
 <%block name="content">
 <div class="wrapper-mast wrapper sr">
   <header class="mast">
-    <h1 class="page-header">${_("{studio_name} Account Activation").format(studio_name=settings.STUDIO_NAME)}</h1>
+    <h1 class="page-header">${_("{studio_name} Account Activation").format(studio_name=settings.STUDIO_SHORT_NAME)}</h1>
   </header>
 </div>
 

--- a/cms/templates/asset_index.html
+++ b/cms/templates/asset_index.html
@@ -63,7 +63,7 @@
 
                 <p>${_("To add files to use in your course, click {em_start}Upload New File{em_end}. Then follow the prompts to upload a file from your computer.").format(em_start='<strong>', em_end="</strong>")}</p>
 
-                <p>${_("{em_start}Caution{em_end}: edX recommends that you limit the file size to {em_start}10 MB{em_end}. In addition, do not upload video or audio files. You should use a third party service to host multimedia files.").format(em_start='<strong>', em_end="</strong>")}</p>
+                <p>${_("{em_start}Caution{em_end}: {platform_name} recommends that you limit the file size to {em_start}10 MB{em_end}. In addition, do not upload video or audio files. You should use a third party service to host multimedia files.").format(em_start='<strong>', em_end="</strong>", platform_name=settings.PLATFORM_NAME)}</p>
 
             	<p>${_("The course image, textbook chapters, and files that appear on your Course Handouts sidebar also appear in this list.")}</p>
             </div>

--- a/cms/templates/base.html
+++ b/cms/templates/base.html
@@ -22,7 +22,7 @@
         <% ctx_loc = context_course.location %>
         ${context_course.display_name_with_default | h} |
         % endif
-        edX Studio
+        ${settings.STUDIO_NAME}
     </title>
 
     <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/cms/templates/checklists.html
+++ b/cms/templates/checklists.html
@@ -54,7 +54,7 @@
       </div>
 
       <div class="bit">
-        <h3 class="title title-3">${_("{studio_name} checklists").format(studio_name=settings.STUDIO_NAME)}</h3>
+        <h3 class="title title-3">${_("{studio_name} checklists").format(studio_name=settings.STUDIO_SHORT_NAME)}</h3>
         <nav class="nav-page checklists-current">
           <ol>
             % for checklist in checklists:

--- a/cms/templates/checklists.html
+++ b/cms/templates/checklists.html
@@ -54,7 +54,7 @@
       </div>
 
       <div class="bit">
-        <h3 class="title title-3">${_("Studio checklists")}</h3>
+        <h3 class="title title-3">${_("{studio_name} checklists").format(studio_name=settings.STUDIO_NAME)}</h3>
         <nav class="nav-page checklists-current">
           <ol>
             % for checklist in checklists:

--- a/cms/templates/emails/activation_email.txt
+++ b/cms/templates/emails/activation_email.txt
@@ -1,6 +1,6 @@
 <%! from django.utils.translation import ugettext as _ %>
 
-${_("Thank you for signing up for edX Studio! To activate your account, please copy and paste this address into your web browser's address bar:")}
+${_("Thank you for signing up for {studio_name}! To activate your account, please copy and paste this address into your web browser's address bar:").format(studio_name=settings.STUDIO_NAME)}
 
 % if is_secure:
   https://${ site }/activate/${ key }
@@ -8,4 +8,4 @@ ${_("Thank you for signing up for edX Studio! To activate your account, please c
   http://${ site }/activate/${ key }
 % endif
 
-${_("If you didn't request this, you don't need to do anything; you won't receive any more email from us. Please do not reply to this e-mail; if you require assistance, check the help section of the edX web site.")}
+${_("If you didn't request this, you don't need to do anything; you won't receive any more email from us. Please do not reply to this e-mail; if you require assistance, check the help section of the {studio_name} web site.").format(studio_name=settings.STUDIO_NAME)}

--- a/cms/templates/emails/activation_email_subject.txt
+++ b/cms/templates/emails/activation_email_subject.txt
@@ -1,2 +1,2 @@
 <%! from django.utils.translation import ugettext as _ %>
-${_("Your account for edX Studio")}
+${_("Your account for {studio_name}").format(studio_name=settings.STUDIO_NAME)}

--- a/cms/templates/emails/course_creator_admin_subject.txt
+++ b/cms/templates/emails/course_creator_admin_subject.txt
@@ -1,2 +1,4 @@
 <%! from django.utils.translation import ugettext as _ %>
-${_("{email} has requested Studio course creator privileges on edge").format(email=user_email)}
+${_("{email} has requested {studio_name} course creator privileges on edge").format(
+    email=user_email, studio_name=settings.STUDIO_NAME,
+)}

--- a/cms/templates/emails/course_creator_admin_subject.txt
+++ b/cms/templates/emails/course_creator_admin_subject.txt
@@ -1,4 +1,4 @@
 <%! from django.utils.translation import ugettext as _ %>
 ${_("{email} has requested {studio_name} course creator privileges on edge").format(
-    email=user_email, studio_name=settings.STUDIO_NAME,
+    email=user_email, studio_name=settings.STUDIO_SHORT_NAME,
 )}

--- a/cms/templates/emails/course_creator_admin_user_pending.txt
+++ b/cms/templates/emails/course_creator_admin_user_pending.txt
@@ -1,6 +1,6 @@
 <%! from django.utils.translation import ugettext as _ %>
 ${_("User '{user}' with e-mail {email} has requested {studio_name} course creator privileges on edge.").format(
-    user=user_name, email=user_email, studio_name=settings.STUDIO_NAME,
+    user=user_name, email=user_email, studio_name=settings.STUDIO_SHORT_NAME,
 )}
 ${_("To grant or deny this request, use the course creator admin table.")}
 

--- a/cms/templates/emails/course_creator_admin_user_pending.txt
+++ b/cms/templates/emails/course_creator_admin_user_pending.txt
@@ -1,5 +1,7 @@
 <%! from django.utils.translation import ugettext as _ %>
-${_("User '{user}' with e-mail {email} has requested Studio course creator privileges on edge.").format(user=user_name, email=user_email)}
+${_("User '{user}' with e-mail {email} has requested {studio_name} course creator privileges on edge.").format(
+    user=user_name, email=user_email, studio_name=settings.STUDIO_NAME,
+)}
 ${_("To grant or deny this request, use the course creator admin table.")}
 
 % if is_secure:

--- a/cms/templates/emails/course_creator_denied.txt
+++ b/cms/templates/emails/course_creator_denied.txt
@@ -1,5 +1,3 @@
 <%! from django.utils.translation import ugettext as _ %>
 
-${_("Your request for course creation rights to edX Studio have been denied. If you believe this was in error, please contact: ")}
-
-${ studio_request_email }
+${_("Your request for course creation rights to {studio_name} have been denied. If you believe this was in error, please contact {email}").format(studio_name=settings.STUDIO_NAME, email=studio_request_email)}

--- a/cms/templates/emails/course_creator_granted.txt
+++ b/cms/templates/emails/course_creator_granted.txt
@@ -1,9 +1,6 @@
 <%! from django.utils.translation import ugettext as _ %>
 
-${_("Your request for course creation rights to edX Studio have been granted. To create your first course, visit:")}
-
-% if is_secure:
-https://${ site }
-% else:
-http://${ site }
-% endif
+${_("Your request for course creation rights to {studio_name} have been granted. To create your first course, visit\n\n{url}").format(
+  studio_name=settings.STUDIO_NAME,
+  url="{scheme}://{site}".format(scheme="https" if is_secure else "http", site=site),
+)}

--- a/cms/templates/emails/course_creator_revoked.txt
+++ b/cms/templates/emails/course_creator_revoked.txt
@@ -1,5 +1,3 @@
 <%! from django.utils.translation import ugettext as _ %>
 
-${_("Your course creation rights to edX Studio have been revoked. If you believe this was in error, please contact: ")}
-
-${ studio_request_email }
+${_("Your course creation rights to {studio_name} have been revoked. If you believe this was in error, please contact {email}").format(studio_name=settings.STUDIO_NAME, email=studio_request_email)}

--- a/cms/templates/emails/course_creator_subject.txt
+++ b/cms/templates/emails/course_creator_subject.txt
@@ -1,2 +1,2 @@
 <%! from django.utils.translation import ugettext as _ %>
-${_("Your course creator status for edX Studio")}
+${_("Your course creator status for {studio_name}").format(studio_name=settings.STUDIO_NAME)}

--- a/cms/templates/error.html
+++ b/cms/templates/error.html
@@ -15,14 +15,14 @@
     % if error == '404':
       <h1>${_("The Page You Requested Page Cannot be Found")}</h1>
       <p class="description">${_("We're sorry. We couldn't find the {studio_name} page you're looking for. You may want to return to the {studio_name} Dashboard and try again. If you are still having problems accessing things, please feel free to {link_start}contact {studio_name} support{link_end} for further help.").format(
-          studio_name=settings.STUDIO_NAME,
+          studio_name=settings.STUDIO_SHORT_NAME,
           link_start='<a href="http://help.edge.edx.org/discussion/new" class="show-tender" title="{title}">'.format(title=_("Use our feedback tool, Tender, to share your feedback")),
           link_end='</a>',
         )}</p>
     % elif error == '500':
       <h1>${_("The Server Encountered an Error")}</h1>
       <p class="description">${_("We're sorry. There was a problem with the server while trying to process your last request. You may want to return to the {studio_name} Dashboard or try this request again. If you are still having problems accessing things, please feel free to {link_start}contact {studio_name} support{link_end} for further help.").format(
-          studio_name=settings.STUDIO_NAME,
+          studio_name=settings.STUDIO_SHORT_NAME,
           link_start='<a href="http://help.edge.edx.org/discussion/new" class="show-tender" title="{title}">'.format(title=_("Use our feedback tool, Tender, to share your feedback")),
           link_end='</a>',
         )}</p>

--- a/cms/templates/error.html
+++ b/cms/templates/error.html
@@ -14,13 +14,15 @@
   <article class="error-prompt">
     % if error == '404':
       <h1>${_("The Page You Requested Page Cannot be Found")}</h1>
-      <p class="description">${_("We're sorry. We couldn't find the Studio page you're looking for. You may want to return to the Studio Dashboard and try again. If you are still having problems accessing things, please feel free to {link_start}contact Studio support{link_end} for further help.").format(
+      <p class="description">${_("We're sorry. We couldn't find the {studio_name} page you're looking for. You may want to return to the {studio_name} Dashboard and try again. If you are still having problems accessing things, please feel free to {link_start}contact {studio_name} support{link_end} for further help.").format(
+          studio_name=settings.STUDIO_NAME,
           link_start='<a href="http://help.edge.edx.org/discussion/new" class="show-tender" title="{title}">'.format(title=_("Use our feedback tool, Tender, to share your feedback")),
           link_end='</a>',
         )}</p>
     % elif error == '500':
       <h1>${_("The Server Encountered an Error")}</h1>
-      <p class="description">${_("We're sorry. There was a problem with the server while trying to process your last request. You may want to return to the Studio Dashboard or try this request again. If you are still having problems accessing things, please feel free to {link_start}contact Studio support{link_end} for further help.").format(
+      <p class="description">${_("We're sorry. There was a problem with the server while trying to process your last request. You may want to return to the {studio_name} Dashboard or try this request again. If you are still having problems accessing things, please feel free to {link_start}contact {studio_name} support{link_end} for further help.").format(
+          studio_name=settings.STUDIO_NAME,
           link_start='<a href="http://help.edge.edx.org/discussion/new" class="show-tender" title="{title}">'.format(title=_("Use our feedback tool, Tender, to share your feedback")),
           link_end='</a>',
         )}</p>

--- a/cms/templates/export.html
+++ b/cms/templates/export.html
@@ -40,7 +40,9 @@
         <h2 class="title">${_("About Exporting Courses")}</h2>
         <div class="copy">
           ## Translators: ".tar.gz" is a file extension, and should not be translated
-          <p>${_("You can export courses and edit them outside of Studio. The exported file is a .tar.gz file (that is, a .tar file compressed with GNU Zip) that contains the course structure and content. You can also re-import courses that you've exported.").format(em_start='<strong>', em_end="</strong>")}</p>
+          <p>${_("You can export courses and edit them outside of {studio_name}. The exported file is a .tar.gz file (that is, a .tar file compressed with GNU Zip) that contains the course structure and content. You can also re-import courses that you've exported.").format(
+            studio_name=settings.STUDIO_NAME, em_start='<strong>', em_end="</strong>"
+          )}</p>
           <p>${_("{em_start}Caution:{em_end} When you export a course, information such as MATLAB API keys, LTI passports, annotation secret token strings, and annotation storage URLs are included in the exported data. If you share your exported files, you may also be sharing sensitive or license-specific information.").format(em_start='<strong>', em_end="</strong>")}</p>
         </div>
       </div>
@@ -87,7 +89,9 @@
     <aside class="content-supplementary" role="complementary">
       <div class="bit">
         <h3 class="title-3">${_("Why export a course?")}</h3>
-        <p>${_("You may want to edit the XML in your course directly, outside of Studio. You may want to create a backup copy of your course. Or, you may want to create a copy of your course that you can later import into another course instance and customize.")}</p>
+        <p>${_("You may want to edit the XML in your course directly, outside of {studio_name}. You may want to create a backup copy of your course. Or, you may want to create a copy of your course that you can later import into another course instance and customize.").format(
+            studio_name=settings.STUDIO_NAME,
+          )}</p>
       </div>
 
       <div class="bit">

--- a/cms/templates/export.html
+++ b/cms/templates/export.html
@@ -41,7 +41,7 @@
         <div class="copy">
           ## Translators: ".tar.gz" is a file extension, and should not be translated
           <p>${_("You can export courses and edit them outside of {studio_name}. The exported file is a .tar.gz file (that is, a .tar file compressed with GNU Zip) that contains the course structure and content. You can also re-import courses that you've exported.").format(
-            studio_name=settings.STUDIO_NAME, em_start='<strong>', em_end="</strong>"
+            studio_name=settings.STUDIO_SHORT_NAME, em_start='<strong>', em_end="</strong>"
           )}</p>
           <p>${_("{em_start}Caution:{em_end} When you export a course, information such as MATLAB API keys, LTI passports, annotation secret token strings, and annotation storage URLs are included in the exported data. If you share your exported files, you may also be sharing sensitive or license-specific information.").format(em_start='<strong>', em_end="</strong>")}</p>
         </div>
@@ -90,7 +90,7 @@
       <div class="bit">
         <h3 class="title-3">${_("Why export a course?")}</h3>
         <p>${_("You may want to edit the XML in your course directly, outside of {studio_name}. You may want to create a backup copy of your course. Or, you may want to create a copy of your course that you can later import into another course instance and customize.").format(
-            studio_name=settings.STUDIO_NAME,
+            studio_name=settings.STUDIO_SHORT_NAME,
           )}</p>
       </div>
 

--- a/cms/templates/howitworks.html
+++ b/cms/templates/howitworks.html
@@ -15,8 +15,14 @@
   <section class="content content-header">
     <header>
       ## "edX Studio" should not be translated
-      <h1><span class="wrapper-text-welcome">${_('Welcome to')}</span><span class="logo">edX Studio</span></h1>
-      <p class="tagline">${_("Studio helps manage your online courses, so you can focus on teaching them")}</p>
+      <h1><span class="wrapper-text-welcome">${_("Welcome to {studio_name}").format(
+        studio_name='</span><span class="logo">{studio_name}</span>'.format(
+          studio_name=settings.STUDIO_NAME
+        )
+      )}</h1>
+      <p class="tagline">${_("{studio_name} helps manage your online courses, so you can focus on teaching them").format(
+        studio_name=settings.STUDIO_NAME
+      )}</p>
     </header>
   </section>
 </div>
@@ -24,15 +30,15 @@
 <div class="wrapper-content-features wrapper">
   <section class="content content-features">
     <header>
-      <h2 class="sr">${_("Studio's Many Features")}</h2>
+      <h2 class="sr">${_("{studio_name}'s Many Features").format(studio_name=settings.STUDIO_NAME)}</h2>
     </header>
 
     <ol class="list-features">
       <li class="feature">
         <figure class="img zoom">
           <a rel="modal" href="#hiw-feature1">
-            <img src="${static.url("images/thumb-hiw-feature1.png")}" alt="${_('Studio Helps You Keep Your Courses Organized')}" />
-            <figcaption class="sr">${_("Studio Helps You Keep Your Courses Organized")}</figcaption>
+            <img src="${static.url("images/thumb-hiw-feature1.png")}" alt="${_('{studio_name} Helps You Keep Your Courses Organized').format(studio_name=settings.STUDIO_NAME)}" />
+            <figcaption class="sr">${_("{studio_name} Helps You Keep Your Courses Organized").format(studio_name=settings.STUDIO_NAME)}</figcaption>
             <span class="action-zoom">
               <i class="icon-zoom-in"></i>
             </span>
@@ -41,12 +47,12 @@
 
         <div class="copy">
           <h3>${_("Keeping Your Course Organized")}</h3>
-          <p>${_("The backbone of your course is how it is organized. Studio offers an <strong>Outline</strong> editor, providing a simple hierarchy and easy drag and drop to help you and your students stay organized.")}</p>
+          <p>${_("The backbone of your course is how it is organized. {studio_name} offers an <strong>Outline</strong> editor, providing a simple hierarchy and easy drag and drop to help you and your students stay organized.").format(studio_name=settings.STUDIO_NAME)}</p>
 
           <ul class="list-proofpoints">
             <li class="proofpoint">
               <h4 class="title">${_("Simple Organization For Content")}</h4>
-              <p>${_("Studio uses a simple hierarchy of <strong>sections</strong> and <strong>subsections</strong> to organize your content.")}</p>
+              <p>${_("{studio_name} uses a simple hierarchy of <strong>sections</strong> and <strong>subsections</strong> to organize your content.").format(studio_name=settings.STUDIO_NAME)}</p>
             </li>
 
             <li class="proofpoint">
@@ -75,7 +81,7 @@
 
         <div class="copy">
           <h3>${_("Learning is More than Just Lectures")}</h3>
-          <p>${_("Studio lets you weave your content together in a way that reinforces learning. Insert videos, discussions, and a wide variety of exercises with just a few clicks.")} </p>
+          <p>${_("{studio_name} lets you weave your content together in a way that reinforces learning. Insert videos, discussions, and a wide variety of exercises with just a few clicks.").format(studio_name=settings.STUDIO_NAME)} </p>
 
           <ul class="list-proofpoints">
             <li class="proofpoint">
@@ -99,8 +105,8 @@
       <li class="feature">
         <figure class="img zoom">
           <a rel="modal" href="#hiw-feature3">
-            <img src="${static.url("images/thumb-hiw-feature3.png")}" alt="${_('Studio Gives You Simple, Fast, and Incremental Publishing. With Friends.')}" />
-            <figcaption class="sr">${_("Studio Gives You Simple, Fast, and Incremental Publishing. With Friends.")}</figcaption>
+            <img src="${static.url("images/thumb-hiw-feature3.png")}" alt="${_('{studio_name} Gives You Simple, Fast, and Incremental Publishing. With Friends.').format(studio_name=settings.STUDIO_NAME)}" />
+            <figcaption class="sr">${_("{studio_name} Gives You Simple, Fast, and Incremental Publishing. With Friends.").format(studio_name=settings.STUDIO_NAME)}</figcaption>
             <span class="action-zoom">
               <i class="icon-zoom-in"></i>
             </span>
@@ -109,7 +115,7 @@
 
         <div class="copy">
           <h3>${_("Simple, Fast, and Incremental Publishing. With Friends.")}</h3>
-          <p>${_("Studio works like web applications you already know, yet understands how you build curriculum. Instant publishing to the web when you want it, incremental release when it makes sense. And with co-authors, you can have a whole team building a course, together.")}</p>
+          <p>${_("{studio_name} works like web applications you already know, yet understands how you build curriculum. Instant publishing to the web when you want it, incremental release when it makes sense. And with co-authors, you can have a whole team building a course, together.").format(studio_name=settings.STUDIO_NAME)}</p>
 
           <ul class="list-proofpoints">
             <li class="proofpoint">
@@ -119,7 +125,7 @@
 
             <li class="proofpoint">
               <h4 class="title">${_("Release-On Date Publishing")}</h4>
-              <p>${_("When you've finished a <strong>section</strong>, pick when you want it to go live and Studio takes care of the rest. Build your course incrementally.")}</p>
+              <p>${_("When you've finished a <strong>section</strong>, pick when you want it to go live and {studio_name} takes care of the rest. Build your course incrementally.").format(studio_name=settings.STUDIO_NAME)}</p>
             </li>
 
             <li class="proofpoint">
@@ -136,15 +142,15 @@
 <div class="wrapper-content-cta wrapper">
   <section class="content content-cta">
     <header>
-      <h2 class="sr">${_("Sign Up for Studio Today!")}</h2>
+      <h2 class="sr">${_("Sign Up for {studio_name} Today!").format(studio_name=settings.STUDIO_NAME)}</h2>
     </header>
 
     <ul class="list-actions">
       <li class="action-item">
-        <a href="${reverse('signup')}" class="action action-primary">${_("Sign Up &amp; Start Making an edX Course")}</a>
+        <a href="${reverse('signup')}" class="action action-primary">${_("Sign Up &amp; Start Making an {platform_name} Course").format(platform_name=settings.PLATFORM_NAME)}</a>
       </li>
       <li class="action-item">
-        <a href="${reverse('login')}" class="action action-secondary">${_("Already have a Studio Account? Sign In")}</a>
+        <a href="${reverse('login')}" class="action action-secondary">${_("Already have a {studio_name} Account? Sign In").format(studio_name=settings.STUDIO_NAME)}</a>
       </li>
     </ul>
   </section>
@@ -180,7 +186,7 @@
   <h3 class="title">${_("Publishing on Date")}</h3>
   <figure>
     <img src="${static.url("images/hiw-feature3.png")}" alt="" />
-    <figcaption class="description">${_("Simply set the date of a section or subsection, and Studio will publish it to your students for you.")}</figcaption>
+    <figcaption class="description">${_("Simply set the date of a section or subsection, and {studio_name} will publish it to your students for you.").format(studio_name=settings.STUDIO_NAME)}</figcaption>
   </figure>
 
   <a href="" rel="view" class="action action-modal-close">

--- a/cms/templates/howitworks.html
+++ b/cms/templates/howitworks.html
@@ -21,7 +21,7 @@
         )
       )}</h1>
       <p class="tagline">${_("{studio_name} helps manage your online courses, so you can focus on teaching them").format(
-        studio_name=settings.STUDIO_NAME
+        studio_name=settings.STUDIO_SHORT_NAME
       )}</p>
     </header>
   </section>
@@ -30,14 +30,14 @@
 <div class="wrapper-content-features wrapper">
   <section class="content content-features">
     <header>
-      <h2 class="sr">${_("{studio_name}'s Many Features").format(studio_name=settings.STUDIO_NAME)}</h2>
+      <h2 class="sr">${_("{studio_name}'s Many Features").format(studio_name=settings.STUDIO_SHORT_NAME)}</h2>
     </header>
 
     <ol class="list-features">
       <li class="feature">
         <figure class="img zoom">
           <a rel="modal" href="#hiw-feature1">
-            <img src="${static.url("images/thumb-hiw-feature1.png")}" alt="${_('{studio_name} Helps You Keep Your Courses Organized').format(studio_name=settings.STUDIO_NAME)}" />
+            <img src="${static.url("images/thumb-hiw-feature1.png")}" alt="${_('{studio_name} Helps You Keep Your Courses Organized').format(studio_name=settings.STUDIO_SHORT_NAME)}" />
             <figcaption class="sr">${_("{studio_name} Helps You Keep Your Courses Organized").format(studio_name=settings.STUDIO_NAME)}</figcaption>
             <span class="action-zoom">
               <i class="icon-zoom-in"></i>
@@ -47,12 +47,12 @@
 
         <div class="copy">
           <h3>${_("Keeping Your Course Organized")}</h3>
-          <p>${_("The backbone of your course is how it is organized. {studio_name} offers an <strong>Outline</strong> editor, providing a simple hierarchy and easy drag and drop to help you and your students stay organized.").format(studio_name=settings.STUDIO_NAME)}</p>
+          <p>${_("The backbone of your course is how it is organized. {studio_name} offers an <strong>Outline</strong> editor, providing a simple hierarchy and easy drag and drop to help you and your students stay organized.").format(studio_name=settings.STUDIO_SHORT_NAME)}</p>
 
           <ul class="list-proofpoints">
             <li class="proofpoint">
               <h4 class="title">${_("Simple Organization For Content")}</h4>
-              <p>${_("{studio_name} uses a simple hierarchy of <strong>sections</strong> and <strong>subsections</strong> to organize your content.").format(studio_name=settings.STUDIO_NAME)}</p>
+              <p>${_("{studio_name} uses a simple hierarchy of <strong>sections</strong> and <strong>subsections</strong> to organize your content.").format(studio_name=settings.STUDIO_SHORT_NAME)}</p>
             </li>
 
             <li class="proofpoint">
@@ -81,7 +81,7 @@
 
         <div class="copy">
           <h3>${_("Learning is More than Just Lectures")}</h3>
-          <p>${_("{studio_name} lets you weave your content together in a way that reinforces learning. Insert videos, discussions, and a wide variety of exercises with just a few clicks.").format(studio_name=settings.STUDIO_NAME)} </p>
+          <p>${_("{studio_name} lets you weave your content together in a way that reinforces learning. Insert videos, discussions, and a wide variety of exercises with just a few clicks.").format(studio_name=settings.STUDIO_SHORT_NAME)} </p>
 
           <ul class="list-proofpoints">
             <li class="proofpoint">
@@ -105,8 +105,8 @@
       <li class="feature">
         <figure class="img zoom">
           <a rel="modal" href="#hiw-feature3">
-            <img src="${static.url("images/thumb-hiw-feature3.png")}" alt="${_('{studio_name} Gives You Simple, Fast, and Incremental Publishing. With Friends.').format(studio_name=settings.STUDIO_NAME)}" />
-            <figcaption class="sr">${_("{studio_name} Gives You Simple, Fast, and Incremental Publishing. With Friends.").format(studio_name=settings.STUDIO_NAME)}</figcaption>
+            <img src="${static.url("images/thumb-hiw-feature3.png")}" alt="${_('{studio_name} Gives You Simple, Fast, and Incremental Publishing. With Friends.').format(studio_name=settings.STUDIO_SHORT_NAME)}" />
+            <figcaption class="sr">${_("{studio_name} Gives You Simple, Fast, and Incremental Publishing. With Friends.").format(studio_name=settings.STUDIO_SHORT_NAME)}</figcaption>
             <span class="action-zoom">
               <i class="icon-zoom-in"></i>
             </span>
@@ -115,7 +115,7 @@
 
         <div class="copy">
           <h3>${_("Simple, Fast, and Incremental Publishing. With Friends.")}</h3>
-          <p>${_("{studio_name} works like web applications you already know, yet understands how you build curriculum. Instant publishing to the web when you want it, incremental release when it makes sense. And with co-authors, you can have a whole team building a course, together.").format(studio_name=settings.STUDIO_NAME)}</p>
+          <p>${_("{studio_name} works like web applications you already know, yet understands how you build curriculum. Instant publishing to the web when you want it, incremental release when it makes sense. And with co-authors, you can have a whole team building a course, together.").format(studio_name=settings.STUDIO_SHORT_NAME)}</p>
 
           <ul class="list-proofpoints">
             <li class="proofpoint">
@@ -125,7 +125,7 @@
 
             <li class="proofpoint">
               <h4 class="title">${_("Release-On Date Publishing")}</h4>
-              <p>${_("When you've finished a <strong>section</strong>, pick when you want it to go live and {studio_name} takes care of the rest. Build your course incrementally.").format(studio_name=settings.STUDIO_NAME)}</p>
+              <p>${_("When you've finished a <strong>section</strong>, pick when you want it to go live and {studio_name} takes care of the rest. Build your course incrementally.").format(studio_name=settings.STUDIO_SHORT_NAME)}</p>
             </li>
 
             <li class="proofpoint">
@@ -142,7 +142,7 @@
 <div class="wrapper-content-cta wrapper">
   <section class="content content-cta">
     <header>
-      <h2 class="sr">${_("Sign Up for {studio_name} Today!").format(studio_name=settings.STUDIO_NAME)}</h2>
+      <h2 class="sr">${_("Sign Up for {studio_name} Today!").format(studio_name=settings.STUDIO_SHORT_NAME)}</h2>
     </header>
 
     <ul class="list-actions">
@@ -150,7 +150,7 @@
         <a href="${reverse('signup')}" class="action action-primary">${_("Sign Up &amp; Start Making an {platform_name} Course").format(platform_name=settings.PLATFORM_NAME)}</a>
       </li>
       <li class="action-item">
-        <a href="${reverse('login')}" class="action action-secondary">${_("Already have a {studio_name} Account? Sign In").format(studio_name=settings.STUDIO_NAME)}</a>
+        <a href="${reverse('login')}" class="action action-secondary">${_("Already have a {studio_name} Account? Sign In").format(studio_name=settings.STUDIO_SHORT_NAME)}</a>
       </li>
     </ul>
   </section>
@@ -186,7 +186,7 @@
   <h3 class="title">${_("Publishing on Date")}</h3>
   <figure>
     <img src="${static.url("images/hiw-feature3.png")}" alt="" />
-    <figcaption class="description">${_("Simply set the date of a section or subsection, and {studio_name} will publish it to your students for you.").format(studio_name=settings.STUDIO_NAME)}</figcaption>
+    <figcaption class="description">${_("Simply set the date of a section or subsection, and {studio_name} will publish it to your students for you.").format(studio_name=settings.STUDIO_SHORT_NAME)}</figcaption>
   </figure>
 
   <a href="" rel="view" class="action action-modal-close">

--- a/cms/templates/import.html
+++ b/cms/templates/import.html
@@ -130,7 +130,7 @@
     <aside class="content-supplementary" role="complementary">
       <div class="bit">
         <h3 class="title-3">${_("Why import a course?")}</h3>
-        <p>${_("You may want to run a new version of an existing course, or replace an existing course altogether. Or, you may have developed a course outside {studio_name}.").format(studio_name=settings.STUDIO_NAME)}</p>
+        <p>${_("You may want to run a new version of an existing course, or replace an existing course altogether. Or, you may have developed a course outside {studio_name}.").format(studio_name=settings.STUDIO_SHORT_NAME)}</p>
       </div>
 
       <div class="bit">

--- a/cms/templates/import.html
+++ b/cms/templates/import.html
@@ -130,7 +130,7 @@
     <aside class="content-supplementary" role="complementary">
       <div class="bit">
         <h3 class="title-3">${_("Why import a course?")}</h3>
-        <p>${_("You may want to run a new version of an existing course, or replace an existing course altogether. Or, you may have developed a course outside Studio.")}</p>
+        <p>${_("You may want to run a new version of an existing course, or replace an existing course altogether. Or, you may have developed a course outside {studio_name}.").format(studio_name=settings.STUDIO_NAME)}</p>
       </div>
 
       <div class="bit">

--- a/cms/templates/index.html
+++ b/cms/templates/index.html
@@ -44,12 +44,12 @@
 
         %if len(courses) > 0:
         <div class="copy">
-          <p>${_("Here are all of the courses you currently have access to in Studio:")}</p>
+          <p>${_("Here are all of the courses you currently have access to in {studio_name}:").format(studio_name=settings.STUDIO_NAME)}</p>
         </div>
 
         %else:
         <div class="copy">
-          <p>${_("You currently aren't associated with any Studio Courses.")}</p>
+          <p>${_("You currently aren't associated with any {studio_name} Courses.").format(studio_name=settings.STUDIO_NAME)}</p>
         </div>
         %endif
       </div>
@@ -252,9 +252,9 @@
       <div class="notice notice-incontext notice-instruction notice-instruction-nocourses list-notices">
         <div class="notice-item">
           <div class="msg">
-            <h3 class="title">${_("Are you staff on an existing Studio course?")}</h3>
+            <h3 class="title">${_("Are you staff on an existing {studio_name} course?").format(studio_name=settings.STUDIO_NAME)}</h3>
             <div class="copy">
-              <p>${_('You will need to be added to the course in Studio by the course creator. Please get in touch with the course creator or administrator for the specific course you are helping to author.')}</p>
+              <p>${_('You will need to be added to the course in {studio_name} by the course creator. Please get in touch with the course creator or administrator for the specific course you are helping to author.').format(studio_name=settings.STUDIO_NAME)}</p>
             </div>
           </div>
         </div>
@@ -283,12 +283,13 @@
       %if course_creator_status == "unrequested":
       <div class="wrapper wrapper-creationrights">
         <h3 class="title">
-          <a href="#instruction-creationrights" class="ui-toggle-control show-creationrights"><span class="label">${_('Becoming a Course Creator in Studio')}</span> <i class="icon-remove-sign"></i></a>
+          <a href="#instruction-creationrights" class="ui-toggle-control show-creationrights"><span class="label">${_('Becoming a Course Creator in {studio_name}').format(studio_name=settings.STUDIO_NAME)}</span> <i class="icon-remove-sign"></i></a>
         </h3>
 
         <div class="notice notice-incontext notice-instruction notice-instruction-creationrights ui-toggle-target" id="instruction-creationrights">
           <div class="copy">
-            <p>${_('edX Studio is a hosted solution for our xConsortium partners and selected guests. Courses for which you are a team member appear above for you to edit, while course creator privileges are granted by edX. Our team will evaluate your request and provide you feedback within 24 hours during the work week.')}</p>
+            <p>${_('{studio_name} is a hosted solution for our xConsortium partners and selected guests. Courses for which you are a team member appear above for you to edit, while course creator privileges are granted by {platform_name}. Our team will evaluate your request and provide you feedback within 24 hours during the work week.').format(
+              studio_name=settings.STUDIO_NAME, platform_name=settings.PLATFORM_NAME)}</p>
           </div>
 
           <div class="status status-creationrights is-unrequested">
@@ -311,7 +312,9 @@
 
         <div class="notice notice-incontext notice-instruction notice-instruction-creationrights ui-toggle-target" id="instruction-creationrights">
           <div class="copy">
-            <p>${_('edX Studio is a hosted solution for our xConsortium partners and selected guests. Courses for which you are a team member appear above for you to edit, while course creator privileges are granted by edX. Our team is has completed evaluating your request.')}</p>
+            <p>${_('{studio_name} is a hosted solution for our xConsortium partners and selected guests. Courses for which you are a team member appear above for you to edit, while course creator privileges are granted by {platform_name}. Our team is has completed evaluating your request.').format(
+              studio_name=settings.STUDIO_NAME, platform_name=settings.PLATFORM_NAME,
+            )}</p>
           </div>
 
           <div class="status status-creationrights has-status is-denied">
@@ -322,7 +325,7 @@
               <dd class="value">
                 <span class="status-indicator"></span>
                 <span class="value-formal">${_('Denied')}</span>
-                <span class="value-description">${_('Your request did not meet the criteria/guidelines specified by edX Staff.')}</span>
+                <span class="value-description">${_('Your request did not meet the criteria/guidelines specified by {platform_name} Staff.').format(platform_name=settings.PLATFORM_NAME)}</span>
               </dd>
             </dl>
           </div>
@@ -337,7 +340,9 @@
 
         <div class="notice notice-incontext notice-instruction notice-instruction-creationrights ui-toggle-target" id="instruction-creationrights">
           <div class="copy">
-            <p>${_('edX Studio is a hosted solution for our xConsortium partners and selected guests. Courses for which you are a team member appear above for you to edit, while course creator privileges are granted by edX. Our team is currently  evaluating your request.')}</p>
+            <p>${_('{studio_name} is a hosted solution for our xConsortium partners and selected guests. Courses for which you are a team member appear above for you to edit, while course creator privileges are granted by {platform_name}. Our team is currently  evaluating your request.').format(
+              studio_name=settings.STUDIO_NAME, platform_name=settings.PLATFORM_NAME,
+            )}</p>
           </div>
 
           <div class="status status-creationrights has-status is-pending">
@@ -348,7 +353,9 @@
               <dd class="value">
                 <span class="status-indicator"></span>
                 <span class="value-formal">${_('Pending')}</span>
-                <span class="value-description">${_('Your request is currently being reviewed by edX staff and should be updated shortly.')}</span>
+                <span class="value-description">
+                  ${_('Your request is currently being reviewed by {platform_name} staff and should be updated shortly.').format(platform_name=settings.PLATFORM_NAME)}
+                </span>
               </dd>
             </dl>
           </div>
@@ -359,24 +366,26 @@
     </article>
     <aside class="content-supplementary" role="complementary">
       <div class="bit">
-        <h3 class="title title-3">${_('New to edX Studio?')}</h3>
-        <p>${_('Click Help in the upper-right corner to get more information about the Studio page you are viewing. You can also use the links at the bottom of the page to access our continously updated documentation and other Studio resources.')}</p>
+        <h3 class="title title-3">${_('New to {studio_name}?').format(studio_name=settings.STUDIO_NAME)}</h3>
+        <p>${_('Click Help in the upper-right corner to get more information about the {studio_name} page you are viewing. You can also use the links at the bottom of the page to access our continously updated documentation and other {studio_name} resources.').format(studio_name=settings.STUDIO_NAME)}</p>
 
         <ol class="list-actions">
           <li class="action-item">
 
-            <a href="${get_online_help_info(online_help_token())['doc_url']}" target="_blank">${_("Getting Started with edX Studio")}</a>
+            <a href="${get_online_help_info(online_help_token())['doc_url']}" target="_blank">${_("Getting Started with {studio_name}").format(studio_name=settings.STUDIO_NAME)}</a>
           </li>
           <li class="action-item">
-            <a href="http://help.edge.edx.org/discussion/new" class="show-tender" title="${_("Use our feedback tool, Tender, to request help")}">${_("Request help with edX Studio")}</a>
+            <a href="http://help.edge.edx.org/discussion/new" class="show-tender" title="${_("Use our feedback tool, Tender, to request help")}">${_("Request help with {studio_name}").format(studio_name=settings.STUDIO_NAME)}</a>
           </li>
         </ol>
       </div>
 
       % if course_creator_status=='disallowed_for_this_site' and settings.FEATURES.get('STUDIO_REQUEST_EMAIL',''):
       <div class="bit">
-        <h3 class="title title-3">${_("Can I create courses in Studio?")}</h3>
-        <p>${_("In order to create courses in Studio, you must {link_start}contact edX staff to help you create a course{link_end}.").format(
+        <h3 class="title title-3">${_("Can I create courses in {studio_name}?").format(studio_name=settings.STUDIO_NAME)}</h3>
+        <p>${_("In order to create courses in {studio_name}, you must {link_start}contact {platform_name} staff to help you create a course{link_end}.").format(
+            studio_name=settings.STUDIO_NAME,
+            platform_name=settings.PLATFORM_NAME,
             link_start='<a href="mailto:{email}">'.format(email=settings.FEATURES.get('STUDIO_REQUEST_EMAIL','')),
             link_end="</a>",
           )}</p>
@@ -385,14 +394,16 @@
 
       % if course_creator_status == "unrequested":
       <div class="bit">
-        <h3 class="title title-3">${_("Can I create courses in Studio?")}</h3>
-        <p>${_('In order to create courses in Studio, you must have course creator privileges to create your own course.')}</p>
+        <h3 class="title title-3">${_("Can I create courses in {studio_name}?").format(studio_name=settings.STUDIO_NAME)}</h3>
+        <p>${_('In order to create courses in {studio_name}, you must have course creator privileges to create your own course.').format(studio_name=settings.STUDIO_NAME)}</p>
       </div>
 
       % elif course_creator_status == "denied":
       <div class="bit">
-        <h3 class="title title-3">${_("Can I create courses in Studio?")}</h3>
-        <p>${_("Your request to author courses in Studio has been denied. Please {link_start}contact edX Staff with further questions{link_end}.").format(
+        <h3 class="title title-3">${_("Can I create courses in {studio_name}?").format(studio_name=settings.STUDIO_NAME)}</h3>
+        <p>${_("Your request to author courses in {studio_name} has been denied. Please {link_start}contact {platform_name} Staff with further questions{link_end}.").format(
+            studio_name=settings.STUDIO_NAME,
+            platform_name=settings.PLATFORM_NAME,
             link_start='<a href="{url}" class="show-tender">'.format(
               url="http://help.edge.edx.org/discussion/new",
             ),
@@ -429,7 +440,7 @@
 
         <ol class='list-actions'>
           <li class="action-item">
-            <a href="http://help.edge.edx.org/discussion/new" class="show-tender" title="${_("Use our feedback tool, Tender, to request help")}">${_("Request help with your Studio account")}</a>
+            <a href="http://help.edge.edx.org/discussion/new" class="show-tender" title="${_("Use our feedback tool, Tender, to request help")}">${_("Request help with your {studio_name} account").format(studio_name=settings.STUDIO_NAME)}</a>
           </li>
         </ol>
       </div>

--- a/cms/templates/index.html
+++ b/cms/templates/index.html
@@ -44,12 +44,12 @@
 
         %if len(courses) > 0:
         <div class="copy">
-          <p>${_("Here are all of the courses you currently have access to in {studio_name}:").format(studio_name=settings.STUDIO_NAME)}</p>
+          <p>${_("Here are all of the courses you currently have access to in {studio_name}:").format(studio_name=settings.STUDIO_SHORT_NAME)}</p>
         </div>
 
         %else:
         <div class="copy">
-          <p>${_("You currently aren't associated with any {studio_name} Courses.").format(studio_name=settings.STUDIO_NAME)}</p>
+          <p>${_("You currently aren't associated with any {studio_name} Courses.").format(studio_name=settings.STUDIO_SHORT_NAME)}</p>
         </div>
         %endif
       </div>
@@ -252,9 +252,9 @@
       <div class="notice notice-incontext notice-instruction notice-instruction-nocourses list-notices">
         <div class="notice-item">
           <div class="msg">
-            <h3 class="title">${_("Are you staff on an existing {studio_name} course?").format(studio_name=settings.STUDIO_NAME)}</h3>
+            <h3 class="title">${_("Are you staff on an existing {studio_name} course?").format(studio_name=settings.STUDIO_SHORT_NAME)}</h3>
             <div class="copy">
-              <p>${_('You will need to be added to the course in {studio_name} by the course creator. Please get in touch with the course creator or administrator for the specific course you are helping to author.').format(studio_name=settings.STUDIO_NAME)}</p>
+              <p>${_('You will need to be added to the course in {studio_name} by the course creator. Please get in touch with the course creator or administrator for the specific course you are helping to author.').format(studio_name=settings.STUDIO_SHORT_NAME)}</p>
             </div>
           </div>
         </div>
@@ -283,7 +283,7 @@
       %if course_creator_status == "unrequested":
       <div class="wrapper wrapper-creationrights">
         <h3 class="title">
-          <a href="#instruction-creationrights" class="ui-toggle-control show-creationrights"><span class="label">${_('Becoming a Course Creator in {studio_name}').format(studio_name=settings.STUDIO_NAME)}</span> <i class="icon-remove-sign"></i></a>
+          <a href="#instruction-creationrights" class="ui-toggle-control show-creationrights"><span class="label">${_('Becoming a Course Creator in {studio_name}').format(studio_name=settings.STUDIO_SHORT_NAME)}</span> <i class="icon-remove-sign"></i></a>
         </h3>
 
         <div class="notice notice-incontext notice-instruction notice-instruction-creationrights ui-toggle-target" id="instruction-creationrights">
@@ -367,7 +367,7 @@
     <aside class="content-supplementary" role="complementary">
       <div class="bit">
         <h3 class="title title-3">${_('New to {studio_name}?').format(studio_name=settings.STUDIO_NAME)}</h3>
-        <p>${_('Click Help in the upper-right corner to get more information about the {studio_name} page you are viewing. You can also use the links at the bottom of the page to access our continously updated documentation and other {studio_name} resources.').format(studio_name=settings.STUDIO_NAME)}</p>
+        <p>${_('Click Help in the upper-right corner to get more information about the {studio_name} page you are viewing. You can also use the links at the bottom of the page to access our continously updated documentation and other {studio_name} resources.').format(studio_name=settings.STUDIO_SHORT_NAME)}</p>
 
         <ol class="list-actions">
           <li class="action-item">

--- a/cms/templates/login.html
+++ b/cms/templates/login.html
@@ -12,15 +12,15 @@ from django.utils.translation import ugettext as _
 <div class="wrapper-content wrapper">
   <section class="content">
     <header>
-      <h1 class="title title-1">${_("Sign In to edX Studio")}</h1>
-      <a href="${reverse('signup')}" class="action action-signin">${_("Don't have a Studio Account? Sign up!")}</a>
+      <h1 class="title title-1">${_("Sign In to {studio_name}").format(studio_name=settings.STUDIO_NAME)}</h1>
+      <a href="${reverse('signup')}" class="action action-signin">${_("Don't have a {studio_name} Account? Sign up!").format(studio_name=settings.STUDIO_NAME)}</a>
     </header>
 
     <article class="content-primary" role="main">
       <form id="login_form" method="post" action="login_post">
 
         <fieldset>
-          <legend class="sr">${_("Required Information to Sign In to edX Studio")}</legend>
+          <legend class="sr">${_("Required Information to Sign In to {studio_name}").format(studio_name=settings.STUDIO_NAME)}</legend>
 
           <ol class="list-input">
             <li class="field text required" id="field-email">
@@ -37,7 +37,7 @@ from django.utils.translation import ugettext as _
         </fieldset>
 
         <div class="form-actions">
-          <button type="submit" id="submit" name="submit" class="action action-primary">${_("Sign In to edX Studio")}</button>
+          <button type="submit" id="submit" name="submit" class="action action-primary">${_("Sign In to {studio_name}").format(studio_name=settings.STUDIO_NAME)}</button>
         </div>
 
         <!-- no honor code for CMS, but need it because we're using the lms student object -->
@@ -46,7 +46,7 @@ from django.utils.translation import ugettext as _
     </article>
 
     <aside class="content-supplementary" role="complementary">
-      <h2 class="sr">${_("Studio Support")}</h2>
+      <h2 class="sr">${_("{studio_name} Support").format(studio_name=settings.STUDIO_NAME)}</h2>
 
       <div class="bit">
         <h3 class="title-3">${_("Need Help?")}</h3>

--- a/cms/templates/login.html
+++ b/cms/templates/login.html
@@ -13,7 +13,7 @@ from django.utils.translation import ugettext as _
   <section class="content">
     <header>
       <h1 class="title title-1">${_("Sign In to {studio_name}").format(studio_name=settings.STUDIO_NAME)}</h1>
-      <a href="${reverse('signup')}" class="action action-signin">${_("Don't have a {studio_name} Account? Sign up!").format(studio_name=settings.STUDIO_NAME)}</a>
+      <a href="${reverse('signup')}" class="action action-signin">${_("Don't have a {studio_name} Account? Sign up!").format(studio_name=settings.STUDIO_SHORT_NAME)}</a>
     </header>
 
     <article class="content-primary" role="main">
@@ -46,7 +46,7 @@ from django.utils.translation import ugettext as _
     </article>
 
     <aside class="content-supplementary" role="complementary">
-      <h2 class="sr">${_("{studio_name} Support").format(studio_name=settings.STUDIO_NAME)}</h2>
+      <h2 class="sr">${_("{studio_name} Support").format(studio_name=settings.STUDIO_SHORT_NAME)}</h2>
 
       <div class="bit">
         <h3 class="title-3">${_("Need Help?")}</h3>

--- a/cms/templates/manage_users.html
+++ b/cms/templates/manage_users.html
@@ -130,7 +130,7 @@
         <div class="msg">
           <h3 class="title">${_('Add Team Members to This Course')}</h3>
           <div class="copy">
-            <p>${_('Adding team members makes course authoring collaborative. Users must be signed up for {studio_name} and have an active account.').format(studio_name=settings.STUDIO_NAME)}</p>
+            <p>${_('Adding team members makes course authoring collaborative. Users must be signed up for {studio_name} and have an active account.').format(studio_name=settings.STUDIO_SHORT_NAME)}</p>
           </div>
         </div>
 

--- a/cms/templates/manage_users.html
+++ b/cms/templates/manage_users.html
@@ -130,7 +130,7 @@
         <div class="msg">
           <h3 class="title">${_('Add Team Members to This Course')}</h3>
           <div class="copy">
-            <p>${_('Adding team members makes course authoring collaborative. Users must be signed up for Studio and have an active account. ')}</p>
+            <p>${_('Adding team members makes course authoring collaborative. Users must be signed up for {studio_name} and have an active account.').format(studio_name=settings.STUDIO_NAME)}</p>
           </div>
         </div>
 

--- a/cms/templates/register.html
+++ b/cms/templates/register.html
@@ -12,7 +12,7 @@
   <section class="content">
     <header>
       <h1 class="title title-1">${_("Sign Up for {studio_name}").format(studio_name=settings.STUDIO_NAME)}</h1>
-      <a href="${reverse('login')}" class="action action-signin">${_("Already have a {studio_name} Account? Sign in").format(studio_name=settings.STUDIO_NAME)}</a>
+      <a href="${reverse('login')}" class="action action-signin">${_("Already have a {studio_name} Account? Sign in").format(studio_name=settings.STUDIO_SHORT_NAME)}</a>
     </header>
 
     <p class="introduction">${_("Ready to start creating online courses? Sign up below and start creating your first {platform_name} course today.").format(platform_name=settings.PLATFORM_NAME)}</p>
@@ -78,19 +78,19 @@
     </article>
 
     <aside class="content-supplementary" role="complementary">
-      <h2 class="sr">${_("Common {studio_name} Questions").format(studio_name=settings.STUDIO_NAME)}</h2>
+      <h2 class="sr">${_("Common {studio_name} Questions").format(studio_name=settings.STUDIO_SHORT_NAME)}</h2>
 
       <div class="bit">
-        <h3 class="title-3">${_("Who is {studio_name} for?").format(studio_name=settings.STUDIO_NAME)}</h3>
+        <h3 class="title-3">${_("Who is {studio_name} for?").format(studio_name=settings.STUDIO_SHORT_NAME)}</h3>
         <p>${_("{studio_name} is for anyone that wants to create online courses that leverage the global {platform_name} platform. Our users are often faculty members, teaching assistants and course staff, and members of instructional technology groups.").format(
-          studio_name=settings.STUDIO_NAME, platform_name=settings.PLATFORM_NAME,
+          studio_name=settings.STUDIO_SHORT_NAME, platform_name=settings.PLATFORM_NAME,
         )}</p>
       </div>
 
       <div class="bit">
         <h3 class="title-3">${_("How technically savvy do I need to be to create courses in {studio_name}?")}</h3>
         <p>${_("{studio_name} is designed to be easy to use by almost anyone familiar with common web-based authoring environments (Wordpress, Moodle, etc.). No programming knowledge is required, but for some of the more advanced features, a technical background would be helpful. As always, we are here to help, so don't hesitate to dive right in.").format(
-          studio_name=settings.STUDIO_NAME,
+          studio_name=settings.STUDIO_SHORT_NAME,
         )}</p>
       </div>
 

--- a/cms/templates/register.html
+++ b/cms/templates/register.html
@@ -11,11 +11,11 @@
 <div class="wrapper-content wrapper">
   <section class="content">
     <header>
-      <h1 class="title title-1">${_("Sign Up for edX Studio")}</h1>
-      <a href="${reverse('login')}" class="action action-signin">${_("Already have a Studio Account? Sign in")}</a>
+      <h1 class="title title-1">${_("Sign Up for {studio_name}").format(studio_name=settings.STUDIO_NAME)}</h1>
+      <a href="${reverse('login')}" class="action action-signin">${_("Already have a {studio_name} Account? Sign in").format(studio_name=settings.STUDIO_NAME)}</a>
     </header>
 
-    <p class="introduction">${_("Ready to start creating online courses? Sign up below and start creating your first edX course today.")}</p>
+    <p class="introduction">${_("Ready to start creating online courses? Sign up below and start creating your first {platform_name} course today.").format(platform_name=settings.PLATFORM_NAME)}</p>
 
     <article class="content-primary" role="main">
       <form id="register_form" method="post">
@@ -23,7 +23,7 @@
         </div>
 
         <fieldset>
-          <legend class="sr">${_("Required Information to Sign Up for edX Studio")}</legend>
+          <legend class="sr">${_("Required Information to Sign Up for {studio_name}").format(studio_name=settings.STUDIO_NAME)}</legend>
 
           <ol class="list-input">
             <li class="field text required" id="field-email">
@@ -78,16 +78,20 @@
     </article>
 
     <aside class="content-supplementary" role="complementary">
-      <h2 class="sr">${_("Common Studio Questions")}</h2>
+      <h2 class="sr">${_("Common {studio_name} Questions").format(studio_name=settings.STUDIO_NAME)}</h2>
 
       <div class="bit">
-        <h3 class="title-3">${_("Who is Studio for?")}</h3>
-        <p>${_("Studio is for anyone that wants to create online courses that leverage the global edX platform. Our users are often faculty members, teaching assistants and course staff, and members of instructional technology groups.")}</p>
+        <h3 class="title-3">${_("Who is {studio_name} for?").format(studio_name=settings.STUDIO_NAME)}</h3>
+        <p>${_("{studio_name} is for anyone that wants to create online courses that leverage the global {platform_name} platform. Our users are often faculty members, teaching assistants and course staff, and members of instructional technology groups.").format(
+          studio_name=settings.STUDIO_NAME, platform_name=settings.PLATFORM_NAME,
+        )}</p>
       </div>
 
       <div class="bit">
-        <h3 class="title-3">${_("How technically savvy do I need to be to create courses in Studio?")}</h3>
-        <p>${_("Studio is designed to be easy to use by almost anyone familiar with common web-based authoring environments (Wordpress, Moodle, etc.). No programming knowledge is required, but for some of the more advanced features, a technical background would be helpful. As always, we are here to help, so don't hesitate to dive right in.")}</p>
+        <h3 class="title-3">${_("How technically savvy do I need to be to create courses in {studio_name}?")}</h3>
+        <p>${_("{studio_name} is designed to be easy to use by almost anyone familiar with common web-based authoring environments (Wordpress, Moodle, etc.). No programming knowledge is required, but for some of the more advanced features, a technical background would be helpful. As always, we are here to help, so don't hesitate to dive right in.").format(
+          studio_name=settings.STUDIO_NAME,
+        )}</p>
       </div>
 
       <div class="bit">

--- a/cms/templates/settings.html
+++ b/cms/templates/settings.html
@@ -106,7 +106,7 @@ CMS.URL.UPLOAD_ASSET = '${upload_asset_url}';
 
           % if not about_page_editable:
           <div class="notice notice-incontext notice-workflow">
-            <h3 class="title">${_("Promoting Your Course with edX")}</h3>
+            <h3 class="title">${_("Promoting Your Course with {platform_name}").format(platform_name=settings.PLATFORM_NAME)}</h3>
             <div class="copy">
               <p>${_(
                 'Your course summary page will not be viewable until your course '

--- a/cms/templates/settings_advanced.html
+++ b/cms/templates/settings_advanced.html
@@ -74,7 +74,7 @@
         <h3 class="title-3">${_("What do advanced settings do?")}</h3>
         <p>${_("Advanced settings control specific course functionality. On this page, you can edit manual policies, which are JSON-based key and value pairs that control specific course settings.")}</p>
 
-        <p>${_("Any policies you modify here override all other information you've defined elsewhere in {studio_name}. Do not edit policies unless you are familiar with both their purpose and syntax.").format(studio_name=settings.STUDIO_NAME)}</p>
+        <p>${_("Any policies you modify here override all other information you've defined elsewhere in {studio_name}. Do not edit policies unless you are familiar with both their purpose and syntax.").format(studio_name=settings.STUDIO_SHORT_NAME)}</p>
 
         <p>${_("{em_start}Note:{em_end} When you enter strings as policy values, ensure that you use double quotation marks (&quot;) around the string. Do not use single quotation marks (&apos;).").format(em_start='<strong>', em_end="</strong>")}</p>
       </div>

--- a/cms/templates/settings_advanced.html
+++ b/cms/templates/settings_advanced.html
@@ -74,7 +74,7 @@
         <h3 class="title-3">${_("What do advanced settings do?")}</h3>
         <p>${_("Advanced settings control specific course functionality. On this page, you can edit manual policies, which are JSON-based key and value pairs that control specific course settings.")}</p>
 
-        <p>${_("Any policies you modify here override all other information you've defined elsewhere in Studio. Do not edit policies unless you are familiar with both their purpose and syntax.")}</p>
+        <p>${_("Any policies you modify here override all other information you've defined elsewhere in {studio_name}. Do not edit policies unless you are familiar with both their purpose and syntax.").format(studio_name=settings.STUDIO_NAME)}</p>
 
         <p>${_("{em_start}Note:{em_end} When you enter strings as policy values, ensure that you use double quotation marks (&quot;) around the string. Do not use single quotation marks (&apos;).").format(em_start='<strong>', em_end="</strong>")}</p>
       </div>

--- a/cms/templates/temp-course-landing.html
+++ b/cms/templates/temp-course-landing.html
@@ -32,7 +32,9 @@
 	</div>
 	</article>
 	<footer>
-		<a href="#" class="edge-logo">edX edge</a>
+		<a href="#" class="edge-logo">
+		  ${_("{platform_name} edge").format(platform_name=settings.PLATFORM_NAME)}
+		</a>
 	</footer>
 </div>
 </%block>

--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -11,8 +11,7 @@
   <header class="primary" role="banner">
 
     <div class="wrapper wrapper-l">
-      ## "edX Studio" should not be translated
-      <h1 class="branding"><a href="/"><img src="${static.url("images/edx-studio-logo.png")}" alt="edX Studio" /></a></h1>
+      <h1 class="branding"><a href="/"><img src="${static.url("images/edx-studio-logo.png")}" alt="${settings.STUDIO_NAME}" /></a></h1>
 
       % if context_course:
       <%

--- a/cms/templates/widgets/sock.html
+++ b/cms/templates/widgets/sock.html
@@ -4,7 +4,10 @@
 <div class="wrapper-sock wrapper">
   <ul class="list-actions list-cta">
     <li class="action-item">
-      <a href="#sock" class="cta cta-show-sock"><i class="icon-question-sign"></i> <span class="copy">${_("Looking for help with {studio_name}?").format(studio_name=settings.STUDIO_NAME)}</span></a>
+      <a href="#sock" class="cta cta-show-sock"><i class="icon-question-sign"></i>
+        <span class="copy-show is-shown">${_("Looking for help with {studio_name}?").format(studio_name=settings.STUDIO_NAME)}</span>
+        <span class="copy-hide is-hidden">${_("Hide {studio_name} Help").format(studio_name=settings.STUDIO_NAME)}</span>
+      </a>
     </li>
   </ul>
 

--- a/cms/templates/widgets/sock.html
+++ b/cms/templates/widgets/sock.html
@@ -4,44 +4,44 @@
 <div class="wrapper-sock wrapper">
   <ul class="list-actions list-cta">
     <li class="action-item">
-      <a href="#sock" class="cta cta-show-sock"><i class="icon-question-sign"></i> <span class="copy">${_("Looking for help with Studio?")}</span></a>
+      <a href="#sock" class="cta cta-show-sock"><i class="icon-question-sign"></i> <span class="copy">${_("Looking for help with {studio_name}?").format(studio_name=settings.STUDIO_NAME)}</span></a>
     </li>
   </ul>
 
   <div class="wrapper-inner wrapper">
     <section class="sock" id="sock">
       <header>
-        <h2 class="title sr">${_("edX Studio Documentation")}</h2>
+        <h2 class="title sr">${_("{studio_name} Documentation").format(studio_name=settings.STUDIO_NAME)}</h2>
       </header>
 
       <div class="support">
-        <h3 class="title">${_("edX Studio Documentation")}</h3>
+        <h3 class="title">${_("{studio_name} Documentation").format(studio_name=settings.STUDIO_NAME)}</h3>
 
         <div class="copy">
-           <p>${_("You can click Help in the upper right corner of any page to get more information about the page you're on. You can also use the links below to download the Building and Running an edX Course PDF file, to go to the edX Author Support site, or to enroll in edX101.")}</p>
+           <p>${_("You can click Help in the upper right corner of any page to get more information about the page you're on. You can also use the links below to download the Building and Running an {platform_name} Course PDF file, to go to the {platform_name} Author Support site, or to enroll in edX101.").format(platform_name=settings.PLATFORM_NAME)}</p>
         </div>
 
       <ul class="list-actions">
           <li class="action-item js-help-pdf">
-            <a href="${get_online_help_info(online_help_token)['pdf_url']}" target="_blank" rel="external" class="action action-primary">${_("Building and Running an edX Course PDF")}</a>
+            <a href="${get_online_help_info(online_help_token)['pdf_url']}" target="_blank" rel="external" class="action action-primary">${_("Building and Running an {platform_name} Course PDF").format(platform_name=settings.PLATFORM_NAME)}</a>
           </li>
 
         <li class="action-item">
-          <a href="http://help.edge.edx.org/" rel="external" class="action action-primary">${_("edX Studio Author Support")}</a>
-          <span class="tip">${_("edX Studio Author Support")}</span>
+          <a href="http://help.edge.edx.org/" rel="external" class="action action-primary">${_("{studio_name} Author Support").format(studio_name=settings.STUDIO_NAME)}</a>
+          <span class="tip">${_("{studio_name} Author Support").format(studio_name=settings.STUDIO_NAME)}</span>
         </li>
         <li class="action-item">
           <a href="https://edge.edx.org/courses/edX/edX101/How_to_Create_an_edX_Course/about" rel="external" class="action action-primary">${_("Enroll in edX101")}</a>
-          <span class="tip">${_("How to use edX Studio to build your course")}</span>
+          <span class="tip">${_("How to use {studio_name} to build your course").format(studio_name=settings.STUDIO_NAME)}</span>
         </li>
       </ul>
       </div>
 
       <div class="feedback">
-        <h3 class="title">${_("Request help with edX Studio")}</h3>
+        <h3 class="title">${_("Request help with {studio_name}").format(studio_name=settings.STUDIO_NAME)}</h3>
 
         <div class="copy">
-           <p>${_("Have problems, questions, or suggestions about edX Studio?")}</p>
+           <p>${_("Have problems, questions, or suggestions about {studio_name}?").format(studio_name=settings.STUDIO_NAME)}</p>
         </div>
 
         <ul class="list-actions">

--- a/cms/templates/widgets/sock.html
+++ b/cms/templates/widgets/sock.html
@@ -5,8 +5,8 @@
   <ul class="list-actions list-cta">
     <li class="action-item">
       <a href="#sock" class="cta cta-show-sock"><i class="icon-question-sign"></i>
-        <span class="copy-show is-shown">${_("Looking for help with {studio_name}?").format(studio_name=settings.STUDIO_NAME)}</span>
-        <span class="copy-hide is-hidden">${_("Hide {studio_name} Help").format(studio_name=settings.STUDIO_NAME)}</span>
+        <span class="copy-show is-shown">${_("Looking for help with {studio_name}?").format(studio_name=settings.STUDIO_SHORT_NAME)}</span>
+        <span class="copy-hide is-hidden">${_("Hide {studio_name} Help").format(studio_name=settings.STUDIO_SHORT_NAME)}</span>
       </a>
     </li>
   </ul>


### PR DESCRIPTION
For [OPEN-423](https://openedx.atlassian.net/browse/OPEN-423). This probably needs further discussion and review -- do we want to have a `{studio_name}` for "edX Studio" and a `{studio_short_name}` for "Studio"? Seems like several places use "Studio" rather than "edX Studio" rather intentionally.
