### PR TITLE
Reorganize indexing to be implemented inside a mix-in

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -122,13 +122,13 @@ def get_course_and_check_access(course_key, user, depth=0):
     return course_module
 
 
-def reindex_course_and_check_access(course_key, user, depth=0):
+def reindex_course_and_check_access(course_key, user):
     """
     Internal method used to restart indexing on a course.
     """
     if not has_course_author_access(user, course_key):
         raise PermissionDenied()
-    return modulestore().do_index(course_key, depth=depth)
+    return modulestore().do_course_reindex(course_key)
 
 
 @login_required
@@ -308,7 +308,7 @@ def course_index_handler(request, course_key_string):
     course_key = CourseKey.from_string(course_key_string)
     with modulestore().bulk_operations(course_key):
         if request.method == 'GET':
-            error = reindex_course_and_check_access(course_key, request.user, depth=3)
+            error = reindex_course_and_check_access(course_key, request.user)
             if error:
                 return HttpResponse(
                     json.dumps({"status": error}),

--- a/cms/envs/bok_choy.py
+++ b/cms/envs/bok_choy.py
@@ -74,7 +74,12 @@ YOUTUBE['TEXT_API']['url'] = "127.0.0.1:{0}/test_transcripts_youtube/".format(YO
 
 FEATURES['ENABLE_COURSEWARE_INDEX'] = True
 SEARCH_ENGINE = "search.tests.mock_search_engine.MockSearchEngine"
-MOCK_SEARCH_BACKING_FILE = (TEST_ROOT / "index_file.dat").abspath()
+# Path at which to store the mock index - can remove disable=invalid-name
+# once global settings are set to disable this error and
+# disable=no-value-for-parameter follow the pattern above
+MOCK_SEARCH_BACKING_FILE = (  # pylint: disable=invalid-name
+    TEST_ROOT / "index_file.dat"  # pylint: disable=no-value-for-parameter
+).abspath()
 
 #####################################################################
 # Lastly, see if the developer has any local overrides.

--- a/common/lib/xmodule/xmodule/modulestore/courseware_index.py
+++ b/common/lib/xmodule/xmodule/modulestore/courseware_index.py
@@ -1,0 +1,118 @@
+""" Code to allow module store to interface with courseware index """
+from __future__ import absolute_import
+
+import logging
+
+from opaque_keys.edx.locator import CourseLocator
+from search.search_engine_base import SearchEngine
+
+from . import ModuleStoreEnum
+from .exceptions import ItemNotFoundError
+
+# Use default index and document names for now
+INDEX_NAME = "courseware_index"
+DOCUMENT_TYPE = "courseware_content"
+
+log = logging.getLogger('edx.modulestore')
+
+
+class IndexWriteError(Exception):
+
+    """ Raised to indicate that indexing of particular key failed """
+    pass
+
+
+class ModuleStoreCoursewareIndexMixin(object):
+
+    """
+    Mixin class to enable indexing for courseware search from different modulestores
+    """
+
+    def do_index(self, location, delete=False):
+        """
+        Main routine to index (for purposes of searching) from given location and other stuff on down
+        """
+        error = []
+        # TODO - inline for now, need to move this out to a celery task
+        searcher = SearchEngine.get_search_engine(INDEX_NAME)
+        if not searcher:
+            return
+
+        course_key = location if isinstance(location, CourseLocator) else location.course_key
+        location_info = {
+            "course": unicode(course_key),
+        }
+
+        def _fetch_item(item_location):
+            """ Fetch the item from the modulestore location, log if not found, but continue """
+            try:
+                if isinstance(item_location, CourseLocator):
+                    item = self.get_course(item_location)
+                else:
+                    item = self.get_item(item_location, revision=ModuleStoreEnum.RevisionOption.published_only)
+            except ItemNotFoundError:
+                log.warning('Cannot find: %s', item_location)
+                return None
+
+            return item
+
+        def index_item_location(item_location, current_start_date):
+            """ add this item to the search index """
+            item = _fetch_item(item_location)
+            if item:
+                if item.category in ['course', 'chapter', 'sequential', 'vertical', 'html', 'video']:
+                    if item.start and (not current_start_date or item.start > current_start_date):
+                        current_start_date = item.start
+
+                    if item.has_children:
+                        for child_loc in item.children:
+                            index_item_location(child_loc, current_start_date)
+
+                    item_index = {}
+                    try:
+                        item_index.update(location_info)
+                        item_index.update(item.index_dictionary())
+                        item_index.update({
+                            'id': unicode(item.scope_ids.usage_id),
+                        })
+
+                        if current_start_date:
+                            item_index.update({
+                                "start_date": current_start_date
+                            })
+
+                        searcher.index(DOCUMENT_TYPE, item_index)
+                    except IndexWriteError:
+                        log.warning('Could not index item: %s', item_location)
+                        error.append('Could not index item: {}'.format(item_location))
+
+        def remove_index_item_location(item_location):
+            """ remove this item from the search index """
+            item = _fetch_item(item_location)
+            if item:
+                if item.has_children:
+                    for child_loc in item.children:
+                        remove_index_item_location(child_loc)
+
+                searcher.remove(DOCUMENT_TYPE, unicode(item.scope_ids.usage_id))
+
+        try:
+            if delete:
+                remove_index_item_location(location)
+            else:
+                index_item_location(location, None)
+        except Exception as err:  # pylint: disable=broad-except
+            # broad exception so that index operation does not prevent the rest of the application from working
+            log.exception(
+                "Indexing error encountered, courseware index may be out of date %s - %s",
+                location.course_key,
+                str(err)
+            )
+
+        return error
+
+    def do_course_reindex(self, course_key):
+        """
+        Get the course with the given courseid (org/course/run)
+        """
+        return self.do_index(course_key, delete=False)

--- a/common/lib/xmodule/xmodule/modulestore/mixed.py
+++ b/common/lib/xmodule/xmodule/modulestore/mixed.py
@@ -19,6 +19,7 @@ from xmodule.assetstore import AssetMetadata
 
 from . import ModuleStoreWriteBase
 from . import ModuleStoreEnum
+from .courseware_index import ModuleStoreCoursewareIndexMixin
 from .exceptions import ItemNotFoundError, DuplicateCourseError
 from .draft_and_published import ModuleStoreDraftAndPublished
 from .split_migrator import SplitMigrator
@@ -95,7 +96,7 @@ def strip_key(func):
     return inner
 
 
-class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
+class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, ModuleStoreCoursewareIndexMixin):
     """
     ModuleStore knows how to route requests to the right persistence ms
     """
@@ -318,21 +319,6 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
         store = self._get_modulestore_for_courseid(course_key)
         try:
             return store.get_course(course_key, depth=depth, **kwargs)
-        except ItemNotFoundError:
-            return None
-
-    @strip_key
-    def do_index(self, course_key, depth=0, **kwargs):
-        """
-        restarts index on a course with the course_id. If no such course exists,
-        it returns None
-
-        :param course_key: must be a CourseKey
-        """
-        assert(isinstance(course_key, CourseKey))
-        store = self._get_modulestore_for_courseid(course_key)
-        try:
-            return store.do_course_reindex(course_key, depth=depth, **kwargs)
         except ItemNotFoundError:
             return None
 

--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -44,13 +44,12 @@ from xmodule.errortracker import null_error_tracker, exc_info_to_str
 from xmodule.exceptions import HeartbeatFailure
 from xmodule.mako_module import MakoDescriptorSystem
 from xmodule.modulestore import ModuleStoreWriteBase, ModuleStoreEnum, BulkOperationsMixin, BulkOpsRecord
+from xmodule.modulestore.courseware_index import ModuleStoreCoursewareIndexMixin
 from xmodule.modulestore.draft_and_published import ModuleStoreDraftAndPublished, DIRECT_ONLY_CATEGORIES
 from xmodule.modulestore.edit_info import EditInfoRuntimeMixin
 from xmodule.modulestore.exceptions import ItemNotFoundError, DuplicateCourseError, ReferentialIntegrityError
 from xmodule.modulestore.inheritance import InheritanceMixin, inherit_metadata, InheritanceKeyValueStore
 from xmodule.modulestore.xml import CourseLocationManager
-
-from search.search_engine_base import SearchEngine
 
 log = logging.getLogger(__name__)
 
@@ -70,10 +69,6 @@ BLOCK_TYPES_WITH_CHILDREN = list(set(
     name for name, class_ in XBlock.load_classes() if getattr(class_, 'has_children', False)
 ))
 
-# Use default index and document names for now
-INDEX_NAME = "courseware_index"
-DOCUMENT_TYPE = "courseware_content"
-
 # Allow us to call _from_deprecated_(son|string) throughout the file
 # pylint: disable=protected-access
 
@@ -91,14 +86,6 @@ class InvalidWriteError(Exception):
     """
     Raised to indicate that writing to a particular key
     in the KeyValueStore is disabled
-    """
-    pass
-
-
-class IndexWriteError(Exception):
-    """
-    Raised to indicate that indexing of particular key
-    failed
     """
     pass
 
@@ -496,7 +483,7 @@ class ParentLocationCache(dict):
             del self[key]
 
 
-class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, MongoBulkOpsMixin):
+class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, MongoBulkOpsMixin, ModuleStoreCoursewareIndexMixin):
     """
     A Mongodb backed ModuleStore
     """
