### PR TITLE
No point creating an email that won't be sent

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -212,3 +212,4 @@ Jolyon Bloomfield <jolyon@mit.edu>
 Kyle McCormick <kylemccor@gmail.com>
 Jim Cai <jimcai@stanford.edu>
 Richard Moch <richard.moch@gmail.com>
+Randy Ostler <rando305@gmail.com>

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1537,17 +1537,6 @@ def create_account_with_params(request, params):
 
     create_comments_service_user(user)
 
-    context = {
-        'name': profile.name,
-        'key': registration.activation_key,
-    }
-
-    # composes activation email
-    subject = render_to_string('emails/activation_email_subject.txt', context)
-    # Email subject *must not* contain newlines
-    subject = ''.join(subject.splitlines())
-    message = render_to_string('emails/activation_email.txt', context)
-
     # Don't send email if we are:
     #
     # 1. Doing load testing.
@@ -1565,6 +1554,17 @@ def create_account_with_params(request, params):
         not (do_external_auth and settings.FEATURES.get('BYPASS_ACTIVATION_EMAIL_FOR_EXTAUTH'))
     )
     if send_email:
+        context = {
+            'name': profile.name,
+            'key': registration.activation_key,
+        }
+
+        # composes activation email
+        subject = render_to_string('emails/activation_email_subject.txt', context)
+        # Email subject *must not* contain newlines
+        subject = ''.join(subject.splitlines())
+        message = render_to_string('emails/activation_email.txt', context)
+
         from_address = microsite.get_value(
             'email_from_address',
             settings.DEFAULT_FROM_EMAIL


### PR DESCRIPTION
The option to skip sending the activation email should be considered prior to going to the effort to create the email message.  (IMO)

Not a major issue - but it tighten's up the code a bit.
