### PR TITLE
Test library failed to export after import

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -1769,8 +1769,8 @@ class RerunCourseTest(ContentStoreTestCase):
         source_course = CourseFactory.create(advertised_start="01-12-2015")
         destination_course_key = self.post_rerun_request(source_course.id)
         destination_course = self.store.get_course(destination_course_key)
-
-        self.assertEqual(None, destination_course.advertised_start)
+        # Advertised_start is String field so it will return empty string if its not set
+        self.assertEqual('', destination_course.advertised_start)
 
     def test_rerun_of_rerun(self):
         source_course = CourseFactory.create()

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -787,7 +787,7 @@ def _rerun_course(request, org, number, run, fields):
     CourseRerunState.objects.initiated(source_course_key, destination_course_key, request.user, fields['display_name'])
 
     # Clear the fields that must be reset for the rerun
-    fields['advertised_start'] = None
+    fields['advertised_start'] = ''
 
     # Rerun the course as a new celery task
     json_fields = json.dumps(fields, cls=EdxJSONEncoder)

--- a/cms/djangoapps/contentstore/views/tests/test_import_export.py
+++ b/cms/djangoapps/contentstore/views/tests/test_import_export.py
@@ -451,6 +451,41 @@ class ExportTestCase(CourseTestCase):
         finally:
             shutil.rmtree(root_dir / name)
 
+    def test_library_import_then_export(self):
+        """
+        Verify that a library exports successfully after being imported.
+        """
+        library = LibraryFactory.create(modulestore=self.store)
+        lib_key = library.location.library_key
+        name = library.url_name
+
+        # import the library
+        extract_dir = path(tempfile.mkdtemp(dir=settings.DATA_DIR))
+        extract_dir_relative = path.relpath(extract_dir, settings.DATA_DIR)
+        try:
+            with tarfile.open(path(TEST_DATA_DIR) / 'imports' / 'library.HhJfPD.tar.gz') as tar:
+                safetar_extractall(tar, extract_dir)
+            library_items = import_library_from_xml(
+                self.store,
+                self.user.id,
+                settings.GITHUB_REPO_ROOT,
+                [extract_dir_relative / 'library'],
+                load_error_modules=False,
+                static_content_store=contentstore(),
+                target_id=lib_key
+            )
+
+            # verify library import correctly
+            self.assertEqual(lib_key, library_items[0].location.library_key)
+            library = self.store.get_library(lib_key)
+            self.assertEqual(len(library.children), 3)
+
+            # export library again
+            export_library_to_xml(self.store, contentstore(), lib_key, extract_dir, name)
+
+        finally:
+            shutil.rmtree(extract_dir)
+
     def test_export_success_with_custom_tag(self):
         """
         Verify that course export with customtag

--- a/cms/djangoapps/contentstore/views/tests/test_item.py
+++ b/cms/djangoapps/contentstore/views/tests/test_item.py
@@ -625,7 +625,7 @@ class TestEditItem(TestEditItemSetup):
             data={'nullout': ['markdown']}
         )
         problem = self.get_item_from_modulestore(self.problem_usage_key, verify_is_draft=True)
-        self.assertIsNone(problem.markdown)
+        self.assertEqual(problem.markdown, '')
 
     def test_date_fields(self):
         """

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -948,7 +948,7 @@ class CourseDescriptor(CourseFields, SequenceDescriptor, LicenseMixin):
         super(CourseDescriptor, self).__init__(*args, **kwargs)
         _ = self.runtime.service(self, "i18n").ugettext
 
-        if self.wiki_slug is None:
+        if not self.wiki_slug:
             self.wiki_slug = self.location.course
 
         if self.due_date_display_format is None and self.show_timezone is False:

--- a/lms/djangoapps/django_comment_client/utils.py
+++ b/lms/djangoapps/django_comment_client/utils.py
@@ -87,7 +87,7 @@ def has_forum_access(uname, course_id, rolename):
 def has_required_keys(module):
     """Returns True iff module has the proper attributes for generating metadata with get_discussion_id_map_entry()"""
     for key in ('discussion_id', 'discussion_category', 'discussion_target'):
-        if getattr(module, key, None) is None:
+        if not getattr(module, key, None):
             log.debug("Required key '%s' not in discussion %s, leaving out of category map", key, module.location)
             return False
     return True

--- a/lms/djangoapps/mobile_api/users/tests.py
+++ b/lms/djangoapps/mobile_api/users/tests.py
@@ -146,9 +146,9 @@ class TestUserEnrollmentApi(MobileAPITestCase, MobileAuthUserTestMixin):
 
     @ddt.data(
         (NEXT_WEEK, ADVERTISED_START, ADVERTISED_START, "string"),
-        (NEXT_WEEK, None, defaultfilters.date(NEXT_WEEK, "DATE_FORMAT"), "timestamp"),
+        (NEXT_WEEK, None, '', "string"),
         (DEFAULT_START_DATE, ADVERTISED_START, ADVERTISED_START, "string"),
-        (DEFAULT_START_DATE, None, None, "empty")
+        (DEFAULT_START_DATE, None, '', "string")
     )
     @ddt.unpack
     @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})

--- a/openedx/core/djangoapps/content/course_overviews/tests.py
+++ b/openedx/core/djangoapps/content/course_overviews/tests.py
@@ -191,7 +191,7 @@ class CourseOverviewTestCase(ModuleStoreTestCase):
                 "display_name": "",                         # Empty display name
                 "start": LAST_MONTH,                        # Course already ended
                 "end": LAST_WEEK,
-                "advertised_start": None,                   # No advertised start
+                "advertised_start": '',                   # No advertised start
                 "pre_requisite_courses": [],                # No pre-requisites
                 "static_asset_path": "",                    # Empty asset path
                 "certificates_show_before_end": False,
@@ -200,7 +200,7 @@ class CourseOverviewTestCase(ModuleStoreTestCase):
                 #                                           # Don't set display name
                 "start": DEFAULT_START_DATE,                # Default start and end dates
                 "end": None,
-                "advertised_start": None,                   # No advertised start
+                "advertised_start": '',                   # No advertised start
                 "pre_requisite_courses": [],                # No pre-requisites
                 "static_asset_path": None,                  # No asset path
                 "certificates_show_before_end": False,

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -34,7 +34,7 @@ git+https://github.com/hmarr/django-debug-toolbar-mongo.git@b0686a76f1ce3532088c
 git+https://github.com/edx/rfc6266.git@v0.0.5-edx#egg=rfc6266==0.0.5-edx
 
 # Our libraries:
--e git+https://github.com/edx/XBlock.git@d1ff8cf31a9b94916ce06ba06d4176bd72e15768#egg=XBlock
+-e git+https://github.com/edx/XBlock.git@0d3d43bd1ef0f882ef70d19d4f652d35dd37eb01#egg=XBlock
 -e git+https://github.com/edx/codejail.git@6b17c33a89bef0ac510926b1d7fea2748b73aadd#egg=codejail
 -e git+https://github.com/edx/js-test-tool.git@v0.1.6#egg=js_test_tool
 -e git+https://github.com/edx/event-tracking.git@0.2.0#egg=event-tracking


### PR DESCRIPTION
[TNL-2686](https://openedx.atlassian.net/browse/TNL-2686)

Test for Xblock [pr#305](https://github.com/edx/XBlock/pull/305) where while setting xml attribute with `None` value throwing `TypeError` , solve this by adding an inline check if value is of `None` Type return empty string to save xml attribute
