### PR TITLE
Remove unneeded block from courses.html template

### DIFF
--- a/lms/templates/courseware/courses.html
+++ b/lms/templates/courseware/courses.html
@@ -5,10 +5,13 @@
   from openedx.core.lib.json_utils import EscapedEdxJSONEncoder
 %>
 <%inherit file="../main.html" />
+<%
+  course_discovery_enabled = settings.FEATURES.get('ENABLE_COURSE_DISCOVERY')
+%>
 
 <%namespace name='static' file='../static_content.html'/>
 
-% if settings.FEATURES.get('ENABLE_COURSE_DISCOVERY'):
+% if course_discovery_enabled:
 <%block name="header_extras">
   % for template_name in ["course_card", "filter_bar", "filter", "facet", "facet_option"]:
   <script type="text/template" id="${template_name}-tpl">
@@ -25,29 +28,6 @@
 % endif
 
 <%block name="pagetitle">${_("Courses")}</%block>
-<%
-  platform_name = microsite.get_value('platform_name', settings.PLATFORM_NAME)
-  course_discovery_enabled = settings.FEATURES.get('ENABLE_COURSE_DISCOVERY')
-  if self.stanford_theme_enabled():
-    course_index_overlay_text = _("Explore free courses from {university_name}.").format(university_name="Stanford University")
-    logo_file = static.url('themes/stanford/images/seal.png')
-    logo_alt_text = "Stanford Seal Logo"
-
-  else:
-    course_index_overlay_text = microsite.get_value('course_index_overlay_text', _("Explore courses from {platform_name}.").format(platform_name=platform_name))
-
-    if settings.FEATURES.get('IS_EDX_DOMAIN', False):
-      # For some reason, `static.url('images/edx-theme/edx-logo-bw.png')` breaks template rendering.
-      default_image_url = settings.STATIC_URL + 'images/edx-theme/edx-logo-bw.png'
-    else:
-      default_image_url = settings.STATIC_URL + 'images/default-theme/logo-large.png'
-
-    logo_file = microsite.get_value(
-      'course_index_overlay_logo_file', default_image_url
-    )
-
-    logo_alt_text = _("{platform_name} Logo").format(platform_name=platform_name)
-%>
 
 <section class="find-courses">
   <section class="courses-container">


### PR DESCRIPTION
The part of the template that referenced these variables was removed in https://github.com/edx/edx-platform/commit/b9ed758246dc44872d61b2a9c89e319253c33a26#diff-bc9d92af206029bc951c0bdcbdd4e841, so it should be safe to remove the logic that defines them.
