### PR TITLE
Make team chat icon appear.

### DIFF
--- a/lms/djangoapps/teams/static/teams/templates/team-country-language.underscore
+++ b/lms/djangoapps/teams/static/teams/templates/team-country-language.underscore
@@ -1,2 +1,2 @@
 <% if (country) { print('<p class="meta-detail team-location"><span class="icon fa-globe"></span>' + country + '</p>'); } %>
-<% if (language) { print('<p class="meta-detail team-language"><span class="icon fa-chat"></span>' + language + '</p>'); } %>
+<% if (language) { print('<p class="meta-detail team-language"><span class="icon fa-comment"></span>' + language + '</p>'); } %>

--- a/lms/templates/ux/reference/teams-base.html
+++ b/lms/templates/ux/reference/teams-base.html
@@ -340,7 +340,7 @@ Teams | Course name
                 </div>
                 <p class="meta-detail project-relation"><span class="icon fa-list"></span> Project 1</p>
                 <p class="meta-detail team-location"><span class="icon fa-globe"></span> North America</p>
-                <p class="meta-detail team-language"><span class="icon fa-chat"></span> English</p>
+                <p class="meta-detail team-language"><span class="icon fa-comment"></span> English</p>
                 <p class="meta-detail team-activity">Last activity: 10 minutes ago</p>
               </div>
             </div>
@@ -368,7 +368,7 @@ Teams | Course name
                 </div>
                 <p class="meta-detail project-relation"><span class="icon fa-list"></span> Project 1</p>
                 <p class="meta-detail team-location"><span class="icon fa-globe"></span> North America</p>
-                <p class="meta-detail team-language"><span class="icon fa-chat"></span> English</p>
+                <p class="meta-detail team-language"><span class="icon fa-comment"></span> English</p>
                 <p class="meta-detail team-activity">Last activity: 10 minutes ago</p>
               </div>
             </div>


### PR DESCRIPTION
@frrrances @dan-f I noticed that no icon appears next to a team's language on the team card. I didn't see an `fa-chat` in Font Awesome's docs, so I think this was just a typo? If not feel free to ignore this PR.
