### PR TITLE
Removing background-image from button hovers

### DIFF
--- a/lms/static/sass/views/_login-register.scss
+++ b/lms/static/sass/views/_login-register.scss
@@ -375,6 +375,8 @@ $sm-btn-linkedin: #0077b5;
 
         &:hover,
         &:focus {
+            background-image: none;
+
             .icon {
                 height: 32px;
                 line-height: 32px;


### PR DESCRIPTION
@frrrances @marcotuts This quick PR removes the background-image from the social media/third-party auth login buttons, which fixes the weird blue button style that seeps in.

![screen shot 2015-05-29 at 10 35 17 am](https://cloud.githubusercontent.com/assets/2112024/7884822/71be03ce-05ee-11e5-98c1-5478f6568ff3.png)
![screen shot 2015-05-29 at 10 35 22 am](https://cloud.githubusercontent.com/assets/2112024/7884823/71c12c02-05ee-11e5-91bc-82796d2f9418.png)
