### PR TITLE
Reorganise reindexing operation

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -481,6 +481,9 @@ def course_index(request, course_key):
     with modulestore().bulk_operations(course_key):
         course_module = get_course_and_check_access(course_key, request.user, depth=None)
         lms_link = get_lms_link_for_item(course_module.location)
+        reindex_link = None
+        if settings.FEATURES.get('ENABLE_COURSEWARE_INDEX', False):
+            reindex_link = "/course_search_index/{course_id}".format(course_id=unicode(course_key))
         sections = course_module.get_children()
         course_structure = _course_outline_json(request, course_module)
         locator_to_show = request.REQUEST.get('show', None)
@@ -504,7 +507,7 @@ def course_index(request, course_key):
             'rerun_notification_id': current_action.id if current_action else None,
             'course_release_date': course_release_date,
             'settings_url': settings_url,
-            'reindex_button': settings.FEATURES.get('ENABLE_COURSEWARE_INDEX', False),
+            'reindex_link': reindex_link,
             'notification_dismiss_url': reverse_course_url(
                 'course_notifications_handler',
                 current_action.course_key,

--- a/cms/static/js/spec/views/pages/course_outline_spec.js
+++ b/cms/static/js/spec/views/pages/course_outline_spec.js
@@ -329,8 +329,10 @@ define(["jquery", "js/common_helpers/ajax_helpers", "js/views/utils/view_utils",
                     var reindexSpy = spyOn(outlinePage, 'startReIndex').andCallThrough();
                     var successSpy = spyOn(outlinePage, 'onIndexSuccess').andCallThrough();
                     var reindexButton = outlinePage.$('.button.button-reindex');
+                    var test_url = '/course_search_index/5';
+                    reindexButton.attr('href', test_url)
                     reindexButton.trigger('click');
-                    AjaxHelpers.expectJsonRequest(requests, 'GET', '/course_search_index/5');
+                    AjaxHelpers.expectJsonRequest(requests, 'GET', test_url);
                     AjaxHelpers.respondWithJson(requests, createMockIndexJSON(true));
                     expect(reindexSpy).toHaveBeenCalled();
                     expect(successSpy).toHaveBeenCalled();
@@ -340,8 +342,10 @@ define(["jquery", "js/common_helpers/ajax_helpers", "js/views/utils/view_utils",
                     createCourseOutlinePage(this, mockSingleSectionCourseJSON);
                     var reindexSpy = spyOn(outlinePage, 'startReIndex').andCallThrough();
                     var reindexButton = outlinePage.$('.button.button-reindex');
+                    var test_url = '/course_search_index/5';
+                    reindexButton.attr('href', test_url)
                     reindexButton.trigger('click');
-                    AjaxHelpers.expectJsonRequest(requests, 'GET', '/course_search_index/5');
+                    AjaxHelpers.expectJsonRequest(requests, 'GET', test_url);
                     AjaxHelpers.respondWithJson(requests, createMockIndexJSON(false));
                     expect(reindexSpy).toHaveBeenCalled();
                 });

--- a/cms/static/js/views/pages/course_outline.js
+++ b/cms/static/js/views/pages/course_outline.js
@@ -110,15 +110,14 @@ define(["jquery", "underscore", "gettext", "js/views/pages/base_page", "js/views
                 event.preventDefault();
                 var target = $(event.currentTarget);
                 target.css('cursor', 'wait');
-                this.startReIndex()
+                this.startReIndex(target.attr('href'))
                     .done(function() {self.onIndexSuccess();})
                     .always(function() {target.css('cursor', 'pointer');});
             },
 
-            startReIndex: function() {
-                var locator =  window.course.id;
+            startReIndex: function(reindex_url) {
                 return $.ajax({
-                    url: '/course_search_index/' + locator,
+                    url: reindex_url,
                     method: 'GET'
                     });
             },

--- a/cms/templates/course_outline.html
+++ b/cms/templates/course_outline.html
@@ -68,9 +68,9 @@ from contentstore.utils import reverse_usage_url
                         <i class="icon fa fa-plus"></i>${_('New Section')}
                     </a>
                 </li>
-                %if reindex_button:
+                %if reindex_link:
                     <li class="nav-item">
-                        <a href="#" class="button button-reindex" data-category="reindex" title="${_('Reindex current course')}">
+                        <a href="${reindex_link}" class="button button-reindex" data-category="reindex" title="${_('Reindex current course')}">
                             <i class="icon-arrow-right"></i>${_('Reindex')}
                         </a>
                     </li>


### PR DESCRIPTION
Rearrange reindexing button to use url formatted from within template; this will hopefully address the apparent flakiness of relying upon `window.course` member within javascript.

@dsego - Can you review as the first review?
