### PR TITLE
Check access for discussion modules in forums tab

### DIFF
--- a/common/test/acceptance/pages/lms/discussion.py
+++ b/common/test/acceptance/pages/lms/discussion.py
@@ -311,13 +311,15 @@ class DiscussionSortPreferencePage(CoursePage):
 
 
 class DiscussionTabSingleThreadPage(CoursePage):
-    def __init__(self, browser, course_id, thread_id):
+    def __init__(self, browser, course_id, discussion_id, thread_id):
         super(DiscussionTabSingleThreadPage, self).__init__(browser, course_id)
         self.thread_page = DiscussionThreadPage(
             browser,
             "body.discussion .discussion-article[data-id='{thread_id}']".format(thread_id=thread_id)
         )
-        self.url_path = "discussion/forum/dummy/threads/" + thread_id
+        self.url_path = "discussion/forum/{discussion_id}/threads/{thread_id}".format(
+            discussion_id=discussion_id, thread_id=thread_id
+        )
 
     def is_browser_on_page(self):
         return self.thread_page.is_browser_on_page()

--- a/common/test/acceptance/tests/discussion/helpers.py
+++ b/common/test/acceptance/tests/discussion/helpers.py
@@ -5,12 +5,15 @@ Helper functions and classes for discussion tests.
 from uuid import uuid4
 import json
 
+from ...fixtures import LMS_BASE_URL
+from ...fixtures.course import CourseFixture
 from ...fixtures.discussion import (
     SingleThreadViewFixture,
     Thread,
     Response,
 )
-from ...fixtures import LMS_BASE_URL
+from ...pages.lms.discussion import DiscussionTabSingleThreadPage
+from ...tests.helpers import UniqueCourseTest
 
 
 class BaseDiscussionMixin(object):
@@ -83,3 +86,22 @@ class CohortTestMixin(object):
         data = {"users": username}
         response = course_fixture.session.post(url, data=data, headers=course_fixture.headers)
         self.assertTrue(response.ok, "Failed to add user to cohort")
+
+
+class BaseDiscussionTestCase(UniqueCourseTest):
+    def setUp(self):
+        super(BaseDiscussionTestCase, self).setUp()
+
+        self.discussion_id = "test_discussion_{}".format(uuid4().hex)
+        self.course_fixture = CourseFixture(**self.course_info)
+        self.course_fixture.add_advanced_settings(
+            {'discussion_topics': {'value': {'Test Discussion Topic': {'id': self.discussion_id}}}}
+        )
+        self.course_fixture.install()
+
+    def create_single_thread_page(self, thread_id):
+        """
+        Sets up a `DiscussionTabSingleThreadPage` for a given
+        `thread_id`.
+        """
+        return DiscussionTabSingleThreadPage(self.browser, self.course_id, self.discussion_id, thread_id)

