### PR TITLE
Get user anonymous id via xblock user service.

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_libraries.py
+++ b/cms/djangoapps/contentstore/tests/test_libraries.py
@@ -80,7 +80,9 @@ class LibraryTestCase(ModuleStoreTestCase):
         of a LibraryContent block
         """
         if 'user' not in lib_content_block.runtime._services:  # pylint: disable=protected-access
-            lib_content_block.runtime._services['user'] = Mock(user_id=self.user.id)  # pylint: disable=protected-access
+            mocked_user_service = Mock(user_id=self.user.id).get_current_user.return_value = {}
+            lib_content_block.runtime._services['user'] = mocked_user_service  # pylint: disable=protected-access
+
         handler_url = reverse_usage_url(
             'component_handler',
             lib_content_block.location,

--- a/common/djangoapps/xblock_django/tests/test_user_service.py
+++ b/common/djangoapps/xblock_django/tests/test_user_service.py
@@ -7,6 +7,7 @@ from xblock_django.user_service import (
     ATTR_KEY_IS_AUTHENTICATED,
     ATTR_KEY_USER_ID,
     ATTR_KEY_USERNAME,
+    ATTR_KEY_USER_IS_STAFF,
 )
 from student.models import anonymous_id_for_user
 from student.tests.factories import UserFactory, AnonymousUserFactory
@@ -39,6 +40,7 @@ class UserServiceTestCase(TestCase):
         self.assertEqual(xb_user.full_name, dj_user.profile.name)
         self.assertEqual(xb_user.opt_attrs[ATTR_KEY_USERNAME], dj_user.username)
         self.assertEqual(xb_user.opt_attrs[ATTR_KEY_USER_ID], dj_user.id)
+        self.assertFalse(xb_user.opt_attrs[ATTR_KEY_USER_IS_STAFF])
 
     def test_convert_anon_user(self):
         """

--- a/common/djangoapps/xblock_django/tests/test_user_service.py
+++ b/common/djangoapps/xblock_django/tests/test_user_service.py
@@ -10,7 +10,7 @@ from xblock_django.user_service import (
 )
 from student.models import anonymous_id_for_user
 from student.tests.factories import UserFactory, AnonymousUserFactory
-from opaque_keys.edx.locations import SlashSeparatedCourseKey
+from opaque_keys.edx.keys import CourseKey
 
 
 class UserServiceTestCase(TestCase):
@@ -80,9 +80,10 @@ class UserServiceTestCase(TestCase):
         """
         Tests for anonymous_user_id method returns anonymous user id for a user.
         """
+        course_key = CourseKey.from_string('edX/toy/2012_Fall')
         anon_user_id = anonymous_id_for_user(
             user=self.user,
-            course_id=SlashSeparatedCourseKey('edX', 'toy', '2012_Fall'),
+            course_id=course_key,
             save=True
         )
 

--- a/common/djangoapps/xblock_django/user_service.py
+++ b/common/djangoapps/xblock_django/user_service.py
@@ -2,12 +2,13 @@
 Support for converting a django user to an XBlock user
 """
 from django.contrib.auth.models import User
-from opaque_keys.edx.locations import SlashSeparatedCourseKey
+from opaque_keys.edx.keys import CourseKey
 from xblock.reference.user_service import XBlockUser, UserService
 
 ATTR_KEY_IS_AUTHENTICATED = 'edx-platform.is_authenticated'
 ATTR_KEY_USER_ID = 'edx-platform.user_id'
 ATTR_KEY_USERNAME = 'edx-platform.username'
+ATTR_KEY_USER_IS_STAFF = 'edx-platform.user_is_staff'
 
 
 class DjangoXBlockUserService(UserService):
@@ -17,7 +18,8 @@ class DjangoXBlockUserService(UserService):
     def __init__(self, django_user, **kwargs):
         super(DjangoXBlockUserService, self).__init__(**kwargs)
         self._django_user = django_user
-        self._user_is_staff = kwargs.get('user_is_staff', False)
+        if self._django_user:
+            self._django_user.user_is_staff = kwargs.get('user_is_staff', False)
 
     def get_current_user(self):
         """
