### PR TITLE
 Test pagination reposition test is failing

### DIFF
--- a/common/test/acceptance/pages/lms/discussion.py
+++ b/common/test/acceptance/pages/lms/discussion.py
@@ -402,12 +402,24 @@ class DiscussionUserProfilePage(CoursePage):
 
     def click_prev_page(self):
         self._click_pager_with_text(self.TEXT_PREV, self.get_current_page() - 1)
+        EmptyPromise(
+            self.is_window_on_top,
+            "Window is on top"
+        ).fulfill()
 
     def click_next_page(self):
         self._click_pager_with_text(self.TEXT_NEXT, self.get_current_page() + 1)
+        EmptyPromise(
+            self.is_window_on_top,
+            "Window is on top"
+        ).fulfill()
 
     def click_on_page(self, page_number):
         self._click_pager_with_text(unicode(page_number), page_number)
+        EmptyPromise(
+            self.is_window_on_top,
+            "Window is on top"
+        ).fulfill()
 
 
 class DiscussionTabHomePage(CoursePage, DiscussionPageMixin):


### PR DESCRIPTION
Test pagination reposition test is failing on release
and master. It was flaky test and this problem was
caused by the javascript animation. Issue was fixed by
adding the promise that we check the value of window
top after the animation is completed.
