### PR TITLE
Fixed wiki pointing to old course's wiki in rerun courses.

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -1844,6 +1844,42 @@ class RerunCourseTest(ContentStoreTestCase):
             self.assertTrue(rerun_state.message.endswith("traceback"))
             self.assertEqual(len(rerun_state.message), CourseRerunState.MAX_MESSAGE_LENGTH)
 
+    def test_rerun_course_wiki_slug(self):
+        """
+        Test that unique wiki_slug is assigned to rerun course.
+        """
+        course_data = {
+            'org': 'edX',
+            'number': '123',
+            'display_name': 'Rerun Course',
+            'run': '2013'
+        }
+
+        source_wiki_slug = '{0}.{1}.{2}'.format(course_data['org'], course_data['number'], course_data['run'])
+
+        source_course_key = _get_course_id(self.store, course_data)
+        _create_course(self, source_course_key, course_data)
+        source_course = self.store.get_course(source_course_key)
+
+        # Verify created course's wiki_slug.
+        self.assertEquals(source_course.wiki_slug, source_wiki_slug)
+
+        destination_course_data = course_data
+        destination_course_data['run'] = '2013_Rerun'
+
+        destination_course_key = self.post_rerun_request(
+            source_course.id, destination_course_data=destination_course_data
+        )
+        self.verify_rerun_course(source_course.id, destination_course_key, destination_course_data['display_name'])
+        destination_course = self.store.get_course(destination_course_key)
+
+        destination_wiki_slug = '{0}.{1}.{2}'.format(
+            destination_course.id.org, destination_course.id.course, destination_course.id.run
+        )
+
+        # Verify rerun course's wiki_slug.
+        self.assertEquals(destination_course.wiki_slug, destination_wiki_slug)
+
 
 class ContentLicenseTest(ContentStoreTestCase):
     """

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -635,6 +635,14 @@ def _create_or_rerun_course(request):
         if display_name is not None:
             fields['display_name'] = display_name
 
+        # Set a unique wiki_slug for newly created courses. To maintain active wiki_slugs for
+        # existing xml courses this cannot be changed in CourseDescriptor.
+        # # TODO get rid of defining wiki slug in this org/course/run specific way and reconcile
+        # w/ xmodule.course_module.CourseDescriptor.__init__
+        wiki_slug = u"{0}.{1}.{2}".format(org, course, run)
+        definition_data = {'wiki_slug': wiki_slug}
+        fields.update(definition_data)
+
         if 'source_course_key' in request.json:
             return _rerun_course(request, org, course, run, fields)
         else:
@@ -679,13 +687,6 @@ def create_new_course_in_store(store, user, org, number, run, fields):
     Create course in store w/ handling instructor enrollment, permissions, and defaulting the wiki slug.
     Separated out b/c command line course creation uses this as well as the web interface.
     """
-    # Set a unique wiki_slug for newly created courses. To maintain active wiki_slugs for
-    # existing xml courses this cannot be changed in CourseDescriptor.
-    # # TODO get rid of defining wiki slug in this org/course/run specific way and reconcile
-    # w/ xmodule.course_module.CourseDescriptor.__init__
-    wiki_slug = u"{0}.{1}.{2}".format(org, number, run)
-    definition_data = {'wiki_slug': wiki_slug}
-    fields.update(definition_data)
 
     # Set default language from settings
     fields.update({'language': getattr(settings, 'DEFAULT_COURSE_LANGUAGE', 'en')})


### PR DESCRIPTION
[TNL-2314](https://openedx.atlassian.net/browse/TNL-2314)

On course rerun in split it was just copying the same `wiki_slug` of the old course into new rerun course.

There was already code for unique `wiki_slug` in `create_new_course_in_store()`, I moved that code into `_create_or_rerun_course()` to fix this issue.
Now it will create a unique `wiki_slug` for both new and rerun courses.

Added unit test.
