### PR TITLE
Add comment editing to discussion API

### DIFF
--- a/lms/djangoapps/discussion_api/tests/test_api.py
+++ b/lms/djangoapps/discussion_api/tests/test_api.py
@@ -27,6 +27,7 @@ from discussion_api.api import (
     get_comment_list,
     get_course_topics,
     get_thread_list,
+    update_comment,
     update_thread,
 )
 from discussion_api.tests.utils import (
@@ -1635,6 +1636,173 @@ class UpdateThreadTest(CommentsServiceMockMixin, UrlResetMixin, ModuleStoreTestC
             assertion.exception.message_dict,
             {"raw_body": ["This field is required."]}
         )
+
+
+@ddt.ddt
+class UpdateCommentTest(CommentsServiceMockMixin, UrlResetMixin, ModuleStoreTestCase):
+    """Tests for update_comment"""
+    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    def setUp(self):
+        super(UpdateCommentTest, self).setUp()
+        httpretty.reset()
+        httpretty.enable()
+        self.addCleanup(httpretty.disable)
+        self.user = UserFactory.create()
+        self.register_get_user_response(self.user)
+        self.request = RequestFactory().get("/test_path")
+        self.request.user = self.user
+        self.course = CourseFactory.create()
+
+        CourseEnrollmentFactory.create(user=self.user, course_id=self.course.id)
+
+    def register_comment(self, overrides=None, thread_overrides=None):
+        """
+        Make a comment with appropriate data overridden by the overrides
+        parameter and register mock responses for both GET and PUT on its
+        endpoint. Also mock GET for the related thread with thread_overrides.
+        """
+        cs_thread_data = make_minimal_cs_thread({
+            "id": "test_thread",
+            "course_id": unicode(self.course.id)
+        })
+        cs_thread_data.update(thread_overrides or {})
+        self.register_get_thread_response(cs_thread_data)
+        cs_comment_data = make_minimal_cs_comment({
+            "id": "test_comment",
+            "course_id": cs_thread_data["course_id"],
+            "thread_id": cs_thread_data["id"],
+            "username": self.user.username,
+            "user_id": str(self.user.id),
+            "created_at": "2015-06-03T00:00:00Z",
+            "updated_at": "2015-06-03T00:00:00Z",
+            "body": "Original body",
+        })
+        cs_comment_data.update(overrides or {})
+        self.register_get_comment_response(cs_comment_data)
+        self.register_put_comment_response(cs_comment_data)
+
+    def test_empty(self):
+        """Check that an empty update does not make any modifying requests."""
+        self.register_comment()
+        update_comment(self.request, "test_comment", {})
+        for request in httpretty.httpretty.latest_requests:
+            self.assertEqual(request.method, "GET")
+
+    def test_basic(self):
+        self.register_comment()
+        actual = update_comment(self.request, "test_comment", {"raw_body": "Edited body"})
+        expected = {
+            "id": "test_comment",
+            "thread_id": "test_thread",
+            "parent_id": None,  # TODO: we can't get this without retrieving from the thread :-(
+            "author": self.user.username,
+            "author_label": None,
+            "created_at": "2015-06-03T00:00:00Z",
+            "updated_at": "2015-06-03T00:00:00Z",
+            "raw_body": "Edited body",
+            "endorsed": False,
+            "endorsed_by": None,
+            "endorsed_by_label": None,
+            "endorsed_at": None,
+            "abuse_flagged": False,
+            "voted": False,
+            "vote_count": 0,
+            "children": [],
+        }
+        self.assertEqual(actual, expected)
+        self.assertEqual(
+            httpretty.last_request().parsed_body,
+            {
+                "body": ["Edited body"],
+                "course_id": [unicode(self.course.id)],
+                "user_id": [str(self.user.id)],
+                "anonymous": ["False"],
+                "anonymous_to_peers": ["False"],
+                "endorsed": ["False"],
+            }
+        )
+
+    def test_nonexistent_comment(self):
+        self.register_get_comment_error_response("test_comment", 404)
+        with self.assertRaises(Http404):
+            update_comment(self.request, "test_comment", {})
+
+    def test_nonexistent_course(self):
+        self.register_comment(thread_overrides={"course_id": "non/existent/course"})
+        with self.assertRaises(Http404):
+            update_comment(self.request, "test_comment", {})
+
+    def test_unenrolled(self):
+        self.register_comment()
+        self.request.user = UserFactory.create()
+        with self.assertRaises(Http404):
+            update_comment(self.request, "test_comment", {})
+
+    def test_discussions_disabled(self):
+        _remove_discussion_tab(self.course, self.user.id)
+        self.register_comment()
+        with self.assertRaises(Http404):
+            update_comment(self.request, "test_comment", {})
+
+    @ddt.data(
+        *itertools.product(
+            [
+                FORUM_ROLE_ADMINISTRATOR,
+                FORUM_ROLE_MODERATOR,
+                FORUM_ROLE_COMMUNITY_TA,
+                FORUM_ROLE_STUDENT,
+            ],
+            [True, False],
+            ["no_group", "match_group", "different_group"],
+        )
+    )
+    @ddt.unpack
+    def test_group_access(self, role_name, course_is_cohorted, thread_group_state):
+        cohort_course = CourseFactory.create(cohort_config={"cohorted": course_is_cohorted})
+        CourseEnrollmentFactory.create(user=self.user, course_id=cohort_course.id)
+        cohort = CohortFactory.create(course_id=cohort_course.id, users=[self.user])
+        role = Role.objects.create(name=role_name, course_id=cohort_course.id)
+        role.users = [self.user]
+        self.register_get_thread_response(make_minimal_cs_thread())
+        self.register_comment(
+            {"thread_id": "test_thread"},
+            thread_overrides={
+                "id": "test_thread",
+                "course_id": unicode(cohort_course.id),
+                "group_id": (
+                    None if thread_group_state == "no_group" else
+                    cohort.id if thread_group_state == "match_group" else
+                    cohort.id + 1
+                ),
+            }
+        )
+        expected_error = (
+            role_name == FORUM_ROLE_STUDENT and
+            course_is_cohorted and
+            thread_group_state == "different_group"
+        )
+        try:
+            update_comment(self.request, "test_comment", {})
+            self.assertFalse(expected_error)
+        except Http404:
+            self.assertTrue(expected_error)
+
+    @ddt.data(
+        FORUM_ROLE_ADMINISTRATOR,
+        FORUM_ROLE_MODERATOR,
+        FORUM_ROLE_COMMUNITY_TA,
+        FORUM_ROLE_STUDENT,
+    )
+    def test_role_access(self, role_name):
+        role = Role.objects.create(name=role_name, course_id=self.course.id)
+        role.users = [self.user]
+        self.register_comment({"user_id": str(self.user.id + 1)})
+        expected_error = role_name == FORUM_ROLE_STUDENT
+        try:
+            update_comment(self.request, "test_comment", {"raw_body": "edited"})
+            self.assertFalse(expected_error)
+        except PermissionDenied:
+            self.assertTrue(expected_error)
 
 
 @ddt.ddt

--- a/lms/djangoapps/discussion_api/tests/test_views.py
+++ b/lms/djangoapps/discussion_api/tests/test_views.py
@@ -13,7 +13,11 @@ from django.core.urlresolvers import reverse
 
 from rest_framework.test import APIClient
 
-from discussion_api.tests.utils import CommentsServiceMockMixin, make_minimal_cs_thread
+from discussion_api.tests.utils import (
+    CommentsServiceMockMixin,
+    make_minimal_cs_comment,
+    make_minimal_cs_thread,
+)
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
 from util.testing import UrlResetMixin
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
@@ -629,6 +633,88 @@ class CommentViewSetCreateTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         )
         expected_response_data = {
             "field_errors": {"thread_id": {"developer_message": "This field is required."}}
+        }
+        self.assertEqual(response.status_code, 400)
+        response_data = json.loads(response.content)
+        self.assertEqual(response_data, expected_response_data)
+
+
+class CommentViewSetPartialUpdateTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
+    """Tests for CommentViewSet partial_update"""
+    def setUp(self):
+        super(CommentViewSetPartialUpdateTest, self).setUp()
+        httpretty.reset()
+        httpretty.enable()
+        self.addCleanup(httpretty.disable)
+        self.register_get_user_response(self.user)
+        self.url = reverse("comment-detail", kwargs={"comment_id": "test_comment"})
+        cs_thread = make_minimal_cs_thread({
+            "id": "test_thread",
+            "course_id": unicode(self.course.id),
+        })
+        self.register_get_thread_response(cs_thread)
+        cs_comment = make_minimal_cs_comment({
+            "id": "test_comment",
+            "course_id": cs_thread["course_id"],
+            "thread_id": cs_thread["id"],
+            "username": self.user.username,
+            "user_id": str(self.user.id),
+            "created_at": "2015-06-03T00:00:00Z",
+            "updated_at": "2015-06-03T00:00:00Z",
+            "body": "Original body",
+        })
+        self.register_get_comment_response(cs_comment)
+        self.register_put_comment_response(cs_comment)
+
+    def test_basic(self):
+        request_data = {"raw_body": "Edited body"}
+        expected_response_data = {
+            "id": "test_comment",
+            "thread_id": "test_thread",
+            "parent_id": None,
+            "author": self.user.username,
+            "author_label": None,
+            "created_at": "2015-06-03T00:00:00Z",
+            "updated_at": "2015-06-03T00:00:00Z",
+            "raw_body": "Edited body",
+            "endorsed": False,
+            "endorsed_by": None,
+            "endorsed_by_label": None,
+            "endorsed_at": None,
+            "abuse_flagged": False,
+            "voted": False,
+            "vote_count": 0,
+            "children": [],
+        }
+        response = self.client.patch(  # pylint: disable=no-member
+            self.url,
+            json.dumps(request_data),
+            content_type="application/json"
+        )
+        self.assertEqual(response.status_code, 200)
+        response_data = json.loads(response.content)
+        self.assertEqual(response_data, expected_response_data)
+        self.assertEqual(
+            httpretty.last_request().parsed_body,
+            {
+                "body": ["Edited body"],
+                "course_id": [unicode(self.course.id)],
+                "user_id": [str(self.user.id)],
+                "anonymous": ["False"],
+                "anonymous_to_peers": ["False"],
+                "endorsed": ["False"],
+            }
+        )
+
+    def test_error(self):
+        request_data = {"raw_body": ""}
+        response = self.client.patch(  # pylint: disable=no-member
+            self.url,
+            json.dumps(request_data),
+            content_type="application/json"
+        )
+        expected_response_data = {
+            "field_errors": {"raw_body": {"developer_message": "This field is required."}}
         }
         self.assertEqual(response.status_code, 400)
         response_data = json.loads(response.content)

