### PR TITLE
Lms should be independent of mathjax

### DIFF
--- a/common/templates/mathjax_include.html
+++ b/common/templates/mathjax_include.html
@@ -6,33 +6,38 @@
 ## This enables ASCIIMathJAX, and is used by js_textbox
 
 
-%if mathjax_mode is not Undefined and mathjax_mode == 'wiki':
-<script type="text/x-mathjax-config">
-  MathJax.Hub.Config({
-    tex2jax: {inlineMath: [ ['$','$'], ["\\(","\\)"]],
-              displayMath: [ ['$$','$$'], ["\\[","\\]"]]}
-  });
-  HUB = MathJax.Hub
-</script>
-%else:
-<script type="text/x-mathjax-config">
-  MathJax.Hub.Config({
-    tex2jax: {
-      inlineMath: [
-        ["\\(","\\)"],
-        ['[mathjaxinline]','[/mathjaxinline]']
-      ],
-      displayMath: [
-        ["\\[","\\]"],
-        ['[mathjax]','[/mathjax]']
-      ]
-    }
-  });
-  HUB = MathJax.Hub
-</script>
-%endif
+<%def name="mathjaxConfig()">
+  %if mathjax_mode is not Undefined and mathjax_mode == 'wiki':
+    MathJax.Hub.Config({
+      tex2jax: {inlineMath: [ ['$','$'], ["\\(","\\)"]],
+                displayMath: [ ['$$','$$'], ["\\[","\\]"]]}
+    });
+  %else:
+    MathJax.Hub.Config({
+      tex2jax: {
+        inlineMath: [
+          ["\\(","\\)"],
+          ['[mathjaxinline]','[/mathjaxinline]']
+        ],
+        displayMath: [
+          ["\\[","\\]"],
+          ['[mathjax]','[/mathjax]']
+        ]
+      }
+    });
+  %endif
+  MathJax.Hub.Configured();
+  window.HUB = MathJax.Hub;
+</%def>
 
 <!-- This must appear after all mathjax-config blocks, so it is after the imports from the other templates.
      It can't be run through static.url because MathJax uses crazy url introspection to do lazy loading of
      MathJax extension libraries -->
-<script type="text/javascript" src="https://cdn.mathjax.org/mathjax/2.4-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full"></script>
+<script type="text/javascript">
+  ;(function (require) {
+  'use strict';
+  require(['mathjax'], function() {
+      ${mathjaxConfig()}
+  });
+  }).call(this, require || RequireJS.require);
+</script>

--- a/lms/static/require-config-lms.js
+++ b/lms/static/require-config-lms.js
@@ -67,6 +67,7 @@
             "ova": 'js/vendor/ova/ova',
             "catch": 'js/vendor/ova/catch/js/catch',
             "handlebars": 'js/vendor/ova/catch/js/handlebars-1.1.2',
+            "mathjax": 'https://cdn.mathjax.org/mathjax/2.4-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full'
             // end of files needed by OVA
         },
         shim: {


### PR DESCRIPTION
When cdn is down specially in the country like china
and others user face problem as application doesn't
work as intended. Instead of making mathjax hard
dependecy I have converted it into soft dependey
so that it won't cause user problem to use application
smothly if mathjax is not present.

TNL-1498
