### PR TITLE
Hide verification messaging if the user has an active verification

### DIFF
--- a/common/djangoapps/student/tests/test_verification_status.py
+++ b/common/djangoapps/student/tests/test_verification_status.py
@@ -193,6 +193,26 @@ class TestCourseVerificationStatus(UrlResetMixin, ModuleStoreTestCase):
         # messaging relating to verification
         self._assert_course_verification_status(None)
 
+    def test_verification_will_expire_by_deadline(self):
+        # Expiration date in the future
+        self._setup_mode_and_enrollment(self.FUTURE, "verified")
+
+        # Create a verification attempt that:
+        # 1) Is current (submitted in the last year)
+        # 2) Will expire by the deadline for the course
+        attempt = SoftwareSecurePhotoVerification.objects.create(user=self.user)
+        attempt.mark_ready()
+        attempt.submit()
+
+        # This attempt will expire tomorrow, before the course deadline
+        attempt.created_at = attempt.created_at - timedelta(days=364)
+        attempt.save()
+
+        # Expect that the "verify now" message is hidden
+        # (since the user isn't allowed to submit another attempt while
+        # a verification is active).
+        self._assert_course_verification_status(None)
+
     def _setup_mode_and_enrollment(self, deadline, enrollment_mode):
         """Create a course mode and enrollment.
 
@@ -221,9 +241,12 @@ class TestCourseVerificationStatus(UrlResetMixin, ModuleStoreTestCase):
     }
 
     NOTIFICATION_MESSAGES = {
-        VERIFY_STATUS_NEED_TO_VERIFY: "You still need to verify for this course.",
-        VERIFY_STATUS_SUBMITTED: "Thanks for your patience as we process your request.",
-        VERIFY_STATUS_APPROVED: "You have already verified your ID!",
+        VERIFY_STATUS_NEED_TO_VERIFY: [
+            "You still need to verify for this course.",
+            "Verification not yet complete"
+        ],
+        VERIFY_STATUS_SUBMITTED: ["Thanks for your patience as we process your request."],
+        VERIFY_STATUS_APPROVED: ["You have already verified your ID!"],
     }
 
     def _assert_course_verification_status(self, status):
@@ -248,7 +271,25 @@ class TestCourseVerificationStatus(UrlResetMixin, ModuleStoreTestCase):
         # Verify that the correct copy is rendered on the dashboard
         if status is not None:
             if status in self.NOTIFICATION_MESSAGES:
-                self.assertContains(response, self.NOTIFICATION_MESSAGES[status])
+                # Different states might have different messaging
+                # so in some cases we check several possibilities
+                # and fail if none of these are found.
+                found_msg = False
+                for message in self.NOTIFICATION_MESSAGES[status]:
+                    if message in response.content:
+                        found_msg = True
+                        break
+
+                fail_msg = "Could not find any of these messages: {expected}".format(
+                    expected=self.NOTIFICATION_MESSAGES[status]
+                )
+                self.assertTrue(found_msg, msg=fail_msg)
         else:
-            for msg in self.NOTIFICATION_MESSAGES.values():
+            # Combine all possible messages into a single list
+            all_messages = []
+            for msg_group in self.NOTIFICATION_MESSAGES.values():
+                all_messages.extend(msg_group)
+
+            # Verify that none of the messages are displayed
+            for msg in all_messages:
                 self.assertNotContains(response, msg)

--- a/lms/djangoapps/verify_student/models.py
+++ b/lms/djangoapps/verify_student/models.py
@@ -211,7 +211,7 @@ class PhotoVerification(StatusModel):
         ).exists()
 
     @classmethod
-    def user_has_valid_or_pending(cls, user, earliest_allowed_date=None, window=None):
+    def user_has_valid_or_pending(cls, user, earliest_allowed_date=None, window=None, queryset=None):
         """
         Return whether the user has a complete verification attempt that is or
         *might* be good. This means that it's approved, been submitted, or would
@@ -222,15 +222,21 @@ class PhotoVerification(StatusModel):
         If window=None, this will check for the user's *initial* verification.  If
         window is anything else, this will check for the reverification associated
         with that window.
+
+        If a queryset is provided, that will be used instead of hitting the database.
         """
         valid_statuses = ['submitted', 'approved']
         if not window:
             valid_statuses.append('must_retry')
-        return cls.objects.filter(
-            user=user,
+        if queryset is None:
+            queryset = cls.objects.filter(user=user)
+
+        return queryset.filter(
             status__in=valid_statuses,
-            created_at__gte=(earliest_allowed_date
-                             or cls._earliest_allowed_date()),
+            created_at__gte=(
+                earliest_allowed_date
+                or cls._earliest_allowed_date()
+            ),
             window=window,
         ).exists()
 


### PR DESCRIPTION
ECOM-864

This is a quick fix for the following situation:
1) A user submits photos for verification on 1/2/2014.  Since verifications are good for 1 year, the verification is set to expire on 1/2/2015.
2) The user completes payment and enrolls in a course with a verification deadline on 1/3/2015.
3) The user views the dashboard before the verification expires.

At this point, a couple of strange things will happen:
- The user will see the "verify now" message on the dashboard, because the verification will have expired by the course's verification deadline.
- The user will _also_ see that the verification status is "pending" or "approved" in the sidebar on the dashboard.
- If the user clicks the "verify now" link, the user will be redirected back to the dashboard, since the user already completed both payment and verification.

The quick fix is to simply hide the "verify now" message in this case.  This isn't a great UX, but it should be sufficient to run the A/B test.

Reviewers: @stephensanchez @dianakhuang 
