### PR TITLE
i18n lon-capa problem explanation title

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -211,3 +211,4 @@ Amir Qayyum Khan <amir.qayyum@arbisoft.com>
 Jolyon Bloomfield <jolyon@mit.edu>
 Kyle McCormick <kylemccor@gmail.com>
 Jim Cai <jimcai@stanford.edu>
+Richard Moch <richard.moch@gmail.com>

--- a/common/lib/xmodule/xmodule/js/src/problem/edit.coffee
+++ b/common/lib/xmodule/xmodule/js/src/problem/edit.coffee
@@ -201,6 +201,8 @@ class @MarkdownEditingDescriptor extends XModule.Descriptor
 #
   @markdownToXml: (markdown)->
     toXml = `function (markdown) {
+      // Translators: This is the title of the text explaining a problem
+      var explanation_title = gettext("Explanation");
       var xml = markdown,
           i, splits, scriptFlag;
 
@@ -348,14 +350,15 @@ class @MarkdownEditingDescriptor extends XModule.Descriptor
       });
 
       // replace explanations
+
       xml = xml.replace(/\[explanation\]\n?([^\]]*)\[\/?explanation\]/gmi, function(match, p1) {
-          var selectString = '<solution>\n<div class="detailed-solution">\nExplanation\n\n' + p1 + '\n</div>\n</solution>';
+          var selectString = '<solution>\n<div class="detailed-solution">\n' + explanation_title + '\n\n' + p1 + '\n</div>\n</solution>';
 
           return selectString;
       });
-      
+
       // replace labels
-      // looks for >>arbitrary text<< and inserts it into the label attribute of the input type directly below the text. 
+      // looks for >>arbitrary text<< and inserts it into the label attribute of the input type directly below the text.
       var split = xml.split('\n');
       var new_xml = [];
       var line, i, curlabel, prevlabel = '';


### PR DESCRIPTION
As seen on screenshot, the title of [explanation] section of problems is not i18ned

As I'm not familiar with Backbone this specific part of the code seems weird to me (quoted Javascript in CoffeeScript, right ?), and I'm not sure this patch reach edX's standards.

![capture explanation](https://cloud.githubusercontent.com/assets/89626/7569381/a8e7a34e-f808-11e4-93bc-344cf305933b.PNG)
