### PR TITLE
Clear children cache when binding an XBlock to a user.

### DIFF
--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -211,7 +211,8 @@ def _load_preview_module(request, descriptor):
         field_data = LmsFieldData(descriptor._field_data, student_data)  # pylint: disable=protected-access
     descriptor.bind_for_student(
         _preview_module_system(request, descriptor, field_data),
-        field_data
+        field_data,
+        request.user.id
     )
     return descriptor
 

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -1195,23 +1195,23 @@ class CourseDescriptor(CourseFields, SequenceDescriptor):
                 for module_descriptor in yield_descriptor_descendents(child):
                     yield module_descriptor
 
-        for c in self.get_children():
-            for s in c.get_children():
-                if s.graded:
-                    xmoduledescriptors = list(yield_descriptor_descendents(s))
-                    xmoduledescriptors.append(s)
+        for chapter in self.get_children():
+            for section in chapter.get_children():
+                if section.graded:
+                    xmoduledescriptors = list(yield_descriptor_descendents(section))
+                    xmoduledescriptors.append(section)
 
                     # The xmoduledescriptors included here are only the ones that have scores.
                     section_description = {
-                        'section_descriptor': s,
-                        'xmoduledescriptors': filter(lambda child: child.has_score, xmoduledescriptors)
+                        'section_descriptor': section,
+                        'xmoduledescriptors': [child for child in xmoduledescriptors if child.has_score]
                     }
 
-                    section_format = s.format if s.format is not None else ''
+                    section_format = section.format if section.format is not None else ''
                     graded_sections[section_format] = graded_sections.get(section_format, []) + [section_description]
 
                     all_descriptors.extend(xmoduledescriptors)
-                    all_descriptors.append(s)
+                    all_descriptors.append(section)
 
         return {'graded_sections': graded_sections,
                 'all_descriptors': all_descriptors, }

--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -218,10 +218,7 @@ class CachingDescriptorSystem(MakoDescriptorSystem, EditInfoRuntimeMixin):
         assert isinstance(location, UsageKey)
         json_data = self.module_data.get(location)
         if json_data is None:
-            module = self.modulestore.get_item(location)
-            if module is not None:
-                # update our own cache after going to the DB to get cache miss
-                self.module_data.update(module.runtime.module_data)
+            module = self.modulestore.get_item(location, using_descriptor_system=self)
             return module
         else:
             # load the module and apply the inherited metadata
@@ -855,9 +852,19 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
 
         return data
 
-    def _load_item(self, course_key, item, data_cache, apply_cached_metadata=True):
+    def _load_item(self, course_key, item, data_cache, apply_cached_metadata=True, using_descriptor_system=None):
         """
         Load an XModuleDescriptor from item, using the children stored in data_cache
+
+        Arguments:
+            course_key (CourseKey): which course to load from
+            item (UsageKey): which xblock to load
+            data_cache (dict): A dictionary mapping from UsageKeys to xblock field data
+                (this is the xblock data loaded from the database)
+            apply_cached_metadata (bool): Whether to use the cached metadata for inheritance
+                purposes.
+            using_descriptor_system (CachingDescriptorSystem): The existing CachingDescriptorSystem
+                to add data to, and to load the XBlocks from.
         """
         course_key = self.fill_in_run(course_key)
         location = Location._from_deprecated_son(item['location'], course_key.run)
@@ -869,32 +876,38 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
         if apply_cached_metadata:
             cached_metadata = self._get_cached_metadata_inheritance_tree(course_key)
 
-        services = {}
-        if self.i18n_service:
-            services["i18n"] = self.i18n_service
+        if using_descriptor_system is None:
+            services = {}
+            if self.i18n_service:
+                services["i18n"] = self.i18n_service
 
-        if self.fs_service:
-            services["fs"] = self.fs_service
+            if self.fs_service:
+                services["fs"] = self.fs_service
 
-        if self.user_service:
-            services["user"] = self.user_service
+            if self.user_service:
+                services["user"] = self.user_service
 
-        system = CachingDescriptorSystem(
-            modulestore=self,
-            course_key=course_key,
-            module_data=data_cache,
-            default_class=self.default_class,
-            resources_fs=resource_fs,
-            error_tracker=self.error_tracker,
-            render_template=self.render_template,
-            cached_metadata=cached_metadata,
-            mixins=self.xblock_mixins,
-            select=self.xblock_select,
-            services=services,
-        )
+            system = CachingDescriptorSystem(
+                modulestore=self,
+                course_key=course_key,
+                module_data=data_cache,
+                default_class=self.default_class,
+                resources_fs=resource_fs,
+                error_tracker=self.error_tracker,
+                render_template=self.render_template,
+                cached_metadata=cached_metadata,
+                mixins=self.xblock_mixins,
+                select=self.xblock_select,
+                services=services,
+            )
+        else:
+            system = using_descriptor_system
+            system.module_data.update(data_cache)
+            system.cached_metadata.update(cached_metadata)
+
         return system.load_item(location)
 
