### PR TITLE
Fixed Celery Serialization Bug

### DIFF
--- a/lms/djangoapps/course_structure_api/v0/tests.py
+++ b/lms/djangoapps/course_structure_api/v0/tests.py
@@ -299,7 +299,7 @@ class CourseStructureTests(CourseDetailMixin, CourseViewTestsMixin, ModuleStoreT
         super(CourseStructureTests, self).setUp()
 
         # Ensure course structure exists for the course
-        update_course_structure(self.course.id)
+        update_course_structure(unicode(self.course.id))
 
     def test_get(self):
         """

--- a/lms/djangoapps/course_structure_api/v0/views.py
+++ b/lms/djangoapps/course_structure_api/v0/views.py
@@ -192,7 +192,7 @@ class CourseStructure(CourseViewMixin, RetrieveAPIView):
             return super(CourseStructure, self).retrieve(request, *args, **kwargs)
         except models.CourseStructure.DoesNotExist:
             # If we don't have data stored, generate it and return a 503.
-            models.update_course_structure.delay(self.course.id)
+            models.update_course_structure.delay(unicode(self.course.id))
             return Response(status=503, headers={'Retry-After': '120'})
 
     def get_object(self, queryset=None):

--- a/openedx/core/djangoapps/content/course_structures/management/commands/generate_course_structure.py
+++ b/openedx/core/djangoapps/content/course_structures/management/commands/generate_course_structure.py
@@ -39,7 +39,7 @@ class Command(BaseCommand):
 
         for course_key in course_keys:
             try:
-                update_course_structure(course_key)
+                update_course_structure(unicode(course_key))
             except Exception as e:
                 logger.error('An error occurred while generating course structure for %s: %s', unicode(course_key), e)
 


### PR DESCRIPTION
CourseLocator is not JSON-serializable. Passing course keys as Unicode instead when scheduling tasks to update course structure.

@ormsbee @cpennington @doctoryes @mulby @brianhw @dsjen 
