### PR TITLE
Make render_xblock return a 404 if access check fails

### DIFF
--- a/lms/djangoapps/courseware/testutils.py
+++ b/lms/djangoapps/courseware/testutils.py
@@ -154,12 +154,12 @@ class RenderXBlockTestMixin(object):
     def test_unauthenticated(self):
         self.setup_course()
         self.setup_user(admin=False, enroll=True, login=False)
-        self.verify_response(expected_response_code=302)
+        self.verify_response(expected_response_code=404)
 
     def test_unenrolled_student(self):
         self.setup_course()
         self.setup_user(admin=False, enroll=False, login=True)
-        self.verify_response(expected_response_code=302)
+        self.verify_response(expected_response_code=404)
 
     @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
     def test_fail_block_unreleased(self):

--- a/lms/djangoapps/courseware/views.py
+++ b/lms/djangoapps/courseware/views.py
@@ -37,7 +37,7 @@ from courseware.courses import (
     get_studio_url, get_course_with_access,
     sort_by_announcement,
     sort_by_start_date,
-)
+    UserNotEnrolled)
 from courseware.masquerade import setup_masquerade
 from openedx.core.djangoapps.credit.api import (
     get_credit_requirement_status,
@@ -1465,7 +1465,10 @@ def render_xblock(request, usage_key_string, check_if_enrolled=True):
 
     with modulestore().bulk_operations(course_key):
         # verify the user has access to the course, including enrollment check
-        course = get_course_with_access(request.user, 'load', course_key, check_if_enrolled=check_if_enrolled)
+        try:
+            course = get_course_with_access(request.user, 'load', course_key, check_if_enrolled=check_if_enrolled)
+        except UserNotEnrolled:
+            raise Http404("Course not found.")
 
         # get the block, which verifies whether the user has access to the block.
         block, _ = get_module_by_usage_id(


### PR DESCRIPTION
The mobile clients need the request to fail if they don't have
permisssions so that they know to refresh a session token.

JIRA: https://openedx.atlassian.net/browse/MA-1003
