### PR TITLE
Capa Styling Fixes for Annotation Problems

### DIFF
--- a/common/lib/xmodule/xmodule/css/capa/display.scss
+++ b/common/lib/xmodule/xmodule/css/capa/display.scss
@@ -17,6 +17,7 @@
 // * +Problem - Annotation
 // * +Problem - Choice Text Group
 // * +Problem - Image Input Overrides
+// * +Problem - Annotation Problem Overrides
 
 // +Variables - Capa
 // ====================
@@ -462,15 +463,6 @@ div.problem {
         width: 25px;
         height: 20px;
         background: url('../images/correct-icon.png') center center no-repeat;
-      }
-
-      &.partially-correct {
-        display: inline-block;
-        position: relative;
-        top: 6px;
-        width: 25px;
-        height: 20px;
-        background: url('../images/partially-correct-icon.png') center center no-repeat;
       }
 
       &.incomplete, &.ui-icon-close {
@@ -1378,10 +1370,44 @@ div.problem .imageinput.capa_inputtype {
     width: 25px;
     height: 20px;
   }
+
   .correct {
     background: url('../images/correct-icon.png') center center no-repeat;
   }
+
   .incorrect {
     background: url('../images/incorrect-icon.png') center center no-repeat;
   }
+
+  .partially-correct {
+    background: url('../images/partially-correct-icon.png') center center no-repeat;
+  }
 }
+
+// +Problem - Annotation Problem Overrides
+// ====================
+
+// NOTE: temporary override until annotation problem inputs use same base html structure as other common capa input types.
+div.problem .annotation-input {
+
+  .tag-status {
+    display: inline-block;
+    position: relative;
+    top: 3px;
+    width: 25px;
+    height: 20px;
+  }
+
+  .correct {
+    background: url('../images/correct-icon.png') center center no-repeat;
+  }
+
+  .incorrect {
+    background: url('../images/incorrect-icon.png') center center no-repeat;
+  }
+
+  .partially-correct {
+    background: url('../images/partially-correct-icon.png') center center no-repeat;
+  }
+}
+


### PR DESCRIPTION
**Description**
An unintended outcome of the cleanup of the capa styling work from last June was that the annotation problems no longer rendered the correct and incorrect icons / indicators. The following work is a fix that adds back in the correct / incorrect visual indicators. 

---

**JIRA Story** ([TNL-2946](https://openedx.atlassian.net/browse/TNL-2946))
**Confluence / Product Asset** N/A
**Sandbox URL** (Last Updated: 08/01) ([pr9159.m.sandbox.edx.org](http://pr9159.m.sandbox.edx.org))
**Dependencies** None

---

**PR Author(s) Notes / To-Do** A list of known open tasks that the PR author has.
- [x] test this using broken course on edge! (export / then import to sandbox)

---

**Screenshots** 
Fix for Correct Icon:
![image](https://cloud.githubusercontent.com/assets/2023680/9038841/6ac8233c-39c5-11e5-86d3-3936bd4ec5f0.png)

Fix for Incorrect Icon:
![image](https://cloud.githubusercontent.com/assets/2023680/9038853/7c05b3b2-39c5-11e5-8441-127954f28f19.png)

Fix for Partially Correct Icon:
![image](https://cloud.githubusercontent.com/assets/2023680/9038855/8670cef4-39c5-11e5-9cc7-2d6ecb94133d.png)

---

**Reviewers**
- [x] Code: @clrux,
- [x] Product: @explorerleslie 

---

**FYI**
- @mslotkeEDX 
