### PR TITLE
Use pip 6.0.8

### DIFF
--- a/requirements/edx/pre.txt
+++ b/requirements/edx/pre.txt
@@ -9,7 +9,7 @@
 numpy==1.6.2
 
 # Needed to make sure that options in base.txt are allowed
-pip==6.0.7
+pip==6.0.8
 
 # Needed for meliae
 Cython==0.21.2


### PR DESCRIPTION
Just to keep us on the upgrade treadmill. [Changelog](http://pip.readthedocs.org/en/latest/news.html)

@cpennington, you added this line originally. Can you review this PR?
