### PR TITLE
Change how conf/locale/eo is cleaned up, so that it happens when needed

### DIFF
--- a/common/lib/i18n/tests/test_extract_and_generate.py
+++ b/common/lib/i18n/tests/test_extract_and_generate.py
@@ -3,12 +3,13 @@ This test tests that i18n extraction (`paver i18n_extract -v`) works properly.
 """
 from datetime import datetime, timedelta
 import os
-import sys
-import string  # pylint: disable=deprecated-module
 import random
 import re
-
+import sys
+import string
+import subprocess
 from unittest import TestCase
+
 from mock import patch
 from polib import pofile
 from pytz import UTC
@@ -40,6 +41,16 @@ class TestGenerate(TestCase):
         sys.stderr.flush()
         extract.main(verbosity=0)
         dummy.main(verbosity=0)
+
+    @classmethod
+    def tearDownClass(cls):
+        # Clear the Esperanto directory of any test artifacts
+        cmd = "git checkout conf/locale/eo"
+        sys.stderr.write("Cleaning up eo: " + cmd)
+        sys.stderr.flush()
+        returncode = subprocess.call(cmd, shell=True)
+        assert returncode == 0
+        super(TestGenerate, cls).tearDownClass()
 
     def setUp(self):
         # Subtract 1 second to help comparisons with file-modify time succeed,

--- a/pavelib/tests.py
+++ b/pavelib/tests.py
@@ -115,9 +115,6 @@ def test_lib(options):
     test_suite = suites.PythonTestSuite('python tests', subsuites=lib_tests, **opts)
     test_suite.run()
 
-    # Clear the Esperanto directory of any test artifacts
-    sh('git checkout conf/locale/eo')
-
 
 @task
 @needs(


### PR DESCRIPTION
With the cleanup in pavelib where it was, it only got cleaned up if you used "paver test_lib".  Now it will be cleaned up however the test is run.  Additional benefit: we won't run the clean up if the i18n tests aren't run.

@sarina ikr?
