### PR TITLE
Fix broken Jasmine tests for course discovery

### DIFF
--- a/lms/static/js/spec/discovery/discovery_spec.js
+++ b/lms/static/js/spec/discovery/discovery_spec.js
@@ -220,16 +220,6 @@ define([
                 expect(this.result.get('id')).toBeDefined();
             });
 
-        it('renders correctly', function () {
-            var data = this.item.model.attributes;
-            this.item.render();
-            expect(this.item.$el).toContainHtml(data.content.display_name);
-            expect(this.item.$el).toContain('a[href="/courses/' + data.course + '/about"]');
-            expect(this.item.$el).toContain('img[src="' + data.image_url + '"]');
-            expect(this.item.$el.find('.course-name')).toContainHtml(data.org);
-            expect(this.item.$el.find('.course-name')).toContainHtml(data.content.number);
-            expect(this.item.$el.find('.course-name')).toContainHtml(data.content.display_name);
-            expect(this.item.$el.find('.course-date')).toContainHtml('Jan 01, 1970');
         });
 
 
@@ -246,7 +236,7 @@ define([
                 var data = this.item.model.attributes;
                 this.item.render();
                 expect(this.item.$el).toContainHtml(data.content.display_name);
-                expect(this.item.$el).toContain('a[href="/courses/' + data.course + '/info"]');
+                expect(this.item.$el).toContain('a[href="/courses/' + data.course + '/about"]');
                 expect(this.item.$el).toContain('img[src="' + data.image_url + '"]');
                 expect(this.item.$el.find('.course-name')).toContainHtml(data.org);
                 expect(this.item.$el.find('.course-name')).toContainHtml(data.content.number);
@@ -492,8 +482,7 @@ define([
 
         });
 
-
-        describe('Discovery App', function () {
+        describe('Discovery Factory', function () {
 
             beforeEach(function () {
                 loadFixtures('js/fixtures/discovery.html');


### PR DESCRIPTION
I discovered that the discovery_spec was being skipped on master because it was malformed JavaScript. It seems that there was a bad merge that ended up duplicating a section without the necessary closing tags.

@cahrens @dsego Please review
