### PR TITLE
Fixed invalid URL in progress page.

### DIFF
--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -774,10 +774,11 @@ class ProgressPageTests(ModuleStoreTestCase):
             'azU3N_8$',
         ]
         for invalid_id in invalid_student_ids:
+
             self.assertRaises(
                 Http404, views.progress,
                 self.request,
-                course_id=self.course.id.to_deprecated_string(),
+                course_id=unicode(self.course.id),
                 student_id=invalid_id
             )
 

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -727,6 +727,7 @@ class StartDateTests(ModuleStoreTestCase):
         self.assertIn("2015-JULY-17", text)
 
 
+@ddt.ddt
 class ProgressPageTests(ModuleStoreTestCase):
     """
     Tests that verify that the progress page works correctly.
@@ -757,8 +758,38 @@ class ProgressPageTests(ModuleStoreTestCase):
         resp = views.progress(self.request, course_id=self.course.id.to_deprecated_string())
         self.assertEqual(resp.status_code, 200)
 
+    @ddt.data(ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split)
+    def test_student_progress_with_valid_and_invalid_id(self, default_store):
+        """
+         Check that invalid 'student_id' raises Http404 for both old mongo and
+         split mongo courses.
+        """
+
+        # Create new course with respect to 'default_store'
+        self.course = CourseFactory.create(default_store=default_store)
+
+        # Invalid Student Ids (Integer and Non-int)
+        invalid_student_ids = [
+            991021,
+            'azU3N_8$',
+        ]
+        for invalid_id in invalid_student_ids:
+            self.assertRaises(
+                Http404, views.progress,
+                self.request,
+                course_id=self.course.id.to_deprecated_string(),
+                student_id=invalid_id
+            )
+
+        # Enroll student into course
+        CourseEnrollment.enroll(self.user, self.course.id, mode='honor')
+        resp = views.progress(self.request, course_id=self.course.id.to_deprecated_string(), student_id=self.user.id)
+        # Assert that valid 'student_id' returns 200 status
+        self.assertEqual(resp.status_code, 200)
+
     def test_non_asci_grade_cutoffs(self):
         resp = views.progress(self.request, course_id=self.course.id.to_deprecated_string())
+
         self.assertEqual(resp.status_code, 200)
 
     def test_generate_cert_config(self):

--- a/lms/djangoapps/courseware/views.py
+++ b/lms/djangoapps/courseware/views.py
@@ -1028,7 +1028,11 @@ def _progress(request, course_key, student_id):
         # Requesting access to a different student's profile
         if not staff_access:
             raise Http404
-        student = User.objects.get(id=int(student_id))
+        try:
+            student = User.objects.get(id=student_id)
+        # Check for ValueError if 'student_id' cannot be converted to integer.
+        except (ValueError, User.DoesNotExist):
+            raise Http404
 
     # NOTE: To make sure impersonation by instructor works, use
     # student instead of request.user in the rest of the function.


### PR DESCRIPTION
[TNL-382](https://openedx.atlassian.net/browse/TNL-382)

System was generating 500 response on progress page, if someone enters invalid student id. 
Fixed it by adding a try catch block on user query.

Added Unit test to check progress page with valid and invalid student id.
