### PR TITLE
Fixed Broken page in "Schedule & Details" due to course image

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_utils.py
@@ -1,25 +1,25 @@
 """ Tests for utils. """
 import collections
-import copy
-import mock
 from datetime import datetime, timedelta
-from pytz import UTC
 
+import mock
+import ddt
+from pytz import UTC
 from django.test import TestCase
 from django.test.utils import override_settings
-
-from contentstore import utils
-from contentstore.tests.utils import CourseTestCase
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
-
 from xmodule.modulestore.django import modulestore
+
+from contentstore import utils
+from contentstore.tests.utils import CourseTestCase
 
 
 class LMSLinksTestCase(TestCase):
     """ Tests for LMS links. """
+
     def about_page_test(self):
         """ Get URL for about page, no marketing site """
         # default for ENABLE_MKTG_SITE is False.
@@ -109,6 +109,7 @@ class ExtraPanelTabTestCase(TestCase):
         return course
 
 
+@ddt.ddt
 class CourseImageTestCase(ModuleStoreTestCase):
     """Tests for course image URLs."""
 
@@ -144,6 +145,16 @@ class CourseImageTestCase(ModuleStoreTestCase):
         self.verify_url(
             unicode(course.id.make_asset_key('asset', course_image.replace(" ", "_"))),
             utils.course_image_url(course)
+        )
+
+    @ddt.data(ModuleStoreEnum.Type.split, ModuleStoreEnum.Type.mongo)
+    def test_empty_image_name(self, default_store):
+        """ Verify that empty image names are cleaned """
+        course_image = u''
+        course = CourseFactory.create(course_image=course_image, default_store=default_store)
+        self.assertEquals(
+            course_image,
+            utils.course_image_url(course),
         )
 
 
@@ -386,6 +397,7 @@ class GroupVisibilityTest(CourseTestCase):
     """
     Test content group access rules.
     """
+
     def setUp(self):
         super(GroupVisibilityTest, self).setUp()
 

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -4,12 +4,12 @@ Common utility functions useful throughout the contentstore
 # pylint: disable=no-member
 
 import logging
+from opaque_keys import InvalidKeyError
 import re
 from datetime import datetime
 from pytz import UTC
 
 from django.conf import settings
-from django.utils.translation import ugettext as _
 from django.core.urlresolvers import reverse
 from django_comment_common.models import assign_default_role
 from django_comment_common.utils import seed_permissions_roles
@@ -160,7 +160,10 @@ def get_lms_link_for_certificate_web_view(user_id, course_key, mode):
 
 def course_image_url(course):
     """Returns the image url for the course."""
-    loc = StaticContent.compute_location(course.location.course_key, course.course_image)
+    try:
+        loc = StaticContent.compute_location(course.location.course_key, course.course_image)
+    except InvalidKeyError:
+        return ''
     path = StaticContent.serialize_asset_key_with_slash(loc)
     return path
 

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -40,7 +40,7 @@ git+https://github.com/hmarr/django-debug-toolbar-mongo.git@b0686a76f1ce3532088c
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
 -e git+https://github.com/edx/edx-ora2.git@release-2015-05-08T16.15#egg=edx-ora2
 -e git+https://github.com/edx/edx-submissions.git@7c766502058e04bc9094e6cbe286e949794b80b3#egg=edx-submissions
--e git+https://github.com/edx/opaque-keys.git@df0dd602869e498e512659bb4bd243309e30e19a#egg=opaque-keys
+-e git+https://github.com/edx/opaque-keys.git@27dc382ea587483b1e3889a3d19cbd90b9023a06#egg=opaque-keys
 -e git+https://github.com/edx/ease.git@b67d2928a26fe497826b6ea359b9a3d0371548a7#egg=ease==0.1.3
 -e git+https://github.com/edx/i18n-tools.git@v0.1.1#egg=i18n-tools
 -e git+https://github.com/edx/edx-oauth2-provider.git@0.5.1#egg=oauth2-provider


### PR DESCRIPTION
`Schedule & Details` page of the course was breaking because it had empty `course_image`. 
with the empty image path, the assert locator throws `InvalidKeyError`. 
Handled this in the utility method which was used to get the image URL. 

[TNL-2435](https://openedx.atlassian.net/browse/TNL-2435)
