### PR TITLE
Invalid Key Error on passing wrong usage key in opaque_keys

### DIFF
--- a/cms/djangoapps/contentstore/tests/tests.py
+++ b/cms/djangoapps/contentstore/tests/tests.py
@@ -21,7 +21,6 @@ from pytz import UTC
 
 from freezegun import freeze_time
 
-
 class ContentStoreTestCase(ModuleStoreTestCase):
     def _login(self, email, password):
         """

--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -154,7 +154,11 @@ def container_handler(request, usage_key_string):
     """
     if 'text/html' in request.META.get('HTTP_ACCEPT', 'text/html'):
 
-        usage_key = UsageKey.from_string(usage_key_string)
+        try:
+           usage_key = UsageKey.from_string(usage_key_string)
+        except Exception:
+               raise Http404("Invalid key")
+
         with modulestore().bulk_operations(usage_key.course_key):
             try:
                 course, xblock, lms_link, preview_lms_link = _get_item_in_course(request, usage_key)

--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -348,6 +348,7 @@ def xblock_container_handler(request, usage_key_string):
     This is used by the container page in particular to get additional information about publish state
     and ancestor state.
     """
+    return Http404
     usage_key = usage_key_with_run(usage_key_string)
 
     if not has_studio_read_access(request.user, usage_key.course_key):

--- a/cms/djangoapps/contentstore/views/tests/test_item.py
+++ b/cms/djangoapps/contentstore/views/tests/test_item.py
@@ -34,6 +34,7 @@ from opaque_keys.edx.keys import UsageKey, CourseKey
 from opaque_keys.edx.locations import Location
 from xmodule.partitions.partitions import Group, UserPartition
 
+from django.test.client import Client
 
 class ItemTest(CourseTestCase):
     """ Base test class for create, save, and delete """
@@ -144,6 +145,11 @@ class GetItemTest(ItemTest):
         self.populate_course(branching_factor)
         with check_mongo_calls(unit_queries):
             self.client.get(reverse_usage_url('xblock_container_handler', self.populated_usage_keys['vertical'][-1]))
+
+    def test_container_handler(self):
+        response = self.client.get(reverse_usage_url('container_handler', "i4x://UAx/Test101/vertical/static/story2.html"))
+        self.assertEqual(response.status_code, 404)
+
 
     def test_get_vertical(self):
         # Add a vertical

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -83,7 +83,7 @@ FEATURES = {
 
     # If set to True, Studio won't restrict the set of advanced components
     # to just those pre-approved by edX
-    'ALLOW_ALL_ADVANCED_COMPONENTS': False,
+    'ALLOW_ALL_ADVANCED_COMPONENTS': True,
 
     # Turn off account locking if failed login attempts exceeds a limit
     'ENABLE_MAX_FAILED_LOGIN_ATTEMPTS': False,

--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -157,6 +157,7 @@ def toc_for_course(request, course, active_chapter, active_section, field_data_c
         required_content = _get_required_content(course, request.user)
 
         chapters = list()
+        chapters_number = 0
         for chapter in course_module.get_display_items():
             # Only show required content, if there is required content
             # chapter.hide_from_toc is read-only (boo)
@@ -183,9 +184,11 @@ def toc_for_course(request, course, active_chapter, active_section, field_data_c
                                      'active': active,
                                      'graded': section.graded,
                                      })
+            chapters_number += 1
             chapters.append({'display_name': chapter.display_name_with_default,
                              'url_name': chapter.url_name,
                              'sections': sections,
+                             'chapters_number': chapters_number,
                              'active': chapter.url_name == active_chapter})
         return chapters
 
@@ -881,7 +884,7 @@ def _invoke_xblock_handler(request, course_id, usage_id, handler, suffix, user):
     if instance is None:
         # Either permissions just changed, or someone is trying to be clever
         # and load something they shouldn't have access to.
-        log.debug("No module %s for user %s -- access denied?", usage_key, user)
+        log.debug("No module %s for user %s -- access denied ?", usage_key, user)
         raise Http404
 
     req = django_to_webob_request(request)

--- a/lms/templates/courseware/accordion.html
+++ b/lms/templates/courseware/accordion.html
@@ -17,7 +17,7 @@
       %>
       <h3 ${active_class} aria-label="${aria_label}">
         <a href="#">
-          ${chapter['display_name']}
+            ${chapter['chapters_number']}.  ${chapter['display_name']}
         </a>
       </h3>
 

--- a/lms/templates/courseware/course_navigation.html
+++ b/lms/templates/courseware/course_navigation.html
@@ -78,7 +78,6 @@ def url_class(is_active):
   </div>
 </nav>
 %endif
-
 % if show_preview_menu:
 <script type="text/javascript">
 (function() {

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -192,6 +192,7 @@ ${fragment.foot_html()}
 % endif
 
 <%include file="/dashboard/_dashboard_prompt_midcourse_reverify.html" />
+
 % if default_tab:
   <%include file="/courseware/course_navigation.html" />
 % else:
@@ -223,6 +224,7 @@ ${fragment.foot_html()}
       % endif
 
       <div id="accordion" style="display: none">
+
         <nav aria-label="${_('Course Navigation')}">
           % if accordion.strip():
             ${accordion}
@@ -242,8 +244,8 @@ ${fragment.foot_html()}
     % endif
   </div>
 </div>
-
 <nav class="nav-utilities ${"has-utility-calculator" if course.show_calculator else ""}">
+
   <h2 class="sr nav-utilities-title">${_('Course Utilities Navigation')}</h2>
 
   ## Utility: Chat


### PR DESCRIPTION
When user was passing the invalid key, he was getting invalid 
key exception. Because container_handler was not able to process
usage key. So I handled that exception and throw 404 message.

TNL-473
