### PR TITLE
Fix failing test due to change to the enrollment API

### DIFF
--- a/common/djangoapps/enrollment/tests/test_views.py
+++ b/common/djangoapps/enrollment/tests/test_views.py
@@ -558,7 +558,7 @@ class EnrollmentCrossDomainTest(ModuleStoreTestCase):
 
         # Expect that the request gets through successfully,
         # passing the CSRF checks (including the referer check).
-        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.status_code, 201)
 
     @cross_domain_config
     def test_cross_domain_missing_csrf(self, *args):  # pylint: disable=unused-argument


### PR DESCRIPTION
@brianhw This should fix the failing test case.

The failure was caused by a recent change to the enrollment API.  @stephensanchez will follow up to determine whether we want to keep this change or bump the version number to maintain backwards compatibility.
