### PR TITLE
Capa problem type filtering via search index (SOL-286)

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_libraries.py
+++ b/cms/djangoapps/contentstore/tests/test_libraries.py
@@ -385,6 +385,7 @@ class TestLibraries(LibraryTestCase):
         html_block = modulestore().get_item(lc_block.children[0])
         self.assertEqual(html_block.data, data2)
 
+    @patch("xmodule.library_tools.SearchEngine.get_search_engine", Mock(return_value=None))
     def test_refreshes_children_if_capa_type_change(self):
         """ Tests that children are automatically refreshed if capa type field changes """
         name1, name2 = "Option Problem", "Multiple Choice Problem"

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -22,7 +22,7 @@ from edxmako.shortcuts import render_to_response
 from xmodule.course_module import DEFAULT_START_DATE
 from xmodule.error_module import ErrorDescriptor
 from xmodule.modulestore.django import modulestore
-from xmodule.modulestore.courseware_index import CoursewareSearchIndexer, SearchIndexingError
+from xmodule.modulestore.search_index import get_indexer_for_location, SearchIndexingError
 from xmodule.contentstore.content import StaticContent
 from xmodule.tabs import PDFTextbookTabs
 from xmodule.partitions.partitions import UserPartition
@@ -137,7 +137,8 @@ def reindex_course_and_check_access(course_key, user):
     """
     if not has_course_author_access(user, course_key):
         raise PermissionDenied()
-    return CoursewareSearchIndexer.do_course_reindex(modulestore(), course_key)
+    indexer = get_indexer_for_location(course_key)
+    return indexer.do_course_reindex(modulestore(), course_key)
 
 
 @login_required

--- a/cms/djangoapps/contentstore/views/tests/test_course_index.py
+++ b/cms/djangoapps/contentstore/views/tests/test_course_index.py
@@ -382,18 +382,20 @@ class TestCourseReIndex(CourseTestCase):
         # create test file in which index for this test will live
         with open(self.TEST_INDEX_FILENAME, "w+") as index_file:
             json.dump({}, index_file)
-            
+
         self.addCleanup(os.remove, self.TEST_INDEX_FILENAME)
 
-    def _perform_search(self):
+    def _perform_search(self, query="unique"):
+        """ Performs search """
         return perform_search(
-            "unique",
+            query,
             user=self.user,
             size=10,
             from_=0,
             course_id=unicode(self.course.id))
 
     def _do_reindex(self):
+        """ Reindexes course """
         indexer = get_indexer_for_location(self.course.id)
         return indexer.do_course_reindex(modulestore(), self.course.id)
 

--- a/cms/djangoapps/contentstore/views/tests/test_course_index.py
+++ b/cms/djangoapps/contentstore/views/tests/test_course_index.py
@@ -19,7 +19,6 @@ from xmodule.modulestore.search_index import get_indexer_for_location, SearchInd
 from xmodule.modulestore.exceptions import ItemNotFoundError
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, LibraryFactory
-from xmodule.modulestore.courseware_index import SearchIndexingError
 from opaque_keys.edx.locator import CourseLocator
 from student.tests.factories import UserFactory
 from course_action_state.managers import CourseRerunUIStateManager
@@ -389,7 +388,7 @@ class TestCourseReIndex(CourseTestCase):
         """ Performs search """
         return perform_search(
             query,
-            user=self.user,
+            user=self.user,  # pylint: disable=no-member
             size=10,
             from_=0,
             course_id=unicode(self.course.id))

--- a/cms/djangoapps/contentstore/views/tests/test_course_index.py
+++ b/cms/djangoapps/contentstore/views/tests/test_course_index.py
@@ -382,8 +382,16 @@ class TestCourseReIndex(CourseTestCase):
         # create test file in which index for this test will live
         with open(self.TEST_INDEX_FILENAME, "w+") as index_file:
             json.dump({}, index_file)
-
+            
         self.addCleanup(os.remove, self.TEST_INDEX_FILENAME)
+
+    def _perform_search(self):
+        return perform_search(
+            "unique",
+            user=self.user,
+            size=10,
+            from_=0,
+            course_id=unicode(self.course.id))
 
     def test_reindex_course(self):
         """
@@ -446,12 +454,7 @@ class TestCourseReIndex(CourseTestCase):
         Test json response with real data
         """
         # Check results not indexed
-        response = perform_search(
-            "unique",
-            user=self.user,
-            size=10,
-            from_=0,
-            course_id=unicode(self.course.id))
+        response = self._perform_search()
         self.assertEqual(response['results'], [])
 
         # Start manual reindex
@@ -464,12 +467,7 @@ class TestCourseReIndex(CourseTestCase):
         reindex_course_and_check_access(self.course.id, self.user)
 
         # Check results indexed now
-        response = perform_search(
-            "unique",
-            user=self.user,
-            size=10,
-            from_=0,
-            course_id=unicode(self.course.id))
+        response = self._perform_search()
         self.assertEqual(response['total'], 1)
 
     @mock.patch('xmodule.video_module.VideoDescriptor.index_dictionary')
@@ -478,12 +476,7 @@ class TestCourseReIndex(CourseTestCase):
         Test json response with mocked error data for video
         """
         # Check results not indexed
