### PR TITLE
Fixing printing for footer v3

### DIFF
--- a/lms/static/sass/shared/_footer-edx.scss
+++ b/lms/static/sass/shared/_footer-edx.scss
@@ -139,6 +139,24 @@ footer#footer-edx-v3 {
     }
   }
 
+  .site-nav,
+  .legal-notices,
+  .footer-logo,
+  .external-links {
+    @extend %ui-print-excluded;
+  }
+
+  @media print {
+    .site-details p {
+      float: left;
+    }
+
+    .openedx-link {
+      margin: 0;
+      float: right;
+    }
+  }
+
   @include media( $edx-bp-large ) {
     padding: 20px 10px;
 

--- a/lms/static/sass/shared/_footer-edx.scss
+++ b/lms/static/sass/shared/_footer-edx.scss
@@ -148,12 +148,12 @@ footer#footer-edx-v3 {
 
   @media print {
     .site-details p {
-      float: left;
+      @include float(left);
     }
 
     .openedx-link {
       margin: 0;
-      float: right;
+      @include float(right);
     }
   }
 

--- a/lms/static/sass/shared/_footer.scss
+++ b/lms/static/sass/shared/_footer.scss
@@ -4,6 +4,7 @@
 @import 'neat/neat'; // lib - Neat
 
 .wrapper-footer {
+  @extend %ui-print-excluded;
   box-shadow: 0 -1px 5px 0 $shadow-l1;
   border-top: 1px solid tint($m-gray, 50%);
   padding: 25px ($baseline/2) ($baseline*1.5) ($baseline/2);


### PR DESCRIPTION
This PR fixes the print media CSS for printing the footer in the LMS.

This was previously fixed for the v2 footer in [this PR](https://github.com/edx/edx-platform/pull/7595), and subsequently undone when the v3 footer was introduced.

Before:
![screen shot 2015-07-18 at 6 24 56 pm](https://cloud.githubusercontent.com/assets/6232546/8763764/7de58a1e-2d7b-11e5-822a-c1a26c026d6b.png)

After:
![screen shot 2015-07-18 at 6 24 33 pm](https://cloud.githubusercontent.com/assets/6232546/8763765/83812eba-2d7b-11e5-8fb2-45af8b4d10bd.png)

Screenshots taken on edx.org; changes also included for open edX.
