### PR TITLE
Fixed two paly_video events emitted on video replay.

### DIFF
--- a/common/lib/xmodule/xmodule/js/spec/video/html5_video_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/html5_video_spec.js
@@ -51,14 +51,14 @@
                             });
                         });
 
-                        it('callback was called', function () {
+                        it('callback was not called', function () {
                             waitsFor(function () {
                                 return state.videoPlayer.player.getPlayerState() !== STATUS.PAUSED;
                             }, 'Player state should be changed', WAIT_TIMEOUT);
 
                             runs(function () {
                                 expect(state.videoPlayer.player.callStateChangeCallback)
-                                    .toHaveBeenCalled();
+                                    .not.toHaveBeenCalled();
                             });
                         });
                     });
@@ -85,14 +85,14 @@
                             });
                         });
 
-                        it('callback was called', function () {
+                        it('callback was not called', function () {
                             waitsFor(function () {
                                 return state.videoPlayer.player.getPlayerState() !== STATUS.PLAYING;
                             }, 'Player state should be changed', WAIT_TIMEOUT);
 
                             runs(function () {
                                 expect(state.videoPlayer.player.callStateChangeCallback)
-                                    .toHaveBeenCalled();
+                                    .not.toHaveBeenCalled();
                             });
                         });
                     });

--- a/common/lib/xmodule/xmodule/js/src/video/02_html5_video.js
+++ b/common/lib/xmodule/xmodule/js/src/video/02_html5_video.js
@@ -290,13 +290,11 @@ function () {
                 var PlayerState = HTML5Video.PlayerState;
 
                 if (_this.playerState === PlayerState.PLAYING) {
-                    _this.pauseVideo();
                     _this.playerState = PlayerState.PAUSED;
-                    _this.callStateChangeCallback();
+                    _this.pauseVideo();
                 } else {
-                    _this.playVideo();
                     _this.playerState = PlayerState.PLAYING;
-                    _this.callStateChangeCallback();
+                    _this.playVideo();
                 }
             });
 


### PR DESCRIPTION
[TNL-2166](https://openedx.atlassian.net/browse/TNL-2166)

Fixed two `play_video` events emitted when we watch the full video and then click again on video player to replay the video.

The 1st event was emitting wrong time which I noticed that is fixed in https://github.com/edx/edx-platform/pull/7825.
