### PR TITLE
Make invoice transaction comments optional

### DIFF
--- a/lms/djangoapps/shoppingcart/models.py
+++ b/lms/djangoapps/shoppingcart/models.py
@@ -911,6 +911,7 @@ class InvoiceTransaction(TimeStampedModel):
     )
     comments = models.TextField(
         null=True,
+        blank=True,
         help_text=ugettext_lazy("Optional: provide additional information for this transaction")
     )
     status = models.CharField(


### PR DESCRIPTION
Small fixup to the admin UI for invoice transactions.  Previously, saving the transaction would show a validation error if the comments field was blank.
