### PR TITLE
Library Content - Filter library content by CAPA problem type

### DIFF
--- a/common/lib/capa/capa/responsetypes.py
+++ b/common/lib/capa/capa/responsetypes.py
@@ -441,7 +441,7 @@ class JavascriptResponse(LoncapaResponse):
     Javascript using Node.js.
     """
 
-    human_name = _('Javascript Input')
+    human_name = _('JavaScript Input')
     tags = ['javascriptresponse']
     max_inputfields = 1
     allowed_inputfields = ['javascriptinput']

--- a/common/lib/capa/capa/responsetypes.py
+++ b/common/lib/capa/capa/responsetypes.py
@@ -58,6 +58,8 @@ registry = TagRegistry()
 CorrectMap = correctmap.CorrectMap  # pylint: disable=invalid-name
 CORRECTMAP_PY = None
 
+# Make '_' a no-op so we can scrape strings
+_ = lambda text: text
 
 #-----------------------------------------------------------------------------
 # Exceptions
@@ -439,6 +441,7 @@ class JavascriptResponse(LoncapaResponse):
     Javascript using Node.js.
     """
 
+    human_name = _('Javascript Input')
     tags = ['javascriptresponse']
     max_inputfields = 1
     allowed_inputfields = ['javascriptinput']
@@ -684,6 +687,7 @@ class ChoiceResponse(LoncapaResponse):
 
     """
 
+    human_name = _('Checkboxes')
     tags = ['choiceresponse']
     max_inputfields = 1
     allowed_inputfields = ['checkboxgroup', 'radiogroup']
@@ -754,6 +758,7 @@ class MultipleChoiceResponse(LoncapaResponse):
     """
     # TODO: handle direction and randomize
 
+    human_name = _('Multiple Choice')
     tags = ['multiplechoiceresponse']
     max_inputfields = 1
     allowed_inputfields = ['choicegroup']
@@ -1042,6 +1047,7 @@ class MultipleChoiceResponse(LoncapaResponse):
 @registry.register
 class TrueFalseResponse(MultipleChoiceResponse):
 
+    human_name = _('True/False Choice')
     tags = ['truefalseresponse']
 
     def mc_setup_response(self):
@@ -1073,6 +1079,7 @@ class OptionResponse(LoncapaResponse):
     TODO: handle direction and randomize
     """
 
+    human_name = _('Dropdown')
     tags = ['optionresponse']
     hint_tag = 'optionhint'
     allowed_inputfields = ['optioninput']
@@ -1108,6 +1115,7 @@ class NumericalResponse(LoncapaResponse):
     to a number (e.g. `4+5/2^2`), and accepts with a tolerance.
     """
 
+    human_name = _('Numerical Input')
     tags = ['numericalresponse']
     hint_tag = 'numericalhint'
     allowed_inputfields = ['textline', 'formulaequationinput']
@@ -1308,6 +1316,7 @@ class StringResponse(LoncapaResponse):
             </hintgroup>
         </stringresponse>
     """
+    human_name = _('Text Input')
     tags = ['stringresponse']
     hint_tag = 'stringhint'
     allowed_inputfields = ['textline']
@@ -1426,6 +1435,7 @@ class CustomResponse(LoncapaResponse):
     or in a <script>...</script>
     """
 
