### PR TITLE
Make course tab refreshing safer.

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -5,6 +5,7 @@ import copy
 from django.shortcuts import redirect
 import json
 import random
+import logging
 import string  # pylint: disable=deprecated-module
 from django.utils.translation import ugettext as _
 import django.utils
@@ -22,7 +23,7 @@ from xmodule.course_module import DEFAULT_START_DATE
 from xmodule.error_module import ErrorDescriptor
 from xmodule.modulestore.django import modulestore
 from xmodule.contentstore.content import StaticContent
-from xmodule.tabs import CourseTab
+from xmodule.tabs import CourseTab, CourseTabList, InvalidTabsException
 from openedx.core.lib.course_tabs import CourseTabPluginManager
 from openedx.core.djangoapps.credit.api import is_credit_course, get_credit_requirements
 from openedx.core.djangoapps.credit.tasks import update_credit_course_requirements
@@ -86,6 +87,8 @@ from util.milestones_helpers import (
     set_prerequisite_courses,
     is_valid_course_key
 )
+
+log = logging.getLogger(__name__)
 
 __all__ = ['course_info_handler', 'course_handler', 'course_listing',
            'course_info_update_handler', 'course_search_index_handler',
@@ -1024,6 +1027,9 @@ def grading_handler(request, course_key_string, grader_index=None):
 def _refresh_course_tabs(request, course_module):
     """
     Automatically adds/removes tabs if changes to the course require them.
+
+    Raises:
+        InvalidTabsException: raised if there's a problem with the new version of the tabs.
     """
 
     def update_tab(tabs, tab_type, tab_enabled):
@@ -1046,6 +1052,8 @@ def _refresh_course_tabs(request, course_module):
         if not tab_type.is_dynamic and tab_type.is_default:
             tab_enabled = tab_type.is_enabled(course_module, user=request.user)
             update_tab(course_tabs, tab_type, tab_enabled)
+
+    CourseTabList.validate_tabs(course_tabs)
 
     # Save the tabs into the course if they have been changed
     if course_tabs != course_module.tabs:
@@ -1090,8 +1098,18 @@ def advanced_settings_handler(request, course_key_string):
                     )
 
                     if is_valid:
-                        # update the course tabs if required by any setting changes
-                        _refresh_course_tabs(request, course_module)
+                        try:
+                            # update the course tabs if required by any setting changes
+                            _refresh_course_tabs(request, course_module)
+                        except InvalidTabsException as err:
+                            log.exception(err.message)
+                            response_message = [
+                                {
+                                    'message': _('An error occurred while trying to save your tabs'),
+                                    'model': {'display_name': _('Tabs Exception')}
+                                }
+                            ]
+                            return JsonResponseBadRequest(response_message)
 
                         # now update mongo
                         modulestore().update_item(course_module, request.user.id)
@@ -1101,7 +1119,7 @@ def advanced_settings_handler(request, course_key_string):
                         return JsonResponseBadRequest(errors)
 
                 # Handle all errors that validation doesn't catch
-                except (TypeError, ValueError) as err:
+                except (TypeError, ValueError, InvalidTabsException) as err:
                     return HttpResponseBadRequest(
                         django.utils.html.escape(err.message),
                         content_type="text/plain"

--- a/lms/djangoapps/course_wiki/tab.py
+++ b/lms/djangoapps/course_wiki/tab.py
@@ -18,6 +18,7 @@ class WikiTab(EnrolledTab):
     title = _('Wiki')
     view_name = "course_wiki"
     is_hideable = True
+    is_default = False
 
     @classmethod
     def is_enabled(cls, course, user=None):

--- a/lms/djangoapps/courseware/tabs.py
+++ b/lms/djangoapps/courseware/tabs.py
@@ -32,6 +32,7 @@ class CoursewareTab(EnrolledTab):
     priority = 10
     view_name = 'courseware'
     is_movable = False
+    is_default = False
 
 
 class CourseInfoTab(CourseTab):
@@ -44,6 +45,7 @@ class CourseInfoTab(CourseTab):
     view_name = 'info'
     tab_id = 'info'
     is_movable = False
+    is_default = False
 
     @classmethod
     def is_enabled(cls, course, user=None):
@@ -59,6 +61,7 @@ class SyllabusTab(EnrolledTab):
     priority = 30
     view_name = 'syllabus'
     allow_multiple = True
+    is_default = False
 
     @classmethod
     def is_enabled(cls, course, user=None):  # pylint: disable=unused-argument
@@ -76,6 +79,7 @@ class ProgressTab(EnrolledTab):
     priority = 40
     view_name = 'progress'
     is_hideable = True
+    is_default = False
 
     @classmethod
     def is_enabled(cls, course, user=None):  # pylint: disable=unused-argument
@@ -91,6 +95,7 @@ class TextbookTabsBase(CourseTab):
     # Translators: 'Textbooks' refers to the tab in the course that leads to the course' textbooks
     title = _("Textbooks")
     is_collection = True
+    is_default = False
 
     @classmethod
     def is_enabled(cls, course, user=None):  # pylint: disable=unused-argument
@@ -222,6 +227,7 @@ class ExternalDiscussionCourseTab(LinkTab):
     # Translators: 'Discussion' refers to the tab in the courseware that leads to the discussion forums
     title = _('Discussion')
     priority = None
+    is_default = False
 
     @classmethod
     def validate(cls, tab_dict, raise_error=True):

--- a/lms/djangoapps/courseware/tests/test_tabs.py
+++ b/lms/djangoapps/courseware/tests/test_tabs.py
@@ -480,6 +480,7 @@ class TabListTestCase(TabTestCase):
             [{'type': CoursewareTab.type}, {'type': 'discussion', 'name': 'fake_name'}],
             # incorrect order
             [{'type': CourseInfoTab.type, 'name': 'fake_name'}, {'type': CoursewareTab.type}],
+            [{'type': 'unknown_type'}]
         ]
 
         # tab types that should appear only once

--- a/lms/djangoapps/django_comment_client/forum/views.py
+++ b/lms/djangoapps/django_comment_client/forum/views.py
@@ -59,6 +59,7 @@ class DiscussionTab(EnrolledTab):
     priority = None
     view_name = 'django_comment_client.forum.views.forum_form_discussion'
     is_hideable = settings.FEATURES.get('ALLOW_HIDING_DISCUSSION_TAB', False)
+    is_default = False
 
     @classmethod
     def is_enabled(cls, course, user=None):


### PR DESCRIPTION
@andy-armstrong and @dan-f 

This PR does a couple different things:
- Certain tabs (like Courseware, etc) that are normally added by default will not be attempted to be re-added.
- We don't save the course if tab validation fails, and an error message is displayed to the user.

https://openedx.atlassian.net/browse/TNL-2488
