### PR TITLE
Ziafazal/entrance exam management on instructor dashboard

### DIFF
--- a/common/test/acceptance/fixtures/course.py
+++ b/common/test/acceptance/fixtures/course.py
@@ -102,7 +102,7 @@ class CourseFixture(XBlockContainerFixture):
     between tests, you should use unique course identifiers for each fixture.
     """
 
-    def __init__(self, org, number, run, display_name, start_date=None, end_date=None):
+    def __init__(self, org, number, run, display_name, start_date=None, end_date=None, settings=None):
         """
         Configure the course fixture to create a course with
 
@@ -112,6 +112,8 @@ class CourseFixture(XBlockContainerFixture):
         The default is for the course to have started in the distant past, which is generally what
         we want for testing so students can enroll.
 
+        `settings` can be any additional course settings needs to be enabled. for example
+        to enable entrance exam settings would be a dict like this {"entrance_exam_enabled": "true"}
         These have the same meaning as in the Studio restful API /course end-point.
         """
         super(CourseFixture, self).__init__()
@@ -133,6 +135,9 @@ class CourseFixture(XBlockContainerFixture):
 
         if end_date is not None:
             self._course_details['end_date'] = end_date.isoformat()
+
+        if settings is not None:
+            self._course_details.update(settings)
 
         self._updates = []
         self._handouts = []

--- a/common/test/acceptance/pages/lms/instructor_dashboard.py
+++ b/common/test/acceptance/pages/lms/instructor_dashboard.py
@@ -37,6 +37,15 @@ class InstructorDashboardPage(CoursePage):
         data_download_section.wait_for_page()
         return data_download_section
 
+    def select_student_admin(self):
+        """
+        Selects the student admin tab and returns the MembershipSection
+        """
+        self.q(css='a[data-section=student_admin]').first.click()
+        student_admin_section = StudentAdminPage(self.browser)
+        student_admin_section.wait_for_page()
+        return student_admin_section
+
     @staticmethod
     def get_asset_path(file_name):
         """
