### PR TITLE
Hiding Billing Address for Orders without Billing Addresses

### DIFF
--- a/lms/static/js/commerce/views/receipt_view.js
+++ b/lms/static/js/commerce/views/receipt_view.js
@@ -109,16 +109,20 @@ var edx = edx || {};
                     purchasedDatetime: order.date_placed,
                     totalCost: self.formatMoney(order.total_excl_tax),
                     isRefunded: false,
-                    billedTo: {
+                    items: [],
+                    billedTo: null
+                };
+
+                if (order.billing_address){
+                    receiptContext.billedTo = {
                         firstName: order.billing_address.first_name,
                         lastName: order.billing_address.last_name,
                         city: order.billing_address.city,
                         state: order.billing_address.state,
                         postalCode: order.billing_address.postcode,
                         country: order.billing_address.country
-                    },
-                    items: []
-                };
+                    }
+                }
 
                 receiptContext.items = _.map(
                     order.lines,

--- a/lms/templates/commerce/receipt.underscore
+++ b/lms/templates/commerce/receipt.underscore
@@ -61,16 +61,18 @@
           <% } %>
         </div>
 
-        <div class="copy">
-          <p><%- gettext( "Billed to" ) %>:
-              <span class="name-first"><%- receipt.billedTo.firstName %></span>
-              <span class="name-last"><%- receipt.billedTo.lastName %></span>
-              (<span class="address-city"><%- receipt.billedTo.city %></span>,
-              <span class="address-state"><%- receipt.billedTo.state %></span>
-              <span class="address-postalcode"><%- receipt.billedTo.postalCode %></span>
-              <span class="address-country"><%- receipt.billedTo.country.toUpperCase() %></span>)
-          </p>
-        </div>
+        <% if ( receipt.billedTo ) { %>
+            <div class="copy">
+              <p><%- gettext( "Billed to" ) %>:
+                  <span class="name-first"><%- receipt.billedTo.firstName %></span>
+                  <span class="name-last"><%- receipt.billedTo.lastName %></span>
+                  (<span class="address-city"><%- receipt.billedTo.city %></span>,
+                  <span class="address-state"><%- receipt.billedTo.state %></span>
+                  <span class="address-postalcode"><%- receipt.billedTo.postalCode %></span>
+                  <span class="address-country"><%- receipt.billedTo.country.toUpperCase() %></span>)
+              </p>
+            </div>
+        <% } %>
       </div>
     </div>
     <% } else { %>


### PR DESCRIPTION
Some orders, specifically those paid for with PayPal, do not have a billing address. This information will not be rendered in such cases.

@jimabramson @rlucioni 
