### PR TITLE
Remove duplicate logged-in-cookie helper methods

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1550,33 +1550,6 @@ def create_account_with_params(request, params):
             AUDIT_LOG.info(u"Login activated on extauth account - {0} ({1})".format(new_user.username, new_user.email))
 
 
-def set_marketing_cookie(request, response):
-    """
-    Set the login cookie for the edx marketing site on the given response. Its
-    expiration will match that of the given request's session.
-    """
-    if request.session.get_expire_at_browser_close():
-        max_age = None
-        expires = None
-    else:
-        max_age = request.session.get_expiry_age()
-        expires_time = time.time() + max_age
-        expires = cookie_date(expires_time)
-
-    # we want this cookie to be accessed via javascript
-    # so httponly is set to None
-    response.set_cookie(
-        settings.EDXMKTG_COOKIE_NAME,
-        'true',
-        max_age=max_age,
-        expires=expires,
-        domain=settings.SESSION_COOKIE_DOMAIN,
-        path='/',
-        secure=None,
-        httponly=None
-    )
-
-
 @csrf_exempt
 def create_account(request, post_override=None):
     """
@@ -1611,7 +1584,7 @@ def create_account(request, post_override=None):
         'success': True,
         'redirect_url': redirect_url,
     })
-    set_marketing_cookie(request, response)
+    set_logged_in_cookie(request, response)
     return response
 
 

--- a/openedx/core/djangoapps/user_api/views.py
+++ b/openedx/core/djangoapps/user_api/views.py
@@ -24,7 +24,8 @@ from openedx.core.lib.api.permissions import ApiKeyHeaderPermission
 import third_party_auth
 from django_comment_common.models import Role
 from edxmako.shortcuts import marketing_link
-from student.views import create_account_with_params, set_marketing_cookie
+from student.views import create_account_with_params
+from student.helpers import set_logged_in_cookie
 from openedx.core.lib.api.authentication import SessionAuthenticationAllowInactiveUser
 from util.json_request import JsonResponse
 from .preferences.api import update_email_opt_in
@@ -306,7 +307,7 @@ class RegistrationView(APIView):
             return JsonResponse(errors, status=400)
 
         response = JsonResponse({"success": True})
-        set_marketing_cookie(request, response)
+        set_logged_in_cookie(request, response)
         return response
 
     def _add_email_field(self, form_desc, required=True):


### PR DESCRIPTION
There were two helper methods that set the marketing site
"logged in" cookie.  This commit deletes one of them
and ensures that all callers are using the other one.

Preparation for [ECOM-1707](https://openedx.atlassian.net/browse/ECOM-1707).

@rlucioni please review.
