### PR TITLE
Update path.py to version 7.2

### DIFF
--- a/docs/shared/requirements.txt
+++ b/docs/shared/requirements.txt
@@ -42,7 +42,7 @@ networkx==1.7
 nltk==2.0.4
 oauthlib==0.6.3
 paramiko==1.9.0
-path.py==3.0.1
+path.py==7.2
 Pillow==2.6.1
 pip>=1.3
 polib==1.0.3

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -60,7 +60,7 @@ nltk==2.0.4
 nose==1.3.3
 oauthlib==0.6.3
 paramiko==1.9.0
-path.py==3.0.1
+path.py==7.2
 Pillow==2.7.0
 polib==1.0.3
 pycrypto>=2.6

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -2,6 +2,6 @@
 Paver==1.2.1
 psutil==1.2.1
 lazy==1.1
-path.py==3.0.1
+path.py==7.2
 watchdog==0.7.1
 python-memcached


### PR DESCRIPTION
[ChangeLog is here.](https://github.com/jaraco/path.py/blob/master/CHANGES.rst) The impetus for this upgrade is due to the following warning we get when trying to install requirements from github:

```
DEPRECATION: Uninstalling a distutils installed project (path.py) has been deprecated and will be removed in a future version. This is due to the fact that uninstalling a distutils project will only partially uninstall the project.
```

`path.py` is used throughout our codebase -- searching for `import path` reveals over 50 usages. Fortunately, it hasn't changed much over time, according to the [changelog](https://github.com/jaraco/path.py/blob/master/CHANGES.rst). This module is covered by our tests, since we have tests for at least some of the places where its called, and the module isn't being stubbed out. Upgrade impact should be minimal -- I don't expect anyone to even notice.
