### PR TITLE
Instructor Dashboard: Add functionality for obtaining list of students who may enroll in a course but haven't signed up yet (TNL-1652)

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -1380,6 +1380,19 @@ class CourseEnrollmentAllowed(models.Model):
     def __unicode__(self):
         return "[CourseEnrollmentAllowed] %s: %s (%s)" % (self.email, self.course_id, self.created)
 
+    @classmethod
+    def may_enroll_and_unenrolled(cls, course_id):
+        """
+        Return QuerySet of students who are allowed to enroll in a course.
+
+        Result excludes students who have already enrolled in the
+        course.
+
+        `course_id` identifies the course for which to compute the QuerySet.
+        """
+        enrolled = CourseEnrollment.objects.users_enrolled_in(course_id=course_id).values_list('email', flat=True)
+        return CourseEnrollmentAllowed.objects.filter(course_id=course_id).exclude(email__in=enrolled)
+
 
 @total_ordering
 class CourseAccessRole(models.Model):

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -1114,6 +1114,36 @@ def get_students_features(request, course_id, csv=False):  # pylint: disable=red
 
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
+@require_level('staff')
+def get_students_who_may_enroll(request, course_id):
+    """
+    Initiate generation of a CSV file containing information about
+    students who may enroll in a course.
+
+    Responds with JSON
+        {"status": "... status message ..."}
+
+    """
+    course_key = CourseKey.from_string(course_id)
+    query_features = ['email']
+    try:
+        instructor_task.api.submit_calculate_may_enroll_csv(request, course_key, query_features)
+        success_status = _(
+            "Your students who may enroll report is being generated! "
+            "You can view the status of the generation task in the 'Pending Instructor Tasks' section."
+        )
+        return JsonResponse({"status": success_status})
+    except AlreadyRunningError:
+        already_running_status = _(
+            "A students who may enroll report generation task is already in progress. "
+            "Check the 'Pending Instructor Tasks' table for the status of the task. "
+            "When completed, the report will be available for download in the table below."
+        )
+        return JsonResponse({"status": already_running_status})
+
+
+@ensure_csrf_cookie
+@cache_control(no_cache=True, no_store=True, must_revalidate=True)
 @require_POST
 @require_level('staff')
 def add_users_to_cohorts(request, course_id):

--- a/lms/djangoapps/instructor/views/api_urls.py
+++ b/lms/djangoapps/instructor/views/api_urls.py
@@ -21,6 +21,8 @@ urlpatterns = patterns(
         'instructor.views.api.get_grading_config', name="get_grading_config"),
     url(r'^get_students_features(?P<csv>/csv)?$',
         'instructor.views.api.get_students_features', name="get_students_features"),