--- a/lms/djangoapps/discussion_api/tests/utils.py
+++ b/lms/djangoapps/discussion_api/tests/utils.py
@@ -30,6 +30,32 @@ def _get_thread_callback(thread_data):
     return callback
 
 
+def _get_comment_callback(comment_data, thread_id, parent_id):
+    """
+    Get a callback function that will return a comment containing the given data
+    plus necessary dummy data, overridden by the content of the POST/PUT
+    request.
+    """
+    def callback(request, _uri, headers):
+        """
+        Simulate the comment creation or update endpoint as described above.
+        """
+        response_data = make_minimal_cs_comment(comment_data)
+        # thread_id and parent_id are not included in request payload but
+        # are returned by the comments service
+        response_data["thread_id"] = thread_id
+        response_data["parent_id"] = parent_id
+        for key, val_list in request.parsed_body.items():
+            val = val_list[0]
+            if key in ["anonymous", "anonymous_to_peers", "endorsed"]:
+                response_data[key] = val == "True"
+            else:
+                response_data[key] = val
+        return (200, headers, json.dumps(response_data))
+
+    return callback
+
+
 class CommentsServiceMockMixin(object):
     """Mixin with utility methods for mocking the comments service"""
     def register_get_threads_response(self, threads, page, num_pages):
