### PR TITLE
Handle the correct exception upon asset not found.

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -840,8 +840,15 @@ class MiscCourseTests(ContentStoreTestCase):
             self.store.unpublish(self.chapter_loc, self.user.id)
 
     def test_bad_contentstore_request(self):
-        resp = self.client.get_html('http://localhost:8001/c4x/CDX/123123/asset/&images_circuits_Lab7Solution2.png')
+        """
+        Test that user get proper responses for urls with invalid url or
+        asset/course key
+        """
+        resp = self.client.get_html('/c4x/CDX/123123/asset/&invalid.png')
         self.assertEqual(resp.status_code, 400)
+
+        resp = self.client.get_html('/c4x/CDX/123123/asset/invalid.png')
+        self.assertEqual(resp.status_code, 404)
 
     def test_delete_course(self):
         """

--- a/common/djangoapps/contentserver/middleware.py
+++ b/common/djangoapps/contentserver/middleware.py
@@ -15,6 +15,7 @@ from xmodule.modulestore import InvalidLocationError
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.locator import AssetLocator
 from cache_toolbox.core import get_cached_content, set_cached_content
+from xmodule.modulestore.exceptions import ItemNotFoundError
 from xmodule.exceptions import NotFoundError
 
 # TODO: Soon as we have a reasonable way to serialize/deserialize AssetKeys, we need
@@ -44,7 +45,7 @@ class StaticContentServer(object):
                 # nope, not in cache, let's fetch from DB
                 try:
                     content = AssetManager.find(loc, as_stream=True)
-                except NotFoundError:
+                except (ItemNotFoundError, NotFoundError):
                     response = HttpResponse()
                     response.status_code = 404
                     return response


### PR DESCRIPTION
Handle the correct exception to cause a 404 error upon asset not found instead of a 500 error.
