### PR TITLE
Fully enable licensing on devstack

### DIFF
--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -80,6 +80,12 @@ FEATURES['ENTRANCE_EXAMS'] = True
 
 ################################ COURSE LICENSES ################################
 FEATURES['LICENSING'] = True
+# Needed to enable licensing on video modules
+XBLOCK_SETTINGS = {
+    "VideoDescriptor": {
+        "licensing_enabled": True
+    }
+}
 
 ################################ SEARCH INDEX ################################
 FEATURES['ENABLE_COURSEWARE_INDEX'] = True


### PR DESCRIPTION
@singingwolfboy I set "LICENSING" to True in devstack.py in both lms and cms, but this is needed as well to fully turn the feature on in devstack.
