### PR TITLE
[LTI Provider] Wiring up LTI views to the courseware template

### DIFF
--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -815,7 +815,7 @@ def xblock_resource(request, block_type, uri):  # pylint: disable=unused-argumen
     return HttpResponse(content, mimetype=mimetype)
 
 
-def _get_module_by_usage_id(request, course_id, usage_id):
+def get_module_by_usage_id(request, course_id, usage_id):
     """
     Gets a module instance based on its `usage_id` in a course, for a given request/user
 
@@ -887,7 +887,7 @@ def _invoke_xblock_handler(request, course_id, usage_id, handler, suffix):
     if error_msg:
         return JsonResponse(object={'success': error_msg}, status=413)
 
-    instance, tracking_context = _get_module_by_usage_id(request, course_id, usage_id)
+    instance, tracking_context = get_module_by_usage_id(request, course_id, usage_id)
 
     tracking_context_name = 'module_callback_handler'
     req = django_to_webob_request(request)
@@ -945,7 +945,7 @@ def xblock_view(request, course_id, usage_id, view_name):
     if not request.user.is_authenticated():
         raise PermissionDenied
 
-    instance, _ = _get_module_by_usage_id(request, course_id, usage_id)
+    instance, _ = get_module_by_usage_id(request, course_id, usage_id)
 
     try:
         fragment = instance.render(view_name, context=request.GET)

--- a/lms/djangoapps/lti_provider/tests/test_views.py
+++ b/lms/djangoapps/lti_provider/tests/test_views.py
@@ -29,7 +29,7 @@ COURSE_PARAMS = {
 }
 
 
-ALL_PARAMS = dict(list(LTI_DEFAULT_PARAMS.items()) + list(COURSE_PARAMS.items()))
+ALL_PARAMS = dict(LTI_DEFAULT_PARAMS.items() + COURSE_PARAMS.items())
 
 
 def build_launch_request(authenticated=True):
@@ -192,21 +192,35 @@ class LtiRunTest(TestCase):
         self.assertNotIn(views.LTI_SESSION_KEY, request.session)
 
 
-MODULE_INSTANCE = MagicMock()
-MODULE_INSTANCE.render = MagicMock(return_value='Fragment')
-
-
-@patch('lti_provider.views.render_to_response', return_value='Rendered page')
-@patch('lti_provider.views.get_module_by_usage_id', return_value=(MODULE_INSTANCE, None))
-@patch('lti_provider.views.has_access', return_value='StaffAccess')
-@patch('lti_provider.views.get_course_with_access', return_value='CourseWithAccess')
-@patch('lti_provider.views.CourseKey.from_string', return_value='CourseKey')
 class RenderCoursewareTest(TestCase):
     """
     Tests for the render_courseware method
     """
 
-    def test_valid_launch(self, _key_mock, _course_mock, _access_mock, _module_mock, _render_mock):
+    def setUp(self):
+        """
+        Configure mocks for all the dependencies of the render method
+        """
+        super(RenderCoursewareTest, self).setUp()
+        self.module_instance = MagicMock()
+        self.module_instance.render.return_value = "Fragment"
+        self.render_mock = self.setup_patch('lti_provider.views.render_to_response', 'Rendered page')
+        self.module_mock = self.setup_patch('lti_provider.views.get_module_by_usage_id', (self.module_instance, None))
+        self.access_mock = self.setup_patch('lti_provider.views.has_access', 'StaffAccess')
+        self.course_mock = self.setup_patch('lti_provider.views.get_course_with_access', 'CourseWithAccess')
+        self.key_mock = self.setup_patch('lti_provider.views.CourseKey.from_string', 'CourseKey')
+
+    def setup_patch(self, function_name, return_value):
+        """
+        Patch a method with a given return value, and return the mock
+        """
+        mock = MagicMock(return_value=return_value)
+        new_patch = patch(function_name, new=mock)
+        new_patch.start()
+        self.addCleanup(new_patch.stop)
+        return mock
+
+    def test_valid_launch(self):
         """
         Verify that the method renders a response when launched correctly
         """
@@ -214,47 +228,47 @@ class RenderCoursewareTest(TestCase):
         response = views.render_courseware(request, ALL_PARAMS.copy())
         self.assertEqual(response, 'Rendered page')
 
-    def test_course_key(self, key_mock, _course_mock, _access_mock, _module_mock, _render_mock):
+    def test_course_key(self):
         """
         Verify that the correct course key is requested
         """
         request = build_run_request()
         views.render_courseware(request, ALL_PARAMS.copy())
-        key_mock.assert_called_with(ALL_PARAMS['course_id'])
+        self.key_mock.assert_called_with(ALL_PARAMS['course_id'])
 
-    def test_course_with_access(self, _key_mock, course_mock, _access_mock, _module_mock, _render_mock):
+    def test_course_with_access(self):
         """
         Verify that get_course_with_access is called with the right parameters
         """
         request = build_run_request()
         views.render_courseware(request, ALL_PARAMS.copy())
-        course_mock.assert_called_with(request.user, 'load', 'CourseKey')
+        self.course_mock.assert_called_with(request.user, 'load', 'CourseKey')
 
-    def test_has_access(self, _key_mock, _course_mock, access_mock, _module_mock, _render_mock):
+    def test_has_access(self):
         """
         Verify that has_access is called with the right parameters
         """
         request = build_run_request()
         views.render_courseware(request, ALL_PARAMS.copy())
-        access_mock.assert_called_with(request.user, 'staff', 'CourseWithAccess')
+        self.access_mock.assert_called_with(request.user, 'staff', 'CourseWithAccess')
 
-    def test_get_module(self, _key_mock, _course_mock, _access_mock, module_mock, _render_mock):
+    def test_get_module(self):
         """
         Verify that get_module_by_usage_id is called with the right parameters
         """
         request = build_run_request()
         views.render_courseware(request, ALL_PARAMS.copy())
-        module_mock.assert_called_with(request, ALL_PARAMS['course_id'], ALL_PARAMS['usage_id'])
+        self.module_mock.assert_called_with(request, ALL_PARAMS['course_id'], ALL_PARAMS['usage_id'])
 
-    def test_render(self, _key_mock, _course_mock, _access_mock, _module_mock, _render_mock):
+    def test_render(self):
         """
         Verify that render is called on the right object with the right parameters
         """
         request = build_run_request()
         views.render_courseware(request, ALL_PARAMS.copy())
-        MODULE_INSTANCE.render.assert_called_with('student_view', context={})
+        self.module_instance.render.assert_called_with('student_view', context={})
 
-    def test_context(self, _key_mock, _course_mock, _access_mock, _module_mock, render_mock):
+    def test_context(self):
         expected_context = {
             'fragment': 'Fragment',
             'course': 'CourseWithAccess',
@@ -264,8 +278,8 @@ class RenderCoursewareTest(TestCase):
             'disable_footer': True,
             'disable_tabs': True,
             'staff_access': 'StaffAccess',
-            'xqa_server': 'http://xqa:server@content-qa.mitx.mit.edu/xqa',
+            'xqa_server': 'http://example.com/xqa',
         }
         request = build_run_request()
         views.render_courseware(request, ALL_PARAMS.copy())
-        render_mock.assert_called_with('courseware/courseware.html', expected_context)
+        self.render_mock.assert_called_with('courseware/courseware.html', expected_context)

--- a/lms/djangoapps/lti_provider/tests/test_views.py
+++ b/lms/djangoapps/lti_provider/tests/test_views.py
@@ -23,6 +23,38 @@ LTI_DEFAULT_PARAMS = {
 }
 
 
+COURSE_PARAMS = {
+    'course_id': 'CourseID',
+    'usage_id': 'UsageID'
+}
+
+
+ALL_PARAMS = dict(list(LTI_DEFAULT_PARAMS.items()) + list(COURSE_PARAMS.items()))
+
+
+def build_launch_request(authenticated=True):
+    """
+    Helper method to create a new request object for the LTI launch.
+    """
+    request = RequestFactory().post('/')
+    request.user = UserFactory.create()
+    request.user.is_authenticated = MagicMock(return_value=authenticated)
+    request.session = {}
+    request.POST.update(LTI_DEFAULT_PARAMS)
+    return request
+
+
+def build_run_request(authenticated=True):
+    """
+    Helper method to create a new request object
+    """
+    request = RequestFactory().get('/')
+    request.user = UserFactory.create()
+    request.user.is_authenticated = MagicMock(return_value=authenticated)
+    request.session = {views.LTI_SESSION_KEY: ALL_PARAMS.copy()}
+    return request
+
+
 class LtiLaunchTest(TestCase):
     """
     Tests for the lti_launch view
