### PR TITLE
LMS: Student Notes - Styling Revamp of Toggle Notes Controls

### DIFF
--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -143,7 +143,8 @@ def xblock_handler(request, usage_key_string):
                     # right now can't combine output of this w/ output of _get_module_info, but worthy goal
                     return JsonResponse(CourseGradingModel.get_section_grader_type(usage_key))
                 # TODO: pass fields to _get_module_info and only return those
-                rsp = _get_module_info(_get_xblock(usage_key, request.user))
+                with modulestore().bulk_operations(usage_key.course_key):
+                    rsp = _get_module_info(_get_xblock(usage_key, request.user))
                 return JsonResponse(rsp)
             else:
                 return HttpResponse(status=406)

--- a/common/lib/xmodule/xmodule/modulestore/modulestore_settings.py
+++ b/common/lib/xmodule/xmodule/modulestore/modulestore_settings.py
@@ -98,6 +98,7 @@ def update_module_store_settings(
         module_store_options=None,
         xml_store_options=None,
         default_store=None,
+        mappings=None,
 ):
     """
     Updates the settings for each store defined in the given module_store_setting settings
@@ -122,6 +123,9 @@ def update_module_store_settings(
                 mixed_stores.insert(0, store)
                 return
         raise Exception("Could not find setting for requested default store: {}".format(default_store))
+
+    if mappings and 'mappings' in module_store_setting['default']['OPTIONS']:
+        module_store_setting['default']['OPTIONS']['mappings'] = mappings
 
 
 def get_mixed_stores(mixed_setting):

--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -29,7 +29,7 @@ from contracts import contract, new_contract
 
 from importlib import import_module
 from opaque_keys.edx.keys import UsageKey, CourseKey, AssetKey
-from opaque_keys.edx.locations import Location
+from opaque_keys.edx.locations import Location, BlockUsageLocator
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
 from opaque_keys.edx.locator import CourseLocator, LibraryLocator
 
@@ -56,6 +56,7 @@ new_contract('CourseKey', CourseKey)
 new_contract('AssetKey', AssetKey)
 new_contract('AssetMetadata', AssetMetadata)
 new_contract('long', long)
+new_contract('BlockUsageLocator', BlockUsageLocator)
 
 # sort order that returns DRAFT items first
 SORT_REVISION_FAVOR_DRAFT = ('_id.revision', pymongo.DESCENDING)
@@ -93,12 +94,13 @@ class MongoKeyValueStore(InheritanceKeyValueStore):
     A KeyValueStore that maps keyed data access to one of the 3 data areas
     known to the MongoModuleStore (data, children, and metadata)
     """
-    def __init__(self, data, children, metadata):
+    def __init__(self, data, parent, children, metadata):
         super(MongoKeyValueStore, self).__init__()
         if not isinstance(data, dict):
             self._data = {'data': data}
         else:
             self._data = data
+        self._parent = parent
         self._children = children
         self._metadata = metadata
 
@@ -106,7 +108,7 @@ class MongoKeyValueStore(InheritanceKeyValueStore):
         if key.scope == Scope.children:
             return self._children
         elif key.scope == Scope.parent:
-            return None
+            return self._parent
         elif key.scope == Scope.settings:
             return self._metadata[key.field_name]
         elif key.scope == Scope.content:
@@ -219,15 +221,35 @@ class CachingDescriptorSystem(MakoDescriptorSystem, EditInfoRuntimeMixin):
                     self._convert_reference_to_key(childloc)
                     for childloc in definition.get('children', [])
                 ]
+
+                parent = None
+                if self.cached_metadata is not None:
+                    # fish the parent out of here if it's available
+                    parent_url = self.cached_metadata.get(unicode(location), {}).get('parent', {}).get(
+                        ModuleStoreEnum.Branch.published_only if location.revision is None
+                        else ModuleStoreEnum.Branch.draft_preferred
+                    )
+                    if parent_url:
+                        parent = BlockUsageLocator.from_string(parent_url)
+                if not parent and category != 'course':
+                    # try looking it up just-in-time (but not if we're working with a root node (course).
+                    parent = self.modulestore.get_parent_location(
+                        as_published(location),
+                        ModuleStoreEnum.RevisionOption.published_only if location.revision is None
+                        else ModuleStoreEnum.RevisionOption.draft_preferred
+                    )
+
                 data = definition.get('data', {})
                 if isinstance(data, basestring):
                     data = {'data': data}
