### PR TITLE
Remove default broken URL added to new courses

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -45,6 +45,8 @@ from lms.envs.common import (
     # The following setting is included as it is used to check whether to
     # display credit eligibility table on the CMS or not.
     ENABLE_CREDIT_ELIGIBILITY, YOUTUBE_API_KEY
+    # Default Course Image static path
+    DEFAULT_COURSE_ABOUT_IMAGE_URL,
 )
 from path import path
 from warnings import simplefilter

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -682,7 +682,7 @@ class CourseFields(object):
         ),
         scope=Scope.settings,
         # Ensure that courses imported from XML keep their image
-        default="images_course_image.jpg"
+        default=""
     )
     issue_badges = Boolean(
         display_name=_("Issue Open Badges"),

--- a/common/lib/xmodule/xmodule/modulestore/xml_exporter.py
+++ b/common/lib/xmodule/xmodule/modulestore/xml_exporter.py
@@ -29,6 +29,8 @@ EXPORT_VERSION_KEY = "export_format"
 
 DEFAULT_CONTENT_FIELDS = ['metadata', 'data']
 
+DEFAULT_XML_COURSE_IMAGE_FILENAME = "images_course_image.jpg"
+
 
 def _export_drafts(modulestore, course_key, export_fs, xml_centric_course_key):
     """
@@ -227,12 +229,17 @@ class CourseExportManager(ExportManager):
 
             # If we are using the default course image, export it to the
             # legacy location to support backwards compatibility.
-            if courselike.course_image == courselike.fields['course_image'].default:
+            is_xml_course = courselike.runtime.modulestore.get_modulestore_type() == ModuleStoreEnum.Type.xml
+            existing_course_image = courselike.course_image
+            if is_xml_course and not existing_course_image:
+                existing_course_image = DEFAULT_XML_COURSE_IMAGE_FILENAME
+
+            if existing_course_image == DEFAULT_XML_COURSE_IMAGE_FILENAME:
                 try:
                     course_image = self.contentstore.find(
                         StaticContent.compute_location(
                             courselike.id,
-                            courselike.course_image
+                            existing_course_image
                         ),
                     )
                 except NotFoundError:

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -122,8 +122,9 @@ def course_image_url(course):
         # courses can use custom course image paths, otherwise just
         # return the default static path.
         url = '/static/' + (course.static_asset_path or getattr(course, 'data_dir', ''))
-        if hasattr(course, 'course_image') and course.course_image != course.fields['course_image'].default:
-            url += '/' + course.course_image
+        static_course_image = getattr(course, 'course_image', None)
+        if static_course_image and static_course_image != settings.DEFAULT_XML_COURSE_IMAGE_FILENAME:
+            url += '/' + static_course_image
         else:
             url += '/images/course_image.jpg'
     elif not course.course_image:

--- a/lms/djangoapps/courseware/tests/test_courses.py
+++ b/lms/djangoapps/courseware/tests/test_courses.py
@@ -85,9 +85,14 @@ class ModuleStoreBranchSettingTest(ModuleStoreTestCase):
 class MongoCourseImageTestCase(ModuleStoreTestCase):
     """Tests for course image URLs when using a mongo modulestore."""
 
-    def test_get_image_url(self):
+    def test_get_no_image_url(self):
         """Test image URL formatting."""
         course = CourseFactory.create(org='edX', course='999')
+        self.assertEquals(course_image_url(course), '/static/images/pencils.jpg')
+
+    def test_get_has_image_url(self):
+        """Test image URL formatting."""
+        course = CourseFactory.create(org='edX', course='999', course_image=u'test_course_image.jpg')
         self.assertEquals(course_image_url(course), '/c4x/edX/999/asset/{0}'.format(course.course_image))
 
     def test_non_ascii_image_name(self):

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -786,6 +786,7 @@ class TestHtmlModifiers(ModuleStoreTestCase):
         self.assertIn('href="/static/toy_course_dir', result_fragment.content)
 
     def test_course_image(self):
+        self.course.course_image = "course_has_image.jpg"
         url = course_image_url(self.course)
         self.assertTrue(url.startswith('/c4x/'))
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -835,6 +835,7 @@ STATICFILES_DIRS = [
 
 FAVICON_PATH = 'images/favicon.ico'
 DEFAULT_COURSE_ABOUT_IMAGE_URL = 'images/pencils.jpg'
+DEFAULT_XML_COURSE_IMAGE_FILENAME = "images_course_image.jpg"
 
 # User-uploaded content
 MEDIA_ROOT = '/edx/var/edxapp/media/'


### PR DESCRIPTION
New courses created in studio currently have a broken default image added by default.
By removing this URL at creation, it enables the default image set in LMS to display: https://github.com/edx/edx-platform/pull/8282
