### PR TITLE
Add discussion API comment list endpoint

### DIFF
--- a/lms/djangoapps/discussion_api/api.py
+++ b/lms/djangoapps/discussion_api/api.py
@@ -1,9 +1,14 @@
 """
 Discussion API internal interface
 """
+from collections import defaultdict
+
+from lazy.lazy import lazy
+
+from django.core.exceptions import ValidationError
 from django.http import Http404
 
-from collections import defaultdict
+from opaque_keys.edx.locator import CourseLocator
 
 from courseware.courses import get_course_with_access
 from discussion_api.pagination import get_paginated_data
@@ -16,6 +21,7 @@ from django_comment_common.models import (
 )
 from lms.lib.comment_client.thread import Thread
 from lms.lib.comment_client.user import User
+from lms.lib.comment_client.utils import CommentClientRequestError
 from openedx.core.djangoapps.course_groups.cohorts import get_cohort_id, get_cohort_names
 from xmodule.tabs import DiscussionTab
 
@@ -92,7 +98,142 @@ def get_course_topics(course_key, user):
     }
 
 
-def _cc_thread_to_api_thread(thread, cc_user, staff_user_ids, ta_user_ids, group_ids_to_names):
+class _DiscussionContext(object):
+    """
+    A class that represents the context in which content can be translated
+    between the comments service format and the API format. This encapsulates
+    various operations involving relating data from the content (such as user
+    ids) with data from django models (such as roles), as well as operations
+    relating the content to the comments service's representation of the user.
+    """
+    def __init__(self, course_key, requester):
+        """
+        Initializes the _DiscussionContext, raising Http404 if the requesting
+        user cannot access the course.
+        """
+        self._course_key = course_key
+        course = _get_course_or_404(course_key, requester)
+        self._requester = requester
+        self._cc_requester = User.from_django_user(requester).retrieve()
+        # TODO: cache staff_user_ids and ta_user_ids if we need to improve perf
+        self._staff_user_ids = {
+            user.id
+            for role in Role.objects.filter(
+                name__in=[FORUM_ROLE_ADMINISTRATOR, FORUM_ROLE_MODERATOR],
+                course_id=course.id
+            )
+            for user in role.users.all()
+        }
+        self._ta_user_ids = {
+            user.id
+            for role in Role.objects.filter(name=FORUM_ROLE_COMMUNITY_TA, course_id=course.id)
+            for user in role.users.all()
+        }
+        # For now, the only groups are cohorts
+        self._group_ids_to_names = get_cohort_names(course)
+
+    def is_user_privileged(self, user_id):
+        """
+        Returns a boolean indicating whether the user with the given user_id has
+        a privileged role in the course.
+        """
+        return user_id in self._staff_user_ids or user_id in self._ta_user_ids
+
+    def is_requester_privileged(self):
+        """
+        Returns a boolean indicating whether the requesting user has a
+        privileged role in the course.
+        """
+        return self.is_user_privileged(self._requester.id)
+
+    def is_content_anonymous(self, cc_content):
+        """
+        Returns a boolean indicating whether the given content should be made
+        anonymous to the requesting user.
+        """
+        return (
+            cc_content["anonymous"] or
+            (cc_content["anonymous_to_peers"] and not self.is_requester_privileged())
+        )
+
+    def get_user_label(self, cc_user_id):
+        """
+        Returns a string indicating what label should be applied to the user
+        with the given user id (the comments service stores user ids as
+        strings); possible values are "staff" and "community_ta".
+        """
+        user_id = int(cc_user_id)
+        return (
+            "staff" if user_id in self._staff_user_ids else
+            "community_ta" if user_id in self._ta_user_ids else
+            None
+        )
+
+    def get_group_name(self, group_id):
+        """Returns the name of the group with the given id in the course."""
+        return self._group_ids_to_names.get(group_id)
+
+    @lazy
+    def _requester_cohort(self):
+        """Returns the id of the requester's cohort in the course."""
+        return get_cohort_id(self._requester, self._course_key)
+
+    def requester_can_access(self, cc_thread):
+        """
+        Returns a boolean indicating whether the requesting user has permission
+        to access the given thread.
+        """
+        return (
+            self.is_requester_privileged() or
+            not cc_thread["group_id"] or
+            self._requester_cohort is None or
+            cc_thread["group_id"] == self._requester_cohort
+        )
+
+    def requester_has_followed(self, cc_thread):
+        """
+        Returns a boolean indicating whether the requesting user has followed
+        the given thread.
+        """
+        return cc_thread["id"] in self._cc_requester["subscribed_thread_ids"]
+
+    def requester_has_flagged(self, cc_content):
+        """
+        Returns a boolean indicating whether the requesting user has flagged the
+        given thread.
+        """
+        return self._cc_requester["id"] in cc_content["abuse_flaggers"]
+
+    def requester_has_voted(self, cc_content):
+        """
+        Returns a boolean indicating whether the requesting user has voted for
+        the given thread.
+        """
+        return cc_content["id"] in self._cc_requester["upvoted_ids"]
+
+
+def _get_common_fields(cc_content, context):  # TODO: find a better pair of names
+    """
+    Convert fields that are common between threads and comments from the
+    comments service format to the discussion API format.
+    """
+    is_anonymous = context.is_content_anonymous(cc_content)
+    ret = {
+        key: cc_content[key]
+        for key in ["id", "created_at", "updated_at"]
+    }
+    ret.update({
+        "author": None if is_anonymous else cc_content["username"],
+        "author_label": (None if is_anonymous else context.get_user_label(cc_content["user_id"])),
+        "raw_body": cc_content["body"],
+        "abuse_flagged": context.requester_has_flagged(cc_content),
+        "voted": context.requester_has_voted(cc_content),
+        "vote_count": cc_content["votes"]["up_count"],
+    })
+    return ret
+
+
+def _cc_thread_to_api_thread(thread, context):
     """
     Convert a thread data dict from the comment_client format (which is a direct
     representation of the format returned by the comments service) to the format
@@ -100,53 +241,27 @@ def _cc_thread_to_api_thread(thread, cc_user, staff_user_ids, ta_user_ids, group
 
     Arguments:
       thread (comment_client.thread.Thread): The thread to convert
-      cc_user (comment_client.user.User): The comment_client representation of
-        the requesting user
-      staff_user_ids (set): The set of user ids for users with the Moderator or
-        Administrator role in the course
-      ta_user_ids (set): The set of user ids for users with the Community TA
-        role in the course
-      group_ids_to_names (dict): A mapping of group ids to names
+      context (_DiscussionContext): The context in which to translate the thread
 
     Returns:
       dict: The discussion_api format representation of the thread.
     """
