### PR TITLE
Fix TNL-2267 - add missing service argument to HeartbeatFailure constructor

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/mongo_connection.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/mongo_connection.py
@@ -309,7 +309,7 @@ class MongoConnection(object):
         if self.database.connection.alive():
             return True
         else:
-            raise HeartbeatFailure("Can't connect to {}".format(self.database.name))
+            raise HeartbeatFailure("Can't connect to {}".format(self.database.name), 'mongo')
 
     def get_structure(self, key, course_context=None):
         """

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_split_mongo_mongo_connection.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_split_mongo_mongo_connection.py
@@ -1,0 +1,19 @@
+""" Test the behavior of split_mongo/MongoConnection """
+import unittest
+from mock import patch
+from xmodule.modulestore.split_mongo.mongo_connection import MongoConnection
+from xmodule.exceptions import HeartbeatFailure
+
+
+class TestHeartbeatFailureException(unittest.TestCase):
+    """ Test that a heartbeat failure is thrown at the appropriate times """
+    @patch('pymongo.MongoClient')
+    @patch('pymongo.database.Database')
+    def test_heartbeat_raises_exception_when_connection_alive_is_false(self, *calls):
+        # pylint: disable=W0613
+        with patch('mongodb_proxy.MongoProxy') as mock_proxy:
+            mock_proxy.return_value.alive.return_value = False
+            useless_conn = MongoConnection('useless', 'useless', 'useless')
+
+            with self.assertRaises(HeartbeatFailure):
+                useless_conn.heartbeat()


### PR DESCRIPTION
This adds the missing second argument, 'service', to the HeartbeatFailure constructor in split_mongo/mongo_connection, as well as adding a test for the heartbeat method to ensure it raises a HeartbeatFailure exception when the underlying connection is not alive.
