### PR TITLE
WIP Microsite backends and database defined microsites

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1016,3 +1016,9 @@ CREDIT_PROVIDER_TIMESTAMP_EXPIRATION = 15 * 60
 ################################ Deprecated Blocks Info ################################
 
 DEPRECATED_BLOCK_TYPES = ['peergrading', 'combinedopenended']
+
+
+################################ Settings for Microsites ################################
+
+### Select an implementation for the microsite backend
+MICROSITE_BACKEND = 'microsite_configuration.backends.filebased.SettingsFileMicrositeBackend'

--- a/common/djangoapps/microsite_configuration/admin.py
+++ b/common/djangoapps/microsite_configuration/admin.py
@@ -1,0 +1,9 @@
+"""
+Django admin page for microsite models
+"""
+from django.contrib import admin
+
+from .models import Microsite
+
+
+admin.site.register(Microsite)

--- a/common/djangoapps/microsite_configuration/backends/__init__.py
+++ b/common/djangoapps/microsite_configuration/backends/__init__.py
@@ -1,0 +1,1 @@
+# Microsite backends shipped with openedx

--- a/common/djangoapps/microsite_configuration/backends/base.py
+++ b/common/djangoapps/microsite_configuration/backends/base.py
@@ -45,6 +45,16 @@ class BaseMicrositeBackend(object):
         pass
 
     @abc.abstractmethod
+    def get_dict(self, dict_name, default={}, **kwargs):
+        """
+        Returns a dictionary product of merging the request's microsite and
+        the default value.
+        This can be used, for example, to return a merged dictonary from the
+        settings.FEATURES dict, including values defined at the microsite
+        """
+        pass
+
+    @abc.abstractmethod
     def is_request_in_microsite(self):
         """
         This will return True/False if the current request is a request within a microsite

--- a/common/djangoapps/microsite_configuration/backends/base.py
+++ b/common/djangoapps/microsite_configuration/backends/base.py
@@ -1,0 +1,91 @@
+"""
+Microsite configuration backend module.
+
+Contains the base class for microsite backends.
+
+"""
+
+from __future__ import absolute_import
+
+import abc
+
+
+# pylint: disable=unused-argument
+class BaseMicrositeBackend(object):
+    """
+    Abstract Base Class for the microsite backends.
+
+    """
+    __metaclass__ = abc.ABCMeta
+
+    def __init__(self, **kwargs):
+        pass
+
+    @abc.abstractmethod
+    def set_config_by_domain(self, domain):
+        """
+        For a given request domain, find a match in our microsite configuration
+        and make it available to the complete django request process
+        """
+        pass
+
+    @abc.abstractmethod
+    def get_template_path(self, relative_path, **kwargs):
+        """
+        Returns a path (string) to a Mako template, which can either be in
+        an override or will just return what is passed in which is expected to be a string
+        """
+        pass
+
+    @abc.abstractmethod
+    def get_value(self, val_name, default=None, **kwargs):
+        """
+        Returns a value associated with the request's microsite, if present
+        """
+        pass
+
+    @abc.abstractmethod
+    def is_request_in_microsite(self):
+        """
+        This will return True/False if the current request is a request within a microsite
+        """
+        pass
+
+    @abc.abstractmethod
+    def has_override_value(self, val_name):
+        """
+        Returns True/False whether a Microsite has a definition for the
+        specified named value
+        """
+        pass
+
+    @abc.abstractmethod
+    def enable_microsites(self, log):
+        """
+        Enable the use of microsites.
+        Used during the startup.py script
+        """
+        pass
+
+    @abc.abstractmethod
+    def get_value_for_org(self, org, val_name, default):
+        """
+        Returns a configuration value for a microsite which has an org_filter that matches
+        what is passed in
+        """
+        pass
+
+    @abc.abstractmethod
+    def get_all_orgs(self):
+        """
+        This returns a set of orgs that are considered within all microsites.
+        This can be used, for example, to do filtering
+        """
+        pass
+
+    @abc.abstractmethod
+    def clear(self):
+        """
+        Clears out any microsite configuration from the current request/thread
+        """
+        pass

--- a/common/djangoapps/microsite_configuration/backends/database.py
+++ b/common/djangoapps/microsite_configuration/backends/database.py
@@ -8,20 +8,15 @@ import edxmako
 import json
 
 from django.conf import settings
-from microsite_configuration.backends.base import BaseMicrositeBackend
+from microsite_configuration.backends.filebased import SettingsFileMicrositeBackend
 from microsite_configuration.models import Microsite
 
 
-class DatabaseMicrositeBackend(BaseMicrositeBackend):
+class DatabaseMicrositeBackend(SettingsFileMicrositeBackend):
     """
     Microsite backend that reads the microsites definitions
     from a table in the database according to the models.py file
     """
-
-    def __init__(self, **kwargs):
-        super(DatabaseMicrositeBackend, self).__init__(**kwargs)
-        self.current_request_configuration = threading.local()
-        self.current_request_configuration.data = {}
 
     def has_configuration_set(self):
         """
