### PR TITLE
Test coverage improvements

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_libraries.py
+++ b/cms/djangoapps/contentstore/tests/test_libraries.py
@@ -441,6 +441,7 @@ class TestLibraries(LibraryTestCase):
         with self.assertRaises(ValueError):
             self._refresh_children(lc_block, status_code_expected=400)
 
+
 @ddt.ddt
 class TestLibraryAccess(LibraryTestCase):
     """

--- a/cms/djangoapps/contentstore/tests/test_libraries.py
+++ b/cms/djangoapps/contentstore/tests/test_libraries.py
@@ -327,6 +327,7 @@ class TestLibraries(LibraryTestCase):
         self.assertEqual(html_block.data, data_value)
 
     def test_refreshes_children_if_libraries_change(self):
+        """ Tests that children are automatically refreshed if libraries list changes """
         library2key = self._create_library("org2", "lib2", "Library2")
         library2 = modulestore().get_library(library2key)
         data1, data2 = "Hello world!", "Hello other world!"
@@ -370,6 +371,7 @@ class TestLibraries(LibraryTestCase):
         self.assertEqual(html_block.data, data2)
 
     def test_refreshes_children_if_capa_type_change(self):
+        """ Tests that children are automatically refreshed if capa type field changes """
         name1, name2 = "Option Problem", "Multiple Choice Problem"
         ItemFactory.create(
             category="problem",
@@ -420,6 +422,7 @@ class TestLibraries(LibraryTestCase):
         self.assertEqual(html_block.display_name, name2)
 
     def test_refresh_fails_for_unknown_library(self):
+        """ Tests that refresh children fails if unknown library is configured """
         # Create a course:
         with modulestore().default_store(ModuleStoreEnum.Type.split):
             course = CourseFactory.create()

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_libraries.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_libraries.py
@@ -13,7 +13,6 @@ from xmodule.modulestore.tests.factories import LibraryFactory, ItemFactory, che
 from xmodule.modulestore.tests.utils import MixedSplitTestCase
 
 
-
 @ddt.ddt
 class TestLibraries(MixedSplitTestCase):
     """

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_libraries.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_libraries.py
@@ -207,6 +207,44 @@ class TestLibraries(MixedSplitTestCase):
                 result = library.render(AUTHOR_VIEW, context)
         self.assertIn(message, result.content)
 
