### PR TITLE
Fix csrf error on studio login

### DIFF
--- a/cms/static/js/factories/login.js
+++ b/cms/static/js/factories/login.js
@@ -8,7 +8,6 @@ define(['jquery.cookie', 'utility'], function() {
                 dataType: 'json',
                 data: data,
                 success: callback,
-                headers : {'X-CSRFToken':$.cookie('csrftoken')}
             });
         }
 

--- a/cms/templates/login.html
+++ b/cms/templates/login.html
@@ -17,7 +17,7 @@ from django.utils.translation import ugettext as _
     </header>
 
     <article class="content-primary" role="main">
-      <form id="login_form" method="post" action="login_post">
+      <form id="login_form" method="post" action="login_post" onsubmit="return false;">
 
         <fieldset>
           <legend class="sr">${_("Required Information to Sign In to {studio_name}").format(studio_name=settings.STUDIO_NAME)}</legend>

--- a/cms/templates/login.html
+++ b/cms/templates/login.html
@@ -21,6 +21,7 @@ from django.utils.translation import ugettext as _
 
         <fieldset>
           <legend class="sr">${_("Required Information to Sign In to {studio_name}").format(studio_name=settings.STUDIO_NAME)}</legend>
+          <input type="hidden" name="csrfmiddlewaretoken" value="${ csrf }" />
 
           <ol class="list-input">
             <li class="field text required" id="field-email">


### PR DESCRIPTION
**Context:** We have witnessed multiple, seemingly random "CSRF verification
failed" errors while signing in (with valid ID) to the Studio.

**Explanation:** The login form does not initially include a CSRF field.
The CSRF header of the request is appended to the studio login request
headers by intercepting the form validation. This intercept is performed
by the login.js script. Unfortunately, the login.js script is loaded
pretty late (at the end of the template). So if the login form is
validated sufficiently fast, the login.js script has no time to load and
append the X-CSRFToken header to the request.

**Proposed solution:** the CSRF token is already passed to the template via
the login view, so we just add a hidden field to the login form to
include the csrf token.
