### PR TITLE
Wait for element to not be present.

### DIFF
--- a/common/test/acceptance/pages/studio/users.py
+++ b/common/test/acceptance/pages/studio/users.py
@@ -107,18 +107,39 @@ class UsersPageMixin(PageObject):
         """ Gets modal dialog text """
         return self.q(css='.prompt.{dialog_type} .message'.format(dialog_type=dialog_type)).text[0]
 
+    def wait_until_no_loading_indicator(self):
+        """
+        When the page first loads, there is a loading indicator and most
+        functionality is not yet available. This waits for that loading to finish
+        and be removed from the DOM.
+
+        This method is different from wait_until_ready because the loading element
+        is removed from the DOM, rather than hidden.
+
+        It also disables animations for improved test reliability.
+        """
+
+        self.wait_for(
+            lambda: not self.q(css='.ui-loading').present,
+            "Wait for page to complete its initial loading"
+        )
+        disable_animations(self)
+
     def wait_until_ready(self):
         """
         When the page first loads, there is a loading indicator and most
         functionality is not yet available. This waits for that loading to
         finish.
 
-        Always call this before using the page. It also disables animations
-        for improved test reliability.
+        This method is different from wait_until_backbone_rendered because this expects
+        the loading indicator to still exist on the page; it is just hidden.
+
+        It also disables animations for improved test reliability.
         """
+
         self.wait_for_element_invisibility(
             '.ui-loading',
-            'Wait for the page to complete its initial loading and rendering via Backbone'
+            'Wait for the page to complete its initial loading'
         )
         disable_animations(self)
 

--- a/common/test/acceptance/tests/studio/test_studio_course_team.py
+++ b/common/test/acceptance/tests/studio/test_studio_course_team.py
@@ -42,7 +42,7 @@ class CourseTeamPageTest(StudioCourseTest):
     def _go_to_course_team_page(self):
         """ Opens Course Team page """
         self.page.visit()
-        self.page.wait_until_ready()
+        self.page.wait_until_no_loading_indicator()
 
     def _refresh_page(self):
         """

--- a/common/test/acceptance/tests/studio/test_studio_library.py
+++ b/common/test/acceptance/tests/studio/test_studio_library.py
@@ -523,7 +523,7 @@ class LibraryUsersPageTest(StudioLibraryTest):
         """
         self.page = LibraryUsersPage(self.browser, self.library_key)
         self.page.visit()
-        self.page.wait_until_ready()
+        self.page.wait_until_no_loading_indicator()
 
     def test_user_management(self):
         """


### PR DESCRIPTION
Compatible with minor bok-choy upgrade, wherein 'not-present' and
'invisible' are two distinct concepts. In the bok-choy upgrade, an
invisible element must be present on the page. In the case of this
commit, the actual wait_for is expecting the element to disappear
from the page because it's injected by backbone while the page is
loading. Once it is removed, the page has loaded. So, the 'invisible'
distinction is not appropriate for what this test is doing. This
test was intended to search for not-present. Updating to make that so.
