### PR TITLE
Fixed grades not appearing on progress page after hiding problem from students.

### DIFF
--- a/lms/djangoapps/courseware/grades.py
+++ b/lms/djangoapps/courseware/grades.py
@@ -448,6 +448,9 @@ def get_score(course_id, user, problem_descriptor, module_creator, scores_cache=
 
         correct = 0.0
         total = problem.max_score()
+        if student_module and student_module.max_grade is None:
+            student_module.max_grade = total
+            student_module.save()
 
         # Problem may be an error module (if something in the problem builder failed)
         # In which case total might be None


### PR DESCRIPTION
[TNL-1135](https://openedx.atlassian.net/browse/TNL-1135)

Grades are not appearing on progress page after hiding problem from students because the problems which student not attempted there `max_grade` value is NULL in `StudentModule`.

Fixed by saving `max_grade` value on grading.
