### PR TITLE
Add CCX SQL query/Mongo read tests

### DIFF
--- a/common/djangoapps/request_cache/middleware.py
+++ b/common/djangoapps/request_cache/middleware.py
@@ -18,7 +18,8 @@ class RequestCache(object):
         """
         return _request_cache_threadlocal.request
 
-    def clear_request_cache(self):
+    @classmethod
+    def clear_request_cache(cls):
         _request_cache_threadlocal.data = {}
         _request_cache_threadlocal.request = None
 

--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -324,7 +324,7 @@ class CachingDescriptorSystem(MakoDescriptorSystem, EditInfoRuntimeMixin):
         """
         Convert a single serialized UsageKey string in a ReferenceField into a UsageKey.
         """
-        key = Location.from_string(ref_string)
+        key = UsageKey.from_string(ref_string)
         return key.replace(run=self.modulestore.fill_in_run(key.course_key).run)
 
     def __setattr__(self, name, value):

--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -228,6 +228,8 @@ class CachingDescriptorSystem(MakoDescriptorSystem, EditInfoRuntimeMixin):
         Return an XModule instance for the specified location
         """
         assert isinstance(location, UsageKey)
+        if location.run is None:
+            location = location.replace(course_key=self.modulestore.fill_in_run(location.course_key))
         json_data = self.module_data.get(location)
         if json_data is None:
             module = self.modulestore.get_item(location, using_descriptor_system=self)
@@ -258,7 +260,7 @@ class CachingDescriptorSystem(MakoDescriptorSystem, EditInfoRuntimeMixin):
                         else ModuleStoreEnum.Branch.draft_preferred
                     )
                     if parent_url:
