### PR TITLE
Explicitly naming task

### DIFF
--- a/openedx/core/djangoapps/content/course_structures/models.py
+++ b/openedx/core/djangoapps/content/course_structures/models.py
@@ -63,7 +63,7 @@ def listen_for_course_publish(sender, course_key, **kwargs):
     update_course_structure.delay(unicode(course_key), countdown=0)
 
 
-@task()
+@task(name=u'openedx.core.djangoapps.content.course_structures.models.update_course_structure')
 def update_course_structure(course_key):
     """
     Regenerates and updates the course structure (in the database) for the specified course.


### PR DESCRIPTION
This should prevent errors due to relative imports. See http://docs.celeryproject.org/en/latest/userguide/tasks.html#automatic-naming-and-relative-imports for additional information.

@ormsbee @dsjen @singingwolfboy 
