### PR TITLE
WIP: Made UserPartitionList advertise itself as immutable to the XBlock API.

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/inheritance.py
+++ b/common/lib/xmodule/xmodule/modulestore/inheritance.py
@@ -18,6 +18,8 @@ _ = lambda text: text
 
 class UserPartitionList(List):
     """Special List class for listing UserPartitions"""
+    MUTABLE=False
+
     def from_json(self, values):
         return [UserPartition.from_json(v) for v in values]
 

--- a/lms/djangoapps/courseware/access.py
+++ b/lms/djangoapps/courseware/access.py
@@ -199,7 +199,7 @@ def _has_access_course_desc(user, action, course):
         else:
             reg_method_ok = True  # if not using this access check, it's always OK.
 
-        now = datetime.now(UTC())
+        now = datetime.now(pytz.UTC)
         start = course.enrollment_start or datetime.min.replace(tzinfo=pytz.UTC)
         end = course.enrollment_end or datetime.max.replace(tzinfo=pytz.UTC)
 
@@ -391,7 +391,6 @@ def _has_group_access(descriptor, user, course_key):
     # all checks passed.
     return True
 
-
 def _has_access_descriptor(user, action, descriptor, course_key=None):
     """
     Check if user has access to this descriptor.
@@ -427,7 +426,8 @@ def _has_access_descriptor(user, action, descriptor, course_key=None):
 
         # Check start date
         if 'detached' not in descriptor._class_tags and descriptor.start is not None:
-            now = datetime.now(UTC())
+            now = datetime.now(pytz.UTC)
+            logging.debug("Can load: {}".format(descriptor.location))
             effective_start = _adjust_start_date_for_beta_testers(
                 user,
                 descriptor,


### PR DESCRIPTION
@cpennington, @nasthagiri 

This isn't acceptable as-is, I only put it up to start a discussion. I ran pyinstruments with `PYINSTRUMENT_USE_SIGNAL = False` in settings, to get more accurate numbers. One of the things that stood out was that we spent a lot of time doing deepcopy() because `user_partitions` is defined as a mutable field and thus gets copied on read. Which we shouldn't really be worrying about on the LMS anyway as that scope is not even writable. That being said, what do you think about making it a tuple instead of a list? A little more expensive to write to, but it would mean we wouldn't have to worry about mutation and could skip the defensive copy.

Index page on the MRev course locally:

```
Before:

1.740
1.772
1.605
1.754
1.567

After:

1.481
1.584
1.464
1.621
1.459
```

So not earth-shattering, but measurable.
