### PR TITLE
ECOM-894: Allow inactive users to request a password reset

### DIFF
--- a/common/test/acceptance/tests/lms/test_lms.py
+++ b/common/test/acceptance/tests/lms/test_lms.py
@@ -136,7 +136,7 @@ class LoginFromCombinedPageTest(UniqueCourseTest):
 
         # Expect that we're shown a failure message
         self.assertIn(
-            "No active user with the provided email address exists.",
+            "No user with the provided email address exists.",
             self.login_page.wait_for_errors()
         )
 

--- a/lms/djangoapps/student_account/test/test_views.py
+++ b/lms/djangoapps/student_account/test/test_views.py
@@ -289,7 +289,11 @@ class StudentAccountUpdateTest(UrlResetMixin, TestCase):
 
         # Send the view the email address tied to the inactive user
         response = self._change_password(email=self.NEW_EMAIL)
-        self.assertEqual(response.status_code, 400)
+
+        # Expect that the activation email is still sent,
+        # since the user may have lost the original activation email.
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(mail.outbox), 1)
 
     def test_password_change_no_user(self):
         # Log out the user created during test setup

--- a/lms/djangoapps/student_account/views.py
+++ b/lms/djangoapps/student_account/views.py
@@ -9,6 +9,7 @@ from django.http import (
 from django.shortcuts import redirect
 from django.core.urlresolvers import reverse
 from django.core.mail import send_mail
+from django.utils.translation import ugettext as _
 from django_future.csrf import ensure_csrf_cookie
 from django.contrib.auth.decorators import login_required
 from django.views.decorators.http import require_http_methods
@@ -261,11 +262,11 @@ def password_change_request_handler(request):
             # Increment the rate limit counter
             limiter.tick_bad_request_counter(request)
 
-            return HttpResponseBadRequest("No active user with the provided email address exists.")
+            return HttpResponseBadRequest(_("No user with the provided email address exists."))
 
         return HttpResponse(status=200)
     else:
-        return HttpResponseBadRequest("No email address provided.")
+        return HttpResponseBadRequest(_("No email address provided."))
 
 
 def _third_party_auth_context(request):

--- a/openedx/core/djangoapps/user_api/api/account.py
+++ b/openedx/core/djangoapps/user_api/api/account.py
@@ -9,8 +9,8 @@ information and preferences).
 from django.conf import settings
 from django.db import transaction, IntegrityError
 from django.core.validators import validate_email, validate_slug, ValidationError
-from django.contrib.auth.forms import PasswordResetForm
 
+from ..forms import PasswordResetFormNoActive
 from ..models import User, UserProfile, Registration, PendingEmailChange
 from ..helpers import intercept_errors
 
@@ -353,9 +353,9 @@ def request_password_change(email, orig_host, is_secure):
     """
     # Binding data to a form requires that the data be passed as a dictionary
     # to the Form class constructor.
-    form = PasswordResetForm({'email': email})
+    form = PasswordResetFormNoActive({'email': email})
 
-    # Validate that an active user exists with the given email address.
+    # Validate that a user exists with the given email address.
     if form.is_valid():
         # Generate a single-use link for performing a password reset
         # and email it to the user.
@@ -365,7 +365,7 @@ def request_password_change(email, orig_host, is_secure):
             use_https=is_secure
         )
     else:
-        # No active user with the provided email address exists.
+        # No user with the provided email address exists.
         raise AccountUserNotFound
 
 

--- a/openedx/core/djangoapps/user_api/forms.py
+++ b/openedx/core/djangoapps/user_api/forms.py
@@ -1,0 +1,2 @@
+# TODO: eventually move this implementation into the user_api
+from student.forms import PasswordResetFormNoActive


### PR DESCRIPTION
[ECOM-894](https://openedx.atlassian.net/browse/ECOM-894): Reset Password should not require an activated email address

Allow inactive users to request a password reset
Internationalize error messages for password reset on the new login page.

@dianakhuang @rlucioni please review
