### PR TITLE
Deactivate HTTPS on devstack

### DIFF
--- a/cms/envs/dev.py
+++ b/cms/envs/dev.py
@@ -13,6 +13,8 @@ from lms.envs.dev import (WIKI_ENABLED)
 
 DEBUG = True
 TEMPLATE_DEBUG = DEBUG
+HTTPS = 'off'
+
 LOGGING = get_logger_config(ENV_ROOT / "log",
                             logging_env="dev",
                             tracking_filename="tracking.log",

--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -11,6 +11,7 @@ MEDIA_ROOT = "/edx/var/edxapp/uploads"
 DEBUG = True
 USE_I18N = True
 TEMPLATE_DEBUG = DEBUG
+HTTPS = 'off'
 
 ################################ LOGGERS ######################################
 

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -16,6 +16,7 @@ SITE_NAME = 'localhost:8000'
 PLATFORM_NAME = ENV_TOKENS.get('PLATFORM_NAME', 'Devstack')
 # By default don't use a worker, execute tasks as if they were local functions
 CELERY_ALWAYS_EAGER = True
+HTTPS = 'off'
 
 ################################ LOGGERS ######################################
 


### PR DESCRIPTION
When running locally, XBlocks which access third-party software no longer
cause server errors.

Because devstack inherits from aws, the HTTPS flag was implicitly set to 'on'.
This meant that XBlocks attempted to use SSL when dealing with third-party
components like LTI.  Since SSL is not enabled on devstack, this caused server
errors whenever these features ran.
