### PR TITLE
Fixed cross icon issue on set date dialog inside schedule tab

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -207,3 +207,4 @@ Phil McGachey <phil_mcgachey@harvard.edu>
 Sri Harsha Pamu <kmitharsha@gmail.com>
 Cris Ewing <cris@crisewing.com>
 Carlos de La Guardia <carlos@jazkarta.com>
+Amir Qayyum Khan <amir.qayyum@arbisoft.com>

--- a/lms/templates/ccx/schedule.html
+++ b/lms/templates/ccx/schedule.html
@@ -32,7 +32,7 @@
 <section id="enter-date-modal" class="modal" aria-hidden="true">
   <div class="inner-wrapper" role="dialog">
     <button class="close-modal">
-      <i class="fa-remove"></i>
+      <i class="icon fa fa-remove"></i>
       <span class="sr">
         ${_("Close")}
       </span>


### PR DESCRIPTION
Hi

Working for MIT ODL, I fixed an issue where the cross icon on the datetime dialog box was not showing. So in this PR I fixed that issue. Now you guys can see cross icon.

@carsongee @pdpinch 
CCX https://github.com/jazkarta/edx-platform/issues/70
![icon_issue](https://cloud.githubusercontent.com/assets/10431250/7372772/1098990c-ede2-11e4-9cb4-12ecc7d67885.png)
