### PR TITLE
Fix 3rd-party auth association auto-link

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1122,6 +1122,9 @@ def login_user(request, error=""):  # pylint: disable-msg=too-many-statements,un
 
         if third_party_auth_successful:
             redirect_url = pipeline.get_complete_url(backend_name)
+        elif third_party_auth_requested:
+            running_pipeline = pipeline.get(request)
+            redirect_url = pipeline.get_login_url(running_pipeline['backend'], pipeline.AUTH_ENTRY_DASHBOARD)
 
         response = JsonResponse({
             "success": True,
@@ -1669,7 +1672,7 @@ def create_account(request, post_override=None):  # pylint: disable-msg=too-many
     # Resume the third-party-auth pipeline if necessary.
     if third_party_auth.is_enabled() and pipeline.running(request):
         running_pipeline = pipeline.get(request)
-        redirect_url = pipeline.get_complete_url(running_pipeline['backend'])
+        redirect_url = pipeline.get_login_url(running_pipeline['backend'], pipeline.AUTH_ENTRY_DASHBOARD)
 
     response = JsonResponse({
         'success': True,


### PR DESCRIPTION
When user authorizes via 3rd party account that isn't linked to any of
edX accounts, they are offered to either create a new account or log
into existing one. After they do either of those things, the 3rd party
account isn't automatically linked to the account they logged in.

If the user just registered a new account, they don't enter the
password, it is automatically generated for them. So if they forget to
manually associate the 3rd party account (and they might because it is
kind of counter-intuitive that one must do it again after just
authorizing), the only way to access the system again is via password
reset process, which is not really user-friendly.

Please see [JIRA ticket](https://openedx.atlassian.net/browse/PLAT-430) as well for more info.

It says that this is just a naive attempt in order to get some feedback, too. :smirk: 
