### PR TITLE
Fix bugs in CSV download of video upload data

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_videos.py
+++ b/cms/djangoapps/contentstore/views/tests/test_videos.py
@@ -347,7 +347,10 @@ class VideoUrlsCsvTestCase(VideoUploadTestMixin, CourseTestCase):
             actual_video_ids.append(response_video["Video ID"])
             original_video = self._get_previous_upload(response_video["Video ID"])
             self.assertEqual(response_video["Name"], original_video["client_video_id"])
+            self.assertEqual(response_video["Duration"], str(original_video["duration"]))
+            dateutil.parser.parse(response_video["Date Added"])
             self.assertEqual(response_video["Video ID"], original_video["edx_video_id"])
+            self.assertEqual(response_video["Status"], StatusDisplayStrings.get(original_video["status"]))
             for profile in expected_profiles:
                 response_profile_url = response_video["{} URL".format(profile)]
                 original_encoded_for_profile = next(

--- a/cms/djangoapps/contentstore/views/videos.py
+++ b/cms/djangoapps/contentstore/views/videos.py
@@ -153,7 +153,7 @@ def video_encodings_download(request, course_key_string):
                 (duration_col, duration_val),
                 (added_col, video["created"].isoformat()),
                 (video_id_col, video["edx_video_id"]),
-                (status_col, StatusDisplayStrings.get(video["status"])),
+                (status_col, video["status"]),
             ] +
             [
                 (get_profile_header(encoded_video["profile"]), encoded_video["url"])
@@ -177,7 +177,11 @@ def video_encodings_download(request, course_key_string):
     )
     writer = csv.DictWriter(
         response,
-        [name_col, duration_col, added_col, video_id_col, status_col] + profile_cols,
+        [
+            col_name.encode("utf-8")
+            for col_name
+            in [name_col, duration_col, added_col, video_id_col, status_col] + profile_cols
+        ],
         dialect=csv.excel
     )
     writer.writeheader()


### PR DESCRIPTION
This fixes two bugs:
1. All statuses were listed as "Unknown"
2. Non-ASCII characters in a header column translation resulted in a 500

@nasthagiri @BenjiLee please review

@AlasdairSwan FYI
