### PR TITLE
Add student response reports, management and dashboard functionality

### DIFF
--- a/common/test/data/unicode_graded/README.md
+++ b/common/test/data/unicode_graded/README.md
@@ -1,0 +1,1 @@
+This is a very simple course for testing student responses reports for courses with unicode information.

--- a/common/test/data/unicode_graded/course.xml
+++ b/common/test/data/unicode_graded/course.xml
@@ -1,0 +1,1 @@
+<course org="edX" course="unicode_graded" url_name="2012_Fall"/>

--- a/common/test/data/unicode_graded/course/2012_Fall.xml
+++ b/common/test/data/unicode_graded/course/2012_Fall.xml
@@ -1,0 +1,15 @@
+<course>
+  <chapter url_name="UnicodeGradedChapter" display_name="Üñîçø∂éßradedChapter">
+    <videosequence url_name="Homework1" display_name="πoméwork 1">
+      <vertical url_name="Homework1Unit" display_name="中oméwork1Uni大">
+        
+        <problem url_name="H1P1">
+          <optionresponse>
+            <optioninput options="('Correct', 'Incorrect')" correct="Correct"></optioninput>
+            <optioninput options="('Correct', 'Incorrect')" correct="Correct"></optioninput>
+          </optionresponse>
+        </problem>
+      </vertical>
+    </videosequence>
+  </chapter>
+</course>

--- a/common/test/data/unicode_graded/grading_policy.json
+++ b/common/test/data/unicode_graded/grading_policy.json
@@ -1,0 +1,16 @@
+{
+  "GRADER" : [
+    {
+      "type" : "Homework",
+      "min_count" : 3,
+      "drop_count" : 1,
+      "short_label" : "HW",
+      "weight" : 0.5
+    }
+  ],
+  "GRADE_CUTOFFS" : {
+    "A" : 0.8,
+    "B" : 0.7,
+    "C" : 0.6
+  }
+}

--- a/common/test/data/unicode_graded/policies/2012_Fall.json
+++ b/common/test/data/unicode_graded/policies/2012_Fall.json
@@ -1,0 +1,15 @@
+{
+    "course/2012_Fall": {
+        "graceperiod": "2 days 5 hours 59 minutes 59 seconds",
+        "start": "2010-07-17T12:00",
+        "display_name": "Üñîçø∂é ßraded Course",
+        "graded": "true"
+    },
+	
+    "videosequence/Homework1": {
+        "display_name": "πoméwork 1", 
+        "graded": true, 
+        "format": "Homework"
+    },
+	
+}

--- a/lms/djangoapps/instructor/management/commands/dump_student_responses.py
+++ b/lms/djangoapps/instructor/management/commands/dump_student_responses.py
@@ -1,0 +1,56 @@
+"""
+Management command to dump CSV student responses for a course.
+"""
+import csv
+from optparse import make_option
+
+from django.core.management.base import BaseCommand, CommandError
+
+from instructor_analytics.basic import student_response_rows
+from xmodule.modulestore.django import modulestore
+from opaque_keys import InvalidKeyError
+from opaque_keys.edx.locations import SlashSeparatedCourseKey
+
+
+class Command(BaseCommand):
+    """
+    Writes CSV student responses to all problems in specified course to
+    specified file, or stdout by default.
+    """
+    args = '<course_id>'
+    help = __doc__
+    option_list = BaseCommand.option_list + (
+        make_option('-o', '--output-file',
+                    dest='filename',
+                    help='Write CSV to FILENAME, defaults to stdout'),
+    )
+
+    def handle(self, *args, **options):
+        if not args:
+            raise CommandError("course_id not specified")
+
+        store = modulestore()
+
+        try:
+            course_id = SlashSeparatedCourseKey.from_deprecated_string(args[0])
+        except InvalidKeyError:
+            raise CommandError("Invalid course_id")
+
+        course = store.get_course(course_id)
+        if course is None:
+            raise CommandError("Invalid course_id")
+
+        rows = student_response_rows(course)
+
+        def _utf8_encoded_rows(rows):
+            """Encode rows as utf-8 for CSV compatibility"""
+            for row in rows:
+                yield [unicode(item).encode('utf-8') for item in row]
+
+        if not options['filename']:
+            csvwriter = csv.writer(self.stdout, dialect='excel', quotechar='"', quoting=csv.QUOTE_ALL)
+            csvwriter.writerows(_utf8_encoded_rows(rows))
+        else:
+            with open(options['filename'], 'wb') as csvfile:
+                csvwriter = csv.writer(csvfile, dialect='excel', quotechar='"', quoting=csv.QUOTE_ALL)
+                csvwriter.writerows(_utf8_encoded_rows(rows))

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -1732,6 +1732,25 @@ def calculate_grades_csv(request, course_id):
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
 @require_level('staff')