+    human_name = _('Custom Evaluated Script')
     tags = ['customresponse']
 
     allowed_inputfields = ['textline', 'textbox', 'crystallography',
@@ -1797,6 +1807,7 @@ class SymbolicResponse(CustomResponse):
     Symbolic math response checking, using symmath library.
     """
 
+    human_name = _('Symbolic Math Input')
     tags = ['symbolicresponse']
     max_inputfields = 1
 
@@ -1865,6 +1876,7 @@ class CodeResponse(LoncapaResponse):
 
     """
 
+    human_name = _('Code Input')
     tags = ['coderesponse']
     allowed_inputfields = ['textbox', 'filesubmission', 'matlabinput']
     max_inputfields = 1
@@ -2142,6 +2154,7 @@ class ExternalResponse(LoncapaResponse):
 
     """
 
+    human_name = _('External Grader')
     tags = ['externalresponse']
     allowed_inputfields = ['textline', 'textbox']
     awdmap = {
@@ -2299,6 +2312,7 @@ class FormulaResponse(LoncapaResponse):
     Checking of symbolic math response using numerical sampling.
     """
 
+    human_name = _('Math Expression Input')
     tags = ['formularesponse']
     hint_tag = 'formulahint'
     allowed_inputfields = ['textline', 'formulaequationinput']
@@ -2511,6 +2525,7 @@ class SchematicResponse(LoncapaResponse):
     """
     Circuit schematic response type.
     """
+    human_name = _('Circuit Schematic Builder')
     tags = ['schematicresponse']
     allowed_inputfields = ['schematic']
 
@@ -2589,6 +2604,7 @@ class ImageResponse(LoncapaResponse):
         True, if click is inside any region or rectangle. Otherwise False.
     """
 
+    human_name = _('Image Mapped Input')
     tags = ['imageresponse']
     allowed_inputfields = ['imageinput']
 
@@ -2707,6 +2723,7 @@ class AnnotationResponse(LoncapaResponse):
     The response contains both a comment (student commentary) and an option (student tag).
     Only the tag is currently graded. Answers may be incorrect, partially correct, or correct.
     """
+    human_name = _('Annotation Input')
     tags = ['annotationresponse']
     allowed_inputfields = ['annotationinput']
     max_inputfields = 1
@@ -2831,6 +2848,7 @@ class ChoiceTextResponse(LoncapaResponse):
     ChoiceResponse.
     """
 
+    human_name = _('Checkboxes With Text Input')
     tags = ['choicetextresponse']
     max_inputfields = 1
     allowed_inputfields = ['choicetextgroup',

--- a/common/lib/xmodule/xmodule/capa_module.py
+++ b/common/lib/xmodule/xmodule/capa_module.py
@@ -2,10 +2,12 @@
 import json
 import logging
 import sys
+from lxml import etree
 
 from pkg_resources import resource_string
 
 from .capa_base import CapaMixin, CapaFields, ComplexEncoder
+from capa import inputtypes
 from .progress import Progress
 from xmodule.x_module import XModule, module_attr
 from xmodule.raw_module import RawDescriptor
@@ -171,6 +173,13 @@ class CapaDescriptor(CapaFields, RawDescriptor):
             CapaDescriptor.use_latex_compiler,
         ])
         return non_editable_fields
+
+    @property
+    def problem_types(self):
+        """ Low-level problem type introspection for content libraries filtering by problem type """
+        tree = etree.XML(self.data)
+        registered_tas = inputtypes.registry.registered_tags()
+        return set([node.tag for node in tree.iter() if node.tag in registered_tas])
 
     # Proxy to CapaModule for access to any of its attributes
     answer_available = module_attr('answer_available')

--- a/common/lib/xmodule/xmodule/capa_module.py
+++ b/common/lib/xmodule/xmodule/capa_module.py
@@ -7,7 +7,7 @@ from lxml import etree
 from pkg_resources import resource_string
 
 from .capa_base import CapaMixin, CapaFields, ComplexEncoder
-from capa import inputtypes
+from capa import responsetypes
 from .progress import Progress
 from xmodule.x_module import XModule, module_attr
 from xmodule.raw_module import RawDescriptor
@@ -178,8 +178,8 @@ class CapaDescriptor(CapaFields, RawDescriptor):
     def problem_types(self):
         """ Low-level problem type introspection for content libraries filtering by problem type """
         tree = etree.XML(self.data)
-        registered_tas = inputtypes.registry.registered_tags()
-        return set([node.tag for node in tree.iter() if node.tag in registered_tas])
+        registered_tags = responsetypes.registry.registered_tags()
+        return set([node.tag for node in tree.iter() if node.tag in registered_tags])
 
     # Proxy to CapaModule for access to any of its attributes
     answer_available = module_attr('answer_available')

--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -35,8 +35,10 @@ def enum(**enums):
 
 
 def _get_capa_types():
+    """
+    Gets capa types tags and labels
+    """
     capa_types = {
-        ANY_CAPA_TYPE_VALUE: _('Any Type'),
         'annotationinput': _('Annotation'),
         'checkboxgroup': _('Checkbox Group'),
         'checkboxtextgroup': _('Checkbox Text Group'),
@@ -54,7 +56,7 @@ def _get_capa_types():
         'javascriptinput': _('Javascript Input'),
         'jsinput': _('JS Input'),
         'matlabinput': _('Matlab'),
-        'optioninput': _('Select option'),
+        'optioninput': _('Select Option'),
         'radiogroup': _('Radio Group'),
         'radiotextgroup': _('Radio Text Group'),
         'schematic': _('Schematic'),
@@ -63,7 +65,7 @@ def _get_capa_types():
         'vsepr_input': _('VSEPR'),
     }
 
-    return sorted([
+    return [{'value': ANY_CAPA_TYPE_VALUE, 'display_name': _('Any Type')}] + sorted([
         {'value': capa_type, 'display_name': caption}
         for capa_type, caption in capa_types.items()
     ], key=lambda item: item.get('display_name'))
@@ -221,6 +223,9 @@ class LibraryContentModule(LibraryContentFields, XModule, StudioEditableModule):
     any particular student.
     """
     def _filter_children(self, child_locator):
+        """
+        Filters children by CAPA problem type, if configured
+        """
         if self.capa_type == ANY_CAPA_TYPE_VALUE:
             return True
 
@@ -233,7 +238,6 @@ class LibraryContentModule(LibraryContentFields, XModule, StudioEditableModule):
             return True
 
         return any(self.capa_type in capa_input.tags for capa_input in block.lcp.inputs.values())
-
 
     def selected_children(self):
         """
@@ -427,8 +431,8 @@ class LibraryContentDescriptor(LibraryContentFields, MakoModuleDescriptor, XmlDe
         If source_libraries has been edited, refresh_children automatically.
         """
         old_source_libraries = LibraryList().from_json(old_metadata.get('source_libraries', []))
-        if (set(old_source_libraries) != set(self.source_libraries) or
-            old_metadata.get('capa_type', ANY_CAPA_TYPE_VALUE) != self.capa_type):
+        if set(old_source_libraries) != set(self.source_libraries) or \
+                old_metadata.get('capa_type', ANY_CAPA_TYPE_VALUE) != self.capa_type:
             try:
                 self.refresh_children(None, None, update_db=False)  # update_db=False since update_item() is about to be called anyways
             except ValueError:

--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -361,7 +361,7 @@ class LibraryContentDescriptor(LibraryContentFields, MakoModuleDescriptor, XmlDe
                         # See https://openedx.atlassian.net/browse/TNL-993
                         action_class='library-update-btn',
                         # Translators: ↻ is an UTF icon symbol, no need translating it.
-                        action_label=_(u"↻ Update now.")
+                        action_label=_(u"{0} Update now.").format(u"↻")
                     )
                 )
                 return False
