### PR TITLE
Update Footer Copyright Notice as per Legal OPEN-444

### DIFF
--- a/cms/templates/widgets/footer.html
+++ b/cms/templates/widgets/footer.html
@@ -4,7 +4,15 @@
 <div class="wrapper-footer wrapper">
   <footer class="primary" role="contentinfo">
     <div class="colophon">
-      <p>&copy; ${settings.COPYRIGHT_YEAR} <a href="${marketing_link('ROOT')}" rel="external">${settings.PLATFORM_NAME}</a>. ${ _("All rights reserved.")}</p>
+      <p>&copy; ${settings.COPYRIGHT_YEAR} <a href="${marketing_link('ROOT')}" rel="external">${settings.PLATFORM_NAME}</a>.</p>
+      ## Site operators: Please do not remove this paragraph! This attributes back to edX and makes your acknowledgement of edX's trademarks clear.
+      <p>
+	## Translators: 'EdX', 'edX', 'Studio', and 'Open edX' are trademarks of 'edX Inc.'. Please do not translate any of these trademarks and company names.
+	${_("EdX, Open edX, Studio, and the edX and Open edX logos are registered trademarks or trademarks of {link_start}edX Inc.{link_end}").format(
+	  link_start=u"<a href='https://www.edx.org/'>",
+	  link_end=u"</a>"
+	)}
+      </p>
     </div>
 
     <nav class="nav-peripheral">

--- a/lms/templates/footer-edx-new.html
+++ b/lms/templates/footer-edx-new.html
@@ -30,12 +30,17 @@
       </div>
 
       <div class="footer-about-copyright">
-        ## Translators: '&copy;' is an HTML character code for the copyright symbol. Please don't remove or change it.
-        <p>${_("&copy; {copyright_year} {platform_name}, some rights reserved").format(
-          platform_name=settings.PLATFORM_NAME,
-          copyright_year=settings.COPYRIGHT_YEAR
-        )}
-      </p>
+	## Using "edX Inc." explicitly here for copyright purposes (settings.PLATFORM_NAME is just "edX", and this footer is only used on edx.org)
+	<p>&copy; ${settings.COPYRIGHT_YEAR} edX Inc.</p>
+
+	## Site operators: Please do not remove this paragraph! This attributes back to edX and makes your acknowledgement of edX's trademarks clear.
+	<p>
+	  ## Translators: 'EdX', 'edX', and 'Open edX' are trademarks of 'edX Inc.'. Please do not translate any of these trademarks and company names.
+	  ${_("EdX, Open edX, and the edX and Open edX logos are registered trademarks or trademarks of {link_start}edX Inc.{link_end}").format(
+	      link_start=u"<a href='https://www.edx.org/'>",
+	      link_end=u"</a>"
+	  )}
+	</p>
       </div>
 
       <div class="footer-about-links">

--- a/lms/templates/footer.html
+++ b/lms/templates/footer.html
@@ -51,11 +51,15 @@
         </p>
       </div>
 
-      ## Translators: '&copy;' is an HTML character code for the copyright symbol. Please don't remove or change it.
-      <p class="copyright">${_("&copy; {copyright_year} {platform_name}, some rights reserved").format(
-        platform_name=settings.PLATFORM_NAME,
-        copyright_year=settings.COPYRIGHT_YEAR
-      )}
+      <p class="copyright">&copy; ${settings.COPYRIGHT_YEAR} ${settings.PLATFORM_NAME}.</p>
+
+      ## Site operators: Please do not remove this paragraph! This attributes back to edX and makes your acknowledgement of edX's trademarks clear.
+      <p class="copyright">
+	## Translators: 'EdX', 'edX', and 'Open edX' are trademarks of 'edX Inc.'. Please do not translate any of these trademarks and company names.
+	${_("EdX, Open edX, and the edX and Open edX logos are registered trademarks or trademarks of {link_start}edX Inc.{link_end}").format(
+	    link_start=u"<a href='https://www.edx.org/'>",
+	    link_end=u"</a>"
+	)}
       </p>
         <nav class="nav-legal">
           <ul>


### PR DESCRIPTION
As per a conversation I've had with Jennifer from Legal, changing the copyright notices in the LMS and Studio footer to:
1. Sync text between the two
2. Cover our copyright of our names and images, as distinct from the copyright notice on the content. This second note should appear on Open edX instances, to indicate that "edX", "Open edX", and "Studio" names and logos are our trademarks.

LMS Open edX Footer:
![screen shot 2015-01-28 at 7 01 57 pm](https://cloud.githubusercontent.com/assets/1985317/5949836/391ae64a-a720-11e4-9a39-5c8c9fc47084.png)

LMS edx.org Footer:
![screen shot 2015-01-30 at 11 32 12 am](https://cloud.githubusercontent.com/assets/1985317/5979206/b245e07a-a873-11e4-8963-b2575c75dcec.png)

Studio Open edX/edx.org Footer:
![screen shot 2015-01-28 at 7 02 54 pm](https://cloud.githubusercontent.com/assets/1985317/5949845/4a95d236-a720-11e4-9ec9-ff7fe21fdf12.png)

Concurrent task is to sync this copyright update with the Drupal site. I've pinged @ndubbaka on a ticket to represent this work: https://openedx.atlassian.net/browse/ECOM-1005
