### PR TITLE
Remove restrictions on library creation in Studio (SOL-808)

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_libraries.py
+++ b/cms/djangoapps/contentstore/tests/test_libraries.py
@@ -523,13 +523,13 @@ class TestLibraryAccess(SignalDisconnectTestMixin, LibraryTestCase):
         self.client.logout()
         self._assert_cannot_create_library(expected_code=302)  # 302 redirect to login expected
 
-        # Now create a non-staff user with no permissions:
+        # Now check that logged-in users without CourseCreator role can still create libraries
         self._login_as_non_staff_user(logout_first=False)
         self.assertFalse(CourseCreatorRole().has_user(self.non_staff_user))
-
-        # Now check that logged-in users without any permissions cannot create libraries
         with patch.dict('django.conf.settings.FEATURES', {'ENABLE_CREATOR_GROUP': True}):
-            self._assert_cannot_create_library()
+            lib_key2 = self._create_library(library="lib2", display_name="Test Library 2")
+            library2 = modulestore().get_library(lib_key2)
+            self.assertIsNotNone(library2)
 
     @ddt.data(
         CourseInstructorRole,

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -458,6 +458,7 @@ def course_listing(request):
         'in_process_course_actions': in_process_course_actions,
         'libraries_enabled': LIBRARIES_ENABLED,
         'libraries': [format_library_for_view(lib) for lib in libraries],
+        'show_new_library_button': LIBRARIES_ENABLED and request.user.is_active,
         'user': request.user,
         'request_course_creator_url': reverse('contentstore.views.request_course_creator'),
         'course_creator_status': _get_course_creator_status(request.user),

--- a/cms/djangoapps/contentstore/views/library.py
+++ b/cms/djangoapps/contentstore/views/library.py
@@ -30,7 +30,7 @@ from .component import get_component_templates, CONTAINER_TEMPLATES
 from student.auth import (
     STUDIO_VIEW_USERS, STUDIO_EDIT_ROLES, get_user_permissions, has_studio_read_access, has_studio_write_access
 )
-from student.roles import CourseCreatorRole, CourseInstructorRole, CourseStaffRole, LibraryUserRole
+from student.roles import CourseInstructorRole, CourseStaffRole, LibraryUserRole
 from student import auth
 from util.json_request import expect_json, JsonResponse, JsonResponseBadRequest
 
@@ -115,9 +115,6 @@ def _create_library(request):
     """
     Helper method for creating a new library.
     """
-    if not auth.has_access(request.user, CourseCreatorRole()):
-        log.exception(u"User %s tried to create a library without permission", request.user.username)
-        raise PermissionDenied()
     display_name = None
     try:
         display_name = request.json['display_name']

--- a/cms/djangoapps/contentstore/views/tests/test_library.py
+++ b/cms/djangoapps/contentstore/views/tests/test_library.py
@@ -87,8 +87,8 @@ class UnitTestLibraries(ModuleStoreTestCase):
     @patch.dict('django.conf.settings.FEATURES', {'ENABLE_CREATOR_GROUP': True})
     def test_lib_create_permission(self):
         """
-        Users who aren't given course creator roles shouldn't be able to create
-        libraries either.
+        Users who are not given course creator roles should still be able to
+        create libraries.
         """
         self.client.logout()
         ns_user, password = self.create_non_staff_user()
@@ -97,7 +97,7 @@ class UnitTestLibraries(ModuleStoreTestCase):
         response = self.client.ajax_post(LIBRARY_REST_URL, {
             'org': 'org', 'library': 'lib', 'display_name': "New Library",
         })
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 200)
 
     @ddt.data(
         {},

--- a/cms/templates/index.html
+++ b/cms/templates/index.html
@@ -24,12 +24,12 @@
           % if course_creator_status=='granted':
           <a href="#" class="button new-button new-course-button"><i class="icon fa fa-plus icon-inline"></i>
               ${_("New Course")}</a>
-            % if libraries_enabled:
-              <a href="#" class="button new-button new-library-button"><i class="icon fa fa-plus icon-inline"></i>
-              ${_("New Library")}</a>
-            % endif
           % elif course_creator_status=='disallowed_for_this_site' and settings.FEATURES.get('STUDIO_REQUEST_EMAIL',''):
           <a href="mailto:${settings.FEATURES.get('STUDIO_REQUEST_EMAIL','')}">${_("Email staff to create course")}</a>
+          % endif
+          % if show_new_library_button:
+            <a href="#" class="button new-button new-library-button"><i class="icon fa fa-plus icon-inline"></i>
+            ${_("New Library")}</a>
           % endif
         </li>
       </ul>
@@ -449,7 +449,7 @@
               </div>
           </div>
         </div>
-        %if course_creator_status == "granted":
+        % if show_new_library_button:
         <div class="notice-item has-actions">
           <div class="msg">
               <h3 class="title">${_('Create Your First Library')}</h3>
@@ -464,7 +464,7 @@
           </li>
         </ul>
         </div>
-        %endif
+        % endif
       </div>
       %endif
 


### PR DESCRIPTION
**Description**:
Currently, only Studio users with the `CourseCreatorRole` are able to create new libraries in Studio. With this change, any user who has access to Studio can also create new libraries.

**JIRA Story**: [SOL-808](https://openedx.atlassian.net/browse/SOL-808)

**Dependencies**: None

**Sandbox**: http://sandbox2.opencraft.com:18010/ but it's hard to tell any difference

**Screenshot**:
![screen shot](https://cloud.githubusercontent.com/assets/945577/8320646/71e878be-19d2-11e5-945f-2ef3406932bb.png)

**Reviewers**: @e-kolpakov and @mattdrayer
