### PR TITLE
WIP: Limit application of CCX overrides to enabled courses and providers

### DIFF
--- a/lms/djangoapps/ccx/overrides.py
+++ b/lms/djangoapps/ccx/overrides.py
@@ -47,6 +47,14 @@ class CustomCoursesForEdxOverrideProvider(FieldOverrideProvider):
             return get_override_for_ccx(ccx, block, name, default)
         return default
 
+    @classmethod
+    def enabled_for(cls, course):
+        """CCX field overrides are enabled per-course
+
+        protect against missing attributes
+        """
+        return getattr(course, 'enable_ccx', False)
+
 
 def get_current_ccx(course_key):
     """

--- a/lms/djangoapps/ccx/tests/test_overrides.py
+++ b/lms/djangoapps/ccx/tests/test_overrides.py
@@ -36,6 +36,7 @@ class TestFieldOverrides(ModuleStoreTestCase):
         """
         super(TestFieldOverrides, self).setUp()
         self.course = course = CourseFactory.create()
+        self.course.enable_ccx = True
 
         # Create a course outline
         self.mooc_start = start = datetime.datetime(
@@ -71,7 +72,7 @@ class TestFieldOverrides(ModuleStoreTestCase):
         OverrideFieldData.provider_classes = None
         for block in iter_blocks(ccx.course):
             block._field_data = OverrideFieldData.wrap(   # pylint: disable=protected-access
-                AdminFactory.create(), block._field_data)   # pylint: disable=protected-access
+                AdminFactory.create(), course, block._field_data)   # pylint: disable=protected-access
 
         def cleanup_provider_classes():
             """

--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -477,7 +477,8 @@ def prep_course_for_grading(course, request):
     field_data_cache = FieldDataCache.cache_for_descriptor_descendents(
         course.id, request.user, course, depth=2)
     course = get_module_for_descriptor(
-        request.user, request, course, field_data_cache, course.id)
+        request.user, request, course, field_data_cache, course.id, course=course
+    )
 
     course._field_data_cache = {}  # pylint: disable=protected-access
     course.set_grading_policy(course.grading_policy)

--- a/lms/djangoapps/course_structure_api/v0/views.py
+++ b/lms/djangoapps/course_structure_api/v0/views.py
@@ -555,7 +555,8 @@ class CourseBlocksAndNavigation(ListAPIView):
             request_info.request,
             block_info.block,
             request_info.field_data_cache,
-            request_info.course.id
+            request_info.course.id,
+            course=request_info.course
         )
 
         # verify the user has access to this block

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -203,7 +203,8 @@ def get_course_about_section(course, section_key):
                 field_data_cache,
                 log_if_not_found=False,
                 wrap_xmodule_display=False,
-                static_asset_path=course.static_asset_path
+                static_asset_path=course.static_asset_path,
+                course=course
             )
 
             html = ''
@@ -256,7 +257,8 @@ def get_course_info_section_module(request, course, section_key):
         field_data_cache,
         log_if_not_found=False,
         wrap_xmodule_display=False,
-        static_asset_path=course.static_asset_path
+        static_asset_path=course.static_asset_path,
+        course=course
     )
 
 

--- a/lms/djangoapps/courseware/entrance_exams.py
+++ b/lms/djangoapps/courseware/entrance_exams.py
@@ -144,7 +144,8 @@ def get_entrance_exam_score(request, course):
             request,
             descriptor,
             field_data_cache,
-            course.id
+            course.id,
+            course=course
         )
 
     exam_module_generators = yield_dynamic_descriptor_descendants(

--- a/lms/djangoapps/courseware/field_overrides.py
+++ b/lms/djangoapps/courseware/field_overrides.py
@@ -138,6 +138,9 @@ class OverrideFieldData(FieldData):
         self.fallback.delete(block, name)
 
     def has(self, block, name):
+        if not self.providers:
+            return self.fallback.has(block, name)
+
         has = self.get_override(block, name)
         if has is NOTSET:
             # If this is an inheritable field and an override is set above,
@@ -157,7 +160,7 @@ class OverrideFieldData(FieldData):
     def default(self, block, name):
         # The `default` method is overloaded by the field storage system to
         # also handle inheritance.
-        if not overrides_disabled():
+        if self.providers and not overrides_disabled():
             inheritable = InheritanceMixin.fields.keys()
             if name in inheritable:
                 for ancestor in _lineage(block):

--- a/lms/djangoapps/courseware/field_overrides.py
+++ b/lms/djangoapps/courseware/field_overrides.py
@@ -19,11 +19,12 @@ import threading
 from abc import ABCMeta, abstractmethod
 from contextlib import contextmanager
 from django.conf import settings
+from request_cache.middleware import RequestCache
 from xblock.field_data import FieldData
 from xmodule.modulestore.inheritance import InheritanceMixin
 
-
 NOTSET = object()
+ENABLED_OVERRIDE_PROVIDERS_KEY = "courseware.field_overrides.enabled_providers"
 
 
 def resolve_dotted(name):
@@ -61,7 +62,7 @@ class OverrideFieldData(FieldData):
     provider_classes = None
 
     @classmethod
-    def wrap(cls, user, wrapped):
+    def wrap(cls, user, course, wrapped):
         """
         Will return a :class:`OverrideFieldData` which wraps the field data
         given in `wrapped` for the given `user`, if override providers are
