### PR TITLE
give the header the right height in the verify flow

### DIFF
--- a/lms/static/sass/views/_verification.scss
+++ b/lms/static/sass/views/_verification.scss
@@ -113,6 +113,11 @@
     padding-bottom: ($baseline +1);
   }
 
+  // HACK: fix global header height in verification flow ECOM-1808
+  header.global {
+    height: 76px;
+  }
+
   // HACK: nasty override due to our bad input/button styling
   button, input[type="submit"], input[type="button"], button[type="submit"] {
     @include font-size(16);


### PR DESCRIPTION
This PR fixes a styling issue on the verification flow where the header height was too small and looked like a strikethrough. (Follow-on work to clean up the header styles more carefully is planned.)
ECOM-1808

@AlasdairSwan  and @wedaly  Can you review?