-        response = perform_search(
-            "unique",
-            user=self.user,
-            size=10,
-            from_=0,
-            course_id=unicode(self.course.id))
+        response = self._perform_search()
         self.assertEqual(response['results'], [])
 
         # set mocked exception response
@@ -500,12 +493,7 @@ class TestCourseReIndex(CourseTestCase):
         Test json response with mocked error data for html
         """
         # Check results not indexed
-        response = perform_search(
-            "unique",
-            user=self.user,
-            size=10,
-            from_=0,
-            course_id=unicode(self.course.id))
+        response = self._perform_search()
         self.assertEqual(response['results'], [])
 
         # set mocked exception response
@@ -522,12 +510,7 @@ class TestCourseReIndex(CourseTestCase):
         Test json response with mocked error data for sequence
         """
         # Check results not indexed
-        response = perform_search(
-            "unique",
-            user=self.user,
-            size=10,
-            from_=0,
-            course_id=unicode(self.course.id))
+        response = self._perform_search()
         self.assertEqual(response['results'], [])
 
         # set mocked exception response
@@ -562,12 +545,7 @@ class TestCourseReIndex(CourseTestCase):
         Test add_to_search_index response with real data
         """
         # Check results not indexed
-        response = perform_search(
-            "unique",
-            user=self.user,
-            size=10,
-            from_=0,
-            course_id=unicode(self.course.id))
+        response = self._perform_search()
         self.assertEqual(response['results'], [])
 
         # Start manual reindex
@@ -580,12 +558,7 @@ class TestCourseReIndex(CourseTestCase):
         CoursewareSearchIndexer.do_course_reindex(modulestore(), self.course.id)
 
         # Check results indexed now
-        response = perform_search(
-            "unique",
-            user=self.user,
-            size=10,
-            from_=0,
-            course_id=unicode(self.course.id))
+        response = self._perform_search()
         self.assertEqual(response['total'], 1)
 
     @mock.patch('xmodule.video_module.VideoDescriptor.index_dictionary')
@@ -594,12 +567,7 @@ class TestCourseReIndex(CourseTestCase):
         Test add_to_search_index response with mocked error data for video
         """
         # Check results not indexed
-        response = perform_search(
-            "unique",
-            user=self.user,
-            size=10,
-            from_=0,
-            course_id=unicode(self.course.id))
+        response = self._perform_search()
         self.assertEqual(response['results'], [])
 
         # set mocked exception response
@@ -616,12 +584,7 @@ class TestCourseReIndex(CourseTestCase):
         Test add_to_search_index response with mocked error data for html
         """
         # Check results not indexed
-        response = perform_search(
-            "unique",
-            user=self.user,
-            size=10,
-            from_=0,
-            course_id=unicode(self.course.id))
+        response = self._perform_search()
         self.assertEqual(response['results'], [])
 
         # set mocked exception response
@@ -638,12 +601,7 @@ class TestCourseReIndex(CourseTestCase):
         Test add_to_search_index response with mocked error data for sequence
         """
         # Check results not indexed
-        response = perform_search(
-            "unique",
-            user=self.user,
-            size=10,
-            from_=0,
-            course_id=unicode(self.course.id))
+        response = self._perform_search()
         self.assertEqual(response['results'], [])
 
         # set mocked exception response

--- a/common/lib/xmodule/xmodule/capa_module.py
+++ b/common/lib/xmodule/xmodule/capa_module.py
@@ -113,6 +113,7 @@ class CapaDescriptor(CapaFields, RawDescriptor):
     Module implementing problems in the LON-CAPA format,
     as implemented by capa.capa_problem
     """
+    INDEX_CONTENT_TYPE = 'CAPA'
 
     module_class = CapaModule
 
@@ -191,7 +192,14 @@ class CapaDescriptor(CapaFields, RawDescriptor):
         Return dictionary prepared with module content and type for indexing.
         """
         result = super(CapaDescriptor, self).index_dictionary()
-        result['problem_types'] = self.problem_types
+        if not result:
+            result = {}
+        index = {
+            'content_type': self.INDEX_CONTENT_TYPE,
+            'problem_types': list(self.problem_types),
+            "display_name": self.display_name
+        }
+        result.update(index)
         return result
 
     # Proxy to CapaModule for access to any of its attributes

--- a/common/lib/xmodule/xmodule/capa_module.py
+++ b/common/lib/xmodule/xmodule/capa_module.py
@@ -186,6 +186,14 @@ class CapaDescriptor(CapaFields, RawDescriptor):
         registered_tags = responsetypes.registry.registered_tags()
         return set([node.tag for node in tree.iter() if node.tag in registered_tags])
 
+    def index_dictionary(self):
+        """
+        Return dictionary prepared with module content and type for indexing.
+        """
+        result = super(CapaDescriptor, self).index_dictionary()
+        result['problem_types'] = self.problem_types
+        return result
+
     # Proxy to CapaModule for access to any of its attributes
     answer_available = module_attr('answer_available')
     check_button_name = module_attr('check_button_name')

--- a/common/lib/xmodule/xmodule/modulestore/mongo/draft.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/draft.py
@@ -12,7 +12,7 @@ import logging
 from opaque_keys.edx.locations import Location
 from xmodule.exceptions import InvalidVersionError
 from xmodule.modulestore import ModuleStoreEnum
