### PR TITLE
PLAT-723 - pymongo 3.0.3 migration

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -229,3 +229,5 @@ Pan Luo <pan.luo@ubc.ca>
 Tyler Nickerson <nickersoft@gmail.com>
 Vedran Karačić <vedran@edx.org>
 William Ono <william.ono@ubc.ca>
+Brian Beggs <bbeggs@edx.org>
+

--- a/common/djangoapps/track/backends/mongodb.py
+++ b/common/djangoapps/track/backends/mongodb.py
@@ -89,7 +89,7 @@ class MongoBackend(BaseBackend):
     def send(self, event):
         """Insert the event in to the Mongo collection"""
         try:
-            self.collection.insert(event, manipulate=False)
+            self.collection.insert_one(event)
         except (PyMongoError, BSONError):
             # The event will be lost in case of a connection error or any error
             # that occurs when trying to insert the event into Mongo.

--- a/common/lib/xmodule/xmodule/modulestore/mongo/draft.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/draft.py
@@ -164,7 +164,7 @@ class DraftModuleStore(MongoModuleStore):
 
         # delete all of the db records for the course
         course_query = self._course_key_to_son(course_key)
-        self.collection.remove(course_query, multi=True)
+        self.collection.delete_many(course_query)
         self.delete_all_asset_metadata(course_key, user_id)
 
     def clone_course(self, source_course_id, dest_course_id, user_id, fields=None, **kwargs):
@@ -432,7 +432,7 @@ class DraftModuleStore(MongoModuleStore):
             bulk_record = self._get_bulk_ops_record(location.course_key)
             bulk_record.dirty = True
             try:
-                self.collection.insert(item)
+                self.collection.insert_one(item)
             except pymongo.errors.DuplicateKeyError:
                 # prevent re-creation of DRAFT versions, unless explicitly requested to ignore
                 if not ignore_if_draft:
@@ -635,7 +635,7 @@ class DraftModuleStore(MongoModuleStore):
         if len(to_be_deleted) > 0:
             bulk_record = self._get_bulk_ops_record(root_usages[0].course_key)
             bulk_record.dirty = True
-            self.collection.remove({'_id': {'$in': to_be_deleted}}, safe=self.collection.safe)
+            self.collection.delete_many({'_id': {'$in': to_be_deleted}})
 
     @memoize_in_request_cache('request_cache')
     def has_changes(self, xblock):
@@ -739,7 +739,7 @@ class DraftModuleStore(MongoModuleStore):
         bulk_record = self._get_bulk_ops_record(course_key)
         if len(to_be_deleted) > 0:
             bulk_record.dirty = True
-            self.collection.remove({'_id': {'$in': to_be_deleted}})
+            self.collection.delete_many({'_id': {'$in': to_be_deleted}})
 
         self._flag_publish_event(course_key)
 

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
@@ -678,7 +678,7 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
         """
         Closes any open connections to the underlying databases
         """
-        self.db.connection.close()
+        self.db.client.close()
 
     def mongo_wire_version(self):
         """
@@ -694,7 +694,7 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
         # drop the assets
         super(SplitMongoModuleStore, self)._drop_database()
 
-        connection = self.db.connection
+        connection = self.db.client
         connection.drop_database(self.db.name)
         connection.close()
 

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_mixed_modulestore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_mixed_modulestore.py
@@ -1180,7 +1180,7 @@ class TestMixedModuleStore(CommonMixedModuleStoreSetup):
 
         mongo_store = self.store._get_modulestore_for_courselike(course_id)  # pylint: disable=protected-access
         # add another parent (unit) "vertical_x1b" for problem "problem_x1a_1"
-        mongo_store.collection.update(
+        mongo_store.collection.update_many(
             self.vertical_x1b.to_deprecated_son('_id.'),
             {'$push': {'definition.children': unicode(self.problem_x1a_1)}}
         )
@@ -1455,11 +1455,11 @@ class TestMixedModuleStore(CommonMixedModuleStoreSetup):
         self.assertEqual(len(set(found_orphans)), 2)
 
         # add orphan vertical and sequential as another parents of problem "problem_x1a_1"
-        mongo_store.collection.update(
+        mongo_store.collection.update_many(
             orphan_sequential.to_deprecated_son('_id.'),
             {'$push': {'definition.children': unicode(self.problem_x1a_1)}}
         )
-        mongo_store.collection.update(
+        mongo_store.collection.update_many(
             orphan_vertical.to_deprecated_son('_id.'),
             {'$push': {'definition.children': unicode(self.problem_x1a_1)}}
         )
@@ -1470,7 +1470,7 @@ class TestMixedModuleStore(CommonMixedModuleStoreSetup):
             self.assertEqual(parent, self.vertical_x1a)
 
         # now add valid published vertical as another parent of problem
-        mongo_store.collection.update(
+        mongo_store.collection.update_many(
             self.sequential_x1.to_deprecated_son('_id.'),
             {'$push': {'definition.children': unicode(self.problem_x1a_1)}}
         )

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -51,7 +51,7 @@ Markdown==2.2.1
 --allow-external meliae
 --allow-unverified meliae
 meliae==0.4.0
-mongoengine==0.7.10
+mongoengine==0.10.0
 networkx==1.7
 nose==1.3.3
 oauthlib==0.7.2
@@ -63,7 +63,7 @@ pycrypto>=2.6
 pygments==2.0.1
 pygraphviz==1.1
 PyJWT==1.0.1
-pymongo==2.7.2
+pymongo==3.0.3
 pyparsing==2.0.1
 python-memcached==1.48
 python-openid==2.2.5
@@ -156,3 +156,4 @@ analytics-python==0.4.4
 # Needed for mailchimp(mailing djangoapp)
 mailsnake==1.6.2
 jsonfield==1.0.3
+blinker


### PR DESCRIPTION
My first pass at https://openedx.atlassian.net/browse/PLAT-723

While running the tests on this upgrade I have noticed that CPU usage inside of devstack has increased by about 2x. I was seeing CPU usage of around 89-100% with pymongo 2.7. With the upgrade I'm seeing cpu usage of around 150-200%. 

Some of the unit tests seem like they take a (very) long to complete such as:
test_container_get_query_count_3__3__30_ (cms.djangoapps.contentstore.views.tests.test_item.GetItemTest) ... #5

I am hoping that this PR will functionally fix everything that needs to be updated for the pymongo 3.0.3 upgrade. The app still needs to be load tested to verify that this is a good release.

Will also need to pull in edx/edx-platform/pull/8980 which will hopefully improve the speed of the testing.
