### PR TITLE
Update copy for On Demand Cert Download

### DIFF
--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -860,7 +860,7 @@ class ProgressPageTests(ModuleStoreTestCase):
         resp = views.progress(self.request, course_id=unicode(self.course.id))
         self.assertContains(resp, u"View Certificate")
 
-        self.assertContains(resp, u"You can now access your certificate")
+        self.assertContains(resp, u"You can keep working for a higher grade")
         cert_url = certs_api.get_certificate_url(
             user_id=self.user.id,
             course_id=self.course.id

--- a/lms/templates/courseware/progress.html
+++ b/lms/templates/courseware/progress.html
@@ -59,7 +59,7 @@ from django.utils.http import urlquote_plus
               <div class="msg-content">
                 <h2 class="title">${_("Your certificate is available")}</h2>
                 <p class="copy">
-                  ${_("You can now access your certificate. If you keep working and receive a higher grade, you can request an updated certificate.")}
+                  ${_("You can keep working for a higher grade, or request your certificate now.")}
                 </p>
               </div>
               <div class="msg-actions">


### PR DESCRIPTION
ECOM-1651

@awais786 @aamir-khan @ahsan-ul-haq @zubair-arbi @wedaly 
Previously this change was introduced in https://github.com/edx/edx-platform/pull/8818 and that PR got reverted in https://github.com/edx/edx-platform/issues/8827 because it broke master on a certificate unit test.

Updated course progress page for  on demand cert download.
<img width="1051" alt="screen shot 2015-07-08 at 4 39 41 pm" src="https://cloud.githubusercontent.com/assets/4245618/8590020/ba8e0d26-2635-11e5-9f5c-6048b47cc0f7.png">
