### PR TITLE
Course navigation markup and styles

### DIFF
--- a/common/djangoapps/embargo/api.py
+++ b/common/djangoapps/embargo/api.py
@@ -10,6 +10,9 @@ import pygeoip
 
 from django.core.cache import cache
 from django.conf import settings
+from rest_framework.response import Response
+from rest_framework import status
+from ipware.ip import get_ip
 
 from embargo.models import CountryAccessRule, RestrictedCourse
 
@@ -166,3 +169,30 @@ def _country_code_from_ip(ip_addr):
         return pygeoip.GeoIP(settings.GEOIPV6_PATH).country_code_by_addr(ip_addr)
     else:
         return pygeoip.GeoIP(settings.GEOIP_PATH).country_code_by_addr(ip_addr)
+
+
+def get_embargo_response(request, course_id, user):
+    """
+    Check whether any country access rules block the user from enrollment.
+
+    Args:
+        request (HttpRequest): The request object
+        course_id (str): The requested course ID
+        user (str): The current user object
+
+    Returns:
+        HttpResponse: Response of the embargo page if embargoed, None if not
+
+    """
+    redirect_url = redirect_if_blocked(
+        course_id, user=user, ip_address=get_ip(request), url=request.path)
+    if redirect_url:
+        return Response(
+            status=status.HTTP_403_FORBIDDEN,
+            data={
+                "message": (
+                    u"Users from this location cannot access the course '{course_id}'."
+                ).format(course_id=course_id),
+                "user_message_url": request.build_absolute_uri(redirect_url)
+            }
+        )

--- a/common/djangoapps/enrollment/tests/test_views.py
+++ b/common/djangoapps/enrollment/tests/test_views.py
@@ -26,6 +26,7 @@ from util.models import RateLimitConfiguration
 from util.testing import UrlResetMixin
 from enrollment import api
 from enrollment.errors import CourseEnrollmentError
+from openedx.core.lib.django_test_client_utils import get_absolute_url
 from openedx.core.djangoapps.user_api.models import UserOrgTag
 from student.tests.factories import UserFactory, CourseModeFactory
 from student.models import CourseEnrollment
@@ -725,10 +726,6 @@ class EnrollmentEmbargoTest(EnrollmentTestMixin, UrlResetMixin, ModuleStoreTestC
             'user': self.user.username
         })
 
-    def _get_absolute_url(self, path):
-        """ Generate an absolute URL for a resource on the test server. """
-        return u'http://testserver/{}'.format(path.lstrip('/'))
-
     def assert_access_denied(self, user_message_path):
         """
         Verify that the view returns HTTP status 403 and includes a URL in the response, and no enrollment is created.
@@ -741,7 +738,7 @@ class EnrollmentEmbargoTest(EnrollmentTestMixin, UrlResetMixin, ModuleStoreTestC
 
         # Expect that the redirect URL is included in the response
         resp_data = json.loads(response.content)
-        user_message_url = self._get_absolute_url(user_message_path)
+        user_message_url = get_absolute_url(user_message_path)
         self.assertEqual(resp_data['user_message_url'], user_message_url)
 
         # Verify that we were not enrolled

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1550,33 +1550,6 @@ def create_account_with_params(request, params):
             AUDIT_LOG.info(u"Login activated on extauth account - {0} ({1})".format(new_user.username, new_user.email))
 
 
-def set_marketing_cookie(request, response):
-    """
-    Set the login cookie for the edx marketing site on the given response. Its
-    expiration will match that of the given request's session.
-    """
-    if request.session.get_expire_at_browser_close():
-        max_age = None
-        expires = None
-    else:
-        max_age = request.session.get_expiry_age()
-        expires_time = time.time() + max_age
-        expires = cookie_date(expires_time)
-
-    # we want this cookie to be accessed via javascript
-    # so httponly is set to None
-    response.set_cookie(
-        settings.EDXMKTG_COOKIE_NAME,
-        'true',
-        max_age=max_age,
-        expires=expires,
-        domain=settings.SESSION_COOKIE_DOMAIN,
-        path='/',
-        secure=None,
-        httponly=None
-    )
-
-
 @csrf_exempt
 def create_account(request, post_override=None):
     """
@@ -1611,7 +1584,7 @@ def create_account(request, post_override=None):
         'success': True,
         'redirect_url': redirect_url,
     })
-    set_marketing_cookie(request, response)
+    set_logged_in_cookie(request, response)
     return response
 
 

--- a/common/test/acceptance/pages/lms/course_nav.py
+++ b/common/test/acceptance/pages/lms/course_nav.py
@@ -82,7 +82,7 @@ class CourseNavPage(PageObject):
 
         # Click the section to ensure it's open (no harm in clicking twice if it's already open)
         # Add one to convert from list index to CSS index
-        section_css = 'nav>div.chapter:nth-of-type({0})>h3>a'.format(sec_index + 1)
+        section_css = 'nav>div.chapter:nth-of-type({0})'.format(sec_index + 1)
         self.q(css=section_css).first.click()
 
         # Get the subsection by index
@@ -94,7 +94,7 @@ class CourseNavPage(PageObject):
             return
 
         # Convert list indices (start at zero) to CSS indices (start at 1)
