### PR TITLE
Expose CORS_ORIGIN_ALLOW_ALL setting

### DIFF
--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -313,6 +313,7 @@ if FEATURES.get('ENABLE_CORS_HEADERS'):
     ) + MIDDLEWARE_CLASSES
     CORS_ALLOW_CREDENTIALS = True
     CORS_ORIGIN_WHITELIST = ENV_TOKENS.get('CORS_ORIGIN_WHITELIST', ())
+    CORS_ORIGIN_ALLOW_ALL = ENV_TOKENS.get('CORS_ORIGIN_ALLOW_ALL', False)
 
 ############################## SECURE AUTH ITEMS ###############
 # Secret things: passwords, access keys, etc.

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1700,6 +1700,7 @@ if FEATURES.get('ENABLE_CORS_HEADERS'):
     ) + MIDDLEWARE_CLASSES
     CORS_ALLOW_CREDENTIALS = True
     CORS_ORIGIN_WHITELIST = ()
+    CORS_ORIGIN_ALLOW_ALL = False
 
 ###################### Registration ##################################
 


### PR DESCRIPTION
Exposing this setting makes it easier to test development on the Drupal marketing site using a sandbox.  When enabled, this setting will allow CORS for any domain, including whatever local hostname is configured in the Acquia local dev environment.

@feanil please review.
