### PR TITLE
Add a directory for storing XBlock in devstack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 requirements/private.txt
 lms/envs/private.py
 cms/envs/private.py
+xblocks/*
+!xblocks/README.txt
+!xblocks/fetch-xblocks.sh
 
 ### Python artifacts
 *.pyc

--- a/xblocks/README.txt
+++ b/xblocks/README.txt
@@ -1,0 +1,38 @@
+This is a directory for holding third party XBlocks not included with
+edx-platform. This is helpful since this directory is shared with
+vagrant in the edX vagrant, and so it is a good place to keep these
+while developing.
+
+There is a script which will grab many of the known XBlocks (but not
+install them). To install them, run 'python setup.py develop' from
+within vagrant (not on the host machine).
+
+Be aware most of the XBlocks in this script were developed by third
+parties, and have not been reviewed by edX:
+
+* We have not audited the source code for security. 
+* We have no audited the code for scaling, robustness, or
+  compatibility with future versions of edX.
+
+Please be very aware of security issues with running programs (these
+and others) from untrusted locations. Before running something which
+manages learner data, you'll want to either:
+
+1. Make sure you either trust the author (for example, running
+   edX-developed prototype XBlocks is probably okay, as is from some
+   of the major companies around the edX ecosystem)
+2. Have looked over the source code to make sure something malicious
+   isn't going on. In most cases, this is pretty fast.
+
+Listing in the file (or lack thereof) isn't any sort of
+endorsement. This is what we could find on the internet on a quick
+skim. In some cases, there are variants of the same XBlock in multiple
+git repos. In such cases, the choice of which one we included was
+nearly random (we did a quick skim to either get the one others forked
+from, most recent commits, or whichever one first came up on
+Google). If you see missing XBlocks, incorrect/non-canonical forks,
+etc., please make a pull request to fix it.
+
+Grabbing all of these XBlocks will use nearly a gig of disk
+space. Installing all of them will most likely result in an unstable
+system -- a few are prototypes, or require external services to work.

--- a/xblocks/fetch-xblocks.sh
+++ b/xblocks/fetch-xblocks.sh
@@ -1,0 +1,78 @@
+# edX Learning Sciences -- working XBlocks
+git clone https://github.com/pmitros/AnimationXBlock.git
+git clone https://github.com/pmitros/AudioXBlock.git
+git clone https://github.com/pmitros/DisqusXBlock.git
+git clone https://github.com/pmitros/DoneXBlock.git
+git clone https://github.com/pmitros/ImageXBlock.git
+git clone https://github.com/pmitros/RateXBlock.git
+git clone https://github.com/pmitros/RecommenderXBlock.git
+git clone https://github.com/pmitros/SelfCheckXBlock.git
+# edX Learning Sciences -- prototypes
+git clone https://github.com/pmitros/ConceptXBlock.git
+git clone https://github.com/pmitros/ProfileXBlock.git
+git clone https://github.com/pmitros/XBadger.git
+git clone https://github.com/DongwookYoon/RichReviewXBlock.git
+git clone https://github.com/solashirai/crowdsourcehinter.git
+
+# edX Solutions
+git clone https://github.com/edx-solutions/xblock-adventure.git
+git clone https://github.com/edx-solutions/xblock-brightcove.git
+git clone https://github.com/edx-solutions/xblock-discussion.git
+git clone https://github.com/edx-solutions/xblock-drag-and-drop-v2.git
+git clone https://github.com/edx-solutions/xblock-drag-and-drop.git
+git clone https://github.com/edx-solutions/xblock-google-drive.git
+git clone https://github.com/edx-solutions/xblock-group-project.git
+git clone https://github.com/edx-solutions/xblock-image-explorer.git
+git clone https://github.com/edx-solutions/xblock-ooyala.git
+
+# UP Valencia poliMedia
+git clone https://github.com/polimediaupv/cdfXblock.git
+git clone https://github.com/polimediaupv/multitabXBlock.git
+git clone https://github.com/polimediaupv/paellaXBlock.git
+git clone https://github.com/polimediaupv/pdfXBlock.git
+git clone https://github.com/polimediaupv/webProblemXBlock
+
+# MarCnu
+git clone https://github.com/MarCnu/flashXBlock.git
+git clone https://github.com/MarCnu/pdfXBlock.git
+git clone https://github.com/MarCnu/videojsXBlock.git
+
+# ExtensionEnginge
+git clone https://github.com/ExtensionEngine/xblock_3d_viewer.git
+git clone https://github.com/ExtensionEngine/xblock_charting.git
+
+# Advanced Digital Learning
+git clone https://github.com/adlnet/Table-XBlock.git
+git clone https://github.com/adlnet/sandbox-xblock.git
+
+# Boston University MET IT
+git clone https://github.com/METIT-BU/xblock-carousel.git
+git clone https://github.com/METIT-BU/xblock-carouselworkspace.git
+
+# Microsoft
+git clone https://github.com/MSOpenTech/xblock-filestorage.git
+git clone https://github.com/OfficeDev/xblock-officemix.git
+
+# OpenCraft
+git clone https://github.com/open-craft/problem-builder.git
+git clone https://github.com/open-craft/xblock-leaderboard.git
+
+# edX
+git clone https://github.com/edx/edx-ora.git
+git clone https://github.com/edx/edx-ora2.git
+
+# UCIII-Madrid
+git clone https://github.com/UC3Mx/ratingXBlock.git
+
+# McKinsey Academy
+git clone https://github.com/mckinseyacademy/xblock-poll.git
+
+# MIT Office of Digital Learning
+git clone https://github.com/mitodl/edx-sga.git
+
+# School Yourself
+git clone https://github.com/schoolyourself/schoolyourself-xblock.git
+
+# Harvard GSE
+git clone https://github.com/gsehub/xblock-mentoring.git
+


### PR DESCRIPTION
Right now, when you develop XBlocks in devstack, they are usually in an ad-hoc location. There's a lot of hassle bringing syncing them if installed inside devstack (devstack doesn't have github ssh keys), and most people don't install them somewhere shared (it's obvious in retrospect that you should put them in one of the shared dirs, but to most developers, not at the time).

Existing XBlocks are also somewhat challenging to find (did you know we're at over 50 XBlocks now?). They're nice to have to build off of, grep for how to do things, etc.

This:
- Creates a consistent place to put XBlocks for development
- Has a script which lets you grab all the XBlocks we know about (but not install them)

@nedbat @e0d Thoughts?
