### PR TITLE
Improve pep8 reporting

### DIFF
--- a/openedx/core/djangoapps/course_groups/tests/test_cohorts.py
+++ b/openedx/core/djangoapps/course_groups/tests/test_cohorts.py
@@ -24,6 +24,7 @@ from ..tests.helpers import (
     CohortFactory, CourseCohortFactory, CourseCohortSettingsFactory
 )
 
+
 @patch("openedx.core.djangoapps.course_groups.cohorts.tracker")
 class TestCohortSignals(TestCase):
     def setUp(self):
@@ -404,7 +405,6 @@ class TestCohorts(ModuleStoreTestCase):
             cohorts.get_cohort_by_name(course.id, cohorts.DEFAULT_COHORT_NAME).id,
             "No groups->default cohort for user2"
         )
-
 
     def test_auto_cohorting_randomization(self):
         """

--- a/openedx/core/djangoapps/user_api/preferences/tests/test_api.py
+++ b/openedx/core/djangoapps/user_api/preferences/tests/test_api.py
@@ -204,7 +204,7 @@ class TestPreferenceAPI(TestCase):
 
         too_long_key = "x" * 256
         with self.assertRaises(PreferenceValidationError) as context_manager:
-            update_user_preferences(self.user, { too_long_key: "new_value"})
+            update_user_preferences(self.user, {too_long_key: "new_value"})
         errors = context_manager.exception.preference_errors
         self.assertEqual(len(errors.keys()), 1)
         self.assertEqual(
@@ -217,7 +217,7 @@ class TestPreferenceAPI(TestCase):
 
         for empty_value in ("", "   "):
             with self.assertRaises(PreferenceValidationError) as context_manager:
-                update_user_preferences(self.user, { self.test_preference_key: empty_value})
+                update_user_preferences(self.user, {self.test_preference_key: empty_value})
             errors = context_manager.exception.preference_errors
             self.assertEqual(len(errors.keys()), 1)
             self.assertEqual(
@@ -230,7 +230,7 @@ class TestPreferenceAPI(TestCase):
 
         user_preference_save.side_effect = [Exception, None]
         with self.assertRaises(PreferenceUpdateError) as context_manager:
-            update_user_preferences(self.user, { self.test_preference_key: "new_value"})
+            update_user_preferences(self.user, {self.test_preference_key: "new_value"})
         self.assertEqual(
             context_manager.exception.developer_message,
             u"Save failed for user preference 'test_key' with value 'new_value': "

--- a/openedx/core/djangoapps/user_api/preferences/views.py
+++ b/openedx/core/djangoapps/user_api/preferences/views.py
@@ -204,5 +204,5 @@ class PreferencesDetailView(APIView):
 
         if not preference_existed:
             return Response(status=status.HTTP_404_NOT_FOUND)
-        
+
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -1686,7 +1686,6 @@ class TestFacebookRegistrationView(
         self._verify_user_existence(user_exists=False, social_link_exists=False)
 
 
-
 @skipUnless(settings.FEATURES.get("ENABLE_THIRD_PARTY_AUTH"), "third party auth not enabled")
 class TestGoogleRegistrationView(
     ThirdPartyRegistrationTestMixin, ThirdPartyOAuthTestMixinGoogle, TransactionTestCase

--- a/openedx/core/djangoapps/user_api/views.py
+++ b/openedx/core/djangoapps/user_api/views.py
@@ -382,8 +382,9 @@ class RegistrationView(APIView):
         # Translators: These instructions appear on the registration form, immediately
         # below a field meant to hold the user's public username.
         username_instructions = _(
-            u"The name that will identify you in your courses - {bold_start}(cannot be changed later){bold_end}").format(bold_start=u'<strong>', bold_end=u'</strong>'
-        )
+            u"The name that will identify you in your courses - "
+            "{bold_start}(cannot be changed later){bold_end}"
+        ).format(bold_start=u'<strong>', bold_end=u'</strong>')
 
         # Translators: This example username is used as a placeholder in
         # a field on the registration form meant to hold the user's username.

--- a/pavelib/paver_tests/test_paver_quality.py
+++ b/pavelib/paver_tests/test_paver_quality.py
@@ -1,7 +1,10 @@
+"""
+Tests for paver quality tasks
+"""
 import os
 import tempfile
 import unittest
-from mock import patch
+from mock import patch, MagicMock
 from ddt import ddt, file_data
 
 import pavelib.quality
@@ -11,22 +14,26 @@ from paver.easy import BuildFailure
 
 @ddt
 class TestPaverQualityViolations(unittest.TestCase):
-
+    """
+    For testing the paver violations-counting tasks
+    """
     def setUp(self):
+        super(TestPaverQualityViolations, self).setUp()
         self.f = tempfile.NamedTemporaryFile(delete=False)
         self.f.close()
+        self.addCleanup(os.remove, self.f.name)
 
     def test_pylint_parser_other_string(self):
         with open(self.f.name, 'w') as f:
             f.write("hello")
-        num = pavelib.quality._count_pylint_violations(f.name)
+        num = pavelib.quality._count_pylint_violations(f.name)  # pylint: disable=protected-access
         self.assertEqual(num, 0)
 
     def test_pylint_parser_pep8(self):
         # Pep8 violations should be ignored.
         with open(self.f.name, 'w') as f:
             f.write("foo/hello/test.py:304:15: E203 whitespace before ':'")
-        num = pavelib.quality._count_pylint_violations(f.name)
+        num = pavelib.quality._count_pylint_violations(f.name)  # pylint: disable=protected-access
         self.assertEqual(num, 0)
 
     @file_data('pylint_test_list.json')
@@ -38,17 +45,14 @@ class TestPaverQualityViolations(unittest.TestCase):
         """
         with open(self.f.name, 'w') as f:
             f.write(value)
