### PR TITLE
Extended hint features

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -47,6 +47,8 @@ LMS: Support adding students to a cohort via the instructor dashboard. TNL-163
 
 LMS: Show cohorts on the new instructor dashboard. TNL-161
 
+LMS: Extended hints feature
+
 LMS: Mobile API available for courses that opt in using the Course Advanced
 Setting "Mobile Course Available" (only used in limited closed beta).
 

--- a/common/lib/capa/capa/inputtypes.py
+++ b/common/lib/capa/capa/inputtypes.py
@@ -483,15 +483,17 @@ class ChoiceGroup(InputTypeBase):
         _ = i18n.ugettext
 
         for choice in element:
-            if choice.tag != 'choice':
-                msg = u"[capa.inputtypes.extract_choices] {error_message}".format(
-                    # Translators: '<choice>' is a tag name and should not be translated.
-                    error_message=_("Expected a <choice> tag; got {given_tag} instead").format(
-                        given_tag=choice.tag
+            if choice.tag == 'choice':
+                choices.append((choice.get("name"), stringify_children(choice)))
+            else:
+                if choice.tag != 'compoundhint':
+                    msg = u'[capa.inputtypes.extract_choices] {error_message}'.format(
+                        # Translators: '<choice>' and '<compoundhint>' are tag names and should not be translated.
+                        error_message=_('Expected a <choice> or <compoundhint> tag; got {given_tag} instead').format(
+                            given_tag=choice.tag
+                        )
                     )
-                )
-                raise Exception(msg)
-            choices.append((choice.get("name"), stringify_children(choice)))
+                    raise Exception(msg)
         return choices
 
     def get_user_visible_answer(self, internal_answer):

--- a/common/lib/capa/capa/responsetypes.py
+++ b/common/lib/capa/capa/responsetypes.py
@@ -844,11 +844,14 @@ class ChoiceResponse(LoncapaResponse):
                             hint_divs += '<div class="{0}">{1}</div>'.format(QUESTION_HINT_TEXT_STYLE, text)
                         break
             if hint_divs:
-                # Complication: if there is only a single label specified, we use it. However if there are multiple, we use none.
+                # Complication: if there is only a single label specified, we use it.
+                # However if there are multiple, we use none.
                 if label_count > 1:
                     label = None
-                new_cmap[self.answer_id]['msg'] += self.make_hint_div(None, new_cmap[self.answer_id]['correctness'] == 'correct',
-                                                                      label, hint_divs)
+                new_cmap[self.answer_id]['msg'] += (
+                    self.make_hint_div(None,
+                                       new_cmap[self.answer_id]['correctness'] == 'correct',
+                                       label, hint_divs))
 
     def get_compound_hints(self, new_cmap, student_answers):
         """
@@ -948,11 +951,14 @@ class MultipleChoiceResponse(LoncapaResponse):
             if isinstance(student_answer, list):
                 student_answer = student_answer[0]
 
-            # Find the named choice used by the student (according to the unit tests, silently ignore a bad choice-name)
-            choice = self.xml.find('./choicegroup[@id="{0}"]/choice[@name="{1}"]'.format(self.answer_id, student_answer))
+            # Find the named choice used by the student. Silently ignore a non-matching
+            # choice name.
+            choice = self.xml.find('./choicegroup[@id="{0}"]/choice[@name="{1}"]'.format(self.answer_id,
+                                                                                         student_answer))
             if choice is not None:
                 hint_node = choice.find('./choicehint')
-                new_cmap[self.answer_id]['msg'] += self.make_hint_div(hint_node, choice.get('correct').upper() == 'TRUE')
+                new_cmap[self.answer_id]['msg'] += self.make_hint_div(hint_node,
+                                                                      choice.get('correct').upper() == 'TRUE')
 
     def mc_setup_response(self):
         """
@@ -1284,7 +1290,8 @@ class OptionResponse(LoncapaResponse):
         if answer_id in student_answers:
             student_answer = student_answers[answer_id]
             # If we run into an old-style optioninput, there is not <option> tag, so we just won't find anything
-            options = self.xml.xpath('//optioninput[@id=$id]/option[contains(.,$ans)]', id=answer_id, ans=student_answer)
+            options = self.xml.xpath('//optioninput[@id=$id]/option[contains(.,$ans)]',
+                                     id=answer_id, ans=student_answer)
             if options:
                 option = options[0]
                 hint_node = option.find('./optionhint')
@@ -1545,9 +1552,10 @@ class StringResponse(LoncapaResponse):
             return
         # end of backward compatibility
 
-        # XML compatibility note: in 2015 additional_answer switched to having a 'answer' attribute.
+        # XML compatibility note: in 2015, additional_answer switched to having a 'answer' attribute.
         # See make_xml_compatible in capa_problem which translates the old format.
-        correct_answers = [self.xml.get('answer')] + [element.get('answer') for element in self.xml.findall('additional_answer')]
+        correct_answers = [self.xml.get('answer')] + [element.get('answer')
+                           for element in self.xml.findall('additional_answer')]
         self.correct_answer = [contextualize_text(answer, self.context).strip() for answer in correct_answers]
 
     def get_score(self, student_answers):

--- a/common/lib/capa/capa/responsetypes.py
+++ b/common/lib/capa/capa/responsetypes.py
@@ -61,6 +61,10 @@ CORRECTMAP_PY = None
 # Make '_' a no-op so we can scrape strings
 _ = lambda text: text
 
+QUESTION_HINT_CORRECT_STYLE = 'feedback_hint_correct'
+QUESTION_HINT_INCORRECT_STYLE = 'feedback_hint_incorrect'
+QUESTION_HINT_TEXT_STYLE = 'feedback_hint_text'
+
 #-----------------------------------------------------------------------------
 # Exceptions
 
@@ -252,6 +256,59 @@ class LoncapaResponse(object):
         # log.debug('new_cmap = %s' % new_cmap)
         return new_cmap
 
+    def make_hint_div(self, hint_node, correct, label=None, hint_text=''):
+        """
+        Given the xml extended hint node and the boolean correctness, returns the extended hint div,
+        like this:
+          <div class="feedback_hint_incorrect">Incorrect: the answer is not 42</div>
+        Optionally, the hint label and the hint_text to use may be passed in,
+        overriding the text found in the hint node, which can be passed as None.
+        This function supports many argument combinations in order to work with the many
+        different contexts where extended hints are constructed.
+        A label with the value '' means inhibit all labeling, while the None means
+        no specific label is provided and we should get the default.
+        The empty string is returned, meaning no hint, if after processing all the arguments,
+        there is no hint.
+        """
+        _ = self.capa_system.i18n.ugettext
+        # Establish the hint text
+        # This can lead to early-exit if the hint is blank.
+        if not hint_text:
+            if hint_node is None or hint_node.text is None:  # .text can be None, maybe just in testing
+                return ''
+            hint_text = hint_node.text.strip()
+            if not hint_text:
+                return ''
+
+        # Establish the label:
+        # Passed in, or from the node, or the default
+        if not label and hint_node is not None:
+            label = hint_node.get('label', None)
+
+        # Tricky: label None means output defaults, while '' means output empty label
+        if label is None:
+            if correct:
+                label = _(u'Correct')
+            else:
+                label = _(u'Incorrect')
+        if label:
+            label += ': '
+
+        # Establish the style
+        if correct:
+            style = QUESTION_HINT_CORRECT_STYLE
+        else:
+            style = QUESTION_HINT_INCORRECT_STYLE
+
+        # Ready to go
+        return u'<div class="{0}">{1}{2}</div>'.format(style, label, hint_text)
+
+    def get_extended_hints(self, student_answers, new_cmap):
+        """
+        Pull "extended hint" information out the xml based on the student answers.
+        Implemented down in the subclasses.
+        """
+
     def get_hints(self, student_answers, new_cmap, old_cmap):
         """
         Generate adaptive hints for this problem based on student answers, the old CorrectMap,
@@ -261,13 +318,17 @@ class LoncapaResponse(object):
 
         Modifies new_cmap, by adding hints to answer_id entries as appropriate.
         """
-        hintgroup = self.xml.find('hintgroup')
-        if hintgroup is None:
-            return
 
-        # hint specified by function?
-        hintfn = hintgroup.get('hintfn')
-        if hintfn:
+        hintfn = None
+        hint_function_provided = False
+        hintgroup = self.xml.find('hintgroup')
+        if hintgroup is not None:
+            hintfn = hintgroup.get('hintfn')
+            if hintfn is not None:
+                hint_function_provided = True
+
+        if hint_function_provided:
+            # if a hint function has been supplied, it will take precedence
             # Hint is determined by a function defined in the <script> context; evaluate
             # that function to obtain list of hint, hintmode for each answer_id.
 
@@ -322,6 +383,7 @@ class LoncapaResponse(object):
             new_cmap.set_dict(globals_dict['new_cmap_dict'])
             return
 
+        # no hint function provided
         # hint specified by conditions and text dependent on conditions (a-la Loncapa design)
         # see http://help.loncapa.org/cgi-bin/fom?file=291
         #
@@ -339,7 +401,8 @@ class LoncapaResponse(object):
         # </formularesponse>
 
         if (self.hint_tag is not None
-            and hintgroup.find(self.hint_tag) is not None
+                and hintgroup is not None
+                and hintgroup.find(self.hint_tag) is not None
                 and hasattr(self, 'check_hint_condition')):
 
             rephints = hintgroup.findall(self.hint_tag)
@@ -356,6 +419,9 @@ class LoncapaResponse(object):
                     aid = self.answer_ids[-1]
                     new_cmap.set_hint_and_mode(aid, hint_text, hintmode)
             log.debug('after hint: new_cmap = %s', new_cmap)
+        else:
+            # If no other hint form matches, try extended hints.
+            self.get_extended_hints(student_answers, new_cmap)
 
     @abc.abstractmethod
     def get_score(self, student_answers):
@@ -447,7 +513,6 @@ class JavascriptResponse(LoncapaResponse):
     allowed_inputfields = ['javascriptinput']
 
     def setup_response(self):
-
         # Sets up generator, grader, display, and their dependencies.
         self.parse_xml()
 
@@ -686,7 +751,6 @@ class ChoiceResponse(LoncapaResponse):
     and it'd be nice to change this at some point.
 
     """
-
     human_name = _('Checkboxes')
     tags = ['choiceresponse']
     max_inputfields = 1
@@ -694,7 +758,6 @@ class ChoiceResponse(LoncapaResponse):
     correct_choices = None
 
     def setup_response(self):
-
         self.assign_choice_names()
 
         correct_xml = self.xml.xpath('//*[@id=$id]//choice[@correct="true"]',
@@ -711,6 +774,9 @@ class ChoiceResponse(LoncapaResponse):
         for index, choice in enumerate(self.xml.xpath('//*[@id=$id]//choice',
                                                       id=self.xml.get('id'))):
             choice.set("name", "choice_" + str(index))
+            # If a choice does not have an id, assign 'A' 'B', .. used by CompoundHint
+            if not choice.get('id'):
+                choice.set("id", chr(ord("A") + index))
 
     def get_score(self, student_answers):
 
@@ -734,6 +800,89 @@ class ChoiceResponse(LoncapaResponse):
 
     def get_answers(self):
         return {self.answer_id: list(self.correct_choices)}
+
+    def get_extended_hints(self, student_answers, new_cmap):
+        """
+        Extract compound and extended hint information from the xml based on the student_answers.
+        The hint information goes into the msg= in new_cmap for display.
+        Each choice in the checkboxgroup can have 2 extended hints, matching the
+        case that the student has or has not selected that choice:
+          <checkboxgroup label="Select the best snack" direction="vertical">
+             <choice correct="true">Donut
+               <choicehint selected="tRuE">A Hint!</choicehint>
+               <choicehint selected="false">Another hint!</choicehint>
+             </choice>
+        """
+        if self.answer_id in student_answers:
+            # Compound hints are a special thing just for checkboxgroup, trying
+            # them first before the regular extended hints.
+            if self.get_compound_hints(new_cmap, student_answers):
+                return
+
+            # Look at all the choices - each can generate some hint text
+            choices = self.xml.xpath('//checkboxgroup[@id=$id]/choice', id=self.answer_id)
+            hint_divs = ''
+            label = None
+            label_count = 0
+            # We build up several hints in hint_divs, then wrap it once at the end.
+            for choice in choices:
+                name = choice.get('name')  # generated name, e.g. choice_2
+                if name in student_answers[self.answer_id]:
+                    selector = 'true'  # true/false attribute used in the hint xml
+                else:
+                    selector = 'false'
+                # We find the matching <choicehint> in python vs xpath so we can be case-insensitive
+                hint_nodes = choice.findall('./choicehint')
+                for hint_node in hint_nodes:
+                    if hint_node.get('selected', '').lower() == selector:
+                        text = hint_node.text.strip()
+                        if hint_node.get('label') is not None:  # tricky: label '' vs None is significant
+                            label = hint_node.get('label')
+                            label_count += 1
+                        if text:
+                            # Unusual: there can be multiple hint divs across the choices, all cat'd together
+                            hint_divs += '<div class="{0}">{1}</div>'.format(QUESTION_HINT_TEXT_STYLE, text)
+                        break
+            if hint_divs:
+                # Complication: if there is only a single label specified, we use it. However if there are multiple, we use none.
+                if label_count > 1:
+                    label = None
+                new_cmap[self.answer_id]['msg'] += self.make_hint_div(None, new_cmap[self.answer_id]['correctness'] == 'correct',
+                                                                      label, hint_divs)
+
+    def get_compound_hints(self, new_cmap, student_answers):
+        """
+        Compound hints are a type of extended hint specific to checkboxgroup with the
+        <compoundhint value="A C"> meaning choices A and C were selected.
+        Checks for a matching compound hint, installing it in new_cmap.
+        Returns True if compound condition hints were matched.
+        """
+        compound_hint_matched = False
+        if self.answer_id in student_answers:
+            # First create a set of the student's selected ids
+            student_set = set()
+            for student_answer in student_answers[self.answer_id]:
+                choice_list = self.xml.xpath('//checkboxgroup[@id=$id]/choice[@name=$name]',
+                                             id=self.answer_id, name=student_answer)
+                if choice_list:
+                    choice = choice_list[0]
+                    student_set.add(choice.get('id').upper())
+
+            for compound_hint in self.xml.xpath('//checkboxgroup[@id=$id]/compoundhint', id=self.answer_id):
+                # Selector words are space separated and not case-sensitive
+                selectors = compound_hint.get('value').upper().split()
+                selector_set = set(selectors)
+
+                if selector_set == student_set:
+                    # This is the atypical case where the hint text is in an inner div with its own style.
+                    hint_text = compound_hint.text.strip()
+                    hint_text = '<div class="{0}">{1}</div>'.format(QUESTION_HINT_TEXT_STYLE, hint_text)
+                    new_cmap[self.answer_id]['msg'] += self.make_hint_div(
+                        compound_hint, new_cmap[self.answer_id]['correctness'] == 'correct',
+                        label=None, hint_text=hint_text)
+                    compound_hint_matched = True
+                    break
+        return compound_hint_matched
 
 #-----------------------------------------------------------------------------
 
@@ -778,8 +927,32 @@ class MultipleChoiceResponse(LoncapaResponse):
         self.correct_choices = [
             contextualize_text(choice.get('name'), self.context)
             for choice in cxml
-            if contextualize_text(choice.get('correct'), self.context) == "true"
+            if contextualize_text(choice.get('correct'), self.context).upper() == "TRUE"
+
         ]
+
+    def get_extended_hints(self, student_answer_dict, new_cmap):
+        """
+        Extract any hints in a <choicegroup> matching the student's answers
+        <choicegroup label="What is your favorite color?" type="MultipleChoice">
+          <choice correct="false">Red
+            <choicehint>No, Blue!</choicehint>
+          </choice>
+          ...
+        Any hint text is installed in the new_cmap.
+        """
+        if self.answer_id in student_answer_dict:
+            student_answer = student_answer_dict[self.answer_id]
+
+            # Warning: mostly student_answer is a string, but sometimes it is a list of strings.
+            if isinstance(student_answer, list):
+                student_answer = student_answer[0]
+
+            # Find the named choice used by the student (according to the unit tests, silently ignore a bad choice-name)
+            choice = self.xml.find('./choicegroup[@id="{0}"]/choice[@name="{1}"]'.format(self.answer_id, student_answer))
+            if choice is not None:
+                hint_node = choice.find('./choicehint')
+                new_cmap[self.answer_id]['msg'] += self.make_hint_div(hint_node, choice.get('correct').upper() == 'TRUE')
 
     def mc_setup_response(self):
         """
@@ -824,8 +997,6 @@ class MultipleChoiceResponse(LoncapaResponse):
         """
         grade student response.
         """
-        # log.debug('%s: student_answers=%s, correct_choices=%s' % (
-        #   unicode(self), student_answers, self.correct_choices))
         if (self.answer_id in student_answers
                 and student_answers[self.answer_id] in self.correct_choices):
             return CorrectMap(self.answer_id, 'correct')
@@ -1007,7 +1178,7 @@ class MultipleChoiceResponse(LoncapaResponse):
         incorrect_choices = []
 
         for choice in choices:
-            if choice.get('correct') == 'true':
+            if choice.get('correct').upper() == 'TRUE':
                 correct_choices.append(choice)
             else:
                 incorrect_choices.append(choice)
@@ -1089,7 +1260,6 @@ class OptionResponse(LoncapaResponse):
         self.answer_fields = self.inputfields
 
     def get_score(self, student_answers):
-        # log.debug('%s: student_answers=%s' % (unicode(self),student_answers))
         cmap = CorrectMap()
         amap = self.get_answers()
         for aid in amap:
@@ -1102,8 +1272,24 @@ class OptionResponse(LoncapaResponse):
     def get_answers(self):
         amap = dict([(af.get('id'), contextualize_text(af.get(
             'correct'), self.context)) for af in self.answer_fields])
-        # log.debug('%s: expected answers=%s' % (unicode(self),amap))
         return amap
+
+    def get_extended_hints(self, student_answers, new_cmap):
+        """
+        Extract optioninput extended hint, e.g.
+        <optioninput correct="Multiple Choice">
+          <option correct="True">Donut <optionhint>Of course</optionhint> </option>
+        """
+        answer_id = self.answer_ids[0]  # Note *not* self.answer_id
+        if answer_id in student_answers:
+            student_answer = student_answers[answer_id]
+            # If we run into an old-style optioninput, there is not <option> tag, so we just won't find anything
+            options = self.xml.xpath('//optioninput[@id=$id]/option[contains(.,$ans)]', id=answer_id, ans=student_answer)
+            if options:
+                option = options[0]
+                hint_node = option.find('./optionhint')
+                if hint_node is not None:
+                    new_cmap[answer_id]['msg'] += self.make_hint_div(hint_node, option.get('correct').upper() == 'TRUE')
 
 #-----------------------------------------------------------------------------
 
@@ -1187,6 +1373,9 @@ class NumericalResponse(LoncapaResponse):
         """
         Grade a numeric response.
         """
+        if self.answer_id not in student_answers:
+            return CorrectMap(self.answer_id, 'incorrect')
+
         student_answer = student_answers[self.answer_id]
 
         _ = self.capa_system.i18n.ugettext
@@ -1280,6 +1469,19 @@ class NumericalResponse(LoncapaResponse):
     def get_answers(self):
         return {self.answer_id: self.correct_answer}
 
+    def get_extended_hints(self, student_answers, new_cmap):
+        """
+        Extract numericalresponse extended hint, e.g.
+          <correcthint>Yes, 1+1 IS 2<correcthint>
+        """
+        if self.answer_id in student_answers:
+            if new_cmap.cmap[self.answer_id]['correctness'] == 'correct':  # if the grader liked the student's answer
+                # Note: using self.id here, not the more typical self.answer_id
+                hints = self.xml.xpath('//numericalresponse[@id=$id]/correcthint', id=self.id)
+                if hints:
+                    hint_node = hints[0]
+                    new_cmap[self.answer_id]['msg'] += self.make_hint_div(hint_node, True)
+
 #-----------------------------------------------------------------------------
 
 
@@ -1297,8 +1499,8 @@ class StringResponse(LoncapaResponse):
         </stringresponse >
 
         <stringresponse answer="a1" type="ci regexp">
-            <additional_answer>\d5</additional_answer>
-            <additional_answer>a3</additional_answer>
+            <additional_answer>d5</additional_answer>
+            <additional_answer answer="a3"><correcthint>a hint - new format</correcthint></additional_answer>
             <textline size="20"/>
             <hintgroup>
                 <stringhint answer="a0" type="ci" name="ha0" />
@@ -1330,7 +1532,6 @@ class StringResponse(LoncapaResponse):
         ]
 
     def setup_response(self):
