### PR TITLE
Add possibility to play video from localhost.

### DIFF
--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -212,11 +212,15 @@ class VideoModule(VideoFields, VideoTranscriptsMixin, VideoStudentViewHandlers, 
         # 'CN' is China ISO 3166-1 country code.
         # Video caching is disabled for Studio. User_location is always None in Studio.
         # CountryMiddleware disabled for Studio.
-        cdn_url = getattr(settings, 'VIDEO_CDN_URL', {}).get(self.system.user_location)
+        cdn_url = getattr(settings, 'VIDEO_CDN_URL', {}).get(self.system.user_location) or settings.FEATURES.get('PLAY_VIDEO_LOCAL', False)
 
         if getattr(self, 'video_speed_optimizations', True) and cdn_url:
             for index, source_url in enumerate(sources):
-                new_url = get_video_from_cdn(cdn_url, source_url)
+                new_url = get_video_from_cdn(
+                    cdn_url,
+                    source_url,
+                    play_video_local=settings.FEATURES.get('PLAY_VIDEO_LOCAL', False)
+                )
                 if new_url:
                     sources[index] = new_url
 

--- a/common/lib/xmodule/xmodule/video_module/video_utils.py
+++ b/common/lib/xmodule/xmodule/video_module/video_utils.py
@@ -5,6 +5,7 @@ import json
 import logging
 import urllib
 import requests
+import urlparse
 
 from requests.exceptions import RequestException
 
@@ -33,7 +34,7 @@ def create_youtube_string(module):
     ])
 
 
-def get_video_from_cdn(cdn_base_url, original_video_url):
+def get_video_from_cdn(cdn_base_url, original_video_url, **kwargs):
     """
     Get video URL from CDN.
 
@@ -54,6 +55,12 @@ def get_video_from_cdn(cdn_base_url, original_video_url):
 
     if not cdn_base_url:
         return None
+
+    if kwargs.get('play_video_local'):
+        scheme, netloc = cdn_base_url.split('://')
+        parsed = urlparse.urlparse(original_video_url)
+        replaced = parsed._replace(netloc=netloc, scheme=scheme)
+        return replaced.geturl()
 
     request_url = cdn_base_url + urllib.quote(original_video_url)
 


### PR DESCRIPTION
This PR allows to host video for Open edX courses on local hard drive w/o access to internet.

Single prerequisite is nginx set up to host video and video files.

Short how-to:
1. Download all videos. Save their url names.
2. Install nginx. Actually even w/o additional modules for video streaming nginx will work. Setup nginx: 
   For example, root entry point is /Users/kry/repos/edx/videos. Then in default nginx config set

```
        location / {
            root   /Users/kry/repos/edx/videos;
            index  index.html index.htm;
            autoindex on;
        }
```

If Open edX video has url: "https://s3.amazonaws.com/edx-course-videos/edx-intro/edX-FA12-cware-1_100.mp4", then if entry point " /Users/kry/repos/edx/videos", create subfolders edx-course-videos/edx-intro, and copy video to the inner, so path to video on local drive will be: "/Users/kry/repos/edx/videos/edx-course-videos/edx-intro/"

To enable feature add 

```
"PLAY_VIDEO_LOCAL": "http://localhost:8080"
```

to FEATURES dict in  lms.env.json file, where http://localhost:8080 is url for  nginx site with hosted videos.
Note, that VIDEO_CDN_URL for country that feature will be used, should not be set.
And video_speed_optimizations flag should be set to true in properties of the video unit (it is set to true by default).

@pmitros please review