-from xmodule.modulestore.courseware_index import get_indexer_for_location
+from xmodule.modulestore.search_index import get_indexer_for_location
 from xmodule.modulestore.exceptions import (
     ItemNotFoundError, DuplicateItemError, DuplicateCourseError, InvalidBranchSetting
 )

--- a/common/lib/xmodule/xmodule/modulestore/search_index.py
+++ b/common/lib/xmodule/xmodule/modulestore/search_index.py
@@ -160,7 +160,11 @@ class SearchIndexerBase(object):
                     for child_loc in item.children:
                         remove_index_item_location(child_loc)
 
-            searcher.remove(self.DOCUMENT_TYPE, unicode(self._id_modifier(item.scope_ids.usage_id)))
+                target_location = item.scope_ids.usage_id
+            else:
+                target_location = item_location
+
+            searcher.remove(self.DOCUMENT_TYPE, unicode(self._id_modifier(target_location)))
 
         try:
             if delete:

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split_draft.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split_draft.py
@@ -5,7 +5,7 @@ Module for the dual-branch fall-back Draft->Published Versioning ModuleStore
 from xmodule.modulestore.split_mongo.split import SplitMongoModuleStore, EXCLUDE_ALL
 from xmodule.exceptions import InvalidVersionError
 from xmodule.modulestore import ModuleStoreEnum
-from xmodule.modulestore.courseware_index import get_indexer_for_location
+from xmodule.modulestore.search_index import get_indexer_for_location
 from xmodule.modulestore.exceptions import InsufficientSpecificationError, ItemNotFoundError
 from xmodule.modulestore.draft_and_published import (
     ModuleStoreDraftAndPublished, DIRECT_ONLY_CATEGORIES, UnsupportedRevisionError
@@ -210,12 +210,6 @@ class DraftVersioningModuleStore(SplitMongoModuleStore, ModuleStoreDraftAndPubli
                     ]
                 )
 
-            # Remove this location from the search index so that searches
-            # will refrain from showing it as a result
-            indexer = get_indexer_for_location(location)
-            if indexer.index_on_delete:
-                indexer.add_to_search_index(self, location, delete=True)
-
             for branch in branches_to_delete:
                 branched_location = location.for_branch(branch)
                 parent_loc = self.get_parent_location(branched_location)
@@ -223,6 +217,12 @@ class DraftVersioningModuleStore(SplitMongoModuleStore, ModuleStoreDraftAndPubli
                 # publish parent w/o child if deleted element is direct only (not based on type of parent)
                 if branch == ModuleStoreEnum.BranchName.draft and branched_location.block_type in DIRECT_ONLY_CATEGORIES:
                     self.publish(parent_loc.version_agnostic(), user_id, blacklist=EXCLUDE_ALL, **kwargs)
+
+        # Remove this location from the search index so that searches
+        # will refrain from showing it as a result
+        indexer = get_indexer_for_location(location)
+        if indexer.index_on_delete:
+            indexer.add_to_search_index(self, location, delete=True)
 
     def _map_revision_to_branch(self, key, revision=None):
         """

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_search_index.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_search_index.py
@@ -2,6 +2,7 @@
 Unit tests for search indexers
 """
 from django.conf import settings
+from django.test.utils import override_settings
 from lazy.lazy import lazy
 import os
 import mock
@@ -9,7 +10,7 @@ import json
 
 from uuid import uuid4
 from datetime import datetime
-from unittest import TestCase
+from django.test import TestCase
 
 from opaque_keys.edx.locator import CourseLocator, LibraryLocator, BlockUsageLocator, LibraryUsageLocator
 
@@ -42,6 +43,9 @@ class TestIndexerForLocation(TestCase):
         self.assertIsInstance(indexer, LibrarySearchIndexer)
 
 
+MOCK_SEARCH_ENGINE = getattr(settings, 'SEARCH_ENGINE', "search.tests.mock_search_engine.MockSearchEngine")
+
+
 # pylint: disable=no-member
 class SearchIndexerBaseTestMixin(object):
     """ Common features for search indexers tests"""
@@ -52,7 +56,6 @@ class SearchIndexerBaseTestMixin(object):
         settings, 'MOCK_SEARCH_BACKING_FILE',
         "test_root/index_file.dat"
     )
