### PR TITLE
Add missing comma to tuple

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -224,4 +224,5 @@ Linda Liu <lliu@edx.org>
 Alessandro Verdura <finalmente2@tin.it>
 Sven Marnach <sven@marnach.net>
 Richard Moch <richard.moch@gmail.com>
+Albert Liang <albertliangcode@gmail.com>
 

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -543,7 +543,7 @@ PIPELINE_JS_COMPRESSOR = None
 
 STATICFILES_IGNORE_PATTERNS = (
     "*.py",
-    "*.pyc"
+    "*.pyc",
     # it would be nice if we could do, for example, "**/*.scss",
     # but these strings get passed down to the `fnmatch` module,
     # which doesn't support that. :(


### PR DESCRIPTION
Currently, Python implicitly concatenates two string entries located next to
each other because there is no comma separating them.  The code concatenates
"_.pyc" and "sass/_.scss", creating a single entry called "_.pycsass/_.scss".
