### PR TITLE
Ignore pylint error 7610 (translation-of-non-string) on where it is intended

### DIFF
--- a/cms/djangoapps/contentstore/views/checklist.py
+++ b/cms/djangoapps/contentstore/views/checklist.py
@@ -132,12 +132,12 @@ def localize_checklist_text(checklist):
     The method does an in-place operation so the input checklist is modified directly.
     """
     # Localize checklist name
-    checklist['short_description'] = ugettext(checklist['short_description'])
+    checklist['short_description'] = ugettext(checklist['short_description'])    # pylint: disable=translation-of-non-string
 
     # Localize checklist items
     for item in checklist.get('items'):
-        item['short_description'] = ugettext(item['short_description'])
-        item['long_description'] = ugettext(item['long_description'])
-        item['action_text'] = ugettext(item['action_text'])
+        item['short_description'] = ugettext(item['short_description'])    # pylint: disable=translation-of-non-string
+        item['long_description'] = ugettext(item['long_description'])      # pylint: disable=translation-of-non-string
+        item['action_text'] = ugettext(item['action_text'])                # pylint: disable=translation-of-non-string
 
     return checklist

--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -275,7 +275,7 @@ def get_component_templates(courselike, library=False):
                 if not filter_templates or filter_templates(template, courselike):
                     templates_for_category.append(
                         create_template_dict(
-                            _(template['metadata'].get('display_name')),
+                            _(template['metadata'].get('display_name')),    # pylint: disable=translation-of-non-string
                             category,
                             template.get('template_id'),
                             template['metadata'].get('markdown') is not None

--- a/cms/djangoapps/contentstore/views/videos.py
+++ b/cms/djangoapps/contentstore/views/videos.py
@@ -73,7 +73,7 @@ class StatusDisplayStrings(object):
     @staticmethod
     def get(val_status):
         """Map a VAL status string to a localized display string"""
-        return _(StatusDisplayStrings._STATUS_MAP.get(val_status, StatusDisplayStrings._UNKNOWN))
+        return _(StatusDisplayStrings._STATUS_MAP.get(val_status, StatusDisplayStrings._UNKNOWN))    # pylint: disable=translation-of-non-string
 
 
 @expect_json

--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -96,8 +96,8 @@ class CourseMetadata(object):
                 continue
             result[field.name] = {
                 'value': field.read_json(descriptor),
-                'display_name': _(field.display_name),
-                'help': _(field.help),
+                'display_name': _(field.display_name),    # pylint: disable=translation-of-non-string
+                'help': _(field.help),                    # pylint: disable=translation-of-non-string
                 'deprecated': field.runtime_options.get('deprecated', False)
             }
         return result

--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -425,9 +425,9 @@ class CapaMixin(CapaFields):
 
         # Apply customizations if present
         if 'custom_check' in self.text_customization:
-            check = _(self.text_customization.get('custom_check'))
+            check = _(self.text_customization.get('custom_check'))                # pylint: disable=translation-of-non-string
         if 'custom_final_check' in self.text_customization:
-            final_check = _(self.text_customization.get('custom_final_check'))
+            final_check = _(self.text_customization.get('custom_final_check'))    # pylint: disable=translation-of-non-string
         # TODO: need a way to get the customized words into the list of
         # words to be translated
 

--- a/common/lib/xmodule/xmodule/open_ended_grading_classes/combined_open_ended_modulev1.py
+++ b/common/lib/xmodule/xmodule/open_ended_grading_classes/combined_open_ended_modulev1.py
@@ -567,12 +567,12 @@ class CombinedOpenEndedV1Module(object):
             'state': self.state,
             'task_count': len(self.task_xml),
             'task_number': self.current_task_number + 1,
-            'status': ugettext(self.get_status(False)),
+            'status': ugettext(self.get_status(False)),    # pylint: disable=translation-of-non-string
             'display_name': self.display_name,
             'accept_file_upload': self.accept_file_upload,
             'location': self.location,
             'legend_list': LEGEND_LIST,
-            'human_state': ugettext(HUMAN_STATES.get(self.state, "Not started.")),
+            'human_state': ugettext(HUMAN_STATES.get(self.state, HUMAN_STATES["intitial"])),    # pylint: disable=translation-of-non-string
             'is_staff': self.system.user_is_staff,
         }
 
@@ -1020,7 +1020,7 @@ class CombinedOpenEndedV1Module(object):
         current_task_human_name = ""
         for i in xrange(0, len(self.task_xml)):
             human_task_name = self.extract_human_name_from_task(self.task_xml[i])
-            human_task_name = ugettext(human_task_name)
+            human_task_name = ugettext(human_task_name)    # pylint: disable=translation-of-non-string
             # Extract the name of the current task for screen readers.
             if self.current_task_number == i:
                 current_task_human_name = human_task_name

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -926,7 +926,7 @@ def sale_validation(request, course_id):
         )
         obj_invoice = obj_invoice.invoice
     except CourseRegistrationCodeInvoiceItem.DoesNotExist:  # Check for old type invoices
-        return HttpResponseNotFound(_("Invoice number '{0}' does not exist.".format(invoice_number)))
+        return HttpResponseNotFound(_("Invoice number '{num}' does not exist.").format(num=invoice_number))
 
     if event_type == "invalidate":
         return invalidate_invoice(obj_invoice)

--- a/lms/djangoapps/instructor_task/views.py
+++ b/lms/djangoapps/instructor_task/views.py
@@ -127,7 +127,7 @@ def get_task_completion_info(instructor_task):
         log.warning(fmt.format(instructor_task.task_id, instructor_task.task_output))
         return (succeeded, _("No progress status information available"))
 
-    action_name = _(task_output['action_name'])
+    action_name = _(task_output['action_name'])    # pylint: disable=translation-of-non-string
     num_attempted = task_output['attempted']
     num_total = task_output['total']
 


### PR DESCRIPTION
As some i18n features need `ugettext` or its shorcut `_` to be called on a non-string-literal, so the pylint check of `translation-of-non-string` should be explicitly disabled in such situations.
