### PR TITLE
Aj/tnl473 studio bad url should return 404

### DIFF
--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -8,6 +8,7 @@ from django.contrib.auth.decorators import login_required
 from django.views.decorators.http import require_GET
 from django.core.exceptions import PermissionDenied
 from django.conf import settings
+from opaque_keys import InvalidKeyError
 from xmodule.modulestore.exceptions import ItemNotFoundError
 from edxmako.shortcuts import render_to_response
 
@@ -154,8 +155,10 @@ def container_handler(request, usage_key_string):
         json: not currently supported
     """
     if 'text/html' in request.META.get('HTTP_ACCEPT', 'text/html'):
-
-        usage_key = UsageKey.from_string(usage_key_string)
+        try:
+            usage_key = UsageKey.from_string(usage_key_string)
+        except InvalidKeyError:
+            raise Http404
         with modulestore().bulk_operations(usage_key.course_key):
             try:
                 course, xblock, lms_link, preview_lms_link = _get_item_in_course(request, usage_key)

--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -155,6 +155,7 @@ def container_handler(request, usage_key_string):
         json: not currently supported
     """
     if 'text/html' in request.META.get('HTTP_ACCEPT', 'text/html'):
+        # Invalid 'usage_key_string' raises 'InvalidKeyError'
         try:
             usage_key = UsageKey.from_string(usage_key_string)
         except InvalidKeyError:

--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -155,10 +155,10 @@ def container_handler(request, usage_key_string):
         json: not currently supported
     """
     if 'text/html' in request.META.get('HTTP_ACCEPT', 'text/html'):
-        # Invalid 'usage_key_string' raises 'InvalidKeyError'
+
         try:
             usage_key = UsageKey.from_string(usage_key_string)
-        except InvalidKeyError:
+        except InvalidKeyError:  # Raise Http404 on invalid 'usage_key_string'
             raise Http404
         with modulestore().bulk_operations(usage_key.course_key):
             try:

--- a/cms/djangoapps/contentstore/views/tests/test_container_page.py
+++ b/cms/djangoapps/contentstore/views/tests/test_container_page.py
@@ -1,8 +1,6 @@
 """
 Unit tests for the container page.
 """
-
-
 import re
 import datetime
 from pytz import UTC

--- a/cms/djangoapps/contentstore/views/tests/test_container_page.py
+++ b/cms/djangoapps/contentstore/views/tests/test_container_page.py
@@ -6,14 +6,16 @@ Unit tests for the container page.
 import re
 import datetime
 from pytz import UTC
+from mock import patch, Mock
+
+from django.http import Http404
+from django.test.client import RequestFactory
+from django.utils import http
+
+import contentstore.views.component as views
 from contentstore.views.tests.utils import StudioPageTestCase
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.factories import ItemFactory
-import contentstore.views.component as views
-from django.test.client import RequestFactory
-from django.utils import http
-from django.http import Http404
-from mock import patch, Mock
 
 
 class ContainerPageTestCase(StudioPageTestCase):
@@ -176,7 +178,7 @@ class ContainerPageTestCase(StudioPageTestCase):
         self.assertRaises(
             Http404, views.container_handler,
             request,
-            usage_key_string='i4x://InvalidOrg/InvalidCourse/vertical/static/InvalidPage',
+            usage_key_string='i4x://InvalidOrg/InvalidCourse/vertical/static/InvalidContent',
             )
 
         # Check 200 response if 'usage_key_string' is correct

--- a/cms/djangoapps/contentstore/views/tests/test_container_page.py
+++ b/cms/djangoapps/contentstore/views/tests/test_container_page.py
@@ -176,7 +176,7 @@ class ContainerPageTestCase(StudioPageTestCase):
         self.assertRaises(
             Http404, views.container_handler,
             request,
-            usage_key_string='i4x://herp/derp/vertical/static/story2.html',
+            usage_key_string='i4x://InvalidOrg/InvalidCourse/vertical/static/InvalidPage',
             )
 
         # Check 200 response if 'usage_key_string' is correct
@@ -184,5 +184,4 @@ class ContainerPageTestCase(StudioPageTestCase):
             request=request,
             usage_key_string=self.vertical.location.to_deprecated_string()
         )
-        # Assert that valid 'usage_key_string' returns 200 status
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
URLs with invalid `usage_key_string` on the container page should return Http404 (Not Found) instead of 500.
Added try/catch check on where `usage_key_string` is transformed to `OpaqueKey` object.

Added Unit test to check container page with valid and invalid `usage_key_string`.
