### PR TITLE
WIP microsites from database, branding enforcement and microsite settings object

### DIFF
--- a/common/djangoapps/microsite_configuration/__init__.py
+++ b/common/djangoapps/microsite_configuration/__init__.py
@@ -1,1 +1,19 @@
+from django.conf import settings as base_settings
+
+from microsite_configuration import microsite
 from .templatetags.microsite import page_title_breadcrumbs
+
+
+class MicrositeAwareSettings():
+    """
+    This class is a handy utility to make a call to the settings
+    completely microsite aware by replacing the:
+    from django.conf import settings
+    with:
+    from microsite_configuration import settings
+    """
+
+    def __getattr__(self, name):
+        return microsite.get_value(name, base_settings.__getattr__(name))
+
+settings = MicrositeAwareSettings()

--- a/common/djangoapps/microsite_configuration/admin.py
+++ b/common/djangoapps/microsite_configuration/admin.py
@@ -1,0 +1,9 @@
+"""
+Django admin page for microsite models
+"""
+from django.contrib import admin
+
+from .models import Microsite
+
+
+admin.site.register(Microsite)

--- a/common/djangoapps/microsite_configuration/microsite.py
+++ b/common/djangoapps/microsite_configuration/microsite.py
@@ -121,7 +121,7 @@ def get_value_for_org(org, val_name, default=None):
 
 def get_all_orgs():
     """
-    This returns a set of orgs that are considered within a microsite. This can be used,
+    This returns a set of orgs that are considered within all microsites. This can be used,
     for example, to do filtering
     """
     org_filter_set = set()

--- a/common/djangoapps/microsite_configuration/middleware.py
+++ b/common/djangoapps/microsite_configuration/middleware.py
@@ -106,12 +106,15 @@ class DatabaseMicrositeMiddleware(MicrositeMiddleware):
         return None
 
 
-# Todo select a better name
-class MicrositeFilterSecurityMiddleware():
+class MicrositeCrossBrandingFilterMiddleware():
     """
+    Middleware class that prevents a course defined in a branded ORG trough a microsite, to be displayed
+    on a different microsite with a different branding.
     """
     def process_request(self, request):
         """
+        Raise an 404 exception if the course being rendered belongs to an ORG in a
+        microsite, but it is not the current microsite
         """
         path = request.path_info
         p = re.compile('/courses/{}/'.format(settings.COURSE_ID_PATTERN))

--- a/common/djangoapps/microsite_configuration/middleware.py
+++ b/common/djangoapps/microsite_configuration/middleware.py
@@ -124,7 +124,7 @@ class MicrositeCrossBrandingFilterMiddleware():
         if m is None:
             return None
 
-        course_id =  m.group('course_id')
+        course_id = m.group('course_id')
         course_key = CourseKey.from_string(course_id)
 
         # If the course org is the same as the current microsite

