### PR TITLE
Redirect to dashboard from non-live courses.

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -662,8 +662,16 @@ def dashboard(request):
             user, course_org_filter, org_filter_out_set
         )
 
+    if 'notlive' in request.GET:
+        redirect_message = _("The course you are looking for does not start until {0}.").format(
+            request.GET['notlive']
+        )
+    else:
+        redirect_message = ''
+
     context = {
         'enrollment_message': enrollment_message,
+        'redirect_message': redirect_message,
         'course_enrollments': course_enrollments,
         'course_optouts': course_optouts,
         'message': message,

--- a/common/test/acceptance/pages/lms/dashboard.py
+++ b/common/test/acceptance/pages/lms/dashboard.py
@@ -48,6 +48,17 @@ class DashboardPage(PageObject):
 
         return self.q(css='h3.course-title > a').map(_get_course_name).results
 
+    @property
+    def banner_text(self):
+        """
+        Return the text of the banner on top of the page, or None if
+        the banner is not present.
+        """
+        message = self.q(css='div.wrapper-msg')
+        if message.present:
+            return message.text[0]
+        return None
+
     def get_enrollment_mode(self, course_name):
         """Get the enrollment mode for a given course on the dashboard.
 

--- a/lms/static/js/views/message_banner.js
+++ b/lms/static/js/views/message_banner.js
@@ -6,7 +6,11 @@
 
         var MessageBannerView = Backbone.View.extend({
 
-            initialize: function () {
+            initialize: function (options) {
+                if (_.isUndefined(options)) {
+                    options = {};
+                }
+                this.options = _.defaults(options, {urgency: 'high', type: ''});
                 this.template = _.template($('#message_banner-tpl').text());
             },
 
@@ -14,9 +18,9 @@
                 if (_.isUndefined(this.message) || _.isNull(this.message)) {
                     this.$el.html('');
                 } else {
-                    this.$el.html(this.template({
+                    this.$el.html(this.template(_.extend(this.options, {
                         message: this.message
-                    }));
+                    })));
                 }
                 return this;
             },

--- a/lms/static/lms/js/build.js
+++ b/lms/static/lms/js/build.js
@@ -27,6 +27,7 @@
             'js/student_account/views/account_settings_factory',
             'js/student_account/views/finish_auth_factory',
             'js/student_profile/views/learner_profile_factory',
+            'js/views/message_banner',
             'teams/js/teams_tab_factory'
         ]),
 

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -7,6 +7,7 @@ import third_party_auth
 from third_party_auth import pipeline
 from microsite_configuration import microsite
 from django.core.urlresolvers import reverse
+import json
 %>
 
 <%
@@ -23,6 +24,9 @@ from django.core.urlresolvers import reverse
 % for template_name in ["donation"]:
 <script type="text/template" id="${template_name}-tpl">
   <%static:include path="dashboard/${template_name}.underscore" />
+</script>
+<script type="text/template" id="message_banner-tpl">
+  <%static:include path="fields/message_banner.underscore" />
 </script>
 % endfor
 
@@ -47,6 +51,13 @@ from django.core.urlresolvers import reverse
   % if settings.FEATURES.get('ENABLE_DASHBOARD_SEARCH'):
     <%static:require_module module_name="js/search/dashboard/dashboard_search_factory" class_name="DashboardSearchFactory">
         DashboardSearchFactory();
+    </%static:require_module>
+  % endif
+  % if redirect_message:
+    <%static:require_module module_name="js/views/message_banner" class_name="MessageBannerView">
+        var banner = new MessageBannerView({urgency: 'low', type: 'warning'});
+        $('#content').prepend(banner.$el);
+        banner.showMessage(${json.dumps(redirect_message)})
     </%static:require_module>
   % endif
 </%block>

--- a/lms/templates/fields/message_banner.underscore
+++ b/lms/templates/fields/message_banner.underscore
@@ -1,4 +1,4 @@
-<div class="wrapper-msg urgency-high">
+<div class="wrapper-msg urgency-<%= urgency %> <%= type %>">
     <div class="msg">
         <div class="msg-content">
             <div class="copy">


### PR DESCRIPTION
Prevents students from seeing confusing 404s when trying to access a course that's not live yet.

[TNL-2693](https://openedx.atlassian.net/browse/TNL-2693)

@catong, can you take a look at the message [here](https://github.com/edx/edx-platform/pull/9020/files#diff-55b798ee23a7fde8d1103408afcd0f16R666)? [Sandbox is here.](http://peter-fogg.m.sandbox.edx.org/dashboard)
