### PR TITLE
Ahodges/staff labeling

### DIFF
--- a/cms/templates/manage_users.html
+++ b/cms/templates/manage_users.html
@@ -53,7 +53,7 @@ from django.core.urlresolvers import reverse
                   <li class="field text required create-user-email">
                     <label for="user-email-input">${_("User's Email Address")}</label>
                     <input id="user-email-input" class="user-email-input" name="user-email" type="text" placeholder="${_('example: username@domain.com')}" value="">
-                    <span class="tip tip-stacked">${_("Please provide the email address of the course staff member you'd like to add")}</span>
+                    <span class="tip tip-stacked">${_("Provide an email address to add the user as Staff")}</span>
                   </li>
                 </ol>
             </fieldset>
@@ -94,14 +94,15 @@ from django.core.urlresolvers import reverse
     <aside class="content-supplementary" role="complementary">
       <div class="bit">
         <h3 class="title-3">${_("Course Team Roles")}</h3>
-        <p>${_("Course team members, or staff, are course co-authors. They have full writing and editing privileges on all course content.")}</p>
+        <p>${_("Course team members with the Staff role are course co-authors. They have full writing and editing privileges on all course content.")}</p>
         <p>${_("Admins are course team members who can add and remove other course team members.")}</p>
+        <p>${_("All course team members are automatically enrolled in the course and can access content in Studio, the LMS, and Insights.")}</p>
       </div>
 
       % if show_transfer_ownership_hint:
       <div class="bit">
         <h3 class="title-3">${_("Transferring Ownership")}</h3>
-        <p>${_("Every course must have an Admin. If you're the Admin and you want transfer ownership of the course, click Add admin access to make another user the Admin, then ask that user to remove you from the Course Team list.")}</p>
+        <p>${_("Every course must have an Admin. If you are the Admin and you want to transfer ownership of the course, click Add admin access to make another user the Admin, then ask that user to remove you from the Course Team list.")}</p>
       </div>
       % endif
     </aside>

--- a/cms/templates/manage_users.html
+++ b/cms/templates/manage_users.html
@@ -53,7 +53,7 @@ from django.core.urlresolvers import reverse
                   <li class="field text required create-user-email">
                     <label for="user-email-input">${_("User's Email Address")}</label>
                     <input id="user-email-input" class="user-email-input" name="user-email" type="text" placeholder="${_('example: username@domain.com')}" value="">
-                    <span class="tip tip-stacked">${_("Provide an email address to add the user as Staff")}</span>
+                    <span class="tip tip-stacked">${_("Provide the email address of the user you want to add as Staff")}</span>
                   </li>
                 </ol>
             </fieldset>
@@ -102,7 +102,7 @@ from django.core.urlresolvers import reverse
       % if show_transfer_ownership_hint:
       <div class="bit">
         <h3 class="title-3">${_("Transferring Ownership")}</h3>
-        <p>${_("Every course must have an Admin. If you are the Admin and you want to transfer ownership of the course, click Add admin access to make another user the Admin, then ask that user to remove you from the Course Team list.")}</p>
+        <p>${_("Every course must have an Admin. If you are the Admin and you want to transfer ownership of the course, click <strong>Add admin access</strong> to make another user the Admin, then ask that user to remove you from the Course Team list.")}</p>
       </div>
       % endif
     </aside>

--- a/cms/templates/manage_users_lib.html
+++ b/cms/templates/manage_users_lib.html
@@ -95,9 +95,9 @@ from django.core.urlresolvers import reverse
       <div class="bit">
         <h3 class="title-3">${_("Library Access Roles")}</h3>
         <p>${_("There are three access roles for libraries: User, Staff, and Admin.")}</p>
-        <p>${_("Users can view library content and can reference or use library components in their courses, but they cannot edit the contents of a library.")}</p>
-        <p>${_("Staff are content co-authors. They have full editing privileges on the contents of a library.")}</p>
-        <p>${_("Admins have full editing privileges and can also add and remove other team members. There must be at least one user with Admin privileges in a library.")}</p>
+        <p>${_("Library Users can view library content and can reference or use library components in their courses, but they cannot edit the contents of a library.")}</p>
+        <p>${_("Library Staff are content co-authors. They have full editing privileges on the contents of a library.")}</p>
+        <p>${_("Library Admins have full editing privileges and can also add and remove other team members. There must be at least one user with the Admin role in a library.")}</p>
       </div>
     </aside>
   </section>

--- a/lms/djangoapps/instructor/features/common.py
+++ b/lms/djangoapps/instructor/features/common.py
@@ -90,7 +90,9 @@ def click_a_button(step, button):  # pylint: disable=unused-argument
         world.css_click('input[name="calculate-grades-csv"]')
 
         # Expect to see a message that grade report is being generated
