### PR TITLE
Fixing Bug - Unicode character in tab number shouldn't return 500

### DIFF
--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -262,8 +262,10 @@ class ViewsTestCase(ModuleStoreTestCase):
         response = self.client.get(request_url)
         self.assertEqual(response.status_code, 404)
 
-    @unittest.skip
     def test_unicode_handling_in_url(self):
+        """
+        Check that view returns 404 if unicode character appears in the url.
+        """
         url_parts = [
             '/courses',
             self.course.id.to_deprecated_string(),

--- a/lms/djangoapps/courseware/views.py
+++ b/lms/djangoapps/courseware/views.py
@@ -360,7 +360,7 @@ def _index_bulk_op(request, course_key, chapter, section, position):
         try:
             int(position)
         except ValueError:
-            raise Http404("Position {} is not an integer!".format(position))
+            raise Http404(u"Position {} is not an integer!".format(position))
 
     user = request.user
     course = get_course_with_access(user, 'load', course_key, depth=2)


### PR DESCRIPTION
TNL-2055 - Unicode character in tab number shouldn't return 500
