### PR TITLE
ECOM-1031: Show requirements in upgrade step of the decoupled verify/payment flow

### DIFF
--- a/lms/templates/verify_student/make_payment_step.underscore
+++ b/lms/templates/verify_student/make_payment_step.underscore
@@ -114,7 +114,6 @@
       <% } %>
     </div>
 
-    <% if ( !upgrade ) { %>
     <div class="requirements-container">
       <ul class="list-reqs <% if ( requirements['account-activation-required'] ) { %>account-not-activated<% } %>">
         <% if ( requirements['account-activation-required'] ) { %>
@@ -156,7 +155,6 @@
         <% } %>
       </ul>
     </div>
-    <% } %>
 
 
   <% if ( isActive ) { %>


### PR DESCRIPTION
[ECOM-1031](https://openedx.atlassian.net/browse/ECOM-1031): Show requirements in upgrade step of the decoupled verify/payment flow

See the ticket for a screenshot.  We were not showing the requirements (webcam, photo ID) on the "upgrade" step of the decoupled verify / payment flow.

@AlasdairSwan please review.  I'm not sure why the "if" statement around the requirements was added in the first place.  Do you remember?

FYI: @aleffert 
