### PR TITLE
Fix cosmetic issues with the split payment and verification flow

### DIFF
--- a/common/djangoapps/student/tests/test_verification_status.py
+++ b/common/djangoapps/student/tests/test_verification_status.py
@@ -255,6 +255,14 @@ class TestCourseVerificationStatus(UrlResetMixin, ModuleStoreTestCase):
         VERIFY_STATUS_APPROVED: ["You have already verified your ID!"],
     }
 
+    MODE_CLASSES = {
+        None: "honor",
+        VERIFY_STATUS_NEED_TO_VERIFY: "verified",
+        VERIFY_STATUS_SUBMITTED: "verified",
+        VERIFY_STATUS_APPROVED: "verified",
+        VERIFY_STATUS_MISSED_DEADLINE: "honor"
+    }
+
     def _assert_course_verification_status(self, status):
         """Check whether the specified verification status is shown on the dashboard.
 
@@ -273,6 +281,12 @@ class TestCourseVerificationStatus(UrlResetMixin, ModuleStoreTestCase):
 
         # Verify that the correct banner is rendered on the dashboard
         self.assertContains(response, self.BANNER_ALT_MESSAGES[status])
+
+        # Verify that the correct banner color is rendered
+        self.assertContains(
+            response,
+            "<article class=\"course {}\">".format(self.MODE_CLASSES[status])
+        )
 
         # Verify that the correct copy is rendered on the dashboard
         if status is not None:

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -29,10 +29,25 @@ from student.helpers import (
 
 <li class="course-item">
   % if settings.FEATURES.get('ENABLE_VERIFIED_CERTIFICATES'):
-    <article class="course ${enrollment.mode}">
+    % if enrollment.mode == "verified":
+      % if settings.FEATURES.get('SEPARATE_VERIFICATION_FROM_PAYMENT') and request.session.get('separate-verified', False):
+        % if verification_status.get('status') in [VERIFY_STATUS_NEED_TO_VERIFY, VERIFY_STATUS_SUBMITTED, VERIFY_STATUS_APPROVED]:
+          <% mode_class = " verified" %>
+        % else:
+          <% mode_class = " honor" %>
+        % endif
+      % else:
+        <% mode_class = " verified" %>
+      % endif
+    % else:
+      <% mode_class = " " + enrollment.mode %>
+    % endif
   % else:
-    <article class="course">
-  %endif
+    <% mode_class = "" %>
+  % endif
+
+  <article class="course${mode_class}">
+
     <%
       course_target = reverse('info', args=[course.id.to_deprecated_string()])
     %>

--- a/lms/templates/verify_student/payment_confirmation_step.underscore
+++ b/lms/templates/verify_student/payment_confirmation_step.underscore
@@ -18,7 +18,7 @@
                 <th scope="col" ><%- gettext( "Order No." ) %></th>
                 <th scope="col" ><%- gettext( "Description" ) %></th>
                 <th scope="col" ><%- gettext( "Date" ) %></th>
-                <th scope="col" ><%- gettext( "Description" ) %></th>
+                <th scope="col" ><%- gettext( "Amount" ) %></th>
               </tr>
             </thead>
 


### PR DESCRIPTION
Use honor code ribbon if verification status is not missing, submitted, or approved, and more appropriately title the column on the payment confirmation page holding dollar amounts. Resolves [ECOM-878](https://openedx.atlassian.net/browse/ECOM-878) and [ECOM-881](https://openedx.atlassian.net/browse/ECOM-881), respectively.

@AlasdairSwan and @wedaly, could you review this when you're able?