@@ -31,15 +26,6 @@ class DatabaseMicrositeBackend(BaseMicrositeBackend):
             return True
         else:
             return False
-
-    def get_configuration(self):
-        """
-        Returns the current request's microsite configuration
-        """
-        if not hasattr(self.current_request_configuration, 'data'):
-            return {}
-
-        return self.current_request_configuration.data
 
     def set_config_by_domain(self, domain):
         """
@@ -91,27 +77,6 @@ class DatabaseMicrositeBackend(BaseMicrositeBackend):
                 return path
 
         return relative_path
-
-    def get_value(self, val_name, default=None, **kwargs):
-        """
-        Returns a value associated with the request's microsite, if present
-        """
-        configuration = self.get_configuration()
-        return configuration.get(val_name, default)
-
-    def is_request_in_microsite(self):
-        """
-        This will return if current request is a request within a microsite
-        """
-        return bool(self.get_configuration())
-
-    def has_override_value(self, val_name):
-        """
-        Will return True/False whether a Microsite has a definition for the
-        specified val_name
-        """
-        configuration = self.get_configuration()
-        return val_name in configuration
 
     def enable_microsites(self, log):
         """
@@ -179,9 +144,3 @@ class DatabaseMicrositeBackend(BaseMicrositeBackend):
         config['subdomain'] = subdomain
         config['site_domain'] = domain
         self.current_request_configuration.data = config
-
-    def clear(self):
-        """
-        Clears out any microsite configuration from the current request/thread
-        """
-        self.current_request_configuration.data = {}

