### PR TITLE
Post complexity metric to a file for downstream collection.

### DIFF
--- a/scripts/all-tests.sh
+++ b/scripts/all-tests.sh
@@ -85,7 +85,7 @@ case "$TEST_SUITE" in
         PATH=$PATH:node_modules/.bin
         paver run_jshint -l $JSHINT_THRESHOLD > jshint.log || { cat jshint.log; EXIT=1; }
         echo "Running code complexity report (python)."
-        paver run_complexity > reports/code_complexity.log || echo "Unable to calculate code complexity. Ignoring error."
+        paver run_complexity || echo "Unable to calculate code complexity. Ignoring error."
         # Need to create an empty test result so the post-build
         # action doesn't fail the build.
         cat > reports/quality.xml <<END


### PR DESCRIPTION
We are currently running a fire-and-forget code complexity report. This is available in jenkins under the reports directory.

This change will log a metric file (much like jshint, pep8, pylint files) that will contain the python cyclomatic complexity score. This can be ingested by downstream processes (e.g., data collection for trends, current state for dashboards, etc). 
