### PR TITLE
Add feature flag to allow hiding the discussion tab for individual courses.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -222,3 +222,4 @@ Xiaolu Xiong <beardeer@gmail.com>
 Tim Krones <t.krones@gmx.net>
 Linda Liu <lliu@edx.org>
 Alessandro Verdura <finalmente2@tin.it>
+Sven Marnach <sven@marnach.net>

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -175,6 +175,9 @@ FEATURES = {
 
     # Enable credit eligibility feature
     'ENABLE_CREDIT_ELIGIBILITY': False,
+
+    # Can the visibility of the discussion tab be configured on a per-course basis?
+    'ALLOW_HIDING_DISCUSSION_TAB': False,
 }
 
 ENABLE_JASMINE = False

--- a/lms/djangoapps/django_comment_client/forum/views.py
+++ b/lms/djangoapps/django_comment_client/forum/views.py
@@ -58,6 +58,7 @@ class DiscussionTab(EnrolledTab):
     title = _('Discussion')
     priority = None
     view_name = 'django_comment_client.forum.views.forum_form_discussion'
+    is_hideable = settings.FEATURES.get('ALLOW_HIDING_DISCUSSION_TAB', False)
 
     @classmethod
     def is_enabled(cls, course, user=None):


### PR DESCRIPTION
**Description**

Similar to the way the [Wiki tab can be hidden in the "Pages" section of a course in Studio](http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/building_course/pages.html#hide-or-show-the-course-wiki-page), allow to hide the Discussion tab if this feature is enabled.  Hiding the tab will only make the link disappear from the tab bar, while manually navigating to the URL of the discussion forum will still work.

You can test this change on the [sandbox](http://sandbox2.opencraft.com:18010/): Navigate to Content > Pages on any course in Studio and click the eye icon on the Discussion tab, then go to the live version of the course and verify it has disappeared.  Note that you need to wait until the change was saved after clicking the icon.

This is a follow-up to #8086, which couldn't be re-opened.  As per discussion on [OSPR-599](https://openedx.atlassian.net/browse/OSPR-599), I put this behind a feature flag.  The implementation is completely different than the old one, since tabs have been refactored and moved into the individual Django apps.  The new implementation doesn't add a test, since it only adds a single assignment at class level, which can't be meaningfully unit-tested.

---

**Partner information** not an edX partner - 3rd party-hosted open edX instance
**JIRA Story** [OSPR-599](https://openedx.atlassian.net/browse/OSPR-599)
**Confluence / Product Asset** N/A
**Sandbox URL** [LMS](http://sandbox2.opencraft.com:/) [Studio](http://sandbox2.opencraft.com:18010/)
**Dependencies** N/A
**PR Author(s) Notes / To-Do** N/A

---

**Screenshots** 
The added icon is highlighted in this screenshot:
![image](https://cloud.githubusercontent.com/assets/249196/8106006/287e559c-103e-11e5-9cfb-d5e20c38e9ff.png)

---

**Reviewers**
Code: @mtyaka, (TBD); Product: (TBD)

---

**Settings**

``` yaml
EDXAPP_FEATURES:
  ALLOW_HIDING_DISCUSSION_TAB: true
```
