### PR TITLE
Added application and course scss files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,10 @@ bin/
 lms/static/css/
 lms/static/sass/*.css
 lms/static/sass/*.css.map
+lms/static/sass/application-rtl.scss
+lms/static/sass/application.scss
+lms/static/sass/course-rtl.scss
+lms/static/sass/course.scss
 lms/static/sass/lms-main.scss
 lms/static/sass/lms-main-rtl.scss
 lms/static/sass/lms-course.scss


### PR DESCRIPTION
In particular, I added the following four stylesheets to .gitignore to prevent having to stash or revert changes when changing branches, etc:
1. lms/static/sass/application-rtl.scss
2. lms/static/sass/application.scss
3. lms/static/sass/course-rtl.scss
4. lms/static/sass/course.scss

@wedaly @clintonb 
