### PR TITLE
Fix self-paced badge naming.

### DIFF
--- a/lms/djangoapps/certificates/badge_handler.py
+++ b/lms/djangoapps/certificates/badge_handler.py
@@ -117,7 +117,7 @@ class BadgeHandler(object):
             )
         else:
             return _(u'Completed the course "{course_name}" ({course_mode})').format(
-                start_date=course.display_name,
+                course_name=course.display_name,
                 course_mode=mode,
             )
 

--- a/lms/djangoapps/certificates/tests/test_badge_handler.py
+++ b/lms/djangoapps/certificates/tests/test_badge_handler.py
@@ -115,6 +115,13 @@ class BadgeHandlerTestCase(ModuleStoreTestCase, EventTrackingTestCase):
             }
         )
 
+    def test_self_paced_description(self):
+        """
+        Verify that a badge created for a course with no end date gets a different description.
+        """
+        self.course.end = None
+        self.assertEqual(BadgeHandler.badge_description(self.course, 'honor'), 'Completed the course "Badged" (honor)')
+
     def test_ensure_badge_created_cache(self):
         """
         Make sure ensure_badge_created doesn't call create_badge if we know the badge is already there.


### PR DESCRIPTION
**Background**: Fixes a bug when setting up a self-paced course badge for the first time where the format name was incorrect.
**Partner information**: 3rd party-hosted open edX instance, for an edX solutions client.
