### PR TITLE
WIP: XCOM-118: Create new purchase endpoint to access e-commerce service.

### DIFF
--- a/lms/djangoapps/shoppingcart/urls.py
+++ b/lms/djangoapps/shoppingcart/urls.py
@@ -1,5 +1,6 @@
 from django.conf.urls import patterns, url
 from django.conf import settings
+from shoppingcart.views import PurchaseView
 
 urlpatterns = patterns(
     'shoppingcart.views',
@@ -19,6 +20,7 @@ urlpatterns = patterns(
     url(r'^reset_code_redemption/$', 'reset_code_redemption'),
     url(r'^billing_details/$', 'billing_details', name='billing_details'),
     url(r'^verify_cart/$', 'verify_cart'),
+    url(r'^purchase', PurchaseView.as_view(), name='purchase'),
 )
 
 if settings.FEATURES.get('ENABLE_PAYMENT_FAKE'):

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2024,6 +2024,9 @@ API_DATE_FORMAT = '%Y-%m-%d'
 # Enrollment API Cache Timeout
 ENROLLMENT_COURSE_DETAILS_CACHE_TIMEOUT = 60
 
+# The E-Commerce Purchase Endpoint
+PURCHASE_API_URL = "http://localhost:8002/purchase"
+
 # for Student Notes we would like to avoid too frequent token refreshes (default is 30 seconds)
 if FEATURES['ENABLE_EDXNOTES']:
     OAUTH_ID_TOKEN_EXPIRATION = 60 * 60


### PR DESCRIPTION
Related to the following task: https://openedx.atlassian.net/browse/XCOM-118

This new endpoint is designed to use the new E-Commerce Service purchase endpoint when a SKU is defined for a course mode. If no SKU is defined, it will default to use the Enrollment API.

This is intended to replace the Enrollment API endpoint for general use, allowing the creation of an Order along with an Enrollment. 

When able, please take a look: @dianakhuang @rlucioni @wedaly 
