### PR TITLE
Bump edx-submissions hash to latest version.

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -38,7 +38,7 @@ git+https://github.com/hmarr/django-debug-toolbar-mongo.git@b0686a76f1ce3532088c
 -e git+https://github.com/edx-solutions/django-splash.git@7579d052afcf474ece1239153cffe1c89935bc4f#egg=django-splash
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
 -e git+https://github.com/edx/edx-ora2.git@release-2015-05-08T16.15#egg=edx-ora2
--e git+https://github.com/edx/edx-submissions.git@e2361932b9bce061a018a31bb3929e9cade80f49#egg=edx-submissions
+-e git+https://github.com/edx/edx-submissions.git@7c766502058e04bc9094e6cbe286e949794b80b3#egg=edx-submissions
 -e git+https://github.com/edx/opaque-keys.git@df0dd602869e498e512659bb4bd243309e30e19a#egg=opaque-keys
 -e git+https://github.com/edx/ease.git@b67d2928a26fe497826b6ea359b9a3d0371548a7#egg=ease==0.1.3
 -e git+https://github.com/edx/i18n-tools.git@3478455a2cc59a734432264e409b8eade1e4b167#egg=i18n-tools


### PR DESCRIPTION
This will pull in the new `get_all_submissions()` interface method, which can be used to retrieve the submissions by all students for a particular item.

The changes have been reviewed in [edx-submissions PR #14](https://github.com/edx/edx-submissions/pull/14).

@ormsbee Can I merge this PR immediately, or do I need another review or an OSPR ticket?
