### PR TITLE
Inline the user api form description calls

### DIFF
--- a/lms/djangoapps/student_account/test/test_views.py
+++ b/lms/djangoapps/student_account/test/test_views.py
@@ -8,6 +8,7 @@ import json
 
 import mock
 import ddt
+import markupsafe
 from django.test import TestCase
 from django.conf import settings
 from django.core.urlresolvers import reverse
@@ -551,11 +552,15 @@ class StudentAccountLoginAndRegistrationTest(ModuleStoreTestCase):
 
     def _assert_third_party_auth_data(self, response, current_provider, providers):
         """Verify that third party auth info is rendered correctly in a DOM data attribute. """
-        expected_data = u"data-third-party-auth='{auth_info}'".format(
-            auth_info=json.dumps({
+        auth_info = markupsafe.escape(
+            json.dumps({
                 "currentProvider": current_provider,
                 "providers": providers
             })
+        )
+
+        expected_data = u"data-third-party-auth='{auth_info}'".format(
+            auth_info=auth_info
         )
         self.assertContains(response, expected_data)
 

--- a/lms/static/js/spec/student_account/access_spec.js
+++ b/lms/static/js/spec/student_account/access_spec.js
@@ -13,20 +13,6 @@ define([
 
             var requests = null,
                 view = null,
-                AJAX_INFO = {
-                    register: {
-                        url: '/user_api/v1/account/registration/',
-                        requestIndex: 1
-                    },
-                    login: {
-                        url: '/user_api/v1/account/login_session/',
-                        requestIndex: 0
-                    },
-                    password_reset: {
-                        url: '/user_api/v1/account/password_reset/',
-                        requestIndex: 1
-                    }
-                },
                 FORM_DESCRIPTION = {
                     method: 'post',
                     submit_url: '/submit',
@@ -58,16 +44,6 @@ define([
                 FORWARD_URL = '/courseware/next',
                 COURSE_KEY = 'edx/DemoX/Fall';
 
-            var ajaxAssertAndRespond = function(url, requestIndex) {
-                // Verify that the client contacts the server as expected
-                AjaxHelpers.expectJsonRequest(requests, 'GET', url, null, requestIndex);
-
-                /* Simulate a response from the server containing
-                /* a dummy form description
-                 */
-                AjaxHelpers.respondWithJson(requests, FORM_DESCRIPTION);
-            };
-
             var ajaxSpyAndInitialize = function(that, mode) {
                 // Spy on AJAX requests
                 requests = AjaxHelpers.requests(that);
@@ -79,7 +55,10 @@ define([
                         currentProvider: null,
                         providers: []
                     },
-                    platformName: 'edX'
+                    platformName: 'edX',
+                    loginFormDesc: FORM_DESCRIPTION,
+                    registrationFormDesc: FORM_DESCRIPTION,
+                    passwordResetFormDesc: FORM_DESCRIPTION
                 });
 
                 // Mock the redirect call
@@ -88,9 +67,6 @@ define([
                 // Mock the enrollment and shopping cart interfaces
                 spyOn( EnrollmentInterface, 'enroll' ).andCallFake( function() {} );
                 spyOn( ShoppingCartInterface, 'addCourseToCart' ).andCallFake( function() {} );
-
-                // Initialize the subview
-                ajaxAssertAndRespond(AJAX_INFO[mode].url);
             };
 
             var assertForms = function(visibleType, hiddenType) {
@@ -106,8 +82,6 @@ define([
 
                 // Load form corresponding to the change event
                 view.toggleForm(changeEvent);
-
-                ajaxAssertAndRespond(AJAX_INFO[type].url, AJAX_INFO[type].requestIndex);
             };
 
             /**
@@ -174,11 +148,6 @@ define([
 
                 // Simulate a click on the reset password link
                 view.resetPassword();
-
-                ajaxAssertAndRespond(
-                    AJAX_INFO.password_reset.url,
-                    AJAX_INFO.password_reset.requestIndex
-                );
 
                 // Verify that the password reset wrapper is populated
                 expect($('#password-reset-wrapper')).not.toBeEmpty();
@@ -253,26 +222,6 @@ define([
                 expect( view.redirect ).toHaveBeenCalledWith( "/dashboard" );
             });
 
-            it('displays an error if a form definition could not be loaded', function() {
-                // Spy on AJAX requests
-                requests = AjaxHelpers.requests(this);
-
-                // Init AccessView
-                view = new AccessView({
-                    mode: 'login',
-                    thirdPartyAuth: {
-                        currentProvider: null,
-                        providers: []
-                    },
-                    platformName: 'edX'
-                });
-
-                // Simulate an error from the LMS servers
-                AjaxHelpers.respondWithError(requests);
-
-                // Error message should be displayed
-                expect( $('#form-load-fail').hasClass('hidden') ).toBe(false);
-            });
         });
     }
 );

--- a/lms/static/js/student_account/accessApp.js
+++ b/lms/static/js/student_account/accessApp.js
@@ -6,9 +6,14 @@ var edx = edx || {};
     edx.student = edx.student || {};
     edx.student.account = edx.student.account || {};
 
+    var container = $('#login-and-registration-container');
+
     return new edx.student.account.AccessView({
-        mode: $('#login-and-registration-container').data('initial-mode'),
-        thirdPartyAuth: $('#login-and-registration-container').data('third-party-auth'),
-        platformName: $('#login-and-registration-container').data('platform-name')
+        mode: container.data('initial-mode'),
+        thirdPartyAuth: container.data('third-party-auth'),
+        platformName: container.data('platform-name'),
+        loginFormDesc: container.data('login-form-desc'),
+        registrationFormDesc: container.data('registration-form-desc'),
+        passwordResetFormDesc: container.data('password-reset-form-desc')
     });
 })(jQuery);

--- a/lms/templates/student_account/access.underscore
+++ b/lms/templates/student_account/access.underscore
@@ -1,9 +1,3 @@
-<section id="form-load-fail" class="form-type hidden">
-    <div class="status submission-error">
-        <p class="message-copy"><%- gettext("Sorry, we're having some technical problems. Wait a few minutes and try again.") %></p>
-    </div>
-</section>
-
 <section id="login-anchor" class="form-type">
     <div id="login-form" class="form-wrapper <% if ( mode !== 'login' ) { %>hidden<% } %>"></div>
 </section>

--- a/lms/templates/student_account/login_and_register.html
+++ b/lms/templates/student_account/login_and_register.html
@@ -26,8 +26,11 @@
     <div id="login-and-registration-container"
         class="login-register"
         data-initial-mode="${initial_mode}"
-        data-third-party-auth='${third_party_auth}'
+        data-third-party-auth='${third_party_auth|h}'
         data-platform-name='${platform_name}'
+        data-login-form-desc='${login_form_desc|h}'
+        data-registration-form-desc='${registration_form_desc|h}'
+        data-password-reset-form-desc='${password_reset_form_desc|h}'
     />
 </div>
 


### PR DESCRIPTION
In the initial implementation of the combined login/registration page, JavaScript in the new form was responsible for contacting the User API directly in order to determine how to render the login, registration, and password reset forms.  The main motivation for this design was encapsulation: we wanted to ensure that any client (JS, mobile, etc.) could render and submit these forms using only the User API. 

The encapsulation came at a performance cost, however, since the user's browser required a second round-trip to retrieve the form definition.

In this PR, I've replaced the AJAX call in the User API with a simulated server-server call.  This change eliminates one round-trip to the server, saving approximately 100 ms (tested on a sandbox; the savings could be higher for users further away from our app servers).

I also played around a bit with in-memory caching of the form descriptions but didn't see any improvement in the response times, so I did not make those changes in this PR.

@stephensanchez @AlasdairSwan please review.
