### PR TITLE
Make entrance exam field non-editable

### DIFF
--- a/cms/djangoapps/contentstore/views/helpers.py
+++ b/cms/djangoapps/contentstore/views/helpers.py
@@ -4,16 +4,22 @@ Helper methods for Studio views.
 
 from __future__ import absolute_import
 
+from uuid import uuid4
 import urllib
 
 from django.conf import settings
 from django.http import HttpResponse
 from django.shortcuts import redirect
 from django.utils.translation import ugettext as _
+
 from edxmako.shortcuts import render_to_string, render_to_response
+from opaque_keys.edx.keys import UsageKey
 from xblock.core import XBlock
 from xmodule.modulestore.django import modulestore
+from xmodule.tabs import StaticTab
+
 from contentstore.utils import reverse_course_url, reverse_library_url, reverse_usage_url
+from models.settings.course_grading import CourseGradingModel
 
 __all__ = ['edge', 'event', 'landing']
 
@@ -154,3 +160,105 @@ def xblock_primary_child_category(xblock):
     elif category == 'sequential':
         return 'vertical'
     return None
+
+
+def usage_key_with_run(usage_key_string):
+    """
+    Converts usage_key_string to a UsageKey, adding a course run if necessary
+    """
+    usage_key = UsageKey.from_string(usage_key_string)
+    usage_key = usage_key.replace(course_key=modulestore().fill_in_run(usage_key.course_key))
+    return usage_key
+
+
+def create_xblock(parent_locator, user, category, display_name, boilerplate=None, is_entrance_exam=False):
+    """
+    Performs the actual grunt work of creating items/xblocks -- knows nothing about requests, views, etc.
+    """
+    store = modulestore()
+    usage_key = usage_key_with_run(parent_locator)
+    with store.bulk_operations(usage_key.course_key):
+        parent = store.get_item(usage_key)
+        dest_usage_key = usage_key.replace(category=category, name=uuid4().hex)
+
+        # get the metadata, display_name, and definition from the caller
+        metadata = {}
+        data = None
+        template_id = boilerplate
+        if template_id:
+            clz = parent.runtime.load_block_type(category)
+            if clz is not None:
+                template = clz.get_template(template_id)
+                if template is not None:
+                    metadata = template.get('metadata', {})
+                    data = template.get('data')
+
+        if display_name is not None:
+            metadata['display_name'] = display_name
+
+        # We should use the 'fields' kwarg for newer module settings/values (vs. metadata or data)
+        fields = {}
+
+        # Entrance Exams: Chapter module positioning
+        child_position = None
+        if settings.FEATURES.get('ENTRANCE_EXAMS', False):
+            if category == 'chapter' and is_entrance_exam:
+                fields['is_entrance_exam'] = is_entrance_exam
+                fields['in_entrance_exam'] = True  # Inherited metadata, all children will have it
+                child_position = 0
+
+        # TODO need to fix components that are sending definition_data as strings, instead of as dicts
+        # For now, migrate them into dicts here.
+        if isinstance(data, basestring):
+            data = {'data': data}
+
+        created_block = store.create_child(
+            user.id,
+            usage_key,
+            dest_usage_key.block_type,
+            block_id=dest_usage_key.block_id,
+            fields=fields,
+            definition_data=data,
+            metadata=metadata,
+            runtime=parent.runtime,
+            position=child_position,
+        )
+
+        # Entrance Exams: Grader assignment
+        if settings.FEATURES.get('ENTRANCE_EXAMS', False):
+            course = store.get_course(usage_key.course_key)
+            if hasattr(course, 'entrance_exam_enabled') and course.entrance_exam_enabled:
+                if category == 'sequential' and parent_locator == course.entrance_exam_id:
+                    grader = {
+                        "type": "Entrance Exam",
+                        "min_count": 0,
+                        "drop_count": 0,
+                        "short_label": "Entrance",
+                        "weight": 0
+                    }
+                    grading_model = CourseGradingModel.update_grader_from_json(
+                        course.id,
+                        grader,
+                        user
+                    )
+                    CourseGradingModel.update_section_grader_type(
+                        created_block,
+                        grading_model['type'],
+                        user
+                    )
+
+        # VS[compat] cdodge: This is a hack because static_tabs also have references from the course module, so
+        # if we add one then we need to also add it to the policy information (i.e. metadata)
+        # we should remove this once we can break this reference from the course to static tabs
+        if category == 'static_tab':
+            display_name = display_name or _("Empty")  # Prevent name being None
+            course = store.get_course(dest_usage_key.course_key)
+            course.tabs.append(
+                StaticTab(
+                    name=display_name,
+                    url_slug=dest_usage_key.name,
+                )
+            )
+            store.update_item(course, user.id)
+
+        return created_block

--- a/cms/djangoapps/contentstore/views/tests/test_item.py
+++ b/cms/djangoapps/contentstore/views/tests/test_item.py
@@ -1378,6 +1378,20 @@ class TestXBlockInfo(ItemTest):
         json_response = json.loads(resp.content)
         self.validate_course_xblock_info(json_response, course_outline=True)
 
+    def test_chapter_entrance_exam_xblock_info(self):
+        chapter = ItemFactory.create(
+            parent_location=self.course.location, category='chapter', display_name="Entrance Exam",
+            user_id=self.user.id, is_entrance_exam=True
+        )
+        chapter = modulestore().get_item(chapter.location)
+        xblock_info = create_xblock_info(
+            chapter,
+            include_child_info=True,
+            include_children_predicate=ALWAYS,
+        )
+        self.assertEqual(xblock_info['override_type'], {'is_entrance_exam': True})
+        self.assertEqual(xblock_info['display_name'], 'Entrance Exam')
+
     def test_chapter_xblock_info(self):
         chapter = modulestore().get_item(self.chapter.location)
         xblock_info = create_xblock_info(

--- a/cms/static/js/spec/models/xblock_info_spec.js
+++ b/cms/static/js/spec/models/xblock_info_spec.js
@@ -7,6 +7,16 @@ define(['backbone', 'js/models/xblock_info'],
                 expect(new XBlockInfo({'category': 'sequential'}).isEditableOnCourseOutline()).toBe(true);
                 expect(new XBlockInfo({'category': 'vertical'}).isEditableOnCourseOutline()).toBe(true);
             });
+
+            it('cannot delete an entrance exam', function(){
+                expect(new XBlockInfo({'category': 'chapter', 'override_type': {'is_entrance_exam':true}})
+                    .canBeDeleted()).toBe(false);
+            });
+
+            it('can delete module rather then entrance exam', function(){
+                expect(new XBlockInfo({'category': 'chapter', 'override_type': {'is_entrance_exam':false}}).canBeDeleted()).toBe(true);
+                expect(new XBlockInfo({'category': 'chapter', 'override_type': {}}).canBeDeleted()).toBe(true);
+            });
         });
     }
 );

--- a/common/lib/xmodule/xmodule/seq_module.py
+++ b/common/lib/xmodule/xmodule/seq_module.py
@@ -52,7 +52,7 @@ class SequenceFields(object):
             "Tag this course module as an Entrance Exam.  " +
             "Note, you must enable Entrance Exams for this course setting to take effect."
         ),
-        scope=Scope.settings,
+        scope=Scope.content,
     )
 
 


### PR DESCRIPTION
@cahrens -- added a new non-editable-metadata block to the SequenceDescriptor and included the is_entrance_exam flag.

Also included in this PR are some follow-on Jasmine tests to increase acceptance test coverage.

local tests, coverage, quality reports look good -- we'll see what Jenkins has to say
