### PR TITLE
WIP Removed native date picker by making input type text

### DIFF
--- a/lms/templates/ccx/schedule.html
+++ b/lms/templates/ccx/schedule.html
@@ -85,12 +85,12 @@
       </div>
       <div class="field datepair">
         <b>${_('Start Date')}</b><br/>
-        <input placeholder="Date" type="date" class="date" name="start_date"/>
+        <input placeholder="Date" type="text" class="date" name="start_date"/>
         <input placeholder="time" type="time" class="time" name="start_time"/>
       </div>
       <div class="field datepair">
         <b>${_('Due Date')}</b> ${_('(Optional)')}<br/>
-        <input placeholder="Date" type="date" class="date" name="due_date"/>
+        <input placeholder="Date" type="text" class="date" name="due_date"/>
         <input placeholder="time" type="time" class="time" name="due_time"/>
       </div>
       <div class="field">
@@ -123,6 +123,19 @@ $(function() {
     $('.datepair .date').datepicker({
         'dateFormat': 'yy-mm-dd',
         'autoclose': true
+    });
+    $('.datepair .date').change(function() {
+       var date = $(this).val();
+       var dateParts;
+       var year;
+       if (date) {
+          dateParts = date.split('-');
+          year = parseInt(dateParts[0]);
+          if (year >= 0 && year < 100) {
+              year = year + 2000;
+              $(this).val(year + "-" + dateParts[1] + "-" + dateParts[2]);
+          }
+       }
     });
 });
 </script>


### PR DESCRIPTION
Hi 

Working for MIT ODL. Previously app was showing 2 date pickers on chrome browser and one date picker on reset of browsers, I have changed input type=date to type=text, now it is showing only customise date picker.

Added a validation, If user enters a date less then 100 , app with change it to **val + 2000**, means if user enters 0001-2-21 on focus out it will change it to 2001-2-21

https://github.com/jazkarta/edx-platform/issues/63
https://github.com/jazkarta/edx-platform/issues/30

@carsongee @pdpinch @pwilkins

![screen shot 2015-05-06 at 3 47 39 pm](https://cloud.githubusercontent.com/assets/10431250/7494516/7ebe058a-f421-11e4-912d-943a44c146c0.png)
