### PR TITLE
WIP: MIT CCX student dashboard display

### DIFF
--- a/lms/djangoapps/ccx/models.py
+++ b/lms/djangoapps/ccx/models.py
@@ -32,6 +32,7 @@ class CustomCourseForEdX(models.Model):
 
     @property
     def course(self):
+        """Return the CourseDescriptor of the course related to this CCX"""
         if self._course is None:
             store = modulestore()
             with store.bulk_operations(self.course_id):
@@ -47,6 +48,8 @@ class CustomCourseForEdX(models.Model):
 
     @property
     def start(self):
+        """Get the value of the override of the 'start' datetime for this CCX
+        """
         if self._start is None:
             # avoid circular import problems
             from .overrides import get_override_for_ccx
@@ -56,6 +59,8 @@ class CustomCourseForEdX(models.Model):
 
     @property
     def due(self):
+        """Get the value of the override of the 'due' datetime for this CCX
+        """
         if self._due is _MARKER:
             # avoid circular import problems
             from .overrides import get_override_for_ccx
@@ -64,15 +69,21 @@ class CustomCourseForEdX(models.Model):
         return self._due
 
     def has_started(self):
+        """Return True if the CCX start date is in the past"""
         return datetime.now(UTC()) > self.start
 
     def has_ended(self):
+        """Return True if the CCX due date is set and is in the past"""
         if self.due is None:
             return False
 
         return datetime.now(UTC()) > self.due
 
     def start_datetime_text(self, format_string="SHORT_DATE"):
+        """Returns the desired text representation of the CCX start datetime
+
+        The returned value is always expressed in UTC
+        """
         i18n = self.course.runtime.service(self.course, "i18n")
         strftime = i18n.strftime
         value = strftime(self.start, format_string)
@@ -81,6 +92,13 @@ class CustomCourseForEdX(models.Model):
         return value
 
     def end_datetime_text(self, format_string="SHORT_DATE"):
+        """Returns the desired text representation of the CCX due datetime
+
+        If the due date for the CCX is not set, the value returned is the empty
+        string.
+
+        The returned value is always expressed in UTC
+        """
         if self.due is None:
             return ''
 

--- a/lms/djangoapps/ccx/tests/test_models.py
+++ b/lms/djangoapps/ccx/tests/test_models.py
@@ -147,6 +147,7 @@ class TestCCX(ModuleStoreTestCase):
         self.ccx = CcxFactory(course_id=course.id, coach=coach)
 
     def set_ccx_override(self, field, value):
+        """Create a field override for the test CCX on <field> with <value>"""
         override_field_for_ccx(self.ccx, self.course, field, value)
 
     def test_ccx_course_is_correct_course(self):
@@ -158,9 +159,12 @@ class TestCCX(ModuleStoreTestCase):
     def test_ccx_course_caching(self):
         """verify that caching the propery works to limit queries"""
         with check_mongo_calls(1):
-            self.ccx.course
+            # these statements are used entirely to demonstrate the
+            # instance-level caching of these values on CCX objects. The
+            # check_mongo_calls context is the point here.
+            self.ccx.course  # pylint: disable=pointless-statement
         with check_mongo_calls(0):
-            self.ccx.course
+            self.ccx.course  # pylint: disable=pointless-statement
 
     def test_ccx_start_is_correct(self):
         """verify that the start datetime for a ccx is correctly retrieved
@@ -172,7 +176,7 @@ class TestCCX(ModuleStoreTestCase):
         """
         expected = datetime.now(UTC())
         self.set_ccx_override('start', expected)
-        actual = self.ccx.start
+        actual = self.ccx.start  # pylint: disable=no-member
         diff = expected - actual
         self.assertEqual(diff.seconds, 0)
 
@@ -181,21 +185,24 @@ class TestCCX(ModuleStoreTestCase):
         now = datetime.now(UTC())
         self.set_ccx_override('start', now)
         with check_mongo_calls(1):
-            self.ccx.start
+            # these statements are used entirely to demonstrate the
+            # instance-level caching of these values on CCX objects. The
+            # check_mongo_calls context is the point here.
+            self.ccx.start  # pylint: disable=pointless-statement, no-member
         with check_mongo_calls(0):
