### PR TITLE
Consistently use display_name_with_default in Studio

### DIFF
--- a/cms/templates/studio_xblock_wrapper.html
+++ b/cms/templates/studio_xblock_wrapper.html
@@ -9,7 +9,7 @@ xblock_url = xblock_studio_url(xblock)
 show_inline = xblock.has_children and not xblock_url
 section_class = "level-nesting" if show_inline else "level-element"
 collapsible_class = "is-collapsible" if xblock.has_children else ""
-label = xblock.display_name or xblock.scope_ids.block_type
+label = xblock.display_name_with_default or xblock.scope_ids.block_type
 messages = json.dumps(xblock.validate().to_json())
 %>
 

--- a/common/test/acceptance/tests/studio/test_studio_container.py
+++ b/common/test/acceptance/tests/studio/test_studio_container.py
@@ -1020,3 +1020,39 @@ class UnitPublishingTest(ContainerBase):
     #     self.assertEqual(2, self.courseware.num_xblock_components)
     #     self.assertEqual('html', self.courseware.xblock_component_type(0))
     #     self.assertEqual('discussion', self.courseware.xblock_component_type(1))
+
+
+class DisplayNameTest(ContainerBase):
+    """
+    Test consistent use of display_name_with_default
+    """
+    def populate_course_fixture(self, course_fixture):
+        """
+        Sets up a course structure with nested verticals.
+        """
+        course_fixture.add_children(
+            XBlockFixtureDesc('chapter', 'Test Section').add_children(
+                XBlockFixtureDesc('sequential', 'Test Subsection').add_children(
+                    XBlockFixtureDesc('vertical', 'Test Unit').add_children(
+                        XBlockFixtureDesc('vertical', None)
+                    )
+                )
+            )
+        )
+
+    def test_display_name_default(self):
+        """
+        Scenario: Given that an XBlock with a dynamic display name has been added to the course,
+            When I view the unit page and note the display name of the block,
+            Then I see the dynamically generated display name,
+            And when I then go to the container page for that same block,
+            Then I see the same generated display name.
+        """
+        # Unfortunately no blocks in the core platform implement display_name_with_default
+        # in an interesting way for this test, so we are just testing for consistency and not
+        # the actual value.
+        unit = self.go_to_unit_page()
+        test_block = unit.xblocks[1]
+        title_on_unit_page = test_block.name
+        container = test_block.go_to_container()
+        self.assertEqual(container.name, title_on_unit_page)


### PR DESCRIPTION
A one-line fix for Studio + acceptance test.

**Description**: If an XBlock has no `display_name` set but instead implements `display_name_with_default`, Studio sometimes uses the latter and sometimes just uses the block type instead. This is a one-line fix to address that inconsistency.

**Discussions**: Discussed with Cale and Ned at https://github.com/open-craft/xblock-mentoring/pull/4#discussion_r26609303

**Sandbox**: Active at http://sandbox.opencraft.com:18010/ though if it's working it should be indistinguishable from normal.

**Partner information**: hosted on edx.org (Harvard)

**Merge timeline**: TBD... but hoping this can get in quickly as it is a fix used by the mentoring v2 block that is almost finished its review.

**Notes**: Not sure if we want a full bok choy test for this, but I wrote one and am including it for now. The test does fail without this fix.
