### PR TITLE
Update SKU field help text and verbose name

### DIFF
--- a/common/djangoapps/course_modes/models.py
+++ b/common/djangoapps/course_modes/models.py
@@ -57,12 +57,13 @@ class CourseMode(models.Model):
     # WARNING: will not be localized
     description = models.TextField(null=True, blank=True)
 
-    #optional SKU for Oscar integration
+    # Optional SKU for integration with the ecommerce service
     sku = models.CharField(
         max_length=255,
         null=True,
         blank=True,
-        help_text="This is the SKU(stock keeping unit) of this mode in external services."
+        verbose_name="SKU",
+        help_text="This is the SKU (stock keeping unit) of this mode in the external ecommerce service."
     )
 
     HONOR = 'honor'


### PR DESCRIPTION
This is a tiny change which cleans up some text seen in the Django admin, adding the uppercase "SKU" as the course mode `sku` field's verbose name and correcting the displayed help text. As far as I know, these changes don't affect information in the database, so they shouldn't require migrations.

@jimabramson and @stephensanchez, could you please review this when you have a moment?
