### PR TITLE
added READMEs for top level directories

### DIFF
--- a/cms/README.rst
+++ b/cms/README.rst
@@ -1,0 +1,4 @@
+CMS (Content Management System)
+-------------------------------
+
+This directory contains code relating to the course management portal for edX, also known as Studio.

--- a/common/README.rst
+++ b/common/README.rst
@@ -1,0 +1,4 @@
+common
+------
+
+This directory contains common code shared between LMS and CMS, such as Mako templates, CSS, and Coffescript.

--- a/lms/README.rst
+++ b/lms/README.rst
@@ -1,0 +1,4 @@
+LMS (Learning Management System)
+--------------------------------
+
+This directory contains code relating to the student portal for edX.

--- a/openedx/README.rst
+++ b/openedx/README.rst
@@ -1,0 +1,8 @@
+OpenEdx
+-------
+
+This is the root package for Open edX. 
+The intent is that all importable code from Open edX will eventually live here, including the code in the lms, cms, and common directories.
+
+Note: for now the code is not structured like this, and hence legacy code will continue to live in a number of different packages. 
+All new code should be created in this package, and the legacy code will be moved here gradually.


### PR DESCRIPTION
This is a small commit that adds initial README docs to the main top level directories. It simply adds a simple explanation of each directory which hopefully allows new contributors to get up to speed with the system much quicker. Me and a few other team members have been analyzing the system for about a month now as part of a class project and felt that having more information scattered through the code would've been helpful and I'm sure future contributors will as well. Please let me know if any of the descriptions of the directories aren't entirely accurate! Thanks!

Studio updates: added README.rst
LMS updates: added README.rst
common updates: added README.rst
openedx updates: added README.rst (note: this description was copied from the **init**.py, but I felt not everyone would be compelled to check that file for a note)

Testing: Since no code was changed I didn't run any tests

Urgency: low
