### PR TITLE
Fix flaky bok-choy tests caused by malformed URL

### DIFF
--- a/common/test/acceptance/pages/lms/pay_and_verify.py
+++ b/common/test/acceptance/pages/lms/pay_and_verify.py
@@ -55,7 +55,7 @@ class PaymentAndVerificationFlow(PageObject):
     @property
     def url(self):
         """Return the URL corresponding to the initial position in the flow."""
-        url = "{base}/verify_student/{entry_point}/{course}".format(
+        url = "{base}/verify_student/{entry_point}/{course}/".format(
             base=BASE_URL,
             entry_point=self._entry_point,
             course=self._course_id

--- a/common/test/acceptance/tests/lms/test_lms.py
+++ b/common/test/acceptance/tests/lms/test_lms.py
@@ -273,7 +273,6 @@ class PayAndVerifyTest(UniqueCourseTest):
         # Add a verified mode to the course
         ModeCreationPage(self.browser, self.course_id, mode_slug=u'verified', mode_display_name=u'Verified Certificate', min_price=10, suggested_prices='10,20').visit()
 
-    @skip('flaky ECOM-1007')
     def test_immediate_verification_enrollment(self):
         # Create a user and log them in
         AutoAuthPage(self.browser).visit()


### PR DESCRIPTION
@jzoldak this addresses [ECOM-1007](https://openedx.atlassian.net/browse/ECOM-1007) and removes the skip added in #6813. I should have caught this in #6769 but didn't; the description on that PR has more information about the issue at play here and why this should fix it.