@@ -84,33 +110,35 @@ class CommentsServiceMockMixin(object):
             status=200
         )
 
-    def register_post_comment_response(self, response_overrides, thread_id, parent_id=None):
+    def register_post_comment_response(self, comment_data, thread_id, parent_id=None):
         """
         Register a mock response for POST on the CS comments endpoint for the
         given thread or parent; exactly one of thread_id and parent_id must be
         specified.
         """
-        def callback(request, _uri, headers):
-            """
-            Simulate the comment creation endpoint by returning the provided data
-            along with the data from response_overrides.
-            """
-            response_data = make_minimal_cs_comment(
-                {key: val[0] for key, val in request.parsed_body.items()}
-            )
-            response_data.update(response_overrides or {})
-            # thread_id and parent_id are not included in request payload but
-            # are returned by the comments service
-            response_data["thread_id"] = thread_id
-            response_data["parent_id"] = parent_id
-            return (200, headers, json.dumps(response_data))
-
         if parent_id:
             url = "http://localhost:4567/api/v1/comments/{}".format(parent_id)
         else:
             url = "http://localhost:4567/api/v1/threads/{}/comments".format(thread_id)
 
-        httpretty.register_uri(httpretty.POST, url, body=callback)
+        httpretty.register_uri(
+            httpretty.POST,
+            url,
+            body=_get_comment_callback(comment_data, thread_id, parent_id)
+        )
+
+    def register_put_comment_response(self, comment_data):
+        """
+        Register a mock response for PUT on the CS endpoint for the given
+        comment data (which must include the key "id").
+        """
+        thread_id = comment_data["thread_id"]
+        parent_id = comment_data.get("parent_id")
+        httpretty.register_uri(
+            httpretty.PUT,
+            "http://localhost:4567/api/v1/comments/{}".format(comment_data["id"]),
+            body=_get_comment_callback(comment_data, thread_id, parent_id)
+        )
 
     def register_get_comment_error_response(self, comment_id, status_code):
         """

--- a/lms/djangoapps/discussion_api/views.py
+++ b/lms/djangoapps/discussion_api/views.py
@@ -18,6 +18,7 @@ from discussion_api.api import (
     get_comment_list,
     get_course_topics,
     get_thread_list,
+    update_comment,
     update_thread,
 )
 from discussion_api.forms import CommentListGetForm, ThreadListGetForm
@@ -212,7 +213,8 @@ class CommentViewSet(_ViewMixin, DeveloperErrorViewMixin, ViewSet):
     """
     **Use Cases**
 
