### PR TITLE
[LTI Provider] Adding options to suppress chrome for embedding courseware

### DIFF
--- a/lms/templates/dashboard/_dashboard_prompt_midcourse_reverify.html
+++ b/lms/templates/dashboard/_dashboard_prompt_midcourse_reverify.html
@@ -1,87 +1,90 @@
 <%! from django.utils.translation import ugettext as _ %>
 <%! from django.core.urlresolvers import reverse %>
-% if reverifications["must_reverify"]:
-  % if len(reverifications["must_reverify"]) > 1:
 
-  <div class="wrapper-msg urgency-high">
-    <div class="msg msg-reverify has-actions">
-        <div class="msg-content">
-          <h2 class="title">${_("You need to re-verify to continue")}</h2>
-          <div class="copy">
-            <p class="activation-message">
-            ${_("People change, and each year we ask you to re-verify your identity for our verified certificates. Take a minute now to help us renew your identity.")}
-            </p>
-            <ul class="reverify-list">
+% if reverifications:
+    % if reverifications["must_reverify"]:
+      % if len(reverifications["must_reverify"]) > 1:
+
+      <div class="wrapper-msg urgency-high">
+        <div class="msg msg-reverify has-actions">
+            <div class="msg-content">
+              <h2 class="title">${_("You need to re-verify to continue")}</h2>
+              <div class="copy">
+                <p class="activation-message">
+                ${_("People change, and each year we ask you to re-verify your identity for our verified certificates. Take a minute now to help us renew your identity.")}
+                </p>
+                <ul class="reverify-list">
+                  % for item in reverifications["must_reverify"]:
+                    <li class="item">
+                      ${_('{course_name}: Re-verify by {date}').format(
+                  course_name=u"<strong>{0}</strong>".format(item.course_name),
+                  date=item.date
+              )}
+                    </li>
+                  % endfor
+                </ul>
+              </div>
+            </div>
+            <nav class="nav-actions" aria-label="${_('Notification Actions')}">
+              <h3 class="sr">${_('Notification Actions')}</h3>
+              <ul>
+                <li class="nav-item"><a class="btn action-primary action-reverify" href="${reverse('verify_student_midcourse_reverify_dash')}">Re-verify</a></li>
+              </ul>
+            </nav>
+          </div>
+        </div>
+
+      % elif reverifications["must_reverify"]:
+      <div class="wrapper-msg urgency-high">
+        <div class="msg msg-reverify has-actions">
+            <div class="msg-content">
+              <h2 class="title">${_("You need to re-verify to continue")}</h2>
               % for item in reverifications["must_reverify"]:
-                <li class="item">
-                  ${_('{course_name}: Re-verify by {date}').format(
-		      course_name=u"<strong>{0}</strong>".format(item.course_name),
-		      date=item.date
-		  )}
-                </li>
-              % endfor
-            </ul>
+              <div class="copy">
+                <p class='activation-message'>
+                  ${_('To continue in the ID Verified track in {course_name}, you need to re-verify your identity by {date}.').format(
+                  course_name=u"<strong>{}</strong>".format(item.course_name),
+                  date=item.date
+              )}
+                </p>
+              </div>
+            </div>
+            <nav class="nav-actions" aria-label="${_('Notification Actions')}">
+              <h3 class="sr">${_('Notification Actions')}</h3>
+              <ul>
+                <li class="nav-item"><a class="btn action-primary action-reverify" href="${reverse('verify_student_midcourse_reverify_dash')}">Re-verify</a></li>
+              </ul>
+            </nav>
           </div>
         </div>
-        <nav class="nav-actions" aria-label="${_('Notification Actions')}">
-          <h3 class="sr">${_('Notification Actions')}</h3>
-          <ul>
-            <li class="nav-item"><a class="btn action-primary action-reverify" href="${reverse('verify_student_midcourse_reverify_dash')}">Re-verify</a></li>
-          </ul>
-        </nav>
-      </div>
-    </div>
+      % endfor
+      %endif
+    %endif
 
-  % elif reverifications["must_reverify"]:
-  <div class="wrapper-msg urgency-high">
-    <div class="msg msg-reverify has-actions">
-        <div class="msg-content">
-          <h2 class="title">${_("You need to re-verify to continue")}</h2>
-          % for item in reverifications["must_reverify"]:
-          <div class="copy">
-            <p class='activation-message'>
-              ${_('To continue in the ID Verified track in {course_name}, you need to re-verify your identity by {date}.').format(
-	          course_name=u"<strong>{}</strong>".format(item.course_name),
-	          date=item.date
-	      )}
-            </p>
+    %if reverifications["denied"] and denied_banner:
+    <div class="wrapper-msg urgency-high" id="failed-verification-banner">
+      <div class="msg msg-reverify is-dismissable">
+          <div class="msg-content">
+            <h2 class="title">${_("Your re-verification failed")}</h2>
+            % for item in reverifications["denied"]:
+            % if item.display:
+            <div class="copy">
+              <p class='activation-message'>
+                ${_('Your re-verification for {course_name} failed and you are no longer eligible for a Verified Certificate.  If you think this is in error, please contact us at {email}.').format(
+                course_name=u"<strong>{}</strong>".format(item.course_name),
+                email=u'<a class="contact-link" href="mailto:{email}">{email}</a>'.format(
+                        email=billing_email
+                )
+            )}
+              </p>
+            </div>
+            % endif
+            % endfor
+          </div>
+          <div class="action-dismiss">
+            <button class="button-dismiss" id="failed-verification-button-dismiss"><i class="icon fa fa-times-circle"></i> <span class="sr">${_('Dismiss')}</span></button>
           </div>
         </div>
