### PR TITLE
LMS: Student Notes - Toggle Visibility (UX-1125)

### DIFF
--- a/lms/static/coffee/src/calculator.coffee
+++ b/lms/static/coffee/src/calculator.coffee
@@ -72,7 +72,7 @@ class @Calculator
       .attr
         'title': text
         'aria-expanded': isExpanded
-      .text text
+      .find('.utility-control-label').text text
 
     $calc.toggleClass 'closed'
 

--- a/lms/static/js/edxnotes/views/toggle_notes_factory.js
+++ b/lms/static/js/edxnotes/views/toggle_notes_factory.js
@@ -1,8 +1,9 @@
 ;(function (define, undefined) {
 'use strict';
 define([
-    'jquery', 'underscore', 'backbone', 'gettext', 'js/edxnotes/views/visibility_decorator'
-], function($, _, Backbone, gettext, EdxnotesVisibilityDecorator) {
+    'jquery', 'underscore', 'backbone', 'gettext',
+    'annotator', 'js/edxnotes/views/visibility_decorator'
+], function($, _, Backbone, gettext, Annotator, EdxnotesVisibilityDecorator) {
     var ToggleNotesView = Backbone.View.extend({
         events: {
             'click .action-toggle-notes': 'toogleHandler'
@@ -16,6 +17,7 @@ define([
             this.checkboxIcon = this.$('.checkbox-icon');
             this.actionLink = this.$('.action-toggle-notes');
             this.actionLink.removeClass('is-disabled');
+            this.notification = new Annotator.Notification();
         },
 
         toogleHandler: function (event) {
@@ -38,13 +40,11 @@ define([
         },
 
         hideErrorMessage: function() {
-            this.$el.removeClass('has-error');
-            this.$('.edx-notes-visibility-error').text('');
+            this.notification.hide();
         },
 
         showErrorMessage: function(message) {
-            this.$el.addClass('has-error');
-            this.$('.edx-notes-visibility-error').text(message);
+            this.notification.show(message, Annotator.Notification.ERROR);
         },
 
         sendRequest: function () {

--- a/lms/static/js/edxnotes/views/toggle_notes_factory.js
+++ b/lms/static/js/edxnotes/views/toggle_notes_factory.js
@@ -14,7 +14,8 @@ define([
             this.visibility = options.visibility;
             this.visibilityUrl = options.visibilityUrl;
             this.checkboxIcon = this.$('.checkbox-icon');
-            this.$('.action-toggle-notes').removeClass('is-disabled');
+            this.actionLink = this.$('.action-toggle-notes');
+            this.actionLink.removeClass('is-disabled');
         },
 
         toogleHandler: function (event) {
@@ -28,17 +29,21 @@ define([
             if (this.visibility) {
                 _.each($('.edx-notes-wrapper'), EdxnotesVisibilityDecorator.enableNote);
                 this.checkboxIcon.removeClass('icon-check-empty').addClass('icon-check');
+                this.actionLink.addClass('is-active');
             } else {
                 EdxnotesVisibilityDecorator.disableNotes();
                 this.checkboxIcon.removeClass('icon-check').addClass('icon-check-empty');
+                this.actionLink.removeClass('is-active');
             }
         },
 
         hideErrorMessage: function() {
+            this.$el.removeClass('has-error');
             this.$('.edx-notes-visibility-error').text('');
         },
 
         showErrorMessage: function(message) {
+            this.$el.addClass('has-error');
             this.$('.edx-notes-visibility-error').text(message);
         },
 

--- a/lms/static/js/fixtures/edxnotes/toggle_notes.html
+++ b/lms/static/js/fixtures/edxnotes/toggle_notes.html
@@ -1,5 +1,5 @@
 <div class="action-inline edx-notes-visibility">
-    <a href="#" class="action-toggle-notes is-disabled" role="button" aria-pressed="">
+    <a href="#" class="action-toggle-notes is-disabled is-active" role="button" aria-pressed="">
         <i class="checkbox-icon icon-check"></i>
         Show notes
     </a>

--- a/lms/static/js/fixtures/edxnotes/toggle_notes.html
+++ b/lms/static/js/fixtures/edxnotes/toggle_notes.html
@@ -3,5 +3,4 @@
         <i class="checkbox-icon icon-check"></i>
         Show notes
     </a>
-    <div class="edx-notes-visibility-error"></div>
 </div>

--- a/lms/static/js/spec/edxnotes/views/toggle_notes_factory_spec.js
+++ b/lms/static/js/spec/edxnotes/views/toggle_notes_factory_spec.js
@@ -75,18 +75,18 @@ define([
             var requests = AjaxHelpers.requests(this),
                 errorContainer = $('.annotator-notice');
 
-            expect(this.toggleNotes.$el).not.toHaveClass('has-error');
             this.button.click();
             AjaxHelpers.respondWithError(requests);
             expect(errorContainer).toContainText(
                 "An error has occurred. Make sure that you are connected to the Internet, and then try refreshing the page."
             );
+            expect(errorContainer).toBeVisible();
+            expect(errorContainer).toHaveClass('annotator-notice-show');
             expect(errorContainer).toHaveClass('annotator-notice-error');
 
             this.button.click();
             AjaxHelpers.respondWithJson(requests, {});
-            expect(errorContainer).toBeEmpty();
-            expect(this.toggleNotes.$el).not.toHaveClass('has-error');
+            expect(errorContainer).not.toHaveClass('annotator-notice-show');
         });
     });
 });

--- a/lms/static/js/spec/edxnotes/views/toggle_notes_factory_spec.js
+++ b/lms/static/js/spec/edxnotes/views/toggle_notes_factory_spec.js
@@ -37,6 +37,7 @@ define([
         afterEach(function () {
             VisibilityDecorator._setVisibility(null);
             _.invoke(Annotator._instances, 'destroy');
+            $('.annotator-notice').remove();
         });
 
         it('can toggle notes', function() {
@@ -72,7 +73,7 @@ define([
 
         it('can handle errors', function() {
             var requests = AjaxHelpers.requests(this),
-                errorContainer = $('.edx-notes-visibility-error');
+                errorContainer = $('.annotator-notice');
 
             expect(this.toggleNotes.$el).not.toHaveClass('has-error');
             this.button.click();
@@ -80,7 +81,7 @@ define([
             expect(errorContainer).toContainText(
                 "An error has occurred. Make sure that you are connected to the Internet, and then try refreshing the page."
             );
-            expect(this.toggleNotes.$el).toHaveClass('has-error');
+            expect(errorContainer).toHaveClass('annotator-notice-error');
 
             this.button.click();
             AjaxHelpers.respondWithJson(requests, {});

--- a/lms/static/js/spec/edxnotes/views/toggle_notes_factory_spec.js
+++ b/lms/static/js/spec/edxnotes/views/toggle_notes_factory_spec.js
@@ -45,10 +45,12 @@ define([
             expect(this.button).not.toHaveClass('is-disabled');
             expect(this.icon).toHaveClass('icon-check');
             expect(this.icon).not.toHaveClass('icon-check-empty');
+            expect(this.button).toHaveClass('is-active');
 
             this.button.click();
             expect(this.icon).toHaveClass('icon-check-empty');
             expect(this.icon).not.toHaveClass('icon-check');
+            expect(this.button).not.toHaveClass('is-active');
             expect(Annotator._instances).toHaveLength(0);
 
             AjaxHelpers.expectJsonRequest(requests, 'PUT', '/test_url', {
@@ -59,6 +61,7 @@ define([
             this.button.click();
             expect(this.icon).toHaveClass('icon-check');
             expect(this.icon).not.toHaveClass('icon-check-empty');
+            expect(this.button).toHaveClass('is-active');
             expect(Annotator._instances).toHaveLength(2);
 
             AjaxHelpers.expectJsonRequest(requests, 'PUT', '/test_url', {
@@ -71,15 +74,18 @@ define([
             var requests = AjaxHelpers.requests(this),
                 errorContainer = $('.edx-notes-visibility-error');
 
+            expect(this.toggleNotes.$el).not.toHaveClass('has-error');
             this.button.click();
             AjaxHelpers.respondWithError(requests);
             expect(errorContainer).toContainText(
                 "An error has occurred. Make sure that you are connected to the Internet, and then try refreshing the page."
             );
+            expect(this.toggleNotes.$el).toHaveClass('has-error');
 
             this.button.click();
             AjaxHelpers.respondWithJson(requests, {});
             expect(errorContainer).toBeEmpty();
+            expect(this.toggleNotes.$el).not.toHaveClass('has-error');
         });
     });
 });

--- a/lms/static/sass/_developer.scss
+++ b/lms/static/sass/_developer.scss
@@ -117,9 +117,3 @@
     padding-left: ($baseline/4);
   }
 }
-
-.edx-notes-visibility {
-  .error {
-    color: $red;
-  }
-}

--- a/lms/static/sass/base/_variables.scss
+++ b/lms/static/sass/base/_variables.scss
@@ -326,6 +326,7 @@ $header-graphic-sub-color: $m-gray-d2;
 $error-color: $error-red;
 $warning-color: $m-pink;
 $confirm-color: $m-green;
+$active-color: $blue;
 
 // Notifications
 $notify-banner-bg-1: rgb(56,56,56);

--- a/lms/static/sass/course-rtl.scss.mako
+++ b/lms/static/sass/course-rtl.scss.mako
@@ -27,36 +27,37 @@
 // base - elements
 @import 'elements/typography';
 @import 'elements/controls';
+@import 'elements/navigation'; // all archetypes of navigation
 
-// Course base / layout styles
+
+// course - base
 @import 'course/layout/courseware_header';
 @import 'course/layout/footer';
 @import 'course/base/mixins';
 @import 'course/base/base';
 @import 'course/base/extends';
 @import 'xmodule/modules/css/module-styles.scss';
-
-// courseware
 @import 'course/courseware/courseware';
 @import 'course/courseware/sidebar';
 @import 'course/courseware/amplifier';
-@import 'course/layout/calculator';
-@import 'course/layout/timer';
-@import 'course/layout/chat';
 
-// course-specific courseware (all styles in these files should be gated by a
-// course-specific class). This should be replaced with a better way of
-// providing course-specific styling.
+// course - modules
+@import 'course/modules/student-notes'; // student notes
+@import 'course/modules/calculator'; // calculator utility
+@import 'course/modules/timer'; // timer
+@import 'course/modules/chat'; // chat utility
+
+// course - specific courses
 @import "course/courseware/courses/_cs188.scss";
 
-// wiki
+// course - wiki
 @import "course/wiki/basic-html";
 @import "course/wiki/sidebar";
 @import "course/wiki/create";
 @import "course/wiki/wiki";
 @import "course/wiki/table";
 
-// pages
+// course - views
 @import "course/info";
 @import "course/syllabus"; // TODO arjun replace w/ custom tabs, see courseware/courses.py
 @import "course/textbook";
@@ -68,11 +69,11 @@
 @import "course/open_ended_grading";
 @import "course/student-notes";
 
-// instructor
+// course - instructor-only views
 @import "course/instructor/instructor";
 @import "course/instructor/instructor_2";
 @import "course/instructor/email";
 @import "xmodule/descriptors/css/module-styles.scss";
 
-// discussion
+// course - discussion
 @import "course/discussion/form-wmd-toolbar";

--- a/lms/static/sass/course.scss.mako
+++ b/lms/static/sass/course.scss.mako
@@ -27,6 +27,7 @@
 // base - elements
 @import 'elements/typography';
 @import 'elements/controls';
+@import 'elements/navigation'; // all archetypes of navigation
 
 // Course base / layout styles
 @import 'course/layout/courseware_header';

--- a/lms/static/sass/course.scss.mako
+++ b/lms/static/sass/course.scss.mako
@@ -29,35 +29,35 @@
 @import 'elements/controls';
 @import 'elements/navigation'; // all archetypes of navigation
 
-// Course base / layout styles
+// course - base
 @import 'course/layout/courseware_header';
 @import 'course/layout/footer';
 @import 'course/base/mixins';
 @import 'course/base/base';
 @import 'course/base/extends';
 @import 'xmodule/modules/css/module-styles.scss';
-
-// courseware
 @import 'course/courseware/courseware';
 @import 'course/courseware/sidebar';
 @import 'course/courseware/amplifier';
-@import 'course/layout/calculator';
-@import 'course/layout/timer';
-@import 'course/layout/chat';
 
-// course-specific courseware (all styles in these files should be gated by a
-// course-specific class). This should be replaced with a better way of
-// providing course-specific styling.
+// course - modules
+@import 'course/modules/student-notes'; // student notes
+@import 'course/modules/calculator'; // calculator utility
+@import 'course/modules/timer'; // timer
+@import 'course/modules/chat'; // chat utility
+
+
+// course - specific courses
 @import "course/courseware/courses/_cs188.scss";
 
-// wiki
+// course - wiki
 @import "course/wiki/basic-html";
 @import "course/wiki/sidebar";
 @import "course/wiki/create";
 @import "course/wiki/wiki";
 @import "course/wiki/table";
 
-// pages
+// course - views
 @import "course/info";
 @import "course/syllabus"; // TODO arjun replace w/ custom tabs, see courseware/courses.py
 @import "course/textbook";
@@ -69,11 +69,11 @@
 @import "course/open_ended_grading";
 @import "course/student-notes";
 
-// instructor
+// course - instructor-only views
 @import "course/instructor/instructor";
 @import "course/instructor/instructor_2";
 @import "course/instructor/email";
 @import "xmodule/descriptors/css/module-styles.scss";
 
-// discussion
+// course - discussion
 @import "course/discussion/form-wmd-toolbar";

--- a/lms/static/sass/course/layout/_calculator.scss
+++ b/lms/static/sass/course/layout/_calculator.scss
@@ -5,7 +5,6 @@ div.calc-main {
   @include transition(bottom 0.75s linear 0s);
   -webkit-appearance: none;
   width: 100%;
-  z-index: 99;
 
   &.open {
     bottom: -36px;
@@ -13,10 +12,11 @@ div.calc-main {
 
   a.calc {
     @include text-hide();
-    background: url("../images/calc-icon.png") rgba(#111, .9) no-repeat center;
+    @include transition(background-color $tmg-f2 ease-in-out 0s);
+    background: url("../images/calc-icon.png") $black-t3 no-repeat center;
     border-bottom: 0;
-    border-radius: 3px 3px 0 0;
-    color: #fff;
+    border-radius: ($baseline/10);
+    color: $white;
     float: right;
     height: 20px;
     display: inline-block;
@@ -27,17 +27,18 @@ div.calc-main {
     width: 16px;
 
     &:hover, &:focus {
-      opacity: 0.8;
+      background-color: $black;
     }
 
     &.closed {
       background-image: url("../images/close-calc-icon.png");
+      background-color: $black;
       top: -36px;
     }
   }
 
   div#calculator_wrapper {
-    background: rgba(#111, .9);
+    background: $black;
     clear: both;
     max-height: 90px;
     position: relative;

--- a/lms/static/sass/course/modules/_calculator.scss
+++ b/lms/static/sass/course/modules/_calculator.scss
@@ -1,3 +1,6 @@
+// LMS -- modules -- calculator
+// ====================
+
 div.calc-main {
   bottom: -126px;
   left: 0;

--- a/lms/static/sass/course/modules/_calculator.scss
+++ b/lms/static/sass/course/modules/_calculator.scss
@@ -13,21 +13,19 @@ div.calc-main {
     bottom: -36px;
   }
 
-  a.calc {
-    @include text-hide();
+  .calc {
     @include transition(background-color $tmg-f2 ease-in-out 0s);
     background: url("../images/calc-icon.png") $black-t3 no-repeat center;
     border-bottom: 0;
     border-radius: ($baseline/10);
     color: $white;
     float: right;
-    height: 20px;
-    display: inline-block;
-    margin-right: 10px;
-    padding: 8px 12px;
+    height: $baseline;
+    margin-right: ($baseline/2);
+    padding: $baseline;
     position: relative;
-    top: -45px;
-    width: 16px;
+    top: -42px;
+    width: ($baseline*0.75);
 
     &:hover, &:focus {
       background-color: $black;

--- a/lms/static/sass/course/modules/_chat.scss
+++ b/lms/static/sass/course/modules/_chat.scss
@@ -1,5 +1,5 @@
-/* Chat
--------------------------------------------------- */
+// LMS -- modules -- chat
+// ====================
 #chat-wrapper {
     position: fixed;
     bottom: 0;

--- a/lms/static/sass/course/modules/_student-notes.scss
+++ b/lms/static/sass/course/modules/_student-notes.scss
@@ -1,0 +1,27 @@
+// LMS -- modules -- student notes
+// ====================
+
+// in this document:
+// --------------------
+// +notes
+// +messages
+// +creating/editing notes
+// +listing notes
+
+// +notes:
+// --------------------
+// this Sass partial contains all of the styling needed for the in-line student notes UI.
+
+// +messages
+// --------------------
+
+// CASE: error in toggling notes
+.edx-notes-visibility {
+
+}
+
+// +creating/editing notes
+// --------------------
+
+// +listing notes
+// --------------------

--- a/lms/static/sass/course/modules/_student-notes.scss
+++ b/lms/static/sass/course/modules/_student-notes.scss
@@ -4,7 +4,7 @@
 // in this document:
 // --------------------
 // +notes
-// +messages
+// +toggling notes
 // +creating/editing notes
 // +listing notes
 
@@ -12,12 +12,51 @@
 // --------------------
 // this Sass partial contains all of the styling needed for the in-line student notes UI.
 
-// +messages
+// +toggling notes
 // --------------------
 
-// CASE: error in toggling notes
 .edx-notes-visibility {
 
+  .edx-notes-visibility-error {
+    @extend %t-copy-sub2;
+    @extend %text-truncated;
+    position: relative;
+    bottom: -($baseline/20); // needed to sync up with current rogue/more complex calc utility alignment
+    max-width: ($baseline*15);
+    display: none;
+    vertical-align: bottom;
+    margin-right: -($baseline/4);
+    border-right: ($baseline/4) solid $error-color;
+    padding: ($baseline/2) $baseline;
+    background: $black-t3;
+    text-align: center;
+    color: $white;
+  }
+
+  // STATE: has error
+  &.has-error {
+
+    .edx-notes-visibility-error {
+      display: inline-block;
+    }
+
+    .utility-control {
+      color: $error-color;
+    }
+  }
+}
+
+// CASE: annotator error in toggling notes (vendor customization)
+.annotator-notice {
+  @extend %t-weight4;
+  @extend %t-copy-sub1;
+  background: $black-t3;
+  padding: ($baseline/4) $baseline;
+}
+
+// vendor customization
+.annotator-notice-error {
+  border-color: $error-color;
 }
 
 // +creating/editing notes

--- a/lms/static/sass/course/modules/_student-notes.scss
+++ b/lms/static/sass/course/modules/_student-notes.scss
@@ -25,8 +25,8 @@
     max-width: ($baseline*15);
     display: none;
     vertical-align: bottom;
-    margin-right: -($baseline/4);
-    border-right: ($baseline/4) solid $error-color;
+    @include margin-right(-($baseline/4));
+    @include border-right(($baseline/4) solid $error-color);
     padding: ($baseline/2) $baseline;
     background: $black-t3;
     text-align: center;

--- a/lms/static/sass/course/modules/_student-notes.scss
+++ b/lms/static/sass/course/modules/_student-notes.scss
@@ -54,6 +54,15 @@
   padding: ($baseline/4) $baseline;
 }
 
+// CASE: annotator error in toggling notes
+// vendor customization
+.annotator-notice {
+  @extend %t-weight4;
+  @extend %t-copy-sub1;
+  background: $gray-d4;
+  padding: ($baseline/2) $baseline;
+}
+
 // vendor customization
 .annotator-notice-error {
   border-color: $error-color;

--- a/lms/static/sass/course/modules/_timer.scss
+++ b/lms/static/sass/course/modules/_timer.scss
@@ -1,3 +1,6 @@
+// LMS -- modules -- student notes
+// ====================
+
 div.timer-main {
   position: fixed;
   z-index: 99;

--- a/lms/static/sass/elements/_navigation.scss
+++ b/lms/static/sass/elements/_navigation.scss
@@ -1,0 +1,62 @@
+// LMS -- elements -- navigation
+// ====================
+
+// in this document:
+// --------------------
+// +notes
+// +skip navigation
+// +utility navigation
+
+// +notes:
+// --------------------
+// this Sass partial should have its contents eventually abstracted out so that onboarding/non-coureware navigation is separate from in course-based navigation systems
+
+
+// +skip navigation
+// --------------------
+%nav-skip {
+  @extend %text-sr;
+}
+
+.nav-contents, .nav-skip {
+  @extend %nav-skip;
+}
+
+// +utility navigation (course utiltiies)
+// --------------------
+.nav-utilities {
+  @extend %ui-depth3;
+  position: fixed;
+  right: ($baseline*2.25);
+  bottom: 0;
+
+
+  .wrapper-utility {
+    @extend %wipe-last-child;
+    display: inline-block;
+    vertical-align: middle;
+    margin-right: ($baseline/2);
+  }
+
+  .utility-control {
+    @include transition(background-color $tmg-f2 ease-in-out 0s);
+    position: relative;
+    bottom: -6px; // needed to sync up with current rogue/more complex calc utility alignment
+    display: inline-block;
+    vertical-align: middle;
+    border-radius: ($baseline/10);
+    padding: ($baseline/2) ($baseline*0.75) ($baseline*0.75) ($baseline*0.75);
+    background: $black-t3;
+    color: $white;
+
+    // STATE: hover/active
+    &:hover, &:active {
+      background: $black;
+    }
+
+    // STATE: is active/in use
+    &.is-active {
+      background: red;
+    }
+  }
+}

--- a/lms/static/sass/elements/_navigation.scss
+++ b/lms/static/sass/elements/_navigation.scss
@@ -27,15 +27,14 @@
 .nav-utilities {
   @extend %ui-depth3;
   position: fixed;
-  right: ($baseline*2.25);
+  @include right($baseline*2.25);
   bottom: 0;
-
 
   .wrapper-utility {
     @extend %wipe-last-child;
     display: inline-block;
     vertical-align: bottom;
-    margin-right: ($baseline/2);
+    @include margin-right($baseline/2);
   }
 
   .utility-control {
@@ -57,6 +56,21 @@
     // STATE: is active/in use
     &.is-active {
       background: $active-color;
+    }
+  }
+
+  // specific reset styling for any controls that are button elements
+  .utility-control-button {
+    border: none;
+    box-shadow: none;
+    text-shadow: none;
+    font-size: inherit;
+    font-weight: inherit;
+
+    // STATE: hover/active
+    &:hover, &:active, &:focus {
+      border: none;
+      box-shadow: none;
     }
   }
 }

--- a/lms/static/sass/elements/_navigation.scss
+++ b/lms/static/sass/elements/_navigation.scss
@@ -34,7 +34,7 @@
   .wrapper-utility {
     @extend %wipe-last-child;
     display: inline-block;
-    vertical-align: middle;
+    vertical-align: bottom;
     margin-right: ($baseline/2);
   }
 

--- a/lms/static/sass/elements/_navigation.scss
+++ b/lms/static/sass/elements/_navigation.scss
@@ -56,7 +56,7 @@
 
     // STATE: is active/in use
     &.is-active {
-      background: red;
+      background: $active-color;
     }
   }
 }

--- a/lms/templates/calculator/toggle_calculator.html
+++ b/lms/templates/calculator/toggle_calculator.html
@@ -1,0 +1,124 @@
+<%! from django.utils.translation import ugettext as _ %>
+<%! from django.core.urlresolvers import reverse %>
+
+<div class="calc-main">
+    <a title="${_('Open Calculator')}" href="#" role="button" aria-controls="calculator_wrapper" aria-expanded="false" class="calc">${_("Open Calculator")}</a>
+
+    <div id="calculator_wrapper">
+      <form id="calculator">
+        <div class="input-wrapper">
+          <input type="text" id="calculator_input" title="${_('Calculator Input Field')}" tabindex="-1" />
+
+          <div class="help-wrapper">
+            <p class="sr" id="hint-instructions">${_('Use the arrow keys to navigate the tips or use the tab key to return to the calculator')}</p>
+
+            <a id="calculator_hint" href="#" role="button" aria-haspopup="true" tabindex="-1" aria-describedby="hint-instructions">${_("Hints")}</a>
+
+            <ul id="calculator_input_help" class="help" aria-activedescendant="hint-moreinfo" role="tooltip" aria-hidden="true">
+              <li class="hint-item" id="hint-moreinfo" tabindex="-1">
+                <p><span class="bold">${_("For detailed information, see <a href='http://edx-guide-for-students.readthedocs.org/en/latest/SFD_mathformatting.html'>Entering Mathematical and Scientific Expressions</a> in the <a href='http://edx-guide-for-students.readthedocs.org/en/latest/index.html'>edX Guide for Students</a>.")}</span></p>
+              </li>
+
+              <li class="hint-item" id="hint-tips" tabindex="-1"><p><span class="bold">${_("Tips")}:</span> </p>
+                <ul>
+                  <li class="hint-item" id="hint-paren" tabindex="-1"><p>Use parentheses () to make expressions clear. You can use parentheses inside other parentheses.</p></li>
+                  <li class="hint-item" id="hint-spaces" tabindex="-1"><p>Do not use spaces in expressions.</p></li>
+                  <li class="hint-item" id="hint-howto-constants" tabindex="-1"><p>For constants, indicate multiplication explicitly (example: 5*c).</p></li>
+                  <li class="hint-item" id="hint-howto-maffixes" tabindex="-1"><p>For affixes, type the number and affix without a space (example: 5c).</p></li>
+                  <li class="hint-item" id="hint-howto-functions" tabindex="-1"><p>For functions, type the name of the function, then the expression in parentheses.</p></li>
+                </ul>
+              </li>
+
+              <li class="hint-item" id="hint-list" tabindex="-1">
+                <table class="calculator-input-help-table">
+                  <tbody>
+                    <tr>
+                      <th scope="col">${_("To Use")}</th>
+                      <th scope="col">${_("Type")}</th>
+                      <th scope="col">${_("Examples")}</th>
+                    </tr>
+                    <tr>
+                      <th scope="row">${_("Numbers")}</th>
+                      <td>Integers<br />
+                        Fractions<br />
+                        Decimals
+                      </td>
+                      <td>2520<br />
+                        2/3<br />
+                        3.14, .98
+                      </td>
+                    </tr>
+                    <tr>
+                      <th scope="row">${_("Operators")}</th>
+                      <td>+ - * / (add, subtract, multiply, divide)<br />
+                        ^ (raise to a power)<br />
+                        _ (add a subscript)<br />
+                        || (parallel resistors)
+                      </td>
+                      <td>x+(2*y)/x-1
+                        x^(n+1)<br />
+                        v_IN+v_OUT<br />
+                        1||2
+                      </td>
+                    </tr>
+                    <tr>
+                      <th scope="row">${_("Greek letters")}</th>
+                      <td>Name of letter</td>
+                      <td>alpha<br />
+                        lambda
+                      </td>
+                    </tr>
+                    <tr>
+                      <th scope="row">${_("Constants")}</th>
+                      <td>c, e, g, i, j, k, pi, q, T</td>
+                      <td>20*c<br />
+                        418*T
+                      </td>
+                    </tr>
+                    <tr>
+                      <th scope="row">${_("Affixes")}</th>
+                      <td>Percent sign (%) and metric affixes (d, c, m, u, n, p, k, M, G, T)</td>
+                      <td>20%<br />
+                        20c<br />
+                        418T
+                      </td>
+                    </tr>
+                    <tr>
+                      <th scope="row">${_("Basic functions")}</th>
+                      <td>abs, exp, fact or factorial, ln, log2, log10, sqrt</td>
+                      <td>abs(x+y)<br />
+                        sqrt(x^2-y)
+                      </td>
+                    </tr>
+                    <tr>
+                      <th scope="row">${_("Trigonometric functions")}</th>
+                      <td>sin, cos, tan, sec, csc, cot<br />
+                        arcsin, sinh, arcsinh, etc.<br />
+                      </td>
+                      <td>sin(4x+y)<br />
+                        arccsch(4x+y)
+                      </td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <th scope="row">${_("Scientific notation")}</th>
+                      <td>10^ and the exponent</td>
+                      <td>10^-9</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">${_("e notation")}</th>
+                      <td>1e and the exponent</td>
+                      <td>1e-9</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </li>
+            </ul>
+          </div>
+        </div>
+
+        <input id="calculator_button" type="submit" title="${_('Calculate')}" value="=" aria-label="${_('Calculate')}" value="=" tabindex="-1" />
+        <input type="text" id="calculator_output" title="${_('Calculator Output Field')}" readonly tabindex="-1" />
+      </form>
+    </div>
+  </div>

--- a/lms/templates/calculator/toggle_calculator.html
+++ b/lms/templates/calculator/toggle_calculator.html
@@ -2,123 +2,143 @@
 <%! from django.core.urlresolvers import reverse %>
 
 <div class="calc-main">
-    <a title="${_('Open Calculator')}" href="#" role="button" aria-controls="calculator_wrapper" aria-expanded="false" class="calc">${_("Open Calculator")}</a>
+  <button title="${_('Open Calculator')}" aria-controls="calculator_wrapper" aria-expanded="false" class="calc utility-control-button">
+    <span class="utility-control-label sr">${_("Open Calculator")}</span>
+  </button>
 
-    <div id="calculator_wrapper">
-      <form id="calculator">
-        <div class="input-wrapper">
-          <input type="text" id="calculator_input" title="${_('Calculator Input Field')}" tabindex="-1" />
+  <div id="calculator_wrapper">
+    <form id="calculator">
+      <div class="input-wrapper">
+        <input type="text" id="calculator_input" title="${_('Calculator Input Field')}" tabindex="-1" />
 
-          <div class="help-wrapper">
-            <p class="sr" id="hint-instructions">${_('Use the arrow keys to navigate the tips or use the tab key to return to the calculator')}</p>
+        <div class="help-wrapper">
+          <p class="sr" id="hint-instructions">${_('Use the arrow keys to navigate the tips or use the tab key to return to the calculator')}</p>
 
-            <a id="calculator_hint" href="#" role="button" aria-haspopup="true" tabindex="-1" aria-describedby="hint-instructions">${_("Hints")}</a>
+          <a id="calculator_hint" href="#" role="button" aria-haspopup="true" tabindex="-1" aria-describedby="hint-instructions">${_("Hints")}</a>
 
-            <ul id="calculator_input_help" class="help" aria-activedescendant="hint-moreinfo" role="tooltip" aria-hidden="true">
-              <li class="hint-item" id="hint-moreinfo" tabindex="-1">
-                <p><span class="bold">${_("For detailed information, see <a href='http://edx-guide-for-students.readthedocs.org/en/latest/SFD_mathformatting.html'>Entering Mathematical and Scientific Expressions</a> in the <a href='http://edx-guide-for-students.readthedocs.org/en/latest/index.html'>edX Guide for Students</a>.")}</span></p>
-              </li>
+          <ul id="calculator_input_help" class="help" aria-activedescendant="hint-moreinfo" role="tooltip" aria-hidden="true">
+            <li class="hint-item" id="hint-moreinfo" tabindex="-1">
+              <p><span class="bold">
+                ${_(
+                    "For detailed information, see {link_mathexpressions_start}Entering Mathematical and Scientific Expressions{link_mathexpressions_end} in the {link_studentguide_start}edX Guide for Students{link_studentguide_end}"
+                    ).format(
+                      link_mathexpressions_start='<a href="http://edx-guide-for-students.readthedocs.org/en/latest/SFD_mathformatting.html">',
+                      link_mathexpressions_end="</a>",
+                      link_studentguide_start='<a href="http://edx-guide-for-students.readthedocs.org/en/latest/index.html">',
+                      link_studentguide_end="</a>"
+                    )
+                 }
+              </span></p>
+            </li>
 
-              <li class="hint-item" id="hint-tips" tabindex="-1"><p><span class="bold">${_("Tips")}:</span> </p>
-                <ul>
-                  <li class="hint-item" id="hint-paren" tabindex="-1"><p>Use parentheses () to make expressions clear. You can use parentheses inside other parentheses.</p></li>
-                  <li class="hint-item" id="hint-spaces" tabindex="-1"><p>Do not use spaces in expressions.</p></li>
-                  <li class="hint-item" id="hint-howto-constants" tabindex="-1"><p>For constants, indicate multiplication explicitly (example: 5*c).</p></li>
-                  <li class="hint-item" id="hint-howto-maffixes" tabindex="-1"><p>For affixes, type the number and affix without a space (example: 5c).</p></li>
-                  <li class="hint-item" id="hint-howto-functions" tabindex="-1"><p>For functions, type the name of the function, then the expression in parentheses.</p></li>
-                </ul>
-              </li>
+            <li class="hint-item" id="hint-tips" tabindex="-1"><p><span class="bold">${_("Tips")}:</span> </p>
+              <ul>
+                <li class="hint-item" id="hint-paren" tabindex="-1"><p>${_("Use parentheses () to make expressions clear. You can use parentheses inside other parentheses.")}</p></li>
+                <li class="hint-item" id="hint-spaces" tabindex="-1"><p>${_("Do not use spaces in expressions.")}</p></li>
+                <li class="hint-item" id="hint-howto-constants" tabindex="-1"><p>${_("For constants, indicate multiplication explicitly (example: 5*c).")}</p></li>
+                <li class="hint-item" id="hint-howto-maffixes" tabindex="-1"><p>${_("For affixes, type the number and affix without a space (example: 5c).")}</p></li>
+                <li class="hint-item" id="hint-howto-functions" tabindex="-1"><p>${_("For functions, type the name of the function, then the expression in parentheses.")}</p></li>
+              </ul>
+            </li>
 
-              <li class="hint-item" id="hint-list" tabindex="-1">
-                <table class="calculator-input-help-table">
-                  <tbody>
-                    <tr>
-                      <th scope="col">${_("To Use")}</th>
-                      <th scope="col">${_("Type")}</th>
-                      <th scope="col">${_("Examples")}</th>
-                    </tr>
-                    <tr>
-                      <th scope="row">${_("Numbers")}</th>
-                      <td>Integers<br />
-                        Fractions<br />
-                        Decimals
-                      </td>
-                      <td>2520<br />
-                        2/3<br />
-                        3.14, .98
-                      </td>
-                    </tr>
-                    <tr>
-                      <th scope="row">${_("Operators")}</th>
-                      <td>+ - * / (add, subtract, multiply, divide)<br />
-                        ^ (raise to a power)<br />
-                        _ (add a subscript)<br />
-                        || (parallel resistors)
-                      </td>
-                      <td>x+(2*y)/x-1
-                        x^(n+1)<br />
-                        v_IN+v_OUT<br />
-                        1||2
-                      </td>
-                    </tr>
-                    <tr>
-                      <th scope="row">${_("Greek letters")}</th>
-                      <td>Name of letter</td>
-                      <td>alpha<br />
-                        lambda
-                      </td>
-                    </tr>
-                    <tr>
-                      <th scope="row">${_("Constants")}</th>
-                      <td>c, e, g, i, j, k, pi, q, T</td>
-                      <td>20*c<br />
-                        418*T
-                      </td>
-                    </tr>
-                    <tr>
-                      <th scope="row">${_("Affixes")}</th>
-                      <td>Percent sign (%) and metric affixes (d, c, m, u, n, p, k, M, G, T)</td>
-                      <td>20%<br />
-                        20c<br />
-                        418T
-                      </td>
-                    </tr>
-                    <tr>
-                      <th scope="row">${_("Basic functions")}</th>
-                      <td>abs, exp, fact or factorial, ln, log2, log10, sqrt</td>
-                      <td>abs(x+y)<br />
-                        sqrt(x^2-y)
-                      </td>
-                    </tr>
-                    <tr>
-                      <th scope="row">${_("Trigonometric functions")}</th>
-                      <td>sin, cos, tan, sec, csc, cot<br />
-                        arcsin, sinh, arcsinh, etc.<br />
-                      </td>
-                      <td>sin(4x+y)<br />
-                        arccsch(4x+y)
-                      </td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <th scope="row">${_("Scientific notation")}</th>
-                      <td>10^ and the exponent</td>
-                      <td>10^-9</td>
-                    </tr>
-                    <tr>
-                      <th scope="row">${_("e notation")}</th>
-                      <td>1e and the exponent</td>
-                      <td>1e-9</td>
-                    </tr>
-                  </tbody>
-                </table>
-              </li>
-            </ul>
-          </div>
+            <li class="hint-item" id="hint-list" tabindex="-1">
+              <table class="calculator-input-help-table">
+                <tbody>
+                  <tr>
+                    <th scope="col">${_("To Use")}</th>
+                    <th scope="col">${_("Type")}</th>
+                    <th scope="col">${_("Examples")}</th>
+                  </tr>
+                  <tr>
+                    <th scope="row">${_("Numbers")}</th>
+                    <td>${_("Integers")}<br />
+                      ${_("Fractions")}<br />
+                      ${_("Decimals")}
+                    </td>
+                    <td>2520<br />
+                      2/3<br />
+                      3.14, .98
+                    </td>
+                  </tr>
+                  <tr>
+                    <th scope="row">${_("Operators")}</th>
+                    ## Translators: Please do not translate mathematical symbols.
+                    <td>${_("+ - * / (add, subtract, multiply, divide)")}<br />
+                      ## Translators: Please do not translate mathematical symbols.
+                      ${_("^ (raise to a power)")}<br />
+                      ## Translators: Please do not translate mathematical symbols.
+                      ${_("_ (add a subscript)")}<br />
+                      ## Translators: Please do not translate mathematical symbols.
+                      ${_("|| (parallel resistors)")}
+                    </td>
+                    <td>x+(2*y)/x-1
+                      x^(n+1)<br />
+                      v_IN+v_OUT<br />
+                      1||2
+                    </td>
+                  </tr>
+                  <tr>
+                    <th scope="row">${_("Greek letters")}</th>
+                    <td>${_("Name of letter")}</td>
+                    <td>alpha<br />
+                      lambda
+                    </td>
+                  </tr>
+                  <tr>
+                    <th scope="row">${_("Constants")}</th>
+                    <td>c, e, g, i, j, k, pi, q, T</td>
+                    <td>20*c<br />
+                      418*T
+                    </td>
+                  </tr>
+                  <tr>
+                    <th scope="row">${_("Affixes")}</th>
+                    <td>${_("Percent sign (%) and metric affixes (d, c, m, u, n, p, k, M, G, T)")}</td>
+                    <td>20%<br />
+                      20c<br />
+                      418T
+                    </td>
+                  </tr>
+                  <tr>
+                    <th scope="row">${_("Basic functions")}</th>
+                    <td>abs, exp, fact or factorial, ln, log2, log10, sqrt</td>
+                    <td>abs(x+y)<br />
+                      sqrt(x^2-y)
+                    </td>
+                  </tr>
+                  <tr>
+                    <th scope="row">${_("Trigonometric functions")}</th>
+                    <td>sin, cos, tan, sec, csc, cot<br />
+                      arcsin, sinh, arcsinh, etc.<br />
+                    </td>
+                    <td>sin(4x+y)<br />
+                      arccsch(4x+y)
+                    </td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    ## Translators: Please see http://en.wikipedia.org/wiki/Scientific_notation
+                    <th scope="row">${_("Scientific notation")}</th>
+                    ## Translators: 10^ is a mathematical symbol. Please do not translate.
+                    <td>${_("10^ and the exponent")}</td>
+                    <td>10^-9</td>
+                  </tr>
+                  <tr>
+                    ## Translators: this is part of scientific notation. Please see http://en.wikipedia.org/wiki/Scientific_notation#E_notation
+                    <th scope="row">${_("e notation")}</th>
+                    ## Translators: 1e is a mathematical symbol. Please do not translate.
+                    <td>${_("1e and the exponent")}</td>
+                    <td>1e-9</td>
+                  </tr>
+                </tbody>
+              </table>
+            </li>
+          </ul>
         </div>
+      </div>
 
-        <input id="calculator_button" type="submit" title="${_('Calculate')}" value="=" aria-label="${_('Calculate')}" value="=" tabindex="-1" />
-        <input type="text" id="calculator_output" title="${_('Calculator Output Field')}" readonly tabindex="-1" />
-      </form>
-    </div>
+      <input id="calculator_button" type="submit" title="${_('Calculate')}" value="=" aria-label="${_('Calculate')}" value="=" tabindex="-1" />
+      <input type="text" id="calculator_output" title="${_('Calculator Output Field')}" readonly tabindex="-1" />
+    </form>
+  </div>
   </div>

--- a/lms/templates/chat/toggle_chat.html
+++ b/lms/templates/chat/toggle_chat.html
@@ -1,0 +1,13 @@
+<%! from django.utils.translation import ugettext as _ %>
+<%! from django.core.urlresolvers import reverse %>
+
+<div id="chat-wrapper">
+  <div id="chat-toggle" class="closed">
+    <span id="chat-open">Open Chat <em class="icon-chevron-up"></em></span>
+    <span id="chat-close">Close Chat <em class="icon-chevron-down"></em></span>
+  </div>
+  <div id="chat-block">
+    ## The Candy.js plugin wants to render in an element with #candy
+    <div id="candy"></div>
+  </div>
+</div>

--- a/lms/templates/chat/toggle_chat.html
+++ b/lms/templates/chat/toggle_chat.html
@@ -3,8 +3,8 @@
 
 <div id="chat-wrapper">
   <div id="chat-toggle" class="closed">
-    <span id="chat-open">Open Chat <em class="icon-chevron-up"></em></span>
-    <span id="chat-close">Close Chat <em class="icon-chevron-down"></em></span>
+    <span id="chat-open">${_('Open Chat')} <em class="icon-chevron-up"></em></span>
+    <span id="chat-close">${_('Close Chat')} <em class="icon-chevron-down"></em></span>
   </div>
   <div id="chat-block">
     ## The Candy.js plugin wants to render in an element with #candy

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -211,148 +211,27 @@ ${fragment.foot_html()}
 
     <section class="course-content" id="course-content">
       ${fragment.body_html()}
-      % if is_edxnotes_enabled(course):
-        <%include file="/edxnotes/toggle_notes.html" args="course=course"/>
-      % endif
     </section>
   </div>
 </div>
 
-% if show_chat:
-  <div id="chat-wrapper">
-    <div id="chat-toggle" class="closed">
-      <span id="chat-open">Open Chat <em class="icon-chevron-up"></em></span>
-      <span id="chat-close">Close Chat <em class="icon-chevron-down"></em></span>
-    </div>
-    <div id="chat-block">
-      ## The Candy.js plugin wants to render in an element with #candy
-      <div id="candy"></div>
-    </div>
-  </div>
-% endif
+<nav class="nav-utilities">
+  <h2 class="sr nav-utilities-title">Course Utilities Navigation</h2>
 
-% if course.show_calculator:
-  <div class="calc-main">
-    <a title="${_('Open Calculator')}" href="#" role="button" aria-controls="calculator_wrapper" aria-expanded="false" class="calc">${_("Open Calculator")}</a>
+  ## Utility: Chat
+  % if show_chat:
+    <%include file="/chat/toggle_chat.html" />
+  % endif
 
-    <div id="calculator_wrapper">
-      <form id="calculator">
-        <div class="input-wrapper">
-          <input type="text" id="calculator_input" title="${_('Calculator Input Field')}" tabindex="-1" />
+  ## Utility: Notes
+  % if is_edxnotes_enabled(course):
+    <%include file="/edxnotes/toggle_notes.html" args="course=course"/>
+  % endif
 
-          <div class="help-wrapper">
-            <p class="sr" id="hint-instructions">${_('Use the arrow keys to navigate the tips or use the tab key to return to the calculator')}</p>
+  ## Utility: Calc
+  % if course.show_calculator:
+    <%include file="/calculator/toggle_calculator.html" />
+  % endif
+</nav>
 
-            <a id="calculator_hint" href="#" role="button" aria-haspopup="true" tabindex="-1" aria-describedby="hint-instructions">${_("Hints")}</a>
-
-            <ul id="calculator_input_help" class="help" aria-activedescendant="hint-moreinfo" role="tooltip" aria-hidden="true">
-              <li class="hint-item" id="hint-moreinfo" tabindex="-1">
-                <p><span class="bold">${_("For detailed information, see <a href='http://edx-guide-for-students.readthedocs.org/en/latest/SFD_mathformatting.html'>Entering Mathematical and Scientific Expressions</a> in the <a href='http://edx-guide-for-students.readthedocs.org/en/latest/index.html'>edX Guide for Students</a>.")}</span></p>
-              </li>
-
-              <li class="hint-item" id="hint-tips" tabindex="-1"><p><span class="bold">${_("Tips")}:</span> </p>
-                <ul>
-                  <li class="hint-item" id="hint-paren" tabindex="-1"><p>Use parentheses () to make expressions clear. You can use parentheses inside other parentheses.</p></li>
-                  <li class="hint-item" id="hint-spaces" tabindex="-1"><p>Do not use spaces in expressions.</p></li>
-                  <li class="hint-item" id="hint-howto-constants" tabindex="-1"><p>For constants, indicate multiplication explicitly (example: 5*c).</p></li>
-                  <li class="hint-item" id="hint-howto-maffixes" tabindex="-1"><p>For affixes, type the number and affix without a space (example: 5c).</p></li>
-                  <li class="hint-item" id="hint-howto-functions" tabindex="-1"><p>For functions, type the name of the function, then the expression in parentheses.</p></li>
-                </ul>
-              </li>
-
-              <li class="hint-item" id="hint-list" tabindex="-1">
-                <table class="calculator-input-help-table">
-                  <tbody>
-                    <tr>
-                      <th scope="col">${_("To Use")}</th>
-                      <th scope="col">${_("Type")}</th>
-                      <th scope="col">${_("Examples")}</th>
-                    </tr>
-                    <tr>
-                      <th scope="row">${_("Numbers")}</th>
-                      <td>Integers<br />
-                        Fractions<br />
-                        Decimals
-                      </td>
-                      <td>2520<br />
-                        2/3<br />
-                        3.14, .98
-                      </td>
-                    </tr>
-                    <tr>
-                      <th scope="row">${_("Operators")}</th>
-                      <td>+ - * / (add, subtract, multiply, divide)<br />
-                        ^ (raise to a power)<br />
-                        _ (add a subscript)<br />
-                        || (parallel resistors)
-                      </td>
-                      <td>x+(2*y)/x-1
-                        x^(n+1)<br />
-                        v_IN+v_OUT<br />
-                        1||2
-                      </td>
-                    </tr>
-                    <tr>
-                      <th scope="row">${_("Greek letters")}</th>
-                      <td>Name of letter</td>
-                      <td>alpha<br />
-                        lambda
-                      </td>
-                    </tr>
-                    <tr>
-                      <th scope="row">${_("Constants")}</th>
-                      <td>c, e, g, i, j, k, pi, q, T</td>
-                      <td>20*c<br />
-                        418*T
-                      </td>
-                    </tr>
-                    <tr>
-                      <th scope="row">${_("Affixes")}</th>
-                      <td>Percent sign (%) and metric affixes (d, c, m, u, n, p, k, M, G, T)</td>
-                      <td>20%<br />
-                        20c<br />
-                        418T
-                      </td>
-                    </tr>
-                    <tr>
-                      <th scope="row">${_("Basic functions")}</th>
-                      <td>abs, exp, fact or factorial, ln, log2, log10, sqrt</td>
-                      <td>abs(x+y)<br />
-                        sqrt(x^2-y)
-                      </td>
-                    </tr>
-                    <tr>
-                      <th scope="row">${_("Trigonometric functions")}</th>
-                      <td>sin, cos, tan, sec, csc, cot<br />
-                        arcsin, sinh, arcsinh, etc.<br />
-                      </td>
-                      <td>sin(4x+y)<br />
-                        arccsch(4x+y)
-                      </td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <th scope="row">${_("Scientific notation")}</th>
-                      <td>10^ and the exponent</td>
-                      <td>10^-9</td>
-                    </tr>
-                    <tr>
-                      <th scope="row">${_("e notation")}</th>
-                      <td>1e and the exponent</td>
-                      <td>1e-9</td>
-                    </tr>
-                  </tbody>
-                </table>
-              </li>
-            </ul>
-          </div>
-        </div>
-
-        <input id="calculator_button" type="submit" title="${_('Calculate')}" value="=" aria-label="${_('Calculate')}" value="=" tabindex="-1" />
-        <input type="text" id="calculator_output" title="${_('Calculator Output Field')}" readonly tabindex="-1" />
-      </form>
-    </div>
-  </div>
-
-% endif
 <%include file="../modal/accessible_confirm.html" />

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -216,7 +216,7 @@ ${fragment.foot_html()}
 </div>
 
 <nav class="nav-utilities">
-  <h2 class="sr nav-utilities-title">Course Utilities Navigation</h2>
+  <h2 class="sr nav-utilities-title">${_('Course Utilities Navigation')}</h2>
 
   ## Utility: Chat
   % if show_chat:

--- a/lms/templates/edxnotes/toggle_notes.html
+++ b/lms/templates/edxnotes/toggle_notes.html
@@ -9,11 +9,12 @@
 %>
 <div class="wrapper-utility edx-notes-visibility">
   <div class="edx-notes-visibility-error error"></div>
-  <a href="#" class="utility-control action-toggle-notes is-disabled" role="button" aria-pressed="">
+  <a href="#" class="utility-control action-toggle-notes is-disabled ${"is-active" if edxnotes_visibility else ""}"  role="button" aria-pressed="">
+    <i class="icon-pencil"></i>
     % if edxnotes_visibility:
-      <i class="icon-pencil"></i> <span class="utility-control-label sr">${_("Hide notes")}</span>
+     <span class="utility-control-label sr">${_("Hide notes")}</span>
     % else:
-      <i class="icon-pencil"></i> <span class="utility-control-label sr">${_("Show notes")}</span>
+     <span class="utility-control-label sr">${_("Show notes")}</span>
     % endif
   </a>
 </div>

--- a/lms/templates/edxnotes/toggle_notes.html
+++ b/lms/templates/edxnotes/toggle_notes.html
@@ -4,24 +4,23 @@
 <%page args="course"/>
 
 <%
-    edxnotes_visibility = course.edxnotes_visibility
-    edxnotes_visibility_url = reverse("edxnotes_visibility", kwargs={"course_id": course.id})
+  edxnotes_visibility = course.edxnotes_visibility
+  edxnotes_visibility_url = reverse("edxnotes_visibility", kwargs={"course_id": course.id})
 %>
-<div class="action-inline edx-notes-visibility">
-    <a href="#" class="action-toggle-notes is-disabled" role="button" aria-pressed="">
-        % if edxnotes_visibility:
-            <i class="checkbox-icon icon-check"></i>
-        % else:
-            <i class="checkbox-icon icon-check-empty"></i>
-        % endif
-        ${_("Show notes")}
-    </a>
-    <div class="edx-notes-visibility-error error"></div>
+<div class="wrapper-utility edx-notes-visibility">
+  <div class="edx-notes-visibility-error error"></div>
+  <a href="#" class="utility-control action-toggle-notes is-disabled" role="button" aria-pressed="">
+    % if edxnotes_visibility:
+      <i class="icon-pencil"></i> <span class="utility-control-label sr">${_("Hide notes")}</span>
+    % else:
+      <i class="icon-pencil"></i> <span class="utility-control-label sr">${_("Show notes")}</span>
+    % endif
+  </a>
 </div>
 <script type="text/javascript">
-    (function (require) {
-        require(['js/edxnotes/views/toggle_notes_factory'], function(ToggleNotesFactory) {
-            ToggleNotesFactory(${json.dumps(edxnotes_visibility)}, '${edxnotes_visibility_url}');
-        });
-    }).call(this, require || RequireJS.require);
+  (function (require) {
+      require(['js/edxnotes/views/toggle_notes_factory'], function(ToggleNotesFactory) {
+          ToggleNotesFactory(${json.dumps(edxnotes_visibility)}, '${edxnotes_visibility_url}');
+      });
+  }).call(this, require || RequireJS.require);
 </script>

--- a/lms/templates/edxnotes/toggle_notes.html
+++ b/lms/templates/edxnotes/toggle_notes.html
@@ -8,15 +8,14 @@
   edxnotes_visibility_url = reverse("edxnotes_visibility", kwargs={"course_id": course.id})
 %>
 <div class="wrapper-utility edx-notes-visibility">
-  <div class="edx-notes-visibility-error error"></div>
-  <a href="#" class="utility-control action-toggle-notes is-disabled ${"is-active" if edxnotes_visibility else ""}"  role="button" aria-pressed="">
+  <button class="utility-control utility-control-button action-toggle-notes is-disabled ${"is-active" if edxnotes_visibility else ""}" aria-pressed="">
     <i class="icon-pencil"></i>
     % if edxnotes_visibility:
      <span class="utility-control-label sr">${_("Hide notes")}</span>
     % else:
      <span class="utility-control-label sr">${_("Show notes")}</span>
     % endif
-  </a>
+  </button>
 </div>
 <script type="text/javascript">
   (function (require) {


### PR DESCRIPTION
This work styles the toggle notes on and off UI being added to the LMS. Included in this work is:
- partial abstraction of utility-based navigation styling/markup
- brief clean up of Sass partial organization (adding in modules)
- styling/rendering of toggle notes specific UI
- styling/rendering of toggle notes errors (both system and vendor errors)

---

**Known Concerns**
- The calculator's styling and markup are particular to that element - the UI added here has been positioned around this element, but utility navigation should be more robust when supporting multiple items per course.
- This UI may not play well with the chat feature, which has not been reviewed.
- The vendor's error message is still displayed when the notes server cannot be reached
- The system message (for when there is an error in toggling) is limited in content and is currently not using a known system feedback pattern

---

**TODOS**
- ~~Wire in the `.has-error` stateful class to `.edx-notes-visibility` element (display is controlled by this toggle)~~
- ~~Wire correctly the `.is-active` class on the `.action-toggle-notes` elements (currently added in HTML, but JS is not toggling class while maintaining state)~~
- ~~Provide RTL styling support~~

---

**Screengrab - Notes Toggled Off**
![screen shot 2014-12-29 at 2 27 42 pm](https://cloud.githubusercontent.com/assets/163763/5572099/80697b54-8f67-11e4-9124-596c44e63898.png)

**Screengrab - Notes Toggled On**
![screen shot 2014-12-29 at 2 27 26 pm](https://cloud.githubusercontent.com/assets/163763/5572098/7b7c0eb8-8f67-11e4-9129-6a761a617b17.png)

**Screengrab - Notes Toggle with System Error**
![screen shot 2014-12-29 at 2 29 35 pm](https://cloud.githubusercontent.com/assets/163763/5572103/8c4a79b4-8f67-11e4-987c-027c07d91c7c.png)
