### PR TITLE
Add super() calls to setUp/tearDown that are missing them

### DIFF
--- a/cms/djangoapps/course_creators/tests/test_admin.py
+++ b/cms/djangoapps/course_creators/tests/test_admin.py
@@ -27,6 +27,7 @@ class CourseCreatorAdminTest(TestCase):
 
     def setUp(self):
         """ Test case setup """
+        super(CourseCreatorAdminTest, self).setUp()
         self.user = User.objects.create_user('test_user', 'test_user+courses@edx.org', 'foo')
         self.table_entry = CourseCreator(user=self.user)
         self.table_entry.save()

--- a/cms/djangoapps/course_creators/tests/test_views.py
+++ b/cms/djangoapps/course_creators/tests/test_views.py
@@ -21,6 +21,7 @@ class CourseCreatorView(TestCase):
 
     def setUp(self):
         """ Test case setup """
+        super(CourseCreatorView, self).setUp()
         self.user = User.objects.create_user('test_user', 'test_user+courses@edx.org', 'foo')
         self.admin = User.objects.create_user('Mark', 'admin+courses@edx.org', 'foo')
         self.admin.is_staff = True

--- a/cms/lib/xblock/test/test_runtime.py
+++ b/cms/lib/xblock/test/test_runtime.py
@@ -12,6 +12,7 @@ class TestHandlerUrl(TestCase):
     """Test the LMS handler_url"""
 
     def setUp(self):
+        super(TestHandlerUrl, self).setUp()
         self.block = Mock()
 
     def test_trailing_characters(self):

--- a/common/djangoapps/config_models/tests.py
+++ b/common/djangoapps/config_models/tests.py
@@ -28,6 +28,7 @@ class ConfigurationModelTests(TestCase):
     Tests of ConfigurationModel
     """
     def setUp(self):
+        super(ConfigurationModelTests, self).setUp()
         self.user = User()
         self.user.save()
 

--- a/common/djangoapps/contentserver/tests/test.py
+++ b/common/djangoapps/contentserver/tests/test.py
@@ -200,6 +200,7 @@ class ParseRangeHeaderTestCase(unittest.TestCase):
     """
 
     def setUp(self):
+        super(ParseRangeHeaderTestCase, self).setUp()
         self.content_length = 10000
 
     def test_bytes_unit(self):

--- a/common/djangoapps/course_action_state/tests/test_managers.py
+++ b/common/djangoapps/course_action_state/tests/test_managers.py
@@ -19,6 +19,7 @@ class TestCourseActionStateManagerBase(TestCase):
     Base class for testing Course Action State Managers.
     """
     def setUp(self):
+        super(TestCourseActionStateManagerBase, self).setUp()
         self.course_key = CourseLocator("test_org", "test_course_num", "test_run")
 
 

--- a/common/djangoapps/course_action_state/tests/test_rerun_manager.py
+++ b/common/djangoapps/course_action_state/tests/test_rerun_manager.py
@@ -14,6 +14,7 @@ class TestCourseRerunStateManager(TestCase):
     Test class for testing the CourseRerunUIStateManager.
     """
     def setUp(self):
+        super(TestCourseRerunStateManager, self).setUp()
         self.source_course_key = CourseLocator("source_org", "source_course_num", "source_run")
         self.course_key = CourseLocator("test_org", "test_course_num", "test_run")
         self.created_user = UserFactory()

--- a/common/djangoapps/course_modes/tests/test_models.py
+++ b/common/djangoapps/course_modes/tests/test_models.py
@@ -22,6 +22,7 @@ class CourseModeModelTest(TestCase):
     """
 
     def setUp(self):
+        super(CourseModeModelTest, self).setUp()
         self.course_key = SlashSeparatedCourseKey('Test', 'TestCourse', 'TestCourseRun')
         CourseMode.objects.all().delete()
 

--- a/common/djangoapps/dark_lang/tests.py
+++ b/common/djangoapps/dark_lang/tests.py
@@ -28,6 +28,7 @@ class DarkLangMiddlewareTests(TestCase):
     Tests of DarkLangMiddleware
     """
     def setUp(self):
