### PR TITLE
don't write to the DB when instantiating CapaModule (CSM-14)

### DIFF
--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -171,7 +171,7 @@ class CapaFields(object):
     input_state = Dict(help=_("Dictionary for maintaining the state of inputtypes"), scope=Scope.user_state)
     student_answers = Dict(help=_("Dictionary with the current student responses"), scope=Scope.user_state)
     done = Boolean(help=_("Whether the student has answered the problem"), scope=Scope.user_state)
-    seed = Integer(help=_("Random seed for this student"), scope=Scope.user_state)
+    seed = Integer(help=_("Random seed for this student"), scope=Scope.user_state, default=1)
     last_submission_time = Date(help=_("Last submission time"), scope=Scope.user_state)
     submission_wait_seconds = Integer(
         display_name=_("Timer Between Attempts"),
@@ -227,7 +227,8 @@ class CapaMixin(CapaFields):
         else:
             self.close_date = due_date
 
-        if self.seed is None:
+        # only choose new seed if the problem should be randomized
+        if self.rerandomize != RANDOMIZATION.NEVER:
             self.choose_new_seed()
 
         # Need the problem location in openendedresponse to send out.  Adding
@@ -288,9 +289,7 @@ class CapaMixin(CapaFields):
         """
         Choose a new seed.
         """
-        if self.rerandomize == RANDOMIZATION.NEVER:
-            self.seed = 1
-        elif self.rerandomize == RANDOMIZATION.PER_STUDENT and hasattr(self.runtime, 'seed'):
+        if self.rerandomize == RANDOMIZATION.PER_STUDENT and hasattr(self.runtime, 'seed'):
             # see comment on randomization_bin
             self.seed = randomization_bin(self.runtime.seed, unicode(self.location).encode('utf-8'))
         else:

--- a/lms/djangoapps/courseware/tests/test_submitting_problems.py
+++ b/lms/djangoapps/courseware/tests/test_submitting_problems.py
@@ -1274,12 +1274,12 @@ class TestModuleInstantiation(TestSubmittingProblems):
         Don't write to StudentModule if instantiating a capa problem
         that isn't randomized
         """
-        self.problem = ItemFactory.create(category='problem')
+        problem = ItemFactory.create(category='problem')
 
-        self.look_at_question(self.problem.url_name)
+        self.look_at_question(problem.url_name)
         self.assertFalse(
             StudentModule.objects.filter(
-                module_state_key=self.problem_location(self.problem.url_name)
+                module_state_key=self.problem_location(problem.url_name)
             ).exists()
         )
 
@@ -1288,14 +1288,14 @@ class TestModuleInstantiation(TestSubmittingProblems):
         Do write to StudentModule if instantiating a capa problem
         that is randomized
         """
-        self.problem = ItemFactory.create(
+        problem = ItemFactory.create(
             category='problem',
             metadata={'rerandomize': RANDOMIZATION.ALWAYS},
         )
 
-        self.look_at_question(self.problem.url_name)
+        self.look_at_question(problem.url_name)
         self.assertTrue(
             StudentModule.objects.filter(
-                module_state_key=self.problem_location(self.problem.url_name)
+                module_state_key=self.problem_location(problem.url_name)
             ).exists()
         )

--- a/lms/djangoapps/courseware/tests/test_submitting_problems.py
+++ b/lms/djangoapps/courseware/tests/test_submitting_problems.py
@@ -21,6 +21,7 @@ from courseware import grades
 from courseware.models import StudentModule
 from courseware.tests.helpers import LoginEnrollmentTestCase
 from xmodule.modulestore.tests.django_utils import TEST_DATA_MOCK_MODULESTORE
+from xmodule.capa_base_constants import RANDOMIZATION
 from lms.djangoapps.lms_xblock.runtime import quote_slashes
 from student.tests.factories import UserFactory
 from student.models import anonymous_id_for_user
@@ -106,6 +107,15 @@ class TestSubmittingProblems(ModuleStoreTestCase, LoginEnrollmentTestCase):
 
         return resp
 
+    def look_at_question(self, problem_url_name):
+        """
+        Create state for a problem, but don't answer it
+        """
+        location = self.problem_location(problem_url_name)
+        modx_url = self.modx_url(location, "problem_get")
+        resp = self.client.get(modx_url)
+        return resp
+
     def reset_question_answer(self, problem_url_name):
         """
         Reset specified problem for current user.
@@ -148,7 +158,7 @@ class TestSubmittingProblems(ModuleStoreTestCase, LoginEnrollmentTestCase):
             parent_location=section_location,
             category='problem',
             data=prob_xml,
-            metadata={'rerandomize': 'always'},
+            metadata={'rerandomize': RANDOMIZATION.ALWAYS},
             display_name=name
         )
 
@@ -180,7 +190,7 @@ class TestSubmittingProblems(ModuleStoreTestCase, LoginEnrollmentTestCase):
                 parent_location=self.chapter.location,
                 display_name=name,
                 category='sequential',
-                rerandomize='always',
+                rerandomize=RANDOMIZATION.ALWAYS,
                 metadata={
                     'graded': True,
                     'format': section_format,
@@ -1252,3 +1262,40 @@ class TestConditionalContent(TestSubmittingProblems):
         homework_1_score = 1.0 / 2
         homework_2_score = 1.0 / 1
         self.check_grade_percent(round((homework_1_score + homework_2_score) / 2, 2))
+
+
+class TestModuleInstantiation(TestSubmittingProblems):
+    """
+    Tests for instantiating xmodules in courseware
+    """
+
+    def test_dont_write_to_csm_if_not_randomized(self):
+        """
+        Don't write to StudentModule if instantiating a capa problem
+        that isn't randomized
+        """
+        self.problem = ItemFactory.create(category='problem')
+
+        self.look_at_question(self.problem.url_name)
+        self.assertFalse(
+            StudentModule.objects.filter(
+                module_state_key=self.problem_location(self.problem.url_name)
+            ).exists()
+        )
+
+    def test_write_to_csm_if_randomized(self):
+        """
+        Do write to StudentModule if instantiating a capa problem
+        that is randomized
+        """
+        self.problem = ItemFactory.create(
+            category='problem',
+            metadata={'rerandomize': RANDOMIZATION.ALWAYS},
+        )
+
+        self.look_at_question(self.problem.url_name)
+        self.assertTrue(
+            StudentModule.objects.filter(
+                module_state_key=self.problem_location(self.problem.url_name)
+            ).exists()
+        )


### PR DESCRIPTION
@cpennington 
@ormsbee 

By avoiding setting "seed" when capa modules are instantiated, we avoid a write to `StudentModule` when capa modules are instantiated. A nice side effect here is that this should help with grading performance by not writing to `StudentModule` for problems that students look at, but don't answer.

https://openedx.atlassian.net/browse/CSM-14
