### PR TITLE
Add evidence_link analytics event. (SOL-881)

### DIFF
--- a/lms/djangoapps/certificates/tests/test_badge_handler.py
+++ b/lms/djangoapps/certificates/tests/test_badge_handler.py
@@ -155,7 +155,7 @@ class BadgeHandlerTestCase(ModuleStoreTestCase, EventTrackingTestCase):
         self.assertTrue(BadgeHandler.badges['edxcourse_testtest_run_honor_fc5519b'])
 
     @patch('requests.post')
-    def test_create_assertion(self, post):
+    def test_evidence_event(self, post):
         result = {
             'json': {'id': 'http://www.example.com/example'},
             'image': 'http://www.example.com/example.png',
@@ -174,7 +174,10 @@ class BadgeHandlerTestCase(ModuleStoreTestCase, EventTrackingTestCase):
             'edxcourse_testtest_run_honor_fc5519b/assertions'
         )
         self.check_headers(kwargs['headers'])
-        self.assertEqual(kwargs['data'], {'email': 'example@example.com'})
+        self.assertEqual(kwargs['data'], {
+            'email': 'example@example.com',
+            'evidence': 'https://edx.org/user/2/course/edX/course_test/test_run?evidence_visit=1'
+        })
         badge = BadgeAssertion.objects.get(user=self.user, course_id=self.course.location.course_key)
         self.assertEqual(badge.data, result)
         self.assertEqual(badge.image_url, 'http://www.example.com/example.png')


### PR DESCRIPTION
**Background**: This PR contains the remaining currently planned Analytics event on OpenBadges.
Jira tickets: Implements [SOL-881](https://openedx.atlassian.net/browse/SOL-881)
Discussions: [Events design spec](https://openedx.atlassian.net/wiki/display/AN/Digital+Badging+Activity+Event+Design)
Partner information: 3rd party-hosted open edX instance, for an edX solutions client.
Dependencies: https://github.com/edx/edx-platform/pull/7882

Example event edx.badges.assertion.evidence_visit:

```
{
  "username": "honor",
  "event_source": "server",
  "name": "edx.badges.assertion.evidence_visit",
  "accept_language": "en-US,en;q=0.5",
  "time": "2015-05-28T23:12:35.874998+00:00",
  "agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:29.0) Gecko/20100101 Firefox/29.0",
  "page": null,
  "host": "192.168.33.10",
  "session": "b3891aed3c8c41f1c5a97cda203e30a8",
  "referer": "",
  "context": {
    "user_id": 1,
    "org_id": "",
    "course_id": "",
    "path": "/user/1/course/course-v1:edX+DemoX+Demo_Course/"
  },
  "ip": "127.0.0.1",
  "event": {
    "enrollment_mode": "honor",
    "user_id": 1,
    "assertion_json_url": "http://localhost:8005/public/assertions/43f3283f-aeeb-49f8-8128-822b61359600",
    "assertion_image_url": "http://localhost:8005/media/issued/598d5918985091e3338ce924d2dd8ab7.png",
    "assertion_id": 2,
    "course_id": "course-v1:edX+DemoX+Demo_Course",
    "issuer": "http://example.com/public/issuers/test-issuer"
  },
  "event_type": "edx.badges.assertion.evidence_visit"
}
```
