### PR TITLE
Revert "Update sass to 3.4.12."

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-gem 'sass', '3.4.12'
+gem 'sass', '3.3.5'
 gem 'bourbon', '~> 4.0.2'
 gem 'neat', '~> 1.6.0'
 gem 'colorize', '~> 0.5.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ GEM
     rb-fsevent (0.9.3)
     rb-inotify (0.9.2)
       ffi (>= 0.5.0)
-    sass (3.4.12)
+    sass (3.3.5)
     sys-proctable (0.9.3)
     thor (0.19.1)
 
@@ -31,5 +31,5 @@ DEPENDENCIES
   neat (~> 1.6.0)
   rb-fsevent (~> 0.9.3)
   rb-inotify (~> 0.9)
-  sass (= 3.4.12)
+  sass (= 3.3.5)
   sys-proctable (~> 0.9.3)


### PR DESCRIPTION
Reverts edx/edx-platform#7143

Turns out this upgrade is no longer relevant.
