### PR TITLE
Changes the nav element to a div

### DIFF
--- a/lms/templates/verify_student/make_payment_step.underscore
+++ b/lms/templates/verify_student/make_payment_step.underscore
@@ -157,7 +157,7 @@
     <% } %>
 
   <% if ( isActive ) { %>
-  <nav class="nav-wizard is-ready <% if ( isActive && !upgrade ) { %>center<% } %>">
+  <div class="nav-wizard is-ready <% if ( isActive && !upgrade ) { %>center<% } %>">
     <% if ( upgrade ) { %>
         <a class="next action-primary is-disabled right" id="pay_button" aria-disabled="true">
           <%- gettext( "Next: Make payment" ) %>
@@ -167,7 +167,7 @@
           <%- gettext( "Continue to payment" ) %>
         </a>
     <% } %>
-  </nav>
+  </div>
   <% } %>
 
   <form id="payment-processor-form"></form>


### PR DESCRIPTION
This work relates to:
- https://openedx.atlassian.net/browse/UX-1911
- https://openedx.atlassian.net/browse/ECOM-1304

It includes a simple change from `nav` to `div` the container that wraps the continue button at the bottom of the page. Visual styling was not affected by this change.

---

@cptvitamin Mind reviewing?
cc @talbs
