### PR TITLE
Refine error page regexes such that they only match 404 and 500

### DIFF
--- a/lms/urls.py
+++ b/lms/urls.py
@@ -662,6 +662,6 @@ handler500 = 'static_template_view.views.render_500'
 
 # display error page templates, for testing purposes
 urlpatterns += (
-    url(r'404', handler404),
-    url(r'500', handler500),
+    url(r'^404$', handler404),
+    url(r'^500$', handler500),
 )


### PR DESCRIPTION
Prevents 500s and 404s from being thrown when users try to enroll in courses which contain 500 or 404 in their course IDs.

@wedaly @singingwolfboy @benpatterson 
