### PR TITLE
Remove unused Ruby gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,12 +2,3 @@ source 'https://rubygems.org'
 gem 'sass', '3.3.5'
 gem 'bourbon', '~> 4.0.2'
 gem 'neat', '~> 1.6.0'
-gem 'colorize', '~> 0.5.8'
-gem 'launchy', '~> 2.1.2'
-gem 'sys-proctable', '~> 0.9.3'
-gem 'dalli', '~> 2.6.4'
-# These gems aren't actually required; they are used by Linux and Mac to
-# detect when files change. If these gems are not installed, the system
-# will fall back to polling files.
-gem 'rb-inotify', '~> 0.9'
-gem 'rb-fsevent', '~> 0.9.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,23 +1,13 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.3.5)
     bourbon (4.0.2)
       sass (~> 3.3)
       thor
-    colorize (0.5.8)
-    dalli (2.6.4)
-    ffi (1.9.0)
-    launchy (2.1.2)
-      addressable (~> 2.3)
     neat (1.6.0)
       bourbon (>= 3.1)
       sass (>= 3.3)
-    rb-fsevent (0.9.3)
-    rb-inotify (0.9.2)
-      ffi (>= 0.5.0)
     sass (3.3.5)
-    sys-proctable (0.9.3)
     thor (0.19.1)
 
 PLATFORMS
@@ -25,11 +15,5 @@ PLATFORMS
 
 DEPENDENCIES
   bourbon (~> 4.0.2)
-  colorize (~> 0.5.8)
-  dalli (~> 2.6.4)
-  launchy (~> 2.1.2)
   neat (~> 1.6.0)
-  rb-fsevent (~> 0.9.3)
-  rb-inotify (~> 0.9)
   sass (= 3.3.5)
-  sys-proctable (~> 0.9.3)


### PR DESCRIPTION
These were only used by rake, and we haven't used rake in a year.

@cpennington, does this seem reasonable to you?