+
                 mixed_class = self.mixologist.mix(class_)
                 if data:  # empty or None means no work
                     data = self._convert_reference_fields_to_keys(mixed_class, location.course_key, data)
                 metadata = self._convert_reference_fields_to_keys(mixed_class, location.course_key, metadata)
                 kvs = MongoKeyValueStore(
                     data,
+                    parent,
                     children,
                     metadata,
                 )
@@ -439,6 +461,32 @@ class MongoBulkOpsMixin(BulkOperationsMixin):
         )
 
 
+class ParentLocationCache(dict):
+    """
+    Dict-based object augmented with a more cache-like interface, for internal use.
+    """
+    # pylint: disable=missing-docstring
+
+    @contract(key=unicode)
+    def has(self, key):
+        return key in self
+
+    @contract(key=unicode, value="BlockUsageLocator | None")
+    def set(self, key, value):
+        self[key] = value
+
+    @contract(key=unicode)
+    def delete(self, key):
+        if key in self:
+            del self[key]
+
+    @contract(value="BlockUsageLocator")
+    def delete_by_value(self, value):
+        keys_to_delete = [k for k, v in self.iteritems() if v == value]
+        for key in keys_to_delete:
+            del self[key]
+
+
 class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, MongoBulkOpsMixin):
     """
     A Mongodb backed ModuleStore
@@ -572,6 +620,16 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
             return location.replace(revision=MongoRevisionKey.draft)
         return location.replace(revision=MongoRevisionKey.published)
 
+    def _get_parent_cache(self, branch):
+        """
+        Provides a reference to one of the two branch-specific
+        ParentLocationCaches associated with the current request (if any).
+        """
+        if self.request_cache is not None:
+            return self.request_cache.data.setdefault('parent-location-{}'.format(branch), ParentLocationCache())
+        else:
+            return ParentLocationCache()
+
     def _compute_metadata_inheritance_tree(self, course_id):
         '''
         TODO (cdodge) This method can be deleted when the 'split module store' work has been completed
@@ -640,7 +698,13 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
                     _compute_inherited_metadata(child)
                 else:
                     # this is likely a leaf node, so let's record what metadata we need to inherit
-                    metadata_to_inherit[child] = my_metadata
+                    metadata_to_inherit[child] = my_metadata.copy()
+                # WARNING: 'parent' is not part of inherited metadata, but
+                # we're piggybacking on this recursive traversal to grab
+                # and cache the child's parent, as a performance optimization.
+                # The 'parent' key will be popped out of the dictionary during
+                # CachingDescriptorSystem.load_item
+                metadata_to_inherit[child].setdefault('parent', {})[self.get_branch_setting()] = url
 
         if root is not None:
             _compute_inherited_metadata(root)
@@ -735,12 +799,18 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
         data = {}
         to_process = list(items)
         course_key = self.fill_in_run(course_key)
+        parent_cache = self._get_parent_cache(self.get_branch_setting())
+
         while to_process and depth is None or depth >= 0:
             children = []
             for item in to_process:
                 self._clean_item_data(item)
-                children.extend(item.get('definition', {}).get('children', []))
-                data[Location._from_deprecated_son(item['location'], course_key.run)] = item
+                item_location = Location._from_deprecated_son(item['location'], course_key.run)
+                item_children = item.get('definition', {}).get('children', [])
+                children.extend(item_children)
+                for item_child in item_children:
+                    parent_cache.set(item_child, item_location)
+                data[item_location] = item
 
             if depth == 0:
                 break
@@ -1245,6 +1315,13 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
             if xblock.has_children:
                 children = self._serialize_scope(xblock, Scope.children)
                 payload.update({'definition.children': children['children']})
+
+                # Remove all old pointers to me, then add my current children back
+                parent_cache = self._get_parent_cache(self.get_branch_setting())
+                parent_cache.delete_by_value(xblock.location)
+                for child in xblock.children:
+                    parent_cache.set(unicode(child), xblock.location)
+
             self._update_single_item(xblock.scope_ids.usage_id, payload, allow_not_found=allow_not_found)
 
             # update subtree edited info for ancestors
@@ -1339,6 +1416,10 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
         assert revision == ModuleStoreEnum.RevisionOption.published_only \
             or revision == ModuleStoreEnum.RevisionOption.draft_preferred
 
+        parent_cache = self._get_parent_cache(self.get_branch_setting())
+        if parent_cache.has(unicode(location)):
+            return parent_cache.get(unicode(location))
+
         # create a query with tag, org, course, and the children field set to the given location
         query = self._course_key_to_son(location.course_key)
         query['definition.children'] = unicode(location)
@@ -1347,30 +1428,35 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
         if revision == ModuleStoreEnum.RevisionOption.published_only:
             query['_id.revision'] = MongoRevisionKey.published
 
-        # query the collection, sorting by DRAFT first
-        parents = self.collection.find(query, {'_id': True}, sort=[SORT_REVISION_FAVOR_DRAFT])
+        def cache_and_return(parent_loc):  # pylint:disable=missing-docstring
+            parent_cache.set(unicode(location), parent_loc)
+            return parent_loc
 
-        if parents.count() == 0:
+        # query the collection, sorting by DRAFT first
+        parents = list(
+            self.collection.find(query, {'_id': True}, sort=[SORT_REVISION_FAVOR_DRAFT])
+        )
+        if len(parents) == 0:
             # no parents were found
-            return None
+            return cache_and_return(None)
 
         if revision == ModuleStoreEnum.RevisionOption.published_only:
-            if parents.count() > 1:
+            if len(parents) > 1:
                 non_orphan_parents = self._get_non_orphan_parents(location, parents, revision)
                 if len(non_orphan_parents) == 0:
                     # no actual parent found
-                    return None
+                    return cache_and_return(None)
 
                 if len(non_orphan_parents) > 1:
                     # should never have multiple PUBLISHED parents
                     raise ReferentialIntegrityError(
-                        u"{} parents claim {}".format(parents.count(), location)
+                        u"{} parents claim {}".format(len(parents), location)
                     )
                 else:
-                    return non_orphan_parents[0]
+                    return cache_and_return(non_orphan_parents[0].replace(run=location.course_key.run))
             else:
                 # return the single PUBLISHED parent
-                return Location._from_deprecated_son(parents[0]['_id'], location.course_key.run)
+                return cache_and_return(Location._from_deprecated_son(parents[0]['_id'], location.course_key.run))
         else:
             # there could be 2 different parents if
             #   (1) the draft item was moved or
@@ -1386,11 +1472,11 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
             # since we sorted by SORT_REVISION_FAVOR_DRAFT, the 0'th parent is the one we want
             if published_parents > 1:
                 non_orphan_parents = self._get_non_orphan_parents(location, all_parents, revision)
-                return non_orphan_parents[0]
+                return cache_and_return(non_orphan_parents[0].replace(run=location.course_key.run))
 
             found_id = all_parents[0]['_id']
             # don't disclose revision outside modulestore
-            return Location._from_deprecated_son(found_id, location.course_key.run)
+            return cache_and_return(Location._from_deprecated_son(found_id, location.course_key.run))
 
     def get_parent_location(self, location, revision=ModuleStoreEnum.RevisionOption.published_only, **kwargs):
         '''
@@ -1409,7 +1495,7 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
         '''
         parent = self._get_raw_parent_location(location, revision)
         if parent:
-            return as_published(parent)
+            return parent
         return None
 
     def get_modulestore_type(self, course_key=None):
@@ -1463,6 +1549,7 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
         """
         kvs = MongoKeyValueStore(
             definition_data,
+            None,
             [],
             metadata,
         )

