### PR TITLE
Fix bug when deleting first of two recently added blocks

### DIFF
--- a/cms/templates/js/mock/mock-container-paged-xblock.underscore
+++ b/cms/templates/js/mock/mock-container-paged-xblock.underscore
@@ -70,80 +70,82 @@
                 </header>
                 <article class="xblock-render">
                     <div class="xblock" data-request-token="page-render-token">
-                        <div class="studio-xblock-wrapper" data-locator="locator-component-A1">
-                            <section class="wrapper-xblock level-element">
-                                <header class="xblock-header">
-                                    <div class="xblock-header-primary">
-                                        <div class="header-actions">
-                                            <ul class="actions-list">
-                                                <li class="action-item action-edit">
-                                                    <a href="#" class="edit-button action-button"></a>
-                                                </li>
-                                                <li class="action-item action-duplicate">
-                                                    <a href="#" class="duplicate-button action-button"></a>
-                                                </li>
-                                                <li class="action-item action-delete">
-                                                    <a href="#" class="delete-button action-button"></a>
-                                                </li>
-                                                <li class="action-item action-drag">
-                                                    <span data-tooltip="Drag to reorder" class="drag-handle action"></span>
-                                                </li>
-                                            </ul>
-                                        </div>
-                                    </div>
-                                </header>
-                                <article class="xblock-render"></article>
-                            </section>
-                        </div>
-                        <div class="studio-xblock-wrapper" data-locator="locator-component-A2">
-                            <section class="wrapper-xblock level-element">
-                                <header class="xblock-header">
-                                    <div class="header-actions">
+                        <div>
+                            <div class="studio-xblock-wrapper" data-locator="locator-component-A1">
+                                <section class="wrapper-xblock level-element">
+                                    <header class="xblock-header">
                                         <div class="xblock-header-primary">
-                                            <ul class="actions-list">
-                                                <li class="action-item action-edit">
-                                                    <a href="#" class="edit-button action-button"></a>
-                                                </li>
-                                                <li class="action-item action-duplicate">
-                                                    <a href="#" class="duplicate-button action-button"></a>
-                                                </li>
-                                                <li class="action-item action-delete">
-                                                    <a href="#" class="delete-button action-button"></a>
-                                                </li>
-                                                <li class="action-item action-drag">
-                                                    <span data-tooltip="Drag to reorder" class="drag-handle action"></span>
-                                                </li>
-                                            </ul>
+                                            <div class="header-actions">
+                                                <ul class="actions-list">
+                                                    <li class="action-item action-edit">
+                                                        <a href="#" class="edit-button action-button"></a>
+                                                    </li>
+                                                    <li class="action-item action-duplicate">
+                                                        <a href="#" class="duplicate-button action-button"></a>
+                                                    </li>
+                                                    <li class="action-item action-delete">
+                                                        <a href="#" class="delete-button action-button"></a>
+                                                    </li>
+                                                    <li class="action-item action-drag">
+                                                        <span data-tooltip="Drag to reorder" class="drag-handle action"></span>
+                                                    </li>
+                                                </ul>
+                                            </div>
                                         </div>
-                                    </div>
-                                </header>
-                                <article class="xblock-render"></article>
-                            </section>
-                        </div>
-                        <div class="studio-xblock-wrapper" data-locator="locator-component-A3">
-                            <section class="wrapper-xblock level-element">
-                                <header class="xblock-header">
-                                    <div class="xblock-header-primary">
+                                    </header>
+                                    <article class="xblock-render"></article>
+                                </section>
+                            </div>
+                            <div class="studio-xblock-wrapper" data-locator="locator-component-A2">
+                                <section class="wrapper-xblock level-element">
+                                    <header class="xblock-header">
                                         <div class="header-actions">
-                                            <ul class="actions-list">
-                                                <li class="action-item action-edit">
-                                                    <a href="#" class="edit-button action-button"></a>
-                                                </li>
-                                                <li class="action-item action-duplicate">
-                                                    <a href="#" class="duplicate-button action-button"></a>
-                                                </li>
-                                                <li class="action-item action-delete">
-                                                    <a href="#" class="delete-button action-button"></a>
-                                                </li>
-                                                <li class="action-item action-drag">
-                                                    <span data-tooltip="Drag to reorder" class="drag-handle action"></span>
-                                                </li>
-                                            </ul>
+                                            <div class="xblock-header-primary">
+                                                <ul class="actions-list">
+                                                    <li class="action-item action-edit">
+                                                        <a href="#" class="edit-button action-button"></a>
+                                                    </li>
+                                                    <li class="action-item action-duplicate">
+                                                        <a href="#" class="duplicate-button action-button"></a>
+                                                    </li>
+                                                    <li class="action-item action-delete">
+                                                        <a href="#" class="delete-button action-button"></a>
+                                                    </li>
+                                                    <li class="action-item action-drag">
+                                                        <span data-tooltip="Drag to reorder" class="drag-handle action"></span>
+                                                    </li>
+                                                </ul>
+                                            </div>
                                         </div>
