### PR TITLE
Cypress - skip test that had a hardcoded date expectation

### DIFF
--- a/lms/djangoapps/mobile_api/testutils.py
+++ b/lms/djangoapps/mobile_api/testutils.py
@@ -12,6 +12,7 @@ Test utilities for mobile API tests:
 # pylint: disable=no-member
 import ddt
 from mock import patch
+from unittest import skip
 
 from django.core.urlresolvers import reverse
 
@@ -159,6 +160,7 @@ class MobileCourseAccessTestMixin(MobileAPIMilestonesMixin):
         response = self.api_response(expected_response_code=None, course_id=non_existent_course_id)
         self.verify_failure(response)  # allow subclasses to override verification
 
+    @skip  # TODO fix this, see MA-1038
     @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
     def test_unreleased_course(self):
         self.init_course_access()


### PR DESCRIPTION
@singingwolfboy @sarina 
