### PR TITLE
Make active menu highlight in blue.

### DIFF
--- a/cms/static/sass/elements/_header.scss
+++ b/cms/static/sass/elements/_header.scss
@@ -336,36 +336,50 @@ body.howitworks .nav-not-signedin-hiw,
 body.dashboard .nav-account-dashboard,
 
 // course content
-body.course.outline .nav-course-courseware .title,
-body.course.updates .nav-course-courseware .title,
-body.course.pages .nav-course-courseware .title,
-body.course.uploads .nav-course-courseware .title,
+body.course.view-outline .nav-course-courseware .title,
+body.course.view-updates .nav-course-courseware .title,
+body.course.view-static-pages .nav-course-courseware .title,
+body.course.view-uploads .nav-course-courseware .title,
+body.course.view-textbooks .nav-course-courseware .title,
+body.course.view-video-uploads .nav-course-courseware .title,
 
-body.course.outline .nav-course-courseware-outline,
-body.course.updates .nav-course-courseware-updates,
-body.course.pages .nav-course-courseware-pages,
-body.course.uploads .nav-course-courseware-uploads,
-body.course.textbooks .nav-course-courseware-textbooks,
+body.course.view-outline .nav-course-courseware-outline,
+body.course.view-updates .nav-course-courseware-updates,
+body.course.view-static-pages .nav-course-courseware-pages,
+body.course.view-uploads .nav-course-courseware-uploads,
+body.course.view-textbooks .nav-course-courseware-textbooks,
+body.course.view-video-uploads .nav-course-courseware-video,
 
 // course settings
 body.course.schedule .nav-course-settings .title,
 body.course.grading .nav-course-settings .title,
-body.course.team .nav-course-settings .title,
+body.course.view-team .nav-course-settings .title,
+body.course.view-group-configurations .nav-course-settings .title,
 body.course.advanced .nav-course-settings .title,
+body.course.view-certificates .nav-course-settings .title,
 
 body.course.schedule .nav-course-settings-schedule,
 body.course.grading .nav-course-settings-grading,
-body.course.team .nav-course-settings-team,
+body.course.view-team .nav-course-settings-team,
+body.course.view-group-configurations .nav-course-settings-group-configurations,
 body.course.advanced .nav-course-settings-advanced,
+body.course.view-certificates .nav-course-settings-certificates,
 
 // course tools
-body.course.import .nav-course-tools .title,
-body.course.export .nav-course-tools .title,
-body.course.checklists .nav-course-tools .title,
+body.course.view-import .nav-course-tools .title,
+body.course.view-export .nav-course-tools .title,
+body.course.view-checklists .nav-course-tools .title,
+body.course.view-export-git .nav-course-tools .title,
 
-body.course.import .nav-course-tools-import,
-body.course.export .nav-course-tools-export,
-body.course.checklists .nav-course-tools-checklists,
+body.course.view-import .nav-course-tools-import,
+body.course.view-export .nav-course-tools-export,
+body.course.view-checklists .nav-course-tools-checklists,
+body.course.view-export-git .nav-course-tools-export-git,
+
+// content library settings
+body.course.view-team .nav-library-settings .title,
+
+body.course.view-team .nav-library-settings-team,
 
 {
   color: $blue;


### PR DESCRIPTION
TNL-296

@talbs can you review? I'm happy to spin up a sandbox if helpful, but figured you might just want to check it out and play with it.

Some of the older menu items that actually worked don't have a unique "view-XX" on the body; for those, I left what was there. Otherwise, I changed everything to use the "view-XX" syntax.

Note that I wasn't able to test the video upload item or the git import item-- I'm just hoping that they work (on prod I was at least able to find a course with video uploads enabled, so I checked the class being put on the body; as far as I know, there is no way to check git upload).

For content libraries, the class names are unique for the "Settings" menu, but share the same Tools menu class names for Import and Export (so those "just worked").
