### PR TITLE
Decouple verified/payment A/B test setup

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -568,13 +568,21 @@ def dashboard(request):
     #
     # If a course is not included in this dictionary,
     # there is no verification messaging to display.
-    if settings.FEATURES.get("SEPARATE_VERIFICATION_FROM_PAYMENT"):
+    #
+    # TODO (ECOM-188): After the A/B test completes, we can remove the check
+    # for the GET param and the session var.
+    # The A/B test framework will set the GET param for users in the experimental
+    # group; we then set the session var so downstream views can check this.
+    if settings.FEATURES.get("SEPARATE_VERIFICATION_FROM_PAYMENT") and request.GET.get('separate-verified', False):
+        request.session['separate-verified'] = True
         verify_status_by_course = check_verify_status_by_course(
             user,
             course_enrollment_pairs,
             all_course_modes
         )
     else:
+        if request.GET.get('disable-separate-verified', False) and 'separate-verified' in request.session:
+            del request.session['separate-verified']
         verify_status_by_course = {}
 
     cert_statuses = {

--- a/lms/djangoapps/shoppingcart/tests/test_models.py
+++ b/lms/djangoapps/shoppingcart/tests/test_models.py
@@ -249,7 +249,7 @@ class OrderTest(UrlResetMixin, ModuleStoreTestCase):
         self.assertEquals('Order Payment Confirmation', mail.outbox[0].subject)
         self.assertIn(settings.PAYMENT_SUPPORT_EMAIL, mail.outbox[0].body)
         self.assertIn(unicode(cart.total_cost), mail.outbox[0].body)
-        self.assertIn(item.additional_instruction_text, mail.outbox[0].body)
+        self.assertIn(item.additional_instruction_text(), mail.outbox[0].body)
 
         # Assert Google Analytics event fired for purchase.
         self.mock_tracker.track.assert_called_once_with(  # pylint: disable=maybe-no-member
@@ -280,7 +280,7 @@ class OrderTest(UrlResetMixin, ModuleStoreTestCase):
 
         self.assertEquals(len(mail.outbox), 1)
         # Verify that the verification reminder appears in the sent email.
-        self.assertIn(item.additional_instruction_text, mail.outbox[0].body)
+        self.assertIn(item.additional_instruction_text(), mail.outbox[0].body)
 
     def test_purchase_item_failure(self):
         # once again, we're testing against the specific implementation of

--- a/lms/djangoapps/shoppingcart/views.py
+++ b/lms/djangoapps/shoppingcart/views.py
@@ -798,7 +798,7 @@ def _show_receipt_html(request, order):
         # TODO (ECOM-188): Once the A/B test of separate verified / payment flow
         # completes, implement this in a more general way.  For now,
         # we simply redirect to the new receipt page (in verify_student).
-        if settings.FEATURES.get('SEPARATE_VERIFICATION_FROM_PAYMENT'):
+        if settings.FEATURES.get('SEPARATE_VERIFICATION_FROM_PAYMENT') and request.session.get('separate-verified', False):
             if receipt_template == 'shoppingcart/verified_cert_receipt.html':
                 url = reverse(
                     'verify_student_payment_confirmation',

--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -754,15 +754,14 @@ def create_order(request):
     """
     Submit PhotoVerification and create a new Order for this verified cert
     """
-    # TODO (ECOM-188): Once the A/B test of separating the payment/verified flow
-    # has completed, we can remove this flag and delete the photo verification
-    # step entirely (since it will be handled in a separate view).
-    submit_photo = True
-    if settings.FEATURES.get("SEPARATE_VERIFICATION_FROM_PAYMENT"):
-        submit_photo = (
-            'face_image' in request.POST and
-            'photo_id_image' in request.POST
-        )
+    # Only submit photos if photo data is provided by the client.
+    # TODO (ECOM-188): Once the A/B test of decoupling verified / payment
+    # completes, we may be able to remove photo submission from this step
+    # entirely.
+    submit_photo = (
+        'face_image' in request.POST and
+        'photo_id_image' in request.POST
+    )
 
     if (
         submit_photo and not

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -54,7 +54,7 @@ from student.helpers import (
     % endif
     % if settings.FEATURES.get('ENABLE_VERIFIED_CERTIFICATES'):
       % if enrollment.mode == "verified":
-        % if settings.FEATURES.get('SEPARATE_VERIFICATION_FROM_PAYMENT'):
+        % if settings.FEATURES.get('SEPARATE_VERIFICATION_FROM_PAYMENT') and request.session.get('separate-verified', False):
           % if verification_status.get('status') in [VERIFY_STATUS_NEED_TO_VERIFY, VERIFY_STATUS_SUBMITTED]:
             <span class="sts-enrollment" title="${_("Your verification is pending")}">
               <span class="label">${_("Enrolled as: ")}</span>
@@ -131,7 +131,7 @@ from student.helpers import (
       <%include file='_dashboard_certificate_information.html' args='cert_status=cert_status,course=course, enrollment=enrollment'/>
       % endif
 
-      % if settings.FEATURES.get('SEPARATE_VERIFICATION_FROM_PAYMENT'):
+      % if settings.FEATURES.get('SEPARATE_VERIFICATION_FROM_PAYMENT') and request.session.get('separate-verified', True):
         % if verification_status.get('status') in [VERIFY_STATUS_NEED_TO_VERIFY, VERIFY_STATUS_SUBMITTED, VERIFY_STATUS_APPROVED] and not is_course_blocked:
         <div class="message message-status is-shown">
           % if verification_status['status'] == VERIFY_STATUS_NEED_TO_VERIFY:
@@ -180,7 +180,7 @@ from student.helpers import (
 
               <ul class="actions message-actions">
                 <li class="action-item">
-                  % if settings.FEATURES.get('SEPARATE_VERIFICATION_FROM_PAYMENT'):
+                  % if settings.FEATURES.get('SEPARATE_VERIFICATION_FROM_PAYMENT') and request.session.get('separate-verified', False):
                   <a class="action action-upgrade" href="${reverse('verify_student_upgrade_and_verify', kwargs={'course_id': unicode(course.id)})}" data-course-id="${course.id | h}" data-user="${user.username | h}">
                   % else:
                   <a class="action action-upgrade" href="${reverse('course_modes_choose', kwargs={'course_id': unicode(course.id)})}?upgrade=True" data-course-id="${course.id | h}" data-user="${user.username | h}">

--- a/lms/templates/emails/order_confirmation_email.txt
+++ b/lms/templates/emails/order_confirmation_email.txt
@@ -39,5 +39,5 @@ ${order.bill_to_country.upper()}
 % endif
 
 % for order_item in order_items:
-${order_item.additional_instruction_text}
+${order_item.additional_instruction_text(separate_verification=getattr(request, 'session', {}).get('separate-verified', False))}
 % endfor


### PR DESCRIPTION
This PR allows users to enter or leave the experimental flow using GET parameters.  The A/B test will need to do the following for the experimental group:

1) Check whether the user is in the experimental group and is on the "choose track" page or student dashboard.

2) Check that the `?separate-verified` flag is not already set

If both (1) and (2) are true, reload the page with `?separate-verified=1`.  This will set a session variable that allows downstream views to check whether the user is in the experimental track.  We need to use a session var because users may return to flow from the payment gateway (CyberSource), and we need to know whether they're in the experimental track.

For testing purposes, I've also added a GET param to clear the session var.  You can use `?disable-separate-verified=1` on either the dashboard or "choose track" page to disable the experiment.

@stephensanchez please review.
