### PR TITLE
Install diff-cover from pypi, update version to 0.7.3

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -60,7 +60,7 @@ Pillow==2.6.1
 pip>=1.4
 polib==1.0.3
 pycrypto>=2.6
-pygments==1.6
+pygments==2.0.1
 pygraphviz==1.1
 pymongo==2.7.2
 pyparsing==2.0.1
@@ -120,6 +120,7 @@ django-debug-toolbar-mongo
 chrono==1.0.2
 coverage==3.7
 ddt==0.8.0
+diff-cover==0.7.3
 django-crum==0.5
 django_nose==1.3
 factory_boy==2.2.1

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -23,7 +23,6 @@ git+https://github.com/mitocw/django-cas.git@60a5b8e5a62e63e0d5d224a87f0b489201a
 # Our libraries:
 -e git+https://github.com/edx/XBlock.git@9c634481dfc85a17dcb3351ca232d7098a38e10e#egg=XBlock
 -e git+https://github.com/edx/codejail.git@2b095e820ff752a108653bb39d518b122f7154db#egg=codejail
--e git+https://github.com/edx/diff-cover.git@v0.7.2#egg=diff_cover
 -e git+https://github.com/edx/js-test-tool.git@v0.1.6#egg=js_test_tool
 -e git+https://github.com/edx/event-tracking.git@0.1.0#egg=event-tracking
 -e git+https://github.com/edx/bok-choy.git@4a259e3548a19e41cc39433caf68ea58d10a27ba#egg=bok_choy


### PR DESCRIPTION
Install diff-cover from PyPi instead of from GitHub.  I believe this is the only place we're installing diff-cover directly from our GitHub repo, so this is one step towards making Matt's fork the official repository.

@nedbat @clytwynec 
