### PR TITLE
use modulestore bulk ops in forum views.

### DIFF
--- a/lms/djangoapps/django_comment_client/forum/views.py
+++ b/lms/djangoapps/django_comment_client/forum/views.py
@@ -1,3 +1,8 @@
+"""
+Views handling read (GET) requests for the Discussion tab and inline discussions.
+"""
+
+from functools import wraps
 import json
 import logging
 import xml.sax.saxutils as saxutils
@@ -18,6 +23,7 @@ from openedx.core.djangoapps.course_groups.cohorts import (
     is_commentable_cohorted
 )
 from courseware.access import has_access
+from xmodule.modulestore.django import modulestore
 
 from django_comment_client.permissions import cached_has_permission
 from django_comment_client.utils import (
@@ -30,7 +36,7 @@ from django_comment_client.utils import (
 import django_comment_client.utils as utils
 import lms.lib.comment_client as cc
 
-from opaque_keys.edx.locations import SlashSeparatedCourseKey
+from opaque_keys.edx.keys import CourseKey
 
 THREADS_PER_PAGE = 20
 INLINE_THREADS_PER_PAGE = 20
@@ -130,13 +136,27 @@ def get_threads(request, course_key, discussion_id=None, per_page=THREADS_PER_PA
     return threads, query_params
 
 
+def use_bulk_ops(view_func):
+    """
+    Wraps internal request handling inside a modulestore bulk op, significantly
+    reducing redundant database calls.  Also converts the course_id parsed from
+    the request uri to a CourseKey before passing to the view.
+    """
+    @wraps(view_func)
+    def wrapped_view(request, course_id, *args, **kwargs):  # pylint: disable=missing-docstring
+        course_key = CourseKey.from_string(course_id)
+        with modulestore().bulk_operations(course_key):
+            return view_func(request, course_key, *args, **kwargs)
+    return wrapped_view
+
+
 @login_required
-def inline_discussion(request, course_id, discussion_id):
+@use_bulk_ops
+def inline_discussion(request, course_key, discussion_id):
     """
     Renders JSON for DiscussionModules
     """
     nr_transaction = newrelic.agent.current_transaction()
-    course_key = SlashSeparatedCourseKey.from_deprecated_string(course_id)
 
     course = get_course_with_access(request.user, 'load_forum', course_key)
     cc_user = cc.User.from_django_user(request.user)
@@ -165,11 +185,11 @@ def inline_discussion(request, course_id, discussion_id):
 
 
 @login_required
-def forum_form_discussion(request, course_id):
+@use_bulk_ops
+def forum_form_discussion(request, course_key):
     """
     Renders the main Discussion page, potentially filtered by a search query
     """
-    course_key = SlashSeparatedCourseKey.from_deprecated_string(course_id)
     nr_transaction = newrelic.agent.current_transaction()
 
     course = get_course_with_access(request.user, 'load_forum', course_key, check_if_enrolled=True)
@@ -232,8 +252,12 @@ def forum_form_discussion(request, course_id):
 
 @require_GET
 @login_required
-def single_thread(request, course_id, discussion_id, thread_id):
-    course_key = SlashSeparatedCourseKey.from_deprecated_string(course_id)
+@use_bulk_ops
+def single_thread(request, course_key, discussion_id, thread_id):
+    """
+    Renders a response to display a single discussion thread.
+    """
+
     nr_transaction = newrelic.agent.current_transaction()
 
     course = get_course_with_access(request.user, 'load_forum', course_key)
@@ -325,8 +349,13 @@ def single_thread(request, course_id, discussion_id, thread_id):
 
 @require_GET
 @login_required
-def user_profile(request, course_id, user_id):
-    course_key = SlashSeparatedCourseKey.from_deprecated_string(course_id)
+@use_bulk_ops
+def user_profile(request, course_key, user_id):
+    """
+    Renders a response to display the user profile page (shown after clicking
+    on a post author's username).
+    """
+
     nr_transaction = newrelic.agent.current_transaction()
 
     #TODO: Allow sorting?
@@ -383,8 +412,12 @@ def user_profile(request, course_id, user_id):
 
 
 @login_required
-def followed_threads(request, course_id, user_id):
-    course_key = SlashSeparatedCourseKey.from_deprecated_string(course_id)
+@use_bulk_ops
+def followed_threads(request, course_key, user_id):
+    """
+    Ajax-only endpoint retrieving the threads followed by a specific user.
+    """
+
     nr_transaction = newrelic.agent.current_transaction()
 
     course = get_course_with_access(request.user, 'load_forum', course_key)


### PR DESCRIPTION
@dmitchell @cpennington @cahrens 

Prior to this change each of the forum views for split courses were triggering 100+ mongo find_one calls prior to rendering any threads, and around (3-4 \* number of displayed posts) calls to render a thread.  After the change I see less than five find_one calls under those same scenarios.

I do not notice any appreciable difference with old-mongo-backed courses (at least, not running under devstack).

@dsjen heads up - fix is intended to address a production perf issue we found today.  PR is set up against release but I can recreate against a specific rc if release is imminent.
