### PR TITLE
[WIP] ORA data export instructor task

### DIFF
--- a/common/djangoapps/util/query.py
+++ b/common/djangoapps/util/query.py
@@ -1,5 +1,6 @@
 """ Utility functions related to database queries """
 from django.conf import settings
+from django.db.utils import ConnectionDoesNotExist
 
 
 def use_read_replica_if_available(queryset):
@@ -7,3 +8,15 @@ def use_read_replica_if_available(queryset):
     If there is a database called 'read_replica', use that database for the queryset.
     """
     return queryset.using("read_replica") if "read_replica" in settings.DATABASES else queryset
+
+
+def get_read_replica_cursor_if_available(db):  # pylint: disable=invalid-name
+    """
+    Returns cursor to read_replica or default if not available
+    """
+    try:
+        cursor = db.connections['read_replica'].cursor()
+    except ConnectionDoesNotExist:
+        cursor = db.connection.cursor()
+
+    return cursor

--- a/lms/djangoapps/instructor/management/commands/collect_ora2_data.py
+++ b/lms/djangoapps/instructor/management/commands/collect_ora2_data.py
@@ -1,0 +1,67 @@
+"""
+Command to retrieve all ORA2 data for a course in a .csv.
+"""
+import csv
+from optparse import make_option
+import os
+
+from instructor.utils import collect_ora2_data
+from opaque_keys import InvalidKeyError
+from opaque_keys.edx.locations import SlashSeparatedCourseKey
+
+from django.core.management.base import BaseCommand, CommandError
+
+
+class Command(BaseCommand):
+    """
+    Query aggregated open assessment data, write to .csv
+    """
+
+    help = ("Usage: collect_ora2_data <course_id> --output-dir=<output_dir>")
+    args = "<course_id>"
+
+    option_list = BaseCommand.option_list + (
+        make_option('-o', '--output-dir',
+                    action='store', dest='output_dir', default=None,
+                    help="Write output to a directory rather than stdout"),
+    )
+
+    def handle(self, *args, **options):
+        if not args:
+            raise CommandError("Course ID must be specified to fetch data")
+
+        if isinstance(args[0], SlashSeparatedCourseKey):
+            course_id = args[0]
+        else:
+            try:
+                course_id = SlashSeparatedCourseKey.from_deprecated_string(args[0].decode('utf-8'))
+            except InvalidKeyError:
+                raise CommandError("The course ID given was invalid")
+
+        file_name = ("%s-ora2.csv" % course_id).replace("/", "-")
+
+        if options['output_dir']:
+            csv_file = open(os.path.join(options['output_dir'], file_name), 'wb')
+        else:
+            csv_file = self.stdout
+
+        writer = csv.writer(csv_file, dialect='excel', quotechar='"', quoting=csv.QUOTE_ALL)
+
+        header, rows = collect_ora2_data(course_id)
+
+        writer.writerow(header)
+        for row in rows:
+            writer.writerow(_preprocess(row))
+
+
+def _preprocess(data_list):
+    """
+    Properly encode ora2 responses for transcription into a .csv
+    """
+    processed_data = []
+
+    for item in data_list:
+        new_item = unicode(item).encode('utf-8')
+        processed_data.append(new_item)
+
+    return processed_data

--- a/lms/djangoapps/instructor/management/tests/test_collect_ora2_data.py
+++ b/lms/djangoapps/instructor/management/tests/test_collect_ora2_data.py
@@ -1,0 +1,75 @@
+""" Test the collect_ora2_data management command """
+
+from mock import patch
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory
+
+
+class CollectOra2DataTest(ModuleStoreTestCase):
+    """ Test collect_ora2_data output and error conditions """
+
+    def setUp(self):
+        self.course = CourseFactory.create()
+
+        self.test_header = [
+            "submission_uuid",
+            "item_id",
+            "anonymized_student_id",
+            "submitted_at",
+            "raw_answer",
+            "assessments",
+            "assessments_parts",
+            "final_score_given_at",
+            "final_score_points_earned",
+            "final_score_points_possible",
+            "feedback_options",
+            "feedback",
+        ]
+
+        self.test_row = [
+            [
+                "33a639de-4e61-11e4-82ab-hash_value",
+                "i4x://edX/DemoX/openassessment/hash_value",
+                "e31b4beb3d191cd47b07e17735728d53",
+                "2014-10-07 20:33:31+00:00",
+                '{""text"": ""This is a response to a question. #dylan""}',
+                "Assessment #1 -- scored_at: 2014-10-07 20:37:54 -- type: T -- scorer_id: hash -- feedback: Test",
+                "Assessment #1 -- Content: Unclear recommendation (5)",
+                "2014-10-07 21:35:47+00:00",
+                "10",
+                "20",
+                "Completed test assessments.",
+                "They were useful.",
+            ]
+        ]
+
+    def test_invalid_course_key(self):
+        """ Verify that management command raises exception for invalid or missing course """
+
+        self.assertRaises(CommandError, call_command, ('collect_ora2_data',))
+        self.assertRaises(CommandError, call_command, ('collect_ora2_data',), 'invalid_course_id')
+
+    @patch('instructor.management.commands.collect_ora2_data.collect_ora2_data')
+    def test_valid_data_output_to_file(self, mock_data):
+        """ Verify that management command writes valid ORA2 data to file. """
+
+        mock_data.return_value = (self.test_header, self.test_row)
+
+        with patch('instructor.management.commands.collect_ora2_data.csv') as mock_write:
+            call_command('collect_ora2_data', self.course.id.to_deprecated_string())
+
+            mock_writerow = mock_write.writer.return_value.writerow
+
+            mock_writerow.assert_any_call(self.test_header)
+            mock_writerow.assert_called_with(self.test_row[0])
+
+            mock_writerow.mock_calls = []
+
+            call_command('collect_ora2_data', self.course.id)
+
+            mock_writerow.assert_any_call(self.test_header)
+            mock_writerow.assert_called_with(self.test_row[0])

--- a/lms/djangoapps/instructor/utils.py
+++ b/lms/djangoapps/instructor/utils.py
@@ -2,10 +2,13 @@
 Helpers for instructor app.
 """
 
