### PR TITLE
Prevent Django admin from loading all users for verify student models.

### DIFF
--- a/lms/djangoapps/verify_student/admin.py
+++ b/lms/djangoapps/verify_student/admin.py
@@ -14,6 +14,7 @@ class SoftwareSecurePhotoVerificationAdmin(admin.ModelAdmin):
     """
     list_display = ('id', 'user', 'status', 'receipt_id', 'submitted_at', 'updated_at')
     exclude = ('window',)   # TODO: Remove after deleting this field from the model.
+    raw_id_fields = ('user',)
     search_fields = (
         'receipt_id',
     )
@@ -25,6 +26,7 @@ class VerificationStatusAdmin(admin.ModelAdmin):
     """
     list_display = ('timestamp', 'user', 'status', 'checkpoint', 'location_id')
     readonly_fields = ()
+    raw_id_fields = ('user',)
     search_fields = ('checkpoint', 'user')
 
     def get_readonly_fields(self, request, obj=None):
@@ -47,6 +49,7 @@ class VerificationStatusAdmin(admin.ModelAdmin):
 class SkippedReverificationAdmin(admin.ModelAdmin):
     """Admin for the SkippedReverification table. """
     list_display = ('created_at', 'user', 'course_id', 'checkpoint')
+    raw_id_fields = ('user',)
     readonly_fields = ('user', 'course_id')
     search_fields = ('user', 'course_id', 'checkpoint')
 


### PR DESCRIPTION
This addresses an issue on Django admin that is preventing us from verifying some changes in stage.  Django admin is trying to load all records in the `auth_user` table, causing the request to time out.

@rlucioni please review.
@jibsheet would it be possible to get this deployed to stage today so that @awais786 has time to verify his changes before tomorrow's release?

JIRA: [ECOM-1494](https://openedx.atlassian.net/browse/ECOM-1494)
