### PR TITLE
Added bokchoy test for library block deletion bug

### DIFF
--- a/common/test/acceptance/tests/studio/test_studio_library.py
+++ b/common/test/acceptance/tests/studio/test_studio_library.py
@@ -148,6 +148,38 @@ class LibraryEditPageTest(StudioLibraryTest):
         add_component(self.lib_page, "problem", "Multiple Choice")
         self.assertTrue(self.lib_page.nav_disabled(position))
 
+    def test_delete_deletes_only_desired_block(self):
+        """
+        Scenario: Ensure that when deleting XBlock only desired XBlock is deleted
+        Given that I have a library in Studio with no XBlocks
+        And I create Blank Common Problem XBlock
+        And I create Checkboxes XBlock
+        When I delete Blank Problem XBlock
+        Then Checkboxes XBlock is not deleted
+        And Blank Common Problem XBlock is deleted
+        """
+        self.assertEqual(len(self.lib_page.xblocks), 0)
+        add_component(self.lib_page, "problem", "Blank Common Problem")
+        add_component(self.lib_page, "problem", "Checkboxes")
+        problem_block = self.lib_page.xblocks[1]
+        # Edit it:
+        problem_block.edit()
+        problem_block.open_basic_tab()
+        problem_block.set_codemirror_text(
+            """
+            >>En Taro ___?<<
+             (x) Adun
+             (x) Tassadar
+             ( ) Zeratul
+            """
+        )
+        problem_block.save_settings()
+        self.assertEqual(len(self.lib_page.xblocks), 2)
+        self.lib_page.click_delete_button(self.lib_page.xblocks[0].locator)
+        self.assertEqual(len(self.lib_page.xblocks), 1)
+        problem_block = self.lib_page.xblocks[0]
+        self.assertIn("Tassadar", problem_block.student_content)
+
 
 @ddt
 class LibraryNavigationTest(StudioLibraryTest):


### PR DESCRIPTION
**Background**: This is a continuation for https://github.com/edx/edx-platform/pull/6580 - added bok choy test verifying the bug was fixed.
**Discussions**: Architecture discussed extensively on the wiki and in meetings, then the revised proposal was presented to the Arch Council on Oct. 21 and given thumbs up.
**Sandbox URL**: LMS at http://content-libraries.sandbox.opencraft.com/ and Studio at http://content-libraries.sandbox.opencraft.com:18010/
**Partner information**: 3rd party-hosted open edX instance, for an edX solutions client.
