### PR TITLE
Remove anonymous caching when SSL is enabled

### DIFF
--- a/common/djangoapps/external_auth/tests/test_ssl.py
+++ b/common/djangoapps/external_auth/tests/test_ssl.py
@@ -2,6 +2,7 @@
 Provides unit tests for SSL based authentication portions
 of the external_auth app.
 """
+import copy
 import unittest
 
 from django.conf import settings
@@ -31,9 +32,12 @@ FEATURES_WITH_SSL_AUTH_AUTO_ACTIVATE = FEATURES_WITH_SSL_AUTH_IMMEDIATE_SIGNUP.c
 FEATURES_WITH_SSL_AUTH_AUTO_ACTIVATE['BYPASS_ACTIVATION_EMAIL_FOR_EXTAUTH'] = True
 FEATURES_WITHOUT_SSL_AUTH = settings.FEATURES.copy()
 FEATURES_WITHOUT_SSL_AUTH['AUTH_USE_CERTIFICATES'] = False
+CACHES_ENABLE_GENERAL = copy.deepcopy(settings.CACHES)
+CACHES_ENABLE_GENERAL['general']['BACKEND'] = 'django.core.cache.backends.locmem.LocMemCache'
 
 
 @override_settings(FEATURES=FEATURES_WITH_SSL_AUTH)
+@override_settings(CACHES=CACHES_ENABLE_GENERAL)
 class SSLClientTest(ModuleStoreTestCase):
     """
     Tests SSL Authentication code sections of external_auth

--- a/common/djangoapps/util/cache.py
+++ b/common/djangoapps/util/cache.py
@@ -8,6 +8,7 @@ not migrating so as not to inconvenience users by logging them all out.
 import urllib
 from functools import wraps
 
+from django.conf import settings
 from django.core import cache
 
 
@@ -49,7 +50,14 @@ def cache_if_anonymous(*get_parameters):
         @wraps(view_func)
         def wrapper(request, *args, **kwargs):
             """The inner wrapper, which wraps the view function."""
-            if not request.user.is_authenticated():
+            # Certificate authentication uses anonymous pages,
+            # specifically the branding index, to do authentication.
+            # If that page is cached the authentication doesn't
+            # happen, so we disable the cache when that feature is enabled.
+            if (
+                not request.user.is_authenticated() and
+                not settings.FEATURES['AUTH_USE_CERTIFICATES']
+            ):
                 # Use the cache. The same view accessed through different domain names may
                 # return different things, so include the domain name in the key.
                 domain = str(request.META.get('HTTP_HOST')) + '.'


### PR DESCRIPTION
With anonymous caching enabled, the branding index page ends up returning a cached redirect instead of doing the actual user SSL login and then redirecting (https://github.com/edx/edx-platform/blob/master/lms/djangoapps/branding/views.py#L53-L61).  This now checks that the feature is enabled before caching the page.

An additional note: we had already been testing for this with a few of the tests, but I didn't realize the test environment didn't have a functioning `general` cache.  Just turning that on caused 5 of the SSL tests to fail without the change to the anonymous cache decorator.

The reason for disabling the cache for SSL authentication alone is because this SSL auth implementation expects the proper authentication to be done at the Web server level, and thus all pages are "authenticated".