--- a/common/test/acceptance/tests/discussion/test_cohorts.py
+++ b/common/test/acceptance/tests/discussion/test_cohorts.py
@@ -3,7 +3,7 @@ Tests related to the cohorting feature.
 """
 from uuid import uuid4
 
-from .helpers import BaseDiscussionMixin
+from .helpers import BaseDiscussionMixin, BaseDiscussionTestCase
 from .helpers import CohortTestMixin
 from ..helpers import UniqueCourseTest
 from ...pages.lms.auto_auth import AutoAuthPage
@@ -57,20 +57,17 @@ class CohortedDiscussionTestMixin(BaseDiscussionMixin, CohortTestMixin):
         self.assertEquals(self.thread_page.get_group_visibility_label(), "This post is visible to everyone.")
 
 
-class DiscussionTabSingleThreadTest(UniqueCourseTest):
+class DiscussionTabSingleThreadTest(BaseDiscussionTestCase):
     """
     Tests for the discussion page displaying a single thread.
     """
     def setUp(self):
         super(DiscussionTabSingleThreadTest, self).setUp()
-        self.discussion_id = "test_discussion_{}".format(uuid4().hex)
-        # Create a course to register for
-        self.course_fixture = CourseFixture(**self.course_info).install()
         self.setup_cohorts()
         AutoAuthPage(self.browser, course_id=self.course_id).visit()
 
     def setup_thread_page(self, thread_id):
-        self.thread_page = DiscussionTabSingleThreadPage(self.browser, self.course_id, thread_id)  # pylint: disable=attribute-defined-outside-init
+        self.thread_page = DiscussionTabSingleThreadPage(self.browser, self.course_id, self.discussion_id, thread_id)  # pylint: disable=attribute-defined-outside-init
         self.thread_page.visit()
 
     # pylint: disable=unused-argument

--- a/lms/djangoapps/django_comment_client/base/tests.py
+++ b/lms/djangoapps/django_comment_client/base/tests.py
@@ -13,7 +13,7 @@ from opaque_keys.edx.locations import SlashSeparatedCourseKey
 from xmodule.modulestore.tests.django_utils import TEST_DATA_MOCK_MODULESTORE
 from django_comment_client.base import views
 from django_comment_client.tests.group_id import CohortedTopicGroupIdTestMixin, NonCohortedTopicGroupIdTestMixin, GroupIdAssertionMixin
-from django_comment_client.tests.utils import CohortedContentTestCase
+from django_comment_client.tests.utils import CohortedTestCase
 from django_comment_client.tests.unicode import UnicodeTestMixin
 from django_comment_common.models import Role
 from django_comment_common.utils import seed_permissions_roles
@@ -41,7 +41,7 @@ class MockRequestSetupMixin(object):
 @patch('lms.lib.comment_client.utils.requests.request')
 class CreateThreadGroupIdTestCase(
         MockRequestSetupMixin,
-        CohortedContentTestCase,
+        CohortedTestCase,
         CohortedTopicGroupIdTestMixin,
         NonCohortedTopicGroupIdTestMixin
 ):
@@ -76,7 +76,7 @@ class CreateThreadGroupIdTestCase(
 @patch('lms.lib.comment_client.utils.requests.request')
 class ThreadActionGroupIdTestCase(
         MockRequestSetupMixin,
-        CohortedContentTestCase,
+        CohortedTestCase,
         GroupIdAssertionMixin
 ):
     def call_view(

--- a/lms/djangoapps/django_comment_client/base/views.py
+++ b/lms/djangoapps/django_comment_client/base/views.py
@@ -120,7 +120,7 @@ def create_thread(request, course_id, commentable_id):
         user = cc.User.from_django_user(request.user)
         user.follow(thread)
     data = thread.to_dict()
-    add_courseware_context([data], course)
+    add_courseware_context([data], course, request.user)
     if request.is_ajax():
         return ajax_content_response(request, course_key, data)
     else:
@@ -149,7 +149,7 @@ def update_thread(request, course_id, thread_id):
         thread.thread_type = request.POST["thread_type"]
     if "commentable_id" in request.POST:
         course = get_course_with_access(request.user, 'load', course_key)
-        commentable_ids = get_discussion_categories_ids(course)
+        commentable_ids = get_discussion_categories_ids(course, request.user)
         if request.POST.get("commentable_id") in commentable_ids:
             thread.commentable_id = request.POST["commentable_id"]
         else:

--- a/lms/djangoapps/django_comment_client/forum/views.py
+++ b/lms/djangoapps/django_comment_client/forum/views.py
@@ -52,7 +52,7 @@ def _attr_safe_json(obj):
 
 
 @newrelic.agent.function_trace()
-def make_course_settings(course):
+def make_course_settings(course, user):
     """
     Generate a JSON-serializable model for course settings, which will be used to initialize a
     DiscussionCourseSettings object on the client.
@@ -63,14 +63,14 @@ def make_course_settings(course):
         'allow_anonymous': course.allow_anonymous,
         'allow_anonymous_to_peers': course.allow_anonymous_to_peers,
         'cohorts': [{"id": str(g.id), "name": g.name} for g in get_course_cohorts(course)],
-        'category_map': utils.get_discussion_category_map(course)
+        'category_map': utils.get_discussion_category_map(course, user)
     }
 
     return obj
 
 
 @newrelic.agent.function_trace()
