### PR TITLE
Fix conflicting 0004_ migrations on course_overviews

### DIFF
--- a/openedx/core/djangoapps/content/course_overviews/migrations/0005_add_enrollment_fields.py
+++ b/openedx/core/djangoapps/content/course_overviews/migrations/0005_add_enrollment_fields.py
@@ -82,7 +82,7 @@ class Migration(SchemaMigration):
             'has_any_active_web_certificate': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
             'id': ('xmodule_django.models.CourseKeyField', [], {'max_length': '255', 'primary_key': 'True', 'db_index': 'True'}),
             'invitation_only': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
-            'lowest_passing_grade': ('django.db.models.fields.DecimalField', [], {'max_digits': '5', 'decimal_places': '2'}),
+            'lowest_passing_grade': ('django.db.models.fields.DecimalField', [], {'max_digits': '5', 'decimal_places': '2', 'null': 'True'}),
             'max_student_enrollments_allowed': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
             'mobile_available': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
             'social_sharing_url': ('django.db.models.fields.TextField', [], {'null': 'True'}),


### PR DESCRIPTION
@cpennington @rlucioni 

What happened:
- First, I merged `0004_default_lowest_passing_grade_to_None.py`, which adds `null=True` to `lowest_passing_grade`.
- Later, Renzo merged `0004_auto__add_field_courseoverview_enrollment_start__add_field_courseoverv.py`, which adds a bunch of enrollment-related fields
- Neither migrations' `models` variables reflects the changes in the other one.
- release currently has just `0004_default...`
- master and rc/2015-07-22 have `0004_auto...` and `0004_default...`, in that order.

What this PR changes:
- Change `0004_auto...` to `0005_add_enrollment_fields.py`
- Update `models` in `0005_...` to have `null=True` for `lowest_passing_grade`

What the effects of that should be, given the environment's original state:

|  | 0004_auto applied | Not applied |
| --- | --- | --- |
| **0004_default applied** | Ghost migrations (master, rc) | Nothing to worry about (release) |
| **Not applied** | Duplicate columns | Nothing to worry about |
