### PR TITLE
Fixing paragraph spacing with inline class (capa)

### DIFF
--- a/common/lib/xmodule/xmodule/css/capa/display.scss
+++ b/common/lib/xmodule/xmodule/css/capa/display.scss
@@ -137,6 +137,10 @@ div.problem {
 
   .inline {
     display: inline;
+
+    + p {
+      margin-top: $baseline;
+    }
   }
 }
 


### PR DESCRIPTION
This PR addresses a CSS issue.

Normally, paragraphs are displayed with margin-top: 0. In order to make paragraphs have a nice break between them, there is code in _reset.scss that adds space if the paragraph is after another paragraph, or a list.

<pre>p + p, ul + p, ol + p {
  margin-top: $baseline;
}</pre>


Sometimes a paragraph is styled inline, so that something else can follow inline at the end of the paragraph. This leads to the preceding tag before a new paragraph _not_ being a paragraph, and thus there is no space inserted. This situation tends to arise with input textboxes.

This PR detects when a paragraph follows from an element styled with the "inline" class (in a capa problem, where the inline class is defined), and inserts space appropriately.

Example before fix:
![screen shot 2015-04-03 at 5 13 10 pm](https://cloud.githubusercontent.com/assets/6232546/6989012/c02b6916-da24-11e4-85c4-76fd83054590.png)

Example after fix:
![screen shot 2015-04-03 at 5 03 42 pm](https://cloud.githubusercontent.com/assets/6232546/6988999/9beebd3c-da24-11e4-9f85-37d92f8ec16a.png)

XML code to generate this example:

<pre><code>&lt;p&gt;Here is another way of doing units in a textbox&lt;/p&gt;

&lt;p style="display:inline"&gt;[mathjaxinline]\Phi =[/mathjaxinline] &lt;/p&gt;
&lt;numericalresponse inline="1" answer="1"&gt;
&nbsp;&nbsp;&lt;textline size="10" inline="1" trailing_text="m/s"/&gt;
&lt;/numericalresponse&gt;

&lt;p&gt;Below, we're embedding units using a different method.&lt;/p&gt;</code></pre>


Notifications: @carsongee 
