### PR TITLE
Add gitlogs link to instructor dashboard

### DIFF
--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -241,6 +241,9 @@ def _section_course_info(course, access):
         message = _("Enrollment data is now available in {dashboard_link}.").format(dashboard_link=dashboard_link)
         section_data['enrollment_message'] = message
 
+    if settings.FEATURES.get('ENABLE_SYSADMIN_DASHBOARD'):
+        section_data['detailed_gitlogs_url'] = reverse('gitlogs_detail', kwargs={'course_id': unicode(course_key)})
+
     try:
         advance = lambda memo, (letter, score): "{}: {}, ".format(letter, score) + memo
         section_data['grade_cutoffs'] = reduce(advance, course.grade_cutoffs.items(), "")[:-2]

--- a/lms/templates/instructor/instructor_dashboard_2/course_info.html
+++ b/lms/templates/instructor/instructor_dashboard_2/course_info.html
@@ -70,12 +70,21 @@
       <b>${_("No")}</b>
       %endif
     </li>
-
     <li class="field text is-not-editable" id="field-grade-cutoffs">
       <label for="start-date">${_("Grade Cutoffs:")}</label>
       <b>${ section_data['grade_cutoffs'] }</b>
     </li>
   </ul>
+
+  %if settings.FEATURES.get('ENABLE_SYSADMIN_DASHBOARD', ''):
+      <p>
+        ## Translators: git is a version-control system; see http://git-scm.com/about
+        ${_("View detailed Git import logs for this course {link_start}by clicking here{link_end}.").format(
+            link_start='<a href="{}">'.format(section_data['detailed_gitlogs_url']),
+            link_end='</a>'
+        )}
+      </p>
+  %endif
 </div>
 
 


### PR DESCRIPTION
This allows staff/instructors to easily access relevant gitlogs from the instructor dashboard.
![Instructor dashboard](http://i.imgur.com/C4H2bXB.png)
