### PR TITLE
Corrected CourseMode Display Name

### DIFF
--- a/lms/djangoapps/commerce/api/v1/models.py
+++ b/lms/djangoapps/commerce/api/v1/models.py
@@ -22,12 +22,29 @@ class Course(object):
         self.modes = list(modes)
         self._deleted_modes = []
 
+    def get_mode_display_name(self, mode):
+        """ Returns display name for the given mode. """
+        slug = mode.mode_slug.strip().lower()
+
+        if slug == 'credit':
+            return 'Credit'
+        if 'professional' in slug:
+            return 'Professional Education'
+        elif slug == 'verified':
+            return 'Verified Certificate'
+        elif slug == 'honor':
+            return 'Honor Certificate'
+        elif slug == 'audit':
+            return 'Audit'
+
+        return mode.mode_slug
+
     @transaction.commit_on_success
     def save(self, *args, **kwargs):  # pylint: disable=unused-argument
         """ Save the CourseMode objects to the database. """
         for mode in self.modes:
             mode.course_id = self.id
-            mode.mode_display_name = mode.mode_slug
+            mode.mode_display_name = self.get_mode_display_name(mode)
             mode.save()
 
         deleted_mode_ids = [mode.id for mode in self._deleted_modes]

--- a/lms/djangoapps/commerce/api/v1/tests/test_models.py
+++ b/lms/djangoapps/commerce/api/v1/tests/test_models.py
@@ -1,0 +1,33 @@
+""" Tests for models. """
+import ddt
+from django.test import TestCase
+
+from commerce.api.v1.models import Course
+from course_modes.models import CourseMode
+
+
+@ddt.ddt
+class CourseTests(TestCase):
+    """ Tests for Course model. """
+    def setUp(self):
+        super(CourseTests, self).setUp()
+        self.course = Course('a/b/c', [])
+
+    @ddt.unpack
+    @ddt.data(
+        ('credit', 'Credit'),
+        ('professional', 'Professional Education'),
+        ('no-id-professional', 'Professional Education'),
+        ('verified', 'Verified Certificate'),
+        ('honor', 'Honor Certificate'),
+        ('audit', 'Audit'),
+    )
+    def test_get_mode_display_name(self, slug, expected_display_name):
+        """ Verify the method properly maps mode slugs to display names. """
+        mode = CourseMode(mode_slug=slug)
+        self.assertEqual(self.course.get_mode_display_name(mode), expected_display_name)
+
+    def test_get_mode_display_name_unknown_slug(self):
+        """ Verify the method returns the slug if it has no known mapping. """
+        mode = CourseMode(mode_slug='Blah!')
+        self.assertEqual(self.course.get_mode_display_name(mode), mode.mode_slug)

--- a/lms/djangoapps/commerce/api/v1/tests/test_views.py
+++ b/lms/djangoapps/commerce/api/v1/tests/test_views.py
@@ -163,6 +163,11 @@ class CourseRetrieveUpdateViewTests(CourseApiViewTestMixin, ModuleStoreTestCase)
         actual = json.loads(response.content)
         self.assertEqual(actual, expected)
 
+        # Verify the display names are correct
+        course_modes = CourseMode.objects.filter(course_id=course.id)
+        actual = [course_mode.mode_display_name for course_mode in course_modes]
+        self.assertListEqual(actual, ['Verified Certificate', 'Honor Certificate'])
+
     def test_create_with_permissions(self):
         """ Verify the view supports creating a course as a user with the appropriate permissions. """
         permissions = Permission.objects.filter(name__in=('Can add course mode', 'Can change course mode'))


### PR DESCRIPTION
The Commerce API now sets the correct display name for known course modes, but continues to default to the mode slug for unknown course modes.

@rlucioni @jimabramson 
