### PR TITLE
Add in-course reverification to advanced components.

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -955,6 +955,9 @@ ADVANCED_COMPONENT_TYPES = [
     # embed public google drive documents and calendars within edX units
     'google-document',
     'google-calendar',
+
+    # In-course reverification checkpoint
+    'edx-reverification-block',
 ]
 
 # Adding components in this list will disable the creation of new problem for those


### PR DESCRIPTION
Adds in-course reverification to the list of allowed "advanced components" in Studio.  Course authors will need to enable reverification in the advanced settings of the course to be able to use this.

@andy-armstrong could I trouble you for a review?
FYI: @zubair-arbi 
