### PR TITLE
Update diff-cover version

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -132,7 +132,7 @@ django-debug-toolbar-mongo
 chrono==1.0.2
 coverage==3.7
 ddt==0.8.0
-diff-cover==0.7.3
+diff-cover==0.7.4
 django-crum==0.5
 django_nose==1.3
 factory_boy==2.2.1


### PR DESCRIPTION
This is to keep up with the latest version, which introduced a fix for duplicate-code (R0801) violations parsing.
