### PR TITLE
FIX - Specifying Open Sans typeface file formats to import

### DIFF
--- a/cms/static/sass/assets/_fonts.scss
+++ b/cms/static/sass/assets/_fonts.scss
@@ -1,13 +1,11 @@
 // studio - assets - fonts
 // ====================
 
-// No subsetting.
-
-@include font-face('Open Sans', '../fonts/OpenSans/OpenSans-Light-webfont', 300);
-@include font-face('Open Sans', '../fonts/OpenSans/OpenSans-LightItalic-webfont', 300, italic);
-@include font-face('Open Sans', '../fonts/OpenSans/OpenSans-Regular-webfont', 400);
-@include font-face('Open Sans', '../fonts/OpenSans/OpenSans-Italic-webfont', 400, italic);
-@include font-face('Open Sans', '../fonts/OpenSans/OpenSans-Semibold-webfont', 600);
-@include font-face('Open Sans', '../fonts/OpenSans/OpenSans-SemiboldItalic-webfont', 600, italic);
-@include font-face('Open Sans', '../fonts/OpenSans/OpenSans-Bold-webfont', 700);
-@include font-face('Open Sans', '../fonts/OpenSans/OpenSans-BoldItalic-webfont', 700, italic);
+@include font-face('Open Sans', '../fonts/OpenSans/OpenSans-Light-webfont', 300, $file-formats: eot woff ttf svg);
+@include font-face('Open Sans', '../fonts/OpenSans/OpenSans-LightItalic-webfont', 300, italic, $file-formats: eot woff ttf svg);
+@include font-face('Open Sans', '../fonts/OpenSans/OpenSans-Regular-webfont', 400, $file-formats: eot woff ttf svg);
+@include font-face('Open Sans', '../fonts/OpenSans/OpenSans-Italic-webfont', 400, italic, $file-formats: eot woff ttf svg);
+@include font-face('Open Sans', '../fonts/OpenSans/OpenSans-Semibold-webfont', 600, $file-formats: eot woff ttf svg);
+@include font-face('Open Sans', '../fonts/OpenSans/OpenSans-SemiboldItalic-webfont', 600, italic, $file-formats: eot woff ttf svg);
+@include font-face('Open Sans', '../fonts/OpenSans/OpenSans-Bold-webfont', 700, $file-formats: eot woff ttf svg);
+@include font-face('Open Sans', '../fonts/OpenSans/OpenSans-BoldItalic-webfont', 700, italic, $file-formats: eot woff ttf svg);

--- a/lms/static/sass/base/_font_face.scss
+++ b/lms/static/sass/base/_font_face.scss
@@ -1,13 +1,11 @@
 // LMS - assets - fonts
 // ====================
 
-// No subsetting.
-
-@include font-face('Open Sans', '../fonts/OpenSans/OpenSans-Light-webfont', 300);
-@include font-face('Open Sans', '../fonts/OpenSans/OpenSans-LightItalic-webfont', 300, italic);
-@include font-face('Open Sans', '../fonts/OpenSans/OpenSans-Regular-webfont', 400);
-@include font-face('Open Sans', '../fonts/OpenSans/OpenSans-Italic-webfont', 400, italic);
-@include font-face('Open Sans', '../fonts/OpenSans/OpenSans-Semibold-webfont', 600);
-@include font-face('Open Sans', '../fonts/OpenSans/OpenSans-SemiboldItalic-webfont', 600, italic);
-@include font-face('Open Sans', '../fonts/OpenSans/OpenSans-Bold-webfont', 700);
-@include font-face('Open Sans', '../fonts/OpenSans/OpenSans-BoldItalic-webfont', 700, italic);
+@include font-face('Open Sans', '../fonts/OpenSans/OpenSans-Light-webfont', 300, $file-formats: eot woff ttf svg);
+@include font-face('Open Sans', '../fonts/OpenSans/OpenSans-LightItalic-webfont', 300, italic, $file-formats: eot woff ttf svg);
+@include font-face('Open Sans', '../fonts/OpenSans/OpenSans-Regular-webfont', 400, $file-formats: eot woff ttf svg);
+@include font-face('Open Sans', '../fonts/OpenSans/OpenSans-Italic-webfont', 400, italic, $file-formats: eot woff ttf svg);
+@include font-face('Open Sans', '../fonts/OpenSans/OpenSans-Semibold-webfont', 600, $file-formats: eot woff ttf svg);
+@include font-face('Open Sans', '../fonts/OpenSans/OpenSans-SemiboldItalic-webfont', 600, italic, $file-formats: eot woff ttf svg);
+@include font-face('Open Sans', '../fonts/OpenSans/OpenSans-Bold-webfont', 700, $file-formats: eot woff ttf svg);
+@include font-face('Open Sans', '../fonts/OpenSans/OpenSans-BoldItalic-webfont', 700, italic, $file-formats: eot woff ttf svg);


### PR DESCRIPTION
This work solves the rare error seen below:

`The file 'fonts/OpenSans/OpenSans-Light-webfont.woff2' could not be found with <cms.lib.django_require.staticstorage.OptimizedCachedRequireJsStorage object at 0x5c08f10>`

This will exclude the `OpenSans-Light-webfont.woff2` file from being included when we call the Bourbon `@font-face` mixin to reference these.
