### PR TITLE
Fix i18n breaking in some js and underscore files

### DIFF
--- a/cms/static/js/views/paging_header.js
+++ b/cms/static/js/views/paging_header.js
@@ -37,13 +37,11 @@ define(["underscore", "gettext", "js/views/baseview"], function(_, gettext, Base
                 if (this.view.collection.sortDirection === 'asc') {
                     // Translators: sample result:
                     // "Showing 0-9 out of 25 total, filtered by Images, sorted by Date Added ascending"
-                    message = gettext('Showing %(current_item_range)s out of %(total_items_count)s, ' +
-                        'filtered by %(asset_type)s, sorted by %(sort_name)s ascending');
+                    message = gettext('Showing %(current_item_range)s out of %(total_items_count)s, filtered by %(asset_type)s, sorted by %(sort_name)s ascending');
                 } else {
                     // Translators: sample result:
                     // "Showing 0-9 out of 25 total, filtered by Images, sorted by Date Added descending"
-                    message = gettext('Showing %(current_item_range)s out of %(total_items_count)s, ' +
-                        'filtered by %(asset_type)s, sorted by %(sort_name)s descending');
+                    message = gettext('Showing %(current_item_range)s out of %(total_items_count)s, filtered by %(asset_type)s, sorted by %(sort_name)s descending');
                 }
                 asset_type = this.filterNameLabel();
             }
@@ -51,13 +49,11 @@ define(["underscore", "gettext", "js/views/baseview"], function(_, gettext, Base
                 if (this.view.collection.sortDirection === 'asc') {
                     // Translators: sample result:
                     // "Showing 0-9 out of 25 total, sorted by Date Added ascending"
-                    message = gettext('Showing %(current_item_range)s out of %(total_items_count)s, ' +
-                        'sorted by %(sort_name)s ascending');
+                    message = gettext('Showing %(current_item_range)s out of %(total_items_count)s, sorted by %(sort_name)s ascending');
                 } else {
                     // Translators: sample result:
                     // "Showing 0-9 out of 25 total, sorted by Date Added descending"
-                    message = gettext('Showing %(current_item_range)s out of %(total_items_count)s, ' +
-                        'sorted by %(sort_name)s descending');
+                    message = gettext('Showing %(current_item_range)s out of %(total_items_count)s, sorted by %(sort_name)s descending');
                 }
             }
 

--- a/cms/templates/js/video/transcripts/messages/transcripts-import.underscore
+++ b/cms/templates/js/video/transcripts/messages/transcripts-import.underscore
@@ -1,6 +1,6 @@
 <div class="transcripts-message-status status-error"><i class="icon fa fa-remove"></i><%= gettext("No EdX Timed Transcript") %></div>
 <p class="transcripts-message">
-<%= gettext("EdX doesn\'t have a timed transcript for this video in Studio, but we found a transcript on YouTube. You can import the YouTube transcript or upload your own .srt transcript file.") %>
+<%= gettext("EdX doesn't have a timed transcript for this video in Studio, but we found a transcript on YouTube. You can import the YouTube transcript or upload your own .srt transcript file.") %>
 </p>
 <div class="transcripts-file-uploader"></div>
 <p class="transcripts-error-message is-invisible">

--- a/cms/templates/js/video/transcripts/metadata-videolist-entry.underscore
+++ b/cms/templates/js/video/transcripts/metadata-videolist-entry.underscore
@@ -8,7 +8,7 @@
         <i class="icon fa fa-plus"></i><%= gettext("Add URLs for additional versions") %> <span class="sr"><%= model.get('display_name')%></span>
       </a>
       <div class="videolist-extra-videos">
-        <span class="tip videolist-extra-videos-tip setting-help"><%= gettext('To be sure all students can access the video, we recommend providing both an .mp4 and a .webm version of your video. Click below to add a URL for another version. These URLs cannot be YouTube URLs. The first listed video that\'s compatible with the student\'s computer will play.') %></span>
+        <span class="tip videolist-extra-videos-tip setting-help"><%= gettext("To be sure all students can access the video, we recommend providing both an .mp4 and a .webm version of your video. Click below to add a URL for another version. These URLs cannot be YouTube URLs. The first listed video that's compatible with the student's computer will play.") %></span>
         <ol class="videolist-settings">
             <li class="videolist-settings-item">
               <input type="text" class="input" value="<%= model.get('value')[1] %>">


### PR DESCRIPTION
Fix i18n breaking in some js and underscore files
1. Spliting a string inside the call to `gettext()` in javascript breaks the string extraction process, so each string should kept in one line.
2. Using escape string inside a string in `gettext()` may cause the extractor to misunderstand the escape string, so that it will escape this escape character.
   For example: a string `I'm not him.` equals to the string `I\'m not him.` written in javascript, as this `\` here will be treated as a escape character, so that the final result is `I'm not him.`.
   However, when written in `I\'m not him.`, the i18n extractor will create a msgid `I\\'m not him.` in .po files for this string, which makes django thinks the original string as `I\'m not him.` rather than `I'm not him.`. Therefore, the original string will be displayed without translated.
