### PR TITLE
ECOM-1088: Student has re-verified but dashboard is still displaying 'honor code'

### DIFF
--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -153,7 +153,21 @@ def check_verify_status_by_course(user, course_enrollment_pairs, all_course_mode
                     else:
                         status = VERIFY_STATUS_NEED_TO_VERIFY
                 else:
-                    status = VERIFY_STATUS_MISSED_DEADLINE
+                    # If a user currently has an active or pending verification,
+                    # then they may have submitted an additional attempt after
+                    # the verification deadline passed.  This can occur,
+                    # for example, when the support team asks a student
+                    # to reverify after the deadline so they can receive
+                    # a verified certificate.
+                    # In this case, we still want to show them as "verified"
+                    # on the dashboard.
+                    if has_active_or_pending:
+                        status = VERIFY_STATUS_APPROVED
+
+                    # Otherwise, the student missed the deadline, so show
+                    # them as "honor" (the kind of certificate they will receive).
+                    else:
+                        status = VERIFY_STATUS_MISSED_DEADLINE
 
             # Set the status for the course only if we're displaying some kind of message
             # Otherwise, leave the course out of the dictionary.

--- a/common/djangoapps/student/tests/test_verification_status.py
+++ b/common/djangoapps/student/tests/test_verification_status.py
@@ -212,6 +212,19 @@ class TestCourseVerificationStatus(UrlResetMixin, ModuleStoreTestCase):
         # a verification is active).
         self._assert_course_verification_status(VERIFY_STATUS_NEED_TO_REVERIFY)
 
+    def test_verification_occurred_after_deadline(self):
+        # Expiration date in the past
+        self._setup_mode_and_enrollment(self.PAST, "verified")
+
+        # The deadline has passed, and we've asked the student
+        # to reverify (through the support team).
+        attempt = SoftwareSecurePhotoVerification.objects.create(user=self.user)
+        attempt.mark_ready()
+        attempt.submit()
+
+        # Expect that the user's displayed enrollment mode is verified.
+        self._assert_course_verification_status(VERIFY_STATUS_APPROVED)
+
     def _setup_mode_and_enrollment(self, deadline, enrollment_mode):
         """Create a course mode and enrollment.
 


### PR DESCRIPTION
Handle the case in which a student reverifies after the verification
deadline has passed.  This will display the user's status as "verified"
on the dashboard even if they technically missed the deadline.

JIRA: [ECOM-1088](https://openedx.atlassian.net/browse/ECOM-1088)

@rlucioni please review
