### PR TITLE
Added flaky decorators to potentally flaky tests

### DIFF
--- a/common/test/acceptance/tests/discussion/test_cohort_management.py
+++ b/common/test/acceptance/tests/discussion/test_cohort_management.py
@@ -4,6 +4,7 @@ End-to-end tests related to the cohort management on the LMS Instructor Dashboar
 """
 
 from datetime import datetime
+from flaky import flaky
 
 from pytz import UTC, utc
 from bok_choy.promise import EmptyPromise
@@ -718,6 +719,7 @@ class CohortDiscussionTopicsTest(UniqueCourseTest, CohortTestMixin):
         self.reload_page()
         self.assertEqual(self.cohort_management_page.get_cohorted_topics_count(key), cohorted_topics)
 
+    @flaky  # TODO: fix this, see TNL-2120
     def test_cohort_course_wide_discussion_topic(self):
         """
         Scenario: cohort a course-wide discussion topic.


### PR DESCRIPTION
Flaky tests:
- CohortDiscussionTopicsTest.test_cohort_course_wide_discussion_topic
- AnnotatableProblemTest.test_annotation_component

**Failed in build:** https://build.testeng.edx.org/job/edx-platform-all-tests-pr-flow/5043/
**JIRA tickets:** [TNL-2120](https://openedx.atlassian.net/browse/TNL-2120)
