### PR TITLE
ECOM-1829 Removing the regen link.

### DIFF
--- a/lms/templates/courseware/progress.html
+++ b/lms/templates/courseware/progress.html
@@ -59,8 +59,7 @@ from django.utils.http import urlquote_plus
               <div class="msg-content">
                 <h2 class="title">${_("Your certificate is available")}</h2>
                 <p class="copy">
-                  ${_("You can now access your certificate. If you keep working and receive a higher grade,you can request an {link_start} updated certificate {link_end}.").format(
-                    link_start=u"<a class='generate_certs' href='#' data-endpoint={}>".format(post_url), link_end=u"</a>")}
+                  ${_("You can now access your certificate. If you keep working and receive a higher grade, you can request an updated certificate.")}
                 </p>
               </div>
               <div class="msg-actions">


### PR DESCRIPTION
Remove the regen-cert link from progress page.
