### PR TITLE
Disable flakily failing JS tests TNL-559

### DIFF
--- a/cms/static/js/spec/video/transcripts/message_manager_spec.js
+++ b/cms/static/js/spec/video/transcripts/message_manager_spec.js
@@ -7,7 +7,8 @@ define(
     ],
 function ($, _, Utils, MessageManager, FileUploader, sinon) {
 
-    describe('Transcripts.MessageManager', function () {
+    // TODO: fix TNL-559 Intermittent failures of Transcript FileUploader JS tests
+    xdescribe('Transcripts.MessageManager', function () {
         var videoListEntryTemplate = readFixtures(
                 'video/transcripts/metadata-videolist-entry.underscore'
             ),


### PR DESCRIPTION
@dan-f @cahrens 

Looks like these are also suffering from TNL-559.
They just failed on a master build.
