### PR TITLE
(WIP) added bok-choy tests for entrance exam [CMS + LMS]

### DIFF
--- a/cms/envs/bok_choy.py
+++ b/cms/envs/bok_choy.py
@@ -54,6 +54,9 @@ for log_name, log_level in LOG_OVERRIDES:
 # Use the auto_auth workflow for creating users and logging them in
 FEATURES['AUTOMATIC_AUTH_FOR_TESTING'] = True
 
+########################### Entrance Exams #################################
+FEATURES['ENTRANCE_EXAMS'] = True
+
 # Unfortunately, we need to use debug mode to serve staticfiles
 DEBUG = True
 

--- a/cms/templates/settings.html
+++ b/cms/templates/settings.html
@@ -316,7 +316,7 @@ CMS.URL.UPLOAD_ASSET = '${upload_asset_url}';
                             <input type="checkbox" id="entrance-exam-enabled" />
                             <label for="entrance-exam-enabled">${_("Require students to pass an exam before beginning the course.")}</label>
                         </div>
-                         <div id="div-grade-requirements">
+                         <div id="div-grade-requirements" hidden="hidden">
                           <p><span class="tip tip-inline">${_("You can now view and author your course entrance exam from the ")}<a href='${course_handler_url}'>${_("Course Outline")}</a></span></p>
                           <p><h3>${_("Grade Requirements")}</h3></p>
                           <p><div><input type="text" id="entrance-exam-minimum-score-pct" aria-describedby="min-score-format"><span id="min-score-format" class="tip tip-inline">${_(" %")}</span></div></p>

--- a/common/test/acceptance/pages/studio/settings.py
+++ b/common/test/acceptance/pages/studio/settings.py
@@ -3,6 +3,7 @@ Course Schedule and Details Settings page.
 """
 
 from .course_page import CoursePage
+from .utils import press_the_notification_button
 
 
 class SettingsPage(CoursePage):
@@ -14,3 +15,29 @@ class SettingsPage(CoursePage):
 
     def is_browser_on_page(self):
         return self.q(css='body.view-settings').present
+
+    @property
+    def pre_requisite_course(self):
+        """
+        Returns the pre-requisite course drop down field.
+        """
+        return self.q(css='#pre-requisite-course')
+
+    @property
+    def entrance_exam_field(self):
+        """
+        Returns the enable entrance exam checkbox.
+        """
+        return self.q(css='#entrance-exam-enabled')
+
+    def save_changes(self):
+        """
+        Clicks save button.
+        """
+        press_the_notification_button(self, "save")
+
+    def refresh_page(self):
+        """
+        Reload the page.
+        """
+        self.browser.refresh()

--- a/common/test/acceptance/tests/helpers.py
+++ b/common/test/acceptance/tests/helpers.py
@@ -167,6 +167,19 @@ def enable_css_animations(page):
     """)
 
 
