### PR TITLE
Styling improvements to openedX search through Find Courses page

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -150,7 +150,7 @@ FEATURES = {
     'LICENSING': False,
 
     # Enable the courseware search functionality
-    'ENABLE_COURSEWARE_INDEX': False,
+    'ENABLE_COURSEWARE_INDEX': True,
 
     # Enable content libraries search functionality
     'ENABLE_LIBRARY_INDEX': False,

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -150,7 +150,7 @@ FEATURES = {
     'LICENSING': False,
 
     # Enable the courseware search functionality
-    'ENABLE_COURSEWARE_INDEX': True,
+    'ENABLE_COURSEWARE_INDEX': False,
 
     # Enable content libraries search functionality
     'ENABLE_LIBRARY_INDEX': False,

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -972,9 +972,9 @@ def login_user(request, error=""):  # pylint: disable-msg=too-many-statements,un
                       platform_name=settings.PLATFORM_NAME, provider_name=requested_provider.name
                 )
                 + "<br/><br/>" +
-                _("If you don't have an {platform_name} account yet, click <strong>Register</strong> at the top of the page.").format(
-                    platform_name=settings.PLATFORM_NAME
-                ),
+                _("If you don't have an {platform_name} account yet, "
+                  "click <strong>Register</strong> at the top of the page.").format(
+                      platform_name=settings.PLATFORM_NAME),
                 content_type="text/plain",
                 status=403
             )

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -972,7 +972,7 @@ def login_user(request, error=""):  # pylint: disable-msg=too-many-statements,un
                       platform_name=settings.PLATFORM_NAME, provider_name=requested_provider.name
                 )
                 + "<br/><br/>" +
