### PR TITLE
Add possibility to play video from localhost.

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -158,7 +158,7 @@ FEATURES = {
     },
 
     # Play video from locally hosted server, for example, value can be "http://192.168.xxx.xxx/static/edx-videos"
-    'PLAY_VIDEO_LOCAL' : "http://localhost:8080/static/edx-videos"
+    'PLAY_VIDEO_LOCAL' : False
 }
 
 ENABLE_JASMINE = False

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -155,7 +155,10 @@ FEATURES = {
     'DASHBOARD_SHARE_SETTINGS': {
         # Note: Ensure 'CUSTOM_COURSE_URLS' has a matching value in lms/envs/common.py
         'CUSTOM_COURSE_URLS': False
-    }
+    },
+
+    # Play video from locally hosted server, for example, value can be "http://192.168.xxx.xxx/static/edx-videos"
+    'PLAY_VIDEO_LOCAL' : "http://localhost:8080/static/edx-videos"
 }
 
 ENABLE_JASMINE = False

--- a/common/lib/xmodule/xmodule/tests/test_video.py
+++ b/common/lib/xmodule/xmodule/tests/test_video.py
@@ -720,6 +720,17 @@ class VideoCdnTest(unittest.TestCase):
         fake_cdn_url = 'http://fake_cdn.com/'
         self.assertIsNone(get_video_from_cdn(fake_cdn_url, original_video_url))
 
+    def test_video_play_local(self):
+        """
+        Test video url substitution for local video playback.
+        """
+        original_video_url = "http://www.original_video.com/folder1/folder2/original_video.mp4"
+        play_video_local = "http://local_server:3000/static/edx-videos"
+        self.assertEqual(
+            get_video_from_cdn(None, original_video_url, play_video_local=play_video_local),
+            "http://local_server:3000/static/edx-videos/folder1/folder2/original_video.mp4"
+        )
+
 
 class VideoDescriptorIndexingTestCase(unittest.TestCase):
     """

--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -218,8 +218,13 @@ class VideoModule(VideoFields, VideoTranscriptsMixin, VideoStudentViewHandlers, 
         if getattr(self, 'video_speed_optimizations', True) and cdn_url:
             branding_info = BrandingInfoConfig.get_config().get(self.system.user_location)
 
+        play_video_local = settings.FEATURES.get('PLAY_VIDEO_LOCAL', False)
+        if getattr(self, 'video_speed_optimizations', True) and cdn_url or play_video_local:
             for index, source_url in enumerate(sources):
-                new_url = get_video_from_cdn(cdn_url, source_url)
+                new_url = get_video_from_cdn(
+                    cdn_url,
+                    source_url,
+                    play_video_local=play_video_local)
                 if new_url:
                     sources[index] = new_url
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -377,6 +377,9 @@ FEATURES = {
         'TWITTER_SHARING': False,
         'TWITTER_SHARING_TEXT': None
     },
+
+    # Play video from locally hosted server, for example, 'PLAY_VIDEO_LOCAL': "http://192.168.xxx.xxx/static/edx-videos".
+    'PLAY_VIDEO_LOCAL' : "http://localhost:8080/static/edx-videos"
 }
 
 # Ignore static asset files on import which match this pattern

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -379,7 +379,7 @@ FEATURES = {
     },
 
     # Play video from locally hosted server, for example, 'PLAY_VIDEO_LOCAL': "http://192.168.xxx.xxx/static/edx-videos".
-    'PLAY_VIDEO_LOCAL' : "http://localhost:8080/static/edx-videos"
+    'PLAY_VIDEO_LOCAL' : False
 }
 
 # Ignore static asset files on import which match this pattern


### PR DESCRIPTION
This PR allows to host video for Open edX courses on local hard drive.
This is finalisation of work started in https://github.com/edx/edx-platform/pull/6684.
Comments from original PR:

@pmitros:
[Done] It'd be good if we could do things like "PLAY_VIDEO_LOCAL": "http://localhost:8080/static/edx-videos"
[Done]  The documentation right now is in the PR, but not in the code. It's important that the code clearly explain what it does, and how to use it.
[Done] A test case would be helpful.

@ormsbee:
 [Done]  @auraz: If there's going to be a new feature flag, please add it to common.py with it's default value and a comment explaining what it does.
@e0d: Will your proposed CDN changes make VIDEO_CDN_URL work more like PLAY_VIDEO_LOCAL is in this PR?
@nasthagiri: Heads up in case it has implications for mobile video delivery (it's hidden behind a non-default feature flag, so I don't think it'll be an issue, but just in case...)

@pmitros @ormsbee please continue review