-        expected_msg = "Your grade report is being generated! You can view the status of the generation task in the 'Pending Tasks' section."
+        expected_msg = "Your grade report is being generated!" \
+                       " You can view the status of the generation" \
+                       " task in the 'Pending Tasks' section."
         world.wait_for_visible('#report-request-response')
         assert_in(
             expected_msg, world.css_text('#report-request-response'),

--- a/lms/djangoapps/instructor/features/common.py
+++ b/lms/djangoapps/instructor/features/common.py
@@ -90,7 +90,7 @@ def click_a_button(step, button):  # pylint: disable=unused-argument
         world.css_click('input[name="calculate-grades-csv"]')
 
         # Expect to see a message that grade report is being generated
-        expected_msg = "Your grade report is being generated! You can view the status of the generation task in the 'Pending Instructor Tasks' section."
+        expected_msg = "Your grade report is being generated! You can view the status of the generation task in the 'Pending Tasks' section."
         world.wait_for_visible('#report-request-response')
         assert_in(
             expected_msg, world.css_text('#report-request-response'),

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -2553,7 +2553,9 @@ class TestInstructorAPILevelsDataDump(ModuleStoreTestCase, LoginEnrollmentTestCa
         CourseFinanceAdminRole(self.course.id).add_users(self.instructor)
         with patch(task_api_endpoint):
             response = self.client.get(url, {})
-        success_status = "Your {report_type} report is being generated! You can view the status of the generation task in the 'Pending Tasks' section.".format(report_type=report_type)
+        success_status = "Your {report_type} report is being generated!" \
+                         " You can view the status of the generation task" \
+                         " in the 'Pending Tasks' section.".format(report_type=report_type)
         self.assertIn(success_status, response.content)
 
     @ddt.data(*EXECUTIVE_SUMMARY_DATA)

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -2553,7 +2553,7 @@ class TestInstructorAPILevelsDataDump(ModuleStoreTestCase, LoginEnrollmentTestCa
         CourseFinanceAdminRole(self.course.id).add_users(self.instructor)
         with patch(task_api_endpoint):
             response = self.client.get(url, {})
-        success_status = "Your {report_type} report is being generated! You can view the status of the generation task in the 'Pending Instructor Tasks' section.".format(report_type=report_type)
+        success_status = "Your {report_type} report is being generated! You can view the status of the generation task in the 'Pending Tasks' section.".format(report_type=report_type)
         self.assertIn(success_status, response.content)
 
     @ddt.data(*EXECUTIVE_SUMMARY_DATA)
@@ -2573,7 +2573,7 @@ class TestInstructorAPILevelsDataDump(ModuleStoreTestCase, LoginEnrollmentTestCa
         with patch(task_api_endpoint):
             response = self.client.get(url, {})
         success_status = "Your {report_type} report is being created." \
-                         " To view the status of the report, see the 'Pending Instructor Tasks'" \
+                         " To view the status of the report, see the 'Pending Tasks'" \
                          " section.".format(report_type=report_type)
         self.assertIn(success_status, response.content)
 
@@ -2595,7 +2595,7 @@ class TestInstructorAPILevelsDataDump(ModuleStoreTestCase, LoginEnrollmentTestCa
             mock.side_effect = AlreadyRunningError()
             response = self.client.get(url, {})
         already_running_status = "An {report_type} report is currently in progress." \
-                                 " To view the status of the report, see the 'Pending Instructor Tasks' section." \
+                                 " To view the status of the report, see the 'Pending Tasks' section." \
                                  " When completed, the report will be available for download in the table below." \
                                  " You will be able to download the" \
                                  " report when it is complete.".format(report_type=report_type)

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -1107,10 +1107,10 @@ def get_students_features(request, course_id, csv=False):  # pylint: disable=red
     else:
         try:
             instructor_task.api.submit_calculate_students_features_csv(request, course_key, query_features)
-            success_status = _("Your enrolled student profile report is being generated! You can view the status of the generation task in the 'Pending Instructor Tasks' section.")
+            success_status = _("Your enrolled student profile report is being generated! You can view the status of the generation task in the 'Pending Tasks' section.")
             return JsonResponse({"status": success_status})
         except AlreadyRunningError:
-            already_running_status = _("An enrolled student profile report generation task is already in progress. Check the 'Pending Instructor Tasks' table for the status of the task. When completed, the report will be available for download in the table below.")
+            already_running_status = _("An enrolled student profile report generation task is already in progress. Check the 'Pending Tasks' table for the status of the task. When completed, the report will be available for download in the table below.")
             return JsonResponse({"status": already_running_status})
 
 
@@ -1132,13 +1132,13 @@ def get_students_who_may_enroll(request, course_id):
         instructor_task.api.submit_calculate_may_enroll_csv(request, course_key, query_features)
         success_status = _(
             "Your students who may enroll report is being generated! "
-            "You can view the status of the generation task in the 'Pending Instructor Tasks' section."
+            "You can view the status of the generation task in the 'Pending Tasks' section."
         )
         return JsonResponse({"status": success_status})
     except AlreadyRunningError:
         already_running_status = _(
             "A students who may enroll report generation task is already in progress. "
-            "Check the 'Pending Instructor Tasks' table for the status of the task. "
+            "Check the 'Pending Tasks' table for the status of the task. "
             "When completed, the report will be available for download in the table below."
         )
         return JsonResponse({"status": already_running_status})
@@ -1230,11 +1230,11 @@ def get_enrollment_report(request, course_id):
     try:
         instructor_task.api.submit_detailed_enrollment_features_csv(request, course_key)
         success_status = _("Your detailed enrollment report is being generated! "
-                           "You can view the status of the generation task in the 'Pending Instructor Tasks' section.")
+                           "You can view the status of the generation task in the 'Pending Tasks' section.")
         return JsonResponse({"status": success_status})
     except AlreadyRunningError:
         already_running_status = _("A detailed enrollment report generation task is already in progress. "
-                                   "Check the 'Pending Instructor Tasks' table for the status of the task. "
+                                   "Check the 'Pending Tasks' table for the status of the task. "
                                    "When completed, the report will be available for download in the table below.")
         return JsonResponse({
             "status": already_running_status
@@ -1253,11 +1253,11 @@ def get_exec_summary_report(request, course_id):
     try:
         instructor_task.api.submit_executive_summary_report(request, course_key)
         status_response = _("Your executive summary report is being created. "
-                            "To view the status of the report, see the 'Pending Instructor Tasks' section.")
+                            "To view the status of the report, see the 'Pending Tasks' section.")
     except AlreadyRunningError:
         status_response = _(
             "An executive summary report is currently in progress. "
-            "To view the status of the report, see the 'Pending Instructor Tasks' section. "
+            "To view the status of the report, see the 'Pending Tasks' section. "
             "When completed, the report will be available for download in the table below. "
             "You will be able to download the report when it is complete."
         )
@@ -2134,11 +2134,11 @@ def calculate_grades_csv(request, course_id):
     try:
         instructor_task.api.submit_calculate_grades_csv(request, course_key)
         success_status = _("Your grade report is being generated! "
-                           "You can view the status of the generation task in the 'Pending Instructor Tasks' section.")
+                           "You can view the status of the generation task in the 'Pending Tasks' section.")
         return JsonResponse({"status": success_status})
     except AlreadyRunningError:
         already_running_status = _("A grade report generation task is already in progress. "
-                                   "Check the 'Pending Instructor Tasks' table for the status of the task. "
+                                   "Check the 'Pending Tasks' table for the status of the task. "
                                    "When completed, the report will be available for download in the table below.")
         return JsonResponse({
             "status": already_running_status
@@ -2160,11 +2160,11 @@ def problem_grade_report(request, course_id):
     try:
         instructor_task.api.submit_problem_grade_report(request, course_key)
         success_status = _("Your problem grade report is being generated! "
-                           "You can view the status of the generation task in the 'Pending Instructor Tasks' section.")
+                           "You can view the status of the generation task in the 'Pending Tasks' section.")
         return JsonResponse({"status": success_status})
     except AlreadyRunningError:
         already_running_status = _("A problem grade report is already being generated. "
-                                   "Check the 'Pending Instructor Tasks' table for the status of the task. "
+                                   "Check the 'Pending Tasks' table for the status of the task. "
                                    "When completed, the report will be available for download in the table below.")
         return JsonResponse({
             "status": already_running_status

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -1107,13 +1107,15 @@ def get_students_features(request, course_id, csv=False):  # pylint: disable=red
     else:
         try:
             instructor_task.api.submit_calculate_students_features_csv(request, course_key, query_features)
-            success_status = _("Your enrolled student profile report is being generated!" \
-                               " You can view the status of the generation task in the 'Pending Tasks' section.")
+            success_status = _(
+                "Your enrolled student profile report is being generated! "
+                "You can view the status of the generation task in the 'Pending Tasks' section.")
             return JsonResponse({"status": success_status})
         except AlreadyRunningError:
-            already_running_status = _("An enrolled student profile report generation task is already in progress." \
-                                       " Check the 'Pending Tasks' table for the status of the task. When completed," \
-                                       " the report will be available for download in the table below.")
+            already_running_status = _(
+                "An enrolled student profile report generation task is already in progress. " 
+                "Check the 'Pending Tasks' table for the status of the task. When completed, " 
+                "the report will be available for download in the table below.")
             return JsonResponse({"status": already_running_status})
 
 
@@ -1232,13 +1234,15 @@ def get_enrollment_report(request, course_id):
     course_key = SlashSeparatedCourseKey.from_deprecated_string(course_id)
     try:
         instructor_task.api.submit_detailed_enrollment_features_csv(request, course_key)
-        success_status = _("Your detailed enrollment report is being generated! "
-                           "You can view the status of the generation task in the 'Pending Tasks' section.")
+        success_status = _(
+            "Your detailed enrollment report is being generated! "
+            "You can view the status of the generation task in the 'Pending Tasks' section.")
         return JsonResponse({"status": success_status})
     except AlreadyRunningError:
-        already_running_status = _("A detailed enrollment report generation task is already in progress. "
-                                   "Check the 'Pending Tasks' table for the status of the task. "
-                                   "When completed, the report will be available for download in the table below.")
+        already_running_status = _(
+            "A detailed enrollment report generation task is already in progress. "
+            "Check the 'Pending Tasks' table for the status of the task. "
+            "When completed, the report will be available for download in the table below.")
         return JsonResponse({
             "status": already_running_status
         })
@@ -1255,8 +1259,9 @@ def get_exec_summary_report(request, course_id):
     course_key = SlashSeparatedCourseKey.from_deprecated_string(course_id)
     try:
         instructor_task.api.submit_executive_summary_report(request, course_key)
-        status_response = _("Your executive summary report is being created. "
-                            "To view the status of the report, see the 'Pending Tasks' section.")
+        status_response = _(
+            "Your executive summary report is being created. "
+            "To view the status of the report, see the 'Pending Tasks' section.")
     except AlreadyRunningError:
         status_response = _(
             "An executive summary report is currently in progress. "
@@ -2136,13 +2141,15 @@ def calculate_grades_csv(request, course_id):
     course_key = SlashSeparatedCourseKey.from_deprecated_string(course_id)
     try:
         instructor_task.api.submit_calculate_grades_csv(request, course_key)
-        success_status = _("Your grade report is being generated! "
-                           "You can view the status of the generation task in the 'Pending Tasks' section.")
+        success_status = _(
+            "Your grade report is being generated! "
+            "You can view the status of the generation task in the 'Pending Tasks' section.")
         return JsonResponse({"status": success_status})
     except AlreadyRunningError:
-        already_running_status = _("A grade report generation task is already in progress. "
-                                   "Check the 'Pending Tasks' table for the status of the task. "
-                                   "When completed, the report will be available for download in the table below.")
+        already_running_status = _(
+            "A grade report generation task is already in progress. "
+            "Check the 'Pending Tasks' table for the status of the task. "
+            "When completed, the report will be available for download in the table below.")
         return JsonResponse({
             "status": already_running_status
         })
@@ -2162,13 +2169,15 @@ def problem_grade_report(request, course_id):
     course_key = SlashSeparatedCourseKey.from_deprecated_string(course_id)
     try:
         instructor_task.api.submit_problem_grade_report(request, course_key)
-        success_status = _("Your problem grade report is being generated! "
-                           "You can view the status of the generation task in the 'Pending Tasks' section.")
+        success_status = _(
+            "Your problem grade report is being generated! "
+            "You can view the status of the generation task in the 'Pending Tasks' section.")
         return JsonResponse({"status": success_status})
     except AlreadyRunningError:
-        already_running_status = _("A problem grade report is already being generated. "
-                                   "Check the 'Pending Tasks' table for the status of the task. "
-                                   "When completed, the report will be available for download in the table below.")
+        already_running_status = _(
+            "A problem grade report is already being generated. "
+            "Check the 'Pending Tasks' table for the status of the task. "
+            "When completed, the report will be available for download in the table below.")
         return JsonResponse({
             "status": already_running_status
         })

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -1113,8 +1113,8 @@ def get_students_features(request, course_id, csv=False):  # pylint: disable=red
             return JsonResponse({"status": success_status})
         except AlreadyRunningError:
             already_running_status = _(
-                "An enrolled student profile report generation task is already in progress. " 
-                "Check the 'Pending Tasks' table for the status of the task. When completed, " 
+                "An enrolled student profile report generation task is already in progress. "
+                "Check the 'Pending Tasks' table for the status of the task. When completed, "
                 "the report will be available for download in the table below.")
             return JsonResponse({"status": already_running_status})
 

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -1107,10 +1107,13 @@ def get_students_features(request, course_id, csv=False):  # pylint: disable=red
     else:
         try:
             instructor_task.api.submit_calculate_students_features_csv(request, course_key, query_features)
-            success_status = _("Your enrolled student profile report is being generated! You can view the status of the generation task in the 'Pending Tasks' section.")
+            success_status = _("Your enrolled student profile report is being generated!" \
+                               " You can view the status of the generation task in the 'Pending Tasks' section.")
             return JsonResponse({"status": success_status})
         except AlreadyRunningError:
-            already_running_status = _("An enrolled student profile report generation task is already in progress. Check the 'Pending Tasks' table for the status of the task. When completed, the report will be available for download in the table below.")
+            already_running_status = _("An enrolled student profile report generation task is already in progress." \
+                                       " Check the 'Pending Tasks' table for the status of the task. When completed," \
+                                       " the report will be available for download in the table below.")
             return JsonResponse({"status": already_running_status})
 
 

--- a/lms/static/coffee/src/instructor_dashboard/util.coffee
+++ b/lms/static/coffee/src/instructor_dashboard/util.coffee
@@ -292,12 +292,12 @@ class @PendingInstructorTasks
           @$no_tasks_message.hide()
           @$running_tasks_section.show()
         else
-          console.log "No pending instructor tasks to display"
+          console.log "No pending tasks to display"
           @$running_tasks_section.hide()
           @$no_tasks_message.empty()
           @$no_tasks_message.append $('<p>').text gettext("No tasks currently running.")
           @$no_tasks_message.show()
-      error: std_ajax_err => console.error "Error finding pending instructor tasks to display"
+      error: std_ajax_err => console.error "Error finding pending tasks to display"
     ### /Pending Instructor Tasks Section ####
 
 class KeywordValidator

--- a/lms/static/js/fixtures/instructor_dashboard/student_admin.html
+++ b/lms/static/js/fixtures/instructor_dashboard/student_admin.html
@@ -70,7 +70,7 @@
 
 
     <p id="task-history-single-help">
-      Rescoring runs in the background, and status for active tasks will appear in the 'Pending Instructor Tasks' table. To see status for all tasks submitted for this problem and student, click on this button:
+      Rescoring runs in the background, and status for active tasks will appear in the 'Pending Tasks' table. To see status for all tasks submitted for this problem and student, click on this button:
     </p>
 
     <p><input type="button" name="task-history-single" value="Show Background Task History for Student" data-endpoint="/courses/PU/FSc/2014_T4/instructor/api/list_instructor_tasks" aria-describedby="task-history-single-help"></p>
@@ -103,7 +103,7 @@
 
 
     <p id="entrance-exam-task-history-help">
-      Rescoring runs in the background, and status for active tasks will appear in the 'Pending Instructor Tasks' table. To see status for all tasks submitted for this problem and student, click on this button:
+      Rescoring runs in the background, and status for active tasks will appear in the 'Pending Tasks' table. To see status for all tasks submitted for this problem and student, click on this button:
     </p>
 
     <p><input type="button" name="entrance-exam-task-history" value="Show Student's Exam Adjustment History" data-endpoint="/courses/PU/FSc/2014_T4/instructor/api/list_entrance_exam_instructor_tasks" aria-describedby="entrance-exam-task-history-help"></p>
@@ -137,7 +137,7 @@
 
   <div class="running-tasks-container action-type-container">
     <hr>
-    <h2> Pending Instructor Tasks </h2>
+    <h2> Pending Tasks </h2>
     <div class="running-tasks-section" style="display: block;">
       <p>The status for any active tasks appears in a table below. </p>
       <br>

--- a/lms/templates/instructor/instructor_dashboard_2/course_info.html
+++ b/lms/templates/instructor/instructor_dashboard_2/course_info.html
@@ -7,7 +7,7 @@
 
     %if settings.FEATURES.get('DISPLAY_ANALYTICS_ENROLLMENTS'):
       ## Translators: 'track' refers to the enrollment type ('honor', 'verified', or 'audit')
-      <span class="tip">${_("Number of enrollees (admins, staff, and students) by track")}</span>instructors
+      <span class="tip">${_("Number of enrollees (admins, staff, and students) by track")}</span>
       <br/><br/>
       <% modes = section_data['enrollment_count'] %>
       <table>

--- a/lms/templates/instructor/instructor_dashboard_2/course_info.html
+++ b/lms/templates/instructor/instructor_dashboard_2/course_info.html
@@ -7,7 +7,7 @@
 
     %if settings.FEATURES.get('DISPLAY_ANALYTICS_ENROLLMENTS'):
       ## Translators: 'track' refers to the enrollment type ('honor', 'verified', or 'audit')
-      <span class="tip">${_("Number of enrollees (instructors, staff members, and students) by track")}</span>
+      <span class="tip">${_("Number of enrollees (admins, staff, and students) by track")}</span>instructors
       <br/><br/>
       <% modes = section_data['enrollment_count'] %>
       <table>
@@ -94,7 +94,7 @@
 %if settings.FEATURES.get('ENABLE_INSTRUCTOR_BACKGROUND_TASKS'):
   <div class="running-tasks-container action-type-container">
     <hr>
-    <h2> ${_("Pending Instructor Tasks")} </h2>
+    <h2> ${_("Pending Tasks")} </h2>
     <div class="running-tasks-section">
       <p>${_("The status for any active tasks appears in a table below.")} </p>
       <br />

--- a/lms/templates/instructor/instructor_dashboard_2/data_download.html
+++ b/lms/templates/instructor/instructor_dashboard_2/data_download.html
@@ -74,7 +74,7 @@
 %if settings.FEATURES.get('ENABLE_INSTRUCTOR_BACKGROUND_TASKS'):
   <div class="running-tasks-container action-type-container">
     <hr>
-    <h2> ${_("Pending Instructor Tasks")} </h2>
+    <h2> ${_("Pending Tasks")} </h2>
     <div class="running-tasks-section">
       <p>${_("The status for any active tasks appears in a table below.")} </p>
       <br />

--- a/lms/templates/instructor/instructor_dashboard_2/e-commerce.html
+++ b/lms/templates/instructor/instructor_dashboard_2/e-commerce.html
@@ -126,7 +126,7 @@ import pytz
           %if settings.FEATURES.get('ENABLE_INSTRUCTOR_BACKGROUND_TASKS'):
           <div class="running-tasks-container action-type-container">
             <hr>
-            <h2> ${_("Pending Instructor Tasks")} </h2>
+            <h2> ${_("Pending Tasks")} </h2>
             <div class="running-tasks-section">
               <p>${_("The status for any active tasks appears in a table below.")} </p>
               <br/>

--- a/lms/templates/instructor/instructor_dashboard_2/membership.html
+++ b/lms/templates/instructor/instructor_dashboard_2/membership.html
@@ -114,7 +114,7 @@ from openedx.core.djangoapps.course_groups.partition_scheme import get_cohorted_
   <p>
     <label for="student-ids-for-beta">
       ${_("Enter email addresses and/or usernames separated by new lines or commas.")}<br/>
-      ${_("Note: Users must have an activated {platform_name} account before they can be enrolled as a beta tester.").format(platform_name=settings.PLATFORM_NAME)}
+      ${_("Note: Users must have an activated {platform_name} account before they can be enrolled as beta testers.").format(platform_name=settings.PLATFORM_NAME)}
     </label>
 
   <textarea rows="6" cols="50" name="student-ids-for-beta" placeholder="${_("Email Addresses/Usernames")}" spellcheck="false"></textarea>
@@ -156,13 +156,13 @@ from openedx.core.djangoapps.course_groups.partition_scheme import get_cohorted_
 
 <div class="member-lists-management membership-section">
   ## Translators: an "Administration List" is a list, such as Course Staff, that users can be added to.
-  <h2> ${_("Administration List Management")} </h2>
+  <h2> ${_("Course Team Management")} </h2>
 
   <div class="request-response-error"></div>
 
   <div class="wrapper-member-select">
     ## Translators: an "Administrator Group" is a group, such as Course Staff, that users can be added to.
-    <label for="member-lists-selector">${_("Select an Administrator Group:")}</label>
+    <label for="member-lists-selector">${_("Select a course team role:")}</label>
     <select id="member-lists-selector" class="member-lists-selector">
       <option> ${_("Getting available lists...")} </option>
     </select>
@@ -172,21 +172,21 @@ from openedx.core.djangoapps.course_groups.partition_scheme import get_cohorted_
 
   %if not section_data['access']['instructor']:
     <p>
-      ${_("Staff cannot modify staff or beta tester lists. To modify these lists, "
-      "contact your instructor and ask them to add you as an instructor for staff "
-      "and beta lists, or a discussion admin for discussion management.")}
+      ${_("Staff cannot modify these lists. To manage course team membership, "
+      "a course Admin must give you the Admin role to add Staff or Beta Testers, "
+      "or the Discussion Admin role to add discussion moderators and TAs.")}
     </p>
   %endif
 
   %if section_data['access']['instructor']:
     <div class="auth-list-container"
       data-rolename="staff"
-      data-display-name="${_("Course Staff")}"
+      data-display-name="${_("Staff")}"
       data-info-text="
-        ${_("Course staff can help you manage limited aspects of your course. Staff "
-        "can enroll and unenroll students, as well as modify their grades and "
-        "see all course data. Course staff are not automatically given access "
-        "to Studio and will not be able to edit your course.")}"
+        ${_("Course team members with the Staff role help you manage your course. "
+        "Staff can enroll and unenroll learners, as well as modify their grades and "
+        "access all course data. Staff also have access to your course in Studio and "
+        "Insights. You can only give course team roles to enrolled users.")}"
       data-list-endpoint="${ section_data['list_course_role_members_url'] }"
       data-modify-endpoint="${ section_data['modify_access_url'] }"
       data-add-button-label="${_("Add Staff")}"
@@ -194,22 +194,25 @@ from openedx.core.djangoapps.course_groups.partition_scheme import get_cohorted_
 
     <div class="auth-list-container"
       data-rolename="instructor"
-      data-display-name="${_("Instructors")}"
+      data-display-name="${_("Admin")}"
       data-info-text="
-        ${_("Instructors are the core administration of your course. Instructors can "
-        "add and remove course staff, as well as administer discussion access.")}"
+        ${_("Course team members with the Admin role help you manage your course. "
+          "They can do all of the tasks that Staff can do, and can also add and "
+          "remove the Staff and Admin roles, discussion moderation roles, and the "
+          "beta tester role to manage course team membership. You can only give "
+          "course team roles to enrolled users.")}"
       data-list-endpoint="${ section_data['list_course_role_members_url'] }"
       data-modify-endpoint="${ section_data['modify_access_url'] }"
-      data-add-button-label="${_("Add Instructor")}"
+      data-add-button-label="${_("Add Admin")}"
     ></div>
 
     <div class="auth-list-container"
       data-rolename="beta"
       data-display-name="${_("Beta Testers")}"
       data-info-text="
-        ${_("Beta testers can see course content before the rest of the students. "
+        ${_("Beta Testers can see course content before otehr learners. "
         "They can make sure that the content works, but have no additional "
-        "privileges.")}"
+        "privileges. You can only give course team roles to enrolled users.")}"
       data-list-endpoint="${ section_data['list_course_role_members_url'] }"
       data-modify-endpoint="${ section_data['modify_access_url'] }"
       data-add-button-label="${_("Add Beta Tester")}"
@@ -219,9 +222,11 @@ from openedx.core.djangoapps.course_groups.partition_scheme import get_cohorted_
       data-rolename="Administrator"
       data-display-name="${_("Discussion Admins")}"
       data-info-text="
-        ${_("Discussion admins can edit or delete any post, clear misuse flags, close "
+        ${_("Discussion Admins can edit or delete any post, clear misuse flags, close "
          "and re-open threads, endorse responses, and see posts from all cohorts. "
-         "They CAN add/delete other moderators and their posts are marked as 'staff'.")}"
+         "Their posts are marked as 'staff'. They can also add and remove the "
+         "discussion moderation roles to manage course team membership. You can "
+         "only give course team roles to enrolled users.")}"
       data-list-endpoint="${ section_data['list_forum_members_url'] }"
       data-modify-endpoint="${ section_data['update_forum_role_membership_url'] }"
       data-add-button-label="${_("Add Discussion Admin")}"
@@ -233,9 +238,11 @@ from openedx.core.djangoapps.course_groups.partition_scheme import get_cohorted_
       data-rolename="Moderator"
       data-display-name="${_("Discussion Moderators")}"
       data-info-text="
-        ${_("Discussion moderators can edit or delete any post, clear misuse flags, close "
+        ${_("Discussion Moderators can edit or delete any post, clear misuse flags, close "
          "and re-open threads, endorse responses, and see posts from all cohorts. "
-         "They CANNOT add/delete other moderators and their posts are marked as 'staff'.")}"
+         "Their posts are marked as 'staff'. They cannot manage course team membership by "
+         "adding or removing discussion moderation roles. You can only give course team "
+         "roles to enrolled users.")}"
       data-list-endpoint="${ section_data['list_forum_members_url'] }"
       data-modify-endpoint="${ section_data['update_forum_role_membership_url'] }"
       data-add-button-label="${_("Add Moderator")}"
@@ -246,9 +253,10 @@ from openedx.core.djangoapps.course_groups.partition_scheme import get_cohorted_
       data-display-name="${_("Discussion Community TAs")}"
       data-info-text="
         ${_("Community TA's are members of the community whom you deem particularly "
-        "helpful on the discussion boards. They can edit or delete any post, clear misuse flags, "
-        "close and re-open threads, endorse responses, and see posts from all cohorts. "
-        "Their posts are marked 'Community TA'.")}"
+        "helpful on the discussion boards. They can edit or delete any post, clear "
+        "misuse flags, close and re-open threads, endorse responses, and see posts from "
+        all cohorts. Their posts are marked as 'Community TA'. You can only give course "
+        "team roles to enrolled users.")}"
       data-list-endpoint="${ section_data['list_forum_members_url'] }"
       data-modify-endpoint="${ section_data['update_forum_role_membership_url'] }"
       data-add-button-label="${_("Add Community TA")}"

--- a/lms/templates/instructor/instructor_dashboard_2/membership.html
+++ b/lms/templates/instructor/instructor_dashboard_2/membership.html
@@ -210,7 +210,7 @@ from openedx.core.djangoapps.course_groups.partition_scheme import get_cohorted_
       data-rolename="beta"
       data-display-name="${_("Beta Testers")}"
       data-info-text="
-        ${_("Beta Testers can see course content before otehr learners. "
+        ${_("Beta Testers can see course content before other learners. "
         "They can make sure that the content works, but have no additional "
         "privileges. You can only give course team roles to enrolled users.")}"
       data-list-endpoint="${ section_data['list_course_role_members_url'] }"

--- a/lms/templates/instructor/instructor_dashboard_2/membership.html
+++ b/lms/templates/instructor/instructor_dashboard_2/membership.html
@@ -255,7 +255,7 @@ from openedx.core.djangoapps.course_groups.partition_scheme import get_cohorted_
         ${_("Community TA's are members of the community whom you deem particularly "
         "helpful on the discussion boards. They can edit or delete any post, clear "
         "misuse flags, close and re-open threads, endorse responses, and see posts from "
-        all cohorts. Their posts are marked as 'Community TA'. You can only give course "
+        "all cohorts. Their posts are marked as 'Community TA'. You can only give course "
         "team roles to enrolled users.")}"
       data-list-endpoint="${ section_data['list_forum_members_url'] }"
       data-modify-endpoint="${ section_data['update_forum_role_membership_url'] }"

--- a/lms/templates/instructor/instructor_dashboard_2/send_email.html
+++ b/lms/templates/instructor/instructor_dashboard_2/send_email.html
@@ -10,14 +10,14 @@
       <select id="id_to" name="send_to">
         <option value="myself">${_("Myself")}</option>
         %if to_option == "staff":
-        <option value="staff" selected="selected">${_("Staff and instructors")}</option>
+        <option value="staff" selected="selected">${_("Staff and admins")}</option>
         %else:
-        <option value="staff">${_("Staff and instructors")}</option>
+        <option value="staff">${_("Staff and admins")}</option>
           %endif
           %if to_option == "all":
-            <option value="all" selected="selected">${_("All (students, staff and instructors)")}</option>
+            <option value="all" selected="selected">${_("All (students, staff, and admins)")}</option>
           %else:
-      <option value="all">${_("All (students, staff and instructors)")}</option>
+      <option value="all">${_("All (students, staff, and admins)")}</option>
       %endif
       </select>
     </li>
@@ -58,7 +58,7 @@
 %if settings.FEATURES.get('ENABLE_INSTRUCTOR_BACKGROUND_TASKS'):
   <div class="running-tasks-container action-type-container">
     <hr>
-    <h2> ${_("Pending Instructor Tasks")} </h2>
+    <h2> ${_("Pending Tasks")} </h2>
     <div class="running-tasks-section">
       <p>${_("Email actions run in the background. The status for any active tasks - including email tasks - appears in a table below.")} </p>
       <br />

--- a/lms/templates/instructor/instructor_dashboard_2/student_admin.html
+++ b/lms/templates/instructor/instructor_dashboard_2/student_admin.html
@@ -78,7 +78,7 @@
 
   %if settings.FEATURES.get('ENABLE_INSTRUCTOR_BACKGROUND_TASKS') and section_data['access']['instructor']:
     <p id="task-history-single-help">
-      ${_("Rescoring runs in the background, and status for active tasks will appear in the 'Pending Instructor Tasks' table. "
+      ${_("Rescoring runs in the background, and status for active tasks will appear in the 'Pending Tasks' table. "
       "To see status for all tasks submitted for this problem and student, click on this button:")}
     </p>
 
@@ -119,7 +119,7 @@
 
   %if settings.FEATURES.get('ENABLE_INSTRUCTOR_BACKGROUND_TASKS') and section_data['access']['instructor']:
     <p id="entrance-exam-task-history-help">
-      ${_("Rescoring runs in the background, and status for active tasks will appear in the 'Pending Instructor Tasks' table. "
+      ${_("Rescoring runs in the background, and status for active tasks will appear in the 'Pending Tasks' table. "
       "To see status for all tasks submitted for this problem and student, click on this button:")}
     </p>
 
@@ -161,7 +161,7 @@
 %if settings.FEATURES.get('ENABLE_INSTRUCTOR_BACKGROUND_TASKS'):
   <div class="running-tasks-container action-type-container">
     <hr>
-    <h2> ${_("Pending Instructor Tasks")} </h2>
+    <h2> ${_("Pending Tasks")} </h2>
     <div class="running-tasks-section">
       <p>${_("The status for any active tasks appears in a table below.")} </p>
       <br />

--- a/lms/templates/peer_grading/peer_grading.html
+++ b/lms/templates/peer_grading/peer_grading.html
@@ -5,7 +5,7 @@ nothing_to_grade_message = _(
 {p_tag}You currently do not have any peer grading to do.  In order to have peer grading to do:
 {ul_tag}
 {li_tag}You need to have submitted a response to a peer grading problem.{end_li_tag}
-{li_tag}The instructor needs to score the essays that are used to help you better understand the grading
+{li_tag}The course team needs to score the essays that are used to help you better understand the grading
 criteria.{end_li_tag}
 {li_tag}There must be submissions that are waiting for grading.{end_li_tag}
 {end_ul_tag}


### PR DESCRIPTION
Fixes TNL-1752. Change "instructor" label to "Admin" to make Studio and LMS role names parallel.
@explorerleslie , @cahrens , @catong @mhoeber @srpearce please take a look and let me know if I've missed any place that exposes the role name "instructor" in the LMS, or if I've mischaracterized anything.

Sandbox available here: http://lamagnifica.m.sandbox.edx.org/
Unfortunately, I don't know how/see instructions for how to enable the bulk email feature in a sandbox. If anyone knows who I could go to for help please let me know.
See companion doc changes here: https://github.com/edx/edx-documentation/pull/416
