### PR TITLE
Fixed Flaky test 

### DIFF
--- a/common/test/acceptance/pages/studio/import_export.py
+++ b/common/test/acceptance/pages/studio/import_export.py
@@ -1,10 +1,14 @@
 """
 Import/Export pages.
 """
+import time
+from datetime import datetime
+
 from bok_choy.promise import EmptyPromise
 import os
 import re
 import requests
+
 from .utils import click_css
 from .library import LibraryPage
 from .course_page import CoursePage
@@ -128,6 +132,15 @@ class ImportMixin(object):
         string = self.q(css='.item-progresspoint-success-date').text[0]
 
         return re.match(r'\(([^ ]+).+?(\d{2}:\d{2})', string).groups()
+
+    @property
+    def parsed_timestamp(self):
+        """
+        Return python datetime object from the parsed timestamp tuple (date, time)
+        """
+        timestamp = "{0} {1}".format(*self.timestamp)
+        formatted_timestamp = time.strptime(timestamp, "%m/%d/%Y %H:%M")
+        return datetime.fromtimestamp(time.mktime(formatted_timestamp))
 
     def is_browser_on_page(self):
         """

--- a/common/test/acceptance/tests/studio/test_import_export.py
+++ b/common/test/acceptance/tests/studio/test_import_export.py
@@ -1,10 +1,10 @@
 """
 Acceptance tests for the Import and Export pages
 """
+from datetime import datetime
+
 from abc import abstractmethod
 from bok_choy.promise import EmptyPromise
-from datetime import datetime
-from flaky import flaky
 
 from .base_studio_test import StudioLibraryTest, StudioCourseTest
 from ...fixtures.course import XBlockFixtureDesc
@@ -186,7 +186,6 @@ class ImportTestMixin(object):
         self.import_page.upload_tarball(self.tarball_name)
         self.import_page.wait_for_upload()
 
-    @flaky  # TODO make this not flaky. See TNL-2886.
     def test_import_timestamp(self):
         """
         Scenario: I perform a course / library import
@@ -194,25 +193,33 @@ class ImportTestMixin(object):
             And if I refresh the page, the timestamp is still displayed
         """
         self.assertFalse(self.import_page.is_timestamp_visible())
+
+        # Get the time when the import has started.
+        # import_page timestamp is in (MM/DD/YYYY at HH:mm) so replacing (second, microsecond) to
+        # keep the comparison consistent
+        upload_start_time = datetime.utcnow().replace(microsecond=0, second=0)
         self.import_page.upload_tarball(self.tarball_name)
         self.import_page.wait_for_upload()
 
-        utc_now = datetime.utcnow()
-        import_date, import_time = self.import_page.timestamp
+        # Get the time when the import has finished.
+        # import_page timestamp is in (MM/DD/YYYY at HH:mm) so replacing (second, microsecond) to
+        # keep the comparison consistent
+        upload_finish_time = datetime.utcnow().replace(microsecond=0, second=0)
 
+        import_timestamp = self.import_page.parsed_timestamp
         self.import_page.wait_for_timestamp_visible()
-        # Flaky pattern:
-        #    This test failed because the utc_now and import date
-        #    might be assigned at different times. The error message
-        #    was "'18:30' != u'18:29'", meaning it uploaded it at 18:29, then,
-        #    when we assigned utc_now, the time had crossed the minute to
-        #    18:30.
-        # Possible fixes:
-        # *  Mock utcnow somehow.
-        # *  Check for the date and time within a certain range, rather than
-        #    doing a string comparison.
-        self.assertEqual(utc_now.strftime('%m/%d/%Y'), import_date)
-        self.assertEqual(utc_now.strftime('%H:%M'), import_time)
+
+        # Verify that 'import_timestamp' is between start and finish upload time
+        self.assertLessEqual(
+            upload_start_time,
+            import_timestamp,
+            "Course import timestamp should be upload_start_time <= import_timestamp <= upload_end_time"
+        )
+        self.assertGreaterEqual(
+            upload_finish_time,
+            import_timestamp,
+            "Course import timestamp should be upload_start_time <= import_timestamp <= upload_end_time"
+        )
 
         self.import_page.visit()
         self.import_page.wait_for_tasks(completed=True)


### PR DESCRIPTION
Fixed a flaky test `TestLibraryImport.test_import_timestamp` and replaced string comparison with `datetime` comparison. 

Used datetime range to compare `import_timestamp`
## To Test

`paver test_bokchoy -t studio/test_import_export.py:TestCourseImport.test_import_timestamp`

It is to be noted that, this test has been marked as flaky. Here is the reference.
[common/test/acceptance/tests/studio/test_import_export.py#L189](https://github.com/edx/edx-platform/blob/b5e6607bc4710ab92de2776d9bbb0dac84523c3f/common/test/acceptance/tests/studio/test_import_export.py#L189)
## Jira

[Flaky test: test_import_timestamp   - PLAT-760](https://openedx.atlassian.net/browse/PLAT-760)
