### PR TITLE
Fixed caret position for LTR and RTL (SOL-693)

### DIFF
--- a/lms/static/sass/discussion/elements/_actions.scss
+++ b/lms/static/sass/discussion/elements/_actions.scss
@@ -58,7 +58,7 @@
       &:after,
       &:before {
         bottom: 100%;
-        @include right(3px);
+        right: 6px;
         border: solid transparent;
         content: " ";
         height: 0;

--- a/lms/static/sass/multicourse/_dashboard.scss
+++ b/lms/static/sass/multicourse/_dashboard.scss
@@ -298,7 +298,6 @@
     @include transition(all 0.15s linear 0s);
     @include clearfix();
     @extend %ui-depth2;
-    position: relative;
     margin: ($baseline/2);
 
     .details {

--- a/lms/static/sass/multicourse/_dashboard.scss
+++ b/lms/static/sass/multicourse/_dashboard.scss
@@ -479,7 +479,7 @@
               &:after,
               &:before {
                 bottom: 100%;
-                @include right(3px);
+                right: 6px;
                 border: solid transparent;
                 content: " ";
                 height: 0;


### PR DESCRIPTION
The work in this PR addresses [UX-1953](https://openedx.atlassian.net/browse/UX-1953) and fixes the following accessibility issues:
- The caret/nob/arrow that displays when a dropdown menu is open wasn't previously RTL-ified. This PR addresses that so it appears in the correct place when viewing LTR and RTL.
- The dropdown menu that appears for social actions was previously behind the next course title (if there was more than one course and no course messages visible). This PR fixes the issue and makes the menu appear on top as it should.

---

@talbs Mind reviewing?
@cptvitamin FYI
