### PR TITLE
Upv courseupdates

### DIFF
--- a/cms/djangoapps/contentstore/course_info_model.py
+++ b/cms/djangoapps/contentstore/course_info_model.py
@@ -15,6 +15,8 @@ Current db representation:
 import re
 import logging
 
+from dateutil import parser
+
 from django.http import HttpResponseBadRequest
 from django.utils.translation import ugettext as _
 
@@ -159,7 +161,29 @@ def _get_html(course_updates_items):
     Method to create course_updates_html from course_updates items
     """
     list_items = []
-    for update in reversed(course_updates_items):
+    date_items = []
+    no_date_items = []
+
+    #print course_updates_items
+
+    #for a in (course_updates_items):
+    #   print a.get("date")
+
+
+    for item in course_updates_items:
+        try:
+            parser.parse(item.get("date"))
+            date_items.append(item)
+        except ValueError:
+            no_date_items.append(item)
+
+    date_items = sorted(date_items, key=lambda k: parser.parse(k.get("date")), reverse=True)
+
+    course_updates_items_sorted = date_items + no_date_items
+
+
+  # for update in reversed(course_updates_items):
+    for update in course_updates_items_sorted:
         # filter course update items which have status "deleted".
         if update.get("status") != CourseInfoModule.STATUS_DELETED:
             list_items.append(u"<article><h2>{date}</h2>{content}</article>".format(**update))

--- a/cms/djangoapps/contentstore/management/commands/tests/test_import.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_import.py
@@ -12,17 +12,13 @@ from django.core.management import call_command
 from django_comment_common.utils import are_permissions_roles_seeded
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from opaque_keys.edx.locations import SlashSeparatedCourseKey
+from xmodule.modulestore import ModuleStoreEnum
 
 
 class TestImport(ModuleStoreTestCase):
     """
     Unit tests for importing a course from command line
     """
-
-    BASE_COURSE_KEY = SlashSeparatedCourseKey(u'edX', u'test_import_course', u'2013_Spring')
-    DIFF_KEY = SlashSeparatedCourseKey(u'edX', u'test_import_course', u'2014_Spring')
-    TRUNCATED_KEY = SlashSeparatedCourseKey(u'edX', u'test_import', u'2014_Spring')
 
     def create_course_xml(self, content_dir, course_id):
         directory = tempfile.mkdtemp(dir=content_dir)
@@ -32,7 +28,7 @@ class TestImport(ModuleStoreTestCase):
                     'course="{0.course}"/>'.format(course_id))
 
         with open(os.path.join(directory, "course", "{0.run}.xml".format(course_id)), "w+") as f:
-            f.write('<course></course>')
+            f.write('<course><chapter name="Test Chapter"></chapter></course>')
 
         return directory
 
@@ -44,38 +40,23 @@ class TestImport(ModuleStoreTestCase):
         self.content_dir = path(tempfile.mkdtemp())
         self.addCleanup(shutil.rmtree, self.content_dir)
 
-        # Create good course xml
-        self.good_dir = self.create_course_xml(self.content_dir, self.BASE_COURSE_KEY)
+        self.base_course_key = self.store.make_course_key(u'edX', u'test_import_course', u'2013_Spring')
+        self.truncated_key = self.store.make_course_key(u'edX', u'test_import', u'2014_Spring')
 
-        # Create run changed course xml
-        self.dupe_dir = self.create_course_xml(self.content_dir, self.DIFF_KEY)
+        # Create good course xml
+        self.good_dir = self.create_course_xml(self.content_dir, self.base_course_key)
 
         # Create course XML where TRUNCATED_COURSE.org == BASE_COURSE_ID.org
         # and BASE_COURSE_ID.startswith(TRUNCATED_COURSE.course)
-        self.course_dir = self.create_course_xml(self.content_dir, self.TRUNCATED_KEY)
+        self.course_dir = self.create_course_xml(self.content_dir, self.truncated_key)
 
     def test_forum_seed(self):
         """
         Tests that forum roles were created with import.
         """
-        self.assertFalse(are_permissions_roles_seeded(self.BASE_COURSE_KEY))
+        self.assertFalse(are_permissions_roles_seeded(self.base_course_key))
         call_command('import', self.content_dir, self.good_dir)
-        self.assertTrue(are_permissions_roles_seeded(self.BASE_COURSE_KEY))
-
-    def test_duplicate_with_url(self):
-        """
-        Check to make sure an import doesn't import courses that have the
-        same org and course, but they have different runs in order to
-        prevent modulestore "findone" exceptions on deletion
-        """
-        # Load up base course and verify it is available
-        call_command('import', self.content_dir, self.good_dir)
-        store = modulestore()
-        self.assertIsNotNone(store.get_course(self.BASE_COURSE_KEY))
-
-        # Now load up duped course and verify it doesn't load
-        call_command('import', self.content_dir, self.dupe_dir)
-        self.assertIsNone(store.get_course(self.DIFF_KEY))
+        self.assertTrue(are_permissions_roles_seeded(self.base_course_key))
 
     def test_truncated_course_with_url(self):
         """
@@ -87,8 +68,28 @@ class TestImport(ModuleStoreTestCase):
         # Load up base course and verify it is available
         call_command('import', self.content_dir, self.good_dir)
         store = modulestore()
-        self.assertIsNotNone(store.get_course(self.BASE_COURSE_KEY))
+        self.assertIsNotNone(store.get_course(self.base_course_key))
 
         # Now load up the course with a similar course_id and verify it loads
         call_command('import', self.content_dir, self.course_dir)
-        self.assertIsNotNone(store.get_course(self.TRUNCATED_KEY))
+        self.assertIsNotNone(store.get_course(self.truncated_key))
+
+    def test_existing_course_with_different_modulestore(self):
+        """
+        Checks that a course that originally existed in old mongo can be re-imported when
+        split is the default modulestore.
+        """
+        with modulestore().default_store(ModuleStoreEnum.Type.mongo):
+            call_command('import', self.content_dir, self.good_dir)
+
+        # Clear out the modulestore mappings, else when the next import command goes to create a destination
+        # course_key, it will find the existing course and return the mongo course_key. To reproduce TNL-1362,
+        # the destination course_key needs to be the one for split modulestore.
+        modulestore().mappings = {}
+
+        with modulestore().default_store(ModuleStoreEnum.Type.split):
+            call_command('import', self.content_dir, self.good_dir)
+            course = modulestore().get_course(self.base_course_key)
+            # With the bug, this fails because the chapter's course_key is the split mongo form,
+            # while the course's course_key is the old mongo form.
+            self.assertEqual(unicode(course.location.course_key), unicode(course.children[0].course_key))

--- a/cms/djangoapps/contentstore/tests/test_import.py
+++ b/cms/djangoapps/contentstore/tests/test_import.py
@@ -83,21 +83,24 @@ class ContentStoreImportTest(ModuleStoreTestCase):
         """
         # Test that importing course with unicode 'id' and 'display name' doesn't give UnicodeEncodeError
         """
-        module_store = modulestore()
-        course_id = SlashSeparatedCourseKey(u'Юникода', u'unicode_course', u'échantillon')
-        import_from_xml(
-            module_store,
-            self.user.id,
-            TEST_DATA_DIR,
-            ['2014_Uni'],
-            target_course_id=course_id
-        )
+        # Test with the split modulestore because store.has_course fails in old mongo with unicode characters.
+        with modulestore().default_store(ModuleStoreEnum.Type.split):
+            module_store = modulestore()
+            course_id = module_store.make_course_key(u'Юникода', u'unicode_course', u'échantillon')
+            import_from_xml(
+                module_store,
+                self.user.id,
+                TEST_DATA_DIR,
+                ['2014_Uni'],
+                target_course_id=course_id,
+                create_course_if_not_present=True
+            )
 
-        course = module_store.get_course(course_id)
-        self.assertIsNotNone(course)
+            course = module_store.get_course(course_id)
+            self.assertIsNotNone(course)
 
