### PR TITLE
Pep8 should ignore pycharm-helpers files on folks' workstations/VMs.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,4 +29,4 @@ no-path-adjustment=1
 #   It's a little unusual, but we have good reasons for doing so, so we disable
 #   this rule.
 ignore=E501,E265,W602
-exclude=migrations,.git
+exclude=migrations,.git,.pycharm_helpers


### PR DESCRIPTION
Project-root is the default location for these helper files, and they are being
examined as part of pep8 runs. This change will ensure they are ignored in this case.
