### PR TITLE
More granular course_publish event

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/django.py
+++ b/common/lib/xmodule/xmodule/modulestore/django.py
@@ -79,7 +79,7 @@ class SignalHandler(object):
        do the actual work.
 
     """
-    course_published = django.dispatch.Signal(providing_args=["course_key"])
+    course_published = django.dispatch.Signal(providing_args=["course_key", "item_keys"])
 
     _mapping = {
         "course_published": course_published

--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -457,7 +457,7 @@ class MongoBulkOpsMixin(BulkOperationsMixin):
             self.refresh_cached_metadata_inheritance_tree(course_id)
 
             if emit_signals and self.signal_handler:
-                self.signal_handler.send("course_published", course_key=course_id)
+                self.send_bulk_published_signal(bulk_ops_record, course_id)
 
             bulk_ops_record.dirty = False  # brand spanking clean now
 

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
@@ -268,9 +268,7 @@ class SplitBulkWriteMixin(BulkOperationsMixin):
                 self.db_connection.update_course_index(bulk_write_record.index, from_index=bulk_write_record.initial_index)
 
         if dirty and emit_signals:
-            signal_handler = getattr(self, 'signal_handler', None)
-            if signal_handler:
-                signal_handler.send("course_published", course_key=course_key)
+            self.send_bulk_published_signal(bulk_write_record, course_key)
 
     def get_course_index(self, course_key, ignore_case=False):
         """


### PR DESCRIPTION
@clintonb - I tried to add some more granularity to the `course_published` event so we can focus on narrow sections of the course that have been changed if desired. Let me know if this seems to work.

@dsego, @marjev - This is preparation for some of the fixes that I am making to SOL-174
