### PR TITLE
TE-883 Add ability to specify starting dir for bok-choy tests

### DIFF
--- a/pavelib/bok_choy.py
+++ b/pavelib/bok_choy.py
@@ -26,6 +26,7 @@ __test__ = False  # do not collect
     ('testsonly', 'o', 'Assume servers are running and execute tests only'),
     ('extra_args=', 'e', 'adds as extra args to the test command'),
     ('default_store=', 's', 'Default modulestore'),
+    ('test_dir=', 'd', 'Directory for finding tests (relative to common/test/acceptance)'),
     make_option("--verbose", action="store_const", const=2, dest="verbosity"),
     make_option("-q", "--quiet", action="store_const", const=0, dest="verbosity"),
     make_option("-v", "--verbosity", action="count", dest="verbosity"),
@@ -64,7 +65,7 @@ def test_bokchoy(options):
         'verbosity': getattr(options, 'verbosity', 2),
         'extra_args': getattr(options, 'extra_args', ''),
         'pdb': getattr(options, 'pdb', False),
-        'test_dir': 'tests',
+        'test_dir': getattr(options, 'test_dir', 'tests'),
     }
     run_bokchoy(**opts)
 

--- a/pavelib/paver_tests/test_paver_bok_choy_cmds.py
+++ b/pavelib/paver_tests/test_paver_bok_choy_cmds.py
@@ -1,4 +1,7 @@
-
+"""
+Tests for the bok-choy paver commands themselves.
+Run just this test with: paver test_lib -t pavelib/paver_tests/test_paver_bok_choy_cmds.py
+"""
 import os
 import unittest
 from pavelib.utils.test.suites import BokChoyTestSuite
@@ -8,57 +11,78 @@ REPO_DIR = os.getcwd()
 
 class TestPaverBokChoyCmd(unittest.TestCase):
 
-    def setUp(self):
-        super(TestPaverBokChoyCmd, self).setUp()
-        self.request = BokChoyTestSuite('')
-
-    def _expected_command(self, expected_text_append, expected_default_store=None):
-        if expected_text_append:
-            expected_text_append = "/" + expected_text_append
+    def _expected_command(self, name, store=None):
+        """
+        Returns the command that is expected to be run for the given test spec
+        and store.
+        """
         shard = os.environ.get('SHARD')
         expected_statement = (
             "DEFAULT_STORE={default_store} "
             "SCREENSHOT_DIR='{repo_dir}/test_root/log{shard_str}' "
             "BOK_CHOY_HAR_DIR='{repo_dir}/test_root/log{shard_str}/hars' "
             "SELENIUM_DRIVER_LOG_DIR='{repo_dir}/test_root/log{shard_str}' "
-            "nosetests {repo_dir}/common/test/acceptance/tests{exp_text} "
+            "nosetests {repo_dir}/common/test/acceptance/{exp_text} "
             "--with-xunit "
             "--xunit-file={repo_dir}/reports/bok_choy{shard_str}/xunit.xml "
             "--verbosity=2 "
         ).format(
-            default_store=expected_default_store,
+            default_store=store,
             repo_dir=REPO_DIR,
-            exp_text=expected_text_append,
             shard_str='/shard_' + shard if shard else '',
+            exp_text=name,
         )
-        return expected_statement.strip()
+        return expected_statement
 
-    def test_default_bokchoy(self):
-        self.assertEqual(self.request.cmd.strip(), self._expected_command(''))
+    def test_default(self):
+        suite = BokChoyTestSuite('')
+        name = 'tests'
+        self.assertEqual(suite.cmd, self._expected_command(name=name))
 
-    def test_suite_request_bokchoy(self):
-        self.request.test_spec = "test_foo.py"
-        self.assertEqual(self.request.cmd.strip(), self._expected_command(self.request.test_spec))
+    def test_suite_spec(self):
+        spec = 'test_foo.py'
+        suite = BokChoyTestSuite('', test_spec=spec)
+        name = 'tests/{}'.format(spec)
+        self.assertEqual(suite.cmd, self._expected_command(name=name))
 
-    def test_class_request_bokchoy(self):
-        self.request.test_spec = "test_foo.py:FooTest"
-        self.assertEqual(self.request.cmd.strip(), self._expected_command(self.request.test_spec))
+    def test_class_spec(self):
+        spec = 'test_foo.py:FooTest'
+        suite = BokChoyTestSuite('', test_spec=spec)
+        name = 'tests/{}'.format(spec)
+        self.assertEqual(suite.cmd, self._expected_command(name=name))
 
-    def test_case_request_bokchoy(self):
-        self.request.test_spec = "test_foo.py:FooTest.test_bar"
-        self.assertEqual(self.request.cmd.strip(), self._expected_command(self.request.test_spec))
+    def test_testcase_spec(self):
+        spec = 'test_foo.py:FooTest.test_bar'
+        suite = BokChoyTestSuite('', test_spec=spec)
+        name = 'tests/{}'.format(spec)
+        self.assertEqual(suite.cmd, self._expected_command(name=name))
 
-    def test_default_bokchoy_with_draft_default_store(self):
-        self.request.test_spec = "test_foo.py"
-        self.request.default_store = "draft"
-        self.assertEqual(self.request.cmd.strip(), self._expected_command(self.request.test_spec, "draft"))
+    def test_spec_with_draft_default_store(self):
+        spec = 'test_foo.py'
+        suite = BokChoyTestSuite('', test_spec=spec, default_store='draft')
+        name = 'tests/{}'.format(spec)
+        self.assertEqual(
+            suite.cmd,
+            self._expected_command(name=name, store='draft')
+        )
 
-    def test_default_bokchoy_with_invalid_default_store(self):
+    def test_invalid_default_store(self):
         # the cmd will dumbly compose whatever we pass in for the default_store
-        self.request.test_spec = "test_foo.py"
-        self.request.default_store = "invalid"
-        self.assertEqual(self.request.cmd.strip(), self._expected_command(self.request.test_spec, "invalid"))
+        suite = BokChoyTestSuite('', default_store='invalid')
+        name = 'tests'
+        self.assertEqual(
+            suite.cmd,
+            self._expected_command(name=name, store='invalid')
+        )
 
     def test_serversonly(self):
-        self.request.serversonly = True
-        self.assertEqual(self.request.cmd.strip(), "")
+        suite = BokChoyTestSuite('', serversonly=True)
+        self.assertEqual(suite.cmd, "")
+
+    def test_test_dir(self):
+        test_dir = 'foo'
+        suite = BokChoyTestSuite('', test_dir=test_dir)
+        self.assertEqual(
+            suite.cmd,
+            self._expected_command(name=test_dir)
+        )


### PR DESCRIPTION
@clytwynec 

I needed this ability so that I can kick off acceptance tests that don't live in common/test/acceptance/tests.
Added a corresponding tests.
Also improved the existing tests because they were not verifying the **init** method of BokChoyTestSuite
