### PR TITLE
Fixed 'play_video' event which was emitting with wrong params.

### DIFF
--- a/common/lib/xmodule/xmodule/js/spec/video/video_player_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_player_spec.js
@@ -333,6 +333,30 @@ function (VideoPlayer) {
             });
         });
 
+        describe('onSeek Youtube', function(){
+            beforeEach(function () {
+                state = jasmine.initializePlayerYouTube();
+                state.videoEl = $('video, iframe');
+            });
+
+           describe('when the video is playing', function () {
+               beforeEach(function(){
+                  state.videoPlayer.onStateChange({
+                      data: YT.PlayerState.PLAYING
+                  });
+               });
+
+               it('Video has started playing', function () {
+                   expect($('.video_control')).toHaveClass('pause');
+               });
+
+               it('seek the player', function () {
+                   state.videoPlayer.seekTo(10);
+                   expect(state.videoPlayer.currentTime).toBe(10);
+               });
+           });
+        });
+
         describe('onSeek', function () {
             beforeEach(function () {
                 state = jasmine.initializePlayer();

--- a/common/lib/xmodule/xmodule/js/src/video/03_video_player.js
+++ b/common/lib/xmodule/xmodule/js/src/video/03_video_player.js
@@ -493,8 +493,6 @@ function (HTML5Video, Resizer) {
 
         if (this.videoPlayer.isPlaying()) {
             this.videoPlayer.stopTimer();
-        } else {
-            this.videoPlayer.currentTime = time;
         }
         var isUnplayed = this.videoPlayer.isUnstarted() ||
                          this.videoPlayer.isCued();
@@ -521,6 +519,8 @@ function (HTML5Video, Resizer) {
         if (this.videoPlayer.isPlaying()) {
             this.videoPlayer.runTimer();
         }
+        // Update the the current time when user seek. (YoutubePlayer)
+        this.videoPlayer.currentTime = time;
     }
 
     function runTimer() {


### PR DESCRIPTION
`'play_video'` event emitted after seeking forward in a video contains old position
After user seeks to the video, the variable `currentTime` was not updated, hence the subsequent `play_video` event was emitted with old time.

[TNL-2165](https://openedx.atlassian.net/browse/TNL-2165)
