### PR TITLE
TNL-143: Escape characters in Textbook modal

### DIFF
--- a/cms/static/js/views/edit_chapter.js
+++ b/cms/static/js/views/edit_chapter.js
@@ -53,7 +53,7 @@ define(["js/views/baseview", "underscore", "underscore.string", "jquery", "gette
             });
             var msg = new FileUploadModel({
                 title: _.template(gettext("Upload a new PDF to “<%= name %>”"),
-                    {name: course.escape('name')}),
+                    {name: course.get('name')}),
                 message: gettext("Please select a PDF file to upload."),
                 mimeTypes: ['application/pdf']
             });


### PR DESCRIPTION
This is a fix for:
https://openedx.atlassian.net/browse/TNL-143
the modal now doesn't escape escapable characters in the
course name.
