### PR TITLE
Make sure slashes in JSON content don't end script tags. PLAT-462

### DIFF
--- a/common/djangoapps/xmodule_modifiers.py
+++ b/common/djangoapps/xmodule_modifiers.py
@@ -113,11 +113,10 @@ def wrap_xblock(runtime_class, block, view, frag, context, usage_id_serializer, 
     }
 
     if hasattr(frag, 'json_init_args') and frag.json_init_args is not None:
-        template_context['js_init_parameters'] = json.dumps(frag.json_init_args)
-        template_context['js_pass_parameters'] = True
+        # Replace / with \/ so that "</script>" in the data won't break things.
+        template_context['js_init_parameters'] = json.dumps(frag.json_init_args).replace("/", r"\/")
     else:
         template_context['js_init_parameters'] = ""
-        template_context['js_pass_parameters'] = False
 
     return wrap_fragment(frag, render_to_string('xblock_wrapper.html', template_context))
 

--- a/common/templates/xblock_wrapper.html
+++ b/common/templates/xblock_wrapper.html
@@ -1,5 +1,5 @@
 <div class="${' '.join(classes) | n}" ${data_attributes}>
-% if js_pass_parameters:
+% if js_init_parameters:
   <script type="json/xblock-args" class="xblock_json_init_args">
     ${js_init_parameters}
   </script>


### PR DESCRIPTION
The string `"</script>"` in JSON data would end the script element we're
embedding the data in.  To make sure the data doesn't disrupt the
script, we escape the slash as `\/` .
