### PR TITLE
Info-level logging for certificate management commands

### DIFF
--- a/lms/djangoapps/certificates/management/commands/ungenerated_certs.py
+++ b/lms/djangoapps/certificates/management/commands/ungenerated_certs.py
@@ -2,20 +2,22 @@
 Management command to find all students that need certificates for
 courses that have finished, and put their cert requests on the queue.
 """
+import logging
+import datetime
+from pytz import UTC
 from django.core.management.base import BaseCommand, CommandError
 from certificates.models import certificate_status_for_student
 from certificates.queue import XQueueCertInterface
 from django.contrib.auth.models import User
 from optparse import make_option
-from django.conf import settings
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
-from xmodule.course_module import CourseDescriptor
 from xmodule.modulestore.django import modulestore
 from certificates.models import CertificateStatuses
-import datetime
-from pytz import UTC
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
@@ -59,12 +61,21 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
 
+        LOGGER.info(
+            (
+                u"Starting to create tasks for ungenerated certificates "
+                u"with arguments %s and options %s"
+            ),
+            unicode(args),
+            unicode(options)
+        )
+
         # Will only generate a certificate if the current
         # status is in the unavailable state, can be set
         # to something else with the force flag
 
         if options['force']:
-            valid_statuses = getattr(CertificateStatuses, options['force'])
+            valid_statuses = [getattr(CertificateStatuses, options['force'])]
         else:
             valid_statuses = [CertificateStatuses.unavailable]
 
@@ -77,7 +88,13 @@ class Command(BaseCommand):
             try:
                 course = CourseKey.from_string(options['course'])
             except InvalidKeyError:
-                print("Course id {} could not be parsed as a CourseKey; falling back to SSCK.from_dep_str".format(options['course']))
+                LOGGER.warning(
+                    (
+                        u"Course id %s could not be parsed as a CourseKey; "
+                        u"falling back to SlashSeparatedCourseKey.from_deprecated_string()"
+                    ),
+                    options['course']
+                )
                 course = SlashSeparatedCourseKey.from_deprecated_string(options['course'])
             ended_courses = [course]
         else:
@@ -87,9 +104,9 @@ class Command(BaseCommand):
             # prefetch all chapters/sequentials by saying depth=2
             course = modulestore().get_course(course_key, depth=2)
 
-            print "Fetching enrolled students for {0}".format(course_key.to_deprecated_string())
             enrolled_students = User.objects.filter(
-                courseenrollment__course_id=course_key)
+                courseenrollment__course_id=course_key
+            )
 
             xq = XQueueCertInterface()
             if options['insecure']:
@@ -112,10 +129,61 @@ class Command(BaseCommand):
                         count, total, hours, minutes)
                     start = datetime.datetime.now(UTC)
 
-                if certificate_status_for_student(
-                        student, course_key)['status'] in valid_statuses:
+                cert_status = certificate_status_for_student(student, course_key)['status']
+                LOGGER.info(
+                    (
+                        u"Student %s has certificate status '%s' "
+                        u"in course '%s'"
+                    ),
+                    student.id,
+                    cert_status,
+                    unicode(course_key)
+                )
+
+                if cert_status in valid_statuses:
+
                     if not options['noop']:
                         # Add the certificate request to the queue
                         ret = xq.add_cert(student, course_key, course=course)
+
                         if ret == 'generating':
-                            print '{0} - {1}'.format(student, ret)
+                            LOGGER.info(
+                                (
+                                    u"Added a certificate generation task to the XQueue "
+                                    u"for student %s in course '%s'. "
+                                    u"The new certificate status is '%s'."
+                                ),
+                                student.id,
+                                unicode(course_key),
+                                ret
+                            )
+
+                    else:
+                        LOGGER.info(
+                            (
+                                u"Skipping certificate generation for "
+                                u"student %s in course '%s' "
+                                u"because the noop flag is set."
+                            ),
+                            student.id,
+                            unicode(course_key)
+                        )
+
+                else:
+                    LOGGER.info(
+                        (
+                            u"Skipped student %s because "
+                            u"certificate status '%s' is not in %s"
+                        ),
+                        student.id,
+                        cert_status,
+                        unicode(valid_statuses)
+                    )
+
+            LOGGER.info(
+                (
+                    u"Completed ungenerated certificates command "
+                    u"for course '%s'"
+                ),
+                unicode(course_key)
+            )


### PR DESCRIPTION
This PR adds info-level logging for the certificates management commands `regenerate_user` and `ungenerated_certs`.  The goal is to make it much easier to determine:

1) When commands were run, and with what arguments.
2) Which users had certificate tasks placed on the XQueue, and which users were skipped.
3) When and why users are skipped.
4) When and why user's "generated certificate" status is updated.

This should make it easier to debug issues like [ECOM-957](https://openedx.atlassian.net/browse/ECOM-957).

@feanil @rlucioni please review.
