### PR TITLE
Fixed ajax login when advanced security check is on for NoneType user.

### DIFF
--- a/common/djangoapps/student/tests/test_login.py
+++ b/common/djangoapps/student/tests/test_login.py
@@ -78,6 +78,14 @@ class LoginTest(TestCase):
                               value='Email or password is incorrect')
         self._assert_audit_log(mock_audit_log, 'warning', [u'Login failed', u'Unknown user email', nonexistent_email])
 
+    @patch.dict("django.conf.settings.FEATURES", {'ADVANCED_SECURITY': True})
+    def test_login_fail_incorrect_email_with_advanced_security(self):
+        nonexistent_email = u'not_a_user@edx.org'
+        response, mock_audit_log = self._login_response(nonexistent_email, 'test_password')
+        self._assert_response(response, success=False,
+                              value='Email or password is incorrect')
+        self._assert_audit_log(mock_audit_log, 'warning', [u'Login failed', u'Unknown user email', nonexistent_email])
+
     @patch.dict("django.conf.settings.FEATURES", {'SQUELCH_PII_IN_LOGS': True})
     def test_login_fail_no_user_exists_no_pii(self):
         nonexistent_email = u'not_a_user@edx.org'

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1034,7 +1034,7 @@ def login_user(request, error=""):  # pylint: disable-msg=too-many-statements,un
             })  # TODO: this should be status code 429  # pylint: disable=fixme
 
     # see if the user must reset his/her password due to any policy settings
-    if PasswordHistory.should_user_reset_password_now(user_found_by_email_lookup):
+    if user_found_by_email_lookup and PasswordHistory.should_user_reset_password_now(user_found_by_email_lookup):
         return JsonResponse({
             "success": False,
             "value": _('Your password has expired due to password policy on this account. You must '


### PR DESCRIPTION
[TNL-1352](https://openedx.atlassian.net/browse/TNL-1352)

If user is `NoneType` and `settings.FEATURES["Advanced_Security"] = True` `PasswordHistory.should_user_reset_password_now(user_found_by_email_lookup)` returns "`NoneType` object has no attribute `is_staff`" error.

Fixed by adding a check for user.