@@ -34,30 +66,20 @@ class LtiLaunchTest(TestCase):
         # Always accept the OAuth signature
         SignatureValidator.verify = MagicMock(return_value=True)
 
-    def build_request(self, authenticated=True):
-        """
-        Helper method to create a new request object for the LTI launch.
-        """
-        request = RequestFactory().post('/')
-        request.user = UserFactory.create()
-        request.user.is_authenticated = MagicMock(return_value=authenticated)
-        request.session = {}
-        request.POST.update(LTI_DEFAULT_PARAMS)
-        return request
-
-    def test_valid_launch(self):
+    @patch('lti_provider.views.render_courseware')
+    def test_valid_launch(self, render):
         """
         Verifies that the LTI launch succeeds when passed a valid request.
         """
-        request = self.build_request()
-        response = views.lti_launch(request, None, None)
-        self.assertEqual(response.status_code, 200)
+        request = build_launch_request()
+        views.lti_launch(request, COURSE_PARAMS['course_id'], COURSE_PARAMS['usage_id'])
+        render.assert_called_with(request, ALL_PARAMS)
 
     def launch_with_missing_parameter(self, missing_param):
         """
         Helper method to remove a parameter from the LTI launch and call the view
         """
-        request = self.build_request()
+        request = build_launch_request()
         del request.POST[missing_param]
         return views.lti_launch(request, None, None)
 
