### PR TITLE
Chaning table th td color to meet AA guidelines

### DIFF
--- a/lms/static/sass/views/_verification.scss
+++ b/lms/static/sass/views/_verification.scss
@@ -219,7 +219,7 @@
           @extend %t-title7;
           @extend %t-weight2;
           vertical-align: middle;
-          color: $m-gray-l1;
+          color: $m-gray-d3;
           background: $m-gray-l4;
         }
       }


### PR DESCRIPTION
This work relates to [UX-2001](https://openedx.atlassian.net/browse/UX-2001) and addresses the low contrast in the report table header. The value for the gray color font has been changed from `$m-gray-l1` to `$m-gray-d3`.

@cptvitamin Mind reviewing?
@talbs Mind reviewing?