@@ -75,14 +76,42 @@ class OverrideFieldData(FieldData):
                 (resolve_dotted(name) for name in
                  settings.FIELD_OVERRIDE_PROVIDERS))
 
-        if cls.provider_classes:
-            return cls(user, wrapped)
+        enabled_providers = cls._providers_for_course(course)
+
+        if enabled_providers:
+            # TODO: we might not actually want to return here.  Might be better
+            # to check for instance.providers after the instance is built. This
+            # would allow for the case where we have registered providers but
+            # none are enabled for the provided course
+            return cls(user, wrapped, enabled_providers)
 
         return wrapped
 
-    def __init__(self, user, fallback):
+    @classmethod
+    def _providers_for_course(cls, course):
+        """
+        Return a filtered list of enabled providers based
+        on the course passed in. Cache this result per request to avoid
+        needing to call the provider filter api hundreds of times.
+
+        Arguments:
+            course: The course XBlock
+        """
+        request_cache = RequestCache.get_request_cache()
+        enabled_providers = request_cache.data.get(
+            ENABLED_OVERRIDE_PROVIDERS_KEY, NOTSET
+        )
+        if enabled_providers == NOTSET:
+            enabled_providers = tuple(
+                (provider_class for provider_class in cls.provider_classes if provider_class.enabled_for(course))
+            )
+            request_cache.data[ENABLED_OVERRIDE_PROVIDERS_KEY] = enabled_providers
+
+        return enabled_providers
+
+    def __init__(self, user, fallback, providers):
         self.fallback = fallback
-        self.providers = tuple((cls(user) for cls in self.provider_classes))
+        self.providers = tuple(provider(user) for provider in providers)
 
     def get_override(self, block, name):
         """
@@ -191,6 +220,17 @@ class FieldOverrideProvider(object):
         Returns the overridden value or `default` if no override is found.
         """
         raise NotImplementedError
+
+    @abstractmethod
+    def enabled_for(self, course):  # pragma no cover
+        """
+        Return True if this provider should be enabled for a given course
+
+        Return False otherwise
+
+        Concrete implementations are responsible for implementing this method
+        """
+        return False
 
 
 def _lineage(block):

--- a/lms/djangoapps/courseware/grades.py
+++ b/lms/djangoapps/courseware/grades.py
@@ -207,7 +207,9 @@ def _grade(student, request, course, keep_raw_scores):
                     # would be simpler
                     with manual_transaction():
                         field_data_cache = FieldDataCache([descriptor], course.id, student)
-                    return get_module_for_descriptor(student, request, descriptor, field_data_cache, course.id)
+                    return get_module_for_descriptor(
+                        student, request, descriptor, field_data_cache, course.id, course=course
+                    )
 
                 for module_descriptor in yield_dynamic_descriptor_descendants(
                         section_descriptor, student.id, create_module
@@ -337,7 +339,9 @@ def _progress_summary(student, request, course):
         )
         # TODO: We need the request to pass into here. If we could
         # forego that, our arguments would be simpler
-        course_module = get_module_for_descriptor(student, request, course, field_data_cache, course.id)
+        course_module = get_module_for_descriptor(
+            student, request, course, field_data_cache, course.id, course=course
+        )
         if not course_module:
             # This student must not have access to the course.
             return None