+from django import db
+
 from xmodule.modulestore.django import modulestore
 
 from courseware.model_data import FieldDataCache
 from courseware.module_render import get_module
+from util.query import get_read_replica_cursor_if_available
 
 
 class DummyRequest(object):
@@ -36,3 +39,120 @@ def get_module_for_student(student, usage_key, request=None):
     descriptor = modulestore().get_item(usage_key, depth=0)
     field_data_cache = FieldDataCache([descriptor], usage_key.course_key, student)
     return get_module(student, request, usage_key, field_data_cache)
+
+
+def collect_ora2_data(course_id):
+    """
+    Query MySQL database for aggregated ora2 response data.
+    """
+    cursor = get_read_replica_cursor_if_available(db)
+
+    # Syntax unsupported by other vendors such as SQLite test db
+    if db.connection.vendor != 'mysql':
+        return '', ['']
+
+    raw_queries = ora2_data_queries().split(';')
+
+    cursor.execute(raw_queries[0])
+    cursor.execute(raw_queries[1], [course_id])
+
+    header = [item[0] for item in cursor.description]
+
+    return header, cursor.fetchall()
+
+
+def ora2_data_queries():
+    """
+    Wraps a raw SQL query which retrieves all ORA2 responses for a course.
+    """
+
+    # pylint: disable=invalid-name
+    RAW_QUERY = """
+SET SESSION group_concat_max_len = 1000000;
+SELECT `sub`.`uuid` AS `submission_uuid`,
+`student`.`item_id` AS `item_id`,
+`student`.`student_id` AS `anonymized_student_id`,
+`sub`.`submitted_at` AS `submitted_at`,
+`sub`.`raw_answer` AS `raw_answer`,
+(
+    SELECT GROUP_CONCAT(
+        CONCAT(
+            "Assessment #", `assessment`.`id`,
+            " -- scored_at: ", `assessment`.`scored_at`,
+            " -- type: ", `assessment`.`score_type`,
+            " -- scorer_id: ", `assessment`.`scorer_id`,
+            IF(
+                `assessment`.`feedback` != "",
+                CONCAT(" -- overall_feedback: ", `assessment`.`feedback`),
+                ""
+            )
+        )
+        SEPARATOR '\n'
+    )
+    FROM `assessment_assessment` AS `assessment`
+    WHERE `assessment`.`submission_uuid`=`sub`.`uuid`
+    ORDER BY `assessment`.`scored_at` ASC
+) AS `assessments`,
+(
+    SELECT GROUP_CONCAT(
+        CONCAT(
+            "Assessment #", `assessment`.`id`,
+            " -- ", `criterion`.`label`,
+            IFNULL(CONCAT(": ", `option`.`label`, " (", `option`.`points`, ")"), ""),
+            IF(
+                `assessment_part`.`feedback` != "",
+                CONCAT(" -- feedback: ", `assessment_part`.`feedback`),
+                ""
+            )
+        )
+        SEPARATOR '\n'
+    )
+    FROM `assessment_assessment` AS `assessment`
+    JOIN `assessment_assessmentpart` AS `assessment_part`
+    ON `assessment_part`.`assessment_id`=`assessment`.`id`
+    JOIN `assessment_criterion` AS `criterion`
+    ON `criterion`.`id`=`assessment_part`.`criterion_id`
+    LEFT JOIN `assessment_criterionoption` AS `option`
+    ON `option`.`id`=`assessment_part`.`option_id`
+    WHERE `assessment`.`submission_uuid`=`sub`.`uuid`
+    ORDER BY `assessment`.`scored_at` ASC, `criterion`.`order_num` DESC
+) AS `assessments_parts`,
+(
+    SELECT `created_at`
+    FROM `submissions_score` AS `score`
+    WHERE `score`.`submission_id`=`sub`.`id`
+    ORDER BY `score`.`created_at` DESC LIMIT 1
+) AS `final_score_given_at`,
+(
+    SELECT `points_earned`
+    FROM `submissions_score` AS `score`
+    WHERE `score`.`submission_id`=`sub`.`id`
+    ORDER BY `score`.`created_at` DESC LIMIT 1
+) AS `final_score_points_earned`,
+(
+    SELECT `points_possible`
+    FROM `submissions_score` AS `score`
+    WHERE `score`.`submission_id`=`sub`.`id`
+    ORDER BY `score`.`created_at` DESC LIMIT 1
+) AS `final_score_points_possible`,
+(
+    SELECT GROUP_CONCAT(`feedbackoption`.`text` SEPARATOR '\n')
+    FROM `assessment_assessmentfeedbackoption` AS `feedbackoption`
+    JOIN `assessment_assessmentfeedback_options` AS `feedback_join`
+    ON `feedback_join`.`assessmentfeedbackoption_id`=`feedbackoption`.`id`
+    JOIN `assessment_assessmentfeedback` AS `feedback`
+    ON `feedback`.`id`=`feedback_join`.`assessmentfeedback_id`
+    WHERE `feedback`.`submission_uuid`=`sub`.`uuid`
+) AS `feedback_options`,
+(
+    SELECT `feedback_text`
+    FROM `assessment_assessmentfeedback` as `feedback`
+    WHERE `feedback`.`submission_uuid`=`sub`.`uuid`
+    LIMIT 1
+) AS `feedback`
+FROM `submissions_submission` AS `sub`
+JOIN `submissions_studentitem` AS `student` ON `sub`.`student_item_id`=`student`.`id`
+WHERE `student`.`item_type`="openassessment" AND `student`.`course_id`=%s
+    """
+
+    return RAW_QUERY

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -1716,12 +1716,10 @@ def calculate_grades_csv(request, course_id):
     try:
         instructor_task.api.submit_calculate_grades_csv(request, course_key)
         success_status = _("Your grade report is being generated! You can view the status of the generation task in the 'Pending Instructor Tasks' section.")
