### PR TITLE
Add "Imported" state to Studio video upload page

### DIFF
--- a/cms/djangoapps/contentstore/views/videos.py
+++ b/cms/djangoapps/contentstore/views/videos.py
@@ -52,6 +52,8 @@ class StatusDisplayStrings(object):
     # Translators: This is the status for a video for which an invalid
     # processing token was provided in the course settings
     _INVALID_TOKEN = ugettext_noop("Invalid Token")
+    # Translators: This is the status for a video that was included in a course import
+    _IMPORTED = ugettext_noop("Imported")
     # Translators: This is the status for a video that is in an unknown state
     _UNKNOWN = ugettext_noop("Unknown")
 
@@ -64,7 +66,8 @@ class StatusDisplayStrings(object):
         "file_complete": _COMPLETE,
         "file_corrupt": _FAILED,
         "pipeline_error": _FAILED,
-        "invalid_token": _INVALID_TOKEN
+        "invalid_token": _INVALID_TOKEN,
+        "imported": _IMPORTED,
     }
 
     @staticmethod


### PR DESCRIPTION
Imported VAL videos get the value "imported" for their status. We
considered not including imported videos on the upload page but have
instead decided to include them, so it is necessary to have a display
string for the imported status value.

@nasthagiri @BenjiLee Please review. Note that the new value is unit tested because the tests for this module iterate over all of the display strings.
