### PR TITLE
Wrap access to CSM (inside FieldDataCache) to use the new interface

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_assets.py
+++ b/cms/djangoapps/contentstore/views/tests/test_assets.py
@@ -309,13 +309,14 @@ class DownloadTestCase(AssetsTestCase):
     def test_metadata_found_in_modulestore(self):
         # Insert asset metadata into the modulestore (with no accompanying asset).
         asset_key = self.course.id.make_asset_key(AssetMetadata.GENERAL_ASSET_TYPE, 'pic1.jpg')
-        asset_md = AssetMetadata(asset_key, {
-            'internal_name': 'EKMND332DDBK',
-            'basename': 'pix/archive',
-            'locked': False,
-            'curr_version': '14',
-            'prev_version': '13'
-        })
+        asset_md = AssetMetadata(
+            asset_key,
+            internal_name='EKMND332DDBK',
+            pathname='pix/archive',
+            locked=False,
+            curr_version='14',
+            prev_version='13',
+        )
         modulestore().save_asset_metadata(asset_md, 15)
         # Get the asset metadata and have it be found in the modulestore.
         # Currently, no asset metadata should be found in the modulestore. The code is not yet storing it there.

--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -119,7 +119,10 @@ class MongoKeyValueStore(InheritanceKeyValueStore):
         elif key.scope == Scope.content:
             return self._data[key.field_name]
         else:
-            raise InvalidScopeError(key)
+            raise InvalidScopeError(
+                key,
+                (Scope.children, Scope.parent, Scope.settings, Scope.content),
+            )
 
     def set(self, key, value):
         if key.scope == Scope.children:
@@ -129,7 +132,10 @@ class MongoKeyValueStore(InheritanceKeyValueStore):
         elif key.scope == Scope.content:
             self._data[key.field_name] = value
         else:
-            raise InvalidScopeError(key)
+            raise InvalidScopeError(
+                key,
+                (Scope.children, Scope.settings, Scope.content),
+            )
 
     def delete(self, key):
         if key.scope == Scope.children:
@@ -141,7 +147,10 @@ class MongoKeyValueStore(InheritanceKeyValueStore):
             if key.field_name in self._data:
                 del self._data[key.field_name]
         else:
-            raise InvalidScopeError(key)
+            raise InvalidScopeError(
+                key,
+                (Scope.children, Scope.settings, Scope.content),
+            )
 
     def has(self, key):
         if key.scope in (Scope.children, Scope.parent):

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split_mongo_kvs.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split_mongo_kvs.py
@@ -18,6 +18,8 @@ class SplitMongoKVS(InheritanceKeyValueStore):
     known to the MongoModuleStore (data, children, and metadata)
     """
 
+    VALID_SCOPES = (Scope.parent, Scope.children, Scope.settings, Scope.content)
+
     @contract(parent="BlockUsageLocator | None")
     def __init__(self, definition, initial_values, default_values, parent, field_decorator=None):
         """
@@ -59,7 +61,7 @@ class SplitMongoKVS(InheritanceKeyValueStore):
                 else:
                     raise KeyError()
             else:
-                raise InvalidScopeError(key)
+                raise InvalidScopeError(key, self.VALID_SCOPES)
 
         if key.field_name in self._fields:
             field_value = self._fields[key.field_name]
@@ -71,8 +73,8 @@ class SplitMongoKVS(InheritanceKeyValueStore):
 
     def set(self, key, value):
         # handle any special cases
-        if key.scope not in [Scope.children, Scope.settings, Scope.content]:
-            raise InvalidScopeError(key)
+        if key.scope not in self.VALID_SCOPES:
+            raise InvalidScopeError(key, self.VALID_SCOPES)
         if key.scope == Scope.content:
             self._load_definition()
 
@@ -90,8 +92,8 @@ class SplitMongoKVS(InheritanceKeyValueStore):
 
     def delete(self, key):
         # handle any special cases
-        if key.scope not in [Scope.children, Scope.settings, Scope.content]:
-            raise InvalidScopeError(key)
+        if key.scope not in self.VALID_SCOPES:
+            raise InvalidScopeError(key, self.VALID_SCOPES)
         if key.scope == Scope.content:
             self._load_definition()
 

--- a/lms/djangoapps/courseware/model_data.py
+++ b/lms/djangoapps/courseware/model_data.py
@@ -95,9 +95,7 @@ class DjangoKeyValueStore(KeyValueStore):
         self._field_data_cache = field_data_cache
 
     def get(self, key):
-        if key.scope not in self._allowed_scopes:
-            raise InvalidScopeError(key)
-
+        self._raise_unless_scope_is_allowed(key)
         return self._field_data_cache.get(key)
 
     def set(self, key, value):
@@ -116,22 +114,22 @@ class DjangoKeyValueStore(KeyValueStore):
         """
         for key in kv_dict:
             # Check key for validity
-            if key.scope not in self._allowed_scopes:
-                raise InvalidScopeError(key)
+            self._raise_unless_scope_is_allowed(key)
 
         self._field_data_cache.set_many(kv_dict)
 
     def delete(self, key):
-        if key.scope not in self._allowed_scopes:
-            raise InvalidScopeError(key)
-
+        self._raise_unless_scope_is_allowed(key)
         self._field_data_cache.delete(key)
 
     def has(self, key):
+        self._raise_unless_scope_is_allowed(key)
+        return self._field_data_cache.has(key)
+
+    def _raise_unless_scope_is_allowed(self, key):
+        """Raise an InvalidScopeError if key.scope is not in self._allowed_scopes."""
         if key.scope not in self._allowed_scopes:
             raise InvalidScopeError(key)
-
-        return self._field_data_cache.has(key)
 
 
 new_contract("DjangoKeyValueStore", DjangoKeyValueStore)

--- a/lms/djangoapps/courseware/model_data.py
+++ b/lms/djangoapps/courseware/model_data.py
@@ -129,7 +129,7 @@ class DjangoKeyValueStore(KeyValueStore):
     def _raise_unless_scope_is_allowed(self, key):
         """Raise an InvalidScopeError if key.scope is not in self._allowed_scopes."""
         if key.scope not in self._allowed_scopes:
-            raise InvalidScopeError(key)
+            raise InvalidScopeError(key, self._allowed_scopes)
 
 
 new_contract("DjangoKeyValueStore", DjangoKeyValueStore)

--- a/lms/djangoapps/courseware/model_data.py
+++ b/lms/djangoapps/courseware/model_data.py
@@ -1,5 +1,24 @@
 """
-Classes to provide the LMS runtime data storage to XBlocks
+Classes to provide the LMS runtime data storage to XBlocks.
+
+:class:`DjangoKeyValueStore`: An XBlock :class:`~KeyValueStore` which
+    stores a subset of xblocks scopes as Django ORM objects. It wraps
+    :class:`~FieldDataCache` to provide an XBlock-friendly interface.
+
+
+:class:`FieldDataCache`: A object which provides a read-through prefetch cache
+    of data to support XBlock fields within a limited set of scopes.
+
+The remaining classes in this module provide read-through prefetch cache implementations
+for specific scopes. The individual classes provide the knowledge of what are the essential
+pieces of information for each scope, and thus how to cache, prefetch, and create new field data
+entries.
+
+UserStateCache: A cache for Scope.user_state
+UserStateSummaryCache: A cache for Scope.user_state_summary
+PreferencesCache: A cache for Scope.preferences
+UserInfoCache: A cache for Scope.user_info
+DjangoOrmFieldCache: A base-class for single-row-per-field caches.
 """
 
 import json
@@ -681,7 +700,7 @@ class UserInfoCache(DjangoOrmFieldCache):
 class FieldDataCache(object):
     """
     A cache of django model objects needed to supply the data
-    for a module and its decendants
+    for a module and its descendants
     """
     def __init__(self, descriptors, course_id, user, select_for_update=False, asides=None):
         '''
@@ -736,13 +755,13 @@ class FieldDataCache(object):
 
     def add_descriptor_descendents(self, descriptor, depth=None, descriptor_filter=lambda descriptor: True):
         """
-        Add all descendents of `descriptor` to this FieldDataCache.
+        Add all descendants of `descriptor` to this FieldDataCache.
 
         Arguments:
             descriptor: An XModuleDescriptor
-            depth is the number of levels of descendent modules to load StudentModules for, in addition to
-                the supplied descriptor. If depth is None, load all descendent StudentModules
-            descriptor_filter is a function that accepts a descriptor and return wether the StudentModule
+            depth is the number of levels of descendant modules to load StudentModules for, in addition to
+                the supplied descriptor. If depth is None, load all descendant StudentModules
+            descriptor_filter is a function that accepts a descriptor and return whether the field data
                 should be cached
         """
 
@@ -782,9 +801,9 @@ class FieldDataCache(object):
         course_id: the course in the context of which we want StudentModules.
         user: the django user for whom to load modules.
         descriptor: An XModuleDescriptor
-        depth is the number of levels of descendent modules to load StudentModules for, in addition to
-            the supplied descriptor. If depth is None, load all descendent StudentModules
-        descriptor_filter is a function that accepts a descriptor and return wether the StudentModule
+        depth is the number of levels of descendant modules to load StudentModules for, in addition to
+            the supplied descriptor. If depth is None, load all descendant StudentModules
+        descriptor_filter is a function that accepts a descriptor and return whether the field data
             should be cached
         select_for_update: Ignored
         """