-        return JsonResponse({"status": success_status})
+        return JsonResponse({"status": success_status}, status=202)
     except AlreadyRunningError:
         already_running_status = _("A grade report generation task is already in progress. Check the 'Pending Instructor Tasks' table for the status of the task. When completed, the report will be available for download in the table below.")
-        return JsonResponse({
-            "status": already_running_status
-        })
+        return JsonResponse({"status": already_running_status}, status=202)
 
 
 @ensure_csrf_cookie
@@ -1784,6 +1782,30 @@ def list_forum_members(request, course_id):
         rolename: map(extract_user_info, users),
     }
     return JsonResponse(response_payload)
+
+
+@ensure_csrf_cookie
+@cache_control(no_cache=True, no_store=True, must_revalidate=True)
+@require_level('staff')
+def get_ora2_responses(request, course_id):
+    """
+    Pushes a Celery task which will aggregate ora2 responses for a course into a .csv
+    """
+    course_key = SlashSeparatedCourseKey.from_deprecated_string(course_id)
+    try:
+        instructor_task.api.submit_ora2_request_task(request, course_key)
+        success_status = _("The ORA2 response report is being generated.")
+
+        return JsonResponse({"status": success_status}, status=202)
+    except AlreadyRunningError:
+        already_running_status = _(
+            "An ORA2 response report generation task is already in "
+            "progress. Check the 'Pending Instructor Tasks' table "
+            "for the status of the task. When completed, the report "
+            "will be available for download in the table below."
+        )
+
+        return JsonResponse({"status": already_running_status}, status=202)
 
 
 @ensure_csrf_cookie

