### PR TITLE
Fix empty promise. It was always evaluating to true.

### DIFF
--- a/common/test/acceptance/pages/lms/instructor_dashboard.py
+++ b/common/test/acceptance/pages/lms/instructor_dashboard.py
@@ -400,7 +400,7 @@ class CohortManagementSection(PageObject):
         """
         if wait_for_messages:
             EmptyPromise(
-                lambda: self.q(css=self._bounded_selector(title_css)).results != 0,
+                lambda: len(self.q(css=self._bounded_selector(title_css)).results) != 0,
                 "Waiting for messages to appear"
             ).fulfill()
         message_title = self.q(css=self._bounded_selector(title_css))


### PR DESCRIPTION
This addresses TNL-1808 (and likely other flaky tests
in this area).
