### PR TITLE
Add params to CS query in thread list endpoint

### DIFF
--- a/lms/djangoapps/discussion_api/tests/test_views.py
+++ b/lms/djangoapps/discussion_api/tests/test_views.py
@@ -182,6 +182,8 @@ class ThreadViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         )
         self.assert_last_query_params({
             "course_id": [unicode(self.course.id)],
+            "sort_key": ["date"],
+            "sort_order": ["desc"],
             "page": ["1"],
             "per_page": ["10"],
             "recursive": ["False"],
@@ -200,6 +202,8 @@ class ThreadViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         )
         self.assert_last_query_params({
             "course_id": [unicode(self.course.id)],
+            "sort_key": ["date"],
+            "sort_order": ["desc"],
             "page": ["18"],
             "per_page": ["4"],
             "recursive": ["False"],


### PR DESCRIPTION
The thread list endpoint needs to restrict the set of threads it
retrieves if the course is cohorted and the user is not privileged.
This also adds an explicit default sort (by most recent activity).

@nasthagiri @BenjiLee Please review
@jimabramson @cahrens FYI
