### PR TITLE
TNL-394: Added sanitization of id names

### DIFF
--- a/lms/static/js/spec/staff_debug_actions_spec.js
+++ b/lms/static/js/spec/staff_debug_actions_spec.js
@@ -14,6 +14,12 @@ define(['backbone', 'jquery', 'js/staff_debug_actions'],
                 });
             });
 
+            describe('sanitize_string', function () {
+                it('escapes escapable characters in a string', function () {
+                    expect(StaffDebug.sanitized_string('.*+?^:${}()|][')).toBe('\\.\\*\\+\\?\\^\\:\\$\\{\\}\\(\\)\\|\\]\\[');
+                });
+            });
+
             describe('get_user', function () {
 
                 it('gets the placeholder username if input field is empty', function () {

--- a/lms/static/js/staff_debug_actions.js
+++ b/lms/static/js/staff_debug_actions.js
@@ -11,7 +11,12 @@ var StaffDebug = (function(){
     return url;
   }
 
+  sanitized_string = function(string) {
+    return string.replace(/[.*+?^:${}()|[\]\\]/g, "\\$&");
+  }
+
   get_user = function(locname){
+    locname = sanitized_string(locname);
     var uname = $('#sd_fu_' + locname).val();
     if (uname==""){
         uname =  $('#sd_fu_' + locname).attr('placeholder');
@@ -108,7 +113,8 @@ var StaffDebug = (function(){
       do_idash_action: do_idash_action,
       get_current_url: get_current_url,
       get_url: get_url,
-      get_user: get_user
+      get_user: get_user,
+      sanitized_string:sanitized_string
   }
 })();
 


### PR DESCRIPTION
This is a fix for
https://openedx.atlassian.net/browse/TNL-394
escaped all escapable characters in id name strings.