--- a/lms/djangoapps/instructor/views/api_urls.py
+++ b/lms/djangoapps/instructor/views/api_urls.py
@@ -76,6 +76,11 @@ urlpatterns = patterns('',  # nopep8
     url(r'spent_registration_codes$',
         'instructor.views.api.spent_registration_codes', name="spent_registration_codes"),
 
+    # pylint: disable=bad-continuation
+    # Ora2 Report download...
+    url(r'get_ora2_responses',
+        'instructor.views.api.get_ora2_responses', name="get_ora2_responses"),
+
     # Coupon Codes..
     url(r'get_coupon_codes',
         'instructor.views.api.get_coupon_codes', name="get_coupon_codes"),

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -339,6 +339,7 @@ def _section_data_download(course, access):
         'list_instructor_tasks_url': reverse('list_instructor_tasks', kwargs={'course_id': unicode(course_key)}),
         'list_report_downloads_url': reverse('list_report_downloads', kwargs={'course_id': unicode(course_key)}),
         'calculate_grades_csv_url': reverse('calculate_grades_csv', kwargs={'course_id': unicode(course_key)}),
+        'get_ora2_responses_url': reverse('get_ora2_responses', kwargs={'course_id': unicode(course_key)}),
     }
     return section_data
 

--- a/lms/djangoapps/instructor_task/api.py
+++ b/lms/djangoapps/instructor_task/api.py
@@ -21,11 +21,13 @@ from instructor_task.tasks import (
     calculate_grades_csv,
     calculate_students_features_csv,
     cohort_students,
+    get_ora2_responses,
 )
-
-from instructor_task.api_helper import (check_arguments_for_rescoring,
-                                        encode_problem_and_student_input,
-                                        submit_task)
+from instructor_task.api_helper import (
+    check_arguments_for_rescoring,
+    encode_problem_and_student_input,
+    submit_task,
+)
 from bulk_email.models import CourseEmail
 
 
