### PR TITLE
Update in-course reverification XBlock SHA in requirements.

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -47,7 +47,7 @@ git+https://github.com/pmitros/pyfs.git@96e1922348bfe6d99201b9512a9ed946c87b7e0b
 git+https://github.com/edx/edx-lint.git@8bf82a32ecb8598c415413df66f5232ab8d974e9#egg=edx_lint==0.2.1
 -e git+https://github.com/edx/xblock-utils.git@581ed636c862b286002bb9a3724cc883570eb54c#egg=xblock-utils
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
--e git+https://github.com/edx/edx-reverification-block.git@5da515ef229e73a137d366beb05ea4aea5881960#egg=edx-reverification-block
+-e git+https://github.com/edx/edx-reverification-block.git@2ff0d21f6614874067168bd244e68d8215041f3b#egg=edx-reverification-block
 git+https://github.com/edx/ecommerce-api-client.git@0.3.0#egg=ecommerce-api-client==0.3.0
 
 # Third Party XBlocks


### PR DESCRIPTION
Update to the latest version of the in-course reverification XBlock (feature complete).  Includes [these changes](https://github.com/edx/edx-reverification-block/compare/5da515ef229e73a137d366beb05ea4aea5881960...2ff0d21f6614874067168bd244e68d8215041f3b).

@awais786 @zubair-arbi @aamir-khan looks right?
