### PR TITLE
Updated course_about API to include additional information

### DIFF
--- a/common/djangoapps/course_about/data.py
+++ b/common/djangoapps/course_about/data.py
@@ -15,7 +15,23 @@ from xmodule.modulestore.exceptions import ItemNotFoundError
 log = logging.getLogger(__name__)
 
 ABOUT_ATTRIBUTES = [
-    'effort'
+    'effort',
+    'overview',
+    'title',
+    'university',
+    'number',
+    'short_description',
+    'description',
+    'key_dates',
+    'video',
+    'course_staff_short',
+    'course_staff_extended',
+    'requirements',
+    'syllabus',
+    'textbook',
+    'faq',
+    'more_info',
+    'ocw_links',
 ]
 
 

--- a/common/djangoapps/course_about/serializers.py
+++ b/common/djangoapps/course_about/serializers.py
@@ -27,9 +27,8 @@ def serialize_content(course_descriptor, about_descriptor):
         'start': _formatted_datetime(course_descriptor, 'start'),
         'end': _formatted_datetime(course_descriptor, 'end'),
         'announcement': None,
-        'effort': about_descriptor.get("effort", None)
-
     }
+    data.update(about_descriptor)
 
     content_id = unicode(course_descriptor.id)
     data["course_id"] = unicode(content_id)


### PR DESCRIPTION
@mattdrayer, @stephensanchez - optional improvements to about, adding some additional properties. In particular the serializer will now add any properties that have been collected within the about_descriptor
