### PR TITLE
Discussion forum should be independent of mathjax 

### DIFF
--- a/common/static/coffee/src/discussion/views/discussion_thread_profile_view.coffee
+++ b/common/static/coffee/src/discussion/views/discussion_thread_profile_view.coffee
@@ -10,7 +10,8 @@ if Backbone?
       @$el.html(Mustache.render(@template, params))
       @$("span.timeago").timeago()
       element = @$(".post-body")
-      MathJax.Hub.Queue ["Typeset", MathJax.Hub, element[0]]
+      if MathJax?
+        MathJax.Hub.Queue ["Typeset", MathJax.Hub, element[0]]
       @
 
     convertMath: ->

--- a/common/static/coffee/src/discussion/views/discussion_thread_show_view.coffee
+++ b/common/static/coffee/src/discussion/views/discussion_thread_show_view.coffee
@@ -32,7 +32,8 @@ if Backbone?
     convertMath: ->
       element = @$(".post-body")
       element.html DiscussionUtil.postMathJaxProcessor DiscussionUtil.markdownWithHighlight element.text()
-      MathJax.Hub.Queue ["Typeset", MathJax.Hub, element[0]]
+      if MathJax?
+        MathJax.Hub.Queue ["Typeset", MathJax.Hub, element[0]]
 
     edit: (event) ->
       @trigger "thread:edit", event

--- a/common/static/coffee/src/discussion/views/response_comment_show_view.coffee
+++ b/common/static/coffee/src/discussion/views/response_comment_show_view.coffee
@@ -33,7 +33,8 @@ if Backbone?
     convertMath: ->
       body = @$el.find(".response-body")
       body.html DiscussionUtil.postMathJaxProcessor DiscussionUtil.markdownWithHighlight body.text()
-      MathJax.Hub.Queue ["Typeset", MathJax.Hub, body[0]]
+      if MathJax?
+        MathJax.Hub.Queue ["Typeset", MathJax.Hub, body[0]]
 
     _delete: (event) =>
         @trigger "comment:_delete", event

--- a/common/static/coffee/src/discussion/views/thread_response_show_view.coffee
+++ b/common/static/coffee/src/discussion/views/thread_response_show_view.coffee
@@ -27,7 +27,8 @@ if Backbone?
     convertMath: ->
       element = @$(".response-body")
       element.html DiscussionUtil.postMathJaxProcessor DiscussionUtil.markdownWithHighlight element.text()
-      MathJax.Hub.Queue ["Typeset", MathJax.Hub, element[0]]
+      if MathJax?
+        MathJax.Hub.Queue ["Typeset", MathJax.Hub, element[0]]
 
     edit: (event) ->
         @trigger "response:edit", event

--- a/common/templates/mathjax_include.html
+++ b/common/templates/mathjax_include.html
@@ -12,6 +12,7 @@
     tex2jax: {inlineMath: [ ['$','$'], ["\\(","\\)"]],
               displayMath: [ ['$$','$$'], ["\\[","\\]"]]}
   });
+  HUB = MathJax.Hub
 </script>
 %else:
 <script type="text/x-mathjax-config">
@@ -27,6 +28,7 @@
       ]
     }
   });
+  HUB = MathJax.Hub
 </script>
 %endif
 

--- a/lms/static/coffee/src/customwmd.coffee
+++ b/lms/static/coffee/src/customwmd.coffee
@@ -2,11 +2,6 @@
 
 $ ->
 
-  if not MathJax?
-    return
-
-  HUB = MathJax.Hub
-
   class MathJaxProcessor
 
     MATHSPLIT = /// (
@@ -116,10 +111,11 @@ $ ->
     Markdown.getMathCompatibleConverter = (postProcessor) ->
       postProcessor ||= ((text) -> text)
       converter = Markdown.getSanitizingConverter()
-      processor = new MathJaxProcessor()
-      converter.hooks.chain "preConversion", MathJaxProcessor.removeMathWrapper(processor)
-      converter.hooks.chain "postConversion", (text) ->
-        postProcessor(MathJaxProcessor.replaceMathWrapper(processor)(text))
+      if MathJax?
+        processor = new MathJaxProcessor()
+        converter.hooks.chain "preConversion", MathJaxProcessor.removeMathWrapper(processor)
+        converter.hooks.chain "postConversion", (text) ->
+          postProcessor(MathJaxProcessor.replaceMathWrapper(processor)(text))
       converter
 
     Markdown.makeWmdEditor = (elem, appended_id, imageUploadUrl, postProcessor) ->

--- a/lms/static/coffee/src/mathjax_delay_renderer.coffee
+++ b/lms/static/coffee/src/mathjax_delay_renderer.coffee
@@ -57,7 +57,7 @@ class @MathJaxDelayRenderer
         @$buffer.html(text)
         curTime = getTime()
         @elapsedTime = curTime - prevTime
-        if MathJax
+        if MathJax?
           prevTime = getTime()
           @mathjaxRunning = true
           MathJax.Hub.Queue ["Typeset", MathJax.Hub, @$buffer.attr("id")], =>


### PR DESCRIPTION
When mathjax is down discussion forum doesn't work 
as we were using markdown.js with processor as 
mathjax. Unavailability of mathjax raise error in 
js which stops discussion to render. So I made 
markdown independent of mathjax. Markdown now will 
use mathjax when it is available otherwise ignore it.

TNL-1149
