### PR TITLE
Exclude filtering for microsite orgs

### DIFF
--- a/cms/djangoapps/contentstore/courseware_index.py
+++ b/cms/djangoapps/contentstore/courseware_index.py
@@ -106,7 +106,7 @@ class SearchIndexerBase(object):
         response = searcher.search(
             doc_type=cls.DOCUMENT_TYPE,
             field_dictionary=cls._get_location_info(structure_key),
-            exclude_ids=exclude_items
+            exclude_dictionary={"id": list(exclude_items)}
         )
         result_ids = [result["data"]["id"] for result in response["results"]]
         for result_id in result_ids:
@@ -298,7 +298,7 @@ class CoursewareSearchIndexer(SearchIndexerBase):
     @classmethod
     def _get_location_info(cls, normalized_structure_key):
         """ Builds location info dictionary """
-        return {"course": unicode(normalized_structure_key)}
+        return {"course": unicode(normalized_structure_key), "org": normalized_structure_key.org}
 
     @classmethod
     def do_course_reindex(cls, modulestore, course_key):

--- a/lms/lib/courseware_search/lms_filter_generator.py
+++ b/lms/lib/courseware_search/lms_filter_generator.py
@@ -2,6 +2,7 @@
 This file contains implementation override of SearchFilterGenerator which will allow
     * Filter by all courses in which the user is enrolled in
 """
+from microsite_configuration import microsite
 from student.models import CourseEnrollment
 
 from search.filter_generator import SearchFilterGenerator
@@ -19,4 +20,20 @@ class LmsSearchFilterGenerator(SearchFilterGenerator):
             user_enrollments = CourseEnrollment.enrollments_for_user(kwargs['user'])
             field_dictionary['course'] = [unicode(enrollment.course_id) for enrollment in user_enrollments]
 
+        # if we have an org filter, only include results for this org filter
+        course_org_filter = microsite.get_value('course_org_filter')
+        if course_org_filter:
+            field_dictionary['org'] = course_org_filter
+
         return field_dictionary
+
+    def exclude_dictionary(self, **kwargs):
+        """ If we are not on a microsite, then exclude any microsites that are defined """
+        exclude_dictionary = super(LmsSearchFilterGenerator, self).exclude_dictionary(**kwargs)
+        course_org_filter = microsite.get_value('course_org_filter')
+        # If we have a course filter we are ensuring that we only get those courses above
+        org_filter_out_set = microsite.get_all_orgs()
+        if not course_org_filter and org_filter_out_set:
+            exclude_dictionary['org'] = list(org_filter_out_set)
+
+        return exclude_dictionary

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -43,7 +43,7 @@ git+https://github.com/pmitros/pyfs.git@96e1922348bfe6d99201b9512a9ed946c87b7e0b
 -e git+https://github.com/edx/edx-val.git@d6087908aa3dd05ceaa7f56a21284f86c53cb3f0#egg=edx-val
 -e git+https://github.com/pmitros/RecommenderXBlock.git@9b07e807c89ba5761827d0387177f71aa57ef056#egg=recommender-xblock
 -e git+https://github.com/edx/edx-milestones.git@547f2250ee49e73ce8d7ff4e78ecf1b049892510#egg=edx-milestones
--e git+https://github.com/edx/edx-search.git@9d566b88fd80cb0b60c052eee2bee30eb9f35b9c#egg=edx-search
+-e git+https://github.com/edx/edx-search.git@59c7b4a8b61e8f7c4607669ea48e070555cca2fe#egg=edx-search
 git+https://github.com/edx/edx-lint.git@8bf82a32ecb8598c415413df66f5232ab8d974e9#egg=edx_lint==0.2.1
 -e git+https://github.com/edx/xblock-utils.git@581ed636c862b286002bb9a3724cc883570eb54c#egg=xblock-utils
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive


### PR DESCRIPTION
Addresses SOL-825 and SOL-826 (Along with corresponding changes to edx-search - https://github.com/edx/edx-search/pull/15).

These changes add the org attribute to all documents in the courseware_content index, and provides filtering upon the content so as to:
i) Exclude "white label" content from showing up in dashboard search results for users who are enrolled in both core and white-label sites, when viewing core site
ii) Include only "white label" content in dashboard search results for users who are enrolled in both core and white-label sites, when viewing white-label site
(SOL-825)

Also, the same filtering changes enable documents within the course_info index to be similarly treated, so that course discovery searches will:
i) Exclude "white label" courses from showing up in discovery results when viewing core site
ii) Include only "white label" courses in discovery results when viewing white-label site
(SOL-826)
