### PR TITLE
LMS/Studio: Update Use of IE Conditional Comments

### DIFF
--- a/cms/templates/base.html
+++ b/cms/templates/base.html
@@ -7,8 +7,8 @@ import json
 <%namespace name='static' file='static_content.html'/>
 
 <!doctype html>
-<!--[if IE 9]><html class="ie9 lte9" lang="${LANGUAGE_CODE}"><![endif]-->
-<!--[if gt IE 9]><!--><html lang="${LANGUAGE_CODE}"><!--<![endif]-->
+<!--[if lte IE 9]><html class="ie9 lte9" lang="${LANGUAGE_CODE}"><![endif]-->
+<!--[if !IE]><<!--><html lang="${LANGUAGE_CODE}"><!--<![endif]-->
 <%
     # set doc language direction
     from django.utils.translation import get_language_bidi

--- a/cms/templates/base.html
+++ b/cms/templates/base.html
@@ -7,8 +7,6 @@ import json
 <%namespace name='static' file='static_content.html'/>
 
 <!doctype html>
-<!--[if IE 7]><html class="ie7 lte9 lte8 lte7" lang="${LANGUAGE_CODE}"><![endif]-->
-<!--[if IE 8]><html class="ie8 lte9 lte8" lang="${LANGUAGE_CODE}"><![endif]-->
 <!--[if IE 9]><html class="ie9 lte9" lang="${LANGUAGE_CODE}"><![endif]-->
 <!--[if gt IE 9]><!--><html lang="${LANGUAGE_CODE}"><!--<![endif]-->
 <%

--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -1,8 +1,6 @@
 <!DOCTYPE html>
-<!--[if IE 7]><html class="ie ie7 lte9 lte8 lte7" lang="${LANGUAGE_CODE}"><![endif]-->
-<!--[if IE 8]><html class="ie ie8 lte9 lte8" lang="${LANGUAGE_CODE}"><![endif]-->
-<!--[if IE 9]><html class="ie ie9 lte9" lang="${LANGUAGE_CODE}"><![endif]-->
-<!--[if gt IE 9]><!--><html lang="${LANGUAGE_CODE}"><!--<![endif]-->
+<!--[if lte IE 9]><html class="ie ie9 lte9" lang="${LANGUAGE_CODE}"><![endif]-->
+<!--[if !IE]><!--><html lang="${LANGUAGE_CODE}"><!--<![endif]-->
 <%
     # set doc language direction
     from django.utils.translation import get_language_bidi
@@ -116,10 +114,6 @@
   % if header_extra_file:
     <%include file="${header_extra_file}" />
   % endif
-
-  <!--[if lt IE 9]>
-    <script src="${static.url('js/html5shiv.js')}"></script>
-  <![endif]-->
 
   <%include file="widgets/optimizely.html" />
   <%include file="widgets/segment-io.html" />

--- a/lms/templates/main_django.html
+++ b/lms/templates/main_django.html
@@ -20,10 +20,6 @@
 
   {% microsite_css_overrides_file %}
 
-  <!--[if lt IE 9]>
-  <script src="{% static 'js/html5shiv.js' %}"></script>
-  <![endif]-->
-
   <meta name="path_prefix" content="{{EDX_ROOT_URL}}">
 </head>
 

--- a/lms/templates/mktg_iframe.html
+++ b/lms/templates/mktg_iframe.html
@@ -1,9 +1,7 @@
 <%namespace name='static' file='static_content.html'/>
 <!DOCTYPE html>
-<!--[if IE 7]><html class="ie ie7 lte9 lte8 lte7 view-iframe" lang="${LANGUAGE_CODE}"><![endif]-->
-<!--[if IE 8]><html class="ie ie8 lte9 lte8 view-iframe" lang="${LANGUAGE_CODE}"><![endif]-->
-<!--[if IE 9]><html class="ie ie9 lte9 view-iframe" lang="${LANGUAGE_CODE}"><![endif]-->
-<!--[if gt IE 9]><!--><html class="view-iframe" lang="${LANGUAGE_CODE}"><!--<![endif]-->
+<!--[if lte IE 9]><html class="ie ie9 lte9 view-iframe" lang="${LANGUAGE_CODE}"><![endif]-->
+<!--[if !IE]><!--><html class="view-iframe" lang="${LANGUAGE_CODE}"><!--<![endif]-->
 <head>
   <%block name="title"></%block>
 
@@ -14,10 +12,6 @@
   <%static:css group='style-vendor'/>
   <%static:css group='style-app'/>
   <%static:js group='base_vendor'/>
-
-  <!--[if lt IE 9]>
-    <script src="${static.url('js/html5shiv.js')}"></script>
-  <![endif]-->
 
   <%block name="headextra"/>
 

--- a/lms/templates/navigation-edx.html
+++ b/lms/templates/navigation-edx.html
@@ -145,7 +145,7 @@ site_status_msg = get_site_status_msg(course_id)
   </div>
 </header>
 % if course:
-<!--[if lte IE 8]>
+<!--[if lte IE 9]>
 <div class="ie-banner" aria-hidden="true">${_('<strong>Warning:</strong> Your browser is not fully supported. We strongly recommend using {chrome_link} or {ff_link}.').format(chrome_link='<a href="https://www.google.com/intl/en/chrome/browser/" target="_blank">Chrome</a>', ff_link='<a href="http://www.mozilla.org/en-US/firefox/new/" target="_blank">Firefox</a>')}</div>
 <![endif]-->
 % endif

--- a/lms/templates/navigation.html
+++ b/lms/templates/navigation.html
@@ -151,7 +151,7 @@ site_status_msg = get_site_status_msg(course_id)
   </nav>
 </header>
 % if course:
-<!--[if lte IE 8]>
+<!--[if lte IE 9]>
 <div class="ie-banner" aria-hidden="true">${_('<strong>Warning:</strong> Your browser is not fully supported. We strongly recommend using {chrome_link} or {ff_link}.').format(chrome_link='<a href="https://www.google.com/intl/en/chrome/browser/" target="_blank">Chrome</a>', ff_link='<a href="http://www.mozilla.org/en-US/firefox/new/" target="_blank">Firefox</a>')}</div>
 <![endif]-->
 % endif


### PR DESCRIPTION
This work updates the IE conditional comments we use in our HTML throughout the platform to bring them up to speed with our current levels of IE browser support (10 and above). 

In short, this:
- removes logic and specific class names added for older IE browser cases (8 and below)
- only flags IE9 with specific html class attrs (in the emergency-level event that we need to isolate an issue for a very specific fringe case in the near future)
- removes an HTML5 shiv (inserted with LTE IE8 conditional comments) that's no longer needed for IE10 and above

---

**Sandboxes**
http://pr8061.m.sandbox.edx.org/
http://studio.pr8061.m.sandbox.edx.org/

---

**Reviewers**
- @marcotuts - FED
- @sarina - Open edX

---

For more information on IE conditional comments (supported in only IE9 and below), see - http://www.quirksmode.org/css/condcom.html