-def get_threads(request, course_key, discussion_id=None, per_page=THREADS_PER_PAGE):
+def get_threads(request, course, discussion_id=None, per_page=THREADS_PER_PAGE):
     """
     This may raise an appropriate subclass of cc.utils.CommentClientError
     if something goes wrong, or ValueError if the group_id is invalid.
@@ -81,11 +81,18 @@ def get_threads(request, course_key, discussion_id=None, per_page=THREADS_PER_PA
         'sort_key': 'date',
         'sort_order': 'desc',
         'text': '',
-        'commentable_id': discussion_id,
-        'course_id': course_key.to_deprecated_string(),
+        'course_id': unicode(course.id),
         'user_id': request.user.id,
-        'group_id': get_group_id_for_comments_service(request, course_key, discussion_id),  # may raise ValueError
+        'group_id': get_group_id_for_comments_service(request, course.id, discussion_id),  # may raise ValueError
     }
+
+    if discussion_id is not None:
+        default_query_params['commentable_id'] = discussion_id
+    else:
+        default_query_params['commentable_ids'] = ','.join(
+            course.top_level_discussion_topic_ids +
+            utils.get_discussion_id_map(course, request.user).keys()
+        )
 
     if not request.GET.get('sort_key'):
         # If the user did not select a sort key, use their last used sort key
@@ -163,7 +170,7 @@ def inline_discussion(request, course_key, discussion_id):
     user_info = cc_user.to_dict()
 
     try:
-        threads, query_params = get_threads(request, course_key, discussion_id, per_page=INLINE_THREADS_PER_PAGE)
+        threads, query_params = get_threads(request, course, discussion_id, per_page=INLINE_THREADS_PER_PAGE)
     except ValueError:
         return HttpResponseBadRequest("Invalid group_id")
 
@@ -172,7 +179,7 @@ def inline_discussion(request, course_key, discussion_id):
     is_staff = cached_has_permission(request.user, 'openclose_thread', course.id)
     threads = [utils.prepare_content(thread, course_key, is_staff) for thread in threads]
     with newrelic.agent.FunctionTrace(nr_transaction, "add_courseware_context"):
-        add_courseware_context(threads, course)
+        add_courseware_context(threads, course, request.user)
     return utils.JsonResponse({
         'is_commentable_cohorted': is_commentable_cohorted(course_key, discussion_id),
         'discussion_data': threads,
@@ -181,7 +188,7 @@ def inline_discussion(request, course_key, discussion_id):
         'page': query_params['page'],
         'num_pages': query_params['num_pages'],
         'roles': utils.get_role_ids(course_key),
-        'course_settings': make_course_settings(course)
+        'course_settings': make_course_settings(course, request.user)
     })
 
 
@@ -194,13 +201,13 @@ def forum_form_discussion(request, course_key):
     nr_transaction = newrelic.agent.current_transaction()
 
     course = get_course_with_access(request.user, 'load_forum', course_key, check_if_enrolled=True)
-    course_settings = make_course_settings(course)
+    course_settings = make_course_settings(course, request.user)
 
     user = cc.User.from_django_user(request.user)
     user_info = user.to_dict()
 
     try:
-        unsafethreads, query_params = get_threads(request, course_key)   # This might process a search query
+        unsafethreads, query_params = get_threads(request, course)   # This might process a search query
         is_staff = cached_has_permission(request.user, 'openclose_thread', course.id)
         threads = [utils.prepare_content(thread, course_key, is_staff) for thread in unsafethreads]
     except cc.utils.CommentClientMaintenanceError:
@@ -213,7 +220,7 @@ def forum_form_discussion(request, course_key):
         annotated_content_info = utils.get_metadata_for_threads(course_key, threads, request.user, user_info)
 
     with newrelic.agent.FunctionTrace(nr_transaction, "add_courseware_context"):
-        add_courseware_context(threads, course)
+        add_courseware_context(threads, course, request.user)
 
     if request.is_ajax():
         return utils.JsonResponse({
@@ -258,14 +265,20 @@ def single_thread(request, course_key, discussion_id, thread_id):
     """
     Renders a response to display a single discussion thread.
     """
-
     nr_transaction = newrelic.agent.current_transaction()
 
     course = get_course_with_access(request.user, 'load_forum', course_key)
-    course_settings = make_course_settings(course)
+    course_settings = make_course_settings(course, request.user)
     cc_user = cc.User.from_django_user(request.user)
     user_info = cc_user.to_dict()
     is_moderator = cached_has_permission(request.user, "see_all_cohorts", course_key)
+
+    # Verify that the student has access to this thread if belongs to a discussion module
+    accessible_discussion_ids = [
+        module.discussion_id for module in utils.get_accessible_discussion_modules(course, request.user)
+    ]
+    if discussion_id not in set(course.top_level_discussion_topic_ids + accessible_discussion_ids):
+        raise Http404
 
     # Currently, the front end always loads responses via AJAX, even for this
     # page; it would be a nice optimization to avoid that extra round trip to
@@ -294,7 +307,7 @@ def single_thread(request, course_key, discussion_id, thread_id):
             annotated_content_info = utils.get_annotated_content_infos(course_key, thread, request.user, user_info=user_info)
         content = utils.prepare_content(thread.to_dict(), course_key, is_staff)
         with newrelic.agent.FunctionTrace(nr_transaction, "add_courseware_context"):
-            add_courseware_context([content], course)
+            add_courseware_context([content], course, request.user)
         return utils.JsonResponse({
             'content': content,
             'annotated_content_info': annotated_content_info,
@@ -302,13 +315,13 @@ def single_thread(request, course_key, discussion_id, thread_id):
 
     else:
         try:
-            threads, query_params = get_threads(request, course_key)
+            threads, query_params = get_threads(request, course)
         except ValueError:
             return HttpResponseBadRequest("Invalid group_id")
         threads.append(thread.to_dict())
 
         with newrelic.agent.FunctionTrace(nr_transaction, "add_courseware_context"):
-            add_courseware_context(threads, course)
+            add_courseware_context(threads, course, request.user)
 
         for thread in threads:
             # patch for backward compatibility with comments service

--- a/lms/djangoapps/django_comment_client/tests/test_utils.py
+++ b/lms/djangoapps/django_comment_client/tests/test_utils.py
@@ -5,13 +5,12 @@ from pytz import UTC
 
 from django.core.urlresolvers import reverse
 from django.test import TestCase
-from django.test.utils import override_settings
 from edxmako import add_lookup
 import mock
 
-from xmodule.modulestore.tests.django_utils import TEST_DATA_MOCK_MODULESTORE
 from django_comment_client.tests.factories import RoleFactory
 from django_comment_client.tests.unicode import UnicodeTestMixin
+from django_comment_client.tests.utils import ContentGroupTestCase
 import django_comment_client.utils as utils
 from student.tests.factories import UserFactory, CourseEnrollmentFactory
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
@@ -90,7 +89,7 @@ class CoursewareContextTestCase(ModuleStoreTestCase):
     comment client service integration
     """
     def setUp(self):
