### PR TITLE
Correctly point to MAX_LENGTH instead of MIN_LENGTH.

### DIFF
--- a/common/test/acceptance/pages/lms/dashboard.py
+++ b/common/test/acceptance/pages/lms/dashboard.py
@@ -51,6 +51,21 @@ class DashboardPage(PageObject):
 
         return self.q(css='section.info > hgroup > h3 > a').map(_get_course_name).results
 
+    @property
+    def full_name(self):
+        """Return the displayed value for the user's full name"""
+        return self.q(css='li.info--username .data').text[0]
+
+    @property
+    def email(self):
+        """Return the displayed value for the user's email address"""
+        return self.q(css='li.info--email .data').text[0]
+
+    @property
+    def username(self):
+        """Return the displayed value for the user's username"""
+        return self.q(css='h1.user-name').text[0]
+
     def get_enrollment_mode(self, course_name):
         """Get the enrollment mode for a given course on the dashboard.
 

--- a/common/test/acceptance/tests/lms/test_lms.py
+++ b/common/test/acceptance/tests/lms/test_lms.py
@@ -170,6 +170,10 @@ class RegisterFromCombinedPageTest(UniqueCourseTest):
         course_names = self.dashboard_page.wait_for_page().available_courses
         self.assertIn(self.course_info["display_name"], course_names)
 
+        self.assertEqual("Test User", self.dashboard_page.full_name)
+        self.assertEqual(email, self.dashboard_page.email)
+        self.assertEqual(username, self.dashboard_page.username)
+
     def test_register_failure(self):
         # Navigate to the registration page
         self.register_page.visit()

--- a/openedx/core/djangoapps/user_api/api/profile.py
+++ b/openedx/core/djangoapps/user_api/api/profile.py
@@ -14,6 +14,7 @@ from pytz import UTC
 import analytics
 
 from eventtracking import tracker
+from ..accounts import NAME_MIN_LENGTH
 from ..accounts.views import AccountView
 from ..models import User, UserPreference, UserOrgTag
 from ..helpers import intercept_errors
@@ -34,6 +35,10 @@ class ProfileUserNotFound(ProfileRequestError):
 class ProfileInternalError(Exception):
     """ An error occurred in an API call. """
     pass
+
+
+FULL_NAME_MAX_LENGTH = 255
+FULL_NAME_MIN_LENGTH = NAME_MIN_LENGTH
 
 
 @intercept_errors(ProfileInternalError, ignore_errors=[ProfileRequestError])

--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -28,7 +28,6 @@ from ..api import account as account_api, profile as profile_api
 from ..models import UserOrgTag
 from ..tests.factories import UserPreferenceFactory
 from ..tests.test_constants import SORTED_COUNTRIES
-from openedx.core.djangoapps.user_api.accounts import NAME_MIN_LENGTH
 
 
 TEST_API_KEY = "test_api_key"
@@ -842,7 +841,7 @@ class RegistrationViewTest(ApiTestCase):
                 u"label": u"Full name",
                 u"instructions": u"The name that will appear on your certificates",
                 u"restrictions": {
-                    "max_length": NAME_MIN_LENGTH,
+                    "max_length": profile_api.FULL_NAME_MAX_LENGTH,
                 },
             }
         )
@@ -922,7 +921,7 @@ class RegistrationViewTest(ApiTestCase):
                     u"label": u"Full name",
                     u"instructions": u"The name that will appear on your certificates",
                     u"restrictions": {
-                        "max_length": NAME_MIN_LENGTH
+                        "max_length": profile_api.FULL_NAME_MAX_LENGTH,
                     }
                 }
             )

--- a/openedx/core/djangoapps/user_api/views.py
+++ b/openedx/core/djangoapps/user_api/views.py
@@ -33,8 +33,6 @@ from .helpers import FormDescription, shim_student_view, require_post_params
 from .models import UserPreference, UserProfile
 from .serializers import UserSerializer, UserPreferenceSerializer
 
-from openedx.core.djangoapps.user_api.accounts import NAME_MIN_LENGTH
-
 
 class LoginSessionView(APIView):
     """HTTP end-points for logging in users. """
@@ -352,7 +350,7 @@ class RegistrationView(APIView):
             label=name_label,
             instructions=name_instructions,
             restrictions={
-                "max_length": NAME_MIN_LENGTH,
+                "max_length": profile_api.FULL_NAME_MAX_LENGTH,
             },
             required=required
         )


### PR DESCRIPTION
Bug introduced in recent commit (#7123).

Fixes https://openedx.atlassian.net/browse/ECOM-1159.
