### PR TITLE
Minor fixes to the schoolyourself xblock

### DIFF
--- a/requirements/edx/edx-private.txt
+++ b/requirements/edx/edx-private.txt
@@ -15,4 +15,4 @@
 
 # This repository contains schoolyourself-xblock, which is used in
 # edX's "AlgebraX" and "GeometryX" courses.
--e git+https://github.com/schoolyourself/schoolyourself-xblock.git@ae028c3c185d1abf93823f7a5d946a8e66b8e7d9#egg=schoolyourself-xblock
+-e git+https://github.com/schoolyourself/schoolyourself-xblock.git@fc0867263ce763f626c1c9754820e2954f6395e1#egg=schoolyourself-xblock


### PR DESCRIPTION
I've made the following changes after a round of feedback with @nedbat:
- A big complaint seemed to be the ugliness of the studio view, which should now look like this:
  ![edit](https://cloud.githubusercontent.com/assets/1812040/5674430/1af6a4e0-9778-11e4-8410-8d83dbe9aa2b.png)
- alt tags and headings added - you can test e.g. by inspecting the green title text and seeing that it's an H1.
- hovering over the tab in the unit/sequence navigation in the student view should show a display name, rather than a cryptic hash. To test this, you should click the save button within the edit window (this sets the display name), and then look at the preview and hover over the unit/sequence navigation.
- fixed some other a11y complaints, like being able to tab to the header on the intro card, or being able to tab to the x button in the modal.
