### PR TITLE
MIT CCX: Use CCX Keys

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -1195,6 +1195,13 @@ class CourseEnrollment(models.Model):
         """
         if not user.is_authenticated():
             return False
+
+        # unwrap CCXLocators so that we use the course as the access control
+        # source
+        from ccx_keys.locator import CCXLocator
+        if isinstance(course_key, CCXLocator):
+            course_key = course_key.to_course_locator()
+
         try:
             record = CourseEnrollment.objects.get(user=user, course_id=course_key)
             return record.is_active

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -618,14 +618,10 @@ def dashboard(request):
 
     ccx_membership_triplets = []
     if settings.FEATURES.get('CUSTOM_COURSES_EDX', False):
-        from ccx import ACTIVE_CCX_KEY
         from ccx.utils import get_ccx_membership_triplets
         ccx_membership_triplets = get_ccx_membership_triplets(
             user, course_org_filter, org_filter_out_set
         )
-        # should we deselect any active CCX at this time so that we don't have
-        # to change the URL for viewing a course?  I think so.
-        request.session[ACTIVE_CCX_KEY] = None
 
     context = {
         'enrollment_message': enrollment_message,

--- a/common/lib/xmodule/xmodule/modulestore/django.py
+++ b/common/lib/xmodule/xmodule/modulestore/django.py
@@ -194,7 +194,12 @@ def modulestore():
         )
 
         if settings.FEATURES.get('CUSTOM_COURSES_EDX'):
-            from ccx.modulestore import CCXModulestoreWrapper
+            # TODO: This import prevents a circular import issue, but is
+            # symptomatic of a lib having a dependency on code in lms.  This
+            # should be updated to have a setting that enumerates modulestore
+            # wrappers and then uses that setting to wrap the modulestore in
+            # appropriate wrappers depending on enabled features.
+            from ccx.modulestore import CCXModulestoreWrapper  # pylint: disable=import-error
             _MIXED_MODULESTORE = CCXModulestoreWrapper(_MIXED_MODULESTORE)
 
     return _MIXED_MODULESTORE

--- a/common/lib/xmodule/xmodule/modulestore/django.py
+++ b/common/lib/xmodule/xmodule/modulestore/django.py
@@ -193,6 +193,10 @@ def modulestore():
             settings.MODULESTORE['default'].get('OPTIONS', {})
         )
 
+        if settings.FEATURES.get('CUSTOM_COURSES_EDX'):
+            from ccx.modulestore import CCXModulestoreWrapper
+            _MIXED_MODULESTORE = CCXModulestoreWrapper(_MIXED_MODULESTORE)
+
     return _MIXED_MODULESTORE
 
 

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/caching_descriptor_system.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/caching_descriptor_system.py
@@ -72,6 +72,9 @@ class CachingDescriptorSystem(MakoDescriptorSystem, EditInfoRuntimeMixin):
         )
         self.modulestore = modulestore
         self.course_entry = course_entry
+        # set course_id attribute to avoid problems with subsystems that expect
+        # it here. (grading, for example)
+        self.course_id = course_entry.course_key
         self.lazy = lazy
         self.module_data = module_data
         self.default_class = default_class

--- a/lms/djangoapps/ccx/__init__.py
+++ b/lms/djangoapps/ccx/__init__.py
@@ -1,4 +1,0 @@
-"""
-we use this to mark the active ccx, for use by ccx middleware and some views
-"""
-ACTIVE_CCX_KEY = '_ccx_id'

--- a/lms/djangoapps/ccx/modulestore.py
+++ b/lms/djangoapps/ccx/modulestore.py
@@ -1,0 +1,312 @@
+# -*- coding: utf-8 -*-
+"""A modulestore wrapper
+
+It will 'unwrap' ccx keys on the way in and re-wrap them on the way out
+
+In practical terms this means that when an object is retrieved from modulestore
+using a CCXLocator or CCXBlockUsageLocator as the key, the equivalent
+CourseLocator or BlockUsageLocator will actually be used. And all objects
+returned from the modulestore will have their keys updated to be the CCX
+version that was passed in.
+"""
+from contextlib import contextmanager
+from ccx_keys.locator import CCXLocator, CCXBlockUsageLocator
+from opaque_keys.edx.locator import CourseLocator, BlockUsageLocator
+
+
+def ccx_locator_to_course_locator(ccx_locator):
+    return CourseLocator(
+        org=ccx_locator.org,
+        course=ccx_locator.course,
+        run=ccx_locator.run,
+        branch=ccx_locator.branch,
+        version_guid=ccx_locator.version_guid,
+    )
+
+
+def strip_ccx(val):
+    retval = val
+    ccx_id = None
+    if hasattr(retval, 'ccx'):
+        if isinstance(retval, CCXLocator):
+            ccx_id = retval.ccx
+            retval = ccx_locator_to_course_locator(retval)
+        elif isinstance(object, CCXBlockUsageLocator):
+            ccx_locator = retval.course_key
+            ccx_id = ccx_locator.ccx
+            course_locator = ccx_locator_to_course_locator(ccx_locator)
+            retval = BlockUsageLocator(
+                course_locator, retval.block_type, retval.block_id
+            )
+    if hasattr(retval, 'location'):
+        retval.location, ccx_id = strip_ccx(retval.location)
+    return retval, ccx_id
+
+
+def restore_ccx(val, ccx_id):
+    if isinstance(val, CourseLocator):
+        return CCXLocator.from_course_locator(val, ccx_id)
+    elif isinstance(val, BlockUsageLocator):
+        ccx_key = restore_ccx(val.course_key, ccx_id)
+        val = CCXBlockUsageLocator(ccx_key, val.block_type, val.block_id)
+    if hasattr(val, 'location'):
+        val.location = restore_ccx(val.location, ccx_id)
+    if hasattr(val, 'children'):
+        val.children = restore_ccx_collection(val.children, ccx_id)
+    return val
+
+
+def restore_ccx_collection(field_value, ccx_id):
+    if isinstance(field_value, list):
+        field_value = [restore_ccx(fv, ccx_id) for fv in field_value]
+    elif isinstance(field_value, dict):
+        for key, val in field_value.iteritems():
+            field_value[key] = restore_ccx(val, ccx_id)
+    else:
+        field_value = restore_ccx(field_value, ccx_id)
+    return field_value
+
+
+class CCXModulestoreWrapper(object):
+
+    def __init__(self, modulestore):
+        self._modulestore = modulestore
+
+    def __getattr__(self, name):
+        """pass missing attributes through to _modulestore
+        """
+        return getattr(self._modulestore, name)
+
+    def _clean_locator_for_mapping(self, locator):
+        locator, ccx = strip_ccx(locator)
+        retval = self._modulestore._clean_locator_for_mapping(locator)
+        if ccx:
+            retval = restore_ccx_collection(retval, ccx)
+        return retval
+
+    def _get_modulestore_for_courselike(self, locator=None):
+        if locator is not None:
+            locator, _ = strip_ccx(locator)
+        return self._modulestore._get_modulestore_for_courselike(locator)
+
+    def fill_in_run(self, course_key):
+        """
+        Some course_keys are used without runs. This function calls the corresponding
+        fill_in_run function on the appropriate modulestore.
+        """
+        course_key, ccx = strip_ccx(course_key)
+        retval = self._modulestore.fill_in_run(course_key)
+        if ccx:
+            retval = restore_ccx_collection(retval, ccx)
+        return retval
+
+    def has_item(self, usage_key, **kwargs):
+        """
+        Does the course include the xblock who's id is reference?
+        """
+        usage_key, ccx = strip_ccx(usage_key)
+        return self._modulestore.has_item(usage_key, **kwargs)
+
+    def get_item(self, usage_key, depth=0, **kwargs):
+        """
+        see parent doc
+        """
+        usage_key, ccx = strip_ccx(usage_key)
+        retval = self._modulestore.get_item(usage_key, depth, **kwargs)
+        if ccx:
+            retval = restore_ccx_collection(retval, ccx)
+        return retval
+
+    def get_items(self, course_key, **kwargs):
+        course_key, ccx = strip_ccx(course_key)
+        retval = self._modulestore.get_items(course_key, **kwargs)
+        if ccx:
+            retval = restore_ccx_collection(retval, ccx)
+        return retval
+
+    def get_course(self, course_key, depth=0, **kwargs):
+        # from nose.tools import set_trace; set_trace()
+        course_key, ccx = strip_ccx(course_key)
+        retval = self._modulestore.get_course(course_key, depth=depth, **kwargs)
+        if ccx:
+            retval = restore_ccx_collection(retval, ccx)
+        return retval
+
+    def has_course(self, course_id, ignore_case=False, **kwargs):
+        course_id, ccx = strip_ccx(course_id)
+        retval = self._modulestore.has_course(
+            course_id, ignore_case=ignore_case, **kwargs
+        )
+        if ccx:
+            retval = restore_ccx_collection(retval, ccx)
+        return retval
+
+    def delete_course(self, course_key, user_id):
+        """
+        See xmodule.modulestore.__init__.ModuleStoreWrite.delete_course
+        """
+        course_key, ccx = strip_ccx(course_key)
+        return self._modulestore.delete_course(course_key, user_id)
+
+    def get_parent_location(self, location, **kwargs):
+        location, ccx = strip_ccx(location)
+        retval = self._modulestore.get_parent_location(location, **kwargs)
+        if ccx:
+            retval = restore_ccx_collection(retval, ccx)
+        return retval
+
+    def get_block_original_usage(self, usage_key):
+        usage_key, ccx = strip_ccx(usage_key)
+        orig_key, version = self._modulestore.get_block_original_usage(usage_key)
+        if orig_key and ccx:
+            orig_key = restore_ccx_collection(orig_key, ccx)
+        return orig_key, version
+
+    def get_modulestore_type(self, course_id):
+        course_id, ccx = strip_ccx(course_id)
+        retval = self._modulestore.get_modulestore_type(course_id)
+        if ccx:
+            retval = restore_ccx_collection(retval, ccx)
+        return retval
+
+    def get_orphans(self, course_key, **kwargs):
+        course_key, ccx = strip_ccx(course_key)
+        retval = self._modulestore.get_orphans(course_key, **kwargs)
+        if ccx:
+            retval = restore_ccx_collection(retval, ccx)
+        return retval
+
+    def clone_course(self, source_course_id, dest_course_id, user_id, fields=None, **kwargs):
+        source_course_id, source_ccx = strip_ccx(source_course_id)
+        dest_course_id, dest_ccx = strip_ccx(dest_course_id)
+        retval = self._modulestore.clone_course(
+            source_course_id, dest_course_id, user_id, fields=fields, **kwargs
+        )
+        if dest_ccx:
+            retval = restore_ccx_collection(retval, dest_ccx)
+        return retval
+
+    def create_item(self, user_id, course_key, block_type, block_id=None, fields=None, **kwargs):
+        course_key, ccx = strip_ccx(course_key)
+        retval = self._modulestore.create_item(
+            user_id, course_key, block_type, block_id=block_id, fields=fields, **kwargs
+        )
+        if ccx:
+            retval = restore_ccx_collection(retval, ccx)
+        return retval
+
+    def create_child(self, user_id, parent_usage_key, block_type, block_id=None, fields=None, **kwargs):
+        parent_usage_key, ccx = strip_ccx(parent_usage_key)
+        retval = self._modulestore.create_child(
+            user_id, parent_usage_key, block_type, block_id=block_id, fields=fields, **kwargs
+        )
+        if ccx:
+            retval = restore_ccx_collection(retval, ccx)
+        return retval
+
+    def import_xblock(self, user_id, course_key, block_type, block_id, fields=None, runtime=None, **kwargs):
+        course_key, ccx = strip_ccx(course_key)
+        retval = self._modulestore.import_xblock(
+            user_id, course_key, block_type, block_id, fields=fields, runtime=runtime, **kwargs
+        )
+        if ccx:
+            retval = restore_ccx_collection(retval, ccx)
+        return retval
+
+    def copy_from_template(self, source_keys, dest_key, user_id, **kwargs):
+        dest_key, ccx = strip_ccx(dest_key)
+        retval = self._modulestore.copy_from_template(
+            source_keys, dest_key, user_id, **kwargs
+        )
+        if ccx:
+            retval = restore_ccx_collection(retval, ccx)
+        return retval
+
+    def update_item(self, xblock, user_id, allow_not_found=False, **kwargs):
+        xblock, ccx = strip_ccx(xblock)
+        retval = self._modulestore.update_item(
+            xblock, user_id, allow_not_found=allow_not_found, **kwargs
+        )
+        if ccx:
+            retval = restore_ccx_collection(retval, ccx)
+        return retval
+
+    def delete_item(self, location, user_id, **kwargs):
+        location, ccx = strip_ccx(location)
+        retval = self._modulestore.delete_item(location, user_id, **kwargs)
+        if ccx:
+            retval = restore_ccx_collection(retval, ccx)
+        return retval
+
+    def revert_to_published(self, location, user_id):
+        location, ccx = strip_ccx(location)
+        retval = self._modulestore.revert_to_published(location, user_id)
+        if ccx:
+            retval = restore_ccx_collection(retval, ccx)
+        return retval
+
+    def create_xblock(self, runtime, course_key, block_type, block_id=None, fields=None, **kwargs):
+        course_key, ccx = strip_ccx(course_key)
+        retval = self._modulestore.create_xblock(
+            runtime, course_key, block_type, block_id=block_id, fields=fields, **kwargs
+        )
+        if ccx:
+            retval = restore_ccx_collection(retval, ccx)
+        return retval
+
+    def has_published_version(self, xblock):
+        xblock.scope_ids.usage_id.course_key, ccx = strip_ccx(
+            xblock.scope_ids.usage_id.course_key
+        )
+        retval = self._modulestore.has_published_version(xblock)
+        if ccx:
+            retval = restore_ccx_collection(retval, ccx)
+        return retval
+
+    def publish(self, location, user_id, **kwargs):
+        location, ccx = strip_ccx(location)
+        retval = self._modulestore.publish(location, user_id, **kwargs)
+        if ccx:
+            retval = restore_ccx_collection(retval, ccx)
+        return retval
+
+    def unpublish(self, location, user_id, **kwargs):
+        location, ccx = strip_ccx(location)
+        retval = self._modulestore.unpublish(location, user_id, **kwargs)
+        if ccx:
+            retval = restore_ccx_collection(retval, ccx)
+        return retval
+
+    def convert_to_draft(self, location, user_id):
+        location, ccx = strip_ccx(location)
+        retval = self._modulestore.convert_to_draft(location, user_id)
+        if ccx:
+            retval = restore_ccx_collection(retval, ccx)
+        return retval
+
+    def has_changes(self, xblock):
+        xblock.location, ccx = strip_ccx(xblock.location)
+        retval = self._modulestore.has_changes(xblock)
+        if ccx:
+            retval = restore_ccx_collection(retval, ccx)
+        return retval
+
+    def check_supports(self, course_key, method):
+        course_key, _ = strip_ccx(course_key)
+        return self._modulestore.check_supports(course_key, method)
+
+    @contextmanager
+    def branch_setting(self, branch_setting, course_id=None):
+        """
+        A context manager for temporarily setting the branch value for the given course' store
+        to the given branch_setting.  If course_id is None, the default store is used.
+        """
+        course_id, _ = strip_ccx(course_id)
+        with self._modulestore.branch_setting(branch_setting, course_id):
+            yield
+
+    @contextmanager
+    def bulk_operations(self, course_id, emit_signals=True):
+        course_id, _ = strip_ccx(course_id)
+        with self._modulestore.bulk_operations(course_id, emit_signals=emit_signals):
+            yield

--- a/lms/djangoapps/ccx/tests/test_ccx_modulestore.py
+++ b/lms/djangoapps/ccx/tests/test_ccx_modulestore.py
@@ -1,0 +1,116 @@
+"""
+Test the CCXModulestoreWrapper
+"""
+from collections import deque
+from ccx_keys.locator import CCXLocator, CCXBlockUsageLocator
+import datetime
+from itertools import izip_longest
+import pytz
+from student.tests.factories import (  # pylint: disable=import-error
+    AdminFactory,
+    CourseEnrollmentFactory,
+    UserFactory,
+)
+from xmodule.modulestore.tests.django_utils import (
+    ModuleStoreTestCase,
+    TEST_DATA_SPLIT_MODULESTORE)
+from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+
+from ..models import CustomCourseForEdX
+
+
+def flatten(seq):
+    """
+    For [[1, 2], [3, 4]] returns [1, 2, 3, 4].  Does not recurse.
+    """
+    return [x for sub in seq for x in sub]
+
+
+class TestCCXModulestoreWrapper(ModuleStoreTestCase):
+    """tests for a modulestore wrapped by CCXModulestoreWrapper
+    """
+    MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
+
+    def setUp(self):
+        """
+        Set up tests
+        """
+        super(TestCCXModulestoreWrapper, self).setUp()
+        course = CourseFactory.create()
+
+        # Create instructor account
+        coach = AdminFactory.create()
+
+        # Create a course outline
+        self.mooc_start = start = datetime.datetime(
+            2010, 5, 12, 2, 42, tzinfo=pytz.UTC)
+        self.mooc_due = due = datetime.datetime(
+            2010, 7, 7, 0, 0, tzinfo=pytz.UTC)
+        chapters = [ItemFactory.create(start=start, parent=course)
+                    for _ in xrange(2)]
+        sequentials = flatten([
+            [
+                ItemFactory.create(parent=chapter) for _ in xrange(2)
+            ] for chapter in chapters
+        ])
+        verticals = flatten([
+            [
+                ItemFactory.create(
+                    due=due, parent=sequential, graded=True, format='Homework'
+                ) for _ in xrange(2)
+            ] for sequential in sequentials
+        ])
+        blocks = flatten([  # pylint: disable=unused-variable
+            [
+                ItemFactory.create(parent=vertical) for _ in xrange(2)
+            ] for vertical in verticals
+        ])
+
+        self.ccx = ccx = CustomCourseForEdX(
+            course_id=course.id,
+            display_name='Test CCX',
+            coach=coach
+        )
+        ccx.save()
+
+        self.ccx_locator = CCXLocator.from_course_locator(course.id, ccx.id)
+
+    def get_all_children_bf(self, block):
+        queue = deque([block])
+        while queue:
+            item = queue.popleft()
+            yield item
+            queue.extend(item.get_children())
+
+    def get_course(self, key):
+        """get a course given a key"""
+        with self.store.bulk_operations(key):
+            course = self.store.get_course(key)
+        return course
+
+    def test_get_course(self):
+        """retrieving a course with a ccx key works"""
+        expected = self.get_course(self.ccx_locator.to_course_locator())
+        actual = self.get_course(self.ccx_locator)
+        self.assertEqual(
+            expected.location.course_key,
+            actual.location.course_key.to_course_locator())
+        self.assertEqual(expected.display_name, actual.display_name)
+
+    def test_get_children(self):
+        """the children of retrieved courses should be the same with course and ccx keys
+        """
+        course_key = self.ccx_locator.to_course_locator()
+        course = self.get_course(course_key)
+        ccx = self.get_course(self.ccx_locator)
+        for expected, actual in izip_longest(
+            self.get_all_children_bf(course), self.get_all_children_bf(ccx)
+        ):
+            if expected is None:
+                self.fail('course children exhausted before ccx children')
+            if actual is None:
+                self.fail('ccx children exhausted before course children')
+            self.assertEqual(expected.display_name, actual.display_name)
+            self.assertEqual(expected.location.course_key, course_key)
+            self.assertEqual(actual.location.course_key, self.ccx_locator)
+

--- a/lms/djangoapps/ccx/tests/test_ccx_modulestore.py
+++ b/lms/djangoapps/ccx/tests/test_ccx_modulestore.py
@@ -48,23 +48,17 @@ class TestCCXModulestoreWrapper(ModuleStoreTestCase):
             2010, 7, 7, 0, 0, tzinfo=pytz.UTC)
         chapters = [ItemFactory.create(start=start, parent=course)
                     for _ in xrange(2)]
-        sequentials = flatten([
-            [
-                ItemFactory.create(parent=chapter) for _ in xrange(2)
-            ] for chapter in chapters
-        ])
-        verticals = flatten([
-            [
-                ItemFactory.create(
-                    due=due, parent=sequential, graded=True, format='Homework'
-                ) for _ in xrange(2)
-            ] for sequential in sequentials
-        ])
-        blocks = flatten([  # pylint: disable=unused-variable
-            [
-                ItemFactory.create(parent=vertical) for _ in xrange(2)
-            ] for vertical in verticals
-        ])
+        sequentials = [
+            ItemFactory.create(parent=c) for _ in xrange(2) for c in chapters
+        ]
+        verticals = [
+            ItemFactory.create(
+                due=due, parent=s, graded=True, format='Homework'
+            ) for _ in xrange(2) for s in sequentials
+        ]
+        blocks = [
+            ItemFactory.create(parent=v) for _ in xrange(2) for v in verticals
+        ]
 
         self.ccx = ccx = CustomCourseForEdX(
             course_id=course.id,

--- a/lms/djangoapps/ccx/tests/test_overrides.py
+++ b/lms/djangoapps/ccx/tests/test_overrides.py
@@ -9,7 +9,9 @@ from nose.plugins.attrib import attr
 from courseware.field_overrides import OverrideFieldData  # pylint: disable=import-error
 from django.test.utils import override_settings
 from student.tests.factories import AdminFactory  # pylint: disable=import-error
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import (
+    ModuleStoreTestCase,
+    TEST_DATA_SPLIT_MODULESTORE)
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
 from ..models import CustomCourseForEdX
@@ -25,6 +27,7 @@ class TestFieldOverrides(ModuleStoreTestCase):
     """
     Make sure field overrides behave in the expected manner.
     """
+    MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
     def setUp(self):
         """
         Set up tests
