### PR TITLE
Style simplification to sync up styles

### DIFF
--- a/lms/static/sass/base/_base.scss
+++ b/lms/static/sass/base/_base.scss
@@ -10,7 +10,6 @@ html, body {
   font-size: 1em;
   font-style: normal;
   line-height: 1em;
-  //-webkit-font-smoothing: antialiased;
 }
 
 html{
@@ -33,7 +32,6 @@ h1 {
   letter-spacing: 1px;
   margin-bottom: ($baseline*1.5);
   text-align: center;
-  //text-transform: uppercase;
 }
 
 h2 {
@@ -50,14 +48,13 @@ p + h2, ul + h2, ol + h2 {
 }
 
 p {
-  color: $base-font-color;
-  font: normal 1em/1.6em $serif;
+  color: inherit;
   margin: 0;
 }
 
 span {
-  font: normal 1em/1.6em $sans-serif;
-  color: $base-font-color;
+  font: inherit;
+  color: inherit;
 }
 
 /* Fix for CodeMirror: prevent top-level span from affecting deeply-embedded span in CodeMirror */
@@ -79,9 +76,10 @@ p + p, ul + p, ol + p {
 }
 
 p {
-  a:link, a:visited {
+  a, a:visited {
     color: $link-color;
-    font: normal 1em/1em $serif;
+    font: inherit;
+    font-weight: inherit;
     text-decoration: none;
     @include transition(all 0.1s linear 0s);
 
@@ -92,9 +90,9 @@ p {
   }
 }
 
-a:link, a:visited {
+a, a:visited {
   color: $link-color;
-  font: normal 1em/1em $sans-serif;
+  font: inherit;
   text-decoration: none;
   @include transition(all 0.1s linear 0s);
 
@@ -107,14 +105,6 @@ a:link, a:visited {
     opacity: 0.5;
     cursor: not-allowed;
   }
-}
-
-a:focus {
-  /**
-   *  Add general focus styling here
-   *  for example:
-   *      outline: 3px groove $black;
-   **/
 }
 
 .content-wrapper {

--- a/lms/static/sass/course/base/_base.scss
+++ b/lms/static/sass/course/base/_base.scss
@@ -43,13 +43,17 @@ body {
   //background-image: $course-bg-image;
 }
 
-body, h1, h2, h3, h4, h5, h6, p, p a:link, p a:visited, a, label {
+body, h1, h2, h3, h4, h5, h6, p, label {
   @include text-align(left);
   font-family: $sans-serif;
 }
 
 table {
   table-layout: fixed;
+}
+
+.xblock table {
+  table-layout: auto
 }
 
 a {

--- a/lms/static/sass/course/courseware/_courseware.scss
+++ b/lms/static/sass/course/courseware/_courseware.scss
@@ -105,11 +105,6 @@ div.course-wrapper {
 
     p {
       margin-bottom: lh();
-
-      &:empty {
-        display: none;
-        margin-bottom: 0;
-      }
     }
 
     .sequential-status-message {

--- a/lms/static/sass/views/_homepage.scss
+++ b/lms/static/sass/views/_homepage.scss
@@ -72,6 +72,11 @@ $learn-more-horizontal-position: calc(50% - 100px); // calculate the left positi
 
       .course-info {
         height: $course-info-height;
+        font-family: $sans-serif;
+
+        h2 {
+          font-family: $sans-serif;
+        }
 
         .course-organization, .course-code, .course-date {
           @extend %t-icon6;


### PR DESCRIPTION
This small bit of work relates to [UX-2534](https://openedx.atlassian.net/browse/UX-2534) and attempts to sync up typography between Studio and LMS by reducing or simplifying the rules. Rather than specifying the font styles for `span` and `a` elements, we're letting them inherit the most of the styles of their respective parent.

---

A few screenshots:

<img width="923" alt="screen shot 2015-07-28 at 2 59 36 pm" src="https://cloud.githubusercontent.com/assets/2112024/8940922/991f7a4e-353a-11e5-9ff7-bafc8cf81f9b.png">
Adding text in Studio

<img width="868" alt="screen shot 2015-07-28 at 2 59 48 pm" src="https://cloud.githubusercontent.com/assets/2112024/8940924/9e69c9aa-353a-11e5-9221-821a0dda5d24.png">
The equivalent view in LMS

---
## Browser testing

I checked these edits in the following browsers:

| Platform | Browser | Version | Passed |
| --- | --- | --- | --- |
| Mac | Chrome | 43 | Yes |
|  | Safari | 8 | Yes |
|  | Firefox | 24 | Yes |
| Windows | Chrome | 43 | Yes |
|  | Firefox | 38 | Yes |
|  | IE | 10 | Yes |
|  | IE | 11 | Yes |

---
## Sandbox

I've provisioned a sandbox for previewing:
http://clrux-2534.m.sandbox.edx.org

---

**Reviewers:**

I spot-checked the LMS and didn't see anything else affected by these changes.
- [ ] @frrrances 
