### PR TITLE
Revert "Remove unnecessary DB call in team pagination."

### DIFF
--- a/lms/djangoapps/teams/views.py
+++ b/lms/djangoapps/teams/views.py
@@ -331,14 +331,7 @@ class TeamsListView(ExpandableFieldViewMixin, GenericAPIView):
 
         queryset = queryset.order_by(order_by_field)
 
-        # TODO: Remove this on update to Django 1.8
-        # Use the cached length of the queryset in order to avoid
-        # making an extra database call to get the number of items in
-        # the collection
-        paginator = self.paginator_class(queryset, self.get_paginate_by())
-        paginator._count = len(queryset)  # pylint: disable=protected-access
-        page = paginator.page(int(request.QUERY_PARAMS.get('page', 1)))
-        # end TODO
+        page = self.paginate_queryset(queryset)
         serializer = self.get_pagination_serializer(page)
         serializer.context.update({'sort_order': order_by_input})  # pylint: disable=maybe-no-member
         return Response(serializer.data)  # pylint: disable=maybe-no-member


### PR DESCRIPTION
Turns out that this patch, while it does remove a SQL query, ends up making pagination far slower in `TeamsListView.get`. Behold:

<img width="802" alt="pagination-fix-new-relic" src="https://cloud.githubusercontent.com/assets/1819831/8990596/696322dc-36c1-11e5-9b00-2e2453637e9c.png">

That Matterhorn-looking part of the graph is without this commit; the gently rolling Irish hills of the right side are the same tests with this commit.

My guess is that there's a space leak introduced by the workaround code, which explains why filtering by `topic_id` results in better performance -- the queryset is much smaller that way. I haven't dug into the Django internals enough to figure out exactly why this is the case, but the moral of the story seems to be "don't mess with ~~Texas~~ the internals of well-maintained open source libraries".
@dan-f @dianakhuang I believe you both reviewed the original commit -- care to review the fix?
