### PR TITLE
Finish Country Access (Part 2 of 3)

### DIFF
--- a/lms/djangoapps/shoppingcart/views.py
+++ b/lms/djangoapps/shoppingcart/views.py
@@ -2,9 +2,11 @@ import logging
 import datetime
 import decimal
 import pytz
+from ipware.ip import get_ip
 from django.db.models import Q
 from django.conf import settings
 from django.contrib.auth.models import Group
+from django.shortcuts import redirect
 from django.http import (
     HttpResponse, HttpResponseRedirect, HttpResponseNotFound,
     HttpResponseBadRequest, HttpResponseForbidden, Http404
@@ -28,6 +30,7 @@ from config_models.decorators import require_config
 from shoppingcart.reports import RefundReport, ItemizedPurchaseReport, UniversityRevenueShareReport, CertificateStatusReport
 from student.models import CourseEnrollment, EnrollmentClosedError, CourseFullError, \
     AlreadyEnrolledError
+from embargo import api as embargo_api
 from .exceptions import (
     ItemAlreadyInCartException, AlreadyEnrolledInCourseException,
     CourseDoesNotExistException, ReportTypeDoesNotExistException,
@@ -49,6 +52,7 @@ from .processors import (
 import json
 from xmodule_django.models import CourseKeyField
 from .decorators import enforce_shopping_cart_enabled
+
 
 log = logging.getLogger("shoppingcart")
 AUDIT_LOG = logging.getLogger("audit")
@@ -352,6 +356,15 @@ def register_code_redemption(request, registration_code):
         reg_code_is_valid, reg_code_already_redeemed, course_registration = get_reg_code_validity(registration_code,
                                                                                                   request, limiter)
         course = get_course_by_id(getattr(course_registration, 'course_id'), depth=0)
+
+        # Restrict the user from enrolling based on country access rules
+        embargo_redirect = embargo_api.redirect_if_blocked(
+            course.id, user=request.user, ip_address=get_ip(request),
+            url=request.path
+        )
+        if embargo_redirect is not None:
+            return redirect(embargo_redirect)
+
         context = {
             'reg_code_already_redeemed': reg_code_already_redeemed,
             'reg_code_is_valid': reg_code_is_valid,
@@ -365,6 +378,15 @@ def register_code_redemption(request, registration_code):
         reg_code_is_valid, reg_code_already_redeemed, course_registration = get_reg_code_validity(registration_code,
                                                                                                   request, limiter)
         course = get_course_by_id(getattr(course_registration, 'course_id'), depth=0)
+
+        # Restrict the user from enrolling based on country access rules
+        embargo_redirect = embargo_api.redirect_if_blocked(
+            course.id, user=request.user, ip_address=get_ip(request),
+            url=request.path
+        )
+        if embargo_redirect is not None:
+            return redirect(embargo_redirect)
+
         context = {
             'reg_code': registration_code,
             'site_name': site_name,

--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -8,6 +8,7 @@ import decimal
 import datetime
 from collections import namedtuple
 from pytz import UTC
+from ipware.ip import get_ip
 
 from edxmako.shortcuts import render_to_response, render_to_string
 
@@ -45,6 +46,8 @@ from opaque_keys.edx.keys import CourseKey
 from .exceptions import WindowExpiredException
 from xmodule.modulestore.django import modulestore
 from microsite_configuration import microsite
+
+from embargo import api as embargo_api
 
 from util.json_request import JsonResponse
 from util.date_utils import get_default_time_display
@@ -255,6 +258,17 @@ class PayAndVerifyView(View):
         if course is None:
             log.warn(u"No course specified for verification flow request.")
             raise Http404
+
+        # Check whether the user has access to this course
+        # based on country access rules.
+        redirect_url = embargo_api.redirect_if_blocked(
+            course_key,
+            user=request.user,
+            ip_address=get_ip(request),
+            url=request.path
+        )
+        if redirect_url:
+            return redirect(redirect_url)
 
         # Check that the course has an unexpired verified mode
         course_mode, expired_course_mode = self._get_verified_modes_for_course(course_key)

--- a/lms/static/js/spec/student_account/enrollment_spec.js
+++ b/lms/static/js/spec/student_account/enrollment_spec.js
@@ -6,7 +6,8 @@ define(['js/common_helpers/ajax_helpers', 'js/student_account/enrollment'],
 
             var COURSE_KEY = 'edX/DemoX/Fall',
                 ENROLL_URL = '/api/enrollment/v1/enrollment',
-                FORWARD_URL = '/course_modes/choose/edX/DemoX/Fall/';
+                FORWARD_URL = '/course_modes/choose/edX/DemoX/Fall/',
+                EMBARGO_MSG_URL = '/embargo/blocked-message/enrollment/default/';
 
             beforeEach(function() {
                 // Mock the redirect call
@@ -47,6 +48,27 @@ define(['js/common_helpers/ajax_helpers', 'js/student_account/enrollment'],
 
                 // Verify that the user was still redirected
                 expect(EnrollmentInterface.redirect).toHaveBeenCalledWith( FORWARD_URL );
+            });
+
+            it('redirects the user if blocked by an embargo', function() {
+                // Spy on Ajax requests
+                var requests = AjaxHelpers.requests( this );
+
+                // Attempt to enroll the user
+                EnrollmentInterface.enroll( COURSE_KEY );
+
+                // Simulate an error response (403) from the server
+                // with a "user_message_url" parameter for the redirect.
+                // This will redirect the user to a page with messaging
+                // explaining why he/she can't enroll.
+                AjaxHelpers.respondWithError(
+                    requests, 403,
+                    { 'user_message_url': EMBARGO_MSG_URL }
+                );
+
+                // Verify that the user was redirected
+                expect(EnrollmentInterface.redirect).toHaveBeenCalledWith( EMBARGO_MSG_URL );
+
             });
 
         });

--- a/lms/static/js/student_account/enrollment.js
+++ b/lms/static/js/student_account/enrollment.js
@@ -36,7 +36,26 @@ var edx = edx || {};
                 data: data,
                 headers: this.headers,
                 context: this
-            }).always(function() {
+            })
+            .fail(function( jqXHR ) {
+                var responseData = JSON.parse(jqXHR.responseText);
+                if ( jqXHR.status === 403 && responseData.user_message_url ) {
+                    // Check if we've been blocked from the course
+                    // because of country access rules.
+                    // If so, redirect to a page explaining to the user
+                    // why they were blocked.
+                    this.redirect( responseData.user_message_url );
+                }
+                else {
+                    // Otherwise, go to the track selection page as usual.
+                    // This can occur, for example, when a course does not
+                    // have a free enrollment mode, so we can't auto-enroll.
+                    this.redirect( this.trackSelectionUrl( courseKey ) );
+                }
+            })
+            .done(function() {
+                // If we successfully enrolled, go to the track selection
+                // page to allow the user to choose a paid enrollment mode.
                 this.redirect( this.trackSelectionUrl( courseKey ) );
             });
         },


### PR DESCRIPTION
Block users from enrolling in a course if the user
is blocked by country access rules.

1) Enrollment via the login/registration page.
2) Enrollment from the marketing iframe (via student.views.change_enrollment)
3) Enrollment using 100% redeem codes.
4) Enrollment via upgrade.

This does NOT cover enrollment through third party authentication,
which is sufficiently complex to deserve its own PR.

JIRA tickets:
[ECOM-997](https://openedx.atlassian.net/browse/ECOM-997)

@dianakhuang please review.
