### PR TITLE
Better i18n extraction and translation

### DIFF
--- a/cms/templates/js/staff-lock-editor.underscore
+++ b/cms/templates/js/staff-lock-editor.underscore
@@ -15,7 +15,7 @@
                   <% if (xblockInfo.isVertical()) { %>
                     <%= gettext('If the unit was previously published and released to students, any changes you made to the unit when it was hidden will now be visible to students.') %>
                   <% } else { %>
-                    <% var message = gettext('If you make this %(xblockType)s visible to students, students will be able to see its content after the release date has passed and you have published the unit(s).'); %>
+                    <% var message = gettext('If you make this %(xblockType)s visible to students, students will be able to see its content after the release date has passed and you have published the unit.'); %>
                     <%= interpolate(message, { xblockType: xblockType }, true) %>
                   <% } %>
                 </p>

--- a/cms/templates/js/validation-error-modal.underscore
+++ b/cms/templates/js/validation-error-modal.underscore
@@ -2,7 +2,11 @@
     <div class "error-header">
         <p>
         <%= _.template(
-        gettext("There were {strong_start}{num_errors} validation error(s){strong_end} while trying to save the course setting(s) in the database."),
+        ngettext(
+            "There was {strong_start}{num_errors} validation error{strong_end} while trying to save the course settings in the database.",
+            "There were {strong_start}{num_errors} validation errors{strong_end} while trying to save the course settings in the database.",
+            num_errors
+        ),
         {
             strong_start:'<strong>',
             num_errors: num_errors,

--- a/cms/templates/settings.html
+++ b/cms/templates/settings.html
@@ -319,7 +319,7 @@ CMS.URL.UPLOAD_ASSET = '${upload_asset_url}';
                             <label for="entrance-exam-enabled">${_("Require students to pass an exam before beginning the course.")}</label>
                         </div>
                          <div class="div-grade-requirements" hidden="hidden">
-                          <p><span class="tip tip-inline">${_("You can now view and author your course entrance exam from the ")}<a href='${course_handler_url}'>${_("Course Outline")}</a></span></p>
+                          <p><span class="tip tip-inline">${_("You can now view and author your course entrance exam from the {link_start}Course Outline{link_end}.").format(link_start="<a href='{}'>".format(course_handler_url), link_end="</a>")}</span></p>
                           <p><h3>${_("Grade Requirements")}</h3></p>
                           <p><div><input type="text" id="entrance-exam-minimum-score-pct" aria-describedby="min-score-format"><span id="min-score-format" class="tip tip-inline">${_(" %")}</span></div></p>
                           <p><span class="tip tip-inline">${_("The score student must meet in order to successfully complete the entrance exam. ")}</span></p>


### PR DESCRIPTION
1. Extract the full sentence rather than parital of a sentence, so that languages with different word orders than English can benifit from this.
2. Using ngettext instead of gettext with 'xxx(s)', as Transifex treats `()` as special characters so that it enforces the translated string must have the same number of `()` pairs. Such enforcement makes translations difficult, as not every language can use forms like 'xxx(s)' to represent both singular & plural within a single word.
