### PR TITLE
Removing @contract from user_state_client.py

### DIFF
--- a/lms/djangoapps/courseware/user_state_client.py
+++ b/lms/djangoapps/courseware/user_state_client.py
@@ -53,12 +53,6 @@ class DjangoXBlockUserStateClient(XBlockUserStateClient):
         """
         self.user = user
 
-    @contract(
-        username="basestring",
-        block_key=UsageKey,
-        scope=ScopeBase,
-        fields="seq(basestring)|set(basestring)|None"
-    )
     def get(self, username, block_key, scope=Scope.user_state, fields=None):
         """
         Retrieve the stored XBlock state for a single xblock usage.
@@ -82,7 +76,6 @@ class DjangoXBlockUserStateClient(XBlockUserStateClient):
 
         return state
 
-    @contract(username="basestring", block_key=UsageKey, state="dict(basestring: *)", scope=ScopeBase)
     def set(self, username, block_key, state, scope=Scope.user_state):
         """
         Set fields for a particular XBlock.
@@ -95,12 +88,6 @@ class DjangoXBlockUserStateClient(XBlockUserStateClient):
         """
         self.set_many(username, {block_key: state}, scope)
 
-    @contract(
-        username="basestring",
-        block_key=UsageKey,
-        scope=ScopeBase,
-        fields="seq(basestring)|set(basestring)|None"
-    )
     def delete(self, username, block_key, scope=Scope.user_state, fields=None):
         """
         Delete the stored XBlock state for a single xblock usage.
@@ -113,12 +100,6 @@ class DjangoXBlockUserStateClient(XBlockUserStateClient):
         """
         return self.delete_many(username, [block_key], scope, fields=fields)
 
-    @contract(
-        username="basestring",
-        block_key=UsageKey,
-        scope=ScopeBase,
-        fields="seq(basestring)|set(basestring)|None"
-    )
     def get_mod_date(self, username, block_key, scope=Scope.user_state, fields=None):
         """
         Get the last modification date for fields from the specified blocks.
@@ -139,7 +120,6 @@ class DjangoXBlockUserStateClient(XBlockUserStateClient):
             field: date for (_, field, date) in results
         }
 
-    @contract(username="basestring", block_keys="seq(UsageKey)|set(UsageKey)")
     def _get_student_modules(self, username, block_keys):
         """
         Retrieve the :class:`~StudentModule`s for the supplied ``username`` and ``block_keys``.
@@ -166,12 +146,6 @@ class DjangoXBlockUserStateClient(XBlockUserStateClient):
                 usage_key = student_module.module_state_key.map_into_course(student_module.course_id)
                 yield (student_module, usage_key)
 
-    @contract(
-        username="basestring",
-        block_keys="seq(UsageKey)|set(UsageKey)",
-        scope=ScopeBase,
-        fields="seq(basestring)|set(basestring)|None"
-    )
     def get_many(self, username, block_keys, scope=Scope.user_state, fields=None):
         """
         Retrieve the stored XBlock state for a single xblock usage.
@@ -197,7 +171,6 @@ class DjangoXBlockUserStateClient(XBlockUserStateClient):
                 state = json.loads(module.state)
             yield (usage_key, state)
 
-    @contract(username="basestring", block_keys_to_state="dict(UsageKey: dict(basestring: *))", scope=ScopeBase)
     def set_many(self, username, block_keys_to_state, scope=Scope.user_state):
         """
         Set fields for a particular XBlock.
@@ -243,12 +216,6 @@ class DjangoXBlockUserStateClient(XBlockUserStateClient):
                 # We just read this object, so we know that we can do an update
                 student_module.save(force_update=True)
 
-    @contract(
-        username="basestring",
-        block_keys="seq(UsageKey)|set(UsageKey)",
-        scope=ScopeBase,
-        fields="seq(basestring)|set(basestring)|None"
-    )
     def delete_many(self, username, block_keys, scope=Scope.user_state, fields=None):
         """
         Delete the stored XBlock state for a many xblock usages.
@@ -276,12 +243,6 @@ class DjangoXBlockUserStateClient(XBlockUserStateClient):
             # We just read this object, so we know that we can do an update
             student_module.save(force_update=True)
 
-    @contract(
-        username="basestring",
-        block_keys="seq(UsageKey)|set(UsageKey)",
-        scope=ScopeBase,
-        fields="seq(basestring)|set(basestring)|None"
-    )
     def get_mod_date_many(self, username, block_keys, scope=Scope.user_state, fields=None):
         """
         Get the last modification date for fields from the specified blocks.
@@ -308,7 +269,6 @@ class DjangoXBlockUserStateClient(XBlockUserStateClient):
             for field in json.loads(student_module.state):
                 yield (usage_key, field, student_module.modified)
 
-    @contract(username="basestring", block_key=UsageKey, scope=ScopeBase)
     def get_history(self, username, block_key, scope=Scope.user_state):
         """
         Retrieve history of state changes for a given block for a given


### PR DESCRIPTION
This PR only removes `@contract` from `user_state_client.py`
Note: will add `@donottrack` decorator in another PR.

PLAT-759 https://openedx.atlassian.net/browse/PLAT-759

@cpennington  @doctoryes  @macdiesel  @alawibaba  Can you please review ?
