### PR TITLE
Added get_course_structure to modulestores

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/__init__.py
+++ b/common/lib/xmodule/xmodule/modulestore/__init__.py
@@ -794,6 +794,18 @@ class ModuleStoreRead(ModuleStoreAssetBase):
         """
         pass
 
+    @abstractmethod
+    def get_course_structure(self, course_id, version=None):
+        """
+        Returns the course structure as a CourseStructure object.
+
+        Args:
+            course_id (CourseKey):
+            version (string): some modulestores hold different versions of courses. A specific version
+                can be specified; otherwise, the latest published version will be returned.
+        """
+        pass
+
 
 # pylint: disable=abstract-method
 class ModuleStoreWrite(ModuleStoreRead, ModuleStoreAssetWriteInterface):
@@ -915,9 +927,9 @@ class ModuleStoreWrite(ModuleStoreRead, ModuleStoreAssetWriteInterface):
 
 # pylint: disable=abstract-method
 class ModuleStoreReadBase(BulkOperationsMixin, ModuleStoreRead):
-    '''
+    """
     Implement interface functionality that can be shared.
-    '''
+    """
 
     # pylint: disable=invalid-name
     def __init__(
@@ -931,9 +943,9 @@ class ModuleStoreReadBase(BulkOperationsMixin, ModuleStoreRead):
         # allow lower level init args to pass harmlessly
         ** kwargs
     ):
-        '''
+        """
         Set up the error-tracking logic.
-        '''
+        """
         super(ModuleStoreReadBase, self).__init__(**kwargs)
         self._course_errors = defaultdict(make_error_tracker)  # location -> ErrorLog
         # pylint: disable=fixme

--- a/common/lib/xmodule/xmodule/modulestore/mixed.py
+++ b/common/lib/xmodule/xmodule/modulestore/mixed.py
@@ -934,3 +934,7 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
         """
         for store in self.modulestores:
             store.ensure_indexes()
+
+    def get_course_structure(self, course_id, version=None):
+        store = self._get_modulestore_for_courselike(course_id)
+        return store.get_course_structure(course_id, version)

--- a/common/lib/xmodule/xmodule/modulestore/models.py
+++ b/common/lib/xmodule/xmodule/modulestore/models.py
@@ -1,0 +1,108 @@
+import copy
+
+
+class EqualityMixin(object):
+    def __eq__(self, other):
+        return isinstance(other, self.__class__) and (self.__dict__ == other.__dict__)
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+
+class Block(EqualityMixin):
+    """
+    Represents a course block/tree node.
+    """
+
+    def __init__(self, usage_key, block_type, display_name=None, format=None, graded=False, children=None):
+        self.usage_key = usage_key
+        self.block_type = block_type
+        self.children = children or []
+        self.display_name = display_name
+        self.format = format
+        self.graded = graded
+
+    def __unicode__(self):
+        return unicode(self.display_name)
+
+    def __str__(self):
+        return unicode(self).encode('utf-8')
+
+    @classmethod
+    def from_dict(cls, d):
+        """
+        Converts a dictionary to a Block object.
+
+        The dictionary MUST have the following format:
+
+        {
+            u'usage_key': u'block-v1:edX+DemoX+2014_T1+type@sequential+block@basic_questions'
+            u'block_type': u'sequential',
+            u'children': [u'block-v1:edX+DemoX+2014_T1+type@vertical+block@2152d4a4aadc4cb0af5256394a3d1fc7',
+                         u'block-v1:edX+DemoX+2014_T1+type@vertical+block@47dbd5f836544e61877a483c0b75606c',
+                         ...],
+           u'display_name': u'Homework - Question Styles',
+           u'format': u'Homework',
+           u'graded': True
+       }
+        """
+        return cls(d[u'id'], d[u'block_type'], d[u'display_name'], d[u'format'], d[u'graded'], d[u'children'])
+
+
+class CourseStructure(EqualityMixin):
+    """
+    Representation of a course's tree structure.
+    """
+
+    def __init__(self, root, blocks, version=None):
+        self.root = root
+        self.blocks = copy.deepcopy(blocks)
+        self.version = version
+
+    def to_dict(self):
+        blocks = {}
+
+        for key, block in self.blocks.iteritems():
+            blocks[key] = block.__dict__
+
+        d = {
+            u'root': self.root,
+            u'version': self.version,
+            u'blocks': blocks
+        }
+
+        return d
+
+    @classmethod
+    def from_dict(cls, d):
+        """
+        Converts a dictionary to a CourseStructure object.
+
+        The dictionary MUST have the following format. Note that the version key is optional.
+        {
+            u'root': u'block-v1:edX+DemoX+2014_T1+type@course+block@course',
+            u'version': '',
+            u'blocks': {
+                u'block-v1:edX+DemoX+2014_T1+type@sequential+block@basic_questions': {
+                    u'usage_key': u'block-v1:edX+DemoX+2014_T1+type@sequential+block@basic_questions',
+                    u'block_type': u'sequential',
+                    u'children': [u'block-v1:edX+DemoX+2014_T1+type@vertical+block@2152d4a4aadc4cb0af5256394a3d1fc7',
+                                 u'block-v1:edX+DemoX+2014_T1+type@vertical+block@47dbd5f836544e61877a483c0b75606c',
+                                 ...],
+                   u'display_name': u'Homework - Question Styles',
+                   u'format': u'Homework',
+                   u'graded': True
+               },
+               ...
+            }
+        }
+        :param d: Dictionary to be converted
+        :return: CourseStructure object
+        """
+        blocks = {}
+        for key, block in d[u'blocks'].iteritems():
+            blocks[key] = Block.from_dict(block)
+
+        structure = cls(d[u'root'], blocks, version=d.get(u'version'))
+
+        return structure

--- a/common/lib/xmodule/xmodule/modulestore/mongo/draft.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/draft.py
@@ -6,21 +6,25 @@ returns the i4x://org/course/cat/name@draft object if that exists,
 and otherwise returns i4x://org/course/cat/name).
 """
 
