### PR TITLE
Improve cohort test

### DIFF
--- a/openedx/core/djangoapps/course_groups/tests/test_cohorts.py
+++ b/openedx/core/djangoapps/course_groups/tests/test_cohorts.py
@@ -886,7 +886,7 @@ class TestCohortsAndPartitionGroups(ModuleStoreTestCase):
             self.partition_id,
             self.group1_id,
         )
-        with self.assertRaisesRegexp(IntegrityError, 'not unique'):
+        with self.assertRaises(IntegrityError):
             self._link_cohort_partition_group(
                 self.first_cohort,
                 self.partition_id,


### PR DESCRIPTION
Remove SQLite version dependent error string check.
Later versions of SQLite have different error message for the same error of uniqueness:
"UNIQUE constraint failed: ..."

This causes it to fail with Stanford's Jenkins build because it has a newer version of SQLite

@jimabramson 
