### PR TITLE
Move forgot_password_modal to login.html.

### DIFF
--- a/lms/templates/login.html
+++ b/lms/templates/login.html
@@ -130,6 +130,8 @@ from microsite_configuration import microsite
   </script>
 </%block>
 
+<%include file="forgot_password_modal.html" />
+
 <section class="introduction">
   <header>
     <h1 class="title">
@@ -239,4 +241,3 @@ from microsite_configuration import microsite
 
   </aside>
   </section>
-

--- a/lms/templates/navigation-edx.html
+++ b/lms/templates/navigation-edx.html
@@ -150,8 +150,4 @@ site_status_msg = get_site_status_msg(course_id)
 <![endif]-->
 % endif
 
-%if not user.is_authenticated():
-  <%include file="forgot_password_modal.html" />
-%endif
-
 <%include file="help_modal.html"/>

--- a/lms/templates/navigation.html
+++ b/lms/templates/navigation.html
@@ -156,8 +156,4 @@ site_status_msg = get_site_status_msg(course_id)
 <![endif]-->
 % endif
 
-%if not user.is_authenticated():
-  <%include file="forgot_password_modal.html" />
-%endif
-
 <%include file="help_modal.html"/>


### PR DESCRIPTION
That is the only place using it (note that dashboard no longer does, since the settings/profile work). Moving it out of the general navigation.html files will make the RequireJS optimizer work easier.
