### PR TITLE
Update the format of the credit provider timestamp.

### DIFF
--- a/common/djangoapps/util/date_utils.py
+++ b/common/djangoapps/util/date_utils.py
@@ -2,7 +2,7 @@
 Convenience methods for working with datetime objects
 """
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 import re
 
 from pytz import timezone, UTC, UnknownTimeZoneError
@@ -71,6 +71,27 @@ def almost_same_datetime(dt1, dt2, allowed_delta=timedelta(minutes=1)):
     :param dt2:
     """
     return abs(dt1 - dt2) < allowed_delta
+
+
+def to_timestamp(datetime_value):
+    """
+    Convert a datetime into a timestamp, represented as the number
+    of seconds since January 1, 1970 UTC.
+    """
+    return int((datetime_value - datetime(1970, 1, 1, tzinfo=UTC)).total_seconds())
+
+
+def from_timestamp(timestamp):
+    """
+    Convert a timestamp (number of seconds since Jan 1, 1970 UTC)
+    into a timezone-aware datetime.
+
+    If the timestamp cannot be converted, returns None instead.
+    """
+    try:
+        return datetime.utcfromtimestamp(timestamp).replace(tzinfo=UTC)
+    except (ValueError, TypeError):
+        return None
 
 
 DEFAULT_SHORT_DATE_FORMAT = "%b %d, %Y"

--- a/openedx/core/djangoapps/credit/api.py
+++ b/openedx/core/djangoapps/credit/api.py
@@ -4,9 +4,13 @@ Contains the APIs for course credit requirements.
 
 import logging
 import uuid
+import datetime
+
+import pytz
 
 from django.db import transaction
 
