### PR TITLE
make course requirement as link

### DIFF
--- a/common/djangoapps/util/milestones_helpers.py
+++ b/common/djangoapps/util/milestones_helpers.py
@@ -111,14 +111,19 @@ def get_pre_requisite_courses_not_completed(user, enrolled_courses):
 def get_prerequisite_courses_display(course_descriptor):
     """
     It would retrieve pre-requisite courses, make display strings
-    and return them as list
+    and return list of dictionary with course key as 'key' field
+    and course display name as `display` field.
     """
     pre_requisite_courses = []
     if settings.FEATURES.get('ENABLE_PREREQUISITE_COURSES', False) and course_descriptor.pre_requisite_courses:
         for course_id in course_descriptor.pre_requisite_courses:
             course_key = CourseKey.from_string(course_id)
             required_course_descriptor = modulestore().get_course(course_key)
-            pre_requisite_courses.append(get_course_display_name(required_course_descriptor))
+            prc = {
+                'key': course_key,
+                'display': get_course_display_name(required_course_descriptor)
+            }
+            pre_requisite_courses.append(prc)
     return pre_requisite_courses
 
 

--- a/lms/djangoapps/courseware/tests/test_about.py
+++ b/lms/djangoapps/courseware/tests/test_about.py
@@ -23,6 +23,7 @@ from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 from util.milestones_helpers import (
     set_prerequisite_courses,
     seed_milestone_relationship_types,
+    get_prerequisite_courses_display,
 )
 
 from .helpers import LoginEnrollmentTestCase
@@ -132,9 +133,10 @@ class AboutTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase):
         url = reverse('about_course', args=[unicode(course.id)])
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
-        self.assertIn("<span class=\"important-dates-item-text pre-requisite\">{} {}</span>"
-                      .format(pre_requisite_course.display_org_with_default,
-                              pre_requisite_course.display_number_with_default),
+        pre_requisite_courses = get_prerequisite_courses_display(course)
+        pre_requisite_course_about_url = reverse('about_course', args=[unicode(pre_requisite_courses[0]['key'])])
+        self.assertIn("<span class=\"important-dates-item-text pre-requisite\"><a href=\"{}\">{}</a></span>"
+                      .format(pre_requisite_course_about_url, pre_requisite_courses[0]['display']),
                       resp.content.strip('\n'))
 
     @patch.dict(settings.FEATURES, {'ENABLE_PREREQUISITE_COURSES': True, 'MILESTONES_APP': True})
@@ -168,9 +170,10 @@ class AboutTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase):
         url = reverse('about_course', args=[unicode(course.id)])
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
-        self.assertIn("<span class=\"important-dates-item-text pre-requisite\">{} {}</span>"
-                      .format(pre_requisite_course.display_org_with_default,
-                              pre_requisite_course.display_number_with_default),
+        pre_requisite_courses = get_prerequisite_courses_display(course)
+        pre_requisite_course_about_url = reverse('about_course', args=[unicode(pre_requisite_courses[0]['key'])])
+        self.assertIn("<span class=\"important-dates-item-text pre-requisite\"><a href=\"{}\">{}</a></span>"
+                      .format(pre_requisite_course_about_url, pre_requisite_courses[0]['display']),
                       resp.content.strip('\n'))
 
         url = reverse('about_course', args=[unicode(pre_requisite_course.id)])

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -320,12 +320,19 @@ from edxmako.shortcuts import marketing_link
           % endif
 
           % if pre_requisite_courses:
+          <% prc_target = reverse('about_course', args=[unicode(pre_requisite_courses[0]['key'])]) %>
           <li class="prerequisite-course important-dates-item">
             <i class="icon fa fa-list-ul"></i>
             <p class="important-dates-item-title">${_("Prerequisites")}</p>
             ## Multiple pre-requisite courses are not supported on frontend that's why we are pulling first element
-            <span class="important-dates-item-text pre-requisite">${pre_requisite_courses[0]}</span>
-            <p class="tip">${_("You must successfully complete {course} before you begin this course").format(course=pre_requisite_courses[0])}.</p>
+            <span class="important-dates-item-text pre-requisite"><a href="${prc_target}">${pre_requisite_courses[0]['display']}</a></span>
+            <p class="tip">
+            ${_("You must successfully complete {link_start}{prc_display}{link_end} before you begin this course.").format(
+              link_start='<a href="{}">'.format(prc_target),
+              link_end='</a>',
+              prc_display=pre_requisite_courses[0]['display'],
+            )}
+            </p>
           </li>
           % endif
           % if get_course_about_section(course, "prerequisites"):


### PR DESCRIPTION
@mattdrayer @marcotuts This PR supports [SOL-198](https://openedx.atlassian.net/browse/SOL-198). It would make Prerequisite course display as links on course about page. Clicking on the link would redirect user to about page of pre-requisite course so they can enrol.
