### PR TITLE
(WIP) SOL-106 added notifications emitter business logic in openedx

### DIFF
--- a/lms/djangoapps/django_comment_client/base/views.py
+++ b/lms/djangoapps/django_comment_client/base/views.py
@@ -5,6 +5,7 @@ import random
 import time
 import urlparse
 
+from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
 from django.core import exceptions
@@ -16,6 +17,11 @@ from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
 
 from courseware.access import has_access
+from edx_notifications.lib.publisher import (
+    publish_notification_to_user,
+    get_notification_type
+)
+from edx_notifications.data import NotificationMessage
 from util.file import store_uploaded_file
 from courseware.courses import get_course_with_access, get_course_by_id
 import django_comment_client.settings as cc_settings
@@ -27,7 +33,8 @@ from django_comment_client.utils import (
     JsonResponse,
     prepare_content,
     get_group_id_for_comments_service,
-    get_discussion_categories_ids
+    get_discussion_categories_ids,
+    permalink
 )
 from django_comment_client.permissions import check_permissions_by_view, cached_has_permission
 import lms.lib.comment_client as cc
@@ -197,6 +204,28 @@ def _create_comment(request, course_key, thread_id=None, parent_id=None):
     if post.get('auto_subscribe', 'false').lower() == 'true':
         user = cc.User.from_django_user(request.user)
         user.follow(comment.thread)
+    # Feature Flag to check that notifications are enabled or not.
+    # parent_id is None: publish notification only when creating the comment on
+    # the thread not replying on the comment. When the user replied on the comment
+    # the parent_id is not None at that time
+    if settings.FEATURES.get("NOTIFICATIONS_ENABLED", False) and parent_id is None:
+        thread = cc.Thread.find(thread_id)
+        action_user_id = request.user.id
+        original_poster_id = int(thread.user_id)
+
+        # we have to only send the notifications when
+        # the user commenting the thread is not
+        # the same user who created the thread
+        if not action_user_id == original_poster_id:
+            publish_discussion_notification(
+                msg_type_name='open-edx.lms.discussions.reply-to-thread',
+                course_id=course_key.to_deprecated_string(),
+                original_poster_id=original_poster_id,
+                action_user_id=action_user_id,
+                action_username=request.user.username,
+                thread_title=thread.title,
+                link_to_thread=permalink(thread)
+            )
     if request.is_ajax():
         return ajax_content_response(request, course_key, comment.to_dict())
     else:
@@ -356,7 +385,24 @@ def vote_for_thread(request, course_id, thread_id, value):
     user = cc.User.from_django_user(request.user)
     thread = cc.Thread.find(thread_id)
     user.vote(thread, value)
+    # Feature Flag to check that notifications are enabled or not.
+    if settings.FEATURES.get("NOTIFICATIONS_ENABLED", False):
+        action_user_id = request.user.id
+        original_poster_id = int(thread.user_id)
 
+        # we have to only send the notifications when
+        # the user voting the thread is not
+        # the same user who created the thread
+        if not action_user_id == original_poster_id:
+            publish_discussion_notification(
+                msg_type_name='open-edx.lms.discussions.post-upvoted',
+                course_id=course_id,
+                original_poster_id=original_poster_id,
+                action_user_id=action_user_id,
+                action_username=request.user.username,
+                thread_title=thread.title,
+                link_to_thread=permalink(thread)
+            )
     return JsonResponse(prepare_content(thread.to_dict(), course_key))
 
 
@@ -478,10 +524,53 @@ def un_pin_thread(request, course_id, thread_id):
 @login_required
 @permitted
 def follow_thread(request, course_id, thread_id):
+    """
+    given a course id and thread id, follow this thread
+    ajax only
+    """
     user = cc.User.from_django_user(request.user)
     thread = cc.Thread.find(thread_id)
     user.follow(thread)