-import pymongo
 import logging
 
+from bson.son import SON
+import pymongo
 from opaque_keys.edx.locations import Location
+from opaque_keys.edx.locator import BlockUsageLocator
 from xmodule.exceptions import InvalidVersionError
 from xmodule.modulestore import ModuleStoreEnum
+from xmodule.modulestore.draft_and_published import UnsupportedRevisionError, DIRECT_ONLY_CATEGORIES
 from xmodule.modulestore.courseware_index import CoursewareSearchIndexer
 from xmodule.modulestore.exceptions import (
     ItemNotFoundError, DuplicateItemError, DuplicateCourseError, InvalidBranchSetting
 )
+from xmodule.modulestore.models import Block, CourseStructure
 from xmodule.modulestore.mongo.base import (
     MongoModuleStore, MongoRevisionKey, as_draft, as_published, SORT_REVISION_FAVOR_DRAFT
 )
 from xmodule.modulestore.store_utilities import rewrite_nonportable_content_links
-from xmodule.modulestore.draft_and_published import UnsupportedRevisionError, DIRECT_ONLY_CATEGORIES
+
 
 log = logging.getLogger(__name__)
 
@@ -47,6 +51,7 @@ class DraftModuleStore(MongoModuleStore):
     This module also includes functionality to promote DRAFT modules (and their children)
     to published modules.
     """
+
     def get_item(self, usage_key, depth=0, revision=None, **kwargs):
         """
         Returns an XModuleDescriptor instance for the item at usage_key.
@@ -77,6 +82,7 @@ class DraftModuleStore(MongoModuleStore):
             xmodule.modulestore.exceptions.ItemNotFoundError if no object
             is found at that usage_key
         """
+
         def get_published():
             return wrap_draft(super(DraftModuleStore, self).get_item(usage_key, depth=depth))
 
@@ -123,6 +129,7 @@ class DraftModuleStore(MongoModuleStore):
                     if branch setting is ModuleStoreEnum.Branch.published_only, checks for the published item only
                     if branch setting is ModuleStoreEnum.Branch.draft_preferred, checks whether draft or published item exists
         """
+
         def has_published():
             return super(DraftModuleStore, self).has_item(usage_key)
 
