### PR TITLE
Default to filestorage when S3 isn't configured (aws.py) - SOL-963

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -43,7 +43,6 @@ TEMPLATE_DEBUG = False
 
 EMAIL_BACKEND = 'django_ses.SESBackend'
 SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
-DEFAULT_FILE_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
 
 # IMPORTANT: With this enabled, the server must always be behind a proxy that
 # strips the header HTTP_X_FORWARDED_PROTO from client requests. Otherwise,
@@ -250,6 +249,13 @@ if AWS_ACCESS_KEY_ID == "":
 AWS_SECRET_ACCESS_KEY = AUTH_TOKENS["AWS_SECRET_ACCESS_KEY"]
 if AWS_SECRET_ACCESS_KEY == "":
     AWS_SECRET_ACCESS_KEY = None
+
+if AUTH_TOKENS.get('DEFAULT_FILE_STORAGE'):
+    DEFAULT_FILE_STORAGE = AUTH_TOKENS.get('DEFAULT_FILE_STORAGE')
+elif AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY:
+    DEFAULT_FILE_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
+else:
+    DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
 
 DATABASES = AUTH_TOKENS['DATABASES']
 MODULESTORE = convert_module_store_setting_if_needed(AUTH_TOKENS.get('MODULESTORE', MODULESTORE))

--- a/lms/djangoapps/certificates/migrations/0022_default_modes.py
+++ b/lms/djangoapps/certificates/migrations/0022_default_modes.py
@@ -16,7 +16,7 @@ class Migration(DataMigration):
             conf.mode = mode
             file_name = mode + '.png'
             conf.icon.save(
-                file_name,
+                'badges/{}'.format(file_name),
                 File(open(settings.PROJECT_ROOT / 'static' / 'images' / 'default-badges' / file_name))
             )
             conf.save()

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -47,7 +47,6 @@ TEMPLATE_DEBUG = False
 
 EMAIL_BACKEND = 'django_ses.SESBackend'
 SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
-DEFAULT_FILE_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
 
 # IMPORTANT: With this enabled, the server must always be behind a proxy that
 # strips the header HTTP_X_FORWARDED_PROTO from client requests. Otherwise,
@@ -399,6 +398,13 @@ if AWS_SECRET_ACCESS_KEY == "":
     AWS_SECRET_ACCESS_KEY = None
 
 AWS_STORAGE_BUCKET_NAME = AUTH_TOKENS.get('AWS_STORAGE_BUCKET_NAME', 'edxuploads')
+
+if AUTH_TOKENS.get('DEFAULT_FILE_STORAGE'):
+    DEFAULT_FILE_STORAGE = AUTH_TOKENS.get('DEFAULT_FILE_STORAGE')
+elif AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY:
+    DEFAULT_FILE_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
+else:
+    DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
 
 # Specific setting for the File Upload Service to store media in a bucket.
 FILE_UPLOAD_STORAGE_BUCKET_NAME = ENV_TOKENS.get('FILE_UPLOAD_STORAGE_BUCKET_NAME', FILE_UPLOAD_STORAGE_BUCKET_NAME)


### PR DESCRIPTION
**Description:** Currently the migration `lms/djangoapps/certificates/migrations/0022_default_modes.py` fails with the default fullstack configuration (aws.py). The migration relies on a file storage being configured, but the default configuration sets `DEFAULT_FILE_STORAGE` to `storages.backends.s3boto.S3BotoStorage`, but without S3 credentials, this fails.

See details in https://openedx.atlassian.net/browse/SOL-963

The current solution aims to provide sensible defaults, without requiring additional configuration from existing setups. It will keep the current default setting of using S3 for storage if the S3 credentials are set, but will use the filesystem storage if the credentials aren't provided. Additionally, instances wishing to explicitly set a storage mechanism can now do so by setting the `DEFAULT_FILE_STORAGE` variable in the `AUTH_TOKENS` (for example via the `EDXAPP_AUTH_EXTRA` variable in the configuration repo).

Also moves the default icons to the badges subfolder to avoid storage conflicts.

**Dependency**: https://github.com/edx/configuration/pull/2082 (_required to be able to use `MEDIA_ROOT` with the default fullstack configuration_)
**Partner information:** Solutions client
**Merge deadline:** ASAP

@Kelketek @fredsmith @feanil @carsongee
