### PR TITLE
Deleting certificate should delete org logo image also

### DIFF
--- a/cms/djangoapps/contentstore/views/certificates.py
+++ b/cms/djangoapps/contentstore/views/certificates.py
@@ -224,6 +224,7 @@ class CertificateManager(object):
             if int(cert['id']) == int(certificate_id):
                 certificate = course.certificates['certificates'][index]
                 # Remove any signatory assets prior to dropping the entire cert record from the course
+                _delete_asset(course.id, certificate['org_logo_path'])
                 for sig_index, signatory in enumerate(certificate.get('signatories')):  # pylint: disable=unused-variable
                     _delete_asset(course.id, signatory['signature_image_path'])
                 # Now drop the certificate record

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -667,6 +667,7 @@ class CourseFields(object):
     ## Course level Certificate Name overrides.
     cert_name_short = String(
         help=_(
+            "Use this setting only when generating PDF certificates. "
             "Between quotation marks, enter the short name of the course to use on the certificate that "
             "students receive when they complete the course."
         ),
@@ -676,6 +677,7 @@ class CourseFields(object):
     )
     cert_name_long = String(
         help=_(
+            "Use this setting only when generating PDF certificates. "
             "Between quotation marks, enter the long name of the course to use on the certificate that students "
             "receive when they complete the course."
         ),

--- a/lms/templates/certificates/accomplishment-base.html
+++ b/lms/templates/certificates/accomplishment-base.html
@@ -8,6 +8,7 @@
 from django.utils.translation import get_language_bidi
 dir_rtl = 'rtl' if get_language_bidi() else 'ltr'
 document_body_class = document_body_class_append if document_body_class_append else ''
+course_mode_class = course_mode if course_mode else ''
 %>
 
 <!DOCTYPE html>
@@ -22,7 +23,7 @@ document_body_class = document_body_class_append if document_body_class_append e
     <%static:css group='style-certificates'/>
 </head>
 
-<body class="layout-accomplishment view-valid-accomplishment ${dir_rtl} ${document_body_class} certificate certificate-${course_mode}" data-view="valid-accomplishment">
+<body class="layout-accomplishment view-valid-accomplishment ${dir_rtl} ${document_body_class} certificate certificate-${course_mode_class}" data-view="valid-accomplishment">
 
     <div class="wrapper-view" dir="${dir_rtl}">
 

--- a/lms/templates/certificates/invalid.html
+++ b/lms/templates/certificates/invalid.html
@@ -4,10 +4,6 @@
 
 <%inherit file="accomplishment-base.html" />
 
-<%include file="_accomplishment-header.html" />
-
-<hr class="divider">
-
 <div class="wrapper-content">
     <div class="wrapper-content-grid">
 
@@ -43,7 +39,3 @@
 
     </div>
 </div>
-
-<hr class="divider sr-only">
-
-<%include file="_accomplishment-footer.html" />


### PR DESCRIPTION
@mattdrayer these changes are related to deleting certificate related image assets and changing of deprecated settings's help text and fixed broken web view related tests by updating invalid certificate template.