@@ -958,92 +945,6 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
             return self.get_item(location, depth=depth)
         except ItemNotFoundError:
             return None
-
-    def do_index(self, location, delete=False):
-        """
-        Main routine to index (for purposes of searching) from given location and other stuff on down
-        """
-        error = []
-        # TODO - inline for now, need to move this out to a celery task
-        searcher = SearchEngine.get_search_engine(INDEX_NAME)
-        if not searcher:
-            return
-
-        location_info = {
-            "course": unicode(location.course_key),
-        }
-
-        def _fetch_item(item_location):
-            """ Fetch the item from the modulestore location, log if not found, but continue """
-            try:
-                item = self.get_item(item_location, revision=ModuleStoreEnum.RevisionOption.published_only)
-            except ItemNotFoundError:
-                log.warning('Cannot find: %s', item_location)
-                return None
-
-            return item
-
-        def index_item_location(item_location, current_start_date):
-            """ add this item to the search index """
-            item = _fetch_item(item_location)
-            if item:
-                if item.category in ['course', 'chapter', 'sequential', 'vertical', 'html', 'video']:
-                    if item.start and (not current_start_date or item.start > current_start_date):
-                        current_start_date = item.start
-
-                    if item.has_children:
-                        for child_loc in item.children:
-                            index_item_location(child_loc, current_start_date)
-
-                    item_index = {}
-                    try:
-                        item_index.update(location_info)
-                        item_index.update(item.index_dictionary())
-                        item_index.update({
-                            'id': unicode(item.scope_ids.usage_id),
-                        })
-
-                        if current_start_date:
-                            item_index.update({
-                                "start_date": current_start_date
-                            })
-
-                        searcher.index(DOCUMENT_TYPE, item_index)
-                    except IndexWriteError:
-                        log.warning('Could not index item: %s', item_location)
-                        error.append('Could not index item: {}'.format(item_location))
-
-        def remove_index_item_location(item_location):
-            """ remove this item from the search index """
-            item = _fetch_item(item_location)
-            if item:
-                if item.has_children:
-                    for child_loc in item.children:
-                        remove_index_item_location(child_loc)
-
-                searcher.remove(DOCUMENT_TYPE, unicode(item.scope_ids.usage_id))
-
-        try:
-            if delete:
-                remove_index_item_location(location)
-            else:
-                index_item_location(location, None)
-        except Exception as err:  # pylint: disable=broad-except
-            # broad exception so that index operation does not prevent the rest of the application from working
-            log.exception(
-                "Indexing error encountered, courseware index may be out of date %s - %s",
-                location.course_key,
-                str(err)
-            )
-
-        return error
-
-    def do_course_reindex(self, course_key, depth=0, **kwargs):
-        """
-        Get the course with the given courseid (org/course/run)
-        """
-        location = course_key.make_usage_key('course', course_key.run)
-        return self.do_index(location, delete=False)
 
     def has_course(self, course_key, ignore_case=False, **kwargs):
         """

--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -276,7 +276,9 @@ class CachingDescriptorSystem(MakoDescriptorSystem, EditInfoRuntimeMixin):
                     raw_metadata = json_data.get('metadata', {})
                     # published_on was previously stored as a list of time components instead of a datetime
                     if raw_metadata.get('published_date'):
-                        module._edit_info['published_date'] = datetime(*raw_metadata.get('published_date')[0:6]).replace(tzinfo=UTC)
+                        module._edit_info['published_date'] = datetime(
+                            *raw_metadata.get('published_date')[0:6]
+                        ).replace(tzinfo=UTC)
                     module._edit_info['published_by'] = raw_metadata.get('published_by')
 
                 # decache any computed pending field settings

--- a/common/lib/xmodule/xmodule/modulestore/mongo/draft.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/draft.py
@@ -637,13 +637,6 @@ class DraftModuleStore(MongoModuleStore):
         else:
             return False
 
-    def do_course_reindex(self, course_key, depth=0, **kwargs):
-        """
-        Get the course with the given courseid (org/course/run)
-        """
-        location = course_key.make_usage_key('course', course_key.run)
-        return self.do_index(location, delete=False)
-
     def publish(self, location, user_id, **kwargs):
         """
         Publish the subtree rooted at location to the live course and remove the drafts.

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
@@ -78,6 +78,7 @@ from xmodule.modulestore import (
 
 from ..exceptions import ItemNotFoundError
 from .caching_descriptor_system import CachingDescriptorSystem
+from xmodule.modulestore.courseware_index import ModuleStoreCoursewareIndexMixin
 from xmodule.modulestore.split_mongo.mongo_connection import MongoConnection, DuplicateKeyError
 from xmodule.modulestore.split_mongo import BlockKey, CourseEnvelope
 from xmodule.error_module import ErrorDescriptor
@@ -591,7 +592,7 @@ class SplitBulkWriteMixin(BulkOperationsMixin):
         return structures
 
 
-class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
+class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase, ModuleStoreCoursewareIndexMixin):
     """
     A Mongodb backed ModuleStore supporting versions, inheritance,
     and sharing.

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split_draft.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split_draft.py
@@ -203,6 +203,8 @@ class DraftVersioningModuleStore(SplitMongoModuleStore, ModuleStoreDraftAndPubli
                 if branch == ModuleStoreEnum.BranchName.draft and branched_location.block_type in DIRECT_ONLY_CATEGORIES:
                     self.publish(parent_loc.version_agnostic(), user_id, blacklist=EXCLUDE_ALL, **kwargs)
 
+        self.do_index(location, delete=True)
+
     def _map_revision_to_branch(self, key, revision=None):
         """
         Maps RevisionOptions to BranchNames, inserting them into the key
