### PR TITLE
Eliminate various Pylint violations

### DIFF
--- a/cms/djangoapps/contentstore/features/checklists.py
+++ b/cms/djangoapps/contentstore/features/checklists.py
@@ -3,7 +3,6 @@
 
 from lettuce import world, step
 from nose.tools import assert_true, assert_equal  # pylint: disable=no-name-in-module
-from terrain.steps import reload_the_page
 from selenium.common.exceptions import StaleElementReferenceException
 
 

--- a/cms/djangoapps/contentstore/features/course-outline.py
+++ b/cms/djangoapps/contentstore/features/course-outline.py
@@ -3,7 +3,7 @@
 
 from lettuce import world, step
 from common import *
-from nose.tools import assert_true, assert_false, assert_equal  # pylint: disable=no-name-in-module
+from nose.tools import assert_true, assert_false  # pylint: disable=no-name-in-module
 
 from logging import getLogger
 logger = getLogger(__name__)

--- a/cms/djangoapps/contentstore/features/course-settings.py
+++ b/cms/djangoapps/contentstore/features/course-settings.py
@@ -2,12 +2,11 @@
 # pylint: disable=redefined-outer-name
 
 from lettuce import world, step
-from terrain.steps import reload_the_page
 from selenium.webdriver.common.keys import Keys
 from common import type_in_codemirror, upload_file
 from django.conf import settings
 
-from nose.tools import assert_true, assert_false, assert_equal  # pylint: disable=no-name-in-module
+from nose.tools import assert_true, assert_false  # pylint: disable=no-name-in-module
 
 TEST_ROOT = settings.COMMON_TEST_DATA_ROOT
 

--- a/cms/djangoapps/contentstore/features/grading.py
+++ b/cms/djangoapps/contentstore/features/grading.py
@@ -6,7 +6,7 @@ from common import *
 from terrain.steps import reload_the_page
 from selenium.common.exceptions import InvalidElementStateException
 from contentstore.utils import reverse_course_url
-from nose.tools import assert_in, assert_not_in, assert_equal, assert_not_equal  # pylint: disable=no-name-in-module
+from nose.tools import assert_in, assert_equal, assert_not_equal  # pylint: disable=no-name-in-module
 
 
 @step(u'I am viewing the grading settings')

--- a/cms/djangoapps/contentstore/features/grading.py
+++ b/cms/djangoapps/contentstore/features/grading.py
@@ -170,7 +170,7 @@ def cannot_edit_fail(_step):
     # try to change the grade range -- this should throw an exception
     try:
         ranges.last.value = 'Failure'
-    except (InvalidElementStateException):
+    except InvalidElementStateException:
         pass  # We should get this exception on failing to edit the element
 
     # check to be sure that nothing has changed

--- a/cms/djangoapps/contentstore/features/pages.py
+++ b/cms/djangoapps/contentstore/features/pages.py
@@ -33,7 +33,7 @@ def see_a_static_page_named_foo(step, name):
 @step(u'I should not see any static pages$')
 def not_see_any_static_pages(step):
     pages_css = 'div.xmodule_StaticTabModule'
-    assert (world.is_css_not_present(pages_css, wait_time=30))
+    assert world.is_css_not_present(pages_css, wait_time=30)
 
 
 @step(u'I "(edit|delete)" the static page$')

--- a/cms/djangoapps/contentstore/features/transcripts.py
+++ b/cms/djangoapps/contentstore/features/transcripts.py
@@ -205,7 +205,7 @@ def check_text_in_the_captions(_step, text):
     world.wait_for_present('.video.is-captions-rendered')
     world.wait_for(lambda _: world.css_text('.subtitles'), timeout=30)
     actual_text = world.css_text('.subtitles')
-    assert (text in actual_text)
+    assert text in actual_text
 
 
 @step('I see value "([^"]*)" in the field "([^"]*)"$')

--- a/cms/djangoapps/contentstore/features/upload.py
+++ b/cms/djangoapps/contentstore/features/upload.py
@@ -74,7 +74,7 @@ def check_not_there(_step, file_name):
     # the only file that was uploaded, our success criteria
     # will be that there are no files.
     # In the future we can refactor if necessary.
-    assert(world.is_css_not_present(ASSET_NAMES_CSS))
+    assert world.is_css_not_present(ASSET_NAMES_CSS)
 
 
 @step(u'I should see the file "([^"]*)" was uploaded$')

--- a/cms/djangoapps/contentstore/management/commands/import.py
+++ b/cms/djangoapps/contentstore/management/commands/import.py
@@ -29,7 +29,7 @@ class Command(BaseCommand):
             raise CommandError("import requires at least one argument: <data directory> [--nostatic] [<course dir>...]")
 
         data_dir = args[0]
-        do_import_static = not (options.get('nostatic', False))
+        do_import_static = not options.get('nostatic', False)
         if len(args) > 1:
             source_dirs = args[1:]
         else:

--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -659,7 +659,7 @@ class MiscCourseTests(ContentStoreTestCase):
         direct_store_items = self.store.get_items(
             self.course.id, revision=ModuleStoreEnum.RevisionOption.published_only
         )
-        items_from_direct_store = [item for item in direct_store_items if (item.location == self.problem.location)]
+        items_from_direct_store = [item for item in direct_store_items if item.location == self.problem.location]
         self.assertEqual(len(items_from_direct_store), 1)
         self.assertFalse(getattr(items_from_direct_store[0], 'is_draft', False))
 
@@ -667,7 +667,7 @@ class MiscCourseTests(ContentStoreTestCase):
         draft_store_items = self.store.get_items(
             self.course.id, revision=ModuleStoreEnum.RevisionOption.draft_only
         )
-        items_from_draft_store = [item for item in draft_store_items if (item.location == self.problem.location)]
+        items_from_draft_store = [item for item in draft_store_items if item.location == self.problem.location]
         self.assertEqual(len(items_from_draft_store), 1)
         # TODO the below won't work for split mongo
         self.assertTrue(getattr(items_from_draft_store[0], 'is_draft', False))

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -87,7 +87,7 @@ def get_lms_link_for_item(location, preview=False):
     :param location: the location to jump to
     :param preview: True if the preview version of LMS should be returned. Default value is false.
     """
-    assert(isinstance(location, UsageKey))
+    assert isinstance(location, UsageKey)
 
     if settings.LMS_BASE is None:
         return None
@@ -109,7 +109,7 @@ def get_lms_link_for_about_page(course_key):
     Returns the url to the course about page from the location tuple.
     """
 
-    assert(isinstance(course_key, CourseKey))
+    assert isinstance(course_key, CourseKey)
 
     if settings.FEATURES.get('ENABLE_MKTG_SITE', False):
         if not hasattr(settings, 'MKTG_URLS'):

--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -242,7 +242,7 @@ def xblock_view_handler(request, usage_key_string, view_name):
                 log.debug("Unable to render %s for %r", view_name, xblock, exc_info=True)
                 fragment = Fragment(render_to_string('html_error.html', {'message': str(exc)}))
 
-        elif view_name in (PREVIEW_VIEWS + container_views):
+        elif view_name in PREVIEW_VIEWS + container_views:
             is_pages_view = view_name == STUDENT_VIEW   # Only the "Pages" view uses student view in Studio
             can_edit = has_studio_write_access(request.user, usage_key.course_key)
 

--- a/cms/djangoapps/contentstore/views/library.py
+++ b/cms/djangoapps/contentstore/views/library.py
@@ -31,7 +31,6 @@ from student.auth import (
     STUDIO_VIEW_USERS, STUDIO_EDIT_ROLES, get_user_permissions, has_studio_read_access, has_studio_write_access
 )
 from student.roles import CourseInstructorRole, CourseStaffRole, LibraryUserRole
-from student import auth
 from util.json_request import expect_json, JsonResponse, JsonResponseBadRequest
 
 __all__ = ['library_handler', 'manage_library_users']

--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -19,7 +19,6 @@ from xmodule.services import SettingsService
 from xmodule.modulestore.django import modulestore, ModuleI18nService
 from xmodule.mixin import wrap_with_license
 from opaque_keys.edx.keys import UsageKey
-from opaque_keys.edx.locator import LibraryUsageLocator
 from xmodule.x_module import ModuleSystem
 from xblock.runtime import KvsFieldData
 from xblock.django.request import webob_to_django_response, django_to_webob_request

--- a/cms/djangoapps/contentstore/views/tabs.py
+++ b/cms/djangoapps/contentstore/views/tabs.py
@@ -5,7 +5,6 @@ from student.auth import has_course_author_access
 from util.json_request import expect_json, JsonResponse
 
 from django.http import HttpResponseNotFound
-from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
 from django.views.decorators.csrf import ensure_csrf_cookie

--- a/common/djangoapps/course_action_state/managers.py
+++ b/common/djangoapps/course_action_state/managers.py
@@ -10,7 +10,7 @@ class CourseActionStateManager(models.Manager):
     An abstract Model Manager class for Course Action State models.
     This abstract class expects child classes to define the ACTION (string) field.
     """
-    class Meta:
+    class Meta(object):
         """Abstract manager class, with subclasses defining the ACTION (string) field."""
         abstract = True
 

--- a/common/djangoapps/course_action_state/models.py
+++ b/common/djangoapps/course_action_state/models.py
@@ -21,7 +21,7 @@ class CourseActionState(models.Model):
     For example: course copying (reruns), import, export, and validation.
     """
 
-    class Meta:
+    class Meta(object):
         """
         For performance reasons, we disable "concrete inheritance", by making the Model base class abstract.
         With the "abstract base class" inheritance model, tables are only created for derived models, not for
@@ -77,7 +77,7 @@ class CourseActionUIState(CourseActionState):
     """
     An abstract django model that is a sub-class of CourseActionState with additional fields related to UI.
     """
-    class Meta:
+    class Meta(object):
         """
         See comment in CourseActionState on disabling "concrete inheritance".
         """
@@ -101,7 +101,7 @@ class CourseRerunState(CourseActionUIState):
     """
     A concrete django model for maintaining state specifically for the Action Course Reruns.
     """
-    class Meta:
+    class Meta(object):
         """
         Set the (destination) course_key field to be unique for the rerun action
         Although multiple reruns can be in progress simultaneously for a particular source course_key,

--- a/common/djangoapps/course_action_state/tests/test_managers.py
+++ b/common/djangoapps/course_action_state/tests/test_managers.py
@@ -105,7 +105,7 @@ class TestCourseActionUIStateManager(TestCourseActionStateManagerBase):
         )
 
         # create course action states for all courses