@@ -79,7 +101,7 @@ class LtiLaunchTest(TestCase):
         is not set
         """
         with patch.dict('django.conf.settings.FEATURES', {'ENABLE_LTI_PROVIDER': False}):
-            request = self.build_request()
+            request = build_launch_request()
             response = views.lti_launch(request, None, None)
             self.assertEqual(response.status_code, 403)
 
@@ -89,8 +111,8 @@ class LtiLaunchTest(TestCase):
         Verifies that the LTI parameters and the course and usage IDs are
         properly stored in the session
         """
-        request = self.build_request()
-        views.lti_launch(request, 'CourseID', 'UsageID')
+        request = build_launch_request()
+        views.lti_launch(request, COURSE_PARAMS['course_id'], COURSE_PARAMS['usage_id'])
         session = request.session[views.LTI_SESSION_KEY]
         self.assertEqual(session['course_id'], 'CourseID', 'Course ID not set in the session')
         self.assertEqual(session['usage_id'], 'UsageID', 'Usage ID not set in the session')
@@ -103,7 +125,7 @@ class LtiLaunchTest(TestCase):
         user, the response will redirect to the login page with the correct
         URL
         """
-        request = self.build_request(False)
+        request = build_launch_request(False)
         response = views.lti_launch(request, None, None)
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response['Location'], '/accounts/login?next=/lti_provider/lti_run')
@@ -114,7 +136,7 @@ class LtiLaunchTest(TestCase):
         incorrect.
         """
         SignatureValidator.verify = MagicMock(return_value=False)
-        request = self.build_request()
+        request = build_launch_request()
         response = views.lti_launch(request, None, None)
         self.assertEqual(response.status_code, 403)
 
