### PR TITLE
Fix two missing replacements of {studio_name}

### DIFF
--- a/cms/templates/howitworks.html
+++ b/cms/templates/howitworks.html
@@ -14,7 +14,6 @@
 <div class="wrapper-content-header wrapper">
   <section class="content content-header">
     <header>
-      ## "edX Studio" should not be translated
       <h1><span class="wrapper-text-welcome">${_("Welcome to {studio_name}").format(
         studio_name=u'</span><span class="logo">{studio_name}</span>'.format(
           studio_name=settings.STUDIO_NAME
@@ -96,7 +95,7 @@
 
             <li class="proofpoint">
               <h4 class="title">${_("A Broad Library of Problem Types")}</h4>
-              <p>${_("It's more than just multiple choice. Studio supports more than a dozen types of problems to challenge your learners.")}</p>
+              <p>${_("It's more than just multiple choice. {studio_name} supports more than a dozen types of problems to challenge your learners.").format(studio_name=settings.STUDIO_SHORT_NAME)}</p>
             </li>
           </ul>
         </div>

--- a/cms/templates/import.html
+++ b/cms/templates/import.html
@@ -198,7 +198,7 @@ else:
     <aside class="content-supplementary" role="complimentary">
       <div class="bit">
           <h3 class="title-3">${_("Why import a library?")}</h3>
-          <p>${_("You might want to update an existing library to a new version, or replace an existing library entirely. You might also have developed a library outside of Studio.")}</p>
+          <p>${_("You might want to update an existing library to a new version, or replace an existing library entirely. You might also have developed a library outside of {studio_name}.").format(studio_name=settings.STUDIO_SHORT_NAME)}</p>
       </div>
 
       <div class="bit">


### PR DESCRIPTION
Located in `howitworks.html` and `import.html`.
Also, the translation comment in this html template is not needed as there is no 'edX Studio' now.