-    is_anonymous = (
-        thread["anonymous"] or
-        (
-            thread["anonymous_to_peers"] and
-            int(cc_user["id"]) not in (staff_user_ids | ta_user_ids)
-        )
-    )
-    ret = {
+    ret = _get_common_fields(thread, context)
+    ret.update({
         key: thread[key]
         for key in [
-            "id",
             "course_id",
             "group_id",
-            "created_at",
-            "updated_at",
             "title",
             "pinned",
             "closed",
         ]
-    }
+    })
     ret.update({
         "topic_id": thread["commentable_id"],
-        "group_name": group_ids_to_names.get(thread["group_id"]),
-        "author": None if is_anonymous else thread["username"],
-        "author_label": (
-            None if is_anonymous else
-            "staff" if int(thread["user_id"]) in staff_user_ids else
-            "community_ta" if int(thread["user_id"]) in ta_user_ids else
-            None
-        ),
+        "group_name": context.get_group_name(thread["group_id"]),
         "type": thread["thread_type"],
-        "raw_body": thread["body"],
-        "following": thread["id"] in cc_user["subscribed_thread_ids"],
-        "abuse_flagged": cc_user["id"] in thread["abuse_flaggers"],
-        "voted": thread["id"] in cc_user["upvoted_ids"],
-        "vote_count": thread["votes"]["up_count"],
+        "following": context.requester_has_followed(thread),
         "comment_count": thread["comments_count"],
         "unread_comment_count": thread["unread_comments_count"],
     })
