### PR TITLE
skip test that are causing incorrect pep8 reports in jenkins builds

### DIFF
--- a/pavelib/paver_tests/test_paver_quality.py
+++ b/pavelib/paver_tests/test_paver_quality.py
@@ -71,6 +71,7 @@ class TestPaverRunQuality(unittest.TestCase):
         self.addCleanup(patcher.stop)
         self.addCleanup(self._mock_paver_needs.stop)
 
+    @unittest.skip("TODO: TE-868")
     def test_failure_on_diffquality_pep8(self):
         """
         If pep8 finds errors, pylint should still be run
@@ -89,6 +90,7 @@ class TestPaverRunQuality(unittest.TestCase):
         self.assertEqual(_mock_pep8_violations.call_count, 1)
         self.assertEqual(self._mock_paver_sh.call_count, 1)
 
+    @unittest.skip("TODO: TE-868")
     def test_failure_on_diffquality_pylint(self):
         """
         If diff-quality fails on pylint, the paver task should also fail
@@ -107,6 +109,7 @@ class TestPaverRunQuality(unittest.TestCase):
         # And assert that sh was called once (for the call to "pylint")
         self.assertEqual(self._mock_paver_sh.call_count, 1)
 
+    @unittest.skip("TODO: Fix order dependency on test_no_diff_quality_failures")
     def test_other_exception(self):
         """
         If diff-quality fails for an unknown reason on the first run (pep8), then
@@ -118,6 +121,7 @@ class TestPaverRunQuality(unittest.TestCase):
         # Test that pylint is NOT called by counting calls
         self.assertEqual(self._mock_paver_sh.call_count, 1)
 
+    @unittest.skip("TODO: TE-868")
     def test_no_diff_quality_failures(self):
         # Assert nothing is raised
         _mock_pep8_violations = MagicMock(return_value=(0, []))


### PR DESCRIPTION
@benpatterson @jzoldak Please review.  This is to skip the tests that are creating false pep8 reports on builds. We have a ticket to fix them, but this will at least make the diff_quality_pep8.html reports accurate in the mean time.

For comparison, the cms-js-commonlib shards:
- [of a build for this PR](https://build.testeng.edx.org/job/edx-platform-test-subset/53546/artifact/reports/)
- [of a recent master build](https://build.testeng.edx.org/job/edx-platform-test-subset/53093/artifact/reports/)
