### PR TITLE
Make Tender optional and configurable

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -502,6 +502,11 @@ REQUIRE_EXCLUDE = ("build.txt",)
 # It can also be a path to a custom class that subclasses require.environments.Environment and defines some "args" function that returns a list with the command arguments to execute.
 REQUIRE_ENVIRONMENT = "node"
 
+# If you want to enable Tender integration (http://tenderapp.com/),
+# put in the domain where Tender hosts tender_widget.js. For example,
+# TENDER_DOMAIN = "example.tenderapp.com"
+TENDER_DOMAIN = None
+
 ################################# CELERY ######################################
 
 # Message configuration

--- a/cms/envs/test.py
+++ b/cms/envs/test.py
@@ -74,6 +74,8 @@ STATICFILES_STORAGE = 'pipeline.storage.NonPackagingPipelineStorage'
 STATIC_URL = "/static/"
 PIPELINE_ENABLED = False
 
+TENDER_DOMAIN = "help.edge.edx.org"
+
 # Update module store settings per defaults for tests
 update_module_store_settings(
     MODULESTORE,

--- a/cms/static/coffee/spec/main.coffee
+++ b/cms/static/coffee/spec/main.coffee
@@ -49,7 +49,7 @@ requirejs.config({
 
         "mathjax": "//cdn.mathjax.org/mathjax/2.2-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&delayStartupUntil=configured",
         "youtube": "//www.youtube.com/player_api?noext",
-        "tender": "//edxedge.tenderapp.com/tender_widget",
+        "tender": "//api.tenderapp.com/tender_widget",
 
         "coffee/src/ajax_prefix": "xmodule_js/common_static/coffee/src/ajax_prefix",
         "js/spec/test_utils": "js/spec/test_utils",

--- a/cms/static/coffee/spec/main_squire.coffee
+++ b/cms/static/coffee/spec/main_squire.coffee
@@ -43,7 +43,7 @@ requirejs.config({
 
         "mathjax": "//cdn.mathjax.org/mathjax/2.2-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&delayStartupUntil=configured",
         "youtube": "//www.youtube.com/player_api?noext",
-        "tender": "//edxedge.tenderapp.com/tender_widget.js"
+        "tender": "//api.tenderapp.com/tender_widget.js"
 
         "coffee/src/ajax_prefix": "xmodule_js/common_static/coffee/src/ajax_prefix"
     }

--- a/cms/static/require-config.js
+++ b/cms/static/require-config.js
@@ -67,7 +67,9 @@ require.config({
 
         // externally hosted files
         "tender": [
-            "//edxedge.tenderapp.com/tender_widget",
+            // if TENDER_DOMAIN is defined, use that; otherwise, use a dummy value
+            // (the application JS will never `require(['tender'])` if it's not defined)
+            "//" + (typeof TENDER_DOMAIN === "string" ? TENDER_DOMAIN : "api.tenderapp.com") + "/tender_widget",
             // if tender fails to load, fallback on a local file
             // so that require doesn't fall over
             "js/src/tender_fallback"

--- a/cms/templates/activation_invalid.html
+++ b/cms/templates/activation_invalid.html
@@ -26,9 +26,13 @@
       </div>
 
       <ul class="list-actions">
+        % if settings.TENDER_DOMAIN:
         <li class="action-item">
-          <a href="http://help.edge.edx.org/discussion/new" class="action action-primary show-tender">${_('Contact edX Support')}</a>
+          <a href="//${settings.TENDER_DOMAIN}/discussion/new" class="action action-primary show-tender">
+            ${_('Contact {platform_name} Support').format(platform_name=settings.PLATFORM_NAME)}
+          </a>
         </li>
+        % endif
       </ul>
     </div>
   </section>

--- a/cms/templates/base.html
+++ b/cms/templates/base.html
@@ -1,6 +1,9 @@
 ## -*- coding: utf-8 -*-
-<%! from django.utils.translation import ugettext as _ %>
-<%! from django.template.defaultfilters import escapejs %>
+<%!
+from django.utils.translation import ugettext as _
+from django.template.defaultfilters import escapejs
+import json
+%>
 <%namespace name='static' file='static_content.html'/>
 
 <!doctype html>
@@ -46,7 +49,8 @@
     <a class="nav-skip" href="#content">${_("Skip to this view's content")}</a>
 
     <script type="text/javascript">
-      window.baseUrl = "${settings.STATIC_URL}";
+      window.baseUrl = ${json.dumps(settings.STATIC_URL)};
+      window.TENDER_DOMAIN = ${json.dumps(settings.TENDER_DOMAIN)};
       var require = {baseUrl: window.baseUrl};
     </script>
     <script type="text/javascript" src="${static.url("js/vendor/require.js")}"></script>

--- a/cms/templates/error.html
+++ b/cms/templates/error.html
@@ -10,21 +10,35 @@
   % endif
 </%block>
 
+<%!
+from django.conf import settings
+
+if settings.TENDER_DOMAIN:
+  help_link_start = '<a href="//{domain}/discussion/new" class="show-tender" title="{title}">'.format(
+    domain=settings.TENDER_DOMAIN,
+    title=_("Use our feedback tool, Tender, to share your feedback")
+  ),
+  help_link_end = '</a>'
+else:
+  help_link_start = '<a href="mailto:{email}">'.format(email=settings.TECH_SUPPORT_EMAIL)
+  help_link_end = '</a>'
+%>
+
 <%block name="content">
   <article class="error-prompt">
     % if error == '404':
       <h1>${_("The Page You Requested Page Cannot be Found")}</h1>
       <p class="description">${_("We're sorry. We couldn't find the {studio_name} page you're looking for. You may want to return to the {studio_name} Dashboard and try again. If you are still having problems accessing things, please feel free to {link_start}contact {studio_name} support{link_end} for further help.").format(
           studio_name=settings.STUDIO_SHORT_NAME,
-          link_start='<a href="http://help.edge.edx.org/discussion/new" class="show-tender" title="{title}">'.format(title=_("Use our feedback tool, Tender, to share your feedback")),
-          link_end='</a>',
+          link_start=help_link_start,
+          link_end=help_link_end,
         )}</p>
     % elif error == '500':
       <h1>${_("The Server Encountered an Error")}</h1>
       <p class="description">${_("We're sorry. There was a problem with the server while trying to process your last request. You may want to return to the {studio_name} Dashboard or try this request again. If you are still having problems accessing things, please feel free to {link_start}contact {studio_name} support{link_end} for further help.").format(
           studio_name=settings.STUDIO_SHORT_NAME,
-          link_start='<a href="http://help.edge.edx.org/discussion/new" class="show-tender" title="{title}">'.format(title=_("Use our feedback tool, Tender, to share your feedback")),
-          link_end='</a>',
+          link_start=help_link_start,
+          link_end=help_link_end,
         )}</p>
     % endif
     <a href="/" class="back-button">${_("Back to dashboard")}</a>

--- a/cms/templates/index.html
+++ b/cms/templates/index.html
@@ -374,9 +374,13 @@
 
             <a href="${get_online_help_info(online_help_token())['doc_url']}" target="_blank">${_("Getting Started with {studio_name}").format(studio_name=settings.STUDIO_NAME)}</a>
           </li>
-          <li class="action-item">
-            <a href="http://help.edge.edx.org/discussion/new" class="show-tender" title="${_("Use our feedback tool, Tender, to request help")}">${_("Request help with {studio_name}").format(studio_name=settings.STUDIO_NAME)}</a>
-          </li>
+          % if settings.TENDER_DOMAIN:
+            <li class="action-item">
+              <a href="//${settings.TENDER_DOMAIN}/discussion/new" class="show-tender" title="${_("Use our feedback tool, Tender, to request help")}">
+                ${_("Request help with {studio_name}").format(studio_name=settings.STUDIO_NAME)}
+              </a>
+            </li>
+          % endif
         </ol>
       </div>
 
@@ -401,13 +405,23 @@
       % elif course_creator_status == "denied":
       <div class="bit">
         <h3 class="title title-3">${_("Can I create courses in {studio_name}?").format(studio_name=settings.STUDIO_NAME)}</h3>
+<%!
+from django.conf import settings
+
+if settings.TENDER_DOMAIN:
+  help_link_start = '<a href="//{domain}/discussion/new" class="show-tender">'.format(
+    domain=settings.TENDER_DOMAIN,
+  )
+  help_link_end = '</a>'
+else:
+  help_link_start = '<a href="mailto:{email}">'.format(email=settings.TECH_SUPPORT_EMAIL)
+  help_link_end = '</a>'
+%>
         <p>${_("Your request to author courses in {studio_name} has been denied. Please {link_start}contact {platform_name} Staff with further questions{link_end}.").format(
             studio_name=settings.STUDIO_NAME,
             platform_name=settings.PLATFORM_NAME,
-            link_start='<a href="{url}" class="show-tender">'.format(
-              url="http://help.edge.edx.org/discussion/new",
-            ),
-            link_end="</a>",
+            link_start=help_link_start,
+            link_end=help_link_end,
           )}</p>
       </div>
 
@@ -439,9 +453,13 @@
         <p>${_('Please check your Junk or Spam folders in case our email isn\'t in your INBOX. Still can\'t find the verification email? Request help via the link below.')}</p>
 
         <ol class='list-actions'>
-          <li class="action-item">
-            <a href="http://help.edge.edx.org/discussion/new" class="show-tender" title="${_("Use our feedback tool, Tender, to request help")}">${_("Request help with your {studio_name} account").format(studio_name=settings.STUDIO_NAME)}</a>
-          </li>
+          % if settings.TENDER_DOMAIN:
+            <li class="action-item">
+              <a href="//${settings.TENDER_DOMAIN}/discussion/new" class="show-tender" title="${_("Use our feedback tool, Tender, to request help")}">
+                ${_("Request help with your {studio_name} account").format(studio_name=settings.STUDIO_NAME)}
+              </a>
+            </li>
+          % endif
         </ol>
       </div>
     </aside>

--- a/cms/templates/login.html
+++ b/cms/templates/login.html
@@ -45,14 +45,19 @@ from django.utils.translation import ugettext as _
       </form>
     </article>
 
-    <aside class="content-supplementary" role="complementary">
-      <h2 class="sr">${_("{studio_name} Support").format(studio_name=settings.STUDIO_SHORT_NAME)}</h2>
+    % if settings.TENDER_DOMAIN:
+      <aside class="content-supplementary" role="complementary">
+        <h2 class="sr">${_("{studio_name} Support").format(studio_name=settings.STUDIO_SHORT_NAME)}</h2>
 
-      <div class="bit">
-        <h3 class="title-3">${_("Need Help?")}</h3>
-        <p>${_('Having trouble with your account? Use {link_start}our support center{link_end} to look over self help steps, find solutions others have found to the same problem, or let us know of your issue.').format(link_start='<a href="http://help.edge.edx.org" rel="external">', link_end='</a>')}</p>
-      </div>
-    </aside>
+        <div class="bit">
+          <h3 class="title-3">${_("Need Help?")}</h3>
+          <p>${_('Having trouble with your account? Use {link_start}our support center{link_end} to look over self help steps, find solutions others have found to the same problem, or let us know of your issue.').format(
+              link_start='<a href="//{domain}" rel="external">'.format(domain=settings.TENDER_DOMAIN),
+              link_end='</a>',
+            )}</p>
+        </div>
+      </aside>
+    % endif
   </section>
 </div>
 </%block>

--- a/cms/templates/widgets/footer.html
+++ b/cms/templates/widgets/footer.html
@@ -15,9 +15,9 @@
         <li class="nav-item nav-peripheral-pp">
           <a data-rel="edx.org" href="${marketing_link('PRIVACY')}">${_("Privacy Policy")}</a>
         </li>
-        % if user.is_authenticated():
+        % if settings.TENDER_DOMAIN and user.is_authenticated():
         <li class="nav-item nav-peripheral-feedback">
-          <a href="http://help.edge.edx.org/discussion/new" class="show-tender" title="${_('Use our feedback tool, Tender, to share your feedback')}">${_("Contact Us")}</a>
+          <a href="//${settings.TENDER_DOMAIN}/discussion/new" class="show-tender" title="${_('Use our feedback tool, Tender, to share your feedback')}">${_("Contact Us")}</a>
         </li>
         % endif
       </ol>

--- a/cms/templates/widgets/sock.html
+++ b/cms/templates/widgets/sock.html
@@ -29,10 +29,13 @@
             <a href="${get_online_help_info(online_help_token)['pdf_url']}" target="_blank" rel="external" class="action action-primary">${_("Building and Running an {platform_name} Course PDF").format(platform_name=settings.PLATFORM_NAME)}</a>
           </li>
 
-        <li class="action-item">
-          <a href="http://help.edge.edx.org/" rel="external" class="action action-primary">${_("{studio_name} Author Support").format(studio_name=settings.STUDIO_NAME)}</a>
-          <span class="tip">${_("{studio_name} Author Support").format(studio_name=settings.STUDIO_NAME)}</span>
-        </li>
+        % if settings.TENDER_DOMAIN:
+          <li class="action-item">
+            <a href="//${settings.TENDER_DOMAIN}" rel="external" class="action action-primary">${_("{studio_name} Author Support").format(studio_name=settings.STUDIO_NAME)}</a>
+            <span class="tip">${_("{studio_name} Author Support").format(studio_name=settings.STUDIO_NAME)}</span>
+          </li>
+        % endif
+
         <li class="action-item">
           <a href="https://edge.edx.org/courses/edX/edX101/How_to_Create_an_edX_Course/about" rel="external" class="action action-primary">${_("Enroll in edX101")}</a>
           <span class="tip">${_("How to use {studio_name} to build your course").format(studio_name=settings.STUDIO_NAME)}</span>
@@ -40,6 +43,7 @@
       </ul>
       </div>
 
+    % if settings.TENDER_DOMAIN:
       <div class="feedback">
         <h3 class="title">${_("Request help with {studio_name}").format(studio_name=settings.STUDIO_NAME)}</h3>
 
@@ -50,10 +54,11 @@
         <ul class="list-actions">
           <li class="action-item">
 
-            <a href="http://help.edge.edx.org/discussion/new" class="action action-primary show-tender" title="${_("Use our feedback tool, Tender, to share your feedback")}"><i class="icon fa fa-comments"></i>${_("Contact Us")}</a>
+            <a href="//${settings.TENDER_DOMAIN}/discussion/new" class="action action-primary show-tender" title="${_("Use our feedback tool, Tender, to share your feedback")}"><i class="icon fa fa-comments"></i>${_("Contact Us")}</a>
           </li>
         </ul>
       </div>
+    % endif
     </section>
   </div>
 </div>

--- a/cms/templates/widgets/tender.html
+++ b/cms/templates/widgets/tender.html
@@ -1,4 +1,4 @@
-% if user.is_authenticated():
+% if settings.TENDER_DOMAIN and user.is_authenticated():
 <script type="text/javascript">
 window.Tender = {
   hideToggle: true,

--- a/lms/static/js/spec/main.js
+++ b/lms/static/js/spec/main.js
@@ -46,7 +46,7 @@
             'domReady': 'xmodule_js/common_static/js/vendor/domReady',
             'mathjax': '//cdn.mathjax.org/mathjax/2.2-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&delayStartupUntil=configured',
             'youtube': '//www.youtube.com/player_api?noext',
-            'tender': '//edxedge.tenderapp.com/tender_widget',
+            'tender': '//api.tenderapp.com/tender_widget',
             'coffee/src/ajax_prefix': 'xmodule_js/common_static/coffee/src/ajax_prefix',
             'xmodule_js/common_static/js/test/add_ajax_prefix': 'xmodule_js/common_static/js/test/add_ajax_prefix',
             'xblock/core': 'xmodule_js/common_static/js/xblock/core',


### PR DESCRIPTION
This pull request changes how edx-platform integrates with [Tender](http://tenderapp.com/), the support system used by studio.edx.org. With this change, website operators can set the `TENDER_DOMAIN` variable to point to whatever Tender instance they want, or can leave the variable set to None (the default) to make the site not link to Tender at all.

For edx.org, we will need to set `TENDER_DOMAIN` to `"help.edge.edx.org"` to preserve the same behavior that exists on the site today.