--- a/common/djangoapps/microsite_configuration/backends/database.py
+++ b/common/djangoapps/microsite_configuration/backends/database.py
@@ -1,0 +1,187 @@
+"""
+Microsite backend that reads the configuration from the database
+
+"""
+import os.path
+import threading
+import edxmako
+import json
+
+from django.conf import settings
+from microsite_configuration.backends.base import BaseMicrositeBackend
+from microsite_configuration.models import Microsite
+
+
+class DatabaseMicrositeBackend(BaseMicrositeBackend):
+    """
+    Microsite backend that reads the microsites definitions
+    from a table in the database according to the models.py file
+    """
+
+    def __init__(self, **kwargs):
+        super(DatabaseMicrositeBackend, self).__init__(**kwargs)
+        self.current_request_configuration = threading.local()
+        self.current_request_configuration.data = {}
+
+    def has_configuration_set(self):
+        """
+        Returns whether there is any Microsite configuration settings
+        """
+        if Microsite.objects.count():
+            return True
+        else:
+            return False
+
+    def get_configuration(self):
+        """
+        Returns the current request's microsite configuration
+        """
+        if not hasattr(self.current_request_configuration, 'data'):
+            return {}
+
+        return self.current_request_configuration.data
+
+    def set_config_by_domain(self, domain):
+        """
+        For a given request domain, find a match in our microsite configuration
+        and then assign it to the thread local in order to make it available
+        to the complete Django request processing
+        """
+        if not self.has_configuration_set() or not domain:
+            return
+
+        candidates = Microsite.objects.all()
+        for microsite in candidates:
+            subdomain = microsite.subdomain
+            if subdomain and domain.startswith(subdomain):
+                values = json.loads(microsite.values)
+                self._set_microsite_config_from_obj(subdomain, domain, values)
+                return
+
+        # if no match on subdomain then see if there is a 'default' microsite
+        # defined in the db. If so, then use it
+        try:
+            microsite = Microsite.objects.get(key='default')
+            values = json.loads(microsite.values)
+            self._set_microsite_config_from_obj(subdomain, domain, values)
+            return
+        except Microsite.DoesNotExist:
+            return
+
+    def get_template_path(self, relative_path, **kwargs):
+        """
+        Returns a path (string) to a Mako template, which can either be in
+        a microsite directory (as an override) or will just return what is passed in which is
+        expected to be a string
+        """
+
+        if not self.is_request_in_microsite():
+            return relative_path
+
+        microsite_template_path = str(self.get_value('template_dir', None))
+
+        if microsite_template_path:
+            search_path = os.path.join(microsite_template_path, relative_path)
+
+            if os.path.isfile(search_path):
+                path = '/{0}/templates/{1}'.format(
+                    self.get_value('microsite_name'),
+                    relative_path
+                )
+                return path
+
+        return relative_path
+
+    def get_value(self, val_name, default=None, **kwargs):
+        """
+        Returns a value associated with the request's microsite, if present
+        """
+        configuration = self.get_configuration()
+        return configuration.get(val_name, default)
+
+    def is_request_in_microsite(self):
+        """
+        This will return if current request is a request within a microsite
+        """
+        return bool(self.get_configuration())
+
+    def has_override_value(self, val_name):
+        """
+        Will return True/False whether a Microsite has a definition for the
+        specified val_name
+        """
+        configuration = self.get_configuration()
+        return val_name in configuration
+
+    def enable_microsites(self, log):
+        """
+        Enable the use of microsites, from a dynamic defined list in the db
+        """
+        if not settings.FEATURES['USE_MICROSITES']:
+            return
+
+        microsites_root = settings.MICROSITE_ROOT_DIR
+
+        if microsites_root.isdir():
+            settings.TEMPLATE_DIRS.append(microsites_root)
+            edxmako.paths.add_lookup('main', microsites_root)
+            settings.STATICFILES_DIRS.insert(0, microsites_root)
+
+            log.info('Loading microsite path at %s', microsites_root)
+        else:
+            log.error(
+                'Error loading %s. Directory does not exist',
+                microsites_root
+            )
+
+    def get_value_for_org(self, org, val_name, default):
+        """
+        Returns a configuration value for a microsite which has an org_filter that matches
+        what is passed in
+        """
+        if not self.has_configuration_set():
+            return default
+
+        # Filter at the db
+        candidates = Microsite.objects.all()
+        for microsite in candidates:
+            current = json.loads(microsite.values)
+            org_filter = current.get('course_org_filter')
+            if org_filter:
+                return current.get(val_name, default)
+
+        return default
+
+    def get_all_orgs(self):
+        """
+        This returns a set of orgs that are considered within all microsites.
+        This can be used, for example, to do filtering
+        """
+        org_filter_set = set()
+        if not self.has_configuration_set():
+            return org_filter_set
+
+        # Get the orgs in the db
+        candidates = Microsite.objects.all()
+        for microsite in candidates:
+            current = json.loads(microsite.values)
+            org_filter = current.get('course_org_filter')
+            if org_filter:
+                org_filter_set.add(org_filter)
+
+        return org_filter_set
+
+    def _set_microsite_config_from_obj(self, subdomain, domain, microsite_object):
+        """
+        Helper internal method to actually find the microsite configuration
+        """
+        config = microsite_object.copy()
+        config['subdomain'] = subdomain
+        config['site_domain'] = domain
+        self.current_request_configuration.data = config
+
+    def clear(self):
+        """
+        Clears out any microsite configuration from the current request/thread
+        """
+        self.current_request_configuration.data = {}

