### PR TITLE
Ignore invalid-name errors for settings files

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -6,6 +6,11 @@ This is the default template for our main set of AWS servers.
 # want to import all variables from base settings files
 # pylint: disable=wildcard-import, unused-wildcard-import
 
+# Pylint gets confused by path.py instances, which report themselves as class
+# objects. As a result, pylint applies the wrong regex in validating names,
+# and throws spurious errors. Therefore, we disable invalid-name checking.
+# pylint: disable=invalid-name
+
 import json
 
 from .common import *

--- a/cms/envs/bok_choy.py
+++ b/cms/envs/bok_choy.py
@@ -5,6 +5,11 @@ Settings for bok choy tests
 import os
 from path import path
 
+# Pylint gets confused by path.py instances, which report themselves as class
+# objects. As a result, pylint applies the wrong regex in validating names,
+# and throws spurious errors. Therefore, we disable invalid-name checking.
+# pylint: disable=invalid-name
+
 
 ########################## Prod-like settings ###################################
 # These should be as close as possible to the settings we use in production.

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -24,6 +24,11 @@ Longer TODO:
 # want to import all variables from base settings files
 # pylint: disable=wildcard-import, unused-import, unused-wildcard-import
 
+# Pylint gets confused by path.py instances, which report themselves as class
+# objects. As a result, pylint applies the wrong regex in validating names,
+# and throws spurious errors. Therefore, we disable invalid-name checking.
+# pylint: disable=invalid-name
+
 import imp
 import os
 import sys

--- a/cms/envs/test.py
+++ b/cms/envs/test.py
@@ -12,6 +12,11 @@ sessions. Assumes structure:
 # want to import all variables from base settings files
 # pylint: disable=wildcard-import, unused-wildcard-import
 
+# Pylint gets confused by path.py instances, which report themselves as class
+# objects. As a result, pylint applies the wrong regex in validating names,
+# and throws spurious errors. Therefore, we disable invalid-name checking.
+# pylint: disable=invalid-name
+
 from .common import *
 import os
 from path import path

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -11,6 +11,11 @@ Common traits:
 # want to import all variables from base settings files
 # pylint: disable=wildcard-import, unused-wildcard-import
 
+# Pylint gets confused by path.py instances, which report themselves as class
+# objects. As a result, pylint applies the wrong regex in validating names,
+# and throws spurious errors. Therefore, we disable invalid-name checking.
+# pylint: disable=invalid-name
+
 import json
 
 from .common import *

--- a/lms/envs/bok_choy.py
+++ b/lms/envs/bok_choy.py
@@ -6,6 +6,11 @@ import os
 from path import path
 from tempfile import mkdtemp
 
+# Pylint gets confused by path.py instances, which report themselves as class
+# objects. As a result, pylint applies the wrong regex in validating names,
+# and throws spurious errors. Therefore, we disable invalid-name checking.
+# pylint: disable=invalid-name
+
 CONFIG_ROOT = path(__file__).abspath().dirname()  # pylint: disable=no-value-for-parameter
 TEST_ROOT = CONFIG_ROOT.dirname().dirname() / "test_root"
 

--- a/lms/envs/cms/microsite_test.py
+++ b/lms/envs/cms/microsite_test.py
@@ -5,6 +5,11 @@ This is a localdev test for the Microsite processing pipeline
 # want to import all variables from base settings files
 # pylint: disable=wildcard-import, unused-wildcard-import
 
+# Pylint gets confused by path.py instances, which report themselves as class
+# objects. As a result, pylint applies the wrong regex in validating names,
+# and throws spurious errors. Therefore, we disable invalid-name checking.
+# pylint: disable=invalid-name
+
 from .dev import *
 from ..dev import ENV_ROOT, FEATURES
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -24,6 +24,11 @@ Longer TODO:
 # want to import all variables from base settings files
 # pylint: disable=wildcard-import, unused-import, unused-wildcard-import, invalid-name
 
+# Pylint gets confused by path.py instances, which report themselves as class
+# objects. As a result, pylint applies the wrong regex in validating names,
+# and throws spurious errors. Therefore, we disable invalid-name checking.
+# pylint: disable=invalid-name
+
 import sys
 import os
 import imp

--- a/lms/envs/dev.py
+++ b/lms/envs/dev.py
@@ -12,6 +12,11 @@ sessions. Assumes structure:
 # want to import all variables from base settings files
 # pylint: disable=wildcard-import, unused-wildcard-import
 
+# Pylint gets confused by path.py instances, which report themselves as class
+# objects. As a result, pylint applies the wrong regex in validating names,
+# and throws spurious errors. Therefore, we disable invalid-name checking.
+# pylint: disable=invalid-name
+
 from .common import *
 from logsettings import get_logger_config
 

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -12,6 +12,11 @@ sessions. Assumes structure:
 # want to import all variables from base settings files
 # pylint: disable=wildcard-import, unused-wildcard-import
 
+# Pylint gets confused by path.py instances, which report themselves as class
+# objects. As a result, pylint applies the wrong regex in validating names,
+# and throws spurious errors. Therefore, we disable invalid-name checking.
+# pylint: disable=invalid-name
+
 from .common import *
 import os
 from path import path


### PR DESCRIPTION
path.py objects report themselves as class objects, which confuses the heck out of
pylint. It tries to match variable names using the class-rgx regular expression
instead of the constant-rgx regular expression, and it doesn't match, so it
throws an error. Not sure how to fix pylint, so we'll just ignore these errors.

Example:

``` pycon
% python
Python 2.7.9 (default, Dec 15 2014, 10:01:34) 
[GCC 4.2.1 Compatible Apple LLVM 6.0 (clang-600.0.56)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from path import path
>>> p = path("/tmp")
>>> type(p)
<class 'path.path'>
>>> 
```

@jzoldak, can you take a look?