@@ -37,7 +39,7 @@ class DjangoXBlockUserService(UserService):
             A unique anonymous_user_id for (user, course) pair.
             None for Non-staff users.
         """
-        if not self._user_is_staff:
+        if not self.get_current_user().opt_attrs.get(ATTR_KEY_USER_IS_STAFF):
             return None
 
         # If we import these in start, it causes the contentstore library tests failed.
@@ -48,7 +50,7 @@ class DjangoXBlockUserService(UserService):
         except User.DoesNotExist:
             return None
 
-        course_id = SlashSeparatedCourseKey.from_deprecated_string(course_id)
+        course_id = CourseKey.from_string(course_id)
         return anonymous_id_for_user(user=user, course_id=course_id, save=False)
 
     def _convert_django_user_to_xblock_user(self, django_user):
@@ -65,6 +67,7 @@ class DjangoXBlockUserService(UserService):
             xblock_user.opt_attrs[ATTR_KEY_IS_AUTHENTICATED] = True
             xblock_user.opt_attrs[ATTR_KEY_USER_ID] = django_user.id
             xblock_user.opt_attrs[ATTR_KEY_USERNAME] = django_user.username
+            xblock_user.opt_attrs[ATTR_KEY_USER_IS_STAFF] = django_user.user_is_staff
         else:
             xblock_user.opt_attrs[ATTR_KEY_IS_AUTHENTICATED] = False
 

--- a/common/djangoapps/xblock_django/user_service.py
+++ b/common/djangoapps/xblock_django/user_service.py
@@ -4,6 +4,7 @@ Support for converting a django user to an XBlock user
 from django.contrib.auth.models import User
 from opaque_keys.edx.keys import CourseKey
 from xblock.reference.user_service import XBlockUser, UserService
+from student.models import anonymous_id_for_user, get_user_by_username_or_email
 
 ATTR_KEY_IS_AUTHENTICATED = 'edx-platform.is_authenticated'
 ATTR_KEY_USER_ID = 'edx-platform.user_id'
@@ -41,9 +42,6 @@ class DjangoXBlockUserService(UserService):
         """
         if not self.get_current_user().opt_attrs.get(ATTR_KEY_USER_IS_STAFF):
             return None
-
-        # If we import these in start, it causes the contentstore library tests failed.
-        from student.models import anonymous_id_for_user, get_user_by_username_or_email
 
         try:
             user = get_user_by_username_or_email(username_or_email=username)

--- a/common/djangoapps/xblock_django/user_service.py
+++ b/common/djangoapps/xblock_django/user_service.py
@@ -1,7 +1,11 @@
 """
 Support for converting a django user to an XBlock user
 """
+from django.contrib.auth.models import User
+
 from xblock.reference.user_service import XBlockUser, UserService
+from student.models import anonymous_id_for_user, get_user_by_username_or_email
+from opaque_keys.edx.locations import SlashSeparatedCourseKey
 
 ATTR_KEY_IS_AUTHENTICATED = 'edx-platform.is_authenticated'
 ATTR_KEY_USER_ID = 'edx-platform.user_id'
@@ -15,12 +19,36 @@ class DjangoXBlockUserService(UserService):
     def __init__(self, django_user, **kwargs):
         super(DjangoXBlockUserService, self).__init__(**kwargs)
         self._django_user = django_user
+        self._user_is_staff = kwargs.get('user_is_staff', False)
 
     def get_current_user(self):
         """
         Returns the currently-logged in user, as an instance of XBlockUser
         """
         return self._convert_django_user_to_xblock_user(self._django_user)
+
+    def get_anonymous_user_id(self, username, course_id):
+        """
+        Get the anonymous user id for a user.
+
+        Args:
+            username(str): username of a user.
+            course_id(str): course id of particular course.
+
+        Returns:
+            A unique anonymous_user_id for (user, course) pair.
+            None for Non-staff users.
+        """
+        if not self._user_is_staff:
+            return None
+
+        try:
+            user = get_user_by_username_or_email(username_or_email=username)
+        except User.DoesNotExist:
+            return None
+
+        course_id = SlashSeparatedCourseKey.from_deprecated_string(course_id)
+        return anonymous_id_for_user(user=user, course_id=course_id, save=False)
 
     def _convert_django_user_to_xblock_user(self, django_user):
         """

--- a/common/djangoapps/xblock_django/user_service.py
+++ b/common/djangoapps/xblock_django/user_service.py
@@ -2,10 +2,8 @@
 Support for converting a django user to an XBlock user
 """
 from django.contrib.auth.models import User