+from util.date_utils import to_timestamp
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 
@@ -191,7 +195,7 @@ def create_credit_request(course_key, provider_id, username):
             "method": "POST",
             "parameters": {
                 "request_uuid": "557168d0f7664fe59097106c67c3f847",
-                "timestamp": "2015-05-04T20:57:57.987119+00:00",
+                "timestamp": 1434631630,
                 "course_org": "HogwartsX",
                 "course_num": "Potions101",
                 "course_run": "1T2015",
@@ -263,6 +267,8 @@ def create_credit_request(course_key, provider_id, username):
 
     if created:
         credit_request.uuid = uuid.uuid4().hex
+    else:
+        credit_request.timestamp = datetime.datetime.now(pytz.UTC)
 
     # Retrieve user account and profile info
     user = User.objects.select_related('profile').get(username=username)
@@ -285,7 +291,7 @@ def create_credit_request(course_key, provider_id, username):
 
     parameters = {
         "request_uuid": credit_request.uuid,
-        "timestamp": credit_request.timestamp.isoformat(),
+        "timestamp": to_timestamp(credit_request.timestamp),
         "course_org": course_key.org,
         "course_num": course_key.course,
         "course_run": course_key.run,
@@ -391,7 +397,7 @@ def get_credit_requests_for_user(username):
     [
         {
             "uuid": "557168d0f7664fe59097106c67c3f847",
-            "timestamp": "2015-05-04T20:57:57.987119+00:00",
+            "timestamp": 1434631630,
             "course_key": "course-v1:HogwartsX+Potions101+1T2015",
             "provider": {
                 "id": "HogwartsX",

--- a/openedx/core/djangoapps/credit/api.py
+++ b/openedx/core/djangoapps/credit/api.py
@@ -267,8 +267,6 @@ def create_credit_request(course_key, provider_id, username):
 
     if created:
         credit_request.uuid = uuid.uuid4().hex
-    else:
-        credit_request.timestamp = datetime.datetime.now(pytz.UTC)
 
     # Retrieve user account and profile info
     user = User.objects.select_related('profile').get(username=username)
@@ -291,7 +289,7 @@ def create_credit_request(course_key, provider_id, username):
 
     parameters = {
         "request_uuid": credit_request.uuid,
-        "timestamp": to_timestamp(credit_request.timestamp),
+        "timestamp": to_timestamp(datetime.datetime.now(pytz.UTC)),
         "course_org": course_key.org,
         "course_num": course_key.course,
         "course_run": course_key.run,

--- a/openedx/core/djangoapps/credit/migrations/0008_delete_credit_provider_timestamp.py
+++ b/openedx/core/djangoapps/credit/migrations/0008_delete_credit_provider_timestamp.py
@@ -1,0 +1,145 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Deleting field 'CreditRequest.timestamp'
+        db.delete_column('credit_creditrequest', 'timestamp')
+
+        # Deleting field 'HistoricalCreditRequest.timestamp'
+        db.delete_column('credit_historicalcreditrequest', 'timestamp')
+
+    def backwards(self, orm):
+        # Adding field 'CreditRequest.timestamp'
+        db.add_column('credit_creditrequest', 'timestamp',
+                      self.gf('django.db.models.fields.DateTimeField')(auto_now_add=True, default=datetime.datetime.utcnow(), blank=True),
+                      keep_default=False)
+
+        # Adding field 'HistoricalCreditRequest.timestamp'
+        db.add_column('credit_historicalcreditrequest', 'timestamp',
+                      self.gf('django.db.models.fields.DateTimeField')(default=datetime.datetime.utcnow(), blank=True),
+                      keep_default=False)
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'credit.creditcourse': {
+            'Meta': {'object_name': 'CreditCourse'},
+            'course_key': ('xmodule_django.models.CourseKeyField', [], {'unique': 'True', 'max_length': '255', 'db_index': 'True'}),
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'providers': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['credit.CreditProvider']", 'symmetrical': 'False'})
+        },
+        'credit.crediteligibility': {
+            'Meta': {'unique_together': "(('username', 'course'),)", 'object_name': 'CreditEligibility'},
+            'course': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'eligibilities'", 'to': "orm['credit.CreditCourse']"}),
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'provider': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'eligibilities'", 'to': "orm['credit.CreditProvider']"}),
+            'username': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'})
+        },
+        'credit.creditprovider': {
+            'Meta': {'object_name': 'CreditProvider'},
+            'active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            'display_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'eligibility_duration': ('django.db.models.fields.PositiveIntegerField', [], {'default': '31556970'}),
+            'enable_integration': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'provider_id': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'provider_url': ('django.db.models.fields.URLField', [], {'default': "''", 'max_length': '200'})
+        },
+        'credit.creditrequest': {
+            'Meta': {'unique_together': "(('username', 'course', 'provider'),)", 'object_name': 'CreditRequest'},
+            'course': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'credit_requests'", 'to': "orm['credit.CreditCourse']"}),
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'parameters': ('jsonfield.fields.JSONField', [], {}),
+            'provider': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'credit_requests'", 'to': "orm['credit.CreditProvider']"}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'pending'", 'max_length': '255'}),
+            'username': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'uuid': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '32', 'db_index': 'True'})
+        },
+        'credit.creditrequirement': {
+            'Meta': {'unique_together': "(('namespace', 'name', 'course'),)", 'object_name': 'CreditRequirement'},
+            'active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'course': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'credit_requirements'", 'to': "orm['credit.CreditCourse']"}),
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            'criteria': ('jsonfield.fields.JSONField', [], {}),
+            'display_name': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '255'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'namespace': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        'credit.creditrequirementstatus': {
+            'Meta': {'object_name': 'CreditRequirementStatus'},
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'reason': ('jsonfield.fields.JSONField', [], {'default': '{}'}),
+            'requirement': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'statuses'", 'to': "orm['credit.CreditRequirement']"}),
+            'status': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'username': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'})
+        },
+        'credit.historicalcreditrequest': {
+            'Meta': {'ordering': "(u'-history_date', u'-history_id')", 'object_name': 'HistoricalCreditRequest'},
+            'course': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'+'", 'null': 'True', 'on_delete': 'models.DO_NOTHING', 'to': "orm['credit.CreditCourse']"}),
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            u'history_date': ('django.db.models.fields.DateTimeField', [], {}),
+            u'history_id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            u'history_type': ('django.db.models.fields.CharField', [], {'max_length': '1'}),
+            u'history_user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'+'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': "orm['auth.User']"}),
+            'id': ('django.db.models.fields.IntegerField', [], {'db_index': 'True', 'blank': 'True'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'parameters': ('jsonfield.fields.JSONField', [], {}),
+            'provider': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'+'", 'null': 'True', 'on_delete': 'models.DO_NOTHING', 'to': "orm['credit.CreditProvider']"}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'pending'", 'max_length': '255'}),
+            'username': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'uuid': ('django.db.models.fields.CharField', [], {'max_length': '32', 'db_index': 'True'})
+        }
+    }
+
+    complete_apps = ['credit']

--- a/openedx/core/djangoapps/credit/models.py
+++ b/openedx/core/djangoapps/credit/models.py
@@ -13,8 +13,8 @@ from django.db import transaction
 from django.core.validators import RegexValidator
 from simple_history.models import HistoricalRecords
 
-
 from jsonfield.fields import JSONField
+from util.date_utils import to_timestamp
 from model_utils.models import TimeStampedModel
 from xmodule_django.models import CourseKeyField
 from django.utils.translation import ugettext_lazy
