### PR TITLE
Remove extra lean modal trigger

### DIFF
--- a/cms/static/js/base.js
+++ b/cms/static/js/base.js
@@ -15,15 +15,6 @@ domReady(function() {
 
     $body.addClass('js');
 
-    // lean/simple modal
-    $('a[rel*=modal]').leanModal({
-        overlay: 0.80,
-        closeButton: '.action-modal-close'
-    });
-    $('a.action-modal-close').click(function(e) {
-        (e).preventDefault();
-    });
-
     // alerts/notifications - manual close
     $('.action-alert-close, .alert.has-actions .nav-actions a').bind('click', hideAlert);
     $('.action-notification-close').bind('click', hideNotification);


### PR DESCRIPTION
There are two lean modal triggers in base.js. First one here: https://github.com/edx/edx-platform/blob/master/cms/static/js/base.js#L61
Extra one introduced in https://github.com/edx/edx-platform/commit/9b09d043bd02d323565a74eb96f7bc93dfabc5de

The effect of this can be seen when you click lean modals in Studio. They will show a darker background first, and then the lighter one, from the 2 triggers. For example, if you go to https://studio.edx.org/ and click the image, you can see this.
