### PR TITLE
Update schoolyourself-xblock CSS to wrap long title text on small screens

### DIFF
--- a/requirements/edx/edx-private.txt
+++ b/requirements/edx/edx-private.txt
@@ -15,4 +15,4 @@
 
 # This repository contains schoolyourself-xblock, which is used in
 # edX's "AlgebraX" and "GeometryX" courses.
--e git+https://github.com/schoolyourself/schoolyourself-xblock.git@fc0867263ce763f626c1c9754820e2954f6395e1#egg=schoolyourself-xblock
+-e git+https://github.com/schoolyourself/schoolyourself-xblock.git@24897124a75b2eaf68dbaa79059ad7468e6de78a#egg=schoolyourself-xblock


### PR DESCRIPTION
This PR contains an update to the schoolyourself xblocks, which has only had one change since the last time I submitted a change to these xblocks: an update to the CSS to make long titles not look so ugly. There is no change to the actual behavior of the xblocks. These are currently in use in the AlgebraX and GeometryX courses.

Here is what it used to look like, on narrower windows (the title would not wrap, so the entire box containing all of the text wraps underneath the image):
![before](https://cloud.githubusercontent.com/assets/1812040/6231015/fa492248-b691-11e4-93e2-7d8462ecfdef.png)
(Users are currently seeing this behavior in prod, although it is not hindering their ability to open and complete the lesson.)

Here is what it looks like with the fixed CSS:
![after](https://cloud.githubusercontent.com/assets/1812040/6231031/0d59722a-b692-11e4-97ae-0f7d8699bc02.png)

@nedbat has been my main contact and has reviewed my previous PRs related to schoolyourself-xblock.

Thanks!

Also, getting this out of the way: (1) I have signed the contributor agreement, and (2) I understand I shouldn't be adding anything to the AUTHORS file for this change despite what the bot will say.
