### PR TITLE
Set REQUIRE_COURSE_EMAIL_AUTH to False

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -138,7 +138,7 @@ FEATURES = {
     #   for each course via django-admin interface.
     # If False and ENABLE_INSTRUCTOR_EMAIL: Email will be turned on by default
     #   for all Mongo-backed courses.
-    'REQUIRE_COURSE_EMAIL_AUTH': True,
+    'REQUIRE_COURSE_EMAIL_AUTH': False,
 
     # Analytics experiments - shows instructor analytics tab in LMS instructor dashboard.
     # Enabling this feature depends on installation of a separate analytics server.


### PR DESCRIPTION
Accidentally closed #6093 and I can't reopen it.

The logic behind making this change is Instructor Email is a highly-visible feature on our production environments that we're not showing, by default, on our sandboxes or developer environments. 

There are automated tests that catch what this feature flag governs (ie, does instructor email show up or not, given the authorization table, when REQUIRE_COURSE_EMAIL_AUTH is set to True). 

However other things are not so easily automatically tested - such as, on your sandbox, are the changes you're making to Celery still allowing the bulk email feature to completely work, including successfully delivering mail to S3 and getting it in your inbox? You need to have email turned on for that, and a lot of people forget to test the feature because it's (bizarrely, in my opinion) being hidden behind a feature flag. I think if we're going to support this feature we should make it visible; if this was a new feature, the flag would be set to 'on' by default.
