### PR TITLE
BUG - Fixes styling issue for course status label on outline page

### DIFF
--- a/cms/static/sass/views/_outline.scss
+++ b/cms/static/sass/views/_outline.scss
@@ -176,7 +176,6 @@
   // course status
   // --------------------
   .course-status {
-    float: $bi-app-left;
     margin-bottom: $baseline;
 
     .status-release {


### PR DESCRIPTION
**Description**
A float rule made its way into the creative commons licensing PR that breaks the outline page styling for course start date setting. This reverts that small change that isn't yet on production! :D 

More specifically, at one point the licensing PR has the course licensing information floated to the right on the outline. When we removed this feature, we didn't catch that the float: left rule remained on the course start date, and we stopped testing / reviewing the outline. Nobody then noticed that this label was hidden / missing. 

---

**JIRA Story** N/A
**Confluence / Product Asset** N/A
**Sandbox URL** None - Verify through browser
**Dependencies** N/A

---

**PR Author(s) Notes / To-Do** A list of known open tasks that the PR author has.
- [x] assign reviewers

---

**Screenshot** - Current
https://s3.amazonaws.com/uploads.hipchat.com/26537/183095/rsAk08uRN1BucMu/upload.png

**Screenshot** - PR
![image](https://cloud.githubusercontent.com/assets/2023680/7730187/c63a3fee-fee6-11e4-9e31-7de3014a5dce.png)

---

**Reviewers**
@cahrens 
