### PR TITLE
Add metatag <path_prefix> for pdf_viewer.html

### DIFF
--- a/common/static/js/spec/logger_spec.js
+++ b/common/static/js/spec/logger_spec.js
@@ -37,6 +37,74 @@
             });
         });
 
+        describe('ajax request settings with path_prefix', function() {
+            var meta_tag;
+
+            beforeEach(function(){
+                this.initialAjaxWithPrefix = jQuery.ajaxWithPrefix;
+                AjaxPrefix.addAjaxPrefix($, _.bind(function () {
+                    return $("meta[name='path_prefix']").attr('content');
+                }, this));
+            });
+
+            afterEach(function(){
+                jQuery.ajaxWithPrefix = this.initialAjaxWithPrefix;
+                meta_tag.remove();
+                meta_tag = null;
+            });
+
+            it('if path_prefix is not defined', function() {
+                meta_tag = $('<meta name="path_prefix1" content="">');
+                meta_tag.appendTo('body');
+                spyOn(jQuery, 'ajax');
+                Logger.log('example', 'data');
+                expect(jQuery.ajax).toHaveBeenCalledWith({
+                    url: 'undefined/event',
+                    type: 'POST',
+                    data: {
+                        event_type: 'example',
+                        event: '"data"',
+                        page: window.location.href
+                    },
+                    async: true
+                });
+            });
+
+            it('if path_prefix is defined', function() {
+                meta_tag = $('<meta name="path_prefix" content="">');
+                meta_tag.appendTo('body');
+                spyOn(jQuery, 'ajax');
+                Logger.log('example', 'data');
+                expect(jQuery.ajax).toHaveBeenCalledWith({
+                    url: '/event',
+                    type: 'POST',
+                    data: {
+                        event_type: 'example',
+                        event: '"data"',
+                        page: window.location.href
+                    },
+                    async: true
+                });
+            });
+
+            it('if path_prefix is custom value', function() {
+                meta_tag = $('<meta name="path_prefix" content="testpath">');
+                meta_tag.appendTo('body');
+                spyOn(jQuery, 'ajax');
+                Logger.log('example', 'data');
+                expect(jQuery.ajax).toHaveBeenCalledWith({
+                    url: 'testpath/event',
+                    type: 'POST',
+                    data: {
+                        event_type: 'example',
+                        event: '"data"',
+                        page: window.location.href
+                    },
+                    async: true
+                });
+            });
+        });
+
         describe('listen', function() {
             beforeEach(function () {
                 spyOn(jQuery, 'ajaxWithPrefix');

--- a/lms/templates/pdf_viewer.html
+++ b/lms/templates/pdf_viewer.html
@@ -23,6 +23,7 @@ http://sourceforge.net/adobe/cmap/wiki/License/
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <meta name="google" content="notranslate">
+    <meta name="path_prefix" content="${EDX_ROOT_URL}">
     <title>${current_chapter['title'] if current_chapter else '' |h}</title>
 
     <link rel="stylesheet" href="${static.url('/static/css/vendor/pdfjs/viewer.css')}"/>


### PR DESCRIPTION
[AN-4618](https://openedx.atlassian.net/browse/AN-4618)

The line no at [here](https://github.com/edx/edx-platform/blob/master/common/static/coffee/src/ajax_prefix.coffee#L11)
is using prefix() function for determine the path_prefix from meta tag as defined [here](https://github.com/edx/edx-platform/blob/a9127c1897d1b30b8c89cb9afd5cea69d67c3e7e/lms/templates/main.html#L127) which is used to determine the address of ajax request but the pdf is loading in iframe and hence unable to access metatag "path_prefix" of its parent element , and so solution is tag we can add metatag "path_prefix" at [pdf template](https://github.com/edx/edx-platform/blob/master/lms/templates/pdf_viewer.html) which is the actual content loading in iframe