@@ -64,7 +67,7 @@ class TestFieldOverrides(ModuleStoreTestCase):
         # sure if there's a way to poke the test harness to do so.  So, we'll
         # just inject the override field storage in this brute force manner.
         OverrideFieldData.provider_classes = None
-        for block in iter_blocks(course):
+        for block in iter_blocks(ccx.course):
             block._field_data = OverrideFieldData.wrap(   # pylint: disable=protected-access
                 AdminFactory.create(), block._field_data)   # pylint: disable=protected-access
 
@@ -81,7 +84,7 @@ class TestFieldOverrides(ModuleStoreTestCase):
         Test that overriding start date on a chapter works.
         """
         ccx_start = datetime.datetime(2014, 12, 25, 00, 00, tzinfo=pytz.UTC)
-        chapter = self.course.get_children()[0]
+        chapter = self.ccx.course.get_children()[0]
         override_field_for_ccx(self.ccx, chapter, 'start', ccx_start)
         self.assertEquals(chapter.start, ccx_start)
 
@@ -90,7 +93,7 @@ class TestFieldOverrides(ModuleStoreTestCase):
         Test that overriding and accessing a field produce same number of queries.
         """
         ccx_start = datetime.datetime(2014, 12, 25, 00, 00, tzinfo=pytz.UTC)
