### PR TITLE
Fixed cms course export using management command.

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/export.py
+++ b/cms/djangoapps/contentstore/management/commands/export.py
@@ -32,6 +32,9 @@ class Command(BaseCommand):
 
         print("Exporting course id = {0} to {1}".format(course_key, output_path))
 
+        if not output_path.endswith('/'):
+            output_path += '/'
+
         root_dir = os.path.dirname(output_path)
         course_dir = os.path.splitext(os.path.basename(output_path))[0]
 

--- a/cms/djangoapps/contentstore/management/commands/tests/test_export.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_export.py
@@ -1,0 +1,65 @@
+"""
+Tests for exporting courseware to the desired path
+"""
+import unittest
+import shutil
+import ddt
+from django.core.management import CommandError, call_command
+from tempfile import mkdtemp
+
+from opaque_keys import InvalidKeyError
+from xmodule.modulestore.tests.factories import CourseFactory
+from xmodule.modulestore import ModuleStoreEnum
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.django import modulestore
+
+
+class TestArgParsingCourseExport(unittest.TestCase):
+    """
+    Tests for parsing arguments for the `export` management command
+    """
+    def setUp(self):
+        super(TestArgParsingCourseExport, self).setUp()
+
+    def test_no_args(self):
+        errstring = "export requires two arguments: <course id> <output path>"
+        with self.assertRaises(SystemExit) as ex:
+            with self.assertRaisesRegexp(CommandError, errstring):
+                call_command('export')
+        self.assertEqual(ex.exception.code, 1)
+
+
+@ddt.ddt
+class TestCourseExport(ModuleStoreTestCase):
+    """
+    Test exporting a course
+    """
+    def setUp(self):
+        super(TestCourseExport, self).setUp()
+
+        # Temp directories (temp_dir_1: relative path, temp_dir_2: absolute path)
+        self.temp_dir_1 = mkdtemp()
+        self.temp_dir_2 = mkdtemp(dir="")
+
+        # Clean temp directories
+        self.addCleanup(shutil.rmtree, self.temp_dir_1)
+        self.addCleanup(shutil.rmtree, self.temp_dir_2)
+
+    @ddt.data(ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split)
+    def test_export_course_with_directory_name(self, store):
+        """
+        Create a new course try exporting in a path specified
+        """
+        course = CourseFactory.create(default_store=store)
+        course_id = unicode(course.id)
+        self.assertTrue(
+            modulestore().has_course(course.id),
+            "Could not find course in {}".format(store)
+        )
+        # Test `export` management command with invalid course_id
+        with self.assertRaises(InvalidKeyError):
+            call_command('export', "InvalidCourseID", self.temp_dir_1)
+
+        # Test `export` management command with correct course_id
+        for output_dir in [self.temp_dir_1, self.temp_dir_2]:
+            call_command('export', course_id, output_dir)


### PR DESCRIPTION
CMS Export command tries to export to the wrong place when exporting to a relative location

Wrote a Python Unit test for verifying. 

[PLAT-643](https://openedx.atlassian.net/browse/PLAT-643)
