### PR TITLE
Removed all references to AUTH_ENTRY_DASHBOARD.

### DIFF
--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -114,7 +114,6 @@ AUTH_EMAIL_OPT_IN_KEY = 'email_opt_in'
 
 
 # The following are various possible values for the AUTH_ENTRY_KEY.
-AUTH_ENTRY_DASHBOARD = 'dashboard'
 AUTH_ENTRY_LOGIN = 'login'
 AUTH_ENTRY_REGISTER = 'register'
 AUTH_ENTRY_ACCOUNT_SETTINGS = 'account_settings'
@@ -143,7 +142,6 @@ def is_api(auth_entry):
 # We don't use "reverse" here because doing so may cause modules
 # to load that depend on this module.
 AUTH_DISPATCH_URLS = {
-    AUTH_ENTRY_DASHBOARD: '/dashboard',
     AUTH_ENTRY_LOGIN: '/login',
     AUTH_ENTRY_REGISTER: '/register',
     AUTH_ENTRY_ACCOUNT_SETTINGS: '/account/settings',
@@ -158,7 +156,6 @@ AUTH_DISPATCH_URLS = {
 }
 
 _AUTH_ENTRY_CHOICES = frozenset([
-    AUTH_ENTRY_DASHBOARD,
     AUTH_ENTRY_LOGIN,
     AUTH_ENTRY_REGISTER,
     AUTH_ENTRY_ACCOUNT_SETTINGS,
@@ -580,7 +577,7 @@ def login_analytics(strategy, auth_entry, *args, **kwargs):
     event_name = None
     if auth_entry in [AUTH_ENTRY_LOGIN, AUTH_ENTRY_LOGIN_2]:
         event_name = 'edx.bi.user.account.authenticated'
-    elif auth_entry in [AUTH_ENTRY_DASHBOARD]:
+    elif auth_entry in [AUTH_ENTRY_ACCOUNT_SETTINGS]:
         event_name = 'edx.bi.user.account.linked'
 
     if event_name is not None:
@@ -626,7 +623,7 @@ def change_enrollment(strategy, auth_entry=None, user=None, *args, **kwargs):
         user (User): The user being authenticated.
     """
     # We skip enrollment if the user entered the flow from the "link account"
-    # button on the student dashboard.  At this point, either:
+    # button on the account settings page.  At this point, either:
     #
     # 1) The user already had a linked account when they started the enrollment flow,
     # in which case they would have been enrolled during the normal authentication process.
@@ -636,7 +633,7 @@ def change_enrollment(strategy, auth_entry=None, user=None, *args, **kwargs):
     # args when sending users to this page, successfully authenticating through this page
     # would also enroll the student in the course.
     enroll_course_id = strategy.session_get('enroll_course_id')
-    if enroll_course_id and auth_entry != AUTH_ENTRY_DASHBOARD:
+    if enroll_course_id and auth_entry != AUTH_ENTRY_ACCOUNT_SETTINGS:
         course_id = CourseKey.from_string(enroll_course_id)
         modes = CourseMode.modes_for_course_dict(course_id)
 

--- a/common/djangoapps/third_party_auth/tests/specs/base.py
+++ b/common/djangoapps/third_party_auth/tests/specs/base.py
@@ -111,42 +111,6 @@ class IntegrationTest(testutil.TestCase, test.TestCase):
         self.client = test.Client()
         self.request_factory = test.RequestFactory()
 
-    def assert_dashboard_response_looks_correct(self, response, user, duplicate=False, linked=None):
-        """Asserts the user's dashboard is in the expected state.
-
-        We check unconditionally that the dashboard 200s and contains the
-        user's info. If duplicate is True, we expect the duplicate account
-        association error to be present. If linked is passed, we conditionally
-        check the content and controls in the Account Links section of the
-        sidebar.
-        """
-        duplicate_account_error_needle = '<section class="dashboard-banner third-party-auth">'
-        assert_duplicate_presence_fn = self.assertIn if duplicate else self.assertNotIn
-
-        self.assertEqual(200, response.status_code)
-        self.assertIn(user.email, response.content.decode('UTF-8'))
-        self.assertIn(user.username, response.content.decode('UTF-8'))
-        assert_duplicate_presence_fn(duplicate_account_error_needle, response.content)
-
-        if linked is not None:
-
-            if linked:
-                expected_control_text = pipeline.ProviderUserState(
-                    self.PROVIDER_CLASS, user, False).get_unlink_form_name()
-            else:
-                expected_control_text = pipeline.get_login_url(self.PROVIDER_CLASS.NAME, pipeline.AUTH_ENTRY_DASHBOARD)
-
-            provider_name = re.search(r'<span class="provider">([^<]+)', response.content, re.DOTALL).groups()[0]
-
-            self.assertIn(expected_control_text, response.content)
-            if linked:
-                self.assertIn("fa fa-link", response.content)
-                self.assertNotIn("fa fa-unlink", response.content)
-            else:
-                self.assertNotIn("fa fa-link", response.content)
-                self.assertIn("fa fa-unlink", response.content)
-            self.assertEqual(self.PROVIDER_CLASS.NAME, provider_name)
-
     def assert_account_settings_context_looks_correct(self, context, user, duplicate=False, linked=None):
         """Asserts the user's account settings page context is in the expected state.
 

--- a/common/djangoapps/third_party_auth/tests/test_change_enrollment.py
+++ b/common/djangoapps/third_party_auth/tests/test_change_enrollment.py
@@ -145,9 +145,9 @@ class PipelineEnrollmentTest(UrlResetMixin, ModuleStoreTestCase):
         strategy = self._fake_strategy()
         strategy.session_set('enroll_course_id', unicode(self.course.id))
 
-        # Simulate completing the pipeline from the student dashboard's
+        # Simulate completing the pipeline from the student account settings
         # "link account" button.
-        result = pipeline.change_enrollment(strategy, 1, user=self.user, auth_entry=pipeline.AUTH_ENTRY_DASHBOARD)  # pylint: disable=assignment-from-no-return,redundant-keyword-arg
+        result = pipeline.change_enrollment(strategy, 1, user=self.user, auth_entry=pipeline.AUTH_ENTRY_ACCOUNT_SETTINGS)  # pylint: disable=assignment-from-no-return,redundant-keyword-arg
 
         # Verify that we were NOT enrolled
         self.assertEqual(result, {})

--- a/lms/templates/student_account/login.underscore
+++ b/lms/templates/student_account/login.underscore
@@ -1,7 +1,7 @@
 <div class="status already-authenticated-msg hidden">
     <% if (context.currentProvider) { %>
         <p class="message-copy">
-            <%- _.sprintf( gettext("You've successfully signed into %(currentProvider)s, but your %(currentProvider)s account isn't linked with an %(platformName)s account. To link your accounts, go to your %(platformName)s dashboard."), context ) %>
+            <%- _.sprintf( gettext("You've successfully signed into %(currentProvider)s, but your %(currentProvider)s account isn't linked with an %(platformName)s account. To link your accounts, go to your %(platformName)s account settings."), context ) %>
         </p>
     <% } %>
 </div>


### PR DESCRIPTION
TNL-2024
1. Replace `AUTH_ENTRY_DASHBOARD` in `change_enrollment` and `login_analytics()` with `AUTH_ENTRY_ACCOUNT_SETTINGS`.
2. Replace reference to "dashboard" to "account settings" in one UI string.
3. Remove unused helper method in `pipeline.py` tests.