-        chapter = self.course.get_children()[0]
+        chapter = self.ccx.course.get_children()[0]
         with self.assertNumQueries(4):
             override_field_for_ccx(self.ccx, chapter, 'start', ccx_start)
             dummy = chapter.start
@@ -100,7 +103,7 @@ class TestFieldOverrides(ModuleStoreTestCase):
         Test no extra queries when accessing an overriden field more than once.
         """
         ccx_start = datetime.datetime(2014, 12, 25, 00, 00, tzinfo=pytz.UTC)
-        chapter = self.course.get_children()[0]
+        chapter = self.ccx.course.get_children()[0]
         with self.assertNumQueries(4):
             override_field_for_ccx(self.ccx, chapter, 'start', ccx_start)
             dummy1 = chapter.start
@@ -112,7 +115,7 @@ class TestFieldOverrides(ModuleStoreTestCase):
         Test that sequentials inherit overridden start date from chapter.
         """
         ccx_start = datetime.datetime(2014, 12, 25, 00, 00, tzinfo=pytz.UTC)
-        chapter = self.course.get_children()[0]
+        chapter = self.ccx.course.get_children()[0]
         override_field_for_ccx(self.ccx, chapter, 'start', ccx_start)
         self.assertEquals(chapter.get_children()[0].start, ccx_start)
         self.assertEquals(chapter.get_children()[1].start, ccx_start)
@@ -124,7 +127,7 @@ class TestFieldOverrides(ModuleStoreTestCase):
         the mooc.
         """
         ccx_due = datetime.datetime(2015, 1, 1, 00, 00, tzinfo=pytz.UTC)
-        chapter = self.course.get_children()[0]
+        chapter = self.ccx.course.get_children()[0]
         chapter.display_name = 'itsme!'
         override_field_for_ccx(self.ccx, chapter, 'due', ccx_due)
         vertical = chapter.get_children()[0].get_children()[0]

--- a/lms/djangoapps/ccx/tests/test_overrides.py
+++ b/lms/djangoapps/ccx/tests/test_overrides.py
@@ -28,6 +28,7 @@ class TestFieldOverrides(ModuleStoreTestCase):
     Make sure field overrides behave in the expected manner.
     """
     MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
+
     def setUp(self):
         """
         Set up tests

--- a/lms/djangoapps/ccx/tests/test_utils.py
+++ b/lms/djangoapps/ccx/tests/test_utils.py
@@ -69,9 +69,9 @@ class TestEmailEnrollmentState(ModuleStoreTestCase):
         """verify behavior for non-user email address
         """
         ee_state = self.create_one(email='nobody@nowhere.com')
-        for attr in ['user', 'member', 'full_name', 'in_ccx']:
-            value = getattr(ee_state, attr, 'missing attribute')
-            self.assertFalse(value, "{}: {}".format(value, attr))
+        for attribute in ['user', 'member', 'full_name', 'in_ccx']:
+            value = getattr(ee_state, attribute, 'missing attribute')
+            self.assertFalse(value, "{}: {}".format(value, attribute))
 
     def test_enrollment_state_for_non_member_user(self):
         """verify behavior for email address of user who is not a ccx memeber
@@ -89,10 +89,10 @@ class TestEmailEnrollmentState(ModuleStoreTestCase):
         self.create_user()
         self.register_user_in_ccx()
         ee_state = self.create_one()
-        for attr in ['user', 'in_ccx']:
+        for attribute in ['user', 'in_ccx']:
             self.assertTrue(
-                getattr(ee_state, attr, False),
-                "attribute {} is missing or False".format(attr)
+                getattr(ee_state, attribute, False),
+                "attribute {} is missing or False".format(attribute)
             )
         self.assertEqual(ee_state.member, self.user)
         self.assertEqual(ee_state.full_name, self.user.profile.name)

--- a/lms/djangoapps/ccx/tests/test_views.py
+++ b/lms/djangoapps/ccx/tests/test_views.py
@@ -11,6 +11,7 @@ from mock import patch, MagicMock
 from nose.plugins.attrib import attr
 
 from capa.tests.response_xml_factory import StringResponseXMLFactory
+from courseware.courses import get_course_by_id  # pyline: disable=import-error
 from courseware.field_overrides import OverrideFieldData  # pylint: disable=import-error
 from courseware.tests.factories import StudentModuleFactory  # pylint: disable=import-error
 from courseware.tests.helpers import LoginEnrollmentTestCase  # pylint: disable=import-error
@@ -28,19 +29,22 @@ from student.tests.factories import (  # pylint: disable=import-error
 
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
 from xmodule.x_module import XModuleMixin
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import (
+    ModuleStoreTestCase,
+    TEST_DATA_SPLIT_MODULESTORE)
 from xmodule.modulestore.tests.factories import (
     CourseFactory,
     ItemFactory,
 )
 import xmodule.tabs as tabs
+from ccx_keys.locator import CCXLocator
+
 from ..models import (
     CustomCourseForEdX,
     CcxMembership,
     CcxFutureMembership,
 )
 from ..overrides import get_override_for_ccx, override_field_for_ccx
-from .. import ACTIVE_CCX_KEY
 from .factories import (
     CcxFactory,
     CcxMembershipFactory,
@@ -78,6 +82,7 @@ class TestCoachDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     Tests for Custom Courses views.
     """
+    MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
     def setUp(self):
         """
         Set up tests
@@ -139,9 +144,10 @@ class TestCoachDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase):
         """
         User is not a coach, should get Forbidden response.
         """
+        ccx = self.make_ccx()
         url = reverse(
             'ccx_coach_dashboard',
-            kwargs={'course_id': self.course.id.to_deprecated_string()})
+            kwargs={'course_id': CCXLocator.from_course_locator(self.course.id, ccx.id)})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 403)
 
@@ -182,14 +188,15 @@ class TestCoachDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase):
         Get CCX schedule, modify it, save it.
         """
         today.return_value = datetime.datetime(2014, 11, 25, tzinfo=pytz.UTC)
-        self.test_create_ccx()
+        self.make_coach()
+        ccx = self.make_ccx()
         url = reverse(
             'ccx_coach_dashboard',
-            kwargs={'course_id': self.course.id.to_deprecated_string()})
+            kwargs={'course_id': CCXLocator.from_course_locator(self.course.id, ccx.id)})
         response = self.client.get(url)
         schedule = json.loads(response.mako_context['schedule'])  # pylint: disable=no-member
         self.assertEqual(len(schedule), 2)
-        self.assertEqual(schedule[0]['hidden'], True)
+        self.assertEqual(schedule[0]['hidden'], False)
         self.assertEqual(schedule[0]['start'], None)
         self.assertEqual(schedule[0]['children'][0]['start'], None)
         self.assertEqual(schedule[0]['due'], None)
@@ -200,7 +207,7 @@ class TestCoachDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase):
 
         url = reverse(
             'save_ccx',
-            kwargs={'course_id': self.course.id.to_deprecated_string()})
+            kwargs={'course_id': CCXLocator.from_course_locator(self.course.id, ccx.id)})
 
         def unhide(unit):
             """
@@ -235,7 +242,7 @@ class TestCoachDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase):
         policy = get_override_for_ccx(ccx, self.course, 'grading_policy',
                                       self.course.grading_policy)
         self.assertEqual(policy['GRADER'][0]['type'], 'Homework')
-        self.assertEqual(policy['GRADER'][0]['min_count'], 4)
+        self.assertEqual(policy['GRADER'][0]['min_count'], 8)
         self.assertEqual(policy['GRADER'][1]['type'], 'Lab')
         self.assertEqual(policy['GRADER'][1]['min_count'], 0)
         self.assertEqual(policy['GRADER'][2]['type'], 'Midterm Exam')
@@ -255,7 +262,7 @@ class TestCoachDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase):
 
         url = reverse(
             'ccx_invite',
-            kwargs={'course_id': self.course.id.to_deprecated_string()}
+            kwargs={'course_id': CCXLocator.from_course_locator(self.course.id, ccx.id)}
         )
         data = {
             'enrollment-button': 'Enroll',
@@ -288,7 +295,7 @@ class TestCoachDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase):
 
         url = reverse(
             'ccx_invite',
-            kwargs={'course_id': self.course.id.to_deprecated_string()}
+            kwargs={'course_id': CCXLocator.from_course_locator(self.course.id, ccx.id)}
         )
         data = {
             'enrollment-button': 'Unenroll',
@@ -318,7 +325,7 @@ class TestCoachDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase):
 
         url = reverse(
             'ccx_invite',
-            kwargs={'course_id': self.course.id.to_deprecated_string()}
+            kwargs={'course_id': CCXLocator.from_course_locator(self.course.id, ccx.id)}
         )
         data = {
             'enrollment-button': 'Enroll',
@@ -350,7 +357,7 @@ class TestCoachDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase):
 
         url = reverse(
             'ccx_invite',
-            kwargs={'course_id': self.course.id.to_deprecated_string()}
+            kwargs={'course_id': CCXLocator.from_course_locator(self.course.id, ccx.id)}
         )
         data = {
             'enrollment-button': 'Unenroll',
@@ -383,7 +390,7 @@ class TestCoachDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase):
 
         url = reverse(
             'ccx_manage_student',
-            kwargs={'course_id': self.course.id.to_deprecated_string()}
+            kwargs={'course_id': CCXLocator.from_course_locator(self.course.id, ccx.id)}
         )
         data = {
             'student-action': 'add',
@@ -414,7 +421,7 @@ class TestCoachDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase):
 
         url = reverse(
             'ccx_manage_student',
-            kwargs={'course_id': self.course.id.to_deprecated_string()}
+            kwargs={'course_id': CCXLocator.from_course_locator(self.course.id, ccx.id)}
         )
         data = {
             'student-action': 'revoke',
@@ -435,9 +442,10 @@ class TestCoachDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase):
 GET_CHILDREN = XModuleMixin.get_children
 
 
