### PR TITLE
Add editable_fields to discussion API responses

### DIFF
--- a/lms/djangoapps/discussion_api/permissions.py
+++ b/lms/djangoapps/discussion_api/permissions.py
@@ -1,0 +1,54 @@
+"""
+Discussion API permission logic
+"""
+
+
+def _is_author(cc_content, context):
+    """
+    Return True if the requester authored the given content, False otherwise
+    """
+    return context["cc_requester"]["id"] == cc_content["user_id"]
+
+
+def _is_author_or_privileged(cc_content, context):
+    """
+    Return True if the requester authored the given content or is a privileged
+    user, False otherwise
+    """
+    return context["is_requester_privileged"] or _is_author(cc_content, context)
+
+
+def get_editable_fields(cc_content, context):
+    """
+    Return the set of fields that the requester can edit on the given content
+    """
+    # Shared fields
+    ret = {"voted"}
+    if _is_author_or_privileged(cc_content, context):
+        ret |= {"raw_body"}
+
+    # Thread fields
+    if cc_content["type"] == "thread":
+        ret |= {"following"}
+        if _is_author_or_privileged(cc_content, context):
+            ret |= {"topic_id", "type", "title"}
+
+    # Comment fields
+    if (
+            cc_content["type"] == "comment" and (
+                context["is_requester_privileged"] or (
+                    _is_author(context["thread"], context) and
+                    context["thread"]["thread_type"] == "question"
+                )
+            )
+    ):
+        ret |= {"endorsed"}
+
+    return ret
+
+
+def can_delete(cc_content, context):
+    """
+    Return True if the requester can delete the given content, False otherwise
+    """
+    return _is_author_or_privileged(cc_content, context)

--- a/lms/djangoapps/discussion_api/serializers.py
+++ b/lms/djangoapps/discussion_api/serializers.py
@@ -10,6 +10,7 @@ from django.core.urlresolvers import reverse
 
 from rest_framework import serializers
 