-
         self.backward = '_or_' in self.xml.get('answer').lower()
         self.regexp = False
         self.case_insensitive = False
@@ -1344,23 +1545,97 @@ class StringResponse(LoncapaResponse):
             return
         # end of backward compatibility
 
-        correct_answers = [self.xml.get('answer')] + [el.text for el in self.xml.findall('additional_answer')]
+        # XML compatibility note: in 2015 additional_answer switched to having a 'answer' attribute.
+        # See make_xml_compatible in capa_problem which translates the old format.
+        correct_answers = [self.xml.get('answer')] + [element.get('answer') for element in self.xml.findall('additional_answer')]
         self.correct_answer = [contextualize_text(answer, self.context).strip() for answer in correct_answers]
-
-        # remove additional_answer from xml, otherwise they will be displayed
-        for el in self.xml.findall('additional_answer'):
-            self.xml.remove(el)
 
     def get_score(self, student_answers):
         """Grade a string response """
-        student_answer = student_answers[self.answer_id].strip()
-        correct = self.check_string(self.correct_answer, student_answer)
+        if self.answer_id not in student_answers:
+            correct = False
+        else:
+            student_answer = student_answers[self.answer_id].strip()
+            correct = self.check_string(self.correct_answer, student_answer)
         return CorrectMap(self.answer_id, 'correct' if correct else 'incorrect')
 
     def check_string_backward(self, expected, given):
         if self.case_insensitive:
             return given.lower() in [i.lower() for i in expected]
         return given in expected
+
+    def get_extended_hints(self, student_answers, new_cmap):
+        """
+        Find and install extended hints in new_cmap depending on the student answers.
+        StringResponse is probably the most complicated form we have.
+        The forms show below match in the order given, and the first matching one stops the matching.
+        <stringresponse answer="A" type="ci">
+          <correcthint>hint1</correcthint>                         <!-- hint for correct answer -->
+          <additional_answer answer="B">hint2</additional_answer>  <!-- additional_answer with its own hint -->
+          <stringequalhint answer="C">hint3</stringequalhint>      <!-- string matcher/hint for an incorrect answer -->
+          <regexphint answer="FG+">hint4</regexphint>              <!-- regex matcher/hint for an incorrect answer -->
+          <textline size="20"/>
+        </stringresponse>
+        The "ci" and "regexp" options are inherited from the parent stringresponse as appropriate.
+        """
+        if self.answer_id in student_answers:
+            student_answer = student_answers[self.answer_id]
+            # Note the atypical case of using self.id instead of self.answer_id
+            responses = self.xml.xpath('//stringresponse[@id=$id]', id=self.id)
+            if responses:
+                response = responses[0]
+
+                # First call the existing check_string to see if this is a right answer by that test.
+                # It handles the various "ci" "regexp" cases internally.
+                expected = response.get('answer').strip()
+                if self.check_string([expected], student_answer):
+                    hint_node = response.find('./correcthint')
+                    if hint_node is not None:
+                        new_cmap[self.answer_id]['msg'] += self.make_hint_div(hint_node, True)
+                    return
+
+                # Then look for additional answer with an answer= attribute
+                for node in response.findall('./additional_answer'):
+                    if self.match_hint_node(node, student_answer, self.regexp, self.case_insensitive):
+                        correct_hint = node.find('./correcthint')
+                        new_cmap[self.answer_id]['msg'] += self.make_hint_div(correct_hint, True)
+                        return
+
+                # stringequalhint and regexphint represent wrong answers
+                for node in response.findall('./stringequalhint'):
+                    if self.match_hint_node(node, student_answer, False, self.case_insensitive):
+                        new_cmap[self.answer_id]['msg'] += self.make_hint_div(node, False)
+                        return
+
+                for node in response.findall('./regexphint'):
+                    if self.match_hint_node(node, student_answer, True, self.case_insensitive):
+                        new_cmap[self.answer_id]['msg'] += self.make_hint_div(node, False)
+                        return
+
+    def match_hint_node(self, node, given, regex_mode, ci_mode):
+        """
+        Given an xml node such as additional_answer or regexphint, which contain an answer=,
+        returns True if the given student answer is a match.
+        """
+        answer = node.get('answer', '').strip()
+        if not answer:
+            return False
+
+        if regex_mode:
+            flags = 0
+            if ci_mode:
+                flags = re.IGNORECASE
+            try:
+                # We follow the check_string convention/exception, adding ^ and $
+                regex = re.compile('^' + answer + '$', flags=flags | re.UNICODE)
+                return re.search(regex, given)
+            except Exception:  # pylint: disable=broad-except
+                return False
+
+        if ci_mode:
+            return answer.lower() == given.lower()
+        else:
+            return answer == given
 
     def check_string(self, expected, given):
         """
@@ -1416,7 +1691,7 @@ class StringResponse(LoncapaResponse):
 
             if self.check_string([hinted_answer], given):
                 hints_to_show.append(name)
-        log.debug('hints_to_show = %s', hints_to_show)
+            log.debug('hints_to_show = %s', hints_to_show)
         return hints_to_show
 
     def get_answers(self):
@@ -2547,7 +2822,6 @@ class SchematicResponse(LoncapaResponse):
             self.code = answer.text
 
     def get_score(self, student_answers):
-        #from capa_problem import global_context
         submission = [
             json.loads(student_answers[k]) for k in sorted(self.answer_ids)
         ]

--- a/common/lib/capa/capa/tests/response_xml_factory.py
+++ b/common/lib/capa/capa/tests/response_xml_factory.py
@@ -699,6 +699,8 @@ class StringResponseXMLFactory(ResponseXMLFactory):
 
             *additional_answers*: list of additional asnwers.
 
+            *old_answers*: list of additional answers to be coded in old format
+
         """
         # Retrieve the **kwargs
         answer = kwargs.get("answer", None)
@@ -707,6 +709,7 @@ class StringResponseXMLFactory(ResponseXMLFactory):
         hint_fn = kwargs.get('hintfn', None)
         regexp = kwargs.get('regexp', None)
         additional_answers = kwargs.get('additional_answers', [])
+        old_answers = kwargs.get('old_answers', [])
         assert answer
 
         # Create the <stringresponse> element
@@ -744,7 +747,12 @@ class StringResponseXMLFactory(ResponseXMLFactory):
                 hintgroup_element.set("hintfn", hint_fn)
 
         for additional_answer in additional_answers:
-            etree.SubElement(response_element, "additional_answer").text = additional_answer
+            additional_node = etree.SubElement(response_element, "additional_answer")
+            additional_node.set("answer", additional_answer)
+
+        for old_answer in old_answers:
+            additional_node = etree.SubElement(response_element, "additional_answer")
+            additional_node.text = old_answer
 
         return response_element
 

--- a/common/lib/capa/capa/tests/test_files/extended_hints.xml
+++ b/common/lib/capa/capa/tests/test_files/extended_hints.xml
@@ -1,0 +1,50 @@
+<problem>
+    <p>What is the correct answer?</p>
+    <multiplechoiceresponse targeted-feedback="">
+      <choicegroup type="MultipleChoice">
+        <choice correct="false" explanation-id="feedback1">wrong-1</choice>
+        <choice correct="false" explanation-id="feedback2">wrong-2</choice>
+        <choice correct="true" explanation-id="feedbackC">correct-1</choice>
+        <choice correct="false" explanation-id="feedback3">wrong-3</choice>
+      </choicegroup>
+    </multiplechoiceresponse>
+
+    <targetedfeedbackset>
+        <targetedfeedback explanation-id="feedback1">
+        <div class="detailed-targeted-feedback">
+            <p>Targeted Feedback</p>
+            <p>This is the 1st WRONG solution</p>
+        </div>
+        </targetedfeedback>
+
+        <targetedfeedback explanation-id="feedback2">
+        <div class="detailed-targeted-feedback">
+            <p>Targeted Feedback</p>
+            <p>This is the 2nd WRONG solution</p>
+        </div>
+        </targetedfeedback>
+
+        <targetedfeedback explanation-id="feedback3">
+        <div class="detailed-targeted-feedback">
+            <p>Targeted Feedback</p>
+            <p>This is the 3rd WRONG solution</p>
+        </div>
+        </targetedfeedback>
+
+        <targetedfeedback explanation-id="feedbackC">
+        <div class="detailed-targeted-feedback-correct">
+            <p>Targeted Feedback</p>
+            <p>Feedback on your correct solution...</p>
+        </div>
+        </targetedfeedback>
+
+    </targetedfeedbackset>
+
+    <solution explanation-id="feedbackC">
+    <div class="detailed-solution">
+        <p>Explanation</p>
+        <p>This is the solution explanation</p>
+        <p>Not much to explain here, sorry!</p>
+    </div>
+    </solution>
+</problem>

