### PR TITLE
Fix callback URL for certificate generation tasks

### DIFF
--- a/lms/djangoapps/certificates/queue.py
+++ b/lms/djangoapps/certificates/queue.py
@@ -416,7 +416,7 @@ class XQueueCertInterface(object):
                 error_reason=unicode(exc)
             )
 
-    def _send_to_xqueue(self, contents, key, task_identifier=None, callback_url_path='update_certificate'):
+    def _send_to_xqueue(self, contents, key, task_identifier=None, callback_url_path='/update_certificate'):
         """Create a new task on the XQueue.
 
         Arguments:


### PR DESCRIPTION
Fix for [ECOM-1169](https://openedx.atlassian.net/browse/ECOM-1169).  The callback URL for certificate generation was missing the forward slash in the URL path, which caused student certificate tasks to remain in the "generating" state even after certificate generation completed successfully.

@rlucioni @feanil please review
