### PR TITLE
adds link to accessibility policy to LMS and CMS page footers

### DIFF
--- a/cms/templates/widgets/footer.html
+++ b/cms/templates/widgets/footer.html
@@ -9,13 +9,16 @@
         <p>&copy; ${settings.COPYRIGHT_YEAR} <a data-rel="edx.org" href="${marketing_link('ROOT')}" rel="external">${settings.PLATFORM_NAME}</a>.</p>
       </div>
 
-      <nav class="nav-peripheral">
+      <nav class="nav-peripheral" aria-label="${_('Legal')}">
         <ol>
           <li class="nav-item nav-peripheral-tos">
             <a data-rel="edx.org" href="${marketing_link('TOS')}">${_("Terms of Service")}</a>
           </li>
           <li class="nav-item nav-peripheral-pp">
             <a data-rel="edx.org" href="${marketing_link('PRIVACY')}">${_("Privacy Policy")}</a>
+          </li>
+          <li class="nav-item nav-peripheral-pp">
+            <a data-rel="edx.org" href="${marketing_link('A11Y')}">${_("Website Accessibility Policy")}</a>
           </li>
           % if settings.TENDER_DOMAIN and user.is_authenticated():
           <li class="nav-item nav-peripheral-feedback">

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1717,6 +1717,7 @@ CSRF_COOKIE_AGE = 60 * 60 * 24 * 7 * 52
 EDXMKTG_COOKIE_NAME = 'edxloggedin'
 MKTG_URLS = {}
 MKTG_URL_LINK_MAP = {
+    'A11Y': 'accessibility',
     'ABOUT': 'about',
     'CONTACT': 'contact',
     'FAQ': 'help',

--- a/lms/static/sass/shared/_footer.scss
+++ b/lms/static/sass/shared/_footer.scss
@@ -124,7 +124,7 @@
 
       }
 
-      .nav-legal-02 a {
+      .nav-legal-02 a, .nav-legal-03 a {
 
         &:before {
           margin-right: ($baseline/4);

--- a/lms/templates/footer-edx-new.html
+++ b/lms/templates/footer-edx-new.html
@@ -59,6 +59,7 @@
 	      date=_("10/22/2014")
 	    )}
 	</span></a>
+        <a href="${marketing_link('A11Y')}"><span class="copy">${_("Website Accessibility Policy")}</span></a>
       </div>
     </div>
 

--- a/lms/templates/footer.html
+++ b/lms/templates/footer.html
@@ -86,6 +86,9 @@
           <li class="nav-legal-02">
             <a href="${marketing_link('PRIVACY')}">${_("Privacy Policy")}</a>
           </li>
+          <li class="nav-legal-03">
+            <a href="${marketing_link('A11Y')}">${_("Website Accessibility Policy")}</a>
+          </li>
         </ul>
       </nav>
     </div>


### PR DESCRIPTION
edX has published a Web Accessibility Policy to the public website (http://www.edx.org/accessibility).  Each page contains a link to this policy in the footer.  This PR adds a similar link to the page footers of both the LMS and CMS for edx.org domains as well as Open edX.  The link to a policy for Open edX instances is configurable along with the other marketing urls.

@cpennington can you review this PR?  It has to do with a very old part of the codebase that does not appear to work as I would have expected it to (MKTG_URL_LINK_MAP).  I expected the url link mapping when referenced like this: ${marketing_link('KEY')} to return a URL constructed from a root/base URL plus the VALUE from that map, but it doesn't seem to do that.  @singingwolfboy debugged this extensively with me and we could not figure it out.

@clrux can you take a look at the CSS?  I stuck with the convention (unique class name for each link in the footer) but now that there are 3  links (not 2) it seems like the convention does not scale very well, and may be unnecessary.

@feanil, can you tell me how marketing URLs get configured for the edX.org domain?  Again, I was not getting expected results (`href="http://www.edx.org/accessibility"`) in the footer of LMS/CMS with ENABLE_MKTG_SITE and IS_EDX_DOMAIN set to True in common.py.
