### PR TITLE
Add Staff Graded Assignments XBlock to edx-platform

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -785,6 +785,7 @@ MAX_FAILED_LOGIN_ATTEMPTS_LOCKOUT_PERIOD_SECS = 15 * 60
 
 OPTIONAL_APPS = (
     'mentoring',
+    'edx_sga',
 
     # edx-ora2
     'submissions',
@@ -847,6 +848,7 @@ ADVANCED_COMPONENT_TYPES = [
     'graphical_slider_tool',
     'lti',
     'library_content',
+    'edx_sga',
     # XBlocks from pmitros repos are prototypes. They should not be used
     # except for edX Learning Sciences experiments on edge.edx.org without
     # further work to make them robust, maintainable, finalize data formats,

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1952,6 +1952,7 @@ ALL_LANGUAGES = (
 ### Apps only installed in some instances
 OPTIONAL_APPS = (
     'mentoring',
+    'edx_sga',
 
     # edx-ora2
     'submissions',

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -43,3 +43,5 @@ git+https://github.com/edx/edx-lint.git@e0e73bcc7b3b7ed632a1db6e3b32b0a249721261
 -e git+https://github.com/edx/xblock-utils.git@17e247d66fabb53f0453515b093a030ee345a1b0#egg=xblock-utils
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
 
+# Third Party XBlocks
+-e git+https://github.com/mitodl/edx-sga@172a90fd2738f8142c10478356b2d9ed3e55334a#egg=edx-sga


### PR DESCRIPTION
We have recently done a new release of Staff Graded Assignments that should have addressed all the issues identified earlier in https://github.com/edx/edx-platform/pull/4373.  This uses the submissions API, has removed it's asserts, added a more fully fleshed out [README](https://github.com/mitodl/edx-sga/blob/release/README.rst), a staff debug panel, and a workflow for course staff to grade and instructors to approve grades.

@pdpinch and @sarina 
