### PR TITLE
Add setting for pyfs xblock service to devstack.py

### DIFF
--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -46,6 +46,15 @@ STATICFILES_FINDERS = [
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
 ]
 
+############################ PYFS XBLOCKS SERVICE #############################
+# Set configuration for Django pyfilesystem
+
+DJFS = {
+    'type': 'osfs',
+    'directory_root': 'cms/static/djpyfs',
+    'url_root': '/static/djpyfs',
+}
+
 ############################# ADVANCED COMPONENTS #############################
 
 # Make it easier to test advanced components in local dev

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -49,6 +49,14 @@ ANALYTICS_API_KEY = ""
 # dashboard to the Analytics Dashboard.
 ANALYTICS_DASHBOARD_URL = None
 
+############################ PYFS XBLOCKS SERVICE #############################
+# Set configuration for Django pyfilesystem
+
+DJFS = {
+    'type': 'osfs',
+    'directory_root': 'lms/static/djpyfs',
+    'url_root': '/static/djpyfs',
+}
 
 ################################ DEBUG TOOLBAR ################################
 


### PR DESCRIPTION
Hi,

@singingwolfboy, @pmitros pyfs stopped working in devstack. It looks like devstack no longer includes dev.py, which configures it. I copied the relevant piece of configuration from dev.py to devstack.py. 