@@ -345,6 +347,9 @@ class DraftVersioningModuleStore(SplitMongoModuleStore, ModuleStoreDraftAndPubli
             [location],
             blacklist=blacklist
         )
+
+        self.do_index(location)
+
         return self.get_item(location.for_branch(ModuleStoreEnum.BranchName.published), **kwargs)
 
     def unpublish(self, location, user_id, **kwargs):

--- a/lms/envs/bok_choy.py
+++ b/lms/envs/bok_choy.py
@@ -117,7 +117,12 @@ PASSWORD_COMPLEXITY = {}
 FEATURES['ENABLE_COURSEWARE_SEARCH'] = True
 # Use MockSearchEngine as the search engine for test scenario
 SEARCH_ENGINE = "search.tests.mock_search_engine.MockSearchEngine"
-MOCK_SEARCH_BACKING_FILE = (TEST_ROOT / "index_file.dat").abspath()
+# Path at which to store the mock index - can remove disable=invalid-name
+# once global settings are set to disable this error and
+# disable=no-value-for-parameter follow the pattern above
+MOCK_SEARCH_BACKING_FILE = (  # pylint: disable=invalid-name
+    TEST_ROOT / "index_file.dat"  # pylint: disable=no-value-for-parameter
+).abspath()
 
 #####################################################################
 # Lastly, see if the developer has any local overrides.


### PR DESCRIPTION
Allows easier integration into both draft and split store

@dino-cikatic - please check that this meets your intent - base.py does not actually include a base class for the 2 different module stores!

@cdodge, @chrisndodge, @singingwolfboy - FYI this will need to be integrated into feature branch
