### PR TITLE
WIP: Footer API

### DIFF
--- a/lms/djangoapps/branding/admin.py
+++ b/lms/djangoapps/branding/admin.py
@@ -4,6 +4,7 @@ Django admin pages for Video Branding Configuration.
 from django.contrib import admin
 from config_models.admin import ConfigurationModelAdmin
 
-from .models import BrandingInfoConfig
+from .models import BrandingInfoConfig, BrandingApiConfig
 
 admin.site.register(BrandingInfoConfig, ConfigurationModelAdmin)
+admin.site.register(BrandingApiConfig, ConfigurationModelAdmin)

--- a/lms/djangoapps/branding/admin.py
+++ b/lms/djangoapps/branding/admin.py
@@ -1,6 +1,4 @@
-'''
-Django admin pages for Video Branding Configuration.
-'''
+"""Django admin pages for branding configuration. """
 from django.contrib import admin
 from config_models.admin import ConfigurationModelAdmin
 

--- a/lms/djangoapps/branding/api.py
+++ b/lms/djangoapps/branding/api.py
@@ -1,11 +1,21 @@
-"""Edx branding API
+"""EdX Branding API
+
+Provides a way to retrieve "branded" parts of the site,
+such as the site footer.
+
+This information exposed to:
+1) Templates in the LMS.
+2) Consumers of the branding API.
+
+This ensures that branded UI elements such as the footer
+are consistent across the LMS and other sites (such as
+the marketing site and blog).
+
 """
 import logging
-import os
+
 from django.conf import settings
 from django.utils.translation import ugettext as _
-from django.shortcuts import render_to_response
-from django.core.cache import cache
 from staticfiles.storage import staticfiles_storage
 
 from microsite_configuration import microsite
@@ -14,201 +24,248 @@ from edxmako.shortcuts import marketing_link
 log = logging.getLogger("edx.footer")
 
 
-def get_footer_json():
-    """ Get the footer links json
+def get_footer(is_secure=True):
+    """Retrieve information used to render the footer.
 
-    Returns:
-        Dict of footer links
+    This will handle both the OpenEdX and EdX.org versions
+    of the footer.  All user-facing text is internationalized.
+
+    Currently, this does NOT support theming.
+
+    Keyword Arguments:
+        is_secure (bool): If True, use https:// in URLs.
+
+    Returns: dict
+
+    Example:
+    >>> get_footer()
+    {
+        "copyright": "(c) 2015 EdX Inc",
+        "logo_image": "http://www.example.com/logo.png",
+        "social_links": [
+            {
+                "name": "facebook",
+                "title": "Facebook",
+                "url": "http://www.facebook.com/example",
+                "icon-class": "fa-facebook-square"
+            },
+            ...
+        ],
+        "navigation_links": [
+            {
+                "name": "about",
+                "title": "About",
+                "url": "http://www.example.com/about.html"
+            },
+            ...
+        ],
+        "mobile_links": [
+            {
+                "name": "apple",
+                "title": "Apple",
+                "url": "http://store.apple.com/example_app"
+                "image": "http://example.com/static/apple_logo.png"
+            },
+            ...
+        ],
+        "openedx_link": {
+            "url": "http://open.edx.org",
+            "title": "Powered by Open edX",
+            "image": "http://example.com/openedx.png"
+        }
+    }
+
     """
     is_edx_domain = settings.FEATURES.get('IS_EDX_DOMAIN', False)
-    key = "footer/json/{domain}".format(domain="edx" if is_edx_domain else "open_edx")
-    footer_json = cache.get(key)
-    if footer_json:
-        return footer_json
     site_name = microsite.get_value('SITE_NAME', settings.SITE_NAME)
 
-    context = dict()
-    context["copy_right"] = copy_right(is_edx_domain)
-    context["heading"] = heading(is_edx_domain)
-    context["logo_img"] = get_footer_logo(site_name, is_edx_domain)
-    context["social_links"] = social_links()
-    context["about_links"] = about_edx_link()
-    context["mobile_urls"] = get_mobile_urls()
-    footer_json = {"footer": context}
-    cache.set(key, footer_json)
-    return footer_json
+    return {
+        "copyright": _footer_copyright(is_edx_domain),
+        "logo_image": _footer_logo_img(is_secure, site_name, is_edx_domain),
+        "social_links": _footer_social_links(),
+        "navigation_links": _footer_navigation_links(),
+        "mobile_links": _footer_mobile_links(is_secure, site_name),
+        "openedx_link": _footer_openedx_link(is_secure, site_name),
+    }
 
 
-def copy_right(is_edx_domain):
-    """ Returns the copy rights text
+def _footer_copyright(is_edx_domain):
+    """Return the copyright to display in the footer.
+
+    Arguments:
+        is_edx_domain (bool): If true, this is an EdX-controlled domain.
+
+    Returns: unicode
+
     """
-    if is_edx_domain:
-        data = _(
-            "(c) 2015 edX Inc. EdX, Open edX, and the edX and Open edX logos "
-            "are registered trademarks or trademarks of edX Inc."
-        )
-    else:
-        data = _(
-            "EdX, Open edX, and the edX and Open edX logos are registered trademarks or "
-            "trademarks of {link_start}edX Inc.{link_end}"
-        ).format(
-            link_start=u"<a href='https://www.edx.org/'>",
-            link_end=u"</a>"
-        )
+    org_name = (
+        "edX Inc" if is_edx_domain
+        else microsite.get_value('PLATFORM_NAME', settings.PLATFORM_NAME)
+    )
 
-    return data
+    # Translators: 'EdX', 'edX', and 'Open edX' are trademarks of 'edX Inc.'.
+    # Please do not translate any of these trademarks and company names.
+    return _(
+        u"\u00A9 {org_name}.  All rights reserved except where noted.  "
+        u"EdX, Open edX and the edX and OpenEdX logos are registered trademarks "
+        u"or trademarks of edX Inc."
+    ).format(org_name=org_name)
 
 
-def heading(is_edx_domain):
-    """ Returns the heading text copy
+def _footer_openedx_link(is_secure, site_name):
+    """Return the image link for "powered by OpenEdX".
+
+    Args:
+        is_secure (bool): Whether the request is using TLS.
+        site_name (str): The site url to get the absolute link
+
+    Returns: dict
+
     """
