### PR TITLE
Change a misleading doc string

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -218,3 +218,4 @@ Andrew Dekker <simultech@gmail.com>
 Christopher Lee <clee@edx.org>
 Mushtaq Ali <mushtaque.ali@arbisoft.com>
 Colin Fredericks <colin.fredericks@gmail.com>
+Xiaolu Xiong <beardeer@gmail.com>

--- a/lms/djangoapps/courseware/model_data.py
+++ b/lms/djangoapps/courseware/model_data.py
@@ -544,7 +544,7 @@ class UserStateSummaryCache(DjangoOrmFieldCache):
         with them.
 
         Arguments:
-            fields (list of str): Field names to return values for
+            fields (list of :class:`~Field`): Fields to return values for
             xblocks (list of :class:`~XBlock`): XBlocks to load fields for
             aside_types (list of str): Asides to load field for (which annotate the supplied
                 xblocks).


### PR DESCRIPTION
I am changing a doc string that is misleading in _read_objects method. The original text indicates 'fields' is a list of Python strings. However, where it uses 'fields' at https://github.com/edx/edx-platform/blob/master/lms/djangoapps/courseware/model_data.py#L555, the methods is calling an attribute called 'name' from elements of 'fields' and Python string doesn't have 'name', so I am changing the text to the more suitable 'Field' class, which has the 'name' attribute.  
