### PR TITLE
Fallout from PR 7111, fixes DOC-1890

### DIFF
--- a/common/lib/xmodule/xmodule/video_module/video_xfields.py
+++ b/common/lib/xmodule/xmodule/video_module/video_xfields.py
@@ -52,13 +52,13 @@ class VideoFields(object):
         default=""
     )
     start_time = RelativeTime(  # datetime.timedelta object
-        help=_("Time you want the video to start if you don't want the entire video to play. Formatted as HH:MM:SS. The maximum value is 23:59:59."),
+        help=_("Time you want the video to start if you don't want the entire video to play. Not supported in the native mobile app: the full video file will play. Formatted as HH:MM:SS. The maximum value is 23:59:59."),
         display_name=_("Video Start Time"),
         scope=Scope.settings,
         default=datetime.timedelta(seconds=0)
     )
     end_time = RelativeTime(  # datetime.timedelta object
-        help=_("Time you want the video to stop if you don't want the entire video to play. Formatted as HH:MM:SS. The maximum value is 23:59:59."),
+        help=_("Time you want the video to stop if you don't want the entire video to play. Not supported in the native mobile app: the full video file will play. Formatted as HH:MM:SS. The maximum value is 23:59:59."),
         display_name=_("Video Stop Time"),
         scope=Scope.settings,
         default=datetime.timedelta(seconds=0)


### PR DESCRIPTION
Discrepancy between app and browser interaction discovered due to https://github.com/edx/edx-platform/pull/7111.
Regardless of the effect that the optional stop and start times have on videos, the mobile app currently ignores them and plays the entire video file. 
_@lou-wang , @nasthagiri , @mhoeber please review._
Duplicate effort -- no need to review