@@ -333,6 +340,7 @@ class DraftModuleStore(MongoModuleStore):
                     if the branch setting is ModuleStoreEnum.Branch.draft_preferred,
                         returns either Draft or Published, preferring Draft items.
         """
+
         def base_get_items(key_revision):
             return super(DraftModuleStore, self).get_items(course_key, key_revision=key_revision, **kwargs)
 
@@ -839,6 +847,89 @@ class DraftModuleStore(MongoModuleStore):
                 expected_setting=expected_branch_setting,
                 actual_setting=actual_branch_setting
             )
+
+    def _compute_course_structure(self, course_id):
+        """
+        Computes the course structure.
+
+        The graded and format fields are inherited from their parents if values are not set on the children.
+        """
+        course_id = self.fill_in_run(course_id)
+        query = SON([
+            ('_id.tag', 'i4x'),
+            ('_id.org', course_id.org),
+            ('_id.course', course_id.course)
+        ])
+        # if we're only dealing in the published branch, then only get published containers
+        if self.get_branch_setting() == ModuleStoreEnum.Branch.published_only:
+            query['_id.revision'] = None
+
+        # Limit the fields returned to only those we actually need.
+        fields = ['_id', 'definition.children', 'metadata.display_name', 'metadata.graded', 'metadata.format']
+        record_filter = {}
+        for field in fields:
+            record_filter[field] = 1
+
+        resultset = self.collection.find(query, record_filter)
+
+        root = None
+        blocks = {}
+
+        for result in resultset:
+            location = as_published(Location._from_deprecated_son(result['_id'], course_id.run))
+            metadata = result['metadata']
+            children = result.get('definition', {}).get('children', [])
+
+            # TODO This level of detail should not be here. It is necessary because the display name for certain modules
+            # defaults to a set value. We should find a better method of setting this value.
+            if not metadata.get('display_name'):
+                if location.category == 'video':
+                    metadata['display_name'] = 'Video'
+                elif location.category == 'html':
+                    metadata['display_name'] = 'Text'
+
+            block = Block(unicode(location),
+                          location.category,
+                          display_name=metadata.get('display_name', None),
+                          format=metadata.get('format', None),
+                          graded=metadata.get('graded', None),
+                          children=children)
+
+            if location.category == 'course':
+                root = block.usage_key
+                course = self.get_course(course_id, depth=0)
+                block.display_name = course.display_name
+                block.graded = block.graded or False
+
+            blocks[block.usage_key] = block
+
+        # Ensure any referenced children are actually present (https://openedx.atlassian.net/browse/TNL-1075)
+        keys = blocks.keys()
+        for block in blocks.values():
+            block.children = [child for child in block.children if child in keys]
+
+        # Inherit a few fields
+        inherited_fields = ['format', 'graded']
+
+        def _bequeath_fields(parent_block):
+            if not parent_block.children:
+                return
+
+            for child_key in parent_block.children:
+                child_block = blocks[child_key]
+
+                for field in inherited_fields:
+                    if getattr(child_block, field) is None:
+                        setattr(child_block, field, getattr(parent_block, field))
+
+                _bequeath_fields(child_block)
+
+        _bequeath_fields(blocks[root])
+
+        return CourseStructure(root, blocks, version=self.get_branch_setting())
+
+    def get_course_structure(self, course_id, version=None):  # pylint: disable=unused-argument
+        return self._compute_course_structure(course_id)
 
 
 def _verify_revision_is_published(location):

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_models.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_models.py
@@ -1,0 +1,135 @@
+from unittest import TestCase
+
+from xmodule.modulestore.models import Block, CourseStructure
+
+
+BLOCK_DATA = {
+    'id': 'i4x://edx/DemoX/1234',
+    'block_type': 'sequential',
+    'display_name': 'Some Block',
+    'format': 'Exam',
+    'graded': True,
+    'children': ['i4x://edx/DemoX/abcd']
+}
+
+
+class BlockTests(TestCase):
+    def test_init(self):
+        """
+        Verify that the constructor instantiates a Block object with the correct attributes.
+        """
+        data = BLOCK_DATA
+        _id = data['id']
+        _type = data['block_type']
+
+        # Test the default parameters
+        block = Block(_id, _type)
+        self.assertEqual(block.id, _id)
+        self.assertEqual(block.type, _type)
+        self.assertIsNone(block.display_name)
+        self.assertIsNone(block.format)
+        self.assertFalse(block.graded)
+        self.assertListEqual(block.children, [])
+
+        # Test that values are copied to the model
+        display_name = data['display_name']
+        _format = data['format']
+        graded = data['graded']
+        children = data['children']
+
+        block = Block(_id, _type, display_name, _format, graded, children)
+        self.assertEqual(block.id, _id)
+        self.assertEqual(block.type, _type)
+        self.assertEqual(block.display_name, display_name)
+        self.assertEqual(block.format, _format)
+        self.assertEqual(block.graded, graded)
+        self.assertListEqual(block.children, children)
+
+    def test_equality(self):
+        """
+        Verify the eq and neq methods behave as expected.
+        """
+        data = BLOCK_DATA
+        block = Block.from_dict(data)
+
+        self.assertNotEqual(block, None)
+        self.assertNotEqual(block, Block('abc', '123'))
+
+        other = Block(data['id'], data['block_type'], data['display_name'], data['format'], data['graded'],
+                      data['children'])
+        self.assertEqual(block, block)
+        self.assertEqual(block, other)
+
+    def test_from_dict(self):
+        """
+        Verify that the method properly converts a dictionary to a Block object.
+        """
+        data = BLOCK_DATA
+        block = Block.from_dict(data)
+
+        self.assertEqual(block.id, data['id'])
+        self.assertEqual(block.type, data['block_type'])
+        self.assertEqual(block.display_name, data['display_name'])
+        self.assertEqual(block.format, data['format'])
+        self.assertEqual(block.graded, data['graded'])
+        self.assertListEqual(block.children, data['children'])
+
+    def test_unicode(self):
+        data = BLOCK_DATA
+        block = Block.from_dict(data)
+        self.assertEqual(unicode(block), block.display_name)
+
+
+class CourseStructureTests(TestCase):
+    def test_init(self):
+        """
+        Verify that the constructor instantiates a CourseStructure object with the correct attributes.
+        """
+        root = BLOCK_DATA['id']
+        blocks = {
+            root: Block.from_dict(BLOCK_DATA)
+        }
+
+        cs = CourseStructure(root, blocks)
+
+        self.assertEqual(cs.root, root)
+        self.assertEqual(cs.blocks, blocks)
+        self.assertIsNone(cs.version)
+
+        version = 'abcd'
+        cs = CourseStructure(root, blocks, version=version)
+        self.assertEqual(cs.version, version)
+
+    def test_equality(self):
+        """
+        Verify the eq and neq methods behave as expected.
+        """
+        root = BLOCK_DATA['id']
+        blocks = {
+            root: Block.from_dict(BLOCK_DATA)
+        }
+        cs = CourseStructure(root, blocks)
+
+        self.assertNotEqual(cs, None)
+        self.assertNotEqual(cs, Block('abc', '123'))
+        self.assertNotEqual(cs, CourseStructure('abc', {}))
+
+        self.assertEqual(cs, cs)
+        self.assertEqual(cs, CourseStructure(root, blocks))
+
+    def test_from_dict(self):
+        """
+        Verify that the method properly converts a dictionary to a CourseStructure object.
+        """
+        root = BLOCK_DATA['id']
+        data = {
+            'root': root,
+            'blocks': {
+                root: BLOCK_DATA
+            }
+        }
+        cs = CourseStructure.from_dict(data)
+
+        self.assertEqual(cs.root, root)
+        blocks = {root: Block.from_dict(BLOCK_DATA)}
+        self.assertDictEqual(cs.blocks, blocks)

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore.py
@@ -29,6 +29,7 @@ from xmodule.modulestore.tests.test_modulestore import check_has_course_method
 from xmodule.modulestore.split_mongo import BlockKey
 from xmodule.modulestore.tests.mongo_connection import MONGO_PORT_NUM, MONGO_HOST
 from xmodule.modulestore.edit_info import EditInfoMixin
+from xmodule.modulestore.tests.utils import CourseStructureTestMixin
 
 
 BRANCH_NAME_DRAFT = ModuleStoreEnum.BranchName.draft
@@ -37,11 +38,11 @@ BRANCH_NAME_PUBLISHED = ModuleStoreEnum.BranchName.published
 
 @attr('mongo')
 class SplitModuleTest(unittest.TestCase):
-    '''
+    """
     The base set of tests manually populates a db w/ courses which have
     versions. It creates unique collection names and removes them after all
     tests finish.