-        num = pavelib.quality._count_pylint_violations(f.name)
+        num = pavelib.quality._count_pylint_violations(f.name)  # pylint: disable=protected-access
         self.assertEqual(num, 1)
 
     def test_pep8_parser(self):
         with open(self.f.name, 'w') as f:
             f.write("hello\nhithere")
-        num = pavelib.quality._count_pep8_violations(f.name)
+        num, _violations = pavelib.quality._pep8_violations(f.name)  # pylint: disable=protected-access
         self.assertEqual(num, 2)
-
-    def tearDown(self):
-        os.remove(self.f.name)
 
 
 class TestPaverRunQuality(unittest.TestCase):
@@ -57,27 +61,33 @@ class TestPaverRunQuality(unittest.TestCase):
     """
 
     def setUp(self):
+        super(TestPaverRunQuality, self).setUp()
 
         # mock the @needs decorator to skip it
         self._mock_paver_needs = patch.object(pavelib.quality.run_quality, 'needs').start()
         self._mock_paver_needs.return_value = 0
-        self._mock_paver_sh = patch('pavelib.quality.sh').start()
-        self.addCleanup(self._mock_paver_sh.stop())
-        self.addCleanup(self._mock_paver_needs.stop())
+        patcher = patch('pavelib.quality.sh')
+        self._mock_paver_sh = patcher.start()
+        self.addCleanup(patcher.stop)
+        self.addCleanup(self._mock_paver_needs.stop)
 
     def test_failure_on_diffquality_pep8(self):
         """
-       If pep8 diff-quality fails due to the percentage threshold, pylint
-       should still be run
+        If pep8 finds errors, pylint should still be run
         """
+        # Mock _get_pep8_violations to return a violation
+        _mock_pep8_violations = MagicMock(
+            return_value=(1, ['lms/envs/common.py:32:2: E225 missing whitespace around operator'])
+        )
+        with patch('pavelib.quality._get_pep8_violations', _mock_pep8_violations):
+            with self.assertRaises(SystemExit):
+                pavelib.quality.run_quality("")
+                self.assertRaises(BuildFailure)
 
-        # Underlying sh call must fail when it is running the pep8 diff-quality task
-        self._mock_paver_sh.side_effect = CustomShMock().fail_on_pep8
-        with self.assertRaises(SystemExit):
-            pavelib.quality.run_quality("")
-            self.assertRaises(BuildFailure)
-        # Test that both pep8 and pylint were called by counting the calls
-        self.assertEqual(self._mock_paver_sh.call_count, 2)
+        # Test that both pep8 and pylint were called by counting the calls to _get_pep8_violations
+        # (for pep8) and sh (for diff-quality pylint)
+        self.assertEqual(_mock_pep8_violations.call_count, 1)
+        self.assertEqual(self._mock_paver_sh.call_count, 1)
 
     def test_failure_on_diffquality_pylint(self):
         """
