### PR TITLE
Avoid loading all users for "reviewing user" on the verify_student admin page.

### DIFF
--- a/lms/djangoapps/verify_student/admin.py
+++ b/lms/djangoapps/verify_student/admin.py
@@ -14,7 +14,7 @@ class SoftwareSecurePhotoVerificationAdmin(admin.ModelAdmin):
     """
     list_display = ('id', 'user', 'status', 'receipt_id', 'submitted_at', 'updated_at')
     exclude = ('window',)   # TODO: Remove after deleting this field from the model.
-    raw_id_fields = ('user',)
+    raw_id_fields = ('user', 'reviewing_user')
     search_fields = (
         'receipt_id',
     )


### PR DESCRIPTION
Follow-on from #8297.  I missed one other case on the verify student Django admin pages where we were loading the full list of users.  Unfortunately, this would also prevent testing the verification flow in stage.

@jibsheet Really sorry to do this at the end of the day, but would it be possible to include this in the deploy to stage tomorrow morning?

@rlucioni could I get a quick review?

FYI: @awais786 This means you won't be able to test the verification flow until stage gets updated tomorrow.  If that's not enough time to test your changes, please let me and @jibsheet know.
