### PR TITLE
Add text_search parameter to discussion API

### DIFF
--- a/lms/djangoapps/discussion_api/tests/test_views.py
+++ b/lms/djangoapps/discussion_api/tests/test_views.py
@@ -182,6 +182,7 @@ class ThreadViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
                 "results": expected_threads,
                 "next": "http://testserver/api/discussion/v1/threads/?course_id=x%2Fy%2Fz&page=2",
                 "previous": None,
+                "text_search_rewrite": None,
             }
         )
         self.assert_last_query_params({
@@ -212,6 +213,28 @@ class ThreadViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
             "page": ["18"],
             "per_page": ["4"],
             "recursive": ["False"],
+        })
+
+    def test_text_search(self):
+        self.register_get_user_response(self.user)
+        self.register_get_threads_search_response([], None)
+        response = self.client.get(
+            self.url,
+            {"course_id": unicode(self.course.id), "text_search": "test search string"}
+        )
+        self.assert_response_correct(
+            response,
+            200,
+            {"results": [], "next": None, "previous": None, "text_search_rewrite": None}
+        )
+        self.assert_last_query_params({
+            "course_id": [unicode(self.course.id)],
+            "sort_key": ["date"],
+            "sort_order": ["desc"],
+            "page": ["1"],
+            "per_page": ["10"],
+            "recursive": ["False"],
+            "text": ["test search string"],
         })
 
 

--- a/lms/djangoapps/discussion_api/tests/utils.py
+++ b/lms/djangoapps/discussion_api/tests/utils.py
@@ -71,6 +71,20 @@ class CommentsServiceMockMixin(object):
             status=200
         )
 
+    def register_get_threads_search_response(self, threads, rewrite):
+        """Register a mock response for GET on the CS thread search endpoint"""
+        httpretty.register_uri(
+            httpretty.GET,
+            "http://localhost:4567/api/v1/search/threads",
+            body=json.dumps({
+                "collection": threads,
+                "page": 1,
+                "num_pages": 1,
+                "corrected_text": rewrite,
+            }),
+            status=200
+        )
+
     def register_post_thread_response(self, thread_data):
         """Register a mock response for POST on the CS commentable endpoint"""
         httpretty.register_uri(

--- a/lms/djangoapps/discussion_api/views.py
+++ b/lms/djangoapps/discussion_api/views.py
@@ -104,6 +104,10 @@ class ThreadViewSet(_ViewMixin, DeveloperErrorViewMixin, ViewSet):
             multiple topic_id queries to retrieve threads from multiple topics
             at once.
 
+        * text_search: A search string to match. Any thread whose content
+            (including the bodies of comments in the thread) matches the search
+            string will be returned.
+
     **POST Parameters**:
 
         * course_id (required): The course to create the thread in
@@ -132,6 +136,10 @@ class ThreadViewSet(_ViewMixin, DeveloperErrorViewMixin, ViewSet):
         * next: The URL of the next page (or null if first page)
 
         * previous: The URL of the previous page (or null if last page)
+
+        * text_search_rewrite: The search string to which the text_search
+            parameter was rewritten in order to match threads (e.g. for spelling
+            correction)
 
     **POST/PATCH response values**:
 
@@ -184,6 +192,7 @@ class ThreadViewSet(_ViewMixin, DeveloperErrorViewMixin, ViewSet):
                 form.cleaned_data["page"],
                 form.cleaned_data["page_size"],
                 form.cleaned_data["topic_id"],
+                form.cleaned_data["text_search"],
             )
         )
 


### PR DESCRIPTION
The thread list endpoint now accepts the text_search parameter and also
includes a text_search_rewrite field in its responses.

@jimabramson @BenjiLee Please review
@nasthagiri @cahrens FYI
