### PR TITLE
Disable test that's too flaky for our flaky policy.

### DIFF
--- a/common/test/acceptance/tests/studio/test_studio_settings_details.py
+++ b/common/test/acceptance/tests/studio/test_studio_settings_details.py
@@ -14,7 +14,6 @@ from ..helpers import (
     is_option_value_selected,
     element_has_text,
 )
-from flaky import flaky
 
 
 class SettingsMilestonesTest(StudioCourseTest):
@@ -41,7 +40,7 @@ class SettingsMilestonesTest(StudioCourseTest):
 
         self.assertTrue(self.settings_detail.pre_requisite_course_options)
 
-    @flaky  # TODO fix this, see SOL-449
+    @skip("Flaky test. See SOL-449")
     def test_prerequisite_course_save_successfully(self):
         """
          Scenario: Selecting course from Pre-Requisite course drop down save the selected course as pre-requisite


### PR DESCRIPTION
@jzoldak @clytwynec 

fyi @andy-armstrong @ziafazal 

Even though this was flagged as flaky, it ran and failed twice in a row on our master branch. So, disabling it entirely.
