### PR TITLE
FIX - Studio: resolving xblock warning messages icons

### DIFF
--- a/cms/static/sass/elements/_xblocks.scss
+++ b/cms/static/sass/elements/_xblocks.scss
@@ -220,7 +220,7 @@
         &.has-warnings {
           border-top: 3px solid $orange;
 
-          .fa-warning {
+          .fa-exclamation-triangle {
             margin-right: ($baseline/2);
             color: $orange;
           }


### PR DESCRIPTION
This work resolves an icon styling issue with xblock warning messages
