### PR TITLE
Mock html_to_text.py for unit tests

### DIFF
--- a/lms/djangoapps/bulk_email/tests/test_course_optout.py
+++ b/lms/djangoapps/bulk_email/tests/test_course_optout.py
@@ -3,7 +3,7 @@
 Unit tests for student optouts from course email
 """
 import json
-from mock import patch
+from mock import patch, Mock
 
 from django.core import mail
 from django.core.management import call_command
@@ -18,6 +18,7 @@ from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
 
+@patch('bulk_email.models.html_to_text', Mock(return_value='Mocking CourseEmail.text_message'))
 @override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class TestOptoutCourseEmails(ModuleStoreTestCase):
 

--- a/lms/djangoapps/bulk_email/tests/test_email.py
+++ b/lms/djangoapps/bulk_email/tests/test_email.py
@@ -108,7 +108,6 @@ class TestEmailSendFromDashboard(ModuleStoreTestCase):
         # We should get back a HttpResponseForbidden (status code 403)
         self.assertContains(response, "Email is not enabled for this course.", status_code=403)
 
-
     @patch('bulk_email.models.html_to_text', Mock(return_value='Mocking CourseEmail.text_message'))
     def test_send_to_self(self):
         """
@@ -230,7 +229,7 @@ class TestEmailSendFromDashboard(ModuleStoreTestCase):
             '[' + self.course.display_name + '] ' + uni_subject
         )
 
-    @skipIf(os.environ.get("Travis")=='true', "Skip this test in Travis CI.")
+    @skipIf(os.environ.get("Travis") == 'true', "Skip this test in Travis CI.")
     def test_unicode_message_send_to_all(self):
         """
         Make sure email (with Unicode characters) send to all goes there.

--- a/lms/djangoapps/bulk_email/tests/test_err_handling.py
+++ b/lms/djangoapps/bulk_email/tests/test_err_handling.py
@@ -36,6 +36,7 @@ class EmailTestException(Exception):
     """Mock exception for email testing."""
     pass
 
+
 @patch('bulk_email.models.html_to_text', Mock(return_value='Mocking CourseEmail.text_message'))
 @override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 @patch.dict(settings.FEATURES, {'ENABLE_INSTRUCTOR_EMAIL': True, 'REQUIRE_COURSE_EMAIL_AUTH': False})

--- a/lms/djangoapps/bulk_email/tests/test_err_handling.py
+++ b/lms/djangoapps/bulk_email/tests/test_err_handling.py
@@ -11,7 +11,7 @@ from django.core.management import call_command
 from django.core.urlresolvers import reverse
 from django.db import DatabaseError
 import json
-from mock import patch
+from mock import patch, Mock
 from smtplib import SMTPDataError, SMTPServerDisconnected, SMTPConnectError
 
 from bulk_email.models import CourseEmail, SEND_TO_ALL
@@ -36,7 +36,7 @@ class EmailTestException(Exception):
     """Mock exception for email testing."""
     pass
 
-
+@patch('bulk_email.models.html_to_text', Mock(return_value='Mocking CourseEmail.text_message'))
 @override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 @patch.dict(settings.FEATURES, {'ENABLE_INSTRUCTOR_EMAIL': True, 'REQUIRE_COURSE_EMAIL_AUTH': False})
 class TestEmailErrors(ModuleStoreTestCase):

--- a/lms/djangoapps/bulk_email/tests/test_models.py
+++ b/lms/djangoapps/bulk_email/tests/test_models.py
@@ -7,12 +7,12 @@ from django.conf import settings
 
 from student.tests.factories import UserFactory
 
-from mock import patch
+from mock import patch, Mock
 
 from bulk_email.models import CourseEmail, SEND_TO_STAFF, CourseEmailTemplate, CourseAuthorization
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
 
-
+@patch('bulk_email.models.html_to_text', Mock(return_value='Mocking CourseEmail.text_message'))
 class CourseEmailTest(TestCase):
     """Test the CourseEmail model."""
 

--- a/lms/djangoapps/bulk_email/tests/test_models.py
+++ b/lms/djangoapps/bulk_email/tests/test_models.py
@@ -12,6 +12,7 @@ from mock import patch, Mock
 from bulk_email.models import CourseEmail, SEND_TO_STAFF, CourseEmailTemplate, CourseAuthorization
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
 
+
 @patch('bulk_email.models.html_to_text', Mock(return_value='Mocking CourseEmail.text_message'))
 class CourseEmailTest(TestCase):
     """Test the CourseEmail model."""

--- a/lms/djangoapps/bulk_email/tests/test_tasks.py
+++ b/lms/djangoapps/bulk_email/tests/test_tasks.py
@@ -71,6 +71,7 @@ def my_update_subtask_status(entry_id, current_task_id, new_subtask_status):
         update_subtask_status(entry_id, current_task_id, new_subtask_status)
 
 
+@patch('bulk_email.models.html_to_text', Mock(return_value='Mocking CourseEmail.text_message'))
 class TestBulkEmailInstructorTask(InstructorTaskCourseTestCase):
     """Tests instructor task that send bulk email."""
 

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -139,6 +139,7 @@ class TestCommonExceptions400(TestCase):
 
 
 @override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
+@patch('bulk_email.models.html_to_text', Mock(return_value='Mocking CourseEmail.text_message'))
 @patch.dict(settings.FEATURES, {'ENABLE_INSTRUCTOR_EMAIL': True, 'REQUIRE_COURSE_EMAIL_AUTH': False})
 class TestInstructorAPIDenyLevels(ModuleStoreTestCase, LoginEnrollmentTestCase):
     """
@@ -2228,6 +2229,7 @@ class TestInstructorAPIRegradeTask(ModuleStoreTestCase, LoginEnrollmentTestCase)
 
 
 @override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
+@patch('bulk_email.models.html_to_text', Mock(return_value='Mocking CourseEmail.text_message'))
 @patch.dict(settings.FEATURES, {'ENABLE_INSTRUCTOR_EMAIL': True, 'REQUIRE_COURSE_EMAIL_AUTH': False})
 class TestInstructorSendEmail(ModuleStoreTestCase, LoginEnrollmentTestCase):
     """

--- a/lms/djangoapps/instructor_task/tests/test_api.py
+++ b/lms/djangoapps/instructor_task/tests/test_api.py
@@ -1,6 +1,7 @@
 """
 Test for LMS instructor background task queue management
 """
+from mock import patch, Mock
 from bulk_email.models import CourseEmail, SEND_TO_ALL
 from courseware.tests.factories import UserFactory
 from xmodule.modulestore.exceptions import ItemNotFoundError
@@ -158,6 +159,7 @@ class InstructorTaskModuleSubmitTest(InstructorTaskModuleTestCase):
         self._test_submit_task(submit_delete_problem_state_for_all_students)
 
 
+@patch('bulk_email.models.html_to_text', Mock(return_value='Mocking CourseEmail.text_message'))
 class InstructorTaskCourseSubmitTest(TestReportMixin, InstructorTaskCourseTestCase):
     """Tests API methods that involve the submission of course-based background tasks."""
 


### PR DESCRIPTION
TE-672

Using [beautifulsoup4's get_text method](http://www.crummy.com/software/BeautifulSoup/bs4/doc/#get-text)  to convert the html to text instead of using lynx via subprocess.
