### PR TITLE
ECOM-990: Fix the redemption codes to allow upgrading course modes.

### DIFF
--- a/lms/djangoapps/shoppingcart/tests/test_views.py
+++ b/lms/djangoapps/shoppingcart/tests/test_views.py
@@ -550,6 +550,33 @@ class ShoppingCartViewsTests(ModuleStoreTestCase):
         self.assertEqual(resp.status_code, 400)
         self.assertIn("Oops! The code '{0}' you entered is either invalid or expired".format(self.reg_code), resp.content)
 
+    def test_upgrade_from_valid_reg_code(self):
+        """Use a valid registration code to upgrade from honor to verified mode. """
+        # Ensure the course has a verified mode
+        course_key = self.course_key.to_deprecated_string()
+        self._add_course_mode(mode_slug='verified')
+        self.add_reg_code(course_key, mode_slug='verified')
+
+        # Enroll as honor in the course with the current user.
+        CourseEnrollment.enroll(self.user, self.course_key)
+        self.login_user()
+        current_enrollment, __ = CourseEnrollment.enrollment_mode_for_user(self.user, self.course_key)
+        self.assertEquals('honor', current_enrollment)
+
+        redeem_url = reverse('register_code_redemption', args=[self.reg_code])
+        response = self.client.get(redeem_url)
+        self.assertEquals(response.status_code, 200)
+        # check button text
+        self.assertTrue('Activate Course Enrollment' in response.content)
+
+        #now activate the user by enrolling him/her to the course
+        response = self.client.post(redeem_url)
+        self.assertEquals(response.status_code, 200)
+
+        # Once upgraded, should be "verified"
+        current_enrollment, __ = CourseEnrollment.enrollment_mode_for_user(self.user, self.course_key)
+        self.assertEquals('verified', current_enrollment)
+
     @patch('shoppingcart.views.log.debug')
     def test_non_existing_coupon_redemption_on_removing_item(self, debug_log):
 


### PR DESCRIPTION
https://openedx.atlassian.net/browse/ECOM-990
100% discount enrollment codes will allow users with generated codes to enroll in a paid course with a full discount. This feature is in production but not currently available, as it is hidden behind Course Access Roles which have not been given to any users.

Testing this feature, we discovered that a user cannot 'upgrade' from 'honor' to 'verified'. They will attempt to use the enrollment code and get a warning that "They are already enrolled."

This PR resolves the issue. When a user hits the URL that allows the use of an enrollment code, we will check to see if the user has an active enrollment in the course, and if the mode associated with the code is different from that of the current role.

There is an assumption in our data model that any course can only have one 'paid' course mode. An enrollment code must be associated with a paid mode. This means if the current enrollment is a different mode than the mode associated with the code, it will be an upgrade. This assumption is being made to avoid hard coding any assumptions about the relationship between 'honor' 'verified', 'audit', 'professional', etc. 

Please review when able: @wedaly @rlucioni @dianakhuang 
