### PR TITLE
LMS: Student Notes - View All/Search Final Styling (UX-1331)

### DIFF
--- a/common/test/acceptance/pages/lms/edxnotes.py
+++ b/common/test/acceptance/pages/lms/edxnotes.py
@@ -142,13 +142,13 @@ class EdxNotesPageView(PageObject):
         """
         Indicates if tab is closable or not.
         """
-        return self.q(css="{} .btn-close".format(self.TAB_SELECTOR)).present
+        return self.q(css="{} .action-close".format(self.TAB_SELECTOR)).present
 
     def close(self):
         """
         Closes the tab.
         """
-        self.q(css="{} .btn-close".format(self.TAB_SELECTOR)).first.click()
+        self.q(css="{} .action-close".format(self.TAB_SELECTOR)).first.click()
 
     @property
     def children(self):

--- a/lms/djangoapps/edxnotes/tests.py
+++ b/lms/djangoapps/edxnotes/tests.py
@@ -803,7 +803,7 @@ class EdxNotesViewsTest(TestCase):
         """
         enable_edxnotes_for_the_course(self.course, self.user.id)
         response = self.client.get(self.notes_page_url)
-        self.assertContains(response, '<h1 class="page-title">Notes')
+        self.assertContains(response, 'Highlights and notes you\'ve made in course content')
 
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_EDXNOTES": False})
     def test_edxnotes_view_is_disabled(self):

--- a/lms/static/coffee/src/calculator.coffee
+++ b/lms/static/coffee/src/calculator.coffee
@@ -72,7 +72,7 @@ class @Calculator
       .attr
         'title': text
         'aria-expanded': isExpanded
-      .text text
+      .find('.utility-control-label').text text
 
     $calc.toggleClass 'closed'
 

--- a/lms/static/js/edxnotes/views/tab_item.js
+++ b/lms/static/js/edxnotes/views/tab_item.js
@@ -10,7 +10,7 @@ function (gettext, _, Backbone, templateUtils) {
         events: {
             'click': 'selectHandler',
             'click a': function (event) { event.preventDefault(); },
-            'click .btn-close': 'closeHandler'
+            'click .action-close': 'closeHandler'
         },
 
         initialize: function (options) {

--- a/lms/static/js/edxnotes/views/tab_view.js
+++ b/lms/static/js/edxnotes/views/tab_view.js
@@ -112,9 +112,9 @@ define([
          * Shows error message.
          */
         showErrorMessage: function (message) {
-            this.$('.inline-error')
-                .text(message)
+            this.$('.wrapper-msg')
                 .removeClass('is-hidden')
+                .find('.msg-content .copy').text(message)
                 .focus();
         },
 

--- a/lms/static/js/edxnotes/views/tab_view.js
+++ b/lms/static/js/edxnotes/views/tab_view.js
@@ -48,7 +48,7 @@ define([
          * Renders content for the view.
          */
         render: function () {
-            this.showLoadingIndicator();
+            this.hideErrorMessage().showLoadingIndicator();
             // If the view is already rendered, destroy it.
             this.destroySubView();
             this.renderContent().always(this.hideLoadingIndicator);
@@ -98,6 +98,7 @@ define([
          */
         showLoadingIndicator: function() {
             this.getLoadingIndicator().removeClass('is-hidden');
+            return this;
         },
 
         /**
@@ -105,6 +106,7 @@ define([
          */
         hideLoadingIndicator: function() {
             this.getLoadingIndicator().addClass('is-hidden');
+            return this;
         },
 
 
@@ -117,6 +119,8 @@ define([
                 .find('.msg-content .copy').text(message)
                 .closest('.msg')
                 .focus();
+
+            return this;
         },
 
         /**
@@ -126,6 +130,8 @@ define([
             this.$('.wrapper-msg')
                 .addClass('is-hidden')
                 .find('.msg-content .copy').text('');
+
+            return this;
         }
     });
 

--- a/lms/static/js/edxnotes/views/tab_view.js
+++ b/lms/static/js/edxnotes/views/tab_view.js
@@ -115,6 +115,7 @@ define([
             this.$('.wrapper-msg')
                 .removeClass('is-hidden')
                 .find('.msg-content .copy').text(message)
+                .closest('.msg')
                 .focus();
         },
 
@@ -122,9 +123,9 @@ define([
          * Hides error message.
          */
         hideErrorMessage: function () {
-            this.$('.inline-error')
-                .text('')
-                .addClass('is-hidden');
+            this.$('.wrapper-msg')
+                .addClass('is-hidden')
+                .find('.msg-content .copy').text('');
         }
     });
 

--- a/lms/static/js/edxnotes/views/tabs/search_results.js
+++ b/lms/static/js/edxnotes/views/tabs/search_results.js
@@ -39,7 +39,7 @@ define([
                 ].join(' ')
             },
             renderContent: function () {
-                var message = gettext('No results found for "%(query_string)s".');
+                var message = gettext('No results found for "%(query_string)s". Please try searching again.');
 
                 this.$el.append($('<p></p>', {
                     text: interpolate(message, {

--- a/lms/static/js/edxnotes/views/toggle_notes_factory.js
+++ b/lms/static/js/edxnotes/views/toggle_notes_factory.js
@@ -1,8 +1,9 @@
 ;(function (define, undefined) {
 'use strict';
 define([
-    'jquery', 'underscore', 'backbone', 'gettext', 'js/edxnotes/views/visibility_decorator'
-], function($, _, Backbone, gettext, EdxnotesVisibilityDecorator) {
+    'jquery', 'underscore', 'backbone', 'gettext',
+    'annotator', 'js/edxnotes/views/visibility_decorator'
+], function($, _, Backbone, gettext, Annotator, EdxnotesVisibilityDecorator) {
     var ToggleNotesView = Backbone.View.extend({
         events: {
             'click .action-toggle-notes': 'toogleHandler'
@@ -16,6 +17,7 @@ define([
             this.checkboxIcon = this.$('.checkbox-icon');
             this.actionLink = this.$('.action-toggle-notes');
             this.actionLink.removeClass('is-disabled');
+            this.notification = new Annotator.Notification();
         },
 
         toogleHandler: function (event) {
@@ -38,13 +40,11 @@ define([
         },
 
         hideErrorMessage: function() {
-            this.$el.removeClass('has-error');
-            this.$('.edx-notes-visibility-error').text('');
+            this.notification.hide();
         },
 
         showErrorMessage: function(message) {
-            this.$el.addClass('has-error');
-            this.$('.edx-notes-visibility-error').text(message);
+            this.notification.show(message, Annotator.Notification.ERROR);
         },
 
         sendRequest: function () {

--- a/lms/static/js/edxnotes/views/toggle_notes_factory.js
+++ b/lms/static/js/edxnotes/views/toggle_notes_factory.js
@@ -14,7 +14,8 @@ define([
             this.visibility = options.visibility;
             this.visibilityUrl = options.visibilityUrl;
             this.checkboxIcon = this.$('.checkbox-icon');
-            this.$('.action-toggle-notes').removeClass('is-disabled');
+            this.actionLink = this.$('.action-toggle-notes');
+            this.actionLink.removeClass('is-disabled');
         },
 
         toogleHandler: function (event) {
@@ -28,17 +29,21 @@ define([
             if (this.visibility) {
                 _.each($('.edx-notes-wrapper'), EdxnotesVisibilityDecorator.enableNote);
                 this.checkboxIcon.removeClass('icon-check-empty').addClass('icon-check');
+                this.actionLink.addClass('is-active');
             } else {
                 EdxnotesVisibilityDecorator.disableNotes();
                 this.checkboxIcon.removeClass('icon-check').addClass('icon-check-empty');
+                this.actionLink.removeClass('is-active');
             }
         },
 
         hideErrorMessage: function() {
+            this.$el.removeClass('has-error');
             this.$('.edx-notes-visibility-error').text('');
         },
 
         showErrorMessage: function(message) {
+            this.$el.addClass('has-error');
             this.$('.edx-notes-visibility-error').text(message);
         },
 

--- a/lms/static/js/fixtures/edxnotes/edxnotes.html
+++ b/lms/static/js/fixtures/edxnotes/edxnotes.html
@@ -15,11 +15,18 @@
         </div>
     </div>
 
+    <div class="wrapper-msg is-hidden error urgency-high inline-error">
+        <div class="msg msg-error" tabindex="-1">
+          <div class="msg-content">
+            <p class="copy"></p>
+          </div>
+        </div>
+    </div>
+
     <section class="wrapper-tabs">
         <div class="tab-list is-hidden">
             <h2 id="tab-view" class="tabs-label">View notes by:</h2>
         </div>
-        <div class="inline-error is-hidden" tabindex="-1"></div>
         <div class="ui-loading" tabindex="-1">
             <p><span class="spin"><i class="icon-refresh"></i></span> <span class="copy">Loading...</span></p>
         </div>

--- a/lms/static/js/fixtures/edxnotes/toggle_notes.html
+++ b/lms/static/js/fixtures/edxnotes/toggle_notes.html
@@ -1,5 +1,5 @@
 <div class="action-inline edx-notes-visibility">
-    <a href="#" class="action-toggle-notes is-disabled" role="button" aria-pressed="">
+    <a href="#" class="action-toggle-notes is-disabled is-active" role="button" aria-pressed="">
         <i class="checkbox-icon icon-check"></i>
         Show notes
     </a>

--- a/lms/static/js/fixtures/edxnotes/toggle_notes.html
+++ b/lms/static/js/fixtures/edxnotes/toggle_notes.html
@@ -3,5 +3,4 @@
         <i class="checkbox-icon icon-check"></i>
         Show notes
     </a>
-    <div class="edx-notes-visibility-error"></div>
 </div>

--- a/lms/static/js/spec/edxnotes/views/note_item_spec.js
+++ b/lms/static/js/spec/edxnotes/views/note_item_spec.js
@@ -29,7 +29,7 @@ define([
             view.$('.note-excerpt-more-link').click();
 
             expect(view.$el).toContainText(Helpers.LONG_TEXT);
-            expect(view.$el).toContainText('(Show less)');
+            expect(view.$el).toContainText('Less');
 
             view = getView({quote: Helpers.SHORT_TEXT});
             expect(view.$el).not.toContain('.note-excerpt-more-link');

--- a/lms/static/js/spec/edxnotes/views/tab_item_spec.js
+++ b/lms/static/js/spec/edxnotes/views/tab_item_spec.js
@@ -47,7 +47,7 @@ define([
             var secondItem = this.tabsList.$('#second-item');
 
             expect(this.tabsList.$('.tab')).toHaveLength(2);
-            secondItem.find('.btn-close').click();
+            secondItem.find('.action-close').click();
             expect(this.tabsList.$('.tab')).toHaveLength(1);
         });
     });

--- a/lms/static/js/spec/edxnotes/views/tab_view_spec.js
+++ b/lms/static/js/spec/edxnotes/views/tab_view_spec.js
@@ -95,15 +95,15 @@ define([
 
         it('can show/hide error messages', function () {
             var view = getView(this.tabsCollection),
-                errorHolder = view.$('.inline-error');
+                errorHolder = view.$('.wrapper-msg');
             view.showErrorMessage('<p>error message is here</p>');
             expect(errorHolder).not.toHaveClass('is-hidden');
-            expect(errorHolder).toBeFocused();
-            expect(errorHolder).toContainText('<p>error message is here</p>');
+            expect(errorHolder.find('.msg')).toBeFocused();
+            expect(errorHolder.find('.copy')).toContainText('<p>error message is here</p>');
 
             view.hideErrorMessage();
             expect(errorHolder).toHaveClass('is-hidden');
-            expect(errorHolder).toBeEmpty();
+            expect(errorHolder.find('.copy')).toBeEmpty();
         });
     });
 });

--- a/lms/static/js/spec/edxnotes/views/tab_view_spec.js
+++ b/lms/static/js/spec/edxnotes/views/tab_view_spec.js
@@ -78,7 +78,7 @@ define([
         it('can remove the content if tab is closed', function () {
             var view = getView(this.tabsCollection);
             view.onClose =  jasmine.createSpy();
-            view.$('.tab .btn-close').click();
+            view.$('.tab .action-close').click();
             expect(view.$('.tab')).toHaveLength(0);
             expect(view.$('.wrapper-tabs')).not.toContainHtml('<p>test view content</p>');
             expect(view.tabModel).toBeNull();

--- a/lms/static/js/spec/edxnotes/views/tab_view_spec.js
+++ b/lms/static/js/spec/edxnotes/views/tab_view_spec.js
@@ -105,5 +105,14 @@ define([
             expect(errorHolder).toHaveClass('is-hidden');
             expect(errorHolder.find('.copy')).toBeEmpty();
         });
+
+        it('should hide error messages before rendering', function () {
+            var view = getView(this.tabsCollection),
+                errorHolder = view.$('.wrapper-msg');
+            view.showErrorMessage('<p>error message is here</p>');
+            view.render();
+            expect(errorHolder).toHaveClass('is-hidden');
+            expect(errorHolder.find('.copy')).toBeEmpty();
+        });
     });
 });

--- a/lms/static/js/spec/edxnotes/views/tabs/search_results_spec.js
+++ b/lms/static/js/spec/edxnotes/views/tabs/search_results_spec.js
@@ -167,16 +167,16 @@ define([
                 })
             );
 
-            expect(view.$('.inline-error')).not.toHaveClass('is-hidden');
-            expect(view.$('.inline-error')).toContainText('test error message');
+            expect(view.$('.wrapper-msg')).not.toHaveClass('is-hidden');
+            expect(view.$('.wrapper-msg .copy')).toContainText('test error message');
             expect(view.$('.note-highlight')).not.toExist();
             expect(view.$('.ui-loading')).toHaveClass('is-hidden');
 
             submitForm(view.searchBox, 'Second');
             AjaxHelpers.respondWithJson(requests, responseJson);
 
-            expect(view.$('.inline-error')).toHaveClass('is-hidden');
-            expect(view.$('.inline-error')).toBeEmpty();
+            expect(view.$('.wrapper-msg')).toHaveClass('is-hidden');
+            expect(view.$('.wrapper-msg .copy')).toBeEmpty();
             expect(view.$('.note-highlight')).toExist();
         });
 

--- a/lms/static/js/spec/edxnotes/views/toggle_notes_factory_spec.js
+++ b/lms/static/js/spec/edxnotes/views/toggle_notes_factory_spec.js
@@ -75,18 +75,18 @@ define([
             var requests = AjaxHelpers.requests(this),
                 errorContainer = $('.annotator-notice');
 
-            expect(this.toggleNotes.$el).not.toHaveClass('has-error');
             this.button.click();
             AjaxHelpers.respondWithError(requests);
             expect(errorContainer).toContainText(
                 'Cannot save your state. This may be happening because of an error with our server or your internet connection. Try refreshing the page or making sure you are online.'
             );
+            expect(errorContainer).toBeVisible();
+            expect(errorContainer).toHaveClass('annotator-notice-show');
             expect(errorContainer).toHaveClass('annotator-notice-error');
 
             this.button.click();
             AjaxHelpers.respondWithJson(requests, {});
-            expect(errorContainer).toBeEmpty();
-            expect(this.toggleNotes.$el).not.toHaveClass('has-error');
+            expect(errorContainer).not.toHaveClass('annotator-notice-show');
         });
     });
 });

--- a/lms/static/js/spec/edxnotes/views/toggle_notes_factory_spec.js
+++ b/lms/static/js/spec/edxnotes/views/toggle_notes_factory_spec.js
@@ -45,10 +45,12 @@ define([
             expect(this.button).not.toHaveClass('is-disabled');
             expect(this.icon).toHaveClass('icon-check');
             expect(this.icon).not.toHaveClass('icon-check-empty');
+            expect(this.button).toHaveClass('is-active');
 
             this.button.click();
             expect(this.icon).toHaveClass('icon-check-empty');
             expect(this.icon).not.toHaveClass('icon-check');
+            expect(this.button).not.toHaveClass('is-active');
             expect(Annotator._instances).toHaveLength(0);
 
             AjaxHelpers.expectJsonRequest(requests, 'PUT', '/test_url', {
@@ -59,6 +61,7 @@ define([
             this.button.click();
             expect(this.icon).toHaveClass('icon-check');
             expect(this.icon).not.toHaveClass('icon-check-empty');
+            expect(this.button).toHaveClass('is-active');
             expect(Annotator._instances).toHaveLength(2);
 
             AjaxHelpers.expectJsonRequest(requests, 'PUT', '/test_url', {
@@ -71,15 +74,18 @@ define([
             var requests = AjaxHelpers.requests(this),
                 errorContainer = $('.edx-notes-visibility-error');
 
+            expect(this.toggleNotes.$el).not.toHaveClass('has-error');
             this.button.click();
             AjaxHelpers.respondWithError(requests);
             expect(errorContainer).toContainText(
                 'Cannot save your state. This may be happening because of an error with our server or your internet connection. Try refreshing the page or making sure you are online.'
             );
+            expect(this.toggleNotes.$el).toHaveClass('has-error');
 
             this.button.click();
             AjaxHelpers.respondWithJson(requests, {});
             expect(errorContainer).toBeEmpty();
+            expect(this.toggleNotes.$el).not.toHaveClass('has-error');
         });
     });
 });

--- a/lms/static/js/spec/edxnotes/views/toggle_notes_factory_spec.js
+++ b/lms/static/js/spec/edxnotes/views/toggle_notes_factory_spec.js
@@ -37,6 +37,7 @@ define([
         afterEach(function () {
             VisibilityDecorator._setVisibility(null);
             _.invoke(Annotator._instances, 'destroy');
+            $('.annotator-notice').remove();
         });
 
         it('can toggle notes', function() {
@@ -72,7 +73,7 @@ define([
 
         it('can handle errors', function() {
             var requests = AjaxHelpers.requests(this),
-                errorContainer = $('.edx-notes-visibility-error');
+                errorContainer = $('.annotator-notice');
 
             expect(this.toggleNotes.$el).not.toHaveClass('has-error');
             this.button.click();
@@ -80,7 +81,7 @@ define([
             expect(errorContainer).toContainText(
                 'Cannot save your state. This may be happening because of an error with our server or your internet connection. Try refreshing the page or making sure you are online.'
             );
-            expect(this.toggleNotes.$el).toHaveClass('has-error');
+            expect(errorContainer).toHaveClass('annotator-notice-error');
 
             this.button.click();
             AjaxHelpers.respondWithJson(requests, {});

--- a/lms/static/sass/_developer.scss
+++ b/lms/static/sass/_developer.scss
@@ -117,9 +117,3 @@
     padding-left: ($baseline/4);
   }
 }
-
-.edx-notes-visibility {
-  .error {
-    color: $red;
-  }
-}

--- a/lms/static/sass/base/_mixins.scss
+++ b/lms/static/sass/base/_mixins.scss
@@ -181,3 +181,25 @@
 %no-border-right {
   border-right: none;
 }
+
+// outline
+%no-outline {
+  outline: none;
+}
+
+// shame-based mixins to centrally override poor styling
+%shame-link-base {
+  color: $link-color;
+
+  &:hover, &:focus {
+    color: saturate($link-color, 50%);
+  }
+}
+
+%shame-link-text {
+  @extend %shame-link-base;
+
+  &:hover, &:focus {
+    text-decoration: underline !important;
+  }
+}

--- a/lms/static/sass/base/_variables.scss
+++ b/lms/static/sass/base/_variables.scss
@@ -442,3 +442,9 @@ $blue1: #4A90E2;
 $blue2: #00A1E5;
 $green1: #61A12E;
 $red1: #D0021B;
+
+// +feature: student notes
+// --------------------
+$student-notes-highlight-color-base: saturate($yellow, 50%);
+$student-notes-highlight-color: tint($student-notes-highlight-color-base, 60%);
+$student-notes-highlight-color-focus: $student-notes-highlight-color-base;

--- a/lms/static/sass/base/_variables.scss
+++ b/lms/static/sass/base/_variables.scss
@@ -326,6 +326,7 @@ $header-graphic-sub-color: $m-gray-d2;
 $error-color: $error-red;
 $warning-color: $m-pink;
 $confirm-color: $m-green;
+$active-color: $blue;
 
 // Notifications
 $notify-banner-bg-1: rgb(56,56,56);

--- a/lms/static/sass/course-rtl.scss.mako
+++ b/lms/static/sass/course-rtl.scss.mako
@@ -27,36 +27,37 @@
 // base - elements
 @import 'elements/typography';
 @import 'elements/controls';
+@import 'elements/navigation'; // all archetypes of navigation
 
-// Course base / layout styles
+
+// course - base
 @import 'course/layout/courseware_header';
 @import 'course/layout/footer';
 @import 'course/base/mixins';
 @import 'course/base/base';
 @import 'course/base/extends';
 @import 'xmodule/modules/css/module-styles.scss';
-
-// courseware
 @import 'course/courseware/courseware';
 @import 'course/courseware/sidebar';
 @import 'course/courseware/amplifier';
-@import 'course/layout/calculator';
-@import 'course/layout/timer';
-@import 'course/layout/chat';
 
-// course-specific courseware (all styles in these files should be gated by a
-// course-specific class). This should be replaced with a better way of
-// providing course-specific styling.
+// course - modules
+@import 'course/modules/student-notes'; // student notes
+@import 'course/modules/calculator'; // calculator utility
+@import 'course/modules/timer'; // timer
+@import 'course/modules/chat'; // chat utility
+
+// course - specific courses
 @import "course/courseware/courses/_cs188.scss";
 
-// wiki
+// course - wiki
 @import "course/wiki/basic-html";
 @import "course/wiki/sidebar";
 @import "course/wiki/create";
 @import "course/wiki/wiki";
 @import "course/wiki/table";
 
-// pages
+// course - views
 @import "course/info";
 @import "course/syllabus"; // TODO arjun replace w/ custom tabs, see courseware/courses.py
 @import "course/textbook";
@@ -68,11 +69,11 @@
 @import "course/open_ended_grading";
 @import "course/student-notes";
 
-// instructor
+// course - instructor-only views
 @import "course/instructor/instructor";
 @import "course/instructor/instructor_2";
 @import "course/instructor/email";
 @import "xmodule/descriptors/css/module-styles.scss";
 
-// discussion
+// course - discussion
 @import "course/discussion/form-wmd-toolbar";

--- a/lms/static/sass/course.scss.mako
+++ b/lms/static/sass/course.scss.mako
@@ -27,6 +27,7 @@
 // base - elements
 @import 'elements/typography';
 @import 'elements/controls';
+@import 'elements/navigation'; // all archetypes of navigation
 
 // Course base / layout styles
 @import 'course/layout/courseware_header';

--- a/lms/static/sass/course.scss.mako
+++ b/lms/static/sass/course.scss.mako
@@ -29,35 +29,35 @@
 @import 'elements/controls';
 @import 'elements/navigation'; // all archetypes of navigation
 
-// Course base / layout styles
+// course - base
 @import 'course/layout/courseware_header';
 @import 'course/layout/footer';
 @import 'course/base/mixins';
 @import 'course/base/base';
 @import 'course/base/extends';
 @import 'xmodule/modules/css/module-styles.scss';
-
-// courseware
 @import 'course/courseware/courseware';
 @import 'course/courseware/sidebar';
 @import 'course/courseware/amplifier';
-@import 'course/layout/calculator';
-@import 'course/layout/timer';
-@import 'course/layout/chat';
 
-// course-specific courseware (all styles in these files should be gated by a
-// course-specific class). This should be replaced with a better way of
-// providing course-specific styling.
+// course - modules
+@import 'course/modules/student-notes'; // student notes
+@import 'course/modules/calculator'; // calculator utility
+@import 'course/modules/timer'; // timer
+@import 'course/modules/chat'; // chat utility
+
+
+// course - specific courses
 @import "course/courseware/courses/_cs188.scss";
 
-// wiki
+// course - wiki
 @import "course/wiki/basic-html";
 @import "course/wiki/sidebar";
 @import "course/wiki/create";
 @import "course/wiki/wiki";
 @import "course/wiki/table";
 
-// pages
+// course - views
 @import "course/info";
 @import "course/syllabus"; // TODO arjun replace w/ custom tabs, see courseware/courses.py
 @import "course/textbook";
@@ -69,11 +69,11 @@
 @import "course/open_ended_grading";
 @import "course/student-notes";
 
-// instructor
+// course - instructor-only views
 @import "course/instructor/instructor";
 @import "course/instructor/instructor_2";
 @import "course/instructor/email";
 @import "xmodule/descriptors/css/module-styles.scss";
 
-// discussion
+// course - discussion
 @import "course/discussion/form-wmd-toolbar";

--- a/lms/static/sass/course/_student-notes.scss
+++ b/lms/static/sass/course/_student-notes.scss
@@ -45,7 +45,7 @@ $divider-visual-tertiary: ($baseline/20) solid $gray-l4;
     margin-bottom: $baseline;
 
     .wrapper-title {
-      float: left;
+      @include float(left);
       width: flex-grid(7,12);
 
       .page-title {
@@ -65,9 +65,9 @@ $divider-visual-tertiary: ($baseline/20) solid $gray-l4;
     }
 
     .wrapper-notes-search {
-      float: right;
+      @include float(right);
       width: flex-grid(5,12);
-      text-align: right;
+      @include text-align(right);
     }
 
     .search-notes-input, .search-notes-submit {
@@ -77,7 +77,7 @@ $divider-visual-tertiary: ($baseline/20) solid $gray-l4;
 
     .search-notes-input {
       width: 55%;
-      margin-right: ($baseline/4);
+      @include margin-right($baseline/4);
       padding: ($baseline/2) ($baseline*0.75);
       color: $active-color;
     }
@@ -142,7 +142,7 @@ $divider-visual-tertiary: ($baseline/20) solid $gray-l4;
           @extend %t-weight2;
           @extend %shame-link-text;
           display: inline;
-          margin-left: ($baseline/4);
+          @include margin-left($baseline/4);
         }
 
         // note - comment made on highlighted content
@@ -271,7 +271,8 @@ $divider-visual-tertiary: ($baseline/20) solid $gray-l4;
         @extend %hd-lv5;
         display: inline;
         margin-bottom: 0;
-        padding: ($baseline*0.75) $baseline ($baseline*0.75) 0;
+        padding: ($baseline*0.75) 0;
+        @include padding-right($baseline);
         color: $gray-l2;
         font-weight: $font-semibold !important; // needed for poor base LMS styling scope
       }
@@ -291,11 +292,13 @@ $divider-visual-tertiary: ($baseline/20) solid $gray-l4;
           @extend %shame-link-base;
           display: inline-block;
           vertical-align: middle;
-          padding: ($baseline/2) $baseline ($baseline/2) ($baseline*0.75);
+          padding: ($baseline/2) 0;
+          @include padding-right($baseline);
+          @include padding-left($baseline*0.75);
           text-align: center;
 
           .icon {
-            margin-right: ($baseline/10);
+            @include margin-right($baseline/10);
           }
         }
 
@@ -312,7 +315,7 @@ $divider-visual-tertiary: ($baseline/20) solid $gray-l4;
         .action-close {
           @extend %shame-link-base;
           position: relative;
-          left: -($baseline*0.75);
+          @include left(-($baseline*0.75));
           display: inline-block;
           vertical-align: middle;
           border-bottom: ($baseline/5) solid $gray-d3;

--- a/lms/static/sass/course/_student-notes.scss
+++ b/lms/static/sass/course/_student-notes.scss
@@ -173,8 +173,7 @@ $divider-visual-tertiary: ($baseline/20) solid $gray-l4;
             }
 
             .note-comment-p {
-              overflow: hidden;
-              text-overflow: ellipsis;
+              @extend %text-truncated;
             }
 
             .note-comment-ul,

--- a/lms/static/sass/course/_student-notes.scss
+++ b/lms/static/sass/course/_student-notes.scss
@@ -1,234 +1,340 @@
-.wrapper-student-notes {
+// LMS -- views -- student notes
+// ====================
 
-  .info-wrapper {
+// in this document:
+// --------------------
+// +notes
+// +base
+// ++header +and search
+// +local variables/utilities
+// +individual group of notes
+// +tabbed views
+// +search - no results
+// +search - error
+
+// +notes:
+// --------------------
+// * this Sass partial contains all of the styling needed for the student notes listing view.
+// * for other notes styling referenced here, see the Sass partial contains the in-line student notes UI.
+
+// +local variables/utilities:
+// --------------------
+$divider-visual-primary: ($baseline/5) solid $gray-l4;
+$divider-visual-secondary: ($baseline/10) solid $gray-l4;
+$divider-visual-tertiary: ($baseline/20) solid $gray-l4;
+
+.view-student-notes {
+
+  // +base:
+  // --------------------
+  .wrapper-student-notes {
     @include clearfix();
     padding-bottom: $baseline;
 
-    .updates {
+    .student-notes {
       @include clearfix();
+      @extend .content; // needed extend carried over from course handouts UI, but should be cleaned up
       width: 100%;
+    }
+  }
 
-      .title-search-container {
-        border-bottom: 1px solid $gray-l4;
-        margin-bottom: $baseline;
+  // +header +and search:
+  // --------------------
+  .title-search-container {
+    @include clearfix();
+    margin-bottom: $baseline;
 
-        .wrapper-title {
-          display: inline-block;
-          width: flex-grid(7,12);
+    .wrapper-title {
+      float: left;
+      width: flex-grid(7,12);
 
-          .page-title {
-            font-weight: $font-light;
+      .page-title {
+        @extend %t-title4;
+        @extend %t-weight1;
+        margin-bottom: 0;
 
-            .page-subtitle {
-              @include line-height(18);
-              @extend %t-title6;
-              display: block;
-            }
-          }
-        }
-
-        .wrapper-notes-search {
-          display: inline-block;
-          width: flex-grid(5,12);
-          text-align: right;
-
-          .search-notes-input {
-            width: 55%;
-            padding: 5px;
-          }
+        .page-subtitle {
+          @extend %t-title7;
+          @extend %t-weight2;
+          display: block;
+          margin-top: ($baseline/4);
+          color: $gray-l1;
+          letter-spacing: 0;
         }
       }
     }
 
-    .note-group {
+    .wrapper-notes-search {
+      float: right;
+      width: flex-grid(5,12);
+      text-align: right;
+    }
 
-      &, .note-section {
-        border-top: 2px solid $gray-l4;
-        padding-top: $baseline;
-      }
+    .search-notes-input, .search-notes-submit {
+      display: inline-block;
+      vertical-align: middle;
+    }
 
-      .course-title + .note-section {
-        border-top: none;
-        padding-top: 0;
-      }
+    .search-notes-input {
+      width: 55%;
+      margin-right: ($baseline/4);
+      padding: ($baseline/2) ($baseline*0.75);
+      color: $active-color;
+    }
 
-      .course-title, .course-subtitle {
-        text-transform: uppercase;
-        letter-spacing: 1px;
-      }
+    .search-notes-submit {
+      @extend %btn-inherited-primary;
+      @extend %t-action2;
+    }
+  }
 
-      .course-subtitle {
-        @extend %t-copy-sub1;
-        padding-bottom: $baseline;
-        font-weight: $font-light;
-        color: inherit;
-      }
+  // +individual group of notes
+  // --------------------
+  .note-group {
+    border-top: $divider-visual-primary;
+    margin: 0;
+    padding-top: ($baseline*1.5);
 
-      .note {
-        @include clearfix();
-        margin: 0;
-        padding: ($baseline*1.5) 0;
-        border-top: 1px dotted $gray-l4;
-        border-bottom: none;
+    // course structure labels
+    .course-title {
+      @extend %t-title6;
+      @extend %t-weight4;
+      margin: 0 0 ($baseline/2) 0;
+      color: $gray-d3;
+    }
 
-        &:first-of-type {
-          border-top: 0px;
-        }
+    .course-subtitle {
+      @extend %t-title7;
+      @extend %t-weight4;
+      margin: 0 0 ($baseline/4) 0;
+      border-bottom: $divider-visual-tertiary;
+      padding-bottom: ($baseline/2);
+      color: $gray-d3;
+    }
 
-        .wrapper-note-excerpts {
-          display: inline-block;
-          width: flex-grid(9, 12);
+    // individual note
+    .note {
+      @include clearfix();
+      margin: ($baseline*1.5) 0;
 
-          .note-excerpt {
-            display: inline-block;
-            vertical-align: top;
-            background: $m-blue-l4;
+      .wrapper-note-excerpts {
+        @include transition(box-shadow $tmg-avg ease-in-out 0, border-color $tmg-avg ease-in-out 0);
+        display: inline-block;
+        width: flex-grid(9, 12);
+        border: 1px solid $gray-l5;
+        border-radius: ($baseline/10);
 
-            .note-excerpt-p,
-            .note-excerpt-ul,
-            .note-excerpt-ol {
-              @extend %t-copy-base;
-              position: relative;
-              padding: $baseline;
-            }
-          }
+        // note - highlighted content
+        .note-excerpt {
+          @include transition(background-color $tmg-avg ease-in-out 0);
+          padding: $baseline;
+          background: $student-notes-highlight-color;
 
-          .note-comments {
-            position: relative;
-            margin: 0;
-            padding: 0;
-            list-style: none;
-
-            .note-comment {
-              padding: ($baseline/2) $baseline;
-              border-bottom: 2px solid $white;
-
-              .note-comment-p,
-              .note-comment-ul,
-              .note-comment-ol {
-                @extend %t-weight4;
-                padding: 0;
-                margin: 0;
-                background: transparent;
-              }
-
-              .note-comment-p {
-                overflow: hidden;
-                text-overflow: ellipsis;
-              }
-
-              .note-comment-ul,
-              .note-comment-ol {
-                padding: auto;
-                margin: auto;
-              }
-
-              .note-highlight {
-                background-color: #FFFF88;
-              }
-            }
+          .note-excerpt-p,
+          .note-excerpt-ul,
+          .note-excerpt-ol {
+            @extend %t-copy-base;
           }
         }
 
-        .reference {
+        .note-excerpt-more-link {
           @extend %t-copy-sub1;
-          display: inline-block;
-          width: flex-grid(3, 12);
-          vertical-align: top;
+          @extend %t-weight2;
+          @extend %shame-link-text;
+          display: inline;
+          margin-left: ($baseline/4);
+        }
 
-          .wrapper-reference-content {
-            padding: 0 $baseline;
-            color: $gray-l2;
+        // note - comment made on highlighted content
+        .note-comments {
+          @extend %ui-no-list;
+          border-top: ($baseline/5) solid $student-notes-highlight-color-focus;
 
-            .reference-title {
-              @extend %t-copy-sub1;
-              margin-top: $baseline;
-              text-transform: uppercase;
-              font-weight: $font-regular;
-              letter-spacing: 1px;
+          .note-comment {
+            @include transition(color $tmg-avg ease-in-out 0);
+            padding: ($baseline*0.75) $baseline;
+            color: $gray;
+
+            .note-comment-title {
+              @extend %t-title8;
+              letter-spacing: ($baseline/20);
+              margin: 0 0 ($baseline/4) 0;
               color: $gray-l2;
             }
 
-            .reference-title:first-child {
-              margin-top: 0;
+            .note-comment-p,
+            .note-comment-ul,
+            .note-comment-ol {
+              @extend %t-copy-sub1;
+              @extend %t-weight2;
+              padding: 0;
+              margin: 0;
+              background: transparent;
             }
 
-            .reference-meta {
-              font-weight: $font-regular;
-              color: $m-gray-d2;
+            .note-comment-p {
+              overflow: hidden;
+              text-overflow: ellipsis;
             }
 
-            a.reference-meta {
-              color: $link-color;
-
-              &:hover,
-              &:focus {
-                color: $link-hover;
-              }
+            .note-comment-ul,
+            .note-comment-ol {
+              padding: auto;
+              margin: auto;
             }
           }
         }
       }
+
+      // note reference
+      .reference {
+        @extend %t-copy-sub1;
+        display: inline-block;
+        width: flex-grid(3, 12);
+        vertical-align: top;
+
+        .wrapper-reference-content {
+          padding: 0 $baseline;
+          color: $gray-l2;
+
+          .reference-title {
+            @extend %t-title8;
+            @extend %t-weight3;
+            margin-top: $baseline;
+            text-transform: uppercase;
+            letter-spacing: ($baseline/20);
+            color: $gray-l2;
+
+            // CASE: first reference title of a note
+            &:first-child {
+              margin-top: 0;
+            }
+          }
+
+          .reference-meta {
+            @extend %t-weight2;
+            color: $m-gray-d2;
+          }
+
+          // needed for poor base LMS styling scope
+          a.reference-meta {
+            @extend %shame-link-text;
+          }
+        }
+      }
+
+      // STATE: hover/focus
+      &:hover, &:focus {
+
+        .wrapper-note-excerpts {
+          box-shadow: 0 2px 0 1px $shadow-l2;
+          border-color: $gray-l4;
+        }
+
+        .note-excerpt {
+          background: $student-notes-highlight-color-focus;
+        }
+
+        .note-comment {
+          color: $gray-d2;
+
+        }
+      }
     }
   }
-}
 
-.wrapper-tabs {
+  // +tabbed views
+  // --------------------
+  .wrapper-tabs {
 
-  .tab-panel, .inline-error, .ui-loading {
-    outline: none;
-  }
-
-  .tab-panel.note-group {
-    padding-top: 0;
-  }
-
-  .inline-error {
-    color: $red;
-    border-bottom: 1px solid $red;
-    padding: 0 0 0.5em;
-    margin: 1em 0;
-  }
-
-  .tab-list {
-    @include clearfix();
-    position: relative;
-    top: 2px;
-
-    .tabs-label {
-      @extend %t-copy-base;
-      @include line-height(14);
-      display: inline;
-      margin-bottom: 0;
-      padding: ($baseline/2) $baseline;
-      padding-left: 0;
-      font-weight: $font-bold;
+    .tab-panel, .inline-error, .ui-loading {
+      @extend %no-outline;
     }
 
-    .tabs {
+    .tab-panel.note-group {
+      padding-top: 0;
+    }
+
+    .inline-error {
+      margin: ($baseline/2) 0;
+      border-bottom: 1px solid $red;
+      padding: 0 0 ($baseline/2) 0;
+      color: $red;
+    }
+
+    .tab-list {
       @include clearfix();
-      display: inline;
-      margin: 0;
-      padding: 0;
-      list-style: none;
+      position: relative;
+      top: ($baseline/5);
+
+      .tabs-label {
+        @extend %hd-lv5;
+        display: inline;
+        margin-bottom: 0;
+        padding: ($baseline*0.75) $baseline ($baseline*0.75) 0;
+        color: $gray-l2;
+        font-weight: $font-semibold !important; // needed for poor base LMS styling scope
+      }
+
+      .tabs {
+        @include clearfix();
+        @extend %ui-no-list;
+        display: inline;
+      }
 
       .tab {
+        position: relative;
         display: inline;
 
         .tab-label {
           @include transition(none);
+          @extend %shame-link-base;
           display: inline-block;
-          padding: ($baseline/2) $baseline;
+          vertical-align: middle;
+          padding: ($baseline/2) $baseline ($baseline/2) ($baseline*0.75);
+          text-align: center;
+
+          .icon {
+            margin-right: ($baseline/10);
+          }
         }
 
+        // STATE: active/current tab being viewed
         &.is-active {
 
           .tab-label {
-            color: $gray-d3;
             border-bottom: ($baseline/5) solid $gray-d3;
+            color: $gray-d3;
           }
+        }
+
+        // CASE: tab-label can be closed
+        .action-close {
+          @extend %shame-link-base;
+          position: relative;
+          left: -($baseline*0.75);
+          display: inline-block;
+          vertical-align: middle;
+          border-bottom: ($baseline/5) solid $gray-d3;
+          padding: ($baseline/2);
         }
       }
     }
+  }
+
+  // +search - no results
+  // --------------------
+  // NOTE: not a lot of elements/classes to reference in this DOM
+  #no-results-panel {
+    p {
+      @extend %t-copy-lead1;
+      margin: ($baseline*1.5) 0;
+    }
+  }
+
+  // +search - error
+  // --------------------
+  .wrapper-msg {
+    margin-bottom: $baseline;
   }
 }

--- a/lms/static/sass/course/layout/_calculator.scss
+++ b/lms/static/sass/course/layout/_calculator.scss
@@ -5,7 +5,6 @@ div.calc-main {
   @include transition(bottom 0.75s linear 0s);
   -webkit-appearance: none;
   width: 100%;
-  z-index: 99;
 
   &.open {
     bottom: -36px;
@@ -13,10 +12,11 @@ div.calc-main {
 
   a.calc {
     @include text-hide();
-    background: url("../images/calc-icon.png") rgba(#111, .9) no-repeat center;
+    @include transition(background-color $tmg-f2 ease-in-out 0s);
+    background: url("../images/calc-icon.png") $black-t3 no-repeat center;
     border-bottom: 0;
-    border-radius: 3px 3px 0 0;
-    color: #fff;
+    border-radius: ($baseline/10);
+    color: $white;
     float: right;
     height: 20px;
     display: inline-block;
@@ -27,17 +27,18 @@ div.calc-main {
     width: 16px;
 
     &:hover, &:focus {
-      opacity: 0.8;
+      background-color: $black;
     }
 
     &.closed {
       background-image: url("../images/close-calc-icon.png");
+      background-color: $black;
       top: -36px;
     }
   }
 
   div#calculator_wrapper {
-    background: rgba(#111, .9);
+    background: $black;
     clear: both;
     max-height: 90px;
     position: relative;

--- a/lms/static/sass/course/modules/_calculator.scss
+++ b/lms/static/sass/course/modules/_calculator.scss
@@ -1,3 +1,6 @@
+// LMS -- modules -- calculator
+// ====================
+
 div.calc-main {
   bottom: -126px;
   left: 0;

--- a/lms/static/sass/course/modules/_calculator.scss
+++ b/lms/static/sass/course/modules/_calculator.scss
@@ -13,21 +13,19 @@ div.calc-main {
     bottom: -36px;
   }
 
-  a.calc {
-    @include text-hide();
+  .calc {
     @include transition(background-color $tmg-f2 ease-in-out 0s);
     background: url("../images/calc-icon.png") $black-t3 no-repeat center;
     border-bottom: 0;
     border-radius: ($baseline/10);
     color: $white;
     float: right;
-    height: 20px;
-    display: inline-block;
-    margin-right: 10px;
-    padding: 8px 12px;
+    height: $baseline;
+    margin-right: ($baseline/2);
+    padding: $baseline;
     position: relative;
-    top: -45px;
-    width: 16px;
+    top: -42px;
+    width: ($baseline*0.75);
 
     &:hover, &:focus {
       background-color: $black;

--- a/lms/static/sass/course/modules/_chat.scss
+++ b/lms/static/sass/course/modules/_chat.scss
@@ -1,5 +1,5 @@
-/* Chat
--------------------------------------------------- */
+// LMS -- modules -- chat
+// ====================
 #chat-wrapper {
     position: fixed;
     bottom: 0;

--- a/lms/static/sass/course/modules/_student-notes.scss
+++ b/lms/static/sass/course/modules/_student-notes.scss
@@ -1,0 +1,27 @@
+// LMS -- modules -- student notes
+// ====================
+
+// in this document:
+// --------------------
+// +notes
+// +messages
+// +creating/editing notes
+// +listing notes
+
+// +notes:
+// --------------------
+// this Sass partial contains all of the styling needed for the in-line student notes UI.
+
+// +messages
+// --------------------
+
+// CASE: error in toggling notes
+.edx-notes-visibility {
+
+}
+
+// +creating/editing notes
+// --------------------
+
+// +listing notes
+// --------------------

--- a/lms/static/sass/course/modules/_student-notes.scss
+++ b/lms/static/sass/course/modules/_student-notes.scss
@@ -4,7 +4,7 @@
 // in this document:
 // --------------------
 // +notes
-// +messages
+// +toggling notes
 // +creating/editing notes
 // +listing notes
 
@@ -12,12 +12,51 @@
 // --------------------
 // this Sass partial contains all of the styling needed for the in-line student notes UI.
 
-// +messages
+// +toggling notes
 // --------------------
 
-// CASE: error in toggling notes
 .edx-notes-visibility {
 
+  .edx-notes-visibility-error {
+    @extend %t-copy-sub2;
+    @extend %text-truncated;
+    position: relative;
+    bottom: -($baseline/20); // needed to sync up with current rogue/more complex calc utility alignment
+    max-width: ($baseline*15);
+    display: none;
+    vertical-align: bottom;
+    margin-right: -($baseline/4);
+    border-right: ($baseline/4) solid $error-color;
+    padding: ($baseline/2) $baseline;
+    background: $black-t3;
+    text-align: center;
+    color: $white;
+  }
+
+  // STATE: has error
+  &.has-error {
+
+    .edx-notes-visibility-error {
+      display: inline-block;
+    }
+
+    .utility-control {
+      color: $error-color;
+    }
+  }
+}
+
+// CASE: annotator error in toggling notes (vendor customization)
+.annotator-notice {
+  @extend %t-weight4;
+  @extend %t-copy-sub1;
+  background: $black-t3;
+  padding: ($baseline/4) $baseline;
+}
+
+// vendor customization
+.annotator-notice-error {
+  border-color: $error-color;
 }
 
 // +creating/editing notes

--- a/lms/static/sass/course/modules/_student-notes.scss
+++ b/lms/static/sass/course/modules/_student-notes.scss
@@ -25,8 +25,8 @@
     max-width: ($baseline*15);
     display: none;
     vertical-align: bottom;
-    margin-right: -($baseline/4);
-    border-right: ($baseline/4) solid $error-color;
+    @include margin-right(-($baseline/4));
+    @include border-right(($baseline/4) solid $error-color);
     padding: ($baseline/2) $baseline;
     background: $black-t3;
     text-align: center;

--- a/lms/static/sass/course/modules/_student-notes.scss
+++ b/lms/static/sass/course/modules/_student-notes.scss
@@ -54,6 +54,15 @@
   padding: ($baseline/4) $baseline;
 }
 
+// CASE: annotator error in toggling notes
+// vendor customization
+.annotator-notice {
+  @extend %t-weight4;
+  @extend %t-copy-sub1;
+  background: $gray-d4;
+  padding: ($baseline/2) $baseline;
+}
+
 // vendor customization
 .annotator-notice-error {
   border-color: $error-color;

--- a/lms/static/sass/course/modules/_timer.scss
+++ b/lms/static/sass/course/modules/_timer.scss
@@ -1,3 +1,6 @@
+// LMS -- modules -- student notes
+// ====================
+
 div.timer-main {
   position: fixed;
   z-index: 99;

--- a/lms/static/sass/elements/_navigation.scss
+++ b/lms/static/sass/elements/_navigation.scss
@@ -1,0 +1,62 @@
+// LMS -- elements -- navigation
+// ====================
+
+// in this document:
+// --------------------
+// +notes
+// +skip navigation
+// +utility navigation
+
+// +notes:
+// --------------------
+// this Sass partial should have its contents eventually abstracted out so that onboarding/non-coureware navigation is separate from in course-based navigation systems
+
+
+// +skip navigation
+// --------------------
+%nav-skip {
+  @extend %text-sr;
+}
+
+.nav-contents, .nav-skip {
+  @extend %nav-skip;
+}
+
+// +utility navigation (course utiltiies)
+// --------------------
+.nav-utilities {
+  @extend %ui-depth3;
+  position: fixed;
+  right: ($baseline*2.25);
+  bottom: 0;
+
+
+  .wrapper-utility {
+    @extend %wipe-last-child;
+    display: inline-block;
+    vertical-align: middle;
+    margin-right: ($baseline/2);
+  }
+
+  .utility-control {
+    @include transition(background-color $tmg-f2 ease-in-out 0s);
+    position: relative;
+    bottom: -6px; // needed to sync up with current rogue/more complex calc utility alignment
+    display: inline-block;
+    vertical-align: middle;
+    border-radius: ($baseline/10);
+    padding: ($baseline/2) ($baseline*0.75) ($baseline*0.75) ($baseline*0.75);
+    background: $black-t3;
+    color: $white;
+
+    // STATE: hover/active
+    &:hover, &:active {
+      background: $black;
+    }
+
+    // STATE: is active/in use
+    &.is-active {
+      background: red;
+    }
+  }
+}

--- a/lms/static/sass/elements/_navigation.scss
+++ b/lms/static/sass/elements/_navigation.scss
@@ -34,7 +34,7 @@
   .wrapper-utility {
     @extend %wipe-last-child;
     display: inline-block;
-    vertical-align: middle;
+    vertical-align: bottom;
     margin-right: ($baseline/2);
   }
 

--- a/lms/static/sass/elements/_navigation.scss
+++ b/lms/static/sass/elements/_navigation.scss
@@ -56,7 +56,7 @@
 
     // STATE: is active/in use
     &.is-active {
-      background: red;
+      background: $active-color;
     }
   }
 }

--- a/lms/static/sass/elements/_navigation.scss
+++ b/lms/static/sass/elements/_navigation.scss
@@ -30,7 +30,6 @@
   @include right($baseline*2.25);
   bottom: 0;
 
-
   .wrapper-utility {
     @extend %wipe-last-child;
     display: inline-block;
@@ -57,6 +56,21 @@
     // STATE: is active/in use
     &.is-active {
       background: $active-color;
+    }
+  }
+
+  // specific reset styling for any controls that are button elements
+  .utility-control-button {
+    border: none;
+    box-shadow: none;
+    text-shadow: none;
+    font-size: inherit;
+    font-weight: inherit;
+
+    // STATE: hover/active
+    &:hover, &:active, &:focus {
+      border: none;
+      box-shadow: none;
     }
   }
 }

--- a/lms/static/sass/elements/_navigation.scss
+++ b/lms/static/sass/elements/_navigation.scss
@@ -27,7 +27,7 @@
 .nav-utilities {
   @extend %ui-depth3;
   position: fixed;
-  right: ($baseline*2.25);
+  @include right($baseline*2.25);
   bottom: 0;
 
 
@@ -35,7 +35,7 @@
     @extend %wipe-last-child;
     display: inline-block;
     vertical-align: bottom;
-    margin-right: ($baseline/2);
+    @include margin-right($baseline/2);
   }
 
   .utility-control {

--- a/lms/static/sass/elements/_system-feedback.scss
+++ b/lms/static/sass/elements/_system-feedback.scss
@@ -120,6 +120,10 @@
     border-top: 3px solid $alert-color;
   }
 
+  &.error {
+    border-top: 3px solid $error-color;
+  }
+
   &.warning {
     border-top: 3px solid $warning-color;
   }

--- a/lms/static/sass/elements/_typography.scss
+++ b/lms/static/sass/elements/_typography.scss
@@ -176,11 +176,11 @@
 
 // typography weights
 %t-weight1 {
-  font-weight: 300;
+  font-weight: $font-light;
 }
 
 %t-weight2 {
-  font-weight: 400;
+  font-weight: $font-regular;
 }
 
 %t-weight3 {
@@ -188,11 +188,11 @@
 }
 
 %t-weight4 {
-  font-weight: 600;
+  font-weight: $font-semibold;
 }
 
 %t-weight5 {
-  font-weight: 700;
+  font-weight: $font-bold;
 }
 
 // ====================

--- a/lms/templates/calculator/toggle_calculator.html
+++ b/lms/templates/calculator/toggle_calculator.html
@@ -1,0 +1,124 @@
+<%! from django.utils.translation import ugettext as _ %>
+<%! from django.core.urlresolvers import reverse %>
+
+<div class="calc-main">
+    <a title="${_('Open Calculator')}" href="#" role="button" aria-controls="calculator_wrapper" aria-expanded="false" class="calc">${_("Open Calculator")}</a>
+
+    <div id="calculator_wrapper">
+      <form id="calculator">
+        <div class="input-wrapper">
+          <input type="text" id="calculator_input" title="${_('Calculator Input Field')}" tabindex="-1" />
+
+          <div class="help-wrapper">
+            <p class="sr" id="hint-instructions">${_('Use the arrow keys to navigate the tips or use the tab key to return to the calculator')}</p>
+
+            <a id="calculator_hint" href="#" role="button" aria-haspopup="true" tabindex="-1" aria-describedby="hint-instructions">${_("Hints")}</a>
+
+            <ul id="calculator_input_help" class="help" aria-activedescendant="hint-moreinfo" role="tooltip" aria-hidden="true">
+              <li class="hint-item" id="hint-moreinfo" tabindex="-1">
+                <p><span class="bold">${_("For detailed information, see <a href='http://edx-guide-for-students.readthedocs.org/en/latest/SFD_mathformatting.html'>Entering Mathematical and Scientific Expressions</a> in the <a href='http://edx-guide-for-students.readthedocs.org/en/latest/index.html'>edX Guide for Students</a>.")}</span></p>
+              </li>
+
+              <li class="hint-item" id="hint-tips" tabindex="-1"><p><span class="bold">${_("Tips")}:</span> </p>
+                <ul>
+                  <li class="hint-item" id="hint-paren" tabindex="-1"><p>Use parentheses () to make expressions clear. You can use parentheses inside other parentheses.</p></li>
+                  <li class="hint-item" id="hint-spaces" tabindex="-1"><p>Do not use spaces in expressions.</p></li>
+                  <li class="hint-item" id="hint-howto-constants" tabindex="-1"><p>For constants, indicate multiplication explicitly (example: 5*c).</p></li>
+                  <li class="hint-item" id="hint-howto-maffixes" tabindex="-1"><p>For affixes, type the number and affix without a space (example: 5c).</p></li>
+                  <li class="hint-item" id="hint-howto-functions" tabindex="-1"><p>For functions, type the name of the function, then the expression in parentheses.</p></li>
+                </ul>
+              </li>
+
+              <li class="hint-item" id="hint-list" tabindex="-1">
+                <table class="calculator-input-help-table">
+                  <tbody>
+                    <tr>
+                      <th scope="col">${_("To Use")}</th>
+                      <th scope="col">${_("Type")}</th>
+                      <th scope="col">${_("Examples")}</th>
+                    </tr>
+                    <tr>
+                      <th scope="row">${_("Numbers")}</th>
+                      <td>Integers<br />
+                        Fractions<br />
+                        Decimals
+                      </td>
+                      <td>2520<br />
+                        2/3<br />
+                        3.14, .98
+                      </td>
+                    </tr>
+                    <tr>
+                      <th scope="row">${_("Operators")}</th>
+                      <td>+ - * / (add, subtract, multiply, divide)<br />
+                        ^ (raise to a power)<br />
+                        _ (add a subscript)<br />
+                        || (parallel resistors)
+                      </td>
+                      <td>x+(2*y)/x-1
+                        x^(n+1)<br />
+                        v_IN+v_OUT<br />
+                        1||2
+                      </td>
+                    </tr>
+                    <tr>
+                      <th scope="row">${_("Greek letters")}</th>
+                      <td>Name of letter</td>
+                      <td>alpha<br />
+                        lambda
+                      </td>
+                    </tr>
+                    <tr>
+                      <th scope="row">${_("Constants")}</th>
+                      <td>c, e, g, i, j, k, pi, q, T</td>
+                      <td>20*c<br />
+                        418*T
+                      </td>
+                    </tr>
+                    <tr>
+                      <th scope="row">${_("Affixes")}</th>
+                      <td>Percent sign (%) and metric affixes (d, c, m, u, n, p, k, M, G, T)</td>
+                      <td>20%<br />
+                        20c<br />
+                        418T
+                      </td>
+                    </tr>
+                    <tr>
+                      <th scope="row">${_("Basic functions")}</th>
+                      <td>abs, exp, fact or factorial, ln, log2, log10, sqrt</td>
+                      <td>abs(x+y)<br />
+                        sqrt(x^2-y)
+                      </td>
+                    </tr>
+                    <tr>
+                      <th scope="row">${_("Trigonometric functions")}</th>
+                      <td>sin, cos, tan, sec, csc, cot<br />
+                        arcsin, sinh, arcsinh, etc.<br />
+                      </td>
+                      <td>sin(4x+y)<br />
+                        arccsch(4x+y)
+                      </td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <th scope="row">${_("Scientific notation")}</th>
+                      <td>10^ and the exponent</td>
+                      <td>10^-9</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">${_("e notation")}</th>
+                      <td>1e and the exponent</td>
+                      <td>1e-9</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </li>
+            </ul>
+          </div>
+        </div>
+
+        <input id="calculator_button" type="submit" title="${_('Calculate')}" value="=" aria-label="${_('Calculate')}" value="=" tabindex="-1" />
+        <input type="text" id="calculator_output" title="${_('Calculator Output Field')}" readonly tabindex="-1" />
+      </form>
+    </div>
+  </div>

--- a/lms/templates/calculator/toggle_calculator.html
+++ b/lms/templates/calculator/toggle_calculator.html
@@ -16,16 +16,20 @@
 
             <ul id="calculator_input_help" class="help" aria-activedescendant="hint-moreinfo" role="tooltip" aria-hidden="true">
               <li class="hint-item" id="hint-moreinfo" tabindex="-1">
-                <p><span class="bold">${_("For detailed information, see <a href='http://edx-guide-for-students.readthedocs.org/en/latest/SFD_mathformatting.html'>Entering Mathematical and Scientific Expressions</a> in the <a href='http://edx-guide-for-students.readthedocs.org/en/latest/index.html'>edX Guide for Students</a>.")}</span></p>
+                <p><span class="bold">
+                  ${_("For detailed information, see {link_mathexpressions_start}Entering Mathematical and Scientific Expressions{link_mathexpressions_end} in the {link_studentguide_start}edX Guide for Students{link_studentguide_end}.format(
+                    link_mathexpressions_start='<a href="http://edx-guide-for-students.readthedocs.org/en/latest/SFD_mathformatting.html">', link_mathexpressions_end="</a>,
+                    link_studentguide_start='<a href="hhttp://edx-guide-for-students.readthedocs.org/en/latest/index.html">', link_studentguide_end="</a>"
+                </span></p>
               </li>
 
               <li class="hint-item" id="hint-tips" tabindex="-1"><p><span class="bold">${_("Tips")}:</span> </p>
                 <ul>
-                  <li class="hint-item" id="hint-paren" tabindex="-1"><p>Use parentheses () to make expressions clear. You can use parentheses inside other parentheses.</p></li>
-                  <li class="hint-item" id="hint-spaces" tabindex="-1"><p>Do not use spaces in expressions.</p></li>
-                  <li class="hint-item" id="hint-howto-constants" tabindex="-1"><p>For constants, indicate multiplication explicitly (example: 5*c).</p></li>
-                  <li class="hint-item" id="hint-howto-maffixes" tabindex="-1"><p>For affixes, type the number and affix without a space (example: 5c).</p></li>
-                  <li class="hint-item" id="hint-howto-functions" tabindex="-1"><p>For functions, type the name of the function, then the expression in parentheses.</p></li>
+                  <li class="hint-item" id="hint-paren" tabindex="-1"><p>${_("Use parentheses () to make expressions clear. You can use parentheses inside other parentheses.")}</p></li>
+                  <li class="hint-item" id="hint-spaces" tabindex="-1"><p>${_("Do not use spaces in expressions.")}</p></li>
+                  <li class="hint-item" id="hint-howto-constants" tabindex="-1"><p>${_("For constants, indicate multiplication explicitly (example: 5*c).")}</p></li>
+                  <li class="hint-item" id="hint-howto-maffixes" tabindex="-1"><p>${_("For affixes, type the number and affix without a space (example: 5c).")}</p></li>
+                  <li class="hint-item" id="hint-howto-functions" tabindex="-1"><p>${_("For functions, type the name of the function, then the expression in parentheses.")}</p></li>
                 </ul>
               </li>
 
@@ -39,9 +43,9 @@
                     </tr>
                     <tr>
                       <th scope="row">${_("Numbers")}</th>
-                      <td>Integers<br />
-                        Fractions<br />
-                        Decimals
+                      <td>${_("Integers")}<br />
+                        ${_("Fractions")}<br />
+                        ${_("Decimals")}
                       </td>
                       <td>2520<br />
                         2/3<br />
@@ -50,10 +54,14 @@
                     </tr>
                     <tr>
                       <th scope="row">${_("Operators")}</th>
-                      <td>+ - * / (add, subtract, multiply, divide)<br />
-                        ^ (raise to a power)<br />
-                        _ (add a subscript)<br />
-                        || (parallel resistors)
+                      ## Translators: Please do not translate mathematical symbols.
+                      <td>${_("+ - * / (add, subtract, multiply, divide)")}<br />
+                        ## Translators: Please do not translate mathematical symbols.
+                        ${_("^ (raise to a power)")}<br />
+                        ## Translators: Please do not translate mathematical symbols.
+                        ${_("_ (add a subscript)")}<br />
+                        ## Translators: Please do not translate mathematical symbols.
+                        ${_("|| (parallel resistors)")}
                       </td>
                       <td>x+(2*y)/x-1
                         x^(n+1)<br />
@@ -63,7 +71,7 @@
                     </tr>
                     <tr>
                       <th scope="row">${_("Greek letters")}</th>
-                      <td>Name of letter</td>
+                      <td>${_("Name of letter")}</td>
                       <td>alpha<br />
                         lambda
                       </td>
@@ -77,7 +85,7 @@
                     </tr>
                     <tr>
                       <th scope="row">${_("Affixes")}</th>
-                      <td>Percent sign (%) and metric affixes (d, c, m, u, n, p, k, M, G, T)</td>
+                      <td>${_("Percent sign (%) and metric affixes (d, c, m, u, n, p, k, M, G, T)")}</td>
                       <td>20%<br />
                         20c<br />
                         418T
@@ -101,13 +109,17 @@
                       <td></td>
                     </tr>
                     <tr>
+                      ## Translators: Please see http://en.wikipedia.org/wiki/Scientific_notation
                       <th scope="row">${_("Scientific notation")}</th>
-                      <td>10^ and the exponent</td>
+                      ## Translators: 10^ is a mathematical symbol. Please do not translate.
+                      <td>${_("10^ and the exponent")}</td>
                       <td>10^-9</td>
                     </tr>
                     <tr>
+                      ## Translators: this is part of scientific notation. Please see http://en.wikipedia.org/wiki/Scientific_notation#E_notation
                       <th scope="row">${_("e notation")}</th>
-                      <td>1e and the exponent</td>
+                      ## Translators: 1e is a mathematical symbol. Please do not translate.
+                      <td>${_("1e and the exponent")}</td>
                       <td>1e-9</td>
                     </tr>
                   </tbody>

--- a/lms/templates/calculator/toggle_calculator.html
+++ b/lms/templates/calculator/toggle_calculator.html
@@ -17,9 +17,11 @@
             <ul id="calculator_input_help" class="help" aria-activedescendant="hint-moreinfo" role="tooltip" aria-hidden="true">
               <li class="hint-item" id="hint-moreinfo" tabindex="-1">
                 <p><span class="bold">
-                  ${_("For detailed information, see {link_mathexpressions_start}Entering Mathematical and Scientific Expressions{link_mathexpressions_end} in the {link_studentguide_start}edX Guide for Students{link_studentguide_end}.format(
-                    link_mathexpressions_start='<a href="http://edx-guide-for-students.readthedocs.org/en/latest/SFD_mathformatting.html">', link_mathexpressions_end="</a>,
-                    link_studentguide_start='<a href="hhttp://edx-guide-for-students.readthedocs.org/en/latest/index.html">', link_studentguide_end="</a>"
+                  ${_("For detailed information, see {link_mathexpressions_start}Entering Mathematical and Scientific Expressions{link_mathexpressions_end} in the {link_studentguide_start}edX Guide for Students{link_studentguide_end}").format(
+                      link_mathexpressions_start='<a href="http://edx-guide-for-students.readthedocs.org/en/latest/SFD_mathformatting.html">',
+                      link_mathexpressions_end="</a>",
+                      link_studentguide_start='<a href="http://edx-guide-for-students.readthedocs.org/en/latest/index.html">',
+                      link_studentguide_end="</a>")}
                 </span></p>
               </li>
 

--- a/lms/templates/calculator/toggle_calculator.html
+++ b/lms/templates/calculator/toggle_calculator.html
@@ -2,137 +2,143 @@
 <%! from django.core.urlresolvers import reverse %>
 
 <div class="calc-main">
-    <a title="${_('Open Calculator')}" href="#" role="button" aria-controls="calculator_wrapper" aria-expanded="false" class="calc">${_("Open Calculator")}</a>
+  <button title="${_('Open Calculator')}" aria-controls="calculator_wrapper" aria-expanded="false" class="calc utility-control-button">
+    <span class="utility-control-label sr">${_("Open Calculator")}</span>
+  </button>
 
-    <div id="calculator_wrapper">
-      <form id="calculator">
-        <div class="input-wrapper">
-          <input type="text" id="calculator_input" title="${_('Calculator Input Field')}" tabindex="-1" />
+  <div id="calculator_wrapper">
+    <form id="calculator">
+      <div class="input-wrapper">
+        <input type="text" id="calculator_input" title="${_('Calculator Input Field')}" tabindex="-1" />
 
-          <div class="help-wrapper">
-            <p class="sr" id="hint-instructions">${_('Use the arrow keys to navigate the tips or use the tab key to return to the calculator')}</p>
+        <div class="help-wrapper">
+          <p class="sr" id="hint-instructions">${_('Use the arrow keys to navigate the tips or use the tab key to return to the calculator')}</p>
 
-            <a id="calculator_hint" href="#" role="button" aria-haspopup="true" tabindex="-1" aria-describedby="hint-instructions">${_("Hints")}</a>
+          <a id="calculator_hint" href="#" role="button" aria-haspopup="true" tabindex="-1" aria-describedby="hint-instructions">${_("Hints")}</a>
 
-            <ul id="calculator_input_help" class="help" aria-activedescendant="hint-moreinfo" role="tooltip" aria-hidden="true">
-              <li class="hint-item" id="hint-moreinfo" tabindex="-1">
-                <p><span class="bold">
-                  ${_("For detailed information, see {link_mathexpressions_start}Entering Mathematical and Scientific Expressions{link_mathexpressions_end} in the {link_studentguide_start}edX Guide for Students{link_studentguide_end}").format(
+          <ul id="calculator_input_help" class="help" aria-activedescendant="hint-moreinfo" role="tooltip" aria-hidden="true">
+            <li class="hint-item" id="hint-moreinfo" tabindex="-1">
+              <p><span class="bold">
+                ${_(
+                    "For detailed information, see {link_mathexpressions_start}Entering Mathematical and Scientific Expressions{link_mathexpressions_end} in the {link_studentguide_start}edX Guide for Students{link_studentguide_end}"
+                    ).format(
                       link_mathexpressions_start='<a href="http://edx-guide-for-students.readthedocs.org/en/latest/SFD_mathformatting.html">',
                       link_mathexpressions_end="</a>",
                       link_studentguide_start='<a href="http://edx-guide-for-students.readthedocs.org/en/latest/index.html">',
-                      link_studentguide_end="</a>")}
-                </span></p>
-              </li>
+                      link_studentguide_end="</a>"
+                    )
+                 }
+              </span></p>
+            </li>
 
-              <li class="hint-item" id="hint-tips" tabindex="-1"><p><span class="bold">${_("Tips")}:</span> </p>
-                <ul>
-                  <li class="hint-item" id="hint-paren" tabindex="-1"><p>${_("Use parentheses () to make expressions clear. You can use parentheses inside other parentheses.")}</p></li>
-                  <li class="hint-item" id="hint-spaces" tabindex="-1"><p>${_("Do not use spaces in expressions.")}</p></li>
-                  <li class="hint-item" id="hint-howto-constants" tabindex="-1"><p>${_("For constants, indicate multiplication explicitly (example: 5*c).")}</p></li>
-                  <li class="hint-item" id="hint-howto-maffixes" tabindex="-1"><p>${_("For affixes, type the number and affix without a space (example: 5c).")}</p></li>
-                  <li class="hint-item" id="hint-howto-functions" tabindex="-1"><p>${_("For functions, type the name of the function, then the expression in parentheses.")}</p></li>
-                </ul>
-              </li>
+            <li class="hint-item" id="hint-tips" tabindex="-1"><p><span class="bold">${_("Tips")}:</span> </p>
+              <ul>
+                <li class="hint-item" id="hint-paren" tabindex="-1"><p>${_("Use parentheses () to make expressions clear. You can use parentheses inside other parentheses.")}</p></li>
+                <li class="hint-item" id="hint-spaces" tabindex="-1"><p>${_("Do not use spaces in expressions.")}</p></li>
+                <li class="hint-item" id="hint-howto-constants" tabindex="-1"><p>${_("For constants, indicate multiplication explicitly (example: 5*c).")}</p></li>
+                <li class="hint-item" id="hint-howto-maffixes" tabindex="-1"><p>${_("For affixes, type the number and affix without a space (example: 5c).")}</p></li>
+                <li class="hint-item" id="hint-howto-functions" tabindex="-1"><p>${_("For functions, type the name of the function, then the expression in parentheses.")}</p></li>
+              </ul>
+            </li>
 
-              <li class="hint-item" id="hint-list" tabindex="-1">
-                <table class="calculator-input-help-table">
-                  <tbody>
-                    <tr>
-                      <th scope="col">${_("To Use")}</th>
-                      <th scope="col">${_("Type")}</th>
-                      <th scope="col">${_("Examples")}</th>
-                    </tr>
-                    <tr>
-                      <th scope="row">${_("Numbers")}</th>
-                      <td>${_("Integers")}<br />
-                        ${_("Fractions")}<br />
-                        ${_("Decimals")}
-                      </td>
-                      <td>2520<br />
-                        2/3<br />
-                        3.14, .98
-                      </td>
-                    </tr>
-                    <tr>
-                      <th scope="row">${_("Operators")}</th>
+            <li class="hint-item" id="hint-list" tabindex="-1">
+              <table class="calculator-input-help-table">
+                <tbody>
+                  <tr>
+                    <th scope="col">${_("To Use")}</th>
+                    <th scope="col">${_("Type")}</th>
+                    <th scope="col">${_("Examples")}</th>
+                  </tr>
+                  <tr>
+                    <th scope="row">${_("Numbers")}</th>
+                    <td>${_("Integers")}<br />
+                      ${_("Fractions")}<br />
+                      ${_("Decimals")}
+                    </td>
+                    <td>2520<br />
+                      2/3<br />
+                      3.14, .98
+                    </td>
+                  </tr>
+                  <tr>
+                    <th scope="row">${_("Operators")}</th>
+                    ## Translators: Please do not translate mathematical symbols.
+                    <td>${_("+ - * / (add, subtract, multiply, divide)")}<br />
                       ## Translators: Please do not translate mathematical symbols.
-                      <td>${_("+ - * / (add, subtract, multiply, divide)")}<br />
-                        ## Translators: Please do not translate mathematical symbols.
-                        ${_("^ (raise to a power)")}<br />
-                        ## Translators: Please do not translate mathematical symbols.
-                        ${_("_ (add a subscript)")}<br />
-                        ## Translators: Please do not translate mathematical symbols.
-                        ${_("|| (parallel resistors)")}
-                      </td>
-                      <td>x+(2*y)/x-1
-                        x^(n+1)<br />
-                        v_IN+v_OUT<br />
-                        1||2
-                      </td>
-                    </tr>
-                    <tr>
-                      <th scope="row">${_("Greek letters")}</th>
-                      <td>${_("Name of letter")}</td>
-                      <td>alpha<br />
-                        lambda
-                      </td>
-                    </tr>
-                    <tr>
-                      <th scope="row">${_("Constants")}</th>
-                      <td>c, e, g, i, j, k, pi, q, T</td>
-                      <td>20*c<br />
-                        418*T
-                      </td>
-                    </tr>
-                    <tr>
-                      <th scope="row">${_("Affixes")}</th>
-                      <td>${_("Percent sign (%) and metric affixes (d, c, m, u, n, p, k, M, G, T)")}</td>
-                      <td>20%<br />
-                        20c<br />
-                        418T
-                      </td>
-                    </tr>
-                    <tr>
-                      <th scope="row">${_("Basic functions")}</th>
-                      <td>abs, exp, fact or factorial, ln, log2, log10, sqrt</td>
-                      <td>abs(x+y)<br />
-                        sqrt(x^2-y)
-                      </td>
-                    </tr>
-                    <tr>
-                      <th scope="row">${_("Trigonometric functions")}</th>
-                      <td>sin, cos, tan, sec, csc, cot<br />
-                        arcsin, sinh, arcsinh, etc.<br />
-                      </td>
-                      <td>sin(4x+y)<br />
-                        arccsch(4x+y)
-                      </td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      ## Translators: Please see http://en.wikipedia.org/wiki/Scientific_notation
-                      <th scope="row">${_("Scientific notation")}</th>
-                      ## Translators: 10^ is a mathematical symbol. Please do not translate.
-                      <td>${_("10^ and the exponent")}</td>
-                      <td>10^-9</td>
-                    </tr>
-                    <tr>
-                      ## Translators: this is part of scientific notation. Please see http://en.wikipedia.org/wiki/Scientific_notation#E_notation
-                      <th scope="row">${_("e notation")}</th>
-                      ## Translators: 1e is a mathematical symbol. Please do not translate.
-                      <td>${_("1e and the exponent")}</td>
-                      <td>1e-9</td>
-                    </tr>
-                  </tbody>
-                </table>
-              </li>
-            </ul>
-          </div>
+                      ${_("^ (raise to a power)")}<br />
+                      ## Translators: Please do not translate mathematical symbols.
+                      ${_("_ (add a subscript)")}<br />
+                      ## Translators: Please do not translate mathematical symbols.
+                      ${_("|| (parallel resistors)")}
+                    </td>
+                    <td>x+(2*y)/x-1
+                      x^(n+1)<br />
+                      v_IN+v_OUT<br />
+                      1||2
+                    </td>
+                  </tr>
+                  <tr>
+                    <th scope="row">${_("Greek letters")}</th>
+                    <td>${_("Name of letter")}</td>
+                    <td>alpha<br />
+                      lambda
+                    </td>
+                  </tr>
+                  <tr>
+                    <th scope="row">${_("Constants")}</th>
+                    <td>c, e, g, i, j, k, pi, q, T</td>
+                    <td>20*c<br />
+                      418*T
+                    </td>
+                  </tr>
+                  <tr>
+                    <th scope="row">${_("Affixes")}</th>
+                    <td>${_("Percent sign (%) and metric affixes (d, c, m, u, n, p, k, M, G, T)")}</td>
+                    <td>20%<br />
+                      20c<br />
+                      418T
+                    </td>
+                  </tr>
+                  <tr>
+                    <th scope="row">${_("Basic functions")}</th>
+                    <td>abs, exp, fact or factorial, ln, log2, log10, sqrt</td>
+                    <td>abs(x+y)<br />
+                      sqrt(x^2-y)
+                    </td>
+                  </tr>
+                  <tr>
+                    <th scope="row">${_("Trigonometric functions")}</th>
+                    <td>sin, cos, tan, sec, csc, cot<br />
+                      arcsin, sinh, arcsinh, etc.<br />
+                    </td>
+                    <td>sin(4x+y)<br />
+                      arccsch(4x+y)
+                    </td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    ## Translators: Please see http://en.wikipedia.org/wiki/Scientific_notation
+                    <th scope="row">${_("Scientific notation")}</th>
+                    ## Translators: 10^ is a mathematical symbol. Please do not translate.
+                    <td>${_("10^ and the exponent")}</td>
+                    <td>10^-9</td>
+                  </tr>
+                  <tr>
+                    ## Translators: this is part of scientific notation. Please see http://en.wikipedia.org/wiki/Scientific_notation#E_notation
+                    <th scope="row">${_("e notation")}</th>
+                    ## Translators: 1e is a mathematical symbol. Please do not translate.
+                    <td>${_("1e and the exponent")}</td>
+                    <td>1e-9</td>
+                  </tr>
+                </tbody>
+              </table>
+            </li>
+          </ul>
         </div>
+      </div>
 
-        <input id="calculator_button" type="submit" title="${_('Calculate')}" value="=" aria-label="${_('Calculate')}" value="=" tabindex="-1" />
-        <input type="text" id="calculator_output" title="${_('Calculator Output Field')}" readonly tabindex="-1" />
-      </form>
-    </div>
+      <input id="calculator_button" type="submit" title="${_('Calculate')}" value="=" aria-label="${_('Calculate')}" value="=" tabindex="-1" />
+      <input type="text" id="calculator_output" title="${_('Calculator Output Field')}" readonly tabindex="-1" />
+    </form>
+  </div>
   </div>

--- a/lms/templates/chat/toggle_chat.html
+++ b/lms/templates/chat/toggle_chat.html
@@ -1,0 +1,13 @@
+<%! from django.utils.translation import ugettext as _ %>
+<%! from django.core.urlresolvers import reverse %>
+
+<div id="chat-wrapper">
+  <div id="chat-toggle" class="closed">
+    <span id="chat-open">Open Chat <em class="icon-chevron-up"></em></span>
+    <span id="chat-close">Close Chat <em class="icon-chevron-down"></em></span>
+  </div>
+  <div id="chat-block">
+    ## The Candy.js plugin wants to render in an element with #candy
+    <div id="candy"></div>
+  </div>
+</div>

--- a/lms/templates/chat/toggle_chat.html
+++ b/lms/templates/chat/toggle_chat.html
@@ -3,8 +3,8 @@
 
 <div id="chat-wrapper">
   <div id="chat-toggle" class="closed">
-    <span id="chat-open">Open Chat <em class="icon-chevron-up"></em></span>
-    <span id="chat-close">Close Chat <em class="icon-chevron-down"></em></span>
+    <span id="chat-open">${_('Open Chat')} <em class="icon-chevron-up"></em></span>
+    <span id="chat-close">${_('Close Chat')} <em class="icon-chevron-down"></em></span>
   </div>
   <div id="chat-block">
     ## The Candy.js plugin wants to render in an element with #candy

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -211,148 +211,27 @@ ${fragment.foot_html()}
 
     <section class="course-content" id="course-content">
       ${fragment.body_html()}
-      % if is_edxnotes_enabled(course):
-        <%include file="/edxnotes/toggle_notes.html" args="course=course"/>
-      % endif
     </section>
   </div>
 </div>
 
-% if show_chat:
-  <div id="chat-wrapper">
-    <div id="chat-toggle" class="closed">
-      <span id="chat-open">Open Chat <em class="icon-chevron-up"></em></span>
-      <span id="chat-close">Close Chat <em class="icon-chevron-down"></em></span>
-    </div>
-    <div id="chat-block">
-      ## The Candy.js plugin wants to render in an element with #candy
-      <div id="candy"></div>
-    </div>
-  </div>
-% endif
+<nav class="nav-utilities">
+  <h2 class="sr nav-utilities-title">Course Utilities Navigation</h2>
 
-% if course.show_calculator:
-  <div class="calc-main">
-    <a title="${_('Open Calculator')}" href="#" role="button" aria-controls="calculator_wrapper" aria-expanded="false" class="calc">${_("Open Calculator")}</a>
+  ## Utility: Chat
+  % if show_chat:
+    <%include file="/chat/toggle_chat.html" />
+  % endif
 
-    <div id="calculator_wrapper">
-      <form id="calculator">
-        <div class="input-wrapper">
-          <input type="text" id="calculator_input" title="${_('Calculator Input Field')}" tabindex="-1" />
+  ## Utility: Notes
+  % if is_edxnotes_enabled(course):
+    <%include file="/edxnotes/toggle_notes.html" args="course=course"/>
+  % endif
 
-          <div class="help-wrapper">
-            <p class="sr" id="hint-instructions">${_('Use the arrow keys to navigate the tips or use the tab key to return to the calculator')}</p>
+  ## Utility: Calc
+  % if course.show_calculator:
+    <%include file="/calculator/toggle_calculator.html" />
+  % endif
+</nav>
 
-            <a id="calculator_hint" href="#" role="button" aria-haspopup="true" tabindex="-1" aria-describedby="hint-instructions">${_("Hints")}</a>
-
-            <ul id="calculator_input_help" class="help" aria-activedescendant="hint-moreinfo" role="tooltip" aria-hidden="true">
-              <li class="hint-item" id="hint-moreinfo" tabindex="-1">
-                <p><span class="bold">${_("For detailed information, see <a href='http://edx-guide-for-students.readthedocs.org/en/latest/SFD_mathformatting.html'>Entering Mathematical and Scientific Expressions</a> in the <a href='http://edx-guide-for-students.readthedocs.org/en/latest/index.html'>edX Guide for Students</a>.")}</span></p>
-              </li>
-
-              <li class="hint-item" id="hint-tips" tabindex="-1"><p><span class="bold">${_("Tips")}:</span> </p>
-                <ul>
-                  <li class="hint-item" id="hint-paren" tabindex="-1"><p>Use parentheses () to make expressions clear. You can use parentheses inside other parentheses.</p></li>
-                  <li class="hint-item" id="hint-spaces" tabindex="-1"><p>Do not use spaces in expressions.</p></li>
-                  <li class="hint-item" id="hint-howto-constants" tabindex="-1"><p>For constants, indicate multiplication explicitly (example: 5*c).</p></li>
-                  <li class="hint-item" id="hint-howto-maffixes" tabindex="-1"><p>For affixes, type the number and affix without a space (example: 5c).</p></li>
-                  <li class="hint-item" id="hint-howto-functions" tabindex="-1"><p>For functions, type the name of the function, then the expression in parentheses.</p></li>
-                </ul>
-              </li>
-
-              <li class="hint-item" id="hint-list" tabindex="-1">
-                <table class="calculator-input-help-table">
-                  <tbody>
-                    <tr>
-                      <th scope="col">${_("To Use")}</th>
-                      <th scope="col">${_("Type")}</th>
-                      <th scope="col">${_("Examples")}</th>
-                    </tr>
-                    <tr>
-                      <th scope="row">${_("Numbers")}</th>
-                      <td>Integers<br />
-                        Fractions<br />
-                        Decimals
-                      </td>
-                      <td>2520<br />
-                        2/3<br />
-                        3.14, .98
-                      </td>
-                    </tr>
-                    <tr>
-                      <th scope="row">${_("Operators")}</th>
-                      <td>+ - * / (add, subtract, multiply, divide)<br />
-                        ^ (raise to a power)<br />
-                        _ (add a subscript)<br />
-                        || (parallel resistors)
-                      </td>
-                      <td>x+(2*y)/x-1
-                        x^(n+1)<br />
-                        v_IN+v_OUT<br />
-                        1||2
-                      </td>
-                    </tr>
-                    <tr>
-                      <th scope="row">${_("Greek letters")}</th>
-                      <td>Name of letter</td>
-                      <td>alpha<br />
-                        lambda
-                      </td>
-                    </tr>
-                    <tr>
-                      <th scope="row">${_("Constants")}</th>
-                      <td>c, e, g, i, j, k, pi, q, T</td>
-                      <td>20*c<br />
-                        418*T
-                      </td>
-                    </tr>
-                    <tr>
-                      <th scope="row">${_("Affixes")}</th>
-                      <td>Percent sign (%) and metric affixes (d, c, m, u, n, p, k, M, G, T)</td>
-                      <td>20%<br />
-                        20c<br />
-                        418T
-                      </td>
-                    </tr>
-                    <tr>
-                      <th scope="row">${_("Basic functions")}</th>
-                      <td>abs, exp, fact or factorial, ln, log2, log10, sqrt</td>
-                      <td>abs(x+y)<br />
-                        sqrt(x^2-y)
-                      </td>
-                    </tr>
-                    <tr>
-                      <th scope="row">${_("Trigonometric functions")}</th>
-                      <td>sin, cos, tan, sec, csc, cot<br />
-                        arcsin, sinh, arcsinh, etc.<br />
-                      </td>
-                      <td>sin(4x+y)<br />
-                        arccsch(4x+y)
-                      </td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <th scope="row">${_("Scientific notation")}</th>
-                      <td>10^ and the exponent</td>
-                      <td>10^-9</td>
-                    </tr>
-                    <tr>
-                      <th scope="row">${_("e notation")}</th>
-                      <td>1e and the exponent</td>
-                      <td>1e-9</td>
-                    </tr>
-                  </tbody>
-                </table>
-              </li>
-            </ul>
-          </div>
-        </div>
-
-        <input id="calculator_button" type="submit" title="${_('Calculate')}" value="=" aria-label="${_('Calculate')}" value="=" tabindex="-1" />
-        <input type="text" id="calculator_output" title="${_('Calculator Output Field')}" readonly tabindex="-1" />
-      </form>
-    </div>
-  </div>
-
-% endif
 <%include file="../modal/accessible_confirm.html" />

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -216,7 +216,7 @@ ${fragment.foot_html()}
 </div>
 
 <nav class="nav-utilities">
-  <h2 class="sr nav-utilities-title">Course Utilities Navigation</h2>
+  <h2 class="sr nav-utilities-title">${_('Course Utilities Navigation')}</h2>
 
   ## Utility: Chat
   % if show_chat:

--- a/lms/templates/edxnotes/edxnotes.html
+++ b/lms/templates/edxnotes/edxnotes.html
@@ -3,71 +3,96 @@
 <%namespace name='static' file='/static_content.html'/>
 <%inherit file="/main.html" />
 
+<%block name="bodyclass">view-student-notes is-in-course course</%block>
 <%block name="pagetitle">${_("Student Notes")}</%block>
 <%block name="headextra">
-    <%static:css group='style-course'/>
+<%static:css group='style-course'/>
 </%block>
 
 <%include file="/courseware/course_navigation.html" args="active_page='edxnotes'" />
-<section class="container wrapper-student-notes">
-    <div class="info-wrapper">
-        <section class="updates">
-            <div class="title-search-container">
-                <div class="wrapper-title">
-                    <h1 class="page-title">${_('Notes')} <small class="page-subtitle">${_("Highlights and notes you've made in course content")}</small></h1>
-                </div>
-            % if notes:
-                <div class="wrapper-notes-search">
-                    <form role="search" action="${search_endpoint}" method="GET" id="search-notes-form" class="is-hidden">
-                        <label for="search-notes-input" class="sr">${_('Search notes for:')}</label>
-                        <input type="search" class="search-notes-input" id="search-notes-input" name="note" placeholder="${_('Search notes for...')}">
-                        <button type="submit" class="search-notes-submit"><i class="icon-search"></i> ${_('Search')}</button>
-                    </form>
-                </div>
-            % endif
+<section class="container">
+  <div class="wrapper-student-notes">
+    <div class="student-notes">
+
+      <div class="title-search-container">
+        <div class="wrapper-title">
+          <h1 class="page-title">
+            ${_('Notes')}
+            <small class="page-subtitle">${_("Highlights and notes you've made in course content")}</small>
+          </h1>
+        </div>
+
+        % if notes:
+        <div class="wrapper-notes-search">
+          <form role="search" action="${search_endpoint}" method="GET" id="search-notes-form" class="is-hidden">
+            <label for="search-notes-input" class="sr">${_('Search notes for:')}</label>
+            <input type="search" class="search-notes-input" id="search-notes-input" name="note" placeholder="${_('Search notes for...')}">
+            <button type="submit" class="search-notes-submit">
+              <i class="icon icon-search"></i>
+              <span class="sr">${_('Search')}</span>
+            </button>
+          </form>
+        </div>
+        % endif
+      </div>
+
+      <div class="wrapper-msg is-hidden error urgency-high inline-error">
+        <div class="msg msg-error" tabindex="-1">
+          <div class="msg-content">
+            <p class="copy"></p>
+          </div>
+        </div>
+      </div>
+
+      <section class="wrapper-tabs">
+        <div class="tab-list is-hidden">
+          <h2 id="tab-view" class="tabs-label">${_('View notes by:')}</h2>
+        </div>
+
+        % if notes:
+        <div class="ui-loading" tabindex="-1">
+          <span class="spin">
+            <i class="icon icon-refresh"></i>
+          </span>
+          <span class="copy">${_("Loading...")}</span>
+        </div>
+
+        % else:
+        <section class="is-empty">
+          <article>
+            <h2>${_('You have not made any notes in this course yet.')}</h2>
+
+            <p>${_('Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.')}</p>
+
+            <h2>${_('Other Students In This Course Are Using Notes To:')}</h2>
+            <ul>
+              <li>${_('Add study notes to course content for exams and homework.')}</li>
+              <li>${_('Highlight important concepts for later coursework or future courses')}</li>
+              <li>${_('Donec id elit non mi porta gravida et eget metus.')}</li>
+              <li>${_('Praesent commodo cursus magna, vel scelerisque nisl consectetur et.')}</li>
+            </ul>
+
+            % if position is not None:
+            <div class="student-notes-cta">
+              <h3 class="sr">${_('Start creating notes')}</h3>
+
+              <p>${_('Get started by making a note in something you just read, like {section_link}.').format(
+                section_link='<a href="{url}">{section_name}</a>'.format(
+                  url=position['url'],
+                  section_name=position['display_name'],
+                  )
+                )}</p>
             </div>
-
-            <section class="wrapper-tabs">
-                <div class="tab-list is-hidden">
-                    <h2 id="tab-view" class="tabs-label">${_('View notes by:')}</h2>
-                </div>
-                <div class="inline-error is-hidden" tabindex="-1"></div>
-            % if notes:
-                <div class="ui-loading" tabindex="-1">
-                    <p><span class="spin"><i class="icon-refresh"></i></span> <span class="copy">${_("Loading...")}</span></p>
-                </div>
-            % else:
-                <section class="is-empty">
-                    <article>
-                        <h2>${_('You have not made any notes in this course yet.')}</h2>
-                        <p>${_('Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.')}</p>
-
-                        <h2>${_('Other Students In This Course Are Using Notes To:')}</h2>
-                        <ul>
-                            <li>${_('Add study notes to course content for exams and homework.')}</li>
-                            <li>${_('Highlight important concepts for later coursework or future courses')}</li>
-                            <li>${_('Donec id elit non mi porta gravida et eget metus.')}</li>
-                            <li>${_('Praesent commodo cursus magna, vel scelerisque nisl consectetur et.')}</li>
-                        </ul>
-
-                    % if position is not None:
-                        <div class="student-notes-cta">
-                            <h3 class="sr">${_('Start creating notes')}</h3>
-                            <p>${_('Get started by making a note in something you just read, like {section_link}.').format(
-                                section_link='<a href="{url}">{section_name}</a>'.format(
-                                    url=position['url'],
-                                    section_name=position['display_name'],
-                                )
-                            )}</p>
-                        </div>
-                    % endif
-                    </article>
-                </section>
             % endif
-            </section>
+          </article>
         </section>
+        % endif
+      </section>
+
     </div>
+  </div>
 </section>
+
 
 ## Include Underscore templates
 <%block name="header_extras">
@@ -79,15 +104,15 @@
 </%block>
 <%block name="js_extra">
 % if notes:
-<script type="text/javascript">
+  <script type="text/javascript">
     (function (require) {
-        require(['js/edxnotes/views/page_factory'], function (NotesFactory) {
-            var pageView = new NotesFactory({
-                notesList: ${notes},
-                debugMode: ${debug}
-            });
+      require(['js/edxnotes/views/page_factory'], function (NotesFactory) {
+        var pageView = new NotesFactory({
+          notesList: ${notes},
+          debugMode: ${debug}
         });
+      });
     }).call(this, require || RequireJS.require);
-</script>
-% endif
-</%block>
+  </script>
+  % endif
+  </%block>

--- a/lms/templates/edxnotes/note-item.underscore
+++ b/lms/templates/edxnotes/note-item.underscore
@@ -1,30 +1,36 @@
 <div class="wrapper-note-excerpts">
-    <% if (message) { %>
-        <div class="note-excerpt" role="region" aria-label="<%- gettext('Highlighted text') %>">
-            <p class="note-excerpt-p"><%= message %>
-                <% if (show_link) { %>
-                    <% if (is_expanded) { %>
-                        <a href="#" class="note-excerpt-more-link"><%- gettext('(Show less)') %></a>
-                    <% } else { %>
-                        <a href="#" class="note-excerpt-more-link"><%- gettext('More') %></a>
-                    <% } %>
-                <% } %>
-            </p>
-        </div>
-    <% } %>
-    <% if (text) { %>
-        <ol class="note-comments" role="region" aria-label="<%- gettext('Note') %>">
-            <li class="note-comment">
-                <p class="note-comment-p"><%= text %></p>
-            </li>
-        </ol>
-    <% } %>
+
+  <% if (message) { %>
+  <div class="note-excerpt" role="region" aria-label="<%- gettext('Highlighted text') %>">
+    <p class="note-excerpt-p"><%= message %>
+      <% if (show_link) { %>
+      <% if (is_expanded) { %>
+      <a href="#" class="note-excerpt-more-link"><%- gettext('Less') %></a>
+      <% } else { %>
+      <a href="#" class="note-excerpt-more-link"><%- gettext('More') %></a>
+      <% } %>
+      <% } %>
+    </p>
+  </div>
+  <% } %>
+
+  <% if (text) { %>
+  <ol class="note-comments" role="region" aria-label="<%- gettext('Note') %>">
+    <li class="note-comment">
+      <h3 class="note-comment-title"><%- gettext("You commented...") %></h3>
+      <p class="note-comment-p"><%= text %></p>
+    </li>
+  </ol>
+  <% } %>
+
 </div>
+
 <footer class="reference" role="complementary" aria-label="<%- gettext('References') %>">
-    <div class="wrapper-reference-content">
-        <h3 class="reference-title"><%- gettext("Location of highlight or note:") %></h3>
-        <a class="reference-meta reference-unit-link" href="<%= unit.url %>#<%= id %>"><%- unit.display_name %></a>
-        <h3 class="reference-title"><%- gettext("Last Edited:") %></h3>
-        <span class="reference-meta reference-updated-date"><%- updated %></span>
-    </div>
+  <div class="wrapper-reference-content">
+    <h3 class="reference-title"><%- gettext("Noted in:") %></h3>
+    <a class="reference-meta reference-unit-link" href="<%= unit.url %>#<%= id %>"><%- unit.display_name %></a>
+
+    <h3 class="reference-title"><%- gettext("Last Edited:") %></h3>
+    <span class="reference-meta reference-updated-date"><%- updated %></span>
+  </div>
 </footer>

--- a/lms/templates/edxnotes/note-item.underscore
+++ b/lms/templates/edxnotes/note-item.underscore
@@ -1,36 +1,35 @@
 <div class="wrapper-note-excerpts">
+    <% if (message) { %>
+    <div class="note-excerpt" role="region" aria-label="<%- gettext('Highlighted text') %>">
+        <p class="note-excerpt-p"><%= message %>
+          <% if (show_link) { %>
+          <% if (is_expanded) { %>
+              <a href="#" class="note-excerpt-more-link"><%- gettext('Less') %></a>
+          <% } else { %>
+              <a href="#" class="note-excerpt-more-link"><%- gettext('More') %></a>
+          <% } %>
+          <% } %>
+        </p>
+    </div>
+    <% } %>
 
-  <% if (message) { %>
-  <div class="note-excerpt" role="region" aria-label="<%- gettext('Highlighted text') %>">
-    <p class="note-excerpt-p"><%= message %>
-      <% if (show_link) { %>
-      <% if (is_expanded) { %>
-      <a href="#" class="note-excerpt-more-link"><%- gettext('Less') %></a>
-      <% } else { %>
-      <a href="#" class="note-excerpt-more-link"><%- gettext('More') %></a>
-      <% } %>
-      <% } %>
-    </p>
-  </div>
-  <% } %>
-
-  <% if (text) { %>
-  <ol class="note-comments" role="region" aria-label="<%- gettext('Note') %>">
-    <li class="note-comment">
-      <h3 class="note-comment-title"><%- gettext("You commented...") %></h3>
-      <p class="note-comment-p"><%= text %></p>
-    </li>
-  </ol>
-  <% } %>
+    <% if (text) { %>
+    <ol class="note-comments" role="region" aria-label="<%- gettext('Note') %>">
+        <li class="note-comment">
+            <h3 class="note-comment-title"><%- gettext("You commented...") %></h3>
+            <p class="note-comment-p"><%= text %></p>
+        </li>
+    </ol>
+    <% } %>
 
 </div>
 
 <footer class="reference" role="complementary" aria-label="<%- gettext('References') %>">
-  <div class="wrapper-reference-content">
-    <h3 class="reference-title"><%- gettext("Noted in:") %></h3>
-    <a class="reference-meta reference-unit-link" href="<%= unit.url %>#<%= id %>"><%- unit.display_name %></a>
+    <div class="wrapper-reference-content">
+        <h3 class="reference-title"><%- gettext("Noted in:") %></h3>
+        <a class="reference-meta reference-unit-link" href="<%= unit.url %>#<%= id %>"><%- unit.display_name %></a>
 
-    <h3 class="reference-title"><%- gettext("Last Edited:") %></h3>
-    <span class="reference-meta reference-updated-date"><%- updated %></span>
-  </div>
+        <h3 class="reference-title"><%- gettext("Last Edited:") %></h3>
+        <span class="reference-meta reference-updated-date"><%- updated %></span>
+    </div>
 </footer>

--- a/lms/templates/edxnotes/tab-item.underscore
+++ b/lms/templates/edxnotes/tab-item.underscore
@@ -1,5 +1,13 @@
 <% var hasIcon = icon ? 1 : 0; %>
-<a class="tab-label <% if (hasIcon) { print('has-icon') } %>" href="#"><% if (hasIcon) { %><i class="icon <%= icon %>"></i> <% } %><%- gettext(name) %></a><% if (is_closable) { %>
-    <a href="#" class="btn-close icon-close">x</a>
+
+<a class="tab-label <% if (hasIcon) { print('has-icon') } %>" href="#">
+  <% if (hasIcon) { %><i class="icon <%= icon %>"></i> <% } %><%- gettext(name) %>
+</a>
+
+<% if (is_closable) { %>
+  <a href="#" class="action-close">
+    <i class="icon-remove-sign"></i>
+    <span class="sr"><%- gettext("Clear search results") %></span>
+  </a>
 <% } %>
 

--- a/lms/templates/edxnotes/toggle_notes.html
+++ b/lms/templates/edxnotes/toggle_notes.html
@@ -9,11 +9,12 @@
 %>
 <div class="wrapper-utility edx-notes-visibility">
   <div class="edx-notes-visibility-error error"></div>
-  <a href="#" class="utility-control action-toggle-notes is-disabled" role="button" aria-pressed="">
+  <a href="#" class="utility-control action-toggle-notes is-disabled ${"is-active" if edxnotes_visibility else ""}"  role="button" aria-pressed="">
+    <i class="icon-pencil"></i>
     % if edxnotes_visibility:
-      <i class="icon-pencil"></i> <span class="utility-control-label sr">${_("Hide notes")}</span>
+     <span class="utility-control-label sr">${_("Hide notes")}</span>
     % else:
-      <i class="icon-pencil"></i> <span class="utility-control-label sr">${_("Show notes")}</span>
+     <span class="utility-control-label sr">${_("Show notes")}</span>
     % endif
   </a>
 </div>

--- a/lms/templates/edxnotes/toggle_notes.html
+++ b/lms/templates/edxnotes/toggle_notes.html
@@ -4,24 +4,23 @@
 <%page args="course"/>
 
 <%
-    edxnotes_visibility = course.edxnotes_visibility
-    edxnotes_visibility_url = reverse("edxnotes_visibility", kwargs={"course_id": course.id})
+  edxnotes_visibility = course.edxnotes_visibility
+  edxnotes_visibility_url = reverse("edxnotes_visibility", kwargs={"course_id": course.id})
 %>
-<div class="action-inline edx-notes-visibility">
-    <a href="#" class="action-toggle-notes is-disabled" role="button" aria-pressed="">
-        % if edxnotes_visibility:
-            <i class="checkbox-icon icon-check"></i>
-        % else:
-            <i class="checkbox-icon icon-check-empty"></i>
-        % endif
-        ${_("Show notes")}
-    </a>
-    <div class="edx-notes-visibility-error error"></div>
+<div class="wrapper-utility edx-notes-visibility">
+  <div class="edx-notes-visibility-error error"></div>
+  <a href="#" class="utility-control action-toggle-notes is-disabled" role="button" aria-pressed="">
+    % if edxnotes_visibility:
+      <i class="icon-pencil"></i> <span class="utility-control-label sr">${_("Hide notes")}</span>
+    % else:
+      <i class="icon-pencil"></i> <span class="utility-control-label sr">${_("Show notes")}</span>
+    % endif
+  </a>
 </div>
 <script type="text/javascript">
-    (function (require) {
-        require(['js/edxnotes/views/toggle_notes_factory'], function(ToggleNotesFactory) {
-            ToggleNotesFactory(${json.dumps(edxnotes_visibility)}, '${edxnotes_visibility_url}');
-        });
-    }).call(this, require || RequireJS.require);
+  (function (require) {
+      require(['js/edxnotes/views/toggle_notes_factory'], function(ToggleNotesFactory) {
+          ToggleNotesFactory(${json.dumps(edxnotes_visibility)}, '${edxnotes_visibility_url}');
+      });
+  }).call(this, require || RequireJS.require);
 </script>

--- a/lms/templates/edxnotes/toggle_notes.html
+++ b/lms/templates/edxnotes/toggle_notes.html
@@ -8,7 +8,6 @@
   edxnotes_visibility_url = reverse("edxnotes_visibility", kwargs={"course_id": course.id})
 %>
 <div class="wrapper-utility edx-notes-visibility">
-  <div class="edx-notes-visibility-error error"></div>
   <a href="#" class="utility-control action-toggle-notes is-disabled ${"is-active" if edxnotes_visibility else ""}"  role="button" aria-pressed="">
     <i class="icon-pencil"></i>
     % if edxnotes_visibility:

--- a/lms/templates/edxnotes/toggle_notes.html
+++ b/lms/templates/edxnotes/toggle_notes.html
@@ -8,14 +8,14 @@
   edxnotes_visibility_url = reverse("edxnotes_visibility", kwargs={"course_id": course.id})
 %>
 <div class="wrapper-utility edx-notes-visibility">
-  <a href="#" class="utility-control action-toggle-notes is-disabled ${"is-active" if edxnotes_visibility else ""}"  role="button" aria-pressed="">
+  <button class="utility-control utility-control-button action-toggle-notes is-disabled ${"is-active" if edxnotes_visibility else ""}" aria-pressed="">
     <i class="icon-pencil"></i>
     % if edxnotes_visibility:
      <span class="utility-control-label sr">${_("Hide notes")}</span>
     % else:
      <span class="utility-control-label sr">${_("Show notes")}</span>
     % endif
-  </a>
+  </button>
 </div>
 <script type="text/javascript">
   (function (require) {


### PR DESCRIPTION
This work styles the various states of the aggregated notes view.

---

**Known Concerns**
- I created this branch from https://github.com/edx/edx-platform/pull/6384, which contains  a few base styles/utilities for this work. Once that PR is merged or cherry-picked, this should be rebased and can stand on its own.
- I revised some existing class names that JS methods relied on (and tried to change the JS). @polesye or @tymofij, I need your help correcting tests and proofing the production JS

---

**Screengrab - Latest Notes**
![screenshot-localhost 8000 2014-12-30 18-23-47](https://cloud.githubusercontent.com/assets/163763/5584069/5fb4351c-9051-11e4-8f34-e718d248af39.png)

**Screengrab - Notes by Course Structure**
![screenshot-localhost 8000 2014-12-30 18-24-57](https://cloud.githubusercontent.com/assets/163763/5584072/65469402-9051-11e4-9579-c826c8ca810d.png)

**Screengrab - Search No Results**
![screenshot-localhost 8000 2014-12-30 18-24-28](https://cloud.githubusercontent.com/assets/163763/5584073/69ea8f2c-9051-11e4-8bc8-b13e8340445a.png)

**Screengrab - Search Blank Error**
![screenshot-localhost 8000 2014-12-30 18-25-41](https://cloud.githubusercontent.com/assets/163763/5584074/6f788174-9051-11e4-8745-565db5862707.png)
