### PR TITLE
Quiet console logging of bok-choy migrations

### DIFF
--- a/scripts/reset-test-db.sh
+++ b/scripts/reset-test-db.sh
@@ -34,12 +34,16 @@ echo "CREATE DATABASE IF NOT EXISTS edxtest;" | mysql -u root
 if [[ -f $DB_CACHE_DIR/bok_choy_schema.sql && -f $DB_CACHE_DIR/bok_choy_data.json ]]; then
 
     # Load the schema, then the data (including the migration history)
+    echo "Loading cached schema and fixture data..."
     mysql -u root edxtest < $DB_CACHE_DIR/bok_choy_schema.sql
     ./manage.py lms --settings bok_choy loaddata $DB_CACHE_DIR/bok_choy_data.json
 
     # Re-run migrations to ensure we are up-to-date
-    ./manage.py lms --settings bok_choy migrate --traceback --noinput
-    ./manage.py cms --settings bok_choy migrate --traceback --noinput
+    echo "Executing lms migrations..."
+    ./manage.py lms --settings bok_choy migrate --traceback --noinput --verbosity 0
+    echo "Executing studio migrations..."
+    ./manage.py cms --settings bok_choy migrate --traceback --noinput --verbosity 0
+    echo "Finished resetting the bok-choy test database."
 
 # Otherwise, update the test database and update the cache
 else


### PR DESCRIPTION
Up for discussion. @clytwynec @benpatterson what do you think?

Pros of logging (current behavior):
- You can use them to judge how far off the cached schema is, to decide if someone should put in a PR to update it.

Pros of suppressing logging:
- Test output is cleaner. You don't need to scroll down past 266 lines of migration output to get to the test results.

FWIW:
- [the current console output for a bok-choy shard](https://build.testeng.edx.org/job/edx-platform-test-subset/114311/console)
- [the console output for a bok-choy shard for this PR](https://build.testeng.edx.org/job/edx-platform-test-subset/114508/console)