@@ -460,3 +469,126 @@ class DataDownloadPage(PageObject):
         """
         reports = self.q(css="#report-downloads-table .file-download-link>a").map(lambda el: el.text)
         return reports.results
+
+
+class StudentAdminPage(PageObject):
+    """
+    Student admin section of the Instructor dashboard.
+    """
+    url = None
+    EE_CONTAINER = ".entrance-exam-grade-container"
+
+    def is_browser_on_page(self):
+        """
+        Confirms student admin section is present
+        """
+        return self.q(css='a[data-section=student_admin].active-section').present
+
+    @property
+    def student_email_input(self):
+        """
+        Returns email address/username input box.
+        """
+        return self.q(css='{} input[name=entrance-exam-student-select-grade]'.format(self.EE_CONTAINER))
+
+    @property
+    def reset_attempts_button(self):
+        """
+        Returns reset student attempts button.
+        """
+        return self.q(css='{} input[name=reset-entrance-exam-attempts]'.format(self.EE_CONTAINER))
+
+    @property
+    def rescore_submission_button(self):
+        """
+        Returns rescore student submission button.
+        """
+        return self.q(css='{} input[name=rescore-entrance-exam]'.format(self.EE_CONTAINER))
+
+    @property
+    def delete_student_state_button(self):
+        """
+        Returns delete student state button.
+        """
+        return self.q(css='{} input[name=delete-entrance-exam-state]'.format(self.EE_CONTAINER))
+
+    @property
+    def background_task_history_button(self):
+        """
+        Returns show background task history for student button.
+        """
+        return self.q(css='{} input[name=entrance-exam-task-history]'.format(self.EE_CONTAINER))
+
+    @property
+    def top_notification(self):
+        """
+        Returns show background task history for student button.
+        """
+        return self.q(css='{} .request-response-error'.format(self.EE_CONTAINER)).first
+
+    def is_student_email_input_visible(self):
+        """
+        Returns True if student email address/username input box is present.
+        """
+        return self.student_email_input.is_present()
+
+    def is_reset_attempts_button_visible(self):
+        """
+        Returns True if reset student attempts button is present.
+        """
+        return self.reset_attempts_button.is_present()
+
+    def is_rescore_submission_button_visible(self):
+        """
+        Returns True if rescore student submission button is present.
+        """
+        return self.rescore_submission_button.is_present()
+
+    def is_delete_student_state_button_visible(self):
+        """
+        Returns True if delete student state for entrance exam button is present.
+        """
+        return self.delete_student_state_button.is_present()
+
+    def is_background_task_history_button_visible(self):
+        """
+        Returns True if show background task history for student button is present.
+        """
+        return self.background_task_history_button.is_present()
+
+    def is_background_task_history_table_visible(self):
+        """
+        Returns True if background task history table is present.
+        """
+        return self.q(css='{} .entrance-exam-task-history-table'.format(self.EE_CONTAINER)).is_present()
+
+    def click_reset_attempts_button(self):
+        """
+        clicks reset student attempts button.
+        """
+        return self.reset_attempts_button.click()
+
+    def click_rescore_submissions_button(self):
+        """
+        clicks rescore submissions button.
+        """
+        return self.rescore_submission_button.click()
+
+    def click_delete_student_state_button(self):
+        """
+        clicks delete student state button.
+        """
+        return self.delete_student_state_button.click()
+
+    def click_task_history_button(self):
+        """
+        clicks background task history button.
+        """
+        return self.background_task_history_button.click()
+
+    def set_student_email(self, email_addres):
+        """
+        Sets given email address as value of student email address/username input box.
+        """
+        input_box = self.student_email_input.first.results[0]
+        input_box.send_keys(email_addres)

--- a/common/test/acceptance/tests/helpers.py
+++ b/common/test/acceptance/tests/helpers.py
@@ -13,6 +13,8 @@ from opaque_keys.edx.locator import CourseLocator
 from xmodule.partitions.partitions import UserPartition
 from xmodule.partitions.tests.test_partitions import MockUserPartitionScheme
 from selenium.webdriver.support.select import Select
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
 
 
 def skip_if_browser(browser):
@@ -250,6 +252,15 @@ def assert_event_emitted_num_times(event_collection, event_name, event_time, eve
             }
         ).count() == num_times_emitted
     )
+
+
+def get_modal_alert(browser):
+    """
+    Returns instance of modal alert box shown in browser after waiting
+    for 4 seconds
+    """
+    WebDriverWait(browser, 4).until(EC.alert_is_present())
+    return browser.switch_to.alert
 
 
 class UniqueCourseTest(WebAppTest):

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -45,7 +45,7 @@ from student.models import (
     CourseEnrollment, CourseEnrollmentAllowed, NonExistentCourseError
 )
 from student.tests.factories import UserFactory, CourseModeFactory
-from student.roles import CourseBetaTesterRole, CourseSalesAdminRole, CourseFinanceAdminRole
+from student.roles import CourseBetaTesterRole, CourseSalesAdminRole, CourseFinanceAdminRole, CourseInstructorRole
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
@@ -2180,6 +2180,7 @@ class TestInstructorAPIRegradeTask(ModuleStoreTestCase, LoginEnrollmentTestCase)
             self.course.id,
             'robot-some-problem-urlname'
         )
+
         self.problem_urlname = self.problem_location.to_deprecated_string()
 
         self.module_to_reset = StudentModule.objects.create(
@@ -2297,7 +2298,251 @@ class TestInstructorAPIRegradeTask(ModuleStoreTestCase, LoginEnrollmentTestCase)
         self.assertEqual(response.status_code, 200)
         self.assertTrue(act.called)
 
+    @patch.dict(settings.FEATURES, {'ENTRANCE_EXAMS': True})
+    def test_course_has_entrance_exam_in_student_attempts_reset(self):
+        """ Test course has entrance exam id set while resetting attempts"""
+        url = reverse('reset_student_attempts_for_entrance_exam',
+                      kwargs={'course_id': unicode(self.course.id)})
+        response = self.client.get(url, {
+            'all_students': True,
+            'delete_module': False,
+        })
+        self.assertEqual(response.status_code, 400)
 
+    @patch.dict(settings.FEATURES, {'ENTRANCE_EXAMS': True})
+    def test_rescore_entrance_exam_with_invalid_exam(self):
+        """ Test course has entrance exam id set while re-scoring. """
+        url = reverse('rescore_entrance_exam', kwargs={'course_id': unicode(self.course.id)})
+        response = self.client.get(url, {
+            'unique_student_identifier': self.student.email,
+        })
+        self.assertEqual(response.status_code, 400)
+
+
+@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
+@patch.dict(settings.FEATURES, {'ENTRANCE_EXAMS': True})
+class TestEntranceExamInstructorAPIRegradeTask(ModuleStoreTestCase, LoginEnrollmentTestCase):
+    """
+    Test endpoints whereby instructors can rescore student grades,
+    reset student attempts and delete state for entrance exam.
+    """
+
+    def setUp(self):
+        super(TestEntranceExamInstructorAPIRegradeTask, self).setUp()
+        self.course = CourseFactory.create(
+            org='test_org',
+            course='test_course',
+            run='test_run',
+            entrance_exam_id='i4x://{}/{}/chapter/Entrance_exam'.format('test_org', 'test_course')
+        )
+        self.course_with_invalid_ee = CourseFactory.create(entrance_exam_id='invalid_exam')
+
+        self.instructor = InstructorFactory(course_key=self.course.id)
+        # Add instructor to invalid ee course
+        CourseInstructorRole(self.course_with_invalid_ee.id).add_users(self.instructor)
+        self.client.login(username=self.instructor.username, password='test')
+
+        self.student = UserFactory()
+        CourseEnrollment.enroll(self.student, self.course.id)
+
+        self.entrance_exam = ItemFactory.create(
+            parent=self.course,
+            category='chapter',
+            display_name='Entrance exam'
+        )
+        subsection = ItemFactory.create(
+            parent=self.entrance_exam,
+            category='sequential',
+            display_name='Subsection 1'
+        )
+        vertical = ItemFactory.create(
+            parent=subsection,
+            category='vertical',
+            display_name='Vertical 1'
+        )
+        self.ee_problem_1 = ItemFactory.create(
+            parent=vertical,
+            category="problem",
+            display_name="Exam Problem - Problem 1"
+        )
+        self.ee_problem_2 = ItemFactory.create(
+            parent=vertical,
+            category="problem",
+            display_name="Exam Problem - Problem 2"
+        )
+
+        ee_module_to_reset1 = StudentModule.objects.create(
+            student=self.student,
+            course_id=self.course.id,
+            module_state_key=self.ee_problem_1.location,
+            state=json.dumps({'attempts': 10}),
+        )
+        ee_module_to_reset2 = StudentModule.objects.create(
+            student=self.student,
+            course_id=self.course.id,
+            module_state_key=self.ee_problem_2.location,
+            state=json.dumps({'attempts': 10}),
+        )
+        self.ee_modules = [ee_module_to_reset1.module_state_key, ee_module_to_reset2.module_state_key]
+
+    def test_reset_entrance_exam_student_attempts_deletall(self):
+        """ Make sure no one can delete all students state on entrance exam. """
+        url = reverse('reset_student_attempts_for_entrance_exam',
+                      kwargs={'course_id': unicode(self.course.id)})
+        response = self.client.get(url, {
+            'all_students': True,
+            'delete_module': True,
+        })
+        self.assertEqual(response.status_code, 400)
+
+    def test_reset_entrance_exam_student_attempts_single(self):
+        """ Test reset single student attempts for entrance exam. """
+        url = reverse('reset_student_attempts_for_entrance_exam',
+                      kwargs={'course_id': unicode(self.course.id)})
+        response = self.client.get(url, {
+            'unique_student_identifier': self.student.email,
+        })
+        self.assertEqual(response.status_code, 200)
+        # make sure problem attempts have been reset.
+        changed_modules = StudentModule.objects.filter(module_state_key__in=self.ee_modules)
+        for changed_module in changed_modules:
+            self.assertEqual(
+                json.loads(changed_module.state)['attempts'],
+                0
+            )
+
+    # mock out the function which should be called to execute the action.
+    @patch.object(instructor_task.api, 'submit_reset_problem_attempts_in_entrance_exam')
+    def test_reset_entrance_exam_all_student_attempts(self, act):
+        """ Test reset all student attempts for entrance exam. """
+        url = reverse('reset_student_attempts_for_entrance_exam',
+                      kwargs={'course_id': unicode(self.course.id)})
+        response = self.client.get(url, {
+            'all_students': True,
+        })
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(act.called)
+
+    def test_reset_student_attempts_invalid_entrance_exam(self):
+        """ Test reset for invalid entrance exam. """
+        url = reverse('reset_student_attempts_for_entrance_exam',
+                      kwargs={'course_id': unicode(self.course_with_invalid_ee.id)})
+        response = self.client.get(url, {
+            'unique_student_identifier': self.student.email,
+        })
+        self.assertEqual(response.status_code, 400)
+
+    def test_entrance_exam_sttudent_delete_state(self):
+        """ Test delete single student entrance exam state. """
+        url = reverse('reset_student_attempts_for_entrance_exam',
+                      kwargs={'course_id': unicode(self.course.id)})
+        response = self.client.get(url, {
+            'unique_student_identifier': self.student.email,
+            'delete_module': True,
+        })
+        self.assertEqual(response.status_code, 200)
+        # make sure the module has been deleted
+        changed_modules = StudentModule.objects.filter(module_state_key__in=self.ee_modules)
+        self.assertEqual(changed_modules.count(), 0)
+
+    def test_entrance_exam_delete_state_with_staff(self):
+        """ Test entrance exam delete state failure with staff access. """
+        self.client.logout()
+        staff_user = StaffFactory(course_key=self.course.id)
+        self.client.login(username=staff_user.username, password='test')
+        url = reverse('reset_student_attempts_for_entrance_exam',
+                      kwargs={'course_id': unicode(self.course.id)})
+        response = self.client.get(url, {
+            'unique_student_identifier': self.student.email,
+            'delete_module': True,
+        })
+        self.assertEqual(response.status_code, 403)
+
+    def test_entrance_exam_reset_student_attempts_nonsense(self):
+        """ Test failure with both unique_student_identifier and all_students. """
+        url = reverse('reset_student_attempts_for_entrance_exam',
+                      kwargs={'course_id': unicode(self.course.id)})
+        response = self.client.get(url, {
+            'unique_student_identifier': self.student.email,
+            'all_students': True,
+        })
+        self.assertEqual(response.status_code, 400)
+
+    @patch.object(instructor_task.api, 'submit_rescore_entrance_exam_for_student')
+    def test_rescore_entrance_exam_single_student(self, act):
+        """ Test re-scoring of entrance exam for single student. """
+        url = reverse('rescore_entrance_exam', kwargs={'course_id': unicode(self.course.id)})
+        response = self.client.get(url, {
+            'unique_student_identifier': self.student.email,
+        })
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(act.called)
+
+    def test_rescore_entrance_exam_all_student(self):
+        """ Test rescoring for all students. """
+        url = reverse('rescore_entrance_exam', kwargs={'course_id': unicode(self.course.id)})
+        response = self.client.get(url, {
+            'all_students': True,
+        })
+        self.assertEqual(response.status_code, 200)
+
+    def test_rescore_entrance_exam_all_student_and_single(self):
+        """ Test re-scoring with both all students and single student parameters. """
+        url = reverse('rescore_entrance_exam', kwargs={'course_id': unicode(self.course.id)})
+        response = self.client.get(url, {
+            'unique_student_identifier': self.student.email,
+            'all_students': True,
+        })
+        self.assertEqual(response.status_code, 400)
+
+    def test_rescore_entrance_exam_with_invalid_exam(self):
+        """ Test re-scoring of entrance exam with invalid exam. """
+        url = reverse('rescore_entrance_exam', kwargs={'course_id': unicode(self.course_with_invalid_ee.id)})
+        response = self.client.get(url, {
+            'unique_student_identifier': self.student.email,
+        })
+        self.assertEqual(response.status_code, 400)
+
+    def test_list_entrance_exam_instructor_tasks_student(self):
+        """ Test list task history for entrance exam AND student. """
+        # create a re-score entrance exam task
+        url = reverse('rescore_entrance_exam', kwargs={'course_id': unicode(self.course.id)})
+        response = self.client.get(url, {
+            'unique_student_identifier': self.student.email,
+        })
+        self.assertEqual(response.status_code, 200)
+
+        url = reverse('list_entrance_exam_instructor_tasks', kwargs={'course_id': unicode(self.course.id)})
+        response = self.client.get(url, {
+            'unique_student_identifier': self.student.email,
+        })
+        self.assertEqual(response.status_code, 200)
+
+        # check response
+        tasks = json.loads(response.content)['tasks']
+        self.assertEqual(len(tasks), 1)
+
+    def test_list_entrance_exam_instructor_tasks_all_student(self):
+        """ Test list task history for entrance exam AND all student. """
+        url = reverse('list_entrance_exam_instructor_tasks', kwargs={'course_id': unicode(self.course.id)})
+        response = self.client.get(url, {})
+        self.assertEqual(response.status_code, 200)
+
+        # check response
+        tasks = json.loads(response.content)['tasks']
+        self.assertEqual(len(tasks), 0)
+
+    def test_list_entrance_exam_instructor_with_invalid_exam_key(self):
+        """ Test list task history for entrance exam failure if course has invalid exam. """
+        url = reverse('list_entrance_exam_instructor_tasks',
+                      kwargs={'course_id': unicode(self.course_with_invalid_ee.id)})
+        response = self.client.get(url, {
+            'unique_student_identifier': self.student.email,
+        })
+        self.assertEqual(response.status_code, 400)
+
+
+@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 @patch('bulk_email.models.html_to_text', Mock(return_value='Mocking CourseEmail.text_message'))
 @patch.dict(settings.FEATURES, {'ENABLE_INSTRUCTOR_EMAIL': True, 'REQUIRE_COURSE_EMAIL_AUTH': False})
 class TestInstructorSendEmail(ModuleStoreTestCase, LoginEnrollmentTestCase):
@@ -2432,8 +2677,9 @@ class TestInstructorAPITaskLists(ModuleStoreTestCase, LoginEnrollmentTestCase):
 
     def setUp(self):
         super(TestInstructorAPITaskLists, self).setUp()
-
-        self.course = CourseFactory.create()
+        self.course = CourseFactory.create(
+            entrance_exam_id='i4x://{}/{}/chapter/Entrance_exam'.format('test_org', 'test_course')
+        )
         self.instructor = InstructorFactory(course_key=self.course.id)
         self.client.login(username=self.instructor.username, password='test')
 

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -1607,6 +1607,71 @@ def reset_student_attempts(request, course_id):
 
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
+@require_level('staff')
+@common_exceptions_400
+def reset_student_attempts_for_entrance_exam(request, course_id):  # pylint: disable=invalid-name
+    """
+
+    Resets a students attempts counter or starts a task to reset all students
+    attempts counters for entrance exam. Optionally deletes student state for
+    entrance exam. Limited to staff access. Some sub-methods limited to instructor access.
+
+    Following are possible query parameters
+        - unique_student_identifier is an email or username
+        - all_students is a boolean
+            requires instructor access
+            mutually exclusive with delete_module
+        - delete_module is a boolean
+            requires instructor access
+            mutually exclusive with all_students
+    """
+    course_id = SlashSeparatedCourseKey.from_deprecated_string(course_id)
+    course = get_course_with_access(
+        request.user, 'staff', course_id, depth=None
+    )
+
+    if not course.entrance_exam_id:
+        return HttpResponseBadRequest(
+            _("Course has no entrance exam section.")
+        )
+
+    student_identifier = request.GET.get('unique_student_identifier', None)
+    student = None
+    if student_identifier is not None:
+        student = get_student_from_identifier(student_identifier)
+    all_students = request.GET.get('all_students', False) in ['true', 'True', True]
+    delete_module = request.GET.get('delete_module', False) in ['true', 'True', True]
+
+    # parameter combinations
+    if all_students and student:
+        return HttpResponseBadRequest(
+            _("all_students and unique_student_identifier are mutually exclusive.")
+        )
+    if all_students and delete_module:
+        return HttpResponseBadRequest(
+            _("all_students and delete_module are mutually exclusive.")
+        )
+
+    # instructor authorization
+    if all_students or delete_module:
+        if not has_access(request.user, 'instructor', course):
+            return HttpResponseForbidden(_("Requires instructor access."))
+
+    try:
+        entrance_exam_key = course_id.make_usage_key_from_deprecated_string(course.entrance_exam_id)
+        if delete_module:
+            instructor_task.api.submit_delete_entrance_exam_state_for_student(request, entrance_exam_key, student)
+        else:
+            instructor_task.api.submit_reset_problem_attempts_in_entrance_exam(request, entrance_exam_key, student)
+    except InvalidKeyError:
+        return HttpResponseBadRequest(_("Course has no valid entrance exam section."))
+
+    response_payload = {'student': student_identifier or _('All Students'), 'task': 'created'}
+    return JsonResponse(response_payload)
+
+
+@ensure_csrf_cookie
+@cache_control(no_cache=True, no_store=True, must_revalidate=True)
 @require_level('instructor')
 @require_query_params(problem_to_reset="problem urlname to reset")
 @common_exceptions_400
@@ -1657,6 +1722,58 @@ def rescore_problem(request, course_id):
     else:
         return HttpResponseBadRequest()
 
+    return JsonResponse(response_payload)
+
+
+@ensure_csrf_cookie
+@cache_control(no_cache=True, no_store=True, must_revalidate=True)
+@require_level('instructor')
+@common_exceptions_400
+def rescore_entrance_exam(request, course_id):
+    """
+    Starts a background process a students attempts counter for entrance exam.
+    Optionally deletes student state for a problem. Limited to instructor access.
+
+    Takes either of the following query parameters
+        - unique_student_identifier is an email or username
+        - all_students is a boolean
+
+    all_students and unique_student_identifier cannot both be present.
+    """
+    course_id = SlashSeparatedCourseKey.from_deprecated_string(course_id)
+    course = get_course_with_access(
+        request.user, 'staff', course_id, depth=None
+    )
+
+    student_identifier = request.GET.get('unique_student_identifier', None)
+    student = None
+    if student_identifier is not None:
+        student = get_student_from_identifier(student_identifier)
+
+    all_students = request.GET.get('all_students') in ['true', 'True', True]
+
+    if not course.entrance_exam_id:
+        return HttpResponseBadRequest(
+            _("Course has no entrance exam section.")
+        )
+
+    if all_students and student:
+        return HttpResponseBadRequest(
+            _("Cannot rescore with all_students and unique_student_identifier.")
+        )
+
+    try:
+        entrance_exam_key = course_id.make_usage_key_from_deprecated_string(course.entrance_exam_id)
+    except InvalidKeyError:
+        return HttpResponseBadRequest(_("Course has no valid entrance exam section."))
+
+    response_payload = {}
+    if student:
+        response_payload['student'] = student_identifier
+    else:
+        response_payload['student'] = _("All Students")
+    instructor_task.api.submit_rescore_entrance_exam_for_student(request, entrance_exam_key, student)
+    response_payload['task'] = 'created'
     return JsonResponse(response_payload)
 
 
@@ -1734,6 +1851,40 @@ def list_instructor_tasks(request, course_id):
     else:
         # If no problem or student, just get currently running tasks
         tasks = instructor_task.api.get_running_instructor_tasks(course_id)
+
+    response_payload = {
+        'tasks': map(extract_task_features, tasks),
+    }
+    return JsonResponse(response_payload)
+
+
+@ensure_csrf_cookie
+@cache_control(no_cache=True, no_store=True, must_revalidate=True)
+@require_level('staff')
+def list_entrance_exam_instructor_tasks(request, course_id):  # pylint: disable=invalid-name
+    """
+    List entrance exam related instructor tasks.
+
+    Takes either of the following query parameters
+        - unique_student_identifier is an email or username
+        - all_students is a boolean
+    """
+    course_id = SlashSeparatedCourseKey.from_deprecated_string(course_id)
+    course = get_course_by_id(course_id)
+    student = request.GET.get('unique_student_identifier', None)
+    if student is not None:
+        student = get_student_from_identifier(student)
+
+    try:
+        entrance_exam_key = course_id.make_usage_key_from_deprecated_string(course.entrance_exam_id)
+    except InvalidKeyError:
+        return HttpResponseBadRequest(_("Course has no valid entrance exam section."))
+    if student:
+        # Specifying for a single student's entrance exam history
+        tasks = instructor_task.api.get_entrance_exam_instructor_task_history(course_id, entrance_exam_key, student)
+    else:
+        # Specifying for all student's entrance exam history
+        tasks = instructor_task.api.get_entrance_exam_instructor_task_history(course_id, entrance_exam_key)
 
     response_payload = {
         'tasks': map(extract_task_features, tasks),

--- a/lms/djangoapps/instructor/views/api_urls.py
+++ b/lms/djangoapps/instructor/views/api_urls.py
@@ -1,3 +1,4 @@
+# pylint: disable=bad-continuation
 """
 Instructor API endpoint urls.
 """
@@ -35,8 +36,16 @@ urlpatterns = patterns('',  # nopep8
         'instructor.views.api.get_student_progress_url', name="get_student_progress_url"),
     url(r'^reset_student_attempts$',
         'instructor.views.api.reset_student_attempts', name="reset_student_attempts"),
-    url(r'^rescore_problem$',
-        'instructor.views.api.rescore_problem', name="rescore_problem"),
+    url(r'^rescore_problem$', 'instructor.views.api.rescore_problem', name="rescore_problem"),
+    # entrance exam tasks
+    url(r'^reset_student_attempts_for_entrance_exam$',
+        'instructor.views.api.reset_student_attempts_for_entrance_exam',
+        name="reset_student_attempts_for_entrance_exam"),
+    url(r'^rescore_entrance_exam$',
+        'instructor.views.api.rescore_entrance_exam', name="rescore_entrance_exam"),
+    url(r'^list_entrance_exam_instructor_tasks',
+        'instructor.views.api.list_entrance_exam_instructor_tasks', name="list_entrance_exam_instructor_tasks"),
+
     url(r'^list_instructor_tasks$',
         'instructor.views.api.list_instructor_tasks', name="list_instructor_tasks"),
     url(r'^list_background_email_tasks$',

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -304,8 +304,15 @@ def _section_student_admin(course, access):
         'get_student_progress_url_url': reverse('get_student_progress_url', kwargs={'course_id': unicode(course_key)}),
         'enrollment_url': reverse('students_update_enrollment', kwargs={'course_id': unicode(course_key)}),
         'reset_student_attempts_url': reverse('reset_student_attempts', kwargs={'course_id': unicode(course_key)}),
+        'reset_student_attempts_for_entrance_exam_url': reverse(
+            'reset_student_attempts_for_entrance_exam',
+            kwargs={'course_id': unicode(course_key)},
+        ),
         'rescore_problem_url': reverse('rescore_problem', kwargs={'course_id': unicode(course_key)}),
+        'rescore_entrance_exam_url': reverse('rescore_entrance_exam', kwargs={'course_id': unicode(course_key)}),
         'list_instructor_tasks_url': reverse('list_instructor_tasks', kwargs={'course_id': unicode(course_key)}),
+        'list_entrace_exam_instructor_tasks_url': reverse('list_entrance_exam_instructor_tasks',
+                                                          kwargs={'course_id': unicode(course_key)}),
         'spoc_gradebook_url': reverse('spoc_gradebook', kwargs={'course_id': unicode(course_key)}),
     }
     return section_data

--- a/lms/static/coffee/src/instructor_dashboard/student_admin.coffee
+++ b/lms/static/coffee/src/instructor_dashboard/student_admin.coffee
@@ -22,7 +22,7 @@ find_and_assert = ($root, selector) ->
     item
 
 
-class StudentAdmin
+class @StudentAdmin
   constructor: (@$section) ->
     # attach self to html so that instructor_dashboard.coffee can find
     #  this object to call event handlers like 'onClickTitle'
@@ -41,6 +41,14 @@ class StudentAdmin
     @$btn_task_history_single     = @$section.find "input[name='task-history-single']"
     @$table_task_history_single   = @$section.find ".task-history-single-table"
 
+    # entrance-exam-specific
+    @$field_entrance_exam_student_select_grade  = @$section.find "input[name='entrance-exam-student-select-grade']"
+    @$btn_reset_entrance_exam_attempts   = @$section.find "input[name='reset-entrance-exam-attempts']"
+    @$btn_delete_entrance_exam_state     = @$section.find "input[name='delete-entrance-exam-state']"
+    @$btn_rescore_entrance_exam          = @$section.find "input[name='rescore-entrance-exam']"
+    @$btn_entrance_exam_task_history     = @$section.find "input[name='entrance-exam-task-history']"
+    @$table_entrance_exam_task_history   = @$section.find ".entrance-exam-task-history-table"
+
     # course-specific
     @$field_problem_select_all    = @$section.find "input[name='problem-select-all']"
     @$btn_reset_attempts_all      = @$section.find "input[name='reset-attempts-all']"
@@ -52,6 +60,7 @@ class StudentAdmin
     # response areas
     @$request_response_error_progress = find_and_assert @$section, ".student-specific-container .request-response-error"
     @$request_response_error_grade = find_and_assert @$section, ".student-grade-container .request-response-error"
+    @$request_response_error_ee       = @$section.find ".entrance-exam-grade-container .request-response-error"
     @$request_response_error_all    = @$section.find ".course-specific-container .request-response-error"
 
     # attach click handlers
@@ -171,6 +180,90 @@ class StudentAdmin
           create_task_list_table @$table_task_history_single, data.tasks
         error: std_ajax_err => @$request_response_error_grade.text full_error_message
 
+   # reset entrance exam attempts for student
+    @$btn_reset_entrance_exam_attempts.click =>
+      unique_student_identifier = @$field_entrance_exam_student_select_grade.val()
+      if not unique_student_identifier
+        return @$request_response_error_ee.text gettext("Please enter a student email address or username.")
+      send_data =
+        unique_student_identifier: unique_student_identifier
+        delete_module: false
+
+      $.ajax
+        dataType: 'json'
+        url: @$btn_reset_entrance_exam_attempts.data 'endpoint'
+        data: send_data
+        success: @clear_errors_then ->
+          success_message = gettext("Entrance exam attempts is being reset for student '{student_id}'.")
+          full_success_message = interpolate_text(success_message, {student_id: unique_student_identifier})
+          alert full_success_message
+        error: std_ajax_err =>
+          error_message = gettext("Error resetting entrance exam attempts for student '{student_id}'. Make sure student identifier is correct.")
+          full_error_message = interpolate_text(error_message, {student_id: unique_student_identifier})
+          @$request_response_error_ee.text full_error_message
+
+   # start task to rescore entrance exam for student
+    @$btn_rescore_entrance_exam.click =>
+      unique_student_identifier = @$field_entrance_exam_student_select_grade.val()
+      if not unique_student_identifier
+        return @$request_response_error_ee.text gettext("Please enter a student email address or username.")
+      send_data =
+        unique_student_identifier: unique_student_identifier
+
+      $.ajax
+        dataType: 'json'
+        url: @$btn_rescore_entrance_exam.data 'endpoint'
+        data: send_data
+        success: @clear_errors_then ->
+          success_message = gettext("Started entrance exam rescore task for student '{student_id}'. Click the 'Show Background Task History for Student' button to see the status of the task.")
+          full_success_message = interpolate_text(success_message, {student_id: unique_student_identifier})
+          alert full_success_message
+        error: std_ajax_err =>
+          error_message = gettext("Error starting a task to rescore entrance exam for student '{student_id}'. Make sure that entrance exam has problems in it and student identifier is correct.")
+          full_error_message = interpolate_text(error_message, {student_id: unique_student_identifier})
+          @$request_response_error_ee.text full_error_message
+
+   # delete student state for entrance exam
+    @$btn_delete_entrance_exam_state.click =>
+      unique_student_identifier = @$field_entrance_exam_student_select_grade.val()
+      if not unique_student_identifier
+        return @$request_response_error_ee.text gettext("Please enter a student email address or username.")
+      send_data =
+        unique_student_identifier: unique_student_identifier
+        delete_module: true
+
+      $.ajax
+        dataType: 'json'
+        url: @$btn_delete_entrance_exam_state.data 'endpoint'
+        data: send_data
+        success: @clear_errors_then ->
+          success_message = gettext("Entrance exam state is being deleted for student '{student_id}'.")
+          full_success_message = interpolate_text(success_message, {student_id: unique_student_identifier})
+          alert full_success_message
+        error: std_ajax_err =>
+          error_message = gettext("Error deleting entrance exam state for student '{student_id}'. Make sure student identifier is correct.")
+          full_error_message = interpolate_text(error_message, {student_id: unique_student_identifier})
+          @$request_response_error_ee.text full_error_message
+
+    # list entrance exam task history for student
+    @$btn_entrance_exam_task_history.click =>
+      unique_student_identifier = @$field_entrance_exam_student_select_grade.val()
+      if not unique_student_identifier
+        return @$request_response_error_ee.text gettext("Please enter a student email address or username.")
+      send_data =
+        unique_student_identifier: unique_student_identifier
+
+      $.ajax
+        dataType: 'json'
+        url: @$btn_entrance_exam_task_history.data 'endpoint'
+        data: send_data
+        success: @clear_errors_then (data) =>
+          create_task_list_table @$table_entrance_exam_task_history, data.tasks
+        error: std_ajax_err =>
+          error_message = gettext("Error getting entrance exam task history for student '{student_id}'. Make sure student identifier is correct.")
+          full_error_message = interpolate_text(error_message, {student_id: unique_student_identifier})
+          @$request_response_error_ee.text full_error_message
+
     # start task to reset attempts on problem for all students
     @$btn_reset_attempts_all.click =>
       problem_to_reset = @$field_problem_select_all.val()
@@ -243,6 +336,7 @@ class StudentAdmin
   clear_errors_then: (cb) ->
     @$request_response_error_progress.empty()
     @$request_response_error_grade.empty()
+    @$request_response_error_ee.empty()
     @$request_response_error_all.empty()
     ->
       cb?.apply this, arguments
@@ -251,6 +345,7 @@ class StudentAdmin
   clear_errors: ->
     @$request_response_error_progress.empty()
     @$request_response_error_grade.empty()
+    @$request_response_error_ee.empty()
     @$request_response_error_all.empty()
 
   # handler for when the section title is clicked.

--- a/lms/static/coffee/src/instructor_dashboard/util.coffee
+++ b/lms/static/coffee/src/instructor_dashboard/util.coffee
@@ -19,7 +19,7 @@ find_and_assert = ($root, selector) ->
 #
 # wraps a `handler` function so that first
 # it prints basic error information to the console.
-std_ajax_err = (handler) -> (jqXHR, textStatus, errorThrown) ->
+@std_ajax_err = (handler) -> (jqXHR, textStatus, errorThrown) ->
   console.warn """ajax error
                   textStatus: #{textStatus}
                   errorThrown: #{errorThrown}"""
