### PR TITLE
use reverification xblock location as an identifier of reverification…

### DIFF
--- a/lms/djangoapps/verify_student/admin.py
+++ b/lms/djangoapps/verify_student/admin.py
@@ -23,9 +23,9 @@ class VerificationStatusAdmin(admin.ModelAdmin):
     """
     Admin for the VerificationStatus table.
     """
-    list_display = ('timestamp', 'user', 'status', 'checkpoint', 'location_id')
+    list_display = ('timestamp', 'user', 'status', 'checkpoint')
     readonly_fields = ()
-    search_fields = ('checkpoint', 'user')
+    search_fields = ('checkpoint__checkpoint_location', 'user__username')
 
     def get_readonly_fields(self, request, obj=None):
         """When editing an existing record, all fields should be read-only.
@@ -36,7 +36,7 @@ class VerificationStatusAdmin(admin.ModelAdmin):
 
         """
         if obj:
-            return self.readonly_fields + ('status', 'checkpoint', 'user', 'location_id', 'response', 'error')
+            return self.readonly_fields + ('status', 'checkpoint', 'user', 'response', 'error')
         return self.readonly_fields
 
     def has_delete_permission(self, request, obj=None):
@@ -48,7 +48,7 @@ class SkippedReverificationAdmin(admin.ModelAdmin):
     """Admin for the SkippedReverification table. """
     list_display = ('created_at', 'user', 'course_id', 'checkpoint')
     readonly_fields = ('user', 'course_id')
-    search_fields = ('user', 'course_id', 'checkpoint')
+    search_fields = ('user__username', 'course_id', 'checkpoint__checkpoint_location')
 
     def has_add_permission(self, request):
         """Skipped verifications can't be created in Django admin. """

