### PR TITLE
Enrollment API to be used without knowing the current user name.

### DIFF
--- a/common/djangoapps/enrollment/tests/test_views.py
+++ b/common/djangoapps/enrollment/tests/test_views.py
@@ -106,6 +106,23 @@ class EnrollmentTest(ModuleStoreTestCase, APITestCase):
         self.assertEqual(1, len(data['course_details']['course_modes']))
         self.assertEqual('professional', data['course_details']['course_modes'][0]['slug'])
 
+    def test_user_not_specified(self):
+        CourseModeFactory.create(
+            course_id=self.course.id,
+            mode_slug='honor',
+            mode_display_name='Honor',
+        )
+        # Create an enrollment
+        self._create_enrollment()
+        resp = self.client.get(
+            reverse('courseenrollment', kwargs={"course_id": unicode(self.course.id)})
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        data = json.loads(resp.content)
+        self.assertEqual(unicode(self.course.id), data['course_details']['course_id'])
+        self.assertEqual('honor', data['mode'])
+        self.assertTrue(data['is_active'])
+
     def test_user_not_authenticated(self):
         # Log out, so we're no longer authenticated
         self.client.logout()

--- a/common/djangoapps/enrollment/urls.py
+++ b/common/djangoapps/enrollment/urls.py
@@ -20,6 +20,11 @@ urlpatterns = patterns(
         EnrollmentView.as_view(),
         name='courseenrollment'
     ),
+    url(
+        r'^enrollment/{course_key}$'.format(course_key=settings.COURSE_ID_PATTERN),
+        EnrollmentView.as_view(),
+        name='courseenrollment'
+    ),
     url(r'^enrollment$', EnrollmentListView.as_view(), name='courseenrollments'),
     url(
         r'^course/{course_key}$'.format(course_key=settings.COURSE_ID_PATTERN),

--- a/common/djangoapps/enrollment/views.py
+++ b/common/djangoapps/enrollment/views.py
@@ -82,6 +82,7 @@ class EnrollmentView(APIView):
             A JSON serialized representation of the course enrollment.
 
         """
+        user = user if user else request.user.username
         if request.user.username != user:
             # Return a 404 instead of a 403 (Unauthorized). If one user is looking up
             # other users, do not let them deduce the existence of an enrollment.


### PR DESCRIPTION
In order for the marketing site to check the current authenticated user's enrollment in a course, based on session auth, we need to have a URL exposed that does not explicitly declare the username for the current request. 

This call would allow us to use the enrollment API without the username present.

@wedaly @AlasdairSwan 

FYI @ormsbee 
