### PR TITLE
Feature flag credit provider messaging on the dashboard.

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -531,7 +531,10 @@ def dashboard(request):
     for course, __ in course_enrollment_pairs:
         enrolled_courses_dict[unicode(course.id)] = course
 
-    credit_messages = _create_credit_availability_message(enrolled_courses_dict, user)
+    if settings.FEATURES.get("ENABLE_CREDIT_ELIGIBILITY"):
+        credit_messages = _create_credit_availability_message(enrolled_courses_dict, user)
+    else:
+        credit_messages = {}
 
     course_optouts = Optout.objects.filter(user=user).values_list('course_id', flat=True)
 

--- a/openedx/core/djangoapps/credit/tests/test_api.py
+++ b/openedx/core/djangoapps/credit/tests/test_api.py
@@ -5,6 +5,8 @@ import unittest
 import datetime
 import ddt
 import pytz
+from mock import patch
+
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.db import connection, transaction
@@ -697,6 +699,7 @@ class CreditMessagesTests(ModuleStoreTestCase, CreditApiTestBase):
         request_status = api.get_credit_request_status(self.student.username, self.course.id)
         self.assertEqual(len(request_status), 0)
 
+    @patch.dict(settings.FEATURES, {"ENABLE_CREDIT_ELIGIBILITY": True})
     def test_credit_messages(self):
         self._set_creditcourse()
 


### PR DESCRIPTION
When the credit eligibility is disabled, skip the code
that access the CreditProvider table.  This will allow us
to safely delete a column from the table in rc/2015-07-08.

I've tested this change locally with migrations 0012 and 0013 from rc/2015-07-08 and verified that the student dashboard renders without error.  I've also checked the other pages that we've modified for credit, and they are all working correctly (dashboard, student progress page, Studio grading and schedule pages)

The plan is to release this as a hotfix ahead of the 2015-07-08 release, so that the migrations in that release will be backwards compatible.

JIRA: [ECOM-1819](https://openedx.atlassian.net/browse/ECOM-1819)

@clintonb could you please review this change?
FYI: @feanil @BenjiLee 
