### PR TITLE
Enable HTML in note tags and support highlighting

### DIFF
--- a/lms/djangoapps/edxnotes/helpers.py
+++ b/lms/djangoapps/edxnotes/helpers.py
@@ -139,13 +139,14 @@ def preprocess_collection(user, course, collection):
     cache = {}
     with store.bulk_operations(course.id):
         for model in collection:
-            model.update({
+            update = {
                 u"text": sanitize_html(model["text"]),
                 u"quote": sanitize_html(model["quote"]),
                 u"updated": dateutil_parse(model["updated"]),
-            })
+            }
             if "tags" in model:
-                model.update({u"tags": [sanitize_html(tag) for tag in model["tags"]]})
+                update[u"tags"] = [sanitize_html(tag) for tag in model["tags"]]
+            model.update(update)
             usage_id = model["usage_id"]
             if usage_id in cache:
                 model.update(cache[usage_id])

--- a/lms/djangoapps/edxnotes/helpers.py
+++ b/lms/djangoapps/edxnotes/helpers.py
@@ -144,6 +144,8 @@ def preprocess_collection(user, course, collection):
                 u"quote": sanitize_html(model["quote"]),
                 u"updated": dateutil_parse(model["updated"]),
             })
+            if "tags" in model:
+                model.update({u"tags": [sanitize_html(tag) for tag in model["tags"]]})
             usage_id = model["usage_id"]
             if usage_id in cache:
                 model.update(cache[usage_id])

--- a/lms/static/sass/course/_student-notes.scss
+++ b/lms/static/sass/course/_student-notes.scss
@@ -233,6 +233,13 @@ $divider-visual-tertiary: ($baseline/20) solid $gray-l4;
             color: $m-gray-d2;
           }
 
+          // CASE: tag matches a search query
+          .reference-meta.reference-tags .note-highlight {
+            // needed because .note-highlight is a span, which overrides the color
+            @extend %shame-link-text;
+            background-color: $result-highlight-color-base;
+          }
+
           // Put commas between tags.
           a.reference-meta.reference-tags:after {
             content: ",";

--- a/lms/templates/edxnotes/note-item.underscore
+++ b/lms/templates/edxnotes/note-item.underscore
@@ -38,7 +38,7 @@
         <% if (tags.length > 0) { %>
             <p class="reference-title"><%- gettext("Tags:") %></p>
             <% for (var i = 0; i < tags.length; i++) { %>
-                <a class="reference-meta reference-tags" href="#"><%- tags[i] %></a>
+                <a class="reference-meta reference-tags" href="#"><%= tags[i] %></a>
             <% } %>
         <% } %>
     </div>


### PR DESCRIPTION
HTML needs to be enabled for highlighting note tags because the API injects `span` tags around the highlighted sections. Please review @cahrens @marcotuts 