@@ -36,6 +38,7 @@ def get_running_instructor_tasks(course_id):
     Used to generate a list of tasks to display on the instructor dashboard.
     """
     instructor_tasks = InstructorTask.objects.filter(course_id=course_id)
+
     # exclude states that are "ready" (i.e. not "running", e.g. failure, success, revoked):
     for state in READY_STATES:
         instructor_tasks = instructor_tasks.exclude(task_state=state)
@@ -248,5 +251,17 @@ def submit_cohort_students(request, course_key, file_name):
     task_class = cohort_students
     task_input = {'file_name': file_name}
     task_key = ""
+
+    return submit_task(request, task_type, task_class, course_key, task_input, task_key)
+
+
+def submit_ora2_request_task(request, course_key):
+    """
+    AlreadyRunningError is raised if an ora2 report is already being generated.
+    """
+    task_type = 'ora2_responses'
+    task_class = get_ora2_responses
+    task_input = {}
+    task_key = ''
 
     return submit_task(request, task_type, task_class, course_key, task_input, task_key)

--- a/lms/djangoapps/instructor_task/tasks.py
+++ b/lms/djangoapps/instructor_task/tasks.py
@@ -32,7 +32,8 @@ from instructor_task.tasks_helper import (
     delete_problem_module_state,
     upload_grades_csv,
     upload_students_csv,
-    cohort_students_and_upload
+    cohort_students_and_upload,
+    push_ora2_responses_to_s3,
 )
 from bulk_email.tasks import perform_delegate_email_batches
 
@@ -165,4 +166,14 @@ def cohort_students(entry_id, xmodule_instance_args):
     # An example of such a message is: "Progress: {action} {succeeded} of {attempted} so far"
     action_name = ugettext_noop('cohorted')
     task_fn = partial(cohort_students_and_upload, xmodule_instance_args)
+    return run_main_task(entry_id, task_fn, action_name)
+
+
+@task(base=BaseInstructorTask, routing_key=settings.ORA2_RESPONSES_DOWNLOAD_ROUTING_KEY)  # pylint: disable=not-callable
+def get_ora2_responses(entry_id, xmodule_instance_args):
+    """
+    Generate a CSV of ora2 responses and push it to S3.
+    """
+    action_name = ugettext_noop('generated')
+    task_fn = partial(push_ora2_responses_to_s3, xmodule_instance_args)
     return run_main_task(entry_id, task_fn, action_name)

--- a/lms/djangoapps/instructor_task/tests/test_tasks.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks.py
@@ -11,6 +11,8 @@ from uuid import uuid4
 from mock import Mock, MagicMock, patch
 
 from celery.states import SUCCESS, FAILURE
+from django.utils.translation import ugettext_noop
+from functools import partial
 
 from xmodule.modulestore.exceptions import ItemNotFoundError
 from opaque_keys.edx.locations import i4xEncoder
@@ -22,8 +24,16 @@ from student.tests.factories import UserFactory, CourseEnrollmentFactory
 from instructor_task.models import InstructorTask
 from instructor_task.tests.test_base import InstructorTaskModuleTestCase
 from instructor_task.tests.factories import InstructorTaskFactory
-from instructor_task.tasks import rescore_problem, reset_problem_attempts, delete_problem_state
-from instructor_task.tasks_helper import UpdateProblemModuleStateError
+from instructor_task.tasks import (
+    rescore_problem,
+    reset_problem_attempts,
+    delete_problem_state,
+    get_ora2_responses,
+)
+from instructor_task.tasks_helper import (
+    UpdateProblemModuleStateError,
+    push_ora2_responses_to_s3,
+)
 
 PROBLEM_URL_NAME = "test_urlname"
 
@@ -438,3 +448,31 @@ class TestDeleteStateInstructorTask(TestInstructorTasks):
                 StudentModule.objects.get(course_id=self.course.id,
                                           student=student,
                                           module_state_key=self.location)
+
+
+class TestOra2ResponsesInstructorTask(TestInstructorTasks):
+    """Tests instructor task that fetches ora2 response data."""
+
+    def test_ora2_missing_current_task(self):
+        self._test_missing_current_task(get_ora2_responses)
+
+    def test_ora2_with_failure(self):
+        self._test_run_with_failure(get_ora2_responses, 'We expected this to fail')
+
+    def test_ora2_with_long_error_msg(self):
+        self._test_run_with_long_error_msg(get_ora2_responses)
+
+    def test_ora2_with_short_error_msg(self):
+        self._test_run_with_short_error_msg(get_ora2_responses)
+
+    def test_ora2_runs_task(self):
+        task_entry = self._create_input_entry()
+        task_xmodule_args = self._get_xmodule_instance_args()
+
+        with patch('instructor_task.tasks.run_main_task') as mock_main_task:
+            get_ora2_responses(task_entry.id, task_xmodule_args)
+
+            action_name = ugettext_noop('generated')
+            task_fn = partial(push_ora2_responses_to_s3, task_xmodule_args)
+
+            mock_main_task.assert_called_once_with_args(task_entry.id, task_fn, action_name)

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -6,10 +6,21 @@ Unit tests for LMS instructor-initiated background tasks helper functions.
 Tests that CSV grade report generation works with unicode emails.
 
 """
