### PR TITLE
Clean up transactional behavior in User API

### DIFF
--- a/openedx/core/djangoapps/course_groups/cohorts.py
+++ b/openedx/core/djangoapps/course_groups/cohorts.py
@@ -175,9 +175,7 @@ def get_cohorted_commentables(course_key):
 
 @transaction.commit_on_success
 def get_cohort(user, course_key, assign=True, use_cached=False):
-    """
-    Given a Django user and a CourseKey, return the user's cohort in that
-    cohort.
+    """Returns the user's cohort for the specified course.
 
     The cohort for the user is cached for the duration of a request. Pass
     use_cached=True to use the cached value instead of fetching from the

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -4,6 +4,7 @@ NOTE: this API is WIP and has not yet been approved. Do not use this API without
 For more information, see:
 https://openedx.atlassian.net/wiki/display/TNL/User+API
 """
+from django.db import transaction
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
@@ -117,7 +118,8 @@ class AccountView(APIView):
         else an error response with status code 415 will be returned.
         """
         try:
-            update_account_settings(request.user, request.DATA, username=username)
+            with transaction.commit_on_success():
+                update_account_settings(request.user, request.DATA, username=username)
         except (UserNotFound, UserNotAuthorized):
             return Response(status=status.HTTP_404_NOT_FOUND)
         except AccountValidationError as err:

--- a/openedx/core/djangoapps/user_api/preferences/api.py
+++ b/openedx/core/djangoapps/user_api/preferences/api.py
@@ -11,8 +11,9 @@ from pytz import UTC
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.exceptions import ObjectDoesNotExist
-from django.db import transaction, IntegrityError
+from django.db import IntegrityError
 from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_noop
 
 from student.models import UserProfile
 
@@ -77,7 +78,6 @@ def get_user_preferences(requesting_user, username=None):
 
 
 @intercept_errors(UserAPIInternalError, ignore_errors=[UserAPIRequestError])
-@transaction.commit_on_success
 def update_user_preferences(requesting_user, update, username=None):
     """Update the user preferences for the given username.
 
@@ -138,7 +138,6 @@ def update_user_preferences(requesting_user, update, username=None):
 
 
 @intercept_errors(UserAPIInternalError, ignore_errors=[UserAPIRequestError])
-@transaction.commit_on_success
 def set_user_preference(requesting_user, preference_key, preference_value, username=None):
     """Update a user preference for the given username.
 
@@ -173,7 +172,6 @@ def set_user_preference(requesting_user, preference_key, preference_value, usern
 
 
 @intercept_errors(UserAPIInternalError, ignore_errors=[UserAPIRequestError])
-@transaction.commit_on_success
 def delete_user_preference(requesting_user, preference_key, username=None):
     """Deletes a user preference on behalf of a requesting user.
 
@@ -353,11 +351,12 @@ def validate_user_preference_serializer(serializer, preference_key, preference_v
         PreferenceValidationError: the supplied key and/or value for a user preference are invalid.
     """
     if preference_value is None or unicode(preference_value).strip() == '':
-        message = _(u"Preference '{preference_key}' cannot be set to an empty value.").format(
-            preference_key=preference_key
-        )
+        format_string = ugettext_noop(u"Preference '{preference_key}' cannot be set to an empty value.")
         raise PreferenceValidationError({
-            preference_key: {"developer_message": message, "user_message": message}
+            preference_key: {
+                "developer_message": format_string.format(preference_key=preference_key),
+                "user_message": _(format_string).format(preference_key=preference_key)
+            }
         })
     if not serializer.is_valid():
         developer_message = u"Value '{preference_value}' not valid for preference '{preference_key}': {error}".format(

--- a/openedx/core/djangoapps/user_api/preferences/views.py
+++ b/openedx/core/djangoapps/user_api/preferences/views.py
@@ -10,6 +10,7 @@ from rest_framework import status
 from util.authentication import SessionAuthenticationAllowInactiveUser, OAuth2AuthenticationAllowInactiveUser
 from rest_framework import permissions
 
+from django.db import transaction
 from django.utils.translation import ugettext as _
 
 from openedx.core.lib.api.parsers import MergePatchParser
@@ -88,7 +89,8 @@ class PreferencesView(APIView):
                 status=status.HTTP_400_BAD_REQUEST
             )
         try:
-            update_user_preferences(request.user, request.DATA, username=username)
+            with transaction.commit_on_success():
+                update_user_preferences(request.user, request.DATA, username=username)
         except (UserNotFound, UserNotAuthorized):
             return Response(status=status.HTTP_404_NOT_FOUND)
         except PreferenceValidationError as error:

--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -1686,7 +1686,6 @@ class TestFacebookRegistrationView(
         self._verify_user_existence(user_exists=False, social_link_exists=False)
 
 
-
 @skipUnless(settings.FEATURES.get("ENABLE_THIRD_PARTY_AUTH"), "third party auth not enabled")
 class TestGoogleRegistrationView(
     ThirdPartyRegistrationTestMixin, ThirdPartyOAuthTestMixinGoogle, TransactionTestCase


### PR DESCRIPTION
I've removed the `@transaction.commit_on_success` decorators from the user preference APIs and instead explicitly used a transaction in the PATCH method that updates multiple user preferences at once. I've written a test that verifies that the rollback behavior works as desired.

While I was here, I also did a sweep for developer messages that were being localized. I've fixed the one place that was doing this, and fixed another message that wasn't unicode.

@cahrens @nasthagiri please review when you have a chance.
