### PR TITLE
Course info page no longer creates enrollments.

### DIFF
--- a/lms/djangoapps/courseware/views.py
+++ b/lms/djangoapps/courseware/views.py
@@ -665,7 +665,6 @@ def course_info(request, course_id):
 
     Assumes the course_id is in a valid format.
     """
-
     course_key = SlashSeparatedCourseKey.from_deprecated_string(course_id)
 
     with modulestore().bulk_operations(course_key):
@@ -1078,11 +1077,12 @@ def fetch_reverify_banner_info(request, course_key):
     user = request.user
     if not user.id:
         return reverifications
-    enrollment = CourseEnrollment.get_or_create_enrollment(request.user, course_key)
-    course = modulestore().get_course(course_key)
-    info = single_course_reverification_info(user, course, enrollment)
-    if info:
-        reverifications[info.status].append(info)
+    enrollment = CourseEnrollment.get_enrollment(request.user, course_key)
+    if enrollment is not None:
+        course = modulestore().get_course(course_key)
+        info = single_course_reverification_info(user, course, enrollment)
+        if info:
+            reverifications[info.status].append(info)
     return reverifications
 
 


### PR DESCRIPTION
The course info page was getting-or-creating a course enrollment with is_active=0.  This commit changes the operation to a "get" so that extra enrollment records are not created.

JIRA: [ECOM-1229](https://openedx.atlassian.net/browse/ECOM-1229)