-    MOCK_SEARCH_ENGINE = getattr(settings, 'SEARCH_ENGINE', "search.tests.mock_search_engine.MockSearchEngine")
 
     def setUp(self):
         """
@@ -220,6 +223,7 @@ class SearchIndexerBaseTestMixin(object):
         self.assertEqual(args, (self.indexer.DOCUMENT_TYPE, self._process_index_id(location)))
 
 
+@override_settings(MOCK_SEARCH_ENGINE=MOCK_SEARCH_ENGINE)
 class TestCoursewareSearchIndexer(SearchIndexerBaseTestMixin, TestCase):
     """ Tests for CoursewareSearchIndexer """
     ROOT_ID = CourseLocator('testx', 'courseware_indexer_test', 'test_run')
@@ -250,6 +254,7 @@ class TestCoursewareSearchIndexer(SearchIndexerBaseTestMixin, TestCase):
         return result
 
 
+@override_settings(MOCK_SEARCH_ENGINE=MOCK_SEARCH_ENGINE)
 class TestLibrarySearchIndexer(SearchIndexerBaseTestMixin, TestCase):
     """ Tests for LibrarySearchIndexer """
     ROOT_ID = LibraryLocator('lib', 'Lib1')

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_search_index.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_search_index.py
@@ -1,0 +1,276 @@
+"""
+Unit tests for search indexers
+"""
+from lazy.lazy import lazy
+import os
+import mock
+import json
+
+from uuid import uuid4
+from datetime import datetime
+from unittest import TestCase
+
+from opaque_keys.edx.locator import CourseLocator, LibraryLocator, BlockUsageLocator, LibraryUsageLocator
+
+from xmodule.modulestore import ModuleStoreWriteBase
+from xmodule.modulestore.exceptions import ItemNotFoundError
+from xmodule.modulestore.search_index import get_indexer_for_location, CoursewareSearchIndexer, LibrarySearchIndexer
+
+
+class TestIndexerForLocation(TestCase):
+    """ Tests for search indexers factory method """
+    def test_given_course_locator_returns_courseware_indexer(self):
+        locator = mock.Mock(spec=CourseLocator)
+        indexer = get_indexer_for_location(locator)
+        self.assertIsInstance(indexer, CoursewareSearchIndexer)
+
+    def test_given_library_locator_returns_library_indexer(self):
+        locator = mock.Mock(spec=LibraryLocator)
+        indexer = get_indexer_for_location(locator)
+        self.assertIsInstance(indexer, LibrarySearchIndexer)
+
+    def test_given_course_item_locator_returns_courseware_indexer(self):
+        locator = mock.Mock(spec=BlockUsageLocator)
+        locator.course_key = mock.Mock(spec=CourseLocator)
+        indexer = get_indexer_for_location(locator)
+        self.assertIsInstance(indexer, CoursewareSearchIndexer)
+
+    def test_given_library_item_locator_returns_library_indexer(self):
+        locator = mock.Mock(spec=LibraryUsageLocator)
+        locator.course_key = mock.Mock(spec=LibraryLocator)
+        indexer = get_indexer_for_location(locator)
+        self.assertIsInstance(indexer, LibrarySearchIndexer)
+
+
+class SearchIndexerBaseTestMixin(object):
+    """ COmmon features for search indexers tests"""
+    ROOT_ID = None
+    TEST_INDEX_FILENAME = "test_root/index_file.dat"
+    modulestore = None
+
+    def setUp(self):
+        """
+        SetUp method. Sincerely yours, CO.
+        Setting up mock search indexer backing file as prescribed by MOCK_SEARCH_BACKING_FILE setting
+        """
+        super(SearchIndexerBaseTestMixin, self).setUp()
+        # this test implicitly uses MockSearchEngine, which in turn uses settings.MOCK_SEARCH_BACKING_FILE
+        # as backing file - so we create it
+        with open(self.TEST_INDEX_FILENAME, "w+") as index_file:
+            json.dump({}, index_file)
+
+        self.modulestore = mock.Mock(spec=ModuleStoreWriteBase)
+
+    def tearDown(self):
+        """
+        TearDown method. Sincerely yours, CO.
+        Removing backing file created in set up
+        """
+        super(SearchIndexerBaseTestMixin, self).tearDown()
+        os.remove(self.TEST_INDEX_FILENAME)
+
+    def _make_location(self, block_type, course_id=ROOT_ID):
+        """ Builds xblock location for specified block type and course id """
+        raise NotImplemented()
+
+    def _process_index_id(self, location):
+        """ Transforms block location to build correct index id """
+        raise NotImplemented()
+
+    @lazy
+    def indexer(self):
+        """ Indexer under test instantiation """
+        raise NotImplemented()
+
+    def _make_item(self, block_type, index_dictionary, course_id=None, start=None, children=None):
+        """ Builds XBlock mock with specified block_type, index disctionary, children, etc."""
+        location = self._make_location(block_type, course_id)
+        result = mock.Mock()
+        if index_dictionary is not None:
+            result.index_dictionary = mock.Mock(return_value=index_dictionary)
+        else:
+            del result.index_dictionary
+        result.start = start
+
+        result.children = children if children else []
+        result.has_children = len(result.children) > 0
+        result.location = location
+        result.scope_ids = mock.Mock()
+        result.scope_ids.usage_id = location
+        return result, location
+
+    def _set_up_modulestore_get_item(self, items):
+        """
+        Sets up mock modulestore get_item method to return only items listed in `items` parameter at specified locations
+        """
+        def side_effect(loc, **kwargs):
+            return items.get(loc, None)
+        self.modulestore.get_item = mock.Mock(side_effect=side_effect)
+
+    def _make_index_entry(self, index_dict, location, start_date=None):
+        """ Helper method: builds index entry dictionary """
+        result = {
+            'id': self._process_index_id(location),
+            'course': unicode(self.ROOT_ID),
+        }
+        result.update(index_dict)
+        if start_date:
+            result['start_date'] = start_date
+        return result
+
+    @mock.patch('search.tests.mock_search_engine.MockSearchEngine.remove')
+    @mock.patch('search.tests.mock_search_engine.MockSearchEngine.index')
+    @mock.patch('xmodule.modulestore.search_index.SearchEngine.get_search_engine')
+    def test_no_searcher_does_nothing(self, search_engine, index, remove):
+        """ Tests that does indexer does nothing if no search engine is available """
+        search_engine.return_value = None
+        item, location = self._make_item('html', {'item': 'value'})
+        self.indexer.add_to_search_index(self.modulestore, location)
+        search_engine.assert_called_with(self.indexer.INDEX_NAME)
+        index.assert_not_called()
+        remove.assert_not_called()
+
+    @mock.patch('search.tests.mock_search_engine.MockSearchEngine.remove')
+    @mock.patch('search.tests.mock_search_engine.MockSearchEngine.index')
+    def test_not_indexable_no_children_does_nothing(self, index, remove):
+        """ Tests that does indexer does nothing if xblock is not indexable """
+        item, location = self._make_item('html', None)
+        self._set_up_modulestore_get_item({location: item})
+        self.indexer.add_to_search_index(self.modulestore, location)
+        index.assert_not_called()
+        remove.assert_not_called()
+
+    @mock.patch('search.tests.mock_search_engine.MockSearchEngine.index')
+    def test_add_to_index_no_children_adds_to_index(self, patched_index):
+        """ Tests that indexer adds XBlock with no children to index """
+        index_dict = {'item': 'value'}
+        item, location = self._make_item('html', index_dict)
+        self._set_up_modulestore_get_item({location: item})
+        self.indexer.add_to_search_index(self.modulestore, location)
+        expected_index_entry = self._make_index_entry(index_dict, location)
+        patched_index.assert_called_with(self.indexer.DOCUMENT_TYPE, expected_index_entry)
+
+    @mock.patch('search.tests.mock_search_engine.MockSearchEngine.remove')
+    def test_add_to_index_with_delete_no_children_simple_removes_from_index(self, patched_remove):
+        """ Tests that indexer removes XBlock with no children from index """
+        item, location = self._make_item('html', {'item': 'value'})
+        self._set_up_modulestore_get_item({location: item})
+        self.indexer.add_to_search_index(self.modulestore, location, delete=True)
+        patched_remove.assert_called_with(self.indexer.DOCUMENT_TYPE, self._process_index_id(location))
+
+    @mock.patch('search.tests.mock_search_engine.MockSearchEngine.index')
+    def test_add_to_index_with_chidlren_adds_all_to_index(self, patched_index):
+        """ Tests that indexer adds XBlock with children to index (both Xblock and all of its children)"""
+        index_dict_child1, index_dict_child2 = {'child': 'child1'}, {'child': 'child2'}
+        child1, child_loc1 = self._make_item('text', index_dict_child1)
+        child2, child_loc2 = self._make_item('html', index_dict_child2)
+
+        index_dict = {'item': 'value'}
+        start_date = datetime(2015, 7, 14, 22, 11, 03)
+
+        item, location = self._make_item(
+            'problem', index_dict,
+            children=[child_loc1, child_loc2],
+            start=start_date
+        )
+        self._set_up_modulestore_get_item({location: item, child_loc1: child1, child_loc2: child2})
+        self.indexer.add_to_search_index(self.modulestore, location)
+
+        calls = patched_index.call_args_list
+        args, kwargs = calls[0]
+        self.assertEqual(args, (
+            self.indexer.DOCUMENT_TYPE,
+            self._make_index_entry(index_dict_child1, child_loc1, start_date=start_date)
+        ))
+        args, kwargs = calls[1]
+        self.assertEqual(args, (
+            self.indexer.DOCUMENT_TYPE,
+            self._make_index_entry(index_dict_child2, child_loc2, start_date=start_date)
+        ))
+        args, kwargs = calls[2]
+        self.assertEqual(args, (
+            self.indexer.DOCUMENT_TYPE,
+            self._make_index_entry(index_dict, location, start_date=start_date)
+        ))
+
+    @mock.patch('search.tests.mock_search_engine.MockSearchEngine.remove')
+    def test_add_to_index_with_chidlren_adds_all_to_index(self, patched_remove):
+        """ Tests that indexer removes XBlock with children from index (both Xblock and all of its children)"""
+        index_dict_child1, index_dict_child2 = {'child': 'child1'}, {'child': 'child2'}
+        child1, child_loc1 = self._make_item('text', index_dict_child1)
+        child2, child_loc2 = self._make_item('html', index_dict_child2)
+
+        index_dict = {'item': 'value'}
+
+        item, location = self._make_item('problem', index_dict, children=[child_loc1, child_loc2])
+        self._set_up_modulestore_get_item({location: item, child_loc1: child1, child_loc2: child2})
+        self.indexer.add_to_search_index(self.modulestore, location, delete=True)
+
+        calls = patched_remove.call_args_list
+        args, kwargs = calls[0]
+        self.assertEqual(args, (self.indexer.DOCUMENT_TYPE, self._process_index_id(child_loc1)))
+        args, kwargs = calls[1]
+        self.assertEqual(args, (self.indexer.DOCUMENT_TYPE, self._process_index_id(child_loc2)))
+        args, kwargs = calls[2]
+        self.assertEqual(args, (self.indexer.DOCUMENT_TYPE, self._process_index_id(location)))
+
+
+class TestCoursewareSearchIndexer(SearchIndexerBaseTestMixin, TestCase):
+    """ Tests for CoursewareSearchIndexer """
+    ROOT_ID = CourseLocator('testx', 'courseware_indexer_test', 'test_run')
+
+    @lazy
+    def indexer(self):
+        """ Indexer under test instantiation """
+        return CoursewareSearchIndexer()
+
+    def _make_location(self, block_type, course_id=None):
+        """ Builds xblock location for specified block type and course id """
+        course_id = course_id if course_id else self.ROOT_ID
+        return BlockUsageLocator(course_id, block_type, uuid4().hex)
+
+    def _process_index_id(self, location):
+        """ Transforms block location to build correct index id """
+        return unicode(location)
+
+    def _make_index_entry(self, index_dict, location, start_date=None):
+        """ Helper method: builds index entry dictionary """
+        result = {
+            'id': self._process_index_id(location),
+            'course': unicode(self.ROOT_ID),
+        }
+        result.update(index_dict)
+        if start_date:
+            result['start_date'] = start_date
+        return result
+
+
+class TestLibrarySearchIndexer(SearchIndexerBaseTestMixin, TestCase):
+    """ Tests for LibrarySearchIndexer """
+    ROOT_ID = LibraryLocator('lib', 'Lib1')
+
+    @lazy
+    def indexer(self):
+        """ Indexer under test instantiation """
+        return LibrarySearchIndexer()
+
+    def _make_location(self, block_type, course_id=None):
+        """ Builds xblock location for specified block type and course id """
+        course_id = course_id if course_id else self.ROOT_ID
+        return LibraryUsageLocator(course_id, block_type, uuid4().hex)
+
+    def _process_index_id(self, location):
+        """ Transforms block location to build correct index id """
+        new_loc = location.replace(library_key=location.library_key.replace(version_guid=None, branch=None))
+        return unicode(new_loc)
+
+    def _make_index_entry(self, index_dict, location, start_date=None):
+        """ Helper method: builds index entry dictionary """
+        result = {
+            'id': self._process_index_id(location),
+            'library': unicode(self.ROOT_ID),
+        }
+        result.update(index_dict)
+        if start_date:
+            result['start_date'] = start_date
+        return result

--- a/common/lib/xmodule/xmodule/tests/test_capa_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_capa_module.py
@@ -1666,19 +1666,26 @@ class CapaModuleTest(unittest.TestCase):
 
 @ddt.ddt
 class CapaDescriptorTest(unittest.TestCase):
-    def _create_descriptor(self, xml):
+    def _create_descriptor(self, xml, name=None):
         """ Creates a CapaDescriptor to run test against """
         descriptor = CapaDescriptor(get_test_system(), scope_ids=1)
         descriptor.data = xml
+        if name:
+            descriptor.display_name = name
         return descriptor
 
     @ddt.data(*responsetypes.registry.registered_tags())
     def test_all_response_types(self, response_tag):
         """ Tests that every registered response tag is correctly returned """
         xml = "<problem><{response_tag}></{response_tag}></problem>".format(response_tag=response_tag)
-        descriptor = self._create_descriptor(xml)
+        name = "Some Capa Problem"
+        descriptor = self._create_descriptor(xml, name=name)
         self.assertEquals(descriptor.problem_types, {response_tag})
-        self.assertEquals(descriptor.index_dictionary(), {'problem_types': {response_tag}})
+        self.assertEquals(descriptor.index_dictionary(), {
+            'content_type': CapaDescriptor.INDEX_CONTENT_TYPE,
+            'display_name': name,
+            'problem_types': [response_tag]
+        })
 
     def test_response_types_ignores_non_response_tags(self):
         xml = textwrap.dedent("""