--- a/lms/djangoapps/courseware/model_data.py
+++ b/lms/djangoapps/courseware/model_data.py
@@ -703,7 +703,7 @@ class FieldDataCache(object):
     for a module and its descendants
     """
     def __init__(self, descriptors, course_id, user, select_for_update=False, asides=None):
-        '''
+        """
         Find any courseware.models objects that are needed by any descriptor
         in descriptors. Attempts to minimize the number of queries to the database.
         Note: Only modules that have store_state = True or have shared
@@ -715,7 +715,7 @@ class FieldDataCache(object):
         user: The user for which to cache data
         select_for_update: Ignored
         asides: The list of aside types to load, or None to prefetch no asides.
-        '''
+        """
         if asides is None:
             self.asides = []
         else:
@@ -823,7 +823,7 @@ class FieldDataCache(object):
 
     @contract(key=DjangoKeyValueStore.Key)
     def get(self, key):
-        '''
+        """
         Load the field value specified by `key`.
 
         Arguments:
@@ -831,7 +831,7 @@ class FieldDataCache(object):
 
         Returns: The found value
         Raises: KeyError if key isn't found in the cache
-        '''
+        """
 
         if key.scope.user == UserScope.ONE and not self.user.is_anonymous():
             # If we're getting user data, we expect that the key matches the

--- a/lms/djangoapps/courseware/model_data.py
+++ b/lms/djangoapps/courseware/model_data.py
@@ -132,14 +132,7 @@ class DjangoKeyValueStore(KeyValueStore):
         if key.scope not in self._allowed_scopes:
             raise InvalidScopeError(key)
 
-        field_object = self._field_data_cache.find(key)
-        if field_object is None:
-            raise KeyError(key.field_name)
-
-        if key.scope == Scope.user_state:
-            return json.loads(field_object.state)[key.field_name]
-        else:
-            return json.loads(field_object.value)
+        return self._field_data_cache.get(key)
 
     def set(self, key, value):
         """
@@ -622,6 +615,25 @@ class FieldDataCache(object):
                 scope_map[field.scope].add(field)
         return scope_map
 
+    @contract(key=DjangoKeyValueStore.Key)
+    def get(self, key):
+        '''
+        Load the field value specified by `key`.
+
+        Arguments:
+            key (`DjangoKeyValueStore.Key`): The field value to load
+
+        Returns: The found value
+        Raises: KeyError if key isn't found in the cache
+        '''
+        field_object = self.find(key)
+        if field_object is None:
+            raise KeyError(key.field_name)
+
+        if key.scope == Scope.user_state:
+            return json.loads(field_object.state)[key.field_name]
+        else:
+            return json.loads(field_object.value)
 
     def find(self, key):
         '''

--- a/lms/djangoapps/courseware/model_data.py
+++ b/lms/djangoapps/courseware/model_data.py
@@ -197,10 +197,26 @@ class DjangoOrmFieldCache(object):
 
     @contract(kvs_key=DjangoKeyValueStore.Key)
     def get(self, kvs_key):
+        """
+        Return the django model object specified by `kvs_key` from
+        the cache.
+
+        Arguments:
+            kvs_key (`DjangoKeyValueStore.Key`): The field value to delete
+
+        Returns: A django orm object from the cache
+        """
         return self._cache.get(self._cache_key_for_kvs_key(kvs_key))
 
     @contract(kvs_key=DjangoKeyValueStore.Key)
     def set(self, kvs_key, value):
+        """
+        Set the specified `kvs_key` to the django model object `value`.
+
+        Arguments:
+            kvs_key (`DjangoKeyValueStore.Key`): The field value to delete
+            value: The django orm object to be stored in the cache
+        """
         self._cache[self._cache_key_for_kvs_key(kvs_key)] = value
 
     @contract(kvs_key=DjangoKeyValueStore.Key)

--- a/lms/djangoapps/courseware/model_data.py
+++ b/lms/djangoapps/courseware/model_data.py
@@ -84,7 +84,7 @@ class UserStateCache(object):
         self.course_id = course_id
 
     def cache_key_for_field_object(self, field_object):
-        return (Scope.user_state, field_object.module_state_key.map_into_course(self.course_id))
+        return field_object.module_state_key.map_into_course(self.course_id)
 
 
 class UserStateSummaryCache(object):
@@ -102,7 +102,7 @@ class UserStateSummaryCache(object):
         self.course_id = course_id
 
     def cache_key_for_field_object(self, field_object):
-        return (Scope.user_state_summary, field_object.usage_id.map_into_course(self.course_id), field_object.field_name)
+        return (field_object.usage_id.map_into_course(self.course_id), field_object.field_name)
 
 
 class PreferencesCache(object):
@@ -120,7 +120,7 @@ class PreferencesCache(object):
         )
 
     def cache_key_for_field_object(self, field_object):
-        return (Scope.preferences, field_object.module_type, field_object.field_name)
+        return (field_object.module_type, field_object.field_name)
 
 
 class UserInfoCache(object):
@@ -136,7 +136,7 @@ class UserInfoCache(object):
         )
 
     def cache_key_for_field_object(self, field_object):
-        return (Scope.user_info, field_object.field_name)
+        return field_object.field_name
 
 
 class FieldDataCache(object):
@@ -158,7 +158,12 @@ class FieldDataCache(object):
         select_for_update: True if rows should be locked until end of transaction
         asides: The list of aside types to load, or None to prefetch no asides.
         '''
-        self.cache = {}
+        self.cache = {
+            Scope.user_state: {},
+            Scope.user_info: {},
+            Scope.preferences: {},
+            Scope.user_state_summary: {},
+        }
         self.select_for_update = select_for_update
 
         if asides is None:
@@ -301,7 +306,7 @@ class FieldDataCache(object):
             return
 
         for field_object in cache._data:
-            self.cache[cache.cache_key_for_field_object(field_object)] = field_object
+            self.cache[scope][cache.cache_key_for_field_object(field_object)] = field_object
 
     def _fields_to_cache(self, descriptors):
         """
@@ -318,13 +323,13 @@ class FieldDataCache(object):
         Return the key used in the FieldDataCache for the specified KeyValueStore key
         """
         if key.scope == Scope.user_state:
-            return (key.scope, key.block_scope_id)
+            return key.block_scope_id
         elif key.scope == Scope.user_state_summary:
-            return (key.scope, key.block_scope_id, key.field_name)
+            return (key.block_scope_id, key.field_name)
         elif key.scope == Scope.preferences:
-            return (key.scope, BlockTypeKeyV1(key.block_family, key.block_scope_id), key.field_name)
+            return (BlockTypeKeyV1(key.block_family, key.block_scope_id), key.field_name)
         elif key.scope == Scope.user_info:
-            return (key.scope, key.field_name)
+            return key.field_name
 
     def find(self, key):
         '''
@@ -339,7 +344,7 @@ class FieldDataCache(object):
             # user we were constructed for.
             assert key.user_id == self.user.id
 
-        return self.cache.get(self._cache_key_from_kvs_key(key))
+        return self.cache[key.scope].get(self._cache_key_from_kvs_key(key))
 
     def find_or_create(self, key):
         '''
@@ -379,7 +384,7 @@ class FieldDataCache(object):
             )
 
         cache_key = self._cache_key_from_kvs_key(key)
-        self.cache[cache_key] = field_object
+        self.cache[key.scope][cache_key] = field_object
         return field_object
 
 

--- a/lms/djangoapps/courseware/model_data.py
+++ b/lms/djangoapps/courseware/model_data.py
@@ -951,3 +951,6 @@ class FieldDataCache(object):
             return None
 
         return self.cache[key.scope].last_modified(key)
+
+    def __len__(self):
+        return sum(len(cache) for cache in self.cache.values())

--- a/lms/djangoapps/courseware/model_data.py
+++ b/lms/djangoapps/courseware/model_data.py
@@ -165,14 +165,8 @@ class DjangoKeyValueStore(KeyValueStore):
         if key.scope not in self._allowed_scopes:
             raise InvalidScopeError(key)
 
-        field_object = self._field_data_cache.find(key)
-        if field_object is None:
-            return False
+        return self._field_data_cache.has(key)
 
-        if key.scope == Scope.user_state:
-            return key.field_name in json.loads(field_object.state)
-        else:
-            return True
 
 new_contract("DjangoKeyValueStore", DjangoKeyValueStore)
 new_contract("DjangoKeyValueStore_Key", DjangoKeyValueStore.Key)
@@ -662,6 +656,26 @@ class FieldDataCache(object):
             field_object.save()
         else:
             field_object.delete()
+
+    @contract(key=DjangoKeyValueStore.Key, returns=bool)
+    def has(self, key):
+        """
+        Return whether the specified `key` is set.
+
+        Arguments:
+            key (`DjangoKeyValueStore.Key`): The field value to delete
+
+        Returns: bool
+        """
+        field_object = self.find(key)
+        if field_object is None:
+            return False
+
+        if key.scope == Scope.user_state:
+            return key.field_name in json.loads(field_object.state)
+        else:
+            return True
+
 
     def find(self, key):
         '''

--- a/lms/djangoapps/courseware/models.py
+++ b/lms/djangoapps/courseware/models.py
@@ -13,6 +13,7 @@ ASSUMPTIONS: modules have unique IDs, even across different module_types
 
 """
 import logging
