### PR TITLE
Refactor and extend paver quality

### DIFF
--- a/pavelib/quality.py
+++ b/pavelib/quality.py
@@ -1,201 +1,92 @@
 """
-Check code quality using pep8, pylint, and diff_quality.
+Check code quality using PEP8, Pylint, and diff_quality.
 """
-from paver.easy import sh, task, cmdopts, needs, BuildFailure
+from __future__ import print_function
 import os
-import re
 
-from .utils.envs import Env
+from paver.easy import task, cmdopts, needs, BuildFailure
 
-ALL_SYSTEMS = 'lms,cms,common'
+from pavelib.utils.wrapper import pep8 as pep8_wrapper
+from pavelib.utils.wrapper import pylint as pylint_wrapper
+from pavelib.utils.wrapper import get_clean_report_directory
+from pavelib.utils.wrapper import get_pylint_reports
+from pavelib.utils.wrapper import get_python_path
+from pavelib.utils.cmd import shell
+from pavelib.utils.envs import Env
+
+ALL_SERVICES = [
+    'lms',
+    'cms',
+    'common',
+]
 
 
 @task
 @needs('pavelib.prereqs.install_python_prereqs')
 @cmdopts([
-    ("system=", "s", "System to act on"),
+    ('system=', 's', 'System to act on'),
 ])
 def find_fixme(options):
     """
-    Run pylint on system code, only looking for fixme items.
+    Run Pylint on system code, only looking for FIXME items
     """
-    num_fixme = 0
-    systems = getattr(options, 'system', ALL_SYSTEMS).split(',')
-
-    for system in systems:
-        # Directory to put the pylint report in.
-        # This makes the folder if it doesn't already exist.
-        report_dir = (Env.REPORT_DIR / system).makedirs_p()
-
-        apps = [system]
-
-        for directory in ['djangoapps', 'lib']:
-            dirs = os.listdir(os.path.join(system, directory))
-            apps.extend([d for d in dirs if os.path.isdir(os.path.join(system, directory, d))])
-
-        apps_list = ' '.join(apps)
-
-        pythonpath_prefix = (
-            "PYTHONPATH={system}:{system}/lib"
-            "common/djangoapps:common/lib".format(
-                system=system
-            )
-        )
-
-        sh(
-            "{pythonpath_prefix} pylint --disable R,C,W,E --enable=fixme "
-            "--msg-template={msg_template} {apps} "
-            "| tee {report_dir}/pylint_fixme.report".format(
-                pythonpath_prefix=pythonpath_prefix,
-                msg_template='"{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}"',
-                apps=apps_list,
-                report_dir=report_dir
-            )
-        )
-
-        num_fixme += _count_pylint_violations(
-            "{report_dir}/pylint_fixme.report".format(report_dir=report_dir))
-
-    print("Number of pylint fixmes: " + str(num_fixme))
+    systems = getattr(options, 'system', ','.join(ALL_SERVICES)).split(',')
+    flags = [
+        '--disable R,C,W,E',
+        '--enable=fixme',
+    ]
+    pylint_wrapper('fixme', systems, *flags)
 
 
 @task
 @needs('pavelib.prereqs.install_python_prereqs')
 @cmdopts([
-    ("system=", "s", "System to act on"),
-    ("errors", "e", "Check for errors only"),
-    ("limit=", "l", "limit for number of acceptable violations"),
+    ('system=', 's', 'System to act on'),
+    ('errors', 'e', 'Check for errors only'),
+    ('limit=', 'l', 'Limit for number of acceptable violations'),
 ])
 def run_pylint(options):
     """
-    Run pylint on system code. When violations limit is passed in,
+    Run Pylint on system code.
+
+    When violations limit is passed in,
     fail the task if too many violations are found.
     """
-    num_violations = 0
-    violations_limit = int(getattr(options, 'limit', -1))
+    limit = int(getattr(options, 'limit', -1))
     errors = getattr(options, 'errors', False)
