### PR TITLE
Bypassing E-Commerce API if user is enrolled in course

### DIFF
--- a/lms/djangoapps/commerce/constants.py
+++ b/lms/djangoapps/commerce/constants.py
@@ -20,3 +20,4 @@ class Messages(object):
     ORDER_COMPLETED = u'Order {order_number} was completed.'
     ORDER_INCOMPLETE_ENROLLED = u'Order {order_number} was created, but is not yet complete. User was enrolled.'
     NO_HONOR_MODE = u'Course {course_id} does not have an honor mode.'
+    ENROLLMENT_EXISTS = u'User {username} is already enrolled in {course_id}.'


### PR DESCRIPTION
If a user is already enrolled in a course, the API is bypassed and a positive status is returned.

@rlucioni @dianakhuang @stephensanchez 
