### PR TITLE
Implement parental controls for the User API

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/serializers.py
+++ b/openedx/core/djangoapps/user_api/accounts/serializers.py
@@ -25,16 +25,17 @@ class AccountLegacyProfileSerializer(serializers.HyperlinkedModelSerializer, Rea
     Class that serializes the portion of UserProfile model needed for account information.
     """
     profile_image = serializers.SerializerMethodField("get_profile_image")
+    requires_parental_consent = serializers.SerializerMethodField("get_requires_parental_consent")
 
     class Meta:
         model = UserProfile
         fields = (
             "name", "gender", "goals", "year_of_birth", "level_of_education", "language", "country",
-            "mailing_address", "bio", "profile_image"
+            "mailing_address", "bio", "profile_image", "requires_parental_consent",
         )
         # Currently no read-only field, but keep this so view code doesn't need to know.
         read_only_fields = ()
-        explicit_read_only_fields = ("profile_image",)
+        explicit_read_only_fields = ("profile_image", "requires_parental_consent")
 
     def validate_name(self, attrs, source):
         """ Enforce minimum length for name. """
@@ -48,15 +49,15 @@ class AccountLegacyProfileSerializer(serializers.HyperlinkedModelSerializer, Rea
 
         return attrs
 
-    def transform_gender(self, obj, value):
+    def transform_gender(self, user_profile, value):
         """ Converts empty string to None, to indicate not set. Replaced by to_representation in version 3. """
         return AccountLegacyProfileSerializer.convert_empty_to_None(value)
 
-    def transform_country(self, obj, value):
+    def transform_country(self, user_profile, value):
         """ Converts empty string to None, to indicate not set. Replaced by to_representation in version 3. """
         return AccountLegacyProfileSerializer.convert_empty_to_None(value)
 
-    def transform_level_of_education(self, obj, value):
+    def transform_level_of_education(self, user_profile, value):
         """ Converts empty string to None, to indicate not set. Replaced by to_representation in version 3. """
         return AccountLegacyProfileSerializer.convert_empty_to_None(value)
 
@@ -65,12 +66,16 @@ class AccountLegacyProfileSerializer(serializers.HyperlinkedModelSerializer, Rea
         """ Helper method to convert empty string to None (other values pass through). """
         return None if value == "" else value
 
-    def get_profile_image(self, obj):
+    def get_profile_image(self, user_profile):
         """ Returns metadata about a user's profile image. """
-        data = {'has_image': obj.has_profile_image}
+        data = {'has_image': user_profile.has_profile_image}
         data.update({
             '{image_key_prefix}_{size}'.format(image_key_prefix=PROFILE_IMAGE_KEY_PREFIX, size=size_display_name):
-            get_profile_image_url_for_user(obj.user, size_value)
+            get_profile_image_url_for_user(user_profile.user, size_value)
             for size_display_name, size_value in PROFILE_IMAGE_SIZES_MAP.items()
         })
         return data
+
+    def get_requires_parental_consent(self, user_profile):
+        """ Returns a boolean representing whether the user requires parental controls.  """
+        return user_profile.requires_parental_consent()

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
@@ -220,6 +220,7 @@ class AccountSettingsOnCreationTest(TestCase):
                 'image_url_full': 'http://example-storage.com/profile_images/default_50.jpg',
                 'image_url_small': 'http://example-storage.com/profile_images/default_10.jpg',
             },
+            'requires_parental_consent': True,
         })
 
 

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import datetime
 import ddt
 import hashlib
 import json
@@ -83,9 +84,10 @@ class UserAPITestCase(APITestCase):
         legacy_profile = UserProfile.objects.get(id=user.id)
         legacy_profile.country = "US"
         legacy_profile.level_of_education = "m"
-        legacy_profile.year_of_birth = 1900
+        legacy_profile.year_of_birth = 2000
         legacy_profile.goals = "world peace"
         legacy_profile.mailing_address = "Park Ave"
+        legacy_profile.gender = "f"
         legacy_profile.bio = "Tired mother of twins"
         legacy_profile.has_profile_image = True
         legacy_profile.save()
@@ -138,27 +140,27 @@ class TestAccountAPI(UserAPITestCase):
         self.assertIsNone(data["languages"])
         self.assertEqual("Tired mother of twins", data["bio"])
 
-    def _verify_private_account_response(self, response):
+    def _verify_private_account_response(self, response, requires_parental_consent=False):
         """
         Verify that only the public fields are returned if a user does not want to share account fields
         """
         data = response.data
         self.assertEqual(2, len(data))
         self.assertEqual(self.user.username, data["username"])
-        self._verify_profile_image_data(data, True)
+        self._verify_profile_image_data(data, not requires_parental_consent)
 
-    def _verify_full_account_response(self, response):
+    def _verify_full_account_response(self, response, requires_parental_consent=False):
         """
         Verify that all account fields are returned (even those that are not shareable).
         """
         data = response.data
-        self.assertEqual(14, len(data))
+        self.assertEqual(15, len(data))
         self.assertEqual(self.user.username, data["username"])
         self.assertEqual(self.user.first_name + " " + self.user.last_name, data["name"])
         self.assertEqual("US", data["country"])
         self.assertEqual("", data["language"])
-        self.assertEqual("m", data["gender"])
-        self.assertEqual(1900, data["year_of_birth"])
+        self.assertEqual("f", data["gender"])
+        self.assertEqual(2000, data["year_of_birth"])
         self.assertEqual("m", data["level_of_education"])
         self.assertEqual("world peace", data["goals"])
         self.assertEqual("Park Ave", data['mailing_address'])
