### PR TITLE
remove explicit mentions to tender (TNL-1020)

### DIFF
--- a/cms/djangoapps/contentstore/features/checklists.py
+++ b/cms/djangoapps/contentstore/features/checklists.py
@@ -5,6 +5,7 @@ from lettuce import world, step
 from nose.tools import assert_true, assert_equal  # pylint: disable=no-name-in-module
 from terrain.steps import reload_the_page
 from selenium.common.exceptions import StaleElementReferenceException
+from django.conf import settings
 
 
 ############### ACTIONS ####################
@@ -85,7 +86,7 @@ def i_am_brought_to_help_page_in_new_window(step):
     windows = world.browser.windows
     assert_equal(2, len(windows))
     world.browser.switch_to_window(windows[1])
-    assert_equal('http://help.edge.edx.org/', world.browser.url)
+    assert_equal(settings.TENDER_URL + '/', world.browser.url)
 
 
 ############### HELPER METHODS ####################

--- a/cms/djangoapps/contentstore/views/tests/test_checklists.py
+++ b/cms/djangoapps/contentstore/views/tests/test_checklists.py
@@ -1,4 +1,5 @@
 """ Unit tests for checklist methods in views.py. """
+from django.conf import settings
 from contentstore.utils import reverse_course_url
 from contentstore.views.checklist import expand_checklist_action_url
 from xmodule.modulestore.tests.factories import CourseFactory
@@ -138,7 +139,7 @@ class ChecklistTestCase(CourseTestCase):
 
         test_expansion(self.course.checklists[0], 0, 'ManageUsers', '/course_team/mitX/333/Checklists_Course/')
         test_expansion(self.course.checklists[1], 1, 'CourseOutline', '/course/mitX/333/Checklists_Course')
-        test_expansion(self.course.checklists[2], 0, 'http://help.edge.edx.org/', 'http://help.edge.edx.org/')
+        test_expansion(self.course.checklists[2], 0, settings.TENDER_URL + '/', settings.TENDER_URL + '/')
 
 
 def get_first_item(checklist):

--- a/cms/templates/activation_invalid.html
+++ b/cms/templates/activation_invalid.html
@@ -27,7 +27,7 @@
 
       <ul class="list-actions">
         <li class="action-item">
-          <a href="http://help.edge.edx.org/discussion/new" class="action action-primary show-tender">${_('Contact edX Support')}</a>
+          <a href="${settings.TENDER_URL}/discussion/new" class="action action-primary show-tender">${_('Contact edX Support')}</a>
         </li>
       </ul>
     </div>

--- a/cms/templates/error.html
+++ b/cms/templates/error.html
@@ -16,14 +16,14 @@
       <h1>${_("The Page You Requested Page Cannot be Found")}</h1>
       <p class="description">${_("We're sorry. We couldn't find the {studio_name} page you're looking for. You may want to return to the {studio_name} Dashboard and try again. If you are still having problems accessing things, please feel free to {link_start}contact {studio_name} support{link_end} for further help.").format(
           studio_name=settings.STUDIO_SHORT_NAME,
-          link_start='<a href="http://help.edge.edx.org/discussion/new" class="show-tender" title="{title}">'.format(title=_("Use our feedback tool, Tender, to share your feedback")),
+          link_start='<a href="${settings.TENDER_URL}/discussion/new" class="show-tender" title="{title}">'.format(title=_("Use our feedback tool, Tender, to share your feedback")),
           link_end='</a>',
         )}</p>
     % elif error == '500':
       <h1>${_("The Server Encountered an Error")}</h1>
       <p class="description">${_("We're sorry. There was a problem with the server while trying to process your last request. You may want to return to the {studio_name} Dashboard or try this request again. If you are still having problems accessing things, please feel free to {link_start}contact {studio_name} support{link_end} for further help.").format(
           studio_name=settings.STUDIO_SHORT_NAME,
-          link_start='<a href="http://help.edge.edx.org/discussion/new" class="show-tender" title="{title}">'.format(title=_("Use our feedback tool, Tender, to share your feedback")),
+          link_start='<a href="${settings.TENDER_URL}/discussion/new" class="show-tender" title="{title}">'.format(title=_("Use our feedback tool, Tender, to share your feedback")),
           link_end='</a>',
         )}</p>
     % endif

--- a/cms/templates/index.html
+++ b/cms/templates/index.html
@@ -375,7 +375,7 @@
             <a href="${get_online_help_info(online_help_token())['doc_url']}" target="_blank">${_("Getting Started with {studio_name}").format(studio_name=settings.STUDIO_NAME)}</a>
           </li>
           <li class="action-item">
-            <a href="http://help.edge.edx.org/discussion/new" class="show-tender" title="${_("Use our feedback tool, Tender, to request help")}">${_("Request help with {studio_name}").format(studio_name=settings.STUDIO_NAME)}</a>
+            <a href="${settings.TENDER_URL}/discussion/new" class="show-tender" title="${_("Use our feedback tool, Tender, to request help")}">${_("Request help with {studio_name}").format(studio_name=settings.STUDIO_NAME)}</a>
           </li>
         </ol>
       </div>
