### PR TITLE
Make addCleanup idempotent.

### DIFF
--- a/common/test/acceptance/tests/helpers.py
+++ b/common/test/acceptance/tests/helpers.py
@@ -96,6 +96,14 @@ def load_data_str(rel_path):
         return data_file.read()
 
 
+def remove_file(filename):
+    """
+    Remove a file if it exists
+    """
+    if os.path.exists(filename):
+        os.remove(filename)
+
+
 def disable_animations(page):
     """
     Disable jQuery and CSS3 animations.
@@ -675,4 +683,4 @@ class TestWithSearchIndexMixin(object):
 
     def _cleanup_index_file(self):
         """ Removes search index backing file """
-        os.remove(self.TEST_INDEX_FILENAME)
+        remove_file(self.TEST_INDEX_FILENAME)

--- a/common/test/acceptance/tests/lms/test_lms_course_discovery.py
+++ b/common/test/acceptance/tests/lms/test_lms_course_discovery.py
@@ -7,6 +7,7 @@ import json
 import os
 
 from bok_choy.web_app_test import WebAppTest
+from ..helpers import remove_file
 from ...pages.common.logout import LogoutPage
 from ...pages.studio.auto_auth import AutoAuthPage
 from ...pages.lms.discovery import CourseDiscoveryPage
@@ -30,7 +31,7 @@ class CourseDiscoveryTest(WebAppTest):
         with open(self.TEST_INDEX_FILENAME, "w+") as index_file:
             json.dump({}, index_file)
 
-        self.addCleanup(os.remove, self.TEST_INDEX_FILENAME)
+        self.addCleanup(remove_file, self.TEST_INDEX_FILENAME)
 
         super(CourseDiscoveryTest, self).setUp()
         self.page = CourseDiscoveryPage(self.browser)

--- a/common/test/acceptance/tests/lms/test_lms_courseware_search.py
+++ b/common/test/acceptance/tests/lms/test_lms_courseware_search.py
@@ -7,7 +7,7 @@ import json
 from nose.plugins.attrib import attr
 from flaky import flaky
 
-from ..helpers import UniqueCourseTest
+from ..helpers import UniqueCourseTest, remove_file
 from ...pages.common.logout import LogoutPage
 from ...pages.studio.utils import add_html_component, click_css, type_in_codemirror
 from ...pages.studio.auto_auth import AutoAuthPage
@@ -49,7 +49,7 @@ class CoursewareSearchTest(UniqueCourseTest):
         # create test file in which index for this test will live
         with open(self.TEST_INDEX_FILENAME, "w+") as index_file:
             json.dump({}, index_file)
-        self.addCleanup(os.remove, self.TEST_INDEX_FILENAME)
+        self.addCleanup(remove_file, self.TEST_INDEX_FILENAME)
 
         super(CoursewareSearchTest, self).setUp()
         self.courseware_search_page = CoursewareSearchPage(self.browser, self.course_id)


### PR DESCRIPTION
Sometimes this file does not exist depending on when a test failed. Remove it gracefully.
