### PR TITLE
Fix test_instructor_dashboard.py tests

### DIFF
--- a/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
+++ b/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
@@ -25,6 +25,7 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase):
         """
         Set up tests
         """
+        super(TestInstructorDashboard, self).setUp()
         self.course = CourseFactory.create()
 
         self.course_mode = CourseMode(course_id=self.course.id,
@@ -76,7 +77,7 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase):
         CourseFinanceAdminRole(self.course.id).add_users(self.instructor)
         total_amount = PaidCourseRegistration.get_total_amount_of_purchased_item(self.course.id)
         response = self.client.get(self.url)
-        self.assertTrue('{currency}{amount}'.format(currency='Rs', amount=total_amount) in response.content)
+        self.assertIn('{currency}{amount}'.format(currency='Rs', amount=total_amount), response.content)
 
     @patch.dict(settings.FEATURES, {'DISPLAY_ANALYTICS_ENROLLMENTS': False})
     @override_settings(ANALYTICS_DASHBOARD_URL='')

--- a/lms/templates/instructor/instructor_dashboard_2/e-commerce.html
+++ b/lms/templates/instructor/instructor_dashboard_2/e-commerce.html
@@ -64,7 +64,7 @@
          <h2>${_("Sales")}</h2>
          <div>
             %if section_data['total_amount'] is not None:
-              <span><strong>${_("Total Credit Card Purchases: ")}</strong></span><span>$${section_data['total_amount']}</span>
+              <span><strong>${_("Total Credit Card Purchases: ")}</strong></span><span>${section_data['currency_symbol']}${section_data['total_amount']}</span>
             %endif
             <span class="csv_tip">
               <div>


### PR DESCRIPTION
This file was never run, because of a missing `__init__.py`.  It needs a
super() call to make the ModuleStoreTestCase work properly.

Then one test failed, because of a missed change from dollar to
configurable currency.