-    if is_edx_domain:
-        data = _(
-            "{EdX} offers interactive online classes and MOOCs from the world's best universities. "
-            "Online courses from {MITx}, {HarvardX}, {BerkeleyX}, {UTx} and many other universities. "
-            "Topics include biology, business, chemistry, computer science, economics, finance, "
-            "electronics, engineering, food and nutrition, history, humanities, law, literature, "
-            "math, medicine, music, philosophy, physics, science, statistics and more. {EdX} is a "
-            "non-profit online initiative created by founding partners {Harvard} and {MIT}."
-        ).format(
-            EdX="EdX", Harvard="Harvard", MIT="MIT", HarvardX="HarvardX", MITx="MITx",
-            BerkeleyX="BerkeleyX", UTx="UTx"
-        )
-    else:
-        data = ""
-    return data
+    return {
+        "url": "http://open.edx.org",
+        "title": _("Powered by Open edX"),
+        "image": _absolute_url(is_secure, site_name, "images/openedx-logo-tag.png")
+    }
 
 
-def social_links():
-    """ Returns the list of social link of footer
+def _footer_social_links():
+    """Return the social media links to display in the footer.
+
+    Returns: list
+
     """
     links = []
     for social_name in settings.SOCIAL_MEDIA_FOOTER_NAMES:
         links.append(
             {
-                "provider": social_name,
+                "name": social_name,
                 "title": unicode(settings.SOCIAL_MEDIA_FOOTER_DISPLAY.get(social_name, {}).get("title", "")),
                 "url": settings.SOCIAL_MEDIA_FOOTER_URLS.get(social_name, "#"),
-                "social_icon": settings.SOCIAL_MEDIA_FOOTER_DISPLAY.get(social_name).get("icon", "")
+                "icon-class": settings.SOCIAL_MEDIA_FOOTER_DISPLAY.get(social_name, {}).get("icon", ""),
             }
         )
     return links
 
 
-def about_edx_link():
-    """ Returns the list of marketing links of footer
-    """
-
+def _footer_navigation_links():
+    """Return the navigation links to display in the footer. """
+    # TODO: make the order configurable in Django settings
+    # TODO: make the title a Django setting
     return [
         {
+            "name": "about",
             "title": _("About"),
-            "url": marketing_link('ABOUT')
+            "url": marketing_link("ABOUT")
         },
         {
+            "name": "news",
             "title": _("News"),
-            "url": marketing_link('NEWS')
+            "url": marketing_link("NEWS")
         },
         {
+            "name": "contact",
             "title": _("Contact"),
-            "url": marketing_link('CONTACT')
+            "url": marketing_link("CONTACT")
         },
         {
+            "name": "faq",
             "title": _("FAQ"),
-            "url": marketing_link('FAQ')
+            "url": marketing_link("FAQ")
         },
         {
+            "name": "blog",
             "title": _("edX Blog"),
-            "url": marketing_link('BLOG')
+            "url": marketing_link("BLOG")
         },
         {
+            "name": "donate",
             "title": _("Donate to edX"),
-            "url": marketing_link('DONATE')
+            "url": marketing_link("DONATE")
         },
         {
+            "name": "jobs",
             "title": _("Jobs at edX"),
-            "url": marketing_link('JOBS')
+            "url": marketing_link("JOBS")
+        },
+        {
+            "name": "terms_of_service",
+            "title": _("Terms of Service"),
+            "url": marketing_link("TOS")
+        },
+        {
+            "name": "privacy_policy",
+            "title": _("Privacy Policy"),
+            "url": marketing_link("PRIVACY")
         }
     ]
 
 
-def get_footer_logo(site_name, is_edx_domain):
-    """ Return the logo used for footer about link
+def _footer_mobile_links(is_secure, site_name):
+    """Return the mobile app store links.
 
     Args:
+        is_secure (bool): Whether the request is using TLS.
+        site_name (str): The site url to get the absolute link
+
+    Returns: list
+
+    """
+    mobile_links = []
+    if settings.FEATURES.get('ENABLE_FOOTER_MOBILE_APP_LINKS'):
+        mobile_links = [
+            {
+                "name": "apple",
+                "title": "Apple",
+                "url": settings.MOBILE_STORE_URLS.get('apple', '#'),
+                "image": _absolute_url(is_secure, site_name, 'images/app/app_store_badge_135x40.svg')
+            },
+            {
+                "name": "google",
+                "title": "Google",
+                "url": settings.MOBILE_STORE_URLS.get('google', '#'),
+                "image": _absolute_url(is_secure, site_name, 'images/app/google_play_badge_45.png')
+            }
+        ]
+    return mobile_links
+
+
+def _footer_logo_img(is_secure, site_name, is_edx_domain):
+    """Return the logo used for footer about link
+
+    Args:
+        is_secure (bool): Whether the request is using TLS.
         site_name(str): The site url to get the absolute link
-        is_edx_domain(bool): Flag to check is it in edx domain or open edx
+        is_edx_domain (bool): If true, this is an EdX-controlled domain.
 
     Returns:
         Absolute url to logo
     """
