### PR TITLE
Remove superfluous empty string check

### DIFF
--- a/cms/djangoapps/contentstore/views/checklist.py
+++ b/cms/djangoapps/contentstore/views/checklist.py
@@ -137,7 +137,7 @@ def localize_checklist_text(checklist):
     # Localize checklist items
     for item in checklist.get('items'):
         item['short_description'] = ugettext(item['short_description'])
-        item['long_description'] = ugettext(item['long_description']) if item['long_description'] != '' else u''
-        item['action_text'] = ugettext(item['action_text']) if item['action_text'] != "" else u""
+        item['long_description'] = ugettext(item['long_description'])
+        item['action_text'] = ugettext(item['action_text'])
 
     return checklist


### PR DESCRIPTION
Since we began monkey-patching `django.utils.translation` [1], we no
longer need to check for empty strings before translating them.
Previously, the empty string would be translated into translation
metadata. Now, translating the empty string intuitively yields the empty
string.

[1] 86633df3dbd76174d7691b13e7b06ab8f9c207d2
