### PR TITLE
[Dependencies] Upgrading oauthlib from 0.6.3 to 0.7.2

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -58,7 +58,7 @@ mongoengine==0.7.10
 networkx==1.7
 nltk==2.0.4
 nose==1.3.3
-oauthlib==0.6.3
+oauthlib==0.7.2
 paramiko==1.9.0
 path.py==3.0.1
 Pillow==2.7.0


### PR DESCRIPTION
This change proposes an upgrade of the oauthlib dependency:
    https://pypi.python.org/pypi/oauthlib
The new version includes pre-configured OAuth endpoints, including one designed to easily verify an OAuth signature (introduced in 0.7.0). This functionality is required for the new LTI Provider feature, since incoming LTI messages are signed using OAuth. The existing LTI Consumer feature already uses the oauthlib library to sign outgoing requests.

The project changelog is at:
    https://github.com/idan/oauthlib/blob/master/CHANGELOG.rst
The project license has not changed between Versions 0.6.3 and 0.7.2.

https://openedx.atlassian.net/wiki/display/TE/Upgrading+Dependent+Libraries
