### PR TITLE
Add tab index for CCX grading policy tab

### DIFF
--- a/lms/templates/ccx/grading_policy.html
+++ b/lms/templates/ccx/grading_policy.html
@@ -3,7 +3,7 @@
 <div id="warn-coach" class="wrapper-msg urgency-high warning">
   <div class="msg">
     <i class="msg-icon icon-warning-sign"></i>
-    <div class="msg-content">
+    <div class="msg-content" tabindex="0">
       <h3 class="title">${_("WARNING")}</h3>
       <div class="copy">
         <p>${_("For advanced users only. Errors in the grading policy can lead to the course failing to display. This form does not check the validity of the policy before saving.")}</p>


### PR DESCRIPTION
Hi

Working for MIT ODL. In this PR I fixed accessibility related issues on grading policy tab inside CCX dashboard.

Now screen readers can read grading policy and warning message on grading policy tab.You can use screen reading tools like chromeVox (A chrome browser plugin) or command +F5 on mac to verify this PR.
Also read http://edx-partner-course-staff.readthedocs.org/en/latest/getting_started/accessibility.html

@carsongee @pdpinch @pwilkins
