### PR TITLE
Configuration error on course re-run

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -38,7 +38,7 @@ git+https://github.com/hmarr/django-debug-toolbar-mongo.git@b0686a76f1ce3532088c
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
 -e git+https://github.com/edx/edx-ora2.git@release-2015-05-08T16.15#egg=edx-ora2
 -e git+https://github.com/edx/edx-submissions.git@e2361932b9bce061a018a31bb3929e9cade80f49#egg=edx-submissions
--e git+https://github.com/edx/opaque-keys.git@1254ed4d615a428591850656f39f26509b86d30a#egg=opaque-keys
+-e git+https://github.com/edx/opaque-keys.git@df0dd602869e498e512659bb4bd243309e30e19a#egg=opaque-keys
 -e git+https://github.com/edx/ease.git@c6dee053eae6b3ac4fdf6be11fa7a9f8265540aa#egg=ease
 -e git+https://github.com/edx/i18n-tools.git@7b89d5e01c1a7cc5d69d813bd8c6b706a8f75119#egg=i18n-tools
 -e git+https://github.com/edx/edx-oauth2-provider.git@0.5.1#egg=oauth2-provider


### PR DESCRIPTION
Fixed Configuration error on course re-run by updating Regex in `Opaque-keys` repo. 
Wrote Unit test to verify that if an asset has `%` in its filename. 
[TNL 2098](https://openedx.atlassian.net/browse/TNL-2098)
