### PR TITLE
ORA2: Focus and outline styles

### DIFF
--- a/lms/static/sass/_shame.scss
+++ b/lms/static/sass/_shame.scss
@@ -252,7 +252,6 @@ footer .references {
 
   &:focus {
     border: none !important;
-    outline: thin dotted !important;
   }
 }
 

--- a/lms/static/sass/base/_reset.scss
+++ b/lms/static/sass/base/_reset.scss
@@ -12,8 +12,6 @@ body { margin: 0; font-size: 1em; line-height: 1.4; }
 a { color: #00e; }
 a:visited { color: #551a8b; }
 a:hover, a:focus { color: #06e; }
-a:focus { outline: thin dotted; }
-a:hover, a:active { outline: 0; }
 abbr[title] { border-bottom: 1px dotted; }
 b, strong { font-weight: bold; }
 blockquote { margin: 1em 40px; }

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -38,7 +38,7 @@ git+https://github.com/hmarr/django-debug-toolbar-mongo.git@b0686a76f1ce3532088c
 -e git+https://github.com/edx/event-tracking.git@0.2.0#egg=event-tracking
 -e git+https://github.com/edx-solutions/django-splash.git@7579d052afcf474ece1239153cffe1c89935bc4f#egg=django-splash
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
--e git+https://github.com/edx/edx-ora2.git@release-2015-05-08T16.15#egg=edx-ora2
+-e git+https://github.com/edx/edx-ora2.git@release-2015-07-09T14.47#egg=edx-ora2
 -e git+https://github.com/edx/edx-submissions.git@7c766502058e04bc9094e6cbe286e949794b80b3#egg=edx-submissions
 -e git+https://github.com/edx/opaque-keys.git@27dc382ea587483b1e3889a3d19cbd90b9023a06#egg=opaque-keys
 -e git+https://github.com/edx/ease.git@b67d2928a26fe497826b6ea359b9a3d0371548a7#egg=ease==0.1.3


### PR DESCRIPTION
This small bit of work is meant to be published alongside [ORA2-707](https://github.com/edx/edx-ora2/pull/707/). It addresses the lack of focus outlines on certain important elements. In general, it also restores any previously removed outlines from focus across the board.

**Important: This PR includes an edit to the `github.txt` requirements file. It is only to be used for the sandbox and should not be merged into master.**