+import itertools
 
 from django.contrib.auth.models import User
 from django.conf import settings
@@ -29,10 +30,49 @@ from xmodule_django.models import CourseKeyField, LocationKeyField, BlockTypeKey
 log = logging.getLogger("edx.courseware")
 
 
+def chunks(items, chunk_size):
+    """
+    Yields the values from items in chunks of size chunk_size
+    """
+    items = list(items)
+    return (items[i:i + chunk_size] for i in xrange(0, len(items), chunk_size))
+
+
+class ChunkingManager(models.Manager):
+    """
+    :class:`~Manager` that adds an additional method :meth:`chunked_filter` to provide
+    the ability to make select queries with specific chunk sizes.
+    """
+    def chunked_filter(self, chunk_field, items, **kwargs):
+        """
+        Queries model_class with `chunk_field` set to chunks of size `chunk_size`,
+        and all other parameters from `**kwargs`.
+
+        This works around a limitation in sqlite3 on the number of parameters
+        that can be put into a single query.
+
+        Arguments:
+            chunk_field (str): The name of the field to chunk the query on.
+            items: The values for of chunk_field to select. This is chunked into ``chunk_size``
+                chunks, and passed as the value for the ``chunk_field`` keyword argument to
+                :meth:`~Manager.filter`. This implies that ``chunk_field`` should be an
+                ``__in`` key.
+            chunk_size (int): The size of chunks to pass. Defaults to 500.
+        """
+        chunk_size = kwargs.pop('chunk_size', 500)
+        res = itertools.chain.from_iterable(
+            self.filter(**dict([(chunk_field, chunk)] + kwargs.items()))
+            for chunk in chunks(items, chunk_size)
+        )
+        return res
+
+
 class StudentModule(models.Model):
     """
     Keeps student state for a particular module in a particular course.
     """
+    objects = ChunkingManager()
+
     MODEL_TAGS = ['course_id', 'module_type']
 
     # For a homework problem, contains a JSON
@@ -142,6 +182,8 @@ class XBlockFieldBase(models.Model):
     """
     Base class for all XBlock field storage.
     """
+    objects = ChunkingManager()
+
     class Meta(object):  # pylint: disable=missing-docstring
         abstract = True
 

--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -728,11 +728,12 @@ def load_single_xblock(request, user_id, course_id, usage_key_string):
     """
     Load a single XBlock identified by usage_key_string.
     """
-    course_id = SlashSeparatedCourseKey.from_deprecated_string(course_id)
-    usage_key = course_id.make_usage_key_from_deprecated_string(usage_key_string)
+    usage_key = UsageKey.from_string(usage_key_string)
+    course_key = CourseKey.from_string(course_id)
+    usage_key = usage_key.map_into_course(course_key)
     user = User.objects.get(id=user_id)
     field_data_cache = FieldDataCache.cache_for_descriptor_descendents(
-        course_id,
+        course_key,
         user,
         modulestore().get_item(usage_key),
         depth=0,

--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -737,7 +737,6 @@ def load_single_xblock(request, user_id, course_id, usage_key_string):
         user,
         modulestore().get_item(usage_key),
         depth=0,
-        select_for_update=True
     )
     instance = get_module(user, request, usage_key, field_data_cache, grade_bucket_type='xqueue')
     if instance is None:

--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -423,13 +423,14 @@ def get_module_system_for_user(user, field_data_cache,
             block_scope_id=descriptor.location,
             field_name='grade'
         )
-
-        student_module = field_data_cache.find_or_create(key)
-        # Update the grades
-        student_module.grade = event.get('value')
-        student_module.max_grade = event.get('max_value')
-        # Save all changes to the underlying KeyValueStore
-        student_module.save()
+        StudentModule.objects.filter(
+            student__id=user_id,
+            module_state_key=descriptor.location,
+            course_id=course_id,
+        ).update(
+            grade=event.get('value'),
+            max_grade=event.get('max_value')
+        )
 
         # Bin score into range and increment stats
         score_bucket = get_score_bucket(student_module.grade, student_module.max_grade)

