### PR TITLE
Update docs.edx.org

### DIFF
--- a/doroob.html
+++ b/doroob.html
@@ -63,7 +63,7 @@
 
               <div class="item-audience__copy">
                 <p>The following documentation is for Doroob partners using the Open edX Platform.</p>
-                <p>This page lists only documentation that is currently customized for our Doroob partners.
+                <p>This page lists only documentation that is currently used by our Doroob partners.
                 See the Documentation <a href="index.html">Home page</a> for a complete list of available documentation.</p>  
               </div>
 
@@ -72,7 +72,8 @@
                 
                 </li>
                 <li class="item-link">
-                  <a class="item-link__action" href="http://edx.readthedocs.org/projects/doroob-course-staff-documentation/en/latest/">Building and Running an edX Course</h4>
+                  <a class="item-link__action" href="http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/latest/">
+                    <h4 class="item-link__title">Building and Running an Open edX Course</h4>
                     <div class="item-link__copy">
                       <p>Instructions for building a course with edX Studio and running the course in the edX Learning Management System.</p>
                     </div>
@@ -80,8 +81,8 @@
                 </li>
 
                 <li class="item-link">
-                  <a class="item-link__action" href="http://edx.readthedocs.org/projects/doroob-student-documentation/en/latest/">
-                    <h4 class="item-link__title">Student Guide</h4>
+                  <a class="item-link__action" href="http://edx.readthedocs.org/projects/open-edx-learner-guide/en/latest/">
+                    <h4 class="item-link__title">Open edX Learner's Guide</h4>
                     <div class="item-link__copy">
                       <p>Help for learners taking an edX course.</p>
                     </div>

--- a/index.html
+++ b/index.html
@@ -59,10 +59,10 @@
 
           <div class="list--docs">
             <section class="item-audience item-audience--partners">
-              <h3 class="item-audience__title">edX Partners</h3>
+              <h3 class="item-audience__title">EdX Partners</h3>
 
               <div class="item-audience__copy">
-                <p>The following documentation is for edX Partners and Members who use the edX Platform on edX.org and edX Edge.</p>
+                <p>Documentation for edX partners and members who use the edX platform on edX.org and edX Edge.</p>
               </div>
 
               <ul class="list--links">
@@ -99,7 +99,7 @@
 
                 <li class="item-link">
                   <a class="item-link__action" href="http://edx.readthedocs.org/projects/devdata/en/latest/">
-                    <h4 class="item-link__title">Research Guide</h4>
+                    <h4 class="item-link__title">EdX Research Guide</h4>
                     <div class="item-link__copy">
                       <p>For researchers and data czars at edX partner institutions who use the edX data exports to gain insight into their courses and students.</p>
                     </div>
@@ -108,7 +108,7 @@
 
                 <li class="item-link">
                   <a class="item-link__action" href="http://edx.readthedocs.org/projects/edx-guide-for-students/en/latest/">
-                    <h4 class="item-link__title">edX Guide for Students</h4>
+                    <h4 class="item-link__title">EdX Learner's Guide</h4>
                     <div class="item-link__copy">
                       <p>Help for learners taking an edX course.</p>
                     </div>
@@ -118,10 +118,10 @@
               </ul>
             </section>
             <section class="item-audience item-audience--release">
-              <h3 class="item-audience__title">Open edX Birch Release</h3>
+              <h3 class="item-audience__title">Open edX Documentation: Birch Release</h3>
 
               <div class="item-audience__copy">
-                <p>The following documentation is for developers and service providers who are contributing to, extending, and hosting Open edX. This documentation is updated for the Open edX <strong>Birch</strong> release.</p>
+                <p>Documentation for the Open edX <strong>Birch</strong> release, published February 24, 2015.</p>
               </div>
 
               <ul class="list--links">
@@ -129,20 +129,12 @@
                 <li class="item-link">
                   <a class="item-link__action" href="http://edx.readthedocs.org/projects/open-edx-release-notes/en/latest/">
                     <h4 class="item-link__title">Open edX Release Notes</h4>