+    @patch('xmodule.modulestore.split_mongo.caching_descriptor_system.CachingDescriptorSystem.render', VanillaRuntime.render)
+    def test_library_author_view_with_paging(self):
+        """
+        Test that LibraryRoot.author_view can apply paging
+        We have to patch the runtime (module system) in order to be able to
+        render blocks in our test environment.
+        """
+        library = LibraryFactory.create(modulestore=self.store)
+        # Add five HTML blocks to the library:
+        blocks = [
+            ItemFactory.create(
+                category="html",
+                parent_location=library.location,
+                user_id=self.user_id,
+                publish_item=False,
+                modulestore=self.store,
+                data="HtmlBlock"+str(i)
+            )
+            for i in range(5)
+        ]
+        library = self.store.get_library(library.location.library_key)
+
+        def render_and_check_contents(page, page_size):
+            context = {'reorderable_items': set(), 'paging': {'page_number': page, 'page_size': page_size}}
+            expected_blocks = blocks[page_size*page:page_size*(page+1)]
+            result = library.render(AUTHOR_VIEW, context)
+
+            for expected_block in expected_blocks:
+                self.assertIn(expected_block.data, result.content)
+
+        hello_render = lambda block, _: Fragment(block.data)
+        with patch('xmodule.html_module.HtmlDescriptor.author_view', hello_render, create=True):
+            with patch('xmodule.x_module.DescriptorSystem.applicable_aside_types', lambda self, block: []):
+                render_and_check_contents(0, 3)
+                render_and_check_contents(1, 3)
+                render_and_check_contents(0, 2)
+                render_and_check_contents(1, 2)
+
     def test_xblock_in_lib_have_published_version_returns_false(self):
         library = LibraryFactory.create(modulestore=self.store)
         block = ItemFactory.create(

--- a/common/lib/xmodule/xmodule/tests/test_library_content.py
+++ b/common/lib/xmodule/xmodule/tests/test_library_content.py
@@ -4,12 +4,10 @@ Basic unit tests for LibraryContentModule
 
 Higher-level tests are in `cms/djangoapps/contentstore/tests/test_libraries.py`.
 """
-import ddt
-from mock import patch
-from unittest import TestCase
 from bson.objectid import ObjectId
-
+from mock import patch
 from opaque_keys.edx.locator import LibraryLocator
+from unittest import TestCase
 
 from xblock.fragment import Fragment
 from xblock.runtime import Runtime as VanillaRuntime
@@ -27,12 +25,12 @@ from xmodule.validation import StudioValidationMessage
 dummy_render = lambda block, _: Fragment(block.data)  # pylint: disable=invalid-name
 
 
-class BaseTestLibraryContainer(MixedSplitTestCase):
+class LibraryContentTest(MixedSplitTestCase):
     """
-    Base class for TestLibraryContainer and TestLibraryContainerRender
+    Base class for tests of LibraryContentModule (library_content_module.py)
     """
     def setUp(self):
-        super(BaseTestLibraryContainer, self).setUp()
+        super(LibraryContentTest, self).setUp()
 
         self.library = LibraryFactory.create(modulestore=self.store)
         self.lib_blocks = [
@@ -123,10 +121,9 @@ class BaseTestLibraryContainer(MixedSplitTestCase):
             )
 
 
-@ddt.ddt
-class TestLibraryContainer(BaseTestLibraryContainer):
+class TestLibraryContentModule(LibraryContentTest):
     """
-    Basic unit tests for LibraryContentModule (library_content_module.py)
+    Basic unit tests for LibraryContentModule
     """
     def test_lib_content_block(self):
         """
@@ -275,9 +272,9 @@ class TestLibraryContainer(BaseTestLibraryContainer):
 @patch('xmodule.modulestore.split_mongo.caching_descriptor_system.CachingDescriptorSystem.render', VanillaRuntime.render)
 @patch('xmodule.html_module.HtmlModule.author_view', dummy_render, create=True)
 @patch('xmodule.x_module.DescriptorSystem.applicable_aside_types', lambda self, block: [])
-class TestLibraryContentRender(BaseTestLibraryContainer):
+class TestLibraryContentRender(LibraryContentTest):
     """
-    Rendering unit tests for LibraryContentModule (library_content_module.py)
+    Rendering unit tests for LibraryContentModule
     """
     def test_preivew_view(self):
         """ Test preview view rendering """

--- a/common/lib/xmodule/xmodule/tests/test_library_content.py
+++ b/common/lib/xmodule/xmodule/tests/test_library_content.py
@@ -14,15 +14,17 @@ from opaque_keys.edx.locator import LibraryLocator
 from xblock.fragment import Fragment
 from xblock.runtime import Runtime as VanillaRuntime
 
-from xmodule.x_module import AUTHOR_VIEW, STUDENT_VIEW
-from xmodule.library_content_module import LibraryVersionReference, LibraryList, ANY_CAPA_TYPE_VALUE, LibraryContentDescriptor 
+from xmodule.x_module import AUTHOR_VIEW
+from xmodule.library_content_module import (
+    LibraryVersionReference, LibraryList, ANY_CAPA_TYPE_VALUE, LibraryContentDescriptor
+)
 from xmodule.modulestore.tests.factories import LibraryFactory, CourseFactory, ItemFactory
 from xmodule.modulestore.tests.utils import MixedSplitTestCase
 from xmodule.tests import get_test_system
 from xmodule.validation import StudioValidationMessage
 
 
-_dummy_render = lambda block, _: Fragment(block.data)
+dummy_render = lambda block, _: Fragment(block.data)
 
 
 class BaseTestLibraryContainer(MixedSplitTestCase):
@@ -74,7 +76,7 @@ class BaseTestLibraryContainer(MixedSplitTestCase):
             }
         )
 
-    def _bind_course_module(self, module, render=None):
+    def _bind_course_module(self, module):
         """
         Bind a module (part of self.course) so we can access student-specific data.
         """
@@ -119,6 +121,7 @@ class BaseTestLibraryContainer(MixedSplitTestCase):
                 data=self._get_capa_problem_type_xml(*problem_type),
                 modulestore=self.store,
             )
+
 
 @ddt.ddt
 class TestLibraryContainer(BaseTestLibraryContainer):
@@ -270,8 +273,7 @@ class TestLibraryContainer(BaseTestLibraryContainer):
 
 
 @patch('xmodule.modulestore.split_mongo.caching_descriptor_system.CachingDescriptorSystem.render', VanillaRuntime.render)
