### PR TITLE
Set Courseware Search to False in default devstack, because it doesn't work.

### DIFF
--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -121,7 +121,7 @@ FEATURES['LICENSING'] = True
 
 
 ########################## Courseware Search #######################
-FEATURES['ENABLE_COURSEWARE_SEARCH'] = True
+FEATURES['ENABLE_COURSEWARE_SEARCH'] = False
 SEARCH_ENGINE = "search.elastic.ElasticSearchEngine"
 
 


### PR DESCRIPTION
Courseware search breaks in Devstack. We do **not** want this released with Cypress; it's a terrible on-boarding experience, and may cause users to get frustrated and discontinue using our project. On devstack, one cannot see any courses or enroll in new courses:

![screen shot 2015-06-24 at 3 19 06 pm](https://cloud.githubusercontent.com/assets/1985317/8385615/807d4462-1c17-11e5-98ba-dfe483e5ab42.png)

This should be off by default in Devstack until it works properly.

@chrisndodge @pbaruah 
