### PR TITLE
BUGFIX: fix  FA4 conversion for a few icons

### DIFF
--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -284,7 +284,7 @@ from edxmako.shortcuts import marketing_link
         </header>
 
         <ol class="important-dates">
-          <li class="important-dates-item"><i class="icon fa fa-info-sign"></i><p class="important-dates-item-title">${_("Course Number")}</p><span class="important-dates-item-text course-number">${course.display_number_with_default | h}</span></li>
+          <li class="important-dates-item"><i class="icon fa fa-info-circle"></i><p class="important-dates-item-title">${_("Course Number")}</p><span class="important-dates-item-text course-number">${course.display_number_with_default | h}</span></li>
           % if not course.start_date_is_still_default:
             <li class="important-dates-item"><i class="icon fa fa-calendar"></i><p class="important-dates-item-title">${_("Classes Start")}</p><span class="important-dates-item-text start-date">${course.start_datetime_text()}</span></li>
           % endif

--- a/lms/templates/wiki/history.html
+++ b/lms/templates/wiki/history.html
@@ -240,7 +240,7 @@
       </header>
       <div class="modal-header">
         <h1>{% trans "Merge with current" %}</h1>
-        <p class="lead"><i class="icon fa fa-info-sign"></i> {% trans "When you merge a revision with the current, all data will be retained from both versions and merged at its approximate location from each revision." %} <strong>{% trans "After this, it's important to do a manual review." %}</strong></p>
+        <p class="lead"><i class="icon fa fa-info-circle"></i> {% trans "When you merge a revision with the current, all data will be retained from both versions and merged at its approximate location from each revision." %} <strong>{% trans "After this, it's important to do a manual review." %}</strong></p>
       </div>
       <div class="modal-body">
         <iframe name="mergeWindow"></iframe>

--- a/lms/templates/wiki/plugins/attachments/index.html
+++ b/lms/templates/wiki/plugins/attachments/index.html
@@ -14,7 +14,7 @@
       <span class="icon fa fa-arrow-circle-o-up"></span>{% trans "Upload new file" %}
     </a>
     <a class="btn" href="#" id="search-for-file-btn">
-      <span class="icon fa fa-plus-sign"></span>{% trans "Search and add file" %}
+      <span class="icon fa fa-plus-circle"></span>{% trans "Search and add file" %}
     </a>
   </div>
 


### PR DESCRIPTION
- course-about sidebar info icon -> correct icon: "fa-info-circle"
- wiki search add file -> correct icon: "fa-plus-circle"
- wiki history paragraph info -> correct icon: "fa-info-circle"

@marcotuts - Same as https://github.com/edx/edx-platform/pull/8222, but with ccx changes removed
