### PR TITLE
Missing discussion blackout throwing exception

### DIFF
--- a/cms/djangoapps/contentstore/tests/tests.py
+++ b/cms/djangoapps/contentstore/tests/tests.py
@@ -319,6 +319,10 @@ class ForumTestCase(CourseTestCase):
         self.course.discussion_blackouts = [(t.isoformat(), t2.isoformat()) for t, t2 in times2]
         self.assertFalse(self.course.forum_posts_allowed)
 
+        # test if user gives empty blackout date it should return true for forum_posts_allowed
+        self.course.discussion_blackouts = [[]]
+        self.assertTrue(self.course.forum_posts_allowed)
+
 
 @ddt
 class CourseKeyVerificationTestCase(CourseTestCase):

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -1294,13 +1294,13 @@ class CourseDescriptor(CourseFields, SequenceDescriptor):
             blackout_periods = [(date_proxy.from_json(start),
                                  date_proxy.from_json(end))
                                 for start, end
-                                in self.discussion_blackouts]
+                                in filter(None, self.discussion_blackouts)]
             now = datetime.now(UTC())
             for start, end in blackout_periods:
                 if start <= now <= end:
                     return False
         except:
-            log.exception("Error parsing discussion_blackouts for course {0}".format(self.id))
+            log.exception("Error parsing discussion_blackouts %s for course %s", self.discussion_blackouts, self.id)
 
         return True
 


### PR DESCRIPTION
When the list is empty in discussion blackout
on studio side it causes the exception on lms
side when we try to access the discussion. We
were expecting the values and try to parse it
in two values start and end date whereas parsing
empty values to two values causing the exception.
Now values will be parse when value exists. Empty
value will be ignored.

TNL-1390