-        <nav class="nav-actions" aria-label="${_('Notification Actions')}">
-          <h3 class="sr">${_('Notification Actions')}</h3>
-          <ul>
-            <li class="nav-item"><a class="btn action-primary action-reverify" href="${reverse('verify_student_midcourse_reverify_dash')}">Re-verify</a></li>
-          </ul>
-        </nav>
       </div>
-    </div>
-  % endfor
-  %endif
-%endif
-
-%if reverifications["denied"] and denied_banner:
-<div class="wrapper-msg urgency-high" id="failed-verification-banner">
-  <div class="msg msg-reverify is-dismissable">
-      <div class="msg-content">
-        <h2 class="title">${_("Your re-verification failed")}</h2>
-        % for item in reverifications["denied"]:
-        % if item.display:
-        <div class="copy">
-          <p class='activation-message'>
-            ${_('Your re-verification for {course_name} failed and you are no longer eligible for a Verified Certificate.  If you think this is in error, please contact us at {email}.').format(
-	        course_name=u"<strong>{}</strong>".format(item.course_name),
-	        email=u'<a class="contact-link" href="mailto:{email}">{email}</a>'.format(
-                    email=billing_email
-	        )
-	    )}
-          </p>
-        </div>
-        % endif
-        % endfor
-      </div>
-      <div class="action-dismiss">
-        <button class="button-dismiss" id="failed-verification-button-dismiss"><i class="icon fa fa-times-circle"></i> <span class="sr">${_('Dismiss')}</span></button>
-      </div>
-    </div>
-  </div>
+    %endif
 %endif

--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -49,14 +49,16 @@
       </title>
   </%block>
 
-  <script type="text/javascript">
-    /* immediately break out of an iframe if coming from the marketing website */
-    (function(window) {
-      if (window.location !== window.top.location) {
-        window.top.location = window.location;
-      }
-    })(this);
-  </script>
+  % if not allow_iframing:
+      <script type="text/javascript">
+        /* immediately break out of an iframe if coming from the marketing website */
+        (function(window) {
+          if (window.location !== window.top.location) {
+            window.top.location = window.location;
+          }
+        })(this);
+      </script>
+  % endif
 
   <script type="text/javascript" src="/jsi18n/"></script>
 
@@ -141,25 +143,29 @@
 
     <%include file="mathjax_accessible.html" />
 
-    <%include file="${header_file}" />
+    % if not disable_header:
+        <%include file="${header_file}" />
+    % endif
 
     <div class="content-wrapper" id="content">
       ${self.body()}
       <%block name="bodyextra"/>
     </div>
 
-    <%block name="footer">
-      ## Can be overridden by child templates wanting to hide the footer.
-      <%
-        if theme_enabled() and not is_microsite():
-          footer_file = 'theme-footer.html'
-        elif settings.FEATURES.get('IS_EDX_DOMAIN', False) and not is_microsite():
-          footer_file = microsite.get_template_path('footer-edx-new.html')
-        else:
-          footer_file = microsite.get_template_path('footer.html')
-      %>
-      <%include file="${footer_file}" />
-    </%block>
+    % if not disable_footer:
+        <%block name="footer">
+          ## Can be overridden by child templates wanting to hide the footer.
+          <%
+            if theme_enabled() and not is_microsite():
+              footer_file = 'theme-footer.html'
+            elif settings.FEATURES.get('IS_EDX_DOMAIN', False) and not is_microsite():
+              footer_file = microsite.get_template_path('footer-edx-new.html')
+            else:
+              footer_file = microsite.get_template_path('footer.html')
+          %>
+          <%include file="${footer_file}" />
+        </%block>
+    % endif
 
   </div>
 


### PR DESCRIPTION
This pull request has some template changes that will enable the courseware.html template to be reused in order to present material launched over LTI. For more background on the LTI provider feature as a whole, see https://docs.google.com/a/g.harvard.edu/document/d/185hdPvIxcKtiDOLjb4sTGovA_WYXWz5Cd79gCzQwBms

The first change modifies _dashboard_prompt_midcourse_reverify.html to include an explicit check for the presence of the 'reverifications' parameter in the context. Currently, the reverifications parameter is mandatory, but it  is not needed for the LTI feature.

The other changes introduce three new boolean flags that allow courseware to be displayed in an iframe and without the edX navigation chrome:
- 'allow_iframing' disables the code that unconditionally breaks out of an iframe;
- 'disable_header' turns off the edX header;
- 'disable_footer' turns off the edX footer.
  If these flags are not set in the context, this change doesn't introduce any new behavior.
