### PR TITLE
Allow released languages to be previewed under dark lang

### DIFF
--- a/common/djangoapps/dark_lang/middleware.py
+++ b/common/djangoapps/dark_lang/middleware.py
@@ -126,7 +126,4 @@ class DarkLangMiddleware(object):
         if not preview_lang:
             return
 
-        if preview_lang in self.released_langs:
-            return
-
         request.session['django_language'] = preview_lang

--- a/common/djangoapps/dark_lang/tests.py
+++ b/common/djangoapps/dark_lang/tests.py
@@ -155,13 +155,14 @@ class DarkLangMiddlewareTests(TestCase):
         )
 
     def test_preview_lang_with_released_language(self):
+        # Preview lang should always override selection.
         self.assertSessionLangEquals(
-            UNSET,
+            'rel',
             self.process_request(preview_lang='rel')
         )
 
         self.assertSessionLangEquals(
-            'notrel',
+            'rel',
             self.process_request(preview_lang='rel', django_language='notrel')
         )
 


### PR DESCRIPTION
I don't really understand the original logic that explicitly prohibited you from using the `?preview-lang=` query param for a released language. It doesn't make sense to me to prohibit that, and in practice it's very annoying when you're in an environment that for whatever reason has a bunch of languages released and you want to just quickly see the page in Arabic, rather than navigating to your account settings and explicitly change your language.

An example of this is on Stage, where Arabic is a released language (this is to be able to test the behavior of visiting pages while not logged in but browser preferences set to Arabic). `?preview-lang=ar` doesn't work but I don't see a compelling reason to prohibit that.
