### PR TITLE
Fix forum response display issue with long labels on action buttons

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -223,3 +223,5 @@ Tim Krones <t.krones@gmx.net>
 Linda Liu <lliu@edx.org>
 Alessandro Verdura <finalmente2@tin.it>
 Sven Marnach <sven@marnach.net>
+Richard Moch <richard.moch@gmail.com>
+

--- a/lms/static/sass/discussion/elements/_actions.scss
+++ b/lms/static/sass/discussion/elements/_actions.scss
@@ -295,6 +295,7 @@
 
   .action-button, .action-list-item {
     .action-label {
+      @include float(left);
       .label-checked {
         display: none;
       }

--- a/lms/static/sass/discussion/elements/_actions.scss
+++ b/lms/static/sass/discussion/elements/_actions.scss
@@ -196,6 +196,7 @@
 
       &:hover, &:focus {
         border-color: $blue-d2;
+        background-color: $white;
 
         .action-label {
           color: $blue-d2;
@@ -216,6 +217,7 @@
 
       &:hover, &:focus {
         border-color: $green-d1;
+        background-color: $white;
 
         .action-label {
           color: $green-d2;
@@ -229,6 +231,7 @@
 
       &:hover, &:focus {
         border-color: $gray;
+        background-color: $white;
 
         .action-icon {
           border: 1px solid $gray;

--- a/lms/static/sass/discussion/views/_thread.scss
+++ b/lms/static/sass/discussion/views/_thread.scss
@@ -39,11 +39,13 @@ body.discussion, .discussion-module {
     .response-header-content {
       display: inline-block;
       vertical-align: top;
-      width: flex-grid(9,12);
+      width: flex-grid(11,12);
     }
 
     .response-header-actions {
-      width: flex-grid(3,12);
+      position: absolute;
+      right: ($baseline);
+      top: ($baseline);
       @include float(right);
     }
   }

--- a/lms/static/sass/discussion/views/_thread.scss
+++ b/lms/static/sass/discussion/views/_thread.scss
@@ -44,7 +44,7 @@ body.discussion, .discussion-module {
 
     .response-header-actions {
       position: absolute;
-      right: ($baseline);
+      @include right($baseline);
       top: ($baseline);
       @include float(right);
     }


### PR DESCRIPTION
In the forum response block, ratio between blocks `.response-header-content` (3/4) and `.response-header-actions (1/4)` does not allow correct display of action button "Mark as answers/Unmark as answer" in languages needing more letters like french ("Marquer comme Réponse/Ne plus marquer comme Réponse").

This modification sets the `.response-header-actions` block to an absolute position allowing long text labels to overlap `.response-header-content` instead of using several lines. 

See screenshot:
![mark as answer in french](http://izi.cat/image/c3ab15f5ec3440c3b35b1eaaffd7018f.png)
