### PR TITLE
Fix right margin of LinkedIn add-to-profile button

### DIFF
--- a/lms/templates/dashboard/_dashboard_certificate_information.html
+++ b/lms/templates/dashboard/_dashboard_certificate_information.html
@@ -78,7 +78,7 @@ else:
   % if cert_status['show_download_url'] and cert_status['linked_in_url']:
   <ul class="actions actions-secondary">
       <li class="action action-share">
-        <a class="action action-linkedin-profile" target="_blank" href="${cert_status['linked_in_url']}"
+        <a class="action-linkedin-profile" target="_blank" href="${cert_status['linked_in_url']}"
          title="${_('Add Certificate to LinkedIn Profile')}"
          data-course-id="${unicode(course.id)}"
          data-certificate-mode="${cert_status['mode']}"


### PR DESCRIPTION
@AlasdairSwan Small style fixup for the LinkedIn button.  Clearing the margin in `action-share` was being overridden by the `action` class in the `<a>` tag, so the right margin wasn't quite aligned with the button above it.  Removing that class resolves the issue.
