### PR TITLE
Remove unused bok_choy paver option ptests

### DIFF
--- a/pavelib/bok_choy.py
+++ b/pavelib/bok_choy.py
@@ -82,7 +82,6 @@ def perf_report_bokchoy(options):
         'imports_dir': getattr(options, 'imports_dir', None),
         'verbosity': getattr(options, 'verbosity', 2),
         'test_dir': 'performance',
-        'ptests': True,
     }
     run_bokchoy(**opts)
 

--- a/pavelib/utils/test/suites/bokchoy_suite.py
+++ b/pavelib/utils/test/suites/bokchoy_suite.py
@@ -39,7 +39,6 @@ class BokChoyTestSuite(TestSuite):
         self.default_store = kwargs.get('default_store', None)
         self.verbosity = kwargs.get('verbosity', 2)
         self.extra_args = kwargs.get('extra_args', '')
-        self.ptests = kwargs.get('ptests', False)
         self.har_dir = self.log_dir / 'hars'
         self.imports_dir = kwargs.get('imports_dir', None)
 


### PR DESCRIPTION
@clytwynec 

This is a remnant left behind from 1be81109e51ab44518be129e509d2b27a003fb43, where its only usage (in pavelib/utils/test/suites/bokchoy_suite.py) was removed.
