### PR TITLE
Fix bug when student scoring error occurs with no message.

### DIFF
--- a/lms/djangoapps/instructor_task/tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tasks_helper.py
@@ -798,8 +798,11 @@ def upload_problem_grade_report(_xmodule_instance_args, _entry_id, course_id, _t
         student_fields = [getattr(student, field_name) for field_name in header_row]
         task_progress.attempted += 1
 
-        if err_msg:
+        if 'percent' not in gradeset or 'raw_scores' not in gradeset:
             # There was an error grading this student.
+            # Generally there will be a non-empty err_msg, but that is not always the case.
+            if not err_msg:
+                err_msg = u"Unknown error"
             error_rows.append(student_fields + [err_msg])
             task_progress.failed += 1
             continue

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -441,6 +441,7 @@ class TestInstructorDetailedEnrollmentReport(TestReportMixin, InstructorTaskCour
                     self.assertEqual(row[column_header], expected_cell_content)
 
 
+@ddt.ddt
 class TestProblemGradeReport(TestReportMixin, InstructorTaskModuleTestCase):
     """
     Test that the problem CSV generation works.
@@ -510,14 +511,14 @@ class TestProblemGradeReport(TestReportMixin, InstructorTaskModuleTestCase):
 
     @patch('instructor_task.tasks_helper._get_current_task')
     @patch('instructor_task.tasks_helper.iterate_grades_for')
-    def test_grading_failure(self, mock_iterate_grades_for, _mock_current_task):
+    @ddt.data(u'Cannöt grade student', '')
+    def test_grading_failure(self, error_message, mock_iterate_grades_for, _mock_current_task):
         """
         Test that any grading errors are properly reported in the progress
         dict and uploaded to the report store.
         """
         # mock an error response from `iterate_grades_for`
         student = self.create_student(u'username', u'student@example.com')
-        error_message = u'Cannöt grade student'
         mock_iterate_grades_for.return_value = [
             (student, {}, error_message)
         ]
@@ -531,7 +532,7 @@ class TestProblemGradeReport(TestReportMixin, InstructorTaskModuleTestCase):
                 u'Student ID': unicode(student.id),
                 u'Email': student.email,
                 u'Username': student.username,
-                u'error_msg': error_message
+                u'error_msg': error_message if error_message else "Unknown error"
             }
         ])
 


### PR DESCRIPTION
TNL-2251

@dan-f and @dianakhuang please review

The only thing I can imagine is that exc.message may be "falsely" in some scenario(s) on the line of code below. I don't have reproduction steps to verify this, but it would produce the failure seen.

https://github.com/edx/edx-platform/blob/master/lms/djangoapps/courseware/grades.py#L552
