### PR TITLE
Switch tabs to use ugettext_noop for titles.

### DIFF
--- a/common/lib/xmodule/xmodule/tabs.py
+++ b/common/lib/xmodule/xmodule/tabs.py
@@ -28,7 +28,8 @@ class CourseTab(object):
     # subclass, shared by all instances of the subclass.
     type = ''
 
-    # The title of the tab, which should be internationalized
+    # The title of the tab, which should be internationalized using
+    # ugettext_noop since the user won't be available in this context.
     title = None
 
     # Class property that specifies whether the tab can be hidden for a particular course

--- a/lms/djangoapps/ccx/plugins.py
+++ b/lms/djangoapps/ccx/plugins.py
@@ -3,7 +3,7 @@ Registers the CCX feature for the edX platform.
 """
 
 from django.conf import settings
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_noop
 
 from xmodule.tabs import CourseTab
 from student.roles import CourseCcxCoachRole
@@ -15,7 +15,7 @@ class CcxCourseTab(CourseTab):
     """
 
     type = "ccx_coach"
-    title = _("CCX Coach")
+    title = ugettext_noop("CCX Coach")
     view_name = "ccx_coach_dashboard"
     is_dynamic = True    # The CCX view is dynamically added to the set of tabs when it is enabled
 

--- a/lms/djangoapps/course_wiki/tab.py
+++ b/lms/djangoapps/course_wiki/tab.py
@@ -4,7 +4,7 @@ a user has on an article.
 """
 
 from django.conf import settings
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_noop
 
 from courseware.tabs import EnrolledTab
 
@@ -15,7 +15,7 @@ class WikiTab(EnrolledTab):
     """
 
     type = "wiki"
-    title = _('Wiki')
+    title = ugettext_noop('Wiki')
     view_name = "course_wiki"
     is_hideable = True
     is_default = False

--- a/lms/djangoapps/courseware/tabs.py
+++ b/lms/djangoapps/courseware/tabs.py
@@ -3,7 +3,7 @@ This module is essentially a broker to xmodule/tabs.py -- it was originally intr
 perform some LMS-specific tab display gymnastics for the Entrance Exams feature
 """
 from django.conf import settings
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext_noop
 
 from courseware.access import has_access
 from courseware.entrance_exams import user_must_complete_entrance_exam
@@ -28,7 +28,7 @@ class CoursewareTab(EnrolledTab):
     The main courseware view.
     """
     type = 'courseware'
-    title = _('Courseware')
+    title = ugettext_noop('Courseware')
     priority = 10
     view_name = 'courseware'
     is_movable = False
@@ -40,7 +40,7 @@ class CourseInfoTab(CourseTab):
     The course info view.
     """
     type = 'course_info'
-    title = _('Course Info')
+    title = ugettext_noop('Course Info')
     priority = 20
     view_name = 'info'
     tab_id = 'info'
@@ -57,7 +57,7 @@ class SyllabusTab(EnrolledTab):
     A tab for the course syllabus.
     """
     type = 'syllabus'
-    title = _('Syllabus')
+    title = ugettext_noop('Syllabus')
     priority = 30
     view_name = 'syllabus'
     allow_multiple = True
@@ -75,7 +75,7 @@ class ProgressTab(EnrolledTab):
     The course progress view.
     """
     type = 'progress'
-    title = _('Progress')
+    title = ugettext_noop('Progress')
     priority = 40
     view_name = 'progress'
     is_hideable = True
@@ -93,7 +93,7 @@ class TextbookTabsBase(CourseTab):
     Abstract class for textbook collection tabs classes.
     """
     # Translators: 'Textbooks' refers to the tab in the course that leads to the course' textbooks
-    title = _("Textbooks")
+    title = ugettext_noop("Textbooks")
     is_collection = True
     is_default = False
 
@@ -225,7 +225,7 @@ class ExternalDiscussionCourseTab(LinkTab):
 
     type = 'external_discussion'
     # Translators: 'Discussion' refers to the tab in the courseware that leads to the discussion forums
-    title = _('Discussion')
+    title = ugettext_noop('Discussion')
     priority = None
     is_default = False
 

--- a/lms/djangoapps/django_comment_client/forum/views.py
+++ b/lms/djangoapps/django_comment_client/forum/views.py
@@ -13,7 +13,7 @@ from django.core.context_processors import csrf
 from django.core.urlresolvers import reverse
 from django.contrib.auth.models import User
 from django.http import Http404, HttpResponseBadRequest
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_noop
 from django.views.decorators.http import require_GET
 import newrelic.agent
 
@@ -55,7 +55,7 @@ class DiscussionTab(EnrolledTab):
     """
 
     type = 'discussion'
-    title = _('Discussion')
+    title = ugettext_noop('Discussion')
     priority = None
     view_name = 'django_comment_client.forum.views.forum_form_discussion'
     is_hideable = settings.FEATURES.get('ALLOW_HIDING_DISCUSSION_TAB', False)

--- a/lms/djangoapps/edxnotes/plugins.py
+++ b/lms/djangoapps/edxnotes/plugins.py
@@ -2,7 +2,7 @@
 Registers the "edX Notes" feature for the edX platform.
 """
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_noop
 
 from courseware.tabs import EnrolledTab
 
@@ -13,7 +13,7 @@ class EdxNotesTab(EnrolledTab):
     """
 
     type = "edxnotes"
-    title = _("Notes")
+    title = ugettext_noop("Notes")
     view_name = "edxnotes"
 
     @classmethod

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -11,7 +11,7 @@ import pytz
 
 from django.contrib.auth.decorators import login_required
 from django.views.decorators.http import require_POST
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext_noop
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.decorators.cache import cache_control
 from edxmako.shortcuts import render_to_response
@@ -53,7 +53,7 @@ class InstructorDashboardTab(CourseTab):
     """
 
     type = "instructor"
-    title = _('Instructor')
+    title = ugettext_noop('Instructor')
     view_name = "instructor_dashboard"
     is_dynamic = True    # The "Instructor" tab is instead dynamically added when it is enabled
 

--- a/lms/djangoapps/notes/views.py
+++ b/lms/djangoapps/notes/views.py
@@ -13,7 +13,7 @@ from courseware.tabs import EnrolledTab
 from notes.models import Note
 from notes.utils import notes_enabled_for_course
 from xmodule.annotator_token import retrieve_token
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_noop
 
 
 @login_required
@@ -45,7 +45,7 @@ class NotesTab(EnrolledTab):
     A tab for the course notes.
     """
     type = 'notes'
-    title = _("My Notes")
+    title = ugettext_noop("My Notes")
     view_name = "notes"
 
     @classmethod

--- a/lms/djangoapps/teams/plugins.py
+++ b/lms/djangoapps/teams/plugins.py
@@ -2,7 +2,7 @@
 Definition of the course team feature.
 """
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_noop
 from courseware.tabs import EnrolledTab
 from .views import is_feature_enabled
 
@@ -13,7 +13,7 @@ class TeamsTab(EnrolledTab):
     """
 
     type = "teams"
-    title = _("Teams")
+    title = ugettext_noop("Teams")
     view_name = "teams_dashboard"
 
     @classmethod


### PR DESCRIPTION
@andy-armstrong @peter-fogg 

Here are updates to switch to using ugettext_noop over ugettext for tab titles. There aren't any tests because testing these code paths is really difficult. I'll try to get a sandbox up and running as soon as we resolve some issues with translations on mater.

https://openedx.atlassian.net/browse/TNL-2539
