### PR TITLE
Show requirements message when there is no verification deadline.

### DIFF
--- a/lms/templates/verify_student/make_payment_step.underscore
+++ b/lms/templates/verify_student/make_payment_step.underscore
@@ -107,7 +107,7 @@
           ) %>
         <% } else if ( !isActive ) { %>
           <%- gettext( "You need to activate your account before you can enroll in courses. Check your inbox for an activation email. After you complete activation you can return and refresh this page." ) %>
-        <% } else if ( !upgrade ) { %>
+        <% } else { %>
             <%- gettext( "You can pay now even if you don't have the following items available, but you will need to have these to qualify to earn a Verified Certificate." ) %>
         <% } %>
       </p>


### PR DESCRIPTION
Related to ECOM-1013.  When no verification deadline is specified, the message explaining what the requirements are was being hidden.  I missed this in the initial fix and discovered it when verifying the fix in stage.

@AlasdairSwan please review.
