### PR TITLE
Compute RTL every time it is needed.

### DIFF
--- a/cms/templates/base.html
+++ b/cms/templates/base.html
@@ -2,16 +2,13 @@
 <%namespace name='static' file='static_content.html'/>
 <%!
 from django.utils.translation import ugettext as _
-from django.utils.translation import get_language_bidi
 from django.template.defaultfilters import escapejs
 import json
-
-dir_rtl = 'rtl' if get_language_bidi() else 'ltr'
 %>
 <!doctype html>
 <!--[if lte IE 9]><html class="ie9 lte9" lang="${LANGUAGE_CODE}"><![endif]-->
 <!--[if !IE]><<!--><html lang="${LANGUAGE_CODE}"><!--<![endif]-->
-  <head dir="${dir_rtl}">
+  <head dir="${static.dir_rtl()}">
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>
@@ -38,7 +35,7 @@ dir_rtl = 'rtl' if get_language_bidi() else 'ltr'
     <%block name="header_extras"></%block>
   </head>
 
-  <body class="${dir_rtl} <%block name='bodyclass'></%block> lang_${LANGUAGE_CODE}">
+  <body class="${static.dir_rtl()} <%block name='bodyclass'></%block> lang_${LANGUAGE_CODE}">
   <%block name="view_notes"></%block>
 
     <a class="nav-skip" href="#content">${_("Skip to main content")}</a>
@@ -57,7 +54,7 @@ dir_rtl = 'rtl' if get_language_bidi() else 'ltr'
     </script>
 
     <!-- view -->
-    <div class="wrapper wrapper-view" dir="${dir_rtl}">
+    <div class="wrapper wrapper-view" dir="${static.dir_rtl()}">
         <% online_help_token = self.online_help_token() if hasattr(self, 'online_help_token') else None %>
         <%include file="widgets/header.html" args="online_help_token=online_help_token" />
 

--- a/common/djangoapps/pipeline_mako/templates/static_content.html
+++ b/common/djangoapps/pipeline_mako/templates/static_content.html
@@ -27,6 +27,7 @@ except:
     % endfor
   %endif
 </%def>
+
 <%def name='js(group)'>
   % if settings.FEATURES['USE_DJANGO_PIPELINE']:
     ${compressed_js(group)}
@@ -36,6 +37,15 @@ except:
     % endfor
   %endif
 </%def>
+
+## A language-direction indicator, suitable for use in class="" attributes,
+## for example:
+##
+##      <body class="${dir_rtl()}">
+##
+<%def name="dir_rtl()"><%
+    return 'rtl' if get_language_bidi() else 'ltr'
+%></%def>
 
 <%def name="include(path)"><%
 from django.template.loaders.filesystem import _loader

--- a/lms/djangoapps/courseware/tests/test_i18n.py
+++ b/lms/djangoapps/courseware/tests/test_i18n.py
@@ -9,19 +9,40 @@ from django.test.utils import override_settings
 
 
 @attr('shard_1')
-@override_settings(LANGUAGES=(('eo', 'Esperanto'),))
+@override_settings(LANGUAGES=[('eo', 'Esperanto'), ('ar', 'Arabic')])
 class I18nTestCase(TestCase):
     """
     Tests for i18n
     """
+    def assert_tag_has_attr(self, content, tag, attname, value):
+        """Assert that a tag in `content` has a certain value in a certain attribute."""
+        regex = r"""<{tag} [^>]*\b{attname}=['"]([\w\d ]+)['"][^>]*>""".format(tag=tag, attname=attname)
+        match = re.search(regex, content)
+        self.assertTrue(match, "Couldn't find desired tag in %r" % content)
+        attvalues = match.group(1).split()
+        self.assertIn(value, attvalues)
+
     def test_default_is_en(self):
         response = self.client.get('/')
-        self.assertIn('<html lang="en">', response.content)
+        self.assert_tag_has_attr(response.content, "html", "lang", "en")
         self.assertEqual(response['Content-Language'], 'en')
-        self.assertTrue(re.search('<body.*class=".*lang_en">', response.content))
+        self.assert_tag_has_attr(response.content, "body", "class", "lang_en")
 
     def test_esperanto(self):
         response = self.client.get('/', HTTP_ACCEPT_LANGUAGE='eo')
