### PR TITLE
View discussion of user profile return 404

### DIFF
--- a/common/static/coffee/spec/discussion/view/discussion_thread_profile_view_spec.coffee
+++ b/common/static/coffee/spec/discussion/view/discussion_thread_profile_view_spec.coffee
@@ -18,6 +18,7 @@ describe "DiscussionThreadProfileView", ->
             body: "dummy body",
             discussion: new Discussion()
             abuse_flaggers: [],
+            commentable_id: 'dummy_discussion',
             votes: {up_count: "42"}
         }
         @imageTag = '<img src="https://www.google.com.pk/images/srpr/logo11w.png">'
@@ -111,3 +112,7 @@ describe "DiscussionThreadProfileView", ->
         for truncatedText in [true, false]
           it "body with #{numImages} images and #{if truncatedText then "truncated" else "untruncated"} text", ->
             checkPostWithImages(numImages, truncatedText, @threadData, @imageTag)
+
+      it "check the thread retrieve url", ->
+        thread = makeThread(@threadData)
+        expect(thread.urlFor('retrieve')).toBe('/courses/edX/999/test/discussion/forum/dummy_discussion/threads/1')

--- a/common/static/coffee/src/discussion/content.coffee
+++ b/common/static/coffee/src/discussion/content.coffee
@@ -126,7 +126,7 @@ if Backbone?
     
   class @Thread extends @Content
     urlMappers:
-      'retrieve'    : -> DiscussionUtil.urlFor('retrieve_single_thread', @discussion.id, @id)
+      'retrieve'    : -> DiscussionUtil.urlFor('retrieve_single_thread', @.get('commentable_id'), @id)
       'reply'       : -> DiscussionUtil.urlFor('create_comment', @id)
       'unvote'      : -> DiscussionUtil.urlFor("undo_vote_for_#{@get('type')}", @id)
       'upvote'      : -> DiscussionUtil.urlFor("upvote_#{@get('type')}", @id)


### PR DESCRIPTION
If you open a particular user profile page there
will be discussion where that user has collaborated.
If you click on view discussion link it would return
404 becuase of the missing discussion id in the link.
I fixed it by adding the thread commentable id to link
instead of getting the id from discussion object.

TNL-1717
