### PR TITLE
Remove submission of verification attempt in shopping cart

### DIFF
--- a/lms/djangoapps/shoppingcart/models.py
+++ b/lms/djangoapps/shoppingcart/models.py
@@ -35,7 +35,6 @@ from edxmako.shortcuts import render_to_string
 from student.models import CourseEnrollment, UNENROLL_DONE
 from util.query import use_read_replica_if_available
 from xmodule_django.models import CourseKeyField
-from verify_student.models import SoftwareSecurePhotoVerification
 from .exceptions import (
     InvalidCartItem,
     PurchasedCallbackException,
@@ -1574,13 +1573,6 @@ class CertificateItem(OrderItem):
         """
         When purchase goes through, activate and update the course enrollment for the correct mode
         """
-        try:
-            verification_attempt = SoftwareSecurePhotoVerification.active_for_user(self.course_enrollment.user)
-            verification_attempt.submit()
-        except Exception:
-            log.exception(
-                "Could not submit verification attempt for enrollment {}".format(self.course_enrollment)
-            )
         self.course_enrollment.change_mode(self.mode)
         self.course_enrollment.activate()
 

--- a/lms/djangoapps/shoppingcart/tests/test_models.py
+++ b/lms/djangoapps/shoppingcart/tests/test_models.py
@@ -12,6 +12,7 @@ from mock import patch, MagicMock
 import pytz
 import ddt
 from django.core import mail
+from django.core.mail.message import EmailMessage
 from django.conf import settings
 from django.db import DatabaseError
 from django.test import TestCase
@@ -298,7 +299,8 @@ class OrderTest(ModuleStoreTestCase):
     def test_purchase_item_email_boto_failure(self, error_logger):
         cart = Order.get_cart_for_user(user=self.user)
         CertificateItem.add_to_order(cart, self.course_key, self.cost, 'honor')
-        with patch('shoppingcart.models.send_mail', side_effect=BotoServerError("status", "reason")):
+        with patch.object(EmailMessage, 'send') as mock_send:
+            mock_send.side_effect = BotoServerError("status", "reason")
             cart.purchase()
             self.assertTrue(error_logger.called)
 


### PR DESCRIPTION
This is no longer needed in the decoupled payment/verification flow, since users won't have a verification attempt at the time of purchase.  This should eliminate some spurious error messages showing up in the logs.

Making this change exposed a problem with one of the test cases, which was passing for the wrong reasons.  I've updated the test case so it's patching the correct object (`EmailMessage.send` instead of `send_mail`).

@rlucioni please review.