@@ -29,7 +29,7 @@ std_ajax_err = (handler) -> (jqXHR, textStatus, errorThrown) ->
 # render a task list table to the DOM
 # `$table_tasks` the $element in which to put the table
 # `tasks_data`
-create_task_list_table = ($table_tasks, tasks_data) ->
+@create_task_list_table = ($table_tasks, tasks_data) ->
   $table_tasks.empty()
 
   options =
@@ -264,7 +264,7 @@ class IntervalManager
     @intervalID = null
 
 
-class PendingInstructorTasks
+class @PendingInstructorTasks
   ### Pending Instructor Tasks Section ####
   constructor: (@$section) ->
     # Currently running tasks

--- a/lms/static/js/fixtures/instructor_dashboard/student_admin.html
+++ b/lms/static/js/fixtures/instructor_dashboard/student_admin.html
@@ -1,0 +1,150 @@
+<section id="student_admin" class="idash-section active-section">
+        
+
+
+<div>
+    <h2>Student Gradebook</h2>
+      <p>
+	Click here to view the gradebook for enrolled students. This feature is only visible to courses with a small number of total enrolled students.
+      </p>
+      <br>
+      <p>
+	<a href="/courses/PU/FSc/2014_T4/instructor/api/gradebook" class="gradebook-link"> View Gradebook </a>
+      </p>
+    <hr>
+</div>
+
+<div class="student-specific-container action-type-container">
+  <h2>Student-specific grade inspection</h2>
+  <div class="request-response-error"></div>
+  <br>
+  <label>
+  Specify the Your Platform Name Here email address or username of a student here:
+  <input type="text" name="student-select-progress" placeholder="Student Email or Username">
+  </label>
+  <br>
+
+  <div class="progress-link-wrapper">
+  <p>
+    Click this link to view the student's progress page:
+
+    <a href="" class="progress-link" data-endpoint="/courses/PU/FSc/2014_T4/instructor/api/get_student_progress_url"> Student Progress Page </a>
+  </p>
+  </div>
+
+  <hr>
+</div>
+
+<div class="student-grade-container action-type-container">
+  <h2>Student-specific grade adjustment</h2>
+  <div class="request-response-error"></div>
+  <p>
+  <label>
+  Specify the Your Platform Name Here email address or username of a student here:
+  <input type="text" name="student-select-grade" placeholder="Student Email or Username">
+  </label>
+  </p>
+  <br>
+
+  <label> Specify a problem in the course here with its complete location:
+  <input type="text" name="problem-select-single" placeholder="Problem location">
+  </label>
+
+  <p>You must provide the complete location of the problem. In the Staff Debug viewer, the location looks like this:<br>
+  <code>i4x://edX/Open_DemoX/problem/78c98390884243b89f6023745231c525</code></p>
+
+  <p>
+  Next, select an action to perform for the given user and problem:
+  </p>
+
+  <p>
+  <input type="button" name="reset-attempts-single" value="Reset Student Attempts" data-endpoint="/courses/PU/FSc/2014_T4/instructor/api/reset_student_attempts">
+
+    <input type="button" name="rescore-problem-single" value="Rescore Student Submission" data-endpoint="/courses/PU/FSc/2014_T4/instructor/api/rescore_problem">
+  </p>
+
+  <p>
+    <label> You may also delete the entire state of a student for the specified problem:
+    <input type="button" class="molly-guard" name="delete-state-single" value="Delete Student State for Problem" data-endpoint="/courses/PU/FSc/2014_T4/instructor/api/reset_student_attempts"></label>
+  </p>
+
+
+    <p id="task-history-single-help">
+      Rescoring runs in the background, and status for active tasks will appear in the 'Pending Instructor Tasks' table. To see status for all tasks submitted for this problem and student, click on this button:
+    </p>
+
+    <p><input type="button" name="task-history-single" value="Show Background Task History for Student" data-endpoint="/courses/PU/FSc/2014_T4/instructor/api/list_instructor_tasks" aria-describedby="task-history-single-help"></p>
+    <div class="task-history-single-table"></div>
+  <hr>
+</div>
+
+<div class="entrance-exam-grade-container action-type-container">
+  <h2>Entrance Exam Adjustment</h2>
+  <div class="request-response-error">Please enter a student email address or username.</div>
+  <label>
+  Student's Your Platform Name Here email address or username:
+  <input type="text" name="entrance-exam-student-select-grade" placeholder="Student Email or Username">
+  </label>
+  <br>
+
+  <p>
+  Select an action for the student's entrance exam. This action will affect every problem in the student's exam.
+  </p>
+
+  <input type="button" name="reset-entrance-exam-attempts" value="Reset Number of Student Attempts" data-endpoint="/courses/PU/FSc/2014_T4/instructor/api/reset_student_attempts_for_entrance_exam">
+
+    <input type="button" name="rescore-entrance-exam" value="Rescore All Problems" data-endpoint="/courses/PU/FSc/2014_T4/instructor/api/rescore_entrance_exam">
+
+  <p>
+    <label> You can also delete all of the student's answers and scores for the entire entrance exam.
+    <input type="button" class="molly-guard" name="delete-entrance-exam-state" value="Delete Student's Answers and Scores" data-endpoint="/courses/PU/FSc/2014_T4/instructor/api/reset_student_attempts_for_entrance_exam"></label>
+  </p>
+
+
+    <p id="entrance-exam-task-history-help">
+      Rescoring runs in the background, and status for active tasks will appear in the 'Pending Instructor Tasks' table. To see status for all tasks submitted for this problem and student, click on this button:
+    </p>
+
+    <p><input type="button" name="entrance-exam-task-history" value="Show Student's Exam Adjustment History" data-endpoint="/courses/PU/FSc/2014_T4/instructor/api/list_entrance_exam_instructor_tasks" aria-describedby="entrance-exam-task-history-help"></p>
+    <div class="entrance-exam-task-history-table"></div>
+  <hr>
+</div>
+
+  <div class="course-specific-container action-type-container">
+    <h2>Course-specific grade adjustment</h2>
+    <div class="request-response-error"></div>
+
+    <label>
+      Specify a problem in the course here with its complete location:
+      <input type="text" name="problem-select-all" size="60" placeholder="Problem location" aria-describedby="problem-select-all-help">
+    </label>
+    <p id="problem-select-all-help">You must provide the complete location of the problem. In the Staff Debug viewer, the location looks like this:<br>
+    <code>i4x://edX/Open_DemoX/problem/78c98390884243b89f6023745231c525</code></p>
+    <p>
+      Then select an action:
+      <input type="button" class="molly-guard" name="reset-attempts-all" value="Reset ALL students' attempts" data-endpoint="/courses/PU/FSc/2014_T4/instructor/api/reset_student_attempts">
+      <input type="button" class="molly-guard" name="rescore-problem-all" value="Rescore ALL students' problem submissions" data-endpoint="/courses/PU/FSc/2014_T4/instructor/api/rescore_problem">
+    </p>
+    <p>
+    </p><p id="task-history-all-help">
+      The above actions run in the background, and status for active tasks will appear in a table on the Course Info tab. To see status for all tasks submitted for this problem, click on this button:
+    </p>
+      <p><input type="button" name="task-history-all" value="Show Background Task History for Problem" data-endpoint="/courses/PU/FSc/2014_T4/instructor/api/list_instructor_tasks" aria-describedby="task-history-all-help"></p>
+      <div class="task-history-all-table"></div>
+    <p></p>
+  </div>
+
+  <div class="running-tasks-container action-type-container">
+    <hr>
+    <h2> Pending Instructor Tasks </h2>
+    <div class="running-tasks-section" style="display: block;">
+      <p>The status for any active tasks appears in a table below. </p>
+      <br>
+
+      <div class="running-tasks-table" data-endpoint="/courses/PU/FSc/2014_T4/instructor/api/list_instructor_tasks"><div class="slickgrid slickgrid_304994 ui-widget" style="overflow: hidden; outline: 0px; position: relative;"><div tabindex="0" hidefocus="" style="position:fixed;width:0;height:0;top:0;left:0;outline:0;"></div><div class="slick-header ui-state-default" style="overflow:hidden;position:relative;"><div class="slick-header-columns" style="left: -1000px; width: 1977px;" unselectable="on"><div class="ui-state-default slick-header-column" id="slickgrid_304994task_type" title="" style="width: 93px;"><span class="slick-column-name">Task Type</span><div class="slick-resizable-handle"></div></div><div class="ui-state-default slick-header-column" id="slickgrid_304994task_input" title="" style="width: 141px;"><span class="slick-column-name">Task inputs</span><div class="slick-resizable-handle"></div></div><div class="ui-state-default slick-header-column" id="slickgrid_304994task_id" title="" style="width: 141px;"><span class="slick-column-name">Task ID</span><div class="slick-resizable-handle"></div></div><div class="ui-state-default slick-header-column" id="slickgrid_304994requester" title="" style="width: 71px;"><span class="slick-column-name">Requester</span><div class="slick-resizable-handle"></div></div><div class="ui-state-default slick-header-column" id="slickgrid_304994created" title="" style="width: 111px;"><span class="slick-column-name">Submitted</span><div class="slick-resizable-handle"></div></div><div class="ui-state-default slick-header-column" id="slickgrid_304994duration_sec" title="" style="width: 71px;"><span class="slick-column-name">Duration (sec)</span><div class="slick-resizable-handle"></div></div><div class="ui-state-default slick-header-column" id="slickgrid_304994task_state" title="" style="width: 71px;"><span class="slick-column-name">State</span><div class="slick-resizable-handle"></div></div><div class="ui-state-default slick-header-column" id="slickgrid_304994status" title="" style="width: 71px;"><span class="slick-column-name">Task Status</span><div class="slick-resizable-handle"></div></div><div class="ui-state-default slick-header-column" id="slickgrid_304994task_message" title="" style="width: 111px;"><span class="slick-column-name">Task Progress</span></div></div></div><div class="slick-headerrow ui-state-default" style="overflow: hidden; position: relative; display: none;"><div class="slick-headerrow-columns" style="width: 962px;"></div><div style="display: block; height: 1px; position: absolute; top: 0px; left: 0px; width: 962px;"></div></div><div class="slick-top-panel-scroller ui-state-default" style="overflow: hidden; position: relative; display: none;"><div class="slick-top-panel" style="width:10000px"></div></div><div class="slick-viewport" style="width: 100%; overflow-y: hidden; overflow-x: auto; outline: 0px; position: relative;"><div class="grid-canvas" style="width: 962px; height: 100px;"><div class="ui-widget-content slick-row even" style="top:0px"><div class="slick-cell l0 r0">rescore_problem</div><div class="slick-cell l1 r1">{"entrance_exam_url": "i4x://PU/FSc/chapter/d2204197cce443c4a0d5c852d4e7f638", "student": "audit"}</div><div class="slick-cell l2 r2">9955d413-eac1-441f-978d-27c60dd1c946</div><div class="slick-cell l3 r3">staff</div><div class="slick-cell l4 r4">2015-02-19T10:59:01+00:00</div><div class="slick-cell l5 r5">unknown</div><div class="slick-cell l6 r6">QUEUING</div><div class="slick-cell l7 r7">Incomplete</div><div class="slick-cell l8 r8">No status information available</div></div></div></div><div tabindex="0" hidefocus="" style="position:fixed;width:0;height:0;top:0;left:0;outline:0;"></div></div></div>
+    </div>
+    <div class="no-pending-tasks-message" style="display: none;"></div>
+  </div>
+
+
+      </section>

