### PR TITLE
User was not able to login on edge

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -586,6 +586,7 @@ class LoginFailures(models.Model):
             return False
 
     @classmethod
+    @transaction.commit_on_success
     def increment_lockout_counter(cls, user):
         """
         Ticks the failed attempt counter


### PR DESCRIPTION
user was not able to login on edge becuase of multiple
entries of loginfailure that was caused by the race
condition when user tried to login with wrong credentials.

TNL-1368