@@ -90,7 +100,8 @@ class TestPaverRunQuality(unittest.TestCase):
             pavelib.quality.run_quality("")
             self.assertRaises(BuildFailure)
         # Test that both pep8 and pylint were called by counting the calls
-        self.assertEqual(self._mock_paver_sh.call_count, 2)
+        # Pep8 is called twice (for lms and cms), then pylint is called an additional time.
+        self.assertEqual(self._mock_paver_sh.call_count, 3)
 
     def test_other_exception(self):
         """
@@ -105,8 +116,13 @@ class TestPaverRunQuality(unittest.TestCase):
 
     def test_no_diff_quality_failures(self):
         # Assert nothing is raised
-        pavelib.quality.run_quality("")
-        self.assertEqual(self._mock_paver_sh.call_count, 2)
+        _mock_pep8_violations = MagicMock(return_value=(0, []))
+        with patch('pavelib.quality._get_pep8_violations', _mock_pep8_violations):
+            pavelib.quality.run_quality("")
+        # Assert that _get_pep8_violations (which calls "pep8") is called once
+        self.assertEqual(_mock_pep8_violations.call_count, 1)
+        # And assert that sh was called once (for the call to "pylint")
+        self.assertEqual(self._mock_paver_sh.call_count, 1)
 
 
 class CustomShMock(object):
@@ -114,17 +130,6 @@ class CustomShMock(object):
     Diff-quality makes a number of sh calls. None of those calls should be made during tests; however, some
     of them need to have certain responses.
     """
-
-    def fail_on_pep8(self, arg):
-        """
-        For our tests, we need the call for diff-quality running pep8 reports to fail, since that is what
-        is going to fail when we pass in a percentage ("p") requirement.
-        """
-        if "pep8" in arg:
-            # Essentially mock diff-quality exiting with 1
-            paver.easy.sh("exit 1")
-        else:
-            return
 
     def fail_on_pylint(self, arg):
         """

--- a/pavelib/quality.py
+++ b/pavelib/quality.py
@@ -56,7 +56,7 @@ def find_fixme(options):
         num_fixme += _count_pylint_violations(
             "{report_dir}/pylint_fixme.report".format(report_dir=report_dir))
 
-    print("Number of pylint fixmes: " + str(num_fixme))
+    print "Number of pylint fixmes: " + str(num_fixme)
 
 
 @task
@@ -75,7 +75,7 @@ def run_pylint(options):
     violations_limit = int(getattr(options, 'limit', -1))
     errors = getattr(options, 'errors', False)
     systems = getattr(options, 'system', ALL_SYSTEMS).split(',')
-    
+
     # Make sure the metrics subdirectory exists
     Env.METRICS_DIR.makedirs_p()
 
@@ -119,7 +119,7 @@ def run_pylint(options):
 
     # Print number of violations to log
     violations_count_str = "Number of pylint violations: " + str(num_violations)
-    print(violations_count_str)
+    print violations_count_str
 
     # Also write the number of violations to a file
     with open(Env.METRICS_DIR / "pylint", "w") as f:
@@ -139,7 +139,7 @@ def _count_pylint_violations(report_file):
     # An example string:
     # common/lib/xmodule/xmodule/tests/test_conditional.py:21: [C0111(missing-docstring), DummySystem] Missing docstring
     # More examples can be found in the unit tests for this method
-    pylint_pattern = re.compile(".(\d+):\ \[(\D\d+.+\]).")
+    pylint_pattern = re.compile(r".(\d+):\ \[(\D\d+.+\]).")
 
     for line in open(report_file):
         violation_list_for_line = pylint_pattern.split(line)
@@ -161,7 +161,7 @@ def _get_pep8_violations():
     report_dir = (Env.REPORT_DIR / 'pep8')
     report_dir.rmtree(ignore_errors=True)
     report_dir.makedirs_p()
-    
+
     # Make sure the metrics subdirectory exists
     Env.METRICS_DIR.makedirs_p()
 
@@ -191,31 +191,29 @@ def _pep8_violations(report_file):
 @cmdopts([
     ("system=", "s", "System to act on"),
 ])
-def run_pep8(options):
+def run_pep8(options):  # pylint: disable=unused-argument
     """
     Run pep8 on system code.
     Fail the task if any violations are found.
     """
     (count, violations_list) = _get_pep8_violations()
-    violations_str = ''.join(violations_list)
+    violations_list = ''.join(violations_list)
 
     # Print number of violations to log
     violations_count_str = "Number of pep8 violations: {count}".format(count=count)
-    print(violations_count_str)
-    print(violations_str)
+    print violations_count_str
+    print violations_list
 
     # Also write the number of violations to a file
     with open(Env.METRICS_DIR / "pep8", "w") as f:
         f.write(violations_count_str + '\n\n')
-        f.write(violations_str)
+        f.write(violations_list)
 
     # Fail if any violations are found
     if count:
-        raise Exception(
-            "Too many pep8 violations. Number of violations found: {count}.\n\n{violations}".format(
-                count=count, violations=violations_str
-            )
-        )
+        failure_string = "Too many pep8 violations. " + violations_count_str
+        failure_string += "\n\nViolations:\n{violations_list}".format(violations_list=violations_list)
+        raise Exception(failure_string)
 
 
 @task
@@ -257,9 +255,11 @@ def run_quality(options):
     dquality_dir = (Env.REPORT_DIR / "diff_quality").makedirs_p()
     diff_quality_percentage_failure = False
 
-    # Run pep8 directly since we have 0 violations on master
     def _pep8_output(count, violations_list, is_html=False):
-
+        """
+        Given a count & list of pep8 violations, pretty-print the pep8 output.
+        If `is_html`, will print out with HTML markup.
+        """
         if is_html:
             lines = ['<body>\n']
             sep = '-------------<br/>\n'
@@ -290,6 +290,7 @@ def run_quality(options):
 
         return ''.join(lines)
 
+    # Run pep8 directly since we have 0 violations on master
     (count, violations_list) = _get_pep8_violations()
 
     # Print number of violations to log

--- a/pavelib/quality.py
+++ b/pavelib/quality.py
@@ -156,8 +156,6 @@ def _get_pep8_violations():
     where violations_string is a string of all pep8 violations found, separated
     by new lines.
     """
