### PR TITLE
Fixes index function to not index children without published version

### DIFF
--- a/cms/djangoapps/contentstore/courseware_index.py
+++ b/cms/djangoapps/contentstore/courseware_index.py
@@ -176,7 +176,8 @@ class SearchIndexerBase(object):
                 skip_child_index = skip_index or \
                     (triggered_at is not None and (triggered_at - item.subtree_edited_on) > reindex_age)
                 for child_item in item.get_children():
-                    index_item(child_item, skip_index=skip_child_index)
+                    if modulestore.has_published_version(child_item):
+                        index_item(child_item, skip_index=skip_child_index)
 
             if skip_index or not item_index_dictionary:
                 return


### PR DESCRIPTION
@martynjames one-liner I believe fixes this new found issue.
get_children returns latest published version if any, but in cases when there is none it returns unpublished version. (for some reason ignoring modulestore revision setting)
