### PR TITLE
Update edx-oauth2-provider to 0.5.2

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -43,7 +43,7 @@ git+https://github.com/hmarr/django-debug-toolbar-mongo.git@b0686a76f1ce3532088c
 -e git+https://github.com/edx/opaque-keys.git@27dc382ea587483b1e3889a3d19cbd90b9023a06#egg=opaque-keys
 -e git+https://github.com/edx/ease.git@b67d2928a26fe497826b6ea359b9a3d0371548a7#egg=ease==0.1.3
 -e git+https://github.com/edx/i18n-tools.git@v0.1.1#egg=i18n-tools
--e git+https://github.com/edx/edx-oauth2-provider.git@0.5.1#egg=oauth2-provider
+git+https://github.com/edx/edx-oauth2-provider.git@0.5.2#egg=oauth2-provider==0.5.2
 -e git+https://github.com/edx/edx-val.git@v0.0.5#egg=edx-val
 -e git+https://github.com/pmitros/RecommenderXBlock.git@518234bc354edbfc2651b9e534ddb54f96080779#egg=recommender-xblock
 -e git+https://github.com/edx/edx-search.git@release-2015-07-03#egg=edx-search


### PR DESCRIPTION
Accompanies [#21](https://github.com/edx/edx-oauth2-provider/pull/21) against edx/edx-oauth2-provider. Requires a yet-to-be created 0.5.2 release.

@jimabramson @clintonb @feanil