-                _("If you don't have an {platform_name} account yet, click <strong>Register Now</strong> at the top of the page.").format(
+                _("If you don't have an {platform_name} account yet, click <strong>Register</strong> at the top of the page.").format(
                     platform_name=settings.PLATFORM_NAME
                 ),
                 content_type="text/plain",

--- a/common/djangoapps/terrain/steps.py
+++ b/common/djangoapps/terrain/steps.py
@@ -65,7 +65,7 @@ def i_should_be_on_the_dashboard(step):
 @step(u'I (?:visit|access|open) the courses page$')
 def i_am_on_the_courses_page(step):
     world.visit('/courses')
-    assert world.is_css_present('section.courses')
+    assert world.is_css_present('div.courses')
 
 
 @step(u'I press the "([^"]*)" button$')

--- a/lms/djangoapps/branding/tests/test_page.py
+++ b/lms/djangoapps/branding/tests/test_page.py
@@ -220,7 +220,7 @@ class IndexPageCourseCardsSortingTests(ModuleStoreTestCase):
         self.assertNotIn('<aside aria-label="Refine your search" class="search-facets phone-menu">', response.content)
 
         # make sure we have the special css class on the section
-        self.assertIn('<section class="courses no-course-discovery">', response.content)
+        self.assertIn('<div class="courses no-course-discovery"', response.content)
 
     @patch('student.views.render_to_response', RENDER_MOCK)
     @patch('courseware.views.render_to_response', RENDER_MOCK)
@@ -239,10 +239,10 @@ class IndexPageCourseCardsSortingTests(ModuleStoreTestCase):
         response = self.client.get(reverse('branding.views.courses'))
         self.assertEqual(response.status_code, 200)
 
-        # assert that the course discovery UI is not present
+        # assert that the course discovery UI is present
         self.assertIn('Search for a course', response.content)
         self.assertIn('<aside aria-label="Refine your search" class="search-facets phone-menu">', response.content)
-        self.assertIn('<section class="courses">', response.content)
+        self.assertIn('<div class="courses"', response.content)
 
     @patch('student.views.render_to_response', RENDER_MOCK)
     @patch('courseware.views.render_to_response', RENDER_MOCK)

--- a/lms/djangoapps/courseware/features/homepage.feature
+++ b/lms/djangoapps/courseware/features/homepage.feature
@@ -8,9 +8,9 @@ Feature: LMS.Homepage for web users
     Given I visit the homepage
     Then I should see a link called "Sign in"
 
-  Scenario: User can see the "Register Now" button
+  Scenario: User can see the "Register" button
     Given I visit the homepage
-    Then I should see a link called "Register Now"
+    Then I should see a link called "Register"
 
   Scenario Outline: User can see main parts of the page
     Given I visit the homepage

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -359,10 +359,10 @@ FEATURES = {
     'MODE_CREATION_FOR_TESTING': False,
 
     # Courseware search feature
-    'ENABLE_COURSEWARE_SEARCH': True,
+    'ENABLE_COURSEWARE_SEARCH': False,
 
     # Dashboard search feature
-    'ENABLE_DASHBOARD_SEARCH': True,
+    'ENABLE_DASHBOARD_SEARCH': False,
 
     # log all information from cybersource callbacks
     'LOG_POSTPAY_CALLBACKS': True,
@@ -389,7 +389,7 @@ FEATURES = {
     },
 
     # Course discovery feature
-    'ENABLE_COURSE_DISCOVERY': True,
+    'ENABLE_COURSE_DISCOVERY': False,
 
     # Software secure fake page feature flag
     'ENABLE_SOFTWARE_SECURE_FAKE': False,

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -359,10 +359,10 @@ FEATURES = {
     'MODE_CREATION_FOR_TESTING': False,
 
     # Courseware search feature
-    'ENABLE_COURSEWARE_SEARCH': False,
+    'ENABLE_COURSEWARE_SEARCH': True,
 
     # Dashboard search feature
-    'ENABLE_DASHBOARD_SEARCH': False,
+    'ENABLE_DASHBOARD_SEARCH': True,
 
     # log all information from cybersource callbacks
     'LOG_POSTPAY_CALLBACKS': True,
@@ -389,7 +389,7 @@ FEATURES = {
     },
 
     # Course discovery feature
-    'ENABLE_COURSE_DISCOVERY': False,
+    'ENABLE_COURSE_DISCOVERY': True,
 
     # Software secure fake page feature flag
     'ENABLE_SOFTWARE_SECURE_FAKE': False,

--- a/lms/static/js/discovery/app.js
+++ b/lms/static/js/discovery/app.js
@@ -37,6 +37,7 @@ define(['backbone', 'course_discovery_meanings'], function(Backbone, meanings) {
 
         dispatcher.listenTo(collection, 'search', function () {
             if (collection.length > 0) {
+                form.showFoundMessage(collection.totalCount);
                 results.render();
             }
             else {

--- a/lms/static/js/discovery/form.js
+++ b/lms/static/js/discovery/form.js
@@ -47,6 +47,15 @@ define(['jquery', 'backbone'], function ($, Backbone) {
             this.$loadingIndicator.addClass('hidden');
         },
 
+        showFoundMessage: function (count) {
+            var msg = ngettext(
+                'Viewing %s course',
+                'Viewing %s courses',
+                count
+            );
+            this.$message.html(interpolate(msg, [count]));
+        },
+
         showNotFoundMessage: function (term) {
             var msg = interpolate(
                 gettext('We couldn\'t find any results for "%s".'),

--- a/lms/static/js/discovery/result_list_view.js
+++ b/lms/static/js/discovery/result_list_view.js
@@ -11,7 +11,7 @@ define([
 
     return Backbone.View.extend({
 
-        el: 'section.courses',
+        el: 'div.courses',
         $window: $(window),
         $document: $(document),
 

--- a/lms/static/js/fixtures/discovery.html
+++ b/lms/static/js/fixtures/discovery.html
@@ -1,26 +1,28 @@
 <section class="courses-container">
-  <div id="discovery-form">
-    <form>
+  <div id="discovery-form" class="wrapper-search-context">
+    <div id="discovery-message" class="search-status-label"></div>
+    <form class="wrapper-search-input">
       <input class="discovery-input" placeholder="Search for a course" type="text"/><!-- removes spacing
       --><button type="submit" class="button postfix discovery-submit" aria-label="Search">
         <i class="icon fa fa-search" aria-hidden="true"></i>
+        <div aria-live="polite" aria-relevant="all">
+          <div id="loading-indicator" class="loading-spinner hidden">
+          <i class="icon fa fa-spinner fa-spin" aria-hidden="true"></i>
+          <span class="sr">Loading</span>
+          </div>
+        </div>
       </button>
     </form>
-    <div id="discovery-message"></div>
-    <div aria-live="polite" aria-relevant="all">
-      <div id="loading-indicator" class="hidden">
-        <i class="icon fa fa-spinner fa-spin"></i> Loading
-      </div>
+    
+    <div id="filter-bar" class="filters hide-phone">
     </div>
-  </div>
 
-  <div id="filter-bar" class="filters hide-phone">
-  </div>
+    <div class="courses" role="region" aria-label="${_('List of Courses')}">
+      <ul class="courses-listing"></ul>
+    </div>
 
-  <section class="courses">
-    <ul class="courses-listing"></ul>
+    <aside aria-label="Refine your search" class="search-facets phone-menu">
+    </aside>
+
   </section>
-
-  <aside aria-label="Refine your search" class="search-facets phone-menu">
-  </aside>
 </section>

--- a/lms/static/js/spec/discovery/discovery_spec.js
+++ b/lms/static/js/spec/discovery/discovery_spec.js
@@ -238,7 +238,7 @@ define([
             var data = this.item.model.attributes;
             this.item.render();
             expect(this.item.$el).toContainHtml(data.content.display_name);
-            expect(this.item.$el).toContain('a[href="/courses/' + data.course + '/info"]');
+            expect(this.item.$el).toContain('a[href="/courses/' + data.course + '/about"]');
             expect(this.item.$el).toContain('img[src="' + data.image_url + '"]');
             expect(this.item.$el.find('.course-name')).toContainHtml(data.org);
             expect(this.item.$el.find('.course-name')).toContainHtml(data.content.number);

--- a/lms/static/sass/_build-lms.scss
+++ b/lms/static/sass/_build-lms.scss
@@ -70,7 +70,7 @@
 @import 'discussion/utilities/shame';
 
 // search
-@import 'search/_search';
+@import 'search/search';
 
 // news
 @import 'news';

--- a/lms/static/sass/base/_base.scss
+++ b/lms/static/sass/base/_base.scss
@@ -121,7 +121,6 @@ a:focus {
   width: flex-grid(12);
   margin: 0 auto;
   background: $content-wrapper-bg;
-  padding-bottom: ($baseline*2);
 
   @media print {
     padding-bottom: 0;

--- a/lms/static/sass/base/_variables.scss
+++ b/lms/static/sass/base/_variables.scss
@@ -82,6 +82,7 @@ $gray-d2: shade($gray,40%); // #4c4c4c
 $gray-d3: shade($gray,60%); // #323232
 $gray-d4: shade($gray,80%); // #191919
 
+
 $pink: rgb(182,37,103); // #b72567;
 $pink-l1: tint($pink,20%);
 $pink-l2: tint($pink,40%);
@@ -133,16 +134,23 @@ $green-u1: desaturate($green,15%);
 $green-u2: desaturate($green,30%);
 $green-u3: desaturate($green,45%);
 
+// ====================
+
 // COLORS: social platforms
 $twitter-blue: #55ACEE;
 $facebook-blue: #3B5998;
 $linkedin-blue: #0077B5;
 
+// ====================
+
 // TODO: both blue and yellow variables differ from CMS rgb value, need to confirm change to CMS variable is ok in current platform uses before switching.
 $blue: rgb(0, 120, 176);
 $yellow: rgb(255, 252, 221);
 
+// ====================
+
 // COLORS: old variables
+// DEPRECATED: use colors in lists above 
 $error-red: rgb(253, 87, 87);
 $danger-red: rgb(212, 64, 64);
 $light-gray: rgb(221, 221, 221);
@@ -152,13 +160,18 @@ $sidebar-color: rgb(246, 246, 246);
 $outer-border-color: rgb(170, 170, 170);
 $light-gray: rgb(221,221,221); // #dddddd
 
+// ====================
+
 // used by descriptor css
+// DEPRECATED: use colors in lists above 
 $lightGrey: rgb(237,241,245); // #edf1f5
 $darkGrey: rgb(136,145,161); // #8891a1
 $lightGrey1: $gray-l3;
 $blue-d1: shade($blue,20%);
 $blue-d2: shade($blue,40%);
 $blue-d4: shade($blue,80%);
+
+// ====================
 
 // edx.org marketing site variables
 $m-gray: rgb(138,140,143); // #8A8C8F

--- a/lms/static/sass/multicourse/_courses.scss
+++ b/lms/static/sass/multicourse/_courses.scss
@@ -1,39 +1,38 @@
-// lms - views - course discovery 
+// lms - views - course discovery
 // ====================
 
-// Table of Contents 
+// Table of Contents
 // * +Imports - Search
 // * +Variables - Search
 // * +Layout - Courses Container
 // * +Header - Course Search
-// * +Search Input 
-// * +Filters - Search
-// * +Facets - Sidebar - Search
+// * +Search Input
+// * +Filters and Facets- Search
 // * +All Other Styles
 
 
 // +Imports - Search
-// ==================== 
+// ====================
 @import '../base/grid-settings';
 @import 'neat/neat'; // lib - Neat
 
 // +Variables - Search
-// ==================== 
+// ====================
 $facet-text-color: #3d3e3f;
 $facet-background-color: #007db8;
 
 // +Layout - Courses Container
-// ==================== 
+// ====================
 .find-courses, .university-profile {
 
   .discovery-button:not(:disabled) {
     @extend %t-action2;
+    @include text-align(left);
     outline: 0 none;
     box-shadow:none;
     border: 0;
     background: none;
     padding: 0 ($baseline*0.6);
-    text-align: left;
     text-decoration: none;
     text-shadow: none;
     text-transform: none;
@@ -45,7 +44,7 @@ $facet-background-color: #007db8;
   }
 
   .courses-container {
-    padding: ($baseline*3) ($baseline/2) 0 ($baseline/2);
+    @include padding(($baseline*2), ($baseline/2), 0, ($baseline/2));
 
     .courses {
       @include rtl() { $layout-direction: "RTL"; }
@@ -95,7 +94,8 @@ $facet-background-color: #007db8;
         @include span-columns(12);
 
         @include media($bp-medium) {
-          @include span-columns(8);
+          @include span-columns(4); // 4 of 8
+          @include omega(2n);
         }
 
         @include media($bp-large) {
@@ -128,11 +128,11 @@ $facet-background-color: #007db8;
 }
 
 // +Hero - Home Header
-// ==================== 
+// ====================
 .find-courses, .university-profile {
 
   header.search {
-    background: $course-profile-bg;
+    background: $gray-l5;
     background-size: cover;
     background-image: $homepage-bg-image;
     background-position: center top !important;
@@ -169,20 +169,20 @@ $facet-background-color: #007db8;
         }
 
         .logo {
-          display: inline-block;
           @include border-right(1px solid $light-gray);
-          height: 80px;
           @include margin-right(30px);
           @include padding-right(30px);
+          display: inline-block;
+          height: 80px;
           position: relative;
           vertical-align: middle;
 
           &::after {
+            @include right(0px);
             content: "";
             display: block;
             height: 80px;
             position: absolute;
-            right: 0px;
             top: 0px;
           }
 
@@ -212,36 +212,69 @@ $facet-background-color: #007db8;
   }
 }
 
-// +Search Input 
-// ==================== 
+// +Search Input
+// ====================
 .find-courses {
 
   .wrapper-search-context {
-    @include clearfix();
+    @include outer-container;
+    @include rtl() { $layout-direction: "RTL"; }
 
     .search-status-label {
-      @extend %t-title4;
-      @include line-height(50);
-      display: inline-block;
-      width: flex-grid(9);
+      @extend %t-title3;
+      @include span-columns(9);
+      min-height: $course-search-input-height;
+
+      @include media($bp-tiny) {
+        @include fill-parent();
+        @include font-size(20);
+      }
+
+      @include media($bp-small) {
+        @include span-columns(4);
+        @include font-size(20);
+      }
+
+      @include media($bp-medium) {
+        @include span-columns(4);
+      }
+
+      @include media($bp-large) {
+        @include span-columns(8);
+      }
 
     }
 
     .wrapper-search-input {
-      display: inline-block;
-      width: flex-grid(3);
-      vertical-align: top;
-      margin-left: 24px;
+      @include span-columns(3);
+      @extend %ui-depth0;
+      position: relative;
+
+      @include media($bp-tiny) {
+        @include fill-parent();
+      }
+
+      @include media($bp-small) {
+        @include span-columns(4);
+      }
+
+      @include media($bp-medium) {
+        @include span-columns(4);
+      }
+
+      @include media($bp-large) {
+        @include span-columns(4);
+      }
     }
   }
-  
+
   .discovery-input {
     @extend %ui-depth1;
     @extend %t-copy-sub1;
     @extend %t-demi-strong;
-    @include border-radius(0);
-    @include border-top-left-radius(3px);
-    @include border-bottom-left-radius(3px);
+    @include border-radius(3px);
+    @include padding-right(55px);
+    width: 100%;
     border: 2px solid $gray-l3;
     height: $course-search-input-height;
     color: $black;
@@ -251,7 +284,7 @@ $facet-background-color: #007db8;
     &:focus {
       @extend %no-outline;
       box-shadow: none;
-      border-color: $m-blue-d1;
+      border-color: $m-blue-d6;
     }
   }
 
@@ -260,11 +293,13 @@ $facet-background-color: #007db8;
     @extend %t-icon3;
     @extend %t-strong;
     @include margin-left(-2px);
-    position: relative;
-    border: 2px solid $m-blue-d1;
+    @include right(0);
+    position: absolute;
+    top: 0;
+    border: 2px solid $m-blue-d6;
     border-radius: ($baseline*0.1);
     box-shadow: none;
-    background: $m-blue-d5;
+    background: $blue;
     padding: 0 ($baseline*0.7);
     height: $course-search-input-height;
     color: $white;
@@ -272,13 +307,20 @@ $facet-background-color: #007db8;
 
     //STATE: hover, focus
     &:hover, &:focus {
-      background: $m-blue-l1;
+      background: $m-blue-d5;
     }
   }
+
+  .loading-spinner {
+    @include transition(all $tmg-f1 ease-out 0s);
+    background: $blue;
+    position: absolute;
+    top: ($baseline*0.7); // same as padding rule for .discovery-submit
+  } 
 }
 
-// +Filters - Search
-// ==================== 
+// +Filters and Facets - Search
+// ====================
 .find-courses {
 
   .filters {
@@ -322,7 +364,7 @@ $facet-background-color: #007db8;
       margin: ($baseline/2);
       width: auto;
       text-align: center;
-      color: $m-blue-d1;
+      color: $m-blue-d5;
     }
 
     .flt-right {
@@ -330,172 +372,126 @@ $facet-background-color: #007db8;
     }
   }
 
-}
-
-// +Facets - Sidebar - Search
-// ==================== 
-.find-courses .search-facets {
-  @include fill-parent();
-  @include omega();
-  @include box-sizing(border-box);
-  @extend %ui-depth1;
-  position: relative;
-  margin: ($baseline*2) 0 ($baseline*3.5) 0;
-  box-shadow: 1px 2px 5px $black-t0;
-  border-top: 1px solid $black;
-  border-bottom: 2px solid $black;
-  background-color: $white;
-  max-height: ($baseline*100);
-
-  @include media($bp-tiny) {
-    @include span-columns(4);
-  }
-
-  @include media($bp-small) {
-    @include span-columns(3);
-  }
-
-  @include media($bp-medium) {
-    @include span-columns(4);
-  }
-
-  @include media($bp-large) {
-    @include span-columns(4);
-  }
-
-  @include media($bp-huge) {
-    @include span-columns(3);
-  }
-
-  &.phone-menu {
-    border: medium none;
-    padding: 0;
-    overflow: visible;
-  }
-
-  &:before {
-    @include right(0);
-    position: absolute;
-    top: (-$baseline*0.15);
-    opacity: 0;
+  .search-facets {
+    @include fill-parent();
+    @include omega();
+    @include box-sizing(border-box);
+    @extend %ui-depth1;
+    position: relative;
+    margin: ($baseline*2) 0 ($baseline*3.5) 0;
+    box-shadow: 1px 2px 5px $black-t0;
+    border-top: 1px solid $black;
+    border-bottom: 2px solid $black;
     background-color: $white;
-    padding: ($baseline*2) ($baseline*0.75) 0 ($baseline*0.75);
-    width: ($baseline*2.5);
-    height: ($baseline/4);
-    content: "";
-  }
+    max-height: ($baseline*100);
 
-  .header-search-facets, section {
-    padding: ($baseline/2);
-    margin: 0;
-    color: $facet-text-color;
-    text-transform: none;
-  }
-  
-  .header-search-facets {
-    @extend %t-title6;
-  }
-
-  section {
-    @extend %t-title6;
-    margin: 0 ($baseline/2);
-  }
-
-  .header-facet {
-    @extend %t-title6;
-    margin: 0 ($baseline/2) ($baseline/2) ($baseline/2);
-    color: $facet-text-color;
-    font-family: $sans-serif;
-  }
-
-  section {
-    margin: 0;
-    padding: ($baseline/2) 0;
-  }
-
-  a {
-    @include float(left);
-    @include box-sizing(border-box);
-    @include line-height(18.92);
-    @include transition(all $tmg-f2 ease-out 0s);
-    opacity: 1;
-    padding: 0 ($baseline*0.6);
-    width: 100%;
-    overflow: hidden;
-    text-decoration: none;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    color: $facet-text-color;
-
-    //STATE: hover, visited
-    &:hover,
-    &:visited {
-      color: $facet-text-color;
-      text-decoration: none;
-    }
-  }
-
-  .facet-option {
-    @include float(left);
-    @include box-sizing(border-box);
-    @include line-height(18.92);
-    @include transition(all $tmg-f2 ease-out 0s);
-    @extend %t-action3;
-    opacity: 1;
-    width: 100%;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    color: $facet-text-color;
-
-    &.collapse {
-      max-height: ($baseline*14);
+    @include media($bp-tiny) {
+      @include fill-parent();
     }
 
-    li {
-      @include clearfix();
-      @include line-height(18.92);
-      @extend %t-icon6;
-      position: relative;
-      clear: both;
-      border-top: 1px solid $white;
+    @include media($bp-small) {
+      @include span-columns(4);
+    }
+
+    @include media($bp-medium) {
+      @include span-columns(8);
+    }
+
+    @include media($bp-large) {
+      @include span-columns(4);
+    }
+
+    @include media($bp-huge) {
+      @include span-columns(3);
+    }
+
+    &.phone-menu {
+      border: medium none;
       padding: 0;
-      height: ($baseline*1.5);
-      overflow: hidden;
+      overflow: visible;
+    }
+
+    &:before {
+      @include right(0);
+      position: absolute;
+      top: (-$baseline*0.15);
+      opacity: 0;
+      background-color: $white;
+      padding: ($baseline*2) ($baseline*0.75) 0 ($baseline*0.75);
+      width: ($baseline*2.5);
+      height: ($baseline/4);
+      content: "";
+    }
+
+    .header-search-facets, .header-facet {
+      @extend %t-title6;
+      @extend %t-strong;
+      padding: ($baseline/2);
+      margin: 0;
+      color: $facet-text-color;
+      text-transform: none;
+    }
+
+    .header-facet {
+      margin: 0 ($baseline/2);
+      padding: ($baseline/2) 0;
+    }
+
+    .search-facets-lists section {
+      border-top: 1px solid $gray-l4;
+    }
+
+    .facet-list {
+      @extend %ui-no-list;
+      @include clearfix();
+      padding-bottom: ($baseline/2); 
+
+      &.collapse {
+        max-height: ($baseline*14);
+      }
+    }
+
+    .facet-option {
+      @include float(left);
+      @include transition(all $tmg-f2 ease-out 0s);
+      @include clearfix();
+      @extend %t-action3;
+      @extend %text-truncated;
+      padding: ($baseline/4) ($baseline/2);
+      border-radius: 0px;
+      opacity: 1;
+      width: 100%;
+      color: $facet-text-color;
+
+      li {
+        @include clearfix();
+        position: relative;
+        clear: both;
+        padding: 0;
+        height: ($baseline*1.5);
+      }
 
       .count {
         @include right($baseline*0.6);
         @include box-sizing(border-box);
         @include transition(all 0.2s ease-out);
-        @include line-height(18.92);
         position: absolute;
       }
 
-      //STATE: hover
-      &:hover {
+      //STATE: hover, focus
+      &:hover, &:focus {
         background: $facet-background-color;
         color: $white;
         text-decoration: none;
 
-        .count,
-        a {
+        .count {
           color: $white;
-
-          .count,
-          .facet-option {
-            color: $white;
-          }
         }
       }
     }
-  }
 
-  .search-facets-lists section {
-    border-top: 1px solid $courseware-button-border-color;
-  }
-
-  .toggle {
-    @include clearfix();
+    .toggle {
+      @include clearfix();
 
       button {
         @extend %t-icon6;
@@ -507,9 +503,9 @@ $facet-background-color: #007db8;
 }
 
 // +All Other Styles
-// ==================== 
+// ====================
 .find-courses, .university-profile {
-  background: $course-profile-bg;
+  background: $gray-l5;
   padding-bottom: ($baseline*3);
 
 

--- a/lms/static/sass/multicourse/_courses.scss
+++ b/lms/static/sass/multicourse/_courses.scss
@@ -55,12 +55,12 @@ $facet-background-color: #007db8;
         max-height: $course-card-height;
       }
 
-      /* Style grid settings if course discovery turned on */
+      // CASE: Course Discovery Search enabled
       &:not(.no-course-discovery) {
         @include span-columns(9);
 
         @include media($bp-medium) {
-          @include span-columns(4);
+          @include span-columns(8);
         }
 
         @include media($bp-large) {
@@ -73,8 +73,8 @@ $facet-background-color: #007db8;
 
         .courses-listing .courses-listing-item {
           @include media($bp-medium) {
-            @include span-columns(8); // 4 of 8
-            @include omega(1n);
+            @include span-columns(4); // 4 of 8
+            @include omega(2n);
           }
 
           @include media($bp-large) {
@@ -89,12 +89,12 @@ $facet-background-color: #007db8;
         }
       }
 
-      /* Style grid settings if course discovery turned off */
-      &.no-course-discovery{
+      // CASE: Course Discovery Search disabled
+      &.no-course-discovery {
         @include span-columns(12);
 
         @include media($bp-medium) {
-          @include span-columns(4); // 4 of 8
+          @include span-columns(8); // 8 of 8
           @include omega(2n);
         }
 

--- a/lms/static/sass/multicourse/_courses.scss
+++ b/lms/static/sass/multicourse/_courses.scss
@@ -1,12 +1,30 @@
+// lms - views - course discovery 
+// ====================
+
+// Table of Contents 
+// * +Imports - Search
+// * +Variables - Search
+// * +Layout - Courses Container
+// * +Header - Course Search
+// * +Search Input 
+// * +Filters - Search
+// * +Facets - Sidebar - Search
+// * +All Other Styles
+
+
+// +Imports - Search
+// ==================== 
 @import '../base/grid-settings';
 @import 'neat/neat'; // lib - Neat
 
+// +Variables - Search
+// ==================== 
 $facet-text-color: #3d3e3f;
 $facet-background-color: #007db8;
 
+// +Layout - Courses Container
+// ==================== 
 .find-courses, .university-profile {
-  background: $course-profile-bg;
-  padding-bottom: ($baseline*3);
 
   .discovery-button:not(:disabled) {
     @extend %t-action2;
@@ -27,17 +45,7 @@ $facet-background-color: #007db8;
   }
 
   .courses-container {
-
-    #discovery-form {
-      * {
-        display:inline;
-      }
-
-      #discovery-message,
-      #loading-indicator {
-        @include line-height(37.84);
-      }
-    }
+    padding: ($baseline*3) ($baseline/2) 0 ($baseline/2);
 
     .courses {
       @include rtl() { $layout-direction: "RTL"; }
@@ -117,6 +125,11 @@ $facet-background-color: #007db8;
       }
     }
   }
+}
+
+// +Hero - Home Header
+// ==================== 
+.find-courses, .university-profile {
 
   header.search {
     background: $course-profile-bg;
@@ -197,18 +210,34 @@ $facet-background-color: #007db8;
       }
     }
   }
+}
 
-  section.message {
-    border-top: 1px solid $border-color-2;
+// +Search Input 
+// ==================== 
+.find-courses {
+
+  .wrapper-search-context {
     @include clearfix();
-    margin-top: $baseline;
-    padding-top: ($baseline*3);
-    @include columns(2 20px);
-  }
 
+    .search-status-label {
+      @extend %t-title4;
+      @include line-height(50);
+      display: inline-block;
+      width: flex-grid(9);
+
+    }
+
+    .wrapper-search-input {
+      display: inline-block;
+      width: flex-grid(3);
+      vertical-align: top;
+      margin-left: 24px;
+    }
+  }
+  
   .discovery-input {
     @extend %ui-depth1;
-    @extend %t-icon4;
+    @extend %t-copy-sub1;
     @extend %t-demi-strong;
     @include border-radius(0);
     @include border-top-left-radius(3px);
@@ -246,12 +275,17 @@ $facet-background-color: #007db8;
       background: $m-blue-l1;
     }
   }
+}
+
+// +Filters - Search
+// ==================== 
+.find-courses {
 
   .filters {
     @include clearfix();
     margin-top: ($baseline/2);
-    border-top: 1px solid $courseware-button-border-color;
-    border-bottom: 1px solid $courseware-button-border-color;
+    border-top: 2px solid $courseware-button-border-color;
+    border-bottom: 2px solid $courseware-button-border-color;
     width: 100%;
     height: auto;
     max-height: ($baseline*10);
@@ -285,7 +319,7 @@ $facet-background-color: #007db8;
       @include line-height(29.73);
       @extend %t-icon5;
       @extend %t-strong;
-      margin: ($baseline/2) 0;
+      margin: ($baseline/2);
       width: auto;
       text-align: center;
       color: $m-blue-d1;
@@ -296,139 +330,156 @@ $facet-background-color: #007db8;
     }
   }
 
+}
 
+// +Facets - Sidebar - Search
+// ==================== 
+.find-courses .search-facets {
+  @include fill-parent();
+  @include omega();
+  @include box-sizing(border-box);
+  @extend %ui-depth1;
+  position: relative;
+  margin: ($baseline*2) 0 ($baseline*3.5) 0;
+  box-shadow: 1px 2px 5px $black-t0;
+  border-top: 1px solid $black;
+  border-bottom: 2px solid $black;
+  background-color: $white;
+  max-height: ($baseline*100);
 
-  .search-facets{
-    @include fill-parent();
-    @include omega();
-    @include box-sizing(border-box);
-    @extend %ui-depth1;
-    position: relative;
-    margin: ($baseline*2) 0 ($baseline*3.5) 0;
-    box-shadow: 1px 2px 5px $black-t0;
-    border-top: 1px solid $black;
-    border-bottom: 2px solid $black;
+  @include media($bp-tiny) {
+    @include span-columns(4);
+  }
+
+  @include media($bp-small) {
+    @include span-columns(3);
+  }
+
+  @include media($bp-medium) {
+    @include span-columns(4);
+  }
+
+  @include media($bp-large) {
+    @include span-columns(4);
+  }
+
+  @include media($bp-huge) {
+    @include span-columns(3);
+  }
+
+  &.phone-menu {
+    border: medium none;
+    padding: 0;
+    overflow: visible;
+  }
+
+  &:before {
+    @include right(0);
+    position: absolute;
+    top: (-$baseline*0.15);
+    opacity: 0;
     background-color: $white;
-    max-height: ($baseline*100);
+    padding: ($baseline*2) ($baseline*0.75) 0 ($baseline*0.75);
+    width: ($baseline*2.5);
+    height: ($baseline/4);
+    content: "";
+  }
 
-    @include media($bp-tiny) {
-      @include span-columns(4);
-    }
+  .header-search-facets, section {
+    padding: ($baseline/2);
+    margin: 0;
+    color: $facet-text-color;
+    text-transform: none;
+  }
+  
+  .header-search-facets {
+    @extend %t-title6;
+  }
 
-    @include media($bp-small) {
-      @include span-columns(3);
-    }
+  section {
+    @extend %t-title6;
+    margin: 0 ($baseline/2);
+  }
 
-    @include media($bp-medium) {
-      @include span-columns(4);
-    }
+  .header-facet {
+    @extend %t-title6;
+    margin: 0 ($baseline/2) ($baseline/2) ($baseline/2);
+    color: $facet-text-color;
+    font-family: $sans-serif;
+  }
 
-    @include media($bp-large) {
-      @include span-columns(4);
-    }
+  section {
+    margin: 0;
+    padding: ($baseline/2) 0;
+  }
 
-    @include media($bp-huge) {
-      @include span-columns(3);
-    }
+  a {
+    @include float(left);
+    @include box-sizing(border-box);
+    @include line-height(18.92);
+    @include transition(all $tmg-f2 ease-out 0s);
+    opacity: 1;
+    padding: 0 ($baseline*0.6);
+    width: 100%;
+    overflow: hidden;
+    text-decoration: none;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: $facet-text-color;
 
-    &.phone-menu {
-      border: medium none;
-      padding: 0;
-      overflow: visible;
-    }
-
-    &:before {
-      @include right(0);
-      position: absolute;
-      top: (-$baseline*0.15);
-      opacity: 0;
-      background-color: $white;
-      padding: ($baseline*2) ($baseline*0.75) 0 ($baseline*0.75);
-      width: ($baseline*2.5);
-      height: ($baseline/4);
-      content: "";
-    }
-
-    h2,
-    section {
-      @extend %t-icon5;
-      @extend %t-strong;
-      margin: 0 ($baseline/2);
-      border: medium none;
-      padding: ($baseline/2);
+    //STATE: hover, visited
+    &:hover,
+    &:visited {
       color: $facet-text-color;
-      font-family: $sans-serif;
-      text-transform: none;
+      text-decoration: none;
+    }
+  }
+
+  .facet-option {
+    @include float(left);
+    @include box-sizing(border-box);
+    @include line-height(18.92);
+    @include transition(all $tmg-f2 ease-out 0s);
+    @extend %t-action3;
+    opacity: 1;
+    width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: $facet-text-color;
+
+    &.collapse {
+      max-height: ($baseline*14);
     }
 
-    h3 {
-      @extend %t-icon6;
-      @extend %t-strong;
-      margin: 0 ($baseline/2) ($baseline/2) ($baseline/2);
-      color: $facet-text-color;
-      font-family: $sans-serif;
-    }
-
-    section {
-      margin: 0;
-      padding: ($baseline/2) 0;
-    }
-
-    .facet-option {
-      @include float(left);
-      @include box-sizing(border-box);
+    li {
+      @include clearfix();
       @include line-height(18.92);
-      @include transition(all $tmg-f2 ease-out 0s);
-      @extend %t-action3;
-      opacity: 1;
-      width: 100%;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      color: $facet-text-color;
-
-      //STATE: hover, visited
-      &:hover,
-      &:visited {
-        color: $facet-text-color;
-        text-decoration: none;
-      }
-    }
-
-    ul {
-      margin: 0;
+      @extend %t-icon6;
+      position: relative;
+      clear: both;
+      border-top: 1px solid $white;
       padding: 0;
+      height: ($baseline*1.5);
       overflow: hidden;
-      list-style: outside none none;
 
-      &.collapse {
-        max-height: ($baseline*14);
+      .count {
+        @include right($baseline*0.6);
+        @include box-sizing(border-box);
+        @include transition(all 0.2s ease-out);
+        @include line-height(18.92);
+        position: absolute;
       }
 
-      li {
-        @include clearfix();
-        @include line-height(18.92);
-        @extend %t-icon6;
-        position: relative;
-        clear: both;
-        border-top: 1px solid $white;
-        padding: 0;
-        height: ($baseline*1.5);
-        overflow: hidden;
+      //STATE: hover
+      &:hover {
+        background: $facet-background-color;
+        color: $white;
+        text-decoration: none;
 
-        .count {
-          @include right($baseline*0.6);
-          @include box-sizing(border-box);
-          @include transition(all 0.2s ease-out);
-          @include line-height(18.92);
-          position: absolute;
-        }
-
-        //STATE: hover
-        &:hover {
-          background: $facet-background-color;
+        .count,
+        a {
           color: $white;
-          text-decoration: none;
 
           .count,
           .facet-option {
@@ -437,13 +488,14 @@ $facet-background-color: #007db8;
         }
       }
     }
+  }
 
-    .search-facets-lists section {
-      border-top: 1px solid $courseware-button-border-color;
-    }
+  .search-facets-lists section {
+    border-top: 1px solid $courseware-button-border-color;
+  }
 
-    .toggle {
-      @include clearfix();
+  .toggle {
+    @include clearfix();
 
       button {
         @extend %t-icon6;
@@ -451,5 +503,22 @@ $facet-background-color: #007db8;
         color: $facet-background-color;
       }
     }
+  }
+}
+
+// +All Other Styles
+// ==================== 
+.find-courses, .university-profile {
+  background: $course-profile-bg;
+  padding-bottom: ($baseline*3);
+
+
+  section.message {
+    @include columns(2 20px);
+    @include clearfix();
+    border-top: 1px solid $border-color-2;
+    margin-top: $baseline;
+    padding-top: ($baseline*3);
+
   }
 }

--- a/lms/static/sass/multicourse/_dashboard.scss
+++ b/lms/static/sass/multicourse/_dashboard.scss
@@ -13,7 +13,7 @@
 // ====================
 .dashboard {
   @include clearfix();
-  padding: ($baseline*2) 0 0 0;
+  padding: ($baseline*2) 0 $baseline 0;
 
   .profile-sidebar {
     background: transparent;

--- a/lms/static/sass/multicourse/_home.scss
+++ b/lms/static/sass/multicourse/_home.scss
@@ -20,7 +20,6 @@ $course-search-input-height: ($button-size);
     background-image: $homepage-bg-image;
     box-shadow: 0 1px 0 0 $course-header-bg, inset 0 -1px 5px 0 $shadow-l1;
     overflow: hidden;
-    margin-top: $header_image_margin;
     padding: 0;
     width: flex-grid(12);
 
@@ -110,6 +109,7 @@ $course-search-input-height: ($button-size);
           height: $course-search-input-height;
           color: $black;
           font-style: normal;
+          font-weight: normal;
 
           // STATE: focus
           &:focus {

--- a/lms/static/sass/multicourse/_home.scss
+++ b/lms/static/sass/multicourse/_home.scss
@@ -1,7 +1,7 @@
 @import '../base/grid-settings';
 @import 'neat/neat'; // lib - Neat
 
-$title-left-margin: grid-width(2) + $gw-gutter;
+$title-left-margin: grid-width(3);
 $button-size: ($baseline*2.75);
 $course-search-input-height: ($button-size);
 
@@ -15,12 +15,10 @@ $course-search-input-height: ($button-size);
 
   > header {
     @include linear-gradient($homepage__header--gradient__color--alpha, $homepage__header--gradient__color--bravo);
+    @include clearfix();
     background-size: cover;
     background-image: $homepage-bg-image;
-    border-bottom: 1px solid $border-color-3;
     box-shadow: 0 1px 0 0 $course-header-bg, inset 0 -1px 5px 0 $shadow-l1;
-    @include clearfix();
-    height: 460px;
     overflow: hidden;
     margin-top: $header_image_margin;
     padding: 0;
@@ -30,8 +28,8 @@ $course-search-input-height: ($button-size);
       @include clearfix();
       @extend .animation-home-header-pop-up;
       position: relative;
-      margin: 0 auto ($baseline);
-      padding: ($baseline*5) ($baseline/2);
+      margin: 0 auto;
+      padding: ($baseline*3);
       max-width: ($baseline*60);
     }
 
@@ -41,8 +39,7 @@ $course-search-input-height: ($button-size);
       @include box-sizing(border-box);
       @include transition(all 0.2s linear 0s);
       position: relative;
-      border: 1px solid $border-color-3;
-      box-shadow: 0 4px 25px 0 rgba(0, 0, 0, 0.5);
+      box-shadow: 0 4px 5px 0 rgba(0, 0, 0, 0.5);
       background: $white;
       padding: ($baseline) ($baseline*1.5);
       min-height: ($baseline*6);
@@ -105,15 +102,14 @@ $course-search-input-height: ($button-size);
           @include padding-right($button-size);
           @include padding-left($baseline*0.5);
           @extend %ui-depth1;
-          @extend %t-icon4;
-          @extend %t-demi-strong;
+          @extend %t-title5;
           border: 2px solid $gray-l3;
           border-radius: 3px;
           box-shadow: none;
           width: 100%;
           height: $course-search-input-height;
           color: $black;
-          font-style: $sans-serif;
+          font-style: normal;
 
           // STATE: focus
           &:focus {

--- a/lms/static/sass/search/_search.scss
+++ b/lms/static/sass/search/_search.scss
@@ -123,7 +123,6 @@
 
 }
 
-
 .courseware-search-bar {
   box-shadow: 0 1px 0 $white inset, 0 -1px 0 $shadow-l1 inset;
 }

--- a/lms/static/sass/shared/_course_object.scss
+++ b/lms/static/sass/shared/_course_object.scss
@@ -226,7 +226,7 @@
       &:hover, &:focus {
         background: $course-profile-bg;
         border-color: $border-color-1;
-        box-shadow: 0 1px 16px 0 rgba($shadow-color, 0.4);
+        box-shadow: 0 1px 4px 0 rgba($shadow-color, 0.4);
 
         .info {
           top: -150px;

--- a/lms/static/sass/shared/_header.scss
+++ b/lms/static/sass/shared/_header.scss
@@ -3,7 +3,7 @@
 
 header.global {
   @extend %ui-depth1;
-  border-bottom: 1px solid $m-gray;
+  border-bottom: 4px solid $courseware-border-bottom-color;
   box-shadow: 0 1px 5px 0 $shadow-l1;
   background: $header-bg;
   position: relative;

--- a/lms/static/sass/shared/_header.scss
+++ b/lms/static/sass/shared/_header.scss
@@ -3,7 +3,7 @@
 
 header.global {
   @extend %ui-depth1;
-  border-bottom: 4px solid $courseware-border-bottom-color;
+  border-bottom: 1px solid $gray-l1;
   box-shadow: 0 1px 5px 0 $shadow-l1;
   background: $header-bg;
   position: relative;
@@ -286,7 +286,7 @@ header.global {
       a {
         display:block;
         padding: ($baseline/4);
-        color: $lighter-base-font-color;
+        color: $link-color;
         font-weight: 600;
 
         &:hover, &:focus, &:active {

--- a/lms/static/sass/views/_homepage.scss
+++ b/lms/static/sass/views/_homepage.scss
@@ -1,11 +1,11 @@
 // lms - views - homepage view
 // ====================
+// TO-DO: combine this with _home.scss as a cleanup story
 
 $learn-more-horizontal-position: calc(50% - 100px); // calculate the left position for "LEARN MORE" content
 
 .courses-container {
   @include outer-container;
-  padding: ($baseline*0.9) ($baseline/2) 0 ($baseline/2);
 
   .courses {
     @include row();
@@ -75,11 +75,12 @@ $learn-more-horizontal-position: calc(50% - 100px); // calculate the left positi
 
         .course-organization, .course-code, .course-date {
           @extend %t-icon6;
-          color: $black;
+          color: $gray-d2;
         }
 
         .course-organization, .course-code, .course-title {
           display: block;
+          text-transform: none;
         }
 
         .course-organization {

--- a/lms/static/sass/views/_homepage.scss
+++ b/lms/static/sass/views/_homepage.scss
@@ -16,7 +16,7 @@ $learn-more-horizontal-position: calc(50% - 100px); // calculate the left positi
       @extend %ui-no-list;
 
       .courses-listing-item {
-        margin: ($baseline*0.75) 0 ($baseline*1.5) 0;
+        margin: 0 0 ($baseline*1.5) 0;
         max-height: $course-card-height;
       }
     }

--- a/lms/templates/course.html
+++ b/lms/templates/course.html
@@ -13,14 +13,14 @@ from courseware.courses import course_image_url, get_course_about_section
         <div class="learn-more" aria-hidden=true>${_("LEARN MORE")}</div>
       </div>
     </header>
-    <section class="course-info" aria-hidden=true>
+    <div class="course-info" aria-hidden="true">
       <h2 class="course-name">
         <span class="course-organization">${get_course_about_section(course, 'university')}</span>
         <span class="course-code">${course.display_number_with_default}</span>
         <span class="course-title">${get_course_about_section(course, 'title')}</span>
       </h2>
       <div class="course-date" aria-hidden="true">${_("Starts")}: ${course.start_datetime_text()}</div>
-    </section>
+    </div>
     <div class="sr">
       <ul>
       <li>${get_course_about_section(course, 'university')}</li>

--- a/lms/templates/courseware/courses.html
+++ b/lms/templates/courseware/courses.html
@@ -56,29 +56,17 @@
 %>
 
 <section class="find-courses">
-
-  <header class="search">
-    <div class="inner-wrapper main-search">
-      <hgroup>
-        <div class="logo">
-          <img src="${logo_file}" alt="${logo_alt_text}" />
-        </div>
-        <h2>${course_index_overlay_text}</h2>
-      </hgroup>
-    </div>
-  </header>
-
   <section class="courses-container">
 
     % if course_discovery_enabled:
-    <div id="discovery-form" role="search" aria-label="course">
-      <form>
+    <div id="discovery-form" role="search" aria-label="course" class="wrapper-search-context">
+      <form class="wrapper-search-input">
         <input class="discovery-input" placeholder="${_('Search for a course')}" type="text"/><!-- removes spacing
         --><button type="submit" class="button postfix discovery-submit" aria-label="${_('Search')}">
           <i class="icon fa fa-search" aria-hidden="true"></i>
         </button>
       </form>
-      <div id="discovery-message"></div>
+      <div id="discovery-message" class="search-status-label"></div>
       <div aria-live="polite" aria-relevant="all">
         <div id="loading-indicator" class="hidden">
           <i class="icon fa fa-spinner fa-spin"></i> ${_('Loading')}

--- a/lms/templates/courseware/courses.html
+++ b/lms/templates/courseware/courses.html
@@ -57,28 +57,28 @@
 
 <section class="find-courses">
   <section class="courses-container">
-
     % if course_discovery_enabled:
     <div id="discovery-form" role="search" aria-label="course" class="wrapper-search-context">
+      <div id="discovery-message" class="search-status-label"></div>
       <form class="wrapper-search-input">
-        <input class="discovery-input" placeholder="${_('Search for a course')}" type="text"/><!-- removes spacing
-        --><button type="submit" class="button postfix discovery-submit" aria-label="${_('Search')}">
+        <input class="discovery-input" placeholder="${_('Search for a course')}" type="text"/>
+        <button type="submit" class="button postfix discovery-submit" aria-label="${_('Search')}">
           <i class="icon fa fa-search" aria-hidden="true"></i>
+          <div aria-live="polite" aria-relevant="all">
+            <div id="loading-indicator" class="loading-spinner hidden">
+              <i class="icon fa fa-spinner fa-spin"></i>
+              <span class="sr">${_('Loading')}</span>
+            </div>
+          </div>
         </button>
       </form>
-      <div id="discovery-message" class="search-status-label"></div>
-      <div aria-live="polite" aria-relevant="all">
-        <div id="loading-indicator" class="hidden">
-          <i class="icon fa fa-spinner fa-spin"></i> ${_('Loading')}
-        </div>
-      </div>
     </div>
 
     <div id="filter-bar" class="filters hide-phone">
     </div>
     % endif
 
-    <section class="courses${'' if course_discovery_enabled else ' no-course-discovery'}">
+    <section class="courses ${'' if course_discovery_enabled else ' no-course-discovery'}" role="region" aria-label="${_('List of Courses')}">
       <ul class="courses-listing">
         %for course in courses:
         <li class="courses-listing-item">

--- a/lms/templates/courseware/courses.html
+++ b/lms/templates/courseware/courses.html
@@ -78,7 +78,7 @@
     </div>
     % endif
 
-    <section class="courses ${'' if course_discovery_enabled else ' no-course-discovery'}" role="region" aria-label="${_('List of Courses')}">
+    <div class="courses${'' if course_discovery_enabled else ' no-course-discovery'}" role="region" aria-label="${_('List of Courses')}">
       <ul class="courses-listing">
         %for course in courses:
         <li class="courses-listing-item">
@@ -86,7 +86,7 @@
         </li>
         %endfor
       </ul>
-    </section>
+    </div>
 
 
     % if course_discovery_enabled:

--- a/lms/templates/discovery/result_item.underscore
+++ b/lms/templates/discovery/result_item.underscore
@@ -1,12 +1,12 @@
 <article class="course" role="region" aria-label="<%= content.display_name %>">
-    <a href="/courses/<%- course %>/info">
+    <a href="/courses/<%- course %>/about">
         <header class="course-image">
             <div class="cover-image">
                 <img src="<%- image_url %>" alt="<%= content.display_name %> <%= content.number %>" />
                 <div class="learn-more" aria-hidden=true><%= gettext("LEARN MORE") %></div>
             </div>
         </header>
-        <section class="course-info" aria-hidden=true>
+        <section class="course-info" aria-hidden="true">
             <h2 class="course-name">
                 <span class="course-organization"><%= org %></span>
                 <span class="course-code"><%= content.number %></span>

--- a/lms/templates/discovery/search_facets_list.underscore
+++ b/lms/templates/discovery/search_facets_list.underscore
@@ -1,4 +1,4 @@
-<h2>
+<h2 class="header-search-facets">
     <%= gettext('Refine your search') %>
 </h2>
 <section class="search-facets-lists">

--- a/lms/templates/discovery/search_facets_section.underscore
+++ b/lms/templates/discovery/search_facets_section.underscore
@@ -1,4 +1,4 @@
-<h3>
+<h3 class="header-facet">
     <%= displayName %>
 </h3>
 <ul data-facet="<%= name %>" class="facet-list collapse">

--- a/lms/templates/navigation.html
+++ b/lms/templates/navigation.html
@@ -124,15 +124,21 @@ site_status_msg = get_site_status_msg(course_id)
         % endif
       </%block>
       % if not settings.FEATURES['DISABLE_LOGIN_BUTTON']:
+          % if settings.FEATURES.get('ENABLE_COURSE_DISCOVERY'):
+          <li class="nav-global-05">
+            <a class="cta cta-discovery" href="/courses">${_("Find Courses")}</a>
+          </li>
+          %endif
           % if course and settings.FEATURES.get('RESTRICT_ENROLL_BY_REG_METHOD') and course.enrollment_domain:
           <li class="nav-global-04">
-            <a class="cta cta-register" href="${reverse('course-specific-register', args=[course.id.to_deprecated_string()])}">${_("Register Now")}</a>
+            <a class="cta cta-register" href="${reverse('course-specific-register', args=[course.id.to_deprecated_string()])}">${_("Register")}</a>
           </li>
           % else:
           <li class="nav-global-04">
-            <a class="cta cta-register" href="/register${login_query()}">${_("Register Now")}</a>
+            <a class="cta cta-register" href="/register${login_query()}">${_("Register")}</a>
           </li>
           % endif
+
       % endif
     </ol>
 


### PR DESCRIPTION
**Description**
This PR addresses some of the styling and UI changes that we'd like to incorporate into the course discovery feature currently in development. This is still a work in progress, and tasks / screenshots are included below. 

---

**JIRA Story** ([UX-2207](https://openedx.atlassian.net/browse/UX-2207))
**Confluence / Product Asset** ([Link to Confluence Docs](https://openedx.atlassian.net/wiki/display/SOL/OpenedX+Search+-+Requirements#OpenedXSearch-Requirements-Project3-CourseDiscoverySearchYellowINDISCOVERY))
**Sandbox URL** (Last Updated: 6/22) ([pr8296.m.sandbox.edx.org](http://pr8296.m.sandbox.edx.org)) 
**Dependencies** Main feature branch was merged to master. (https://github.com/edx/edx-platform/pull/7697).

---

**Must Have List**
- [x] tests passing
- [x] improve diff quality (currently is blocking merge.)
- [x] currently, search input element is fragile (especially with a styling change I added). It would take a bit more time to clean this up to work better on load and for mobile screen sizes.
- [x] remove common.py changes in this PR. 
- [x] review RTL (filter headers / txt and search header are broken currently) (MUST)
- [x] fix loading text which breaks styling, move to just on the outside left of the search area, or simply replace the search icon with the loading icon when loading. (Not sure what the best approach is here. cc'ed @dsego )

**Nice to Have / Should Have**
- [x] add "Viewing 126 courses" label when you have results. Currently we only have a label if there are zero results.

**Moved to JIRA Stories / Backlog**
- [x] transition for filtering sidebar to animate in (cc'ed @dsego) - ([SOL-959](https://openedx.atlassian.net/browse/SOL-959)) 
- [x] active filter should have different styling in sidebar as on edx.org (with clear / remove icon to also allow learners to unset a filter from the sidebar. ([SOL-959](https://openedx.atlassian.net/browse/SOL-959)) 
- [x] additional cleanup could be done for the styling / html work on search, if not in this PR, another story should be created. (this is more a styling organization and inheritance issue.) ([UX-2286](https://openedx.atlassian.net/browse/UX-2286))

---

**Screenshots** 
Find Courses Page:
![image](https://cloud.githubusercontent.com/assets/2023680/7737878/d652f084-ff1c-11e4-8c5b-523465b405e1.png)

Small changes to filters:
![image](https://cloud.githubusercontent.com/assets/2023680/7737883/e5ac39aa-ff1c-11e4-9a73-be46f694a07f.png)

Home page changes (including header for Find Courses link) :
![image](https://cloud.githubusercontent.com/assets/2023680/7737896/f8ee805e-ff1c-11e4-83bb-18f78cc0aedc.png)

---

**Reviewers**
- [x] @frrrances 
- [x] @mattdrayer 

---

**Product Verification**
- [x] @pbaruah  

---

**FYI**
@talbs - The following PR updates the openedx course discovery work to move the find courses experience to its own page and update some of the styling to be closer to what we have on edx.org. As noted in the tasks above, there is still additional cleanup that should be explored. It might make sense to bundle that cleanup into a story that also incorporates the latest and greated PL work as well ;) Thanks! 
