### PR TITLE
Catch BSON errors as well as PyMongo errors when emitting MongoDB events.

### DIFF
--- a/common/djangoapps/track/backends/mongodb.py
+++ b/common/djangoapps/track/backends/mongodb.py
@@ -7,6 +7,7 @@ import logging
 import pymongo
 from pymongo import MongoClient
 from pymongo.errors import PyMongoError
+from bson.errors import BSONError
 
 from track.backends import BaseBackend
 
@@ -89,8 +90,9 @@ class MongoBackend(BaseBackend):
         """Insert the event in to the Mongo collection"""
         try:
             self.collection.insert(event, manipulate=False)
-        except PyMongoError:
-            # The event will be lost in case of a connection error.
+        except (PyMongoError, BSONError):
+            # The event will be lost in case of a connection error or any error
+            # that occurs when trying to insert the event into Mongo.
             # pymongo will re-connect/re-authenticate automatically
             # during the next event.
             msg = 'Error inserting to MongoDB event tracker backend'

--- a/common/test/acceptance/tests/studio/test_studio_split_test.py
+++ b/common/test/acceptance/tests/studio/test_studio_split_test.py
@@ -1044,7 +1044,6 @@ class GroupConfigurationsTest(ContainerBase, SplitTestMixin):
         rendered_group_names = self.get_select_options(page=courseware_page, selector=".split-test-select")
         self.assertListEqual(group_names, rendered_group_names)
 
-    @skip  # TODO fix this, see TNL-2035
     def test_split_test_LMS_staff_view(self):
         """
         Scenario: Ensure that split test is correctly rendered in LMS staff mode as it is


### PR DESCRIPTION
We were seeing errors when emitting an event with this context in the Bok Choy tests:

```
'context': {'course_user_tags': {u'xblock.partition_service.partition_0': u'2'}, 
```

Mongo doesn't like that we have `.` in our key name and throws an `InvalidDocument` error. This fix also means that we will not record this event type (`xmodule.partitions.assigned_user_to_partition`) properly in the Bok Choy tests. There may be a better fix out there.

TNL-2035
