### PR TITLE
Update privacy policy date to the most recent

### DIFF
--- a/lms/templates/footer-edx-new.html
+++ b/lms/templates/footer-edx-new.html
@@ -45,7 +45,14 @@
 
       <div class="footer-about-links">
         <a href="${marketing_link('TOS')}"><span class="copy">${_("Terms of Service and Honor Code")}</span></a>
-        <a href="${marketing_link('PRIVACY')}"><span class="copy">${_("Privacy Policy")}</span> <span class="note">${_("(Revised 4/16/2014)")}</span></a>
+        <a href="${marketing_link('PRIVACY')}"><span class="copy">${_("Privacy Policy")}</span>
+	  <span class="note">
+	    ## Translators: {date} will be an abbreviated date, indicating when the privacy policy was most recently revised.
+	    ${_("(Revised {date})").format(
+	      ## Translators: 10/22/2014 is a US-style date representing October 22, 2014. Please convert to use your local date system.
+	      date=_("10/22/2014")
+	    )}
+	</span></a>
       </div>
     </div>
 


### PR DESCRIPTION
Syncs up the Drupal site and courses.edx.org in terms of when the privacy policy was last updated. I spoke with Jennifer from Legal and she said that the 10/22/2014 date is correct, and should be present in both locations.

As a bonus I also made the internationalization a bit nicer here.

Screenshot from my local dev (compare to prod, where the old 4/16/2014 date is present):
![screen shot 2015-02-04 at 1 54 09 pm](https://cloud.githubusercontent.com/assets/1985317/6047076/5c9d2f06-ac75-11e4-95cd-9600cc9a8ca9.png)

@ndubbaka @rlucioni please take a look
