### PR TITLE
handle invalid-key exception for split courses

### DIFF
--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -134,6 +134,10 @@ def course_image_url(course):
             url += '/' + course.course_image
         else:
             url += '/images/course_image.jpg'
+    elif course.course_image == '':
+        # if course_image is empty the url will be blank as location
+        # of the course_image does not exist
+        url = ''
     else:
         loc = StaticContent.compute_location(course.id, course.course_image)
         url = StaticContent.serialize_asset_key_with_slash(loc)

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -529,6 +529,7 @@ class TestTOC(ModuleStoreTestCase):
                 self.assertIn(toc_section, actual)
 
 
+@ddt.ddt
 class TestHtmlModifiers(ModuleStoreTestCase):
     """
     Tests to verify that standard modifications to the output of XModule/XBlock
@@ -638,6 +639,17 @@ class TestHtmlModifiers(ModuleStoreTestCase):
         url = course_image_url(self.course)
         self.assertTrue(url.startswith('/static/toy_course_dir/'))
         self.course.static_asset_path = ""
+
+    @ddt.data(ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split)
+    def test_course_image_for_split_course(self, store):
+        """
+        for split courses if course_image is empty then course_image_url will be blank
+        """
+        self.course = CourseFactory.create(default_store=store)
+        self.course.course_image = ''
+
+        url = course_image_url(self.course)
+        self.assertEqual('', url)
 
     def test_get_course_info_section(self):
         self.course.static_asset_path = "toy_course_dir"


### PR DESCRIPTION
[PLAT-466](https://openedx.atlassian.net/browse/PLAT-466)

If course_image for split courses is blank then course_image_url will be empty instead of throwing 500 error
