### PR TITLE
MA-879 Fix bug in course_start_datetime_text

### DIFF
--- a/common/lib/xmodule/xmodule/course_metadata_utils.py
+++ b/common/lib/xmodule/xmodule/course_metadata_utils.py
@@ -157,12 +157,13 @@ def course_start_datetime_text(start_date, advertised_start, format_string, uget
         try:
             # from_json either returns a Date, returns None, or raises a ValueError
             parsed_advertised_start = Date().from_json(advertised_start)
+            if parsed_advertised_start is not None:
+                # In the Django implementation of strftime_localized, if
+                # the year is <1900, _datetime_to_string will raise a ValueError.
+                return _datetime_to_string(parsed_advertised_start, format_string, strftime_localized)
         except ValueError:
-            parsed_advertised_start = None
-        return (
-            _datetime_to_string(parsed_advertised_start, format_string, strftime_localized) if parsed_advertised_start
-            else advertised_start.title()
-        )
+            pass
+        return advertised_start.title()
     elif start_date != DEFAULT_START_DATE:
         return _datetime_to_string(start_date, format_string, strftime_localized)
     else:


### PR DESCRIPTION
See https://openedx.atlassian.net/browse/MA-879 for bug description.

**Problem**
- In original `start_datetime_text` function, the call to `strftime_localized` was wrapped in a `try/except`.
- In the new implementation of `course_start_datetime_text`, introduced in [PR#8484](https://github.com/pull/8484), the call was moved outside of the `try/catch`.
- When exposed to production data, this caused an uncaught `ValueError` to be raised.

**Solution**
- Put call to `strftime_localized` back in `try/except`.
- Add test scenario with data that causes `strftime_localized` to raise.

Reviewers: @nasthagiri, @doctoryes 
FYI: @BenjiLee 
