### PR TITLE
Switching between discussion threads take focus to bottom of the page.

### DIFF
--- a/common/djangoapps/terrain/stubs/comments.py
+++ b/common/djangoapps/terrain/stubs/comments.py
@@ -100,7 +100,9 @@ class StubCommentsServiceHandler(StubHttpRequestHandler):
             self.send_response(404, content="404 Not Found")
 
     def do_threads(self):
-        self.send_json_response({"collection": [], "page": 1, "num_pages": 1})
+        threads = self.server.config.get('threads', {})
+        threads_data = [val for key, val in threads.items()]
+        self.send_json_response({"collection": threads_data, "page": 1, "num_pages": 1})
 
     def do_search_threads(self):
         self.send_json_response(self.server.config.get('search_result', {}))

--- a/common/static/coffee/src/discussion/views/discussion_thread_view.coffee
+++ b/common/static/coffee/src/discussion/views/discussion_thread_view.coffee
@@ -125,7 +125,7 @@ if Backbone?
           resp_limit: responseLimit if responseLimit
         $elem: elem
         $loading: elem
-        takeFocus: true
+        takeFocus: false
         complete: =>
           @responsesRequest = null
         success: (data, textStatus, xhr) =>

--- a/common/test/acceptance/fixtures/discussion.py
+++ b/common/test/acceptance/fixtures/discussion.py
@@ -119,6 +119,16 @@ class SingleThreadViewFixture(DiscussionContentFixture):
         }
 
 
+class MultipleThreadFixture(DiscussionContentFixture):
+
+    def __init__(self, threads):
+        self.threads = threads
+
+    def get_config_data(self):
+        threads_list = {thread['id']: thread for thread in self.threads}
+        return {"threads": json.dumps(threads_list), "comments": '{}'}
+
+
 class UserProfileViewFixture(DiscussionContentFixture):
 
     def __init__(self, threads):

--- a/common/test/acceptance/pages/lms/discussion.py
+++ b/common/test/acceptance/pages/lms/discussion.py
@@ -341,6 +341,42 @@ class DiscussionTabSingleThreadPage(CoursePage):
         with self.thread_page._secondary_action_menu_open(".forum-thread-main-wrapper"):
             self._find_within(".forum-thread-main-wrapper .action-close").first.click()
 
+    @wait_for_js
+    def is_window_on_top(self):
+        """
+        Check if window's scroll is at top
+        """
+        return self.browser.execute_script("return $('html, body').offset().top") == 0
+
+    def _thread_is_rendered_successfully(self, thread_id):
+        return self.q(css=".discussion-article[data-id='{}']".format(thread_id)).visible
+
+    def click_and_open_thread(self, thread_id):
+        """
+        Click specific thread on the list.
+        """
+        thread_selector = "li[data-id='{}']".format(thread_id)
+        self.q(css=thread_selector).first.click()
+        EmptyPromise(
+            lambda: self._thread_is_rendered_successfully(thread_id),
+            "Thread has been rendered"
+        ).fulfill()
+
+    def check_threads_rendered_successfully(self, thread_count):
+        """
+        Count the number of threads available on page.
+        """
+        return len(self.q(css=".forum-nav-thread").results) == thread_count
+
+    def check_window_is_on_top(self):
+        """
+        Check window is on top of the page
+        """
+        EmptyPromise(
+            self.is_window_on_top,
+            "Window is on top"
+        ).fulfill()
+
 
 class InlineDiscussionPage(PageObject):
     url = None


### PR DESCRIPTION
[TNL-1530](https://openedx.atlassian.net/browse/TNL-1530)

Fixed switching between discussion threads take control to the bottom of the page.
Write a `Bok-Choy` Where two threads were created and after switching between them tested that the page is not scrolled to the bottom.
