### PR TITLE
fix tolerance rounding error (TNL-904)

### DIFF
--- a/common/lib/capa/capa/tests/test_util.py
+++ b/common/lib/capa/capa/tests/test_util.py
@@ -81,6 +81,29 @@ class UtilTest(unittest.TestCase):
         self.assertFalse(result)
         result = compare_with_tolerance(infinity, infinity, '1.0', False)
         self.assertTrue(result)
+        # Test absolute tolerance for smaller values
+        result = compare_with_tolerance(100.01, 100.0, 0.01, False)
+        self.assertTrue(result)
+        result = compare_with_tolerance(100.001, 100.0, 0.001, False)
+        self.assertTrue(result)
+        result = compare_with_tolerance(100.01, 100.0, '0.01%', False)
+        self.assertTrue(result)
+        result = compare_with_tolerance(100.002, 100.0, 0.001, False)
+        self.assertFalse(result)
+        result = compare_with_tolerance(0.4, 0.44, 0.01, False)
+        self.assertFalse(result)
+        result = compare_with_tolerance(100.01, 100.0, 0.010, False)
+        self.assertTrue(result)
+
+        # Test complex_number instructor_complex
+        result = compare_with_tolerance(0.4, complex(0.44, 0), 0.01, False)
+        self.assertFalse(result)
+        result = compare_with_tolerance(100.01, complex(100.0, 0), 0.010, False)
+        self.assertTrue(result)
+        result = compare_with_tolerance(110.1, complex(100.0, 0), '10.0', False)
+        self.assertFalse(result)
+        result = compare_with_tolerance(111.0, complex(100.0, 0), '10%', True)
+        self.assertTrue(result)
 
     def test_sanitize_html(self):
         """


### PR DESCRIPTION
@Shrhawk ,
@waheedahmed 

This addresses [TNL-904](https://openedx.atlassian.net/browse/TNL-904). If we're comparing float values, we use the [`Decimal`](https://docs.python.org/2/library/decimal.html) class, to avoid rounding issues like this:

```
In [22]: abs(100.01 - 100.0)
Out[22]: 0.010000000000005116
```