@@ -169,16 +284,13 @@ def get_thread_list(request, course_key, page, page_size):
     A paginated result containing a list of threads; see
     discussion_api.views.ThreadViewSet for more detail.
     """
-    course = _get_course_or_404(course_key, request.user)
-    user_is_privileged = Role.objects.filter(
-        course_id=course.id,
-        name__in=[FORUM_ROLE_ADMINISTRATOR, FORUM_ROLE_MODERATOR, FORUM_ROLE_COMMUNITY_TA],
-        users=request.user
-    ).exists()
-    cc_user = User.from_django_user(request.user).retrieve()
+    context = _DiscussionContext(course_key, request.user)
     threads, result_page, num_pages, _ = Thread.search({
-        "course_id": unicode(course.id),
-        "group_id": None if user_is_privileged else get_cohort_id(request.user, course.id),
+        "course_id": unicode(course_key),
+        "group_id": (
+            None if context.is_requester_privileged() else
+            get_cohort_id(request.user, course_key)
+        ),
         "sort_key": "date",
         "sort_order": "desc",
         "page": page,
@@ -189,25 +301,107 @@ def get_thread_list(request, course_key, page, page_size):
     # behavior and return a 404 in that case
     if result_page != page:
         raise Http404
-    # TODO: cache staff_user_ids and ta_user_ids if we need to improve perf
-    staff_user_ids = {
-        user.id
-        for role in Role.objects.filter(
-            name__in=[FORUM_ROLE_ADMINISTRATOR, FORUM_ROLE_MODERATOR],
-            course_id=course.id
-        )
-        for user in role.users.all()
-    }
-    ta_user_ids = {
-        user.id
-        for role in Role.objects.filter(name=FORUM_ROLE_COMMUNITY_TA, course_id=course.id)
-        for user in role.users.all()
-    }
-    # For now, the only groups are cohorts
-    group_ids_to_names = get_cohort_names(course)
 
-    results = [
-        _cc_thread_to_api_thread(thread, cc_user, staff_user_ids, ta_user_ids, group_ids_to_names)
-        for thread in threads
-    ]
+    results = [_cc_thread_to_api_thread(thread, context) for thread in threads]
+    return get_paginated_data(request, results, page, num_pages)
+
+
+def _cc_comment_to_api_comment(cc_comment, parent_id, context):
+    """
+    Convert a comment data dict from the comment_client format (which is a
+    direct representation of the format returned by the comments service) to the
+    format used in this API
+
+    Arguments:
+      cc_comment (comment_client.comment.Comment): The comment to convert
+      context (_DiscussionContext): The context in which to translate the
+        comment
+
+    Returns:
+      dict: The discussion_api format representation of the comment.
+    """
+    ret = _get_common_fields(cc_comment, context)
+    ret.update({
+        key: cc_comment[key]
+        for key in ["thread_id"]
+    })
+    ret.update({
+        "parent_id": parent_id,
+        "children": [
+            _cc_comment_to_api_comment(child, cc_comment["id"], context)
+            for child in cc_comment["children"]
+        ],
+    })
+    return ret
+
+
+def get_comment_list(request, thread_id, endorsed, page, page_size):
+    """
+    Return the list of comments in the given thread.
+
+    Parameters:
+
+    request: The django request object used for build_absolute_uri and
+      determining the requesting user.
+    thread_id: The id of the thread to get comments for.
+    endorsed: Boolean indicating whether to get endorsed or non-endorsed
+      comments (or None for all comments). Must be None for a discussion thread
+      and non-None for a question thread.
+    page: The page number (1-indexed) to retrieve
+    page_size: The number of threads to retrieve per page
+
+    Returns:
+
+    A paginated result containing a list of comments; see
+    discussion_api.views.CommentViewSet for more detail.
+    """
+    response_skip = page_size * (page - 1)
+    try:
+        cc_thread = Thread(id=thread_id).retrieve(
+            recursive=True,
+            user_id=request.user.id,
+            mark_as_read=True,
+            response_skip=response_skip,
+            response_limit=page_size
+        )
+    except CommentClientRequestError:
+        raise Http404
+
+    course_key = CourseLocator.from_string(cc_thread["course_id"])
+
+    # Ensure user has access to thread
+    context = _DiscussionContext(course_key, request.user)
+    if not context.requester_can_access(cc_thread):
+        raise Http404
+
+    # Responses to discussion threads cannot be separated by endorsed, but
+    # responses to question threads must be separated by endorsed due to the
+    # existing comments service interface
+    if cc_thread["thread_type"] == "question":
+        if endorsed is None:
+            raise ValidationError({"endorsed": ["This field is required for question threads."]})
+        elif endorsed:
+            # CS does not apply resp_skip and resp_limit to endorsed responses
+            # of a question post
+            responses = cc_thread["endorsed_responses"][response_skip:(response_skip + page_size)]
+            resp_total = len(cc_thread["endorsed_responses"])
+        else:
+            responses = cc_thread["non_endorsed_responses"]
+            resp_total = cc_thread["non_endorsed_resp_total"]
+    else:
+        if endorsed is not None:
+            raise ValidationError(
+                {"endorsed": ["This field may not be specified for discussion threads."]}
+            )
+        responses = cc_thread["children"]
+        resp_total = cc_thread["resp_total"]
+
+    # The comments service returns the last page of results if the requested
+    # page is beyond the last page, but we want be consistent with DRF's general
+    # behavior and return a 404 in that case
+    if not responses and page != 1:
+        raise Http404
+    num_pages = (resp_total + page_size - 1) / page_size if resp_total else 1
+
+    results = [_cc_comment_to_api_comment(response, None, context) for response in responses]
     return get_paginated_data(request, results, page, num_pages)

--- a/lms/djangoapps/discussion_api/forms.py
+++ b/lms/djangoapps/discussion_api/forms.py
@@ -2,19 +2,31 @@
 Discussion API forms
 """
 from django.core.exceptions import ValidationError