--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -416,24 +416,18 @@ def get_module_system_for_user(user, field_data_cache,
         """
         user_id = event.get('user_id', user.id)
 
-        # Construct the key for the module
-        key = KeyValueStore.Key(
-            scope=Scope.user_state,
-            user_id=user_id,
-            block_scope_id=descriptor.location,
-            field_name='grade'
-        )
-        StudentModule.objects.filter(
-            student__id=user_id,
-            module_state_key=descriptor.location,
-            course_id=course_id,
-        ).update(
-            grade=event.get('value'),
-            max_grade=event.get('max_value')
+        grade = event.get('value')
+        max_grade = event.get('max_value')
+
+        field_data_cache.set_score(
+            user_id,
+            descriptor.location,
+            grade,
+            max_grade,
         )
 
         # Bin score into range and increment stats
-        score_bucket = get_score_bucket(student_module.grade, student_module.max_grade)
+        score_bucket = get_score_bucket(grade, max_grade)
 
         tags = [
             u"org:{}".format(course_id.org),

--- a/lms/djangoapps/courseware/tests/test_model_data.py
+++ b/lms/djangoapps/courseware/tests/test_model_data.py
@@ -230,7 +230,7 @@ class TestMissingStudentModule(TestCase):
 
     def test_set_field_in_missing_student_module(self):
         "Test that setting a field in a missing StudentModule creates the student module"
-        self.assertEquals(0, len(self.field_data_cache.cache))
+        self.assertEquals(0, sum(len(cache) for cache in self.field_data_cache.cache.values()))
         self.assertEquals(0, StudentModule.objects.all().count())
 
         # We are updating a problem, so we write to courseware_studentmodulehistory
@@ -238,7 +238,7 @@ class TestMissingStudentModule(TestCase):
         with self.assertNumQueries(6):
             self.kvs.set(user_state_key('a_field'), 'a_value')
 
-        self.assertEquals(1, len(self.field_data_cache.cache))
+        self.assertEquals(1, sum(len(cache) for cache in self.field_data_cache.cache.values()))
         self.assertEquals(1, StudentModule.objects.all().count())
 
         student_module = StudentModule.objects.all()[0]

--- a/lms/djangoapps/courseware/tests/test_model_data.py
+++ b/lms/djangoapps/courseware/tests/test_model_data.py
@@ -134,7 +134,10 @@ class TestStudentModuleStorage(OtherUserFailureTestMixin, TestCase):
     def test_set_existing_field(self):
         "Test that setting an existing user_state field changes the value"
         # We are updating a problem, so we write to courseware_studentmodulehistory
-        # as well as courseware_studentmodule
+        # as well as courseware_studentmodule. We also need to read the database
+        # to discover if something other than the DjangoXBlockUserStateClient
+        # has written to the StudentModule (such as UserStateCache setting the score
+        # on the StudentModule).
         with self.assertNumQueries(3):
             self.kvs.set(user_state_key('a_field'), 'new_value')
         self.assertEquals(1, StudentModule.objects.all().count())
@@ -143,7 +146,10 @@ class TestStudentModuleStorage(OtherUserFailureTestMixin, TestCase):
     def test_set_missing_field(self):
         "Test that setting a new user_state field changes the value"
         # We are updating a problem, so we write to courseware_studentmodulehistory
-        # as well as courseware_studentmodule
+        # as well as courseware_studentmodule. We also need to read the database
+        # to discover if something other than the DjangoXBlockUserStateClient
+        # has written to the StudentModule (such as UserStateCache setting the score
+        # on the StudentModule).
         with self.assertNumQueries(3):
             self.kvs.set(user_state_key('not_a_field'), 'new_value')
         self.assertEquals(1, StudentModule.objects.all().count())
@@ -152,7 +158,10 @@ class TestStudentModuleStorage(OtherUserFailureTestMixin, TestCase):
     def test_delete_existing_field(self):
         "Test that deleting an existing field removes it from the StudentModule"
         # We are updating a problem, so we write to courseware_studentmodulehistory
-        # as well as courseware_studentmodule
+        # as well as courseware_studentmodule. We also need to read the database
+        # to discover if something other than the DjangoXBlockUserStateClient
+        # has written to the StudentModule (such as UserStateCache setting the score
+        # on the StudentModule).
         with self.assertNumQueries(3):
             self.kvs.delete(user_state_key('a_field'))
         self.assertEquals(1, StudentModule.objects.all().count())
@@ -190,6 +199,9 @@ class TestStudentModuleStorage(OtherUserFailureTestMixin, TestCase):
         # Scope.user_state is stored in a single row in the database, so we only
         # need to send a single update to that table.
         # We also are updating a problem, so we write to courseware student module history
+        # We also need to read the database to discover if something other than the
+        # DjangoXBlockUserStateClient has written to the StudentModule (such as
+        # UserStateCache setting the score on the StudentModule).
         with self.assertNumQueries(3):
             self.kvs.set_many(kv_dict)
 
@@ -207,7 +219,7 @@ class TestStudentModuleStorage(OtherUserFailureTestMixin, TestCase):
         with patch('django.db.models.Model.save', side_effect=DatabaseError):
             with self.assertRaises(KeyValueMultiSaveError) as exception_context:
                 self.kvs.set_many(kv_dict)
-        self.assertEquals(len(exception_context.exception.saved_field_names), 0)
+        self.assertEquals(exception_context.exception.saved_field_names, [])
 
 
 @attr('shard_1')
@@ -234,8 +246,11 @@ class TestMissingStudentModule(TestCase):
         self.assertEquals(0, StudentModule.objects.all().count())
 
         # We are updating a problem, so we write to courseware_studentmodulehistory
-        # as well as courseware_studentmodule
-        with self.assertNumQueries(6):
+        # as well as courseware_studentmodule. We also need to read the database
+        # to discover if something other than the DjangoXBlockUserStateClient
+        # has written to the StudentModule (such as UserStateCache setting the score
+        # on the StudentModule).
+        with self.assertNumQueries(3):
             self.kvs.set(user_state_key('a_field'), 'a_value')
 
         self.assertEquals(1, sum(len(cache) for cache in self.field_data_cache.cache.values()))
@@ -289,7 +304,7 @@ class StorageTestBase(object):
         self.kvs = DjangoKeyValueStore(self.field_data_cache)
 
     def test_set_and_get_existing_field(self):
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(1):
             self.kvs.set(self.key_factory('existing_field'), 'test_value')
         with self.assertNumQueries(0):
             self.assertEquals('test_value', self.kvs.get(self.key_factory('existing_field')))
@@ -306,14 +321,14 @@ class StorageTestBase(object):
 
     def test_set_existing_field(self):
         "Test that setting an existing field changes the value"
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(1):
             self.kvs.set(self.key_factory('existing_field'), 'new_value')
         self.assertEquals(1, self.storage_class.objects.all().count())
         self.assertEquals('new_value', json.loads(self.storage_class.objects.all()[0].value))
 
     def test_set_missing_field(self):
         "Test that setting a new field changes the value"
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(1):
             self.kvs.set(self.key_factory('missing_field'), 'new_value')
         self.assertEquals(2, self.storage_class.objects.all().count())
         self.assertEquals('old_value', json.loads(self.storage_class.objects.get(field_name='existing_field').value))
@@ -355,7 +370,7 @@ class StorageTestBase(object):
 
         # Each field is a separate row in the database, hence
         # a separate query
-        with self.assertNumQueries(len(kv_dict) * 3):
+        with self.assertNumQueries(len(kv_dict)):
             self.kvs.set_many(kv_dict)
         for key in kv_dict:
             self.assertEquals(self.kvs.get(key), kv_dict[key])
@@ -363,8 +378,8 @@ class StorageTestBase(object):
     def test_set_many_failure(self):
         """Test that setting many regular fields with a DB error """
         kv_dict = self.construct_kv_dict()
-        with self.assertNumQueries(6):
-            for key in kv_dict:
+        for key in kv_dict:
+            with self.assertNumQueries(1):
                 self.kvs.set(key, 'test value')
 
         with patch('django.db.models.Model.save', side_effect=[None, DatabaseError]):
@@ -372,8 +387,7 @@ class StorageTestBase(object):
                 self.kvs.set_many(kv_dict)
 
         exception = exception_context.exception
-        self.assertEquals(len(exception.saved_field_names), 1)
-        self.assertIn(exception.saved_field_names[0], ('existing_field', 'other_existing_field'))
+        self.assertEquals(exception.saved_field_names, ['existing_field', 'other_existing_field'])
 
 
 class TestUserStateSummaryStorage(StorageTestBase, TestCase):

--- a/lms/djangoapps/courseware/tests/test_model_data.py
+++ b/lms/djangoapps/courseware/tests/test_model_data.py
@@ -373,7 +373,7 @@ class StorageTestBase(object):
 
         exception = exception_context.exception
         self.assertEquals(len(exception.saved_field_names), 1)
-        self.assertEquals(exception.saved_field_names[0], 'other_existing_field')
+        self.assertIn(exception.saved_field_names[0], ('existing_field', 'other_existing_field'))
 
 
 class TestUserStateSummaryStorage(StorageTestBase, TestCase):

--- a/lms/djangoapps/courseware/tests/test_model_data.py
+++ b/lms/djangoapps/courseware/tests/test_model_data.py
@@ -373,7 +373,7 @@ class StorageTestBase(object):
 
         exception = exception_context.exception
         self.assertEquals(len(exception.saved_field_names), 1)
-        self.assertEquals(exception.saved_field_names[0], 'existing_field')
+        self.assertEquals(exception.saved_field_names[0], 'other_existing_field')
 
 
 class TestUserStateSummaryStorage(StorageTestBase, TestCase):

--- a/lms/djangoapps/courseware/tests/test_model_data.py
+++ b/lms/djangoapps/courseware/tests/test_model_data.py
@@ -242,7 +242,7 @@ class TestMissingStudentModule(TestCase):
 
     def test_set_field_in_missing_student_module(self):
         "Test that setting a field in a missing StudentModule creates the student module"
-        self.assertEquals(0, sum(len(cache) for cache in self.field_data_cache.cache.values()))
+        self.assertEquals(0, len(self.field_data_cache))
         self.assertEquals(0, StudentModule.objects.all().count())
 
         # We are updating a problem, so we write to courseware_studentmodulehistory

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -160,8 +160,7 @@ class ModuleRenderTestCase(ModuleStoreTestCase, LoginEnrollmentTestCase):
         }
 
         # Patch getmodule to return our mock module
-        with patch('courseware.module_render.find_target_student_module') as get_fake_module:
-            get_fake_module.return_value = self.mock_module
+        with patch('courseware.module_render.load_single_xblock', return_value=self.mock_module):
             # call xqueue_callback with our mocked information
             request = self.request_factory.post(self.callback_url, data)
             render.xqueue_callback(request, self.course_key, self.mock_user.id, self.mock_module.id, self.dispatch)
@@ -176,8 +175,7 @@ class ModuleRenderTestCase(ModuleStoreTestCase, LoginEnrollmentTestCase):
             'xqueue_body': 'hello world',
         }
 
-        with patch('courseware.module_render.find_target_student_module') as get_fake_module:
-            get_fake_module.return_value = self.mock_module
+        with patch('courseware.module_render.load_single_xblock', return_value=self.mock_module):
             # Test with missing xqueue data
             with self.assertRaises(Http404):
                 request = self.request_factory.post(self.callback_url, {})

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -48,7 +48,7 @@ from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import ItemFactory, CourseFactory, check_mongo_calls
-from xmodule.x_module import XModuleDescriptor, XModule, STUDENT_VIEW, CombinedSystem
+from xmodule.x_module import XModuleDescriptor, XModule, STUDENT_VIEW, CombinedSystem, DescriptorSystem
 
 TEST_DATA_DIR = settings.COMMON_TEST_DATA_ROOT
 
@@ -1063,7 +1063,7 @@ class TestAnonymousStudentId(ModuleStoreTestCase, LoginEnrollmentTestCase):
             location=location,
             static_asset_path=None,
             _runtime=Mock(
-                spec=Runtime,
+                spec=DescriptorSystem,
                 resources_fs=None,
                 mixologist=Mock(_mixins=(), name='mixologist'),
                 name='runtime',

--- a/lms/djangoapps/courseware/user_state_client.py
+++ b/lms/djangoapps/courseware/user_state_client.py
@@ -1,0 +1,63 @@
+"""
+An implementation of :class:`XBlockUserStateClient`, which stores XBlock Scope.user_state
+data in a Django ORM model.
+"""
+
+from xblock_user_state.interface import DjangoXBlockUserStateClient
+
+
+class DjangoXBlockUserStateClient(DjangoXBlockUserStateClient):
+    """
+    An interface that uses the Django ORM StudentModule as a backend.
+    """
+
+    class ServiceUnavailable(XBlockUserStateClient.ServiceUnavailable):
+        """
+        This error is raised if the service backing this client is currently unavailable.
+        """
+        pass
+
+    class PermissionDenied(XBlockUserStateClient.PermissionDenied):
+        """
+        This error is raised if the caller is not allowed to access the requested data.
+        """
+        pass
+
+    class DoesNotExist(XBlockUserStateClient.DoesNotExist):
+        """
+        This error is raised if the caller has requested data that does not exist.
+        """
+        pass
+
+    def get(username, block_key, scope=Scope.user_state):
+        return self.get_many(username, [block_key], scope)
+
+    def set(username, block_key, state, scope=Scope.user_state):
+        self.set_many(username, {block_key: state}, scope)
+
+    def get_many(username, block_keys, scope=Scope.user_state):
+        """Returns dict of block_id -> state."""
+        raise NotImplementedError()
+
+    def set_many(username, block_keys_to_state, scope=Scope.user_state):
+        raise NotImplementedError()
+
+    def get_history(username, block_key, scope=Scope.user_state):
+        """We don't guarantee that history for many blocks will be fast."""
+        raise NotImplementedError()
+
+    def iter_all_for_block(block_key, scope=Scope.user_state, batch_size=None):
+        """
+        You get no ordering guarantees. Fetching will happen in batch_size
+        increments. If you're using this method, you should be running in an
+        async task.
+        """
+        raise NotImplementedError()
+
+    def iter_all_for_course(course_key, block_type=None, scope=Scope.user_state, batch_size=None):
+        """
+        You get no ordering guarantees. Fetching will happen in batch_size
+        increments. If you're using this method, you should be running in an
+        async task.
+        """
+        raise NotImplementedError()

--- a/lms/djangoapps/courseware/user_state_client.py
+++ b/lms/djangoapps/courseware/user_state_client.py
@@ -37,13 +37,19 @@ class DjangoXBlockUserStateClient(DjangoXBlockUserStateClient):
 
     def get_many(username, block_keys, scope=Scope.user_state):
         """Returns dict of block_id -> state."""
+        if scope != Scope.user_state:
+            raise ValueError("Only Scope.user_state is supported")
         raise NotImplementedError()
 
     def set_many(username, block_keys_to_state, scope=Scope.user_state):
+        if scope != Scope.user_state:
+            raise ValueError("Only Scope.user_state is supported")
         raise NotImplementedError()
 
     def get_history(username, block_key, scope=Scope.user_state):
         """We don't guarantee that history for many blocks will be fast."""
+        if scope != Scope.user_state:
+            raise ValueError("Only Scope.user_state is supported")
         raise NotImplementedError()
 
     def iter_all_for_block(block_key, scope=Scope.user_state, batch_size=None):
@@ -52,6 +58,8 @@ class DjangoXBlockUserStateClient(DjangoXBlockUserStateClient):
         increments. If you're using this method, you should be running in an
         async task.
         """
+        if scope != Scope.user_state:
+            raise ValueError("Only Scope.user_state is supported")
         raise NotImplementedError()
 
     def iter_all_for_course(course_key, block_type=None, scope=Scope.user_state, batch_size=None):
@@ -60,4 +68,6 @@ class DjangoXBlockUserStateClient(DjangoXBlockUserStateClient):
         increments. If you're using this method, you should be running in an
         async task.
         """
+        if scope != Scope.user_state:
+            raise ValueError("Only Scope.user_state is supported")
         raise NotImplementedError()

--- a/lms/djangoapps/courseware/user_state_client.py
+++ b/lms/djangoapps/courseware/user_state_client.py
@@ -3,10 +3,20 @@ An implementation of :class:`XBlockUserStateClient`, which stores XBlock Scope.u
 data in a Django ORM model.
 """
 
-from xblock_user_state.interface import DjangoXBlockUserStateClient
+import itertools
+from operator import attrgetter
+
+try:
+    import simplejson as json
+except ImportError:
+    import json
+
+from xblock.fields import Scope
+from xblock_user_state.interface import XBlockUserStateClient
+from courseware.models import StudentModule
 
 
-class DjangoXBlockUserStateClient(DjangoXBlockUserStateClient):
+class DjangoXBlockUserStateClient(XBlockUserStateClient):
     """
     An interface that uses the Django ORM StudentModule as a backend.
     """
@@ -29,7 +39,11 @@ class DjangoXBlockUserStateClient(DjangoXBlockUserStateClient):
         """
         pass
 
-    def get(username, block_key, scope=Scope.user_state, fields=None):
+    def __init__(self, user):
+        self._student_module_cache = {}
+        self.user = user
+
+    def get(self, username, block_key, scope=Scope.user_state, fields=None):
         """
         Retrieve the stored XBlock state for a single xblock usage.
 
@@ -45,6 +59,7 @@ class DjangoXBlockUserStateClient(DjangoXBlockUserStateClient):
         Raises:
             DoesNotExist if no entry is found.
         """
+        assert self.user.username == username
         try:
             _usage_key, state = next(self.get_many(username, [block_key], scope, fields=fields))
         except StopIteration:
@@ -52,19 +67,68 @@ class DjangoXBlockUserStateClient(DjangoXBlockUserStateClient):
 
         return state
 
-    def set(username, block_key, state, scope=Scope.user_state):
+    def set(self, username, block_key, state, scope=Scope.user_state):
         """
         Set fields for a particular XBlock.
 
         Arguments:
             username: The name of the user whose state should be retrieved
-            block_key (UsageKey): The UsageKey identifying which xblock state to load.
+            block_key (UsageKey): The UsageKey identifying which xblock state to update.
             state (dict): A dictionary mapping field names to values
             scope (Scope): The scope to load data from
         """
+        assert self.user.username == username
         self.set_many(username, {block_key: state}, scope)
 
-    def get_many(username, block_keys, scope=Scope.user_state, fields=None):
+    def delete(self, username, block_key, scope=Scope.user_state, fields=None):
+        """
+        Delete the stored XBlock state for a single xblock usage.
+
+        Arguments:
+            username: The name of the user whose state should be deleted
+            block_key (UsageKey): The UsageKey identifying which xblock state to delete.
+            scope (Scope): The scope to delete data from
+            fields: A list of fields to delete. If None, delete all stored fields.
+        """
+        assert self.user.username == username
+        return self.delete_many(username, [block_key], scope, fields=fields)
+
+    def _get_field_objects(self, username, block_keys):
+        """
+        Retrieve the :class:`~StudentModule`s for the supplied ``username`` and ``block_keys``.
+
+        Arguments:
+            username (str): The name of the user to load `StudentModule`s for.
+            block_keys (list of :class:`~UsageKey`): The set of XBlocks to load data for.
+        """
+        course_key_func = attrgetter('course_key')
+        by_course = itertools.groupby(
+            sorted(block_keys, key=course_key_func),
+            course_key_func,
+        )
+
+        for course_key, usage_keys in by_course:
+            not_cached = []
+            for usage_key in usage_keys:
+                if usage_key in self._student_module_cache:
+                    yield self._student_module_cache[usage_key]
+                else:
+                    not_cached.append(usage_key)
+
+            query = StudentModule.objects.chunked_filter(
+                'module_state_key__in',
+                not_cached,
+                student__username=username,
+                course_id=course_key,
+            )
+
+            for student_module in query:
+                usage_key = student_module.module_state_key.map_into_course(student_module.course_id)
+                self._student_module_cache[usage_key] = student_module
+                yield (student_module, usage_key)
+
+
+    def get_many(self, username, block_keys, scope=Scope.user_state, fields=None):
         """
         Retrieve the stored XBlock state for a single xblock usage.
 
@@ -78,11 +142,19 @@ class DjangoXBlockUserStateClient(DjangoXBlockUserStateClient):
             (UsageKey, field_state) tuples for each specified UsageKey in block_keys.
             field_state is a dict mapping field names to values.
         """
+        assert self.user.username == username
         if scope != Scope.user_state:
-            raise ValueError("Only Scope.user_state is supported")
-        raise NotImplementedError()
+            raise ValueError("Only Scope.user_state is supported, not {}".format(scope))
 
-    def set_many(username, block_keys_to_state, scope=Scope.user_state):
+        modules = self._get_field_objects(username, block_keys)
+        for module, usage_key in modules:
+            if module.state is None:
+                state = {}
+            else:
+                state = json.loads(module.state)
+            yield (usage_key, state)
+
+    def set_many(self, username, block_keys_to_state, scope=Scope.user_state):
         """
         Set fields for a particular XBlock.
 
@@ -94,17 +166,75 @@ class DjangoXBlockUserStateClient(DjangoXBlockUserStateClient):
                 :meth:`delete` or :meth:`delete_many`.
             scope (Scope): The scope to load data from
         """
+        assert self.user.username == username
         if scope != Scope.user_state:
             raise ValueError("Only Scope.user_state is supported")
-        raise NotImplementedError()
 
-    def get_history(username, block_key, scope=Scope.user_state):
+        field_objects = self._get_field_objects(username, block_keys_to_state.keys())
+        for field_object in field_objects:
+            usage_key = field_object.module_state_key.map_into_course(field_object.course_id)
+            current_state = json.loads(field_object.state)
+            current_state.update(block_keys_to_state.pop(usage_key))
+            field_object.state = json.dumps(current_state)
+            field_object.save()
+
+        for usage_key, state in block_keys_to_state.items():
+            student_module, created = StudentModule.objects.get_or_create(
+                student=self.user,
+                course_id=usage_key.course_key,
+                module_state_key=usage_key,
+                defaults={
+                    'state': json.dumps(state),
+                    'module_type': usage_key.block_type,
+                },
+            )
+
+            if not created:
+                if student_module.state is None:
+                    current_state = {}
+                else:
+                    current_state = json.loads(student_module.state)
+                current_state.update(state)
+                student_module.state = json.dumps(current_state)
+                # We just read this object, so we know that we can do an update
+                student_module.save(force_update=True)
+
+    def delete_many(self, username, block_keys, scope=Scope.user_state, fields=None):
+        """
+        Delete the stored XBlock state for a many xblock usages.
+
+        Arguments:
+            username: The name of the user whose state should be deleted
+            block_key (UsageKey): The UsageKey identifying which xblock state to delete.
+            scope (Scope): The scope to delete data from
+            fields: A list of fields to delete. If None, delete all stored fields.
+        """
+        assert self.user.username == username
+        if scope != Scope.user_state:
+            raise ValueError("Only Scope.user_state is supported")
+
+        student_modules = self._get_field_objects(username, block_keys)
+        for student_module, _ in student_modules:
+            if fields is None:
+                field_object.state = "{}"
+            else:
+                current_state = json.loads(field_object.state)
+                for field in fields:
+                    if field in current_state:
+                        del current_state[field]
+
+                student_module.state = json.dumps(current_state)
+            # We just read this object, so we know that we can do an update
+            student_module.save(force_update=True)
+
+    def get_history(self, username, block_key, scope=Scope.user_state):
         """We don't guarantee that history for many blocks will be fast."""
+        assert self.user.username == username
         if scope != Scope.user_state:
             raise ValueError("Only Scope.user_state is supported")
         raise NotImplementedError()
 
-    def iter_all_for_block(block_key, scope=Scope.user_state, batch_size=None):
+    def iter_all_for_block(self, block_key, scope=Scope.user_state, batch_size=None):
         """
         You get no ordering guarantees. Fetching will happen in batch_size
         increments. If you're using this method, you should be running in an
@@ -114,7 +244,7 @@ class DjangoXBlockUserStateClient(DjangoXBlockUserStateClient):
             raise ValueError("Only Scope.user_state is supported")
         raise NotImplementedError()
 
-    def iter_all_for_course(course_key, block_type=None, scope=Scope.user_state, batch_size=None):
+    def iter_all_for_course(self, course_key, block_type=None, scope=Scope.user_state, batch_size=None):
         """
         You get no ordering guarantees. Fetching will happen in batch_size
         increments. If you're using this method, you should be running in an

--- a/lms/djangoapps/courseware/user_state_client.py
+++ b/lms/djangoapps/courseware/user_state_client.py
@@ -136,7 +136,7 @@ class DjangoXBlockUserStateClient(XBlockUserStateClient):
         }
 
     @contract(username="basestring", block_keys="seq(UsageKey)|set(UsageKey)")
