### PR TITLE
Assigning focus to the selected topic

### DIFF
--- a/common/static/coffee/spec/discussion/view/discussion_thread_view_spec.coffee
+++ b/common/static/coffee/spec/discussion/view/discussion_thread_view_spec.coffee
@@ -158,6 +158,18 @@ describe "DiscussionThreadView", ->
                 expect($.ajax).not.toHaveBeenCalled()
                 expect(@view.$el.find(".responses li").length).toEqual(0)
 
+        describe "focus", ->
+            it "sends focus to the conversation when opened", ->
+                DiscussionViewSpecHelper.setNextResponseContent({resp_total: 0, children: []})
+                @view.render()
+                @view.expand()
+                waitsFor (->
+                    # This is the implementation of "toBeFocused". However, simply calling that method
+                    # with no wait seems to be flaky.
+                    article = @view.$el.find('.discussion-article')
+                    return article[0] == article[0].ownerDocument.activeElement
+                ), "conversation did not receive focus", 3000
+
         describe "expand/collapse", ->
             it "shows/hides appropriate content", ->
                 DiscussionViewSpecHelper.setNextResponseContent({resp_total: 0, children: []})

--- a/common/static/coffee/src/discussion/views/discussion_thread_view.coffee
+++ b/common/static/coffee/src/discussion/views/discussion_thread_view.coffee
@@ -162,6 +162,7 @@ if Backbone?
           )
           @trigger "thread:responses:rendered"
           @loadedResponses = true
+          @$el.find('.discussion-article[data-id="' + @model.id + '"]').focus() # Sends focus to the discussion once the thread loads
         error: (xhr, textStatus) =>
           return if textStatus == 'abort'
 

--- a/common/static/common/templates/discussion/thread.underscore
+++ b/common/static/common/templates/discussion/thread.underscore
@@ -1,5 +1,5 @@
-<article class="discussion-article" data-id="<%- id %>">
-    <div class="thread-wrapper" tabindex="-1">
+<article class="discussion-article" data-id="<%- id %>" tabindex="-1">
+    <div class="thread-wrapper">
         <div class="forum-thread-main-wrapper">
             <div class="thread-content-wrapper"></div>
             <div class="post-extended-content">


### PR DESCRIPTION
This piece of work sends focus to the selected topic in the discussion forums. It addresses [TNL-2620](https://openedx.atlassian.net/browse/TNL-2620) as well as an [RCA](https://openedx.atlassian.net/wiki/display/TNL/RCA%3A+2015-06-29+-+Expanding+The+jumps+the+user+to+the+bottom+of+page) (in which we had to rollback previous work done).
## History

Previously, focus was sent to the `$('.thread-wrapper')` class, but in some cases where were more than one instance of this container and focus would be sent to the last one on the page, often skipping over previous topics.

This fix sends focus to the selected `id` of the topic, ensuring focus goes where it's intended to.
## Browsers

This work was checked in the following browsers:

| Platform | Browser | Version | Passed |
| --- | --- | --- | --- |
| Mac | Chrome | 43 | Yes |
|  | Safari | 8 | Yes |
|  | Firefox | 24 | Yes |
| Windows | Chrome | 43 | Yes |
|  | Firefox | 38 | Yes |
|  | IE | 10 | Yes |
|  | IE | 11 | Yes |
## Sandbox

A sandbox to preview this is here: http://clrux-2576.m.sandbox.edx.org/

---
### Reviewers
- [x] @cahrens (Python/JS)
- [x] @cptvitamin (Accessibility)