@@ -124,32 +146,21 @@ class LtiRunTest(TestCase):
     Tests for the lti_run view
     """
 
-    def build_request(self, authenticated=True):
-        """
-        Helper method to create a new request object
-        """
-        request = RequestFactory().get('/')
-        request.user = UserFactory.create()
-        request.user.is_authenticated = MagicMock(return_value=authenticated)
-        params = {'course_id': 'CourseID', 'usage_id': 'UsageID'}
-        params.update(LTI_DEFAULT_PARAMS)
-        request.session = {views.LTI_SESSION_KEY: params}
-        return request
-
-    def test_valid_launch(self):
+    @patch('lti_provider.views.render_courseware')
+    def test_valid_launch(self, render):
         """
         Verifies that the view returns OK if called with the correct context
         """
-        request = self.build_request()
+        request = build_run_request()
         response = views.lti_run(request)
-        self.assertEqual(response.status_code, 200)
+        render.assert_called_with(request, ALL_PARAMS)
 
     def test_forbidden_if_session_key_missing(self):
         """
         Verifies that the lti_run view returns a Forbidden status if the session
         doesn't have an entry for the LTI parameters.
         """
-        request = self.build_request()
+        request = build_run_request()
         del request.session[views.LTI_SESSION_KEY]
         response = views.lti_run(request)
         self.assertEqual(response.status_code, 403)
@@ -161,7 +172,7 @@ class LtiRunTest(TestCase):
         """
         extra_keys = ['course_id', 'usage_id']
         for key in views.REQUIRED_PARAMETERS + extra_keys:
-            request = self.build_request()
+            request = build_run_request()
             del request.session[views.LTI_SESSION_KEY][key]
             response = views.lti_run(request)
             self.assertEqual(
@@ -170,11 +181,91 @@ class LtiRunTest(TestCase):
                 'Expected Forbidden response when session is missing ' + key
             )
 
-    def test_session_cleared_in_view(self):
+    @patch('lti_provider.views.render_courseware')
+    def test_session_cleared_in_view(self, _render):
         """
         Verifies that the LTI parameters are cleaned out of the session after
         launching the view to prevent a launch being replayed.
         """
-        request = self.build_request()
+        request = build_run_request()
         views.lti_run(request)
         self.assertNotIn(views.LTI_SESSION_KEY, request.session)
