### PR TITLE
Resolved LogHandler bug in rf6266

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -75,7 +75,6 @@ pysrt==0.4.7
 PyYAML==3.10
 requests==2.3.0
 requests-oauthlib==0.4.1
-rfc6266==0.0.4
 scipy==0.14.0
 Shapely==1.2.16
 singledispatch==3.4.0.2

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -31,6 +31,7 @@ git+https://github.com/pmitros/pyfs.git@96e1922348bfe6d99201b9512a9ed946c87b7e0b
 git+https://github.com/hmarr/django-debug-toolbar-mongo.git@b0686a76f1ce3532088c4aee6e76b9abe61cc808
 # custom opaque-key implementations for ccx
 -e git+https://github.com/jazkarta/ccx-keys.git@e6b03704b1bb97c1d2f31301ecb4e3a687c536ea#egg=ccx-keys
+git+https://github.com/edx/rfc6266.git@v0.0.5-edx#egg=rfc6266
 
 # Our libraries:
 -e git+https://github.com/edx/XBlock.git@017b46b80e712b1318379912257cf1cc1b68eb0e#egg=XBlock


### PR DESCRIPTION
With a certain set of feature flags enabled, the CMS worker processes are failing to start with:

```
[2015-07-27 10:56:22,231: ERROR/Worker-1] Process Worker-1
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/billiard/process.py", line 278, in _bootstrap
    for name in logger_names:
TypeError: unbound method createLock() must be called with NullHandler instance as first argument (got nothing instead)
```

After extensive debugging, we tracked this down to [videos.py](https://github.com/edx/edx-platform/blob/master/cms/djangoapps/contentstore/views/videos.py), and [rfc6266](https://github.com/g2p/rfc6266) on the `0.0.4` release.  which adds a logging handler that is a class instead of an instance of a class.  The next and only other commit on master fixes this, but hasn't been released, and considering it was made in November 2013 I don't think it will, so this PR is to switch to the "latest" rfc6266.  Here is the compare between 0.0.4 and this sha1: https://github.com/g2p/rfc6266/compare/v0.0.4...master

huge props for @bdero helping me track this crazy thing down.
