### PR TITLE
Added ccx enable/disable flag to advance settings and show hide ccx coach option on lms

### DIFF
--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -83,6 +83,10 @@ class CourseMetadata(object):
         if not settings.FEATURES.get('ENABLE_VIDEO_BUMPER'):
             filtered_list.append('video_bumper')
 
+        # Do not show enable_ccx if feature is not enabled.
+        if not settings.FEATURES.get('CUSTOM_COURSES_EDX'):
+            filtered_list.append('enable_ccx')
+
         return filtered_list
 
     @classmethod

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -386,6 +386,21 @@ class CourseFields(object):
         ),
         scope=Scope.settings
     )
+    enable_ccx = Boolean(
+        # Translators: Custom Courses for edX (CCX) is an edX feature for re-using course content. CCX Coach is
+        # a role created by a course Instructor to enable a person (the "Coach") to manage the custom course for
+        # his students.
+        display_name=_("Enable CCX"),
+        # Translators: Custom Courses for edX (CCX) is an edX feature for re-using course content. CCX Coach is
+        # a role created by a course Instructor to enable a person (the "Coach") to manage the custom course for
+        # his students.
+        help=_(
+            "Allow course instructors to assign CCX Coach roles, and allow coaches to manage Custom Courses on edX."
+            " When false, Custom Courses cannot be created, but existing Custom Courses will be preserved."
+        ),
+        default=False,
+        scope=Scope.settings
+    )
     allow_anonymous = Boolean(
         display_name=_("Allow Anonymous Discussion Posts"),
         help=_("Enter true or false. If true, students can create discussion posts that are anonymous to all users."),

--- a/common/lib/xmodule/xmodule/tabs.py
+++ b/common/lib/xmodule/xmodule/tabs.py
@@ -758,7 +758,7 @@ class CcxCoachTab(CourseTab):
         the user is one.
         """
         user_is_coach = False
-        if settings.FEATURES.get('CUSTOM_COURSES_EDX', False):
+        if settings.FEATURES.get('CUSTOM_COURSES_EDX', False) and course.enable_ccx:
             from opaque_keys.edx.locations import SlashSeparatedCourseKey
             from student.roles import CourseCcxCoachRole  # pylint: disable=import-error
             from ccx.overrides import get_current_request  # pylint: disable=import-error

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -324,10 +324,12 @@ def _section_course_info(course, access):
 def _section_membership(course, access):
     """ Provide data for the corresponding dashboard section """
     course_key = course.id
+    ccx_enabled = settings.FEATURES.get('CUSTOM_COURSES_EDX', False) and course.enable_ccx
     section_data = {
         'section_key': 'membership',
         'section_display_name': _('Membership'),
         'access': access,
+        'ccx_is_enabled': ccx_enabled,
         'enroll_button_url': reverse('students_update_enrollment', kwargs={'course_id': unicode(course_key)}),
         'unenroll_button_url': reverse('students_update_enrollment', kwargs={'course_id': unicode(course_key)}),
         'upload_student_csv_button_url': reverse('register_and_enroll_students', kwargs={'course_id': unicode(course_key)}),

--- a/lms/templates/instructor/instructor_dashboard_2/membership.html
+++ b/lms/templates/instructor/instructor_dashboard_2/membership.html
@@ -243,8 +243,8 @@
       data-add-button-label="${_("Add Community TA")}"
     ></div>
   %endif
-  
-  %if section_data['access']['instructor'] and settings.FEATURES.get('CUSTOM_COURSES_EDX', False):
+
+  %if section_data['access']['instructor'] and section_data['ccx_is_enabled']:
     <div class="auth-list-container"
       data-rolename="ccx_coach"
       data-display-name="${_("CCX Coaches")}"


### PR DESCRIPTION
**Background:** In this PR I have added CCX enable setting to Advance settings of course. 

**Studio Updates:** 
1. User can set CCX enable from studio -> course -> Advance settings -> Enable CCX.
2. When CCX is disabled on platform, the user will not see ccx_enable field on advance settings.  

**LMS Updates:** 
1. After enabling setting only then can the user can see CCX Coaches option in drop down under ADMINISTRATION LIST MANAGEMENT inside membership -> instructor dashboard.
2. On making ccx_enable setting false then ccx coach tab will be hidden from coach

**Testing:** For instructions on enabling CCX and for creating CCX coaches, see https://openedx.atlassian.net/wiki/display/OPEN/CCX+Test+Plan and http://draft-custom-courses.readthedocs.org/en/latest/building_course/custom_courses.html

https://github.com/jazkarta/edx-platform/issues/85
@carsongee @pdpinch  @pwilkins 
![screen shot 2015-05-13 at 8 53 15 pm](https://cloud.githubusercontent.com/assets/10431250/7628364/bc8bca76-fa3b-11e4-819d-8c08ed842504.png)

![screen shot 2015-05-12 at 5 34 13 pm](https://cloud.githubusercontent.com/assets/10431250/7628360/b434021c-fa3b-11e4-95b1-5a3d05550f43.png)
