### PR TITLE
fixed broken link to edx-documentation repo

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -22,7 +22,7 @@ By moving documentation to its own repository, we will be better able to
 develop workflows, manage versioning, create translations, and automate
 testing, without complicating ongoing development of the edX Platform.
 
-.. _edx_documentation: https://github.com/edx/edx-documentation
+.. _edx-documentation: https://github.com/edx/edx-documentation
 
 ******************************
 View Published Documentation


### PR DESCRIPTION
This fixes the target link to edx-documentation repo, as rendered from README.rst.
The .rst source had an incorrect hyperlink target that used an underscore rather than a dash.

a wonderful 1 char diff!
