### PR TITLE
Clean up capa polling to have exponential backoff

### DIFF
--- a/common/lib/capa/capa/templates/matlabinput.html
+++ b/common/lib/capa/capa/templates/matlabinput.html
@@ -49,9 +49,8 @@
   </div>
   %endif
 
-  <script>
+  <script type="text/javascript">
     $(function(){
-      var IntervalManager, PendingMatlabResult;
       var gentle_alert = function (parent_elt, msg) {
           if($(parent_elt).find('.capa_alert').length) {
               $(parent_elt).find('.capa_alert').remove();
@@ -63,7 +62,6 @@
 
       // hook up the plot button
       var plot = function(event) {
-          var matlab_result_task;
           var problem_elt = $(event.target).closest('.problems-wrapper');
           url = $(event.target).closest('.problems-wrapper').data('url');
           input_id = "${id}";
@@ -82,27 +80,36 @@
           answer = input.serialize();
 
           // a chain of callbacks, each querying the server on success of the previous one
-
-          var get_callback = function(response) {
-              var new_result_elem = $(response.html).find(".ungraded-matlab-result").html();
-              var external_grader_msg = $(response.html).find(".external-grader-message").html();
-              result_elem = $(problem_elt).find(".ungraded-matlab-result");
-              result_elem.addClass("is-fading-in");
-              result_elem.html(new_result_elem);
-              external_grader_msg_elem = $(problem_elt).find(".external-grader-message");
-              external_grader_msg_elem.addClass("is-fading-in");
-              external_grader_msg_elem.html(external_grader_msg);
-              if (!external_grader_msg.trim()) {
-                  matlab_result_task.task_poller.stop();
-              } else {
-                  result_elem.html('');
-              }
+          var poll = function(prev_timeout) {
+              $.postWithPrefix(url + "/problem_get", function(response) {
+                   var new_result_elem = $(response.html).find(".ungraded-matlab-result").html();
+                   var external_grader_msg = $(response.html).find(".external-grader-message").html();
+                   var result_elem = $(problem_elt).find(".ungraded-matlab-result");
+                   result_elem.addClass("is-fading-in");
+                   result_elem.html(new_result_elem);
+                   var external_grader_msg_elem = $(problem_elt).find(".external-grader-message");
+                   external_grader_msg_elem.addClass("is-fading-in");
+                   external_grader_msg_elem.html(external_grader_msg);
+                   // If we have a message about waiting for the external grader.
+                   if (external_grader_msg.trim()) {
+                        result_elem.html('');
+                        // Setup the polling for the next round
+                        var next_timeout = prev_timeout * 2;
+                        // The XML parsing that capa uses doesn't handle the greater-than symbol properly here, so we are forced to work around it.
+                        // The backend MatlabInput code will also terminate after 35 seconds, so this is mostly a protective measure.
+                        if (next_timeout === 64000) {
+                            gentle_alert(problem_elt, gettext("Your code is still being run. Refresh the page to see updates."));
+                        }
+                        window.setTimeout(function(){ poll(next_timeout); }, next_timeout);
+                   }
+              });
           };
 
           var plot_callback = function(response) {
               if(response.success) {
-                  matlab_result_task = new PendingMatlabResult(get_callback);
-                  matlab_result_task.task_poller.start();
+                  // If successful, start polling.
+                  // If we change the initial polling value, we will also need to change the check within poll (next_time === 64000) to match it.
+                  poll(1000);
               } else {
                   // Used response.message because input_ajax is returning "message"
                   gentle_alert(problem_elt, response.message);
@@ -126,55 +133,6 @@
       };
       $('#plot_${id}').click(plot);
 
-      // Copied from lms/static/coffee/src/instructor_dashboard/util.js
-      IntervalManager = (function() {
-
-        function IntervalManager(ms, fn) {
-          this.ms = ms;
-          this.fn = fn;
-          this.intervalID = null;
-        }
-
-        IntervalManager.prototype.start = function() {
-          this.fn();
-          if (this.intervalID === null) {
-            return this.intervalID = setInterval(this.fn, this.ms);
-          }
-        };
-
-        IntervalManager.prototype.stop = function() {
-          clearInterval(this.intervalID);
-          return this.intervalID = null;
-        };
-
-        return IntervalManager;
-
-      })();
-
-      PendingMatlabResult = (function() {
-        /* Pending Matlab Result Section
-        */
-
-        function PendingMatlabResult(get_callback) {
-          var MATLAB_RESULT_POLL_INTERVAL,
-            _this = this;
-          this.reload_matlab_result = function(get_callback) {
-            return PendingMatlabResult.prototype.reload_matlab_result.apply(_this, arguments);
-          };
-          MATLAB_RESULT_POLL_INTERVAL = 1000;
-          this.reload_matlab_result(get_callback);
-          this.task_poller = new IntervalManager(MATLAB_RESULT_POLL_INTERVAL, function() {
-            return _this.reload_matlab_result(get_callback);
-          });
-        }
-
-        PendingMatlabResult.prototype.reload_matlab_result = function(get_callback) {
-          return $.postWithPrefix(url + "/problem_get", get_callback)
-        };
-
-        return PendingMatlabResult;
-
-        })();
     });
   </script>
 </section>

--- a/common/lib/xmodule/xmodule/js/fixtures/matlabinput_problem.html
+++ b/common/lib/xmodule/xmodule/js/fixtures/matlabinput_problem.html
@@ -1,0 +1,43 @@
+<div class="problem">
+    <div aria-live="polite">
+        <div>
+  <span>
+    <p>
+    <p></p>
+  </span>
+  <span><section id="textbox_test_matlab_plot1_2_1" class="capa_inputtype cminput">
+    <textarea rows="10" cols="80" name="input_i4x-MITx-2_01x-problem-test_matlab_plot1_2_1" aria-describedby="answer_i4x-MITx-2_01x-problem-test_matlab_plot1_2_1" id="input_i4x-MITx-2_01x-problem-test_matlab_plot1_2_1" data-tabsize="4" data-mode="octave" data-linenums="true" style="display: none;">This is the MATLAB input, whatever that may be.</textarea>
+
+  <div class="grader-status" tabindex="-1">
+      <span id="status_test_matlab_plot1_2_1" class="processing" aria-describedby="input_test_matlab_plot1_2_1">
+          <span class="status sr">processing</span>
+      </span>
+      <span style="display:none;" class="xqueue" id="test_matlab_plot1_2_1">1</span>
+
+
+    <p class="debug">processing</p>
+  </div>
+
+  <span id="answer_test_matlab_plot1_2_1"></span>
+
+  <div class="external-grader-message" aria-live="polite">
+    Submitted. As soon as a response is returned, this message will be replaced by that feedback.
+  </div>
+  <div class="ungraded-matlab-result" aria-live="polite">
+    
+  </div>
+
+  <div class="plot-button">
+      <input type="button" class="save" name="plot-button" id="plot_test_matlab_plot1_2_1" value="Run Code">
+  </div>
+
+  
+</section></span>
+</div>
+    </div>
+  <div class="action">
+    <input type="hidden" name="problem_id" value="Plot a straight line">
+    <button class="reset" data-value="Reset">Reset<span class="sr"> your answer</span></button>
+    <button class="show"><span class="show-label">Show Answer</span> </button>
+  </div>
+</div>

--- a/common/lib/xmodule/xmodule/js/spec/capa/display_spec.coffee
+++ b/common/lib/xmodule/xmodule/js/spec/capa/display_spec.coffee
@@ -628,3 +628,31 @@ describe 'Problem', ->
     it 'check_save_waitfor should return false', ->
       $(@problem.inputs[0]).data('waitfor', ->)
       expect(@problem.check_save_waitfor()).toEqual(false)
+
+  describe 'Submitting an xqueue-graded problem', ->
+    matlabinput_html = readFixtures('matlabinput_problem.html')
+
+    beforeEach ->
+      spyOn($, 'postWithPrefix').andCallFake (url, callback) ->
+        callback html: matlabinput_html
+      jasmine.Clock.useMock()
+      @problem = new Problem($('.xblock-student_view'))
+      spyOn(@problem, 'poll').andCallThrough()
+      @problem.render(matlabinput_html)
+
+    it 'check that we stop polling after a fixed amount of time', ->
+      expect(@problem.poll).not.toHaveBeenCalled()
+      jasmine.Clock.tick(1)
+      time_steps = [1000, 2000, 4000, 8000, 16000, 32000]
+      num_calls = 1
+      for time_step in time_steps
+        do (time_step) =>
+          jasmine.Clock.tick(time_step)
+          expect(@problem.poll.callCount).toEqual(num_calls)
+          num_calls += 1
+
+      # jump the next step and verify that we are not still continuing to poll
+      jasmine.Clock.tick(64000)
+      expect(@problem.poll.callCount).toEqual(6)
+
+      expect($('.capa_alert').text()).toEqual("The grading process is still running. Refresh the page to see updates.")


### PR DESCRIPTION
Stop polling when the backoff reaches one minute and display a message alerting the user on what they need to do next.

Reviewers: @peter-fogg @cahrens 
Text Review: @catong (There's two strings that are pretty much the same).

FYI: @ormsbee 

https://openedx.atlassian.net/browse/TNL-2557
