### PR TITLE
Delete mention of direction from checkboxgroup.

### DIFF
--- a/common/lib/capa/capa/responsetypes.py
+++ b/common/lib/capa/capa/responsetypes.py
@@ -860,7 +860,7 @@ class ChoiceResponse(LoncapaResponse):
         The hint information goes into the msg= in new_cmap for display.
         Each choice in the checkboxgroup can have 2 extended hints, matching the
         case that the student has or has not selected that choice:
-          <checkboxgroup label="Select the best snack" direction="vertical">
+          <checkboxgroup label="Select the best snack">
              <choice correct="true">Donut
                <choicehint selected="tRuE">A Hint!</choicehint>
                <choicehint selected="false">Another hint!</choicehint>
@@ -986,7 +986,7 @@ class MultipleChoiceResponse(LoncapaResponse):
     to translate back to choice_0 name style for recording in the logs, so
     the logging is in terms of the regular names.
     """
-    # TODO: handle direction and randomize
+    # TODO: randomize
 
     human_name = _('Multiple Choice')
     tags = ['multiplechoiceresponse']
@@ -1336,7 +1336,7 @@ class TrueFalseResponse(MultipleChoiceResponse):
 @registry.register
 class OptionResponse(LoncapaResponse):
     """
-    TODO: handle direction and randomize
+    TODO: handle randomize
     """
 
     human_name = _('Dropdown')

--- a/common/lib/capa/capa/tests/test_files/extended_hints_checkbox.xml
+++ b/common/lib/capa/capa/tests/test_files/extended_hints_checkbox.xml
@@ -1,7 +1,7 @@
 <problem>
     <p>Select all the fruits from the list. In retrospect, the wordiness of these tests increases the dizziness!</p>
     <choiceresponse>
-      <checkboxgroup label="Select all the fruits from the list" direction="vertical">
+      <checkboxgroup label="Select all the fruits from the list">
         <choice correct="true" id="alpha">Apple
                    <choicehint selected="TrUe">You are right that apple is a fruit.
                    </choicehint>
@@ -35,7 +35,7 @@
     </choiceresponse>
     <p>Select all the vegetables from the list</p>
     <choiceresponse>
-      <checkboxgroup label="Select all the vegetables from the list" direction="vertical">
+      <checkboxgroup label="Select all the vegetables from the list">
         <choice correct="false">Banana
                    <choicehint selected="true">No, sorry, a banana is a fruit.
                    </choicehint>
@@ -68,7 +68,7 @@
     </choiceresponse>
     <p>Compoundhint vs. correctness</p>
     <choiceresponse>
-      <checkboxgroup direction="vertical">
+      <checkboxgroup>
         <choice correct="true">A</choice>
         <choice correct="false">B</choice>
         <choice correct="true">C</choice>
@@ -78,7 +78,7 @@
     </choiceresponse>
     <p>If one label matches we use it, otherwise go with the default, and whitespace scattered around.</p>
     <choiceresponse>
-      <checkboxgroup direction="vertical">
+      <checkboxgroup>
         <choice correct="true">
         
               A      
@@ -97,7 +97,7 @@
 
     <p>Blank labels</p>
     <choiceresponse>
-      <checkboxgroup direction="vertical">
+      <checkboxgroup>
         <choice correct="true">A <choicehint selected="true" label="">aa</choicehint></choice>
         <choice correct="true">B <choicehint selected="true">bb</choicehint></choice>
         <compoundhint value="A B" label="">compoundo</compoundhint>
@@ -106,7 +106,7 @@
 
     <p>Case where the student selects nothing, but there's feedback</p>
     <choiceresponse>
-      <checkboxgroup direction="vertical">
+      <checkboxgroup>
         <choice correct="true">A <choicehint selected="true">aa</choicehint></choice>
         <choice correct="false">B <choicehint selected="false">bb</choicehint></choice>
       </checkboxgroup>

--- a/common/lib/capa/capa/tests/test_files/extended_hints_with_errors.xml
+++ b/common/lib/capa/capa/tests/test_files/extended_hints_with_errors.xml
@@ -1,6 +1,6 @@
 <problem>
     <choiceresponse>
-      <checkboxgroup label="Select all the vegetables from the list" direction="vertical">
+      <checkboxgroup label="Select all the vegetables from the list">
         <choice correct="false">Banana
                    <choicehint selected="true">No, sorry, a banana is a fruit.
                    </choicehint>

--- a/common/lib/capa/capa/tests/test_hint_functionality.py
+++ b/common/lib/capa/capa/tests/test_hint_functionality.py
@@ -338,7 +338,7 @@ class CheckboxHintsTestTracking(HintTest):
     <problem>
         <p>question</p>
         <choiceresponse>
-        <checkboxgroup direction="vertical">
+        <checkboxgroup>
             <choice correct="true">Apple
               <choicehint selected="true">A true</choicehint>
               <choicehint selected="false">A false</choicehint>

--- a/common/lib/xmodule/xmodule/js/spec/problem/edit_spec.coffee
+++ b/common/lib/xmodule/xmodule/js/spec/problem/edit_spec.coffee
@@ -724,7 +724,7 @@ describe 'MarkdownEditingDescriptor', ->
 
         <p>Choice checks</p>
         <choiceresponse>
-          <checkboxgroup direction="vertical">
+          <checkboxgroup>
             <choice correct="false">option1 [x]</choice>
             <choice correct="true">correct</choice>
             <choice correct="true">redundant</choice>

--- a/common/lib/xmodule/xmodule/js/spec/problem/edit_spec_hint.coffee
+++ b/common/lib/xmodule/xmodule/js/spec/problem/edit_spec_hint.coffee
@@ -188,7 +188,7 @@ describe 'Markdown to xml extended hint checkbox', ->
     <problem>
     <p>Select all the fruits from the list</p>
     <choiceresponse>
-      <checkboxgroup label="Select all the fruits from the list" direction="vertical">
+      <checkboxgroup label="Select all the fruits from the list">
         <choice correct="true">Apple
           <choicehint selected="true">You're right that apple is a fruit.</choicehint>
           <choicehint selected="false">Remember that apple is also a fruit.</choicehint></choice>
@@ -209,7 +209,7 @@ describe 'Markdown to xml extended hint checkbox', ->
 
     <p>Select all the vegetables from the list</p>
     <choiceresponse>
-      <checkboxgroup label="Select all the vegetables from the list" direction="vertical">
+      <checkboxgroup label="Select all the vegetables from the list">
         <choice correct="false">Banana
           <choicehint selected="true">No, sorry, a banana is a fruit.</choicehint>
           <choicehint selected="false">poor banana.</choicehint></choice>
@@ -266,7 +266,7 @@ describe 'Markdown to xml extended hint checkbox', ->
     <problem>
     <p>Select all the fruits from the list</p>
     <choiceresponse>
-      <checkboxgroup label="Select all the fruits from the list" direction="vertical">
+      <checkboxgroup label="Select all the fruits from the list">
         <choice correct="true">Apple
           <choicehint selected="true">You're right that apple is a fruit.</choicehint>
           <choicehint selected="false">Remember that apple is also a fruit.</choicehint></choice>
@@ -287,7 +287,7 @@ describe 'Markdown to xml extended hint checkbox', ->
 
     <p>Select all the vegetables from the list</p>
     <choiceresponse>
-      <checkboxgroup label="Select all the vegetables from the list" direction="vertical">
+      <checkboxgroup label="Select all the vegetables from the list">
         <choice correct="false">Banana
           <choicehint selected="true">No, sorry, a banana is a fruit.</choicehint>
           <choicehint selected="false">poor banana.</choicehint></choice>
@@ -753,7 +753,7 @@ describe 'Markdown to xml extended hint with multiline hints', ->
     <problem>
     <p>Checkboxes</p>
     <choiceresponse>
-      <checkboxgroup label="Checkboxes" direction="vertical">
+      <checkboxgroup label="Checkboxes">
         <choice correct="true">A
           <choicehint selected="true">aaa</choicehint>
           <choicehint selected="false">bbb</choicehint></choice>
@@ -891,7 +891,7 @@ describe 'Markdown to xml extended hint with tricky syntax cases', ->
     <p>q1</p>
     <p>this [x]</p>
     <choiceresponse>
-      <checkboxgroup label="q1" direction="vertical">
+      <checkboxgroup label="q1">
         <choice correct="false">a [square]</choice>
         <choice correct="true">b {{ this hint passes through }}</choice>
       </checkboxgroup>

--- a/common/lib/xmodule/xmodule/js/src/problem/edit.coffee
+++ b/common/lib/xmodule/xmodule/js/src/problem/edit.coffee
@@ -353,7 +353,7 @@ class @MarkdownEditingDescriptor extends XModule.Descriptor
           var groupString = '<choiceresponse>\n',
               options, value, correct;
 
-          groupString += '  <checkboxgroup direction="vertical">\n';
+          groupString += '  <checkboxgroup>\n';
           options = match.split('\n');
           
           endHints = '';  // save these up to emit at the end

--- a/common/lib/xmodule/xmodule/templates/problem/checkboxes_response.yaml
+++ b/common/lib/xmodule/xmodule/templates/problem/checkboxes_response.yaml
@@ -29,7 +29,7 @@ data: |
         <p>You can use the following example problem as a model.</p>
           <p>The following languages are in the Indo-European family:</p>
           <choiceresponse>
-            <checkboxgroup direction="vertical">
+            <checkboxgroup>
               <choice correct="true" name="urdu">Urdu</choice>
               <choice correct="false" name="finnish">Finnish</choice>
               <choice correct="true" name="marathi">Marathi</choice>

--- a/common/lib/xmodule/xmodule/templates/problem/checkboxes_response_hint.yaml
+++ b/common/lib/xmodule/xmodule/templates/problem/checkboxes_response_hint.yaml
@@ -41,7 +41,7 @@ data: |
       
       <p>Which of the following is a fruit? Check all that apply.</p>
       <choiceresponse>
-        <checkboxgroup direction="vertical">
+        <checkboxgroup>
           <choice correct="true">apple
             <choicehint selected="true">You are correct that an apple is a fruit because it is the fertilized ovary that comes from an apple tree and contains seeds.</choicehint>
             <choicehint selected="false">Remember that an apple is also a fruit.</choicehint>

--- a/common/lib/xmodule/xmodule/tests/test_capa_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_capa_module.py
@@ -1822,7 +1822,7 @@ class TestProblemCheckTracking(unittest.TestCase):
               </multiplechoiceresponse>
               <p>Which of the following are musical instruments?</p>
               <choiceresponse>
-                <checkboxgroup direction="vertical" label="Which of the following are musical instruments?">
+                <checkboxgroup label="Which of the following are musical instruments?">
                   <choice correct="true">a piano</choice>
                   <choice correct="false">a tree</choice>
                   <choice correct="true">a guitar</choice>

--- a/common/test/acceptance/tests/data/multiple_choice.xml
+++ b/common/test/acceptance/tests/data/multiple_choice.xml
@@ -17,7 +17,7 @@
   </multiplechoiceresponse>
   <p>Which of the following are musical instruments?</p>
   <choiceresponse>
-    <checkboxgroup direction="vertical">
+    <checkboxgroup>
       <choice correct="true">a piano</choice>
       <choice correct="false">a tree</choice>
       <choice correct="true">a guitar</choice>

--- a/common/test/acceptance/tests/lms/test_lms_user_preview.py
+++ b/common/test/acceptance/tests/lms/test_lms_user_preview.py
@@ -62,7 +62,7 @@ class CourseWithoutContentGroupsTest(StaffViewTest):
             <problem markdown="Simple Problem" max_attempts="" weight="">
               <p>Choose Yes.</p>
               <choiceresponse>
-                <checkboxgroup direction="vertical">
+                <checkboxgroup>
                   <choice correct="true">Yes</choice>
                 </checkboxgroup>
               </choiceresponse>
@@ -258,7 +258,7 @@ class CourseWithContentGroupsTest(StaffViewTest):
             <problem markdown="Simple Problem" max_attempts="" weight="">
               <p>Choose Yes.</p>
               <choiceresponse>
-                <checkboxgroup direction="vertical">
+                <checkboxgroup>
                   <choice correct="true">Yes</choice>
                 </checkboxgroup>
               </choiceresponse>

--- a/common/test/acceptance/tests/studio/test_studio_settings.py
+++ b/common/test/acceptance/tests/studio/test_studio_settings.py
@@ -136,7 +136,7 @@ class ContentGroupConfigurationTest(StudioCourseTest):
             <problem markdown="Simple Problem" max_attempts="" weight="">
               <p>Choose Yes.</p>
               <choiceresponse>
-                <checkboxgroup direction="vertical">
+                <checkboxgroup>
                   <choice correct="true">Yes</choice>
                 </checkboxgroup>
               </choiceresponse>

--- a/common/test/data/manual-testing-complete/problem/a473cecce312487a8339995bde24be53.xml
+++ b/common/test/data/manual-testing-complete/problem/a473cecce312487a8339995bde24be53.xml
@@ -2,7 +2,7 @@
   <p>A checkboxes problem presents checkbox buttons for student input. Students can select more than one option presented.</p>
   <p>Select the answer that matches</p>
   <choiceresponse>
-    <checkboxgroup direction="vertical" label="Select the answer that matches">
+    <checkboxgroup label="Select the answer that matches">
       <choice correct="true">correct</choice>
       <choice correct="false">incorrect</choice>
       <choice correct="true">correct</choice>

--- a/common/test/data/manual-testing-complete/problem/dcada38f8944442799ac2fed42201641.xml
+++ b/common/test/data/manual-testing-complete/problem/dcada38f8944442799ac2fed42201641.xml
@@ -2,7 +2,7 @@
   <p>A checkboxes problem presents checkbox buttons for student input. Students can select more than one option presented.</p>
   <p>Select the answer that matches</p>
   <choiceresponse>
-    <checkboxgroup direction="vertical" label="Select the answer that matches">
+    <checkboxgroup label="Select the answer that matches">
       <choice correct="true">correct</choice>
       <choice correct="false">incorrect</choice>
       <choice correct="true">correct</choice>


### PR DESCRIPTION
It was never implemented.
TNL-231

@dianakhuang and @adampalay can you code review?

@catong http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/exercises_tools/checkbox.html still has one place where it shows direction="vertical" (in a coding example). It would be good to delete that.
