### PR TITLE
Distribute to setuptools

### DIFF
--- a/common/lib/capa/setup.py
+++ b/common/lib/capa/setup.py
@@ -4,5 +4,5 @@ setup(
     name="capa",
     version="0.1",
     packages=find_packages(exclude=["tests"]),
-    install_requires=["distribute>=0.6.28"],
+    install_requires=["setuptools"],
 )

--- a/common/lib/chem/setup.py
+++ b/common/lib/chem/setup.py
@@ -8,6 +8,6 @@ setup(
         "pyparsing==2.0.1",
         "numpy",
         "scipy",
-        "nltk==2.0.5",
+        "nltk<3.0",
     ],
 )

--- a/common/lib/xmodule/setup.py
+++ b/common/lib/xmodule/setup.py
@@ -54,7 +54,7 @@ setup(
     version="0.1",
     packages=find_packages(exclude=["tests"]),
     install_requires=[
-        'distribute',
+        'setuptools',
         'docopt',
         'capa',
         'path.py',

--- a/pavelib/prereqs.py
+++ b/pavelib/prereqs.py
@@ -16,7 +16,6 @@ PYTHON_REQ_FILES = [
     'requirements/edx/github.txt',
     'requirements/edx/local.txt',
     'requirements/edx/base.txt',
-    'requirements/edx/post.txt',
 ]
 
 # Developers can have private requirements, for local copies of github repos,

--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -11,4 +11,4 @@ pyparsing==2.0.1
 matplotlib==1.3.1
 
 # We forked NLTK just to make it work with setuptools instead of distribute
--e git+https://github.com/edx/nltk.git@2.0.6#egg=nltk
+git+https://github.com/edx/nltk.git@2.0.6#egg=nltk==2.0.6

--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -8,5 +8,7 @@ numpy==1.6.2
 networkx==1.7
 sympy==0.7.1
 pyparsing==2.0.1
-nltk==2.0.5
 matplotlib==1.3.1
+
+# We forked NLTK just to make it work with setuptools instead of distribute
+-e git+https://github.com/edx/nltk.git@2.0.6#egg=nltk

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -13,7 +13,6 @@ celery==3.1.18
 cssselect==0.9.1
 dealer==2.0.4
 defusedxml==0.4.1
-distribute>=0.6.28, <0.7
 django-babel-underscore==0.1.0
 django-celery==3.1.16
 django-countries==3.3
@@ -52,6 +51,7 @@ Markdown==2.2.1
 --allow-unverified meliae
 meliae==0.4.0
 mongoengine==0.7.10
+MySQL-python==1.2.5
 networkx==1.7
 nltk==2.0.5
 nose==1.3.3

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -53,7 +53,6 @@ meliae==0.4.0
 mongoengine==0.7.10
 MySQL-python==1.2.5
 networkx==1.7
-nltk==2.0.5
 nose==1.3.3
 oauthlib==0.7.2
 paramiko==1.9.0

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -13,7 +13,7 @@
 -e git+https://github.com/edx/django-wiki.git@cd0b2b31997afccde519fe5b3365e61a9edb143f#egg=django-wiki
 -e git+https://github.com/edx/django-oauth2-provider.git@0.2.7-fork-edx-5#egg=django-oauth2-provider
 -e git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=mongodb_proxy
--e git+https://github.com/edx/nltk.git@2.0.6#egg=nltk
+git+https://github.com/edx/nltk.git@2.0.6#egg=nltk==2.0.6
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev
 -e git+https://github.com/eventbrite/zendesk.git@d53fe0e81b623f084e91776bcf6369f8b7b63879#egg=zendesk
 -e git+https://github.com/un33k/django-ipware.git@42cb1bb1dc680a60c6452e8bb2b843c2a0382c90#egg=django-ipware

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -13,6 +13,7 @@
 -e git+https://github.com/edx/django-wiki.git@cd0b2b31997afccde519fe5b3365e61a9edb143f#egg=django-wiki
 -e git+https://github.com/edx/django-oauth2-provider.git@0.2.7-fork-edx-5#egg=django-oauth2-provider
 -e git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=mongodb_proxy
+-e git+https://github.com/edx/nltk.git@2.0.6#egg=nltk
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev
 -e git+https://github.com/eventbrite/zendesk.git@d53fe0e81b623f084e91776bcf6369f8b7b63879#egg=zendesk
 -e git+https://github.com/un33k/django-ipware.git@42cb1bb1dc680a60c6452e8bb2b843c2a0382c90#egg=django-ipware

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -42,7 +42,7 @@ git+https://github.com/hmarr/django-debug-toolbar-mongo.git@b0686a76f1ce3532088c
 -e git+https://github.com/edx/edx-ora2.git@release-2015-07-09T15.00#egg=edx-ora2
 -e git+https://github.com/edx/edx-submissions.git@7c766502058e04bc9094e6cbe286e949794b80b3#egg=edx-submissions
 -e git+https://github.com/edx/opaque-keys.git@27dc382ea587483b1e3889a3d19cbd90b9023a06#egg=opaque-keys
--e git+https://github.com/edx/ease.git@release-2015-07-09#egg=ease==0.1.3
+git+https://github.com/edx/ease.git@release-2015-07-09#egg=ease==0.1.3
 -e git+https://github.com/edx/i18n-tools.git@v0.1.1#egg=i18n-tools
 -e git+https://github.com/edx/edx-oauth2-provider.git@0.5.1#egg=oauth2-provider
 -e git+https://github.com/edx/edx-val.git@v0.0.5#egg=edx-val

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -39,10 +39,10 @@ git+https://github.com/hmarr/django-debug-toolbar-mongo.git@b0686a76f1ce3532088c
 -e git+https://github.com/edx/event-tracking.git@0.2.0#egg=event-tracking
 -e git+https://github.com/edx-solutions/django-splash.git@7579d052afcf474ece1239153cffe1c89935bc4f#egg=django-splash
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
--e git+https://github.com/edx/edx-ora2.git@release-2015-07-09T14.47#egg=edx-ora2
+-e git+https://github.com/edx/edx-ora2.git@release-2015-07-09T15.00#egg=edx-ora2
 -e git+https://github.com/edx/edx-submissions.git@7c766502058e04bc9094e6cbe286e949794b80b3#egg=edx-submissions
 -e git+https://github.com/edx/opaque-keys.git@27dc382ea587483b1e3889a3d19cbd90b9023a06#egg=opaque-keys
--e git+https://github.com/edx/ease.git@b67d2928a26fe497826b6ea359b9a3d0371548a7#egg=ease==0.1.3
+-e git+https://github.com/edx/ease.git@release-2015-07-09#egg=ease==0.1.3
 -e git+https://github.com/edx/i18n-tools.git@v0.1.1#egg=i18n-tools
 -e git+https://github.com/edx/edx-oauth2-provider.git@0.5.1#egg=oauth2-provider
 -e git+https://github.com/edx/edx-val.git@v0.0.5#egg=edx-val

--- a/requirements/edx/post.txt
+++ b/requirements/edx/post.txt
@@ -1,9 +1,0 @@
-# DON'T JUST ADD NEW DEPENDENCIES!!!
-#
-# If you open a pull request that adds a new dependency, you should notify:
-#   * @mollydb to check licensing
-#   * One of @e0d, @feanil, @fredsmith, @maxrothman, or @jibsheet
-#     to check system requirements
-
-# This must be installed after distribute has been updated.
-MySQL-python==1.2.4

--- a/requirements/edx/pre.txt
+++ b/requirements/edx/pre.txt
@@ -5,6 +5,9 @@
 #   * One of @e0d, @feanil, @fredsmith, @maxrothman, or @jibsheet
 #     to check system requirements
 
+# Use a modern setuptools instead of distribute
+setuptools==18.0.1
+
 # Numpy and scipy can't be installed in the same pip run.
 # Install numpy before other things to help resolve the problem.
 numpy==1.6.2

--- a/scripts/create-dev-env.sh
+++ b/scripts/create-dev-env.sh
@@ -441,27 +441,6 @@ if [[ -n $compile ]]; then
     rm -rf numpy-${NUMPY_VER} scipy-${SCIPY_VER}
 fi
 
-# building correct version of distribute from source
-DISTRIBUTE_VER="0.6.28"
-output "Building Distribute"
-SITE_PACKAGES="$WORKON_HOME/edx-platform/lib/python2.7/site-packages"
-cd "$SITE_PACKAGES"
-curl -sSLO http://pypi.python.org/packages/source/d/distribute/distribute-${DISTRIBUTE_VER}.tar.gz
-tar -xzvf distribute-${DISTRIBUTE_VER}.tar.gz
-cd distribute-${DISTRIBUTE_VER}
-python setup.py install
-cd ..
-rm distribute-${DISTRIBUTE_VER}.tar.gz
-
-DISTRIBUTE_VERSION=`pip freeze | grep distribute`
-
-if [[ "$DISTRIBUTE_VERSION" == "distribute==0.6.28" ]]; then
-  output "Distribute successfully installed"
-else
-  error "Distribute failed to build correctly. This script requires a working version of Distribute 0.6.28 in your virtualenv's python installation"
-  exit 1
-fi
-
 case `uname -s` in
     Darwin)
         # on mac os x get the latest distribute and pip

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup
 setup(
     name="Open edX",
     version="0.4",
-    install_requires=["distribute"],
+    install_requires=["setuptools"],
     requires=[],
     # NOTE: These are not the names we should be installing.  This tree should
     # be reorganized to be a more conventional Python tree.


### PR DESCRIPTION
Follow-on PR from #7465.
- Replaces `distribute` with `setuptools`
- Updates `MySQL-python` to 1.2.5 for `setuptools` compatibility
- Uses a [forked version of NLTK 2](https://github.com/nltk/nltk/compare/2.0.4...singingwolfboy:2.0.6) that does not require `distribute`
