### PR TITLE
SOL-1045: hiding generated certificate button in case of self paced courses

### DIFF
--- a/lms/djangoapps/instructor/tests/test_certificates.py
+++ b/lms/djangoapps/instructor/tests/test_certificates.py
@@ -111,6 +111,23 @@ class CertificatesInstructorDashTest(ModuleStoreTestCase):
         self.assertContains(response, 'enable-certificates-submit')
         self.assertNotContains(response, 'Generate Example Certificates')
 
+    @mock.patch.dict(settings.FEATURES, {'CERTIFICATES_HTML_VIEW': True})
+    def test_buttons_for_html_certs_in_self_paced_course(self):
+        """
+        Tests `Enable Student-Generated Certificates` button is enabled
+        and `Generate Certificates` button is not available if
+        course has Web/HTML certificates view enabled on a self paced course.
+        """
+        self.course.cert_html_view_enabled = True
+        self.course.save()
+        self.store.update_item(self.course, self.global_staff.id)  # pylint: disable=no-member
+        self.client.login(username=self.global_staff.username, password="test")
+        response = self.client.get(self.url)
+        self.assertContains(response, 'Enable Student-Generated Certificates')
+        self.assertContains(response, 'enable-certificates-submit')
+        self.assertNotContains(response, 'Generate Certificates')
+        self.assertNotContains(response, 'btn-start-generating-certificates')
+
     def _assert_certificates_visible(self, is_visible):
         """Check that the certificates section is visible on the instructor dash. """
         response = self.client.get(self.url)

--- a/lms/templates/instructor/instructor_dashboard_2/certificates.html
+++ b/lms/templates/instructor/instructor_dashboard_2/certificates.html
@@ -58,7 +58,7 @@
         % endif
     </div>
 
-    % if section_data['instructor_generation_enabled']:
+    % if section_data['instructor_generation_enabled'] and not (section_data['enabled_for_course'] and section_data['html_cert_enabled']):
         <hr />
 
         <div class="start-certificate-generation">


### PR DESCRIPTION
@mattdrayer this is a fix for SOL-1045. It is required to hide "Generate Certificates" button when web certificates is enabled for self-paced courses.
