### PR TITLE
Fix: users without course creation permission were not shown new libr…

### DIFF
--- a/cms/static/js/index.js
+++ b/cms/static/js/index.js
@@ -141,6 +141,8 @@ define(["domReady", "jquery", "underscore", "js/utils/cancel_on_escape", "js/vie
             e.preventDefault();
             $('.courses-tab').toggleClass('active', tab === 'courses');
             $('.libraries-tab').toggleClass('active', tab === 'libraries');
+            // Also toggle this course-related notice shown below the course tab, if it is present:
+            $('.wrapper-creationrights').toggleClass('is-hidden', tab === 'libraries');
           };
         };
 

--- a/cms/templates/index.html
+++ b/cms/templates/index.html
@@ -103,57 +103,57 @@
         </form>
       </div>
 
-        %if libraries_enabled:
-        <div class="wrapper-create-element wrapper-create-library">
-          <form class="form-create create-library library-info" id="create-library-form" name="create-library-form">
-            <div class="wrap-error">
-              <div id="library_creation_error" name="library_creation_error" class="message message-status message-status error" role="alert">
-              <p>${_("Please correct the highlighted fields below.")}</p>
-              </div>
+      % endif
+
+      %if libraries_enabled and show_new_library_button:
+      <div class="wrapper-create-element wrapper-create-library">
+        <form class="form-create create-library library-info" id="create-library-form" name="create-library-form">
+          <div class="wrap-error">
+            <div id="library_creation_error" name="library_creation_error" class="message message-status message-status error" role="alert">
+            <p>${_("Please correct the highlighted fields below.")}</p>
             </div>
+          </div>
 
-            <div class="wrapper-form">
-              <h3 class="title">${_("Create a New Library")}</h3>
+          <div class="wrapper-form">
+            <h3 class="title">${_("Create a New Library")}</h3>
 
-              <fieldset>
-                <legend class="sr">${_("Required Information to Create a New Library")}</legend>
+            <fieldset>
+              <legend class="sr">${_("Required Information to Create a New Library")}</legend>
 
-                <ol class="list-input">
-                  <li class="field text required" id="field-library-name">
-                    <label for="new-library-name">${_("Library Name")}</label>
-                    ## Translators: This is an example name for a new content library, seen when filling out the form to create a new library. (A library is a collection of content or problems.)
-                    <input class="new-library-name" id="new-library-name" type="text" name="new-library-name" required placeholder="${_('e.g. Computer Science Problems')}" aria-describedby="tip-new-library-name tip-error-new-library-name" />
-                    <span class="tip" id="tip-new-library-name">${_("The public display name for your library.")}</span>
-                    <span class="tip tip-error is-hiding" id="tip-error-new-library-name"></span>
-                  </li>
-                  <li class="field text required" id="field-organization">
-                    <label for="new-library-org">${_("Organization")}</label>
-                    <input class="new-library-org" id="new-library-org" type="text" name="new-library-org" required placeholder="${_('e.g. UniversityX or OrganizationX')}" aria-describedby="tip-new-library-org tip-error-new-library-org" />
-                    <span class="tip" id="tip-new-library-org">${_("The public organization name for your library.")} ${_("This cannot be changed.")}</span>
-                    <span class="tip tip-error is-hiding" id="tip-error-new-library-org"></span>
-                  </li>
+              <ol class="list-input">
+                <li class="field text required" id="field-library-name">
+                  <label for="new-library-name">${_("Library Name")}</label>
+                  ## Translators: This is an example name for a new content library, seen when filling out the form to create a new library. (A library is a collection of content or problems.)
+                  <input class="new-library-name" id="new-library-name" type="text" name="new-library-name" required placeholder="${_('e.g. Computer Science Problems')}" aria-describedby="tip-new-library-name tip-error-new-library-name" />
+                  <span class="tip" id="tip-new-library-name">${_("The public display name for your library.")}</span>
+                  <span class="tip tip-error is-hiding" id="tip-error-new-library-name"></span>
+                </li>
+                <li class="field text required" id="field-organization">
+                  <label for="new-library-org">${_("Organization")}</label>
+                  <input class="new-library-org" id="new-library-org" type="text" name="new-library-org" required placeholder="${_('e.g. UniversityX or OrganizationX')}" aria-describedby="tip-new-library-org tip-error-new-library-org" />
+                  <span class="tip" id="tip-new-library-org">${_("The public organization name for your library.")} ${_("This cannot be changed.")}</span>
+                  <span class="tip tip-error is-hiding" id="tip-error-new-library-org"></span>
+                </li>
 
