### PR TITLE
SOL-1062: generate verify_uuid for web based certificates also

### DIFF
--- a/lms/djangoapps/certificates/queue.py
+++ b/lms/djangoapps/certificates/queue.py
@@ -4,6 +4,7 @@ import random
 import logging
 import lxml.html
 from lxml.etree import XMLSyntaxError, ParserError  # pylint:disable=no-name-in-module
+from uuid import uuid4
 
 from django.test.client import RequestFactory
 from django.conf import settings
@@ -336,7 +337,12 @@ class XQueueCertInterface(object):
                     }
                     if template_file:
                         contents['template_pdf'] = template_file
-                    new_status = status.generating if generate_pdf else status.downloadable
+                    if generate_pdf:
+                        new_status = status.generating
+                    else:
+                        new_status = status.downloadable
+                        cert.verify_uuid = uuid4().hex
+
                     cert.status = new_status
                     cert.save()
 

--- a/lms/djangoapps/certificates/tests/test_queue.py
+++ b/lms/djangoapps/certificates/tests/test_queue.py
@@ -22,7 +22,12 @@ from xmodule.modulestore.tests.factories import CourseFactory
 from capa.xqueue_interface import XQueueInterface
 
 from certificates.queue import XQueueCertInterface
-from certificates.models import ExampleCertificateSet, ExampleCertificate
+from certificates.models import (
+    ExampleCertificateSet,
+    ExampleCertificate,
+    GeneratedCertificate,
+    CertificateStatuses,
+)
 
 
 @attr('shard_1')
@@ -64,6 +69,9 @@ class XQueueCertInterfaceAddCertificateTest(ModuleStoreTestCase):
 
         # Verify that add_cert method does not add message to queue
         self.assertFalse(mock_send.called)
+        certificate = GeneratedCertificate.objects.get(user=self.user, course_id=self.course.id)
+        self.assertEqual(certificate.status, CertificateStatuses.downloadable)
+        self.assertIsNotNone(certificate.verify_uuid)
 
 
 @attr('shard_1')


### PR DESCRIPTION
@mattdrayer this PR fixes issue reported in SOL-1062 by generating verify_uuid for web based certificates also. @smagoun FYI.