-    '''
+    """
     # Snippets of what would be in the django settings envs file
     DOC_STORE_CONFIG = {
         'host': MONGO_HOST,
@@ -468,9 +469,9 @@ class SplitModuleTest(unittest.TestCase):
 
     @staticmethod
     def bootstrapDB(split_store):  # pylint: disable=invalid-name
-        '''
+        """
         Sets up the initial data into the db
-        '''
+        """
         for _course_id, course_spec in SplitModuleTest.COURSE_CONTENT.iteritems():
             course = split_store.create_course(
                 course_spec['org'],
@@ -580,10 +581,10 @@ class TestHasChildrenAtDepth(SplitModuleTest):
         self.assertFalse(ch3.has_children_at_depth(1))
 
 
-class SplitModuleCourseTests(SplitModuleTest):
-    '''
+class SplitModuleCourseTests(CourseStructureTestMixin, SplitModuleTest):
+    """
     Course CRUD operation tests
-    '''
+    """
 
     def test_get_courses(self):
         courses = modulestore().get_courses(branch=BRANCH_NAME_DRAFT)
@@ -638,9 +639,9 @@ class SplitModuleCourseTests(SplitModuleTest):
         )
 
     def test_get_course(self):
-        '''
+        """
         Test the various calling forms for get_course
-        '''
+        """
         locator = CourseLocator(org='testx', course='GreekHero', run="run", branch=BRANCH_NAME_DRAFT)
         head_course = modulestore().get_course(locator)
         self.assertNotEqual(head_course.location.version_guid, head_course.previous_version)
@@ -733,16 +734,28 @@ class SplitModuleCourseTests(SplitModuleTest):
         self.assertEqual(len(result.children[0].children), 1)
         self.assertEqual(result.children[0].children[0].locator.version_guid, versions[0])
 
+    def _get_course_version(self, course_key, ms):
+        course_index = ms.get_course_index(course_key)
+        versions = course_index[u'versions']
+        return versions.get(ModuleStoreEnum.BranchName.published) or versions.get(ModuleStoreEnum.BranchName.draft)
+
+    def test_get_course_structure(self):
+        """
+        Tests the implementation of ModuleStoreRead.get_course_structure.
+        """
+        course_key = CourseLocator(org='testx', course='wonderful', run="run", branch=BRANCH_NAME_PUBLISHED)
+        self.assertValidCourseStructure(course_key, modulestore())
+
 
 class SplitModuleItemTests(SplitModuleTest):
-    '''
+    """
     Item read tests including inheritance
-    '''
+    """
 
     def test_has_item(self):
-        '''
+        """
         has_item(BlockUsageLocator)
-        '''
+        """
         org = 'testx'
         course = 'GreekHero'
         run = 'run'

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_xml.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_xml.py
@@ -11,6 +11,7 @@ from xmodule.modulestore.xml import XMLModuleStore
 from xmodule.modulestore import ModuleStoreEnum
 
 from xmodule.tests import DATA_DIR
+from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
 from xmodule.modulestore.tests.test_modulestore import check_has_course_method
 
@@ -138,3 +139,12 @@ class TestXMLModuleStore(unittest.TestCase):
         other_parent = store.get_item(other_parent_loc)
         # children rather than get_children b/c the instance returned by get_children != shared_item
         self.assertIn(shared_item_loc, other_parent.children)
+
+    def test_get_course_structure(self):
+        """
+        Tests the implementation of ModuleStoreRead.get_course_structure.
+        """
+        # The XML modulestore does not support this method and should raise an exception when called.
+        store = XMLModuleStore(DATA_DIR, course_dirs=[])
+        course_key = CourseKey.from_string('edX/DemoX/Demo_Course')
+        self.assertRaises(NotImplementedError, store.get_course_structure, [course_key])

--- a/common/lib/xmodule/xmodule/modulestore/tests/utils.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/utils.py
@@ -3,6 +3,7 @@ Helper classes and methods for running modulestore tests without Django.
 """
 from importlib import import_module
 from opaque_keys.edx.keys import UsageKey
+from opaque_keys.edx.locator import BlockUsageLocator
 from unittest import TestCase
 from xblock.fields import XBlockMixin
 from xmodule.modulestore import ModuleStoreEnum
@@ -10,6 +11,7 @@ from xmodule.modulestore.draft_and_published import ModuleStoreDraftAndPublished
 from xmodule.modulestore.edit_info import EditInfoMixin
 from xmodule.modulestore.inheritance import InheritanceMixin
 from xmodule.modulestore.mixed import MixedModuleStore
+from xmodule.modulestore.models import Block, CourseStructure
 from xmodule.modulestore.tests.factories import ItemFactory
 from xmodule.modulestore.tests.mongo_connection import MONGO_PORT_NUM, MONGO_HOST
 from xmodule.tests import DATA_DIR
@@ -132,3 +134,58 @@ class MixedSplitTestCase(TestCase):
             modulestore=self.store,
             **extra
         )
