### PR TITLE
Fixes broken answer and endorse icons on discussion forums

### DIFF
--- a/common/static/coffee/spec/discussion/discussion_spec_helper.coffee
+++ b/common/static/coffee/spec/discussion/discussion_spec_helper.coffee
@@ -546,7 +546,7 @@ browser and pasting the output.  When that file changes, this one should be rege
         <li class="actions-item">
             <a href="javascript:void(0)" class="action-list-item action-edit" role="button">
                 <span class="action-label">Edit</span>
-                <span class="action-icon"><i class="icon fa fa-pencil-square-o"></i></span>
+                <span class="action-icon"><i class="icon fa fa-pencil"></i></span>
             </a>
         </li>
     </script>

--- a/lms/templates/discussion/_underscore_templates.html
+++ b/lms/templates/discussion/_underscore_templates.html
@@ -514,8 +514,8 @@
     </script>
 </%def>
 
-${primaryAction("endorse", "ok", _("Endorse"), _("Endorse"), _("Unendorse"))}
-${primaryAction("answer", "ok", _("Mark as Answer"), _("Mark as Answer"), _("Unmark as Answer"))}
+${primaryAction("endorse", "check", _("Endorse"), _("Endorse"), _("Unendorse"))}
+${primaryAction("answer", "check", _("Mark as Answer"), _("Mark as Answer"), _("Unmark as Answer"))}
 ${primaryAction("follow", "star", _("Follow"), _("Follow"), _("Unfollow"))}
 
 <script type="text/template" id="forum-action-vote">
@@ -571,7 +571,7 @@ ${secondaryStateAction("close", "lock", _("Close"), _("Close"), _("Open"))}
     </script>
 </%def>
 
-${secondaryAction("edit", "pencil-square-o", _("Edit"))}
+${secondaryAction("edit", "pencil", _("Edit"))}
 ${secondaryAction("delete", "remove", _("Delete"))}
 
 <script type="text/template" id="forum-actions">


### PR DESCRIPTION
Tentative fix for the discussion forum endorse and answer action icons. Currently unable to preview this locally due to a devstack issue. 

Product Review: @explorerleslie - No ticket created yet for this, but I wanted to flag this as a T&L related bug that would be good to have someone review at some point. This is a result of the font-awesome upgrade, and is currently an issue on production for Discussion & Question post types. The way the code was setting the icon type is different from most of the other cases on edx-platform, which made this one easy to slip by. 

Also changes the small icon in the edit menu to use the pencil (making it easier to read). This is technically a drive-by 'fix' so I can roll this back if the other icon is preferred. 

TNL-1330
Screenshot: 
![image](https://cloud.githubusercontent.com/assets/2023680/5990342/e6d3c1a2-a979-11e4-993c-a83a92f5e148.png)
