### PR TITLE
Complete Printing Cleanup

### DIFF
--- a/common/lib/xmodule/xmodule/css/capa/display.scss
+++ b/common/lib/xmodule/xmodule/css/capa/display.scss
@@ -269,6 +269,13 @@ div.problem {
       }
     }
 
+    // Hides equation previews in symbolic response problems when printing
+    [id^='display'].equation {
+      @media print {
+        display:none;
+      }
+    }
+
     span {
       &.unanswered, &.ui-icon-bullet {
         display: inline-block;
@@ -628,6 +635,10 @@ div.problem {
       height: ($baseline*2);
       vertical-align: middle;
       font-weight: 600;
+
+      @media print {
+        display: none;
+      }
     }
 
     .save {

--- a/common/lib/xmodule/xmodule/css/sequence/display.scss
+++ b/common/lib/xmodule/xmodule/css/sequence/display.scss
@@ -40,6 +40,10 @@ $sequence--border-color: #C8C8C8;
   position: relative;
   border-bottom: none;
 
+  @media print {
+    display: none;
+  }
+
   .left-shadow {
     @extend %ui-depth4;
     @include linear-gradient(left, $shadow, $transparent);
@@ -277,6 +281,10 @@ nav.sequence-bottom {
   height: 1px;
   margin: lh(2) auto;
   text-align: center;
+
+  @media print {
+    display: none;
+  }
 }
 
 #seq_content {

--- a/lms/static/sass/base/_base.scss
+++ b/lms/static/sass/base/_base.scss
@@ -122,6 +122,10 @@ a:focus {
   margin: 0 auto;
   background: $content-wrapper-bg;
   padding-bottom: ($baseline*2);
+
+  @media print {
+    padding-bottom: 0;
+  }
 }
 
 .container {
@@ -246,6 +250,7 @@ mark {
   @include transform(rotate(-90deg));
   @include transform-origin(0 0);
   @extend %ui-depth2;
+  @extend %ui-print-excluded;
   top: 250px;
   left: 0;
   position: fixed;
@@ -337,6 +342,8 @@ mark {
 
 // UI - skipnav
 .nav-skip {
+  @extend %ui-print-excluded;
+
   display: block;
   position: absolute;
   left: 0;

--- a/lms/static/sass/base/_extends.scss
+++ b/lms/static/sass/base/_extends.scss
@@ -128,3 +128,10 @@
   white-space: nowrap;
   text-overflow: ellipsis;
 }
+
+// Adds a simple extend that indicates that this user interface element should not print
+%ui-print-excluded {
+  @media print {
+    display:none;
+  }
+}

--- a/lms/static/sass/course/_info.scss
+++ b/lms/static/sass/course/_info.scss
@@ -237,4 +237,8 @@ div.info-wrapper {
       }
     }
   }
+
+  @media print {
+    border: 0;
+  }
 }

--- a/lms/static/sass/course/_tabs.scss
+++ b/lms/static/sass/course/_tabs.scss
@@ -9,4 +9,8 @@ div.static_tab_wrapper {
   section {
     margin: 0px 0px 20px;
   }
+
+  @media print {
+    border: 0;
+  }
 }

--- a/lms/static/sass/course/courseware/_courseware.scss
+++ b/lms/static/sass/course/courseware/_courseware.scss
@@ -12,6 +12,8 @@ html.video-fullscreen{
 }
 
 .wrap-instructor-info {
+  @extend %ui-print-excluded;
+
   margin: ($baseline/2) ($baseline/4) 0 0;
   overflow: hidden;
 
@@ -246,6 +248,10 @@ div.course-wrapper {
         padding: 0;
       }
     }
+
+    @media print {
+      padding: 0 2mm;
+    }
   }
 
   &.closed {
@@ -279,6 +285,10 @@ div.course-wrapper {
     section.course-content {
       width: flex-grid(11.5) + flex-gutter();
     }
+  }
+
+  @media print {
+    border: 0;
   }
 }
 

--- a/lms/static/sass/course/layout/_courseware_header.scss
+++ b/lms/static/sass/course/layout/_courseware_header.scss
@@ -1,6 +1,8 @@
 .wrapper-course-material {
   @include clearfix();
   @include box-sizing(border-box);
+  @extend %ui-print-excluded;
+
   border-bottom: none;
   margin: 0 auto 0;
   padding: 0;

--- a/lms/static/sass/course/modules/_calculator.scss
+++ b/lms/static/sass/course/modules/_calculator.scss
@@ -2,6 +2,8 @@
 // ====================
 
 div.calc-main {
+  @extend %ui-print-excluded;
+
   bottom: -126px;
   left: 0;
   position: fixed;

--- a/lms/static/sass/discussion/_discussion.scss
+++ b/lms/static/sass/discussion/_discussion.scss
@@ -673,6 +673,8 @@ body.discussion {
 // inline discussion module and profile thread styling
 .discussion-module {
   @extend .discussion-body;
+  @extend %ui-print-excluded;
+
   position: relative;
   margin: $baseline 0;
   padding: $baseline;

--- a/lms/static/sass/shared/_footer.scss
+++ b/lms/static/sass/shared/_footer.scss
@@ -289,6 +289,10 @@ $edx-footer-bg-color: rgb(252,252,252);
 .edx-footer-new {
   background: $edx-footer-bg-color;
 
+  @media print {
+    @include padding(10px, 10px, 0, 10px);
+  }
+
   // NOTE: resetting older footer styles - can be removed once not needed
   box-shadow: none;
   border-top: none;
@@ -300,10 +304,19 @@ $edx-footer-bg-color: rgb(252,252,252);
     @extend %edx-footer-reset;
     @extend %edx-footer-section;
     width: flex-grid(6,12);
+
+    @media print {
+      @include margin-right(0);
+      @include padding-right(0);
+      width: flex-grid(12,12);
+      border: none;
+      min-height: 0;
+    }
   }
 
   .footer-about-title {
     @extend %edx-footer-title;
+    @extend %ui-print-excluded;
   }
 
   .footer-about-logo, .footer-about-openedx {
@@ -324,14 +337,19 @@ $edx-footer-bg-color: rgb(252,252,252);
 
   .footer-about-logo {
     @include float(left);
+    @extend %ui-print-excluded;
   }
 
   .footer-about-openedx-logo {
     @include float(right);
+    @media print {
+      @include float(left);
+    }
   }
 
   .footer-about-copy {
     @extend %t-copy-sub1;
+    @extend %ui-print-excluded;
     margin-bottom: $edx-footer-spacing;
     color: rgb(61, 62, 63);
     clear: both;
@@ -357,9 +375,14 @@ $edx-footer-bg-color: rgb(252,252,252);
       display: inline-block;
       margin-bottom: ($edx-footer-spacing/2);
     }
+
+    @media print {
+      margin-bottom: 0;
+    }
   }
 
   .footer-about-links {
+    @extend %ui-print-excluded;
 
     a {
       @extend %edx-footer-link;
@@ -376,6 +399,7 @@ $edx-footer-bg-color: rgb(252,252,252);
   .footer-nav {
     @extend %edx-footer-reset;
     @extend %edx-footer-section;
+    @extend %ui-print-excluded;
     width: flex-grid(3,12);
   }
 
@@ -397,8 +421,8 @@ $edx-footer-bg-color: rgb(252,252,252);
   .footer-follow {
     @extend %edx-footer-reset;
     @extend %edx-footer-section;
+    @extend %ui-print-excluded;
     width: flex-grid(3,12);
-
   }
 
   .footer-follow-title {

--- a/lms/static/sass/shared/_header.scss
+++ b/lms/static/sass/shared/_header.scss
@@ -117,6 +117,8 @@ header.global {
 
   .user {
     @include float(right);
+    @extend %ui-print-excluded;
+
     margin-top: ($baseline/4);
 
     > .primary {


### PR DESCRIPTION
This PR applies a number of changes to the print media CSS.

Being able to print nicely from edX is important for a number of reasons, including making PDFs for students to view offline, and for a variety of accessibility issues. Currently, printing in the edX platform is unusable. For example, here is a print to pdf of a page from MITx: http://web.mit.edu/jolyon/Public/printing_present.pdf

This pull request modifies a number of things in the print media CSS to make this beautiful. I'll jump straight to the punchline. Here is what that same page looks like with this pull request in place: http://web.mit.edu/jolyon/Public/printing_with_changes.pdf

(Two other pull requests are also in place for this second pdf; https://github.com/edx/edx-platform/pull/7592 and https://github.com/edx/edx-platform/pull/7591)

All of the changes included in this PR modify print media CSS _only_. I'll go through and annotate each change individually, so that you can see what it is doing. Most of the changes are hiding things; a few of them are changing borders and whitespace.
