### PR TITLE
Fix markdown editor reference link having colon issue

### DIFF
--- a/common/test/acceptance/pages/lms/discussion.py
+++ b/common/test/acceptance/pages/lms/discussion.py
@@ -143,6 +143,11 @@ class DiscussionThreadPage(PageObject, DiscussionPageMixin):
                 "Response edit started"
             ).fulfill()
 
+    def get_link_href(self):
+        """Extracts href attribute of the referenced link"""
+        link_href = self._find_within(".post-body p a").attrs('href')
+        return link_href[0] if link_href else None
+
     def get_response_vote_count(self, response_id):
         return self._get_element_text(".response_{} .discussion-response .action-vote .vote-count".format(response_id))
 

--- a/common/test/acceptance/tests/discussion/test_discussion.py
+++ b/common/test/acceptance/tests/discussion/test_discussion.py
@@ -236,6 +236,26 @@ class DiscussionTabSingleThreadTest(BaseDiscussionTestCase, DiscussionResponsePa
         self.assertTrue(self.thread_page.is_mathjax_preview_available())
         self.assertTrue(self.thread_page.is_mathjax_rendered())
 
+    def test_markdown_reference_link(self):
+        """
+        Check markdown editor renders reference link correctly
+        and colon(:) in reference link is not converted to %3a
+        """
+        sample_link = "http://example.com/colon:test"
+        thread_content = """[enter link description here][1]\n[1]: http://example.com/colon:test"""
+        thread_id = "test_thread_{}".format(uuid4().hex)
+        thread_fixture = SingleThreadViewFixture(
+            Thread(
+                id=thread_id,
+                body=thread_content,
+                commentable_id=self.discussion_id,
+                thread_type="discussion"
+            )
+        )
+        thread_fixture.push()
+        self.setup_thread_page(thread_id)
+        self.assertEqual(self.thread_page.get_link_href(), sample_link)
+
     def test_marked_answer_comments(self):
         thread_id = "test_thread_{}".format(uuid4().hex)
         response_id = "test_response_{}".format(uuid4().hex)

--- a/lms/static/js/Markdown.Converter.js
+++ b/lms/static/js/Markdown.Converter.js
@@ -4,7 +4,7 @@ if (typeof exports === "object" && typeof require === "function") // we're in a 
     Markdown = exports;
 else
     Markdown = {};
-    
+
 // The following text is included for historical reasons, but should
 // be taken with a pinch of salt; it's not all true anymore.
 
@@ -583,8 +583,7 @@ else
                     }
                 }
             }
-            url = encodeProblemUrlChars(url);
-            url = escapeCharacters(url, "*_");
+            url = attributeSafeUrl(url);
             var result = "<a href=\"" + url + "\"";
 
             if (title != "") {
@@ -1201,7 +1200,7 @@ else
             // *except* for the <http://www.foo.com> case
 
             // automatically add < and > around unadorned raw hyperlinks
-            // must be preceded by space/BOF and followed by non-word/EOF character    
+            // must be preceded by space/BOF and followed by non-word/EOF character
             text = text.replace(/(^|\s)(https?|ftp)(:\/\/[-A-Z0-9+&@#\/%?=~_|\[\]\(\)!:,\.;]*[-A-Z0-9+&@#\/%=~_|\[\]])($|\W)/gi, "$1<$2$3>$4");
 
             //  autolink anything like <http://example.com>
@@ -1285,26 +1284,12 @@ else
         //  attacklab: Utility functions
         //
 
-        var _problemUrlChars = /(?:["'*()[\]:]|~D)/g;
-
-        // hex-encodes some unusual "problem" chars in URLs to avoid URL detection problems 
-        function encodeProblemUrlChars(url) {
-            if (!url)
-                return "";
-
-            var len = url.length;
-
-            return url.replace(_problemUrlChars, function (match, offset) {
-                if (match == "~D") // escape for dollar
-                    return "%24";
-                if (match == ":") {
-                    if (offset == len - 1 || /[0-9\/]/.test(url.charAt(offset + 1)))
-                        return ":"
-                }
-                return "%" + match.charCodeAt(0).toString(16);
-            });
+        // Replacing encodeProblemUrlChars with attributeSafeUrl. See more at https://code.google.com/p/pagedown/source/detail?r=016a78c093843e203de5364117d34d406a09e8c0
+        function attributeSafeUrl(url) {
+            url = attributeEncode(url);
+            url = escapeCharacters(url, "*_:()[]")
+            return url;
         }
-
 
         function escapeCharacters(text, charsToEscape, afterBackslash) {
             // First we have to escape the escape characters so that


### PR DESCRIPTION
[TNL-2609](https://openedx.atlassian.net/browse/TNL-2609)

This PR fixes the markdown editor issue of reference link having a colon in it. Actually http://example.com/colon:test was converted to http://example.com/colon%3atest