@@ -378,7 +378,7 @@ class CreditRequest(TimeStampedModel):
         [
             {
                 "uuid": "557168d0f7664fe59097106c67c3f847",
-                "timestamp": "2015-05-04T20:57:57.987119+00:00",
+                "timestamp": 1434631630,
                 "course_key": "course-v1:HogwartsX+Potions101+1T2015",
                 "provider": {
                     "id": "HogwartsX",
@@ -393,7 +393,7 @@ class CreditRequest(TimeStampedModel):
         return [
             {
                 "uuid": request.uuid,
-                "timestamp": request.modified,
+                "timestamp": to_timestamp(request.modified),
                 "course_key": request.course.course_key,
                 "provider": {
                     "id": request.provider.provider_id,

--- a/openedx/core/djangoapps/credit/models.py
+++ b/openedx/core/djangoapps/credit/models.py
@@ -14,7 +14,6 @@ from django.core.validators import RegexValidator
 from simple_history.models import HistoricalRecords
 
 from jsonfield.fields import JSONField
-from util.date_utils import to_timestamp
 from model_utils.models import TimeStampedModel
 from xmodule_django.models import CourseKeyField
 from django.utils.translation import ugettext_lazy
@@ -343,7 +342,6 @@ class CreditRequest(TimeStampedModel):
     username = models.CharField(max_length=255, db_index=True)
     course = models.ForeignKey(CreditCourse, related_name="credit_requests")
     provider = models.ForeignKey(CreditProvider, related_name="credit_requests")
-    timestamp = models.DateTimeField(auto_now_add=True)
     parameters = JSONField()
 
     REQUEST_STATUS_PENDING = "pending"
@@ -393,7 +391,7 @@ class CreditRequest(TimeStampedModel):
         return [
             {
                 "uuid": request.uuid,
-                "timestamp": to_timestamp(request.modified),
+                "timestamp": request.parameters.get("timestamp"),
                 "course_key": request.course.course_key,
                 "provider": {
                     "id": request.provider.provider_id,

--- a/openedx/core/djangoapps/credit/tests/test_api.py
+++ b/openedx/core/djangoapps/credit/tests/test_api.py
@@ -5,7 +5,6 @@ Tests for the API functions in the credit app.
 import datetime
 import ddt
 import pytz
-import dateutil.parser as date_parser
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.db import connection, transaction
@@ -13,6 +12,7 @@ from django.db import connection, transaction
 from opaque_keys.edx.keys import CourseKey
 
 from student.tests.factories import UserFactory
+from util.date_utils import from_timestamp
 from openedx.core.djangoapps.credit import api
 from openedx.core.djangoapps.credit.exceptions import (
     InvalidCreditRequirements,
@@ -340,7 +340,7 @@ class CreditProviderIntegrationApiTests(CreditApiTestBase):
 
         # Validate the timestamp
         self.assertIn('timestamp', parameters)
-        parsed_date = date_parser.parse(parameters['timestamp'])
+        parsed_date = from_timestamp(parameters['timestamp'])
         self.assertTrue(parsed_date < datetime.datetime.now(pytz.UTC))
 
         # Validate course information

--- a/openedx/core/djangoapps/credit/tests/test_views.py
+++ b/openedx/core/djangoapps/credit/tests/test_views.py
@@ -15,6 +15,7 @@ from django.conf import settings
 
 from student.tests.factories import UserFactory
 from util.testing import UrlResetMixin
+from util.date_utils import to_timestamp
 from opaque_keys.edx.keys import CourseKey
 from openedx.core.djangoapps.credit import api
 from openedx.core.djangoapps.credit.signature import signature
@@ -186,8 +187,8 @@ class CreditProviderViewTests(UrlResetMixin, TestCase):
         # Simulate a callback from the credit provider with a timestamp too far in the past
         # (slightly more than 15 minutes)
         # Since the message isn't timely, respond with a 403.
-        timestamp = datetime.datetime.now(pytz.UTC) - datetime.timedelta(0, 60 * 15 + 1)
-        response = self._credit_provider_callback(request_uuid, "approved", timestamp=timestamp.isoformat())
+        timestamp = to_timestamp(datetime.datetime.now(pytz.UTC) - datetime.timedelta(0, 60 * 15 + 1))
+        response = self._credit_provider_callback(request_uuid, "approved", timestamp=timestamp)
         self.assertEqual(response.status_code, 403)
 
     def test_credit_provider_callback_is_idempotent(self):
@@ -311,7 +312,7 @@ class CreditProviderViewTests(UrlResetMixin, TestCase):
         """
         provider_id = kwargs.get("provider_id", self.PROVIDER_ID)
         secret_key = kwargs.get("secret_key", TEST_CREDIT_PROVIDER_SECRET_KEY)
-        timestamp = kwargs.get("timestamp", datetime.datetime.now(pytz.UTC).isoformat())
+        timestamp = kwargs.get("timestamp", to_timestamp(datetime.datetime.now(pytz.UTC)))
 
         url = reverse("credit:provider_callback", args=[provider_id])
 


### PR DESCRIPTION
Use the number of seconds since the epoch (Jan 1 1970 UTC)
instead of an ISO-formatted datetime string.  This is easier
for credit providers to parse.