-    def _load_items(self, course_key, items, depth=0):
+    def _load_items(self, course_key, items, depth=0, using_descriptor_system=None):
         """
         Load a list of xmodules from the data in items, with children cached up
         to specified depth
@@ -906,8 +919,11 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
         # bother with the metadata inheritance
         return [
             self._load_item(
-                course_key, item, data_cache,
-                apply_cached_metadata=(item['location']['category'] != 'course' or depth != 0)
+                course_key,
+                item,
+                data_cache,
+                apply_cached_metadata=(item['location']['category'] != 'course' or depth != 0),
+                using_descriptor_system=using_descriptor_system
             )
             for item in items
         ]
@@ -1006,7 +1022,7 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
         except ItemNotFoundError:
             return False
 
-    def get_item(self, usage_key, depth=0):
+    def get_item(self, usage_key, depth=0, using_descriptor_system=None):
         """
         Returns an XModuleDescriptor instance for the item at location.
 
@@ -1015,14 +1031,22 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
         If no object is found at that location, raises
             xmodule.modulestore.exceptions.ItemNotFoundError
 
-        usage_key: a :class:`.UsageKey` instance
-        depth (int): An argument that some module stores may use to prefetch
-            descendents of the queried modules for more efficient results later
-            in the request. The depth is counted in the number of
-            calls to get_children() to cache. None indicates to cache all descendents.
+        Arguments:
+            usage_key: a :class:`.UsageKey` instance
+            depth (int): An argument that some module stores may use to prefetch
+                descendents of the queried modules for more efficient results later
+                in the request. The depth is counted in the number of
+                calls to get_children() to cache. None indicates to cache all descendents.
+            using_descriptor_system (CachingDescriptorSystem): The existing CachingDescriptorSystem
+                to add data to, and to load the XBlocks from.
         """
         item = self._find_one(usage_key)
-        module = self._load_items(usage_key.course_key, [item], depth)[0]
+        module = self._load_items(
+            usage_key.course_key,
+            [item],
+            depth,
+            using_descriptor_system=using_descriptor_system
+        )[0]
         return module
 
     @staticmethod
@@ -1054,6 +1078,7 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
             content=None,
             key_revision=MongoRevisionKey.published,
             qualifiers=None,
+            using_descriptor_system=None,
             **kwargs
     ):
         """
@@ -1085,6 +1110,8 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
                 For this modulestore, ``name`` is a commonly provided key (Location based stores)
                 This modulestore does not allow searching dates by comparison or edited_by, previous_version,
                 update_version info.
+            using_descriptor_system (CachingDescriptorSystem): The existing CachingDescriptorSystem
+                to add data to, and to load the XBlocks from.
         """
         qualifiers = qualifiers.copy() if qualifiers else {}  # copy the qualifiers (destructively manipulated here)
         query = self._course_key_to_son(course_id)
@@ -1106,7 +1133,11 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
             sort=[SORT_REVISION_FAVOR_DRAFT],
         )
 
-        modules = self._load_items(course_id, list(items))
+        modules = self._load_items(
+            course_id,
+            list(items),
+            using_descriptor_system=using_descriptor_system
+        )
         return modules
 
     def create_course(self, org, course, run, user_id, fields=None, **kwargs):

--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -151,12 +151,28 @@ class MongoKeyValueStore(InheritanceKeyValueStore):
         else:
             return False
 
+    def __repr__(self):
+        return "MongoKeyValueStore{!r}<{!r}, {!r}>".format(
+            (self._data, self._parent, self._children, self._metadata),
+            self._fields,
+            self.inherited_settings
+        )
+
 
 class CachingDescriptorSystem(MakoDescriptorSystem, EditInfoRuntimeMixin):
     """
     A system that has a cache of module json that it will use to load modules
     from, with a backup of calling to the underlying modulestore for more data
     """
+    def __repr__(self):
+        return "CachingDescriptorSystem{!r}".format((
+            self.modulestore,
+            unicode(self.course_id),
+            [unicode(key) for key in self.module_data.keys()],
+            self.default_class,
+            [unicode(key) for key in self.cached_metadata.keys()],
+        ))
+
     def __init__(self, modulestore, course_key, module_data, default_class, cached_metadata, **kwargs):
         """
         modulestore: the module store that can be used to retrieve additional modules

--- a/common/lib/xmodule/xmodule/tests/__init__.py
+++ b/common/lib/xmodule/xmodule/tests/__init__.py
@@ -110,7 +110,7 @@ def get_test_system(course_id=SlashSeparatedCourseKey('org', 'course', 'run')):
         # So, bind to the same one as the current descriptor.
         module_system.descriptor_runtime = descriptor._runtime  # pylint: disable=protected-access
 
-        descriptor.bind_for_student(module_system, descriptor._field_data)
+        descriptor.bind_for_student(module_system, descriptor._field_data, user.id)
 
         return descriptor
 

