### PR TITLE
Add missing sysadmin dashboard unicode cast

### DIFF
--- a/lms/djangoapps/dashboard/sysadmin.py
+++ b/lms/djangoapps/dashboard/sysadmin.py
@@ -425,7 +425,7 @@ class Courses(SysadminDashboardView):
             color = 'blue'
 
         msg = u"<h4 style='color:{0}'>{1}</h4>".format(color, msg_header)
-        msg += "<pre>{0}</pre>".format(escape(ret))
+        msg += u"<pre>{0}</pre>".format(escape(ret))
         return msg
 
     def import_xml_course(self, gitloc, branch):


### PR DESCRIPTION
This was raising 500s on courses with unicode in their `url_name`s and appears to be the only one missing the unicode casting.
