### PR TITLE
instructor tasks convert int to dict

### DIFF
--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -3210,6 +3210,11 @@ class TestInstructorAPITaskLists(ModuleStoreTestCase, LoginEnrollmentTestCase):
             # can't be properly parsed
             self.duration_sec = 'unknown'
 
+        def task_output_integer_response(self):
+            """Mock task_output to contain integer"""
+            self.task_output = '1500000'
+            self.duration_sec = 1500000 / 1000.0
+
         def to_dict(self):
             """ Convert fake task to dictionary representation. """
             attr_dict = {key: getattr(self, key) for key in self.FEATURES}
@@ -3242,6 +3247,7 @@ class TestInstructorAPITaskLists(ModuleStoreTestCase, LoginEnrollmentTestCase):
         mock_factory = MockCompletionInfo()
         self.tasks = [self.FakeTask(mock_factory.mock_get_task_completion_info) for _ in xrange(7)]
         self.tasks[-1].make_invalid_output()
+        self.tasks[-2].task_output_integer_response()
 
     @patch.object(instructor_task.api, 'get_running_instructor_tasks')
     def test_list_instructor_tasks_running(self, act):

--- a/lms/djangoapps/instructor/views/instructor_task_helpers.py
+++ b/lms/djangoapps/instructor/views/instructor_task_helpers.py
@@ -121,6 +121,8 @@ def extract_task_features(task):
         except ValueError:
             log.error("Could not parse task output as valid json; task output: %s", task.task_output)
         else:
+            if isinstance(task_output, int):
+                task_output = {'duration_ms': task_output}
             if 'duration_ms' in task_output:
                 duration_sec = int(task_output['duration_ms'] / 1000.0)
     task_feature_dict['duration_sec'] = duration_sec


### PR DESCRIPTION
[TNL-2502](https://openedx.atlassian.net/browse/TNL-2502)

If task_output of task is `integer` instead of `dict` (contains "duration_ms" value) then convert this integer value to dict have key value pair in the form of `{duration_ms:integer_value}`
