### PR TITLE
Web Certificates: Revising and Adding Share Actions

### DIFF
--- a/lms/static/certificates/sass/_components.scss
+++ b/lms/static/certificates/sass/_components.scss
@@ -118,6 +118,15 @@
 
         .icon {
             @include margin-right(spacing-horizontal(x-small));
+            font-size: font-size(mid-large);
+        }
+
+        // CASE: icon display only
+        &.icon-only {
+
+            .action-label {
+                @extend %a11y-hide;
+            }
         }
 
         // CASE mozilla open badges logo

--- a/lms/static/certificates/sass/_layouts.scss
+++ b/lms/static/certificates/sass/_layouts.scss
@@ -81,15 +81,29 @@
 
         .message-actions .action {
             display: block;
+            width: 100%;
             margin: 0 auto spacing-vertical(small) auto;
 
             &:last-child {
                 margin-bottom: 0;
             }
 
+            // CASE: icon display only
+            &.icon-only {
+
+                @include susy-breakpoint($bp-medium, $susy) {
+                    padding: spacing-vertical(x-small) spacing-horizontal(base);
+
+                    .icon {
+                        @include margin-right(0);
+                    }
+                }
+            }
+
             @include susy-breakpoint($bp-medium, $susy) {
                 display: inline-block;
                 vertical-align: middle;
+                width: auto;
                 margin-bottom: 0;
                 margin-right: spacing-horizontal(mid-small);
 

--- a/lms/templates/certificates/_accomplishment-banner.html
+++ b/lms/templates/certificates/_accomplishment-banner.html
@@ -34,6 +34,23 @@
                 <div class="message-actions">
                     <h3 class="sr-only">${_("Take this with you:")}</h3>
 
+                    <a href="" class="action action-share-facebook btn btn-overlay btn-small icon-only" id="action-share-facebook">
+                        <i class="icon fa fa-facebook-official" aria-hidden="true"></i>
+                        <span class="action-label">${_("Post this on Facebook")}</span>
+                    </a>
+
+                    <a href="" class="action action-share-twitter btn btn-overlay btn-small icon-only" id="action-share-twitter">
+                        <i class="icon fa fa-twitter" aria-hidden="true"></i>
+                        <span class="action-label">${_("Tweet this Accomplishment")}</span>
+                    </a>
+
+                    %if linked_in_url:
+                    <a class="action action-share-linkedin btn btn-overlay btn-small icon-only" id="action-share-linkedin" target="_blank" href="${linked_in_url}" title="${_('Add to LinkedIn Profile')}" data-course-id="${course_id}" data-certificate-mode="${course_mode}">
+                        <i class="icon fa fa-linkedin" aria-hidden="true"></i>
+                        <span class="action-label">${_("Add to LinkedIn Profile")}</span>
+                    </a>
+                    %endif
+
                     %if badge:
                     <button class="action action-share-mozillaopenbadges btn btn-overlay btn-small">
                         <img class="icon icon-mozillaopenbadges" src="/static/certificates/images/ico-mozillaopenbadges.png" alt="Mozilla Open Badges Backpack">
@@ -45,16 +62,6 @@
                         <i class="icon fa fa-print" aria-hidden="true"></i>
                         ${_("Print Certificate")}
                     </button>
-                %if linked_in_url:
-                    <a class="action-linkedin-profile" target="_blank" href="${linked_in_url}"
-                        title="${_('Add to LinkedIn Profile')}"
-                        data-course-id="${course_id}"
-                        data-certificate-mode="${course_mode}">
-                        <img class="action-linkedin-profile-img"
-                            src="${static.url('images/linkedin_add_to_profile.png')}"
-                            alt="${_('Add to LinkedIn Profile')}" />
-                    </a>
-                %endif
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This work revises share action order, styling, and markup to accommodate Facebook and Twitter options as well as make the layout more consistent.

This work still needs actual `href`` values for the new share actions (as well as any analytics tracking we want to place on them).

---

**Screenshot - Larger Layout**
![screen shot 2015-06-23 at 2 42 51 pm](https://cloud.githubusercontent.com/assets/163763/8314315/be5a2ca4-19b6-11e5-9efa-1e7f69dac246.png)

**Screenshot - Smaller Layout**
![screen shot 2015-06-23 at 2 42 56 pm](https://cloud.githubusercontent.com/assets/163763/8314322/c4c83dba-19b6-11e5-8aec-c6d0e824e749.png)

---
#### Reviewers
- [x] UI/FED - @frrrances 
- [x] Product - @pbaruah
