### PR TITLE
Fix errors with fetching Shibboleth metadata

### DIFF
--- a/common/djangoapps/third_party_auth/tasks.py
+++ b/common/djangoapps/third_party_auth/tasks.py
@@ -63,7 +63,7 @@ def fetch_saml_metadata():
 
             try:
                 parser = etree.XMLParser(remove_comments=True)
-                xml = etree.fromstring(response.text, parser)
+                xml = etree.fromstring(response.content, parser)
             except etree.XMLSyntaxError:
                 raise
             # TODO: Can use OneLogin_Saml2_Utils to validate signed XML if anyone is using that
@@ -80,7 +80,7 @@ def fetch_saml_metadata():
         except Exception as err:  # pylint: disable=broad-except
             log.exception(err.message)
             num_failed += 1
-        return (num_changed, num_failed, len(url_map))
+    return (num_changed, num_failed, len(url_map))
 
 
 def _parse_metadata_xml(xml, entity_id):

--- a/common/djangoapps/third_party_auth/tests/data/testshib_metadata.xml
+++ b/common/djangoapps/third_party_auth/tests/data/testshib_metadata.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- Cached and simplified copy of https://www.testshib.org/metadata/testshib-providers.xml -->
 <EntitiesDescriptor Name="urn:mace:shibboleth:testshib:two"
     xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#"


### PR DESCRIPTION
**Description**:
I found a couple of bugs with the Shibboleth metadata fetching (See #8155, #8140).

First, due to an indentation error, the fetch code was `return`ing prematurely and wouldn't fetch all the providers.

Second, if a provider's metadata specifies an encoding, e.g. `<?xml version="1.0" encoding="UTF-8"?>`, then the XML parser would reject it:

```
ValueError: Unicode strings with encoding declaration are not supported. Please use bytes input or XML fragments without declaration.
```

The solution is to pass the XML data as a bytestring rather than a unicode string. I included an updated test for this.

**Merge target**: Should be included in Cypress as it is pretty key to the SAML functionality.

**JIRA**: None

**Dependencies**: None

**Sandbox**: http://sandbox5.opencraft.com

**Test Instructions**:
To test on the sandbox, SSH in and as `edxapp` run the command `./manage.py lms saml pull --settings=aws`.

To test on a devstack, configure at least two SAML providers and run the command `./manage.py lms saml pull --settings=devstack`. For the metadata URL setting, one can be any a nonexistent URL and the other should be `http://calnet-tin.ist.berkeley.edu/shib/shib-test.b.e-metadata.xml` which is the metadata file that made me aware of the encoding issue.

**Reviewers**: @e-kolpakov and Cale