-def patched_get_children(self, usage_key_filter=None):  # pylint: disable=missing-docstring
-    def iter_children():  # pylint: disable=missing-docstring
-        print self.__dict__
+def patched_get_children(self, usage_key_filter=None):
+    """Emulate system tools that mask courseware not visible to students"""
+    def iter_children():
+        """skip children not visible to students"""
         for child in GET_CHILDREN(self, usage_key_filter=usage_key_filter):
             child._field_data_cache = {}  # pylint: disable=protected-access
             if not child.visible_to_staff_only:
@@ -453,16 +461,14 @@ class TestCCXGrades(ModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     Tests for Custom Courses views.
     """
+    MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
+
     def setUp(self):
         """
         Set up tests
         """
         super(TestCCXGrades, self).setUp()
-        self.course = course = CourseFactory.create()
-
-        # Create instructor account
-        self.coach = coach = AdminFactory.create()
-        self.client.login(username=coach.username, password="test")
+        course = CourseFactory.create()
 
         # Create a course outline
         self.mooc_start = start = datetime.datetime(
@@ -475,31 +481,24 @@ class TestCCXGrades(ModuleStoreTestCase, LoginEnrollmentTestCase):
                 category="sequential",
                 metadata={'graded': True, 'format': 'Homework'})
             for _ in xrange(4)]
-
-        role = CourseCcxCoachRole(self.course.id)
-        role.add_users(coach)
-        self.ccx = ccx = CcxFactory(course_id=self.course.id, coach=self.coach)
-
-        self.student = student = UserFactory.create()
-        CourseEnrollmentFactory.create(user=student, course_id=self.course.id)
-        CcxMembershipFactory(ccx=ccx, student=student, active=True)
-
-        for i, section in enumerate(sections):
-            for j in xrange(4):
-                item = ItemFactory.create(
+        problems = [
+            [
+                ItemFactory.create(
                     parent=section,
                     category="problem",
                     data=StringResponseXMLFactory().build_xml(answer='foo'),
                     metadata={'rerandomize': 'always'}
-                )
+                ) for _ in xrange(4)
+            ] for section in sections
+        ]
 
-                StudentModuleFactory.create(
-                    grade=1 if i < j else 0,
-                    max_grade=1,
-                    student=student,
-                    course_id=self.course.id,
-                    module_state_key=item.location
-                )
+        # Create instructor account
+        self.coach = coach = AdminFactory.create()
+
+        # Create CCX
+        role = CourseCcxCoachRole(course.id)
+        role.add_users(coach)
+        ccx = CcxFactory(course_id=course.id, coach=self.coach)
 
         # Apparently the test harness doesn't use LmsFieldStorage, and I'm not
         # sure if there's a way to poke the test harness to do so.  So, we'll
@@ -521,11 +520,7 @@ class TestCCXGrades(ModuleStoreTestCase, LoginEnrollmentTestCase):
             OverrideFieldData.provider_classes = None
         self.addCleanup(cleanup_provider_classes)
 
-        patch_context = patch('ccx.views.get_course_by_id')
-        get_course = patch_context.start()
-        get_course.return_value = course
-        self.addCleanup(patch_context.stop)
-
+        # override course grading policy and make last section invisible to students
         override_field_for_ccx(ccx, course, 'grading_policy', {
             'GRADER': [
                 {'drop_count': 0,
@@ -539,11 +534,35 @@ class TestCCXGrades(ModuleStoreTestCase, LoginEnrollmentTestCase):
         override_field_for_ccx(
             ccx, sections[-1], 'visible_to_staff_only', True)
 
+        # create a ccx locator and retrieve the course structure using that key
+        # which emulates how a student would get access.
+        self.ccx_key = CCXLocator.from_course_locator(course.id, ccx.id)
+        self.course = get_course_by_id(self.ccx_key)
+
+        self.student = student = UserFactory.create()
+        CourseEnrollmentFactory.create(user=student, course_id=self.course.id)
+        CcxMembershipFactory(ccx=ccx, student=student, active=True)
+
+        # create grades for self.student as if they'd submitted the ccx
+        for chapter in self.course.get_children():
+            for i, section in enumerate(chapter.get_children()):
+                for j, problem in enumerate(section.get_children()):
+                    # if not problem.visible_to_staff_only:
+                    StudentModuleFactory.create(
+                        grade=1 if i < j else 0,
+                        max_grade=1,
+                        student=self.student,
+                        course_id=self.course.id,
+                        module_state_key=problem.location
+                    )
+
+        self.client.login(username=coach.username, password="test")
+
     @patch('ccx.views.render_to_response', intercept_renderer)
     def test_gradebook(self):
         url = reverse(
             'ccx_gradebook',
-            kwargs={'course_id': self.course.id.to_deprecated_string()}
+            kwargs={'course_id': self.ccx_key}
         )
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
@@ -558,7 +577,7 @@ class TestCCXGrades(ModuleStoreTestCase, LoginEnrollmentTestCase):
     def test_grades_csv(self):
         url = reverse(
             'ccx_grades_csv',
-            kwargs={'course_id': self.course.id.to_deprecated_string()}
+            kwargs={'course_id': self.ccx_key}
         )
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
@@ -581,13 +600,9 @@ class TestCCXGrades(ModuleStoreTestCase, LoginEnrollmentTestCase):
         self.addCleanup(patch_context.stop)
 
         self.client.login(username=self.student.username, password="test")
-        session = self.client.session
-        session[ACTIVE_CCX_KEY] = self.ccx.id  # pylint: disable=no-member
-        session.save()
-        self.client.session.get(ACTIVE_CCX_KEY)
         url = reverse(
             'progress',
-            kwargs={'course_id': self.course.id.to_deprecated_string()}
+            kwargs={'course_id': self.ccx_key}
         )
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
@@ -595,182 +610,6 @@ class TestCCXGrades(ModuleStoreTestCase, LoginEnrollmentTestCase):
         self.assertEqual(grades['percent'], 0.5)
         self.assertEqual(grades['grade_breakdown'][0]['percent'], 0.5)
         self.assertEqual(len(grades['section_breakdown']), 4)
-
-
-@attr('shard_1')
-class TestSwitchActiveCCX(ModuleStoreTestCase, LoginEnrollmentTestCase):
-    """Verify the view for switching which CCX is active, if any
-    """
-    def setUp(self):
-        super(TestSwitchActiveCCX, self).setUp()
-        self.course = course = CourseFactory.create()
-        coach = AdminFactory.create()
-        role = CourseCcxCoachRole(course.id)
-        role.add_users(coach)
-        self.ccx = CcxFactory(course_id=course.id, coach=coach)
-        enrollment = CourseEnrollmentFactory.create(course_id=course.id)
-        self.user = enrollment.user
-        self.target_url = reverse(
-            'course_root', args=[course.id.to_deprecated_string()]
-        )
-
-    def register_user_in_ccx(self, active=False):
-        """create registration of self.user in self.ccx
-
-        registration will be inactive unless active=True
-        """
-        CcxMembershipFactory(ccx=self.ccx, student=self.user, active=active)
-
-    def revoke_ccx_registration(self):
-        """
-        delete membership
-        """
-        membership = CcxMembership.objects.filter(
-            ccx=self.ccx, student=self.user
-        )
-        membership.delete()
-
-    def verify_active_ccx(self, request, id=None):  # pylint: disable=redefined-builtin, invalid-name
-        """verify that we have the correct active ccx"""
-        if id:
-            id = str(id)
-        self.assertEqual(id, request.session.get(ACTIVE_CCX_KEY, None))
-
-    def test_unauthorized_cannot_switch_to_ccx(self):
-        switch_url = reverse(
-            'switch_active_ccx',
-            args=[self.course.id.to_deprecated_string(), self.ccx.id]
-        )
-        response = self.client.get(switch_url)
-        self.assertEqual(response.status_code, 302)
-
-    def test_unauthorized_cannot_switch_to_mooc(self):
-        switch_url = reverse(
-            'switch_active_ccx',
-            args=[self.course.id.to_deprecated_string()]
-        )
-        response = self.client.get(switch_url)
-        self.assertEqual(response.status_code, 302)
-
-    def test_enrolled_inactive_user_cannot_select_ccx(self):
-        self.register_user_in_ccx(active=False)
-        self.client.login(username=self.user.username, password="test")
-        switch_url = reverse(
-            'switch_active_ccx',
-            args=[self.course.id.to_deprecated_string(), self.ccx.id]
-        )
-        response = self.client.get(switch_url)
-        self.assertEqual(response.status_code, 302)
-        self.assertTrue(response.get('Location', '').endswith(self.target_url))  # pylint: disable=no-member
-        # if the ccx were active, we'd need to pass the ID of the ccx here.
-        self.verify_active_ccx(self.client)
-
-    def test_enrolled_user_can_select_ccx(self):
-        self.register_user_in_ccx(active=True)
-        self.client.login(username=self.user.username, password="test")
-        switch_url = reverse(
-            'switch_active_ccx',
-            args=[self.course.id.to_deprecated_string(), self.ccx.id]
-        )
-        response = self.client.get(switch_url)
-        self.assertEqual(response.status_code, 302)
-        self.assertTrue(response.get('Location', '').endswith(self.target_url))  # pylint: disable=no-member
-        self.verify_active_ccx(self.client, self.ccx.id)
-
-    def test_enrolled_user_can_select_mooc(self):
-        self.register_user_in_ccx(active=True)
-        self.client.login(username=self.user.username, password="test")
-        # pre-seed the session with the ccx id
-        session = self.client.session
-        session[ACTIVE_CCX_KEY] = str(self.ccx.id)
-        session.save()
-        switch_url = reverse(
-            'switch_active_ccx',
-            args=[self.course.id.to_deprecated_string()]
-        )
-        response = self.client.get(switch_url)
-        self.assertEqual(response.status_code, 302)
-        self.assertTrue(response.get('Location', '').endswith(self.target_url))  # pylint: disable=no-member
-        self.verify_active_ccx(self.client)
-
-    def test_unenrolled_user_cannot_select_ccx(self):
-        self.client.login(username=self.user.username, password="test")
-        switch_url = reverse(
-            'switch_active_ccx',
-            args=[self.course.id.to_deprecated_string(), self.ccx.id]
-        )
-        response = self.client.get(switch_url)
-        self.assertEqual(response.status_code, 302)
-        self.assertTrue(response.get('Location', '').endswith(self.target_url))  # pylint: disable=no-member
-        # if the ccx were active, we'd need to pass the ID of the ccx here.
-        self.verify_active_ccx(self.client)
-
-    def test_unenrolled_user_switched_to_mooc(self):
-        self.client.login(username=self.user.username, password="test")
-        # pre-seed the session with the ccx id
-        session = self.client.session
-        session[ACTIVE_CCX_KEY] = str(self.ccx.id)
-        session.save()
-        switch_url = reverse(
-            'switch_active_ccx',
-            args=[self.course.id.to_deprecated_string(), self.ccx.id]
-        )
-        response = self.client.get(switch_url)
-        self.assertEqual(response.status_code, 302)
-        self.assertTrue(response.get('Location', '').endswith(self.target_url))  # pylint: disable=no-member
-        # we tried to select the ccx but are not registered, so we are switched
-        # back to the mooc view
-        self.verify_active_ccx(self.client)
-
-    def test_unassociated_course_and_ccx_not_selected(self):
-        new_course = CourseFactory.create()
-        self.client.login(username=self.user.username, password="test")
-        expected_url = reverse(
-            'course_root', args=[new_course.id.to_deprecated_string()]
-        )
-        # the ccx and the course are not related.
-        switch_url = reverse(
-            'switch_active_ccx',
-            args=[new_course.id.to_deprecated_string(), self.ccx.id]
-        )
-        response = self.client.get(switch_url)
-        self.assertEqual(response.status_code, 302)
-        self.assertTrue(response.get('Location', '').endswith(expected_url))  # pylint: disable=no-member
-        # the mooc should be active
-        self.verify_active_ccx(self.client)
-
-    def test_missing_ccx_cannot_be_selected(self):
-        self.register_user_in_ccx()
-        self.client.login(username=self.user.username, password="test")
-        switch_url = reverse(
-            'switch_active_ccx',
-            args=[self.course.id.to_deprecated_string(), self.ccx.id]
-        )
-        # delete the ccx
-        self.ccx.delete()  # pylint: disable=no-member
-
-        response = self.client.get(switch_url)
-        self.assertEqual(response.status_code, 302)
-        self.assertTrue(response.get('Location', '').endswith(self.target_url))  # pylint: disable=no-member
-        # we tried to select the ccx it doesn't exist anymore, so we are
-        # switched back to the mooc view
-        self.verify_active_ccx(self.client)
-
-    def test_revoking_ccx_membership_revokes_active_ccx(self):
-        self.register_user_in_ccx(active=True)
-        self.client.login(username=self.user.username, password="test")
-        # ensure ccx is active in the request session
-        switch_url = reverse(
-            'switch_active_ccx',
-            args=[self.course.id.to_deprecated_string(), self.ccx.id]
-        )
-        self.client.get(switch_url)
-        self.verify_active_ccx(self.client, self.ccx.id)
-        # unenroll the user from the ccx
-        self.revoke_ccx_registration()
-        # request the course root and verify that the ccx is not active
-        self.client.get(self.target_url)
-        self.verify_active_ccx(self.client)
 
 
 @ddt.ddt

--- a/lms/djangoapps/ccx/tests/test_views.py
+++ b/lms/djangoapps/ccx/tests/test_views.py
@@ -6,7 +6,6 @@ import json
 import re
 import pytz
 import ddt
-import unittest
 from mock import patch, MagicMock
 from nose.plugins.attrib import attr
 
@@ -27,7 +26,6 @@ from student.tests.factories import (  # pylint: disable=import-error
     UserFactory,
 )
 
-from opaque_keys.edx.locations import SlashSeparatedCourseKey
 from xmodule.x_module import XModuleMixin
 from xmodule.modulestore.tests.django_utils import (
     ModuleStoreTestCase,
@@ -36,7 +34,6 @@ from xmodule.modulestore.tests.factories import (
     CourseFactory,
     ItemFactory,
 )
-import xmodule.tabs as tabs
 from ccx_keys.locator import CCXLocator
 
 from ..models import (
@@ -83,6 +80,7 @@ class TestCoachDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase):
     Tests for Custom Courses views.
     """
     MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
+
     def setUp(self):
         """
         Set up tests
@@ -481,6 +479,7 @@ class TestCCXGrades(ModuleStoreTestCase, LoginEnrollmentTestCase):
                 category="sequential",
                 metadata={'graded': True, 'format': 'Homework'})
             for _ in xrange(4)]
+        # pylint: disable=unused-variable
         problems = [
             [
                 ItemFactory.create(

--- a/lms/djangoapps/ccx/urls.py
+++ b/lms/djangoapps/ccx/urls.py
@@ -24,6 +24,4 @@ urlpatterns = patterns(
         'ccx.views.ccx_grades_csv', name='ccx_grades_csv'),
     url(r'^ccx_set_grading_policy$',
         'ccx.views.set_grading_policy', name='ccx_set_grading_policy'),
-    url(r'^switch_ccx(?:/(?P<ccx_id>[\d]+))?$',
-        'ccx.views.switch_active_ccx', name='switch_active_ccx'),
 )

--- a/lms/djangoapps/ccx/utils.py
+++ b/lms/djangoapps/ccx/utils.py
@@ -4,8 +4,6 @@ CCX Enrollment operations for use by Coach APIs.
 Does not include any access control, be sure to check access before calling.
 """
 import logging
-from courseware.courses import get_course_about_section  # pylint: disable=import-error
-from courseware.courses import get_course_by_id  # pylint: disable=import-error
 from django.contrib.auth.models import User
 from django.conf import settings
 from django.core.urlresolvers import reverse
@@ -20,7 +18,6 @@ from .models import (
     CcxMembership,
     CcxFutureMembership,
 )
-from .overrides import get_current_ccx
 
 
 log = logging.getLogger("edx.ccx")
@@ -154,7 +151,7 @@ def get_email_params(ccx, auto_enroll, secure=True):
         site=stripped_site_name,
         path=reverse(
             'course_root',
-            kwargs={'course_id':  CCXLocator.from_course_locator(ccx.course_id, ccx.id)}
+            kwargs={'course_id': CCXLocator.from_course_locator(ccx.course_id, ccx.id)}
         )
     )
 