+    url(r'^get_students_who_may_enroll$',
+        'instructor.views.api.get_students_who_may_enroll', name="get_students_who_may_enroll"),
     url(r'^get_user_invoice_preference$',
         'instructor.views.api.get_user_invoice_preference', name="get_user_invoice_preference"),
     url(r'^get_sale_records(?P<csv>/csv)?$',

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -445,6 +445,9 @@ def _section_data_download(course, access):
         'access': access,
         'get_grading_config_url': reverse('get_grading_config', kwargs={'course_id': unicode(course_key)}),
         'get_students_features_url': reverse('get_students_features', kwargs={'course_id': unicode(course_key)}),
+        'get_students_who_may_enroll_url': reverse(
+            'get_students_who_may_enroll', kwargs={'course_id': unicode(course_key)}
+        ),
         'get_anon_ids_url': reverse('get_anon_ids', kwargs={'course_id': unicode(course_key)}),
         'list_instructor_tasks_url': reverse('list_instructor_tasks', kwargs={'course_id': unicode(course_key)}),
         'list_report_downloads_url': reverse('list_report_downloads', kwargs={'course_id': unicode(course_key)}),

--- a/lms/djangoapps/instructor/views/legacy.py
+++ b/lms/djangoapps/instructor/views/legacy.py
@@ -307,12 +307,6 @@ def instructor_dashboard(request, course_id):
     #----------------------------------------
     # enrollment
 
-    elif action == 'List students who may enroll but may not have yet signed up':
-        ceaset = CourseEnrollmentAllowed.objects.filter(course_id=course_key)
-        datatable = {'header': ['StudentEmail']}
-        datatable['data'] = [[x.email] for x in ceaset]
-        datatable['title'] = action
-
     elif action == 'Enroll multiple students':
 
         is_shib_course = uses_shib(course)

--- a/lms/djangoapps/instructor_analytics/basic.py
+++ b/lms/djangoapps/instructor_analytics/basic.py
@@ -15,6 +15,7 @@ from django.core.urlresolvers import reverse
 import xmodule.graders as xmgraders
 from django.core.exceptions import ObjectDoesNotExist
 from microsite_configuration import microsite
+from student.models import CourseEnrollmentAllowed
 
 
 STUDENT_FEATURES = ('id', 'username', 'first_name', 'last_name', 'is_staff', 'email')
@@ -207,6 +208,31 @@ def enrolled_students_features(course_key, features):
         return student_dict
 
     return [extract_student(student, features) for student in students]
+
+
+def list_may_enroll(course_key, features):
+    """
+    Return info about students who may enroll in a course as a dict.
+
+    list_may_enroll(course_key, ['email'])
+    would return [
+        {'email': 'email1'}
+        {'email': 'email2'}
+        {'email': 'email3'}
+    ]
+
+    Note that result does not include students who may enroll and have
+    already done so.
+    """
+    may_enroll_and_unenrolled = CourseEnrollmentAllowed.may_enroll_and_unenrolled(course_key)
+
+    def extract_student(student, features):
+        """
+        Build dict containing information about a single student.
+        """
+        return dict((feature, getattr(student, feature)) for feature in features)
+
+    return [extract_student(student, features) for student in may_enroll_and_unenrolled]
 
 
 def coupon_codes_features(features, coupons_list):

--- a/lms/djangoapps/instructor_task/api.py
+++ b/lms/djangoapps/instructor_task/api.py
@@ -22,7 +22,9 @@ from instructor_task.tasks import (
     calculate_problem_grade_report,
     calculate_students_features_csv,
     cohort_students,
-    enrollment_report_features_csv)
+    enrollment_report_features_csv,
+    calculate_may_enroll_csv,
+)
 
 from instructor_task.api_helper import (
     check_arguments_for_rescoring,
@@ -370,6 +372,21 @@ def submit_detailed_enrollment_features_csv(request, course_key):  # pylint: dis
     task_type = 'detailed_enrollment_report'
     task_class = enrollment_report_features_csv
     task_input = {}
+    task_key = ""
+
+    return submit_task(request, task_type, task_class, course_key, task_input, task_key)
+
+
+def submit_calculate_may_enroll_csv(request, course_key, features):
+    """
+    Submits a task to generate a CSV file containing information about
+    invited students who have not enrolled in a given course yet.
+
+    Raises AlreadyRunningError if said file is already being updated.
+    """
+    task_type = 'may_enroll_info_csv'
+    task_class = calculate_may_enroll_csv
+    task_input = {'features': features}
     task_key = ""
 
     return submit_task(request, task_type, task_class, course_key, task_input, task_key)

--- a/lms/djangoapps/instructor_task/tasks.py
+++ b/lms/djangoapps/instructor_task/tasks.py
@@ -38,7 +38,9 @@ from instructor_task.tasks_helper import (
     upload_problem_grade_report,
     upload_students_csv,
     cohort_students_and_upload,
-    upload_enrollment_report)
+    upload_enrollment_report,
+    upload_may_enroll_csv,
+)
 
 
 TASK_LOG = logging.getLogger('edx.celery.task')
@@ -194,6 +196,19 @@ def enrollment_report_features_csv(entry_id, xmodule_instance_args):
     # Translators: This is a past-tense verb that is inserted into task progress messages as {action}.
     action_name = ugettext_noop('generating_enrollment_report')
     task_fn = partial(upload_enrollment_report, xmodule_instance_args)
+    return run_main_task(entry_id, task_fn, action_name)
+
+
+@task(base=BaseInstructorTask, routing_key=settings.GRADES_DOWNLOAD_ROUTING_KEY)  # pylint: disable=not-callable
+def calculate_may_enroll_csv(entry_id, xmodule_instance_args):
+    """
+    Compute information about invited students who have not enrolled
+    in a given course yet and upload the CSV to an S3 bucket for
+    download.
+    """
+    # Translators: This is a past-tense verb that is inserted into task progress messages as {action}.
+    action_name = ugettext_noop('generated')
+    task_fn = partial(upload_may_enroll_csv, xmodule_instance_args)
     return run_main_task(entry_id, task_fn, action_name)
 
 

