### PR TITLE
Include middleware database queries in Django debug toolbar

### DIFF
--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -45,8 +45,12 @@ ANALYTICS_DASHBOARD_URL = None
 ################################ DEBUG TOOLBAR ################################
 
 INSTALLED_APPS += ('debug_toolbar', 'debug_toolbar_mongo')
-MIDDLEWARE_CLASSES += ('django_comment_client.utils.QueryCountDebugMiddleware',
-                       'debug_toolbar.middleware.DebugToolbarMiddleware',)
+MIDDLEWARE_CLASSES = (
+    (
+        'django_comment_client.utils.QueryCountDebugMiddleware',
+        'debug_toolbar.middleware.DebugToolbarMiddleware',
+    ) + MIDDLEWARE_CLASSES
+)
 INTERNAL_IPS = ('127.0.0.1',)
 
 DEBUG_TOOLBAR_PANELS = (


### PR DESCRIPTION
I noticed that the Django debug toolbar in devstack wasn't including SQL queries from middleware earlier in the middleware stack.  Moving the Django debug toolbar middleware first ensures that these queries are included in the results.

@benpatterson could you please review this when you have a moment?
