### PR TITLE
Upgrade rednose to latest to fix bad output.

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -144,7 +144,7 @@ pylint==1.4.2
 python-subunit==0.0.16
 pyquery==1.2.9
 radon==1.2
-rednose==0.4.1
+rednose==0.4.3
 selenium==2.42.1
 splinter==0.5.4
 testtools==0.9.34


### PR DESCRIPTION
With version 0.4.1, the stdout of the failed test is somehow merged into the assertion message:

![screen shot 2015-06-22 at 10 37 00 am](https://cloud.githubusercontent.com/assets/23789/8284406/bbafec7e-18ca-11e5-942d-8dbf7a554165.png)

With version 0.4.3, the output is correct:
![screen shot 2015-06-22 at 10 37 23 am](https://cloud.githubusercontent.com/assets/23789/8284415/c96913fe-18ca-11e5-9a28-32127a01e1d1.png)