+def element_has_text(page, css_selector, text):
+    """
+    Return true if the given text is present in the list.
+    """
+    text_present = False
+    text_list = page.q(css=css_selector).text
+
+    if len(text_list) > 0 and (text in text_list):
+        text_present = True
+
+    return text_present
+
+
 class UniqueCourseTest(WebAppTest):
     """
     Test that provides a unique course ID.

--- a/common/test/acceptance/tests/lms/test_lms.py
+++ b/common/test/acceptance/tests/lms/test_lms.py
@@ -8,7 +8,7 @@ from unittest import skip
 from nose.plugins.attrib import attr
 
 from bok_choy.web_app_test import WebAppTest
-from ..helpers import UniqueCourseTest, load_data_str
+from ..helpers import UniqueCourseTest, load_data_str, element_has_text
 from ...pages.lms.auto_auth import AutoAuthPage
 from ...pages.common.logout import LogoutPage
 from ...pages.lms.find_courses import FindCoursesPage
@@ -21,6 +21,7 @@ from ...pages.lms.dashboard import DashboardPage
 from ...pages.lms.problem import ProblemPage
 from ...pages.lms.video.video import VideoPage
 from ...pages.lms.courseware import CoursewarePage
+from ...pages.studio.settings import SettingsPage
 from ...pages.lms.login_and_register import CombinedLoginAndRegisterPage
 from ...fixtures.course import CourseFixture, XBlockFixtureDesc, CourseUpdateDesc
 
@@ -680,3 +681,73 @@ class ProblemExecutionTest(UniqueCourseTest):
         problem_page.fill_answer("4")
         problem_page.click_check()
         self.assertFalse(problem_page.is_correct())
+
+
+class EntranceExamTest(UniqueCourseTest):
+    """
+    Tests that course has an entrance exam.
+    """
+
+    def setUp(self):
+        """
+        Initialize pages and install a course fixture.
+        """
+        super(EntranceExamTest, self).setUp()
+
+        CourseFixture(
+            self.course_info['org'], self.course_info['number'],
+            self.course_info['run'], self.course_info['display_name']
+        ).install()
+
+        self.course_info_page = CourseInfoPage(self.browser, self.course_id)
+        self.settings_page = SettingsPage(
+            self.browser,
+            self.course_info['org'],
+            self.course_info['number'],
+            self.course_info['run']
+        )
+
+        # Auto-auth register for the course
+        AutoAuthPage(self.browser, course_id=self.course_id).visit()
+
+    def test_entrance_exam_section(self):
+        """
+         Scenario: Any course that is enabled for an entrance exam, should have entrance exam section at course info
+         page.
+            Given that I am on the course info page
+            When I view the course info that has an entrance exam
+            Then there should be an "Entrance Exam" section.'
+        """
+
+        # visit course info page and make sure there is not entrance exam section.
+        self.course_info_page.visit()
+        self.course_info_page.wait_for_page()
+        self.assertFalse(element_has_text(
+            page=self.course_info_page,
+            css_selector='div ol li a',
+            text='Entrance Exam'
+        ))
+
+        # Logout and login as a staff.
+        LogoutPage(self.browser).visit()
+        AutoAuthPage(self.browser, course_id=self.course_id, staff=True).visit()
+
+        # visit course settings page and set/enabled entrance exam for that course.
+        self.settings_page.visit()
+        self.settings_page.wait_for_page()
+        self.assertTrue(self.settings_page.is_browser_on_page())
+        self.settings_page.entrance_exam_field.click()
+        self.settings_page.save_changes()
+
+        # Logout and login as a student.
+        LogoutPage(self.browser).visit()
+        AutoAuthPage(self.browser, course_id=self.course_id, staff=False).visit()
+
+        # visit course info page and make sure there is an "Entrance Exam" section.
+        self.course_info_page.visit()
+        self.course_info_page.wait_for_page()
+        self.assertTrue(element_has_text(
+            page=self.course_info_page,
+            css_selector='div ol li a',
+            text='Entrance Exam'
+        ))

--- a/common/test/acceptance/tests/studio/test_studio_settings_details.py
+++ b/common/test/acceptance/tests/studio/test_studio_settings_details.py
@@ -1,0 +1,82 @@
+"""
+Acceptance tests for Studio's Settings Details pages
+"""
+
+from ...pages.studio.settings import SettingsPage
+from ...pages.studio.overview import CourseOutlinePage
+from ...tests.studio.base_studio_test import StudioCourseTest
+from ..helpers import (
+    element_has_text,
+)
+
+
+class SettingsMilestonesTest(StudioCourseTest):
+    """
+    Tests for milestones feature in Studio's settings tab
+    """
+    def setUp(self):
+        super(SettingsMilestonesTest, self).setUp(is_staff=True)
+        self.number = self.course_info['number']
+        self.settings_detail = SettingsPage(
+            self.browser,
+            self.course_info['org'],
+            self.number,
+            self.course_info['run']
+        )
+
+        # Before every test, make sure to visit the page first
+        self.settings_detail.visit()
+        self.assertTrue(self.settings_detail.is_browser_on_page())
+
+    def test_page_has_enable_entrance_exam_field(self):
+        """
+        Test to make sure page has 'enable entrance exam' field.
+        """
+        self.assertTrue(self.settings_detail.entrance_exam_field.present)
+
+    def test_enable_entrance_exam_for_course(self):
+        """
+        Test that entrance exam should be created after checking the 'enable entrance exam' checkbox.
+        """
+        self.settings_detail.entrance_exam_field.click()
+        self.settings_detail.save_changes()
+        self.assertTrue(element_has_text(
+            page=self.settings_detail,
+            css_selector='#alert-confirmation-title',
+            text='Your changes have been saved.'
+        ))
+
+        # getting the course outline page.
+        course_outline_page = CourseOutlinePage(
+            self.browser, self.course_info['org'], self.number, self.course_info['run']
+        )
+        course_outline_page.visit()
+        course_outline_page.wait_for_page()
+        self.assertTrue(course_outline_page.is_browser_on_page())
+
+        # title with text 'Entrance Exam' should be present on page.
+        self.assertTrue(element_has_text(
+            page=course_outline_page,
+            css_selector='span.section-title',
+            text='Entrance Exam'
+        ))
+
+        # Delete the currently created entrance exam.
+        self.settings_detail.visit()
+        self.settings_detail.entrance_exam_field.click()
+        self.settings_detail.save_changes()
+        self.assertTrue(element_has_text(
+            page=self.settings_detail,
+            css_selector='#alert-confirmation-title',
+            text='Your changes have been saved.'
+        ))
+
+        course_outline_page.visit()
+        course_outline_page.wait_for_page()
+        self.assertTrue(course_outline_page.is_browser_on_page())
+
+        self.assertFalse(element_has_text(
+            page=course_outline_page,
+            css_selector='span.section-title',
+            text='Entrance Exam'
+        ))

--- a/lms/envs/bok_choy.py
+++ b/lms/envs/bok_choy.py
@@ -83,6 +83,10 @@ for log_name, log_level in LOG_OVERRIDES:
 # Unfortunately, we need to use debug mode to serve staticfiles
 DEBUG = True
 
+########################### Entrance Exams #################################
+FEATURES['MILESTONES_APP'] = True
+FEATURES['ENTRANCE_EXAMS'] = True
+
 # Point the URL used to test YouTube availability to our stub YouTube server
 YOUTUBE_PORT = 9080
 YOUTUBE['API'] = "127.0.0.1:{0}/get_youtube_api/".format(YOUTUBE_PORT)


### PR DESCRIPTION
@ziafazal  
@mattdrayer today, I rebased this branch with [ mattdrayer/entrance-exams] but the issue is still persist that i have discussed. 
[entrance exam is not removing / deleting from course outline page if module store = 'split' ] 
however i am sending PR for your review. 

This PR contains Bok-Choy tests for entrance exam: 
- for CMS module. (test would be fail)
- for LMS module.

Kindly look into the changes and let me know if something is missing at my end.
Thank you. 
