### PR TITLE
Fix for DB table conflict preventing DB update on fresh installs

### DIFF
--- a/requirements/edx/edx-private.txt
+++ b/requirements/edx/edx-private.txt
@@ -2,7 +2,7 @@
 
 # For Harvard courses:
 -e git+https://github.com/gsehub/xblock-mentoring.git@4d1cce78dc232d5da6ffd73817b5c490e87a6eee#egg=xblock-mentoring
--e git+https://github.com/open-craft/problem-builder.git@4817f9d93f8ce07bbe496f4e1681450f26ef9d19#egg=xblock-problem-builder
+-e git+https://github.com/open-craft/problem-builder.git@d7ab348db5292e5840673bac51dfaf0c492b4083#egg=xblock-problem-builder
 
 # Prototype XBlocks from edX learning sciences limited roll-outs and user testing.
 # Concept XBlock, in particular, is nowhere near finished and an early prototype.


### PR DESCRIPTION
**Description**: Two XBlocks specified in `edx-private.txt` both contain Django apps that try to create a table called `mentoring_answers`. This causes South to abort its migrations in some cases, due to the table already existing. Full details are in https://github.com/open-craft/problem-builder/pull/18

This fix renames the table used by Problem Builder, so that there is no longer any conflict. It includes a data migration in case any important student data was saved to the old table.

Problem reported by @maxrothman.

**JIRA**: [OSPR-547](https://openedx.atlassian.net/browse/OSPR-547)

**Discussions**: Fix discussed with @nedbat on HipChat 'dev' channel.

**Internal Review**: Not done yet

**Merge deadline**: ASAP since it blocks DB sync on fresh installs.

**Partner information**: hosted on edx.org (Harvard)

**Sandbox**: I tested the DB update when neither table existed using http://sandbox2.opencraft.com:18010/

**Note**: This should not be merged until https://github.com/open-craft/problem-builder/pull/18 is merged, and the hash updated.
