### PR TITLE
Revert "Update bok-choy version and move to base.txt"

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -123,7 +123,6 @@ django_debug_toolbar==1.2.2
 
 # Used for testing
 astroid==1.3.4
-bok_choy==0.4.0
 chrono==1.0.2
 coverage==3.7
 ddt==0.8.0

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -36,6 +36,7 @@ git+https://github.com/hmarr/django-debug-toolbar-mongo.git@b0686a76f1ce3532088c
 -e git+https://github.com/edx/codejail.git@6b17c33a89bef0ac510926b1d7fea2748b73aadd#egg=codejail
 -e git+https://github.com/edx/js-test-tool.git@v0.1.6#egg=js_test_tool
 -e git+https://github.com/edx/event-tracking.git@0.2.0#egg=event-tracking
+-e git+https://github.com/edx/bok-choy.git@1c968796129f4d281e112804b889b6f369f52011#egg=bok_choy
 -e git+https://github.com/edx-solutions/django-splash.git@7579d052afcf474ece1239153cffe1c89935bc4f#egg=django-splash
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
 -e git+https://github.com/edx/edx-ora2.git@release-2015-05-08T16.15#egg=edx-ora2


### PR DESCRIPTION
Reverts edx/edx-platform#8533

This broke the a11y tests.
Also I just realized that the paver command is finding and executing tests outside the accessibility folder. I'll troubleshoot that too.

@clytwynec 
@benpatterson FYI