-        for CourseState in (self.course_actions_displayable_states + self.courses_with_state3_non_displayable):
+        for CourseState in self.course_actions_displayable_states + self.courses_with_state3_non_displayable:
             action_class.objects.update_state(
                 CourseState.course_key,
                 CourseState.state,

--- a/common/djangoapps/course_modes/admin.py
+++ b/common/djangoapps/course_modes/admin.py
@@ -16,7 +16,7 @@ from util.date_utils import get_time_display
 
 class CourseModeForm(forms.ModelForm):
 
-    class Meta:
+    class Meta(object):  # pylint: disable=missing-docstring
         model = CourseMode
 
     COURSE_MODE_SLUG_CHOICES = (

--- a/common/djangoapps/course_modes/models.py
+++ b/common/djangoapps/course_modes/models.py
@@ -82,7 +82,7 @@ class CourseMode(models.Model):
     # Modes that allow a student to earn credit with a university partner
     CREDIT_MODES = [CREDIT_MODE]
 
-    class Meta:
+    class Meta(object):
         """ meta attributes of this model """
         unique_together = ('course_id', 'mode_slug', 'currency')
 

--- a/common/djangoapps/course_modes/models.py
+++ b/common/djangoapps/course_modes/models.py
@@ -457,7 +457,7 @@ class CourseMode(models.Model):
             return False
 
         # Check that the default mode is available.
-        return (cls.HONOR in modes_dict)
+        return cls.HONOR in modes_dict
 
     @classmethod
     def is_white_label(cls, course_id, modes_dict=None):

--- a/common/djangoapps/django_comment_common/models.py
+++ b/common/djangoapps/django_comment_common/models.py
@@ -57,7 +57,7 @@ class Role(models.Model):
     users = models.ManyToManyField(User, related_name="roles")
     course_id = CourseKeyField(max_length=255, blank=True, db_index=True)
 
-    class Meta:
+    class Meta(object):  # pylint: disable=missing-docstring
         # use existing table that was originally created from django_comment_client app
         db_table = 'django_comment_client_role'
 
@@ -99,7 +99,7 @@ class Permission(models.Model):
     name = models.CharField(max_length=30, null=False, blank=False, primary_key=True)
     roles = models.ManyToManyField(Role, related_name="permissions")
 
-    class Meta:
+    class Meta(object):  # pylint: disable=missing-docstring
         # use existing table that was originally created from django_comment_client app
         db_table = 'django_comment_client_permission'
 

--- a/common/djangoapps/embargo/forms.py
+++ b/common/djangoapps/embargo/forms.py
@@ -55,7 +55,7 @@ class RestrictedCourseForm(forms.ModelForm):
         return course_key
 
 
-class IPFilterForm(forms.ModelForm):  # pylint: disable=incomplete-protocol
+class IPFilterForm(forms.ModelForm):
     """Form validating entry of IP addresses"""
 
     class Meta:  # pylint: disable=missing-docstring

--- a/common/djangoapps/embargo/forms.py
+++ b/common/djangoapps/embargo/forms.py
@@ -25,7 +25,7 @@ class RestrictedCourseForm(forms.ModelForm):
     error message instead.
 
     """
-    class Meta:  # pylint: disable=missing-docstring
+    class Meta(object):  # pylint: disable=missing-docstring
         model = RestrictedCourse
 
     def clean_course_key(self):
@@ -58,7 +58,7 @@ class RestrictedCourseForm(forms.ModelForm):
 class IPFilterForm(forms.ModelForm):
     """Form validating entry of IP addresses"""
 
-    class Meta:  # pylint: disable=missing-docstring
+    class Meta(object):  # pylint: disable=missing-docstring
         model = IPFilter
 
     def _is_valid_ip(self, address):

--- a/common/djangoapps/embargo/models.py
+++ b/common/djangoapps/embargo/models.py
@@ -379,7 +379,7 @@ class Country(models.Model):
             code=unicode(self.country)
         )
 
-    class Meta:
+    class Meta(object):
         """Default ordering is ascending by country code """
         ordering = ['country']
 
@@ -522,7 +522,7 @@ class CountryAccessRule(models.Model):
         cache.delete(cache_key)
         log.info("Invalidated country access list for course %s", course_key)
 
-    class Meta:
+    class Meta(object):
         """a course can be added with either black or white list.  """
         unique_together = (
             # This restriction ensures that a country is on
@@ -646,7 +646,7 @@ class CourseAccessRuleHistory(models.Model):
             else:
                 CourseAccessRuleHistory.save_snapshot(restricted_course)
 
-    class Meta:  # pylint: disable=missing-docstring,old-style-class
+    class Meta(object):  # pylint: disable=missing-docstring
         get_latest_by = 'timestamp'
 
 

--- a/common/djangoapps/external_auth/models.py
+++ b/common/djangoapps/external_auth/models.py
@@ -14,7 +14,7 @@ from django.contrib.auth.models import User
 
 
 class ExternalAuthMap(models.Model):
-    class Meta:
+    class Meta(object):  # pylint: disable=missing-docstring
         unique_together = (('external_id', 'external_domain'), )
     external_id = models.CharField(max_length=255, db_index=True)
     external_domain = models.CharField(max_length=255, db_index=True)

--- a/common/djangoapps/external_auth/views.py
+++ b/common/djangoapps/external_auth/views.py
@@ -25,7 +25,7 @@ if settings.FEATURES.get('AUTH_USE_CAS'):
 from student.helpers import get_next_url_for_login_page
 from student.models import UserProfile
 
-from django.http import HttpResponse, HttpResponseRedirect, HttpRequest, HttpResponseForbidden
+from django.http import HttpResponse, HttpResponseRedirect, HttpResponseForbidden
 from django.utils.http import urlquote, is_safe_url
 from django.shortcuts import redirect
 from django.utils.translation import ugettext as _

--- a/common/djangoapps/microsite_configuration/middleware.py
+++ b/common/djangoapps/microsite_configuration/middleware.py
@@ -38,7 +38,7 @@ class MicrositeMiddleware(object):
         return response
 
 
-class MicrositeSessionCookieDomainMiddleware():
+class MicrositeSessionCookieDomainMiddleware(object):
     """
     Special case middleware which should be at the very end of the MIDDLEWARE list (so that it runs first
     on the process_response chain). This middleware will define a wrapper function for the set_cookie() function

--- a/common/djangoapps/monitoring/startup.py
+++ b/common/djangoapps/monitoring/startup.py
@@ -1,4 +1,4 @@
 # Register signal handlers
-# pylint: disable=unused-imports
+# pylint: disable=unused-import
 import signals
 import exceptions

--- a/common/djangoapps/performance/tests/test_logs.py
+++ b/common/djangoapps/performance/tests/test_logs.py
@@ -2,8 +2,6 @@
 import datetime
 import dateutil
 import json
-import mock
-import unittest
 
 import logging
 from StringIO import StringIO

--- a/common/djangoapps/student/admin.py
+++ b/common/djangoapps/student/admin.py
@@ -20,7 +20,7 @@ from opaque_keys import InvalidKeyError
 
 class CourseAccessRoleForm(forms.ModelForm):
     """Form for adding new Course Access Roles view the Django Admin Panel."""
-    class Meta:
+    class Meta(object):  # pylint: disable=missing-docstring
         model = CourseAccessRole
 
     email = forms.EmailField(required=True)
@@ -123,7 +123,7 @@ class CourseAccessRoleAdmin(admin.ModelAdmin):
 class LinkedInAddToProfileConfigurationAdmin(admin.ModelAdmin):
     """Admin interface for the LinkedIn Add to Profile configuration. """
 
-    class Meta:
+    class Meta(object):  # pylint: disable=missing-docstring
         model = LinkedInAddToProfileConfiguration
 
     # Exclude deprecated fields

--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -1,16 +1,12 @@
 """Helpers for the student app. """
-import time
 from datetime import datetime
 import urllib
 
 from pytz import UTC
-
-from django.utils.http import cookie_date
-from django.conf import settings
 from django.core.urlresolvers import reverse, NoReverseMatch
 
 import third_party_auth
-from verify_student.models import SoftwareSecurePhotoVerification  # pylint: disable=F0401
+from verify_student.models import SoftwareSecurePhotoVerification  # pylint: disable=import-error
 from course_modes.models import CourseMode
 
 

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -885,7 +885,7 @@ class CourseEnrollment(models.Model):
         # save it to the database so that it can have an ID that we can throw
         # into our CourseEnrollment object. Otherwise, we'll get an
         # IntegrityError for having a null user_id.
-        assert(isinstance(course_key, CourseKey))
+        assert isinstance(course_key, CourseKey)
 
         if user.id is None:
             user.save()
@@ -994,7 +994,7 @@ class CourseEnrollment(models.Model):
 
         try:
             context = contexts.course_context_from_course_id(self.course_id)
-            assert(isinstance(self.course_id, CourseKey))
+            assert isinstance(self.course_id, CourseKey)
             data = {
                 'user_id': self.user.id,
                 'course_id': self.course_id.to_deprecated_string(),

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -216,7 +216,7 @@ class UserProfile(models.Model):
     MITx fall prototype.
     """
 
-    class Meta:  # pylint: disable=missing-docstring
+    class Meta(object):  # pylint: disable=missing-docstring
         db_table = "auth_userprofile"
 
     # CRITICAL TODO/SECURITY
@@ -436,7 +436,7 @@ class Registration(models.Model):
         registration profile is created when the user creates an
         account, but that account is inactive. Once the user clicks
         on the activation key, it becomes active. '''
-    class Meta:
+    class Meta(object):  # pylint: disable=missing-docstring
         db_table = "auth_registration"
 
     user = models.ForeignKey(User, unique=True)
@@ -846,7 +846,7 @@ class CourseEnrollment(models.Model):
 
     objects = CourseEnrollmentManager()
 
-    class Meta:
+    class Meta(object):  # pylint: disable=missing-docstring
         unique_together = (('user', 'course_id'),)
         ordering = ('user', 'course_id')
 
@@ -1407,7 +1407,7 @@ class CourseEnrollmentAllowed(models.Model):
 
     created = models.DateTimeField(auto_now_add=True, null=True, db_index=True)
 
-    class Meta:  # pylint: disable=missing-docstring
+    class Meta(object):  # pylint: disable=missing-docstring
         unique_together = (('email', 'course_id'),)
 
     def __unicode__(self):
@@ -1444,7 +1444,7 @@ class CourseAccessRole(models.Model):
     course_id = CourseKeyField(max_length=255, db_index=True, blank=True)
     role = models.CharField(max_length=64, db_index=True)
 
-    class Meta:  # pylint: disable=missing-docstring
+    class Meta(object):  # pylint: disable=missing-docstring
         unique_together = ('user', 'org', 'course_id', 'role')
 
     @property
@@ -1835,7 +1835,7 @@ class LanguageProficiency(models.Model):
     /edx-platform/openedx/core/djangoapps/user_api/accounts/views.py or its associated api method
     (update_account_settings) so that the events are emitted.
     """
-    class Meta:
+    class Meta(object):  # pylint: disable=missing-docstring
         unique_together = (('code', 'user_profile'),)
 
     user_profile = models.ForeignKey(UserProfile, db_index=True, related_name='language_proficiencies')

--- a/common/djangoapps/student/roles.py
+++ b/common/djangoapps/student/roles.py
@@ -99,7 +99,7 @@ class GlobalStaff(AccessRole):
 
     def add_users(self, *users):
         for user in users:
-            if (user.is_authenticated() and user.is_active):
+            if user.is_authenticated() and user.is_active:
                 user.is_staff = True
                 user.save()
 

--- a/common/djangoapps/student/tests/test_email.py
+++ b/common/djangoapps/student/tests/test_email.py
@@ -11,11 +11,11 @@ from student.views import (
 from student.models import UserProfile, PendingEmailChange
 from django.core.urlresolvers import reverse
 from django.core import mail
-from django.contrib.auth.models import User, AnonymousUser
+from django.contrib.auth.models import User
 from django.test import TestCase, TransactionTestCase
 from django.test.client import RequestFactory
 from mock import Mock, patch
-from django.http import Http404, HttpResponse
+from django.http import HttpResponse
 from django.conf import settings
 from edxmako.shortcuts import render_to_string
 from edxmako.tests import mako_middleware_process_request

--- a/common/djangoapps/student/tests/test_login_registration_forms.py
+++ b/common/djangoapps/student/tests/test_login_registration_forms.py
@@ -1,7 +1,6 @@
 """Tests for the login and registration form rendering. """
 import urllib
 import unittest
-from collections import OrderedDict
 
 import ddt
 from mock import patch
@@ -10,7 +9,6 @@ from django.core.urlresolvers import reverse
 
 from util.testing import UrlResetMixin
 from xmodule.modulestore.tests.factories import CourseFactory
-from student.tests.factories import CourseModeFactory
 from third_party_auth.tests.testutil import ThirdPartyAuthTestMixin
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 

--- a/common/djangoapps/student/tests/test_verification_status.py
+++ b/common/djangoapps/student/tests/test_verification_status.py
@@ -20,7 +20,7 @@ from xmodule.modulestore.tests.factories import CourseFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from student.tests.factories import UserFactory, CourseEnrollmentFactory
 from course_modes.tests.factories import CourseModeFactory
-from verify_student.models import SoftwareSecurePhotoVerification  # pylint: disable=F0401
+from verify_student.models import SoftwareSecurePhotoVerification  # pylint: disable=import-error
 from util.testing import UrlResetMixin
 
 

--- a/common/djangoapps/student/tests/tests.py
+++ b/common/djangoapps/student/tests/tests.py
@@ -10,18 +10,20 @@ import ddt
 
 from django.conf import settings
 from django.contrib.auth.models import User, AnonymousUser
-from django.contrib.sessions.middleware import SessionMiddleware
 from django.core.urlresolvers import reverse
 from django.test import TestCase
-from django.test.client import RequestFactory, Client
+from django.test.client import Client
 from mock import Mock, patch
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
 
 from student.models import (
     anonymous_id_for_user, user_by_anonymous_id, CourseEnrollment, unique_id_for_user, LinkedInAddToProfileConfiguration
 )
-from student.views import (process_survey_link, _cert_info,
-                           change_enrollment, complete_course_mode_info)
+from student.views import (
+    process_survey_link,
+    _cert_info,
+    complete_course_mode_info,
+)
 from student.tests.factories import UserFactory, CourseModeFactory
 from util.testing import EventTestMixin
 from util.model_utils import USER_SETTINGS_CHANGED_EVENT_NAME

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1043,7 +1043,7 @@ def accounts_login(request):
 
 # Need different levels of logging
 @ensure_csrf_cookie
-def login_user(request, error=""):  # pylint: disable-msg=too-many-statements,unused-argument
+def login_user(request, error=""):  # pylint: disable=too-many-statements,unused-argument
     """AJAX request to log in the user."""
 
     backend_name = None

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -6,7 +6,6 @@ import logging
 import uuid
 import json
 import warnings
-from datetime import timedelta
 from collections import defaultdict
 from pytz import UTC
 from requests import HTTPError
@@ -26,9 +25,8 @@ from django.db import IntegrityError, transaction
 from django.http import (HttpResponse, HttpResponseBadRequest, HttpResponseForbidden,
                          HttpResponseServerError, Http404)
 from django.shortcuts import redirect
-from django.utils import timezone
 from django.utils.translation import ungettext
-from django.utils.http import cookie_date, base36_to_int
+from django.utils.http import base36_to_int
 from django.utils.translation import ugettext as _, get_language
 from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_exempt, ensure_csrf_cookie
@@ -49,7 +47,7 @@ from edxmako.shortcuts import render_to_response, render_to_string
 from course_modes.models import CourseMode
 from shoppingcart.api import order_history
 from student.models import (
-    Registration, UserProfile, PendingNameChange,
+    Registration, UserProfile,
     PendingEmailChange, CourseEnrollment, CourseEnrollmentAttribute, unique_id_for_user,
     CourseEnrollmentAllowed, UserStanding, LoginFailures,
     create_comments_service_user, PasswordHistory, UserSignupSource,
@@ -60,10 +58,8 @@ from verify_student.models import SoftwareSecurePhotoVerification  # pylint: dis
 from certificates.models import CertificateStatuses, certificate_status_for_student
 from certificates.api import (  # pylint: disable=import-error
     get_certificate_url,
-    get_active_web_certificate,
     has_html_certificates_enabled,
 )
-from dark_lang.models import DarkLangConfig
 
 from xmodule.modulestore.django import modulestore
 from opaque_keys import InvalidKeyError
@@ -86,7 +82,6 @@ from external_auth.login_and_register import (
 )
 
 from bulk_email.models import Optout, CourseAuthorization
-import shoppingcart
 from lang_pref import LANGUAGE_KEY
 
 import track.views

--- a/common/djangoapps/terrain/steps.py
+++ b/common/djangoapps/terrain/steps.py
@@ -95,7 +95,7 @@ def the_page_title_should_be(step, title):
 
 @step(u'the page title should contain "([^"]*)"$')
 def the_page_title_should_contain(step, title):
-    assert(title in world.browser.title)
+    assert title in world.browser.title
 
 
 @step('I log in$')

--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -58,7 +58,7 @@ See http://psa.matiasaguirre.net/docs/pipeline.html for more docs.
 """
 
 import random
-import string  # pylint: disable-msg=deprecated-module
+import string  # pylint: disable=deprecated-module
 from collections import OrderedDict
 import urllib
 import analytics
@@ -431,7 +431,7 @@ def running(request):
 # Pipeline functions.
 # Signatures are set by python-social-auth; prepending 'unused_' causes
 # TypeError on dispatch to the auth backend's authenticate().
-# pylint: disable-msg=unused-argument
+# pylint: disable=unused-argument
 
 
 def parse_query_params(strategy, response, *args, **kwargs):

--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -80,9 +80,6 @@ from logging import getLogger
 
 from . import provider
 
-# Note that this lives in openedx, so this dependency should be refactored.
-from openedx.core.djangoapps.user_api.preferences.api import update_email_opt_in
-
 
 # These are the query string params you can pass
 # to the URL that starts the authentication process.

--- a/common/djangoapps/third_party_auth/tests/specs/base.py
+++ b/common/djangoapps/third_party_auth/tests/specs/base.py
@@ -1,6 +1,5 @@
 """Base integration test for provider implementations."""
 
-import re
 import unittest
 
 import json

--- a/common/djangoapps/third_party_auth/tests/specs/test_google.py
+++ b/common/djangoapps/third_party_auth/tests/specs/test_google.py
@@ -1,6 +1,5 @@
 """Integration tests for Google providers."""
 
-from third_party_auth import provider
 from third_party_auth.tests.specs import base
 
 

--- a/common/djangoapps/third_party_auth/tests/specs/test_linkedin.py
+++ b/common/djangoapps/third_party_auth/tests/specs/test_linkedin.py
@@ -1,6 +1,5 @@
 """Integration tests for LinkedIn providers."""
 
-from third_party_auth import provider
 from third_party_auth.tests.specs import base
 
 

--- a/common/djangoapps/third_party_auth/tests/test_pipeline.py
+++ b/common/djangoapps/third_party_auth/tests/test_pipeline.py
@@ -2,7 +2,7 @@
 
 import random
 
-from third_party_auth import pipeline, provider
+from third_party_auth import pipeline
 from third_party_auth.tests import testutil
 import unittest
 

--- a/common/djangoapps/third_party_auth/tests/test_pipeline.py
+++ b/common/djangoapps/third_party_auth/tests/test_pipeline.py
@@ -7,8 +7,8 @@ from third_party_auth.tests import testutil
 import unittest
 
 
-# Allow tests access to protected methods (or module-protected methods) under
-# test. pylint: disable-msg=protected-access
+# Allow tests access to protected methods (or module-protected methods) under test.
+# pylint: disable=protected-access
 
 
 class MakeRandomPasswordTest(testutil.TestCase):

--- a/common/djangoapps/third_party_auth/tests/test_pipeline_integration.py
+++ b/common/djangoapps/third_party_auth/tests/test_pipeline_integration.py
@@ -13,7 +13,7 @@ from social.apps.django_app.default import models as social_models
 
 # Get Django User model by reference from python-social-auth. Not a type
 # constant, pylint.
-User = social_models.DjangoStorage.user.user_model()  # pylint: disable-msg=invalid-name
+User = social_models.DjangoStorage.user.user_model()  # pylint: disable=invalid-name
 
 
 class TestCase(testutil.TestCase, test.TestCase):

--- a/common/djangoapps/third_party_auth/tests/test_settings.py
+++ b/common/djangoapps/third_party_auth/tests/test_settings.py
@@ -21,10 +21,10 @@ _SETTINGS_MAP = {
 class SettingsUnitTest(testutil.TestCase):
     """Unit tests for settings management code."""
 
-    # Allow access to protected methods (or module-protected methods) under
-    # test. pylint: disable-msg=protected-access
+    # Allow access to protected methods (or module-protected methods) under test.
+    # pylint: disable=protected-access
     # Suppress sprurious no-member warning on fakes.
-    # pylint: disable-msg=no-member
+    # pylint: disable=no-member
 
     def setUp(self):
         super(SettingsUnitTest, self).setUp()

--- a/common/djangoapps/track/backends/django.py
+++ b/common/djangoapps/track/backends/django.py
@@ -46,7 +46,7 @@ class TrackingLog(models.Model):
     time = models.DateTimeField('event time')
     host = models.CharField(max_length=64, blank=True)
 
-    class Meta:
+    class Meta(object):  # pylint: disable=missing-docstring
         app_label = 'track'
         db_table = 'track_trackinglog'
 

--- a/common/djangoapps/track/contexts.py
+++ b/common/djangoapps/track/contexts.py
@@ -49,7 +49,7 @@ def course_context_from_course_id(course_id):
         return {'course_id': '', 'org_id': ''}
 
     # TODO: Make this accept any CourseKey, and serialize it using .to_string
-    assert(isinstance(course_id, CourseKey))
+    assert isinstance(course_id, CourseKey)
     return {
         'course_id': course_id.to_deprecated_string(),
         'org_id': course_id.org,

--- a/common/djangoapps/track/models.py
+++ b/common/djangoapps/track/models.py
@@ -1,1 +1,2 @@
+# pylint: disable=unused-import, missing-docstring
 from track.backends.django import TrackingLog

--- a/common/djangoapps/track/views/tests/test_views.py
+++ b/common/djangoapps/track/views/tests/test_views.py
@@ -3,17 +3,13 @@
 from mock import patch, sentinel
 
 from django.contrib.auth.models import User
-from django.test import TestCase
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
 
-from eventtracking import tracker
 from track import views
 from track.middleware import TrackMiddleware
 from track.tests import EventTrackingTestCase, FROZEN_TIME
 from openedx.core.lib.tests.assertions.events import assert_event_matches
-
-from datetime import datetime
 
 
 class TestTrackViews(EventTrackingTestCase):

--- a/common/lib/capa/capa/capa_problem.py
+++ b/common/lib/capa/capa/capa_problem.py
@@ -853,7 +853,7 @@ class LoncapaProblem(object):
             answer_id = 1
             input_tags = inputtypes.registry.registered_tags()
             inputfields = tree.xpath(
-                "|".join(['//' + response.tag + '[@id=$id]//' + x for x in (input_tags + solution_tags)]),
+                "|".join(['//' + response.tag + '[@id=$id]//' + x for x in input_tags + solution_tags]),
                 id=response_id_str
             )
 

--- a/common/lib/capa/capa/capa_problem.py
+++ b/common/lib/capa/capa/capa_problem.py
@@ -631,7 +631,7 @@ class LoncapaProblem(object):
                 parent = inc.getparent()
                 parent.insert(parent.index(inc), incxml)
                 parent.remove(inc)
-                log.debug('Included %s into %s' % (filename, self.problem_id))
+                log.debug('Included %s into %s', filename, self.problem_id)
 
     def _extract_system_path(self, script):
         """

--- a/common/lib/capa/capa/checker.py
+++ b/common/lib/capa/capa/checker.py
@@ -99,7 +99,7 @@ def check_that_blanks_fail(problem):
                          for answer_id in problem.get_question_answers())
     grading_results = problem.grade_answers(blank_answers)
     try:
-        assert(all(result == 'incorrect' for result in grading_results.values()))
+        assert all(result == 'incorrect' for result in grading_results.values())
     except AssertionError:
         log.error("Blank accepted as correct answer in {0} for {1}"
                   .format(problem,

--- a/common/lib/capa/capa/responsetypes.py
+++ b/common/lib/capa/capa/responsetypes.py
@@ -2719,7 +2719,7 @@ class ExternalResponse(LoncapaResponse):
                 exans = [''] * len(self.answer_ids)
                 exans[0] = msg
 
-        if not (len(exans) == len(self.answer_ids)):
+        if not len(exans) == len(self.answer_ids):
             log.error('Expected %s answers from external server, only got %s!',
                       len(self.answer_ids), len(exans))
             raise Exception('Short response from external server')

--- a/common/lib/capa/capa/tests/response_xml_factory.py
+++ b/common/lib/capa/capa/tests/response_xml_factory.py
@@ -80,7 +80,7 @@ class ResponseXMLFactory(object):
             # Add input elements
             for __ in range(int(num_inputs)):
                 input_element = self.create_input_element(**kwargs)
-                if not (None == input_element):
+                if not None == input_element:
                     response_element.append(input_element)
 
             # The problem has an explanation of the solution
@@ -146,7 +146,7 @@ class ResponseXMLFactory(object):
         choice_names = kwargs.get('choice_names', [None] * len(choices))
 
         # Create the <choicegroup>, <checkboxgroup>, or <radiogroup> element
-        assert(choice_type in group_element_names)
+        assert choice_type in group_element_names
         group_element = etree.Element(group_element_names[choice_type])
 
         # Create the <choice> elements
@@ -412,8 +412,8 @@ class FormulaResponseXMLFactory(ResponseXMLFactory):
         answer = kwargs.get("answer", None)
         hint_list = kwargs.get("hints", None)
 
-        assert(answer)
-        assert(sample_dict and num_samples)
+        assert answer
+        assert sample_dict and num_samples
 
         # Create the <formularesponse> element
         response_element = etree.Element("formularesponse")
@@ -518,7 +518,7 @@ class ImageResponseXMLFactory(ResponseXMLFactory):
         rectangle = kwargs.get('rectangle', None)
         regions = kwargs.get('regions', None)
 
-        assert(rectangle or regions)
+        assert rectangle or regions
 
         # Create the <imageinput> element
         input_element = etree.Element("imageinput")
@@ -635,9 +635,9 @@ class OptionResponseXMLFactory(ResponseXMLFactory):
         options_list = kwargs.get('options', None)
         correct_option = kwargs.get('correct_option', None)
 
-        assert(options_list and correct_option)
-        assert(len(options_list) > 1)
-        assert(correct_option in options_list)
+        assert options_list and correct_option
+        assert len(options_list) > 1
+        assert correct_option in options_list
 
         # Create the <optioninput> element
         optioninput_element = etree.Element("optioninput")

--- a/common/lib/safe_lxml/safe_lxml/etree.py
+++ b/common/lib/safe_lxml/safe_lxml/etree.py
@@ -12,7 +12,7 @@ from lxml.etree import XMLParser as _XMLParser
 from lxml.etree import _Element, _ElementTree  # pylint: disable=unused-import, no-name-in-module
 
 # This should be imported after lxml.etree so that it overrides the following attributes.
-from defusedxml.lxml import parse, fromstring, XML
+from defusedxml.lxml import parse, fromstring, XML  # pylint: disable=unused-import
 
 
 class XMLParser(_XMLParser):  # pylint: disable=function-redefined

--- a/common/lib/symmath/symmath/formula.py
+++ b/common/lib/symmath/symmath/formula.py
@@ -309,7 +309,7 @@ class formula(object):
             with 'scriptN'. There have been problems using script_N or script(N)
             """
             for child in parent:
-                if (gettag(child) == 'mstyle' and child.get('mathvariant') == 'script'):
+                if gettag(child) == 'mstyle' and child.get('mathvariant') == 'script':
                     newchild = etree.Element('mi')
                     newchild.text = 'script%s' % flatten_pmathml(child[0])
                     parent.replace(child, newchild)
@@ -397,7 +397,7 @@ class formula(object):
             """
             for child in parent:
                 # fix msubsup
-                if (gettag(child) == 'msubsup' and len(child) == 3):
+                if gettag(child) == 'msubsup' and len(child) == 3:
                     newchild = etree.Element('msup')
                     newbase = etree.Element('mi')
                     newbase.text = '%s_%s' % (flatten_pmathml(child[0]), flatten_pmathml(child[1]))

--- a/common/lib/symmath/symmath/symmath_check.py
+++ b/common/lib/symmath/symmath/symmath_check.py
@@ -255,7 +255,7 @@ def symmath_check(expect, ans, dynamath=None, options=None, debug=None, xml=None
         fsym = f.sympy
         msg += '<p>You entered: %s</p>' % to_latex(f.sympy)
     except Exception, err:
-        log.exception("Error evaluating expression '%s' as a valid equation" % ans)
+        log.exception("Error evaluating expression '%s' as a valid equation", ans)
         msg += "<p>Error in evaluating your expression '%s' as a valid equation</p>" % (ans)
         if "Illegal math" in str(err):
             msg += "<p>Illegal math expression</p>"

--- a/common/lib/symmath/symmath/symmath_check.py
+++ b/common/lib/symmath/symmath/symmath_check.py
@@ -86,7 +86,7 @@ def check(expect, given, numerical=False, matrix=False, normphase=False, abcsym=
         threshold = float(st)
         numerical = True
 
-    if str(given) == '' and not (str(expect) == ''):
+    if str(given) == '' and not str(expect) == '':
         return {'ok': False, 'msg': ''}
 
     try:
@@ -125,12 +125,12 @@ def check(expect, given, numerical=False, matrix=False, normphase=False, abcsym=
             #msg += "dm = " + to_latex(dm) + " diff = " + str(abs(dm.vec().norm().evalf()))
             #msg += "expect = " + to_latex(xexpect)
     elif dosimplify:
-        if (sympy.simplify(xexpect) == sympy.simplify(xgiven)):
+        if sympy.simplify(xexpect) == sympy.simplify(xgiven):
             return {'ok': True, 'msg': msg}
     elif numerical:
-        if (abs((xexpect - xgiven).evalf(chop=True)) < threshold):
+        if abs((xexpect - xgiven).evalf(chop=True)) < threshold:
             return {'ok': True, 'msg': msg}
-    elif (xexpect == xgiven):
+    elif xexpect == xgiven:
         return {'ok': True, 'msg': msg}
 
     #msg += "<p/>expect='%s', given='%s'" % (expect,given)	# debugging
@@ -149,9 +149,9 @@ def make_error_message(msg):
 
 def is_within_tolerance(expected, actual, tolerance):
     if expected == 0:
-        return (abs(actual) < tolerance)
+        return abs(actual) < tolerance
     else:
-        return (abs(abs(actual - expected) / expected) < tolerance)
+        return abs(abs(actual - expected) / expected) < tolerance
 
 #-----------------------------------------------------------------------------
 # Check function interface, which takes pmathml input
@@ -198,10 +198,11 @@ def symmath_check(expect, ans, dynamath=None, options=None, debug=None, xml=None
             DEBUG = False
 
     # options
-    do_matrix = 'matrix' in (options or '')
-    do_qubit = 'qubit' in (options or '')
-    do_imaginary = 'imaginary' in (options or '')
-    do_numerical = 'numerical' in (options or '')
+    if options is None:
+        options = ''
+    do_matrix = 'matrix' in options
+    do_qubit = 'qubit' in options
+    do_numerical = 'numerical' in options
 
     # parse expected answer
     try:

--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -469,7 +469,7 @@ class CapaMixin(CapaFields):
 
         # If the problem is closed (and not a survey question with max_attempts==0),
         # then do NOT show the reset button.
-        if (self.closed() and not is_survey_question):
+        if self.closed() and not is_survey_question:
             return False
 
         # Button only shows up for randomized problems if the question has been submitted

--- a/common/lib/xmodule/xmodule/capa_module.py
+++ b/common/lib/xmodule/xmodule/capa_module.py
@@ -143,7 +143,7 @@ class CapaDescriptor(CapaFields, RawDescriptor):
         Show them only if use_latex_compiler is set to True in
         course settings.
         """
-        return ('latex' not in template['template_id'] or course.use_latex_compiler)
+        return 'latex' not in template['template_id'] or course.use_latex_compiler
 
     def get_context(self):
         _context = RawDescriptor.get_context(self)

--- a/common/lib/xmodule/xmodule/contentstore/content.py
+++ b/common/lib/xmodule/xmodule/contentstore/content.py
@@ -105,7 +105,7 @@ class StaticContent(object):
         if course_key is None:
             return None
 
-        assert(isinstance(course_key, CourseKey))
+        assert isinstance(course_key, CourseKey)
         placeholder_id = uuid.uuid4().hex
         # create a dummy asset location with a fake but unique name. strip off the name, and return it
         url_path = StaticContent.serialize_asset_key_with_slash(

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -118,7 +118,7 @@ class Textbook(object):
             pass
 
         # Get the table of contents from S3
-        log.info("Retrieving textbook table of contents from %s" % toc_url)
+        log.info("Retrieving textbook table of contents from %s", toc_url)
         try:
             r = requests.get(toc_url)
         except Exception as err:

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -1009,7 +1009,7 @@ class CourseDescriptor(CourseFields, SequenceDescriptor, LicenseMixin):
                     policy_str = grading_policy_file.read()
                     # if we successfully read the file, stop looking at backups
                     break
-            except (IOError):
+            except IOError:
                 msg = "Unable to load course settings file from '{0}'".format(policy_path)
                 log.warning(msg)
 

--- a/common/lib/xmodule/xmodule/discussion_module.py
+++ b/common/lib/xmodule/xmodule/discussion_module.py
@@ -4,7 +4,6 @@ from xmodule.x_module import XModule
 from xmodule.raw_module import RawDescriptor
 from xmodule.editing_module import MetadataOnlyEditingDescriptor
 from xblock.fields import String, Scope, UNIQUE_ID
-from uuid import uuid4
 
 # Make '_' a no-op so we can scrape strings
 _ = lambda text: text

--- a/common/lib/xmodule/xmodule/graders.py
+++ b/common/lib/xmodule/xmodule/graders.py
@@ -310,7 +310,7 @@ class AssignmentFormatGrader(CourseGrader):
                 if index not in dropped_indices:
                     aggregate_score += mark['percent']
 
-            if (len(breakdown) - drop_count > 0):
+            if len(breakdown) - drop_count > 0:
                 aggregate_score /= len(breakdown) - drop_count
 
             return aggregate_score, dropped_indices

--- a/common/lib/xmodule/xmodule/html_module.py
+++ b/common/lib/xmodule/xmodule/html_module.py
@@ -135,7 +135,7 @@ class HtmlDescriptor(HtmlFields, XmlDescriptor, EditingDescriptor):  # pylint: d
         Show them only if use_latex_compiler is set to True in
         course settings.
         """
-        return ('latex' not in template['template_id'] or course.use_latex_compiler)
+        return 'latex' not in template['template_id'] or course.use_latex_compiler
 
     def get_context(self):
         """

--- a/common/lib/xmodule/xmodule/modulestore/__init__.py
+++ b/common/lib/xmodule/xmodule/modulestore/__init__.py
@@ -1151,7 +1151,7 @@ class ModuleStoreReadBase(BulkOperationsMixin, ModuleStoreRead):
         # pylint: disable=fixme
         # TODO (vshnayder): post-launch, make errors properties of items
         # self.get_item(location)
-        assert(isinstance(course_key, CourseKey))
+        assert isinstance(course_key, CourseKey)
         return self._course_errors[course_key].errors
 
     def get_errored_courses(self):
@@ -1169,7 +1169,7 @@ class ModuleStoreReadBase(BulkOperationsMixin, ModuleStoreRead):
 
         Default impl--linear search through course list
         """
-        assert(isinstance(course_id, CourseKey))
+        assert isinstance(course_id, CourseKey)
         for course in self.get_courses(**kwargs):
             if course.id == course_id:
                 return course
@@ -1184,7 +1184,7 @@ class ModuleStoreReadBase(BulkOperationsMixin, ModuleStoreRead):
                 to search for whether a potentially conflicting course exists in that case.
         """
         # linear search through list
-        assert(isinstance(course_id, CourseKey))
+        assert isinstance(course_id, CourseKey)
         if ignore_case:
             return next(
                 (

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
@@ -1495,7 +1495,7 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
             partitioned_fields = self.partition_fields_by_scope(block_type, fields)
             new_def_data = partitioned_fields.get(Scope.content, {})
             # persist the definition if persisted != passed
-            if (definition_locator is None or isinstance(definition_locator.definition_id, LocalId)):
+            if definition_locator is None or isinstance(definition_locator.definition_id, LocalId):
                 definition_locator = self.create_definition_from_data(course_key, new_def_data, block_type, user_id)
             elif new_def_data:
                 definition_locator, _ = self.update_definition_from_data(course_key, definition_locator, new_def_data, user_id)
@@ -2770,7 +2770,7 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
                 course_key.version_guid is None or
                 index_entry['versions'][course_key.branch] == course_key.version_guid
             )
-            if (is_head or force):
+            if is_head or force:
                 return index_entry
             else:
                 raise VersionConflictError(

--- a/common/lib/xmodule/xmodule/modulestore/tests/factories.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/factories.py
@@ -3,8 +3,6 @@ Factories for use in tests of XBlocks.
 """
 
 import functools
-import inspect
-import pprint
 import pymongo.message
 import threading
 import traceback
@@ -14,7 +12,7 @@ from uuid import uuid4
 
 from factory import Factory, Sequence, lazy_attribute_sequence, lazy_attribute
 from factory.containers import CyclicDefinitionError
-from mock import Mock, patch
+from mock import patch
 from nose.tools import assert_less_equal, assert_greater_equal
 import dogstats_wrapper as dog_stats_api
 

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_mixed_modulestore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_mixed_modulestore.py
@@ -8,7 +8,6 @@ import logging
 import ddt
 import itertools
 import mimetypes
-from unittest import skip
 from uuid import uuid4
 from contextlib import contextmanager
 from mock import patch

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_mixed_modulestore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_mixed_modulestore.py
@@ -1407,7 +1407,7 @@ class TestMixedModuleStore(CommonMixedModuleStoreSetup):
             course_id.make_usage_key('course_info', 'updates'),
         ]
 
-        for location in (orphan_locations + detached_locations):
+        for location in orphan_locations + detached_locations:
             self.store.create_item(
                 self.user_id,
                 location.course_key,

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_xml_importer.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_xml_importer.py
@@ -3,7 +3,6 @@ Tests for XML importer.
 """
 import mock
 from opaque_keys.edx.locator import BlockUsageLocator, CourseLocator
-from xblock.core import XBlock
 from xblock.fields import String, Scope, ScopeIds, List
 from xblock.runtime import Runtime, KvsFieldData, DictKeyValueStore
 from xmodule.x_module import XModuleMixin

--- a/common/lib/xmodule/xmodule/modulestore/xml.py
+++ b/common/lib/xmodule/xmodule/modulestore/xml.py
@@ -866,7 +866,7 @@ class XMLModuleStore(ModuleStoreReadBase):
         :return: list of course locations
         """
         courses = self.get_courses()
-        return [course.location.course_key for course in courses if (course.wiki_slug == wiki_slug)]
+        return [course.location.course_key for course in courses if course.wiki_slug == wiki_slug]
 
     def heartbeat(self):
         """

--- a/common/lib/xmodule/xmodule/open_ended_grading_classes/openendedchild.py
+++ b/common/lib/xmodule/xmodule/open_ended_grading_classes/openendedchild.py
@@ -298,7 +298,7 @@ class OpenEndedChild(object):
 
     def _allow_reset(self):
         """Can the module be reset?"""
-        return (self.child_state == self.DONE and self.child_attempts < self.max_attempts)
+        return self.child_state == self.DONE and self.child_attempts < self.max_attempts
 
     def max_score(self):
         """
@@ -396,7 +396,7 @@ class OpenEndedChild(object):
         @return: Boolean correct.
         """
         correct = False
-        if (isinstance(score, (int, long, float, complex))):
+        if isinstance(score, (int, long, float, complex)):
             score_ratio = int(score) / float(self.max_score())
             correct = (score_ratio >= 0.66)
         return correct

--- a/common/lib/xmodule/xmodule/peer_grading_module.py
+++ b/common/lib/xmodule/xmodule/peer_grading_module.py
@@ -118,7 +118,7 @@ class PeerGradingModule(PeerGradingFields, XModule):
 
         # We need to set the location here so the child modules can use it.
         self.runtime.set('location', self.location)
-        if (self.runtime.open_ended_grading_interface):
+        if self.runtime.open_ended_grading_interface:
             self.peer_gs = PeerGradingService(self.system.open_ended_grading_interface, self.system.render_template)
         else:
             self.peer_gs = MockPeerGradingService()

--- a/common/lib/xmodule/xmodule/tabs.py
+++ b/common/lib/xmodule/xmodule/tabs.py
@@ -146,7 +146,7 @@ class CourseTab(object):
         """
         Overrides the not equal operator as a partner to the equal operator.
         """
-        return not (self == other)
+        return not self == other
 
     @classmethod
     def validate(cls, tab_dict, raise_error=True):

--- a/common/lib/xmodule/xmodule/tests/test_capa_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_capa_module.py
@@ -63,7 +63,7 @@ class CapaFactory(object):
         """
         Return the input key to use when passing GET parameters
         """
-        return ("input_" + cls.answer_key(response_num, input_num))
+        return "input_" + cls.answer_key(response_num, input_num)
 
     @classmethod
     def answer_key(cls, response_num=2, input_num=1):

--- a/common/lib/xmodule/xmodule/tests/test_course_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_course_module.py
@@ -241,25 +241,25 @@ class IsNewCourseTestCase(unittest.TestCase):
 
     def test_is_newish(self):
         descriptor = get_dummy_course(start='2012-12-02T12:00', is_new=True)
-        assert(descriptor.is_newish is True)
+        assert descriptor.is_newish is True
 
         descriptor = get_dummy_course(start='2013-02-02T12:00', is_new=False)
-        assert(descriptor.is_newish is False)
+        assert descriptor.is_newish is False
 
         descriptor = get_dummy_course(start='2013-02-02T12:00', is_new=True)
-        assert(descriptor.is_newish is True)
+        assert descriptor.is_newish is True
 
         descriptor = get_dummy_course(start='2013-01-15T12:00')
-        assert(descriptor.is_newish is True)
+        assert descriptor.is_newish is True
 
         descriptor = get_dummy_course(start='2013-03-01T12:00')
-        assert(descriptor.is_newish is True)
+        assert descriptor.is_newish is True
 
         descriptor = get_dummy_course(start='2012-10-15T12:00')
-        assert(descriptor.is_newish is False)
+        assert descriptor.is_newish is False
 
         descriptor = get_dummy_course(start='2012-12-31T12:00')
-        assert(descriptor.is_newish is True)
+        assert descriptor.is_newish is True
 
     def test_end_date_text(self):
         # No end date set, returns empty string.

--- a/common/lib/xmodule/xmodule/tests/test_delay_between_attempts.py
+++ b/common/lib/xmodule/xmodule/tests/test_delay_between_attempts.py
@@ -58,7 +58,7 @@ class CapaFactoryWithDelay(object):
         """
         Return the input key to use when passing GET parameters
         """
-        return ("input_" + cls.answer_key(input_num))
+        return "input_" + cls.answer_key(input_num)
 
     @classmethod
     def answer_key(cls, input_num=2):

--- a/common/lib/xmodule/xmodule/video_module/transcripts_utils.py
+++ b/common/lib/xmodule/xmodule/video_module/transcripts_utils.py
@@ -462,7 +462,7 @@ def get_or_create_sjson(item, transcripts):
     source_subs_id, result_subs_dict = user_subs_id, {1.0: user_subs_id}
     try:
         sjson_transcript = Transcript.asset(item.location, source_subs_id, item.transcript_language).data
-    except (NotFoundError):  # generating sjson from srt
+    except NotFoundError:  # generating sjson from srt
         generate_sjson_for_all_speeds(item, user_filename, result_subs_dict, item.transcript_language)
     sjson_transcript = Transcript.asset(item.location, source_subs_id, item.transcript_language).data
     return sjson_transcript

--- a/common/lib/xmodule/xmodule/video_module/video_handlers.py
+++ b/common/lib/xmodule/xmodule/video_module/video_handlers.py
@@ -125,7 +125,7 @@ class VideoStudentViewHandlers(object):
 
             try:
                 sjson_transcript = Transcript.asset(self.location, youtube_id, self.transcript_language).data
-            except (NotFoundError):
+            except NotFoundError:
                 log.info("Can't find content in storage for %s transcript: generating.", youtube_id)
                 generate_sjson_for_all_speeds(
                     self,

--- a/common/lib/xmodule/xmodule/video_module/video_xfields.py
+++ b/common/lib/xmodule/xmodule/video_module/video_xfields.py
@@ -6,7 +6,6 @@ import datetime
 from xblock.fields import Scope, String, Float, Boolean, List, Dict, DateTime
 
 from xmodule.fields import RelativeTime
-from xmodule.mixin import LicenseMixin
 
 # Make '_' a no-op so we can scrape strings
 _ = lambda text: text

--- a/common/lib/xmodule/xmodule/wrapper_module.py
+++ b/common/lib/xmodule/xmodule/wrapper_module.py
@@ -2,7 +2,6 @@
 # But w/o css delimiters between children
 
 from xmodule.vertical_block import VerticalBlock
-from pkg_resources import resource_string
 
 # HACK: This shouldn't be hard-coded to two types
 # OBSOLETE: This obsoletes 'type'

--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -371,7 +371,7 @@ class XModuleMixin(XModuleFields, XBlock):
         """
         result = {}
         for field in self.fields.values():
-            if (field.scope == scope and field.is_set_on(self)):
+            if field.scope == scope and field.is_set_on(self):
                 result[field.name] = field.read_json(self)
         return result
 

--- a/common/test/acceptance/pages/lms/dashboard.py
+++ b/common/test/acceptance/pages/lms/dashboard.py
@@ -4,7 +4,6 @@ Student dashboard page.
 """
 
 from bok_choy.page_object import PageObject
-from bok_choy.promise import EmptyPromise
 from . import BASE_URL
 
 

--- a/common/test/acceptance/pages/lms/edxnotes.py
+++ b/common/test/acceptance/pages/lms/edxnotes.py
@@ -174,7 +174,7 @@ class EdxNotesPageView(PageObject):
         self.q(css=self.TAB_SELECTOR).first.click()
         try:
             return self.wait_for_page()
-        except (BrokenPromise):
+        except BrokenPromise:
             raise PageLoadError("Timed out waiting to load page '{!r}'".format(self))
 
     def is_browser_on_page(self):

--- a/common/test/acceptance/pages/lms/find_courses.py
+++ b/common/test/acceptance/pages/lms/find_courses.py
@@ -3,7 +3,6 @@ Find courses page (main page of the LMS).
 """
 
 from bok_choy.page_object import PageObject
-from bok_choy.promise import BrokenPromise
 from . import BASE_URL
 
 

--- a/common/test/acceptance/pages/lms/login_and_register.py
+++ b/common/test/acceptance/pages/lms/login_and_register.py
@@ -197,7 +197,7 @@ class CombinedLoginAndRegisterPage(PageObject):
             self.q(css="#register-password").fill(password)
         if country:
             self.q(css="#register-country option[value='{country}']".format(country=country)).click()
-        if (terms_of_service):
+        if terms_of_service:
             self.q(css="#register-honor_code").click()
 
         # Submit it

--- a/common/test/acceptance/pages/lms/pay_and_verify.py
+++ b/common/test/acceptance/pages/lms/pay_and_verify.py
@@ -1,10 +1,9 @@
 """Payment and verification pages"""
 
 import re
-from urllib import urlencode
 
-from bok_choy.page_object import PageObject, unguarded
-from bok_choy.promise import Promise, EmptyPromise
+from bok_choy.page_object import PageObject
+from bok_choy.promise import Promise
 from . import BASE_URL
 from .dashboard import DashboardPage
 

--- a/common/test/acceptance/pages/lms/track_selection.py
+++ b/common/test/acceptance/pages/lms/track_selection.py
@@ -1,9 +1,5 @@
 """Track selection page"""
-
-from urllib import urlencode
-
-from bok_choy.page_object import PageObject, unguarded
-from bok_choy.promise import Promise, EmptyPromise
+from bok_choy.page_object import PageObject
 from . import BASE_URL
 from .dashboard import DashboardPage
 from .pay_and_verify import PaymentAndVerificationFlow

--- a/common/test/acceptance/pages/studio/overview.py
+++ b/common/test/acceptance/pages/studio/overview.py
@@ -8,7 +8,6 @@ from bok_choy.promise import EmptyPromise
 
 from selenium.webdriver.support.ui import Select
 from selenium.webdriver.common.keys import Keys
-from selenium.webdriver.common.action_chains import ActionChains
 
 from .course_page import CoursePage
 from .container import ContainerPage

--- a/common/test/acceptance/pages/studio/overview.py
+++ b/common/test/acceptance/pages/studio/overview.py
@@ -404,7 +404,7 @@ class CourseOutlineSection(CourseOutlineContainer, CourseOutlineChild):
         self.add_child()
 
 
-class ExpandCollapseLinkState:
+class ExpandCollapseLinkState(object):
     """
     Represents the three states that the expand/collapse link can be in
     """

--- a/common/test/acceptance/performance/test_lms_performance.py
+++ b/common/test/acceptance/performance/test_lms_performance.py
@@ -1,7 +1,7 @@
 """
 Single page performance tests for LMS.
 """
-from bok_choy.web_app_test import WebAppTest, with_cache
+from bok_choy.web_app_test import with_cache
 from ..pages.lms.auto_auth import AutoAuthPage
 from ..pages.lms.courseware import CoursewarePage
 from ..pages.lms.dashboard import DashboardPage

--- a/common/test/acceptance/tests/lms/test_lms.py
+++ b/common/test/acceptance/tests/lms/test_lms.py
@@ -9,7 +9,6 @@ from unittest import skip
 from nose.plugins.attrib import attr
 
 from bok_choy.promise import EmptyPromise
-from bok_choy.web_app_test import WebAppTest
 from ..helpers import (
     UniqueCourseTest,
     EventsTestMixin,

--- a/common/test/acceptance/tests/lms/test_lms_course_discovery.py
+++ b/common/test/acceptance/tests/lms/test_lms_course_discovery.py
@@ -2,9 +2,7 @@
 Test course discovery.
 """
 import datetime
-from flaky import flaky
 import json
-import os
 
 from bok_choy.web_app_test import WebAppTest
 from ..helpers import remove_file

--- a/common/test/acceptance/tests/lms/test_lms_courseware_search.py
+++ b/common/test/acceptance/tests/lms/test_lms_courseware_search.py
@@ -1,7 +1,6 @@
 """
 Test courseware search
 """
-import os
 import json
 
 from nose.plugins.attrib import attr

--- a/common/test/acceptance/tests/lms/test_lms_edxnotes.py
+++ b/common/test/acceptance/tests/lms/test_lms_edxnotes.py
@@ -1,4 +1,6 @@
-import os
+"""
+Test LMS Notes
+"""
 from uuid import uuid4
 from datetime import datetime
 from nose.plugins.attrib import attr

--- a/common/test/acceptance/tests/lms/test_lms_user_preview.py
+++ b/common/test/acceptance/tests/lms/test_lms_user_preview.py
@@ -7,7 +7,6 @@ from ..helpers import UniqueCourseTest, create_user_partition_json
 from ...pages.studio.auto_auth import AutoAuthPage
 from ...pages.lms.courseware import CoursewarePage
 from ...pages.lms.staff_view import StaffPage
-from ...pages.lms.course_nav import CourseNavPage
 from ...fixtures.course import CourseFixture, XBlockFixtureDesc
 from xmodule.partitions.partitions import Group
 from textwrap import dedent

--- a/common/test/acceptance/tests/studio/test_studio_home.py
+++ b/common/test/acceptance/tests/studio/test_studio_home.py
@@ -3,7 +3,6 @@ Acceptance tests for Home Page (My Courses / My Libraries).
 """
 from bok_choy.web_app_test import WebAppTest
 from opaque_keys.edx.locator import LibraryLocator
-from unittest import skip
 
 from ...pages.studio.auto_auth import AutoAuthPage
 from ...pages.studio.library import LibraryEditPage

--- a/common/test/acceptance/tests/studio/test_studio_library.py
+++ b/common/test/acceptance/tests/studio/test_studio_library.py
@@ -2,7 +2,6 @@
 Acceptance tests for Content Libraries in Studio
 """
 from ddt import ddt, data
-from unittest import skip
 from nose.plugins.attrib import attr
 from flaky import flaky
 

--- a/common/test/acceptance/tests/studio/test_studio_outline.py
+++ b/common/test/acceptance/tests/studio/test_studio_outline.py
@@ -141,13 +141,16 @@ class WarningMessagesTest(CourseOutlineTest):
     FUTURE_UNPUBLISHED_WARNING = 'Unpublished changes to content that will release in the future'
     NEVER_PUBLISHED_WARNING = 'Unpublished units will not be released'
 
-    class PublishState:
+    class PublishState(object):
+        """
+        Default values for representing the published state of a unit
+        """
         NEVER_PUBLISHED = 1
         UNPUBLISHED_CHANGES = 2
         PUBLISHED = 3
         VALUES = [NEVER_PUBLISHED, UNPUBLISHED_CHANGES, PUBLISHED]
 
-    class UnitState:
+    class UnitState(object):
         """ Represents the state of a unit """
 
         def __init__(self, is_released, publish_state, is_locked):

--- a/common/test/acceptance/tests/studio/test_studio_settings.py
+++ b/common/test/acceptance/tests/studio/test_studio_settings.py
@@ -14,7 +14,6 @@ from ...pages.studio.settings import SettingsPage
 from ...pages.studio.settings_advanced import AdvancedSettingsPage
 from ...pages.studio.settings_group_configurations import GroupConfigurationsPage
 from ...pages.lms.courseware import CoursewarePage
-from unittest import skip
 from textwrap import dedent
 from xmodule.partitions.partitions import Group
 

--- a/common/test/acceptance/tests/studio/test_studio_split_test.py
+++ b/common/test/acceptance/tests/studio/test_studio_split_test.py
@@ -2,7 +2,6 @@
 Acceptance tests for Studio related to the split_test module.
 """
 
-import json
 import math
 from unittest import skip
 from nose.plugins.attrib import attr

--- a/common/test/acceptance/tests/test_annotatable.py
+++ b/common/test/acceptance/tests/test_annotatable.py
@@ -2,8 +2,6 @@
 """
 E2E tests for the LMS.
 """
-import time
-
 from unittest import skip
 
 from .helpers import UniqueCourseTest
@@ -11,7 +9,6 @@ from ..pages.studio.auto_auth import AutoAuthPage
 from ..pages.lms.courseware import CoursewarePage
 from ..pages.lms.annotation_component import AnnotationComponentPage
 from ..fixtures.course import CourseFixture, XBlockFixtureDesc
-from ..fixtures.xqueue import XQueueResponseFixture
 from textwrap import dedent
 
 

--- a/lms/djangoapps/ccx/models.py
+++ b/lms/djangoapps/ccx/models.py
@@ -150,7 +150,7 @@ class CcxFieldOverride(models.Model):
     location = LocationKeyField(max_length=255, db_index=True)
     field = models.CharField(max_length=255)
 
-    class Meta:  # pylint: disable=missing-docstring,old-style-class
+    class Meta(object):  # pylint: disable=missing-docstring
         unique_together = (('ccx', 'location', 'field'),)
 
     value = models.TextField(default='null')

--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -16,7 +16,6 @@ from django.core.urlresolvers import reverse
 from django.http import (
     HttpResponse,
     HttpResponseForbidden,
-    HttpResponseRedirect,
 )
 from django.contrib import messages
 from django.core.exceptions import ValidationError
@@ -26,23 +25,22 @@ from django.shortcuts import redirect
 from django.utils.translation import ugettext as _
 from django.views.decorators.cache import cache_control
 from django.views.decorators.csrf import ensure_csrf_cookie
-from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
 
-from courseware.courses import get_course_by_id  # pylint: disable=import-error
+from courseware.courses import get_course_by_id
 
-from courseware.field_overrides import disable_overrides  # pylint: disable=import-error
-from courseware.grades import iterate_grades_for  # pylint: disable=import-error
-from courseware.model_data import FieldDataCache  # pylint: disable=import-error
-from courseware.module_render import get_module_for_descriptor  # pylint: disable=import-error
-from edxmako.shortcuts import render_to_response  # pylint: disable=import-error
+from courseware.field_overrides import disable_overrides
+from courseware.grades import iterate_grades_for
+from courseware.model_data import FieldDataCache
+from courseware.module_render import get_module_for_descriptor
+from edxmako.shortcuts import render_to_response
 from opaque_keys.edx.keys import CourseKey
 from ccx_keys.locator import CCXLocator
-from student.roles import CourseCcxCoachRole  # pylint: disable=import-error
+from student.roles import CourseCcxCoachRole
 
-from instructor.offline_gradecalc import student_grades  # pylint: disable=import-error
-from instructor.views.api import _split_input_list  # pylint: disable=import-error
-from instructor.views.tools import get_student_from_identifier  # pylint: disable=import-error
+from instructor.offline_gradecalc import student_grades
+from instructor.views.api import _split_input_list
+from instructor.views.tools import get_student_from_identifier
 
 from .models import CustomCourseForEdX, CcxMembership
 from .overrides import (

--- a/lms/djangoapps/certificates/models.py
+++ b/lms/djangoapps/certificates/models.py
@@ -241,7 +241,7 @@ class ExampleCertificateSet(TimeStampedModel):
     """
     course_key = CourseKeyField(max_length=255, db_index=True)
 
-    class Meta:  # pylint: disable=missing-docstring, old-style-class
+    class Meta(object):  # pylint: disable=missing-docstring
         get_latest_by = 'created'
 
     @classmethod
@@ -498,7 +498,7 @@ class CertificateGenerationCourseSetting(TimeStampedModel):
     course_key = CourseKeyField(max_length=255, db_index=True)
     enabled = models.BooleanField(default=False)
 
-    class Meta:  # pylint: disable=missing-docstring, old-style-class
+    class Meta(object):  # pylint: disable=missing-docstring
         get_latest_by = 'created'
 
     @classmethod

--- a/lms/djangoapps/certificates/views.py
+++ b/lms/djangoapps/certificates/views.py
@@ -105,10 +105,13 @@ def update_certificate(request):
                 key=xqueue_header['lms_key'])
 
         except GeneratedCertificate.DoesNotExist:
-            logger.critical('Unable to lookup certificate\n'
-                            'xqueue_body: {0}\n'
-                            'xqueue_header: {1}'.format(
-                                xqueue_body, xqueue_header))
+            logger.critical(
+                'Unable to lookup certificate\n'
+                'xqueue_body: %s\n'
+                'xqueue_header: %s',
+                xqueue_body,
+                xqueue_header
+            )
 
             return HttpResponse(json.dumps({
                 'return_code': 1,
@@ -139,8 +142,9 @@ def update_certificate(request):
             elif cert.status in [status.deleting]:
                 cert.status = status.deleted
             else:
-                logger.critical('Invalid state for cert update: {0}'.format(
-                    cert.status))
+                logger.critical(
+                    'Invalid state for cert update: %s', cert.status
+                )
                 return HttpResponse(
                     json.dumps({
                         'return_code': 1,

--- a/lms/djangoapps/class_dashboard/dashboard_data.py
+++ b/lms/djangoapps/class_dashboard/dashboard_data.py
@@ -326,7 +326,7 @@ def get_d3_section_grade_distrib(course_id, section):
             c_unit += 1
             c_problem = 0
             for child in unit.get_children():
-                if (child.location.category == 'problem'):
+                if child.location.category == 'problem':
                     c_problem += 1
                     problem_set.append(child.location)
                     problem_info[child.location] = {

--- a/lms/djangoapps/commerce/urls.py
+++ b/lms/djangoapps/commerce/urls.py
@@ -1,7 +1,7 @@
 """
 Defines the URL routes for this app.
 """
-from django.conf.urls import patterns, url, include
+from django.conf.urls import patterns, url
 
 from commerce import views
 

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -224,14 +224,15 @@ def get_course_about_section(course, section_key):
                 except Exception:  # pylint: disable=broad-except
                     html = render_to_string('courseware/error-message.html', None)
                     log.exception(
-                        u"Error rendering course={course}, section_key={section_key}".format(
-                            course=course, section_key=section_key
-                        ))
+                        u"Error rendering course=%s, section_key=%s",
+                        course, section_key
+                    )
             return html
 
         except ItemNotFoundError:
             log.warning(
-                u"Missing about section {key} in course {url}".format(key=section_key, url=course.location.to_deprecated_string())
+                u"Missing about section %s in course %s",
+                section_key, course.location.to_deprecated_string()
             )
             return None
     elif section_key == "title":
@@ -291,9 +292,9 @@ def get_course_info_section(request, course, section_key):
         except Exception:  # pylint: disable=broad-except
             html = render_to_string('courseware/error-message.html', None)
             log.exception(
-                u"Error rendering course={course}, section_key={section_key}".format(
-                    course=course, section_key=section_key
-                ))
+                u"Error rendering course=%s, section_key=%s",
+                course, section_key
+            )
 
     return html
 
@@ -330,7 +331,8 @@ def get_course_syllabus_section(course, section_key):
                 )
         except ResourceNotFoundError:
             log.exception(
-                u"Missing syllabus section {key} in course {url}".format(key=section_key, url=course.location.to_deprecated_string())
+                u"Missing syllabus section %s in course %s",
+                section_key, course.location.to_deprecated_string()
             )
             return "! Syllabus missing !"
 

--- a/lms/djangoapps/courseware/features/gst.py
+++ b/lms/djangoapps/courseware/features/gst.py
@@ -1,9 +1,8 @@
 
 from lettuce import world, steps
-from nose.tools import assert_in, assert_equals, assert_true
+from nose.tools import assert_equals
 
 from common import i_am_registered_for_the_course, visit_scenario_item
-from problems_setup import add_problem_to_course, answer_problem
 
 
 DEFAULT_DATA = """\

--- a/lms/djangoapps/courseware/features/problems.py
+++ b/lms/djangoapps/courseware/features/problems.py
@@ -82,8 +82,8 @@ def input_problem_answer(_, problem_type, correctness):
     """
     Have the browser input an answer (either correct or incorrect)
     """
-    assert(correctness in ['correct', 'incorrect'])
-    assert(problem_type in PROBLEM_DICT)
+    assert correctness in ['correct', 'incorrect']
+    assert problem_type in PROBLEM_DICT
     answer_problem(world.scenario_dict['COURSE'].number, problem_type, correctness)
 
 
@@ -166,8 +166,8 @@ def assert_answer_mark(_step, problem_type, isnt_marked, correctness):
     *correctness* is in ['correct', 'incorrect', 'unanswered']
     """
     # Determine which selector(s) to look for based on correctness
-    assert(correctness in ['correct', 'incorrect', 'unanswered'])
-    assert(problem_type in PROBLEM_DICT)
+    assert correctness in ['correct', 'incorrect', 'unanswered']
+    assert problem_type in PROBLEM_DICT
 
     # At least one of the correct selectors should be present
     for sel in PROBLEM_DICT[problem_type][correctness]:
@@ -183,4 +183,4 @@ def assert_answer_mark(_step, problem_type, isnt_marked, correctness):
             break
 
     # Expect that we found the expected selector
-    assert(has_expected)
+    assert has_expected

--- a/lms/djangoapps/courseware/features/problems_setup.py
+++ b/lms/djangoapps/courseware/features/problems_setup.py
@@ -356,7 +356,7 @@ def add_problem_to_course(course, problem_type, extra_meta=None):
     Add a problem to the course we have created using factories.
     '''
 
-    assert(problem_type in PROBLEM_DICT)
+    assert problem_type in PROBLEM_DICT
 
     # Generate the problem XML using capa.tests.response_xml_factory
     factory_dict = PROBLEM_DICT[problem_type]

--- a/lms/djangoapps/courseware/features/video.py
+++ b/lms/djangoapps/courseware/features/video.py
@@ -471,14 +471,14 @@ def check_text_in_the_captions(_step, text):
     world.wait_for_present('.video.is-captions-rendered')
     world.wait_for(lambda _: world.css_text('.subtitles'))
     actual_text = world.css_text('.subtitles')
-    assert (text in actual_text)
+    assert text in actual_text
 
 
 @step('I see text in the captions:')
 def check_captions(_step):
     world.wait_for_present('.video.is-captions-rendered')
     for index, video in enumerate(_step.hashes):
-        assert (video.get('text') in world.css_text('.subtitles', index=index))
+        assert video.get('text') in world.css_text('.subtitles', index=index)
 
 
 @step('I select language with code "([^"]*)"$')
@@ -594,7 +594,7 @@ def i_can_download_transcript(_step, format, text):
     request = RequestHandlerWithSessionId()
     assert request.get(url).is_success()
     assert request.check_header('content-type', formats[format])
-    assert (text.encode('utf-8') in request.content)
+    assert text.encode('utf-8') in request.content
 
 
 @step('I select the transcript format "([^"]*)"$')

--- a/lms/djangoapps/courseware/features/video.py
+++ b/lms/djangoapps/courseware/features/video.py
@@ -6,7 +6,7 @@ import json
 import os
 import time
 import requests
-from nose.tools import assert_less, assert_equal, assert_true, assert_false
+from nose.tools import assert_equal, assert_true, assert_false
 from common import i_am_registered_for_the_course, visit_scenario_item
 from django.utils.translation import ugettext as _
 from django.conf import settings

--- a/lms/djangoapps/courseware/features/word_cloud.py
+++ b/lms/djangoapps/courseware/features/word_cloud.py
@@ -26,7 +26,7 @@ def press_the_save_button(_step):
 
 @step('I see the empty result')
 def see_empty_result(_step):
-    assert (world.css_text('.your_words', 0) == '')
+    assert world.css_text('.your_words', 0) == ''
 
 
 @step('I fill inputs')

--- a/lms/djangoapps/courseware/features/word_cloud.py
+++ b/lms/djangoapps/courseware/features/word_cloud.py
@@ -1,9 +1,6 @@
 # pylint: disable=missing-docstring
 
-from time import sleep
-
 from lettuce import world, step
-from lettuce.django import django_url
 from common import i_am_registered_for_the_course, section_location, visit_scenario_item
 
 

--- a/lms/djangoapps/courseware/grades.py
+++ b/lms/djangoapps/courseware/grades.py
@@ -230,14 +230,16 @@ def answer_distributions(course_key):
                 answer_counts[(url, display_name, problem_part_id)][answer] += 1
 
         except (ItemNotFoundError, InvalidKeyError):
-            msg = "Answer Distribution: Item {} referenced in StudentModule {} " + \
-                  "for user {} in course {} not found; " + \
-                  "This can happen if a student answered a question that " + \
-                  "was later deleted from the course. This answer will be " + \
-                  "omitted from the answer distribution CSV."
-            log.warning(
-                msg.format(module.module_state_key, module.id, module.student_id, course_key)
+            msg = (
+                "Answer Distribution: Item {} referenced in StudentModule {} " +
+                "for user {} in course {} not found; " +
+                "This can happen if a student answered a question that " +
+                "was later deleted from the course. This answer will be " +
+                "omitted from the answer distribution CSV."
+            ).format(
+                module.module_state_key, module.id, module.student_id, course_key
             )
+            log.warning(msg)
             continue
 
     return answer_counts

--- a/lms/djangoapps/courseware/management/commands/regrade_partial.py
+++ b/lms/djangoapps/courseware/management/commands/regrade_partial.py
@@ -159,8 +159,8 @@ class Command(BaseCommand):
 
         save_changes = options['save_changes']
 
-        LOG.info("Starting run: save_changes = {0}".format(save_changes))
+        LOG.info("Starting run: save_changes = %s", save_changes)
 
         self.fix_studentmodules(save_changes)
 
-        LOG.info("Finished run:  updating {0} of {1} modules".format(self.num_changed, self.num_visited))
+        LOG.info("Finished run: updating %s of %s modules", self.num_changed, self.num_visited)

--- a/lms/djangoapps/courseware/management/commands/remove_input_state.py
+++ b/lms/djangoapps/courseware/management/commands/remove_input_state.py
@@ -80,9 +80,12 @@ class Command(BaseCommand):
                 self.remove_studentmodulehistory_input_state(hist_module, save_changes)
 
             if self.num_visited % 1000 == 0:
-                LOG.info(" Progress: updated {0} of {1} student modules".format(self.num_changed, self.num_visited))
-                LOG.info(" Progress: updated {0} of {1} student history modules".format(self.num_hist_changed,
-                                                                                        self.num_hist_visited))
+                LOG.info(" Progress: updated %s of %s student modules", self.num_changed, self.num_visited)
+                LOG.info(
+                    " Progress: updated %s of %s student history modules",
+                    self.num_hist_changed,
+                    self.num_hist_visited
+                )
 
     @transaction.autocommit
     def remove_studentmodule_input_state(self, module, save_changes):
@@ -90,9 +93,11 @@ class Command(BaseCommand):
         module_state = module.state
         if module_state is None:
             # not likely, since we filter on it.  But in general...
-            LOG.info("No state found for {type} module {id} for student {student} in course {course_id}"
-                     .format(type=module.module_type, id=module.module_state_key,
-                             student=module.student.username, course_id=module.course_id))
+            LOG.info(
+                "No state found for %s module %s for student %s in course %s",
+                module.module_type, module.module_state_key,
+                module.student.username, module.course_id
+            )
             return
 
         state_dict = json.loads(module_state)
@@ -116,9 +121,11 @@ class Command(BaseCommand):
         module_state = module.state
         if module_state is None:
             # not likely, since we filter on it.  But in general...
-            LOG.info("No state found for {type} module {id} for student {student} in course {course_id}"
-                     .format(type=module.module_type, id=module.module_state_key,
-                             student=module.student.username, course_id=module.course_id))
+            LOG.info(
+                "No state found for %s module %s for student %s in course %s",
+                module.module_type, module.module_state_key,
+                module.student.username, module.course_id
+            )
             return
 
         state_dict = json.loads(module_state)
@@ -142,10 +149,13 @@ class Command(BaseCommand):
             raise CommandError("missing idlist file")
         idlist_path = args[0]
         save_changes = options['save_changes']
-        LOG.info("Starting run:  reading from idlist file {0}; save_changes = {1}".format(idlist_path, save_changes))
+        LOG.info("Starting run:  reading from idlist file %s; save_changes = %s", idlist_path, save_changes)
 
         self.fix_studentmodules_in_list(save_changes, idlist_path)
 
-        LOG.info("Finished run:  updating {0} of {1} student modules".format(self.num_changed, self.num_visited))
-        LOG.info("Finished run:  updating {0} of {1} student history modules".format(self.num_hist_changed,
-                                                                                     self.num_hist_visited))
+        LOG.info("Finished run:  updating %s of %s student modules", self.num_changed, self.num_visited)
+        LOG.info(
+            "Finished run:  updating %s of %s student history modules",
+            self.num_hist_changed,
+            self.num_hist_visited
+        )

--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -1055,9 +1055,9 @@ def get_score_bucket(grade, max_grade):
     Used with statsd tracking.
     """
     score_bucket = "incorrect"
-    if(grade > 0 and grade < max_grade):
+    if grade > 0 and grade < max_grade:
         score_bucket = "partial"
-    elif(grade == max_grade):
+    elif grade == max_grade:
         score_bucket = "correct"
 
     return score_bucket

--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -890,10 +890,9 @@ def get_module_by_usage_id(request, course_id, usage_id, disable_staff_debug_inf
         descriptor_orig_usage_key, descriptor_orig_version = modulestore().get_block_original_usage(usage_key)
     except ItemNotFoundError:
         log.warn(
-            "Invalid location for course id {course_id}: {usage_key}".format(
-                course_id=usage_key.course_key,
-                usage_key=usage_key
-            )
+            "Invalid location for course id %s: %s",
+            usage_key.course_key,
+            usage_key
         )
         raise Http404
 

--- a/lms/djangoapps/courseware/tests/test_submitting_problems.py
+++ b/lms/djangoapps/courseware/tests/test_submitting_problems.py
@@ -174,7 +174,7 @@ class TestSubmittingProblems(ModuleStoreTestCase, LoginEnrollmentTestCase):
         """
 
         # if we don't already have a chapter create a new one
-        if not(hasattr(self, 'chapter')):
+        if not hasattr(self, 'chapter'):
             self.chapter = ItemFactory.create(
                 parent_location=self.course.location,
                 category='chapter'

--- a/lms/djangoapps/courseware/views.py
+++ b/lms/djangoapps/courseware/views.py
@@ -7,7 +7,6 @@ import urllib
 import json
 import cgi
 
-from collections import OrderedDict
 from datetime import datetime
 from django.utils import translation
 from django.utils.translation import ugettext as _

--- a/lms/djangoapps/courseware/views.py
+++ b/lms/djangoapps/courseware/views.py
@@ -598,14 +598,13 @@ def _index_bulk_op(request, course_key, chapter, section, position):
             raise
         else:
             log.exception(
-                u"Error in index view: user={user}, course={course}, chapter={chapter}"
-                u" section={section} position={position}".format(
-                    user=user,
-                    course=course,
-                    chapter=chapter,
-                    section=section,
-                    position=position
-                ))
+                u"Error in index view: user=%s, course=%s, chapter=%s, section=%s, position=%s",
+                user,
+                course,
+                chapter,
+                section,
+                position
+            )
             try:
                 result = render_to_response('courseware/courseware-error.html', {
                     'staff_access': staff_access,
@@ -637,9 +636,12 @@ def jump_to_id(request, course_id, module_id):
             ))
     if len(items) > 1:
         log.warning(
-            u"Multiple items found with id: {0} in course_id: {1}. Referer: {2}. Using first: {3}".format(
-                module_id, course_id, request.META.get("HTTP_REFERER", ""), items[0].location.to_deprecated_string()
-            ))
+            u"Multiple items found with id: %s in course_id: %s. Referer: %s. Using first: %s",
+            module_id,
+            course_id,
+            request.META.get("HTTP_REFERER", ""),
+            items[0].location.to_deprecated_string()
+        )
 
     return jump_to(request, course_id, items[0].location.to_deprecated_string())
 
@@ -1239,7 +1241,7 @@ def get_static_tab_contents(request, course, tab):
         request.user, request, loc, field_data_cache, static_asset_path=course.static_asset_path, course=course
     )
 
-    logging.debug('course_module = {0}'.format(tab_module))
+    logging.debug('course_module = %s', tab_module)
 
     html = ''
     if tab_module is not None:
@@ -1248,7 +1250,7 @@ def get_static_tab_contents(request, course, tab):
         except Exception:  # pylint: disable=broad-except
             html = render_to_string('courseware/error-message.html', None)
             log.exception(
-                u"Error rendering course={course}, tab={tab_url}".format(course=course, tab_url=tab['url_slug'])
+                u"Error rendering course=%s, tab=%s", course, tab['url_slug']
             )
 
     return html

--- a/lms/djangoapps/dashboard/git_import.py
+++ b/lms/djangoapps/dashboard/git_import.py
@@ -59,9 +59,9 @@ def cmd_log(cmd, cwd):
     command doesn't return 0, and returns the command's output.
     """
     output = subprocess.check_output(cmd, cwd=cwd, stderr=subprocess.STDOUT)
-    log.debug('Command was: {0!r}. '
-              'Working directory was: {1!r}'.format(' '.join(cmd), cwd))
-    log.debug('Command output was: {0!r}'.format(output))
+
+    log.debug(u'Command was: %r. Working directory was: %r', ' '.join(cmd), cwd)
+    log.debug(u'Command output was: %r', output)
     return output
 
 
@@ -152,7 +152,7 @@ def add_repo(repo, rdir_in, branch=None):
         rdir = os.path.basename(rdir_in)
     else:
         rdir = repo.rsplit('/', 1)[-1].rsplit('.git', 1)[0]
-    log.debug('rdir = {0}'.format(rdir))
+    log.debug('rdir = %s', rdir)
 
     rdirp = '{0}/{1}'.format(GIT_REPO_DIR, rdir)
     if os.path.exists(rdirp):
@@ -239,7 +239,7 @@ def add_repo(repo, rdir_in, branch=None):
         except InvalidKeyError:
             course_key = SlashSeparatedCourseKey.from_deprecated_string(course_id)
         cdir = '{0}/{1}'.format(GIT_REPO_DIR, course_key.course)
-        log.debug('Studio course dir = {0}'.format(cdir))
+        log.debug('Studio course dir = %s', cdir)
 
         if os.path.exists(cdir) and not os.path.islink(cdir):
             log.debug('   -> exists, but is not symlink')
@@ -251,7 +251,7 @@ def add_repo(repo, rdir_in, branch=None):
                 log.exception('Failed to remove course directory')
 
         if not os.path.exists(cdir):
-            log.debug('   -> creating symlink between {0} and {1}'.format(rdirp, cdir))
+            log.debug('   -> creating symlink between %s and %s', rdirp, cdir)
             try:
                 os.symlink(os.path.abspath(rdirp), os.path.abspath(cdir))
             except OSError:
@@ -280,5 +280,5 @@ def add_repo(repo, rdir_in, branch=None):
     )
     cil.save()
 
-    log.debug('saved CourseImportLog for {0}'.format(cil.course_id))
+    log.debug('saved CourseImportLog for %s', cil.course_id)
     mdb.disconnect()

--- a/lms/djangoapps/dashboard/sysadmin.py
+++ b/lms/djangoapps/dashboard/sysadmin.py
@@ -387,7 +387,7 @@ class Courses(SysadminDashboardView):
 
         msg = u''
 
-        log.debug('Adding course using git repo {0}'.format(gitloc))
+        log.debug('Adding course using git repo %s', gitloc)
 
         # Grab logging output for debugging imports
         output = StringIO.StringIO()
@@ -723,7 +723,7 @@ class GitLogs(TemplateView):
             try:
                 course = get_course_by_id(course_id)
             except Exception:  # pylint: disable=broad-except
-                log.info('Cannot find course {0}'.format(course_id))
+                log.info('Cannot find course %s', course_id)
                 raise Http404
 
             # Allow only course team, instructors, and staff
@@ -731,11 +731,11 @@ class GitLogs(TemplateView):
                     CourseInstructorRole(course.id).has_user(request.user) or
                     CourseStaffRole(course.id).has_user(request.user)):
                 raise Http404
-            log.debug('course_id={0}'.format(course_id))
+            log.debug('course_id=%s', course_id)
             cilset = CourseImportLog.objects.filter(
                 course_id=course_id
             ).order_by('-created')
-            log.debug('cilset length={0}'.format(len(cilset)))
+            log.debug('cilset length=%s', len(cilset))
 
         # Paginate the query set
         paginator = Paginator(cilset, page_size)

--- a/lms/djangoapps/discussion_api/forms.py
+++ b/lms/djangoapps/discussion_api/forms.py
@@ -5,7 +5,6 @@ from django.core.exceptions import ValidationError
 from django.forms import (
     BooleanField,
     CharField,
-    ChoiceField,
     Field,
     Form,
     IntegerField,

--- a/lms/djangoapps/django_comment_client/forum/tests.py
+++ b/lms/djangoapps/django_comment_client/forum/tests.py
@@ -2,7 +2,6 @@ import json
 import logging
 
 import ddt
-from django.core import cache
 from django.core.urlresolvers import reverse
 from django.http import Http404
 from django.test.client import Client, RequestFactory

--- a/lms/djangoapps/django_comment_client/permissions.py
+++ b/lms/djangoapps/django_comment_client/permissions.py
@@ -120,5 +120,5 @@ def check_permissions_by_view(user, course_id, content, name):
     try:
         p = VIEW_PERMISSIONS[name]
     except KeyError:
-        logging.warning("Permission for view named %s does not exist in permissions.py" % name)
+        logging.warning("Permission for view named %s does not exist in permissions.py", name)
     return _check_conditions_permissions(user, p, course_id, content)

--- a/lms/djangoapps/django_comment_client/permissions.py
+++ b/lms/djangoapps/django_comment_client/permissions.py
@@ -4,7 +4,6 @@ Module for checking permissions with the comment_client backend
 
 import logging
 from types import NoneType
-from django.core import cache
 
 from request_cache.middleware import RequestCache
 from lms.lib.comment_client import Thread

--- a/lms/djangoapps/django_comment_client/tests/mock_cs_server/mock_cs_server.py
+++ b/lms/djangoapps/django_comment_client/tests/mock_cs_server/mock_cs_server.py
@@ -33,7 +33,7 @@ class MockCommentServiceRequestHandler(BaseHTTPRequestHandler):
         if 'X-Edx-Api-Key' in self.headers:
             response = self.server._response_str
             # Log the response
-            logger.debug("Comment Service: sending response %s" % json.dumps(response))
+            logger.debug("Comment Service: sending response %s", json.dumps(response))
 
             # Send a response back to the client
             self.send_response(200)
@@ -71,7 +71,7 @@ class MockCommentServiceRequestHandler(BaseHTTPRequestHandler):
         if 'X-Edx-Api-Key' in self.headers:
             response = self.server._response_str
             # Log the response
-            logger.debug("Comment Service: sending response %s" % json.dumps(response))
+            logger.debug("Comment Service: sending response %s", json.dumps(response))
 
             # Send a response back to the client
             self.send_response(200)

--- a/lms/djangoapps/django_comment_client/tests/mock_cs_server/mock_cs_server.py
+++ b/lms/djangoapps/django_comment_client/tests/mock_cs_server/mock_cs_server.py
@@ -23,6 +23,7 @@ class MockCommentServiceRequestHandler(BaseHTTPRequestHandler):
         post_dict = json.loads(data_string)
 
         # Log the request
+        # pylint: disable=logging-format-interpolation
         logger.debug(
             "Comment Service received POST request {0} to path {1}"
             .format(json.dumps(post_dict), self.path)
@@ -60,6 +61,7 @@ class MockCommentServiceRequestHandler(BaseHTTPRequestHandler):
         post_dict = json.loads(data_string)
 
         # Log the request
+        # pylint: disable=logging-format-interpolation
         logger.debug(
             "Comment Service received PUT request {0} to path {1}"
             .format(json.dumps(post_dict), self.path)

--- a/lms/djangoapps/django_comment_client/utils.py
+++ b/lms/djangoapps/django_comment_client/utils.py
@@ -476,7 +476,11 @@ def extend_content(content):
             user = User.objects.get(pk=content['user_id'])
             roles = dict(('name', role.name.lower()) for role in user.roles.filter(course_id=content['course_id']))
         except User.DoesNotExist:
-            log.error('User ID {0} in comment content {1} but not in our DB.'.format(content.get('user_id'), content.get('id')))
+            log.error(
+                'User ID %s in comment content %s but not in our DB.',
+                content.get('user_id'),
+                content.get('id')
+            )
 
     content_info = {
         'displayed_title': content.get('highlighted_title') or content.get('title', ''),
@@ -547,9 +551,10 @@ def prepare_content(content, course_key, is_staff=False, course_is_cohorted=None
             try:
                 endorser = User.objects.get(pk=endorsement["user_id"])
             except User.DoesNotExist:
-                log.error("User ID {0} in endorsement for comment {1} but not in our DB.".format(
+                log.error(
+                    "User ID %s in endorsement for comment %s but not in our DB.",
                     content.get('user_id'),
-                    content.get('id'))
+                    content.get('id')
                 )
 
         # Only reveal endorser if requester can see author or if endorser is staff

--- a/lms/djangoapps/django_comment_client/utils.py
+++ b/lms/djangoapps/django_comment_client/utils.py
@@ -389,7 +389,7 @@ class QueryCountDebugMiddleware(object):
                     query_time = query.get('duration', 0) / 1000
                 total_time += float(query_time)
 
-            log.info('%s queries run, total %s seconds' % (len(connection.queries), total_time))
+            log.info(u'%s queries run, total %s seconds', len(connection.queries), total_time)
         return response
 
 

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -112,7 +112,7 @@ def instructor_dashboard_2(request, course_id):
             unicode(course_key), len(paid_modes)
         )
 
-    if (settings.FEATURES.get('INDIVIDUAL_DUE_DATES') and access['instructor']):
+    if settings.FEATURES.get('INDIVIDUAL_DUE_DATES') and access['instructor']:
         sections.insert(3, _section_extensions(course))
 
     # Gate access to course email by feature flag & by course-specific authorization

--- a/lms/djangoapps/instructor/views/legacy.py
+++ b/lms/djangoapps/instructor/views/legacy.py
@@ -3,6 +3,7 @@ Instructor Views
 """
 ## NOTE: This is the code for the legacy instructor dashboard
 ## We are no longer supporting this file or accepting changes into it.
+# pylint: disable=line-too-long, missing-docstring
 from contextlib import contextmanager
 import csv
 import json
@@ -155,7 +156,7 @@ def instructor_dashboard(request, course_id):
     if settings.FEATURES['ENABLE_MANUAL_GIT_RELOAD']:
         if 'GIT pull' in action:
             data_dir = course.data_dir
-            log.debug('git pull {0}'.format(data_dir))
+            log.debug('git pull %s', data_dir)
             gdir = settings.DATA_DIR / data_dir
             if not os.path.exists(gdir):
                 msg += "====> ERROR in gitreload - no such directory {0}".format(gdir)
@@ -166,7 +167,7 @@ def instructor_dashboard(request, course_id):
                 track.views.server_track(request, "git-pull", {"directory": data_dir}, page="idashboard")
 
         if 'Reload course' in action:
-            log.debug('reloading {0} ({1})'.format(course_key, course))
+            log.debug('reloading %s (%s)', course_key, course)
             try:
                 data_dir = course.data_dir
                 modulestore().try_load_course(data_dir)
@@ -908,7 +909,7 @@ def _do_enroll_students(course, course_key, students, secure=False, overload=Fal
     datatable['data'] = [[x, status[x]] for x in sorted(status)]
     datatable['title'] = _('Enrollment of students')
 
-    def sf(stat):
+    def sf(stat):  # pylint: disable=invalid-name
         return [x for x in status if status[x] == stat]
 
     data = dict(added=sf('added'), rejected=sf('rejected') + sf('exists'),

--- a/lms/djangoapps/instructor_task/tests/test_integration.py
+++ b/lms/djangoapps/instructor_task/tests/test_integration.py
@@ -19,7 +19,6 @@ from capa.tests.response_xml_factory import (CodeResponseXMLFactory,
                                              CustomResponseXMLFactory)
 from xmodule.modulestore.tests.factories import ItemFactory
 from xmodule.modulestore import ModuleStoreEnum
-from xmodule.partitions.partitions import Group, UserPartition
 
 from courseware.model_data import StudentModule
 
@@ -29,8 +28,12 @@ from instructor_task.api import (submit_rescore_problem_for_all_students,
                                  submit_delete_problem_state_for_all_students)
 from instructor_task.models import InstructorTask
 from instructor_task.tasks_helper import upload_grades_csv
-from instructor_task.tests.test_base import (InstructorTaskModuleTestCase, TestReportMixin, TEST_COURSE_ORG,
-                                             TEST_COURSE_NUMBER, OPTION_1, OPTION_2)
+from instructor_task.tests.test_base import (
+    InstructorTaskModuleTestCase,
+    TestReportMixin,
+    OPTION_1,
+    OPTION_2,
+)
 from capa.responsetypes import StudentInputError
 from lms.djangoapps.lms_xblock.runtime import quote_slashes
 

--- a/lms/djangoapps/lms_migration/migrate.py
+++ b/lms/djangoapps/lms_migration/migrate.py
@@ -77,7 +77,7 @@ def manage_modulestores(request, reload_dir=None, commit_id=None):
         else:
             html += 'Permission denied'
             html += "</body></html>"
-            log.debug('request denied, ALLOWED_IPS=%s' % ALLOWED_IPS)
+            log.debug('request denied, ALLOWED_IPS=%s', ALLOWED_IPS)
             return HttpResponse(html, status=403)
 
     #----------------------------------------
@@ -90,8 +90,8 @@ def manage_modulestores(request, reload_dir=None, commit_id=None):
             # reloading based on commit_id is needed when running mutiple worker threads,
             # so that a given thread doesn't reload the same commit multiple times
             current_commit_id = get_commit_id(def_ms.courses[reload_dir])
-            log.debug('commit_id="%s"' % commit_id)
-            log.debug('current_commit_id="%s"' % current_commit_id)
+            log.debug('commit_id="%s"', commit_id)
+            log.debug('current_commit_id="%s"', current_commit_id)
 
             if (commit_id is not None) and (commit_id == current_commit_id):
                 html += "<h2>Already at commit id %s for %s</h2>" % (commit_id, reload_dir)
@@ -158,9 +158,9 @@ def manage_modulestores(request, reload_dir=None, commit_id=None):
 
     #----------------------------------------
 
-    log.debug('_MODULESTORES=%s' % ms)
-    log.debug('courses=%s' % courses)
-    log.debug('def_ms=%s' % unicode(def_ms))
+    log.debug('_MODULESTORES=%s', ms)
+    log.debug('courses=%s', courses)
+    log.debug('def_ms=%s', unicode(def_ms))
 
     html += "</body></html>"
     return HttpResponse(html)
@@ -189,7 +189,7 @@ def gitreload(request, reload_dir=None):
         else:
             html += 'Permission denied'
             html += "</body></html>"
-            log.debug('request denied from %s, ALLOWED_IPS=%s' % (ip, ALLOWED_IPS))
+            log.debug('request denied from %s, ALLOWED_IPS=%s', ip, ALLOWED_IPS)
             return HttpResponse(html)
 
     #----------------------------------------
@@ -197,14 +197,14 @@ def gitreload(request, reload_dir=None):
 
     if reload_dir is None and 'payload' in request.POST:
         payload = request.POST['payload']
-        log.debug("payload=%s" % payload)
+        log.debug("payload=%s", payload)
         gitargs = json.loads(payload)
-        log.debug("gitargs=%s" % gitargs)
+        log.debug("gitargs=%s", gitargs)
         reload_dir = gitargs['repository']['name']
-        log.debug("github reload_dir=%s" % reload_dir)
+        log.debug("github reload_dir=%s", reload_dir)
         gdir = settings.DATA_DIR / reload_dir
         if not os.path.exists(gdir):
-            log.debug("====> ERROR in gitreload - no such directory %s" % reload_dir)
+            log.debug("====> ERROR in gitreload - no such directory %s", reload_dir)
             return HttpResponse('Error')
         cmd = "cd %s; git reset --hard HEAD; git clean -f -d; git pull origin; chmod g+w course.xml" % gdir
         log.debug(os.popen(cmd).read())
@@ -213,7 +213,7 @@ def gitreload(request, reload_dir=None):
             if gh:
                 ghurl = '%s/%s' % (gh, reload_dir)
                 r = requests.get(ghurl)
-                log.debug("GITRELOAD_HOOK to %s: %s" % (ghurl, r.text))
+                log.debug("GITRELOAD_HOOK to %s: %s", ghurl, r.text)
 
     #----------------------------------------
     # reload course if specified

--- a/lms/djangoapps/lti_provider/views.py
+++ b/lms/djangoapps/lti_provider/views.py
@@ -3,9 +3,6 @@ LTI Provider view functions
 """
 
 from django.conf import settings
-from django.contrib.auth.decorators import login_required
-from django.contrib.auth.views import redirect_to_login
-from django.core.urlresolvers import reverse
 from django.http import HttpResponseBadRequest, HttpResponseForbidden, Http404
 from django.views.decorators.csrf import csrf_exempt
 import logging

--- a/lms/djangoapps/mobile_api/course_info/views.py
+++ b/lms/djangoapps/mobile_api/course_info/views.py
@@ -5,7 +5,7 @@ from django.http import Http404
 from rest_framework import generics
 from rest_framework.response import Response
 
-from courseware.courses import get_course_about_section, get_course_info_section_module
+from courseware.courses import get_course_info_section_module
 from static_replace import make_static_urls_absolute, replace_static_urls
 from openedx.core.lib.xblock_utils import get_course_update_items
 

--- a/lms/djangoapps/mobile_api/users/serializers.py
+++ b/lms/djangoapps/mobile_api/users/serializers.py
@@ -4,7 +4,6 @@ Serializer for user API
 from rest_framework import serializers
 from rest_framework.reverse import reverse
 
-from courseware.courses import course_image_url
 from student.models import CourseEnrollment, User
 from certificates.models import certificate_status_for_student, CertificateStatuses
 

--- a/lms/djangoapps/open_ended_grading/staff_grading_service.py
+++ b/lms/djangoapps/open_ended_grading/staff_grading_service.py
@@ -257,7 +257,7 @@ def get_next(request, course_id):
 
     'error': if success is False, will have an error message with more info.
     """
-    assert(isinstance(course_id, basestring))
+    assert isinstance(course_id, basestring)
     course_key = SlashSeparatedCourseKey.from_deprecated_string(course_id)
     _check_access(request.user, course_key)
 
@@ -300,7 +300,7 @@ def get_problem_list(request, course_id):
 
         'error': if success is False, will have an error message with more info.
     """
-    assert(isinstance(course_id, basestring))
+    assert isinstance(course_id, basestring)
     course_key = SlashSeparatedCourseKey.from_deprecated_string(course_id)
     _check_access(request.user, course_key)
     try:

--- a/lms/djangoapps/psychometrics/psychoanalyze.py
+++ b/lms/djangoapps/psychometrics/psychoanalyze.py
@@ -266,7 +266,7 @@ def generate_plots_for_problem(problem):
                 yset['fitx'] = fitx
                 yset['fity'] = func_2pl(np.array(fitx), *cfp[0])
             except Exception as err:
-                log.debug('Error in psychoanalyze curve fitting: %s' % err)
+                log.debug('Error in psychoanalyze curve fitting: %s', err)
 
         dataset['grade_%d' % grade] = yset
 
@@ -339,14 +339,14 @@ def make_psychometrics_data_update_handler(course_id, user, module_state_key):
             state = json.loads(sm.state)
             done = state['done']
         except:
-            log.exception("Oops, failed to eval state for %s (state=%s)" % (sm, sm.state))
+            log.exception("Oops, failed to eval state for %s (state=%s)", sm, sm.state)
             return
 
         pmd.done = done
         try:
             pmd.attempts = state.get('attempts', 0)
         except:
-            log.exception("no attempts for %s (state=%s)" % (sm, sm.state))
+            log.exception("no attempts for %s (state=%s)", sm, sm.state)
 
         try:
             checktimes = eval(pmd.checktimes)  # update log of attempt timestamps
@@ -357,6 +357,6 @@ def make_psychometrics_data_update_handler(course_id, user, module_state_key):
         try:
             pmd.save()
         except:
-            log.exception("Error in updating psychometrics data for %s" % sm)
+            log.exception("Error in updating psychometrics data for %s", sm)
 
     return psychometrics_data_update_handler

--- a/lms/djangoapps/shoppingcart/models.py
+++ b/lms/djangoapps/shoppingcart/models.py
@@ -1163,7 +1163,7 @@ class InvoiceHistory(models.Model):
         elif hasattr(instance, 'invoice'):
             InvoiceHistory.save_invoice_snapshot(instance.invoice)
 
-    class Meta:  # pylint: disable=missing-docstring,old-style-class
+    class Meta(object):  # pylint: disable=missing-docstring
         get_latest_by = "timestamp"
 
 

--- a/lms/djangoapps/shoppingcart/tests/payment_fake.py
+++ b/lms/djangoapps/shoppingcart/tests/payment_fake.py
@@ -102,7 +102,7 @@ class PaymentFakeView(View):
         ])
         public_sig = processor_hash(hash_val)
 
-        return (public_sig == post_params.get('signature'))
+        return public_sig == post_params.get('signature')
 
     @classmethod
     def response_post_params(cls, post_params):

--- a/lms/djangoapps/shoppingcart/tests/test_views.py
+++ b/lms/djangoapps/shoppingcart/tests/test_views.py
@@ -12,7 +12,6 @@ from django.conf import settings
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.core.urlresolvers import reverse
-from django.utils.translation import ugettext as _
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth.models import Group, User
 from django.contrib.messages.storage.fallback import FallbackStorage

--- a/lms/djangoapps/shoppingcart/utils.py
+++ b/lms/djangoapps/shoppingcart/utils.py
@@ -27,7 +27,7 @@ def is_shopping_cart_enabled():
         settings.FEATURES.get('ENABLE_SHOPPING_CART')
     )
 
-    return (enable_paid_course_registration and enable_shopping_cart)
+    return enable_paid_course_registration and enable_shopping_cart
 
 
 def parse_pages(pdf_buffer, password):

--- a/lms/djangoapps/shoppingcart/views.py
+++ b/lms/djangoapps/shoppingcart/views.py
@@ -50,7 +50,6 @@ from .processors import (
 )
 
 import json
-from xmodule_django.models import CourseKeyField
 from .decorators import enforce_shopping_cart_enabled
 
 

--- a/lms/djangoapps/student_account/test/test_views.py
+++ b/lms/djangoapps/student_account/test/test_views.py
@@ -18,15 +18,13 @@ from django.test import TestCase
 from django.test.utils import override_settings
 from django.test.client import RequestFactory
 
-from embargo.test_utils import restrict_course
 from openedx.core.djangoapps.user_api.accounts.api import activate_account, create_account
 from openedx.core.djangoapps.user_api.accounts import EMAIL_MAX_LENGTH
-from student.tests.factories import CourseModeFactory, UserFactory
+from student.tests.factories import UserFactory
 from student_account.views import account_settings_context
 from third_party_auth.tests.testutil import simulate_running_pipeline, ThirdPartyAuthTestMixin
 from util.testing import UrlResetMixin
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory
 
 
 @ddt.ddt

--- a/lms/djangoapps/student_profile/views.py
+++ b/lms/djangoapps/student_profile/views.py
@@ -17,8 +17,6 @@ from openedx.core.djangoapps.user_api.preferences.api import get_user_preference
 from student.models import User
 from microsite_configuration import microsite
 
-from django.utils.translation import ugettext as _
-
 
 @login_required
 @require_http_methods(['GET'])

--- a/lms/djangoapps/verify_student/models.py
+++ b/lms/djangoapps/verify_student/models.py
@@ -25,7 +25,7 @@ from django.contrib.auth.models import User
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.urlresolvers import reverse
 from django.db import models
-from django.utils.translation import ugettext as _, ugettext_lazy
+from django.utils.translation import ugettext as _
 
 from boto.s3.connection import S3Connection
 from boto.s3.key import Key

--- a/lms/djangoapps/verify_student/models.py
+++ b/lms/djangoapps/verify_student/models.py
@@ -895,7 +895,7 @@ class VerificationCheckpoint(models.Model):
     checkpoint_location = models.CharField(max_length=255)
     photo_verification = models.ManyToManyField(SoftwareSecurePhotoVerification)
 
-    class Meta:  # pylint: disable=missing-docstring, old-style-class
+    class Meta(object):  # pylint: disable=missing-docstring
         unique_together = ('course_id', 'checkpoint_location')
 
     def __unicode__(self):
@@ -1089,7 +1089,7 @@ class SkippedReverification(models.Model):
     checkpoint = models.ForeignKey(VerificationCheckpoint, related_name="skipped_checkpoint")
     created_at = models.DateTimeField(auto_now_add=True)
 
-    class Meta:  # pylint: disable=missing-docstring, old-style-class
+    class Meta(object):  # pylint: disable=missing-docstring
         unique_together = (('user', 'course_id'),)
 
     @classmethod

--- a/lms/djangoapps/verify_student/tests/test_models.py
+++ b/lms/djangoapps/verify_student/tests/test_models.py
@@ -8,8 +8,7 @@ import pytz
 from django.conf import settings
 from django.db.utils import IntegrityError
 from mock import patch
-from nose.tools import assert_is_none, assert_equals, assert_raises, assert_true, assert_false  # pylint: disable=E0611
-from opaque_keys.edx.locations import SlashSeparatedCourseKey
+from nose.tools import assert_is_none, assert_equals, assert_raises, assert_true, assert_false  # pylint: disable=no-name-in-module
 
 from student.tests.factories import UserFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase

--- a/lms/djangoapps/verify_student/tests/test_views.py
+++ b/lms/djangoapps/verify_student/tests/test_views.py
@@ -17,7 +17,6 @@ from mock import patch, Mock, ANY
 
 from django.conf import settings
 from django.core.urlresolvers import reverse
-from django.core.exceptions import ObjectDoesNotExist
 from django.core import mail
 from django.test import TestCase
 from django.test.client import Client, RequestFactory
@@ -33,7 +32,6 @@ from course_modes.tests.factories import CourseModeFactory
 from courseware.url_helpers import get_redirect_url
 from commerce.tests import TEST_PAYMENT_DATA, TEST_API_URL, TEST_API_SIGNING_KEY
 from embargo.test_utils import restrict_course
-from microsite_configuration import microsite
 from openedx.core.djangoapps.user_api.accounts.api import get_account_settings
 from shoppingcart.models import Order, CertificateItem
 from student.tests.factories import UserFactory, CourseEnrollmentFactory
@@ -42,7 +40,7 @@ from util.date_utils import get_default_time_display
 from util.testing import UrlResetMixin
 from verify_student.views import (
     checkout_with_ecommerce_service, render_to_response, PayAndVerifyView,
-    _send_email, _compose_message_reverification_email
+    _compose_message_reverification_email
 )
 from verify_student.models import (
     SoftwareSecurePhotoVerification, VerificationCheckpoint,

--- a/lms/lib/comment_client/models.py
+++ b/lms/lib/comment_client/models.py
@@ -35,7 +35,7 @@ class Model(object):
             return self.__getattr__(name)
 
     def __setattr__(self, name, value):
-        if name == 'attributes' or name not in (self.accessible_fields + self.updatable_fields):
+        if name == 'attributes' or name not in self.accessible_fields + self.updatable_fields:
             super(Model, self).__setattr__(name, value)
         else:
             self.attributes[name] = value
@@ -46,7 +46,7 @@ class Model(object):
         return self.attributes.get(key)
 
     def __setitem__(self, key, value):
-        if key not in (self.accessible_fields + self.updatable_fields):
+        if key not in self.accessible_fields + self.updatable_fields:
             raise KeyError("Field {0} does not exist".format(key))
         self.attributes.__setitem__(key, value)
 

--- a/lms/lib/courseware_search/lms_result_processor.py
+++ b/lms/lib/courseware_search/lms_result_processor.py
@@ -4,12 +4,10 @@ This file contains implementation override of SearchResultProcessor which will a
     * Confirms user access to object
 """
 from django.core.urlresolvers import reverse
-from django.utils.translation import ugettext as _
 
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
 from search.result_processor import SearchResultProcessor
 from xmodule.modulestore.django import modulestore
-from xmodule.modulestore.search import path_to_location, navigation_index
 
 from courseware.access import has_access
 

--- a/lms/lib/xblock/test/test_mixin.py
+++ b/lms/lib/xblock/test/test_mixin.py
@@ -230,7 +230,7 @@ class XBlockGetParentTest(LmsXBlockMixinTestCase):
                 )
 
 
-class RenamedTuple(tuple):  # pylint: disable=incomplete-protocol
+class RenamedTuple(tuple):
     """
     This class is only used to allow overriding __name__ on the tuples passed
     through ddt, in order to have the generated test names make sense.

--- a/lms/startup.py
+++ b/lms/startup.py
@@ -117,11 +117,11 @@ def enable_microsites():
             ms_config['template_dir'] = template_dir
 
             ms_config['microsite_name'] = ms_name
-            log.info('Loading microsite {0}'.format(ms_root))
+            log.info('Loading microsite %s', ms_root)
         else:
             # not sure if we have application logging at this stage of
             # startup
-            log.error('Error loading microsite {0}. Directory does not exist'.format(ms_root))
+            log.error('Error loading microsite %s. Directory does not exist', ms_root)
             # remove from our configuration as it is not valid
             del microsite_config_dict[ms_name]
 

--- a/lms/tests.py
+++ b/lms/tests.py
@@ -10,7 +10,6 @@ from edxmako import add_lookup, LOOKUP
 from lms import startup
 from xmodule.modulestore.tests.factories import CourseFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from util import keyword_substitution
 
 
 class LmsModuleTests(TestCase):

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -605,7 +605,6 @@ if settings.FEATURES.get('RUN_AS_ANALYTICS_SERVER_ENABLED'):
     urlpatterns += (
         url(r'^edinsights_service/', include('edinsights.core.urls')),
     )
-    import edinsights.core.registry
 
 # FoldIt views
 urlpatterns += (

--- a/openedx/core/djangoapps/course_groups/models.py
+++ b/openedx/core/djangoapps/course_groups/models.py
@@ -18,7 +18,7 @@ class CourseUserGroup(models.Model):
     which may be treated specially.  For example, a user can be in at most one cohort per
     course, and cohorts are used to split up the forums by group.
     """
-    class Meta:
+    class Meta(object):  # pylint: disable=missing-docstring
         unique_together = (('name', 'course_id'), )
 
     name = models.CharField(max_length=255,

--- a/openedx/core/djangoapps/course_groups/tests/test_partition_scheme.py
+++ b/openedx/core/djangoapps/course_groups/tests/test_partition_scheme.py
@@ -6,7 +6,6 @@ Test the partitions and partitions service
 import json
 from django.conf import settings
 import django.test
-from django.test.utils import override_settings
 from mock import patch
 from unittest import skipUnless
 
@@ -14,8 +13,8 @@ from courseware.masquerade import handle_ajax, setup_masquerade
 from courseware.tests.test_masquerade import StaffMasqueradeTestCase
 from student.tests.factories import UserFactory
 from xmodule.partitions.partitions import Group, UserPartition, UserPartitionError
-from xmodule.modulestore.django import modulestore, clear_existing_modulestores
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, mixed_store_config, TEST_DATA_MIXED_TOY_MODULESTORE
+from xmodule.modulestore.django import modulestore
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, TEST_DATA_MIXED_TOY_MODULESTORE
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
 
 from openedx.core.djangoapps.user_api.partition_schemes import RandomUserPartitionScheme

--- a/openedx/core/djangoapps/course_groups/views.py
+++ b/openedx/core/djangoapps/course_groups/views.py
@@ -7,7 +7,7 @@ from django.views.decorators.http import require_POST
 from django.contrib.auth.models import User
 from django.core.paginator import Paginator, EmptyPage
 from django.core.urlresolvers import reverse
-from django.http import Http404, HttpResponse, HttpResponseBadRequest
+from django.http import Http404, HttpResponseBadRequest
 from django.views.decorators.http import require_http_methods
 from util.json_request import expect_json, JsonResponse
 from django.contrib.auth.decorators import login_required

--- a/openedx/core/djangoapps/user_api/accounts/serializers.py
+++ b/openedx/core/djangoapps/user_api/accounts/serializers.py
@@ -15,7 +15,7 @@ class LanguageProficiencySerializer(serializers.ModelSerializer):
     Class that serializes the LanguageProficiency model for account
     information.
     """
-    class Meta:
+    class Meta(object):  # pylint: disable=missing-docstring
         model = LanguageProficiency
         fields = ("code",)
 
@@ -36,7 +36,7 @@ class AccountUserSerializer(serializers.HyperlinkedModelSerializer, ReadOnlyFiel
     """
     Class that serializes the portion of User model needed for account information.
     """
-    class Meta:
+    class Meta(object):  # pylint: disable=missing-docstring
         model = User
         fields = ("username", "email", "date_joined", "is_active")
         read_only_fields = ("username", "email", "date_joined", "is_active")
@@ -51,7 +51,7 @@ class AccountLegacyProfileSerializer(serializers.HyperlinkedModelSerializer, Rea
     requires_parental_consent = serializers.SerializerMethodField("get_requires_parental_consent")
     language_proficiencies = LanguageProficiencySerializer(many=True, allow_add_remove=True, required=False)
 
-    class Meta:
+    class Meta(object):  # pylint: disable=missing-docstring
         model = UserProfile
         fields = (
             "name", "gender", "goals", "year_of_birth", "level_of_education", "country",

--- a/openedx/core/djangoapps/user_api/forms.py
+++ b/openedx/core/djangoapps/user_api/forms.py
@@ -1,2 +1,3 @@
+# pylint: disable=unused-import, missing-docstring
 # TODO: eventually move this implementation into the user_api
 from student.forms import PasswordResetFormNoActive

--- a/openedx/core/djangoapps/user_api/management/tests/test_email_opt_in_list.py
+++ b/openedx/core/djangoapps/user_api/management/tests/test_email_opt_in_list.py
@@ -7,14 +7,11 @@ import csv
 from collections import defaultdict
 from unittest import skipUnless
 
-
 import ddt
 from django.conf import settings
-from django.test.utils import override_settings
 from django.core.management.base import CommandError
 
-
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, mixed_store_config
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 from student.tests.factories import UserFactory, CourseEnrollmentFactory
 from student.models import CourseEnrollment

--- a/openedx/core/djangoapps/user_api/models.py
+++ b/openedx/core/djangoapps/user_api/models.py
@@ -1,7 +1,7 @@
 from django.contrib.auth.models import User
 from django.core.validators import RegexValidator
 from django.db import models
-from django.db.models.signals import pre_delete, post_delete, pre_save, post_save
+from django.db.models.signals import post_delete, pre_save, post_save
 from django.dispatch import receiver
 from model_utils.models import TimeStampedModel
 

--- a/openedx/core/djangoapps/user_api/models.py
+++ b/openedx/core/djangoapps/user_api/models.py
@@ -24,7 +24,7 @@ class UserPreference(models.Model):
     key = models.CharField(max_length=255, db_index=True, validators=[RegexValidator(KEY_REGEX)])
     value = models.TextField()
 
-    class Meta:  # pylint: disable=missing-docstring
+    class Meta(object):  # pylint: disable=missing-docstring
         unique_together = ("user", "key")
 
     @classmethod
@@ -93,7 +93,7 @@ class UserCourseTag(models.Model):
     course_id = CourseKeyField(max_length=255, db_index=True)
     value = models.TextField()
 
-    class Meta:  # pylint: disable=missing-docstring
+    class Meta(object):  # pylint: disable=missing-docstring
         unique_together = ("user", "course_id", "key")
 
 
@@ -108,6 +108,6 @@ class UserOrgTag(TimeStampedModel):
     org = models.CharField(max_length=255, db_index=True)
     value = models.TextField()
 
-    class Meta:
+    class Meta(object):
         """ Meta class for defining unique constraints. """
         unique_together = ("user", "org", "key")

--- a/openedx/core/djangoapps/user_api/serializers.py
+++ b/openedx/core/djangoapps/user_api/serializers.py
@@ -16,7 +16,7 @@ class UserSerializer(serializers.HyperlinkedModelSerializer):
     def get_preferences(self, user):
         return dict([(pref.key, pref.value) for pref in user.preferences.all()])
 
-    class Meta:
+    class Meta(object):  # pylint: disable=missing-docstring
         model = User
         # This list is the minimal set required by the notification service
         fields = ("id", "url", "email", "name", "username", "preferences")
@@ -26,7 +26,7 @@ class UserSerializer(serializers.HyperlinkedModelSerializer):
 class UserPreferenceSerializer(serializers.HyperlinkedModelSerializer):
     user = UserSerializer()
 
-    class Meta:
+    class Meta(object):  # pylint: disable=missing-docstring
         model = UserPreference
         depth = 1
 
@@ -36,7 +36,7 @@ class RawUserPreferenceSerializer(serializers.ModelSerializer):
     """
     user = serializers.PrimaryKeyRelatedField()
 
-    class Meta:
+    class Meta(object):  # pylint: disable=missing-docstring
         model = UserPreference
         depth = 1
 

--- a/openedx/core/djangoapps/user_api/tests/test_models.py
+++ b/openedx/core/djangoapps/user_api/tests/test_models.py
@@ -1,5 +1,6 @@
-import json
-
+"""
+Test UserPreferenceModel and UserPreference events
+"""
 from django.db import IntegrityError
 from django.test import TestCase
 

--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -78,7 +78,7 @@ class ApiTestCase(TestCase):
         """Given a user preference object, get the URI for the corresponding resource"""
         prefs = self.get_json(USER_PREFERENCE_LIST_URI)["results"]
         for pref in prefs:
-            if (pref["user"]["id"] == target_pref.user.id and pref["key"] == target_pref.key):
+            if pref["user"]["id"] == target_pref.user.id and pref["key"] == target_pref.key:
                 return pref["url"]
         self.fail()
 

--- a/openedx/core/djangoapps/user_api/views.py
+++ b/openedx/core/djangoapps/user_api/views.py
@@ -196,7 +196,7 @@ class RegistrationView(APIView):
 
         # Map field names to the instance method used to add the field to the form
         self.field_handlers = {}
-        for field_name in (self.DEFAULT_FIELDS + self.EXTRA_FIELDS):
+        for field_name in self.DEFAULT_FIELDS + self.EXTRA_FIELDS:
             handler = getattr(self, "_add_{field_name}_field".format(field_name=field_name))
             self.field_handlers[field_name] = handler
 

--- a/pavelib/acceptance_test.py
+++ b/pavelib/acceptance_test.py
@@ -8,7 +8,7 @@ from optparse import make_option
 try:
     from pygments.console import colorize
 except ImportError:
-    colorize = lambda color, text: text  # pylint: disable-msg=invalid-name
+    colorize = lambda color, text: text  # pylint: disable=invalid-name
 
 __test__ = False  # do not collect
 

--- a/pavelib/bok_choy.py
+++ b/pavelib/bok_choy.py
@@ -12,7 +12,7 @@ import os
 try:
     from pygments.console import colorize
 except ImportError:
-    colorize = lambda color, text: text  # pylint: disable-msg=invalid-name
+    colorize = lambda color, text: text  # pylint: disable=invalid-name
 
 __test__ = False  # do not collect
 

--- a/pavelib/i18n.py
+++ b/pavelib/i18n.py
@@ -9,7 +9,7 @@ from paver.easy import task, cmdopts, needs, sh
 try:
     from pygments.console import colorize
 except ImportError:
-    colorize = lambda color, text: text  # pylint: disable-msg=invalid-name
+    colorize = lambda color, text: text  # pylint: disable=invalid-name
 
 
 @task

--- a/pavelib/paver_tests/test_paver_get_quality_reports.py
+++ b/pavelib/paver_tests/test_paver_get_quality_reports.py
@@ -1,12 +1,9 @@
-import os
-import tempfile
+"""
+Tests to ensure only the report files we want are returned as part of run_quality.
+"""
 import unittest
-from mock import patch, Mock
-from ddt import ddt, file_data
-
+from mock import patch
 import pavelib.quality
-import paver.easy
-from paver.easy import BuildFailure
 
 
 class TestGetReportFiles(unittest.TestCase):

--- a/pavelib/tests.py
+++ b/pavelib/tests.py
@@ -11,7 +11,7 @@ from optparse import make_option
 try:
     from pygments.console import colorize
 except ImportError:
-    colorize = lambda color, text: text  # pylint: disable-msg=invalid-name
+    colorize = lambda color, text: text  # pylint: disable=invalid-name
 
 __test__ = False  # do not collect
 

--- a/pavelib/tests.py
+++ b/pavelib/tests.py
@@ -3,7 +3,7 @@ Unit test tasks
 """
 import os
 import sys
-from paver.easy import sh, task, cmdopts, needs, call_task, no_help
+from paver.easy import sh, task, cmdopts, needs, call_task
 from pavelib.utils.test import suites
 from pavelib.utils.envs import Env
 from optparse import make_option

--- a/pavelib/utils/test/bokchoy_utils.py
+++ b/pavelib/utils/test/bokchoy_utils.py
@@ -13,7 +13,7 @@ from pavelib.utils.process import run_background_process
 try:
     from pygments.console import colorize
 except ImportError:
-    colorize = lambda color, text: text  # pylint: disable-msg=invalid-name
+    colorize = lambda color, text: text  # pylint: disable=invalid-name
 
 __test__ = False  # do not collect
 
@@ -80,7 +80,7 @@ def wait_for_server(server, port):
             if int(response.status) == 200:
                 server_ok = True
                 break
-        except:  # pylint: disable-msg=bare-except
+        except:  # pylint: disable=bare-except
             pass
 
         attempts += 1

--- a/pavelib/utils/test/suites/bokchoy_suite.py
+++ b/pavelib/utils/test/suites/bokchoy_suite.py
@@ -12,7 +12,7 @@ from pavelib.utils.test import utils as test_utils
 try:
     from pygments.console import colorize
 except ImportError:
-    colorize = lambda color, text: text  # pylint: disable-msg=invalid-name
+    colorize = lambda color, text: text  # pylint: disable=invalid-name
 
 __test__ = False  # do not collect
 

--- a/pavelib/utils/test/suites/nose_suite.py
+++ b/pavelib/utils/test/suites/nose_suite.py
@@ -2,7 +2,6 @@
 Classes used for defining and running nose test suites
 """
 import os
-from paver.easy import call_task
 from pavelib.utils.test import utils as test_utils
 from pavelib.utils.test.suites.suite import TestSuite
 from pavelib.utils.envs import Env

--- a/pavelib/utils/test/suites/suite.py
+++ b/pavelib/utils/test/suites/suite.py
@@ -10,7 +10,7 @@ from pavelib.utils.process import kill_process
 try:
     from pygments.console import colorize
 except ImportError:
-    colorize = lambda color, text: text  # pylint: disable-msg=invalid-name
+    colorize = lambda color, text: text  # pylint: disable=invalid-name
 
 __test__ = False  # do not collect
 

--- a/scripts/all-tests.sh
+++ b/scripts/all-tests.sh
@@ -58,7 +58,7 @@ git clean -qxfd
 source scripts/jenkins-common.sh
 
 # Violations thresholds for failing the build
-PYLINT_THRESHOLD=7000
+PYLINT_THRESHOLD=6600
 JSHINT_THRESHOLD=3700
 
 # If the environment variable 'SHARD' is not set, default to 'all'.


### PR DESCRIPTION
- Eliminate instances of `unused-import` Pylint violation
- Eliminate instances of `deprecated-pragma` and `bad-option-value`
- Eliminate instances of `old-style-class`
- Eliminate instances of `superfluous-parens` (except for `print` statement violations, since print-as-function is Python 3k syntax and ideally we accept both syntaxes)
- Eliminate `logging-not-lazy` violations
- Partially eliminate `logging-format-interpolation` violations

On these last two please see https://bitbucket.org/logilab/pylint/pull-request/169/add-new-warning-logging-format/diff for more explination (this is a relatively new Pylint warning)
