### PR TITLE
adding back in image response overrides for styling

### DIFF
--- a/common/lib/xmodule/xmodule/css/capa/display.scss
+++ b/common/lib/xmodule/xmodule/css/capa/display.scss
@@ -16,6 +16,7 @@
 // * +Problem - Rubric
 // * +Problem - Annotation
 // * +Problem - Choice Text Group
+// * +Problem - Image Input Overrides
 
 // +Variables - Capa
 // ==================== 
@@ -1348,5 +1349,26 @@ div.problem {
     span.mock_label {
       cursor : default;
     }
+  }
+}
+
+// +Problem - Image Input Overrides
+// ====================
+
+// NOTE: temporary override until image inputs use same base html structure as other common capa input types.
+div.problem .imageinput.capa_inputtype {
+
+  .status {
+    display: inline-block;
+    position: relative;
+    top: 3px;
+    width: 25px;
+    height: 20px;
+  }
+  .correct {
+    background: url('../images/correct-icon.png') center center no-repeat;
+  }
+  .incorrect {
+    background: url('../images/incorrect-icon.png') center center no-repeat;
   }
 }


### PR DESCRIPTION
_Merged into rc/2015-06-29 in PR #8730._

---

**Description**
This PR adds in styling to image response types that was removed as a part of cleanup for capa styling input. 

---

**JIRA Story** ([TNL-2623](https://openedx.atlassian.net/browse/TNL-2623))
**Confluence / Product Asset** N/A
**Sandbox URL** (N/A) ([N/A](N/A)) 
**Dependencies** N/A

---

**PR Author(s) Notes / To-Do** A list of known open tasks that the PR author has.
- [x] confirm locally (running into devstack issues currently)
- [x] review from @mekkz 
- [x] merge into RC branch, or whatever the process is for fixes. cc'ed @alawibaba 

---

**Screenshots** 
Current Production:
https://s3.amazonaws.com/uploads.hipchat.com/26537/183095/iiJjyLwLc4I7zvZ/upload.png

Current Stage: 
https://s3.amazonaws.com/uploads.hipchat.com/26537/183095/zveOCC3yjgXRCbE/upload.png

---

**Reviewers**
Code: @mekkz 
FED @lou-wang, @nasthagiri 
