### PR TITLE
reduce log severity when building marketing links

### DIFF
--- a/common/djangoapps/edxmako/shortcuts.py
+++ b/common/djangoapps/edxmako/shortcuts.py
@@ -53,7 +53,7 @@ def marketing_link(name):
         if link_map[name] is not None:
             return reverse(link_map[name])
     else:
-        log.warning("Cannot find corresponding link for name: {name}".format(name=name))
+        log.debug("Cannot find corresponding link for name: %s", name)
         return '#'
 
 


### PR DESCRIPTION
@e0d @dianakhuang @wedaly FYI

This warning is very noisy and accounts for 5% of our entire logs in production (according to a splunk search of the last 60 minutes).  As far as I can tell, nobody needs to take action on this, so I think we can make it debug.
