### PR TITLE
Fix failed test_course_about_in_cart

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -225,4 +225,4 @@ Alessandro Verdura <finalmente2@tin.it>
 Sven Marnach <sven@marnach.net>
 Richard Moch <richard.moch@gmail.com>
 Albert Liang <albertliangcode@gmail.com>
-
+Pa Luo <pan.luo@ubc.ca>

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -31,7 +31,6 @@ from certificates.tests.factories import GeneratedCertificateFactory
 from course_modes.models import CourseMode
 from courseware.testutils import RenderXBlockTestMixin
 from courseware.tests.factories import StudentModuleFactory
-from edxmako.middleware import MakoMiddleware
 from edxmako.tests import mako_middleware_process_request
 from student.models import CourseEnrollment
 from student.tests.factories import AdminFactory, UserFactory, CourseEnrollmentFactory
@@ -201,6 +200,7 @@ class ViewsTestCase(ModuleStoreTestCase):
         course = CourseFactory.create(org="new", number="unenrolled", display_name="course")
         request = self.request_factory.get(reverse('about_course', args=[course.id.to_deprecated_string()]))
         request.user = AnonymousUser()
+        mako_middleware_process_request(request)
         response = views.course_about(request, course.id.to_deprecated_string())
         self.assertEqual(response.status_code, 200)
         self.assertNotIn(in_cart_span, response.content)
@@ -343,7 +343,7 @@ class ViewsTestCase(ModuleStoreTestCase):
         request.user = self.user
 
         # TODO: Remove the dependency on MakoMiddleware (by making the views explicitly supply a RequestContext)
-        MakoMiddleware().process_request(request)
+        mako_middleware_process_request(request)
 
         result = views.course_about(request, course_id)
         if expected_end_text is not None:
@@ -748,8 +748,7 @@ class ProgressPageTests(ModuleStoreTestCase):
         self.request = self.request_factory.get("foo")
         self.request.user = self.user
 
-        MakoMiddleware().process_request(self.request)
-
+        mako_middleware_process_request(self.request)
         course = CourseFactory.create(
             start=datetime(2013, 9, 16, 7, 17, 28),
             grade_cutoffs={u'çü†øƒƒ': 0.75, 'Pass': 0.5},


### PR DESCRIPTION
This test failed since d240785 and it is only shown on devstack but not on jenkins. And all the changes in d240785 don't seem to related to this failed test. There are several factors causing this failed test so mysterious.
1. The issue in the test: https://github.com/edx/edx-platform/blob/d240785b17bdcaeb11e4ef24ee4a3697da26c9b4/lms/djangoapps/courseware/tests/test_views.py#L202
   the self.request_factory.get() just give you a request object, which is being passed to views.course_about() directly without being processed by edxmako.middleware. That’s why REQUEST_CONTEXT.request in https://github.com/edx/edx-platform/blob/d240785b17bdcaeb11e4ef24ee4a3697da26c9b4/common/djangoapps/edxmako/middleware.py#L39 is None, instead of request object, which contains the LANGUAGE_CODE and other stuff used by views.course_about view to render.
2. Why did commit d240785^1 pass? Because REQUEST_CONTEXT.request is cleaned upon the call of process_response (https://github.com/edx/edx-platform/blob/d240785b17bdcaeb11e4ef24ee4a3697da26c9b4/common/djangoapps/edxmako/middleware.py#L30). However, the REQUEST_CONTEXT is a thread local storage, which is shared between tests. One of the tests before test_course_about_in_cart didn’t call process_response, and left the request object in the local storage. If you set up a break point, you can see the path in the request object is actually “foo” instead of whatever the reverse(‘about_course’) generated URL. 
3. Why did commit d240785 fail on devstack? By comparing test output of d240785 and d240785^1 running locally, TestRenderXBlock did run before VerifyCourseKeyDecoratorTests(no tests called process_response), which ran before ViewsTestCase.test_course_about_in_cart. In TestRenderXBlock, test_success_unenrolled_staff called process_response and cleared the request object. So when test_course_about_in_cart ran, REQUEST_CONTEXT.request is None.
4. Why did jenkins tests pass even on and after d240785, but failed on devstack in local VM? It is because of "@attr('shard_1’)” decoration on the test class ViewsTestCase and other classes, but not on newly added TestRenderXBlock test class. I guess jenkins put all test classes with shard_1 to a slave node and others (TestRenderXBlock) to a separate node. So TestRenderXBlock never ran before ViewsTestCase.test_course_about_in_cart on jenkins and test_course_about_in_cart still got the left over request object from REQUEST_CONTEXT.

Because of the MakoMiddleware is using thread local storage, it makes tests running not completely isolated. thread local storage may need be cleaned after each test.
