### PR TITLE
Remove unnecessary DB call in team pagination.

### DIFF
--- a/lms/djangoapps/teams/views.py
+++ b/lms/djangoapps/teams/views.py
@@ -319,7 +319,14 @@ class TeamsListView(ExpandableFieldViewMixin, GenericAPIView):
 
         queryset = queryset.order_by(order_by_field)
 
-        page = self.paginate_queryset(queryset)
+        # TODO: Remove this on update to Django 1.8
+        # Use the cached length of the queryset in order to avoid
+        # making an extra database call to get the number of items in
+        # the collection
+        paginator = self.paginator_class(queryset, self.get_paginate_by())
+        paginator._count = len(queryset)  # pylint: disable=protected-access
+        page = paginator.page(int(request.QUERY_PARAMS.get('page', 1)))
+        # end TODO
         serializer = self.get_pagination_serializer(page)
         serializer.context.update({'sort_order': order_by_input})  # pylint: disable=maybe-no-member
         return Response(serializer.data)  # pylint: disable=maybe-no-member


### PR DESCRIPTION
In order to verify this, you can go to `/api/team/v0/teams?course_id=edX%2FDemoX%2FDemo_Course` before checking out the changes. You should see a SQL query along the lines of 

``` sql
SELECT COUNT(*) FROM `teams_courseteam` WHERE (`teams_courseteam`.`course_id` = %s  AND `teams_courseteam`.`is_active` = %s )
```

After the changes, that query should not be present.

@dianakhuang @dan-f 
