### PR TITLE
Upgrade from distribute to modern version of setuptools

### DIFF
--- a/common/lib/capa/setup.py
+++ b/common/lib/capa/setup.py
@@ -4,5 +4,5 @@ setup(
     name="capa",
     version="0.1",
     packages=find_packages(exclude=["tests"]),
-    install_requires=["distribute>=0.6.28"],
+    install_requires=["setuptools"],
 )

--- a/common/lib/xmodule/setup.py
+++ b/common/lib/xmodule/setup.py
@@ -54,7 +54,7 @@ setup(
     version="0.1",
     packages=find_packages(exclude=["tests"]),
     install_requires=[
-        'distribute',
+        'setuptools',
         'docopt',
         'capa',
         'path.py',

--- a/pavelib/prereqs.py
+++ b/pavelib/prereqs.py
@@ -16,7 +16,6 @@ PYTHON_REQ_FILES = [
     'requirements/edx/github.txt',
     'requirements/edx/local.txt',
     'requirements/edx/base.txt',
-    'requirements/edx/post.txt',
 ]
 
 # Developers can have private requirements, for local copies of github repos,

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -13,7 +13,6 @@ celery==3.1.18
 cssselect==0.9.1
 dealer==2.0.4
 defusedxml==0.4.1
-distribute>=0.6.28, <0.7
 django-babel-underscore==0.1.0
 django-celery==3.1.16
 django-countries==3.3
@@ -51,6 +50,7 @@ Markdown==2.2.1
 --allow-unverified meliae
 meliae==0.4.0
 mongoengine==0.7.10
+MySQL-python==1.2.5
 networkx==1.7
 nltk==2.0.5
 nose==1.3.3

--- a/requirements/edx/post.txt
+++ b/requirements/edx/post.txt
@@ -1,8 +1,0 @@
-# DON'T JUST ADD NEW DEPENDENCIES!!!
-#
-# If you open a pull request that adds a new dependency, you should notify:
-#   * @mollydb - to check licensing
-#   * One of @e0d, @jarv, or @feanil - to check system requirements
-
-# This must be installed after distribute has been updated.
-MySQL-python==1.2.4

--- a/requirements/edx/pre.txt
+++ b/requirements/edx/pre.txt
@@ -4,6 +4,9 @@
 #   * @mollydb - to check licensing
 #   * One of @e0d, @jarv, or @feanil - to check system requirements
 
+# Use a modern setuptools instead of distribute
+setuptools==15.2
+
 # Numpy and scipy can't be installed in the same pip run.
 # Install numpy before other things to help resolve the problem.
 numpy==1.6.2

--- a/scripts/create-dev-env.sh
+++ b/scripts/create-dev-env.sh
@@ -441,27 +441,6 @@ if [[ -n $compile ]]; then
     rm -rf numpy-${NUMPY_VER} scipy-${SCIPY_VER}
 fi
 
-# building correct version of distribute from source
-DISTRIBUTE_VER="0.6.28"
-output "Building Distribute"
-SITE_PACKAGES="$WORKON_HOME/edx-platform/lib/python2.7/site-packages"
-cd "$SITE_PACKAGES"
-curl -sSLO http://pypi.python.org/packages/source/d/distribute/distribute-${DISTRIBUTE_VER}.tar.gz
-tar -xzvf distribute-${DISTRIBUTE_VER}.tar.gz
-cd distribute-${DISTRIBUTE_VER}
-python setup.py install
-cd ..
-rm distribute-${DISTRIBUTE_VER}.tar.gz
-
-DISTRIBUTE_VERSION=`pip freeze | grep distribute`
-
-if [[ "$DISTRIBUTE_VERSION" == "distribute==0.6.28" ]]; then
-  output "Distribute successfully installed"
-else
-  error "Distribute failed to build correctly. This script requires a working version of Distribute 0.6.28 in your virtualenv's python installation"
-  exit 1
-fi
-
 case `uname -s` in
     Darwin)
         # on mac os x get the latest distribute and pip

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup
 setup(
     name="Open edX",
     version="0.2",
-    install_requires=['distribute'],
+    install_requires=['setuptools'],
     requires=[],
     # NOTE: These are not the names we should be installing.  This tree should
     # be reorganized to be a more conventional Python tree.


### PR DESCRIPTION
**Context**: 'distribute' is the ancestor of 'setuptools', and many packages require
setuptools to be installed. Actually, some requirements of edx-platform require an old version of distribute, while others require a more recent one.

**Proposed solution**: migrate to a recent version of setuptools (10.1). As a consequence, Mysql-Python needs to be upgraded, too.
