### PR TITLE
Add fields to discussion thread list endpoint

### DIFF
--- a/lms/djangoapps/discussion_api/tests/test_views.py
+++ b/lms/djangoapps/discussion_api/tests/test_views.py
@@ -141,6 +141,7 @@ class ThreadViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         )
 
     def test_basic(self):
+        self.register_user_response(self.user, upvoted_ids=["test_thread"])
         source_threads = [{
             "id": "test_thread",
             "course_id": unicode(self.course.id),
@@ -152,6 +153,8 @@ class ThreadViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
             "body": "Test body",
             "pinned": False,
             "closed": False,
+            "abuse_flaggers": [],
+            "votes": {"up_count": 4},
             "comments_count": 5,
             "unread_comments_count": 3,
         }]
@@ -166,6 +169,10 @@ class ThreadViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
             "raw_body": "Test body",
             "pinned": False,
             "closed": False,
+            "following": False,
+            "abuse_flagged": False,
+            "voted": True,
+            "vote_count": 4,
             "comment_count": 5,
             "unread_comment_count": 3,
         }]
@@ -188,6 +195,7 @@ class ThreadViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         })
 
     def test_pagination(self):
+        self.register_user_response(self.user)
         self.register_get_threads_response([], page=1, num_pages=1)
         response = self.client.get(
             self.url,

--- a/lms/djangoapps/discussion_api/tests/utils.py
+++ b/lms/djangoapps/discussion_api/tests/utils.py
@@ -21,6 +21,18 @@ class CommentsServiceMockMixin(object):
             status=200
         )
 
+    def register_user_response(self, user, subscribed_thread_ids=None, upvoted_ids=None):
+        httpretty.register_uri(
+            httpretty.GET,
+            "http://localhost:4567/api/v1/users/{id}".format(id=user.id),
+            body=json.dumps({
+                "id": str(user.id),
+                "subscribed_thread_ids": subscribed_thread_ids or [],
+                "upvoted_ids": upvoted_ids or [],
+            }),
+            status=200
+        )
+
     def assert_last_query_params(self, expected_params):
         """
         Assert that the last mock request had the expected query parameters


### PR DESCRIPTION
This commit adds fields that are related to the requesting user's
interaction with the thread (e.g. following).

@BenjiLee @nasthagiri Please review
@cahrens @jimabramson FYI