@@ -453,8 +453,8 @@ class LibraryContentDescriptor(LibraryContentFields, MakoModuleDescriptor, XmlDe
         If source_libraries has been edited, refresh_children automatically.
         """
         old_source_libraries = LibraryList().from_json(old_metadata.get('source_libraries', []))
-        if set(old_source_libraries) != set(self.source_libraries) or \
-                old_metadata.get('capa_type', ANY_CAPA_TYPE_VALUE) != self.capa_type:
+        if (set(old_source_libraries) != set(self.source_libraries) or
+                old_metadata.get('capa_type', ANY_CAPA_TYPE_VALUE) != self.capa_type):
             try:
                 self.refresh_children(None, None, update_db=False)  # update_db=False since update_item() is about to be called anyways
             except ValueError:

--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -26,7 +26,6 @@ _ = lambda text: text
 
 
 ANY_CAPA_TYPE_VALUE = 'any'
-CAPA_BLOCK_TYPE = 'problem'
 
 
 def enum(**enums):
@@ -362,6 +361,9 @@ class LibraryContentDescriptor(LibraryContentFields, MakoModuleDescriptor, XmlDe
         return Response()
 
     def _validate_library_version(self, validation, lib_tools, version, library_key):
+        """
+        Validates library version
+        """
         latest_version = lib_tools.get_library_version(library_key)
         if latest_version is not None:
             if version is None or version != latest_version:
@@ -423,7 +425,7 @@ class LibraryContentDescriptor(LibraryContentFields, MakoModuleDescriptor, XmlDe
                     StudioValidationMessage.WARNING,
                     _(u'There are no content matching configured filters in the selected libraries.'),
                     action_class='edit-button',
-                    action_label=_(u"Edit Library List")
+                    action_label=_(u"Edit Problem Type Filter")
                 )
             )
 

--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -188,7 +188,7 @@ class LibraryContentFields(object):
     )
     capa_type = String(
         display_name=_("Problem Type"),
-        help=_("The type of components to include in this block"),
+        help=_('Choose a problem type to fetch from the library. If "Any Type" is selected no filtering is applied.'),
         default=ANY_CAPA_TYPE_VALUE,
         values=_get_capa_types(),
         scope=Scope.settings,

--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -323,7 +323,7 @@ class LibraryContentDescriptor(LibraryContentFields, MakoModuleDescriptor, XmlDe
     js_module_name = "VerticalDescriptor"
 
     @XBlock.handler
-    def refresh_children(self, request, suffix, update_db=True):  # pylint: disable=unused-argument
+    def refresh_children(self, request=None, suffix=None, update_db=True):  # pylint: disable=unused-argument
         """
         Refresh children:
         This method is to be used when any of the libraries that this block
@@ -402,17 +402,12 @@ class LibraryContentDescriptor(LibraryContentFields, MakoModuleDescriptor, XmlDe
             )
             return validation
         lib_tools = self.runtime.service(self, 'library_tools')
-        matching_children_count = 0
         for library_key, version in self.source_libraries:
             if not self._validate_library_version(validation, lib_tools, version, library_key):
                 break
 
-            library = lib_tools.get_library(library_key)
-            children_matching_filter = lib_tools.get_filtered_children(library, self.capa_type)
-            # get_filtered_children returns generator, so can't use len.
-            # And we don't actually need those children, so no point of constructing a list
-            matching_children_count += sum(1 for child in children_matching_filter)
-
+        # Note: we assume refresh_children() has been called since the last time fields like source_libraries or capa_types were changed.
+        matching_children_count = len(self.children)  # pylint: disable=no-member
         if matching_children_count == 0:
             self._set_validation_error_if_empty(
                 validation,

--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -39,30 +39,28 @@ def _get_capa_types():
     Gets capa types tags and labels
     """
     capa_types = {
-        'annotationinput': _('Annotation'),
-        'checkboxgroup': _('Checkbox Group'),
-        'checkboxtextgroup': _('Checkbox Text Group'),
-        'chemicalequationinput': _('Chemical Equation'),
-        'choicegroup': _('Choice Group'),
-        'codeinput': _('Code Input'),
-        'crystallography': _('Crystallography'),
-        'designprotein2dinput': _('Design Protein 2D'),
-        'drag_and_drop_input': _('Drag and Drop'),
-        'editageneinput': _('Edit A Gene'),
-        'editamoleculeinput': _('Edit A Molecule'),
-        'filesubmission': _('File Submission'),
-        'formulaequationinput': _('Formula Equation'),
-        'imageinput': _('Image'),
-        'javascriptinput': _('Javascript Input'),
-        'jsinput': _('JS Input'),
-        'matlabinput': _('Matlab'),
-        'optioninput': _('Select Option'),
-        'radiogroup': _('Radio Group'),
-        'radiotextgroup': _('Radio Text Group'),
-        'schematic': _('Schematic'),
-        'textbox': _('Code Text Input'),
-        'textline': _('Text Line'),
-        'vsepr_input': _('VSEPR'),
+        # basic tab
+        'choiceresponse': _('Checkboxes'),
+        'optionresponse': _('Dropdown'),
+        'multiplechoiceresponse': _('Multiple Choice'),
+        'truefalseresponse': _('True/False Choice'),
+        'numericalresponse': _('Numerical Input'),
+        'stringresponse': _('Text Input'),
+
+        # advanced tab
+        'schematicresponse': _('Circuit Schematic Builder'),
+        'customresponse': _('Custom Evaluated Script'),
+        'imageresponse': _('Image Mapped Input'),
+        'formularesponse': _('Math Expression Input'),
+        'jsmeresponse': _('Molecular Structure'),
+
+        # not in "Add Component" menu
+        'javascriptresponse': _('Javascript Input'),
+        'symbolicresponse': _('Symbolic Math Input'),
+        'coderesponse': _('Code Input'),
+        'externalresponse': _('External Grader'),
+        'annotationresponse': _('Annotation Input'),
+        'choicetextresponse': _('Checkboxes With Text Input'),
     }
 
     return [{'value': ANY_CAPA_TYPE_VALUE, 'display_name': _('Any Type')}] + sorted([

--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -6,6 +6,7 @@ from bson.objectid import ObjectId, InvalidId
 from collections import namedtuple
 from copy import copy
 from capa.responsetypes import registry
+from gettext import ngettext
 
 from .mako_module import MakoModuleDescriptor
 from opaque_keys import InvalidKeyError
@@ -359,7 +360,8 @@ class LibraryContentDescriptor(LibraryContentFields, MakoModuleDescriptor, XmlDe
                         # TODO: change this to action_runtime_event='...' once the unit page supports that feature.
                         # See https://openedx.atlassian.net/browse/TNL-993
                         action_class='library-update-btn',
-                        action_label=_(u"↻ Update now")
+                        # Translators: ↻ is an UTF icon symbol, no need translating it.
+                        action_label=_(u"↻ Update now.")
                     )
                 )
                 return False
@@ -369,7 +371,7 @@ class LibraryContentDescriptor(LibraryContentFields, MakoModuleDescriptor, XmlDe
                     StudioValidationMessage.ERROR,
                     _(u'Library is invalid, corrupt, or has been deleted.'),
                     action_class='edit-button',
-                    action_label=_(u"Edit Library List")
+                    action_label=_(u"Edit Library List.")
                 )
             )
             return False
@@ -395,7 +397,7 @@ class LibraryContentDescriptor(LibraryContentFields, MakoModuleDescriptor, XmlDe
                     StudioValidationMessage.NOT_CONFIGURED,
                     _(u"A library has not yet been selected."),
                     action_class='edit-button',
-                    action_label=_(u"Select a Library")
+                    action_label=_(u"Select a Library.")
                 )
             )
             return validation
@@ -418,7 +420,7 @@ class LibraryContentDescriptor(LibraryContentFields, MakoModuleDescriptor, XmlDe
                     StudioValidationMessage.WARNING,
                     _(u'There are no matching problem types in the specified libraries.'),
                     action_class='edit-button',
-                    action_label=_(u"Select another problem type")
+                    action_label=_(u"Select another problem type.")
                 )
             )
 
@@ -427,11 +429,20 @@ class LibraryContentDescriptor(LibraryContentFields, MakoModuleDescriptor, XmlDe
                 validation,
                 StudioValidationMessage(
                     StudioValidationMessage.WARNING,
-                    _(u'The specified libraries are configured to fetch {count} problems, '
-                      u'but there are only {actual} matching problems.')
-                    .format(actual=matching_children_count, count=self.max_count),
+                    (
+                        ngettext(
+                            u'The specified libraries are configured to fetch {count} problem, ',
+                            u'The specified libraries are configured to fetch {count} problems, ',
+                            self.max_count
+                        ) +
+                        ngettext(
+                            u'but there are only {actual} matching problem.',
+                            u'but there are only {actual} matching problems.',
+                            matching_children_count
+                        )
+                    ).format(count=self.max_count, actual=matching_children_count),
                     action_class='edit-button',
-                    action_label=_(u"Edit configuration")
+                    action_label=_(u"Edit the library configuration.")
                 )
             )
 

--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -360,8 +360,8 @@ class LibraryContentDescriptor(LibraryContentFields, MakoModuleDescriptor, XmlDe
                         # TODO: change this to action_runtime_event='...' once the unit page supports that feature.
                         # See https://openedx.atlassian.net/browse/TNL-993
                         action_class='library-update-btn',
-                        # Translators: ↻ is an UTF icon symbol, no need translating it.
-                        action_label=_(u"{0} Update now.").format(u"↻")
+                        # Translators: {refresh_icon} placeholder is substituted to "↻" (without double quotes)
+                        action_label=_(u"{refresh_icon} Update now.").format(refresh_icon=u"↻")
                     )
                 )
                 return False
@@ -445,7 +445,7 @@ class LibraryContentDescriptor(LibraryContentFields, MakoModuleDescriptor, XmlDe
 
     def editor_saved(self, user, old_metadata, old_content):
         """
-        If source_libraries has been edited, refresh_children automatically.
+        If source_libraries or capa_type has been edited, refresh_children automatically.
         """
         old_source_libraries = LibraryList().from_json(old_metadata.get('source_libraries', []))
         if (set(old_source_libraries) != set(self.source_libraries) or

--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -356,7 +356,9 @@ class LibraryContentDescriptor(LibraryContentFields, MakoModuleDescriptor, XmlDe
                     StudioValidationMessage(
                         StudioValidationMessage.WARNING,
                         _(u'This component is out of date. The library has new content.'),
-                        action_class='library-update-btn',  # TODO: change this to action_runtime_event='...' once the unit page supports that feature.
+                        # TODO: change this to action_runtime_event='...' once the unit page supports that feature.
+                        # See https://openedx.atlassian.net/browse/TNL-993
+                        action_class='library-update-btn',
                         action_label=_(u"↻ Update now")
                     )
                 )

--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -222,23 +222,6 @@ class LibraryContentModule(LibraryContentFields, XModule, StudioEditableModule):
     as children of this block, but only a subset of those children are shown to
     any particular student.
     """
-    def _filter_children(self, child_locator):
-        """
-        Filters children by CAPA problem type, if configured
-        """
-        if self.capa_type == ANY_CAPA_TYPE_VALUE:
-            return True
-
-        if child_locator.block_type != CAPA_BLOCK_TYPE:
-            return False
-
-        block = self.runtime.get_block(child_locator)
-
-        if not hasattr(block, 'lcp'):
-            return True
-
-        return any(self.capa_type in capa_input.tags for capa_input in block.lcp.inputs.values())
-
     def selected_children(self):
         """
         Returns a set() of block_ids indicating which of the possible children
@@ -255,7 +238,7 @@ class LibraryContentModule(LibraryContentFields, XModule, StudioEditableModule):
             return self._selected_set  # pylint: disable=access-member-before-definition
         # Determine which of our children we will show:
         selected = set(tuple(k) for k in self.selected)  # set of (block_type, block_id) tuples
-        valid_block_keys = set([(c.block_type, c.block_id) for c in self.children if self._filter_children(c)])  # pylint: disable=no-member
+        valid_block_keys = set([(c.block_type, c.block_id) for c in self.children])  # pylint: disable=no-member
         # Remove any selected blocks that are no longer valid:
         selected -= (selected - valid_block_keys)
         # If max_count has been decreased, we may have to drop some previously selected blocks:

--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -5,6 +5,7 @@ LibraryContent: The XBlock used to include blocks from a library in a course.
 from bson.objectid import ObjectId, InvalidId
 from collections import namedtuple
 from copy import copy
+
 from .mako_module import MakoModuleDescriptor
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.locator import LibraryLocator
@@ -19,6 +20,7 @@ from xmodule.studio_editable import StudioEditableModule, StudioEditableDescript
 from .xml_module import XmlDescriptor
 from pkg_resources import resource_string
 
+
 # Make '_' a no-op so we can scrape strings
 _ = lambda text: text
 
@@ -26,6 +28,40 @@ _ = lambda text: text
 def enum(**enums):
     """ enum helper in lieu of enum34 """
     return type('Enum', (), enums)
+
+
+def _get_capa_types():
+    capa_types = {
+        'annotationinput': _('Annotation'),
+        'checkboxgroup': _('Checkbox Group'),
+        'checkboxtextgroup': _('Checkbox Text Group'),
+        'chemicalequationinput': _('Chemical Equation'),
+        'choicegroup': _('Choice Group'),
+        'codeinput': _('Code Input'),
+        'crystallography': _('Crystallography'),
+        'designprotein2dinput': _('Design Protein 2D'),
+        'drag_and_drop_input': _('Drag and Drop'),
+        'editageneinput': _('Edit A Gene'),
+        'editamoleculeinput': _('Edit A Molecule'),
+        'filesubmission': _('File Submission'),
+        'formulaequationinput': _('Formula Equation'),
+        'imageinput': _('Image'),
+        'javascriptinput': _('Javascript Input'),
+        'jsinput': _('JS Input'),
+        'matlabinput': _('Matlab'),
+        'optioninput': _('Select option'),
+        'radiogroup': _('Radio Group'),
+        'radiotextgroup': _('Radio Text Group'),
+        'schematic': _('Schematic'),
+        'textbox': _('Code Text Input'),
+        'textline': _('Text Line'),
+        'vsepr_input': _('VSEPR'),
+    }
+
+    return sorted([
+        {'value': capa_type, 'display_name': caption}
+        for capa_type, caption in capa_types.items()
+    ], key=lambda item: item.get('display_name'))
 
 
 class LibraryVersionReference(namedtuple("LibraryVersionReference", "library_id version")):
@@ -144,6 +180,13 @@ class LibraryContentFields(object):
         display_name=_("Count"),
         help=_("Enter the number of components to display to each student."),
         default=1,
+        scope=Scope.settings,
+    )
+    capa_type = String(
+        display_name=_("Problem Type"),
+        help=_("The type of components to include in this block"),
+        default="any",
+        values=[{"display_name": _("Any Type"), "value": "any"}] + _get_capa_types(),
         scope=Scope.settings,
     )
     filters = String(default="")  # TBD

--- a/common/lib/xmodule/xmodule/library_tools.py
+++ b/common/lib/xmodule/xmodule/library_tools.py
@@ -104,7 +104,7 @@ class LibraryToolsService(object):
             new_libraries = []
             for library_key, library in libraries:
 
-                def copy_children_recursively(from_block, filter_problem_type=True):
+                def copy_children_recursively(from_block, filter_problem_type=False):
                     """
                     Internal method to copy blocks from the library recursively
                     """

--- a/common/lib/xmodule/xmodule/library_tools.py
+++ b/common/lib/xmodule/xmodule/library_tools.py
@@ -64,7 +64,7 @@ class LibraryToolsService(object):
         Returns generator containing (child_key, child) for all children matching filter criteria
         """
         children = (
-            (child_key, self.store.get_item(child_key, depth=9))
+            (child_key, self.store.get_item(child_key, depth=None))
             for child_key in from_block.children
         )
         return (

--- a/common/lib/xmodule/xmodule/tests/test_capa_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_capa_module.py
@@ -19,10 +19,11 @@ from webob.multidict import MultiDict
 
 import xmodule
 from xmodule.tests import DATA_DIR
+from capa import responsetypes
 from capa.responsetypes import (StudentInputError, LoncapaProblemError,
                                 ResponseError)
 from capa.xqueue_interface import XQueueInterface
-from xmodule.capa_module import CapaModule, ComplexEncoder
+from xmodule.capa_module import CapaModule, CapaDescriptor, ComplexEncoder
 from opaque_keys.edx.locations import Location
 from xblock.field_data import DictFieldData
 from xblock.fields import ScopeIds
@@ -1660,6 +1661,62 @@ class CapaModuleTest(unittest.TestCase):
                               ('answerpool', ['choice_1', 'choice_3', 'choice_2', 'choice_0']))
             self.assertEquals(event_info['success'], 'incorrect')
 
+@ddt.ddt
+class CapaDescriptorTest(unittest.TestCase):
+    def _create_descriptor(self, xml):
+        """ Creates a CapaDescriptor to run test against """
+        descriptor = CapaDescriptor(get_test_system(), scope_ids=1)
+        descriptor.data = xml
+        return descriptor
+
+    @ddt.data(*responsetypes.registry.registered_tags())
+    def test_all_response_types(self, response_tag):
+        """ Tests that every registered response tag is correctly returned """
+        xml = "<problem><{response_tag}></{response_tag}></problem>".format(response_tag=response_tag)
+        descriptor = self._create_descriptor(xml)
+        self.assertEquals(descriptor.problem_types, {response_tag})
+
+    def test_response_types_ignores_non_response_tags(self):
+        xml = textwrap.dedent("""
+            <problem>
+            <p>Label</p>
+            <div>Some comment</div>
+            <multiplechoiceresponse>
+              <choicegroup type="MultipleChoice" answer-pool="4">
+                <choice correct="false">Apple</choice>
+                <choice correct="false">Banana</choice>
+                <choice correct="false">Chocolate</choice>
+                <choice correct ="true">Donut</choice>
+              </choicegroup>
+            </multiplechoiceresponse>
+            </problem>
+        """)
+        descriptor = self._create_descriptor(xml)
+        self.assertEquals(descriptor.problem_types, {"multiplechoiceresponse"})
+
+    def test_response_types_multiple_tags(self):
+        xml = textwrap.dedent("""
+            <problem>
+                <p>Label</p>
+                <div>Some comment</div>
+                <multiplechoiceresponse>
+                  <choicegroup type="MultipleChoice" answer-pool="1">
+                    <choice correct ="true">Donut</choice>
+                  </choicegroup>
+                </multiplechoiceresponse>
+                <multiplechoiceresponse>
+                  <choicegroup type="MultipleChoice" answer-pool="1">
+                    <choice correct ="true">Buggy</choice>
+                  </choicegroup>
+                </multiplechoiceresponse>
+                <optionresponse>
+                    <optioninput label="Option" options="('1','2')" correct="2"></optioninput>
+                </optionresponse>
+            </problem>
+        """)
+        descriptor = self._create_descriptor(xml)
+        self.assertEquals(descriptor.problem_types, {"multiplechoiceresponse", "optionresponse"})
+
 
 class ComplexEncoderTest(unittest.TestCase):
     def test_default(self):
@@ -1690,18 +1747,10 @@ class TestProblemCheckTracking(unittest.TestCase):
               <p>Which piece of furniture is built for sitting?</p>
               <multiplechoiceresponse>
                 <choicegroup type="MultipleChoice">
-                  <choice correct="false">
-                    <text>a table</text>
-                  </choice>
-                  <choice correct="false">
-                    <text>a desk</text>
-                  </choice>
-                  <choice correct="true">
-                    <text>a chair</text>
-                  </choice>
-                  <choice correct="false">
-                    <text>a bookshelf</text>
-                  </choice>
+                  <choice correct="false"><text>a table</text></choice>
+                  <choice correct="false"><text>a desk</text></choice>
+                  <choice correct="true"><text>a chair</text></choice>
+                  <choice correct="false"><text>a bookshelf</text></choice>
                 </choicegroup>
               </multiplechoiceresponse>
               <p>Which of the following are musical instruments?</p>

--- a/common/lib/xmodule/xmodule/tests/test_capa_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_capa_module.py
@@ -1661,6 +1661,7 @@ class CapaModuleTest(unittest.TestCase):
                               ('answerpool', ['choice_1', 'choice_3', 'choice_2', 'choice_0']))
             self.assertEquals(event_info['success'], 'incorrect')
 
+
 @ddt.ddt
 class CapaDescriptorTest(unittest.TestCase):
     def _create_descriptor(self, xml):

--- a/common/test/acceptance/pages/lms/library.py
+++ b/common/test/acceptance/pages/lms/library.py
@@ -16,6 +16,9 @@ class LibraryContentXBlockWrapper(PageObject):
         self.locator = locator
 
     def is_browser_on_page(self):
+        """
+        Checks if page is opened
+        """
         return self.q(css='{}[data-id="{}"]'.format(self.BODY_SELECTOR, self.locator)).present
 
     def _bounded_selector(self, selector):
@@ -35,3 +38,11 @@ class LibraryContentXBlockWrapper(PageObject):
         """
         child_blocks = self.q(css=self._bounded_selector("div[data-id]"))
         return frozenset(child.text for child in child_blocks)
+
+    @property
+    def children_headers(self):
+        """
+        Gets headers if all child XBlocks as list of strings
+        """
+        child_blocks_headers = self.q(css=self._bounded_selector("div[data-id] h2.problem-header"))
+        return frozenset(child.text for child in child_blocks_headers)

--- a/common/test/acceptance/pages/lms/library.py
+++ b/common/test/acceptance/pages/lms/library.py
@@ -42,7 +42,7 @@ class LibraryContentXBlockWrapper(PageObject):
     @property
     def children_headers(self):
         """
-        Gets headers if all child XBlocks as list of strings
+        Gets headers of all child XBlocks as list of strings
         """
         child_blocks_headers = self.q(css=self._bounded_selector("div[data-id] h2.problem-header"))
         return frozenset(child.text for child in child_blocks_headers)

--- a/common/test/acceptance/pages/studio/library.py
+++ b/common/test/acceptance/pages/studio/library.py
@@ -122,6 +122,7 @@ class StudioLibraryContentXBlockEditModal(CourseOutlineModal, PageObject):
     LIBRARY_LABEL = "Libraries"
     COUNT_LABEL = "Count"
     SCORED_LABEL = "Scored"
+    PROBLEM_TYPE_LABEL = "Problem Type"
 
     def is_browser_on_page(self):
         """
@@ -195,6 +196,24 @@ class StudioLibraryContentXBlockEditModal(CourseOutlineModal, PageObject):
         scored_select = Select(select_element)
         scored_select.select_by_value(str(scored))
         EmptyPromise(lambda: self.scored == scored, "scored is updated in modal.").fulfill()
+
+    @property
+    def capa_type(self):
+        """
+        Gets value of CAPA type select
+        """
+        return self.get_metadata_input(self.PROBLEM_TYPE_LABEL).get_attribute('value')
+
+    @capa_type.setter
+    def capa_type(self, value):
+        """
+        Sets value of CAPA type select
+        """
+        select_element = self.get_metadata_input(self.PROBLEM_TYPE_LABEL)
+        select_element.click()
+        problem_type_select = Select(select_element)
+        problem_type_select.select_by_value(value)
+        EmptyPromise(lambda: self.capa_type == value, "problem type is updated in modal.").fulfill()
 
     def _add_library_key(self):
         """

--- a/common/test/acceptance/tests/lms/test_library.py
+++ b/common/test/acceptance/tests/lms/test_library.py
@@ -19,22 +19,22 @@ SUBSECTION_NAME = 'Test Subsection'
 UNIT_NAME = 'Test Unit'
 
 
-@ddt.ddt
-class LibraryContentTest(UniqueCourseTest):
-    """
-    Test courseware.
-    """
+class LibraryContentTestBase(UniqueCourseTest):
+    """ Base class for library content block tests """
     USERNAME = "STUDENT_TESTER"
     EMAIL = "student101@example.com"
 
     STAFF_USERNAME = "STAFF_TESTER"
     STAFF_EMAIL = "staff101@example.com"
 
+    def populate_library_fixture(self, library_fixture):
+        pass
+
     def setUp(self):
         """
         Set up library, course and library content XBlock
         """
-        super(LibraryContentTest, self).setUp()
+        super(LibraryContentTestBase, self).setUp()
 
         self.courseware_page = CoursewarePage(self.browser, self.course_id)
 
@@ -46,11 +46,7 @@ class LibraryContentTest(UniqueCourseTest):
         )
 
         self.library_fixture = LibraryFixture('test_org', self.unique_id, 'Test Library {}'.format(self.unique_id))
-        self.library_fixture.add_children(
-            XBlockFixtureDesc("html", "Html1", data='html1'),
-            XBlockFixtureDesc("html", "Html2", data='html2'),
-            XBlockFixtureDesc("html", "Html3", data='html3'),
-        )
+        self.populate_library_fixture(self.library_fixture)
 
         self.library_fixture.install()
         self.library_info = self.library_fixture.library_info
@@ -83,7 +79,7 @@ class LibraryContentTest(UniqueCourseTest):
 
         self.course_fixture.install()
 
-    def _refresh_library_content_children(self, count=1):
+    def _change_library_content_settings(self, count=1, capa_type=None):
         """
         Performs library block refresh in Studio, configuring it to show {count} children
         """
@@ -91,6 +87,8 @@ class LibraryContentTest(UniqueCourseTest):
         library_container_block = StudioLibraryContainerXBlockWrapper.from_xblock_wrapper(unit_page.xblocks[0])
         modal = StudioLibraryContentXBlockEditModal(library_container_block.edit())
         modal.count = count
+        if capa_type is not None:
+            modal.capa_type = capa_type
         library_container_block.save_settings()
         self._go_to_unit_page(change_login=False)
         unit_page.wait_for_page()
@@ -124,6 +122,7 @@ class LibraryContentTest(UniqueCourseTest):
         block_id = block_id if block_id is not None else self.lib_block.locator
         #pylint: disable=attribute-defined-outside-init
         self.library_content_page = LibraryContentXBlockWrapper(self.browser, block_id)
+        self.library_content_page.wait_for_page()
 
     def _auto_auth(self, username, email, staff):
         """
@@ -131,6 +130,22 @@ class LibraryContentTest(UniqueCourseTest):
         """
         AutoAuthPage(self.browser, username=username, email=email,
                      course_id=self.course_id, staff=staff).visit()
+
+
+@ddt.ddt
+class LibraryContentTest(LibraryContentTestBase):
+    """
+    Test courseware.
+    """
+    def populate_library_fixture(self, library_fixture):
+        """
+        Populates library fixture with XBlock Fixtures
+        """
+        library_fixture.add_children(
+            XBlockFixtureDesc("html", "Html1", data='html1'),
+            XBlockFixtureDesc("html", "Html2", data='html2'),
+            XBlockFixtureDesc("html", "Html3", data='html3'),
+        )
 
     @ddt.data(1, 2, 3)
     def test_shows_random_xblocks_from_configured(self, count):
@@ -143,7 +158,7 @@ class LibraryContentTest(UniqueCourseTest):
         When I go to LMS courseware page for library content xblock as student
         Then I can see {count} random xblocks from the library
         """
-        self._refresh_library_content_children(count=count)
+        self._change_library_content_settings(count=count)
         self._auto_auth(self.USERNAME, self.EMAIL, False)
         self._goto_library_block_page()
         children_contents = self.library_content_page.children_contents
@@ -160,9 +175,128 @@ class LibraryContentTest(UniqueCourseTest):
         When I go to LMS courseware page for library content xblock as student
         Then I can see all xblocks from the library
         """
-        self._refresh_library_content_children(count=10)
+        self._change_library_content_settings(count=10)
         self._auto_auth(self.USERNAME, self.EMAIL, False)
         self._goto_library_block_page()
         children_contents = self.library_content_page.children_contents
         self.assertEqual(len(children_contents), 3)
         self.assertEqual(children_contents, self.library_xblocks_texts)
+
+
+@ddt.ddt
+class StudioLibraryContainerCapaFilterTest(LibraryContentTestBase):
+    """
+    Test Library Content block in LMS
+    """
+    def _get_problem_choice_group_text(self, name, items):
+        """ Generates Choice Group CAPA problem XML """
+        items_text = "\n".join([
+            "<choice correct='{correct}'>{item}</choice>".format(correct=correct, item=item)
+            for item, correct in items
+        ])
+
+        return """<problem>
+    <p>{name}</p>
+    <multiplechoiceresponse>
+        <choicegroup label="{name}" type="MultipleChoice">{items}</choicegroup>
+    </multiplechoiceresponse>
+</problem>""".format(name=name, items=items_text)
+
+    def _get_problem_select_text(self, name, items, correct):
+        """ Generates Select Option CAPA problem XML """
+        items_text = ",".join(map(lambda item: "'{0}'".format(item), items))
+
+        return """<problem>
+<p>{name}</p>
+<optionresponse>
+  <optioninput label="{name}" options="({options})" correct="{correct}"></optioninput>
+</optionresponse>
+</problem>""".format(name=name, options=items_text, correct=correct)
+
+    def populate_library_fixture(self, library_fixture):
+        """
+        Populates library fixture with XBlock Fixtures
+        """
+        library_fixture.add_children(
+            XBlockFixtureDesc(
+                "problem", "Problem Choice Group 1",
+                data=self._get_problem_choice_group_text("Problem Choice Group 1 Text", [("1", False), ('2', True)])
+            ),
+            XBlockFixtureDesc(
+                "problem", "Problem Choice Group 2",
+                data=self._get_problem_choice_group_text("Problem Choice Group 2 Text", [("Q", True), ('W', False)])
+            ),
+            XBlockFixtureDesc(
+                "problem", "Problem Select 1",
+                data=self._get_problem_select_text("Problem Select 1 Text", ["Option 1", "Option 2"], "Option 1")
+            ),
+            XBlockFixtureDesc(
+                "problem", "Problem Select 2",
+                data=self._get_problem_select_text("Problem Select 2 Text", ["Option 3", "Option 4"], "Option 4")
+            ),
+        )
+
+    @property
+    def _problem_headers(self):
+        """ Expected XBLock headers according to populate_library_fixture """
+        return frozenset(child.display_name.upper() for child in self.library_fixture.children)
+
+    @ddt.data(1, 3)
+    def test_any_capa_type_shows_all(self, count):
+        """
+        Scenario: Ensure setting "Any Type" for Problem Type does not filter out Problems
+        Given I have a library with two "Select Option" and two "Choice Group" problems, and a course containing
+               LibraryContent XBlock configured to draw XBlocks from that library
+        When I go to studio unit page for library content xblock as staff
+        And I set library content xblock Problem Type to "Any Type" and Count to {count}
+        And I refresh library content xblock and pulbish unit
+        When I go to LMS courseware page for library content xblock as student
+        Then I can see {count} xblocks from the library of any type
+        """
+        self._change_library_content_settings(count=count, capa_type="Any Type")
+        self._auto_auth(self.USERNAME, self.EMAIL, False)
+        self._goto_library_block_page()
+        children_headers = self.library_content_page.children_headers
+        self.assertEqual(len(children_headers), count)
+        self.assertLessEqual(children_headers, self._problem_headers)
+
+    @ddt.data(
+        ('Choice Group', 1, ["Problem Choice Group 1", "Problem Choice Group 2"]),
+        ('Select Option', 2, ["Problem Select 1", "Problem Select 2"]),
+    )
+    @ddt.unpack
+    def test_capa_type_shows_only_chosen_type(self, capa_type, count, expected_headers):
+        """
+        Scenario: Ensure setting "{capa_type}" for Problem Type draws aonly problem of {capa_type} from library
+        Given I have a library with two "Select Option" and two "Choice Group" problems, and a course containing
+               LibraryContent XBlock configured to draw XBlocks from that library
+        When I go to studio unit page for library content xblock as staff
+        And I set library content xblock Problem Type to "{capa_type}" and Count to {count}
+        And I refresh library content xblock and pulbish unit
+        When I go to LMS courseware page for library content xblock as student
+        Then I can see {count} xblocks from the library of {capa_type}
+        """
+        self._change_library_content_settings(count=count, capa_type=capa_type)
+        self._auto_auth(self.USERNAME, self.EMAIL, False)
+        self._goto_library_block_page()
+        children_headers = self.library_content_page.children_headers
+        self.assertEqual(len(children_headers), count)
+        self.assertLessEqual(children_headers, self._problem_headers)
+        self.assertLessEqual(children_headers, set(map(lambda header: header.upper(), expected_headers)))
+
+    def test_missing_capa_type_shows_none(self):
+        """
+        Scenario: Ensure setting "{capa_type}" for Problem Type that is not present in library results in empty XBlock
+        Given I have a library with two "Select Option" and two "Choice Group" problems, and a course containing
+               LibraryContent XBlock configured to draw XBlocks from that library
+        When I go to studio unit page for library content xblock as staff
+        And I set library content xblock Problem Type to type not present in library
+        And I refresh library content xblock and pulbish unit
+        When I go to LMS courseware page for library content xblock as student
+        Then I can see no xblocks
+        """
+        self._change_library_content_settings(count=1, capa_type="Matlab")
+        self._auto_auth(self.USERNAME, self.EMAIL, False)
+        self._goto_library_block_page()
+        children_headers = self.library_content_page.children_headers
+        self.assertEqual(len(children_headers), 0)

--- a/common/test/acceptance/tests/lms/test_library.py
+++ b/common/test/acceptance/tests/lms/test_library.py
@@ -28,7 +28,10 @@ class LibraryContentTestBase(UniqueCourseTest):
     STAFF_EMAIL = "staff101@example.com"
 
     def populate_library_fixture(self, library_fixture):
-        pass
+        """
+        To be overwritten by subclassed tests. Used to install a library to
+        run tests on.
+        """
 
     def setUp(self):
         """
@@ -207,7 +210,7 @@ class StudioLibraryContainerCapaFilterTest(LibraryContentTestBase):
 
     def _get_problem_select_text(self, name, items, correct):
         """ Generates Select Option CAPA problem XML """
-        items_text = ",".join(map(lambda item: "'{0}'".format(item), items))
+        items_text = ",".join(["'{0}'".format(item) for item in items])
 
         return """<problem>
 <p>{name}</p>
@@ -281,7 +284,7 @@ class StudioLibraryContainerCapaFilterTest(LibraryContentTestBase):
         self.assertEqual(len(children_headers), 1)
         self.assertLessEqual(
             children_headers,
-            set(map(lambda header: header.upper(), ["Problem Choice Group 1", "Problem Choice Group 2"]))
+            set([header.upper() for header in ["Problem Choice Group 1", "Problem Choice Group 2"]])
         )
 
         # Choice group test
@@ -289,7 +292,7 @@ class StudioLibraryContainerCapaFilterTest(LibraryContentTestBase):
         self.assertEqual(len(children_headers), 2)
         self.assertLessEqual(
             children_headers,
-            set(map(lambda header: header.upper(), ["Problem Select 1", "Problem Select 2"]))
+            set([header.upper() for header in ["Problem Select 1", "Problem Select 2"]])
         )
 
         # Missing problem type test

--- a/common/test/acceptance/tests/lms/test_library.py
+++ b/common/test/acceptance/tests/lms/test_library.py
@@ -277,7 +277,7 @@ class StudioLibraryContainerCapaFilterTest(LibraryContentTestBase):
         self.assertLessEqual(children_headers, self._problem_headers)
 
         # Choice group test
-        children_headers = self._set_library_content_settings(count=1, capa_type="Choice Group")
+        children_headers = self._set_library_content_settings(count=1, capa_type="Multiple Choice")
         self.assertEqual(len(children_headers), 1)
         self.assertLessEqual(
             children_headers,
@@ -285,7 +285,7 @@ class StudioLibraryContainerCapaFilterTest(LibraryContentTestBase):
         )
 
         # Choice group test
-        children_headers = self._set_library_content_settings(count=2, capa_type="Select Option")
+        children_headers = self._set_library_content_settings(count=2, capa_type="Dropdown")
         self.assertEqual(len(children_headers), 2)
         self.assertLessEqual(
             children_headers,
@@ -293,5 +293,5 @@ class StudioLibraryContainerCapaFilterTest(LibraryContentTestBase):
         )
 
         # Missing problem type test
-        children_headers = self._set_library_content_settings(count=2, capa_type="Matlab")
+        children_headers = self._set_library_content_settings(count=2, capa_type="Custom Evaluated Script")
         self.assertEqual(children_headers, set())

--- a/common/test/acceptance/tests/lms/test_library.py
+++ b/common/test/acceptance/tests/lms/test_library.py
@@ -3,6 +3,7 @@
 End-to-end tests for LibraryContent block in LMS
 """
 import ddt
+import textwrap
 
 from ..helpers import UniqueCourseTest
 from ...pages.studio.auto_auth import AutoAuthPage
@@ -201,23 +202,25 @@ class StudioLibraryContainerCapaFilterTest(LibraryContentTestBase):
             for item, correct in items
         ])
 
