### PR TITLE
Print CSS: Fixing Links

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -208,3 +208,4 @@ Sri Harsha Pamu <kmitharsha@gmail.com>
 Cris Ewing <cris@crisewing.com>
 Carlos de La Guardia <carlos@jazkarta.com>
 Amir Qayyum Khan <amir.qayyum@arbisoft.com>
+Jolyon Bloomfield <jolyon@mit.edu>

--- a/lms/static/sass/base/_reset.scss
+++ b/lms/static/sass/base/_reset.scss
@@ -86,9 +86,8 @@ td { vertical-align: top; }
 @media print {
   * { background: transparent !important; color: black !important; box-shadow:none !important; text-shadow: none !important; filter:none !important; -ms-filter: none !important; }
   a, a:visited { text-decoration: underline; }
-  a[href]:after { content: " (" attr(href) ")"; }
   abbr[title]:after { content: " (" attr(title) ")"; }
-  .ir a:after, a[href^="javascript:"]:after, a[href^="#"]:after { content: ""; }
+  .ir a:after { content: ""; }
   pre, blockquote { border: 1px solid #999; page-break-inside: avoid; }
   thead { display: table-header-group; }
   tr, img { page-break-inside: avoid; }


### PR DESCRIPTION
This PR changes the print media CSS for edX.

Issue:
- In the print media, links are modified to display their linking location when printing. These links are typically meaningless to end users, who are the ones who will want to print. Furthermore, they are particularly ugly. I have no idea why things were done this way in the first place.

Example page (website view):
![screen shot 2015-04-03 at 3 13 06 pm](https://cloud.githubusercontent.com/assets/6232546/6987410/bfa33a88-da14-11e4-82c0-ed66d817f691.png)

Current print view (as PDF):
![screen shot 2015-04-03 at 3 13 34 pm](https://cloud.githubusercontent.com/assets/6232546/6987418/cf3ae0a4-da14-11e4-8d1e-ac7a7e0a4699.png)

After change:
![screen shot 2015-04-03 at 3 16 45 pm](https://cloud.githubusercontent.com/assets/6232546/6987420/d6688250-da14-11e4-92c7-893dffd9c02c.png)
