### PR TITLE
Added Payment Cancellation Page

### DIFF
--- a/lms/djangoapps/commerce/urls.py
+++ b/lms/djangoapps/commerce/urls.py
@@ -4,9 +4,10 @@ Defines the URL routes for this app.
 
 from django.conf.urls import patterns, url
 
-from .views import OrdersView
+from .views import OrdersView, checkout_cancel
 
 urlpatterns = patterns(
     '',
     url(r'^orders/$', OrdersView.as_view(), name="orders"),
+    url(r'^checkout/cancel/$', checkout_cancel, name="checkout_cancel"),
 )

--- a/lms/templates/commerce/checkout_cancel.html
+++ b/lms/templates/commerce/checkout_cancel.html
@@ -1,0 +1,12 @@
+<%! from django.utils.translation import ugettext as _ %>
+
+<%inherit file="../main.html" />
+
+<%block name="pagetitle">${_("Checkout Cancelled")}</%block>
+
+
+<section class="container">
+    <h1>${_("Checkout Cancelled")}</h1>
+    ${ _(u"Your transaction has been cancelled. If you feel an error has occurred, contact {email}.").format(
+    email="<a href=\"mailto:{email}\">{email}</a>".format(email=payment_support_email)) }
+</section>


### PR DESCRIPTION
This commit creates a new page intended only for use when the user cancels payment. The previous implementation relied on the CyberSource callback page, which is not useful for orders placed with the E-Commerce Service.

@jimabramson @rlucioni @wedaly 
