### PR TITLE
Certificate status when XQueue is unavailable.

### DIFF
--- a/lms/djangoapps/certificates/api.py
+++ b/lms/djangoapps/certificates/api.py
@@ -22,6 +22,10 @@ def generate_user_certificates(student, course_key, course=None):
     """
     It will add the add-cert request into the xqueue.
 
+    A new record will be created to track the certificate
+    generation task.  If an error occurs while adding the certificate
+    to the queue, the task will have status 'error'.
+
     Args:
         student (User)
         course_key (CourseKey)
@@ -29,24 +33,9 @@ def generate_user_certificates(student, course_key, course=None):
     Keyword Arguments:
         course (Course): Optionally provide the course object; if not provided
             it will be loaded.
-
-    Returns:
-        returns status of generated certificate
-
     """
     xqueue = XQueueCertInterface()
-    ret = xqueue.add_cert(student, course_key, course=course)
-    log.info(
-        (
-            u"Added a certificate generation task to the XQueue "
-            u"for student %s in course '%s'. "
-            u"The new certificate status is '%s'."
-        ),
-        student.id,
-        unicode(course_key),
-        ret
-    )
-    return ret
+    xqueue.add_cert(student, course_key, course=course)
 
 
 def certificate_downloadable_status(student, course_key):
@@ -162,8 +151,6 @@ def generate_example_certificates(course_key):
     xqueue = XQueueCertInterface()
     for cert in ExampleCertificateSet.create_example_set(course_key):
         xqueue.add_example_cert(cert)
-
-    log.info(u"Started generated example certificates for course '%s'.", course_key)
 
 
 def example_certificates_status(course_key):

--- a/lms/djangoapps/certificates/queue.py
+++ b/lms/djangoapps/certificates/queue.py
@@ -333,17 +333,32 @@ class XQueueCertInterface(object):
                     new_status = status.generating
                     cert.status = new_status
                     cert.save()
-                    self._send_to_xqueue(contents, key)
 
-                    LOGGER.info(
-                        (
-                            u"The certificate status has been set to '%s'.  "
-                            u"Sent a certificate grading task to the XQueue "
-                            u"with the key '%s'. "
-                        ),
-                        key,
-                        new_status
-                    )
+                    try:
+                        self._send_to_xqueue(contents, key)
+                    except XQueueAddToQueueError as exc:
+                        new_status = ExampleCertificate.STATUS_ERROR
+                        cert.status = new_status
+                        cert.error_reason = unicode(exc)
+                        cert.save()
+                        LOGGER.critical(
+                            (
+                                u"Could not add certificate task to XQueue.  "
+                                u"The course was '%s' and the student was '%s'."
+                                u"The certificate task status has been marked as 'error' "
+                                u"and can be re-submitted with a management command."
+                            ), student.id, course_id
+                        )
+                    else:
+                        LOGGER.info(
+                            (
+                                u"The certificate status has been set to '%s'.  "
+                                u"Sent a certificate grading task to the XQueue "
+                                u"with the key '%s'. "
+                            ),
+                            key,
+                            new_status
+                        )
             else:
                 new_status = status.notpassing
                 cert.status = new_status
@@ -410,10 +425,18 @@ class XQueueCertInterface(object):
                 task_identifier=example_cert.uuid,
                 callback_url_path=callback_url_path
             )
+            LOGGER.info(u"Started generating example certificates for course '%s'.", example_cert.course_key)
         except XQueueAddToQueueError as exc:
             example_cert.update_status(
                 ExampleCertificate.STATUS_ERROR,
                 error_reason=unicode(exc)
+            )
+            LOGGER.critical(
+                (
+                    u"Could not add example certificate with uuid '%s' to XQueue.  "
+                    u"The exception was %s.  "
+                    u"The example certificate has been marked with status 'error'."
+                ), example_cert.uuid, unicode(exc)
             )
 
     def _send_to_xqueue(self, contents, key, task_identifier=None, callback_url_path='update_certificate'):


### PR DESCRIPTION
If certificates cannot be added to the queue, mark the certificate status as 'error' so that it can be re-run by management commands.

Clean up logging and return values.

Part of [ECOM-1132](https://openedx.atlassian.net/browse/ECOM-1132)

@dianakhuang please review
