### PR TITLE
Allow course creation after deletion at same URL

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -1101,6 +1101,17 @@ class ContentStoreTest(ContentStoreTestCase):
         self.assertFalse(instructor_role.has_user(self.user))
         self.assertEqual(len(instructor_role.users_with_role()), 0)
 
+    def test_create_course_after_delete(self):
+        """
+        Test that course creation works after deleting a course with the same URL
+        """
+        test_course_data = self.assert_created_course()
+        course_id = _get_course_id(self.store, test_course_data)
+
+        delete_course_and_groups(course_id, self.user.id)
+
+        self.assert_created_course()
+
     def test_create_course_duplicate_course(self):
         """Test new course creation - error path"""
         self.client.ajax_post('/course/', self.course_data)

--- a/common/lib/xmodule/xmodule/modulestore/mixed.py
+++ b/common/lib/xmodule/xmodule/modulestore/mixed.py
@@ -586,7 +586,7 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
         """
         # first make sure an existing course doesn't already exist in the mapping
         course_key = self.make_course_key(org, course, run)
-        if course_key in self.mappings:
+        if course_key in self.mappings and self.mappings[course_key].has_course(course_key):
             raise DuplicateCourseError(course_key, course_key)
 
         # create the course


### PR DESCRIPTION
After deleting a course, creating one with the same URL did not work because its mapping is not removed from the modulestore. This fix adds a more robust check to see if a course with the URL
actually exists.

To verify, create a course in studio, then delete it through the sysadmin dashboard or management command. Then when you go to create a course at the same URL, it will error saying a course already exists.

Possibly related to https://openedx.atlassian.net/browse/PLAT-442, @carsongee 