--- a/common/lib/capa/capa/tests/test_files/extended_hints_checkbox.xml
+++ b/common/lib/capa/capa/tests/test_files/extended_hints_checkbox.xml
@@ -1,0 +1,108 @@
+<problem schema="edXML/1.0">
+    <p>Select all the fruits from the list</p>
+    <choiceresponse>
+      <checkboxgroup label="Select all the fruits from the list" direction="vertical">
+        <choice correct="true" id="alpha">Apple
+                   <choicehint selected="TrUe">You are right that apple is a fruit.
+                   </choicehint>
+                   <choicehint selected="false">Remember that apple is also a fruit.
+                   </choicehint>
+        </choice>
+        <choice correct="false">Mushroom
+                   <choicehint selected="true">Mushroom is a fungus, not a fruit.
+                   </choicehint>
+                   <choicehint selected="false">You are right that mushrooms are not fruit
+                   </choicehint>
+        </choice>
+        <choice correct="true">Grape
+                   <choicehint selected="true">You are right that grape is a fruit
+                   </choicehint>
+                   <choicehint selected="false">Remember that grape is also a fruit.
+                   </choicehint>
+        </choice>
+        <choice correct="false">Mustang</choice>
+        <choice correct="false">Camero
+                   <choicehint selected="true">I do not know what a Camero is but it is not a fruit.
+                   </choicehint>
+                   <choicehint selected="false">What is a camero anyway?
+                   </choicehint>
+        </choice>
+        <compoundhint value="alpha B" label="Almost right"> You are right that apple is a fruit, but there is one you are missing. Also, mushroom is not a fruit.
+        </compoundhint>
+        <compoundhint value="  c     b   "> You are right that grape is a fruit, but there is one you are missing. Also, mushroom is not a fruit.
+        </compoundhint>
+      </checkboxgroup>
+    </choiceresponse>
+    <p>Select all the vegetables from the list</p>
+    <choiceresponse>
+      <checkboxgroup label="Select all the vegetables from the list" direction="vertical">
+        <choice correct="false">Banana
+                   <choicehint selected="true">No, sorry, a banana is a fruit.
+                   </choicehint>
+                   <choicehint selected="false">poor banana.
+                   </choicehint>
+        </choice>
+        <choice correct="false">Ice Cream</choice>
+        <choice correct="false">Mushroom
+                   <choicehint selected="true">Mushroom is a fungus, not a vegetable.
+                   </choicehint>
+                   <choicehint selected="false">You are right that mushrooms are not vegatbles
+                   </choicehint>
+        </choice>
+        <choice correct="true">
+        Brussel Sprout
+                   <choicehint selected="true">
+                   
+                   Brussel sprouts are vegetables.
+                   </choicehint>
+                   <choicehint selected="false">
+                   
+                   Brussel sprout is the only vegetable in this list.
+                   </choicehint>
+        </choice>
+        <compoundhint value="A B" label="Very funny"> Making a banana split?
+        </compoundhint>
+        <compoundhint value="B D"> That will make a horrible dessert: a brussel sprout split?
+        </compoundhint>
+      </checkboxgroup>
+    </choiceresponse>
+    <p>Compoundhint vs. correctness</p>
+    <choiceresponse>
+      <checkboxgroup direction="vertical">
+        <choice correct="true">A</choice>
+        <choice correct="false">B</choice>
+        <choice correct="true">C</choice>
+        <compoundhint value="A B">AB</compoundhint>
+        <compoundhint value="A C">AC</compoundhint>
+      </checkboxgroup>
+    </choiceresponse>
+    <p>If one label matches we use it, otherwise go with the default, and whitespace scattered around.</p>
+    <choiceresponse>
+      <checkboxgroup direction="vertical">
+        <choice correct="true">
+        
+              A      
+          <choicehint selected="true" label="AA">
+        
+        aa
+        
+        </choicehint></choice>
+        <choice correct="true">
+        B <choicehint selected="false" label="BB">
+           bb
+               
+        </choicehint></choice>
+      </checkboxgroup>
+    </choiceresponse>
+
+    <p>Blank labels</p>
+    <choiceresponse>
+      <checkboxgroup direction="vertical">
+        <choice correct="true">A <choicehint selected="true" label="">aa</choicehint></choice>
+        <choice correct="true">B <choicehint selected="true">bb</choicehint></choice>
+        <compoundhint value="A B" label="">compoundo</compoundhint>
+      </checkboxgroup>
+    </choiceresponse>
+    
+</problem>
+

--- a/common/lib/capa/capa/tests/test_files/extended_hints_dropdown.xml
+++ b/common/lib/capa/capa/tests/test_files/extended_hints_dropdown.xml
@@ -1,0 +1,30 @@
+<problem>
+<p>Translation between Dropdown and ________ is straightforward.</p>
+<optionresponse>
+    <optioninput>
+        <option correct="True">Multiple Choice
+           <optionhint label="Good Job">Yes, multiple choice is the right answer.
+           </optionhint> </option>
+        <option correct="False">Text Input
+           <optionhint>No, text input problems do not present options.
+           </optionhint> </option>
+        <option correct="False">Numerical Input
+           <optionhint>No, numerical input problems do not present options.
+           </optionhint> </option>
+    </optioninput>
+</optionresponse>
+<p>Clowns have funny _________ to make people laugh.</p>
+<optionresponse>
+    <optioninput>
+        <option correct="False">dogs
+           <optionhint label="NOPE">Not dogs, not cats, not toads
+           </optionhint> </option>
+        <option correct="True">FACES
+           <optionhint>With lots of makeup, doncha know?
+           </optionhint> </option>
+        <option correct="False">money
+           <optionhint>Clowns do not have any money, of course
+           </optionhint> </option>
+    </optioninput>
+</optionresponse>
+</problem>

--- a/common/lib/capa/capa/tests/test_files/extended_hints_multiple_choice.xml
+++ b/common/lib/capa/capa/tests/test_files/extended_hints_multiple_choice.xml
@@ -1,0 +1,34 @@
+<problem>
+<p>(note the blank line before mushroom -- be sure to include this test case)</p>
+<p>Select the fruit from the list</p>
+<multiplechoiceresponse>
+  <choicegroup label="Select the fruit from the list" type="MultipleChoice">
+    <choice correct="false">Mushroom
+        <choicehint label="">Mushroom is a fungus, not a fruit.
+        </choicehint>
+    </choice>
+    <choice correct="false">Potato</choice>
+    <choice correct="true">Apple
+        <choicehint label="OUTSTANDING">Apple is indeed a fruit.
+        </choicehint>
+    </choice>
+  </choicegroup>
+</multiplechoiceresponse>
+<p>Select the vegetables from the list</p>
+<multiplechoiceresponse>
+  <choicegroup label="Select the vegetables from the list" type="MultipleChoice">
+    <choice correct="false">Mushroom
+        <choicehint>Mushroom is a fungus, not a vegetable.
+        </choicehint>
+    </choice>
+    <choice correct="true">Potato
+        <choicehint>Potato is a root vegetable.
+        </choicehint>
+    </choice>
+    <choice correct="false">Apple
+        <choicehint label="OOPS">Apple is a fruit.
+        </choicehint>
+    </choice>
+  </choicegroup>
+</multiplechoiceresponse>
+</problem>

--- a/common/lib/capa/capa/tests/test_files/extended_hints_numeric_input.xml
+++ b/common/lib/capa/capa/tests/test_files/extended_hints_numeric_input.xml
@@ -1,0 +1,37 @@
+<problem>
+    <numericalresponse answer="1.141">
+        <responseparam default=".01" type="tolerance"/>
+        <formulaequationinput label="What value when squared is approximately equal to 2 (give your answer to 2 decimal places)?"/>
+
+        <correcthint label="Nice">
+            The square root of two turns up in the strangest places.
+        </correcthint>
+
+
+    </numericalresponse>
+
+    <numericalresponse answer="4">
+        <responseparam default=".01" type="tolerance"/>
+        <formulaequationinput label="What is 2 + 2?"/>
+        <correcthint>
+            Pretty easy, uh?.
+        </correcthint>
+    </numericalresponse>
+<!-- I don't think we're supporting these yet
+
+also not multiple correcthint
+
+        <numerichint answer="-1.141" tolerance="0.01">
+            Yes, squaring a negative number yields a positive
+        </numerichint>
+
+        <numerichint answer="7">
+            7 x 7 = 49 which is much too high.
+        </numerichint>
+
+        <lehint answer="1">
+            Much too low. You may be rounding down.
+        </lehint>
+-->
+</problem>
+

--- a/common/lib/capa/capa/tests/test_files/extended_hints_text_input.xml
+++ b/common/lib/capa/capa/tests/test_files/extended_hints_text_input.xml
@@ -1,0 +1,78 @@
+<problem>
+    <p>In which country would you find the city of Paris?</p>
+
+    <stringresponse answer="France" type="ci" >
+        <textline label="In which country would you find the city of Paris?" size="20"/>
+        <correcthint>
+            Viva la France!
+        </correcthint>
+
+        <additional_answer answer="USA">
+             <correcthint>Less well known, but yes, there is a Paris, Texas.</correcthint>
+        </additional_answer>
+
+        <stringequalhint answer="Germany">
+            I do not think so.
+        </stringequalhint>
+
+        <regexphint answer=".*land">
+             The country name does not end in LAND
+        </regexphint>
+    </stringresponse>
+
+    <p>What color is the sky? A minimal example, case sensitive, not regex.</p>
+    <stringresponse answer="Blue">
+        <correcthint >The red light is scattered by water molecules leaving only blue light.
+        </correcthint>
+        <textline label="What color is the sky?" size="20"/>
+    </stringresponse>
+
+    <p>(This question will cause an illegal regular expression exception)</p>
+    <stringresponse answer="Bonk">
+        <correcthint >This hint should never appear.
+        </correcthint>
+        <textline label="Why not?" size="20"/>
+        <regexphint answer="[">
+             This hint should never appear either because the regex is illegal.
+        </regexphint>
+    </stringresponse>
+
+    <!-- string response with extended hints + case_insensitive + blank labels -->
+    <p>And also some unicode åΩ</p>
+    <stringresponse answer="A" type="ci">
+        <correcthint label="Woo Hooå">hint1Ω</correcthint>
+        <additional_answer answer="B"> <correcthint label=""> hint2 </correcthint> </additional_answer>
+        <stringequalhint answer="C" label=""> hint4 </stringequalhint>
+        <regexphint answer="FG+" label=""> hint6 </regexphint>
+        <regexphint answer="(abc"> erroneous regex don't match anything </regexphint>
+        <textline size="20"/>
+    </stringresponse>
+
+    <!-- string response with extended hints + case_insensitive = False -->
+    <stringresponse answer="A">
+        <correcthint>hint1</correcthint>
+        <additional_answer answer="B">  <correcthint> hint2 </correcthint>   </additional_answer>
+        <stringequalhint answer="C"> hint4 </stringequalhint>
+        <regexphint answer="FG+"> hint6 </regexphint>
+        <textline size="20"/>
+    </stringresponse>
+    
+    <!-- backward compatibility for additional_answer: old and new format together in
+         a problem, scored correclty and new style has a hint -->
+    <stringresponse answer="A">
+        <correcthint>hint1</correcthint>
+        <additional_answer>B</additional_answer>
+        <additional_answer answer="C"><correcthint> hint2 </correcthint> </additional_answer>
+        <additional_answer>&lt;&amp;"'&gt;</additional_answer>
+        <textline size="20"/>
+    </stringresponse>
+
+    <!-- type regexp with extended hints -->
+    <stringresponse answer="AB+C" type="ci regexp">
+        <correcthint>hint1</correcthint>
+        <additional_answer answer="B+"><correcthint> hint2 </correcthint> </additional_answer>
+        <stringequalhint answer="C"> hint4 </stringequalhint>
+        <regexphint answer="D"> hint6 </regexphint>
+        <textline size="20"/>
+    </stringresponse>
+</problem>

--- a/common/lib/capa/capa/tests/test_files/extended_hints_with_errors.xml
+++ b/common/lib/capa/capa/tests/test_files/extended_hints_with_errors.xml
@@ -1,0 +1,13 @@
+<problem schema="edXML/1.0">
+    <choiceresponse>
+      <checkboxgroup label="Select all the vegetables from the list" direction="vertical">
+        <choice correct="false">Banana
+                   <choicehint selected="true">No, sorry, a banana is a fruit.
+                   </choicehint>
+                   <choicehint selected="false">poor banana.
+                   </choicehint>
+        </choice>
+        <badElement>  this element is not a legal sibling of 'choice' and 'booleanhint' </badElement>
+      </checkboxgroup>
+    </choiceresponse>
+</problem>

