### PR TITLE
Improve logging of ecommerce interactions

### DIFF
--- a/lms/djangoapps/commerce/tests/test_utils.py
+++ b/lms/djangoapps/commerce/tests/test_utils.py
@@ -1,0 +1,18 @@
+"""Tests of commerce utilities."""
+from django.test import TestCase
+from mock import patch
+
+from commerce.utils import audit_log
+
+
+class AuditLogTests(TestCase):
+    """Tests of the commerce audit logging helper."""
+    @patch('commerce.utils.log')
+    def test_log_message(self, mock_log):
+        """Verify that log messages are constructed correctly."""
+        audit_log('foo', qux='quux', bar='baz')
+
+        # Verify that the logged message contains comma-separated
+        # key-value pairs ordered alphabetically by key.
+        message = 'foo: bar="baz", qux="quux"'
+        self.assertTrue(mock_log.info.called_with(message))

--- a/lms/djangoapps/commerce/tests/test_views.py
+++ b/lms/djangoapps/commerce/tests/test_views.py
@@ -162,7 +162,11 @@ class BasketsViewTests(EnrollmentEventTestMixin, UserMixin, ModuleStoreTestCase)
         """
         Verifies that the view contacts the E-Commerce API with the correct data and headers.
         """
-        response = self._post_to_view()
+        with mock.patch('commerce.views.audit_log') as mock_audit_log:
+            response = self._post_to_view()
+
+            # Verify that an audit message was logged
+            self.assertTrue(mock_audit_log.called)
 
         # Validate the response content
         if is_completed:

--- a/lms/djangoapps/commerce/utils.py
+++ b/lms/djangoapps/commerce/utils.py
@@ -1,0 +1,34 @@
+"""Utilities to assist with commerce tasks."""
+import logging
+
+
+log = logging.getLogger(__name__)
+
+
+def audit_log(name, **kwargs):
+    """DRY helper used to emit an INFO-level log message.
+
+    Messages logged with this function are used to construct an audit trail. Log messages
+    should be emitted immediately after the event they correspond to has occurred and, if
+    applicable, after the database has been updated. These log messages use a verbose
+    key-value pair syntax to make it easier to extract fields when parsing the application's
+    logs.
+
+    This function is variadic, accepting a variable number of keyword arguments.
+
+    Arguments:
+        name (str): The name of the message to log. For example, 'payment_received'.
+
+    Keyword Arguments:
+        Indefinite. Keyword arguments are strung together as comma-separated key-value
+        pairs ordered alphabetically by key in the resulting log message.
+
+    Returns:
+        None
+    """
+    # Joins sorted keyword argument keys and values with an "=", wraps each value
+    # in quotes, and separates each pair with a comma and a space.
+    payload = u', '.join(['{k}="{v}"'.format(k=k, v=v) for k, v in sorted(kwargs.items())])
+    message = u'{name}: {payload}'.format(name=name, payload=payload)
+
+    log.info(message)

--- a/lms/djangoapps/commerce/views.py
+++ b/lms/djangoapps/commerce/views.py
@@ -16,6 +16,7 @@ from commerce import ecommerce_api_client
 from commerce.constants import Messages
 from commerce.exceptions import InvalidResponseError
 from commerce.http import DetailResponse, InternalRequestErrorResponse
+from commerce.utils import audit_log
 from course_modes.models import CourseMode
 from courseware import courses
 from edxmako.shortcuts import render_to_response
@@ -126,7 +127,7 @@ class BasketsView(APIView):
                 # Pass data to the client to begin the payment flow.
                 return JsonResponse(payment_data)
             elif response_data['order']:
-                # The order was completed immediately because there isno charge.
+                # The order was completed immediately because there is no charge.
                 msg = Messages.ORDER_COMPLETED.format(order_number=response_data['order']['number'])
                 log.debug(msg)
                 return DetailResponse(msg)
@@ -140,6 +141,14 @@ class BasketsView(APIView):
         except (exceptions.SlumberBaseException, exceptions.Timeout) as ex:
             log.exception(ex.message)
             return InternalRequestErrorResponse(ex.message)
+        finally:
+            audit_log(
+                'checkout_requested',
+                course_id=course_id,
+                mode=honor_mode.slug,
+                processor_name=None,
+                user_id=user.id
+            )
 
 
 @csrf_exempt

--- a/lms/djangoapps/verify_student/tests/test_views.py
+++ b/lms/djangoapps/verify_student/tests/test_views.py
@@ -1028,7 +1028,7 @@ class TestCheckoutWithEcommerceService(ModuleStoreTestCase):
         ecommerce api, we correctly call to that api to create a basket.
         """
         user = UserFactory.create(username="test-username")
-        course_mode = CourseModeFactory(sku="test-sku")
+        course_mode = CourseModeFactory(sku="test-sku").to_tuple()  # pylint: disable=no-member
         expected_payment_data = {'foo': 'bar'}
         # mock out the payment processors endpoint
         httpretty.register_uri(
@@ -1037,15 +1037,26 @@ class TestCheckoutWithEcommerceService(ModuleStoreTestCase):
             body=json.dumps({'payment_data': expected_payment_data}),
             content_type="application/json",
         )
-        # call the function
-        actual_payment_data = checkout_with_ecommerce_service(user, 'dummy-course-key', course_mode, 'test-processor')
-        # check the api call
+
+        with mock.patch('verify_student.views.audit_log') as mock_audit_log:
+            # Call the function
+            actual_payment_data = checkout_with_ecommerce_service(
+                user,
+                'dummy-course-key',
+                course_mode,
+                'test-processor'
+            )
+
+            # Verify that an audit message was logged
+            self.assertTrue(mock_audit_log.called)
+
+        # Check the api call
         self.assertEqual(json.loads(httpretty.last_request().body), {
             'products': [{'sku': 'test-sku'}],
             'checkout': True,
             'payment_processor_name': 'test-processor',
         })
-        # check the response
+        # Check the response
         self.assertEqual(actual_payment_data, expected_payment_data)
 
 


### PR DESCRIPTION
Adds logging of LMS checkout requests and requested enrollment changes.  [XCOM-427](https://openedx.atlassian.net/browse/XCOM-427). This is a work in progress, but I'd appreciate some eyes.

The LMS doesn't currently install `testfixtures`, so testing these log messages won't be practical without adding a dependency. Is it worth it?

@clintonb @jimabramson 
