### PR TITLE
Add pagination to sysadmin dashboard Git import logs

### DIFF
--- a/lms/djangoapps/dashboard/sysadmin.py
+++ b/lms/djangoapps/dashboard/sysadmin.py
@@ -744,8 +744,10 @@ class GitLogs(TemplateView):
         except PageNotAnInteger:
             logs = paginator.page(1)
         except EmptyPage:
-            # If the page is too high
-            logs = paginator.page(paginator.num_pages)
+            # If the page is too high or low
+            given_page = int(request.GET.get('page'))
+            page = min(max(1, given_page), paginator.num_pages)
+            logs = paginator.page(page)
 
         mdb.disconnect()
         context = {

--- a/lms/djangoapps/dashboard/tests/test_sysadmin.py
+++ b/lms/djangoapps/dashboard/tests/test_sysadmin.py
@@ -25,6 +25,7 @@ from xmodule.modulestore.tests.django_utils import (
 from dashboard.models import CourseImportLog
 from dashboard.sysadmin import Users
 from dashboard.git_import import GitImportError
+from datetime import datetime
 from external_auth.models import ExternalAuthMap
 from student.roles import CourseStaffRole, GlobalStaff
 from student.tests.factories import UserFactory
@@ -589,26 +590,32 @@ class TestSysAdminMongoCourseImport(SysadminBaseTestCase):
         """
 
         self._setstaff_login()
-        self._mkdir(getattr(settings, 'GIT_REPO_DIR'))
 
-        self._add_edx4edx()
+        mongoengine.connect(TEST_MONGODB_LOG['db'])
 
-        for page in [-1, 0, 1, 2, 'abc']:
-            # Test the page parameter in various different ways
+        for _ in xrange(15):
+            CourseImportLog(
+                course_id=SlashSeparatedCourseKey("test", "test", "test"),
+                location="location",
+                import_log="import_log",
+                git_log="git_log",
+                repo_dir="repo_dir",
+                created=datetime.now()
+            ).save()
+
+        for page, expected in [(-1, 1), (1, 1), (2, 2), (30, 2), ('abc', 1)]:
             response = self.client.get(
                 '{}?page={}'.format(
-                    reverse('gitlogs_detail', kwargs={
-                        'course_id': 'MITx/edx4edx/edx4edx'
-                    }),
+                    reverse('gitlogs'),
                     page
                 )
             )
             self.assertIn(
-                'Page 1 of 1',
+                'Page {} of 2'.format(expected),
                 response.content
             )
 
-        self._rm_edx4edx()
+        CourseImportLog.objects.delete()
 
     def test_gitlog_courseteam_access(self):
         """

--- a/lms/djangoapps/dashboard/tests/test_sysadmin.py
+++ b/lms/djangoapps/dashboard/tests/test_sysadmin.py
@@ -582,6 +582,34 @@ class TestSysAdminMongoCourseImport(SysadminBaseTestCase):
 
         self._rm_edx4edx()
 
+    def test_gitlog_pagination_out_of_range_invalid(self):
+        """
+        Make sure the pagination behaves properly when the requested page is out
+        of range.
+        """
+
+        self._setstaff_login()
+        self._mkdir(getattr(settings, 'GIT_REPO_DIR'))
+
+        self._add_edx4edx()
+
+        for page in [-1, 0, 1, 2, 'abc']:
+            # Test the page parameter in various different ways
+            response = self.client.get(
+                '{}?page={}'.format(
+                    reverse('gitlogs_detail', kwargs={
+                        'course_id': 'MITx/edx4edx/edx4edx'
+                    }),
+                    page
+                )
+            )
+            self.assertIn(
+                'Page 1 of 1',
+                response.content
+            )
+
+        self._rm_edx4edx()
+
     def test_gitlog_courseteam_access(self):
         """
         Ensure course team users are allowed to access only their own course.

--- a/lms/templates/sysadmin_dashboard_gitlogs.html
+++ b/lms/templates/sysadmin_dashboard_gitlogs.html
@@ -30,6 +30,28 @@
       });
   </script>
 </%block>
+<%def name="pagination()">
+    <div class="pagination">
+        %if logs.has_previous():
+            <span class="previous-page">
+              <a href="?page=${logs.previous_page_number()}">
+                ${_("previous")}
+              </a>
+            </span>
+        %endif
+        ${_("Page {current_page} of {total_pages}".format(
+            current_page=logs.number,
+            total_pages=logs.paginator.num_pages
+        ))}
+        %if logs.has_next():
+            <span class="next-page">
+              <a href="?page=${logs.next_page_number()}">
+                ${_("next")}
+              </a>
+            </span>
+        %endif
+      </div>
+</%def>
 <style type="text/css">
 a.active-section {
 	color: #551A8B;
@@ -61,6 +83,19 @@ table.stat_table td {
 }
 .import-log {
     display: none;
+}
+
+.pagination, .page-status {
+    text-align: center;
+    padding: 12px 0 12px 0;
+}
+
+.pagination .previous-page {
+    padding-right: 10px;
+}
+
+.pagination .next-page {
+    padding-left: 10px;
 }
 
 a.selectedmode { background-color: yellow; }
@@ -102,64 +137,69 @@ textarea {
           %endif
       %endif
 
-      <table class="stat_table" width="100%">
-        <thead>
-          <tr>
-            <th width="15%">${_('Date')}</th>
-            <th width="15%">${_('Course ID')}</th>
-            ## Translators: Git is a version-control system; see http://git-scm.com/about
-            <th>${_('Git Action')}</th>
-          </tr>
-        </thead>
-        <tbody>
-          <%
-          if course_id == None:
-              logs = cilset[:10]
-          else:
-              logs = cilset[:5]
+      %if len(logs):
+          ${pagination()}
 
-          cil = None
-          %>
-          % for index, cil in enumerate(logs):
-              <%
-                  # Appropriate datetime string for current locale and timezone
-                  date = get_time_display(cil.created.replace(tzinfo=UTC),
-                                          DEFAULT_DATE_TIME_FORMAT, coerce_tz=settings.TIME_ZONE)
-              %>
+          <table class="stat_table" width="100%">
+            <thead>
               <tr>
-                <td>${date}</td>
-                <td>
-                  <a href="${reverse('gitlogs_detail', kwargs={'course_id': unicode(cil.course_id)})}">
-                    ${cil.course_id | h}
-                  </a>
-                </td>
-                <td>
-                  %if course_id is not None:
-                      <a class="toggle-import-log" data-import-log="${index}" href="#">[ + ]</a>
-                  %endif
-                  ${cil.git_log}
-                </td>
+                <th width="15%">${_('Date')}</th>
+                <th width="15%">${_('Course ID')}</th>
+                ## Translators: Git is a version-control system; see http://git-scm.com/about
+                <th>${_('Git Action')}</th>
               </tr>
-
-              ## Show the full log of the latest import if viewing logs for a specific course
-              %if course_id is not None:
-                  <tr class="import-log" id="import-log-${index}">
-                    <td colspan="3">
-                      <pre>
-                        ${cil.import_log | h}
-                      </pre>
+            </thead>
+            <tbody>
+              %for index, cil in enumerate(logs):
+                  <%
+                      # Appropriate datetime string for current locale and timezone
+                      date = get_time_display(cil.created.replace(tzinfo=UTC),
+                                              DEFAULT_DATE_TIME_FORMAT, coerce_tz=settings.TIME_ZONE)
+                  %>
+                  <tr>
+                    <td>${date}</td>
+                    <td>
+                      <a href="${reverse('gitlogs_detail', kwargs={'course_id': unicode(cil.course_id)})}">
+                        ${cil.course_id | h}
+                      </a>
+                    </td>
+                    <td>
+                      %if course_id is not None:
+                          <a class="toggle-import-log" data-import-log="${index}" href="#">[ + ]</a>
+                      %endif
+                      ${cil.git_log}
                     </td>
                   </tr>
-              %endif
-          %endfor
-        </tbody>
-      </table>
 
-      ## If viewing a single course and there are no logs available, let the user know
-      %if course_id is not None and cil is None:
-        ## Translators: git is a version-control system; see http://git-scm.com/about
-        ${_('No git import logs have been recorded for this course.')}
+                  ## Show the full log of the latest import if viewing logs for a specific course
+                  %if course_id is not None:
+                      <tr class="import-log" id="import-log-${index}">
+                        <td colspan="3">
+                          <pre>
+                            ${cil.import_log | h}
+                          </pre>
+                        </td>
+                      </tr>
+                  %endif
+              %endfor
+            </tbody>
+          </table>
+
+          ${pagination()}
+      %else:
+          <div class="page-status">
+            %if not course_id:
+                # If viewing all logs there are no logs available, let the user know
+                ## Translators: git is a version-control system; see http://git-scm.com/about
+                ${_('No git import logs have been recorded.')}
+            %else:
+                # If viewing a single course and there are no logs available, let the user know
+                ## Translators: git is a version-control system; see http://git-scm.com/about
+                ${_('No git import logs have been recorded for this course.')}
+            %endif
+          </div>
       %endif
+
     </section>
   </div>
 </section>


### PR DESCRIPTION
Add pagination to the git import log view in the Sysadmin dashboard. @carsongee 
## Log overview

![Log overview screenshot](http://i.imgur.com/9z1nFoE.png)
## Focused (single course) logs

![Focused logs screenshot](http://i.imgur.com/XFQ0Z6F.png)
