### PR TITLE
Fixed Sorting Bug

### DIFF
--- a/lms/djangoapps/course_structure_api/v0/tests.py
+++ b/lms/djangoapps/course_structure_api/v0/tests.py
@@ -11,6 +11,7 @@ from mock import patch, Mock
 from oauth2_provider.tests.factories import AccessTokenFactory, ClientFactory
 from opaque_keys.edx.locator import CourseLocator
 from xmodule.error_module import ErrorDescriptor
+from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 from xmodule.modulestore.xml import CourseLocationManager
@@ -77,7 +78,9 @@ class CourseViewTestsMixin(object):
         self.empty_course = CourseFactory.create(
             start=datetime(2014, 6, 16, 14, 30),
             end=datetime(2015, 1, 16),
-            org="MTD"
+            org="MTD",
+            # Use mongo so that we can get a test with a SlashSeparatedCourseKey
+            default_store=ModuleStoreEnum.Type.mongo
         )
 
     def build_absolute_url(self, path=None):

--- a/lms/djangoapps/course_structure_api/v0/views.py
+++ b/lms/djangoapps/course_structure_api/v0/views.py
@@ -1,7 +1,6 @@
 """ API implementation for course-oriented interactions. """
 
 import logging
-from operator import attrgetter
 
 from django.conf import settings
 from django.http import Http404
@@ -132,7 +131,7 @@ class CourseList(CourseViewMixin, ListAPIView):
         results = (course for course in results if self.user_can_access_course(self.request.user, course))
 
         # Sort the results in a predictable manner.
-        return sorted(results, key=attrgetter('id'))
+        return sorted(results, key=lambda course: unicode(course.id))
 
 
 class CourseDetail(CourseViewMixin, RetrieveAPIView):


### PR DESCRIPTION
Sorting on unicode value of course ID since CourseLocator objects cannot be compared to SlashSeparatedCourseKey objects.

@cpennington @brianhw @mulby @jab5569 @doctoryes 