-    if is_edx_domain:
-        logo_file = 'images/edx-theme/edx-header-logo.png'
-    else:
-        logo_file = 'images/default-theme/logo.png'
-    try:
-        url = site_name + staticfiles_storage.url(logo_file)
-    except:
-        url = site_name + logo_file
-    return url
+    logo_name = (
+        u"images/edx-theme/edx-header-logo.png"
+        if is_edx_domain
+        else u"images/default-theme/logo.png"
+    )
+
+    return _absolute_url(is_secure, site_name, logo_name)
 
 
-def get_mobile_urls():
-    """ Returns the mobile app urls
+def _absolute_url(is_secure, site_name, name):
+    """Construct an absolute URL back to the site.
 
-    """
-    mobile_urls = []
-    if settings.FEATURES.get('ENABLE_FOOTER_MOBILE_APP_LINKS'):
-        mobile_urls = [
-            {
-                "title": "Apple",
-                "url": settings.MOBILE_STORE_URLS.get('apple', '#'),
-                "logo_image_url": 'images/app/app_store_badge_135x40.svg'
-            },
-            {
-                "title": "Google",
-                "url": settings.MOBILE_STORE_URLS.get('google', '#'),
-                "logo_image_url": 'images/app/google_play_badge_45.png'
-            }
-        ]
-    return mobile_urls
+    Arguments:
+        is_secure (bool): If true, use HTTPS as the protocol.
+        site_name (unicode): The site name of this server.
+        path (unicode): The URL path.
 
-
-def get_footer_static(file_name):
-    """ Returns the static js/css contents as a string
-
-    Args:
-        file_name(str): path to the static file name under static folder
-
-    Raises:
-        I/O Error if file not found
     Returns:
