### PR TITLE
fix settings page not handling unicode (TNL-1237)

### DIFF
--- a/cms/templates/settings.html
+++ b/cms/templates/settings.html
@@ -110,14 +110,8 @@ CMS.URL.UPLOAD_ASSET = '${upload_asset_url}';
               <p>${_(
                 'Your course summary page will not be viewable until your course '
                 'has been announced. To provide content for the page and preview '
-                'it, follow the instructions provided by your {manager}.').format(
-                  manager='<abbr title="{program_manager}">{pm}</abbr>'.format(
-                    ## Translators: This is a job title
-                    program_manager=_("Program Manager"),
-                    ## Translators: This is an abbreviation for "Program Manager", which is a job title
-                    pm=_("PM"),
-                  )
-              )}</p>
+                'it, follow the instructions provided by your Program Manager.')
+              }</p>
             </div>
           </div>
           % endif


### PR DESCRIPTION
Addresses an issue—[TNL-1237](https://openedx.atlassian.net/browse/TNL-1237)—where unicode translations of "PM" were breaking an ascii string it was supposed to be interpolated into.

Rather than fix that string, this PR makes the content of the string more clear, with the side effect of circumventing that bug.

There's an additional issue that this brings up. In this case, there were multiple translations of "PM", and we currently don't have the capability to handle multiple translations for one string. A story for that is in the backlog though. (https://openedx.atlassian.net/browse/LOC-67)

@zubair-arbi 
@sarina 