--- a/lms/djangoapps/courseware/student_field_overrides.py
+++ b/lms/djangoapps/courseware/student_field_overrides.py
@@ -17,6 +17,11 @@ class IndividualStudentOverrideProvider(FieldOverrideProvider):
     def get(self, block, name, default):
         return get_override_for_user(self.user, block, name, default)
 
+    @classmethod
+    def enabled_for(cls, course):
+        """This simple override provider is always enabled"""
+        return True
+
 
 def get_override_for_user(user, block, name, default=None):
     """

--- a/lms/djangoapps/courseware/tests/test_courses.py
+++ b/lms/djangoapps/courseware/tests/test_courses.py
@@ -262,7 +262,8 @@ class CourseInstantiationTests(ModuleStoreTestCase):
                 fake_request,
                 course,
                 field_data_cache,
-                course.id
+                course.id,
+                course=course
             )
             for chapter in course_module.get_children():
                 for section in chapter.get_children():

--- a/lms/djangoapps/courseware/tests/test_field_overrides.py
+++ b/lms/djangoapps/courseware/tests/test_field_overrides.py
@@ -4,9 +4,12 @@ Tests for `field_overrides` module.
 import unittest
 from nose.plugins.attrib import attr
 
-from django.test import TestCase
 from django.test.utils import override_settings
 from xblock.field_data import DictFieldData
+from xmodule.modulestore.tests.factories import CourseFactory
+from xmodule.modulestore.tests.django_utils import (
+    ModuleStoreTestCase,
+)
 
 from ..field_overrides import (
     disable_overrides,
@@ -22,13 +25,14 @@ TESTUSER = "testuser"
 @attr('shard_1')
 @override_settings(FIELD_OVERRIDE_PROVIDERS=(
     'courseware.tests.test_field_overrides.TestOverrideProvider',))
-class OverrideFieldDataTests(TestCase):
+class OverrideFieldDataTests(ModuleStoreTestCase):
     """
     Tests for `OverrideFieldData`.
     """
 
     def setUp(self):
         super(OverrideFieldDataTests, self).setUp()
+        self.course = CourseFactory.create(enable_ccx=True)
         OverrideFieldData.provider_classes = None
 
     def tearDown(self):
@@ -39,7 +43,7 @@ class OverrideFieldDataTests(TestCase):
         """
         Factory method.
         """
-        return OverrideFieldData.wrap(TESTUSER, DictFieldData({
+        return OverrideFieldData.wrap(TESTUSER, self.course, DictFieldData({
             'foo': 'bar',
             'bees': 'knees',
         }))
@@ -124,3 +128,7 @@ class TestOverrideProvider(FieldOverrideProvider):
         if name == 'oh':
             return 'man'
         return default
+
+    @classmethod
+    def enabled_for(cls, course):
+        return True

--- a/lms/djangoapps/courseware/tests/test_split_module.py
+++ b/lms/djangoapps/courseware/tests/test_split_module.py
@@ -310,7 +310,8 @@ class SplitTestPosition(ModuleStoreTestCase):
             MagicMock(name='request'),
             self.course,
             mock_field_data_cache,
-            self.course.id
+            self.course.id,
+            course=self.course
         )
 
         # Now that we have the course, change the position and save, nothing should explode!

--- a/lms/djangoapps/edxnotes/tests.py
+++ b/lms/djangoapps/edxnotes/tests.py
@@ -831,7 +831,9 @@ class EdxNotesViewsTest(ModuleStoreTestCase):
         Returns the course module.
         """
         field_data_cache = FieldDataCache([self.course], self.course.id, self.user)
