### PR TITLE
Fix grades download in courses with cohorted content

### DIFF
--- a/lms/djangoapps/instructor_task/tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tasks_helper.py
@@ -20,6 +20,7 @@ from pytz import UTC
 from track.views import task_track
 from util.file import course_filename_prefix_generator, UniversalNewlineIterator
 from xmodule.modulestore.django import modulestore
+from xmodule.split_test_module import get_split_user_partitions
 
 from courseware.courses import get_course_by_id
 from courseware.grades import iterate_grades_for
@@ -553,9 +554,8 @@ def upload_grades_csv(_xmodule_instance_args, _entry_id, course_id, _task_input,
     course = get_course_by_id(course_id)
     cohorts_header = ['Cohort Name'] if course.is_cohorted else []
 
-    partition_service = LmsPartitionService(user=None, course_id=course_id)
-    partitions = partition_service.course_partitions
-    group_configs_header = ['Experiment Group ({})'.format(partition.name) for partition in partitions]
+    experiment_partitions = get_split_user_partitions(course.user_partitions)
+    group_configs_header = [u'Experiment Group ({})'.format(partition.name) for partition in experiment_partitions]
 
     # Loop over all our students and build our CSV lists in memory
     header = None
@@ -589,7 +589,7 @@ def upload_grades_csv(_xmodule_instance_args, _entry_id, course_id, _task_input,
                 cohorts_group_name.append(group.name if group else '')
 
             group_configs_group_names = []
-            for partition in partitions:
+            for partition in experiment_partitions:
                 group = LmsPartitionService(student, course_id).get_group(partition, assign=False)
                 group_configs_group_names.append(group.name if group else '')
 

--- a/openedx/core/djangoapps/user_api/partition_schemes.py
+++ b/openedx/core/djangoapps/user_api/partition_schemes.py
@@ -22,7 +22,7 @@ class RandomUserPartitionScheme(object):
         Returns the group from the specified user position to which the user is assigned.
         If the user has not yet been assigned, a group will be randomly chosen for them if assign flag is True.
         """
-        partition_key = cls._key_for_partition(user_partition)
+        partition_key = cls.key_for_partition(user_partition)
         group_id = course_tag_api.get_course_tag(user, course_key, partition_key)
 
         group = None
@@ -72,7 +72,7 @@ class RandomUserPartitionScheme(object):
         return group
 
     @classmethod
-    def _key_for_partition(cls, user_partition):
+    def key_for_partition(cls, user_partition):
         """
         Returns the key to use to look up and save the user's group for a given user partition.
         """


### PR DESCRIPTION
Fixes a bug in the grades CSV download where the task failed due to the course having `UserPartition`s with a  `CohortPartitionScheme` (the `get_group_for_user` method on the `CohortPartitionScheme` did not understand or obey the `assign=False` argument).

Since the grades CSV download should not be looking at cohort-schemed partitions anyways, we're now filtering out such partitions to achieve this fix.

TNL-1351

@adampalay @cahrens please review.
