### PR TITLE
Exposing course name via Commerce API

### DIFF
--- a/lms/djangoapps/commerce/api/v1/serializers.py
+++ b/lms/djangoapps/commerce/api/v1/serializers.py
@@ -25,6 +25,7 @@ class CourseModeSerializer(serializers.ModelSerializer):
 class CourseSerializer(serializers.Serializer):
     """ Course serializer. """
     id = serializers.CharField()  # pylint: disable=invalid-name
+    name = serializers.CharField(read_only=True)
     modes = CourseModeSerializer(many=True, allow_add_remove=True)
 
     def restore_object(self, attrs, instance=None):


### PR DESCRIPTION
The course now includes a read-only name attribute.

XCOM-536

Replaces #9162 

@jimabramson @rlucioni 
