### PR TITLE
Update Pillow to 2.7.0

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -56,7 +56,7 @@ nose==1.3.3
 oauthlib==0.6.3
 paramiko==1.9.0
 path.py==3.0.1
-Pillow==2.6.1
+Pillow==2.7.0
 pip>=1.4
 polib==1.0.3
 pycrypto>=2.6


### PR DESCRIPTION
Django put out a [security advisory](https://www.djangoproject.com/weblog/2015/jan/02/pillow-security-release/) suggested that users upgrade to Pillow 2.7.0 if they use the `ImageField` in Django's ORM. Django-wiki uses `ImageField`, and we use django-wiki, so we should upgrade Pillow.
