### PR TITLE
Move debug toolbar to end of devstack middleware

### DIFF
--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -45,11 +45,9 @@ ANALYTICS_DASHBOARD_URL = None
 ################################ DEBUG TOOLBAR ################################
 
 INSTALLED_APPS += ('debug_toolbar', 'debug_toolbar_mongo')
-MIDDLEWARE_CLASSES = (
-    (
-        'django_comment_client.utils.QueryCountDebugMiddleware',
-        'debug_toolbar.middleware.DebugToolbarMiddleware',
-    ) + MIDDLEWARE_CLASSES
+MIDDLEWARE_CLASSES += (
+    'django_comment_client.utils.QueryCountDebugMiddleware',
+    'debug_toolbar.middleware.DebugToolbarMiddleware',
 )
 INTERNAL_IPS = ('127.0.0.1',)
 


### PR DESCRIPTION
The django debug toolbar circumvents other middleware with process_view
functions, so it needs to go at the end of our MIDDLEWARE_CLASSES
setting.

https://django-debug-toolbar.readthedocs.org/en/1.3/tips.html#middleware-isn-t-working-correctly

@wedaly Please review
