### PR TITLE
Remove the DjDT profiling panel from devstack.py. It appears to cause…

### DIFF
--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -62,7 +62,10 @@ DEBUG_TOOLBAR_PANELS = (
     'debug_toolbar.panels.signals.SignalsPanel',
     'debug_toolbar.panels.logging.LoggingPanel',
     'debug_toolbar_mongo.panel.MongoDebugPanel',
-    'debug_toolbar.panels.profiling.ProfilingPanel',
+    # ProfilingPanel has been intentionally removed for default devstack.py
+    # runtimes for performance reasons. If you wish to re-enable it in your
+    # local development environment, please create a new settings file
+    # that imports and extends devstack.py.
 )
 
 DEBUG_TOOLBAR_CONFIG = {


### PR DESCRIPTION
… horrendeous performance issues, while offering very little benefit.
