### PR TITLE
BUGFIX: shopping_cart_enabled + cosmetic price

### DIFF
--- a/lms/djangoapps/courseware/tests/test_about.py
+++ b/lms/djangoapps/courseware/tests/test_about.py
@@ -544,3 +544,17 @@ class AboutPurchaseCourseTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertIn("Course is full", resp.content)
         self.assertNotIn("Add buyme to Cart ($10)", resp.content)
+
+    def test_free_course_display(self):
+        """
+        Make sure other courses that don't have shopping cart enabled don't display the add-to-cart button
+        and don't display the course_price field if Cosmetic Price is disabled.
+        """
+        course = CourseFactory.create(org='MITx', number='free', display_name='Course For Free')
+        self.setup_user()
+        url = reverse('about_course', args=[course.id.to_deprecated_string()])
+
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 200)
+        self.assertNotIn("Add free to Cart (Free)", resp.content)
+        self.assertNotIn('<p class="important-dates-item-title">Price</p>', resp.content)

--- a/lms/djangoapps/courseware/views.py
+++ b/lms/djangoapps/courseware/views.py
@@ -815,6 +815,7 @@ def course_about(request, course_id):
                 reg_url=reverse('register_user'), course_id=course.id.to_deprecated_string())
 
         course_price = get_cosmetic_display_price(course, registration_price)
+        can_add_course_to_cart = _is_shopping_cart_enabled and registration_price
 
         # Used to provide context to message to student if enrollment not allowed
         can_enroll = has_access(request.user, 'enroll', course)
@@ -851,7 +852,7 @@ def course_about(request, course_id):
             # We do not want to display the internal courseware header, which is used when the course is found in the
             # context. This value is therefor explicitly set to render the appropriate header.
             'disable_courseware_header': True,
-            'is_shopping_cart_enabled': _is_shopping_cart_enabled,
+            'can_add_course_to_cart': can_add_course_to_cart,
             'cart_link': reverse('shoppingcart.views.show_cart'),
             'pre_requisite_courses': pre_requisite_courses
         })

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -37,7 +37,7 @@ from edxmako.shortcuts import marketing_link
       event.preventDefault();
     });
 
-    % if is_shopping_cart_enabled:
+    % if can_add_course_to_cart:
       add_course_complete_handler = function(jqXHR, textStatus) {
         if (jqXHR.status == 200) {
           location.href = "${cart_link}";
@@ -157,7 +157,7 @@ from edxmako.shortcuts import marketing_link
         ## so that they can register and become a real user that can enroll.
         % elif not is_shib_course and not can_enroll:
           <span class="register disabled">${_("Enrollment is Closed")}</span>
-        %elif is_shopping_cart_enabled and course_price:
+        %elif can_add_course_to_cart:
           <%
           if user.is_authenticated():
             reg_href = "#"
@@ -310,7 +310,7 @@ from edxmako.shortcuts import marketing_link
 
           ##<li class="important-dates-item"><i class="icon fa fa-clock-o"></i><p class="important-dates-item-title">${_('Course Length')}</p><span class="important-dates-item-text course-length">${_('{number} weeks').format(number=15)}</span></li>
 
-          %if course_price and (is_shopping_cart_enabled or is_cosmetic_price_enabled):
+          %if course_price and (can_add_course_to_cart or is_cosmetic_price_enabled):
             <li class="important-dates-item">
               <i class="icon fa fa-money"></i>
               <p class="important-dates-item-title">${_("Price")}</p>


### PR DESCRIPTION
- pass through registration price for use in template
- change conditional for add-to-cart to use registration price
- change conditional for sidebar price field to also include registration price
- add test for this case

this is a fix for: https://groups.google.com/forum/#!topic/edx-code/qQsIXkIs0D0

@chrisndodge & @sarina 
