### PR TITLE
Videos should emit `stop_video` event once the video segment is compelte...

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/video/03_video_player.js
+++ b/common/lib/xmodule/xmodule/js/src/video/03_video_player.js
@@ -49,7 +49,8 @@ function (HTML5Video, Resizer) {
             update: update,
             figureOutStartEndTime: figureOutStartEndTime,
             figureOutStartingTime: figureOutStartingTime,
-            updatePlayTime: updatePlayTime
+            updatePlayTime: updatePlayTime,
+            logStopVideo:logStopVideo
         };
 
     VideoPlayer.prototype = methodsDict;
@@ -348,6 +349,8 @@ function (HTML5Video, Resizer) {
                 this.trigger('videoProgressSlider.notifyThroughHandleEnd', {
                     end: true
                 });
+                // Emit `stop_video` event
+                this.videoPlayer.logStopVideo();
             }
         }
     }
@@ -531,12 +534,7 @@ function (HTML5Video, Resizer) {
 
     function onEnded() {
         var time = this.videoPlayer.duration();
-        this.videoPlayer.log(
-            'stop_video',
-            {
-                currentTime: this.videoPlayer.currentTime
-            }
-        );
+        this.videoPlayer.logStopVideo();
 
         this.trigger('videoControl.pause', null);
         this.trigger('videoProgressSlider.notifyThroughHandleEnd', {
@@ -591,6 +589,15 @@ function (HTML5Video, Resizer) {
 
     function handlePlaybackQualityChange(value) {
         this.videoPlayer.player.setPlaybackQuality(value);
+    }
+
+    function logStopVideo(){
+        this.videoPlayer.log(
+            'stop_video',
+            {
+                currentTime: this.videoPlayer.currentTime
+            }
+        );
     }
 
     function onPlaybackQualityChange() {


### PR DESCRIPTION
`stop_video` event was not emitted for video segments, fixed by adding `logStopVideo` method & calling when a `play-time` reaches `end-time`

Tests are present and disabled for verifying if events are emitted for segmented videos with the follwing comment by Will Daly.

`Disabled 1/13/14 due to flakiness observed in master` 
### Reference:

`common/lib/xmodule/xmodule/js/spec/video/video_player_spec.js:575`

[TNL-2008](https://openedx.atlassian.net/browse/TNL-2008)
