### PR TITLE
Fix Django Debug Toolbar circular imports

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -595,6 +595,15 @@ REQUIRE_EXCLUDE = ("build.txt",)
 # It can also be a path to a custom class that subclasses require.environments.Environment and defines some "args" function that returns a list with the command arguments to execute.
 REQUIRE_ENVIRONMENT = "node"
 
+
+########################## DJANGO DEBUG TOOLBAR ###############################
+
+# We don't enable Django Debug Toolbar universally, but whenever we do, we want
+# to avoid patching settings.  Patched settings can cause circular import
+# problems: http://django-debug-toolbar.readthedocs.org/en/1.0/installation.html#explicit-setup
+
+DEBUG_TOOLBAR_PATCH_SETTINGS = False
+
 ################################# TENDER ######################################
 
 # If you want to enable Tender integration (http://tenderapp.com/),

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -190,6 +190,11 @@ if settings.DEBUG:
     except ImportError:
         pass
 
+    import debug_toolbar
+    urlpatterns += (
+        url(r'^__debug__/', include(debug_toolbar.urls)),
+    )
+
 # Custom error pages
 # pylint: disable=invalid-name
 handler404 = 'contentstore.views.render_404'

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -708,7 +708,12 @@ if settings.DEBUG:
     # in debug mode, allow any template to be rendered (most useful for UX reference templates)
     urlpatterns += url(r'^template/(?P<template>.+)$', 'debug.views.show_reference_template'),
 
-#Custom error pages
+    import debug_toolbar
+    urlpatterns += (
+        url(r'^__debug__/', include(debug_toolbar.urls)),
+    )
+
+# Custom error pages
 handler404 = 'static_template_view.views.render_404'
 handler500 = 'static_template_view.views.render_500'
 


### PR DESCRIPTION
There's an "explicit" way to configure Django Debug Toolbar that isn't
prone to circular import errors:

http://django-debug-toolbar.readthedocs.org/en/1.0/installation.html#explicit-setup

Do that.
