### PR TITLE
Logistration backend updates, minor frontend cleanup

### DIFF
--- a/common/static/js/utils/edx.utils.validate.js
+++ b/common/static/js/utils/edx.utils.validate.js
@@ -19,9 +19,9 @@ var edx = edx || {};
 
                 msg: {
                     email: '<li><%- gettext("The email address you\'ve provided isn\'t formatted correctly.") %></li>',
-                    min: '<li><%- _.sprintf(gettext("%(field)s must have at least %(count)d characters."), context) %></li>',
-                    max: '<li><%- _.sprintf(gettext("%(field)s can only contain up to %(count)d characters."), context) %></li>',
-                    required: '<li><%- _.sprintf(gettext("The %(field)s field cannot be empty."), context) %></li>',
+                    min: '<li><%- _.sprintf( gettext("%(field)s must have at least %(count)d characters."), context ) %></li>',
+                    max: '<li><%- _.sprintf( gettext("%(field)s can only contain up to %(count)d characters."), context ) %></li>',
+                    required: '<li><%- _.sprintf( gettext("The %(field)s field cannot be empty."), context ) %></li>',
                     custom: '<li><%= content %></li>'
                 },
 

--- a/common/test/acceptance/pages/lms/login_and_register.py
+++ b/common/test/acceptance/pages/lms/login_and_register.py
@@ -171,7 +171,7 @@ class CombinedLoginAndRegisterPage(PageObject):
         # Submit it
         self.q(css=".register-button").click()
 
-    def login(self, email="", password="", remember_me=True):
+    def login(self, email="", password=""):
         """Fills in and submits the login form.
 
         Requires that the "login" form is visible.
@@ -182,14 +182,11 @@ class CombinedLoginAndRegisterPage(PageObject):
         Keyword Arguments:
             email (unicode): The user's email address.
             password (unicode): The user's password.
-            remember_me (boolean): If True, check the "remember me" box.
 
         """
         # Fill in the form
         self.q(css="#login-email").fill(email)
         self.q(css="#login-password").fill(password)
-        if remember_me:
-            self.q(css="#login-remember").click()
 
         # Submit it
         self.q(css=".login-button").click()
@@ -219,6 +216,8 @@ class CombinedLoginAndRegisterPage(PageObject):
 
         # Submit it
         self.q(css="button.js-reset").click()
+
+        return CombinedLoginAndRegisterPage(self.browser).wait_for_page()
 
     @property
     @unguarded

--- a/lms/static/js/student_account/views/AccessView.js
+++ b/lms/static/js/student_account/views/AccessView.js
@@ -44,6 +44,8 @@ var edx = edx || {};
             };
 
             this.platformName = obj.platformName;
