### PR TITLE
TNL-1353: Fix annotator dependency.

### DIFF
--- a/lms/static/js/edxnotes/plugins/events.js
+++ b/lms/static/js/edxnotes/plugins/events.js
@@ -1,7 +1,7 @@
 ;(function (define, undefined) {
 'use strict';
 define([
-    'underscore', 'annotator', 'underscore.string'
+    'underscore', 'annotator_1.2.9', 'underscore.string'
 ], function (_, Annotator) {
     /**
      * Modifies Annotator.Plugin.Store.annotationCreated to make it trigger a new

--- a/lms/static/js/edxnotes/plugins/scroller.js
+++ b/lms/static/js/edxnotes/plugins/scroller.js
@@ -1,6 +1,6 @@
 ;(function (define, undefined) {
 'use strict';
-define(['jquery', 'underscore', 'annotator'], function ($, _, Annotator) {
+define(['jquery', 'underscore', 'annotator_1.2.9'], function ($, _, Annotator) {
     /**
      * Adds the Scroller Plugin which scrolls to a note with a certain id and
      * opens it.

--- a/lms/static/js/edxnotes/views/notes_factory.js
+++ b/lms/static/js/edxnotes/views/notes_factory.js
@@ -1,7 +1,7 @@
 ;(function (define, undefined) {
 'use strict';
 define([
-     'jquery', 'underscore', 'annotator', 'js/edxnotes/utils/logger',
+     'jquery', 'underscore', 'annotator_1.2.9', 'js/edxnotes/utils/logger',
      'js/edxnotes/views/shim', 'js/edxnotes/plugins/scroller',
      'js/edxnotes/plugins/events'
 ], function ($, _, Annotator, NotesLogger) {

--- a/lms/static/js/edxnotes/views/shim.js
+++ b/lms/static/js/edxnotes/views/shim.js
@@ -1,7 +1,7 @@
 ;(function (define, undefined) {
 'use strict';
 define([
-    'jquery', 'underscore', 'annotator', 'js/edxnotes/utils/utils'
+    'jquery', 'underscore', 'annotator_1.2.9', 'js/edxnotes/utils/utils'
 ], function ($, _, Annotator, Utils) {
     var _t = Annotator._t;
 

--- a/lms/static/js/edxnotes/views/toggle_notes_factory.js
+++ b/lms/static/js/edxnotes/views/toggle_notes_factory.js
@@ -2,7 +2,7 @@
 'use strict';
 define([
     'jquery', 'underscore', 'backbone', 'gettext',
-    'annotator', 'js/edxnotes/views/visibility_decorator'
+    'annotator_1.2.9', 'js/edxnotes/views/visibility_decorator'
 ], function($, _, Backbone, gettext, Annotator, EdxnotesVisibilityDecorator) {
     var ToggleNotesView = Backbone.View.extend({
         events: {

--- a/lms/static/js/spec/edxnotes/plugins/events_spec.js
+++ b/lms/static/js/spec/edxnotes/plugins/events_spec.js
@@ -1,6 +1,6 @@
 define([
     'jquery', 'underscore', 'js/common_helpers/ajax_helpers', 'js/spec/edxnotes/helpers',
-    'annotator', 'logger', 'js/edxnotes/views/notes_factory'
+    'annotator_1.2.9', 'logger', 'js/edxnotes/views/notes_factory'
 ], function($, _, AjaxHelpers, Helpers, Annotator, Logger, NotesFactory) {
     'use strict';
     describe('EdxNotes Events Plugin', function() {

--- a/lms/static/js/spec/edxnotes/plugins/scroller_spec.js
+++ b/lms/static/js/spec/edxnotes/plugins/scroller_spec.js
@@ -1,5 +1,5 @@
 define([
-    'jquery', 'underscore', 'annotator', 'js/edxnotes/views/notes_factory',
+    'jquery', 'underscore', 'annotator_1.2.9', 'js/edxnotes/views/notes_factory',
     'js/spec/edxnotes/custom_matchers'
 ], function($, _, Annotator, NotesFactory, customMatchers) {
     'use strict';

--- a/lms/static/js/spec/edxnotes/views/notes_factory_spec.js
+++ b/lms/static/js/spec/edxnotes/views/notes_factory_spec.js
@@ -1,5 +1,5 @@
 define([
-    'annotator', 'js/edxnotes/views/notes_factory', 'js/common_helpers/ajax_helpers',
+    'annotator_1.2.9', 'js/edxnotes/views/notes_factory', 'js/common_helpers/ajax_helpers',
     'js/spec/edxnotes/helpers', 'js/spec/edxnotes/custom_matchers'
 ], function(Annotator, NotesFactory, AjaxHelpers, Helpers, customMatchers) {
     'use strict';

--- a/lms/static/js/spec/edxnotes/views/shim_spec.js
+++ b/lms/static/js/spec/edxnotes/views/shim_spec.js
@@ -1,5 +1,5 @@
 define([
-    'jquery', 'underscore', 'annotator', 'js/edxnotes/views/notes_factory', 'jasmine-jquery'
+    'jquery', 'underscore', 'annotator_1.2.9', 'js/edxnotes/views/notes_factory', 'jasmine-jquery'
 ], function($, _, Annotator, NotesFactory) {
     'use strict';
     describe('EdxNotes Shim', function() {

--- a/lms/static/js/spec/edxnotes/views/toggle_notes_factory_spec.js
+++ b/lms/static/js/spec/edxnotes/views/toggle_notes_factory_spec.js
@@ -1,5 +1,5 @@
 define([
-    'jquery', 'annotator', 'js/common_helpers/ajax_helpers', 'js/edxnotes/views/visibility_decorator',
+    'jquery', 'annotator_1.2.9', 'js/common_helpers/ajax_helpers', 'js/edxnotes/views/visibility_decorator',
     'js/edxnotes/views/toggle_notes_factory', 'js/spec/edxnotes/helpers',
     'js/spec/edxnotes/custom_matchers', 'jasmine-jquery'
 ], function(

--- a/lms/static/js/spec/edxnotes/views/visibility_decorator_spec.js
+++ b/lms/static/js/spec/edxnotes/views/visibility_decorator_spec.js
@@ -1,5 +1,5 @@
 define([
-    'annotator', 'js/edxnotes/views/visibility_decorator',
+    'annotator_1.2.9', 'js/edxnotes/views/visibility_decorator',
     'js/spec/edxnotes/helpers', 'js/spec/edxnotes/custom_matchers'
 ], function(Annotator, VisibilityDecorator, Helpers, customMatchers) {
     'use strict';

--- a/lms/static/js/spec/main.js
+++ b/lms/static/js/spec/main.js
@@ -82,7 +82,7 @@
             'js/student_profile/profile': 'js/student_profile/profile',
 
             // edxnotes
-            'annotator': 'xmodule_js/common_static/js/vendor/edxnotes/annotator-full.min'
+            'annotator_1.2.9': 'xmodule_js/common_static/js/vendor/edxnotes/annotator-full.min'
         },
         shim: {
             'gettext': {
@@ -511,7 +511,7 @@
                 ]
             },
             // Student Notes
-            'annotator': {
+            'annotator_1.2.9': {
                 exports: 'Annotator',
                 deps: ['jquery']
             }

--- a/lms/static/require-config-lms.js
+++ b/lms/static/require-config-lms.js
@@ -145,11 +145,6 @@
                 ]
             },
             // End of needed by OVA
-        },
-        map: {
-          "js/edxnotes/*": {
-              "annotator": "annotator_1.2.9"
-          }
         }
     };
 


### PR DESCRIPTION
This PR fixes dependency issue with annotator.js library. Version 1.2.8 from Harvard Annotation Tool was used due to wrong [map config](http://requirejs.org/docs/api.html#config-map). 
To avoid misunderstandings in the future, `map` configuration is removed and `annotator_1.2.9` dependency is used explicitly. 

@jmclaus please review.
