### PR TITLE
pass opts From PythonTestSuite to NoseTestSuite

### DIFF
--- a/pavelib/utils/test/suites/python_suite.py
+++ b/pavelib/utils/test/suites/python_suite.py
@@ -14,9 +14,8 @@ class PythonTestSuite(TestSuite):
     """
     def __init__(self, *args, **kwargs):
         super(PythonTestSuite, self).__init__(*args, **kwargs)
+        self.opts = kwargs
         self.fasttest = kwargs.get('fasttest', False)
-        self.failed_only = kwargs.get('failed_only', None)
-        self.fail_fast = kwargs.get('fail_fast', None)
         self.subsuites = kwargs.get('subsuites', self._default_subsuites)
 
     def __enter__(self):
@@ -30,19 +29,13 @@ class PythonTestSuite(TestSuite):
         The default subsuites to be run. They include lms, cms,
         and all of the libraries in common/lib.
         """
-        opts = {
-            'failed_only': self.failed_only,
-            'fail_fast': self.fail_fast,
-            'fasttest': self.fasttest,
-        }
-
         lib_suites = [
-            LibTestSuite(d, **opts) for d in Env.LIB_TEST_DIRS
+            LibTestSuite(d, **self.opts) for d in Env.LIB_TEST_DIRS
         ]
 
         system_suites = [
-            SystemTestSuite('cms', **opts),
-            SystemTestSuite('lms', **opts),
+            SystemTestSuite('cms', **self.opts),
+            SystemTestSuite('lms', **self.opts),
         ]
 
         return system_suites + lib_suites


### PR DESCRIPTION
@benpatterson @nedbat 

This is a follow up to Ned's report that `--extra_args` doesn't work for `paver test_python`.
