### PR TITLE
adjust margin-bottom on courseware with license

### DIFF
--- a/lms/static/sass/base/_layouts.scss
+++ b/lms/static/sass/base/_layouts.scss
@@ -57,7 +57,7 @@ body.view-incourse {
   .course-wrapper,
   .profile-wrapper {
     max-width: 1180px;
-    margin: 0 auto ($baseline*2) auto;
+    margin: 0 auto;
     padding: 0;
   }
 
@@ -77,6 +77,7 @@ body.view-incourse {
 
   // site footer
   .wrapper-footer {
+    margin-top: $baseline;
     padding-right: 2%;
     padding-left: 2%;
 


### PR DESCRIPTION
This PR addresses a small margin bug in courseware that came out of the responsive LMS changes. The current margin when a content license is enabled is too big on top: 

![license-before](https://cloud.githubusercontent.com/assets/4327102/8262602/6c2770b2-16a1-11e5-845a-f8d1750b33c7.png)

The new margin is closer to the content but leaves room before the footer: 

![license-after](https://cloud.githubusercontent.com/assets/4327102/8262615/89aa4100-16a1-11e5-8349-a9ccad008c8d.png)

Bug: UX-2400

@marcotuts Can you review?
