### PR TITLE
fixed bug reported in SOL-934 and broken tests

### DIFF
--- a/common/djangoapps/student/tests/tests.py
+++ b/common/djangoapps/student/tests/tests.py
@@ -440,6 +440,7 @@ class DashboardTest(ModuleStoreTestCase):
         self.assertNotContains(response, response_url)
 
     @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+    @patch.dict('django.conf.settings.FEATURES', {'CERTIFICATES_HTML_VIEW': False})
     def test_linked_in_add_to_profile_btn_with_certificate(self):
         # If user has a certificate with valid linked-in config then Add Certificate to LinkedIn button
         # should be visible. and it has URL value with valid parameters.

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -305,13 +305,17 @@ def _cert_info(user, course, cert_status, course_mode):
 
     if status == 'ready':
         # showing the certificate web view button if certificate is ready state and feature flags are enabled.
-        if settings.FEATURES.get('CERTIFICATES_HTML_VIEW', False) and get_active_web_certificate(course) is not None:
-            status_dict.update({
-                'show_cert_web_view': True,
-                'cert_web_view_url': u'{url}'.format(
-                    url=get_certificate_url(user_id=user.id, course_id=unicode(course.id))
-                )
-            })
+        if settings.FEATURES.get('CERTIFICATES_HTML_VIEW', False):
+            if get_active_web_certificate(course) is not None:
+                status_dict.update({
+                    'show_cert_web_view': True,
+                    'cert_web_view_url': u'{url}'.format(
+                        url=get_certificate_url(user_id=user.id, course_id=unicode(course.id))
+                    )
+                })
+            else:
+                # don't show download certificate button if we don't have an active certificate for course
+                status_dict['show_download_url'] = False
         elif 'download_url' not in cert_status:
             log.warning(
                 u"User %s has a downloadable cert for %s, but no download url",


### PR DESCRIPTION
@mattdrayer this PR supports SOL-934. Download Certificate button should not be visible when no active certificate present.
