### PR TITLE
www.stage.edx.org is our Drupal site

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -466,7 +466,7 @@ def generate_email(start_ref, end_ref, release_date=None):
 
         https://openedx.atlassian.net/wiki/display/ENG/{date}+Release
 
-        The staging server is: https://www.stage.edx.org
+        The staging server is: https://stage.edx.org
 
         Note that you are responsible for verifying any pull requests that you
         merged, whether you wrote the code or not. (If you didn't write the code,


### PR DESCRIPTION
It also serves the production SSL cert (*.edx.org) meaning people who
visit www.stage.edx.org get an SSL error.  Send them to stage.edx.org
instead.

@feanil @singingwolfboy

My more ambitious change involved more of the github API than was prudent, so just a small fixup.
