### PR TITLE
Show the payment section if no contribution amount is selected

### DIFF
--- a/lms/templates/verify_student/make_payment_step.underscore
+++ b/lms/templates/verify_student/make_payment_step.underscore
@@ -19,7 +19,66 @@
       </div>
     <% } %>
 
-    <% if ( isActive && ( !hasVisibleReqs || upgrade ) ) { %>
+    <div class="instruction <% if ( !upgrade ) { %>center-col<% } %>">
+      <% if ( _.some( requirements, function( isVisible ) { return isVisible; } ) ) { %>
+      <p>
+        <% if ( verificationDeadline ) { %>
+          <%- _.sprintf(
+            gettext( "You can pay now even if you don't have the following items available, but you will need to have these by %(date)s to qualify to earn a Verified Certificate." ),
+            { date: verificationDeadline }
+          ) %>
+        <% } else if ( !isActive ) { %>
+          <%- gettext( "You need to activate your account before you can enroll in courses. Check your inbox for an activation email. After you complete activation you can return and refresh this page." ) %>
+        <% } else { %>
+            <%- gettext( "You can pay now even if you don't have the following items available, but you will need to have these to qualify to earn a Verified Certificate." ) %>
+        <% } %>
+      </p>
+      <% } %>
+    </div>
+
+    <div class="requirements-container">
+      <ul class="list-reqs <% if ( requirements['account-activation-required'] ) { %>account-not-activated<% } %>">
+        <% if ( requirements['account-activation-required'] ) { %>
+          <li class="req req-0 req-activate">
+            <h4 class="title"><%- gettext( "Activate Your Account" ) %></h4>
+            <div class="placeholder-art">
+              <i class="icon fa fa-envelope-o" aria-hidden="true"></i>
+            </div>
+
+            <div class="copy">
+              <p>
+                <span class="copy-super"><%- gettext( "Check Your Email" ) %></span>
+              </p>
+            </div>
+          </li>
+        <% } else {%>
+          <% if ( requirements['photo-id-required'] ) { %>
+          <li class="req req-1 req-id">
+            <h4 class="title"><%- gettext( "Government-Issued Photo ID" ) %></h4>
+            <div class="placeholder-art fa-lg">
+              <i class="icon fa fa-list-alt fa-stack-2x" aria-hidden="true"></i>
+              <i class="icon fa fa-user id-photo fa-stack-1x" aria-hidden="true"></i>
+            </div>
+
+            <div class="copy"></div>
+          </li>
+          <% } %>
+
+          <% if ( requirements['webcam-required'] ) { %>
+          <li class="req req-2 req-webcam">
+            <h4 class="title"><%- gettext( "Webcam" ) %></h4>
+            <div class="placeholder-art">
+              <i class="icon fa fa-video-camera" aria-hidden="true"></i>
+            </div>
+
+            <div class="copy"></div>
+          </li>
+          <% } %>
+        <% } %>
+      </ul>
+    </div>
+
+    <% if ( isActive && ( !hasVisibleReqs || upgrade || !contributionAmount) ) { %>
       <div class="wrapper-task hidden" aria-hidden="true">
         <ol class="review-tasks">
           <% if ( suggestedPrices.length > 0 ) { %>
@@ -96,66 +155,6 @@
       </div>
     </div>
     <% } %>
-
-    <div class="instruction <% if ( !upgrade ) { %>center-col<% } %>">
-      <% if ( _.some( requirements, function( isVisible ) { return isVisible; } ) ) { %>
-      <p>
-        <% if ( verificationDeadline ) { %>
-          <%- _.sprintf(
-            gettext( "You can pay now even if you don't have the following items available, but you will need to have these by %(date)s to qualify to earn a Verified Certificate." ),
-            { date: verificationDeadline }
-          ) %>
-        <% } else if ( !isActive ) { %>
-          <%- gettext( "You need to activate your account before you can enroll in courses. Check your inbox for an activation email. After you complete activation you can return and refresh this page." ) %>
-        <% } else { %>
-            <%- gettext( "You can pay now even if you don't have the following items available, but you will need to have these to qualify to earn a Verified Certificate." ) %>
-        <% } %>
-      </p>
-      <% } %>
-    </div>
-
-    <div class="requirements-container">
-      <ul class="list-reqs <% if ( requirements['account-activation-required'] ) { %>account-not-activated<% } %>">
-        <% if ( requirements['account-activation-required'] ) { %>
-          <li class="req req-0 req-activate">
-            <h4 class="title"><%- gettext( "Activate Your Account" ) %></h4>
-            <div class="placeholder-art">
-              <i class="icon fa fa-envelope-o" aria-hidden="true"></i>
-            </div>
-
-            <div class="copy">
-              <p>
-                <span class="copy-super"><%- gettext( "Check Your Email" ) %></span>
-              </p>
-            </div>
-          </li>
-        <% } else {%>
-          <% if ( requirements['photo-id-required'] ) { %>
-          <li class="req req-1 req-id">
-            <h4 class="title"><%- gettext( "Government-Issued Photo ID" ) %></h4>
-            <div class="placeholder-art fa-lg">
-              <i class="icon fa fa-list-alt fa-stack-2x" aria-hidden="true"></i>
-              <i class="icon fa fa-user id-photo fa-stack-1x" aria-hidden="true"></i>
-            </div>
-
-            <div class="copy"></div>
-          </li>
-          <% } %>
-
-          <% if ( requirements['webcam-required'] ) { %>
-          <li class="req req-2 req-webcam">
-            <h4 class="title"><%- gettext( "Webcam" ) %></h4>
-            <div class="placeholder-art">
-              <i class="icon fa fa-video-camera" aria-hidden="true"></i>
-            </div>
-
-            <div class="copy"></div>
-          </li>
-          <% } %>
-        <% } %>
-      </ul>
-    </div>
-
 
   <% if ( isActive ) { %>
   <nav class="nav-wizard is-ready <% if ( isActive && !upgrade ) { %>center<% } %>">


### PR DESCRIPTION
[ECOM-1151](https://openedx.atlassian.net/browse/ECOM-1151): Display price selection in the payment/verification flow for professional education courses.

The issue was:
- Professional education courses skip the "track selection" page, where users usually select a price.
- The payment / verification flow asks the user for a price _only_ when upgrading, assuming that the user has already selected a price on the track selection page.

In this PR, I have made two changes (although it looks like more in the diff):
1) Ask the user to choose the amount any time no contribution amount has been specified, not just when coming from the upgrade page.
2) Move the "payment" section below the requirements section (webcam/photo ID, etc).

This is what it looks like with the configuration for a prof-ed course (same as the issue in prod):
![image](https://cloud.githubusercontent.com/assets/2948394/6446868/efaa40e8-c0db-11e4-9c24-641dc8747cfc.png)

@stephensanchez @AlasdairSwan @dianakhuang @rlucioni can two of you please review this?

@adampalay FYI this will need to be hotfixed.
