### PR TITLE
add test for course_id_from_url (TNL-362)

### DIFF
--- a/common/djangoapps/util/tests/test_request.py
+++ b/common/djangoapps/util/tests/test_request.py
@@ -53,3 +53,10 @@ class ResponseTestCase(unittest.TestCase):
         self.assertEqual(course_id.org, 'edX')
         self.assertEqual(course_id.course, 'maths')
         self.assertEqual(course_id.run, '2020')
+
+        course_id = course_id_from_url(
+            '/api/courses/slashes:sample+course+id/static/detail?tab=tab_name'
+        )
+        self.assertEqual(course_id.org, 'sample')
+        self.assertEqual(course_id.course, 'course')
+        self.assertEqual(course_id.run, 'id')


### PR DESCRIPTION
@mattdrayer -- looks like https://openedx.atlassian.net/browse/TNL-362 is no longer an issue (as this test passes)
