### PR TITLE
Upgrade Django 1.4 to latest point release

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -34,7 +34,7 @@ django-storages==1.1.5
 django-threaded-multihost==1.4-1
 django-method-override==0.1.0
 djangorestframework==2.3.14
-django==1.4.18
+django==1.4.20
 elasticsearch==0.4.5
 facebook-sdk==0.4.0
 feedparser==5.1.3


### PR DESCRIPTION
The latest Django release is 1.4.20. We should upgrade this to get the newest patches in.

https://docs.djangoproject.com/en/1.4/releases/1.4.20/ : small security fix
https://docs.djangoproject.com/en/1.4/releases/1.4.19/ : fixes a bug that went out in 1.4.18 (our current version)

Code diff: https://github.com/django/django/compare/1.4.18...1.4.20 
