### PR TITLE
CAPA CSS: Fixing indicator spacing on dropdown problems

### DIFF
--- a/common/lib/xmodule/xmodule/css/capa/display.scss
+++ b/common/lib/xmodule/xmodule/css/capa/display.scss
@@ -783,7 +783,7 @@ div.problem {
     .indicator-container {
       display: inline-block;
 
-      .status.correct:after, .status.incorrect:after {
+      .status.correct:after, .status.incorrect:after, .status.unanswered:after {
         @include margin-left(0);
       }
     }


### PR DESCRIPTION
The recent overhaul of the CAPA CSS missed a tiny little piece for dropdown problems.

The question mark indicator after the dropdown list in the following problem is underneath text.
![screen shot 2015-07-29 at 5 07 49 pm](https://cloud.githubusercontent.com/assets/6232546/8970006/fb84aecc-3614-11e5-987c-dd8fd1113af0.png)
The cross and checkmarks are perfectly fine.
![screen shot 2015-07-29 at 5 08 06 pm](https://cloud.githubusercontent.com/assets/6232546/8970018/0af8cf96-3615-11e5-9e0a-5520df5cb3d6.png)
![screen shot 2015-07-29 at 5 13 07 pm](https://cloud.githubusercontent.com/assets/6232546/8970024/1a2ba57e-3615-11e5-9dab-4070ec3b44b2.png)

A specific fix for the cross and checkmarks needs to also apply to the question mark, as fixed in this PR.

Code to generate this example:

<pre>
The &lt;optionresponse inline=&quot;1&quot;&gt;&lt;optioninput label=&quot;animal&quot; inline=&quot;1&quot; options=&quot;('cat','dog')&quot; correct=&quot;cat&quot;/&gt;&lt;/optionresponse&gt; purrs at night.</pre>
