### PR TITLE
Updated Checkout Cancel Page SCSS

### DIFF
--- a/lms/static/sass/_developer.scss
+++ b/lms/static/sass/_developer.scss
@@ -1,6 +1,6 @@
 // edX LMS - developer
 // ====================
-// NOTE: use this area for any developer-needed or created styling that needs to be refactored into patterns or visually polished. Please list any template/view that your styles reference when definining them (example below):
+// NOTE: use this area for any developer-needed or created styling that needs to be refactored into patterns or visually polished. Please list any template/view that your styles reference when defining them (example below):
 
 // Views: Login, Sign Up
 // .crazy-new-feature {
@@ -49,4 +49,16 @@
   background-color: $white;
   padding: ($baseline*1.5) $baseline;
   text-align: center;
+}
+
+
+// Views: Checkout Cancel Page
+.checkout-error {
+  .heading {
+    @extend h1;
+  }
+
+  .body {
+    @extend .text-center;
+  }
 }

--- a/lms/templates/commerce/checkout_cancel.html
+++ b/lms/templates/commerce/checkout_cancel.html
@@ -5,8 +5,10 @@
 <%block name="pagetitle">${_("Checkout Cancelled")}</%block>
 
 
-<section class="container">
-    <h1>${_("Checkout Cancelled")}</h1>
-    ${ _(u"Your transaction has been cancelled. If you feel an error has occurred, contact {email}.").format(
-    email="<a href=\"mailto:{email}\">{email}</a>".format(email=payment_support_email)) }
+<section class="container checkout-error">
+    <div class="heading">${_("Checkout Cancelled")}</div>
+    <div class="body">
+        ${ _(u"Your transaction has been cancelled. If you feel an error has occurred, contact {email}.").format(
+        email="<a href=\"mailto:{email}\">{email}</a>".format(email=payment_support_email)) }
+    </div>
 </section>


### PR DESCRIPTION
- Using CSS styling, instead of h1 tag, for page header (for accessibility purposes).
- Centering body text (for aesthetic purposes).

@rlucioni @wedaly @jimabramson @cptvitamin 

![cancel-new](https://cloud.githubusercontent.com/assets/910510/7279891/33fe6218-e8ed-11e4-85ff-eed3a81d849c.png)
