### PR TITLE
Reverts removed styling rule which broke certificate status message on the course dashboard

### DIFF
--- a/lms/static/sass/multicourse/_dashboard.scss
+++ b/lms/static/sass/multicourse/_dashboard.scss
@@ -602,6 +602,7 @@
 
         // STATE: shown
         &.is-shown {
+          @include clearfix();
           display: block;
         }
 
@@ -758,8 +759,11 @@
 
         // TYPE: status
         &.message-status {
-          background: tint($yellow,70%);
-          border-color: $gray-l3;
+          border-color: $gray-l4;
+
+          .wrapper-message-primary {
+            @include clearfix();
+          }
 
           .message-copy {
             @extend %t-copy-sub1;
@@ -856,19 +860,8 @@
             }
           }
 
-          &.course-status-processing {
-            background-color: $gray-l5;
-            border: 0;
-          }
-
-          &.course-status-certnotavailable {
-            background-color: $gray-l5;
-            border: 0;
-          }
 
           &.course-status-certrendering {
-            background-color: $gray-l5;
-            border: 0;
 
             .cta {
               margin-top: 2px;
@@ -876,8 +869,6 @@
           }
 
           &.course-status-certavailable {
-            background-color: $gray-l5;
-            border: 0;
 
             .message-copy {
               width: flex-grid(6, 12);
@@ -886,8 +877,6 @@
             }
 
             .actions-primary {
-              width: flex-grid(6, 12);
-              position: relative;
               @include float(right);
 
               .action {


### PR DESCRIPTION
**Description:** A fix for message styling issues on the dashboard uncovered by @wedaly. 

**JIRA Epic / Story:** ([SOL-634](https://openedx.atlassian.net/browse/SOL-634)) 

**Confluence / Product Assets** - N/A

**Sandbox URLs** (still being built) - ([pr.7562.m.sandbox.edx.org](pr.7562.m.sandbox.edx.org)) NOTE- sign in as verified@example.com to see fix 

**Dependencies** Prior to merge of this, the plan is to look through the full message list and double check these states. (Full list here - ([Dashboard Testing Workflow v1](https://openedx.atlassian.net/wiki/display/SOL/Dashboard+Testing+Workflow)) 

**PR Author(s) Notes / To-Dos** A list of known open tasks that the PR author has. 
- [x] review with DedX team to ensure manual testing for this and related cases checks out.
- [x] tag reviewer

**Reviewers:** @mattdrayer 

**FYI:** @wedaly  

**Screenshot - Current** Bug shown below
https://s3.amazonaws.com/uploads.hipchat.com/26537/235387/u5kH5gp5d3JPfs3/Screen%20Shot%202015-04-01%20at%2012.30.15%20PM.png

**Screenshot - Fix** Shown below
![image](https://cloud.githubusercontent.com/assets/2023680/6969639/1bc6e422-d93e-11e4-966b-a0c4361d7b50.png)
