### PR TITLE
Allow multiple external_link tabs for one course.

### DIFF
--- a/lms/djangoapps/courseware/tabs.py
+++ b/lms/djangoapps/courseware/tabs.py
@@ -234,6 +234,7 @@ class ExternalLinkCourseViewType(EnrolledCourseViewType):
     name = 'external_link'
     priority = None
     is_default = False    # An external link tab is not added to a course by default
+    allow_multiple = True
 
     @classmethod
     def create_tab(cls, tab_dict):

--- a/lms/djangoapps/courseware/tests/test_tabs.py
+++ b/lms/djangoapps/courseware/tests/test_tabs.py
@@ -510,6 +510,7 @@ class TabListTestCase(TabTestCase):
                 {'type': CourseInfoViewType.name, 'name': 'fake_name'},
                 {'type': 'discussion', 'name': 'fake_name'},
                 {'type': ExternalLinkCourseViewType.name, 'name': 'fake_name', 'link': 'fake_link'},
+                {'type': ExternalLinkCourseViewType.name, 'name': 'fake_name', 'link': 'fake_link'},
                 {'type': 'textbooks'},
                 {'type': 'pdf_textbooks'},
                 {'type': 'html_textbooks'},


### PR DESCRIPTION
This is causing errors in old versions of CS50.

TNL-2397