-        return """<problem>
-    <p>{name}</p>
-    <multiplechoiceresponse>
-        <choicegroup label="{name}" type="MultipleChoice">{items}</choicegroup>
-    </multiplechoiceresponse>
-</problem>""".format(name=name, items=items_text)
+        return textwrap.dedent("""
+        <problem>
+            <p>{name}</p>
+            <multiplechoiceresponse>
+                <choicegroup label="{name}" type="MultipleChoice">{items}</choicegroup>
+            </multiplechoiceresponse>
+        </problem>""").format(name=name, items=items_text)
 
     def _get_problem_select_text(self, name, items, correct):
         """ Generates Select Option CAPA problem XML """
         items_text = ",".join(["'{0}'".format(item) for item in items])
 
-        return """<problem>
-<p>{name}</p>
-<optionresponse>
-  <optioninput label="{name}" options="({options})" correct="{correct}"></optioninput>
-</optionresponse>
-</problem>""".format(name=name, options=items_text, correct=correct)
+        return textwrap.dedent("""
+        <problem>
+            <p>{name}</p>
+            <optionresponse>
+              <optioninput label="{name}" options="({options})" correct="{correct}"></optioninput>
+            </optionresponse>
+        </problem>""").format(name=name, options=items_text, correct=correct)
 
     def populate_library_fixture(self, library_fixture):
         """

--- a/common/test/acceptance/tests/lms/test_library.py
+++ b/common/test/acceptance/tests/lms/test_library.py
@@ -293,7 +293,7 @@ class StudioLibraryContainerCapaFilterTest(LibraryContentTestBase):
         # Choice group test
         children_headers = self._set_library_content_settings(count=2, capa_type="Dropdown")
         self.assertEqual(len(children_headers), 2)
-        self.assertLessEqual(
+        self.assertEqual(
             children_headers,
             set([header.upper() for header in ["Problem Select 1", "Problem Select 2"]])
         )

--- a/common/test/acceptance/tests/studio/test_studio_library_container.py
+++ b/common/test/acceptance/tests/studio/test_studio_library_container.py
@@ -43,16 +43,6 @@ class StudioLibraryContainerTest(StudioLibraryTest, UniqueCourseTest):
             XBlockFixtureDesc("html", "Html1"),
             XBlockFixtureDesc("html", "Html2"),
             XBlockFixtureDesc("html", "Html3"),
-
-            XBlockFixtureDesc(
-                "problem", "Dropdown",
-                data=textwrap.dedent("""
-                    <problem>
-                        <p>Dropdown</p>
-                        <optionresponse><optioninput label="Dropdown" options="('1', '2')" correct="'2'"></optioninput></optionresponse>
-                    </problem>
-                    """)
-            )
         )
 
     def populate_course_fixture(self, course_fixture):
@@ -189,9 +179,20 @@ class StudioLibraryContainerTest(StudioLibraryTest, UniqueCourseTest):
         When I go to studio unit page for library content block
         And I set Problem Type selector so that no libraries have matching content
         Then I can see that "No matching content" warning is shown
-        When I set Problem Type selector so that there are matching content
+        When I set Problem Type selector so that there is matching content
         Then I can see that warning messages are not shown
         """