+
+import os
+import shutil
+from datetime import datetime
+import urllib
+
 import ddt
+from freezegun import freeze_time
 from mock import Mock, patch
 import tempfile
 import unicodecsv
+
+from django.conf import settings
+from django.test.testcases import TestCase
+from pytz import UTC
 
 from xmodule.modulestore.tests.factories import CourseFactory
 from student.tests.factories import UserFactory
@@ -20,6 +31,11 @@ from openedx.core.djangoapps.course_groups.tests.helpers import CohortFactory
 from instructor_task.models import ReportStore
 from instructor_task.tasks_helper import cohort_students_and_upload, upload_grades_csv, upload_students_csv
 from instructor_task.tests.test_base import InstructorTaskCourseTestCase, TestReportMixin
+from instructor_task.tasks_helper import (
+    push_ora2_responses_to_s3,
+    UPDATE_STATUS_FAILED,
+    UPDATE_STATUS_SUCCEEDED,
+)
 
 
 @ddt.ddt
@@ -434,3 +450,50 @@ class TestCohortStudents(TestReportMixin, InstructorTaskCourseTestCase):
             ],
             verify_order=False
         )
+
+
+class TestInstructorOra2Report(TestCase):
+    """
+    Tests that ORA2 response report generation works.
+    """
+    def setUp(self):
+        self.course = CourseFactory.create()
+
+        self.current_task = Mock()
+        self.current_task.update_state = Mock()
+
+    def tearDown(self):
+        if os.path.exists(settings.ORA2_RESPONSES_DOWNLOAD['ROOT_PATH']):
+            shutil.rmtree(settings.ORA2_RESPONSES_DOWNLOAD['ROOT_PATH'])
+
+    def test_report_fails_if_error(self):
+        with patch('instructor_task.tasks_helper.collect_ora2_data') as mock_collect_data:
+            mock_collect_data.side_effect = KeyError
+
+            with patch('instructor_task.tasks_helper._get_current_task') as mock_current_task:
+                mock_current_task.return_value = self.current_task
+
+                response = push_ora2_responses_to_s3(None, None, self.course.id, None, 'generated')
+                self.assertEqual(response, UPDATE_STATUS_FAILED)
+
+    @freeze_time('2001-01-01 00:00:00')
+    def test_report_stores_results(self):
+        test_header = ['field1', 'field2']
+        test_rows = [['row1_field1', 'row1_field2'], ['row2_field1', 'row2_field2']]
+
+        with patch('instructor_task.tasks_helper._get_current_task') as mock_current_task:
+            mock_current_task.return_value = self.current_task
+
+            with patch('instructor_task.tasks_helper.collect_ora2_data') as mock_collect_data:
+                mock_collect_data.return_value = (test_header, test_rows)
+
+                with patch('instructor_task.models.LocalFSReportStore.store_rows') as mock_store_rows:
+                    return_val = push_ora2_responses_to_s3(None, None, self.course.id, None, 'generated')
+
+                    # pylint: disable=maybe-no-member
+                    timestamp_str = datetime.now(UTC).strftime('%Y-%m-%d-%H%M')
+                    course_id_string = urllib.quote(self.course.id.to_deprecated_string().replace('/', '_'))
+                    filename = u'{}_ORA2_responses_{}.csv'.format(course_id_string, timestamp_str)
+
+                    self.assertEqual(return_val, UPDATE_STATUS_SUCCEEDED)
+                    mock_store_rows.assert_called_once_with(self.course.id, filename, [test_header] + test_rows)

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -424,6 +424,11 @@ GRADES_DOWNLOAD_ROUTING_KEY = HIGH_MEM_QUEUE
 
 GRADES_DOWNLOAD = ENV_TOKENS.get("GRADES_DOWNLOAD", GRADES_DOWNLOAD)
 
