### PR TITLE
PLAT-324: Custom error message for export course command

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/export.py
+++ b/cms/djangoapps/contentstore/management/commands/export.py
@@ -26,11 +26,17 @@ class Command(BaseCommand):
         try:
             course_key = CourseKey.from_string(args[0])
         except InvalidKeyError:
-            course_key = SlashSeparatedCourseKey.from_deprecated_string(args[0])
+            try:
+                course_key = SlashSeparatedCourseKey.from_deprecated_string(args[0])
+            except InvalidKeyError:
+                raise CommandError("Invalid course_key: '%s'. " % args[0])
+
+        if not modulestore().get_course(course_key):
+            raise CommandError("Course with %s key not found." % args[0])
 
         output_path = args[1]
 
-        print("Exporting course id = {0} to {1}".format(course_key, output_path))
+        print "Exporting course id = {0} to {1}".format(course_key, output_path)
 
         if not output_path.endswith('/'):
             output_path += '/'

--- a/cms/djangoapps/contentstore/management/commands/tests/test_export.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_export.py
@@ -7,7 +7,6 @@ import ddt
 from django.core.management import CommandError, call_command
 from tempfile import mkdtemp
 
-from opaque_keys import InvalidKeyError
 from xmodule.modulestore.tests.factories import CourseFactory
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
@@ -22,6 +21,9 @@ class TestArgParsingCourseExport(unittest.TestCase):
         super(TestArgParsingCourseExport, self).setUp()
 
     def test_no_args(self):
+        """
+        Test export command with no arguments
+        """
         errstring = "export requires two arguments: <course id> <output path>"
         with self.assertRaises(SystemExit) as ex:
             with self.assertRaisesRegexp(CommandError, errstring):
@@ -57,9 +59,22 @@ class TestCourseExport(ModuleStoreTestCase):
             "Could not find course in {}".format(store)
         )
         # Test `export` management command with invalid course_id
-        with self.assertRaises(InvalidKeyError):
-            call_command('export', "InvalidCourseID", self.temp_dir_1)
+        errstring = "Invalid course_key 'InvalidCourseID'."
+        with self.assertRaises(SystemExit) as ex:
+            with self.assertRaisesRegexp(CommandError, errstring):
+                call_command('export', "InvalidCourseID", self.temp_dir_1)
+        self.assertEqual(ex.exception.code, 1)
 
         # Test `export` management command with correct course_id
         for output_dir in [self.temp_dir_1, self.temp_dir_2]:
             call_command('export', course_id, output_dir)
+
+    def test_course_key_not_found(self):
+        """
+        Test export command with a valid course key that doesn't exist
+        """
+        errstring = "Course with x/y/z key not found."
+        with self.assertRaises(SystemExit) as ex:
+            with self.assertRaisesRegexp(CommandError, errstring):
+                call_command('export', "x/y/z", self.temp_dir_1)
+        self.assertEqual(ex.exception.code, 1)


### PR DESCRIPTION
This is a fix for
https://openedx.atlassian.net/browse/PLAT-324
added custom CommandError messages for invalid course key.