@@ -165,7 +162,7 @@ def get_email_params(ccx, auto_enroll, secure=True):
             site=stripped_site_name,
             path=reverse(
                 'about_course',
-                kwargs={'course_id':  CCXLocator.from_course_locator(ccx.course_id, ccx.id)}
+                kwargs={'course_id': CCXLocator.from_course_locator(ccx.course_id, ccx.id)}
             )
         )
 
@@ -267,9 +264,9 @@ def get_ccx_membership_triplets(user, course_org_filter, org_filter_out_set):
                 # warning to the log so we can clean up.
                 if course.location.deprecated:
                     log.warning(
-                        "CCX {} exists for course {} with deprecated id".format(
-                            ccx, ccx.course_id
-                        )
+                        "CCX %s exists for course %s with deprecated id",
+                        ccx,
+                        ccx.course_id
                     )
                     continue
 

--- a/lms/djangoapps/ccx/utils.py
+++ b/lms/djangoapps/ccx/utils.py
@@ -262,6 +262,17 @@ def get_ccx_membership_triplets(user, course_org_filter, org_filter_out_set):
                 elif course.location.org in org_filter_out_set:
                     continue
 
+                # If, somehow, we've got a ccx that has been created for a
+                # course with a deprecated ID, we must filter it out. Emit a
+                # warning to the log so we can clean up.
+                if course.location.deprecated:
+                    log.warning(
+                        "CCX {} exists for course {} with deprecated id".format(
+                            ccx, ccx.course_id
+                        )
+                    )
+                    continue
+
                 yield (ccx, membership, course)
             else:
                 log.error("User {0} enrolled in {2} course {1}".format(  # pylint: disable=logging-format-interpolation

--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -110,7 +110,10 @@ def dashboard(request, course, ccx=None):
     if ccx is None:
         ccx = get_ccx_for_coach(course, request.user)
         if ccx:
-            url = reverse('ccx_coach_dashboard', kwargs={'course_id': CCXLocator.from_course_locator(course.id, ccx.id)})
+            url = reverse(
+                'ccx_coach_dashboard',
+                kwargs={'course_id': CCXLocator.from_course_locator(course.id, ccx.id)}
+            )
             return redirect(url)
 
     context = {
@@ -151,11 +154,10 @@ def create_ccx(request, course, ccx=None):
 
     # prevent CCX objects from being created for deprecated course ids.
     if course.id.deprecated:
-        messages.error(_(
+        messages.error(request, _(
             "You cannot create a CCX from a course using a deprecated id. "
             "Please create a rerun of this course in the studio to allow "
-            "this action.")
-        )
+            "this action."))
         url = reverse('ccx_coach_dashboard', kwargs={'course_id', course.id})
         return redirect(url)
 
@@ -179,7 +181,7 @@ def create_ccx(request, course, ccx=None):
             for vertical in sequential.get_children():
                 override_field_for_ccx(ccx, vertical, hidden, True)
 
-    ccx_id = CCXLocator.from_course_locator(course.id, ccx.id)
+    ccx_id = CCXLocator.from_course_locator(course.id, ccx.id)  # pylint: disable=no-member
     url = reverse('ccx_coach_dashboard', kwargs={'course_id': ccx_id})
     return redirect(url)
 
@@ -369,7 +371,7 @@ def get_ccx_schedule(course, ccx):
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
 @coach_dashboard
-def ccx_schedule(request, course, ccx=None):
+def ccx_schedule(request, course, ccx=None):  # pylint: disable=unused-argument
     """
     get json representation of ccx schedule
     """
@@ -464,6 +466,8 @@ def ccx_student_management(request, course, ccx=None):
 
 @contextmanager
 def ccx_course(ccx_locator):
+    """Create a context in which the course identified by course_locator exists
+    """
     course = get_course_by_id(ccx_locator)
     yield course
 

--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -8,6 +8,7 @@ import json
 import logging
 import pytz
 
+from contextlib import contextmanager
 from copy import deepcopy
 from cStringIO import StringIO
 
@@ -19,6 +20,7 @@ from django.http import (
 )
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
+from django.http import Http404
 from django.shortcuts import redirect
 from django.utils.translation import ugettext as _
 from django.views.decorators.cache import cache_control
@@ -34,6 +36,7 @@ from courseware.model_data import FieldDataCache  # pylint: disable=import-error
 from courseware.module_render import get_module_for_descriptor  # pylint: disable=import-error
 from edxmako.shortcuts import render_to_response  # pylint: disable=import-error
 from opaque_keys.edx.keys import CourseKey
+from ccx_keys.locator import CCXLocator
 from student.roles import CourseCcxCoachRole  # pylint: disable=import-error
 
 from instructor.offline_gradecalc import student_grades  # pylint: disable=import-error
@@ -45,13 +48,11 @@ from .overrides import (
     clear_override_for_ccx,
     get_override_for_ccx,
     override_field_for_ccx,
-    ccx_context,
 )
 from .utils import (
     enroll_email,
     unenroll_email,
 )
-from ccx import ACTIVE_CCX_KEY  # pylint: disable=import-error
 
 
 log = logging.getLogger(__name__)
@@ -71,43 +72,60 @@ def coach_dashboard(view):
         and modifying the view's call signature.
         """
         course_key = CourseKey.from_string(course_id)
+        ccx = None
+        if isinstance(course_key, CCXLocator):
+            # is there a security leak here in not checking that this user is
+            # the coach for this ccx?
+            ccx_id = course_key.ccx
+            ccx = CustomCourseForEdX.objects.get(pk=ccx_id)
+            course_key = ccx.course_id
+
         role = CourseCcxCoachRole(course_key)
         if not role.has_user(request.user):
             return HttpResponseForbidden(
                 _('You must be a CCX Coach to access this view.'))
+
         course = get_course_by_id(course_key, depth=None)
-        return view(request, course)
+        return view(request, course, ccx)
     return wrapper
 
 
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
 @coach_dashboard
-def dashboard(request, course):
+def dashboard(request, course, ccx=None):
     """
     Display the CCX Coach Dashboard.
     """
-    ccx = get_ccx_for_coach(course, request.user)
+    # right now, we can only have one ccx per user and course
+    # so, if no ccx is passed in, we can sefely redirect to that
+    if ccx is None:
+        ccx = get_ccx_for_coach(course, request.user)
+        if ccx:
+            url = reverse('ccx_coach_dashboard', kwargs={'course_id': CCXLocator.from_course_locator(course.id, ccx.id)})
+            return redirect(url)
+
     context = {
         'course': course,
         'ccx': ccx,
     }
 
     if ccx:
+        ccx_locator = CCXLocator.from_course_locator(course.id, ccx.id)
         schedule = get_ccx_schedule(course, ccx)
         grading_policy = get_override_for_ccx(
             ccx, course, 'grading_policy', course.grading_policy)
         context['schedule'] = json.dumps(schedule, indent=4)
         context['save_url'] = reverse(
-            'save_ccx', kwargs={'course_id': course.id})
+            'save_ccx', kwargs={'course_id': ccx_locator})
         context['ccx_members'] = CcxMembership.objects.filter(ccx=ccx)
         context['gradebook_url'] = reverse(
-            'ccx_gradebook', kwargs={'course_id': course.id})
+            'ccx_gradebook', kwargs={'course_id': ccx_locator})
         context['grades_csv_url'] = reverse(
-            'ccx_grades_csv', kwargs={'course_id': course.id})
+            'ccx_grades_csv', kwargs={'course_id': ccx_locator})
         context['grading_policy'] = json.dumps(grading_policy, indent=4)
         context['grading_policy_url'] = reverse(
-            'ccx_set_grading_policy', kwargs={'course_id': course.id})
+            'ccx_set_grading_policy', kwargs={'course_id': ccx_locator})
     else:
         context['create_ccx_url'] = reverse(
             'create_ccx', kwargs={'course_id': course.id})
@@ -117,7 +135,7 @@ def dashboard(request, course):
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
 @coach_dashboard
-def create_ccx(request, course):
+def create_ccx(request, course, ccx=None):
     """
     Create a new CCX
     """
@@ -142,18 +160,20 @@ def create_ccx(request, course):
             for vertical in sequential.get_children():
                 override_field_for_ccx(ccx, vertical, hidden, True)
 
-    url = reverse('ccx_coach_dashboard', kwargs={'course_id': course.id})
+    ccx_id = CCXLocator.from_course_locator(course.id, ccx.id)
+    url = reverse('ccx_coach_dashboard', kwargs={'course_id': ccx_id})
     return redirect(url)
 
 
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
 @coach_dashboard
-def save_ccx(request, course):
+def save_ccx(request, course, ccx=None):
     """
     Save changes to CCX.
     """
-    ccx = get_ccx_for_coach(course, request.user)
+    if not ccx:
+        raise Http404
 
     def override_fields(parent, data, graded, earliest=None):
         """
@@ -220,15 +240,20 @@ def save_ccx(request, course):
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
 @coach_dashboard
-def set_grading_policy(request, course):
+def set_grading_policy(request, course, ccx=None):
     """
     Set grading policy for the CCX.
     """
-    ccx = get_ccx_for_coach(course, request.user)
+    if not ccx:
+        raise Http404
+
     override_field_for_ccx(
         ccx, course, 'grading_policy', json.loads(request.POST['policy']))
 
-    url = reverse('ccx_coach_dashboard', kwargs={'course_id': course.id})
+    url = reverse(
+        'ccx_coach_dashboard',
+        kwargs={'course_id': CCXLocator.from_course_locator(course.id, ccx.id)}
+    )
     return redirect(url)
 
 
@@ -271,12 +296,15 @@ def get_ccx_for_coach(course, coach):
     Looks to see if user is coach of a CCX for this course.  Returns the CCX or
     None.
     """
-    try:
-        return CustomCourseForEdX.objects.get(
-            course_id=course.id,
-            coach=coach)
-    except CustomCourseForEdX.DoesNotExist:
-        return None
+    ccxs = CustomCourseForEdX.objects.filter(
+        course_id=course.id,
+        coach=coach
+    )
+    # XXX: In the future, it would be nice to support more than one ccx per
+    # coach per course.  This is a place where that might happen.
+    if ccxs.exists():
+        return ccxs[0]
+    return None
 
 
 def get_ccx_schedule(course, ccx):
@@ -322,11 +350,13 @@ def get_ccx_schedule(course, ccx):
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
 @coach_dashboard
-def ccx_schedule(request, course):
+def ccx_schedule(request, course, ccx=None):
     """
     get json representation of ccx schedule
     """
-    ccx = get_ccx_for_coach(course, request.user)
+    if not ccx:
+        raise Http404
+
     schedule = get_ccx_schedule(course, ccx)
     json_schedule = json.dumps(schedule, indent=4)
     return HttpResponse(json_schedule, mimetype='application/json')
@@ -335,11 +365,13 @@ def ccx_schedule(request, course):
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
 @coach_dashboard
-def ccx_invite(request, course):
+def ccx_invite(request, course, ccx=None):
     """
     Invite users to new ccx
     """
-    ccx = get_ccx_for_coach(course, request.user)
+    if not ccx:
+        raise Http404
+
     action = request.POST.get('enrollment-button')
     identifiers_raw = request.POST.get('student-ids')
     identifiers = _split_input_list(identifiers_raw)
@@ -367,17 +399,22 @@ def ccx_invite(request, course):
                 unenroll_email(ccx, email, email_students=email_students)
         except ValidationError:
             log.info('Invalid user name or email when trying to invite students: %s', email)
-    url = reverse('ccx_coach_dashboard', kwargs={'course_id': course.id})
+    url = reverse(
+        'ccx_coach_dashboard',
+        kwargs={'course_id': CCXLocator.from_course_locator(course.id, ccx.id)}
+    )
     return redirect(url)
 
 
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
 @coach_dashboard
-def ccx_student_management(request, course):
+def ccx_student_management(request, course, ccx=None):
     """Manage the enrollment of individual students in a CCX
     """
-    ccx = get_ccx_for_coach(course, request.user)
+    if not ccx:
+        raise Http404
+
     action = request.POST.get('student-action', None)
     student_id = request.POST.get('student-id', '')
     user = email = None
@@ -399,28 +436,42 @@ def ccx_student_management(request, course):
     except ValidationError:
         log.info('Invalid user name or email when trying to enroll student: %s', email)
 
-    url = reverse('ccx_coach_dashboard', kwargs={'course_id': course.id})
+    url = reverse(
+        'ccx_coach_dashboard',
+        kwargs={'course_id': CCXLocator.from_course_locator(course.id, ccx.id)}
+    )
     return redirect(url)
 
 
-@cache_control(no_cache=True, no_store=True, must_revalidate=True)
-@coach_dashboard
-def ccx_gradebook(request, course):
-    """
-    Show the gradebook for this CCX.
-    """
-    # Need course module for overrides to function properly
+@contextmanager
+def ccx_course(ccx_locator):
+    course = get_course_by_id(ccx_locator)
+    yield course
+
+
+def prep_course_for_grading(course, request):
+    """Set up course module for overrides to function properly"""
     field_data_cache = FieldDataCache.cache_for_descriptor_descendents(
         course.id, request.user, course, depth=2)
     course = get_module_for_descriptor(
         request.user, request, course, field_data_cache, course.id)
 
-    ccx = get_ccx_for_coach(course, request.user)
-    with ccx_context(ccx):
-        # The grading policy for the MOOC is probably already cached.  We need
-        # to make sure we have the CCX grading policy loaded.
-        course._field_data_cache = {}  # pylint: disable=protected-access
-        course.set_grading_policy(course.grading_policy)
+    course._field_data_cache = {}  # pylint: disable=protected-access
+    course.set_grading_policy(course.grading_policy)
+
+
+@cache_control(no_cache=True, no_store=True, must_revalidate=True)
+@coach_dashboard
+def ccx_gradebook(request, course, ccx=None):
+    """
+    Show the gradebook for this CCX.
+    """
+    if not ccx:
+        raise Http404
+
+    ccx_key = CCXLocator.from_course_locator(course.id, ccx.id)
+    with ccx_course(ccx_key) as course:
+        prep_course_for_grading(course, request)
 
         enrolled_students = User.objects.filter(
             ccxmembership__ccx=ccx,
@@ -450,21 +501,16 @@ def ccx_gradebook(request, course):
 
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
 @coach_dashboard
-def ccx_grades_csv(request, course):
+def ccx_grades_csv(request, course, ccx=None):
     """
     Download grades as CSV.
     """
-    # Need course module for overrides to function properly
-    field_data_cache = FieldDataCache.cache_for_descriptor_descendents(
-        course.id, request.user, course, depth=2)
-    course = get_module_for_descriptor(
-        request.user, request, course, field_data_cache, course.id)
-    ccx = get_ccx_for_coach(course, request.user)
-    with ccx_context(ccx):
-        # The grading policy for the MOOC is probably already cached.  We need
-        # to make sure we have the CCX grading policy loaded.
-        course._field_data_cache = {}  # pylint: disable=protected-access
-        course.set_grading_policy(course.grading_policy)
+    if not ccx:
+        raise Http404
+
+    ccx_key = CCXLocator.from_course_locator(course.id, ccx.id)
+    with ccx_course(ccx_key) as course:
+        prep_course_for_grading(course, request)
 
         enrolled_students = User.objects.filter(
             ccxmembership__ccx=ccx,
@@ -501,33 +547,3 @@ def ccx_grades_csv(request, course):
             writer.writerow(row)
 
         return HttpResponse(buf.getvalue(), content_type='text/plain')
-
-
-@login_required
-def switch_active_ccx(request, course_id, ccx_id=None):
-    """set the active CCX for the logged-in user
-    """
-    course_key = CourseKey.from_string(course_id)
-    # will raise Http404 if course_id is bad
-    course = get_course_by_id(course_key)
-    course_url = reverse(
-        'course_root', args=[course.id.to_deprecated_string()]
-    )
-    if ccx_id is not None:
-        try:
-            requested_ccx = CustomCourseForEdX.objects.get(pk=ccx_id)
-            assert unicode(requested_ccx.course_id) == course_id
-            if not CcxMembership.objects.filter(
-                    ccx=requested_ccx, student=request.user, active=True
-            ).exists():
-                ccx_id = None
-        except CustomCourseForEdX.DoesNotExist:
-            # what to do here?  Log the failure?  Do we care?
-            ccx_id = None
-        except AssertionError:
-            # what to do here?  Log the failure?  Do we care?
-            ccx_id = None
-
-    request.session[ACTIVE_CCX_KEY] = ccx_id
-
-    return HttpResponseRedirect(course_url)

--- a/lms/djangoapps/courseware/access.py
+++ b/lms/djangoapps/courseware/access.py
@@ -110,9 +110,10 @@ def has_access(user, action, obj, course_key=None):
     if isinstance(obj, XBlock):
         return _has_access_descriptor(user, action, obj, course_key)
 
+    if isinstance(obj, CCXLocator):
+        return _has_access_ccx_key(user, action, obj)
+
     if isinstance(obj, CourseKey):
-        if isinstance(obj, CCXLocator):
-            obj = obj.to_course_locator()
         return _has_access_course_key(user, action, obj)
 
     if isinstance(obj, UsageKey):
@@ -492,6 +493,10 @@ def _has_access_course_key(user, action, course_key):
     }
 
     return _dispatch(checkers, action, user, course_key)
+
+def _has_access_ccx_key(user, action, ccx_key):
+    course_key = ccx_key.to_course_locator()
+    return _has_access_course_key(user, action, course_key)
 
 
 def _has_access_string(user, action, perm):

--- a/lms/djangoapps/courseware/access.py
+++ b/lms/djangoapps/courseware/access.py
@@ -494,7 +494,13 @@ def _has_access_course_key(user, action, course_key):
 
     return _dispatch(checkers, action, user, course_key)
 
+
 def _has_access_ccx_key(user, action, ccx_key):
+    """Check if user has access to the course for this ccx_key
+
+    Delegates checking to _has_access_course_key
+    Valid actions: same as for that function
+    """
     course_key = ccx_key.to_course_locator()
     return _has_access_course_key(user, action, course_key)
 

--- a/lms/djangoapps/courseware/access.py
+++ b/lms/djangoapps/courseware/access.py
@@ -43,6 +43,7 @@ from util.milestones_helpers import (
     get_pre_requisite_courses_not_completed,
     any_unfulfilled_milestones,
 )
+from ccx_keys.locator import CCXLocator
 
 import dogstats_wrapper as dog_stats_api
 
@@ -91,6 +92,9 @@ def has_access(user, action, obj, course_key=None):
     if not user:
         user = AnonymousUser()
 
+    if isinstance(course_key, CCXLocator):
+        course_key = course_key.to_course_locator()
+
     # delegate the work to type-specific functions.
     # (start with more specific types, then get more general)
     if isinstance(obj, CourseDescriptor):
@@ -107,6 +111,8 @@ def has_access(user, action, obj, course_key=None):
         return _has_access_descriptor(user, action, obj, course_key)
 
     if isinstance(obj, CourseKey):
+        if isinstance(obj, CCXLocator):
+            obj = obj.to_course_locator()
         return _has_access_course_key(user, action, obj)
 
     if isinstance(obj, UsageKey):

--- a/lms/djangoapps/dashboard/sysadmin.py
+++ b/lms/djangoapps/dashboard/sysadmin.py
@@ -43,6 +43,7 @@ from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.xml import XMLModuleStore
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
+from ccx.modulestore import CCXModulestoreWrapper
 
 
 log = logging.getLogger(__name__)
@@ -59,9 +60,13 @@ class SysadminDashboardView(TemplateView):
         modulestore_type and return msg
         """
 
-        self.def_ms = modulestore()
+        self.def_ms = check_ms = modulestore()
+        # if the modulestore is wrapped by CCX, unwrap it for checking purposes
+        if isinstance(check_ms, CCXModulestoreWrapper):
+            check_ms = check_ms._modulestore
+
         self.is_using_mongo = True
-        if isinstance(self.def_ms, XMLModuleStore):
+        if isinstance(check_ms, XMLModuleStore):
             self.is_using_mongo = False
         self.msg = u''
         self.datatable = []

--- a/lms/djangoapps/dashboard/sysadmin.py
+++ b/lms/djangoapps/dashboard/sysadmin.py
@@ -41,9 +41,7 @@ from student.models import CourseEnrollment, UserProfile, Registration
 import track.views
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
-from xmodule.modulestore.xml import XMLModuleStore
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
-from ccx.modulestore import CCXModulestoreWrapper
 
 
 log = logging.getLogger(__name__)
@@ -60,13 +58,10 @@ class SysadminDashboardView(TemplateView):
         modulestore_type and return msg
         """
 
-        self.def_ms = check_ms = modulestore()
-        # if the modulestore is wrapped by CCX, unwrap it for checking purposes
-        if isinstance(check_ms, CCXModulestoreWrapper):
-            check_ms = check_ms._modulestore
+        self.def_ms = modulestore()
 
         self.is_using_mongo = True
-        if isinstance(check_ms, XMLModuleStore):
+        if self.def_ms.get_modulestore_type(None) == 'xml':
             self.is_using_mongo = False
         self.msg = u''
         self.datatable = []

--- a/lms/djangoapps/dashboard/tests/test_sysadmin.py
+++ b/lms/djangoapps/dashboard/tests/test_sysadmin.py
@@ -32,8 +32,6 @@ from student.tests.factories import UserFactory
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.mongo_connection import MONGO_PORT_NUM, MONGO_HOST
-from xmodule.modulestore.xml import XMLModuleStore
-from ccx.modulestore import CCXModulestoreWrapper
 
 
 TEST_MONGODB_LOG = {
@@ -316,12 +314,9 @@ class TestSysadmin(SysadminBaseTestCase):
         # Create git loaded course
         response = self._add_edx4edx()
 
-        def_ms = check_ms = modulestore()
-        # if the modulestore is wrapped by CCX, unwrap it for testing purposes
-        if isinstance(check_ms, CCXModulestoreWrapper):
-            check_ms = check_ms._modulestore
+        def_ms = modulestore()
 
-        self.assertIn('xml', str(check_ms.__class__))
+        self.assertEqual('xml', def_ms.get_modulestore_type(None))
         course = def_ms.courses.get('{0}/edx4edx_lite'.format(
             os.path.abspath(settings.DATA_DIR)), None)
         self.assertIsNotNone(course)
@@ -465,7 +460,7 @@ class TestSysAdminMongoCourseImport(SysadminBaseTestCase):
         self._mkdir(getattr(settings, 'GIT_REPO_DIR'))
 
         def_ms = modulestore()
-        self.assertFalse(isinstance(def_ms, XMLModuleStore))
+        self.assertFalse('xml' == def_ms.get_modulestore_type(None))
 
         self._add_edx4edx()
         course = def_ms.get_course(SlashSeparatedCourseKey('MITx', 'edx4edx', 'edx4edx'))

--- a/lms/djangoapps/dashboard/tests/test_sysadmin.py
+++ b/lms/djangoapps/dashboard/tests/test_sysadmin.py
@@ -33,6 +33,7 @@ from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.mongo_connection import MONGO_PORT_NUM, MONGO_HOST
 from xmodule.modulestore.xml import XMLModuleStore
+from ccx.modulestore import CCXModulestoreWrapper
 
 
 TEST_MONGODB_LOG = {
@@ -315,8 +316,12 @@ class TestSysadmin(SysadminBaseTestCase):
         # Create git loaded course
         response = self._add_edx4edx()
 
-        def_ms = modulestore()
-        self.assertIn('xml', str(def_ms.__class__))
+        def_ms = check_ms = modulestore()
+        # if the modulestore is wrapped by CCX, unwrap it for testing purposes
+        if isinstance(check_ms, CCXModulestoreWrapper):
+            check_ms = check_ms._modulestore
+
+        self.assertIn('xml', str(check_ms.__class__))
         course = def_ms.courses.get('{0}/edx4edx_lite'.format(
             os.path.abspath(settings.DATA_DIR)), None)
         self.assertIsNotNone(course)

--- a/lms/djangoapps/django_comment_client/forum/views.py
+++ b/lms/djangoapps/django_comment_client/forum/views.py
@@ -65,7 +65,7 @@ class DiscussionTab(EnrolledTab):
             return False
 
         if settings.FEATURES.get('CUSTOM_COURSES_EDX', False):
-            if get_current_ccx():
+            if get_current_ccx(course.id):
                 return False
         return settings.FEATURES.get('ENABLE_DISCUSSION_SERVICE')
 

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -612,7 +612,6 @@ ECOMMERCE_API_TIMEOUT = ENV_TOKENS.get('ECOMMERCE_API_TIMEOUT', ECOMMERCE_API_TI
 ##### Custom Courses for EdX #####
 if FEATURES.get('CUSTOM_COURSES_EDX'):
     INSTALLED_APPS += ('ccx',)
-    MIDDLEWARE_CLASSES += ('ccx.overrides.CcxMiddleware',)
     FIELD_OVERRIDE_PROVIDERS += (
         'ccx.overrides.CustomCoursesForEdxOverrideProvider',
     )

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -473,7 +473,6 @@ FEATURES['CERTIFICATES_HTML_VIEW'] = True
 
 ######### custom courses #########
 INSTALLED_APPS += ('ccx',)
-MIDDLEWARE_CLASSES += ('ccx.overrides.CcxMiddleware',)
 FEATURES['CUSTOM_COURSES_EDX'] = True
 
 # Set dummy values for profile image settings.

--- a/lms/envs/yaml_config.py
+++ b/lms/envs/yaml_config.py
@@ -307,7 +307,6 @@ GRADES_DOWNLOAD_ROUTING_KEY = HIGH_MEM_QUEUE
 ##### Custom Courses for EdX #####
 if FEATURES.get('CUSTOM_COURSES_EDX'):
     INSTALLED_APPS += ('ccx',)
-    MIDDLEWARE_CLASSES += ('ccx.overrides.CcxMiddleware',)
     FIELD_OVERRIDE_PROVIDERS += (
         'ccx.overrides.CustomCoursesForEdxOverrideProvider',
     )

--- a/lms/templates/ccx/_dashboard_ccx_listing.html
+++ b/lms/templates/ccx/_dashboard_ccx_listing.html
@@ -4,9 +4,10 @@
 from django.utils.translation import ugettext as _
 from django.core.urlresolvers import reverse
 from courseware.courses import course_image_url, get_course_about_section
+from ccx_keys.locator import CCXLocator
 %>
 <%
-  ccx_switch_target = reverse('switch_active_ccx', args=[course.id.to_deprecated_string(), ccx.id])
+  ccx_target = reverse('info', args=[CCXLocator.from_course_locator(course.id, ccx.id)])
 %>
 <li class="course-item">
   <article class="course">
@@ -14,7 +15,7 @@ from courseware.courses import course_image_url, get_course_about_section
       <div class="wrapper-course-image" aria-hidden="true">
         % if show_courseware_link:
           % if not is_course_blocked:
-              <a href="${ccx_switch_target}" class="cover">
+              <a href="${ccx_target}" class="cover">
                 <img src="${course_image_url(course)}" class="course-image" alt="${_('{course_number} {ccx_name} Cover Image').format(course_number=course.number, ccx_name=ccx.display_name) |h}" />
               </a>
           % else:
@@ -32,7 +33,7 @@ from courseware.courses import course_image_url, get_course_about_section
         <h3 class="course-title">
           % if show_courseware_link:
             % if not is_course_blocked:
-              <a href="${ccx_switch_target}">${ccx.display_name}</a>
+              <a href="${ccx_target}">${ccx.display_name}</a>
             % else:
               <a class="disable-look">${ccx.display_name}</a>
             % endif
@@ -58,13 +59,13 @@ from courseware.courses import course_image_url, get_course_about_section
             <div class="course-actions">
               % if ccx.has_ended():
                 % if not is_course_blocked:
-                  <a href="${ccx_switch_target}" class="enter-course archived">${_('View Archived Custom Course')}<span class="sr">&nbsp;${ccx.display_name}</span></a>
+                  <a href="${ccx_target}" class="enter-course archived">${_('View Archived Custom Course')}<span class="sr">&nbsp;${ccx.display_name}</span></a>
                 % else:
                   <a class="enter-course-blocked archived">${_('View Archived Custom Course')}<span class="sr">&nbsp;${ccx.display_name}</span></a>
                 % endif
               % else:
                 % if not is_course_blocked:
-                  <a href="${ccx_switch_target}" class="enter-course">${_('View Custom Course')}<span class="sr">&nbsp;${ccx.display_name}</span></a>
+                  <a href="${ccx_target}" class="enter-course">${_('View Custom Course')}<span class="sr">&nbsp;${ccx.display_name}</span></a>
                 % else:
                   <a class="enter-course-blocked">${_('View Custom Course')}<span class="sr">&nbsp;${ccx.display_name}</span></a>
                 % endif

--- a/lms/templates/ccx/coach_dashboard.html
+++ b/lms/templates/ccx/coach_dashboard.html
@@ -22,6 +22,18 @@ from django.core.urlresolvers import reverse
     <section class="instructor-dashboard-content-2" id="ccx-coach-dashboard-content">
       <h1>${_("CCX Coach Dashboard")}</h1>
 
+      % if messages:
+      <ul class="messages">
+        % for message in messages:
+          % if message.tags:
+          <li class="${message.tags}">${message}</li>
+          % else:
+          <li>${message}</li>
+          % endif
+        % endfor
+        </ul>
+      % endif
+
       %if not ccx:
       <section>
         <form action="${create_ccx_url}" method="POST">

--- a/lms/templates/navigation.html
+++ b/lms/templates/navigation.html
@@ -53,7 +53,7 @@ site_status_msg = get_site_status_msg(course_id)
       <%
         display_name = course.display_name_with_default
         if settings.FEATURES.get('CUSTOM_COURSES_EDX', False):
-          ccx = get_current_ccx()
+          ccx = get_current_ccx(course.id)
           if ccx:
             display_name = ccx.display_name
       %>

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -54,6 +54,7 @@ git+https://github.com/edx/edx-lint.git@ed8c8d2a0267d4d42f43642d193e25f8bd575d9b
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
 -e git+https://github.com/edx/edx-reverification-block.git@6e2834c5f7e998ad9b81170e7ceb4d8a64900eb0#egg=edx-reverification-block
 git+https://github.com/edx/ecommerce-api-client.git@1.0.0#egg=ecommerce-api-client==1.0.0
+-e git+https://github.com/jazkarta/ccx-keys.git@e6b03704b1bb97c1d2f31301ecb4e3a687c536ea#egg=ccx-keys
 
 # Third Party XBlocks
 -e git+https://github.com/mitodl/edx-sga@172a90fd2738f8142c10478356b2d9ed3e55334a#egg=edx-sga

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -54,7 +54,6 @@ git+https://github.com/edx/edx-lint.git@ed8c8d2a0267d4d42f43642d193e25f8bd575d9b
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
 -e git+https://github.com/edx/edx-reverification-block.git@6e2834c5f7e998ad9b81170e7ceb4d8a64900eb0#egg=edx-reverification-block
 git+https://github.com/edx/ecommerce-api-client.git@1.0.0#egg=ecommerce-api-client==1.0.0
--e git+https://github.com/jazkarta/ccx-keys.git@e6b03704b1bb97c1d2f31301ecb4e3a687c536ea#egg=ccx-keys
 
 # Third Party XBlocks
 -e git+https://github.com/mitodl/edx-sga@172a90fd2738f8142c10478356b2d9ed3e55334a#egg=edx-sga


### PR DESCRIPTION
This pull request implements the use of ccx-specific opaque keys (`CCXLocator` and `CCXBlockUsageLocator` throughout the codebase.  
### History

The request to implement custom opaque keys for ccx was first brought up in an architecture review of the PR referenced above.  It was felt that using such keys would allow ccx to better integrate with existing logging and analytics systems.  The outcome of this conversation was captured in jazkarta/edx-platform#43 

A separate PR (https://github.com/edx/edx-platform/pull/8259) has been opened to add the dependency upon the [custom key implementation](https://github.com/jazkarta/ccx-keys).  That PR is under review and should be merged prior to this.

During implementation of this code, @nedbat, @cpennington, @ormsbee, and @carsongee have all been pulled into discussions at various points.

The work has been overseen by @pdpinch and the team at MIT.
### Purpose

By creating a custom opaque-key implementation, the mechanism by which a user views CCX content (as opposed to the course from which the ccx was created) is simplified, and made to fall in line with existing mechanisms for retrieving course modules, assets and so on.  In addition, because there is a "locator" for a ccx that is distinct from that for the course, logging and analytics can register the use of CCX content separately from the use of the same materials for the original course.
### Impacts

This implementation adds a wrapper around the modulestore returned by `xmodule.modulestore.django.modulestore`.  When the CCX feature is enabled in settings, then wherever that method is called, a wrapped version of the modulestore will be returned.  This wrapper strips the ccx information out of locators and keys as queries are sent in to the modulestore and restores the information to the data that is returned.  Because of this, there is little in the system that is not impacted by this change.  For queries to the modulestore that use non-ccx keys or locations, this wrapper should be transparent, but it is present.

An additional implication of this work is that CCXs can not be created from legacy courses that use the pre-split deprecated form of course keys and locations. This restriction can be worked around by creating a re-run of such a course, which will convert it to the new form of storage and keys/locations.  It is therefore not considered a blocker.

In all other respects, the work should not have any direct impact on users.  CCX functionality continues to work as it did before this change.  There are no user-facing UI elements that have changed.

This work is integrated with previous CCX work, so it will be released initially only on edge, where CCX is already in use. 
### Manual Testing

In order to test these changes, you must begin with a course that uses the split-modulestore and has opaque-key course keys and locations (`course-v1:org+course+run...`).  Once that is in place, then you can follow these steps:
1.  Log in to the LMS an admin for the course, view the "instructor" tab and select "membership"
2.  In the course staff section, select the 'CCX Coach' role and add a user as a ccx coach.
3.  Log in as the CCX Coach user and visit the CCX Coach tab.
4.  Fill in a name for your ccx and submit to create it. You should be redirected to the Coach Dashboard view for the CCX.
5.  verify that when viewing the coach tab, you see a url that contains `ccx-v1:` and has `+ccx@n` in the identifier (`n` is the integer primary key of the CCX that was created). 
6.  verify that when viewing any other top level tab, you see only the course id (it should start with `course-v1:` and _not_ contain any mention of ccx).
7.  From the coach tab schedule some course content, but not all the items from the original course (so you can easily tell which you are seeing).
8.  From the coach tab, enroll a user in your ccx.
9.  Log in to the LMS as the student just enrolled by the coach.  You should see both the original course and the CCX on your dashboard.  They should be visually distinct
10.  Click on the CCX to go to the course info page.  It should look identical to the original course info page.  The URL for the page should contain `ccx-v1:` and `+ccx@n`.  (this verifies that you are viewing the ccx).
11.  Click on the courseware tab, verify that you see _only_ those course elements that were scheduled by the coach, and not any others.
12.  View and interact with the courseware.  Verify that everything works as expected.
13.  Check your progress report and verify that it operates as expected.
14.  Verify that the student cannot see the discussion tab (it should be hidden for any ccx).
15.  Log in as Coach and check the grade reports under `student admin` to verify that grades are being correctly calculated.  Update the grading policy and verify that it is applied to both the Coach grade views and the student progress view.
### Concerns

The modulestore wrapper is not well covered with tests.  We are not comfortable that we understand how best to approach the testing of this element.  We would appreciate any pointers in that regard.  

The management of CCX keys and locations versus Course keys and locations is a bit tricky and there are many possible edge cases we have yet to uncover.  There are a few places where manually unwrapping a ccx key is required to get course access information directly.  We would appreciate attention paid to this aspect.  If there are other places we have not yet found or thought of that might need special attention, please let us know.

It should be noted that at the time of this PR, there are 5 test failures and one error happening in my local development environment.  All of these are in the tests for the sysadmin dashboard and have to do with importing XML course content from git.  I believe the problem to be in my development environment, but if anyone (like @carsongee) has suggestions about fixing them should they also appear in jenkins, I'd appreciate it.
