### PR TITLE
[LTI Provider] Bugfix in LtiConsumer handling code

### DIFF
--- a/lms/djangoapps/lti_provider/models.py
+++ b/lms/djangoapps/lti_provider/models.py
@@ -62,7 +62,6 @@ class LtiConsumer(models.Model):
         if not consumer:
             consumer = LtiConsumer.objects.get(
                 consumer_key=consumer_key,
-                instance_guid=instance_guid if instance_guid else None
             )
 
         # Add the instance_guid field to the model if it's not there already.

--- a/lms/djangoapps/lti_provider/tests/test_views.py
+++ b/lms/djangoapps/lti_provider/tests/test_views.py
@@ -257,6 +257,17 @@ class LtiRunTest(TestCase):
         views.lti_run(request)
         self.assertNotIn(views.LTI_SESSION_KEY, request.session)
 
+    @patch('lti_provider.views.render_courseware')
+    def test_lti_consumer_record_supplemented_with_guid(self, _render):
+        request = build_run_request()
+        request.session[views.LTI_SESSION_KEY]['tool_consumer_instance_guid'] = 'instance_guid'
+        with self.assertNumQueries(4):
+            views.lti_run(request)
+        consumer = models.LtiConsumer.objects.get(
+            consumer_key=LTI_DEFAULT_PARAMS['oauth_consumer_key']
+        )
+        self.assertEqual(consumer.instance_guid, 'instance_guid')
+
 
 class RenderCoursewareTest(TestCase):
     """


### PR DESCRIPTION
The line below was left in during the refactoring shuffle from PR https://github.com/edx/edx-platform/pull/8205, and causes an issue in a corner case where an LTI launch provides an instance GUID where there wasn't one already set for the consumer. This change fixes the bug, and adds a test to prevent it from recurring.
