### PR TITLE
MA-272 Updated analytics shim for mobile video events

### DIFF
--- a/common/djangoapps/track/shim.py
+++ b/common/djangoapps/track/shim.py
@@ -76,6 +76,8 @@ NAME_TO_EVENT_TYPE_MAP = {
     'edx.video.paused': 'pause_video',
     'edx.video.stopped': 'stop_video',
     'edx.video.loaded': 'load_video',
+    'edx.video.position.changed': 'seek_video',
+    'edx.video.seeked': 'seek_video',
     'edx.video.transcript.shown': 'show_transcript',
     'edx.video.transcript.hidden': 'hide_transcript',
 }
@@ -101,11 +103,14 @@ class VideoEventProcessor(object):
         if name not in NAME_TO_EVENT_TYPE_MAP:
             return
 
+        # Convert edx.video.seeked to edx.video.positiion.changed
+        if name == "edx.video.seeked":
+            event['name'] = "edx.video.position.changed"
+
         event['event_type'] = NAME_TO_EVENT_TYPE_MAP[name]
 
         if 'event' not in event:
             return
-
         payload = event['event']
 
         if 'module_id' in payload:
@@ -122,13 +127,38 @@ class VideoEventProcessor(object):
         if 'current_time' in payload:
             payload['currentTime'] = payload.pop('current_time')
 
+        if 'context' in event:
+            context = event['context']
+
+            # Converts seek_type to seek and skip|slide to onSlideSeek|onSkipSeek
+            if 'seek_type' in payload:
+                seek_type = payload['seek_type']
+                if seek_type == 'slide':
+                    payload['type'] = "onSlideSeek"
+                elif seek_type == 'skip':
+                    payload['type'] = "onSkipSeek"
+                del payload['seek_type']
+
+            # For the iOS build that is returning a +30 for back skip 30
+            if (
+                context['application']['version'] == "1.0.02" and
+                context['application']['name'] == "edx.mobileapp.iOS"
+            ):
+                if 'requested_skip_interval' in payload and 'type' in payload:
+                    if (
+                        payload['requested_skip_interval'] == 30 and
+                        payload['type'] == "onSkipSeek"
+                    ):
+                        payload['requested_skip_interval'] = -30
+
+            # For the Android build that isn't distinguishing between skip/seek
+            if 'requested_skip_interval' in payload:
+                if abs(payload['requested_skip_interval']) != 30:
+                    if 'type' in payload:
+                        payload['type'] = 'onSlideSeek'
+
+            if 'open_in_browser_url' in context:
+                page, _sep, _tail = context.pop('open_in_browser_url').rpartition('/')
+                event['page'] = page
+
         event['event'] = json.dumps(payload)
-
-        if 'context' not in event:
-            return
-
-        context = event['context']
-
-        if 'open_in_browser_url' in context:
-            page, _sep, _tail = context.pop('open_in_browser_url').rpartition('/')
-            event['page'] = page


### PR DESCRIPTION
Shim has been updated to handle currents builds of the android and iOS
apps which are not returning the correct semantics/events. Shim now
includes the seek event.
https://github.com/edx/edx-platform/pull/7112
