### PR TITLE
Upgrade rednose

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -146,7 +146,7 @@ pylint==1.4.2
 python-subunit==0.0.16
 pyquery==1.2.9
 radon==1.2
-rednose==0.3
+rednose==0.4.1
 selenium==2.42.1
 splinter==0.5.4
 testtools==0.9.34


### PR DESCRIPTION
TE-779

The latest release of rednose will allow for output of the
flaky test repoort. (It was being swallowed in rednose 0.3)

Here is the diff: https://github.com/gfxmonk/rednose/compare/version-0.3.1...version-0.4.1
Here is likely the commit we care about most: https://github.com/gfxmonk/rednose/commit/c66b37c92bb02ad8c16cabe7863cf6cb50c70adc
