### PR TITLE
Event-testing pattern should be made available in a Mixin.

### DIFF
--- a/common/test/acceptance/tests/discussion/test_cohort_management.py
+++ b/common/test/acceptance/tests/discussion/test_cohort_management.py
@@ -5,13 +5,11 @@ End-to-end tests related to the cohort management on the LMS Instructor Dashboar
 
 from datetime import datetime
 
-from pymongo import MongoClient
-
 from pytz import UTC, utc
 from bok_choy.promise import EmptyPromise
 from nose.plugins.attrib import attr
 from .helpers import CohortTestMixin
-from ..helpers import UniqueCourseTest, create_user_partition_json
+from ..helpers import UniqueCourseTest, EventsTestMixin, create_user_partition_json
 from xmodule.partitions.partitions import Group
 from ...fixtures.course import CourseFixture
 from ...pages.lms.auto_auth import AutoAuthPage
@@ -23,7 +21,7 @@ import uuid
 
 
 @attr('shard_3')
-class CohortConfigurationTest(UniqueCourseTest, CohortTestMixin):
+class CohortConfigurationTest(EventsTestMixin, UniqueCourseTest, CohortTestMixin):
     """
     Tests for cohort management on the LMS Instructor Dashboard
     """
@@ -33,8 +31,6 @@ class CohortConfigurationTest(UniqueCourseTest, CohortTestMixin):
         Set up a cohorted course
         """
         super(CohortConfigurationTest, self).setUp()
-
-        self.event_collection = MongoClient()["test"]["events"]
 
         # create course with cohorts
         self.manual_cohort_name = "ManualCohort1"


### PR DESCRIPTION
@rlucioni @mulby @gwprice @clytwynec 

I just finished off the PayAndVerify tests a week or two ago, but now I'd like to move some of this to the base class so we can start establishing some patterns in bok-choy for testing events.

Although I'm moving the assertion to the base class, I'd like to put additional work for it in a subsequent PR. Ideally that assertion would be flexible enough to handle different needs (e.g., PayAndVerifyTest assertions vs CohortConfigurationTest). I decided to put the assertion into the base class here because unittest.assertEqual will give more information in the case of a failure.

Anyway...for your review and I welcome any feedback. Again my main goal here is to establish some good patterns. Once patterns are established, I would broadcast & point to a couple of examples for folks to follow when testing for events via bok-choy.
