### PR TITLE
Skip country access check if feature flag is disabled

### DIFF
--- a/common/djangoapps/embargo/api.py
+++ b/common/djangoapps/embargo/api.py
@@ -51,6 +51,10 @@ def check_course_access(course_key, user=None, ip_address=None, url=None):
         Boolean: True if the user has access to the course; False otherwise
 
     """
+    # No-op if the country access feature is not enabled
+    if not settings.FEATURES.get('ENABLE_COUNTRY_ACCESS'):
+        return True
+
     # First, check whether there are any restrictions on the course.
     # If not, then we do not need to do any further checks
     course_is_restricted = RestrictedCourse.is_restricted_course(course_key)

--- a/common/djangoapps/embargo/tests/test_api.py
+++ b/common/djangoapps/embargo/tests/test_api.py
@@ -36,6 +36,7 @@ MODULESTORE_CONFIG = mixed_store_config(settings.COMMON_TEST_DATA_ROOT, {}, incl
 @ddt.ddt
 @override_settings(MODULESTORE=MODULESTORE_CONFIG)
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@mock.patch.dict(settings.FEATURES, {'ENABLE_COUNTRY_ACCESS': True})
 class EmbargoCheckAccessApiTests(ModuleStoreTestCase):
     """Test the embargo API calls to determine whether a user has access. """
 


### PR DESCRIPTION
Small fixup from #6957: now that the third party auth pipeline is calling `embargo.api.check_access()` directly, we need to disable the check when the feature flag is disabled.

@rlucioni please review.
