### PR TITLE
Prevent nested field_data

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/xml.py
+++ b/common/lib/xmodule/xmodule/modulestore/xml.py
@@ -14,6 +14,7 @@ from importlib import import_module
 from lxml import etree
 from path import path
 from contextlib import contextmanager
+from lazy import lazy
 
 from xmodule.error_module import ErrorDescriptor
 from xmodule.errortracker import make_error_tracker, exc_info_to_str
@@ -933,6 +934,9 @@ class LibraryXMLModuleStore(XMLModuleStore):
         here manually.
         """
         init_dict = {key: getattr(library_descriptor, key) for key in library_descriptor.fields.keys()}
+        # if set, invalidate '_unwrapped_field_data' so it will be reset
+        # the next time it will be called
+        lazy.invalidate(library_descriptor, '_unwrapped_field_data')
         # pylint: disable=protected-access
         library_descriptor._field_data = inheriting_field_data(InheritanceKeyValueStore(init_dict))
 

--- a/common/lib/xmodule/xmodule/tests/__init__.py
+++ b/common/lib/xmodule/xmodule/tests/__init__.py
@@ -126,7 +126,7 @@ def get_test_system(course_id=SlashSeparatedCourseKey('org', 'course', 'run')):
         # So, bind to the same one as the current descriptor.
         module_system.descriptor_runtime = descriptor._runtime  # pylint: disable=protected-access
 
-        descriptor.bind_for_student(module_system, descriptor._field_data, user.id)
+        descriptor.bind_for_student(module_system, user.id)
 
         return descriptor
 

--- a/common/lib/xmodule/xmodule/tests/test_import.py
+++ b/common/lib/xmodule/xmodule/tests/test_import.py
@@ -281,7 +281,13 @@ class ImportTestCase(BaseCourseTestCase):
             due=from_date_string, org=ORG, course=COURSE, url_name=url_name, unicorn_color=unicorn_color
         )
         descriptor = system.process_xml(start_xml)
+
+        # pylint: disable=protected-access
+        original_unwrapped = descriptor._unwrapped_field_data
         LibraryXMLModuleStore.patch_descriptor_kvs(descriptor)
+        # '_unwrapped_field_data' is reset in `patch_descriptor_kvs`
+        # pylint: disable=protected-access
+        self.assertIsNot(original_unwrapped, descriptor._unwrapped_field_data)
         compute_inherited_metadata(descriptor)
         # Check the course module, since it has inheritance
         descriptor = descriptor.get_children()[0]

--- a/common/lib/xmodule/xmodule/tests/test_library_content.py
+++ b/common/lib/xmodule/xmodule/tests/test_library_content.py
@@ -60,7 +60,7 @@ class LibraryContentTest(MixedSplitTestCase):
             sub_module_system = get_test_system(course_id=module.location.course_key)
             sub_module_system.get_module = get_module
             sub_module_system.descriptor_runtime = descriptor._runtime  # pylint: disable=protected-access
-            descriptor.bind_for_student(sub_module_system, descriptor._field_data, self.user_id)  # pylint: disable=protected-access
+            descriptor.bind_for_student(sub_module_system, self.user_id)
             return descriptor
 
         module_system.get_module = get_module

--- a/common/lib/xmodule/xmodule/tests/test_split_test_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_split_test_module.py
@@ -100,7 +100,6 @@ class SplitTestModuleTest(XModuleXmlImportTest, PartitionTestCase):
         self.split_test_module = self.course_sequence.get_children()[0]
         self.split_test_module.bind_for_student(
             self.module_system,
-            self.split_test_module._field_data,  # pylint: disable=protected-access
             user.id
         )
 

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -12,6 +12,7 @@ from django.http import Http404, HttpResponse
 from django.core.urlresolvers import reverse
 from django.conf import settings
 from django.test.client import RequestFactory
+from django.test.utils import override_settings
 from django.contrib.auth.models import AnonymousUser
 from mock import MagicMock, patch, Mock
 from opaque_keys.edx.keys import UsageKey, CourseKey
@@ -27,6 +28,7 @@ from xblock.fragment import Fragment
 from capa.tests.response_xml_factory import OptionResponseXMLFactory
 from courseware import module_render as render
 from courseware.courses import get_course_with_access, course_image_url, get_course_info_section
+from courseware.field_overrides import OverrideFieldData
 from courseware.model_data import FieldDataCache
 from courseware.module_render import hash_resource, get_module_for_descriptor
 from courseware.models import StudentModule
@@ -34,6 +36,7 @@ from courseware.tests.factories import StudentModuleFactory, UserFactory, Global
 from courseware.tests.tests import LoginEnrollmentTestCase
 from courseware.tests.test_submitting_problems import TestSubmittingProblems
 from lms.djangoapps.lms_xblock.runtime import quote_slashes
+from lms.djangoapps.lms_xblock.field_data import LmsFieldData
 from student.models import anonymous_id_for_user
 from xmodule.modulestore.tests.django_utils import (
     TEST_DATA_MIXED_TOY_MODULESTORE,
@@ -99,10 +102,15 @@ class ModuleRenderTestCase(ModuleStoreTestCase, LoginEnrollmentTestCase):
         self.dispatch = 'score_update'
 
         # Construct a 'standard' xqueue_callback url
-        self.callback_url = reverse('xqueue_callback', kwargs=dict(course_id=self.course_key.to_deprecated_string(),
-                                                                   userid=str(self.mock_user.id),
-                                                                   mod_id=self.mock_module.id,
-                                                                   dispatch=self.dispatch))
+        self.callback_url = reverse(
+            'xqueue_callback',
+            kwargs=dict(
+                course_id=self.course_key.to_deprecated_string(),
+                userid=str(self.mock_user.id),
+                mod_id=self.mock_module.id,
+                dispatch=self.dispatch
+            )
+        )
 
     def test_get_module(self):
         self.assertEqual(
@@ -256,6 +264,84 @@ class ModuleRenderTestCase(ModuleStoreTestCase, LoginEnrollmentTestCase):
         """
         resources = ['ASCII text', u'❄ I am a special snowflake.', "❄ So am I, but I didn't tell you."]
         self.assertEqual(hash_resource(resources), 'a76e27c8e80ca3efd7ce743093aa59e0')
