### PR TITLE
update edx-search hash to include faceted search

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -48,7 +48,7 @@ git+https://github.com/hmarr/django-debug-toolbar-mongo.git@b0686a76f1ce3532088c
 -e git+https://github.com/edx/edx-val.git@b1e11c9af3233bc06a17acbb33179f46d43c3b87#egg=edx-val
 -e git+https://github.com/pmitros/RecommenderXBlock.git@518234bc354edbfc2651b9e534ddb54f96080779#egg=recommender-xblock
 -e git+https://github.com/edx/edx-milestones.git@547f2250ee49e73ce8d7ff4e78ecf1b049892510#egg=edx-milestones
--e git+https://github.com/edx/edx-search.git@release-2015-06-08#egg=edx-search
+-e git+https://github.com/edx/edx-search.git@release-2015-06-16#egg=edx-search
 git+https://github.com/edx/edx-lint.git@ed8c8d2a0267d4d42f43642d193e25f8bd575d9b#egg=edx_lint==0.2.3
 -e git+https://github.com/edx/xblock-utils.git@db22bc40fd2a75458a3c66d057f88aff5a7383e6#egg=xblock-utils
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive


### PR DESCRIPTION
We discovered that the faceted search feature has not been merged into edx-search. This is the latest tag to point to in the edx-search.

@feanil not sure you to tag on this. @marcotuts can also brief you on what happened.