--- a/lms/static/js/spec/instructor_dashboard/student_admin_spec.js
+++ b/lms/static/js/spec/instructor_dashboard/student_admin_spec.js
@@ -1,0 +1,251 @@
+define(['jquery', 'coffee/src/instructor_dashboard/student_admin', 'js/common_helpers/ajax_helpers'],
+    function ($, StudentAdmin, AjaxHelpers) {
+        //'coffee/src/instructor_dashboard/student_admin'
+        'use strict';
+        describe("edx.instructor_dashboard.student_admin.StudentAdmin", function() {
+            var studentadmin, dashboard_api_url, unique_student_identifier, alert_msg;
+
+            beforeEach(function() {
+                loadFixtures('js/fixtures/instructor_dashboard/student_admin.html');
+                window.InstructorDashboard = {};
+                window.InstructorDashboard.util = {
+                    std_ajax_err: std_ajax_err,
+                    PendingInstructorTasks: PendingInstructorTasks,
+                    create_task_list_table: create_task_list_table
+                };
+                studentadmin = new window.StudentAdmin($('#student_admin'));
+                dashboard_api_url = '/courses/PU/FSc/2014_T4/instructor/api';
+                unique_student_identifier = "test@example.com";
+                alert_msg = '';
+                spyOn(window, 'alert').andCallFake(function(message) {
+                    alert_msg = message;
+                });
+
+            });
+
+            it('binds reset entrance exam ajax call and the result will be success', function() {
+                studentadmin.$btn_reset_entrance_exam_attempts.click();
+                // expect error to be shown since student identifier is not set
+                expect(studentadmin.$request_response_error_ee.text()).toEqual(gettext("Please enter a student email address or username."));
+
+                var success_message = gettext("Entrance exam attempts is being reset for student '{student_id}'.");
+                var full_success_message = interpolate_text(success_message, {
+                  student_id: unique_student_identifier
+                });
+
+                // Spy on AJAX requests
+                var requests = AjaxHelpers.requests(this);
+
+                studentadmin.$field_entrance_exam_student_select_grade.val(unique_student_identifier)
+                studentadmin.$btn_reset_entrance_exam_attempts.click();
+                // Verify that the client contacts the server to start instructor task
+                var params = $.param({
+                    unique_student_identifier: unique_student_identifier,
+                    delete_module: false
+                });
+                var url = dashboard_api_url + '/reset_student_attempts_for_entrance_exam?' + params;
+                AjaxHelpers.expectJsonRequest(requests, 'GET', url);
+
+                // Simulate a success response from the server
+                AjaxHelpers.respondWithJson(requests, {
+                    message: full_success_message
+                });
+                expect(alert_msg).toEqual(full_success_message);
+            });
+
+            it('binds reset entrance exam ajax call and the result will be error', function() {
+                // Spy on AJAX requests
+                var requests = AjaxHelpers.requests(this);
+                studentadmin.$field_entrance_exam_student_select_grade.val(unique_student_identifier)
+                studentadmin.$btn_reset_entrance_exam_attempts.click();
+                // Verify that the client contacts the server to start instructor task
+                var params = $.param({
+                    unique_student_identifier: unique_student_identifier,
+                    delete_module: false
+                });
+                var url = dashboard_api_url + '/reset_student_attempts_for_entrance_exam?' + params;
+                AjaxHelpers.expectJsonRequest(requests, 'GET', url);
+
+                // Simulate an error response from the server
+                AjaxHelpers.respondWithError(requests, 400,{});
+
+                var error_message = gettext("Error resetting entrance exam attempts for student '{student_id}'. Make sure student identifier is correct.");
+                var full_error_message = interpolate_text(error_message, {
+                  student_id: unique_student_identifier
+                });
+                expect(studentadmin.$request_response_error_ee.text()).toEqual(full_error_message);
+            });
+
+            it('initiates rescoring of the entrance exam when the button is clicked', function() {
+                studentadmin.$btn_rescore_entrance_exam.click();
+                // expect error to be shown since student identifier is not set
+                expect(studentadmin.$request_response_error_ee.text()).toEqual(gettext("Please enter a student email address or username."));
+
+                var success_message = gettext("Started entrance exam rescore task for student '{student_id}'." +
+                    " Click the 'Show Background Task History for Student' button to see the status of the task.");
+                var full_success_message = interpolate_text(success_message, {
+                  student_id: unique_student_identifier
+                });
+
+                // Spy on AJAX requests
+                var requests = AjaxHelpers.requests(this);
+
+                studentadmin.$field_entrance_exam_student_select_grade.val(unique_student_identifier)
+                studentadmin.$btn_rescore_entrance_exam.click();
+                // Verify that the client contacts the server to start instructor task
+                var params = $.param({
+                    unique_student_identifier: unique_student_identifier
+                });
+                var url = dashboard_api_url + '/rescore_entrance_exam?' + params;
+                AjaxHelpers.expectJsonRequest(requests, 'GET', url);
+
+                // Simulate a success response from the server
+                AjaxHelpers.respondWithJson(requests, {
+                    message: full_success_message
+                });
+                expect(alert_msg).toEqual(full_success_message);
+            });
+
+            it('shows an error when entrance exam rescoring fails', function() {
+                // Spy on AJAX requests
+                var requests = AjaxHelpers.requests(this);
+                studentadmin.$field_entrance_exam_student_select_grade.val(unique_student_identifier)
+                studentadmin.$btn_rescore_entrance_exam.click();
+                // Verify that the client contacts the server to start instructor task
+                var params = $.param({
+                    unique_student_identifier: unique_student_identifier
+                });
+                var url = dashboard_api_url + '/rescore_entrance_exam?' + params;
+                AjaxHelpers.expectJsonRequest(requests, 'GET', url);
+
+                // Simulate an error response from the server
+                AjaxHelpers.respondWithError(requests, 400,{});
+
+                var error_message = gettext("Error starting a task to rescore entrance exam for student '{student_id}'." +
+                    " Make sure that entrance exam has problems in it and student identifier is correct.");
+                var full_error_message = interpolate_text(error_message, {
+                  student_id: unique_student_identifier
+                });
+                expect(studentadmin.$request_response_error_ee.text()).toEqual(full_error_message);
+            });
+
+            it('binds delete student state for entrance exam ajax call and the result will be success', function() {
+                studentadmin.$btn_delete_entrance_exam_state.click();
+                // expect error to be shown since student identifier is not set
+                expect(studentadmin.$request_response_error_ee.text()).toEqual(gettext("Please enter a student email address or username."));
+
+                var success_message = gettext("Entrance exam state is being deleted for student '{student_id}'.");
+                var full_success_message = interpolate_text(success_message, {
+                  student_id: unique_student_identifier
+                });
+
+                // Spy on AJAX requests
+                var requests = AjaxHelpers.requests(this);
+
+                studentadmin.$field_entrance_exam_student_select_grade.val(unique_student_identifier)
+                studentadmin.$btn_delete_entrance_exam_state.click();
+                // Verify that the client contacts the server to start instructor task
+                var params = $.param({
+                    unique_student_identifier: unique_student_identifier,
+                    delete_module: true
+                });
+                var url = dashboard_api_url + '/reset_student_attempts_for_entrance_exam?' + params;
+                AjaxHelpers.expectJsonRequest(requests, 'GET', url);
+
+                // Simulate a success response from the server
+                AjaxHelpers.respondWithJson(requests, {
+                    message: full_success_message
+                });
+                expect(alert_msg).toEqual(full_success_message);
+            });
+
+            it('binds delete student state for entrance exam ajax call and the result will be error', function() {
+                // Spy on AJAX requests
+                var requests = AjaxHelpers.requests(this);
+                studentadmin.$field_entrance_exam_student_select_grade.val(unique_student_identifier)
+                studentadmin.$btn_delete_entrance_exam_state.click();
+                // Verify that the client contacts the server to start instructor task
+                var params = $.param({
+                    unique_student_identifier: unique_student_identifier,
+                    delete_module: true
+                });
+                var url = dashboard_api_url + '/reset_student_attempts_for_entrance_exam?' + params;
+                AjaxHelpers.expectJsonRequest(requests, 'GET', url);
+
+                // Simulate an error response from the server
+                AjaxHelpers.respondWithError(requests, 400,{});
+
+                var error_message = gettext("Error deleting entrance exam state for student '{student_id}'. " +
+                    "Make sure student identifier is correct.");
+                var full_error_message = interpolate_text(error_message, {
+                  student_id: unique_student_identifier
+                });
+                expect(studentadmin.$request_response_error_ee.text()).toEqual(full_error_message);
+            });
+
+            it('binds list entrance exam task history ajax call and the result will be success', function() {
+                studentadmin.$btn_entrance_exam_task_history.click();
+                // expect error to be shown since student identifier is not set
+                expect(studentadmin.$request_response_error_ee.text()).toEqual(gettext("Please enter a student email address or username."));
+
+                var success_message = gettext("Entrance exam state is being deleted for student '{student_id}'.");
+                var full_success_message = interpolate_text(success_message, {
+                  student_id: unique_student_identifier
+                });
+
+                // Spy on AJAX requests
+                var requests = AjaxHelpers.requests(this);
+
+                studentadmin.$field_entrance_exam_student_select_grade.val(unique_student_identifier)
+                studentadmin.$btn_entrance_exam_task_history.click();
+                // Verify that the client contacts the server to start instructor task
+                var params = $.param({
+                    unique_student_identifier: unique_student_identifier
+                });
+                var url = dashboard_api_url + '/list_entrance_exam_instructor_tasks?' + params;
+                AjaxHelpers.expectJsonRequest(requests, 'GET', url);
+
+                // Simulate a success response from the server
+                AjaxHelpers.respondWithJson(requests, {
+                    "tasks": [
+                        {
+                            "status": "Incomplete",
+                            "task_type": "rescore_problem",
+                            "task_id": "9955d413-eac1-441f-978d-27c60dd1c946",
+                            "created": "2015-02-19T10:59:01+00:00",
+                            "task_input": "{\"entrance_exam_url\": \"i4x://PU/FSc/chapter/d2204197cce443c4a0d5c852d4e7f638\", \"student\": \"audit\"}",
+                            "duration_sec": "unknown",
+                            "task_message": "No status information available",
+                            "requester": "staff",
+                            "task_state": "QUEUING"
+                        }
+                    ]
+                });
+                expect($('.entrance-exam-task-history-table')).toBeVisible();
+            });
+
+            it('binds list entrance exam task history ajax call and the result will be error', function() {
+                // Spy on AJAX requests
+                var requests = AjaxHelpers.requests(this);
+                studentadmin.$field_entrance_exam_student_select_grade.val(unique_student_identifier)
+                studentadmin.$btn_entrance_exam_task_history.click();
+                // Verify that the client contacts the server to start instructor task
+                var params = $.param({
+                    unique_student_identifier: unique_student_identifier
+                });
+                var url = dashboard_api_url + '/list_entrance_exam_instructor_tasks?' + params;
+                AjaxHelpers.expectJsonRequest(requests, 'GET', url);
+
+                // Simulate an error response from the server
+                AjaxHelpers.respondWithError(requests, 400,{});
+
+                var error_message = gettext("Error getting entrance exam task history for student '{student_id}'. " +
+                    "Make sure student identifier is correct.");
+                var full_error_message = interpolate_text(error_message, {
+                  student_id: unique_student_identifier
+                });
+                expect(studentadmin.$request_response_error_ee.text()).toEqual(full_error_message);
+            });
+
+        });
+    });

