### PR TITLE
re-shard cms lettuce tests back to 1 shards

### DIFF
--- a/cms/djangoapps/contentstore/features/transcripts.feature
+++ b/cms/djangoapps/contentstore/features/transcripts.feature
@@ -1,4 +1,4 @@
-@shard_3 @requires_stub_youtube
+@shard_1 @requires_stub_youtube
 Feature: CMS Transcripts
   As a course author, I want to be able to create video components
 

--- a/cms/djangoapps/contentstore/features/video.feature
+++ b/cms/djangoapps/contentstore/features/video.feature
@@ -1,4 +1,4 @@
-@shard_3 @requires_stub_youtube
+@shard_2 @requires_stub_youtube
 Feature: CMS Video Component
   As a course author, I want to be able to view my created videos in Studio
 

--- a/scripts/all-tests.sh
+++ b/scripts/all-tests.sh
@@ -156,13 +156,20 @@ END
     "cms-acceptance")
         case "$SHARD" in
 
-            "all")
+            "all"|"1")
                 paver test_acceptance -s cms --extra_args="-v 3"
                 ;;
 
-            *)
-                paver test_acceptance -s cms --extra_args="-v 3 --tag shard_${SHARD}"
+            "2"|"3")
+                mkdir -p reports/acceptance
+                cat > reports/acceptance/xunit.xml <<END
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="nosetests" tests="1" errors="0" failures="0" skip="0">
+<testcase classname="lettuce.tests" name="shard_placeholder" time="0.001"></testcase>
+</testsuite>
+END
                 ;;
+
         esac
         ;;
 


### PR DESCRIPTION
This moves the tests from CMS lettuce shard 3 to shards 1 or 2.  Shard 3 was taking about 5 minutes, most of which was setup.  The changes adds ~20 seconds to shard 1, but will let us free up another worker per build.
