### PR TITLE
Fixed i18n Problem with xBlock Menu

### DIFF
--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -94,7 +94,7 @@ class CapaFields(object):
         scope=Scope.settings,
         # it'd be nice to have a useful default but it screws up other things; so,
         # use display_name_with_default for those
-        default="Blank Advanced Problem"
+        default=_("Blank Advanced Problem")
     )
     attempts = Integer(
         help=_("Number of attempts taken by the student on this problem"),


### PR DESCRIPTION
![screen shot 2015-03-30 at 1 42 37 am](https://cloud.githubusercontent.com/assets/2852075/6889265/0fa5415a-d693-11e4-8a8f-aec37ef57c0b.png)
![screen shot 2015-03-30 at 2 00 20 am](https://cloud.githubusercontent.com/assets/2852075/6889266/1b682174-d693-11e4-9100-04e0ec537d28.png)

Addressed bug in the following issue:
https://openedx.atlassian.net/browse/TNL-1296

There were strings that were not i18n in the xblock problem menu. The fix I made seems a little hacky. The yaml files controlled what the titles ended up being in menu. Since yaml has no i18n capabilities, and since mako does not allow for hashtables (unless they are introduced from the function/class that renders them) the commit I made was the best solution I could think of. If you know how to introduce i18n strings into yaml files or where this file is being rendered so I can pass in a hashtable that would be great! I also think the code could be refactored to use a function in those three spots instead of duplicate code, but it's 5am so I'll try and fix that tomorrow. Also note that the html has awful white spacing for some reason. I don't know how to fix that with mako. More discussion/information on this issue can be found in the issue thread linked above.

Observe bad behavior:
1. Load Studio.
2. Log in as staff@example.com.
3. Click "Content" and go to "Outline" in the dropdown.
4. In Example Week 1 click on "Homework."
5. Click on any question from the dropdown.
6. Click on "Problem."
7. Clicking on both "Common Problem Types" and "Advanced," notice how some options are not i18n.

~Please keep this webpage open after viewing the bad results~

View Correction:
1. Put my code into your edx-platform folder.
2. Kill the studio process.
3. While logged in as edxapp enter the following into your commandline: 
paver i18n_extract && paver i18n_dummy && paver i18n_generate && paver devstack studio
4. Reload the studio page and notice how the strings are in the correct i18n format.
