### PR TITLE
Small printing fixes (LMS)

### DIFF
--- a/common/lib/xmodule/xmodule/css/capa/display.scss
+++ b/common/lib/xmodule/xmodule/css/capa/display.scss
@@ -1,7 +1,7 @@
-// capa - styling 
+// capa - styling
 // ====================
 
-// Table of Contents 
+// Table of Contents
 // * +Variables - Capa
 // * +Extends - Capa
 // * +Mixins - Status Icon - Capa
@@ -19,14 +19,14 @@
 // * +Problem - Image Input Overrides
 
 // +Variables - Capa
-// ==================== 
+// ====================
 $annotation-yellow: rgba(255,255,10,0.3);
 $color-copy-tip: rgb(100,100,100);
 $correct: $green-d1;
-$incorrect: $red; 
+$incorrect: $red;
 
 // +Extends - Capa
-// ==================== 
+// ====================
 // Duplicated from _mixins.scss due to xmodule compilation, inheritance issues
 %use-font-awesome {
   font-family: FontAwesome;
@@ -36,9 +36,9 @@ $incorrect: $red;
 }
 
 // +Mixins - Status Icon - Capa
-// ==================== 
+// ====================
 @mixin status-icon($color: $gray, $fontAwesomeIcon: "\f00d"){
-  
+
   &:after {
     @extend %use-font-awesome;
     @include margin-left(17px);
@@ -49,7 +49,7 @@ $incorrect: $red;
 }
 
 // +Resets - Deprecate Please
-// ==================== 
+// ====================
 h2 {
   margin-top: 0;
   margin-bottom: ($baseline*0.75);
@@ -123,7 +123,7 @@ div.problem-progress {
 }
 
 // +Problem - Base
-// ==================== 
+// ====================
 div.problem {
   @media print {
     display: block;
@@ -141,7 +141,7 @@ div.problem {
 }
 
 // +Problem - Choice Group
-// ==================== 
+// ====================
 div.problem {
   .choicegroup {
     @include clearfix();
@@ -163,7 +163,7 @@ div.problem {
         @include status-icon($correct, "\f00c");
         border: 2px solid $correct;
 
-        // keep green for correct answers on hover. 
+        // keep green for correct answers on hover.
         &:hover {
           border-color: $correct;
         }
@@ -173,7 +173,7 @@ div.problem {
         @include status-icon($incorrect, "\f00d");
         border: 2px solid $incorrect;
 
-        // keep red for incorrect answers on hover. 
+        // keep red for incorrect answers on hover.
         &:hover {
           border-color: $incorrect;
         }
@@ -206,10 +206,10 @@ div.problem {
   }
 }
 
-// +Problem - Status Indicators 
-// ==================== 
-// Summary status indicators shown after the input area 
-div.problem { 
+// +Problem - Status Indicators
+// ====================
+// Summary status indicators shown after the input area
+div.problem {
 
   .indicator-container {
 
@@ -240,8 +240,8 @@ div.problem {
 }
 
 // +Problem - Misc, Unclassified Mess
-// ==================== 
-div.problem { 
+// ====================
+div.problem {
   ol.enumerate {
     li {
       &:before {
@@ -422,12 +422,12 @@ div.problem {
           background: #f1f1f1;
         }
       }
-    } 
+    }
 
     // Hides equation previews in symbolic response problems when printing
     [id^='display'].equation {
       @media print {
-        display:none;
+        display: none;
       }
     }
 
@@ -699,10 +699,10 @@ div.problem {
 }
 
 // +Problem - Text Input, Numerical Input
-// ==================== 
+// ====================
 .problem {
   .capa_inputtype.textline, .inputtype.formulaequationinput {
-    
+
     input {
       @include box-sizing(border-box);
       border: 2px solid $gray-l4;
@@ -723,7 +723,7 @@ div.problem {
     // CASE: incorrect answer
     > .incorrect {
 
-      input { 
+      input {
         border: 2px solid $incorrect;
       }
 
@@ -734,8 +734,8 @@ div.problem {
 
     // CASE: correct answer
     > .correct {
-      
-      input { 
+
+      input {
         border: 2px solid $correct;
       }
 
@@ -747,7 +747,7 @@ div.problem {
     // CASE: unanswered
     > .unanswered {
 
-      input { 
+      input {
         border: 2px solid $gray-l4;
       }
 
@@ -760,7 +760,7 @@ div.problem {
 
 
 // +Problem - Option Input (Dropdown)
-// ==================== 
+// ====================
 .problem {
   .inputtype.option-input {
     margin: (-$baseline/2) 0 $baseline;
@@ -781,8 +781,8 @@ div.problem {
 }
 
 // +Problem - CodeMirror
-// ==================== 
-div.problem { 
+// ====================
+div.problem {
 
   .CodeMirror {
     border: 1px solid black;
@@ -836,7 +836,7 @@ div.problem {
 }
 
 // +Problem - Actions
-// ==================== 
+// ====================
 div.problem .action {
   margin-top: $baseline;
 
@@ -847,6 +847,9 @@ div.problem .action {
     vertical-align: middle;
     text-transform: uppercase;
     font-weight: 600;
+    @media print {
+      display: none;
+    }
   }
 
   .save {
@@ -877,8 +880,8 @@ div.problem .action {
 }
 
 // +Problem - Misc, Unclassified Mess Part 2
-// ==================== 
-div.problem { 
+// ====================
+div.problem {
   hr {
     float: none;
     clear: both;
@@ -907,7 +910,7 @@ div.problem {
     padding: lh();
     border: 1px solid $gray-l3;
   }
-  
+
   .detailed-solution {
     > p:first-child {
       @extend %t-strong;
@@ -1159,7 +1162,7 @@ div.problem {
 
 
 // +Problem - Rubric
-// ==================== 
+// ====================
 div.problem {
   .rubric {
     tr {
@@ -1216,7 +1219,7 @@ div.problem {
 }
 
 // +Problem - Annotation
-// ==================== 
+// ====================
 div.problem {
   .annotation-input {
     margin: 0 0 1em 0;
@@ -1318,7 +1321,7 @@ div.problem {
 }
 
 // +Problem - Choice Text Group
-// ==================== 
+// ====================
 div.problem {
   .choicetextgroup {
     @extend .choicegroup;

--- a/lms/static/sass/course/courseware/_courseware.scss
+++ b/lms/static/sass/course/courseware/_courseware.scss
@@ -302,7 +302,7 @@ div.course-wrapper {
     }
 
     @media print {
-      padding: 0 2mm;
+      padding: 4mm 2mm 0;
       background: transparent !important;
     }
   }

--- a/lms/static/sass/course/layout/_courseware_preview.scss
+++ b/lms/static/sass/course/layout/_courseware_preview.scss
@@ -5,6 +5,10 @@
   padding: ($baseline*0.75);
   background-color: $gray-l3;
 
+  @media print {
+    display: none;
+  }
+
   .preview-menu {
     @extend %inner-wrapper;
     width: auto;

--- a/lms/static/sass/discussion/_discussion.scss
+++ b/lms/static/sass/discussion/_discussion.scss
@@ -673,7 +673,6 @@ body.discussion {
 // inline discussion module and profile thread styling
 .discussion-module {
   @extend .discussion-body;
-  @extend %ui-print-excluded;
 
   position: relative;
   margin: $baseline 0;
@@ -1017,6 +1016,10 @@ body.discussion {
   .discussion-post {
     padding-bottom: $baseline !important;
   }
+}
+
+.xblock-student_view-discussion {
+  @extend %ui-print-excluded;
 }
 
 // ====================


### PR DESCRIPTION
This PR includes a number of small changes to styling to improve user printing in the LMS. The changes include the following:
- Hiding action buttons in CAPA problems
- Hiding the course preview menu for staff
- Hiding inline discussion forums
- Adding to the margin below the header for aesthetics

All of these were fixed previously, but were undone by subsequent large-scale styling updates which ignored printing.
