### PR TITLE
Update edx-oauth2-provider to 0.5.6

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -44,7 +44,7 @@ git+https://github.com/hmarr/django-debug-toolbar-mongo.git@b0686a76f1ce3532088c
 -e git+https://github.com/edx/opaque-keys.git@27dc382ea587483b1e3889a3d19cbd90b9023a06#egg=opaque-keys
 git+https://github.com/edx/ease.git@release-2015-07-14#egg=ease==0.1.3
 -e git+https://github.com/edx/i18n-tools.git@v0.1.1#egg=i18n-tools
-git+https://github.com/edx/edx-oauth2-provider.git@0.5.5#egg=oauth2-provider==0.5.5
+git+https://github.com/edx/edx-oauth2-provider.git@0.5.6#egg=oauth2-provider==0.5.6
 -e git+https://github.com/edx/edx-val.git@v0.0.5#egg=edx-val
 -e git+https://github.com/pmitros/RecommenderXBlock.git@518234bc354edbfc2651b9e534ddb54f96080779#egg=recommender-xblock
 -e git+https://github.com/edx/edx-search.git@release-2015-07-22#egg=edx-search


### PR DESCRIPTION
Corresponds to https://github.com/edx/edx-oauth2-provider/pull/27. Requires a yet-to-be-created 0.5.6 release of edx-oauth2-provider.

@mulby @feanil 
