### PR TITLE
Visually hidden content accessible through keyboard

### DIFF
--- a/cms/static/sass/elements/_forms.scss
+++ b/cms/static/sass/elements/_forms.scss
@@ -434,20 +434,18 @@ form {
 // +Form - Create New Wrapper 
 // ==================== 
 .wrapper-create-element {
-  height: 0;
-  opacity: 0.0;
-  pointer-events: none;
+  height: auto;
+  opacity: 1.0;
+  pointer-events: auto;
   overflow: hidden;
+  display: none;
 
   &.animate {
     @include transition(opacity $tmg-f1 ease-in-out 0s, height $tmg-f1 ease-in-out 0s);
   }
 
   &.is-shown {
-    height: auto; // define a specific height for the animating version of this UI to work properly
-    margin-bottom: $baseline;
-    opacity: 1.0;
-    pointer-events: auto;
+    display: block;
   }
 }
 


### PR DESCRIPTION
The "New Course" and "New Library" buttons reveal a form to add course or library.
When not displayed, these forms are still accessible to a keyboard user.
Added display: "none" in css so that contents are visually as well as via
keyboard inaccessible

AC-34
