### PR TITLE
Set test as flaky. SOL-618.

### DIFF
--- a/common/test/acceptance/tests/studio/test_studio_library.py
+++ b/common/test/acceptance/tests/studio/test_studio_library.py
@@ -2,6 +2,7 @@
 Acceptance tests for Content Libraries in Studio
 """
 from ddt import ddt, data
+from flaky import flaky
 
 from .base_studio_test import StudioLibraryTest
 from ...fixtures.course import XBlockFixtureDesc
@@ -517,6 +518,7 @@ class LibraryUsersPageTest(StudioLibraryTest):
         """
         self.page = LibraryUsersPage(self.browser, self.library_key).wait_for_page()
 
+    @flaky  # TODO fix this, see SOL-618
     def test_user_management(self):
         """
         Scenario: Ensure that we can edit the permissions of users.


### PR DESCRIPTION
@andy-armstrong @sarina @jzoldak 

CC @bradenmacdonald I can't explain why this is flaky now as opposed to previously, but it's become flaky. Until it can get further triage, we should tag it as such. More info on https://openedx.atlassian.net/browse/SOL-618
