### PR TITLE
TNL-394: Fixed confirmation message display for StaffDebug actions

### DIFF
--- a/lms/static/js/spec/staff_debug_actions_spec.js
+++ b/lms/static/js/spec/staff_debug_actions_spec.js
@@ -1,5 +1,10 @@
-define(['backbone', 'jquery', 'js/staff_debug_actions'],
-    function (Backbone, $) {
+define([
+    'backbone', 
+    'jquery', 
+    'js/staff_debug_actions', 
+    'common/js/spec_helpers/ajax_helpers'
+    ],
+    function (Backbone, $, tmp, AjaxHelpers) {
 
         describe('StaffDebugActions', function () {
             var location = 'i4x://edX/Open_DemoX/edx_demo_course/problem/test_loc';
@@ -9,6 +14,9 @@ define(['backbone', 'jquery', 'js/staff_debug_actions'],
             var escapableLocationName = 'test\.\*\+\?\^\:\$\{\}\(\)\|\]\[loc';
             var escapableFixture_id = 'sd_fu_' + escapableLocationName;
             var escapableFixture = $('<input>', {id: escapableFixture_id, placeholder: "userman"});
+            var esclocationName = 'P2:problem_1';
+            var escapableId = 'result_' + esclocationName; 
+            var escapableResultArea = $('<div>', {id: escapableId});
 
             describe('get_url ', function () {
                 it('defines url to courseware ajax entry point', function () {
@@ -41,9 +49,37 @@ define(['backbone', 'jquery', 'js/staff_debug_actions'],
                 it('gets the placeholder name if the id has escapable characters', function() {
                     $('body').append(escapableFixture);
                     expect(StaffDebug.get_user('test.*+?^:${}()|][loc')).toBe('userman');
-                    $('#' + escapableFixture_id).remove();
+                    $("input[id^='sd_fu_']").remove();
                 });
             });
+            describe('do_idash_action success', function () {
+                it('adds a success message to the results element after using an action', function () {
+                    $('body').append(escapableResultArea);
+                    var requests = AjaxHelpers.requests(this);
+                    var action = {
+                        locationName: esclocationName,
+                        success_msg: 'Successfully reset the attempts for user userman',
+                    };
+                    StaffDebug.do_idash_action(action);
+                    AjaxHelpers.respondWithJson(requests, action);
+                    expect($('#idash_msg').text()).toBe('Successfully reset the attempts for user userman');
+                    $('#result_' + locationName).remove();
+                });
+            });
+            describe('do_idash_action error', function () {
+                it('adds a failure message to the results element after using an action', function () {
+                    $('body').append(escapableResultArea);
+                    var requests = AjaxHelpers.requests(this);
+                    var action = {
+                        locationName: esclocationName,
+                        error_msg: 'Failed to reset attempts.',
+                    };
+                    StaffDebug.do_idash_action(action);
+                    AjaxHelpers.respondWithError(requests);
+                    expect($('#idash_msg').text()).toBe('Failed to reset attempts. ');
+                    $('#result_' + locationName).remove();
+                });
+            });                    
             describe('reset', function () {
                 it('makes an ajax call with the expected parameters', function () {
                     $('body').append(fixture);

--- a/lms/static/js/staff_debug_actions.js
+++ b/lms/static/js/staff_debug_actions.js
@@ -1,35 +1,35 @@
 // Build StaffDebug object
-var StaffDebug = (function(){
+var StaffDebug = (function (){
 
   get_current_url = function() {
     return window.location.pathname;
-  }
+  };
 
   get_url = function(action){
     var pathname = this.get_current_url();
     var url = pathname.substr(0,pathname.indexOf('/courseware')) + '/instructor/api/' + action;
     return url;
-  }
+  };
 
   sanitized_string = function(string) {
     return string.replace(/[.*+?^:${}()|[\]\\]/g, "\\$&");
-  }
+  };
 
   get_user = function(locname){
     locname = sanitized_string(locname);
     var uname = $('#sd_fu_' + locname).val();
-    if (uname==""){
+    if (uname===""){
         uname =  $('#sd_fu_' + locname).attr('placeholder');
     }
     return uname;
-  }
+  };
 
   do_idash_action = function(action){
     var pdata = {
         'problem_to_reset': action.location,
         'unique_student_identifier': get_user(action.locationName),
         'delete_module': action.delete_module
-    }
+    };
     $.ajax({
         type: "GET",
         url: get_url(action.method),
@@ -39,13 +39,13 @@ var StaffDebug = (function(){
                 action.success_msg,
                 {user: data.student},
                 {interpolate: /\{(.+?)\}/g}
-            )
+            );
             var html = _.template(
                 '<p id="idash_msg" class="success">{text}</p>',
                 {text: text},
                 {interpolate: /\{(.+?)\}/g}
-            )
-            $("#result_"+action.locationName).html(html);
+            );
+            $("#result_"+sanitized_string(action.locationName)).html(html);
         },
         error: function(request, status, error) {
             var response_json;
@@ -61,17 +61,18 @@ var StaffDebug = (function(){
                     error: response_json.error
                 },
                 {interpolate: /\{(.+?)\}/g}
-            )
+            );
             var html = _.template(
                 '<p id="idash_msg" class="error">{text}</p>',
                 {text: text},
                 {interpolate: /\{(.+?)\}/g}
-            )
-            $("#result_"+action.locationName).html(html);
+            );
+            $("#result_"+sanitized_string(action.locationName)).html(html);
+
         },
         dataType: 'json'
     });
-  }
+  };
 
   reset = function(locname, location){
     this.do_idash_action({
@@ -82,7 +83,7 @@ var StaffDebug = (function(){
         error_msg: gettext('Failed to reset attempts.'),
         delete_module: false
     });
-  }
+  };
 
   sdelete = function(locname, location){
     this.do_idash_action({
@@ -93,7 +94,7 @@ var StaffDebug = (function(){
         error_msg: gettext('Failed to delete student state.'),
         delete_module: true
     });
-  }
+  };
 
   rescore = function(locname, location){
     this.do_idash_action({
@@ -104,7 +105,7 @@ var StaffDebug = (function(){
         error_msg: gettext('Failed to rescore problem.'),
         delete_module: false
     });
-  }
+  };
 
   return {
       reset: reset,
@@ -115,11 +116,11 @@ var StaffDebug = (function(){
       get_url: get_url,
       get_user: get_user,
       sanitized_string:sanitized_string
-  }
-})();
+  }; })();
 
 // Register click handlers
 $(document).ready(function() {
+
     var $courseContent = $('.course-content');
     $courseContent.on("click", '.staff-debug-reset', function() {
         StaffDebug.reset($(this).parent().data('location-name'), $(this).parent().data('location'));


### PR DESCRIPTION
This is an addition to TNL-394:
https://openedx.atlassian.net/browse/TNL-394
Fixed the confirmation messages that didn't appear when an escapable character
is in the location name of the problem.
