### PR TITLE
Make "View Updates in Studio" link appear TNL-2467

### DIFF
--- a/lms/djangoapps/courseware/masquerade.py
+++ b/lms/djangoapps/courseware/masquerade.py
@@ -74,6 +74,12 @@ def setup_masquerade(request, course_key, staff_access=False):
         return None
 
     masquerade_settings = request.session.get(MASQUERADE_SETTINGS_KEY, {})
+    if not masquerade_settings:
+        masquerade_settings[course_key] = CourseMasquerade(
+            course_key,
+            role='staff',
+        )
+        request.session[MASQUERADE_SETTINGS_KEY] = masquerade_settings
 
     # Store the masquerade settings on the user so it can be accessed without the request
     request.user.masquerade_settings = masquerade_settings


### PR DESCRIPTION
It was not displaying because no initial masquerade setting is assigned.
The old masquerade code that was removed did: https://github.com/edx/edx-platform/commit/561c57dbe9c26f518e177f0934c876492641b3c7#diff-2ad237e74ccb2af44c5817cc78d4a732L50

So I just added back the updated equivalent of that assignment.

https://openedx.atlassian.net/browse/TNL-2467
@andy-armstrong 
