### PR TITLE
Add cov_args and extra_args to python unittest commands

### DIFF
--- a/pavelib/tests.py
+++ b/pavelib/tests.py
@@ -27,6 +27,8 @@ __test__ = False  # do not collect
     ("failed", "f", "Run only failed tests"),
     ("fail_fast", "x", "Run only failed tests"),
     ("fasttest", "a", "Run without collectstatic"),
+    ('extra_args=', 'e', 'adds as extra args to the test command'),
+    ('cov_args=', 'c', 'adds as args to coverage for the test run'),
     make_option("--verbose", action="store_const", const=2, dest="verbosity"),
     make_option("-q", "--quiet", action="store_const", const=0, dest="verbosity"),
     make_option("-v", "--verbosity", action="count", dest="verbosity", default=1),
@@ -43,6 +45,8 @@ def test_system(options):
         'fail_fast': getattr(options, 'fail_fast', None),
         'fasttest': getattr(options, 'fasttest', None),
         'verbosity': getattr(options, 'verbosity', 1),
+        'extra_args': getattr(options, 'extra_args', ''),
+        'cov_args': getattr(options, 'cov_args', ''),
     }
 
     if test_id:
@@ -73,6 +77,8 @@ def test_system(options):
     ("test_id=", "t", "Test id"),
     ("failed", "f", "Run only failed tests"),
     ("fail_fast", "x", "Run only failed tests"),
+    ('extra_args=', 'e', 'adds as extra args to the test command'),
+    ('cov_args=', 'c', 'adds as args to coverage for the test run'),
     make_option("--verbose", action="store_const", const=2, dest="verbosity"),
     make_option("-q", "--quiet", action="store_const", const=0, dest="verbosity"),
     make_option("-v", "--verbosity", action="count", dest="verbosity", default=1),
@@ -88,6 +94,8 @@ def test_lib(options):
         'failed_only': getattr(options, 'failed', None),
         'fail_fast': getattr(options, 'fail_fast', None),
         'verbosity': getattr(options, 'verbosity', 1),
+        'extra_args': getattr(options, 'extra_args', ''),
+        'cov_args': getattr(options, 'cov_args', ''),
     }
 
     if test_id:
@@ -115,6 +123,8 @@ def test_lib(options):
 @cmdopts([
     ("failed", "f", "Run only failed tests"),
     ("fail_fast", "x", "Run only failed tests"),
+    ('extra_args=', 'e', 'adds as extra args to the test command'),
+    ('cov_args=', 'c', 'adds as args to coverage for the test run'),
     make_option("--verbose", action="store_const", const=2, dest="verbosity"),
     make_option("-q", "--quiet", action="store_const", const=0, dest="verbosity"),
     make_option("-v", "--verbosity", action="count", dest="verbosity", default=1),
@@ -127,6 +137,8 @@ def test_python(options):
         'failed_only': getattr(options, 'failed', None),
         'fail_fast': getattr(options, 'fail_fast', None),
         'verbosity': getattr(options, 'verbosity', 1),
+        'extra_args': getattr(options, 'extra_args', ''),
+        'cov_args': getattr(options, 'cov_args', ''),
     }
 
     python_suite = suites.PythonTestSuite('Python Tests', **opts)

--- a/pavelib/utils/test/suites/nose_suite.py
+++ b/pavelib/utils/test/suites/nose_suite.py
@@ -23,6 +23,8 @@ class NoseTestSuite(TestSuite):
         self.report_dir = Env.REPORT_DIR / self.root
         self.test_id_dir = Env.TEST_DIR / self.root
         self.test_ids = self.test_id_dir / 'noseids'
+        self.extra_args = kwargs.get('extra_args', '')
+        self.cov_args = kwargs.get('cov_args', '')
 
     def __enter__(self):
         super(NoseTestSuite, self).__enter__()
@@ -52,8 +54,9 @@ class NoseTestSuite(TestSuite):
                 cmd0 = "`which {}`".format(cmd0)
 
             cmd = (
-                "python -m coverage run --rcfile={root}/.coveragerc "
+                "python -m coverage run {cov_args} --rcfile={root}/.coveragerc "
                 "{cmd0} {cmd_rest}".format(
+                    cov_args=self.cov_args,
                     root=self.root,
                     cmd0=cmd0,
                     cmd_rest=cmd_rest,
@@ -106,11 +109,12 @@ class SystemTestSuite(NoseTestSuite):
     def cmd(self):
         cmd = (
             './manage.py {system} test --verbosity={verbosity} '
-            '{test_id} {test_opts} --traceback --settings=test'.format(
+            '{test_id} {test_opts} --traceback --settings=test {extra}'.format(
                 system=self.root,
                 verbosity=self.verbosity,
                 test_id=self.test_id,
                 test_opts=self.test_options_flags,
+                extra=self.extra_args,
             )
         )
 
@@ -157,13 +161,14 @@ class LibTestSuite(NoseTestSuite):
     def cmd(self):
         cmd = (
             "nosetests --id-file={test_ids} {test_id} {test_opts} "
-            "--with-xunit --xunit-file={xunit_report} "
+            "--with-xunit --xunit-file={xunit_report} {extra}"
             "--verbosity={verbosity}".format(
                 test_ids=self.test_ids,
                 test_id=self.test_id,
                 test_opts=self.test_options_flags,
                 xunit_report=self.xunit_report,
                 verbosity=self.verbosity,
+                extra=self.extra_args,
             )
         )
 


### PR DESCRIPTION
This adds the options `extra_args` and `cov_args` to the paver commands `test_system`, `test_lib`, and `test_python` (the commands for various python unittests).

`extra_args`:  Works the same as in the bok choy command. It just appends the passed value as to the end of the test command. We may want to use this to split unit tests into different shards.

`cov_args`:  Adds the passed value to the coverage command that is used to collect coverage during the tests. The commands that could be used here are any that can be used with the `coverage run` command. In particular, we may want to use the `-p` flag to generate uniquely named coverage files that will be recognized by `coverage combine`.
