### PR TITLE
MA-977 Use "supports" decorator on XBlocks for multi-device support

### DIFF
--- a/common/lib/capa/capa/capa_problem.py
+++ b/common/lib/capa/capa/capa_problem.py
@@ -575,11 +575,13 @@ class LoncapaProblem(object):
             return {}
 
     @property
-    def has_responsive_ui(self):
+    def has_multi_device_support(self):
         """
-        Returns whether this capa problem has support for responsive UI.
+        Returns whether this capa problem has multi-device support.
         """
-        return all(responder.has_responsive_ui for responder in self.responders.values())
+        return all(
+            responder.multi_device_support for responder in self.responders.values()
+        )
 
     # ======= Private Methods Below ========
 

--- a/common/lib/capa/capa/responsetypes.py
+++ b/common/lib/capa/capa/responsetypes.py
@@ -145,9 +145,9 @@ class LoncapaResponse(object):
     required_attributes = []
 
     # Overridable field that specifies whether this capa response type has support for
-    # responsive UI, for rendering on devices of different sizes and shapes.
+    # for rendering on devices of different sizes and shapes.
     # By default, we set this to False, allowing subclasses to override as appropriate.
-    has_responsive_ui = False
+    multi_device_support = False
 
     def __init__(self, xml, inputfields, context, system, capa_module):
         """
@@ -808,7 +808,7 @@ class ChoiceResponse(LoncapaResponse):
     max_inputfields = 1
     allowed_inputfields = ['checkboxgroup', 'radiogroup']
     correct_choices = None
-    has_responsive_ui = True
+    multi_device_support = True
 
     def setup_response(self):
         self.assign_choice_names()
@@ -993,7 +993,7 @@ class MultipleChoiceResponse(LoncapaResponse):
     max_inputfields = 1
     allowed_inputfields = ['choicegroup']
     correct_choices = None
-    has_responsive_ui = True
+    multi_device_support = True
 
     def setup_response(self):
         # call secondary setup for MultipleChoice questions, to set name
@@ -1346,7 +1346,7 @@ class OptionResponse(LoncapaResponse):
     hint_tag = 'optionhint'
     allowed_inputfields = ['optioninput']
     answer_fields = None
-    has_responsive_ui = True
+    multi_device_support = True
 
     def setup_response(self):
         self.answer_fields = self.inputfields
@@ -1421,7 +1421,7 @@ class NumericalResponse(LoncapaResponse):
     allowed_inputfields = ['textline', 'formulaequationinput']
     required_attributes = ['answer']
     max_inputfields = 1
-    has_responsive_ui = True
+    multi_device_support = True
 
     def __init__(self, *args, **kwargs):
         self.correct_answer = ''
@@ -1645,7 +1645,7 @@ class StringResponse(LoncapaResponse):
     required_attributes = ['answer']
     max_inputfields = 1
     correct_answer = []
-    has_responsive_ui = True
+    multi_device_support = True
 
     def setup_response_backward(self):
         self.correct_answer = [

--- a/common/lib/xmodule/xmodule/capa_module.py
+++ b/common/lib/xmodule/xmodule/capa_module.py
@@ -189,13 +189,6 @@ class CapaDescriptor(CapaFields, RawDescriptor):
         registered_tags = responsetypes.registry.registered_tags()
         return set([node.tag for node in tree.iter() if node.tag in registered_tags])
 
-    @property
-    def has_responsive_ui(self):
-        """
-        Returns whether this module has support for responsive UI.
-        """
-        return self.lcp.has_responsive_ui
-
     def index_dictionary(self):
         """
         Return dictionary prepared with module content and type for indexing.
@@ -210,6 +203,17 @@ class CapaDescriptor(CapaFields, RawDescriptor):
         }
         result.update(index)
         return result
+
+    def has_support(self, view, functionality):
+        """
+        Override the XBlock.has_support method to return appropriate
+        value for the multi-device functionality.
+        Returns whether the given view has support for the given functionality.
+        """
+        if functionality == "multi_device":
+            return self.lcp.has_multi_device_support
+        else:
+            return False
 
     # Proxy to CapaModule for access to any of its attributes
     answer_available = module_attr('answer_available')

--- a/common/lib/xmodule/xmodule/html_module.py
+++ b/common/lib/xmodule/xmodule/html_module.py
@@ -84,7 +84,9 @@ class HtmlModule(HtmlModuleMixin):
     """
     Module for putting raw html in a course
     """
-    pass
+    @XBlock.supports("multi_device")
+    def student_view(self, context):
+        return super(HtmlModule, self).student_view(context)
 
 
 class HtmlDescriptor(HtmlFields, XmlDescriptor, EditingDescriptor):  # pylint: disable=abstract-method
@@ -95,7 +97,6 @@ class HtmlDescriptor(HtmlFields, XmlDescriptor, EditingDescriptor):  # pylint: d
     module_class = HtmlModule
     filename_extension = "xml"
     template_dir_name = "html"
-    has_responsive_ui = True
     show_in_read_only_mode = True
 
     js = {'coffee': [resource_string(__name__, 'js/src/html/edit.coffee')]}

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -34,7 +34,7 @@ git+https://github.com/hmarr/django-debug-toolbar-mongo.git@b0686a76f1ce3532088c
 git+https://github.com/edx/rfc6266.git@v0.0.5-edx#egg=rfc6266==0.0.5-edx
 
 # Our libraries:
--e git+https://github.com/edx/XBlock.git@017b46b80e712b1318379912257cf1cc1b68eb0e#egg=XBlock
+-e git+https://github.com/edx/XBlock.git@d1ff8cf31a9b94916ce06ba06d4176bd72e15768#egg=XBlock
 -e git+https://github.com/edx/codejail.git@6b17c33a89bef0ac510926b1d7fea2748b73aadd#egg=codejail
 -e git+https://github.com/edx/js-test-tool.git@v0.1.6#egg=js_test_tool
 -e git+https://github.com/edx/event-tracking.git@0.2.0#egg=event-tracking


### PR DESCRIPTION
I had a verbal discussion with @talbs and we agreed that the term "multi_device" would be appropriate for indicating that an xBlock view supports rendering on multiple types of devices, with support for responsive layout and touch.  It didn't make sense to separate those out into independent functionalities.

@cpennington @ormsbee Please review.
@marcotuts FYI.
