### PR TITLE
Creating a settings object that is aware of the microsite settings.

### DIFF
--- a/common/djangoapps/microsite_configuration/__init__.py
+++ b/common/djangoapps/microsite_configuration/__init__.py
@@ -33,4 +33,4 @@ class MicrositeAwareSettings(object):
             base_settings.__getattr__(name)
 
 
-settings = MicrositeAwareSettings()
+settings = MicrositeAwareSettings()  # pylint: disable=invalid-name

--- a/common/djangoapps/microsite_configuration/__init__.py
+++ b/common/djangoapps/microsite_configuration/__init__.py
@@ -27,22 +27,10 @@ class MicrositeAwareSettings(object):
     def __getattr__(self, name):
         try:
             if isinstance(microsite.get_value(name), dict):
-                return self.merge_dict(name)
+                return microsite.get_dict(name, base_settings.__getattr__(name))
             return microsite.get_value(name, base_settings.__getattr__(name))
         except KeyError:
             base_settings.__getattr__(name)
-
-    def merge_dict(self, name):
-        """
-        Handles the merge of two dictonaries, the one from the base_settings
-        updated to include the overrides defined at the microsite
-        """
-        if microsite.has_override_value(name):
-            temp = base_settings.__getattr__(name).copy()
-            temp.update(microsite.get_value(name, {}))
-            return temp
-        else:
-            return base_settings.__getattr__(name)
 
 
 settings = MicrositeAwareSettings()

--- a/common/djangoapps/microsite_configuration/__init__.py
+++ b/common/djangoapps/microsite_configuration/__init__.py
@@ -1,1 +1,19 @@
+from django.conf import settings as base_settings
+
+from microsite_configuration import microsite
 from .templatetags.microsite import page_title_breadcrumbs
+
+
+class MicrositeAwareSettings():
+    """
+    This class is a handy utility to make a call to the settings
+    completely microsite aware by replacing the:
+    from django.conf import settings
+    with:
+    from microsite_configuration import settings
+    """
+
+    def __getattr__(self, name):
+        return microsite.get_value(name, base_settings.__getattr__(name))
+
+settings = MicrositeAwareSettings()

--- a/common/djangoapps/microsite_configuration/__init__.py
+++ b/common/djangoapps/microsite_configuration/__init__.py
@@ -25,7 +25,24 @@ class MicrositeAwareSettings(object):
     """
 
     def __getattr__(self, name):
-        return microsite.get_value(name, base_settings.__getattr__(name))
+        try:
+            if isinstance(microsite.get_value(name), dict):
+                return self.merge_dict(name)
+            return microsite.get_value(name, base_settings.__getattr__(name))
+        except KeyError:
+            base_settings.__getattr__(name)
+
+    def merge_dict(self, name):
+        """
+        Handles the merge of two dictonaries, the one from the base_settings
+        updated to include the overrides defined at the microsite
+        """
+        if microsite.has_override_value(name):
+            temp = base_settings.__getattr__(name).copy()
+            temp.update(microsite.get_value(name, {}))
+            return temp
+        else:
+            return base_settings.__getattr__(name)
 
 
 settings = MicrositeAwareSettings()

--- a/common/djangoapps/microsite_configuration/__init__.py
+++ b/common/djangoapps/microsite_configuration/__init__.py
@@ -1,19 +1,31 @@
+"""
+This file implements a class which is a handy utility to make any
+call to the settings completely microsite aware by replacing the:
+
+from django.conf import settings
+
+with:
+
+from microsite_configuration import settings
+or
+from openedx.conf import settings
+
+"""
 from django.conf import settings as base_settings
 
 from microsite_configuration import microsite
 from .templatetags.microsite import page_title_breadcrumbs
 
 
-class MicrositeAwareSettings():
+class MicrositeAwareSettings(object):
     """
-    This class is a handy utility to make a call to the settings
-    completely microsite aware by replacing the:
-    from django.conf import settings
-    with:
-    from microsite_configuration import settings
+    This class is a proxy object of the settings object from django.
+    It will try to get a value from the microsite and default to the
+    django settings
     """
 
     def __getattr__(self, name):
         return microsite.get_value(name, base_settings.__getattr__(name))
+
 
 settings = MicrositeAwareSettings()

--- a/common/djangoapps/microsite_configuration/microsite.py
+++ b/common/djangoapps/microsite_configuration/microsite.py
@@ -40,6 +40,7 @@ def get_key_from_cache(key):
     if hasattr(CURRENT_REQUEST_CONFIGURATION, 'cache'):
         return CURRENT_REQUEST_CONFIGURATION.cache.get(key)
 
+
 def set_key_to_cache(key, value):
     """
     Stores a key value pair in a cache scoped to the thread
@@ -63,7 +64,7 @@ def get_value(val_name, default=None):
     return configuration.get(val_name, default)
 
 
-def get_dict(dict_name, default={}, **kwargs):
+def get_dict(dict_name, default=None):
     """
     Returns a dictionary product of merging the request's microsite and
     the default value.
@@ -73,6 +74,9 @@ def get_dict(dict_name, default={}, **kwargs):
     cached_dict = get_key_from_cache(dict_name)
     if cached_dict:
         return cached_dict
+
+    if default is None:
+        default = {}
 
     output = default.copy()
     output.update(get_value(dict_name, {}))

--- a/openedx/conf.py
+++ b/openedx/conf.py
@@ -8,4 +8,4 @@ This file adds a definition for the Microsite Settings with a nicer notation
 from microsite_configuration import MicrositeAwareSettings
 
 
-settings = MicrositeAwareSettings()  # pylint: disable=C0103
+settings = MicrositeAwareSettings()  # pylint: disable=invalid-name

--- a/openedx/conf.py
+++ b/openedx/conf.py
@@ -3,11 +3,9 @@ This is the root package for all core Open edX functionality. In particular,
 the djangoapps subpackage is the location for all Django apps that are shared
 between LMS and CMS.
 
-Note: the majority of the core functionality currently lives in the root
-common directory. All new Django apps should be created here instead, and
-the pre-existing apps will be moved here over time.
+This file adds a definition for the Microsite Settings with a nicer notation
 """
 from microsite_configuration import MicrositeAwareSettings
 
 
-settings = MicrositeAwareSettings()
+settings = MicrositeAwareSettings()  # pylint: disable=C0103

--- a/openedx/conf.py
+++ b/openedx/conf.py
@@ -1,0 +1,13 @@
+"""
+This is the root package for all core Open edX functionality. In particular,
+the djangoapps subpackage is the location for all Django apps that are shared
+between LMS and CMS.
+
+Note: the majority of the core functionality currently lives in the root
+common directory. All new Django apps should be created here instead, and
+the pre-existing apps will be moved here over time.
+"""
+from microsite_configuration import MicrositeAwareSettings
+
+
+settings = MicrositeAwareSettings()


### PR DESCRIPTION
This PR creates a settings object which can look for a setting in the microsite configuration and default to the regular django.conf settings value when the microsite does not have a particular override.

This should not have any impact on running code, but will allow a developer to call

```
from microsite_configuration import settings
```

instead of 

```
from django.conf import settings
```

and then use the settings object as it would normally with django. e.g.

```
settings.SITE_NAME
```

The current instances of microsite.get_value are not being changed in this PR.

This is a part of the changes contained in #7867 . I'm spliting that PR to have more isolated changes and make it easier to merge.