+
+
+class CourseStructureTestMixin(object):
+    """
+    Mixin used to help test implementations of implementation of ModuleStoreRead.get_course_structure.
+    """
+    def _add_item_to_structure(self, modulestore, locator, structure):
+        item = modulestore.get_item(locator)
+        locator_string = unicode(locator)
+        block = {
+            u'id': locator_string,
+            u'block_type': item.category,
+            u'display_name': item.display_name or item.name,
+            u'format': getattr(item, 'format', None),
+            u'graded': getattr(item, 'graded', False),
+            u'children': []
+        }
+
+        if item.has_children:
+            block[u'children'] = [unicode(child) for child in item.children]
+
+        structure[locator_string] = Block.from_dict(block)
+
+        if item.has_children:
+            for child in item.children:
+                self._add_item_to_structure(modulestore, child, structure)
+
+    def _get_course_version(self, course_key, modulestore):  # pylint: disable=unused-argument
+        return modulestore.get_branch_setting()
+
+    def assertValidCourseStructure(self, course_key, modulestore):
+        """
+        Verifies that the course structure returned by a module store is valid.
+        """
+        actual = modulestore.get_course_structure(course_key)
+
+        course = modulestore.get_course(course_key, depth=None)
+        course_locator_string = unicode(BlockUsageLocator(course_key, 'course', course.scope_ids.usage_id.block_id))
+        blocks = {
+            course_locator_string: Block.from_dict({
+                u'id': course_locator_string,
+                u'block_type': u'course',
+                u'display_name': course.display_name,
+                u'format': None,
+                u'graded': False,
+                u'children': [unicode(child) for child in course.children]
+            })
+        }
+
+        for child in course.children:
+            self._add_item_to_structure(modulestore, child, blocks)
+
+        expected = CourseStructure(course_locator_string, blocks,
+                                   version=self._get_course_version(course_key, modulestore))
+        self.assertEqual(actual, expected)

--- a/common/lib/xmodule/xmodule/modulestore/xml.py
+++ b/common/lib/xmodule/xmodule/modulestore/xml.py
@@ -793,3 +793,8 @@ class XMLModuleStore(ModuleStoreReadBase):
         """
         log.warning("get_all_asset_metadata request of XML modulestore - not implemented.")
         return []
+
+    def get_course_structure(self, course_id, version=None):
+        # This method will not be implemented for this modulestore. If you need this method, consider using
+        # a supported modulestore.
+        raise NotImplementedError


### PR DESCRIPTION
This commit adds the get_course_structure to the various modulestores.

TODO:
- Fix inheritance issues for the draft store
- Fix tests: invalid course URL for split

@ormsbee @cpennington @doctoryes Please share your feedback on this first pass. I'd also appreciate any help you can offer regarding retrieving non-inherited data--display_name, format--for the draft store.