-                      <div class="item-link__updated-date">Last Updated: February 24, 2015 for the Birch Release</div>
                     <div class="item-link__copy">
-                      <p>A list of the changes in the most recent release of Open edX.</p>
+                      <p>A list of the changes in the Birch release of Open edX.</p>
                     </div>
                   </a>
                 </li>
-                <li class="item-link">
-                  <a class="item-link__action" href="http://edx.readthedocs.org/projects/edx-installing-configuring-and-running/en/latest/">
-                    <h4 class="item-link__title">Installing, Configuring, and Running the edX Platform</h4>
-                    <div class="item-link__copy">
-                      <p>Instructions for setting up Open edX.</p>
-                    </div>
-                  </a>
-                </li>
+                
                 <li class="item-link">
                   <a class="item-link__action" href="http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-birch/">
                     <h4 class="item-link__title">Building and Running an Open edX Course</h4>
@@ -154,16 +146,44 @@
               </ul>
             </section>
             <section class="item-audience item-audience--release">
-              <h3 class="item-audience__title">Open edX Developer Documentation</h3>
+              <h3 class="item-audience__title">Open edX Documentation: Latest Version</h3>
 
               <div class="item-audience__copy">
-                <p>The following documentation is for developers who are contributing to and extending Open edX.</p>
+                <p>The <strong>latest</strong> documentation available for Open edX users.</p>
               </div>
 
               <ul class="list--links">
                 <li class="item-link">
+                  <a class="item-link__action" href="http://edx.readthedocs.org/projects/edx-installing-configuring-and-running/en/latest/">
+                    <h4 class="item-link__title">Installing, Configuring, and Running the Open edX Platform</h4>
+                    <div class="item-link__copy">
+                      <p>Instructions for setting up Open edX.</p>
+                    </div>
+                  </a>
+                </li>
+
+                <li class="item-link">
+                  <a class="item-link__action" href="http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/latest/">
+                    <h4 class="item-link__title">Building and Running an Open edX Course</h4>
+                    <div class="item-link__copy">
+                      <p>Instructions for building an Open edX course with Studio and running the course in the Learning Management System.</p>
+                    </div>
+                  </a>
+                </li>
+
+                <li class="item-link">
+                  <a class="item-link__action" href="http://edx.readthedocs.org/projects/open-edx-learner-guide/en/latest/">
+                    <h4 class="item-link__title">Open edX Learner's Guide</h4>
+                    <div class="item-link__copy">
+                      <p>Help for learners taking an Open edX course.</p>
+                    </div>
+                  </a>
+                </li>
+
+               
+                <li class="item-link">
                   <a class="item-link__action" href="http://edx.readthedocs.org/projects/edx-developer-guide/en/latest/">
-                    <h4 class="item-link__title">edX Developer Documentation</h4>
+                    <h4 class="item-link__title">Open edX Developer's Guide</h4>
                     <div class="item-link__copy">
                       <p>For developers contributing to the edX platform.</p>
                     </div>
@@ -174,7 +194,7 @@
                   <a class="item-link__action" href="http://edx.readthedocs.org/projects/xblock/en/latest/">
                     <h4 class="item-link__title">XBlock</h4>
                     <div class="item-link__copy">
-                      <p>Describes XBlock, the component architecture for building courseware.</p>
+                      <p>For developers extending the edX platform with XBlock, the component architecture for building courseware.</p>
                     </div>
                   </a>
                 </li>
@@ -193,7 +213,7 @@
               <h3 class="item-audience__title">Open edX APIs</h3>
 
               <div class="item-audience__copy">
-                <p>The following documentation is for developers who are using the Open edX APIs.</p>
+                <p>Documentation for the Open edX REST APIs.</p>
               </div>
 
               <ul class="list--links">


### PR DESCRIPTION
This PR updates docs.edx.org:
- Separate sections for Open edX Birch release and Latest docs
- Updated Doroob URLs to point to latest Open edX doc, not separate Saudi branch doc.
- Other minor tweaks.

Best way to test/view is to synch to this branch and open index.html and doroob.html locally.

@lamagnifica @nedbat 
