### PR TITLE
Enrollment API course details include credit modes.

### DIFF
--- a/common/djangoapps/enrollment/serializers.py
+++ b/common/djangoapps/enrollment/serializers.py
@@ -40,7 +40,9 @@ class CourseField(serializers.RelatedField):
 
     def to_native(self, course):
         course_id = unicode(course.id)
-        course_modes = ModeSerializer(CourseMode.modes_for_course(course.id)).data  # pylint: disable=no-member
+        course_modes = ModeSerializer(
+            CourseMode.modes_for_course(course.id, only_selectable=False)
+        ).data  # pylint: disable=no-member
 
         return {
             "course_id": course_id,

--- a/common/djangoapps/enrollment/tests/test_views.py
+++ b/common/djangoapps/enrollment/tests/test_views.py
@@ -306,6 +306,23 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase):
         self.assertEqual(mode['sku'], '123')
         self.assertEqual(mode['name'], CourseMode.HONOR)
 
+    def test_get_course_details_with_credit_course(self):
+        CourseModeFactory.create(
+            course_id=self.course.id,
+            mode_slug=CourseMode.CREDIT_MODE,
+            mode_display_name=CourseMode.CREDIT_MODE,
+        )
+        resp = self.client.get(
+            reverse('courseenrollmentdetails', kwargs={"course_id": unicode(self.course.id)})
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+        data = json.loads(resp.content)
+        self.assertEqual(unicode(self.course.id), data['course_id'])
+        mode = data['course_modes'][0]
+        self.assertEqual(mode['slug'], CourseMode.CREDIT_MODE)
+        self.assertEqual(mode['name'], CourseMode.CREDIT_MODE)
+
     @ddt.data(
         # NOTE: Studio requires a start date, but this is not
         # enforced at the data layer, so we need to handle the case


### PR DESCRIPTION
Credit modes are hidden by default, since the user
isn't allowed to select them on the track selection page.
This commit exposes credit modes through the enrollment
API so that consumers can see that a course has a credit
track.

JIRA: [ECOM-1445](https://openedx.atlassian.net/browse/ECOM-1445)

@clintonb please review when you have a moment.
FYI: @AlasdairSwan 
