### PR TITLE
Web Certificates: Only Hide Staff Signature for Honor/Base Rendering

### DIFF
--- a/lms/static/certificates/sass/_components.scss
+++ b/lms/static/certificates/sass/_components.scss
@@ -188,11 +188,6 @@
     margin-bottom: spacing-vertical(base);
     border-bottom: rem(2) solid palette(grayscale-cool, x-light);
     padding-bottom: spacing-vertical(base);
-
-    &:last-child {
-        border: none;
-        padding-bottom: 0;
-    }
 }
 
 %rendering-hd-section {
@@ -270,7 +265,7 @@
 
     // organizations
     .accomplishment-orgs {
-        @extend %rendering-section;
+        margin-bottom: spacing-vertical(base);
 
         .list-orgs {
             @extend %list-unstyled;
@@ -452,8 +447,8 @@
 }
 
 // certificate - base + honor
-.certificate-honor,
-.certificate-base {
+.layout-accomplishment.certificate-honor,
+.layout-accomplishment.certificate-base {
 
     .introduction {
         margin-bottom: 0;
@@ -470,7 +465,7 @@
         }
 
         // hide the fancy
-        .accomplishment-signatories,
+        .accomplishment-signatories .signatory-signature,
         .accomplishment-type-symbol {
             display: none;
         }
@@ -478,8 +473,8 @@
 }
 
 // certificate - distinguished + verified
-.certificate-verified,
-.certificate-distinguished {
+.layout-accomplishment.certificate-verified,
+.layout-accomplishment.certificate-distinguished {
 
     .introduction {
         margin-bottom: spacing-vertical(base);


### PR DESCRIPTION
This work adjusts base/honor-code rendering to only hide staff signatures (SOL-973).

**Current**
![before-honor base](https://cloud.githubusercontent.com/assets/163763/8092410/8a3ecfd0-0f87-11e5-84b3-5cfae0176fe8.png)

---

**Proposed**
![after-honor base](https://cloud.githubusercontent.com/assets/163763/8092412/8d9d250a-0f87-11e5-8bb5-e3523afc851d.png)