+# ORA2 Responses Download
+ORA2_RESPONSES_DOWNLOAD_ROUTING_KEY = HIGH_MEM_QUEUE
+
+ORA2_RESPONSES_DOWNLOAD = ENV_TOKENS.get("ORA2_RESPONSES_DOWNLOAD", ORA2_RESPONSES_DOWNLOAD)
+
 ##### ORA2 ######
 # Prefix for uploads of example-based assessment AI classifiers
 # This can be used to separate uploads for different environments

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1746,6 +1746,15 @@ GRADES_DOWNLOAD = {
     'ROOT_PATH': '/tmp/edx-s3/grades',
 }
 
+##################### ORA2 Responses Download #######################
+ORA2_RESPONSES_DOWNLOAD_ROUTING_KEY = HIGH_MEM_QUEUE
+
+ORA2_RESPONSES_DOWNLOAD = {
+    'STORAGE_TYPE': 'localfs',
+    'BUCKET': 'edx-grades',
+    'ROOT_PATH': '/tmp/edx-s3/ora2-responses',
+}
+
 ######################## PROGRESS SUCCESS BUTTON ##############################
 # The following fields are available in the URL: {course_id} {student_id}
 PROGRESS_SUCCESS_BUTTON_URL = 'http://<domain>/<path>/{course_id}'

--- a/lms/static/coffee/src/instructor_dashboard/data_download.coffee
+++ b/lms/static/coffee/src/instructor_dashboard/data_download.coffee
@@ -21,7 +21,7 @@ class DataDownload
     @$list_studs_csv_btn = @$section.find("input[name='list-profiles-csv']'")
     @$list_anon_btn = @$section.find("input[name='list-anon-ids']'")
     @$grade_config_btn = @$section.find("input[name='dump-gradeconf']'")
-    @$calculate_grades_csv_btn = @$section.find("input[name='calculate-grades-csv']'")
+    @$async_report_btn = @$section.find("input[class='async-report-btn']'")
 
     # response areas
     @$download                        = @$section.find '.data-download-container'
@@ -31,6 +31,7 @@ class DataDownload
     @$download_display_table          = @$reports.find '.data-display-table'
     @$reports_request_response        = @$reports.find '.request-response'
     @$reports_request_response_error  = @$reports.find '.request-response-error'
+
 
     @report_downloads = new ReportDownloads(@$section)
     @instructor_tasks = new (PendingInstructorTasks()) @$section
@@ -107,17 +108,20 @@ class DataDownload
           @clear_display()
           @$download_display_text.html data['grading_config_summary']
 
-    @$calculate_grades_csv_btn.click (e) =>
+    @$async_report_btn.click (e) =>
       # Clear any CSS styling from the request-response areas
       #$(".msg-confirm").css({"display":"none"})
       #$(".msg-error").css({"display":"none"})
       @clear_display()
-      url = @$calculate_grades_csv_btn.data 'endpoint'
+      url = $(e.target).data 'endpoint'
       $.ajax
         dataType: 'json'
         url: url
-        error: (std_ajax_err) =>
-          @$reports_request_response_error.text gettext("Error generating grades. Please try again.")
+        error: std_ajax_err =>
+          if e.target.name == 'calculate-grades-csv'
+            @$grades_request_response_error.text gettext("Error generating grades. Please try again.")
+          else if e.target.name == 'ora2-response-btn'
+            @$grades_request_response_error.text gettext("Error getting ORA2 responses. Please try again.")
           $(".msg-error").css({"display":"block"})
         success: (data) =>
           @$reports_request_response.text data['status']

--- a/lms/templates/instructor/instructor_dashboard_2/data_download.html
+++ b/lms/templates/instructor/instructor_dashboard_2/data_download.html
@@ -39,8 +39,10 @@
 
   %if settings.FEATURES.get('ALLOW_COURSE_STAFF_GRADE_DOWNLOADS') or section_data['access']['admin']:
     <p>${_("Click to generate a CSV grade report for all currently enrolled students.")}</p>
