### PR TITLE
fix bok-choy reporting on failure

### DIFF
--- a/scripts/all-tests.sh
+++ b/scripts/all-tests.sh
@@ -95,13 +95,13 @@ END
     "unit")
         case "$SHARD" in
             "lms")
-                paver test_system -s lms --extra_args="--with-flaky"
+                paver test_system -s lms --extra_args="--with-flaky" || { EXIT=1; }
                 paver coverage
                 ;;
             "cms-js-commonlib")
-                paver test_system -s cms --extra_args="--with-flaky"
-                paver test_js --coverage --skip_clean
-                paver test_lib --skip_clean --extra_args="--with-flaky"
+                paver test_system -s cms --extra_args="--with-flaky" || { EXIT=1; }
+                paver test_js --coverage --skip_clean || { EXIT=1; }
+                paver test_lib --skip_clean --extra_args="--with-flaky" || { EXIT=1; }
                 paver coverage
                 ;;
             *)
@@ -109,6 +109,8 @@ END
                 paver coverage
                 ;;
         esac
+
+        exit $EXIT
         ;;
 
     "lms-acceptance")
@@ -158,23 +160,23 @@ END
         case "$SHARD" in
 
             "all")
-                paver test_bokchoy
+                paver test_bokchoy || { EXIT=1; }
                 ;;
 
             "1")
-                paver test_bokchoy --extra_args="-a shard_1 --with-flaky"
+                paver test_bokchoy --extra_args="-a shard_1 --with-flaky" || { EXIT=1; }
                 ;;
 
             "2")
-                paver test_bokchoy --extra_args="-a 'shard_2' --with-flaky"
+                paver test_bokchoy --extra_args="-a 'shard_2' --with-flaky" || { EXIT=1; }
                 ;;
 
             "3")
-                paver test_bokchoy --extra_args="-a 'shard_3' --with-flaky"
+                paver test_bokchoy --extra_args="-a 'shard_3' --with-flaky" || { EXIT=1; }
                 ;;
 
             "4")
-                paver test_bokchoy --extra_args="-a shard_1=False,shard_2=False,shard_3=False --with-flaky"
+                paver test_bokchoy --extra_args="-a shard_1=False,shard_2=False,shard_3=False --with-flaky" || { EXIT=1; }
                 ;;
 
             # Default case because if we later define another bok-choy shard on Jenkins
@@ -197,6 +199,15 @@ END
 END
                 ;;
         esac
+
+        # Move the reports to a directory that is unique to the shard
+        # so that when they are 'slurped' to the main flow job, they
+        # do not conflict with and overwrite reports from other shards.
+        mv reports/ reports_tmp/
+        mkdir -p reports/${TEST_SUITE}/${SHARD}
+        mv reports_tmp/* reports/${TEST_SUITE}/${SHARD}
+        rm -r reports_tmp/
+        exit $EXIT
         ;;
 
 esac


### PR DESCRIPTION
It looks like there were two different things causing the bok choy failures to not show up in test results for the main build flow.  

1) The JUnit pattern in the job config needed to be `reports/bok-choy/**/xunit.xml`  instead of  `reports/bok_choy/**/xunit.xml`.  Even when the artifacts were being collected correctly, they were not being found by the xunit publisher. I've already updated the config to look for both of these patterns, so this part of the issue is resolved.

2) The artifacts were not being moved to the correct folder on failure (they were being left in `reports/bok_choy/xunit.xml`).  This means that these xml files were being found by the xunit publisher, but if there was more than one failing bok choy build step, only the results from the last one to finish would be published.  This PR addresses this issue.
