### PR TITLE
code suggestion changes.

### DIFF
--- a/cms/djangoapps/contentstore/views/certificates.py
+++ b/cms/djangoapps/contentstore/views/certificates.py
@@ -74,6 +74,7 @@ class CertificateManager(object):
         # Ensure a signatories list is always returned
         if certificate.get("signatories") is None:
             certificate["signatories"] = []
+        certificate["editing"] = False
         return certificate
 
     @staticmethod
@@ -141,7 +142,7 @@ class CertificateManager(object):
         }
 
     @staticmethod
-    def deserialize_certificate(course, json_string):
+    def deserialize_certificate(course, value):
         """
         Deserialize from a JSON representation into a Certificate object.
         'value' should be either a Certificate instance, or a valid JSON string

--- a/cms/templates/certificates.html
+++ b/cms/templates/certificates.html
@@ -20,7 +20,7 @@
 
 <%block name="requirejs">
   require(["js/certificates/factories/certificates_page_factory"], function(CertificatesPageFactory) {
-      CertificatesPageFactory('${certificates}', "${certificate_url}", "${course_outline_url}");
+      CertificatesPageFactory(${json.dumps(certificates)}, "${certificate_url}", "${course_outline_url}");
   });
 </%block>
 

--- a/cms/templates/js/certificate-editor.underscore
+++ b/cms/templates/js/certificate-editor.underscore
@@ -18,7 +18,7 @@
                     </span>
                 <% } %>
                 <input id="certificate-name-<%= uniqueId %>" class="collection-name-input input-text" name="certificate-name" type="text" placeholder="<%= gettext("Name of the certificate") %>" value="<%= name %>" aria-describedby="certificate-name-<%=uniqueId %>-tip">
-                <span id="certificate-name-<%= uniqueId %>-tip"> class="tip tip-stacked"><%= gettext("Name of the certificate") %></span>
+                <span id="certificate-name-<%= uniqueId %>-tip" class="tip tip-stacked"><%= gettext("Name of the certificate") %></span>
             </div>
             <div class="input-wrap field text add-certificate-description">
                 <label for="certificate-description-<%= uniqueId %>"><%= gettext("Description") %></label>
@@ -31,7 +31,7 @@
          </header>
         <div class="signatory-edit-list"> </div>
         <span>
-           <button class="action action-add-signatory" type="button" href="javascript:void(0);"><%= gettext("Add Signatory") %></button>
+           <button class="action action-add-signatory" type="button"><%= gettext("Add Signatory") %></button>
            <span class="tip tip-stacked"><%= gettext("(Up to 4 signatories are allowed for a certificate)") %></span>
         </span>
     </div>


### PR DESCRIPTION
@ziafazal  @mattdrayer  I have fixed the following: 
- Upon revisiting Certificates page, the views for existing certificates are in edit mode - seems that we should be opening them in view mode.
- Having a single-quote character ( ' ) in a certificate body is problematic, and causes javascript to fail on the page when reopened. e.g. Try a description of "It's easy as 123". Probably need to escape the json for the CertificatesPageFactory initialization. 

Kindly let me know if anything else required from my side. 
Thanks
