### PR TITLE
Fix hinted login view to be compatible with secondary providers.

### DIFF
--- a/lms/static/js/spec/student_account/hinted_login_spec.js
+++ b/lms/static/js/spec/student_account/hinted_login_spec.js
@@ -28,15 +28,23 @@ define([
                         loginUrl: '/auth/login/facebook/?auth_entry=account_login',
                         registerUrl: '/auth/login/facebook/?auth_entry=account_register'
                     }
+                ],
+                secondaryProviders: [
+                    {
+                        id: 'saml-harvard',
+                        name: 'Harvard',
+                        iconClass: 'fa-university',
+                        loginUrl: '/auth/login/tpa-saml/?auth_entry=account_login&idp=harvard',
+                        registerUrl: '/auth/login/tpa-saml/?auth_entry=account_register&idp=harvard'
+                    }
                 ]
-            },
-            HINTED_PROVIDER = "oa2-google-oauth2";
+            };
 
-        var createHintedLoginView = function(test) {
+        var createHintedLoginView = function(hintedProvider) {
             // Initialize the login view
             view = new HintedLoginView({
                 thirdPartyAuth: THIRD_PARTY_AUTH,
-                hintedProvider: HINTED_PROVIDER,
+                hintedProvider: hintedProvider,
                 platformName: PLATFORM_NAME
             });
 
@@ -52,15 +60,23 @@ define([
         });
 
         it('displays a choice as two buttons', function() {
-            createHintedLoginView(this);
+            createHintedLoginView("oa2-google-oauth2");
 
             expect($('.proceed-button.button-oa2-google-oauth2')).toBeVisible();
             expect($('.form-toggle')).toBeVisible();
             expect($('.proceed-button.button-oa2-facebook')).not.toBeVisible();
         });
 
+        it('works with secondary providers as well', function() {
+            createHintedLoginView("saml-harvard");
+
+            expect($('.proceed-button.button-saml-harvard')).toBeVisible();
+            expect($('.form-toggle')).toBeVisible();
+            expect($('.proceed-button.button-oa2-google-oauth2')).not.toBeVisible();
+        });
+
         it('redirects the user to the hinted provider if the user clicks the proceed button', function() {
-            createHintedLoginView(this);
+            createHintedLoginView("oa2-google-oauth2");
 
             // Click the "Yes, proceed" button
             $('.proceed-button').click();

--- a/lms/static/js/student_account/views/HintedLoginView.js
+++ b/lms/static/js/student_account/views/HintedLoginView.js
@@ -19,18 +19,14 @@ var edx = edx || {};
 
         initialize: function( data ) {
             this.tpl = $(this.tpl).html();
-            this.providers = data.thirdPartyAuth.providers || [];
-            this.hintedProvider = _.findWhere(this.providers, {id: data.hintedProvider})
-            this.platformName = data.platformName;
-
+            this.hintedProvider = (
+                _.findWhere(data.thirdPartyAuth.providers, {id: data.hintedProvider}) ||
+                _.findWhere(data.thirdPartyAuth.secondaryProviders, {id: data.hintedProvider})
+            );
         },
 
         render: function() {
             $(this.el).html( _.template( this.tpl, {
-                // We pass the context object to the template so that
-                // we can perform variable interpolation using sprintf
-                providers: this.providers,
-                platformName: this.platformName,
                 hintedProvider: this.hintedProvider
             }));
 


### PR DESCRIPTION
**Bug**
Two features were developed in parallel and merged at about the same time during the SSO work, and though they work fine in isolation, they don't work together:
- Ability to configure third party auth providers as "secondary" providers #8603
- Ability to specify default ("hinted") third_party_auth provider via query param #8591

I was recently taking some screenshots on a sandbox and noticed that the "hinting" feature doesn't work for providers marked as "secondary".

**Fix**
The fix is quite simple: In the JS, the code currently looks for information about the hinted provider in the list of `providers` it is given. With this fix, it will also search the list of `secondaryProviders`.

Includes an updated JS test to cover this case, and I confirmed that the test fails without this fix.

**Affects**
This two features are key to the user experience of the new SSO functionality, and it is critical that they are able to work together.

**Sandbox**
http://sandbox5.opencraft.com/

**Testing Instructions**:
Try the following links in an incognito window. Note: the actual login process may not complete successfully on this sandbox as the providers are not configured, but the login form should at least display properly and the buttons should all work.

This link should display the Google login hint (this was working before):
http://sandbox5.opencraft.com/courses/course-v1:BradenX+DW+15/courseware/3d6ec3a921a645fea6e63e3e240f8946/0ae68e6072cd47beb332a87693339d8a/1?tpa_hint=oa2-google-oauth2

This link should also work, and display a UBC prompt (this was broken):
http://sandbox5.opencraft.com/courses/course-v1:BradenX+DW+15/courseware/3d6ec3a921a645fea6e63e3e240f8946/0ae68e6072cd47beb332a87693339d8a/1?tpa_hint=saml-ubc-staging

Before this fix, the above page was blank except for a header, due to a JS error.

**Reviewers**
@Kelketek and ??

**Merge deadline**
ASAP.