--- a/lms/djangoapps/instructor_task/tests/test_api.py
+++ b/lms/djangoapps/instructor_task/tests/test_api.py
@@ -16,7 +16,9 @@ from instructor_task.api import (
     submit_bulk_course_email,
     submit_calculate_students_features_csv,
     submit_cohort_students,
-    submit_detailed_enrollment_features_csv)
+    submit_detailed_enrollment_features_csv,
+    submit_calculate_may_enroll_csv,
+)
 
 from instructor_task.api_helper import AlreadyRunningError
 from instructor_task.models import InstructorTask, PROGRESS
@@ -210,6 +212,14 @@ class InstructorTaskCourseSubmitTest(TestReportMixin, InstructorTaskCourseTestCa
     def test_submit_enrollment_report_features_csv(self):
         api_call = lambda: submit_detailed_enrollment_features_csv(self.create_task_request(self.instructor),
                                                                    self.course.id)
+        self._test_resubmission(api_call)
+
+    def test_submit_calculate_may_enroll(self):
+        api_call = lambda: submit_calculate_may_enroll_csv(
+            self.create_task_request(self.instructor),
+            self.course.id,
+            features=[]
+        )
         self._test_resubmission(api_call)
 
     def test_submit_cohort_students(self):

--- a/lms/static/coffee/src/instructor_dashboard/data_download.coffee
+++ b/lms/static/coffee/src/instructor_dashboard/data_download.coffee
@@ -20,6 +20,7 @@ class DataDownload
     # gather elements
     @$list_studs_btn = @$section.find("input[name='list-profiles']'")
     @$list_studs_csv_btn = @$section.find("input[name='list-profiles-csv']'")
+    @$list_may_enroll_csv_btn = @$section.find("input[name='list-may-enroll-csv']")
     @$list_anon_btn = @$section.find("input[name='list-anon-ids']'")
     @$grade_config_btn = @$section.find("input[name='dump-gradeconf']'")
     @$calculate_grades_csv_btn = @$section.find("input[name='calculate-grades-csv']'")
@@ -95,6 +96,20 @@ class DataDownload
           @$download_display_table.append $table_placeholder
           grid = new Slick.Grid($table_placeholder, grid_data, columns, options)
           # grid.autosizeColumns()
+
+    @$list_may_enroll_csv_btn.click (e) =>
+      @clear_display()
+
+      url = @$list_may_enroll_csv_btn.data 'endpoint'
+      $.ajax
+        dataType: 'json'
+        url: url
+        error: (std_ajax_err) =>
+          @$reports_request_response_error.text gettext("Error generating list of students who may enroll. Please try again.")
+          $(".msg-error").css({"display":"block"})
+        success: (data) =>
+          @$reports_request_response.text data['status']
+          $(".msg-confirm").css({"display":"block"})
 
     @$grade_config_btn.click (e) =>
       url = @$grade_config_btn.data 'endpoint'

--- a/lms/templates/courseware/legacy_instructor_dashboard.html
+++ b/lms/templates/courseware/legacy_instructor_dashboard.html
@@ -330,8 +330,14 @@ function goto( mode)
     </div>
     % endif
 
-    <input type="submit" name="action" value="List enrolled students" class="${'is-disabled' if disable_buttons else ''}" aria-disabled="${'true' if disable_buttons else 'false'}">
-    <input type="submit" name="action" value="List students who may enroll but may not have yet signed up" class="${'is-disabled' if disable_buttons else ''}" aria-disabled="${'true' if disable_buttons else 'false'}" >
+    <p class="is-deprecated">
+      ${_("To download a CSV file containing profile information for students who are enrolled in this course, visit the Data Download section of the Instructor Dashboard.")}
+    </p>
+
+    <p class="is-deprecated">
+      ${_("To download a list of students who may enroll in this course but have not yet signed up for it, visit the Data Download section of the Instructor Dashboard.")}
+    </p>
+
     <hr width="40%" style="align:left">
 
   %if settings.FEATURES.get('REMOTE_GRADEBOOK_URL','') and instructor_access:

--- a/lms/templates/instructor/instructor_dashboard_2/data_download.html
+++ b/lms/templates/instructor/instructor_dashboard_2/data_download.html
@@ -31,6 +31,10 @@
 
     <p><input type="button" name="list-profiles-csv" value="${_("Download profile information as a CSV")}" data-endpoint="${ section_data['get_students_features_url'] }" data-csv="true"></p>
 
+    <p>${_("Click to generate a CSV file that lists learners who can enroll in the course but have not yet done so.")}</p>
+
+    <p><input type="button" name="list-may-enroll-csv" value="${_("Download a CSV of learners who can enroll")}" data-endpoint="${ section_data['get_students_who_may_enroll_url'] }" data-csv="true"></p>
+
   % if not disable_buttons:
     <p>${_("For smaller courses, click to list profile information for enrolled students directly on this page:")}</p>
     <p><input type="button" name="list-profiles" value="${_("List enrolled students' profile information")}" data-endpoint="${ section_data['get_students_features_url'] }"></p>


### PR DESCRIPTION
## Background

This PR addresses JIRA ticket [TNL-1652](https://openedx.atlassian.net/browse/TNL-1652), which is based on the following feature proposal: [OSPR-171](https://openedx.atlassian.net/browse/OSPR-171)

It moves functionality for obtaining a list of students who may enroll in a given course but have not signed up yet from the legacy dashboard to the Instructor Dashboard.

The functionality that this PR adds to the Instructor Dashboard differs from the functionality that used to be available on the legacy dashboard in two ways:
1.  Instead of displaying a list of students who may enroll in a course on the dashboard, results are made available for download in the form of a CSV file.
2.  Existing enrollments are taken into account when computing the list of students who may enroll in a course. This means that students who are allowed to enroll in the course **and** have already done so will not be added to the resulting CSV file.
## Affected components

This PR affects the LMS. In particular, it introduces changes to the legacy dashboard and the new instructor dashboard (as explained above).
## Affected users

The changes introduced in this PR only affect users with staff privileges; they do not affect all edX students.
## Instructions for manual testing
1.  On Devstack, start a Django shell via
   
   ```
   ./manage.py lms shell --settings=devstack
   ```
   
   and add test data by executing the following code:
   
   ```
   from student.models import CourseEnrollmentAllowed
   course_id = "edX/DemoX/Demo_Course"
   for n in range(3):
       CourseEnrollmentAllowed.objects.create(email="student{}@example.com".format(n), course_id=course_id)
   
   CourseEnrollmentAllowed.objects.create(email="staff@example.com", course_id=course_id)
   ```
2.  Run the LMS and sign in as `staff@example.com`.
3.  Navigate to http://localhost:8000/courses/edX/DemoX/Demo_Course/instructor and click on the "Data Download" tab.
4.  Click "Download info about students who may enroll as a CSV" to generate a CSV file with the same data (will be added to the list of files available for download when it's ready).
5.  Check the contents of the CSV file (as `vagrant` user) via:
   
   ```
   cd /tmp/edx-s3/grades/edX%2FDemoX%2FDemo_Course/
   cat edX_DemoX_Demo_Course_may_enroll_info_YYYY-MM-DD-HHMM.csv
   ```

Observe that the results do not include students who are already enrolled in the Demo Course (in this case: `staff@example.com`).
## Screenshots
### Legacy dashboard

Legacy dashboard displaying instructions on where to find deprecated functionality:

![legacy-dashboard-message](https://cloud.githubusercontent.com/assets/961441/7771810/604e294c-009a-11e5-9d6b-c7903779b31f.png)
### Instructor dashboard

New controls for downloading list of students who may enroll:

![data-download-reports-highlighted](https://cloud.githubusercontent.com/assets/961441/7771828/72a64e58-009a-11e5-8d75-534a03444019.png)

CSV generation in progress:

![data-download-reports-in-progress-highlighted](https://cloud.githubusercontent.com/assets/961441/7771844/8309b65e-009a-11e5-8b12-5ac747e7ae65.png)

Results have become available:

![data-download-reports-with-results-highlighted](https://cloud.githubusercontent.com/assets/961441/7771855/8f11160e-009a-11e5-9e40-6bba36bfe10d.png)
## Licensing

This PR is covered by the OpenCraft contributor agreement (@antoviaque).

---

Please review this PR. I'll be happy to incorporate any suggestions for improvements. Thanks!
