### PR TITLE
Update lxml to 3.4.4

### DIFF
--- a/docs/shared/requirements.txt
+++ b/docs/shared/requirements.txt
@@ -34,7 +34,7 @@ feedparser==5.1.3
 git+https://github.com/pmitros/pyfs.git@96e1922348bfe6d99201b9512a9ed946c87b7e0b
 GitPython==0.3.2.RC1
 glob2==0.3
-lxml==3.3.6
+lxml==3.4.4
 mako==0.7.3
 Markdown==2.2.1
 mock==1.0.1

--- a/requirements/edx-sandbox/post.txt
+++ b/requirements/edx-sandbox/post.txt
@@ -6,4 +6,4 @@
 
 # Packages to install in the Python sandbox for secured execution.
 scipy==0.14.0
-lxml==3.3.6
+lxml==3.4.4

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -44,7 +44,7 @@ glob2==0.3
 gunicorn==0.17.4
 httpretty==0.8.3
 lazy==1.1
-lxml==3.3.6
+lxml==3.4.4
 mako==0.9.1
 Markdown==2.2.1
 --allow-external meliae

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -39,10 +39,10 @@ git+https://github.com/hmarr/django-debug-toolbar-mongo.git@b0686a76f1ce3532088c
 -e git+https://github.com/edx/event-tracking.git@0.2.0#egg=event-tracking
 -e git+https://github.com/edx-solutions/django-splash.git@7579d052afcf474ece1239153cffe1c89935bc4f#egg=django-splash
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
--e git+https://github.com/edx/edx-ora2.git@release-2015-07-09T15.00#egg=edx-ora2
+-e git+https://github.com/edx/edx-ora2.git@release-2015-07-14T11.10#egg=edx-ora2
 -e git+https://github.com/edx/edx-submissions.git@7c766502058e04bc9094e6cbe286e949794b80b3#egg=edx-submissions
 -e git+https://github.com/edx/opaque-keys.git@27dc382ea587483b1e3889a3d19cbd90b9023a06#egg=opaque-keys
-git+https://github.com/edx/ease.git@release-2015-07-09#egg=ease==0.1.3
+git+https://github.com/edx/ease.git@release-2015-07-14#egg=ease==0.1.3
 -e git+https://github.com/edx/i18n-tools.git@v0.1.1#egg=i18n-tools
 git+https://github.com/edx/edx-oauth2-provider.git@0.5.2#egg=oauth2-provider==0.5.2
 -e git+https://github.com/edx/edx-val.git@v0.0.5#egg=edx-val


### PR DESCRIPTION
This is needed to make the release go out. Also depends on https://github.com/edx/edx-ora2/pull/710 and https://github.com/edx/ease/pull/68.

Sandbox: http://lxml.m.sandbox.edx.org
