### PR TITLE
Use the supplied user for the log-out signal, rather than the one from t...

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -1376,9 +1376,9 @@ def log_successful_login(sender, request, user, **kwargs):  # pylint: disable=un
 def log_successful_logout(sender, request, user, **kwargs):  # pylint: disable=unused-argument
     """Handler to log when logouts have occurred successfully."""
     if settings.FEATURES['SQUELCH_PII_IN_LOGS']:
-        AUDIT_LOG.info(u"Logout - user.id: {0}".format(request.user.id))
+        AUDIT_LOG.info(u"Logout - user.id: {0}".format(user.id))
     else:
-        AUDIT_LOG.info(u"Logout - {0}".format(request.user))
+        AUDIT_LOG.info(u"Logout - {0}".format(user))
 
 
 @receiver(user_logged_in)


### PR DESCRIPTION
...he request (which may not exist, if no user is logged in)
