### PR TITLE
Enforced '000' prefix for xmodule.js and added unit test.

### DIFF
--- a/common/lib/xmodule/xmodule/static_content.py
+++ b/common/lib/xmodule/xmodule/static_content.py
@@ -122,9 +122,11 @@ def _write_js(output_root, classes):
     js_fragments = set()
     for class_ in classes:
         module_js = class_.get_javascript()
+        # It will enforce 000 prefix for xmodule.js.
+        js_fragments.add((0, 'js', module_js.get('xmodule_js')))
         for filetype in ('coffee', 'js'):
             for idx, fragment in enumerate(module_js.get(filetype, [])):
-                js_fragments.add((idx, filetype, fragment))
+                js_fragments.add((idx + 1, filetype, fragment))
 
     for idx, filetype, fragment in sorted(js_fragments):
         filename = "{idx:0=3d}-{hash}.{type}".format(

--- a/common/lib/xmodule/xmodule/tests/test_content.py
+++ b/common/lib/xmodule/xmodule/tests/test_content.py
@@ -1,8 +1,13 @@
+"""Tests for contents"""
+
+import os
 import unittest
 import ddt
+from path import path
 from xmodule.contentstore.content import StaticContent, StaticContentStream
 from xmodule.contentstore.content import ContentStore
 from opaque_keys.edx.locations import SlashSeparatedCourseKey, AssetLocation
+from xmodule.static_content import _write_js, _list_descriptors
 
 SAMPLE_STRING = """
 This is a sample string with more than 1024 bytes, the default STREAM_DATA_CHUNK_SIZE
@@ -155,3 +160,13 @@ class ContentTest(unittest.TestCase):
             total_length += len(chunck)
 
         self.assertEqual(total_length, last_byte - first_byte + 1)
+
+    def test_static_content_write_js(self):
+        """
+        Test that only one filename starts with 000.
+        """
+        output_root = path(u'common/static/xmodule/descriptors/js')
+        js_file_paths = _write_js(output_root, _list_descriptors())
+        js_file_paths = [file_path for file_path in js_file_paths if os.path.basename(file_path).startswith('000-')]
+        self.assertEqual(len(js_file_paths), 1)
+        self.assertIn("XModule.Descriptor = (function () {", open(js_file_paths[0]).read())

--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -200,10 +200,8 @@ class HTMLSnippet(object):
         coffee = cls.js.setdefault('coffee', [])
         js = cls.js.setdefault('js', [])
 
-        fragment = resource_string(__name__, 'js/src/xmodule.js')
-
-        if fragment not in js:
-            js.insert(0, fragment)
+        # Added xmodule.js separately to enforce 000 prefix for this only.
+        cls.js.setdefault('xmodule_js', resource_string(__name__, 'js/src/xmodule.js'))
 
         return cls.js
 


### PR DESCRIPTION
[TNL-1070](https://openedx.atlassian.net/browse/TNL-1070)

For `xmodule.js` the prefix will be `000` and for other dependencies it will be greater than `>= 001`, in this way `xmodule.js` will be loaded first.

Added unit test.
