### PR TITLE
Utkjad/removing@contract fromuser state client.py

### DIFF
--- a/lms/djangoapps/courseware/user_state_client.py
+++ b/lms/djangoapps/courseware/user_state_client.py
@@ -55,12 +55,6 @@ class DjangoXBlockUserStateClient(XBlockUserStateClient):
         self.user = user
 
     @donottrack(StudentModule, StudentModuleHistory)
-    @contract(
-        username="basestring",
-        block_key=UsageKey,
-        scope=ScopeBase,
-        fields="seq(basestring)|set(basestring)|None"
-    )
     def get(self, username, block_key, scope=Scope.user_state, fields=None):
         """
         Retrieve the stored XBlock state for a single xblock usage.
@@ -85,10 +79,6 @@ class DjangoXBlockUserStateClient(XBlockUserStateClient):
         return state
 
     @donottrack(StudentModule, StudentModuleHistory)
-    @contract(username="basestring",
-              block_key=UsageKey,
-              state="dict(basestring: *)",
-              scope=ScopeBase)
     def set(self, username, block_key, state, scope=Scope.user_state):
         """
         Set fields for a particular XBlock.
@@ -102,12 +92,6 @@ class DjangoXBlockUserStateClient(XBlockUserStateClient):
         self.set_many(username, {block_key: state}, scope)
 
     @donottrack(StudentModule, StudentModuleHistory)
-    @contract(
-        username="basestring",
-        block_key=UsageKey,
-        scope=ScopeBase,
-        fields="seq(basestring)|set(basestring)|None"
-    )
     def delete(self, username, block_key, scope=Scope.user_state, fields=None):
         """
         Delete the stored XBlock state for a single xblock usage.
@@ -121,12 +105,6 @@ class DjangoXBlockUserStateClient(XBlockUserStateClient):
         return self.delete_many(username, [block_key], scope, fields=fields)
 
     @donottrack(StudentModule, StudentModuleHistory)
-    @contract(
-        username="basestring",
-        block_key=UsageKey,
-        scope=ScopeBase,
-        fields="seq(basestring)|set(basestring)|None"
-    )
     def get_mod_date(self, username, block_key, scope=Scope.user_state, fields=None):
         """
         Get the last modification date for fields from the specified blocks.
@@ -148,7 +126,6 @@ class DjangoXBlockUserStateClient(XBlockUserStateClient):
         }
 
     @donottrack(StudentModule, StudentModuleHistory)
-    @contract(username="basestring", block_keys="seq(UsageKey)|set(UsageKey)")
     def _get_student_modules(self, username, block_keys):
         """
         Retrieve the :class:`~StudentModule`s for the supplied ``username`` and ``block_keys``.
@@ -176,12 +153,6 @@ class DjangoXBlockUserStateClient(XBlockUserStateClient):
                 yield (student_module, usage_key)
 
     @donottrack(StudentModule, StudentModuleHistory)
-    @contract(
-        username="basestring",
-        block_keys="seq(UsageKey)|set(UsageKey)",
-        scope=ScopeBase,
-        fields="seq(basestring)|set(basestring)|None"
-    )
     def get_many(self, username, block_keys, scope=Scope.user_state, fields=None):
         """
         Retrieve the stored XBlock state for a single xblock usage.
@@ -208,7 +179,6 @@ class DjangoXBlockUserStateClient(XBlockUserStateClient):
             yield (usage_key, state)
 
     @donottrack(StudentModule, StudentModuleHistory)
-    @contract(username="basestring", block_keys_to_state="dict(UsageKey: dict(basestring: *))", scope=ScopeBase)
     def set_many(self, username, block_keys_to_state, scope=Scope.user_state):
         """
         Set fields for a particular XBlock.
@@ -255,12 +225,6 @@ class DjangoXBlockUserStateClient(XBlockUserStateClient):
                 student_module.save(force_update=True)
 
     @donottrack(StudentModule, StudentModuleHistory)
-    @contract(
-        username="basestring",
-        block_keys="seq(UsageKey)|set(UsageKey)",
-        scope=ScopeBase,
-        fields="seq(basestring)|set(basestring)|None"
-    )
     def delete_many(self, username, block_keys, scope=Scope.user_state, fields=None):
         """
         Delete the stored XBlock state for a many xblock usages.
