### PR TITLE
Allow enrollment API to deactivate enrollments

### DIFF
--- a/common/djangoapps/enrollment/api.py
+++ b/common/djangoapps/enrollment/api.py
@@ -225,7 +225,8 @@ def update_enrollment(user_id, course_id, mode=None, is_active=None):
         }
 
     """
-    _validate_course_mode(course_id, mode)
+    if mode is not None:
+        _validate_course_mode(course_id, mode)
     enrollment = _data_api().update_course_enrollment(user_id, course_id, mode=mode, is_active=is_active)
     if enrollment is None:
         msg = u"Course Enrollment not found for user {user} in course {course}".format(user=user_id, course=course_id)


### PR DESCRIPTION
Will allow Otto to revoke fulfillment of course seat products. Only server-to-server calls are currently allowed to deactivate or otherwise modify existing enrollments. The act of "unenrollment" doesn't delete an enrollment; it instead marks said unenrollment as inactive. This being the case, I've refrained from separating this new logic into an `EnrollmentListView.delete()` method.

@clintonb and @jimabramson, could you please review this when you're able? @Nickersoft, FYI.
