### PR TITLE
Fix for ECOM-876

### DIFF
--- a/lms/static/js/verify_student/pay_and_verify.js
+++ b/lms/static/js/verify_student/pay_and_verify.js
@@ -55,7 +55,7 @@ var edx = edx || {};
                 minPrice: el.data('course-mode-min-price'),
                 contributionAmount: el.data('contribution-amount'),
                 suggestedPrices: _.filter(
-                    (el.data('course-mode-suggested-prices') || "").split(","),
+                    (el.data('course-mode-suggested-prices').toString()).split(","),
                     function( price ) { return Boolean( price ); }
                 ),
                 currency: el.data('course-mode-currency'),


### PR DESCRIPTION
[ECOM-876](https://openedx.atlassian.net/browse/ECOM-876): TypeError in payment JavaScript

The error would occur for course modes with exactly one suggested price.  Since `data()` returns a number in this case, not a string, the `split()` function raised a type error.

We don't have existing tests that cover this, so in the interest of unblocking the release, I'd like to merge this into the RC and wait until we implement Selenium tests (next sprint) to cover this case.

I manually tested the payment flow with a course mode that had 0, 1, and 2 suggested prices.

@AlasdairSwan please review
FYI: @dsjen @cdodge  