-
-    <p><input type="button" name="calculate-grades-csv" value="${_("Generate Grade Report")}" data-endpoint="${ section_data['calculate_grades_csv_url'] }"/></p>
+    <p>
+      <input type="button" name="calculate-grades-csv" class="async-report-btn" value="${_("Generate Grade Report")}" data-endpoint="${ section_data['calculate_grades_csv_url'] }"/>
+      <input type="button" name="ora2-response-btn" class="async-report-btn" value="${_("Download ORA2 Responses")}" data-endpoint="${ section_data['get_ora2_responses_url'] }"/>
+    </p>
   %endif
 
     <div class="request-response msg msg-confirm copy" id="report-request-response"></div>


### PR DESCRIPTION
Initial review was done in https://github.com/edx/edx-platform/pull/5987

Includes management command and instructor dashboard button which gather all open assessment response data for a given course in a user friendly format and output it as a .csv

WIP finished collect_ora2_data management command, wired it to instructor dashboard UI, still needs to have logic factored out and exposed in instructor_analytics.basic

Remove extraneous print statement

Refactored sql querying logic into instructor.utils and wired the html button and management command to it there

Added comments to several methods

Added optional output_dir argument to collect_ora2_data management command and default behavior to write to stdout

Simplified code structure in management command and comments per jrbl's PR comments

Responded to jrbl's style comments, added test reference to check endpoint, and parameterized database name from django.conf.settings

Removed reference to django.conf.settings['DATABASE'] in favor of django's natural default

Removed extraneous import and whitespace per overlooked jrbl comment

Factored db connection logic into common/djangoapps/util/query.py

Whitespace changes

This implements a celery-ized button for downloading ORA2 responses via the instructor data download dashboard.

WIP finished collect_ora2_data management command, wired it to instructor dashboard UI, still needs to have logic factored out and exposed in instructor_analytics.basic

Remove extraneous print statement

Refactored sql querying logic into instructor.utils and wired the html button and management command to it there

Added comments to several methods

Added optional output_dir argument to collect_ora2_data management command and default behavior to write to stdout

Simplified code structure in management command and comments per jrbl's PR comments

Responded to jrbl's style comments, added test reference to check endpoint, and parameterized database name from django.conf.settings

Removed reference to django.conf.settings['DATABASE'] in favor of django's natural default

Removed extraneous import and whitespace per overlooked jrbl comment

Factored db connection logic into common/djangoapps/util/query.py

Whitespace changes

First stab at conversion to celery command from synchronous version

WIP Converted ora2 report to asynchronous/celery format, still needs integration with progress table and proper S3 key.

Implemented unit tests for instructor api, integrated ora2 celery job with pending tasks table, and cleaned up code for pylint

Removed extraneously included file from commits

Added more unit tests and reformatted whitespace

Fixed PEP8 violations, replaced pylint disable codes with string representations, and improved brittle unit test

Reformatted long string and removed extraneous redirect from javascript

Conflicts:

```
common/djangoapps/util/query.py
lms/djangoapps/instructor/tests/test_api.py
lms/djangoapps/instructor/views/instructor_dashboard.py
lms/djangoapps/instructor_task/api.py
lms/djangoapps/instructor_task/tasks.py
lms/djangoapps/instructor_task/tasks_helper.py
lms/djangoapps/instructor_task/tests/test_api.py
lms/djangoapps/instructor_task/tests/test_tasks_helper.py
lms/envs/aws.py
lms/envs/common.py
lms/static/coffee/src/instructor_dashboard/data_download.coffee
lms/templates/instructor/instructor_dashboard_2/data_download.html
```

Resolved additional merge conflicts

Corrected PEP8 violations and removed extraneous imports to Stanford specific functions.

Whitespace change and test case improvement.

Whitespace change to fix PEP8 violation

Remove string escape from management command data preprocesing

Responded to comments on upstream PR

Switched status code and fixed Javascript problems and PEP8 violations

Add pylint disable comments

Switched unit tests to new status code for asynchronous report requests and fixed minor pep8 whitespace issues

Added missing import statement

Fixed pep8 violations

Fixed pep8 violation

Changed whitespace

Fixing pep8 violation

Attempt at pep8 fix

Disabled pylint check for indent continuation in api_urls.py

Small change to event strings and whitespace issue

Added test cases for collect_ora2_data management command
