### PR TITLE
Bump python-social-auth to upstream's latest master

### DIFF
--- a/common/djangoapps/third_party_auth/models.py
+++ b/common/djangoapps/third_party_auth/models.py
@@ -300,7 +300,7 @@ class SAMLConfiguration(ConfigurationModel):
         default='{\n"SECURITY_CONFIG": {"metadataCacheDuration": 604800, "signMetadata": false}\n}',
         help_text=(
             "JSON object defining advanced settings that are passed on to python-saml. "
-            "Valid keys that can be set here include: SECURITY_CONFIG, SP_NAMEID_FORMATS, SP_EXTRA"
+            "Valid keys that can be set here include: SECURITY_CONFIG and SP_EXTRA"
         ),
     )
 
@@ -344,7 +344,7 @@ class SAMLConfiguration(ConfigurationModel):
         if name == "SUPPORT_CONTACT":
             return {"givenName": "SAML Support", "emailAddress": settings.TECH_SUPPORT_EMAIL}
         other_config = json.loads(self.other_config_str)
-        return other_config[name]  # SECURITY_CONFIG, SP_NAMEID_FORMATS, SP_EXTRA
+        return other_config[name]  # SECURITY_CONFIG, SP_EXTRA, or similar extra settings
 
 
 class SAMLProviderData(models.Model):

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -69,7 +69,8 @@ pyparsing==2.0.1
 python-memcached==1.48
 python-openid==2.2.5
 python-dateutil==2.1
-# python-social-auth==0.2.7 was here but is temporarily moved to github.txt
+python-social-auth==0.2.11
+python-saml==2.1.3
 pytz==2015.2
 pysrt==0.4.7
 PyYAML==3.10

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -30,9 +30,6 @@ git+https://github.com/pmitros/pyfs.git@96e1922348bfe6d99201b9512a9ed946c87b7e0b
 git+https://github.com/hmarr/django-debug-toolbar-mongo.git@b0686a76f1ce3532088c4aee6e76b9abe61cc808
 # custom opaque-key implementations for ccx
 -e git+https://github.com/jazkarta/ccx-keys.git@e6b03704b1bb97c1d2f31301ecb4e3a687c536ea#egg=ccx-keys
-# For SAML Support (To be moved to PyPi installation in base.txt once our changes are merged):
--e git+https://github.com/open-craft/python-saml.git@9602b8133056d8c3caa7c3038761147df3d4b257#egg=python-saml
--e git+https://github.com/open-craft/python-social-auth.git@02ab628b8961b969021de87aeb23551da4e751b7#egg=python-social-auth
 
 # Our libraries:
 -e git+https://github.com/edx/XBlock.git@e1831fa86bff778ffe1308e00d8ed51b26f7c047#egg=XBlock


### PR DESCRIPTION
**Summary**
The python-social-auth and python-saml projects have merged our changes. This switches us back to using official PyPI releases, which are now compatible with our new SAML backend.

This also pulls in the OAuth2 backend required to support Office 365 logins, therefore providing a replacement for most of #8248.

This is part of the Shibboleth/SSO work and is being merged to the [shibboleth-tpa feature branch](https://github.com/edx/edx-platform/pull/8140)

**Details**
Noteworthy changelog entries between python-social-auth version 0.2.7 and 0.2.11:
- **SAML Backend**
- Avoid storing empty values from user details
- **Added provider for Microsoft Azure Active Directory OAuth2**
- Fixes "ImportError: No module named packages.urllib3.poolmanager" error (bumps 'requests' version)
- Make URLs trailing slash be configurable by setting. Refs #505

For python-saml, the only commits added to the PyPI release that weren't previously included in our fork are:
- additional tests, comments, and code cleanup
- a small bugfix to the metadata "valid until" time specification code
- PR 67, "NameIDFormat/NameIDPolicy Improvements" was rejected and an alternate fix was included: https://github.com/onelogin/python-saml/commit/3a5847be93fd7e3af695d791989825cc6c118808 . I have tested this and it seems to work well with both of our current testing IdPs (TestShib and UBC Staging).

**Sandbox**:
http://sandbox5.opencraft.com/login has been updated to use the new versions via PyPI (on June 24)

**Reviewers**
@Kelketek and @rlucioni 