--- a/common/djangoapps/microsite_configuration/middleware.py
+++ b/common/djangoapps/microsite_configuration/middleware.py
@@ -6,8 +6,12 @@ A microsite enables the following features:
 2) Present a landing page with a listing of courses that are specific to the 'brand'
 3) Ability to swap out some branding elements in the website
 """
+import re
 
 from django.conf import settings
+from django.http import Http404
+
+from opaque_keys.edx.keys import CourseKey
 from microsite_configuration import microsite
 
 
@@ -100,3 +104,34 @@ class DatabaseMicrositeMiddleware(MicrositeMiddleware):
         domain = request.META.get('HTTP_HOST', None)
         microsite.set_from_db_by_domain(domain)
         return None
+
+
+# Todo select a better name
+class MicrositeFilterSecurityMiddleware():
+    """
+    """
+    def process_request(self, request):
+        """
+        """
+        path = request.path_info
+        p = re.compile('/courses/{}/'.format(settings.COURSE_ID_PATTERN))
+        m = p.match(path)
+
+        # If there is no match, then we are not in a ORG-restricted area
+        if m is None:
+            return None
+
+        course_id =  m.group('course_id')
+        course_key = CourseKey.from_string(course_id)
+
+        # If the course org is the same as the current microsite
+        if microsite.get_value('course_org_filter') == course_key.org:
+            return None
+
+        # If the course does not belong to an ORG defined in a microsite
+        all_orgs = microsite.get_all_orgs()
+        if course_key.org not in all_orgs:
+            return None
+
+        # We could log some of the output here for forensic analysis
+        raise Http404

--- a/common/djangoapps/microsite_configuration/middleware.py
+++ b/common/djangoapps/microsite_configuration/middleware.py
@@ -83,3 +83,20 @@ class MicrositeSessionCookieDomainMiddleware():
             response.set_cookie = _set_cookie_wrapper
 
         return response
+
+
+class DatabaseMicrositeMiddleware(MicrositeMiddleware):
+    """
+    Middleware class which will bind configuration information regarding 'microsites' on a per request basis.
+    The actual configuration information is taken from the microsite model in the database
+    """
+
+    def process_request(self, request):
+        """
+        Middleware entry point on every request processing. This will associate a request's domain name
+        with a 'University' and any corresponding microsite configuration information
+        """
+        microsite.clear()
+        domain = request.META.get('HTTP_HOST', None)
+        microsite.set_from_db_by_domain(domain)
+        return None

--- a/common/djangoapps/microsite_configuration/migrations/0001_initial.py
+++ b/common/djangoapps/microsite_configuration/migrations/0001_initial.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'Microsite'
+        db.create_table('microsite_configuration_microsite', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('key', self.gf('django.db.models.fields.CharField')(max_length=63, db_index=True)),
+            ('subdomain', self.gf('django.db.models.fields.CharField')(max_length=127, db_index=True)),
+            ('values', self.gf('django.db.models.fields.TextField')(blank=True)),
+        ))
+        db.send_create_signal('microsite_configuration', ['Microsite'])
+
+
+    def backwards(self, orm):
+        # Deleting model 'Microsite'
+        db.delete_table('microsite_configuration_microsite')
+
+
+    models = {
+        'microsite_configuration.microsite': {
+            'Meta': {'object_name': 'Microsite'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '63', 'db_index': 'True'}),
+            'subdomain': ('django.db.models.fields.CharField', [], {'max_length': '127', 'db_index': 'True'}),
+            'values': ('django.db.models.fields.TextField', [], {'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['microsite_configuration']

--- a/common/djangoapps/microsite_configuration/models.py
+++ b/common/djangoapps/microsite_configuration/models.py
@@ -7,7 +7,7 @@ from django.core.exceptions import ValidationError
 def validate_json(values):
     try:
         json.loads(values)
-    except ValueError, e:
+    except ValueError:
         raise ValidationError("The values field must be a valid json.")
 
 
@@ -29,5 +29,5 @@ class Microsite(models.Model):
     subdomain = models.CharField(max_length=127, db_index=True)
     values = models.TextField(null=False, blank=True, validators=[validate_json])
 
-    def __str__( self):
-      return self.key
+    def __str__(self):
+        return self.key

--- a/common/djangoapps/microsite_configuration/models.py
+++ b/common/djangoapps/microsite_configuration/models.py
@@ -1,12 +1,22 @@
+import json
+
 from django.db import models
+from django.core.exceptions import ValidationError
+
+
+def validate_json(values):
+    try:
+        json.loads(values)
+    except ValueError, e:
+        raise ValidationError("The values field must be a valid json.")
 
 
 class Microsite(models.Model):
     key = models.CharField(max_length=63, db_index=True)
     subdomain = models.CharField(max_length=127, db_index=True)
-    values = models.TextField(null=False, blank=True)
+    values = models.TextField(null=False, blank=True, validators=[validate_json])
 
-    # TODO: must add a is_active flag
+    # TODO: an is_active flag would be useful
 
     def __str__( self):
       return self.key

--- a/common/djangoapps/microsite_configuration/models.py
+++ b/common/djangoapps/microsite_configuration/models.py
@@ -12,11 +12,22 @@ def validate_json(values):
 
 
 class Microsite(models.Model):
+    """
+    This is where the information about the microsite gets stored to the db.
+    To achieve the maximum flexibility, most of the fields are stored inside
+    a json field.
+
+    Notes:
+        - The key field was required for the dict definition at the settings, and it
+        is used in some of the microsite_configuration methods.
+        - The subdomain is outside of the json so that it is posible to use a db query
+        to improve performance.
+        - The values field must be validated on save to prevent the platform from crashing
+        badly in the case the string is not able to be loaded as json.
+    """
     key = models.CharField(max_length=63, db_index=True)
     subdomain = models.CharField(max_length=127, db_index=True)
     values = models.TextField(null=False, blank=True, validators=[validate_json])
-
-    # TODO: an is_active flag would be useful
 
     def __str__( self):
       return self.key

--- a/common/djangoapps/microsite_configuration/models.py
+++ b/common/djangoapps/microsite_configuration/models.py
@@ -1,0 +1,12 @@
+from django.db import models
+
+
+class Microsite(models.Model):
+    key = models.CharField(max_length=63, db_index=True)
+    subdomain = models.CharField(max_length=127, db_index=True)
+    values = models.TextField(null=False, blank=True)
+
+    # TODO: must add a is_active flag
+
+    def __str__( self):
+      return self.key

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1049,7 +1049,7 @@ TEMPLATE_LOADERS = (
 
 MIDDLEWARE_CLASSES = (
     'request_cache.middleware.RequestCache',
-    'microsite_configuration.middleware.MicrositeMiddleware',
+    'microsite_configuration.middleware.DatabaseMicrositeMiddleware',
     'django_comment_client.middleware.AjaxExceptionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -1110,6 +1110,8 @@ MIDDLEWARE_CLASSES = (
 
     'course_wiki.middleware.WikiAccessMiddleware',
 
+    # to have a course render fail with 404 if it is in the wrong microsite
+    'microsite_configuration.middleware.MicrositeCrossBrandingFilterMiddleware',
     # This must be last
     'microsite_configuration.middleware.MicrositeSessionCookieDomainMiddleware',
 )

--- a/lms/startup.py
+++ b/lms/startup.py
@@ -126,7 +126,7 @@ def enable_microsites():
             del microsite_config_dict[ms_name]
 
     # if we have any valid microsites defined, let's wire in the Mako and STATIC_FILES search paths
-    if microsite_config_dict:
+    if microsite_config_dict or "microsite_configuration.middleware.DatabaseMicrositeMiddleware" in settings.MIDDLEWARE_CLASSES:
         settings.TEMPLATE_DIRS.append(microsites_root)
         edxmako.paths.add_lookup('main', microsites_root)
 


### PR DESCRIPTION
In it's current form this PR is only for review purposes. 
For those looking at it, it does 3 things:
- Adds the ability to define the microsites as a record in the database instead of the current definition at the settings file.
- Adds a middleware to prevent courses defined in a ORG from a microsite to be displayed in other microsite or a non-microsited view
- Adds a microsite aware settings object to be used as a helper when dealing with microsite support

Notes:
- I can break this into 3 PRs if it is necessary
- Since the starting commit is the last commit from the birch branch, there are 3 commits by the edx team that probably don't belong here.