-@patch('xmodule.html_module.HtmlModule.author_view', _dummy_render, create=True)
-@patch('xmodule.html_module.HtmlModule.student_view', _dummy_render, create=True)
+@patch('xmodule.html_module.HtmlModule.author_view', dummy_render, create=True)
 @patch('xmodule.x_module.DescriptorSystem.applicable_aside_types', lambda self, block: [])
 class TestLibraryContentRender(BaseTestLibraryContainer):
     """
@@ -321,7 +323,7 @@ class TestLibraryList(TestCase):
         lib_list = LibraryList()
         lib1_key, lib1_version = u'library-v1:Org1+Lib1', '5436ffec56c02c13806a4c1b'
         lib2_key, lib2_version = u'library-v1:Org2+Lib2', '112dbaf312c0daa019ce9992'
-        raw = [lib1_key+','+lib1_version, lib2_key+','+lib2_version]
+        raw = [lib1_key + ',' + lib1_version, lib2_key + ',' + lib2_version]
         parsed = lib_list.from_json(raw)
         self.assertEqual(len(parsed), 2)
         self.assertEquals(parsed[0].library_id, LibraryLocator.from_string(lib1_key))

--- a/common/lib/xmodule/xmodule/tests/test_library_content.py
+++ b/common/lib/xmodule/xmodule/tests/test_library_content.py
@@ -24,7 +24,7 @@ from xmodule.tests import get_test_system
 from xmodule.validation import StudioValidationMessage
 
 
-dummy_render = lambda block, _: Fragment(block.data)
+dummy_render = lambda block, _: Fragment(block.data)  # pylint: disable=invalid-name
 
 
 class BaseTestLibraryContainer(MixedSplitTestCase):

--- a/common/lib/xmodule/xmodule/tests/test_library_root.py
+++ b/common/lib/xmodule/xmodule/tests/test_library_root.py
@@ -1,19 +1,26 @@
+# -*- coding: utf-8 -*-
+"""
+Basic unit tests for LibraryRoot
+"""
 from mock import patch
 
 from xblock.fragment import Fragment
 from xblock.runtime import Runtime as VanillaRuntime
 from xmodule.x_module import AUTHOR_VIEW
 
-from xmodule.modulestore.tests.factories import LibraryFactory, CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import LibraryFactory, ItemFactory
 from xmodule.modulestore.tests.utils import MixedSplitTestCase
 
-_dummy_render = lambda block, _: Fragment(block.data)
+dummy_render = lambda block, _: Fragment(block.data)
 
 
 @patch('xmodule.modulestore.split_mongo.caching_descriptor_system.CachingDescriptorSystem.render', VanillaRuntime.render)
-@patch('xmodule.html_module.HtmlDescriptor.author_view', _dummy_render, create=True)
+@patch('xmodule.html_module.HtmlDescriptor.author_view', dummy_render, create=True)
 @patch('xmodule.x_module.DescriptorSystem.applicable_aside_types', lambda self, block: [])
 class TestLibraryRoot(MixedSplitTestCase):
+    """
+    Basic unit tests for LibraryRoot (library_root_xblock.py)
+    """
     def test_library_author_view(self):
         """
         Test that LibraryRoot.author_view can run and includes content from its
@@ -62,8 +69,9 @@ class TestLibraryRoot(MixedSplitTestCase):
         library = self.store.get_library(library.location.library_key)
 
         def render_and_check_contents(page, page_size):
+            """ Renders block and asserts on returned content """
             context = {'reorderable_items': set(), 'paging': {'page_number': page, 'page_size': page_size}}
-            expected_blocks = blocks[page_size*page:page_size*(page+1)]
+            expected_blocks = blocks[page_size * page:page_size * (page + 1)]
             result = library.render(AUTHOR_VIEW, context)
 
             for expected_block in expected_blocks:

--- a/common/lib/xmodule/xmodule/tests/test_library_root.py
+++ b/common/lib/xmodule/xmodule/tests/test_library_root.py
@@ -11,7 +11,7 @@ from xmodule.x_module import AUTHOR_VIEW
 from xmodule.modulestore.tests.factories import LibraryFactory, ItemFactory
 from xmodule.modulestore.tests.utils import MixedSplitTestCase
 
