### PR TITLE
Make newly created xblock's display name localized by default

### DIFF
--- a/cms/djangoapps/contentstore/features/discussion-editor.py
+++ b/cms/djangoapps/contentstore/features/discussion-editor.py
@@ -18,7 +18,7 @@ def i_see_only_the_settings_and_values(step):
     world.verify_all_setting_entries(
         [
             ['Category', "Week 1", False],
-            ['Display Name', "Discussion", False],
+            ['Display Name', "Discussion", True],
             ['Subcategory', "Topic-Level Student-Visible Label", False]
         ])
 

--- a/cms/djangoapps/contentstore/features/html-editor.py
+++ b/cms/djangoapps/contentstore/features/html-editor.py
@@ -34,7 +34,7 @@ def i_created_raw_html(step):
 def i_see_only_the_html_display_name(step):
     world.verify_all_setting_entries(
         [
-            ['Display Name', "Text", False],
+            ['Display Name', "Text", True],
             ['Editor', "Visual", False]
         ]
     )


### PR DESCRIPTION
Before applying this patch, new xblock created by studio will use the default display_name defined in python code or the display_name read from .yaml files.
For example, when I enabled the 'Chinese(China)' language, I got the following display when I clicked the 'problem' button.
![001](https://cloud.githubusercontent.com/assets/1275238/6934938/722425a2-d86f-11e4-81ac-c80e0d4fc15a.png)
If I create a 'Dropdown' problem, I'll get the following created xblock:
![004](https://cloud.githubusercontent.com/assets/1275238/6934944/83c30abc-d86f-11e4-91aa-0791920e7c82.png)
Note that, the xblock's name is still 'Dropdown', while in the menu it was already translated into Chinese.
![005](https://cloud.githubusercontent.com/assets/1275238/6934945/87fdf722-d86f-11e4-9c7b-02287a48e309.png)
And take a look at its properties, we can find that the value of 'display_name' field keeps its original English form (Here the '显示名称' is the Chinese translation of 'Display Name').

After applying the patch, I can get the following outputs when I created another 'Dropdown' problem.
![002](https://cloud.githubusercontent.com/assets/1275238/6934941/78feaa1e-d86f-11e4-9d65-cce053cc1081.png)
We can see that here the translated form of 'Dropdown' is displayed.
![003](https://cloud.githubusercontent.com/assets/1275238/6934942/7fa88aec-d86f-11e4-9e29-4053aeaac2fe.png)
And the display_name field is already translated.
