### PR TITLE
mattdrayer/SOL-1053: CSS transition workaround

### DIFF
--- a/common/test/acceptance/pages/studio/settings_certificates.py
+++ b/common/test/acceptance/pages/studio/settings_certificates.py
@@ -131,9 +131,11 @@ class CertificatesPage(CoursePage):
     def click_confirmation_prompt_primary_button(self):
         """
         Clicks the main action presented by the prompt (such as 'Delete')
+        We need to use Javascript here because the confirmation prompt is a CSS transition
         """
         self.wait_for_confirmation_prompt()
-        self.q(css='a.button.action-primary').first.click()
+        jquery_cmd = "$('a.button.action-primary').focus().click()"
+        self.browser.execute_script(jquery_cmd)
         self.wait_for_ajax()
 
 

--- a/common/test/acceptance/tests/studio/test_studio_settings_certificates.py
+++ b/common/test/acceptance/tests/studio/test_studio_settings_certificates.py
@@ -1,6 +1,7 @@
 """
 Acceptance tests for Studio's Setting pages
 """
+from flaky import flaky
 from .base_studio_test import StudioCourseTest
 from ...pages.studio.settings_certificates import CertificatesPage
 
@@ -105,6 +106,7 @@ class CertificatesTest(StudioCourseTest):
 
         self.assertIn("Updated Course Title Override 2", certificate.course_title)
 
+    @flaky(max_runs=20, min_passes=20)
     def test_can_delete_certificate(self):
         """
         Scenario: Ensure that the user can delete certificate.


### PR DESCRIPTION
@jzoldak -- following the pattern used in press_the_notification_button, but this particular confirmation prompt is slightly different in terms of HTML/class structure.  Going to run it w/ the specific tests job to see if the flakiness has been addressed -- fingers crossed...