-        Contents of static file
+        unicode
 
     """
-    key = "footer/{file_name}".format(file_name=file_name)
-    contents = cache.get(key)
-    if contents:
-        return contents
-    file_dir = os.path.dirname(os.path.abspath(__file__))
-    file_path = os.path.join(file_dir, "static/{}".format(file_name))
-    with open(file_path, "r") as _file:
-        contents = _file.read()
-    cache.set(key, contents)
-    return contents
-
-
-def get_footer_html():
-    """ Return the html representation of footer
-
-    """
-    is_edx_domain = settings.FEATURES.get('IS_EDX_DOMAIN', False)
-    key = "footer/html/{domain}".format(domain="edx" if is_edx_domain else "open_edx")
-    response_string = cache.get(key)
-    if response_string:
-        return response_string
-    if is_edx_domain:
-        response_string = render_to_response("footer.html")
-    else:
-        response_string = render_to_response("footer-edx-new.html")
-    cache.set(key, response_string)
-    return response_string
+    url_path = staticfiles_storage.url(name)
+    protocol = "https://" if is_secure else "http://"
+    return u"{protocol}{site_name}{url_path}".format(
+        protocol=protocol,
+        site_name=site_name,
+        url_path=url_path
+    )

--- a/lms/djangoapps/branding/api.py
+++ b/lms/djangoapps/branding/api.py
@@ -1,0 +1,214 @@
+"""Edx branding API
+"""
+import logging
+import os
+from django.conf import settings
+from django.utils.translation import ugettext as _
+from django.shortcuts import render_to_response
+from django.core.cache import cache
+from staticfiles.storage import staticfiles_storage
+
+from microsite_configuration import microsite
+from edxmako.shortcuts import marketing_link
+
+log = logging.getLogger("edx.footer")
+
+
+def get_footer_json():
+    """ Get the footer links json
+
+    Returns:
+        Dict of footer links
+    """
+    is_edx_domain = settings.FEATURES.get('IS_EDX_DOMAIN', False)
+    key = "footer/json/{domain}".format(domain="edx" if is_edx_domain else "open_edx")
+    footer_json = cache.get(key)
+    if footer_json:
+        return footer_json
+    site_name = microsite.get_value('SITE_NAME', settings.SITE_NAME)
+
+    context = dict()
+    context["copy_right"] = copy_right(is_edx_domain)
+    context["heading"] = heading(is_edx_domain)
+    context["logo_img"] = get_footer_logo(site_name, is_edx_domain)
+    context["social_links"] = social_links()
+    context["about_links"] = about_edx_link()
+    context["mobile_urls"] = get_mobile_urls()
+    footer_json = {"footer": context}
+    cache.set(key, footer_json)
+    return footer_json
+
+
+def copy_right(is_edx_domain):
+    """ Returns the copy rights text
+    """
+    if is_edx_domain:
+        data = _(
+            "(c) 2015 edX Inc. EdX, Open edX, and the edX and Open edX logos "
+            "are registered trademarks or trademarks of edX Inc."
+        )
+    else:
+        data = _(
+            "EdX, Open edX, and the edX and Open edX logos are registered trademarks or "
+            "trademarks of {link_start}edX Inc.{link_end}"
+        ).format(
+            link_start=u"<a href='https://www.edx.org/'>",
+            link_end=u"</a>"
+        )
+
+    return data
+
+
+def heading(is_edx_domain):
+    """ Returns the heading text copy
+    """
+    if is_edx_domain:
+        data = _(
+            "{EdX} offers interactive online classes and MOOCs from the world's best universities. "
+            "Online courses from {MITx}, {HarvardX}, {BerkeleyX}, {UTx} and many other universities. "
+            "Topics include biology, business, chemistry, computer science, economics, finance, "
+            "electronics, engineering, food and nutrition, history, humanities, law, literature, "
+            "math, medicine, music, philosophy, physics, science, statistics and more. {EdX} is a "
+            "non-profit online initiative created by founding partners {Harvard} and {MIT}."
+        ).format(
+            EdX="EdX", Harvard="Harvard", MIT="MIT", HarvardX="HarvardX", MITx="MITx",
+            BerkeleyX="BerkeleyX", UTx="UTx"
+        )
+    else:
+        data = ""
+    return data
+
+
+def social_links():
+    """ Returns the list of social link of footer
+    """
+    links = []
+    for social_name in settings.SOCIAL_MEDIA_FOOTER_NAMES:
+        links.append(
+            {
+                "provider": social_name,
+                "title": unicode(settings.SOCIAL_MEDIA_FOOTER_DISPLAY.get(social_name, {}).get("title", "")),
+                "url": settings.SOCIAL_MEDIA_FOOTER_URLS.get(social_name, "#"),
+                "social_icon": settings.SOCIAL_MEDIA_FOOTER_DISPLAY.get(social_name).get("icon", "")
+            }
+        )
+    return links
+
+
+def about_edx_link():
+    """ Returns the list of marketing links of footer
+    """
+
+    return [
+        {
+            "title": _("About"),
+            "url": marketing_link('ABOUT')
+        },
+        {
+            "title": _("News"),
+            "url": marketing_link('NEWS')
+        },
+        {
+            "title": _("Contact"),
+            "url": marketing_link('CONTACT')
+        },
+        {
+            "title": _("FAQ"),
+            "url": marketing_link('FAQ')
+        },
+        {
+            "title": _("edX Blog"),
+            "url": marketing_link('BLOG')
+        },
+        {
+            "title": _("Donate to edX"),
+            "url": marketing_link('DONATE')
+        },
+        {
+            "title": _("Jobs at edX"),
+            "url": marketing_link('JOBS')
+        }
+    ]
+
+
+def get_footer_logo(site_name, is_edx_domain):
+    """ Return the logo used for footer about link
+
+    Args:
+        site_name(str): The site url to get the absolute link
+        is_edx_domain(bool): Flag to check is it in edx domain or open edx
+
+    Returns:
+        Absolute url to logo
+    """
+    if is_edx_domain:
+        logo_file = 'images/edx-theme/edx-header-logo.png'
+    else:
+        logo_file = 'images/default-theme/logo.png'
+    try:
+        url = site_name + staticfiles_storage.url(logo_file)
+    except:
+        url = site_name + logo_file
+    return url
+
+
+def get_mobile_urls():
+    """ Returns the mobile app urls
+
+    """
+    mobile_urls = []
+    if settings.FEATURES.get('ENABLE_FOOTER_MOBILE_APP_LINKS'):
+        mobile_urls = [
+            {
+                "title": "Apple",
+                "url": settings.MOBILE_STORE_URLS.get('apple', '#'),
+                "logo_image_url": 'images/app/app_store_badge_135x40.svg'
+            },
+            {
+                "title": "Google",
+                "url": settings.MOBILE_STORE_URLS.get('google', '#'),
+                "logo_image_url": 'images/app/google_play_badge_45.png'
+            }
+        ]
+    return mobile_urls
+
+
+def get_footer_static(file_name):
+    """ Returns the static js/css contents as a string
+
+    Args:
+        file_name(str): path to the static file name under static folder
+
+    Raises:
+        I/O Error if file not found
+    Returns:
+        Contents of static file
+
+    """
+    key = "footer/{file_name}".format(file_name=file_name)
+    contents = cache.get(key)
+    if contents:
+        return contents
+    file_dir = os.path.dirname(os.path.abspath(__file__))
+    file_path = os.path.join(file_dir, "static/{}".format(file_name))
+    with open(file_path, "r") as _file:
+        contents = _file.read()
+    cache.set(key, contents)
+    return contents
+
+
+def get_footer_html():
+    """ Return the html representation of footer
+
+    """
+    is_edx_domain = settings.FEATURES.get('IS_EDX_DOMAIN', False)
+    key = "footer/html/{domain}".format(domain="edx" if is_edx_domain else "open_edx")
+    response_string = cache.get(key)
+    if response_string:
+        return response_string
+    if is_edx_domain:
+        response_string = render_to_response("footer.html")
+    else:
+        response_string = render_to_response("footer-edx-new.html")
+    cache.set(key, response_string)
+    return response_string

--- a/lms/djangoapps/branding/api_urls.py
+++ b/lms/djangoapps/branding/api_urls.py
@@ -1,0 +1,12 @@
+"""
+Branding API endpoint urls.
+"""
+
+from django.conf.urls import patterns, url
+
+urlpatterns = patterns(
+    '',
+
+    url(r'^footer/$',
+        'branding.views.footer', name="get_footer_data"),
+)

--- a/lms/djangoapps/branding/api_urls.py
+++ b/lms/djangoapps/branding/api_urls.py
@@ -5,8 +5,17 @@ Branding API endpoint urls.
 from django.conf.urls import patterns, url
 
 urlpatterns = patterns(
-    '',
+    "",
 
-    url(r'^footer/$',
-        'branding.views.footer', name="get_footer_data"),
+    url(
+        r"^footer$",
+        "branding.views.footer",
+        name="branding_footer",
+    ),
+
+    url(
+        r"^footer\.(?P<extension>json|html|css|js)$",
+        "branding.views.footer",
+        name="branding_footer_ext",
+    ),
 )

--- a/lms/djangoapps/branding/migrations/0002_auto__add_brandingapiconfig.py
+++ b/lms/djangoapps/branding/migrations/0002_auto__add_brandingapiconfig.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'BrandingApiConfig'
+        db.create_table('branding_brandingapiconfig', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('change_date', self.gf('django.db.models.fields.DateTimeField')(auto_now_add=True, blank=True)),
+            ('changed_by', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['auth.User'], null=True, on_delete=models.PROTECT)),
+            ('enabled', self.gf('django.db.models.fields.BooleanField')(default=False)),
+        ))
+        db.send_create_signal('branding', ['BrandingApiConfig'])
+
+
+    def backwards(self, orm):
+        # Deleting model 'BrandingApiConfig'
+        db.delete_table('branding_brandingapiconfig')
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'branding.brandingapiconfig': {
+            'Meta': {'object_name': 'BrandingApiConfig'},
+            'change_date': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'changed_by': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']", 'null': 'True', 'on_delete': 'models.PROTECT'}),
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'branding.brandinginfoconfig': {
+            'Meta': {'object_name': 'BrandingInfoConfig'},
+            'change_date': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'changed_by': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']", 'null': 'True', 'on_delete': 'models.PROTECT'}),
+            'configuration': ('django.db.models.fields.TextField', [], {}),
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        }
+    }
+
+    complete_apps = ['branding']

--- a/lms/djangoapps/branding/models.py
+++ b/lms/djangoapps/branding/models.py
@@ -44,3 +44,14 @@ class BrandingInfoConfig(ConfigurationModel):
         """
         info = cls.current()
         return json.loads(info.configuration) if info.enabled else {}
