### PR TITLE
Change instances of 'register' to 'enroll'

### DIFF
--- a/lms/templates/shoppingcart/registration_code_receipt.html
+++ b/lms/templates/shoppingcart/registration_code_receipt.html
@@ -51,18 +51,18 @@ from courseware.courses import course_image_url, get_course_about_section
           % elif registered_for_course:
           <% dashboard_url = reverse('dashboard')%>
           <p class="enrollment-text">
-            ${_("You're already registered for this course."
+            ${_("You're already enrolled for this course."
             " Visit your <a href={dashboard_url}>dashboard</a> to see the course.").format(dashboard_url=dashboard_url)}
           </p>
           % elif course_full:
           <% dashboard_url = reverse('dashboard')%>
           <p class="enrollment-text">
-            ${_("The course you are registering for is full.")}
+            ${_("The course you are enrolling for is full.")}
           </p>
           % elif enrollment_closed:
           <% dashboard_url = reverse('dashboard')%>
           <p class="enrollment-text">
-            ${_("The course you are registering for is closed.")}
+            ${_("The course you are enrolling for is closed.")}
           </p>
           % elif redeem_code_error:
           <% dashboard_url = reverse('dashboard')%>

--- a/lms/templates/shoppingcart/registration_code_redemption.html
+++ b/lms/templates/shoppingcart/registration_code_redemption.html
@@ -66,7 +66,7 @@ from courseware.courses import course_image_url, get_course_about_section
           % elif registered_for_course:
           <p class="enrollment-text">
             ${_(
-              "You're already registered for this course. "
+              "You're already enrolled for this course. "
               "Visit your {link_start}dashboard{link_end} to see the course."
             ).format(
               link_start='<a href="{url}">'.format(url=reverse('dashboard')),


### PR DESCRIPTION
The page that appears when you attempt to redeem a code for a course in which you are already enrolled currently reads "You're already registered for this course." Instances of the word "registered" should be changed to "enrolled."

@stephensanchez, could you review this when you get a chance? It's a small copy change, so I don't think it needs two reviews.
