### PR TITLE
when removing field from _field_data_cache when rebinding a module to…

### DIFF
--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -587,6 +587,11 @@ class XModuleMixin(XModuleFields, XBlock):
 
             if field.scope.user == UserScope.ONE:
                 field._del_cached_value(self)  # pylint: disable=protected-access
+                # not the most elegant way of doing this, but if we're removing
+                # a field from the module's field_data_cache, we should also
+                # remove it from its _dirty_fields
+                if field in self._dirty_fields:
+                    del self._dirty_fields[field]  # pylint: disable=protected-access
 
         # Set the new xmodule_runtime and field_data (which are user-specific)
         self.xmodule_runtime = xmodule_runtime

--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -590,8 +590,9 @@ class XModuleMixin(XModuleFields, XBlock):
                 # not the most elegant way of doing this, but if we're removing
                 # a field from the module's field_data_cache, we should also
                 # remove it from its _dirty_fields
+                # pylint: disable=protected-access
                 if field in self._dirty_fields:
-                    del self._dirty_fields[field]  # pylint: disable=protected-access
+                    del self._dirty_fields[field]
 
         # Set the new xmodule_runtime and field_data (which are user-specific)
         self.xmodule_runtime = xmodule_runtime

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -1384,18 +1384,10 @@ class TestRebindModule(TestSubmittingProblems):
     def test_rebind_module_to_new_users(self):
         module = self.get_module_for_user(self.user, self.problem)
 
-        correct_map_field = module.fields['correct_map']
-        # pylint: disable=protected-access
-        self.assertIn(correct_map_field, module._dirty_fields)
-        self.assertIn(correct_map_field.name, module._field_data_cache)
-
         # Bind the module to another student, which will remove "correct_map"
         # from the module's _field_data_cache and _dirty_fields.
         user2 = UserFactory.create()
         module.descriptor.bind_for_student(module.system, user2.id)
-        # pylint: disable=protected-access
-        self.assertNotIn(correct_map_field, module._dirty_fields)
-        self.assertNotIn(correct_map_field.name, module._field_data_cache)
 
         # XBlock's save method assumes that if a field is in _dirty_fields,
         # then it's also in _field_data_cache. If this assumption

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -1360,22 +1360,52 @@ class TestRebindModule(TestSubmittingProblems):
         super(TestRebindModule, self).setUp()
         self.homework = self.add_graded_section_to_course('homework')
         self.lti = ItemFactory.create(category='lti', parent=self.homework)
+        self.problem = ItemFactory.create(category='problem', parent=self.homework)
         self.user = UserFactory.create()
         self.anon_user = AnonymousUser()
 
-    def get_module_for_user(self, user):
+    def get_module_for_user(self, user, item=None):
         """Helper function to get useful module at self.location in self.course_id for user"""
         mock_request = MagicMock()
         mock_request.user = user
         field_data_cache = FieldDataCache.cache_for_descriptor_descendents(
             self.course.id, user, self.course, depth=2)
 
+        if item is None:
+            item = self.lti
+
         return render.get_module(  # pylint: disable=protected-access
             user,
             mock_request,
-            self.lti.location,
+            item.location,
             field_data_cache,
         )._xmodule
+
+    def test_rebind_module_to_new_users(self):
+        module = self.get_module_for_user(self.user, self.problem)
+        # read a mutable field, scoped to a single user,
+        # in order to mark it as dirty
+        module.correct_map
+
+        correct_map_field = module.fields['correct_map']
+        self.assertIn(correct_map_field, module._dirty_fields)
+        self.assertIn(correct_map_field.name, module._field_data_cache)
+
+        # Bind the module to another student, which will remove "correct_map"
+        # from the module's _field_data_cache and _dirty_fields.
+        user2 = UserFactory.create()
+        module.bind_for_student(module.system, user2.id)
+        self.assertNotIn(correct_map_field, module._dirty_fields)
+        self.assertNotIn(correct_map_field.name, module._field_data_cache)
+
+        # XBlock's save method assumes that if a field is in _dirty_fields,
+        # then it's also in _field_data_cache. If this assumption
+        # doesn't hold, then we get an error trying to bind this module
+        # to a third student, since we've removed "correct_map" from
+        # _field_data cache, but not _dirty_fields, when we bound
+        # this module to the second student. (TNL-2640)
+        user3 = UserFactory.create()
+        module.bind_for_student(module.system, user3.id)
 
     def test_rebind_noauth_module_to_user_not_anonymous(self):
         """

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -1394,7 +1394,7 @@ class TestRebindModule(TestSubmittingProblems):
         # Bind the module to another student, which will remove "correct_map"
         # from the module's _field_data_cache and _dirty_fields.
         user2 = UserFactory.create()
-        module.bind_for_student(module.system, user2.id)
+        module.descriptor.bind_for_student(module.system, user2.id)
         self.assertNotIn(correct_map_field, module._dirty_fields)
         self.assertNotIn(correct_map_field.name, module._field_data_cache)
 
@@ -1405,7 +1405,7 @@ class TestRebindModule(TestSubmittingProblems):
         # _field_data cache, but not _dirty_fields, when we bound
         # this module to the second student. (TNL-2640)
         user3 = UserFactory.create()
-        module.bind_for_student(module.system, user3.id)
+        module.descriptor.bind_for_student(module.system, user3.id)
 
     def test_rebind_noauth_module_to_user_not_anonymous(self):
         """

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -1383,11 +1383,9 @@ class TestRebindModule(TestSubmittingProblems):
 
     def test_rebind_module_to_new_users(self):
         module = self.get_module_for_user(self.user, self.problem)
-        # read a mutable field, scoped to a single user,
-        # in order to mark it as dirty
-        module.correct_map
 
         correct_map_field = module.fields['correct_map']
+        # pylint: disable=protected-access
         self.assertIn(correct_map_field, module._dirty_fields)
         self.assertIn(correct_map_field.name, module._field_data_cache)
 
@@ -1395,6 +1393,7 @@ class TestRebindModule(TestSubmittingProblems):
         # from the module's _field_data_cache and _dirty_fields.
         user2 = UserFactory.create()
         module.descriptor.bind_for_student(module.system, user2.id)
+        # pylint: disable=protected-access
         self.assertNotIn(correct_map_field, module._dirty_fields)
         self.assertNotIn(correct_map_field.name, module._field_data_cache)
 


### PR DESCRIPTION
… a new user, also remove it from _dirty_fields (TNL-2640)

@cpennington , @doctoryes , may you please review? It's a fix to https://openedx.atlassian.net/browse/TNL-2640, where, when rebinding an xmodule to a new user (like during grading), fields are removed from `_field_data_cache`, but not `_dirty_fields`. 

If possible, I'd like to get this out as a hotfix

@Shrhawk , @waheedahmed , FYIs