+
+
+class BrandingApiConfig(ConfigurationModel):
+    """Configure Branding api's
+
+    Enable or disable api's functionality.
+    When this flag is disabled, the api will return 404.
+
+    When the flag is enabled, the api will returns the valid reponse.
+    """
+    pass

--- a/lms/djangoapps/branding/static/footer.css
+++ b/lms/djangoapps/branding/static/footer.css
@@ -1,0 +1,3 @@
+.dummy {
+    display: none;
+}

--- a/lms/djangoapps/branding/static/footer.js
+++ b/lms/djangoapps/branding/static/footer.js
@@ -1,0 +1,3 @@
+function f(){
+    var a = "This is a dummy function"
+}

--- a/lms/djangoapps/branding/tests/test_views.py
+++ b/lms/djangoapps/branding/tests/test_views.py
@@ -1,28 +1,115 @@
 # encoding: utf-8
-"""
-Tests of branding api views.
-"""
+"""Tests of Branding API views. """
 
+import contextlib
+import json
 from django.test import TestCase
 from django.core.urlresolvers import reverse
-import json
+from django.conf import settings
+
+import mock
+import ddt
+from config_models.models import cache
 from branding.models import BrandingApiConfig
 
 
+@ddt.ddt
 class TestFooter(TestCase):
-    """ Test for getting the footer data as json
-    """
+    """Test API end-point for retrieving the footer. """
 
