### PR TITLE
ziafazal/SOL-1088: Show Certificate function only when advanced setting is true

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_header_menu.py
+++ b/cms/djangoapps/contentstore/views/tests/test_header_menu.py
@@ -1,0 +1,47 @@
+#-*- coding: utf-8 -*-
+
+"""
+Course Header Menu Tests.
+"""
+from django.conf import settings
+from django.test.utils import override_settings
+
+from contentstore.tests.utils import CourseTestCase
+from contentstore.utils import reverse_course_url
+
+FEATURES_WITH_CERTS_ENABLED = settings.FEATURES.copy()
+FEATURES_WITH_CERTS_ENABLED['CERTIFICATES_HTML_VIEW'] = True
+
+
+@override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+class TestHeaderMenu(CourseTestCase):
+    """
+    Unit tests for the course header menu.
+    """
+    def setUp(self):
+        """
+        Set up the for the course header menu tests.
+        """
+        super(TestHeaderMenu, self).setUp()
+
+    def test_header_menu_without_web_certs_enabled(self):
+        """
+        Tests course header menu should not have `Certificates` menu item
+        if course has not web/HTML certificates enabled.
+        """
+        outline_url = reverse_course_url('course_handler', self.course.id)
+        resp = self.client.get(outline_url, HTTP_ACCEPT='text/html')
+        self.assertEqual(resp.status_code, 200)
+        self.assertNotContains(resp, '<li class="nav-item nav-course-settings-certificates">')
+
+    def test_header_menu_with_web_certs_enabled(self):
+        """
+        Tests course header menu should have `Certificates` menu item
+        if course has web/HTML certificates enabled.
+        """
+        self.course.cert_html_view_enabled = True
+        self.save_course()
+        outline_url = reverse_course_url('course_handler', self.course.id)
+        resp = self.client.get(outline_url, HTTP_ACCEPT='text/html')
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, '<li class="nav-item nav-course-settings-certificates">')

--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -4,7 +4,6 @@
   from django.core.urlresolvers import reverse
   from django.utils.translation import ugettext as _
   from contentstore.context_processors import doc_url
-  from student.roles import CourseCreatorRole, CourseInstructorRole, CourseStaffRole
 %>
 <%page args="online_help_token"/>
 
@@ -36,12 +35,10 @@
             grading_url = reverse('contentstore.views.grading_handler', kwargs={'course_key_string': unicode(course_key)})
             advanced_settings_url = reverse('contentstore.views.advanced_settings_handler', kwargs={'course_key_string': unicode(course_key)})
             tabs_url = reverse('contentstore.views.tabs_handler', kwargs={'course_key_string': unicode(course_key)})
+            certificates_url = ''
+            if settings.FEATURES.get("CERTIFICATES_HTML_VIEW") and context_course.cert_html_view_enabled:
+                certificates_url = reverse('contentstore.views.certificates.certificates_list_handler', kwargs={'course_key_string': unicode(course_key)})
       %>
-      % if settings.FEATURES.get("CERTIFICATES_HTML_VIEW") and context_course:
-        <%
-          certificates_url = reverse('contentstore.views.certificates.certificates_list_handler', kwargs={'course_key_string': unicode(course_key)})
-        %>
-      % endif
       <h2 class="info-course">
         <span class="sr">${_("Current Course:")}</span>
         <a class="course-link" href="${index_url}">
@@ -105,11 +102,7 @@
                   <li class="nav-item nav-course-settings-advanced">
                     <a href="${advanced_settings_url}">${_("Advanced Settings")}</a>
                   </li>
-                  % if settings.FEATURES.get('CERTIFICATES_HTML_VIEW', False) and \
-                    (user.is_superuser or user.is_staff or \
-                    CourseCreatorRole(course_key).has_user(user) or \
-                    CourseInstructorRole(course_key).has_user(user) or \
-                    CourseStaffRole(course_key).has_user(user)):
+                  % if certificates_url:
                   <li class="nav-item nav-course-settings-certificates">
                     <a href="${certificates_url}">${_("Certificates")}</a>
                   </li>


### PR DESCRIPTION
@mattdrayer @asadiqbal08 this PR supports SOL-1088. It would show `Certificate` menu item only when HTML/Web Certificates are enabled for the course. 

I have removed User permissions check since they seems to be overhead here. Every time user access a studio page it would cause a db hit. We already have these permission checks on the backend. 
