### PR TITLE
Add "following" parameter to thread creation

### DIFF
--- a/lms/djangoapps/discussion_api/forms.py
+++ b/lms/djangoapps/discussion_api/forms.py
@@ -2,7 +2,7 @@
 Discussion API forms
 """
 from django.core.exceptions import ValidationError
-from django.forms import CharField, Form, IntegerField, NullBooleanField
+from django.forms import BooleanField, CharField, Form, IntegerField, NullBooleanField
 
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.locator import CourseLocator
@@ -35,6 +35,14 @@ class ThreadListGetForm(_PaginationForm):
             return CourseLocator.from_string(value)
         except InvalidKeyError:
             raise ValidationError("'{}' is not a valid course id".format(value))
+
+
+class ThreadCreateExtrasForm(Form):
+    """
+    A form to handle fields in thread creation that require separate
+    interactions with the comments service.
+    """
+    following = BooleanField(required=False)
 
 
 class CommentListGetForm(_PaginationForm):

--- a/lms/djangoapps/discussion_api/tests/utils.py
+++ b/lms/djangoapps/discussion_api/tests/utils.py
@@ -74,6 +74,17 @@ class CommentsServiceMockMixin(object):
             status=200
         )
 
+    def register_subscription_response(self, user):
+        """
+        Register a mock response for POST on the CS user subscription endpoint
+        """
+        httpretty.register_uri(
+            httpretty.POST,
+            "http://localhost:4567/api/v1/users/{id}/subscriptions".format(id=user.id),
+            body=json.dumps({}),  # body is unused
+            status=200
+        )
+
     def assert_query_params_equal(self, httpretty_request, expected_params):
         """
         Assert that the given mock request had the expected query parameters

--- a/lms/djangoapps/discussion_api/views.py
+++ b/lms/djangoapps/discussion_api/views.py
@@ -96,6 +96,9 @@ class ThreadViewSet(_ViewMixin, DeveloperErrorViewMixin, ViewSet):
 
         * raw_body (required): The thread's raw body text
 
+        * following (optional): A boolean indicating whether the user should
+            follow the thread upon its creation; defaults to false
+
     **GET Response Values**:
 
         * results: The list of threads; each item in the list has the same


### PR DESCRIPTION
This allows authors to follow the thread immediately upon creation.

@jimabramson @BenjiLee Please review
@nasthagiri @cahrens FYI