@@ -1695,9 +1702,14 @@ class CapaDescriptorTest(unittest.TestCase):
             </multiplechoiceresponse>
             </problem>
         """)
-        descriptor = self._create_descriptor(xml)
+        name = "Test Capa Problem"
+        descriptor = self._create_descriptor(xml, name=name)
         self.assertEquals(descriptor.problem_types, {"multiplechoiceresponse"})
-        self.assertEquals(descriptor.index_dictionary(), {'problem_types': {"multiplechoiceresponse"}})
+        self.assertEquals(descriptor.index_dictionary(), {
+            'content_type': CapaDescriptor.INDEX_CONTENT_TYPE,
+            'display_name': name,
+            'problem_types': ["multiplechoiceresponse"]
+        })
 
     def test_response_types_multiple_tags(self):
         xml = textwrap.dedent("""
@@ -1719,10 +1731,15 @@ class CapaDescriptorTest(unittest.TestCase):
                 </optionresponse>
             </problem>
         """)
-        descriptor = self._create_descriptor(xml)
+        name = "Other Test Capa Problem"
+        descriptor = self._create_descriptor(xml, name=name)
         self.assertEquals(descriptor.problem_types, {"multiplechoiceresponse", "optionresponse"})
         self.assertEquals(
-            descriptor.index_dictionary(), {'problem_types': {"multiplechoiceresponse", "optionresponse"}}
+            descriptor.index_dictionary(), {
+                'content_type': CapaDescriptor.INDEX_CONTENT_TYPE,
+                'display_name': name,
+                'problem_types': ["optionresponse", "multiplechoiceresponse"]
+            }
         )
 
 

--- a/common/lib/xmodule/xmodule/tests/test_capa_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_capa_module.py
@@ -1678,6 +1678,7 @@ class CapaDescriptorTest(unittest.TestCase):
         xml = "<problem><{response_tag}></{response_tag}></problem>".format(response_tag=response_tag)
         descriptor = self._create_descriptor(xml)
         self.assertEquals(descriptor.problem_types, {response_tag})
+        self.assertEquals(descriptor.index_dictionary(), {'problem_types': {response_tag}})
 
     def test_response_types_ignores_non_response_tags(self):
         xml = textwrap.dedent("""
