### PR TITLE
Fix documentation comment for enrollment API

### DIFF
--- a/common/djangoapps/enrollment/views.py
+++ b/common/djangoapps/enrollment/views.py
@@ -72,7 +72,7 @@ class EnrollmentView(APIView, ApiKeyPermissionMixIn):
 
         **Example Requests**:
 
-            GET /api/enrollment/v1/enrollment/{user_id},{course_id}
+            GET /api/enrollment/v1/enrollment/{username},{course_id}
 
         **Response Values**
 


### PR DESCRIPTION
Example request should say `username`, not `user_id`. It doesn’t work using the `user_id`.
