### PR TITLE
WIP versioned urls for profile images.

### DIFF
--- a/common/djangoapps/student/migrations/0048_add_profile_image_version.py
+++ b/common/djangoapps/student/migrations/0048_add_profile_image_version.py
@@ -8,15 +8,15 @@ from django.db import models
 class Migration(SchemaMigration):
 
     def forwards(self, orm):
-        # Adding field 'UserProfile.has_profile_image'
-        db.add_column('auth_userprofile', 'has_profile_image',
-                      self.gf('django.db.models.fields.BooleanField')(default=False),
+        # Adding field 'UserProfile.profile_image_uploaded_at'
+        db.add_column('auth_userprofile', 'profile_image_uploaded_at',
+                      self.gf('django.db.models.fields.DateTimeField')(null=True),
                       keep_default=False)
 
 
     def backwards(self, orm):
-        # Deleting field 'UserProfile.has_profile_image'
-        db.delete_column('auth_userprofile', 'has_profile_image')
+        # Deleting field 'UserProfile.profile_image_uploaded_at'
+        db.delete_column('auth_userprofile', 'profile_image_uploaded_at')
 
 
     models = {

--- a/common/djangoapps/student/migrations/0049_auto__add_languageproficiency__add_unique_languageproficiency_code_use.py
+++ b/common/djangoapps/student/migrations/0049_auto__add_languageproficiency__add_unique_languageproficiency_code_use.py
@@ -173,7 +173,7 @@ class Migration(SchemaMigration):
             'courseware': ('django.db.models.fields.CharField', [], {'default': "'course.xml'", 'max_length': '255', 'blank': 'True'}),
             'gender': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '6', 'null': 'True', 'blank': 'True'}),
             'goals': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
-            'has_profile_image': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'profile_image_uploaded_at': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
             'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'language': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '255', 'blank': 'True'}),
             'level_of_education': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '6', 'null': 'True', 'blank': 'True'}),

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -251,7 +251,15 @@ class UserProfile(models.Model):
     goals = models.TextField(blank=True, null=True)
     allow_certificate = models.BooleanField(default=1)
     bio = models.TextField(blank=True, null=True)
-    has_profile_image = models.BooleanField(default=0)
+    profile_image_uploaded_at = models.DateTimeField(null=True)
+
+    @property
+    def has_profile_image(self):
+        """
+        Convenience method that returns a boolean indicating whether or not
+        this user has uploaded a profile image.
+        """
+        return self.profile_image_uploaded_at is not None
 
     def get_meta(self):  # pylint: disable=missing-docstring
         js_str = self.meta
@@ -321,7 +329,7 @@ def user_profile_pre_save_callback(sender, **kwargs):
 
     # Remove profile images for users who require parental consent
     if user_profile.requires_parental_consent() and user_profile.has_profile_image:
-        user_profile.has_profile_image = False
+        user_profile.profile_image_uploaded_at = None
 
 
 class UserSignupSource(models.Model):

--- a/common/djangoapps/student/tests/test_auto_auth.py
+++ b/common/djangoapps/student/tests/test_auto_auth.py
@@ -43,7 +43,9 @@ class AutoAuthEnabledTestCase(UrlResetMixin, TestCase):
         """
         self._auto_auth()
         self.assertEqual(User.objects.count(), 1)
-        self.assertTrue(User.objects.all()[0].is_active)
+        user = User.objects.all()[0]
+        self.assertTrue(user.is_active)
+        self.assertFalse(user.profile.requires_parental_consent())
 
     def test_create_same_user(self):
         self._auto_auth(username='test')

--- a/common/djangoapps/student/tests/test_parental_controls.py
+++ b/common/djangoapps/student/tests/test_parental_controls.py
@@ -69,14 +69,14 @@ class ProfileParentalControlsTest(TestCase):
         """Verify that a profile's image obeys parental controls."""
 
         # Verify that an image cannot be set for a user with no year of birth set
-        self.profile.has_profile_image = True
+        self.profile.profile_image_uploaded_at = datetime.datetime.now()
         self.profile.save()
         self.assertFalse(self.profile.has_profile_image)
 
         # Verify that an image can be set for an adult user
         current_year = datetime.datetime.now().year
         self.set_year_of_birth(current_year - 20)
-        self.profile.has_profile_image = True
+        self.profile.profile_image_uploaded_at = datetime.datetime.now()
         self.profile.save()
         self.assertTrue(self.profile.has_profile_image)
 

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1717,13 +1717,14 @@ def auto_auth(request):
     # If successful, this will return a tuple containing
     # the new user object.
     try:
-        user, _profile, reg = _do_create_account(form)
+        user, profile, reg = _do_create_account(form)
     except AccountValidationError:
         # Attempt to retrieve the existing user.
         user = User.objects.get(username=username)
         user.email = email
         user.set_password(password)
         user.save()
+        profile = UserProfile.objects.get(user=user)
         reg = Registration.objects.get(user=user)
 
     # Set the user's global staff bit
@@ -1734,6 +1735,12 @@ def auto_auth(request):
     # Activate the user
     reg.activate()
     reg.save()
+
+    # ensure parental consent threshold is met
+    year = datetime.date.today().year
+    age_limit = settings.PARENTAL_CONSENT_AGE_LIMIT
+    profile.year_of_birth = (year - age_limit) - 1
+    profile.save()
 
     # Enroll the user in a course
     if course_key is not None:


### PR DESCRIPTION
@dan-f @andy-armstrong @maxrothman please have a look.

This adds a version (first 8 chars from an md5 hash of the timestamp at the moment of upload) to the filenames / urls of user-uploaded profile images.  This avoids the need to do any cache busting - images should be cacheable indefinitely, as their urls will change automatically when updated.

This was hacked together fairly rapidly.  All tests passing locally, but I think coverage might need to be adjusted a little better.