-from django.forms import Form, CharField, IntegerField
+from django.forms import CharField, Form, IntegerField, NullBooleanField
 
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.locator import CourseLocator
 
 
-class ThreadListGetForm(Form):
+class _PaginationForm(Form):
+    """A form that includes pagination fields"""
+    page = IntegerField(required=False, min_value=1)
+    page_size = IntegerField(required=False, min_value=1)
+
+    def clean_page(self):
+        """Return given valid page or default of 1"""
+        return self.cleaned_data.get("page") or 1
+
+    def clean_page_size(self):
+        """Return given valid page_size (capped at 100) or default of 10"""
+        return min(self.cleaned_data.get("page_size") or 10, 100)
+
+
+class ThreadListGetForm(_PaginationForm):
     """
     A form to validate query parameters in the thread list retrieval endpoint
     """
     course_id = CharField()
-    page = IntegerField(required=False, min_value=1)
-    page_size = IntegerField(required=False, min_value=1)
 
     def clean_course_id(self):
         """Validate course_id"""
@@ -24,10 +36,12 @@ class ThreadListGetForm(Form):
         except InvalidKeyError:
             raise ValidationError("'{}' is not a valid course id".format(value))
 
-    def clean_page(self):
-        """Return given valid page or default of 1"""
-        return self.cleaned_data.get("page") or 1
 