-    systems = getattr(options, 'system', ALL_SYSTEMS).split(',')
-    
-    # Make sure the metrics subdirectory exists
-    Env.METRICS_DIR.makedirs_p()
-
-    for system in systems:
-        # Directory to put the pylint report in.
-        # This makes the folder if it doesn't already exist.
-        report_dir = (Env.REPORT_DIR / system).makedirs_p()
-
-        flags = []
-        if errors:
-            flags.append("--errors-only")
-
-        apps = [system]
-
-        for directory in ['lib']:
-            dirs = os.listdir(os.path.join(system, directory))
-            apps.extend([d for d in dirs if os.path.isdir(os.path.join(system, directory, d))])
-
-        apps_list = ' '.join(apps)
-
-        pythonpath_prefix = (
-            "PYTHONPATH={system}:{system}/djangoapps:{system}/"
-            "lib:common/djangoapps:common/lib".format(
-                system=system
-            )
-        )
-
-        sh(
-            "{pythonpath_prefix} pylint {flags} --msg-template={msg_template} {apps} | "
-            "tee {report_dir}/pylint.report".format(
-                pythonpath_prefix=pythonpath_prefix,
-                flags=" ".join(flags),
-                msg_template='"{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}"',
-                apps=apps_list,
-                report_dir=report_dir
-            )
-        )
-
-        num_violations += _count_pylint_violations(
-            "{report_dir}/pylint.report".format(report_dir=report_dir))
-
-    # Print number of violations to log
-    violations_count_str = "Number of pylint violations: " + str(num_violations)
-    print(violations_count_str)
-
-    # Also write the number of violations to a file
-    with open(Env.METRICS_DIR / "pylint", "w") as f:
-        f.write(violations_count_str)
-
-    # Fail number of violations is greater than the limit
-    if num_violations > violations_limit > -1:
-        raise Exception("Failed. Too many pylint violations. "
-                        "The limit is {violations_limit}.".format(violations_limit=violations_limit))
-
-
-def _count_pylint_violations(report_file):
-    """
-    Parses a pylint report line-by-line and determines the number of violations reported
-    """
-    num_violations_report = 0
-    # An example string:
-    # common/lib/xmodule/xmodule/tests/test_conditional.py:21: [C0111(missing-docstring), DummySystem] Missing docstring
-    # More examples can be found in the unit tests for this method
-    pylint_pattern = re.compile(".(\d+):\ \[(\D\d+.+\]).")
-
-    for line in open(report_file):
-        violation_list_for_line = pylint_pattern.split(line)
-        # If the string is parsed into four parts, then we've found a violation. Example of split parts:
-        # test file, line number, violation name, violation details
-        if len(violation_list_for_line) == 4:
-            num_violations_report += 1
-    return num_violations_report
+    systems = getattr(options, 'system', ','.join(ALL_SERVICES)).split(',')
+    flags = []
+    if errors:
+        flags.append('--errors-only')
+    count = pylint_wrapper('pylint', systems, *flags)
+    if count > limit > -1:
+        raise Exception((
+            "Failed. Too many Pylint violations. "
+            "The limit is {limit}."
+        ).format(
+            limit=limit,
+        ))
 
 
 @task
 @needs('pavelib.prereqs.install_python_prereqs')
 @cmdopts([
-    ("system=", "s", "System to act on"),
+    ('system=', 's', 'System to act on'),
 ])
 def run_pep8(options):
     """
-    Run pep8 on system code.
-    Fail the task if any violations are found.
+    Run PEP8 on system code.
+    :raise Exception: if any violations are found
     """
