### PR TITLE
Remove use of to_deprecated_string in sandbox regex check.

### DIFF
--- a/common/djangoapps/util/sandboxing.py
+++ b/common/djangoapps/util/sandboxing.py
@@ -25,7 +25,7 @@ def can_execute_unsafe_code(course_id):
     # To others using this: the code as-is is brittle and likely to be changed in the future,
     # as per the TODO, so please consider carefully before adding more values to COURSES_WITH_UNSAFE_CODE
     for regex in getattr(settings, 'COURSES_WITH_UNSAFE_CODE', []):
-        if re.match(regex, course_id.to_deprecated_string()):
+        if re.match(regex, unicode(course_id)):
             return True
     return False
 

--- a/common/djangoapps/util/tests/test_sandboxing.py
+++ b/common/djangoapps/util/tests/test_sandboxing.py
@@ -3,6 +3,7 @@ Tests for sandboxing.py in util app
 """
 
 from django.test import TestCase
+from opaque_keys.edx.locator import LibraryLocator
 from util.sandboxing import can_execute_unsafe_code
 from django.test.utils import override_settings
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
@@ -12,12 +13,13 @@ class SandboxingTest(TestCase):
     """
     Test sandbox whitelisting
     """
-    @override_settings(COURSES_WITH_UNSAFE_CODE=['edX/full/.*'])
+    @override_settings(COURSES_WITH_UNSAFE_CODE=['edX/full/.*', 'library:v1-edX+.*'])
     def test_sandbox_exclusion(self):
         """
         Test to make sure that a non-match returns false
         """
         self.assertFalse(can_execute_unsafe_code(SlashSeparatedCourseKey('edX', 'notful', 'empty')))
+        self.assertFalse(can_execute_unsafe_code(LibraryLocator('edY', 'test_bank')))
 
     @override_settings(COURSES_WITH_UNSAFE_CODE=['edX/full/.*'])
     def test_sandbox_inclusion(self):
@@ -26,10 +28,12 @@ class SandboxingTest(TestCase):
         """
         self.assertTrue(can_execute_unsafe_code(SlashSeparatedCourseKey('edX', 'full', '2012_Fall')))
         self.assertTrue(can_execute_unsafe_code(SlashSeparatedCourseKey('edX', 'full', '2013_Spring')))
+        self.assertFalse(can_execute_unsafe_code(LibraryLocator('edX', 'test_bank')))
 
-    def test_courses_with_unsafe_code_default(self):
+    def test_courselikes_with_unsafe_code_default(self):
         """
         Test that the default setting for COURSES_WITH_UNSAFE_CODE is an empty setting, e.g. we don't use @override_settings in these tests
         """
         self.assertFalse(can_execute_unsafe_code(SlashSeparatedCourseKey('edX', 'full', '2012_Fall')))
         self.assertFalse(can_execute_unsafe_code(SlashSeparatedCourseKey('edX', 'full', '2013_Spring')))
+        self.assertFalse(can_execute_unsafe_code(LibraryLocator('edX', 'test_bank')))


### PR DESCRIPTION
**Description**: Resolves an issue where Libraries will fail to execute blocks with jailable Python if an installation has entries in COURSES_WITH_UNSAFE_CODE
**Jira ticket**: https://openedx.atlassian.net/browse/SOL-515

@raeeschachar @antoviaque Anyone else I should ping?
