### PR TITLE
Allow configuration to override links to mobile app stores

### DIFF
--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -210,6 +210,9 @@ THEME_NAME = ENV_TOKENS.get('THEME_NAME', None)
 # Marketing link overrides
 MKTG_URL_LINK_MAP.update(ENV_TOKENS.get('MKTG_URL_LINK_MAP', {}))
 
+# Mobile store URL overrides
+MOBILE_STORE_URLS = ENV_TOKENS.get('MOBILE_STORE_URLS', MOBILE_STORE_URLS)
+
 # Timezone overrides
 TIME_ZONE = ENV_TOKENS.get('TIME_ZONE', TIME_ZONE)
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1596,6 +1596,13 @@ MKTG_URL_LINK_MAP = {
     'WHAT_IS_VERIFIED_CERT': 'verified-certificate',
 }
 
+################# Mobile URLS ##########################
+
+# These are URLs to the app store for mobile.
+MOBILE_STORE_URLS = {
+    'apple': '#',
+    'google': '#'
+}
 
 ################# Student Verification #################
 VERIFY_STUDENT = {

--- a/lms/templates/footer-edx-new.html
+++ b/lms/templates/footer-edx-new.html
@@ -99,12 +99,12 @@
       <div class="footer-mobile-apps">
         <h2 class="footer-nav-title">${_("Mobile Apps")}</h2>
         <div class="mobile-app-wrapper">
-          <a href="#">
+          <a href="${settings.MOBILE_STORE_URLS.get('apple', '#')}">
             <img class="app-store" alt="${_("Apple app on Apple Store")}" src="${static.url('images/app/app_store_badge_135x40.svg')}">
           </a>
         </div>
         <div class="mobile-app-wrapper">
-          <a href="https://play.google.com/store/apps/details?id=org.edx.mobile">
+          <a href="${settings.MOBILE_STORE_URLS.get('google', '#')}">
             <img class="google-play" alt="${_("Android app on Google Play")}" src="${static.url('images/app/google_play_badge_45.png')}">
           </a>
         </div>


### PR DESCRIPTION
This will allow ops to override the URLs to the mobile app store in configuration.

The new configuration param (in `lms.envs.json`) is `MOBILE_STORE_URLS`.  It is a dictionary with keys "apple" and "google" specifying the URL to the respective app stores.

@AlasdairSwan feel free to merge this into your branch.
FYI: @feanil 
