### PR TITLE
Fix codemirror css for long text

### DIFF
--- a/common/lib/xmodule/xmodule/css/capa/display.scss
+++ b/common/lib/xmodule/xmodule/css/capa/display.scss
@@ -576,6 +576,16 @@ div.problem {
     visibility: visible;
   }
 
+  .CodeMirror-code pre {
+    width: -webkit-fit-content;
+    width: -moz-fit-content;
+    width: fit-content;
+  }
+
+  .CodeMirror-scroll {
+    margin-right: 0px;
+  }
+
   hr {
     float: none;
     clear: both;


### PR DESCRIPTION
TNL-1026

Longer text in code mirror is not visible to users so fixed it by changing the width from auto to fit-content and padding
