### PR TITLE
WIP: Add has_endorsed field to Threads in discussion API

### DIFF
--- a/lms/djangoapps/discussion_api/serializers.py
+++ b/lms/djangoapps/discussion_api/serializers.py
@@ -172,7 +172,8 @@ class ThreadSerializer(_ContentSerializer):
     comment_list_url = serializers.SerializerMethodField("get_comment_list_url")
     endorsed_comment_list_url = serializers.SerializerMethodField("get_endorsed_comment_list_url")
     non_endorsed_comment_list_url = serializers.SerializerMethodField("get_non_endorsed_comment_list_url")
-
+    has_endorsed = serializers.BooleanField(read_only=True, source="endorsed")
+    read = serializers.BooleanField(read_only=True)
     non_updatable_fields = ("course_id",)
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
No unit tests, 

MA-757
I would imagine I need to include this new field in unit tests which would be the majority of this PR.
