### PR TITLE
Thread sort key and direction for discussion api

### DIFF
--- a/lms/djangoapps/discussion_api/forms.py
+++ b/lms/djangoapps/discussion_api/forms.py
@@ -54,8 +54,24 @@ class ThreadListGetForm(_PaginationForm):
     following = NullBooleanField(required=False)
     view = ChoiceField(
         choices=[(choice, choice) for choice in ["unread", "unanswered"]],
+        required=False,
+    )
+    order_by = ChoiceField(
+        choices=[(choice, choice) for choice in ["last_activity_at", "comment_count", "vote_count"]],
         required=False
     )
+    order_direction = ChoiceField(
+        choices=[(choice, choice) for choice in ["asc", "desc"]],
+        required=False
+    )
+
+    def clean_order_by(self):
+        """Return a default choice"""
+        return self.cleaned_data.get("order_by") or "last_activity_at"
+
+    def clean_order_direction(self):
+        """Return a default choice"""
+        return self.cleaned_data.get("order_direction") or "desc"
 
     def clean_course_id(self):
         """Validate course_id"""

--- a/lms/djangoapps/discussion_api/tests/test_api.py
+++ b/lms/djangoapps/discussion_api/tests/test_api.py
@@ -810,6 +810,74 @@ class GetThreadListTest(CommentsServiceMockMixin, UrlResetMixin, ModuleStoreTest
             query: ["true"],
         })
 
+    @ddt.data(
+        ("last_activity_at", "date"),
+        ("comment_count", "comments"),
+        ("vote_count", "votes")
+    )
+    @ddt.unpack
+    def test_order_by_query(self, http_query, cc_query):
+        """
+        Tests the order_by parameter
+
+        Arguments:
+            http_query (str): Query string sent in the http request
+            cc_query (str): Query string used for the comments client service
+        """
+        self.register_get_threads_response([], page=1, num_pages=1)
+        result = get_thread_list(
+            self.request,
+            self.course.id,
+            page=1,
+            page_size=11,
+            order_by=http_query,
+        )
+        self.assertEqual(
+            result,
+            {"results": [], "next": None, "previous": None, "text_search_rewrite": None}
+        )
+        self.assertEqual(
+            urlparse(httpretty.last_request().path).path,
+            "/api/v1/threads"
+        )
+        self.assert_last_query_params({
+            "user_id": [unicode(self.user.id)],
+            "course_id": [unicode(self.course.id)],
+            "sort_key": [cc_query],
+            "sort_order": ["desc"],
+            "page": ["1"],
+            "per_page": ["11"],
+            "recursive": ["False"],
+        })
+
+    @ddt.data("asc", "desc")
+    def test_order_direction_query(self, http_query):
+        self.register_get_threads_response([], page=1, num_pages=1)
+        result = get_thread_list(
+            self.request,
+            self.course.id,
+            page=1,
+            page_size=11,
+            order_direction=http_query,
+        )
+        self.assertEqual(
+            result,
+            {"results": [], "next": None, "previous": None, "text_search_rewrite": None}
+        )
+        self.assertEqual(
+            urlparse(httpretty.last_request().path).path,
+            "/api/v1/threads"
+        )
+        self.assert_last_query_params({
+            "user_id": [unicode(self.user.id)],
+            "course_id": [unicode(self.course.id)],
+            "sort_key": ["date"],
+            "sort_order": [http_query],
+            "page": ["1"],
+            "per_page": ["11"],
+            "recursive": ["False"],
+        })
+
 
 @ddt.ddt
 class GetCommentListTest(CommentsServiceMockMixin, ModuleStoreTestCase):

--- a/lms/djangoapps/discussion_api/tests/test_forms.py
+++ b/lms/djangoapps/discussion_api/tests/test_forms.py
@@ -95,7 +95,9 @@ class ThreadListGetFormTest(FormTestMixin, PaginationTestMixin, TestCase):
                 "topic_id": [],
                 "text_search": "",
                 "following": None,
-                "view": ""
+                "view": "",
+                "order_by": "last_activity_at",
+                "order_direction": "desc",
             }
         )
 
