### PR TITLE
Update pip to 6.1.1

### DIFF
--- a/requirements/edx/pre.txt
+++ b/requirements/edx/pre.txt
@@ -9,7 +9,7 @@
 numpy==1.6.2
 
 # Needed to make sure that options in base.txt are allowed
-pip==6.0.8
+pip==6.1.1
 
 # Needed for meliae
 Cython==0.21.2


### PR DESCRIPTION
Just to keep us on the upgrade treadmill. Also, pip constantly alerts when a newer version is available, and it's annoying. [Changelog](http://pip.readthedocs.org/en/latest/news.html)

@cpennington, can you review this PR?