--- a/common/djangoapps/microsite_configuration/backends/filebased.py
+++ b/common/djangoapps/microsite_configuration/backends/filebased.py
@@ -1,0 +1,191 @@
+"""
+Microsite backend that reads the configuration from a file
+
+"""
+import os.path
+import threading
+import edxmako
+
+from django.conf import settings
+from microsite_configuration.backends.base import BaseMicrositeBackend
+
+
+class SettingsFileMicrositeBackend(BaseMicrositeBackend):
+    """
+    Microsite backend that reads the microsites definitions
+    from a dictionary called MICROSITE_CONFIGURATION in the settings file
+    """
+
+    def __init__(self, **kwargs):
+        super(SettingsFileMicrositeBackend, self).__init__(**kwargs)
+        self.current_request_configuration = threading.local()
+        self.current_request_configuration.data = {}
+
+    def has_configuration_set(self):
+        """
+        Returns whether there is any Microsite configuration settings
+        """
+        return getattr(settings, "MICROSITE_CONFIGURATION", False)
+
+    def get_configuration(self):
+        """
+        Returns the current request's microsite configuration
+        """
+        if not hasattr(self.current_request_configuration, 'data'):
+            return {}
+
+        return self.current_request_configuration.data
+
+    def set_config_by_domain(self, domain):
+        """
+        For a given request domain, find a match in our microsite configuration
+        and then assign it to the thread local in order to make it available
+        to the complete Django request processing
+        """
+        if not self.has_configuration_set() or not domain:
+            return
+
+        for key, value in settings.MICROSITE_CONFIGURATION.items():
+            subdomain = value.get('domain_prefix')
+            if subdomain and domain.startswith(subdomain):
+                self._set_microsite_config(key, subdomain, domain)
+                return
+
+        # if no match on subdomain then see if there is a 'default' microsite defined
+        # if so, then use that
+        if 'default' in settings.MICROSITE_CONFIGURATION:
+            self._set_microsite_config('default', subdomain, domain)
+            return
+
+    def get_template_path(self, relative_path, **kwargs):
+        """
+        Returns a path (string) to a Mako template, which can either be in
+        a microsite directory (as an override) or will just return what is passed in which is
+        expected to be a string
+        """
+
+        if not self.is_request_in_microsite():
+            return relative_path
+
+        microsite_template_path = str(self.get_value('template_dir', None))
+
+        if microsite_template_path:
+            search_path = os.path.join(microsite_template_path, relative_path)
+
+            if os.path.isfile(search_path):
+                path = '/{0}/templates/{1}'.format(
+                    self.get_value('microsite_name'),
+                    relative_path
+                )
+                return path
+
+        return relative_path
+
+    def get_value(self, val_name, default=None, **kwargs):
+        """
+        Returns a value associated with the request's microsite, if present
+        """
+        configuration = self.get_configuration()
+        return configuration.get(val_name, default)
+
+    def is_request_in_microsite(self):
+        """
+        This will return if current request is a request within a microsite
+        """
+        return bool(self.get_configuration())
+
+    def has_override_value(self, val_name):
+        """
+        Will return True/False whether a Microsite has a definition for the
+        specified val_name
+        """
+        configuration = self.get_configuration()
+        return val_name in configuration
+
+    def enable_microsites(self, log):
+        """
+        Enable the use of microsites, which are websites that allow
+        for subdomains for the edX platform, e.g. foo.edx.org
+        """
+
+        microsites_root = settings.MICROSITE_ROOT_DIR
+        microsite_config_dict = settings.MICROSITE_CONFIGURATION
+
+        for ms_name, ms_config in microsite_config_dict.items():
+            # Calculate the location of the microsite's files
+            ms_root = microsites_root / ms_name
+            ms_config = microsite_config_dict[ms_name]
+
+            # pull in configuration information from each
+            # microsite root
+
+            if ms_root.isdir():
+                # store the path on disk for later use
+                ms_config['microsite_root'] = ms_root
+
+                template_dir = ms_root / 'templates'
+                ms_config['template_dir'] = template_dir
+
+                ms_config['microsite_name'] = ms_name
+                log.info('Loading microsite %s', ms_root)
+            else:
+                # not sure if we have application logging at this stage of
+                # startup
+                log.error('Error loading microsite %s. Directory does not exist', ms_root)
+                # remove from our configuration as it is not valid
+                del microsite_config_dict[ms_name]
+
+        # if we have any valid microsites defined, let's wire in the Mako and STATIC_FILES search paths
+        if microsite_config_dict:
+            settings.TEMPLATE_DIRS.append(microsites_root)
+            edxmako.paths.add_lookup('main', microsites_root)
+
+            settings.STATICFILES_DIRS.insert(0, microsites_root)
+
+    def get_value_for_org(self, org, val_name, default):
+        """
+        Returns a configuration value for a microsite which has an org_filter that matches
+        what is passed in
+        """
+        if not self.has_configuration_set():
+            return default
+
+        # Filter at the setting file
+        for value in settings.MICROSITE_CONFIGURATION.values():
+            org_filter = value.get('course_org_filter', None)
+            if org_filter == org:
+                return value.get(val_name, default)
+        return default
+
+    def get_all_orgs(self):
+        """
+        This returns a set of orgs that are considered within all microsites.
+        This can be used, for example, to do filtering
+        """
+        org_filter_set = set()
+        if not self.has_configuration_set():
+            return org_filter_set
+
+        # Get the orgs in the settings file
+        for value in settings.MICROSITE_CONFIGURATION.values():
+            org_filter = value.get('course_org_filter')
+            if org_filter:
+                org_filter_set.add(org_filter)
+
+        return org_filter_set
+
+    def _set_microsite_config(self, microsite_config_key, subdomain, domain):
+        """
+        Helper internal method to actually find the microsite configuration
+        """
+        config = settings.MICROSITE_CONFIGURATION[microsite_config_key].copy()
+        config['subdomain'] = subdomain
+        config['microsite_config_key'] = microsite_config_key
+        config['site_domain'] = domain
+        self.current_request_configuration.data = config
+
+    def clear(self):
+        """
+        Clears out any microsite configuration from the current request/thread
+        """
+        self.current_request_configuration.data = {}

