### PR TITLE
(WIP / Demo) Course outline styling adjustments

### DIFF
--- a/lms/static/sass/base/_variables.scss
+++ b/lms/static/sass/base/_variables.scss
@@ -400,7 +400,7 @@ $modal-bg-color: rgb(245,245,245);
 // MISC: sidebar
 $sidebar-chapter-bg-top: rgba(255, 255, 255, .6);
 $sidebar-chapter-bg-bottom: rgba(255, 255, 255, 0);
-$sidebar-chapter-bg: rgb(238,238,238); // #eeeeee
+$sidebar-chapter-bg: $gray-l6;
 $sidebar-active-image: linear-gradient(top, rgb(230,230,230), rgb(214,214,214));
 
 // TOP HEADER IMAGE MARGIN

--- a/lms/static/sass/course-rtl.scss.mako
+++ b/lms/static/sass/course-rtl.scss.mako
@@ -31,6 +31,7 @@
 
 
 // course - base
+@import 'course/base/layout';
 @import 'course/layout/courseware_header';
 @import 'course/layout/courseware_preview';
 @import 'course/layout/footer';

--- a/lms/static/sass/course.scss.mako
+++ b/lms/static/sass/course.scss.mako
@@ -30,6 +30,7 @@
 @import 'elements/navigation'; // all archetypes of navigation
 
 // course - base
+@import 'course/base/layout';
 @import 'course/layout/courseware_header';
 @import 'course/layout/courseware_preview';
 @import 'course/layout/footer';

