### PR TITLE
Keep platform_name in the password_reset_confirm.html always TNL-1654

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1846,6 +1846,7 @@ def password_reset_confirm_wrapper(
             'form': None,
             'title': _('Password reset unsuccessful'),
             'err_msg': err_msg,
+            'platform_name': settings.PLATFORM_NAME,
         }
         return TemplateResponse(request, 'registration/password_reset_confirm.html', context)
     else:


### PR DESCRIPTION
This fixes [platform_name disappears in the password_reset_confirm.html - TNL-1654](https://openedx.atlassian.net/browse/TNL-1654).

The bug can be verified by using the following settings locally:

```
diff --git a/lms/envs/devstack.py b/lms/envs/devstack.py
index 6cdbe07..65943f8 100644
--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -101,12 +101,12 @@ FEATURES['ENABLE_MOBILE_REST_API'] = True
 FEATURES['ENABLE_VIDEO_ABSTRACTION_LAYER_API'] = True

 ########################## SECURITY #######################
-FEATURES['ENFORCE_PASSWORD_POLICY'] = False
+FEATURES['ENFORCE_PASSWORD_POLICY'] = True
 FEATURES['ENABLE_MAX_FAILED_LOGIN_ATTEMPTS'] = False
 FEATURES['SQUELCH_PII_IN_LOGS'] = False
 FEATURES['PREVENT_CONCURRENT_LOGINS'] = False
 FEATURES['ADVANCED_SECURITY'] = False
-PASSWORD_MIN_LENGTH = None
+PASSWORD_MIN_LENGTH = 8
 PASSWORD_COMPLEXITY = {}
```
