### PR TITLE
Add student response reports, management and dashboard functionality

### DIFF
--- a/common/test/acceptance/pages/lms/instructor_dashboard.py
+++ b/common/test/acceptance/pages/lms/instructor_dashboard.py
@@ -744,6 +744,13 @@ class DataDownloadPage(PageObject):
         """
         return self.q(css="#report-downloads-table .file-download-link>a")
 
+    @property
+    def student_response_report_button(self):
+        """
+        Returns the 'Generate Student Reponses Report' button
+        """
+        return self.q(css='.reports-download-container input[name="student-response-report"]')
+
     def wait_for_available_report(self):
         """
         Waits for a downloadable report to be available.
@@ -757,6 +764,15 @@ class DataDownloadPage(PageObject):
         Returns a list of all the available reports for download.
         """
         return self.report_download_links.map(lambda el: el.text)
+
+    def get_report_generation_msg(self):
+        """
+        Waits for and returns the message populated in the report request-response section
+        after a report generation task is kicked off.
+        """
+        self.wait_for_element_visibility('#report-request-response', 'Grade report task success message is shown')
+        text = self.q(css="#report-request-response").text[0]
+        return text
 
 
 class StudentAdminPage(PageObject):

--- a/common/test/acceptance/tests/lms/test_lms_instructor_dashboard.py
+++ b/common/test/acceptance/tests/lms/test_lms_instructor_dashboard.py
@@ -172,7 +172,7 @@ class CSVReportGeneration(UniqueCourseTest):
         # Expect to see a message that grade report is being generated
         expected_msg = (
             "Your student responses report is being generated! You can view the status of "
-            "the generation task in the 'Pending Instructor Tasks' section."
+            "the generation task in the 'Pending Tasks' section."
         )
         actual_msg = self.data_download_section.get_report_generation_msg()
         self.assertEqual(expected_msg, actual_msg)

--- a/common/test/data/unicode_graded/README.md
+++ b/common/test/data/unicode_graded/README.md
@@ -1,0 +1,1 @@
+This is a very simple course for testing student responses reports for courses with unicode information.

--- a/common/test/data/unicode_graded/course.xml
+++ b/common/test/data/unicode_graded/course.xml
@@ -1,0 +1,1 @@
+<course org="edX" course="unicode_graded" url_name="2012_Fall"/>

--- a/common/test/data/unicode_graded/course/2012_Fall.xml
+++ b/common/test/data/unicode_graded/course/2012_Fall.xml
@@ -1,0 +1,15 @@
+<course>
+  <chapter url_name="UnicodeGradedChapter" display_name="Üñîçø∂éßradedChapter">
+    <videosequence url_name="Homework1" display_name="πoméwork 1">
+      <vertical url_name="Homework1Unit" display_name="中oméwork1Uni大">
+        
+        <problem url_name="H1P1">
+          <optionresponse>
+            <optioninput options="('Correct', 'Incorrect')" correct="Correct"></optioninput>
+            <optioninput options="('Correct', 'Incorrect')" correct="Correct"></optioninput>
+          </optionresponse>
+        </problem>
+      </vertical>
+    </videosequence>
+  </chapter>
+</course>

--- a/common/test/data/unicode_graded/grading_policy.json
+++ b/common/test/data/unicode_graded/grading_policy.json
@@ -1,0 +1,16 @@
+{
+  "GRADER" : [
+    {
+      "type" : "Homework",
+      "min_count" : 3,
+      "drop_count" : 1,
+      "short_label" : "HW",
+      "weight" : 0.5
+    }
+  ],
+  "GRADE_CUTOFFS" : {
+    "A" : 0.8,
+    "B" : 0.7,
+    "C" : 0.6
+  }
+}

--- a/common/test/data/unicode_graded/policies/2012_Fall.json
+++ b/common/test/data/unicode_graded/policies/2012_Fall.json
@@ -1,0 +1,14 @@
+{
+    "course/2012_Fall": {
+        "graceperiod": "2 days 5 hours 59 minutes 59 seconds",
+        "start": "2010-07-17T12:00",
+        "display_name": "Üñîçø∂é ßraded Course",
+        "graded": "true"
+    },
+	
+    "videosequence/Homework1": {
+        "display_name": "πoméwork 1", 
+        "graded": true, 
+        "format": "Homework"
+    }	
+}

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -101,7 +101,13 @@ REPORTS_DATA = (
         'instructor_api_endpoint': 'get_students_who_may_enroll',
         'task_api_endpoint': 'instructor_task.api.submit_calculate_may_enroll_csv',
         'extra_instructor_api_kwargs': {},
-    }
+    },
+    {
+        'report_type': 'student responses',
+        'instructor_api_endpoint': 'calculate_student_responses_csv',
+        'task_api_endpoint': 'instructor_task.api.submit_calculate_student_responses_csv',
+        'extra_instructor_api_kwargs': {}
+    },
 )
 
 # ddt data for test cases involving executive summary report
@@ -202,6 +208,7 @@ class TestInstructorAPIDenyLevels(ModuleStoreTestCase, LoginEnrollmentTestCase):
         )
 
         # Endpoints that only Staff or Instructors can access
+        # Entries should be a tuple of (api_method_name, {request_args_sent_to_endpoint})
         self.staff_level_endpoints = [
             ('students_update_enrollment',
              {'identifiers': 'foo@example.org', 'action': 'enroll'}),
@@ -220,6 +227,7 @@ class TestInstructorAPIDenyLevels(ModuleStoreTestCase, LoginEnrollmentTestCase):
             ('list_financial_report_downloads', {}),
             ('calculate_grades_csv', {}),
             ('get_students_features', {}),
+            ('calculate_student_responses_csv', {}),
             ('get_enrollment_report', {}),
             ('get_students_who_may_enroll', {}),
             ('get_exec_summary_report', {}),

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -2137,13 +2137,13 @@ def calculate_student_responses_csv(request, course_id):
         instructor_task.api.submit_calculate_student_responses_csv(request, course_key)
         success_status = _(
             "Your student responses report is being generated! "
-            "You can view the status of the generation task in the 'Pending Instructor Tasks' section."
+            "You can view the status of the generation task in the 'Pending Tasks' section."
         )
         return JsonResponse({"status": success_status})
     except AlreadyRunningError:
         already_running_status = _(
             "A student responses report generation task is already in progress. "
-            "Check the 'Pending Instructor Tasks' table for the status of the task. "
+            "Check the 'Pending Tasks' table for the status of the task. "
             "When completed, the report will be available for download in the table below."
         )
         return JsonResponse({

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -2128,6 +2128,32 @@ def problem_grade_report(request, course_id):
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
 @require_level('staff')
+def calculate_student_responses_csv(request, course_id):
+    """
+    AlreadyRunningError is raised if the student response CSV is still being generated.
+    """
+    course_key = SlashSeparatedCourseKey.from_deprecated_string(course_id)
+    try:
+        instructor_task.api.submit_calculate_student_responses_csv(request, course_key)
+        success_status = _(
+            "Your student responses report is being generated! "
+            "You can view the status of the generation task in the 'Pending Instructor Tasks' section."
+        )
+        return JsonResponse({"status": success_status})
+    except AlreadyRunningError:
+        already_running_status = _(
+            "A student responses report generation task is already in progress. "
+            "Check the 'Pending Instructor Tasks' table for the status of the task. "
+            "When completed, the report will be available for download in the table below."
+        )
+        return JsonResponse({
+            "status": already_running_status
+        })
+
+
+@ensure_csrf_cookie
+@cache_control(no_cache=True, no_store=True, must_revalidate=True)
+@require_level('staff')
 @require_query_params('rolename')
 def list_forum_members(request, course_id):
     """

