### PR TITLE
Fix discussion_api to handle old threads

### DIFF
--- a/lms/djangoapps/discussion_api/serializers.py
+++ b/lms/djangoapps/discussion_api/serializers.py
@@ -180,6 +180,10 @@ class ThreadSerializer(_ContentSerializer):
         # type is an invalid class attribute name, so we must declare a
         # different name above and modify it here
         self.fields["type"] = self.fields.pop("type_")
+        # Compensate for the fact that some threads in the comments service do
+        # not have the pinned field set
+        if self.object and self.object.get("pinned") is None:
+            self.object["pinned"] = False
 
     def get_group_name(self, obj):
         """Returns the name of the group identified by the thread's group_id."""

--- a/lms/djangoapps/discussion_api/tests/test_serializers.py
+++ b/lms/djangoapps/discussion_api/tests/test_serializers.py
@@ -212,6 +212,17 @@ class ThreadSerializerSerializationTest(SerializerTestMixin, ModuleStoreTestCase
         })
         self.assertEqual(self.serialize(thread), expected)
 
+    def test_pinned_missing(self):
+        """
+        Make sure that older threads in the comments service without the pinned
+        field do not break serialization
+        """
+        thread_data = self.make_cs_content({})
+        del thread_data["pinned"]
+        self.register_get_thread_response(thread_data)
+        serialized = self.serialize(Thread(id=thread_data["id"]))
+        self.assertEqual(serialized["pinned"], False)
+
     def test_group(self):
         cohort = CohortFactory.create(course_id=self.course.id)
         serialized = self.serialize(self.make_cs_content({"group_id": cohort.id}))


### PR DESCRIPTION
Some old threads do not have the pinned field set, which the thread
serializer should handle.

@jimabramson @BenjiLee Please review
@nasthagiri @cahrens FYI