-        Retrieve the list of comments in a thread.
+        Retrieve the list of comments in a thread, create a comment, or modify
+        an existing comment.
 
     **Example Requests**:
 
@@ -223,6 +225,9 @@ class CommentViewSet(_ViewMixin, DeveloperErrorViewMixin, ViewSet):
             "thread_id": "0123456789abcdef01234567",
             "raw_body": "Body text"
         }
+
+        PATCH /api/discussion/v1/comments/comment_id
+        {"raw_body": "Edited text"}
 
     **GET Parameters**:
 
@@ -245,6 +250,10 @@ class CommentViewSet(_ViewMixin, DeveloperErrorViewMixin, ViewSet):
 
         * raw_body: The comment's raw body text
 
+    **PATCH Parameters**:
+
+        raw_body is accepted with the same meaning as in a POST request
+
     **GET Response Values**:
 
         * results: The list of comments; each item in the list has the same
@@ -254,7 +263,7 @@ class CommentViewSet(_ViewMixin, DeveloperErrorViewMixin, ViewSet):
 
         * previous: The URL of the previous page (or null if last page)
 
-    **POST Response Values**:
+    **POST/PATCH Response Values**:
 
         * id: The id of the comment
 
@@ -298,6 +307,8 @@ class CommentViewSet(_ViewMixin, DeveloperErrorViewMixin, ViewSet):
 
         * children: The list of child comments (with the same format)
     """
+    lookup_field = "comment_id"
+
     def list(self, request):
         """
         Implements the GET method for the list endpoint as described in the
@@ -322,3 +333,10 @@ class CommentViewSet(_ViewMixin, DeveloperErrorViewMixin, ViewSet):
         class docstring.
         """
         return Response(create_comment(request, request.DATA))
+
+    def partial_update(self, request, comment_id):
+        """
+        Implements the PATCH method for the instance endpoint as described in
+        the class docstring.
+        """
+        return Response(update_comment(request, comment_id, request.DATA))


### PR DESCRIPTION
This is done via PATCH on a comment instance endpoint.

@jimabramson @BenjiLee Please review
@nasthagiri @cahrens FYI
