### PR TITLE
fixes invalid aria-role dialogalert which should be alertdialog

### DIFF
--- a/lms/templates/modal/accessible_confirm.html
+++ b/lms/templates/modal/accessible_confirm.html
@@ -18,7 +18,7 @@
         </span>
       </h2>
     </header>
-    <div role="dialogalert" class="status message" tabindex="-1">
+    <div role="alertdialog" class="status message" tabindex="-1">
         <p class="message-title"></p>
     </div>
     <hr aria-hidden="true" />


### PR DESCRIPTION
@clrux, @sarina here is a quick fix for an invalid aria-role which was being used on an Alert Dialog box.  It changes nothing visually and only adds additional context to screen reader users.  
