### PR TITLE
Make LMS base gray AA compliant

### DIFF
--- a/lms/static/sass/base/_variables.scss
+++ b/lms/static/sass/base/_variables.scss
@@ -69,7 +69,7 @@ $white-t1: rgba($white, 0.25);
 $white-t2: rgba($white, 0.5);
 $white-t3: rgba($white, 0.75);
 
-$gray: rgb(127,127,127);    // #7f7f7f
+$gray: rgb(118,118,118);    // #767676 AA compliant
 $gray-l1: tint($gray,20%);  // #989898
 $gray-l2: tint($gray,40%);  // #b2b2b2
 $gray-l3: tint($gray,60%);  // #cbcbcb


### PR DESCRIPTION
Updated the base $gray variable to meet accessibility requirements. 

@cptvitamin and @clrux Can you review?
