### PR TITLE
ECOM-1911: Fixes to credit requirements in Studio.

### DIFF
--- a/openedx/core/djangoapps/credit/models.py
+++ b/openedx/core/djangoapps/credit/models.py
@@ -286,6 +286,7 @@ class CreditRequirement(TimeStampedModel):
         Model metadata.
         """
         unique_together = ('namespace', 'name', 'course')
+        ordering = ["order"]
 
     @classmethod
     def add_or_update_course_requirement(cls, credit_course, requirement, order):
@@ -337,7 +338,7 @@ class CreditRequirement(TimeStampedModel):
 
         """
         # order credit requirements according to their appearance in courseware
-        requirements = CreditRequirement.objects.filter(course__course_key=course_key, active=True).order_by("-order")
+        requirements = CreditRequirement.objects.filter(course__course_key=course_key, active=True)
 
         if namespace is not None:
             requirements = requirements.filter(namespace=namespace)

--- a/openedx/core/djangoapps/credit/tests/test_tasks.py
+++ b/openedx/core/djangoapps/credit/tests/test_tasks.py
@@ -3,14 +3,16 @@ Tests for credit course tasks.
 """
 
 import mock
-from datetime import datetime
+from datetime import datetime, timedelta
 
+from pytz import UTC
 from openedx.core.djangoapps.credit.api import get_credit_requirements
 from openedx.core.djangoapps.credit.exceptions import InvalidCreditRequirements
 from openedx.core.djangoapps.credit.models import CreditCourse
 from openedx.core.djangoapps.credit.signals import on_course_publish
+from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, check_mongo_calls
+from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, check_mongo_calls_range
 
 from edx_proctoring.api import create_exam
 
@@ -30,22 +32,32 @@ class TestTaskExecution(ModuleStoreTestCase):
         """
         raise InvalidCreditRequirements
 
-    def add_icrv_xblock(self):
+    def add_icrv_xblock(self, related_assessment_name=None, start_date=None):
         """ Create the 'edx-reverification-block' in course tree """
-
-        section = ItemFactory.create(parent=self.course, category='chapter', display_name='Test Section')
-        subsection = ItemFactory.create(parent=section, category='sequential', display_name='Test Subsection')
-        vertical = ItemFactory.create(parent=subsection, category='vertical', display_name='Test Unit')
-        ItemFactory.create(
-            parent=vertical,
+        block = ItemFactory.create(
+            parent=self.vertical,
             category='edx-reverification-block',
-            display_name='Test Verification Block'
         )
+
+        if related_assessment_name is not None:
+            block.related_assessment = related_assessment_name
+
+        block.start = start_date
+
+        self.store.update_item(block, ModuleStoreEnum.UserID.test)
+
+        with self.store.branch_setting(ModuleStoreEnum.Branch.draft_preferred, self.course.id):
+            self.store.publish(block.location, ModuleStoreEnum.UserID.test)
+
+        return block
 
     def setUp(self):
         super(TestTaskExecution, self).setUp()
 
         self.course = CourseFactory.create(start=datetime(2015, 3, 1))
+        self.section = ItemFactory.create(parent=self.course, category='chapter', display_name='Test Section')
+        self.subsection = ItemFactory.create(parent=self.section, category='sequential', display_name='Test Subsection')
+        self.vertical = ItemFactory.create(parent=self.subsection, category='vertical', display_name='Test Unit')
 
     def test_task_adding_requirements_invalid_course(self):
         """
@@ -172,8 +184,64 @@ class TestTaskExecution(ModuleStoreTestCase):
         self.add_credit_course(self.course.id)
         self.add_icrv_xblock()
 
-        with check_mongo_calls(3):
+        with check_mongo_calls_range(max_finds=7):
             on_course_publish(self.course.id)
+
+    def test_remove_icrv_requirement(self):
+        self.add_credit_course(self.course.id)
+        self.add_icrv_xblock()
+        on_course_publish(self.course.id)
+
+        # There should be one ICRV requirement
+        requirements = get_credit_requirements(self.course.id, namespace="reverification")
+        self.assertEqual(len(requirements), 1)
+
+        # Delete the parent section containing the ICRV block
+        with self.store.branch_setting(ModuleStoreEnum.Branch.draft_preferred, self.course.id):
+            self.store.delete_item(self.subsection.location, ModuleStoreEnum.UserID.test)
+
+        # Check that the ICRV block is no longer visible in the requirements
+        on_course_publish(self.course.id)
+        requirements = get_credit_requirements(self.course.id, namespace="reverification")
+        self.assertEqual(len(requirements), 0)
+
+    def test_icrv_requirement_ordering(self):
+        self.add_credit_course(self.course.id)
+
+        # Create multiple ICRV blocks
+        start = datetime.now(UTC)
+        self.add_icrv_xblock(related_assessment_name="Midterm A", start_date=start)
+
+        start = start - timedelta(days=1)
+        self.add_icrv_xblock(related_assessment_name="Midterm B", start_date=start)
+
+        # Primary sort is based on start date
+        on_course_publish(self.course.id)
+        requirements = get_credit_requirements(self.course.id, namespace="reverification")
+        self.assertEqual(len(requirements), 2)
+        self.assertEqual(requirements[0]["display_name"], "Midterm B")
+        self.assertEqual(requirements[1]["display_name"], "Midterm A")
+
+        # Add two additional ICRV blocks that have no start date
+        # and the same name.
+        start = datetime.now(UTC)
+        first_block = self.add_icrv_xblock(related_assessment_name="Midterm Start Date")
+
+        start = start + timedelta(days=1)
+        second_block = self.add_icrv_xblock(related_assessment_name="Midterm Start Date")
+
+        on_course_publish(self.course.id)
+        requirements = get_credit_requirements(self.course.id, namespace="reverification")
+        self.assertEqual(len(requirements), 4)
+        self.assertEqual(requirements[0]["display_name"], "Midterm Start Date")
+        self.assertEqual(requirements[1]["display_name"], "Midterm Start Date")
+        self.assertEqual(requirements[2]["display_name"], "Midterm B")
+        self.assertEqual(requirements[3]["display_name"], "Midterm A")
+
+        # Since the first two requirements have the same display name,
+        # we need to also check that their internal names (locations) are the same.
+        self.assertEqual(requirements[0]["name"], first_block.get_credit_requirement_name())
+        self.assertEqual(requirements[1]["name"], second_block.get_credit_requirement_name())
 
     @mock.patch(
         'openedx.core.djangoapps.credit.tasks.set_credit_requirements',


### PR DESCRIPTION
- Exclude orphaned XBlocks from requirements because they have been deleted.
- Sort ICRV requirements by start date, then by display name.

JIRA: [ECOM-1911](https://openedx.atlassian.net/browse/ECOM-1911)

@jimabramson please review when you have a moment.
