### PR TITLE
footer <nav> accessibility issue

### DIFF
--- a/cms/templates/widgets/footer.html
+++ b/cms/templates/widgets/footer.html
@@ -15,7 +15,7 @@
       </p>
     </div>
 
-    <nav class="nav-peripheral">
+    <nav class="nav-peripheral" aria-label="{_('Legal')}">
       <ol>
         <li class="nav-item nav-peripheral-tos">
           <a data-rel="edx.org" href="${marketing_link('TOS')}">${_("Terms of Service")}</a>


### PR DESCRIPTION
<nav> in the footer of the studio does not have accessible label(aria-label,
aria-labelledby) which causes accessibility issues for the screen reader users.

TNL-1523
