### PR TITLE
Add Mocks to Enrollment API Doc Config

### DIFF
--- a/docs/en_us/enrollment_api/source/conf.py
+++ b/docs/en_us/enrollment_api/source/conf.py
@@ -7,6 +7,37 @@
 import os
 from path import path
 import sys
+import mock
+
+MOCK_MODULES = [
+    'ipware',
+    'ip',
+    'ipware.ip',
+    'get_ip',
+    'pygeoip',
+    'ipaddr',
+    'django_countries',
+    'fields',
+    'django_countries.fields',
+    'opaque_keys',
+    'opaque_keys.edx',
+    'opaque_keys.edx.keys',
+    'CourseKey',
+    'UsageKey',
+    'BlockTypeKey',
+    'opaque_keys.edx.locations',
+    'SlashSeparatedCourseKey',
+    'Location',
+    'opaque_keys.edx.locator',
+    'Locator',
+    'south',
+    'modelsinspector',
+    'south.modelsinspector',
+    'add_introspection_rules'
+]
+
+for mod_name in MOCK_MODULES:
+    sys.modules[mod_name] = mock.Mock()
 
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 


### PR DESCRIPTION
@stephensanchez   something changed so that the view docstrings wouldn't import without mocking all the modules used by the view.  You can see that latest build doesn't have the docstrings: http://edx.readthedocs.org/projects/edx-enrollment-api/en/latest/enrollment.html

I added the needed modules to the sphinx config file
