### PR TITLE
No "Main" region landmark on Student Dashboard

### DIFF
--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -174,7 +174,7 @@
 
   </section>
 
-  <section class="my-courses" id="my-courses">
+  <section id="my-courses" class="my-courses" role="main" aria-label="Content">
     <header>
       <h2>${_("Current Courses")}</h2>
     </header>


### PR DESCRIPTION
On student dashboard currently there was currently no main region landmark.
So added the role with the main conents of the dashboard.

TNL-1567
