### PR TITLE
Improve import speed with ParentLocationCache tweaks.

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -11,12 +11,12 @@ structure:
     'definition.children': <list of all child location.to_deprecated_string()s>
 }
 """
-
 import pymongo
 import sys
 import logging
 import copy
 import re
+from collections import defaultdict
 from uuid import uuid4
 
 from bson.son import SON
@@ -504,6 +504,27 @@ class ParentLocationCache(dict):
     Dict-based object augmented with a more cache-like interface, for internal use.
     """
     # pylint: disable=missing-docstring
+    def __init__(self, *args, **kwargs):
+        self._values_to_keys = defaultdict(set)
+        super(ParentLocationCache, self).__init__(*args, **kwargs)
+
+        # Needed in the case where we were given data on __init__()
+        for key, value in self.items():
+            self._values_to_keys[value].add(key)
+
+    def __setitem__(self, key, value):
+        # If the key already exists, we have to remove it from the reverse lookup
+        if key in self:
+            old_val = self[key]
+            old_val_keys = self._values_to_keys[old_val]
+            if key in old_val_keys:
+                old_val_keys.remove(key)
+
+        # Now invoke dict's __setitem__
+        super(ParentLocationCache, self).__setitem__(key, value)
+
+        # Add to our reverse lookup, so that we can make delete_by_value() fast
+        self._values_to_keys[value].add(key)
 
     @contract(key=unicode)
     def has(self, key):
@@ -515,9 +536,10 @@ class ParentLocationCache(dict):
 
     @contract(value="BlockUsageLocator")
     def delete_by_value(self, value):
-        keys_to_delete = [k for k, v in self.iteritems() if v == value]
+        keys_to_delete = self._values_to_keys.pop(value, set())
         for key in keys_to_delete:
-            del self[key]
+            if key in self:
+                del self[key]
 
 
 class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, MongoBulkOpsMixin):

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_mongo.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_mongo.py
@@ -30,8 +30,9 @@ from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.mongo import MongoKeyValueStore
 from xmodule.modulestore.draft import DraftModuleStore
 from opaque_keys.edx.locations import SlashSeparatedCourseKey, AssetLocation
-from opaque_keys.edx.locator import LibraryLocator, CourseLocator
-from opaque_keys.edx.keys import UsageKey
+from opaque_keys.edx.locator import LibraryLocator, CourseLocator, BlockUsageLocator
+from opaque_keys.edx.keys import UsageKey 
+
 from xmodule.modulestore.xml_exporter import export_course_to_xml
 from xmodule.modulestore.xml_importer import import_course_from_xml, perform_xlint
 from xmodule.contentstore.mongo import MongoContentStore
@@ -40,7 +41,7 @@ from nose.tools import assert_in
 from xmodule.exceptions import NotFoundError
 from git.test.lib.asserts import assert_not_none
 from xmodule.x_module import XModuleMixin
-from xmodule.modulestore.mongo.base import as_draft
+from xmodule.modulestore.mongo.base import as_draft, ParentLocationCache
 from xmodule.modulestore.tests.mongo_connection import MONGO_PORT_NUM, MONGO_HOST
 from xmodule.modulestore.tests.utils import LocationMixin, mock_tab_from_json
 from xmodule.modulestore.edit_info import EditInfoMixin
@@ -902,3 +903,61 @@ def _build_requested_filter(requested_filter):
         "$where": ' || '.join(where),
     }
     return filter_params
+
+
+class TestParentLocationCache(unittest.TestCase):
+    """
+    Test the small helper parent location lookup cache -- how we quickly find
+    the parent for a given node. This is being tested because we do a little
+    bookkeeping in order to make `delete_by_value()` run quickly without having
+    to iterate through the entire collection.
+    """
+
+    def test_delete_by_value(self):
+        course_key = CourseLocator(org="edX", course="parenting_101", run="2014")
+        parent_keys = [
+            BlockUsageLocator(course_key, u"vertical", unicode(block_id))
+            for block_id in range(3)
+        ]
+        # These are unicode, not Locators.
+        child_ids = [
+            unicode(BlockUsageLocator(course_key, u"html", unicode(block_id)))
+            for block_id in range(3)
+        ]
+
+        # Simplest happy path...
+        p_cache = ParentLocationCache()
+        p_cache.set(child_ids[0], parent_keys[0])
+        p_cache[child_ids[1]] = parent_keys[1]
+        p_cache.delete_by_value(parent_keys[0])
+        assert_equals(p_cache, {child_ids[1]: parent_keys[1]})
+
+        # Changing keys
+        p_cache[child_ids[1]] = parent_keys[2]
+        p_cache.delete_by_value(parent_keys[1])  # should do nothing
+        assert_equals(p_cache, {child_ids[1]: parent_keys[2]})
+        p_cache.delete_by_value(parent_keys[2])
+        assert_equals(p_cache, {})
+
+        # Multiple pointers to the same parent
+        p_cache[child_ids[0]] = parent_keys[2]
+        p_cache[child_ids[1]] = parent_keys[2]
+        p_cache[child_ids[2]] = parent_keys[2]
+        assert_equals(
+            p_cache,
+            {
+                child_ids[0]: parent_keys[2],
+                child_ids[1]: parent_keys[2],
+                child_ids[2]: parent_keys[2],
+            }
+        )
+        p_cache.delete_by_value(parent_keys[2])
+        assert_equals(p_cache, {})
+
+        # Initializing the dict in the constructor
+        p_cache2 = ParentLocationCache([
+            (child_ids[0], parent_keys[0]),
+            (child_ids[1], parent_keys[1])
+        ])
+        p_cache2.delete_by_value(parent_keys[0])
+        assert_equals(p_cache2, {child_ids[1]: parent_keys[1]})


### PR DESCRIPTION
@adampalay, @cpennington: This is an optimization. Previously, `ParentLocationCache.delete_by_value()` would iterate through all items in the dict to find what it needed to delete. This could become very expensive during the import of large courses. This commit creates a reverse lookup dict so that we can avoid that iteration. Quick local testing shows that this iteration could account for up to 1/3rd the processing time when importing large courses.

Heads up to T&L folks: @andy-armstrong, @cahrens

Import is still slow of course. But assuming tests pass, it's a decent return on seven lines of code.
