### PR TITLE
BUGFIX: CCX Font Awesome icon name fixes

### DIFF
--- a/lms/templates/ccx/enrollment.html
+++ b/lms/templates/ccx/enrollment.html
@@ -65,7 +65,7 @@
             <tr>
               <td>${member.student}</td>
               <td>${member.student.email}</td>
-              <td><div class="revoke"><i class="icon-remove-sign"></i> Revoke access</div></td>
+              <td><div class="revoke"><i class="fa fa-times-circle"></i> Revoke access</div></td>
             </tr>
             %endfor
           </tbody>

--- a/lms/templates/ccx/grading_policy.html
+++ b/lms/templates/ccx/grading_policy.html
@@ -2,7 +2,7 @@
 
 <div id="warn-coach" class="wrapper-msg urgency-high warning">
   <div class="msg">
-    <i class="msg-icon icon-warning-sign"></i>
+    <i class="msg-icon fa fa-warning"></i>
     <div class="msg-content">
       <h3 class="title">${_("WARNING")}</h3>
       <div class="copy">


### PR DESCRIPTION
BUGFIX: a few icons were converted incorrectly to FA4...
- ~~course-about sidebar info icon -> correct icon: "fa-info-circle"~~
- ccx enrollment remove icon -> correct icon: "fa-times-circle"
- ccx grading policy warning -> correct icon: "fa-warning"
- ~~wiki search add file -> correct icon: "fa-plus-circle"~~
- ~~wiki history paragraph info -> correct icon: "fa-info-circle"~~

@talbs 
