### PR TITLE
rc/2015-07-08-mattdrayer: Hide button behind feature flag

### DIFF
--- a/common/test/acceptance/tests/lms/test_lms_instructor_dashboard.py
+++ b/common/test/acceptance/tests/lms/test_lms_instructor_dashboard.py
@@ -416,8 +416,9 @@ class CertificatesTest(BaseInstructorDashboardTest):
         """
         Scenario: On the Certificates tab of the Instructor Dashboard, Generate Certificates button is visible.
             Given that I am on the Certificates tab on the Instructor Dashboard
-            Then I see 'Generate Certificates' button
-            And when I click on 'Generate Certificates' button
+            And the instructor-generation feature flag has been enabled
+            Then I see a 'Generate Certificates' button
+            And when I click on the 'Generate Certificates' button
             Then I should see a status message and 'Generate Certificates' button should be disabled.
         """
         self.assertTrue(self.certificates_section.generate_certificates_button.visible)

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -245,12 +245,15 @@ def _section_certificates(course):
             for cert_status in example_cert_status
         )
     )
+    instructor_generation_enabled = settings.FEATURES.get('CERTIFICATES_INSTRUCTOR_GENERATION', False)
+
     return {
         'section_key': 'certificates',
         'section_display_name': _('Certificates'),
         'example_certificate_status': example_cert_status,
         'can_enable_for_course': can_enable_for_course,
         'enabled_for_course': certs_api.cert_generation_enabled(course.id),
+        'instructor_generation_enabled': instructor_generation_enabled,
         'urls': {
             'generate_example_certificates': reverse(
                 'generate_example_certificates',

--- a/lms/envs/bok_choy.env.json
+++ b/lms/envs/bok_choy.env.json
@@ -66,6 +66,7 @@
         "AUTH_USE_OPENID_PROVIDER": true,
         "CERTIFICATES_ENABLED": true,
         "CERTIFICATES_HTML_VIEW": true,
+        "CERTIFICATES_INSTRUCTOR_GENERATION": true,
         "MULTIPLE_ENROLLMENT_ROLES": true,
         "SOCIAL_SHARING_SETTINGS": {
             "CUSTOM_COURSE_URLS": true,

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -379,6 +379,9 @@ FEATURES = {
     # Certificates Web/HTML Views
     'CERTIFICATES_HTML_VIEW': False,
 
+    # Batch-Generated Certificates from Instructor Dashboard
+    'CERTIFICATES_INSTRUCTOR_GENERATION': False,
+
     # Social Media Sharing on Student Dashboard
     'SOCIAL_SHARING_SETTINGS': {
         # Note: Ensure 'CUSTOM_COURSE_URLS' has a matching value in cms/envs/common.py

--- a/lms/templates/instructor/instructor_dashboard_2/certificates.html
+++ b/lms/templates/instructor/instructor_dashboard_2/certificates.html
@@ -56,26 +56,28 @@
         % endif
     </div>
 
-    <hr />
+    % if section_data['instructor_generation_enabled']:
+        <hr />
 
-    <div class="start-certificate-generation">
-        <h2>${_("Generate Certificates")}</h2>
-        <form id="certificates-generating-form" method="post" action="${section_data['urls']['start_certificate_generation']}">
-            <input type="button" id="btn-start-generating-certificates" value="${_('Generate Certificates')}" data-endpoint="${section_data['urls']['start_certificate_generation']}"/>
-        </form>
-        <div class="certificate-generation-status"></div>
-    </div>
-
-    %if settings.FEATURES.get('ENABLE_INSTRUCTOR_BACKGROUND_TASKS'):
-        <div class="running-tasks-container action-type-container">
-            <hr>
-            <h2> ${_("Pending Tasks")} </h2>
-            <div class="running-tasks-section">
-                <p>${_("The status for any active tasks appears in a table below.")} </p>
-                <br />
-                <div class="running-tasks-table" data-endpoint="${ section_data['urls']['list_instructor_tasks_url'] }"></div>
-            </div>
-            <div class="no-pending-tasks-message"></div>
+        <div class="start-certificate-generation">
+            <h2>${_("Generate Certificates")}</h2>
+            <form id="certificates-generating-form" method="post" action="${section_data['urls']['start_certificate_generation']}">
+                <input type="button" id="btn-start-generating-certificates" value="${_('Generate Certificates')}" data-endpoint="${section_data['urls']['start_certificate_generation']}"/>
+            </form>
+            <div class="certificate-generation-status"></div>
         </div>
-    %endif
+
+        %if settings.FEATURES.get('ENABLE_INSTRUCTOR_BACKGROUND_TASKS'):
+            <div class="running-tasks-container action-type-container">
+                <hr>
+                <h2> ${_("Pending Tasks")} </h2>
+                <div class="running-tasks-section">
+                    <p>${_("The status for any active tasks appears in a table below.")} </p>
+                    <br />
+                    <div class="running-tasks-table" data-endpoint="${ section_data['urls']['list_instructor_tasks_url'] }"></div>
+                </div>
+                <div class="no-pending-tasks-message"></div>
+            </div>
+        %endif
+    % endif
 </div>


### PR DESCRIPTION
@chrisndodge @BenjiLee @pbaruah -- here is the PR to hide the "Generate Certificates" button away on the Instructor Dashboard.  Tests are passing locally, and fail when I disable the flag in the Bok Choy suite (this is a template behavior mod), so Chris D, if you can perform the sanity check that would be great.
