### PR TITLE
Clean up ModuleStoreTestCase

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/tests/test_cleanup_assets.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_cleanup_assets.py
@@ -22,6 +22,8 @@ class ExportAllCourses(ModuleStoreTestCase):
     """
     def setUp(self):
         """ Common setup. """
+        super(ExportAllCourses, self).setUp()
+
         self.content_store = contentstore()
         self.module_store = modulestore()
 

--- a/cms/djangoapps/contentstore/management/commands/tests/test_create_course.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_create_course.py
@@ -16,6 +16,8 @@ class TestArgParsing(unittest.TestCase):
     Tests for parsing arguments for the `create_course` management command
     """
     def setUp(self):
+        super(TestArgParsing, self).setUp()
+
         self.command = Command()
 
     def test_no_args(self):

--- a/cms/djangoapps/contentstore/management/commands/tests/test_export_all_courses.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_export_all_courses.py
@@ -18,6 +18,7 @@ class ExportAllCourses(ModuleStoreTestCase):
     """
     def setUp(self):
         """ Common setup. """
+        super(ExportAllCourses, self).setUp()
         self.store = modulestore()._get_modulestore_by_type(ModuleStoreEnum.Type.mongo)
         self.temp_dir = mkdtemp()
         self.first_course = CourseFactory.create(org="test", course="course1", display_name="run1")

--- a/cms/djangoapps/contentstore/management/commands/tests/test_export_convert_format.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_export_convert_format.py
@@ -16,6 +16,8 @@ class ConvertExportFormat(TestCase):
     """
     def setUp(self):
         """ Common setup. """
+        super(ConvertExportFormat, self).setUp()
+
         self.temp_dir = mkdtemp()
         self.data_dir = path(__file__).realpath().parent / 'data'
         self.version0 = self.data_dir / "Version0_drafts.tar.gz"

--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -1747,6 +1747,7 @@ class EntryPageTestCase(TestCase):
     Tests entry pages that aren't specific to a course.
     """
     def setUp(self):
+        super(EntryPageTestCase, self).setUp()
         self.client = AjaxEnabledTestClient()
 
     def _test_page(self, page, status_code=200):

--- a/cms/djangoapps/contentstore/tests/test_crud.py
+++ b/cms/djangoapps/contentstore/tests/test_crud.py
@@ -20,6 +20,7 @@ class TemplateTests(unittest.TestCase):
     """
 
     def setUp(self):
+        super(TemplateTests, self).setUp()
         clear_existing_modulestores()  # redundant w/ cleanup but someone was getting errors
         self.addCleanup(self._drop_mongo_collections)
         self.addCleanup(clear_existing_modulestores)

--- a/cms/djangoapps/contentstore/tests/test_i18n.py
+++ b/cms/djangoapps/contentstore/tests/test_i18n.py
@@ -19,6 +19,8 @@ class InternationalizationTest(ModuleStoreTestCase):
         will be cleared out before each test case execution and deleted
         afterwards.
         """
+        super(InternationalizationTest, self).setUp(create_user=False)
+
         self.uname = 'testuser'
         self.email = 'test+courses@edx.org'
         self.password = 'foo'

--- a/cms/djangoapps/contentstore/tests/test_transcripts_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_transcripts_utils.py
@@ -28,6 +28,8 @@ TEST_DATA_CONTENTSTORE['DOC_STORE_CONFIG']['db'] = 'test_xcontent_%s' % uuid4().
 class TestGenerateSubs(unittest.TestCase):
     """Tests for `generate_subs` function."""
     def setUp(self):
+        super(TestGenerateSubs, self).setUp()
+
         self.source_subs = {
             'start': [100, 200, 240, 390, 1000],
             'end': [200, 240, 380, 1000, 1500],
@@ -93,6 +95,7 @@ class TestSaveSubsToStore(ModuleStoreTestCase):
 
     def setUp(self):
 
+        super(TestSaveSubsToStore, self).setUp()
         self.course = CourseFactory.create(
             org=self.org, number=self.number, display_name=self.display_name)
 
@@ -183,6 +186,7 @@ class TestDownloadYoutubeSubs(ModuleStoreTestCase):
             self.clear_sub_content(subs_id)
 
     def setUp(self):
+        super(TestDownloadYoutubeSubs, self).setUp()
         self.course = CourseFactory.create(
             org=self.org, number=self.number, display_name=self.display_name)
 
@@ -477,6 +481,7 @@ class TestTranscript(unittest.TestCase):
     Tests for Transcript class e.g. different transcript conversions.
     """
     def setUp(self):
+        super(TestTranscript, self).setUp()
 
         self.srt_transcript = textwrap.dedent("""\
             0

--- a/cms/djangoapps/contentstore/tests/test_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_utils.py
@@ -12,6 +12,7 @@ from contentstore import utils
 from contentstore.tests.utils import CourseTestCase
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
 
 from xmodule.modulestore.django import modulestore
@@ -164,7 +165,7 @@ class ExtraPanelTabTestCase(TestCase):
                 self.assertEqual(actual_tabs, expected_tabs)
 
 
-class CourseImageTestCase(TestCase):
+class CourseImageTestCase(ModuleStoreTestCase):
     """Tests for course image URLs."""
 
     def test_get_image_url(self):

--- a/cms/djangoapps/contentstore/tests/test_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_utils.py
@@ -196,6 +196,8 @@ class XBlockVisibilityTestCase(TestCase):
     """Tests for xblock visibility for students."""
 
     def setUp(self):
+        super(XBlockVisibilityTestCase, self).setUp()
+
         self.dummy_user = ModuleStoreEnum.UserID.test
         self.past = datetime(1970, 1, 1)
         self.future = datetime.now(UTC) + timedelta(days=1)

--- a/cms/djangoapps/contentstore/tests/tests.py
+++ b/cms/djangoapps/contentstore/tests/tests.py
@@ -88,6 +88,8 @@ class AuthTestCase(ContentStoreTestCase):
     """Check that various permissions-related things work"""
 
     def setUp(self):
+        super(AuthTestCase, self).setUp(create_user=False)
+
         self.email = 'a@b.com'
         self.pw = 'xyz'
         self.username = 'testuser'

--- a/cms/djangoapps/contentstore/tests/utils.py
+++ b/cms/djangoapps/contentstore/tests/utils.py
@@ -67,7 +67,6 @@ class AjaxEnabledTestClient(Client):
         return self.get(path, data or {}, follow, HTTP_ACCEPT="application/json", **extra)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class CourseTestCase(ModuleStoreTestCase):
     """
     Base class for Studio tests that require a logged in user and a course.
@@ -81,6 +80,7 @@ class CourseTestCase(ModuleStoreTestCase):
         will be cleared out before each test case execution and deleted
         afterwards.
         """
+
         self.user_password = super(CourseTestCase, self).setUp()
 
         self.client = AjaxEnabledTestClient()

--- a/cms/djangoapps/contentstore/views/tests/test_access.py
+++ b/cms/djangoapps/contentstore/views/tests/test_access.py
@@ -17,6 +17,8 @@ class RolesTest(TestCase):
     """
     def setUp(self):
         """ Test case setup """
+        super(RolesTest, self).setUp()
+
         self.global_admin = AdminFactory()
         self.instructor = User.objects.create_user('testinstructor', 'testinstructor+courses@edx.org', 'foo')
         self.staff = User.objects.create_user('teststaff', 'teststaff+courses@edx.org', 'foo')

--- a/cms/djangoapps/contentstore/views/tests/test_item.py
+++ b/cms/djangoapps/contentstore/views/tests/test_item.py
@@ -1188,6 +1188,8 @@ class TestEditSplitModule(ItemTest):
 @ddt.ddt
 class TestComponentHandler(TestCase):
     def setUp(self):
+        super(TestComponentHandler, self).setUp()
+
         self.request_factory = RequestFactory()
 
         patcher = patch('contentstore.views.component.modulestore')

--- a/cms/djangoapps/contentstore/views/tests/test_preview.py
+++ b/cms/djangoapps/contentstore/views/tests/test_preview.py
@@ -22,7 +22,7 @@ from cms.djangoapps.xblock_config.models import StudioConfig
 from xmodule.modulestore.django import modulestore
 
 
-class GetPreviewHtmlTestCase(TestCase):
+class GetPreviewHtmlTestCase(ModuleStoreTestCase):
     """
     Tests for get_preview_fragment.
 

--- a/cms/djangoapps/contentstore/views/tests/test_tabs.py
+++ b/cms/djangoapps/contentstore/views/tests/test_tabs.py
@@ -6,6 +6,7 @@ from contentstore.tests.utils import CourseTestCase
 from django.test import TestCase
 from xmodule.x_module import STUDENT_VIEW
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.tabs import CourseTabList, WikiTab
 from contentstore.utils import reverse_course_url
 from xmodule.modulestore.django import modulestore
@@ -192,7 +193,7 @@ class TabsPageTests(CourseTestCase):
         self.assertIn('<span data-tooltip="Drag to reorder" class="drag-handle action"></span>', html)
 
 
-class PrimitiveTabEdit(TestCase):
+class PrimitiveTabEdit(ModuleStoreTestCase):
     """Tests for the primitive tab edit data manipulations"""
 
     def test_delete(self):

--- a/cms/djangoapps/contentstore/views/tests/test_textbooks.py
+++ b/cms/djangoapps/contentstore/views/tests/test_textbooks.py
@@ -292,6 +292,8 @@ class TextbookValidationTestCase(TestCase):
 
     def setUp(self):
         "Set some useful content for tests"
+        super(TextbookValidationTestCase, self).setUp()
+
         self.tb1 = {
             "tab_title": "Hi, mom!",
             "url": "/mom.pdf"

--- a/common/djangoapps/course_about/tests/test_api.py
+++ b/common/djangoapps/course_about/tests/test_api.py
@@ -17,14 +17,8 @@ from xmodule.modulestore.tests.django_utils import (
 from xmodule.modulestore.tests.factories import CourseFactory, CourseAboutFactory
 from student.tests.factories import UserFactory
 
-# Since we don't need any XML course fixtures, use a modulestore configuration
-# that disables the XML modulestore.
-
-MODULESTORE_CONFIG = mixed_store_config(settings.COMMON_TEST_DATA_ROOT, {}, include_xml=False)
-
 
 @ddt.ddt
-@override_settings(MODULESTORE=MODULESTORE_CONFIG)
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 class CourseInfoTest(ModuleStoreTestCase, APITestCase):
     """

--- a/common/djangoapps/course_about/tests/test_data.py
+++ b/common/djangoapps/course_about/tests/test_data.py
@@ -16,12 +16,7 @@ from course_about import data
 from course_about.errors import CourseNotFoundError
 from xmodule.modulestore.django import modulestore
 
-# Since we don't need any XML course fixtures, use a modulestore configuration
-# that disables the XML modulestore.
-MODULESTORE_CONFIG = mixed_store_config(settings.COMMON_TEST_DATA_ROOT, {}, include_xml=False)
 
-
-@override_settings(MODULESTORE=MODULESTORE_CONFIG)
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 class CourseAboutDataTest(ModuleStoreTestCase):
     """

--- a/common/djangoapps/course_about/tests/test_views.py
+++ b/common/djangoapps/course_about/tests/test_views.py
@@ -22,14 +22,8 @@ from course_about import api
 from course_about.errors import CourseNotFoundError, CourseAboutError
 from xmodule.modulestore.django import modulestore
 
-# Since we don't need any XML course fixtures, use a modulestore configuration
-# that disables the XML modulestore.
-
-MODULESTORE_CONFIG = mixed_store_config(settings.COMMON_TEST_DATA_ROOT, {}, include_xml=False)
-
 
 @ddt.ddt
-@override_settings(MODULESTORE=MODULESTORE_CONFIG)
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 class CourseInfoTest(ModuleStoreTestCase, APITestCase):
     """

--- a/common/djangoapps/course_modes/tests/test_views.py
+++ b/common/djangoapps/course_modes/tests/test_views.py
@@ -18,13 +18,7 @@ from student.models import CourseEnrollment
 from course_modes.models import CourseMode, Mode
 
 
-# Since we don't need any XML course fixtures, use a modulestore configuration
-# that disables the XML modulestore.
-MODULESTORE_CONFIG = mixed_store_config(settings.COMMON_TEST_DATA_ROOT, {}, include_xml=False)
-
-
 @ddt.ddt
-@override_settings(MODULESTORE=MODULESTORE_CONFIG)
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 class CourseModeViewTest(UrlResetMixin, ModuleStoreTestCase):
     @patch.dict(settings.FEATURES, {'MODE_CREATION_FOR_TESTING': True})

--- a/common/djangoapps/embargo/tests/test_forms.py
+++ b/common/djangoapps/embargo/tests/test_forms.py
@@ -21,6 +21,7 @@ class EmbargoCourseFormTest(ModuleStoreTestCase):
     """Test the course form properly validates course IDs"""
 
     def setUp(self):
+        super(EmbargoCourseFormTest, self).setUp()
         self.course = CourseFactory.create()
         self.true_form_data = {'course_id': self.course.id.to_deprecated_string(), 'embargoed': True}
         self.false_form_data = {'course_id': self.course.id.to_deprecated_string(), 'embargoed': False}

--- a/common/djangoapps/embargo/tests/test_forms.py
+++ b/common/djangoapps/embargo/tests/test_forms.py
@@ -16,7 +16,6 @@ from xmodule.modulestore.tests.factories import CourseFactory
 from xmodule.modulestore.tests.django_utils import TEST_DATA_MOCK_MODULESTORE
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class EmbargoCourseFormTest(ModuleStoreTestCase):
     """Test the course form properly validates course IDs"""
 

--- a/common/djangoapps/embargo/tests/test_middleware.py
+++ b/common/djangoapps/embargo/tests/test_middleware.py
@@ -24,13 +24,7 @@ from config_models.models import cache
 from embargo.models import EmbargoedCourse, EmbargoedState, IPFilter
 
 
-# Since we don't need any XML course fixtures, use a modulestore configuration
-# that disables the XML modulestore.
-MODULESTORE_CONFIG = mixed_store_config(settings.COMMON_TEST_DATA_ROOT, {}, include_xml=False)
-
-
 @ddt.ddt
-@override_settings(MODULESTORE=MODULESTORE_CONFIG)
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 class EmbargoMiddlewareTests(ModuleStoreTestCase):
     """

--- a/common/djangoapps/embargo/tests/test_middleware.py
+++ b/common/djangoapps/embargo/tests/test_middleware.py
@@ -37,6 +37,8 @@ class EmbargoMiddlewareTests(ModuleStoreTestCase):
     Tests of EmbargoMiddleware
     """
     def setUp(self):
+        super(EmbargoMiddlewareTests, self).setUp()
+
         self.user = UserFactory(username='fred', password='secret')
         self.client.login(username='fred', password='secret')
         self.embargo_course = CourseFactory.create()

--- a/common/djangoapps/enrollment/tests/test_data.py
+++ b/common/djangoapps/enrollment/tests/test_data.py
@@ -19,13 +19,8 @@ from student.tests.factories import UserFactory, CourseModeFactory
 from student.models import CourseEnrollment, EnrollmentClosedError, CourseFullError, AlreadyEnrolledError
 from enrollment import data
 
-# Since we don't need any XML course fixtures, use a modulestore configuration
-# that disables the XML modulestore.
-MODULESTORE_CONFIG = mixed_store_config(settings.COMMON_TEST_DATA_ROOT, {}, include_xml=False)
-
 
 @ddt.ddt
-@override_settings(MODULESTORE=MODULESTORE_CONFIG)
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 class EnrollmentDataTest(ModuleStoreTestCase):
     """

--- a/common/djangoapps/enrollment/tests/test_views.py
+++ b/common/djangoapps/enrollment/tests/test_views.py
@@ -20,13 +20,8 @@ from enrollment.errors import CourseEnrollmentError
 from student.tests.factories import UserFactory, CourseModeFactory
 from student.models import CourseEnrollment
 
-# Since we don't need any XML course fixtures, use a modulestore configuration
-# that disables the XML modulestore.
-MODULESTORE_CONFIG = mixed_store_config(settings.COMMON_TEST_DATA_ROOT, {}, include_xml=False)
-
 
 @ddt.ddt
-@override_settings(MODULESTORE=MODULESTORE_CONFIG)
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 class EnrollmentTest(ModuleStoreTestCase, APITestCase):
     """

--- a/common/djangoapps/external_auth/tests/test_shib.py
+++ b/common/djangoapps/external_auth/tests/test_shib.py
@@ -73,7 +73,7 @@ def gen_all_identities():
 
 
 @ddt
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE, SESSION_ENGINE='django.contrib.sessions.backends.cache')
+@override_settings(SESSION_ENGINE='django.contrib.sessions.backends.cache')
 class ShibSPTest(ModuleStoreTestCase):
     """
     Tests for the Shibboleth SP, which communicates via request.META

--- a/common/djangoapps/geoinfo/tests/test_middleware.py
+++ b/common/djangoapps/geoinfo/tests/test_middleware.py
@@ -20,6 +20,7 @@ class CountryMiddlewareTests(TestCase):
     Tests of CountryMiddleware.
     """
     def setUp(self):
+        super(CountryMiddlewareTests, self).setUp()
         self.country_middleware = CountryMiddleware()
         self.session_middleware = SessionMiddleware()
         self.authenticated_user = UserFactory.create()

--- a/common/djangoapps/geoinfo/tests/test_middleware.py
+++ b/common/djangoapps/geoinfo/tests/test_middleware.py
@@ -14,7 +14,6 @@ from xmodule.modulestore.tests.django_utils import TEST_DATA_MOCK_MODULESTORE
 from student.tests.factories import UserFactory, AnonymousUserFactory
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class CountryMiddlewareTests(TestCase):
     """
     Tests of CountryMiddleware.

--- a/common/djangoapps/reverification/tests/test_models.py
+++ b/common/djangoapps/reverification/tests/test_models.py
@@ -14,7 +14,6 @@ from xmodule.modulestore.tests.factories import CourseFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class TestMidcourseReverificationWindow(ModuleStoreTestCase):
     """ Tests for MidcourseReverificationWindow objects """
 

--- a/common/djangoapps/student/management/tests/test_transfer_students.py
+++ b/common/djangoapps/student/management/tests/test_transfer_students.py
@@ -27,6 +27,8 @@ class TestTransferStudents(ModuleStoreTestCase):
 
     def setUp(self, **kwargs):
         """Connect a stub receiver, and analytics event tracking."""
+        super(TestTransferStudents, self).setUp()
+
         UNENROLL_DONE.connect(self.assert_unenroll_signal)
         patcher = patch('student.models.tracker')
         self.mock_tracker = patcher.start()

--- a/common/djangoapps/student/tests/test_bulk_email_settings.py
+++ b/common/djangoapps/student/tests/test_bulk_email_settings.py
@@ -24,12 +24,12 @@ from xmodule.modulestore.tests.factories import CourseFactory
 from bulk_email.models import CourseAuthorization  # pylint: disable=import-error
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 class TestStudentDashboardEmailView(ModuleStoreTestCase):
     """
     Check for email view displayed with flag
     """
+
     def setUp(self):
         super(TestStudentDashboardEmailView, self).setUp()
 
@@ -92,12 +92,13 @@ class TestStudentDashboardEmailView(ModuleStoreTestCase):
         self.assertTrue(self.email_modal_link in response.content)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MIXED_TOY_MODULESTORE)
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 class TestStudentDashboardEmailViewXMLBacked(ModuleStoreTestCase):
     """
     Check for email view on student dashboard, with XML backed course.
     """
+    MODULESTORE = TEST_DATA_MIXED_TOY_MODULESTORE
+
     def setUp(self):
         self.course_name = 'edX/toy/2012_Fall'
 

--- a/common/djangoapps/student/tests/test_bulk_email_settings.py
+++ b/common/djangoapps/student/tests/test_bulk_email_settings.py
@@ -31,6 +31,8 @@ class TestStudentDashboardEmailView(ModuleStoreTestCase):
     Check for email view displayed with flag
     """
     def setUp(self):
+        super(TestStudentDashboardEmailView, self).setUp()
+
         self.course = CourseFactory.create()
 
         # Create student account

--- a/common/djangoapps/student/tests/test_enrollment.py
+++ b/common/djangoapps/student/tests/test_enrollment.py
@@ -8,25 +8,19 @@ from mock import patch
 from django.test.utils import override_settings
 from django.conf import settings
 from django.core.urlresolvers import reverse
-from xmodule.modulestore.tests.django_utils import (
-    ModuleStoreTestCase, mixed_store_config
-)
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 from student.tests.factories import UserFactory, CourseModeFactory
 from student.models import CourseEnrollment
 
-# Since we don't need any XML course fixtures, use a modulestore configuration
-# that disables the XML modulestore.
-MODULESTORE_CONFIG = mixed_store_config(settings.COMMON_TEST_DATA_ROOT, {}, include_xml=False)
-
 
 @ddt.ddt
-@override_settings(MODULESTORE=MODULESTORE_CONFIG)
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 class EnrollmentTest(ModuleStoreTestCase):
     """
     Test student enrollment, especially with different course modes.
     """
+
     USERNAME = "Bob"
     EMAIL = "bob@example.com"
     PASSWORD = "edx"

--- a/common/djangoapps/student/tests/test_login.py
+++ b/common/djangoapps/student/tests/test_login.py
@@ -319,11 +319,11 @@ class LoginTest(TestCase):
             self.assertNotIn(log_string, format_string)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class ExternalAuthShibTest(ModuleStoreTestCase):
     """
     Tests how login_user() interacts with ExternalAuth, in particular Shib
     """
