### PR TITLE
Support for inline explanatory popups in problem XML

### DIFF
--- a/common/lib/capa/capa/customrender.py
+++ b/common/lib/capa/capa/customrender.py
@@ -6,8 +6,6 @@ These tags do not have state, so they just get passed the system (for access to 
 and the xml element.
 """
 
-from .registry import TagRegistry
-
 import logging
 import re
 
@@ -137,3 +135,35 @@ class TargetedFeedbackRenderer(object):
         return xhtml
 
 registry.register(TargetedFeedbackRenderer)
+
+#-----------------------------------------------------------------------------
+
+
+class ClarificationRenderer(object):
+    """
+    A clarification appears as an inline icon which reveals more information when the user
+    hovers over it.
+
+    e.g. <p>Enter the ROA <clarification>Return on Assets</clarification> for 2015:</p>
+    """
+    tags = ['clarification']
+
+    def __init__(self, system, xml):
+        self.system = system
+        # Get any text content found inside this tag prior to the first child tag. It may be a string or None type.
+        initial_text = xml.text if xml.text else ''
+        self.inner_html = initial_text + ''.join(etree.tostring(element) for element in xml)  # pylint: disable=no-member
+        self.tail = xml.tail
+
+    def get_html(self):
+        """
+        Return the contents of this tag, rendered to html, as an etree element.
+        """
+        context = {'clarification': self.inner_html}
+        html = self.system.render_template("clarification.html", context)
+        xml = etree.XML(html)  # pylint: disable=no-member
+        # We must include any text that was following our original <clarification>...</clarification> XML node.:
+        xml.tail = self.tail
+        return xml
+
+registry.register(ClarificationRenderer)

--- a/common/lib/capa/capa/templates/clarification.html
+++ b/common/lib/capa/capa/templates/clarification.html
@@ -1,0 +1,4 @@
+<span class="clarification">
+	<i data-tooltip="${clarification | h}" data-tooltip-show-on-click="true" class="fa fa-info-circle"></i>
+    <span class="sr">(${clarification})</span>
+</span>

--- a/common/lib/capa/capa/templates/clarification.html
+++ b/common/lib/capa/capa/templates/clarification.html
@@ -1,4 +1,5 @@
-<span class="clarification">
-	<i data-tooltip="${clarification | h}" data-tooltip-show-on-click="true" class="fa fa-info-circle"></i>
+<span class="clarification" tabindex="0" role="note" aria-label="Clarification">
+    <i data-tooltip="${clarification | h}" data-tooltip-show-on-click="true"
+       class="fa fa-info-circle" aria-hidden="true"></i>
     <span class="sr">(${clarification})</span>
 </span>

--- a/common/lib/xmodule/xmodule/css/capa/display.scss
+++ b/common/lib/xmodule/xmodule/css/capa/display.scss
@@ -162,6 +162,12 @@ div.problem {
         white-space: nowrap;
         overflow: hidden;
       }
+      span.clarification i {
+        font-style: normal;
+        &:hover {
+          color: $blue;
+        }
+      }
     }
 
     &.unanswered {

--- a/common/lib/xmodule/xmodule/js/src/capa/display.coffee
+++ b/common/lib/xmodule/xmodule/js/src/capa/display.coffee
@@ -34,6 +34,17 @@ class @Problem
     @$('div.action input.reset').click @reset
     @$('div.action button.show').click @show
     @$('div.action input.save').click @save
+    # Accessibility helper for sighted keyboard users to show <clarification> tooltips on focus:
+    @$('.clarification').focus (ev) =>
+      icon = $(ev.target).children "i"
+      iconPos = icon.offset()
+      fakeEvent = jQuery.Event "mouseover", {
+        pageX: iconPos.left + icon.width()/2,
+        pageY: iconPos.top + icon.height()/2
+      }
+      icon.trigger(fakeEvent).trigger "click"
+    @$('.clarification').blur (ev) =>
+      $(ev.target).children("i").trigger "mouseout"
 
     @bindResetCorrectness()
 

--- a/common/lib/xmodule/xmodule/js/src/capa/display.coffee
+++ b/common/lib/xmodule/xmodule/js/src/capa/display.coffee
@@ -37,14 +37,9 @@ class @Problem
     # Accessibility helper for sighted keyboard users to show <clarification> tooltips on focus:
     @$('.clarification').focus (ev) =>
       icon = $(ev.target).children "i"
-      iconPos = icon.offset()
-      fakeEvent = jQuery.Event "mouseover", {
-        pageX: iconPos.left + icon.width()/2,
-        pageY: iconPos.top + icon.height()/2
-      }
-      icon.trigger(fakeEvent).trigger "click"
+      window.globalTooltipManager.openTooltip icon
     @$('.clarification').blur (ev) =>
-      $(ev.target).children("i").trigger "mouseout"
+      window.globalTooltipManager.hide()
 
     @bindResetCorrectness()
 

--- a/common/static/js/spec/tooltip_manager_spec.js
+++ b/common/static/js/spec/tooltip_manager_spec.js
@@ -70,6 +70,12 @@ describe('TooltipManager', function () {
         expect($('.tooltip')).toBeHidden();
     });
 
+    it('can be configured to show when user clicks on the element', function () {
+        this.element.attr('data-tooltip-show-on-click', true);
+        this.element.trigger($.Event("click"));
+        expect($('.tooltip')).toBeVisible();
+    });
+
     it('should moves correctly', function () {
         showTooltip(this.element);
         expect($('.tooltip')).toBeVisible();

--- a/common/static/js/spec/tooltip_manager_spec.js
+++ b/common/static/js/spec/tooltip_manager_spec.js
@@ -76,6 +76,11 @@ describe('TooltipManager', function () {
         expect($('.tooltip')).toBeVisible();
     });
 
+    it('can be be triggered manually', function () {
+        this.tooltip.openTooltip(this.element);
+        expect($('.tooltip')).toBeVisible();
+    });
+
     it('should moves correctly', function () {
         showTooltip(this.element);
         expect($('.tooltip')).toBeVisible();

--- a/common/static/js/src/tooltip_manager.js
+++ b/common/static/js/src/tooltip_manager.js
@@ -46,15 +46,29 @@
         },
 
         showTooltip: function(event) {
-            var tooltipText = $(event.currentTarget).attr('data-tooltip');
-            this.tooltip
-                .html(tooltipText)
-                .css(this.getCoords(event.pageX, event.pageY));
-
+            this.prepareTooltip(event.currentTarget, event.pageX, event.pageY);
             if (this.tooltipTimer) {
                 clearTimeout(this.tooltipTimer);
             }
             this.tooltipTimer = setTimeout(this.show, 500);
+        },
+
+        prepareTooltip: function(element, pageX, pageY) {
+            pageX = typeof pageX !== 'undefined' ? pageX : element.offset().left + element.width()/2;
+            pageY = typeof pageY !== 'undefined' ? pageY : element.offset().top + element.height()/2;
+            var tooltipText = $(element).attr('data-tooltip');
+            this.tooltip
+                .html(tooltipText)
+                .css(this.getCoords(pageX, pageY));
+        },
+
+        // To manually trigger a tooltip to reveal, other than through user mouse movement:
+        openTooltip: function(element) {
+            this.prepareTooltip(element);
+            this.show();
+            if (this.tooltipTimer) {
+                clearTimeout(this.tooltipTimer);
+            }
         },
 
         moveTooltip: function(event) {
@@ -90,6 +104,6 @@
 
     window.TooltipManager = TooltipManager;
     $(document).ready(function () {
-        new TooltipManager(document.body);
+        window.globalTooltipManager = new TooltipManager(document.body);
     });
 }());

--- a/common/static/js/src/tooltip_manager.js
+++ b/common/static/js/src/tooltip_manager.js
@@ -26,7 +26,7 @@
                 'mouseover.TooltipManager': this.showTooltip,
                 'mousemove.TooltipManager': this.moveTooltip,
                 'mouseout.TooltipManager': this.hideTooltip,
-                'click.TooltipManager': this.hideTooltip
+                'click.TooltipManager': this.click
             }, this.SELECTOR);
         },
 
@@ -66,6 +66,18 @@
             // Wait for a 50ms before hiding the tooltip to avoid blinking when
             // the item contains nested elements.
             this.tooltipTimer = setTimeout(this.hide, 50);
+        },
+
+        click: function(event) {
+            var showOnClick = !!$(event.currentTarget).data('tooltip-show-on-click'); // Default is false
+            if (showOnClick) {
+                this.show();
+                if (this.tooltipTimer) {
+                    clearTimeout(this.tooltipTimer);
+                }
+            } else {
+                this.hideTooltip(event);
+            }
         },
 
         destroy: function () {

--- a/common/test/acceptance/pages/lms/problem.py
+++ b/common/test/acceptance/pages/lms/problem.py
@@ -46,3 +46,19 @@ class ProblemPage(PageObject):
         Is there a "correct" status showing?
         """
         return self.q(css="div.problem div.capa_inputtype.textline div.correct p.status").is_present()
+
+    def click_clarification(self, index=0):
+        """
+        Click on an inline icon that can be included in problem text using an HTML <clarification> element:
+
+        Problem <clarification>clarification text hidden by an icon in rendering</clarification> Text
+        """
+        self.q(css='div.problem .clarification:nth-child({index}) i[data-tooltip]'.format(index=index + 1)).click()
+
+    @property
+    def visible_tooltip_text(self):
+        """
+        Get the text seen in any tooltip currently visible on the page.
+        """
+        self.wait_for_element_visibility('body > .tooltip', 'A tooltip is visible.')
+        return self.q(css='body > .tooltip').text[0]

--- a/common/test/acceptance/tests/lms/test_lms_problems.py
+++ b/common/test/acceptance/tests/lms/test_lms_problems.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+"""
+Bok choy acceptance tests for problems in the LMS
+
+See also old lettuce tests in lms/djangoapps/courseware/features/problems.feature
+"""
+from ..helpers import UniqueCourseTest
+from ...pages.studio.auto_auth import AutoAuthPage
+from ...pages.lms.courseware import CoursewarePage
+from ...pages.lms.problem import ProblemPage
+from ...fixtures.course import CourseFixture, XBlockFixtureDesc
+from textwrap import dedent
+
+
+class ProblemsTest(UniqueCourseTest):
+    """
+    Base class for tests of problems in the LMS.
+    """
+    USERNAME = "joe_student"
+    EMAIL = "joe@example.com"
+
+    def setUp(self):
+        super(ProblemsTest, self).setUp()
+
+        self.xqueue_grade_response = None
+
+        self.courseware_page = CoursewarePage(self.browser, self.course_id)
+
+        # Install a course with a hierarchy and problems
+        course_fixture = CourseFixture(
+            self.course_info['org'], self.course_info['number'],
+            self.course_info['run'], self.course_info['display_name']
+        )
+
+        problem = self.get_problem()
+        course_fixture.add_children(
+            XBlockFixtureDesc('chapter', 'Test Section').add_children(
+                XBlockFixtureDesc('sequential', 'Test Subsection').add_children(problem)
+            )
+        ).install()
+
+        # Auto-auth register for the course.
+        AutoAuthPage(self.browser, username=self.USERNAME, email=self.EMAIL,
+                     course_id=self.course_id, staff=False).visit()
+
+    def get_problem(self):
+        """ Subclasses should override this to complete the fixture """
+        raise NotImplementedError()
+
+
+class ProblemClarificationTest(ProblemsTest):
+    """
+    Tests the <clarification> element that can be used in problem XML.
+    """
+    def get_problem(self):
+        """
+        Create a problem with a <clarification>
+        """
+        xml = dedent("""
+            <problem markdown="null">
+                <text>
+                    <p>
+                        Given the data in Table 7 <clarification>Table 7: "Example PV Installation Costs",
+                        Page 171 of Roberts textbook</clarification>, compute the ROI
+                        <clarification>Return on Investment <strong>(per year)</strong></clarification> over 20 years.
+                    </p>
+                    <numericalresponse answer="6.5">
+                        <textline label="Enter the annual ROI" trailing_text="%" />
+                    </numericalresponse>
+                </text>
+            </problem>
+        """)
+        return XBlockFixtureDesc('problem', 'TOOLTIP TEST PROBLEM', data=xml)
+
+    def test_clarification(self):
+        """
+        Test that we can see the <clarification> tooltips.
+        """
+        self.courseware_page.visit()
+        problem_page = ProblemPage(self.browser)
+        self.assertEqual(problem_page.problem_name, 'TOOLTIP TEST PROBLEM')
+        problem_page.click_clarification(0)
+        self.assertIn('"Example PV Installation Costs"', problem_page.visible_tooltip_text)
+        problem_page.click_clarification(1)
+        tooltip_text = problem_page.visible_tooltip_text
+        self.assertIn('Return on Investment', tooltip_text)
+        self.assertIn('per year', tooltip_text)
+        self.assertNotIn('strong', tooltip_text)


### PR DESCRIPTION
**Description**: This patch implements the ability to add an inline marker in the text of problems, which can reveal more information to the user when he hovers over it. This allows course authors to keep the main problem text succinct, while still providing extra information for students who need it. It requires the advanced XML editor. It was created for the University of St. Gallen by OpenCraft, and we'd like to contribute it to upstream.

**Components affected**: Studio, LMS

**Discussions**: None

**Prior code reviews**: Internal code review at https://github.com/open-craft/edx-platform/pull/29

**Partner information**: 3rd party-hosted open edX instance

**Merge deadline**: would be nice to have it merged by to minimize code drift, but not an edX partner so no hard requirement

**JIRA**: [OSPR-353](https://openedx.atlassian.net/browse/OSPR-353)
### Screenshots

Below you can see a two clarification markers - the one on the right is active because the user is hovering over it. There is an un-hovered state seen on the left.
![screen shot 2015-02-04 at 5 21 18 pm](https://cloud.githubusercontent.com/assets/945577/6053285/58220f74-ac92-11e4-872b-26459f2c8742.png)

The tooltips can also contain HTML as demonstrated above (&lt;strong&gt; tag around "ROI").
### XML Example

The following XML is taken from the bok choy test:

``` xml
<problem markdown="null">
    <p>
        Given the data in Table 7 <clarification>Table 7: "Example PV Installation Costs",
        Page 171 of Roberts textbook</clarification>, compute the ROI
        <clarification>Return on Investment <strong>(per year)</strong></clarification> over 20 years.
    </p>
    <numericalresponse answer="6.5">
        <textline label="Enter the annual ROI" trailing_text="%" />
    </numericalresponse>
</problem>
```