--- a/common/lib/xmodule/xmodule/tests/test_conditional.py
+++ b/common/lib/xmodule/xmodule/tests/test_conditional.py
@@ -206,6 +206,7 @@ class ConditionalModuleXmlTest(unittest.TestCase):
                 location = descriptor
                 descriptor = self.modulestore.get_item(location, depth=None)
             descriptor.xmodule_runtime = get_test_system()
+            descriptor.xmodule_runtime.descriptor_runtime = descriptor._runtime
             descriptor.xmodule_runtime.get_module = inner_get_module
             return descriptor
 

--- a/common/lib/xmodule/xmodule/tests/test_library_content.py
+++ b/common/lib/xmodule/xmodule/tests/test_library_content.py
@@ -62,7 +62,7 @@ class LibraryContentTest(MixedSplitTestCase):
             sub_module_system = get_test_system(course_id=self.course.location.course_key)
             sub_module_system.get_module = get_module
             sub_module_system.descriptor_runtime = descriptor._runtime  # pylint: disable=protected-access
-            descriptor.bind_for_student(sub_module_system, descriptor._field_data)  # pylint: disable=protected-access
+            descriptor.bind_for_student(sub_module_system, descriptor._field_data, self.user_id)  # pylint: disable=protected-access
             return descriptor
 
         module_system.get_module = get_module

--- a/common/lib/xmodule/xmodule/tests/test_split_test_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_split_test_module.py
@@ -81,6 +81,7 @@ class SplitTestModuleTest(XModuleXmlImportTest, PartitionTestCase):
         self.module_system.descriptor_runtime = self.course._runtime  # pylint: disable=protected-access
         self.course.runtime.export_fs = MemoryFS()
 
+        user = user=Mock(username='ma', email='ma@edx.org', is_staff=False, is_active=True)
         self.partitions_service = StaticPartitionService(
             [
                 self.user_partition,
@@ -90,14 +91,18 @@ class SplitTestModuleTest(XModuleXmlImportTest, PartitionTestCase):
                     MockUserPartitionScheme()
                 )
             ],
-            user=Mock(username='ma', email='ma@edx.org', is_staff=False, is_active=True),
+            user,
             course_id=self.course.id,
             track_function=Mock(name='track_function'),
         )
         self.module_system._services['partitions'] = self.partitions_service  # pylint: disable=protected-access
 
         self.split_test_module = self.course_sequence.get_children()[0]
-        self.split_test_module.bind_for_student(self.module_system, self.split_test_module._field_data)  # pylint: disable=protected-access
+        self.split_test_module.bind_for_student(
+            self.module_system,
+            self.split_test_module._field_data,
+            user.id
+        )  # pylint: disable=protected-access
 
 
 @ddt.ddt

--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -1572,7 +1572,7 @@ class ModuleSystem(MetricsMixin, ConfigurableFragmentWrapper, Runtime):  # pylin
         self.__dict__[attr] = val
 
     def __str__(self):
-        return str(self.__dict__)
+        return "LmsModuleSystem{}".format(self.__dict__)
 
     @property
     def ajax_url(self):

--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -625,6 +625,14 @@ class XModule(XModuleMixin, HTMLSnippet, XBlock):  # pylint: disable=abstract-me
         self._loaded_children = None
         self.runtime.xmodule_instance = self
 
+    @property
+    def runtime(self):
+        return CombinedSystem(self._runtime, self.descriptor._runtime)
+
+    @runtime.setter
+    def runtime(self, value):
+        self._runtime = value
+
     def __unicode__(self):
         return u'<x_module(id={0})>'.format(self.id)
 
@@ -664,26 +672,6 @@ class XModule(XModuleMixin, HTMLSnippet, XBlock):  # pylint: disable=abstract-me
 
         response_data = self.handle_ajax(suffix, request_post)
         return Response(response_data, content_type='application/json')
-
-    def get_children(self):
-        """
-        Return module instances for all the children of this module.
-        """
-        if self._loaded_children is None:
-            child_descriptors = self.get_child_descriptors()
-
-            # This deliberately uses system.get_module, rather than runtime.get_block,
-            # because we're looking at XModule children, rather than XModuleDescriptor children.
-            # That means it can use the deprecated XModule apis, rather than future XBlock apis
-
-            # TODO: Once we're in a system where this returns a mix of XModuleDescriptors
-            # and XBlocks, we're likely to have to change this more
-            children = [self.system.get_module(descriptor) for descriptor in child_descriptors]
-            # get_module returns None if the current user doesn't have access
-            # to the location.
-            self._loaded_children = [c for c in children if c is not None]
-
-        return self._loaded_children
 
     def get_child_descriptors(self):
         """

--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -281,6 +281,8 @@ class XModuleMixin(XBlockMixin):
 
     def __init__(self, *args, **kwargs):
         self.xmodule_runtime = None
+        self._child_instances = None
+
         super(XModuleMixin, self).__init__(*args, **kwargs)
 
     @property
@@ -410,7 +412,7 @@ class XModuleMixin(XBlockMixin):
         if not self.has_children:
             return []
 
-        if getattr(self, '_child_instances', None) is None:
+        if self._child_instances is None:
             self._child_instances = []  # pylint: disable=attribute-defined-outside-init
             for child_loc in self.children:
                 # Skip if it doesn't satisfy the filter function
@@ -534,6 +536,10 @@ class XModuleMixin(XBlockMixin):
             field_data (:class:`FieldData`): The :class:`FieldData` to use for all subsequent data access
         """
         # pylint: disable=attribute-defined-outside-init
