### PR TITLE
Variablize copyright year for LMS footer

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -41,6 +41,8 @@ from lms.djangoapps.lms_xblock.mixin import LmsBlockMixin
 # The display name of the platform to be used in templates/emails/etc.
 PLATFORM_NAME = "Your Platform Name Here"
 CC_MERCHANT_NAME = PLATFORM_NAME
+# Shows up in the platform footer, eg "(c) COPYRIGHT_YEAR"
+COPYRIGHT_YEAR = "2015"
 
 PLATFORM_FACEBOOK_ACCOUNT = "http://www.facebook.com/YourPlatformFacebookAccount"
 PLATFORM_TWITTER_ACCOUNT = "@YourPlatformTwitterAccount"

--- a/lms/templates/footer-edx-new.html
+++ b/lms/templates/footer-edx-new.html
@@ -31,7 +31,8 @@
       </div>
 
       <div class="footer-about-copyright">
-        <p>${_("&copy; 2014 edX, some rights reserved.")}</p>
+        ## Translators: '&copy;' is an HTML character code for the copyright symbol. Please don't remove or change it.
+        <p>${_("&copy; {copyright_year} edX, some rights reserved.").format(copyright_year=settings.COPYRIGHT_YEAR)}</p>
       </div>
 
       <div class="footer-about-links">

--- a/lms/templates/footer.html
+++ b/lms/templates/footer.html
@@ -47,7 +47,12 @@
         </p>
       </div>
 
-      <p class="copyright">${_("&copy; 2014 {platform_name}, some rights reserved").format(platform_name=settings.PLATFORM_NAME)}</p>
+      ## Translators: '&copy;' is an HTML character code for the copyright symbol. Please don't remove or change it.
+      <p class="copyright">${_("&copy; {copyright_year} {platform_name}, some rights reserved").format(
+	platform_name=settings.PLATFORM_NAME,
+	copyright_year=settings.COPYRIGHT_YEAR
+	)}
+      </p>
         <nav class="nav-legal">
           <ul>
             <li class="nav-legal-01">


### PR DESCRIPTION
This enables our translators to only have to translate the copyright notice one time, rather than every year.

@singingwolfboy 
