### PR TITLE
PEP8 needs to ignore .git

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,4 +29,4 @@ no-path-adjustment=1
 #   It's a little unusual, but we have good reasons for doing so, so we disable
 #   this rule.
 ignore=E501,E265,W602
-exclude=migrations
+exclude=migrations,.git


### PR DESCRIPTION
If you have a branch called "fix-something.py", then the .git directory has a file called fix-something.py somewhere in it, and pep8 complains.
