### PR TITLE
Avoid POSTing unnecessary payment processor parameter

### DIFF
--- a/lms/djangoapps/commerce/views.py
+++ b/lms/djangoapps/commerce/views.py
@@ -112,7 +112,6 @@ class BasketsView(APIView):
             response_data = api.baskets.post({
                 'products': [{'sku': honor_mode.sku}],
                 'checkout': True,
-                'payment_processor_name': 'cybersource'
             })
 
             payment_data = response_data["payment_data"]


### PR DESCRIPTION
Just a tiny bit of cleanup I noticed while reviewing an open-source PR yesterday. Passing a payment processor parameter to Otto when purchasing an honor enrollment for the user isn't necessary; [Otto uses the default payment processor](https://github.com/edx/ecommerce/blob/master/ecommerce/extensions/api/v2/views.py#L174) when the parameter is missing from the response.

@clintonb or @jimabramson, please review.
