### PR TITLE
ECOM-1678: Fix broken footer image URLs when using a CDN.

### DIFF
--- a/lms/djangoapps/branding/api.py
+++ b/lms/djangoapps/branding/api.py
@@ -277,7 +277,7 @@ def _absolute_url(is_secure, url_path):
 
 
 def _absolute_url_staticfile(is_secure, name):
-    """Construct an absolute URL back to a static resource on the site.
+    """Construct an absolute URL to a static resource on the site.
 
     Arguments:
         is_secure (bool): If true, use HTTPS as the protocol.
@@ -288,4 +288,13 @@ def _absolute_url_staticfile(is_secure, name):
 
     """
     url_path = staticfiles_storage.url(name)
+
+    # In production, the static files URL will be an absolute
+    # URL pointing to a CDN.  If this happens, we can just
+    # return the URL.
+    if urlparse.urlparse(url_path).netloc:
+        return url_path
+
+    # For local development, the returned URL will be relative,
+    # so we need to make it absolute.
     return _absolute_url(is_secure, url_path)


### PR DESCRIPTION
Fix an issue that was causing broken image links in the V3 version of the edx.org footer.  (See the JIRA ticket for detailed steps to reproduce).

In production, "STATIC_URL" is an absolute URL pointing to a CDN, so we don't need to prepend the site name to build an absolute URL.

@jimabramson could you please review?
FYI: @jibsheet @AlasdairSwan 

JIRA: [ECOM-1678](https://openedx.atlassian.net/browse/ECOM-1678)
