### PR TITLE
fix contextual menu (make it clickable) for HTML5 videos

### DIFF
--- a/common/lib/xmodule/xmodule/css/video/accessible_menu.scss
+++ b/common/lib/xmodule/xmodule/css/video/accessible_menu.scss
@@ -216,7 +216,7 @@ $a11y--blue-s1: saturate($blue,15%);
 }
 
 .overlay {
-  @extend %ui-depth5;
+  @extend %ui-depth4;
   position: fixed;
   top: 0;
   left: 0;


### PR DESCRIPTION
TNL-1335

fixed the issue where contextual menu for non YouTube HTML5 videos shows but doesn't react to mouse hovering and clicking.
updated 'z-index' for overlay to "ui-depth4". Since 'z-index' value of "ui-depth5" was getting same as 'contextmenu' (Its parent), also increasing 'z-index' value more than 100000 ("ui-depth5") was not working.
@adampalay @marcotuts @polesye 