+
     def setUp(self):
         super(ExternalAuthShibTest, self).setUp()
         self.course = CourseFactory.create(

--- a/common/djangoapps/student/tests/test_login_registration_forms.py
+++ b/common/djangoapps/student/tests/test_login_registration_forms.py
@@ -12,9 +12,7 @@ from django.test.utils import override_settings
 from util.testing import UrlResetMixin
 from xmodule.modulestore.tests.factories import CourseFactory
 from student.tests.factories import CourseModeFactory
-from xmodule.modulestore.tests.django_utils import (
-    ModuleStoreTestCase, mixed_store_config
-)
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 
 
 # This relies on third party auth being enabled and configured
@@ -22,10 +20,6 @@ from xmodule.modulestore.tests.django_utils import (
 # and the feature flag `ENABLE_THIRD_PARTY_AUTH`
 THIRD_PARTY_AUTH_BACKENDS = ["google-oauth2", "facebook"]
 THIRD_PARTY_AUTH_PROVIDERS = ["Google", "Facebook"]
-
-# Since we don't need any XML course fixtures, use a modulestore configuration
-# that disables the XML modulestore.
-MODULESTORE_CONFIG = mixed_store_config(settings.COMMON_TEST_DATA_ROOT, {}, include_xml=False)
 
 
 def _third_party_login_url(backend_name, auth_entry, course_id=None, redirect_url=None):
@@ -43,7 +37,6 @@ def _third_party_login_url(backend_name, auth_entry, course_id=None, redirect_ur
 
 
 @ddt.ddt
-@override_settings(MODULESTORE=MODULESTORE_CONFIG)
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 class LoginFormTest(UrlResetMixin, ModuleStoreTestCase):
     """Test rendering of the login form. """
@@ -156,7 +149,6 @@ class LoginFormTest(UrlResetMixin, ModuleStoreTestCase):
 
 
 @ddt.ddt
-@override_settings(MODULESTORE=MODULESTORE_CONFIG)
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 class RegisterFormTest(UrlResetMixin, ModuleStoreTestCase):
     """Test rendering of the registration form. """

--- a/common/djangoapps/student/tests/test_login_registration_forms.py
+++ b/common/djangoapps/student/tests/test_login_registration_forms.py
@@ -50,6 +50,7 @@ class LoginFormTest(UrlResetMixin, ModuleStoreTestCase):
     @patch.dict(settings.FEATURES, {"ENABLE_COMBINED_LOGIN_REGISTRATION": False})
     def setUp(self):
         super(LoginFormTest, self).setUp('lms.urls')
+
         self.url = reverse("signin_user")
         self.course = CourseFactory.create()
         self.course_id = unicode(self.course.id)
@@ -162,6 +163,7 @@ class RegisterFormTest(UrlResetMixin, ModuleStoreTestCase):
     @patch.dict(settings.FEATURES, {"ENABLE_COMBINED_LOGIN_REGISTRATION": False})
     def setUp(self):
         super(RegisterFormTest, self).setUp('lms.urls')
+
         self.url = reverse("register_user")
         self.course = CourseFactory.create()
         self.course_id = unicode(self.course.id)

--- a/common/djangoapps/student/tests/test_verification_status.py
+++ b/common/djangoapps/student/tests/test_verification_status.py
@@ -17,17 +17,13 @@ from student.helpers import (
 )
 
 from xmodule.modulestore.tests.factories import CourseFactory
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, mixed_store_config
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from student.tests.factories import UserFactory, CourseEnrollmentFactory
 from course_modes.tests.factories import CourseModeFactory
 from verify_student.models import SoftwareSecurePhotoVerification  # pylint: disable=F0401
 from util.testing import UrlResetMixin
 
 
-MODULESTORE_CONFIG = mixed_store_config(settings.COMMON_TEST_DATA_ROOT, {}, include_xml=False)
-
-
-@override_settings(MODULESTORE=MODULESTORE_CONFIG)
 @patch.dict(settings.FEATURES, {'AUTOMATIC_VERIFY_STUDENT_IDENTITY_FOR_TESTING': True})
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 @ddt.ddt

--- a/common/djangoapps/student/tests/tests.py
+++ b/common/djangoapps/student/tests/tests.py
@@ -28,7 +28,6 @@ from student.views import (process_survey_link, _cert_info,
 from student.tests.factories import UserFactory, CourseModeFactory
 from xmodule.modulestore.tests.factories import CourseFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from xmodule.modulestore.tests.django_utils import TEST_DATA_MOCK_MODULESTORE
 
 # These imports refer to lms djangoapps.
 # Their testcases are only run under lms.
@@ -180,7 +179,6 @@ class CourseEndingTest(TestCase):
         self.assertIsNone(_cert_info(user, course2, cert_status))
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class DashboardTest(ModuleStoreTestCase):
     """
     Tests for dashboard utility functions
@@ -615,7 +613,6 @@ class EnrollInCourseTest(TestCase):
         self.assert_enrollment_mode_change_event_was_emitted(user, course_id, "honor")
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 class ChangeEnrollmentViewTest(ModuleStoreTestCase):
     """Tests the student.views.change_enrollment view"""
@@ -698,7 +695,6 @@ class ChangeEnrollmentViewTest(ModuleStoreTestCase):
         self.assertEqual(enrollment_mode, u'honor')
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class PaidRegistrationTest(ModuleStoreTestCase):
     """
     Tests for paid registration functionality (not verified student), involves shoppingcart
@@ -731,7 +727,6 @@ class PaidRegistrationTest(ModuleStoreTestCase):
             shoppingcart.models.Order.get_cart_for_user(self.user), self.course.id))
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class AnonymousLookupTable(ModuleStoreTestCase):
     """
     Tests for anonymous_id_functions

--- a/common/djangoapps/terrain/factories.py
+++ b/common/djangoapps/terrain/factories.py
@@ -8,6 +8,9 @@ import xmodule.modulestore.tests.factories as xf
 import course_modes.tests.factories as cmf
 from lettuce import world
 
+# Unlock XBlock factories, because we're randomizing the collection
+# name above to prevent collisions
+xf.XMODULE_FACTORY_LOCK.enable()
 
 world.absorb(sf.UserFactory)
 world.absorb(sf.UserProfileFactory)

--- a/common/djangoapps/third_party_auth/tests/test_change_enrollment.py
+++ b/common/djangoapps/third_party_auth/tests/test_change_enrollment.py
@@ -16,13 +16,9 @@ from django.test.utils import override_settings
 from xmodule.modulestore.tests.factories import CourseFactory
 from student.tests.factories import UserFactory, CourseModeFactory
 from student.models import CourseEnrollment
-from xmodule.modulestore.tests.django_utils import (
-    ModuleStoreTestCase, mixed_store_config
-)
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from openedx.core.djangoapps.user_api.models import UserOrgTag
 
-
-MODULESTORE_CONFIG = mixed_store_config(settings.COMMON_TEST_DATA_ROOT, {}, include_xml=False)
 
 THIRD_PARTY_AUTH_CONFIGURED = (
     settings.FEATURES.get('ENABLE_THIRD_PARTY_AUTH') and
@@ -31,7 +27,6 @@ THIRD_PARTY_AUTH_CONFIGURED = (
 
 
 @unittest.skipUnless(THIRD_PARTY_AUTH_CONFIGURED, "Third party auth must be configured")
-@override_settings(MODULESTORE=MODULESTORE_CONFIG)
 @ddt.ddt
 class PipelineEnrollmentTest(ModuleStoreTestCase):
     """Test that the pipeline auto-enrolls students upon successful authentication. """

--- a/common/djangoapps/util/tests/test_keyword_sub_utils.py
+++ b/common/djangoapps/util/tests/test_keyword_sub_utils.py
@@ -18,6 +18,7 @@ class KeywordSubTest(ModuleStoreTestCase):
     """ Tests for the keyword substitution feature """
 
     def setUp(self):
+        super(KeywordSubTest, self).setUp(create_user=False)
         self.user = UserFactory.create(
             email="testuser@edx.org",
             username="testuser",

--- a/common/lib/capa/capa/tests/test_correctmap.py
+++ b/common/lib/capa/capa/tests/test_correctmap.py
@@ -13,6 +13,7 @@ class CorrectMapTest(unittest.TestCase):
     """
 
     def setUp(self):
+        super(CorrectMapTest, self).setUp()
         self.cmap = CorrectMap()
 
     def test_set_input_properties(self):

--- a/common/lib/capa/capa/tests/test_input_templates.py
+++ b/common/lib/capa/capa/tests/test_input_templates.py
@@ -34,6 +34,7 @@ class TemplateTestCase(unittest.TestCase):
         """
         Load the template under test.
         """
+        super(TemplateTestCase, self).setUp()
         capa_path = capa.__path__[0]
         self.template_path = os.path.join(capa_path,
                                           'templates',

--- a/common/lib/capa/capa/tests/test_inputtypes.py
+++ b/common/lib/capa/capa/tests/test_inputtypes.py
@@ -393,6 +393,7 @@ class MatlabTest(unittest.TestCase):
     Test Matlab input types
     '''
     def setUp(self):
+        super(MatlabTest, self).setUp()
         self.rows = '10'
         self.cols = '80'
         self.tabsize = '4'
@@ -1003,6 +1004,7 @@ class ChemicalEquationTest(unittest.TestCase):
     Check that chemical equation inputs work.
     '''
     def setUp(self):
+        super(ChemicalEquationTest, self).setUp()
         self.size = "42"
         xml_str = """<chemicalequationinput id="prob_1_2" size="{size}"/>""".format(size=self.size)
 
@@ -1089,6 +1091,7 @@ class FormulaEquationTest(unittest.TestCase):
     Check that formula equation inputs work.
     """
     def setUp(self):
+        super(FormulaEquationTest, self).setUp()
         self.size = "42"
         xml_str = """<formulaequationinput id="prob_1_2" size="{size}"/>""".format(size=self.size)
 

--- a/common/lib/capa/capa/tests/test_responsetypes.py
+++ b/common/lib/capa/capa/tests/test_responsetypes.py
@@ -37,6 +37,7 @@ class ResponseTest(unittest.TestCase):
     maxDiff = None
 
     def setUp(self):
+        super(ResponseTest, self).setUp()
         if self.xml_factory_class:
             self.xml_factory = self.xml_factory_class()
 

--- a/common/lib/symmath/symmath/test_formula.py
+++ b/common/lib/symmath/symmath/test_formula.py
@@ -19,6 +19,7 @@ class FormulaTest(unittest.TestCase):
     mathml_end = '</mstyle></math>'
 
     def setUp(self):
+        super(FormulaTest, self).setUp()
         self.formulaInstance = formula.formula('')
 
     def test_replace_mathvariants(self):

--- a/common/lib/xmodule/xmodule/modulestore/tests/django_utils.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/django_utils.py
@@ -20,6 +20,7 @@ from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore, clear_existing_modulestores
 from xmodule.modulestore.tests.mongo_connection import MONGO_PORT_NUM, MONGO_HOST
 from xmodule.modulestore.tests.sample_courses import default_block_info_tree, TOY_BLOCK_INFO_TREE
+from xmodule.modulestore.tests.factories import XMODULE_FACTORY_LOCK
 from xmodule.tabs import CoursewareTab, CourseInfoTab, StaticTab, DiscussionTab, ProgressTab, WikiTab
 
 
@@ -241,6 +242,10 @@ class ModuleStoreTestCase(TestCase):
         self.addCleanup(self.drop_mongo_collections)
 
         self.addCleanup(RequestCache().clear_request_cache)
+
+        # Enable XModuleFactories for the space of this test (and its setUp).
+        self.addCleanup(XMODULE_FACTORY_LOCK.disable)
+        XMODULE_FACTORY_LOCK.enable()
 
         super(ModuleStoreTestCase, self).setUp()
 

--- a/common/lib/xmodule/xmodule/modulestore/tests/django_utils.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/django_utils.py
@@ -12,6 +12,7 @@ from mock import patch
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.test import TestCase
+from django.test.utils import override_settings
 from request_cache.middleware import RequestCache
 
 from xmodule.contentstore.django import _CONTENTSTORE
@@ -189,15 +190,14 @@ class ModuleStoreTestCase(TestCase):
     Usage:
 
         1. Create a subclass of `ModuleStoreTestCase`
-        2. Use Django's @override_settings decorator to use
-           the desired modulestore configuration.
+        2. (optional) If you need a specific variety of modulestore, or particular ModuleStore
+           options, set the MODULESTORE class attribute of your test class to the
+           appropriate modulestore config.
 
            For example:
 
-               MIXED_CONFIG = mixed_store_config(data_dir, mappings)
-
-               @override_settings(MODULESTORE=MIXED_CONFIG)
                class FooTest(ModuleStoreTestCase):
+                   MODULESTORE = mixed_store_config(data_dir, mappings)
                    # ...
 
         3. Use factories (e.g. `CourseFactory`, `ItemFactory`) to populate
@@ -219,6 +219,9 @@ class ModuleStoreTestCase(TestCase):
           `clear_existing_modulestores()` directly in
           your `setUp()` method.
     """
+
+    MODULESTORE = TEST_DATA_MOCK_MODULESTORE
+
     def setUp(self, **kwargs):
         """
         Creates a test User if `create_user` is True.
@@ -227,6 +230,18 @@ class ModuleStoreTestCase(TestCase):
         Args:
             create_user - specifies whether or not to create a test User.  Default is True.
         """
+        settings_override = override_settings(MODULESTORE=self.MODULESTORE)
+        settings_override.__enter__()
+        self.addCleanup(settings_override.__exit__, None, None, None)
+
+        # Clear out any existing modulestores,
+        # which will cause them to be re-created
+        clear_existing_modulestores()
+
+        self.addCleanup(self.drop_mongo_collections)
+
+        self.addCleanup(RequestCache().clear_request_cache)
+
         super(ModuleStoreTestCase, self).setUp()
 
         self.store = modulestore()
@@ -292,43 +307,6 @@ class ModuleStoreTestCase(TestCase):
         _CONTENTSTORE.clear()
         if hasattr(module_store, 'close_connections'):
             module_store.close_connections()
-
-    @classmethod
-    def setUpClass(cls):
-        """
-        Delete the existing modulestores, causing them to be reloaded.
-        """
-        # Clear out any existing modulestores,
-        # which will cause them to be re-created
-        # the next time they are accessed.
-        clear_existing_modulestores()
-        TestCase.setUpClass()
-
-    def _pre_setup(self):
-        """
-        Flush the ModuleStore.
-        """
-        # Flush the Mongo modulestore
-        self.drop_mongo_collections()
-
-        # Call superclass implementation
-        super(ModuleStoreTestCase, self)._pre_setup()
-
-    def _post_teardown(self):
-        """
-        Flush the ModuleStore after each test.
-        """
-        self.drop_mongo_collections()
-        # Clear out the existing modulestores,
-        # which will cause them to be re-created
-        # the next time they are accessed.
-        # We do this at *both* setup and teardown just to be safe.
-        clear_existing_modulestores()
-        # clear RequestCache to emulate its clearance after each http request.
-        RequestCache().clear_request_cache()
-
-        # Call superclass implementation
-        super(ModuleStoreTestCase, self)._post_teardown()
 
     def create_sample_course(self, org, course, run, block_info_tree=None, course_fields=None):
         """

--- a/common/lib/xmodule/xmodule/modulestore/tests/factories.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/factories.py
@@ -22,6 +22,44 @@ class Dummy(object):
     pass
 
 
+class XModuleFactoryLock(threading.local):
+    """
+    This class exists to store whether XModuleFactory can be accessed in a safe
+    way (meaning, in a context where the data it creates will be cleaned up).
+
+    Users of XModuleFactory (or its subclasses) should only call XModuleFactoryLock.enable
+    after ensuring that a) the modulestore will be cleaned up, and b) that XModuleFactoryLock.disable
+    will be called.
+    """
+    def __init__(self):
+        super(XModuleFactoryLock, self).__init__()
+        self._enabled = False
+
+    def enable(self):
+        """
+        Enable XModuleFactories. This should only be turned in a context
+        where the modulestore will be reset at the end of the test (such
+        as inside ModuleStoreTestCase).
+        """
+        self._enabled = True
+
+    def disable(self):
+        """
+        Disable XModuleFactories. This should be called once the data
+        from the factory has been cleaned up.
+        """
+        self._enabled = False
+
+    def is_enabled(self):
+        """
+        Return whether XModuleFactories are enabled.
+        """
+        return self._enabled
+
+
+XMODULE_FACTORY_LOCK = XModuleFactoryLock()
+
+
 class XModuleFactory(Factory):
     """
     Factory for XModules
@@ -34,6 +72,9 @@ class XModuleFactory(Factory):
 
     @lazy_attribute
     def modulestore(self):
+        msg = "XMODULE_FACTORY_LOCK not enabled. Please use ModuleStoreTestCase as your test baseclass."
+        assert XMODULE_FACTORY_LOCK.is_enabled(), msg
+
         from xmodule.modulestore.django import modulestore
         return modulestore()
 

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_assetstore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_assetstore.py
@@ -62,6 +62,7 @@ class TestSortedAssetList(unittest.TestCase):
     Tests the SortedAssetList class.
     """
     def setUp(self):
+        super(TestSortedAssetList, self).setUp()
         asset_list = [dict(zip(AssetStoreTestData.asset_fields, asset)) for asset in AssetStoreTestData.all_asset_data]
         self.sorted_asset_list_by_filename = SortedAssetList(iterable=asset_list)
         self.sorted_asset_list_by_last_edit = SortedAssetList(iterable=asset_list, key=lambda x: x['edited_on'])

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_mongo.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_mongo.py
@@ -153,13 +153,9 @@ class TestMongoModuleStoreBase(unittest.TestCase):
         # Destroy the test db.
         connection.drop_database(DB)
 
-    @classmethod
-    def setUp(cls):
-        cls.dummy_user = ModuleStoreEnum.UserID.test
-
-    @classmethod
-    def tearDown(cls):
-        pass
+    def setUp(self):
+        super(TestMongoModuleStoreBase, self).setUp()
+        self.dummy_user = ModuleStoreEnum.UserID.test
 
 
 class TestMongoModuleStore(TestMongoModuleStoreBase):
@@ -742,12 +738,13 @@ class TestMongoModuleStoreWithNoAssetCollection(TestMongoModuleStore):
         self.assertRaises(ItemNotFoundError, lambda: self.draft_store.get_all_asset_metadata(course_key, 'asset')[:1])
 
 
-class TestMongoKeyValueStore(object):
+class TestMongoKeyValueStore(unittest.TestCase):
     """
     Tests for MongoKeyValueStore.
     """
 
     def setUp(self):
+        super(TestMongoKeyValueStore, self).setUp()
         self.data = {'foo': 'foo_value'}
         self.course_id = SlashSeparatedCourseKey('org', 'course', 'run')
         self.parent = self.course_id.make_usage_key('parent', 'p')

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore.py
@@ -519,6 +519,7 @@ class SplitModuleTest(unittest.TestCase):
         split_store.copy("test@edx.org", source_course, destination, [to_publish], None)
 
     def setUp(self):
+        super(SplitModuleTest, self).setUp()
         self.user_id = random.getrandbits(32)
 
     def tearDown(self):
@@ -1707,7 +1708,7 @@ class TestPublish(SplitModuleTest):
     Test the publishing api
     """
     def setUp(self):
-        SplitModuleTest.setUp(self)
+        super(TestPublish, self).setUp()
 
     def tearDown(self):
         SplitModuleTest.tearDown(self)

--- a/common/lib/xmodule/xmodule/partitions/tests/test_partitions.py
+++ b/common/lib/xmodule/xmodule/partitions/tests/test_partitions.py
@@ -114,6 +114,7 @@ class PartitionTestCase(TestCase):
     TEST_SCHEME_NAME = "mock"
 
     def setUp(self):
+        super(PartitionTestCase, self).setUp()
         # Set up two user partition schemes: mock and random
         self.non_random_scheme = MockUserPartitionScheme(self.TEST_SCHEME_NAME)
         self.random_scheme = MockUserPartitionScheme("random")

--- a/common/lib/xmodule/xmodule/tests/__init__.py
+++ b/common/lib/xmodule/xmodule/tests/__init__.py
@@ -172,9 +172,6 @@ def mock_render_template(*args, **kwargs):
 
 
 class ModelsTest(unittest.TestCase):
-    def setUp(self):
-        pass
-
     def test_load_class(self):
         vc = XModuleDescriptor.load_class('video')
         vc_str = "<class 'xmodule.video_module.video_module.VideoDescriptor'>"
@@ -187,6 +184,7 @@ class LogicTest(unittest.TestCase):
     raw_field_data = {}
 
     def setUp(self):
+        super(LogicTest, self).setUp()
         self.system = get_test_system()
         self.descriptor = Mock(name="descriptor", url_name='', category='test')
 

--- a/common/lib/xmodule/xmodule/tests/test_annotatable_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_annotatable_module.py
@@ -32,6 +32,7 @@ class AnnotatableModuleTestCase(unittest.TestCase):
     '''
 
     def setUp(self):
+        super(AnnotatableModuleTestCase, self).setUp()
         self.annotatable = AnnotatableModule(
             Mock(),
             get_test_system(),

--- a/common/lib/xmodule/xmodule/tests/test_capa_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_capa_module.py
@@ -187,6 +187,8 @@ if submission[0] == '':
 class CapaModuleTest(unittest.TestCase):
 
     def setUp(self):
+        super(CapaModuleTest, self).setUp()
+
         now = datetime.datetime.now(UTC)
         day_delta = datetime.timedelta(days=1)
         self.yesterday_str = str(now - day_delta)
@@ -1736,6 +1738,7 @@ class TestProblemCheckTracking(unittest.TestCase):
     """
 
     def setUp(self):
+        super(TestProblemCheckTracking, self).setUp()
         self.maxDiff = None
 
     def test_choice_answer_text(self):

--- a/common/lib/xmodule/xmodule/tests/test_combined_open_ended.py
+++ b/common/lib/xmodule/xmodule/tests/test_combined_open_ended.py
@@ -85,6 +85,7 @@ class OpenEndedChildTest(unittest.TestCase):
     descriptor = Mock()
 
     def setUp(self):
+        super(OpenEndedChildTest, self).setUp()
         self.test_system = get_test_system()
         self.test_system.open_ended_grading_interface = None
         self.openendedchild = OpenEndedChild(self.test_system, self.location,
@@ -249,6 +250,7 @@ class OpenEndedModuleTest(unittest.TestCase):
     }
 
     def setUp(self):
+        super(OpenEndedModuleTest, self).setUp()
         self.test_system = get_test_system()
         self.test_system.open_ended_grading_interface = None
         self.test_system.location = self.location
@@ -529,6 +531,7 @@ class CombinedOpenEndedModuleTest(unittest.TestCase):
     )
 
     def setUp(self):
+        super(CombinedOpenEndedModuleTest, self).setUp()
         self.combinedoe = CombinedOpenEndedV1Module(self.test_system,
                                                     self.location,
                                                     self.definition,
@@ -885,6 +888,7 @@ class CombinedOpenEndedModuleConsistencyTest(unittest.TestCase):
     )
 
     def setUp(self):
+        super(CombinedOpenEndedModuleConsistencyTest, self).setUp()
         self.combinedoe = CombinedOpenEndedV1Module(self.test_system,
                                                     self.location,
                                                     self.definition,
@@ -987,6 +991,7 @@ class OpenEndedModuleXmlTest(unittest.TestCase, DummyModulestore):
         return test_system
 
     def setUp(self):
+        super(OpenEndedModuleXmlTest, self).setUp()
         self.setup_modulestore(COURSE)
 
     def _handle_ajax(self, dispatch, content):
@@ -1229,6 +1234,7 @@ class OpenEndedModuleXmlAttemptTest(unittest.TestCase, DummyModulestore):
         return test_system
 
     def setUp(self):
+        super(OpenEndedModuleXmlAttemptTest, self).setUp()
         self.setup_modulestore(COURSE)
 
     def _handle_ajax(self, dispatch, content):
@@ -1304,6 +1310,7 @@ class OpenEndedModuleXmlImageUploadTest(unittest.TestCase, DummyModulestore):
         return test_system
 
     def setUp(self):
+        super(OpenEndedModuleXmlImageUploadTest, self).setUp()
         self.setup_modulestore(COURSE)
 
     def test_file_upload_fail(self):

--- a/common/lib/xmodule/xmodule/tests/test_conditional.py
+++ b/common/lib/xmodule/xmodule/tests/test_conditional.py
@@ -116,6 +116,7 @@ class ConditionalModuleBasicTest(unittest.TestCase):
     """
 
     def setUp(self):
+        super(ConditionalModuleBasicTest, self).setUp()
         self.test_system = get_test_system()
 
     def test_icon_class(self):
@@ -178,6 +179,7 @@ class ConditionalModuleXmlTest(unittest.TestCase):
         return DummySystem(load_error_modules)
 
     def setUp(self):
+        super(ConditionalModuleXmlTest, self).setUp()
         self.test_system = get_test_system()
 
     def get_course(self, name):

--- a/common/lib/xmodule/xmodule/tests/test_course_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_course_module.py
@@ -91,6 +91,8 @@ class HasEndedMayCertifyTestCase(unittest.TestCase):
     """Double check the semantics around when to finalize courses."""
 
     def setUp(self):
+        super(HasEndedMayCertifyTestCase, self).setUp()
+
         system = DummySystem(load_error_modules=True)
         #sample_xml = """
         # <course org="{org}" course="{course}" display_organization="{org}_display" display_coursenumber="{course}_display"
@@ -139,6 +141,8 @@ class IsNewCourseTestCase(unittest.TestCase):
     """Make sure the property is_new works on courses"""
 
     def setUp(self):
+        super(IsNewCourseTestCase, self).setUp()
+
         # Needed for test_is_newish
         datetime_patcher = patch.object(
             xmodule.course_module, 'datetime',

--- a/common/lib/xmodule/xmodule/tests/test_error_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_error_module.py
@@ -14,8 +14,10 @@ from xblock.fields import ScopeIds
 from xblock.test.tools import unabc
 
 
-class SetupTestErrorModules():
+class SetupTestErrorModules(unittest.TestCase):
+    """Common setUp for use in ErrorModule tests."""
     def setUp(self):
+        super(SetupTestErrorModules, self).setUp()
         self.system = get_test_system()
         self.course_id = SlashSeparatedCourseKey('org', 'course', 'run')
         self.location = self.course_id.make_usage_key('foo', 'bar')
@@ -23,13 +25,10 @@ class SetupTestErrorModules():
         self.error_msg = "Error"
 
 
-class TestErrorModule(unittest.TestCase, SetupTestErrorModules):
+class TestErrorModule(SetupTestErrorModules):
     """
     Tests for ErrorModule and ErrorDescriptor
     """
-    def setUp(self):
-        SetupTestErrorModules.setUp(self)
-
     def test_error_module_xml_rendering(self):
         descriptor = ErrorDescriptor.from_xml(
             self.valid_xml,
@@ -58,13 +57,10 @@ class TestErrorModule(unittest.TestCase, SetupTestErrorModules):
         self.assertIn(repr(descriptor), context_repr)
 
 
-class TestNonStaffErrorModule(unittest.TestCase, SetupTestErrorModules):
+class TestNonStaffErrorModule(SetupTestErrorModules):
     """
     Tests for NonStaffErrorModule and NonStaffErrorDescriptor
     """
-    def setUp(self):
-        SetupTestErrorModules.setUp(self)
-
     def test_non_staff_error_module_create(self):
         descriptor = NonStaffErrorDescriptor.from_xml(
             self.valid_xml,
@@ -125,6 +121,7 @@ class TestErrorModuleConstruction(unittest.TestCase):
     """
 
     def setUp(self):
+        super(TestErrorModuleConstruction, self).setUp()
         field_data = Mock(spec=FieldData)
         self.descriptor = BrokenDescriptor(
             TestRuntime(Mock(spec=IdReader), field_data),

--- a/common/lib/xmodule/xmodule/tests/test_export.py
+++ b/common/lib/xmodule/xmodule/tests/test_export.py
@@ -70,6 +70,7 @@ class RoundTripTestCase(unittest.TestCase):
     """
 
     def setUp(self):
+        super(RoundTripTestCase, self).setUp()
         self.maxDiff = None
         self.temp_dir = mkdtemp()
         self.addCleanup(shutil.rmtree, self.temp_dir)
@@ -158,6 +159,8 @@ class TestEdxJsonEncoder(unittest.TestCase):
     Tests for xml_exporter.EdxJSONEncoder
     """
     def setUp(self):
+        super(TestEdxJsonEncoder, self).setUp()
+
         self.encoder = EdxJSONEncoder()
 
         class OffsetTZ(tzinfo):
@@ -220,6 +223,7 @@ class ConvertExportFormat(unittest.TestCase):
     """
     def setUp(self):
         """ Common setup. """
+        super(ConvertExportFormat, self).setUp()
 
         # Directory for expanding all the test archives
         self.temp_dir = mkdtemp()

--- a/common/lib/xmodule/xmodule/tests/test_imageannotation.py
+++ b/common/lib/xmodule/xmodule/tests/test_imageannotation.py
@@ -46,6 +46,8 @@ class ImageAnnotationModuleTestCase(unittest.TestCase):
         """
             Makes sure that the Module is declared and mocked with the sample xml above.
         """
+        super(ImageAnnotationModuleTestCase, self).setUp()
+
         # return anything except None to test LMS
         def test_real_user(useless):
             useless_user = Mock(email='fake@fake.com', id=useless)

--- a/common/lib/xmodule/xmodule/tests/test_peer_grading.py
+++ b/common/lib/xmodule/xmodule/tests/test_peer_grading.py
@@ -48,6 +48,7 @@ class PeerGradingModuleTest(unittest.TestCase, DummyModulestore):
         Create a peer grading module from a test system
         @return:
         """
+        super(PeerGradingModuleTest, self).setUp()
         self.setup_modulestore(self.course_id.course)
         self.peer_grading = self.get_module_from_location(self.problem_location)
         self.coe = self.get_module_from_location(self.coe_location)
@@ -264,6 +265,7 @@ class PeerGradingModuleScoredTest(unittest.TestCase, DummyModulestore):
         Create a peer grading module from a test system
         @return:
         """
+        super(PeerGradingModuleScoredTest, self).setUp()
         self.setup_modulestore(self.course_id.course)
 
     def test_metadata_load(self):
@@ -305,6 +307,7 @@ class PeerGradingModuleLinkedTest(unittest.TestCase, DummyModulestore):
         """
         Create a peer grading module from a test system.
         """
+        super(PeerGradingModuleLinkedTest, self).setUp()
         self.setup_modulestore(self.course_id.course)
 
     @property

--- a/common/lib/xmodule/xmodule/tests/test_self_assessment.py
+++ b/common/lib/xmodule/xmodule/tests/test_self_assessment.py
@@ -35,6 +35,8 @@ class SelfAssessmentTest(unittest.TestCase):
     descriptor = Mock()
 
     def setUp(self):
+        super(SelfAssessmentTest, self).setUp()
+
         self.static_data = {
             'max_attempts': 10,
             'rubric': etree.XML(self.rubric),

--- a/common/lib/xmodule/xmodule/tests/test_tabs.py
+++ b/common/lib/xmodule/xmodule/tests/test_tabs.py
@@ -8,6 +8,7 @@ from opaque_keys.edx.locations import SlashSeparatedCourseKey
 class TabTestCase(unittest.TestCase):
     """Base class for Tab-related test cases."""
     def setUp(self):
+        super(TabTestCase, self).setUp()
 
         self.course = MagicMock()
         self.course.id = SlashSeparatedCourseKey('edX', 'toy', '2012_Fall')
@@ -450,6 +451,7 @@ class KeyCheckerTestCase(unittest.TestCase):
     """Test cases for KeyChecker class"""
 
     def setUp(self):
+        super(KeyCheckerTestCase, self).setUp()
 
         self.valid_keys = ['a', 'b']
         self.invalid_keys = ['a', 'v', 'g']
@@ -467,6 +469,7 @@ class NeedNameTestCase(unittest.TestCase):
     """Test cases for NeedName validator"""
 
     def setUp(self):
+        super(NeedNameTestCase, self).setUp()
 
         self.valid_dict1 = {'a': 1, 'name': 2}
         self.valid_dict2 = {'name': 1}

--- a/common/lib/xmodule/xmodule/tests/test_textannotation.py
+++ b/common/lib/xmodule/xmodule/tests/test_textannotation.py
@@ -31,6 +31,8 @@ class TextAnnotationModuleTestCase(unittest.TestCase):
         """
             Makes sure that the Module is declared and mocked with the sample xml above.
         """
+        super(TextAnnotationModuleTestCase, self).setUp()
+
         # return anything except None to test LMS
         def test_real_user(useless):
             useless_user = Mock(email='fake@fake.com', id=useless)

--- a/common/lib/xmodule/xmodule/tests/test_vertical.py
+++ b/common/lib/xmodule/xmodule/tests/test_vertical.py
@@ -14,6 +14,7 @@ class BaseVerticalModuleTest(XModuleXmlImportTest):
     test_html_2 = 'Test HTML 2'
 
     def setUp(self):
+        super(BaseVerticalModuleTest, self).setUp()
         # construct module
         course = xml.CourseFactory.build()
         sequence = xml.SequenceFactory.build(parent=course)

--- a/common/lib/xmodule/xmodule/tests/test_video.py
+++ b/common/lib/xmodule/xmodule/tests/test_video.py
@@ -185,6 +185,7 @@ class VideoDescriptorTestBase(unittest.TestCase):
     """
 
     def setUp(self):
+        super(VideoDescriptorTestBase, self).setUp()
         self.descriptor = instantiate_descriptor()
 
 

--- a/common/lib/xmodule/xmodule/tests/test_videoannotation.py
+++ b/common/lib/xmodule/xmodule/tests/test_videoannotation.py
@@ -27,6 +27,8 @@ class VideoAnnotationModuleTestCase(unittest.TestCase):
         """
         Makes sure that the Video Annotation Module is created.
         """
+        super(VideoAnnotationModuleTestCase, self).setUp()
+
         # return anything except None to test LMS
         def test_real_user(useless):
             useless_user = Mock(email='fake@fake.com', id=useless)

--- a/common/lib/xmodule/xmodule/tests/test_xblock_wrappers.py
+++ b/common/lib/xmodule/xmodule/tests/test_xblock_wrappers.py
@@ -362,6 +362,7 @@ class TestXModuleHandler(TestCase):
     """
 
     def setUp(self):
+        super(TestXModuleHandler, self).setUp()
         self.module = XModule(descriptor=Mock(), field_data=Mock(), runtime=Mock(), scope_ids=Mock())
         self.module.handle_ajax = Mock(return_value='{}')
         self.request = webob.Request({})

--- a/common/lib/xmodule/xmodule/tests/test_xml_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_xml_module.py
@@ -64,6 +64,7 @@ class InheritingFieldDataTest(unittest.TestCase):
         not_inherited = String(scope=Scope.settings, default="nothing")
 
     def setUp(self):
+        super(InheritingFieldDataTest, self).setUp()
         self.system = get_test_descriptor_system()
         self.all_blocks = {}
         self.system.get_block = self.all_blocks.get

--- a/lms/djangoapps/branding/tests/test_page.py
+++ b/lms/djangoapps/branding/tests/test_page.py
@@ -123,6 +123,8 @@ class PreRequisiteCourseCatalog(ModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     @patch.dict(settings.FEATURES, {'ENABLE_PREREQUISITE_COURSES': True, 'MILESTONES_APP': True})
     def setUp(self):
+        super(PreRequisiteCourseCatalog, self).setUp()
+
         seed_milestone_relationship_types()
 
     @patch.dict(settings.FEATURES, {'ENABLE_PREREQUISITE_COURSES': True, 'MILESTONES_APP': True})

--- a/lms/djangoapps/branding/tests/test_page.py
+++ b/lms/djangoapps/branding/tests/test_page.py
@@ -41,7 +41,6 @@ def mock_render_to_response(*args, **kwargs):
 RENDER_MOCK = Mock(side_effect=mock_render_to_response)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class AnonymousIndexPageTest(ModuleStoreTestCase):
     """
     Tests that anonymous users can access the '/' page,  Need courses with start date
@@ -115,7 +114,6 @@ class AnonymousIndexPageTest(ModuleStoreTestCase):
         self.assertEqual(response._headers.get("location")[1], "/login")  # pylint: disable=protected-access
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class PreRequisiteCourseCatalog(ModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     Test to simulate and verify fix for disappearing courses in
@@ -163,7 +161,6 @@ class PreRequisiteCourseCatalog(ModuleStoreTestCase, LoginEnrollmentTestCase):
         self.assertIn('course that has pre requisite', resp.content)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class IndexPageCourseCardsSortingTests(ModuleStoreTestCase):
     """
     Test for Index page course cards sorting

--- a/lms/djangoapps/bulk_email/tests/test_course_optout.py
+++ b/lms/djangoapps/bulk_email/tests/test_course_optout.py
@@ -19,7 +19,6 @@ from xmodule.modulestore.tests.factories import CourseFactory
 
 
 @patch('bulk_email.models.html_to_text', Mock(return_value='Mocking CourseEmail.text_message'))
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class TestOptoutCourseEmails(ModuleStoreTestCase):
 
     """

--- a/lms/djangoapps/bulk_email/tests/test_course_optout.py
+++ b/lms/djangoapps/bulk_email/tests/test_course_optout.py
@@ -27,6 +27,7 @@ class TestOptoutCourseEmails(ModuleStoreTestCase):
     """
 
     def setUp(self):
+        super(TestOptoutCourseEmails, self).setUp()
         course_title = u"ẗëṡẗ title ｲ乇丂ｲ ﾶ乇丂丂ﾑg乇 ｷo尺 ﾑﾚﾚ тэѕт мэѕѕаБэ"
         self.course = CourseFactory.create(display_name=course_title)
         self.instructor = AdminFactory.create()

--- a/lms/djangoapps/bulk_email/tests/test_email.py
+++ b/lms/djangoapps/bulk_email/tests/test_email.py
@@ -51,6 +51,7 @@ class EmailSendFromDashboardTestCase(ModuleStoreTestCase):
 
     @patch.dict(settings.FEATURES, {'ENABLE_INSTRUCTOR_EMAIL': True, 'REQUIRE_COURSE_EMAIL_AUTH': False})
     def setUp(self):
+        super(EmailSendFromDashboardTestCase, self).setUp()
         course_title = u"ẗëṡẗ title ｲ乇丂ｲ ﾶ乇丂丂ﾑg乇 ｷo尺 ﾑﾚﾚ тэѕт мэѕѕаБэ"
         self.course = CourseFactory.create(display_name=course_title)
 

--- a/lms/djangoapps/bulk_email/tests/test_email.py
+++ b/lms/djangoapps/bulk_email/tests/test_email.py
@@ -92,7 +92,6 @@ class EmailSendFromDashboardTestCase(ModuleStoreTestCase):
         patch.stopall()
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 @patch.dict(settings.FEATURES, {'ENABLE_INSTRUCTOR_EMAIL': True, 'REQUIRE_COURSE_EMAIL_AUTH': False})
 @patch('bulk_email.models.html_to_text', Mock(return_value='Mocking CourseEmail.text_message'))
 class TestEmailSendFromDashboardMockedHtmlToText(EmailSendFromDashboardTestCase):
@@ -300,7 +299,6 @@ class TestEmailSendFromDashboardMockedHtmlToText(EmailSendFromDashboardTestCase)
         self.assertItemsEqual(outbox_contents, should_send_contents)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 @patch.dict(settings.FEATURES, {'ENABLE_INSTRUCTOR_EMAIL': True, 'REQUIRE_COURSE_EMAIL_AUTH': False})
 @skipIf(os.environ.get("TRAVIS") == 'true', "Skip this test in Travis CI.")
 class TestEmailSendFromDashboard(EmailSendFromDashboardTestCase):

--- a/lms/djangoapps/bulk_email/tests/test_err_handling.py
+++ b/lms/djangoapps/bulk_email/tests/test_err_handling.py
@@ -46,6 +46,7 @@ class TestEmailErrors(ModuleStoreTestCase):
     """
 
     def setUp(self):
+        super(TestEmailErrors, self).setUp()
         course_title = u"ẗëṡẗ title ｲ乇丂ｲ ﾶ乇丂丂ﾑg乇 ｷo尺 ﾑﾚﾚ тэѕт мэѕѕаБэ"
         self.course = CourseFactory.create(display_name=course_title)
         self.instructor = AdminFactory.create()

--- a/lms/djangoapps/bulk_email/tests/test_err_handling.py
+++ b/lms/djangoapps/bulk_email/tests/test_err_handling.py
@@ -38,7 +38,6 @@ class EmailTestException(Exception):
 
 
 @patch('bulk_email.models.html_to_text', Mock(return_value='Mocking CourseEmail.text_message'))
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 @patch.dict(settings.FEATURES, {'ENABLE_INSTRUCTOR_EMAIL': True, 'REQUIRE_COURSE_EMAIL_AUTH': False})
 class TestEmailErrors(ModuleStoreTestCase):
     """

--- a/lms/djangoapps/bulk_email/tests/test_forms.py
+++ b/lms/djangoapps/bulk_email/tests/test_forms.py
@@ -18,7 +18,6 @@ from xmodule.modulestore.django import modulestore
 from xmodule.modulestore import ModuleStoreEnum
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class CourseAuthorizationFormTest(ModuleStoreTestCase):
     """Test the CourseAuthorizationAdminForm form for Mongo-backed courses."""
 
@@ -123,9 +122,9 @@ class CourseAuthorizationFormTest(ModuleStoreTestCase):
             form.save()
 
 
-@override_settings(MODULESTORE=TEST_DATA_MIXED_TOY_MODULESTORE)
 class CourseAuthorizationXMLFormTest(ModuleStoreTestCase):
     """Check that XML courses cannot be authorized for email."""
+    MODULESTORE = TEST_DATA_MIXED_TOY_MODULESTORE
 
     @patch.dict(settings.FEATURES, {'ENABLE_INSTRUCTOR_EMAIL': True, 'REQUIRE_COURSE_EMAIL_AUTH': True})
     def test_xml_course_authorization(self):
@@ -146,7 +145,6 @@ class CourseAuthorizationXMLFormTest(ModuleStoreTestCase):
             form.save()
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class CourseEmailTemplateFormTest(ModuleStoreTestCase):
     """Test the CourseEmailTemplateForm that is used in the Django admin subsystem."""
 

--- a/lms/djangoapps/bulk_email/tests/test_forms.py
+++ b/lms/djangoapps/bulk_email/tests/test_forms.py
@@ -23,6 +23,7 @@ class CourseAuthorizationFormTest(ModuleStoreTestCase):
     """Test the CourseAuthorizationAdminForm form for Mongo-backed courses."""
 
     def setUp(self):
+        super(CourseAuthorizationFormTest, self).setUp()
         course_title = u"ẗëṡẗ title ｲ乇丂ｲ ﾶ乇丂丂ﾑg乇 ｷo尺 ﾑﾚﾚ тэѕт мэѕѕаБэ"
         self.course = CourseFactory.create(display_name=course_title)
 

--- a/lms/djangoapps/bulk_email/tests/test_models.py
+++ b/lms/djangoapps/bulk_email/tests/test_models.py
@@ -69,6 +69,8 @@ class CourseEmailTemplateTest(TestCase):
     """Test the CourseEmailTemplate model."""
 
     def setUp(self):
+        super(CourseEmailTemplateTest, self).setUp()
+
         # load initial content (since we don't run migrations as part of tests):
         call_command("loaddata", "course_email_template.json")
 

--- a/lms/djangoapps/class_dashboard/tests/test_dashboard_data.py
+++ b/lms/djangoapps/class_dashboard/tests/test_dashboard_data.py
@@ -27,7 +27,6 @@ from class_dashboard.views import has_instructor_access_for_class
 USER_COUNT = 11
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class TestGetProblemGradeDistribution(ModuleStoreTestCase):
     """
     Tests related to class_dashboard/dashboard_data.py

--- a/lms/djangoapps/class_dashboard/tests/test_dashboard_data.py
+++ b/lms/djangoapps/class_dashboard/tests/test_dashboard_data.py
@@ -34,6 +34,7 @@ class TestGetProblemGradeDistribution(ModuleStoreTestCase):
     """
 
     def setUp(self):
+        super(TestGetProblemGradeDistribution, self).setUp()
 
         self.request_factory = RequestFactory()
         self.instructor = AdminFactory.create()

--- a/lms/djangoapps/class_dashboard/tests/test_views.py
+++ b/lms/djangoapps/class_dashboard/tests/test_views.py
@@ -21,6 +21,7 @@ class TestViews(ModuleStoreTestCase):
     """
 
     def setUp(self):
+        super(TestViews, self).setUp()
 
         self.request_factory = RequestFactory()
         self.request = self.request_factory.get('')

--- a/lms/djangoapps/class_dashboard/tests/test_views.py
+++ b/lms/djangoapps/class_dashboard/tests/test_views.py
@@ -14,7 +14,6 @@ from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from class_dashboard import views
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class TestViews(ModuleStoreTestCase):
     """
     Tests related to class_dashboard/views.py

--- a/lms/djangoapps/course_wiki/tests/test_access.py
+++ b/lms/djangoapps/course_wiki/tests/test_access.py
@@ -17,7 +17,6 @@ from course_wiki.utils import user_is_article_course_staff, course_wiki_slug
 from course_wiki import settings
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class TestWikiAccessBase(ModuleStoreTestCase):
     """Base class for testing wiki access."""
     def setUp(self):

--- a/lms/djangoapps/course_wiki/tests/test_access.py
+++ b/lms/djangoapps/course_wiki/tests/test_access.py
@@ -21,6 +21,7 @@ from course_wiki import settings
 class TestWikiAccessBase(ModuleStoreTestCase):
     """Base class for testing wiki access."""
     def setUp(self):
+        super(TestWikiAccessBase, self).setUp()
 
         self.wiki = get_or_create_root()
 

--- a/lms/djangoapps/course_wiki/tests/test_middleware.py
+++ b/lms/djangoapps/course_wiki/tests/test_middleware.py
@@ -14,7 +14,6 @@ from xmodule.modulestore.tests.django_utils import TEST_DATA_MOCK_MODULESTORE
 from course_wiki.views import get_or_create_root
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class TestWikiAccessMiddleware(ModuleStoreTestCase):
     """Tests for WikiAccessMiddleware."""
 

--- a/lms/djangoapps/course_wiki/tests/test_middleware.py
+++ b/lms/djangoapps/course_wiki/tests/test_middleware.py
@@ -20,6 +20,8 @@ class TestWikiAccessMiddleware(ModuleStoreTestCase):
 
     def setUp(self):
         """Test setup."""
+        super(TestWikiAccessMiddleware, self).setUp()
+
         self.wiki = get_or_create_root()
 
         self.course_math101 = CourseFactory.create(org='edx', number='math101', display_name='2014', metadata={'use_unique_wiki_id': 'false'})

--- a/lms/djangoapps/course_wiki/tests/tests.py
+++ b/lms/djangoapps/course_wiki/tests/tests.py
@@ -14,11 +14,9 @@ class WikiRedirectTestCase(LoginEnrollmentTestCase):
     Tests for wiki course redirection.
     """
 
-    @classmethod
-    def setUpClass(cls):
-        cls.toy = CourseFactory.create(org='edX', course='toy', display_name='2012_Fall')
-
     def setUp(self):
+        super(WikiRedirectTestCase, self).setUp()
+        self.toy = CourseFactory.create(org='edX', course='toy', display_name='2012_Fall')
 
         # Create two accounts
         self.student = 'view@test.com'

--- a/lms/djangoapps/course_wiki/tests/tests.py
+++ b/lms/djangoapps/course_wiki/tests/tests.py
@@ -2,14 +2,13 @@ from django.core.urlresolvers import reverse
 from django.test.utils import override_settings
 
 from courseware.tests.tests import LoginEnrollmentTestCase
-from xmodule.modulestore.tests.django_utils import TEST_DATA_MOCK_MODULESTORE
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
 from mock import patch
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
-class WikiRedirectTestCase(LoginEnrollmentTestCase):
+class WikiRedirectTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase):
     """
     Tests for wiki course redirection.
     """

--- a/lms/djangoapps/courseware/management/commands/tests/test_dump_course.py
+++ b/lms/djangoapps/courseware/management/commands/tests/test_dump_course.py
@@ -200,17 +200,17 @@ class CommandsTestBase(TestCase):
         assert_in('edX-simple-2012_Fall/sequential/Lecture_2.xml', names)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MIXED_XML_MODULESTORE)
 class CommandsXMLTestCase(CommandsTestBase, ModuleStoreTestCase):
     """
     Test case for management commands using the xml modulestore.
 
     """
+    MODULESTORE = TEST_DATA_MIXED_XML_MODULESTORE
 
 
-@override_settings(MODULESTORE=TEST_DATA_MONGO_MODULESTORE)
 class CommandsMongoTestCase(CommandsTestBase, ModuleStoreTestCase):
     """
     Test case for management commands using the mixed mongo modulestore.
 
     """
+    MODULESTORE = TEST_DATA_MONGO_MODULESTORE

--- a/lms/djangoapps/courseware/management/commands/tests/test_dump_course.py
+++ b/lms/djangoapps/courseware/management/commands/tests/test_dump_course.py
@@ -46,6 +46,7 @@ class CommandsTestBase(TestCase):
     """
 
     def setUp(self):
+        super(CommandsTestBase, self).setUp()
         self.loaded_courses = self.load_courses()
 
     def load_courses(self):

--- a/lms/djangoapps/courseware/tests/__init__.py
+++ b/lms/djangoapps/courseware/tests/__init__.py
@@ -24,7 +24,6 @@ from lms.djangoapps.lms_xblock.field_data import LmsFieldData
 from lms.djangoapps.lms_xblock.runtime import quote_slashes
 
 
-@override_settings(MODULESTORE=TEST_DATA_MONGO_MODULESTORE)
 class BaseTestXmodule(ModuleStoreTestCase):
     """Base class for testing Xmodules with mongo store.
 
@@ -41,6 +40,8 @@ class BaseTestXmodule(ModuleStoreTestCase):
     This class should not contain any tests, because CATEGORY
     should be defined in child class.
     """
+    MODULESTORE = TEST_DATA_MONGO_MODULESTORE
+
     USER_COUNT = 2
     COURSE_DATA = {}
 

--- a/lms/djangoapps/courseware/tests/test_about.py
+++ b/lms/djangoapps/courseware/tests/test_about.py
@@ -33,7 +33,6 @@ REG_STR = "<form id=\"class_enroll_form\" method=\"post\" data-remote=\"true\" a
 SHIB_ERROR_STR = "The currently logged-in user account does not have permission to enroll in this course."
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class AboutTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase):
     """
     Tests about xblock.
@@ -182,11 +181,12 @@ class AboutTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase):
         self.assertEqual(resp.status_code, 200)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MIXED_CLOSED_MODULESTORE)
 class AboutTestCaseXML(LoginEnrollmentTestCase, ModuleStoreTestCase):
     """
     Tests for the course about page
     """
+    MODULESTORE = TEST_DATA_MIXED_CLOSED_MODULESTORE
+
     # The following XML test course (which lives at common/test/data/2014)
     # is closed; we're testing that an about page still appears when
     # the course is already closed
@@ -212,7 +212,6 @@ class AboutTestCaseXML(LoginEnrollmentTestCase, ModuleStoreTestCase):
         self.assertIn(self.xml_data, resp.content)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class AboutWithCappedEnrollmentsTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase):
     """
     This test case will check the About page when a course has a capped enrollment
@@ -263,7 +262,6 @@ class AboutWithCappedEnrollmentsTestCase(LoginEnrollmentTestCase, ModuleStoreTes
         self.assertNotIn(REG_STR, resp.content)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class AboutWithInvitationOnly(ModuleStoreTestCase):
     """
     This test case will check the About page when a course is invitation only.
@@ -311,7 +309,6 @@ class AboutWithInvitationOnly(ModuleStoreTestCase):
 
 
 @patch.dict(settings.FEATURES, {'RESTRICT_ENROLL_BY_REG_METHOD': True})
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class AboutTestCaseShibCourse(LoginEnrollmentTestCase, ModuleStoreTestCase):
     """
     Test cases covering about page behavior for courses that use shib enrollment domain ("shib courses")
@@ -351,7 +348,6 @@ class AboutTestCaseShibCourse(LoginEnrollmentTestCase, ModuleStoreTestCase):
         self.assertIn(REG_STR, resp.content)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class AboutWithClosedEnrollment(ModuleStoreTestCase):
     """
     This test case will check the About page for a course that has enrollment start/end
@@ -395,7 +391,6 @@ class AboutWithClosedEnrollment(ModuleStoreTestCase):
         self.assertNotIn('<span class="important-dates-item-text">$10</span>', resp.content)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 @patch.dict(settings.FEATURES, {'ENABLE_SHOPPING_CART': True})
 @patch.dict(settings.FEATURES, {'ENABLE_PAID_COURSE_REGISTRATION': True})
 class AboutPurchaseCourseTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase):

--- a/lms/djangoapps/courseware/tests/test_about.py
+++ b/lms/djangoapps/courseware/tests/test_about.py
@@ -39,6 +39,7 @@ class AboutTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase):
     Tests about xblock.
     """
     def setUp(self):
+        super(AboutTestCase, self).setUp()
         self.course = CourseFactory.create()
         self.about = ItemFactory.create(
             category="about", parent_location=self.course.location,
@@ -220,6 +221,7 @@ class AboutWithCappedEnrollmentsTestCase(LoginEnrollmentTestCase, ModuleStoreTes
         """
         Set up the tests
         """
+        super(AboutWithCappedEnrollmentsTestCase, self).setUp()
         self.course = CourseFactory.create(metadata={"max_student_enrollments_allowed": 1})
 
         self.about = ItemFactory.create(
@@ -267,6 +269,7 @@ class AboutWithInvitationOnly(ModuleStoreTestCase):
     This test case will check the About page when a course is invitation only.
     """
     def setUp(self):
+        super(AboutWithInvitationOnly, self).setUp()
 
         self.course = CourseFactory.create(metadata={"invitation_only": True})
 
@@ -314,6 +317,7 @@ class AboutTestCaseShibCourse(LoginEnrollmentTestCase, ModuleStoreTestCase):
     Test cases covering about page behavior for courses that use shib enrollment domain ("shib courses")
     """
     def setUp(self):
+        super(AboutTestCaseShibCourse, self).setUp()
         self.course = CourseFactory.create(enrollment_domain="shib:https://idp.stanford.edu/")
 
         self.about = ItemFactory.create(

--- a/lms/djangoapps/courseware/tests/test_access.py
+++ b/lms/djangoapps/courseware/tests/test_access.py
@@ -32,6 +32,7 @@ class AccessTestCase(LoginEnrollmentTestCase):
     Tests for the various access controls on the student dashboard
     """
     def setUp(self):
+        super(AccessTestCase, self).setUp()
         course_key = SlashSeparatedCourseKey('edX', 'toy', '2012_Fall')
         self.course = course_key.make_usage_key('course', course_key.run)
         self.anonymous_user = AnonymousUserFactory()
@@ -329,6 +330,7 @@ class UserRoleTestCase(TestCase):
     Tests for user roles.
     """
     def setUp(self):
+        super(UserRoleTestCase, self).setUp()
         self.course_key = SlashSeparatedCourseKey('edX', 'toy', '2012_Fall')
         self.anonymous_user = AnonymousUserFactory()
         self.student = UserFactory()

--- a/lms/djangoapps/courseware/tests/test_access.py
+++ b/lms/djangoapps/courseware/tests/test_access.py
@@ -16,6 +16,7 @@ from xmodule.course_module import (
     CATALOG_VISIBILITY_NONE
 )
 from xmodule.modulestore.tests.factories import CourseFactory
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 
 from util.milestones_helpers import (
     set_prerequisite_courses,
@@ -27,7 +28,7 @@ from util.milestones_helpers import (
 # pylint: disable=protected-access
 
 
-class AccessTestCase(LoginEnrollmentTestCase):
+class AccessTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase):
     """
     Tests for the various access controls on the student dashboard
     """

--- a/lms/djangoapps/courseware/tests/test_course_info.py
+++ b/lms/djangoapps/courseware/tests/test_course_info.py
@@ -15,7 +15,6 @@ from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 from .helpers import LoginEnrollmentTestCase
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class CourseInfoTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase):
     """
     Tests for the Course Info page
@@ -49,11 +48,12 @@ class CourseInfoTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase):
         self.assertNotIn("OOGIE BLOOGIE", resp.content)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MIXED_CLOSED_MODULESTORE)
 class CourseInfoTestCaseXML(LoginEnrollmentTestCase, ModuleStoreTestCase):
     """
     Tests for the Course Info page for an XML course
     """
+    MODULESTORE = TEST_DATA_MIXED_CLOSED_MODULESTORE
+
     # The following XML test course (which lives at common/test/data/2014)
     # is closed; we're testing that a course info page still appears when
     # the course is already closed

--- a/lms/djangoapps/courseware/tests/test_course_info.py
+++ b/lms/djangoapps/courseware/tests/test_course_info.py
@@ -21,6 +21,7 @@ class CourseInfoTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase):
     Tests for the Course Info page
     """
     def setUp(self):
+        super(CourseInfoTestCase, self).setUp()
         self.course = CourseFactory.create()
         self.page = ItemFactory.create(
             category="course_info", parent_location=self.course.location,

--- a/lms/djangoapps/courseware/tests/test_course_survey.py
+++ b/lms/djangoapps/courseware/tests/test_course_survey.py
@@ -9,10 +9,11 @@ from django.core.urlresolvers import reverse
 from survey.models import SurveyForm
 
 from xmodule.modulestore.tests.factories import CourseFactory
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from courseware.tests.helpers import LoginEnrollmentTestCase
 
 
-class SurveyViewsTests(LoginEnrollmentTestCase):
+class SurveyViewsTests(LoginEnrollmentTestCase, ModuleStoreTestCase):
     """
     All tests for the views.py file
     """

--- a/lms/djangoapps/courseware/tests/test_courses.py
+++ b/lms/djangoapps/courseware/tests/test_courses.py
@@ -148,7 +148,6 @@ class XmlCourseImageTestCase(XModuleXmlImportTest):
         self.assertEquals(course_image_url(course), u'/static/xml_test_course/before after.jpg')
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class CoursesRenderTest(ModuleStoreTestCase):
     """Test methods related to rendering courses content."""
 
@@ -196,9 +195,10 @@ class CoursesRenderTest(ModuleStoreTestCase):
             self.assertIn("this module is temporarily unavailable", course_about)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MIXED_TOY_MODULESTORE)
 class XmlCoursesRenderTest(ModuleStoreTestCase):
     """Test methods related to rendering courses content for an XML course."""
+    MODULESTORE = TEST_DATA_MIXED_TOY_MODULESTORE
+
     toy_course_key = SlashSeparatedCourseKey('edX', 'toy', '2012_Fall')
 
     def test_get_course_info_section_render(self):

--- a/lms/djangoapps/courseware/tests/test_draft_modulestore.py
+++ b/lms/djangoapps/courseware/tests/test_draft_modulestore.py
@@ -7,7 +7,6 @@ from opaque_keys.edx.locations import SlashSeparatedCourseKey
 from xmodule.modulestore.tests.django_utils import TEST_DATA_MOCK_MODULESTORE
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class TestDraftModuleStore(TestCase):
     """
     Test the draft modulestore

--- a/lms/djangoapps/courseware/tests/test_entrance_exam.py
+++ b/lms/djangoapps/courseware/tests/test_entrance_exam.py
@@ -15,7 +15,6 @@ from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 from util.milestones_helpers import generate_milestone_namespace, NAMESPACE_CHOICES
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class EntranceExamTestCases(ModuleStoreTestCase):
     """
     Check that content is properly gated.  Create a test course from scratch to mess with.

--- a/lms/djangoapps/courseware/tests/test_grades.py
+++ b/lms/djangoapps/courseware/tests/test_grades.py
@@ -39,6 +39,8 @@ class TestGradeIteration(ModuleStoreTestCase):
         """
         Create a course and a handful of users to assign grades
         """
+        super(TestGradeIteration, self).setUp()
+
         self.course = CourseFactory.create(
             display_name=self.COURSE_NAME,
             number=self.COURSE_NUM

--- a/lms/djangoapps/courseware/tests/test_grades.py
+++ b/lms/djangoapps/courseware/tests/test_grades.py
@@ -27,7 +27,6 @@ def _grade_with_errors(student, request, course, keep_raw_scores=False):
     return grade(student, request, course, keep_raw_scores=keep_raw_scores)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class TestGradeIteration(ModuleStoreTestCase):
     """
     Test iteration through student gradesets.

--- a/lms/djangoapps/courseware/tests/test_group_access.py
+++ b/lms/djangoapps/courseware/tests/test_group_access.py
@@ -72,6 +72,7 @@ class GroupAccessTestCase(ModuleStoreTestCase):
         modulestore().update_item(block, 1)
 
     def setUp(self):
+        super(GroupAccessTestCase, self).setUp()
 
         UserPartition.scheme_extensions = ExtensionManager.make_test_instance(
             [

--- a/lms/djangoapps/courseware/tests/test_i18n.py
+++ b/lms/djangoapps/courseware/tests/test_i18n.py
@@ -9,7 +9,7 @@ from django.test.utils import override_settings
 from xmodule.modulestore.tests.django_utils import TEST_DATA_MOCK_MODULESTORE
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE, LANGUAGES=(('eo', 'Esperanto'),))
+@override_settings(LANGUAGES=(('eo', 'Esperanto'),))
 class I18nTestCase(TestCase):
     """
     Tests for i18n

--- a/lms/djangoapps/courseware/tests/test_lti_integration.py
+++ b/lms/djangoapps/courseware/tests/test_lti_integration.py
@@ -124,7 +124,6 @@ class TestLTI(BaseTestXmodule):
         self.assertEqual(generated_content, expected_content)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class TestLTIModuleListing(ModuleStoreTestCase):
     """
     a test for the rest endpoint that lists LTI modules in a course

--- a/lms/djangoapps/courseware/tests/test_lti_integration.py
+++ b/lms/djangoapps/courseware/tests/test_lti_integration.py
@@ -135,6 +135,7 @@ class TestLTIModuleListing(ModuleStoreTestCase):
 
     def setUp(self):
         """Create course, 2 chapters, 2 sections"""
+        super(TestLTIModuleListing, self).setUp()
         self.course = CourseFactory.create(display_name=self.COURSE_NAME, number=self.COURSE_SLUG)
         self.chapter1 = ItemFactory.create(
             parent_location=self.course.location,

--- a/lms/djangoapps/courseware/tests/test_masquerade.py
+++ b/lms/djangoapps/courseware/tests/test_masquerade.py
@@ -26,6 +26,8 @@ class MasqueradeTestCase(ModuleStoreTestCase, LoginEnrollmentTestCase):
     Base class for masquerade tests that sets up a test course and enrolls a user in the course.
     """
     def setUp(self):
+        super(MasqueradeTestCase, self).setUp()
+
         # By default, tests run with DISABLE_START_DATES=True. To test that masquerading as a student is
         # working properly, we must use start dates and set a start date in the past (otherwise the access
         # checks exist prematurely).

--- a/lms/djangoapps/courseware/tests/test_masquerade.py
+++ b/lms/djangoapps/courseware/tests/test_masquerade.py
@@ -20,7 +20,6 @@ from xmodule.modulestore.tests.factories import ItemFactory, CourseFactory
 from xmodule.partitions.partitions import Group, UserPartition
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class MasqueradeTestCase(ModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     Base class for masquerade tests that sets up a test course and enrolls a user in the course.

--- a/lms/djangoapps/courseware/tests/test_microsites.py
+++ b/lms/djangoapps/courseware/tests/test_microsites.py
@@ -23,6 +23,8 @@ class TestMicrosites(ModuleStoreTestCase, LoginEnrollmentTestCase):
     STUDENT_INFO = [('view@test.com', 'foo'), ('view2@test.com', 'foo')]
 
     def setUp(self):
+        super(TestMicrosites, self).setUp()
+
         # use a different hostname to test Microsites since they are
         # triggered on subdomain mappings
         #

--- a/lms/djangoapps/courseware/tests/test_microsites.py
+++ b/lms/djangoapps/courseware/tests/test_microsites.py
@@ -14,7 +14,6 @@ from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class TestMicrosites(ModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     This is testing of the Microsite feature

--- a/lms/djangoapps/courseware/tests/test_middleware.py
+++ b/lms/djangoapps/courseware/tests/test_middleware.py
@@ -20,6 +20,8 @@ class CoursewareMiddlewareTestCase(ModuleStoreTestCase):
     """Tests that courseware middleware is correctly redirected"""
 
     def setUp(self):
+        super(CoursewareMiddlewareTestCase, self).setUp()
+
         self.course = CourseFactory.create()
 
     def check_user_not_enrolled_redirect(self):

--- a/lms/djangoapps/courseware/tests/test_middleware.py
+++ b/lms/djangoapps/courseware/tests/test_middleware.py
@@ -15,7 +15,6 @@ from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class CoursewareMiddlewareTestCase(ModuleStoreTestCase):
     """Tests that courseware middleware is correctly redirected"""
 

--- a/lms/djangoapps/courseware/tests/test_model_data.py
+++ b/lms/djangoapps/courseware/tests/test_model_data.py
@@ -54,6 +54,7 @@ class StudentModuleFactory(cmfStudentModuleFactory):
 
 class TestInvalidScopes(TestCase):
     def setUp(self):
+        super(TestInvalidScopes, self).setUp()
         self.user = UserFactory.create(username='user')
         self.field_data_cache = FieldDataCache([mock_descriptor([mock_field(Scope.user_state, 'a_field')])], course_id, self.user)
         self.kvs = DjangoKeyValueStore(self.field_data_cache)
@@ -101,6 +102,7 @@ class TestStudentModuleStorage(OtherUserFailureTestMixin, TestCase):
     existing_field_name = "a_field"
 
     def setUp(self):
+        super(TestStudentModuleStorage, self).setUp()
         student_module = StudentModuleFactory(state=json.dumps({'a_field': 'a_value', 'b_field': 'b_value'}))
         self.user = student_module.student
         self.assertEqual(self.user.id, 1)   # check our assumption hard-coded in the key functions above.
@@ -179,6 +181,8 @@ class TestStudentModuleStorage(OtherUserFailureTestMixin, TestCase):
 
 class TestMissingStudentModule(TestCase):
     def setUp(self):
+        super(TestMissingStudentModule, self).setUp()
+
         self.user = UserFactory.create(username='user')
         self.assertEqual(self.user.id, 1)   # check our assumption hard-coded in the key functions above.
         self.field_data_cache = FieldDataCache([mock_descriptor()], course_id, self.user)

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -72,7 +72,6 @@ class EmptyXModuleDescriptor(XModuleDescriptor):  # pylint: disable=abstract-met
 
 
 @ddt.ddt
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class ModuleRenderTestCase(ModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     Tests of courseware.module_render
@@ -248,7 +247,6 @@ class ModuleRenderTestCase(ModuleStoreTestCase, LoginEnrollmentTestCase):
         render.get_module_for_descriptor(self.mock_user, request, descriptor, field_data_cache, self.toy_course.id)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class TestHandleXBlockCallback(ModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     Test the handle_xblock_callback function
@@ -403,7 +401,6 @@ class TestHandleXBlockCallback(ModuleStoreTestCase, LoginEnrollmentTestCase):
 
 
 @ddt.ddt
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class TestTOC(ModuleStoreTestCase):
     """Check the Table of Contents for a course"""
     def setup_modulestore(self, default_ms, num_finds, num_sends):
@@ -499,7 +496,6 @@ class TestTOC(ModuleStoreTestCase):
                 self.assertIn(toc_section, actual)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class TestHtmlModifiers(ModuleStoreTestCase):
     """
     Tests to verify that standard modifications to the output of XModule/XBlock
@@ -695,7 +691,6 @@ class ViewInStudioTest(ModuleStoreTestCase):
         self.module = self._get_module(course_key, descriptor, location)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class MongoViewInStudioTest(ViewInStudioTest):
     """Test the 'View in Studio' link visibility in a mongo backed course."""
 
@@ -724,12 +719,10 @@ class MongoViewInStudioTest(ViewInStudioTest):
         self.assertNotIn('View Unit in Studio', result_fragment.content)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MIXED_TOY_MODULESTORE)
 class MixedViewInStudioTest(ViewInStudioTest):
     """Test the 'View in Studio' link visibility in a mixed mongo backed course."""
 
-    def setUp(self):
-        super(MixedViewInStudioTest, self).setUp()
+    MODULESTORE = TEST_DATA_MIXED_TOY_MODULESTORE
 
     def test_view_in_studio_link_mongo_backed(self):
         """Mixed mongo courses that are mongo backed should see 'View in Studio' links."""
@@ -750,12 +743,9 @@ class MixedViewInStudioTest(ViewInStudioTest):
         self.assertNotIn('View Unit in Studio', result_fragment.content)
 
 
-@override_settings(MODULESTORE=TEST_DATA_XML_MODULESTORE)
 class XmlViewInStudioTest(ViewInStudioTest):
     """Test the 'View in Studio' link visibility in an xml backed course."""
-
-    def setUp(self):
-        super(XmlViewInStudioTest, self).setUp()
+    MODULESTORE = TEST_DATA_XML_MODULESTORE
 
     def test_view_in_studio_link_xml_backed(self):
         """Course in XML only modulestore should not see 'View in Studio' links."""
@@ -764,7 +754,6 @@ class XmlViewInStudioTest(ViewInStudioTest):
         self.assertNotIn('View Unit in Studio', result_fragment.content)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 @patch.dict('django.conf.settings.FEATURES', {'DISPLAY_DEBUG_INFO_TO_STAFF': True, 'DISPLAY_HISTOGRAMS_TO_STAFF': True})
 @patch('courseware.module_render.has_access', Mock(return_value=True))
 class TestStaffDebugInfo(ModuleStoreTestCase):
@@ -886,7 +875,6 @@ PER_STUDENT_ANONYMIZED_DESCRIPTORS = set(
 
 
 @ddt.ddt
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class TestAnonymousStudentId(ModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     Test that anonymous_student_id is set correctly across a variety of XBlock types
@@ -954,7 +942,6 @@ class TestAnonymousStudentId(ModuleStoreTestCase, LoginEnrollmentTestCase):
         )
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 @patch('track.views.tracker')
 class TestModuleTrackingContext(ModuleStoreTestCase):
     """
@@ -1148,7 +1135,6 @@ class TestRebindModule(TestSubmittingProblems):
 
 
 @ddt.ddt
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class TestEventPublishing(ModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     Tests of event publishing for both XModules and XBlocks.

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -506,6 +506,7 @@ class TestHtmlModifiers(ModuleStoreTestCase):
     student_view are taking place
     """
     def setUp(self):
+        super(TestHtmlModifiers, self).setUp()
         self.user = UserFactory.create()
         self.request = RequestFactory().get('/')
         self.request.user = self.user
@@ -637,6 +638,7 @@ class ViewInStudioTest(ModuleStoreTestCase):
 
     def setUp(self):
         """ Set up the user and request that will be used. """
+        super(ViewInStudioTest, self).setUp()
         self.staff_user = GlobalStaffFactory.create()
         self.request = RequestFactory().get('/')
         self.request.user = self.staff_user
@@ -696,9 +698,6 @@ class ViewInStudioTest(ModuleStoreTestCase):
 @override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class MongoViewInStudioTest(ViewInStudioTest):
     """Test the 'View in Studio' link visibility in a mongo backed course."""
-
-    def setUp(self):
-        super(MongoViewInStudioTest, self).setUp()
 
     def test_view_in_studio_link_studio_course(self):
         """Regular Studio courses should see 'View in Studio' links."""
@@ -772,6 +771,7 @@ class TestStaffDebugInfo(ModuleStoreTestCase):
     """Tests to verify that Staff Debug Info panel and histograms are displayed to staff."""
 
     def setUp(self):
+        super(TestStaffDebugInfo, self).setUp()
         self.user = UserFactory.create()
         self.request = RequestFactory().get('/')
         self.request.user = self.user
@@ -893,6 +893,7 @@ class TestAnonymousStudentId(ModuleStoreTestCase, LoginEnrollmentTestCase):
     """
 
     def setUp(self):
+        super(TestAnonymousStudentId, self).setUp(create_user=False)
         self.user = UserFactory()
 
     @patch('courseware.module_render.has_access', Mock(return_value=True))
@@ -961,6 +962,8 @@ class TestModuleTrackingContext(ModuleStoreTestCase):
     """
 
     def setUp(self):
+        super(TestModuleTrackingContext, self).setUp()
+
         self.user = UserFactory.create()
         self.request = RequestFactory().get('/')
         self.request.user = self.user

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -14,7 +14,7 @@ from django.test.client import RequestFactory
 from django.test.utils import override_settings
 from django.contrib.auth.models import AnonymousUser
 from mock import MagicMock, patch, Mock
-from opaque_keys.edx.keys import UsageKey
+from opaque_keys.edx.keys import UsageKey, CourseKey
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
 from xblock.field_data import FieldData
 from xblock.runtime import Runtime
@@ -922,7 +922,7 @@ class TestAnonymousStudentId(ModuleStoreTestCase, LoginEnrollmentTestCase):
                 # This value is set by observation, so that later changes to the student
                 # id computation don't break old data
                 '5afe5d9bb03796557ee2614f5c9611fb',
-                self._get_anonymous_id(SlashSeparatedCourseKey.from_deprecated_string(course_id), descriptor_class)
+                self._get_anonymous_id(CourseKey.from_string(course_id), descriptor_class)
             )
 
     @ddt.data(*PER_COURSE_ANONYMIZED_DESCRIPTORS)

--- a/lms/djangoapps/courseware/tests/test_navigation.py
+++ b/lms/djangoapps/courseware/tests/test_navigation.py
@@ -14,7 +14,6 @@ from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class TestNavigation(ModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     Check that navigation state is saved properly.

--- a/lms/djangoapps/courseware/tests/test_recommender.py
+++ b/lms/djangoapps/courseware/tests/test_recommender.py
@@ -20,10 +20,7 @@ from courseware.tests.factories import GlobalStaffFactory
 
 from lms.djangoapps.lms_xblock.runtime import quote_slashes
 
-MODULESTORE_CONFIG = mixed_store_config(settings.COMMON_TEST_DATA_ROOT, {}, include_xml=False)
 
-
-@override_settings(MODULESTORE=MODULESTORE_CONFIG)
 class TestRecommender(ModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     Check that Recommender state is saved properly

--- a/lms/djangoapps/courseware/tests/test_recommender.py
+++ b/lms/djangoapps/courseware/tests/test_recommender.py
@@ -35,6 +35,8 @@ class TestRecommender(ModuleStoreTestCase, LoginEnrollmentTestCase):
     XBLOCK_NAMES = ['recommender', 'recommender_second']
 
     def setUp(self):
+        super(TestRecommender, self).setUp()
+
         self.course = CourseFactory.create(
             display_name='Recommender_Test_Course'
         )

--- a/lms/djangoapps/courseware/tests/test_split_module.py
+++ b/lms/djangoapps/courseware/tests/test_split_module.py
@@ -15,7 +15,6 @@ from xmodule.partitions.partitions import Group, UserPartition
 from openedx.core.djangoapps.user_api.tests.factories import UserCourseTagFactory
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class SplitTestBase(ModuleStoreTestCase):
     """
     Sets up a basic course and user for split test testing.
@@ -271,7 +270,6 @@ class TestSplitTestVert(SplitTestBase):
         html1 = self._html(cond1vert, 1)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class SplitTestPosition(ModuleStoreTestCase):
     """
     Check that we can change positions in a course with partitions defined

--- a/lms/djangoapps/courseware/tests/test_split_module.py
+++ b/lms/djangoapps/courseware/tests/test_split_module.py
@@ -29,6 +29,7 @@ class SplitTestBase(ModuleStoreTestCase):
     VISIBLE_CONTENT = None
 
     def setUp(self):
+        super(SplitTestBase, self).setUp()
         self.partition = UserPartition(
             0,
             'first_partition',
@@ -276,6 +277,8 @@ class SplitTestPosition(ModuleStoreTestCase):
     Check that we can change positions in a course with partitions defined
     """
     def setUp(self):
+        super(SplitTestPosition, self).setUp()
+
         self.partition = UserPartition(
             0,
             'first_partition',

--- a/lms/djangoapps/courseware/tests/test_submitting_problems.py
+++ b/lms/djangoapps/courseware/tests/test_submitting_problems.py
@@ -30,7 +30,6 @@ from xmodule.partitions.partitions import Group, UserPartition
 from openedx.core.djangoapps.user_api.tests.factories import UserCourseTagFactory
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class TestSubmittingProblems(ModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     Check that a course gets graded properly.
@@ -648,7 +647,6 @@ class ProblemWithUploadedFilesTest(TestSubmittingProblems):
         self.assertItemsEqual(kwargs['files'].keys(), filenames.split())
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class TestPythonGradedResponse(TestSubmittingProblems):
     """
     Check that we can submit a schematic and custom response, and it answers properly.

--- a/lms/djangoapps/courseware/tests/test_tabs.py
+++ b/lms/djangoapps/courseware/tests/test_tabs.py
@@ -31,6 +31,7 @@ class StaticTabDateTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase):
     """Test cases for Static Tab Dates."""
 
     def setUp(self):
+        super(StaticTabDateTestCase, self).setUp()
         self.course = CourseFactory.create()
         self.page = ItemFactory.create(
             category="static_tab", parent_location=self.course.location,
@@ -117,6 +118,8 @@ class EntranceExamsTabsTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase):
             """
             Test case scaffolding
             """
+            super(EntranceExamsTabsTestCase, self).setUp()
+
             self.course = CourseFactory.create()
             self.instructor_tab = ItemFactory.create(
                 category="instructor", parent_location=self.course.location,

--- a/lms/djangoapps/courseware/tests/test_tabs.py
+++ b/lms/djangoapps/courseware/tests/test_tabs.py
@@ -26,9 +26,10 @@ if settings.FEATURES.get('MILESTONES_APP', False):
     from milestones.models import MilestoneRelationshipType
 
 
-@override_settings(MODULESTORE=TEST_DATA_MIXED_TOY_MODULESTORE)
 class StaticTabDateTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase):
     """Test cases for Static Tab Dates."""
+
+    MODULESTORE = TEST_DATA_MIXED_TOY_MODULESTORE
 
     def setUp(self):
         super(StaticTabDateTestCase, self).setUp()
@@ -76,11 +77,13 @@ class StaticTabDateTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase):
             self.assertIn("this module is temporarily unavailable", static_tab)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MIXED_CLOSED_MODULESTORE)
 class StaticTabDateTestCaseXML(LoginEnrollmentTestCase, ModuleStoreTestCase):
     """
     Tests for the static tab dates of an XML course
     """
+
+    MODULESTORE = TEST_DATA_MIXED_CLOSED_MODULESTORE
+
     # The following XML test course (which lives at common/test/data/2014)
     # is closed; we're testing that tabs still appear when
     # the course is already closed
@@ -107,11 +110,12 @@ class StaticTabDateTestCaseXML(LoginEnrollmentTestCase, ModuleStoreTestCase):
         self.assertIn(self.xml_data, resp.content)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MIXED_CLOSED_MODULESTORE)
 class EntranceExamsTabsTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase):
     """
     Validate tab behavior when dealing with Entrance Exams
     """
+    MODULESTORE = TEST_DATA_MIXED_CLOSED_MODULESTORE
+
     if settings.FEATURES.get('ENTRANCE_EXAMS', False):
 
         def setUp(self):

--- a/lms/djangoapps/courseware/tests/test_video_mongo.py
+++ b/lms/djangoapps/courseware/tests/test_video_mongo.py
@@ -150,6 +150,7 @@ class TestGetHtmlMethod(BaseTestXmodule):
     METADATA = {}
 
     def setUp(self):
+        super(TestGetHtmlMethod, self).setUp()
         self.setup_course()
 
     def test_get_html_track(self):
@@ -766,6 +767,7 @@ class TestVideoDescriptorInitialization(BaseTestXmodule):
     METADATA = {}
 
     def setUp(self):
+        super(TestVideoDescriptorInitialization, self).setUp()
         self.setup_course()
 
     def test_source_not_in_html5sources(self):

--- a/lms/djangoapps/courseware/tests/test_view_authentication.py
+++ b/lms/djangoapps/courseware/tests/test_view_authentication.py
@@ -395,6 +395,7 @@ class TestBetatesterAccess(ModuleStoreTestCase):
     Tests for the beta tester feature
     """
     def setUp(self):
+        super(TestBetatesterAccess, self).setUp()
 
         now = datetime.datetime.now(pytz.UTC)
         tomorrow = now + datetime.timedelta(days=1)

--- a/lms/djangoapps/courseware/tests/test_view_authentication.py
+++ b/lms/djangoapps/courseware/tests/test_view_authentication.py
@@ -22,7 +22,6 @@ from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 from student.tests.factories import UserFactory, CourseEnrollmentFactory
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class TestViewAuth(ModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     Check that view authentication works properly.
@@ -389,7 +388,6 @@ class TestViewAuth(ModuleStoreTestCase, LoginEnrollmentTestCase):
         self.assertTrue(self.enroll(self.course))
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class TestBetatesterAccess(ModuleStoreTestCase):
     """
     Tests for the beta tester feature

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -36,12 +36,13 @@ from util.views import ensure_valid_course_key
 
 
 @override_settings(MODULESTORE=TEST_DATA_MIXED_TOY_MODULESTORE)
-class TestJumpTo(TestCase):
+class TestJumpTo(ModuleStoreTestCase):
     """
     Check the jumpto link for a course.
     """
 
     def setUp(self):
+        super(TestJumpTo, self).setUp()
         # Use toy course from XML
         self.course_key = SlashSeparatedCourseKey('edX', 'toy', '2012_Fall')
 
@@ -82,6 +83,7 @@ class ViewsTestCase(TestCase):
     Tests for views.py methods.
     """
     def setUp(self):
+        super(ViewsTestCase, self).setUp()
         self.course = CourseFactory.create()
         self.chapter = ItemFactory.create(category='chapter', parent_location=self.course.location)  # pylint: disable=no-member
         self.section = ItemFactory.create(category='sequential', parent_location=self.chapter.location, due=datetime(2013, 9, 18, 11, 30, 00))
@@ -493,6 +495,7 @@ class BaseDueDateTests(ModuleStoreTestCase):
         return course
 
     def setUp(self):
+        super(BaseDueDateTests, self).setUp()
         self.request_factory = RequestFactory()
         self.user = UserFactory.create()
         self.request = self.request_factory.get("foo")
@@ -588,6 +591,7 @@ class StartDateTests(ModuleStoreTestCase):
     """
 
     def setUp(self):
+        super(StartDateTests, self).setUp()
         self.request_factory = RequestFactory()
         self.user = UserFactory.create()
         self.request = self.request_factory.get("foo")
@@ -642,6 +646,7 @@ class ProgressPageTests(ModuleStoreTestCase):
     """
 
     def setUp(self):
+        super(ProgressPageTests, self).setUp()
         self.request_factory = RequestFactory()
         self.user = UserFactory.create()
         self.request = self.request_factory.get("foo")
@@ -676,6 +681,8 @@ class VerifyCourseKeyDecoratorTests(TestCase):
     """
 
     def setUp(self):
+        super(VerifyCourseKeyDecoratorTests, self).setUp()
+
         self.request = RequestFactory().get("foo")
         self.valid_course_id = "edX/test/1"
         self.invalid_course_id = "edX/"

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -35,11 +35,11 @@ from util.tests.test_date_utils import fake_ugettext, fake_pgettext
 from util.views import ensure_valid_course_key
 
 
-@override_settings(MODULESTORE=TEST_DATA_MIXED_TOY_MODULESTORE)
 class TestJumpTo(ModuleStoreTestCase):
     """
     Check the jumpto link for a course.
     """
+    MODULESTORE = TEST_DATA_MIXED_TOY_MODULESTORE
 
     def setUp(self):
         super(TestJumpTo, self).setUp()
@@ -77,8 +77,7 @@ class TestJumpTo(ModuleStoreTestCase):
 
 
 @ddt.ddt
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
-class ViewsTestCase(TestCase):
+class ViewsTestCase(ModuleStoreTestCase):
     """
     Tests for views.py methods.
     """
@@ -467,7 +466,7 @@ class ViewsTestCase(TestCase):
 
 
 # setting TIME_ZONE_DISPLAYED_FOR_DEADLINES explicitly
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE, TIME_ZONE_DISPLAYED_FOR_DEADLINES="UTC")
+@override_settings(TIME_ZONE_DISPLAYED_FOR_DEADLINES="UTC")
 class BaseDueDateTests(ModuleStoreTestCase):
     """
     Base class that verifies that due dates are rendered correctly on a page
@@ -583,7 +582,6 @@ class TestAccordionDueDate(BaseDueDateTests):
         )
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class StartDateTests(ModuleStoreTestCase):
     """
     Test that start dates are properly localized and displayed on the student
@@ -639,7 +637,6 @@ class StartDateTests(ModuleStoreTestCase):
         self.assertIn("2015-JULY-17", text)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class ProgressPageTests(ModuleStoreTestCase):
     """
     Tests that verify that the progress page works correctly.

--- a/lms/djangoapps/courseware/tests/tests.py
+++ b/lms/djangoapps/courseware/tests/tests.py
@@ -113,11 +113,11 @@ class PageLoaderTestCase(LoginEnrollmentTestCase):
             self.assertNotIsInstance(descriptor, ErrorDescriptor)
 
 
-@override_settings(MODULESTORE=XML_MODULESTORE)
 class TestXmlCoursesLoad(ModuleStoreTestCase, PageLoaderTestCase):
     """
     Check that all pages in test courses load properly from XML.
     """
+    MODULESTORE = XML_MODULESTORE
 
     def setUp(self):
         super(TestXmlCoursesLoad, self).setUp()
@@ -130,11 +130,11 @@ class TestXmlCoursesLoad(ModuleStoreTestCase, PageLoaderTestCase):
         self.check_all_pages_load(SlashSeparatedCourseKey('edX', 'toy', '2012_Fall'))
 
 
-@override_settings(MODULESTORE=TOY_MODULESTORE)
 class TestMongoCoursesLoad(ModuleStoreTestCase, PageLoaderTestCase):
     """
     Check that all pages in test courses load properly from Mongo.
     """
+    MODULESTORE = TOY_MODULESTORE
 
     def setUp(self):
         super(TestMongoCoursesLoad, self).setUp()

--- a/lms/djangoapps/courseware/tests/tests.py
+++ b/lms/djangoapps/courseware/tests/tests.py
@@ -23,6 +23,7 @@ class ActivateLoginTest(LoginEnrollmentTestCase):
     Test logging in and logging out.
     """
     def setUp(self):
+        super(ActivateLoginTest, self).setUp()
         self.setup_user()
 
     def test_activate_login(self):

--- a/lms/djangoapps/dashboard/management/commands/tests/test_git_add_course.py
+++ b/lms/djangoapps/dashboard/management/commands/tests/test_git_add_course.py
@@ -35,7 +35,6 @@ FEATURES_WITH_SSL_AUTH = settings.FEATURES.copy()
 FEATURES_WITH_SSL_AUTH['AUTH_USE_CERTIFICATES'] = True
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 @override_settings(MONGODB_LOG=TEST_MONGODB_LOG)
 @unittest.skipUnless(settings.FEATURES.get('ENABLE_SYSADMIN_DASHBOARD'),
                      "ENABLE_SYSADMIN_DASHBOARD not set")

--- a/lms/djangoapps/dashboard/tests/test_support.py
+++ b/lms/djangoapps/dashboard/tests/test_support.py
@@ -16,7 +16,6 @@ from xmodule.modulestore.tests.factories import CourseFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class RefundTests(ModuleStoreTestCase):
     """
     Tests for the manual refund page

--- a/lms/djangoapps/dashboard/tests/test_support.py
+++ b/lms/djangoapps/dashboard/tests/test_support.py
@@ -22,6 +22,8 @@ class RefundTests(ModuleStoreTestCase):
     Tests for the manual refund page
     """
     def setUp(self):
+        super(RefundTests, self).setUp()
+
         self.course = CourseFactory.create(
             org='testorg', number='run1', display_name='refundable course'
         )

--- a/lms/djangoapps/dashboard/tests/test_sysadmin.py
+++ b/lms/djangoapps/dashboard/tests/test_sysadmin.py
@@ -115,7 +115,6 @@ class SysadminBaseTestCase(ModuleStoreTestCase):
         self.addCleanup(shutil.rmtree, path)
 
 
-@override_settings(MODULESTORE=TEST_DATA_XML_MODULESTORE)
 @unittest.skipUnless(settings.FEATURES.get('ENABLE_SYSADMIN_DASHBOARD'),
                      "ENABLE_SYSADMIN_DASHBOARD not set")
 @override_settings(GIT_IMPORT_WITH_XMLMODULESTORE=True)
@@ -123,6 +122,7 @@ class TestSysadmin(SysadminBaseTestCase):
     """
     Test sysadmin dashboard features using XMLModuleStore
     """
+    MODULESTORE = TEST_DATA_XML_MODULESTORE
 
     def test_staff_access(self):
         """Test access controls."""
@@ -405,7 +405,6 @@ class TestSysadmin(SysadminBaseTestCase):
 
 
 @override_settings(MONGODB_LOG=TEST_MONGODB_LOG)
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 @unittest.skipUnless(settings.FEATURES.get('ENABLE_SYSADMIN_DASHBOARD'),
                      "ENABLE_SYSADMIN_DASHBOARD not set")
 class TestSysAdminMongoCourseImport(SysadminBaseTestCase):

--- a/lms/djangoapps/django_comment_client/base/tests.py
+++ b/lms/djangoapps/django_comment_client/base/tests.py
@@ -162,7 +162,6 @@ class ThreadActionGroupIdTestCase(
         )
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 @patch('lms.lib.comment_client.utils.requests.request')
 class ViewsTestCase(UrlResetMixin, ModuleStoreTestCase, MockRequestSetupMixin):
 
@@ -750,7 +749,6 @@ class ViewsTestCase(UrlResetMixin, ModuleStoreTestCase, MockRequestSetupMixin):
 
 
 @patch("lms.lib.comment_client.utils.requests.request")
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class ViewPermissionsTestCase(UrlResetMixin, ModuleStoreTestCase, MockRequestSetupMixin):
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
@@ -844,7 +842,6 @@ class ViewPermissionsTestCase(UrlResetMixin, ModuleStoreTestCase, MockRequestSet
         self.assertEqual(response.status_code, 200)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class CreateThreadUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin, MockRequestSetupMixin):
     def setUp(self):
         super(CreateThreadUnicodeTestCase, self).setUp()
@@ -868,7 +865,6 @@ class CreateThreadUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin, MockReq
         self.assertEqual(mock_request.call_args[1]["data"]["title"], text)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class UpdateThreadUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin, MockRequestSetupMixin):
     def setUp(self):
         super(UpdateThreadUnicodeTestCase, self).setUp()
@@ -898,7 +894,6 @@ class UpdateThreadUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin, MockReq
         self.assertEqual(mock_request.call_args[1]["data"]["commentable_id"], "test_commentable")
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class CreateCommentUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin, MockRequestSetupMixin):
     def setUp(self):
         super(CreateCommentUnicodeTestCase, self).setUp()
@@ -923,7 +918,6 @@ class CreateCommentUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin, MockRe
         self.assertEqual(mock_request.call_args[1]["data"]["body"], text)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class UpdateCommentUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin, MockRequestSetupMixin):
     def setUp(self):
         super(UpdateCommentUnicodeTestCase, self).setUp()
@@ -949,7 +943,6 @@ class UpdateCommentUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin, MockRe
         self.assertEqual(mock_request.call_args[1]["data"]["body"], text)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class CreateSubCommentUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin, MockRequestSetupMixin):
     def setUp(self):
         super(CreateSubCommentUnicodeTestCase, self).setUp()
@@ -975,7 +968,6 @@ class CreateSubCommentUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin, Moc
         self.assertEqual(mock_request.call_args[1]["data"]["body"], text)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class UsersEndpointTestCase(ModuleStoreTestCase, MockRequestSetupMixin):
 
     def set_post_counts(self, mock_request, threads_count=1, comments_count=1):

--- a/lms/djangoapps/django_comment_client/base/tests.py
+++ b/lms/djangoapps/django_comment_client/base/tests.py
@@ -847,6 +847,8 @@ class ViewPermissionsTestCase(UrlResetMixin, ModuleStoreTestCase, MockRequestSet
 @override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class CreateThreadUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin, MockRequestSetupMixin):
     def setUp(self):
+        super(CreateThreadUnicodeTestCase, self).setUp()
+
         self.course = CourseFactory.create()
         seed_permissions_roles(self.course.id)
         self.student = UserFactory.create()
@@ -869,6 +871,8 @@ class CreateThreadUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin, MockReq
 @override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class UpdateThreadUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin, MockRequestSetupMixin):
     def setUp(self):
+        super(UpdateThreadUnicodeTestCase, self).setUp()
+
         self.course = CourseFactory.create()
         seed_permissions_roles(self.course.id)
         self.student = UserFactory.create()
@@ -897,6 +901,8 @@ class UpdateThreadUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin, MockReq
 @override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class CreateCommentUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin, MockRequestSetupMixin):
     def setUp(self):
+        super(CreateCommentUnicodeTestCase, self).setUp()
+
         self.course = CourseFactory.create()
         seed_permissions_roles(self.course.id)
         self.student = UserFactory.create()
@@ -920,6 +926,8 @@ class CreateCommentUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin, MockRe
 @override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class UpdateCommentUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin, MockRequestSetupMixin):
     def setUp(self):
+        super(UpdateCommentUnicodeTestCase, self).setUp()
+
         self.course = CourseFactory.create()
         seed_permissions_roles(self.course.id)
         self.student = UserFactory.create()
@@ -944,6 +952,8 @@ class UpdateCommentUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin, MockRe
 @override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class CreateSubCommentUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin, MockRequestSetupMixin):
     def setUp(self):
+        super(CreateSubCommentUnicodeTestCase, self).setUp()
+
         self.course = CourseFactory.create()
         seed_permissions_roles(self.course.id)
         self.student = UserFactory.create()
@@ -978,6 +988,8 @@ class UsersEndpointTestCase(ModuleStoreTestCase, MockRequestSetupMixin):
         })
 
     def setUp(self):
+        super(UsersEndpointTestCase, self).setUp()
+
         self.course = CourseFactory.create()
         seed_permissions_roles(self.course.id)
         self.student = UserFactory.create()

--- a/lms/djangoapps/django_comment_client/forum/tests.py
+++ b/lms/djangoapps/django_comment_client/forum/tests.py
@@ -38,7 +38,6 @@ log = logging.getLogger(__name__)
 # pylint: disable=missing-docstring
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class ViewsExceptionTestCase(UrlResetMixin, ModuleStoreTestCase):
 
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
@@ -182,7 +181,6 @@ class PartialDictMatcher(object):
         ])
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 @patch('requests.request')
 class SingleThreadTestCase(ModuleStoreTestCase):
     def setUp(self):
@@ -295,12 +293,12 @@ class SingleThreadTestCase(ModuleStoreTestCase):
 
 @ddt.ddt
 @patch('requests.request')
-@override_settings(MODULESTORE=TEST_DATA_MONGO_MODULESTORE)
 class SingleThreadQueryCountTestCase(ModuleStoreTestCase):
     """
     Ensures the number of modulestore queries is deterministic based on the
     number of responses retrieved for a given discussion thread.
     """
+    MODULESTORE = TEST_DATA_MONGO_MODULESTORE
 
     @ddt.data(
         # old mongo: number of responses plus 16.  TODO: O(n)!
@@ -341,7 +339,6 @@ class SingleThreadQueryCountTestCase(ModuleStoreTestCase):
             self.assertEquals(len(json.loads(response.content)["content"]["children"]), num_thread_responses)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 @patch('requests.request')
 class SingleCohortedThreadTestCase(CohortedContentTestCase):
     def _create_mock_cohorted_thread(self, mock_request):
@@ -834,7 +831,6 @@ class FollowedThreadsDiscussionGroupIdTestCase(CohortedContentTestCase, Cohorted
         )
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class InlineDiscussionTestCase(ModuleStoreTestCase):
     def setUp(self):
         super(InlineDiscussionTestCase, self).setUp()
@@ -866,7 +862,6 @@ class InlineDiscussionTestCase(ModuleStoreTestCase):
         self.assertEqual(response_data["discussion_data"][0]["courseware_title"], expected_courseware_title)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 @patch('requests.request')
 class UserProfileTestCase(ModuleStoreTestCase):
 
@@ -980,7 +975,6 @@ class UserProfileTestCase(ModuleStoreTestCase):
         self.assertEqual(response.status_code, 405)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 @patch('requests.request')
 class CommentsServiceRequestHeadersTestCase(UrlResetMixin, ModuleStoreTestCase):
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
@@ -991,7 +985,7 @@ class CommentsServiceRequestHeadersTestCase(UrlResetMixin, ModuleStoreTestCase):
         password = "bar"
 
         # Invoke UrlResetMixin
-        super(CommentsServiceRequestHeadersTestCase, self).setUp()
+        super(CommentsServiceRequestHeadersTestCase, self).setUp(create_user=False)
         self.course = CourseFactory.create()
         self.student = UserFactory.create(username=username, password=password)
         CourseEnrollmentFactory.create(user=self.student, course_id=self.course.id)
@@ -1043,7 +1037,6 @@ class CommentsServiceRequestHeadersTestCase(UrlResetMixin, ModuleStoreTestCase):
         self.assert_all_calls_have_header(mock_request, "X-Edx-Api-Key", "test_api_key")
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class InlineDiscussionUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin):
     def setUp(self):
         super(InlineDiscussionUnicodeTestCase, self).setUp()
@@ -1065,7 +1058,6 @@ class InlineDiscussionUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin):
         self.assertEqual(response_data["discussion_data"][0]["body"], text)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class ForumFormDiscussionUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin):
     def setUp(self):
         super(ForumFormDiscussionUnicodeTestCase, self).setUp()
@@ -1088,7 +1080,6 @@ class ForumFormDiscussionUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin):
         self.assertEqual(response_data["discussion_data"][0]["body"], text)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class ForumDiscussionSearchUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin):
     def setUp(self):
         super(ForumDiscussionSearchUnicodeTestCase, self).setUp()
@@ -1115,7 +1106,6 @@ class ForumDiscussionSearchUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin
         self.assertEqual(response_data["discussion_data"][0]["body"], text)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class SingleThreadUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin):
     def setUp(self):
         super(SingleThreadUnicodeTestCase, self).setUp()
@@ -1139,7 +1129,6 @@ class SingleThreadUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin):
         self.assertEqual(response_data["content"]["body"], text)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class UserProfileUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin):
     def setUp(self):
         super(UserProfileUnicodeTestCase, self).setUp()
@@ -1162,7 +1151,6 @@ class UserProfileUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin):
         self.assertEqual(response_data["discussion_data"][0]["body"], text)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class FollowedThreadsUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin):
     def setUp(self):
         super(FollowedThreadsUnicodeTestCase, self).setUp()
@@ -1185,7 +1173,6 @@ class FollowedThreadsUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin):
         self.assertEqual(response_data["discussion_data"][0]["body"], text)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class EnrollmentTestCase(ModuleStoreTestCase):
     """
     Tests for the behavior of views depending on if the student is enrolled

--- a/lms/djangoapps/django_comment_client/forum/tests.py
+++ b/lms/djangoapps/django_comment_client/forum/tests.py
@@ -186,6 +186,8 @@ class PartialDictMatcher(object):
 @patch('requests.request')
 class SingleThreadTestCase(ModuleStoreTestCase):
     def setUp(self):
+        super(SingleThreadTestCase, self).setUp(create_user=False)
+
         self.course = CourseFactory.create()
         self.student = UserFactory.create()
         CourseEnrollmentFactory.create(user=self.student, course_id=self.course.id)
@@ -835,6 +837,8 @@ class FollowedThreadsDiscussionGroupIdTestCase(CohortedContentTestCase, Cohorted
 @override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class InlineDiscussionTestCase(ModuleStoreTestCase):
     def setUp(self):
+        super(InlineDiscussionTestCase, self).setUp()
+
         self.course = CourseFactory.create(org="TestX", number="101", display_name="Test Course")
         self.student = UserFactory.create()
         CourseEnrollmentFactory(user=self.student, course_id=self.course.id)
@@ -870,6 +874,8 @@ class UserProfileTestCase(ModuleStoreTestCase):
     TEST_THREAD_ID = 'userprofile-test-thread-id'
 
     def setUp(self):
+        super(UserProfileTestCase, self).setUp()
+
         self.course = CourseFactory.create()
         self.student = UserFactory.create()
         self.profiled_user = UserFactory.create()
@@ -979,6 +985,8 @@ class UserProfileTestCase(ModuleStoreTestCase):
 class CommentsServiceRequestHeadersTestCase(UrlResetMixin, ModuleStoreTestCase):
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
+        super(CommentsServiceRequestHeadersTestCase, self).setUp()
+
         username = "foo"
         password = "bar"
 
@@ -1038,6 +1046,8 @@ class CommentsServiceRequestHeadersTestCase(UrlResetMixin, ModuleStoreTestCase):
 @override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class InlineDiscussionUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin):
     def setUp(self):
+        super(InlineDiscussionUnicodeTestCase, self).setUp()
+
         self.course = CourseFactory.create()
         self.student = UserFactory.create()
         CourseEnrollmentFactory(user=self.student, course_id=self.course.id)
@@ -1058,6 +1068,8 @@ class InlineDiscussionUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin):
 @override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class ForumFormDiscussionUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin):
     def setUp(self):
+        super(ForumFormDiscussionUnicodeTestCase, self).setUp()
+
         self.course = CourseFactory.create()
         self.student = UserFactory.create()
         CourseEnrollmentFactory(user=self.student, course_id=self.course.id)
@@ -1079,6 +1091,8 @@ class ForumFormDiscussionUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin):
 @override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class ForumDiscussionSearchUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin):
     def setUp(self):
+        super(ForumDiscussionSearchUnicodeTestCase, self).setUp()
+
         self.course = CourseFactory.create()
         self.student = UserFactory.create()
         CourseEnrollmentFactory(user=self.student, course_id=self.course.id)
@@ -1104,6 +1118,8 @@ class ForumDiscussionSearchUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin
 @override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class SingleThreadUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin):
     def setUp(self):
+        super(SingleThreadUnicodeTestCase, self).setUp()
+
         self.course = CourseFactory.create()
         self.student = UserFactory.create()
         CourseEnrollmentFactory(user=self.student, course_id=self.course.id)
@@ -1126,6 +1142,8 @@ class SingleThreadUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin):
 @override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class UserProfileUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin):
     def setUp(self):
+        super(UserProfileUnicodeTestCase, self).setUp()
+
         self.course = CourseFactory.create()
         self.student = UserFactory.create()
         CourseEnrollmentFactory(user=self.student, course_id=self.course.id)
@@ -1147,6 +1165,8 @@ class UserProfileUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin):
 @override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class FollowedThreadsUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin):
     def setUp(self):
+        super(FollowedThreadsUnicodeTestCase, self).setUp()
+
         self.course = CourseFactory.create()
         self.student = UserFactory.create()
         CourseEnrollmentFactory(user=self.student, course_id=self.course.id)

--- a/lms/djangoapps/django_comment_client/tests.py
+++ b/lms/djangoapps/django_comment_client/tests.py
@@ -17,6 +17,7 @@ class PermissionsTestCase(TestCase):
         return ''.join(random.choice(chars) for x in range(length))
 
     def setUp(self):
+        super(PermissionsTestCase, self).setUp()
 
         self.course_id = "edX/toy/2012_Fall"
 

--- a/lms/djangoapps/django_comment_client/tests/mock_cs_server/test_mock_cs_server.py
+++ b/lms/djangoapps/django_comment_client/tests/mock_cs_server/test_mock_cs_server.py
@@ -13,6 +13,8 @@ class MockCommentServiceServerTest(unittest.TestCase):
     '''
 
     def setUp(self):
+        super(MockCommentServiceServerTest, self).setUp()
+
         # This is a test of the test setup,
         # so it does not need to run as part of the unit test suite
         # You can re-enable it by commenting out the line below

--- a/lms/djangoapps/django_comment_client/tests/test_middleware.py
+++ b/lms/djangoapps/django_comment_client/tests/test_middleware.py
@@ -8,6 +8,7 @@ import django_comment_client.middleware as middleware
 
 class AjaxExceptionTestCase(TestCase):
     def setUp(self):
+        super(AjaxExceptionTestCase, self).setUp()
         self.a = middleware.AjaxExceptionMiddleware()
         self.request1 = django.http.HttpRequest()
         self.request0 = django.http.HttpRequest()

--- a/lms/djangoapps/django_comment_client/tests/test_models.py
+++ b/lms/djangoapps/django_comment_client/tests/test_models.py
@@ -16,6 +16,8 @@ class RoleClassTestCase(ModuleStoreTestCase):
     Tests for roles of the comment client service integration
     """
     def setUp(self):
+        super(RoleClassTestCase, self).setUp()
+
         # For course ID, syntax edx/classname/classdate is important
         # because xmodel.course_module.id_to_location looks for a string to split
 
@@ -57,6 +59,7 @@ class PermissionClassTestCase(TestCase):
     Tests for permissions of the comment client service integration
     """
     def setUp(self):
+        super(PermissionClassTestCase, self).setUp()
         self.permission = models.Permission.objects.get_or_create(name="test")[0]
 
     def test_unicode(self):

--- a/lms/djangoapps/django_comment_client/tests/test_models.py
+++ b/lms/djangoapps/django_comment_client/tests/test_models.py
@@ -10,11 +10,12 @@ import django_comment_common.models as models
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 
 
-@override_settings(MODULESTORE=TEST_DATA_MIXED_TOY_MODULESTORE)
 class RoleClassTestCase(ModuleStoreTestCase):
     """
     Tests for roles of the comment client service integration
     """
+    MODULESTORE = TEST_DATA_MIXED_TOY_MODULESTORE
+
     def setUp(self):
         super(RoleClassTestCase, self).setUp()
 

--- a/lms/djangoapps/django_comment_client/tests/test_mustache_helpers.py
+++ b/lms/djangoapps/django_comment_client/tests/test_mustache_helpers.py
@@ -4,6 +4,7 @@ import django_comment_client.mustache_helpers as mustache_helpers
 
 class PluralizeTest(TestCase):
     def setUp(self):
+        super(PluralizeTest, self).setUp()
         self.text1 = '0 goat'
         self.text2 = '1 goat'
         self.text3 = '7 goat'
@@ -17,6 +18,7 @@ class PluralizeTest(TestCase):
 
 class CloseThreadTextTest(TestCase):
     def setUp(self):
+        super(CloseThreadTextTest, self).setUp()
         self.contentClosed = {'closed': True}
         self.contentOpen = {'closed': False}
 

--- a/lms/djangoapps/django_comment_client/tests/test_utils.py
+++ b/lms/djangoapps/django_comment_client/tests/test_utils.py
@@ -49,6 +49,8 @@ class AccessUtilsTestCase(ModuleStoreTestCase):
     comment client service integration
     """
     def setUp(self):
+        super(AccessUtilsTestCase, self).setUp(create_user=False)
+
         self.course = CourseFactory.create()
         self.course_id = self.course.id
         self.student_role = RoleFactory(name='Student', course_id=self.course_id)
@@ -90,6 +92,8 @@ class CoursewareContextTestCase(ModuleStoreTestCase):
     comment client service integration
     """
     def setUp(self):
+        super(CoursewareContextTestCase, self).setUp()
+
         self.course = CourseFactory.create(org="TestX", number="101", display_name="Test Course")
         self.discussion1 = ItemFactory.create(
             parent_location=self.course.location,
@@ -151,6 +155,8 @@ class CategoryMapTestCase(ModuleStoreTestCase):
     comment client service integration
     """
     def setUp(self):
+        super(CategoryMapTestCase, self).setUp()
+
         self.course = CourseFactory.create(
             org="TestX", number="101", display_name="Test Course",
             # This test needs to use a course that has already started --

--- a/lms/djangoapps/django_comment_client/tests/test_utils.py
+++ b/lms/djangoapps/django_comment_client/tests/test_utils.py
@@ -42,7 +42,6 @@ class DictionaryTestCase(TestCase):
         self.assertEqual(utils.merge_dict(d1, d2), expected)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class AccessUtilsTestCase(ModuleStoreTestCase):
     """
     Base testcase class for access and roles for the
@@ -85,7 +84,6 @@ class AccessUtilsTestCase(ModuleStoreTestCase):
         self.assertFalse(ret)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class CoursewareContextTestCase(ModuleStoreTestCase):
     """
     Base testcase class for courseware context for the
@@ -148,7 +146,6 @@ class CoursewareContextTestCase(ModuleStoreTestCase):
         assertThreadCorrect(threads[1], self.discussion2, "Subsection / Discussion 2")
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class CategoryMapTestCase(ModuleStoreTestCase):
     """
     Base testcase class for discussion categories for the

--- a/lms/djangoapps/django_comment_client/tests/utils.py
+++ b/lms/djangoapps/django_comment_client/tests/utils.py
@@ -10,7 +10,6 @@ from xmodule.modulestore.tests.factories import CourseFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class CohortedContentTestCase(ModuleStoreTestCase):
     """
     Sets up a course with a student, a moderator and their cohorts.

--- a/lms/djangoapps/edxnotes/tests.py
+++ b/lms/djangoapps/edxnotes/tests.py
@@ -56,7 +56,7 @@ class TestProblem(object):
 
 
 @skipUnless(settings.FEATURES["ENABLE_EDXNOTES"], "EdxNotes feature needs to be enabled.")
-class EdxNotesDecoratorTest(TestCase):
+class EdxNotesDecoratorTest(ModuleStoreTestCase):
     """
     Tests for edxnotes decorator.
     """
@@ -775,7 +775,7 @@ class EdxNotesHelpersTest(ModuleStoreTestCase):
 
 
 @skipUnless(settings.FEATURES["ENABLE_EDXNOTES"], "EdxNotes feature needs to be enabled.")
-class EdxNotesViewsTest(TestCase):
+class EdxNotesViewsTest(ModuleStoreTestCase):
     """
     Tests for EdxNotes views.
     """

--- a/lms/djangoapps/edxnotes/tests.py
+++ b/lms/djangoapps/edxnotes/tests.py
@@ -62,6 +62,8 @@ class EdxNotesDecoratorTest(TestCase):
     """
 
     def setUp(self):
+        super(EdxNotesDecoratorTest, self).setUp()
+
         ClientFactory(name="edx-notes")
         self.course = CourseFactory.create(edxnotes=True)
         self.user = UserFactory.create(username="Bob", email="bob@example.com", password="edx")

--- a/lms/djangoapps/foldit/tests.py
+++ b/lms/djangoapps/foldit/tests.py
@@ -22,6 +22,8 @@ log = logging.getLogger(__name__)
 class FolditTestCase(TestCase):
     """Tests for various responses of the FoldIt module"""
     def setUp(self):
+        super(FolditTestCase, self).setUp()
+
         self.factory = RequestFactory()
         self.url = reverse('foldit_ops')
 

--- a/lms/djangoapps/instructor/management/tests/test_openended_commands.py
+++ b/lms/djangoapps/instructor/management/tests/test_openended_commands.py
@@ -29,7 +29,6 @@ from instructor.utils import get_module_for_student
 TEST_DATA_DIR = settings.COMMON_TEST_DATA_ROOT
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class OpenEndedPostTest(ModuleStoreTestCase):
     """Test the openended_post management command."""
 
@@ -131,7 +130,6 @@ class OpenEndedPostTest(ModuleStoreTestCase):
         self.assertFalse(result)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class OpenEndedStatsTest(ModuleStoreTestCase):
     """Test the openended_stats management command."""
 

--- a/lms/djangoapps/instructor/management/tests/test_openended_commands.py
+++ b/lms/djangoapps/instructor/management/tests/test_openended_commands.py
@@ -34,6 +34,7 @@ class OpenEndedPostTest(ModuleStoreTestCase):
     """Test the openended_post management command."""
 
     def setUp(self):
+        super(OpenEndedPostTest, self).setUp()
         self.user = UserFactory()
         store = modulestore()
         course_items = import_from_xml(store, self.user.id, TEST_DATA_DIR, ['open_ended'])  # pylint: disable=maybe-no-member
@@ -135,6 +136,8 @@ class OpenEndedStatsTest(ModuleStoreTestCase):
     """Test the openended_stats management command."""
 
     def setUp(self):
+        super(OpenEndedStatsTest, self).setUp()
+
         self.user = UserFactory()
         store = modulestore()
         course_items = import_from_xml(store, self.user.id, TEST_DATA_DIR, ['open_ended'])  # pylint: disable=maybe-no-member

--- a/lms/djangoapps/instructor/tests/test_access.py
+++ b/lms/djangoapps/instructor/tests/test_access.py
@@ -23,6 +23,8 @@ from instructor.access import (allow_access,
 class TestInstructorAccessList(ModuleStoreTestCase):
     """ Test access listings. """
     def setUp(self):
+        super(TestInstructorAccessList, self).setUp()
+
         self.course = CourseFactory.create()
 
         self.instructors = [UserFactory.create() for _ in xrange(4)]
@@ -45,6 +47,8 @@ class TestInstructorAccessList(ModuleStoreTestCase):
 class TestInstructorAccessAllow(ModuleStoreTestCase):
     """ Test access allow. """
     def setUp(self):
+        super(TestInstructorAccessAllow, self).setUp()
+
         self.course = CourseFactory.create()
 
     def test_allow(self):
@@ -79,6 +83,8 @@ class TestInstructorAccessAllow(ModuleStoreTestCase):
 class TestInstructorAccessRevoke(ModuleStoreTestCase):
     """ Test access revoke. """
     def setUp(self):
+        super(TestInstructorAccessRevoke, self).setUp()
+
         self.course = CourseFactory.create()
 
         self.staff = [UserFactory.create() for _ in xrange(4)]
@@ -115,6 +121,8 @@ class TestInstructorAccessForum(ModuleStoreTestCase):
     Test forum access control.
     """
     def setUp(self):
+        super(TestInstructorAccessForum, self).setUp()
+
         self.course = CourseFactory.create()
 
         self.mod_role = Role.objects.create(

--- a/lms/djangoapps/instructor/tests/test_access.py
+++ b/lms/djangoapps/instructor/tests/test_access.py
@@ -19,7 +19,6 @@ from instructor.access import (allow_access,
                                update_forum_role)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class TestInstructorAccessList(ModuleStoreTestCase):
     """ Test access listings. """
     def setUp(self):
@@ -43,7 +42,6 @@ class TestInstructorAccessList(ModuleStoreTestCase):
         self.assertEqual(set(beta_testers), set(self.beta_testers))
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class TestInstructorAccessAllow(ModuleStoreTestCase):
     """ Test access allow. """
     def setUp(self):
@@ -79,7 +77,6 @@ class TestInstructorAccessAllow(ModuleStoreTestCase):
         allow_access(self.course, user, 'staff')
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class TestInstructorAccessRevoke(ModuleStoreTestCase):
     """ Test access revoke. """
     def setUp(self):
@@ -115,7 +112,6 @@ class TestInstructorAccessRevoke(ModuleStoreTestCase):
         revoke_access(self.course, user, 'robot-not-a-level')
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class TestInstructorAccessForum(ModuleStoreTestCase):
     """
     Test forum access control.

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -9,7 +9,6 @@ import pytz
 import io
 import json
 import os
-import random
 import requests
 import shutil
 import tempfile

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -109,6 +109,7 @@ class TestCommonExceptions400(TestCase):
     """
 
     def setUp(self):
+        super(TestCommonExceptions400, self).setUp()
         self.request = Mock(spec=HttpRequest)
         self.request.META = {}
 
@@ -152,6 +153,7 @@ class TestInstructorAPIDenyLevels(ModuleStoreTestCase, LoginEnrollmentTestCase):
     """
 
     def setUp(self):
+        super(TestInstructorAPIDenyLevels, self).setUp()
         self.course = CourseFactory.create()
         self.user = UserFactory.create()
         CourseEnrollment.enroll(self.user, self.course.id)
@@ -306,6 +308,8 @@ class TestInstructorAPIBulkAccountCreationAndEnrollment(ModuleStoreTestCase, Log
     Test Bulk account creation and enrollment from csv file
     """
     def setUp(self):
+        super(TestInstructorAPIBulkAccountCreationAndEnrollment, self).setUp()
+
         self.request = RequestFactory().request()
         self.course = CourseFactory.create()
         self.instructor = InstructorFactory(course_key=self.course.id)
@@ -557,6 +561,8 @@ class TestInstructorAPIEnrollment(ModuleStoreTestCase, LoginEnrollmentTestCase):
     """
 
     def setUp(self):
+        super(TestInstructorAPIEnrollment, self).setUp()
+
         self.request = RequestFactory().request()
         self.course = CourseFactory.create()
         self.instructor = InstructorFactory(course_key=self.course.id)
@@ -1140,6 +1146,8 @@ class TestInstructorAPIBulkBetaEnrollment(ModuleStoreTestCase, LoginEnrollmentTe
     """
 
     def setUp(self):
+        super(TestInstructorAPIBulkBetaEnrollment, self).setUp()
+
         self.course = CourseFactory.create()
         self.instructor = InstructorFactory(course_key=self.course.id)
         self.client.login(username=self.instructor.username, password='test')
@@ -1460,6 +1468,8 @@ class TestInstructorAPILevelsAccess(ModuleStoreTestCase, LoginEnrollmentTestCase
     """
 
     def setUp(self):
+        super(TestInstructorAPILevelsAccess, self).setUp()
+
         self.course = CourseFactory.create()
         self.instructor = InstructorFactory(course_key=self.course.id)
         self.client.login(username=self.instructor.username, password='test')
@@ -2158,6 +2168,7 @@ class TestInstructorAPIRegradeTask(ModuleStoreTestCase, LoginEnrollmentTestCase)
     """
 
     def setUp(self):
+        super(TestInstructorAPIRegradeTask, self).setUp()
         self.course = CourseFactory.create()
         self.instructor = InstructorFactory(course_key=self.course.id)
         self.client.login(username=self.instructor.username, password='test')
@@ -2298,6 +2309,8 @@ class TestInstructorSendEmail(ModuleStoreTestCase, LoginEnrollmentTestCase):
     """
 
     def setUp(self):
+        super(TestInstructorSendEmail, self).setUp()
+
         self.course = CourseFactory.create()
         self.instructor = InstructorFactory(course_key=self.course.id)
         self.client.login(username=self.instructor.username, password='test')
@@ -2420,6 +2433,8 @@ class TestInstructorAPITaskLists(ModuleStoreTestCase, LoginEnrollmentTestCase):
             return attr_dict
 
     def setUp(self):
+        super(TestInstructorAPITaskLists, self).setUp()
+
         self.course = CourseFactory.create()
         self.instructor = InstructorFactory(course_key=self.course.id)
         self.client.login(username=self.instructor.username, password='test')
@@ -2540,6 +2555,8 @@ class TestInstructorEmailContentList(ModuleStoreTestCase, LoginEnrollmentTestCas
     """
 
     def setUp(self):
+        super(TestInstructorEmailContentList, self).setUp()
+
         self.course = CourseFactory.create()
         self.instructor = InstructorFactory(course_key=self.course.id)
         self.client.login(username=self.instructor.username, password='test')
@@ -2691,6 +2708,8 @@ class TestInstructorAPIAnalyticsProxy(ModuleStoreTestCase, LoginEnrollmentTestCa
             self.content = '{"test_content": "robot test content"}'
 
     def setUp(self):
+        super(TestInstructorAPIAnalyticsProxy, self).setUp()
+
         self.course = CourseFactory.create()
         self.instructor = InstructorFactory(course_key=self.course.id)
         self.client.login(username=self.instructor.username, password='test')
@@ -3050,6 +3069,8 @@ class TestCourseRegistrationCodes(ModuleStoreTestCase):
         """
         Fixtures.
         """
+        super(TestCourseRegistrationCodes, self).setUp()
+
         self.course = CourseFactory.create()
         CourseModeFactory.create(course_id=self.course.id, min_price=50)
         self.instructor = InstructorFactory(course_key=self.course.id)

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -144,7 +144,6 @@ class TestCommonExceptions400(TestCase):
         self.assertIn("Task is already running", result["error"])
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 @patch('bulk_email.models.html_to_text', Mock(return_value='Mocking CourseEmail.text_message'))
 @patch.dict(settings.FEATURES, {'ENABLE_INSTRUCTOR_EMAIL': True, 'REQUIRE_COURSE_EMAIL_AUTH': False})
 class TestInstructorAPIDenyLevels(ModuleStoreTestCase, LoginEnrollmentTestCase):
@@ -301,7 +300,6 @@ class TestInstructorAPIDenyLevels(ModuleStoreTestCase, LoginEnrollmentTestCase):
             )
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 @patch.dict(settings.FEATURES, {'ALLOW_AUTOMATED_SIGNUPS': True})
 class TestInstructorAPIBulkAccountCreationAndEnrollment(ModuleStoreTestCase, LoginEnrollmentTestCase):
     """
@@ -551,7 +549,6 @@ class TestInstructorAPIBulkAccountCreationAndEnrollment(ModuleStoreTestCase, Log
 
 
 @ddt.ddt
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class TestInstructorAPIEnrollment(ModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     Test enrollment modification endpoint.
@@ -1139,7 +1136,6 @@ class TestInstructorAPIEnrollment(ModuleStoreTestCase, LoginEnrollmentTestCase):
 
 
 @ddt.ddt
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class TestInstructorAPIBulkBetaEnrollment(ModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     Test bulk beta modify access endpoint.
@@ -1454,7 +1450,6 @@ class TestInstructorAPIBulkBetaEnrollment(ModuleStoreTestCase, LoginEnrollmentTe
         )
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class TestInstructorAPILevelsAccess(ModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     Test endpoints whereby instructors can change permissions
@@ -1694,7 +1689,6 @@ class TestInstructorAPILevelsAccess(ModuleStoreTestCase, LoginEnrollmentTestCase
 
 
 @ddt.ddt
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 @patch.dict('django.conf.settings.FEATURES', {'ENABLE_PAID_COURSE_REGISTRATION': True})
 class TestInstructorAPILevelsDataDump(ModuleStoreTestCase, LoginEnrollmentTestCase):
     """
@@ -2157,7 +2151,6 @@ class TestInstructorAPILevelsDataDump(ModuleStoreTestCase, LoginEnrollmentTestCa
         self.assertEqual(response.status_code, 400)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class TestInstructorAPIRegradeTask(ModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     Test endpoints whereby instructors can change student grades.
@@ -2298,7 +2291,6 @@ class TestInstructorAPIRegradeTask(ModuleStoreTestCase, LoginEnrollmentTestCase)
         self.assertTrue(act.called)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 @patch('bulk_email.models.html_to_text', Mock(return_value='Mocking CourseEmail.text_message'))
 @patch.dict(settings.FEATURES, {'ENABLE_INSTRUCTOR_EMAIL': True, 'REQUIRE_COURSE_EMAIL_AUTH': False})
 class TestInstructorSendEmail(ModuleStoreTestCase, LoginEnrollmentTestCase):
@@ -2383,7 +2375,6 @@ class MockCompletionInfo(object):
         return False, 'Task Errored In Some Way'
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class TestInstructorAPITaskLists(ModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     Test instructor task list endpoint.
@@ -2547,7 +2538,6 @@ class TestInstructorAPITaskLists(ModuleStoreTestCase, LoginEnrollmentTestCase):
         self.assertEqual(actual_tasks, expected_tasks)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 @patch.object(instructor_task.api, 'get_instructor_task_history')
 class TestInstructorEmailContentList(ModuleStoreTestCase, LoginEnrollmentTestCase):
     """
@@ -2685,7 +2675,6 @@ class TestInstructorEmailContentList(ModuleStoreTestCase, LoginEnrollmentTestCas
 
 
 @ddt.ddt
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 @override_settings(ANALYTICS_SERVER_URL="http://robotanalyticsserver.netbot:900/")
 @override_settings(ANALYTICS_API_KEY="robot_api_key")
 class TestInstructorAPIAnalyticsProxy(ModuleStoreTestCase, LoginEnrollmentTestCase):
@@ -2869,7 +2858,6 @@ class TestInstructorAPIHelpers(TestCase):
         msk_from_problem_urlname(*args)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class TestDueDateExtensions(ModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     Test data dumps for reporting.
@@ -3058,7 +3046,6 @@ class TestDueDateExtensions(ModuleStoreTestCase, LoginEnrollmentTestCase):
                 self.user1.profile.name, self.user1.username)})
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 @override_settings(REGISTRATION_CODE_LENGTH=8)
 class TestCourseRegistrationCodes(ModuleStoreTestCase):
     """
@@ -3510,7 +3497,6 @@ class TestCourseRegistrationCodes(ModuleStoreTestCase):
         self.assertTrue(body.startswith(EXPECTED_COUPON_CSV_HEADER))
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class TestBulkCohorting(ModuleStoreTestCase):
     """
     Test adding users to cohorts in bulk via CSV upload.

--- a/lms/djangoapps/instructor/tests/test_api_email_localization.py
+++ b/lms/djangoapps/instructor/tests/test_api_email_localization.py
@@ -5,7 +5,6 @@ Unit tests for the localization of emails sent by instructor.api methods.
 
 from django.core import mail
 from django.core.urlresolvers import reverse
-from django.test import TestCase
 
 from courseware.tests.factories import InstructorFactory
 from lang_pref import LANGUAGE_KEY
@@ -13,9 +12,10 @@ from student.models import CourseEnrollment
 from student.tests.factories import UserFactory
 from openedx.core.djangoapps.user_api.models import UserPreference
 from xmodule.modulestore.tests.factories import CourseFactory
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 
 
-class TestInstructorAPIEnrollmentEmailLocalization(TestCase):
+class TestInstructorAPIEnrollmentEmailLocalization(ModuleStoreTestCase):
     """
     Test whether the enroll, unenroll and beta role emails are sent in the
     proper language, i.e: the student's language.

--- a/lms/djangoapps/instructor/tests/test_api_email_localization.py
+++ b/lms/djangoapps/instructor/tests/test_api_email_localization.py
@@ -22,6 +22,8 @@ class TestInstructorAPIEnrollmentEmailLocalization(TestCase):
     """
 
     def setUp(self):
+        super(TestInstructorAPIEnrollmentEmailLocalization, self).setUp()
+
         # Platform language is English, instructor's language is Chinese,
         # student's language is French, so the emails should all be sent in
         # French.

--- a/lms/djangoapps/instructor/tests/test_ecommerce.py
+++ b/lms/djangoapps/instructor/tests/test_ecommerce.py
@@ -17,7 +17,6 @@ from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class TestECommerceDashboardViews(ModuleStoreTestCase):
     """
     Check for E-commerce view on the new instructor dashboard

--- a/lms/djangoapps/instructor/tests/test_ecommerce.py
+++ b/lms/djangoapps/instructor/tests/test_ecommerce.py
@@ -23,6 +23,7 @@ class TestECommerceDashboardViews(ModuleStoreTestCase):
     Check for E-commerce view on the new instructor dashboard
     """
     def setUp(self):
+        super(TestECommerceDashboardViews, self).setUp()
         self.course = CourseFactory.create()
 
         # Create instructor account

--- a/lms/djangoapps/instructor/tests/test_email.py
+++ b/lms/djangoapps/instructor/tests/test_email.py
@@ -11,9 +11,8 @@ from mock import patch
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
 
 from bulk_email.models import CourseAuthorization
-from xmodule.modulestore.tests.django_utils import TEST_DATA_MOCK_MODULESTORE
+from xmodule.modulestore.tests.django_utils import TEST_DATA_MIXED_TOY_MODULESTORE, ModuleStoreTestCase
 from student.tests.factories import AdminFactory
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
 
@@ -24,6 +23,7 @@ class TestNewInstructorDashboardEmailViewMongoBacked(ModuleStoreTestCase):
     for Mongo-backed courses
     """
     def setUp(self):
+        super(TestNewInstructorDashboardEmailViewMongoBacked, self).setUp()
         self.course = CourseFactory.create()
 
         # Create instructor account
@@ -111,7 +111,11 @@ class TestNewInstructorDashboardEmailViewXMLBacked(ModuleStoreTestCase):
     """
     Check for email view on the new instructor dashboard
     """
+
+    MODULESTORE = TEST_DATA_MIXED_TOY_MODULESTORE
+
     def setUp(self):
+        super(TestNewInstructorDashboardEmailViewXMLBacked, self).setUp()
         self.course_key = SlashSeparatedCourseKey('edX', 'toy', '2012_Fall')
 
         # Create instructor account

--- a/lms/djangoapps/instructor/tests/test_email.py
+++ b/lms/djangoapps/instructor/tests/test_email.py
@@ -16,7 +16,6 @@ from student.tests.factories import AdminFactory
 from xmodule.modulestore.tests.factories import CourseFactory
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class TestNewInstructorDashboardEmailViewMongoBacked(ModuleStoreTestCase):
     """
     Check for email view on the new instructor dashboard
@@ -106,7 +105,6 @@ class TestNewInstructorDashboardEmailViewMongoBacked(ModuleStoreTestCase):
         self.assertFalse(self.email_link in response.content)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class TestNewInstructorDashboardEmailViewXMLBacked(ModuleStoreTestCase):
     """
     Check for email view on the new instructor dashboard

--- a/lms/djangoapps/instructor/tests/test_enrollment.py
+++ b/lms/djangoapps/instructor/tests/test_enrollment.py
@@ -292,7 +292,6 @@ class TestInstructorUnenrollDB(TestEnrollmentChangeBase):
         return self._run_state_change_test(before_ideal, after_ideal, action)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class TestInstructorEnrollmentStudentModule(TestCase):
     """ Test student module manipulations. """
     def setUp(self):
@@ -439,7 +438,6 @@ class TestSendBetaRoleEmail(TestCase):
             send_beta_role_email(bad_action, self.user, self.email_params)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class TestGetEmailParams(ModuleStoreTestCase):
     """
     Test what URLs the function get_email_params returns under different
@@ -484,7 +482,7 @@ class TestGetEmailParams(ModuleStoreTestCase):
         self.assertEqual(result['course_url'], self.course_url)
 
 
-class TestRenderMessageToString(TestCase):
+class TestRenderMessageToString(ModuleStoreTestCase):
     """
     Test that email templates can be rendered in a language chosen manually.
     """

--- a/lms/djangoapps/instructor/tests/test_enrollment.py
+++ b/lms/djangoapps/instructor/tests/test_enrollment.py
@@ -36,6 +36,7 @@ from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 class TestSettableEnrollmentState(TestCase):
     """ Test the basis class for enrollment tests. """
     def setUp(self):
+        super(TestSettableEnrollmentState, self).setUp()
         self.course_key = SlashSeparatedCourseKey('Robot', 'fAKE', 'C-%-se-%-ID')
 
     def test_mes_create(self):
@@ -66,6 +67,7 @@ class TestEnrollmentChangeBase(TestCase):
     __metaclass__ = ABCMeta
 
     def setUp(self):
+        super(TestEnrollmentChangeBase, self).setUp()
         self.course_key = SlashSeparatedCourseKey('Robot', 'fAKE', 'C-%-se-%-ID')
 
     def _run_state_change_test(self, before_ideal, after_ideal, action):
@@ -294,6 +296,7 @@ class TestInstructorUnenrollDB(TestEnrollmentChangeBase):
 class TestInstructorEnrollmentStudentModule(TestCase):
     """ Test student module manipulations. """
     def setUp(self):
+        super(TestInstructorEnrollmentStudentModule, self).setUp()
         self.course_key = SlashSeparatedCourseKey('fake', 'course', 'id')
 
     def test_reset_student_attempts(self):
@@ -425,6 +428,7 @@ class TestSendBetaRoleEmail(TestCase):
     """
 
     def setUp(self):
+        super(TestSendBetaRoleEmail, self).setUp()
         self.user = UserFactory.create()
         self.email_params = {'course': 'Robot Super Course'}
 
@@ -442,6 +446,8 @@ class TestGetEmailParams(ModuleStoreTestCase):
     production-like conditions.
     """
     def setUp(self):
+        super(TestGetEmailParams, self).setUp()
+
         self.course = CourseFactory.create()
 
         # Explicitly construct what we expect the course URLs to be
@@ -484,6 +490,7 @@ class TestRenderMessageToString(TestCase):
     """
 
     def setUp(self):
+        super(TestRenderMessageToString, self).setUp()
         self.subject_template = 'emails/enroll_email_allowedsubject.txt'
         self.message_template = 'emails/enroll_email_allowedmessage.txt'
         self.course = CourseFactory.create()

--- a/lms/djangoapps/instructor/tests/test_hint_manager.py
+++ b/lms/djangoapps/instructor/tests/test_hint_manager.py
@@ -23,6 +23,8 @@ class HintManagerTest(ModuleStoreTestCase):
         Makes a course, which will be the same for all tests.
         Set up mako middleware, which is necessary for template rendering to happen.
         """
+        super(HintManagerTest, self).setUp()
+
         self.course = CourseFactory.create(org='Me', number='19.002', display_name='test_course')
         self.url = '/courses/Me/19.002/test_course/hint_manager'
         self.user = UserFactory.create(username='robot', email='robot@edx.org', password='test', is_staff=True)

--- a/lms/djangoapps/instructor/tests/test_hint_manager.py
+++ b/lms/djangoapps/instructor/tests/test_hint_manager.py
@@ -15,7 +15,6 @@ from xmodule.modulestore.tests.factories import CourseFactory
 # pylint: disable=missing-docstring
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class HintManagerTest(ModuleStoreTestCase):
 
     def setUp(self):

--- a/lms/djangoapps/instructor/tests/test_legacy_enrollment.py
+++ b/lms/djangoapps/instructor/tests/test_legacy_enrollment.py
@@ -29,6 +29,7 @@ class TestInstructorEnrollsStudent(ModuleStoreTestCase, LoginEnrollmentTestCase)
     """
 
     def setUp(self):
+        super(TestInstructorEnrollsStudent, self).setUp()
 
         instructor = AdminFactory.create()
         self.client.login(username=instructor.username, password='test')

--- a/lms/djangoapps/instructor/tests/test_legacy_enrollment.py
+++ b/lms/djangoapps/instructor/tests/test_legacy_enrollment.py
@@ -22,7 +22,6 @@ USER_COUNT = 4
 
 
 @ddt.ddt
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class TestInstructorEnrollsStudent(ModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     Check Enrollment/Unenrollment with/without auto-enrollment on activation and with/without email notification

--- a/lms/djangoapps/instructor/tests/test_legacy_xss.py
+++ b/lms/djangoapps/instructor/tests/test_legacy_xss.py
@@ -18,7 +18,6 @@ from instructor.views import legacy
 # pylint: disable=missing-docstring
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class TestXss(ModuleStoreTestCase):
     def setUp(self):
         super(TestXss, self).setUp()

--- a/lms/djangoapps/instructor/tests/test_legacy_xss.py
+++ b/lms/djangoapps/instructor/tests/test_legacy_xss.py
@@ -21,6 +21,8 @@ from instructor.views import legacy
 @override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class TestXss(ModuleStoreTestCase):
     def setUp(self):
+        super(TestXss, self).setUp()
+
         self._request_factory = RequestFactory()
         self._course = CourseFactory.create()
         self._evil_student = UserFactory.create(

--- a/lms/djangoapps/instructor/tests/test_spoc_gradebook.py
+++ b/lms/djangoapps/instructor/tests/test_spoc_gradebook.py
@@ -26,6 +26,8 @@ class TestGradebook(ModuleStoreTestCase):
     grading_policy = None
 
     def setUp(self):
+        super(TestGradebook, self).setUp()
+
         instructor = AdminFactory.create()
         self.client.login(username=instructor.username, password='test')
 

--- a/lms/djangoapps/instructor/tests/test_spoc_gradebook.py
+++ b/lms/djangoapps/instructor/tests/test_spoc_gradebook.py
@@ -16,7 +16,6 @@ from xmodule.modulestore.django import modulestore
 USER_COUNT = 11
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class TestGradebook(ModuleStoreTestCase):
     """
     Test functionality of the spoc gradebook. Sets up a course with assignments and

--- a/lms/djangoapps/instructor/tests/test_tools.py
+++ b/lms/djangoapps/instructor/tests/test_tools.py
@@ -70,6 +70,7 @@ class TestRequireStudentIdentifier(unittest.TestCase):
         """
         Fixtures
         """
+        super(TestRequireStudentIdentifier, self).setUp()
         self.student = UserFactory.create()
 
     def test_valid_student_id(self):
@@ -107,6 +108,8 @@ class TestFindUnit(ModuleStoreTestCase):
         """
         Fixtures.
         """
+        super(TestFindUnit, self).setUp()
+
         course = CourseFactory.create()
         week1 = ItemFactory.create(parent=course)
         homework = ItemFactory.create(parent=week1)
@@ -140,6 +143,8 @@ class TestGetUnitsWithDueDate(ModuleStoreTestCase):
         """
         Fixtures.
         """
+        super(TestGetUnitsWithDueDate, self).setUp()
+
         due = datetime.datetime(2010, 5, 12, 2, 42, tzinfo=utc)
         course = CourseFactory.create()
         week1 = ItemFactory.create(due=due, parent=course)
@@ -188,6 +193,8 @@ class TestSetDueDateExtension(ModuleStoreTestCase):
         """
         Fixtures.
         """
+        super(TestSetDueDateExtension, self).setUp()
+
         due = datetime.datetime(2010, 5, 12, 2, 42, tzinfo=utc)
         course = CourseFactory.create()
         week1 = ItemFactory.create(due=due, parent=course)
@@ -263,6 +270,8 @@ class TestDataDumps(ModuleStoreTestCase):
         """
         Fixtures.
         """
+        super(TestDataDumps, self).setUp()
+
         due = datetime.datetime(2010, 5, 12, 2, 42, tzinfo=utc)
         course = CourseFactory.create()
         week1 = ItemFactory.create(due=due, parent=course)

--- a/lms/djangoapps/instructor/tests/test_tools.py
+++ b/lms/djangoapps/instructor/tests/test_tools.py
@@ -98,7 +98,6 @@ class TestParseDatetime(unittest.TestCase):
             tools.parse_datetime('foo')
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class TestFindUnit(ModuleStoreTestCase):
     """
     Test the find_unit function.
@@ -134,7 +133,6 @@ class TestFindUnit(ModuleStoreTestCase):
             tools.find_unit(self.course, url)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class TestGetUnitsWithDueDate(ModuleStoreTestCase):
     """
     Test the get_units_with_due_date function.
@@ -184,7 +182,6 @@ class TestTitleOrUrl(unittest.TestCase):
         self.assertEquals(tools.title_or_url(unit), 'test:hello')
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class TestSetDueDateExtension(ModuleStoreTestCase):
     """
     Test the set_due_date_extensions function.
@@ -260,7 +257,6 @@ class TestSetDueDateExtension(ModuleStoreTestCase):
         self.assertEqual(self.extended_due(self.homework), None)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class TestDataDumps(ModuleStoreTestCase):
     """
     Test data dumps for reporting.

--- a/lms/djangoapps/instructor_analytics/tests/test_csvs.py
+++ b/lms/djangoapps/instructor_analytics/tests/test_csvs.py
@@ -96,6 +96,7 @@ class TestAnalyticsFormatInstances(TestCase):
             return 'dval'
 
     def setUp(self):
+        super(TestAnalyticsFormatInstances, self).setUp()
         self.instances = [self.TestDataClass() for _ in xrange(5)]
 
     def test_format_instances_response(self):

--- a/lms/djangoapps/instructor_analytics/tests/test_distributions.py
+++ b/lms/djangoapps/instructor_analytics/tests/test_distributions.py
@@ -13,6 +13,7 @@ class TestAnalyticsDistributions(TestCase):
     '''Test analytics distribution gathering.'''
 
     def setUp(self):
+        super(TestAnalyticsDistributions, self).setUp()
         self.course_id = SlashSeparatedCourseKey('robot', 'course', 'id')
 
         self.users = [UserFactory(
@@ -75,6 +76,7 @@ class TestAnalyticsDistributionsNoData(TestCase):
     '''Test analytics distribution gathering.'''
 
     def setUp(self):
+        super(TestAnalyticsDistributionsNoData, self).setUp()
         self.course_id = SlashSeparatedCourseKey('robot', 'course', 'id')
 
         self.users = [UserFactory(

--- a/lms/djangoapps/instructor_task/tests/test_api.py
+++ b/lms/djangoapps/instructor_task/tests/test_api.py
@@ -73,6 +73,8 @@ class InstructorTaskModuleSubmitTest(InstructorTaskModuleTestCase):
     """Tests API methods that involve the submission of module-based background tasks."""
 
     def setUp(self):
+        super(InstructorTaskModuleSubmitTest, self).setUp()
+
         self.initialize_course()
         self.student = UserFactory.create(username="student", email="student@edx.org")
         self.instructor = UserFactory.create(username="instructor", email="instructor@edx.org")
@@ -164,6 +166,8 @@ class InstructorTaskCourseSubmitTest(TestReportMixin, InstructorTaskCourseTestCa
     """Tests API methods that involve the submission of course-based background tasks."""
 
     def setUp(self):
+        super(InstructorTaskCourseSubmitTest, self).setUp()
+
         self.initialize_course()
         self.student = UserFactory.create(username="student", email="student@edx.org")
         self.instructor = UserFactory.create(username="instructor", email="instructor@edx.org")

--- a/lms/djangoapps/instructor_task/tests/test_base.py
+++ b/lms/djangoapps/instructor_task/tests/test_base.py
@@ -50,6 +50,8 @@ class InstructorTaskTestCase(TestCase):
     Tests API and view methods that involve the reporting of status for background tasks.
     """
     def setUp(self):
+        super(InstructorTaskTestCase, self).setUp()
+
         self.student = UserFactory.create(username="student", email="student@edx.org")
         self.instructor = UserFactory.create(username="instructor", email="instructor@edx.org")
         self.problem_url = InstructorTaskTestCase.problem_location("test_urlname")

--- a/lms/djangoapps/instructor_task/tests/test_base.py
+++ b/lms/djangoapps/instructor_task/tests/test_base.py
@@ -100,7 +100,6 @@ class InstructorTaskTestCase(TestCase):
         return self._create_entry(task_state=task_state, task_output=progress, student=student)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class InstructorTaskCourseTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase):
     """
     Base test class for InstructorTask-related tests that require
@@ -185,7 +184,6 @@ class InstructorTaskCourseTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase)
         return request
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class InstructorTaskModuleTestCase(InstructorTaskCourseTestCase):
     """
     Base test class for InstructorTask-related tests that require

--- a/lms/djangoapps/instructor_task/tests/test_integration.py
+++ b/lms/djangoapps/instructor_task/tests/test_integration.py
@@ -101,6 +101,8 @@ class TestRescoringTask(TestIntegrationTask):
     """
 
     def setUp(self):
+        super(TestRescoringTask, self).setUp()
+
         self.initialize_course()
         self.create_instructor('instructor')
         self.create_student('u1')
@@ -374,6 +376,7 @@ class TestResetAttemptsTask(TestIntegrationTask):
     userlist = ['u1', 'u2', 'u3', 'u4']
 
     def setUp(self):
+        super(TestResetAttemptsTask, self).setUp()
         self.initialize_course()
         self.create_instructor('instructor')
         for username in self.userlist:
@@ -442,6 +445,8 @@ class TestDeleteProblemTask(TestIntegrationTask):
     userlist = ['u1', 'u2', 'u3', 'u4']
 
     def setUp(self):
+        super(TestDeleteProblemTask, self).setUp()
+
         self.initialize_course()
         self.create_instructor('instructor')
         for username in self.userlist:

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -28,6 +28,7 @@ class TestInstructorGradeReport(TestReportMixin, InstructorTaskCourseTestCase):
     Tests that CSV grade report generation works.
     """
     def setUp(self):
+        super(TestInstructorGradeReport, self).setUp()
         self.course = CourseFactory.create()
 
     @ddt.data([u'student@example.com', u'ni\xf1o@example.com'])
@@ -163,6 +164,7 @@ class TestStudentReport(TestReportMixin, InstructorTaskCourseTestCase):
     Tests that CSV student profile report generation works.
     """
     def setUp(self):
+        super(TestStudentReport, self).setUp()
         self.course = CourseFactory.create()
 
     def test_success(self):
@@ -218,6 +220,8 @@ class TestCohortStudents(TestReportMixin, InstructorTaskCourseTestCase):
     Tests that bulk student cohorting works.
     """
     def setUp(self):
+        super(TestCohortStudents, self).setUp()
+
         self.course = CourseFactory.create()
         self.cohort_1 = CohortFactory(course_id=self.course.id, name='Cohort 1')
         self.cohort_2 = CohortFactory(course_id=self.course.id, name='Cohort 2')

--- a/lms/djangoapps/licenses/tests.py
+++ b/lms/djangoapps/licenses/tests.py
@@ -60,6 +60,8 @@ class LicenseTestCase(TestCase):
     '''Tests for licenses.views'''
     def setUp(self):
         '''creates a user and logs in'''
+
+        super(LicenseTestCase, self).setUp()
         # self.setup_viewtest_user()
         self.user = UserFactory(username='test',
                                 email='test@edx.org', password='test_password')
@@ -148,6 +150,8 @@ class LicenseTestCase(TestCase):
 class CommandTest(ModuleStoreTestCase):
     '''Test management command for importing serial numbers'''
     def setUp(self):
+        super(CommandTest, self).setUp()
+
         course = CourseFactory.create()
         self.course_id = course.id
 

--- a/lms/djangoapps/licenses/tests.py
+++ b/lms/djangoapps/licenses/tests.py
@@ -146,7 +146,6 @@ class LicenseTestCase(TestCase):
         self.assertEqual(302, response.status_code)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class CommandTest(ModuleStoreTestCase):
     '''Test management command for importing serial numbers'''
     def setUp(self):

--- a/lms/djangoapps/lms_xblock/test/test_runtime.py
+++ b/lms/djangoapps/lms_xblock/test/test_runtime.py
@@ -43,6 +43,7 @@ class TestHandlerUrl(TestCase):
     """Test the LMS handler_url"""
 
     def setUp(self):
+        super(TestHandlerUrl, self).setUp()
         self.block = Mock(name='block', scope_ids=ScopeIds(None, None, None, 'dummy'))
         self.course_key = SlashSeparatedCourseKey("org", "course", "run")
         self.runtime = LmsModuleSystem(
@@ -107,6 +108,7 @@ class TestUserServiceAPI(TestCase):
     """Test the user service interface"""
 
     def setUp(self):
+        super(TestUserServiceAPI, self).setUp()
         self.course_id = SlashSeparatedCourseKey("org", "course", "run")
 
         self.user = User(username='runtime_robot', email='runtime_robot@edx.org', password='test', first_name='Robot')

--- a/lms/djangoapps/notes/tests.py
+++ b/lms/djangoapps/notes/tests.py
@@ -23,6 +23,7 @@ class UtilsTest(TestCase):
         Setup a dummy course-like object with a tabs field that can be
         accessed via attribute lookup.
         '''
+        super(UtilsTest, self).setUp()
         self.course = collections.namedtuple('DummyCourse', ['tabs'])
         self.course.tabs = []
 
@@ -48,6 +49,7 @@ class UtilsTest(TestCase):
 class ApiTest(TestCase):
 
     def setUp(self):
+        super(ApiTest, self).setUp()
         self.client = Client()
 
         # Mocks
@@ -343,6 +345,8 @@ class ApiTest(TestCase):
 
 class NoteTest(TestCase):
     def setUp(self):
+        super(NoteTest, self).setUp()
+
         self.password = 'abc'
         self.student = User.objects.create_user('student', 'student@test.com', self.password)
         self.course_key = SlashSeparatedCourseKey('HarvardX', 'CB22x', 'The_Ancient_Greek_Hero')

--- a/lms/djangoapps/oauth2_handler/tests.py
+++ b/lms/djangoapps/oauth2_handler/tests.py
@@ -16,9 +16,10 @@ from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from oauth2_provider.tests import IDTokenTestCase, UserInfoTestCase
 
 
-@override_settings(MODULESTORE=TEST_DATA_MIXED_TOY_MODULESTORE)
 class BaseTestMixin(ModuleStoreTestCase):
     profile = None
+
+    MODULESTORE = TEST_DATA_MIXED_TOY_MODULESTORE
 
     def setUp(self):
         super(BaseTestMixin, self).setUp()

--- a/lms/djangoapps/open_ended_grading/tests.py
+++ b/lms/djangoapps/open_ended_grading/tests.py
@@ -104,13 +104,13 @@ class StudentProblemListMockQuery(object):
         }
 
 
-@override_settings(MODULESTORE=TEST_DATA_MIXED_TOY_MODULESTORE)
 class TestStaffGradingService(ModuleStoreTestCase, LoginEnrollmentTestCase):
     '''
     Check that staff grading service proxy works.  Basically just checking the
     access control and error handling logic -- all the actual work is on the
     backend.
     '''
+    MODULESTORE = TEST_DATA_MIXED_TOY_MODULESTORE
 
     def setUp(self):
         super(TestStaffGradingService, self).setUp()
@@ -258,7 +258,6 @@ class TestStaffGradingService(ModuleStoreTestCase, LoginEnrollmentTestCase):
         )
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class TestPeerGradingService(ModuleStoreTestCase, LoginEnrollmentTestCase):
     '''
     Check that staff grading service proxy works.  Basically just checking the
@@ -446,7 +445,6 @@ class TestPeerGradingService(ModuleStoreTestCase, LoginEnrollmentTestCase):
         )
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class TestPanel(ModuleStoreTestCase):
     """
     Run tests on the open ended panel
@@ -491,7 +489,6 @@ class TestPanel(ModuleStoreTestCase):
         self.assertRegexpMatches(response.content, "Here is a list of open ended problems for this course.")
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class TestPeerGradingFound(ModuleStoreTestCase):
     """
     Test to see if peer grading modules can be found properly.
@@ -514,7 +511,6 @@ class TestPeerGradingFound(ModuleStoreTestCase):
         self.assertEqual(found, False)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class TestStudentProblemList(ModuleStoreTestCase):
     """
     Test if the student problem list correctly fetches and parses problems.

--- a/lms/djangoapps/open_ended_grading/tests.py
+++ b/lms/djangoapps/open_ended_grading/tests.py
@@ -113,6 +113,7 @@ class TestStaffGradingService(ModuleStoreTestCase, LoginEnrollmentTestCase):
     '''
 
     def setUp(self):
+        super(TestStaffGradingService, self).setUp()
         self.student = 'view@test.com'
         self.instructor = 'view2@test.com'
         self.password = 'foo'
@@ -266,6 +267,7 @@ class TestPeerGradingService(ModuleStoreTestCase, LoginEnrollmentTestCase):
     '''
 
     def setUp(self):
+        super(TestPeerGradingService, self).setUp()
         self.student = 'view@test.com'
         self.instructor = 'view2@test.com'
         self.password = 'foo'
@@ -450,6 +452,7 @@ class TestPanel(ModuleStoreTestCase):
     Run tests on the open ended panel
     """
     def setUp(self):
+        super(TestPanel, self).setUp()
         self.user = factories.UserFactory()
         store = modulestore()
         course_items = import_from_xml(store, self.user.id, TEST_DATA_DIR, ['open_ended'])  # pylint: disable=maybe-no-member
@@ -494,6 +497,7 @@ class TestPeerGradingFound(ModuleStoreTestCase):
     Test to see if peer grading modules can be found properly.
     """
     def setUp(self):
+        super(TestPeerGradingFound, self).setUp()
         self.user = factories.UserFactory()
         store = modulestore()
         course_items = import_from_xml(store, self.user.id, TEST_DATA_DIR, ['open_ended_nopath'])  # pylint: disable=maybe-no-member
@@ -516,6 +520,8 @@ class TestStudentProblemList(ModuleStoreTestCase):
     Test if the student problem list correctly fetches and parses problems.
     """
     def setUp(self):
+        super(TestStudentProblemList, self).setUp()
+
         # Load an open ended course with several problems.
         self.user = factories.UserFactory()
         store = modulestore()

--- a/lms/djangoapps/shoppingcart/management/tests/test_retire_order.py
+++ b/lms/djangoapps/shoppingcart/management/tests/test_retire_order.py
@@ -12,6 +12,8 @@ from student.tests.factories import UserFactory
 class TestRetireOrder(ModuleStoreTestCase):
     """Test the retire_order command"""
     def setUp(self):
+        super(TestRetireOrder, self).setUp()
+
         course = CourseFactory.create()
         self.course_key = course.id
 

--- a/lms/djangoapps/shoppingcart/processors/tests/test_CyberSource2.py
+++ b/lms/djangoapps/shoppingcart/processors/tests/test_CyberSource2.py
@@ -41,6 +41,8 @@ class CyberSource2Test(TestCase):
 
     def setUp(self):
         """ Create a user and an order. """
+        super(CyberSource2Test, self).setUp()
+
         self.user = UserFactory()
         self.order = Order.get_cart_for_user(self.user)
         self.order_item = OrderItem.objects.create(

--- a/lms/djangoapps/shoppingcart/tests/test_context_processor.py
+++ b/lms/djangoapps/shoppingcart/tests/test_context_processor.py
@@ -16,7 +16,6 @@ from shoppingcart.models import Order, PaidCourseRegistration
 from shoppingcart.context_processor import user_has_cart_context_processor
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class UserCartContextProcessorUnitTest(ModuleStoreTestCase):
     """
     Unit test for shoppingcart context_processor

--- a/lms/djangoapps/shoppingcart/tests/test_context_processor.py
+++ b/lms/djangoapps/shoppingcart/tests/test_context_processor.py
@@ -22,6 +22,8 @@ class UserCartContextProcessorUnitTest(ModuleStoreTestCase):
     Unit test for shoppingcart context_processor
     """
     def setUp(self):
+        super(UserCartContextProcessorUnitTest, self).setUp()
+
         self.user = UserFactory.create()
         self.request = Mock()
 

--- a/lms/djangoapps/shoppingcart/tests/test_microsites.py
+++ b/lms/djangoapps/shoppingcart/tests/test_microsites.py
@@ -53,6 +53,8 @@ class TestOrderHistoryOnMicrositeDashboard(ModuleStoreTestCase):
     Test for microsite dashboard order history
     """
     def setUp(self):
+        super(TestOrderHistoryOnMicrositeDashboard, self).setUp()
+
         patcher = patch('student.models.tracker')
         self.mock_tracker = patcher.start()
         self.user = UserFactory.create()

--- a/lms/djangoapps/shoppingcart/tests/test_microsites.py
+++ b/lms/djangoapps/shoppingcart/tests/test_microsites.py
@@ -20,11 +20,6 @@ from student.tests.factories import UserFactory
 from course_modes.models import CourseMode
 
 
-# Since we don't need any XML course fixtures, use a modulestore configuration
-# that disables the XML modulestore.
-MODULESTORE_CONFIG = mixed_store_config(settings.COMMON_TEST_DATA_ROOT, {}, include_xml=False)
-
-
 def fake_all_orgs(default=None):  # pylint: disable=unused-argument
     """
     create a fake list of all microsites
@@ -46,7 +41,6 @@ def non_microsite(name, default=None):  # pylint: disable=unused-argument
     return None
 
 
-@override_settings(MODULESTORE=MODULESTORE_CONFIG)
 @patch.dict('django.conf.settings.FEATURES', {'ENABLE_PAID_COURSE_REGISTRATION': True})
 class TestOrderHistoryOnMicrositeDashboard(ModuleStoreTestCase):
     """

--- a/lms/djangoapps/shoppingcart/tests/test_models.py
+++ b/lms/djangoapps/shoppingcart/tests/test_models.py
@@ -378,6 +378,8 @@ class OrderTest(ModuleStoreTestCase):
 
 class OrderItemTest(TestCase):
     def setUp(self):
+        super(OrderItemTest, self).setUp()
+
         self.user = UserFactory.create()
 
     def test_order_item_purchased_callback(self):
@@ -405,6 +407,8 @@ class OrderItemTest(TestCase):
 @override_settings(MODULESTORE=MODULESTORE_CONFIG)
 class PaidCourseRegistrationTest(ModuleStoreTestCase):
     def setUp(self):
+        super(PaidCourseRegistrationTest, self).setUp()
+
         self.user = UserFactory.create()
         self.cost = 40
         self.course = CourseFactory.create()
@@ -547,6 +551,8 @@ class CertificateItemTest(ModuleStoreTestCase):
     Tests for verifying specific CertificateItem functionality
     """
     def setUp(self):
+        super(CertificateItemTest, self).setUp()
+
         self.user = UserFactory.create()
         self.cost = 40
         course = CourseFactory.create()

--- a/lms/djangoapps/shoppingcart/tests/test_models.py
+++ b/lms/djangoapps/shoppingcart/tests/test_models.py
@@ -41,12 +41,7 @@ from shoppingcart.exceptions import (
 
 from opaque_keys.edx.locator import CourseLocator
 
-# Since we don't need any XML course fixtures, use a modulestore configuration
-# that disables the XML modulestore.
-MODULESTORE_CONFIG = mixed_store_config(settings.COMMON_TEST_DATA_ROOT, {}, include_xml=False)
 
-
-@override_settings(MODULESTORE=MODULESTORE_CONFIG)
 @ddt.ddt
 class OrderTest(ModuleStoreTestCase):
     def setUp(self):
@@ -404,7 +399,6 @@ class OrderItemTest(TestCase):
         self.assertEquals(set([]), inst_set)
 
 
-@override_settings(MODULESTORE=MODULESTORE_CONFIG)
 class PaidCourseRegistrationTest(ModuleStoreTestCase):
     def setUp(self):
         super(PaidCourseRegistrationTest, self).setUp()
@@ -545,7 +539,6 @@ class PaidCourseRegistrationTest(ModuleStoreTestCase):
         self.assertTrue(PaidCourseRegistration.contained_in_order(cart, self.course_key))
 
 
-@override_settings(MODULESTORE=MODULESTORE_CONFIG)
 class CertificateItemTest(ModuleStoreTestCase):
     """
     Tests for verifying specific CertificateItem functionality
@@ -781,7 +774,6 @@ class CertificateItemTest(ModuleStoreTestCase):
         self.assertFalse(ret_val)
 
 
-@override_settings(MODULESTORE=MODULESTORE_CONFIG)
 class DonationTest(ModuleStoreTestCase):
     """Tests for the donation order item type. """
 

--- a/lms/djangoapps/shoppingcart/tests/test_pdf.py
+++ b/lms/djangoapps/shoppingcart/tests/test_pdf.py
@@ -39,6 +39,8 @@ class TestPdfFile(unittest.TestCase):
     Unit test cases for pdf file generation
     """
     def setUp(self):
+        super(TestPdfFile, self).setUp()
+
         self.items_data = [self.get_item_data(1)]
         self.item_id = '1'
         self.date = datetime.now()

--- a/lms/djangoapps/shoppingcart/tests/test_reports.py
+++ b/lms/djangoapps/shoppingcart/tests/test_reports.py
@@ -30,38 +30,16 @@ class ReportTypeTests(ModuleStoreTestCase):
 
     def setUp(self):
         super(ReportTypeTests, self).setUp()
+
         # Need to make a *lot* of users for this one
-        self.first_verified_user = UserFactory.create()
-        self.first_verified_user.profile.name = "John Doe"
-        self.first_verified_user.profile.save()
-
-        self.second_verified_user = UserFactory.create()
-        self.second_verified_user.profile.name = "Jane Deer"
-        self.second_verified_user.profile.save()
-
-        self.first_audit_user = UserFactory.create()
-        self.first_audit_user.profile.name = "Joe Miller"
-        self.first_audit_user.profile.save()
-
-        self.second_audit_user = UserFactory.create()
-        self.second_audit_user.profile.name = "Simon Blackquill"
-        self.second_audit_user.profile.save()
-
-        self.third_audit_user = UserFactory.create()
-        self.third_audit_user.profile.name = "Super Mario"
-        self.third_audit_user.profile.save()
-
-        self.honor_user = UserFactory.create()
-        self.honor_user.profile.name = "Princess Peach"
-        self.honor_user.profile.save()
-
-        self.first_refund_user = UserFactory.create()
-        self.first_refund_user.profile.name = u"King Bowsér"
-        self.first_refund_user.profile.save()
-
-        self.second_refund_user = UserFactory.create()
-        self.second_refund_user.profile.name = u"Súsan Smith"
-        self.second_refund_user.profile.save()
+        self.first_verified_user = UserFactory.create(profile__name="John Doe")
+        self.second_verified_user = UserFactory.create(profile__name="Jane Deer")
+        self.first_audit_user = UserFactory.create(profile__name="Joe Miller")
+        self.second_audit_user = UserFactory.create(profile__name="Simon Blackquill")
+        self.third_audit_user = UserFactory.create(profile__name="Super Mario")
+        self.honor_user = UserFactory.create(profile__name="Princess Peach")
+        self.first_refund_user = UserFactory.create(profile__name="King Bowsér")
+        self.second_refund_user = UserFactory.create(profile__name="Súsan Smith")
 
         # Two are verified, three are audit, one honor
 

--- a/lms/djangoapps/shoppingcart/tests/test_reports.py
+++ b/lms/djangoapps/shoppingcart/tests/test_reports.py
@@ -30,6 +30,7 @@ class ReportTypeTests(ModuleStoreTestCase):
     FIVE_MINS = datetime.timedelta(minutes=5)
 
     def setUp(self):
+        super(ReportTypeTests, self).setUp()
         # Need to make a *lot* of users for this one
         self.first_verified_user = UserFactory.create()
         self.first_verified_user.profile.name = "John Doe"
@@ -188,6 +189,8 @@ class ItemizedPurchaseReportTest(ModuleStoreTestCase):
     TEST_ANNOTATION = u'Ba\xfc\u5305'
 
     def setUp(self):
+        super(ItemizedPurchaseReportTest, self).setUp()
+
         self.user = UserFactory.create()
         self.cost = 40
         self.course = CourseFactory.create(org='MITx', number='999', display_name=u'Robot Super Course')

--- a/lms/djangoapps/shoppingcart/tests/test_reports.py
+++ b/lms/djangoapps/shoppingcart/tests/test_reports.py
@@ -22,7 +22,6 @@ from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class ReportTypeTests(ModuleStoreTestCase):
     """
     Tests for the models used to generate certificate status reports
@@ -180,7 +179,6 @@ class ReportTypeTests(ModuleStoreTestCase):
         self.assertEqual(csv.replace('\r\n', '\n').strip(), self.CORRECT_UNI_REVENUE_SHARE_CSV.strip())
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class ItemizedPurchaseReportTest(ModuleStoreTestCase):
     """
     Tests for the models used to generate itemized purchase reports

--- a/lms/djangoapps/shoppingcart/tests/test_views.py
+++ b/lms/djangoapps/shoppingcart/tests/test_views.py
@@ -62,12 +62,6 @@ render_mock = Mock(side_effect=mock_render_to_response)
 postpay_mock = Mock()
 
 
-# Since we don't need any XML course fixtures, use a modulestore configuration
-# that disables the XML modulestore.
-MODULESTORE_CONFIG = mixed_store_config(settings.COMMON_TEST_DATA_ROOT, {}, include_xml=False)
-
-
-@override_settings(MODULESTORE=MODULESTORE_CONFIG)
 @patch.dict('django.conf.settings.FEATURES', {'ENABLE_PAID_COURSE_REGISTRATION': True})
 @ddt.ddt
 class ShoppingCartViewsTests(ModuleStoreTestCase):
@@ -1255,7 +1249,6 @@ class ShoppingCartViewsTests(ModuleStoreTestCase):
         self._assert_404(reverse('shoppingcart.views.billing_details', args=[]))
 
 
-@override_settings(MODULESTORE=MODULESTORE_CONFIG)
 class ReceiptRedirectTest(ModuleStoreTestCase):
     """Test special-case redirect from the receipt page. """
 
@@ -1317,7 +1310,6 @@ class ReceiptRedirectTest(ModuleStoreTestCase):
         self.assertRedirects(resp, redirect_url)
 
 
-@override_settings(MODULESTORE=MODULESTORE_CONFIG)
 @patch.dict('django.conf.settings.FEATURES', {'ENABLE_PAID_COURSE_REGISTRATION': True})
 class ShoppingcartViewsClosedEnrollment(ModuleStoreTestCase):
     """
@@ -1431,7 +1423,6 @@ class ShoppingcartViewsClosedEnrollment(ModuleStoreTestCase):
         self.assertIn('40.00', resp.content)
 
 
-@override_settings(MODULESTORE=MODULESTORE_CONFIG)
 @patch.dict('django.conf.settings.FEATURES', {'ENABLE_PAID_COURSE_REGISTRATION': True})
 class RegistrationCodeRedemptionCourseEnrollment(ModuleStoreTestCase):
     """
@@ -1562,7 +1553,6 @@ class RegistrationCodeRedemptionCourseEnrollment(ModuleStoreTestCase):
         self.assertIn(self.course.display_name, response.content)
 
 
-@override_settings(MODULESTORE=MODULESTORE_CONFIG)
 @ddt.ddt
 class DonationViewTest(ModuleStoreTestCase):
     """Tests for making a donation.
@@ -1720,7 +1710,6 @@ class DonationViewTest(ModuleStoreTestCase):
         return reverse("shoppingcart.views.show_receipt", kwargs={"ordernum": order_id})
 
 
-@override_settings(MODULESTORE=MODULESTORE_CONFIG)
 class CSVReportViewsTest(ModuleStoreTestCase):
     """
     Test suite for CSV Purchase Reporting

--- a/lms/djangoapps/shoppingcart/tests/test_views.py
+++ b/lms/djangoapps/shoppingcart/tests/test_views.py
@@ -72,6 +72,8 @@ MODULESTORE_CONFIG = mixed_store_config(settings.COMMON_TEST_DATA_ROOT, {}, incl
 @ddt.ddt
 class ShoppingCartViewsTests(ModuleStoreTestCase):
     def setUp(self):
+        super(ShoppingCartViewsTests, self).setUp()
+
         patcher = patch('student.models.tracker')
         self.mock_tracker = patcher.start()
         self.user = UserFactory.create()
@@ -1436,6 +1438,8 @@ class RegistrationCodeRedemptionCourseEnrollment(ModuleStoreTestCase):
     Test suite for RegistrationCodeRedemption Course Enrollments
     """
     def setUp(self, **kwargs):
+        super(RegistrationCodeRedemptionCourseEnrollment, self).setUp()
+
         self.user = UserFactory.create()
         self.user.set_password('password')
         self.user.save()
@@ -1722,6 +1726,8 @@ class CSVReportViewsTest(ModuleStoreTestCase):
     Test suite for CSV Purchase Reporting
     """
     def setUp(self):
+        super(CSVReportViewsTest, self).setUp()
+
         self.user = UserFactory.create()
         self.user.set_password('password')
         self.user.save()
@@ -1834,6 +1840,8 @@ class UtilFnsTest(TestCase):
     Tests for utility functions in views.py
     """
     def setUp(self):
+        super(UtilFnsTest, self).setUp()
+
         self.user = UserFactory.create()
 
     def test_can_download_report_no_group(self):

--- a/lms/djangoapps/staticbook/tests.py
+++ b/lms/djangoapps/staticbook/tests.py
@@ -46,7 +46,6 @@ HTML_BOOK = {
 }
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class StaticBookTest(ModuleStoreTestCase):
     """
     Helpers for the static book tests.

--- a/lms/djangoapps/student_account/test/test_views.py
+++ b/lms/djangoapps/student_account/test/test_views.py
@@ -26,9 +26,6 @@ from xmodule.modulestore.tests.factories import CourseFactory
 from student.tests.factories import CourseModeFactory
 
 
-MODULESTORE_CONFIG = mixed_store_config(settings.COMMON_TEST_DATA_ROOT, {}, include_xml=False)
-
-
 @ddt.ddt
 class StudentAccountUpdateTest(UrlResetMixin, TestCase):
     """ Tests for the student account views that update the user's account information. """
@@ -377,7 +374,6 @@ class StudentAccountUpdateTest(UrlResetMixin, TestCase):
 
 
 @ddt.ddt
-@override_settings(MODULESTORE=MODULESTORE_CONFIG)
 class StudentAccountLoginAndRegistrationTest(ModuleStoreTestCase):
     """ Tests for the student account views that update the user's account information. """
 

--- a/lms/djangoapps/survey/tests/test_models.py
+++ b/lms/djangoapps/survey/tests/test_models.py
@@ -21,6 +21,7 @@ class SurveyModelsTests(TestCase):
         """
         Set up the test data used in the specific tests
         """
+        super(SurveyModelsTests, self).setUp()
         self.client = Client()
 
         # Create two accounts

--- a/lms/djangoapps/survey/tests/test_utils.py
+++ b/lms/djangoapps/survey/tests/test_utils.py
@@ -23,6 +23,8 @@ class SurveyModelsTests(TestCase):
         """
         Set up the test data used in the specific tests
         """
+        super(SurveyModelsTests, self).setUp()
+
         self.client = Client()
 
         # Create two accounts

--- a/lms/djangoapps/survey/tests/test_utils.py
+++ b/lms/djangoapps/survey/tests/test_utils.py
@@ -11,11 +11,12 @@ from django.contrib.auth.models import User
 from survey.models import SurveyForm
 
 from xmodule.modulestore.tests.factories import CourseFactory
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 
 from survey.utils import is_survey_required_for_course, must_answer_survey
 
 
-class SurveyModelsTests(TestCase):
+class SurveyModelsTests(ModuleStoreTestCase):
     """
     All tests for the utils.py file
     """

--- a/lms/djangoapps/survey/tests/test_views.py
+++ b/lms/djangoapps/survey/tests/test_views.py
@@ -23,6 +23,8 @@ class SurveyViewsTests(TestCase):
         """
         Set up the test data used in the specific tests
         """
+        super(SurveyViewsTests, self).setUp()
+
         self.client = Client()
 
         # Create two accounts

--- a/lms/djangoapps/survey/tests/test_views.py
+++ b/lms/djangoapps/survey/tests/test_views.py
@@ -13,9 +13,10 @@ from django.core.urlresolvers import reverse
 from survey.models import SurveyForm
 
 from xmodule.modulestore.tests.factories import CourseFactory
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 
 
-class SurveyViewsTests(TestCase):
+class SurveyViewsTests(ModuleStoreTestCase):
     """
     All tests for the views.py file
     """

--- a/lms/djangoapps/verify_student/tests/test_integration.py
+++ b/lms/djangoapps/verify_student/tests/test_integration.py
@@ -29,6 +29,8 @@ class TestProfEdVerification(ModuleStoreTestCase):
     MIN_PRICE = 1438
 
     def setUp(self):
+        super(TestProfEdVerification, self).setUp()
+
         self.user = UserFactory.create(username="rusty", password="test")
         self.client.login(username="rusty", password="test")
         course = CourseFactory.create(org='Robot', number='999', display_name='Test Course')

--- a/lms/djangoapps/verify_student/tests/test_integration.py
+++ b/lms/djangoapps/verify_student/tests/test_integration.py
@@ -14,12 +14,6 @@ from student.models import CourseEnrollment
 from course_modes.tests.factories import CourseModeFactory
 
 
-# Since we don't need any XML course fixtures, use a modulestore configuration
-# that disables the XML modulestore.
-MODULESTORE_CONFIG = mixed_store_config(settings.COMMON_TEST_DATA_ROOT, {}, include_xml=False)
-
-
-@override_settings(MODULESTORE=MODULESTORE_CONFIG)
 class TestProfEdVerification(ModuleStoreTestCase):
     """
     Integration test for professional ed verification, including course mode selection.

--- a/lms/djangoapps/verify_student/tests/test_models.py
+++ b/lms/djangoapps/verify_student/tests/test_models.py
@@ -505,7 +505,6 @@ class TestPhotoVerification(TestCase):
         self.assertEqual(result, second_attempt)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 @patch.dict(settings.VERIFY_STUDENT, FAKE_SETTINGS)
 @patch('verify_student.models.S3Connection', new=MockS3Connection)
 @patch('verify_student.models.Key', new=MockKey)

--- a/lms/djangoapps/verify_student/tests/test_views.py
+++ b/lms/djangoapps/verify_student/tests/test_views.py
@@ -776,6 +776,8 @@ class TestCreateOrder(ModuleStoreTestCase):
     """
     def setUp(self):
         """ Create a user and course. """
+        super(TestCreateOrder, self).setUp()
+
         self.user = UserFactory.create(username="test", password="test")
         self.course = CourseFactory.create()
         for mode in ('audit', 'honor', 'verified'):
@@ -861,6 +863,8 @@ class TestCreateOrderView(ModuleStoreTestCase):
     IMAGE_DATA = ','
 
     def setUp(self):
+        super(TestCreateOrderView, self).setUp()
+
         self.user = UserFactory.create(username="rusty", password="test")
         self.client.login(username="rusty", password="test")
         self.course_id = 'Robot/999/Test_Course'
@@ -1128,6 +1132,8 @@ class TestPhotoVerificationResultsCallback(ModuleStoreTestCase):
     Tests for the results_callback view.
     """
     def setUp(self):
+        super(TestPhotoVerificationResultsCallback, self).setUp()
+
         self.course = CourseFactory.create(org='Robot', number='999', display_name='Test Course')
         self.course_id = self.course.id
         self.user = UserFactory.create()
@@ -1343,6 +1349,8 @@ class TestReverifyView(ModuleStoreTestCase):
     Tests for the reverification views
     """
     def setUp(self):
+        super(TestReverifyView, self).setUp()
+
         self.user = UserFactory.create(username="rusty", password="test")
         self.user.profile.name = u"Røøsty Bøøgins"
         self.user.profile.save()
@@ -1390,6 +1398,8 @@ class TestMidCourseReverifyView(ModuleStoreTestCase):
     Tests for the midcourse reverification views.
     """
     def setUp(self):
+        super(TestMidCourseReverifyView, self).setUp()
+
         self.user = UserFactory.create(username="rusty", password="test")
         self.client.login(username="rusty", password="test")
         self.course_key = SlashSeparatedCourseKey("Robot", "999", "Test_Course")
@@ -1513,6 +1523,8 @@ class TestReverificationBanner(ModuleStoreTestCase):
 
     @patch.dict(settings.FEATURES, {'AUTOMATIC_VERIFY_STUDENT_IDENTITY_FOR_TESTING': True})
     def setUp(self):
+        super(TestReverificationBanner, self).setUp()
+
         self.user = UserFactory.create(username="rusty", password="test")
         self.client.login(username="rusty", password="test")
         self.course_id = 'Robot/999/Test_Course'

--- a/lms/djangoapps/verify_student/tests/test_views.py
+++ b/lms/djangoapps/verify_student/tests/test_views.py
@@ -37,11 +37,6 @@ from verify_student.models import SoftwareSecurePhotoVerification
 from reverification.tests.factories import MidcourseReverificationWindowFactory
 
 
-# Since we don't need any XML course fixtures, use a modulestore configuration
-# that disables the XML modulestore.
-MODULESTORE_CONFIG = mixed_store_config(settings.COMMON_TEST_DATA_ROOT, {}, include_xml=False)
-
-
 def mock_render_to_response(*args, **kwargs):
     return render_to_response(*args, **kwargs)
 
@@ -64,7 +59,6 @@ class StartView(TestCase):
         self.assertHttpForbidden(self.client.get(self.start_url()))
 
 
-@override_settings(MODULESTORE=MODULESTORE_CONFIG)
 @ddt.ddt
 class TestPayAndVerifyView(ModuleStoreTestCase):
     """
@@ -769,7 +763,6 @@ class TestPayAndVerifyView(ModuleStoreTestCase):
         self.assertRedirects(response, url)
 
 
-@override_settings(MODULESTORE=MODULESTORE_CONFIG)
 class TestCreateOrder(ModuleStoreTestCase):
     """
     Tests for the create order view.
@@ -854,7 +847,6 @@ class TestCreateOrder(ModuleStoreTestCase):
         attempt.approve()
 
 
-@override_settings(MODULESTORE=MODULESTORE_CONFIG)
 class TestCreateOrderView(ModuleStoreTestCase):
     """
     Tests for the create_order view of verified course enrollment process.
@@ -1126,7 +1118,6 @@ class TestSubmitPhotosForVerification(TestCase):
         self.assertEqual(info['full_name'], full_name)
 
 
-@override_settings(MODULESTORE=MODULESTORE_CONFIG)
 class TestPhotoVerificationResultsCallback(ModuleStoreTestCase):
     """
     Tests for the results_callback view.
@@ -1343,7 +1334,6 @@ class TestPhotoVerificationResultsCallback(ModuleStoreTestCase):
         self.assertIsNotNone(CourseEnrollment.objects.get(course_id=self.course_id))
 
 
-@override_settings(MODULESTORE=MODULESTORE_CONFIG)
 class TestReverifyView(ModuleStoreTestCase):
     """
     Tests for the reverification views
@@ -1392,7 +1382,6 @@ class TestReverifyView(ModuleStoreTestCase):
         self.assertTrue(context['error'])
 
 
-@override_settings(MODULESTORE=MODULESTORE_CONFIG)
 class TestMidCourseReverifyView(ModuleStoreTestCase):
     """
     Tests for the midcourse reverification views.
@@ -1515,7 +1504,6 @@ class TestMidCourseReverifyView(ModuleStoreTestCase):
         self.assertEqual(response.status_code, 404)
 
 
-@override_settings(MODULESTORE=MODULESTORE_CONFIG)
 class TestReverificationBanner(ModuleStoreTestCase):
     """
     Tests for toggling the "midcourse reverification failed" banner off.

--- a/lms/lib/courseware_search/test/test_lms_result_processor.py
+++ b/lms/lib/courseware_search/test/test_lms_result_processor.py
@@ -47,6 +47,7 @@ class LmsSearchResultProcessorTestCase(ModuleStoreTestCase):
     def setUp(self):
         # from nose.tools import set_trace
         # set_trace()
+        super(LmsSearchResultProcessorTestCase, self).setUp()
         self.build_course()
 
     def test_url_parameter(self):

--- a/lms/lib/xblock/test/test_mixin.py
+++ b/lms/lib/xblock/test/test_mixin.py
@@ -8,7 +8,7 @@ from xblock.validation import ValidationMessage
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.modulestore_settings import update_module_store_settings
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, TEST_DATA_MIXED_TOY_MODULESTORE
 from xmodule.partitions.partitions import Group, UserPartition
 
 
@@ -147,16 +147,7 @@ class XBlockGetParentTest(LmsXBlockMixinTestCase):
     Test that XBlock.get_parent returns correct results with each modulestore
     backend.
     """
-    def _pre_setup(self):
-        # load the one xml course into the xml store
-        update_module_store_settings(
-            settings.MODULESTORE,
-            mappings={'edX/toy/2012_Fall': ModuleStoreEnum.Type.xml},
-            xml_store_options={
-                'data_dir': settings.COMMON_TEST_DATA_ROOT  # where toy course lives
-            },
-        )
-        super(XBlockGetParentTest, self)._pre_setup()
+    MODULESTORE = TEST_DATA_MIXED_TOY_MODULESTORE
 
     @ddt.data(ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split, ModuleStoreEnum.Type.xml)
     def test_parents(self, modulestore_type):

--- a/lms/tests.py
+++ b/lms/tests.py
@@ -46,6 +46,7 @@ class TemplateLookupTests(TestCase):
 class HelpModalTests(TestCase):
     """Tests for the help modal"""
     def setUp(self):
+        super(HelpModalTests, self).setUp()
         self.course = CourseFactory.create()
 
     def test_simple_test(self):

--- a/lms/tests.py
+++ b/lms/tests.py
@@ -9,6 +9,7 @@ from django.core.urlresolvers import reverse
 from edxmako import add_lookup, LOOKUP
 from lms import startup
 from xmodule.modulestore.tests.factories import CourseFactory
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from util import keyword_substitution
 
 
@@ -43,7 +44,7 @@ class TemplateLookupTests(TestCase):
 
 
 @patch.dict('django.conf.settings.FEATURES', {'ENABLE_FEEDBACK_SUBMISSION': True})
-class HelpModalTests(TestCase):
+class HelpModalTests(ModuleStoreTestCase):
     """Tests for the help modal"""
     def setUp(self):
         super(HelpModalTests, self).setUp()

--- a/openedx/core/djangoapps/course_groups/tests/test_cohorts.py
+++ b/openedx/core/djangoapps/course_groups/tests/test_cohorts.py
@@ -28,6 +28,7 @@ TEST_DATA_MIXED_MODULESTORE = mixed_store_config(TEST_DATA_DIR, TEST_MAPPING)
 @patch("openedx.core.djangoapps.course_groups.cohorts.tracker")
 class TestCohortSignals(TestCase):
     def setUp(self):
+        super(TestCohortSignals, self).setUp()
         self.course_key = SlashSeparatedCourseKey("dummy", "dummy", "dummy")
 
     def test_cohort_added(self, mock_tracker):
@@ -131,7 +132,7 @@ class TestCohorts(TestCase):
         """
         Make sure that course is reloaded every time--clear out the modulestore.
         """
-        clear_existing_modulestores()
+        super(TestCohorts, self).setUp()
         self.toy_course_key = SlashSeparatedCourseKey("edX", "toy", "2012_Fall")
 
     def test_is_course_cohorted(self):
@@ -601,6 +602,8 @@ class TestCohortsAndPartitionGroups(TestCase):
         """
         Regenerate a test course and cohorts for each test
         """
+        super(TestCohortsAndPartitionGroups, self).setUp()
+
         self.test_course_key = SlashSeparatedCourseKey("edX", "toy", "2012_Fall")
         self.course = modulestore().get_course(self.test_course_key)
 

--- a/openedx/core/djangoapps/course_groups/tests/test_cohorts.py
+++ b/openedx/core/djangoapps/course_groups/tests/test_cohorts.py
@@ -10,19 +10,11 @@ from opaque_keys.edx.locations import SlashSeparatedCourseKey
 from student.models import CourseEnrollment
 from student.tests.factories import UserFactory
 from xmodule.modulestore.django import modulestore, clear_existing_modulestores
-from xmodule.modulestore.tests.django_utils import TEST_DATA_MIXED_TOY_MODULESTORE, mixed_store_config
+from xmodule.modulestore.tests.django_utils import TEST_DATA_MIXED_TOY_MODULESTORE, mixed_store_config, ModuleStoreTestCase
 
 from ..models import CourseUserGroup, CourseUserGroupPartitionGroup
 from .. import cohorts
 from ..tests.helpers import topic_name_to_id, config_course_cohorts, CohortFactory
-
-# NOTE: running this with the lms.envs.test config works without
-# manually overriding the modulestore.  However, running with
-# cms.envs.test doesn't.
-
-TEST_DATA_DIR = settings.COMMON_TEST_DATA_ROOT
-TEST_MAPPING = {'edX/toy/2012_Fall': 'xml'}
-TEST_DATA_MIXED_MODULESTORE = mixed_store_config(TEST_DATA_DIR, TEST_MAPPING)
 
 
 @patch("openedx.core.djangoapps.course_groups.cohorts.tracker")
@@ -123,11 +115,12 @@ class TestCohortSignals(TestCase):
         self.assertFalse(mock_tracker.emit.called)
 
 
-@override_settings(MODULESTORE=TEST_DATA_MIXED_TOY_MODULESTORE)
-class TestCohorts(TestCase):
+class TestCohorts(ModuleStoreTestCase):
     """
     Test the cohorts feature
     """
+    MODULESTORE = TEST_DATA_MIXED_TOY_MODULESTORE
+
     def setUp(self):
         """
         Make sure that course is reloaded every time--clear out the modulestore.
@@ -595,8 +588,8 @@ class TestCohorts(TestCase):
         )
 
 
-@override_settings(MODULESTORE=TEST_DATA_MIXED_MODULESTORE)
-class TestCohortsAndPartitionGroups(TestCase):
+class TestCohortsAndPartitionGroups(ModuleStoreTestCase):
+    MODULESTORE = TEST_DATA_MIXED_TOY_MODULESTORE
 
     def setUp(self):
         """

--- a/openedx/core/djangoapps/course_groups/tests/test_partition_scheme.py
+++ b/openedx/core/djangoapps/course_groups/tests/test_partition_scheme.py
@@ -42,6 +42,8 @@ class TestCohortPartitionScheme(django.test.TestCase):
         Regenerate a course with cohort configuration, partition and groups,
         and a student for each test.
         """
+        super(TestCohortPartitionScheme, self).setUp()
+
         self.course_key = SlashSeparatedCourseKey("edX", "toy", "2012_Fall")
         self.course = modulestore().get_course(self.course_key)
         config_course_cohorts(self.course, [], cohorted=True)
@@ -282,6 +284,7 @@ class TestGetCohortedUserPartition(django.test.TestCase):
         Regenerate a course with cohort configuration, partition and groups,
         and a student for each test.
         """
+        super(TestGetCohortedUserPartition, self).setUp()
         self.course_key = SlashSeparatedCourseKey("edX", "toy", "2012_Fall")
         self.course = modulestore().get_course(self.course_key)
         self.student = UserFactory.create()

--- a/openedx/core/djangoapps/course_groups/tests/test_partition_scheme.py
+++ b/openedx/core/djangoapps/course_groups/tests/test_partition_scheme.py
@@ -15,7 +15,7 @@ from courseware.tests.test_masquerade import StaffMasqueradeTestCase
 from student.tests.factories import UserFactory
 from xmodule.partitions.partitions import Group, UserPartition, UserPartitionError
 from xmodule.modulestore.django import modulestore, clear_existing_modulestores
-from xmodule.modulestore.tests.django_utils import mixed_store_config
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, mixed_store_config, TEST_DATA_MIXED_TOY_MODULESTORE
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
 
 from openedx.core.djangoapps.user_api.partition_schemes import RandomUserPartitionScheme
@@ -26,16 +26,11 @@ from ..cohorts import add_user_to_cohort, get_course_cohorts
 from .helpers import CohortFactory, config_course_cohorts
 
 
-TEST_DATA_DIR = settings.COMMON_TEST_DATA_ROOT
-TEST_MAPPING = {'edX/toy/2012_Fall': 'xml'}
-TEST_DATA_MIXED_MODULESTORE = mixed_store_config(TEST_DATA_DIR, TEST_MAPPING, include_xml=True)
-
-
-@override_settings(MODULESTORE=TEST_DATA_MIXED_MODULESTORE)
-class TestCohortPartitionScheme(django.test.TestCase):
+class TestCohortPartitionScheme(ModuleStoreTestCase):
     """
     Test the logic for linking a user to a partition group based on their cohort.
     """
+    MODULESTORE = TEST_DATA_MIXED_TOY_MODULESTORE
 
     def setUp(self):
         """
@@ -274,11 +269,12 @@ class TestExtension(django.test.TestCase):
             UserPartition.get_scheme('other')
 
 
-@override_settings(MODULESTORE=TEST_DATA_MIXED_MODULESTORE)
-class TestGetCohortedUserPartition(django.test.TestCase):
+class TestGetCohortedUserPartition(ModuleStoreTestCase):
     """
     Test that `get_cohorted_user_partition` returns the first user_partition with scheme `CohortPartitionScheme`.
     """
+    MODULESTORE = TEST_DATA_MIXED_TOY_MODULESTORE
+
     def setUp(self):
         """
         Regenerate a course with cohort configuration, partition and groups,

--- a/openedx/core/djangoapps/course_groups/tests/test_views.py
+++ b/openedx/core/djangoapps/course_groups/tests/test_views.py
@@ -35,6 +35,7 @@ class CohortViewsTestCase(ModuleStoreTestCase):
     Base class which sets up a course and staff/non-staff users.
     """
     def setUp(self):
+        super(CohortViewsTestCase, self).setUp()
         self.course = CourseFactory.create()
         self.staff_user = UserFactory(is_staff=True, username="staff")
         self.non_staff_user = UserFactory(username="nonstaff")

--- a/openedx/core/djangoapps/course_groups/tests/test_views.py
+++ b/openedx/core/djangoapps/course_groups/tests/test_views.py
@@ -29,7 +29,6 @@ from ..cohorts import (
 from .helpers import config_course_cohorts, CohortFactory
 
 
-@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class CohortViewsTestCase(ModuleStoreTestCase):
     """
     Base class which sets up a course and staff/non-staff users.

--- a/openedx/core/djangoapps/user_api/management/tests/test_email_opt_in_list.py
+++ b/openedx/core/djangoapps/user_api/management/tests/test_email_opt_in_list.py
@@ -51,6 +51,8 @@ class EmailOptInListTest(ModuleStoreTestCase):
     DEFAULT_DATETIME_STR = "2014-12-01 00:00:00"
 
     def setUp(self):
+        super(EmailOptInListTest, self).setUp()
+
         self.user = UserFactory.create(
             username=self.USER_USERNAME,
             first_name=self.USER_FIRST_NAME,

--- a/openedx/core/djangoapps/user_api/management/tests/test_email_opt_in_list.py
+++ b/openedx/core/djangoapps/user_api/management/tests/test_email_opt_in_list.py
@@ -24,12 +24,8 @@ from openedx.core.djangoapps.user_api.models import UserOrgTag
 from openedx.core.djangoapps.user_api.management.commands import email_opt_in_list
 
 
-MODULESTORE_CONFIG = mixed_store_config(settings.COMMON_TEST_DATA_ROOT, {}, include_xml=False)
-
-
 @ddt.ddt
 @skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
-@override_settings(MODULESTORE=MODULESTORE_CONFIG)
 class EmailOptInListTest(ModuleStoreTestCase):
     """Tests for the email opt-in list management command. """
 

--- a/openedx/core/djangoapps/user_api/tests/test_models.py
+++ b/openedx/core/djangoapps/user_api/tests/test_models.py
@@ -1,13 +1,13 @@
 from django.db import IntegrityError
-from django.test import TestCase
 from xmodule.modulestore.tests.factories import CourseFactory
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from student.tests.factories import UserFactory
 
 from ..tests.factories import UserPreferenceFactory, UserCourseTagFactory, UserOrgTagFactory
 from ..models import UserPreference
 
 
-class UserPreferenceModelTest(TestCase):
+class UserPreferenceModelTest(ModuleStoreTestCase):
     def test_duplicate_user_key(self):
         user = UserFactory.create()
         UserPreferenceFactory.create(user=user, key="testkey", value="first")

--- a/openedx/core/djangoapps/user_api/tests/test_profile_api.py
+++ b/openedx/core/djangoapps/user_api/tests/test_profile_api.py
@@ -2,13 +2,13 @@
 """ Tests for the profile API. """
 from django.contrib.auth.models import User
 
-from django.test import TestCase
 import ddt
 from django.test.utils import override_settings
 from nose.tools import raises
 from dateutil.parser import parse as parse_datetime
 from pytz import UTC
 from xmodule.modulestore.tests.factories import CourseFactory
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 import datetime
 
 from ..api import account as account_api
@@ -17,7 +17,7 @@ from ..models import UserProfile, UserOrgTag
 
 
 @ddt.ddt
-class ProfileApiTest(TestCase):
+class ProfileApiTest(ModuleStoreTestCase):
 
     USERNAME = u'frank-underwood'
     PASSWORD = u'ṕáśśẃőŕd'

--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -15,6 +15,7 @@ import ddt
 from pytz import UTC
 import mock
 from xmodule.modulestore.tests.factories import CourseFactory
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 
 from student.tests.factories import UserFactory
 from unittest import SkipTest
@@ -1465,7 +1466,7 @@ class RegistrationViewTest(ApiTestCase):
 
 
 @ddt.ddt
-class UpdateEmailOptInTestCase(ApiTestCase):
+class UpdateEmailOptInTestCase(ApiTestCase, ModuleStoreTestCase):
     """Tests the UpdateEmailOptInPreference view. """
 
     USERNAME = "steve"

--- a/pylintrc
+++ b/pylintrc
@@ -19,7 +19,7 @@ persistent=yes
 
 # List of plugins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.
-load-plugins=
+load-plugins=edx_lint.pylint
 
 
 [MESSAGES CONTROL]

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -37,3 +37,4 @@ git+https://github.com/mitocw/django-cas.git@60a5b8e5a62e63e0d5d224a87f0b489201a
 -e git+https://github.com/pmitros/RecommenderXBlock.git@9b07e807c89ba5761827d0387177f71aa57ef056#egg=recommender-xblock
 -e git+https://github.com/edx/edx-milestones.git@547f2250ee49e73ce8d7ff4e78ecf1b049892510#egg=edx-milestones
 -e git+https://github.com/edx/edx-search.git@264bb3317f98e9cb22b932aa11b89d0651fd741c#egg=edx-search
+git+https://github.com/edx/edx-lint.git@65852c0#egg=edx_lint


### PR DESCRIPTION
The existing pattern of using `override_settings(MODULESTORE=...)` prevented
us from having more than one layer of subclassing in modulestore tests.

In a structure like:

```
@override_settings(MODULESTORE=store_a)
class BaseTestCase(ModuleStoreTestCase):
    def setUp(self):
        # use store

@override_settings(MODULESTORE=store_b)
class ChildTestCase(BaseTestCase):
    def setUp(self):
        # use store
```

In this case, the store actions performed in `BaseTestCase` on behalf of
`ChildTestCase` would still use `store_a`, even though the `ChildTestCase`
had specified to use `store_b`. This is because the `override_settings`
decorator would be the innermost wrapper around the `BaseTestCase.setUp` method,
no matter what `ChildTestCase` does.

To remedy this, we move the call to `override_settings` into the
`ModuleStoreTestCase.setUp` method, and use a cleanup to remove the override.
Subclasses can just defined the `MODULESTORE` class attribute to specify which
modulestore to use _for the entire `setUp` chain_.

[PLAT-419]