-        self.assertIn('<html lang="eo">', response.content)
+        self.assert_tag_has_attr(response.content, "html", "lang", "eo")
         self.assertEqual(response['Content-Language'], 'eo')
-        self.assertTrue(re.search('<body.*class=".*lang_eo">', response.content))
+        self.assert_tag_has_attr(response.content, "body", "class", "lang_eo")
+
+    def test_switching_languages_bidi(self):
+        response = self.client.get('/')
+        self.assert_tag_has_attr(response.content, "html", "lang", "en")
+        self.assertEqual(response['Content-Language'], 'en')
+        self.assert_tag_has_attr(response.content, "body", "class", "lang_en")
+        self.assert_tag_has_attr(response.content, "body", "class", "ltr")
+
+        response = self.client.get('/', HTTP_ACCEPT_LANGUAGE='ar')
+        self.assert_tag_has_attr(response.content, "html", "lang", "ar")
+        self.assertEqual(response['Content-Language'], 'ar')
+        self.assert_tag_has_attr(response.content, "body", "class", "lang_ar")
+        self.assert_tag_has_attr(response.content, "body", "class", "rtl")

--- a/lms/templates/certificates/certificate-base.html
+++ b/lms/templates/certificates/certificate-base.html
@@ -1,17 +1,15 @@
+<%namespace name='static' file='/static_content.html'/>
 <%! from django.utils.translation import ugettext as _ %>
 <%! import mako.runtime %>
 <% mako.runtime.UNDEFINED = '' %>
 
 <%
-    # set doc language direction
-    from django.utils.translation import get_language_bidi
-    dir_rtl = 'rtl' if get_language_bidi() else 'ltr'
     document_body_class = document_body_class_append if document_body_class_append else ''
 %>
 
 <!DOCTYPE html>
 <html class="no-js" lang="en">
-    <head dir=-"${dir_rtl}">
+    <head dir=-"${static.dir_rtl()}">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -21,7 +19,7 @@
         <%include file="_assets-primary.html" />
     </head>
 
-    <body class="view-certificate view-valid-certificate ${dir_rtl} ${document_body_class}" data-view="valid-certificate">
+    <body class="view-certificate view-valid-certificate ${static.dir_rtl()} ${document_body_class}" data-view="valid-certificate">
 
         <div class="wrapper-view">
             ${self.body()}

--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -4,17 +4,14 @@
 from django.core.urlresolvers import reverse
 from django.utils.http import urlquote_plus
 from django.utils.translation import ugettext as _
-from django.utils.translation import get_language_bidi
 from microsite_configuration import microsite
 from microsite_configuration import page_title_breadcrumbs
 from branding import api as branding_api
-
-dir_rtl = 'rtl' if get_language_bidi() else 'ltr'
 %>
 <!DOCTYPE html>
 <!--[if lte IE 9]><html class="ie ie9 lte9" lang="${LANGUAGE_CODE}"><![endif]-->
 <!--[if !IE]><!--><html lang="${LANGUAGE_CODE}"><!--<![endif]-->
-<head dir="${dir_rtl}">
+<head dir="${static.dir_rtl()}">
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     % if responsive:
@@ -131,8 +128,8 @@ dir_rtl = 'rtl' if get_language_bidi() else 'ltr'
 
 </head>
 
-<body class="${dir_rtl} <%block name='bodyclass'/> lang_${LANGUAGE_CODE}">
-  <div class="window-wrap" dir="${dir_rtl}">
+<body class="${static.dir_rtl()} <%block name='bodyclass'/> lang_${LANGUAGE_CODE}">
+  <div class="window-wrap" dir="${static.dir_rtl()}">
     <a class="nav-skip" href="<%block name="nav_skip">#content</%block>">${_("Skip to main content")}</a>
 
     % if not disable_header:


### PR DESCRIPTION
The old code would compute the RTL setting when the Mako template was
first loaded (on import).  Now we compute it in a function called each
time the template is rendered.  This gives the correct result when the
language is changing.
