### PR TITLE
Fix string extraction error in underscore files

### DIFF
--- a/cms/templates/js/course-outline.underscore
+++ b/cms/templates/js/course-outline.underscore
@@ -44,7 +44,10 @@ if (xblockInfo.get('graded')) {
     <div class="<%= xblockType %>-header">
         <% if (includesChildren) { %>
             <h3 class="<%= xblockType %>-header-details expand-collapse <%= isCollapsed ? 'expand' : 'collapse' %> ui-toggle-expansion"
-                title="<%= interpolate(gettext('Collapse/Expand this %(xblock_type)s'), { xblock_type: xblockTypeDisplayName }, true) %>">
+                title="<%= interpolate(
+                      gettext('Collapse/Expand this %(xblock_type)s'), { xblock_type: xblockTypeDisplayName }, true
+                ) %>"
+            >
                 <i class="icon fa fa-caret-down"></i>
         <% } else { %>
             <h3 class="<%= xblockType %>-header-details">
@@ -156,7 +159,10 @@ if (xblockInfo.get('graded')) {
             <p><%= gettext("You haven't added any content to this course yet.") %>
                 <a href="#" class="button button-new" data-category="<%= childCategory %>"
                    data-parent="<%= xblockInfo.get('id') %>" data-default-name="<%= defaultNewChildName %>"
-                   title="<%= interpolate(gettext('Click to add a new %(xblock_type)s'), { xblock_type: defaultNewChildName }, true) %>" >
+                   title="<%= interpolate(
+                         gettext('Click to add a new %(xblock_type)s'), { xblock_type: defaultNewChildName }, true
+                   ) %>"
+                >
                     <i class="icon fa fa-plus"></i><%= addChildLabel %>
                 </a>
             </p>
@@ -174,7 +180,10 @@ if (xblockInfo.get('graded')) {
                 <div class="add-<%= childType %> add-item">
                     <a href="#" class="button button-new" data-category="<%= childCategory %>"
                        data-parent="<%= xblockInfo.get('id') %>" data-default-name="<%= defaultNewChildName %>"
-                       title="<%= interpolate(gettext('Click to add a new %(xblock_type)s'), { xblock_type: defaultNewChildName }, true) %>" >
+                       title="<%= interpolate(
+                             gettext('Click to add a new %(xblock_type)s'), { xblock_type: defaultNewChildName }, true
+                       ) %>"
+                    >
                         <i class="icon fa fa-plus"></i><%= addChildLabel %>
                     </a>
                 </div>

--- a/cms/templates/js/list.underscore
+++ b/cms/templates/js/list.underscore
@@ -2,14 +2,20 @@
     <div class="no-content">
         <p>
             <%- emptyMessage %>
-            <a href="#" class="button new-button"><i class="icon fa fa-plus"></i> <%= interpolate(gettext("Add your first %(item_type)s"), {item_type: itemCategoryDisplayName}, true) %></a>
+            <a href="#" class="button new-button"><i class="icon fa fa-plus"></i>
+            <%= interpolate(
+                gettext("Add your first %(item_type)s"), {item_type: itemCategoryDisplayName}, true
+            ) %></a>
         </p>
     </div>
 <% } else { %>
     <div class="list-items"></div>
     <% if (!isEditing) { %>
         <button class="action action-add">
-            <i class="icon fa fa-plus"></i><%- interpolate(gettext('New %(item_type)s'), {item_type: itemCategoryDisplayName}, true) %>
+            <i class="icon fa fa-plus"></i>
+            <%- interpolate(
+                gettext('New %(item_type)s'), {item_type: itemCategoryDisplayName}, true
+            ) %>
         </button>
     <% } %>
 <% } %>