-        # test that course 'display_name' same as imported course 'display_name'
-        self.assertEqual(course.display_name, u"Φυσικά το όνομα Unicode")
+            # test that course 'display_name' same as imported course 'display_name'
+            self.assertEqual(course.display_name, u"Φυσικά το όνομα Unicode")
 
     def test_static_import(self):
         '''

--- a/cms/djangoapps/contentstore/tests/test_libraries.py
+++ b/cms/djangoapps/contentstore/tests/test_libraries.py
@@ -847,3 +847,27 @@ class TestOverrides(LibraryTestCase):
         self.assertEqual(self.problem_in_course.display_name, new_display_name)
         self.assertEqual(self.problem_in_course.weight, new_weight)
         self.assertEqual(self.problem_in_course.data, new_data_value)
+
+
+class TestIncompatibleModuleStore(LibraryTestCase):
+    """
+    Tests for proper validation errors with an incompatible course modulestore.
+    """
+    def setUp(self):
+        super(TestIncompatibleModuleStore, self).setUp()
+        # Create a course in an incompatible modulestore.
+        with modulestore().default_store(ModuleStoreEnum.Type.mongo):
+            self.course = CourseFactory.create()
+
+        # Add a LibraryContent block to the course:
+        self.lc_block = self._add_library_content_block(self.course, self.lib_key)
+
+    def test_incompatible_modulestore(self):
+        """
+        Verifies that, if a user is using a modulestore that doesn't support libraries,
+        a validation error will be produced.
+        """
+        validation = self.lc_block.validate()
+        self.assertEqual(validation.summary.type, validation.summary.ERROR)
+        self.assertIn(
+            "This course does not support content libraries.", validation.summary.text)

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -1426,7 +1426,7 @@ class GroupConfiguration(object):
 
             validation_summary = split_test.general_validation_message()
             usage_info[split_test.user_partition_id].append({
-                'label': '{} / {}'.format(unit.display_name, split_test.display_name),
+                'label': u"{} / {}".format(unit.display_name, split_test.display_name),
                 'url': unit_url,
                 'validation': validation_summary.to_json() if validation_summary else None,
             })

--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -185,7 +185,8 @@ def _preview_module_system(request, descriptor, field_data):
         wrappers=wrappers,
         error_descriptor_class=ErrorDescriptor,
         get_user_role=lambda: get_user_role(request.user, course_id),
-        descriptor_runtime=descriptor.runtime,
+        # Get the raw DescriptorSystem, not the CombinedSystem
+        descriptor_runtime=descriptor._runtime,  # pylint: disable=protected-access
         services={
             "i18n": ModuleI18nService(),
             "field-data": field_data,

--- a/cms/djangoapps/contentstore/views/tests/test_group_configurations.py
+++ b/cms/djangoapps/contentstore/views/tests/test_group_configurations.py
@@ -492,7 +492,7 @@ class GroupConfigurationsUsageInfoTestCase(CourseTestCase, HelperMethods):
 
         self.assertEqual(actual, expected)
 
-    def test_can_get_correct_usage_info_when_special_characters_are_in_content(self):
+    def test_can_get_usage_info_when_special_characters_are_used(self):
         """
         Test if group configurations json updated successfully when special
          characters are being used in content experiment

--- a/cms/djangoapps/contentstore/views/tests/test_group_configurations.py
+++ b/cms/djangoapps/contentstore/views/tests/test_group_configurations.py
@@ -1,3 +1,4 @@
+#-*- coding: utf-8 -*-
 """
 Group Configuration Tests.
 """
@@ -35,7 +36,7 @@ class HelperMethods(object):
     """
     Mixin that provides useful methods for Group Configuration tests.
     """
-    def _create_content_experiment(self, cid=-1, name_suffix=''):
+    def _create_content_experiment(self, cid=-1, name_suffix='', special_characters=''):
         """
         Create content experiment.
 
@@ -53,7 +54,7 @@ class HelperMethods(object):
             category='split_test',
             parent_location=vertical.location,
             user_partition_id=cid,
-            display_name='Test Content Experiment {}'.format(name_suffix),
+            display_name=u"Test Content Experiment {}{}".format(name_suffix, special_characters),
             group_id_to_child={"0": c0_url, "1": c1_url, "2": c2_url}
         )
         ItemFactory.create(
@@ -487,6 +488,36 @@ class GroupConfigurationsUsageInfoTestCase(CourseTestCase, HelperMethods):
                 {'id': 2, 'name': 'Group C', 'version': 1},
             ],
             'usage': [],
+        }]
+
+        self.assertEqual(actual, expected)
+
+    def test_can_get_correct_usage_info_when_special_characters_are_in_content(self):
+        """
+        Test if group configurations json updated successfully when special
+         characters are being used in content experiment
+        """
+        self._add_user_partitions(count=1)
+        vertical, __ = self._create_content_experiment(cid=0, name_suffix='0', special_characters=u"JOSÉ ANDRÉS")
+
+        actual = GroupConfiguration.get_split_test_partitions_with_usage(self.course, self.store)
+
+        expected = [{
+            'id': 0,
+            'name': 'Name 0',
+            'scheme': 'random',
+            'description': 'Description 0',
+            'version': UserPartition.VERSION,
+            'groups': [
+                {'id': 0, 'name': 'Group A', 'version': 1},
+                {'id': 1, 'name': 'Group B', 'version': 1},
+                {'id': 2, 'name': 'Group C', 'version': 1},
+            ],
+            'usage': [{
+                'url': '/container/{}'.format(vertical.location),
+                'label': u"Test Unit 0 / Test Content Experiment 0JOSÉ ANDRÉS",
+                'validation': None,
+            }],
         }]
 
         self.assertEqual(actual, expected)

--- a/cms/templates/js/course_info_update.underscore
+++ b/cms/templates/js/course_info_update.underscore
@@ -4,7 +4,7 @@
 		<div class="row">
 			<label class="inline-label">Date:</label>
 			<!-- TODO replace w/ date widget and actual date (problem is that persisted version is "Month day" not an actual date obj -->
-			<input type="text" class="date" value="<%= updateModel.get('date') %>">
+			<input type="text" class="date" value="<%= updateModel.get('date') %>" readonly="true">
 		</div>
 		<div class="row">
 			<textarea class="new-update-content text-editor"><%= updateModel.get('content') %></textarea>

--- a/cms/templates/settings.html
+++ b/cms/templates/settings.html
@@ -199,13 +199,7 @@ CMS.URL.UPLOAD_ASSET = '${upload_asset_url}';
                 'These dates impact <strong>when your courseware can be viewed</strong>, '
                 'but they are <strong>not the dates shown on your course summary page</strong>. '
                 'To provide the course start and registration dates as shown on your course '
-                'summary page, follow the instructions provided by your {manager}.').format(
-                  manager='<abbr title="{program_manager}">{pm}</abbr>'.format(
-                    ## Translators: This is a job title
-                    program_manager=_("Program Manager"),
-                    ## Translators: This is an abbreviation for "Program Manager", which is a job title
-                    pm=_("PM"),
-                  )
+                'summary page, follow the instructions provided by your Program Manager.'
               )}</p>
             </div>
           </div>

--- a/cms/templates/widgets/footer.html
+++ b/cms/templates/widgets/footer.html
@@ -4,7 +4,15 @@
 <div class="wrapper-footer wrapper">
   <footer class="primary" role="contentinfo">
     <div class="colophon">
-      <p>&copy; ${settings.COPYRIGHT_YEAR} <a href="${marketing_link('ROOT')}" rel="external">${settings.PLATFORM_NAME}</a>. ${ _("All rights reserved.")}</p>
+      <p>&copy; ${settings.COPYRIGHT_YEAR} <a href="${marketing_link('ROOT')}" rel="external">${settings.PLATFORM_NAME}</a>.</p>
+      ## Site operators: Please do not remove this paragraph! This attributes back to edX and makes your acknowledgement of edX's trademarks clear.
+      <p>
+	## Translators: 'EdX', 'edX', 'Studio', and 'Open edX' are trademarks of 'edX Inc.'. Please do not translate any of these trademarks and company names.
+	${_("EdX, Open edX, Studio, and the edX and Open edX logos are registered trademarks or trademarks of {link_start}edX Inc.{link_end}").format(
+	  link_start=u"<a href='https://www.edx.org/'>",
+	  link_end=u"</a>"
+	)}
+      </p>
     </div>
 
     <nav class="nav-peripheral">

--- a/cms/templates/widgets/footer.html
+++ b/cms/templates/widgets/footer.html
@@ -4,12 +4,12 @@
 <div class="wrapper-footer wrapper">
   <footer class="primary" role="contentinfo">
     <div class="colophon">
-      <p>&copy; ${settings.COPYRIGHT_YEAR} <a href="${marketing_link('ROOT')}" rel="external">${settings.PLATFORM_NAME}</a>.</p>
+      <p>&copy; ${settings.COPYRIGHT_YEAR} <a data-rel="edx.org" href="${marketing_link('ROOT')}" rel="external">${settings.PLATFORM_NAME}</a>.</p>
       ## Site operators: Please do not remove this paragraph! This attributes back to edX and makes your acknowledgement of edX's trademarks clear.
       <p>
 	## Translators: 'EdX', 'edX', 'Studio', and 'Open edX' are trademarks of 'edX Inc.'. Please do not translate any of these trademarks and company names.
 	${_("EdX, Open edX, Studio, and the edX and Open edX logos are registered trademarks or trademarks of {link_start}edX Inc.{link_end}").format(
-	  link_start=u"<a href='https://www.edx.org/'>",
+	  link_start=u"<a data-rel='edx.org' href='https://www.edx.org/'>",
 	  link_end=u"</a>"
 	)}
       </p>
@@ -25,7 +25,7 @@
         </li>
         % if settings.TENDER_DOMAIN and user.is_authenticated():
         <li class="nav-item nav-peripheral-feedback">
-          <a href="http://${settings.TENDER_DOMAIN}/discussion/new" class="show-tender" title="${_('Use our feedback tool, Tender, to share your feedback')}">${_("Contact Us")}</a>
+          <a data-rel="edx.org" href="http://${settings.TENDER_DOMAIN}/discussion/new" class="show-tender" title="${_('Use our feedback tool, Tender, to share your feedback')}">${_("Contact Us")}</a>
         </li>
         % endif
       </ol>

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1428,7 +1428,7 @@ def _do_create_account(post_vars, extended_profile=None):
     return (user, profile, registration)
 
 
-@ensure_csrf_cookie
+@csrf_exempt
 def create_account(request, post_override=None):  # pylint: disable-msg=too-many-statements
     """
     JSON call to create new edX account.

--- a/common/lib/xmodule/xmodule/js/fixtures/problem_content_1240.html
+++ b/common/lib/xmodule/xmodule/js/fixtures/problem_content_1240.html
@@ -1,0 +1,22 @@
+<h2 class="problem-header">Problem Header</h2>
+
+<div class='problem-progress'></div>
+
+<div class="problem">
+  <p>${_("Problem Content")}</p>
+
+  <div class="action">
+    <input type="hidden" name="problem_id" value="1">
+
+    <input type="text" name="input_example_1.Test" id="input_example_1.Test" value="" class="math" />
+    <span id="display_example_1"></span>
+    <span id="input_example_1_dynamath"></span>
+
+    <input class="check" type="button" value="Check">
+    <input class="reset" type="button" value="Reset">
+    <input class="save" type="button" value="Save">
+    <button class="show"><span class="show-label">Show Answer(s)</span> <span class="sr">(for question(s) above - adjacent to each field)</span></button>
+    <a href="/courseware/6.002_Spring_2012/${ explain }" class="new-page">Explanation</a>
+    <div class="submission_feedback"></div>
+  </div>
+</div>

--- a/common/lib/xmodule/xmodule/js/spec/capa/display_spec.coffee
+++ b/common/lib/xmodule/xmodule/js/spec/capa/display_spec.coffee
@@ -78,6 +78,19 @@ describe 'Problem', ->
         [@problem.updateMathML, @stubbedJax, $('#input_example_1').get(0)]
       ]
 
+  describe 'bind_with_custom_input_id', ->
+    beforeEach ->
+      spyOn window, 'update_schematics'
+      MathJax.Hub.getAllJax.andReturn [@stubbedJax]
+      @problem = new Problem($('.xblock-student_view'))
+      $(@).html readFixtures('problem_content_1240.html')
+
+    it 'bind the check button', ->
+      expect($('div.action input.check')).toHandleWith 'click', @problem.check_fd
+
+    it 'bind the show button', ->
+      expect($('div.action button.show')).toHandleWith 'click', @problem.show
+
   describe 'renderProgressState', ->
     beforeEach ->
       @problem = new Problem($('.xblock-student_view'))

--- a/common/lib/xmodule/xmodule/js/src/capa/display.coffee
+++ b/common/lib/xmodule/xmodule/js/src/capa/display.coffee
@@ -25,7 +25,7 @@ class @Problem
     window.update_schematics()
 
     problem_prefix = @element_id.replace(/problem_/,'')
-    @inputs = @$("[id^=input_#{problem_prefix}_]")
+    @inputs = @$("[id^='input_#{problem_prefix}_']")
     @$('div.action input:button').click @refreshAnswers
     @checkButton = @$('div.action input.check')
     @checkButtonCheckText = @checkButton.val()

--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -434,6 +434,18 @@ class LibraryContentDescriptor(LibraryContentFields, MakoModuleDescriptor, XmlDe
         validation = super(LibraryContentDescriptor, self).validate()
         if not isinstance(validation, StudioValidation):
             validation = StudioValidation.copy(validation)
+        library_tools = self.runtime.service(self, "library_tools")
+        if not (library_tools and library_tools.can_use_library_content(self)):
+            validation.set_summary(
+                StudioValidationMessage(
+                    StudioValidationMessage.ERROR,
+                    _(
+                        u"This course does not support content libraries. "
+                        u"Contact your system administrator for more information."
+                    )
+                )
+            )
+            return validation
         if not self.source_libraries:
             validation.set_summary(
                 StudioValidationMessage(

--- a/common/lib/xmodule/xmodule/library_tools.py
+++ b/common/lib/xmodule/xmodule/library_tools.py
@@ -96,6 +96,12 @@ class LibraryToolsService(object):
         assert isinstance(descriptor, CapaDescriptor)
         return capa_type in descriptor.problem_types
 
+    def can_use_library_content(self, block):
+        """
+        Determines whether a modulestore holding a course_id supports libraries.
+        """
+        return self.store.check_supports(block.location.course_key, 'copy_from_template')
+
     def update_children(self, dest_block, user_id, user_perms=None):
         """
         This method is to be used when any of the libraries that a LibraryContentModule

--- a/common/lib/xmodule/xmodule/modulestore/__init__.py
+++ b/common/lib/xmodule/xmodule/modulestore/__init__.py
@@ -441,6 +441,17 @@ class ModuleStoreAssetBase(object):
             ret_assets.append(new_asset)
         return ret_assets
 
+    # pylint: disable=unused-argument
+    def check_supports(self, course_key, method):
+        """
+        Verifies that a modulestore supports a particular method.
+
+        Some modulestores may differ based on the course_key, such
+        as mixed (since it has to find the underlying modulestore),
+        so it's required as part of the method signature.
+        """
+        return hasattr(self, method)
+
 
 class ModuleStoreAssetWriteInterface(ModuleStoreAssetBase):
     """

--- a/common/lib/xmodule/xmodule/modulestore/mixed.py
+++ b/common/lib/xmodule/xmodule/modulestore/mixed.py
@@ -850,6 +850,17 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
         store = self._verify_modulestore_support(xblock.location.course_key, 'has_changes')
         return store.has_changes(xblock)
 
+    def check_supports(self, course_key, method):
+        """
+        Verifies that the modulestore for a particular course supports a feature.
+        Returns True/false based on this.
+        """
+        try:
+            self._verify_modulestore_support(course_key, method)
+            return True
+        except NotImplementedError:
+            return False
+
     def _verify_modulestore_support(self, course_key, method):
         """
         Finds and returns the store that contains the course for the given location, and verifying

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
@@ -1513,6 +1513,10 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
                 user_id, parent_usage_key.course_key, block_type, block_id=block_id, fields=fields,
                 **kwargs)
 
+            # skip attach to parent if xblock has 'detached' tag
+            if 'detached' in xblock._class_tags:    # pylint: disable=protected-access
+                return xblock
+
             # don't version the structure as create_item handled that already.
             new_structure = self._lookup_course(xblock.location.course_key).structure
 

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_mixed_modulestore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_mixed_modulestore.py
@@ -840,6 +840,27 @@ class TestMixedModuleStore(CourseComparisonTest):
             published_courses = self.store.get_courses(remove_branch=True)
         self.assertEquals([c.id for c in draft_courses], [c.id for c in published_courses])
 
+    @ddt.data('draft', 'split')
+    def test_create_child_detached_tabs(self, default_ms):
+        """
+        test 'create_child' method with a detached category ('static_tab')
+        to check that new static tab is not a direct child of the course
+        """
+        self.initdb(default_ms)
+        mongo_course = self.store.get_course(self.course_locations[self.MONGO_COURSEID].course_key)
+        self.assertEqual(len(mongo_course.children), 1)
+
+        # create a static tab of the course
+        self.store.create_child(
+            self.user_id,
+            self.course.location,
+            'static_tab'
+        )
+
+        # now check that the course has same number of children
+        mongo_course = self.store.get_course(self.course_locations[self.MONGO_COURSEID].course_key)
+        self.assertEqual(len(mongo_course.children), 1)
+
     def test_xml_get_courses(self):
         """
         Test that the xml modulestore only loaded the courses from the maps.

--- a/common/lib/xmodule/xmodule/modulestore/xml_importer.py
+++ b/common/lib/xmodule/xmodule/modulestore/xml_importer.py
@@ -195,11 +195,18 @@ def import_from_xml(
         if target_course_id is not None:
             dest_course_id = target_course_id
         else:
+            # Note that dest_course_id will be in the format for the default modulestore.
             dest_course_id = store.make_course_key(course_key.org, course_key.course, course_key.run)
+
+        existing_course_id = store.has_course(dest_course_id, ignore_case=True)
+        # store.has_course will return the course_key in the format for the modulestore in which it was found.
+        # This may be different from dest_course_id, so correct to the format found.
+        if existing_course_id:
+            dest_course_id = existing_course_id
 
         runtime = None
         # Creates a new course if it doesn't already exist
-        if create_course_if_not_present and not store.has_course(dest_course_id, ignore_case=True):
+        if create_course_if_not_present and not existing_course_id:
             try:
                 new_course = store.create_course(dest_course_id.org, dest_course_id.course, dest_course_id.run, user_id)
                 runtime = new_course.runtime

--- a/common/lib/xmodule/xmodule/open_ended_grading_classes/combined_open_ended_modulev1.py
+++ b/common/lib/xmodule/xmodule/open_ended_grading_classes/combined_open_ended_modulev1.py
@@ -138,7 +138,7 @@ class CombinedOpenEndedV1Module():
         self.skip_basic_checks = instance_state.get('skip_spelling_checks', SKIP_BASIC_CHECKS) in TRUE_DICT
 
         if system.open_ended_grading_interface:
-            self.peer_gs = PeerGradingService(system.open_ended_grading_interface, system)
+            self.peer_gs = PeerGradingService(system.open_ended_grading_interface, system.render_template)
         else:
             self.peer_gs = MockPeerGradingService()
 
@@ -159,7 +159,7 @@ class CombinedOpenEndedV1Module():
             raise
         self.display_due_date = self.timeinfo.display_due_date
 
-        self.rubric_renderer = CombinedOpenEndedRubric(system, True)
+        self.rubric_renderer = CombinedOpenEndedRubric(system.render_template, True)
         rubric_string = stringify_children(definition['rubric'])
         self._max_score = self.rubric_renderer.check_if_rubric_is_parseable(rubric_string, location, MAX_SCORE_ALLOWED)
 

--- a/common/lib/xmodule/xmodule/open_ended_grading_classes/combined_open_ended_rubric.py
+++ b/common/lib/xmodule/xmodule/open_ended_grading_classes/combined_open_ended_rubric.py
@@ -40,10 +40,10 @@ class RubricParsingError(Exception):
 class CombinedOpenEndedRubric(object):
     TEMPLATE_DIR = "combinedopenended/openended"
 
-    def __init__(self, system, view_only=False):
+    def __init__(self, render_template, view_only=False):
         self.has_score = False
         self.view_only = view_only
-        self.system = system
+        self.render_template = render_template
 
     def render_rubric(self, rubric_xml, score_list=None):
         '''
