### PR TITLE
Openfun/editable user info

### DIFF
--- a/common/djangoapps/student/forms.py
+++ b/common/djangoapps/student/forms.py
@@ -20,6 +20,8 @@ from util.password_policy_validators import (
     validate_password_dictionary,
 )
 
+from .models import UserProfile
+
 
 class PasswordResetFormNoActive(PasswordResetForm):
     def clean_email(self):
@@ -234,3 +236,41 @@ class AccountCreationForm(forms.Form):
             for key, value in self.cleaned_data.items()
             if key in self.extended_profile_fields and value is not None
         }
+
+
+class EditUserInformationForm(forms.ModelForm):
+
+    class Meta:
+        model = UserProfile
+        fields = ('city', 'country', 'level_of_education', 'gender', 'year_of_birth', 'mailing_address', 'goals',)
+
+    def clean_city(self):
+        return self.clean_field('city')
+
+    def clean_country(self):
+        return self.clean_field('country')
+
+    def clean_level_of_education(self):
+        return self.clean_field('level_of_education')
+
+    def clean_gender(self):
+        return self.clean_field('gender')
+
+    def clean_year_of_birth(self):
+        return self.clean_field('year_of_birth')
+
+    def clean_mailing_address(self):
+        return self.clean_field('mailing_address')
+
+    def clean_goals(self):
+        return self.clean_field('goals')
+
+    def clean_field(self, field):
+        if field in self.data and settings.REGISTRATION_EXTRA_FIELDS[field] == 'hidden':
+            raise forms.ValidationError(_("This field is not editable"))
+        if field not in self.data:
+            # Data was not submitted
+            self.cleaned_data[field] = getattr(self.instance, field)
+        if settings.REGISTRATION_EXTRA_FIELDS[field] == 'required' and not self.cleaned_data[field]:
+            raise forms.ValidationError(_("This field is required"))
+        return self.cleaned_data[field]

