### PR TITLE
updating bokchoy version

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -25,7 +25,7 @@ git+https://github.com/mitocw/django-cas.git@60a5b8e5a62e63e0d5d224a87f0b489201a
 -e git+https://github.com/edx/codejail.git@2b095e820ff752a108653bb39d518b122f7154db#egg=codejail
 -e git+https://github.com/edx/js-test-tool.git@v0.1.6#egg=js_test_tool
 -e git+https://github.com/edx/event-tracking.git@0.1.0#egg=event-tracking
--e git+https://github.com/edx/bok-choy.git@9fd05383dc434e0275c9874fd50ad14e519448bc#egg=bok_choy
+-e git+https://github.com/edx/bok-choy.git@94430eb3e50e84330b81a3f5bc0ba4cc0171516f#egg=bok_choy
 -e git+https://github.com/edx-solutions/django-splash.git@7579d052afcf474ece1239153cffe1c89935bc4f#egg=django-splash
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
 -e git+https://github.com/edx/edx-ora2.git@release-2015-01-05T12.24#egg=edx-ora2


### PR DESCRIPTION
For https://openedx.atlassian.net/browse/TE-701 

Other changes since the last update of bok choy:
- Added support for faking media device access in Chrome
