### PR TITLE
Fix recommenders' bugs: initialization, syntax error, and the incompatibility of the underscore library

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -35,4 +35,4 @@ git+https://github.com/mitocw/django-cas.git@60a5b8e5a62e63e0d5d224a87f0b489201a
 -e git+https://github.com/edx/edx-oauth2-provider.git@0.4.0#egg=oauth2-provider
 -e git+https://github.com/edx/edx-val.git@ba00a5f2e0571e9a3f37d293a98efe4cbca850d5#egg=edx-val
 -e git+https://github.com/edx/edx-milestones.git@4dfe78a2aae9559ccc979746d13a9b67f0ec311e#egg=edx-milestones
--e git+https://github.com/pmitros/RecommenderXBlock.git@a606d00bdf39bd0a4ae9c51773b69b9eb98934ff#egg=recommender-xblock
+-e git+https://github.com/pmitros/RecommenderXBlock.git@9b07e807c89ba5761827d0387177f71aa57ef056#egg=recommender-xblock


### PR DESCRIPTION
@pmitros  I fixed recommender's bug in lms by removing the usage of underscore.js. I think there is some conflict. I also fixed the bug in studio. 
