### PR TITLE
Login error fix TNL-140

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -186,3 +186,4 @@ Afzal Wali <afzaledx@edx.org>
 Julien Romagnoli <julien.romagnoli@fbmx.net>
 Wenjie Wu <wuwenjie718@gmail.com>
 Aamir <aamir.nu.206@gmail.com>
+Steve Jackson <sjackso@ixoreus.net>

--- a/cms/djangoapps/contentstore/features/signup.feature
+++ b/cms/djangoapps/contentstore/features/signup.feature
@@ -27,3 +27,18 @@ Feature: CMS.Sign in
     When I fill in and submit the signin form
     And I wait for "2" seconds
     Then I should see that the path is "/course/"
+
+  Scenario: Login with mistyped credentials
+    Given I have opened a new course in Studio
+    And I am not logged in
+    And I visit the Studio homepage
+    When I click the link with the text "Sign In"
+    Then I should see that the path is "/signin"
+    And I should not see a login error message
+    And I fill in and submit the signin form incorrectly
+    Then I should see a login error message
+    And I edit the password field
+    Then I should not see a login error message
+    And I submit the signin form
+    And I wait for "2" seconds
+    Then I should see that the path is "/course/"

--- a/cms/djangoapps/contentstore/features/signup.py
+++ b/cms/djangoapps/contentstore/features/signup.py
@@ -2,6 +2,7 @@
 # pylint: disable=redefined-outer-name
 
 from lettuce import world, step
+from nose.tools import assert_true, assert_false  # pylint: disable=no-name-in-module
 
 
 @step('I fill in the registration form$')
@@ -36,3 +37,36 @@ def i_fill_in_the_signin_form(step):
         login_form.find_by_name('password').fill('test')
         login_form.find_by_name('submit').click()
     world.retry_on_exception(fill_login_form)
+
+
+@step(u'I should( not)? see a login error message$')
+def i_should_see_a_login_error(step, should_not_see):
+    if should_not_see:
+        # the login error may be absent or invisible. Check absence first,
+        # because css_visible will throw an exception if the element is not present
+        if world.is_css_present('div#login_error'):
+            assert_false(world.css_visible('div#login_error'))
+    else:
+        assert_true(world.css_visible('div#login_error'))
+
+
+@step(u'I fill in and submit the signin form incorrectly$')
+def i_goof_in_the_signin_form(step):
+    def fill_login_form():
+        login_form = world.browser.find_by_css('form#login_form')
+        login_form.find_by_name('email').fill('robot+studio@edx.org')
+        login_form.find_by_name('password').fill('oops')
+        login_form.find_by_name('submit').click()
+    world.retry_on_exception(fill_login_form)
+
+
+@step(u'I edit the password field$')
+def i_edit_the_password_field(step):
+    password_css = 'form#login_form input#password'
+    world.css_fill(password_css, 'test')
+
+
+@step(u'I submit the signin form$')
+def i_submit_the_signin_form(step):
+    submit_css = 'form#login_form button#submit'
+    world.css_click(submit_css)

--- a/cms/static/js/factories/login.js
+++ b/cms/static/js/factories/login.js
@@ -12,6 +12,15 @@ define(['jquery.cookie', 'utility'], function() {
             });
         }
 
+        // Clear the login error message when credentials are edited
+        $('input#email').on('input',function() {
+            $('#login_error').removeClass('is-shown');
+        });
+
+        $('input#password').on('input',function() {
+            $('#login_error').removeClass('is-shown');
+        });
+
         $('form#login_form').submit(function(event) {
             event.preventDefault();
             var submit_data = $('#login_form').serialize();


### PR DESCRIPTION
Fix for [TNL140](https://openedx.atlassian.net/browse/TNL-140): Studio's signin page appears unresponsive after a user submits one incorrect login.  If further logins were also incorrect, the error message remained unchanged, which could give the impression that the server was no longer responsive. 

Per the comments in the original Jira ticket, I have addressed this by making the error message invisible if the user edits either the username or password fields.  I've also provided a Lettuce test that verifies the new behavior.

Feedback is appreciated; I am new to this codebase.  

This contribution is covered under the OpenCraft contributor agreement.  Attn: @antoviaque 
