### PR TITLE
Preserve enrollment_action and course_id querystring params in header 'Sign In' button

### DIFF
--- a/lms/djangoapps/student_account/test/test_views.py
+++ b/lms/djangoapps/student_account/test/test_views.py
@@ -408,6 +408,26 @@ class StudentAccountLoginAndRegistrationTest(UrlResetMixin, ModuleStoreTestCase)
         response = self.client.get(reverse(url_name))
         self.assertRedirects(response, reverse("dashboard"))
 
+    @ddt.data(
+        (False, "account_login"),
+        (False, "account_login"),
+        (True, "account_login"),
+        (True, "account_register"),
+    )
+    @ddt.unpack
+    def test_login_and_registration_form_signin_preserves_params(self, is_edx_domain, url_name):
+        params = {
+            'enrollment_action': 'enroll',
+            'course_id': 'edX/DemoX/Demo_Course'
+        }
+
+        with mock.patch.dict(settings.FEATURES, {'IS_EDX_DOMAIN': is_edx_domain}):
+            response = self.client.get(reverse(url_name), params)
+
+        # The response should have a "Sign In" button with the URL
+        # that preserves the querystring params
+        self.assertContains(response, "login?course_id=edX%2FDemoX%2FDemo_Course&enrollment_action=enroll")
+
     @mock.patch.dict(settings.FEATURES, {"ENABLE_THIRD_PARTY_AUTH": False})
     @ddt.data("account_login", "account_register")
     def test_third_party_auth_disabled(self, url_name):

--- a/lms/djangoapps/student_account/views.py
+++ b/lms/djangoapps/student_account/views.py
@@ -114,6 +114,11 @@ def login_and_registration_form(request, initial_mode="login"):
         'login_form_desc': form_descriptions['login'],
         'registration_form_desc': form_descriptions['registration'],
         'password_reset_form_desc': form_descriptions['password_reset'],
+
+        # We need to pass these parameters so that the header's
+        # "Sign In" button preserves the querystring params.
+        'enrollment_action': request.GET.get('enrollment_action'),
+        'course_id': request.GET.get('course_id')
     }
 
     return render_to_response('student_account/login_and_register.html', context)


### PR DESCRIPTION
The "sign in" button in the header of the new combined login/registration page was not preserving the query-string parameters `enrollment_action` and `course_id`.  Users who click the "sign in" button in the header in the process of enrolling in a course would end up on the dashboard instead of continuing through the enrollment flow.

JIRA: [ECOM-1108](https://openedx.atlassian.net/browse/ECOM-1108)

@rlucioni please review.
