### PR TITLE
Don't event first_name and last_name.

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -374,7 +374,7 @@ def user_post_save_callback(sender, **kwargs):
         user,
         user,
         sender._meta.db_table,
-        excluded_fields=['last_login'],
+        excluded_fields=['last_login', 'first_name', 'last_name'],
         hidden_fields=['password']
     )
 

--- a/common/djangoapps/student/tests/test_events.py
+++ b/common/djangoapps/student/tests/test_events.py
@@ -146,3 +146,12 @@ class TestUserEvents(UserSettingsEventTestMixin, TestCase):
         with self.assertRaises(IntegrityError):
             self.user.save()
         self.assert_no_events_were_emitted()
+
+    def test_no_first_and_last_name_events(self):
+        """
+        Verify that first_name and last_name events are not emitted.
+        """
+        self.user.first_name = "Donald"
+        self.user.last_name = "Duck"
+        self.user.save()
+        self.assert_no_events_were_emitted()


### PR DESCRIPTION
TNL-2044

@dan-f please review

I don't plan to put this in the RC due to the extremely low incidence of it (since it is tied to third party auth). Lou was OK with it not being in the release.
