### PR TITLE
RTL-ifying the due icon

### DIFF
--- a/lms/static/sass/course/courseware/_sidebar.scss
+++ b/lms/static/sass/course/courseware/_sidebar.scss
@@ -126,7 +126,7 @@
           background: transparent;
           border-radius: 4px;
           display: block;
-          padding: ($baseline/4) 36px ($baseline/4) ($baseline/2);
+          @include padding( ($baseline/4), ($baseline*1.5), ($baseline/4), ($baseline/2));
           position: relative;
           text-decoration: none;
 
@@ -206,11 +206,11 @@
         &.graded {
          > a {
            > img {
-             margin: auto;
              position: absolute;
              top: 0;
              bottom: 0;
-             right: 7px;
+             @include right(7px);
+             margin: auto;
            }
           }
 


### PR DESCRIPTION
This work relates to [UX-1632](https://openedx.atlassian.net/browse/UX-1632) and corrects the icon display for RTL oriented views.

@frrrances Mind reviewing the FED for this?
