### PR TITLE
Discussion forum doesn't work when mathjax is down

### DIFF
--- a/common/static/coffee/src/discussion/views/discussion_thread_profile_view.coffee
+++ b/common/static/coffee/src/discussion/views/discussion_thread_profile_view.coffee
@@ -10,7 +10,8 @@ if Backbone?
       @$el.html(Mustache.render(@template, params))
       @$("span.timeago").timeago()
       element = @$(".post-body")
-      MathJax.Hub.Queue ["Typeset", MathJax.Hub, element[0]]
+      if MathJax?
+        MathJax.Hub.Queue ["Typeset", MathJax.Hub, element[0]]
       @
 
     convertMath: ->

--- a/common/static/coffee/src/discussion/views/discussion_thread_show_view.coffee
+++ b/common/static/coffee/src/discussion/views/discussion_thread_show_view.coffee
@@ -32,7 +32,8 @@ if Backbone?
     convertMath: ->
       element = @$(".post-body")
       element.html DiscussionUtil.postMathJaxProcessor DiscussionUtil.markdownWithHighlight element.text()
-      MathJax.Hub.Queue ["Typeset", MathJax.Hub, element[0]]
+      if MathJax?
+        MathJax.Hub.Queue ["Typeset", MathJax.Hub, element[0]]
 
     edit: (event) ->
       @trigger "thread:edit", event

--- a/common/static/coffee/src/discussion/views/response_comment_show_view.coffee
+++ b/common/static/coffee/src/discussion/views/response_comment_show_view.coffee
@@ -33,7 +33,8 @@ if Backbone?
     convertMath: ->
       body = @$el.find(".response-body")
       body.html DiscussionUtil.postMathJaxProcessor DiscussionUtil.markdownWithHighlight body.text()
-      MathJax.Hub.Queue ["Typeset", MathJax.Hub, body[0]]
+      if MathJax?
+        MathJax.Hub.Queue ["Typeset", MathJax.Hub, body[0]]
 
     _delete: (event) =>
         @trigger "comment:_delete", event

--- a/common/static/coffee/src/discussion/views/thread_response_show_view.coffee
+++ b/common/static/coffee/src/discussion/views/thread_response_show_view.coffee
@@ -27,7 +27,8 @@ if Backbone?
     convertMath: ->
       element = @$(".response-body")
       element.html DiscussionUtil.postMathJaxProcessor DiscussionUtil.markdownWithHighlight element.text()
-      MathJax.Hub.Queue ["Typeset", MathJax.Hub, element[0]]
+      if MathJax?
+        MathJax.Hub.Queue ["Typeset", MathJax.Hub, element[0]]
 
     edit: (event) ->
         @trigger "response:edit", event

--- a/common/templates/discussion_mathjax_include.html
+++ b/common/templates/discussion_mathjax_include.html
@@ -1,0 +1,45 @@
+## mako
+## File:   templates/mathjax_include.html
+##
+## Advanced mathjax using 2.0-latest CDN for Dynamic Math
+##
+## This enables ASCIIMathJAX, and is used by js_textbox
+
+
+<%def name="mathjaxConfig()">
+  %if mathjax_mode is not Undefined and mathjax_mode == 'wiki':
+    MathJax.Hub.Config({
+      tex2jax: {inlineMath: [ ['$','$'], ["\\(","\\)"]],
+                displayMath: [ ['$$','$$'], ["\\[","\\]"]]}
+    });
+  %else:
+    MathJax.Hub.Config({
+      tex2jax: {
+        inlineMath: [
+          ["\\(","\\)"],
+          ['[mathjaxinline]','[/mathjaxinline]']
+        ],
+        displayMath: [
+          ["\\[","\\]"],
+          ['[mathjax]','[/mathjax]']
+        ]
+      }
+    });
+  %endif
+  MathJax.Hub.Configured();
+</%def>
+
+<!-- This must appear after all mathjax-config blocks, so it is after the imports from the other templates.
+     It can't be run through static.url because MathJax uses crazy url introspection to do lazy loading of
+     MathJax extension libraries -->
+<script type="text/javascript">
+  var require = RequireJS.require;
+  var define = RequireJS.define;
+  require(['domReady'], function (domReady) {
+    domReady(function () {
+        require(['mathjax'], function(){
+          ${mathjaxConfig()}
+        });;
+    });
+  });
+</script>

--- a/lms/static/coffee/src/customwmd.coffee
+++ b/lms/static/coffee/src/customwmd.coffee
@@ -2,10 +2,8 @@
 
 $ ->
 
-  if not MathJax?
-    return
-
-  HUB = MathJax.Hub
+  if MathJax?
+    HUB = MathJax.Hub
 
   class MathJaxProcessor
 
@@ -116,10 +114,11 @@ $ ->
     Markdown.getMathCompatibleConverter = (postProcessor) ->
       postProcessor ||= ((text) -> text)
       converter = Markdown.getSanitizingConverter()
-      processor = new MathJaxProcessor()
-      converter.hooks.chain "preConversion", MathJaxProcessor.removeMathWrapper(processor)
-      converter.hooks.chain "postConversion", (text) ->
-        postProcessor(MathJaxProcessor.replaceMathWrapper(processor)(text))
+      if MathJax?
+        processor = new MathJaxProcessor()
+        converter.hooks.chain "preConversion", MathJaxProcessor.removeMathWrapper(processor)
+        converter.hooks.chain "postConversion", (text) ->
+          postProcessor(MathJaxProcessor.replaceMathWrapper(processor)(text))
       converter
 
     Markdown.makeWmdEditor = (elem, appended_id, imageUploadUrl, postProcessor) ->

--- a/lms/static/coffee/src/mathjax_delay_renderer.coffee
+++ b/lms/static/coffee/src/mathjax_delay_renderer.coffee
@@ -57,7 +57,7 @@ class @MathJaxDelayRenderer
         @$buffer.html(text)
         curTime = getTime()
         @elapsedTime = curTime - prevTime
-        if MathJax
+        if MathJax?
           prevTime = getTime()
           @mathjaxRunning = true
           MathJax.Hub.Queue ["Typeset", MathJax.Hub, @$buffer.attr("id")], =>

--- a/lms/static/require-config-lms.js
+++ b/lms/static/require-config-lms.js
@@ -44,6 +44,7 @@
         // NOTE: baseUrl has been previously set in lms/static/templates/main.html
         waitSeconds: 60,
         paths: {
+            "domReady": "js/vendor/domReady",
             "annotator_1.2.9": "js/vendor/edxnotes/annotator-full.min",
             "date": "js/vendor/date",
             "backbone": "js/vendor/backbone-min",
@@ -67,6 +68,7 @@
             "ova": 'js/vendor/ova/ova',
             "catch": 'js/vendor/ova/catch/js/catch',
             "handlebars": 'js/vendor/ova/catch/js/handlebars-1.1.2',
+            "mathjax": "//cdn.mathjax.org/mathjax/2.2-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&delayStartupUntil=configured",
             // end of files needed by OVA
         },
         shim: {

--- a/lms/templates/discussion/_js_body_dependencies.html
+++ b/lms/templates/discussion/_js_body_dependencies.html
@@ -1,4 +1,4 @@
 <%! from django_comment_client.helpers import include_mustache_templates %>
 
-<%include file="/mathjax_include.html" />
+<%include file="/discussion_mathjax_include.html" />
 ${include_mustache_templates()}


### PR DESCRIPTION
When mathjax is down forum discussion threads won't render
because of the dependency of the mathjax with markdown. This
was fixed by making mathjax optional instead of having it a
hard dependency in the forum

TNL-1149
