### PR TITLE
Fix XBlock class loading in local resource view

### DIFF
--- a/cms/djangoapps/contentstore/views/xblock.py
+++ b/cms/djangoapps/contentstore/views/xblock.py
@@ -20,7 +20,7 @@ def xblock_resource(request, block_type, uri):  # pylint: disable=unused-argumen
     Return a package resource for the specified XBlock.
     """
     try:
-        xblock_class = XBlock.load_class(block_type, settings.XBLOCK_SELECT_FUNCTION)
+        xblock_class = XBlock.load_class(block_type, select=settings.XBLOCK_SELECT_FUNCTION)
         content = xblock_class.open_local_resource(uri)
     except IOError:
         log.info('Failed to load xblock resource', exc_info=True)


### PR DESCRIPTION
Some XBlock classes were being (randomly) incorrectly loaded. This was
due to an error in the way the XBlock.load_class method was called.
Error was happening randomly because of the cache mechanism in the class
loading method. (see PLUGIN_CACHE)
