### PR TITLE
Improve Django Admin Panel for Admin Roles.

### DIFF
--- a/common/djangoapps/student/admin.py
+++ b/common/djangoapps/student/admin.py
@@ -1,11 +1,31 @@
 '''
 django admin pages for courseware model
 '''
+from django import forms
 from config_models.admin import ConfigurationModelAdmin
 
 from student.models import UserProfile, UserTestGroup, CourseEnrollmentAllowed, DashboardConfiguration
-from student.models import CourseEnrollment, Registration, PendingNameChange, CourseAccessRole, CourseAccessRoleAdmin
+from student.models import CourseEnrollment, Registration, PendingNameChange, CourseAccessRole
 from ratelimitbackend import admin
+from student.roles import REGISTERED_ACCESS_ROLES
+
+
+class CourseAccessRoleForm(forms.ModelForm):
+    """Form for adding new Course Access Roles view the Django Admin Panel."""
+    class Meta:
+        model = CourseAccessRole
+
+    COURSE_ACCESS_ROLES = [(role_name, role_name) for role_name in REGISTERED_ACCESS_ROLES.keys()]
+    role = forms.ChoiceField(choices=COURSE_ACCESS_ROLES)
+
+
+class CourseAccessRoleAdmin(admin.ModelAdmin):
+    """Admin panel for the Course Access Role. """
+    form = CourseAccessRoleForm
+    raw_id_fields = ("user",)
+    list_display = (
+        'id', 'user', 'org', 'course_id', 'role'
+    )
 
 admin.site.register(UserProfile)
 

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -1267,9 +1267,6 @@ class CourseAccessRole(models.Model):
         return "[CourseAccessRole] user: {}   role: {}   org: {}   course: {}".format(self.user.username, self.role, self.org, self.course_id)
 
 
-class CourseAccessRoleAdmin(admin.ModelAdmin):
-    raw_id_fields = ("user",)
-
 #### Helper methods for use from python manage.py shell and other classes.
 
 

--- a/common/djangoapps/student/roles.py
+++ b/common/djangoapps/student/roles.py
@@ -6,9 +6,32 @@ adding users, removing users, and listing members
 from abc import ABCMeta, abstractmethod
 
 from django.contrib.auth.models import User
+import logging
 
 from student.models import CourseAccessRole
 from xmodule_django.models import CourseKeyField
+
+
+log = logging.getLogger(__name__)
+
+# A list of registered access roles.
+REGISTERED_ACCESS_ROLES = {}
+
+
+def register_access_role(cls):
+    """
+    Decorator that allows access roles to be registered within the roles module and referenced by their
+    string values.
+
+    Assumes that the decorated class has a "ROLE" attribute, defining its type.
+
+    """
+    try:
+        role_name = getattr(cls, 'ROLE')
+        REGISTERED_ACCESS_ROLES[role_name] = cls
+    except AttributeError:
+        log.exception(u"Unable to register Access Role with attribute 'ROLE'.")
+    return cls
 
 
 class RoleCache(object):
@@ -187,6 +210,7 @@ class OrgRole(RoleBase):
         super(OrgRole, self).__init__(role, org)
 
 
+@register_access_role
 class CourseStaffRole(CourseRole):
     """A Staff member of a course"""
     ROLE = 'staff'
@@ -195,6 +219,7 @@ class CourseStaffRole(CourseRole):
         super(CourseStaffRole, self).__init__(self.ROLE, *args, **kwargs)
 
 
+@register_access_role
 class CourseInstructorRole(CourseRole):
     """A course Instructor"""
     ROLE = 'instructor'
@@ -203,6 +228,7 @@ class CourseInstructorRole(CourseRole):
         super(CourseInstructorRole, self).__init__(self.ROLE, *args, **kwargs)
 
 
+@register_access_role
 class CourseFinanceAdminRole(CourseRole):
     """A course staff member with privileges to review financial data."""
     ROLE = 'finance_admin'
@@ -211,6 +237,7 @@ class CourseFinanceAdminRole(CourseRole):
         super(CourseFinanceAdminRole, self).__init__(self.ROLE, *args, **kwargs)
 
 
+@register_access_role
 class CourseSalesAdminRole(CourseRole):
     """A course staff member with privileges to perform sales operations. """
     ROLE = 'sales_admin'
@@ -219,6 +246,7 @@ class CourseSalesAdminRole(CourseRole):
         super(CourseSalesAdminRole, self).__init__(self.ROLE, *args, **kwargs)
 
 
+@register_access_role
 class CourseBetaTesterRole(CourseRole):
     """A course Beta Tester"""
     ROLE = 'beta_testers'
@@ -227,6 +255,7 @@ class CourseBetaTesterRole(CourseRole):
         super(CourseBetaTesterRole, self).__init__(self.ROLE, *args, **kwargs)
 
 
+@register_access_role
 class LibraryUserRole(CourseRole):
     """
     A user who can view a library and import content from it, but not edit it.
@@ -261,6 +290,7 @@ class OrgLibraryUserRole(OrgRole):
         super(OrgLibraryUserRole, self).__init__(self.ROLE, *args, **kwargs)
 
 
+@register_access_role
 class CourseCreatorRole(RoleBase):
     """
     This is the group of people who have permission to create new courses (we may want to eventually


### PR DESCRIPTION
@wedaly @ormsbee @e0d -- Thoughts?

This is related to https://openedx.atlassian.net/browse/ECOM-857

The goal is to make the Django Admin Panel a bit more user friendly for adding new admin roles, such that Marketing / Support internal staff can create new finance_admins and sales_admins. 

The 'REGISTERED_ACCESS_ROLES' could be a useful way to look up roles by their string identifiers, as well. For now, I'm using it to update the admin panel.

![image](https://cloud.githubusercontent.com/assets/235752/5724067/ebd38e10-9b16-11e4-9ce8-8d5dc15bf3a3.png)

![image](https://cloud.githubusercontent.com/assets/235752/5724073/f12e5318-9b16-11e4-9a25-fd4245612424.png)