+
+
+@ddt.ddt
+@override_settings(FIELD_OVERRIDE_PROVIDERS=('ccx.overrides.CustomCoursesForEdxOverrideProvider',))
+class ModuleRenderTestCaseCCX(ModuleStoreTestCase, LoginEnrollmentTestCase):
+    """
+    Tests of courseware.module_render for CCX enabled courses.
+    Caveat: this class was created because passing override_settings on
+    a single test in ModuleRenderTestCase didn't override that setting
+    when the whole test case was run, or the settings weren't overridden
+    at the right time.
+    """
+    def setUp(self):
+        """
+        Set up the course and user context
+        """
+        super(ModuleRenderTestCaseCCX, self).setUp()
+
+        self.course_key = self.create_toy_course()
+        self.toy_course = modulestore().get_course(self.course_key)
+        self.request_factory = RequestFactory()
+        self.mock_user = UserFactory()
+        self.mock_user.id = 1
+
+    def test_rebind_different_users_ccx(self):
+        """
+        This tests the rebinding a descriptor to a student does not result
+        in overly nested _field_data when CCX is enabled.
+        """
+        request = self.request_factory.get('')
+        request.user = self.mock_user
+        course = CourseFactory()
+
+        descriptor = ItemFactory(category='html', parent=course)
+        field_data_cache = FieldDataCache(
+            [self.toy_course, descriptor], self.toy_course.id, self.mock_user
+        )
+
+        # grab what _field_data was originally set to
+        original_field_data = descriptor._field_data  # pylint: disable=protected-access, no-member
+
+        render.get_module_for_descriptor(
+            self.mock_user, request, descriptor, field_data_cache, self.toy_course.id
+        )
+
+        # check that _unwrapped_field_data is the same as the original
+        # _field_data, but now _field_data as been reset.
+        # pylint: disable=protected-access, no-member
+        self.assertIs(descriptor._unwrapped_field_data, original_field_data)
+        self.assertIsNot(descriptor._unwrapped_field_data, descriptor._field_data)
+
+        # now bind this module to a few other students
+        for user in [UserFactory(), UserFactory(), UserFactory()]:
+            render.get_module_for_descriptor(
+                user,
+                request,
+                descriptor,
+                field_data_cache,
+                self.toy_course.id
+            )
+
+        # _field_data should now be wrapped by LmsFieldData
+        # pylint: disable=protected-access, no-member
+        self.assertIsInstance(descriptor._field_data, LmsFieldData)
+
+        # the LmsFieldData should now wrap OverrideFieldData
+        self.assertIsInstance(
+            # pylint: disable=protected-access, no-member
+            descriptor._field_data._authored_data._source,
+            OverrideFieldData
+        )
+
+        # the OverrideFieldData should point to the original unwrapped field_data
+        self.assertIs(
+            # pylint: disable=protected-access, no-member
+            descriptor._field_data._authored_data._source.fallback,
+            descriptor._unwrapped_field_data
+        )
 
 
 class TestHandleXBlockCallback(ModuleStoreTestCase, LoginEnrollmentTestCase):


### PR DESCRIPTION
When a descriptor is bound to a new student, the old `_field_data` is wrapped by the OverrideFieldData.wrap class function. But then this is passed into bind_for_student, and so we get a long chain of [descriptor -> _field_data -> LmsFieldData -> OverrideFieldData -> LmsFieldData](https://github.com/edx/edx-platform/blob/master/lms/djangoapps/courseware/module_render.py#L695-L696), etc. references.

This PR prevents such a long chain from appearing

https://openedx.atlassian.net/browse/TNL-2050
