### PR TITLE
Add context for navigation states

### DIFF
--- a/common/djangoapps/course_modes/views.py
+++ b/common/djangoapps/course_modes/views.py
@@ -119,7 +119,8 @@ class ChooseModeView(View):
             "course_num": course.display_number_with_default,
             "chosen_price": chosen_price,
             "error": error,
-            "responsive": True
+            "responsive": True,
+            "nav_hidden": True,
         }
         if "verified" in modes:
             context["suggested_prices"] = [

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -698,6 +698,7 @@ def dashboard(request):
         'order_history_list': order_history_list,
         'courses_requirements_not_met': courses_requirements_not_met,
         'ccx_membership_triplets': ccx_membership_triplets,
+        'nav_course_search': True,
     }
 
     return render_to_response('dashboard.html', context)

--- a/lms/djangoapps/commerce/views.py
+++ b/lms/djangoapps/commerce/views.py
@@ -202,6 +202,7 @@ def checkout_receipt(request):
         'error_text': error_text,
         'for_help_text': for_help_text,
         'payment_support_email': payment_support_email,
+        'nav_hidden': True,
     }
     return render_to_response('commerce/checkout_receipt.html', context)
 

--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -376,6 +376,7 @@ class PayAndVerifyView(View):
             'already_verified': already_verified,
             'verification_good_until': verification_good_until,
             'capture_sound': staticfiles_storage.url("audio/camera_capture.wav"),
+            'nav_hidden': True,
         }
         return render_to_response("verify_student/pay_and_verify.html", context)
 


### PR DESCRIPTION
@AlasdairSwan This adds the following context variables:
- `nav_hidden`: when True, hide navigation.  Nav is hidden on the track selection, pay/verify, and receipt pages.
- `nav_course_search`: Set to True on the student dashboard.

A couple of thoughts on the implementation here:
- For "nav hidden", you can probably just skip including navigation in `main.html`.  This would work for both Open Source and the EdX.org header.
- Before we merge this back into master, we should add Python unit tests for these pages to verify that navigation is hidden or course search is displayed.  Let me know when your branch is ready and I can add those tests.
