### PR TITLE
return proper 404 for assets of some invalid course from split modulesto...

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -888,6 +888,12 @@ class MiscCourseTests(ContentStoreTestCase):
         resp = self.client.get_html('/c4x/CDX/123123/asset/invalid.png')
         self.assertEqual(resp.status_code, 404)
 
+        # Now test that 404 response is returned when user tries to access
+        # asset of some invalid course from split ModuleStore
+        with self.store.default_store(ModuleStoreEnum.Type.split):
+            resp = self.client.get_html('/c4x/InvalidOrg/InvalidCourse/asset/invalid.png')
+            self.assertEqual(resp.status_code, 404)
+
     def test_delete_course(self):
         """
         This test creates a course, makes a draft item, and deletes the course. This will also assert that the

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
@@ -2474,7 +2474,15 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
         """
         Split specific lookup
         """
-        return self._lookup_course(course_key).structure.get('assets', {})
+        try:
+            course_assets = self._lookup_course(course_key).structure.get('assets', {})
+        except (InsufficientSpecificationError, VersionConflictError) as err:
+            log.warning(u'Error finding assets for org "%s" course "%s" on asset '
+                        u'request. Either version of course_key is None or invalid.',
+                        course_key.org, course_key.course)
+            return {}
+
+        return course_assets
 
     def _update_course_assets(self, user_id, asset_key, update_function):
         """


### PR DESCRIPTION
...re

PLAT-456
1. Catch exceptions ['InsufficientSpecificationError', 'VersionConflictError'] raised from '_lookup_course' method for split modulestore and return empty dict so that user gets proper 404 instead of when tries to access asset of some invalid course.
2. Add test
