### PR TITLE
Don't delete *.pyc files in the .git directory

### DIFF
--- a/pavelib/utils/test/utils.py
+++ b/pavelib/utils/test/utils.py
@@ -18,7 +18,7 @@ def clean_test_files():
     Clean fixture files used by tests and .pyc files
     """
     sh("git clean -fqdx test_root/logs test_root/data test_root/staticfiles test_root/uploads")
-    sh("find . -type f -name \"*.pyc\" -delete")
+    sh("find . -type f -name \"*.pyc\" -not -path './.git/*' -delete")
     sh("rm -rf test_root/log/auto_screenshots/*")
     sh("rm -rf /tmp/mako_[cl]ms")
 


### PR DESCRIPTION
If you have a branch named "remove-all-.pyc", the original code would
clobber it inside the .git directory, because branches become files with
the same name.  This prevents find from looking in .git, saving your
precious oddly named branches.