-    def _get_field_objects(self, username, block_keys):
+    def _get_student_modules(self, username, block_keys):
         """
         Retrieve the :class:`~StudentModule`s for the supplied ``username`` and ``block_keys``.
 
@@ -186,7 +186,7 @@ class DjangoXBlockUserStateClient(XBlockUserStateClient):
         if scope != Scope.user_state:
             raise ValueError("Only Scope.user_state is supported, not {}".format(scope))
 
-        modules = self._get_field_objects(username, block_keys)
+        modules = self._get_student_modules(username, block_keys)
         for module, usage_key in modules:
             if module.state is None:
                 state = {}
@@ -256,12 +256,12 @@ class DjangoXBlockUserStateClient(XBlockUserStateClient):
         if scope != Scope.user_state:
             raise ValueError("Only Scope.user_state is supported")
 
-        student_modules = self._get_field_objects(username, block_keys)
+        student_modules = self._get_student_modules(username, block_keys)
         for student_module, _ in student_modules:
             if fields is None:
-                field_object.state = "{}"
+                student_module.state = "{}"
             else:
-                current_state = json.loads(field_object.state)
+                current_state = json.loads(student_module.state)
                 for field in fields:
                     if field in current_state:
                         del current_state[field]
@@ -295,13 +295,13 @@ class DjangoXBlockUserStateClient(XBlockUserStateClient):
         if scope != Scope.user_state:
             raise ValueError("Only Scope.user_state is supported")
 
-        field_objects = self._get_field_objects(username, block_keys)
-        for field_object, usage_key in field_objects:
-            if field_object.state is None:
+        student_modules = self._get_student_modules(username, block_keys)
+        for student_module, usage_key in student_modules:
+            if student_module.state is None:
                 continue
 
-            for field in json.loads(field_object.state):
-                yield (usage_key, field, field_object.modified)
+            for field in json.loads(student_module.state):
+                yield (usage_key, field, student_module.modified)
 
     def get_history(self, username, block_key, scope=Scope.user_state):
         """We don't guarantee that history for many blocks will be fast."""

