### PR TITLE
Be more specific about where we compile sass from.

### DIFF
--- a/pavelib/assets.py
+++ b/pavelib/assets.py
@@ -16,7 +16,7 @@ from .utils.cmd import cmd, django_cmd
 
 COFFEE_DIRS = ['lms', 'cms', 'common']
 SASS_LOAD_PATHS = ['./common/static/sass']
-SASS_UPDATE_DIRS = ['*/static']
+SASS_UPDATE_DIRS = ['*/static/sass', 'common/static']
 SASS_CACHE_PATH = '/tmp/sass-cache'
 
 


### PR DESCRIPTION
There are now folders under static that have sass that should not be compiled
as a part of our asset pipeline,  they were getting pulled in because the wildcard
for `SASS_UPDATE_DIRS` was too broad.  This update makes it more specific for most
folders but leaves it broad for the common folder where the xmodule has its own sass
that needs compiling from a non-standard location.

Review: @talbs @sarina @jzoldak 
