### PR TITLE
Enable Credit API

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -408,7 +408,7 @@ FEATURES = {
     'ENABLE_OPENBADGES': False,
 
     # Credit course API
-    'ENABLE_CREDIT_API': False,
+    'ENABLE_CREDIT_API': True,
 
     # The block types to disable need to be specified in "x block disable config" in django admin.
     'ENABLE_DISABLING_XBLOCK_TYPES': True,


### PR DESCRIPTION
The Course Administration Tool will benefit from having access to the `api/credit/v1/providers/` endpoint. Once the API is enabled, we should be able to configure test providers on stage using the Django admin.

@wedaly @clintonb
