### PR TITLE
Fix help token for Libraries: Learn More button

### DIFF
--- a/cms/templates/library.html
+++ b/cms/templates/library.html
@@ -89,7 +89,7 @@ from django.utils.translation import ugettext as _
                 </div>
                 % endif
                 <div class="bit external-help">
-                    <a href="${get_online_help_info('library')['doc_url']}" target="_blank" class="button external-help-button">${_("Learn more about content libraries")}</a>
+                    <a href="${get_online_help_info(online_help_token())['doc_url']}" target="_blank" class="button external-help-button">${_("Learn more about content libraries")}</a>
                 </div>
             </aside>
         </section>


### PR DESCRIPTION
This PR fixes the online help token for the "Learn More" link in the sidebar text of the Libraries page in Studio. Addresses https://openedx.atlassian.net/browse/DOC-1810.
@mhoeber can you please review?
