### PR TITLE
Add link to sysadmin dashboard on core theme

### DIFF
--- a/lms/templates/navigation.html
+++ b/lms/templates/navigation.html
@@ -58,6 +58,11 @@ site_status_msg = get_site_status_msg(course_id)
             <a href="${marketing_link('COURSES')}">${_('Find Courses')}</a>
           </li>
         % endif
+        %if settings.FEATURES.get('ENABLE_SYSADMIN_DASHBOARD','') and user.is_staff:
+          <li>
+            <a href="${reverse('sysadmin')}">Sysadmin</a>
+          </li>
+        %endif
       </%block>
     </ol>
     <ol class="user">


### PR DESCRIPTION
If the feature flag is set, it'll now show up in the core theme:
![Navigation links](http://i.imgur.com/3Tsieol.png)
