### PR TITLE
Fix errors with libraries when old mongo is default (first) modulestore (SOL-234)

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/fix_not_found.py
+++ b/cms/djangoapps/contentstore/management/commands/fix_not_found.py
@@ -21,7 +21,7 @@ class Command(BaseCommand):
         course_key = CourseKey.from_string(args[0])
         # for now only support on split mongo
         # pylint: disable=protected-access
-        owning_store = modulestore()._get_modulestore_for_courseid(course_key)
+        owning_store = modulestore()._get_modulestore_for_courselike(course_key)
         if hasattr(owning_store, 'fix_not_found'):
             owning_store.fix_not_found(course_key, ModuleStoreEnum.UserID.mgmt_command)
         else:

--- a/cms/djangoapps/contentstore/management/commands/tests/test_create_course.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_create_course.py
@@ -65,4 +65,4 @@ class TestCreateCourse(ModuleStoreTestCase):
             "Could not find course in {}".format(store)
         )
         # pylint: disable=protected-access
-        self.assertEqual(store, modulestore()._get_modulestore_for_courseid(new_key).get_modulestore_type())
+        self.assertEqual(store, modulestore()._get_modulestore_for_courselike(new_key).get_modulestore_type())

--- a/cms/djangoapps/contentstore/management/commands/tests/test_migrate_to_split.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_migrate_to_split.py
@@ -81,7 +81,7 @@ class TestMigrateToSplit(ModuleStoreTestCase):
         # default mapping in mixed modulestore. I left the test here so we can debate what it ought to do.
 #         self.assertEqual(
 #             ModuleStoreEnum.Type.split,
-#             modulestore()._get_modulestore_for_courseid(new_key).get_modulestore_type(),
+#             modulestore()._get_modulestore_for_courselike(new_key).get_modulestore_type(),
 #             "Split is not the new default for the course"
 #         )
 

--- a/cms/djangoapps/contentstore/tests/utils.py
+++ b/cms/djangoapps/contentstore/tests/utils.py
@@ -316,7 +316,7 @@ class CourseTestCase(ModuleStoreTestCase):
             course2_item_loc = course2_id.make_usage_key(course1_item_loc.block_type, course1_item_loc.block_id)
             if course1_item_loc.block_type == 'course':
                 # mongo uses the run as the name, split uses 'course'
-                store = self.store._get_modulestore_for_courseid(course2_id)  # pylint: disable=protected-access
+                store = self.store._get_modulestore_for_courselike(course2_id)  # pylint: disable=protected-access
                 new_name = 'course' if isinstance(store, SplitMongoModuleStore) else course2_item_loc.run
                 course2_item_loc = course2_item_loc.replace(name=new_name)
             course2_item = self.store.get_item(course2_item_loc)

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
@@ -944,6 +944,21 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
         course_index = self.get_course_index(course_id, ignore_case)
         return CourseLocator(course_index['org'], course_index['course'], course_index['run'], course_id.branch) if course_index else None
 
+    def has_library(self, library_id, ignore_case=False, **kwargs):
+        '''
+        Does this library exist in this modulestore. This method does not verify that the branch &/or
+        version in the library_id exists.
+
+        Returns the library_id of the course if it was found, else None.
+        '''
+        if not isinstance(library_id, LibraryLocator):
+            return None
+
+        index = self.get_course_index(library_id, ignore_case)
+        if index:
+            return LibraryLocator(index['org'], index['course'], library_id.branch)
+        return None
+
     def has_item(self, usage_key):
         """
         Returns True if usage_key exists in its course. Returns false if

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -413,7 +413,7 @@ class TestTOC(ModuleStoreTestCase):
         factory = RequestFactory()
         self.request = factory.get(chapter_url)
         self.request.user = UserFactory()
-        self.modulestore = self.store._get_modulestore_for_courseid(self.course_key)
+        self.modulestore = self.store._get_modulestore_for_courselike(self.course_key)  # pylint: disable=protected-access, attribute-defined-outside-init
         with self.modulestore.bulk_operations(self.course_key):
             with check_mongo_calls(num_finds, num_sends):
                 self.toy_course = self.store.get_course(self.toy_loc, depth=2)


### PR DESCRIPTION
**Background**: This commit fixes a major error that went unnoticed during the content libraries MVP: If an edX instance is configured such that old mongo is the default modulestore in MixedModulestore's options (regardless of the value of `DEFAULT_STORE_FOR_NEW_COURSE`), then content libraries cannot be edited in Studio.

**Explanation**: Libraries are always created in split, but once a library has been created, the system would only ever look for libraries in the default modulestore. Thus it wouldn't be able to actually read the contents of the newly created library. This fixes the problem by searching all modulestores for the requested library in the same manner we do for courses.

**JIRA Ticket**: [SOL-234](https://openedx.atlassian.net/browse/SOL-234)

**Discussions**: Error was pointed out by @andy-armstrong and @antoviaque. Fix has not yet been discussed.

**Dependencies**: None

**Sandbox URL**: TBD

**Partner information**: 3rd party-hosted open edX instance, for an edX solutions client.