-    def test_footer(self):
-        """ Test the footer json
-        """
-        config = BrandingApiConfig(enabled=True)
+    def setUp(self):
+        """Clear the configuration cache. """
+        super(TestFooter, self).setUp()
+        cache.clear()
+
+    @ddt.data("", "css", "js", "html")
+    def test_feature_flag(self, extension):
+        self._set_feature_flag(False)
+        resp = self._get_footer(extension=extension)
+        self.assertEqual(resp.status_code, 404)
+
+    @ddt.data(
+        # Open source version
+        (False, "", "application/json; charset=utf-8"),
+        (False, "css", "text/css"),
+        (False, "js", "text/javascript"),
+        (False, "html", "text/html; charset=utf-8"),
+
+        # EdX.org version
+        (True, "", "application/json; charset=utf-8"),
+        (True, "css", "text/css"),
+        (True, "js", "text/javascript"),
+        (True, "html", "text/html; charset=utf-8"),
+    )
+    @ddt.unpack
+    def test_footer_content_types(self, is_edx_domain, extension, content_type):
+        self._set_feature_flag(True)
+        with self._set_is_edx_domain(is_edx_domain):
+            resp = self._get_footer(extension=extension)
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp["Content-Type"], content_type)
+
+    @mock.patch.dict(settings.FEATURES, {'ENABLE_FOOTER_MOBILE_APP_LINKS': True})
+    @ddt.data(True, False)
+    def test_footer_json(self, is_edx_domain):
+        self._set_feature_flag(True)
+        with self._set_is_edx_domain(is_edx_domain):
+            resp = self._get_footer()
+
+        self.assertEqual(resp.status_code, 200)
+        json_data = json.loads(resp.content)
+        self.assertTrue(isinstance(json_data, dict))
+
+        # Logo
+        self.assertIn("logo_image", json_data)
+
+        # Links
+        self.assertIn("navigation_links", json_data)
+        for link in json_data["navigation_links"]:
+            self.assertIn("name", link)
+            self.assertIn("title", link)
+            self.assertIn("url", link)
+
+        # Social links
+        self.assertIn("social_links", json_data)
+        for link in json_data["social_links"]:
+            self.assertIn("name", link)
+            self.assertIn("title", link)
+            self.assertIn("url", link)
+            self.assertIn("icon-class", link)
+
+        # Mobile links
+        self.assertIn("mobile_links", json_data)
+        for link in json_data["mobile_links"]:
+            self.assertIn("name", link)
+            self.assertIn("title", link)
+            self.assertIn("url", link)
+            self.assertIn("image", link)
+
+        # OpenEdX
+        self.assertIn("openedx_link", json_data)
+        self.assertIn("url", json_data["openedx_link"])
+        self.assertIn("title", json_data["openedx_link"])
+        self.assertIn("image", json_data["openedx_link"])
+
+        # Copyright
+        self.assertIn("copyright", json_data)
+
+    def _set_feature_flag(self, enabled):
+        """Enable or disable the feature flag for the branding API end-points. """
+        config = BrandingApiConfig(enabled=enabled)
         config.save()
-        url = reverse("get_footer_data")
-        footer_data = self.client.get(url, HTTP_ACCEPT="application/json")
-        json_data = json.loads(footer_data.content)
 
-        self.assertIn("footer", json_data)
-        self.assertIn("about_links", json_data["footer"])
-        self.assertIn("social_links", json_data["footer"])
-        self.assertIn("heading", json_data["footer"])
+    def _get_footer(self, extension=""):
+        """Retrieve the footer. """
+        url = reverse("branding_footer")
+        if extension:
+            url = u"{url}.{ext}".format(url=url, ext=extension)
+        return self.client.get(url)
+
+    @contextlib.contextmanager
+    def _set_is_edx_domain(self, is_edx_domain):
+        """Configure whether this an EdX-controlled domain. """
+        with mock.patch.dict(settings.FEATURES, {'IS_EDX_DOMAIN': is_edx_domain}):
+            yield

--- a/lms/djangoapps/branding/tests/test_views.py
+++ b/lms/djangoapps/branding/tests/test_views.py
@@ -1,0 +1,28 @@
+# encoding: utf-8
+"""
+Tests of branding api views.
+"""
+
+from django.test import TestCase
+from django.core.urlresolvers import reverse
+import json
+from branding.models import BrandingApiConfig
+
+
+class TestFooter(TestCase):
+    """ Test for getting the footer data as json
+    """
+
+    def test_footer(self):
+        """ Test the footer json
+        """
+        config = BrandingApiConfig(enabled=True)
+        config.save()
+        url = reverse("get_footer_data")
+        footer_data = self.client.get(url, HTTP_ACCEPT="application/json")
+        json_data = json.loads(footer_data.content)
+
+        self.assertIn("footer", json_data)
+        self.assertIn("about_links", json_data["footer"])
+        self.assertIn("social_links", json_data["footer"])
+        self.assertIn("heading", json_data["footer"])

--- a/lms/djangoapps/branding/views.py
+++ b/lms/djangoapps/branding/views.py
@@ -1,20 +1,28 @@
+"""Views for the branding app. """
+import logging
+
 from django.conf import settings
 from django.core.urlresolvers import reverse
-from branding.models import BrandingApiConfig
-from django.http import Http404
+from django.http import HttpResponse, Http404
+from staticfiles.storage import staticfiles_storage
+from staticfiles.finders import find as staticfiles_find
 from django.shortcuts import redirect
 from django_future.csrf import ensure_csrf_cookie
+from sendfile import sendfile
 
+from edxmako.shortcuts import render_to_response
 import student.views
 from student.models import CourseEnrollment
-
 import courseware.views
-
 from microsite_configuration import microsite
 from edxmako.shortcuts import marketing_link
 from util.cache import cache_if_anonymous
-from .api import get_footer_json, get_footer_static, get_footer_html
-from util.json_request import JsonResponse, HttpResponse
+from util.json_request import JsonResponse
+from branding.models import BrandingApiConfig
+import branding.api as branding_api
+
+
+log = logging.getLogger(__name__)
 
 
 def get_course_enrollments(user):
@@ -107,26 +115,165 @@ def courses(request):
     return courseware.views.courses(request)
 
 