@@ -166,7 +168,8 @@ class TestAccountAPI(UserAPITestCase):
         self.assertTrue(data["is_active"])
         self.assertIsNotNone(data["date_joined"])
         self.assertEqual("Tired mother of twins", data["bio"])
-        self._verify_profile_image_data(data, True)
+        self._verify_profile_image_data(data, not requires_parental_consent)
+        self.assertEquals(requires_parental_consent, data["requires_parental_consent"])
 
     def test_anonymous_access(self):
         """
@@ -268,7 +271,7 @@ class TestAccountAPI(UserAPITestCase):
         def verify_get_own_information():
             response = self.send_get(self.client)
             data = response.data
-            self.assertEqual(14, len(data))
+            self.assertEqual(15, len(data))
             self.assertEqual(self.user.username, data["username"])
             self.assertEqual(self.user.first_name + " " + self.user.last_name, data["name"])
             for empty_field in ("year_of_birth", "level_of_education", "mailing_address", "bio"):
@@ -282,6 +285,7 @@ class TestAccountAPI(UserAPITestCase):
             self.assertIsNotNone(data["date_joined"])
             self.assertEqual(self.user.is_active, data["is_active"])
             self._verify_profile_image_data(data, False)
+            self.assertTrue(data["requires_parental_consent"])
 
         self.client.login(username=self.user.username, password=self.test_password)
         verify_get_own_information()
@@ -405,8 +409,8 @@ class TestAccountAPI(UserAPITestCase):
                 "Field '{0}' cannot be edited.".format(field_name), data["field_errors"][field_name]["user_message"]
             )
 
-        for field_name in ["username", "date_joined", "is_active"]:
-            response = self.send_patch(client, {field_name: "will_error", "gender": "f"}, expected_status=400)
+        for field_name in ["username", "date_joined", "is_active", "profile_image", "requires_parental_consent"]:
+            response = self.send_patch(client, {field_name: "will_error", "gender": "o"}, expected_status=400)
             verify_error_response(field_name, response.data)
 
         # Make sure that gender did not change.
@@ -562,3 +566,48 @@ class TestAccountAPI(UserAPITestCase):
                 "image_url_small": "http://testserver/profile_images/default_10.jpg"
             }
         )
+
+    @ddt.data(
+        ("client", "user", True),
+        ("different_client", "different_user", False),
+        ("staff_client", "staff_user", True),
+    )
+    @ddt.unpack
+    def test_parental_consent(self, api_client, requesting_username, has_full_access):
+        """
+        Verifies that under thirteens never return a public profile.
+        """
+        client = self.login_client(api_client, requesting_username)
+
+        # Set the user to be ten years old with a public profile
+        legacy_profile = UserProfile.objects.get(id=self.user.id)
+        current_year = datetime.datetime.now().year
+        legacy_profile.year_of_birth = current_year - 10
+        legacy_profile.save()
+        set_user_preference(self.user, ACCOUNT_VISIBILITY_PREF_KEY, ALL_USERS_VISIBILITY)
+
+        # Verify that the default view is still private (except for clients with full access)
+        response = self.send_get(client)
+        if has_full_access:
+            data = response.data
+            self.assertEqual(15, len(data))
+            self.assertEqual(self.user.username, data["username"])
+            self.assertEqual(self.user.first_name + " " + self.user.last_name, data["name"])
+            self.assertEqual(self.user.email, data["email"])
+            self.assertEqual(current_year - 10, data["year_of_birth"])
+            for empty_field in ("country", "level_of_education", "mailing_address", "bio"):
+                self.assertIsNone(data[empty_field])
+            # TODO: what should the format of this be?
+            self.assertEqual("", data["language"])
+            self.assertEqual("m", data["gender"])
+            self.assertEqual("Learn a lot", data["goals"])
+            self.assertTrue(data["is_active"])
+            self.assertIsNotNone(data["date_joined"])
+            self._verify_profile_image_data(data, False)
+            self.assertTrue(data["requires_parental_consent"])
+        else:
+            self._verify_private_account_response(response, requires_parental_consent=True)
+
+        # Verify that the shared view is still private
+        response = self.send_get(client, query_parameters='view=shared')
+        self._verify_private_account_response(response, requires_parental_consent=True)

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -69,6 +69,15 @@ class AccountView(APIView):
 
                 * bio: null or textural representation of user biographical information ("about me")
 
+                * profile_image: a dict with the following keys describing the user's profile image
+                    * "has_image": true if the user has a profile image
+                    * "image_url_full": an absolute URL to the user's full profile image
+                    * "image_url_large": an absolute URL to a large thumbnail of the profile image
+                    * "image_url_medium": an absolute URL to a medium thumbnail of the profile image
+                    * "image_url_small": an absolute URL to a small thumbnail of the profile image
+
+                * requires_parental_consent: true if the user is a minor requiring parental consent
+
             For all text fields, clients rendering the values should take care to HTML escape them to avoid
             script injections, as the data is stored exactly as specified. The intention is that plain text is
             supported, not HTML.


### PR DESCRIPTION
https://openedx.atlassian.net/browse/TNL-1739

Updated the User API to make account settings private for all users who require parental consent. Also added a new "requires_parental_consent" boolean value to the API so that the Account Settings page can obey it appropriately.

@cahrens @dan-f please review.