--- a/common/lib/capa/capa/tests/test_hint_functionality.py
+++ b/common/lib/capa/capa/tests/test_hint_functionality.py
@@ -1,0 +1,297 @@
+# -*- coding: utf-8 -*-
+"""
+Tests of extended hints
+"""
+
+
+import unittest
+
+from ddt import ddt, data, unpack
+
+from . import new_loncapa_problem, load_fixture
+
+
+class HintTest(unittest.TestCase):
+    """Base class for tests of extended hinting functionality."""
+
+    def correctness(self, problem_id, choice):
+        """Grades and returns the 'correctness' string from cmap."""
+        student_answers = {problem_id: choice}
+        cmap = self.problem.grade_answers(answers=student_answers)    # pylint: disable=no-member
+        return cmap[problem_id]['correctness']
+
+    def get_hint(self, problem_id, choice):
+        """Grades the problem and returns its hint from cmap."""
+        student_answers = {problem_id: choice}
+        cmap = self.problem.grade_answers(answers=student_answers)    # pylint: disable=no-member
+        adict = cmap.cmap.get(problem_id)
+        if adict:
+            return adict['msg']
+        else:
+            return ''
+
+    def _check_student_selection_result(self, problem_id, choice, expected_string, expect_failure=False):
+        """
+        This helper function simplifies a call to either 'assertNotEqual' or 'assertEqual' to
+        make the tests in this file easier to read.
+        """
+        message_text = self.get_hint(problem_id, choice)
+        if expect_failure:
+            self.assertNotEqual(
+                message_text,
+                expected_string,
+                '\n   The produced HTML hint string:\n                           ' + message_text +
+                '\n   Should not have matched the expected HTML:\n                           ' + expected_string)
+        else:
+            self.assertEqual(
+                message_text,
+                expected_string,
+                '\nThe produced HTML hint string:\n                           ' + message_text +
+                '\nDoes not match the expected HTML:\n                           ' + expected_string)
+
+
+# It is a little surprising how much more complicated TextInput is than all the other cases.
+@ddt
+class TextInputHintsTest(HintTest):
+    """
+    Typical
+    """
+    xml = load_fixture('extended_hints_text_input.xml')
+    problem = new_loncapa_problem(xml)
+
+    @data(
+        {'problem_id': u'1_2_1', 'choice': 'Germany', 'expected_string': u'<div class="feedback_hint_incorrect">Incorrect: I do not think so.</div>'},
+        {'problem_id': u'1_2_1', 'choice': 'Germany', 'expected_string': u'<div class="feedback_hint_incorrect">Incorrect: I do not think so.</div>'},
+        {'problem_id': u'1_2_1', 'choice': 'france', 'expected_string': u'<div class="feedback_hint_correct">Correct: Viva la France!</div>'},
+        {'problem_id': u'1_2_1', 'choice': 'France', 'expected_string': u'<div class="feedback_hint_correct">Correct: Viva la France!</div>'},
+        {'problem_id': u'1_2_1', 'choice': 'Mexico', 'expected_string': ''},
+        {'problem_id': u'1_2_1', 'choice': 'USA', 'expected_string': u'<div class="feedback_hint_correct">Correct: Less well known, but yes, there is a Paris, Texas.</div>'},
+        {'problem_id': u'1_2_1', 'choice': 'usa', 'expected_string': u'<div class="feedback_hint_correct">Correct: Less well known, but yes, there is a Paris, Texas.</div>'},
+        {'problem_id': u'1_2_1', 'choice': 'uSAx', 'expected_string': u''},
+        {'problem_id': u'1_2_1', 'choice': 'NICKLAND', 'expected_string': u'<div class="feedback_hint_incorrect">Incorrect: The country name does not end in LAND</div>'},
+        {'problem_id': u'1_3_1', 'choice': 'Blue', 'expected_string': u'<div class="feedback_hint_correct">Correct: The red light is scattered by water molecules leaving only blue light.</div>'},
+        {'problem_id': u'1_3_1', 'choice': 'blue', 'expected_string': u''},
+        {'problem_id': u'1_3_1', 'choice': 'b', 'expected_string': u''},
+    )
+    @unpack
+    def test_text_input_hints(self, problem_id, choice, expected_string):
+        hint = self.get_hint(problem_id, choice)
+        self.assertEqual(hint, expected_string)
+
+
+@ddt
+class TextInputExtendedHintsCaseInsensitive(HintTest):
+    """Sometimes the semantics can be encoded in the class name."""
+    xml = load_fixture('extended_hints_text_input.xml')
+    problem = new_loncapa_problem(xml)
+
+    @data(
+        {'problem_id': u'1_5_1', 'choice': 'abc', 'expected_string': ''},  # wrong answer yielding no hint
+        {'problem_id': u'1_5_1', 'choice': 'A', 'expected_string': u'<div class="feedback_hint_correct">Woo Hooå: hint1Ω</div>'},
+        {'problem_id': u'1_5_1', 'choice': 'a', 'expected_string': u'<div class="feedback_hint_correct">Woo Hooå: hint1Ω</div>'},
+        {'problem_id': u'1_5_1', 'choice': 'B', 'expected_string': u'<div class="feedback_hint_correct">hint2</div>'},
+        {'problem_id': u'1_5_1', 'choice': 'b', 'expected_string': u'<div class="feedback_hint_correct">hint2</div>'},
+        {'problem_id': u'1_5_1', 'choice': 'C', 'expected_string': u'<div class="feedback_hint_incorrect">hint4</div>'},
+        {'problem_id': u'1_5_1', 'choice': 'c', 'expected_string': u'<div class="feedback_hint_incorrect">hint4</div>'},
+        # regexp cases
+        {'problem_id': u'1_5_1', 'choice': 'FGG', 'expected_string': u'<div class="feedback_hint_incorrect">hint6</div>'},
+        {'problem_id': u'1_5_1', 'choice': 'fgG', 'expected_string': u'<div class="feedback_hint_incorrect">hint6</div>'},
+    )
+    @unpack
+    def test_text_input_hints(self, problem_id, choice, expected_string):
+        hint = self.get_hint(problem_id, choice)
+        self.assertEqual(hint, expected_string)
+
+
+@ddt
+class TextInputExtendedHintsCaseSensitive(HintTest):
+    """Sometimes the semantics can be encoded in the class name."""
+    xml = load_fixture('extended_hints_text_input.xml')
+    problem = new_loncapa_problem(xml)
+
+    @data(
+        {'problem_id': u'1_6_1', 'choice': 'abc', 'expected_string': ''},
+        {'problem_id': u'1_6_1', 'choice': 'A', 'expected_string': u'<div class="feedback_hint_correct">Correct: hint1</div>'},
+        {'problem_id': u'1_6_1', 'choice': 'a', 'expected_string': u''},
+        {'problem_id': u'1_6_1', 'choice': 'B', 'expected_string': u'<div class="feedback_hint_correct">Correct: hint2</div>'},
+        {'problem_id': u'1_6_1', 'choice': 'b', 'expected_string': u''},
+        {'problem_id': u'1_6_1', 'choice': 'C', 'expected_string': u'<div class="feedback_hint_incorrect">Incorrect: hint4</div>'},
+        {'problem_id': u'1_6_1', 'choice': 'c', 'expected_string': u''},
+        # regexp cases
+        {'problem_id': u'1_6_1', 'choice': 'FGG', 'expected_string': u'<div class="feedback_hint_incorrect">Incorrect: hint6</div>'},
+        {'problem_id': u'1_6_1', 'choice': 'fgG', 'expected_string': u''},
+    )
+    @unpack
+    def test_text_input_hints(self, problem_id, choice, expected_string):
+        message_text = self.get_hint(problem_id, choice)
+        self.assertEqual(message_text, expected_string)
+
+
+@ddt
+class TextInputExtendedHintsCompatible(HintTest):
+    """
+    Compatibility test with mixed old and new style additional_answer tags.
+    """
+    xml = load_fixture('extended_hints_text_input.xml')
+    problem = new_loncapa_problem(xml)
+
+    @data(
+        {'problem_id': u'1_7_1', 'choice': 'A', 'correct': 'correct', 'expected_string': '<div class="feedback_hint_correct">Correct: hint1</div>'},
+        {'problem_id': u'1_7_1', 'choice': 'B', 'correct': 'correct', 'expected_string': ''},
+        {'problem_id': u'1_7_1', 'choice': 'C', 'correct': 'correct', 'expected_string': '<div class="feedback_hint_correct">Correct: hint2</div>'},
+        {'problem_id': u'1_7_1', 'choice': 'D', 'correct': 'incorrect', 'expected_string': ''},
+        # check going through conversion with difficult chars
+        {'problem_id': u'1_7_1', 'choice': """<&"'>""", 'correct': 'correct', 'expected_string': ''},
+    )
+    @unpack
+    def test_text_input_hints(self, problem_id, choice, correct, expected_string):
+        message_text = self.get_hint(problem_id, choice)
+        self.assertEqual(message_text, expected_string)
+        self.assertEqual(self.correctness(problem_id, choice), correct)
+
+
+@ddt
+class TextInputExtendedHintsRegex(HintTest):
+    """
+    Extended hints where the answer is regex mode.
+    """
+    xml = load_fixture('extended_hints_text_input.xml')
+    problem = new_loncapa_problem(xml)
+
+    @data(
+        {'problem_id': u'1_8_1', 'choice': 'ABwrong', 'correct': 'incorrect', 'expected_string': ''},
+        {'problem_id': u'1_8_1', 'choice': 'ABC', 'correct': 'correct', 'expected_string': '<div class="feedback_hint_correct">Correct: hint1</div>'},
+        {'problem_id': u'1_8_1', 'choice': 'ABBBBC', 'correct': 'correct', 'expected_string': '<div class="feedback_hint_correct">Correct: hint1</div>'},
+        {'problem_id': u'1_8_1', 'choice': 'aBc', 'correct': 'correct', 'expected_string': '<div class="feedback_hint_correct">Correct: hint1</div>'},
+        {'problem_id': u'1_8_1', 'choice': 'BBBB', 'correct': 'correct', 'expected_string': '<div class="feedback_hint_correct">Correct: hint2</div>'},
+        {'problem_id': u'1_8_1', 'choice': 'bbb', 'correct': 'correct', 'expected_string': '<div class="feedback_hint_correct">Correct: hint2</div>'},
+        {'problem_id': u'1_8_1', 'choice': 'C', 'correct': 'incorrect', 'expected_string': u'<div class="feedback_hint_incorrect">Incorrect: hint4</div>'},
+        {'problem_id': u'1_8_1', 'choice': 'c', 'correct': 'incorrect', 'expected_string': u'<div class="feedback_hint_incorrect">Incorrect: hint4</div>'},
+        {'problem_id': u'1_8_1', 'choice': 'D', 'correct': 'incorrect', 'expected_string': u'<div class="feedback_hint_incorrect">Incorrect: hint6</div>'},
+        {'problem_id': u'1_8_1', 'choice': 'd', 'correct': 'incorrect', 'expected_string': u'<div class="feedback_hint_incorrect">Incorrect: hint6</div>'},
+    )
+    @unpack
+    def test_text_input_hints(self, problem_id, choice, correct, expected_string):
+        message_text = self.get_hint(problem_id, choice)
+        self.assertEqual(message_text, expected_string)
+        self.assertEqual(self.correctness(problem_id, choice), correct)
+
+
+@ddt
+class NumericInputHintsTest(HintTest):
+    """
+    This class consists of a suite of test cases to be run on the numeric input problem represented by the XML below.
+    """
+    xml = load_fixture('extended_hints_numeric_input.xml')
+    problem = new_loncapa_problem(xml)          # this problem is properly constructed
+
+    @data(
+        {'problem_id': u'1_2_1', 'choice': '1.141', 'expected_string': u'<div class="feedback_hint_correct">Nice: The square root of two turns up in the strangest places.</div>'},
+        {'problem_id': u'1_3_1', 'choice': '4', 'expected_string': u'<div class="feedback_hint_correct">Correct: Pretty easy, uh?.</div>'},
+        # should get hint, when correct via numeric-tolerance
+        {'problem_id': u'1_2_1', 'choice': '1.15', 'expected_string': u'<div class="feedback_hint_correct">Nice: The square root of two turns up in the strangest places.</div>'},
+        # when they answer wrong, nothing
+        {'problem_id': u'1_2_1', 'choice': '2', 'expected_string': ''},
+
+    )
+    @unpack
+    def test_numeric_input_hints(self, problem_id, choice, expected_string):
+        self._check_student_selection_result(problem_id, choice, expected_string, False)
+
+
+@ddt
+class CheckboxHintsTest(HintTest):
+    """
+    This class consists of a suite of test cases to be run on the checkbox problem represented by the XML below.
+    """
+    xml = load_fixture('extended_hints_checkbox.xml')
+    problem = new_loncapa_problem(xml)          # this problem is properly constructed
+
+    @data(
+        {'problem_id': u'1_2_1', 'choice': [u'choice_0'], 'expected_string': u'<div class="feedback_hint_incorrect">Incorrect: <div class="feedback_hint_text">You are right that apple is a fruit.</div><div class="feedback_hint_text">You are right that mushrooms are not fruit</div><div class="feedback_hint_text">Remember that grape is also a fruit.</div><div class="feedback_hint_text">What is a camero anyway?</div></div>'},
+        {'problem_id': u'1_2_1', 'choice': [u'choice_1'], 'expected_string': u'<div class="feedback_hint_incorrect">Incorrect: <div class="feedback_hint_text">Remember that apple is also a fruit.</div><div class="feedback_hint_text">Mushroom is a fungus, not a fruit.</div><div class="feedback_hint_text">Remember that grape is also a fruit.</div><div class="feedback_hint_text">What is a camero anyway?</div></div>'},
+        {'problem_id': u'1_2_1', 'choice': [u'choice_2'], 'expected_string': u'<div class="feedback_hint_incorrect">Incorrect: <div class="feedback_hint_text">Remember that apple is also a fruit.</div><div class="feedback_hint_text">You are right that mushrooms are not fruit</div><div class="feedback_hint_text">You are right that grape is a fruit</div><div class="feedback_hint_text">What is a camero anyway?</div></div>'},
+        {'problem_id': u'1_2_1', 'choice': [u'choice_3'], 'expected_string': u'<div class="feedback_hint_incorrect">Incorrect: <div class="feedback_hint_text">Remember that apple is also a fruit.</div><div class="feedback_hint_text">You are right that mushrooms are not fruit</div><div class="feedback_hint_text">Remember that grape is also a fruit.</div><div class="feedback_hint_text">What is a camero anyway?</div></div>'},
+        {'problem_id': u'1_2_1', 'choice': [u'choice_4'], 'expected_string': u'<div class="feedback_hint_incorrect">Incorrect: <div class="feedback_hint_text">Remember that apple is also a fruit.</div><div class="feedback_hint_text">You are right that mushrooms are not fruit</div><div class="feedback_hint_text">Remember that grape is also a fruit.</div><div class="feedback_hint_text">I do not know what a Camero is but it is not a fruit.</div></div>'},
+        {'problem_id': u'1_2_1', 'choice': [u'choice_0', u'choice_1'], 'expected_string': u'<div class="feedback_hint_incorrect">Almost right: <div class="feedback_hint_text">You are right that apple is a fruit, but there is one you are missing. Also, mushroom is not a fruit.</div></div>'},
+        {'problem_id': u'1_2_1', 'choice': [u'choice_1', u'choice_2'], 'expected_string': u'<div class="feedback_hint_incorrect">Incorrect: <div class="feedback_hint_text">You are right that grape is a fruit, but there is one you are missing. Also, mushroom is not a fruit.</div></div>'},
+        {'problem_id': u'1_2_1', 'choice': [u'choice_0', u'choice_2'], 'expected_string': u'<div class="feedback_hint_correct">Correct: <div class="feedback_hint_text">You are right that apple is a fruit.</div><div class="feedback_hint_text">You are right that mushrooms are not fruit</div><div class="feedback_hint_text">You are right that grape is a fruit</div><div class="feedback_hint_text">What is a camero anyway?</div></div>'},
+        {'problem_id': u'1_3_1', 'choice': [u'choice_0'], 'expected_string': u'<div class="feedback_hint_incorrect">Incorrect: <div class="feedback_hint_text">No, sorry, a banana is a fruit.</div><div class="feedback_hint_text">You are right that mushrooms are not vegatbles</div><div class="feedback_hint_text">Brussel sprout is the only vegetable in this list.</div></div>'},
+        {'problem_id': u'1_3_1', 'choice': [u'choice_1'], 'expected_string': u'<div class="feedback_hint_incorrect">Incorrect: <div class="feedback_hint_text">poor banana.</div><div class="feedback_hint_text">You are right that mushrooms are not vegatbles</div><div class="feedback_hint_text">Brussel sprout is the only vegetable in this list.</div></div>'},
+        {'problem_id': u'1_3_1', 'choice': [u'choice_2'], 'expected_string': u'<div class="feedback_hint_incorrect">Incorrect: <div class="feedback_hint_text">poor banana.</div><div class="feedback_hint_text">Mushroom is a fungus, not a vegetable.</div><div class="feedback_hint_text">Brussel sprout is the only vegetable in this list.</div></div>'},
+        {'problem_id': u'1_3_1', 'choice': [u'choice_3'], 'expected_string': u'<div class="feedback_hint_correct">Correct: <div class="feedback_hint_text">poor banana.</div><div class="feedback_hint_text">You are right that mushrooms are not vegatbles</div><div class="feedback_hint_text">Brussel sprouts are vegetables.</div></div>'},
+        {'problem_id': u'1_3_1', 'choice': [u'choice_0', u'choice_1'], 'expected_string': u'<div class="feedback_hint_incorrect">Very funny: <div class="feedback_hint_text">Making a banana split?</div></div>'},
+        {'problem_id': u'1_3_1', 'choice': [u'choice_1', u'choice_2'], 'expected_string': u'<div class="feedback_hint_incorrect">Incorrect: <div class="feedback_hint_text">poor banana.</div><div class="feedback_hint_text">Mushroom is a fungus, not a vegetable.</div><div class="feedback_hint_text">Brussel sprout is the only vegetable in this list.</div></div>'},
+        {'problem_id': u'1_3_1', 'choice': [u'choice_0', u'choice_2'], 'expected_string': u'<div class="feedback_hint_incorrect">Incorrect: <div class="feedback_hint_text">No, sorry, a banana is a fruit.</div><div class="feedback_hint_text">Mushroom is a fungus, not a vegetable.</div><div class="feedback_hint_text">Brussel sprout is the only vegetable in this list.</div></div>'},
+
+        # check for interaction between compoundhint and correct/incorrect
+        {'problem_id': u'1_4_1', 'choice': [u'choice_0', u'choice_1'], 'expected_string': u'<div class="feedback_hint_incorrect">Incorrect: <div class="feedback_hint_text">AB</div></div>'},
+        {'problem_id': u'1_4_1', 'choice': [u'choice_0', u'choice_2'], 'expected_string': u'<div class="feedback_hint_correct">Correct: <div class="feedback_hint_text">AC</div></div>'},
+
+        # check for labeling where multiple child hints have labels
+        # These are some tricky cases
+        {'problem_id': '1_5_1', 'choice': ['choice_0', 'choice_1'], 'expected_string': '<div class="feedback_hint_correct">AA: <div class="feedback_hint_text">aa</div></div>'},
+        {'problem_id': '1_5_1', 'choice': ['choice_0'], 'expected_string': '<div class="feedback_hint_incorrect">Incorrect: <div class="feedback_hint_text">aa</div><div class="feedback_hint_text">bb</div></div>'},
+        {'problem_id': '1_5_1', 'choice': ['choice_1'], 'expected_string': ''},
+        {'problem_id': '1_5_1', 'choice': [], 'expected_string': '<div class="feedback_hint_incorrect">BB: <div class="feedback_hint_text">bb</div></div>'},
+
+        {'problem_id': '1_6_1', 'choice': ['choice_0'], 'expected_string': '<div class="feedback_hint_incorrect"><div class="feedback_hint_text">aa</div></div>'},
+        {'problem_id': '1_6_1', 'choice': ['choice_0', 'choice_1'], 'expected_string': '<div class="feedback_hint_correct"><div class="feedback_hint_text">compoundo</div></div>'},
+
+    )
+    @unpack
+    def test_checkbox_hints(self, problem_id, choice, expected_string):
+        self._check_student_selection_result(problem_id, choice, expected_string, False)
+
+
+@ddt
+class MultpleChoiceHintsTest(HintTest):
+    """
+    This class consists of a suite of test cases to be run on the multiple choice problem represented by the XML below.
+    """
+    xml = load_fixture('extended_hints_multiple_choice.xml')
+    problem = new_loncapa_problem(xml)
+
+    @data(
+        {'problem_id': u'1_2_1', 'choice': u'choice_0', 'expected_string': '<div class="feedback_hint_incorrect">Mushroom is a fungus, not a fruit.</div>'},
+        {'problem_id': u'1_2_1', 'choice': u'choice_1', 'expected_string': ''},
+        {'problem_id': u'1_3_1', 'choice': u'choice_1', 'expected_string': '<div class="feedback_hint_correct">Correct: Potato is a root vegetable.</div>'},
+        {'problem_id': u'1_2_1', 'choice': u'choice_2', 'expected_string': '<div class="feedback_hint_correct">OUTSTANDING: Apple is indeed a fruit.</div>'},
+        {'problem_id': u'1_3_1', 'choice': u'choice_2', 'expected_string': '<div class="feedback_hint_incorrect">OOPS: Apple is a fruit.</div>'},
+        {'problem_id': u'1_3_1', 'choice': u'choice_9', 'expected_string': ''},
+    )
+    @unpack
+    def test_multiplechoice_hints(self, problem_id, choice, expected_string):
+        self._check_student_selection_result(problem_id, choice, expected_string, False)
+
+
+@ddt
+class DropdownHintsTest(HintTest):
+    """
+    This class consists of a suite of test cases to be run on the drop down problem represented by the XML below.
+    """
+    xml = load_fixture('extended_hints_dropdown.xml')
+    problem = new_loncapa_problem(xml)
+
+    @data(
+        {'problem_id': u'1_2_1', 'choice': 'Multiple Choice', 'expected_string': '<div class="feedback_hint_correct">Good Job: Yes, multiple choice is the right answer.</div>'},
+        {'problem_id': u'1_2_1', 'choice': 'Text Input', 'expected_string': '<div class="feedback_hint_incorrect">Incorrect: No, text input problems do not present options.</div>'},
+        {'problem_id': u'1_2_1', 'choice': 'Numerical Input', 'expected_string': '<div class="feedback_hint_incorrect">Incorrect: No, numerical input problems do not present options.</div>'},
+        {'problem_id': u'1_3_1', 'choice': 'FACES', 'expected_string': '<div class="feedback_hint_correct">Correct: With lots of makeup, doncha know?</div>'},
+        {'problem_id': u'1_3_1', 'choice': 'dogs', 'expected_string': '<div class="feedback_hint_incorrect">NOPE: Not dogs, not cats, not toads</div>'},
+        {'problem_id': u'1_3_1', 'choice': 'wrongo', 'expected_string': ''},
+    )
+    @unpack
+    def test_dropdown_hints(self, problem_id, choice, expected_string):
+        self._check_student_selection_result(problem_id, choice, expected_string, False)
+
+
+class ErrorConditionsTest(HintTest):
+    """
+    Intentional errors are exercised.
+    """
+
+    def test_error_conditions_illegal_element(self):
+        xml_with_errors = load_fixture('extended_hints_with_errors.xml')
+        with self.assertRaises(Exception):
+            new_loncapa_problem(xml_with_errors)    # this problem is improperly constructed

