### PR TITLE
Add abuse flagging to discussion API

### DIFF
--- a/lms/djangoapps/discussion_api/api.py
+++ b/lms/djangoapps/discussion_api/api.py
@@ -368,6 +368,11 @@ def _do_extra_actions(api_content, cc_content, request_fields, actions_form, con
                     context["cc_requester"].follow(cc_content)
                 else:
                     context["cc_requester"].unfollow(cc_content)
+            elif field == "abuse_flagged":
+                if form_value:
+                    cc_content.flagAbuse(context["cc_requester"], cc_content)
+                else:
+                    cc_content.unFlagAbuse(context["cc_requester"], cc_content, removeAll=False)
             else:
                 assert field == "voted"
                 if form_value:

--- a/lms/djangoapps/discussion_api/forms.py
+++ b/lms/djangoapps/discussion_api/forms.py
@@ -80,6 +80,7 @@ class ThreadActionsForm(Form):
     """
     following = BooleanField(required=False)
     voted = BooleanField(required=False)
+    abuse_flagged = BooleanField(required=False)
 
 
 class CommentListGetForm(_PaginationForm):
@@ -98,3 +99,4 @@ class CommentActionsForm(Form):
     interactions with the comments service.
     """
     voted = BooleanField(required=False)
+    abuse_flagged = BooleanField(required=False)

--- a/lms/djangoapps/discussion_api/permissions.py
+++ b/lms/djangoapps/discussion_api/permissions.py
@@ -23,7 +23,7 @@ def get_editable_fields(cc_content, context):
     Return the set of fields that the requester can edit on the given content
     """
     # Shared fields
-    ret = {"voted"}
+    ret = {"abuse_flagged", "voted"}
     if _is_author_or_privileged(cc_content, context):
         ret |= {"raw_body"}
 

--- a/lms/djangoapps/discussion_api/tests/test_permissions.py
+++ b/lms/djangoapps/discussion_api/tests/test_permissions.py
@@ -30,7 +30,7 @@ class GetEditableFieldsTest(TestCase):
         thread = Thread(user_id="5" if is_author else "6", type="thread")
         context = _get_context(requester_id="5", is_requester_privileged=is_privileged)
         actual = get_editable_fields(thread, context)
-        expected = {"following", "voted"}
+        expected = {"abuse_flagged", "following", "voted"}
         if is_author or is_privileged:
             expected |= {"topic_id", "type", "title", "raw_body"}
         self.assertEqual(actual, expected)
@@ -45,7 +45,7 @@ class GetEditableFieldsTest(TestCase):
             thread=Thread(user_id="5" if is_thread_author else "6", thread_type=thread_type)
         )
         actual = get_editable_fields(comment, context)
-        expected = {"voted"}
+        expected = {"abuse_flagged", "voted"}
         if is_author or is_privileged:
             expected |= {"raw_body"}
         if (is_thread_author and thread_type == "question") or is_privileged:

--- a/lms/djangoapps/discussion_api/tests/test_serializers.py
+++ b/lms/djangoapps/discussion_api/tests/test_serializers.py
@@ -197,7 +197,7 @@ class ThreadSerializerSerializationTest(SerializerTestMixin, ModuleStoreTestCase
             "comment_list_url": "http://testserver/api/discussion/v1/comments/?thread_id=test_thread",
             "endorsed_comment_list_url": None,
             "non_endorsed_comment_list_url": None,
-            "editable_fields": ["following", "voted"],
+            "editable_fields": ["abuse_flagged", "following", "voted"],
         }
         self.assertEqual(self.serialize(thread), expected)
 
@@ -305,7 +305,7 @@ class CommentSerializerTest(SerializerTestMixin, ModuleStoreTestCase):
             "voted": False,
             "vote_count": 4,
             "children": [],
-            "editable_fields": ["voted"],
+            "editable_fields": ["abuse_flagged", "voted"],
         }
         self.assertEqual(self.serialize(comment), expected)
 

--- a/lms/djangoapps/discussion_api/tests/test_views.py
+++ b/lms/djangoapps/discussion_api/tests/test_views.py
@@ -204,7 +204,7 @@ class ThreadViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
             "comment_list_url": "http://testserver/api/discussion/v1/comments/?thread_id=test_thread",
             "endorsed_comment_list_url": None,
             "non_endorsed_comment_list_url": None,
-            "editable_fields": ["following", "voted"],
+            "editable_fields": ["abuse_flagged", "following", "voted"],
         }]
         self.register_get_threads_response(source_threads, page=1, num_pages=2)
         response = self.client.get(self.url, {"course_id": unicode(self.course.id)})
@@ -318,7 +318,7 @@ class ThreadViewSetCreateTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
             "comment_list_url": "http://testserver/api/discussion/v1/comments/?thread_id=test_thread",
             "endorsed_comment_list_url": None,
             "non_endorsed_comment_list_url": None,
-            "editable_fields": ["following", "raw_body", "title", "topic_id", "type", "voted"],
+            "editable_fields": ["abuse_flagged", "following", "raw_body", "title", "topic_id", "type", "voted"],
         }
         response = self.client.post(
             self.url,
@@ -409,7 +409,7 @@ class ThreadViewSetPartialUpdateTest(DiscussionAPIViewTestMixin, ModuleStoreTest
             "comment_list_url": "http://testserver/api/discussion/v1/comments/?thread_id=test_thread",
             "endorsed_comment_list_url": None,
             "non_endorsed_comment_list_url": None,
-            "editable_fields": ["following", "raw_body", "title", "topic_id", "type", "voted"],
+            "editable_fields": ["abuse_flagged", "following", "raw_body", "title", "topic_id", "type", "voted"],
         }
         response = self.client.patch(  # pylint: disable=no-member
             self.url,
@@ -553,7 +553,7 @@ class CommentViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
             "voted": True,
             "vote_count": 4,
             "children": [],
-            "editable_fields": ["voted"],
+            "editable_fields": ["abuse_flagged", "voted"],
         }]
         self.register_get_thread_response({
             "id": self.thread_id,
@@ -707,7 +707,7 @@ class CommentViewSetCreateTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
             "voted": False,
             "vote_count": 0,
             "children": [],
-            "editable_fields": ["raw_body", "voted"],
+            "editable_fields": ["abuse_flagged", "raw_body", "voted"],
         }
         response = self.client.post(
             self.url,
@@ -791,7 +791,7 @@ class CommentViewSetPartialUpdateTest(DiscussionAPIViewTestMixin, ModuleStoreTes
             "voted": False,
             "vote_count": 0,
             "children": [],
-            "editable_fields": ["raw_body", "voted"],
+            "editable_fields": ["abuse_flagged", "raw_body", "voted"],
         }
         response = self.client.patch(  # pylint: disable=no-member
             self.url,

--- a/lms/djangoapps/discussion_api/tests/utils.py
+++ b/lms/djangoapps/discussion_api/tests/utils.py
@@ -230,6 +230,28 @@ class CommentsServiceMockMixin(object):
                 status=200
             )
 
+    def register_flag_response(self, content_type, content_id):
+        """Register a mock response for PUT on the CS flag endpoints"""
+        for path in ["abuse_flag", "abuse_unflag"]:
+            httpretty.register_uri(
+                "PUT",
+                "http://localhost:4567/api/v1/{content_type}s/{content_id}/{path}".format(
+                    content_type=content_type,
+                    content_id=content_id,
+                    path=path
+                ),
+                body=json.dumps({}),  # body is unused
+                status=200
+            )
+
+    def register_thread_flag_response(self, thread_id):
+        """Register a mock response for PUT on the CS thread flag endpoints"""
+        self.register_flag_response("thread", thread_id)
+
+    def register_comment_flag_response(self, comment_id):
+        """Register a mock response for PUT on the CS comment flag endpoints"""
+        self.register_flag_response("comment", comment_id)
+
     def register_delete_thread_response(self, thread_id):
         """
         Register a mock response for DELETE on the CS thread instance endpoint


### PR DESCRIPTION
Flagging/unflagging is done by issuing a PATCH request on a thread or
comment endpoint with the "abuse_flagged" field set.

@jimabramson @BenjiLee Please review
@nasthagiri @cahrens FYI
