### PR TITLE
Relative_url assets are not loading in Iframe

### DIFF
--- a/common/djangoapps/contentserver/middleware.py
+++ b/common/djangoapps/contentserver/middleware.py
@@ -31,6 +31,8 @@ class StaticContentServer(object):
             request.path.startswith('/' + XASSET_LOCATION_TAG + '/') or
             request.path.startswith('/' + AssetLocator.CANONICAL_NAMESPACE)
         ):
+            if AssetLocator.CANONICAL_NAMESPACE in request.path:
+                request.path = request.path.replace('block/', 'block@', 1)
             try:
                 loc = StaticContent.get_location_from_path(request.path)
             except (InvalidLocationError, InvalidKeyError):

--- a/common/djangoapps/static_replace/__init__.py
+++ b/common/djangoapps/static_replace/__init__.py
@@ -9,6 +9,8 @@ from xmodule.modulestore.django import modulestore
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.contentstore.content import StaticContent
 
+from opaque_keys.edx.locator import AssetLocator
+
 log = logging.getLogger(__name__)
 
 
@@ -152,7 +154,6 @@ def replace_static_urls(text, data_directory=None, course_id=None, static_asset_
         """
         Replace a single matched url.
         """
-
         # Don't mess with things that end in '?raw'
         if rest.endswith('?raw'):
             return original
@@ -180,6 +181,10 @@ def replace_static_urls(text, data_directory=None, course_id=None, static_asset_
                 # if not, then assume it's courseware specific content and then look in the
                 # Mongo-backed database
                 url = StaticContent.convert_legacy_static_url_with_course_id(rest, course_id)
+
+                if AssetLocator.CANONICAL_NAMESPACE in url:
+                    url = url.replace('block@', 'block/', 1)
+
         # Otherwise, look the file up in staticfiles_storage, and append the data directory if needed
         else:
             course_path = "/".join((static_asset_path or data_directory, rest))


### PR DESCRIPTION
[TNL-1747](https://openedx.atlassian.net/browse/TNL-1747)

Problem:
Html src attribute (for scripts, images, links etc) the value of src attr is append after the last  forward slash "/"  of current url Example:
url ==> http://abc.com/
element ==> `<img src="application.js"></img>`
Final static path will be ===> http://abc.com/application.js

For old mongo courses e.g "http://localhost:8001/c4x/DartmouthX/SS101/asset/index.html" the url is fine for src attribute ==> "http://localhost:8001/c4x/DartmouthX/SS101/asset/application.js" but for split courses the url is in this format "http://localhost:8001/asset-v1:DartmouthX+SS101+2015_SP15+type@asset+block@index1.html" so the url for static path becomes "http://localhost:8001/application.js" which is throwing 404 (append after last forward slash)

Solution 
The current url for to access static contents for split courses is e.g
http://localhost:8001/asset-v1:DartmouthX+SS101+2015_SP15+type@asset+block@index1.html
Now add another url through which we can access asset also using following format:
http://localhost:8001/asset-v1:DartmouthX+SS101+2015_SP15+type@asset+block/index1.html

Scenario:
When an iframe is loaded with new url just like above "http://localhost:8001/asset-v1:DartmouthX+SS101+2015_SP15+type@asset+block/index1.html" and an iframe children is like `<script src="abc.js">` the url of this script will be "http://localhost:8001/asset-v1:DartmouthX+SS101+2015_SP15+type@asset+block/abc.js"
