### PR TITLE
SOL-1030 Index staff visibility and use it for result processing [EXPERIMENTAL]

### DIFF
--- a/cms/djangoapps/contentstore/courseware_index.py
+++ b/cms/djangoapps/contentstore/courseware_index.py
@@ -233,6 +233,7 @@ class SearchIndexerBase(object):
                 if item.start:
                     item_index['start_date'] = item.start
                 item_index['content_groups'] = item_content_groups if item_content_groups else None
+                item_index['staff_visibility'] = item.visible_to_staff_only if item.visible_to_staff_only else None
                 item_index.update(cls.supplemental_fields(item))
                 searcher.index(cls.DOCUMENT_TYPE, item_index)
                 indexed_count["count"] += 1

--- a/lms/lib/courseware_search/lms_result_processor.py
+++ b/lms/lib/courseware_search/lms_result_processor.py
@@ -11,7 +11,8 @@ from search.result_processor import SearchResultProcessor
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.search import path_to_location, navigation_index
 
-from courseware.access import has_access
+from student.auth import has_access
+from student.roles import CourseInstructorRole, CourseStaffRole
 
 
 class LmsSearchResultProcessor(SearchResultProcessor):
@@ -62,10 +63,7 @@ class LmsSearchResultProcessor(SearchResultProcessor):
 
     def should_remove(self, user):
         """ Test to see if this result should be removed due to access restriction """
-        user_has_access = has_access(
-            user,
-            "load",
-            self.get_item(self.get_usage_key()),
-            self.get_course_key()
-        )
-        return not user_has_access
+        if self._results_fields['staff_visibility']:
+            return not (has_access(user, CourseStaffRole(self.get_course_key()))
+                or has_access(user, CourseInstructorRole(self.get_course_key())))
+        return False


### PR DESCRIPTION
@ormsbee this is just an idea we were looking at on how to improve search performance. 
Slowest part of search process by far is doing access check in results processor. Method we used before actually loads the whole course, which is inefficient. 
Idea was to instead index items visible_to_staff_only flag, and later on in results processor resolve permissions by getting users permissions on selected course. This generally increases search performance, for example on 8.MechCx from 42 sec to 1,6 sec. 
More information can be found in Jira: https://openedx.atlassian.net/browse/SOL-1030

Note: 
This is not an actual PR expected to be merged, just using github as a tool to get your eyes on potential changes and get some feedback.
