### PR TITLE
Add tests for enrollment deactivation under various modes.

### DIFF
--- a/common/djangoapps/enrollment/views.py
+++ b/common/djangoapps/enrollment/views.py
@@ -425,7 +425,7 @@ class EnrollmentListView(APIView, ApiKeyPermissionMixIn):
                 response = api.update_enrollment(username, unicode(course_id), mode=mode, is_active=is_active)
             else:
                 # Will reactivate inactive enrollments.
-                response = api.add_enrollment(username, unicode(course_id), mode=mode)
+                response = api.add_enrollment(username, unicode(course_id), mode=mode, is_active=is_active)
 
             email_opt_in = request.DATA.get('email_opt_in', None)
             if email_opt_in is not None:


### PR DESCRIPTION
XCOM-388

This PR jacks up our test coverage around deactivation of enrollments using the enrollment api.  The primary motivation for these changes is to build confidence around a fix for an integration bug in [this ecommerce PR](https://github.com/edx/ecommerce/pull/123).  There's no reasonable way to automate verification of that fix.

While adding this coverage I discovered and fixed a bug that caused the value of `is_active` to be ignored when creating honor enrollments via the api.  I'm fairly certain this bug has never been awakened outside of test scenarios, since there's no real use case I can think of to create an honor enrollment with an inactive state. 

@clintonb OR @rlucioni 
@wedaly FYI