+
+
+MODULE_INSTANCE = MagicMock()
+MODULE_INSTANCE.render = MagicMock(return_value='Fragment')
+
+
+@patch('lti_provider.views.render_to_response', return_value='Rendered page')
+@patch('lti_provider.views.get_module_by_usage_id', return_value=(MODULE_INSTANCE, None))
+@patch('lti_provider.views.has_access', return_value='StaffAccess')
+@patch('lti_provider.views.get_course_with_access', return_value='CourseWithAccess')
+@patch('lti_provider.views.CourseKey.from_string', return_value='CourseKey')
+class RenderCoursewareTest(TestCase):
+    """
+    Tests for the render_courseware method
+    """
+
+    def test_valid_launch(self, _key_mock, _course_mock, _access_mock, _module_mock, _render_mock):
+        """
+        Verify that the method renders a response when launched correctly
+        """
+        request = build_run_request()
+        response = views.render_courseware(request, ALL_PARAMS.copy())
+        self.assertEqual(response, 'Rendered page')
+
+    def test_course_key(self, key_mock, _course_mock, _access_mock, _module_mock, _render_mock):
+        """
+        Verify that the correct course key is requested
+        """
+        request = build_run_request()
+        views.render_courseware(request, ALL_PARAMS.copy())
+        key_mock.assert_called_with(ALL_PARAMS['course_id'])
+
+    def test_course_with_access(self, _key_mock, course_mock, _access_mock, _module_mock, _render_mock):
+        """
+        Verify that get_course_with_access is called with the right parameters
+        """
+        request = build_run_request()
+        views.render_courseware(request, ALL_PARAMS.copy())
+        course_mock.assert_called_with(request.user, 'load', 'CourseKey')
+
+    def test_has_access(self, _key_mock, _course_mock, access_mock, _module_mock, _render_mock):
+        """
+        Verify that has_access is called with the right parameters
+        """
+        request = build_run_request()
+        views.render_courseware(request, ALL_PARAMS.copy())
+        access_mock.assert_called_with(request.user, 'staff', 'CourseWithAccess')
+
+    def test_get_module(self, _key_mock, _course_mock, _access_mock, module_mock, _render_mock):
+        """
+        Verify that get_module_by_usage_id is called with the right parameters
+        """
+        request = build_run_request()
+        views.render_courseware(request, ALL_PARAMS.copy())
+        module_mock.assert_called_with(request, ALL_PARAMS['course_id'], ALL_PARAMS['usage_id'])
+
+    def test_render(self, _key_mock, _course_mock, _access_mock, _module_mock, _render_mock):
+        """
+        Verify that render is called on the right object with the right parameters
+        """
+        request = build_run_request()
+        views.render_courseware(request, ALL_PARAMS.copy())
+        MODULE_INSTANCE.render.assert_called_with('student_view', context={})
+
+    def test_context(self, _key_mock, _course_mock, _access_mock, _module_mock, render_mock):
+        expected_context = {
+            'fragment': 'Fragment',
+            'course': 'CourseWithAccess',
+            'disable_accordion': True,
+            'allow_iframing': True,
+            'disable_header': True,
+            'disable_footer': True,
+            'disable_tabs': True,
+            'staff_access': 'StaffAccess',
+            'xqa_server': 'http://xqa:server@content-qa.mitx.mit.edu/xqa',
+        }
+        request = build_run_request()
+        views.render_courseware(request, ALL_PARAMS.copy())
+        render_mock.assert_called_with('courseware/courseware.html', expected_context)

--- a/lms/djangoapps/lti_provider/views.py
+++ b/lms/djangoapps/lti_provider/views.py
@@ -173,7 +173,7 @@ def render_courseware(request, lti_params):
         'disable_footer': True,
         'disable_tabs': True,
         'staff_access': staff,
-        'xqa_server': settings.FEATURES.get('USE_XQA_SERVER', 'http://xqa:server@content-qa.mitx.mit.edu/xqa'),
+        'xqa_server': settings.FEATURES.get('USE_XQA_SERVER', 'http://example.com/xqa'),
     }
 
     return render_to_response('courseware/courseware.html', context)

--- a/lms/templates/courseware/xqa_interface.html
+++ b/lms/templates/courseware/xqa_interface.html
@@ -51,7 +51,7 @@ function sendlog(element_id, edit_link, staff_context){
                 $('#' + element_id + '_xqa_log_data').html(result);
         },
         error: function() {
-            alert('Error: cannot connect to XQA server');
+            alert('Error: cannot connect to XQA server. Check the value of the USE_XQA_SERVER feature.');
             console.log('error!');
         }
     });
@@ -78,7 +78,7 @@ function getlog(element_id, staff_context){
             $('#' + element_id + '_xqa_log_data').html(result);
         },
         error: function() {
-            alert('Error: cannot connect to XQA server');
+            alert('Error: cannot connect to XQA server. Check the value of the USE_XQA_SERVER feature.');
         }
     });
 


### PR DESCRIPTION
This change modifies the render_courseware view in the LTI Provider app to call the courseware.html template, using a set of options that suppress the edX chrome. For more details on the edX as an LTI provider feature, see the spec at https://docs.google.com/document/d/185hdPvIxcKtiDOLjb4sTGovA_WYXWz5Cd79gCzQwBms

This change needs the functionality from _get_module_by_usage_id in module_render.py. To avoid duplication, I've changed that method to be public. Is it still appropriate for it to be in the module_render.py file, or is there somewhere more generic where it would make sense to move it?

Tagging @ormsbee for feedback.
