### PR TITLE
SSO: Make email addresses in SAML metadata fully configurable

### DIFF
--- a/common/djangoapps/third_party_auth/models.py
+++ b/common/djangoapps/third_party_auth/models.py
@@ -363,11 +363,14 @@ class SAMLConfiguration(ConfigurationModel):
             return self.public_key
         if name == "SP_PRIVATE_KEY":
             return self.private_key
-        if name == "TECHNICAL_CONTACT":
-            return {"givenName": "Technical Support", "emailAddress": settings.TECH_SUPPORT_EMAIL}
-        if name == "SUPPORT_CONTACT":
-            return {"givenName": "SAML Support", "emailAddress": settings.TECH_SUPPORT_EMAIL}
         other_config = json.loads(self.other_config_str)
+        if name in ("TECHNICAL_CONTACT", "SUPPORT_CONTACT"):
+            contact = {
+                "givenName": "{} Support".format(settings.PLATFORM_NAME),
+                "emailAddress": settings.TECH_SUPPORT_EMAIL
+            }
+            contact.update(other_config.get(name, {}))
+            return contact
         return other_config[name]  # SECURITY_CONFIG, SP_EXTRA, or similar extra settings
 
 

--- a/common/djangoapps/third_party_auth/tests/testutil.py
+++ b/common/djangoapps/third_party_auth/tests/testutil.py
@@ -114,6 +114,15 @@ class SAMLTestCase(TestCase):
         with open(os.path.join(os.path.dirname(__file__), 'data', filename)) as f:
             return f.read()
 
+    def enable_saml(self, **kwargs):
+        """ Enable SAML support (via SAMLConfiguration, not for any particular provider) """
+        if 'private_key' not in kwargs:
+            kwargs['private_key'] = self._get_private_key()
+        if 'public_key' not in kwargs:
+            kwargs['public_key'] = self._get_public_key()
+        kwargs.setdefault('entity_id', "https://saml.example.none")
+        super(SAMLTestCase, self).enable_saml(**kwargs)
+
 
 @contextmanager
 def simulate_running_pipeline(pipeline_target, backend, email=None, fullname=None, username=None):


### PR DESCRIPTION
**Description**: Per [@e0d's request in OPS-820](https://openedx.atlassian.net/browse/OPS-820?focusedCommentId=130023&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-130023), this PR makes the names and email addresses that appear in SAML metadata configurable.

The default values still just use `settings.TECH_SUPPORT_EMAIL` but admin/ops can now override that default by adding new entries to the "other_config_str" in /admin/third_party_auth/samlconfiguration/ .

Example of the new settings in the `other_config_str` JSON:

```
{
    "TECHNICAL_CONTACT": {"givenName": "Jane S", "emailAddress": "jane@example.com"}, 
    "SUPPORT_CONTACT": {"givenName": "Joe B", "emailAddress": "joe@example.com"}, 
}
```

Would result in XML like this:

```
<md:ContactPerson contactType="technical">
<md:GivenName>Jane S</md:GivenName>
<md:EmailAddress>jane@example.com</md:EmailAddress>
</md:ContactPerson>
<md:ContactPerson contactType="support">
<md:GivenName>Joe B</md:GivenName>
<md:EmailAddress>joe@example.com</md:EmailAddress>
</md:ContactPerson>
```

**Screenshot of Config Screen**:
![screen shot 2015-07-29 at 3 01 29 pm](https://cloud.githubusercontent.com/assets/945577/8971136/bf3dd022-3602-11e5-86db-09284c7818f3.png)

**JIRA**: None

**Merge deadline**: No huge rush AFAIK

**Sandbox**: http://sandbox5.opencraft.com/auth/saml/metadata.xml

**Reviewers**: @smarnach and TBD
