### PR TITLE
Update schoolyourself-xblock to the latest version

### DIFF
--- a/requirements/edx/edx-private.txt
+++ b/requirements/edx/edx-private.txt
@@ -17,4 +17,4 @@
 
 # This repository contains schoolyourself-xblock, which is used in
 # edX's "AlgebraX" and "GeometryX" courses.
--e git+https://github.com/schoolyourself/schoolyourself-xblock.git@3058bf589d44151310089f7f892aa31f7d92c1a8#egg=schoolyourself-xblock
+-e git+https://github.com/schoolyourself/schoolyourself-xblock.git@5e4d37716e3e72640e832e961f7cc0d38d4ec47b#egg=schoolyourself-xblock


### PR DESCRIPTION
This latest version contains just 1 commit, with a cosmetic change: https://github.com/schoolyourself/schoolyourself-xblock/commit/5e4d37716e3e72640e832e961f7cc0d38d4ec47b

Some background:
- the xblock, when graded, has a grade between 0 and 1
- this grade is shown in the xblock's student view in the form of a yellow progress bar
- in the past, our cutoff for getting credit was 0.7. Students were free to continue answering questions to reach 1.0, but 0.7 was the minimum. So the bar would turn green at 0.7, but wouldn't be completely full.
- we're changing that -- just saying now that 0.7 mastery will give a full, green bar. Now, getting a score above 0.7 doesn't look any different from getting exactly 0.7.

Here is what it used to look like before (half complete, and complete):
![edx_old](https://cloud.githubusercontent.com/assets/1812040/7595063/b29d01ae-f8b2-11e4-8e66-7eea79c1efa5.png)

And here's what it would look like now:
![edx_new](https://cloud.githubusercontent.com/assets/1812040/7595065/b84a9c10-f8b2-11e4-807f-15f8b08a623e.png)

A few weeks ago I updated this page with new instructions on how to use it: https://openedx.atlassian.net/wiki/display/OPEN/Schoolyourself+XBlock

But it is also testable by just using the XBlock workbench.
@nedbat is our goto person who could review this change.
