### PR TITLE
fixed invalid CSS selectors

### DIFF
--- a/cms/static/js/views/settings/main.js
+++ b/cms/static/js/views/settings/main.js
@@ -122,8 +122,8 @@ var DetailsView = ValidatingView.extend({
     setupDatePicker: function (fieldName) {
         var cacheModel = this.model;
         var div = this.$el.find('#' + this.fieldToSelectorMap[fieldName]);
-        var datefield = $(div).find("input:.date");
-        var timefield = $(div).find("input:.time");
+        var datefield = $(div).find("input.date");
+        var timefield = $(div).find("input.time");
         var cachethis = this;
         var setfield = function () {
             var newVal = DateUtils.getDate(datefield, timefield),


### PR DESCRIPTION
Removed a surplus ":" in the input selector causes jquery versions past 1.9 to throw an error.

_Why do you need this change?_ I'm implementing a theme on top of Birch that requires Bootstrap, which also requires jquery to be updated past version 1.9.  Birch's version of jQuery is 1.7, which apparently accepts the selector that I changed, but 1.9.x and 2.x.x don't like the new selector.  

_Who have you talked to at EdX about this work?_ Well, in this case, nobody really.  I opened a thread in the [Google groups](https://groups.google.com/forum/#!topic/edx-code/65M2sDcwrKA) that is related, but pursuing a fix there led me to this as one of the roots of my issues.

_test plan_: The easiest way to test this is to replace  
    /edx-platform/common/static/js/vendor/jquery.min.js with an updated
with a [newer version of jquery's minified library](http://jquery.com/download/).  
Once that's done, fire up studio and go into a course.  
Then, go to Settings>Schedule & Details, and open up the Console in the _browser dev tools_.  You'll see an error referencing main.js:
![image](https://cloud.githubusercontent.com/assets/1844496/7756821/aed126b6-ffcb-11e4-9a4e-e8d1d3330dbf.png)
Functionally, this manifests itself on any date/time field on this form.  If you place your cursor in any of those fields, you'll see that the helpful autocomplete for dates/times don't appear, which silently causes this form to be rendered useless.

_Screenshot with broken autocompletes:_
![image](https://cloud.githubusercontent.com/assets/1844496/7756885/35622946-ffcc-11e4-8cbc-9b98894bbc24.png)

_Screenshot once selectors are fixed:_
![image](https://cloud.githubusercontent.com/assets/1844496/7756896/436e7382-ffcc-11e4-9b10-90cc28e1bedc.png)

Applying the code change in this PR will cause that error to go away, without changing the intended behavior of the selector in main.js.

_Notes_:
This PR _doesn't_ include a request to update jquery.min, as that isn't strictly necessary.  I would, however, love to know if there's a best practice for using a newer version of jQuery, or if there's a plan to update the library in future named releases.
