### PR TITLE
Fixed optioninput problem, option was not remain selected after submitting.

### DIFF
--- a/common/lib/capa/capa/capa_problem.py
+++ b/common/lib/capa/capa/capa_problem.py
@@ -710,12 +710,14 @@ class LoncapaProblem(object):
             hint = ''
             hintmode = None
             input_id = problemtree.get('id')
+            answervariable = None
             if problemid in self.correct_map:
                 pid = input_id
                 status = self.correct_map.get_correctness(pid)
                 msg = self.correct_map.get_msg(pid)
                 hint = self.correct_map.get_hint(pid)
                 hintmode = self.correct_map.get_hintmode(pid)
+                answervariable = self.correct_map.get_property(pid, 'answervariable')
 
             value = ""
             if self.student_answers and problemid in self.student_answers:
@@ -730,6 +732,7 @@ class LoncapaProblem(object):
                 'status': status,
                 'id': input_id,
                 'input_state': self.input_state[input_id],
+                'answervariable': answervariable,
                 'feedback': {
                     'message': msg,
                     'hint': hint,

--- a/common/lib/capa/capa/correctmap.py
+++ b/common/lib/capa/capa/correctmap.py
@@ -46,6 +46,7 @@ class CorrectMap(object):
         hint='',
         hintmode=None,
         queuestate=None,
+        answervariable=None,    # pylint: disable=C0330
         **kwargs
     ):
 
@@ -57,6 +58,7 @@ class CorrectMap(object):
                 'hint': hint,
                 'hintmode': hintmode,
                 'queuestate': queuestate,
+                'answervariable': answervariable,
             }
 
     def __repr__(self):

--- a/common/lib/capa/capa/inputtypes.py
+++ b/common/lib/capa/capa/inputtypes.py
@@ -213,6 +213,7 @@ class InputTypeBase(object):
         self.hint = feedback.get('hint', '')
         self.hintmode = feedback.get('hintmode', None)
         self.input_state = state.get('input_state', {})
+        self.answervariable = state.get("answervariable", None)
 
         # put hint above msg if it should be displayed
         if self.hintmode == 'always':
@@ -310,6 +311,8 @@ class InputTypeBase(object):
             (a, v) for (a, v) in self.loaded_attributes.iteritems() if a in self.to_render
         )
         context.update(self._extra_context())
+        if self.answervariable:
+            context.update({'answervariable': self.answervariable})
         return context
 
     def _extra_context(self):

--- a/common/lib/capa/capa/responsetypes.py
+++ b/common/lib/capa/capa/responsetypes.py
@@ -1097,6 +1097,9 @@ class OptionResponse(LoncapaResponse):
                 cmap.set(aid, 'correct')
             else:
                 cmap.set(aid, 'incorrect')
+            answer_variable = self.get_student_answer_variable_name(student_answers, aid)
+            if answer_variable:
+                cmap.set_property(aid, 'answervariable', answer_variable)
         return cmap
 
     def get_answers(self):
@@ -1104,6 +1107,18 @@ class OptionResponse(LoncapaResponse):
             'correct'), self.context)) for af in self.answer_fields])
         # log.debug('%s: expected answers=%s' % (unicode(self),amap))
         return amap
+
+    def get_student_answer_variable_name(self, student_answers, aid):
+        """
+        Return student answers variable name if exist in context else None.
+        """
+        if aid in student_answers:
+            for key, val in self.context.iteritems():
+                # convert val into unicode because student answer always be a unicode string
+                # even it is a list, dict etc.
+                if unicode(val) == student_answers[aid]:
+                    return '$' + key
+        return None
 
 #-----------------------------------------------------------------------------
 

--- a/common/lib/capa/capa/templates/optioninput.html
+++ b/common/lib/capa/capa/templates/optioninput.html
@@ -5,7 +5,7 @@
       <option value="option_${id}_dummy_default">  </option>
       % for option_id, option_description in options:
           <option value="${option_id}"
-          % if (option_id==value):
+          % if (option_id==value or option_id==answervariable):
         	selected="true"
           % endif
           > ${option_description}</option>

--- a/common/lib/capa/capa/tests/test_responsetypes.py
+++ b/common/lib/capa/capa/tests/test_responsetypes.py
@@ -347,6 +347,26 @@ class OptionResponseTest(ResponseTest):
         self.assert_grade(problem, "hasn\'t", "correct")
         self.assert_grade(problem, "has'nt", "incorrect")
 
+    def test_variable_options(self):
+        """
+        Test that if variable are given in option response then correct map must contain answervariable value.
+        """
+        script = textwrap.dedent("""\
+        a = 1000
+        b = a*2
+        c = a*3
+        """)
+        problem = self.build_problem(
+            options=['$a', '$b', '$c'],
+            correct_option='$a',
+            script=script
+        )
+
+        input_dict = {'1_2_1': '1000'}
+        correct_map = problem.grade_answers(input_dict)
+        self.assertEqual(correct_map.get_correctness('1_2_1'), 'correct')
+        self.assertEqual(correct_map.get_property('1_2_1', 'answervariable'), '$a')
+
 
 class FormulaResponseTest(ResponseTest):
     """


### PR DESCRIPTION
[TNL-1419](https://openedx.atlassian.net/browse/TNL-1419)

If options are created with python variables in `optioninput` problem then student submitted option was not remain selected due to following check in optioninput template because `option_id=variable_name` and `value=student_answer_integer`:

```
<option value="${option_id}"
          % if (option_id==value):
            selected="true"
          % endif
> ${option_description}</option>
```
