### PR TITLE
Don't use the working tree as storage for test-created files.

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore.py
@@ -12,6 +12,7 @@ import uuid
 from contracts import contract
 from nose.plugins.attrib import attr
 
+from openedx.core.lib import tempdir
 from xblock.fields import Reference, ReferenceList, ReferenceValueDict
 from xmodule.course_module import CourseDescriptor
 from xmodule.modulestore import ModuleStoreEnum
@@ -51,7 +52,7 @@ class SplitModuleTest(unittest.TestCase):
     }
     modulestore_options = {
         'default_class': 'xmodule.raw_module.RawDescriptor',
-        'fs_root': '',
+        'fs_root': tempdir.mkdtemp_clean(),
         'xblock_mixins': (InheritanceMixin, XModuleMixin, EditInfoMixin)
     }
 


### PR DESCRIPTION
When running the test suite, the working tree is left with directories named, "best", "counter", "guestx", "new", "nihilx", "test_course", "test_org", and "testx". These are all due to the modulestore creating OSFS directories. This pull request puts them all into a temp directory cleaned up at the end of the process.
@singingwolfboy ?
