### PR TITLE
WIP: Change the receipt page to take in Oscar Basket numbers.

### DIFF
--- a/lms/djangoapps/commerce/tests/__init__.py
+++ b/lms/djangoapps/commerce/tests/__init__.py
@@ -15,13 +15,19 @@ class EcommerceApiTestMixin(object):
     ECOMMERCE_API_URL = 'http://example.com/api'
     ECOMMERCE_API_SIGNING_KEY = 'edx'
     ORDER_NUMBER = '100004'
+    BASKET_NUMBER = '10001'
     ECOMMERCE_API_SUCCESSFUL_BODY = {
         'status': OrderStatus.COMPLETE,
         'number': ORDER_NUMBER,
         'payment_processor': 'cybersource',
         'payment_parameters': {'orderNumber': ORDER_NUMBER}
     }
+    ECOMMERCE_API_SUCCESSFUL_BASKET_BODY = {
+        'order': ECOMMERCE_API_SUCCESSFUL_BODY,
+    }
     ECOMMERCE_API_SUCCESSFUL_BODY_JSON = json.dumps(ECOMMERCE_API_SUCCESSFUL_BODY)  # pylint: disable=invalid-name
+    # pylint: disable=invalid-name
+    ECOMMERCE_API_SUCCESSFUL_BASKET_BODY_JSON = json.dumps(ECOMMERCE_API_SUCCESSFUL_BASKET_BODY)
 
     def assertValidJWTAuthHeader(self, request, user, key):
         """ Verifies that the JWT Authorization header is correct. """
@@ -35,7 +41,7 @@ class EcommerceApiTestMixin(object):
         self.assertEqual(request.body, '{{"sku": "{}"}}'.format(sku))
         self.assertEqual(request.headers['Content-Type'], 'application/json')
 
-    def _mock_ecommerce_api(self, status=200, body=None):
+    def _mock_ecommerce_api(self, status=200, body=None, uri='/orders/', method=httpretty.POST):
         """
         Mock calls to the E-Commerce API.
 
@@ -43,9 +49,9 @@ class EcommerceApiTestMixin(object):
         """
         self.assertTrue(httpretty.is_enabled(), 'Test is missing @httpretty.activate decorator.')
 
-        url = self.ECOMMERCE_API_URL + '/orders/'
+        url = self.ECOMMERCE_API_URL + uri
         body = body or self.ECOMMERCE_API_SUCCESSFUL_BODY_JSON
-        httpretty.register_uri(httpretty.POST, url, status=status, body=body)
+        httpretty.register_uri(method, url, status=status, body=body)
 
     class mock_create_order(object):    # pylint: disable=invalid-name
         """ Mocks calls to EcommerceAPI.create_order. """

--- a/lms/djangoapps/commerce/tests/test_api.py
+++ b/lms/djangoapps/commerce/tests/test_api.py
@@ -23,6 +23,7 @@ class EcommerceAPITests(EcommerceApiTestMixin, TestCase):
     """ Tests for the E-Commerce API client. """
 
     SKU = '1234'
+    BASKET_NUMBER = '10001'
 
     def setUp(self):
         super(EcommerceAPITests, self).setUp()
@@ -61,6 +62,37 @@ class EcommerceAPITests(EcommerceApiTestMixin, TestCase):
         self.assertEqual(number, self.ORDER_NUMBER)
         self.assertEqual(status, OrderStatus.COMPLETE)
         self.assertEqual(body, self.ECOMMERCE_API_SUCCESSFUL_BODY)
+
+    @httpretty.activate
+    def test_get_order(self):
+        """ Verify the method makes a call to the E-Commerce API with the correct headers and data. """
+        self._mock_ecommerce_api(method=httpretty.GET)
+        number, status, body = self.api.get_order(self.user, self.SKU)
+
+        # Validate the request sent to the E-Commerce API endpoint.
+        request = httpretty.last_request()
+        self.assertValidOrderRequest(request, self.user, self.ECOMMERCE_API_SIGNING_KEY, self.SKU)
+
+        # Validate the data returned by the method
+        self.assertEqual(number, self.ORDER_NUMBER)
+        self.assertEqual(status, OrderStatus.COMPLETE)
+        self.assertEqual(body, self.ECOMMERCE_API_SUCCESSFUL_BODY)
+
+    @httpretty.activate
+    def test_get_basket(self):
+        """ Verify the method makes a call to the E-Commerce API with the correct headers and data. """
+        self._mock_ecommerce_api(
+            body=self.ECOMMERCE_API_SUCCESSFUL_BASKET_BODY_JSON, uri='/baskets/', method=httpretty.GET
+        )
+        number, body = self.api.get_basket(self.user, self.BASKET_NUMBER)
+
+        # Validate the request sent to the E-Commerce API endpoint.
+        request = httpretty.last_request()
+        self.assertValidOrderRequest(request, self.user, self.ECOMMERCE_API_SIGNING_KEY, self.SKU)
+
+        # Validate the data returned by the method
+        self.assertEqual(number, self.BASKET_NUMBER)
+        self.assertEqual(body, self.ECOMMERCE_API_SUCCESSFUL_BASKET_BODY)
 
     @httpretty.activate
     @data(400, 401, 405, 406, 429, 500, 503)

--- a/lms/djangoapps/shoppingcart/tests/test_views.py
+++ b/lms/djangoapps/shoppingcart/tests/test_views.py
@@ -948,21 +948,24 @@ class ShoppingCartViewsTests(ModuleStoreTestCase):
             "unit_price_excl_tax": 40.0
         }
 
+        BASKET = {
+            'order': ORDER
+        }
+
         def __init__(self, **kwargs):
 
-            result = copy.deepcopy(self.ORDER)
-            result['lines'] = [copy.deepcopy(self.LINE) for _ in xrange(kwargs['num_items'])]
+            result = copy.deepcopy(self.BASKET)
+            result['order']['lines'] = [copy.deepcopy(self.LINE) for _ in xrange(kwargs['num_items'])]
             default_kwargs = {
                 'return_value': (
-                    EcommerceApiTestMixin.ORDER_NUMBER,
-                    OrderStatus.COMPLETE,
+                    '10001',
                     result,
                 )
             }
 
             default_kwargs.update(kwargs)
 
-            self.patch = mock.patch.object(EcommerceAPI, 'get_order', mock.Mock(**default_kwargs))
+            self.patch = mock.patch.object(EcommerceAPI, 'get_basket', mock.Mock(**default_kwargs))
 
         def __enter__(self):
             self.patch.start()

--- a/lms/static/js/verify_student/views/payment_confirmation_step_view.js
+++ b/lms/static/js/verify_student/views/payment_confirmation_step_view.js
@@ -42,7 +42,8 @@ var edx = edx || {};
             var view = this;
             return $.Deferred(
                 function( defer ) {
-                    var paymentOrderNum = $.url( '?payment-order-num' );
+                    var basketNum = $.url('?basket-num');
+                    var paymentOrderNum = basketNum ? basketNum : $.url( '?payment-order-num' );
                     if ( paymentOrderNum ) {
                         // If there is a payment order number, try to retrieve
                         // the receipt information from the shopping cart.


### PR DESCRIPTION
@rlucioni @clintonb 

I'm trying to figure out why the two new tests for commerce are failing, but otherwise this should be the complete set of changes to use baskets instead of orders for generating the receipt on the LMS.
