### PR TITLE
(SOL-618) Fix for flaky library users studio test

### DIFF
--- a/common/test/acceptance/tests/studio/test_studio_course_team.py
+++ b/common/test/acceptance/tests/studio/test_studio_course_team.py
@@ -44,9 +44,9 @@ class CourseTeamPageTest(StudioCourseTest):
         self.page.visit()
         self.page.wait_until_ready()
 
-    def _expect_refresh(self):
+    def _refresh_page(self):
         """
-        Wait for the page to reload.
+        Reload the page.
         """
         self.page = CourseTeamPage(
             self.browser, self.course_info['org'], self.course_info['number'], self.course_info['run']
@@ -198,7 +198,7 @@ class CourseTeamPageTest(StudioCourseTest):
         other = self.page.get_user(self.other_user.get('email'))
         self._assert_is_staff(other)
         other.click_promote()
-        self._expect_refresh()
+        self._refresh_page()
         self._assert_is_admin(other)
 
         self.log_in(self.other_user)
@@ -227,7 +227,7 @@ class CourseTeamPageTest(StudioCourseTest):
         other = self.page.get_user(self.other_user.get('email'))
         self._assert_is_staff(other)
         other.click_promote()
-        self._expect_refresh()
+        self._refresh_page()
         other = self.page.get_user(self.other_user.get('email'))
         self._assert_is_admin(other)
 
@@ -242,7 +242,7 @@ class CourseTeamPageTest(StudioCourseTest):
         self._go_to_course_team_page()
         other = self.page.get_user(self.other_user.get('email'))
         other.click_demote()
-        self._expect_refresh()
+        self._refresh_page()
         other = self.page.get_user(self.other_user.get('email'))
         self._assert_is_staff(other)
 
@@ -276,7 +276,7 @@ class CourseTeamPageTest(StudioCourseTest):
 
         other = self.page.get_user(self.other_user.get('email'))
         other.click_promote()
-        self._expect_refresh()
+        self._refresh_page()
         other = self.page.get_user(self.other_user.get('email'))
         self._assert_is_admin(other)
 
@@ -316,7 +316,7 @@ class CourseTeamPageTest(StudioCourseTest):
 
         other = self.page.get_user(self.other_user.get('email'))
         other.click_promote()
-        self._expect_refresh()
+        self._refresh_page()
 
         other = self.page.get_user(self.other_user.get('email'))
         self._assert_is_admin(other)
@@ -325,7 +325,7 @@ class CourseTeamPageTest(StudioCourseTest):
         self.assertTrue(current.can_demote)
         self.assertTrue(current.can_delete)
         current.click_demote()
-        self._expect_refresh()
+        self._refresh_page()
         current = self.page.get_user(self.user.get('email'))
         self._assert_is_staff(current, can_manage=False)
         self._assert_can_not_manage_users()
@@ -336,7 +336,7 @@ class CourseTeamPageTest(StudioCourseTest):
 
         current = self.page.get_user(self.user.get('email'))
         current.click_delete()
-        self._expect_refresh()
+        self._refresh_page()
         self._assert_user_present(self.user, present=False)
 
         self.log_in(self.user)

--- a/common/test/acceptance/tests/studio/test_studio_library.py
+++ b/common/test/acceptance/tests/studio/test_studio_library.py
@@ -515,13 +515,14 @@ class LibraryUsersPageTest(StudioLibraryTest):
         self.page = LibraryUsersPage(self.browser, self.library_key)
         self.page.visit()
 
-    def _expect_refresh(self):
+    def _refresh_page(self):
         """
-        Wait for the page to reload.
+        Reload the page.
         """
-        self.page = LibraryUsersPage(self.browser, self.library_key).wait_for_page()
+        self.page = LibraryUsersPage(self.browser, self.library_key)
+        self.page.visit()
+        self.page.wait_until_ready()
 
-    @skip  # TODO fix this, see SOL-618
     def test_user_management(self):
         """
         Scenario: Ensure that we can edit the permissions of users.
@@ -585,7 +586,7 @@ class LibraryUsersPageTest(StudioLibraryTest):
             else:
                 return users[1], users[0]
 
-        self._expect_refresh()
+        self._refresh_page()
         user_me, them = get_two_users()
         check_is_only_admin(user_me)
 
@@ -599,7 +600,7 @@ class LibraryUsersPageTest(StudioLibraryTest):
         # Add Staff permissions to the new user:
 
         them.click_promote()
-        self._expect_refresh()
+        self._refresh_page()
         user_me, them = get_two_users()
         check_is_only_admin(user_me)
 
@@ -614,7 +615,7 @@ class LibraryUsersPageTest(StudioLibraryTest):
         # Add Admin permissions to the new user:
 
         them.click_promote()
-        self._expect_refresh()
+        self._refresh_page()
         user_me, them = get_two_users()
         self.assertIn("admin", user_me.role_label.lower())
         self.assertFalse(user_me.can_promote)
@@ -632,7 +633,7 @@ class LibraryUsersPageTest(StudioLibraryTest):
         # Delete the new user:
 
         them.click_delete()
-        self._expect_refresh()
+        self._refresh_page()
         self.assertEqual(len(self.page.users), 1)
         user = self.page.users[0]
         self.assertTrue(user.is_current_user)


### PR DESCRIPTION
Background: Fixes a known flaky test for managing library users.
Jira tickets: [SOL-618](https://openedx.atlassian.net/browse/SOL-618)

@bradenmacdonald , I will be force running Jenkins tests several times on this PR to verify Jenkins doesn't have an issue with the solution. Please look over the change and see if it makes sense.
