### PR TITLE
Add course_id as label for Google Analytics events

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -782,6 +782,9 @@ EVENT_TRACKING_BACKENDS = {
                     'OPTIONS': {
                         'whitelist': []
                     }
+                },
+                {
+                    'ENGINE': 'track.shim.GoogleAnalyticsProcessor'
                 }
             ]
         }

--- a/common/djangoapps/track/shim.py
+++ b/common/djangoapps/track/shim.py
@@ -166,3 +166,18 @@ class VideoEventProcessor(object):
                 event['page'] = page
 
         event['event'] = json.dumps(payload)
+
+
+class GoogleAnalyticsProcessor(object):
+    """Adds course_id as label, and sets nonInteraction property"""
+
+    # documentation of fields here: https://segment.com/docs/integrations/google-analytics/
+    # this should *only* be used on events destined for segment.com and eventually google analytics
+    def __call__(self, event):
+        context = event.get('context', {})
+        course_id = context.get('course_id')
+
+        if course_id is not None:
+            event['label'] = course_id
+
+        event['nonInteraction'] = 1

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -623,6 +623,9 @@ EVENT_TRACKING_BACKENDS = {
                     'OPTIONS': {
                         'whitelist': []
                     }
+                },
+                {
+                    'ENGINE': 'track.shim.GoogleAnalyticsProcessor'
                 }
             ]
         }


### PR DESCRIPTION
@mulby I verified that this works with my Student Note events to pass the course_id as label.

I added unit tests and put the same configuration in both CMS and LMS envs files (though I don't think we do any eventing in Studio at this point). Please review.
