### PR TITLE
Don't package or optimize assets on devstack

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -277,13 +277,6 @@ XQUEUE_INTERFACE = {
 simplefilter('ignore')
 
 ################################# Middleware ###################################
-# List of finder classes that know how to find static files in
-# various locations.
-STATICFILES_FINDERS = (
-    'staticfiles.finders.FileSystemFinder',
-    'staticfiles.finders.AppDirectoriesFinder',
-    'pipeline.finders.PipelineFinder',
-)
 
 # List of callables that know how to import templates from various sources.
 TEMPLATE_LOADERS = (
@@ -460,8 +453,22 @@ MESSAGE_STORAGE = 'django.contrib.messages.storage.session.SessionStorage'
 ##### EMBARGO #####
 EMBARGO_SITE_REDIRECT_URL = None
 
-############################### Pipeline #######################################
+############################### PIPELINE #######################################
+
+# Process static files using RequireJS Optimizer
 STATICFILES_STORAGE = 'openedx.core.lib.django_require.staticstorage.OptimizedCachedRequireJsStorage'
+
+# List of finder classes that know how to find static files in various locations.
+# Note: the pipeline finder is included to be able to discover optimized files
+STATICFILES_FINDERS = [
+    'staticfiles.finders.FileSystemFinder',
+    'staticfiles.finders.AppDirectoriesFinder',
+    'pipeline.finders.PipelineFinder',
+]
+
+# Don't use compression by default
+PIPELINE_CSS_COMPRESSOR = None
+PIPELINE_JS_COMPRESSOR = None
 
 from openedx.core.lib.rooted_paths import rooted_glob
 
@@ -550,7 +557,9 @@ PIPELINE_JS_COMPRESSOR = None
 STATICFILES_IGNORE_PATTERNS = (
     "*.py",
     "*.pyc",
-    # it would be nice if we could do, for example, "**/*.scss",
+    "*.html",
+
+    # It would be nice if we could do, for example, "**/*.scss",
     # but these strings get passed down to the `fnmatch` module,
     # which doesn't support that. :(
     # http://docs.python.org/2/library/fnmatch.html
@@ -562,6 +571,10 @@ STATICFILES_IGNORE_PATTERNS = (
     "coffee/*/*.coffee",
     "coffee/*/*/*.coffee",
     "coffee/*/*/*/*.coffee",
+
+    # Ignore tests
+    "spec",
+    "spec_helpers",
 
     # Symlinks used by js-test-tool
     "xmodule_js",

--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -33,8 +33,14 @@ FEATURES['PREVIEW_LMS_BASE'] = "preview." + LMS_BASE
 
 ########################### PIPELINE #################################
 
-# Skip RequireJS optimizer in development
-STATICFILES_STORAGE = 'pipeline.storage.PipelineCachedStorage'
+# Skip packaging and optimization in development
+STATICFILES_STORAGE = 'pipeline.storage.NonPackagingPipelineStorage'
+
+# Revert to the default set of finders as we don't want the production pipeline
+STATICFILES_FINDERS = [
+    'staticfiles.finders.FileSystemFinder',
+    'staticfiles.finders.AppDirectoriesFinder',
+]
 
 ############################# ADVANCED COMPONENTS #############################
 

--- a/cms/envs/test_static_optimized.py
+++ b/cms/envs/test_static_optimized.py
@@ -20,7 +20,17 @@ DATABASES = {
     },
 
 }
-######################### Static file overrides ####################################
+
+######################### PIPELINE ####################################
+
+# Use RequireJS optimized storage
+STATICFILES_STORAGE = 'openedx.core.lib.django_require.staticstorage.OptimizedCachedRequireJsStorage'
+
+# Revert to the default set of finders as we don't want to dynamically pick up files from the pipeline
+STATICFILES_FINDERS = [
+    'staticfiles.finders.FileSystemFinder',
+    'staticfiles.finders.AppDirectoriesFinder',
+]
 
 # Redirect to the test_root folder within the repo
 TEST_ROOT = REPO_ROOT / "test_root"
@@ -33,4 +43,3 @@ STATIC_ROOT = (TEST_ROOT / "staticfiles" / "cms").abspath()
 # 1. Uglify is by far the slowest part of the build process
 # 2. Having full source code makes debugging tests easier for developers
 os.environ['REQUIRE_BUILD_PROFILE_OPTIMIZE'] = 'none'
-PIPELINE_JS_COMPRESSOR = None

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -85,8 +85,17 @@ def should_show_debug_toolbar(_):
 
 ########################### PIPELINE #################################
 
-# # Skip RequireJS optimizer in development
-STATICFILES_STORAGE = 'pipeline.storage.PipelineCachedStorage'
+# Skip packaging and optimization in development
+STATICFILES_STORAGE = 'pipeline.storage.NonPackagingPipelineStorage'
+
+# Revert to the default set of finders as we don't want the production pipeline
+STATICFILES_FINDERS = [
+    'staticfiles.finders.FileSystemFinder',
+    'staticfiles.finders.AppDirectoriesFinder',
+]
+
+# Disable JavaScript compression in development
+PIPELINE_JS_COMPRESSOR = None
 
 # Whether to run django-require in debug mode.
 REQUIRE_DEBUG = DEBUG

--- a/lms/envs/test_static_optimized.py
+++ b/lms/envs/test_static_optimized.py
@@ -32,7 +32,16 @@ XQUEUE_INTERFACE = {
 }
 
 
-######################### Static file overrides ####################################
+######################### PIPELINE ####################################
+
+# Use RequireJS optimized storage
+STATICFILES_STORAGE = 'openedx.core.lib.django_require.staticstorage.OptimizedCachedRequireJsStorage'
+
+# Revert to the default set of finders as we don't want to dynamically pick up files from the pipeline
+STATICFILES_FINDERS = [
+    'staticfiles.finders.FileSystemFinder',
+    'staticfiles.finders.AppDirectoriesFinder',
+]
 
 # Redirect to the test_root folder within the repo
 TEST_ROOT = REPO_ROOT / "test_root"
@@ -45,4 +54,3 @@ STATIC_ROOT = (TEST_ROOT / "staticfiles" / "lms").abspath()
 # 1. Uglify is by far the slowest part of the build process
 # 2. Having full source code makes debugging tests easier for developers
 os.environ['REQUIRE_BUILD_PROFILE_OPTIMIZE'] = 'none'
-PIPELINE_JS_COMPRESSOR = None


### PR DESCRIPTION
This change includes a few improvements to the static pipeline for both LMS and Studio:
- stops `collectstatic` from packaging and optimizing files on devstack, because developers don't actually use the files under `staticfiles` in development. This should speed up update_assets on devstack.
- fixes a bug run into by @clrux where the optimizer would attempt to optimize files from the pipeline directory
- standardizes the set of file extensions that are excluded from staticfiles
### Sandbox
- [x] http://andy-armstrong.sandbox.edx.org/
### Testing
- [x] Performance
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @peter-fogg 
- [x] Code review: @wedaly  
  FYIs: @clrux, @feanil 
### Post-review
- [x] Squash commits