+        super(DarkLangMiddlewareTests, self).setUp()
         self.user = User()
         self.user.save()
         DarkLangConfig(

--- a/common/djangoapps/django_comment_common/tests.py
+++ b/common/djangoapps/django_comment_common/tests.py
@@ -12,6 +12,7 @@ class RoleAssignmentTest(TestCase):
     """
 
     def setUp(self):
+        super(RoleAssignmentTest, self).setUp()
         # Check a staff account because those used to get the Moderator role
         self.staff_user = User.objects.create_user(
             "patty",

--- a/common/djangoapps/edxmako/tests.py
+++ b/common/djangoapps/edxmako/tests.py
@@ -69,6 +69,7 @@ class MakoMiddlewareTest(TestCase):
     """
 
     def setUp(self):
+        super(MakoMiddlewareTest, self).setUp()
         self.middleware = edxmako.middleware.MakoMiddleware()
         self.user = UserFactory.create()
         self.url = "/"

--- a/common/djangoapps/embargo/tests/test_api.py
+++ b/common/djangoapps/embargo/tests/test_api.py
@@ -201,6 +201,7 @@ class EmbargoMessageUrlApiTests(UrlResetMixin, ModuleStoreTestCase):
         self.course = CourseFactory.create()
 
     def tearDown(self):
+        super(EmbargoMessageUrlApiTests, self).tearDown()
         cache.clear()
 
     @ddt.data(

--- a/common/djangoapps/embargo/tests/test_forms.py
+++ b/common/djangoapps/embargo/tests/test_forms.py
@@ -54,6 +54,7 @@ class IPFilterFormTest(TestCase):
     """Test form for adding [black|white]list IP addresses"""
 
     def tearDown(self):
+        super(IPFilterFormTest, self).tearDown()
         # Explicitly clear ConfigurationModel's cache so tests have a clear cache
         # and don't interfere with each other
         cache.clear()

--- a/common/djangoapps/embargo/tests/test_models.py
+++ b/common/djangoapps/embargo/tests/test_models.py
@@ -243,6 +243,7 @@ class CourseAccessRuleHistoryTest(TestCase):
     """Test course access rule history. """
 
     def setUp(self):
+        super(CourseAccessRuleHistoryTest, self).setUp()
         self.course_key = CourseLocator('edx', 'DemoX', 'Demo_Course')
         self.restricted_course = RestrictedCourse.objects.create(course_key=self.course_key)
         self.countries = {

--- a/common/djangoapps/enrollment/tests/test_api.py
+++ b/common/djangoapps/enrollment/tests/test_api.py
@@ -24,6 +24,7 @@ class EnrollmentTest(TestCase):
     COURSE_ID = "some/great/course"
 
     def setUp(self):
+        super(EnrollmentTest, self).setUp()
         fake_data_api.reset()
         cache.clear()
 

--- a/common/djangoapps/geoinfo/tests/test_middleware.py
+++ b/common/djangoapps/geoinfo/tests/test_middleware.py
@@ -25,9 +25,7 @@ class CountryMiddlewareTests(TestCase):
         self.request_factory = RequestFactory()
         self.patcher = patch.object(pygeoip.GeoIP, 'country_code_by_addr', self.mock_country_code_by_addr)
         self.patcher.start()
-
-    def tearDown(self):
-        self.patcher.stop()
+        self.addCleanup(self.patcher.stop)
 
     def mock_country_code_by_addr(self, ip_addr):
         """

--- a/common/djangoapps/lang_pref/tests/test_middleware.py
+++ b/common/djangoapps/lang_pref/tests/test_middleware.py
@@ -14,6 +14,7 @@ class TestUserPreferenceMiddleware(TestCase):
     """
 
     def setUp(self):
+        super(TestUserPreferenceMiddleware, self).setUp()
         self.middleware = LanguagePreferenceMiddleware()
         self.session_middleware = SessionMiddleware()
         self.user = UserFactory.create()

--- a/common/djangoapps/microsite_configuration/tests/test_middleware.py
+++ b/common/djangoapps/microsite_configuration/tests/test_middleware.py
@@ -21,6 +21,7 @@ class MicroSiteSessionCookieTests(TestCase):
     """
 
     def setUp(self):
+        super(MicroSiteSessionCookieTests, self).setUp()
         # create a test client
         self.client = Client()
 

--- a/common/djangoapps/monkey_patch/tests/test_django_utils_translation.py
+++ b/common/djangoapps/monkey_patch/tests/test_django_utils_translation.py
@@ -78,6 +78,7 @@ class MonkeyPatchTest(TestCase):
         """
         Remember the current state, then reset
         """
+        super(MonkeyPatchTest, self).setUp()
         self.was_patched = unpatch()
         self.unpatch_all()
         self.addCleanup(self.cleanup)

--- a/common/djangoapps/performance/tests/test_logs.py
+++ b/common/djangoapps/performance/tests/test_logs.py
@@ -19,6 +19,7 @@ class PerformanceTrackingTest(TestCase):
     """
 
     def setUp(self):
+        super(PerformanceTrackingTest, self).setUp()
         self.request_factory = RequestFactory()
         self.stream = StringIO()
         self.handler = logging.StreamHandler(self.stream)

--- a/common/djangoapps/service_status/test.py
+++ b/common/djangoapps/service_status/test.py
@@ -15,6 +15,7 @@ class CeleryConfigTest(unittest.TestCase):
         """
         Create a django test client
         """
+        super(CeleryConfigTest, self).setUp()
         self.client = Client()
         self.ping_url = reverse('status.service.celery.ping')
 

--- a/common/djangoapps/status/tests.py
+++ b/common/djangoapps/status/tests.py
@@ -57,8 +57,10 @@ class TestStatus(TestCase):
         Fake course ids, since we don't have to have full django
         settings (common tests run without the lms settings imported)
         """
+        super(TestStatus, self).setUp()
         self.full_id = 'edX/full/2012_Fall'
         self.toy_id = 'edX/toy/2012_Fall'
+        self.addCleanup(self.remove_status_file)
 
     def create_status_file(self, contents):
         """
@@ -78,9 +80,6 @@ class TestStatus(TestCase):
         """Delete the status file if it exists"""
         if os.path.exists(settings.STATUS_MESSAGE_PATH):
             os.remove(settings.STATUS_MESSAGE_PATH)
-
-    def tearDown(self):
-        self.remove_status_file()
 
     @ddt.data(*checks)
     @ddt.unpack

--- a/common/djangoapps/student/management/tests/test_transfer_students.py
+++ b/common/djangoapps/student/management/tests/test_transfer_students.py
@@ -33,10 +33,7 @@ class TestTransferStudents(ModuleStoreTestCase):
         patcher = patch('student.models.tracker')
         self.mock_tracker = patcher.start()
         self.addCleanup(patcher.stop)
-
-    def tearDown(self):
-        """Disconnects the UNENROLL stub receiver."""
-        UNENROLL_DONE.disconnect(self.assert_unenroll_signal)
+        self.addCleanup(UNENROLL_DONE.disconnect, self.assert_unenroll_signal)
 
     def assert_unenroll_signal(self, skip_refund=False, **kwargs):   # pylint: disable=unused-argument
         """ Signal Receiver stub for testing that the unenroll signal was fired. """

--- a/common/djangoapps/student/tests/test_authz.py
+++ b/common/djangoapps/student/tests/test_authz.py
@@ -20,6 +20,7 @@ class CreatorGroupTest(TestCase):
 
     def setUp(self):
         """ Test case setup """
+        super(CreatorGroupTest, self).setUp()
         self.user = User.objects.create_user('testuser', 'test+courses@edx.org', 'foo')
         self.admin = User.objects.create_user('Mark', 'admin+courses@edx.org', 'foo')
         self.admin.is_staff = True
@@ -138,6 +139,7 @@ class CourseGroupTest(TestCase):
 
     def setUp(self):
         """ Test case setup """
+        super(CourseGroupTest, self).setUp()
         self.global_admin = AdminFactory()
         self.creator = User.objects.create_user('testcreator', 'testcreator+courses@edx.org', 'foo')
         self.staff = User.objects.create_user('teststaff', 'teststaff+courses@edx.org', 'foo')

--- a/common/djangoapps/student/tests/test_bulk_email_settings.py
+++ b/common/djangoapps/student/tests/test_bulk_email_settings.py
@@ -49,12 +49,6 @@ class TestStudentDashboardEmailView(ModuleStoreTestCase):
             name=self.course.display_name.replace(' ', '_'),
         )
 
-    def tearDown(self):
-        """
-        Undo all patches.
-        """
-        patch.stopall()
-
     @patch.dict(settings.FEATURES, {'ENABLE_INSTRUCTOR_EMAIL': True, 'REQUIRE_COURSE_EMAIL_AUTH': False})
     def test_email_flag_true(self):
         # Assert that the URL for the email view is in the response
@@ -97,6 +91,7 @@ class TestStudentDashboardEmailViewXMLBacked(ModuleStoreTestCase):
     MODULESTORE = TEST_DATA_MIXED_TOY_MODULESTORE
 
     def setUp(self):
+        super(TestStudentDashboardEmailViewXMLBacked, self).setUp()
         self.course_name = 'edX/toy/2012_Fall'
 
         # Create student account

--- a/common/djangoapps/student/tests/test_change_name.py
+++ b/common/djangoapps/student/tests/test_change_name.py
@@ -19,6 +19,7 @@ class TestChangeName(TestCase):
     Check the change_name view of student.
     """
     def setUp(self):
+        super(TestChangeName, self).setUp()
         self.student = UserFactory.create(password='test')
         self.client = Client()
 

--- a/common/djangoapps/student/tests/test_create_account.py
+++ b/common/djangoapps/student/tests/test_create_account.py
@@ -45,6 +45,7 @@ class TestCreateAccount(TestCase):
     """Tests for account creation"""
 
     def setUp(self):
+        super(TestCreateAccount, self).setUp()
         self.username = "test_user"
         self.url = reverse("create_account")
         self.request_factory = RequestFactory()
@@ -477,6 +478,7 @@ class TestCreateAccountValidation(TestCase):
 class TestCreateCommentsServiceUser(TransactionTestCase):
 
     def setUp(self):
+        super(TestCreateCommentsServiceUser, self).setUp()
         self.username = "test_user"
         self.url = reverse("create_account")
         self.params = {

--- a/common/djangoapps/student/tests/test_email.py
+++ b/common/djangoapps/student/tests/test_email.py
@@ -139,6 +139,7 @@ class ReactivationEmailTests(EmailTestMixin, TestCase):
     """Test sending a reactivation email to a user"""
 
     def setUp(self):
+        super(ReactivationEmailTests, self).setUp()
         self.user = UserFactory.create()
         self.unregisteredUser = UserFactory.create()
         self.registration = RegistrationFactory.create(user=self.user)
@@ -336,6 +337,7 @@ class EmailChangeRequestTests(EventTestMixin, TestCase):
 class EmailChangeConfirmationTests(EmailTestMixin, TransactionTestCase):
     """Test that confirmation of email change requests function even in the face of exceptions thrown while sending email"""
     def setUp(self):
+        super(EmailChangeConfirmationTests, self).setUp()
         self.user = UserFactory.create()
         self.profile = UserProfile.objects.get(user=self.user)
         self.req_factory = RequestFactory()

--- a/common/djangoapps/student/tests/test_login.py
+++ b/common/djangoapps/student/tests/test_login.py
@@ -32,6 +32,7 @@ class LoginTest(TestCase):
     '''
 
     def setUp(self):
+        super(LoginTest, self).setUp()
         # Create one user and save it to the database
         self.user = UserFactory.build(username='test', email='test@edx.org')
         self.user.set_password('test_password')

--- a/common/djangoapps/student/tests/test_long_username_email.py
+++ b/common/djangoapps/student/tests/test_long_username_email.py
@@ -8,6 +8,7 @@ from django.core.urlresolvers import reverse
 class TestLongUsernameEmail(TestCase):
 
     def setUp(self):
+        super(TestLongUsernameEmail, self).setUp()
         self.url = reverse('create_account')
         self.url_params = {
             'username': 'username',

--- a/common/djangoapps/student/tests/test_microsite.py
+++ b/common/djangoapps/student/tests/test_microsite.py
@@ -46,6 +46,7 @@ def fake_microsite_get_value(name, default=None):
 class TestMicrosite(TestCase):
     """Test for Account Creation from a white labeled Micro-Sites"""
     def setUp(self):
+        super(TestMicrosite, self).setUp()
         self.username = "test_user"
         self.url = reverse("create_account")
         self.params = {

--- a/common/djangoapps/student/tests/test_roles.py
+++ b/common/djangoapps/student/tests/test_roles.py
@@ -20,6 +20,7 @@ class RolesTestCase(TestCase):
     """
 
     def setUp(self):
+        super(RolesTestCase, self).setUp()
         self.course_key = SlashSeparatedCourseKey('edX', 'toy', '2012_Fall')
         self.course_loc = self.course_key.make_usage_key('course', '2012_Fall')
         self.anonymous_user = AnonymousUserFactory()
@@ -171,6 +172,7 @@ class RoleCacheTestCase(TestCase):
     )
 
     def setUp(self):
+        super(RoleCacheTestCase, self).setUp()
         self.user = UserFactory()
 
     @ddt.data(*ROLES)

--- a/common/djangoapps/student/tests/test_userstanding.py
+++ b/common/djangoapps/student/tests/test_userstanding.py
@@ -15,6 +15,7 @@ class UserStandingTest(TestCase):
     """test suite for user standing view for enabling and disabling accounts"""
 
     def setUp(self):
+        super(UserStandingTest, self).setUp()
         # create users
         self.bad_user = UserFactory.create(
             username='bad_user',

--- a/common/djangoapps/terrain/stubs/tests/test_edxnotes.py
+++ b/common/djangoapps/terrain/stubs/tests/test_edxnotes.py
@@ -17,6 +17,7 @@ class StubEdxNotesServiceTest(unittest.TestCase):
         """
         Start the stub server.
         """
+        super(StubEdxNotesServiceTest, self).setUp()
         self.server = StubEdxNotesService()
         dummy_notes = self._get_dummy_notes(count=2)
         self.server.add_notes(dummy_notes)

--- a/common/djangoapps/terrain/stubs/tests/test_http.py
+++ b/common/djangoapps/terrain/stubs/tests/test_http.py
@@ -11,6 +11,7 @@ from terrain.stubs.http import StubHttpService, StubHttpRequestHandler, require_
 class StubHttpServiceTest(unittest.TestCase):
 
     def setUp(self):
+        super(StubHttpServiceTest, self).setUp()
         self.server = StubHttpService()
         self.addCleanup(self.server.shutdown)
         self.url = "http://127.0.0.1:{0}/set_config".format(self.server.port)
@@ -86,6 +87,7 @@ class RequireParamTest(unittest.TestCase):
     """
 
     def setUp(self):
+        super(RequireParamTest, self).setUp()
         self.server = RequireHttpService()
         self.addCleanup(self.server.shutdown)
         self.url = "http://127.0.0.1:{port}".format(port=self.server.port)

--- a/common/djangoapps/terrain/stubs/tests/test_lti_stub.py
+++ b/common/djangoapps/terrain/stubs/tests/test_lti_stub.py
@@ -16,6 +16,7 @@ class StubLtiServiceTest(unittest.TestCase):
     Used for lettuce BDD tests in lms/courseware/features/lti.feature
     """
     def setUp(self):
+        super(StubLtiServiceTest, self).setUp()
         self.server = StubLtiService()
         self.uri = 'http://127.0.0.1:{}/'.format(self.server.port)
         self.launch_uri = self.uri + 'correct_lti_endpoint'

--- a/common/djangoapps/terrain/stubs/tests/test_ora.py
+++ b/common/djangoapps/terrain/stubs/tests/test_ora.py
@@ -14,6 +14,7 @@ class StubOraServiceTest(unittest.TestCase):
         """
         Start the stub server.
         """
+        super(StubOraServiceTest, self).setUp()
         self.server = StubOraService()
         self.addCleanup(self.server.shutdown)
 

--- a/common/djangoapps/terrain/stubs/tests/test_xqueue_stub.py
+++ b/common/djangoapps/terrain/stubs/tests/test_xqueue_stub.py
@@ -23,6 +23,7 @@ class FakeTimer(object):
 class StubXQueueServiceTest(unittest.TestCase):
 
     def setUp(self):
+        super(StubXQueueServiceTest, self).setUp()
         self.server = StubXQueueService()
         self.url = "http://127.0.0.1:{0}/xqueue/submit".format(self.server.port)
         self.addCleanup(self.server.shutdown)

--- a/common/djangoapps/terrain/stubs/tests/test_youtube_stub.py
+++ b/common/djangoapps/terrain/stubs/tests/test_youtube_stub.py
@@ -10,6 +10,7 @@ from ..youtube import StubYouTubeService
 class StubYouTubeServiceTest(unittest.TestCase):
 
     def setUp(self):
+        super(StubYouTubeServiceTest, self).setUp()
         self.server = StubYouTubeService()
         self.url = "http://127.0.0.1:{0}/".format(self.server.port)
         self.server.config['time_to_response'] = 0.0

--- a/common/djangoapps/track/backends/tests/test_django.py
+++ b/common/djangoapps/track/backends/tests/test_django.py
@@ -7,6 +7,7 @@ from track.backends.django import DjangoBackend, TrackingLog
 
 class TestDjangoBackend(TestCase):
     def setUp(self):
+        super(TestDjangoBackend, self).setUp()
         self.backend = DjangoBackend()
 
     def test_django_backend(self):

--- a/common/djangoapps/track/backends/tests/test_logger.py
+++ b/common/djangoapps/track/backends/tests/test_logger.py
@@ -11,7 +11,7 @@ from track.backends.logger import LoggerBackend
 
 class TestLoggerBackend(TestCase):
     def setUp(self):
-
+        super(TestLoggerBackend, self).setUp()
         self.handler = MockLoggingHandler()
         self.handler.setLevel(logging.INFO)
 

--- a/common/djangoapps/track/backends/tests/test_mongodb.py
+++ b/common/djangoapps/track/backends/tests/test_mongodb.py
@@ -9,9 +9,10 @@ from track.backends.mongodb import MongoBackend
 
 class TestMongoBackend(TestCase):
     def setUp(self):
+        super(TestMongoBackend, self).setUp()
         self.mongo_patcher = patch('track.backends.mongodb.MongoClient')
-        self.addCleanup(self.mongo_patcher.stop)
         self.mongo_patcher.start()
+        self.addCleanup(self.mongo_patcher.stop)
 
         self.backend = MongoBackend()
 

--- a/common/djangoapps/track/tests/test_middleware.py
+++ b/common/djangoapps/track/tests/test_middleware.py
@@ -14,6 +14,7 @@ from track.middleware import TrackMiddleware
 class TrackMiddlewareTestCase(TestCase):
 
     def setUp(self):
+        super(TrackMiddlewareTestCase, self).setUp()
         self.track_middleware = TrackMiddleware()
         self.request_factory = RequestFactory()
 

--- a/common/djangoapps/track/tests/test_tracker.py
+++ b/common/djangoapps/track/tests/test_tracker.py
@@ -29,6 +29,7 @@ class TestTrackerInstantiation(TestCase):
     """Test that a helper function can instantiate backends from their name."""
     def setUp(self):
         # pylint: disable=protected-access
+        super(TestTrackerInstantiation, self).setUp()
         self.get_backend = tracker._instantiate_backend_from_name
 
     def test_instatiate_backend(self):

--- a/common/djangoapps/util/tests/test_disable_rate_limit.py
+++ b/common/djangoapps/util/tests/test_disable_rate_limit.py
@@ -30,6 +30,7 @@ class DisableRateLimitTest(TestCase):
     """Check that we can disable rate limiting for perf testing. """
 
     def setUp(self):
+        super(DisableRateLimitTest, self).setUp()
         cache.clear()
         self.view = FakeApiView()
 

--- a/common/djangoapps/util/tests/test_file.py
+++ b/common/djangoapps/util/tests/test_file.py
@@ -52,6 +52,7 @@ class FilenameGeneratorTestCase(TestCase):
     NOW = datetime.strptime('1974-06-22T01:02:03', '%Y-%m-%dT%H:%M:%S').replace(tzinfo=UTC())
 
     def setUp(self):
+        super(FilenameGeneratorTestCase, self).setUp()
         datetime_patcher = patch.object(
             util.file, 'datetime',
             Mock(wraps=datetime)
@@ -84,6 +85,7 @@ class StoreUploadedFileTestCase(TestCase):
     """
 
     def setUp(self):
+        super(StoreUploadedFileTestCase, self).setUp()
         self.request = Mock(spec=HttpRequest)
         self.file_content = "test file content"
         self.request.FILES = {"uploaded_file": SimpleUploadedFile("tempfile.csv", self.file_content)}
@@ -92,6 +94,7 @@ class StoreUploadedFileTestCase(TestCase):
         self.default_max_size = 2000000
 
     def tearDown(self):
+        super(StoreUploadedFileTestCase, self).tearDown()
         if self.file_storage and self.stored_file_name:
             self.file_storage.delete(self.stored_file_name)
 

--- a/common/djangoapps/util/tests/test_memcache.py
+++ b/common/djangoapps/util/tests/test_memcache.py
@@ -17,6 +17,7 @@ class MemcacheTest(TestCase):
                           [129, 500, 2 ** 8 - 1, 2 ** 8 + 1, 2 ** 16 - 1])
 
     def setUp(self):
+        super(MemcacheTest, self).setUp()
         self.cache = get_cache('default')
 
     def test_safe_key(self):

--- a/common/djangoapps/util/tests/test_request.py
+++ b/common/djangoapps/util/tests/test_request.py
@@ -12,10 +12,12 @@ from util.request import course_id_from_url, safe_get_host
 class ResponseTestCase(unittest.TestCase):
     """ Tests for response-related utility functions """
     def setUp(self):
+        super(ResponseTestCase, self).setUp()
         self.old_site_name = settings.SITE_NAME
         self.old_allowed_hosts = settings.ALLOWED_HOSTS
 
     def tearDown(self):
+        super(ResponseTestCase, self).tearDown()
         settings.SITE_NAME = self.old_site_name
         settings.ALLOWED_HOSTS = self.old_allowed_hosts
 

--- a/common/djangoapps/util/tests/test_submit_feedback.py
+++ b/common/djangoapps/util/tests/test_submit_feedback.py
@@ -21,6 +21,7 @@ from student.tests.test_microsite import fake_microsite_get_value
 class SubmitFeedbackTest(TestCase):
     def setUp(self):
         """Set up data for the test case"""
+        super(SubmitFeedbackTest, self).setUp()
         self._request_factory = RequestFactory()
         self._anon_user = AnonymousUser()
         self._auth_user = UserFactory.create(

--- a/common/djangoapps/xblock_django/tests/test_user_service.py
+++ b/common/djangoapps/xblock_django/tests/test_user_service.py
@@ -19,6 +19,7 @@ class UserServiceTestCase(TestCase):
     Tests for the DjangoXBlockUserService.
     """
     def setUp(self):
+        super(UserServiceTestCase, self).setUp()
         self.user = UserFactory(username="tester", email="test@tester.com")
         self.user.profile.name = "Test Tester"
         self.anon_user = AnonymousUserFactory()

--- a/common/lib/capa/capa/safe_exec/tests/test_lazymod.py
+++ b/common/lib/capa/capa/safe_exec/tests/test_lazymod.py
@@ -28,6 +28,7 @@ class ModuleIsolation(object):
 class TestLazyMod(unittest.TestCase):
 
     def setUp(self):
+        super(TestLazyMod, self).setUp()
         # Each test will remove modules that it imported.
         self.addCleanup(ModuleIsolation().clean_up)
 

--- a/common/test/acceptance/tests/lms/test_lms_courseware_search.py
+++ b/common/test/acceptance/tests/lms/test_lms_courseware_search.py
@@ -49,6 +49,7 @@ class CoursewareSearchTest(UniqueCourseTest):
         # create test file in which index for this test will live
         with open(self.TEST_INDEX_FILENAME, "w+") as index_file:
             json.dump({}, index_file)
+        self.addCleanup(os.remove, self.TEST_INDEX_FILENAME)
 
         super(CoursewareSearchTest, self).setUp()
         self.courseware_search_page = CoursewareSearchPage(self.browser, self.course_id)
@@ -76,9 +77,6 @@ class CoursewareSearchTest(UniqueCourseTest):
                 XBlockFixtureDesc('sequential', 'Subsection 2')
             )
         ).install()
-
-    def tearDown(self):
-        os.remove(self.TEST_INDEX_FILENAME)
 
     def _auto_auth(self, username, email, staff):
         """

--- a/common/test/acceptance/tests/lms/test_lms_edxnotes.py
+++ b/common/test/acceptance/tests/lms/test_lms_edxnotes.py
@@ -95,10 +95,9 @@ class EdxNotesTestMixin(UniqueCourseTest):
                 ),
             )).install()
 
-        AutoAuthPage(self.browser, username=self.username, email=self.email, course_id=self.course_id).visit()
+        self.addCleanup(self.edxnotes_fixture.cleanup)
 
-    def tearDown(self):
-        self.edxnotes_fixture.cleanup()
+        AutoAuthPage(self.browser, username=self.username, email=self.email, course_id=self.course_id).visit()
 
     def _add_notes(self):
         xblocks = self.course_fixture.get_nested_xblocks(category="html")

--- a/lms/djangoapps/ccx/tests/test_views.py
+++ b/lms/djangoapps/ccx/tests/test_views.py
@@ -118,13 +118,6 @@ class TestCoachDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase):
         from django.core import mail
         return mail.outbox
 
-    def tearDown(self):
-        """
-        Undo patches.
-        """
-        super(TestCoachDashboard, self).tearDown()
-        patch.stopall()
-
     def test_not_a_coach(self):
         """
         User is not a coach, should get Forbidden response.

--- a/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
+++ b/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
@@ -40,12 +40,6 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase):
         # URL for instructor dash
         self.url = reverse('instructor_dashboard', kwargs={'course_id': self.course.id.to_deprecated_string()})
 
