### PR TITLE
Use actual meliae version.

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -50,10 +50,10 @@ httpretty==0.8.3
 lazy==1.1
 lxml==3.3.6
 mako==0.9.1
+meliae==0.4.0
 Markdown==2.2.1
 --allow-external meliae
 --allow-unverified meliae
-meliae==0.4.0
 mongoengine==0.7.10
 networkx==1.7
 nltk==2.0.5


### PR DESCRIPTION
Previously, this was being ignored becasue it could not be found. Example message from Jenkins:

13:02:18   meliae is potentially insecure and unverifiable.
13:02:19   Requested meliae==0.4.0 (from -r requirements/edx/base.txt (line 56)), but installing version None
