### PR TITLE
XCOM-147: Change error handling to report back internal errors.

### DIFF
--- a/lms/djangoapps/commerce/http.py
+++ b/lms/djangoapps/commerce/http.py
@@ -1,6 +1,6 @@
 """ HTTP-related entities. """
 
-from rest_framework.status import HTTP_503_SERVICE_UNAVAILABLE, HTTP_200_OK
+from rest_framework.status import HTTP_500_INTERNAL_SERVER_ERROR, HTTP_200_OK
 
 from util.json_request import JsonResponse
 
@@ -13,9 +13,13 @@ class DetailResponse(JsonResponse):
         super(DetailResponse, self).__init__(object=data, status=status)
 
 
-class ApiErrorResponse(DetailResponse):
-    """ Response returned when calls to the E-Commerce API fail or the returned data is invalid. """
+class InternalRequestErrorResponse(DetailResponse):
+    """ Response returned when an internal service request fails. """
 
-    def __init__(self):
-        message = 'Call to E-Commerce API failed. Order creation failed.'
-        super(ApiErrorResponse, self).__init__(message=message, status=HTTP_503_SERVICE_UNAVAILABLE)
+    def __init__(self, internal_message, internal_status):
+        message = (
+            'Call to E-Commerce API failed. Internal Request Status Code: '
+            '[{internal_status}], Internal Service Message: [{internal_message}]'
+            .format(internal_status=internal_status, internal_message=internal_message)
+        )
+        super(InternalRequestErrorResponse, self).__init__(message=message, status=HTTP_500_INTERNAL_SERVER_ERROR)

--- a/lms/djangoapps/commerce/http.py
+++ b/lms/djangoapps/commerce/http.py
@@ -16,10 +16,9 @@ class DetailResponse(JsonResponse):
 class InternalRequestErrorResponse(DetailResponse):
     """ Response returned when an internal service request fails. """
 
-    def __init__(self, internal_message, internal_status):
+    def __init__(self, internal_message):
         message = (
-            'Call to E-Commerce API failed. Internal Request Status Code: '
-            '[{internal_status}], Internal Service Message: [{internal_message}]'
-            .format(internal_status=internal_status, internal_message=internal_message)
+            'Call to E-Commerce API failed. Internal Service Message: [{internal_message}]'
+            .format(internal_message=internal_message)
         )
         super(InternalRequestErrorResponse, self).__init__(message=message, status=HTTP_500_INTERNAL_SERVER_ERROR)

--- a/lms/djangoapps/commerce/tests/test_views.py
+++ b/lms/djangoapps/commerce/tests/test_views.py
@@ -48,12 +48,11 @@ class OrdersViewTests(EnrollmentEventTestMixin, EcommerceApiTestMixin, ModuleSto
         actual = json.loads(response.content)['detail']
         self.assertEqual(actual, expected_msg)
 
-    def assertValidEcommerceInternalRequestErrorResponse(self, response, internal_status):
+    def assertValidEcommerceInternalRequestErrorResponse(self, response):
         """ Asserts the response is a valid response sent when the E-Commerce API is unavailable. """
         self.assertEqual(response.status_code, 500)
         actual = json.loads(response.content)['detail']
         self.assertIn('Call to E-Commerce API failed', actual)
-        self.assertIn(str(internal_status), actual)
 
     def assertUserNotEnrolled(self):
         """ Asserts that the user is NOT enrolled in the course, and that an enrollment event was NOT fired. """
@@ -114,7 +113,7 @@ class OrdersViewTests(EnrollmentEventTestMixin, EcommerceApiTestMixin, ModuleSto
         with self.mock_create_order(side_effect=TimeoutError):
             response = self._post_to_view()
 
-        self.assertValidEcommerceInternalRequestErrorResponse(response, 408)
+        self.assertValidEcommerceInternalRequestErrorResponse(response)
         self.assertUserNotEnrolled()
 
     def test_ecommerce_api_error(self):
@@ -124,7 +123,7 @@ class OrdersViewTests(EnrollmentEventTestMixin, EcommerceApiTestMixin, ModuleSto
         with self.mock_create_order(side_effect=ApiError):
             response = self._post_to_view()
 
-        self.assertValidEcommerceInternalRequestErrorResponse(response, 500)
+        self.assertValidEcommerceInternalRequestErrorResponse(response)
         self.assertUserNotEnrolled()
 
     def _test_successful_ecommerce_api_call(self):

--- a/lms/djangoapps/commerce/views.py
+++ b/lms/djangoapps/commerce/views.py
@@ -10,7 +10,7 @@ from rest_framework.views import APIView
 from commerce.api import EcommerceAPI
 from commerce.constants import OrderStatus, Messages
 from commerce.exceptions import ApiError, InvalidConfigurationError
-from commerce.http import DetailResponse, ApiErrorResponse
+from commerce.http import DetailResponse, InternalRequestErrorResponse
 from course_modes.models import CourseMode
 from courseware import courses
 from enrollment.api import add_enrollment
@@ -120,6 +120,6 @@ class OrdersView(APIView):
 
                 msg = Messages.ORDER_INCOMPLETE_ENROLLED.format(order_number=order_number)
                 return DetailResponse(msg, status=HTTP_202_ACCEPTED)
-        except ApiError:
+        except ApiError as err:
             # The API will handle logging of the error.
-            return ApiErrorResponse()
+            return InternalRequestErrorResponse(err.message)


### PR DESCRIPTION
This is related to JIRA Ticket: https://openedx.atlassian.net/browse/XCOM-147
Originally, our errors from the new commerce endpoint in the LMS were returning 503 when there was an error with the internal request to the E-Commerce Service. This change is designed to retain some additional information about the underlying request failures.

I wanted to be careful to not just simply propagate the response code from the internal request. Saying that the LMS commerce end point 'timed out' because the E-Commerce end point did, would end up being pretty confusing. Instead, I added the internal response message and status code to the error message. 

Thoughts?
@clintonb @rlucioni  