-    def tearDown(self):
-        """
-        Undo patches.
-        """
-        patch.stopall()
-
     def get_dashboard_enrollment_message(self):
         """
         Returns expected dashboard enrollment message with link to Insights.

--- a/openedx/core/djangoapps/user_api/course_tag/tests/test_api.py
+++ b/openedx/core/djangoapps/user_api/course_tag/tests/test_api.py
@@ -13,6 +13,7 @@ class TestCourseTagAPI(TestCase):
     Test the user service
     """
     def setUp(self):
+        super(TestCourseTagAPI, self).setUp()
         self.user = UserFactory.create()
         self.course_id = SlashSeparatedCourseKey('test_org', 'test_course_number', 'test_run')
         self.test_key = 'test_key'

--- a/openedx/core/djangoapps/user_api/tests/test_helpers.py
+++ b/openedx/core/djangoapps/user_api/tests/test_helpers.py
@@ -134,6 +134,7 @@ class FormDescriptionTest(TestCase):
 class StudentViewShimTest(TestCase):
     "Tests of the student view shim."
     def setUp(self):
+        super(StudentViewShimTest, self).setUp()
         self.captured_request = None
 
     def test_strip_enrollment_action(self):

--- a/openedx/core/djangoapps/user_api/tests/test_middleware.py
+++ b/openedx/core/djangoapps/user_api/tests/test_middleware.py
@@ -16,6 +16,7 @@ class TagsMiddlewareTest(TestCase):
     Test the UserTagsEventContextMiddleware
     """
     def setUp(self):
+        super(TagsMiddlewareTest, self).setUp()
         self.middleware = UserTagsEventContextMiddleware()
         self.user = UserFactory.create()
         self.other_user = UserFactory.create()

--- a/openedx/core/djangoapps/user_api/tests/test_partition_schemes.py
+++ b/openedx/core/djangoapps/user_api/tests/test_partition_schemes.py
@@ -42,12 +42,10 @@ class TestRandomUserPartitionScheme(PartitionTestCase):
             'openedx.core.djangoapps.user_api.partition_schemes.course_tag_api', course_tag_api
         )
         self.user_service_patcher.start()
+        self.addCleanup(self.user_service_patcher.stop)
 
         # Create a test user
         self.user = UserFactory.create()
-
-    def tearDown(self):
-        self.user_service_patcher.stop()
 
     def test_get_group_for_user(self):
         # get a group assigned to the user

--- a/pavelib/paver_tests/test_paver_bok_choy_cmds.py
+++ b/pavelib/paver_tests/test_paver_bok_choy_cmds.py
@@ -9,6 +9,7 @@ REPO_DIR = os.getcwd()
 class TestPaverBokChoyCmd(unittest.TestCase):
 
     def setUp(self):
+        super(TestPaverBokChoyCmd, self).setUp()
         self.request = BokChoyTestSuite('')
 
     def _expected_command(self, expected_text_append, expected_default_store=None):


### PR DESCRIPTION
Also, I replaced a number of tearDown methods with addCleanup instead.
And also remove some unneeded patch.stopall() calls.