+from discussion_api.permissions import get_editable_fields
 from discussion_api.render import render_body
 from django_comment_common.models import (
     FORUM_ROLE_ADMINISTRATOR,
@@ -70,6 +71,7 @@ class _ContentSerializer(serializers.Serializer):
     abuse_flagged = serializers.SerializerMethodField("get_abuse_flagged")
     voted = serializers.SerializerMethodField("get_voted")
     vote_count = serializers.SerializerMethodField("get_vote_count")
+    editable_fields = serializers.SerializerMethodField("get_editable_fields")
 
     non_updatable_fields = ()
 
@@ -145,6 +147,10 @@ class _ContentSerializer(serializers.Serializer):
     def get_vote_count(self, obj):
         """Returns the number of votes for the content."""
         return obj["votes"]["up_count"]
+
+    def get_editable_fields(self, obj):
+        """Return the list of the fields the requester can edit"""
+        return sorted(get_editable_fields(obj, self.context))
 
 
 class ThreadSerializer(_ContentSerializer):

--- a/lms/djangoapps/discussion_api/tests/test_permissions.py
+++ b/lms/djangoapps/discussion_api/tests/test_permissions.py
@@ -1,0 +1,75 @@
+"""
+Tests for discussion API permission logic
+"""
+import itertools
+from unittest import TestCase
+
+import ddt
+
+from discussion_api.permissions import can_delete, get_editable_fields
+from lms.lib.comment_client.comment import Comment
+from lms.lib.comment_client.thread import Thread
+from lms.lib.comment_client.user import User
+
+
+def _get_context(requester_id, is_requester_privileged, thread=None):
+    """Return a context suitable for testing the permissions module"""
+    return {
+        "cc_requester": User(id=requester_id),
+        "is_requester_privileged": is_requester_privileged,
+        "thread": thread,
+    }
+
+
+@ddt.ddt
+class GetEditableFieldsTest(TestCase):
+    """Tests for get_editable_fields"""
+    @ddt.data(*itertools.product([True, False], [True, False]))
+    @ddt.unpack
+    def test_thread(self, is_author, is_privileged):
+        thread = Thread(user_id="5" if is_author else "6", type="thread")
+        context = _get_context(requester_id="5", is_requester_privileged=is_privileged)
+        actual = get_editable_fields(thread, context)
+        expected = {"following", "voted"}
+        if is_author or is_privileged:
+            expected |= {"topic_id", "type", "title", "raw_body"}
+        self.assertEqual(actual, expected)
+
+    @ddt.data(*itertools.product([True, False], [True, False], ["question", "discussion"], [True, False]))
+    @ddt.unpack
+    def test_comment(self, is_author, is_thread_author, thread_type, is_privileged):
+        comment = Comment(user_id="5" if is_author else "6", type="comment")
+        context = _get_context(
+            requester_id="5",
+            is_requester_privileged=is_privileged,
+            thread=Thread(user_id="5" if is_thread_author else "6", thread_type=thread_type)
+        )
+        actual = get_editable_fields(comment, context)
+        expected = {"voted"}
+        if is_author or is_privileged:
+            expected |= {"raw_body"}
+        if (is_thread_author and thread_type == "question") or is_privileged:
+            expected |= {"endorsed"}
+        self.assertEqual(actual, expected)
+
+
+@ddt.ddt
+class CanDeleteTest(TestCase):
+    """Tests for can_delete"""
+    @ddt.data(*itertools.product([True, False], [True, False]))
+    @ddt.unpack
+    def test_thread(self, is_author, is_privileged):
+        thread = Thread(user_id="5" if is_author else "6")
+        context = _get_context(requester_id="5", is_requester_privileged=is_privileged)
+        self.assertEqual(can_delete(thread, context), is_author or is_privileged)
+
+    @ddt.data(*itertools.product([True, False], [True, False], [True, False]))
+    @ddt.unpack
+    def test_comment(self, is_author, is_thread_author, is_privileged):
+        comment = Comment(user_id="5" if is_author else "6")
+        context = _get_context(
+            requester_id="5",
+            is_requester_privileged=is_privileged,
+            thread=Thread(user_id="5" if is_thread_author else "6")
+        )
+        self.assertEqual(can_delete(comment, context), is_author or is_privileged)

--- a/lms/djangoapps/discussion_api/tests/test_serializers.py
+++ b/lms/djangoapps/discussion_api/tests/test_serializers.py
@@ -151,6 +151,7 @@ class ThreadSerializerSerializationTest(SerializerTestMixin, ModuleStoreTestCase
 
     def test_basic(self):
         thread = {
+            "type": "thread",
             "id": "test_thread",
             "course_id": unicode(self.course.id),
             "commentable_id": "test_topic",
@@ -196,6 +197,7 @@ class ThreadSerializerSerializationTest(SerializerTestMixin, ModuleStoreTestCase
             "comment_list_url": "http://testserver/api/discussion/v1/comments/?thread_id=test_thread",
             "endorsed_comment_list_url": None,
             "non_endorsed_comment_list_url": None,
+            "editable_fields": ["following", "voted"],
         }
         self.assertEqual(self.serialize(thread), expected)
 
@@ -259,6 +261,7 @@ class CommentSerializerTest(SerializerTestMixin, ModuleStoreTestCase):
 
     def test_basic(self):
         comment = {
+            "type": "comment",
             "id": "test_comment",
             "thread_id": "test_thread",
             "user_id": str(self.author.id),
@@ -291,6 +294,7 @@ class CommentSerializerTest(SerializerTestMixin, ModuleStoreTestCase):
             "voted": False,
             "vote_count": 4,
             "children": [],
+            "editable_fields": ["voted"],
         }
         self.assertEqual(self.serialize(comment), expected)
 

--- a/lms/djangoapps/discussion_api/tests/test_views.py
+++ b/lms/djangoapps/discussion_api/tests/test_views.py
@@ -158,6 +158,7 @@ class ThreadViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
     def test_basic(self):
         self.register_get_user_response(self.user, upvoted_ids=["test_thread"])
         source_threads = [{
+            "type": "thread",
             "id": "test_thread",
             "course_id": unicode(self.course.id),
             "commentable_id": "test_topic",
@@ -203,6 +204,7 @@ class ThreadViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
             "comment_list_url": "http://testserver/api/discussion/v1/comments/?thread_id=test_thread",
             "endorsed_comment_list_url": None,
             "non_endorsed_comment_list_url": None,
+            "editable_fields": ["following", "voted"],
         }]
         self.register_get_threads_response(source_threads, page=1, num_pages=2)
         response = self.client.get(self.url, {"course_id": unicode(self.course.id)})
@@ -316,6 +318,7 @@ class ThreadViewSetCreateTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
             "comment_list_url": "http://testserver/api/discussion/v1/comments/?thread_id=test_thread",
             "endorsed_comment_list_url": None,
             "non_endorsed_comment_list_url": None,
+            "editable_fields": ["following", "raw_body", "title", "topic_id", "type", "voted"],
         }
         response = self.client.post(
             self.url,
@@ -406,6 +409,7 @@ class ThreadViewSetPartialUpdateTest(DiscussionAPIViewTestMixin, ModuleStoreTest
             "comment_list_url": "http://testserver/api/discussion/v1/comments/?thread_id=test_thread",
             "endorsed_comment_list_url": None,
             "non_endorsed_comment_list_url": None,
+            "editable_fields": ["following", "raw_body", "title", "topic_id", "type", "voted"],
         }
         response = self.client.patch(  # pylint: disable=no-member
             self.url,
@@ -515,6 +519,7 @@ class CommentViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
     def test_basic(self):
         self.register_get_user_response(self.user, upvoted_ids=["test_comment"])
         source_comments = [{
+            "type": "comment",
             "id": "test_comment",
             "thread_id": self.thread_id,
             "parent_id": None,
@@ -548,6 +553,7 @@ class CommentViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
             "voted": True,
             "vote_count": 4,
             "children": [],
+            "editable_fields": ["voted"],
         }]
         self.register_get_thread_response({
             "id": self.thread_id,
@@ -701,6 +707,7 @@ class CommentViewSetCreateTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
             "voted": False,
             "vote_count": 0,
             "children": [],
+            "editable_fields": ["raw_body", "voted"],
         }
         response = self.client.post(
             self.url,
@@ -784,6 +791,7 @@ class CommentViewSetPartialUpdateTest(DiscussionAPIViewTestMixin, ModuleStoreTes
             "voted": False,
             "vote_count": 0,
             "children": [],
+            "editable_fields": ["raw_body", "voted"],
         }
         response = self.client.patch(  # pylint: disable=no-member
             self.url,

--- a/lms/djangoapps/discussion_api/tests/utils.py
+++ b/lms/djangoapps/discussion_api/tests/utils.py
@@ -273,6 +273,7 @@ def make_minimal_cs_thread(overrides=None):
     comments service with dummy data and optional overrides
     """
     ret = {
+        "type": "thread",
         "id": "dummy",
         "course_id": "dummy/dummy/dummy",
         "commentable_id": "dummy",
@@ -305,6 +306,7 @@ def make_minimal_cs_comment(overrides=None):
     comments service with dummy data and optional overrides
     """
     ret = {
+        "type": "comment",
         "id": "dummy",
         "thread_id": "dummy",
         "parent_id": None,

--- a/lms/djangoapps/discussion_api/views.py
+++ b/lms/djangoapps/discussion_api/views.py
@@ -203,6 +203,9 @@ class ThreadViewSet(_ViewMixin, DeveloperErrorViewMixin, ViewSet):
             that were created or updated since the last time the user read
             the thread
 
+        * editable_fields: The fields that the requesting user is allowed to
+            modify with a PATCH request
+
     **DELETE response values:
 
         No content is returned for a DELETE request
@@ -351,6 +354,9 @@ class CommentViewSet(_ViewMixin, DeveloperErrorViewMixin, ViewSet):
         * vote_count: The number of votes for the comment
 
         * children: The list of child comments (with the same format)
+
+        * editable_fields: The fields that the requesting user is allowed to
+            modify with a PATCH request
 
     **DELETE Response Value**
 


### PR DESCRIPTION
This will allow clients to determine what actions (e.g. following,
endorsing, and editing content) a user can take on a piece of content.

@BenjiLee @jimabramson Please review
@nasthagiri @cahrens FYI
