### PR TITLE
properly handle ItemNotFoundError exception for finding asset with inval...

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -840,8 +840,15 @@ class MiscCourseTests(ContentStoreTestCase):
             self.store.unpublish(self.chapter_loc, self.user.id)
 
     def test_bad_contentstore_request(self):
-        resp = self.client.get_html('http://localhost:8001/c4x/CDX/123123/asset/&images_circuits_Lab7Solution2.png')
+        """
+        Test that user get proper responses for urls with invalid url or
+        asset/course key
+        """
+        resp = self.client.get_html('/c4x/CDX/123123/asset/&invalid.png')
         self.assertEqual(resp.status_code, 400)
+
+        resp = self.client.get_html('/c4x/CDX/123123/asset/invalid.png')
+        self.assertEqual(resp.status_code, 404)
 
     def test_delete_course(self):
         """

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_assetstore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_assetstore.py
@@ -230,10 +230,8 @@ class TestMongoAssetMetadataStorage(unittest.TestCase):
                 ))
                 new_asset_loc = fake_course_id.make_asset_key('asset', 'burnside.jpg')
                 # Find asset metadata from non-existent course.
-                with self.assertRaises(ItemNotFoundError):
-                    store.find_asset_metadata(new_asset_loc)
-                with self.assertRaises(ItemNotFoundError):
-                    store.get_all_asset_metadata(fake_course_id, 'asset')
+                self.assertIsNone(store.find_asset_metadata(new_asset_loc))
+                self.assertIsNone(store.get_all_asset_metadata(fake_course_id, 'asset'))
 
     @ddt.data(*MODULESTORE_SETUPS)
     def test_add_same_asset_twice(self, storebuilder):

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_mongo.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_mongo.py
@@ -705,8 +705,8 @@ class TestMongoModuleStoreWithNoAssetCollection(TestMongoModuleStore):
 
     def test_no_asset_invalid_key(self):
         course_key = CourseLocator(org="edx3", course="test_course", run=None, deprecated=True)
-        # Confirm that invalid course key raises ItemNotFoundError
-        self.assertRaises(ItemNotFoundError, lambda: self.draft_store.get_all_asset_metadata(course_key, 'asset')[:1])
+        # Confirm that invalid course key returns None
+        self.assertIsNone(self.draft_store.get_all_asset_metadata(course_key, 'asset'))
 
 
 class TestMongoKeyValueStore(object):


### PR DESCRIPTION
...id course key

TNL-1159
If a user sends asset request with invalid course key (org, course number) then instead of getting 404 that user gets a server error response (500).
The method '_find_course_assets' raises 'ItemNotFoundError' which was not handled by other methods calling it.
@adampalay @waheedahmed @doctoryes 
