### PR TITLE
Omit migrations when calculating bok-choy coverage.

### DIFF
--- a/common/test/acceptance/.coveragerc
+++ b/common/test/acceptance/.coveragerc
@@ -1,7 +1,7 @@
 [run]
 data_file = reports/bok_choy/.coverage
 source = lms, cms, common/djangoapps, common/lib
-omit = lms/envs/*, cms/envs/*, common/djangoapps/terrain/*, common/djangoapps/*/migrations/*, openedx/core/djangoapps/*/migrations/*, */test*, */management/*, */urls*, */wsgi*
+omit = lms/envs/*, cms/envs/*, common/djangoapps/terrain/*, common/djangoapps/*/migrations/*, openedx/core/djangoapps/*/migrations/*, */test*, */management/*, */urls*, */wsgi*, lms/djangoapps/*/migrations/*, cms/djangoapps/*/migrations/*
 parallel = True
 
 [report]


### PR DESCRIPTION
When we calculate bok-choy coverage, we are including various migraitons
as part of the calculation. This does not represent the kind of
code that bok-choy can cover, since that is part of the RDBMS build-out
and maintenance.