-        subsection_css = "nav>div.chapter:nth-of-type({0})>ul>li:nth-of-type({1})>a".format(
+        subsection_css = "nav>div.chapter-content-container:nth-of-type({0})>div>ol>li:nth-of-type({1})>a".format(
             sec_index + 1, subsec_index + 1
         )
 
@@ -130,7 +130,7 @@ class CourseNavPage(PageObject):
         """
         Return a list of all section titles on the page.
         """
-        chapter_css = 'nav > div.chapter > h3 > a'
+        chapter_css = 'nav > button.chapter > h3'
         return self.q(css=chapter_css).map(lambda el: el.text.strip()).results
 
     def _subsection_titles(self, section_index):
@@ -140,7 +140,7 @@ class CourseNavPage(PageObject):
         """
         # Retrieve the subsection title for the section
         # Add one to the list index to get the CSS index, which starts at one
-        subsection_css = 'nav>div.chapter:nth-of-type({0})>ul>li>a>p:nth-of-type(1)'.format(section_index)
+        subsection_css = 'nav>div.chapter-content-container:nth-of-type({0})>div>ol>li>a>p:nth-of-type(1)'.format(section_index)
 
         # If the element is visible, we can get its text directly
         # Otherwise, we need to get the HTML
@@ -171,8 +171,8 @@ class CourseNavPage(PageObject):
         That's true right after we click the section/subsection, but not true in general
         (the user could go to a section, then expand another tab).
         """
-        current_section_list = self.q(css='nav>div.chapter.is-open>h3>a').text
-        current_subsection_list = self.q(css='nav>div.chapter.is-open li.active>a>p').text
+        current_section_list = self.q(css='nav>button.chapter.is-open>h3').text
+        current_subsection_list = self.q(css='nav div.chapter-content-container ol li.active>a>p').text
 
         if len(current_section_list) == 0:
             self.warning("Could not find the current section")

--- a/common/test/acceptance/pages/lms/course_nav.py
+++ b/common/test/acceptance/pages/lms/course_nav.py
@@ -140,7 +140,9 @@ class CourseNavPage(PageObject):
         """
         # Retrieve the subsection title for the section
         # Add one to the list index to get the CSS index, which starts at one
-        subsection_css = 'nav>div.chapter-content-container:nth-of-type({0})>div>ol>li>a>p:nth-of-type(1)'.format(section_index)
+        subsection_css = 'nav>.chapter-content-container:nth-of-type({0})>div>ol>li>a>p:nth-of-type(1)'.format(
+            section_index
+        )
 
         # If the element is visible, we can get its text directly
         # Otherwise, we need to get the HTML

--- a/common/test/acceptance/pages/lms/courseware.py
+++ b/common/test/acceptance/pages/lms/courseware.py
@@ -14,7 +14,7 @@ class CoursewarePage(CoursePage):
     url_path = "courseware/"
     xblock_component_selector = '.vert .xblock'
     section_selector = '.chapter'
-    subsection_selector = '.chapter ul li'
+    subsection_selector = '.chapter-content-container ol li'
 
     def is_browser_on_page(self):
         return self.q(css='body.courseware').present

--- a/common/test/acceptance/pages/lms/courseware.py
+++ b/common/test/acceptance/pages/lms/courseware.py
@@ -102,7 +102,7 @@ class CoursewarePage(CoursePage):
         """
         return the url of the active subsection in the left nav
         """
-        return self.q(css='.chapter ul li.active a').attrs('href')[0]
+        return self.q(css='.chapter-content-container ol li.active a').attrs('href')[0]
 
 
 class CoursewareSequentialTabPage(CoursePage):

--- a/common/test/acceptance/tests/lms/test_lms.py
+++ b/common/test/acceptance/tests/lms/test_lms.py
@@ -1007,7 +1007,7 @@ class EntranceExamTest(UniqueCourseTest):
             When I view the courseware that has an entrance exam
             Then there should be an "Entrance Exam" chapter.'
         """
-        entrance_exam_link_selector = 'div#accordion nav div h3 a'
+        entrance_exam_link_selector = 'div#accordion nav button h3'
         # visit courseware page and make sure there is not entrance exam chapter.
         self.courseware_page.visit()
         self.courseware_page.wait_for_page()

--- a/common/test/acceptance/tests/lms/test_lms.py
+++ b/common/test/acceptance/tests/lms/test_lms.py
@@ -1092,7 +1092,7 @@ class EntranceExamTest(UniqueCourseTest):
             When I view the courseware that has an entrance exam
             Then there should be an "Entrance Exam" chapter.'
         """
-        entrance_exam_link_selector = 'div#accordion nav div h3 a'
+        entrance_exam_link_selector = 'div#accordion nav button h3'
         # visit courseware page and make sure there is not entrance exam chapter.
         self.courseware_page.visit()
         self.courseware_page.wait_for_page()

--- a/lms/djangoapps/commerce/views.py
+++ b/lms/djangoapps/commerce/views.py
@@ -20,6 +20,7 @@ from course_modes.models import CourseMode
 from courseware import courses
 from edxmako.shortcuts import render_to_response
 from enrollment.api import add_enrollment
+from embargo import api as embargo_api
 from microsite_configuration import microsite
 from student.models import CourseEnrollment
 from openedx.core.lib.api.authentication import SessionAuthenticationAllowInactiveUser
@@ -75,6 +76,11 @@ class BasketsView(APIView):
         valid, course_key, error = self._is_data_valid(request)
         if not valid:
             return DetailResponse(error, status=HTTP_406_NOT_ACCEPTABLE)
+
+        embargo_response = embargo_api.get_embargo_response(request, course_key, user)
+
+        if embargo_response:
+            return embargo_response
 
         # Don't do anything if an enrollment already exists
         course_id = unicode(course_key)

--- a/lms/djangoapps/courseware/features/navigation.py
+++ b/lms/djangoapps/courseware/features/navigation.py
@@ -92,7 +92,7 @@ def when_i_navigate_to_a_section(step):
     world.disable_jquery_animations()
 
     # Open the 2nd section
-    world.css_click(css_selector='div.chapter', index=1)
+    world.css_click(css_selector='button.chapter', index=1)
     subsection_css = 'a[href*="Test_Subsection_2/"]'
 
     # Click on the subsection to see the content

--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -157,6 +157,7 @@ def toc_for_course(request, course, active_chapter, active_section, field_data_c
         for chapter in chapters:
             # Only show required content, if there is required content
             # chapter.hide_from_toc is read-only (boo)
+            name_without_spaces = chapter.display_name_with_default.replace(" ", "-").replace(":", "")
             local_hide_from_toc = False
             if required_content:
                 if unicode(chapter.location) not in required_content:
@@ -182,6 +183,7 @@ def toc_for_course(request, course, active_chapter, active_section, field_data_c
                                      })
             toc_chapters.append({
                 'display_name': chapter.display_name_with_default,
+                'display_id': name_without_spaces,
                 'url_name': chapter.url_name,
                 'sections': sections,
                 'active': chapter.url_name == active_chapter

--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -69,6 +69,7 @@ from xmodule.modulestore.exceptions import ItemNotFoundError
 from xmodule.x_module import XModuleDescriptor
 from xmodule.mixin import wrap_with_license
 from util.json_request import JsonResponse
+from util.model_utils import slugify
 from util.sandboxing import can_execute_unsafe_code, get_python_lib_zip
 from util import milestones_helpers
 from verify_student.services import ReverificationService
@@ -157,7 +158,7 @@ def toc_for_course(request, course, active_chapter, active_section, field_data_c
         for chapter in chapters:
             # Only show required content, if there is required content
             # chapter.hide_from_toc is read-only (boo)
-            name_without_spaces = chapter.display_name_with_default.replace(" ", "-").replace(":", "")
+            display_id = slugify(chapter.display_name_with_default)
             local_hide_from_toc = False
             if required_content:
                 if unicode(chapter.location) not in required_content:
@@ -183,7 +184,7 @@ def toc_for_course(request, course, active_chapter, active_section, field_data_c
                                      })
             toc_chapters.append({
                 'display_name': chapter.display_name_with_default,
-                'display_id': name_without_spaces,
+                'display_id': display_id,
                 'url_name': chapter.url_name,
                 'sections': sections,
                 'active': chapter.url_name == active_chapter

--- a/lms/djangoapps/courseware/tests/test_entrance_exam.py
+++ b/lms/djangoapps/courseware/tests/test_entrance_exam.py
@@ -155,7 +155,8 @@ class EntranceExamTestCases(LoginEnrollmentTestCase, ModuleStoreTestCase):
                         }
                     ],
                     'url_name': u'Entrance_Exam_Section_-_Chapter_1',
-                    'display_name': u'Entrance Exam Section - Chapter 1'
+                    'display_name': u'Entrance Exam Section - Chapter 1',
+                    'display_id': u'Entrance-Exam-Section---Chapter-1',
                 }
             ]
         )
@@ -182,19 +183,22 @@ class EntranceExamTestCases(LoginEnrollmentTestCase, ModuleStoreTestCase):
                         }
                     ],
                     'url_name': u'Overview',
-                    'display_name': u'Overview'
+                    'display_name': u'Overview',
+                    'display_id': u'Overview'
                 },
                 {
                     'active': False,
                     'sections': [],
                     'url_name': u'Week_1',
-                    'display_name': u'Week 1'
+                    'display_name': u'Week 1',
+                    'display_id': u'Week-1'
                 },
                 {
                     'active': False,
                     'sections': [],
                     'url_name': u'Instructor',
-                    'display_name': u'Instructor'
+                    'display_name': u'Instructor',
+                    'display_id': u'Instructor'
                 },
                 {
                     'active': True,
@@ -209,7 +213,8 @@ class EntranceExamTestCases(LoginEnrollmentTestCase, ModuleStoreTestCase):
                         }
                     ],
                     'url_name': u'Entrance_Exam_Section_-_Chapter_1',
-                    'display_name': u'Entrance Exam Section - Chapter 1'
+                    'display_name': u'Entrance Exam Section - Chapter 1',
+                    'display_id': u'Entrance-Exam-Section---Chapter-1'
                 }
             ]
         )

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -592,11 +592,11 @@ class TestTOC(ModuleStoreTestCase):
                             'format': '', 'due': None, 'active': False},
                            {'url_name': 'video_4f66f493ac8f', 'display_name': 'Video', 'graded': True,
                             'format': '', 'due': None, 'active': False}],
-                          'url_name': 'Overview', 'display_name': u'Overview'},
+                          'url_name': 'Overview', 'display_name': u'Overview', 'display_id': u'Overview'},
                          {'active': False, 'sections':
                           [{'url_name': 'toyvideo', 'display_name': 'toyvideo', 'graded': True,
                             'format': '', 'due': None, 'active': False}],
-                          'url_name': 'secret:magic', 'display_name': 'secret:magic'}])
+                          'url_name': 'secret:magic', 'display_name': 'secret:magic', 'display_id': 'secretmagic'}])
 
             with check_mongo_calls(toc_finds):
                 actual = render.toc_for_course(
@@ -631,11 +631,11 @@ class TestTOC(ModuleStoreTestCase):
                             'format': '', 'due': None, 'active': False},
                            {'url_name': 'video_4f66f493ac8f', 'display_name': 'Video', 'graded': True,
                             'format': '', 'due': None, 'active': False}],
-                          'url_name': 'Overview', 'display_name': u'Overview'},
+                          'url_name': 'Overview', 'display_name': u'Overview', 'display_id': u'Overview'},
                          {'active': False, 'sections':
                           [{'url_name': 'toyvideo', 'display_name': 'toyvideo', 'graded': True,
                             'format': '', 'due': None, 'active': False}],
-                          'url_name': 'secret:magic', 'display_name': 'secret:magic'}])
+                          'url_name': 'secret:magic', 'display_name': 'secret:magic', 'display_id': 'secretmagic'}])
 
             with check_mongo_calls(toc_finds):
                 actual = render.toc_for_course(

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -628,11 +628,11 @@ class TestTOC(ModuleStoreTestCase):
                             'format': '', 'due': None, 'active': False},
                            {'url_name': 'video_4f66f493ac8f', 'display_name': 'Video', 'graded': True,
                             'format': '', 'due': None, 'active': False}],
-                          'url_name': 'Overview', 'display_name': u'Overview'},
+                          'url_name': 'Overview', 'display_name': u'Overview', 'display_id': u'Overview'},
                          {'active': False, 'sections':
                           [{'url_name': 'toyvideo', 'display_name': 'toyvideo', 'graded': True,
                             'format': '', 'due': None, 'active': False}],
-                          'url_name': 'secret:magic', 'display_name': 'secret:magic'}])
+                          'url_name': 'secret:magic', 'display_name': 'secret:magic', 'display_id': 'secretmagic'}])
 
             with check_mongo_calls(toc_finds):
                 actual = render.toc_for_course(
@@ -667,11 +667,11 @@ class TestTOC(ModuleStoreTestCase):
                             'format': '', 'due': None, 'active': False},
                            {'url_name': 'video_4f66f493ac8f', 'display_name': 'Video', 'graded': True,
                             'format': '', 'due': None, 'active': False}],
-                          'url_name': 'Overview', 'display_name': u'Overview'},
+                          'url_name': 'Overview', 'display_name': u'Overview', 'display_id': u'Overview'},
                          {'active': False, 'sections':
                           [{'url_name': 'toyvideo', 'display_name': 'toyvideo', 'graded': True,
                             'format': '', 'due': None, 'active': False}],
-                          'url_name': 'secret:magic', 'display_name': 'secret:magic'}])
+                          'url_name': 'secret:magic', 'display_name': 'secret:magic', 'display_id': 'secretmagic'}])
 
             with check_mongo_calls(toc_finds):
                 actual = render.toc_for_course(

--- a/lms/djangoapps/discussion_api/api.py
+++ b/lms/djangoapps/discussion_api/api.py
@@ -92,14 +92,28 @@ def _get_comment_and_context(request, comment_id):
         raise Http404
 
 
-def get_thread_list_url(request, course_key, topic_id_list=None):
+def _is_user_author_or_privileged(cc_content, context):
+    """
+    Check if the user is the author of a content object or a privileged user.
+
+    Returns:
+        Boolean
+    """
+    return (
+        context["is_requester_privileged"] or
+        context["cc_requester"]["id"] == cc_content["user_id"]
+    )
+
+
+def get_thread_list_url(request, course_key, topic_id_list=None, following=False):
     """
     Returns the URL for the thread_list_url field, given a list of topic_ids
     """
     path = reverse("thread-list")
     query_list = (
         [("course_id", unicode(course_key))] +
-        [("topic_id", topic_id) for topic_id in topic_id_list or []]
+        [("topic_id", topic_id) for topic_id in topic_id_list or []] +
+        ([("following", following)] if following else [])
     )
     return request.build_absolute_uri(urlunparse(("", "", path, "", urlencode(query_list), "")))
 
@@ -132,7 +146,8 @@ def get_course(request, course_key):
             {"start": blackout["start"].isoformat(), "end": blackout["end"].isoformat()}
             for blackout in course.get_discussion_blackout_datetimes()
         ],
-        "thread_list_url": get_thread_list_url(request, course_key, topic_id_list=[]),
+        "thread_list_url": get_thread_list_url(request, course_key),
+        "following_thread_list_url": get_thread_list_url(request, course_key, following=True),
         "topics_url": request.build_absolute_uri(
             reverse("course_topics", kwargs={"course_id": course_key})
         )
@@ -211,7 +226,7 @@ def get_course_topics(request, course_key):
     }
 
 
-def get_thread_list(request, course_key, page, page_size, topic_id_list=None, text_search=None):
+def get_thread_list(request, course_key, page, page_size, topic_id_list=None, text_search=None, following=False):
     """
     Return the list of all discussion threads pertaining to the given course
 
@@ -223,8 +238,9 @@ def get_thread_list(request, course_key, page, page_size, topic_id_list=None, te
     page_size: The number of threads to retrieve per page
     topic_id_list: The list of topic_ids to get the discussion threads for
     text_search A text search query string to match
+    following: If true, retrieve only threads the requester is following
 
-    Note that topic_id_list and text_search are mutually exclusive.
+    Note that topic_id_list, text_search, and following are mutually exclusive.
 
     Returns:
 
@@ -238,15 +254,13 @@ def get_thread_list(request, course_key, page, page_size, topic_id_list=None, te
     Http404: if the requesting user does not have access to the requested course
       or a page beyond the last is requested
     """
-    exclusive_param_count = sum(1 for param in [topic_id_list, text_search] if param)
+    exclusive_param_count = sum(1 for param in [topic_id_list, text_search, following] if param)
     if exclusive_param_count > 1:  # pragma: no cover
         raise ValueError("More than one mutually exclusive param passed to get_thread_list")
 
     course = _get_course_or_404(course_key, request.user)
     context = get_context(course, request)
-    topic_ids_csv = ",".join(topic_id_list) if topic_id_list else None
-    threads, result_page, num_pages, text_search_rewrite = Thread.search({
-        "course_id": unicode(course.id),
+    query_params = {
         "group_id": (
             None if context["is_requester_privileged"] else
             get_cohort_id(request.user, course.id)
@@ -255,9 +269,16 @@ def get_thread_list(request, course_key, page, page_size, topic_id_list=None, te
         "sort_order": "desc",
         "page": page,
         "per_page": page_size,
-        "commentable_ids": topic_ids_csv,
         "text": text_search,
-    })
+    }
+    text_search_rewrite = None
+    if following:
+        threads, result_page, num_pages = context["cc_requester"].subscribed_threads(query_params)
+    else:
+        query_params["course_id"] = unicode(course.id)
+        query_params["commentable_ids"] = ",".join(topic_id_list) if topic_id_list else None
+        query_params["text"] = text_search
+        threads, result_page, num_pages, text_search_rewrite = Thread.search(query_params)
     # The comments service returns the last page of results if the requested
     # page is beyond the last page, but we want be consistent with DRF's general
     # behavior and return a 404 in that case

--- a/lms/djangoapps/discussion_api/forms.py
+++ b/lms/djangoapps/discussion_api/forms.py
@@ -5,6 +5,7 @@ from django.core.exceptions import ValidationError
 from django.forms import (
     BooleanField,
     CharField,
+    ChoiceField,
     Field,
     Form,
     IntegerField,
@@ -45,11 +46,12 @@ class ThreadListGetForm(_PaginationForm):
     """
     A form to validate query parameters in the thread list retrieval endpoint
     """
-    EXCLUSIVE_PARAMS = ["topic_id", "text_search"]
+    EXCLUSIVE_PARAMS = ["topic_id", "text_search", "following"]
 
     course_id = CharField()
     topic_id = TopicIdField(required=False)
     text_search = CharField(required=False)
+    following = NullBooleanField(required=False)
 
     def clean_course_id(self):
         """Validate course_id"""
@@ -58,6 +60,14 @@ class ThreadListGetForm(_PaginationForm):
             return CourseLocator.from_string(value)
         except InvalidKeyError:
             raise ValidationError("'{}' is not a valid course id".format(value))
+
+    def clean_following(self):
+        """Validate following"""
+        value = self.cleaned_data["following"]
+        if value is False:
+            raise ValidationError("The value of the 'following' parameter must be true.")
+        else:
+            return value
 
     def clean(self):
         cleaned_data = super(ThreadListGetForm, self).clean()

--- a/lms/djangoapps/discussion_api/serializers.py
+++ b/lms/djangoapps/discussion_api/serializers.py
@@ -47,6 +47,8 @@ def get_context(course, request, thread=None):
         for user in role.users.all()
     }
     requester = request.user
+    cc_requester = CommentClientUser.from_django_user(requester).retrieve()
+    cc_requester["course_id"] = course.id
     return {
         "course": course,
         "request": request,
@@ -56,7 +58,7 @@ def get_context(course, request, thread=None):
         "is_requester_privileged": requester.id in staff_user_ids or requester.id in ta_user_ids,
         "staff_user_ids": staff_user_ids,
         "ta_user_ids": ta_user_ids,
-        "cc_requester": CommentClientUser.from_django_user(requester).retrieve(),
+        "cc_requester": cc_requester,
     }
 
 

--- a/lms/djangoapps/discussion_api/tests/test_api.py
+++ b/lms/djangoapps/discussion_api/tests/test_api.py
@@ -99,6 +99,9 @@ class GetCourseTest(UrlResetMixin, ModuleStoreTestCase):
                 "id": unicode(self.course.id),
                 "blackouts": [],
                 "thread_list_url": "http://testserver/api/discussion/v1/threads/?course_id=x%2Fy%2Fz",
+                "following_thread_list_url": (
+                    "http://testserver/api/discussion/v1/threads/?course_id=x%2Fy%2Fz&following=True"
+                ),
                 "topics_url": "http://testserver/api/discussion/v1/course_topics/x/y/z",
             }
         )
@@ -739,6 +742,31 @@ class GetThreadListTest(CommentsServiceMockMixin, UrlResetMixin, ModuleStoreTest
             "per_page": ["10"],
             "recursive": ["False"],
             "text": ["test search string"],
+        })
+
+    def test_following(self):
+        self.register_subscribed_threads_response(self.user, [], page=1, num_pages=1)
+        result = get_thread_list(
+            self.request,
+            self.course.id,
+            page=1,
+            page_size=11,
+            following=True,
+        )
+        self.assertEqual(
+            result,
+            {"results": [], "next": None, "previous": None, "text_search_rewrite": None}
+        )
+        self.assertEqual(
+            urlparse(httpretty.last_request().path).path,
+            "/api/v1/users/{}/subscribed_threads".format(self.user.id)
+        )
+        self.assert_last_query_params({
+            "course_id": [unicode(self.course.id)],
+            "sort_key": ["date"],
+            "sort_order": ["desc"],
+            "page": ["1"],
+            "per_page": ["11"],
         })
 
 

--- a/lms/djangoapps/discussion_api/tests/test_forms.py
+++ b/lms/djangoapps/discussion_api/tests/test_forms.py
@@ -94,6 +94,7 @@ class ThreadListGetFormTest(FormTestMixin, PaginationTestMixin, TestCase):
                 "page_size": 13,
                 "topic_id": [],
                 "text_search": "",
+                "following": None,
             }
         )
 
@@ -125,12 +126,20 @@ class ThreadListGetFormTest(FormTestMixin, PaginationTestMixin, TestCase):
         self.form_data.setlist("topic_id", ["", "not empty"])
         self.assert_error("topic_id", "This field cannot be empty.")
 
-    @ddt.data(*itertools.combinations(["topic_id", "text_search"], 2))
+    def test_following_true(self):
+        self.form_data["following"] = "True"
+        self.assert_field_value("following", True)
+
+    def test_following_false(self):
+        self.form_data["following"] = "False"
+        self.assert_error("following", "The value of the 'following' parameter must be true.")
+
+    @ddt.data(*itertools.combinations(["topic_id", "text_search", "following"], 2))
     def test_mutually_exclusive(self, params):
-        self.form_data.update({param: "dummy" for param in params})
+        self.form_data.update({param: "True" for param in params})
         self.assert_error(
             "__all__",
-            "The following query parameters are mutually exclusive: topic_id, text_search"
+            "The following query parameters are mutually exclusive: topic_id, text_search, following"
         )
 
 

--- a/lms/djangoapps/discussion_api/tests/utils.py
+++ b/lms/djangoapps/discussion_api/tests/utils.py
@@ -191,6 +191,19 @@ class CommentsServiceMockMixin(object):
             status=200
         )
 
+    def register_subscribed_threads_response(self, user, threads, page, num_pages):
+        """Register a mock response for GET on the CS user instance endpoint"""
+        httpretty.register_uri(
+            httpretty.GET,
+            "http://localhost:4567/api/v1/users/{}/subscribed_threads".format(user.id),
+            body=json.dumps({
+                "collection": threads,
+                "page": page,
+                "num_pages": num_pages,
+            }),
+            status=200
+        )
+
     def register_subscription_response(self, user):
         """
         Register a mock response for POST and DELETE on the CS user subscription

--- a/lms/djangoapps/discussion_api/views.py
+++ b/lms/djangoapps/discussion_api/views.py
@@ -141,6 +141,12 @@ class ThreadViewSet(_ViewMixin, DeveloperErrorViewMixin, ViewSet):
             (including the bodies of comments in the thread) matches the search
             string will be returned.
 
+        * following: If true, retrieve only threads the requesting user is
+            following
+
+        The topic_id, text_search, and following parameters are mutually
+        exclusive (i.e. only one may be specified in a request)
+
     **POST Parameters**:
 
         * course_id (required): The course to create the thread in
@@ -229,6 +235,7 @@ class ThreadViewSet(_ViewMixin, DeveloperErrorViewMixin, ViewSet):
                 form.cleaned_data["page_size"],
                 form.cleaned_data["topic_id"],
                 form.cleaned_data["text_search"],
+                form.cleaned_data["following"],
             )
         )
 

--- a/lms/djangoapps/verify_student/tests/test_views.py
+++ b/lms/djangoapps/verify_student/tests/test_views.py
@@ -2023,8 +2023,7 @@ class TestEmailMessageWithCustomICRVBlock(ModuleStoreTestCase):
 
     def test_denied_email_message_with_close_verification_dates(self):
         # Due date given and expired
-
-        return_value = datetime(2016, 1, 1, tzinfo=timezone.utc)
+        return_value = datetime.now(tz=pytz.UTC) + timedelta(days=22)
         with patch.object(timezone, 'now', return_value=return_value):
             __, body = _compose_message_reverification_email(
                 self.course.id, self.user.id, self.reverification_location, "denied", self.request

--- a/lms/static/coffee/fixtures/accordion.html
+++ b/lms/static/coffee/fixtures/accordion.html
@@ -2,5 +2,11 @@
   <header id="open_close_accordion">
     <a href="#">close</a>
   </header>
-  <div id="accordion"></div>
+  <div id="accordion">
+    <button class="chapter">
+      <h3>
+          Introduction Chapter
+      </h3>
+    </button>
+  </div>
 </div>

--- a/lms/static/coffee/spec/navigation_spec.coffee
+++ b/lms/static/coffee/spec/navigation_spec.coffee
@@ -76,15 +76,22 @@ describe 'Navigation', ->
 
   describe 'setChapter', ->
     beforeEach ->
-      $('#accordion').append('<div><div><ol><li class="active"></li></ol></div></div>')
+      $('#accordion').append('<div><div><ol><li class="active"><a href="#"></a></li></ol></div></div>')
       new Navigation
     it 'Chapter opened', ->
       e = jQuery.Event('click')
       $('#accordion .chapter').trigger(e)
       expect($('.chapter')).toHaveClass('is-open')
+
     it 'content active on chapter opened', ->
       e = jQuery.Event('click')
       $('#accordion .chapter').trigger(e)
       expect($('.chapter').next('div').children('div')).toHaveClass('ui-accordion-content-active')
       expect($('.ui-accordion-content-active')).toHaveAttr('aria-hidden', 'false')
+
+    it 'focus move to first child on chapter opened', ->
+      spyOn($.fn, 'focus')
+      e = jQuery.Event('click')
+      $('#accordion .chapter').trigger(e)
+      expect($('.ui-accordion-content-active li:first-child a').focus).toHaveBeenCalled()
 

--- a/lms/static/coffee/spec/navigation_spec.coffee
+++ b/lms/static/coffee/spec/navigation_spec.coffee
@@ -8,7 +8,7 @@ describe 'Navigation', ->
       describe 'when there is an active section', ->
         beforeEach ->
           spyOn $.fn, 'accordion'
-          $('#accordion').append('<ul><li></li></ul><ul><li class="active"></li></ul>')
+          $('#accordion').append('<div><div><ol><li></li></ol></div></div><div><div><ol><li class="active"></li></ol></div></div>')
           new Navigation
 
         it 'activate the accordion with correct active section', ->
@@ -21,7 +21,7 @@ describe 'Navigation', ->
       describe 'when there is no active section', ->
         beforeEach ->
           spyOn $.fn, 'accordion'
-          $('#accordion').append('<ul><li></li></ul><ul><li></li></ul>')
+          $('#accordion').append('<div><div><ol><li></li></ol></div></div><div><div><ol><li></li></ol></div></div>')
           new Navigation
 
         it 'activate the accordian with no section as active', ->
@@ -36,6 +36,9 @@ describe 'Navigation', ->
 
       it 'bind the navigation toggle', ->
         expect($('#open_close_accordion a')).toHandleWith 'click', @navigation.toggle
+
+      it 'bind the setChapter', ->
+        expect($('#accordion .chapter')).toHandleWith 'click', @navigation.setChapter
 
     describe 'when the #accordion does not exists', ->
       beforeEach ->
@@ -70,3 +73,18 @@ describe 'Navigation', ->
       expect(Logger.log).toHaveBeenCalledWith 'accordion',
         newheader: 'new'
         oldheader: 'old'
+
+  describe 'setChapter', ->
+    beforeEach ->
+      $('#accordion').append('<div><div><ol><li class="active"></li></ol></div></div>')
+      new Navigation
+    it 'Chapter opened', ->
+      e = jQuery.Event('click')
+      $('#accordion .chapter').trigger(e)
+      expect($('.chapter')).toHaveClass('is-open')
+    it 'content active on chapter opened', ->
+      e = jQuery.Event('click')
+      $('#accordion .chapter').trigger(e)
+      expect($('.chapter').next('div').children('div')).toHaveClass('ui-accordion-content-active')
+      expect($('.ui-accordion-content-active')).toHaveAttr('aria-hidden', 'false')
+

--- a/lms/static/coffee/src/navigation.coffee
+++ b/lms/static/coffee/src/navigation.coffee
@@ -15,9 +15,15 @@ class @Navigation
         autoHeight: false
         heightStyle: 'content'
       $('#accordion .ui-state-active').closest('.chapter').addClass('is-open')
+      $('#accordion .ui-state-active').parent().next('div').children('div').addClass('ui-accordion-content-active')
+      $('#accordion .ui-state-active').parent().next('div').show()
+      $('#accordion .ui-state-active').parent().attr('aria-expanded' , 'true').attr('aria-pressed' , 'true')
+      $('#accordion div').filter(':not(.chapter-content-container)').addClass("ui-accordion-content ui-helper-reset ui-widget-content ui-corner-bottom").filter(":not(.ui-accordion-content-active)").hide()
+      $('.ui-accordion-content div').attr('aria-hidden', 'false')
+      $('.ui-accordion-content-active div').attr('aria-hidden', 'true')
       $('#open_close_accordion a').click @toggle
       $('#accordion').show()
-      $('#accordion a').click @setChapter
+      $('#accordion .chapter').click @setChapter
 
   log: (event, ui) ->
     Logger.log 'accordion',
@@ -28,6 +34,13 @@ class @Navigation
     $('.course-wrapper').toggleClass('closed')
 
   setChapter: ->
-    $('#accordion .is-open').removeClass('is-open')
-    $(this).closest('.chapter').addClass('is-open')
-    
+    $('#accordion .is-open').removeClass('is-open').attr('aria-expanded' , 'false').attr('aria-pressed' , 'false')
+    $(this).closest('.chapter').addClass('is-open').attr('aria-expanded' , 'true').attr('aria-pressed' , 'true')
+    $('.ui-accordion-content-active').attr('aria-hidden', 'true')
+    $('.ui-accordion-content-active').parent().hide()
+    $('#accordion .ui-accordion-content-active').removeClass('ui-accordion-content-active')
+    $(this).closest('.chapter').next('div').children('div').addClass('ui-accordion-content-active')
+    $('.ui-accordion-content-active').parent().show()
+    $('.ui-accordion-content-active').show()
+    $('.ui-accordion-content-active').attr('aria-hidden', 'false')
+

--- a/lms/static/coffee/src/navigation.coffee
+++ b/lms/static/coffee/src/navigation.coffee
@@ -2,7 +2,7 @@ class @Navigation
   constructor: ->
     if $('#accordion').length
       # First look for an active section
-      active = $('#accordion ul:has(li.active)').index('#accordion ul')
+      active = $('#accordion div div ol:has(li.active)').index('#accordion div div ol')
       # if we didn't find one, look for an active chapter
       if active < 0
         active = $('#accordion h3.active').index('#accordion h3')

--- a/lms/static/coffee/src/navigation.coffee
+++ b/lms/static/coffee/src/navigation.coffee
@@ -42,5 +42,6 @@ class @Navigation
     $(this).closest('.chapter').next('div').children('div').addClass('ui-accordion-content-active')
     $('.ui-accordion-content-active').parent().show()
     $('.ui-accordion-content-active').show()
+    $('.ui-accordion-content-active li:first-child a').focus()
     $('.ui-accordion-content-active').attr('aria-hidden', 'false')
 

--- a/lms/static/coffee/src/navigation.coffee
+++ b/lms/static/coffee/src/navigation.coffee
@@ -34,8 +34,8 @@ class @Navigation
     $('.course-wrapper').toggleClass('closed')
 
   setChapter: ->
-    $('#accordion .is-open').removeClass('is-open').attr('aria-expanded' , 'false').attr('aria-pressed' , 'false')
-    $(this).closest('.chapter').addClass('is-open').attr('aria-expanded' , 'true').attr('aria-pressed' , 'true')
+    $('#accordion .is-open').removeClass('is-open').attr('aria-expanded' , 'false').attr('aria-pressed' , 'false').find('h3 span').removeClass('ui-icon-triangle-1-s').addClass('ui-icon-triangle-1-e')
+    $(this).closest('.chapter').addClass('is-open').attr('aria-expanded' , 'true').attr('aria-pressed' , 'true').find('h3 span').removeClass('ui-icon-triangle-1-e').addClass('ui-icon-triangle-1-s')
     $('.ui-accordion-content-active').attr('aria-hidden', 'true')
     $('.ui-accordion-content-active').parent().hide()
     $('#accordion .ui-accordion-content-active').removeClass('ui-accordion-content-active')

--- a/lms/static/sass/course/courseware/_sidebar.scss
+++ b/lms/static/sass/course/courseware/_sidebar.scss
@@ -25,6 +25,9 @@
       margin: 0;
       overflow: visible;
       font-size: 16px;
+      box-shadow: none;
+      @include padding-left(19px);
+      color: $link-color;
 
       &:first-child {
         border: none;
@@ -108,7 +111,12 @@
       }
     }
 
-    ul.ui-accordion-content {
+    div.chapter-content-container{
+      padding: 11px 14px;
+      display: none;
+    }
+
+    div.ui-accordion-content {
       background: transparent;
       border: none;
       border-radius: 0;

--- a/lms/static/sass/course/courseware/_sidebar.scss
+++ b/lms/static/sass/course/courseware/_sidebar.scss
@@ -17,46 +17,36 @@
   }
 
   div#accordion {
+    @extend %t-copy-sub1;
     width: auto;
-    font-size: 14px;
 
     h3 {
-      border-radius: 0;
-      margin: 0;
+      @extend %t-title6;
+      @include padding-left($baseline);
       overflow: visible;
-      font-size: 16px;
+      margin: 0;
+      border-radius: 0;
       box-shadow: none;
-      @include padding-left(19px);
       color: $link-color;
 
       &:first-child {
         border: none;
       }
 
-      &:hover, &:focus {
-        color: #666;
-      }
-
-      &.ui-state-hover, &.ui-state-focus {
-        a {
-          color: #666;
-        }
-      }
-
       &.ui-accordion-header {
+        @extend %t-regular;
         border-bottom: none;
-        color: $black;
 
         a {
+          @include padding-left($baseline);
           border-radius: 0;
           box-shadow: none;
-          @include padding-left(19px);
           color: $link-color;
         }
 
         &.ui-state-active {
-          @extend .active;
           border-bottom: none;
+          color: $base-font-color;
 
           &:hover, &:focus {
             background: none;
@@ -64,9 +54,9 @@
         }
 
         span.ui-icon {
-          @include left(0);
-          opacity: 0.3;
+          @include left($baseline);
           background-image: url("/static/images/ui-icons_222222_256x240.png");  // jQuery UI sprite
+          opacity: 0.3;
 
           &.ui-icon-triangle-1-e {
 
@@ -85,25 +75,24 @@
     }
 
     .chapter {
-      width: 100% !important;
       @include box-sizing(border-box);
-      padding: 11px 14px;
       @include linear-gradient(top, $sidebar-chapter-bg-top, $sidebar-chapter-bg-bottom);
-      background-color: $sidebar-chapter-bg;
-      box-shadow: 0 1px 0 $white inset, 0 -1px 0 $shadow-l1 inset;
       @include transition(background-color .1s linear 0s);
+      width: 100% !important;
+      padding: 0;
+      border: 0;
+      border-radius: 0;
+      box-shadow: 0 1px 0 $white inset, 0 -1px 0 $shadow-l1 inset;
+      background-color: $sidebar-chapter-bg;
+      color: $link-color;
+
+      h3 {
+        padding: ($baseline*.75) $baseline ($baseline*.75) ($baseline*2);
+      }
 
       &.is-open {
         background: $white;
-      }
-
-      &:first-child {
-        border-radius: 3px 0 0 0;
-      }
-
-      &:last-child {
-        border-radius: 0 0 0 3px;
-        box-shadow: 0 1px 0 $white inset;
+        box-shadow: none;
       }
 
       &:hover, &:focus {
@@ -112,44 +101,46 @@
     }
 
     div.chapter-content-container{
-      padding: 11px 14px;
       display: none;
+      padding: 0 14px ($baseline/2) 14px;
+      border-bottom: 1px solid $shadow-l1;
+      background: $white;
     }
 
     div.ui-accordion-content {
-      background: transparent;
+      margin: 0;
+      padding: 0 ($baseline*.75);
       border: none;
       border-radius: 0;
-      margin: 0;
-      padding: 9px 0 9px 9px;
-      overflow: auto;
-      width: 100%;
+      background: transparent;
 
       li {
+        margin: ($baseline/5) 0;
+        // margin-bottom: ($baseline/5);
         border-bottom: 0;
         border-radius: 0;
-        margin-bottom: ($baseline/5);
 
         a {
-          background: transparent;
-          border-radius: 4px;
-          display: block;
-          @include padding( ($baseline/4), ($baseline*1.5), ($baseline/4), ($baseline/2));
+          @extend %t-strong;
+          @include padding(($baseline/4) ($baseline/2));
           position: relative;
+          display: block;
+          border-radius: ($baseline/5);
+          background: transparent;
           text-decoration: none;
 
           p {
-            font-weight: bold;
-            font-family: $sans-serif;
+            @extend %t-action3;
+            @extend %t-strong;
             margin-bottom: 0;
-            line-height: 1.3;
+            font-family: $sans-serif;
 
             &.subtitle {
-              color: #666;
-              font-size: 13px;
-              font-weight: normal;
+              @extend %t-action3;
+              @extend %t-regular;
               display: block;
               margin: 0;
+              color: $gray-d1;
 
               &:empty {
                 display: none;
@@ -161,7 +152,7 @@
             background: $shadow-l1;
 
             > a p {
-              color: #333;
+              color: $gray-d3;
             }
           }
 
@@ -176,19 +167,19 @@
         }
 
         &.active {
-          font-weight: bold;
+          @extend %t-strong;
 
           &:after {
+            @extend %t-regular;
+            @include transition(none);
+            @include right($baseline);
             content: '›';
             position: absolute;
             top: 50%;
-            right: 20px;
             margin-top: -13px;
             font-size: 30px;
-            font-weight: normal;
-            color: #333;
+            color: $gray-d3;
             opacity: 0;
-            @include transition(none);
           }
 
           > a {
@@ -202,28 +193,27 @@
             }
 
             p {
-              color: #333;
+              color: $gray-d3;
             }
           }
 
           span.subtitle {
-            font-weight: normal;
+            @extend %t-regular;
           }
         }
 
         &.graded {
          > a {
            > img {
+             @include right($baseline/4);
              position: absolute;
-             top: 0;
-             bottom: 0;
-             @include right(7px);
+             bottom: ($baseline/4);
              margin: auto;
            }
           }
 
           &.active > a {
-            background: linear-gradient(to bottom, #e6e6e6, #d6d6d6);
+            background: linear-gradient(to bottom, $gray-l4, #d6d6d6);
           }
         }
       }

--- a/lms/static/sass/course/courseware/_sidebar.scss
+++ b/lms/static/sass/course/courseware/_sidebar.scss
@@ -149,7 +149,6 @@
           }
 
           &:hover, &:focus {
-            background: $shadow-l1;
 
             > a p {
               color: $gray-d3;

--- a/lms/templates/courseware/accordion.html
+++ b/lms/templates/courseware/accordion.html
@@ -6,7 +6,7 @@
 %>
 
 <%def name="make_chapter(chapter)">
-  <div class="chapter">
+  <button class="chapter" id="${chapter['display_id']}-parent" aria-controls="${chapter['display_id']}-child" aria-expanded="false" aria-pressed="false">
       <%
           if chapter.get('active'):
               aria_label = _('{chapter}, current chapter').format(chapter=chapter['display_name'])
@@ -16,12 +16,12 @@
               active_class = ''
       %>
       <h3 ${active_class} aria-label="${aria_label}">
-        <a href="#">
           ${chapter['display_name']}
-        </a>
       </h3>
-
-    <ul>
+    </button>
+    <div class="chapter-content-container">
+    <div id="${chapter['display_id']}-child" role="region" aria-labelledby="${chapter['display_id']}-parent" aria-hidden="false">
+    <ol>
       % for section in chapter['sections']:
           <li class="${'active' if 'active' in section and section['active'] else ''} ${'graded'  if 'graded' in section and section['graded'] else ''}">
             <a href="${reverse('courseware_section', args=[course_id, chapter['url_name'], section['url_name']])}">
@@ -41,8 +41,9 @@
             </a>
           </li>
       % endfor
-    </ul>
-  </div>
+    </ol>
+    </div>
+    </div>
 </%def>
 
 % for chapter in toc:

--- a/lms/templates/courseware/accordion.html
+++ b/lms/templates/courseware/accordion.html
@@ -20,29 +20,29 @@
       </h3>
     </button>
     <div class="chapter-content-container">
-    <div id="${chapter['display_id']}-child" role="region" aria-labelledby="${chapter['display_id']}-parent" aria-hidden="false">
-    <ol>
-      % for section in chapter['sections']:
-          <li class="${'active' if 'active' in section and section['active'] else ''} ${'graded'  if 'graded' in section and section['graded'] else ''}">
-            <a href="${reverse('courseware_section', args=[course_id, chapter['url_name'], section['url_name']])}">
-              <p>${section['display_name']} ${'<span class="sr">, current section</span>' if 'active' in section and section['active'] else ''}</p>
-              <%
-                if section.get('due') is None:
-                    due_date = ''
-                else:
-                    formatted_string = get_time_display(section['due'], due_date_display_format, coerce_tz=settings.TIME_ZONE_DISPLAYED_FOR_DEADLINES)
-                    due_date = '' if len(formatted_string)==0 else _('due {date}').format(date=formatted_string)
-              %>
-              <p class="subtitle">${section['format']} ${due_date}</p>
+        <div id="${chapter['display_id']}-child" role="region" aria-labelledby="${chapter['display_id']}-parent" aria-hidden="false">
+            <ol>
+              % for section in chapter['sections']:
+                  <li class="${'active' if 'active' in section and section['active'] else ''} ${'graded'  if 'graded' in section and section['graded'] else ''}">
+                    <a href="${reverse('courseware_section', args=[course_id, chapter['url_name'], section['url_name']])}">
+                      <p>${section['display_name']} ${'<span class="sr">, current section</span>' if 'active' in section and section['active'] else ''}</p>
+                      <%
+                        if section.get('due') is None:
+                            due_date = ''
+                        else:
+                            formatted_string = get_time_display(section['due'], due_date_display_format, coerce_tz=settings.TIME_ZONE_DISPLAYED_FOR_DEADLINES)
+                            due_date = '' if len(formatted_string)==0 else _('due {date}').format(date=formatted_string)
+                      %>
+                      <p class="subtitle">${section['format']} ${due_date}</p>
 
-              % if 'graded' in section and section['graded']:
-                  <img src="/static/images/graded.png" alt="Graded Section">
-              % endif
-            </a>
-          </li>
-      % endfor
-    </ol>
-    </div>
+                      % if 'graded' in section and section['graded']:
+                          <img src="/static/images/graded.png" alt="Graded Section">
+                      % endif
+                    </a>
+                  </li>
+              % endfor
+            </ol>
+        </div>
     </div>
 </%def>
 

--- a/openedx/core/djangoapps/user_api/views.py
+++ b/openedx/core/djangoapps/user_api/views.py
@@ -24,7 +24,8 @@ from openedx.core.lib.api.permissions import ApiKeyHeaderPermission
 import third_party_auth
 from django_comment_common.models import Role
 from edxmako.shortcuts import marketing_link
-from student.views import create_account_with_params, set_marketing_cookie
+from student.views import create_account_with_params
+from student.helpers import set_logged_in_cookie
 from openedx.core.lib.api.authentication import SessionAuthenticationAllowInactiveUser
 from util.json_request import JsonResponse
 from .preferences.api import update_email_opt_in
@@ -306,7 +307,7 @@ class RegistrationView(APIView):
             return JsonResponse(errors, status=400)
 
         response = JsonResponse({"success": True})
-        set_marketing_cookie(request, response)
+        set_logged_in_cookie(request, response)
         return response
 
     def _add_email_field(self, form_desc, required=True):

--- a/openedx/core/lib/django_test_client_utils.py
+++ b/openedx/core/lib/django_test_client_utils.py
@@ -52,3 +52,8 @@ if not hasattr(RequestFactory, 'patch'):
 
 if not hasattr(Client, 'patch'):
     setattr(Client, 'patch', client_patch)
+
+
+def get_absolute_url(path):
+    """ Generate an absolute URL for a resource on the test server. """
+    return u'http://testserver/{}'.format(path.lstrip('/'))

--- a/pavelib/assets.py
+++ b/pavelib/assets.py
@@ -132,10 +132,12 @@ def compile_coffeescript(*files):
 
 @task
 @no_help
-def compile_sass(debug=False):
+@cmdopts([('debug', 'd', 'Debug mode')])
+def compile_sass(options):
     """
     Compile Sass to CSS.
     """
+    debug = options.get('debug')
     parts = ["sass"]
     parts.append("--update")
     parts.append("--cache-location {cache}".format(cache=SASS_CACHE_PATH))
@@ -244,7 +246,7 @@ def update_assets(args):
     compile_templated_sass(args.system, args.settings)
     process_xmodule_assets()
     compile_coffeescript()
-    compile_sass(args.debug)
+    call_task('compile_sass', options={'debug': args.debug})
 
     if args.collect:
         collect_assets(args.system, args.settings)


### PR DESCRIPTION
This work addresses the style discrepancies after a positive markup update from @ahsan-ul-haq that increases the accessibility of the course navigation sidebar. The styles should closely match what existed before the markup updates.

Note: One goal was to send focus to the first menu item after a menu has opened. To do that, we had to remove the `slideUp()` and `slideDown()` functions, which slid open and closed the accordion panels, and replace them with `show()` and `hide()`. This is because after jQuery slides open the menu, it sends focus to the first item, but because the focus event is triggered before the animation completes, the first link is still hidden so focus is never sent.

**Browser testing:**

This code has been tested in the following browsers:

```
| Platform | Browser | Version | Passed | 
|----------|---------|---------|--------|
| Mac      | Chrome  | 43      | Yes    |
|          | Safari  | 8       | Yes    |
|          | Firefox | 24      | Yes    |
| Windows  | IE      | 10      | Yes    |
|          |         | 11      | Yes    |
|          | Firefox | 37      | Yes    |
```

---

@frrrances @marcotuts mind reviewing the FED and UI?
