### PR TITLE
BUG - remove username label from dashboard sidebar #UX-2153

### DIFF
--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -155,7 +155,7 @@
 
   <section class="profile-sidebar" id="profile-sidebar" role="region" aria-label="User info">
     <header class="profile">
-      <h2 class="username-header"><span class="sr">${_("Username")}: </span><span class="username-label">${ user.username }</span></h2>
+      <h2 class="username-header"><span class="sr">${_("Username")}: </span></h2>
     </header>
     <section class="user-info">
       <ul>


### PR DESCRIPTION
**Description** Updated dashboard to remove rebase bug which displayed an unstyled username label to learners

---

**JIRA Story** ([UX-2153](https://openedx.atlassian.net/browse/UX-2153))
**Confluence / Product Asset** N/A
**Sandbox URL** N/A
**Dependencies** N/A

---

**PR Author(s) Notes / To-Do** A list of known open tasks that the PR author has.
- [x] assign reviewers

---

**Screenshot: Current**
![image](https://cloud.githubusercontent.com/assets/2023680/7686752/2efc216e-fd66-11e4-9436-4e9d97966d94.png)

**Screenshot: Change**
![image](https://cloud.githubusercontent.com/assets/2023680/7686756/384b0bae-fd66-11e4-813f-cbe67a42dbbf.png)

---

**Reviewers**
Code: @clrux  
