### PR TITLE
Fix performance problem with Split course import/export.

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/__init__.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/__init__.py
@@ -21,3 +21,27 @@ class BlockKey(namedtuple('BlockKey', 'type id')):
 
 
 CourseEnvelope = namedtuple('CourseEnvelope', 'course_key structure')
+
+
+class CourseStructure(dict):
+    """
+    Wrap the course structure in an object instead of using a straight Python dictionary.
+    Allows the storing of meta-information about a structure that doesn't persist along with
+    the structure itself.
+    """
+    def __init__(self, *args, **kwargs):
+        super(CourseStructure, self).__init__(*args, **kwargs)
+        # Set of all the loaded definitions.
+        self.definitions_loaded = set()
+
+    def is_definition_loaded(self, block):
+        """
+        Returns True if the block definition has been loaded.
+        """
+        return block in self.definitions_loaded
+
+    def mark_definition_loaded(self, block):
+        """
+        Marks the block definition as loaded.
+        """
+        self.definitions_loaded.add(block)

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/caching_descriptor_system.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/caching_descriptor_system.py
@@ -173,7 +173,9 @@ class CachingDescriptorSystem(MakoDescriptorSystem, EditInfoRuntimeMixin):
             course_key, class_, field, self.course_entry.structure['blocks'],
         )
 
-        if definition_id is not None and not json_data.get('definition_loaded', False):
+        # ALERT: I'm most unsure about this line below! Tests seem to pass - but I'm likely running
+        # afoul of caching since I'm not using json_data?
+        if definition_id is not None and not self.course_entry.structure.is_definition_loaded(block_key):
             definition_loader = DefinitionLazyLoader(
                 self.modulestore,
                 course_key,

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/mongo_connection.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/mongo_connection.py
@@ -8,13 +8,17 @@ import pymongo
 # Import this just to export it
 from pymongo.errors import DuplicateKeyError  # pylint: disable=unused-import
 
-from contracts import check
+from contracts import check, contract, new_contract
 from xmodule.exceptions import HeartbeatFailure
-from xmodule.modulestore.split_mongo import BlockKey
+from xmodule.modulestore.split_mongo import BlockKey, CourseStructure
 import datetime
 import pytz
 
 
+new_contract('CourseStructure', CourseStructure)
+
+
+@contract(returns='CourseStructure')
 def structure_from_mongo(structure):
     """
     Converts the 'blocks' key from a list [block_data] to a map
@@ -37,9 +41,10 @@ def structure_from_mongo(structure):
         new_blocks[BlockKey(block['block_type'], block.pop('block_id'))] = block
     structure['blocks'] = new_blocks
 
-    return structure
+    return CourseStructure(structure)
 
 
+@contract(structure='CourseStructure')
 def structure_to_mongo(structure):
     """
     Converts the 'blocks' key from a map {BlockKey: block_data} to
@@ -165,6 +170,7 @@ class MongoConnection(object):
             })
         ]
 
+    @contract(structure='CourseStructure')
     def insert_structure(self, structure):
         """
         Insert a new structure into the database.


### PR DESCRIPTION
Add CourseStructure object to wrap all course structures loaded from the Split modulestore, in order to separate modulestore-saved structure data from non-saved, temporary metadata.

Eliminate the deepcopy causing performance problems with import/export.

https://openedx.atlassian.net/browse/PLAT-416
