### PR TITLE
Trying to remove the second blank page from printed certs

### DIFF
--- a/lms/static/certificates/sass/_print.scss
+++ b/lms/static/certificates/sass/_print.scss
@@ -15,10 +15,15 @@
 
 // page set up - only available to modern browsers now
 @page {
-    size : landscape;
+    size: landscape; // sets the printer page size
+    margin: 0mm; // affects the margin in the printer settings
 }
 
 @media print {
+
+    body {
+        margin: 0px; // the margin on the content before printing
+    }
 
     // helpers
     %print-no-background {
@@ -93,6 +98,11 @@
 // #LAYOUT
 // ------------------------------
 @media print {
+
+    html,
+    body {
+        page-break-after: avoid; // avoids a line break after the content if possible
+    }
 
     // hide elements not needed for print rendering
     .wrapper-banner-user,


### PR DESCRIPTION
This PR tried various methods to remove the second, blank page when printing certs. Research turned up several ideas, but nothing seemed to work. I tried removing margins and padding, and hiding (entirely) all of the `.sr-only` elements.

FYI @talbs @pbaruah 