--- a/common/lib/xmodule/xmodule/modulestore/mongo/draft.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/draft.py
@@ -643,6 +643,9 @@ class DraftModuleStore(MongoModuleStore):
 
         Raises:
             ItemNotFoundError: if any of the draft subtree nodes aren't found
+
+        Returns:
+            The newly published xblock
         """
         # NOTE: cannot easily use self._breadth_first b/c need to get pub'd and draft as pairs
         # (could do it by having 2 breadth first scans, the first to just get all published children

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_xml.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_xml.py
@@ -31,7 +31,7 @@ class TestXMLModuleStore(unittest.TestCase):
     Test around the XML modulestore
     """
     def test_xml_modulestore_type(self):
-        store = XMLModuleStore(DATA_DIR, course_dirs=['toy', 'simple'])
+        store = XMLModuleStore(DATA_DIR, course_dirs=[])
         self.assertEqual(store.get_modulestore_type(), ModuleStoreEnum.Type.xml)
 
     def test_unicode_chars_in_xml_content(self):

--- a/common/lib/xmodule/xmodule/modulestore/xml_importer.py
+++ b/common/lib/xmodule/xmodule/modulestore/xml_importer.py
@@ -28,7 +28,7 @@ import json
 import re
 from lxml import etree
 
-from .xml import XMLModuleStore, ImportSystem, ParentTracker
+from .xml import XMLModuleStore, ImportSystem
 from xblock.runtime import KvsFieldData, DictKeyValueStore
 from xmodule.x_module import XModuleDescriptor
 from opaque_keys.edx.keys import UsageKey
