### PR TITLE
Web Certificates: RTL Proofing - Take 2

### DIFF
--- a/lms/static/certificates/sass/_components.scss
+++ b/lms/static/certificates/sass/_components.scss
@@ -118,14 +118,14 @@
     .message-actions .action {
         display: inline-block;
         vertical-align: middle;
-        margin-right: spacing-horizontal(small);
+        @include margin-right(spacing-horizontal(small));
 
         &:last-child {
-            margin-right: 0;
+            @include margin-right(0);
         }
 
         .icon {
-            margin-right: spacing-horizontal(x-small);
+            @include margin-right(spacing-horizontal(x-small));
         }
 
         // CASE mozilla open badges logo
@@ -360,7 +360,7 @@
     .recipient-img {
         @extend %img-cropped;
         width: rem(100);
-        margin-right: spacing-horizontal(small);
+        @include margin-right(spacing-horizontal(small));
 
         .src {
             max-height: 100%;

--- a/lms/static/certificates/sass/_layouts.scss
+++ b/lms/static/certificates/sass/_layouts.scss
@@ -220,7 +220,7 @@
             max-width: 80%;
             position: absolute;
             top: 50%;
-            left: 50%;
+            @include left(50%);
             transform: translate(-50%, -50%);
         }
     }

--- a/static/pattern-library/sass/_build.scss
+++ b/static/pattern-library/sass/_build.scss
@@ -7,6 +7,7 @@
 // #UTILITIES
 // ------------------------------
 @import 'utilities/functions';
+@import 'utilities/variables';
 @import 'utilities/mixins';
 @import 'utilities/helpers';
 

--- a/static/pattern-library/sass/main-ltr.scss
+++ b/static/pattern-library/sass/main-ltr.scss
@@ -14,7 +14,7 @@
 // ------------------------------
 // #UTILITIES
 // ------------------------------
-@import 'utilities/variables';
+@import 'utilities/variables-ltr';
 
 // ------------------------------
 // #BUILD


### PR DESCRIPTION
This work adds in additional proofing of the web certs UI to make sure it is RTL-layout friendly. There are no UI changes added here - the UI should render appropriately now for RTL contexts.

---

**Reviewers**
- [x] UX/FED - @marcotuts 

---

**Notes**
- I'll need to sync up the PL assets touched here statically with the ux-pattern-library repo source.

---

FYI, @mattdrayer and @pbaruah 
