### PR TITLE
Fix visual bug with large file error msg in cms.

### DIFF
--- a/cms/static/js/spec/views/assets_spec.js
+++ b/cms/static/js/spec/views/assets_spec.js
@@ -169,6 +169,21 @@ define([ "jquery", "js/common_helpers/ajax_helpers", "js/views/asset", "js/views
 
                     expect(assetsView.largeFileErrorMsg).toBeNull();
                 });
+
+                it('hides the error modal if a large file, then small file is uploaded', function() {
+                    expect(assetsView).toBeDefined();
+                    mockFileUpload.files[0].size = assetsView.maxFileSize;
+
+                    $('.choose-file-button').click();
+                    $(".upload-modal .file-chooser").fileupload('add', mockFileUpload);
+
+                    expect(assetsView.largeFileErrorMsg).toBeDefined();
+
+                    mockFileUpload.files[0].size = assetsView.maxFileSize / 10;
+                    $('.choose-file-button').click();
+                    $(".upload-modal .file-chooser").fileupload('add', mockFileUpload);
+                    expect(assetsView.largeFileErrorMsg).toBeNull();
+                });
             });
         });
     });

--- a/cms/static/js/views/assets.js
+++ b/cms/static/js/views/assets.js
@@ -135,6 +135,7 @@ define(["jquery", "underscore", "gettext", "js/models/asset", "js/views/paging",
                 event.preventDefault();
                 self.resetUploadModal();
                 ModalUtils.showModal();
+                $('.modal-cover').on('click', self.hideModal);
                 $('.file-input').bind('change', self.startUpload);
                 $('.upload-modal .file-chooser').fileupload({
                     dataType: 'json',
@@ -182,6 +183,9 @@ define(["jquery", "underscore", "gettext", "js/models/asset", "js/views/paging",
 
             showFileSelectionMenu: function(event) {
                 event.preventDefault();
+                if (assetsView.largeFileErrorMsg) {
+                  assetsView.largeFileErrorMsg.hide();
+                }
                 $('.file-input').click();
             },
 


### PR DESCRIPTION
This hotfix patches the functionality of the GridFS PR described by @sarina here: https://github.com/edx/edx-platform/pull/5731 by dismissing the error msg when the user uploads a large file and fails, then uploads a regular file. This includes a Jasmine test to cover this case.
