### PR TITLE
Improve JS course key validation to not allow special chars.

### DIFF
--- a/cms/static/js/spec/views/utils/view_utils_spec.js
+++ b/cms/static/js/spec/views/utils/view_utils_spec.js
@@ -40,5 +40,53 @@ define(["jquery", "underscore", "js/views/baseview", "js/views/utils/view_utils"
                     ViewHelpers.verifyNotificationShowing(notificationSpy, /Testing/);
                 });
             });
+
+            describe("course/library fields validation", function() {
+                describe("without unicode support", function() {
+                    it("validates presence of field", function() {
+                        var error = ViewUtils.validateURLItemEncoding('', false);
+                        expect(error).toBeTruthy();
+                    });
+
+                    it("checks for presence of special characters in the field", function() {
+                        var error;
+                        // Special characters are not allowed.
+                        error = ViewUtils.validateURLItemEncoding('my+field', false);
+                        expect(error).toBeTruthy();
+                        error = ViewUtils.validateURLItemEncoding('2014!', false);
+                        expect(error).toBeTruthy();
+                        error = ViewUtils.validateURLItemEncoding('*field*', false);
+                        expect(error).toBeTruthy();
+                        // Spaces not allowed.
+                        error = ViewUtils.validateURLItemEncoding('Jan 2014', false);
+                        expect(error).toBeTruthy();
+                        // -_~. are allowed.
+                        error = ViewUtils.validateURLItemEncoding('2015-Math_X1.0~', false);
+                        expect(error).toBeFalsy();
+                    });
+
+                    it("does not allow unicode characters", function() {
+                        var error = ViewUtils.validateURLItemEncoding('Field-\u010d', false);
+                        expect(error).toBeTruthy();
+                    });
+                });
+
+                describe("with unicode support", function() {
+                    it("validates presence of field", function() {
+                        var error = ViewUtils.validateURLItemEncoding('', true);
+                        expect(error).toBeTruthy();
+                    });
+
+                    it("checks for presence of spaces", function() {
+                        var error = ViewUtils.validateURLItemEncoding('My Field', true);
+                        expect(error).toBeTruthy();
+                    });
+
+                    it("allows unicode characters", function() {
+                        var error = ViewUtils.validateURLItemEncoding('Field-\u010d', true);
+                        expect(error).toBeFalsy();
+                    });
+                });
+            });
         });
     });

--- a/cms/static/js/views/utils/view_utils.js
+++ b/cms/static/js/views/utils/view_utils.js
@@ -199,7 +199,7 @@ define(["jquery", "underscore", "gettext", "js/views/feedback_notification", "js
                 }
             }
             else {
-                if (item !== encodeURIComponent(item)) {
+                if (item !== encodeURIComponent(item) || item.match(/[!'()*]/)) {
                     return gettext('Please do not use any spaces or special characters in this field.');
                 }
             }


### PR DESCRIPTION
**Background**: Existing JS validation on new course and library forms prevents the user from submitting course/library keys that contain special characters, but it fails to detect these special characters: `!'()*`.
**Discussions**: The issue was discovered by @catong while reviewing https://github.com/open-craft/edx-platform/pull/23#discussion-diff-22058927
**Affected Components**: Studio
**Jira Ticket**: https://openedx.atlassian.net/browse/SOL-233
**Test Instructions**: Go to the Studio home page and click the 'New Course' button to display the new course form. Put a string containing one of the special `!'()*` characters in any of 'Organization', 'Course Number', or 'Course Run' fields. Without this patch, the JS validation will fail to detect the special characters and will let you submit the form. Course creation will fail on the server because special characters are not allowed in these fields. With this patch enabled, JS validation will detect the special characters and will not let you submit the form (see screenshot).
**Internal Code Review PR**: https://github.com/open-craft/edx-platform/pull/28
**Partner Information**: 3rd party-hosted open edX instance, for an edX solutions client.

![screen shot 2015-01-09 at 08 50 28](https://cloud.githubusercontent.com/assets/32585/5676824/efbdb7cc-97dc-11e4-90b0-93d26192eb3b.png)
