### PR TITLE
Install CORS middleware for API end-points.

### DIFF
--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -424,6 +424,11 @@ GRADES_DOWNLOAD_ROUTING_KEY = HIGH_MEM_QUEUE
 
 GRADES_DOWNLOAD = ENV_TOKENS.get("GRADES_DOWNLOAD", GRADES_DOWNLOAD)
 
+###### CORS ###########
+
+CORS_ORIGIN_WHITELIST = AUTH_TOKENS.get('CORS_ORIGIN_WHITELIST', CORS_ORIGIN_WHITELIST)
+CORS_ORIGIN_ALLOW_ALL = AUTH_TOKENS.get('CORS_ORIGIN_ALLOW_ALL', CORS_ORIGIN_ALLOW_ALL)
+
 ##### ORA2 ######
 # Prefix for uploads of example-based assessment AI classifiers
 # This can be used to separate uploads for different environments

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -979,6 +979,7 @@ MIDDLEWARE_CLASSES = (
     'request_cache.middleware.RequestCache',
     'microsite_configuration.middleware.MicrositeMiddleware',
     'django_comment_client.middleware.AjaxExceptionMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
 
@@ -1500,6 +1501,9 @@ INSTALLED_APPS = (
     'djcelery',
     'south',
 
+    # CORS middleware
+    'corsheaders',
+
     # Database-backed configuration
     'config_models',
 
@@ -1657,6 +1661,18 @@ MOBILE_STORE_URLS = {
     'apple': '#',
     'google': '#'
 }
+
+
+################# CORS #################################
+
+# By default, don't allow any cross-origin requests
+# This can be overridden in configuration.
+CORS_ORIGIN_WHITELIST = tuple()
+CORS_ORIGIN_ALLOW_ALL = False
+
+# Enable CORS only to API calls
+CORS_URLS_REGEX = r'^/api/.*$'
+
 
 ################# Student Verification #################
 VERIFY_STUDENT = {

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -16,6 +16,7 @@ defusedxml==0.4.1
 distribute>=0.6.28, <0.7
 django-babel-underscore==0.1.0
 django-celery==3.0.17
+django-cors-headers==1.0.0
 django-countries==2.1.2
 django-extensions==1.2.5
 django-filter==0.6.0


### PR DESCRIPTION
In order to make cross-domain requests from "edx.org" to "courses.edx.org" for the enrollment button on the marketing site, we need to configure CORS.  This PR adds the middleware and configuration options to make this possible.

Initially, I've enabled CORS only for `/api` end-points, and the default whitelist is empty.  We can override the whitelist in `lms.auth.json` in production.

I'm using the CORS middleware library [recommended by the Django Rest Framework documentation](http://www.django-rest-framework.org/topics/ajax-csrf-cors/).

JIRA: [ECOM-1070](https://openedx.atlassian.net/browse/ECOM-1070)

Reviewers: @stephensanchez @feanil 