@@ -289,12 +253,6 @@ class DjangoXBlockUserStateClient(XBlockUserStateClient):
             student_module.save(force_update=True)
 
     @donottrack(StudentModule, StudentModuleHistory)
-    @contract(
-        username="basestring",
-        block_keys="seq(UsageKey)|set(UsageKey)",
-        scope=ScopeBase,
-        fields="seq(basestring)|set(basestring)|None"
-    )
     def get_mod_date_many(self, username, block_keys, scope=Scope.user_state, fields=None):
         """
         Get the last modification date for fields from the specified blocks.
@@ -322,7 +280,6 @@ class DjangoXBlockUserStateClient(XBlockUserStateClient):
                 yield (usage_key, field, student_module.modified)
 
     @donottrack(StudentModule, StudentModuleHistory)
-    @contract(username="basestring", block_key=UsageKey, scope=ScopeBase)
     def get_history(self, username, block_key, scope=Scope.user_state):
         """
         Retrieve history of state changes for a given block for a given

--- a/lms/djangoapps/courseware/user_state_client.py
+++ b/lms/djangoapps/courseware/user_state_client.py
@@ -18,7 +18,7 @@ from courseware.models import StudentModule, StudentModuleHistory
 from contracts import contract, new_contract
 from opaque_keys.edx.keys import UsageKey
 
-from openedx.core.djangoapps.call_stack_manager import donottrack
+from openedx.core.djangoapps.call_stack_manager.core import donottrack
 
 new_contract('UsageKey', UsageKey)
 
@@ -358,6 +358,7 @@ class DjangoXBlockUserStateClient(XBlockUserStateClient):
 
         return history_entries
 
+    @donottrack(StudentModule, StudentModuleHistory)
     def iter_all_for_block(self, block_key, scope=Scope.user_state, batch_size=None):
         """
         You get no ordering guarantees. Fetching will happen in batch_size
@@ -368,6 +369,7 @@ class DjangoXBlockUserStateClient(XBlockUserStateClient):
             raise ValueError("Only Scope.user_state is supported")
         raise NotImplementedError()
 
+    @donottrack(StudentModule, StudentModuleHistory)
     def iter_all_for_course(self, course_key, block_type=None, scope=Scope.user_state, batch_size=None):
         """
         You get no ordering guarantees. Fetching will happen in batch_size

--- a/openedx/core/djangoapps/call_stack_manager/tests.py
+++ b/openedx/core/djangoapps/call_stack_manager/tests.py
@@ -109,11 +109,15 @@ def donottrack_func_child():
     ModelMixin.objects.all()
 
 
-@donottrack()
-def donottrack_check_with_return():
-    """ function that returns something i.e. a wrapped function returning some value
+class ClassReturingValue(object):
     """
-    return 42
+    Test class with a decorated method
+    """
+    @donottrack()
+    def donottrack_check_with_return(cls, a=43):
+        """ function that returns something i.e. a wrapped function returning some value
+        """
+        return 42+a
 
 
 @patch('openedx.core.djangoapps.call_stack_manager.core.log.info')
@@ -225,6 +229,7 @@ class TestingCallStackManager(TestCase):
         """ Test for @donottrack
         Checks if wrapper function returns the same value as wrapped function
         """
-        everything = donottrack_check_with_return()
-        self.assertEqual(everything, 42)
+        class_returning_value = ClassReturingValue()
+        everything = class_returning_value.donottrack_check_with_return(a=42)
+        self.assertEqual(everything, 84)
         self.assertEqual(len(log_capt.call_args_list), 0)

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -91,6 +91,7 @@ django-ratelimit-backend==0.6
 unicodecsv==0.9.4
 django-require==1.0.6
 pyuca==1.1
+wrapt==1.10.5
 
 # Used for shopping cart's pdf invoice/receipt generation
 reportlab==3.1.44


### PR DESCRIPTION
This PR does following-
- remove `@contract` from `DjangoXBlockUserStateClient` in `user_state_client.py` because we have it in `interface.py` 
