### PR TITLE
LMS User menu cleanup

### DIFF
--- a/common/test/acceptance/pages/lms/dashboard.py
+++ b/common/test/acceptance/pages/lms/dashboard.py
@@ -176,12 +176,12 @@ class DashboardPage(PageObject):
 
     def click_account_settings_link(self):
         """
-        Click on `Account Settings` link.
+        Click on `Account` link.
         """
-        self.q(css='.dropdown-menu li a').first.click()
+        self.q(css='.dropdown-menu li a').nth(1).click()
 
     def click_my_profile_link(self):
         """
-        Click on `My Profile` link.
+        Click on `Profile` link.
         """
-        self.q(css='.dropdown-menu li a').nth(1).click()
+        self.q(css='.dropdown-menu li a').nth(2).click()

--- a/common/test/acceptance/pages/lms/dashboard.py
+++ b/common/test/acceptance/pages/lms/dashboard.py
@@ -174,14 +174,14 @@ class DashboardPage(PageObject):
         """
         return self.q(css='.dropdown-menu li a').text
 
+        def click_my_profile_link(self):
+            """
+            Click on `Profile` link.
+            """
+            self.q(css='.dropdown-menu li a').nth(1).click()
+
     def click_account_settings_link(self):
         """
         Click on `Account` link.
-        """
-        self.q(css='.dropdown-menu li a').nth(1).click()
-
-    def click_my_profile_link(self):
-        """
-        Click on `Profile` link.
         """
         self.q(css='.dropdown-menu li a').nth(2).click()

--- a/common/test/acceptance/pages/lms/dashboard.py
+++ b/common/test/acceptance/pages/lms/dashboard.py
@@ -174,11 +174,11 @@ class DashboardPage(PageObject):
         """
         return self.q(css='.dropdown-menu li a').text
 
-        def click_my_profile_link(self):
-            """
-            Click on `Profile` link.
-            """
-            self.q(css='.dropdown-menu li a').nth(1).click()
+    def click_my_profile_link(self):
+        """
+        Click on `Profile` link.
+        """
+        self.q(css='.dropdown-menu li a').nth(1).click()
 
     def click_account_settings_link(self):
         """

--- a/common/test/acceptance/tests/lms/test_account_settings.py
+++ b/common/test/acceptance/tests/lms/test_account_settings.py
@@ -85,19 +85,19 @@ class DashboardMenuTest(AccountSettingsTestMixin, WebAppTest):
     """
     def test_link_on_dashboard_works(self):
         """
-        Scenario: Verify that the "Account Settings" link works from the dashboard.
+        Scenario: Verify that the "Account" link works from the dashboard.
 
 
         Given that I am a registered user
         And I visit my dashboard
-        And I click on "Account Settings" in the top drop down
+        And I click on "Account" in the top drop down
         Then I should see my account settings page
         """
         self.log_in_as_unique_user()
         dashboard_page = DashboardPage(self.browser)
         dashboard_page.visit()
         dashboard_page.click_username_dropdown()
-        self.assertIn('Account Settings', dashboard_page.username_dropdown_link_text)
+        self.assertIn('Account', dashboard_page.username_dropdown_link_text)
         dashboard_page.click_account_settings_link()
 
 

--- a/common/test/acceptance/tests/lms/test_learner_profile.py
+++ b/common/test/acceptance/tests/lms/test_learner_profile.py
@@ -237,15 +237,15 @@ class OwnLearnerProfilePageTest(LearnerProfileTestMixin, WebAppTest):
         Given that I am a registered user.
         When I go to Dashboard page.
         And I click on username dropdown.
