### PR TITLE
Returning complete URL for Enrollment API user messaging

### DIFF
--- a/common/djangoapps/enrollment/views.py
+++ b/common/djangoapps/enrollment/views.py
@@ -384,7 +384,7 @@ class EnrollmentListView(APIView, ApiKeyPermissionMixIn):
                     "message": (
                         u"Users from this location cannot access the course '{course_id}'."
                     ).format(course_id=course_id),
-                    "user_message_url": redirect_url
+                    "user_message_url": request.build_absolute_uri(redirect_url)
                 }
             )
 


### PR DESCRIPTION
The Enrollment API now returns the complete URL in the user_message_url field. Returning just the path can result in 404s if the consuming code simply redirects to the value of this field without first checking to see if the hostname is included. Using the full URL solves this problem for all clients.

@wedaly @rlucioni
