### PR TITLE
Allow services to ignore user throttling. Set a more realistic throttle for users.

### DIFF
--- a/common/djangoapps/enrollment/views.py
+++ b/common/djangoapps/enrollment/views.py
@@ -24,12 +24,6 @@ from enrollment.errors import (
 )
 
 
-class EnrollmentUserThrottle(UserRateThrottle):
-    """Limit the number of requests users can make to the enrollment API."""
-    # TODO Limit significantly after performance testing.  # pylint: disable=fixme
-    rate = '50/second'
-
-
 class ApiKeyPermissionMixIn(object):
     """
     This mixin is used to provide a convenience function for doing individual permission checks
@@ -47,6 +41,14 @@ class ApiKeyPermissionMixIn(object):
             False otherwise
         """
         return ApiKeyHeaderPermission().has_permission(request, self)
+
+
+class EnrollmentUserThrottle(UserRateThrottle, ApiKeyPermissionMixIn):
+    """Limit the number of requests users can make to the enrollment API."""
+    rate = '40/minute'
+
+    def allow_request(self, request, view):
+        return self.has_api_key_permissions(request) or super(EnrollmentUserThrottle, self).allow_request(request, view)
 
 
 @can_disable_rate_limit


### PR DESCRIPTION
The throttle for the Enrollment API was set far too high (50/second). Changing this to a more reasonable throughput (40/minute) per user.  This should still be well beyond any current user activity.

Changed the throttle implementation on the enrollment API such that it will be ignored if the request is being made with the server token. This will prevent our Fulfillment API from getting bottlenecked by the Enrollment API throttle.

Tests were written, though based on performance of individual machines, these could be flakey. Given the new throttle (40/minute) most machines should be fine to run these, but looking for second opinions. I'd be fine dropping these tests and trusting DRF to throttle appropriately.

Review if able!
@dianakhuang @rlucioni @clintonb 
