### PR TITLE
Bump XBlock version to include unique default field values

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -21,7 +21,7 @@
 git+https://github.com/mitocw/django-cas.git@60a5b8e5a62e63e0d5d224a87f0b489201a0c695#egg=django-cas
 
 # Our libraries:
--e git+https://github.com/edx/XBlock.git@3682847a91acac6640a330fbe797ef56ce988517#egg=XBlock
+-e git+https://github.com/edx/XBlock.git@0b865f62f2deaa81b77f819b9b7df0303cb0f70c#egg=XBlock
 -e git+https://github.com/edx/codejail.git@2b095e820ff752a108653bb39d518b122f7154db#egg=codejail
 -e git+https://github.com/edx/js-test-tool.git@v0.1.6#egg=js_test_tool
 -e git+https://github.com/edx/event-tracking.git@0.1.0#egg=event-tracking


### PR DESCRIPTION
We have some ongoing work that depends on https://github.com/edx/XBlock/pull/249 (Provide ability to set field to a unique string by default) which has recently been merged, so I'm wondering if we can bump the version of XBlock used in platform to include that change. Would be ideal if this could make it into Birch.

Partner information: not an edX partner - 3rd party-hosted open edX instance
