### PR TITLE
Update "paver i18n_dummy" to compile assets

### DIFF
--- a/pavelib/i18n.py
+++ b/pavelib/i18n.py
@@ -63,6 +63,9 @@ def i18n_dummy():
     """
     cmd = "i18n_tool dummy"
     sh(cmd)
+    # Need to then compile the new dummy strings
+    cmd = "i18n_tool generate"
+    sh(cmd)
 
 
 @task


### PR DESCRIPTION
@nedbat @clytwynec can you review?

right now the [i18n guide](http://edx.readthedocs.org/projects/edx-developer-guide/en/latest/internationalization/i18n.html#coverage-testing) instructs to run "i18n_tool dummy" to generate test strings. however you then need to compile the assets to actually get them to show. I think it makes more sense to have the command do that than to have people run 2 separate commands.
