### PR TITLE
Bump mongoengine version to 0.10.0

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -51,7 +51,7 @@ Markdown==2.2.1
 --allow-external meliae
 --allow-unverified meliae
 meliae==0.4.0
-mongoengine==0.7.10
+mongoengine==0.10.0
 networkx==1.7
 nose==1.3.3
 oauthlib==0.7.2


### PR DESCRIPTION
To prepare for using MongoDB v3.0, mongoengine needs to be upgraded to a version that supports MongoDB v3.0.
