### PR TITLE
Centering the third-party social media buttons

### DIFF
--- a/lms/static/sass/views/_login-register.scss
+++ b/lms/static/sass/views/_login-register.scss
@@ -147,6 +147,10 @@ $sm-btn-linkedin: #0077b5;
             @include clearfix();
             clear: both;
         }
+
+        .login-providers {
+            text-align: center;
+        }
     }
 
     .login-form {


### PR DESCRIPTION
The buttons were previously left-aligned, made noticeable when we widened the form. This quick fix centers them.

@frrrances Can you quickly thumbs this guy up?

cc @mattdrayer 
