### PR TITLE
Fixed slow transaction on xblock outline handler.

### DIFF
--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -332,13 +332,14 @@ def xblock_outline_handler(request, usage_key_string):
     response_format = request.REQUEST.get('format', 'html')
     if response_format == 'json' or 'application/json' in request.META.get('HTTP_ACCEPT', 'application/json'):
         store = modulestore()
-        root_xblock = store.get_item(usage_key)
-        return JsonResponse(create_xblock_info(
-            root_xblock,
-            include_child_info=True,
-            course_outline=True,
-            include_children_predicate=lambda xblock: not xblock.category == 'vertical'
-        ))
+        with store.bulk_operations(usage_key.course_key):
+            root_xblock = store.get_item(usage_key)
+            return JsonResponse(create_xblock_info(
+                root_xblock,
+                include_child_info=True,
+                course_outline=True,
+                include_children_predicate=lambda xblock: not xblock.category == 'vertical'
+            ))
     else:
         return Http404
 


### PR DESCRIPTION
[TNL-2425](https://openedx.atlassian.net/browse/TNL-2425)

In this view studio transaction is doing over 100 `modulestore.structures find_one` calls.

Fixed with `with modulestore().bulk_operations(course_key):`.

Already reviewed in PR: https://github.com/edx/edx-platform/pull/8457
