### PR TITLE
avoid database error when recording task exception

### DIFF
--- a/common/djangoapps/course_action_state/managers.py
+++ b/common/djangoapps/course_action_state/managers.py
@@ -143,7 +143,7 @@ class CourseRerunUIStateManager(CourseActionUIStateManager):
         self.update_state(
             course_key=course_key,
             new_state=self.State.FAILED,
-            message=traceback.format_exc(),
+            message=traceback.format_exc()[-self.model.MAX_MESSAGE_LENGTH:],  # truncate to fit
         )
 
 

--- a/common/djangoapps/course_action_state/models.py
+++ b/common/djangoapps/course_action_state/models.py
@@ -83,13 +83,17 @@ class CourseActionUIState(CourseActionState):
         """
         abstract = True
 
+    # WARNING - when you edit this value, you're also modifying the max_length
+    # of the `message` column (see below)
+    MAX_MESSAGE_LENGTH = 1000
+
     # FIELDS
 
     # Whether or not the status should be displayed to users
     should_display = models.BooleanField()
 
     # Message related to the status
-    message = models.CharField(max_length=1000)
+    message = models.CharField(max_length=MAX_MESSAGE_LENGTH)
 
 
 # Rerun courses also need these fields. All rerun course actions will have a row here as well.


### PR DESCRIPTION
@nasthagiri @dan-f  please review (non-urgent, but very small change)

this should fix a problem where processing a course rerun throws an exception, but the attempt to store that outcome in the database fails because the exception message is too long.
