### PR TITLE
Stop hitting the database when no courses are blocked.

### DIFF
--- a/common/djangoapps/embargo/models.py
+++ b/common/djangoapps/embargo/models.py
@@ -156,7 +156,7 @@ class RestrictedCourse(models.Model):
         Cache all restricted courses and returns the list of course_keys that are restricted
         """
         restricted_courses = cache.get(cls.COURSE_LIST_CACHE_KEY)
-        if not restricted_courses:
+        if restricted_courses is None:
             restricted_courses = list(RestrictedCourse.objects.values_list('course_key', flat=True))
             cache.set(cls.COURSE_LIST_CACHE_KEY, restricted_courses)
         return restricted_courses
@@ -413,7 +413,7 @@ class CountryAccessRule(models.Model):
         """
         cache_key = cls.CACHE_KEY.format(course_key=course_id)
         allowed_countries = cache.get(cache_key)
-        if not allowed_countries:
+        if allowed_countries is None:
             allowed_countries = cls._get_country_access_list(course_id)
             cache.set(cache_key, allowed_countries)
 

--- a/common/djangoapps/embargo/tests/test_api.py
+++ b/common/djangoapps/embargo/tests/test_api.py
@@ -166,6 +166,16 @@ class EmbargoCheckAccessApiTests(ModuleStoreTestCase):
         with self.assertNumQueries(0):
             embargo_api.check_course_access(self.course.id, user=self.user, ip_address='0.0.0.0')
 
+    def test_caching_no_restricted_courses(self):
+        RestrictedCourse.objects.all().delete()
+        cache.clear()
+
+        with self.assertNumQueries(1):
+            embargo_api.check_course_access(self.course.id, user=self.user, ip_address='0.0.0.0')
+
+        with self.assertNumQueries(0):
+            embargo_api.check_course_access(self.course.id, user=self.user, ip_address='0.0.0.0')
+
 
 @ddt.ddt
 @override_settings(MODULESTORE=MODULESTORE_CONFIG)


### PR DESCRIPTION
Noticed this issue while running the performance tests on the embargo feature.  When the cached lists are empty, we were hitting the database.  This change ensures that we hit the database only when there is a cache miss.

@stephensanchez please review.
