### PR TITLE
Force English for email opt in text appearing on the marketing site

### DIFF
--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -370,13 +370,17 @@ class ViewsTestCase(ModuleStoreTestCase):
         # in the label escaped as expected.
         self._email_opt_in_checkbox(response, cgi.escape(self.org_html))
 
-    @patch.dict(settings.FEATURES, {'IS_EDX_DOMAIN': True})
+    @patch.dict(settings.FEATURES, {
+        'IS_EDX_DOMAIN': True,
+        'ENABLE_MKTG_EMAIL_OPT_IN': True
+    })
     def test_mktg_about_language_edx_domain(self):
         # Since we're in an edx-controlled domain, and our marketing site
         # supports only English, override the language setting
         # and use English.
-        response = self._load_mktg_about(language='eo')
+        response = self._load_mktg_about(language='eo', org=self.org_html)
         self.assertContains(response, "Enroll in")
+        self.assertContains(response, "and learn about its other programs")
 
     @patch.dict(settings.FEATURES, {'IS_EDX_DOMAIN': False})
     def test_mktg_about_language_openedx(self):

--- a/lms/djangoapps/courseware/views.py
+++ b/lms/djangoapps/courseware/views.py
@@ -899,6 +899,15 @@ def mktg_course_about(request, course_id):
         'course_modes': course_modes,
     }
 
+    # The edx.org marketing site currently displays only in English.
+    # To avoid displaying a different language in the register / access button,
+    # we force the language to English.
+    # However, OpenEdX installations with a different marketing front-end
+    # may want to respect the language specified by the user or the site settings.
+    force_english = settings.FEATURES.get('IS_EDX_DOMAIN', False)
+    if force_english:
+        translation.activate('en-us')
+
     if settings.FEATURES.get('ENABLE_MKTG_EMAIL_OPT_IN'):
         # Drupal will pass organization names using a GET parameter, as follows:
         #     ?org=Harvard
@@ -931,15 +940,6 @@ def mktg_course_about(request, course_id):
                 "I would like to receive email from {institution_series} and learn about their other programs.",
                 len(org_list)
             ).format(institution_series=org_name_string)
-
-    # The edx.org marketing site currently displays only in English.
-    # To avoid displaying a different language in the register / access button,
-    # we force the language to English.
-    # However, OpenEdX installations with a different marketing front-end
-    # may want to respect the language specified by the user or the site settings.
-    force_english = settings.FEATURES.get('IS_EDX_DOMAIN', False)
-    if force_english:
-        translation.activate('en-us')
 
     try:
         return render_to_response('courseware/mktg_course_about.html', context)


### PR DESCRIPTION
Fix for [ECOM-1091](https://openedx.atlassian.net/browse/ECOM-1091).  The issue was that we added new translation strings before the code that forced the language to English (since the Drupal site currently supports only English).

@sarina @dianakhuang please review.

@dianakhuang This addresses a bug in the release candidate when the user's language preference is Arabic.  Can we get this into the RC before tomorrow's deploy?
