### PR TITLE
Fix 'stuck in publish issue' when deleting a component

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
@@ -2397,6 +2397,8 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
                 parent_block.edit_info.edited_by = user_id
                 parent_block.edit_info.previous_version = parent_block.edit_info.update_version
                 parent_block.edit_info.update_version = new_id
+                # remove the source_version reference
+                parent_block.edit_info.source_version = None
                 self.decache_block(usage_locator.course_key, new_id, parent_block_key)
 
             self._remove_subtree(BlockKey.from_usage_key(usage_locator), new_blocks)


### PR DESCRIPTION
[PLAT-633 ](https://openedx.atlassian.net/browse/PLAT-633) Delete Case

<h4>Description</h4> 

After discarding a unit's changes, deleting a component creates 'stuck in publish mode' issue. 

<h4>Steps to Reproduce</h4>
1. Create a Unit
2. Add a component 
3. Add changes to the component ( Example : Change it's name ) 
4. Discard changes
5. Now delete the component
6. Observe that Unit is stuck in publish mode