-    def clean_page_size(self):
-        """Return given valid page_size (capped at 100) or default of 10"""
-        return min(self.cleaned_data.get("page_size") or 10, 100)
+class CommentListGetForm(_PaginationForm):
+    """
+    A form to validate query parameters in the comment list retrieval endpoint
+    """
+    thread_id = CharField()
+    # TODO: should we use something better here? This only accepts "True",
+    # "False", "1", and "0"
+    endorsed = NullBooleanField(required=False)

--- a/lms/djangoapps/discussion_api/tests/test_forms.py
+++ b/lms/djangoapps/discussion_api/tests/test_forms.py
@@ -5,25 +5,17 @@ from unittest import TestCase
 
 from opaque_keys.edx.locator import CourseLocator
 
-from discussion_api.forms import ThreadListGetForm
+from discussion_api.forms import CommentListGetForm, ThreadListGetForm
 
 
-class ThreadListGetFormTest(TestCase):
-    """Tests for ThreadListGetForm"""
-    def setUp(self):
-        super(ThreadListGetFormTest, self).setUp()
-        self.form_data = {
-            "course_id": "Foo/Bar/Baz",
-            "page": "2",
-            "page_size": "13",
-        }
-
+class FormTestMixin(object):
+    """A mixin for testing forms"""
     def get_form(self, expected_valid):
         """
         Return a form bound to self.form_data, asserting its validity (or lack
         thereof) according to expected_valid
         """
-        form = ThreadListGetForm(self.form_data)
+        form = self.FORM_CLASS(self.form_data)
         self.assertEqual(form.is_valid(), expected_valid)
         return form
 
@@ -44,25 +36,9 @@ class ThreadListGetFormTest(TestCase):
         form = self.get_form(expected_valid=True)
         self.assertEqual(form.cleaned_data[field], expected_value)
 
-    def test_basic(self):
-        form = self.get_form(expected_valid=True)
-        self.assertEqual(
-            form.cleaned_data,
-            {
-                "course_id": CourseLocator.from_string("Foo/Bar/Baz"),
-                "page": 2,
-                "page_size": 13,
-            }
-        )
 
-    def test_missing_course_id(self):
-        self.form_data.pop("course_id")
-        self.assert_error("course_id", "This field is required.")
-
-    def test_invalid_course_id(self):
-        self.form_data["course_id"] = "invalid course id"
-        self.assert_error("course_id", "'invalid course id' is not a valid course id")
-
+class PaginationTestMixin(object):
+    """A mixin for testing forms with pagination fields"""
     def test_missing_page(self):
         self.form_data.pop("page")
         self.assert_field_value("page", 1)
@@ -82,3 +58,69 @@ class ThreadListGetFormTest(TestCase):
     def test_excessive_page_size(self):
         self.form_data["page_size"] = "101"
         self.assert_field_value("page_size", 100)
+
+
+class ThreadListGetFormTest(FormTestMixin, PaginationTestMixin, TestCase):
+    """Tests for ThreadListGetForm"""
+    FORM_CLASS = ThreadListGetForm
+
+    def setUp(self):
+        super(ThreadListGetFormTest, self).setUp()
+        self.form_data = {
+            "course_id": "Foo/Bar/Baz",
+            "page": "2",
+            "page_size": "13",
+        }
+
+    def test_basic(self):
+        form = self.get_form(expected_valid=True)
+        self.assertEqual(
+            form.cleaned_data,
+            {
+                "course_id": CourseLocator.from_string("Foo/Bar/Baz"),
+                "page": 2,
+                "page_size": 13,
+            }
+        )
+
+    def test_missing_course_id(self):
+        self.form_data.pop("course_id")
+        self.assert_error("course_id", "This field is required.")
+
+    def test_invalid_course_id(self):
+        self.form_data["course_id"] = "invalid course id"
+        self.assert_error("course_id", "'invalid course id' is not a valid course id")
+
+
+class CommentListGetFormTest(FormTestMixin, PaginationTestMixin, TestCase):
+    """Tests for CommentListGetForm"""
+    FORM_CLASS = CommentListGetForm
+
+    def setUp(self):
+        super(CommentListGetFormTest, self).setUp()
+        self.form_data = {
+            "thread_id": "deadbeef",
+            "endorsed": "False",
+            "page": "2",
+            "page_size": "13",
+        }
+
+    def test_basic(self):
+        form = self.get_form(expected_valid=True)
+        self.assertEqual(
+            form.cleaned_data,
+            {
+                "thread_id": "deadbeef",
+                "endorsed": False,
+                "page": 2,
+                "page_size": 13,
+            }
+        )
+
+    def test_missing_thread_id(self):
+        self.form_data.pop("thread_id")
+        self.assert_error("thread_id", "This field is required.")
+
+    def test_missing_endorsed(self):
+        self.form_data.pop("endorsed")
+        self.assert_field_value("endorsed", None)