--- a/lms/static/js/spec/main.js
+++ b/lms/static/js/spec/main.js
@@ -47,6 +47,7 @@
             'youtube': '//www.youtube.com/player_api?noext',
             'tender': '//api.tenderapp.com/tender_widget',
             'coffee/src/ajax_prefix': 'xmodule_js/common_static/coffee/src/ajax_prefix',
+            'coffee/src/instructor_dashboard/student_admin': 'coffee/src/instructor_dashboard/student_admin',
             'xmodule_js/common_static/js/test/add_ajax_prefix': 'xmodule_js/common_static/js/test/add_ajax_prefix',
             'xblock/core': 'xmodule_js/common_static/js/xblock/core',
             'xblock/runtime.v1': 'xmodule_js/common_static/coffee/src/xblock/runtime.v1',
@@ -251,7 +252,10 @@
                 exports: 'AjaxPrefix',
                 deps: ['coffee/src/ajax_prefix']
             },
-
+            'coffee/src/instructor_dashboard/student_admin': {
+                exports: 'coffee/src/instructor_dashboard/student_admin',
+                deps: ['jquery', 'underscore', 'coffee/src/instructor_dashboard/util', 'string_utils']
+            },
             // LMS class loaded explicitly until they are converted to use RequireJS
             'js/student_account/account': {
                 exports: 'js/student_account/account',
@@ -539,6 +543,7 @@
         'lms/include/js/spec/groups/views/cohorts_spec.js',
         'lms/include/js/spec/shoppingcart/shoppingcart_spec.js',
         'lms/include/js/spec/instructor_dashboard/ecommerce_spec.js',
+        'lms/include/js/spec/instructor_dashboard/student_admin_spec.js',
         'lms/include/js/spec/student_account/account_spec.js',
         'lms/include/js/spec/student_account/access_spec.js',
         'lms/include/js/spec/student_account/login_spec.js',

--- a/lms/static/js_test.yml
+++ b/lms/static/js_test.yml
@@ -47,6 +47,7 @@ lib_paths:
     - xmodule_js/common_static/coffee/src/jquery.immediateDescendents.js
     - xmodule_js/common_static/js/xblock
     - xmodule_js/common_static/coffee/src/xblock
+    - coffee/src/instructor_dashboard
     - xmodule_js/common_static/js/vendor/sinon-1.7.1.js
     - xmodule_js/src/capa/
     - xmodule_js/src/video/

--- a/lms/templates/instructor/instructor_dashboard_2/student_admin.html
+++ b/lms/templates/instructor/instructor_dashboard_2/student_admin.html
@@ -19,10 +19,11 @@
 <div class="student-specific-container action-type-container">
   <h2>${_("Student-specific grade inspection")}</h2>
   <div class="request-response-error"></div>
-  <p>
+  <br />
+  <label>
   ${_("Specify the {platform_name} email address or username of a student here:").format(platform_name=settings.PLATFORM_NAME)}
-  <input type="text" name="student-select-progress" placeholder="${_("Student Email or Username")}">
-  </p>
+  <input type="text" name="student-select-progress" placeholder="${_("Student Email or Username")}" >
+  </label>
   <br>
 
   <div class="progress-link-wrapper">
@@ -40,18 +41,20 @@
   <h2>${_("Student-specific grade adjustment")}</h2>
   <div class="request-response-error"></div>
   <p>
+  <label>
   ${_("Specify the {platform_name} email address or username of a student here:").format(platform_name=settings.PLATFORM_NAME)}
   <input type="text" name="student-select-grade" placeholder="${_("Student Email or Username")}">
+  </label>
   </p>
   <br>
 
-  <p> ${_("Specify a problem in the course here with its complete location:")}
+  <label> ${_("Specify a problem in the course here with its complete location:")}
   <input type="text" name="problem-select-single" placeholder="${_("Problem location")}">
-  </p>
+  </label>
 
   ## Translators: A location (string of text) follows this sentence.
   <p>${_("You must provide the complete location of the problem. In the Staff Debug viewer, the location looks like this:")}<br/>
-  <tt>i4x://edX/Open_DemoX/problem/78c98390884243b89f6023745231c525</tt></p>
+  <code>i4x://edX/Open_DemoX/problem/78c98390884243b89f6023745231c525</code></p>
 
   <p>
   ${_("Next, select an action to perform for the given user and problem:")}
@@ -67,47 +70,88 @@
 
   <p>
   %if section_data['access']['instructor']:
-    <p> ${_('You may also delete the entire state of a student for the specified problem:')} </p>
-    <p><input type="button" class="molly-guard" name="delete-state-single" value="${_("Delete Student State for Problem")}" data-endpoint="${ section_data['reset_student_attempts_url'] }"></p>
+    <label> ${_('You may also delete the entire state of a student for the specified problem:')}
+    <input type="button" class="molly-guard" name="delete-state-single" value="${_("Delete Student State for Problem")}" data-endpoint="${ section_data['reset_student_attempts_url'] }"></label>
   %endif
   </p>
 
 
   %if settings.FEATURES.get('ENABLE_INSTRUCTOR_BACKGROUND_TASKS') and section_data['access']['instructor']:
-    <p>
+    <p id="task-history-single-help">
       ${_("Rescoring runs in the background, and status for active tasks will appear in the 'Pending Instructor Tasks' table. "
       "To see status for all tasks submitted for this problem and student, click on this button:")}
     </p>
 
-    <p><input type="button" name="task-history-single" value="${_("Show Background Task History for Student")}" data-endpoint="${ section_data['list_instructor_tasks_url'] }"></p>
+    <p><input type="button" name="task-history-single" value="${_("Show Background Task History for Student")}" data-endpoint="${ section_data['list_instructor_tasks_url'] }" aria-describedby="task-history-single-help"></p>
     <div class="task-history-single-table"></div>
   %endif
   <hr>
 </div>
+
+% if course.entrance_exam_enabled:
+<div class="entrance-exam-grade-container action-type-container">
+  <h2>${_("Entrance Exam Adjustment")}</h2>
+  <div class="request-response-error"></div>
+  <label>
+  ${_("Student's {platform_name} email address or username:").format(platform_name=settings.PLATFORM_NAME)}
+  <input type="text" name="entrance-exam-student-select-grade" placeholder="${_('Student Email or Username')}">
+  </label>
+  <br>
+
+  <p>
+  ${_("Select an action for the student's entrance exam. This action will affect every problem in the student's exam.")}
+  </p>
+
+  <input type="button" name="reset-entrance-exam-attempts" value="${_('Reset Number of Student Attempts')}" data-endpoint="${ section_data['reset_student_attempts_for_entrance_exam_url'] }">
+
+  %if settings.FEATURES.get('ENABLE_INSTRUCTOR_BACKGROUND_TASKS') and section_data['access']['instructor']:
+    <input type="button" name="rescore-entrance-exam" value="${_('Rescore All Problems')}" data-endpoint="${ section_data['rescore_entrance_exam_url'] }">
+  %endif
+
+  <p>
+  %if section_data['access']['instructor']:
+    <label> ${_("You can also delete all of the student's answers and scores for the entire entrance exam.")}
+    <input type="button" class="molly-guard" name="delete-entrance-exam-state" value="${_("Delete Student's Answers and Scores")}" data-endpoint="${ section_data['reset_student_attempts_for_entrance_exam_url'] }"></label>
+  %endif
+  </p>
+
+
+  %if settings.FEATURES.get('ENABLE_INSTRUCTOR_BACKGROUND_TASKS') and section_data['access']['instructor']:
+    <p id="entrance-exam-task-history-help">
+      ${_("Rescoring runs in the background, and status for active tasks will appear in the 'Pending Instructor Tasks' table. "
+      "To see status for all tasks submitted for this problem and student, click on this button:")}
+    </p>
+
+    <p><input type="button" name="entrance-exam-task-history" value="${_("Show Student's Exam Adjustment History")}" data-endpoint="${ section_data['list_entrace_exam_instructor_tasks_url'] }" aria-describedby="entrance-exam-task-history-help"></p>
+    <div class="entrance-exam-task-history-table"></div>
+  %endif
+  <hr>
+</div>
+%endif
 
 %if settings.FEATURES.get('ENABLE_INSTRUCTOR_BACKGROUND_TASKS') and section_data['access']['instructor']:
   <div class="course-specific-container action-type-container">
     <h2>${_('Course-specific grade adjustment')}</h2>
     <div class="request-response-error"></div>
 
-    <p>
+    <label>
       ${_("Specify a problem in the course here with its complete location:")}
-      <input type="text" name="problem-select-all" size="60" placeholder="${_("Problem location")}">
-    </p>
+      <input type="text" name="problem-select-all" size="60" placeholder="${_("Problem location")}" aria-describedby="problem-select-all-help">
+    </label>
     ## Translators: A location (string of text) follows this sentence.
-    <p>${_("You must provide the complete location of the problem. In the Staff Debug viewer, the location looks like this:")}<br/>
-    <tt>i4x://edX/Open_DemoX/problem/78c98390884243b89f6023745231c525</tt></p>
+    <p id="problem-select-all-help">${_("You must provide the complete location of the problem. In the Staff Debug viewer, the location looks like this:")}<br/>
+    <code>i4x://edX/Open_DemoX/problem/78c98390884243b89f6023745231c525</code></p>
     <p>
       ${_("Then select an action")}:
       <input type="button" class="molly-guard" name="reset-attempts-all" value="${_("Reset ALL students' attempts")}" data-endpoint="${ section_data['reset_student_attempts_url'] }">
       <input type="button" class="molly-guard" name="rescore-problem-all" value="${_("Rescore ALL students' problem submissions")}" data-endpoint="${ section_data['rescore_problem_url'] }">
     </p>
     <p>
-    <p>
+    <p id="task-history-all-help">
       ${_("The above actions run in the background, and status for active tasks will appear in a table on the Course Info tab. "
       "To see status for all tasks submitted for this problem, click on this button")}:
     </p>
-      <p><input type="button" name="task-history-all" value="${_("Show Background Task History for Problem")}" data-endpoint="${ section_data['list_instructor_tasks_url'] }"></p>
+      <p><input type="button" name="task-history-all" value="${_("Show Background Task History for Problem")}" data-endpoint="${ section_data['list_instructor_tasks_url'] }" aria-describedby="task-history-all-help"></p>
       <div class="task-history-all-table"></div>
     </p>
   </div>


### PR DESCRIPTION
@mattdrayer @chrisndodge I have improved the code based on your feedback. 
1) Added ability to `reset_student_attempt` across all problems in entrance exam via single celery task instead of created multiple tasks for problem
2) Created separate api entrance exam reset instead of using existing problem reset api.
