### PR TITLE
Prevent Jasmine tests from redirecting in dev mode

### DIFF
--- a/lms/static/js/spec/student_account/access_spec.js
+++ b/lms/static/js/spec/student_account/access_spec.js
@@ -157,6 +157,9 @@ define([
             it('toggles between the login and registration forms', function() {
                 ajaxSpyAndInitialize(this, 'login');
 
+                // Prevent URL from updating
+                spyOn(history, 'pushState').andCallFake( function() {} );
+
                 // Simulate selection of the registration form
                 selectForm('register');
                 assertForms('#register-form', '#login-form');

--- a/lms/static/js/spec/verify_student/make_payment_step_view_spec.js
+++ b/lms/static/js/spec/verify_student/make_payment_step_view_spec.js
@@ -136,7 +136,6 @@ define([
 
                 setFixtures( '<div id="current-step-container"></div>' );
                 TemplateHelpers.installTemplate( 'templates/verify_student/make_payment_step' );
-                TemplateHelpers.installTemplate( 'templates/verify_student/requirements' );
             });
 
             it( 'allows users to choose a suggested price', function() {

--- a/lms/static/js/spec/verify_student/pay_and_verify_view_spec.js
+++ b/lms/static/js/spec/verify_student/pay_and_verify_view_spec.js
@@ -12,8 +12,6 @@ define(['jquery', 'js/common_helpers/template_helpers', 'js/verify_student/views
                 'intro_step',
                 'make_payment_step',
                 'payment_confirmation_step',
-                'progress',
-                'requirements',
                 'review_photos_step',
                 'webcam_photo'
             ];


### PR DESCRIPTION
Also prevents Jasmine from attempting to load deleted templates.

@andy-armstrong this should fix the redirection issues you noticed on Friday and filed as [ECOM-885](https://openedx.atlassian.net/browse/ECOM-885). It doesn't completely clean out the console errors we saw, but it does remove several.

@wedaly or @AlasdairSwan, could one of you also review this? Andy was having issues with the Jasmine tests appearing to redirect while running in dev mode; this was caused by `history.pushState` not being mocked out.

EDIT: An [instructor dashboard test](https://github.com/edx/edx-platform/commit/10f8d8c0975a0bacb8a7d290b0b9dca5a25885ce#diff-0b43d5fc0763070e99b9b3894d10dec9R23) related to coupons, added on Friday by @muhhshoaib, is still failing.
