### PR TITLE
Short-circuit group_access check if only user_partitions are split_test ...

### DIFF
--- a/common/lib/xmodule/xmodule/partitions/tests/test_partitions.py
+++ b/common/lib/xmodule/xmodule/partitions/tests/test_partitions.py
@@ -115,13 +115,14 @@ class PartitionTestCase(TestCase):
 
     def setUp(self):
         # Set up two user partition schemes: mock and random
+        self.non_random_scheme = MockUserPartitionScheme(self.TEST_SCHEME_NAME)
+        self.random_scheme = MockUserPartitionScheme("random")
         extensions = [
             Extension(
-                self.TEST_SCHEME_NAME, USER_PARTITION_SCHEME_NAMESPACE,
-                MockUserPartitionScheme(self.TEST_SCHEME_NAME), None
+                self.non_random_scheme.name, USER_PARTITION_SCHEME_NAMESPACE, self.non_random_scheme, None
             ),
             Extension(
-                "random", USER_PARTITION_SCHEME_NAMESPACE, MockUserPartitionScheme("random"), None
+                self.random_scheme.name, USER_PARTITION_SCHEME_NAMESPACE, self.random_scheme, None
             ),
         ]
         UserPartition.scheme_extensions = ExtensionManager.make_test_instance(
@@ -136,6 +137,10 @@ class PartitionTestCase(TestCase):
             self.TEST_GROUPS,
             extensions[0].plugin
         )
+
+        # Make sure the names are set on the schemes (which happens normally in code, but may not happen in tests).
+        self.user_partition.get_scheme(self.non_random_scheme.name)
+        self.user_partition.get_scheme(self.random_scheme.name)
 
 
 class TestUserPartition(PartitionTestCase):

--- a/lms/djangoapps/courseware/access.py
+++ b/lms/djangoapps/courseware/access.py
@@ -13,6 +13,7 @@ from xmodule.course_module import (
     CATALOG_VISIBILITY_ABOUT)
 from xmodule.error_module import ErrorDescriptor
 from xmodule.x_module import XModule
+from xmodule.split_test_module import get_split_user_partitions
 
 from xblock.core import XBlock
 from xmodule.partitions.partitions import NoSuchUserPartitionError, NoSuchUserPartitionGroupError
@@ -307,8 +308,10 @@ def _has_group_access(descriptor, user, course_key):
     This function returns a boolean indicating whether or not `user` has
     sufficient group memberships to "load" a block (the `descriptor`)
     """
-    if len(descriptor.user_partitions) == 0:
-        # short circuit the process, since there are no defined user partitions
+    if len(descriptor.user_partitions) == len(get_split_user_partitions(descriptor.user_partitions)):
+        # Short-circuit the process, since there are no defined user partitions that are not
+        # user_partitions used by the split_test module. The split_test module handles its own access
+        # via updating the children of the split_test module.
         return True
 
     # use merged_group_access which takes group access on the block's


### PR DESCRIPTION
...partitions.

@andy-armstrong and @jimabramson please review.

Note that I couldn't reference the cohort user partition explicitly due to circular dependencies (openedx.core.djangoapps.course_groups imports courseware.courses). So instead I went with the approach of short-circuiting if all user_partitions are "split_test" partitions. I had already written this method for Dan's PR (#6397), just checking name because code in common can't call into the plugin code.
