### PR TITLE
default parameter for retreive url

### DIFF
--- a/common/static/coffee/src/discussion/content.coffee
+++ b/common/static/coffee/src/discussion/content.coffee
@@ -126,7 +126,7 @@ if Backbone?
     
   class @Thread extends @Content
     urlMappers:
-      'retrieve'    : -> DiscussionUtil.urlFor('retrieve_single_thread', @discussion.id || "", @id)
+      'retrieve'    : -> DiscussionUtil.urlFor('retrieve_single_thread', @attributes.commentable_id, @id)
       'reply'       : -> DiscussionUtil.urlFor('create_comment', @id)
       'unvote'      : -> DiscussionUtil.urlFor("undo_vote_for_#{@get('type')}", @id)
       'upvote'      : -> DiscussionUtil.urlFor("upvote_#{@get('type')}", @id)

--- a/common/static/coffee/src/discussion/content.coffee
+++ b/common/static/coffee/src/discussion/content.coffee
@@ -126,7 +126,7 @@ if Backbone?
     
   class @Thread extends @Content
     urlMappers:
-      'retrieve'    : -> DiscussionUtil.urlFor('retrieve_single_thread', @discussion.id, @id)
+      'retrieve'    : -> DiscussionUtil.urlFor('retrieve_single_thread', @discussion.id || "", @id)
       'reply'       : -> DiscussionUtil.urlFor('create_comment', @id)
       'unvote'      : -> DiscussionUtil.urlFor("undo_vote_for_#{@get('type')}", @id)
       'upvote'      : -> DiscussionUtil.urlFor("upvote_#{@get('type')}", @id)


### PR DESCRIPTION
[TNL-1696](https://openedx.atlassian.net/browse/TNL-1696)

When the discussion_id is undefined its now throwing 404 [here](https://github.com/edx/edx-platform/blob/f0322b966246e14b7b11ae22bdad716847036bce/lms/djangoapps/django_comment_client/forum/views.py#L283) and this is introduce in PR [here](https://github.com/edx/edx-platform/pull/7266/files#diff-5fcc01de4fe7b25beff18d2f8309cf89R282) which is merged in release of 10 march

Solution:
As defined [here](https://github.com/edx/edx-platform/blob/78deaed2458811253972db870ebbd50bb091def2/common/static/coffee/src/discussion/views/discussion_thread_view.coffee#L122) is passing commentable_id to view

Note:
Before the release discussion_id was "undefined" in url and its not throwing 404 
[here](https://github.com/edx/edx-platform/pull/7266/files#diff-5fcc01de4fe7b25beff18d2f8309cf89R73) is more details before release 
