### PR TITLE
allows platform version formatting as a part of static url served by …

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -238,6 +238,8 @@ with open(CONFIG_ROOT / CONFIG_PREFIX + "auth.json") as auth_file:
 ############### XBlock filesystem field config ##########
 if 'DJFS' in AUTH_TOKENS and AUTH_TOKENS['DJFS'] is not None:
     DJFS = AUTH_TOKENS['DJFS']
+    if 'url_root' in DJFS:
+        DJFS['url_root'] = DJFS['url_root'].format(platform_revision=EDX_PLATFORM_REVISION)
 
 EMAIL_HOST_USER = AUTH_TOKENS.get('EMAIL_HOST_USER', EMAIL_HOST_USER)
 EMAIL_HOST_PASSWORD = AUTH_TOKENS.get('EMAIL_HOST_PASSWORD', EMAIL_HOST_PASSWORD)


### PR DESCRIPTION
This is a fix for allowing djpyfs users to set platform revision as a part of url setting in cms.auth.json. This additional code snippet hooks up the AUTH_TOKENS and format DFJS with the platform's revision number.