-def footer(request):
-    # if configuration is not enabled then return 404
+def _render_footer_html():
+    """Render the footer as HTML. """
+    # TODO: pass information from branding_api.get_footer()
+    # as context to ensure that these are rendered consistently.
+    # TODO: use v3 of the footer for edx.org (waiting on Alasdair's changes).
+    return (
+        render_to_response("footer-edx-new.html")
+        if settings.FEATURES.get("IS_EDX_DOMAIN", False)
+        else render_to_response("footer.html")
+    )
+
+
+def _send_footer_static(request, name):
+    """Send static files for the footer.
+
+    Send static files required for rendering the footer
+    client-side (JavaScript and CSS).
+
+    Ordinarily, clients would load static resources like
+    this from /static/ URLs.  In production, these URLs always
+    include cache-busting hashes.  Since these URLs are meant
+    to be included directly in the DOM, we want a URL
+    that is always available (e.g. /api/v1/branding/footer.css).
+
+    On the other hand, we *don't* want to serve these
+    files directy through Django, because nginx is much
+    faster at this.
+
+    For this reason, we use `django-sendfile` as a compromise.
+    In production, this will use the "X-Accel-Redirect" header
+    to trigger an internal redirect to the static file.
+    That way, Django can resolve the path, but nginx still
+    serves the file.
+
+    If the file can't be found, this will return a 404.
+
+    Arguments:
+        request (HttpRequest)
+        name (unicode): The name of the static file to load
+            (relative to `settings.STATIC_ROOT`)
+
+    Returns:
+        HttpResponse
+    """
+    # In production, we process static files and save them
+    # in the STATIC_ROOT directory.  Our proxy server serves static
+    # files directly from this location.
+    # In development, however, we don't run collectstatic, so
+    # we need to find the files in this repository.
+    path = (
+        staticfiles_find(name) if settings.DEBUG
+        else staticfiles_storage.path(name)
+    )
+
+    if path is None:
+        raise Http404
+
+    return sendfile(request, path)
+
+
+# TODO: make these settings
+# TODO: update the paths when Alasdair's changes are merged
+# and delete the dummy JS / CSS.
+FOOTER_JS_STATIC_NAME = "footer.js"  # "js/footer_edx.js"
+FOOTER_CSS_STATIC_NAME = "footer.css"  # "css/lms-style-edx-footer.css"
+
+
+def footer(request, extension="json"):
+    """Retrieve the branded footer.
+
+    This end-point provides information about the site footer,
+    allowing for consistent display of the footer across other sites
+    (for example, on the marketing site and blog).
+
+    It can be used in one of two ways:
+    1) The client renders the footer from a JSON description.
+    2) The client includes JavaScript and CSS from this end-point,
+        and the JavaScript renders the footer within the DOM.
+
+    In case (2), we assume that the following dependencies
+    are included on the page:
+    a) JQuery (same version as used in edx-platform)
+    b) font-awesome (same version as used in edx-platform)
+
+    Example: Retrieving the footer as JSON
+
+        GET /api/branding/v1/footer
+
+        {
+            "navigation_links": [
+                {
+                  "url": "http://example.com/about",
+                  "name": "about",
+                  "title": "About"
+                },
+                # ...
+            ],
+            "social_links": [
+                {
+                    "url": "http://example.com/social",
+                    "name": "facebook",
+                    "icon-class": "fa-facebook-square",
+                    "title": "Facebook"
+                },
+                # ...
+            ],
+            "mobile_links": [
+                {
+                    "url": "http://example.com/android",
+                    "name": "google",
+                    "image": "http://example.com/google.png",
+                    "title": "Google"
+                },
+                # ...
+            ],
+            "openedx_link": {
+                "url": "http://open.edx.org",
+                "title": "Powered by Open edX",
+                "image": "http://example.com/openedx.png"
+            },
+            "logo_image": "http://example.com/static/images/default-theme/logo.png",
+            "copyright": "EdX, Open edX, and the edX and Open edX logos are \
+                registered trademarks or trademarks of edX Inc."
+        }
+
+
+    Example: Including the footer within a page
+
+        <html>
+            <head>
+                <!-- Include JQuery and FontAwesome here -->
+                <title>Footer API Test</title>
+            </head>
+            <body>
+                <h1>Footer API Test</h1>
+                <p>This is a test of the footer API.</p>
+                <footer id="edx-branding-footer"></footer>
+
+                <!-- Load this at the bottom of the page so it doesn't block the DOM from loading -->
+                <script type="text/css" src="http://example.com/api/v1/branding/footer.css"></script>
+                <script type="text/javascript" src="http://example.com/api/v1/branding/footer.js"></script>
+            </body>
+        </html>
+
+    """
+    # If configuration is not enabled then return 404
     if not BrandingApiConfig.current().enabled:
         raise Http404
-    if "application/json" in request.META.get('HTTP_ACCEPT') or "*/*" in request.META.get('HTTP_ACCEPT'):
-        return JsonResponse(get_footer_json(), 200)
-    elif "text/html" in request.META.get('HTTP_ACCEPT'):
-        html = get_footer_html()
-        return HttpResponse(html, status=200)
-    elif "text/javascript" in request.META.get('HTTP_ACCEPT'):
-        try:
-            content = get_footer_static("footer.js")
-        except IOError:
-            return HttpResponse(content="No js file found", status=404)
-        return HttpResponse(content, content_type='text/javascript', status=200)
-    elif "text/css" in request.META.get('HTTP_ACCEPT'):
-        try:
-            content = get_footer_static("footer.css")
-        except IOError:
-            return HttpResponse(content="No css file found", status=404)
-        return HttpResponse(content, content_type='text/css', status=200)
+
+    # Render the footer information based on the extension
+    if extension == "json":
+        footer_dict = branding_api.get_footer(is_secure=request.is_secure())
+        return JsonResponse(footer_dict, 200, content_type="application/json; charset=utf-8")
+    elif extension == "html":
+        content = _render_footer_html()
+        return HttpResponse(content, status=200)
+    elif extension == "css":
+        return _send_footer_static(request, FOOTER_CSS_STATIC_NAME)
+    elif extension == "js":
+        return _send_footer_static(request, FOOTER_JS_STATIC_NAME)
     else:
