### PR TITLE
Bok-choy on chrome: fix sequence for adding user to team.

### DIFF
--- a/common/test/acceptance/pages/studio/users.py
+++ b/common/test/acceptance/pages/studio/users.py
@@ -64,7 +64,8 @@ class UsersPageMixin(PageObject):
         """
         Click on the "New Team Member" button
         """
-        self.q(css='.create-user-button').click()
+        self.q(css='.create-user-button').first.click()
+        self.wait_for(lambda: self.new_user_form_visible, "Add user form is visible")
 
     @property
     def new_user_form_visible(self):
@@ -88,8 +89,8 @@ class UsersPageMixin(PageObject):
 
     def add_user_to_course(self, email):
         """ Adds user to a course/library """
+        self.wait_for_element_visibility('.create-user-button', "Add team member button is available")
         self.click_add_button()
-        self.wait_for(lambda: self.new_user_form_visible, "Add user form is visible")
         self.set_new_user_email(email)
         self.click_submit_new_user_form()
 


### PR DESCRIPTION
TE-849

This passes fine in firefox; however in chrome, the click is occurring before
the page is ready; and then the click itself is not specific enough.
