### PR TITLE
Replace broken logic in import template with working logic in view.

### DIFF
--- a/cms/djangoapps/contentstore/views/import_export.py
+++ b/cms/djangoapps/contentstore/views/import_export.py
@@ -304,6 +304,7 @@ def _import_handler(request, courselike_key, root_name, successful_url, context_
             context_name: courselike_module,
             'successful_import_redirect_url': successful_url,
             'import_status_url': status_url,
+            'library': isinstance(courselike_key, LibraryLocator)
         })
     else:
         return HttpResponseNotFound()

--- a/cms/templates/import.html
+++ b/cms/templates/import.html
@@ -4,10 +4,6 @@
 <%!
   from django.utils.translation import ugettext as _
   import json
-  try:
-      library = True
-  except NameError:
-      library = False
 %>
 <%block name="title">
 %if library:

--- a/common/test/acceptance/pages/studio/import_export.py
+++ b/common/test/acceptance/pages/studio/import_export.py
@@ -10,6 +10,19 @@ from .course_page import CoursePage
 from . import BASE_URL
 
 
+class TemplateCheckMixin(object):
+    """
+    Mixin for verifying that a template is loading the correct text.
+    """
+    @property
+    def header_text(self):
+        """
+        Get the header text of the page.
+        """
+        # There are prefixes like 'Tools' and '>', but the text itself is not in a span.
+        return self.q(css='h1.page-header')[0].text.split('\n')[-1]
+
+
 class ExportMixin(object):
     """
     Export page Mixin.
@@ -86,13 +99,13 @@ class LibraryLoader(object):
         return "/".join([BASE_URL, self.url_path, unicode(self.locator)])
 
 
-class ExportCoursePage(ExportMixin, CoursePage):
+class ExportCoursePage(ExportMixin, TemplateCheckMixin, CoursePage):
     """
     Export page for Courses
     """
 
 
-class ExportLibraryPage(ExportMixin, LibraryLoader, LibraryPage):
+class ExportLibraryPage(ExportMixin, TemplateCheckMixin, LibraryLoader, LibraryPage):
     """
     Export page for Libraries
     """
@@ -226,13 +239,13 @@ class ImportMixin(object):
         return self.q(css='.action.action-primary')[0].get_attribute('href')
 
 
-class ImportCoursePage(ImportMixin, CoursePage):
+class ImportCoursePage(ImportMixin, TemplateCheckMixin, CoursePage):
     """
     Import page for Courses
     """
 
 
-class ImportLibraryPage(ImportMixin, LibraryLoader, LibraryPage):
+class ImportLibraryPage(ImportMixin, TemplateCheckMixin, LibraryLoader, LibraryPage):
     """
     Import page for Libraries
     """

--- a/common/test/acceptance/tests/studio/test_import_export.py
+++ b/common/test/acceptance/tests/studio/test_import_export.py
@@ -41,6 +41,15 @@ class TestCourseExport(ExportTestMixin, StudioCourseTest):
         )
         self.export_page.visit()
 
+    def test_header(self):
+        """
+        Scenario: I should see the correct text when exporting a course.
+            Given that I have a course to export from
+            When I visit the export page
+            The correct header should be shown
+        """
+        self.assertEqual(self.export_page.header_text, 'Course Export')
+
 
 class TestLibraryExport(ExportTestMixin, StudioLibraryTest):
     """
@@ -53,6 +62,15 @@ class TestLibraryExport(ExportTestMixin, StudioLibraryTest):
         super(TestLibraryExport, self).setUp()
         self.export_page = ExportLibraryPage(self.browser, self.library_key)
         self.export_page.visit()
+
+    def test_header(self):
+        """
+        Scenario: I should see the correct text when exporting a library.
+            Given that I have a library to export from
+            When I visit the export page
+            The correct header should be shown
+        """
+        self.assertEqual(self.export_page.header_text, 'Library Export')
 
 
 # pylint: disable=no-member
@@ -243,6 +261,15 @@ class TestCourseImport(ImportTestMixin, StudioCourseTest):
         # There's a section named 'Section' in the tarball.
         self.landing_page.section("Section")
 
+    def test_header(self):
+        """
+        Scenario: I should see the correct text when importing a course.
+            Given that I have a course to import to
+            When I visit the import page
+            The correct header should be shown
+        """
+        self.assertEqual(self.import_page.header_text, 'Course Import')
+
 
 class TestLibraryImport(ImportTestMixin, StudioLibraryTest):
     """
@@ -276,3 +303,12 @@ class TestLibraryImport(ImportTestMixin, StudioLibraryTest):
         self.landing_page.wait_until_ready()
         # There are three blocks in the tarball.
         self.assertEqual(len(self.landing_page.xblocks), 3)
+
+    def test_header(self):
+        """
+        Scenario: I should see the correct text when importing a library.
+            Given that I have a library to import to
+            When I visit the import page
+            The correct header should be shown
+        """
+        self.assertEqual(self.import_page.header_text, 'Library Import')


### PR DESCRIPTION
@antoviaque @marcotuts 

Patch to fix the issue where library import verbiage was shown where course import verbage should be.
