### PR TITLE
Use platform name, not edX, in all strings

### DIFF
--- a/lms/djangoapps/instructor/paidcourse_enrollment_report.py
+++ b/lms/djangoapps/instructor/paidcourse_enrollment_report.py
@@ -4,9 +4,11 @@ Defines concrete class for cybersource  Enrollment Report.
 """
 from courseware.access import has_access
 import collections
+from django.conf import settings
 from django.utils.translation import ugettext as _
 from courseware.courses import get_course_by_id
 from instructor.enrollment_report import BaseAbstractEnrollmentReportProvider
+from microsite_configuration import microsite
 from shoppingcart.models import RegistrationCodeRedemption, PaidCourseRegistration, CouponRedemption, OrderItem, \
     InvoiceTransaction
 from student.models import CourseEnrollment
@@ -26,7 +28,8 @@ class PaidCourseEnrollmentReportProvider(BaseAbstractEnrollmentReportProvider):
 
         # check the user enrollment role
         if user.is_staff:
-            enrollment_role = _('Edx Staff')
+            platform_name = microsite.get_value('platform_name', settings.PLATFORM_NAME)
+            enrollment_role = _('{platform_name} Staff').format(platform_name=platform_name)
         elif is_course_staff:
             enrollment_role = _('Course Staff')
         else:


### PR DESCRIPTION
@muhhshoaib this file looks like it was committed by you. Just something to remember for Open edX is to please not hardcode "edX", "Studio", or "edX Studio" into any strings, so the platform is easily customizable by everyone.

@smagoun may someone from your team please review this as well?