@@ -1696,6 +1697,7 @@ class CapaDescriptorTest(unittest.TestCase):
         """)
         descriptor = self._create_descriptor(xml)
         self.assertEquals(descriptor.problem_types, {"multiplechoiceresponse"})
+        self.assertEquals(descriptor.index_dictionary(), {'problem_types': {"multiplechoiceresponse"}})
 
     def test_response_types_multiple_tags(self):
         xml = textwrap.dedent("""
@@ -1719,6 +1721,9 @@ class CapaDescriptorTest(unittest.TestCase):
         """)
         descriptor = self._create_descriptor(xml)
         self.assertEquals(descriptor.problem_types, {"multiplechoiceresponse", "optionresponse"})
+        self.assertEquals(
+            descriptor.index_dictionary(), {'problem_types': {"multiplechoiceresponse", "optionresponse"}}
+        )
 
 
 class ComplexEncoderTest(unittest.TestCase):

--- a/common/test/acceptance/tests/helpers.py
+++ b/common/test/acceptance/tests/helpers.py
@@ -417,3 +417,17 @@ def create_user_partition_json(partition_id, name, description, groups, scheme="
     return UserPartition(
         partition_id, name, description, groups, MockUserPartitionScheme(scheme)
     ).to_json()
+
+
+class TestWithSearchIndexMixin(object):
+    """ Mixin encapsulating search index creation """
+    TEST_INDEX_FILENAME = "test_root/index_file.dat"
+
+    def _create_search_index(self):
+        """ Creates search index backing file """
+        with open(self.TEST_INDEX_FILENAME, "w+") as index_file:
+            json.dump({}, index_file)
+
+    def _cleanup_index_file(self):
+        """ Removes search index backing file """
+        os.remove(self.TEST_INDEX_FILENAME)

--- a/common/test/acceptance/tests/lms/test_library.py
+++ b/common/test/acceptance/tests/lms/test_library.py
@@ -6,7 +6,7 @@ import ddt
 import textwrap
 
 from nose.plugins.attrib import attr
-from ..helpers import UniqueCourseTest
+from ..helpers import UniqueCourseTest, TestWithSearchIndexMixin
 from ...pages.studio.auto_auth import AutoAuthPage
 from ...pages.studio.overview import CourseOutlinePage
 from ...pages.studio.library import StudioLibraryContentEditor, StudioLibraryContainerXBlockWrapper
@@ -196,10 +196,19 @@ class LibraryContentTest(LibraryContentTestBase):
 
 @ddt.ddt
 @attr('shard_3')
-class StudioLibraryContainerCapaFilterTest(LibraryContentTestBase):
+class StudioLibraryContainerCapaFilterTest(LibraryContentTestBase, TestWithSearchIndexMixin):
     """
     Test Library Content block in LMS
     """
+    def setUp(self):
+        """ SetUp method """
+        self._create_search_index()
+        super(StudioLibraryContainerCapaFilterTest, self).setUp()
+
+    def tearDown(self):
+        self._cleanup_index_file()
+        super(StudioLibraryContainerCapaFilterTest, self).tearDown()
+
     def _get_problem_choice_group_text(self, name, items):
         """ Generates Choice Group CAPA problem XML """
         items_text = "\n".join([
@@ -231,7 +240,7 @@ class StudioLibraryContainerCapaFilterTest(LibraryContentTestBase):
         """
         Populates library fixture with XBlock Fixtures
         """
-        library_fixture.add_children(
+        items = (
             XBlockFixtureDesc(
                 "problem", "Problem Choice Group 1",
                 data=self._get_problem_choice_group_text("Problem Choice Group 1 Text", [("1", False), ('2', True)])
@@ -249,6 +258,7 @@ class StudioLibraryContainerCapaFilterTest(LibraryContentTestBase):
                 data=self._get_problem_select_text("Problem Select 2 Text", ["Option 3", "Option 4"], "Option 4")
             ),
         )
+        library_fixture.add_children(*items)
 
     @property
     def _problem_headers(self):

--- a/common/test/acceptance/tests/studio/test_studio_library_container.py
+++ b/common/test/acceptance/tests/studio/test_studio_library_container.py
@@ -7,7 +7,7 @@ import textwrap
 
 from .base_studio_test import StudioLibraryTest
 from ...fixtures.course import CourseFixture
-from ..helpers import UniqueCourseTest
+from ..helpers import UniqueCourseTest, TestWithSearchIndexMixin
 from ...pages.studio.library import StudioLibraryContentEditor, StudioLibraryContainerXBlockWrapper
 from ...pages.studio.overview import CourseOutlinePage
 from ...fixtures.course import XBlockFixtureDesc
@@ -18,7 +18,7 @@ UNIT_NAME = 'Test Unit'
 
 
 @ddt.ddt
-class StudioLibraryContainerTest(StudioLibraryTest, UniqueCourseTest):
+class StudioLibraryContainerTest(StudioLibraryTest, UniqueCourseTest, TestWithSearchIndexMixin):
     """
     Test Library Content block in LMS
     """
@@ -26,6 +26,7 @@ class StudioLibraryContainerTest(StudioLibraryTest, UniqueCourseTest):
         """
         Install library with some content and a course using fixtures
         """
+        self._create_search_index()
         super(StudioLibraryContainerTest, self).setUp()
         # Also create a course:
         self.course_fixture = CourseFixture(
@@ -41,6 +42,11 @@ class StudioLibraryContainerTest(StudioLibraryTest, UniqueCourseTest):
         self.outline.visit()
         subsection = self.outline.section(SECTION_NAME).subsection(SUBSECTION_NAME)
         self.unit_page = subsection.expand_subsection().unit(UNIT_NAME).go_to()
+
+    def tearDown(self):
+        """ Cleans up search index backing file """
+        self._cleanup_index_file()
+        super(StudioLibraryContainerTest, self).tearDown()
 
     def populate_library_fixture(self, library_fixture):
         """

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -462,6 +462,9 @@ FEATURES['ENTRANCE_EXAMS'] = True
 FEATURES['ENABLE_COURSEWARE_SEARCH'] = True
 # Use MockSearchEngine as the search engine for test scenario
 SEARCH_ENGINE = "search.tests.mock_search_engine.MockSearchEngine"