-        Then I see My Profile link in the dropdown menu.
-        When I click on My Profile link.
-        Then I will be navigated to My Profile page.
+        Then I see Profile link in the dropdown menu.
+        When I click on Profile link.
+        Then I will be navigated to Profile page.
         """
         username, user_id = self.log_in_as_unique_user()
         dashboard_page = DashboardPage(self.browser)
         dashboard_page.visit()
         dashboard_page.click_username_dropdown()
-        self.assertTrue('My Profile' in dashboard_page.username_dropdown_link_text)
+        self.assertTrue('Profile' in dashboard_page.username_dropdown_link_text)
         dashboard_page.click_my_profile_link()
         my_profile_page = LearnerProfilePage(self.browser, username)
         my_profile_page.wait_for_page()
@@ -255,7 +255,7 @@ class OwnLearnerProfilePageTest(LearnerProfileTestMixin, WebAppTest):
         Scenario: Verify that desired fields are shown when looking at her own private profile.
 
         Given that I am a registered user.
-        And I visit My Profile page.
+        And I visit my Profile page.
         And I set the profile visibility to private.
         And I reload the page.
         Then I should see the profile visibility selector dropdown.
@@ -271,7 +271,7 @@ class OwnLearnerProfilePageTest(LearnerProfileTestMixin, WebAppTest):
         Scenario: Verify that desired fields are shown when looking at her own public profile.
 
         Given that I am a registered user.
-        And I visit My Profile page.
+        And I visit my Profile page.
         And I set the profile visibility to public.
         And I reload the page.
         Then I should see the profile visibility selector dropdown.
@@ -316,7 +316,7 @@ class OwnLearnerProfilePageTest(LearnerProfileTestMixin, WebAppTest):
         Test behaviour of `Country` field.
 
         Given that I am a registered user.
-        And I visit My Profile page.
+        And I visit my Profile page.
         And I set the profile visibility to public and set default values for public fields.
         Then I set country value to `Pakistan`.
         Then displayed country should be `Pakistan` and country field mode should be `display`
@@ -340,7 +340,7 @@ class OwnLearnerProfilePageTest(LearnerProfileTestMixin, WebAppTest):
         Test behaviour of `Language` field.
 
         Given that I am a registered user.
-        And I visit My Profile page.
+        And I visit my Profile page.
         And I set the profile visibility to public and set default values for public fields.
         Then I set language value to `Urdu`.
         Then displayed language should be `Urdu` and language field mode should be `display`
@@ -369,7 +369,7 @@ class OwnLearnerProfilePageTest(LearnerProfileTestMixin, WebAppTest):
         Test behaviour of `About Me` field.
 
         Given that I am a registered user.
-        And I visit My Profile page.
+        And I visit my Profile page.
         And I set the profile visibility to public and set default values for public fields.
         Then I set about me value to `Eat Sleep Code`.
         Then displayed about me should be `Eat Sleep Code` and about me field mode should be `display`

--- a/lms/static/sass/shared/_header.scss
+++ b/lms/static/sass/shared/_header.scss
@@ -88,8 +88,6 @@ header.global {
     > a {
       @include background-image($button-bg-image);
       background-color: $button-bg-color;
-      border: 1px solid $border-color-2;
-      border-radius: 3px;
       @include box-sizing(border-box);
       box-shadow: 0 1px 0 0 rgba(255,255,255, 0.6);
       color: $base-font-color;
@@ -128,15 +126,12 @@ header.global {
 
       > a {
         margin: 0;
-        @include border-right-radius(0px);
         background-image: none;
       }
 
       &:last-child {
         > a {
-          @include border-radius(0, 4px, 4px, 0);
-          @include border-left(none);
-          padding: ($baseline/4) 8px 11px ($baseline/2);
+          padding: ($baseline/5) ($baseline/2);
 
           &.shopping-cart {
             border-radius: 4px;
@@ -149,7 +144,7 @@ header.global {
     }
 
     a.user-link {
-      @include padding(5px, 12px, 10px, 10px);
+      @include padding(5px, 2px, 10px, 10px);
       position: relative;
       text-transform: none;
       font-size: 14px;
@@ -437,8 +432,6 @@ header.global-new {
     > a {
       @include background-image($button-bg-image);
       background-color: $button-bg-color;
-      border: 1px solid $border-color-2;
-      border-radius: 3px;
       @include box-sizing(border-box);
       box-shadow: 0 1px 0 0 rgba(255,255,255, 0.6);
       color: $base-font-color;
@@ -482,7 +475,7 @@ header.global-new {
         > a {
           @include border-radius(0, 4px, 4px, 0);
           @include border-left(none);
-          padding: 5px 8px 7px 8px;
+          padding: ($baseline/5) ($baseline/2);
 
           &.shopping-cart {
             border-radius: 4px;
@@ -494,7 +487,7 @@ header.global-new {
       }
     }
      a.user-link {
-      @include padding(3px, 12px, 8px, 8px);
+      @include padding(5px, 2px, 10px, 10px);
       position: relative;
       text-transform: none;
       font-size: 14px;

--- a/lms/templates/navigation-edx.html
+++ b/lms/templates/navigation-edx.html
@@ -82,8 +82,8 @@ site_status_msg = get_site_status_msg(course_id)
         <ul class="dropdown-menu" aria-label="More Options" role="menu">
           <%block name="navigation_dropdown_menu_links" >
             <li><a href="${reverse('dashboard')}">${_("Dashboard")}</a></li>
-            <li><a href="${reverse('account_settings')}">${_("Account")}</a></li>
             <li><a href="${reverse('learner_profile', kwargs={'username': user.username})}">${_("Profile")}</a></li>
+            <li><a href="${reverse('account_settings')}">${_("Account")}</a></li>
           </%block>
           <li><a href="${reverse('logout')}" role="menuitem">${_("Sign Out")}</a></li>
         </ul>

--- a/lms/templates/navigation-edx.html
+++ b/lms/templates/navigation-edx.html
@@ -73,7 +73,6 @@ site_status_msg = get_site_status_msg(course_id)
     <ul class="user">
       <li class="primary">
         <a href="${reverse('dashboard')}" class="user-link">
-          <i class="icon fa fa-home" aria-hidden="true"></i>
           <span class="sr">${_("Dashboard for:")}</span>
           <div>${user.username}</div>
         </a>
@@ -82,8 +81,9 @@ site_status_msg = get_site_status_msg(course_id)
         <a href="#" class="dropdown" aria-haspopup="true" aria-expanded="false"><span class="sr">${_("More options dropdown")}</span> &#9662;</a>
         <ul class="dropdown-menu" aria-label="More Options" role="menu">
           <%block name="navigation_dropdown_menu_links" >
-            <li><a href="${reverse('account_settings')}">${_("Account Settings")}</a></li>
-            <li><a href="${reverse('learner_profile', kwargs={'username': user.username})}">${_("My Profile")}</a></li>
+            <li><a href="${reverse('dashboard')}">${_("Dashboard")}</a></li>
+            <li><a href="${reverse('account_settings')}">${_("Account")}</a></li>
+            <li><a href="${reverse('learner_profile', kwargs={'username': user.username})}">${_("Profile")}</a></li>
           </%block>
           <li><a href="${reverse('logout')}" role="menuitem">${_("Sign Out")}</a></li>
         </ul>

--- a/lms/templates/navigation.html
+++ b/lms/templates/navigation.html
@@ -79,7 +79,6 @@ site_status_msg = get_site_status_msg(course_id)
     <ol class="user">
       <li class="primary">
         <a href="${reverse('dashboard')}" class="user-link">
-          <i class="icon fa fa-home" aria-hidden="true"></i>
           <span class="sr">${_("Dashboard for:")}</span>
           <div>
           ${user.username}
@@ -90,8 +89,9 @@ site_status_msg = get_site_status_msg(course_id)
         <a href="#" class="dropdown" aria-haspopup="true" aria-expanded="false"><span class="sr">${_("More options dropdown")}</span><i class="fa fa-sort-desc" aria-hidden="true"></i></a>
         <ul class="dropdown-menu" aria-label="More Options" role="menu">
           <%block name="navigation_dropdown_menu_links" >
-            <li><a href="${reverse('account_settings')}">${_("Account Settings")}</a></li>
-            <li><a href="${reverse('learner_profile', kwargs={'username': user.username})}">${_("My Profile")}</a></li>
+            <li><a href="${reverse('dashboard')}">${_("Dashboard")}</a></li>
+            <li><a href="${reverse('account_settings')}">${_("Account")}</a></li>
+            <li><a href="${reverse('learner_profile', kwargs={'username': user.username})}">${_("Profile")}</a></li>
           </%block>
           <li><a href="${reverse('logout')}" role="menuitem">${_("Sign Out")}</a></li>
         </ul>

--- a/lms/templates/navigation.html
+++ b/lms/templates/navigation.html
@@ -90,8 +90,8 @@ site_status_msg = get_site_status_msg(course_id)
         <ul class="dropdown-menu" aria-label="More Options" role="menu">
           <%block name="navigation_dropdown_menu_links" >
             <li><a href="${reverse('dashboard')}">${_("Dashboard")}</a></li>
-            <li><a href="${reverse('account_settings')}">${_("Account")}</a></li>
             <li><a href="${reverse('learner_profile', kwargs={'username': user.username})}">${_("Profile")}</a></li>
+            <li><a href="${reverse('account_settings')}">${_("Account")}</a></li>
           </%block>
           <li><a href="${reverse('logout')}" role="menuitem">${_("Sign Out")}</a></li>
         </ul>


### PR DESCRIPTION
This PR removes extra chrome around the user menu, simplifying the design so it can be used throughout edx.org and the LMS without looking out of place. Changes: removed borders, tightened spacing between arrow and user name, added explicit menu item for user dashboard (but left link in place for user name), and simplified the list item names.

![closed-menu](https://cloud.githubusercontent.com/assets/4327102/7944739/86ecffe4-093a-11e5-92c7-c9b983fa13bf.png) 

![open-menu](https://cloud.githubusercontent.com/assets/4327102/7944738/86eb5630-093a-11e5-9794-974a1333f322.png)

@marcotuts and @AlasdairSwan can you review?
