### PR TITLE
Bump version of Problem Builder

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -799,6 +799,7 @@ MAX_FAILED_LOGIN_ATTEMPTS_LOCKOUT_PERIOD_SECS = 15 * 60
 
 OPTIONAL_APPS = (
     'mentoring',
+    'problem_builder',
     'edx_sga',
 
     # edx-ora2
@@ -863,6 +864,8 @@ ADVANCED_COMPONENT_TYPES = [
     'lti',
     'library_content',
     'edx_sga',
+    'problem-builder',
+    'pb-dashboard',
     # XBlocks from pmitros repos are prototypes. They should not be used
     # except for edX Learning Sciences experiments on edge.edx.org without
     # further work to make them robust, maintainable, finalize data formats,

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2100,6 +2100,7 @@ ALL_LANGUAGES = (
 ### Apps only installed in some instances
 OPTIONAL_APPS = (
     'mentoring',
+    'problem_builder',
     'edx_sga',
 
     # edx-ora2

--- a/requirements/edx/edx-private.txt
+++ b/requirements/edx/edx-private.txt
@@ -2,7 +2,7 @@
 
 # For Harvard courses:
 -e git+https://github.com/gsehub/xblock-mentoring.git@4d1cce78dc232d5da6ffd73817b5c490e87a6eee#egg=xblock-mentoring
--e git+https://github.com/open-craft/problem-builder.git@700f1834c0e8249ce9273c58ad074a1391939cd5#egg=xblock-problem-builder
+-e git+https://github.com/open-craft/problem-builder.git@4817f9d93f8ce07bbe496f4e1681450f26ef9d19#egg=xblock-problem-builder
 
 # Prototype XBlocks from edX learning sciences limited roll-outs and user testing.
 # Concept XBlock, in particular, is nowhere near finished and an early prototype.


### PR DESCRIPTION
**Description:** This bumps the "Problem Builder" XBlock to the latest version that has been reviewed by the edX team, and includes the configuration settings necessary for authors to use it.

This will be the final version bump required for an upcoming Harvard course.

This version of Problem Builder includes:
- Problem Builder ("Mentoring v2") - the `edx-release` branch, which only contains changes reviewed by both OpenCraft and the edX team.  (See [this PR](https://github.com/open-craft/problem-builder/pull/9))
- Dashboard XBlock (part of Problem Builder)

There should be minimal consequences to this PR as it only affects a new XBlock not yet used in any courses.

**Partner information**: hosted on edx.org (Harvard)
**Merge deadline**: ASAP

**Sandbox**: http://sandbox2.opencraft.com:18010/
