### PR TITLE
Fixed flakiness of annotation acceptance test.

### DIFF
--- a/common/test/acceptance/pages/lms/annotation_component.py
+++ b/common/test/acceptance/pages/lms/annotation_component.py
@@ -70,7 +70,8 @@ class AnnotationComponentPage(PageObject):
         # Selenium will first move the element into view then click on it.
         self.q(css=answer_css).click()
         # Wait for the click to take effect, which is after the class is applied.
-        self.wait_for(lambda: 'selected' in self.q(css=answer_css).attrs('class')[0], description='answer selected')
+        selected_answer_css = self.active_problem_selector('.selected[data-id="{}"]'.format(self.active_problem))
+        self.wait_for_element_presence(selected_answer_css, 'selected answer present')
         # Click the "Check" button.
         self.q(css=self.active_problem_selector('.check')).click()
         # This will trigger a POST to problem_check so wait until the response is returned.

--- a/common/test/acceptance/tests/test_annotatable.py
+++ b/common/test/acceptance/tests/test_annotatable.py
@@ -2,17 +2,14 @@
 """
 E2E tests for the LMS.
 """
-import time
-
-from unittest import skip
+from flaky import flaky
+from textwrap import dedent
 
 from .helpers import UniqueCourseTest
 from ..pages.studio.auto_auth import AutoAuthPage
 from ..pages.lms.courseware import CoursewarePage
 from ..pages.lms.annotation_component import AnnotationComponentPage
 from ..fixtures.course import CourseFixture, XBlockFixtureDesc
-from ..fixtures.xqueue import XQueueResponseFixture
-from textwrap import dedent
 
 
 def _correctness(choice, target):
@@ -122,6 +119,7 @@ class AnnotatableProblemTest(UniqueCourseTest):
         )
         return annotation_component_page
 
+    @flaky(max_runs=20, min_passes=20)
     def test_annotation_component(self):
         """
         Test annotation components links to annotation problems.

--- a/common/test/acceptance/tests/test_annotatable.py
+++ b/common/test/acceptance/tests/test_annotatable.py
@@ -122,7 +122,6 @@ class AnnotatableProblemTest(UniqueCourseTest):
         )
         return annotation_component_page
 
-    @skip  # TODO fix TNL-1590
     def test_annotation_component(self):
         """
         Test annotation components links to annotation problems.


### PR DESCRIPTION
[TNL-1590](https://openedx.atlassian.net/browse/TNL-1590)

According to my thinking, here we are passing the value of class attribute of answer element like this `self.q(css=answer_css).attrs('class')[0]` not the query object to `wait_for()` and may be at that time the `selected` class was not added into class attribute, and note that this is not an query object its a value that's why it will not be updated and `wait_for()` will timeout here.