-            self.ccx.start
+            self.ccx.start  # pylint: disable=pointless-statement, no-member
 
     def test_ccx_due_without_override(self):
         """verify that due returns None when the field has not been set"""
         expected = None
-        actual = self.ccx.due
+        actual = self.ccx.due  # pylint: disable=no-member
         self.assertTrue(expected is actual)
 
     def test_ccx_due_is_correct(self):
         """verify that the due datetime for a ccx is correctly retrieved"""
         expected = datetime.now(UTC())
         self.set_ccx_override('due', expected)
-        actual = self.ccx.due
+        actual = self.ccx.due  # pylint: disable=no-member
         diff = expected - actual
         self.assertEqual(diff.seconds, 0)
 
@@ -204,9 +211,12 @@ class TestCCX(ModuleStoreTestCase):
         expected = datetime.now(UTC())
         self.set_ccx_override('due', expected)
         with check_mongo_calls(1):
-            self.ccx.due
+            # these statements are used entirely to demonstrate the
+            # instance-level caching of these values on CCX objects. The
+            # check_mongo_calls context is the point here.
+            self.ccx.due  # pylint: disable=pointless-statement, no-member
         with check_mongo_calls(0):
-            self.ccx.due
+            self.ccx.due  # pylint: disable=pointless-statement, no-member
 
     def test_ccx_has_started(self):
         """verify that a ccx marked as starting yesterday has started"""
@@ -214,7 +224,7 @@ class TestCCX(ModuleStoreTestCase):
         delta = timedelta(1)
         then = now - delta
         self.set_ccx_override('start', then)
-        self.assertTrue(self.ccx.has_started())
+        self.assertTrue(self.ccx.has_started())  # pylint: disable=no-member
 
     def test_ccx_has_not_started(self):
         """verify that a ccx marked as starting tomorrow has not started"""
@@ -222,7 +232,7 @@ class TestCCX(ModuleStoreTestCase):
         delta = timedelta(1)
         then = now + delta
         self.set_ccx_override('start', then)
-        self.assertFalse(self.ccx.has_started())
+        self.assertFalse(self.ccx.has_started())  # pylint: disable=no-member
 
     def test_ccx_has_ended(self):
         """verify that a ccx that has a due date in the past has ended"""
@@ -230,7 +240,7 @@ class TestCCX(ModuleStoreTestCase):
         delta = timedelta(1)
         then = now - delta
         self.set_ccx_override('due', then)
