### PR TITLE
Fix "No data to report" coverage errors in bok choy tests

### DIFF
--- a/pavelib/utils/process.py
+++ b/pavelib/utils/process.py
@@ -104,4 +104,7 @@ def run_background_process(cmd, out_log=None, err_log=None, cwd=None):
         for child_pid in child_pids:
             os.kill(child_pid.pid, signal.SIGINT)
 
+        # Wait for process to actually finish
+        proc.wait()
+
     atexit.register(exit_handler)


### PR DESCRIPTION
Occasionally the bok choy tests pass but a shard fails generating coverage reports.  The issue seems to be that `coverage combine` is run before the servers actually finish shutting down.  Since the reports are generated when the server process is complete, there is no data to combine at that time.  This change makes it so that we wait for the services to shut down before moving on.

@benpatterson @jzoldak 
