### PR TITLE
transcript name param in url

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_transcripts_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_transcripts_utils.py
@@ -270,6 +270,107 @@ class TestDownloadYoutubeSubs(ModuleStoreTestCase):
 
         self.clear_sub_content(good_youtube_sub)
 
+    @patch('xmodule.video_module.transcripts_utils.requests.get')
+    def test_get_transcript_name_youtube_server_success(self, mock_get):
+        """
+        Get transcript name from transcript_list fetch from youtube server api
+        depends on language code, default language in YOUTUBE Text Api is "en"
+        """
+        youtube_text_api = copy.deepcopy(settings.YOUTUBE['TEXT_API'])
+        youtube_text_api['params']['v'] = 'dummy_video_id'
+        response_success = """
+        <transcript_list>
+            <track id="1" name="Custom" lang_code="en" />
+            <track id="0" name="Custom1" lang_code="en-GB"/>
+        </transcript_list>
+        """
+        mock_get.return_value = Mock(status_code=200, text=response_success, content=response_success)
+
+        transcript_name = transcripts_utils.youtube_video_transcript_name(youtube_text_api)
+        self.assertEqual(transcript_name, 'Custom')
+
+    @patch('xmodule.video_module.transcripts_utils.requests.get')
+    def test_get_transcript_name_youtube_server_no_transcripts(self, mock_get):
+        """
+        When there are no transcripts of video transcript name will be None
+        """
+        youtube_text_api = copy.deepcopy(settings.YOUTUBE['TEXT_API'])
+        youtube_text_api['params']['v'] = 'dummy_video_id'
+        response_success = "<transcript_list></transcript_list>"
+        mock_get.return_value = Mock(status_code=200, text=response_success, content=response_success)
+
+        transcript_name = transcripts_utils.youtube_video_transcript_name(youtube_text_api)
+        self.assertIsNone(transcript_name)
+
+    @patch('xmodule.video_module.transcripts_utils.requests.get')
+    def test_get_transcript_name_youtube_server_language_not_exist(self, mock_get):
+        """
+        When the language does not exist in transcript_list transcript name will be None
+        """
+        youtube_text_api = copy.deepcopy(settings.YOUTUBE['TEXT_API'])
+        youtube_text_api['params']['v'] = 'dummy_video_id'
+        youtube_text_api['params']['lang'] = 'abc'
+        response_success = """
+        <transcript_list>
+            <track id="1" name="Custom" lang_code="en" />
+            <track id="0" name="Custom1" lang_code="en-GB"/>
+        </transcript_list>
+        """
+        mock_get.return_value = Mock(status_code=200, text=response_success, content=response_success)
+
+        transcript_name = transcripts_utils.youtube_video_transcript_name(youtube_text_api)
+        self.assertIsNone(transcript_name)
+
+    def mocked_requests_get(*args, **kwargs):
+        """
+        This method will be used by the mock to replace requests.get
+        """
+        # pylint: disable=no-method-argument
+        response_transcript_list = """
+        <transcript_list>
+            <track id="1" name="Custom" lang_code="en" />
+            <track id="0" name="Custom1" lang_code="en-GB"/>
+        </transcript_list>
+        """
+        response_transcript = textwrap.dedent("""
+        <transcript>
+            <text start="0" dur="0.27"></text>
+            <text start="0.27" dur="2.45">Test text 1.</text>
+            <text start="2.72">Test text 2.</text>
+            <text start="5.43" dur="1.73">Test text 3.</text>
+        </transcript>
+        """)
+
+        if kwargs == {'params': {'lang': 'en', 'v': 'good_id_2'}}:
+            return Mock(status_code=200, text='')
+        elif kwargs == {'params': {'type': 'list', 'v': 'good_id_2'}}:
+            return Mock(status_code=200, text=response_transcript_list, content=response_transcript_list)
+        elif kwargs == {'params': {'lang': 'en', 'v': 'good_id_2', 'name': 'Custom'}}:
+            return Mock(status_code=200, text=response_transcript, content=response_transcript)
+
+        return Mock(status_code=404, text='')
+
+    @patch('xmodule.video_module.transcripts_utils.requests.get', side_effect=mocked_requests_get)
+    def test_downloading_subs_using_transcript_name(self, mock_get):
+        """
+        Download transcript using transcript name in url
+        """
+        good_youtube_sub = 'good_id_2'
+        self.clear_sub_content(good_youtube_sub)
+
+        transcripts_utils.download_youtube_subs(good_youtube_sub, self.course, settings)
+        mock_get.assert_any_call(
+            'http://video.google.com/timedtext',
+            params={'lang': 'en', 'v': 'good_id_2', 'name': 'Custom'}
+        )
+
+        # Check asset status after import of transcript.
+        filename = 'subs_{0}.srt.sjson'.format(good_youtube_sub)
+        content_location = StaticContent.compute_location(self.course.id, filename)
+        self.assertTrue(contentstore().find(content_location))
+
+        self.clear_sub_content(good_youtube_sub)
+
 
 class TestGenerateSubsFromSource(TestDownloadYoutubeSubs):
     """Tests for `generate_subs_from_source` function."""


### PR DESCRIPTION
[TNL-2122](https://openedx.atlassian.net/browse/TNL-2122)

The url for getting transcript from youtube server is in the form of http://video.google.com/timedtext?lang=en&v={VideoId} which works fine if the name of transcript is empty but if its not we have to pass name of the transcript in the url in order to get transcript so the new url to get transcript becomes http://video.google.com/timedtext?lang=en&v={VideoId}&name={transcript_name}