-        super(CoursewareContextTestCase, self).setUp()
+        super(CoursewareContextTestCase, self).setUp(create_user=True)
 
         self.course = CourseFactory.create(org="TestX", number="101", display_name="Test Course")
         self.discussion1 = ItemFactory.create(
@@ -109,12 +108,12 @@ class CoursewareContextTestCase(ModuleStoreTestCase):
         )
 
     def test_empty(self):
-        utils.add_courseware_context([], self.course)
+        utils.add_courseware_context([], self.course, self.user)
 
     def test_missing_commentable_id(self):
         orig = {"commentable_id": "non-inline"}
         modified = dict(orig)
-        utils.add_courseware_context([modified], self.course)
+        utils.add_courseware_context([modified], self.course, self.user)
         self.assertEqual(modified, orig)
 
     def test_basic(self):
@@ -122,7 +121,7 @@ class CoursewareContextTestCase(ModuleStoreTestCase):
             {"commentable_id": self.discussion1.discussion_id},
             {"commentable_id": self.discussion2.discussion_id}
         ]
-        utils.add_courseware_context(threads, self.course)
+        utils.add_courseware_context(threads, self.course, self.user)
 
         def assertThreadCorrect(thread, discussion, expected_title):  # pylint: disable=invalid-name
             """Asserts that the given thread has the expected set of properties"""
@@ -146,13 +145,29 @@ class CoursewareContextTestCase(ModuleStoreTestCase):
         assertThreadCorrect(threads[1], self.discussion2, "Subsection / Discussion 2")
 
 
-class CategoryMapTestCase(ModuleStoreTestCase):
+class CategoryMapTestMixin(object):
+    """
+    Provides functionality for classes that test
+    `get_discussion_category_map`.
+    """
+    def assert_category_map_equals(self, expected, requesting_user=None):
+        """
+        Call `get_discussion_category_map`, and verify that it returns
+        what is expected.
+        """
+        self.assertEqual(
+            utils.get_discussion_category_map(self.course, requesting_user or self.user),
+            expected
+        )
+
+
+class CategoryMapTestCase(CategoryMapTestMixin, ModuleStoreTestCase):
     """
     Base testcase class for discussion categories for the
     comment client service integration
     """
     def setUp(self):
-        super(CategoryMapTestCase, self).setUp()
+        super(CategoryMapTestCase, self).setUp(create_user=True)
 
         self.course = CourseFactory.create(
             org="TestX", number="101", display_name="Test Course",
@@ -178,17 +193,8 @@ class CategoryMapTestCase(ModuleStoreTestCase):
             **kwargs
         )
 
-    def assertCategoryMapEquals(self, expected):
-        self.assertEqual(
-            utils.get_discussion_category_map(self.course),
-            expected
-        )
-
     def test_empty(self):
-        self.assertEqual(
-            utils.get_discussion_category_map(self.course),
-            {"entries": {}, "subcategories": {}, "children": []}
-        )
+        self.assert_category_map_equals({"entries": {}, "subcategories": {}, "children": []})
 
     def test_configured_topics(self):
         self.course.discussion_topics = {
@@ -198,7 +204,7 @@ class CategoryMapTestCase(ModuleStoreTestCase):
         }
 
         def check_cohorted_topics(expected_ids):
