### PR TITLE
TNL-136: Added New page creation animation

### DIFF
--- a/cms/static/coffee/src/views/tabs.coffee
+++ b/cms/static/coffee/src/views/tabs.coffee
@@ -89,7 +89,9 @@ define ["jquery", "jquery.ui", "backbone", "js/views/feedback_prompt", "js/views
       editor.$el.addClass('new')
       setTimeout(=>
         editor.$el.removeClass('new')
-      , 500)
+      , 1000)
+      $('html, body').animate {scrollTop: $('.new-component-item').offset().top}, 500
+      
 
       editor.createItem(
         @model.get('id'),


### PR DESCRIPTION
This is a fix for
https://openedx.atlassian.net/browse/TNL-136
added scroll to new page and remove class 'new' on hover to better
indicate that a new page is created.

The old way:
https://youtu.be/n6ddncy9TAk

The new way:
https://youtu.be/j8XCK6s-m_k

(sorry for the length, my devstack is pretty slow)
