### PR TITLE
allows platform version formatting as a part of static url served by …

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -229,3 +229,4 @@ Pan Luo <pan.luo@ubc.ca>
 Tyler Nickerson <nickersoft@gmail.com>
 Vedran Karačić <vedran@edx.org>
 William Ono <william.ono@ubc.ca>
+Dongwook Yoon <dy252@cornell.edu>

--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -238,6 +238,8 @@ with open(CONFIG_ROOT / CONFIG_PREFIX + "auth.json") as auth_file:
 ############### XBlock filesystem field config ##########
 if 'DJFS' in AUTH_TOKENS and AUTH_TOKENS['DJFS'] is not None:
     DJFS = AUTH_TOKENS['DJFS']
+    if 'url_root' in DJFS:
+        DJFS['url_root'] = DJFS['url_root'].format(platform_revision=EDX_PLATFORM_REVISION)
 
 EMAIL_HOST_USER = AUTH_TOKENS.get('EMAIL_HOST_USER', EMAIL_HOST_USER)
 EMAIL_HOST_PASSWORD = AUTH_TOKENS.get('EMAIL_HOST_PASSWORD', EMAIL_HOST_PASSWORD)


### PR DESCRIPTION
Hi @pmitros @andy-armstrong ,

This is a fix for djpyfs's static url issue that the platform revision number had to be hard coded in cms.auth.json. With this fix, you can format the version number in the auth setting using the {platform_revision} tag.

I would like to have your reviews on this quick change.

Thanks!