-        return get_module_for_descriptor(self.user, MagicMock(), self.course, field_data_cache, self.course.id)
+        return get_module_for_descriptor(
+            self.user, MagicMock(), self.course, field_data_cache, self.course.id, course=self.course
+        )
 
     def test_edxnotes_tab(self):
         """

--- a/lms/djangoapps/edxnotes/views.py
+++ b/lms/djangoapps/edxnotes/views.py
@@ -53,7 +53,9 @@ def edxnotes(request, course_id):
         field_data_cache = FieldDataCache.cache_for_descriptor_descendents(
             course.id, request.user, course, depth=2
         )
-        course_module = get_module_for_descriptor(request.user, request, course, field_data_cache, course_key)
+        course_module = get_module_for_descriptor(
+            request.user, request, course, field_data_cache, course_key, course=course
+        )
         position = get_course_position(course_module)
         if position:
             context.update({
@@ -103,7 +105,9 @@ def edxnotes_visibility(request, course_id):
     course_key = CourseKey.from_string(course_id)
     course = get_course_with_access(request.user, "load", course_key)
     field_data_cache = FieldDataCache([course], course_key, request.user)
-    course_module = get_module_for_descriptor(request.user, request, course, field_data_cache, course_key)
+    course_module = get_module_for_descriptor(
+        request.user, request, course, field_data_cache, course_key, course=course
+    )
 
     if not is_feature_enabled(course):
         raise Http404

--- a/lms/djangoapps/instructor/hint_manager.py
+++ b/lms/djangoapps/instructor/hint_manager.py
@@ -31,7 +31,7 @@ def hint_manager(request, course_id):
     """
     course_key = SlashSeparatedCourseKey.from_deprecated_string(course_id)
     try:
-        get_course_with_access(request.user, 'staff', course_key, depth=None)
+        course = get_course_with_access(request.user, 'staff', course_key, depth=None)
     except Http404:
         out = 'Sorry, but students are not allowed to access the hint manager!'
         return HttpResponse(out)
@@ -57,13 +57,13 @@ def hint_manager(request, course_id):
     error_text = switch_dict[request.POST['op']](request, course_key, field)
     if error_text is None:
         error_text = ''
-    render_dict = get_hints(request, course_key, field)
+    render_dict = get_hints(request, course_key, field, course=course)
     render_dict.update({'error': error_text})
     rendered_html = render_to_string('instructor/hint_manager_inner.html', render_dict)
     return HttpResponse(json.dumps({'success': True, 'contents': rendered_html}))
 
 
-def get_hints(request, course_id, field):
+def get_hints(request, course_id, field, course=None):  # pylint: disable=unused-argument
     """
     Load all of the hints submitted to the course.
 
@@ -148,7 +148,7 @@ def location_to_problem_name(course_id, loc):
         return None
 
 
-def delete_hints(request, course_id, field):
+def delete_hints(request, course_id, field, course=None):  # pylint: disable=unused-argument
     """
     Deletes the hints specified.
 
@@ -176,7 +176,7 @@ def delete_hints(request, course_id, field):
         this_problem.save()
 
 
-def change_votes(request, course_id, field):
+def change_votes(request, course_id, field, course=None):  # pylint: disable=unused-argument
     """
     Updates the number of votes.
 
@@ -203,7 +203,7 @@ def change_votes(request, course_id, field):
         this_problem.save()
 
 
-def add_hint(request, course_id, field):
+def add_hint(request, course_id, field, course=None):
     """
     Add a new hint.  `request.POST`:
     op
@@ -226,7 +226,14 @@ def add_hint(request, course_id, field):
     except ItemNotFoundError:
         descriptors = []
     field_data_cache = model_data.FieldDataCache(descriptors, course_id, request.user)
-    hinter_module = module_render.get_module(request.user, request, problem_key, field_data_cache, course_id)
+    hinter_module = module_render.get_module(
+        request.user,
+        request,
+        problem_key,
+        field_data_cache,
+        course_id,
+        course=course
+    )
     if not hinter_module.validate_answer(answer):
         # Invalid answer.  Don't add it to the database, or else the
         # hinter will crash when we encounter it.
@@ -247,7 +254,7 @@ def add_hint(request, course_id, field):
     this_problem.save()
 
 