--- a/common/djangoapps/microsite_configuration/microsite.py
+++ b/common/djangoapps/microsite_configuration/microsite.py
@@ -36,6 +36,16 @@ def get_value(val_name, default=None, **kwargs):
     return BACKEND.get_value(val_name, default, **kwargs)
 
 
+def get_dict(dict_name, default={}, **kwargs):
+    """
+    Returns a dictionary product of merging the request's microsite and
+    the default value.
+    This can be used, for example, to return a merged dictonary from the
+    settings.FEATURES dict, including values defined at the microsite
+    """
+    return BACKEND.get_dict(dict_name, default, **kwargs)
+
+
 def has_override_value(val_name):
     """
     Returns True/False whether a Microsite has a definition for the

--- a/common/djangoapps/microsite_configuration/microsite.py
+++ b/common/djangoapps/microsite_configuration/microsite.py
@@ -6,45 +6,34 @@ A microsite enables the following features:
 2) Present a landing page with a listing of courses that are specific to the 'brand'
 3) Ability to swap out some branding elements in the website
 """
-import threading
-import os.path
+import inspect
 
+from importlib import import_module
 from django.conf import settings
-
-CURRENT_REQUEST_CONFIGURATION = threading.local()
-CURRENT_REQUEST_CONFIGURATION.data = {}
+from microsite_configuration.backends.base import BaseMicrositeBackend
 
 
-def has_configuration_set():
-    """
-    Returns whether there is any Microsite configuration settings
-    """
-    return getattr(settings, "MICROSITE_CONFIGURATION", False)
+__all__ = [
+    'is_request_in_microsite', 'get_value', 'has_override_value',
+    'get_template_path', 'get_value_for_org', 'get_all_orgs',
+    'clear', 'set_by_domain', 'enable_microsites',
+]
 