--- a/lms/djangoapps/courseware/user_state_client.py
+++ b/lms/djangoapps/courseware/user_state_client.py
@@ -11,9 +11,13 @@ try:
 except ImportError:
     import json
 
-from xblock.fields import Scope
+from xblock.fields import Scope, ScopeBase
 from xblock_user_state.interface import XBlockUserStateClient
 from courseware.models import StudentModule
+from contracts import contract, new_contract
+from opaque_keys.edx.keys import UsageKey
+
+new_contract('UsageKey', UsageKey)
 
 
 class DjangoXBlockUserStateClient(XBlockUserStateClient):
@@ -42,6 +46,12 @@ class DjangoXBlockUserStateClient(XBlockUserStateClient):
     def __init__(self, user):
         self.user = user
 
+    @contract(
+        username="basestring",
+        block_key=UsageKey,
+        scope=ScopeBase,
+        fields="seq(basestring)|set(basestring)|None"
+    )
     def get(self, username, block_key, scope=Scope.user_state, fields=None):
         """
         Retrieve the stored XBlock state for a single xblock usage.
@@ -66,6 +76,7 @@ class DjangoXBlockUserStateClient(XBlockUserStateClient):
 
         return state
 
+    @contract(username="basestring", block_key=UsageKey, state="dict(basestring: *)", scope=ScopeBase)
     def set(self, username, block_key, state, scope=Scope.user_state):
         """
         Set fields for a particular XBlock.
@@ -79,6 +90,12 @@ class DjangoXBlockUserStateClient(XBlockUserStateClient):
         assert self.user.username == username
         self.set_many(username, {block_key: state}, scope)
 
+    @contract(
+        username="basestring",
+        block_key=UsageKey,
+        scope=ScopeBase,
+        fields="seq(basestring)|set(basestring)|None"
+    )
     def delete(self, username, block_key, scope=Scope.user_state, fields=None):
         """
         Delete the stored XBlock state for a single xblock usage.
@@ -92,7 +109,12 @@ class DjangoXBlockUserStateClient(XBlockUserStateClient):
         assert self.user.username == username
         return self.delete_many(username, [block_key], scope, fields=fields)
 
-    @contract(username="basestring", block_key=UsageKey, scope=ScopeBase, fields="seq(basestring)|set(basestring)|None")
+    @contract(
+        username="basestring",
+        block_key=UsageKey,
+        scope=ScopeBase,
+        fields="seq(basestring)|set(basestring)|None"
+    )
     def get_mod_date(self, username, block_key, scope=Scope.user_state, fields=None):
         """
         Get the last modification date for fields from the specified blocks.
@@ -140,7 +162,12 @@ class DjangoXBlockUserStateClient(XBlockUserStateClient):
                 usage_key = student_module.module_state_key.map_into_course(student_module.course_id)
                 yield (student_module, usage_key)
 
-
+    @contract(
+        username="basestring",
+        block_keys="seq(UsageKey)|set(UsageKey)",
+        scope=ScopeBase,
+        fields="seq(basestring)|set(basestring)|None"
+    )
     def get_many(self, username, block_keys, scope=Scope.user_state, fields=None):
         """
         Retrieve the stored XBlock state for a single xblock usage.
@@ -167,6 +194,7 @@ class DjangoXBlockUserStateClient(XBlockUserStateClient):
                 state = json.loads(module.state)
             yield (usage_key, state)
 
+    @contract(username="basestring", block_keys_to_state="dict(UsageKey: dict(basestring: *))", scope=ScopeBase)
     def set_many(self, username, block_keys_to_state, scope=Scope.user_state):
         """
         Set fields for a particular XBlock.
@@ -208,6 +236,12 @@ class DjangoXBlockUserStateClient(XBlockUserStateClient):
                 # We just read this object, so we know that we can do an update
                 student_module.save(force_update=True)
 
+    @contract(
+        username="basestring",
+        block_keys="seq(UsageKey)|set(UsageKey)",
+        scope=ScopeBase,
+        fields="seq(basestring)|set(basestring)|None"
+    )
     def delete_many(self, username, block_keys, scope=Scope.user_state, fields=None):
         """
         Delete the stored XBlock state for a many xblock usages.

--- a/lms/djangoapps/courseware/user_state_client.py
+++ b/lms/djangoapps/courseware/user_state_client.py
@@ -29,19 +29,71 @@ class DjangoXBlockUserStateClient(DjangoXBlockUserStateClient):
         """
         pass
 
