### PR TITLE
Remove course_title from bulk email subject.

### DIFF
--- a/lms/djangoapps/bulk_email/tasks.py
+++ b/lms/djangoapps/bulk_email/tasks.py
@@ -475,7 +475,6 @@ def _send_course_email(entry_id, email_id, to_list, global_email_context, subtas
         subtask_status.increment(skipped=num_optout)
 
     course_title = global_email_context['course_title']
-    subject = "[" + course_title + "] " + course_email.subject
 
     # use the email from address in the CourseEmail, if it is present, otherwise compute it
     from_addr = course_email.from_addr if course_email.from_addr else \
@@ -511,7 +510,7 @@ def _send_course_email(entry_id, email_id, to_list, global_email_context, subtas
 
             # Create email:
             email_msg = EmailMultiAlternatives(
-                subject,
+                course_email.subject,
                 plaintext_msg,
                 from_addr,
                 [email],

--- a/lms/djangoapps/bulk_email/tasks.py
+++ b/lms/djangoapps/bulk_email/tasks.py
@@ -159,7 +159,7 @@ def _get_course_email_context(course):
         'course_url': course_url,
         'course_image_url': image_url,
         'course_end_date': course_end_date,
-        'account_settings_url': 'https://{}{}'.format(settings.SITE_NAME, reverse('dashboard')),
+        'account_settings_url': 'https://{}{}'.format(settings.SITE_NAME, reverse('account_settings')),
         'platform_name': settings.PLATFORM_NAME,
     }
     return email_context

--- a/lms/djangoapps/bulk_email/tests/test_email.py
+++ b/lms/djangoapps/bulk_email/tests/test_email.py
@@ -129,10 +129,7 @@ class TestEmailSendFromDashboardMockedHtmlToText(EmailSendFromDashboardTestCase)
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(len(mail.outbox[0].to), 1)
         self.assertEquals(mail.outbox[0].to[0], self.instructor.email)
-        self.assertEquals(
-            mail.outbox[0].subject,
-            '[' + self.course.display_name + ']' + ' test subject for myself'
-        )
+        self.assertEquals(mail.outbox[0].subject, 'test subject for myself')
 
     def test_send_to_staff(self):
         """
@@ -240,10 +237,7 @@ class TestEmailSendFromDashboardMockedHtmlToText(EmailSendFromDashboardTestCase)
             [e.to[0] for e in mail.outbox],
             [self.instructor.email] + [s.email for s in self.staff] + [s.email for s in self.students]
         )
-        self.assertEquals(
-            mail.outbox[0].subject,
-            '[' + self.course.display_name + '] ' + uni_subject
-        )
+        self.assertEquals(mail.outbox[0].subject, uni_subject)
 
     def test_unicode_students_send_to_all(self):
         """


### PR DESCRIPTION
This PR updates the ~~email template and~~ account_settings_url and removes the course title from email subject.

Sandbox: https://muzaffar-bulk-emails.m.sandbox.edx.org/

JIRA TICKETS: 
1 - https://openedx.atlassian.net/browse/TNL-1877

For testing of this ticket https://openedx.atlassian.net/browse/TNL-1878 we would be using the same sandbox.
