### PR TITLE
don't add xblock with 'detached' tag as direct child of course for split...

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
@@ -1513,6 +1513,10 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
                 user_id, parent_usage_key.course_key, block_type, block_id=block_id, fields=fields,
                 **kwargs)
 
+            # skip attach to parent if xblock has 'detached' tag
+            if 'detached' in xblock._class_tags:    # pylint: disable=protected-access
+                return xblock
+
             # don't version the structure as create_item handled that already.
             new_structure = self._lookup_course(xblock.location.course_key).structure
 

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_mixed_modulestore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_mixed_modulestore.py
@@ -840,6 +840,27 @@ class TestMixedModuleStore(CourseComparisonTest):
             published_courses = self.store.get_courses(remove_branch=True)
         self.assertEquals([c.id for c in draft_courses], [c.id for c in published_courses])
 
+    @ddt.data('draft', 'split')
+    def test_create_child_detached_tabs(self, default_ms):
+        """
+        test 'create_child' method with a detached category ('static_tab')
+        to check that new static tab is not a direct child of the course
+        """
+        self.initdb(default_ms)
+        mongo_course = self.store.get_course(self.course_locations[self.MONGO_COURSEID].course_key)
+        self.assertEqual(len(mongo_course.children), 1)
+
+        # create a static tab of the course
+        self.store.create_child(
+            self.user_id,
+            self.course.location,
+            'static_tab'
+        )
+
+        # now check that the course has same number of children
+        mongo_course = self.store.get_course(self.course_locations[self.MONGO_COURSEID].course_key)
+        self.assertEqual(len(mongo_course.children), 1)
+
     def test_xml_get_courses(self):
         """
         Test that the xml modulestore only loaded the courses from the maps.


### PR DESCRIPTION
... in 'create_child' method

PLAT-420

While creating an item with 'create_child' method of split modulestore, the new item was added as child of parent without checking that it's category has 'detached' tag.
So if a user creates a xblock with 'detached' category like 'static_tab' it was added as a direct child of the course and that static tab starts showing on course outline in Studio.

Added a condition to check if xblock has 'detached' tag before adding as child to parent in 'create_child' method of split modulestore (like modulestore https://github.com/edx/edx-platform/blob/master/common/lib/xmodule/xmodule/modulestore/mongo/base.py#L1236).