-    def get(username, block_key, scope=Scope.user_state):
-        return self.get_many(username, [block_key], scope)
+    def get(username, block_key, scope=Scope.user_state, fields=None):
+        """
+        Retrieve the stored XBlock state for a single xblock usage.
+
+        Arguments:
+            username: The name of the user whose state should be retrieved
+            block_key (UsageKey): The UsageKey identifying which xblock state to load.
+            scope (Scope): The scope to load data from
+            fields: A list of field values to retrieve. If None, retrieve all stored fields.
+
+        Returns:
+            dict: A dictionary mapping field names to values
+
+        Raises:
+            DoesNotExist if no entry is found.
+        """
+        try:
+            _usage_key, state = next(self.get_many(username, [block_key], scope, fields=fields))
+        except StopIteration:
+            raise self.DoesNotExist()
+
+        return state
 
     def set(username, block_key, state, scope=Scope.user_state):
+        """
+        Set fields for a particular XBlock.
+
+        Arguments:
+            username: The name of the user whose state should be retrieved
+            block_key (UsageKey): The UsageKey identifying which xblock state to load.
+            state (dict): A dictionary mapping field names to values
+            scope (Scope): The scope to load data from
+        """
         self.set_many(username, {block_key: state}, scope)
 
-    def get_many(username, block_keys, scope=Scope.user_state):
-        """Returns dict of block_id -> state."""
+    def get_many(username, block_keys, scope=Scope.user_state, fields=None):
+        """
+        Retrieve the stored XBlock state for a single xblock usage.
+
+        Arguments:
+            username: The name of the user whose state should be retrieved
+            block_keys ([UsageKey]): A list of UsageKeys identifying which xblock states to load.
+            scope (Scope): The scope to load data from
+            fields: A list of field values to retrieve. If None, retrieve all stored fields.
+
+        Yields:
+            (UsageKey, field_state) tuples for each specified UsageKey in block_keys.
+            field_state is a dict mapping field names to values.
+        """
         if scope != Scope.user_state:
             raise ValueError("Only Scope.user_state is supported")
         raise NotImplementedError()
 
     def set_many(username, block_keys_to_state, scope=Scope.user_state):
+        """
+        Set fields for a particular XBlock.
+
+        Arguments:
+            username: The name of the user whose state should be retrieved
+            block_keys_to_state (dict): A dict mapping UsageKeys to state dicts.
+                Each state dict maps field names to values. These state dicts
+                are overlaid over the stored state. To delete fields, use
+                :meth:`delete` or :meth:`delete_many`.
+            scope (Scope): The scope to load data from
+        """
         if scope != Scope.user_state:
             raise ValueError("Only Scope.user_state is supported")
         raise NotImplementedError()

--- a/lms/djangoapps/lms_xblock/test/test_runtime.py
+++ b/lms/djangoapps/lms_xblock/test/test_runtime.py
@@ -11,6 +11,7 @@ from urlparse import urlparse
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
 from lms.djangoapps.lms_xblock.runtime import quote_slashes, unquote_slashes, LmsModuleSystem
 from xblock.fields import ScopeIds
+from xmodule.x_module import DescriptorSystem
 
 TEST_STRINGS = [
     '',
@@ -48,12 +49,12 @@ class TestHandlerUrl(TestCase):
         self.course_key = SlashSeparatedCourseKey("org", "course", "run")
         self.runtime = LmsModuleSystem(
             static_url='/static',
-            track_function=Mock(),
-            get_module=Mock(),
-            render_template=Mock(),
+            track_function=Mock(name='track_function'),
+            get_module=Mock(name='get_module'),
+            render_template=Mock(name='render_template'),
             replace_urls=str,
             course_id=self.course_key,
-            descriptor_runtime=Mock(),
+            descriptor_runtime=Mock(spec=DescriptorSystem, name='descriptor_runtime'),
         )
 
     def test_trailing_characters(self):
@@ -120,13 +121,13 @@ class TestUserServiceAPI(TestCase):
 
         self.runtime = LmsModuleSystem(
             static_url='/static',
-            track_function=Mock(),
-            get_module=Mock(),
-            render_template=Mock(),
+            track_function=Mock(name="track_function"),
+            get_module=Mock(name="get_module"),
+            render_template=Mock(name="render_template"),
             replace_urls=str,
             course_id=self.course_id,
             get_real_user=mock_get_real_user,
-            descriptor_runtime=Mock(),
+            descriptor_runtime=Mock(spec=DescriptorSystem, name="descriptor_runtime"),
         )
         self.scope = 'course'
         self.key = 'key1'

--- a/lms/djangoapps/mobile_api/users/views.py
+++ b/lms/djangoapps/mobile_api/users/views.py
@@ -149,12 +149,10 @@ class UserCourseStatus(views.APIView):
                 block_scope_id=course.location,
                 field_name=None
             )
-            student_module = field_data_cache.find(key)
-            if student_module:
-                original_store_date = student_module.modified
-                if modification_date < original_store_date:
-                    # old modification date so skip update
-                    return self._get_course_info(request, course)
+            original_store_date = field_data_cache.last_modified(key)
+            if original_store_date is not None and modification_date < original_store_date:
+                # old modification date so skip update
+                return self._get_course_info(request, course)
 
         save_positions_recursively_up(request.user, request, field_data_cache, module)
         return self._get_course_info(request, course)

--- a/lms/djangoapps/mobile_api/users/views.py
+++ b/lms/djangoapps/mobile_api/users/views.py
@@ -147,7 +147,7 @@ class UserCourseStatus(views.APIView):
                 scope=Scope.user_state,
                 user_id=request.user.id,
                 block_scope_id=course.location,
-                field_name=None
+                field_name='position'
             )
             original_store_date = field_data_cache.last_modified(key)
             if original_store_date is not None and modification_date < original_store_date:

--- a/lms/djangoapps/open_ended_grading/tests.py
+++ b/lms/djangoapps/open_ended_grading/tests.py
@@ -24,6 +24,7 @@ from lms.djangoapps.lms_xblock.runtime import LmsModuleSystem
 from student.roles import CourseStaffRole
 from student.models import unique_id_for_user
 from xmodule import peer_grading_module
+from xmodule.x_module import DescriptorSystem
 from xmodule.error_module import ErrorDescriptor
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
@@ -288,7 +289,7 @@ class TestPeerGradingService(ModuleStoreTestCase, LoginEnrollmentTestCase):
             open_ended_grading_interface=test_util_open_ended.OPEN_ENDED_GRADING_INTERFACE,
             mixins=settings.XBLOCK_MIXINS,
             error_descriptor_class=ErrorDescriptor,
-            descriptor_runtime=None,
+            descriptor_runtime=Mock(spec=DescriptorSystem, name="descriptor_runtime"),
         )
         self.descriptor = peer_grading_module.PeerGradingDescriptor(self.system, field_data, ScopeIds(None, None, None, None))
         self.descriptor.xmodule_runtime = self.system