--- a/lms/static/sass/course/_gradebook.scss
+++ b/lms/static/sass/course/_gradebook.scss
@@ -4,7 +4,7 @@ $table-border-color: #c8c8c8;
 div.gradebook-wrapper {
 
   section.gradebook-content {
-    @extend .content;
+    @extend .content-old;
     display: block;
     width: 100%;
     @include clearfix();

--- a/lms/static/sass/course/_info.scss
+++ b/lms/static/sass/course/_info.scss
@@ -1,7 +1,7 @@
 div.info-wrapper {
 
   section.updates {
-    @extend .content;
+    @extend .content-old;
     line-height: lh();
 
     > h1 {
@@ -78,7 +78,7 @@ div.info-wrapper {
   }
 
   section.handouts {
-    @extend .sidebar;
+    @extend .sidebar-old;
     border-radius: 0 4px 4px 0;
     @include border-left(1px solid #ddd);
     box-shadow: none;

--- a/lms/static/sass/course/_profile.scss
+++ b/lms/static/sass/course/_profile.scss
@@ -2,7 +2,7 @@
   color: $black;
 
   .user-info {
-    @extend .sidebar;
+    @extend .sidebar-old;
     border-left: 1px solid #d3d3d3;
     border-radius: 0px 4px 4px 0;
     border-right: 0;
@@ -131,7 +131,7 @@
   }
 
   .course-info {
-    @extend .content;
+    @extend .content-old;
 
     header {
       @extend .clearfix;

--- a/lms/static/sass/course/_student-notes.scss
+++ b/lms/static/sass/course/_student-notes.scss
@@ -42,7 +42,7 @@ $divider-visual-tertiary: ($baseline/20) solid $gray-l4;
 
     .student-notes {
       @include clearfix();
-      @extend .content; // needed extend carried over from course handouts UI, but should be cleaned up
+      @extend .content-old; // needed extend carried over from course handouts UI, but should be cleaned up
       width: 100%;
     }
   }

--- a/lms/static/sass/course/_textbook.scss
+++ b/lms/static/sass/course/_textbook.scss
@@ -18,7 +18,7 @@ div.book-wrapper {
   }
 
   section.book-sidebar {
-    @extend .sidebar;
+    @extend .sidebar-old;
     @extend .tran;
     @include box-sizing(border-box);
     padding: ($baseline/2) 0;
@@ -102,7 +102,7 @@ div.book-wrapper {
   }
 
   .book {
-    @extend .content;
+    @extend .content-old;
     padding: 0;
     width:76%;
 

--- a/lms/static/sass/course/base/_extends.scss
+++ b/lms/static/sass/course/base/_extends.scss
@@ -1,14 +1,26 @@
 // lms - course - extends
 // ====================
 
-// lms inner wrapper
+// Table of Contents 
+// * +LMS - Inner Wrapper
+// * +Older Headers and Buttons  [TO-DO]
+// * +Extends - Content Old [TO-DO]
+// * +Extends - Sidebar Old [TO-DO]
+// * +Extends - Topbar
+// * +Extends - Transition
+
+
+// +LMS - Inner Wrapper
+// ==================== 
 %inner-wrapper {
   margin: 0 auto;
   max-width: 1180px;
   width: flex-grid(12);
 }
 
-// Older Course Extends - to review/remove with LMS cleanup
+// +Older Course Extends
+// ==================== 
+// TO-DO: remove or cleanup and use current standards / patterns
 h1.top-header {
   border-bottom: 1px solid $border-color-2;
   @include text-align(left);
@@ -45,19 +57,26 @@ h1.top-header {
   font-size: em(13);
 }
 
-.content {
+// +Extends - Content Old
+// ==================== 
+// TO-DO: remove or cleanup and use current standards / patterns
+.content-old {
   @include box-sizing(border-box);
   display: table-cell;
   padding: 2em 2.5em;
   vertical-align: top;
-  width: flex-grid(9) + flex-gutter();
+  width: flex-grid(9);
 
   @media print {
     box-shadow: none;
   }
 }
 
-.sidebar {
+
+// +Extends - Sidebar Old
+// ==================== 
+// TO-DO: remove or cleanup use of old sidebar extend
+.sidebar-old {
   @include box-sizing(border-box);
   display: table-cell;
   font-family: $sans-serif;
@@ -175,6 +194,8 @@ h1.top-header {
   }
 }
 
+// +Extends - Topbar
+// ==================== 
 .topbar {
   @extend .clearfix;
   border-bottom: 1px solid $border-color;
@@ -195,6 +216,8 @@ h1.top-header {
   }
 }
 
+// +Extends - Transition
+// ==================== 
 .tran {
   @include transition( all .2s $ease-in-out-quad 0s);
 }

--- a/lms/static/sass/course/base/_layout.scss
+++ b/lms/static/sass/course/base/_layout.scss
@@ -15,7 +15,7 @@
 %content-primary {
 	@include float(left);
 	@include margin-right(flex-gutter());
-	width: flex-grid(8,12);
+	width: flex-grid(9,12);
 	box-shadow: none;
 	border: 0;
 	background-color: $white;
@@ -25,5 +25,5 @@
 // ==================== 
 %content-supplementary {
 	@include float(left);
-	width: flex-grid(4,12);
+	width: flex-grid(3,12);
 }

--- a/lms/static/sass/course/base/_layout.scss
+++ b/lms/static/sass/course/base/_layout.scss
@@ -1,0 +1,29 @@
+// lms - course - layout
+// ====================
+
+// Table of Contents 
+// * +Basic Page Content
+// * +Primary Content
+// * +Supplementary Content
+
+// +Basic Page Content
+// ==================== 
+
+
+// +Primary Content
+// ==================== 
+%content-primary {
+	@include float(left);
+	@include margin-right(flex-gutter());
+	width: flex-grid(8,12);
+	box-shadow: none;
+	border: 0;
+	background-color: $white;
+}
+
+// +Supplementary Content
+// ==================== 
+%content-supplementary {
+	@include float(left);
+	width: flex-grid(4,12);
+}

--- a/lms/static/sass/course/courseware/_courseware.scss
+++ b/lms/static/sass/course/courseware/_courseware.scss
@@ -1,3 +1,19 @@
+// lms - views - courseware
+// ====================
+ 
+// Table of Contents 
+// * +Deprecated - Resets  [TO-DO]
+// * +Instructor Info [TO-DO]
+// * +Course Wrapper - Base
+// * +Course Wrapper - Home
+// * +Course Wrapper - Content Views
+// * +Miscellaneous Resets and Overrides [TO-DO]
+
+
+// +Deprecated - Resets
+// ==================== 
+// not clear when these are necessary, TO-DO: cleanup / review
+
 html {
   height: 100%;
   max-height: 100%;
@@ -10,6 +26,10 @@ html.video-fullscreen{
     overflow: hidden;
   }
 }
+
+// +Instructor Info 
+// ==================== 
+// not clear when this is used, TO-DO: cleanup / review
 
 .wrap-instructor-info {
   margin: ($baseline/2) ($baseline/4) 0 0;
@@ -39,11 +59,40 @@ html.video-fullscreen{
   }
 }
 
+// +Course Wrapper - Base
+// ==================== 
+.course-wrapper {
+  
+}
+
+// +Course Wrapper - Home 
+// ==================== 
+// TO-DO: nest within .view-outline once tag has been added to <body>
+.course-wrapper.home {
+  background-color: $gray-l6; // TO-DO remove / fix specificity 
+
+  .course-content {
+    @extend %content-supplementary;
+    padding: 0;
+    @include padding-left($baseline/2);
+
+    h2 {
+      // TO-DO use class instead of element selector 
+      text-transform: none;
+      letter-spacing: normal;
+    }
+
+  }
+}
+
+// +Course Wrapper - Old Content Views 
+// ==================== 
 div.course-wrapper {
   position: relative;
 
-  section.course-content {
-    @extend .content;
+
+  .course-content {
+    @extend .content-old;
     padding: 40px;
     line-height: 1.6;
 
@@ -276,10 +325,12 @@ div.course-wrapper {
   }
 }
 
+
+// +Miscellaneous Resets and Overrides
+// ==================== 
+
 .xmodule_VideoModule {
   margin-bottom: ($baseline*1.5);
-
-
 }
 
 textarea.short-form-response {

--- a/lms/static/sass/course/courseware/_courseware_search.scss
+++ b/lms/static/sass/course/courseware/_courseware_search.scss
@@ -1,45 +1,5 @@
-.course-index .courseware-search-bar {
-
-  @include box-sizing(border-box);
-  position: relative;
-  padding: 5px;
-  box-shadow: 0 1px 0 #fff inset, 0 -1px 0 rgba(0, 0, 0, .1) inset;
-  font-family: $sans-serif;
-
-  .search-field {
-    @include box-sizing(border-box);
-    top: 5px;
-    width: 100%;
-    @include border-radius(4px);
-    background: $white-t1;
-    &.is-active {
-      background: $white;
-    }
-  }
-
-  .search-button, .cancel-button {
-    @include box-sizing(border-box);
-    color: #888;
-    font-size: 14px;
-    font-weight: normal;
-    display: block;
-    position: absolute;
-    right: 12px;
-    top: 5px;
-    height: 35px;
-    line-height: 35px;
-    padding: 0;
-    border: none;
-    box-shadow: none;
-    background: transparent;
-  }
-
-  .cancel-button {
-    display: none;
-  }
-
-}
-
+// lms - views - search results
+// ====================
 
 .courseware-search-results {
 

--- a/lms/static/sass/course/courseware/_sidebar.scss
+++ b/lms/static/sass/course/courseware/_sidebar.scss
@@ -1,8 +1,97 @@
-.course-index {
-  @extend .sidebar;
+// lms - views - course outline
+// ====================
+// TO-DO: rename partial to _outline instead of _sidebar
+ 
+// Table of Contents 
+// * +Outline - Sidebar [TO-DO]
+// * +CASE: Outline - Home [TO-DO]
+// * +Outline - Sidebar Old [TO-DO]
+
+
+// +Outline - Sidebar 
+// ==================== 
+.course-wrapper .course-index {
   @extend .tran;
-  @include border-right(1px solid $border-color-2);
+  @include box-sizing(border-box);
+  @include border-right(1px solid $border-color-l3);
   @include border-radius(3px, 0, 0, 3px);
+  width: flex-grid(3);
+
+  .ui-accordion {
+
+
+    .chapter {
+      background-color: $sidebar-chapter-bg;
+      border-bottom: 1px solid $border-color-l3;
+
+      &.is-open {
+        background: $white;
+      }
+
+      &:first-child {
+        border-radius: 3px 0 0 0;
+      }
+
+      &:last-child {
+        border-radius: 0 0 0 3px;
+        box-shadow: 0 1px 0 $white inset;
+      }
+
+      &:hover, &:focus {
+        background-color: $action-primary-focused-fg;
+      }
+    }
+  }
+
+  .ui-accordion-header {
+    padding: ($baseline/2);
+  }
+
+  .ui-accordion-content {
+    padding: 0 $baseline ($baseline/2);
+
+    // TO-DO: add class instead of using element selector
+    a {
+      border-radius: 3px;
+      padding: ($baseline/2) ($baseline*2) ($baseline/2) ($baseline/2);
+
+    }
+
+  }
+}
+
+// +CASE: Outline - Home 
+// ==================== 
+.course-wrapper.home .course-index {
+  // TO-DO: replace .course-wrapper with nesting using .view-outline once tag has been added to <body>
+  @extend %content-primary;
+  @include border-right(1px solid $border-color-l3);
+
+
+  .chapter {
+    @include box-sizing(border-box);
+    background-color: $gray-l6;
+    border-radius: 3px;
+    border: 1px solid $border-color-l3;
+    margin: ($baseline/2);
+
+    &:first-child, &:last-child {
+      border-radius: 3px;
+    }
+
+    &:hover, &:focus {
+      border-color: $action-primary-focused-bg;
+    }
+
+  }
+}
+
+
+// +Outline - Sidebar Old
+// ==================== 
+// TO-DO: review for sass cleanups and update to current standards 
+.course-index {
+  @extend .sidebar-old;
 
   #open_close_accordion {
     display: none;
@@ -16,7 +105,7 @@
     }
   }
 
-  div#accordion {
+  .ui-accordion {
     width: auto;
     font-size: 14px;
 
@@ -25,10 +114,6 @@
       margin: 0;
       overflow: visible;
       font-size: 16px;
-
-      &:first-child {
-        border: none;
-      }
 
       &:hover, &:focus {
         color: #666;
@@ -41,7 +126,6 @@
       }
 
       &.ui-accordion-header {
-        border-bottom: none;
         color: $black;
 
         a {
@@ -61,7 +145,6 @@
         }
 
         span.ui-icon {
-          @include left(0);
           opacity: 0.3;
           background-image: url("/static/images/ui-icons_222222_256x240.png");  // jQuery UI sprite
 
@@ -82,30 +165,10 @@
     }
 
     .chapter {
-      width: 100% !important;
       @include box-sizing(border-box);
-      padding: 11px 14px;
-      @include linear-gradient(top, $sidebar-chapter-bg-top, $sidebar-chapter-bg-bottom);
       background-color: $sidebar-chapter-bg;
-      box-shadow: 0 1px 0 $white inset, 0 -1px 0 $shadow-l1 inset;
       @include transition(background-color .1s linear 0s);
 
-      &.is-open {
-        background: $white;
-      }
-
-      &:first-child {
-        border-radius: 3px 0 0 0;
-      }
-
-      &:last-child {
-        border-radius: 0 0 0 3px;
-        box-shadow: 0 1px 0 $white inset;
-      }
-
-      &:hover, &:focus {
-        background-color: $white;
-      }
     }
 
     ul.ui-accordion-content {
@@ -113,9 +176,7 @@
       border: none;
       border-radius: 0;
       margin: 0;
-      padding: 9px 0 9px 9px;
       overflow: auto;
-      width: 100%;
 
       li {
         border-bottom: 0;
@@ -124,9 +185,7 @@
 
         a {
           background: transparent;
-          border-radius: 4px;
           display: block;
-          padding: ($baseline/4) 36px ($baseline/4) ($baseline/2);
           position: relative;
           text-decoration: none;
 
@@ -169,6 +228,7 @@
 
         &.active {
           font-weight: bold;
+          background-color: $gray-l5;
 
           &:after {
             content: '›';
@@ -210,7 +270,7 @@
              position: absolute;
              top: 0;
              bottom: 0;
-             right: 7px;
+             right: ($baseline/2);
            }
           }
 

--- a/lms/static/sass/course/courseware/_sidebar.scss
+++ b/lms/static/sass/course/courseware/_sidebar.scss
@@ -67,6 +67,64 @@
   @extend %content-primary;
   @include border-right(1px solid $border-color-l3);
 
+  .wrapper-course-nav-tools {
+    padding: ($baseline/2);
+
+    // UI: courseware search bar
+    .course-tools-header {
+      @extend %t-regular;
+      @include box-sizing(border-box);
+      width: flex-grid(3);
+      display: inline-block;
+      margin: ($baseline/4);
+    }
+
+
+    // UI: courseware search bar
+    .courseware-search-bar {
+      @include box-sizing(border-box);
+      width: flex-grid(3);
+      display: inline-block;
+      position: relative;
+      float: right;
+
+      .search-field {
+        @include box-sizing(border-box);
+        box-shadow: none;
+        border-radius: 3px;
+        width: 100%;
+        background: $white-t1;
+
+        &.is-active {
+          background: $white;
+        }
+      }
+
+      .search-button, .cancel-button {
+        @include box-sizing(border-box);
+        @include right(12px);
+        color: #888;
+        font-size: 14px;
+        font-weight: normal;
+        display: block;
+        position: absolute;
+        top: 0;
+        height: 35px;
+        line-height: 35px;
+        padding: 0;
+        border: none;
+        box-shadow: none;
+        background: transparent;
+      }
+
+      .cancel-button {
+        display: none;
+      }
+
+    }
+
+
+  }
 
   .chapter {
     @include box-sizing(border-box);
@@ -82,6 +140,25 @@
     &:hover, &:focus {
       border-color: $action-primary-focused-bg;
     }
+
+  }
+}
+
+// +UI: Outline - Supplemental Info 
+// ==================== 
+.course-content {
+  padding:  $baseline;
+
+  .header-outline-info {
+    @extend %t-title7;
+    @extend %t-ultrastrong;
+    text-transform: uppercase;
+    margin-bottom: 0;
+  }
+  
+  .content-outline-info {
+    margin-bottom: $baseline;
+    display: inline-block;
 
   }
 }

--- a/lms/static/sass/course/instructor/_instructor.scss
+++ b/lms/static/sass/course/instructor/_instructor.scss
@@ -15,7 +15,7 @@
   }
 
   section.instructor-dashboard-content {
-    @extend .content;
+    @extend .content-old;
     padding: 40px;
     width: 100%;
 

--- a/lms/static/sass/course/instructor/_instructor_2.scss
+++ b/lms/static/sass/course/instructor/_instructor_2.scss
@@ -138,7 +138,7 @@
 // instructor dashboard 2
 // ====================
 .instructor-dashboard-content-2 {
-  @extend .content;
+  @extend .content-old;
   width: 100%;
   padding: 40px;
 

--- a/lms/static/sass/course/wiki/_sidebar.scss
+++ b/lms/static/sass/course/wiki/_sidebar.scss
@@ -1,5 +1,5 @@
 div#wiki_panel {
-  @extend .sidebar;
+  @extend .sidebar-old;
   overflow: auto;
 
   ul {

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -140,29 +140,32 @@ ${fragment.foot_html()}
 % endif
 
 <div class="container">
-  <div class="course-wrapper">
+  ## TO-DO: apply home class only for main courseware tab experience
+  <div class="course-wrapper home">
 
 % if disable_accordion is UNDEFINED or not disable_accordion:
     <div class="course-index" role="navigation">
-      <header id="open_close_accordion">
-        <a href="#">${_("close")}</a>
-      </header>
-
-      % if settings.FEATURES.get('ENABLE_COURSEWARE_SEARCH'):
-        <div id="courseware-search-bar" class="courseware-search-bar" role="search" aria-label="Course">
-          <form>
-            <label for="course-search-input" class="sr">${_('Course Search')}</label>
-            <input id="course-search-input" type="text" class="search-field"/>
-            <button type="submit" class="search-button">
-              ${_('search')} <i class="icon fa fa-search" aria-hidden="true"></i>
-            </button>
-            <button type="button" class="cancel-button" aria-label="${_('Clear search')}">
-              <i class="icon fa fa-remove" aria-hidden="true"></i>
-            </button>
-          </form>
+      <header class="wrapper-course-nav-tools">
+        <h2 class="course-tools-header">${_('Course Outline')}</h2>
+        <div id="open_close_accordion">
+          <a href="#">${_("close")}</a>
         </div>
-      % endif
 
+        % if settings.FEATURES.get('ENABLE_COURSEWARE_SEARCH'):
+          <div id="courseware-search-bar" class="courseware-search-bar" role="search" aria-label="Course">
+            <form>
+              <label for="course-search-input" class="sr">${_('Course Search')}</label>
+              <input id="course-search-input" type="text" class="search-field"/>
+              <button type="submit" class="search-button">
+                ${_('search')} <i class="icon fa fa-search" aria-hidden="true"></i>
+              </button>
+              <button type="button" class="cancel-button" aria-label="${_('Clear search')}">
+                <i class="icon fa fa-remove" aria-hidden="true"></i>
+              </button>
+            </form>
+          </div>
+        % endif
+      </header>
       <div id="accordion" style="display: none">
         <nav aria-label="${_('Course Navigation')}">
           % if accordion.strip():

--- a/lms/templates/courseware/welcome-back.html
+++ b/lms/templates/courseware/welcome-back.html
@@ -2,9 +2,11 @@
 from django.utils.translation import ugettext as _ 
 %>
 
-<h2>${chapter_module.display_name_with_default}</h2>
+<h2>Welcome to ${course.display_org_with_default | h}'s ${course.display_name_with_default}</h2>
 
-<p>${_("You were most recently in {section_link}.  If you\'re done with that, choose another section on the left.").format(
+<span>${chapter_module.display_name_with_default}</span>
+
+<p>${_("You were most recently in {section_link}.").format(
 	    section_link=u'<a href="{url}">{section_name}</a>'.format(
 	        url=prev_section_url,
 	        section_name=prev_section.display_name_with_default,

--- a/lms/templates/courseware/welcome-back.html
+++ b/lms/templates/courseware/welcome-back.html
@@ -2,13 +2,8 @@
 from django.utils.translation import ugettext as _ 
 %>
 
-<h2>Welcome to ${course.display_org_with_default | h}'s ${course.display_name_with_default}</h2>
+<h2 class="header-outline-info">${course.display_org_with_default | h}</h2>
+<span class="content-outline-info">${course.display_name_with_default}</span>
 
-<span>${chapter_module.display_name_with_default}</span>
-
-<p>${_("You were most recently in {section_link}.").format(
-	    section_link=u'<a href="{url}">{section_name}</a>'.format(
-	        url=prev_section_url,
-	        section_name=prev_section.display_name_with_default,
-	    )
-    )}</p>
+<h2 class="header-outline-info">${_("Last Visit")}</h2>
+<a href="{prev_section_url}" class="content-outline-info">${chapter_module.display_name_with_default} <i class="icon fa fa-caret-right" aria-hidden="true"></i> ${prev_section.display_name_with_default}</a>


### PR DESCRIPTION
**Description** This is a demo PR to show some of the styling cleanup / rewrite for the course outline (home / sidebar cases). The idea is to share this with @talbs  and @clrux to see how similar this work is to a11y improvements we'd like to also make to this sidebar. 
**JIRA Story** related to: ([UX-2101](https://openedx.atlassian.net/browse/UX-2101))
**Confluence / Product Asset** This relates to the bookmarks + search experience cleanup described here: ([Search + Bookmarks Experience](https://openedx.atlassian.net/wiki/pages/viewpage.action?pageId=28279473))
**Sandbox URL** (Last Updated: 05/06) ([pr7947.m.sandbox.edx.org](http://pr7947.m.sandbox.edx.org))
**Dependencies** N/A
**PR Author(s) Notes / To-Do** N/A

**Reviewers**
Code: N/A; UX: No review necessary, this is meant to provide context for another story / UX change. 