@@ -405,7 +405,7 @@
             studio_name=settings.STUDIO_NAME,
             platform_name=settings.PLATFORM_NAME,
             link_start='<a href="{url}" class="show-tender">'.format(
-              url="http://help.edge.edx.org/discussion/new",
+              url="${settings.TENDER_URL}/discussion/new",
             ),
             link_end="</a>",
           )}</p>
@@ -440,7 +440,7 @@
 
         <ol class='list-actions'>
           <li class="action-item">
-            <a href="http://help.edge.edx.org/discussion/new" class="show-tender" title="${_("Use our feedback tool, Tender, to request help")}">${_("Request help with your {studio_name} account").format(studio_name=settings.STUDIO_NAME)}</a>
+            <a href="${settings.TENDER_URL}/discussion/new" class="show-tender" title="${_("Use our feedback tool, Tender, to request help")}">${_("Request help with your {studio_name} account").format(studio_name=settings.STUDIO_NAME)}</a>
           </li>
         </ol>
       </div>

--- a/cms/templates/login.html
+++ b/cms/templates/login.html
@@ -50,7 +50,7 @@ from django.utils.translation import ugettext as _
 
       <div class="bit">
         <h3 class="title-3">${_("Need Help?")}</h3>
-        <p>${_('Having trouble with your account? Use {link_start}our support center{link_end} to look over self help steps, find solutions others have found to the same problem, or let us know of your issue.').format(link_start='<a href="http://help.edge.edx.org" rel="external">', link_end='</a>')}</p>
+        <p>${_('Having trouble with your account? Use {link_start}our support center{link_end} to look over self help steps, find solutions others have found to the same problem, or let us know of your issue.').format(link_start='<a href="${settings.TENDER_URL}" rel="external">', link_end='</a>')}</p>
       </div>
     </aside>
   </section>

--- a/cms/templates/widgets/footer.html
+++ b/cms/templates/widgets/footer.html
@@ -17,7 +17,7 @@
         </li>
         % if user.is_authenticated():
         <li class="nav-item nav-peripheral-feedback">
-          <a href="http://help.edge.edx.org/discussion/new" class="show-tender" title="${_('Use our feedback tool, Tender, to share your feedback')}">${_("Contact Us")}</a>
+          <a href="${settings.TENDER_URL}/discussion/new" class="show-tender" title="${_('Use our feedback tool, Tender, to share your feedback')}">${_("Contact Us")}</a>
         </li>
         % endif
       </ol>

--- a/cms/templates/widgets/sock.html
+++ b/cms/templates/widgets/sock.html
@@ -30,7 +30,7 @@
           </li>
 
         <li class="action-item">
-          <a href="http://help.edge.edx.org/" rel="external" class="action action-primary">${_("{studio_name} Author Support").format(studio_name=settings.STUDIO_NAME)}</a>
+          <a href="${settings.TENDER_URL}/" rel="external" class="action action-primary">${_("{studio_name} Author Support").format(studio_name=settings.STUDIO_NAME)}</a>
           <span class="tip">${_("{studio_name} Author Support").format(studio_name=settings.STUDIO_NAME)}</span>
         </li>
         <li class="action-item">
@@ -50,7 +50,7 @@
         <ul class="list-actions">
           <li class="action-item">
 
-            <a href="http://help.edge.edx.org/discussion/new" class="action action-primary show-tender" title="${_("Use our feedback tool, Tender, to share your feedback")}"><i class="icon-comments"></i>${_("Contact Us")}</a>
+            <a href="${settings.TENDER_URL}/discussion/new" class="action action-primary show-tender" title="${_("Use our feedback tool, Tender, to share your feedback")}"><i class="icon-comments"></i>${_("Contact Us")}</a>
           </li>
         </ul>
       </div>

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -16,6 +16,7 @@ import json
 from xblock.fields import Scope, List, String, Dict, Boolean, Integer
 from .fields import Date
 from django.utils.timezone import UTC
+from django.conf import settings
 
 log = logging.getLogger(__name__)
 
@@ -444,7 +445,7 @@ class CourseFields(object):
                         "short_description": _("Explore the Studio Help Forum"),
                         "long_description": _("Access the Studio Help forum from the menu that appears when you click your user name in the top right corner of Studio."),
                         "is_checked": False,
-                        "action_url": "http://help.edge.edx.org/",
+                        "action_url": settings.TENDER_URL + "/",
                         "action_text": _("Visit Studio Help"),
                         "action_external": True,
                     },

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -57,6 +57,8 @@ DISCUSSION_SETTINGS = {
     'MAX_COMMENT_DEPTH': 2,
 }
 
+# Base url for course author support service
+TENDER_URL = 'http://help.example.com'
 
 # Features
 FEATURES = {


### PR DESCRIPTION
@e0d 
@nedbat 

We were hardcoding our author support into open instances of edX. Before merging this, we'll have to make sure we're setting the help url on prod to help.edge.edx.org

https://openedx.atlassian.net/browse/TNL-1020