--- a/common/djangoapps/student/tests/test_edit_user_information.py
+++ b/common/djangoapps/student/tests/test_edit_user_information.py
@@ -1,0 +1,98 @@
+"""
+Unit tests for edit_user_profile view of student.
+"""
+
+import json
+import unittest
+from mock import patch
+
+from django.conf import settings
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+from django.utils.translation import ugettext as _
+
+from student.tests.factories import UserFactory, UserProfileFactory
+from student.models import UserProfile
+
+
+class lms_patch_dict(object):
+    """
+    Tiny utility to patch dict settings only when we are running the lms tests.
+    This is necessary because e.g: the REGISTRATION_EXTRA_FIELDS does not exist
+    in cms settings. Overriding settings does not work, as it does not modify
+    the currently imported settings object. If you wish to try an alternate
+    solution, try to run this test case with both the lms and cms service.
+    """
+
+    def __init__(self, setting, in_dict):
+        self.setting = setting
+        self.in_dict = in_dict
+
+    def __call__(self, func):
+        if settings.ROOT_URLCONF == 'lms.urls':
+            return patch.dict(getattr(settings, self.setting), self.in_dict)(func)
+        else:
+            return func
+
+
+@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+class TestEditUserInformation(TestCase):
+
+    def setUp(self):
+        self.student = UserFactory.create(
+            first_name='john',
+            last_name='doe',
+            password='test',
+        )
+        self.student.profile = UserProfileFactory.create(
+            user=self.student,
+        )
+        self.client.login(username=self.student.username, password='test')
+
+    def set_field(self, field, value):
+        setattr(self.student.profile, field, value)
+        self.student.profile.save()
+
+    def post(self, **data):
+        url = reverse('edit_user_information')
+        return self.client.post(url, data=data)
+
+    @lms_patch_dict("REGISTRATION_EXTRA_FIELDS", {'city': 'optional'})
+    def test_dont_change_anything(self):
+        self.set_field("city", "Smallville")
+        response = self.post()
+
+        self.assertEqual(200, response.status_code)
+        self.assertTrue(json.loads(response.content)["success"])
+        self.assertEqual('Smallville', UserProfile.objects.get(user=self.student).city)
+
+    @lms_patch_dict("REGISTRATION_EXTRA_FIELDS", {'city': 'optional'})
+    def test_change_optional_field(self):
+        self.set_field("city", "Smallville")
+        self.post(city='Madranque')
+        self.assertEqual('Madranque', UserProfile.objects.get(user=self.student).city)
+
+    @lms_patch_dict("REGISTRATION_EXTRA_FIELDS", {'city': 'hidden'})
+    def test_hidden_field_is_skipped(self):
+        self.set_field("city", "Smallville")
+        response = self.post(city='Madranque')
+        response_result = json.loads(response.content)
+
+        self.assertFalse(response_result["success"])
+        self.assertIn("errors", response_result)
+        self.assertIn(_("City"), response_result["errors"])
+        self.assertEqual(1, len(response_result["errors"][_("City")]))
+        self.assertEqual(_("This field is not editable"), response_result["errors"][_("City")][0])
+        self.assertEqual("Smallville", UserProfile.objects.get(user=self.student).city)
+
+    @lms_patch_dict("REGISTRATION_EXTRA_FIELDS", {'country': 'required'})
+    def test_required_field_must_be_set(self):
+        self.set_field('country', None)
+        response = self.post()
+        response_result = json.loads(response.content)
+        self.assertEqual(1, len(response_result["errors"][_('Country')]))
+
+    def test_logged_out_user_has_no_access(self):
+        self.client.logout()
+        response = self.post()
+        self.assertEqual(302, response.status_code)

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -3,7 +3,6 @@ Student Views
 """
 import datetime
 import logging
-import re
 import uuid
 import time
 import json
@@ -46,7 +45,6 @@ from social.apps.django_app import utils as social_utils
 from social.backends import oauth as social_oauth
 
 from edxmako.shortcuts import render_to_response, render_to_string
-from mako.exceptions import TopLevelLookupException
 
 from course_modes.models import CourseMode
 from shoppingcart.api import order_history
@@ -56,7 +54,7 @@ from student.models import (
     CourseEnrollmentAllowed, UserStanding, LoginFailures,
     create_comments_service_user, PasswordHistory, UserSignupSource,
     DashboardConfiguration, LinkedInAddToProfileConfiguration)
-from student.forms import AccountCreationForm, PasswordResetFormNoActive
+from student.forms import AccountCreationForm, PasswordResetFormNoActive, EditUserInformationForm
 
 from verify_student.models import SoftwareSecurePhotoVerification, MidcourseReverificationWindow
 from certificates.models import CertificateStatuses, certificate_status_for_student
@@ -1761,6 +1759,21 @@ def activate_account(request, key):
             {'csrf': csrf(request)['csrf_token']}
         )
     return HttpResponse(_("Unknown error. Please e-mail us to let us know how it happened."))
+
+
+@require_POST
+@login_required
+def edit_user_information(request):
+    form = EditUserInformationForm(request.POST, instance=request.user.profile)
+    if form.is_valid():
+        form.save()
+    errors = {
+        field.label: field.errors for field in form if len(field.errors) > 0
+    }
+    return JsonResponse({
+        'success': (len(errors) == 0),
+        'errors': errors
+    })
 
 
 @csrf_exempt

--- a/lms/static/js/dashboard/legacy.js
+++ b/lms/static/js/dashboard/legacy.js
@@ -216,6 +216,35 @@
             return false;
         });
 
+        $("#edit_user_information_form").submit(function(){
+            $.ajax({
+                type: "POST",
+                url: urls.editUserInformation,
+                data: $(this).serializeArray(),
+                success: function(data) {
+                    if(data.success) {
+                        location.reload();
+                    }
+                    else {
+                        $("#edit_user_information_errors").html("");
+                        for(var field in data.errors) {
+                            var errors = data.errors[field];
+                            for(var e = 0; e < errors.length; e += 1) {
+                                $("#edit_user_information_errors").append("<li>" + field + " - " + errors[e] + "</li>");
+                            }
+                        }
+                        $("#edit_user_information_error").css("display", "block");
+                    }
+                },
+                error: function(xhr) {
+                    if (xhr.status === 403) {
+                        location.href = urls.signInUser;
+                    }
+                }
+            });
+            return false;
+        });
+
         accessibleModal(
             ".edit-name",
             "#apply_name_change .close-modal",

--- a/lms/static/sass/shared/_modal.scss
+++ b/lms/static/sass/shared/_modal.scss
@@ -225,6 +225,12 @@
         }
       }
 
+      .field-large {
+        select {
+          width: 100%;
+        }
+      }
+
       .citizenship, .gender {
         margin-right: flex-gutter();
       }

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -7,6 +7,7 @@
 <%!
   from django.core.urlresolvers import reverse
 %>
+<%! from django_countries import countries %>
 
 <%
   cert_name_short = settings.CERT_NAME_SHORT
@@ -40,6 +41,7 @@
         changeEmail: "${reverse('change_email')}",
         changeEmailSettings: "${reverse('change_email_settings')}",
         changeName: "${reverse('change_name')}",
+        editUserInformation: "${reverse('edit_user_information')}",
         verifyToggleBannerFailedOff: "${reverse('verify_student_toggle_failed_banner_off')}",
       });
     });
@@ -164,6 +166,10 @@
           </form>
         </li>
         % endif
+
+        <li class="controls--account">
+            <span class="title"><a href="#edit_user_information" rel="leanModal">${_("Edit Profile")}</a></span>
+        </li>
 
         <%include file='dashboard/_dashboard_status_verification.html' />
 
@@ -373,6 +379,98 @@
           </div>
       </form>
     </div>
+  </div>
+</section>
+
+<section id="edit_user_information" class="modal edit-user-information-modal" aria-hidden="true">
+  <div class="inner-wrapper" role="dialog" aria-labelledby="edit-user-information-modal-title">
+    <button class="close-modal">
+      <i class="icon fa fa-remove"></i>
+      <span class="sr">
+        ## Translators: this is a control to allow users to exit out of this modal interface (a menu or piece of UI that takes the full focus of the screen)
+        ${_("Close")}
+      </span>
+    </button>
+
+    <header>
+      <h2>${_("Change My Profile Information")}</h2>
+    </header>
+
+      <form id="edit_user_information_form">
+        <div id="edit_user_information_error" class="modal-form-error">
+            <ul id="edit_user_information_errors"></ul>
+        </div>
+        <fieldset>
+          <div class="input-group">
+            <%def name="selected_value(value, expected)">${"selected='selected'" if value == expected else ""}</%def>
+            <%def name="required_field(field)">${'required aria-required="true"' if settings.REGISTRATION_EXTRA_FIELDS[field] == 'required' else ''}</%def>
+            <%!
+                from django.conf import settings
+                def should_display(field):
+                    return settings.REGISTRATION_EXTRA_FIELDS['city'] != 'hidden'
+            %>
+            % if should_display('city'):
+            <label for="city">${_('City')}</label>
+            <input  type="text" name="city" value="${user.profile.city}" placeholder="${_('example: New York')}" aria-describedby="city-tip" ${required_field('city')} />
+            % endif
+            % if should_display('country'):
+            <div class="field-large">
+              <label for="country">${_("Country")}</label>
+              <select name="country" ${required_field('country')}>
+                <option value="" ${selected_value(user.profile.country, None)}>--</option>
+                %for code, country_name in sorted(countries.countries, key=lambda (__, name): unicode(name)):
+                <option value="${code}" ${selected_value(user.profile.country, code)}>${ unicode(country_name) }</option>
+                %endfor
+              </select>
+            </div>
+            % endif
+            % if should_display('level_of_education'):
+            <div class="field-large">
+              <label for="education-level">${_("Highest Level of Education Completed")}</label>
+              <select name="level_of_education" ${required_field('level_of_education')}>
+                <option value="" ${selected_value(user.profile.level_of_education, None)}>--</option>
+                %for code, ed_level in user.profile.LEVEL_OF_EDUCATION_CHOICES:
+                <option value="${code}" ${selected_value(user.profile.level_of_education, code)}>${_(ed_level)}</option>
+                %endfor
+              </select>
+            </div>
+            % endif
+            % if should_display('gender'):
+            <div class="field-large">
+              <label for="gender">${_("Gender")}</label>
+              <select name="gender" ${required_field('gender')}>
+                <option value="" ${selected_value(user.profile.gender, None)}>--</option>
+                %for code, gender in user.profile.GENDER_CHOICES:
+                <option value="${code}" ${selected_value(user.profile.gender, gender)}>${_(gender)}</option>
+                %endfor
+              </select>
+            </div>
+            % endif
+            % if should_display('year_of_birth'):
+            <div class="field-large">
+              <label for="yob">${_("Year of Birth")}</label>
+              <select id="yob" name="year_of_birth" ${required_field('year_of_birth')}>
+                <option value="" ${selected_value(user.profile.year_of_birth, None)}>--</option>
+                %for year in user.profile.VALID_YEARS:
+                <option value="${year}" ${selected_value(user.profile.year_of_birth, year)}>${year}</option>
+                %endfor
+              </select>
+            </div>
+            % endif
+            % if should_display('mailing_address'):
+            <label for="address-mailing">${_("Mailing Address")}</label>
+            <textarea id="address-mailing" name="mailing_address" value="${user.profile.mailing_address}" ${required_field('mailing_address')}></textarea>
+            % endif
+            % if should_display('goals'):
+            <label for="goals">${_("Please share with us your reasons for registering with {platform_name}").format(platform_name=platform_name)}</label>
+            <textarea id="goals" name="goals" value="${user.profile.goals}" ${required_field('goals')}></textarea>
+            % endif
+          </div>
+          <div class="submit">
+            <input type="submit" id="submit" value="${_("Change My Profile Information")}">
+          </div>
+        </fieldset>
+      </form>
   </div>
 </section>
 

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -43,6 +43,8 @@ urlpatterns = (
     url(r'^create_account$', 'student.views.create_account', name='create_account'),
     url(r'^activate/(?P<key>[^/]*)$', 'student.views.activate_account', name="activate"),
 
+    url(r'^edit_user_information/$', 'student.views.edit_user_information', name='edit_user_information'),
+
     url(r'^password_reset/$', 'student.views.password_reset', name='password_reset'),
     ## Obsolete Django views for password resets
     ## TODO: Replace with Mako-ized views


### PR DESCRIPTION
**Context**: User input certain informations at signup time, such as gender, country, city, etc. This fields may be hidden, required, or optional, depending on some settings.  Users might want to update some of their profile informations after signing up. In France, for instance, websites that collect personal user information have an obligation to modify or delete it if the user demands it.

**Proposed solution**: this PR proposes to add a "Edit Profile" link to the user dashboard. Upon clicking this link, the user is presented with a modal form that includes modifiable field forms.

**Problems**: in the current state, there are certain issues that this PR does not address:
1. Do we actually want to allow students to modify their personal information?
2. How do we handle translations for newly inserted strings? (I'm not familiar with the translation process. I can just offer French translations.)
3. How do we handle users that have signed up with a third-party account (e.g: Google+, Facebook)?

I hope that I can collect answers to these questions in this PR.