+        # Add a single "Dropdown" type problem to the library (which otherwise has only HTML blocks):
+        self.library_fixture.create_xblock(self.library_fixture.library_location, XBlockFixtureDesc(
+            "problem", "Dropdown",
+            data=textwrap.dedent("""
+                <problem>
+                    <p>Dropdown</p>
+                    <optionresponse><optioninput label="Dropdown" options="('1', '2')" correct="'2'"></optioninput></optionresponse>
+                </problem>
+                """)
+        ))
+
         expected_text = 'There are no matching problem types in the specified libraries. Select another problem type'
 
         library_container = self._get_library_xblock_wrapper(self.unit_page.xblocks[0])

--- a/common/test/acceptance/tests/studio/test_studio_library_container.py
+++ b/common/test/acceptance/tests/studio/test_studio_library_container.py
@@ -189,8 +189,7 @@ class StudioLibraryContainerTest(StudioLibraryTest, UniqueCourseTest):
         When I set Problem Type selector so that there are matching content
         Then I can see that warning messages are not shown
         """
-        expected_text = 'There are no content matching configured filters in the selected libraries. ' \
-                        'Edit Problem Type Filter'
+        expected_text = 'There are no matching problem types in the specified libraries. Select another problem type'
 
         library_container = self._get_library_xblock_wrapper(self.unit_page.xblocks[0])
 
@@ -223,7 +222,8 @@ class StudioLibraryContainerTest(StudioLibraryTest, UniqueCourseTest):
         And I set Problem Type selector so "Any"
         Then I can see that "No matching content" warning is shown
         """
