### PR TITLE
Removing html comments before indexing html content

### DIFF
--- a/common/lib/xmodule/xmodule/html_module.py
+++ b/common/lib/xmodule/xmodule/html_module.py
@@ -258,6 +258,7 @@ class HtmlDescriptor(HtmlFields, XmlDescriptor, EditingDescriptor):
         xblock_body = super(HtmlDescriptor, self).index_dictionary()
         html_content = re.sub(r"(\s|&nbsp;|//)+", " ", html_to_text(self.data))
         html_content = re.sub(r"<!\[CDATA\[.*\]\]>", "", html_content)
+        html_content = re.sub(r"<!--.*-->", "", html_content)
         html_body = {
             "html_content": html_content,
             "display_name": self.display_name,

--- a/common/lib/xmodule/xmodule/tests/test_html_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_html_module.py
@@ -94,3 +94,30 @@ class HtmlDescriptorIndexingTestCase(unittest.TestCase):
             "content": {"html_content": " Text has spaces :) ", "display_name": "Text"},
             "content_type": "HTML Content"
         })
+
+        sample_xml_comment = '''
+            <html>
+                <p>This has HTML comment in it.</p>
+                <!-- Html Comment -->
+            </html>
+        '''
+        descriptor = instantiate_descriptor(data=sample_xml_comment)
+        self.assertEqual(descriptor.index_dictionary(), {
+            "content": {"html_content": " This has HTML comment in it. ", "display_name": "Text"},
+            "content_type": "HTML Content"
+        })
+
+        sample_xml_mix_comment_cdata = '''
+            <html>
+                <!-- Beginning of the html -->
+                <p>This has HTML comment in it.<!-- Commenting Content --></p>
+                <!-- Here comes CDATA -->
+                <![CDATA[This is just a CDATA!]]>
+                <p>HTML end.</p>
+            </html>
+        '''
+        descriptor = instantiate_descriptor(data=sample_xml_mix_comment_cdata)
+        self.assertEqual(descriptor.index_dictionary(), {
+            "content": {"html_content": " This has HTML comment in it. HTML end. ", "display_name": "Text"},
+            "content_type": "HTML Content"
+        })


### PR DESCRIPTION
@martynjames please review this. Now, every html xmodule should omit html comments from html_content that's been indexed.
