### PR TITLE
Add referer and accept_language to tracking logs

### DIFF
--- a/common/djangoapps/track/shim.py
+++ b/common/djangoapps/track/shim.py
@@ -14,7 +14,9 @@ CONTEXT_FIELDS_TO_INCLUDE = [
     'session',
     'ip',
     'agent',
-    'host'
+    'host',
+    'referer',
+    'accept_language'
 ]
 
 

--- a/common/djangoapps/track/tests/test_middleware.py
+++ b/common/djangoapps/track/tests/test_middleware.py
@@ -53,6 +53,8 @@ class TrackMiddlewareTestCase(TestCase):
     def test_default_request_context(self):
         context = self.get_context_for_path('/courses/')
         self.assertEquals(context, {
+            'accept_language': '',
+            'referer': '',
             'user_id': '',
             'session': '',
             'username': '',

--- a/common/djangoapps/track/tests/test_shim.py
+++ b/common/djangoapps/track/tests/test_shim.py
@@ -23,6 +23,8 @@ class LegacyFieldMappingProcessorTestCase(EventTrackingTestCase):
         data = {sentinel.key: sentinel.value}
 
         context = {
+            'accept_language': sentinel.accept_language,
+            'referer': sentinel.referer,
             'username': sentinel.username,
             'session': sentinel.session,
             'ip': sentinel.ip,
@@ -40,6 +42,8 @@ class LegacyFieldMappingProcessorTestCase(EventTrackingTestCase):
         emitted_event = self.get_event()
 
         expected_event = {
+            'accept_language': sentinel.accept_language,
+            'referer': sentinel.referer,
             'event_type': sentinel.name,
             'name': sentinel.name,
             'context': {
@@ -58,7 +62,7 @@ class LegacyFieldMappingProcessorTestCase(EventTrackingTestCase):
             'page': None,
             'session': sentinel.session,
         }
-        self.assertEqual(expected_event, emitted_event)
+        self.assertEqualUnicode(expected_event, emitted_event)
 
     @override_settings(
         EVENT_TRACKING_PROCESSORS=LEGACY_SHIM_PROCESSOR,
@@ -69,6 +73,8 @@ class LegacyFieldMappingProcessorTestCase(EventTrackingTestCase):
         emitted_event = self.get_event()
 
         expected_event = {
+            'accept_language': '',
+            'referer': '',
             'event_type': sentinel.name,
             'name': sentinel.name,
             'context': {},
@@ -82,4 +88,4 @@ class LegacyFieldMappingProcessorTestCase(EventTrackingTestCase):
             'page': None,
             'session': '',
         }
-        self.assertEqual(expected_event, emitted_event)
+        self.assertEqualUnicode(expected_event, emitted_event)

--- a/common/djangoapps/track/views/__init__.py
+++ b/common/djangoapps/track/views/__init__.py
@@ -58,6 +58,8 @@ def user_track(request):
             "username": username,
             "session": context.get('session', ''),
             "ip": _get_request_header(request, 'REMOTE_ADDR'),
+            "referer": _get_request_header(request, 'HTTP_REFERER'),
+            "accept_language": _get_request_header(request, 'HTTP_ACCEPT_LANGUAGE'),
             "event_source": "browser",
             "event_type": _get_request_value(request, 'event_type'),
             "event": _get_request_value(request, 'event'),
@@ -95,6 +97,8 @@ def server_track(request, event_type, event, page=None):
     event = {
         "username": username,
         "ip": _get_request_header(request, 'REMOTE_ADDR'),
+        "referer": _get_request_header(request, 'HTTP_REFERER'),
+        "accept_language": _get_request_header(request, 'HTTP_ACCEPT_LANGUAGE'),
         "event_source": "server",
         "event_type": event_type,
         "event": event,

--- a/common/djangoapps/track/views/tests/test_segmentio.py
+++ b/common/djangoapps/track/views/tests/test_segmentio.py
@@ -53,6 +53,7 @@ class SegmentIOTrackingTestCase(EventTrackingTestCase):
 
     def setUp(self):
         super(SegmentIOTrackingTestCase, self).setUp()
+        self.maxDiff = None  # pylint: disable=invalid-name
         self.request_factory = RequestFactory()
 
     def test_get_request(self):
@@ -189,6 +190,8 @@ class SegmentIOTrackingTestCase(EventTrackingTestCase):
             self.assertEquals(response.status_code, 200)
 
             expected_event = {
+                'accept_language': '',
+                'referer': '',
                 'username': str(sentinel.username),
                 'ip': '',
                 'session': '',
@@ -207,7 +210,7 @@ class SegmentIOTrackingTestCase(EventTrackingTestCase):
                     },
                     'user_id': USER_ID,
                     'course_id': course_id,
-                    'org_id': 'foo',
+                    'org_id': u'foo',
                     'path': ENDPOINT,
                     'client': {
                         'library': {
@@ -224,7 +227,7 @@ class SegmentIOTrackingTestCase(EventTrackingTestCase):
         finally:
             middleware.process_response(request, None)
 
-        self.assertEquals(self.get_event(), expected_event)
+        self.assertEqualUnicode(self.get_event(), expected_event)
 
     def test_invalid_course_id(self):
         request = self.create_request(
@@ -352,6 +355,8 @@ class SegmentIOTrackingTestCase(EventTrackingTestCase):
             self.assertEquals(response.status_code, 200)
 
             expected_event_without_payload = {
+                'accept_language': '',
+                'referer': '',
                 'username': str(sentinel.username),
                 'ip': '',
                 'session': '',
@@ -397,5 +402,5 @@ class SegmentIOTrackingTestCase(EventTrackingTestCase):
         actual_event = dict(self.get_event())
         payload = json.loads(actual_event.pop('event'))
 
-        self.assertEquals(actual_event, expected_event_without_payload)
-        self.assertEquals(payload, expected_payload)
+        self.assertEqualUnicode(actual_event, expected_event_without_payload)
+        self.assertEqualUnicode(payload, expected_payload)

--- a/common/djangoapps/track/views/tests/test_views.py
+++ b/common/djangoapps/track/views/tests/test_views.py
@@ -41,6 +41,8 @@ class TestTrackViews(TestCase):
             views.user_track(request)
 
         expected_event = {
+            'accept_language': '',
+            'referer': '',
             'username': 'anonymous',
             'session': sentinel.session,
             'ip': '127.0.0.1',
@@ -65,6 +67,8 @@ class TestTrackViews(TestCase):
             views.user_track(request)
 
         expected_event = {
+            'accept_language': '',
+            'referer': '',
             'username': 'anonymous',
             'session': sentinel.session,
             'ip': '127.0.0.1',
@@ -95,6 +99,8 @@ class TestTrackViews(TestCase):
             views.user_track(request)
 
             expected_event = {
+                'accept_language': '',
+                'referer': '',
                 'username': 'anonymous',
                 'session': '',
                 'ip': '127.0.0.1',
@@ -123,6 +129,8 @@ class TestTrackViews(TestCase):
         views.server_track(request, str(sentinel.event_type), '{}')
 
         expected_event = {
+            'accept_language': '',
+            'referer': '',
             'username': 'anonymous',
             'ip': '127.0.0.1',
             'event_source': 'server',
@@ -147,6 +155,8 @@ class TestTrackViews(TestCase):
             views.server_track(request, str(sentinel.event_type), '{}')
 
             expected_event = {
+                'accept_language': '',
+                'referer': '',
                 'username': 'anonymous',
                 'ip': '127.0.0.1',
                 'event_source': 'server',
@@ -180,6 +190,8 @@ class TestTrackViews(TestCase):
             views.server_track(request, str(sentinel.event_type), '{}')
 
             expected_event = {
+                'accept_language': '',
+                'referer': '',
                 'username': 'anonymous',
                 'ip': '127.0.0.1',
                 'event_source': 'server',
@@ -207,6 +219,8 @@ class TestTrackViews(TestCase):
         views.server_track(request, str(sentinel.event_type), '{}')
 
         expected_event = {
+            'accept_language': '',
+            'referer': '',
             'username': 'anonymous',
             'ip': '',
             'event_source': 'server',
@@ -223,6 +237,8 @@ class TestTrackViews(TestCase):
     @freeze_time(expected_time)
     def test_task_track(self):
         request_info = {
+            'accept_language': '',
+            'referer': '',
             'username': 'anonymous',
             'ip': '127.0.0.1',
             'agent': 'agent',


### PR DESCRIPTION
@mulby @rlucioni This is a small PR which adds:
1. Referer to the tracking logs.
2. Accept language to the tracking logs.
3. A comment about obsolescence of MD5 as a TODO. I was not comfortable making this change myself, but if nothing else, there should be more documentation there.

I'm super-excited about accept_language, by the way. We'll know a lot more about learner demographics.
