### PR TITLE
don't use hardcoded date in verification email test

### DIFF
--- a/lms/djangoapps/verify_student/tests/test_views.py
+++ b/lms/djangoapps/verify_student/tests/test_views.py
@@ -2023,8 +2023,7 @@ class TestEmailMessageWithCustomICRVBlock(ModuleStoreTestCase):
 
     def test_denied_email_message_with_close_verification_dates(self):
         # Due date given and expired
-
-        return_value = datetime(2016, 1, 1, tzinfo=timezone.utc)
+        return_value = datetime.now(tz=pytz.UTC) + timedelta(days=22)
         with patch.object(timezone, 'now', return_value=return_value):
             __, body = _compose_message_reverification_email(
                 self.course.id, self.user.id, self.reverification_location, "denied", self.request


### PR DESCRIPTION
@jzoldak @benpatterson  I noticed this when looking into a failure on my branch (which has already been fixed).  I thought it would be good to update this while I noticed it so we don't get a new failing test on new years day.
