### PR TITLE
Fixed MathJax rendering in problem hint

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/capa/display.coffee
+++ b/common/lib/xmodule/xmodule/js/src/capa/display.coffee
@@ -711,7 +711,13 @@ class @Problem
     else
       next_index = parseInt(hint_index) + 1
     $.postWithPrefix "#{@url}/hint_button", hint_index: next_index, input_id: @id, (response) =>
-      @$('.problem-hint').html(response.contents)
-      @$('.problem-hint').attr('hint_index', response.hint_index)
+      hint_container = @.$('.problem-hint')
+      hint_container.html(response.contents)
+      MathJax.Hub.Queue [
+        'Typeset'
+        MathJax.Hub
+        hint_container[0]
+      ]
+      hint_container.attr('hint_index', response.hint_index)
       @$('.hint-button').focus()  # a11y focus on click, like the Check button
 

--- a/common/test/acceptance/pages/lms/problem.py
+++ b/common/test/acceptance/pages/lms/problem.py
@@ -42,6 +42,22 @@ class ProblemPage(PageObject):
         """
         return self.q(css="div.problem div.problem-hint").text[0]
 
+    @property
+    def mathjax_rendered_in_problem(self):
+        """
+        Check that MathJax have been rendered in problem hint
+        """
+        mathjax_container = self.q(css="div.problem p .MathJax .math")
+        return mathjax_container.visible and mathjax_container.present
+
+    @property
+    def mathjax_rendered_in_hint(self):
+        """
+        Check that MathJax have been rendered in problem hint
+        """
+        mathjax_container = self.q(css="div.problem div.problem-hint .MathJax .math")
+        return mathjax_container.visible and mathjax_container.present
+
     def fill_answer(self, text):
         """
         Fill in the answer to the problem.


### PR DESCRIPTION
A case where if you add `Mathjax` in a problem hint, it was not rendered. 
## To Test
1. Create a Unit with `Problem` - >`Blank Common Problem`
2. Edit the problem, and goto `Advance Editor`
3. Paste the following problem

```
<problem>
<p>This question demonstrates that mathjax doesn't work in hints. To view, click 'HINT' twice.</p>
  <p> Here is working mathjax in text: \(E=mc^2\)</p>
<multiplechoiceresponse>
  <choicegroup label="Which of the following is a vegetable?" type="MultipleChoice"> 
    <choice correct="true">potato <choicehint>A potato is an edible part of a plant in tuber form and is a vegetable.</choicehint></choice>
    <choice correct="false">Here is working mathjax in a choice:  \(E=mc^2\) However, click check, and inline mathjax does not look right. This is partially covered in TNL-298. (i.e. not the focus of this bug, but related).<choicehint>This equation should be inline and red: \(E=mc^2\) Instead, it is black and in a new line in the LMS. </choicehint></choice>
  </choicegroup>
</multiplechoiceresponse>
<demandhint>
        <hint>And mathjax \(E=mc^2\) doesn't work at all in hints.</hint>
        <hint>Let's try it this way [mathjax]E=mc^2[/mathjax] nope that doesn't work.</hint> 
</demandhint>
</problem>
```

Click `Ok` and click the `Hint` button. Observe `Mathjax` has not been rendered. It is rendered as `\(E=mc^2\)` and it should be `E is equal to mc square`
## Jira

[Mathjax doesn't work in hints - TNL-2857](https://openedx.atlassian.net/browse/TNL-2857)
