### PR TITLE
ECOM-1055: Add messaging for when a student's verification will expire before the deadline

### DIFF
--- a/common/djangoapps/student/tests/test_verification_status.py
+++ b/common/djangoapps/student/tests/test_verification_status.py
@@ -13,7 +13,8 @@ from student.helpers import (
     VERIFY_STATUS_NEED_TO_VERIFY,
     VERIFY_STATUS_SUBMITTED,
     VERIFY_STATUS_APPROVED,
-    VERIFY_STATUS_MISSED_DEADLINE
+    VERIFY_STATUS_MISSED_DEADLINE,
+    VERIFY_STATUS_NEED_TO_REVERIFY
 )
 
 from xmodule.modulestore.tests.factories import CourseFactory
@@ -209,7 +210,7 @@ class TestCourseVerificationStatus(UrlResetMixin, ModuleStoreTestCase):
         # Expect that the "verify now" message is hidden
         # (since the user isn't allowed to submit another attempt while
         # a verification is active).
-        self._assert_course_verification_status(None)
+        self._assert_course_verification_status(VERIFY_STATUS_NEED_TO_REVERIFY)
 
     def _setup_mode_and_enrollment(self, deadline, enrollment_mode):
         """Create a course mode and enrollment.
@@ -235,7 +236,8 @@ class TestCourseVerificationStatus(UrlResetMixin, ModuleStoreTestCase):
         VERIFY_STATUS_NEED_TO_VERIFY: "ID verification pending",
         VERIFY_STATUS_SUBMITTED: "ID verification pending",
         VERIFY_STATUS_APPROVED: "ID Verified Ribbon/Badge",
-        VERIFY_STATUS_MISSED_DEADLINE: "Honor"
+        VERIFY_STATUS_MISSED_DEADLINE: "Honor",
+        VERIFY_STATUS_NEED_TO_REVERIFY: "Honor"
     }
 
     NOTIFICATION_MESSAGES = {
@@ -245,6 +247,7 @@ class TestCourseVerificationStatus(UrlResetMixin, ModuleStoreTestCase):
         ],
         VERIFY_STATUS_SUBMITTED: ["Thanks for your patience as we process your request."],
         VERIFY_STATUS_APPROVED: ["You have already verified your ID!"],
+        VERIFY_STATUS_NEED_TO_REVERIFY: ["Your verification will expire soon!"]
     }
 
     MODE_CLASSES = {
@@ -252,7 +255,8 @@ class TestCourseVerificationStatus(UrlResetMixin, ModuleStoreTestCase):
         VERIFY_STATUS_NEED_TO_VERIFY: "verified",
         VERIFY_STATUS_SUBMITTED: "verified",
         VERIFY_STATUS_APPROVED: "verified",
-        VERIFY_STATUS_MISSED_DEADLINE: "honor"
+        VERIFY_STATUS_MISSED_DEADLINE: "honor",
+        VERIFY_STATUS_NEED_TO_REVERIFY: "honor"
     }
 
     def _assert_course_verification_status(self, status):

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -10,7 +10,8 @@ from student.helpers import (
   VERIFY_STATUS_NEED_TO_VERIFY,
   VERIFY_STATUS_SUBMITTED,
   VERIFY_STATUS_APPROVED,
-  VERIFY_STATUS_MISSED_DEADLINE
+  VERIFY_STATUS_MISSED_DEADLINE,
+  VERIFY_STATUS_NEED_TO_REVERIFY
 )
 %>
 
@@ -134,7 +135,7 @@ from student.helpers import (
       <%include file='_dashboard_certificate_information.html' args='cert_status=cert_status,course=course, enrollment=enrollment'/>
       % endif
 
-      % if verification_status.get('status') in [VERIFY_STATUS_NEED_TO_VERIFY, VERIFY_STATUS_SUBMITTED, VERIFY_STATUS_APPROVED] and not is_course_blocked:
+      % if verification_status.get('status') in [VERIFY_STATUS_NEED_TO_VERIFY, VERIFY_STATUS_SUBMITTED, VERIFY_STATUS_APPROVED, VERIFY_STATUS_NEED_TO_REVERIFY] and not is_course_blocked:
       <div class="message message-status is-shown">
         % if verification_status['status'] == VERIFY_STATUS_NEED_TO_VERIFY:
           <div class="verification-reminder">
@@ -161,6 +162,11 @@ from student.helpers import (
           % if verification_status['verification_good_until'] is not None:
             <p class="message-copy">${_('Your verification status is good until {date}.').format(date=verification_status['verification_good_until'])}
           % endif
+        % elif verification_status['status'] == VERIFY_STATUS_NEED_TO_REVERIFY:
+          <h4 class="message-title">${_('Your verification will expire soon!')}</h4>
+          ## Translators: start_link and end_link will be replaced with HTML tags;
+          ## please do not translate these.
+          <p class="message-copy">${_('Your current verification will expire before the verification deadline for this course. {start_link}Re-verify your identity now{end_link} using a webcam and a government-issued ID.').format(start_link='<a href="{href}">'.format(href=reverse('verify_student_reverify')), end_link='</a>')}</p>
         % endif
       </div>
       % endif

--- a/lms/templates/verify_student/_reverification_support.html
+++ b/lms/templates/verify_student/_reverification_support.html
@@ -4,9 +4,9 @@
   <aside class="content-supplementary">
     <ul class="list-help">
       <li class="help-item help-item-whyreverify">
-        <h3 class="title">${_("Why Do I Need to Re-Verify?")}</h3>
+        <h3 class="title">${_("Why Do I Need to Re-Verify My Identity?")}</h3>
         <div class="copy">
-          <p>${_("At key points in a course, the professor will ask you to re-verify your identity. We will send the new photo to be matched up with the photo of the original ID you submitted when you signed up for the course.")}</p>
+          <p>${_("You may need to re-verify your identity if an error occurs with your verification or if your verification has expired. All verifications expire after one year.  The re-verification process is the same as the original verification process. You need a webcam and a government-issued photo ID.")}</p>
         </div>
       </li>
 

--- a/lms/templates/verify_student/photo_reverification.html
+++ b/lms/templates/verify_student/photo_reverification.html
@@ -60,9 +60,11 @@
     <div class="wrapper-reverification">
       <section class="reverification">
         <div class="message">
-          <h3 class="title">${_("Please Resubmit Your Verification Information")}</h3>
+          <h3 class="title">${_("Verify Your Identity")}</h3>
           <div class="copy">
-            <p>${_("There was an error with your previous verification. In order proceed in the verified certificate of achievement track of your current courses, please complete the following steps.")}</p>
+          ## Translators: {start_bold} and {end_bold} will be replaced with HTML tags.
+          ## Please do not translate these variables.
+            <p>${_("To verify your identity and continue as a verified student in this course, complete the following steps {start_bold}before the course verification deadline{end_bold}. If you do not verify your identity, you can still receive an honor code certificate for the course.").format(start_bold="<b>", end_bold="</b>")}</p>
           </div>
         </div>
 


### PR DESCRIPTION
[ECOM-1055](https://openedx.atlassian.net/browse/ECOM-1055): Add messaging for when a student's verification will expire before the deadline

This resolves a bug in which a student's status would appear to be "honor" even though the user had an active verification.  Since the verification was set to expire before the verification deadline, the "you need to verify" message would not be displayed.  In this PR, I've added messaging explaining that a student's verification is about to expire, so they need to reverify, with a link to the re-verification flow.

@dianakhuang could you please review this?

@srpearce Could you please review the text in the new message?  I have also removed the text "There was an error with your previous verification." from the re-verification flow, since users can now enter the flow even if an error hasn't occurred.

![image](https://cloud.githubusercontent.com/assets/2948394/6155246/c59be472-b1ff-11e4-9d29-6b84a579cf2c.png)
