### PR TITLE
Fix two content library analytics issues (SOL-521)

### DIFF
--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -133,6 +133,19 @@ class LibraryContentModule(LibraryContentFields, XModule, StudioEditableModule):
     as children of this block, but only a subset of those children are shown to
     any particular student.
     """
+
+    def _publish_event(self, event_name, result, **kwargs):
+        """ Helper method to publish an event for analytics purposes """
+        event_data = {
+            "location": unicode(self.location),
+            "result": result,
+            "previous_count": getattr(self, "_last_event_result_count", len(self.selected)),
+            "max_count": self.max_count,
+        }
+        event_data.update(kwargs)
+        self.runtime.publish(self, "edx.librarycontentblock.content.{}".format(event_name), event_data)
+        self._last_event_result_count = len(result)  # pylint: disable=attribute-defined-outside-init
+
     def selected_children(self):
         """
         Returns a set() of block_ids indicating which of the possible children
@@ -149,21 +162,9 @@ class LibraryContentModule(LibraryContentFields, XModule, StudioEditableModule):
             return self._selected_set  # pylint: disable=access-member-before-definition
 
         selected = set(tuple(k) for k in self.selected)  # set of (block_type, block_id) tuples assigned to this student
-        previous_count = len(selected)
 
         lib_tools = self.runtime.service(self, 'library_tools')
         format_block_keys = lambda keys: lib_tools.create_block_analytics_summary(self.location.course_key, keys)
-
-        def publish_event(event_name, **kwargs):
-            """ Publish an event for analytics purposes """
-            event_data = {
-                "location": unicode(self.location),
-                "result": format_block_keys(selected),
-                "previous_count": previous_count,
-                "max_count": self.max_count,
-            }
-            event_data.update(kwargs)
-            self.runtime.publish(self, "edx.librarycontentblock.content.{}".format(event_name), event_data)
 
         # Determine which of our children we will show:
         valid_block_keys = set([(c.block_type, c.block_id) for c in self.children])  # pylint: disable=no-member
@@ -173,14 +174,24 @@ class LibraryContentModule(LibraryContentFields, XModule, StudioEditableModule):
             selected -= invalid_block_keys
             # Publish an event for analytics purposes:
             # reason "invalid" means deleted from library or a different library is now being used.
-            publish_event("removed", removed=format_block_keys(invalid_block_keys), reason="invalid")
+            self._publish_event(
+                "removed",
+                result=format_block_keys(selected),
+                removed=format_block_keys(invalid_block_keys),
+                reason="invalid"
+            )
         # If max_count has been decreased, we may have to drop some previously selected blocks:
         overlimit_block_keys = set()
         while len(selected) > self.max_count:
             overlimit_block_keys.add(selected.pop())
         if overlimit_block_keys:
             # Publish an event for analytics purposes:
-            publish_event("removed", removed=format_block_keys(overlimit_block_keys), reason="overlimit")
+            self._publish_event(
+                "removed",
+                result=format_block_keys(selected),
+                removed=format_block_keys(overlimit_block_keys),
+                reason="overlimit"
+            )
         # Do we have enough blocks now?
         num_to_add = self.max_count - len(selected)
         if num_to_add > 0:
@@ -196,7 +207,11 @@ class LibraryContentModule(LibraryContentFields, XModule, StudioEditableModule):
             selected |= added_block_keys
             if added_block_keys:
                 # Publish an event for analytics purposes:
-                publish_event("assigned", added=format_block_keys(added_block_keys))
+                self._publish_event(
+                    "assigned",
+                    result=format_block_keys(selected),
+                    added=format_block_keys(added_block_keys)
+                )
         # Save our selections to the user state, to ensure consistency:
         self.selected = list(selected)  # TODO: this doesn't save from the LMS "Progress" page.
         # Cache the results

--- a/common/lib/xmodule/xmodule/modulestore/__init__.py
+++ b/common/lib/xmodule/xmodule/modulestore/__init__.py
@@ -327,6 +327,8 @@ class EditInfo(object):
         # User ID which changed this XBlock last.
         self.edited_by = edit_info.get('edited_by', None)
 
+        # If this block has been copied from a library using copy_from_template,
+        # these fields point to the original block in the library, for analytics.
         self.original_usage = edit_info.get('original_usage', None)
         self.original_usage_version = edit_info.get('original_usage_version', None)
 

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
@@ -2286,9 +2286,7 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
             new_block_info.fields = existing_block_info.fields  # Preserve any existing overrides
             if 'children' in new_block_info.defaults:
                 del new_block_info.defaults['children']  # Will be set later
-            # ALERT! Why was this 'block_id' stored here? Nothing else stores block_id
-            # in the block data. Was this a harmless error?
-            #new_block_info['block_id'] = new_block_key.id
+
             new_block_info.edit_info = existing_block_info.edit_info
             new_block_info.edit_info.previous_version = new_block_info.edit_info.update_version
             new_block_info.edit_info.update_version = dest_structure['_id']
@@ -2922,6 +2920,10 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
                 raw=True,
                 block_defaults=new_block.defaults
             )
+            # Extend the block's new edit_info with any extra edit_info fields from the source (e.g. original_usage):
+            for key, val in new_block.edit_info.to_storable().iteritems():
+                if getattr(destination_block.edit_info, key) is None:
+                    setattr(destination_block.edit_info, key, val)
 
         # introduce new edit info field for tracing where copied/published blocks came
         destination_block.edit_info.source_version = new_block.edit_info.update_version


### PR DESCRIPTION
**Description**: This resolves [SOL-521](https://openedx.atlassian.net/browse/SOL-521) by fixing the following two issues:
- Some analytics events emitted by randomized content blocks were missing the important `original_usage_key` values.
- If a randomized content block emitted a `removed` and `assigned` event as part of a single "refresh" of the content, the `previous_count` was not updated in between the events.

The main problem was the split modulestore's "publish" method would not preserve the `["edit_info"]["original_usage"]` field when first publishing a block. It was only present on blocks that were published multiple times.

**Discussions**: Discussed with @stroilova, @marcotuts, @smagoun, and @antoviaque 

**Dependencies**: None

**Sandbox URL**: No user-visible changes. Includes a new test to verify the fix, however.

**Partner information**: 3rd party-hosted open edX instance, for an edX solutions client.

**Manual testing**: To test manually on a devstack, as the `vagrant` user start the command `tail -f /edx/var/log/tracking/tracking.log |grep librarycontentblock`, then create and publish a randomized content block in studio with at least one problem. When you view that block in the LMS, an analytics event will be emitted. If the fix worked, it should contain the `original_usage_key` information.
