### PR TITLE
TNL-2223 Inline discussion jumps to the bottom of the page when threa…

### DIFF
--- a/common/static/coffee/src/discussion/views/discussion_thread_view.coffee
+++ b/common/static/coffee/src/discussion/views/discussion_thread_view.coffee
@@ -118,6 +118,12 @@ if Backbone?
         @responsesRequest.abort()
 
     loadResponses: (responseLimit, elem, firstLoad) ->
+      # takeFocus take the page focus to response loading element while responses are being fetched.
+      # - When viewing in the Discussions tab, responses are loaded automatically, Do not scroll to the
+      # element(TNL-1530)
+      # - When viewing inline in courseware, user clicks 'expand' to open responses, Its ok to scroll to the
+      # element (Default)
+      takeFocus = if @mode == "tab" then false else true
       @responsesRequest = DiscussionUtil.safeAjax
         url: DiscussionUtil.urlFor('retrieve_single_thread', @model.get('commentable_id'), @model.id)
         data:
@@ -125,7 +131,7 @@ if Backbone?
           resp_limit: responseLimit if responseLimit
         $elem: elem
         $loading: elem
-        takeFocus: false
+        takeFocus: takeFocus
         complete: =>
           @responsesRequest = null
         success: (data, textStatus, xhr) =>
@@ -144,7 +150,6 @@ if Backbone?
           )
           @trigger "thread:responses:rendered"
           @loadedResponses = true
-          $(".thread-wrapper").focus() # Sends focus to the conversation once the thread finishes loading
         error: (xhr, textStatus) =>
           return if textStatus == 'abort'
 

--- a/common/test/acceptance/fixtures/discussion.py
+++ b/common/test/acceptance/fixtures/discussion.py
@@ -135,6 +135,20 @@ class MultipleThreadFixture(DiscussionContentFixture):
         threads_list = {thread['id']: thread for thread in self.threads}
         return {"threads": json.dumps(threads_list), "comments": '{}'}
 
+    def add_response(self, response, comments, thread):
+        """
+        Add responses to the thread
+        """
+        response['children'] = comments
+        if thread["thread_type"] == "discussion":
+            response_list_attr = "children"
+        elif response["endorsed"]:
+            response_list_attr = "endorsed_responses"
+        else:
+            response_list_attr = "non_endorsed_responses"
+        thread.setdefault(response_list_attr, []).append(response)
+        thread['comments_count'] += len(comments) + 1
+
 
 class UserProfileViewFixture(DiscussionContentFixture):
 

--- a/common/test/acceptance/pages/lms/discussion.py
+++ b/common/test/acceptance/pages/lms/discussion.py
@@ -464,6 +464,13 @@ class InlineDiscussionThreadPage(DiscussionThreadPage):
     def is_thread_anonymous(self):
         return not self.q(css=".posted-details > .username").present
 
+    @wait_for_js
+    def check_if_selector_is_focused(self, selector):
+        """
+        Check if selector is focused
+        """
+        return self.browser.execute_script("return $('{}').is(':focus')".format(selector))
+
 
 class DiscussionUserProfilePage(CoursePage):
 


### PR DESCRIPTION
In `Inline Discussion`, when a thread is expanded & `responses` are loaded against that thread, an invalid selector take the focus to the bottom of the page. 
Also added a bokchoy test for verification. 

@explorerleslie 

>  We don't need to move the scroll at all once a discussion is expanded.

[TNL-2223](https://openedx.atlassian.net/browse/TNL-2223)
