### PR TITLE
set prefix for xmodule.js

### DIFF
--- a/common/lib/xmodule/xmodule/static_content.py
+++ b/common/lib/xmodule/xmodule/static_content.py
@@ -12,6 +12,9 @@ import sys
 from collections import defaultdict
 from docopt import docopt
 from path import path
+import zlib
+from pkg_resources import resource_string
+
 
 from xmodule.x_module import XModuleDescriptor
 
@@ -120,12 +123,17 @@ def _write_js(output_root, classes):
     contents = {}
 
     js_fragments = set()
+    xmodule_js_fragment = resource_string(__name__, 'js/src/xmodule.js')
+    xmodule_js_crc = zlib.crc32(xmodule_js_fragment)
     for class_ in classes:
         module_js = class_.get_javascript()
         for filetype in ('coffee', 'js'):
             for idx, fragment in enumerate(module_js.get(filetype, [])):
-                if filetype != 'js':
-                    idx += 1
+                idx += 1
+                if filetype == 'js':
+                    fragment_crc = zlib.crc32(fragment)
+                    if xmodule_js_crc == fragment_crc :
+                        idx = 0
                 js_fragments.add((idx, filetype, fragment))
 
     for idx, filetype, fragment in sorted(js_fragments):

--- a/common/lib/xmodule/xmodule/static_content.py
+++ b/common/lib/xmodule/xmodule/static_content.py
@@ -124,6 +124,8 @@ def _write_js(output_root, classes):
         module_js = class_.get_javascript()
         for filetype in ('coffee', 'js'):
             for idx, fragment in enumerate(module_js.get(filetype, [])):
+                if filetype != 'js':
+                    idx += 1
                 js_fragments.add((idx, filetype, fragment))
 
     for idx, filetype, fragment in sorted(js_fragments):


### PR DESCRIPTION
TNL-1070

for xmodule.js the prefix will be 000 and for other dependencies it will be greater than  > 000 e.g 001 and so on
in this way xmodule.js will be loaded first
