### PR TITLE
Adding master directory structure to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ autodeploy.properties
 .vagrant/
 logs
 .testids/
+
+cms/
+lms/
+common/


### PR DESCRIPTION
This work resolves the issue @catong was running into where our `cms/`, `common/`, and `lms/` directories became local, untracked changes when switching from the `master` branch of the repo to the `gh-pages` branch.
