### PR TITLE
Pass standard list of xblock mixins to MixedModulestore in tests

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/tests/test_mixed_modulestore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_mixed_modulestore.py
@@ -111,7 +111,8 @@ class TestMixedModuleStore(CourseComparisonTest):
                     'xblock_mixins': modulestore_options['xblock_mixins'],
                 }
             },
-        ]
+        ],
+        'xblock_mixins': modulestore_options['xblock_mixins'],
     }
 
     def _compare_ignore_version(self, loc1, loc2, msg=None):


### PR DESCRIPTION
@doctoryes @jzoldak @martynjames: This should fix the failing tests on master.
