### PR TITLE
Adding ARIA label to selected conversation

### DIFF
--- a/common/static/coffee/src/discussion/views/discussion_thread_list_view.coffee
+++ b/common/static/coffee/src/discussion/views/discussion_thread_list_view.coffee
@@ -243,13 +243,14 @@ if Backbone?
       @trigger("thread:removed", thread_id)
 
     setActiveThread: (thread_id) ->
-      @$(".forum-nav-thread[data-id!='#{thread_id}'] .forum-nav-thread-link").removeClass("is-active").removeAttr('aria-label')
-      @$(".forum-nav-thread[data-id='#{thread_id}'] .forum-nav-thread-link").addClass("is-active").attr('aria-label', 'Current conversation')
+      @$(".forum-nav-thread-link").find(".sr").remove()
+      @$(".forum-nav-thread[data-id!='#{thread_id}'] .forum-nav-thread-link").removeClass("is-active")
+      @$(".forum-nav-thread[data-id='#{thread_id}'] .forum-nav-thread-link").addClass("is-active").find(".forum-nav-thread-wrapper-1").prepend('<span class="sr">' + gettext("Current conversation") + '</span>')
 
     goHome: ->
       @template = _.template($("#discussion-home").html())
       $(".forum-content").html(@template)
-      $(".forum-nav-thread-list a").removeClass("is-active").removeAttr('aria-label')
+      $(".forum-nav-thread-list a").removeClass("is-active").find(".sr").remove()
       $("input.email-setting").bind "click", @updateEmailNotifications
       url = DiscussionUtil.urlFor("notifications_status",window.user.get("id"))
       DiscussionUtil.safeAjax

--- a/common/static/coffee/src/discussion/views/discussion_thread_list_view.coffee
+++ b/common/static/coffee/src/discussion/views/discussion_thread_list_view.coffee
@@ -243,13 +243,13 @@ if Backbone?
       @trigger("thread:removed", thread_id)
 
     setActiveThread: (thread_id) ->
-      @$(".forum-nav-thread[data-id!='#{thread_id}'] .forum-nav-thread-link").removeClass("is-active")
-      @$(".forum-nav-thread[data-id='#{thread_id}'] .forum-nav-thread-link").addClass("is-active")
+      @$(".forum-nav-thread[data-id!='#{thread_id}'] .forum-nav-thread-link").removeClass("is-active").removeAttr('aria-label')
+      @$(".forum-nav-thread[data-id='#{thread_id}'] .forum-nav-thread-link").addClass("is-active").attr('aria-label', 'Current conversation')
 
     goHome: ->
       @template = _.template($("#discussion-home").html())
       $(".forum-content").html(@template)
-      $(".forum-nav-thread-list a").removeClass("is-active")
+      $(".forum-nav-thread-list a").removeClass("is-active").removeAttr('aria-label')
       $("input.email-setting").bind "click", @updateEmailNotifications
       url = DiscussionUtil.urlFor("notifications_status",window.user.get("id"))
       DiscussionUtil.safeAjax


### PR DESCRIPTION
This work pertains to [UX-1575](https://openedx.atlassian.net/browse/UX-1575) and addresses adding an `aria-label` to the current or selected conversation. This does not include sending focus to said conversation. That will be addresses in UX-1576.

I will spin up a sandbox once it's freed up after the current review is complete.

@cptvitamin Would you review when you get time?
@talbs @frrrances Would one of you review the FED here? It's not much.