-        expected_tpl = "Configured to fetch {count} blocks, library and filter settings yield only {actual} blocks."
+        expected_tpl = "The specified libraries are configured to fetch {count} problems, " \
+                       "but there are only {actual} matching problems."
 
         library_container = self._get_library_xblock_wrapper(self.unit_page.xblocks[0])
 

--- a/common/test/acceptance/tests/studio/test_studio_library_container.py
+++ b/common/test/acceptance/tests/studio/test_studio_library_container.py
@@ -1,6 +1,7 @@
 """
 Acceptance tests for Library Content in LMS
 """
+import textwrap
 import ddt
 from .base_studio_test import StudioLibraryTest
 from ...fixtures.course import CourseFixture
@@ -45,11 +46,13 @@ class StudioLibraryContainerTest(StudioLibraryTest, UniqueCourseTest):
 
             XBlockFixtureDesc(
                 "problem", "Dropdown",
-                data="""
-<problem>
-    <p>Dropdown</p>
-    <optionresponse><optioninput label="Dropdown" options="('1', '2')" correct="'2'"></optioninput></optionresponse>
-</problem>""")
+                data=textwrap.dedent("""
+                    <problem>
+                        <p>Dropdown</p>
+                        <optionresponse><optioninput label="Dropdown" options="('1', '2')" correct="'2'"></optioninput></optionresponse>
+                    </problem>
+                    """)
+            )
         )
 
     def populate_course_fixture(self, course_fixture):