@@ -479,11 +479,13 @@ def _import_module_and_update_references(
 
     fields = {}
     for field_name, field in module.fields.iteritems():
-        if field.is_set_on(module):
-            if field.scope == Scope.parent:
-                continue
+        if field.scope != Scope.parent and field.is_set_on(module):
             if isinstance(field, Reference):
-                fields[field_name] = _convert_reference_fields_to_new_namespace(field.read_from(module))
+                value = field.read_from(module)
+                if value is None:
+                    fields[field_name] = None
+                else:
+                    fields[field_name] = _convert_reference_fields_to_new_namespace(field.read_from(module))
             elif isinstance(field, ReferenceList):
                 references = field.read_from(module)
                 fields[field_name] = [_convert_reference_fields_to_new_namespace(reference) for reference in references]
@@ -548,7 +550,6 @@ def _import_course_draft(
         course_id=source_course_id,
         course_dir=draft_course_dir,
         error_tracker=errorlog.tracker,
-        parent_tracker=ParentTracker(),
         load_error_modules=False,
         mixins=xml_module_store.xblock_mixins,
         field_data=KvsFieldData(kvs=DictKeyValueStore()),

--- a/common/lib/xmodule/xmodule/tests/test_conditional.py
+++ b/common/lib/xmodule/xmodule/tests/test_conditional.py
@@ -30,7 +30,6 @@ class DummySystem(ImportSystem):
             course_id=SlashSeparatedCourseKey(ORG, COURSE, 'test_run'),
             course_dir='test_dir',
             error_tracker=Mock(),
-            parent_tracker=Mock(),
             load_error_modules=load_error_modules,
         )
 

--- a/common/lib/xmodule/xmodule/tests/test_course_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_course_module.py
@@ -36,14 +36,12 @@ class DummySystem(ImportSystem):
         course_id = SlashSeparatedCourseKey(ORG, COURSE, 'test_run')
         course_dir = "test_dir"
         error_tracker = Mock()
-        parent_tracker = Mock()
 
         super(DummySystem, self).__init__(
             xmlstore=xmlstore,
             course_id=course_id,
             course_dir=course_dir,
             error_tracker=error_tracker,
-            parent_tracker=parent_tracker,
             load_error_modules=load_error_modules,
             field_data=KvsFieldData(DictKeyValueStore()),
         )

--- a/common/lib/xmodule/xmodule/tests/test_import.py
+++ b/common/lib/xmodule/xmodule/tests/test_import.py
@@ -39,14 +39,12 @@ class DummySystem(ImportSystem):
         course_id = SlashSeparatedCourseKey(ORG, COURSE, 'test_run')
         course_dir = "test_dir"
         error_tracker = Mock()
-        parent_tracker = Mock()
 
         super(DummySystem, self).__init__(
             xmlstore=xmlstore,
             course_id=course_id,
             course_dir=course_dir,
             error_tracker=error_tracker,
-            parent_tracker=parent_tracker,
             load_error_modules=load_error_modules,
             mixins=(InheritanceMixin, XModuleMixin),
             field_data=KvsFieldData(DictKeyValueStore()),

--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -918,7 +918,8 @@ class XModuleDescriptor(XModuleMixin, HTMLSnippet, ResourceTemplates, XBlock):
 
     # =============================== BUILTIN METHODS ==========================
     def __eq__(self, other):
-        return (self.scope_ids == other.scope_ids and
+        return (hasattr(other, 'scope_ids') and
+                self.scope_ids == other.scope_ids and
                 self.fields.keys() == other.fields.keys() and
                 all(getattr(self, field.name) == getattr(other, field.name)
                     for field in self.fields.values()))

--- a/lms/djangoapps/courseware/tests/test_lti_integration.py
+++ b/lms/djangoapps/courseware/tests/test_lti_integration.py
@@ -163,7 +163,7 @@ class TestLTIModuleListing(ModuleStoreTestCase):
             parent_location=self.section2.location,
             display_name="lti draft",
             category="lti",
-            location=self.course.id.make_usage_key('lti', 'lti_published'),
+            location=self.course.id.make_usage_key('lti', 'lti_draft'),
             publish_item=False,
         )
 
@@ -199,7 +199,7 @@ class TestLTIModuleListing(ModuleStoreTestCase):
             "lti_1_1_result_service_xml_endpoint": self.expected_handler_url('grade_handler'),
             "lti_2_0_result_service_json_endpoint":
             self.expected_handler_url('lti_2_0_result_rest_handler') + "/user/{anon_user_id}",
-            "display_name": self.lti_draft.display_name
+            "display_name": self.lti_published.display_name,
         }
         self.assertEqual([expected], json.loads(response.content))
 

--- a/lms/djangoapps/courseware/tests/test_submitting_problems.py
+++ b/lms/djangoapps/courseware/tests/test_submitting_problems.py
@@ -1159,11 +1159,11 @@ class TestConditionalContent(TestSubmittingProblems):
         vertical_0, vertical_1 = self.split_setup(user_partition_group)
 
         # Group 0 will have 2 problems in the section, worth a total of 4 points.
-        self.add_dropdown_to_section(vertical_0.location, 'H2P1', 1).location.html_id()
-        self.add_dropdown_to_section(vertical_0.location, 'H2P2', 3).location.html_id()
+        self.add_dropdown_to_section(vertical_0.location, 'H2P1_GROUP0', 1).location.html_id()
+        self.add_dropdown_to_section(vertical_0.location, 'H2P2_GROUP0', 3).location.html_id()
 
         # Group 1 will have 1 problem in the section, worth a total of 1 point.
-        self.add_dropdown_to_section(vertical_1.location, 'H2P1', 1).location.html_id()
+        self.add_dropdown_to_section(vertical_1.location, 'H2P1_GROUP1', 1).location.html_id()
 
         # Submit answers for problem in Section 1, which is visible to all students.
         self.submit_question_answer('H1P1', {'2_1': 'Correct', '2_2': 'Incorrect'})
@@ -1175,8 +1175,8 @@ class TestConditionalContent(TestSubmittingProblems):
         """
         self.split_different_problems_setup(self.user_partition_group_0)
 
-        self.submit_question_answer('H2P1', {'2_1': 'Correct'})
-        self.submit_question_answer('H2P2', {'2_1': 'Correct', '2_2': 'Incorrect', '2_3': 'Correct'})
+        self.submit_question_answer('H2P1_GROUP0', {'2_1': 'Correct'})
+        self.submit_question_answer('H2P2_GROUP0', {'2_1': 'Correct', '2_2': 'Incorrect', '2_3': 'Correct'})
 
         self.assertEqual(self.score_for_hw('homework1'), [1.0])
         self.assertEqual(self.score_for_hw('homework2'), [1.0, 2.0])
@@ -1194,7 +1194,7 @@ class TestConditionalContent(TestSubmittingProblems):
         """
         self.split_different_problems_setup(self.user_partition_group_1)
 
-        self.submit_question_answer('H2P1', {'2_1': 'Correct'})
+        self.submit_question_answer('H2P1_GROUP1', {'2_1': 'Correct'})
 
         self.assertEqual(self.score_for_hw('homework1'), [1.0])
         self.assertEqual(self.score_for_hw('homework2'), [1.0])
@@ -1219,7 +1219,7 @@ class TestConditionalContent(TestSubmittingProblems):
         [_, vertical_1] = self.split_setup(user_partition_group)
 
         # Group 1 will have 1 problem in the section, worth a total of 1 point.
-        self.add_dropdown_to_section(vertical_1.location, 'H2P1', 1).location.html_id()
+        self.add_dropdown_to_section(vertical_1.location, 'H2P1_GROUP1', 1).location.html_id()
 
         self.submit_question_answer('H1P1', {'2_1': 'Correct'})
 
@@ -1244,7 +1244,7 @@ class TestConditionalContent(TestSubmittingProblems):
         """
         self.split_one_group_no_problems_setup(self.user_partition_group_1)
 
-        self.submit_question_answer('H2P1', {'2_1': 'Correct'})
+        self.submit_question_answer('H2P1_GROUP1', {'2_1': 'Correct'})
 
         self.assertEqual(self.score_for_hw('homework1'), [1.0])
         self.assertEqual(self.score_for_hw('homework2'), [1.0])

--- a/lms/djangoapps/instructor/tests/test_tools.py
+++ b/lms/djangoapps/instructor/tests/test_tools.py
@@ -119,7 +119,8 @@ class TestFindUnit(ModuleStoreTestCase):
         Test finding a nested unit.
         """
         url = self.homework.location.to_deprecated_string()
-        self.assertEqual(tools.find_unit(self.course, url), self.homework)
+        found_unit = tools.find_unit(self.course, url)
+        self.assertEqual(found_unit.location, self.homework.location)
 
     def test_find_unit_notfound(self):
         """

--- a/lms/static/js/edxnotes/views/toggle_notes_factory.js
+++ b/lms/static/js/edxnotes/views/toggle_notes_factory.js
@@ -6,37 +6,57 @@ define([
 ], function($, _, Backbone, gettext, Annotator, EdxnotesVisibilityDecorator) {
     var ToggleNotesView = Backbone.View.extend({
         events: {
-            'click .action-toggle-notes': 'toogleHandler'
+            'click .action-toggle-notes': 'toggleHandler'
         },
 
         errorMessage: gettext("An error has occurred. Make sure that you are connected to the Internet, and then try refreshing the page."),
 
         initialize: function (options) {
+            _.bindAll(this, 'onSuccess', 'onError');
             this.visibility = options.visibility;
             this.visibilityUrl = options.visibilityUrl;
             this.label = this.$('.utility-control-label');
             this.actionLink = this.$('.action-toggle-notes');
             this.actionLink.removeClass('is-disabled');
+            this.actionToggleMessage = this.$('.action-toggle-message');
             this.notification = new Annotator.Notification();
         },
 
-        toogleHandler: function (event) {
+        toggleHandler: function (event) {
             event.preventDefault();
             this.visibility = !this.visibility;
-            this.toggleNotes();
+            this.showActionMessage();
+            this.toggleNotes(this.visibility);
+        },
+
+        toggleNotes: function (visibility) {
+            if (visibility) {
+                this.enableNotes();
+            } else {
+                this.disableNotes();
+            }
             this.sendRequest();
         },
 
-        toggleNotes: function () {
-            if (this.visibility) {
-                _.each($('.edx-notes-wrapper'), EdxnotesVisibilityDecorator.enableNote);
-                this.actionLink.addClass('is-active').attr('aria-pressed', true);
-                this.label.text(gettext('Hide notes'));
-            } else {
-                EdxnotesVisibilityDecorator.disableNotes();
-                this.actionLink.removeClass('is-active').attr('aria-pressed', false);
-                this.label.text(gettext('Show notes'));
-            }
+        showActionMessage: function () {
+            // The following lines are necessary to re-trigger the CSS animation on span.action-toggle-message
+            this.actionToggleMessage.removeClass('is-fleeting');
+            this.actionToggleMessage.offset().width = this.actionToggleMessage.offset().width;
+            this.actionToggleMessage.addClass('is-fleeting');
+        },
+
+        enableNotes: function () {
+            _.each($('.edx-notes-wrapper'), EdxnotesVisibilityDecorator.enableNote);
+            this.actionLink.addClass('is-active').attr('aria-pressed', true);
+            this.label.text(gettext('Hide notes'));
+            this.actionToggleMessage.text(gettext('Showing notes'));
+        },
+
+        disableNotes: function () {
+            EdxnotesVisibilityDecorator.disableNotes();
+            this.actionLink.removeClass('is-active').attr('aria-pressed', false);
+            this.label.text(gettext('Show notes'));
+            this.actionToggleMessage.text(gettext('Hiding notes'));
         },
 
         hideErrorMessage: function() {
@@ -53,8 +73,8 @@ define([
                 url: this.visibilityUrl,
                 dataType: 'json',
                 data: JSON.stringify({'visibility': this.visibility}),
-                success: _.bind(this.onSuccess, this),
-                error: _.bind(this.onError, this)
+                success: this.onSuccess,
+                error: this.onError
             });
         },
 

--- a/lms/static/js/fixtures/edxnotes/toggle_notes.html
+++ b/lms/static/js/fixtures/edxnotes/toggle_notes.html
@@ -1,4 +1,5 @@
 <div class="wrapper-utility edx-notes-visibility">
+  <span class="action-toggle-message">Hiding notes</span>
   <button class="utility-control utility-control-button action-toggle-notes is-disabled is-active" aria-pressed="true">
     <i class="icon fa fa-pencil"></i>
      <span class="utility-control-label sr">Hide notes</span>

--- a/lms/static/js/spec/edxnotes/views/toggle_notes_factory_spec.js
+++ b/lms/static/js/spec/edxnotes/views/toggle_notes_factory_spec.js
@@ -32,6 +32,7 @@ define([
             this.toggleNotes = ToggleNotesFactory(true, '/test_url');
             this.button = $('.action-toggle-notes');
             this.label = this.button.find('.utility-control-label');
+            this.toggleMessage = $('.action-toggle-message');
         });
 
         afterEach(function () {
@@ -47,11 +48,15 @@ define([
             expect(this.label).toContainText('Hide notes');
             expect(this.button).toHaveClass('is-active');
             expect(this.button).toHaveAttr('aria-pressed', 'true');
+            expect(this.toggleMessage).not.toHaveClass('is-fleeting');
+            expect(this.toggleMessage).toContainText('Hiding notes');
 
             this.button.click();
             expect(this.label).toContainText('Show notes');
             expect(this.button).not.toHaveClass('is-active');
             expect(this.button).toHaveAttr('aria-pressed', 'false');
+            expect(this.toggleMessage).toHaveClass('is-fleeting');
+            expect(this.toggleMessage).toContainText('Hiding notes');
             expect(Annotator._instances).toHaveLength(0);
 
             AjaxHelpers.expectJsonRequest(requests, 'PUT', '/test_url', {
@@ -63,6 +68,8 @@ define([
             expect(this.label).toContainText('Hide notes');
             expect(this.button).toHaveClass('is-active');
             expect(this.button).toHaveAttr('aria-pressed', 'true');
+            expect(this.toggleMessage).toHaveClass('is-fleeting');
+            expect(this.toggleMessage).toContainText('Showing notes');
             expect(Annotator._instances).toHaveLength(2);
 
             AjaxHelpers.expectJsonRequest(requests, 'PUT', '/test_url', {

--- a/lms/static/sass/base/_animations.scss
+++ b/lms/static/sass/base/_animations.scss
@@ -261,3 +261,21 @@
 @-webkit-keyframes fade-in-animation{ @include fade-in-keyframes; }
    @-moz-keyframes fade-in-animation{ @include fade-in-keyframes; }
         @keyframes fade-in-animation{ @include fade-in-keyframes; }
+
+
+// +utility animations
+// --------------------
+// pulse - double + fade out
+@include keyframes(pulse-out) {
+  0%, 100% {
+    opacity: 0;
+  }
+
+  25%, 75% {
+    opacity: 1.0;
+  }
+
+  100% {
+    opacity: 0;
+  }
+}

--- a/lms/static/sass/course/modules/_calculator.scss
+++ b/lms/static/sass/course/modules/_calculator.scss
@@ -15,20 +15,19 @@ div.calc-main {
 
   .calc {
     @include transition(background-color $tmg-f2 ease-in-out 0s);
-    background: url("../images/calc-icon.png") $black-t3 no-repeat center;
+    background: url("../images/calc-icon.png") $black-t1 no-repeat center;
     border-bottom: 0;
-    border-radius: ($baseline/10);
     color: $white;
     float: right;
     height: $baseline;
-    margin-right: ($baseline/2);
+    margin-right: ($baseline*0.75);
     padding: $baseline;
     position: relative;
     top: -42px;
     width: ($baseline*0.75);
 
     &:hover, &:focus {
-      background-color: $black;
+      background-color: $gray-d1;
     }
 
     &.closed {

--- a/lms/static/sass/elements/_navigation.scss
+++ b/lms/static/sass/elements/_navigation.scss
@@ -6,6 +6,7 @@
 // +notes
 // +skip navigation
 // +utility navigation
+// +case - calculator spacing
 
 // +notes:
 // --------------------
@@ -27,7 +28,7 @@
 .nav-utilities {
   @extend %ui-depth3;
   position: fixed;
-  @include right($baseline*2.25);
+  right: 0;
   bottom: 0;
 
   .wrapper-utility {
@@ -72,5 +73,11 @@
       border: none;
       box-shadow: none;
     }
+  }
+
+  // +case - calculator spacing (needed for overriding calculator positioning)
+  // --------------------
+  &.has-utility-calculator {
+    @include right($baseline*2.25);
   }
 }

--- a/lms/static/sass/elements/_navigation.scss
+++ b/lms/static/sass/elements/_navigation.scss
@@ -6,6 +6,7 @@
 // +notes
 // +skip navigation
 // +utility navigation
+// +toggling utilities
 // +case - calculator spacing
 
 // +notes:
@@ -28,35 +29,34 @@
 .nav-utilities {
   @extend %ui-depth3;
   position: fixed;
-  right: 0;
+  right: ($baseline/4);
   bottom: 0;
 
   .wrapper-utility {
     @extend %wipe-last-child;
     display: inline-block;
     vertical-align: bottom;
-    @include margin-right($baseline/2);
+    @include margin-right(6px);
   }
 
   .utility-control {
-    @include transition(background-color $tmg-f2 ease-in-out 0s);
+    @include transition(background-color $tmg-f2 ease-in-out 0s, color $tmg-f2 ease-in-out 0s);
     position: relative;
-    bottom: -6px; // needed to sync up with current rogue/more complex calc utility alignment
+    bottom: -($baseline/5);
     display: inline-block;
     vertical-align: middle;
-    border-radius: ($baseline/10);
     padding: ($baseline/2) ($baseline*0.75) ($baseline*0.75) ($baseline*0.75);
-    background: $black-t3;
+    background: $black-t1;
     color: $white;
 
     // STATE: hover/active
     &:hover, &:active {
-      background: $black;
+      background: $gray-d1;
     }
 
     // STATE: is active/in use
     &.is-active {
-      background: $active-color;
+      background: $gray-d1;
     }
   }
 
@@ -67,6 +67,8 @@
     text-shadow: none;
     font-size: inherit;
     font-weight: inherit;
+    line-height: 0;
+    border-radius: 0;
 
     // STATE: hover/active
     &:hover, &:active, &:focus {
@@ -75,9 +77,41 @@
     }
   }
 
+  // specific utility navigation - student notes toggling
+  .action-toggle-notes {
+    @extend %no-outline;
+
+    // STATE: is active/in use
+    &.is-active {
+      color: $student-notes-highlight-color-base;
+    }
+  }
+
+  // +toggling utilities
+  // --------------------
+  .action-toggle-message {
+    @extend %t-title8;
+    @extend %t-strong;
+    position: absolute;
+    bottom: 0;
+    @include right($baseline*2.5);
+    display: inline-block;
+    min-width: ($baseline*5);
+    padding: ($baseline/2) ($baseline*0.75);
+    opacity: 0;
+    background-color: $gray-d1;
+    color: $white;
+    text-align: center;
+
+    // STATE: is fleeting/temporary
+    &.is-fleeting {
+      @include animation(pulse-out $tmg-s2 ease-in-out);
+    }
+  }
+
   // +case - calculator spacing (needed for overriding calculator positioning)
   // --------------------
   &.has-utility-calculator {
-    @include right($baseline*2.25);
+    @include right($baseline*2.50);
   }
 }

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -215,7 +215,7 @@ ${fragment.foot_html()}
   </div>
 </div>
 
-<nav class="nav-utilities">
+<nav class="nav-utilities ${"has-utility-calculator" if course.show_calculator else ""}">
   <h2 class="sr nav-utilities-title">${_('Course Utilities Navigation')}</h2>
 
   ## Utility: Chat

--- a/lms/templates/edxnotes/toggle_notes.html
+++ b/lms/templates/edxnotes/toggle_notes.html
@@ -11,9 +11,9 @@
   <button class="utility-control utility-control-button action-toggle-notes is-disabled ${"is-active" if edxnotes_visibility else ""}" aria-pressed="${"true" if edxnotes_visibility else "false"}">
     <i class="icon fa fa-pencil"></i>
     % if edxnotes_visibility:
-     <span class="utility-control-label sr">${_("Hide notes")}</span>
+      <span class="utility-control-label sr">${_("Hide notes")}</span>
     % else:
-     <span class="utility-control-label sr">${_("Show notes")}</span>
+      <span class="utility-control-label sr">${_("Show notes")}</span>
     % endif
   </button>
 </div>

--- a/lms/templates/edxnotes/toggle_notes.html
+++ b/lms/templates/edxnotes/toggle_notes.html
@@ -8,12 +8,13 @@
   edxnotes_visibility_url = reverse("edxnotes_visibility", kwargs={"course_id": course.id})
 %>
 <div class="wrapper-utility edx-notes-visibility">
+  <span class="action-toggle-message" aria-live="polite"></span>
   <button class="utility-control utility-control-button action-toggle-notes is-disabled ${"is-active" if edxnotes_visibility else ""}" aria-pressed="${"true" if edxnotes_visibility else "false"}">
     <i class="icon fa fa-pencil"></i>
     % if edxnotes_visibility:
-      <span class="utility-control-label sr">${_("Hide notes")}</span>
+    <span class="utility-control-label sr">${_("Hide notes")}</span>
     % else:
-      <span class="utility-control-label sr">${_("Show notes")}</span>
+    <span class="utility-control-label sr">${_("Show notes")}</span>
     % endif
   </button>
 </div>


### PR DESCRIPTION
This work addresses the following:
- visually moves the toggle notes to far right and accounts for the toggle calculator UI in a more logical way.
- de-emphasizes the toggle notes control in general and visually revamps the `is-active` state of the toggle
- adds in status text to communicate system activity with each toggle on/off
  ---

**Screengrab - Notes Off State**
![screen shot 2015-01-13 at 6 29 11 pm](https://cloud.githubusercontent.com/assets/163763/5731509/29c7f432-9b52-11e4-9a4b-4115db0b8f4c.png)

**Screengrab - Notes On State**
![screen shot 2015-01-13 at 6 29 24 pm](https://cloud.githubusercontent.com/assets/163763/5731513/36f92586-9b52-11e4-995b-7d15a303066b.png)

**Screengrab - Notes On w/ Fleeting Showing Message**
![screen shot 2015-01-13 at 6 29 16 pm](https://cloud.githubusercontent.com/assets/163763/5731510/2f80c4ee-9b52-11e4-842c-14f0d93bba31.png)
