### PR TITLE
Return just the CourseDescriptor in discussions get_course()

### DIFF
--- a/common/lib/xmodule/xmodule/discussion_module.py
+++ b/common/lib/xmodule/xmodule/discussion_module.py
@@ -66,9 +66,11 @@ class DiscussionModule(DiscussionFields, XModule):
 
     def get_course(self):
         """
-        Return course by course id.
+        Return the CourseDescriptor by course id.
         """
-        return self.descriptor.runtime.modulestore.get_course(self.course_id)
+        course_key = self.location.course_key
+        root_course_loc = course_key.make_usage_key(u'course', u'course')
+        return self.runtime.get_block(root_course_loc)
 
 
 class DiscussionDescriptor(DiscussionFields, MetadataOnlyEditingDescriptor, RawDescriptor):


### PR DESCRIPTION
Instead of calling the `modulestore's get_course()`, return the descriptor via `self.runtime.get_block()`. Doing this means that bulk ops caching works within CCX courses.

Note: The long term fix for this is to have some course-level scope so that we're not peeking at the top of the tree just for some basic discussion-specific configuration information (in this case the blackout dates).

@cpennington, @adampalay 