+        self._child_instances = None
+        self._field_data_cache.clear()
+        self._dirty_fields.clear()
+
         self.xmodule_runtime = xmodule_runtime
         self._field_data = field_data
 

--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -543,13 +543,13 @@ class XModuleMixin(XBlockMixin):
 
         # Skip rebinding if we're already bound for this user.
         if user_id == self.scope_ids.user_id:
-            continue
+            return
 
         # If we are switching users mid-request, save the data from the old user.
         self.save()
 
         # Update scope_ids to point to the new user.
-        self.scope_ids = self.scope_ids.replace(user_id=user_id)
+        self.scope_ids = self.scope_ids._replace(user_id=user_id)
 
         # Clear out any cached instantiated children.
         self._child_instances = None

--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -358,7 +358,7 @@ class XModuleMixin(XBlockMixin):
         return result
 
     def has_children_at_depth(self, depth):
-        """
+        r"""
         Returns true if self has children at the given depth. depth==0 returns
         false if self is a leaf, true otherwise.
 
@@ -381,7 +381,7 @@ class XModuleMixin(XBlockMixin):
             return any(child.has_children_at_depth(depth - 1) for child in self.get_children())
 
     def get_content_titles(self):
-        """
+        r"""
         Returns list of content titles for all of self's children.
 
                          SEQUENCE

