### PR TITLE
Fix shib code to handle course.enrollment_domain=None

### DIFF
--- a/common/djangoapps/external_auth/tests/test_shib.py
+++ b/common/djangoapps/external_auth/tests/test_shib.py
@@ -376,7 +376,7 @@ class ShibSPTest(ModuleStoreTestCase):
             self.assertEqual(profile.name, identity.get('displayName').decode('utf-8'))
 
     @unittest.skipUnless(settings.FEATURES.get('AUTH_USE_SHIB'), "AUTH_USE_SHIB not set")
-    @data("", "shib:https://idp.stanford.edu/")
+    @data(None, "", "shib:https://idp.stanford.edu/")
     def test_course_specific_login_and_reg(self, domain):
         """
         Tests that the correct course specific login and registration urls work for shib
@@ -407,7 +407,7 @@ class ShibSPTest(ModuleStoreTestCase):
         login_response = course_specific_login(login_request, 'MITx/999/Robot_Super_Course')
         reg_response = course_specific_register(login_request, 'MITx/999/Robot_Super_Course')
 
-        if "shib" in domain:
+        if domain and "shib" in domain:
             self.assertIsInstance(login_response, HttpResponseRedirect)
             self.assertEqual(login_response['Location'],
                              reverse('shib-login') +

--- a/common/djangoapps/external_auth/views.py
+++ b/common/djangoapps/external_auth/views.py
@@ -597,7 +597,11 @@ def course_specific_login(request, course_id):
         return redirect_with_get('signin_user', request.GET)
 
     # now the dispatching conditionals.  Only shib for now
-    if settings.FEATURES.get('AUTH_USE_SHIB') and course.enrollment_domain.startswith(SHIBBOLETH_DOMAIN_PREFIX):
+    if (
+        settings.FEATURES.get('AUTH_USE_SHIB') and
+        course.enrollment_domain and
+        course.enrollment_domain.startswith(SHIBBOLETH_DOMAIN_PREFIX)
+    ):
         return redirect_with_get('shib-login', request.GET)
 
     # Default fallthrough to normal signin page
@@ -617,7 +621,11 @@ def course_specific_register(request, course_id):
         return redirect_with_get('register_user', request.GET)
 
     # now the dispatching conditionals.  Only shib for now
-    if settings.FEATURES.get('AUTH_USE_SHIB') and course.enrollment_domain.startswith(SHIBBOLETH_DOMAIN_PREFIX):
+    if (
+        settings.FEATURES.get('AUTH_USE_SHIB') and
+        course.enrollment_domain and
+        course.enrollment_domain.startswith(SHIBBOLETH_DOMAIN_PREFIX)
+    ):
         # shib-login takes care of both registration and login flows
         return redirect_with_get('shib-login', request.GET)
 


### PR DESCRIPTION
small bugfix
`course.enrollment_domain` defaults to None, so this little bit of code is necessary to handle that case.
@carsongee (You were the person aside from me who looked at shib last I think)
