### PR TITLE
update 'UserPartition' to add extra field 'parameters'

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_group_configurations.py
+++ b/cms/djangoapps/contentstore/views/tests/test_group_configurations.py
@@ -263,6 +263,7 @@ class GroupConfigurationsListHandlerTestCase(CourseTestCase, GroupConfigurations
                 {u'name': u'Group A', u'version': 1},
                 {u'name': u'Group B', u'version': 1},
             ],
+            u'parameters': {}
         }
         response = self.client.ajax_post(
             self._url(),
@@ -284,6 +285,7 @@ class GroupConfigurationsListHandlerTestCase(CourseTestCase, GroupConfigurations
         self.assertEqual(len(user_partititons[0].groups), 2)
         self.assertEqual(user_partititons[0].groups[0].name, u'Group A')
         self.assertEqual(user_partititons[0].groups[1].name, u'Group B')
+        self.assertEqual(user_partititons[0].parameters, {})
 
     def test_lazily_creates_cohort_configuration(self):
         """
@@ -329,6 +331,7 @@ class GroupConfigurationsDetailHandlerTestCase(CourseTestCase, GroupConfiguratio
                 {u'id': 0, u'name': u'Group A', u'version': 1, u'usage': []},
                 {u'id': 1, u'name': u'Group B', u'version': 1, u'usage': []},
             ],
+            u'parameters': {}
         }
         response = self.client.put(
             self._url(cid=666),
@@ -348,6 +351,7 @@ class GroupConfigurationsDetailHandlerTestCase(CourseTestCase, GroupConfiguratio
         self.assertEqual(len(user_partitions[0].groups), 2)
         self.assertEqual(user_partitions[0].groups[0].name, u'Group A')
         self.assertEqual(user_partitions[0].groups[1].name, u'Group B')
+        self.assertEqual(user_partitions[0].parameters, {})
 
     def test_can_edit_content_group(self):
         """
@@ -366,6 +370,7 @@ class GroupConfigurationsDetailHandlerTestCase(CourseTestCase, GroupConfiguratio
                 {u'id': 0, u'name': u'New Group Name', u'version': 1, u'usage': []},
                 {u'id': 2, u'name': u'Group C', u'version': 1, u'usage': []},
             ],
+            u'parameters': {}
         }
 
         response = self.client.put(
@@ -387,6 +392,7 @@ class GroupConfigurationsDetailHandlerTestCase(CourseTestCase, GroupConfiguratio
         self.assertEqual(len(user_partititons[0].groups), 2)
         self.assertEqual(user_partititons[0].groups[0].name, u'New Group Name')
         self.assertEqual(user_partititons[0].groups[1].name, u'Group C')
+        self.assertEqual(user_partititons[0].parameters, {})
 
     def test_can_delete_content_group(self):
         """
@@ -468,6 +474,7 @@ class GroupConfigurationsDetailHandlerTestCase(CourseTestCase, GroupConfiguratio
                 {u'id': 1, u'name': u'Group B', u'version': 1},
             ],
             u'usage': [],
+            u'parameters': {}
         }
 
         response = self.client.put(
@@ -487,6 +494,7 @@ class GroupConfigurationsDetailHandlerTestCase(CourseTestCase, GroupConfiguratio
         self.assertEqual(len(user_partitions[0].groups), 2)
         self.assertEqual(user_partitions[0].groups[0].name, u'Group A')
         self.assertEqual(user_partitions[0].groups[1].name, u'Group B')
+        self.assertEqual(user_partitions[0].parameters, {})
 
     def test_can_edit_group_configuration(self):
         """
@@ -506,6 +514,7 @@ class GroupConfigurationsDetailHandlerTestCase(CourseTestCase, GroupConfiguratio
                 {u'id': 2, u'name': u'Group C', u'version': 1},
             ],
             u'usage': [],
+            u'parameters': {}
         }
 
         response = self.client.put(
@@ -527,6 +536,7 @@ class GroupConfigurationsDetailHandlerTestCase(CourseTestCase, GroupConfiguratio
         self.assertEqual(len(user_partititons[0].groups), 2)
         self.assertEqual(user_partititons[0].groups[0].name, u'New Group Name')
         self.assertEqual(user_partititons[0].groups[1].name, u'Group C')
+        self.assertEqual(user_partititons[0].parameters, {})
 
     def test_can_delete_group_configuration(self):
         """
@@ -612,6 +622,7 @@ class GroupConfigurationsUsageInfoTestCase(CourseTestCase, HelperMethods):
                 {'id': 1, 'name': 'Group B', 'version': 1, 'usage': usage_for_group},
                 {'id': 2, 'name': 'Group C', 'version': 1, 'usage': []},
             ],
+            u'parameters': {}
         }
 
     def test_content_group_not_used(self):
@@ -704,6 +715,7 @@ class GroupConfigurationsUsageInfoTestCase(CourseTestCase, HelperMethods):
                 {'id': 2, 'name': 'Group C', 'version': 1},
             ],
             'usage': [],
+            u'parameters': {}
         }]
         self.assertEqual(actual, expected)
 
@@ -733,6 +745,7 @@ class GroupConfigurationsUsageInfoTestCase(CourseTestCase, HelperMethods):
                 'label': 'Test Unit 0 / Test Content Experiment 0',
                 'validation': None,
             }],
+            u'parameters': {}
         }, {
             'id': 1,
             'name': 'Name 1',
@@ -745,6 +758,7 @@ class GroupConfigurationsUsageInfoTestCase(CourseTestCase, HelperMethods):
                 {'id': 2, 'name': 'Group C', 'version': 1},
             ],
             'usage': [],
+            u'parameters': {}
         }]
 
         self.assertEqual(actual, expected)
@@ -775,6 +789,7 @@ class GroupConfigurationsUsageInfoTestCase(CourseTestCase, HelperMethods):
                 'label': u"Test Unit 0 / Test Content Experiment 0JOSÉ ANDRÉS",
                 'validation': None,
             }],
+            u'parameters': {}
         }]
 
         self.assertEqual(actual, expected)
@@ -810,6 +825,7 @@ class GroupConfigurationsUsageInfoTestCase(CourseTestCase, HelperMethods):
                 'label': 'Test Unit 1 / Test Content Experiment 1',
                 'validation': None,
             }],
+            u'parameters': {}
         }]
         self.assertEqual(actual, expected)
 

--- a/common/lib/xmodule/xmodule/partitions/tests/test_partitions.py
+++ b/common/lib/xmodule/xmodule/partitions/tests/test_partitions.py
@@ -110,6 +110,7 @@ class PartitionTestCase(TestCase):
     TEST_ID = 0
     TEST_NAME = "Mock Partition"
     TEST_DESCRIPTION = "for testing purposes"
+    TEST_PARAMETERS = {"location": "block-v1:edX+DemoX+Demo+type@block@uuid"}
     TEST_GROUPS = [Group(0, 'Group 1'), Group(1, 'Group 2')]
     TEST_SCHEME_NAME = "mock"
 
@@ -136,7 +137,8 @@ class PartitionTestCase(TestCase):
             self.TEST_NAME,
             self.TEST_DESCRIPTION,
             self.TEST_GROUPS,
-            extensions[0].plugin
+            extensions[0].plugin,
+            self.TEST_PARAMETERS,
         )
 
         # Make sure the names are set on the schemes (which happens normally in code, but may not happen in tests).
@@ -149,17 +151,29 @@ class TestUserPartition(PartitionTestCase):
 
     def test_construct(self):
         user_partition = UserPartition(
-            self.TEST_ID, self.TEST_NAME, self.TEST_DESCRIPTION, self.TEST_GROUPS, MockUserPartitionScheme()
+            self.TEST_ID,
+            self.TEST_NAME,
+            self.TEST_DESCRIPTION,
+            self.TEST_GROUPS,
+            MockUserPartitionScheme(),
+            self.TEST_PARAMETERS,
         )
         self.assertEqual(user_partition.id, self.TEST_ID)    # pylint: disable=no-member
         self.assertEqual(user_partition.name, self.TEST_NAME)
         self.assertEqual(user_partition.description, self.TEST_DESCRIPTION)    # pylint: disable=no-member
+        self.assertEqual(user_partition.description, self.TEST_DESCRIPTION)    # pylint: disable=no-member
         self.assertEqual(user_partition.groups, self.TEST_GROUPS)    # pylint: disable=no-member
         self.assertEquals(user_partition.scheme.name, self.TEST_SCHEME_NAME)    # pylint: disable=no-member
+        self.assertEquals(user_partition.parameters, self.TEST_PARAMETERS)    # pylint: disable=no-member
 
     def test_string_id(self):
         user_partition = UserPartition(
-            "70", self.TEST_NAME, self.TEST_DESCRIPTION, self.TEST_GROUPS
+            "70",
+            self.TEST_NAME,
+            self.TEST_DESCRIPTION,
+            self.TEST_GROUPS,
+            MockUserPartitionScheme(),
+            self.TEST_PARAMETERS,
         )
         self.assertEqual(user_partition.id, 70)    # pylint: disable=no-member
 
@@ -169,6 +183,7 @@ class TestUserPartition(PartitionTestCase):
             "id": self.TEST_ID,
             "name": self.TEST_NAME,
             "description": self.TEST_DESCRIPTION,
+            "parameters": self.TEST_PARAMETERS,
             "groups": [group.to_json() for group in self.TEST_GROUPS],
             "version": self.user_partition.VERSION,
             "scheme": self.TEST_SCHEME_NAME
@@ -180,6 +195,7 @@ class TestUserPartition(PartitionTestCase):
             "id": self.TEST_ID,
             "name": self.TEST_NAME,
             "description": self.TEST_DESCRIPTION,
+            "parameters": self.TEST_PARAMETERS,
             "groups": [group.to_json() for group in self.TEST_GROUPS],
             "version": UserPartition.VERSION,
             "scheme": "mock",
@@ -188,6 +204,7 @@ class TestUserPartition(PartitionTestCase):
         self.assertEqual(user_partition.id, self.TEST_ID)    # pylint: disable=no-member
         self.assertEqual(user_partition.name, self.TEST_NAME)    # pylint: disable=no-member
         self.assertEqual(user_partition.description, self.TEST_DESCRIPTION)    # pylint: disable=no-member
+        self.assertEqual(user_partition.parameters, self.TEST_PARAMETERS)    # pylint: disable=no-member
         for act_group in user_partition.groups:    # pylint: disable=no-member
             self.assertIn(act_group.id, [0, 1])
             exp_group = self.TEST_GROUPS[act_group.id]
@@ -195,7 +212,8 @@ class TestUserPartition(PartitionTestCase):
             self.assertEqual(exp_group.name, act_group.name)
 
     def test_version_upgrade(self):
-        # Version 1 partitions did not have a scheme specified
+        # Test that version 1 partitions did not have a scheme specified
+        # and have empty parameters
         jsonified = {
             "id": self.TEST_ID,
             "name": self.TEST_NAME,
@@ -205,12 +223,57 @@ class TestUserPartition(PartitionTestCase):
         }
         user_partition = UserPartition.from_json(jsonified)
         self.assertEqual(user_partition.scheme.name, "random")    # pylint: disable=no-member
+        self.assertEqual(user_partition.parameters, {})
+
+    def test_version_upgrade_2_to_3(self):
+        # Test that version 3 user partition raises error if 'scheme' field is
+        # not provided (same behavior as version 2)
+        jsonified = {
+            'id': self.TEST_ID,
+            "name": self.TEST_NAME,
+            "description": self.TEST_DESCRIPTION,
+            "parameters": self.TEST_PARAMETERS,
+            "groups": [group.to_json() for group in self.TEST_GROUPS],
+            "version": UserPartition.VERSION,
+        }
+        with self.assertRaisesRegexp(TypeError, "missing value key 'scheme'"):
+            UserPartition.from_json(jsonified)
+
+        # Test that version 3 partitions have a scheme specified
+        # and a field 'parameters' (optional while setting user partition but
+        # always present in response)
+        jsonified = {
+            "id": self.TEST_ID,
+            "name": self.TEST_NAME,
+            "description": self.TEST_DESCRIPTION,
+            "groups": [group.to_json() for group in self.TEST_GROUPS],
+            "version": UserPartition.VERSION,
+            "scheme": self.TEST_SCHEME_NAME,
+        }
+        user_partition = UserPartition.from_json(jsonified)
+        self.assertEqual(user_partition.scheme.name, self.TEST_SCHEME_NAME)
+        self.assertEqual(user_partition.parameters, {})
+
+        # now test that parameters dict is present in response with same value
+        # as provided
+        jsonified = {
+            "id": self.TEST_ID,
+            "name": self.TEST_NAME,
+            "description": self.TEST_DESCRIPTION,
+            "groups": [group.to_json() for group in self.TEST_GROUPS],
+            "parameters": self.TEST_PARAMETERS,
+            "version": 3,
+            "scheme": self.TEST_SCHEME_NAME,
+        }
+        user_partition = UserPartition.from_json(jsonified)
+        self.assertEqual(user_partition.parameters, self.TEST_PARAMETERS)
 
     def test_from_json_broken(self):
         # Missing field
         jsonified = {
             "name": self.TEST_NAME,
             "description": self.TEST_DESCRIPTION,
+            "parameters": self.TEST_PARAMETERS,
             "groups": [group.to_json() for group in self.TEST_GROUPS],
             "version": UserPartition.VERSION,
             "scheme": self.TEST_SCHEME_NAME,
@@ -223,6 +286,7 @@ class TestUserPartition(PartitionTestCase):
             'id': self.TEST_ID,
             "name": self.TEST_NAME,
             "description": self.TEST_DESCRIPTION,
+            "parameters": self.TEST_PARAMETERS,
             "groups": [group.to_json() for group in self.TEST_GROUPS],
             "version": UserPartition.VERSION,
         }
@@ -234,6 +298,7 @@ class TestUserPartition(PartitionTestCase):
             'id': self.TEST_ID,
             "name": self.TEST_NAME,
             "description": self.TEST_DESCRIPTION,
+            "parameters": self.TEST_PARAMETERS,
             "groups": [group.to_json() for group in self.TEST_GROUPS],
             "version": UserPartition.VERSION,
             "scheme": "no_such_scheme",
@@ -242,11 +307,11 @@ class TestUserPartition(PartitionTestCase):
             UserPartition.from_json(jsonified)
 
         # Wrong version (it's over 9000!)
-        # Wrong version (it's over 9000!)
         jsonified = {
             'id': self.TEST_ID,
             "name": self.TEST_NAME,
             "description": self.TEST_DESCRIPTION,
+            "parameters": self.TEST_PARAMETERS,
             "groups": [group.to_json() for group in self.TEST_GROUPS],
             "version": 9001,
             "scheme": self.TEST_SCHEME_NAME,
@@ -259,6 +324,7 @@ class TestUserPartition(PartitionTestCase):
             'id': self.TEST_ID,
             "name": self.TEST_NAME,
             "description": self.TEST_DESCRIPTION,
+            "parameters": self.TEST_PARAMETERS,
             "groups": [group.to_json() for group in self.TEST_GROUPS],
             "version": UserPartition.VERSION,
             "scheme": "mock",
@@ -266,6 +332,18 @@ class TestUserPartition(PartitionTestCase):
         }
         user_partition = UserPartition.from_json(jsonified)
         self.assertNotIn("programmer", user_partition.to_json())
+
+        # No error on missing parameters key (which is optional)
+        jsonified = {
+            'id': self.TEST_ID,
+            "name": self.TEST_NAME,
+            "description": self.TEST_DESCRIPTION,
+            "groups": [group.to_json() for group in self.TEST_GROUPS],
+            "version": UserPartition.VERSION,
+            "scheme": "mock",
+        }
+        user_partition = UserPartition.from_json(jsonified)
+        self.assertEqual(user_partition.parameters, {})
 
     def test_get_group(self):
         """


### PR DESCRIPTION
ECOM-1978

@awais786 @aamir-khan @ahsan-ul-haq @tasawernawaz 
- Update `UserPartition` version from `2` to `3`
- Add `parameters` dict type field to store extra parameters for `UserPartition`. For now it will be used to save `location` key with value location of the block in courseware.
- Update/add tests