--- a/common/lib/capa/capa/tests/test_responsetypes.py
+++ b/common/lib/capa/capa/tests/test_responsetypes.py
@@ -708,6 +708,12 @@ class StringResponseTest(ResponseTest):
         # Other strings and the lowercase version of the string are incorrect
         self.assert_grade(problem, "Other String", "incorrect")
 
+    def test_compatible_old_additional_answer_xml(self):
+        problem = self.build_problem(answer="Donut", old_answers=["Sprinkles"])
+        self.assert_grade(problem, "Donut", "correct")
+        self.assert_grade(problem, "Sprinkles", "correct")
+        self.assert_grade(problem, "Meh", "incorrect")
+
     def test_partial_matching(self):
         problem = self.build_problem(answer="a2", case_sensitive=False, regexp=True, additional_answers=['.?\\d.?'])
         self.assert_grade(problem, "a3", "correct")

--- a/common/lib/xmodule/xmodule/capa_module.py
+++ b/common/lib/xmodule/xmodule/capa_module.py
@@ -58,6 +58,7 @@ class CapaModule(CapaMixin, XModule):
           <other request-specific values here > }
         """
         handlers = {
+            'hint_button': self.hint_button,
             'problem_get': self.get_problem,
             'problem_check': self.check_problem,
             'problem_reset': self.reset_problem,
@@ -193,6 +194,7 @@ class CapaDescriptor(CapaFields, RawDescriptor):
     get_problem_html = module_attr('get_problem_html')
     get_state_for_lcp = module_attr('get_state_for_lcp')
     handle_input_ajax = module_attr('handle_input_ajax')
+    hint_button = module_attr('hint_button')
     handle_problem_html_error = module_attr('handle_problem_html_error')
     handle_ungraded_response = module_attr('handle_ungraded_response')
     is_attempted = module_attr('is_attempted')

--- a/common/lib/xmodule/xmodule/css/capa/display.scss
+++ b/common/lib/xmodule/xmodule/css/capa/display.scss
@@ -19,6 +19,22 @@ h2 {
   }
 }
 
+div.feedback_hint_correct {
+    color: green;
+}
+
+div.feedback_hint_incorrect {
+    color: red;
+}
+
+div.feedback_hint_text {
+    color: black;
+}
+
+div.problem_hint {
+    color: #808080;
+    margin-bottom: 20px;
+}
 
 iframe[seamless]{
   overflow: hidden;
@@ -618,7 +634,7 @@ div.problem {
   div.action {
     margin-top: $baseline;
 
-    .save, .check, .show, .reset {
+    .save, .check, .show, .reset, .hint_button {
       height: ($baseline*2);
       vertical-align: middle;
       font-weight: 600;

--- a/common/lib/xmodule/xmodule/js/spec/problem/edit_spec.coffee
+++ b/common/lib/xmodule/xmodule/js/spec/problem/edit_spec.coffee
@@ -455,9 +455,9 @@ describe 'MarkdownEditingDescriptor', ->
       expect(data).toEqual("""<problem>
         <p>Who lead the civil right movement in the United States of America?</p>
         <stringresponse answer="Dr. Martin Luther King Jr." type="ci" >
-          <additional_answer>Doctor Martin Luther King Junior</additional_answer>
-          <additional_answer>Martin Luther King</additional_answer>
-          <additional_answer>Martin Luther King Junior</additional_answer>
+          <additional_answer answer="Doctor Martin Luther King Junior"></additional_answer>
+          <additional_answer answer="Martin Luther King"></additional_answer>
+          <additional_answer answer="Martin Luther King Junior"></additional_answer>
           <textline size="20"/>
         </stringresponse>
 
