### PR TITLE
[TNL-1371] Adds a SR only legend for fieldset and translates

### DIFF
--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -367,11 +367,12 @@ from edxmako.shortcuts import marketing_link
   <div style="display: none;">
     <form id="class_enroll_form" method="post" data-remote="true" action="${reverse('change_enrollment')}">
       <fieldset class="enroll_fieldset">
+        <legend class="sr">${_("Enroll")}</legend>
         <input name="course_id" type="hidden" value="${course.id | h}">
         <input name="enrollment_action" type="hidden" value="enroll">
       </fieldset>
       <div class="submit">
-        <input name="submit" type="submit" value="enroll">
+        <input name="submit" type="submit" value="${_('enroll')}">
       </div>
     </form>
   </div>

--- a/lms/templates/courseware/mktg_course_about.html
+++ b/lms/templates/courseware/mktg_course_about.html
@@ -121,13 +121,14 @@
   <div style="display: none;">
     <form id="class_enroll_form" method="post" data-remote="true" action="${reverse('change_enrollment')}">
       <fieldset class="enroll_fieldset">
+        <legend class="sr">${_("Enroll")}</legend>
         <input name="course_id" type="hidden" value="${course.id | h}">
         <input name="enrollment_action" type="hidden" value="enroll">
         <input name="email_opt_in" type="hidden" value="true">
         <input type="hidden" name="csrfmiddlewaretoken" value="${ csrf_token }">
       </fieldset>
       <div class="submit">
-        <input name="enroll" type="submit" value="enroll">
+        <input name="enroll" type="submit" value="${_('enroll')}">
       </div>
     </form>
   </div>


### PR DESCRIPTION
This issue was picked up by automated accessibility scan.  `<fieldset>` elements must have a `<legend>` element as a child for them to be accessible.  It's not clear to me when this form gets displayed (it's hidden by default) but this change will reduce the number of errors found during automated scans at the very least.  While I was in there, I internationalized the word "enroll" in both the legend and the button text.  
@sarina and @singingwolfboy, can you review?  [TNL-1371] 
