### PR TITLE
Fixed CodeMirror editor view height in studio.

### DIFF
--- a/cms/static/sass/elements/_modal-window.scss
+++ b/cms/static/sass/elements/_modal-window.scss
@@ -222,6 +222,10 @@
       height: 365px;
     }
 
+    .CodeMirror-advanced {
+      height: 435px;
+    }
+
     .wrapper-comp-settings {
 
       .list-input {

--- a/common/lib/xmodule/xmodule/js/src/combinedopenended/edit.coffee
+++ b/common/lib/xmodule/xmodule/js/src/combinedopenended/edit.coffee
@@ -80,6 +80,9 @@ Write a persuasive essay to a newspaper reflecting your views on censorship in l
     if text
       @xml_editor.setValue(text)
     @setCurrentEditor(@xml_editor)
+    $(@xml_editor.getWrapperElement()).toggleClass("CodeMirror-advanced");
+    # Need to refresh to get line numbers to display properly.
+    @xml_editor.refresh()
 
   ###
   User has clicked to show the XML editor. Before XML editor is swapped in,
@@ -92,9 +95,8 @@ Write a persuasive essay to a newspaper reflecting your views on censorship in l
       @toggleCheatsheetVisibility()
     if @confirmConversionToXml()
       @createXMLEditor(OpenEndedMarkdownEditingDescriptor.markdownToXml(@markdown_editor.getValue()))
-      # Need to refresh to get line numbers to display properly (and put cursor position to 0)
+      # Put cursor position to 0.
       @xml_editor.setCursor(0)
-      @xml_editor.refresh()
       # Hide markdown-specific toolbar buttons
       $(@element.find('.editor-bar')).hide()
 

--- a/common/lib/xmodule/xmodule/js/src/problem/edit.coffee
+++ b/common/lib/xmodule/xmodule/js/src/problem/edit.coffee
@@ -41,6 +41,9 @@ class @MarkdownEditingDescriptor extends XModule.Descriptor
     if text
       @xml_editor.setValue(text)
     @setCurrentEditor(@xml_editor)
+    $(@xml_editor.getWrapperElement()).toggleClass("CodeMirror-advanced");
+    # Need to refresh to get line numbers to display properly.
+    @xml_editor.refresh()
 
   ###
   User has clicked to show the XML editor. Before XML editor is swapped in,
@@ -53,9 +56,8 @@ class @MarkdownEditingDescriptor extends XModule.Descriptor
       @toggleCheatsheetVisibility()
     if @confirmConversionToXml()
       @createXMLEditor(MarkdownEditingDescriptor.markdownToXml(@markdown_editor.getValue()))
-      # Need to refresh to get line numbers to display properly (and put cursor position to 0)
+      # Put cursor position to 0.
       @xml_editor.setCursor(0)
-      @xml_editor.refresh()
       # Hide markdown-specific toolbar buttons
       $(@element.find('.editor-bar')).hide()
 


### PR DESCRIPTION
[TNL-920](https://openedx.atlassian.net/browse/TNL-920)

`.CodeMirror` height fixed by adding a new class for advanced editor.

Sandbox Link: http://studio.waheedahmed.m.sandbox.edx.org
