### PR TITLE
Support tight loop bok_choy testing

### DIFF
--- a/pavelib/bok_choy.py
+++ b/pavelib/bok_choy.py
@@ -3,7 +3,7 @@ Run acceptance tests that use the bok-choy framework
 http://bok-choy.readthedocs.org/en/latest/
 """
 from paver.easy import task, needs, cmdopts, sh
-from pavelib.utils.test.suites.bokchoy_suite import BokChoyTestSuite
+from pavelib.utils.test.suites.bokchoy_suite import BokChoyTestSuite, BokChoyDevelopmentSuite
 from pavelib.utils.envs import Env
 from pavelib.utils.test.utils import check_firefox_version
 from optparse import make_option
@@ -86,6 +86,39 @@ def perf_report_bokchoy(options):
         'test_dir': 'performance',
     }
     run_bokchoy(**opts)
+
+
+@task
+@needs('pavelib.prereqs.install_prereqs')
+@cmdopts([
+    ('fasttest', 'a', 'Skip some setup'),
+    ('imports_dir=', 'd', 'Directory containing (un-archived) courses to be imported'),
+    ('default_store=', 's', 'Default modulestore'),
+    make_option("--external-service", action="append", dest="external_services"),
+])
+def dev_bokchoy(options):
+    """
+    Run the expensive setup for bok choy tests once and just keep them all alive while you run tests in another process.
+    Note this will not actually run any tests, it will simply show you the command you can run from the other process.
+    """
+    opts = {
+        'test_spec': getattr(options, 'test_spec', None),
+        'fasttest': getattr(options, 'fasttest', False),
+        'default_store': getattr(options, 'default_store', 'split'),
+        'imports_dir': getattr(options, 'imports_dir', None),
+        'verbosity': getattr(options, 'verbosity', 2),
+        'test_dir': 'tests',
+        'external_services': getattr(options, 'external_services', None),
+    }
+    test_suite = BokChoyDevelopmentSuite('bok-choy', **opts)
+    msg = colorize(
+        'green',
+        'Running tests using {default_store} modulestore.'.format(
+            default_store=test_suite.default_store,
+        )
+    )
+    print(msg)
+    test_suite.run()
 
 
 def run_bokchoy(**opts):

--- a/pavelib/utils/test/bokchoy_utils.py
+++ b/pavelib/utils/test/bokchoy_utils.py
@@ -18,10 +18,13 @@ except ImportError:
 __test__ = False  # do not collect
 
 
-def start_servers(default_store):
+def start_servers(default_store, external_services=None):
     """
     Start the servers we will run tests on, returns PIDs for servers.
     """
+
+    if external_services is None:
+        external_services = []
 
     def start_server(cmd, logfile, cwd=None):
         """
@@ -31,6 +34,10 @@ def start_servers(default_store):
         run_background_process(cmd, out_log=logfile, err_log=logfile, cwd=cwd)
 
     for service, info in Env.BOK_CHOY_SERVERS.iteritems():
+        if service in external_services:
+            print('Assuming {0} service is being managed externally...'.format(service))
+            continue
+
         address = "0.0.0.0:{}".format(info['port'])
         cmd = (
             "DEFAULT_STORE={default_store} "

--- a/pavelib/utils/test/suites/bokchoy_suite.py
+++ b/pavelib/utils/test/suites/bokchoy_suite.py
@@ -1,6 +1,8 @@
 """
 Class used for defining and running Bok Choy acceptance test suite
 """
+import time
+
 from paver.easy import sh
 from pavelib.utils.test.suites import TestSuite
 from pavelib.utils.envs import Env
@@ -41,6 +43,7 @@ class BokChoyTestSuite(TestSuite):
         self.extra_args = kwargs.get('extra_args', '')
         self.har_dir = self.log_dir / 'hars'
         self.imports_dir = kwargs.get('imports_dir', None)
+        self.external_services = kwargs.get('external_services', None)
 
     def __enter__(self):
         super(BokChoyTestSuite, self).__enter__()
@@ -92,7 +95,7 @@ class BokChoyTestSuite(TestSuite):
         # Ensure the test servers are available
         msg = colorize('green', "Starting test servers...")
         print(msg)
-        bokchoy_utils.start_servers(self.default_store)
+        bokchoy_utils.start_servers(self.default_store, external_services=self.external_services)
 
         msg = colorize('green', "Waiting for servers to start...")
         print(msg)
@@ -135,3 +138,11 @@ class BokChoyTestSuite(TestSuite):
 
         cmd = (" ").join(cmd)
         return cmd
+
+
+class BokChoyDevelopmentSuite(BokChoyTestSuite):
+
+    def run_test(self):
+        print('Run command:\n\n{0}\n\nPress Ctrl-C to exit...'.format(self.cmd))
+        while True:
+            time.sleep(10000)


### PR DESCRIPTION
This allows you to do 2 things:

1) Run all of the setup for bok_choy and then just sit in a loop so that you can open a new shell and run just the tests in a "dirty" environment. This greatly reduces the iteration time for running bok_choy tests.
2) Tell bok_choy not to start the LMS or Studio so that you can start your own version with a debugger attached.

@benpatterson @jzoldak - is this the kind of thing you guys were thinking of?
