### PR TITLE
Add empty introspection rule for BlockTypeKeyField.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -199,3 +199,4 @@ Mat Moore <mat@mooresoftware.co.uk>
 Muzaffar Yousaf <muzaffar@edx.org>
 Sylvain <sylvain@openfun.fr>
 Mayank Jain <mjmayank@gmail.com>
+Carlos de la Guardia <cguardia@yahoo.com>

--- a/common/djangoapps/xmodule_django/models.py
+++ b/common/djangoapps/xmodule_django/models.py
@@ -179,3 +179,4 @@ class BlockTypeKeyField(OpaqueKeyField):
 add_introspection_rules([], [r"^xmodule_django\.models\.CourseKeyField"])
 add_introspection_rules([], [r"^xmodule_django\.models\.LocationKeyField"])
 add_introspection_rules([], [r"^xmodule_django\.models\.UsageKeyField"])
+add_introspection_rules([], [r"^xmodule_django\.models\.BlockTypeKeyField"])


### PR DESCRIPTION
From 0.7 on, South requires explicit introspection rules. schemamigration --auto won't work without this change.