--- a/lms/djangoapps/instructor/views/api_urls.py
+++ b/lms/djangoapps/instructor/views/api_urls.py
@@ -92,6 +92,10 @@ urlpatterns = patterns(
     url(r'^list_financial_report_downloads$',
         'instructor.views.api.list_financial_report_downloads', name="list_financial_report_downloads"),
 
+    # Student responses for questions
+    url(r'^calculate_student_responses_csv$',
+        'instructor.views.api.calculate_student_responses_csv', name="calculate_student_responses_csv"),
+
     # Registration Codes..
     url(r'get_registration_codes$',
         'instructor.views.api.get_registration_codes', name="get_registration_codes"),

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -477,6 +477,10 @@ def _section_data_download(course, access):
         'list_report_downloads_url': reverse('list_report_downloads', kwargs={'course_id': unicode(course_key)}),
         'calculate_grades_csv_url': reverse('calculate_grades_csv', kwargs={'course_id': unicode(course_key)}),
         'problem_grade_report_url': reverse('problem_grade_report', kwargs={'course_id': unicode(course_key)}),
+        'calculate_student_responses_csv_url': reverse(
+            'calculate_student_responses_csv',
+            kwargs={'course_id': unicode(course_key)}
+        ),
     }
     return section_data
 

--- a/lms/djangoapps/instructor_analytics/basic.py
+++ b/lms/djangoapps/instructor_analytics/basic.py
@@ -3,7 +3,9 @@ Student and course analytics.
 
 Serve miscellaneous course and student data
 """
+from itertools import chain
 import json
+import logging
 from shoppingcart.models import (
     PaidCourseRegistration, CouponRedemption, CourseRegCodeItem,
     RegistrationCodeRedemption, CourseRegistrationCodeInvoiceItem
@@ -17,6 +19,9 @@ from django.core.exceptions import ObjectDoesNotExist
 from microsite_configuration import microsite
 from student.models import CourseEnrollmentAllowed
 
+from courseware.models import StudentModule
+
+log = logging.getLogger(__name__)
 
 STUDENT_FEATURES = ('id', 'username', 'first_name', 'last_name', 'is_staff', 'email')
 PROFILE_FEATURES = ('name', 'language', 'location', 'year_of_birth', 'gender',
@@ -399,3 +404,71 @@ def dump_grading_context(course):
     msg += "length=%d\n" % len(gcontext['all_descriptors'])
     msg = '<pre>%s</pre>' % msg.replace('<', '&lt;')
     return msg
+
+
+def iterate_problem_components(course):
+    """
+    Python generator for iterating through all problems of a course.
+    """
+    for section in course.get_children():
+        section_name = section.display_name_with_default
+        for subsection in section.get_children():
+            subsection_name = subsection.display_name_with_default
+            for unit in subsection.get_children():
+                unit_name = unit.display_name_with_default
+
+                parent_metadata = [section_name, subsection_name, unit_name]
+                for component in unit.get_children():
+                    if component.category == 'problem':
+                        yield component, parent_metadata
+
+
+def student_responses(course):
+    """
+    Yields student responses for all problems in course for writing out to a CSV file.
+    """
+    # `order` is for the corresponding "order" column in the CSV for problem
+    # order in the course, so instructors could sort by it.
+    order = 1
+    for problem_component, parent_metadata in iterate_problem_components(course):
+        problem_component_info = (parent_metadata +
+                                  [problem_component.display_name_with_default, order, problem_component.location])
+        modules = StudentModule.objects.filter(
+            course_id=course.id,
+            grade__isnull=False,
+            module_state_key=problem_component.location,
+        ).order_by('student__username')
+        # Check if this particular problem_component has any student responses (i.e. modules with non-null grade)
+        if modules:
+            # Default: we have not retrieved an answer for the current problem
+            has_answer = False
+            for module in modules:
+                try:
+                    state_dict = json.loads(module.state) if module.state else {}
+                    raw_answers = state_dict.get("student_answers", {})
+                except ValueError:
+                    log.error(
+                        "Student responses: Could not parse module state for StudentModule id=%s, course=%s",
+                        module.id,
+                        course.id
+                    )
+                    continue
+
+                pretty_answers = u', '.join(
+                    u"{problem}={answer}".format(problem=problem, answer=answer)
+                    for (problem, answer) in raw_answers.items()
+                )
+                yield problem_component_info + [module.student.username, pretty_answers]
+                if not has_answer:
+                    has_answer = True
+            # Barring no errors up to this point, this problem has yielded at least one response,
+            # so we need to increment the order variable for the next problem.
+            if has_answer:
+                order += 1
+
+
+def student_response_rows(course):
+    """ Wrapper to return all (header and data) rows for student responses reports for a course """
+    header = ["Section", "Subsection", "Unit", "Problem", "Order In Course", "Location", "Student", "Response"]
+    rows = chain([header], student_responses(course))
+    return rows

--- a/lms/djangoapps/instructor_task/api.py
+++ b/lms/djangoapps/instructor_task/api.py
@@ -26,6 +26,7 @@ from instructor_task.tasks import (
     calculate_may_enroll_csv,
     exec_summary_report_csv,
     generate_certificates,
+    calculate_student_responses_csv,
 )
 
 from instructor_task.api_helper import (
@@ -430,6 +431,18 @@ def generate_certificates_for_all_students(request, course_key):   # pylint: dis
     """
     task_type = 'generate_certificates_all_student'
     task_class = generate_certificates