-            self.assertCategoryMapEquals(
+            self.assert_category_map_equals(
                 {
                     "entries": {
                         "Topic A": {"id": "Topic_A", "sort_key": "Topic A", "is_cohorted": "Topic_A" in expected_ids},
@@ -230,7 +236,7 @@ class CategoryMapTestCase(ModuleStoreTestCase):
 
     def test_single_inline(self):
         self.create_discussion("Chapter", "Discussion")
-        self.assertCategoryMapEquals(
+        self.assert_category_map_equals(
             {
                 "entries": {},
                 "subcategories": {
@@ -260,7 +266,7 @@ class CategoryMapTestCase(ModuleStoreTestCase):
 
         def check_cohorted(is_cohorted):
 
-            self.assertCategoryMapEquals(
+            self.assert_category_map_equals(
                 {
                     "entries": {},
                     "subcategories": {
@@ -363,7 +369,7 @@ class CategoryMapTestCase(ModuleStoreTestCase):
         self.create_discussion("Chapter 2 / Section 1 / Subsection 2", "Discussion", start=later)
         self.create_discussion("Chapter 3 / Section 1", "Discussion", start=later)
 
-        self.assertCategoryMapEquals(
+        self.assert_category_map_equals(
             {
                 "entries": {},
                 "subcategories": {
@@ -401,7 +407,7 @@ class CategoryMapTestCase(ModuleStoreTestCase):
         self.create_discussion("Chapter", "Discussion 4", sort_key="C")
         self.create_discussion("Chapter", "Discussion 5", sort_key="B")
 
-        self.assertCategoryMapEquals(
+        self.assert_category_map_equals(
             {
                 "entries": {},
                 "subcategories": {
@@ -453,7 +459,7 @@ class CategoryMapTestCase(ModuleStoreTestCase):
             "Topic B": {"id": "Topic_B", "sort_key": "C"},
             "Topic C": {"id": "Topic_C", "sort_key": "A"}
         }
-        self.assertCategoryMapEquals(
+        self.assert_category_map_equals(
             {
                 "entries": {
                     "Topic A": {"id": "Topic_A", "sort_key": "B", "is_cohorted": False},
@@ -474,7 +480,7 @@ class CategoryMapTestCase(ModuleStoreTestCase):
         self.create_discussion("Chapter", "Discussion C")
         self.create_discussion("Chapter", "Discussion B")
 
-        self.assertCategoryMapEquals(
+        self.assert_category_map_equals(
             {
                 "entries": {},
                 "subcategories": {
@@ -527,7 +533,7 @@ class CategoryMapTestCase(ModuleStoreTestCase):
         self.create_discussion("Chapter B", "Discussion 1")
         self.create_discussion("Chapter A", "Discussion 2")
 
-        self.assertCategoryMapEquals(
+        self.assert_category_map_equals(
             {
                 "entries": {},
                 "subcategories": {
@@ -580,7 +586,7 @@ class CategoryMapTestCase(ModuleStoreTestCase):
         )
 
     def test_ids_empty(self):
-        self.assertEqual(utils.get_discussion_categories_ids(self.course), [])
+        self.assertEqual(utils.get_discussion_categories_ids(self.course, self.user), [])
 
     def test_ids_configured_topics(self):
         self.course.discussion_topics = {
@@ -589,7 +595,7 @@ class CategoryMapTestCase(ModuleStoreTestCase):
             "Topic C": {"id": "Topic_C"}
         }
         self.assertItemsEqual(
-            utils.get_discussion_categories_ids(self.course),
+            utils.get_discussion_categories_ids(self.course, self.user),
             ["Topic_A", "Topic_B", "Topic_C"]
         )
 
@@ -601,7 +607,7 @@ class CategoryMapTestCase(ModuleStoreTestCase):
         self.create_discussion("Chapter 2 / Section 1 / Subsection 2", "Discussion")
         self.create_discussion("Chapter 3 / Section 1", "Discussion")
         self.assertItemsEqual(
-            utils.get_discussion_categories_ids(self.course),
+            utils.get_discussion_categories_ids(self.course, self.user),
             ["discussion1", "discussion2", "discussion3", "discussion4", "discussion5", "discussion6"]
         )
 
@@ -615,8 +621,174 @@ class CategoryMapTestCase(ModuleStoreTestCase):
         self.create_discussion("Chapter 2", "Discussion")
         self.create_discussion("Chapter 2 / Section 1 / Subsection 1", "Discussion")
         self.assertItemsEqual(
-            utils.get_discussion_categories_ids(self.course),
+            utils.get_discussion_categories_ids(self.course, self.user),
             ["Topic_A", "Topic_B", "Topic_C", "discussion1", "discussion2", "discussion3"]
+        )
+
+
+class ContentGroupCategoryMapTestCase(CategoryMapTestMixin, ContentGroupTestCase):
+    """
+    Tests `get_discussion_category_map` on discussion modules which are
+    only visible to some content groups.
+    """
+    def test_staff_user(self):
+        """
+        Verify that the staff user can access the alpha, beta, and
+        global discussion topics.
+        """
+        self.assert_category_map_equals(
+            {
+                'subcategories': {
+                    'Week 1': {
+                        'subcategories': {},
+                        'children': [
+                            'Visible to Alpha',
+                            'Visible to Beta',
+                            'Visible to Everyone'
+                        ],
+                        'entries': {
+                            'Visible to Alpha': {
+                                'sort_key': None,
+                                'is_cohorted': True,
+                                'id': 'alpha_group_discussion'
+                            },
+                            'Visible to Beta': {
+                                'sort_key': None,
+                                'is_cohorted': True,
+                                'id': 'beta_group_discussion'
+                            },
+                            'Visible to Everyone': {
+                                'sort_key': None,
+                                'is_cohorted': True,
+                                'id': 'global_group_discussion'
+                            }
+                        }
+                    }
+                },
+                'children': ['General', 'Week 1'],
+                'entries': {
+                    'General': {
+                        'sort_key': 'General',
+                        'is_cohorted': False,
+                        'id': 'i4x-org-number-course-run'
+                    }
+                }
+            },
+            requesting_user=self.staff_user
+        )
+
+    def test_alpha_user(self):
+        """
+        Verify that the alpha user can access the alpha and global
+        discussion topics.
+        """
+        self.assert_category_map_equals(
+            {
+                'subcategories': {
+                    'Week 1': {
+                        'subcategories': {},
+                        'children': [
+                            'Visible to Alpha',
+                            'Visible to Everyone'
+                        ],
+                        'entries': {
+                            'Visible to Alpha': {
+                                'sort_key': None,
+                                'is_cohorted': True,
+                                'id': 'alpha_group_discussion'
+                            },
+                            'Visible to Everyone': {
+                                'sort_key': None,
+                                'is_cohorted': True,
+                                'id': 'global_group_discussion'
+                            }
+                        }
+                    }
+                },
+                'children': ['General', 'Week 1'],
+                'entries': {
+                    'General': {
+                        'sort_key': 'General',
+                        'is_cohorted': False,
+                        'id': 'i4x-org-number-course-run'
+                    }
+                }
+            },
+            requesting_user=self.alpha_user
+        )
+
+    def test_beta_user(self):
+        """
+        Verify that the beta user can access the beta and global
+        discussion topics.
+        """
+        self.assert_category_map_equals(
+            {
+                'subcategories': {
+                    'Week 1': {
+                        'subcategories': {},
+                        'children': [
+                            'Visible to Beta',
+                            'Visible to Everyone'
+                        ],
+                        'entries': {
+                            'Visible to Beta': {
+                                'sort_key': None,
+                                'is_cohorted': True,
+                                'id': 'beta_group_discussion'
+                            },
+                            'Visible to Everyone': {
+                                'sort_key': None,
+                                'is_cohorted': True,
+                                'id': 'global_group_discussion'
+                            }
+                        }
+                    }
+                },
+                'children': ['General', 'Week 1'],
+                'entries': {
+                    'General': {
+                        'sort_key': 'General',
+                        'is_cohorted': False,
+                        'id': 'i4x-org-number-course-run'
+                    }
+                }
+            },
+            requesting_user=self.beta_user
+        )
+
+    def test_non_cohorted_user(self):
+        """
+        Verify that the non-cohorted user can access the global
+        discussion topic.
+        """
+        self.assert_category_map_equals(
+            {
+                'subcategories': {
+                    'Week 1': {
+                        'subcategories': {},
+                        'children': [
+                            'Visible to Everyone'
+                        ],
+                        'entries': {
+                            'Visible to Everyone': {
+                                'sort_key': None,
+                                'is_cohorted': True,
+                                'id': 'global_group_discussion'
+                            }
+                        }
+                    }
+                },
+                'children': ['General', 'Week 1'],
+                'entries': {
+                    'General': {
+                        'sort_key': 'General',
+                        'is_cohorted': False,
+                        'id': 'i4x-org-number-course-run'
+                    }
+                }
+            },
+            requesting_user=self.non_cohorted_user
         )
 
 

--- a/lms/djangoapps/django_comment_client/tests/utils.py
+++ b/lms/djangoapps/django_comment_client/tests/utils.py
@@ -1,22 +1,28 @@
+"""
+Utilities for tests within the django_comment_client module.
+"""
+from datetime import datetime
 from django.test.utils import override_settings
 from mock import patch
+from pytz import UTC
 
-from openedx.core.djangoapps.course_groups.models import CourseUserGroup
-from xmodule.modulestore.tests.django_utils import TEST_DATA_MOCK_MODULESTORE
+from openedx.core.djangoapps.course_groups.models import CourseUserGroupPartitionGroup
+from openedx.core.djangoapps.course_groups.tests.helpers import CohortFactory
 from django_comment_common.models import Role
 from django_comment_common.utils import seed_permissions_roles
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
-from xmodule.modulestore.tests.factories import CourseFactory
+from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.partitions.partitions import UserPartition, Group
 
 
-class CohortedContentTestCase(ModuleStoreTestCase):
+class CohortedTestCase(ModuleStoreTestCase):
     """
     Sets up a course with a student, a moderator and their cohorts.
     """
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
-        super(CohortedContentTestCase, self).setUp()
+        super(CohortedTestCase, self).setUp()
 
         self.course = CourseFactory.create(
             discussion_topics={
@@ -28,15 +34,13 @@ class CohortedContentTestCase(ModuleStoreTestCase):
                 "cohorted_discussions": ["cohorted_topic"]
             }
         )
-        self.student_cohort = CourseUserGroup.objects.create(
+        self.student_cohort = CohortFactory.create(
             name="student_cohort",
-            course_id=self.course.id,
-            group_type=CourseUserGroup.COHORT
+            course_id=self.course.id
         )
-        self.moderator_cohort = CourseUserGroup.objects.create(
+        self.moderator_cohort = CohortFactory.create(
             name="moderator_cohort",
-            course_id=self.course.id,
-            group_type=CourseUserGroup.COHORT
+            course_id=self.course.id
         )
 
         seed_permissions_roles(self.course.id)
@@ -47,3 +51,82 @@ class CohortedContentTestCase(ModuleStoreTestCase):
         self.moderator.roles.add(Role.objects.get(name="Moderator", course_id=self.course.id))
         self.student_cohort.users.add(self.student)
         self.moderator_cohort.users.add(self.moderator)
+
+
+class ContentGroupTestCase(ModuleStoreTestCase):
+    """
+    Sets up discussion modules visible to content groups 'Alpha' and
+    'Beta', as well as a module visible to all students.  Creates a
+    staff user, users with access to Alpha/Beta (by way of cohorts),
+    and a non-cohorted user with no special access.
+    """
+    def setUp(self):
+        super(ContentGroupTestCase, self).setUp()
+
+        self.course = CourseFactory.create(
+            org='org', number='number', run='run',
+            # This test needs to use a course that has already started --
+            # discussion topics only show up if the course has already started,
+            # and the default start date for courses is Jan 1, 2030.
+            start=datetime(2012, 2, 3, tzinfo=UTC),
+            user_partitions=[
+                UserPartition(
+                    0,
+                    'Content Group Configuration',
+                    '',
+                    [Group(1, 'Alpha'), Group(2, 'Beta')],
+                    scheme_id='cohort'
+                )
+            ],
+            cohort_config={'cohorted': True},
+            discussion_topics={}
+        )
+
+        self.staff_user = UserFactory.create(is_staff=True)
+        self.alpha_user = UserFactory.create()
+        self.beta_user = UserFactory.create()
+        self.non_cohorted_user = UserFactory.create()
+        for user in [self.staff_user, self.alpha_user, self.beta_user, self.non_cohorted_user]:
+            CourseEnrollmentFactory.create(user=user, course_id=self.course.id)
+
+        alpha_cohort = CohortFactory(
+            course_id=self.course.id,
+            name='Cohort Alpha',
+            users=[self.alpha_user]
+        )
+        beta_cohort = CohortFactory(
+            course_id=self.course.id,
+            name='Cohort Beta',
+            users=[self.beta_user]
+        )
+        CourseUserGroupPartitionGroup.objects.create(
+            course_user_group=alpha_cohort,
+            partition_id=self.course.user_partitions[0].id,
+            group_id=self.course.user_partitions[0].groups[0].id
+        )
+        CourseUserGroupPartitionGroup.objects.create(
+            course_user_group=beta_cohort,
+            partition_id=self.course.user_partitions[0].id,
+            group_id=self.course.user_partitions[0].groups[1].id
+        )
+        self.alpha_module = ItemFactory.create(
+            parent_location=self.course.location,
+            category='discussion',
+            discussion_id='alpha_group_discussion',
+            discussion_target='Visible to Alpha',
+            group_access={self.course.user_partitions[0].id: [self.course.user_partitions[0].groups[0].id]}
+        )
+        self.beta_module = ItemFactory.create(
+            parent_location=self.course.location,
+            category='discussion',
+            discussion_id='beta_group_discussion',
+            discussion_target='Visible to Beta',
+            group_access={self.course.user_partitions[0].id: [self.course.user_partitions[0].groups[1].id]}
+        )
+        self.global_module = ItemFactory.create(
+            parent_location=self.course.location,
+            category='discussion',
+            discussion_id='global_group_discussion',
+            discussion_target='Visible to Everyone'
+        )
+        self.course = self.store.get_item(self.course.location)

--- a/lms/djangoapps/django_comment_client/utils.py
+++ b/lms/djangoapps/django_comment_client/utils.py
@@ -17,6 +17,7 @@ from django_comment_client.permissions import check_permissions_by_view, cached_
 from edxmako import lookup_template
 import pystache_custom as pystache
 
+from courseware.access import has_access
 from openedx.core.djangoapps.course_groups.cohorts import get_cohort_by_id, get_cohort_id, is_commentable_cohorted, is_course_cohorted
 from openedx.core.djangoapps.course_groups.models import CourseUserGroup
 from opaque_keys.edx.locations import i4xEncoder
@@ -59,7 +60,12 @@ def has_forum_access(uname, course_id, rolename):
     return role.users.filter(username=uname).exists()
 
 
-def _get_discussion_modules(course):
+# pylint: disable=invalid-name
+def get_accessible_discussion_modules(course, user):
+    """
+    Get all discussion modules within a course which are accessible to
+    the user.
+    """
     all_modules = modulestore().get_items(course.id, qualifiers={'category': 'discussion'})
 
     def has_required_keys(module):
@@ -69,17 +75,23 @@ def _get_discussion_modules(course):
                 return False
         return True
 
-    return filter(has_required_keys, all_modules)
+    return [
+        module for module in all_modules
+        if has_required_keys(module) and has_access(user, 'load', module, course.id)
+    ]
 
 
-def get_discussion_id_map(course):
+def get_discussion_id_map(course, user):
+    """
+    Get metadata about discussion modules visible to the user in a course.
+    """
     def get_entry(module):
         discussion_id = module.discussion_id
         title = module.discussion_target
         last_category = module.discussion_category.split("/")[-1].strip()
         return (discussion_id, {"location": module.location, "title": last_category + " / " + title})
 
-    return dict(map(get_entry, _get_discussion_modules(course)))
+    return dict(map(get_entry, get_accessible_discussion_modules(course, user)))
 
 
 def _filter_unstarted_categories(category_map):
@@ -132,12 +144,14 @@ def _sort_map_entries(category_map, sort_alpha):
     category_map["children"] = [x[0] for x in sorted(things, key=lambda x: x[1]["sort_key"])]
 
 
-def get_discussion_category_map(course):
-    course_id = course.id
-
+def get_discussion_category_map(course, user):
+    """
+    Get a mapping of categories and subcategories that are visible to
+    the user within a course.
+    """
     unexpanded_category_map = defaultdict(list)
 
-    modules = _get_discussion_modules(course)
+    modules = get_accessible_discussion_modules(course, user)
 
     is_course_cohorted = course.is_cohorted
     cohorted_discussion_ids = course.cohorted_discussions
@@ -203,12 +217,12 @@ def get_discussion_category_map(course):
     return _filter_unstarted_categories(category_map)
 
 
-def get_discussion_categories_ids(course):
+def get_discussion_categories_ids(course, user):
     """
     Returns a list of available ids of categories for the course.
     """
     ids = []
-    queue = [get_discussion_category_map(course)]
+    queue = [get_discussion_category_map(course, user)]
     while queue:
         category_map = queue.pop()
         for child in category_map["children"]:
@@ -369,8 +383,11 @@ def extend_content(content):
     return merge_dict(content, content_info)
 
 
-def add_courseware_context(content_list, course):
-    id_map = get_discussion_id_map(course)
+def add_courseware_context(content_list, course, user):
+    """
+    Decorates `content_list` with courseware metadata.
+    """
+    id_map = get_discussion_id_map(course, user)
 
     for content in content_list:
         commentable_id = content['commentable_id']


### PR DESCRIPTION
When populating the 'category' view in the discussion forums, make sure that categories scraped from discussion modules can be accessed by the current user. Also do not allow users without access to a discussion to be direct-linked to a thread in that discussion. Addresses [TNL-650](https://openedx.atlassian.net/browse/TNL-650).
