### PR TITLE
Fix 500 errors on video upload page

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_videos.py
+++ b/cms/djangoapps/contentstore/views/tests/test_videos.py
@@ -97,6 +97,20 @@ class VideoUploadTestMixin(object):
                 ]
             },
         ]
+        # Ensure every status string is tested
+        self.previous_uploads += [
+            {
+                "edx_video_id": "status_test_{}".format(status),
+                "client_video_id": "status_test.mp4",
+                "duration": 3.14,
+                "status": status,
+                "encoded_videos": [],
+            }
+            for status in (
+                StatusDisplayStrings._STATUS_MAP.keys() +  # pylint:disable=protected-access
+                ["non_existent_status"]
+            )
+        ]
         for profile in self.profiles:
             create_profile(profile)
         for video in self.previous_uploads:

--- a/cms/djangoapps/contentstore/views/videos.py
+++ b/cms/djangoapps/contentstore/views/videos.py
@@ -48,10 +48,10 @@ class StatusDisplayStrings(object):
     # Translators: This is the status for a video that the servers have successfully processed
     _COMPLETE = ugettext_noop("Complete")
     # Translators: This is the status for a video that the servers have failed to process
-    _FAILED = ugettext_noop("Failed"),
+    _FAILED = ugettext_noop("Failed")
     # Translators: This is the status for a video for which an invalid
     # processing token was provided in the course settings
-    _INVALID_TOKEN = ugettext_noop("Invalid Token"),
+    _INVALID_TOKEN = ugettext_noop("Invalid Token")
     # Translators: This is the status for a video that is in an unknown state
     _UNKNOWN = ugettext_noop("Unknown")
 


### PR DESCRIPTION
Some status strings were accidentally tuples thanks to stray commas, and
ugettext raised an exception as a result.

@nasthagiri @BenjiLee Please review
@singingwolfboy FYI
