### PR TITLE
catch and rename IntegrityErrors on KVS set_many (TNL-367)

### DIFF
--- a/lms/djangoapps/courseware/model_data.py
+++ b/lms/djangoapps/courseware/model_data.py
@@ -16,7 +16,7 @@ from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.block_types import BlockTypeKeyV1
 from opaque_keys.edx.asides import AsideUsageKeyV1
 
-from django.db import DatabaseError
+from django.db import DatabaseError, IntegrityError
 
 from xblock.runtime import KeyValueStore
 from xblock.exceptions import KeyValueMultiSaveError, InvalidScopeError
@@ -411,7 +411,7 @@ class DjangoKeyValueStore(KeyValueStore):
                 # If save is successful on this scope, add the saved fields to
                 # the list of successful saves
                 saved_fields.extend([field.field_name for field in field_objects[field_object]])
-            except DatabaseError:
+            except DatabaseError, IntegrityError:
                 log.exception('Error saving fields %r', field_objects[field_object])
                 raise KeyValueMultiSaveError(saved_fields)
 


### PR DESCRIPTION
@e0d @cpennington @ormsbee 

This doesn't fix the `IntegrityError` issue, but it will make the logs less noisy by raising `IntegrityErrors` here as `KeyValueMultiSaveError`s.

https://openedx.atlassian.net/browse/TNL-367
