### PR TITLE
use pip-accel if it is available

### DIFF
--- a/pavelib/prereqs.py
+++ b/pavelib/prereqs.py
@@ -6,6 +6,7 @@ import os
 import hashlib
 from distutils import sysconfig
 from paver.easy import *
+import subprocess
 from .utils.envs import Env
 
 
@@ -133,8 +134,24 @@ def python_prereqs_installation():
     """
     Installs Python prerequisites
     """
+
+    try:
+        subprocess.check_call(
+            "pip-accel --version",
+            stdout=file("/dev/null"),
+            stderr=file("/dev/null"),
+            shell=True
+        )
+        executable = 'pip-accel'
+    except subprocess.CalledProcessError:
+        executable = 'pip'
+
     for req_file in PYTHON_REQ_FILES:
-        sh("pip install -q --exists-action w -r {req_file}".format(req_file=req_file))
+        sh("{ex} install -q --exists-action=w -r {req_file}".format(
+            ex=executable,
+            req_file=req_file,
+            )
+        )
 
 
 @task


### PR DESCRIPTION
@benpatterson @jzoldak  How does this look?  This will need some more thought around getting requirements setup on devstack in order to use pip-accel.  This seemed like the quickest way to get it working in jenkins.
