### PR TITLE
ECOM-959 Making verification msg strings unicode friendly.

### DIFF
--- a/lms/djangoapps/verify_student/tests/test_views.py
+++ b/lms/djangoapps/verify_student/tests/test_views.py
@@ -309,6 +309,8 @@ class TestVerifiedView(ModuleStoreTestCase):
     """
     def setUp(self):
         self.user = UserFactory.create(username="abc", password="test")
+        self.user.profile.name = u"Røøsty Bøøgins"
+        self.user.save()
         self.client.login(username="abc", password="test")
         self.course = CourseFactory.create(org='MITx', number='999.1x', display_name='Verified Course')
         self.course_id = self.course.id
@@ -357,6 +359,8 @@ class TestReverifyView(ModuleStoreTestCase):
     """
     def setUp(self):
         self.user = UserFactory.create(username="rusty", password="test")
+        self.user.profile.name = u"Røøsty Bøøgins"
+        self.user.profile.save()
         self.client.login(username="rusty", password="test")
         self.course = CourseFactory.create(org='MITx', number='999', display_name='Robot Super Course')
         self.course_key = self.course.id

--- a/lms/templates/verify_student/photo_reverification.html
+++ b/lms/templates/verify_student/photo_reverification.html
@@ -347,8 +347,8 @@
                     <h4 class="title">${_("Check Your Name")}</h4>
 
                     <div class="copy">
-                        <p>${_("Make sure your full name on your {platform_name} account ({full_name}) matches your ID. We will also use this as the name on your certificate.").format(
-                          full_name="<span id='full-name'>{name}</span>".format(name=user_full_name),
+                        <p>${_(u"Make sure your full name on your {platform_name} account ({full_name}) matches your ID. We will also use this as the name on your certificate.").format(
+                          full_name=u"<span id='full-name'>{name}</span>".format(name=user_full_name),
                           platform_name=settings.PLATFORM_NAME,
                         )}</p>
                     </div>

--- a/lms/templates/verify_student/photo_verification.html
+++ b/lms/templates/verify_student/photo_verification.html
@@ -376,8 +376,8 @@
                     <h4 class="title">${_("Check Your Name")}</h4>
 
                     <div class="copy">
-                        <p>${_("Make sure your full name on your {platform_name} account ({full_name}) matches your ID. We will also use this as the name on your certificate.").format(
-                          full_name="<span id='full-name'>{name}</span>".format(name=user_full_name),
+                        <p>${_(u"Make sure your full name on your {platform_name} account ({full_name}) matches your ID. We will also use this as the name on your certificate.").format(
+                          full_name=u"<span id='full-name'>{name}</span>".format(name=user_full_name),
                           platform_name=settings.PLATFORM_NAME,
                         )}</p>
                     </div>


### PR DESCRIPTION
@wedaly @dianakhuang @rocha 

Fix against RC for https://openedx.atlassian.net/browse/ECOM-959
- Fixes the verification and re-verification workflow for usernames with unicode characters
- Simply converting a few strings to unicode
- Added tests that will now fail if the strings are not unicode.
