### PR TITLE
ECOM-1045: Add messaging for when students miss the verification deadline

### DIFF
--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -256,19 +256,36 @@ class PayAndVerifyView(View):
             log.warn(u"No course specified for verification flow request.")
             raise Http404
 
-        # Verify that the course has a verified mode
-        course_mode = CourseMode.verified_mode_for_course(course_key)
-        if course_mode is None:
-            log.warn(
-                u"No verified course mode found for course '{course_id}' for verification flow request"
-                .format(course_id=course_id)
-            )
-            raise Http404
+        # Check that the course has an unexpired verified mode
+        course_mode, expired_course_mode = self._get_verified_modes_for_course(course_key)
 
-        log.info(
-            u"Entering verified workflow for user '{user}', course '{course_id}', with current step '{current_step}'."
-            .format(user=request.user, course_id=course_id, current_step=current_step)
-        )
+        if course_mode is None:
+            # Check if there is an *expired* verified course mode;
+            # if so, we should show a message explaining that the verification
+            # deadline has passed.
+            if expired_course_mode is not None:
+                log.info(u"Verification deadline for '%s' has passed.", course_id)
+                context = {
+                    'course': course,
+                    'deadline': (
+                        get_default_time_display(expired_course_mode.expiration_datetime)
+                        if expired_course_mode.expiration_datetime else ""
+                    )
+                }
+                return render_to_response("verify_student/missed_verification_deadline.html", context)
+            else:
+                # Otherwise, there has never been a verified mode,
+                # so return a page not found response.
+                log.warn(
+                    u"No verified course mode found for course '{course_id}' for verification flow request"
+                    .format(course_id=course_id)
+                )
+                raise Http404
+        else:
+            log.info(
+                u"Entering verified workflow for user '{user}', course '{course_id}', with current step '{current_step}'."
+                .format(user=request.user, course_id=course_id, current_step=current_step)
+            )
 
         # Check whether the user has verified, paid, and enrolled.
         # A user is considered "paid" if he or she has an enrollment
@@ -426,6 +443,31 @@ class PayAndVerifyView(View):
         # Redirect if necessary, otherwise implicitly return None
         if url is not None:
             return redirect(url)
+
+    def _get_verified_modes_for_course(self, course_key):
+        """Retrieve unexpired and expired verified modes for a course.
+
+        Arguments:
+            course_key (CourseKey): The location of the course.
+
+        Returns:
+            Tuple of `(verified_mode, expired_verified_mode)`.  If provided,
+                `verified_mode` is an *unexpired* verified mode for the course.
+                If provided, `expired_verified_mode` is an *expired* verified
+                mode for the course.  Either of these may be None.
+
+        """
+        # Retrieve all the modes at once to reduce the number of database queries
+        all_modes, unexpired_modes = CourseMode.all_and_unexpired_modes_for_courses([course_key])
+
+        # Find an unexpired verified mode
+        verified_mode = CourseMode.verified_mode_for_course(course_key, modes=unexpired_modes[course_key])
+        expired_verified_mode = None
+
+        if verified_mode is None:
+            expired_verified_mode = CourseMode.verified_mode_for_course(course_key, modes=all_modes[course_key])
+
+        return (verified_mode, expired_verified_mode)
 
     def _display_steps(self, always_show_payment, already_verified, already_paid):
         """Determine which steps to display to the user.

--- a/lms/templates/verify_student/missed_verification_deadline.html
+++ b/lms/templates/verify_student/missed_verification_deadline.html
@@ -1,0 +1,18 @@
+<%! from django.utils.translation import ugettext as _ %>
+<%namespace name='static' file='../static_content.html'/>
+
+<%inherit file="../main.html" />
+
+<%block name="pagetitle">${_("Verification Deadline Has Passed")}</%block>
+
+<%block name="content">
+<section class="outside-app">
+  <p>${_(
+    u"The verification deadline for {course_name} was {date}.  "
+    u"Verification is no longer available."
+    ).format(
+      course_name=course.display_name,
+      date=deadline
+    )}</p>
+</section>
+</%block>


### PR DESCRIPTION
[ECOM-1045](https://openedx.atlassian.net/browse/ECOM-1045).  When the verification deadline for a course has passed, the verified mode no longer shows up in the list of available course modes.  Users visiting the "verify later" link from their email would get a 404 after the verification deadline had passed.

This PR adds a check for this condition and renders a message explaining that the deadline has passed.

Reviewers: @stephensanchez @dianakhuang 
@srpearce Please review the text in `missed_verification_deadline.html`  It currently looks like this:

![image](https://cloud.githubusercontent.com/assets/2948394/6080517/1a582cce-ade0-11e4-8d70-0c9031d40b79.png)
