### PR TITLE
Update Bok Choy tests

### DIFF
--- a/common/test/acceptance/pages/lms/login_and_register.py
+++ b/common/test/acceptance/pages/lms/login_and_register.py
@@ -120,8 +120,8 @@ class CombinedLoginAndRegisterPage(PageObject):
     def is_browser_on_page(self):
         """Check whether the combined login/registration page has loaded. """
         return (
-            self.q(css="#register-option").is_present() and
-            self.q(css="#login-option").is_present() and
+            self.q(css="#login-anchor").is_present() and
+            self.q(css="#register-anchor").is_present() and
             self.current_form is not None
         )
 
@@ -130,7 +130,10 @@ class CombinedLoginAndRegisterPage(PageObject):
         old_form = self.current_form
 
         # Toggle the form
-        self.q(css=".form-toggle:not(:checked)").click()
+        if old_form == "login":
+            self.q(css=".form-toggle[data-type='register']").click()
+        else:
+            self.q(css=".form-toggle[data-type='login']").click()
 
         # Wait for the form to change before returning
         EmptyPromise(
@@ -157,9 +160,9 @@ class CombinedLoginAndRegisterPage(PageObject):
         """
         # Fill in the form
         self.q(css="#register-email").fill(email)
-        self.q(css="#register-password").fill(password)
-        self.q(css="#register-username").fill(username)
         self.q(css="#register-name").fill(full_name)
+        self.q(css="#register-username").fill(username)
+        self.q(css="#register-password").fill(password)
         if country:
             self.q(css="#register-country option[value='{country}']".format(country=country)).click()
         if (terms_of_service):
@@ -233,7 +236,7 @@ class CombinedLoginAndRegisterPage(PageObject):
             return "register"
         elif self.q(css=".login-button").visible:
             return "login"
-        elif self.q(css=".js-reset").visible or self.q(css=".js-reset-success").visible:
+        elif self.q(css=".js-reset").visible:
             return "password-reset"
 
     @property


### PR DESCRIPTION
@AlasdairSwan this updates the Bok Choy tests on your logistration branch.

One of the tests is still failing, but the failure is expected. The test checks that an error message is displayed when a user requests a password reset by providing an email address not associated with an active user. When I do this on your branch, I'm taken to the login form as if my request succeeded, when in reality no password reset email was sent. Formerly, the user was shown an error message contained in the server's 400 response: "No active user with the provided email address exists." The failing test will pass once this behavior is corrected.