+    task_input = {}
+    task_key = ""
+
+    return submit_task(request, task_type, task_class, course_key, task_input, task_key)
+
+
+def submit_calculate_student_responses_csv(request, course_key):  # pylint: disable=invalid-name
+    """
+    AlreadyRunningError is raised if the student responses report is already being generated.
+    """
+    task_type = 'student_responses'
+    task_class = calculate_student_responses_csv
     task_input = {}
     task_key = ""
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -255,14 +255,14 @@ FEATURES = {
     # when enrollment exceeds this number
     'MAX_ENROLLMENT_INSTR_BUTTONS': 200,
 
-    # Grade calculation started from the new instructor dashboard will write
-    # grades CSV files to S3 and give links for downloads.
+    # Grade calculation and response report requests started from the new instructor dashboard will write
+    # CSV files to S3 and give links for downloads.
     'ENABLE_S3_GRADE_DOWNLOADS': False,
 
     # whether to use password policy enforcement or not
     'ENFORCE_PASSWORD_POLICY': True,
 
-    # Give course staff unrestricted access to grade downloads (if set to False,
+    # Give course staff unrestricted access to grade and student responses downloads (if set to False,
     # only edX superusers can perform the downloads)
     'ALLOW_COURSE_STAFF_GRADE_DOWNLOADS': False,
 

--- a/lms/static/coffee/src/instructor_dashboard/data_download.coffee
+++ b/lms/static/coffee/src/instructor_dashboard/data_download.coffee
@@ -25,6 +25,7 @@ class DataDownload
     @$grade_config_btn = @$section.find("input[name='dump-gradeconf']'")
     @$calculate_grades_csv_btn = @$section.find("input[name='calculate-grades-csv']'")
     @$problem_grade_report_csv_btn = @$section.find("input[name='problem-grade-report']'")
+    @$student_response_report_btn = @$section.find("input[name='student-response-report']'")
 
     # response areas
     @$download                        = @$section.find '.data-download-container'
@@ -129,6 +130,9 @@ class DataDownload
 
     @$problem_grade_report_csv_btn.click (e) =>
       @onClickGradeDownload @$problem_grade_report_csv_btn, gettext("Error generating problem grade report. Please try again.")
+
+    @$student_response_report_btn.click (e) =>
+      @onClickGradeDownload @$student_response_report_btn, gettext("Error generating student responses. Please try again.")
 
   onClickGradeDownload: (button, errorMessage) ->
       # Clear any CSS styling from the request-response areas

--- a/lms/templates/courseware/legacy_instructor_dashboard.html
+++ b/lms/templates/courseware/legacy_instructor_dashboard.html
@@ -427,7 +427,7 @@ function goto( mode)
 
 %if instructor_tasks is not None and len(instructor_tasks) > 0:
     <hr width="100%">
-    <h2>${_("Pending Instructor Tasks")}</h2>
+    <h2>${_("Pending Tasks")}</h2>
     <div id="task-progress-wrapper">
       <table class="stat_table">
         <tr>

--- a/lms/templates/instructor/instructor_dashboard_2/data_download.html
+++ b/lms/templates/instructor/instructor_dashboard_2/data_download.html
@@ -42,11 +42,13 @@
   <div class="data-display-table" id="data-student-profiles-table"></div>
 
   %if settings.FEATURES.get('ALLOW_COURSE_STAFF_GRADE_DOWNLOADS') or section_data['access']['admin']:
-    <p>${_("Click to generate a CSV grade report for all currently enrolled students.")}</p>
+    <p>${_("Use the following buttons to generate various types of CSV reports for all currently enrolled students.")}</p>
 
     <p><input type="button" name="calculate-grades-csv" value="${_("Generate Grade Report")}" data-endpoint="${ section_data['calculate_grades_csv_url'] }"/></p>
 
     <p><input type="button" name="problem-grade-report" value="${_("Generate Problem Grade Report")}" data-endpoint="${ section_data['problem_grade_report_url'] }"/></p>
+
+    <p><input type="button" name="student-response-report" value="${_("Generate Student Responses Report")}" data-endpoint="${ section_data['calculate_student_responses_csv_url'] }"/></p>
   %endif
 
     <div class="request-response msg msg-confirm copy" id="report-request-response"></div>


### PR DESCRIPTION
[OSPR-362](https://openedx.atlassian.net/browse/OSPR-362) - originally contributed by @kluo 

[Doc Review Ticket: DOC-1620](https://openedx.atlassian.net/browse/DOC-1620)

This PR adds an additional report option for instructors in the instructor dashboard, which outputs a CSV with all student responses to problems in the course.

This feature is enabled with the same flags for grade reports, ENABLE_S3_GRADE_DOWNLOADS and ALLOW_COURSE_STAFF_GRADE_DOWNLOADS, so make sure to set these to True to test it.

Go to the Data Download section of the instructor dashboard, and you should see a "Get Student Submissions Report" button next to "Generate Grade Report" in the Reports section. Click it and you should see the green message below, and your report should appear in the list underneath afterwards.

![screen shot 2015-01-26 at 1 20 59 pm](https://cloud.githubusercontent.com/assets/868615/5908660/57790cde-a55e-11e4-84a9-39017d577b42.png)

The report displays one row per problem / student, and does not include students with no submissions. Each row has the metadata for the Section, Subsection, and Unit for the problem, the problem display name, it's order in the course (number that you can sort by), location, student, and response(s). These responses are retrieved from courseware_studentmodule module state. The responses show each problem subquestion and answer, though the subquestion is showed by its id unfortunately, I haven't figured out how to display its human readable form yet.

Say you answered a numerical input problem:
![screen shot 2015-01-27 at 2 43 41 am](https://cloud.githubusercontent.com/assets/868615/5917165/c0a0a35a-a5ce-11e4-934a-62734e4b93f7.png)

You can see the response in the 2nd row of the report:
![screen shot 2015-01-27 at 2 53 31 am](https://cloud.githubusercontent.com/assets/868615/5917267/bfebb4e4-a5cf-11e4-9f15-eaea0815a39d.png)

This PR also includes a management command that can be called like follows if you want to generate it manually:

```
./manage.py lms dump_student_responses edX/DemoX/Demo_Course -o output.csv
```