-    systems = getattr(options, 'system', ALL_SYSTEMS).split(',')
-
-    report_dir = (Env.REPORT_DIR / 'pep8')
-    report_dir.rmtree(ignore_errors=True)
-    report_dir.makedirs_p()
-    
-    # Make sure the metrics subdirectory exists
-    Env.METRICS_DIR.makedirs_p()
-
-    for system in systems:
-        sh('pep8 {system} | tee {report_dir}/pep8.report -a'.format(system=system, report_dir=report_dir))
-
-    count = _count_pep8_violations(
-        "{report_dir}/pep8.report".format(report_dir=report_dir)
-    )
-
-    # Print number of violations to log
-    violations_count_str = "Number of pep8 violations: {count}".format(count=count)
-    print(violations_count_str)
-
-    # Also write the number of violations to a file
-    with open(Env.METRICS_DIR / "pep8", "w") as f:
-        f.write(violations_count_str)
-
-    # Fail if any violations are found
+    systems = getattr(options, 'system', '')
+    systems = systems.split(',')
+    count = pep8_wrapper(systems)
     if count:
         raise Exception(
-            "Too many pep8 violations. Number of violations found: {count}.".format(
-                count=count
+            "Too many PEP8 violations. Number of violations found: {count}.".format(
+                count=count,
             )
         )
-
-
-def _count_pep8_violations(report_file):
-    num_lines = sum(1 for line in open(report_file))
-    return num_lines
 
 
 @task
@@ -206,22 +97,23 @@ def run_complexity():
     For additional details on radon, see http://radon.readthedocs.org/
     """
     system_string = 'cms/ lms/ common/ openedx/'
-    print "--> Calculating cyclomatic complexity of files..."
+    print('--> Calculating cyclomatic complexity of files...')
     try:
-        sh(
-            "radon cc {system_string} --total-average".format(
-                system_string=system_string
-            )
+        shell(
+            'radon',
+            'cc',
+            system_string,
+            '--total-average',
         )
     except BuildFailure:
-        print "ERROR: Unable to calculate python-only code-complexity."
+        print('ERROR: Unable to calculate python-only code-complexity.')
 
 
 @task
 @needs('pavelib.prereqs.install_python_prereqs')
 @cmdopts([
-    ("compare-branch=", "b", "Branch to compare against, defaults to origin/master"),
-    ("percentage=", "p", "fail if diff-quality is below this percentage"),
+    ('compare-branch=', 'b', 'Branch to compare against, defaults to origin/master'),
+    ('percentage=', 'p', 'Fail if diff-quality is below this percentage'),
 ])
 def run_quality(options):
     """
@@ -230,103 +122,45 @@ def run_quality(options):
     :param: p, diff-quality will fail if the quality percentage calculated is
         below this percentage. For example, if p is set to 80, and diff-quality finds
         quality of the branch vs the compare branch is less than 80%, then this task will fail.
-        This threshold would be applied to both pep8 and pylint.
+        This threshold would be applied to both PEP8 and Pylint.
     """
 
-    # Directory to put the diff reports in.
-    # This makes the folder if it doesn't already exist.
-    dquality_dir = (Env.REPORT_DIR / "diff_quality").makedirs_p()
-    diff_quality_percentage_failure = False
+    directory_report = get_clean_report_directory('diff_quality')
+    percentage_failure = False
 
-    # Set the string, if needed, to be used for the diff-quality --compare-branch switch.
-    compare_branch = getattr(options, 'compare_branch', None)
-    compare_branch_string = ''
+    compare_branch = getattr(options, 'compare_branch', '')
     if compare_branch:
-        compare_branch_string = '--compare-branch={0}'.format(compare_branch)
+        compare_branch = "--compare-branch={0}".format(compare_branch)
 
-    # Set the string, if needed, to be used for the diff-quality --fail-under switch.
     diff_threshold = int(getattr(options, 'percentage', -1))
     percentage_string = ''
     if diff_threshold > -1:
         percentage_string = '--fail-under={0}'.format(diff_threshold)
 
-    # Generate diff-quality html report for pep8, and print to console
-    # If pep8 reports exist, use those
-    # Otherwise, `diff-quality` will call pep8 itself
+    pep8_count = pep8_wrapper()
+    percentage_failure = pep8_count > 0
 
-    pep8_files = get_violations_reports("pep8")
-    pep8_reports = u' '.join(pep8_files)
-
-    try:
-        sh(
-            "diff-quality --violations=pep8 {pep8_reports} {percentage_string} "
-            "{compare_branch_string} --html-report {dquality_dir}/diff_quality_pep8.html".format(
-                pep8_reports=pep8_reports,
-                percentage_string=percentage_string,
-                compare_branch_string=compare_branch_string,
-                dquality_dir=dquality_dir
-            )
-        )
-    except BuildFailure, error_message:
-        if is_percentage_failure(error_message):
-            diff_quality_percentage_failure = True
-        else:
-            raise BuildFailure(error_message)
-
-    # Generate diff-quality html report for pylint, and print to console
-    # If pylint reports exist, use those
-    # Otherwise, `diff-quality` will call pylint itself
-
-    pylint_files = get_violations_reports("pylint")
+    pylint_files = get_pylint_reports()
     pylint_reports = u' '.join(pylint_files)
-
-    pythonpath_prefix = (
-        "PYTHONPATH=$PYTHONPATH:lms:lms/djangoapps:lms/lib:cms:cms/djangoapps:cms/lib:"
-        "common:common/djangoapps:common/lib"
+    html_report = "{directory_report}/diff_quality_pylint.html ".format(
+        directory_report=directory_report,
     )
-
+    pythonpath_prefix = get_python_path('lms', 'cms')
     try:
-        sh(
-            "{pythonpath_prefix} diff-quality --violations=pylint "
-            "{pylint_reports} {percentage_string} {compare_branch_string} "
-            "--html-report {dquality_dir}/diff_quality_pylint.html ".format(
-                pythonpath_prefix=pythonpath_prefix,
-                pylint_reports=pylint_reports,
-                percentage_string=percentage_string,
-                compare_branch_string=compare_branch_string,
-                dquality_dir=dquality_dir,
-            )
+        shell(
+            pythonpath_prefix,
+            'diff-quality',
+            '--violations=pylint',
+            pylint_reports,
+            percentage_string,
+            compare_branch,
+            '--html-report',
+            html_report,
         )
     except BuildFailure, error_message:
-        if is_percentage_failure(error_message):
-            diff_quality_percentage_failure = True
+        if 'Subprocess return code: 1' in error_message:
+            percentage_failure = True
         else:
             raise BuildFailure(error_message)
-
-    # If one of the diff-quality runs fails, then paver exits with an error when it is finished
-    if diff_quality_percentage_failure:
-        raise BuildFailure("Diff-quality failure(s).")
-
-
-def is_percentage_failure(error_message):
-    """
-    When diff-quality is run with a threshold percentage, it ends with an exit code of 1. This bubbles up to
-    paver with a subprocess return code error. If the subprocess exits with anything other than 1, raise
-    a paver exception.
-    """
-    if "Subprocess return code: 1" not in error_message:
-        return False
-    else:
-        return True
-
-
-def get_violations_reports(violations_type):
-    """
-    Finds violations reports files by naming convention (e.g., all "pep8.report" files)
-    """
-    violations_files = []
-    for subdir, _dirs, files in os.walk(os.path.join(Env.REPORT_DIR)):
-        for f in files:
-            if f == "{violations_type}.report".format(violations_type=violations_type):
-                violations_files.append(os.path.join(subdir, f))
-    return violations_files
+    if percentage_failure:
+        raise BuildFailure('Diff-quality failure(s).')

--- a/pavelib/quality.py
+++ b/pavelib/quality.py
@@ -100,13 +100,12 @@ def run_complexity():
     Uses radon to examine cyclomatic complexity.
     For additional details on radon, see http://radon.readthedocs.org/
     """
-    system_string = 'cms/ lms/ common/ openedx/'
     print('--> Calculating cyclomatic complexity of files...')
     try:
         shell(
             'radon',
             'cc',
-            system_string,
+            ' '.join(ALL_SERVICES),
             '--total-average',
         )
     except BuildFailure:

--- a/pavelib/quality.py
+++ b/pavelib/quality.py
@@ -18,6 +18,10 @@ ALL_SERVICES = [
     'lms',
     'cms',
     'common',
+    'docs',
+    'scripts',
+    'pavelib',
+    'openedx',
 ]
 
 

--- a/pavelib/utils/cmd.py
+++ b/pavelib/utils/cmd.py
@@ -1,6 +1,7 @@
 """
 Helper functions for constructing shell commands.
 """
+from paver.easy import sh
 
 
 def cmd(*args):
@@ -22,3 +23,9 @@ def django_cmd(sys, settings, *args):
     # which calls "studio" "cms"
     sys = 'cms' if sys == 'studio' else sys
     return cmd("python manage.py", sys, "--settings={}".format(settings), *args)
+
+
+def shell(*args):
+    command = cmd(*args)
+    result = sh(command)
+    return result

--- a/pavelib/utils/wrapper.py
+++ b/pavelib/utils/wrapper.py
@@ -1,0 +1,147 @@
+from __future__ import print_function
+import os
+import re
+
+from pavelib.utils.cmd import shell
+from pavelib.utils.envs import Env
+
+PACKAGE_DIRECTORIES = [
+    'lib',
+]
+
+
+def pep8(services=None):
+    services = services or []
+    services = ' '.join(services)
+    Env.METRICS_DIR.makedirs_p()
+    report_dir = get_clean_report_directory('pep8')
+    report_file = "{report_dir}/pep8.txt".format(
+        report_dir=report_dir,
+    )
+    shell(
+        'pep8',
+        services,
+        '|',
+        'tee',
+        report_file,
+    )
+    count = sum(1 for line in open(report_file))
+    message_count = "Number of PEP8 violations: {count}".format(count=count)
+    print(message_count)
+    with open(Env.METRICS_DIR / 'pep8', 'w') as file_out:
+        file_out.write(message_count)
+
+
+def pylint(name, services, *flags):
+    Env.METRICS_DIR.makedirs_p()
+    count = 0
+    for service in services:
+        modules = _get_modules(service)
+        environment = get_python_path(service)
+        directory = get_clean_report_directory(service)
+        report = "{directory}/{name}.txt".format(
+            directory=directory,
+            name=name,
+        )
+        shell(
+            environment,
+            'pylint',
+            '--msg-template',
+            "'{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}'",
+            ' '.join(flags),
+            modules,
+            '|',
+            'tee',
+            report,
+        )
+        count += _count_pylint_violations(report)
+    message = "Number of {name} violations: {count}".format(
+        name=name,
+        count=count,
+    )
+    print(message)
+    with open(Env.METRICS_DIR / 'pylint', 'w') as file_out:
+        file_out.write(message)
+    return count
+
+
+def get_clean_report_directory(service):
+    """
+    Directory to put the Pylint report in.
+
+    This makes the folder if it doesn't already exist.
+    """
+    directory = Env.REPORT_DIR / service
+    directory = directory.makedirs_p()
+    return directory
+
+
+def _count_pylint_violations(path_file_report):
+    """
+    Parses a pylint report line-by-line and determines the number of violations reported
+
+    An example string:
+    common/lib/xmodule/xmodule/tests/test_conditional.py:21:
+        [C0111(missing-docstring), DummySystem] Missing docstring
+    """
+    count = 0
+    pattern = re.compile(r'.(\d+):\ \[(\D\d+.+\]).')
+
+    for line in open(path_file_report):
+        parts = pattern.split(line)
+        if len(parts) == 4:
+            count += 1
+    return count
+
+
+def _get_modules(service, directories=None):
+    directories = directories or PACKAGE_DIRECTORIES
+    applications = [
+        service,
+    ]
+
+    for directory in directories:
+        try:
+            directory_path = os.path.join(service, directory)
+            subdirectories = os.listdir(directory_path)
+        except OSError:
+            continue
+        applications.extend([
+            application
+            for application in subdirectories
+            if os.path.isdir(os.path.join(service, directory, application))
+        ])
+
+    applications = ' '.join(applications)
+    return applications
+
+
+def get_pylint_reports():
+    """
+    Find Pylint violations reports files
+    """
+    reports = []
+    path = os.path.join(Env.REPORT_DIR)
+    for directory, _directories, files in os.walk(path):
+        for report in files:
+            if report == 'pylint.txt':
+                report = os.path.join(directory, report)
+                reports.append(report)
+    return reports
+
+
+def get_python_path(*services):
+    paths = [
+        '${PYTHONPATH}',
+        'common/lib',
+        'common/djangoapps',
+    ]
+    for service in services:
+        paths.extend([
+            service,
+            os.path.join(service, 'lib'),
+            os.path.join(service, 'djangoapps'),
+        ])
+    path = ':'.join(paths)
+    path = 'PYTHONPATH=' + path
+    return path

--- a/scripts/all-tests.sh
+++ b/scripts/all-tests.sh
@@ -61,7 +61,7 @@ git clean -qxfd
 source scripts/jenkins-common.sh
 
 # Violations thresholds for failing the build
-PYLINT_THRESHOLD=5800
+PYLINT_THRESHOLD=9500
 
 # If the environment variable 'SHARD' is not set, default to 'all'.
 # This could happen if you are trying to use this script from


### PR DESCRIPTION
This refactors paver's quality commands by splitting out and sharing code.

By default, quality checks are now performed against all top-level Python directories.

In the process, it was discovered that Pylint had already been under-reporting the count. Combined with the newly scanned directories, the total Pylint violation count jumped to ~9400.
