### PR TITLE
ECOM-1858

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -63,6 +63,7 @@ from certificates.api import (  # pylint: disable=import-error
 
 from xmodule.modulestore.django import modulestore
 from opaque_keys import InvalidKeyError
+from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
 from opaque_keys.edx.locator import CourseLocator
 from xmodule.modulestore import ModuleStoreEnum
@@ -867,7 +868,7 @@ def _credit_statuses(user, course_enrollments):
 
     statuses = {}
     for eligibility in credit_api.get_eligibilities_for_user(user.username):
-        course_key = eligibility["course_key"]
+        course_key = CourseKey.from_string(unicode(eligibility["course_key"]))
         status = {
             "course_key": unicode(course_key),
             "eligible": True,

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -184,6 +184,13 @@ if FEATURES.get('ENABLE_THIRD_PARTY_AUTH') and 'third_party_auth.dummy.DummyBack
 ############## ECOMMERCE API CONFIGURATION SETTINGS ###############
 ECOMMERCE_PUBLIC_URL_ROOT = "http://localhost:8002"
 
+###################### Cross-domain requests ######################
+FEATURES['ENABLE_CORS_HEADERS'] = True
+CORS_ALLOW_CREDENTIALS = True
+CORS_ORIGIN_WHITELIST = ()
+CORS_ORIGIN_ALLOW_ALL = True
+
+
 #####################################################################
 # See if the developer has any local overrides.
 try:

--- a/openedx/core/djangoapps/credit/api/eligibility.py
+++ b/openedx/core/djangoapps/credit/api/eligibility.py
@@ -13,6 +13,8 @@ from openedx.core.djangoapps.credit.models import (
     CreditEligibility,
 )
 
+from opaque_keys.edx.keys import CourseKey
+
 
 log = logging.getLogger(__name__)
 
@@ -182,13 +184,13 @@ def get_eligibilities_for_user(username, course_key=None):
 
     """
     eligibilities = CreditEligibility.get_user_eligibilities(username)
-
     if course_key:
-        eligibilities = eligibilities.filter(course_key=course_key)
+        course_key = CourseKey.from_string(unicode(course_key))
+        eligibilities = eligibilities.filter(course__course_key=course_key)
 
     return [
         {
-            "course_key": eligibility.course.course_key,
+            "course_key": unicode(eligibility.course.course_key),
             "deadline": eligibility.deadline,
         }
         for eligibility in eligibilities


### PR DESCRIPTION
Update code of get_eligibility api.

@awais786 @aamir-khan @zubair-arbi @ahsan-ul-haq @wedaly 

Changes in `get_eligibilities_for_user` method in credit eligibility api:
- filter eligibilities by course key
- send `course_key` in unicode string in response

Enable cross-domain requests for devstack

Related PR: https://github.com/edx/edx-platform/pull/8853
