### PR TITLE
MA-844 Video Upload: remove dependency on AssetMetaDataStore.

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -45,7 +45,7 @@ git+https://github.com/hmarr/django-debug-toolbar-mongo.git@b0686a76f1ce3532088c
 -e git+https://github.com/edx/ease.git@b67d2928a26fe497826b6ea359b9a3d0371548a7#egg=ease==0.1.3
 -e git+https://github.com/edx/i18n-tools.git@3478455a2cc59a734432264e409b8eade1e4b167#egg=i18n-tools
 -e git+https://github.com/edx/edx-oauth2-provider.git@0.5.1#egg=oauth2-provider
--e git+https://github.com/edx/edx-val.git@b1e11c9af3233bc06a17acbb33179f46d43c3b87#egg=edx-val
+-e git+https://github.com/edx/edx-val.git@v0.0.5#egg=edx-val
 -e git+https://github.com/pmitros/RecommenderXBlock.git@518234bc354edbfc2651b9e534ddb54f96080779#egg=recommender-xblock
 -e git+https://github.com/edx/edx-milestones.git@547f2250ee49e73ce8d7ff4e78ecf1b049892510#egg=edx-milestones
 -e git+https://github.com/edx/edx-search.git@release-2015-06-08#egg=edx-search


### PR DESCRIPTION
https://openedx.atlassian.net/browse/MA-844

Since we now continue to associate courses to videos in VAL, we can use VAL as the primary source of information for the list of VAL videos in a course.  This also means, we can eliminate our dependency on the AssetMetaDataStore for keeping track of videos uploaded for a course.

This PR removes our dependency on the AssetMetaDataStore.
It requires a new version of VAL since it needs new sort parameters on the `get_videos_for_course` function, as added in this PR: https://github.com/edx/edx-val/pull/47.

Reviewers: @BenjiLee @gwprice 
