### PR TITLE
Fixed unicode error in CSV grade report generation.

### DIFF
--- a/lms/djangoapps/instructor_task/tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tasks_helper.py
@@ -572,8 +572,7 @@ def upload_grades_csv(_xmodule_instance_args, _entry_id, course_id, _task_input,
             # We were able to successfully grade this student for this course.
             task_progress.succeeded += 1
             if not header:
-                # Encode the header row in utf-8 encoding in case there are unicode characters
-                header = [section['label'].encode('utf-8') for section in gradeset[u'section_breakdown']]
+                header = [section['label'] for section in gradeset[u'section_breakdown']]
                 rows.append(
                     ["id", "email", "username", "grade"] + header + cohorts_header + group_configs_header
                 )


### PR DESCRIPTION
[TNL-1196](https://openedx.atlassian.net/browse/TNL-1196)

Related to https://github.com/edx/edx-platform/pull/5524, forgot to remove ".encode('utf-8')"
