### PR TITLE
Fix updating immutable request dictionary.

### DIFF
--- a/lms/djangoapps/teams/views.py
+++ b/lms/djangoapps/teams/views.py
@@ -300,7 +300,7 @@ class TeamsListView(GenericAPIView):
         if course_key and not has_team_api_access(request.user, course_key):
             return Response(status=status.HTTP_403_FORBIDDEN)
 
-        data = request.DATA
+        data = request.DATA.copy()
         data['course_id'] = course_key
 
         serializer = CourseTeamCreationSerializer(data=data)


### PR DESCRIPTION
Django's `QueryDict`s are immutable during normal running, and so they
must be copied if any updates are to be made to them. In testing,
though, `request.DATA._mutable` is `True`, so tests can falsely pass.

@benmcmorran 
