### PR TITLE
Default search engine to None

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -873,7 +873,7 @@ FILES_AND_UPLOAD_TYPE_FILTERS = {
 }
 
 # Default to no Search Engine
-SEARCH_ENGINE = "search.tests.mock_search_engine.MockSearchEngine"
+SEARCH_ENGINE = None
 ELASTIC_FIELD_MAPPINGS = {
     "start_date": {
         "type": "date"

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2014,6 +2014,6 @@ PDF_RECEIPT_COBRAND_LOGO_PATH = PROJECT_ROOT + '/static/images/default-theme/log
 PDF_RECEIPT_COBRAND_LOGO_HEIGHT_MM = 12
 
 # Use None for the default search engine
-SEARCH_ENGINE = "search.tests.mock_search_engine.MockSearchEngine"
+SEARCH_ENGINE = None
 # Use the LMS specific result processor
 SEARCH_RESULT_PROCESSOR = "lms.lib.courseware_search.lms_result_processor.LmsSearchResultProcessor"


### PR DESCRIPTION
, so that all search/indexing operations are disabled until enabled. This avoids having the mock index active in configurations until searching/indexing is turned ON.

@chrisndodge, @singingwolfboy, @andy-armstrong - with apologies that I missed this with full commit.
