### PR TITLE
Fix two tests failing on January 1, 2015

### DIFF
--- a/common/test/acceptance/tests/lms/test_lms_courseware.py
+++ b/common/test/acceptance/tests/lms/test_lms_courseware.py
@@ -67,7 +67,7 @@ class CoursewareTest(UniqueCourseTest):
 
         """
         self.course_outline.q(css=".subsection-header-actions .configure-button").first.click()
-        self.course_outline.q(css="#start_date").fill("01/01/2015")
+        self.course_outline.q(css="#start_date").fill("01/01/2030")
         self.course_outline.q(css=".action-save").first.click()
 
     def _auto_auth(self, username, email, staff):

--- a/openedx/core/djangoapps/user_api/tests/test_profile_api.py
+++ b/openedx/core/djangoapps/user_api/tests/test_profile_api.py
@@ -7,6 +7,7 @@ import ddt
 from django.test.utils import override_settings
 from nose.tools import raises
 from dateutil.parser import parse as parse_datetime
+from pytz import UTC
 from xmodule.modulestore.tests.factories import CourseFactory
 import datetime
 
@@ -167,7 +168,7 @@ class ProfileApiTest(TestCase):
         # Set year of birth
         user = User.objects.get(username=self.USERNAME)
         profile = UserProfile.objects.get(user=user)
-        year_of_birth = datetime.datetime.now().year - age  # pylint: disable=maybe-no-member
+        year_of_birth = datetime.datetime.now(UTC).year - age  # pylint: disable=maybe-no-member
         profile.year_of_birth = year_of_birth
         profile.save()
 


### PR DESCRIPTION
Two tests started failing when we entered 2015:
- One bok choy test had "01/01/2015" as a hard-coded date, and once we passed that date, its behaviour changed, causing it to fail.
- One test related to user age created a naive datetime and tested code that used a UTC datetime to calculate age, causing it to fail for up to 23 hours surrounding any new year, whenever the test is run in a non-UTC timezone. It is no longer failing but should be fixed anyways. 

No discussion, JIRA ticket, or internal review yet as this is a quick fix to get my builds passing again.

@sarina can you please guide this PR toward a merge?
