### PR TITLE
Changed value of NA to 0 for ungraded problems

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -197,3 +197,4 @@ Marko Jevtić <mjevtic@edx.org>
 Ahsan Ulhaq <ahsan@edx.org>
 Mat Moore <mat@mooresoftware.co.uk>
 Muzaffar Yousaf <muzaffar@edx.org>
+Kyle Boots <indagation@gmail.com>

--- a/common/lib/xmodule/xmodule/js/src/sequence/display.coffee
+++ b/common/lib/xmodule/xmodule/js/src/sequence/display.coffee
@@ -32,10 +32,10 @@ class @Sequence
     $('.problems-wrapper').bind 'progressChanged', @updateProgress
 
   mergeProgress: (p1, p2) ->
-    # if either is "NA", return the other one
-    if p1 == "NA"
+    # if either is "0", return the other one
+    if p1 == "0"
       return p2
-    if p2 == "NA"
+    if p2 == "0"
       return p1
 
     # Both real progresses
@@ -51,7 +51,7 @@ class @Sequence
     return "none"
 
   updateProgress: =>
-    new_progress = "NA"
+    new_progress = "0"
     _this = this
     $('.problems-wrapper').each (index) ->
       progress = $(this).data 'progress_status'
@@ -61,7 +61,7 @@ class @Sequence
     @setProgress(new_progress, @link_for(@position))
 
   setProgress: (progress, element) ->
-      # If progress is "NA", don't add any css class
+      # If progress is "0", don't add any css class
       element.removeClass('progress-none')
              .removeClass('progress-some')
              .removeClass('progress-done')


### PR DESCRIPTION
This is a pull request for a bug in the navigation bar. The issue occurs when a vertical has a graded and a non graded problem. The problem is that the vertical is never given the proper class to display that it has been completed. The following screenshot displays the issue. 
![screen shot 2015-02-13 at 12 50 17 pm](https://cloud.githubusercontent.com/assets/2379693/6261483/0acfb3f2-b7be-11e4-975c-ee27c81d9502.png)
This problem can be viewed live at the following. https://edge.edx.org/courses/MITx/CF101/2T2014/courseware/c35f63db28c9444c8499948e1d88edd5/58b253013742443ea06de851dcbd2869/
You can answer both questions correctly and the progress bar still only shows the vertical as half completed. To recreate the issue answer both questions correctly and you will see that the bar only fills partially. I am including a screenshot of the issue.

I tracked this bug down to a previously accepted pull request.
https://github.com/edx/edx-platform/commit/1a0055ae77d3f967f648af0435efe8edae819ab4

This pull request shows that the value of "NA" was formerly assigned to ungraded questions. However, there was a change made to set the value to "0" for ungraded questions. This change was made in XModule/progress.py, but it wasn't made in the javascript file that assigns the class. The file edx-platform/common/lib/xmodule/xmodule/js/src/sequence/display.coffee is still expecting the previously assigned value of "NA". My pull request is simply changing the value of "NA" to the value "0" in the javascript.

The change has been tested on my local environment, and it behaves properly. That is to say that the vertical is marked as completed after the graded problem is completed.
