### PR TITLE
Optimize OpenID Course Claims for non-global-staff users.

### DIFF
--- a/lms/djangoapps/oauth2_handler/handlers.py
+++ b/lms/djangoapps/oauth2_handler/handlers.py
@@ -4,12 +4,11 @@ from django.conf import settings
 from django.core.cache import cache
 from xmodule.modulestore.django import modulestore
 
-from courseware.access import has_access
 from openedx.core.djangoapps.user_api.models import UserPreference
 from student.models import anonymous_id_for_user
 from student.models import UserProfile
 from lang_pref import LANGUAGE_KEY
-from student.roles import GlobalStaff, CourseStaffRole, CourseInstructorRole
+from student.roles import (GlobalStaff, CourseStaffRole, CourseInstructorRole, UserBasedRole)
 
 
 class OpenIDHandler(object):
@@ -190,23 +189,31 @@ class CourseAccessHandler(object):
 
         return course_ids
 
-    # pylint: disable=missing-docstring
     def _get_courses_with_access_type(self, user, access_type):
+        """
+        If global staff, returns all courses. Otherwise, returns list of courses
+        based on role access (e.g. courses that course staff has access to).
+        """
+
         # Check the application cache and update if not present. The application
         # cache is useful since there are calls to different endpoints in close
         # succession, for example the id_token and user_info endpoints.
-
         key = '-'.join([str(self.__class__), str(user.id), access_type])
         course_ids = cache.get(key)
 
         if not course_ids:
-            courses = _get_all_courses()
 
-            # Global staff have access to all courses. Filter courses for non-global staff.
-            if not GlobalStaff().has_user(user):
-                courses = [course for course in courses if has_access(user, access_type, course)]
-
-            course_ids = [unicode(course.id) for course in courses]
+            if GlobalStaff().has_user(user):
+                # TODO: This code should be optimized in the future to caching
+                # the list of all courses in the system.
+                # The modulestore has all courses, while the roles table only has courses
+                # with roles. Thus, we'll use the modulestore to fetch all courses.
+                courses = _get_all_courses()
+                course_ids = [unicode(course.id) for course in courses]
+            else:
+                # Getting courses based on roles avoid querying mongo and thus faster
+                courses = UserBasedRole(user, access_type).courses_with_role()
+                course_ids = [unicode(course.course_id) for course in courses]
 
             cache.set(key, course_ids, self.COURSE_CACHE_TIMEOUT)
 


### PR DESCRIPTION
In order to make login to Insights faster for non-global staff, I've modified the oauth2 handler to check against the user's role for courses instead of verifying against the resultstore/mongo.  Global staff access can't be sped up using the same method because the roles table doesn't contain all courses.

I'll be load testing this solution in a bit and wanted to get an early PR out for review, and I won't merge this until the load test results are put together.

@ormsbee @mekkz @nasthagiri 
