### PR TITLE
Forgot password model not visible when user clicks 'Forgot Password' link on CMS.

### DIFF
--- a/common/test/acceptance/pages/lms/login_and_register.py
+++ b/common/test/acceptance/pages/lms/login_and_register.py
@@ -63,6 +63,30 @@ class RegisterPage(PageObject):
         return dashboard
 
 
+class ResetPasswordPage(PageObject):
+    """Initialize the page.
+
+        Arguments:
+            browser (Browser): The browser instance.
+    """
+    url = BASE_URL + "/login#forgot-password-modal"
+
+    def __init__(self, browser):
+        super(ResetPasswordPage, self).__init__(browser)
+
+    def is_browser_on_page(self):
+        return (
+            self.q(css="#login-anchor").is_present() and
+            self.q(css="#password-reset-anchor").is_present()
+        )
+
+    def is_form_visible(self):
+        return (
+            not self.q(css="#login-anchor").visible and
+            self.q(css="#password-reset-form").visible
+        )
+
+
 class CombinedLoginAndRegisterPage(PageObject):
     """Interact with combined login and registration page.
 

--- a/common/test/acceptance/tests/lms/test_lms.py
+++ b/common/test/acceptance/tests/lms/test_lms.py
@@ -30,11 +30,31 @@ from ...pages.lms.problem import ProblemPage
 from ...pages.lms.video.video import VideoPage
 from ...pages.lms.courseware import CoursewarePage
 from ...pages.studio.settings import SettingsPage
-from ...pages.lms.login_and_register import CombinedLoginAndRegisterPage
+from ...pages.lms.login_and_register import CombinedLoginAndRegisterPage, ResetPasswordPage
 from ...pages.lms.track_selection import TrackSelectionPage
 from ...pages.lms.pay_and_verify import PaymentAndVerificationFlow, FakePaymentPage
 from ...pages.lms.course_wiki import CourseWikiPage, CourseWikiEditPage
 from ...fixtures.course import CourseFixture, XBlockFixtureDesc, CourseUpdateDesc
+
+
+@attr('shard_1')
+class ForgotPasswordPageTest(UniqueCourseTest):
+    """
+    Test that forgot password forms is rendered if url contains 'forgot-password-modal'
+    in hash.
+    """
+
+    def setUp(self):
+        """ Initialize the page object """
+        super(ForgotPasswordPageTest, self).setUp()
+        self.reset_password_page = ResetPasswordPage(self.browser)
+
+    def test_reset_password_form_visibility(self):
+        # Navigate to the password reset page
+        self.reset_password_page.visit()
+
+        # Expect that reset password form is visible on the page
+        self.assertTrue(self.reset_password_page.is_form_visible())
 
 
 @attr('shard_1')

--- a/lms/static/js/spec/student_account/access_spec.js
+++ b/lms/static/js/spec/student_account/access_spec.js
@@ -149,8 +149,11 @@ define([
                 // Simulate a click on the reset password link
                 view.resetPassword();
 
-                // Verify that the password reset wrapper is populated
-                expect($('#password-reset-wrapper')).not.toBeEmpty();
+                // Verify that the login-anchor is hidden
+                expect($("#login-anchor")).toHaveClass('hidden');
+
+                // Verify that the password reset form is not hidden
+                expect($("#password-reset-form")).not.toHaveClass('hidden');
             });
 
             it('enrolls the user on auth complete', function() {

--- a/lms/static/js/student_account/views/AccessView.js
+++ b/lms/static/js/student_account/views/AccessView.js
@@ -82,8 +82,12 @@ var edx = edx || {};
         },
 
         postRender: function() {
-            // Load the default form
-            this.loadForm( this.activeForm );
+            //get & check current url hash part & load form accordingly
+            if (Backbone.history.getHash() === "forgot-password-modal") {
+                this.resetPassword();
+            } else {
+                this.loadForm(this.activeForm);
+            }
         },
 
         loadForm: function( type ) {


### PR DESCRIPTION
Navigating to `Forgot Password` from `CMS` was not showing forgot password model. 
Fixed by checking the hash of the page & rendered forgot password layout.

TNL-1921
