### PR TITLE
New teams advanced setting

### DIFF
--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -74,6 +74,10 @@ class CourseMetadata(object):
                 not settings.FEATURES.get("DASHBOARD_SHARE_SETTINGS").get("CUSTOM_COURSE_URLS")):
             filtered_list.append('social_sharing_url')
 
+        # Do not show teams configuration if feature is disabled.
+        if not settings.FEATURES.get('ENABLE_TEAMS'):
+            filtered_list.append('teams_configuration')
+
         return filtered_list
 
     @classmethod

--- a/cms/envs/bok_choy.py
+++ b/cms/envs/bok_choy.py
@@ -68,6 +68,9 @@ FEATURES['ENABLE_PREREQUISITE_COURSES'] = True
 # Enable student notes
 FEATURES['ENABLE_EDXNOTES'] = True
 
+# Enable teams feature
+FEATURES['ENABLE_TEAMS'] = True
+
 ########################### Entrance Exams #################################
 FEATURES['ENTRANCE_EXAMS'] = True
 

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -155,7 +155,10 @@ FEATURES = {
     'DASHBOARD_SHARE_SETTINGS': {
         # Note: Ensure 'CUSTOM_COURSE_URLS' has a matching value in lms/envs/common.py
         'CUSTOM_COURSE_URLS': False
-    }
+    },
+
+    # Teams feature
+    'ENABLE_TEAMS': False,
 }
 
 ENABLE_JASMINE = False

--- a/cms/envs/test.py
+++ b/cms/envs/test.py
@@ -271,5 +271,9 @@ FEATURES['ENABLE_COURSEWARE_INDEX'] = True
 FEATURES['ENABLE_LIBRARY_INDEX'] = True
 SEARCH_ENGINE = "search.tests.mock_search_engine.MockSearchEngine"
 
+
+# teams feature
+FEATURES['ENABLE_TEAMS'] = True
+
 # Dummy secret key for dev/test
 SECRET_KEY = '85920908f28904ed733fe576320db18cabd7b6cd'

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -846,6 +846,15 @@ class CourseFields(object):
         scope=Scope.settings,
     )
 
+    teams_configuration = Dict(
+        display_name=_("Teams Configuration"),
+        help=_(
+            "Enter configuration for the teams feature. Expects two entries: max_team_size and topics, where "
+            "topics is a list of topics."
+        ),
+        scope=Scope.settings
+    )
+
 
 class CourseModule(CourseFields, SequenceModule):  # pylint: disable=abstract-method
     """
@@ -1408,3 +1417,28 @@ class CourseDescriptor(CourseFields, SequenceDescriptor):
         return "course_{}".format(
             b32encode(unicode(self.location.course_key)).replace('=', padding_char)
         )
+
+    @property
+    def teams_enabled(self):
+        """
+        Returns whether or not teams has been enabled for this course.
+
+        Currently, teams are considered enabled when at least one topic has been configured for the course.
+        """
+        if self.teams_configuration:
+            return len(self.teams_configuration.get('topics', [])) > 0
+        return False
+
+    @property
+    def teams_max_size(self):
+        """
+        Returns the max size for teams if teams has been configured, else None.
+        """
+        return self.teams_configuration.get('max_team_size', None)
+
+    @property
+    def teams_topics(self):
+        """
+        Returns the topics that have been configured for teams for this course, else None.
+        """
+        return self.teams_configuration.get('topics', None)

--- a/common/test/acceptance/pages/studio/settings_advanced.py
+++ b/common/test/acceptance/pages/studio/settings_advanced.py
@@ -198,4 +198,5 @@ class AdvancedSettingsPage(CoursePage):
             'text_customization',
             'annotation_storage_url',
             'social_sharing_url',
+            'teams_configuration',
         ]

--- a/lms/envs/bok_choy.py
+++ b/lms/envs/bok_choy.py
@@ -96,6 +96,9 @@ FEATURES['ENABLE_PREREQUISITE_COURSES'] = True
 # Enable student notes
 FEATURES['ENABLE_EDXNOTES'] = True
 
+# Enable teams feature
+FEATURES['ENABLE_TEAMS'] = True
+
 # Unfortunately, we need to use debug mode to serve staticfiles
 DEBUG = True
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -386,6 +386,9 @@ FEATURES = {
 
     # Software secure fake page feature flag
     'ENABLE_SOFTWARE_SECURE_FAKE': False,
+
+    # Teams feature
+    'ENABLE_TEAMS': False,
 }
 
 # Ignore static asset files on import which match this pattern

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -449,6 +449,9 @@ MONGODB_LOG = {
 # Enable EdxNotes for tests.
 FEATURES['ENABLE_EDXNOTES'] = True
 
+# Enable teams feature for tests.
+FEATURES['ENABLE_TEAMS'] = True
+
 # Add milestones to Installed apps for testing
 INSTALLED_APPS += ('milestones', )
 


### PR DESCRIPTION
Add a new advanced setting for controlling teams configurations. The visibility of this setting is dependent on the feature flag `ENABLE_TEAMS`. By default, `ENABLE_TEAMS` is set to `False`.

@andy-armstrong

https://openedx.atlassian.net/browse/TNL-1889
