### PR TITLE
Docstring/messaging cleanup in self-generated certs view.

### DIFF
--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -876,7 +876,6 @@ class GenerateUserCertTests(ModuleStoreTestCase):
             mock_send_to_queue.return_value = (0, "Successfully queued")
             resp = self.client.post(self.url)
             self.assertEqual(resp.status_code, 200)
-            self.assertIn("Creating certificate", resp.content)
 
             #Verify Google Analytics event fired after generating certificate
             mock_tracker.track.assert_called_once_with(  # pylint: disable=no-member
@@ -906,7 +905,7 @@ class GenerateUserCertTests(ModuleStoreTestCase):
         )
         resp = self.client.post(self.url)
         self.assertEqual(resp.status_code, HttpResponseBadRequest.status_code)
-        self.assertIn("Creating certificate", resp.content)
+        self.assertIn("Certificate is already being created.", resp.content)
 
     @patch('courseware.grades.grade', Mock(return_value={'grade': 'Pass', 'percent': 0.75}))
     def test_user_with_passing_existing_downloadable_cert(self):
@@ -920,7 +919,7 @@ class GenerateUserCertTests(ModuleStoreTestCase):
         )
         resp = self.client.post(self.url)
         self.assertEqual(resp.status_code, HttpResponseBadRequest.status_code)
-        self.assertIn("Creating certificate", resp.content)
+        self.assertIn("Certificate has already been created.", resp.content)
 
     def test_user_with_non_existing_course(self):
         # If try to access a course with valid key pattern then it will return

--- a/lms/static/js/courseware/certificates_api.js
+++ b/lms/static/js/courseware/certificates_api.js
@@ -1,4 +1,6 @@
 $(document).ready(function() {
+    'use strict';
+
     $("#btn_generate_cert").click(function(e){
         e.preventDefault();
         var post_url = $("#btn_generate_cert").data("endpoint");


### PR DESCRIPTION
Small cleanup to clarify the behavior of the POST request to start generating a certificate from the progress page.
- There was a 400 response with content "Creating Certificate".  Users would have to POST directly to the end-point to see this error, but I thought it was still pretty confusing to have a 400 request with a message that seems like a success.  I've changed the message to indicate that the 400 is because certificates are _already_ being generated.
- I updated docstrings and comments in places where I felt they were unclear or inaccurate.
- I added 'use strict' to the JavaScript, because it's the Right Thing To Do.

@rlucioni Please review when you have a moment.
