### PR TITLE
TNL-930: Turn off Student Notes when Harvard Annotation Tool is enabled.

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/inheritance.py
+++ b/common/lib/xmodule/xmodule/modulestore/inheritance.py
@@ -173,14 +173,15 @@ class InheritanceMixin(XBlockMixin):
         default=default_reset_button
     )
     edxnotes = Boolean(
-        display_name=_("Enable Notes"),
-        help=_("Enter true or false. If true, you can use the Notes for HTML components."),
+        display_name=_("Enable Student Notes"),
+        help=_("Enter true or false. If true, students can use the Student Notes feature."),
         default=False,
         scope=Scope.settings
     )
     edxnotes_visibility = Boolean(
-        display_name=_("Enable visibility of Notes"),
-        help=_("Enter true or false. If true, Notes for HTML components will be visible."),
+        display_name="Student Notes Visibility",
+        help=_("Indicates whether Student Notes are visible in the course. "
+               "Students can also show or hide their notes in the courseware."),
         default=True,
         scope=Scope.user_info
     )

--- a/lms/djangoapps/edxnotes/decorators.py
+++ b/lms/djangoapps/edxnotes/decorators.py
@@ -26,8 +26,10 @@ def edxnotes(cls):
         is_studio = getattr(self.system, "is_author_mode", False)
         course = self.descriptor.runtime.modulestore.get_course(self.runtime.course_id)
 
-        # Must be disabled in Studio or depends on the feature flag/advanced
-        # settings of the course.
+        # Must be disabled:
+        # - in Studio;
+        # - when Harvard Annotation Tool is enabled for the course;
+        # - when the feature flag or `edxnotes` setting of the course is set to False.
         if is_studio or not is_feature_enabled(course):
             return original_get_html(self, *args, **kwargs)
         else:

--- a/lms/djangoapps/edxnotes/helpers.py
+++ b/lms/djangoapps/edxnotes/helpers.py
@@ -323,13 +323,27 @@ def generate_uid():
 
 def is_feature_enabled(course):
     """
-    Returns True if the edxnotes app is enabled for the course, False otherwise.
+    Returns True if Student Notes feature is enabled for the course,
+    False otherwise.
 
-    In order for the app to be enabled it must be:
+    In order for the application to be enabled it must be:
         1) enabled globally via FEATURES.
         2) present in the course tab configuration.
+        3) Harvard Annotation Tool must be disabled for the course.
     """
     tab_found = next((True for t in course.tabs if t["type"] == "edxnotes"), False)
     feature_enabled = settings.FEATURES.get("ENABLE_EDXNOTES")
 
-    return feature_enabled and tab_found
+    return (feature_enabled and tab_found) and not is_harvard_notes_enabled(course)
+
+
+def is_harvard_notes_enabled(course):
+    """
+    Returns True if Harvard Annotation Tool is enabled for the course,
+    False otherwise.
+
+    Checks for 'textannotation', 'imageannotation', 'videoannotation' in the list
+    of advanced modules of the course.
+    """
+    modules = set(['textannotation', 'imageannotation', 'videoannotation'])
+    return bool(modules.intersection(course.advanced_modules))


### PR DESCRIPTION
Disables Student Notes if one of `textannotation`, `imageannotation`, `videoannotation` modules exist in the list of `Advanced Modules`.

There is still possibility to break `Student Notes` and `Harvard Annotation Tool`:
- add one of `textannotation`, `imageannotation`, `videoannotation` to the `Advanced Modules` list;
- add one of `textannotation`, `imageannotation`, `videoannotation` to the unit;
- remove it form the `Advanced Modules` list => **You can enable Student Notes now. If you have both modules in the sequential, it breaks one of these modules.**

I think we should write a good note about this situation.

@tymofij , @olmar, @jmclaus, @srpearce  please review.

**sandbox:** http://studio.polesye.m.sandbox.edx.org/