### PR DESCRIPTION
**Background**: This PR contains the LibraryContent XBlock, which allows to display library content in a course.
**JIRA ticket**: [SOL-122](https://openedx.atlassian.net/browse/SOL-122)
**Discussions**: Architecture discussed extensively on the wiki and in meetings, then the revised proposal was presented to the Arch Council on Oct. 21 and given thumbs up.
**Dependencies**: https://github.com/edx/edx-platform/pull/6155 (probably will require a rebase after 6155 merged)
**Sandbox URL**: LMS at http://content-libraries.sandbox.opencraft.com/ and Studio at http://content-libraries.sandbox.opencraft.com:18010/
**Internal code reviews PRs**: https://github.com/open-craft/edx-platform/pull/24
**Partner information**: 3rd party-hosted open edX instance, for an edX solutions client.

**Testing instructions**:
1. Create a library with a couple of Problem XBlocks of different types (e.g. "Checkboxes", "Dropdown", "Multiple Choice")
2. Add Library Content XBlock to a course.
3. Edit Library Content settings. By default "Problem Type" should be set to "Any Type", LMS view should display problems of any type.
4. Set "Problem Type" to one of the problem types in the library (e.g. "Checkboxes", "Dropdown" or "Multiple Choice""). Please note that some problem type templates fall into same problem type (e.g. "Custom Javascript/Python" and "Drag and Drop" fall into "Custom Evaluated Script"). Save, publish, navigate to LMS as a student and ensure only Problems of selected type are shown.
5. Set "Problem Type" to any problem type **not** in the library (e.g. any except "Checkboxes", "Dropdown" or "Multiple Choice""). Save, publish, note the warning message in Studio, navigate to LMS as a student and ensure no XBlocks are shown.
