### PR TITLE
Hotfix: Make the linked in configuration migration backwards compatible

### DIFF
--- a/common/djangoapps/student/migrations/0044_linkedin_add_company_identifier.py
+++ b/common/djangoapps/student/migrations/0044_linkedin_add_company_identifier.py
@@ -8,9 +8,6 @@ from django.db import models
 class Migration(SchemaMigration):
 
     def forwards(self, orm):
-        # Deleting field 'LinkedInAddToProfileConfiguration.dashboard_tracking_code'
-        db.delete_column('student_linkedinaddtoprofileconfiguration', 'dashboard_tracking_code')
-
         # Adding field 'LinkedInAddToProfileConfiguration.company_identifier'
         db.add_column('student_linkedinaddtoprofileconfiguration', 'company_identifier',
                       self.gf('django.db.models.fields.TextField')(default=''),
@@ -18,11 +15,6 @@ class Migration(SchemaMigration):
 
 
     def backwards(self, orm):
-        # Adding field 'LinkedInAddToProfileConfiguration.dashboard_tracking_code'
-        db.add_column('student_linkedinaddtoprofileconfiguration', 'dashboard_tracking_code',
-                      self.gf('django.db.models.fields.TextField')(default='', blank=True),
-                      keep_default=False)
-
         # Deleting field 'LinkedInAddToProfileConfiguration.company_identifier'
         db.delete_column('student_linkedinaddtoprofileconfiguration', 'company_identifier')
 
@@ -109,6 +101,7 @@ class Migration(SchemaMigration):
             'change_date': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
             'changed_by': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']", 'null': 'True', 'on_delete': 'models.PROTECT'}),
             'company_identifier': ('django.db.models.fields.TextField', [], {}),
+            'dashboard_tracking_code': ('django.db.models.fields.TextField', [], {'default': "''", 'blank': 'True'}),
             'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
             'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
         },

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -1464,6 +1464,9 @@ class LinkedInAddToProfileConfiguration(ConfigurationModel):
         )
     )
 
+    # Deprecated
+    dashboard_tracking_code = models.TextField(default="", blank=True)
+
     def add_to_profile_url(self, course_name, enrollment_mode, cert_url, source="o"):
         """Construct the URL for the "add to profile" button.
 


### PR DESCRIPTION
In #6982, I renamed a field in the model `LinkedInAddToProfileConfiguration`.  This caused the old field to be deleted from the database table during the migration.  Since the table did not have the field expected by the old code, this would cause a 500 error on the student dashboard when checking if the LinkedIn configuration was enabled (for students who had received a certificate).

The fix is to leave the old field in the model definition, so that the database table is backwards-compatible with the old code.  I have tested running the forwards migration with both the old and new versions of the code in devstack.

@dianakhuang please review.

FYI: @e0d 
