### PR TITLE
Fixed pluralization of matching problems in Library Content Module.

### DIFF
--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -471,7 +471,7 @@ class LibraryContentDescriptor(LibraryContentFields, MakoModuleDescriptor, XmlDe
                             self.max_count
                         ) +
                         ngettext(
-                            u'but there are only {actual} matching problem.',
+                            u'but there is only {actual} matching problem.',
                             u'but there are only {actual} matching problems.',
                             matching_children_count
                         )


### PR DESCRIPTION
**Background**: Teach the content library module subject-verb agreement. :)
**Jira ticket number(s)**: https://openedx.atlassian.net/browse/SOL-224
**Previous discussions**: https://openedx.atlassian.net/wiki/display/SOL/Content+Libraries+-+Testing+Results?focusedCommentId=18351578#comment-18351578
**Dependencies**: None, can be applied right atop master.
**Sandbox**: None provided, but can be if needed.
**Internal Code Review PRs**: Thumbs-up given directly on the commit, since there was a bit of confusion on how to do review PRs when we were working on this. https://github.com/open-craft/edx-platform/commit/f7fd2aa56f1bc0787e2e01eaa13bd9c8a5d9339c#commitcomment-9273633
**Partner information**: 3rd party-hosted open edX instance, for an edX solutions client.