+def get_student_responses(request, course_id):
+    """
+    AlreadyRunningError is raised if the student response CSV is still being generated.
+    """
+    course_key = SlashSeparatedCourseKey.from_deprecated_string(course_id)
+    try:
+        instructor_task.api.submit_get_student_responses(request, course_key)
+        success_status = _("Your student responses report is being generated! You can view the status of the generation task in the 'Pending Instructor Tasks' section.")
+        return JsonResponse({"status": success_status})
+    except AlreadyRunningError:
+        already_running_status = _("A student responses report generation task is already in progress. Check the 'Pending Instructor Tasks' table for the status of the task. When completed, the report will be available for download in the table below.")
+        return JsonResponse({
+            "status": already_running_status
+        })
+
+
+@ensure_csrf_cookie
+@cache_control(no_cache=True, no_store=True, must_revalidate=True)
+@require_level('staff')
 @require_query_params('rolename')
 def list_forum_members(request, course_id):
     """

--- a/lms/djangoapps/instructor/views/api_urls.py
+++ b/lms/djangoapps/instructor/views/api_urls.py
@@ -66,6 +66,10 @@ urlpatterns = patterns('',  # nopep8
     url(r'calculate_grades_csv$',
         'instructor.views.api.calculate_grades_csv', name="calculate_grades_csv"),
 
+    # Student responses for questions
+    url(r'^get_student_responses$',
+        'instructor.views.api.get_student_responses', name="get_student_responses"),
+
     # Registration Codes..
     url(r'get_registration_codes$',
         'instructor.views.api.get_registration_codes', name="get_registration_codes"),

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -339,6 +339,7 @@ def _section_data_download(course, access):
         'list_instructor_tasks_url': reverse('list_instructor_tasks', kwargs={'course_id': unicode(course_key)}),
         'list_report_downloads_url': reverse('list_report_downloads', kwargs={'course_id': unicode(course_key)}),
         'calculate_grades_csv_url': reverse('calculate_grades_csv', kwargs={'course_id': unicode(course_key)}),
+        'get_student_responses_url': reverse('get_student_responses', kwargs={'course_id': unicode(course_key)}),
     }
     return section_data
 

--- a/lms/djangoapps/instructor_analytics/tests/test_basic.py
+++ b/lms/djangoapps/instructor_analytics/tests/test_basic.py
@@ -4,11 +4,13 @@ Tests for instructor.basic
 
 import json
 from student.models import CourseEnrollment
+from django.conf import settings
 from django.core.urlresolvers import reverse
+from django.test.utils import override_settings
 from mock import patch
 from student.roles import CourseSalesAdminRole
 from student.tests.factories import UserFactory, CourseModeFactory
-from opaque_keys.edx.locations import SlashSeparatedCourseKey
+from opaque_keys.edx.locations import Location, SlashSeparatedCourseKey
 from shoppingcart.models import (
     CourseRegistrationCode, RegistrationCodeRedemption, Order,
     Invoice, Coupon, CourseRegCodeItem, CouponRedemption
@@ -16,16 +18,20 @@ from shoppingcart.models import (
 from course_modes.models import CourseMode
 from instructor_analytics.basic import (
     sale_record_features, sale_order_record_features, enrolled_students_features, course_registration_features,
-    coupon_codes_features, AVAILABLE_FEATURES, STUDENT_FEATURES, PROFILE_FEATURES
+    coupon_codes_features, student_responses, AVAILABLE_FEATURES, STUDENT_FEATURES, PROFILE_FEATURES
 )
 from openedx.core.djangoapps.course_groups.tests.helpers import CohortFactory
-from courseware.tests.factories import InstructorFactory
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from courseware.courses import get_course
+from courseware.tests.factories import StudentModuleFactory, InstructorFactory
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, xml_store_config
 from xmodule.modulestore.tests.factories import CourseFactory
 
 import datetime
 from django.db.models import Q
 import pytz
+
+TEST_DATA_DIR = settings.COMMON_TEST_DATA_ROOT
+TEST_DATA_XML_MODULESTORE = xml_store_config(TEST_DATA_DIR, course_dirs=['simple', 'graded', 'unicode_graded'])
 
 
 class TestAnalyticsBasic(ModuleStoreTestCase):
@@ -353,3 +359,45 @@ class TestCourseRegistrationCodeAnalyticsBasic(ModuleStoreTestCase):
                 active_coupon['course_id'],
                 [coupon.course_id.to_deprecated_string() for coupon in active_coupons]
             )
+
+
+@override_settings(MODULESTORE=TEST_DATA_XML_MODULESTORE)
+class TestStudentSubmissionsAnalyticsBasic(ModuleStoreTestCase):
+    """ Test basic student responses analytics function. """
+    def load_course(self, course_id):
+        course_key = SlashSeparatedCourseKey.from_deprecated_string(course_id)
+        self.course = get_course(course_key)
+
+    def create_student(self):
+        self.student = UserFactory()
+        CourseEnrollment.enroll(self.student, self.course.id)
+
+    def test_empty_course(self):
+        self.course = CourseFactory.create()
+        self.create_student()
+
+        datarows = list(student_responses(self.course))
+        self.assertEqual(datarows, [])
+
+    def test_full_course_no_students(self):
+        self.load_course('edX/simple/2012_Fall')
+
+        datarows = list(student_responses(self.course))
+        self.assertEqual(datarows, [])
+
+    def test_invalid_module_state(self):
+        self.load_course('edX/graded/2012_Fall')
+        self.problem_location = Location("edX", "graded", "2012_Fall", "problem", "H1P2")
+
+        self.create_student()
+        StudentModuleFactory.create(
+            course_id=self.course.id,
+            module_state_key=self.problem_location,
+            student=self.student,
+            grade=0,
+            state=u'{"student_answers":{"fake-problem":"No idea"}}}'
+        )
+
+        datarows = list(student_responses(self.course))
+        #Invalid module state response will be skipped, so datarows should be empty
+        self.assertEqual(len(datarows), 0)

--- a/lms/djangoapps/instructor_task/api.py
+++ b/lms/djangoapps/instructor_task/api.py
@@ -21,6 +21,7 @@ from instructor_task.tasks import (
     calculate_grades_csv,
     calculate_students_features_csv,
     cohort_students,
+    get_student_responses,
 )
 
 from instructor_task.api_helper import (check_arguments_for_rescoring,
@@ -247,6 +248,18 @@ def submit_cohort_students(request, course_key, file_name):
     task_type = 'cohort_students'
     task_class = cohort_students
     task_input = {'file_name': file_name}
+    task_key = ""
+
+    return submit_task(request, task_type, task_class, course_key, task_input, task_key)
+
+
+def submit_get_student_responses(request, course_key):
+    """
+    AlreadyRunningError is raised if the student responses report is already being generated.
+    """
+    task_type = 'student_responses'
+    task_class = get_student_responses
+    task_input = {}
     task_key = ""
 
     return submit_task(request, task_type, task_class, course_key, task_input, task_key)

--- a/lms/djangoapps/instructor_task/tasks.py
+++ b/lms/djangoapps/instructor_task/tasks.py
@@ -32,7 +32,8 @@ from instructor_task.tasks_helper import (
     delete_problem_module_state,
     upload_grades_csv,
     upload_students_csv,
-    cohort_students_and_upload
+    cohort_students_and_upload,
+    push_student_responses_to_s3,
 )
 from bulk_email.tasks import perform_delegate_email_batches
 
@@ -165,4 +166,14 @@ def cohort_students(entry_id, xmodule_instance_args):
     # An example of such a message is: "Progress: {action} {succeeded} of {attempted} so far"
     action_name = ugettext_noop('cohorted')
     task_fn = partial(cohort_students_and_upload, xmodule_instance_args)
+    return run_main_task(entry_id, task_fn, action_name)
+
+
+@task(base=BaseInstructorTask, routing_key=settings.GRADES_DOWNLOAD_ROUTING_KEY)  # pylint: disable=E1102
+def get_student_responses(entry_id, xmodule_instance_args):
+    """
+    Generate a CSV file of student responses to all course problems and store in S3.
+    """
+    action_name = ugettext_noop('generated')
+    task_fn = partial(push_student_responses_to_s3, xmodule_instance_args)
     return run_main_task(entry_id, task_fn, action_name)

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -227,14 +227,14 @@ FEATURES = {
     # when enrollment exceeds this number
     'MAX_ENROLLMENT_INSTR_BUTTONS': 200,
 
-    # Grade calculation started from the new instructor dashboard will write
-    # grades CSV files to S3 and give links for downloads.
+    # Grade calculation and response report requests started from the new instructor dashboard will write
+    # CSV files to S3 and give links for downloads.
     'ENABLE_S3_GRADE_DOWNLOADS': False,
 
     # whether to use password policy enforcement or not
     'ENFORCE_PASSWORD_POLICY': True,
 
-    # Give course staff unrestricted access to grade downloads (if set to False,
+    # Give course staff unrestricted access to grade and student responses downloads (if set to False,
     # only edX superusers can perform the downloads)
     'ALLOW_COURSE_STAFF_GRADE_DOWNLOADS': False,
 

--- a/lms/static/coffee/src/instructor_dashboard/data_download.coffee
+++ b/lms/static/coffee/src/instructor_dashboard/data_download.coffee
@@ -21,7 +21,7 @@ class DataDownload
     @$list_studs_csv_btn = @$section.find("input[name='list-profiles-csv']'")
     @$list_anon_btn = @$section.find("input[name='list-anon-ids']'")
     @$grade_config_btn = @$section.find("input[name='dump-gradeconf']'")
-    @$calculate_grades_csv_btn = @$section.find("input[name='calculate-grades-csv']'")
+    @$grades_btn = @$section.find ".reports-download-container input[type='button']"
 
     # response areas
     @$download                        = @$section.find '.data-download-container'
@@ -107,17 +107,17 @@ class DataDownload
           @clear_display()
           @$download_display_text.html data['grading_config_summary']
 
-    @$calculate_grades_csv_btn.click (e) =>
-      # Clear any CSS styling from the request-response areas
-      #$(".msg-confirm").css({"display":"none"})
-      #$(".msg-error").css({"display":"none"})
+    @$grades_btn.click (e) =>
       @clear_display()
-      url = @$calculate_grades_csv_btn.data 'endpoint'
+      url = $(e.target).data 'endpoint'
       $.ajax
         dataType: 'json'
         url: url
         error: (std_ajax_err) =>
-          @$reports_request_response_error.text gettext("Error generating grades. Please try again.")
+          if e.target.name == 'calculate-grades-csv'
+            @$reports_request_response_error.text gettext("Error generating grades. Please try again.")
+          else
+            @$reports_request_response_error.text gettext("Error getting student responses. Please try again.")
           $(".msg-error").css({"display":"block"})
         success: (data) =>
           @$reports_request_response.text data['status']

--- a/lms/templates/instructor/instructor_dashboard_2/data_download.html
+++ b/lms/templates/instructor/instructor_dashboard_2/data_download.html
@@ -38,9 +38,12 @@
   <div class="data-display-table" id="data-student-profiles-table"></div>
 
   %if settings.FEATURES.get('ALLOW_COURSE_STAFF_GRADE_DOWNLOADS') or section_data['access']['admin']:
-    <p>${_("Click to generate a CSV grade report for all currently enrolled students.")}</p>
+    <p>${_("Click to generate a CSV grade report for all currently enrolled students, or a CSV submissions report for all problems.")}</p>
 
-    <p><input type="button" name="calculate-grades-csv" value="${_("Generate Grade Report")}" data-endpoint="${ section_data['calculate_grades_csv_url'] }"/></p>
+    <p>
+      <input type="button" name="calculate-grades-csv" value="${_("Generate Grade Report")}" data-endpoint="${ section_data['calculate_grades_csv_url'] }"/>
+      <input type="button" name="get-student-responses" value="${_("Get Student Responses Report")}" data-endpoint="${ section_data['get_student_responses_url'] }"/>
+    </p>
   %endif
 
     <div class="request-response msg msg-confirm copy" id="report-request-response"></div>


### PR DESCRIPTION
@shnayder 
This PR adds an additional report option for instructors in the instructor dashboard, which outputs a CSV with all student responses to problems in the course.

This feature is enabled with the same flags for grade reports, ENABLE_S3_GRADE_DOWNLOADS and ALLOW_COURSE_STAFF_GRADE_DOWNLOADS, so make sure to set these to True to test it.

Go to the Data Download section of the instructor dashboard, and you should see a "Get Student Submissions Report" button next to "Generate Grade Report" in the Reports section. Click it and you should see the green message below, and your report should appear in the list underneath afterwards.

![screen shot 2015-01-26 at 1 20 59 pm](https://cloud.githubusercontent.com/assets/868615/5908660/57790cde-a55e-11e4-84a9-39017d577b42.png)

The report displays one row per problem / student, and does not include students with no submissions. Each row has the metadata for the Section, Subsection, and Unit for the problem, the problem display name, it's order in the course (number that you can sort by), location, student, and response(s). These responses are retrieved from courseware_studentmodule module state. The responses show each problem subquestion and answer, though the subquestion is showed by its id unfortunately, I haven't figured out how to display its human readable form yet.

Say you answered a numerical input problem:
![screen shot 2015-01-27 at 2 43 41 am](https://cloud.githubusercontent.com/assets/868615/5917165/c0a0a35a-a5ce-11e4-934a-62734e4b93f7.png)

You can see the response in the 2nd row of the report:
![screen shot 2015-01-27 at 2 53 31 am](https://cloud.githubusercontent.com/assets/868615/5917267/bfebb4e4-a5cf-11e4-9f15-eaea0815a39d.png)

This PR also includes a management command that can be called like follows if you want to generate it manually:
./manage.py lms dump_student_responses edX/DemoX/Demo_Course -o output.csv