+
+            // The login view listens for 'sync' events from the reset model
             this.resetModel = new edx.student.account.PasswordResetModel({}, {
                 method: 'GET',
                 url: '#'
@@ -95,10 +97,8 @@ var edx = edx || {};
             },
 
             reset: function( data, context ) {
-                context.resetModel.set({
-                    ajaxType: data.method,
-                    urlRoot: data.submit_url
-                });
+                context.resetModel.ajaxType = data.method;
+                context.resetModel.urlRoot = data.submit_url;
 
                 context.subview.passwordHelp = new edx.student.account.PasswordResetView({
                     fields: data.fields,
@@ -187,8 +187,7 @@ var edx = edx || {};
             this.element.scrollTop( $anchor );
 
             // Update url without reloading page
-            // window.history.pushState( '', type + ' form', '/account/' + type + '/' );
-            History.pushState( null, type + ' form', '/account/' + type + '/' );
+            History.pushState( null, document.title, '/account/' + type + '/' );
         },
 
         /**

--- a/lms/static/js/student_account/views/LoginView.js
+++ b/lms/static/js/student_account/views/LoginView.js
@@ -81,8 +81,7 @@ var edx = edx || {};
             this.element.hide( this.$resetSuccess );
         },
 
-        resetEmail: function( a ) {
-            console.log('resetEmail ', a);
+        resetEmail: function() {
             this.element.hide( this.$errors );
             this.element.show( this.$resetSuccess );
         },
@@ -95,7 +94,7 @@ var edx = edx || {};
             }
         },
 
-        saveSuccess: function () {
+        saveSuccess: function() {
             this.trigger('auth-complete');
             this.element.hide( this.$resetSuccess );
         },

--- a/lms/templates/student_account/login.underscore
+++ b/lms/templates/student_account/login.underscore
@@ -1,7 +1,7 @@
 <div class="status already-authenticated-msg hidden" aria-hidden="true">
     <% if (context.currentProvider) { %>
         <p class="message-copy">
-            <%- _.sprintf(gettext("You've successfully logged into %(currentProvider)s, but your %(currentProvider)s account isn't linked with an %(platformName)s account. To link your accounts, go to your %(platformName)s dashboard."), context) %>
+            <%- _.sprintf( gettext("You've successfully logged into %(currentProvider)s, but your %(currentProvider)s account isn't linked with an %(platformName)s account. To link your accounts, go to your %(platformName)s dashboard."), context ) %>
         </p>
     <% } %>
 </div>
@@ -47,19 +47,13 @@
                 </button>
             <% }
         }); %>
-
-        <!-- For testing only -->
-        <button type="submit" class="button button-primary button-Facebook login-provider register-facebook" data-provider-url="#">
-            <span class="icon icon-facebook" aria-hidden="true"></span>
-            Facebook
-        </button>
     </div>
 </form>
 
 <div class="toggle-form">
     <div class="section-title">
         <h2>
-            <span class="text"><%- gettext("New to edX?") %></span>
+            <span class="text"><%- _.sprintf( gettext("New to %(platformName)s?"), context ) %></span>
         </h2>
     </div>
     <button class="nav-btn form-toggle" data-type="register"><%- gettext("Create an account") %></button>

--- a/lms/templates/student_account/login_and_register.html
+++ b/lms/templates/student_account/login_and_register.html
@@ -3,7 +3,7 @@
 
 <%inherit file="../main.html" />
 
-<%block name="pagetitle">${_("Log in or Register")}</%block>
+<%block name="pagetitle">${_("Sign in or Register")}</%block>
 
 <%block name="js_extra">
     <script src="${static.url('js/vendor/underscore-min.js')}"></script>

--- a/lms/templates/student_account/password_reset.underscore
+++ b/lms/templates/student_account/password_reset.underscore
@@ -15,5 +15,5 @@
 
     <%= fields %>
 
-    <button class="action action-primary action-update js-reset"><%- gettext("Reset password") %></button>
+    <button class="action action-primary action-update js-reset"><%- gettext("Reset my password") %></button>
 </form>

--- a/lms/templates/student_account/register.underscore
+++ b/lms/templates/student_account/register.underscore
@@ -7,8 +7,8 @@
     <% if (context.currentProvider) { %>
         <div class="status" aria-hidden="false">
             <p class="message-copy">
-                <%- _.sprintf(gettext("You've successfully logged into %(currentProvider)s."), context) %>
-                <%- _.sprintf(gettext("We just need a little more information before you start learning with %(platformName)s."), context) %>
+                <%- _.sprintf( gettext("You've successfully logged into %(currentProvider)s."), context ) %>
+                <%- _.sprintf( gettext("We just need a little more information before you start learning with %(platformName)s."), context ) %>
             </p>
         </div>
     <% } else {  %>
@@ -38,7 +38,7 @@
 
     <%= context.fields %>
 
-    <button class="action action-primary action-update js-register register-button"><%- gettext("Register") %></button>
+    <button class="action action-primary action-update js-register register-button"><%- gettext("Create your account") %></button>
     <p class="note">* <%- gettext("Required field") %></p>
 </form>
 

--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -633,17 +633,6 @@ class LoginSessionViewTest(ApiTestCase):
                     "max_length": account_api.PASSWORD_MAX_LENGTH
                 },
                 "errorMessages": {},
-            },
-            {
-                "name": "remember",
-                "defaultValue": False,
-                "type": "checkbox",
-                "required": False,
-                "label": "Remember me",
-                "placeholder": "",
-                "instructions": "",
-                "restrictions": {},
-                "errorMessages": {},
             }
         ])
 

--- a/openedx/core/djangoapps/user_api/views.py
+++ b/openedx/core/djangoapps/user_api/views.py
@@ -112,19 +112,6 @@ class LoginSessionView(APIView):
             }
         )
 
-        # Translators: This phrase appears next to a checkbox on the login form
-        # which the user can check in order to remain logged in after their
-        # session ends.
-        remember_label = _(u"Remember me")
-
-        form_desc.add_field(
-            "remember",
-            field_type="checkbox",
-            label=remember_label,
-            default=False,
-            required=False,
-        )
-
         return HttpResponse(form_desc.to_json(), content_type="application/json")
 
     @method_decorator(require_post_params(["email", "password"]))
@@ -171,9 +158,15 @@ class RegistrationView(APIView):
     DEFAULT_FIELDS = ["email", "name", "username", "password"]
 
     EXTRA_FIELDS = [
-        "city", "country", "level_of_education", "gender",
-        "year_of_birth", "mailing_address", "goals",
-        "honor_code", "terms_of_service",
+        "city",
+        "country",
+        "gender",
+        "year_of_birth",
+        "level_of_education",
+        "mailing_address",
+        "goals",
+        "honor_code",
+        "terms_of_service",
     ]
 
     # This end-point is available to anonymous users,
@@ -348,7 +341,7 @@ class RegistrationView(APIView):
         """
         # Translators: This label appears above a field on the registration form
         # meant to hold the user's full name.
-        name_label = _(u"Full Name")
+        name_label = _(u"Full name")
 
         # Translators: These instructions appear on the registration form, immediately
         # below a field meant to hold the user's full name.
@@ -432,7 +425,7 @@ class RegistrationView(APIView):
         """
         # Translators: This label appears above a dropdown menu on the registration
         # form used to select the user's highest completed level of education.
-        education_level_label = _(u"Highest Level of Education Completed")
+        education_level_label = _(u"Highest level of education completed")
 
         form_desc.add_field(
             "level_of_education",
@@ -478,7 +471,7 @@ class RegistrationView(APIView):
         """
         # Translators: This label appears above a dropdown menu on the registration
         # form used to select the user's year of birth.
-        yob_label = _(u"Year of Birth")
+        yob_label = _(u"Year of birth")
 
         options = [(unicode(year), unicode(year)) for year in UserProfile.VALID_YEARS]
         form_desc.add_field(
@@ -502,7 +495,7 @@ class RegistrationView(APIView):
         """
         # Translators: This label appears above a field on the registration form
         # meant to hold the user's mailing address.
-        mailing_address_label = _(u"Mailing Address")
+        mailing_address_label = _(u"Mailing address")
 
         form_desc.add_field(
             "mailing_address",
@@ -524,7 +517,7 @@ class RegistrationView(APIView):
         # Translators: This phrase appears above a field on the registration form
         # meant to hold the user's reasons for registering with edX.
         goals_label = _(
-            u"If you'd like, tell us why you're interested in {platform_name}"
+            u"Tell us why you're interested in {platform_name}"
         ).format(platform_name=settings.PLATFORM_NAME)
 
         form_desc.add_field(


### PR DESCRIPTION
This takes care of the backend updates required by @andywaldrop's comps. It also cleans up some of the frontend, fixing a bug where the password reset model's urlRoot and ajaxType properties weren't being assigned.

@AlasdairSwan, could you take a look when you're able? Feel free to merge it into your branch if you're happy with what you see.

@wedaly, I stopped the backend from adding the "remember me" checkbox to the form description, but the login model continues to pass a value of `false` for the "remember me" data attribute. My thought was that if/when this design is deployed, we can return and more completely remove the checkbox. I've left things in such a state that we can easily re-add the checkbox if necessary.
