### PR TITLE
Revert "To support UNICODE xblock.location"

### DIFF
--- a/cms/djangoapps/contentstore/views/helpers.py
+++ b/cms/djangoapps/contentstore/views/helpers.py
@@ -110,7 +110,7 @@ def xblock_studio_url(xblock, parent_xblock=None):
     elif category in ('chapter', 'sequential'):
         return u'{url}?show={usage_key}'.format(
             url=reverse_course_url('course_handler', xblock.location.course_key),
-            usage_key=urllib.quote(unicode(xblock.location).encode('utf8'))
+            usage_key=urllib.quote(unicode(xblock.location))
         )
     elif category == 'library':
         library_key = xblock.location.course_key

--- a/cms/djangoapps/contentstore/views/tests/test_helpers.py
+++ b/cms/djangoapps/contentstore/views/tests/test_helpers.py
@@ -5,8 +5,6 @@ Unit tests for helpers.py.
 from contentstore.tests.utils import CourseTestCase
 from contentstore.views.helpers import xblock_studio_url, xblock_type_display_name
 from xmodule.modulestore.tests.factories import ItemFactory, LibraryFactory
-from xmodule.modulestore.xml import XMLModuleStore
-from xmodule.tests import DATA_DIR
 from django.utils import http
 
 
@@ -56,17 +54,6 @@ class HelpersTestCase(CourseTestCase):
         library = LibraryFactory.create()
         expected_url = u'/library/{}'.format(unicode(library.location.library_key))
         self.assertEqual(xblock_studio_url(library), expected_url)
-
-    def test_unicode_xblock_studio_url(self):
-
-        #import unicode course
-        modulestore = XMLModuleStore(DATA_DIR, course_dirs=['2014_Uni'])
-        courses = modulestore.get_courses()
-        course = courses[0]
-
-        # Verify course URL
-        course_url = http.urlquote('/course/{}'.format(course.id))
-        self.assertEqual(xblock_studio_url(course), course_url)
 
     def test_xblock_type_display_name(self):
 


### PR DESCRIPTION
Reverts edx/edx-platform#6167

Master is failing. Reproducible with `paver test_system -t cms/djangoapps/contentstore/views/tests/test_helpers.py:HelpersTestCase.test_unicode_xblock_studio_url`

@sarina 
