### PR TITLE
ALT text describes image, not action

### DIFF
--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -51,7 +51,7 @@ from student.helpers import (
     % if show_courseware_link:
       % if not is_course_blocked:
         <a href="${course_target}" class="cover">
-        <img src="${course_image_url(course)}" alt="${_('{course_number} {course_name} Cover Image').format(course_number=course.number, course_name=course.display_name_with_default) |h}" />
+        <img src="${course_image_url(course)}" alt="${_('{course_number} {course_name} Home Page').format(course_number=course.number, course_name=course.display_name_with_default) |h}" />
       </a>
         % else:
         <a class="fade-cover">


### PR DESCRIPTION
At LMS dashboard course listing the course cover has alt
attribute that have course name and then Cover Page it describe
image not the action which is to take user to course home page

TNL-1383
