### PR TITLE
update the attrib using dict-->update() function

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_import_export.py
+++ b/cms/djangoapps/contentstore/views/tests/test_import_export.py
@@ -427,3 +427,20 @@ class ExportTestCase(CourseTestCase):
             self.assertEqual(video_xml.get('youtube_id_1_0'), youtube_id)
         finally:
             shutil.rmtree(root_dir / name)
+
+    def test_export_success_with_custom_tag(self):
+        """
+        Verify that course export with customtag
+        """
+        xml_string = '<impl>slides</impl>'
+        vertical = ItemFactory.create(
+            parent_location=self.course.location, category='vertical', display_name='foo'
+        )
+        ItemFactory.create(
+            parent_location=vertical.location,
+            category='customtag',
+            display_name='custom_tag_foo',
+            data=xml_string
+        )
+
+        self.test_export_targz_urlparam()

--- a/common/lib/xmodule/xmodule/xml_module.py
+++ b/common/lib/xmodule/xmodule/xml_module.py
@@ -446,7 +446,7 @@ class XmlParserMixin(object):
             node.tag = xml_object.tag
             node.text = xml_object.text
             node.tail = xml_object.tail
-            node.attrib = xml_object.attrib
+            node.attrib.update(xml_object.attrib)
             node.extend(xml_object)
 
         node.set('url_name', self.url_name)


### PR DESCRIPTION
[TNL-2094](https://github.com/edx/edx-platform/pull/7871)

Problem :

This problem occur while processing the custom tag [here](https://github.com/edx/edx-platform/blob/8f133f6696abf189e1ae2d62b47d54d3a337b395/common/lib/xmodule/xmodule/xml_module.py#L449)

From xml library document [here](https://docs.python.org/2/library/xml.etree.elementtree.html#xml.etree.ElementTree.Element.attrib) the attrib is mutable Python dictionary object and we cannot assign value to attrib like [here](https://github.com/edx/edx-platform/blob/8f133f6696abf189e1ae2d62b47d54d3a337b395/common/lib/xmodule/xmodule/xml_module.py#L449)

Solution:
From documentation we can use dictionary methods like update() to change the value of node.attrib
