### PR TITLE
Allow enrollments in expired modes to be deactivated

### DIFF
--- a/common/djangoapps/enrollment/serializers.py
+++ b/common/djangoapps/enrollment/serializers.py
@@ -40,7 +40,11 @@ class CourseField(serializers.RelatedField):
 
     def to_native(self, course, **kwargs):
         course_modes = ModeSerializer(
-            CourseMode.modes_for_course(course.id, kwargs.get('include_expired', False), only_selectable=False)
+            CourseMode.modes_for_course(
+                course.id,
+                include_expired=kwargs.get('include_expired', False),
+                only_selectable=False
+            )
         ).data  # pylint: disable=no-member
 
         return {

--- a/common/djangoapps/enrollment/views.py
+++ b/common/djangoapps/enrollment/views.py
@@ -598,7 +598,7 @@ class EnrollmentListView(APIView, ApiKeyPermissionMixIn):
                 data={
                     "message": (
                         u"The course mode '{mode}' is not available for course '{course_id}'."
-                    ).format(mode="honor", course_id=course_id),
+                    ).format(mode=mode, course_id=course_id),
                     "course_details": error.data
                 })
         except CourseNotFoundError:


### PR DESCRIPTION
Facilitates revocation of enrollments in expired modes. XCOM-490.

@jimabramson and @clintonb, please review when able.
