### PR TITLE
Visual cleanup to LMS course tab styling

### DIFF
--- a/lms/static/sass/base/_layouts.scss
+++ b/lms/static/sass/base/_layouts.scss
@@ -32,7 +32,14 @@ body.view-incourse {
   .wrapper-course-material .course-material,
   .wrapper-preview-menu .preview-menu  {
     width: auto;
+  }
+
+  .wrapper-preview-menu .preview-menu {
     padding: 15px 2%;
+  }
+
+  .wrapper-course-material .course-material {
+    padding: ($baseline/2) 0 0 0;
   }
 
   .wrapper-course-material .course-material .course-tabs {

--- a/lms/static/sass/base/_variables.scss
+++ b/lms/static/sass/base/_variables.scss
@@ -149,7 +149,7 @@ $light-gray: rgb(221, 221, 221);
 $dark-gray: rgb(51, 51, 51);
 $border-color: rgb(200, 200, 200);
 $sidebar-color: rgb(246, 246, 246);
-$outer-border-color: rgb(170, 170, 170);
+$outer-border-color: $gray-l3;
 $light-gray: rgb(221,221,221); // #dddddd
 
 // used by descriptor css

--- a/lms/static/sass/course/layout/_courseware_header.scss
+++ b/lms/static/sass/course/layout/_courseware_header.scss
@@ -15,48 +15,46 @@
   ol.course-tabs {
     @include border-top-radius(4px);
     @include clearfix();
-    @include margin-left(10px);
     padding: ($baseline*0.75) 0 ($baseline*0.75) 0;
 
     li {
       @include float(left);
       list-style: none;
-      margin-right: 6px;
 
       &.prominent {
-        margin-right: 16px;
-        background: rgba(255, 255, 255, .5);
+        @include margin-right(16px);
+        background: rgba(255, 255, 255, 0.5);
         border-radius: 3px;
       }
 
       &.prominent + li {
-          padding-left: ($baseline*0.75);
-          border-left: 1px solid #333;
+        @include padding-left($baseline*0.75);
+        @include border-left(1px solid $gray-d3);
       }
 
       a {
-        border-radius: 3px;
-        color: #555;
+        @include padding(($baseline/2), ($baseline*0.75), 13px, ($baseline*0.75));
+        @extend %t-title7;
+        @extend %t-strong;
+        border-bottom: 3px solid transparent;
+        color: $gray-d1;
         display: block;
         text-align: center;
-        padding: ($baseline/2) 13px 12px;
-        font-size: 14px;
-        font-weight: bold;
         text-decoration: none;
-        // text-shadow: 0 1px 0 rgba(0, 0, 0, .4);
 
         &:hover, &:focus {
-          color: #333;
-          background: rgba(255, 255, 255, .6);
+          color: $blue;
+          border-bottom: 3px solid $blue;
         }
 
         &.active {
-          // background: $shadow;
-          @include linear-gradient(top, rgba(0, 0, 0, .4), rgba(0, 0, 0, .25));
+          border-bottom: 3px solid $gray-d4;
           background-color: transparent;
-          box-shadow: 0 1px 0 rgba(255, 255, 255, .5), 0 1px 1px rgba(0, 0, 0, .3) inset;
-          color: $white;
-          text-shadow: 0 1px 0 rgba(0, 0, 0, .4);
+          color: $gray-d4;
+
+          &:hover, &:focus {
+            color: $gray-d4;
+          }
         }
       }
     }
@@ -87,7 +85,7 @@ header.global.slim {
   }
 
   .guest .secondary {
-    margin-right: 0;
+    @include margin-right(0);
   }
 
   .guest .secondary a {


### PR DESCRIPTION
**Description**
The following styling changes cleans up the course tab UI to use a lighter tab style matching patterns from the upcoming Teams application as well as tabs used on ux.edx.org. Prior to review and merge, will want to see if there is any other related cleanup or changes based on @frrrances's visual and FED work with the teams application. 

---

**JIRA Story** ([UX-2503](https://openedx.atlassian.net/browse/UX-2503))
**Confluence / Product Asset** N/A
**Sandbox URL** (N/A) 
**Dependencies** (N/A)

---

**PR Author(s) Notes / To-Do** A list of known open tasks that the PR author has.
- [ ] review with @frrrances to make sure we are using teams styles where possible
- [ ] time for product / UX reviews happen (see full list of reviewers below)
- [ ] tag PR reviewers

---

**Screenshots** 
Current: 
![image](https://cloud.githubusercontent.com/assets/2023680/8664610/78a1faa6-29a7-11e5-9f0a-691633608afb.png)

Proposed Change:
![image](https://cloud.githubusercontent.com/assets/2023680/8664594/31327146-29a7-11e5-85aa-7b9e6e8ff29f.png)

Current (Hover):
![image](https://cloud.githubusercontent.com/assets/2023680/8664643/de62ca00-29a7-11e5-9db9-c181e879554c.png)

Proposed Change (Hover):
![image](https://cloud.githubusercontent.com/assets/2023680/8664660/1ef70a5e-29a8-11e5-8d85-c4e72c7ca1cb.png)

---

**Reviewers** (tagged once PR is ready) 
- [ ] FED, VIZ : @frrrances,  
- [ ] Product: @explorerleslie,
- [ ] Documentation: Sylvia, 
- [ ] Accessibility: Chris / Mark

FYI: @talbs - I wanted to tag you as well on this in case you had any feedback or suggestions! The styling for these tabs not only echoes the teams work, but also stems from the LMS visual direction work you did back in UX-1521 :). :guitar: 
