### PR TITLE
Teams-related JS test cleanup

### DIFF
--- a/common/static/common/js/spec/components/paginated_view_spec.js
+++ b/common/static/common/js/spec/components/paginated_view_spec.js
@@ -1,10 +1,11 @@
 define([
+    'jquery',
     'backbone',
     'underscore',
     'common/js/spec_helpers/ajax_helpers',
     'common/js/components/views/paginated_view',
     'common/js/components/collections/paging_collection'
-], function (Backbone, _, AjaxHelpers, PaginatedView, PagingCollection) {
+], function ($, Backbone, _, AjaxHelpers, PaginatedView, PagingCollection) {
     'use strict';
     describe('PaginatedView', function () {
         var TestItemView = Backbone.View.extend({

--- a/common/static/common/js/spec/components/paging_collection_spec.js
+++ b/common/static/common/js/spec/components/paging_collection_spec.js
@@ -239,7 +239,7 @@ define(['jquery',
                             }
                             expect(collection.getPage()).toBe(newPage);
                         }
-                    )
+                    );
                 });
             });
         });

--- a/common/static/common/js/spec/components/paging_footer_spec.js
+++ b/common/static/common/js/spec/components/paging_footer_spec.js
@@ -1,10 +1,11 @@
 define([
+    'jquery',
     'URI',
     'underscore',
     'common/js/spec_helpers/ajax_helpers',
     'common/js/components/views/paging_footer',
     'common/js/components/collections/paging_collection'
-], function (URI, _, AjaxHelpers, PagingFooter, PagingCollection) {
+], function ($, URI, _, AjaxHelpers, PagingFooter, PagingCollection) {
     'use strict';
     describe("PagingFooter", function () {
         var pagingFooter,

--- a/common/static/common/js/spec/components/paging_header_spec.js
+++ b/common/static/common/js/spec/components/paging_header_spec.js
@@ -1,7 +1,8 @@
 define([
+    'underscore',
     'common/js/components/views/paging_header',
     'common/js/components/collections/paging_collection'
-], function (PagingHeader, PagingCollection) {
+], function (_, PagingHeader, PagingCollection) {
         'use strict';
         describe('PagingHeader', function () {
             var pagingHeader,

--- a/lms/djangoapps/teams/static/teams/js/spec/teams_factory_spec.js
+++ b/lms/djangoapps/teams/static/teams/js/spec/teams_factory_spec.js
@@ -11,7 +11,7 @@ define(["jquery", "backbone", "teams/js/teams_tab_factory"],
                     topics: {results: []},
                     topics_url: '',
                     teams_url: '',
-                    maxTeamSize: 9999
+                    maxTeamSize: 9999,
                     course_id: 'edX/DemoX/Demo_Course'
                 });
             });

--- a/lms/djangoapps/teams/static/teams/js/teams_tab_factory.js
+++ b/lms/djangoapps/teams/static/teams/js/teams_tab_factory.js
@@ -1,8 +1,8 @@
 ;(function (define) {
     'use strict';
 
-    define(['jquery', 'teams/js/views/teams_tab'],
-        function ($, TeamsTabView) {
+    define(['jquery', 'underscore', 'backbone', 'teams/js/views/teams_tab'],
+        function ($, _, Backbone, TeamsTabView) {
             return function (options) {
                 var teamsTab = new TeamsTabView(_.extend(options, {el: $('.teams-content')}));
                 teamsTab.render();


### PR DESCRIPTION
@andy-armstrong or @dan-f please review.

The teams factory spec wasn't running because of a syntax error.

Note that https://build.testeng.edx.org/job/edx-platform-js-pr/1010/cobertura/javascript/ still claims that the common specs aren't running (the ones I cleaned up), but when I put intentional errors in the test cases, they did fail in Jenkins. So the coverage report just isn't finding them (I let @clytwynec know).
