### PR TITLE
Update migration dependency.

### DIFF
--- a/common/djangoapps/student/migrations/0035_access_roles.py
+++ b/common/djangoapps/student/migrations/0035_access_roles.py
@@ -20,6 +20,11 @@ class Migration(DataMigration):
     Converts course_creator, instructor_, staff_, and betatestuser_ to new table
     """
 
+    # Because we instantiate the module store and the modulestore needs this config table to exist.
+    depends_on = (
+        ("xblock_django", "0001_initial"),
+    )
+
     GROUP_ENTRY_RE = re.compile(r'(?P<role_id>staff|instructor|beta_testers|course_creator_group)_?(?P<course_id_string>.*)')
 
     def forwards(self, orm):


### PR DESCRIPTION
@andy-armstrong @symbolist   Not having this dependency broke migrations if building from scratch because of migration order.
