### PR TITLE
i18n fix in studio

### DIFF
--- a/cms/djangoapps/contentstore/courseware_index.py
+++ b/cms/djangoapps/contentstore/courseware_index.py
@@ -159,7 +159,7 @@ class CoursewareSearchIndexer(object):
             error_list.append(_('General indexing error occurred'))
 
         if error_list:
-            raise SearchIndexingError(_('Error(s) present during indexing'), error_list)
+            raise SearchIndexingError('Error(s) present during indexing', error_list)
 
         return indexed_count["count"]
 

--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -813,8 +813,14 @@ def create_xblock_info(xblock, data=None, metadata=None, include_ancestor_info=F
         if parent_xblock is None:
             parent_xblock = get_parent_xblock(xblock)
 
-        explanatory_message = _('Students must score {score}% or higher to access course materials.').format(
-            score=int(parent_xblock.entrance_exam_minimum_score_pct * 100))
+        # Translators: The {pct_sign} here represents the percent sign, i.e., '%'
+        # in many languages. This is used to avoid Transifex's misinterpreting of
+        # '% o'. The percent sign is also translatable as a standalone string.
+        explanatory_message = _('Students must score {score}{pct_sign} or higher to access course materials.').format(
+            score=int(parent_xblock.entrance_exam_minimum_score_pct * 100),
+            # Translators: This is the percent sign. It will be used to represent
+            # a percent value out of 100, e.g. "58%" means "58/100".
+            pct_sign=_('%'))
 
     xblock_info = {
         "id": unicode(xblock.location),

--- a/cms/static/js/models/settings/course_details.js
+++ b/cms/static/js/models/settings/course_details.js
@@ -53,8 +53,7 @@ var CourseDetails = Backbone.Model.extend({
                 max: 100
             };
             if(!ValidationHelpers.validateIntegerRange(newattrs.entrance_exam_minimum_score_pct, range)){
-                errors.entrance_exam_minimum_score_pct = gettext("Please enter an integer between "
-                    + range.min +" and "+ range.max +".");
+                errors.entrance_exam_minimum_score_pct = interpolate(gettext("Please enter an integer between %(min)s and %(max)s."), range, true);
             }
         }
         if (!_.isEmpty(errors)) return errors;

--- a/cms/templates/activation_invalid.html
+++ b/cms/templates/activation_invalid.html
@@ -17,7 +17,7 @@
       <div class="msg">
         <h1 class="title">${_("Your account activation is invalid")}</h1>
         <div class="copy">
-          <p>${_("We're sorry. Something went wrong with your activation. Check to make sure the URL you went to was correct — e-mail programs will sometimes split it into two lines.")}</p>
+          <p>${_("We're sorry. Something went wrong with your activation. Check to make sure the URL you went to was correct, as e-mail programs will sometimes split it into two lines.")}</p>
           <p>${_("If you still have issues, contact {platform_name} Support. In the meantime, you can also return to {link_start}the {studio_name} homepage.{link_end}").format(
               platform_name=settings.PLATFORM_NAME, studio_name=settings.STUDIO_NAME,
               link_start='<a href="/">', link_end="</a>"

--- a/cms/templates/js/checklist.underscore
+++ b/cms/templates/js/checklist.underscore
@@ -7,7 +7,17 @@
     <% } %>
     id="<%= 'course-checklist' + checklistIndex %>">
     <span class="viz viz-checklist-status"><span class="viz value viz-checklist-status-value" style="width: <%= percentChecked %>%;">
-        <%= _.template(gettext("{number}% of checklists completed"), {number: '<span class="int">' + percentChecked + '</span>'}, {interpolate: /\{(.+?)\}/g}) %>
+        <%= _.template(
+                // Translators: The {pct_sign} here represents the percent sign, i.e., '%'
+                // in many languages. This is used to avoid Transifex's misinterpreting of
+                // '% o'. The percent sign is also translatable as a standalone string.
+                gettext("{number}{pct_sign} of checklists completed"),
+                // Translators: This is the percent sign. It will be used to represent a
+				// percent value out of 100, e.g. "58%" means "58/100".
+                {number: '<span class="int">' + percentChecked + '</span>', pct_sign: gettext('%')},
+                {interpolate: /\{(.+?)\}/g}
+            )
+        %>
     </span></span>
     <header>
         <h3 class="checklist-title title-2 is-selectable" title="Collapse/Expand this Checklist">

--- a/cms/templates/js/mock/mock-container-page.underscore
+++ b/cms/templates/js/mock/mock-container-page.underscore
@@ -67,12 +67,12 @@
                     <div id="publish-history"></div>
                 </aside>
                 <div class="unit-location">
-                        <h4 class="header">${_("Unit Location")}</h4>
+                        <h4 class="header">Unit Location</h4>
                         <div class="wrapper-unit-id content-bit">
                             <h5 class="title">Unit Location ID</h5>
                             <p class="unit-id">
                                 <span class="unit-id-value" id="unit-location-id-input">${unit.location.name}</span>
-                                <span class="tip"><span class="sr">Tip: </span>${_("Use this ID when you create links to this unit from other course content. You enter the ID in the URL field.")}</span>
+                                <span class="tip"><span class="sr">Tip: </span>Use this ID when you create links to this unit from other course content. You enter the ID in the URL field.</span>
                             </p>
                         </div>
                         <div class="wrapper-unit-tree-location bar-mod-content">

--- a/cms/templates/js/mock/mock-index-page.underscore
+++ b/cms/templates/js/mock/mock-index-page.underscore
@@ -209,8 +209,8 @@
       </div>
 
       <ul id="course-index-tabs">
-        <li class="courses-tab active"><a>${_("Courses")}</a></li>
-        <li class="libraries-tab"><a>${_("Libraries")}</a></li>
+        <li class="courses-tab active"><a>Courses</a></li>
+        <li class="libraries-tab"><a>Libraries</a></li>
       </ul>
 
       <div class="courses courses-tab active">

--- a/cms/templates/js/mock/mock-settings-page.underscore
+++ b/cms/templates/js/mock/mock-settings-page.underscore
@@ -74,17 +74,17 @@
                     <span class="tip tip-inline">Course that students must complete before beginning this course</span>
                     <button type="submit" class="sr" name="submit" value="submit">set pre-requisite course</button>
     </li>
-        <h3 id="heading-entrance-exam">${_("Entrance Exam")}</h3>
+        <h3 id="heading-entrance-exam">Entrance Exam</h3>
             <div class="show-data">
                 <div class="heading">
                     <input type="checkbox" id="entrance-exam-enabled" />
-                    <label for="entrance-exam-enabled">${_("Require students to pass an exam before beginning the course.")}</label>
+                    <label for="entrance-exam-enabled">Require students to pass an exam before beginning the course.</label>
                 </div>
                 <div class="div-grade-requirements">
-                    <p><span class="tip tip-inline">${_("To create your course entrance exam, go to the ")}<a href='${course_handler_url}'>${_("Course Outline")}</a>${_(". An Entrance Exam section will be created automatically.")}</span></p>
-                    <p><label for="entrance-exam-minimum-score-pct">${_("Minimum Passing Score")}</label></p>
-                    <p><div><input type="text" id="entrance-exam-minimum-score-pct" aria-describedby="min-score-format min-score-tip"><span id="min-score-format" class="tip tip-inline">${_(" %")}</span></div></p>
-                    <p><span class="tip tip-inline" id="min-score-tip">${_("The minimum score a student must receive to pass the entrance exam.")}</span></p>
+                    <p><span class="tip tip-inline">To create your course entrance exam, go to the <a href='${course_handler_url}'>Course Outline</a>. An Entrance Exam section will be created automatically.</span></p>
+                    <p><label for="entrance-exam-minimum-score-pct">Minimum Passing Score</label></p>
+                    <p><div><input type="text" id="entrance-exam-minimum-score-pct" aria-describedby="min-score-format min-score-tip"><span id="min-score-format" class="tip tip-inline"> %</span></div></p>
+                    <p><span class="tip tip-inline" id="min-score-tip">The minimum score a student must receive to pass the entrance exam.</span></p>
                 </div>
             </div>
     </li>

--- a/cms/templates/js/mock/mock-xmodule-editor.underscore
+++ b/cms/templates/js/mock/mock-xmodule-editor.underscore
@@ -18,8 +18,8 @@
             <div class="wrapper-comp-setting">
                 \t<label class="label setting-label" for="<%= uniqueId %>"><%= model.get('display_name') %></label>
                 \t<input class="input setting-input" type="text" id="<%= uniqueId %>" value='<%= model.get("value") %>'/>
-                \t<button class="action setting-clear inactive" type="button" name="setting-clear" value="<%= gettext("Clear") %>" data-tooltip="<%= gettext("Clear") %>">
-                <i class="icon fa fa-undo"></i><span class="sr">"<%= gettext("Clear Value") %>"</span>
+                \t<button class="action setting-clear inactive" type="button" name="setting-clear" value="Clear" data-tooltip="Clear">
+                <i class="icon fa fa-undo"></i><span class="sr">"Clear Value"</span>
                 </button>
             </div>
             <span class="tip setting-help"><%= model.get('help') %></span>

--- a/cms/templates/js/mock/mock-xmodule-settings-only-editor.underscore
+++ b/cms/templates/js/mock/mock-xmodule-settings-only-editor.underscore
@@ -14,8 +14,8 @@
             <div class="wrapper-comp-setting">
                 \t<label class="label setting-label" for="<%= uniqueId %>"><%= model.get('display_name') %></label>
                 \t<input class="input setting-input" type="text" id="<%= uniqueId %>" value='<%= model.get("value") %>'/>
-                \t<button class="action setting-clear inactive" type="button" name="setting-clear" value="<%= gettext("Clear") %>" data-tooltip="<%= gettext("Clear") %>">
-                <i class="icon fa fa-undo"></i><span class="sr">"<%= gettext("Clear Value") %>"</span>
+                \t<button class="action setting-clear inactive" type="button" name="setting-clear" value="Clear" data-tooltip="Clear">
+                <i class="icon fa fa-undo"></i><span class="sr">"Clear Value"</span>
                 </button>
             </div>
             <span class="tip setting-help"><%= model.get('help') %></span>

--- a/cms/templates/js/video/transcripts/messages/transcripts-choose.underscore
+++ b/cms/templates/js/video/transcripts/messages/transcripts-choose.underscore
@@ -18,7 +18,7 @@
     <% _.each(html5_list, function(value, index) {
         var type = grouped_list[value][0].type,
             file_name = value + ((type) ? ('.' + type) : ''),
-            message = gettext("Timed Transcript from ") + file_name;
+            message = interpolate(gettext("Timed Transcript from %(filename)s"), { filename: file_name }, true);
     %>
         <button
             class="action setting-choose"


### PR DESCRIPTION
1. Fix the broken `gettext()` call in `courde_detail.js`
2. Change the string to avoid Transifex misunderstand the pattern '% o' in `checklist.underscore`.
3. Embed the `{filename}` part inside the string in `transcripts-choose.underscore` to provide better i18n flexibililty.
4. Remove all the call of `gettext()` and `${_()}` inside the `mock` directory to aovid mis-extraction by babel. (It seems that the `mock` directory is soly used in test? So the strings in this directory need not to be extracted and translated?)
