### PR TITLE
Update commit hash for problem-builder.

### DIFF
--- a/requirements/edx/edx-private.txt
+++ b/requirements/edx/edx-private.txt
@@ -2,7 +2,7 @@
 
 # For Harvard courses:
 -e git+https://github.com/gsehub/xblock-mentoring.git@4d1cce78dc232d5da6ffd73817b5c490e87a6eee#egg=xblock-mentoring
--e git+https://github.com/open-craft/problem-builder.git@2b6e5705ffadef51abff3b8574c9bd34777e858d#egg=xblock-problem-builder
+-e git+https://github.com/open-craft/problem-builder.git@86d0611bd6384a69b416a8b4b43dbe422a2de7cb#egg=xblock-problem-builder
 
 # Prototype XBlocks from edX learning sciences limited roll-outs and user testing.
 # Concept XBlock, in particular, is nowhere near finished and an early prototype.


### PR DESCRIPTION
This PR pulls in the latest commit to the edx-release branch of Problem Builder, allowing to include custom HTML in the downloadable summary reports.

Partner information: hosted on edx.org (Harvard).
