### PR TITLE
Revert hotfix for PLAT-452

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split_draft.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split_draft.py
@@ -500,10 +500,6 @@ class DraftVersioningModuleStore(SplitMongoModuleStore, ModuleStoreDraftAndPubli
                 draft_course = course_key.for_branch(ModuleStoreEnum.BranchName.draft)
                 with self.branch_setting(ModuleStoreEnum.Branch.draft_preferred, draft_course):
                     draft_block = self.import_xblock(user_id, draft_course, block_type, block_id, fields, runtime)
-                    # if block was published once and now it is in draft state then return draft version
-                    # as current state of block is draft state
-                    if self.has_published_version(draft_block) and block_type not in DIRECT_ONLY_CATEGORIES:
-                        return draft_block
                     return self.publish(draft_block.location.version_agnostic(), user_id, blacklist=EXCLUDE_ALL, **kwargs)
 
             # do the import


### PR DESCRIPTION
The hotfix was released of [PLAT-452](https://openedx.atlassian.net/browse/PLAT-452)--> Drafts are mistakenly published on course import in split courses but some of the cases are missing for that 

1) When there is draft_version and and not have public version of block ( in case of new block)—->return draft 
2) When the xblock is in published state (current) and have draft version as well—->return publish

as above cases are missed in the pr which causes  (PLAT-608)[https://openedx.atlassian.net/browse/PLAT-608] so reverting the [pr](https://github.com/edx/edx-platform/pull/7614)