-        self.assertTrue(self.ccx.has_ended())
+        self.assertTrue(self.ccx.has_ended())  # pylint: disable=no-member
 
     def test_ccx_has_not_ended(self):
         """verify that a ccx that has a due date in the future has not eneded
@@ -239,11 +249,11 @@ class TestCCX(ModuleStoreTestCase):
         delta = timedelta(1)
         then = now + delta
         self.set_ccx_override('due', then)
-        self.assertFalse(self.ccx.has_ended())
+        self.assertFalse(self.ccx.has_ended())  # pylint: disable=no-member
 
     def test_ccx_without_due_date_has_not_ended(self):
         """verify that a ccx without a due date has not ended"""
-        self.assertFalse(self.ccx.has_ended())
+        self.assertFalse(self.ccx.has_ended())  # pylint: disable=no-member
 
     def test_start_datetime_short_date(self):
         """verify that the start date for a ccx formats properly by default"""
@@ -251,7 +261,7 @@ class TestCCX(ModuleStoreTestCase):
         # This relies on SHORT_DATE remaining the same, is there a better way?
         expected = "Jan 01, 2015"
         self.set_ccx_override('start', start)
-        actual = self.ccx.start_datetime_text()
+        actual = self.ccx.start_datetime_text()  # pylint: disable=no-member
         self.assertEqual(expected, actual)
 
     def test_start_datetime_date_time_format(self):
@@ -260,7 +270,7 @@ class TestCCX(ModuleStoreTestCase):
         # This relies on SHORT_DATE remaining the same, is there a better way?
         expected = "Jan 01, 2015 at 12:00 UTC"
         self.set_ccx_override('start', start)
-        actual = self.ccx.start_datetime_text('DATE_TIME')
+        actual = self.ccx.start_datetime_text('DATE_TIME')  # pylint: disable=no-member
         self.assertEqual(expected, actual)
 
     def test_end_datetime_short_date(self):
@@ -269,7 +279,7 @@ class TestCCX(ModuleStoreTestCase):
         # This relies on SHORT_DATE remaining the same, is there a better way?
         expected = "Jan 01, 2015"
         self.set_ccx_override('due', end)
-        actual = self.ccx.end_datetime_text()
+        actual = self.ccx.end_datetime_text()  # pylint: disable=no-member
         self.assertEqual(expected, actual)
 
     def test_end_datetime_date_time_format(self):
@@ -278,13 +288,13 @@ class TestCCX(ModuleStoreTestCase):
         # This relies on SHORT_DATE remaining the same, is there a better way?
         expected = "Jan 01, 2015 at 12:00 UTC"
         self.set_ccx_override('due', end)
-        actual = self.ccx.end_datetime_text('DATE_TIME')
+        actual = self.ccx.end_datetime_text('DATE_TIME')  # pylint: disable=no-member
         self.assertEqual(expected, actual)
 
     def test_end_datetime_no_due_date(self):
         """verify that without a due date, the end date is an empty string"""
         expected = ''
-        actual = self.ccx.end_datetime_text()
+        actual = self.ccx.end_datetime_text()  # pylint: disable=no-member
         self.assertEqual(expected, actual)
-        actual = self.ccx.end_datetime_text('DATE_TIME')
+        actual = self.ccx.end_datetime_text('DATE_TIME')  # pylint: disable=no-member
         self.assertEqual(expected, actual)

--- a/lms/djangoapps/ccx/tests/test_models.py
+++ b/lms/djangoapps/ccx/tests/test_models.py
@@ -1,6 +1,8 @@
 """
 tests for the models
 """
+from datetime import datetime, timedelta
+from django.utils.timezone import UTC
 from student.models import CourseEnrollment  # pylint: disable=import-error
 from student.roles import CourseCcxCoachRole  # pylint: disable=import-error
 from student.tests.factories import (  # pylint: disable=import-error
@@ -9,7 +11,10 @@ from student.tests.factories import (  # pylint: disable=import-error
     UserFactory,
 )
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory
+from xmodule.modulestore.tests.factories import (
+    CourseFactory,
+    check_mongo_calls
+)
 
 from .factories import (
     CcxFactory,
@@ -19,6 +24,7 @@ from ..models import (
     CcxMembership,
     CcxFutureMembership,
 )
+from ..overrides import override_field_for_ccx
 
 
 class TestCcxMembership(ModuleStoreTestCase):
@@ -125,3 +131,160 @@ class TestCcxMembership(ModuleStoreTestCase):
         self.assertFalse(self.has_course_enrollment(user))
         self.assertFalse(self.has_ccx_membership(user))
         self.assertTrue(self.has_ccx_future_membership(user))
+
+
+class TestCCX(ModuleStoreTestCase):
+    """Unit tests for the CustomCourseForEdX model
+    """
+
+    def setUp(self):
+        """common setup for all tests"""
+        super(TestCCX, self).setUp()
+        self.course = course = CourseFactory.create()
+        coach = AdminFactory.create()
+        role = CourseCcxCoachRole(course.id)
+        role.add_users(coach)
+        self.ccx = CcxFactory(course_id=course.id, coach=coach)
+
+    def set_ccx_override(self, field, value):
+        override_field_for_ccx(self.ccx, self.course, field, value)
+
+    def test_ccx_course_is_correct_course(self):
+        """verify that the course property of a ccx returns the right course"""
+        expected = self.course
+        actual = self.ccx.course
+        self.assertEqual(expected, actual)
+
+    def test_ccx_course_caching(self):
+        """verify that caching the propery works to limit queries"""
+        with check_mongo_calls(1):
+            self.ccx.course
+        with check_mongo_calls(0):
+            self.ccx.course
+
+    def test_ccx_start_is_correct(self):
+        """verify that the start datetime for a ccx is correctly retrieved
+
+        Note that after setting the start field override microseconds are
+        truncated, so we can't do a direct comparison between before and after.
+        For this reason we test the difference between and make sure it is less
+        than one second.
+        """
+        expected = datetime.now(UTC())
+        self.set_ccx_override('start', expected)
+        actual = self.ccx.start
+        diff = expected - actual
+        self.assertEqual(diff.seconds, 0)
+
+    def test_ccx_start_caching(self):
+        """verify that caching the start property works to limit queries"""
+        now = datetime.now(UTC())
+        self.set_ccx_override('start', now)
+        with check_mongo_calls(1):
+            self.ccx.start
+        with check_mongo_calls(0):
+            self.ccx.start
+
+    def test_ccx_due_without_override(self):
+        """verify that due returns None when the field has not been set"""
+        expected = None
+        actual = self.ccx.due
+        self.assertTrue(expected is actual)
+
+    def test_ccx_due_is_correct(self):
+        """verify that the due datetime for a ccx is correctly retrieved"""
+        expected = datetime.now(UTC())
+        self.set_ccx_override('due', expected)
+        actual = self.ccx.due
+        diff = expected - actual
+        self.assertEqual(diff.seconds, 0)
+
+    def test_ccx_due_caching(self):
+        """verify that caching the due property works to limit queries"""
+        expected = datetime.now(UTC())
+        self.set_ccx_override('due', expected)
+        with check_mongo_calls(1):
+            self.ccx.due
+        with check_mongo_calls(0):
+            self.ccx.due
+
+    def test_ccx_has_started(self):
+        """verify that a ccx marked as starting yesterday has started"""
+        now = datetime.now(UTC())
+        delta = timedelta(1)
+        then = now - delta
+        self.set_ccx_override('start', then)
+        self.assertTrue(self.ccx.has_started())
+
+    def test_ccx_has_not_started(self):
+        """verify that a ccx marked as starting tomorrow has not started"""
+        now = datetime.now(UTC())
+        delta = timedelta(1)
+        then = now + delta
+        self.set_ccx_override('start', then)
+        self.assertFalse(self.ccx.has_started())
+
+    def test_ccx_has_ended(self):
+        """verify that a ccx that has a due date in the past has ended"""
+        now = datetime.now(UTC())
+        delta = timedelta(1)
+        then = now - delta
+        self.set_ccx_override('due', then)
+        self.assertTrue(self.ccx.has_ended())
+
+    def test_ccx_has_not_ended(self):
+        """verify that a ccx that has a due date in the future has not eneded
+        """
+        now = datetime.now(UTC())
+        delta = timedelta(1)
+        then = now + delta
+        self.set_ccx_override('due', then)
+        self.assertFalse(self.ccx.has_ended())
+
+    def test_ccx_without_due_date_has_not_ended(self):
+        """verify that a ccx without a due date has not ended"""
+        self.assertFalse(self.ccx.has_ended())
+
+    def test_start_datetime_short_date(self):
+        """verify that the start date for a ccx formats properly by default"""
+        start = datetime(2015, 1, 1, 12, 0, 0, tzinfo=UTC())
+        # This relies on SHORT_DATE remaining the same, is there a better way?
+        expected = "Jan 01, 2015"
+        self.set_ccx_override('start', start)
+        actual = self.ccx.start_datetime_text()
+        self.assertEqual(expected, actual)
+
+    def test_start_datetime_date_time_format(self):
+        """verify that the DATE_TIME format also works as expected"""
+        start = datetime(2015, 1, 1, 12, 0, 0, tzinfo=UTC())
+        # This relies on SHORT_DATE remaining the same, is there a better way?
+        expected = "Jan 01, 2015 at 12:00 UTC"
+        self.set_ccx_override('start', start)
+        actual = self.ccx.start_datetime_text('DATE_TIME')
+        self.assertEqual(expected, actual)
+
+    def test_end_datetime_short_date(self):
+        """verify that the end date for a ccx formats properly by default"""
+        end = datetime(2015, 1, 1, 12, 0, 0, tzinfo=UTC())
+        # This relies on SHORT_DATE remaining the same, is there a better way?
+        expected = "Jan 01, 2015"
+        self.set_ccx_override('due', end)
+        actual = self.ccx.end_datetime_text()
+        self.assertEqual(expected, actual)
+
+    def test_end_datetime_date_time_format(self):
+        """verify that the DATE_TIME format also works as expected"""
+        end = datetime(2015, 1, 1, 12, 0, 0, tzinfo=UTC())
+        # This relies on SHORT_DATE remaining the same, is there a better way?
+        expected = "Jan 01, 2015 at 12:00 UTC"
+        self.set_ccx_override('due', end)
+        actual = self.ccx.end_datetime_text('DATE_TIME')
+        self.assertEqual(expected, actual)
+
+    def test_end_datetime_no_due_date(self):
+        """verify that without a due date, the end date is an empty string"""
+        expected = ''
+        actual = self.ccx.end_datetime_text()
+        self.assertEqual(expected, actual)
+        actual = self.ccx.end_datetime_text('DATE_TIME')
+        self.assertEqual(expected, actual)

--- a/lms/templates/ccx/_dashboard_ccx_listing.html
+++ b/lms/templates/ccx/_dashboard_ccx_listing.html
@@ -1,4 +1,4 @@
-<%page args="ccx, membership, course" />
+<%page args="ccx, membership, course, show_courseware_link, is_course_blocked" />
 
 <%! from django.utils.translation import ugettext as _ %>
 <%!
@@ -10,20 +10,70 @@
 %>
 <li class="course-item">
   <article class="course">
-    <a href="${ccx_switch_target}" class="cover">
-      <img src="${course_image_url(course)}" alt="${_('{course_number} {ccx_name} Cover Image').format(course_number=course.number, ccx_name=ccx.display_name) |h}" />
-    </a>
-    <section class="info">
-      <hgroup>
-        <p class="date-block">
-        Custom Course
-        </p>
-        <h2 class="university">${get_course_about_section(course, 'university')}</h2>
-        <h3>
-          <a href="${ccx_switch_target}">${course.display_number_with_default | h} ${ccx.display_name}</a>
+    <section class="details">
+      <div class="wrapper-course-image" aria-hidden="true">
+        % if show_courseware_link:
+          % if not is_course_blocked:
+              <a href="${ccx_switch_target}" class="cover">
+                <img src="${course_image_url(course)}" class="course-image" alt="${_('{course_number} {ccx_name} Cover Image').format(course_number=course.number, ccx_name=ccx.display_name) |h}" />
+              </a>
+          % else:
+              <a class="fade-cover">
+                <img src="${course_image_url(course)}" class="course-image" alt="${_('{course_number} {ccx_name} Cover Image').format(course_number=course.number, ccx_name=ccx.display_name) |h}" />
+              </a>
+          % endif
+        % else:
+          <a class="cover">
+            <img src="${course_image_url(course)}" class="course-image" alt="${_('{course_number} {ccx_name} Cover Image').format(course_number=course.number, ccx_name=ccx.display_name) |h}" />
+          </a>
+        % endif
+      </div>
+      <div class="wrapper-course-details">
+        <h3 class="course-title">
+          % if show_courseware_link:
+            % if not is_course_blocked:
+              <a href="${ccx_switch_target}">${ccx.display_name}</a>
+            % else:
+              <a class="disable-look">${ccx.display_name}</a>
+            % endif
+          % else:
+            <span>${ccx.display_name}</span>
+          % endif
         </h3>
-      </hgroup>
-      <a href="${ccx_switch_target}" class="enter-course">${_('View Course')}</a>
+        <div class="course-info">
+          <span class="info-university">${get_course_about_section(course, 'university')} - </span>
+          <span class="info-course-id">${course.display_number_with_default | h}</span>
+          <span class="info-date-block" data-tooltip="Hi">
+          % if ccx.has_ended():
+            ${_("Ended - {end_date}").format(end_date=ccx.end_datetime_text("SHORT_DATE"))}
+          % elif ccx.has_started():
+            ${_("Started - {start_date}").format(start_date=ccx.start_datetime_text("SHORT_DATE"))}
+          % else:   # hasn't started yet
+            ${_("Starts - {start_date}").format(start_date=ccx.start_datetime_text("SHORT_DATE"))}
+          % endif
+          </span>
+        </div>
+        % if show_courseware_link:
+          <div class="wrapper-course-actions">
+            <div class="course-actions">
+              % if ccx.has_ended():
+                % if not is_course_blocked:
+                  <a href="${ccx_switch_target}" class="enter-course archived">${_('View Archived Custom Course')}<span class="sr">&nbsp;${ccx.display_name}</span></a>
+                % else:
+                  <a class="enter-course-blocked archived">${_('View Archived Custom Course')}<span class="sr">&nbsp;${ccx.display_name}</span></a>
+                % endif
+              % else:
+                % if not is_course_blocked:
+                  <a href="${ccx_switch_target}" class="enter-course">${_('View Custom Course')}<span class="sr">&nbsp;${ccx.display_name}</span></a>
+                % else:
+                  <a class="enter-course-blocked">${_('View Custom Course')}<span class="sr">&nbsp;${ccx.display_name}</span></a>
+                % endif
+              % endif
+
+            </div>
+          </div>
+        % endif
+      </div>
     </section>
   </article>
 </li>

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -89,7 +89,9 @@
 
       % if settings.FEATURES.get('CUSTOM_COURSES_EDX', False):
         % for ccx, membership, course in ccx_membership_triplets:
-            <%include file='ccx/_dashboard_ccx_listing.html' args="ccx=ccx, membership=membership, course=course" />
+          <% show_courseware_link = ccx.has_started() %>
+          <% is_course_blocked = False %>
+          <%include file='ccx/_dashboard_ccx_listing.html' args="ccx=ccx, membership=membership, course=course, show_courseware_link=show_courseware_link, is_course_blocked=is_course_blocked" />
         % endfor
       % endif
 


### PR DESCRIPTION
This pull request addresses display issues identified after the merging of the MIT CCX extension work in https://github.com/edx/edx-platform/pull/6636 and reported in [this JIRA ticket](https://openedx.atlassian.net/browse/TNL-2007) (and reported also as jazkarta/edx-platform#74).  At the same time, it also addresses an issue identified by the MIT team and reported as jazkarta/edx-platform#75.  

The PR updates the display of CCX courses to which a student has been granted membership to match the display of "normal" EdX courses.  It ensures that the start and end dates displayed for the CCX are in fact those of the CCX itself, and not those of the course from which it was created.  It also ensures that if the start date of a CCX has not yet arrived the student will not be able to click on the CCX and view it.

A CCX which has not yet started:
![not_yet_started](https://cloud.githubusercontent.com/assets/417109/7264287/ff095d5a-e83e-11e4-812b-017c3df7e562.png)

A CCX which has started:
![already_started](https://cloud.githubusercontent.com/assets/417109/7264294/081cd6a6-e83f-11e4-8606-d91cb5ae35b4.png)

The code updated for this pull request resides in the `lms/djangoapps/ccx` app as well as in the template for the shared dashboard.

This pull request is a Work In Progress, we seek advice on the approach taken to solving the problem of display of CCX instances on the shared dashboard as well as pointers to any opportunities to better use internal code to accomplish our goals. In particular, we are curious as to the advisability of replicating API provided by a Course Descriptor as part of the CCX model.  Is there a better way of accomplishing the goal of treating a CCX more similarly to a standard course?

For context on ongoing work to make CCXs work more like regular courses it may be valuable to look over the discussion on jazkarta/edx-platform#43 and the related tickets in that tracker which have been opened.  It may be that work yet to be done for that issue may help to resolve some of the questions asked here.

Please note that as this is a WIP PR, tests have yet to be written to cover the work done herein. They will be added once the direction is clear.
