### PR TITLE
Added keyword substitution for course announcements

### DIFF
--- a/cms/static/js/views/course_info_update.js
+++ b/cms/static/js/views/course_info_update.js
@@ -1,6 +1,6 @@
 define(["js/views/baseview", "codemirror", "js/models/course_update",
-    "js/views/feedback_prompt", "js/views/feedback_notification", "js/views/course_info_helper", "js/utils/modal"],
-    function(BaseView, CodeMirror, CourseUpdateModel, PromptView, NotificationView, CourseInfoHelper, ModalUtils) {
+    "js/views/feedback_prompt", "js/views/feedback_notification", "js/views/course_info_helper", "js/utils/modal", "js/views/utils/view_utils"],
+    function(BaseView, CodeMirror, CourseUpdateModel, PromptView, NotificationView, CourseInfoHelper, ModalUtils, viewUtils) {
 
     var CourseInfoUpdateView = BaseView.extend({
         // collection is CourseUpdateCollection
@@ -73,6 +73,13 @@ define(["js/views/baseview", "codemirror", "js/models/course_update",
 
         onSave: function(event) {
             event.preventDefault();
+            var validation = viewUtils.keywordValidator.validate_string(this.$codeMirror.getValue());
+            if (!validation.is_valid) {
+                var message = gettext('There are invalid keywords in your message. Please check the following keywords and try again:');
+                message += "\n" + validation.invalid_keywords.join('\n');
+                window.alert(message);
+                return;
+            }
             var targetModel = this.eventModel(event);
             targetModel.set({ date : this.dateEntry(event).val(), content : this.$codeMirror.getValue() });
             // push change to display, hide the editor, submit the change

--- a/cms/static/js/views/utils/view_utils.js
+++ b/cms/static/js/views/utils/view_utils.js
@@ -6,7 +6,8 @@ define(["jquery", "underscore", "gettext", "js/views/feedback_notification", "js
         var toggleExpandCollapse, showLoadingIndicator, hideLoadingIndicator, confirmThenRunOperation,
             runOperationShowingMessage, disableElementWhileRunning, getScrollOffset, setScrollOffset,
             setScrollTop, redirect, reload, hasChangedAttributes, deleteNotificationHandler,
-            validateRequiredField, validateURLItemEncoding, validateTotalKeyLength, checkTotalKeyLengthViolations;
+            validateRequiredField, validateURLItemEncoding, validateTotalKeyLength, checkTotalKeyLengthViolations,
+            keywordValidator;
 
         // see https://openedx.atlassian.net/browse/TNL-889 for what is it and why it's 65
         var MAX_SUM_KEY_LENGTH = 65;
@@ -226,6 +227,33 @@ define(["jquery", "underscore", "gettext", "js/views/feedback_notification", "js
             }
         };
 
+        keywordValidator = (function () {
+            var regexp = /%%+[^%]+%%/g;
+            var keywords = ['%%USER_ID%%', '%%USER_FULLNAME%%', '%%COURSE_DISPLAY_NAME%%', '%%COURSE_END_DATE%%'];
+            var validate = function (string) {
+                var regex_match = string.match(regexp);
+                var found_keywords = regex_match == null ? [] : regex_match;
+                var invalid_keywords = [];
+                var num_found = found_keywords.length;
+                var curr_keyword;
+
+                $.each(found_keywords, function(i, keyword) {
+                    if ($.inArray(keyword, keywords) == -1) {
+                        invalid_keywords.push(keyword);
+                    }
+                });
+
+                return {
+                    'is_valid': invalid_keywords.length == 0,
+                    'invalid_keywords': invalid_keywords,
+                }
+
+            };
+            return {
+                'validate_string': validate,
+            };
+        }());
+
         return {
             'toggleExpandCollapse': toggleExpandCollapse,
             'showLoadingIndicator': showLoadingIndicator,
@@ -243,6 +271,7 @@ define(["jquery", "underscore", "gettext", "js/views/feedback_notification", "js
             'validateRequiredField': validateRequiredField,
             'validateURLItemEncoding': validateURLItemEncoding,
             'validateTotalKeyLength': validateTotalKeyLength,
-            'checkTotalKeyLengthViolations': checkTotalKeyLengthViolations
+            'checkTotalKeyLengthViolations': checkTotalKeyLengthViolations,
+            'keywordValidator': keywordValidator,
         };
     });

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -17,6 +17,7 @@ from static_replace import replace_static_urls
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.x_module import STUDENT_VIEW
 from microsite_configuration import microsite
+from util.keyword_substitution import substitute_keywords_with_data
 
 from courseware.access import has_access
 from courseware.model_data import FieldDataCache
@@ -277,6 +278,7 @@ def get_course_info_section(request, course, section_key):
     if info_module is not None:
         try:
             html = info_module.render(STUDENT_VIEW).content
+            html = substitute_keywords_with_data(html, request.user.id, course.id)
         except Exception:  # pylint: disable=broad-except
             html = render_to_string('courseware/error-message.html', None)
             log.exception(


### PR DESCRIPTION
This commit pulls in changes from #4487 that implement keyword
substitution for course announcements, using the keyword
substitution mechanism added by #5449. The changes introduced
by this commit allow an instructor to include keywords in
course announcements. The same keywords available for bulk emails
are also available here.
