### PR TITLE
Add missing import of override_settings to fix a broken test in courseware

### DIFF
--- a/lms/djangoapps/courseware/tests/test_footer.py
+++ b/lms/djangoapps/courseware/tests/test_footer.py
@@ -7,6 +7,7 @@ from mock import patch
 
 from django.conf import settings
 from django.test import TestCase
+from django.test.utils import override_settings
 
 
 class TestFooter(TestCase):


### PR DESCRIPTION
Not sure how this broke, since the tests passed in #7383.

@clytwynec 
