### PR TITLE
Allow `id` as a variable name

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -135,7 +135,7 @@ class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
 inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
 
 # Good variable names which should always be accepted, separated by a comma
-good-names=f,i,j,k,db,ex,Run,_,__
+good-names=f,i,j,k,db,id,ex,Run,_,__
 
 # Bad variable names which should always be refused, separated by a comma
 bad-names=foo,bar,baz,toto,tutu,tata


### PR DESCRIPTION
@chrisndodge Is this what you wanted?

Definitely want the testeng team to review this, and determine if it's a good idea. Note that `id` is a Python builtin function, and defining a variable by that name will override it -- which might be fine.
