### PR TITLE
Fix modal close button

### DIFF
--- a/lms/static/sass/shared/_modal.scss
+++ b/lms/static/sass/shared/_modal.scss
@@ -282,7 +282,7 @@
       position: absolute;
       right: 2px;
       top: 0px;
-      z-index: 3;
+      z-index: 100;
       color: $lighter-base-font-color;
       font: normal 1.2rem/1.2rem $sans-serif;
       text-align: center;


### PR DESCRIPTION
This pull request doesn't address a JIRA ticket. It was just a very small and very easy to fix bug that I noticed. The bug occurs on the LMS dashboard when a user opens the Email Settings modal. The issue is that the user is only able to click on a small part of the x button that closes the modal. So to recreate this issue open the email settings modal and try and click on the actual X that should close the modal. The button isn't working because its z-index is lower than the z-index of the header. So essentially the header is covering up the button.
![screen shot 2015-04-06 at 2 15 29 pm](https://cloud.githubusercontent.com/assets/2379693/7010210/778f6b9e-dc6d-11e4-8e04-8e208205cce1.png)

My fix simply increases the z-index of the .close-modal. This allows a user to click on the actual button. I set the z-index to 100. It could be set higher since there probably shouldn't ever be anything on top of it. After the z-index change the close button works properly.
![screen shot 2015-04-06 at 2 14 41 pm](https://cloud.githubusercontent.com/assets/2379693/7010222/887241ca-dc6d-11e4-9870-fb7de7fa714d.png)

I didn't write any tests or create a separate ticket because this is so small and simple.