-
-def get_configuration():
-    """
-    Returns the current request's microsite configuration
-    """
-    if not hasattr(CURRENT_REQUEST_CONFIGURATION, 'data'):
-        return {}
-
-    return CURRENT_REQUEST_CONFIGURATION.data
+BACKEND = None
 
 
 def is_request_in_microsite():
     """
     This will return if current request is a request within a microsite
     """
-    return bool(get_configuration())
+    return BACKEND.is_request_in_microsite()
 
 
-def get_value(val_name, default=None):
+def get_value(val_name, default=None, **kwargs):
     """
     Returns a value associated with the request's microsite, if present
     """
-    configuration = get_configuration()
-    return configuration.get(val_name, default)
+    return BACKEND.get_value(val_name, default, **kwargs)
 
 
 def has_override_value(val_name):
@@ -52,33 +41,14 @@ def has_override_value(val_name):
     Returns True/False whether a Microsite has a definition for the
     specified named value
     """
-    configuration = get_configuration()
-    return val_name in configuration
+    return BACKEND.has_override_value(val_name)
 
 
-def get_template_path(relative_path):
+def get_template_path(relative_path, **kwargs):
     """
-    Returns a path (string) to a Mako template, which can either be in
-    a microsite directory (as an override) or will just return what is passed in which is
-    expected to be a string
+    Returns a path (string) to a Mako template
     """
-
-    if not is_request_in_microsite():
-        return relative_path
-
-    microsite_template_path = str(get_value('template_dir'))
-
-    if microsite_template_path:
-        search_path = os.path.join(microsite_template_path, relative_path)
-
-        if os.path.isfile(search_path):
-            path = '/{0}/templates/{1}'.format(
-                get_value('microsite_name'),
-                relative_path
-            )
-            return path
-
-    return relative_path
+    return BACKEND.get_template_path(relative_path, **kwargs)
 
 
 def get_value_for_org(org, val_name, default=None):
@@ -86,14 +56,7 @@ def get_value_for_org(org, val_name, default=None):
     This returns a configuration value for a microsite which has an org_filter that matches
     what is passed in
     """
-    if not has_configuration_set():
-        return default
-
-    for value in settings.MICROSITE_CONFIGURATION.values():
-        org_filter = value.get('course_org_filter', None)
-        if org_filter == org:
-            return value.get(val_name, default)
-    return default
+    return BACKEND.get_value_for_org(org, val_name, default)
 
 
 def get_all_orgs():
@@ -101,52 +64,54 @@ def get_all_orgs():
     This returns a set of orgs that are considered within a microsite. This can be used,
     for example, to do filtering
     """
-    org_filter_set = set()
-    if not has_configuration_set():
-        return org_filter_set
-
-    for value in settings.MICROSITE_CONFIGURATION.values():
-        org_filter = value.get('course_org_filter')
-        if org_filter:
-            org_filter_set.add(org_filter)
-
-    return org_filter_set
+    return BACKEND.get_all_orgs()
 
 
 def clear():
     """
     Clears out any microsite configuration from the current request/thread
     """
-    CURRENT_REQUEST_CONFIGURATION.data = {}
-
-
-def _set_current_microsite(microsite_config_key, subdomain, domain):
-    """
-    Helper internal method to actually put a microsite on the threadlocal
-    """
-    config = settings.MICROSITE_CONFIGURATION[microsite_config_key].copy()
-    config['subdomain'] = subdomain
-    config['microsite_config_key'] = microsite_config_key
-    config['site_domain'] = domain
-    CURRENT_REQUEST_CONFIGURATION.data = config
+    BACKEND.clear()
 
 
 def set_by_domain(domain):
     """
