### PR TITLE
FIX - Compile Sass to CSS directory Clean Up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,18 +73,16 @@ bin/
 ### Static assets pipeline artifacts
 *.scssc
 lms/static/css/
-lms/static/sass/*.css
-lms/static/sass/*.css.map
+lms/static/certificates/css/
+cms/static/css/
+
+### Styling generated from templates
 lms/static/sass/lms-main.scss
 lms/static/sass/lms-main-rtl.scss
 lms/static/sass/lms-course.scss
 lms/static/sass/lms-course-rtl.scss
 lms/static/sass/lms-footer.scss
 lms/static/sass/lms-footer-rtl.scss
-lms/static/certificates/sass/*.css
-cms/static/css/
-cms/static/sass/*.css
-cms/static/sass/*.css.map
 
 
 ### Logging artifacts

--- a/pavelib/assets.py
+++ b/pavelib/assets.py
@@ -19,6 +19,7 @@ SASS_DIRS = {
     "lms/static/sass": "lms/static/css",
     "cms/static/sass": "cms/static/css",
     "common/static/sass": "common/static/css",
+    "lms/static/certificates/sass": "lms/static/certificates/css",
 }
 SASS_LOAD_PATHS = ['common/static', 'common/static/sass']
 SASS_CACHE_PATH = '/tmp/sass-cache'


### PR DESCRIPTION
This work cleans up some loose ends from sass compilation to css dir change (https://github.com/edx/edx-platform/pull/8419), including:
- adding in missing web certs Sass/CSS asset settings
- updating .gitignore