+MOCK_SEARCH_BACKING_FILE = (
+    TEST_ROOT / "index_file.dat"  # pylint: disable=no-value-for-parameter
+).abspath()
 
 FACEBOOK_APP_SECRET = "Test"
 FACEBOOK_APP_ID = "Test"

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -38,7 +38,7 @@ git+https://github.com/mitocw/django-cas.git@60a5b8e5a62e63e0d5d224a87f0b489201a
 -e git+https://github.com/edx/edx-val.git@64aa7637e3459fb3000a85a9e156880a40307dd1#egg=edx-val
 -e git+https://github.com/pmitros/RecommenderXBlock.git@9b07e807c89ba5761827d0387177f71aa57ef056#egg=recommender-xblock
 -e git+https://github.com/edx/edx-milestones.git@547f2250ee49e73ce8d7ff4e78ecf1b049892510#egg=edx-milestones
--e git+https://github.com/edx/edx-search.git@21ac6b06b3bfe789dcaeaf4e2ab5b00a688324d4#egg=edx-search
+-e git+https://github.com/edx/edx-search.git@b5444b2702817bc04f5d0d025779ee50dbdec465#egg=edx-search
 git+https://github.com/edx/edx-lint.git@8bf82a32ecb8598c415413df66f5232ab8d974e9#egg=edx_lint==0.2.1
 -e git+https://github.com/edx/xblock-utils.git@17e247d66fabb53f0453515b093a030ee345a1b0#egg=xblock-utils
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive


