### PR TITLE
Re-upgrade to setuptools

### DIFF
--- a/common/lib/capa/setup.py
+++ b/common/lib/capa/setup.py
@@ -4,5 +4,5 @@ setup(
     name="capa",
     version="0.1",
     packages=find_packages(exclude=["tests"]),
-    install_requires=["distribute>=0.6.28"],
+    install_requires=["setuptools"],
 )

--- a/common/lib/xmodule/setup.py
+++ b/common/lib/xmodule/setup.py
@@ -54,7 +54,7 @@ setup(
     version="0.1",
     packages=find_packages(exclude=["tests"]),
     install_requires=[
-        'distribute',
+        'setuptools',
         'docopt',
         'capa',
         'path.py',

--- a/pavelib/prereqs.py
+++ b/pavelib/prereqs.py
@@ -16,7 +16,6 @@ PYTHON_REQ_FILES = [
     'requirements/edx/github.txt',
     'requirements/edx/local.txt',
     'requirements/edx/base.txt',
-    'requirements/edx/post.txt',
 ]
 
 # Developers can have private requirements, for local copies of github repos,

--- a/pavelib/prereqs.py
+++ b/pavelib/prereqs.py
@@ -16,6 +16,7 @@ PYTHON_REQ_FILES = [
     'requirements/edx/github.txt',
     'requirements/edx/local.txt',
     'requirements/edx/base.txt',
+    'requirements/edx/post.txt',
 ]
 
 # Developers can have private requirements, for local copies of github repos,

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -13,7 +13,6 @@ celery==3.1.18
 cssselect==0.9.1
 dealer==2.0.4
 defusedxml==0.4.1
-distribute>=0.6.28, <0.7
 django-babel-underscore==0.1.0
 django-celery==3.1.16
 django-countries==3.3

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -51,6 +51,7 @@ Markdown==2.2.1
 --allow-unverified meliae
 meliae==0.4.0
 mongoengine==0.10.0
+MySQL-python==1.2.5
 networkx==1.7
 nose==1.3.3
 oauthlib==0.7.2

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -44,7 +44,6 @@ glob2==0.3
 gunicorn==0.17.4
 httpretty==0.8.3
 lazy==1.1
-lxml==3.4.4
 mako==0.9.1
 Markdown==2.2.1
 --allow-external meliae
@@ -69,7 +68,6 @@ python-memcached==1.48
 python-openid==2.2.5
 python-dateutil==2.1
 python-social-auth==0.2.11
-python-saml==2.1.3
 pytz==2015.2
 pysrt==0.4.7
 PyYAML==3.10
@@ -89,6 +87,9 @@ django-ratelimit-backend==0.6
 unicodecsv==0.9.4
 django-require==1.0.6
 pyuca==1.1
+
+# This needs to be installed *after* Cython, which is in pre.txt
+lxml==3.4.4
 
 # Used for shopping cart's pdf invoice/receipt generation
 reportlab==3.1.44

--- a/requirements/edx/post.txt
+++ b/requirements/edx/post.txt
@@ -1,0 +1,12 @@
+# DON'T JUST ADD NEW DEPENDENCIES!!!
+#
+# If you open a pull request that adds a new dependency, you should notify:
+#   * @mollydb - to check licensing
+#   * support@edx.org - to check system requirements
+
+# This needs to be installed *after* lxml, which is in base.txt.
+# python-saml pulls in lxml as a dependency, and due to a bug in setuptools,
+# trying to compile lxml as a dependency causes setuptools to go into an
+# infinite loop and run out of memory. Because why would you trust a
+# dependency management tool to manage dependencies for you?
+python-saml==2.1.3

--- a/requirements/edx/post.txt
+++ b/requirements/edx/post.txt
@@ -1,9 +1,0 @@
-# DON'T JUST ADD NEW DEPENDENCIES!!!
-#
-# If you open a pull request that adds a new dependency, you should notify:
-#   * @mollydb to check licensing
-#   * One of @e0d, @feanil, @fredsmith, @maxrothman, or @jibsheet
-#     to check system requirements
-
-# This must be installed after distribute has been updated.
-MySQL-python==1.2.4

--- a/requirements/edx/pre.txt
+++ b/requirements/edx/pre.txt
@@ -5,6 +5,9 @@
 #   * One of @e0d, @feanil, @fredsmith, @maxrothman, or @jibsheet
 #     to check system requirements
 
+# Use a modern setuptools instead of distribute
+setuptools==18.0.1
+
 # Numpy and scipy can't be installed in the same pip run.
 # Install numpy before other things to help resolve the problem.
 numpy==1.6.2

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup
 setup(
     name="Open edX",
     version="0.4",
-    install_requires=["distribute"],
+    install_requires=["setuptools"],
     requires=[],
     # NOTE: These are not the names we should be installing.  This tree should
     # be reorganized to be a more conventional Python tree.


### PR DESCRIPTION
Re-introduces setuptools. This was originally done in #8161, reverted in #8933, and is now going back in.

The latest version of setuptools has a bug where installing python-saml before lxml is installed caused setuptools to go into an infinite loop. See reproducible failure and workaround here: https://gist.github.com/singingwolfboy/7f11ffc5b95b4437ba9d
