### PR TITLE
Disable flaky bok-choy tests of payment and verification flow

### DIFF
--- a/common/test/acceptance/tests/lms/test_lms.py
+++ b/common/test/acceptance/tests/lms/test_lms.py
@@ -242,6 +242,7 @@ class RegisterFromCombinedPageTest(UniqueCourseTest):
         self.assertEqual(self.register_page.current_form, "login")
 
 
+@skip('ECOM-956: Failing intermittently due to 500 errors when trying to hit the mode creation endpoint.')
 @attr('shard_1')
 class PayAndVerifyTest(UniqueCourseTest):
     """Test that we can proceed through the payment and verification flow."""


### PR DESCRIPTION
@wedaly, as discussed in [ECOM-956](https://openedx.atlassian.net/browse/ECOM-956). We can re-enable the tests in a separate PR once we have a fix.

@jzoldak, FYI.