-def approve(request, course_id, field):
+def approve(request, course_id, field, course=None):  # pylint: disable=unused-argument
     """
     Approve a list of hints, moving them from the mod_queue to the real
     hint list.  POST:

--- a/lms/djangoapps/instructor/management/commands/openended_post.py
+++ b/lms/djangoapps/instructor/management/commands/openended_post.py
@@ -77,7 +77,7 @@ def post_submission_for_student(student, course, location, task_number, dry_run=
     request.host = hostname
 
     try:
-        module = get_module_for_student(student, location, request=request)
+        module = get_module_for_student(student, location, request=request, course=course)
         if module is None:
             print "  WARNING: No state found."
             return False

--- a/lms/djangoapps/instructor/management/commands/openended_stats.py
+++ b/lms/djangoapps/instructor/management/commands/openended_stats.py
@@ -89,7 +89,7 @@ def calculate_task_statistics(students, course, location, task_number, write_to_
         student = student_module.student
         print "{0}:{1}".format(student.id, student.username)
 
-        module = get_module_for_student(student, location)
+        module = get_module_for_student(student, location, course=course)
         if module is None:
             print "  WARNING: No state found"
             students_with_no_state.append(student)

--- a/lms/djangoapps/instructor/tests/test_tools.py
+++ b/lms/djangoapps/instructor/tests/test_tools.py
@@ -227,7 +227,7 @@ class TestSetDueDateExtension(ModuleStoreTestCase):
         # just inject the override field storage in this brute force manner.
         for block in (course, week1, week2, week3, homework, assignment):
             block._field_data = OverrideFieldData.wrap(  # pylint: disable=protected-access
-                user, block._field_data)  # pylint: disable=protected-access
+                user, course, block._field_data)  # pylint: disable=protected-access
 
     def tearDown(self):
         super(TestSetDueDateExtension, self).tearDown()

--- a/lms/djangoapps/instructor/utils.py
+++ b/lms/djangoapps/instructor/utils.py
@@ -27,7 +27,7 @@ class DummyRequest(object):
         return False
 
 
-def get_module_for_student(student, usage_key, request=None):
+def get_module_for_student(student, usage_key, request=None, course=None):
     """Return the module for the (student, location) using a DummyRequest."""
     if request is None:
         request = DummyRequest()
@@ -35,4 +35,4 @@ def get_module_for_student(student, usage_key, request=None):
 
     descriptor = modulestore().get_item(usage_key, depth=0)
     field_data_cache = FieldDataCache([descriptor], usage_key.course_key, student)
-    return get_module(student, request, usage_key, field_data_cache)
+    return get_module(student, request, usage_key, field_data_cache, course=course)

--- a/lms/djangoapps/mobile_api/users/views.py
+++ b/lms/djangoapps/mobile_api/users/views.py
@@ -106,7 +106,9 @@ class UserCourseStatus(views.APIView):
         field_data_cache = FieldDataCache.cache_for_descriptor_descendents(
             course.id, request.user, course, depth=2)
 
-        course_module = get_module_for_descriptor(request.user, request, course, field_data_cache, course.id)
+        course_module = get_module_for_descriptor(
+            request.user, request, course, field_data_cache, course.id, course=course
+        )
 
         path = [course_module]
         chapter = get_current_child(course_module, min_depth=2)
@@ -140,7 +142,9 @@ class UserCourseStatus(views.APIView):
             module_descriptor = modulestore().get_item(module_key)
         except ItemNotFoundError:
             return Response(errors.ERROR_INVALID_MODULE_ID, status=400)
-        module = get_module_for_descriptor(request.user, request, module_descriptor, field_data_cache, course.id)
+        module = get_module_for_descriptor(
+            request.user, request, module_descriptor, field_data_cache, course.id, course=course
+        )
 
         if modification_date:
             key = KeyValueStore.Key(
@@ -154,7 +158,7 @@ class UserCourseStatus(views.APIView):
                 # old modification date so skip update
                 return self._get_course_info(request, course)
 
-        save_positions_recursively_up(request.user, request, field_data_cache, module)
+        save_positions_recursively_up(request.user, request, field_data_cache, module, course=course)
         return self._get_course_info(request, course)
 
     @mobile_course_access(depth=2)

--- a/lms/djangoapps/mobile_api/video_outlines/serializers.py
+++ b/lms/djangoapps/mobile_api/video_outlines/serializers.py
@@ -4,7 +4,9 @@ Serializer for video outline
 from rest_framework.reverse import reverse
 
 from xmodule.modulestore.mongo.base import BLOCK_TYPES_WITH_CHILDREN
+from xmodule.modulestore.django import modulestore
 from courseware.access import has_access
+from courseware.courses import get_course_by_id
 from courseware.model_data import FieldDataCache
 from courseware.module_render import get_module_for_descriptor
 from util.module_utils import get_dynamic_descriptor_children
@@ -49,50 +51,52 @@ class BlockOutline(object):
             field_data_cache = FieldDataCache.cache_for_descriptor_descendents(
                 self.course_id, self.request.user, descriptor, depth=0,
             )
+            course = get_course_by_id(self.course_id)
             return get_module_for_descriptor(
-                self.request.user, self.request, descriptor, field_data_cache, self.course_id
+                self.request.user, self.request, descriptor, field_data_cache, self.course_id, course=course
             )
 
-        child_to_parent = {}
-        stack = [self.start_block]
-        while stack:
-            curr_block = stack.pop()
+        with modulestore().bulk_operations(self.course_id):
+            child_to_parent = {}
+            stack = [self.start_block]
+            while stack:
+                curr_block = stack.pop()
 
-            if curr_block.hide_from_toc:
-                # For now, if the 'hide_from_toc' setting is set on the block, do not traverse down
-                # the hierarchy.  The reason being is that these blocks may not have human-readable names
-                # to display on the mobile clients.
-                # Eventually, we'll need to figure out how we want these blocks to be displayed on the
-                # mobile clients.  As they are still accessible in the browser, just not navigatable
-                # from the table-of-contents.
-                continue
-
-            if curr_block.location.block_type in self.block_types:
-                if not has_access(self.request.user, 'load', curr_block, course_key=self.course_id):
+                if curr_block.hide_from_toc:
+                    # For now, if the 'hide_from_toc' setting is set on the block, do not traverse down
+                    # the hierarchy.  The reason being is that these blocks may not have human-readable names
+                    # to display on the mobile clients.
+                    # Eventually, we'll need to figure out how we want these blocks to be displayed on the
+                    # mobile clients.  As they are still accessible in the browser, just not navigatable
+                    # from the table-of-contents.
                     continue
 
-                summary_fn = self.block_types[curr_block.category]
-                block_path = list(path(curr_block, child_to_parent, self.start_block))
-                unit_url, section_url = find_urls(self.course_id, curr_block, child_to_parent, self.request)
+                if curr_block.location.block_type in self.block_types:
+                    if not has_access(self.request.user, 'load', curr_block, course_key=self.course_id):
+                        continue
 
-                yield {
-                    "path": block_path,
-                    "named_path": [b["name"] for b in block_path],
-                    "unit_url": unit_url,
-                    "section_url": section_url,
-                    "summary": summary_fn(self.course_id, curr_block, self.request, self.local_cache)
-                }
+                    summary_fn = self.block_types[curr_block.category]
+                    block_path = list(path(curr_block, child_to_parent, self.start_block))
+                    unit_url, section_url = find_urls(self.course_id, curr_block, child_to_parent, self.request)
 
-            if curr_block.has_children:
-                children = get_dynamic_descriptor_children(
-                    curr_block,
-                    self.request.user.id,
-                    create_module,
-                    usage_key_filter=parent_or_requested_block_type
-                )
-                for block in reversed(children):
-                    stack.append(block)
-                    child_to_parent[block] = curr_block
+                    yield {
+                        "path": block_path,
+                        "named_path": [b["name"] for b in block_path],
+                        "unit_url": unit_url,
+                        "section_url": section_url,
+                        "summary": summary_fn(self.course_id, curr_block, self.request, self.local_cache)
+                    }
+
+                if curr_block.has_children:
+                    children = get_dynamic_descriptor_children(
+                        curr_block,
+                        self.request.user.id,
+                        create_module,
+                        usage_key_filter=parent_or_requested_block_type
+                    )
+                    for block in reversed(children):
+                        stack.append(block)
+                        child_to_parent[block] = curr_block
 
 
 def path(block, child_to_parent, start_block):


### PR DESCRIPTION
This PR limits the application of CCX overrides only for enabled override providers on courses that have the advanced setting `enable_ccx` set to true. 

Currently, the field override mechanism used by CCX applies to all courses, whether they have a CCX or not. This was causing memory performance issues, particularly for courses in MongoModuleStore. With this PR, the `enable_ccx` setting can be used to limit field overrides to only the courses that need them. 

The scope of this PR is limited to the LMS system.

This PR was developer in consultation with @ormsbee and @cpennington at edX. 

We plan to stand up sandboxes for manual testing and will update this PR when they are ready.