+    # Feature Flag to check that notifications are enabled or not.
+    if settings.FEATURES.get("NOTIFICATIONS_ENABLED", False):
+        # only send notifications when the user
+        # who is following the thread is not the same
+        # who created the thread
+        action_user_id = request.user.id
+        original_poster_id = int(thread.user_id)
+        if not original_poster_id == action_user_id:
+            publish_discussion_notification(
+                msg_type_name='open-edx.lms.discussions.thread-followed',
+                course_id=course_id,
+                original_poster_id=original_poster_id,
+                action_user_id=action_user_id,
+                action_username=request.user.username,
+                thread_title=thread.title,
+                link_to_thread=permalink(thread)
+            )
     return JsonResponse({})
+
+
+def publish_discussion_notification(msg_type_name, course_id, original_poster_id,  # pylint: disable=invalid-name
+                                    action_user_id, action_username, thread_title, link_to_thread):
+    """
+    registers and publish the notification to the original
+    poster of the thread.
+    """
+    msg_type = get_notification_type(msg_type_name)
+    msg = NotificationMessage(
+        namespace=course_id,
+        msg_type=msg_type,
+        payload={
+            '_schema_version': '1',
+            'action_user_id': action_user_id,
+            'action_username': action_username,
+            'thread_title': thread_title,
+            'link_to_thread': link_to_thread
+        }
+    )
+
+    publish_notification_to_user(original_poster_id, msg)
 
 
 @require_POST

--- a/lms/djangoapps/django_comment_client/urls.py
+++ b/lms/djangoapps/django_comment_client/urls.py
@@ -1,6 +1,7 @@
 from django.conf.urls.defaults import url, patterns, include
 
