### PR TITLE
Add the Poll XBlock to the requirements.

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -922,6 +922,8 @@ ADVANCED_COMPONENT_TYPES = [
     'edx_sga',
     'problem-builder',
     'pb-dashboard',
+    'poll',
+    'survey',
     # XBlocks from pmitros repos are prototypes. They should not be used
     # except for edX Learning Sciences experiments on edge.edx.org without
     # further work to make them robust, maintainable, finalize data formats,

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -57,3 +57,4 @@ git+https://github.com/edx/ecommerce-api-client.git@1.0.0#egg=ecommerce-api-clie
 
 # Third Party XBlocks
 -e git+https://github.com/mitodl/edx-sga@172a90fd2738f8142c10478356b2d9ed3e55334a#egg=edx-sga
+-e git+https://github.com/open-craft/xblock-poll@v1.0#egg=xblock-poll


### PR DESCRIPTION
**Description**
Add an XBlock for polls and surveys to the requirements. The code base has been reviewed in https://github.com/mckinseyacademy/xblock-poll/pull/13 and the comments there are addressed by the changes in https://github.com/open-craft/xblock-poll/pull/2.

---

**JIRA Story** [OSPR-548](https://openedx.atlassian.net/browse/OSPR-548)
**Confluence / Product Asset** N/A
**Sandbox URL** (Last Updated 2015-06-30) [Example poll](http://sandbox3.opencraft.com/courses/TestOrg/ImportCourse1/now/courseware/b0041b6d74f244b2a44beb637719ad95/5e91b58180be43d88ec7c556571b0ca2/)
**Dependencies** N/A
**PR Author(s) Notes / To-Do** N/A
**Screenshots** N/A

---

**Reviewers**
(TBD)
