### PR TITLE
Make resetting of attempts and student state on blocks recursive. (SOL-858)

### DIFF
--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -8,7 +8,6 @@ import random
 import pytz
 import io
 import json
-import os
 import requests
 import shutil
 import tempfile

--- a/lms/djangoapps/instructor/tests/test_enrollment.py
+++ b/lms/djangoapps/instructor/tests/test_enrollment.py
@@ -13,7 +13,8 @@ from django.utils.translation import get_language
 from django.utils.translation import override as override_language
 from nose.plugins.attrib import attr
 from student.tests.factories import UserFactory
-from xmodule.modulestore.tests.factories import CourseFactory
+from xmodule.modulestore.django import modulestore
+from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
 from student.models import CourseEnrollment, CourseEnrollmentAllowed
 from instructor.enrollment import (
@@ -295,31 +296,102 @@ class TestInstructorUnenrollDB(TestEnrollmentChangeBase):
 
 
 @attr('shard_1')
-class TestInstructorEnrollmentStudentModule(TestCase):
+class TestInstructorEnrollmentStudentModule(ModuleStoreTestCase):
     """ Test student module manipulations. """
     def setUp(self):
         super(TestInstructorEnrollmentStudentModule, self).setUp()
-        self.course_key = SlashSeparatedCourseKey('fake', 'course', 'id')
+        store = modulestore()
+        self.user = UserFactory()
+        self.course = CourseFactory(
+            name='fake',
+            org='course',
+            run='id',
+        )
+        # pylint: disable=no-member
+        self.course_key = self.course.location.course_key
+        self.parent = ItemFactory(
+            category="library_content",
+            # pylint: disable=no-member
+            user_id=self.user.id,
+            parent=self.course,
+            publish_item=True,
+            modulestore=store,
+        )
+        self.child = ItemFactory(
+            category="html",
+            # pylint: disable=no-member
+            user_id=self.user.id,
+            parent=self.parent,
+            publish_item=True,
+            modulestore=store,
+        )
+        self.unrelated = ItemFactory(
+            category="html",
+            # pylint: disable=no-member
+            user_id=self.user.id,
+            parent=self.course,
+            publish_item=True,
+            modulestore=store,
+        )
+        parent_state = json.dumps({'attempts': 32, 'otherstuff': 'alsorobots'})
+        child_state = json.dumps({'attempts': 10, 'whatever': 'things'})
+        unrelated_state = json.dumps({'attempts': 12, 'brains': 'zombie'})
+        StudentModule.objects.create(
+            student=self.user,
+            course_id=self.course_key,
+            module_state_key=self.parent.location,
+            state=parent_state,
+        )
+        StudentModule.objects.create(
+            student=self.user,
+            course_id=self.course_key,
+            module_state_key=self.child.location,
+            state=child_state,
+        )
+        StudentModule.objects.create(
+            student=self.user,
+            course_id=self.course_key,
+            module_state_key=self.unrelated.location,
+            state=unrelated_state,
+        )
 
     def test_reset_student_attempts(self):
-        user = UserFactory()
         msk = self.course_key.make_usage_key('dummy', 'module')
         original_state = json.dumps({'attempts': 32, 'otherstuff': 'alsorobots'})
-        StudentModule.objects.create(student=user, course_id=self.course_key, module_state_key=msk, state=original_state)
+        StudentModule.objects.create(
+            student=self.user,
+            course_id=self.course_key,
+            module_state_key=msk,
+            state=original_state
+        )
         # lambda to reload the module state from the database
-        module = lambda: StudentModule.objects.get(student=user, course_id=self.course_key, module_state_key=msk)
+        module = lambda: StudentModule.objects.get(student=self.user, course_id=self.course_key, module_state_key=msk)
         self.assertEqual(json.loads(module().state)['attempts'], 32)
-        reset_student_attempts(self.course_key, user, msk)
+        reset_student_attempts(self.course_key, self.user, msk)
         self.assertEqual(json.loads(module().state)['attempts'], 0)
 
     def test_delete_student_attempts(self):
-        user = UserFactory()
         msk = self.course_key.make_usage_key('dummy', 'module')
         original_state = json.dumps({'attempts': 32, 'otherstuff': 'alsorobots'})
-        StudentModule.objects.create(student=user, course_id=self.course_key, module_state_key=msk, state=original_state)
-        self.assertEqual(StudentModule.objects.filter(student=user, course_id=self.course_key, module_state_key=msk).count(), 1)
-        reset_student_attempts(self.course_key, user, msk, delete_module=True)
-        self.assertEqual(StudentModule.objects.filter(student=user, course_id=self.course_key, module_state_key=msk).count(), 0)
+        StudentModule.objects.create(
+            student=self.user,
+            course_id=self.course_key,
+            module_state_key=msk,
+            state=original_state
+        )
+        self.assertEqual(
+            StudentModule.objects.filter(
+                student=self.user,
+                course_id=self.course_key,
+                module_state_key=msk
+            ).count(), 1)
+        reset_student_attempts(self.course_key, self.user, msk, delete_module=True)
+        self.assertEqual(
+            StudentModule.objects.filter(
+                student=self.user,
+                course_id=self.course_key,
+                module_state_key=msk
+            ).count(), 0)
 
     def test_delete_submission_scores(self):
         user = UserFactory()
@@ -352,6 +424,61 @@ class TestInstructorEnrollmentStudentModule(TestCase):
         # Verify that the student's scores have been reset in the submissions API
         score = sub_api.get_score(student_item)
         self.assertIs(score, None)
+
+    def get_state(self, location):
+        """Reload and grab the module state from the database"""
+        return StudentModule.objects.get(
+            student=self.user, course_id=self.course_key, module_state_key=location
+        ).state
+
+    def test_reset_student_attempts_children(self):
+        parent_state = json.loads(self.get_state(self.parent.location))
+        self.assertEqual(parent_state['attempts'], 32)
+        self.assertEqual(parent_state['otherstuff'], 'alsorobots')
+
+        child_state = json.loads(self.get_state(self.child.location))
+        self.assertEqual(child_state['attempts'], 10)
+        self.assertEqual(child_state['whatever'], 'things')
+
+        unrelated_state = json.loads(self.get_state(self.unrelated.location))
+        self.assertEqual(unrelated_state['attempts'], 12)
+        self.assertEqual(unrelated_state['brains'], 'zombie')
+
+        reset_student_attempts(self.course_key, self.user, self.parent.location)
+
+        parent_state = json.loads(self.get_state(self.parent.location))
+        self.assertEqual(json.loads(self.get_state(self.parent.location))['attempts'], 0)
+        self.assertEqual(parent_state['otherstuff'], 'alsorobots')
+
+        child_state = json.loads(self.get_state(self.child.location))
+        self.assertEqual(child_state['attempts'], 0)
+        self.assertEqual(child_state['whatever'], 'things')
+
+        unrelated_state = json.loads(self.get_state(self.unrelated.location))
+        self.assertEqual(unrelated_state['attempts'], 12)
+        self.assertEqual(unrelated_state['brains'], 'zombie')
+
+    def test_delete_submission_scores_attempts_children(self):
+        parent_state = json.loads(self.get_state(self.parent.location))
+        self.assertEqual(parent_state['attempts'], 32)
+        self.assertEqual(parent_state['otherstuff'], 'alsorobots')
+
+        child_state = json.loads(self.get_state(self.child.location))
+        self.assertEqual(child_state['attempts'], 10)
+        self.assertEqual(child_state['whatever'], 'things')
+
+        unrelated_state = json.loads(self.get_state(self.unrelated.location))
+        self.assertEqual(unrelated_state['attempts'], 12)
+        self.assertEqual(unrelated_state['brains'], 'zombie')
+
+        reset_student_attempts(self.course_key, self.user, self.parent.location, delete_module=True)
+
+        self.assertRaises(StudentModule.DoesNotExist, self.get_state, self.parent.location)
+        self.assertRaises(StudentModule.DoesNotExist, self.get_state, self.child.location)
+
+        unrelated_state = json.loads(self.get_state(self.unrelated.location))
+        self.assertEqual(unrelated_state['attempts'], 12)
+        self.assertEqual(unrelated_state['brains'], 'zombie')
 
 
 class EnrollmentObjects(object):


### PR DESCRIPTION
**Background**: This PR allows for the instructor API to recursively reset the state of a block in the course.
**Jira tickets**: Implements [SOL-858](https://openedx.atlassian.net/browse/SOL-858)
**Partner information**: For an edX solutions client, on edx.org.
**Sandbox**: Studio: http://sandbox3.opencraft.com:18010/ LMS: http://sandbox3.opencraft.com/

Testing instructions:
1. Create a library with multiple problem blocks (Or use the provided one, "Problems").
2. Add "library_content" to the advanced modules of a course you wish to test the functionality in (The course "Real Problem Reset Demo" has already been created to showcase the functionality).
3. Use the Advanced menu to create a new Randomized Content Block, and set its library to point to your target library (Or use the preconfigured block in the provided course).
4. View the unit in the LMS. Answer a problem, and refresh to verify it remembers your answer. Use the Staff debug menu under the problem to delete the student state for the problem. Refresh, and the state should be gone.
5. Also use the staff debug menu at the bottom of the RCB to clear out the state for ALL blocks under it, and verify that not only is a new selection of blocks made, but if any of the blocks are ones that were picked before, they did not retain the previous answers given.