-dummy_render = lambda block, _: Fragment(block.data)
+dummy_render = lambda block, _: Fragment(block.data)  # pylint: disable=invalid-name
 
 
 @patch('xmodule.modulestore.split_mongo.caching_descriptor_system.CachingDescriptorSystem.render', VanillaRuntime.render)
@@ -62,7 +62,7 @@ class TestLibraryRoot(MixedSplitTestCase):
                 user_id=self.user_id,
                 publish_item=False,
                 modulestore=self.store,
-                data="HtmlBlock"+str(i)
+                data="HtmlBlock" + str(i)
             )
             for i in range(5)
         ]

--- a/common/lib/xmodule/xmodule/tests/test_library_root.py
+++ b/common/lib/xmodule/xmodule/tests/test_library_root.py
@@ -1,0 +1,76 @@
+from mock import patch
+
+from xblock.fragment import Fragment
+from xblock.runtime import Runtime as VanillaRuntime
+from xmodule.x_module import AUTHOR_VIEW
+
+from xmodule.modulestore.tests.factories import LibraryFactory, CourseFactory, ItemFactory
+from xmodule.modulestore.tests.utils import MixedSplitTestCase
+
+
+class TestLibraryRoot(MixedSplitTestCase):
+    @patch('xmodule.modulestore.split_mongo.caching_descriptor_system.CachingDescriptorSystem.render', VanillaRuntime.render)
+    def test_library_author_view(self):
+        """
+        Test that LibraryRoot.author_view can run and includes content from its
+        children.
+        We have to patch the runtime (module system) in order to be able to
+        render blocks in our test environment.
+        """
+        library = LibraryFactory.create(modulestore=self.store)
+        # Add one HTML block to the library:
+        ItemFactory.create(
+            category="html",
+            parent_location=library.location,
+            user_id=self.user_id,
+            publish_item=False,
+            modulestore=self.store,
+        )
+        library = self.store.get_library(library.location.library_key)
+
+        context = {'reorderable_items': set(), }
+        # Patch the HTML block to always render "Hello world"
+        message = u"Hello world"
+        hello_render = lambda _, context: Fragment(message)
+        with patch('xmodule.html_module.HtmlDescriptor.author_view', hello_render, create=True):
+            with patch('xmodule.x_module.DescriptorSystem.applicable_aside_types', lambda self, block: []):
+                result = library.render(AUTHOR_VIEW, context)
+        self.assertIn(message, result.content)
+
+    @patch('xmodule.modulestore.split_mongo.caching_descriptor_system.CachingDescriptorSystem.render', VanillaRuntime.render)
+    def test_library_author_view_with_paging(self):
+        """
+        Test that LibraryRoot.author_view can apply paging
+        We have to patch the runtime (module system) in order to be able to
+        render blocks in our test environment.
+        """
+        library = LibraryFactory.create(modulestore=self.store)
+        # Add five HTML blocks to the library:
+        blocks = [
+            ItemFactory.create(
+                category="html",
+                parent_location=library.location,
+                user_id=self.user_id,
+                publish_item=False,
+                modulestore=self.store,
+                data="HtmlBlock"+str(i)
+            )
+            for i in range(5)
+        ]
+        library = self.store.get_library(library.location.library_key)
+
+        def render_and_check_contents(page, page_size):
+            context = {'reorderable_items': set(), 'paging': {'page_number': page, 'page_size': page_size}}
+            expected_blocks = blocks[page_size*page:page_size*(page+1)]
+            result = library.render(AUTHOR_VIEW, context)
+
+            for expected_block in expected_blocks:
+                self.assertIn(expected_block.data, result.content)
+
+        hello_render = lambda block, _: Fragment(block.data)
+        with patch('xmodule.html_module.HtmlDescriptor.author_view', hello_render, create=True):
+            with patch('xmodule.x_module.DescriptorSystem.applicable_aside_types', lambda self, block: []):
+                render_and_check_contents(0, 3)
+                render_and_check_contents(1, 3)
+                render_and_check_contents(0, 2)
+                render_and_check_contents(1, 2)


### PR DESCRIPTION
**Background**: This PR contains the LibraryContent XBlock, which allows to display library content in a course.
**JIRA ticket**: [Content Libraries MVP](SOL-119)
**Discussions**: Architecture discussed extensively on the wiki and in meetings, then the revised proposal was presented to the Arch Council on Oct. 21 and given thumbs up.
**Dependencies**: none
**Partner information**: 3rd party-hosted open edX instance, for an edX solutions client.
