### PR TITLE
Fix ECOM-872

### DIFF
--- a/lms/djangoapps/shoppingcart/tests/test_views.py
+++ b/lms/djangoapps/shoppingcart/tests/test_views.py
@@ -1217,7 +1217,14 @@ class ReceiptRedirectTest(UrlResetMixin, ModuleStoreTestCase):
 
     @patch.dict(settings.FEATURES, {'SEPARATE_VERIFICATION_FROM_PAYMENT': True})
     def test_show_receipt_redirect_to_verify_student(self):
+        # Create other carts first
+        # This ensures that the order ID and order item IDs do not match
+        Order.get_cart_for_user(self.user).start_purchase()
+        Order.get_cart_for_user(self.user).start_purchase()
+        Order.get_cart_for_user(self.user).start_purchase()
+
         # Purchase a verified certificate
+        self.cart = Order.get_cart_for_user(self.user)
         CertificateItem.add_to_order(
             self.cart,
             self.course_key,

--- a/lms/djangoapps/shoppingcart/views.py
+++ b/lms/djangoapps/shoppingcart/views.py
@@ -818,7 +818,7 @@ def _show_receipt_html(request, order):
                 # Add a query string param for the order ID
                 # This allows the view to query for the receipt information later.
                 url += '?payment-order-num={order_num}'.format(
-                    order_num=order_items[0].id
+                    order_num=order_items[0].order.id
                 )
                 return HttpResponseRedirect(url)
 


### PR DESCRIPTION
Fix for [ECOM-872](https://openedx.atlassian.net/browse/ECOM-872): Decoupled verified payment confirmation uses order item ID instead of order ID

Caught this while testing my changes in stage.

@dianakhuang @stephensanchez please review
@dsjen FYI
