### PR TITLE
PLAT-295: Reset advertised date on course rerun

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -1765,6 +1765,13 @@ class RerunCourseTest(ContentStoreTestCase):
         self.assertEqual(1, len(source_videos))
         self.assertEqual(source_videos, target_videos)
 
+    def test_rerun_course_resets_advertised_date(self):
+        source_course = CourseFactory.create(advertised_start="01-12-2015")
+        destination_course_key = self.post_rerun_request(source_course.id)
+        destination_course = self.store.get_course(destination_course_key)
+
+        self.assertEqual(None, destination_course.advertised_start)
+
     def test_rerun_of_rerun(self):
         source_course = CourseFactory.create()
         rerun_course_key = self.post_rerun_request(source_course.id)

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -786,6 +786,9 @@ def _rerun_course(request, org, number, run, fields):
     # Mark the action as initiated
     CourseRerunState.objects.initiated(source_course_key, destination_course_key, request.user, fields['display_name'])
 
+    # Clear the fields that must be reset for the rerun
+    fields['advertised_start'] = None
+
     # Rerun the course as a new celery task
     json_fields = json.dumps(fields, cls=EdxJSONEncoder)
     rerun_course.delay(unicode(source_course_key), unicode(destination_course_key), request.user.id, json_fields)


### PR DESCRIPTION
_(This PR is covered by the OpenCraft contributor agreement)_
_(cc @antoviaque )_
#### JIRA Ticket

[PLAT-295](https://openedx.atlassian.net/browse/PLAT-295)
#### Background

If a Studio user reruns a course which has a set "Course Advertised Start Date" value, the rerun keeps the advertised date value of the original course. As a result any new start date that the user will set will be overrode in the LMS by the advertised one, of which probably the user will not be aware of.

So it makes sense to reset the advertised start date whenever a rerun is created, just as it happens for the standard start date
#### LMS Updates

None
#### Studio updates

So from what I saw there are 3 places where you can perform the reset of the field:
- In the [view](https://github.com/edx/edx-platform/blob/master/cms/djangoapps/contentstore/views/course.py#L615)
- In the [task](https://github.com/edx/edx-platform/blob/master/cms/djangoapps/contentstore/tasks.py#L26)
- In [split](https://github.com/edx/edx-platform/blob/master/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py#L1602)

and in the end I decided for the view since there is already an explicit field being set there

``` javascript
fields['display_name'] = display_name`
```

but of course I'm open to suggestions!
#### Testing

Before the fix
1. Set up a course with a "Course Advertised Start Date" value set
2. Rerun the course
3. Check that the rerun has still the advertised start date set
4. Set up a new (standard) start date
5. In the lms, check that for the rerun you see the advertised date, not the standard one

After the fix
1. Set up a course with a "Course Advertised Start Date" value set
2. Rerun the course
3. Check that the rerun doesn't have the advertised date set
4. Set up a new (standard) start date
5. In the lms, check that for the rerun you see the standard start date
