### PR TITLE
Fixed duplicating discussion component was having same 'discussion_id'

### DIFF
--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -574,7 +574,9 @@ def _duplicate_item(parent_usage_key, duplicate_source_usage_key, user, display_
         duplicate_metadata = {}
         for field in source_item.fields.values():
             if field.scope == Scope.settings and field.is_set_on(source_item):
-                duplicate_metadata[field.name] = field.read_from(source_item)
+                # Do not duplicate 'discussion_id' TNL-1754
+                if field.name != 'discussion_id':
+                    duplicate_metadata[field.name] = field.read_from(source_item)
         if display_name is not None:
             duplicate_metadata['display_name'] = display_name
         else:

--- a/common/test/data/test_course_discussion/chapter/3aff11fca52d4f1eaa4c9b6126db97b3.xml
+++ b/common/test/data/test_course_discussion/chapter/3aff11fca52d4f1eaa4c9b6126db97b3.xml
@@ -1,0 +1,3 @@
+<chapter display_name="Week1">
+  <sequential url_name="d6fe595fca7d4ebf8f85e733702aa6dc"/>
+</chapter>

--- a/common/test/data/test_course_discussion/course.xml
+++ b/common/test/data/test_course_discussion/course.xml
@@ -1,0 +1,1 @@
+<course url_name="2015_S1" org="Arbisoft" course="Test101"/>

--- a/common/test/data/test_course_discussion/course/2015_S1.xml
+++ b/common/test/data/test_course_discussion/course/2015_S1.xml
@@ -1,0 +1,3 @@
+<course display_name="Intro to Testing" start="2030-01-01T00:00:00Z">
+  <chapter url_name="3aff11fca52d4f1eaa4c9b6126db97b3"/>
+</course>

--- a/common/test/data/test_course_discussion/discussion/discussion_component.xml
+++ b/common/test/data/test_course_discussion/discussion/discussion_component.xml
@@ -1,0 +1,1 @@
+<discussion discussion_id="af4565a8af09dc517a2f2b6edb3be43c321cdb65"/>

--- a/common/test/data/test_course_discussion/sequential/d6fe595fca7d4ebf8f85e733702aa6dc.xml
+++ b/common/test/data/test_course_discussion/sequential/d6fe595fca7d4ebf8f85e733702aa6dc.xml
@@ -1,0 +1,3 @@
+<sequential display_name="Testing">
+  <vertical url_name="1df706259c3d4137954a9e9e7f934eeb"/>
+</sequential>

--- a/common/test/data/test_course_discussion/vertical/1df706259c3d4137954a9e9e7f934eeb.xml
+++ b/common/test/data/test_course_discussion/vertical/1df706259c3d4137954a9e9e7f934eeb.xml
@@ -1,0 +1,3 @@
+<vertical display_name="Unit">
+  <discussion url_name="discussion_component"/>
+</vertical>


### PR DESCRIPTION
[TNL-1754](https://openedx.atlassian.net/browse/TNL-1754)

Duplicating a discussion item was having same same `discussion_id` if it is present in `xml`.
Wrote a Unit test for verification. 
