### PR TITLE
Send confirmation email on successful photo submission

### DIFF
--- a/lms/djangoapps/verify_student/tests/test_views.py
+++ b/lms/djangoapps/verify_student/tests/test_views.py
@@ -25,6 +25,7 @@ from django.test.utils import override_settings
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.core.exceptions import ObjectDoesNotExist
+from django.core import mail
 from bs4 import BeautifulSoup
 
 from util.testing import UrlResetMixin
@@ -923,6 +924,15 @@ class TestSubmitPhotosForVerification(UrlResetMixin, TestCase):
 
         response = self.client.post(url, params)
         self.assertEqual(response.status_code, expected_status_code)
+
+        if expected_status_code == 200:
+            # Verify that photo submission confirmation email was sent
+            self.assertEqual(len(mail.outbox), 1)
+            self.assertEqual("Verification photos received", mail.outbox[0].subject)
+        else:
+            # Verify that photo submission confirmation email was not sent
+            self.assertEqual(len(mail.outbox), 0)
+
         return response
 
     def _assert_full_name(self, full_name):

--- a/lms/templates/emails/photo_submission_confirmation.txt
+++ b/lms/templates/emails/photo_submission_confirmation.txt
@@ -1,0 +1,11 @@
+<%! from django.utils.translation import ugettext as _ %>
+
+${_("Hi {full_name},").format(full_name=full_name)}
+
+${_("Thanks for submitting your photos!")}
+
+${_("We've received your information and the verification process has begun. You can check the status of the verification process on your dashboard.")}
+
+${_("Thank you,")}
+
+${_("The {platform_name} team").format(platform_name=platform_name)}


### PR DESCRIPTION
As per [ECOM-724](https://openedx.atlassian.net/browse/ECOM-724), this sends a confirmation email to the user when they successfully submit their verification photos.

@dianakhuang and @stephensanchez, could you review this when you're able?
