### PR TITLE
Allow specification of ReadPreference via DOC_STORE_CONFIG, and use a…

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -255,6 +255,15 @@ DATABASES = AUTH_TOKENS['DATABASES']
 MODULESTORE = convert_module_store_setting_if_needed(AUTH_TOKENS.get('MODULESTORE', MODULESTORE))
 CONTENTSTORE = AUTH_TOKENS['CONTENTSTORE']
 DOC_STORE_CONFIG = AUTH_TOKENS['DOC_STORE_CONFIG']
+
+try:
+    from pymongo import ReadPreference
+except ImportError:
+    pass
+else:
+    if 'read_preference' in DOC_STORE_CONFIG:
+        DOC_STORE_CONFIG = getattr(ReadPreference, DOC_STORE_CONFIG['read_preference'])
+
 # Datadog for events!
 DATADOG = AUTH_TOKENS.get("DATADOG", {})
 DATADOG.update(ENV_TOKENS.get("DATADOG", {}))

--- a/common/lib/xmodule/xmodule/contentstore/mongo.py
+++ b/common/lib/xmodule/xmodule/contentstore/mongo.py
@@ -27,7 +27,7 @@ class MongoContentStore(ContentStore):
         """
         logging.debug('Using MongoDB for static content serving at host={0} port={1} db={2}'.format(host, port, db))
         _db = pymongo.database.Database(
-            pymongo.MongoClient(
+            pymongo.MongoReplicaSetClient(
                 host=host,
                 port=port,
                 document_class=dict,

--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -554,7 +554,7 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
             """
             self.database = MongoProxy(
                 pymongo.database.Database(
-                    pymongo.MongoClient(
+                    pymongo.MongoReplicaSetClient(
                         host=host,
                         port=port,
                         tz_aware=tz_aware,

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/mongo_connection.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/mongo_connection.py
@@ -83,7 +83,7 @@ class MongoConnection(object):
         """
         self.database = MongoProxy(
             pymongo.database.Database(
-                pymongo.MongoClient(
+                pymongo.MongoReplicaSetClient(
                     host=host,
                     port=port,
                     tz_aware=tz_aware,

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_mixed_modulestore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_mixed_modulestore.py
@@ -140,7 +140,7 @@ class CommonMixedModuleStoreSetup(CourseComparisonTest):
         self.ignore_asset_key('thumbnail_location')
 
         self.options = getattr(self, 'options', self.OPTIONS)
-        self.connection = pymongo.MongoClient(
+        self.connection = pymongo.MongoReplicaSetClient(
             host=self.HOST,
             port=self.PORT,
             tz_aware=True,

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_mongo.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_mongo.py
@@ -78,7 +78,7 @@ class TestMongoModuleStoreBase(unittest.TestCase):
 
     @classmethod
     def setupClass(cls):
-        cls.connection = pymongo.MongoClient(
+        cls.connection = pymongo.MongoReplicaSetClient(
             host=HOST,
             port=PORT,
             tz_aware=True,

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -403,6 +403,15 @@ XQUEUE_INTERFACE = AUTH_TOKENS['XQUEUE_INTERFACE']
 MODULESTORE = convert_module_store_setting_if_needed(AUTH_TOKENS.get('MODULESTORE', MODULESTORE))
 CONTENTSTORE = AUTH_TOKENS.get('CONTENTSTORE', CONTENTSTORE)
 DOC_STORE_CONFIG = AUTH_TOKENS.get('DOC_STORE_CONFIG', DOC_STORE_CONFIG)
+
+try:
+    from pymongo import ReadPreference
+except ImportError:
+    pass
+else:
+    if 'read_preference' in DOC_STORE_CONFIG:
+        DOC_STORE_CONFIG = getattr(ReadPreference, DOC_STORE_CONFIG['read_preference'])
+
 MONGODB_LOG = AUTH_TOKENS.get('MONGODB_LOG', {})
 
 OPEN_ENDED_GRADING_INTERFACE = AUTH_TOKENS.get('OPEN_ENDED_GRADING_INTERFACE',


### PR DESCRIPTION
… MongoReplicaSetClient for modulestore

This lets us set a `read_preference` key in `DOC_STORE_CONFIG` via `aws.py`, and loads the correct python value from `pymongo.ReadPreferences` via `getattr`.

The goal is to allow us to distribute document reads to secondaries.