-
-from xblock.reference.user_service import XBlockUser, UserService
-from student.models import anonymous_id_for_user, get_user_by_username_or_email
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
+from xblock.reference.user_service import XBlockUser, UserService
 
 ATTR_KEY_IS_AUTHENTICATED = 'edx-platform.is_authenticated'
 ATTR_KEY_USER_ID = 'edx-platform.user_id'
@@ -41,6 +39,9 @@ class DjangoXBlockUserService(UserService):
         """
         if not self._user_is_staff:
             return None
+
+        # If we import these in start, it causes the contentstore library tests failed.
+        from student.models import anonymous_id_for_user, get_user_by_username_or_email
 
         try:
             user = get_user_by_username_or_email(username_or_email=username)

--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -598,6 +598,8 @@ def get_module_system_for_user(user, field_data_cache,
 
     field_data = LmsFieldData(descriptor._field_data, student_data)  # pylint: disable=protected-access
 
+    user_is_staff = has_access(user, u'staff', descriptor.location, course_id)
+
     system = LmsModuleSystem(
         track_function=track_function,
         render_template=render_to_string,
@@ -644,7 +646,7 @@ def get_module_system_for_user(user, field_data_cache,
             'i18n': ModuleI18nService(),
             'fs': xblock.reference.plugins.FSService(),
             'field-data': field_data,
-            'user': DjangoXBlockUserService(user),
+            'user': DjangoXBlockUserService(user, user_is_staff=user_is_staff),
         },
         get_user_role=lambda: get_user_role(user, course_id),
         descriptor_runtime=descriptor.runtime,
@@ -668,7 +670,7 @@ def get_module_system_for_user(user, field_data_cache,
             make_psychometrics_data_update_handler(course_id, user, descriptor.location)
         )
 
-    system.set(u'user_is_staff', has_access(user, u'staff', descriptor.location, course_id))
+    system.set(u'user_is_staff', user_is_staff)
     system.set(u'user_is_admin', has_access(user, u'staff', 'global'))
 
     # make an ErrorDescriptor -- assuming that the descriptor's system is ok

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -1218,23 +1218,3 @@ class LMSXBlockServiceBindingTest(ModuleStoreTestCase):
         )
         service = runtime.service(descriptor, expected_service)
         self.assertIsNotNone(service)
-
-    @XBlock.register_temp_plugin(PureXBlock, identifier='pure')
-    @ddt.data("user")
-    def test_expected_user_service_exists_with_staff_info(self, expected_service):
-        """
-        Tests that the LMS runtime contains the 'user' service with appropriate staff info.
-        """
-        descriptor = ItemFactory(category="pure", parent=self.course)
-        runtime, _ = render.get_module_system_for_user(
-            self.user,
-            self.field_data_cache,
-            descriptor,
-            self.course.id,
-            self.track_function,
-            self.xqueue_callback_url_prefix,
-            self.request_token
-        )
-        service = runtime.service(descriptor, expected_service)
-        self.assertIsNotNone(service)
-        self.assertTrue(hasattr(service, '_user_is_staff'))

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -1218,3 +1218,23 @@ class LMSXBlockServiceBindingTest(ModuleStoreTestCase):
         )
         service = runtime.service(descriptor, expected_service)
         self.assertIsNotNone(service)
+
+    @XBlock.register_temp_plugin(PureXBlock, identifier='pure')
+    @ddt.data("user")
+    def test_expected_user_service_exists_with_staff_info(self, expected_service):
+        """
+        Tests that the LMS runtime contains the 'user' service with appropriate staff info.
+        """
+        descriptor = ItemFactory(category="pure", parent=self.course)
+        runtime, _ = render.get_module_system_for_user(
+            self.user,
+            self.field_data_cache,
+            descriptor,
+            self.course.id,
+            self.track_function,
+            self.xqueue_callback_url_prefix,
+            self.request_token
+        )
+        service = runtime.service(descriptor, expected_service)
+        self.assertIsNotNone(service)
+        self.assertTrue(hasattr(service, '_user_is_staff'))


### PR DESCRIPTION
The goal of this PR is to get anonymous_user_id for particular user by using their username. For this we've added a method to xblock 'user' service and that method would return anonymous_user_id only if the requester is staff.

https://openedx.atlassian.net/browse/TNL-836
