### PR TITLE
Adding outline styles (none) to the sr focus div

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/sequence/display.coffee
+++ b/common/lib/xmodule/xmodule/js/src/sequence/display.coffee
@@ -4,7 +4,7 @@ class @Sequence
     @el = $(element).find('.sequence')
     @contents = @$('.seq_contents')
     @content_container = @$('#seq_content')
-    @sr_container = @$('#sr-is-focusable')
+    @sr_container = @$('.sr-is-focusable')
     @num_contents = @contents.length
     @id = @el.data('id')
     @ajaxUrl = @el.data('ajax-url')

--- a/lms/static/sass/course/courseware/_courseware.scss
+++ b/lms/static/sass/course/courseware/_courseware.scss
@@ -60,6 +60,12 @@ div.course-wrapper {
       }
     }
 
+    #sr-is-focusable,
+    #sr-is-focusable:focus,
+    #sr-is-focusable:active {
+      outline: none;
+    }
+
     .sequential-status-message {
       margin-bottom: $baseline;
       background-color: $gray-l5;

--- a/lms/static/sass/course/courseware/_courseware.scss
+++ b/lms/static/sass/course/courseware/_courseware.scss
@@ -60,9 +60,9 @@ div.course-wrapper {
       }
     }
 
-    #sr-is-focusable,
-    #sr-is-focusable:focus,
-    #sr-is-focusable:active {
+    .sr-is-focusable,
+    .sr-is-focusable:focus,
+    .sr-is-focusable:active {
       outline: none;
     }
 

--- a/lms/templates/seq_module.html
+++ b/lms/templates/seq_module.html
@@ -30,7 +30,7 @@
     <button class="sequence-nav-button button-next">${_('Next')}</button>
   </div>
 
-  <div id="sr-is-focusable" tabindex="-1"></div>
+  <div class="sr-is-focusable" tabindex="-1"></div>
 
   % for idx, item in enumerate(items):
   <div id="seq_contents_${idx}"


### PR DESCRIPTION
This work relates to [UX-1946](https://openedx.atlassian.net/browse/UX-1946) and addresses the outline/focus ring that appears on the empty `div` used for keyboard focus upon sequence navigation. It adds Sass rules to remove the outline for this `div`.

@cptvitamin Would you mind reviewing?
@talbs Mind reviewing?
