### PR TITLE
Fix Print Media CSS: Page margins

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -208,3 +208,4 @@ Sri Harsha Pamu <kmitharsha@gmail.com>
 Cris Ewing <cris@crisewing.com>
 Carlos de La Guardia <carlos@jazkarta.com>
 Amir Qayyum Khan <amir.qayyum@arbisoft.com>
+Jolyon Bloomfield <jolyon@mit.edu>

--- a/lms/static/sass/base/_reset.scss
+++ b/lms/static/sass/base/_reset.scss
@@ -93,7 +93,7 @@ td { vertical-align: top; }
   thead { display: table-header-group; }
   tr, img { page-break-inside: avoid; }
   img { max-width: 100% !important; }
-  @page { margin: 0.5cm; }
+  @page { margin: 1cm 1.2cm 2cm; }
   p, h2, h3 { orphans: 3; widows: 3; }
   h2, h3 { page-break-after: avoid; }
 }


### PR DESCRIPTION
This PR concerns print media CSS.

Issue:
- The print media CSS currently sets a very small margin. This causes details that are usually added by browsers when printing to be printed on top of information.

Current code (example taken from edX demo course, running on MIT's server):
![screen shot 2015-04-03 at 3 44 23 pm](https://cloud.githubusercontent.com/assets/6232546/6987932/7a95c20c-da1a-11e4-9a6f-8ee4e27b82f6.png)

With update:
![screen shot 2015-04-03 at 3 52 51 pm](https://cloud.githubusercontent.com/assets/6232546/6987938/836565f4-da1a-11e4-9e27-babab381c6c2.png)

Both screenshots are from "print to PDF" printings using Firefox 31.5.0. Note that the top left, top right, bottom left and bottom right are much more nicely margined.
