### PR TITLE
TNL-2665 Prevent Taiwan from being translated

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2421,7 +2421,8 @@ INVOICE_PAYMENT_INSTRUCTIONS = "This is where you can\nput directions on how peo
 # Country code overrides
 # Used by django-countries
 COUNTRIES_OVERRIDE = {
-    "TW": _("Taiwan"),
+    # Taiwan is specifically not translated to avoid it being translated as "Taiwan (Province of China)"
+    "TW": "Taiwan",
 }
 
 # which access.py permission name to check in order to determine if a course is visible in


### PR DESCRIPTION
Currently, a student who has selected Simplified Chinese on the account settings page will see "中国台湾省" at the bottom of the countries list, which translates to "Taiwan Province of China". This happens because Taiwan is defined explicitly in COUNTRIES_OVERRIDE from common.py as "Taiwan" instead of the django-countries default of "Taiwan (Province of China)". Because the string now exists in edx-platform source, it is scraped and delivered to Transifex, where it gets translated to the string above. We can't really control the translations we get from Transifex, so not translating seems like the best option. It's not ideal, but I don't think we have a good way to override translations.

@sarina @cahrens please review.
