### PR TITLE
change redirect url from '/accounts/login' to '/login'

### DIFF
--- a/common/djangoapps/external_auth/tests/test_ssl.py
+++ b/common/djangoapps/external_auth/tests/test_ssl.py
@@ -170,7 +170,7 @@ class SSLClientTest(ModuleStoreTestCase):
         """
         response = self.client.get(reverse('dashboard'), follows=True)
         self.assertEqual(response.status_code, 302)
-        self.assertIn(reverse('accounts_login'), response['location'])
+        self.assertIn(reverse('signin_user'), response['location'])
 
         response = self.client.get(
             reverse('dashboard'), follow=True,

--- a/common/djangoapps/student/tests/test_login.py
+++ b/common/djangoapps/student/tests/test_login.py
@@ -429,7 +429,7 @@ class ExternalAuthShibTest(ModuleStoreTestCase):
         """
         response = self.client.get(reverse('dashboard'))
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(response['Location'], 'http://testserver/accounts/login?next=/dashboard')
+        self.assertEqual(response['Location'], 'http://testserver/login?next=/dashboard')
 
     @unittest.skipUnless(settings.FEATURES.get('AUTH_USE_SHIB'), "AUTH_USE_SHIB not set")
     def test_externalauth_login_required_course_context(self):
@@ -440,7 +440,7 @@ class ExternalAuthShibTest(ModuleStoreTestCase):
         TARGET_URL = reverse('courseware', args=[self.course.id.to_deprecated_string()])            # pylint: disable=invalid-name
         noshib_response = self.client.get(TARGET_URL, follow=True)
         self.assertEqual(noshib_response.redirect_chain[-1],
-                         ('http://testserver/accounts/login?next={url}'.format(url=TARGET_URL), 302))
+                         ('http://testserver/login?next={url}'.format(url=TARGET_URL), 302))
         self.assertContains(noshib_response, ("Sign in or Register | {platform_name}"
                                               .format(platform_name=settings.PLATFORM_NAME)))
         self.assertEqual(noshib_response.status_code, 200)

--- a/common/djangoapps/student/tests/test_login_registration_forms.py
+++ b/common/djangoapps/student/tests/test_login_registration_forms.py
@@ -90,7 +90,7 @@ class LoginFormTest(ThirdPartyAuthTestMixin, UrlResetMixin, ModuleStoreTestCase)
         self.assertRedirects(
             response,
             u"{url}?next={redirect_url}".format(
-                url=reverse("accounts_login"),
+                url=reverse("signin_user"),
                 redirect_url=self.courseware_url
             )
         )

--- a/lms/djangoapps/course_wiki/middleware.py
+++ b/lms/djangoapps/course_wiki/middleware.py
@@ -46,7 +46,7 @@ class WikiAccessMiddleware(object):
 
         # wiki pages are login required
         if not request.user.is_authenticated():
-            return redirect(reverse('accounts_login'), next=request.path)
+            return redirect(reverse('signin_user'), next=request.path)
 
         course_id = course_id_from_url(request.path)
         wiki_path = request.path.partition('/wiki/')[2]

--- a/lms/djangoapps/course_wiki/tests/tests.py
+++ b/lms/djangoapps/course_wiki/tests/tests.py
@@ -165,4 +165,4 @@ class WikiRedirectTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase):
         # and end up at the login page
         resp = self.client.get(course_wiki_page, follow=True)
         target_url, __ = resp.redirect_chain[-1]
-        self.assertTrue(reverse('accounts_login') in target_url)
+        self.assertTrue(reverse('signin_user') in target_url)

--- a/lms/djangoapps/verify_student/tests/test_views.py
+++ b/lms/djangoapps/verify_student/tests/test_views.py
@@ -543,7 +543,7 @@ class TestPayAndVerifyView(UrlResetMixin, ModuleStoreTestCase):
 
         original_url = reverse(url_name, kwargs={'course_id': unicode(course.id)})
         login_url = u"{login_url}?next={original_url}".format(
-            login_url=reverse('accounts_login'),
+            login_url=reverse('signin_user'),
             original_url=original_url
         )
         self.assertRedirects(response, login_url)

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -546,8 +546,8 @@ DEV_CONTENT = True
 
 EDX_ROOT_URL = ''
 
-LOGIN_REDIRECT_URL = EDX_ROOT_URL + '/accounts/login'
-LOGIN_URL = EDX_ROOT_URL + '/accounts/login'
+LOGIN_REDIRECT_URL = EDX_ROOT_URL + '/login'
+LOGIN_URL = EDX_ROOT_URL + '/login'
 
 COURSE_NAME = "6.002_Spring_2012"
 COURSE_NUMBER = "6.002x"

--- a/lms/static/js/ajax-error.js
+++ b/lms/static/js/ajax-error.js
@@ -9,7 +9,7 @@ $(document).ajaxError(function (event, jXHR) {
 
         if (window.confirm(message)) {
             var currentLocation = window.location.href;
-            window.location.href = '/accounts/login?next=' + currentLocation;
+            window.location.href = '/login?next=' + currentLocation;
         };
     }
 });


### PR DESCRIPTION
ECOM-1734

@awais786 @aamir-khan @ahsan-ul-haq @wedaly 
On live site url `https://courses.edx.org/accounts/login` was observed taking relatively longer time than `https://courses.edx.org/login` or `https://courses.edx.org/register`.
Changed redirect login url from `https://courses.edx.org/accounts/login` to `https://courses.edx.org/login`.

@wedaly I tested load time of different urls on devstack but there was just a slight difference.
