### PR TITLE
Update django-debug-toolbar-mongo to work with DJDT 1.x

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -118,7 +118,6 @@ django-cors-headers==0.13
 
 # Debug toolbar
 django_debug_toolbar==1.2.2
-django-debug-toolbar-mongo
 
 # Used for testing
 astroid==1.3.4

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -25,6 +25,8 @@ git+https://github.com/mfogel/django-settings-context-processor.git@b758c3930862
 # back to master when and if this fix is merged back.
 # fs==0.4.0
 git+https://github.com/pmitros/pyfs.git@96e1922348bfe6d99201b9512a9ed946c87b7e0b
+# The officially released version of django-debug-toolbar-mongo doesn't support DJDT 1.x. This commit does.
+git+https://github.com/hmarr/django-debug-toolbar-mongo.git@b0686a76f1ce3532088c4aee6e76b9abe61cc808
 
 # Our libraries:
 -e git+https://github.com/edx/XBlock.git@1934a2978cdd3e2414486c74b76e3040ff1fb138#egg=XBlock


### PR DESCRIPTION
@doctoryes, @singingwolfboy (or whoever you think is appropriate):

The version of django-debug-toolbar-mongo we have installed does
not support our version of Django Debug Toolbar. The author did
accept a patch that supports the latest version, but has not
published it to PyPI. This just grabs it from the github commit
instead.

Note: This will not uninstall your old version. If the MongoDB info
is not showing up for you in DJDT, try manually uninstalling with:

  `pip uninstall django-debug-toolbar-mongo`

Running "paver lms" after that should install the right thing.
