### PR TITLE
Content libraries analytics enhancements (SOL-121)

### DIFF
--- a/cms/djangoapps/contentstore/features/courses.py
+++ b/cms/djangoapps/contentstore/features/courses.py
@@ -34,9 +34,8 @@ def i_create_a_course(step):
     create_a_course()
 
 
-# pylint: disable=invalid-name
 @step('I click the course link in Studio Home$')
-def i_click_the_course_link_in_studio_home(step):
+def i_click_the_course_link_in_studio_home(step):  # pylint: disable=invalid-name
     course_css = 'a.course-link'
     world.css_click(course_css)
 

--- a/common/djangoapps/terrain/ui_helpers.py
+++ b/common/djangoapps/terrain/ui_helpers.py
@@ -28,28 +28,27 @@ GLOBAL_WAIT_FOR_TIMEOUT = 60
 
 REQUIREJS_WAIT = {
     # Settings - Schedule & Details
-    re.compile('^Schedule & Details Settings \|'): [
+    re.compile(r'^Schedule & Details Settings \|'): [
         "jquery", "js/base", "js/models/course",
         "js/models/settings/course_details", "js/views/settings/main"],
 
     # Settings - Advanced Settings
-    re.compile('^Advanced Settings \|'): [
+    re.compile(r'^Advanced Settings \|'): [
         "jquery", "js/base", "js/models/course", "js/models/settings/advanced",
         "js/views/settings/advanced", "codemirror"],
 
     # Unit page
-    re.compile('^Unit \|'): [
+    re.compile(r'^Unit \|'): [
         "jquery", "js/base", "js/models/xblock_info", "js/views/pages/container",
         "js/collections/component_template", "xmodule", "coffee/src/main", "xblock/cms.runtime.v1"],
 
     # Content - Outline
     # Note that calling your org, course number, or display name, 'course' will mess this up
-    re.compile('^Course Outline \|'): [
+    re.compile(r'^Course Outline \|'): [
         "js/base", "js/models/course", "js/models/location", "js/models/section"],
 
     # Dashboard
-    # pylint: disable=anomalous-backslash-in-string
-    re.compile('^Studio Home \|'): [
+    re.compile(r'^Studio Home \|'): [
         "js/sock", "gettext", "js/base",
         "jquery.ui", "coffee/src/main", "underscore"],
 
@@ -60,7 +59,7 @@ REQUIREJS_WAIT = {
     ],
 
     # Pages
-    re.compile('^Pages \|'): [
+    re.compile(r'^Pages \|'): [
         'js/models/explicit_url', 'coffee/src/views/tabs',
         'xmodule', 'coffee/src/main', 'xblock/cms.runtime.v1'
     ],

--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -221,35 +221,39 @@ class LibraryContentModule(LibraryContentFields, XModule, StudioEditableModule):
             # Already done:
             return self._selected_set  # pylint: disable=access-member-before-definition
 
+        selected = set(tuple(k) for k in self.selected)  # set of (block_type, block_id) tuples assigned to this student
+        previous_count = len(selected)
+
         lib_tools = self.runtime.service(self, 'library_tools')
         format_block_keys = lambda keys: lib_tools.create_block_analytics_summary(self.location.course_key, keys)
 
+        def publish_event(event_name, **kwargs):
+            """ Publish an event for analytics purposes """
+            event_data = {
+                "location": unicode(self.location),
+                "result": format_block_keys(selected),
+                "previous_count": previous_count,
+                "max_count": self.max_count,
+            }
+            event_data.update(kwargs)
+            self.runtime.publish(self, "edx.librarycontentblock.content.{}".format(event_name), event_data)
+
         # Determine which of our children we will show:
-        selected = set(tuple(k) for k in self.selected)  # set of (block_type, block_id) tuples
         valid_block_keys = set([(c.block_type, c.block_id) for c in self.children])  # pylint: disable=no-member
         # Remove any selected blocks that are no longer valid:
         invalid_block_keys = (selected - valid_block_keys)
         if invalid_block_keys:
             selected -= invalid_block_keys
             # Publish an event for analytics purposes:
-            self.runtime.publish(self, "edx.librarycontentblock.content.removed", {
-                "location": unicode(self.location),
-                "removed": format_block_keys(invalid_block_keys),
-                "reason": "invalid",  # Deleted from library or library being used has changed
-                "result": format_block_keys(selected),
-            })
+            # reason "invalid" means deleted from library or a different library is now being used.
+            publish_event("removed", removed=format_block_keys(invalid_block_keys), reason="invalid")
         # If max_count has been decreased, we may have to drop some previously selected blocks:
         overlimit_block_keys = set()
         while len(selected) > self.max_count:
             overlimit_block_keys.add(selected.pop())
         if overlimit_block_keys:
             # Publish an event for analytics purposes:
-            self.runtime.publish(self, "edx.librarycontentblock.content.removed", {
-                "location": unicode(self.location),
-                "removed": format_block_keys(overlimit_block_keys),
-                "reason": "overlimit",
-                "result": format_block_keys(selected),
-            })
+            publish_event("removed", removed=format_block_keys(overlimit_block_keys), reason="overlimit")
         # Do we have enough blocks now?
         num_to_add = self.max_count - len(selected)
         if num_to_add > 0:
@@ -265,11 +269,7 @@ class LibraryContentModule(LibraryContentFields, XModule, StudioEditableModule):
             selected |= added_block_keys
             if added_block_keys:
                 # Publish an event for analytics purposes:
-                self.runtime.publish(self, "edx.librarycontentblock.content.assigned", {
-                    "location": unicode(self.location),
-                    "added": format_block_keys(added_block_keys),
-                    "result": format_block_keys(selected),
-                })
+                publish_event("assigned", added=format_block_keys(added_block_keys))
         # Save our selections to the user state, to ensure consistency:
         self.selected = list(selected)  # TODO: this doesn't save from the LMS "Progress" page.
         # Cache the results

--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -222,7 +222,7 @@ class LibraryContentModule(LibraryContentFields, XModule, StudioEditableModule):
             return self._selected_set  # pylint: disable=access-member-before-definition
 
         lib_tools = self.runtime.service(self, 'library_tools')
-        format_block_keys = lambda block_keys: lib_tools.create_block_analytics_summary(self.location.course_key, block_keys)
+        format_block_keys = lambda keys: lib_tools.create_block_analytics_summary(self.location.course_key, keys)
 
         # Determine which of our children we will show:
         selected = set(tuple(k) for k in self.selected)  # set of (block_type, block_id) tuples

--- a/common/lib/xmodule/xmodule/modulestore/mixed.py
+++ b/common/lib/xmodule/xmodule/modulestore/mixed.py
@@ -509,6 +509,18 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
         store = self._get_modulestore_for_courseid(location.course_key)
         return store.get_parent_location(location, **kwargs)
 
+    def get_block_original_usage(self, usage_key):
+        """
+        If a block was inherited into another structure using copy_from_template,
+        this will return the original block usage locator from which the
+        copy was inherited.
+        """
+        try:
+            store = self._verify_modulestore_support(usage_key.course_key, 'get_block_original_usage')
+            return store.get_block_original_usage(usage_key)
+        except NotImplementedError:
+            return None, None
+
     def get_modulestore_type(self, course_id):
         """
         Returns a type which identifies which modulestore is servicing the given course_id.

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split_draft.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split_draft.py
@@ -268,6 +268,15 @@ class DraftVersioningModuleStore(SplitMongoModuleStore, ModuleStoreDraftAndPubli
         location = self._map_revision_to_branch(location, revision=revision)
         return super(DraftVersioningModuleStore, self).get_parent_location(location, **kwargs)
 
+    def get_block_original_usage(self, usage_key):
+        """
+        If a block was inherited into another structure using copy_from_template,
+        this will return the original block usage locator from which the
+        copy was inherited.
+        """
+        usage_key = self._map_revision_to_branch(usage_key)
+        return super(DraftVersioningModuleStore, self).get_block_original_usage(usage_key)
+
     def get_orphans(self, course_key, **kwargs):
         course_key = self._map_revision_to_branch(course_key)
         return super(DraftVersioningModuleStore, self).get_orphans(course_key, **kwargs)

--- a/common/lib/xmodule/xmodule/modulestore/tests/utils.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/utils.py
@@ -119,6 +119,7 @@ class MixedSplitTestCase(TestCase):
         extra.update(kwargs)
         return ItemFactory.create(
             category=category,
+            parent=parent_block,
             parent_location=parent_block.location,
             modulestore=self.store,
             **extra

--- a/common/lib/xmodule/xmodule/tests/test_library_content.py
+++ b/common/lib/xmodule/xmodule/tests/test_library_content.py
@@ -5,22 +5,22 @@ Basic unit tests for LibraryContentModule
 Higher-level tests are in `cms/djangoapps/contentstore/tests/test_libraries.py`.
 """
 from bson.objectid import ObjectId
-from mock import patch
+from mock import Mock, patch
 from opaque_keys.edx.locator import LibraryLocator
 from unittest import TestCase
 
 from xblock.fragment import Fragment
 from xblock.runtime import Runtime as VanillaRuntime
 
-from xmodule.x_module import AUTHOR_VIEW
 from xmodule.library_content_module import (
     LibraryVersionReference, LibraryList, ANY_CAPA_TYPE_VALUE, LibraryContentDescriptor
 )
-from xmodule.modulestore.tests.factories import LibraryFactory, CourseFactory, ItemFactory
+from xmodule.library_tools import LibraryToolsService
+from xmodule.modulestore.tests.factories import LibraryFactory, CourseFactory
 from xmodule.modulestore.tests.utils import MixedSplitTestCase
 from xmodule.tests import get_test_system
 from xmodule.validation import StudioValidationMessage
-
+from xmodule.x_module import AUTHOR_VIEW
 
 dummy_render = lambda block, _: Fragment(block.data)  # pylint: disable=invalid-name
 
@@ -32,46 +32,21 @@ class LibraryContentTest(MixedSplitTestCase):
     def setUp(self):
         super(LibraryContentTest, self).setUp()
 
+        self.tools = LibraryToolsService(self.store)
         self.library = LibraryFactory.create(modulestore=self.store)
         self.lib_blocks = [
-            ItemFactory.create(
-                category="html",
-                parent_location=self.library.location,
-                user_id=self.user_id,
-                publish_item=False,
-                metadata={"data": "Hello world from block {}".format(i), },
-                modulestore=self.store,
-            )
+            self.make_block("html", self.library, data="Hello world from block {}".format(i))
             for i in range(1, 5)
         ]
         self.course = CourseFactory.create(modulestore=self.store)
-        self.chapter = ItemFactory.create(
-            category="chapter",
-            parent_location=self.course.location,
-            user_id=self.user_id,
-            modulestore=self.store,
-        )
-        self.sequential = ItemFactory.create(
-            category="sequential",
-            parent_location=self.chapter.location,
-            user_id=self.user_id,
-            modulestore=self.store,
-        )
-        self.vertical = ItemFactory.create(
-            category="vertical",
-            parent_location=self.sequential.location,
-            user_id=self.user_id,
-            modulestore=self.store,
-        )
-        self.lc_block = ItemFactory.create(
-            category="library_content",
-            parent_location=self.vertical.location,
-            user_id=self.user_id,
-            modulestore=self.store,
-            metadata={
-                'max_count': 1,
-                'source_libraries': [LibraryVersionReference(self.library.location.library_key)]
-            }
+        self.chapter = self.make_block("chapter", self.course)
+        self.sequential = self.make_block("sequential", self.chapter)
+        self.vertical = self.make_block("vertical", self.sequential)
+        self.lc_block = self.make_block(
+            "library_content",
+            self.vertical,
+            max_count=1,
+            source_libraries=[LibraryVersionReference(self.library.location.library_key)]
         )
 
     def _bind_course_module(self, module):
@@ -80,6 +55,7 @@ class LibraryContentTest(MixedSplitTestCase):
         """
         module_system = get_test_system(course_id=self.course.location.course_key)
         module_system.descriptor_runtime = module.runtime
+        module_system._services['library_tools'] = self.tools  # pylint: disable=protected-access
 
         def get_module(descriptor):
             """Mocks module_system get_module function"""
@@ -92,6 +68,11 @@ class LibraryContentTest(MixedSplitTestCase):
         module_system.get_module = get_module
         module.xmodule_runtime = module_system
 
+
+class TestLibraryContentModule(LibraryContentTest):
+    """
+    Basic unit tests for LibraryContentModule
+    """
     def _get_capa_problem_type_xml(self, *args):
         """ Helper function to create empty CAPA problem definition """
         problem = "<problem>"
@@ -111,20 +92,8 @@ class LibraryContentTest(MixedSplitTestCase):
             ["coderesponse", "optionresponse"]
         ]
         for problem_type in problem_types:
-            ItemFactory.create(
-                category="problem",
-                parent_location=self.library.location,
-                user_id=self.user_id,
-                publish_item=False,
-                data=self._get_capa_problem_type_xml(*problem_type),
-                modulestore=self.store,
-            )
+            self.make_block("problem", self.library, data=self._get_capa_problem_type_xml(*problem_type))
 
-
-class TestLibraryContentModule(LibraryContentTest):
-    """
-    Basic unit tests for LibraryContentModule
-    """
     def test_lib_content_block(self):
         """
         Test that blocks from a library are copied and added as children
@@ -338,3 +307,167 @@ class TestLibraryList(TestCase):
         lib_list = LibraryList()
         with self.assertRaises(ValueError):
             lib_list.from_json(["Not-a-library-key,whatever"])
+
+
+class TestLibraryContentAnalytics(LibraryContentTest):
+    """
+    Test analytics features of LibraryContentModule
+    """
+    def setUp(self):
+        super(TestLibraryContentAnalytics, self).setUp()
+        self.publisher = Mock()
+        self.lc_block.refresh_children()
+        self.lc_block = self.store.get_item(self.lc_block.location)
+        self._bind_course_module(self.lc_block)
+        self.lc_block.xmodule_runtime.publish = self.publisher
+
+    def _assert_event_was_published(self, event_type):
+        """
+        Check that a LibraryContentModule analytics event was published by self.lc_block.
+        """
+        self.assertTrue(self.publisher.called)
+        self.assertTrue(len(self.publisher.call_args[0]), 3)
+        _, event_name, event_data = self.publisher.call_args[0]
+        self.assertEqual(event_name, "edx.librarycontentblock.content.{}".format(event_type))
+        self.assertEqual(event_data["location"], unicode(self.lc_block.location))
+        return event_data
+
+    def test_assigned_event(self):
+        """
+        Test the "assigned" event emitted when a student is assigned specific blocks.
+        """
+        # In the beginning was the lc_block and it assigned one child to the student:
+        child = self.lc_block.get_child_descriptors()[0]
+        child_lib_location, child_lib_version = self.store.get_block_original_usage(child.location)
+        self.assertIsInstance(child_lib_version, ObjectId)
+        event_data = self._assert_event_was_published("assigned")
+        block_info = {
+            "usage_key": unicode(child.location),
+            "original_usage_key": unicode(child_lib_location),
+            "original_usage_version": unicode(child_lib_version),
+            "descendants": [],
+        }
+        self.assertEqual(event_data, {
+            "location": unicode(self.lc_block.location),
+            "added": [block_info],
+            "result": [block_info],
+        })
+        self.publisher.reset_mock()
+
+        # Now increase max_count so that one more child will be added:
+        self.lc_block.max_count = 2
+        del self.lc_block._xmodule._selected_set  # Clear the cache (only needed because we skip saving/re-loading the block) pylint: disable=protected-access
+        children = self.lc_block.get_child_descriptors()
+        self.assertEqual(len(children), 2)
+        child, new_child = children if children[0].location == child.location else reversed(children)
+        event_data = self._assert_event_was_published("assigned")
+        self.assertEqual(event_data["added"][0]["usage_key"], unicode(new_child.location))
+        self.assertEqual(len(event_data["result"]), 2)
+
+    def test_assigned_descendants(self):
+        """
+        Test the "assigned" event emitted includes descendant block information.
+        """
+        # Replace the blocks in the library with a block that has descendants:
+        with self.store.bulk_operations(self.library.location.library_key):
+            self.library.children = []
+            main_vertical = self.make_block("vertical", self.library)
+            inner_vertical = self.make_block("vertical", main_vertical)
+            html_block = self.make_block("html", inner_vertical)
+            problem_block = self.make_block("problem", inner_vertical)
+            self.lc_block.refresh_children()
+
+        # Reload lc_block and set it up for a student:
+        self.lc_block = self.store.get_item(self.lc_block.location)
+        self._bind_course_module(self.lc_block)
+        self.lc_block.xmodule_runtime.publish = self.publisher
+
+        # Get the keys of each of our blocks, as they appear in the course:
+        course_usage_main_vertical = self.lc_block.children[0]
+        course_usage_inner_vertical = self.store.get_item(course_usage_main_vertical).children[0]
+        inner_vertical_in_course = self.store.get_item(course_usage_inner_vertical)
+        course_usage_html = inner_vertical_in_course.children[0]
+        course_usage_problem = inner_vertical_in_course.children[1]
+
+        # Trigger a publish event:
+        self.lc_block.get_child_descriptors()
+        event_data = self._assert_event_was_published("assigned")
+
+        for block_list in (event_data["added"], event_data["result"]):
+            self.assertEqual(len(block_list), 1)  # The main_vertical is the only root block added, and is the only result.
+            self.assertEqual(block_list[0]["usage_key"], unicode(course_usage_main_vertical))
+
+            # Check that "descendants" is a flat, unordered list of all of main_vertical's descendants:
+            descendants_expected = {}
+            for lib_key, course_usage_key in (
+                (inner_vertical.location, course_usage_inner_vertical),
+                (html_block.location, course_usage_html),
+                (problem_block.location, course_usage_problem),
+            ):
+                descendants_expected[unicode(course_usage_key)] = {
+                    "usage_key": unicode(course_usage_key),
+                    "original_usage_key": unicode(lib_key),
+                    "original_usage_version": unicode(self.store.get_block_original_usage(course_usage_key)[1]),
+                }
+            self.assertEqual(len(block_list[0]["descendants"]), len(descendants_expected))
+            for descendant in block_list[0]["descendants"]:
+                self.assertEqual(descendant, descendants_expected.get(descendant["usage_key"]))
+
+    def test_removed_overlimit(self):
+        """
+        Test the "removed" event emitted when we un-assign blocks previously assigned to a student.
+        We go from one blocks assigned to none because max_count has been decreased.
+        """
+        # Decrease max_count to 1, causing the block to be overlimit:
+        self.lc_block.get_child_descriptors()  # We must call an XModule method before we can change max_count - otherwise the change has no effect
+        self.publisher.reset_mock()  # Clear the "assigned" event that was just published.
+        self.lc_block.max_count = 0
+        del self.lc_block._xmodule._selected_set  # Clear the cache (only needed because we skip saving/re-loading the block) pylint: disable=protected-access
+
+        # Check that the event says that one block was removed, leaving no blocks left:
+        children = self.lc_block.get_child_descriptors()
+        self.assertEqual(len(children), 0)
+        event_data = self._assert_event_was_published("removed")
+        self.assertEqual(len(event_data["removed"]), 1)
+        self.assertEqual(event_data["result"], [])
+        self.assertEqual(event_data["reason"], "overlimit")
+
+    def test_removed_invalid(self):
+        """
+        Test the "removed" event emitted when we un-assign blocks previously assigned to a student.
+        We go from two blocks assigned, to one because the others have been deleted from the library.
+        """
+        # Start by assigning two blocks to the student:
+        self.lc_block.get_child_descriptors()  # We must call an XModule method before we can change max_count - otherwise the change has no effect
+        self.lc_block.max_count = 2
+        del self.lc_block._xmodule._selected_set  # Clear the cache (only needed because we skip saving/re-loading the block) pylint: disable=protected-access
+        initial_blocks_assigned = self.lc_block.get_child_descriptors()
+        self.assertEqual(len(initial_blocks_assigned), 2)
+        self.publisher.reset_mock()  # Clear the "assigned" event that was just published.
+        # Now make sure that one of the assigned blocks will have to be un-assigned.
+        # To cause an "invalid" event, we delete all blocks from the content library except for one of the two already assigned to the student:
+        keep_block_key = initial_blocks_assigned[0].location
+        keep_block_lib_usage_key, keep_block_lib_version = self.store.get_block_original_usage(keep_block_key)
+        deleted_block_key = initial_blocks_assigned[1].location
+        self.library.children = [keep_block_lib_usage_key]
+        self.store.update_item(self.library, self.user_id)
+        self.lc_block.refresh_children()
+        del self.lc_block._xmodule._selected_set  # Clear the cache (only needed because we skip saving/re-loading the block) pylint: disable=protected-access
+
+        # Check that the event says that one block was removed, leaving one block left:
+        children = self.lc_block.get_child_descriptors()
+        self.assertEqual(len(children), 1)
+        event_data = self._assert_event_was_published("removed")
+        self.assertEqual(event_data["removed"], [{
+            "usage_key": unicode(deleted_block_key),
+            "original_usage_key": None,  # Note: original_usage_key info is sadly unavailable because the block has been deleted so that info can no longer be retrieved
+            "original_usage_version": None,
+            "descendants": [],
+        }])
+        self.assertEqual(event_data["result"], [{
+            "usage_key": unicode(keep_block_key),
+            "original_usage_key": unicode(keep_block_lib_usage_key),
+            "original_usage_version": unicode(keep_block_lib_version),
+            "descendants": [],
+        }])
+        self.assertEqual(event_data["reason"], "invalid")

--- a/common/lib/xmodule/xmodule/tests/test_library_content.py
+++ b/common/lib/xmodule/xmodule/tests/test_library_content.py
@@ -351,6 +351,8 @@ class TestLibraryContentAnalytics(LibraryContentTest):
             "location": unicode(self.lc_block.location),
             "added": [block_info],
             "result": [block_info],
+            "previous_count": 0,
+            "max_count": 1,
         })
         self.publisher.reset_mock()
 
@@ -364,6 +366,8 @@ class TestLibraryContentAnalytics(LibraryContentTest):
         event_data = self._assert_event_was_published("assigned")
         self.assertEqual(event_data["added"][0]["usage_key"], unicode(new_child.location))
         self.assertEqual(len(event_data["result"]), 2)
+        self.assertEqual(event_data["previous_count"], 1)
+        self.assertEqual(event_data["max_count"], 2)
 
     def test_assigned_descendants(self):
         """

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -973,10 +973,10 @@ class TestModuleTrackingContext(ModuleStoreTestCase):
 
     def test_context_contains_display_name(self, mock_tracker):
         problem_display_name = u'Option Response Problem'
-        module_info = self.handle_callback_and_get_module_info_from_event(mock_tracker, problem_display_name)
+        module_info = self.handle_callback_and_get_module_info(mock_tracker, problem_display_name)
         self.assertEquals(problem_display_name, module_info['display_name'])
 
-    def handle_callback_and_get_module_info_from_event(self, mock_tracker, problem_display_name=None):
+    def handle_callback_and_get_module_info(self, mock_tracker, problem_display_name=None):
         """
         Creates a fake module, invokes the callback and extracts the 'module'
         metadata from the emitted problem_check event.
@@ -1006,7 +1006,7 @@ class TestModuleTrackingContext(ModuleStoreTestCase):
         return event['context']['module']
 
     def test_missing_display_name(self, mock_tracker):
-        actual_display_name = self.handle_callback_and_get_module_info_from_event(mock_tracker)['display_name']
+        actual_display_name = self.handle_callback_and_get_module_info(mock_tracker)['display_name']
         self.assertTrue(actual_display_name.startswith('problem'))
 
     def test_library_source_information(self, mock_tracker):
@@ -1017,8 +1017,9 @@ class TestModuleTrackingContext(ModuleStoreTestCase):
         """
         original_usage_key = UsageKey.from_string(u'block-v1:A+B+C+type@problem+block@abcd1234')
         original_usage_version = ObjectId()
-        with patch('xmodule.modulestore.mixed.MixedModuleStore.get_block_original_usage', lambda _, key: (original_usage_key, original_usage_version)):
-            module_info = self.handle_callback_and_get_module_info_from_event(mock_tracker)
+        mock_get_original_usage = lambda _, key: (original_usage_key, original_usage_version)
+        with patch('xmodule.modulestore.mixed.MixedModuleStore.get_block_original_usage', mock_get_original_usage):
+            module_info = self.handle_callback_and_get_module_info(mock_tracker)
             self.assertIn('original_usage_key', module_info)
             self.assertEqual(module_info['original_usage_key'], unicode(original_usage_key))
             self.assertIn('original_usage_version', module_info)

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -5,6 +5,7 @@ Test for lms courseware app, module render unit
 from functools import partial
 import json
 
+from bson import ObjectId
 import ddt
 from django.http import Http404, HttpResponse
 from django.core.urlresolvers import reverse
@@ -13,6 +14,7 @@ from django.test.client import RequestFactory
 from django.test.utils import override_settings
 from django.contrib.auth.models import AnonymousUser
 from mock import MagicMock, patch, Mock
+from opaque_keys.edx.keys import UsageKey
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
 from xblock.field_data import FieldData
 from xblock.runtime import Runtime
@@ -971,12 +973,13 @@ class TestModuleTrackingContext(ModuleStoreTestCase):
 
     def test_context_contains_display_name(self, mock_tracker):
         problem_display_name = u'Option Response Problem'
-        actual_display_name = self.handle_callback_and_get_display_name_from_event(mock_tracker, problem_display_name)
-        self.assertEquals(problem_display_name, actual_display_name)
+        module_info = self.handle_callback_and_get_module_info_from_event(mock_tracker, problem_display_name)
+        self.assertEquals(problem_display_name, module_info['display_name'])
 
-    def handle_callback_and_get_display_name_from_event(self, mock_tracker, problem_display_name=None):
+    def handle_callback_and_get_module_info_from_event(self, mock_tracker, problem_display_name=None):
         """
-        Creates a fake module, invokes the callback and extracts the display name from the emitted problem_check event.
+        Creates a fake module, invokes the callback and extracts the 'module'
+        metadata from the emitted problem_check event.
         """
         descriptor_kwargs = {
             'category': 'problem',
@@ -1000,11 +1003,26 @@ class TestModuleTrackingContext(ModuleStoreTestCase):
         event = mock_call[1][0]
 
         self.assertEquals(event['event_type'], 'problem_check')
-        return event['context']['module']['display_name']
+        return event['context']['module']
 
     def test_missing_display_name(self, mock_tracker):
-        actual_display_name = self.handle_callback_and_get_display_name_from_event(mock_tracker)
+        actual_display_name = self.handle_callback_and_get_module_info_from_event(mock_tracker)['display_name']
         self.assertTrue(actual_display_name.startswith('problem'))
+
+    def test_library_source_information(self, mock_tracker):
+        """
+        Check that XBlocks that are inherited from a library include the
+        information about their library block source in events.
+        We patch the modulestore to avoid having to create a library.
+        """
+        original_usage_key = UsageKey.from_string(u'block-v1:A+B+C+type@problem+block@abcd1234')
+        original_usage_version = ObjectId()
+        with patch('xmodule.modulestore.mixed.MixedModuleStore.get_block_original_usage', lambda _, key: (original_usage_key, original_usage_version)):
+            module_info = self.handle_callback_and_get_module_info_from_event(mock_tracker)
+            self.assertIn('original_usage_key', module_info)
+            self.assertEqual(module_info['original_usage_key'], unicode(original_usage_key))
+            self.assertIn('original_usage_version', module_info)
+            self.assertEqual(module_info['original_usage_version'], unicode(original_usage_version))
 
 
 class TestXmoduleRuntimeEvent(TestSubmittingProblems):

--- a/lms/djangoapps/lms_xblock/runtime.py
+++ b/lms/djangoapps/lms_xblock/runtime.py
@@ -10,6 +10,7 @@ from django.conf import settings
 from lms.djangoapps.lms_xblock.models import XBlockAsidesConfig
 from openedx.core.djangoapps.user_api.api import course_tag as user_course_tag_api
 from xmodule.modulestore.django import modulestore
+from xmodule.library_tools import LibraryToolsService
 from xmodule.x_module import ModuleSystem
 from xmodule.partitions.partitions_service import PartitionService
 
@@ -199,6 +200,7 @@ class LmsModuleSystem(LmsHandlerUrls, ModuleSystem):  # pylint: disable=abstract
             course_id=kwargs.get('course_id'),
             track_function=kwargs.get('track_function', None),
         )
+        services['library_tools'] = LibraryToolsService(modulestore())
         services['fs'] = xblock.reference.plugins.FSService()
         self.request_token = kwargs.pop('request_token', None)
         super(LmsModuleSystem, self).__init__(**kwargs)


### PR DESCRIPTION
**Background**: This PR implements three changes to support better analytics when content libraries are used:
- Adds a new field to the `edit_info` of blocks in split mongo's structures table, in order to track the original usage key of blocks copied from a library.
- Adds extra data to LMS events like `problem_check` such as the library usage ID of the problem (builds on #2696)
- Emits new `assigned` and `removed` events when students are randomly assigned problems from a library

**Discussion**: Has largely taken place on [this Confluence wiki page](https://openedx.atlassian.net/wiki/display/SOL/Content+Libraries) in the comments and the section near the top entitled "Analytics Considerations".

**Dependencies:** Depends on the PRs already merged into the `content-libraries` feature branch.

**Sandbox URL**: TBD

**Prior code reviews**: https://github.com/open-craft/edx-platform/pull/26

This implements support for analytics of content libraries, built to implement the ideas of Brian Wilson and Don Mitchell described on [the Confluence wiki page](https://openedx.atlassian.net/wiki/display/SOL/Content+Libraries) in the section near the top entitled "Analytics Considerations".
## New tracking events:

Two new events will appear in the tracking logs (see example below):
- `edx.librarycontentblock.content.assigned` - indicates that a student has been assigned their subset of blocks. Data includes:
  - `location` The BlockUsageLocator of the LibraryContentModule emitting the event
  - `added`: a list of data about the blocks added (usage keys in both the course and the library, the block's "update_version", and a _flat_ list of the same information about any descendants the block has)
  - `result`: a list of the complete set of blocks now assigned to this student (will always equal `added` at first, but if `max_count` is increased, `added` may be different)
  - `max_count`: The new value of max_count. May be greater than `len(result)` if the library contains fewer matching blocks than max_count.
  - `previous_count`: The number of blocks that were previously assigned to this student (before this event)
- `edx.librarycontentblock.content.removed` - indicates that a previously-assigned block is no longer being shown to this student. This should be very rare. Data includes:
  - `location` The BlockUsageLocator of the LibraryContentModule emitting the event
  - `removed`: a list of the blocks that were removed (same format as "added", above **but may not have the library usage key and version in some cases**)
  - `result`: a list of the complete set of remaining blocks now assigned to this student
  - `reason`: Either `overlimit` (`max_count` was decreased by the course author) or `invalid` (Block was deleted from library or library setting was changed and no longer includes this block)
  - `max_count`: The new value of max_count. May be greater than `len(result)` if the library contains fewer matching blocks than max_count.
  - `previous_count`: The number of blocks that were previously assigned to this student (before this event)

To test: As the vagrant user you can run `sudo tail -f /edx/var/log/tracking/tracking.log` to watch the tracking log. If you sign in to the LMS as a student and view a course containing a LibraryContent block, the first time that you view the courseware should result in an "edx.librarycontentblock.content.assigned" entry appearing in the logs. This entry should appear as below.

Also the Django admin interface at http://localhost:8000/admin/courseware/studentmodule/ is helpful for resetting the student state for your test student user.
## Example tracking log entries

First, I made a library with two main blocks - one without children and one with a hierarchy. This is what it looks like:
![screen shot 2015-01-05 at 10 07 52 pm](https://cloud.githubusercontent.com/assets/945577/5625058/9d87a4ca-9527-11e4-8c8a-6c6a75a05e4c.png)

Next, if a student sees a library content block using this library that has recently been edited to go from showing 1 block to showing 2, they will generate this analytics "added" event:

``` json
{
    "username": "honor",
    "host": "precise64",
    "event_source": "server",
    "event_type": "edx.librarycontentblock.content.assigned",
    "context": {
        "course_user_tags": {},
        "user_id": 1,
        "org_id": "BradenX",
        "course_id": "course-v1:BradenX+TEST+1",
        "path": "/courses/course-v1:BradenX+TEST+1/courseware/f61bfa6228e948f59ac1107f6077e00c/1aac970a9128469ea78c8ef1c1d0a965/"
    },
    "time": "2015-01-06T05:47:09.501831+00:00",
    "ip": "10.0.2.2",
    "event": {
        "added": [
            {
                "usage_key": "block-v1:BradenX+TEST+1+type@vertical+block@2a983fb828ee8bf6e34b",
                "original_usage_key": "lib-block-v1:BradenX+OVRD+type@vertical+block@108c4492010d49c2b3844eebdd99626b",
                "original_usage_version": "54ab715f56c02c5a88bb5df9",
                "descendants": [
                    {
                        "original_usage_version": "54ab716d56c02c5a88bb5dfb",
                        "usage_key": "block-v1:BradenX+TEST+1+type@vertical+block@975fbb4d7cde4642e81e",
                        "original_usage_key": "lib-block-v1:BradenX+OVRD+type@vertical+block@d14de4dfc5fc4fc3a2b1e5c08de3c6e8"
                    },
                    {
                        "original_usage_version": "54ab717b56c02c5a88bb5dfd",
                        "usage_key": "block-v1:BradenX+TEST+1+type@html+block@af83d86bd23f3385cb8d",
                        "original_usage_key": "lib-block-v1:BradenX+OVRD+type@html+block@120657bdb6714a3096518e4fc020b1a9"
                    },
                    {
                        "original_usage_version": "54ab6fb356c02c591fefcdb9",
                        "usage_key": "block-v1:BradenX+TEST+1+type@html+block@2779f12e43582c7e0789",
                        "original_usage_key": "lib-block-v1:BradenX+OVRD+type@html+block@8d79a3991a2d467cb9095bd1fa365e71"
                    }
                ]
            }
        ],
        "location": "block-v1:BradenX+TEST+1+type@library_content+block@f3ebf2bfd1d047c284deebbff984e4e3",
        "previous_count": 1,
        "max_count": 2,
        "result": [
            {
                "usage_key": "block-v1:BradenX+TEST+1+type@problem+block@c279e825df7fb020cb2c",
                "original_usage_key": "lib-block-v1:BradenX+OVRD+type@problem+block@4b0043c672b54878b4600f7b1655435c",
                "original_usage_version": "54ab718c56c02c5a88bb5dff",
                "descendants": []
            },
            {
                "usage_key": "block-v1:BradenX+TEST+1+type@vertical+block@2a983fb828ee8bf6e34b",
                "original_usage_key": "lib-block-v1:BradenX+OVRD+type@vertical+block@108c4492010d49c2b3844eebdd99626b",
                "original_usage_version": "54ab715f56c02c5a88bb5df9",
                "descendants": [
                    {
                        "original_usage_version": "54ab716d56c02c5a88bb5dfb",
                        "usage_key": "block-v1:BradenX+TEST+1+type@vertical+block@975fbb4d7cde4642e81e",
                        "original_usage_key": "lib-block-v1:BradenX+OVRD+type@vertical+block@d14de4dfc5fc4fc3a2b1e5c08de3c6e8"
                    },
                    {
                        "original_usage_version": "54ab717b56c02c5a88bb5dfd",
                        "usage_key": "block-v1:BradenX+TEST+1+type@html+block@af83d86bd23f3385cb8d",
                        "original_usage_key": "lib-block-v1:BradenX+OVRD+type@html+block@120657bdb6714a3096518e4fc020b1a9"
                    },
                    {
                        "original_usage_version": "54ab6fb356c02c591fefcdb9",
                        "usage_key": "block-v1:BradenX+TEST+1+type@html+block@2779f12e43582c7e0789",
                        "original_usage_key": "lib-block-v1:BradenX+OVRD+type@html+block@8d79a3991a2d467cb9095bd1fa365e71"
                    }
                ]
            }
        ]
    },
    "agent": "Mozilla/5.0 ...",
    "page": "x_module"
}
```

And if I then edit the course and change the "count" back to 1, it will generate this analytics removed event when the student next views the course:

``` json
{
    "username": "honor",
    "host": "precise64",
    "event_source": "server",
    "event_type": "edx.librarycontentblock.content.removed",
    "context": {
        "course_user_tags": {},
        "user_id": 1,
        "org_id": "BradenX",
        "course_id": "course-v1:BradenX+TEST+1",
        "path": "/courses/course-v1:BradenX+TEST+1/courseware/f61bfa6228e948f59ac1107f6077e00c/1aac970a9128469ea78c8ef1c1d0a965/"
    },
    "time": "2015-01-06T05:36:15.601560+00:00",
    "ip": "10.0.2.2",
    "event": {
        "reason": "overlimit",
        "removed": [
            {
                "original_usage_version": "54ab718c56c02c5a88bb5dff",
                "descendants": [],
                "usage_key": "block-v1:BradenX+TEST+1+type@problem+block@c279e825df7fb020cb2c",
                "original_usage_key": "lib-block-v1:BradenX+OVRD+type@problem+block@4b0043c672b54878b4600f7b1655435c"
            }
        ],
        "location": "block-v1:BradenX+TEST+1+type@library_content+block@f3ebf2bfd1d047c284deebbff984e4e3",
        "previous_count": 2,
        "max_count": 1,
        "result": [
            {
                "usage_key": "block-v1:BradenX+TEST+1+type@vertical+block@2a983fb828ee8bf6e34b",
                "original_usage_key": "lib-block-v1:BradenX+OVRD+type@vertical+block@108c4492010d49c2b3844eebdd99626b",
                "original_usage_version": "54ab715f56c02c5a88bb5df9",
                "descendants": [
                    {
                        "original_usage_version": "54ab716d56c02c5a88bb5dfb",
                        "usage_key": "block-v1:BradenX+TEST+1+type@vertical+block@975fbb4d7cde4642e81e",
                        "original_usage_key": "lib-block-v1:BradenX+OVRD+type@vertical+block@d14de4dfc5fc4fc3a2b1e5c08de3c6e8"
                    },
                    {
                        "original_usage_version": "54ab717b56c02c5a88bb5dfd",
                        "usage_key": "block-v1:BradenX+TEST+1+type@html+block@af83d86bd23f3385cb8d",
                        "original_usage_key": "lib-block-v1:BradenX+OVRD+type@html+block@120657bdb6714a3096518e4fc020b1a9"
                    },
                    {
                        "original_usage_version": "54ab6fb356c02c591fefcdb9",
                        "usage_key": "block-v1:BradenX+TEST+1+type@html+block@2779f12e43582c7e0789",
                        "original_usage_key": "lib-block-v1:BradenX+OVRD+type@html+block@8d79a3991a2d467cb9095bd1fa365e71"
                    }
                ]
            }
        ]
    },
    "agent": "Mozilla/5.0 ...",
    "page": "x_module"
}
```
## Information added to other events

This PR also adds tracking context data (`usage_key`, `original_usage_key`, and `original_usage_version`) to some normal events like `problem_check`:

``` json
{
    "username": "honor",
    "event_source": "server",
    "event_type": "problem_check",
    "context": {
        "course_user_tags": {},
        "user_id": 1,
        "org_id": "BradenX",
        "module": {
            "usage_key": "block-v1:BradenX+OVRD_TEST+1+type@problem+block@c279e825df7fb020cb2c",
            "original_usage_version": "54a2234656c02c0fdaa54f57",
            "display_name": "A Friendly Test Problem",
            "original_usage_key": "lib-block-v1:BradenX+OVRD+type@problem+block@4b0043c672b54878b4600f7b1655435c"
        },
        "course_id": "course-v1:BradenX+OVRD_TEST+1",
        "path": "/courses/course-v1:BradenX+OVRD_TEST+1/xblock/block-v1:BradenX+OVRD_TEST+1+type@problem+block@c279e825df7fb020cb2c/handler/xmodule_handler/problem_check"
    },
    "time": "2015-01-02T22:08:54.091389+00:00",
    "event": {
        "submission": {},
        "success": "incorrect"
    }
}
```
## TODO:
- When viewing the course "Progress" page, spurious `assigned` events are emitted, because the XBlock assigns children but isn't able to save its state to the database - so in the future, children will be re-assigned. Addressing this issue appears to be too involved to achieve as part of this PR.