-                                    </div>
-                                </header>
-                                <article class="xblock-render"></article>
-                            </section>
+                                    </header>
+                                    <article class="xblock-render"></article>
+                                </section>
+                            </div>
+                            <div class="studio-xblock-wrapper" data-locator="locator-component-A3">
+                                <section class="wrapper-xblock level-element">
+                                    <header class="xblock-header">
+                                        <div class="xblock-header-primary">
+                                            <div class="header-actions">
+                                                <ul class="actions-list">
+                                                    <li class="action-item action-edit">
+                                                        <a href="#" class="edit-button action-button"></a>
+                                                    </li>
+                                                    <li class="action-item action-duplicate">
+                                                        <a href="#" class="duplicate-button action-button"></a>
+                                                    </li>
+                                                    <li class="action-item action-delete">
+                                                        <a href="#" class="delete-button action-button"></a>
+                                                    </li>
+                                                    <li class="action-item action-drag">
+                                                        <span data-tooltip="Drag to reorder" class="drag-handle action"></span>
+                                                    </li>
+                                                </ul>
+                                            </div>
+                                        </div>
+                                    </header>
+                                    <article class="xblock-render"></article>
+                                </section>
+                            </div>
                         </div>
                         <div class="add-xblock-component new-component-item adding"></div>
                     </div>
@@ -173,80 +175,82 @@
 
                 <article class="xblock-render">
                     <div class="xblock" data-request-token="page-render-token">
-                        <div class="studio-xblock-wrapper" data-locator="locator-component-B1">
-                            <section class="wrapper-xblock level-element">
-                                <header class="xblock-header">
-                                    <div class="xblock-header-primary">
-                                        <div class="header-actions">
-                                            <ul class="actions-list">
-                                                <li class="action-item action-edit">
-                                                    <a href="#" class="edit-button action-button"></a>
-                                                </li>
-                                                <li class="action-item action-duplicate">
-                                                    <a href="#" class="duplicate-button action-button"></a>
-                                                </li>
-                                                <li class="action-item action-delete">
-                                                    <a href="#" class="delete-button action-button"></a>
-                                                </li>
-                                                <li class="action-item action-drag">
-                                                    <span data-tooltip="Drag to reorder" class="drag-handle action"></span>
-                                                </li>
-                                            </ul>
+                        <div>
+                            <div class="studio-xblock-wrapper" data-locator="locator-component-B1">
+                                <section class="wrapper-xblock level-element">
+                                    <header class="xblock-header">
+                                        <div class="xblock-header-primary">
+                                            <div class="header-actions">
+                                                <ul class="actions-list">
+                                                    <li class="action-item action-edit">
+                                                        <a href="#" class="edit-button action-button"></a>
+                                                    </li>
+                                                    <li class="action-item action-duplicate">
+                                                        <a href="#" class="duplicate-button action-button"></a>
+                                                    </li>
+                                                    <li class="action-item action-delete">
+                                                        <a href="#" class="delete-button action-button"></a>
+                                                    </li>
+                                                    <li class="action-item action-drag">
+                                                        <span data-tooltip="Drag to reorder" class="drag-handle action"></span>
+                                                    </li>
+                                                </ul>
+                                            </div>
                                         </div>
