### PR TITLE
MA-227 Mobile announcements sort order correction.

### DIFF
--- a/lms/djangoapps/mobile_api/course_info/views.py
+++ b/lms/djangoapps/mobile_api/course_info/views.py
@@ -39,7 +39,7 @@ class CourseUpdatesList(generics.ListAPIView):
     @mobile_course_access()
     def list(self, request, course, *args, **kwargs):
         course_updates_module = get_course_info_section_module(request, course, 'updates')
-        update_items = list(reversed(get_course_update_items(course_updates_module)))
+        update_items = get_course_update_items(course_updates_module)
 
         updates_to_show = [
             update for update in update_items


### PR DESCRIPTION
https://openedx.atlassian.net/browse/MA-227

This regression was caused by the following PR: https://github.com/edx/edx-platform/pull/6495.
The list of updates was being doubly reversed: by the common helper function in the platform as well as by the Mobile API.  The fix is to remove the (now) extra reverse in the Mobile API.
