### PR TITLE
Fix team count in topic serializers

### DIFF
--- a/lms/djangoapps/teams/serializers.py
+++ b/lms/djangoapps/teams/serializers.py
@@ -123,17 +123,23 @@ class TopicSerializer(BaseTopicSerializer):
     """
     Adds team_count to the basic topic serializer.  Use only when
     serializing a single topic.  When serializing many topics, use
-    `PaginatedTopicSerializer` to avoid O(N) SQL queries.
+    `PaginatedTopicSerializer` to avoid O(N) SQL queries.  Requires
+    that `context` is provided with a valid course_id in order to
+    filter teams within the course.
     """
     team_count = serializers.SerializerMethodField('get_team_count')
 
     def get_team_count(self, topic):
         """Get the number of teams associated with this topic"""
-        return CourseTeam.objects.filter(topic_id=topic['id']).count()
+        return CourseTeam.objects.filter(course_id=self.context['course_id'], topic_id=topic['id']).count()
 
 
 class PaginatedTopicSerializer(PaginationSerializer):
-    """Serializes a set of topics.  Adds team_count field to each topic."""
+    """
+    Serializes a set of topics, adding team_count field to each topic.
+    Requires that `context` is provided with a valid course_id in
+    order to filter teams within the course.
+    """
     class Meta(object):
         """Defines meta information for the PaginatedTopicSerializer."""
         object_serializer_class = BaseTopicSerializer
@@ -146,6 +152,7 @@ class PaginatedTopicSerializer(PaginationSerializer):
         # and outputs the result as a list of dicts (one per topic).
         topic_ids = [topic['id'] for topic in self.data['results']]
         teams_per_topic = CourseTeam.objects.filter(
+            course_id=self.context['course_id'],
             topic_id__in=topic_ids
         ).values('topic_id').annotate(team_count=Count('topic_id'))
 

--- a/lms/djangoapps/teams/views.py
+++ b/lms/djangoapps/teams/views.py
@@ -82,7 +82,10 @@ class TeamsDashboardView(View):
         sort_order = 'name'
         topics = get_ordered_topics(course, sort_order)
         topics_page = Paginator(topics, TOPICS_PER_PAGE).page(1)
-        topics_serializer = PaginatedTopicSerializer(instance=topics_page, context={'sort_order': sort_order})
+        topics_serializer = PaginatedTopicSerializer(
+            instance=topics_page,
+            context={'course_id': course.id, 'sort_order': sort_order}
+        )
         context = {
             "course": course,
             "topics": topics_serializer.data,
@@ -570,7 +573,7 @@ class TopicListView(GenericAPIView):
             }, status=status.HTTP_400_BAD_REQUEST)
 
         page = self.paginate_queryset(topics)
-        serializer = self.pagination_serializer_class(page, context={'sort_order': ordering})
+        serializer = self.pagination_serializer_class(page, context={'course_id': course_id, 'sort_order': ordering})
         return Response(serializer.data)  # pylint: disable=maybe-no-member
 
 
@@ -649,7 +652,7 @@ class TopicDetailView(APIView):
         if len(topics) == 0:
             return Response(status=status.HTTP_404_NOT_FOUND)
 
-        serializer = TopicSerializer(topics[0])
+        serializer = TopicSerializer(topics[0], context={'course_id': course_id})
         return Response(serializer.data)
 
 


### PR DESCRIPTION
This PR fixes a bug in which team counts presented to the user could be too large. This error occurred due to a couple factors:
- Multiple teams can share the same topic_id
- Topics can share IDs with each other -- we may reconsider this when we get to [TNL-2563](https://openedx.atlassian.net/browse/TNL-2563), but for now it's not a problem

This fixes the problem by further filtering Teams by course_id.

TNL-2892

@peter-fogg @dianakhuang please review.
