### PR TITLE
Updated version of PyContracts.

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -143,7 +143,7 @@ rednose==0.3
 selenium==2.42.1
 splinter==0.5.4
 testtools==0.9.34
-PyContracts==1.6.5
+PyContracts==1.7.1
 
 # Used for Segment.io analytics
 analytics-python==0.4.4


### PR DESCRIPTION
The main reason for this upgrade is to include the functionality which disables contracts completely when the DISABLE_CONTRACTS environment variable is set.

This module is enabled in local and devstack environments only. It's disabled in staging and production environments.

This upgrade is low risk. Absolutely _no_ functionality in edx-platform depends on this module. The existing unit tests will ensure that the upgrade did not break the existing usage of the module. No communication to our user base is needed. No licensing changes occurred in this upgrade.
