### PR TITLE
Put CCX URLs behind their feature flag

### DIFF
--- a/lms/djangoapps/ccx/urls.py
+++ b/lms/djangoapps/ccx/urls.py
@@ -1,0 +1,29 @@
+"""
+URLs for the CCX Feature.
+"""
+from django.conf.urls import patterns, url
+
+
+urlpatterns = patterns(
+    '',
+    url(r'^ccx_coach$',
+        'ccx.views.dashboard', name='ccx_coach_dashboard'),
+    url(r'^create_ccx$',
+        'ccx.views.create_ccx', name='create_ccx'),
+    url(r'^save_ccx$',
+        'ccx.views.save_ccx', name='save_ccx'),
+    url(r'^ccx_invite$',
+        'ccx.views.ccx_invite', name='ccx_invite'),
+    url(r'^ccx_schedule$',
+        'ccx.views.ccx_schedule', name='ccx_schedule'),
+    url(r'^ccx_manage_student$',
+        'ccx.views.ccx_student_management', name='ccx_manage_student'),
+    url(r'^ccx_gradebook$',
+        'ccx.views.ccx_gradebook', name='ccx_gradebook'),
+    url(r'^ccx_grades.csv$',
+        'ccx.views.ccx_grades_csv', name='ccx_grades_csv'),
+    url(r'^ccx_set_grading_policy$',
+        'ccx.views.set_grading_policy', name='ccx_set_grading_policy'),
+    url(r'^switch_ccx(?:/(?P<ccx_id>[\d]+))?$',
+        'ccx.views.switch_active_ccx', name='switch_active_ccx'),
+)

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -472,3 +472,4 @@ FEATURES['CERTIFICATES_HTML_VIEW'] = True
 ######### custom courses #########
 INSTALLED_APPS += ('ccx',)
 MIDDLEWARE_CLASSES += ('ccx.overrides.CcxMiddleware',)
+FEATURES['CUSTOM_COURSES_EDX'] = True

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -343,26 +343,8 @@ if settings.COURSEWARE_ENABLED:
         # For the instructor
         url(r'^courses/{}/instructor$'.format(settings.COURSE_ID_PATTERN),
             'instructor.views.instructor_dashboard.instructor_dashboard_2', name="instructor_dashboard"),
-        url(r'^courses/{}/ccx_coach$'.format(settings.COURSE_ID_PATTERN),
-            'ccx.views.dashboard', name='ccx_coach_dashboard'),
-        url(r'^courses/{}/create_ccx$'.format(settings.COURSE_ID_PATTERN),
-            'ccx.views.create_ccx', name='create_ccx'),
-        url(r'^courses/{}/save_ccx$'.format(settings.COURSE_ID_PATTERN),
-            'ccx.views.save_ccx', name='save_ccx'),
-        url(r'^courses/{}/ccx_invite$'.format(settings.COURSE_ID_PATTERN),
-            'ccx.views.ccx_invite', name='ccx_invite'),
-        url(r'^courses/{}/ccx_schedule$'.format(settings.COURSE_ID_PATTERN),
-            'ccx.views.ccx_schedule', name='ccx_schedule'),
-        url(r'^courses/{}/ccx_manage_student$'.format(settings.COURSE_ID_PATTERN),
-            'ccx.views.ccx_student_management', name='ccx_manage_student'),
-        url(r'^courses/{}/ccx_gradebook$'.format(settings.COURSE_ID_PATTERN),
-            'ccx.views.ccx_gradebook', name='ccx_gradebook'),
-        url(r'^courses/{}/ccx_grades.csv$'.format(settings.COURSE_ID_PATTERN),
-            'ccx.views.ccx_grades_csv', name='ccx_grades_csv'),
-        url(r'^courses/{}/ccx_set_grading_policy$'.format(settings.COURSE_ID_PATTERN),
-            'ccx.views.set_grading_policy', name='ccx_set_grading_policy'),
-        url(r'^courses/{}/switch_ccx(?:/(?P<ccx_id>[\d]+))?$'.format(settings.COURSE_ID_PATTERN),
-            'ccx.views.switch_active_ccx', name='switch_active_ccx'),
+
+
         url(r'^courses/{}/set_course_mode_price$'.format(settings.COURSE_ID_PATTERN),
             'instructor.views.instructor_dashboard.set_course_mode_price', name="set_course_mode_price"),
         url(r'^courses/{}/instructor/api/'.format(settings.COURSE_ID_PATTERN),
@@ -642,6 +624,14 @@ if settings.FEATURES.get('CERTIFICATES_HTML_VIEW', False):
 urlpatterns += (
     url(r'^xdomain_proxy.html$', 'cors_csrf.views.xdomain_proxy', name='xdomain_proxy'),
 )
+
+# Custom courses on edX (CCX) URLs
+if settings.FEATURES["CUSTOM_COURSES_EDX"]:
+    urlpatterns += (
+        url(r'^courses/{}/'.format(settings.COURSE_ID_PATTERN),
+            include('ccx.urls')),
+    )
+
 
 urlpatterns = patterns(*urlpatterns)
 


### PR DESCRIPTION
If the `CUSTOM_COURSES_EDX` feature flag is disable (the default), the migrations, middleware, and django app aren't added, but as it is now, the URLs still are.  This can lead to unhandled exceptions for models not existing, but even potentially worse, if the feature is enabled, migrations are run, and then it is decided the feature is disabled the URLs will still work, and users will still be able to create CCXs.

This hides those URLs behind the feature flag, and cleans up the URLs for CCX to reduce clutter in lms/urls.py and more properly follow django app design practices.
