### PR TITLE
MIT CCX add ccx-keys as a dependency of edx

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -28,6 +28,8 @@ git+https://github.com/mfogel/django-settings-context-processor.git@b758c3930862
 git+https://github.com/pmitros/pyfs.git@96e1922348bfe6d99201b9512a9ed946c87b7e0b
 # The officially released version of django-debug-toolbar-mongo doesn't support DJDT 1.x. This commit does.
 git+https://github.com/hmarr/django-debug-toolbar-mongo.git@b0686a76f1ce3532088c4aee6e76b9abe61cc808
+# custom opaque-key implementations for ccx
+-e git+https://github.com/jazkarta/ccx-keys.git@e6b03704b1bb97c1d2f31301ecb4e3a687c536ea#egg=ccx-keys
 
 # Our libraries:
 -e git+https://github.com/edx/XBlock.git@e1831fa86bff778ffe1308e00d8ed51b26f7c047#egg=XBlock


### PR DESCRIPTION
This PR adds a dependency to the edx-platform repository on a newly created package [`ccx-keys`](https://github.com/jazkarta/ccx-keys), an implementation of opaque-keys for the Custom Course for EdX extension first accepted into edx in https://github.com/edx/edx-platform/pull/6636
### History

The request to implement custom opaque keys for ccx was first brought up in an architecture review of the PR referenced above.  It was felt that using such keys would allow ccx to better integrate with existing logging and analytics systems.  The outcome of this conversation was captured in jazkarta/edx-platform#43 

Work on implementing the package itself has been undertaken with attention from @cpennington.  It was approved and has been managed by @pdpinch of MIT.  @nedbat and @ormsbee have also been pulled into discussions around bugs and implementation details.

As this pull request adds a new dependency to the edx-platform repository, we would also like to beg the attention of @mollydb and @e0d.
### Impacts

As it stands, this change will impact no-one.  The keys themselves are not yet used in the CCX code in edx-platform.  This PR is intended as a prelude to a coming PR where the change over to using ccx-keys will be implemented.  

Once implemented the changes will be limited to the LMS.  The only user-visible changes will be the presence of ccx identifiers in split-mongo compatible URLs.  As ccx is only currently released to edge, the effects will only be felt there.  
### Testing

The only  manual test possible for this change is to install the dependencies of edx-platform and verify that the package is downloaded.  There should be no change whatsoever in functionality at this stage.  All functions and features of EdX, both in studio and lms should continue to work exactly as before.
### Urgency

As a second pull request with the changes to CCX implementing the use of ccx-keys is anticipated during the weekend (5/31/2015), it would be good to have this PR land as soon as possible to simplify the review of that work.  