-    For a given request domain, find a match in our microsite configuration and then assign
-    it to the thread local so that it is available throughout the entire
-    Django request processing
+    For a given request domain, find a match in our microsite configuration
+    and make it available to the complete django request process
     """
-    if not has_configuration_set() or not domain:
-        return
+    BACKEND.set_config_by_domain(domain)
 
-    for key, value in settings.MICROSITE_CONFIGURATION.items():
-        subdomain = value.get('domain_prefix')
-        if subdomain and domain.startswith(subdomain):
-            _set_current_microsite(key, subdomain, domain)
-            return
 
-    # if no match on subdomain then see if there is a 'default' microsite defined
-    # if so, then use that
-    if 'default' in settings.MICROSITE_CONFIGURATION:
-        _set_current_microsite('default', subdomain, domain)
+def enable_microsites(log):
+    """
+    Enable the use of microsites during the startup script
+    """
+    BACKEND.enable_microsites(log)
+
+
+def get_backend(backend_name=None, **kwds):
+    """
+    Load a microsites backend and return an instance of it.
+    If backend is None (default) settings.MICROSITE_BACKEND is used.
+    Any aditional args(kwds) will be used in the constructor of the backend.
+    """
+    name = backend_name or settings.MICROSITE_BACKEND
+    try:
+        parts = name.split('.')
+        module_name = '.'.join(parts[:-1])
+        class_name = parts[-1]
+    except IndexError:
+        raise ValueError('Invalid microsites backend %s' % name)
+
+    try:
+        module = import_module(module_name)
+        cls = getattr(module, class_name)
+        if not inspect.isclass(cls) or not issubclass(cls, BaseMicrositeBackend):
+            raise TypeError
+    except (AttributeError, ValueError):
+        raise ValueError('Cannot find microsites backend %s' % module_name)
+
+    return cls(**kwds)
+
+
+BACKEND = get_backend()

--- a/common/djangoapps/microsite_configuration/models.py
+++ b/common/djangoapps/microsite_configuration/models.py
@@ -1,0 +1,44 @@
+"""
+Model to store a microsite in the database.
+
+The object is stored as a json representation of the python dict
+that would have been used in the settings.
+
+"""
+
+import json
+
+from django.db import models
+from django.core.exceptions import ValidationError
+
+
+def validate_json(values):
+    """
+    Guarantees the value passed is a valid json
+    """
+    try:
+        json.loads(values)
+    except ValueError:
+        raise ValidationError("The values field must be a valid json.")
+
+
+class Microsite(models.Model):
+    """
+    This is where the information about the microsite gets stored to the db.
+    To achieve the maximum flexibility, most of the fields are stored inside
+    a json field.
+
+    Notes:
+        - The key field was required for the dict definition at the settings, and it
+        is used in some of the microsite_configuration methods.
+        - The subdomain is outside of the json so that it is posible to use a db query
+        to improve performance.
+        - The values field must be validated on save to prevent the platform from crashing
+        badly in the case the string is not able to be loaded as json.
+    """
+    key = models.CharField(max_length=63, db_index=True)
+    subdomain = models.CharField(max_length=127, db_index=True)
+    values = models.TextField(null=False, blank=True, validators=[validate_json])
+
+    def __unicode__(self):
+        return self.key

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2568,3 +2568,9 @@ LTI_USER_EMAIL_DOMAIN = 'lti.example.com'
 # Number of seconds before JWT tokens expire
 JWT_EXPIRATION = 30
 JWT_ISSUER = None
+
+
+################################ Settings for Microsites ################################
+
+### Select an implementation for the microsite backend
+MICROSITE_BACKEND = 'microsite_configuration.backends.filebased.SettingsFileMicrositeBackend'

--- a/lms/startup.py
+++ b/lms/startup.py
@@ -15,6 +15,8 @@ import logging
 from monkey_patch import django_utils_translation
 import analytics
 
+from microsite_configuration import microsite
+
 
 log = logging.getLogger(__name__)
 
@@ -33,7 +35,7 @@ def run():
         enable_theme()
 
     if settings.FEATURES.get('USE_MICROSITES', False):
-        enable_microsites()
+        microsite.enable_microsites(log)
 
     if settings.FEATURES.get('ENABLE_THIRD_PARTY_AUTH', False):
         enable_third_party_auth()
@@ -90,47 +92,6 @@ def enable_theme():
 
     # Include theme locale path for django translations lookup
     settings.LOCALE_PATHS = (theme_root / 'conf/locale',) + settings.LOCALE_PATHS
-
-
-def enable_microsites():
-    """
-    Enable the use of microsites, which are websites that allow
-    for subdomains for the edX platform, e.g. foo.edx.org
-    """
-
-    microsites_root = settings.MICROSITE_ROOT_DIR
-    microsite_config_dict = settings.MICROSITE_CONFIGURATION
-
-    for ms_name, ms_config in microsite_config_dict.items():
-        # Calculate the location of the microsite's files
-        ms_root = microsites_root / ms_name
-        ms_config = microsite_config_dict[ms_name]
-
-        # pull in configuration information from each
-        # microsite root
-
-        if ms_root.isdir():
-            # store the path on disk for later use
-            ms_config['microsite_root'] = ms_root
-
-            template_dir = ms_root / 'templates'
-            ms_config['template_dir'] = template_dir
-
-            ms_config['microsite_name'] = ms_name
-            log.info('Loading microsite %s', ms_root)
-        else:
-            # not sure if we have application logging at this stage of
-            # startup
-            log.error('Error loading microsite %s. Directory does not exist', ms_root)
-            # remove from our configuration as it is not valid
-            del microsite_config_dict[ms_name]
-
-    # if we have any valid microsites defined, let's wire in the Mako and STATIC_FILES search paths
-    if microsite_config_dict:
-        settings.TEMPLATE_DIRS.append(microsites_root)
-        edxmako.paths.add_lookup('main', microsites_root)
-
-        settings.STATICFILES_DIRS.insert(0, microsites_root)
 
 
 def enable_third_party_auth():

--- a/lms/startup.py
+++ b/lms/startup.py
@@ -94,6 +94,14 @@ def enable_theme():
     settings.LOCALE_PATHS = (theme_root / 'conf/locale',) + settings.LOCALE_PATHS
 
 
+def enable_microsites():
+    """
+    Calls the enable_microsites function in the microsite backend.
+    Here for backwards compatibility
+    """
+    microsite.enable_microsites(log)
+
+
 def enable_third_party_auth():
     """
     Enable the use of third_party_auth, which allows users to sign in to edX


### PR DESCRIPTION
This PR follows the discussion on #7867 

> I have opened this PR to have some more discussion around this code, before I carry on with the complete bulk of the work.

This PR creates a selectable backend for the microsite implementation. It is inspired in the django EMAIL_BACKEND  and the event tracking backend from the track django app.

The idea is to have a class which extends the abstract BaseMicrositeBackend and which handles all the operations currently required from the microsite module and adds a new enable_microsites operation.

Notes:
- For now I have implemented only one backend, the SettingsFileMicrositeBackend. This backend does the same as the current implemented solution for microsites and should be the default backend for new instances.
- The remaining work would be to implement one more backend for the database defined microsites.
- Optionally a 3rd backend could be made that serves as a compatibility backend to solve the issues with the definitions that differ in the regular settings vs the microsite values. E.g: 'platform_name' and 'PLATFORM_NAME'