-        return HttpResponse(status=406)
+        raise Http404

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -130,6 +130,14 @@ if STATIC_URL_BASE:
     if not STATIC_URL.endswith("/"):
         STATIC_URL += "/"
 
+# Configure sendfile to use nginx.
+# This uses the X-Accel-Redirect header so nginx
+# will serve the requested file.
+# See https://github.com/johnsensible/django-sendfile for details.
+SENDFILE_ROOT = STATIC_ROOT
+SENDFILE_URL = STATIC_URL
+SENDFILE_BACKEND = "sendfile.backends.nginx"
+
 # MEDIA_ROOT specifies the directory where user-uploaded files are stored.
 MEDIA_ROOT = ENV_TOKENS.get('MEDIA_ROOT', MEDIA_ROOT)
 MEDIA_URL = ENV_TOKENS.get('MEDIA_URL', MEDIA_URL)

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1465,6 +1465,15 @@ PIPELINE_UGLIFYJS_BINARY = 'node_modules/.bin/uglifyjs'
 # Setting that will only affect the edX version of django-pipeline until our changes are merged upstream
 PIPELINE_COMPILE_INPLACE = True
 
+# By default, use the "simple" backend for sendfiles
+# This will simply serve files from disk.
+# In production, we should use the "nginx" backend
+# so nginx will serve the files for us.
+# See https://github.com/johnsensible/django-sendfile
+SENDFILE_ROOT = STATIC_ROOT
+SENDFILE_URL = STATIC_URL
+SENDFILE_BACKEND = "sendfile.backends.simple"
+
 ################################# CELERY ######################################
 
 # Message configuration

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -77,6 +77,12 @@ def should_show_debug_toolbar(_):
 
 PIPELINE_SASS_ARGUMENTS = '--debug-info --require {proj_dir}/static/sass/bourbon/lib/bourbon.rb'.format(proj_dir=PROJECT_ROOT)
 
+# For local development, use the development backend for sendfiles.
+# In production, we'll use nginx to serve the files for us,
+# but devstack doesn't run nginx.
+# See https://github.com/johnsensible/django-sendfile
+SENDFILE_BACKEND = "sendfile.backends.development"
+
 ########################### VERIFIED CERTIFICATES #################################
 
 FEATURES['AUTOMATIC_VERIFY_STUDENT_IDENTITY_FOR_TESTING'] = True

--- a/lms/static/js/branding/footer.js
+++ b/lms/static/js/branding/footer.js
@@ -1,0 +1,3 @@
+function f(){
+    var a = "This is a dummy function"
+}

--- a/lms/static/js/branding/footer.js
+++ b/lms/static/js/branding/footer.js
@@ -1,3 +1,0 @@
-function f(){
-    var a = "This is a dummy function"
-}

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -427,6 +427,8 @@ if settings.COURSEWARE_ENABLED:
         # Student Notes
         url(r'^courses/{}/edxnotes'.format(settings.COURSE_ID_PATTERN),
             include('edxnotes.urls'), name="edxnotes_endpoints"),
+
+        url(r'^api/v1/branding/', include('branding.api_urls')),
     )
 
     # allow course staff to change to student view of courseware

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -29,6 +29,7 @@ django-mptt==0.5.5
 django-openid-auth==0.4
 django-robots==0.9.1
 django-sekizai==0.6.1
+django-sendfile==0.3.7
 django-ses==0.4.1
 django-storages==1.1.5
 django-threaded-multihost==1.4-1


### PR DESCRIPTION
This is a WIP PR based on #7998.
It will not be completed until #7986 is merged and integrated into this work.  I've marked the remaining work in the code with "TODO" comments.

I'm opening this early because there are a number of folks who might be interested in these changes:
- DevOps: This PR introduces django-sendfile as a dependency.  This will allow us to serve static files (JS and CSS) from a consistent URL while still using nginx to serve the file in production.  I still need to test that this is configured correctly in a sandbox.  FYI: @feanil 
- Docs: This PR introduces a new API end-point (/api/v1/branding/footer).  I've included examples in the docstring, but I want to make sure this is consistent with our other API documentation.  FYI: @srpearce 
- Theming / Microsites: The purpose of this end-point is to be able to display a consistent footer across edx.org, courses.edx.org, and blog.edx.org (eventually).  The end-point uses `IS_EDX_DOMAIN` to serve different versions of the footer for OpenEdX and EdX.org, but it doesn't fully support theming or microsites.  Since the end-point is disabled by default, I think this is a reasonable trade-off to control the scope of the PR.  FYI: @chrisndodge @sarina 

@awais786 @aamir-khan This will replace #7998.  Once #7986 is merged, I'll integrate those changes into this PR.  This will include using the `get_footer()` dict within the footer templates to ensure that they are consistent with the API.

JIRA: [ECOM-1339](https://openedx.atlassian.net/browse/ECOM-1339)
