### PR TITLE
Expose user id in user API

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/serializers.py
+++ b/openedx/core/djangoapps/user_api/accounts/serializers.py
@@ -38,8 +38,8 @@ class AccountUserSerializer(serializers.HyperlinkedModelSerializer, ReadOnlyFiel
     """
     class Meta:
         model = User
-        fields = ("username", "email", "date_joined", "is_active")
-        read_only_fields = ("username", "email", "date_joined", "is_active")
+        fields = ("id", "username", "email", "date_joined", "is_active")
+        read_only_fields = ("id", "username", "email", "date_joined", "is_active")
         explicit_read_only_fields = ()
 
 

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -39,6 +39,8 @@ class AccountView(APIView):
             request for another account and has "is_staff" access, the response
             contains:
 
+            * id: The unique and immutable identifier of the user account.
+
             * username: The username associated with the account.
 
             * name: The full name of the user.


### PR DESCRIPTION
This PR exposes `user.id` in `user_api`.

In practice, usernames can change, I need to have a unique, immutable identifier.

`id` is good for that.
