### PR TITLE
added links to docs for listed libraries in overview.md

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -198,4 +198,4 @@ Ahsan Ulhaq <ahsan@edx.org>
 Mat Moore <mat@mooresoftware.co.uk>
 Muzaffar Yousaf <muzaffar@edx.org>
 Sylvain <sylvain@openfun.fr>
-
+Mayank Jain <mjmayank@gmail.com>

--- a/docs/en_us/internal/overview.md
+++ b/docs/en_us/internal/overview.md
@@ -6,13 +6,13 @@ This document explains the general structure of the edX platform, and defines so
 
 You should be familiar with the following.  If you're not, go read some docs...
 
- - python
- - django
+ - [python](http://docs.python.org)
+ - [django](http://docs.djangoproject.com)
  - javascript
  - html, xml -- xpath, xslt
  - css
- - git
- - mako templates -- we use these instead of django templates, because they support embedding real python.
+ - [git](http://git-scm.com/documentation)
+ - [mako templates](http://www.makotemplates.org/docs) -- we use these instead of django templates, because they support embedding real python.
 
 ## Other relevant terms
 


### PR DESCRIPTION
This is repeat of https://github.com/edx/edx-platform/pull/7183 because I accidentally made the pull request from my master branch previously so the commits seem to have vanished.

---

This is a small commit to the overview docs that explains the system and acronyms to new contributors. This commit simply adds links to the relevant docs that newcomers are encouraged to read if they are unfamiliar with the system. I'm hoping to use this small commit as a gateway to make more meaningful contributions to the project, just so I can get a feel for the approval process.

Studio updates: none

LMS updates: none

Testing: Since no code was changed I didn't run any tests, however I clicked on each of the links to make sure that they work.

Urgency: low
