### PR TITLE
Adds events to video player for CC menu

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
@@ -107,8 +107,8 @@ function (Sjson, AsyncProcess) {
 
             if (this.showLanguageMenu) {
                 this.container.on({
-                    mouseenter: this.onContainerMouseEnter,
-                    mouseleave: this.onContainerMouseLeave
+                    mouseenter: this.onContainerMouseEnter.bind(this),
+                    mouseleave: this.onContainerMouseLeave.bind(this)
                 });
             }
 
@@ -130,6 +130,7 @@ function (Sjson, AsyncProcess) {
             }
         },
 
+
         /**
         * @desc Opens language menu.
         *
@@ -137,7 +138,7 @@ function (Sjson, AsyncProcess) {
         */
         onContainerMouseEnter: function (event) {
             event.preventDefault();
-
+            this.state.videoPlayer.log('video_show_cc_menu', {});
             $(event.currentTarget).addClass('is-opened');
         },
 
@@ -148,7 +149,7 @@ function (Sjson, AsyncProcess) {
         */
         onContainerMouseLeave: function (event) {
             event.preventDefault();
-
+            this.state.videoPlayer.log('video_hide_cc_menu', {});
             $(event.currentTarget).removeClass('is-opened');
         },
 


### PR DESCRIPTION
This adds events to the CC menu. This builds on top of 6867, so I'd like to wait for that one to merge before reviewing this, but once tests pass, I'll flag this for review. 

The code moves functions in-line because the logging infrastructure does not appear to be available where the functions were previously defined.

This is slightly urgent -- we're investigating language issues in the platform, and the data we need is not being collected. 