--- a/lms/djangoapps/xblock_user_state/interface.py
+++ b/lms/djangoapps/xblock_user_state/interface.py
@@ -1,0 +1,254 @@
+"""
+A baseclass for a generic client for accessing XBlock Scope.user_state field data.
+"""
+
+from abc import abstractmethod
+
+from contracts import contract, new_contract, ContractsMeta
+from opaque_keys.edx.keys import UsageKey
+from xblock.fields import Scope, ScopeBase
+
+new_contract('UsageKey', UsageKey)
+
+class XBlockUserStateClient(object):
+    """
+    First stab at an interface for accessing XBlock User State. This will have
+    use StudentModule as a backing store in the default case.
+
+    Scope/Goals:
+    1. Mediate access to all student-specific state stored by XBlocks.
+        a. This includes "preferences" and "user_info" (i.e. UserScope.ONE)
+        b. This includes XBlock Asides.
+        c. This may later include user_state_summary (i.e. UserScope.ALL).
+        d. This may include group state in the future.
+        e. This may include other key types + UserScope.ONE (e.g. Definition)
+    2. Assume network service semantics.
+        At some point, this will probably be calling out to an external service.
+        Even if it doesn't, we want to be able to implement circuit breakers, so
+        that a failure in StudentModule doesn't bring down the whole site.
+        This also implies that the client is running as a user, and whatever is
+        backing it is smart enough to do authorization checks.
+    3. This does not yet cover export-related functionality.
+
+    Open Questions:
+    1. Is it sufficient to just send the block_key in and extract course +
+       version info from it?
+    2. Do we want to use the username as the identifier? Privacy implications?
+       Ease of debugging?
+    3. Would a get_many_by_type() be useful?
+    """
+
+    __metaclass__ = ContractsMeta
+
+    class ServiceUnavailable(Exception):
+        """
+        This error is raised if the service backing this client is currently unavailable.
+        """
+        pass
+
+    class PermissionDenied(Exception):
+        """
+        This error is raised if the caller is not allowed to access the requested data.
+        """
+        pass
+
+    class DoesNotExist(Exception):
+        """
+        This error is raised if the caller has requested data that does not exist.
+        """
+        pass
+
+    @contract(
+        username="basestring",
+        block_key=UsageKey,
+        scope=ScopeBase,
+        fields="seq(basestring)|set(basestring)|None",
+        returns="dict(basestring: *)"
+    )
+    def get(self, username, block_key, scope=Scope.user_state, fields=None):
+        """
+        Retrieve the stored XBlock state for a single xblock usage.
+
+        Arguments:
+            username: The name of the user whose state should be retrieved
+            block_key (UsageKey): The UsageKey identifying which xblock state to load.
+            scope (Scope): The scope to load data from
+            fields: A list of field values to retrieve. If None, retrieve all stored fields.
+
+        Returns
+            dict: A dictionary mapping field names to values
+        """
+        return next(self.get_many(username, [block_key], scope, fields=fields))[1]
+
+    @contract(
+        username="basestring",
+        block_key=UsageKey,
+        state="dict(basestring: *)",
+        scope=ScopeBase,
+        returns=None,
+    )
+    def set(self, username, block_key, state, scope=Scope.user_state):
+        """
+        Set fields for a particular XBlock.
+
+        Arguments:
+            username: The name of the user whose state should be retrieved
+            block_key (UsageKey): The UsageKey identifying which xblock state to load.
+            state (dict): A dictionary mapping field names to values
+            scope (Scope): The scope to store data to
+        """
+        self.set_many(username, {block_key: state}, scope)
+
+    @contract(
+        username="basestring",
+        block_key=UsageKey,
+        scope=ScopeBase,
+        fields="seq(basestring)|set(basestring)|None",
+        returns=None,
+    )
+    def delete(self, username, block_key, scope=Scope.user_state, fields=None):
+        """
+        Delete the stored XBlock state for a single xblock usage.
+
+        Arguments:
+            username: The name of the user whose state should be deleted
+            block_key (UsageKey): The UsageKey identifying which xblock state to delete.
+            scope (Scope): The scope to delete data from
+            fields: A list of fields to delete. If None, delete all stored fields.
+        """
+        return self.delete_many(username, [block_key], scope, fields=fields)
+
+    @contract(
+        username="basestring",
+        block_key=UsageKey,
+        scope=ScopeBase,
+        fields="seq(basestring)|set(basestring)|None",
+        returns="dict(basestring: datetime)",
+    )
+    def get_mod_date(self, username, block_key, scope=Scope.user_state, fields=None):
+        """
+        Get the last modification date for fields from the specified blocks.
+
+        Arguments:
+            username: The name of the user whose state should queried
+            block_key (UsageKey): The UsageKey identifying which xblock modification dates to retrieve.
+            scope (Scope): The scope to retrieve from.
+            fields: A list of fields to query. If None, query all fields.
+                Specific implementations are free to return the same modification date
+                for all fields, if they don't store changes individually per field.
+                Implementations may omit fields for which data has not been stored.
+
+        Returns: list a dict of {field_name: modified_date} for each selected field.
+        """
+        results = self.get_mod_date_many(username, [block_key], scope, fields=fields)
+        return {
+            field: date for (_, field, date) in results
+        }
+
+    @contract(
+        username="basestring",
+        block_keys="seq(UsageKey)|set(UsageKey)",
+        scope=ScopeBase,
+        fields="seq(basestring)|set(basestring)|None",
+    )
+    @abstractmethod
+    def get_many(self, username, block_keys, scope=Scope.user_state, fields=None):
+        """
+        Retrieve the stored XBlock state for a single xblock usage.
+
+        Arguments:
+            username: The name of the user whose state should be retrieved
+            block_keys ([UsageKey]): A list of UsageKeys identifying which xblock states to load.
+            scope (Scope): The scope to load data from
+            fields: A list of field values to retrieve. If None, retrieve all stored fields.
+
+        Yields:
+            (UsageKey, field_state) tuples for each specified UsageKey in block_keys.
+            field_state is a dict mapping field names to values.
+        """
+        raise NotImplementedError()
+
+    @contract(
+        username="basestring",
+        block_keys_to_state="dict(UsageKey: dict(basestring: *))",
+        scope=ScopeBase,
+        returns=None,
+    )
+    @abstractmethod
+    def set_many(self, username, block_keys_to_state, scope=Scope.user_state):
+        """
+        Set fields for a particular XBlock.
+
+        Arguments:
+            username: The name of the user whose state should be retrieved
+            block_keys_to_state (dict): A dict mapping UsageKeys to state dicts.
+                Each state dict maps field names to values. These state dicts
+                are overlaid over the stored state. To delete fields, use
+                :meth:`delete` or :meth:`delete_many`.
+            scope (Scope): The scope to load data from
+        """
+        raise NotImplementedError()
+
+    @contract(
+        username="basestring",
+        block_keys="seq(UsageKey)|set(UsageKey)",
+        scope=ScopeBase,
+        fields="seq(basestring)|set(basestring)|None",
+        returns=None,
+    )
+    @abstractmethod
+    def delete_many(self, username, block_keys, scope=Scope.user_state, fields=None):
+        """
+        Delete the stored XBlock state for a many xblock usages.
+
+        Arguments:
+            username: The name of the user whose state should be deleted
+            block_key (UsageKey): The UsageKey identifying which xblock state to delete.
+            scope (Scope): The scope to delete data from
+            fields: A list of fields to delete. If None, delete all stored fields.
+        """
+        raise NotImplementedError()
+
+    @contract(
+        username="basestring",
+        block_keys="seq(UsageKey)|set(UsageKey)",
+        scope=ScopeBase,
+        fields="seq(basestring)|set(basestring)|None",
+    )
+    @abstractmethod
+    def get_mod_date_many(self, username, block_keys, scope=Scope.user_state, fields=None):
+        """
+        Get the last modification date for fields from the specified blocks.
+
+        Arguments:
+            username: The name of the user whose state should be queried
+            block_key (UsageKey): The UsageKey identifying which xblock modification dates to retrieve.
+            scope (Scope): The scope to retrieve from.
+            fields: A list of fields to query. If None, delete all stored fields.
+                Specific implementations are free to return the same modification date
+                for all fields, if they don't store changes individually per field.
+                Implementations may omit fields for which data has not been stored.
+
+        Yields: tuples of (block, field_name, modified_date) for each selected field.
+        """
+        raise NotImplementedError()
+
+    def get_history(self, username, block_key, scope=Scope.user_state):
+        """We don't guarantee that history for many blocks will be fast."""
+        raise NotImplementedError()
+
+    def iter_all_for_block(self, block_key, scope=Scope.user_state, batch_size=None):
+        """
+        You get no ordering guarantees. Fetching will happen in batch_size
+        increments. If you're using this method, you should be running in an
+        async task.
+        """
+        raise NotImplementedError()
+
+    def iter_all_for_course(self, course_key, block_type=None, scope=Scope.user_state, batch_size=None):
+        """
+        You get no ordering guarantees. Fetching will happen in batch_size
+        increments. If you're using this method, you should be running in an
+        async task.
+        """
+        raise NotImplementedError()

--- a/lms/djangoapps/xblock_user_state/interface.py
+++ b/lms/djangoapps/xblock_user_state/interface.py
@@ -10,6 +10,7 @@ from xblock.fields import Scope, ScopeBase
 
 new_contract('UsageKey', UsageKey)
 
+
 class XBlockUserStateClient(object):
     """
     First stab at an interface for accessing XBlock User State. This will have

--- a/manage.py
+++ b/manage.py
@@ -113,4 +113,5 @@ if __name__ == "__main__":
 
     from django.core.management import execute_from_command_line
 
-    execute_from_command_line([sys.argv[0]] + django_args)
+    sys.argv[1:] = django_args
+    execute_from_command_line(sys.argv)

--- a/pavelib/utils/test/suites/nose_suite.py
+++ b/pavelib/utils/test/suites/nose_suite.py
@@ -120,7 +120,7 @@ class SystemTestSuite(NoseTestSuite):
     @property
     def cmd(self):
         cmd = (
-            './manage.py {system} test --verbosity={verbosity} '
+            './manage.py {system} --contracts test --verbosity={verbosity} '
             '{test_id} {test_opts} --traceback --settings=test {extra} '
             '--with-xunit --xunit-file={xunit_report}'.format(
                 system=self.root,

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -29,7 +29,7 @@ git+https://github.com/pmitros/pyfs.git@96e1922348bfe6d99201b9512a9ed946c87b7e0b
 git+https://github.com/hmarr/django-debug-toolbar-mongo.git@b0686a76f1ce3532088c4aee6e76b9abe61cc808
 
 # Our libraries:
--e git+https://github.com/edx/XBlock.git@1934a2978cdd3e2414486c74b76e3040ff1fb138#egg=XBlock
+-e git+https://github.com/cpennington/XBlock.git@e9c4d441d1eaf7c9f176b873fe23e24c1152dba6#egg=XBlock
 -e git+https://github.com/edx/codejail.git@6b17c33a89bef0ac510926b1d7fea2748b73aadd#egg=codejail
 -e git+https://github.com/edx/js-test-tool.git@v0.1.6#egg=js_test_tool
 -e git+https://github.com/edx/event-tracking.git@0.2.0#egg=event-tracking


### PR DESCRIPTION
This PR is the first step in swapping the backing store for XBlock `Scope.user_state` from being stored in `courseware.models.StudentModel` to a more performant/scalable backend. The goal of this particular PR is to isolate all access to `StudentModel` used for loading XBlocks field state (by the LMS) behind a single interface which we believe that we can write additional backends to.
