### PR TITLE
Load creative-commons icon CSS on RTL pages

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1293,6 +1293,7 @@ PIPELINE_CSS = {
     'style-main-rtl': {
         'source_filenames': [
             'sass/lms-main-rtl.css',
+            'css/edx-cc.css',
         ],
         'output_filename': 'css/lms-main-rtl.css',
     },


### PR DESCRIPTION
@sarina I think we need this for RTL pages with Creative Commons enabled. Must have missed it in #7315. Can you verify?