--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -530,18 +530,31 @@ class XModuleMixin(XBlockMixin):
         """
         return None
 
-    def bind_for_student(self, xmodule_runtime, field_data):
+    def bind_for_student(self, xmodule_runtime, field_data, user_id):
         """
         Set up this XBlock to act as an XModule instead of an XModuleDescriptor.
 
         Arguments:
             xmodule_runtime (:class:`ModuleSystem'): the runtime to use when accessing student facing methods
             field_data (:class:`FieldData`): The :class:`FieldData` to use for all subsequent data access
+            user_id: The user_id to set in scope_ids
         """
         # pylint: disable=attribute-defined-outside-init
+
+        # Skip rebinding if we're already bound for this user.
+        if user_id == self.scope_ids.user_id:
+            continue
+
+        # If we are switching users mid-request, save the data from the old user.
         self.save()
 
+        # Update scope_ids to point to the new user.
+        self.scope_ids = self.scope_ids.replace(user_id=user_id)
+
+        # Clear out any cached instantiated children.
         self._child_instances = None
+
+        # Clear out any cached field data scoped to the old user.
         for field in self.fields.values():
             if field.scope in (Scope.parent, Scope.children):
                 continue
@@ -549,6 +562,7 @@ class XModuleMixin(XBlockMixin):
             if field.scope.user == UserScope.ONE:
                 field._del_cached_value(self)
 
+        # Set the new xmodule_runtime and field_data (which are user-specific)
         self.xmodule_runtime = xmodule_runtime
         self._field_data = field_data
 

--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -535,10 +535,8 @@ def get_module_system_for_user(user, field_data_cache,
         # rebinds module to a different student.  We'll change system, student_data, and scope_ids
         module.descriptor.bind_for_student(
             inner_system,
-            LmsFieldData(module.descriptor._field_data, inner_student_data)  # pylint: disable=protected-access
-        )
-        module.descriptor.scope_ids = (
-            module.descriptor.scope_ids._replace(user_id=real_user.id)  # pylint: disable=protected-access
+            LmsFieldData(module.descriptor._field_data, inner_student_data),  # pylint: disable=protected-access
+            real_user.id,
         )
         module.scope_ids = module.descriptor.scope_ids  # this is needed b/c NamedTuples are immutable
         # now bind the module to the new ModuleSystem instance and vice-versa
@@ -726,8 +724,7 @@ def get_module_for_descriptor_internal(user, descriptor, field_data_cache, cours
         request_token=request_token
     )
 
-    descriptor.bind_for_student(system, field_data)  # pylint: disable=protected-access
-    descriptor.scope_ids = descriptor.scope_ids._replace(user_id=user.id)  # pylint: disable=protected-access
+    descriptor.bind_for_student(system, field_data, user.id)  # pylint: disable=protected-access
     return descriptor
 
 

--- a/lms/djangoapps/courseware/tests/test_courses.py
+++ b/lms/djangoapps/courseware/tests/test_courses.py
@@ -2,25 +2,32 @@
 """
 Tests for course access
 """
+import ddt
+import itertools
+import mock
+
 from django.conf import settings
 from django.test.utils import override_settings
-import mock
+from django.core.urlresolvers import reverse
+from django.test.client import RequestFactory
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
 
 from courseware.courses import (
     get_course_by_id, get_cms_course_link, course_image_url,
     get_course_info_section, get_course_about_section, get_cms_block_link
 )
+from courseware.module_render import get_module_for_descriptor
 from courseware.tests.helpers import get_request_for_user
+from courseware.model_data import FieldDataCache
 from student.tests.factories import UserFactory
-import xmodule.modulestore.django as store_django
+from xmodule.modulestore.django import _get_modulestore_branch_setting, modulestore
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.xml_importer import import_from_xml
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.django_utils import (
     TEST_DATA_MOCK_MODULESTORE, TEST_DATA_MIXED_TOY_MODULESTORE
 )
-from xmodule.modulestore.tests.factories import CourseFactory
+from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 from xmodule.tests.xml import factories as xml
 from xmodule.tests.xml import XModuleXmlImportTest
 
@@ -60,7 +67,7 @@ class ModuleStoreBranchSettingTest(ModuleStoreTestCase):
         MODULESTORE_BRANCH='fake_default_branch',
     )
     def test_default_modulestore_preview_mapping(self):
-        self.assertEqual(store_django._get_modulestore_branch_setting(), ModuleStoreEnum.Branch.draft_preferred)
+        self.assertEqual(_get_modulestore_branch_setting(), ModuleStoreEnum.Branch.draft_preferred)
 
     @mock.patch(
         'xmodule.modulestore.django.get_current_request_hostname',
@@ -71,7 +78,7 @@ class ModuleStoreBranchSettingTest(ModuleStoreTestCase):
         MODULESTORE_BRANCH='fake_default_branch',
     )
     def test_default_modulestore_branch_mapping(self):
-        self.assertEqual(store_django._get_modulestore_branch_setting(), 'fake_default_branch')
+        self.assertEqual(_get_modulestore_branch_setting(), 'fake_default_branch')
 
 
 @override_settings(
@@ -159,7 +166,7 @@ class CoursesRenderTest(ModuleStoreTestCase):
         """
         super(CoursesRenderTest, self).setUp()
 
-        store = store_django.modulestore()
+        store = modulestore()
         course_items = import_from_xml(store, self.user.id, TEST_DATA_DIR, ['toy'])
         course_key = course_items[0].id
         self.course = get_course_by_id(course_key)
@@ -216,3 +223,46 @@ class XmlCoursesRenderTest(ModuleStoreTestCase):
             )
             course_info = get_course_info_section(request, course, 'handouts')
             self.assertIn("this module is temporarily unavailable", course_info)
+
+
+@ddt.ddt
+class CourseInstantiationTests(ModuleStoreTestCase):
+    """
+    Tests around instantiating a course multiple times in the same request.
+    """
+    def setUp(self):
+        super(CourseInstantiationTests, self).setUp()
+
+        self.factory = RequestFactory()
+
+    @ddt.data(*itertools.product(xrange(5), [ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split], [None, 0, 5]))
+    @ddt.unpack
+    def test_repeated_course_module_instantiation(self, loops, default_store, course_depth):
+
+        with modulestore().default_store(default_store):
+            course = CourseFactory()
+            chapter = ItemFactory(parent=course, category='chapter', graded=True)
+            section = ItemFactory(parent=chapter, category='sequential')
+            problem = ItemFactory(parent=section, category='problem')
+
+        fake_request = self.factory.get(
+            reverse('progress', kwargs={'course_id': unicode(course.id)})
+        )
+
+        course = modulestore().get_course(course.id, depth=course_depth)
+
+        for _ in xrange(loops):
+            field_data_cache = FieldDataCache.cache_for_descriptor_descendents(
+                course.id, self.user, course, depth=course_depth
+            )
+            course_module = get_module_for_descriptor(
+                self.user,
+                fake_request,
+                course,
+                field_data_cache,
+                course.id
+            )
+            for chapter in course_module.get_children():
+                for section in chapter.get_children():
+                    for item in chapter.get_children():
+                        self.assertTrue(item.graded)

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -458,11 +458,11 @@ class TestTOC(ModuleStoreTestCase):
     # Split makes 6 queries to load the course to depth 2:
     #     - load the structure
     #     - load 5 definitions
-    # Split makes 2 queries to render the toc:
+    # Split makes 6 queries to render the toc:
     #     - it loads the active version at the start of the bulk operation
-    #     - it loads the course definition for inheritance, because it's outside
-    #     the bulk-operation marker that loaded the course descriptor
-    @ddt.data((ModuleStoreEnum.Type.mongo, 3, 0, 0), (ModuleStoreEnum.Type.split, 6, 0, 2))
+    #     - it loads 5 definitions, because it instantiates the a CourseModule and 4 VideoModules
+    #       each of which access a Scope.content field in __init__
+    @ddt.data((ModuleStoreEnum.Type.mongo, 3, 0, 0), (ModuleStoreEnum.Type.split, 6, 0, 6))
     @ddt.unpack
     def test_toc_toy_from_chapter(self, default_ms, setup_finds, setup_sends, toc_finds):
         with self.store.default_store(default_ms):
@@ -498,9 +498,9 @@ class TestTOC(ModuleStoreTestCase):
     #     - load 5 definitions
     # Split makes 2 queries to render the toc:
     #     - it loads the active version at the start of the bulk operation
-    #     - it loads the course definition for inheritance, because it's outside
-    #     the bulk-operation marker that loaded the course descriptor
-    @ddt.data((ModuleStoreEnum.Type.mongo, 3, 0, 0), (ModuleStoreEnum.Type.split, 6, 0, 2))
+    #     - it loads 5 definitions, because it instantiates the a CourseModule and 4 VideoModules
+    #       each of which access a Scope.content field in __init__
+    @ddt.data((ModuleStoreEnum.Type.mongo, 3, 0, 0), (ModuleStoreEnum.Type.split, 6, 0, 6))
     @ddt.unpack
     def test_toc_toy_from_section(self, default_ms, setup_finds, setup_sends, toc_finds):
         with self.store.default_store(default_ms):

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -922,7 +922,7 @@ class TestAnonymousStudentId(ModuleStoreTestCase, LoginEnrollmentTestCase):
         location = course_id.make_usage_key('dummy_category', 'dummy_name')
         descriptor = Mock(
             spec=xblock_class,
-            _field_data=Mock(spec=FieldData),
+            _field_data=Mock(spec=FieldData, name='field_data'),
             location=location,
             static_asset_path=None,
             _runtime=Mock(
@@ -932,7 +932,9 @@ class TestAnonymousStudentId(ModuleStoreTestCase, LoginEnrollmentTestCase):
                 name='runtime',
             ),
             scope_ids=Mock(spec=ScopeIds),
-            name='descriptor'
+            name='descriptor',
+            _field_data_cache={},
+            _dirty_fields={},
         )
         descriptor.runtime = CombinedSystem(descriptor._runtime, None)  # pylint: disable=protected-access
         # Use the xblock_class's bind_for_student method

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -5,6 +5,7 @@ Test for lms courseware app, module render unit
 import ddt
 import itertools
 import json
+from functools import partial
 
 from bson import ObjectId
 from django.http import Http404, HttpResponse
@@ -13,11 +14,9 @@ from django.conf import settings
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
 from django.contrib.auth.models import AnonymousUser
-from functools import partial
 from mock import MagicMock, patch, Mock
 from opaque_keys.edx.keys import UsageKey, CourseKey
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
-from courseware.module_render import hash_resource, get_module_for_descriptor
 from xblock.field_data import FieldData
 from xblock.runtime import Runtime
 from xblock.fields import ScopeIds
@@ -27,18 +26,18 @@ from capa.tests.response_xml_factory import OptionResponseXMLFactory
 from courseware import module_render as render
 from courseware.courses import get_course_with_access, course_image_url, get_course_info_section
 from courseware.model_data import FieldDataCache
+from courseware.module_render import hash_resource, get_module_for_descriptor
 from courseware.models import StudentModule
 from courseware.tests.factories import StudentModuleFactory, UserFactory, GlobalStaffFactory
 from courseware.tests.tests import LoginEnrollmentTestCase
+from courseware.tests.test_submitting_problems import TestSubmittingProblems
+from lms.djangoapps.lms_xblock.runtime import quote_slashes
+from student.models import anonymous_id_for_user
 from xmodule.modulestore.tests.django_utils import (
     TEST_DATA_MOCK_MODULESTORE, TEST_DATA_MIXED_TOY_MODULESTORE,
     TEST_DATA_XML_MODULESTORE, TEST_DATA_MIXED_CLOSED_MODULESTORE
 )
-from courseware.tests.test_submitting_problems import TestSubmittingProblems
-from lms.djangoapps.lms_xblock.runtime import quote_slashes
-from student.models import anonymous_id_for_user
 from xmodule.lti_module import LTIDescriptor
-
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -937,7 +937,7 @@ class TestAnonymousStudentId(ModuleStoreTestCase, LoginEnrollmentTestCase):
         )
         descriptor.runtime = CombinedSystem(descriptor._runtime, None)  # pylint: disable=protected-access
         # Use the xblock_class's bind_for_student method
-        descriptor.bind_for_student = partial(xblock_class.bind_for_student, descriptor)
+        descriptor.bind_for_student = partial(xblock_class.bind_for_student, descriptor, self.user.id)
 
         if hasattr(xblock_class, 'module_class'):
             descriptor.module_class = xblock_class.module_class

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -2,21 +2,22 @@
 """
 Test for lms courseware app, module render unit
 """
-from functools import partial
+import ddt
+import itertools
 import json
 
 from bson import ObjectId
-import ddt
 from django.http import Http404, HttpResponse
 from django.core.urlresolvers import reverse
 from django.conf import settings
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
 from django.contrib.auth.models import AnonymousUser
+from functools import partial
 from mock import MagicMock, patch, Mock
 from opaque_keys.edx.keys import UsageKey, CourseKey
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
-from courseware.module_render import hash_resource
+from courseware.module_render import hash_resource, get_module_for_descriptor
 from xblock.field_data import FieldData
 from xblock.runtime import Runtime
 from xblock.fields import ScopeIds
@@ -1242,3 +1243,169 @@ class LMSXBlockServiceBindingTest(ModuleStoreTestCase):
         )
         service = runtime.service(descriptor, expected_service)
         self.assertIsNotNone(service)
+
+
+class PureXBlockWithChildren(PureXBlock):
+    """
+    Pure XBlock with children to use in tests.
+    """
+    has_children = True
+
+
+class EmptyXModuleWithChildren(EmptyXModule):  # pylint: disable=abstract-method
+    """
+    Empty XModule for testing with no dependencies.
+    """
+    has_children = True
+
+
+class EmptyXModuleDescriptorWithChildren(EmptyXModuleDescriptor):  # pylint: disable=abstract-method
+    """
+    Empty XModule for testing with no dependencies.
+    """
+    module_class = EmptyXModuleWithChildren
+    has_children = True
+
+
+BLOCK_TYPES = ['xblock', 'xmodule']
+USER_NUMBERS = range(2)
+
+
+@ddt.ddt
+class TestFilteredChildren(ModuleStoreTestCase):
+    """
+    Tests that verify access to XBlock/XModule children work correctly
+    even when those children are filtered by the runtime when loaded.
+    """
+    # pylint: disable=attribute-defined-outside-init, no-member
+    def setUp(self):
+        super(TestFilteredChildren, self).setUp()
+        self.users = {number: UserFactory() for number in USER_NUMBERS}
+        self.course = CourseFactory()
+
+        self._old_has_access = render.has_access
+        patcher = patch('courseware.module_render.has_access', self._has_access)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    @ddt.data(*BLOCK_TYPES)
+    @XBlock.register_temp_plugin(PureXBlockWithChildren, identifier='xblock')
+    @XBlock.register_temp_plugin(EmptyXModuleDescriptorWithChildren, identifier='xmodule')
+    def test_unbound(self, block_type):
+        block = self._load_block(block_type)
+        self.assertUnboundChildren(block)
+
+    @ddt.data(*itertools.product(BLOCK_TYPES, USER_NUMBERS))
+    @ddt.unpack
+    @XBlock.register_temp_plugin(PureXBlockWithChildren, identifier='xblock')
+    @XBlock.register_temp_plugin(EmptyXModuleDescriptorWithChildren, identifier='xmodule')
+    def test_unbound_then_bound_as_descriptor(self, block_type, user_number):
+        user = self.users[user_number]
+        block = self._load_block(block_type)
+        self.assertUnboundChildren(block)
+        self._bind_block(block, user)
+        self.assertBoundChildren(block, user)
+
+    @ddt.data(*itertools.product(BLOCK_TYPES, USER_NUMBERS))
+    @ddt.unpack
+    @XBlock.register_temp_plugin(PureXBlockWithChildren, identifier='xblock')
+    @XBlock.register_temp_plugin(EmptyXModuleDescriptorWithChildren, identifier='xmodule')
+    def test_unbound_then_bound_as_xmodule(self, block_type, user_number):
+        user = self.users[user_number]
+        block = self._load_block(block_type)
+        self.assertUnboundChildren(block)
+        self._bind_block(block, user)
+
+        # Validate direct XModule access as well
+        if isinstance(block, XModuleDescriptor):
+            self.assertBoundChildren(block._xmodule, user)  # pylint: disable=protected-access
+        else:
+            self.assertBoundChildren(block, user)
+
+    @ddt.data(*itertools.product(BLOCK_TYPES, USER_NUMBERS))
+    @ddt.unpack
+    @XBlock.register_temp_plugin(PureXBlockWithChildren, identifier='xblock')
+    @XBlock.register_temp_plugin(EmptyXModuleDescriptorWithChildren, identifier='xmodule')
+    def test_bound_only_as_descriptor(self, block_type, user_number):
+        user = self.users[user_number]
+        block = self._load_block(block_type)
+        self._bind_block(block, user)
+        self.assertBoundChildren(block, user)
+
+    @ddt.data(*itertools.product(BLOCK_TYPES, USER_NUMBERS))
+    @ddt.unpack
+    @XBlock.register_temp_plugin(PureXBlockWithChildren, identifier='xblock')
+    @XBlock.register_temp_plugin(EmptyXModuleDescriptorWithChildren, identifier='xmodule')
+    def test_bound_only_as_xmodule(self, block_type, user_number):
+        user = self.users[user_number]
+        block = self._load_block(block_type)
+        self._bind_block(block, user)
+
+        # Validate direct XModule access as well
+        if isinstance(block, XModuleDescriptor):
+            self.assertBoundChildren(block._xmodule, user)  # pylint: disable=protected-access
+        else:
+            self.assertBoundChildren(block, user)
+
+    def _load_block(self, block_type):
+        """
+        Instantiate an XBlock of `block_type` with the appropriate set of children.
+        """
+        self.parent = ItemFactory(category=block_type, parent=self.course)
+
+        # Create a child of each block type for each user
+        self.children_for_user = {
+            user: [
+                ItemFactory(category=child_type, parent=self.parent).scope_ids.usage_id
+                for child_type in BLOCK_TYPES
+            ]
+            for user in self.users.itervalues()
+        }
+
+        self.all_children = sum(self.children_for_user.values(), [])
+
+        return modulestore().get_item(self.parent.scope_ids.usage_id)
+
+    def _bind_block(self, block, user):
+        """
+        Bind `block` to the supplied `user`.
+        """
+        course_id = self.course.id
+        field_data_cache = FieldDataCache.cache_for_descriptor_descendents(
+            course_id,
+            user,
+            block,
+        )
+        return get_module_for_descriptor(
+            user,
+            Mock(name='request', user=user),
+            block,
+            field_data_cache,
+            course_id,
+        )
+
+    def _has_access(self, user, action, obj, course_key=None):
+        """
+        Mock implementation of `has_access` used to control which blocks
+        have access to which children during tests.
+        """
+        if action != 'load':
+            return self._old_has_access(user, action, obj, course_key)
+
+        if isinstance(obj, XBlock):
+            key = obj.scope_ids.usage_id
+        elif isinstance(obj, UsageKey):
+            key = obj
+
+        if key == self.parent.scope_ids.usage_id:
+            return True
+        return key in self.children_for_user[user]
+
+    def assertBoundChildren(self, block, user):
+        self.assertChildren(block, self.children_for_user[user])
+
+    def assertUnboundChildren(self, block):
+        self.assertChildren(block, self.all_children)
+
+    def assertChildren(self, block, child_usage_ids):
+        self.assertEquals(set(child_usage_ids), set(child.scope_ids.usage_id for child in block.get_children()))

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -934,10 +934,11 @@ class TestAnonymousStudentId(ModuleStoreTestCase, LoginEnrollmentTestCase):
             name='descriptor',
             _field_data_cache={},
             _dirty_fields={},
+            fields={},
         )
         descriptor.runtime = CombinedSystem(descriptor._runtime, None)  # pylint: disable=protected-access
         # Use the xblock_class's bind_for_student method
-        descriptor.bind_for_student = partial(xblock_class.bind_for_student, descriptor, self.user.id)
+        descriptor.bind_for_student = partial(xblock_class.bind_for_student, descriptor)
 
         if hasattr(xblock_class, 'module_class'):
             descriptor.module_class = xblock_class.module_class

--- a/lms/djangoapps/lms_xblock/field_data.py
+++ b/lms/djangoapps/lms_xblock/field_data.py
@@ -33,3 +33,6 @@ class LmsFieldData(SplitFieldData):
             Scope.user_info: student_data,
             Scope.preferences: student_data,
         })
+
+    def __repr__(self):
+        return "LmsFieldData{!r}".format((self._authored_data, self._student_data))

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -22,7 +22,7 @@
 git+https://github.com/mitocw/django-cas.git@60a5b8e5a62e63e0d5d224a87f0b489201a0c695#egg=django-cas
 
 # Our libraries:
--e git+https://github.com/edx/XBlock.git@0b865f62f2deaa81b77f819b9b7df0303cb0f70c#egg=XBlock
+-e git+https://github.com/edx/XBlock.git@b5e83915d9d205076eac357b71a91f7cd6d8010d#egg=XBlock
 -e git+https://github.com/edx/codejail.git@6b17c33a89bef0ac510926b1d7fea2748b73aadd#egg=codejail
 -e git+https://github.com/edx/js-test-tool.git@v0.1.6#egg=js_test_tool
 -e git+https://github.com/edx/event-tracking.git@0.1.0#egg=event-tracking


### PR DESCRIPTION
The impetus for this PR was that recent changes for cohorted content meant that the list of children for an XBlock might change depending on which user the XBlock was bound to. The first commit adds test to make sure that XBlocks, XModules, and XModuleDescriptors all function correctly when listing their children before and after being bound to a user.

The remainder of the changes were follow-on to fix errors exposed by the first test.
1. The cache of children wasn't being cleared when a user was bound to an XBlock, so the user's permissions might not be correctly taken into account.
2. MongoModuleStore didn't re-use the CachingDescriptorSystem when it had to read new data from the database (to fill in a hole in the cached data in that DescriptorSystem). As a result, the cache of data used for inheritance (`cached_metadata`) wasn't being updated, and successive bindings of the same XBlock to different users would result in the slow disappearance of inherited data. This was resolved by allowing the modulestore to re-use the same CachingDescriptorSystem when loading new child blocks.