--- a/lms/djangoapps/discussion_api/tests/test_views.py
+++ b/lms/djangoapps/discussion_api/tests/test_views.py
@@ -201,3 +201,120 @@ class ThreadViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
             "per_page": ["4"],
             "recursive": ["False"],
         })
+
+
+@httpretty.activate
+class CommentViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
+    """Tests for CommentViewSet list"""
+    def setUp(self):
+        super(CommentViewSetListTest, self).setUp()
+        self.author = UserFactory.create()
+        self.url = reverse("comment-list")
+        self.thread_id = "test_thread"
+
+    def test_thread_id_missing(self):
+        response = self.client.get(self.url)
+        self.assert_response_correct(
+            response,
+            400,
+            {"field_errors": {"thread_id": "This field is required."}}
+        )
+
+    def test_404(self):
+        self.register_get_thread_error_response(self.thread_id, 404)
+        response = self.client.get(self.url, {"thread_id": self.thread_id})
+        self.assert_response_correct(
+            response,
+            404,
+            {"developer_message": "Not found."}
+        )
+
+    def test_basic(self):
+        self.register_get_user_response(self.user, upvoted_ids=["test_comment"])
+        source_comments = [{
+            "id": "test_comment",
+            "thread_id": self.thread_id,
+            "parent_id": None,
+            "user_id": str(self.author.id),
+            "username": self.author.username,
+            "anonymous": False,
+            "anonymous_to_peers": False,
+            "created_at": "2015-05-11T00:00:00Z",
+            "updated_at": "2015-05-11T11:11:11Z",
+            "body": "Test body",
+            "abuse_flaggers": [],
+            "votes": {"up_count": 4},
+            "children": [],
+        }]
+        expected_comments = [{
+            "id": "test_comment",
+            "thread_id": self.thread_id,
+            "parent_id": None,
+            "author": self.author.username,
+            "author_label": None,
+            "created_at": "2015-05-11T00:00:00Z",
+            "updated_at": "2015-05-11T11:11:11Z",
+            "raw_body": "Test body",
+            "abuse_flagged": False,
+            "voted": True,
+            "vote_count": 4,
+            "children": [],
+        }]
+        self.register_get_thread_response({
+            "id": self.thread_id,
+            "course_id": unicode(self.course.id),
+            "thread_type": "discussion",
+            "children": source_comments,
+            "resp_total": 100,
+        })
+        response = self.client.get(self.url, {"thread_id": self.thread_id})
+        self.assert_response_correct(
+            response,
+            200,
+            {
+                "results": expected_comments,
+                "next": "http://testserver/api/discussion/v1/comments/?thread_id={}&page=2".format(
+                    self.thread_id
+                ),
+                "previous": None,
+            }
+        )
+        self.assert_query_params_equal(
+            httpretty.httpretty.latest_requests[-2],
+            {
+                "recursive": ["True"],
+                "resp_skip": ["0"],
+                "resp_limit": ["10"],
+                "user_id": [str(self.user.id)],
+                "mark_as_read": ["True"],
+            }
+        )
+
+    def test_pagination(self):
+        self.register_get_user_response(self.user)
+        self.register_get_thread_response({
+            "id": self.thread_id,
+            "course_id": unicode(self.course.id),
+            "thread_type": "discussion",
+            "children": [],
+            "resp_total": 10,
+        })
+        response = self.client.get(
+            self.url,
+            {"thread_id": self.thread_id, "page": "18", "page_size": "4"}
+        )
+        self.assert_response_correct(
+            response,
+            404,
+            {"developer_message": "Not found."}
+        )
+        self.assert_query_params_equal(
+            httpretty.httpretty.latest_requests[-2],
+            {
+                "recursive": ["True"],
+                "resp_skip": ["68"],
+                "resp_limit": ["4"],
+                "user_id": [str(self.user.id)],
+                "mark_as_read": ["True"],
+            }
+        )

