### PR TITLE
Hide the trash icon for entrance exam

### DIFF
--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -787,6 +787,7 @@ def create_xblock_info(xblock, data=None, metadata=None, include_ancestor_info=F
         "format": xblock.format,
         "course_graders": json.dumps([grader.get('type') for grader in graders]),
         "has_changes": has_changes,
+        "is_entrance_exam": xblock.is_entrance_exam if getattr(xblock, "is_entrance_exam", None) else None
     }
     if data is not None:
         xblock_info["data"] = data

--- a/cms/static/js/models/xblock_info.js
+++ b/cms/static/js/models/xblock_info.js
@@ -120,7 +120,11 @@ function(Backbone, _, str, ModuleUtils) {
             /**
              * True iff this xblock should display a "Contains staff only content" message.
              */
-            'staff_only_message': null
+            'staff_only_message': null,
+            /**
+             * True if this xblock contains an entrance exam module.
+             */
+            'is_entrance_exam': null
         },
 
         initialize: function () {
@@ -155,6 +159,10 @@ function(Backbone, _, str, ModuleUtils) {
 
         isPublishable: function(){
             return !this.get('published') || this.get('has_changes');
+        },
+
+        isEntranceExam: function(){
+            return this.get('is_entrance_exam') ;
         },
 
         /**

--- a/cms/templates/js/course-outline.underscore
+++ b/cms/templates/js/course-outline.underscore
@@ -78,12 +78,14 @@ if (xblockInfo.get('graded')) {
                         </a>
                     </li>
                 <% } %>
-                <li class="action-item action-delete">
-                    <a href="#" data-tooltip="<%= gettext('Delete') %>" class="delete-button action-button">
-                        <i class="icon fa fa-trash-o"></i>
-                        <span class="sr action-button-text"><%= gettext('Delete') %></span>
-                    </a>
-                </li>
+                <% if (!(xblockInfo.isEntranceExam())) { %>
+                    <li class="action-item action-delete">
+                        <a href="#" data-tooltip="<%= gettext('Delete') %>" class="delete-button action-button">
+                            <i class="icon fa fa-trash-o"></i>
+                            <span class="sr action-button-text"><%= gettext('Delete') %></span>
+                        </a>
+                    </li>
+                <% } %>
                 <li class="action-item action-drag">
                     <span data-tooltip="<%= gettext('Drag to reorder') %>"
                           class="drag-handle <%= xblockType %>-drag-handle action">


### PR DESCRIPTION
@mattdrayer here are the changes:
- hiding the trash icon from course outline page if module is 'Entrance Exam'. 

kindly look into the change set.
@ziafazal 

Thanks