@@ -484,9 +484,9 @@ describe 'MarkdownEditingDescriptor', ->
       expect(data).toEqual("""<problem>
         <p>Write a number from 1 to 4.</p>
         <stringresponse answer="^One$" type="ci regexp" >
-          <additional_answer>two</additional_answer>
-          <additional_answer>^thre+</additional_answer>
-          <additional_answer>^4|Four$</additional_answer>
+          <additional_answer answer="two"></additional_answer>
+          <additional_answer answer="^thre+"></additional_answer>
+          <additional_answer answer="^4|Four$"></additional_answer>
           <textline size="20"/>
         </stringresponse>
 

--- a/common/lib/xmodule/xmodule/js/spec/problem/edit_spec_hint.coffee
+++ b/common/lib/xmodule/xmodule/js/spec/problem/edit_spec_hint.coffee
@@ -1,0 +1,772 @@
+# This file tests the parsing of  extended-hints, double bracket sections {{ .. }}
+# for all sorts of markdown.
+describe 'drop down optionresponse components', ->
+  it 'multiple multiline (new-style) drop down with hints', ->
+    data = MarkdownEditingDescriptor.markdownToXml("""
+      Translation between Dropdown and ________ is straightforward.
+
+      [[
+         (Multiple Choice) 	 {{ Good Job::Yes, multiple choice is the right answer. }}
+         Text Input	                  {{ No, text input problems don't present options. }}
+         Numerical Input	 {{ No, numerical input problems don't present options. }}
+      ]]
+
+
+
+      Clowns have funny _________ to make people laugh.
+      
+      [[
+        dogs		{{ NOPE::Not dogs, not cats, not toads }}
+        (FACES)	{{ With lots of makeup, doncha know?}}
+            
+        money       {{ Clowns don't have any money, of course }}
+        donkeys     {{don't be an ass.}}
+        -no hint-
+      ]]
+
+    """)
+    expect(data).toEqual("""
+    <problem>
+    <p>Translation between Dropdown and ________ is straightforward.</p>
+    <optionresponse>
+      <optioninput>
+        <option correct="True">Multiple Choice <optionhint label="Good Job">Yes, multiple choice is the right answer.</optionhint></option>
+        <option correct="False">Text Input <optionhint>No, text input problems don't present options.</optionhint></option>
+        <option correct="False">Numerical Input <optionhint>No, numerical input problems don't present options.</optionhint></option>
+      </optioninput>
+    </optionresponse>
+
+    <p>Clowns have funny _________ to make people laugh.</p>
+    <optionresponse>
+      <optioninput>
+        <option correct="False">dogs <optionhint label="NOPE">Not dogs, not cats, not toads</optionhint></option>
+        <option correct="True">FACES <optionhint>With lots of makeup, doncha know?</optionhint></option>
+        <option correct="False">money <optionhint>Clowns don't have any money, of course</optionhint></option>
+        <option correct="False">donkeys <optionhint>don't be an ass.</optionhint></option>
+        <option correct="False">-no hint-</option>
+      </optioninput>
+    </optionresponse>
+    
+    </problem>
+    """)
+
+  it 'drop down with demand hint', ->
+    data = MarkdownEditingDescriptor.markdownToXml("""
+      Translation between Dropdown and ________ is straightforward.
+
+      [[
+         (Right) 	 {{ Good Job::yes }}
+         Wrong 1	                  {{no}}
+         Wrong 2	 {{ Label::no }}
+      ]]
+
+      || 0) zero ||
+      || 1) one ||
+      || 2) two ||
+    """)
+    expect(data).toEqual("""
+    <problem>
+    <p>Translation between Dropdown and ________ is straightforward.</p>
+    <optionresponse>
+      <optioninput>
+        <option correct="True">Right <optionhint label="Good Job">yes</optionhint></option>
+        <option correct="False">Wrong 1 <optionhint>no</optionhint></option>
+        <option correct="False">Wrong 2 <optionhint label="Label">no</optionhint></option>
+      </optioninput>
+    </optionresponse>
+
+    <demandhint>
+      <hint>0) zero</hint>
+      <hint>1) one</hint>
+      <hint>2) two</hint>
+    </demandhint>
+    </problem>
+    """)
+
+  it 'single-line (old-style) drop down plus demand hint', ->
+    data = MarkdownEditingDescriptor.markdownToXml("""
+      A Question ________ is answered.
+
+      [[(Right), Wrong 1, Wrong 2]]
+      || 0) zero ||
+      || 1) one ||
+    """)
+    expect(data).toEqual("""
+    <problem>
+    <p>A Question ________ is answered.</p>
+    <optionresponse>
+      <optioninput options="('Right','Wrong 1','Wrong 2')" correct="Right"></optioninput>
+    </optionresponse>
+
+    <demandhint>
+      <hint>0) zero</hint>
+      <hint>1) one</hint>
+    </demandhint>
+    </problem>
+    """)
+
+  it ' multiline (new-style) drop down with fewer newlines', ->
+    data = MarkdownEditingDescriptor.markdownToXml("""
+      >>q1<<
+      [[ (aa) 	 {{ hint1 }}
+         bb
+         cc	 {{ hint2 }} ]]
+    """)
+    expect(data).toEqual("""
+    <problem>
+    <p>q1</p>
+    
+    <optionresponse>
+      <optioninput label="q1">
+        <option correct="True">aa <optionhint>hint1</optionhint></option>
+        <option correct="False">bb</option>
+        <option correct="False">cc <optionhint>hint2</optionhint></option>
+      </optioninput>
+    </optionresponse>
+    
+    
+    </problem>
+    """)
+
+  it ' multiline (new-style) drop down with extra blank lines and whitespace', ->
+    data = MarkdownEditingDescriptor.markdownToXml("""
+      >>q1<<
+      [[
+      
+            
+          aa   {{ hint1 }}
+        
+              bb   {{ hint2 }}
+       (cc)
+         
+              ]]
+    """)
+    expect(data).toEqual("""
+    <problem>
+    <p>q1</p>
+    
+    <optionresponse>
+      <optioninput label="q1">
+        <option correct="False">aa <optionhint>hint1</optionhint></option>
+        <option correct="False">bb <optionhint>hint2</optionhint></option>
+        <option correct="True">cc</option>
+      </optioninput>
+    </optionresponse>
+    
+    
+    </problem>
+    """)
+
+describe 'checkbox components', ->
+  it 'multiple checkbox components', ->
+    data = MarkdownEditingDescriptor.markdownToXml("""
+      >>Select all the fruits from the list<<
+            
+      [x] Apple     	 	 {{ selected: You're right that apple is a fruit. }, {unselected: Remember that apple is also a fruit.}}
+      [ ] Mushroom	   	 {{U: You're right that mushrooms aren't fruit}, { selected: Mushroom is a fungus, not a fruit.}}
+      [x] Grape		     {{ selected: You're right that grape is a fruit }, {unselected: Remember that grape is also a fruit.}}
+      [ ] Mustang
+      [ ] Camero            {{S:I don't know what a Camero is but it isn't a fruit.},{U:What is a camero anyway?}}
+
+                
+      {{ ((A*B)) You're right that apple is a fruit, but there's one you're missing. Also, mushroom is not a fruit.}}
+      {{ ((B*C)) You're right that grape is a fruit, but there's one you're missing. Also, mushroom is not a fruit.    }}
+
+
+      >>Select all the vegetables from the list<<
+             
+      [ ] Banana     	 	 {{ selected: No, sorry, a banana is a fruit. }, {unselected: poor banana.}}
+      [ ] Ice Cream
+      [ ] Mushroom	   	 {{U: You're right that mushrooms aren't vegetables.}, { selected: Mushroom is a fungus, not a vegetable.}}
+      [x] Brussel Sprout	 {{S: Brussel sprouts are vegetables.}, {u: Brussel sprout is the only vegetable in this list.}}
+
+
+      {{ ((A*B)) Making a banana split? }}
+      {{ ((B*D)) That will make a horrible dessert: a brussel sprout split? }}
+    """)
+    expect(data).toEqual("""
+    <problem>
+    <p>Select all the fruits from the list</p>
+    <choiceresponse>
+      <checkboxgroup label="Select all the fruits from the list" direction="vertical">
+        <choice correct="true">Apple
+          <choicehint selected="true">You're right that apple is a fruit.</choicehint>
+          <choicehint selected="false">Remember that apple is also a fruit.</choicehint></choice>
+        <choice correct="false">Mushroom
+          <choicehint selected="true">Mushroom is a fungus, not a fruit.</choicehint>
+          <choicehint selected="false">You're right that mushrooms aren't fruit</choicehint></choice>
+        <choice correct="true">Grape
+          <choicehint selected="true">You're right that grape is a fruit</choicehint>
+          <choicehint selected="false">Remember that grape is also a fruit.</choicehint></choice>
+        <choice correct="false">Mustang</choice>
+        <choice correct="false">Camero
+          <choicehint selected="true">I don't know what a Camero is but it isn't a fruit.</choicehint>
+          <choicehint selected="false">What is a camero anyway?</choicehint></choice>
+        <compoundhint value="A*B">You're right that apple is a fruit, but there's one you're missing. Also, mushroom is not a fruit.</compoundhint>
+        <compoundhint value="B*C">You're right that grape is a fruit, but there's one you're missing. Also, mushroom is not a fruit.</compoundhint>
+      </checkboxgroup>
+    </choiceresponse>
+
+    <p>Select all the vegetables from the list</p>
+    <choiceresponse>
+      <checkboxgroup label="Select all the vegetables from the list" direction="vertical">
+        <choice correct="false">Banana
+          <choicehint selected="true">No, sorry, a banana is a fruit.</choicehint>
+          <choicehint selected="false">poor banana.</choicehint></choice>
+        <choice correct="false">Ice Cream</choice>
+        <choice correct="false">Mushroom
+          <choicehint selected="true">Mushroom is a fungus, not a vegetable.</choicehint>
+          <choicehint selected="false">You're right that mushrooms aren't vegetables.</choicehint></choice>
+        <choice correct="true">Brussel Sprout
+          <choicehint selected="true">Brussel sprouts are vegetables.</choicehint>
+          <choicehint selected="false">Brussel sprout is the only vegetable in this list.</choicehint></choice>
+        <compoundhint value="A*B">Making a banana split?</compoundhint>
+        <compoundhint value="B*D">That will make a horrible dessert: a brussel sprout split?</compoundhint>
+      </checkboxgroup>
+    </choiceresponse>
+
+
+    </problem>
+    """)
+
+
+  it 'multiple checkbox components plus demand hints', ->
+    data = MarkdownEditingDescriptor.markdownToXml("""
+      >>Select all the fruits from the list<<
+
+              [x] Apple     	 	 {{ selected: You're right that apple is a fruit. }, {unselected: Remember that apple is also a fruit.}}
+              [ ] Mushroom	   	 {{U: You're right that mushrooms aren't fruit}, { selected: Mushroom is a fungus, not a fruit.}}
+              [x] Grape		     {{ selected: You're right that grape is a fruit }, {unselected: Remember that grape is also a fruit.}}
+              [ ] Mustang
+              [ ] Camero            {{S:I don't know what a Camero is but it isn't a fruit.},{U:What is a camero anyway?}}
+
+
+              {{ ((A*B)) You're right that apple is a fruit, but there's one you're missing. Also, mushroom is not a fruit.}}
+              {{ ((B*C)) You're right that grape is a fruit, but there's one you're missing. Also, mushroom is not a fruit.}}
+
+
+
+      >>Select all the vegetables from the list<<
+
+              [ ] Banana     	 	 {{ selected: No, sorry, a banana is a fruit. }, {unselected: poor banana.}}
+              [ ] Ice Cream
+              [ ] Mushroom	   	 {{U: You're right that mushrooms aren't vegatbles}, { selected: Mushroom is a fungus, not a vegetable.}}
+              [x] Brussel Sprout	 {{S: Brussel sprouts are vegetables.}, {u: Brussel sprout is the only vegetable in this list.}}
+
+
+              {{ ((A*B)) Making a banana split? }}
+              {{ ((B*D)) That will make a horrible dessert: a brussel sprout split? }}
+
+
+      || Hint one.||
+      || Hint two. ||
+      || Hint three. ||
+    """)
+    expect(data).toEqual("""
+    <problem>
+    <p>Select all the fruits from the list</p>
+    <choiceresponse>
+      <checkboxgroup label="Select all the fruits from the list" direction="vertical">
+        <choice correct="true">Apple
+          <choicehint selected="true">You're right that apple is a fruit.</choicehint>
+          <choicehint selected="false">Remember that apple is also a fruit.</choicehint></choice>
+        <choice correct="false">Mushroom
+          <choicehint selected="true">Mushroom is a fungus, not a fruit.</choicehint>
+          <choicehint selected="false">You're right that mushrooms aren't fruit</choicehint></choice>
+        <choice correct="true">Grape
+          <choicehint selected="true">You're right that grape is a fruit</choicehint>
+          <choicehint selected="false">Remember that grape is also a fruit.</choicehint></choice>
+        <choice correct="false">Mustang</choice>
+        <choice correct="false">Camero
+          <choicehint selected="true">I don't know what a Camero is but it isn't a fruit.</choicehint>
+          <choicehint selected="false">What is a camero anyway?</choicehint></choice>
+        <compoundhint value="A*B">You're right that apple is a fruit, but there's one you're missing. Also, mushroom is not a fruit.</compoundhint>
+        <compoundhint value="B*C">You're right that grape is a fruit, but there's one you're missing. Also, mushroom is not a fruit.</compoundhint>
+      </checkboxgroup>
+    </choiceresponse>
+
+    <p>Select all the vegetables from the list</p>
+    <choiceresponse>
+      <checkboxgroup label="Select all the vegetables from the list" direction="vertical">
+        <choice correct="false">Banana
+          <choicehint selected="true">No, sorry, a banana is a fruit.</choicehint>
+          <choicehint selected="false">poor banana.</choicehint></choice>
+        <choice correct="false">Ice Cream</choice>
+        <choice correct="false">Mushroom
+          <choicehint selected="true">Mushroom is a fungus, not a vegetable.</choicehint>
+          <choicehint selected="false">You're right that mushrooms aren't vegatbles</choicehint></choice>
+        <choice correct="true">Brussel Sprout
+          <choicehint selected="true">Brussel sprouts are vegetables.</choicehint>
+          <choicehint selected="false">Brussel sprout is the only vegetable in this list.</choicehint></choice>
+        <compoundhint value="A*B">Making a banana split?</compoundhint>
+        <compoundhint value="B*D">That will make a horrible dessert: a brussel sprout split?</compoundhint>
+      </checkboxgroup>
+    </choiceresponse>
+
+
+    <demandhint>
+      <hint>Hint one.</hint>
+      <hint>Hint two.</hint>
+      <hint>Hint three.</hint>
+    </demandhint>
+    </problem>
+    """)
+
+
+describe 'multiple choice components', ->
+  it 'multiple choice with hints', ->
+    data = MarkdownEditingDescriptor.markdownToXml("""
+      >>Select the fruit from the list<<
+                     
+            () Mushroom	  	 {{ Mushroom is a fungus, not a fruit.}}
+            () Potato
+           (x) Apple     	 	 {{ OUTSTANDING::Apple is indeed a fruit.}}
+
+      >>Select the vegetables from the list<<
+
+            () Mushroom	  	 {{ Mushroom is a fungus, not a vegetable.}}
+            (x) Potato	                 {{ Potato is a root vegetable. }}
+            () Apple     	 	 {{ OOPS::Apple is a fruit.}}
+    """)
+    expect(data).toEqual("""
+    <problem>
+    <p>Select the fruit from the list</p>
+    <multiplechoiceresponse>
+      <choicegroup label="Select the fruit from the list" type="MultipleChoice">
+        <choice correct="false">Mushroom <choicehint>Mushroom is a fungus, not a fruit.</choicehint></choice>
+        <choice correct="false">Potato</choice>
+        <choice correct="true">Apple <choicehint label="OUTSTANDING">Apple is indeed a fruit.</choicehint></choice>
+      </choicegroup>
+    </multiplechoiceresponse>
+    
+    <p>Select the vegetables from the list</p>
+    <multiplechoiceresponse>
+      <choicegroup label="Select the vegetables from the list" type="MultipleChoice">
+        <choice correct="false">Mushroom <choicehint>Mushroom is a fungus, not a vegetable.</choicehint></choice>
+        <choice correct="true">Potato <choicehint>Potato is a root vegetable.</choicehint></choice>
+        <choice correct="false">Apple <choicehint label="OOPS">Apple is a fruit.</choicehint></choice>
+      </choicegroup>
+    </multiplechoiceresponse>
+    
+    
+    </problem>
+    """)
+
+  it 'multiple choice with hints and demand hints', ->
+      data = MarkdownEditingDescriptor.markdownToXml("""
+                     >>Select the fruit from the list<<
+
+                                () Mushroom	  	 {{ Mushroom is a fungus, not a fruit.}}
+                                () Potato
+                               (x) Apple     	 	 {{ OUTSTANDING::Apple is indeed a fruit.}}
+                         
+                         
+                     || 0) spaces on previous line. ||
+                     || 1) roses are red. ||
+                     >>Select the vegetables from the list<<
+
+                                () Mushroom	  	 {{ Mushroom is a fungus, not a vegetable.}}
+                                                      
+                                (x) Potato	                 {{ Potato is a root vegetable. }}
+                                () Apple     	 	 {{ OOPS::Apple is a fruit.}}
+                       
+                       
+                     || 2) where are the lions? ||
+
+
+
+      """)
+      expect(data).toEqual("""
+    <problem>
+    <p>Select the fruit from the list</p>
+    <multiplechoiceresponse>
+      <choicegroup label="Select the fruit from the list" type="MultipleChoice">
+        <choice correct="false">Mushroom <choicehint>Mushroom is a fungus, not a fruit.</choicehint></choice>
+        <choice correct="false">Potato</choice>
+        <choice correct="true">Apple <choicehint label="OUTSTANDING">Apple is indeed a fruit.</choicehint></choice>
+      </choicegroup>
+    </multiplechoiceresponse>
+
+    <p>Select the vegetables from the list</p>
+    <multiplechoiceresponse>
+      <choicegroup label="Select the vegetables from the list" type="MultipleChoice">
+        <choice correct="false">Mushroom <choicehint>Mushroom is a fungus, not a vegetable.</choicehint></choice>
+        <choice correct="true">Potato <choicehint>Potato is a root vegetable.</choicehint></choice>
+        <choice correct="false">Apple <choicehint label="OOPS">Apple is a fruit.</choicehint></choice>
+      </choicegroup>
+    </multiplechoiceresponse>
+
+
+    <demandhint>
+      <hint>0) spaces on previous line.</hint>
+      <hint>1) roses are red.</hint>
+      <hint>2) where are the lions?</hint>
+    </demandhint>
+    </problem>
+    """)
+
+
+describe 'text input components', ->
+  it 'text input with hints', ->
+    data = MarkdownEditingDescriptor.markdownToXml(""">>In which country would you find the city of Paris?<<
+                    = France		{{ BRAVO::Viva la France! }}
+
+    """)
+    expect(data).toEqual("""
+    <problem>
+    <p>In which country would you find the city of Paris?</p>
+    <stringresponse answer="France" type="ci" >
+      <correcthint label="BRAVO">Viva la France!</correcthint>
+      <textline label="In which country would you find the city of Paris?" size="20"/>
+    </stringresponse>
+
+    </problem>
+    """)
+
+  it 'text input with or= with hints', ->
+    data = MarkdownEditingDescriptor.markdownToXml(""">>Where Paris?<<
+      = France		{{ BRAVO::hint1}}
+      or= USA			{{   meh::hint2  }}
+
+    """)
+    expect(data).toEqual("""
+    <problem>
+    <p>Where Paris?</p>
+    <stringresponse answer="France" type="ci" >
+      <correcthint label="BRAVO">hint1</correcthint>
+      <additional_answer answer="USA"><correcthint label="meh">hint2</correcthint></additional_answer>
+      <textline label="Where Paris?" size="20"/>
+    </stringresponse>
+    
+    </problem>
+    """)
+
+  it 'text input with demand hints', ->
+    data = MarkdownEditingDescriptor.markdownToXml(""">>Where Paris?<<
+          = France		{{ BRAVO::hint1 }}
+
+          || There are actually two countries with cities named Paris. ||
+          || Paris is the capital of one of those countries. ||
+
+    """)
+    expect(data).toEqual("""
+    <problem>
+    <p>Where Paris?</p>
+    <stringresponse answer="France" type="ci" >
+      <correcthint label="BRAVO">hint1</correcthint>
+      <textline label="Where Paris?" size="20"/>
+    </stringresponse>
+    
+    <demandhint>
+      <hint>There are actually two countries with cities named Paris.</hint>
+      <hint>Paris is the capital of one of those countries.</hint>
+    </demandhint>
+    </problem>""")
+
+
+describe 'numeric input components', ->
+  it 'numeric input with hints', ->
+    data = MarkdownEditingDescriptor.markdownToXml("""
+        >>Enter the numerical value of Pi:<<
+        = 3.14159 +- .02   {{ Pie for everyone!   }}
+
+        >>Enter the approximate value of 502*9:<<
+        = 4518 +- 15%  {{PIE:: No pie for you!}}
+
+        >>Enter the number of fingers on a human hand<<
+        = 5
+        
+
+    """)
+    expect(data).toEqual("""
+    <problem>
+    <p>Enter the numerical value of Pi:</p>
+    <numericalresponse answer="3.14159">
+      <responseparam type="tolerance" default=".02" />
+      <formulaequationinput label="Enter the numerical value of Pi:" />
+      <correcthint>Pie for everyone!</correcthint>
+    </numericalresponse>
+
+    <p>Enter the approximate value of 502*9:</p>
+    <numericalresponse answer="4518">
+      <responseparam type="tolerance" default="15%" />
+      <formulaequationinput label="Enter the approximate value of 502*9:" />
+      <correcthint label="PIE">No pie for you!</correcthint>
+    </numericalresponse>
+
+    <p>Enter the number of fingers on a human hand</p>
+    <numericalresponse answer="5">
+      <formulaequationinput label="Enter the number of fingers on a human hand" />
+    </numericalresponse>
+
+
+    </problem>
+    """)
+
+  # The output xml here shows some of the quirks of how historical markdown parsing does or does not put
+  # in blank lines.
+  # TODO nparlante: there's a bug in the parsing stack if the >>text<< is the same twice
+  it 'numeric input with hints and demand hints', ->
+    data = MarkdownEditingDescriptor.markdownToXml("""
+        >>text1<<
+        = 1   {{ hint1  }}
+        || hintA ||
+        >>text2<<
+        = 2 {{ hint2 }}
+
+        || hintB ||
+
+    """)
+    expect(data).toEqual("""
+    <problem>
+    <p>text1</p>
+    <numericalresponse answer="1">
+      <formulaequationinput label="text1" />
+      <correcthint>hint1</correcthint>
+    </numericalresponse>
+    <p>text2</p>
+    <numericalresponse answer="2">
+      <formulaequationinput label="text2" />
+      <correcthint>hint2</correcthint>
+    </numericalresponse>
+
+    <demandhint>
+      <hint>hintA</hint>
+      <hint>hintB</hint>
+    </demandhint>
+    </problem>
+    """)
+
+
+describe 'multi-line extended hints', ->
+  it 'with all question types', ->
+    data = MarkdownEditingDescriptor.markdownToXml("""
+        >>Checkboxes<<
+
+        [x] A {{ 
+        selected:  aaa  },
+        {unselected:bbb}}
+        [ ] B {{U: c}, { 
+        selected: d.}}
+
+        {{ ((A*B)) A*B hint}}
+
+        >>What is 1 + 1?<<
+        = 2  {{ part one, and
+                part two
+             }}
+
+        >>hello?<<
+        = hello {{
+        hello
+        hint
+        }}
+        
+        >>multiple choice<<
+        (x) AA{{hint1}}
+        () BB    {{
+             hint2
+        }}
+        ( )  CC  {{ hint3
+        }}
+        
+        >>dropdown<<
+        [[
+           W1  {{ 
+          	no }}
+           W2	                  {{
+           nope}}
+           (C1)	 {{ yes
+            }}
+        ]]
+
+        || aaa ||
+        ||bbb||
+        ||       ccc      ||
+
+    """)
+    expect(data).toEqual("""
+    <problem>
+    <p>Checkboxes</p>
+    <choiceresponse>
+      <checkboxgroup label="Checkboxes" direction="vertical">
+        <choice correct="true">A
+          <choicehint selected="true">aaa</choicehint>
+          <choicehint selected="false">bbb</choicehint></choice>
+        <choice correct="false">B
+          <choicehint selected="true">d.</choicehint>
+          <choicehint selected="false">c</choicehint></choice>
+        <compoundhint value="A*B">A*B hint</compoundhint>
+      </checkboxgroup>
+    </choiceresponse>
+
+    <p>What is 1 + 1?</p>
+    <numericalresponse answer="2">
+      <formulaequationinput label="What is 1 + 1?" />
+      <correcthint>part one, and part two</correcthint>
+    </numericalresponse>
+
+    <p>hello?</p>
+    <stringresponse answer="hello" type="ci" >
+      <correcthint>hello hint</correcthint>
+      <textline label="hello?" size="20"/>
+    </stringresponse>
+
+    <p>multiple choice</p>
+    <multiplechoiceresponse>
+      <choicegroup label="multiple choice" type="MultipleChoice">
+        <choice correct="true">AA <choicehint>hint1</choicehint></choice>
+        <choice correct="false">BB <choicehint>hint2</choicehint></choice>
+        <choice correct="false">CC <choicehint>hint3</choicehint></choice>
+      </choicegroup>
+    </multiplechoiceresponse>
+
+    <p>dropdown</p>
+
+    <optionresponse>
+      <optioninput label="dropdown">
+        <option correct="False">W1 <optionhint>no</optionhint></option>
+        <option correct="False">W2 <optionhint>nope</optionhint></option>
+        <option correct="True">C1 <optionhint>yes</optionhint></option>
+      </optioninput>
+    </optionresponse>
+
+    <demandhint>
+      <hint>aaa</hint>
+      <hint>bbb</hint>
+      <hint>ccc</hint>
+    </demandhint>
+    </problem>
+    """)
+
+describe 'tricky syntax cases', ->
+  # I'm entering this as utf-8 in this file.
+  # I cannot find a way to set the encoding for .coffee files but it seems to work.
+  it 'unicode', ->
+    data = MarkdownEditingDescriptor.markdownToXml("""
+        >>á and Ø<<
+
+        (x) Ø{{Ø}}
+        () BB
+
+        || Ø ||
+
+    """)
+    expect(data).toEqual("""
+    <problem>
+    <p>á and Ø</p>
+    <multiplechoiceresponse>
+      <choicegroup label="á and Ø" type="MultipleChoice">
+        <choice correct="true">Ø <choicehint>Ø</choicehint></choice>
+        <choice correct="false">BB</choice>
+      </choicegroup>
+    </multiplechoiceresponse>
+    
+    
+    <demandhint>
+      <hint>Ø</hint>
+    </demandhint>
+    </problem>
+    """)
+    
+  it 'quote-type characters', ->
+    data = MarkdownEditingDescriptor.markdownToXml("""
+        >>"quotes" aren't `fun`<<
+        () "hello" {{ isn't }}
+        (x) "isn't"  {{ "hello" }}
+
+    """)
+    expect(data).toEqual("""
+    <problem>
+    <p>"quotes" aren't `fun`</p>
+    <multiplechoiceresponse>
+      <choicegroup label="&quot;quotes&quot; aren&apos;t `fun`" type="MultipleChoice">
+        <choice correct="false">"hello" <choicehint>isn't</choicehint></choice>
+        <choice correct="true">"isn't" <choicehint>"hello"</choicehint></choice>
+      </choicegroup>
+    </multiplechoiceresponse>
+
+
+    </problem>
+    """)
+
+  it 'almost but not quite multiple choice syntax', ->
+    data = MarkdownEditingDescriptor.markdownToXml("""
+        >>q1<<
+        this (x)
+        () a  {{ (hint) }}
+        (x) b
+        that (y)
+    """)
+    expect(data).toEqual("""
+    <problem>
+    <p>q1</p>
+    <p>this (x)</p>
+    <multiplechoiceresponse>
+      <choicegroup label="q1" type="MultipleChoice">
+        <choice correct="false">a <choicehint>(hint)</choicehint></choice>
+        <choice correct="true">b</choice>
+      </choicegroup>
+    </multiplechoiceresponse>
+
+    <p>that (y)</p>
+    </problem>
+    """)
+
+  # An incomplete checkbox hint passes through to cue the author
+  it 'almost checkboxgroup syntax', ->
+    data = MarkdownEditingDescriptor.markdownToXml("""
+        >>q1<<
+        this [x]
+        [ ] a [square]
+        [x] b {{ this hint passes through }}
+        that []
+    """)
+    expect(data).toEqual("""
+    <problem>
+    <p>q1</p>
+    <p>this [x]</p>
+    <choiceresponse>
+      <checkboxgroup label="q1" direction="vertical">
+        <choice correct="false">a [square]</choice>
+        <choice correct="true">b {{ this hint passes through }}</choice>
+      </checkboxgroup>
+    </choiceresponse>
+
+    <p>that []</p>
+    </problem>
+    """)
+
+  # It's sort of a pain to edit DOS line endings without some editor or other "fixing" them
+  # for you. Therefore, we construct DOS line endings on the fly just for the test.
+  it 'check for DOS \r\n line endings', ->
+    markdown = """
+           q22
+
+           [[  
+              (x) {{ hintx
+                  these
+                  span
+                  }}
+
+              yy	                 {{ meh::hinty }}
+              zzz	{{ hintz }}
+           ]]
+      """
+    markdown = markdown.replace(/\n/g, '\r\n')  # make DOS line endings
+    data = MarkdownEditingDescriptor.markdownToXml(markdown)
+    expect(data).toEqual("""
+    <problem>
+    <p>q22</p>
+    <optionresponse>
+      <optioninput>
+        <option correct="True">x <optionhint>hintx these span</optionhint></option>
+        <option correct="False">yy <optionhint label="meh">hinty</optionhint></option>
+        <option correct="False">zzz <optionhint>hintz</optionhint></option>
+      </optioninput>
+    </optionresponse>
+    
+    
+    </problem>
+    """)
+

--- a/common/lib/xmodule/xmodule/js/src/capa/display.coffee
+++ b/common/lib/xmodule/xmodule/js/src/capa/display.coffee
@@ -31,6 +31,8 @@ class @Problem
     @checkButtonCheckText = @checkButton.val()
     @checkButtonCheckingText = @checkButton.data('checking')
     @checkButton.click @check_fd
+
+    @$('div.action input.hint_button').click @hint_button
     @$('div.action input.reset').click @reset
     @$('div.action button.show').click @show
     @$('div.action input.save').click @save
@@ -696,3 +698,20 @@ class @Problem
       if @has_response
         @enableCheckButton true
     window.setTimeout(enableCheckButton, 750)
+
+  hint_button: =>
+    next_hint_index = -1
+    problemId = this.element_id
+    for problemElement in document.getElementsByClassName('problems-wrapper')
+      for pAttribute in problemElement.attributes
+        if pAttribute.name == 'id'
+          if pAttribute.value == problemId
+            hintButtonElements = problemElement.getElementsByClassName("hint_button")
+            for hbAttribute in hintButtonElements[0].attributes
+              if hbAttribute.name == 'next_hint_index'
+                next_hint_index = hbAttribute.value
+                break
+            break
+
+    $.postWithPrefix "#{@url}/hint_button", next_hint_index: next_hint_index, input_id: @id,(response) =>
+        @render(response.contents)

--- a/common/lib/xmodule/xmodule/templates/problem/checkboxes_response.yaml
+++ b/common/lib/xmodule/xmodule/templates/problem/checkboxes_response.yaml
@@ -3,21 +3,46 @@ metadata:
     display_name: Checkboxes
     markdown: |
       A checkboxes problem presents checkbox buttons for student input. Students can select more than one option presented.
-      >>Select the answer that matches<<
+      
+      Ideally, compound feedback would be provided for all possible combinations of answers.  In practice, that is extremely difficult for problems with more than 3 options.  A good compromise is to write individual feedback for each option, and compound feedback for common combinations of answers or combinations of answers that address common student misconceptions.  
 
-      [x] correct
-      [ ] incorrect
-      [x] correct
+      The compound feedback will be shown first if it exists for a given set of answer options.  If no compound feedback is present, individual feedback is shown.  Feedback is defined for each answer option, for both the selected (checked) and unselected (unchecked) states.  This is indicated using the keywords "selected" (or "S") and "unselected (or "U").
+
+      Compound feedback is specified by using A, B, C, etc to indicate the relevant answer options, with each letter separated by a space.  For example, "(A C)" indicates that the feedback will be provided if the student has checked the first and third answer options.  Try it below!
+      
+      >>Select all the fruits from the list<<
+
+      [x] Apple  {{ selected: You are right that apple is a fruit. }, {unselected: Remember that apple is also a fruit.}}
+      [ ] Mushroom   {{U: You are right that mushrooms aren't fruit}, { selected: Mushroom is a fungus, not a fruit.}}
+      [x] Grape  {{ selected: You are right that grape is a fruit }, {unselected: Remember that grape is also a fruit.}}
+
+
+      {{ ((A C)) Yes, both Apple and Grape belong to the fruit family. }}
+      {{ ((A B C)) Almost, but mushroom is not a fruit }}
 
 data: |
       <problem>
         <p>A checkboxes problem presents checkbox buttons for student input. Students can select more than one option presented.</p>
-        <p>Select the answer that matches</p>
+        <p>Ideally, compound feedback would be provided for all possible combinations of answers.  In practice, that is extremely difficult for problems with more than 3 options.  A good compromise is to write individual feedback for each option, and compound feedback for common combinations of answers or combinations of answers that address common student misconceptions.  </p>
+        <p>The compound feedback will be shown first if it exists for a given set of answer options.  If no compound feedback is present, individual feedback is shown.  Feedback is defined for each answer option, for both the selected (checked) and unselected (unchecked) states.  This is indicated using the keywords "selected" (or "S") and "unselected (or "U").</p>
+        <p>Compound feedback is specified by using A, B, C, etc to indicate the relevant answer options, with each letter separated by a space.  For example, "(A C)" indicates that the feedback will be provided if the student has checked the first and third answer options.  Try it below!</p>
+        <p>Select all the fruits from the list</p>
         <choiceresponse>
-          <checkboxgroup direction="vertical" label="Select the answer that matches">
-            <choice correct="true">correct</choice>
-            <choice correct="false">incorrect</choice>
-            <choice correct="true">correct</choice>
+          <checkboxgroup label="Select all the fruits from the list" direction="vertical">
+            <choice correct="true">Apple      
+              <choicehint selected="true">You are right that apple is a fruit.</choicehint>
+              <choicehint selected="false">Remember that apple is also a fruit.</choicehint>
+            </choice>
+            <choice correct="false">Mushroom
+              <choicehint selected="true">Mushroom is a fungus, not a fruit.</choicehint>
+              <choicehint selected="false">You are right that mushrooms aren't fruit</choicehint>
+            </choice>
+            <choice correct="true">Grape
+              <choicehint selected="true">You are right that grape is a fruit</choicehint>
+              <choicehint selected="false">Remember that grape is also a fruit.</choicehint>
+            </choice>
+            <compoundhint value="A C">Yes, both Apple and Grape belong to the fruit family.</compoundhint>
+            <compoundhint value="A B C">Almost, but mushroom is not a fruit</compoundhint>
           </checkboxgroup>
         </choiceresponse>
       </problem>

--- a/common/lib/xmodule/xmodule/templates/problem/multiplechoice.yaml
+++ b/common/lib/xmodule/xmodule/templates/problem/multiplechoice.yaml
@@ -5,13 +5,18 @@ metadata:
        A multiple choice problem presents radio buttons for student input. Students can only select a single option presented. Multiple Choice questions have been the subject of many areas of research due to the early invention and adoption of bubble sheets.
        
        One of the main elements that goes into a good multiple choice question is the existence of good distractors. That is, each of the alternate responses presented to the student should be the result of a plausible mistake that a student might make.
+
+       Feedback can then be provided for each answer choice to address those mistakes.  The feedback is provided immediately below the question after the student clicks the "Check" button.  Hints can also be available for students to request when they are struggling.
     
        >>What Apple device competed with the portable CD player?<<
-            ( ) The iPad
-            ( ) Napster
-            (x) The iPod
-            ( ) The vegetable peeler
-            
+            ( ) The iPad {{The iPad didn't come out until much later}}
+            ( ) Napster {{Napster was a service, not a device}}
+            (x) The iPod {{Good job!::When the iPod came out in 2001, offering "1000 songs in your pocket", consumers started flocking to this device over the portable CD player.}}
+            ( ) The vegetable peeler {{::No! You're not even close.}}
+       
+            ||An important feature of the portable CD player was that it allowed consumers to take their music with them.||
+            ||In 2001, Apple announced a device that would allow consumers to carry "1000 songs in your pocket"||
+     
        [explanation]
        The release of the iPod allowed consumers to carry their entire music library with them in a format that did not rely on fragile and energy-intensive spinning disks.
        [explanation]
@@ -22,14 +27,15 @@ data: |
    input. Students can only select a single option presented. Multiple Choice questions have been the subject of many areas of research due to the early invention and adoption of bubble sheets.</p>
    <p> One of the main elements that goes into a good multiple choice question is the existence of good distractors. That is, each of the alternate responses presented to the student should be the result of a plausible mistake that a student might make. 
    </p>
+   <p>Feedback can then be provided for each answer choice to address those mistakes.  The feedback is provided immediately below the question after the student clicks the "Check" button.  Hints can also be available for students to request when they are struggling.</p>
 
    <p>What Apple device competed with the portable CD player?</p>
        <multiplechoiceresponse>
         <choicegroup type="MultipleChoice" label="What Apple device competed with the portable CD player?">
-           <choice correct="false" name="ipad">The iPad</choice>
-           <choice correct="false" name="beatles">Napster</choice>
-           <choice correct="true" name="ipod">The iPod</choice>
-           <choice correct="false" name="peeler">The vegetable peeler</choice>
+           <choice correct="false">The iPad <choicehint>The iPad didn't come out until much later</choicehint></choice>
+           <choice correct="false">Napster <choicehint>Napster was a service, not a device</choicehint></choice>
+           <choice correct="true">The iPod <choicehint label="Good job!">When the iPod came out in 2001, offering "1000 songs in your pocket", consumers started flocking to this device over the portable CD player.</choicehint></choice>
+           <choice correct="false">The vegetable peeler <choicehint label="">No! You're not even close.</choicehint></choice>
         </choicegroup>
        </multiplechoiceresponse>
        <solution>
@@ -38,4 +44,8 @@ data: |
                <p>The release of the iPod allowed consumers to carry their entire music library with them in a format that did not rely on fragile and energy-intensive spinning disks. </p>
            </div>
        </solution>
+       <demandhint>
+           <hint>An important feature of the portable CD player was that it allowed consumers to take their music with them.</hint>
+           <hint>In 2001, Apple announced a device that would allow consumers to carry "1000 songs in your pocket"</hint>
+       </demandhint>
    </problem>

--- a/common/lib/xmodule/xmodule/templates/problem/numericalresponse.yaml
+++ b/common/lib/xmodule/xmodule/templates/problem/numericalresponse.yaml
@@ -7,13 +7,13 @@ metadata:
        The answer is correct if it is within a specified numerical tolerance of the expected answer.
 
        >>Enter the numerical value of Pi:<<
-       = 3.14159 +- .02
+       = 3.14159 +- .02 {{Pi represented to 5 decimal places is 3.14159}}
        
        >>Enter the approximate value of 502*9:<<
-       = 4518 +- 15%
+       = 4518 +- 15% {{502*9 is 4518}}
 
        >>Enter the number of fingers on a human hand<<
-       = 5
+       = 5 {{Most humans have 5 fingers on each of their hands.}}
 
        [explanation]
        Pi, or the the ratio between a circle's circumference to its diameter, is an irrational number known to extreme precision. It is value is approximately equal to 3.14.
@@ -42,18 +42,21 @@ data: |
        <numericalresponse answer="3.14159">
            <responseparam type="tolerance" default=".02" />
            <formulaequationinput label="Enter the numerical value of Pi" />
+           <correcthint>Pi represented to 5 decimal places is 3.14159</correcthint>
        </numericalresponse>
    </p>
    <p>Enter the approximate value of 502*9:
        <numericalresponse answer="$computed_response">
            <responseparam type="tolerance" default="15%"/>
            <formulaequationinput label="Enter the approximate value of 502 times 9"/>
+           <correcthint>502*9 is 4518</correcthint>
        </numericalresponse>
    </p>
 
    <p>Enter the number of fingers on a human hand:
        <numericalresponse answer="5">
            <formulaequationinput label="Enter the number of fingers on a human hand"/>
+           <correcthint>Most humans have 5 fingers on each of their hands.</correcthint>
        </numericalresponse>
    </p>
        <solution>

--- a/common/lib/xmodule/xmodule/templates/problem/optionresponse.yaml
+++ b/common/lib/xmodule/xmodule/templates/problem/optionresponse.yaml
@@ -4,33 +4,54 @@ metadata:
     markdown: |
         Dropdown problems give a limited set of options for students to respond with, and present those options in a format that encourages them to search for a specific answer rather than being immediately presented with options from which to recognize the correct answer.
 
-        The answer options and the identification of the correct answer is defined in the <b>optioninput</b> tag.
+        The answer options and the identification of the correct answer is defined in the <b>optioninput</b> tag.  Feedback can be specified for each option.
 
         >>Translation between Dropdown and __________ is extremely straightforward:<<
 
         [[(Multiple Choice), Text Input, Numerical Input, External Response, Image Response]]
 
+        >>Numerical Input questions take numeric values while ___________ questions take text values:<<
+
+        [[
+          Multiple Choice {{Multiple Choice questions require the student to click buttons to select an answer}}
+          (Text Input) {{Students enter text values in a Text Input question}}
+          Numerical Input {{Numerical Input questions require the student to enter numeric values}}
+          External Response {{External Response questions require the student to enter code}}
+          Image Response {{Image Response questions require the student to click on an image}}
+        ]]
+
         [explanation]
         Multiple Choice also allows students to select from a variety of pre-written responses, although the format makes it easier for students to read very long response options. Dropdowns also differ slightly because students are more likely to think of an answer and then search for it rather than relying purely on recognition to answer the question.
         [explanation]
 data: |
-  <problem>
-  <p>Dropdown problems give a limited set of options for students to respond with, and present those options
-  in a format that encourages them to search for a specific answer rather than being immediately presented with options from which to recognize the correct answer.</p>
+    <problem>
+    <p>Dropdown problems give a limited set of options for students to respond with, and present those options in a format that encourages them to search for a specific answer rather than being immediately presented with options from which to recognize the correct answer.</p>
 
-  <p>
-  The answer options and the identification of the correct answer is defined in the <b>optioninput</b> tag. 
-  </p>
-  <p>Translation between Dropdown and __________ is extremely straightforward:
-      
-  <optionresponse>
-        <optioninput options="('Multiple Choice','Text Input','Numerical Input','External Response','Image Response')" correct="Multiple Choice" label="Translation between Dropdown and __________ is extremely straightforward"></optioninput>
-  </optionresponse>
-  </p>
-      <solution>
-          <div class="detailed-solution">
-              <p>Explanation</p>
-              <p>Multiple Choice also allows students to select from a variety of pre-written responses, although the format makes it easier for students to read very long response options. Optionresponse also differs slightly because students are more likely to think of an answer and then search for it rather than relying purely on recognition to answer the question.</p>
-          </div>
-      </solution>
-  </problem>
+    <p>The answer options and the identification of the correct answer is defined in the <b>optioninput</b> tag.  Feedback can be specified for each option.</p>
+
+    <p>Translation between Dropdown and __________ is extremely straightforward:</p>
+    <optionresponse>
+      <optioninput label="Translation between Dropdown and __________ is extremely straightforward:" options="('Multiple Choice','Text Input','Numerical Input','External Response','Image Response')" correct="Multiple Choice"></optioninput>
+    </optionresponse>
+
+    <p>Numerical Input questions take numeric values while ___________ questions take text values:</p>
+    <optionresponse>
+      <optioninput label="Numerical Input questions take numeric values while ___________ questions take text values:">
+        <option correct="False">Multiple Choice <optionhint>Multiple Choice questions require the student to click buttons to select an answer</optionhint></option>
+        <option correct="True">Text Input <optionhint>Students enter text values in a Text Input question</optionhint></option>
+        <option correct="False">Numerical Input <optionhint>Numerical Input questions require the student to enter numeric values</optionhint></option>
+        <option correct="False">External Response <optionhint>External Response questions require the student to enter code</optionhint></option>
+        <option correct="False">Image Response <optionhint>Image Response questions require the student to click on an image</optionhint></option>
+      </optioninput>
+    </optionresponse>
+    <solution>
+    <div class="detailed-solution">
+    <p>Explanation</p>
+
+    <p>Multiple Choice also allows students to select from a variety of pre-written responses, although the format makes it easier for students to read very long response options. Dropdowns also differ slightly because students are more likely to think of an answer and then search for it rather than relying purely on recognition to answer the question.</p>
+
+    </div>
+    </solution>
+
+    </problem>
+

--- a/common/lib/xmodule/xmodule/templates/problem/string_response.yaml
+++ b/common/lib/xmodule/xmodule/templates/problem/string_response.yaml
@@ -6,14 +6,13 @@ metadata:
     
         The answer is correct if it matches every character of the expected answer. This can be a problem with international spelling, dates, or anything where the format of the answer is not clear.
     
-        >>Which US state has Lansing as its capital?<<
+        Alternate answers can be defined using "or=", and feedback can be provided for expected answers.
 
-        = Michigan
-        
+        >>In which country would you find the city of Paris?<<
 
-        [explanation]
-        Lansing is the capital of Michigan, although it is not Michigan's largest city, or even the seat of the county in which it resides.
-        [explanation]
+        =France {{Good job!!::The answer is France}}
+        or=USA {{Yes, there is a Paris, Texas in the USA}}
+
 data: |
     <problem>
     <p>
@@ -25,15 +24,14 @@ data: |
     <p>
     The answer is correct if it matches every character of the expected answer. This can be a problem with international spelling, dates, or anything where the format of the answer is not clear. 
     </p>
+    <p>Alternate answers can be defined using "or=", and feedback can be provided for expected answers.</p>
 
-     <p>Which US state has Lansing as its capital? </p>
-     <stringresponse answer="Michigan" type="ci">
-      <textline size="20" label="Which US state has Lansing as its capital?"/>
+     <p>In which country would you find the city of Paris?</p>
+
+     <stringresponse answer="France" type="ci" >
+       <correcthint label="Good job!!">The answer is France</correcthint>
+       <additional_answer answer="USA"><correcthint>Yes, there is a Paris, Texas in the USA</correcthint></additional_answer>
+       <textline label="In which country would you find the city of Paris?" size="20"/>
      </stringresponse>
-        <solution>
-            <div class="detailed-solution">
-                <p>Explanation</p>
-                <p>Lansing is the capital of Michigan, although it is not Michigan's largest city, or even the seat of the county in which it resides.</p>
-            </div>
-        </solution>
+
     </problem>

--- a/common/lib/xmodule/xmodule/tests/test_capa_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_capa_module.py
@@ -1772,7 +1772,6 @@ class TestProblemCheckTracking(unittest.TestCase):
             factory.input_key(3): 'choice_0',
             factory.input_key(4): ['choice_0', 'choice_1'],
         }
-
         event = self.get_event_for_answers(module, answer_input_dict)
 
         self.assertEquals(event['submission'], {
@@ -1873,6 +1872,71 @@ class TestProblemCheckTracking(unittest.TestCase):
             factory.answer_key(2, 2): {
                 'question': '',
                 'answer': 'yellow',
+                'response_type': 'optionresponse',
+                'input_type': 'optioninput',
+                'correct': False,
+                'variant': '',
+            },
+        })
+
+    def test_optioninput_extended_xml(self):
+        """Test the new XML form of writing with <option> tag instead of options= attribute."""
+        factory = self.capa_factory_for_problem_xml("""\
+            <problem display_name="Woo Hoo">
+              <p>Are you the Gatekeeper?</p>
+                <optionresponse>
+                   <optioninput>
+                       <option correct="True" label="Good Job">
+                           apple
+                           <optionhint>
+                               banana
+                           </optionhint>
+                       </option>
+                       <option correct="False" label="blorp">
+                           cucumber
+                           <optionhint>
+                               donut
+                           </optionhint>
+                       </option>
+                   </optioninput>
+
+                   <optioninput>
+                       <option correct="True">
+                           apple
+                           <optionhint>
+                               banana
+                           </optionhint>
+                       </option>
+                       <option correct="False">
+                           cucumber
+                           <optionhint>
+                               donut
+                           </optionhint>
+                       </option>
+                   </optioninput>
+                 </optionresponse>
+            </problem>
+            """)
+        module = factory.create()
+
+        answer_input_dict = {
+            factory.input_key(2, 1): 'apple',
+            factory.input_key(2, 2): 'cucumber',
+        }
+
+        event = self.get_event_for_answers(module, answer_input_dict)
+        self.assertEquals(event['submission'], {
+            factory.answer_key(2, 1): {
+                'question': '',
+                'answer': 'apple',
+                'response_type': 'optionresponse',
+                'input_type': 'optioninput',
+                'correct': True,
+                'variant': '',
+            },
+            factory.answer_key(2, 2): {
+                'question': '',
+                'answer': 'cucumber',
                 'response_type': 'optionresponse',
                 'input_type': 'optioninput',
                 'correct': False,

--- a/lms/templates/problem.html
+++ b/lms/templates/problem.html
@@ -12,9 +12,14 @@
 
   <div class="action">
     <input type="hidden" name="problem_id" value="${ problem['name'] }" />
-
+    % if show_demand_hint:
+    <div class="problem_hint">${demand_hint}</div>
+    % endif
     % if check_button:
     <input class="check ${ check_button }" type="button" data-checking="${ check_button_checking }" value="${ check_button }" />
+    % endif
+    % if show_hint_button:
+    <input class="hint_button" type="button" value="${_('Hint')}" next_hint_index="${ next_hint_index }"/>
     % endif
     % if reset_button:
     <input class="reset" type="button" value="${_('Reset')}" />


### PR DESCRIPTION
This PR adds new "extended hint" features for many question types.

For example per-choice feedback..

```
  >>What is your favorite color?<<
  () Red   {{A lot of people think it's Red, but those people are wrong.}}
  () Green
  (x) Blue
```

When the user tries Red as an answer, the extended hint appears.
For a sample course .tar.gz with examples of all the extended hint features see
 https://drive.google.com/file/d/0BzXwXoUU5YRpdVJhbUphT19Hb1E

Here I will outline the implementation side of things.

The implementation has roughly three parts:
-The markdown parser, adding support for {{ ... }} as above
-The capa xml layer, to store and retrieve extended hints per question
-Problem html generation, to show the extended hints

Thomas Brennan-Marquez wrote an original draft of many of these features,
and I, Nick Parlante, then did some heavy revision and extension.
## 1. Markdown Parsing

See edit.coffee and companion edit_spec_hint.coffee

I made a high level decision to not change the old markdown
parsing at all, staying quirk for quirk compatible.
So all the old tests pass unchanged. The extended hint parsing is layered on top.
The original parsing code is written in a rather functional style,
so the additions are written that way too.
## 2. responsetypes.py - get_extended_hints

Many extended hints associate with particular choices in the xml, e.g.

```
  <choicegroup label="What is your favorite color?" type="MultipleChoice">
    <choice correct="false">Red <choicehint>No, Blue!</choicehint> </choice>
```

Therefore, for each response type - multiple choice, checkbox, dropdown, text input, numeric input -
there's a get_extended_hints() method that digs the appropriate hint out of the xml
and puts it in the map 'msg' to go back to the client. In some cases, there is nontrivial
logic to pick out the right extended hint depending on the specific student choices.
## 3. capa_base.py - get_problem_html

Many extended hints are sent to the client through the existing cmap['msg'] mechanism.

The demand hints are added in their own div in the problem.html template.

As an additional wrinkle, with the addition of extended hints, the question xml
often has tags that are not just to be echoed to the user, e.g. in the <choice> above.
Therefore, the get-html path needs logic to strip out these tags.
## 4. Other XML changes:

Change additional_answer to use an attribute attribute, as below, to be consistent with the
other text-input cases. Compatibility code is provided.

```
  <additional_answer answer="Blue"> <correcthint>hint2</correcthint> </additional_answer>
```

We provide a longer <optioninput> xml form, as below, that also supports per-option hints.
Compatibility is provided.

```
<optioninput>
  <option correct="False">dog <optionhint>No, too friendly</optionhint> </option>
  <option correct="True">cat</option>
  <option correct="False">parrot</option>
</optioninput>
```

Also the various studio question templates have been updated to show off the
new extended-hint features in markdown.
