### PR TITLE
Add progress bars for Studio video uploads

### DIFF
--- a/cms/static/js/models/active_video_upload.js
+++ b/cms/static/js/models/active_video_upload.js
@@ -19,7 +19,8 @@ define(
         var ActiveVideoUpload = Backbone.Model.extend(
             {
                 defaults: {
-                    status: statusStrings.STATUS_QUEUED
+                    status: statusStrings.STATUS_QUEUED,
+                    progress: 0
                 }
             },
             statusStrings

--- a/cms/static/js/views/active_video_upload.js
+++ b/cms/static/js/views/active_video_upload.js
@@ -2,6 +2,13 @@ define(
     ["js/models/active_video_upload", "js/views/baseview"],
     function(ActiveVideoUpload, BaseView) {
         "use strict";
+
+        var STATUS_CLASSES = [
+            {status: ActiveVideoUpload.STATUS_QUEUED, cls: "queued"},
+            {status: ActiveVideoUpload.STATUS_COMPLETED, cls: "success"},
+            {status: ActiveVideoUpload.STATUS_FAILED, cls: "error"}
+        ];
+
         var ActiveVideoUploadView = BaseView.extend({
             tagName: "li",
             className: "active-video-upload",
@@ -12,11 +19,15 @@ define(
             },
 
             render: function() {
-                this.$el.html(this.template(this.model.attributes));
-                var $statusEl = this.$el.find(".video-detail-status");
+                var $el = this.$el;
+                $el.html(this.template(this.model.attributes));
                 var status = this.model.get("status");
-                $statusEl.toggleClass("success", status == ActiveVideoUpload.STATUS_COMPLETED);
-                $statusEl.toggleClass("error", status == ActiveVideoUpload.STATUS_FAILED);
+                _.each(
+                    STATUS_CLASSES,
+                    function(statusClass) {
+                        $el.toggleClass(statusClass.cls, status == statusClass.status);
+                    }
+                );
                 return this;
             },
         });

--- a/cms/static/js/views/active_video_upload_list.js
+++ b/cms/static/js/views/active_video_upload_list.js
@@ -36,6 +36,7 @@ define(
                     dragover: this.dragover.bind(this),
                     add: this.fileUploadAdd.bind(this),
                     send: this.fileUploadSend.bind(this),
+                    progress: this.fileUploadProgress.bind(this),
                     done: this.fileUploadDone.bind(this),
                     fail: this.fileUploadFail.bind(this)
                 });
@@ -124,12 +125,22 @@ define(
                 this.collection.get(cid).set("status", status);
             },
 
+            // progress should be a number between 0 and 1 (inclusive)
+            setProgress: function(cid, progress) {
+                this.collection.get(cid).set("progress", progress);
+            },
+
             fileUploadSend: function(event, data) {
                 this.setStatus(data.cid, ActiveVideoUpload.STATUS_UPLOADING);
             },
 
+            fileUploadProgress: function(event, data) {
+                this.setProgress(data.cid, data.loaded / data.total);
+            },
+
             fileUploadDone: function(event, data) {
                 this.setStatus(data.cid, ActiveVideoUpload.STATUS_COMPLETED);
+                this.setProgress(data.cid, 1);
             },
 
             fileUploadFail: function(event, data) {

--- a/cms/static/sass/views/_video-upload.scss
+++ b/cms/static/sass/views/_video-upload.scss
@@ -68,19 +68,61 @@
         .video-detail-status {
           @include font-size(12);
           @include line-height(12);
+        }
 
-          &.error {
-            color: $color-error;
-          }
+        .video-detail-progress {
+          -webkit-appearance: none;
+          -moz-appearance: none;
+          appearance: none;
+          margin-bottom: ($baseline/2);
+          border: none;
+          width: 100%;
+          height: ($baseline/4);
+        }
 
-          &.success {
-            color: $color-ready;
-          }
+        .video-detail-progress::-webkit-progress-bar {
+          background-color: $white;
+        }
+
+        // Sadly, these rules must be separate or both Chrome and Firefox break
+        .video-detail-progress::-webkit-progress-value {
+          background-color: $color-ready;
+        }
+
+        .video-detail-progress::-moz-progress-bar {
+          background-color: $color-ready;
         }
 
         &:hover {
           @include transition(all $tmg-f3);
           background: $white;
+        }
+
+        &.queued {
+          .video-detail-progress {
+            visibility: hidden;
+          }
+        }
+
+        &.error {
+          .video-detail-status {
+            color: $color-error;
+          }
+
+          // Sadly, these rules must be separate or both Chrome and Firefox break
+          .video-detail-progress::-webkit-progress-value {
+            background-color: $color-error;
+          }
+
+          .video-detail-progress::-moz-progress-bar {
+            background-color: $color-error;
+          }
+        }
+
+        &.success {
+          .video-detail-status {
+            color: $color-ready;
+          }
         }
       }
     }

--- a/cms/templates/js/active-video-upload.underscore
+++ b/cms/templates/js/active-video-upload.underscore
@@ -1,2 +1,3 @@
 <h4 class="video-detail-name"><%- fileName %></h4>
+<progress class="video-detail-progress" value="<%= progress %>"></progress>
 <p class="video-detail-status"><%- gettext(status) %></p>


### PR DESCRIPTION
The CSS is also restructured a bit to style both the progress bar and
the status text based on the state of the upload using a single class
on the parent element.

@nasthagiri @BenjiLee @clrux @frrrances please review

Queued:
![screen shot 2015-01-22 at 1 21 33 pm](https://cloud.githubusercontent.com/assets/4027165/5861689/c90035f8-a239-11e4-986b-2c5b3f23613e.png)

Uploading (w/ and w/out hover):
![screen shot 2015-01-22 at 1 21 08 pm](https://cloud.githubusercontent.com/assets/4027165/5861688/c8ffd9a0-a239-11e4-8451-195a25d8ca12.png)
![screen shot 2015-01-22 at 1 21 01 pm](https://cloud.githubusercontent.com/assets/4027165/5861690/c9003a8a-a239-11e4-9d37-dfdda9e5ea32.png)

Completed:
![screen shot 2015-01-22 at 1 20 13 pm](https://cloud.githubusercontent.com/assets/4027165/5861692/c905d77e-a239-11e4-9e4b-cb3d20345669.png)

Failed:
![screen shot 2015-01-22 at 1 23 54 pm](https://cloud.githubusercontent.com/assets/4027165/5861724/1c972bfe-a23a-11e4-8b58-6720a7e892ff.png)