-                                    </div>
-                                </header>
-                                <article class="xblock-render"></article>
-                            </section>
-                        </div>
-                        <div class="studio-xblock-wrapper" data-locator="locator-component-B2">
-                            <section class="wrapper-xblock level-element">
-                                <header class="xblock-header">
-                                    <div class="xblock-header-primary">
-                                        <div class="header-actions">
-                                            <ul class="actions-list">
-                                                <li class="action-item action-edit">
-                                                    <a href="#" class="edit-button action-button"></a>
-                                                </li>
-                                                <li class="action-item action-duplicate">
-                                                    <a href="#" class="duplicate-button action-button"></a>
-                                                </li>
-                                                <li class="action-item action-delete">
-                                                    <a href="#" class="delete-button action-button"></a>
-                                                </li>
-                                                <li class="action-item action-drag">
-                                                    <span data-tooltip="Drag to reorder" class="drag-handle action"></span>
-                                                </li>
-                                            </ul>
+                                    </header>
+                                    <article class="xblock-render"></article>
+                                </section>
+                            </div>
+                            <div class="studio-xblock-wrapper" data-locator="locator-component-B2">
+                                <section class="wrapper-xblock level-element">
+                                    <header class="xblock-header">
+                                        <div class="xblock-header-primary">
+                                            <div class="header-actions">
+                                                <ul class="actions-list">
+                                                    <li class="action-item action-edit">
+                                                        <a href="#" class="edit-button action-button"></a>
+                                                    </li>
+                                                    <li class="action-item action-duplicate">
+                                                        <a href="#" class="duplicate-button action-button"></a>
+                                                    </li>
+                                                    <li class="action-item action-delete">
+                                                        <a href="#" class="delete-button action-button"></a>
+                                                    </li>
+                                                    <li class="action-item action-drag">
+                                                        <span data-tooltip="Drag to reorder" class="drag-handle action"></span>
+                                                    </li>
+                                                </ul>
+                                            </div>
                                         </div>
-                                    </div>
-                                </header>
-                                <article class="xblock-render"></article>
-                            </section>
-                        </div>
-                        <div class="studio-xblock-wrapper" data-locator="locator-component-B3">
-                            <section class="wrapper-xblock level-element">
-                                <header class="xblock-header">
-                                    <div class="xblock-header-primary">
-                                        <div class="header-actions">
-                                            <ul class="actions-list">
-                                                <li class="action-item action-edit">
-                                                    <a href="#" class="edit-button action-button"></a>
-                                                </li>
-                                                <li class="action-item action-duplicate">
-                                                    <a href="#" class="duplicate-button action-button"></a>
-                                                </li>
-                                                <li class="action-item action-delete">
-                                                    <a href="#" class="delete-button action-button"></a>
-                                                </li>
-                                                <li class="action-item action-drag">
-                                                    <span data-tooltip="Drag to reorder" class="drag-handle action"></span>
-                                                </li>
-                                            </ul>
+                                    </header>
+                                    <article class="xblock-render"></article>
+                                </section>
+                            </div>
+                            <div class="studio-xblock-wrapper" data-locator="locator-component-B3">
+                                <section class="wrapper-xblock level-element">
+                                    <header class="xblock-header">
+                                        <div class="xblock-header-primary">
+                                            <div class="header-actions">
+                                                <ul class="actions-list">
+                                                    <li class="action-item action-edit">
+                                                        <a href="#" class="edit-button action-button"></a>
+                                                    </li>
+                                                    <li class="action-item action-duplicate">
+                                                        <a href="#" class="duplicate-button action-button"></a>
+                                                    </li>
+                                                    <li class="action-item action-delete">
+                                                        <a href="#" class="delete-button action-button"></a>
+                                                    </li>
+                                                    <li class="action-item action-drag">
+                                                        <span data-tooltip="Drag to reorder" class="drag-handle action"></span>
+                                                    </li>
+                                                </ul>
+                                            </div>
                                         </div>
-                                    </div>
-                                </header>
-                                <article class="xblock-render"></article>
-                            </section>
+                                    </header>
+                                    <article class="xblock-render"></article>
+                                </section>
+                            </div>
                         </div>
                         <div class="add-xblock-component new-component-item adding"></div>
                     </div>

--- a/lms/templates/studio_render_paged_children_view.html
+++ b/lms/templates/studio_render_paged_children_view.html
@@ -12,9 +12,11 @@
 
 <div class="container-paging-header"></div>
 
+<div>
 % for item in items:
     ${item['content']}
 % endfor
+</div>
 
 % if can_add:
     <div class="add-xblock-component new-component-item adding"></div>


### PR DESCRIPTION
**Background**: This PR fixes an issue with editing a library. Before the fix, due to differences between expected and actual DOM structure, XBlocks were sometimes added inside sibling XBlocks' wrapper elements.
**JIRA ticket**: https://openedx.atlassian.net/browse/OSPR-347
**Discussions**: Architecture discussed extensively on the wiki and in meetings, then the revised proposal was presented to the Arch Council on Oct. 21 and given thumbs up.
**Sandbox URL**: LMS at http://content-libraries.sandbox.opencraft.com/ and Studio at http://content-libraries.sandbox.opencraft.com:18010/
**Partner information**: 3rd party-hosted open edX instance, for an edX solutions client.

**Testing instructions:**
- Create a new empty library
- Add Blank Common Problem
- Add Checkboxes
- Delete the Blank Common Problem
- Checkboxes block should **not** disappear.