--- a/cms/templates/js/publish-xblock.underscore
+++ b/cms/templates/js/publish-xblock.underscore
@@ -48,7 +48,9 @@ var visibleToStaffOnly = visibilityState === 'staff_only';
             <% if (releaseDate) { %>
                 <span class="release-date"><%= releaseDate %></span>
                 <span class="release-with">
-                    <%= interpolate(gettext('with %(release_date_from)s'), { release_date_from: releaseDateFrom }, true) %>
+                    <%= interpolate(
+                        gettext('with %(release_date_from)s'), { release_date_from: releaseDateFrom }, true
+                    ) %>
                 </span>
 
             <% } else { %>
@@ -70,7 +72,9 @@ var visibleToStaffOnly = visibilityState === 'staff_only';
                 <%= gettext("Staff Only") %>
                 <% if (!hasExplicitStaffLock) { %>
                     <span class="inherited-from">
-                        <%= interpolate(gettext("with %(section_or_subsection)s"),{ section_or_subsection: staffLockFrom }, true) %>
+                        <%= interpolate(
+                            gettext("with %(section_or_subsection)s"),{ section_or_subsection: staffLockFrom }, true
+                        ) %>
                     </span>
                 <% } %>
             </p>

--- a/cms/templates/js/xblock-outline.underscore
+++ b/cms/templates/js/xblock-outline.underscore
@@ -7,7 +7,10 @@
         <div class="wrapper-xblock-header-primary">
             <% if (includesChildren) { %>
                 <h3 class="xblock-title expand-collapse <%= isCollapsed ? 'expand' : 'collapse' %>"
-                    title="<%= interpolate(gettext('Collapse/Expand this %(xblock_type)s'), { xblock_type: xblockTypeDisplayName }, true) %>">
+                    title="<%= interpolate(
+                          gettext('Collapse/Expand this %(xblock_type)s'), { xblock_type: xblockTypeDisplayName }, true
+                    ) %>"
+                >
                     <i class="icon fa fa-caret-down ui-toggle-expansion"></i>
             <% } else { %>
                 <h3 class="xblock-title">
@@ -54,7 +57,10 @@
             <p><%= gettext("You haven't added any content to this course yet.") %>
                 <a href="#" class="button button-new" data-category="<%= childCategory %>"
                    data-parent="<%= xblockInfo.get('id') %>" data-default-name="<%= defaultNewChildName %>"
-                   title="<%= interpolate(gettext('Click to add a new %(xblock_type)s'), { xblock_type: defaultNewChildName }, true) %>" >
+                   title="<%= interpolate(
+                         gettext('Click to add a new %(xblock_type)s'), { xblock_type: defaultNewChildName }, true
+                   ) %>"
+                >
                     <i class="icon fa fa-plus"></i><%= addChildLabel %>
                 </a>
             </p>
@@ -67,7 +73,10 @@
             <div class="add-xblock-component">
                 <a href="#" class="button button-new" data-category="<%= childCategory %>"
                    data-parent="<%= xblockInfo.get('id') %>" data-default-name="<%= defaultNewChildName %>"
-                   title="<%= interpolate(gettext('Click to add a new %(xblock_type)s'), { xblock_type: defaultNewChildName }, true) %>" >
+                   title="<%= interpolate(
+                         gettext('Click to add a new %(xblock_type)s'), { xblock_type: defaultNewChildName }, true
+                   ) %>"
+                >
                     <i class="icon fa fa-plus"></i><%= addChildLabel %>
                 </a>
             </div>

--- a/lms/templates/courseware_search/search_list.underscore
+++ b/lms/templates/courseware_search/search_list.underscore
@@ -9,7 +9,11 @@
 
     <% if (hasMoreResults) { %>
         <a class="search-load-next" href="javascript:void(0);">
-            <%= interpolate(gettext("Load next %s results"), [pageSize]) %>
+            <%= interpolate(
+                ngettext("Load next %(num_items) result", "Load next %(num_items) results", pageSize),
+                { num_items: pageSize },
+                true
+            ) %>
             <i class="icon fa-spinner fa-spin"></i>
         </a>
     <% } %>


### PR DESCRIPTION
The written style `interpolate(gettext('some text'), {...}, ...)` will will cause the string inside gettext() not be extracted.
So a separate line is needed for `gettext` when gettext function is directly called inside a call to the interpolate function.
