### PR TITLE
Moving no-outline use to be more global

### DIFF
--- a/lms/static/sass/_build-lms.scss
+++ b/lms/static/sass/_build-lms.scss
@@ -9,6 +9,7 @@
 @import 'base/font_face';
 @import 'base/extends';
 @import 'base/animations';
+@import 'base/utilities';
 
 // base - starter
 @import 'base/base';

--- a/lms/static/sass/base/_utilities.scss
+++ b/lms/static/sass/base/_utilities.scss
@@ -1,0 +1,12 @@
+// ------------------------------
+// LMS: Utilities
+
+// About: Shared utility classes that extend or enhance the interface
+// ------------------------------
+
+// No focus outline on programmatic focus
+.sr-is-focusable,
+.sr-is-focusable:focus,
+.sr-is-focusable:active {
+    @extend %no-outline;
+}

--- a/lms/static/sass/course/courseware/_courseware.scss
+++ b/lms/static/sass/course/courseware/_courseware.scss
@@ -60,12 +60,6 @@ div.course-wrapper {
       }
     }
 
-    .sr-is-focusable,
-    .sr-is-focusable:focus,
-    .sr-is-focusable:active {
-      outline: none;
-    }
-
     .sequential-status-message {
       margin-bottom: $baseline;
       background-color: $gray-l5;


### PR DESCRIPTION
This work moves the `.sr-is-focusable` style rules from scoped courseware to a utility available across the platform.

@talbs Quick review?
