### PR TITLE
Fix migrations 0012 and 0013 in the credit app

### DIFF
--- a/openedx/core/djangoapps/credit/migrations/0012_remove_m2m_course_and_provider.py
+++ b/openedx/core/djangoapps/credit/migrations/0012_remove_m2m_course_and_provider.py
@@ -124,7 +124,8 @@ class Migration(SchemaMigration):
             'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
             'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
-            'namespace': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+            'namespace': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'order': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'})
         },
         'credit.creditrequirementstatus': {
             'Meta': {'unique_together': "(('username', 'requirement'),)", 'object_name': 'CreditRequirementStatus'},

--- a/openedx/core/djangoapps/credit/migrations/0013_add_provider_status_url.py
+++ b/openedx/core/djangoapps/credit/migrations/0013_add_provider_status_url.py
@@ -105,7 +105,8 @@ class Migration(SchemaMigration):
             'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
             'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
-            'namespace': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+            'namespace': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'order': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'})
         },
         'credit.creditrequirementstatus': {
             'Meta': {'unique_together': "(('username', 'requirement'),)", 'object_name': 'CreditRequirementStatus'},


### PR DESCRIPTION
Adds the "order" field that was introduced in 0011 to the "models"
dictionary of migrations 0012 and 0013 so South knows that
the field should exist after 0011 is run.

@rlucioni please review
FYI: @feanil @zubair-arbi @BenjiLee 
