### PR TITLE
Import missing settings module in tests of commerce views

### DIFF
--- a/lms/djangoapps/commerce/tests/test_views.py
+++ b/lms/djangoapps/commerce/tests/test_views.py
@@ -4,6 +4,7 @@ from uuid import uuid4
 from nose.plugins.attrib import attr
 
 import ddt
+from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 import mock


### PR DESCRIPTION
@jimabramson @maxrothman, as mentioned in #8941, this should resolve build failures.

@maxrothman, be advised, this may cause merge conflicts when merging release back into master.
