### PR TITLE
Accessibility: Updating the color blue on LMS

### DIFF
--- a/lms/static/sass/base/_variables.scss
+++ b/lms/static/sass/base/_variables.scss
@@ -139,7 +139,7 @@ $facebook-blue: #3B5998;
 $linkedin-blue: #0077B5;
 
 // TODO: both blue and yellow variables differ from CMS rgb value, need to confirm change to CMS variable is ok in current platform uses before switching.
-$blue: rgb(29,157,217);
+$blue: rgb(0, 120, 176);
 $yellow: rgb(255, 252, 221);
 
 // COLORS: old variables
@@ -183,7 +183,7 @@ $m-blue-l4: tint($m-blue,90%);
 $m-blue-l5: tint($m-blue,95%);
 $m-blue-l6: #4bb4fb;
 $m-blue-d1: rgb(23,144,199); // #1790C7
-$m-blue-d2: rgb(21,128,176); // #1580B0
+$m-blue-d2: $blue;
 $m-blue-d3: rgb(18,111,154); // #126F9A
 $m-blue-d4: rgb(10,74,103); // #0A4A67
 $m-blue-d5: rgb(0,158,231); // #009EE7
@@ -252,7 +252,7 @@ $courseware-footer-margin: 0px;
 $courseware-border-bottom-color: rgb(68,162,222); // #44a2de
 $courseware-button-border-color: rgb(230,230,230); // #e6e6e6
 $courseware-hover-color: rgb(51,52,53); // #333435
-$courseware-navigation-color: rgb(0,158,231); // #009ee7
+$courseware-navigation-color: $blue;
 
 // ====================
 
@@ -386,7 +386,7 @@ $border-color-l4: $m-gray-l4;
 
 // MISC: links and buttons
 $link-color: $blue;
-$link-color-d1: $m-blue-d2;
+$link-color-d1: $blue;
 $link-hover: $pink;
 $site-status-color: $pink;
 $button-color: $blue;

--- a/lms/static/sass/course/_info.scss
+++ b/lms/static/sass/course/_info.scss
@@ -84,6 +84,10 @@ div.info-wrapper {
     box-shadow: none;
     font-size: 14px;
 
+    a {
+      color: $link-color;
+    }
+
     &:after {
       left: -1px;
       right: auto;
@@ -104,6 +108,7 @@ div.info-wrapper {
         a {
           display: block;
           padding: 0;
+          color: $link-color;
 
           &:hover, &:focus {
             background: transparent;

--- a/lms/static/sass/course/wiki/_wiki.scss
+++ b/lms/static/sass/course/wiki/_wiki.scss
@@ -49,6 +49,7 @@ section.wiki {
         height: 100%;
         text-overflow: ellipsis;
         white-space: nowrap;
+        color: $link-color;
       }
 
       &:after {

--- a/lms/static/sass/shared/_footer.scss
+++ b/lms/static/sass/shared/_footer.scss
@@ -35,7 +35,6 @@
 
       &:hover, &:focus, &:active {
         border-bottom: 1px dotted $link-color;
-        color: $link-color;
       }
     }
 
@@ -208,7 +207,7 @@
 // edX theme: LMS Footer
 // ====================
 $edx-footer-spacing: ($baseline*0.75);
-$edx-footer-link-color: rgb(0, 158, 231);
+$edx-footer-link-color: $link-color;
 $edx-footer-bg-color: rgb(252,252,252);
 
 %edx-footer-reset {


### PR DESCRIPTION
# This work includes...

As part of our commitment to accessibility we are going through both the LMS and CMS (in addition to the Drupal site, which is another repo) and updating the colors to meet or exceed AA compliance.

This group of work updates the offending blues.
## Changes

`$blue` was changed from `rgb(29,157,217)` to `rgb(0, 125, 184)`
`$m-blue-d2` was changed from `rgb(21, 128, 176)` to `$blue`
`$link-blue` - a themeable property - was left unchanged, as it points to `$blue` already (which is now accessible)
### Blue-on-gray locations
- Courseware course navigation (accordions)
- Wiki article functions (nav)
- Wiki breadcrumb (nav)
- Course updates and news sidebar

---

@cptvitamin @frrrances Would you guys review when you get a chance?