-urlpatterns = patterns('',  # nopep8
-    url(r'forum/?', include('django_comment_client.forum.urls')),
+urlpatterns = patterns(
+    '',
+    url(r'forum/', include('django_comment_client.forum.urls')),
     url(r'', include('django_comment_client.base.urls')),
 )

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -78,6 +78,7 @@ CELERYD_PREFETCH_MULTIPLIER = 1
 # Skip djcelery migrations, since we don't use the database as the broker
 SOUTH_MIGRATION_MODULES = {
     'djcelery': 'ignore',
+    'edx_notifications': 'edx_notifications.stores.sql.migrations',
 }
 
 # Rename the exchange and queues for each variant

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -339,6 +339,9 @@ FEATURES = {
     # Milestones application flag
     'MILESTONES_APP': False,
 
+    # edx_notifications application feature flag
+    'NOTIFICATIONS_ENABLED': False,
+
     # Prerequisite courses feature flag
     'ENABLE_PREREQUISITE_COURSES': False,
 
@@ -978,7 +981,7 @@ TEMPLATE_LOADERS = (
     'edxmako.makoloader.MakoAppDirectoriesLoader',
 
     # 'django.template.loaders.filesystem.Loader',
-    # 'django.template.loaders.app_directories.Loader',
+    'django.template.loaders.app_directories.Loader',
 
 )
 
@@ -1634,7 +1637,14 @@ INSTALLED_APPS = (
     'lms.djangoapps.lms_xblock',
 
     'openedx.core.djangoapps.content.course_structures',
+
     'course_structure_api',
+
+    # Edx notifications
+    'edx_notifications',
+
+    # Edx notifications web server
+    'edx_notifications.server.web',
 )
 
 ######################### MARKETING SITE ###############################
@@ -1984,6 +1994,28 @@ for app_name in OPTIONAL_APPS:
         except ImportError:
             continue
     INSTALLED_APPS += (app_name,)
+
+NOTIFICATION_STORE_PROVIDER = {
+    "class": "edx_notifications.stores.sql.store_provider.SQLNotificationStoreProvider",
+    "options": {
+    }
+}
+
+# to prevent run-away queries from happening
+MAX_NOTIFICATION_LIST_SIZE = 100
+
+# list all known channel providers
+NOTIFICATION_CHANNEL_PROVIDERS = {
+    'durable': {
+        'class': 'edx_notifications.channels.durable.BaseDurableNotificationChannel',
+        'options': {}
+    }
+}
+
+# list all of the mappings of notification types to channel
+NOTIFICATION_CHANNEL_PROVIDER_TYPE_MAPS = {
+    '*': 'durable',  # default global mapping
+}
 
 # Stub for third_party_auth options.
 # See common/djangoapps/third_party_auth/settings.py for configuration details.

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -110,6 +110,8 @@ PASSWORD_COMPLEXITY = {}
 ########################### Milestones #################################
 FEATURES['MILESTONES_APP'] = True
 
+########################### Notifications #################################
+FEATURES['NOTIFICATIONS_ENABLED'] = True
 
 ########################### Entrance Exams #################################
 FEATURES['ENTRANCE_EXAMS'] = True

--- a/lms/startup.py
+++ b/lms/startup.py
@@ -15,6 +15,7 @@ import logging
 from monkey_patch import django_utils_translation
 import analytics
 from util import keyword_substitution
+from edx_notifications import startup
 
 
 log = logging.getLogger(__name__)
@@ -29,6 +30,9 @@ def run():
     autostartup()
 
     add_mimetypes()
+
+    if settings.FEATURES.get('NOTIFICATIONS_ENABLED', False):
+        startup_notification_subsystem()
 
     if settings.FEATURES.get('USE_CUSTOM_THEME', False):
         enable_theme()
@@ -149,6 +153,13 @@ def enable_third_party_auth():
 
     from third_party_auth import settings as auth_settings
     auth_settings.apply_settings(settings.THIRD_PARTY_AUTH, settings)
+
+
+def startup_notification_subsystem():
+    """
+    Initialize the Notification subsystem
+    """
+    startup.initialize()
 
 
 def get_keyword_function_map():

--- a/lms/tests/__init__.py
+++ b/lms/tests/__init__.py
@@ -1,0 +1,4 @@
+"""
+Module for test in lms folder
+All lms/test/* are already included in paver test
+"""

--- a/lms/tests/test_startup.py
+++ b/lms/tests/test_startup.py
@@ -1,0 +1,25 @@
+"""
+Test lms startup
+"""
+
+from django.conf import settings
+from django.test import TestCase
+
+from mock import patch
+from lms.startup import run
+
+
+class StartupTestCase(TestCase):
+    """
+    Test lms startup
+    """
+
+    def setUp(self):
+        super(StartupTestCase, self).setUp()
+
+    @patch.dict("django.conf.settings.FEATURES", {"NOTIFICATIONS_ENABLED": True, "ENABLE_THIRD_PARTY_AUTH": False})
+    def test_run_with_notifications_enabled(self):
+        self.assertEqual(settings.FEATURES["NOTIFICATIONS_ENABLED"], True)
+        with patch('lms.startup.startup_notification_subsystem') as mock_notification_subsystem:
+            run()
+            self.assertTrue(mock_notification_subsystem.called)

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -39,3 +39,4 @@ git+https://github.com/mitocw/django-cas.git@60a5b8e5a62e63e0d5d224a87f0b489201a
 -e git+https://github.com/edx/edx-milestones.git@547f2250ee49e73ce8d7ff4e78ecf1b049892510#egg=edx-milestones
 -e git+https://github.com/edx/edx-search.git@264bb3317f98e9cb22b932aa11b89d0651fd741c#egg=edx-search
 git+https://github.com/edx/edx-lint.git@e0e73bcc7b3b7ed632a1db6e3b32b0a249721261#egg=edx_lint
+-e git+https://github.com/edx/edx-notifications.git@447779d34d7c817d6f2b2b68be2800dc7ae5b4cc#egg=edx-notifications


### PR DESCRIPTION
added the test cases

updated the test cases according to chris suggestions

update the latest commit hash of edx-notifications repo

removed the typecast, update the quality issues and rename the register_publish_notifications to register_and_publish_notifications

updated the hash and added the field renderer in the notification_type

updated with the latest hash of notifications repo and initialized the notifications subsystem