@@ -146,6 +148,20 @@ class ThreadListGetFormTest(FormTestMixin, PaginationTestMixin, TestCase):
     def test_invalid_view_choice(self):
         self.form_data["view"] = "not_a_valid_choice"
         self.assert_error("view", "Select a valid choice. not_a_valid_choice is not one of the available choices.")
+
+    def test_invalid_sort_by_choice(self):
+        self.form_data["order_by"] = "not_a_valid_choice"
+        self.assert_error(
+            "order_by",
+            "Select a valid choice. not_a_valid_choice is not one of the available choices."
+        )
+
+    def test_invalid_sort_direction_choice(self):
+        self.form_data["order_direction"] = "not_a_valid_choice"
+        self.assert_error(
+            "order_direction",
+            "Select a valid choice. not_a_valid_choice is not one of the available choices."
+        )
 
 
 class CommentListGetFormTest(FormTestMixin, PaginationTestMixin, TestCase):

--- a/lms/djangoapps/discussion_api/tests/test_views.py
+++ b/lms/djangoapps/discussion_api/tests/test_views.py
@@ -327,6 +327,62 @@ class ThreadViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
             "/api/v1/users/{}/subscribed_threads".format(self.user.id)
         )
 
+    @ddt.data(
+        ("last_activity_at", "date"),
+        ("comment_count", "comments"),
+        ("vote_count", "votes")
+    )
+    @ddt.unpack
+    def test_order_by(self, http_query, cc_query):
+        """
+        Tests the order_by parameter
+
+        Arguments:
+            http_query (str): Query string sent in the http request
+            cc_query (str): Query string used for the comments client service
+        """
+        threads = [make_minimal_cs_thread()]
+        self.register_get_user_response(self.user)
+        self.register_get_threads_response(threads, page=1, num_pages=1)
+        self.client.get(
+            self.url,
+            {
+                "course_id": unicode(self.course.id),
+                "order_by": http_query,
+            }
+        )
+        self.assert_last_query_params({
+            "user_id": [unicode(self.user.id)],
+            "course_id": [unicode(self.course.id)],
+            "sort_order": ["desc"],
+            "recursive": ["False"],
+            "page": ["1"],
+            "per_page": ["10"],
+            "sort_key": [cc_query],
+        })
+
+    @ddt.data("asc", "desc")
+    def test_order_direction(self, query):
+        threads = [make_minimal_cs_thread()]
+        self.register_get_user_response(self.user)
+        self.register_get_threads_response(threads, page=1, num_pages=1)
+        self.client.get(
+            self.url,
+            {
+                "course_id": unicode(self.course.id),
+                "order_direction": query,
+            }
+        )
+        self.assert_last_query_params({
+            "user_id": [unicode(self.user.id)],
+            "course_id": [unicode(self.course.id)],
+            "sort_key": ["date"],
+            "recursive": ["False"],
+            "page": ["1"],
+            "per_page": ["10"],
+            "sort_order": [query],
+        })
+
 
 @httpretty.activate
 class ThreadViewSetCreateTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):

--- a/lms/djangoapps/discussion_api/views.py
+++ b/lms/djangoapps/discussion_api/views.py
@@ -141,6 +141,13 @@ class ThreadViewSet(_ViewMixin, DeveloperErrorViewMixin, ViewSet):
             (including the bodies of comments in the thread) matches the search
             string will be returned.
 
+        * order_by: Must be "last_activity_at", "comment_count", or
+            "vote_count". The key to sort the threads by. The default is
+            "last_activity_at".
+
+        * order_direction: Must be "asc" or "desc". The direction in which to
+            sort the threads by. The default is "desc".
+
         * following: If true, retrieve only threads the requesting user is
             following
 
@@ -245,6 +252,8 @@ class ThreadViewSet(_ViewMixin, DeveloperErrorViewMixin, ViewSet):
                 form.cleaned_data["text_search"],
                 form.cleaned_data["following"],
                 form.cleaned_data["view"],
+                form.cleaned_data["order_by"],
+                form.cleaned_data["order_direction"],
             )
         )
 


### PR DESCRIPTION
MA-647

Adds the query parameters order_by for ordering by date, votes, or comments, and order_direction by ascending or descending to the discussion API. 

Note to reviewers: The unit tests are mocked responses from the CCS. 

@mekkz @cahrens 

FYI @nasthagiri @jimabramson 