@@ -70,7 +70,7 @@ class CombinedOpenEndedRubric(object):
             rubric_template = '{0}/open_ended_rubric.html'.format(self.TEMPLATE_DIR)
             if self.view_only:
                 rubric_template = '{0}/open_ended_view_only_rubric.html'.format(self.TEMPLATE_DIR)
-            html = self.system.render_template(
+            html = self.render_template(
                 rubric_template,
                 {
                     'categories': rubric_categories,
@@ -254,7 +254,7 @@ class CombinedOpenEndedRubric(object):
             else:
                 correct.append(.5)
 
-        html = self.system.render_template(
+        html = self.render_template(
             '{0}/open_ended_combined_rubric.html'.format(self.TEMPLATE_DIR),
             {
                 'categories': rubric_categories,

--- a/common/lib/xmodule/xmodule/open_ended_grading_classes/controller_query_service.py
+++ b/common/lib/xmodule/xmodule/open_ended_grading_classes/controller_query_service.py
@@ -13,8 +13,8 @@ class ControllerQueryService(GradingService):
 
     METRIC_NAME = 'edxapp.open_ended_grading.controller_query_service'
 
-    def __init__(self, config, system):
-        config['system'] = system
+    def __init__(self, config, render_template):
+        config['render_template'] = render_template
         super(ControllerQueryService, self).__init__(config)
         self.url = config['url'] + config['grading_controller']
         self.login_url = self.url + '/login/'
@@ -105,7 +105,7 @@ class MockControllerQueryService(object):
     Mock controller query service for testing
     """
 
-    def __init__(self, config, system):
+    def __init__(self, config, render_template):
         pass
 
     def check_for_eta(self, *args, **kwargs):

--- a/common/lib/xmodule/xmodule/open_ended_grading_classes/grading_service_module.py
+++ b/common/lib/xmodule/xmodule/open_ended_grading_classes/grading_service_module.py
@@ -27,7 +27,7 @@ class GradingService(object):
         self.username = config['username']
         self.password = config['password']
         self.session = requests.Session()
-        self.system = config['system']
+        self.render_template = config['render_template']
 
     def _login(self):
         """
@@ -142,7 +142,7 @@ class GradingService(object):
         try:
             if 'rubric' in response:
                 rubric = response['rubric']
-                rubric_renderer = CombinedOpenEndedRubric(self.system, view_only)
+                rubric_renderer = CombinedOpenEndedRubric(self.render_template, view_only)
                 rubric_dict = rubric_renderer.render_rubric(rubric)
                 success = rubric_dict['success']
                 rubric_html = rubric_dict['html']

--- a/common/lib/xmodule/xmodule/open_ended_grading_classes/open_ended_module.py
+++ b/common/lib/xmodule/xmodule/open_ended_grading_classes/open_ended_module.py
@@ -484,7 +484,7 @@ class OpenEndedModule(openendedchild.OpenEndedChild):
         feedback = self._convert_longform_feedback_to_html(response_items)
         rubric_scores = []
         if response_items['rubric_scores_complete'] is True:
-            rubric_renderer = CombinedOpenEndedRubric(system, True)
+            rubric_renderer = CombinedOpenEndedRubric(system.render_template, True)
             rubric_dict = rubric_renderer.render_rubric(response_items['rubric_xml'])
             success = rubric_dict['success']
             rubric_feedback = rubric_dict['html']

--- a/common/lib/xmodule/xmodule/open_ended_grading_classes/openendedchild.py
+++ b/common/lib/xmodule/xmodule/open_ended_grading_classes/openendedchild.py
@@ -145,9 +145,9 @@ class OpenEndedChild(object):
         # Used for progress / grading.  Currently get credit just for
         # completion (doesn't matter if you self-assessed correct/incorrect).
         if system.open_ended_grading_interface:
-            self.peer_gs = PeerGradingService(system.open_ended_grading_interface, system)
+            self.peer_gs = PeerGradingService(system.open_ended_grading_interface, system.render_template)
             self.controller_qs = controller_query_service.ControllerQueryService(
-                system.open_ended_grading_interface, system
+                system.open_ended_grading_interface, system.render_template
             )
         else:
             self.peer_gs = MockPeerGradingService()

--- a/common/lib/xmodule/xmodule/open_ended_grading_classes/peer_grading_service.py
+++ b/common/lib/xmodule/xmodule/open_ended_grading_classes/peer_grading_service.py
@@ -14,8 +14,8 @@ class PeerGradingService(GradingService):
 
     METRIC_NAME = 'edxapp.open_ended_grading.peer_grading_service'
 
-    def __init__(self, config, system):
-        config['system'] = system
+    def __init__(self, config, render_template):
+        config['render_template'] = render_template
         super(PeerGradingService, self).__init__(config)
         self.url = config['url'] + config['peer_grading']
         self.login_url = self.url + '/login/'
@@ -27,7 +27,6 @@ class PeerGradingService(GradingService):
         self.get_problem_list_url = self.url + '/get_problem_list/'
         self.get_notifications_url = self.url + '/get_notifications/'
         self.get_data_for_location_url = self.url + '/get_data_for_location/'
-        self.system = system
 
     def get_data_for_location(self, problem_location, student_id):
         if isinstance(problem_location, UsageKey):

--- a/common/lib/xmodule/xmodule/open_ended_grading_classes/self_assessment_module.py
+++ b/common/lib/xmodule/xmodule/open_ended_grading_classes/self_assessment_module.py
@@ -119,7 +119,7 @@ class SelfAssessmentModule(openendedchild.OpenEndedChild):
         if self.child_state == self.INITIAL:
             return ''
 
-        rubric_renderer = CombinedOpenEndedRubric(system, False)
+        rubric_renderer = CombinedOpenEndedRubric(system.render_template, False)
         rubric_dict = rubric_renderer.render_rubric(self.child_rubric)
         success = rubric_dict['success']
         rubric_html = rubric_dict['html']

--- a/common/lib/xmodule/xmodule/peer_grading_module.py
+++ b/common/lib/xmodule/xmodule/peer_grading_module.py
@@ -125,7 +125,7 @@ class PeerGradingModule(PeerGradingFields, XModule):
         # We need to set the location here so the child modules can use it.
         self.runtime.set('location', self.location)
         if (self.runtime.open_ended_grading_interface):
-            self.peer_gs = PeerGradingService(self.system.open_ended_grading_interface, self.system)
+            self.peer_gs = PeerGradingService(self.system.open_ended_grading_interface, self.system.render_template)
         else:
             self.peer_gs = MockPeerGradingService()
 
@@ -497,7 +497,7 @@ class PeerGradingModule(PeerGradingFields, XModule):
         try:
             response = self.peer_gs.save_calibration_essay(**data_dict)
             if 'actual_rubric' in response:
-                rubric_renderer = combined_open_ended_rubric.CombinedOpenEndedRubric(self.system, True)
+                rubric_renderer = combined_open_ended_rubric.CombinedOpenEndedRubric(self.system.render_template, True)
                 response['actual_rubric'] = rubric_renderer.render_rubric(response['actual_rubric'])['html']
             return response
         except GradingServiceError:

--- a/common/lib/xmodule/xmodule/tabs.py
+++ b/common/lib/xmodule/xmodule/tabs.py
@@ -558,7 +558,9 @@ class TextbookTabs(TextbookTabsBase):
             yield SingleTextbookTab(
                 name=textbook.title,
                 tab_id='textbook/{0}'.format(index),
-                link_func=lambda course, reverse_func: reverse_func('book', args=[course.id.to_deprecated_string(), index]),
+                link_func=lambda course, reverse_func, index=index: reverse_func(
+                    'book', args=[course.id.to_deprecated_string(), index]
+                ),
             )
 
 
@@ -578,7 +580,9 @@ class PDFTextbookTabs(TextbookTabsBase):
             yield SingleTextbookTab(
                 name=textbook['tab_title'],
                 tab_id='pdftextbook/{0}'.format(index),
-                link_func=lambda course, reverse_func: reverse_func('pdf_book', args=[course.id.to_deprecated_string(), index]),
+                link_func=lambda course, reverse_func, index=index: reverse_func(
+                    'pdf_book', args=[course.id.to_deprecated_string(), index]
+                ),
             )
 
 
@@ -598,7 +602,9 @@ class HtmlTextbookTabs(TextbookTabsBase):
             yield SingleTextbookTab(
                 name=textbook['tab_title'],
                 tab_id='htmltextbook/{0}'.format(index),
-                link_func=lambda course, reverse_func: reverse_func('html_book', args=[course.id.to_deprecated_string(), index]),
+                link_func=lambda course, reverse_func, index=index: reverse_func(
+                    'html_book', args=[course.id.to_deprecated_string(), index]
+                ),
             )
 
 

--- a/common/lib/xmodule/xmodule/tests/__init__.py
+++ b/common/lib/xmodule/xmodule/tests/__init__.py
@@ -94,7 +94,7 @@ def get_test_system(course_id=SlashSeparatedCourseKey('org', 'course', 'run')):
     """
     user = Mock(name='get_test_system.user', is_staff=False)
 
-    descriptor_system = get_test_descriptor_system(),
+    descriptor_system = get_test_descriptor_system()
 
     def get_module(descriptor):
         """Mocks module_system get_module function"""
@@ -107,7 +107,7 @@ def get_test_system(course_id=SlashSeparatedCourseKey('org', 'course', 'run')):
 
         # Descriptors can all share a single DescriptorSystem.
         # So, bind to the same one as the current descriptor.
-        module_system.descriptor_runtime = descriptor.runtime._descriptor_system
+        module_system.descriptor_runtime = descriptor._runtime  # pylint: disable=protected-access
 
         descriptor.bind_for_student(module_system, descriptor._field_data)
 

--- a/common/lib/xmodule/xmodule/tests/test_library_content.py
+++ b/common/lib/xmodule/xmodule/tests/test_library_content.py
@@ -54,14 +54,14 @@ class LibraryContentTest(MixedSplitTestCase):
         Bind a module (part of self.course) so we can access student-specific data.
         """
         module_system = get_test_system(course_id=self.course.location.course_key)
-        module_system.descriptor_runtime = module.runtime
+        module_system.descriptor_runtime = module.runtime._descriptor_system  # pylint: disable=protected-access
         module_system._services['library_tools'] = self.tools  # pylint: disable=protected-access
 
         def get_module(descriptor):
             """Mocks module_system get_module function"""
             sub_module_system = get_test_system(course_id=self.course.location.course_key)
             sub_module_system.get_module = get_module
-            sub_module_system.descriptor_runtime = descriptor.runtime
+            sub_module_system.descriptor_runtime = descriptor._runtime  # pylint: disable=protected-access
             descriptor.bind_for_student(sub_module_system, descriptor._field_data)  # pylint: disable=protected-access
             return descriptor
 

--- a/common/lib/xmodule/xmodule/tests/test_split_test_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_split_test_module.py
@@ -78,7 +78,7 @@ class SplitTestModuleTest(XModuleXmlImportTest, PartitionTestCase):
         self.course_sequence = self.course.get_children()[0]
         self.module_system = get_test_system()
 
-        self.module_system.descriptor_runtime = self.course.runtime._descriptor_system  # pylint: disable=protected-access
+        self.module_system.descriptor_runtime = self.course._runtime  # pylint: disable=protected-access
         self.course.runtime.export_fs = MemoryFS()
 
         self.partitions_service = StaticPartitionService(

--- a/common/lib/xmodule/xmodule/tests/test_vertical.py
+++ b/common/lib/xmodule/xmodule/tests/test_vertical.py
@@ -27,7 +27,7 @@ class BaseVerticalModuleTest(XModuleXmlImportTest):
         course_seq = self.course.get_children()[0]
         self.module_system = get_test_system()
 
-        self.module_system.descriptor_runtime = self.course.runtime._descriptor_system  # pylint: disable=protected-access
+        self.module_system.descriptor_runtime = self.course._runtime  # pylint: disable=protected-access
         self.course.runtime.export_fs = MemoryFS()
 
         self.vertical = course_seq.get_children()[0]

--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -3,6 +3,7 @@ import os
 import sys
 import yaml
 
+from contracts import contract, new_contract
 from functools import partial
 from lxml import etree
 from collections import namedtuple
@@ -1307,6 +1308,9 @@ class DescriptorSystem(MetricsMixin, ConfigurableFragmentWrapper, Runtime):  # p
         pass
 
 
+new_contract('DescriptorSystem', DescriptorSystem)
+
+
 class XMLParsingSystem(DescriptorSystem):
     def __init__(self, process_xml, **kwargs):
         """
@@ -1427,6 +1431,8 @@ class ModuleSystem(MetricsMixin, ConfigurableFragmentWrapper, Runtime):  # pylin
     Note that these functions can be closures over e.g. a django request
     and user, or other environment-specific info.
     """
+
+    @contract(descriptor_runtime='DescriptorSystem')
     def __init__(
             self, static_url, track_function, get_module, render_template,
             replace_urls, descriptor_runtime, user=None, filestore=None,

--- a/common/test/acceptance/fixtures/course.py
+++ b/common/test/acceptance/fixtures/course.py
@@ -137,6 +137,7 @@ class CourseFixture(XBlockContainerFixture):
         self._updates = []
         self._handouts = []
         self._assets = []
+        self._textbooks = []
         self._advanced_settings = {}
         self._course_key = None
 
@@ -165,6 +166,12 @@ class CourseFixture(XBlockContainerFixture):
         """
         self._assets.extend(asset_name)
 
+    def add_textbook(self, book_title, chapters):
+        """
+        Add textbook to the list of textbooks to be added when the install method is called.
+        """
+        self._textbooks.append({"chapters": chapters, "tab_title": book_title})
+
     def add_advanced_settings(self, settings):
         """
         Adds advanced settings to be set on the course when the install method is called.
@@ -181,6 +188,7 @@ class CourseFixture(XBlockContainerFixture):
         self._create_course()
         self._install_course_updates()
         self._install_course_handouts()
+        self._install_course_textbooks()
         self._configure_course()
         self._upload_assets()
         self._add_advanced_settings()
@@ -351,6 +359,21 @@ class CourseFixture(XBlockContainerFixture):
             if not upload_response.ok:
                 raise FixtureError('Could not upload {asset_name} with {url}. Status code: {code}'.format(
                     asset_name=asset_name, url=url, code=upload_response.status_code))
+
+    def _install_course_textbooks(self):
+        """
+        Add textbooks to the course, if any are configured.
+        """
+        url = STUDIO_BASE_URL + '/textbooks/' + self._course_key
+
+        for book in self._textbooks:
+            payload = json.dumps(book)
+            response = self.session.post(url, headers=self.headers, data=payload)
+
+            if not response.ok:
+                raise FixtureError(
+                    "Could not add book to course: {0} with {1}.  Status was {2}".format(
+                        book, url, response.status_code))
 
     def _add_advanced_settings(self):
         """

--- a/common/test/acceptance/tests/lms/test_lms.py
+++ b/common/test/acceptance/tests/lms/test_lms.py
@@ -541,6 +541,46 @@ class HighLevelTabTest(UniqueCourseTest):
             self.assertIn(expected, actual_items)
 
 
+class PDFTextBooksTabTest(UniqueCourseTest):
+    """
+    Tests that verify each of the textbook tabs available within a course.
+    """
+
+    def setUp(self):
+        """
+        Initialize pages and install a course fixture.
+        """
+        super(PDFTextBooksTabTest, self).setUp()
+
+        self.course_info_page = CourseInfoPage(self.browser, self.course_id)
+        self.tab_nav = TabNavPage(self.browser)
+
+        # Install a course with TextBooks
+        course_fix = CourseFixture(
+            self.course_info['org'], self.course_info['number'],
+            self.course_info['run'], self.course_info['display_name']
+        )
+
+        # Add PDF textbooks to course fixture.
+        for i in range(1, 3):
+            course_fix.add_textbook("PDF Book {}".format(i), [{"title": "Chapter Of Book {}".format(i), "url": ""}])
+
+        course_fix.install()
+
+        # Auto-auth register for the course
+        AutoAuthPage(self.browser, course_id=self.course_id).visit()
+
+    def test_verify_textbook_tabs(self):
+        """
+        Test multiple pdf textbooks loads correctly in lms.
+        """
+        self.course_info_page.visit()
+
+        # Verify each PDF textbook tab by visiting, it will fail if correct tab is not loaded.
+        for i in range(1, 3):
+            self.tab_nav.go_to_tab("PDF Book {}".format(i))
+
+
 class VideoTest(UniqueCourseTest):
     """
     Navigate to a video in the courseware and play it.

--- a/docs/config.ini
+++ b/docs/config.ini
@@ -1,13 +1,13 @@
 # below are the server-wide settings for documentation
 [help_settings]
-url_base = http://edx.readthedocs.org/projects/edx-partner-course-staff
-version = latest
+url_base = http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course
+version = named-release-birch
 
 
 # below are the pdf settings for the pdf file
 [pdf_settings]
-pdf_base = https://media.readthedocs.org/pdf/edx-partner-course-staff
-pdf_file = edx-partner-course-staff.pdf
+pdf_base = https://media.readthedocs.org/pdf/open-edx-building-and-running-a-course
+pdf_file = open-edx-building-and-running-a-course.pdf
 
 
 # below are the sub-paths to the documentation for the various pages

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -287,15 +287,6 @@ def get_course_info_section(request, course, section_key):
     """
     info_module = get_course_info_section_module(request, course, section_key)
 
-    cur_lang_code = UserPreference.get_preference(request.user, LANGUAGE_KEY) #User preferred language
-    if cur_lang_code is None:
-       cur_lang_code = settings.LANGUAGE_CODE
-    #print cur_lang_code
-
-
-    #correct_format = formats.get_format("SHORT_DATE_FORMAT", cur_lang_code)
-    #print correct_format
-
     html = ''
     if info_module is not None:
         try:

--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -647,7 +647,7 @@ def get_module_system_for_user(user, field_data_cache,
             'user': DjangoXBlockUserService(user),
         },
         get_user_role=lambda: get_user_role(user, course_id),
-        descriptor_runtime=descriptor.runtime,
+        descriptor_runtime=descriptor._runtime,  # pylint: disable=protected-access
         rebind_noauth_module_to_user=rebind_noauth_module_to_user,
         user_location=user_location,
         request_token=request_token,

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -41,7 +41,7 @@ from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import ItemFactory, CourseFactory, check_mongo_calls
-from xmodule.x_module import XModuleDescriptor, XModule, STUDENT_VIEW
+from xmodule.x_module import XModuleDescriptor, XModule, STUDENT_VIEW, CombinedSystem
 
 TEST_DATA_DIR = settings.COMMON_TEST_DATA_ROOT
 
@@ -903,13 +903,16 @@ class TestAnonymousStudentId(ModuleStoreTestCase, LoginEnrollmentTestCase):
             _field_data=Mock(spec=FieldData),
             location=location,
             static_asset_path=None,
-            runtime=Mock(
+            _runtime=Mock(
                 spec=Runtime,
                 resources_fs=None,
-                mixologist=Mock(_mixins=())
+                mixologist=Mock(_mixins=(), name='mixologist'),
+                name='runtime',
             ),
             scope_ids=Mock(spec=ScopeIds),
+            name='descriptor'
         )
+        descriptor.runtime = CombinedSystem(descriptor._runtime, None)  # pylint: disable=protected-access
         # Use the xblock_class's bind_for_student method
         descriptor.bind_for_student = partial(xblock_class.bind_for_student, descriptor)
 
@@ -919,10 +922,10 @@ class TestAnonymousStudentId(ModuleStoreTestCase, LoginEnrollmentTestCase):
         return render.get_module_for_descriptor_internal(
             user=self.user,
             descriptor=descriptor,
-            field_data_cache=Mock(spec=FieldDataCache),
+            field_data_cache=Mock(spec=FieldDataCache, name='field_data_cache'),
             course_id=course_id,
-            track_function=Mock(),  # Track Function
-            xqueue_callback_url_prefix=Mock(),  # XQueue Callback Url Prefix
+            track_function=Mock(name='track_function'),  # Track Function
+            xqueue_callback_url_prefix=Mock(name='xqueue_callback_url_prefix'),  # XQueue Callback Url Prefix
             request_token='request_token',
         ).xmodule_runtime.anonymous_student_id
 

--- a/lms/djangoapps/courseware/tests/test_tabs.py
+++ b/lms/djangoapps/courseware/tests/test_tabs.py
@@ -11,12 +11,12 @@ from opaque_keys.edx.locations import SlashSeparatedCourseKey
 
 from courseware.courses import get_course_by_id
 from courseware.tests.helpers import get_request_for_user, LoginEnrollmentTestCase
+from xmodule import tabs
 from xmodule.modulestore.tests.django_utils import (
     TEST_DATA_MIXED_TOY_MODULESTORE, TEST_DATA_MIXED_CLOSED_MODULESTORE
 )
 from courseware.views import get_static_tab_contents, static_tab
 from student.tests.factories import UserFactory
-from xmodule.tabs import CourseTabList
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
@@ -59,7 +59,7 @@ class StaticTabDateTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase):
     def test_get_static_tab_contents(self):
         course = get_course_by_id(self.toy_course_key)
         request = get_request_for_user(UserFactory.create())
-        tab = CourseTabList.get_tab_by_slug(course.tabs, 'resources')
+        tab = tabs.CourseTabList.get_tab_by_slug(course.tabs, 'resources')
 
         # Test render works okay
         tab_content = get_static_tab_contents(request, course, tab)
@@ -170,3 +170,55 @@ class EntranceExamsTabsTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase):
             self.assertEqual(course_tab_list[0]['tab_id'], 'courseware')
             self.assertEqual(course_tab_list[0]['name'], 'Entrance Exam')
             self.assertEqual(course_tab_list[1]['tab_id'], 'instructor')
+
+
+@override_settings(MODULESTORE=TEST_DATA_MIXED_TOY_MODULESTORE)
+class TextBookTabsTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase):
+    """
+    Validate tab behavior when dealing with textbooks.
+    """
+
+    def setUp(self):
+        self.course = CourseFactory.create()
+        self.set_up_books(2)
+        self.course.tabs = [
+            tabs.CoursewareTab(),
+            tabs.CourseInfoTab(),
+            tabs.TextbookTabs(),
+            tabs.PDFTextbookTabs(),
+            tabs.HtmlTextbookTabs(),
+        ]
+        self.setup_user()
+        self.enroll(self.course)
+        self.num_textbook_tabs = sum(1 for tab in self.course.tabs if isinstance(tab, tabs.TextbookTabsBase))
+        self.num_textbooks = self.num_textbook_tabs * len(self.books)
+
+    def set_up_books(self, num_books):
+        """Initializes the textbooks in the course and adds the given number of books to each textbook"""
+        self.books = [MagicMock() for _ in range(num_books)]
+        for book_index, book in enumerate(self.books):
+            book.title = 'Book{0}'.format(book_index)
+        self.course.textbooks = self.books
+        self.course.pdf_textbooks = self.books
+        self.course.html_textbooks = self.books
+
+    def test_pdf_textbook_tabs(self):
+        """
+        Test that all textbooks tab links generating correctly.
+        """
+        type_to_reverse_name = {'textbook': 'book', 'pdftextbook': 'pdf_book', 'htmltextbook': 'html_book'}
+
+        course_tab_list = get_course_tab_list(self.course, self.user)
+        num_of_textbooks_found = 0
+        for tab in course_tab_list:
+            # Verify links of all textbook type tabs.
+            if isinstance(tab, tabs.SingleTextbookTab):
+                book_type, book_index = tab.tab_id.split("/", 1)
+                expected_link = reverse(
+                    type_to_reverse_name[book_type],
+                    args=[self.course.id.to_deprecated_string(), book_index]
+                )
+                tab_link = tab.link_func(self.course, reverse)
+                self.assertEqual(tab_link, expected_link)
+                num_of_textbooks_found += 1
+        self.assertEqual(num_of_textbooks_found, self.num_textbooks)

--- a/lms/djangoapps/instructor_task/tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tasks_helper.py
@@ -20,6 +20,7 @@ from pytz import UTC
 from track.views import task_track
 from util.file import course_filename_prefix_generator, UniversalNewlineIterator
 from xmodule.modulestore.django import modulestore
+from xmodule.split_test_module import get_split_user_partitions
 
 from courseware.courses import get_course_by_id
 from courseware.grades import iterate_grades_for
@@ -553,9 +554,8 @@ def upload_grades_csv(_xmodule_instance_args, _entry_id, course_id, _task_input,
     course = get_course_by_id(course_id)
     cohorts_header = ['Cohort Name'] if course.is_cohorted else []
 
-    partition_service = LmsPartitionService(user=None, course_id=course_id)
-    partitions = partition_service.course_partitions
-    group_configs_header = ['Experiment Group ({})'.format(partition.name) for partition in partitions]
+    experiment_partitions = get_split_user_partitions(course.user_partitions)
+    group_configs_header = [u'Experiment Group ({})'.format(partition.name) for partition in experiment_partitions]
 
     # Loop over all our students and build our CSV lists in memory
     header = None
@@ -589,7 +589,7 @@ def upload_grades_csv(_xmodule_instance_args, _entry_id, course_id, _task_input,
                 cohorts_group_name.append(group.name if group else '')
 
             group_configs_group_names = []
-            for partition in partitions:
+            for partition in experiment_partitions:
                 group = LmsPartitionService(student, course_id).get_group(partition, assign=False)
                 group_configs_group_names.append(group.name if group else '')
 

--- a/lms/djangoapps/instructor_task/tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tasks_helper.py
@@ -555,7 +555,7 @@ def upload_grades_csv(_xmodule_instance_args, _entry_id, course_id, _task_input,
 
     partition_service = LmsPartitionService(user=None, course_id=course_id)
     partitions = partition_service.course_partitions
-    group_configs_header = ['Group Configuration Group Name ({})'.format(partition.name) for partition in partitions]
+    group_configs_header = ['Experiment Group ({})'.format(partition.name) for partition in partitions]
 
     # Loop over all our students and build our CSV lists in memory
     header = None

--- a/lms/djangoapps/instructor_task/tests/test_integration.py
+++ b/lms/djangoapps/instructor_task/tests/test_integration.py
@@ -622,7 +622,7 @@ class TestGradeReportConditionalContent(TestReportMixin, TestIntegrationTask):
 
         def user_partition_group(user):
             """Return a dict having single key with value equals to students group in partition"""
-            group_config_hdr_tpl = 'Group Configuration Group Name ({})'
+            group_config_hdr_tpl = 'Experiment Group ({})'
             return {
                 group_config_hdr_tpl.format(self.partition.name): self.partition.scheme.get_group_for_user(   # pylint: disable=E1101
                     self.course.id, user, self.partition, track_function=None

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -16,7 +16,10 @@ from student.tests.factories import UserFactory
 from student.models import CourseEnrollment
 from xmodule.partitions.partitions import Group, UserPartition
 
+from openedx.core.djangoapps.course_groups.models import CourseUserGroupPartitionGroup
 from openedx.core.djangoapps.course_groups.tests.helpers import CohortFactory
+import openedx.core.djangoapps.user_api.api.course_tag as course_tag_api
+from openedx.core.djangoapps.user_api.partition_schemes import RandomUserPartitionScheme
 from instructor_task.models import ReportStore
 from instructor_task.tasks_helper import cohort_students_and_upload, upload_grades_csv, upload_students_csv
 from instructor_task.tests.test_base import InstructorTaskCourseTestCase, TestReportMixin
@@ -63,11 +66,10 @@ class TestInstructorGradeReport(TestReportMixin, InstructorTaskCourseTestCase):
         report_store = ReportStore.from_config()
         self.assertTrue(any('grade_report_err' in item[0] for item in report_store.links_for(self.course.id)))
 
-    def _verify_cohort_data(self, course_id, expected_cohort_groups):
+    def _verify_cell_data_for_user(self, username, course_id, column_header, expected_cell_content):
         """
-        Verify cohort data.
+        Verify cell data in the grades CSV for a particular user.
         """
-        cohort_groups_in_csv = []
         with patch('instructor_task.tasks_helper._get_current_task'):
             result = upload_grades_csv(None, None, course_id, None, 'graded')
             self.assertDictContainsSubset({'attempted': 2, 'succeeded': 2, 'failed': 0}, result)
@@ -75,9 +77,8 @@ class TestInstructorGradeReport(TestReportMixin, InstructorTaskCourseTestCase):
             report_csv_filename = report_store.links_for(course_id)[0][0]
             with open(report_store.path_to(course_id, report_csv_filename)) as csv_file:
                 for row in unicodecsv.DictReader(csv_file):
-                    cohort_groups_in_csv.append(row['Cohort Name'])
-
-        self.assertEqual(cohort_groups_in_csv, expected_cohort_groups)
+                    if row.get('username') == username:
+                        self.assertEqual(row[column_header], expected_cell_content)
 
     def test_cohort_data_in_grading(self):
         """
@@ -86,20 +87,22 @@ class TestInstructorGradeReport(TestReportMixin, InstructorTaskCourseTestCase):
         cohort_groups = ['cohort 1', 'cohort 2']
         course = CourseFactory.create(cohort_config={'cohorted': True, 'auto_cohort': True,
                                                      'auto_cohort_groups': cohort_groups})
-        for _ in range(2):
-            CourseEnrollment.enroll(UserFactory.create(), course.id)
+
+        user_1 = 'user_1'
+        user_2 = 'user_2'
+        CourseEnrollment.enroll(UserFactory.create(username=user_1), course.id)
+        CourseEnrollment.enroll(UserFactory.create(username=user_2), course.id)
 
         # In auto cohorting a group will be assigned to a user only when user visits a problem
         # In grading calculation we only add a group in csv if group is already assigned to
         # user rather than creating a group automatically at runtime
-        expected_groups = ['', '']
-        self._verify_cohort_data(course.id, expected_groups)
+        self._verify_cell_data_for_user(user_1, course.id, 'Cohort Name', '')
+        self._verify_cell_data_for_user(user_2, course.id, 'Cohort Name', '')
 
     def test_unicode_cohort_data_in_grading(self):
         """
         Test that cohorts can contain unicode characters.
         """
-        cohort_groups = [u'ÞrÖfessÖr X', u'MàgnëtÖ']
         course = CourseFactory.create(cohort_config={'cohorted': True})
 
         # Create users and manually assign cohorts
@@ -107,12 +110,15 @@ class TestInstructorGradeReport(TestReportMixin, InstructorTaskCourseTestCase):
         user2 = UserFactory.create(username='user2')
         CourseEnrollment.enroll(user1, course.id)
         CourseEnrollment.enroll(user2, course.id)
-        cohort1 = CohortFactory(course_id=course.id, name=u'ÞrÖfessÖr X')
-        cohort2 = CohortFactory(course_id=course.id, name=u'MàgnëtÖ')
+        professor_x = u'ÞrÖfessÖr X'
+        magneto = u'MàgnëtÖ'
+        cohort1 = CohortFactory(course_id=course.id, name=professor_x)
+        cohort2 = CohortFactory(course_id=course.id, name=magneto)
         cohort1.users.add(user1)
         cohort2.users.add(user2)
 
-        self._verify_cohort_data(course.id, cohort_groups)
+        self._verify_cell_data_for_user(user1.username, course.id, 'Cohort Name', professor_x)
+        self._verify_cell_data_for_user(user2.username, course.id, 'Cohort Name', magneto)
 
     def test_unicode_user_partitions(self):
         """
@@ -138,6 +144,100 @@ class TestInstructorGradeReport(TestReportMixin, InstructorTaskCourseTestCase):
 
         _groups = [group.name for group in self.course.user_partitions[0].groups]
         self.assertEqual(_groups, user_groups)
+
+    def test_cohort_scheme_partition(self):
+        """
+        Test that cohort-schemed user partitions are ignored in the
+        grades export.
+        """
+        # Set up a course with 'cohort' and 'random' user partitions.
+        cohort_scheme_partition = UserPartition(
+            0,
+            'Cohort-schemed Group Configuration',
+            'Group Configuration based on Cohorts',
+            [Group(0, 'Group A'), Group(1, 'Group B')],
+            scheme_id='cohort'
+        )
+        experiment_group_a = Group(2, u'Expériment Group A')
+        experiment_group_b = Group(3, u'Expériment Group B')
+        experiment_partition = UserPartition(
+            1,
+            u'Content Expériment Configuration',
+            u'Group Configuration for Content Expériments',
+            [experiment_group_a, experiment_group_b],
+            scheme_id='random'
+        )
+        course = CourseFactory.create(
+            cohort_config={'cohorted': True},
+            user_partitions=[cohort_scheme_partition, experiment_partition]
+        )
+
+        # Create user_a and user_b which are enrolled in the course
+        # and assigned to experiment_group_a and experiment_group_b,
+        # respectively.
+        user_a = UserFactory.create(username='user_a')
+        user_b = UserFactory.create(username='user_b')
+        CourseEnrollment.enroll(user_a, course.id)
+        CourseEnrollment.enroll(user_b, course.id)
+        course_tag_api.set_course_tag(
+            user_a,
+            course.id,
+            RandomUserPartitionScheme.key_for_partition(experiment_partition),
+            experiment_group_a.id
+        )
+        course_tag_api.set_course_tag(
+            user_b,
+            course.id,
+            RandomUserPartitionScheme.key_for_partition(experiment_partition),
+            experiment_group_b.id
+        )
+
+        # Assign user_a to a group in the 'cohort'-schemed user
+        # partition (by way of a cohort) to verify that the user
+        # partition group does not show up in the "Experiment Group"
+        # cell.
+        cohort_a = CohortFactory.create(course_id=course.id, name=u'Cohørt A', users=[user_a])
+        CourseUserGroupPartitionGroup(
+            course_user_group=cohort_a,
+            partition_id=cohort_scheme_partition.id,
+            group_id=cohort_scheme_partition.groups[0].id
+        ).save()
+
+        # Verify that we see user_a and user_b in their respective
+        # content experiment groups, and that we do not see any
+        # content groups.
+        experiment_group_message = u'Experiment Group ({content_experiment})'
+        self._verify_cell_data_for_user(
+            user_a.username,
+            course.id,
+            experiment_group_message.format(
+                content_experiment=experiment_partition.name
+            ),
+            experiment_group_a.name
+        )
+        self._verify_cell_data_for_user(
+            user_b.username,
+            course.id,
+            experiment_group_message.format(
+                content_experiment=experiment_partition.name
+            ),
+            experiment_group_b.name
+        )
+
+        # Make sure cohort info is correct.
+        cohort_name_header = 'Cohort Name'
+        self._verify_cell_data_for_user(
+            user_a.username,
+            course.id,
+            cohort_name_header,
+            cohort_a.name
+        )
+        self._verify_cell_data_for_user(
+            user_b.username,
+            course.id,
+            cohort_name_header,
+            ''
+        )
 
     @patch('instructor_task.tasks_helper._get_current_task')
     @patch('instructor_task.tasks_helper.iterate_grades_for')

--- a/lms/djangoapps/open_ended_grading/open_ended_notifications.py
+++ b/lms/djangoapps/open_ended_grading/open_ended_notifications.py
@@ -10,7 +10,6 @@ from xmodule.open_ended_grading_classes.controller_query_service import Controll
 from xmodule.modulestore.django import ModuleI18nService
 
 from courseware.access import has_access
-from lms.djangoapps.lms_xblock.runtime import LmsModuleSystem
 from edxmako.shortcuts import render_to_string
 from student.models import unique_id_for_user
 from util.cache import cache
@@ -66,17 +65,7 @@ def staff_grading_notifications(course, user):
 
 
 def peer_grading_notifications(course, user):
-    system = LmsModuleSystem(
-        track_function=None,
-        get_module=None,
-        render_template=render_to_string,
-        replace_urls=None,
-        descriptor_runtime=None,
-        services={
-            'i18n': ModuleI18nService(),
-        },
-    )
-    peer_gs = peer_grading_service.PeerGradingService(settings.OPEN_ENDED_GRADING_INTERFACE, system)
+    peer_gs = peer_grading_service.PeerGradingService(settings.OPEN_ENDED_GRADING_INTERFACE, render_to_string)
     pending_grading = False
     img_path = ""
     course_id = course.id
@@ -128,20 +117,8 @@ def combined_notifications(course, user):
     if not user.is_authenticated():
         return notification_dict
 
-    #Define a mock modulesystem
-    system = LmsModuleSystem(
-        static_url="/static",
-        track_function=None,
-        get_module=None,
-        render_template=render_to_string,
-        replace_urls=None,
-        descriptor_runtime=None,
-        services={
-            'i18n': ModuleI18nService(),
-        },
-    )
     #Initialize controller query service using our mock system
-    controller_qs = ControllerQueryService(settings.OPEN_ENDED_GRADING_INTERFACE, system)
+    controller_qs = ControllerQueryService(settings.OPEN_ENDED_GRADING_INTERFACE, render_to_string)
     student_id = unique_id_for_user(user)
     user_is_staff = has_access(user, 'staff', course)
     course_id = course.id

--- a/lms/djangoapps/open_ended_grading/staff_grading_service.py
+++ b/lms/djangoapps/open_ended_grading/staff_grading_service.py
@@ -14,7 +14,6 @@ from xmodule.open_ended_grading_classes.grading_service_module import GradingSer
 from xmodule.modulestore.django import ModuleI18nService
 
 from courseware.access import has_access
-from lms.djangoapps.lms_xblock.runtime import LmsModuleSystem
 from edxmako.shortcuts import render_to_string
 from student.models import unique_id_for_user
 
@@ -90,17 +89,7 @@ class StaffGradingService(GradingService):
     METRIC_NAME = 'edxapp.open_ended_grading.staff_grading_service'
 
     def __init__(self, config):
-        config['system'] = LmsModuleSystem(
-            static_url='/static',
-            track_function=None,
-            get_module=None,
-            render_template=render_to_string,
-            replace_urls=None,
-            descriptor_runtime=None,
-            services={
-                'i18n': ModuleI18nService(),
-            },
-        )
+        config['render_template'] = render_to_string
         super(StaffGradingService, self).__init__(config)
         self.url = config['url'] + config['staff_grading']
         self.login_url = self.url + '/login/'

--- a/lms/djangoapps/open_ended_grading/tests.py
+++ b/lms/djangoapps/open_ended_grading/tests.py
@@ -469,7 +469,7 @@ class TestPanel(ModuleStoreTestCase):
         Mock(
             return_value=controller_query_service.MockControllerQueryService(
                 settings.OPEN_ENDED_GRADING_INTERFACE,
-                utils.SYSTEM
+                utils.render_to_string
             )
         )
     )

--- a/lms/djangoapps/open_ended_grading/utils.py
+++ b/lms/djangoapps/open_ended_grading/utils.py
@@ -9,7 +9,6 @@ from xmodule.open_ended_grading_classes.grading_service_module import GradingSer
 from django.utils.translation import ugettext as _
 from django.conf import settings
 
-from lms.djangoapps.lms_xblock.runtime import LmsModuleSystem
 from edxmako.shortcuts import render_to_string
 
 
@@ -25,18 +24,6 @@ GRADER_DISPLAY_NAMES = {
 
 STUDENT_ERROR_MESSAGE = _("Error occurred while contacting the grading service.  Please notify course staff.")
 STAFF_ERROR_MESSAGE = _("Error occurred while contacting the grading service.  Please notify your edX point of contact.")
-
-SYSTEM = LmsModuleSystem(
-    static_url='/static',
-    track_function=None,
-    get_module=None,
-    render_template=render_to_string,
-    replace_urls=None,
-    descriptor_runtime=None,
-    services={
-        'i18n': ModuleI18nService(),
-    },
-)
 
 
 def generate_problem_url(problem_url_parts, base_course_url):
@@ -85,7 +72,7 @@ def create_controller_query_service():
     """
     Return an instance of a service that can query edX ORA.
     """
-    return ControllerQueryService(settings.OPEN_ENDED_GRADING_INTERFACE, SYSTEM)
+    return ControllerQueryService(settings.OPEN_ENDED_GRADING_INTERFACE, render_to_string)
 
 
 class StudentProblemList(object):

--- a/lms/djangoapps/shoppingcart/tests/test_views.py
+++ b/lms/djangoapps/shoppingcart/tests/test_views.py
@@ -551,6 +551,33 @@ class ShoppingCartViewsTests(ModuleStoreTestCase):
         self.assertEqual(resp.status_code, 400)
         self.assertIn("Oops! The code '{0}' you entered is either invalid or expired".format(self.reg_code), resp.content)
 
+    def test_upgrade_from_valid_reg_code(self):
+        """Use a valid registration code to upgrade from honor to verified mode. """
+        # Ensure the course has a verified mode
+        course_key = self.course_key.to_deprecated_string()
+        self._add_course_mode(mode_slug='verified')
+        self.add_reg_code(course_key, mode_slug='verified')
+
+        # Enroll as honor in the course with the current user.
+        CourseEnrollment.enroll(self.user, self.course_key)
+        self.login_user()
+        current_enrollment, __ = CourseEnrollment.enrollment_mode_for_user(self.user, self.course_key)
+        self.assertEquals('honor', current_enrollment)
+
+        redeem_url = reverse('register_code_redemption', args=[self.reg_code])
+        response = self.client.get(redeem_url)
+        self.assertEquals(response.status_code, 200)
+        # check button text
+        self.assertTrue('Activate Course Enrollment' in response.content)
+
+        #now activate the user by enrolling him/her to the course
+        response = self.client.post(redeem_url)
+        self.assertEquals(response.status_code, 200)
+
+        # Once upgraded, should be "verified"
+        current_enrollment, __ = CourseEnrollment.enrollment_mode_for_user(self.user, self.course_key)
+        self.assertEquals('verified', current_enrollment)
+
     @patch('shoppingcart.views.log.debug')
     def test_non_existing_coupon_redemption_on_removing_item(self, debug_log):
 

--- a/lms/static/sass/shared/_footer.scss
+++ b/lms/static/sass/shared/_footer.scss
@@ -20,6 +20,11 @@
 
     p, ol, ul {
       font-family: $sans-serif;
+
+      // override needed for poorly scoped font-family styling on p a:link {}
+      a {
+        font-family: $sans-serif;
+      }
     }
 
     a {
@@ -27,7 +32,6 @@
       border-bottom: none;
       color: $link-color;
       text-decoration: none !important;
-      font-family: $sans-serif;
 
       &:hover, &:focus, &:active {
         border-bottom: 1px dotted $link-color;
@@ -326,6 +330,12 @@ $edx-footer-bg-color: rgb(252,252,252);
     p {
       // NOTE: needed for poor LMS span styling
       color: inherit;
+    }
+
+    a {
+      @extend %edx-footer-link;
+      display: inline-block;
+      margin-bottom: ($edx-footer-spacing/2);
     }
   }
 

--- a/lms/templates/footer-edx-new.html
+++ b/lms/templates/footer-edx-new.html
@@ -30,12 +30,17 @@
       </div>
 
       <div class="footer-about-copyright">
-        ## Translators: '&copy;' is an HTML character code for the copyright symbol. Please don't remove or change it.
-        <p>${_("&copy; {copyright_year} {platform_name}, some rights reserved").format(
-          platform_name=settings.PLATFORM_NAME,
-          copyright_year=settings.COPYRIGHT_YEAR
-        )}
-      </p>
+	## Using "edX Inc." explicitly here for copyright purposes (settings.PLATFORM_NAME is just "edX", and this footer is only used on edx.org)
+	<p>&copy; ${settings.COPYRIGHT_YEAR} edX Inc.</p>
+
+	## Site operators: Please do not remove this paragraph! This attributes back to edX and makes your acknowledgement of edX's trademarks clear.
+	<p>
+	  ## Translators: 'EdX', 'edX', and 'Open edX' are trademarks of 'edX Inc.'. Please do not translate any of these trademarks and company names.
+	  ${_("EdX, Open edX, and the edX and Open edX logos are registered trademarks or trademarks of {link_start}edX Inc.{link_end}").format(
+	      link_start=u"<a href='https://www.edx.org/'>",
+	      link_end=u"</a>"
+	  )}
+	</p>
       </div>
 
       <div class="footer-about-links">

--- a/lms/templates/footer-edx-new.html
+++ b/lms/templates/footer-edx-new.html
@@ -30,17 +30,17 @@
       </div>
 
       <div class="footer-about-copyright">
-	## Using "edX Inc." explicitly here for copyright purposes (settings.PLATFORM_NAME is just "edX", and this footer is only used on edx.org)
-	<p>&copy; ${settings.COPYRIGHT_YEAR} edX Inc.</p>
+      	## Using "edX Inc." explicitly here for copyright purposes (settings.PLATFORM_NAME is just "edX", and this footer is only used on edx.org)
+      	<p>&copy; ${settings.COPYRIGHT_YEAR} edX Inc.</p>
 
-	## Site operators: Please do not remove this paragraph! This attributes back to edX and makes your acknowledgement of edX's trademarks clear.
-	<p>
-	  ## Translators: 'EdX', 'edX', and 'Open edX' are trademarks of 'edX Inc.'. Please do not translate any of these trademarks and company names.
-	  ${_("EdX, Open edX, and the edX and Open edX logos are registered trademarks or trademarks of {link_start}edX Inc.{link_end}").format(
-	      link_start=u"<a href='https://www.edx.org/'>",
-	      link_end=u"</a>"
-	  )}
-	</p>
+      	## Site operators: Please do not remove this paragraph! This attributes back to edX and makes your acknowledgement of edX's trademarks clear.
+      	<p>
+      	  ## Translators: 'EdX', 'edX', and 'Open edX' are trademarks of 'edX Inc.'. Please do not translate any of these trademarks and company names.
+      	  ${_("EdX, Open edX, and the edX and Open edX logos are registered trademarks or trademarks of {link_start}edX Inc.{link_end}").format(
+      	      link_start=u"<a href='https://www.edx.org/'><span class='copy'>",
+      	      link_end=u"</span></a>"
+      	  )}
+      	</p>
       </div>
 
       <div class="footer-about-links">

--- a/lms/templates/footer.html
+++ b/lms/templates/footer.html
@@ -51,11 +51,15 @@
         </p>
       </div>
 
-      ## Translators: '&copy;' is an HTML character code for the copyright symbol. Please don't remove or change it.
-      <p class="copyright">${_("&copy; {copyright_year} {platform_name}, some rights reserved").format(
-        platform_name=settings.PLATFORM_NAME,
-        copyright_year=settings.COPYRIGHT_YEAR
-      )}
+      <p class="copyright">&copy; ${settings.COPYRIGHT_YEAR} ${settings.PLATFORM_NAME}.</p>
+
+      ## Site operators: Please do not remove this paragraph! This attributes back to edX and makes your acknowledgement of edX's trademarks clear.
+      <p class="copyright">
+	## Translators: 'EdX', 'edX', and 'Open edX' are trademarks of 'edX Inc.'. Please do not translate any of these trademarks and company names.
+	${_("EdX, Open edX, and the edX and Open edX logos are registered trademarks or trademarks of {link_start}edX Inc.{link_end}").format(
+	    link_start=u"<a href='https://www.edx.org/'>",
+	    link_end=u"</a>"
+	)}
       </p>
         <nav class="nav-legal">
           <ul>

--- a/lms/templates/verify_student/make_payment_step.underscore
+++ b/lms/templates/verify_student/make_payment_step.underscore
@@ -114,7 +114,6 @@
       <% } %>
     </div>
 
-    <% if ( !upgrade ) { %>
     <div class="requirements-container">
       <ul class="list-reqs <% if ( requirements['account-activation-required'] ) { %>account-not-activated<% } %>">
         <% if ( requirements['account-activation-required'] ) { %>
@@ -156,7 +155,6 @@
         <% } %>
       </ul>
     </div>
-    <% } %>
 
 
   <% if ( isActive ) { %>

--- a/openedx/core/djangoapps/user_api/partition_schemes.py
+++ b/openedx/core/djangoapps/user_api/partition_schemes.py
@@ -22,7 +22,7 @@ class RandomUserPartitionScheme(object):
         Returns the group from the specified user position to which the user is assigned.
         If the user has not yet been assigned, a group will be randomly chosen for them if assign flag is True.
         """
-        partition_key = cls._key_for_partition(user_partition)
+        partition_key = cls.key_for_partition(user_partition)
         group_id = course_tag_api.get_course_tag(user, course_key, partition_key)
 
         group = None
@@ -72,7 +72,7 @@ class RandomUserPartitionScheme(object):
         return group
 
     @classmethod
-    def _key_for_partition(cls, user_partition):
+    def key_for_partition(cls, user_partition):
         """
         Returns the key to use to look up and save the user's group for a given user partition.
         """

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -56,7 +56,7 @@ nose==1.3.3
 oauthlib==0.6.3
 paramiko==1.9.0
 path.py==3.0.1
-Pillow==2.6.1
+Pillow==2.7.0
 pip>=1.4
 polib==1.0.3
 pycrypto>=2.6

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -35,4 +35,4 @@ git+https://github.com/mitocw/django-cas.git@60a5b8e5a62e63e0d5d224a87f0b489201a
 -e git+https://github.com/edx/edx-oauth2-provider.git@0.4.0#egg=oauth2-provider
 -e git+https://github.com/edx/edx-val.git@ba00a5f2e0571e9a3f37d293a98efe4cbca850d5#egg=edx-val
 -e git+https://github.com/edx/edx-milestones.git@4dfe78a2aae9559ccc979746d13a9b67f0ec311e#egg=edx-milestones
--e git+https://github.com/pmitros/RecommenderXBlock.git@a606d00bdf39bd0a4ae9c51773b69b9eb98934ff#egg=recommender-xblock
+-e git+https://github.com/pmitros/RecommenderXBlock.git@9b07e807c89ba5761827d0387177f71aa57ef056#egg=recommender-xblock

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -11,7 +11,7 @@
 -e git+https://github.com/edx/django-pipeline.git@88ec8a011e481918fdc9d2682d4017c835acd8be#egg=django-pipeline
 -e git+https://github.com/edx/django-wiki.git@cd0b2b31997afccde519fe5b3365e61a9edb143f#egg=django-wiki
 -e git+https://github.com/edx/django-oauth2-provider.git@0.2.7-fork-edx-2#egg=django-oauth2-provider
--e git+https://github.com/edx/MongoDBProxy.git@efe14679c9263ab491916ed960f5930127e05faf#egg=mongodb_proxy
+-e git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=mongodb_proxy
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev
 -e git+https://github.com/eventbrite/zendesk.git@d53fe0e81b623f084e91776bcf6369f8b7b63879#egg=zendesk
 -e git+https://github.com/un33k/django-ipware.git@42cb1bb1dc680a60c6452e8bb2b843c2a0382c90#egg=django-ipware

--- a/scripts/all-tests.sh
+++ b/scripts/all-tests.sh
@@ -190,7 +190,7 @@ END
                 # action doesn't fail the build.
                 # May be unnecessary if we changed the "Skip if there are no test files"
                 # option to True in the jenkins job definitions.
-                mkdir -p reports
+                mkdir -p reports/bok_choy
                 cat > reports/bok_choy/xunit.xml <<END
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuite name="nosetests" tests="1" errors="0" failures="0" skip="0">


### PR DESCRIPTION
**Background:**
Currently the updates of the courses are thought to be introduced as the course is being developed. All of them are seen in the course info page as you introduce them in the Studio, independently of the date field. But if we want to run a fully automatised course in regards to updates, that is, with pre-loaded updates with a release date, there is no mechanism now to do it so. This PR orders the updates entries by date in the HTML that is used to back them up, and shows the updates only when the release date is being reached. 

**Studio Updates:**
The datepicker which is used to introduce the data is being blocked to only receive dates, via JS. Then the updates are reordered by date before being saved as HTML. Compatibility with old updates with text instead of a date is kept. 

**LMS Updates:**
The updates that are shown in the LMS info page are the subset of updates whose date is less than current date. Thus, we can preload the updates before the beginning of the course and these updates will be released automatically when their release date is reached. The dates are shown in the format corresponding to the language chosen by the user in the dashboard.

**Testing**

Updates you see in Studio:
![cms_updates](https://cloud.githubusercontent.com/assets/7533324/8675165/a52cd00a-2a42-11e5-8cc4-a47c0202e994.png)

And the updates seen in the LMS:

![lms_updates](https://cloud.githubusercontent.com/assets/7533324/8675176/bbb07f2a-2a42-11e5-968b-28e38fdaae5b.png)
