### PR TITLE
Applying unicode to the content experiment display name.

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -1460,7 +1460,7 @@ class GroupConfiguration(object):
 
             validation_summary = split_test.general_validation_message()
             usage_info[split_test.user_partition_id].append({
-                'label': '{} / {}'.format(unit.display_name, split_test.display_name),
+                'label': u"{} / {}".format(unit.display_name, split_test.display_name),
                 'url': unit_url,
                 'validation': validation_summary.to_json() if validation_summary else None,
             })

--- a/cms/djangoapps/contentstore/views/tests/test_group_configurations.py
+++ b/cms/djangoapps/contentstore/views/tests/test_group_configurations.py
@@ -492,7 +492,7 @@ class GroupConfigurationsUsageInfoTestCase(CourseTestCase, HelperMethods):
 
         self.assertEqual(actual, expected)
 
-    def test_can_get_correct_usage_info_when_special_characters_are_in_content(self):
+    def test_can_get_usage_info_when_special_characters_are_used(self):
         """
         Test if group configurations json updated successfully when special
          characters are being used in content experiment

--- a/cms/djangoapps/contentstore/views/tests/test_group_configurations.py
+++ b/cms/djangoapps/contentstore/views/tests/test_group_configurations.py
@@ -1,3 +1,4 @@
+#-*- coding: utf-8 -*-
 """
 Group Configuration Tests.
 """
@@ -35,7 +36,7 @@ class HelperMethods(object):
     """
     Mixin that provides useful methods for Group Configuration tests.
     """
-    def _create_content_experiment(self, cid=-1, name_suffix=''):
+    def _create_content_experiment(self, cid=-1, name_suffix='', special_characters=''):
         """
         Create content experiment.
 
@@ -53,7 +54,7 @@ class HelperMethods(object):
             category='split_test',
             parent_location=vertical.location,
             user_partition_id=cid,
-            display_name='Test Content Experiment {}'.format(name_suffix),
+            display_name=u"Test Content Experiment {}{}".format(name_suffix, special_characters),
             group_id_to_child={"0": c0_url, "1": c1_url, "2": c2_url}
         )
         ItemFactory.create(
@@ -487,6 +488,36 @@ class GroupConfigurationsUsageInfoTestCase(CourseTestCase, HelperMethods):
                 {'id': 2, 'name': 'Group C', 'version': 1},
             ],
             'usage': [],
+        }]
+
+        self.assertEqual(actual, expected)
+
+    def test_can_get_correct_usage_info_when_special_characters_are_in_content(self):
+        """
+        Test if group configurations json updated successfully when special
+         characters are being used in content experiment
+        """
+        self._add_user_partitions(count=1)
+        vertical, __ = self._create_content_experiment(cid=0, name_suffix='0', special_characters=u"JOSÉ ANDRÉS")
+
+        actual = GroupConfiguration.get_split_test_partitions_with_usage(self.course, self.store)
+
+        expected = [{
+            'id': 0,
+            'name': 'Name 0',
+            'scheme': 'random',
+            'description': 'Description 0',
+            'version': UserPartition.VERSION,
+            'groups': [
+                {'id': 0, 'name': 'Group A', 'version': 1},
+                {'id': 1, 'name': 'Group B', 'version': 1},
+                {'id': 2, 'name': 'Group C', 'version': 1},
+            ],
+            'usage': [{
+                'url': '/container/{}'.format(vertical.location),
+                'label': u"Test Unit 0 / Test Content Experiment 0JOSÉ ANDRÉS",
+                'validation': None,
+            }],
         }]
 
         self.assertEqual(actual, expected)


### PR DESCRIPTION
This PR includes the fix for unicode problem with experiment groups i.e. on the group configuration page. This also includes the test for that fix.