-                  <li class="field text required" id="field-library-number">
-                    <label for="new-library-number">${_("Library Code")}</label>
-                    ## Translators: This is an example for the "code" used to identify a library, seen when filling out the form to create a new library. This example is short for "Computer Science Problems". The example number may contain letters but must not contain spaces.
-                    <input class="new-library-number" id="new-library-number" type="text" name="new-library-number" required placeholder="${_('e.g. CSPROB')}" aria-describedby="tip-new-library-number tip-error-new-library-number" />
-                    <span class="tip" id="tip-new-library-number">${_("The unique code that identifies this library.")} <strong>${_("Note: This is part of your library URL, so no spaces or special characters are allowed.")}</strong> ${_("This cannot be changed.")}</span>
-                    <span class="tip tip-error is-hiding" id="tip-error-new-library-number"></span>
-                  </li>
-                </ol>
+                <li class="field text required" id="field-library-number">
+                  <label for="new-library-number">${_("Library Code")}</label>
+                  ## Translators: This is an example for the "code" used to identify a library, seen when filling out the form to create a new library. This example is short for "Computer Science Problems". The example number may contain letters but must not contain spaces.
+                  <input class="new-library-number" id="new-library-number" type="text" name="new-library-number" required placeholder="${_('e.g. CSPROB')}" aria-describedby="tip-new-library-number tip-error-new-library-number" />
+                  <span class="tip" id="tip-new-library-number">${_("The unique code that identifies this library.")} <strong>${_("Note: This is part of your library URL, so no spaces or special characters are allowed.")}</strong> ${_("This cannot be changed.")}</span>
+                  <span class="tip tip-error is-hiding" id="tip-error-new-library-number"></span>
+                </li>
+              </ol>
 
-              </fieldset>
-            </div>
+            </fieldset>
+          </div>
 
-            <div class="actions">
-              <input type="hidden" value="${allow_unicode_course_id}" class="allow-unicode-course-id" />
-              <input type="submit" value="${_('Create')}" class="action action-primary new-library-save" />
-              <input type="button" value="${_('Cancel')}" class="action action-secondary action-cancel new-library-cancel" />
-            </div>
-          </form>
-        </div>
-        % endif
-
+          <div class="actions">
+            <input type="hidden" value="${allow_unicode_course_id}" class="allow-unicode-course-id" />
+            <input type="submit" value="${_('Create')}" class="action action-primary new-library-save" />
+            <input type="button" value="${_('Cancel')}" class="action action-secondary action-cancel new-library-cancel" />
+          </div>
+        </form>
+      </div>
       % endif
 
       <!-- STATE: processing courses -->


### PR DESCRIPTION
This is a fix for https://github.com/edx/edx-platform/pull/8658 ("Remove restrictions on library creation in Studio" / SOL-808).

When deployed to Stage, the change in functionality was not working as expected. Users without the course creation permission can now see the "New Library" button, but cannot create a library because the HTML for the new library form was not included.

This fix changes the template so that it will include the form.

Basically it moves the form HTML from being inside an `% if course_creator_status=='granted':` _and_ an `if libraries_enabled:` condition to just being inside a `%if libraries_enabled and show_new_library_button:` condition. The diff is a bit messy due to a necessary change in indentation of the form HTML.

It also fixes another minor issue: When a user does not have course creation permissions and clicks on the "libraries" tab, a message about course creation permissions ("Become a Course Creator") was shown in an awkward spot:
![screen shot 2015-06-29 at 1 17 18 pm](https://cloud.githubusercontent.com/assets/945577/8417381/2acc620e-1e61-11e5-9648-3afe4389f328.png)

That message is now hidden when the user switches to the libraries tab.

Reviewers: @Kelketek and @mattdrayer 

**Sandbox**: http://sandbox2.opencraft.com:18010/ - e.g. login as "verified" and you cannot create courses but you can create libraries.

CC @alawibaba
