### PR TITLE
Add i18n_fastgenerate

### DIFF
--- a/pavelib/i18n.py
+++ b/pavelib/i18n.py
@@ -34,6 +34,15 @@ def i18n_extract(options):
 
 
 @task
+def i18n_fastgenerate():
+    """
+    Compile localizable strings from sources without re-extracting strings first.
+    """
+    cmd = "i18n_tool generate"
+    sh(cmd)
+
+
+@task
 @needs("pavelib.i18n.i18n_extract")
 def i18n_generate():
     """


### PR DESCRIPTION
I remember that last year I've complained about the time-consuming step of `i18n_extract` before `i18n_generate`. In my installation of edx-platform, I always comment out the `@needs("pavelib.i18n.i18n_extract")` before the `i18n_generate` function.
But, maybe providing a separate function is a better solution as that users can choose one of these two functions as their wish without modifing the source code. In my solution, this function is called 'i18n_fastgenerate', and it can be used when only the translated strings are modified but the original strings are the same (For example, fix translation errors in existing translations). In such situations, re-extracting strings will make exactly the same result as the previous extracting process, so there is no need to do so.
