### PR TITLE
Increasing contrast in course nav accordions

### DIFF
--- a/lms/static/sass/base/_variables.scss
+++ b/lms/static/sass/base/_variables.scss
@@ -398,9 +398,9 @@ $form-bg-color: $white;
 $modal-bg-color: rgb(245,245,245);
 
 // MISC: sidebar
-$sidebar-chapter-bg-top: rgba(255, 255, 255, .6);
+$sidebar-chapter-bg-top: rgba(255, 255, 255, .5);
 $sidebar-chapter-bg-bottom: rgba(255, 255, 255, 0);
-$sidebar-chapter-bg: rgb(238,238,238); // #eeeeee
+$sidebar-chapter-bg: rgb(246,246,246); // #f6f6f6
 $sidebar-active-image: linear-gradient(top, rgb(230,230,230), rgb(214,214,214));
 
 // TOP HEADER IMAGE MARGIN


### PR DESCRIPTION
This work increases the accessibility/contrast of course navigation (accordion) menu items.

The previous background color of each menu item was `#eeeeee`, which was a tad too dark with our updated blue. There's a gradient (white, all transparent and white, mostly transparent) that gives depth to the menu items, but the contrast checks foreground with background. The `background-image` gradient doesn't count.

I lightened the background base from `#eeeeee` to `#f6f6f6` which provides enough "programatic" contrast to pass tests. I also lightened the gradient a tad, giving each menu item a lighter look.

All in all, we have a cleaner looking course nav, with slightly lighter background gradients, that pass AA specifications for contrast ratios.

---

**Reviewers:**
@frrrances Sass
@cptvitamin Accessibility
