### PR TITLE
Fix not being able to set course passing grades above 80%.

### DIFF
--- a/cms/static/coffee/spec/models/settings_grading_spec.coffee
+++ b/cms/static/coffee/spec/models/settings_grading_spec.coffee
@@ -1,4 +1,4 @@
-define ["js/models/settings/course_grading_policy"], (CourseGradingPolicy) ->
+define ["underscore", "js/models/settings/course_grading_policy"], (_, CourseGradingPolicy) ->
     describe "CourseGradingPolicy", ->
         beforeEach ->
             @model = new CourseGradingPolicy()
@@ -23,3 +23,14 @@ define ["js/models/settings/course_grading_policy"], (CourseGradingPolicy) ->
                 expect(@model.parseGracePeriod("asdf")).toBe(null)
                 expect(@model.parseGracePeriod("7:19")).toBe(null)
                 expect(@model.parseGracePeriod("1000:00")).toBe(null)
+
+        describe "validate", ->
+            it "enforces that the passing grade is <= the minimum grade to receive credit if credit is enabled", ->
+                @model.set({minimum_grade_credit: 0.8, grace_period: '01:00', is_credit_course: true})
+                @model.set('grade_cutoffs', [0.9], validate: true)
+                expect(_.keys(@model.validationError)).toContain('minimum_grade_credit')
+
+            it "does not enforce the passing grade limit in non-credit courses", ->
+                @model.set({minimum_grade_credit: 0.8, grace_period: '01:00', is_credit_course: false})
+                @model.set({grade_cutoffs: [0.9]}, validate: true)
+                expect(@model.validationError).toBe(null)

--- a/cms/static/js/models/settings/course_grading_policy.js
+++ b/cms/static/js/models/settings/course_grading_policy.js
@@ -76,7 +76,7 @@ var CourseGradingPolicy = Backbone.Model.extend({
                 }
             }
         }
-        if(_.has(attrs, 'minimum_grade_credit')) {
+        if(this.get('is_credit_course') && _.has(attrs, 'minimum_grade_credit')) {
             var minimum_grade_cutoff = _.values(attrs.grade_cutoffs).pop();
             if(isNaN(attrs.minimum_grade_credit) || attrs.minimum_grade_credit === null || attrs.minimum_grade_credit < minimum_grade_cutoff) {
                 return {

--- a/cms/templates/settings_graders.html
+++ b/cms/templates/settings_graders.html
@@ -5,6 +5,7 @@
 
 <%namespace name='static' file='static_content.html'/>
 <%!
+  import json
   from contentstore import utils
   from django.utils.translation import ugettext as _
 %>
@@ -22,7 +23,7 @@
 </%block>
 <%block name="requirejs">
     require(["js/factories/settings_graders"], function(SettingsGradersFactory) {
-        SettingsGradersFactory(${course_details|n}, "${grading_url}");
+        SettingsGradersFactory(_.extend(${course_details|n}, {is_credit_course: ${json.dumps(is_credit_course)}}), "${grading_url}");
     });
 </%block>
 


### PR DESCRIPTION
[TNL-2582](https://openedx.atlassian.net/browse/TNL-2582)

@cahrens @explorerleslie This is the least invasive fix I could make. It seems like this may actually be the intended behavior for courses which have credit enabled, but in non-credit courses it's just leading to a silent failure.

Sandbox is [here](http://studio.peter-fogg.m.sandbox.edx.org).
