### PR TITLE
Fixed Embargo Bug in Enrollment API

### DIFF
--- a/common/djangoapps/enrollment/urls.py
+++ b/common/djangoapps/enrollment/urls.py
@@ -11,12 +11,13 @@ from .views import (
     EnrollmentCourseDetailView
 )
 
-USER_PATTERN = '(?P<user>[\w.@+-]+)'
+USERNAME_PATTERN = '(?P<username>[\w.@+-]+)'
 
 urlpatterns = patterns(
     'enrollment.views',
     url(
-        r'^enrollment/{user},{course_key}$'.format(user=USER_PATTERN, course_key=settings.COURSE_ID_PATTERN),
+        r'^enrollment/{username},{course_key}$'.format(username=USERNAME_PATTERN,
+                                                       course_key=settings.COURSE_ID_PATTERN),
         EnrollmentView.as_view(),
         name='courseenrollment'
     ),


### PR DESCRIPTION
This issue was not found sooner because the test helper used only tested for GeoIP embargoes, and neglected the user profile. An additional test has been added to test for embargoes against the country assigned to the user's profile. Additionally, variable names have been cleaned up--user replaced with username--to avoid confusion in the future.

[ECOM-1418](https://openedx.atlassian.net/browse/ECOM-1418)

@wedaly @rlucioni 
