### PR TITLE
Make Discussions tab hideable.

### DIFF
--- a/common/lib/xmodule/xmodule/tabs.py
+++ b/common/lib/xmodule/xmodule/tabs.py
@@ -360,7 +360,7 @@ class WikiTab(HideableTab):
         return super(WikiTab, cls).validate(tab_dict, raise_error) and need_name(tab_dict, raise_error)
 
 
-class DiscussionTab(EnrolledOrStaffTab):
+class DiscussionTab(HideableTab, EnrolledOrStaffTab):
     """
     A tab only for the new Berkeley discussion forums.
     """
@@ -373,6 +373,7 @@ class DiscussionTab(EnrolledOrStaffTab):
             name=tab_dict['name'] if tab_dict else _('Discussion'),
             tab_id=self.type,
             link_func=link_reverse_func('django_comment_client.forum.views.forum_form_discussion'),
+            tab_dict=tab_dict,
         )
 
     def can_display(self, course, settings, is_user_authenticated, is_user_staff, is_user_enrolled):

--- a/common/lib/xmodule/xmodule/tests/test_tabs.py
+++ b/common/lib/xmodule/xmodule/tests/test_tabs.py
@@ -694,6 +694,7 @@ class DiscussionLinkTestCase(TabTestCase):
         discussion_link_in_course="",
         is_staff=True,
         is_enrolled=True,
+        is_hideable=False,
     ):
         """Helper function to verify whether the discussion tab exists and can be displayed"""
         self.course.tabs = tab_list
@@ -707,6 +708,14 @@ class DiscussionLinkTestCase(TabTestCase):
             ),
             expected_can_display_value
         )
+
+        if is_hideable:
+            # Test that the discussion tab can be hidden
+            self.assertEquals(discussion.is_hideable, True)
+            self.assertEquals(discussion['is_hidden'], False)
+            discussion.is_hidden = True
+            self.assertEquals(discussion['is_hidden'], True)
+            discussion.is_hidden = False
 
     def test_explicit_discussion_link(self):
         """Test that setting discussion_link overrides everything else"""
@@ -735,6 +744,7 @@ class DiscussionLinkTestCase(TabTestCase):
             tab_list=self.tabs_with_discussion,
             expected_discussion_link="default_discussion_link",
             expected_can_display_value=True,
+            is_hideable=True,
         )
 
     def test_tabs_without_discussion(self):

--- a/common/lib/xmodule/xmodule/tests/test_tabs.py
+++ b/common/lib/xmodule/xmodule/tests/test_tabs.py
@@ -694,7 +694,6 @@ class DiscussionLinkTestCase(TabTestCase):
         discussion_link_in_course="",
         is_staff=True,
         is_enrolled=True,
-        is_hideable=False,
     ):
         """Helper function to verify whether the discussion tab exists and can be displayed"""
         self.course.tabs = tab_list
@@ -708,14 +707,6 @@ class DiscussionLinkTestCase(TabTestCase):
             ),
             expected_can_display_value
         )
-
-        if is_hideable:
-            # Test that the discussion tab can be hidden
-            self.assertEquals(discussion.is_hideable, True)
-            self.assertEquals(discussion['is_hidden'], False)
-            discussion.is_hidden = True
-            self.assertEquals(discussion['is_hidden'], True)
-            discussion.is_hidden = False
 
     def test_explicit_discussion_link(self):
         """Test that setting discussion_link overrides everything else"""
@@ -744,7 +735,6 @@ class DiscussionLinkTestCase(TabTestCase):
             tab_list=self.tabs_with_discussion,
             expected_discussion_link="default_discussion_link",
             expected_can_display_value=True,
-            is_hideable=True,
         )
 
     def test_tabs_without_discussion(self):
@@ -777,3 +767,15 @@ class DiscussionLinkTestCase(TabTestCase):
             is_enrolled=is_enrolled,
             is_staff=is_staff
         )
+
+    def test_discussion_visibility(self):
+        """Test that the discussion tab can be hidden."""
+        self.settings.FEATURES['ENABLE_DISCUSSION_SERVICE'] = True
+        self.course.tabs = self.tabs_with_discussion
+        self.course.discussion_link = ''
+        discussion = tabs.CourseTabList.get_discussion(self.course)
+        self.assertTrue(discussion.is_hideable)
+        self.assertFalse(discussion['is_hidden'])
+        discussion.is_hidden = True
+        self.assertTrue(discussion['is_hidden'])
+        discussion.is_hidden = False


### PR DESCRIPTION
Similar to the way the [Wiki tab can be hidden in the "Pages" section of a course in Studio](http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/building_course/pages.html#hide-or-show-the-course-wiki-page), allow to hide the Discussion tab.  Hiding the tab will only make the link disappear from the tab bar, while manually navigating to the URL of the discussion forum will still work.

You can test this change on the [sandbox](http://sandbox2.opencraft.com:18010/): Navigate to Content > Pages on any course in Studio and click the eye icon on the Discussion tab, then go to the live version of the course and verify it has disappeared.  Note that you need to wait until the change was saved after clicking the icon.

JIRA ticket: [OSPR-599](https://openedx.atlassian.net/browse/OSPR-599)

Partner information: not an edX partner - 3rd party-hosted open edX instance