-    systems = ALL_SYSTEMS.split(',')
-
     report_dir = (Env.REPORT_DIR / 'pep8')
     report_dir.rmtree(ignore_errors=True)
     report_dir.makedirs_p()
@@ -165,8 +163,7 @@ def _get_pep8_violations():
     # Make sure the metrics subdirectory exists
     Env.METRICS_DIR.makedirs_p()
 
-    for system in systems:
-        sh('pep8 {system} | tee {report_dir}/pep8.report -a'.format(system=system, report_dir=report_dir))
+    sh('pep8 . | tee {report_dir}/pep8.report -a'.format(report_dir=report_dir))
 
     count, violations_list = _pep8_violations(
         "{report_dir}/pep8.report".format(report_dir=report_dir)

--- a/pavelib/quality.py
+++ b/pavelib/quality.py
@@ -179,16 +179,22 @@ def run_pep8(options):
     # Print number of violations to log
     violations_count_str = "Number of pep8 violations: {count}".format(count=count)
     print(violations_count_str)
+    violations = ''
+    with open("{report_dir}/pep8.report".format(report_dir=report_dir), 'r') as f:
+        violations_list = f.readlines()
+        violations_str = '\n'.join(violations_list)
+    print(violations_str)
 
     # Also write the number of violations to a file
     with open(Env.METRICS_DIR / "pep8", "w") as f:
-        f.write(violations_count_str)
+        f.write(violations_count_str + '\n\n')
+        f.write(violations_str)
 
     # Fail if any violations are found
     if count:
         raise Exception(
-            "Too many pep8 violations. Number of violations found: {count}.".format(
-                count=count
+            "Too many pep8 violations. Number of violations found: {count}.\n\n{violations}".format(
+                count=count, violations=violations_str
             )
         )
 


### PR DESCRIPTION
Right now people keep asking me why their build fails - if they have pep8 failures they aren't necessarily reported in diff-quality but do still fail the build.

My aim is to patch the output of "paver run_pep8" and "paver run_quality" to be more helpful. I think my "run_pep8" changes are reasonable, but it would be good to discuss what we'd actually like to see in the output of run_quality - do we want to change the behavior of diff-quality? or just short circuit it because we expect pep8 to remain at 0?
