### PR TITLE
(WIP) Updated django-countries to v3.2 to get the latest translations

### DIFF
--- a/lms/templates/register-shib.html
+++ b/lms/templates/register-shib.html
@@ -7,7 +7,6 @@
 
 <%! from django.core.urlresolvers import reverse %>
 <%! from django.utils import html %>
-<%! from django_countries import countries %>
 <%! from student.models import UserProfile %>
 <%! from datetime import date %>
 <%! import calendar %>

--- a/lms/templates/register.html
+++ b/lms/templates/register.html
@@ -256,7 +256,7 @@
               <label for="country">${_("Country")}</label>
               <select id="country" name="country" ${'required aria-required="true"' if settings.REGISTRATION_EXTRA_FIELDS['country'] == 'required' else ''}>
                 <option value="">--</option>
-                %for code, country_name in sorted(countries.countries, key=lambda (__, name): unicode(name)):
+                %for code, country_name in sorted(countries, key=lambda (__, name): unicode(name)):
                 <option value="${code}">${ unicode(country_name) }</option>
                 %endfor
               </select>

--- a/lms/templates/signup_modal.html
+++ b/lms/templates/signup_modal.html
@@ -3,7 +3,6 @@
 <%namespace name='static' file='static_content.html'/>
 <%! from django.conf import settings %>
 <%! from django.core.urlresolvers import reverse %>
-<%! from django_countries import countries %>
 <%! from student.models import UserProfile %>
 <%! from datetime import date %>
 <%! import calendar %>

--- a/openedx/core/djangoapps/user_api/views.py
+++ b/openedx/core/djangoapps/user_api/views.py
@@ -562,7 +562,7 @@ class RegistrationView(APIView):
         country_label = _(u"Country")
 
         sorted_countries = sorted(
-            countries.countries, key=lambda(__, name): unicode(name)
+            countries, key=lambda(__, name): unicode(name)
         )
         options = [
             (country_code, unicode(country_name))

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -16,7 +16,7 @@ defusedxml==0.4.1
 distribute>=0.6.28, <0.7
 django-babel-underscore==0.1.0
 django-celery==3.0.17
-django-countries==2.1.2
+django-countries==3.2
 django-extensions==1.2.5
 django-filter==0.6.0
 django-followit==0.0.3


### PR DESCRIPTION
Django countries v2.1.2 is not translated to Arabic (among other languages). This PR updates the version to v3.2 to get update [`ar/django.po`](https://github.com/SmileyChris/django-countries/compare/v2.1.2...v3.2#diff-f1752812475eb09deb49f2c049aa8129).

I'm waiting for this issue https://github.com/SmileyChris/django-countries/issues/99 to get resolved before marking this as good to merge.
