### PR TITLE
Making background pictures printable

### DIFF
--- a/lms/static/sass/base/_reset.scss
+++ b/lms/static/sass/base/_reset.scss
@@ -84,7 +84,8 @@ td { vertical-align: top; }
 .clearfix { *zoom: 1; }
 
 @media print {
-  * { background: transparent !important; color: black !important; box-shadow:none !important; text-shadow: none !important; filter:none !important; -ms-filter: none !important; }
+  * { background: transparent; color: black !important; box-shadow:none !important; text-shadow: none !important; filter:none !important; -ms-filter: none !important; }
+  html, body { background: transparent !important; }
   a, a:visited { text-decoration: underline; }
   abbr[title]:after { content: " (" attr(title) ")"; }
   .ir a:after { content: ""; }

--- a/lms/static/sass/course/_info.scss
+++ b/lms/static/sass/course/_info.scss
@@ -236,6 +236,14 @@ div.info-wrapper {
         }
       }
     }
+
+    @media print {
+      background: transparent !important;
+    }
+  }
+
+  @media print {
+    background: transparent !important;
   }
 
   @media print {

--- a/lms/static/sass/course/_info.scss
+++ b/lms/static/sass/course/_info.scss
@@ -244,9 +244,6 @@ div.info-wrapper {
 
   @media print {
     background: transparent !important;
-  }
-
-  @media print {
     border: 0;
   }
 }

--- a/lms/static/sass/course/_tabs.scss
+++ b/lms/static/sass/course/_tabs.scss
@@ -12,5 +12,6 @@ div.static_tab_wrapper {
 
   @media print {
     border: 0;
+    background: transparent !important;
   }
 }

--- a/lms/static/sass/course/courseware/_courseware.scss
+++ b/lms/static/sass/course/courseware/_courseware.scss
@@ -295,6 +295,7 @@ div.course-wrapper {
 
     @media print {
       padding: 0 2mm;
+      background: transparent !important;
     }
   }
 
@@ -333,6 +334,7 @@ div.course-wrapper {
 
   @media print {
     border: 0;
+    background: transparent !important;
   }
 }
 

--- a/lms/static/sass/course/layout/_courseware_header.scss
+++ b/lms/static/sass/course/layout/_courseware_header.scss
@@ -193,4 +193,8 @@ header.global.slim {
     font-weight: bold;
     letter-spacing: 0;
   }
+
+  @media print {
+    background: transparent !important;
+  }
 }


### PR DESCRIPTION
This PR changes the print media CSS for edX.

The issue:
- Background images have been set to vanish when printing by the present CSS.
- Green checkmarks and red crosses are often encoded by background images, so they don't print.
- Image problems are encoded by background images too, so these do not print properly.
## What appears on the website (examples taken from the edX demo course):

![website1](https://cloud.githubusercontent.com/assets/6232546/6986783/b80091dc-da0e-11e4-8983-f12ef2831867.png)

![website2](https://cloud.githubusercontent.com/assets/6232546/6986787/c307f7be-da0e-11e4-8177-7e32ad451093.png)
## What appears in printing currently:

![badprint1](https://cloud.githubusercontent.com/assets/6232546/6986789/c9c57afe-da0e-11e4-946e-2f2a9fbd730a.png)
(note that multiple choice problems do not use background images for their checkmarks)

![badprint2](https://cloud.githubusercontent.com/assets/6232546/6986792/dad4ef6e-da0e-11e4-84fa-f65e8ef0498f.png)
## What things look like after this fix is applied (make sure to tell the browser to print background images!):

![goodprint1](https://cloud.githubusercontent.com/assets/6232546/6986801/ef71b6a0-da0e-11e4-898f-4a491f1a1528.png)

![goodprint2](https://cloud.githubusercontent.com/assets/6232546/6986803/f2422018-da0e-11e4-801d-51343df2fc1f.png)

I realize that this is a hefty change to the print media CSS, as it applies to the reset style sheet. However, marking \* {background: transparent !important} is hugely overkill, and is often impossible to override.
