### PR TITLE
Remove unused code left over from ECOM-188.

### DIFF
--- a/common/djangoapps/student/tests/test_verification_status.py
+++ b/common/djangoapps/student/tests/test_verification_status.py
@@ -41,12 +41,7 @@ class TestCourseVerificationStatus(UrlResetMixin, ModuleStoreTestCase):
         self.course = CourseFactory.create()
         success = self.client.login(username=self.user.username, password="edx")
         self.assertTrue(success, msg="Did not log in successfully")
-
-        # Use the URL with the querystring param to put the user
-        # in the experimental track.
-        # TODO (ECOM-188): Once the A/B test of decoupling verified / payment
-        # completes, we can remove the querystring param.
-        self.dashboard_url = reverse('dashboard') + '?separate-verified=1'
+        self.dashboard_url = reverse('dashboard')
 
     def test_enrolled_as_non_verified(self):
         self._setup_mode_and_enrollment(None, "honor")

--- a/lms/djangoapps/verify_student/tests/test_views.py
+++ b/lms/djangoapps/verify_student/tests/test_views.py
@@ -1054,8 +1054,6 @@ class TestCreateOrderView(ModuleStoreTestCase):
     """
     Tests for the create_order view of verified course enrollment process.
     """
-    # Minimum size valid image data
-    IMAGE_DATA = ','
 
     def setUp(self):
         super(TestCreateOrderView, self).setUp()
@@ -1082,24 +1080,9 @@ class TestCreateOrderView(ModuleStoreTestCase):
             course_mode_post_data
         )
 
-    def test_invalid_photos_data(self):
-        self._create_order(
-            50,
-            self.course_id,
-            face_image='',
-            photo_id_image='',
-            expect_success=False
-        )
-
     @patch.dict(settings.FEATURES, {'AUTOMATIC_VERIFY_STUDENT_IDENTITY_FOR_TESTING': True})
     def test_invalid_amount(self):
-        response = self._create_order(
-            '1.a',
-            self.course_id,
-            face_image=self.IMAGE_DATA,
-            photo_id_image=self.IMAGE_DATA,
-            expect_status_code=400
-        )
+        response = self._create_order('1.a', self.course_id, expect_status_code=400)
         self.assertIn('Selected price is not valid number.', response.content)
 
     @patch.dict(settings.FEATURES, {'AUTOMATIC_VERIFY_STUDENT_IDENTITY_FOR_TESTING': True})
@@ -1107,13 +1090,7 @@ class TestCreateOrderView(ModuleStoreTestCase):
         # Create a course that does not have a verified mode
         course_id = 'Fake/999/Test_Course'
         CourseFactory.create(org='Fake', number='999', display_name='Test Course')
-        response = self._create_order(
-            '50',
-            course_id,
-            face_image=self.IMAGE_DATA,
-            photo_id_image=self.IMAGE_DATA,
-            expect_status_code=400
-        )
+        response = self._create_order('50', course_id, expect_status_code=400)
         self.assertIn('This course doesn\'t support paid certificates', response.content)
 
     @patch.dict(settings.FEATURES, {'AUTOMATIC_VERIFY_STUDENT_IDENTITY_FOR_TESTING': True})
@@ -1121,8 +1098,6 @@ class TestCreateOrderView(ModuleStoreTestCase):
         create_order_post_data = {
             'contribution': 50,
             'course_id': self.course_id,
-            'face_image': self.IMAGE_DATA,
-            'photo_id_image': self.IMAGE_DATA,
         }
 
         # Use the wrong HTTP method
@@ -1131,12 +1106,7 @@ class TestCreateOrderView(ModuleStoreTestCase):
 
     @patch.dict(settings.FEATURES, {'AUTOMATIC_VERIFY_STUDENT_IDENTITY_FOR_TESTING': True})
     def test_create_order_success(self):
-        response = self._create_order(
-            50,
-            self.course_id,
-            face_image=self.IMAGE_DATA,
-            photo_id_image=self.IMAGE_DATA
-        )
+        response = self._create_order(50, self.course_id)
         json_response = json.loads(response.content)
         self.assertIsNotNone(json_response['payment_form_data'].get('orderNumber'))  # TODO not canonical
 
@@ -1148,13 +1118,7 @@ class TestCreateOrderView(ModuleStoreTestCase):
         self.assertEqual(item.course_id, self.course.id)
         self.assertEqual(item.mode, 'verified')
 
-    def _create_order(
-            self, contribution, course_id,
-            face_image=None,
-            photo_id_image=None,
-            expect_success=True,
-            expect_status_code=200
-    ):
+    def _create_order(self, contribution, course_id, expect_success=True, expect_status_code=200):
         """Create a new order.
 
         Arguments:
@@ -1162,8 +1126,6 @@ class TestCreateOrderView(ModuleStoreTestCase):
             course_id (CourseKey): The course to purchase.
 
         Keyword Arguments:
-            face_image (string): Base-64 encoded image data
-            photo_id_image (string): Base-64 encoded image data
             expect_success (bool): If True, verify that the response was successful.
             expect_status_code (int): The expected HTTP status code
 
@@ -1177,11 +1139,6 @@ class TestCreateOrderView(ModuleStoreTestCase):
             'course_id': course_id,
             'processor': None,
         }
-
-        if face_image is not None:
-            data['face_image'] = face_image
-        if photo_id_image is not None:
-            data['photo_id_image'] = photo_id_image
 
         response = self.client.post(url, data)
         self.assertEqual(response.status_code, expect_status_code)

--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -708,35 +708,6 @@ def create_order(request):
     actual use is to add a single product to the user's cart and request
     immediate checkout.
     """
-    # Only submit photos if photo data is provided by the client.
-    # TODO (ECOM-188): Once the A/B test of decoupling verified / payment
-    # completes, we may be able to remove photo submission from this step
-    # entirely.
-    submit_photo = (
-        'face_image' in request.POST and
-        'photo_id_image' in request.POST
-    )
-
-    if (
-        submit_photo and not
-        SoftwareSecurePhotoVerification.user_has_valid_or_pending(request.user)
-    ):
-        attempt = SoftwareSecurePhotoVerification(user=request.user)
-        try:
-            b64_face_image = request.POST['face_image'].split(",")[1]
-            b64_photo_id_image = request.POST['photo_id_image'].split(",")[1]
-        except IndexError:
-            log.error(u"Invalid image data during photo verification.")
-            context = {
-                'success': False,
-            }
-            return JsonResponse(context)
-        attempt.upload_face_image(b64_face_image.decode('base64'))
-        attempt.upload_photo_id_image(b64_photo_id_image.decode('base64'))
-        attempt.mark_ready()
-
-        attempt.save()
-
     course_id = request.POST['course_id']
     course_id = CourseKey.from_string(course_id)
     donation_for_course = request.session.get('donation_for_course', {})

--- a/lms/static/js/verify_student/views/incourse_reverify_view.js
+++ b/lms/static/js/verify_student/views/incourse_reverify_view.js
@@ -70,7 +70,7 @@
 
         submitPhoto: function() {
             // disable the submit button to prevent multiple submissions.
-            this.setSubmitButtonEnabled(false)
+            this.setSubmitButtonEnabled(false);
             this.model.save();
         },
 


### PR DESCRIPTION
Quick cleanup of some unused code left over from the work to decouple payment from verification.  The "create order" end-point used to _both_ submit photos and create an order; now it only creates an order (since students verify after payment).  This PR removes the code to support the old flow.

Fixing this as preparation for [ECOM-1495](https://openedx.atlassian.net/browse/ECOM-1495).

@rlucioni please review
