### PR TITLE
Fixing aria values and contrast for accessibility

### DIFF
--- a/lms/static/sass/course/modules/_calculator.scss
+++ b/lms/static/sass/course/modules/_calculator.scss
@@ -68,9 +68,7 @@ div.calc-main {
       @include box-sizing(border-box);
       padding: lh();
 
-      label.sr {
-        // including the label here in case other .sr values are added
-        // we want to limit this 'white' only to the label
+      .calc-output-label {
         color: $white;
       }
 
@@ -95,9 +93,7 @@ div.calc-main {
           color: #333;
         }
 
-        span.sr {
-          // including the element here in case other .sr values are added
-          // we want to limit this 'white' only to the span
+        .calc-button-label {
           background: $black;
           color: $white;
         }
@@ -163,9 +159,7 @@ div.calc-main {
               border: none;
             }
 
-            span.sr {
-              // including the element here in case other .sr values are added
-              // we want to limit this 'white' only to the span
+            .calc-hint {
               background: $black;
               color: $white;
             }

--- a/lms/static/sass/course/modules/_calculator.scss
+++ b/lms/static/sass/course/modules/_calculator.scss
@@ -37,14 +37,20 @@ div.calc-main {
       background-color: $black;
       top: -36px;
     }
+
+    .utility-control-label {
+      background: $black;
+      color: $white;
+    }
   }
 
   div#calculator_wrapper {
-    background: $black;
     clear: both;
-    max-height: 90px;
     position: relative;
     top: -36px;
+    max-height: 90px;
+    background: $black;
+    color: $white;
 
     // UI: input help table
     .calculator-input-help-table {
@@ -61,6 +67,12 @@ div.calc-main {
       @extend .clearfix;
       @include box-sizing(border-box);
       padding: lh();
+
+      label.sr {
+        // including the label here in case other .sr values are added
+        // we want to limit this 'white' only to the label
+        color: $white;
+      }
 
       button#calculator_button {
         background: #111;
@@ -81,6 +93,13 @@ div.calc-main {
 
         &:hover, &:focus {
           color: #333;
+        }
+
+        span.sr {
+          // including the element here in case other .sr values are added
+          // we want to limit this 'white' only to the span
+          background: $black;
+          color: $white;
         }
       }
 
@@ -125,18 +144,30 @@ div.calc-main {
           right: 0;
           top: 0;
 
+          #hint-instructions {
+            color: $white;
+          }
+
           #calculator_hint {
-            background: url("../images/info-icon.png") center center no-repeat;
-            height: 35px;
             @include hide-text;
-            width: 35px;
             display: block;
+            height: 35px;
+            width: 35px;
             border: none;
+            background: url("../images/info-icon.png") center center no-repeat;
+            color: $white;
 
             &:focus {
               outline: 5px auto #5b9dd9;
               box-shadow: none;
               border: none;
+            }
+
+            span.sr {
+              // including the element here in case other .sr values are added
+              // we want to limit this 'white' only to the span
+              background: $black;
+              color: $white;
             }
           }
 

--- a/lms/templates/calculator/toggle_calculator.html
+++ b/lms/templates/calculator/toggle_calculator.html
@@ -17,7 +17,7 @@ from django.core.urlresolvers import reverse
         <div class="help-wrapper">
           <p class="sr" id="hint-instructions">${_('Use the arrow keys to navigate the tips or use the tab key to return to the calculator')}</p>
 
-          <button id="calculator_hint" aria-haspopup="true" aria-expanded="false" aria-controls="calculator_input_help" aria-describedby="hint-instructions"><span class="sr">${_("Hints")}</span></button>
+          <button id="calculator_hint" aria-haspopup="true" aria-expanded="false" aria-controls="calculator_input_help" aria-describedby="hint-instructions"><span class="calc-hint sr">${_("Hints")}</span></button>
 
           <ul id="calculator_input_help" class="help" aria-hidden="true">
             <li class="hint-item" id="hint-moreinfo">
@@ -135,8 +135,8 @@ from django.core.urlresolvers import reverse
         </div>
       </div>
 
-      <button id="calculator_button">=<span class="sr">${_('Calculate')}</span></button>
-      <label for="calculator_output" class="sr">${_('Calculator Output')}</label>
+      <button id="calculator_button">=<span class="calc-button-label sr">${_('Calculate')}</span></button>
+      <label for="calculator_output" class="calc-output-label sr">${_('Calculator Output')}</label>
       <input type="text" id="calculator_output" readonly />
     </form>
   </div>

--- a/lms/templates/calculator/toggle_calculator.html
+++ b/lms/templates/calculator/toggle_calculator.html
@@ -17,7 +17,7 @@ from django.core.urlresolvers import reverse
         <div class="help-wrapper">
           <p class="sr" id="hint-instructions">${_('Use the arrow keys to navigate the tips or use the tab key to return to the calculator')}</p>
 
-          <button id="calculator_hint" aria-haspopup="true" aria-expanded="false" aria-controls=“calculator_input_help” aria-describedby="hint-instructions"><span class="sr">${_("Hints")}</span></button>
+          <button id="calculator_hint" aria-haspopup="true" aria-expanded="false" aria-controls="calculator_input_help" aria-describedby="hint-instructions"><span class="sr">${_("Hints")}</span></button>
 
           <ul id="calculator_input_help" class="help" aria-hidden="true">
             <li class="hint-item" id="hint-moreinfo">


### PR DESCRIPTION
This work addresses [UX-2337](https://openedx.atlassian.net/browse/UX-2337) which fixes an `aria` value and increases contrast on some screen-reader only elements to pass automated validators.

In most cases, foreground and background colors weren't specified, but by adding `color` and `background` to the screen-reader only elements (which aren't seen visually anyway), the automated tests will not fail on contrast tests.

Note: This work doesn't affect anything visually.

Sandbox: http://clrux-2337.m.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/courseware/interactive_demonstrations/basic_questions/

---

Reviewers:
- [x] @cptvitamin (accessibility)
- [x] @talbs (FED)