--- a/lms/djangoapps/discussion_api/tests/utils.py
+++ b/lms/djangoapps/discussion_api/tests/utils.py
@@ -21,6 +21,26 @@ class CommentsServiceMockMixin(object):
             status=200
         )
 
+    def register_get_thread_error_response(self, thread_id, status_code):
+        """Register a mock error response for GET on the CS thread endpoint."""
+        httpretty.register_uri(
+            httpretty.GET,
+            "http://localhost:4567/api/v1/threads/{id}".format(id=thread_id),
+            body="",
+            status=status_code
+        )
+
+    def register_get_thread_response(self, thread):
+        """
+        Register a mock response for GET on the CS thread instance endpoint.
+        """
+        httpretty.register_uri(
+            httpretty.GET,
+            "http://localhost:4567/api/v1/threads/{id}".format(id=thread["id"]),
+            body=json.dumps(thread),
+            status=200
+        )
+
     def register_get_user_response(self, user, subscribed_thread_ids=None, upvoted_ids=None):
         """Register a mock response for GET on the CS user instance endpoint"""
         httpretty.register_uri(
@@ -34,10 +54,16 @@ class CommentsServiceMockMixin(object):
             status=200
         )
 
+    def assert_query_params_equal(self, httpretty_request, expected_params):
+        """
+        Assert that the given mock request had the expected query parameters
+        """
+        actual_params = dict(httpretty_request.querystring)
+        actual_params.pop("request_id")  # request_id is random
+        self.assertEqual(actual_params, expected_params)
+
     def assert_last_query_params(self, expected_params):
         """
         Assert that the last mock request had the expected query parameters
         """
-        actual_params = dict(httpretty.last_request().querystring)
-        actual_params.pop("request_id")  # request_id is random
-        self.assertEqual(actual_params, expected_params)
+        self.assert_query_params_equal(httpretty.last_request(), expected_params)

--- a/lms/djangoapps/discussion_api/urls.py
+++ b/lms/djangoapps/discussion_api/urls.py
@@ -6,11 +6,12 @@ from django.conf.urls import include, patterns, url
 
 from rest_framework.routers import SimpleRouter
 
-from discussion_api.views import CourseTopicsView, ThreadViewSet
+from discussion_api.views import CommentViewSet, CourseTopicsView, ThreadViewSet
 
 
 ROUTER = SimpleRouter()
 ROUTER.register("threads", ThreadViewSet, base_name="thread")
+ROUTER.register("comments", CommentViewSet, base_name="comment")
 
 urlpatterns = patterns(
     "discussion_api",


### PR DESCRIPTION
This is a partially complete initial implementation.

This PR also contains a commit to move access control checks from views.py to api.py. Some access control checks necessarily must be done in api.py, such as ensuring that a requester can access a particular thread (which can only be done after fetching the thread). Thus, the existing access checks are also moved into api.py.

@jimabramson @BenjiLee Please review
@nasthagiri @cahrens FYI
