### PR TITLE
disable PayAndVerifyTest.test_immediate_verification_enrollment

### DIFF
--- a/common/test/acceptance/tests/lms/test_lms.py
+++ b/common/test/acceptance/tests/lms/test_lms.py
@@ -229,6 +229,7 @@ class PayAndVerifyTest(UniqueCourseTest):
         # Add a verified mode to the course
         ModeCreationPage(self.browser, self.course_id, mode_slug=u'verified', mode_display_name=u'Verified Certificate', min_price=10, suggested_prices='10,20').visit()
 
+    @skip("Flaky 02/02/2015")
     def test_immediate_verification_enrollment(self):
         # Create a user and log them in
         AutoAuthPage(self.browser).visit()


### PR DESCRIPTION
Bok choy test PayAndVerifyTest.test_immediate_verification_enrollment is flaky. This PR disables it.

@rlucioni @jzoldak 

See https://openedx.atlassian.net/browse/ECOM-1024