-                        parent = BlockUsageLocator.from_string(parent_url)
+                        parent = self._convert_reference_to_key(parent_url)
                 if not parent and category != 'course':
                     # try looking it up just-in-time (but not if we're working with a root node (course).
                     parent = self.modulestore.get_parent_location(

--- a/common/lib/xmodule/xmodule/modulestore/tests/factories.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/factories.py
@@ -330,18 +330,18 @@ def check_sum_of_calls(object_, methods, maximum_calls, minimum_calls=1):
         yield
 
     call_count = sum(mock.call_count for mock in mocks.values())
-    calls = pprint.pformat({
-        method_name: mock.call_args_list
-        for method_name, mock in mocks.items()
-    })
 
     # Assertion errors don't handle multi-line values, so pretty-print to std-out instead
     if not minimum_calls <= call_count <= maximum_calls:
+        calls = {
+            method_name: mock.call_args_list
+            for method_name, mock in mocks.items()
+        }
         print "Expected between {} and {} calls, {} were made. Calls: {}".format(
             minimum_calls,
             maximum_calls,
             call_count,
-            calls,
+            pprint.pformat(calls),
         )
 
     # verify the counter actually worked by ensuring we have counted greater than (or equal to) the minimum calls

--- a/common/lib/xmodule/xmodule/modulestore/tests/factories.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/factories.py
@@ -321,12 +321,24 @@ def check_sum_of_calls(object_, methods, maximum_calls, minimum_calls=1):
     Instruments the given methods on the given object to verify that the total sum of calls made to the
     methods falls between minumum_calls and maximum_calls.
     """
+
     mocks = {
         method: Mock(wraps=getattr(object_, method))
         for method in methods
     }
 
-    with patch.multiple(object_, **mocks):
+    if isinstance(object_, type):
+        # If the object that we're intercepting methods on is a class, rather than a module,
+        # then we need to set the method to a real function, so that self gets passed to it,
+        # and then explicitly pass that self into the call to the mock
+        mock_kwargs = {
+            method: lambda self, *args, **kwargs: mocks[method](self, *args, **kwargs)
+            for method in methods
+        }
+    else:
+        mock_kwargs = mocks
+
+    with patch.multiple(object_, **mock_kwargs):
         yield
 
     call_count = sum(mock.call_count for mock in mocks.values())

--- a/common/lib/xmodule/xmodule/modulestore/tests/utils.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/utils.py
@@ -143,3 +143,34 @@ class MixedSplitTestCase(TestCase):
             modulestore=self.store,
             **extra
         )
+
+
+class ProceduralCourseTestMixin(object):
+    """
+    Contains methods for testing courses generated procedurally
+    """
+    def populate_course(self, branching=2):
+        """
+        Add k chapters, k^2 sections, k^3 verticals, k^4 problems to self.course (where k = branching)
+        """
+        user_id = self.user.id
+        self.populated_usage_keys = {}  # pylint: disable=attribute-defined-outside-init
+
+        def descend(parent, stack):  # pylint: disable=missing-docstring
+            if not stack:
+                return
+
+            xblock_type = stack[0]
+            for _ in range(branching):
+                child = ItemFactory.create(
+                    category=xblock_type,
+                    parent_location=parent.location,
+                    user_id=user_id
+                )
+                print child.location
+                self.populated_usage_keys.setdefault(xblock_type, []).append(
+                    child.location
+                )
+                descend(child, stack[1:])
+
+        descend(self.course, ['chapter', 'sequential', 'vertical', 'problem'])

--- a/lms/djangoapps/ccx/tests/test_field_override_performance.py
+++ b/lms/djangoapps/ccx/tests/test_field_override_performance.py
@@ -1,0 +1,203 @@
+# coding=UTF-8
+"""
+Performance tests for field overrides.
+"""
+import ddt
+import mock
+
+from courseware.views import progress  # pylint: disable=import-error
+from datetime import datetime
+from django.core.cache import cache
+from django.test.client import RequestFactory
+from django.test.utils import override_settings
+from edxmako.middleware import MakoMiddleware  # pylint: disable=import-error
+from nose.plugins.attrib import attr
+from pytz import UTC
+from student.models import CourseEnrollment
+from student.tests.factories import UserFactory  # pylint: disable=import-error
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, \
+    TEST_DATA_SPLIT_MODULESTORE, TEST_DATA_MONGO_MODULESTORE
+from xmodule.modulestore.tests.factories import check_mongo_calls, CourseFactory
+from xmodule.modulestore.tests.utils import ProceduralCourseTestMixin
+
+
+@attr('shard_1')
+@mock.patch.dict(
+    'django.conf.settings.FEATURES', {'ENABLE_XBLOCK_VIEW_ENDPOINT': True}
+)
+@ddt.ddt
+class FieldOverridePerformanceTestCase(ProceduralCourseTestMixin,
+                                       ModuleStoreTestCase):
+    """
+    Base class for instrumenting SQL queries and Mongo reads for field override
+    providers.
+    """
+    def setUp(self):
+        """
+        Create a test client, course, and user.
+        """
+        super(FieldOverridePerformanceTestCase, self).setUp()
+
+        self.request_factory = RequestFactory()
+        self.student = UserFactory.create()
+        self.request = self.request_factory.get("foo")
+        self.request.user = self.student
+
+        MakoMiddleware().process_request(self.request)
+
+        # TEST_DATA must be overridden by subclasses, otherwise the test is
+        # skipped.
+        self.TEST_DATA = None
+
+    def setup_course(self, size):
+        grading_policy = {
+            "GRADER": [
+                {
+                    "drop_count": 2,
+                    "min_count": 12,
+                    "short_label": "HW",
+                    "type": "Homework",
+                    "weight": 0.15
+                },
+                {
+                    "drop_count": 2,
+                    "min_count": 12,
+                    "type": "Lab",
+                    "weight": 0.15
+                },
+                {
+                    "drop_count": 0,
+                    "min_count": 1,
+                    "short_label": "Midterm",
+                    "type": "Midterm Exam",
+                    "weight": 0.3
+                },
+                {
+                    "drop_count": 0,
+                    "min_count": 1,
+                    "short_label": "Final",
+                    "type": "Final Exam",
+                    "weight": 0.4
+                }
+            ],
+            "GRADE_CUTOFFS": {
+                "Pass": 0.5
+            }
+        }
+
+        self.course = CourseFactory.create(
+            graded=True,
+            start=datetime.now(UTC),
+            grading_policy=grading_policy
+        )
+        self.populate_course(size)
+
+        CourseEnrollment.enroll(
+            self.student,
+            self.course.id
+        )
+
+    def grade_course(self, course):
+        """
+        Renders the progress page for the given course.
+        """
+        return progress(
+            self.request,
+            course_id=course.id.to_deprecated_string(),
+            student_id=self.student.id
+        )
+
+    def instrument_course_progress_render(self, dataset_index, queries, reads):
+        """
+        Renders the progress page, instrumenting Mongo reads and SQL queries.
+        """
+        self.setup_course(dataset_index + 1)
+
+        # Clear the cache before measuring
+        # TODO: remove once django cache is disabled in tests
+        cache.clear()
+        with self.assertNumQueries(queries):
+            with check_mongo_calls(reads):
+                self.grade_course(self.course)
+
+    def run_if_subclassed(self, test_type, dataset_index):
+        """
+        Run the query/read instrumentation only if TEST_DATA has been
+        overridden.
+        """
+        if not self.TEST_DATA:
+            self.skipTest(
+                "Test not properly configured. TEST_DATA must be overridden "
+                "by a subclass."
+            )
+
+        queries, reads = self.TEST_DATA[test_type][dataset_index]
+        self.instrument_course_progress_render(dataset_index, queries, reads)
+
+    @ddt.data((0,), (1,), (2,))
+    @ddt.unpack
+    @override_settings(
+        FIELD_OVERRIDE_PROVIDERS=(),
+    )
+    def test_instrument_without_field_override(self, dataset):
+        """
+        Test without any field overrides.
+        """
+        self.run_if_subclassed('no_overrides', dataset)
+
+    @ddt.data((0,), (1,), (2,))
+    @ddt.unpack
+    @override_settings(
+        FIELD_OVERRIDE_PROVIDERS=(
+            'ccx.overrides.CustomCoursesForEdxOverrideProvider',
+        ),
+    )
+    def test_instrument_with_field_override(self, dataset):
+        """
+        Test with the CCX field override enabled.
+        """
+        self.run_if_subclassed('ccx', dataset)
+
+
+class TestFieldOverrideMongoPerformance(FieldOverridePerformanceTestCase):
+    """
+    Test cases for instrumenting field overrides against the Mongo modulestore.
+    """
+    MODULESTORE = TEST_DATA_MONGO_MODULESTORE
+
+    def setUp(self):
+        """
+        Set the modulestore and scaffold the test data.
+        """
+        super(TestFieldOverrideMongoPerformance, self).setUp()
+
+        self.TEST_DATA = {
+            'no_overrides': [
+                (22, 6), (130, 6), (590, 6)
+            ],
+            'ccx': [
+                (22, 6), (130, 6), (590, 6)
+            ],
+        }
+
+
+class TestFieldOverrideSplitPerformance(FieldOverridePerformanceTestCase):
+    """
+    Test cases for instrumenting field overrides against the Split modulestore.
+    """
+    MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
+
+    def setUp(self):
+        """
+        Set the modulestore and scaffold the test data.
+        """
+        super(TestFieldOverrideSplitPerformance, self).setUp()
+
+        self.TEST_DATA = {
+            'no_overrides': [
+                (22, 4), (130, 19), (590, 84)
+            ],
+            'ccx': [
+                (22, 4), (130, 19), (590, 84)
+            ]
+        }

--- a/lms/djangoapps/ccx/tests/test_field_override_performance.py
+++ b/lms/djangoapps/ccx/tests/test_field_override_performance.py
@@ -17,10 +17,11 @@ from pytz import UTC
 from request_cache.middleware import RequestCache
 from student.models import CourseEnrollment
 from student.tests.factories import UserFactory  # pylint: disable=import-error
+from xblock.core import XBlock
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, \
     TEST_DATA_SPLIT_MODULESTORE, TEST_DATA_MONGO_MODULESTORE
-from xmodule.modulestore.tests.factories import check_mongo_calls, CourseFactory
+from xmodule.modulestore.tests.factories import check_mongo_calls, CourseFactory, check_sum_of_calls
 from xmodule.modulestore.tests.utils import ProceduralCourseTestMixin
 
 
@@ -112,7 +113,7 @@ class FieldOverridePerformanceTestCase(ProceduralCourseTestMixin,
             student_id=self.student.id
         )
 
-    def instrument_course_progress_render(self, dataset_index, queries, reads):
+    def instrument_course_progress_render(self, dataset_index, queries, reads, xblocks):
         """
         Renders the progress page, instrumenting Mongo reads and SQL queries.
         """
@@ -133,7 +134,8 @@ class FieldOverridePerformanceTestCase(ProceduralCourseTestMixin,
 
             with self.assertNumQueries(queries):
                 with check_mongo_calls(reads):
-                    self.grade_course(self.course)
+                    with check_sum_of_calls(XBlock, ['__init__'], xblocks):
+                        self.grade_course(self.course)
 
     @ddt.data(*itertools.product(('no_overrides', 'ccx'), range(3)))
     @ddt.unpack
@@ -149,8 +151,8 @@ class FieldOverridePerformanceTestCase(ProceduralCourseTestMixin,
             'ccx': ('ccx.overrides.CustomCoursesForEdxOverrideProvider',)
         }
         with self.settings(FIELD_OVERRIDE_PROVIDERS=providers[overrides]):
-            queries, reads = self.TEST_DATA[overrides][dataset_index]
-            self.instrument_course_progress_render(dataset_index, queries, reads)
+            queries, reads, xblocks = self.TEST_DATA[overrides][dataset_index]
+            self.instrument_course_progress_render(dataset_index, queries, reads, xblocks)
 
 
 class TestFieldOverrideMongoPerformance(FieldOverridePerformanceTestCase):
@@ -168,10 +170,10 @@ class TestFieldOverrideMongoPerformance(FieldOverridePerformanceTestCase):
 
         self.TEST_DATA = {
             'no_overrides': [
-                (26, 7), (132, 7), (592, 7)
+                (26, 7, 19), (132, 7, 131), (592, 7, 537)
             ],
             'ccx': [
-                (24, 35), (132, 331), (592, 1507)
+                (24, 35, 47), (132, 331, 455), (592, 1507, 2037)
             ],
         }
 
@@ -191,9 +193,9 @@ class TestFieldOverrideSplitPerformance(FieldOverridePerformanceTestCase):
 
         self.TEST_DATA = {
             'no_overrides': [
-                (24, 4), (132, 19), (592, 84)
+                (24, 4, 9), (132, 19, 54), (592, 84, 215)
             ],
             'ccx': [
-                (24, 4), (132, 19), (592, 84)
+                (24, 4, 9), (132, 19, 54), (592, 84, 215)
             ]
         }

--- a/lms/djangoapps/ccx/tests/test_field_override_performance.py
+++ b/lms/djangoapps/ccx/tests/test_field_override_performance.py
@@ -3,18 +3,21 @@
 Performance tests for field overrides.
 """
 import ddt
+import itertools
 import mock
 
 from courseware.views import progress  # pylint: disable=import-error
 from datetime import datetime
-from django.core.cache import cache
+from django.core.cache import get_cache
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
 from edxmako.middleware import MakoMiddleware  # pylint: disable=import-error
 from nose.plugins.attrib import attr
 from pytz import UTC
+from request_cache.middleware import RequestCache
 from student.models import CourseEnrollment
 from student.tests.factories import UserFactory  # pylint: disable=import-error
+from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, \
     TEST_DATA_SPLIT_MODULESTORE, TEST_DATA_MONGO_MODULESTORE
 from xmodule.modulestore.tests.factories import check_mongo_calls, CourseFactory
@@ -32,6 +35,8 @@ class FieldOverridePerformanceTestCase(ProceduralCourseTestMixin,
     Base class for instrumenting SQL queries and Mongo reads for field override
     providers.
     """
+    __test__ = False
+
     def setUp(self):
         """
         Create a test client, course, and user.
@@ -113,50 +118,39 @@ class FieldOverridePerformanceTestCase(ProceduralCourseTestMixin,
         """
         self.setup_course(dataset_index + 1)
 
-        # Clear the cache before measuring
-        # TODO: remove once django cache is disabled in tests
-        cache.clear()
-        with self.assertNumQueries(queries):
-            with check_mongo_calls(reads):
-                self.grade_course(self.course)
+        # Switch to published-only mode to simulate the LMS
+        with self.settings(MODULESTORE_BRANCH='published-only'):
+            # Clear the cache before measuring
+            # We clear the mongo_metadata_inheritance cache so that we can refill it
+            # with published-only contents.
+            get_cache('mongo_metadata_inheritance').clear()
 
-    def run_if_subclassed(self, test_type, dataset_index):
-        """
-        Run the query/read instrumentation only if TEST_DATA has been
-        overridden.
-        """
-        if not self.TEST_DATA:
-            self.skipTest(
-                "Test not properly configured. TEST_DATA must be overridden "
-                "by a subclass."
-            )
+            # Refill the metadata inheritance cache
+            modulestore().get_course(self.course.id, depth=None)
 
-        queries, reads = self.TEST_DATA[test_type][dataset_index]
-        self.instrument_course_progress_render(dataset_index, queries, reads)
+            # We clear the request cache to simulate a new request in the LMS.
+            RequestCache.clear_request_cache()
 
-    @ddt.data((0,), (1,), (2,))
+            with self.assertNumQueries(queries):
+                with check_mongo_calls(reads):
+                    self.grade_course(self.course)
+
+    @ddt.data(*itertools.product(('no_overrides', 'ccx'), range(3)))
     @ddt.unpack
     @override_settings(
         FIELD_OVERRIDE_PROVIDERS=(),
     )
-    def test_instrument_without_field_override(self, dataset):
+    def test_field_overrides(self, overrides, dataset_index):
         """
         Test without any field overrides.
         """
-        self.run_if_subclassed('no_overrides', dataset)
-
-    @ddt.data((0,), (1,), (2,))
-    @ddt.unpack
-    @override_settings(
-        FIELD_OVERRIDE_PROVIDERS=(
-            'ccx.overrides.CustomCoursesForEdxOverrideProvider',
-        ),
-    )
-    def test_instrument_with_field_override(self, dataset):
-        """
-        Test with the CCX field override enabled.
-        """
-        self.run_if_subclassed('ccx', dataset)
+        providers = {
+            'no_overrides': (),
+            'ccx': ('ccx.overrides.CustomCoursesForEdxOverrideProvider',)
+        }
+        with self.settings(FIELD_OVERRIDE_PROVIDERS=providers[overrides]):
+            queries, reads = self.TEST_DATA[overrides][dataset_index]
+            self.instrument_course_progress_render(dataset_index, queries, reads)
 
 
 class TestFieldOverrideMongoPerformance(FieldOverridePerformanceTestCase):
@@ -164,6 +158,7 @@ class TestFieldOverrideMongoPerformance(FieldOverridePerformanceTestCase):
     Test cases for instrumenting field overrides against the Mongo modulestore.
     """
     MODULESTORE = TEST_DATA_MONGO_MODULESTORE
+    __test__ = True
 
     def setUp(self):
         """
@@ -173,10 +168,10 @@ class TestFieldOverrideMongoPerformance(FieldOverridePerformanceTestCase):
 
         self.TEST_DATA = {
             'no_overrides': [
-                (22, 6), (130, 6), (590, 6)
+                (26, 7), (132, 7), (592, 7)
             ],
             'ccx': [
-                (22, 6), (130, 6), (590, 6)
+                (24, 35), (132, 331), (592, 1507)
             ],
         }
 
@@ -186,6 +181,7 @@ class TestFieldOverrideSplitPerformance(FieldOverridePerformanceTestCase):
     Test cases for instrumenting field overrides against the Split modulestore.
     """
     MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
+    __test__ = True
 
     def setUp(self):
         """
@@ -195,9 +191,9 @@ class TestFieldOverrideSplitPerformance(FieldOverridePerformanceTestCase):
 
         self.TEST_DATA = {
             'no_overrides': [
-                (22, 4), (130, 19), (590, 84)
+                (24, 4), (132, 19), (592, 84)
             ],
             'ccx': [
-                (22, 4), (130, 19), (590, 84)
+                (24, 4), (132, 19), (592, 84)
             ]
         }

--- a/lms/djangoapps/ccx/tests/test_field_override_performance.py
+++ b/lms/djangoapps/ccx/tests/test_field_override_performance.py
@@ -8,6 +8,7 @@ import mock
 
 from courseware.views import progress  # pylint: disable=import-error
 from datetime import datetime
+from django.conf import settings
 from django.core.cache import get_cache
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
@@ -121,10 +122,9 @@ class FieldOverridePerformanceTestCase(ProceduralCourseTestMixin,
 
         # Switch to published-only mode to simulate the LMS
         with self.settings(MODULESTORE_BRANCH='published-only'):
-            # Clear the cache before measuring
-            # We clear the mongo_metadata_inheritance cache so that we can refill it
-            # with published-only contents.
-            get_cache('mongo_metadata_inheritance').clear()
+            # Clear all caches before measuring
+            for cache in settings.CACHES:
+                get_cache(cache).clear()
 
             # Refill the metadata inheritance cache
             modulestore().get_course(self.course.id, depth=None)

--- a/lms/djangoapps/ccx/tests/test_field_override_performance.py
+++ b/lms/djangoapps/ccx/tests/test_field_override_performance.py
@@ -173,7 +173,7 @@ class TestFieldOverrideMongoPerformance(FieldOverridePerformanceTestCase):
                 (26, 7, 19), (132, 7, 131), (592, 7, 537)
             ],
             'ccx': [
-                (24, 35, 47), (132, 331, 455), (592, 1507, 2037)
+                (24, 7, 47), (132, 7, 455), (592, 7, 2037)
             ],
         }
 

--- a/lms/djangoapps/ccx/tests/test_overrides.py
+++ b/lms/djangoapps/ccx/tests/test_overrides.py
@@ -1,3 +1,4 @@
+# coding=UTF-8
 """
 tests for overrides
 """


### PR DESCRIPTION
This PR adds tests that instrument the amount of SQL queries and Mongo reads when grading in four states:
- No field overrides; XML modulestore
- CCX field override; XML modulestore
- No field overrides; Split modulestore
- CCX field override; Split modulestore

For each test, three slightly different courses are tested against: A course with 1 problem, a course with 2 problems, and a course with 3 problems respectively.

This provides a base for testing a solution to the field override performance issue as it's being developed. These tests should be passing currently, but once the problem with field overrides is addressed, they should be decreased to reflect the improved numbers.

If these end up being flaky, we should probably mark these tests as skipped as other flaky instrumenting tests already do.

FYI @pdpinch, @cpennington.
