### PR TITLE
[LTI Provider] Updating submissions dependency to pull in new scoring signals

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -35,7 +35,7 @@ git+https://github.com/pmitros/pyfs.git@96e1922348bfe6d99201b9512a9ed946c87b7e0b
 -e git+https://github.com/edx-solutions/django-splash.git@7579d052afcf474ece1239153cffe1c89935bc4f#egg=django-splash
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
 -e git+https://github.com/edx/edx-ora2.git@release-2015-04-29T15.45#egg=edx-ora2
--e git+https://github.com/edx/edx-submissions.git@8fb070d2a3087dd7656d27022e550d12e3b85ba3#egg=edx-submissions
+-e git+https://github.com/edx/edx-submissions.git@e2361932b9bce061a018a31bb3929e9cade80f49#egg=edx-submissions
 -e git+https://github.com/edx/opaque-keys.git@1254ed4d615a428591850656f39f26509b86d30a#egg=opaque-keys
 -e git+https://github.com/edx/ease.git@c6dee053eae6b3ac4fdf6be11fa7a9f8265540aa#egg=ease
 -e git+https://github.com/edx/i18n-tools.git@7b89d5e01c1a7cc5d69d813bd8c6b706a8f75119#egg=i18n-tools


### PR DESCRIPTION
This change bumps the version of the edx-submissions dependency to the latest on master. The submissions code has been modified to include two new signals that are triggered when a score changes. These signals are required for the LTI provider work, as described in https://github.com/edx/edx-platform/pull/7928.
