### PR TITLE
Clrux/lms nav content focus reload update

### DIFF
--- a/common/lib/xmodule/xmodule/css/sequence/display.scss
+++ b/common/lib/xmodule/xmodule/css/sequence/display.scss
@@ -302,6 +302,14 @@ $sequence--border-color: #C8C8C8;
   display: none;
 }
 
+#seq_content {
+
+  &:focus,
+  &:active {
+    outline: none;
+  }
+}
+
 .sequence-bottom {
   position: relative;
   width: ($baseline*4) - 1;

--- a/common/lib/xmodule/xmodule/css/sequence/display.scss
+++ b/common/lib/xmodule/xmodule/css/sequence/display.scss
@@ -32,12 +32,14 @@ $sequence--border-color: #C8C8C8;
 
 // ====================
 
-nav.sequence-nav {
+.sequence-nav {
   // TODO (cpennington): This doesn't work anymore. XModules aren't able to
   // import from external sources.
   @extend .topbar;
-  margin: -4px 0 ($baseline*1.5);
   position: relative;
+  margin: -4px 0 ($baseline*1.5);
+  padding-left: ($baseline*2);
+  padding-right: ($baseline*2);
   border-bottom: none;
 
   .left-shadow {
@@ -45,11 +47,12 @@ nav.sequence-nav {
     @include linear-gradient(left, $shadow, $transparent);
     position: absolute;
     top: 0;
-    left: 0;
+    left: ($baseline*2);
     width: 20px;
-    height: 46px;
+    height: 44px;
     background-color: transparent;
     pointer-events: none;
+    z-index: 40;
   }
 
   .right-shadow {
@@ -57,279 +60,175 @@ nav.sequence-nav {
     @include linear-gradient(right, $shadow, $transparent);
     position: absolute;
     top: 0;
-    right: 0;
+    right: ($baseline*2);
     width: 20px;
-    height: 46px;
+    height: 44px;
     background-color: transparent;
     pointer-events: none;
+    z-index: 40;
   }
 
   .sequence-list-wrapper {
     @extend %ui-depth2;
     @include linear-gradient(top, #ddd, #eee);
-    position: relative;
+    @include box-sizing(border-box);
+    display: block;
     border: 1px solid $gray-l3;
     height: 44px;
-    margin: 0 ($baseline*1.5);
     box-shadow: 0 1px 3px $shadow-l1 inset;
-  }
-
-  ol {
-    position: absolute;
-    top: 0;
-    left: 0;
-    @include box-sizing(border-box);
-    display: table;
-    height: 100%;
-    margin: 0;
-    padding: 0 ($baseline/2);
     width: 100%;
 
-    a {
-      @extend .block-link;
-    }
-
-    li {
-      display: table-cell;
-      min-width: 20px;
+    .sequence-list {
+      position: relative;
+      display: inline-block;
+      vertical-align: top;
 
       a {
-        @extend %ui-fake-link;
-        @include transition(none);
-        width: 100%;
-        height: 42px;
-        margin: 0;
-        background-position: center 14px;
-        background-repeat: no-repeat;
-        border: 1px solid transparent;
-        display: block;
-        padding: 0;
-        position: relative;
+        @extend .block-link;
+      }
 
-/*        &:focus {
-          outline: 0;
-        }
-*/
-        &:hover, &:focus {
-          background-color: $white;
-          background-repeat: no-repeat;
-          background-position: center 14px;
-        }
+      ol {
+        position: absolute;
 
-        &.active {
-          @extend %ui-depth1;
-          background-color: $white;
+        li {
+          display: table-cell;
+          min-width: 20px;
 
-          // &:after {
-          //   content: '▲';
-          //   position: absolute;
-          //   top: 28px;
-          //   left: 50%;
-          //   z-index: 9999;
-          //   margin-left: -5px;
-          //   font-size: 12px;
-          //   color: #aaa;
-          // }
-
-          &:hover, &:focus {
-            background-color: $white;
-            background-repeat: no-repeat;
+          a {
+            @extend %ui-fake-link;
+            @include transition(none);
+            width: ($baseline*5);
+            height: ($baseline*2);
+            margin: 0;
             background-position: center 14px;
-          }
-        }
+            background-repeat: no-repeat;
+            border: 1px solid transparent;
+            display: block;
+            padding: 0;
+            position: relative;
 
-        //video
-        &.seq_video {
-          &.inactive {
-            background-image: url('../images/sequence-nav/video-icon-normal.png');
-          }
-
-          &.visited {
-            background-image: url('../images/sequence-nav/video-icon-visited.png');
-          }
-
-          &.active {
-            @extend .active;
-            background-image: url('../images/sequence-nav/video-icon-current.png');
-          }
-        }
-
-        //other
-        &.seq_other {
-          &.inactive {
-            background-image: url('../images/sequence-nav/document-icon-normal.png');
-          }
-
-          &.visited {
-            background-image: url('../images/sequence-nav/document-icon-visited.png');
-          }
-
-          &.active {
-            background-image: url('../images/sequence-nav/document-icon-current.png');
-          }
-        }
-
-        //vertical & problems
-        &.seq_vertical, &.seq_problem {
-          &.inactive {
-            background-image: url('../images/sequence-nav/list-icon-normal.png');
-          }
-
-          &.visited {
-            background-image: url('../images/sequence-nav/list-icon-visited.png');
-          }
-
-          &.active {
-            background-image: url('../images/sequence-nav/list-icon-current.png');
-          }
-
-          &.progress-none {
-            background-image: url('../images/sequence-nav/list-unstarted.png');
-          }
-
-          &.progress-some, &.progress-in_progress {
-            background-image: url('../images/sequence-nav/list-unfinished.png');
-          }
-
-          &.progress-done {
-            background-image: url('../images/sequence-nav/list-finished.png');
-          }
-        }
-
-        p {
-          @extend %ui-depth2;
-          background: #333;
-          color: $white;
-          font-family: $sans-serif;
-          line-height: lh();
-          right: 0;
-          opacity: 0.0;
-          padding: 6px;
-          position: absolute;
-          top: 48px;
-          text-shadow: 0 -1px 0 $black;
-          @include transition(all .1s $ease-in-out-quart 0s);
-          white-space: pre;
-          visibility: hidden;
-          pointer-events: none;
-
-
-          &:empty {
-            background: none;
-
-            &::after {
-              display: none;
+            &:hover, &:focus {
+              background-color: $white;
+              background-repeat: no-repeat;
+              background-position: center 14px;
             }
-          }
 
-          &::after {
-            background: #333;
-            content: " ";
-            display: block;
-            height: 10px;
-            right: 18px;
-            position: absolute;
-            top: -5px;
-            @include transform(rotate(45deg));
-            width: 10px;
-          }
-        }
+            &.active {
+              @extend %ui-depth1;
+              background-color: $white;
 
-        &:hover, &:focus {
-          p {
-            display: block;
-            margin-top: ($baseline/5);
-            opacity: 1.0;
-            visibility: visible;
-          }
-        }
-      }
-    }
-  }
+              &:hover, &:focus {
+                background-color: $white;
+                background-repeat: no-repeat;
+                background-position: center 14px;
+              }
+            }
 
-  ul {
-    position: absolute;
-    top: 0;
-    list-style: none !important;
-    height: 100%;
-    right: 0;
-    top: 0;
-    width: 100%;
-    margin: 0;
-    border: none;
+            //video
+            &.seq_video {
+              &.inactive {
+                background-image: url('../images/sequence-nav/video-icon-normal.png');
+              }
 
-    li {
-      position: absolute;
-      margin-bottom: 0;
-      height: 44px;
-      width: 70px;
-      border: 1px solid $gray-l3;
-      @include linear-gradient(top, #eee, #ddd);
-      box-shadow: 0 1px 0 rgba(255, 255, 255, .7) inset;
-      z-index: 1;
+              &.visited {
+                background-image: url('../images/sequence-nav/video-icon-visited.png');
+              }
 
-      &.prev, &.next {
+              &.active {
+                @extend .active;
+                background-image: url('../images/sequence-nav/video-icon-current.png');
+              }
+            }
 
-        a {
-          background-position: center;
-          background-repeat: no-repeat;
-          display: block;
-          height: 100%;
-          width: 40px;
-          text-indent: -9999px;
-          overflow: hidden;
-          @include transition(all .2s $ease-in-out-quad 0s);
+            //other
+            &.seq_other {
+              &.inactive {
+                background-image: url('../images/sequence-nav/document-icon-normal.png');
+              }
 
-/*          &:focus {
-            outline: 0;
-          }
-*/
-          &:hover, &:focus {
-            opacity: 0.5;
-          }
+              &.visited {
+                background-image: url('../images/sequence-nav/document-icon-visited.png');
+              }
 
-          &.disabled {
-            cursor: normal;
-            opacity: 0.4;
-          }
-        }
-      }
+              &.active {
+                background-image: url('../images/sequence-nav/document-icon-current.png');
+              }
+            }
 
-      &.prev {
-        @include left(-10px);
-        @include border-radius(35px, 0, 0, 35px);
+            //vertical & problems
+            &.seq_vertical, &.seq_problem {
+              &.inactive {
+                background-image: url('../images/sequence-nav/list-icon-normal.png');
+              }
 
-        a {
-          background-position: center 15px;
+              &.visited {
+                background-image: url('../images/sequence-nav/list-icon-visited.png');
+              }
 
-          // CASE: left to right layout
-          @include ltr {
-            background-image: url('../images/sequence-nav/previous-icon.png');
-          }
+              &.active {
+                background-image: url('../images/sequence-nav/list-icon-current.png');
+              }
 
-          // CASE: right to left layout
-          @include rtl {
-            background-image: url('../images/sequence-nav/next-icon.png');
-          }
-        }
-      }
+              &.progress-none {
+                background-image: url('../images/sequence-nav/list-unstarted.png');
+              }
 
-      &.next {
-        @include right(-10px);
-        @include border-radius(0, 35px, 35px, 0);
+              &.progress-some, &.progress-in_progress {
+                background-image: url('../images/sequence-nav/list-unfinished.png');
+              }
 
-        a {
-          @include margin-left(30px);
-          background-position: center 15px;
+              &.progress-done {
+                background-image: url('../images/sequence-nav/list-finished.png');
+              }
+            }
 
-          // CASE: left to right layout
-          @include ltr {
-            background-image: url('../images/sequence-nav/next-icon.png');
-          }
+            p {
+              @extend %ui-depth2;
+              background: #333;
+              color: $white;
+              font-family: $sans-serif;
+              line-height: lh();
+              right: 0;
+              opacity: 0.0;
+              padding: 6px;
+              position: absolute;
+              top: 48px;
+              text-shadow: 0 -1px 0 $black;
+              @include transition(all .1s $ease-in-out-quart 0s);
+              white-space: pre;
+              visibility: hidden;
+              pointer-events: none;
 
-          // CASE: right to left layout
-          @include rtl {
-            background-image: url('../images/sequence-nav/previous-icon.png');
+
+              &:empty {
+                background: none;
+
+                &::after {
+                  display: none;
+                }
+              }
+
+              &::after {
+                background: #333;
+                content: " ";
+                display: block;
+                height: 10px;
+                right: 18px;
+                position: absolute;
+                top: -5px;
+                @include transform(rotate(45deg));
+                width: 10px;
+              }
+            }
+
+            &:hover, &:focus {
+              p {
+                display: block;
+                margin-top: ($baseline/5);
+                opacity: 1.0;
+                visibility: visible;
+              }
+            }
           }
         }
       }
@@ -341,92 +240,74 @@ nav.sequence-nav {
   }
 }
 
+.sequence-nav-button {
+  @include linear-gradient(top, #eee, #ddd);
+  @include transition(all .2s $ease-in-out-quad 0s);
+  position: absolute;
+  top: 0;
+  z-index: 50;
+  display: block;
+  height: 44px;
+  width: ($baseline*2);
+  border: 1px solid $gray-l3;
+  box-shadow: 0 1px 0 rgba(255, 255, 255, .7) inset;
+  background-position: center;
+  background-repeat: no-repeat;
+  text-indent: -9999px;
+  overflow: hidden;
+
+  &.prev {
+    @include border-radius(35px, 0, 0, 35px);
+    @include left(0);
+    background-position: center 15px;
+
+    // CASE: left to right layout
+    @include ltr {
+      background-image: url('../images/sequence-nav/previous-icon.png');
+    }
+
+    // CASE: right to left layout
+    @include rtl {
+      background-image: url('../images/sequence-nav/next-icon.png');
+    }
+  }
+
+  &.next {
+    @include border-radius(0, 35px, 35px, 0);
+    @include right(0);
+    background-position: center 15px;
+
+    // CASE: left to right layout
+    @include ltr {
+      background-image: url('../images/sequence-nav/next-icon.png');
+    }
+
+    // CASE: right to left layout
+    @include rtl {
+      background-image: url('../images/sequence-nav/previous-icon.png');
+    }
+  }
+
+  &:hover, &:focus {
+    opacity: 0.5;
+  }
+
+  &.disabled {
+    cursor: normal;
+    opacity: 0.4;
+  }
+}
+
 .seq_contents {
   display: none;
 }
 
-nav.sequence-bottom {
-  margin: lh(2) 0 0;
-  text-align: center;
-
-  ul {
-    @include clearfix();
-    display: inline-block;
-
-    li {
-      @include float(left);
-      width: 50px;
-      height: 44px;
-      border: 1px solid $gray-l3;
-      @include linear-gradient(top, #eee, #ddd);
-      box-shadow: 0 1px 0 rgba(255, 255, 255, .7) inset;
-
-      &.prev, &.next {
-        margin-bottom: 0;
-
-        a {
-          background-position: center center;
-          background-repeat: no-repeat;
-          border: none;
-          display: block;
-          padding: lh(0.5) 4px;
-          text-indent: -9999px;
-          overflow: hidden;
-          @include transition(all .2s $ease-in-out-quad 0s);
-
-          &:hover, &:focus {
-            opacity: 0.5;
-            background-position: center 15px;
-          }
-
-          &.disabled {
-            opacity: 0.4;
-          }
-
-/*          &:focus {
-            outline: 0;
-          }
-*/        }
-      }
-
-      &.prev {
-        @include border-radius(35px, 0, 0, 35px);
-
-        a {
-          background-position: center 15px;
-
-         // CASE: left to right layout
-         @include ltr {
-            background-image: url('../images/sequence-nav/previous-icon.png');
-          }
-
-          // CASE: right to left layout
-          @include rtl {
-            background-image: url('../images/sequence-nav/next-icon.png');
-          }
-        }
-      }
-
-      &.next {
-        @include border-radius(0, 35px, 35px, 0);
-        @include border-left(none);
-
-        a {
-          background-position: center 15px;
-
-          // CASE: left to right layout
-          @include ltr {
-            background-image: url('../images/sequence-nav/next-icon.png');
-          }
-
-          // CASE: right to left layout
-          @include rtl {
-            background-image: url('../images/sequence-nav/previous-icon.png');
-          }
-        }
-      }
-    }
-  }
+.sequence-bottom {
+  position: relative;
+  width: ($baseline*4) - 1;
+  height: 44px;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .xmodule_VerticalModule div.vert-mod > div ul.sequence-nav-buttons {

--- a/common/lib/xmodule/xmodule/js/spec/sequence/display_spec.coffee
+++ b/common/lib/xmodule/xmodule/js/spec/sequence/display_spec.coffee
@@ -40,11 +40,11 @@ xdescribe 'Sequence', ->
         @sequence.toggleArrows()
 
       it 'disable the previous button', ->
-        expect($('.sequence-nav-buttons .prev a')).toHaveClass 'disabled'
+        expect($('.sequence-nav-button.prev')).toHaveClass 'disabled'
 
       it 'enable the next button', ->
-        expect($('.sequence-nav-buttons .next a')).not.toHaveClass 'disabled'
-        expect($('.sequence-nav-buttons .next a')).toHandleWith 'click', @sequence.next
+        expect($('.sequence-nav-button.next')).not.toHaveClass 'disabled'
+        expect($('.sequence-nav-button.next')).toHandleWith 'click', @sequence.next
 
     describe 'when the middle tab is active', ->
       beforeEach ->
@@ -52,12 +52,12 @@ xdescribe 'Sequence', ->
         @sequence.toggleArrows()
 
       it 'enable the previous button', ->
-        expect($('.sequence-nav-buttons .prev a')).not.toHaveClass 'disabled'
-        expect($('.sequence-nav-buttons .prev a')).toHandleWith 'click', @sequence.previous
+        expect($('.sequence-nav-button.prev')).not.toHaveClass 'disabled'
+        expect($('.sequence-nav-button.prev')).toHandleWith 'click', @sequence.previous
 
       it 'enable the next button', ->
-        expect($('.sequence-nav-buttons .next a')).not.toHaveClass 'disabled'
-        expect($('.sequence-nav-buttons .next a')).toHandleWith 'click', @sequence.next
+        expect($('.sequence-nav-button.next')).not.toHaveClass 'disabled'
+        expect($('.sequence-nav-button.next')).toHandleWith 'click', @sequence.next
 
     describe 'when the last tab is active', ->
       beforeEach ->
@@ -65,11 +65,11 @@ xdescribe 'Sequence', ->
         @sequence.toggleArrows()
 
       it 'enable the previous button', ->
-        expect($('.sequence-nav-buttons .prev a')).not.toHaveClass 'disabled'
-        expect($('.sequence-nav-buttons .prev a')).toHandleWith 'click', @sequence.previous
+        expect($('.sequence-nav-button.prev')).not.toHaveClass 'disabled'
+        expect($('.sequence-nav-button.prev')).toHandleWith 'click', @sequence.previous
 
       it 'disable the next button', ->
-        expect($('.sequence-nav-buttons .next a')).toHaveClass 'disabled'
+        expect($('.sequence-nav-button.next')).toHaveClass 'disabled'
 
   describe 'render', ->
     beforeEach ->

--- a/common/lib/xmodule/xmodule/js/src/sequence/display.coffee
+++ b/common/lib/xmodule/xmodule/js/src/sequence/display.coffee
@@ -114,6 +114,8 @@ class @Sequence
 
       sequence_links = @content_container.find('a.seqnav')
       sequence_links.click @goto
+
+      @content_container.focus();
     @$("a.active").blur()
 
   goto: (event) =>

--- a/common/lib/xmodule/xmodule/js/src/sequence/display.coffee
+++ b/common/lib/xmodule/xmodule/js/src/sequence/display.coffee
@@ -71,22 +71,22 @@ class @Sequence
         when 'done' then element.addClass('progress-done')
 
   toggleArrows: =>
-    @$('.sequence-nav-buttons a').unbind('click')
+    @$('.sequence-nav-button').unbind('click')
 
     if @contents.length == 0
-      @$('.sequence-nav-buttons .prev a').addClass('disabled').attr('aria-hidden', 'true')
-      @$('.sequence-nav-buttons .next a').addClass('disabled').attr('aria-hidden', 'true')
+      @$('.sequence-nav-button.prev').addClass('disabled').attr('aria-hidden', 'true').attr('disabled')
+      @$('.sequence-nav-button.next').addClass('disabled').attr('aria-hidden', 'true').attr('disabled')
       return
 
     if @position == 1
-      @$('.sequence-nav-buttons .prev a').addClass('disabled').attr('aria-hidden', 'true')
+      @$('.sequence-nav-button.prev').addClass('disabled').attr('aria-hidden', 'true').attr('disabled')
     else
-      @$('.sequence-nav-buttons .prev a').removeClass('disabled').attr('aria-hidden', 'false').click(@previous)
+      @$('.sequence-nav-button.prev').removeClass('disabled').attr('aria-hidden', 'false').removeAttr('disabled').click(@previous)
 
     if @position == @contents.length
-      @$('.sequence-nav-buttons .next a').addClass('disabled').attr('aria-hidden', 'true')
+      @$('.sequence-nav-button.next').addClass('disabled').attr('aria-hidden', 'true').attr('disabled')
     else
-      @$('.sequence-nav-buttons .next a').removeClass('disabled').attr('aria-hidden', 'false').click(@next)
+      @$('.sequence-nav-button.next').removeClass('disabled').attr('aria-hidden', 'false').removeAttr('disabled').click(@next)
 
   render: (new_position) ->
     if @position != new_position

--- a/common/lib/xmodule/xmodule/js/src/sequence/display/jquery.sequence.js
+++ b/common/lib/xmodule/xmodule/js/src/sequence/display/jquery.sequence.js
@@ -3,7 +3,7 @@ var SequenceNav = function($element) {
 	var $element = $element;
 	var $wrapper = $element.find('.sequence-list-wrapper');
 	var $list = $element.find('#sequence-list');
-	var $arrows = $element.find('.sequence-nav-buttons');
+	var $arrows = $element.find('.sequence-nav-button');
 	var maxScroll = $list.width() - $wrapper.width() + 20;
 	var $leftShadow = $('<div class="left-shadow"></div>');
 	var $rightShadow = $('<div class="right-shadow"></div>');

--- a/lms/templates/seq_module.html
+++ b/lms/templates/seq_module.html
@@ -40,7 +40,7 @@
      ${item['content'] | h}
   </div>
   % endfor
-  <div id="seq_content" role="tabpanel"></div>
+  <div id="seq_content" tabindex="-1"></div>
 
   <nav class="sequence-bottom" aria-label="${_('Section Navigation')}">
     <button class="sequence-nav-button button-prev prev">${_('Previous')}</button>

--- a/lms/templates/seq_module.html
+++ b/lms/templates/seq_module.html
@@ -1,40 +1,36 @@
 <%! from django.utils.translation import ugettext as _ %>
 
 <div id="sequence_${element_id}" class="sequence" data-id="${item_id}" data-position="${position}" data-ajax-url="${ajax_url}" >
-  <nav class="sequence-nav">
-    <ul class="sequence-nav-buttons">
-      <li class="prev"><a role="button" href="#">${_('Previous')}</a></li>
-    </ul>
-
-    <div class="sequence-list-wrapper">
-      <ol role="tablist" aria-label="${_('Section Navigation')}" id="sequence-list">
-        % for idx, item in enumerate(items):
-        ## TODO (vshnayder): add item.progress_detail either to the title or somewhere else.
-        ## Make sure it gets updated after ajax calls.
-        ## implementation note: will need to figure out how to handle combining detail
-        ## statuses of multiple modules in js.
-        <li>
-        <a class="seq_${item['type']} inactive progress-${item['progress_status']}"
-           data-id="${item['id']}"
-           data-element="${idx+1}"
-           href="javascript:void(0);"
-           title="${item['title']|h}"
-           data-page-title="${item['page_title']|h}"
-           aria-controls="seq_contents_${idx}"
-           id="tab_${idx}"
-           tabindex="0"
-           role="tab">
-            <p aria-hidden="false">${item['title']}</p>
-          </a>
-        </li>
-        % endfor
-      </ol>
-    </div>
-
-    <ul class="sequence-nav-buttons">
-      <li class="next"><a role="button" href="#">${_("Next")}</a></li>
-    </ul>
-  </nav>
+  <div class="sequence-nav">
+    <nav class="sequence-list-wrapper" aria-label="Unit">
+      <button class="sequence-nav-button button-previous prev">${_('Previous')}</button>
+      <div class="sequence-list">
+        <ol aria-label="${_('Section Navigation')}" id="sequence-list">
+          % for idx, item in enumerate(items):
+          ## TODO (vshnayder): add item.progress_detail either to the title or somewhere else.
+          ## Make sure it gets updated after ajax calls.
+          ## implementation note: will need to figure out how to handle combining detail
+          ## statuses of multiple modules in js.
+          <li>
+            <a class="seq_${item['type']} inactive progress-${item['progress_status']}"
+             data-id="${item['id']}"
+             data-element="${idx+1}"
+             href="javascript:void(0);"
+             title="${item['title']|h}"
+             aria-label="${item['title']|h}"
+             data-page-title="${item['page_title']|h}"
+             aria-controls="seq_contents_${idx}"
+             id="tab_${idx}"
+             tabindex="0">
+              <p aria-hidden="false">${item['title']}</p>
+            </a>
+          </li>
+          % endfor
+        </ol>
+      </div>
+      <button class="sequence-nav-button button-next next">${_('Next')}</button>
+    </nav>
+  </div>
 
   % for idx, item in enumerate(items):
   <div id="seq_contents_${idx}"
@@ -46,11 +42,9 @@
   % endfor
   <div id="seq_content" role="tabpanel"></div>
 
-  <nav class="sequence-bottom">
-    <ul aria-label="${_('Section Navigation')}" class="sequence-nav-buttons">
-      <li class="prev"><a role="button" href="#">${_("Previous")}</a></li>
-      <li class="next"><a role="button" href="#">${_("Next")}</a></li>
-    </ul>
+  <nav class="sequence-bottom" aria-label="${_('Section Navigation')}">
+    <button class="sequence-nav-button button-prev prev">${_('Previous')}</button>
+    <button class="sequence-nav-button button-next next">${_('Next')}</button>
   </nav>
 </div>
 


### PR DESCRIPTION
This work includes all the work in [UX-1572](https://openedx.atlassian.net/browse/UX-1572). It provides a way to send focus to the content area after clicking an item in the sequence/unit navigation.

Currently when one activates a link in the sequence/unit navigation, focus is lost and sent back to the top of the page, forcing keyboard users to navigate through all of the elements until he or she reaches the content area. This work sends focus directly to the content area upon navigation link activation.

---

@cptvitamin When you get time, would you mind reviewing?

---

@frrrances @talbs Would one of you review the FED here?