### PR DESCRIPTION
**Background:** This PR is a reimplementation of https://github.com/edx/edx-platform/pull/6346 and contains the following:
- Capa problems search index support
- Machinery to create dedicated index for library contents
- Library capa problem type filtering reimplemented using search

**Jira tickets:** SOL-286, OC-557
**Discussions:** [discussion on related PR](https://github.com/edx/edx-platform/pull/6506#issuecomment-82912066), personal email to @martynjames 
**Dependencies:** [Search in multivalue fields](https://github.com/edx/edx-search/pull/6)
**Sandbox URL:** [LMS](http://content-libraries.sandbox.opencraft.com), [Studio](http://content-libraries.sandbox.opencraft.com:18010/)
**Partner information:** 3rd party-hosted open edX instance, for an edX solutions client.

**Testing instructions:** no user facing changes should appear. Test instructions similar to https://github.com/edx/edx-platform/pull/6346:
1. Create a library with a couple of Problem XBlocks of different types (e.g. "Checkboxes", "Dropdown", "Multiple Choice")
2. Add Library Content XBlock to a course.
3. Edit Library Content settings. By default "Problem Type" should be set to "Any Type", LMS view should display problems of any type.
4. Set "Problem Type" to one of the problem types in the library (e.g. "Checkboxes", "Dropdown" or "Multiple Choice""). Please note that some problem type templates fall into same problem type (e.g. "Custom Javascript/Python" and "Drag and Drop" fall into "Custom Evaluated Script"). Save, publish, navigate to LMS as a student and ensure only Problems of selected type are shown.
5. Set "Problem Type" to any problem type **not** in the library (e.g. any except "Checkboxes", "Dropdown" or "Multiple Choice""). Save, publish, note the warning message in Studio, navigate to LMS as a student and ensure no XBlocks are shown.