--- a/lms/djangoapps/verify_student/migrations/0008_auto__del_field_verificationcheckpoint_checkpoint_name__add_field_veri.py
+++ b/lms/djangoapps/verify_student/migrations/0008_auto__del_field_verificationcheckpoint_checkpoint_name__add_field_veri.py
@@ -1,0 +1,153 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Removing unique constraint on 'VerificationCheckpoint', fields ['course_id', 'checkpoint_name']
+        db.delete_unique('verify_student_verificationcheckpoint', ['course_id', 'checkpoint_name'])
+
+        # Deleting field 'VerificationCheckpoint.checkpoint_name'
+        db.delete_column('verify_student_verificationcheckpoint', 'checkpoint_name')
+
+        # Adding field 'VerificationCheckpoint.checkpoint_location'
+        db.add_column('verify_student_verificationcheckpoint', 'checkpoint_location',
+                      self.gf('django.db.models.fields.CharField')(default='', max_length=255),
+                      keep_default=False)
+
+        # Adding unique constraint on 'VerificationCheckpoint', fields ['course_id', 'checkpoint_location']
+        db.create_unique('verify_student_verificationcheckpoint', ['course_id', 'checkpoint_location'])
+
+        # Deleting field 'VerificationStatus.location_id'
+        db.delete_column('verify_student_verificationstatus', 'location_id')
+
+
+    def backwards(self, orm):
+        # Removing unique constraint on 'VerificationCheckpoint', fields ['course_id', 'checkpoint_location']
+        db.delete_unique('verify_student_verificationcheckpoint', ['course_id', 'checkpoint_location'])
+
+
+        # User chose to not deal with backwards NULL issues for 'VerificationCheckpoint.checkpoint_name'
+        raise RuntimeError("Cannot reverse this migration. 'VerificationCheckpoint.checkpoint_name' and its values cannot be restored.")
+        
+        # The following code is provided here to aid in writing a correct migration        # Adding field 'VerificationCheckpoint.checkpoint_name'
+        db.add_column('verify_student_verificationcheckpoint', 'checkpoint_name',
+                      self.gf('django.db.models.fields.CharField')(max_length=32),
+                      keep_default=False)
+
+        # Deleting field 'VerificationCheckpoint.checkpoint_location'
+        db.delete_column('verify_student_verificationcheckpoint', 'checkpoint_location')
+
+        # Adding unique constraint on 'VerificationCheckpoint', fields ['course_id', 'checkpoint_name']
+        db.create_unique('verify_student_verificationcheckpoint', ['course_id', 'checkpoint_name'])
+
+        # Adding field 'VerificationStatus.location_id'
+        db.add_column('verify_student_verificationstatus', 'location_id',
+                      self.gf('django.db.models.fields.CharField')(max_length=255, null=True, blank=True),
+                      keep_default=False)
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'reverification.midcoursereverificationwindow': {
+            'Meta': {'object_name': 'MidcourseReverificationWindow'},
+            'course_id': ('xmodule_django.models.CourseKeyField', [], {'max_length': '255', 'db_index': 'True'}),
+            'end_date': ('django.db.models.fields.DateTimeField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'start_date': ('django.db.models.fields.DateTimeField', [], {'default': 'None', 'null': 'True', 'blank': 'True'})
+        },
+        'verify_student.incoursereverificationconfiguration': {
+            'Meta': {'object_name': 'InCourseReverificationConfiguration'},
+            'change_date': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'changed_by': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']", 'null': 'True', 'on_delete': 'models.PROTECT'}),
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'verify_student.skippedreverification': {
+            'Meta': {'unique_together': "(('user', 'course_id'),)", 'object_name': 'SkippedReverification'},
+            'checkpoint': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'skipped_checkpoint'", 'to': "orm['verify_student.VerificationCheckpoint']"}),
+            'course_id': ('xmodule_django.models.CourseKeyField', [], {'max_length': '255', 'db_index': 'True'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"})
+        },
+        'verify_student.softwaresecurephotoverification': {
+            'Meta': {'ordering': "['-created_at']", 'object_name': 'SoftwareSecurePhotoVerification'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'display': ('django.db.models.fields.BooleanField', [], {'default': 'True', 'db_index': 'True'}),
+            'error_code': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'error_msg': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'face_image_url': ('django.db.models.fields.URLField', [], {'max_length': '255', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'photo_id_image_url': ('django.db.models.fields.URLField', [], {'max_length': '255', 'blank': 'True'}),
+            'photo_id_key': ('django.db.models.fields.TextField', [], {'max_length': '1024'}),
+            'receipt_id': ('django.db.models.fields.CharField', [], {'default': "'4ae40fdd-c39a-4a23-a593-41beec90013b'", 'max_length': '255', 'db_index': 'True'}),
+            'reviewing_service': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'reviewing_user': ('django.db.models.fields.related.ForeignKey', [], {'default': 'None', 'related_name': "'photo_verifications_reviewed'", 'null': 'True', 'to': "orm['auth.User']"}),
+            'status': ('model_utils.fields.StatusField', [], {'default': "'created'", 'max_length': '100', u'no_check_for_status': 'True'}),
+            'status_changed': ('model_utils.fields.MonitorField', [], {'default': 'datetime.datetime.now', u'monitor': "u'status'"}),
+            'submitted_at': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'db_index': 'True'}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"}),
+            'window': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['reverification.MidcourseReverificationWindow']", 'null': 'True'})
+        },
+        'verify_student.verificationcheckpoint': {
+            'Meta': {'unique_together': "(('course_id', 'checkpoint_location'),)", 'object_name': 'VerificationCheckpoint'},
+            'checkpoint_location': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'course_id': ('xmodule_django.models.CourseKeyField', [], {'max_length': '255', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'photo_verification': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['verify_student.SoftwareSecurePhotoVerification']", 'symmetrical': 'False'})
+        },
+        'verify_student.verificationstatus': {
+            'Meta': {'object_name': 'VerificationStatus'},
+            'checkpoint': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'checkpoint_status'", 'to': "orm['verify_student.VerificationCheckpoint']"}),
+            'error': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'response': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'status': ('django.db.models.fields.CharField', [], {'max_length': '32', 'db_index': 'True'}),
+            'timestamp': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"})
+        }
+    }
+
+    complete_apps = ['verify_student']

--- a/lms/djangoapps/verify_student/services.py
+++ b/lms/djangoapps/verify_student/services.py
@@ -9,6 +9,7 @@ from django.core.urlresolvers import reverse
 from django.db import IntegrityError
 
 from opaque_keys.edx.keys import CourseKey
+
 from verify_student.models import VerificationCheckpoint, VerificationStatus, SkippedReverification
 
 
@@ -20,19 +21,19 @@ class ReverificationService(object):
     Reverification XBlock service
     """
 
-    def get_status(self, user_id, course_id, related_assessment):
-        """
-        Get verification attempt status against a user for a given 'checkpoint'
-        and 'course_id'.
+    def get_status(self, user_id, course_id, related_assessment_location):
+        """Get verification attempt status against a user for a given
+        'checkpoint' and 'course_id'.
 
         Args:
             user_id(str): User Id string
             course_id(str): A string of course id
-            related_assessment(str): Verification checkpoint name
+            related_assessment_location(str): Location of Reverification XBlock
 
         Returns:
-            "skipped" if has skip the re-verification or Verification Status string if
-            any attempt submitted by user else None
+            "skipped" if the user has skipped the re-verification or
+            Verification Status string if the user has submitted photo
+            verification attempt else None
         """
         course_key = CourseKey.from_string(course_id)
         has_skipped = SkippedReverification.check_user_skipped_reverification_exists(user_id, course_key)
@@ -42,69 +43,73 @@ class ReverificationService(object):
             checkpoint_status = VerificationStatus.objects.filter(
                 user_id=user_id,
                 checkpoint__course_id=course_key,
-                checkpoint__checkpoint_name=related_assessment
+                checkpoint__checkpoint_location=related_assessment_location
             ).latest()
             return checkpoint_status.status
         except ObjectDoesNotExist:
             return None
 
-    def start_verification(self, course_id, related_assessment, item_id):
-        """
-        Create re-verification link against a verification checkpoint.
+    def start_verification(self, course_id, related_assessment_location):
+        """Create re-verification link against a verification checkpoint.
 
         Args:
             course_id(str): A string of course id
-            related_assessment(str): Verification checkpoint name
+            related_assessment_location(str): Location of Reverification XBlock
 
         Returns:
             Re-verification link
         """
         course_key = CourseKey.from_string(course_id)
-        VerificationCheckpoint.objects.get_or_create(course_id=course_key, checkpoint_name=related_assessment)
+        VerificationCheckpoint.objects.get_or_create(
+            course_id=course_key,
+            checkpoint_location=related_assessment_location
+        )
+
         re_verification_link = reverse(
             'verify_student_incourse_reverify',
             args=(
                 unicode(course_key),
-                unicode(related_assessment),
-                unicode(item_id)
+                unicode(related_assessment_location)
             )
         )
         return re_verification_link
 
-    def skip_verification(self, checkpoint_name, user_id, course_id):
-        """
-        Add skipped verification attempt entry against a given 'checkpoint'
+    def skip_verification(self, user_id, course_id, related_assessment_location):
+        """Add skipped verification attempt entry for a user against a given
+        'checkpoint'.
 
         Args:
-            checkpoint_name(str): Verification checkpoint name
             user_id(str): User Id string
             course_id(str): A string of course_id
+            related_assessment_location(str): Location of Reverification XBlock
 
         Returns:
             None
         """
         course_key = CourseKey.from_string(course_id)
-        checkpoint = VerificationCheckpoint.objects.get(course_id=course_key, checkpoint_name=checkpoint_name)
+        checkpoint = VerificationCheckpoint.objects.get(
+            course_id=course_key,
+            checkpoint_location=related_assessment_location
+        )
 
-        # if user do not already skipped the attempt for this course only then he can skip
+        # user can skip a reverification attempt only if that user has not already
+        # skipped an attempt
         try:
             SkippedReverification.add_skipped_reverification_attempt(checkpoint, user_id, course_key)
         except IntegrityError:
             log.exception("Skipped attempt already exists for user %s: with course %s:", user_id, unicode(course_id))
 
-    def get_attempts(self, user_id, course_id, related_assessment, location_id):
-        """
-        Get re-verification attempts against a user for a given 'checkpoint'
+    def get_attempts(self, user_id, course_id, related_assessment_location):
+        """Get re-verification attempts against a user for a given 'checkpoint'
         and 'course_id'.
 
         Args:
             user_id(str): User Id string
             course_id(str): A string of course id
-            related_assessment(str): Verification checkpoint name
-            location_id(str): Location of Reverification XBlock in courseware
+            related_assessment_location(str): Location of Reverification XBlock
 
         Returns:
             Number of re-verification attempts of a user
         """
         course_key = CourseKey.from_string(course_id)
-        return VerificationStatus.get_user_attempts(user_id, course_key, related_assessment, location_id)
+        return VerificationStatus.get_user_attempts(user_id, course_key, related_assessment_location)

--- a/lms/djangoapps/verify_student/urls.py
+++ b/lms/djangoapps/verify_student/urls.py
@@ -116,9 +116,8 @@ urlpatterns = patterns(
     # Users are sent to this end-point from within courseware
     # to re-verify their identities by re-submitting face photos.
     url(
-        r'^reverify/{course_id}/{checkpoint}/{usage_id}/$'.format(
+        r'^reverify/{course_id}/{usage_id}/$'.format(
             course_id=settings.COURSE_ID_PATTERN,
-            checkpoint=settings.CHECKPOINT_PATTERN,
             usage_id=settings.USAGE_ID_PATTERN
         ),
         views.InCourseReverifyView.as_view(),

--- a/lms/static/js/verify_student/incourse_reverify.js
+++ b/lms/static/js/verify_student/incourse_reverify.js
@@ -20,7 +20,6 @@
 
     return new edx.verify_student.InCourseReverifyView({
         courseKey: el.data('course-key'),
-        checkpointName: el.data('checkpoint-name'),
         platformName: el.data('platform-name'),
         usageId: el.data('usage-id'),
         errorModel: errorView.model

--- a/lms/static/js/verify_student/models/reverification_model.js
+++ b/lms/static/js/verify_student/models/reverification_model.js
@@ -16,7 +16,6 @@ var edx = edx || {};
 
         defaults: {
             courseKey: '',
-            checkpointName: '',
             faceImage: '',
             usageId: ''
         },
@@ -28,9 +27,8 @@ var edx = edx || {};
                     face_image: model.get( 'faceImage' )
                 },
                 url = _.str.sprintf(
-                    '/verify_student/reverify/%(courseKey)s/%(checkpointName)s/%(usageId)s/', {
+                    '/verify_student/reverify/%(courseKey)s/%(usageId)s/', {
                         courseKey: model.get('courseKey'),
-                        checkpointName: model.get('checkpointName'),
                         usageId: model.get('usageId')
                     }
                 );

--- a/lms/static/js/verify_student/views/incourse_reverify_view.js
+++ b/lms/static/js/verify_student/views/incourse_reverify_view.js
@@ -26,14 +26,12 @@
 
             this.errorModel = obj.errorModel || null;
             this.courseKey = obj.courseKey || null;
-            this.checkpointName = obj.checkpointName || null;
             this.platformName = obj.platformName || null;
             this.usageId = obj.usageId || null;
 
 
             this.model = new edx.verify_student.ReverificationModel({
                 courseKey: this.courseKey,
-                checkpointName: this.checkpointName,
                 usageId: this.usageId
             });
 
@@ -47,7 +45,6 @@
                 $( this.templateId ).html(),
                 {
                     courseKey: this.courseKey,
-                    checkpointName: this.checkpointName,
                     platformName: this.platformName
                 }
             );

--- a/lms/templates/verify_student/incourse_reverify.html
+++ b/lms/templates/verify_student/incourse_reverify.html
@@ -43,7 +43,6 @@ from verify_student.views import PayAndVerifyView
     <div id="incourse-reverify-container"
     class="incourse-reverify"
     data-course-key='${course_key}'
-    data-checkpoint-name='${checkpoint_name}'
     data-platform-name='${platform_name}'
     data-usage-id='${usage_id}'
   ></div>

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -50,7 +50,7 @@ git+https://github.com/hmarr/django-debug-toolbar-mongo.git@b0686a76f1ce3532088c
 git+https://github.com/edx/edx-lint.git@8bf82a32ecb8598c415413df66f5232ab8d974e9#egg=edx_lint==0.2.1
 -e git+https://github.com/edx/xblock-utils.git@db22bc40fd2a75458a3c66d057f88aff5a7383e6#egg=xblock-utils
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
--e git+https://github.com/edx/edx-reverification-block.git@2ff0d21f6614874067168bd244e68d8215041f3b#egg=edx-reverification-block
+-e git+https://github.com/edx/edx-reverification-block.git@03da85753d5f563a22c1282c0e89fcb2e828b8c1#egg=edx-reverification-block
 git+https://github.com/edx/ecommerce-api-client.git@1.0.0#egg=ecommerce-api-client==1.0.0
 
 # Third Party XBlocks


### PR DESCRIPTION
… checkpoint

ECOM-1612

@awais786 @aamir-khan @ahsan-ul-haq 
- Remove `checkpoint_name` field from `VerificationCheckpoint` model and add `checkpoint_location` field to store `reverification` XBlock's location in courseware [migration added].
- Use `reverification` XBlock's location in courseware as a unique identifier for reverification checkpoints instead of `related_assessment` (checkpoints name).
- Update views and methods accordingly

**Note:** The database migration added for removing `location_id` field from `VerificationStatus` model, removing `checkpoint_name` field and adding `checkpoint_location` field in `VerificationCheckpoint` model is not backward compatible (cannot go back to previous migrations state). 
We are assuming that this is the default state of reverification models as there is not actual related data in database.

_This PR will also depend on changes in edx reverification block's repo: https://github.com/edx/edx-reverification-block/pull/32 [Merged]_
