### PR TITLE
Fixes DOC-1715, video doc is now in the correct RTD project

### DIFF
--- a/docs/config.ini
+++ b/docs/config.ini
@@ -39,7 +39,7 @@ content_libraries = creating_content/libraries.html
 content_groups = cohorts/cohorted_courseware.html
 group_configurations = content_experiments/content_experiments_configure.html#set-up-group-configurations-in-edx-studio
 container = developing_course/course_components.html#components-that-contain-other-components
-video = index.html
+video = video/video_uploads.html
 certificates = building_course/creating_course_certificates.html
 
 # below are the language directory names for the different locales


### PR DESCRIPTION
@mhoeber this changes the video token to link to the new location for video upload procedures. See https://openedx.atlassian.net/browse/DOC-1715 and https://github.com/edx/edx-documentation/pull/406
