### PR TITLE
Update schoolyourself-xblock to the latest version

### DIFF
--- a/requirements/edx/edx-private.txt
+++ b/requirements/edx/edx-private.txt
@@ -17,4 +17,4 @@
 
 # This repository contains schoolyourself-xblock, which is used in
 # edX's "AlgebraX" and "GeometryX" courses.
--e git+https://github.com/schoolyourself/schoolyourself-xblock.git@64186170d11db477b25e9b811c25b8bcd2afb1b7#egg=schoolyourself-xblock
+-e git+https://github.com/schoolyourself/schoolyourself-xblock.git@3058bf589d44151310089f7f892aa31f7d92c1a8#egg=schoolyourself-xblock


### PR DESCRIPTION
This commit updates the School Yourself XBlocks to the latest version (it was updated today), which consists of three commits (listed below). These commits accomplish two things:
- adds "partner ID" field, settable via the studio interface
- adds a simple unit test

There is only one visible change, which is that the studio interface will have another row at the bottom that lets you type in a partner ID. This is a piece of data that's simply passed along in the URL of the iframe that gets opened, and it indicates to our server that the traffic is coming from edX and it should be treated as such.

The rash of IntegrityErrors in the past week, plus the subsequent attempts to repro this locally, made it clear that it was a little difficult to do end-to-end testing without both parties (SY and edX) working on it at the same time. In particular, there were some issues with edX developers seeing blank pages returned by our server (due to security issues) when trying to test locally. So, by setting the partner_id field, we can send the traffic to the SY server not with an ID of "edx", but as something else, such as "edx_test", which allows us to differentiate the traffic on our end and relax some of the restrictions, while also making sure that your local testing will be better sandboxed. This way, at least edX developers can run this locally and not just see blank screens and unrelated errors all over the place.

With this new setup, you'll be able to use a partner_id of "edx_test" and also a shared_key of "edx_test" to do all of your testing from now on. I also have just noticed the existence of the following page, which I'll update as soon as this PR gets merged: https://openedx.atlassian.net/wiki/display/OPEN/Schoolyourself+XBlock

@nedbat is probably the best person to take a look at this.
(cc @adampalay @cpennington )

This change is not terribly urgent, as we have a workaround to the issues listed above, but it would be nice to get this in maybe for the following release cycle.

The commits:

https://github.com/schoolyourself/schoolyourself-xblock/commit/c967a786462d13e5e5b5196530ff623daaeb3f64

https://github.com/schoolyourself/schoolyourself-xblock/commit/2a58655c92601bd448b4d8471daa64bd84a69e43

https://github.com/schoolyourself/schoolyourself-xblock/commit/0c88d25e4df6a09c67753aa3d4ebce6ad73aff6d
