### PR TITLE
UX-384: Improved visual indicator for graded subsections in LMS sidebar

### DIFF
--- a/lms/static/sass/course/courseware/_sidebar.scss
+++ b/lms/static/sass/course/courseware/_sidebar.scss
@@ -137,10 +137,11 @@
             line-height: 1.3;
 
             &.subtitle {
-              color: #666;
-              font-size: 13px;
-              font-weight: normal;
-              display: block;
+              @extend %t-copy-sub2;
+              @extend %t-weight2;
+              display: inline-block;
+              width: 90%;
+              color: $gray-d1;
               margin: 0;
 
               &:empty {
@@ -153,7 +154,7 @@
             background: $shadow-l1;
 
             > a p {
-              color: #333;
+              color: $gray-d3;
             }
           }
 
@@ -168,7 +169,7 @@
         }
 
         &.active {
-          font-weight: bold;
+          @extend %t-weight5;
 
           &:after {
             content: '›';
@@ -199,19 +200,15 @@
           }
 
           span.subtitle {
-            font-weight: normal;
+            @extend %t-weight2;
           }
         }
 
         &.graded {
-         > a {
-           > img {
-             position: absolute;
-             top: 0;
-             bottom: 0;
-             @include right(7px);
-             margin: auto;
-           }
+          > a {
+            .icon {
+              vertical-align: middle;
+            }
           }
 
           &.active > a {

--- a/lms/templates/courseware/accordion.html
+++ b/lms/templates/courseware/accordion.html
@@ -36,7 +36,7 @@
               <p class="subtitle">${section['format']} ${due_date}</p>
 
               % if 'graded' in section and section['graded']:
-                  <img src="/static/images/graded.png" alt="Graded Section">
+              <i class="icon fa fa-pencil-square-o" aria-hidden="true" data-tooltip="${_("This section is graded.")}"></i>
               % endif
             </a>
           </li>


### PR DESCRIPTION
**Description**
This PR changes the current image on subsections which marks them as 'graded.' The proposal is to use a font-awesome icon with a data-tooltip, hidden to screenreaders due to the fact that the subsection support text already explains its assignment type and due date.

---

**JIRA Story** ([UX-384](https://openedx.atlassian.net/browse/UX-384))
**Confluence / Product Asset** N/A
**Sandbox URL** (7/14, 8:15am) ([pr8812.m.sandbox.edx.org](http://pr8812.m.sandbox.edx.org)) 
**Dependencies** None

---

**PR Author(s) Notes / To-Do** A list of known open tasks that the PR author has.
- [x] spin up sandbox
- [x] tag reviewers 

---

**Screenshots** 
Base Changes:
https://s3.amazonaws.com/uploads.hipchat.com/26537/183095/dc2xZboOsckob2k/upload.png
Hover with Tooltip:
https://s3.amazonaws.com/uploads.hipchat.com/26537/183095/8N18W2zouV3tbQq/upload.png

---

**Reviewers**
- [x] Code: @clrux, 
- [x] UX/VIZ: @frrrances,
- [x] Product: @explorerleslie,
- [x] Documentation: @srpearce 
