### PR TITLE
Zub/story/ecom 1980 create verification partitions tag course content

### DIFF
--- a/common/lib/xmodule/xmodule/partitions/partitions.py
+++ b/common/lib/xmodule/xmodule/partitions/partitions.py
@@ -40,7 +40,7 @@ class Group(namedtuple("Group", "id name")):
 
     def __new__(cls, id, name):
         # pylint: disable=super-on-old-class
-        return super(Group, cls).__new__(cls, id, name)
+        return super(Group, cls).__new__(cls, int(id), name)
 
     def to_json(self):
         """
@@ -112,7 +112,7 @@ class UserPartition(namedtuple("UserPartition", "id name description groups sche
         if parameters is None:
             parameters = {}
 
-        return super(UserPartition, cls).__new__(cls, id, name, description, groups, scheme, parameters)
+        return super(UserPartition, cls).__new__(cls, int(id), name, description, groups, scheme, parameters)
 
     @staticmethod
     def get_scheme(name):

--- a/common/lib/xmodule/xmodule/partitions/partitions.py
+++ b/common/lib/xmodule/xmodule/partitions/partitions.py
@@ -40,7 +40,7 @@ class Group(namedtuple("Group", "id name")):
 
     def __new__(cls, id, name):
         # pylint: disable=super-on-old-class
-        return super(Group, cls).__new__(cls, int(id), name)
+        return super(Group, cls).__new__(cls, id, name)
 
     def to_json(self):
         """
@@ -112,7 +112,7 @@ class UserPartition(namedtuple("UserPartition", "id name description groups sche
         if parameters is None:
             parameters = {}
 
-        return super(UserPartition, cls).__new__(cls, int(id), name, description, groups, scheme, parameters)
+        return super(UserPartition, cls).__new__(cls, id, name, description, groups, scheme, parameters)
 
     @staticmethod
     def get_scheme(name):

--- a/lms/djangoapps/lms_xblock/mixin.py
+++ b/lms/djangoapps/lms_xblock/mixin.py
@@ -16,7 +16,7 @@ class GroupAccessDict(Dict):
     """Special Dict class for serializing the group_access field"""
     def from_json(self, access_dict):
         if access_dict is not None:
-            return {k: access_dict[k] for k in access_dict}
+            return {int(k): access_dict[k] for k in access_dict}
 
     def to_json(self, access_dict):
         if access_dict is not None:

--- a/lms/djangoapps/lms_xblock/mixin.py
+++ b/lms/djangoapps/lms_xblock/mixin.py
@@ -16,7 +16,7 @@ class GroupAccessDict(Dict):
     """Special Dict class for serializing the group_access field"""
     def from_json(self, access_dict):
         if access_dict is not None:
-            return {int(k): access_dict[k] for k in access_dict}
+            return {k: access_dict[k] for k in access_dict}
 
     def to_json(self, access_dict):
         if access_dict is not None:

--- a/lms/djangoapps/verify_student/models.py
+++ b/lms/djangoapps/verify_student/models.py
@@ -1287,7 +1287,7 @@ class SkippedReverification(models.Model):
     future that user cannot see the reverification link.
     """
 
-    USER_SKIPPED_VERIFICATION_CACHE_KEY = u"skipped_reverification.{}"
+    USER_SKIPPED_VERIFICATION_CACHE_KEY = u"skipped_reverification.{}"  # pylint: disable=invalid-name
     user = models.ForeignKey(User)
     course_id = CourseKeyField(max_length=255, db_index=True)
     checkpoint = models.ForeignKey(VerificationCheckpoint, related_name="skipped_checkpoint")

--- a/openedx/core/djangoapps/credit/partition_schemes.py
+++ b/openedx/core/djangoapps/credit/partition_schemes.py
@@ -7,6 +7,7 @@ import logging
 from course_modes.models import CourseMode
 from lms.djangoapps.verify_student.models import SkippedReverification, VerificationStatus
 from student.models import CourseEnrollment
+from xmodule.partitions.partitions import NoSuchUserPartitionGroupError
 
 
 log = logging.getLogger(__name__)
@@ -53,13 +54,12 @@ class VerificationPartitionScheme(object):
             string of allowed access group
         """
         checkpoint = user_partition.parameters['location']
-
         if (
                 not is_enrolled_in_verified_mode(user, course_key)
         ):
             # the course content tagged with given 'user_partition' is
             # accessible/visible to all the students
-            return cls.NON_VERIFIED
+            partition_group = cls.NON_VERIFIED
         elif (
                 has_skipped_any_checkpoint(user, course_key) or
                 was_denied_at_any_checkpoint(user, course_key) or
@@ -70,13 +70,20 @@ class VerificationPartitionScheme(object):
             # and has either `skipped any ICRV` or `was denied at any ICRV
             # (used all attempts for an ICRV but still denied by the software
             # secure)` or `has submitted/approved verification for given ICRV`
-            return cls.VERIFIED_ALLOW
+            partition_group = cls.VERIFIED_ALLOW
         else:
             # the course content tagged with given 'user_partition' is
             # accessible/visible to the students enrolled as `verified` users
             # and has not yet submitted for the related ICRV
-            return cls.VERIFIED_DENY
+            partition_group = cls.VERIFIED_DENY
 
+        # return matching user partition group if it exists
+        try:
+            return user_partition.get_group(partition_group)
+        except NoSuchUserPartitionGroupError:
+            return None
+
+    # TODO: Remove this method and related tests since it is not used anymore
     @classmethod
     def key_for_partition(cls, xblock_location_id):
         """ Returns the key for partition scheme to use for look up and save

--- a/openedx/core/djangoapps/credit/partition_schemes.py
+++ b/openedx/core/djangoapps/credit/partition_schemes.py
@@ -34,9 +34,9 @@ class VerificationPartitionScheme(object):
     all ICRV blocks will be hidden and the student will have access to all
     the gated exams content.
     """
-    NON_VERIFIED = 'non_verified'
-    VERIFIED_ALLOW = 'verified_allow'
-    VERIFIED_DENY = 'verified_deny'
+    NON_VERIFIED = 0
+    VERIFIED_ALLOW = 1
+    VERIFIED_DENY = 2
 
     @classmethod
     def get_group_for_user(cls, course_key, user, user_partition):

--- a/openedx/core/djangoapps/credit/signals.py
+++ b/openedx/core/djangoapps/credit/signals.py
@@ -205,22 +205,27 @@ def _update_content_group_access(block, group_configuration):
     # will have access control)
     ancestor_for_update = parent_block
     if not set(ancestor_categories).difference(set(GATED_COURSE_CATEGORIES)):
-        # category of parent and grand parent are 'vertical' and
-        # 'sequential' respectively so update 'group_access' field of
-        # child's only
+        # category of parent and grand parent are 'vertical' and 'sequential'
+        # respectively so update 'group_access' field of grand children
+        # (immediate sibling and horizontal siblings) of the grand parent
         ancestor_for_update = grandparent_block
         for child in ancestor_for_update.get_children():
             for grand_child in child.get_children():
-                grand_child.group_access = access_dict
-                _update_published_block(grand_child)
+                if grand_child.location.category not in GATED_CREDIT_XBLOCK_CATEGORIES:
+                    # update `group_access` for non gated course content e.g.,
+                    # exclude ICRV blocks from updating
+                    grand_child.group_access = access_dict
+                    _update_published_block(grand_child)
     else:
+        # category of parent and grand parent are not 'vertical' and
+        # 'sequential' respectively so update 'group_access' field of children
+        # (only immediate siblings of current block) of the parent
         for child in ancestor_for_update.get_children():
-            child.group_access = access_dict
-            _update_published_block(child)
-
-    # ancestor_for_update.group_access = access_dict
-    # # Update only published version of the block in database
-    # _update_published_block(ancestor_for_update)
+            if child.location.category not in GATED_CREDIT_XBLOCK_CATEGORIES:
+                # update `group_access` for non gated course content e.g.,
+                # exclude ICRV blocks from updating
+                child.group_access = access_dict
+                _update_published_block(child)
 
 
 def _update_course_user_partitions(course_key, partition_scheme, new_user_partitions):

--- a/openedx/core/djangoapps/credit/signals.py
+++ b/openedx/core/djangoapps/credit/signals.py
@@ -32,11 +32,12 @@ def on_course_publish(course_key):  # pylint: disable=unused-argument
     IMPORTANT: It is assumed that the edx-proctoring subsystem has been appropriate refreshed
     with any on_publish event workflow *BEFORE* this method is called.
     """
+    # synchronously tag course content with ICRV access control
+    tag_course_content_with_partition_scheme(course_key, partition_scheme='verification')
 
     # Import here, because signal is registered at startup, but items in tasks
     # are not yet able to be loaded
     from openedx.core.djangoapps.credit import api, tasks
-    tag_course_content_with_partition_scheme(course_key, partition_scheme='verification')
 
     if api.is_credit_course(course_key):
         tasks.update_credit_course_requirements.delay(unicode(course_key))

--- a/openedx/core/djangoapps/credit/signals.py
+++ b/openedx/core/djangoapps/credit/signals.py
@@ -56,9 +56,10 @@ def on_course_publish(course_key):  # pylint: disable=unused-argument
         log.info(u'Added task to update credit requirements for course "%s" to the task queue', course_key)
 
     # now synchronously tag course content with ICRV access control
-    log.info(u'Start tagging course "%s" content with ICRV Access Control', course_key)
-    tag_course_content_with_partition_scheme(course_key, partition_scheme='verification')
-    log.info(u'Finished tagging course "%s" content with ICRV Access Control', course_key)
+    with modulestore().bulk_operations(course_key, emit_signals=True):
+        log.info(u'Start tagging course "%s" content with ICRV Access Control', course_key)
+        tag_course_content_with_partition_scheme(course_key, partition_scheme='verification')
+        log.info(u'Finished tagging course "%s" content with ICRV Access Control', course_key)
 
 
 @receiver(GRADES_UPDATED)

--- a/openedx/core/djangoapps/credit/signals.py
+++ b/openedx/core/djangoapps/credit/signals.py
@@ -10,7 +10,7 @@ from opaque_keys.edx.keys import CourseKey
 
 from util.db import generate_int_id, MYSQL_MAX_INT
 
-from contentstore.course_group_config import GroupConfiguration, MINIMUM_GROUP_ID
+from cms.djangoapps.contentstore.course_group_config import GroupConfiguration, MINIMUM_GROUP_ID
 from openedx.core.djangoapps.credit.partition_schemes import VerificationPartitionScheme
 from openedx.core.djangoapps.credit.utils import get_course_xblocks, filter_by_scheme, get_group_access_blocks
 from openedx.core.djangoapps.signals.signals import GRADES_UPDATED
@@ -87,7 +87,7 @@ def listen_for_grade_calculation(sender, username, grade_summary, course_key, de
                     )
 
 
-def tag_course_content_with_partition_scheme(course_key, partition_scheme):
+def tag_course_content_with_partition_scheme(course_key, partition_scheme):  # pylint: disable=invalid-name
     """ Create user partitions with provided partition scheme and tag credit
     blocks for the given course with those user partitions.
 
@@ -99,7 +99,7 @@ def tag_course_content_with_partition_scheme(course_key, partition_scheme):
         partition_scheme (str): Name of the user partition scheme
 
     """
-    # TODO: Refactor code (move code to proper files e.g., 'common/lib/xmodule/xmodule/partitions/partitions.py') in once ICRV access control functionality is complete
+    # TODO: Refactor code (move code to proper files e.g., 'common/lib/xmodule/xmodule/partitions/partitions.py')
     # TODO: Increase logging (add logging for errors and success)
 
     # get user partition with provided partition scheme
@@ -223,7 +223,7 @@ def _update_course_user_partitions(course_key, new_user_partitions):
     _sync_course_content_deleted_partitions(course_key, deleted_partitions)
 
 
-def _sync_course_content_deleted_partitions(course_key, deleted_partitions):
+def _sync_course_content_deleted_partitions(course_key, deleted_partitions):  # pylint: disable=invalid-name
     """ Sync blocks with access roles according to new user partitions for
     the provided course.
 
@@ -253,7 +253,7 @@ def _sync_course_content_deleted_partitions(course_key, deleted_partitions):
             modulestore().update_item(block, block.edited_by)
 
 
-def _verification_partition_group_configuration(course_key, user_partition, block):
+def _verification_partition_group_configuration(course_key, user_partition, block):  # pylint: disable=invalid-name
     """ Create verification user partition for given block.
 
     Group and UserPartition id's will be int.
@@ -298,7 +298,7 @@ def _verification_partition_group_configuration(course_key, user_partition, bloc
     return group_configuration
 
 
-def _get_credit_xblocks_for_access_control(course_key):
+def _get_credit_xblocks_for_access_control(course_key):  # pylint: disable=invalid-name
     """ Retrieve all credit requirements XBlocks in the course for categories
      in list 'GATED_CREDIT_XBLOCK_CATEGORIES'.
 

--- a/openedx/core/djangoapps/credit/signals.py
+++ b/openedx/core/djangoapps/credit/signals.py
@@ -195,8 +195,10 @@ def _update_content_group_access(block, group_configuration):
     # otherwise add groups to current ICRV's parent only
     access_groups_id_list = [VerificationPartitionScheme.NON_VERIFIED, VerificationPartitionScheme.VERIFIED_ALLOW]
     access_dict = _access_dict(group_configuration, access_groups_id_list)
+
     parent_block = block.get_parent()
     grandparent_block = parent_block.get_parent()
+
     ancestor_categories = [parent_block.location.category, grandparent_block.location.category]
 
     # update 'group_access' field of parent only (immediate siblings
@@ -205,12 +207,20 @@ def _update_content_group_access(block, group_configuration):
     if not set(ancestor_categories).difference(set(GATED_COURSE_CATEGORIES)):
         # category of parent and grand parent are 'vertical' and
         # 'sequential' respectively so update 'group_access' field of
-        # grandparent
+        # child's only
         ancestor_for_update = grandparent_block
+        for child in ancestor_for_update.get_children():
+            for grand_child in child.get_children():
+                grand_child.group_access = access_dict
+                _update_published_block(grand_child)
+    else:
+        for child in ancestor_for_update.get_children():
+            child.group_access = access_dict
+            _update_published_block(child)
 
-    ancestor_for_update.group_access = access_dict
-    # Update only published version of the block in database
-    _update_published_block(ancestor_for_update)
+    # ancestor_for_update.group_access = access_dict
+    # # Update only published version of the block in database
+    # _update_published_block(ancestor_for_update)
 
 
 def _update_course_user_partitions(course_key, partition_scheme, new_user_partitions):

--- a/openedx/core/djangoapps/credit/signals.py
+++ b/openedx/core/djangoapps/credit/signals.py
@@ -10,9 +10,13 @@ from opaque_keys.edx.keys import CourseKey
 
 from util.db import generate_int_id, MYSQL_MAX_INT
 
-from cms.djangoapps.contentstore.course_group_config import GroupConfiguration, MINIMUM_GROUP_ID
 from openedx.core.djangoapps.credit.partition_schemes import VerificationPartitionScheme
-from openedx.core.djangoapps.credit.utils import get_course_xblocks, filter_by_scheme, get_group_access_blocks
+from openedx.core.djangoapps.credit.utils import (
+    get_course_xblocks,
+    filter_by_scheme,
+    get_group_access_blocks,
+    get_course_partitions_used_ids,
+)
 from openedx.core.djangoapps.signals.signals import GRADES_UPDATED
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
@@ -282,7 +286,7 @@ def _verification_partition_group_configuration(course_key, user_partition, bloc
 
     # make int id for user partition scheme `VerificationPartitionScheme` which
     # is unique in user partitions of the provided course
-    group_configuration_id = generate_int_id(MINIMUM_GROUP_ID, MYSQL_MAX_INT, GroupConfiguration.get_used_ids(course))
+    group_configuration_id = generate_int_id(MINIMUM_GROUP_ID, MYSQL_MAX_INT, get_course_partitions_used_ids(course))
     group_configuration_name = u"Verification Checkpoint for {checkpoint_name}".format(
         checkpoint_name=block.display_name
     )

--- a/openedx/core/djangoapps/credit/signals.py
+++ b/openedx/core/djangoapps/credit/signals.py
@@ -206,16 +206,22 @@ def _update_content_group_access(block, group_configuration):
     ancestor_for_update = parent_block
     if not set(ancestor_categories).difference(set(GATED_COURSE_CATEGORIES)):
         # category of parent and grand parent are 'vertical' and 'sequential'
-        # respectively so update 'group_access' field of grand children
-        # (immediate sibling and horizontal siblings) of the grand parent
+        # respectively so update 'group_access' field of immediate siblings
+        # (unit components) and siblings of parent (verticals) of current block
         ancestor_for_update = grandparent_block
         for child in ancestor_for_update.get_children():
-            for grand_child in child.get_children():
-                if grand_child.location.category not in GATED_CREDIT_XBLOCK_CATEGORIES:
-                    # update `group_access` for non gated course content e.g.,
-                    # exclude ICRV blocks from updating
-                    grand_child.group_access = access_dict
-                    _update_published_block(grand_child)
+            if child.location != parent_block.location:
+                # siblings of parent (verticals) of current block
+                child.group_access = access_dict
+                _update_published_block(child)
+            else:
+                # immediate siblings (unit components) of current block
+                for grand_child in child.get_children():
+                    if grand_child.location.category not in GATED_CREDIT_XBLOCK_CATEGORIES:
+                        # update `group_access` for non gated course content e.g.,
+                        # exclude ICRV blocks from updating
+                        grand_child.group_access = access_dict
+                        _update_published_block(grand_child)
     else:
         # category of parent and grand parent are not 'vertical' and
         # 'sequential' respectively so update 'group_access' field of children

--- a/openedx/core/djangoapps/credit/signals.py
+++ b/openedx/core/djangoapps/credit/signals.py
@@ -156,9 +156,7 @@ def _access_dict(group_configuration, access_groups_id_list):
 
     """
     access_dict = {
-        group_configuration.id: [
-            group_configuration.get_group(group_id).id for group_id in access_groups_id_list
-        ]
+        group_configuration.id: access_groups_id_list
     }
     return access_dict
 

--- a/openedx/core/djangoapps/credit/signals.py
+++ b/openedx/core/djangoapps/credit/signals.py
@@ -179,7 +179,9 @@ def _update_content_group_access(block, verification_partition):
     # update 'group_access' field of gating xblock with groups
     # 'verified_allow' and 'verified_deny' of provided user partition
     # 'group_configuration'
-    icrv_block_access_groups_ids = [VerificationPartitionScheme.VERIFIED_ALLOW, VerificationPartitionScheme.VERIFIED_DENY]
+    icrv_block_access_groups_ids = [
+        VerificationPartitionScheme.VERIFIED_ALLOW, VerificationPartitionScheme.VERIFIED_DENY
+    ]
     # Assuming that there will be only one user partition for a block
     block.group_access = _access_dict(verification_partition, icrv_block_access_groups_ids)
 
@@ -200,10 +202,10 @@ def _update_content_group_access(block, verification_partition):
     # current ICRV's grand parent (if category of parent and grand
     # parent are 'vertical' and 'sequential' respectively);
     # otherwise add groups to current ICRV's parent only
-    gated_contents_access_groups_ids = [
+    gated_content_access_groups_id = [
         VerificationPartitionScheme.NON_VERIFIED, VerificationPartitionScheme.VERIFIED_ALLOW
     ]
-    access_dict = _access_dict(verification_partition, gated_contents_access_groups_ids)
+    access_dict = _access_dict(verification_partition, gated_content_access_groups_id)
 
     parent_block = block.get_parent()
     grandparent_block = parent_block.get_parent()
@@ -340,6 +342,7 @@ def _verification_partition_group_configuration(course, user_partition, block): 
     ]
     group_configuration_parameters = {'location': unicode(block.location)}
 
+    # pylint: disable=invalid-name
     verification_partition_configuration = UserPartition(
         id=group_configuration_id,
         name=group_configuration_name,

--- a/openedx/core/djangoapps/credit/tasks.py
+++ b/openedx/core/djangoapps/credit/tasks.py
@@ -2,9 +2,6 @@
 This file contains celery tasks for credit course views.
 """
 
-import datetime
-from pytz import UTC
-
 from django.conf import settings
 
 from celery import task
@@ -12,12 +9,13 @@ from celery.utils.log import get_task_logger
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 
-from .api import set_credit_requirements
+from openedx.core.djangoapps.credit.api import set_credit_requirements
 from openedx.core.djangoapps.credit.exceptions import InvalidCreditRequirements
 from openedx.core.djangoapps.credit.models import CreditCourse
+from openedx.core.djangoapps.credit.utils import get_course_xblocks
 from xmodule.modulestore.django import modulestore
-from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.exceptions import ItemNotFoundError
+
 
 LOGGER = get_task_logger(__name__)
 
@@ -132,52 +130,11 @@ def _get_credit_course_requirement_xblocks(course_key):  # pylint: disable=inval
                 "display_name": block.get_credit_requirement_display_name(),
                 "criteria": {},
             }
-            for block in _get_xblocks(course_key, category)
+            for block in get_course_xblocks(course_key, category)
             if _is_credit_requirement(block)
         ])
 
     return requirements
-
-
-def _is_in_course_tree(block):
-    """
-    Check that the XBlock is in the course tree.
-
-    It's possible that the XBlock is not in the course tree
-    if its parent has been deleted and is now an orphan.
-    """
-    ancestor = block.get_parent()
-    while ancestor is not None and ancestor.location.category != "course":
-        ancestor = ancestor.get_parent()
-
-    return ancestor is not None
-
-
-def _get_xblocks(course_key, category):
-    """
-    Retrieve all XBlocks in the course for a particular category.
-
-    Returns only XBlocks that are published and haven't been deleted.
-    """
-    xblocks = [
-        block for block in modulestore().get_items(
-            course_key,
-            qualifiers={"category": category},
-            revision=ModuleStoreEnum.RevisionOption.published_only,
-        )
-        if _is_in_course_tree(block)
-    ]
-
-    # Secondary sort on credit requirement name
-    xblocks = sorted(xblocks, key=lambda block: block.get_credit_requirement_display_name())
-
-    # Primary sort on start date
-    xblocks = sorted(xblocks, key=lambda block: (
-        block.start if block.start is not None
-        else datetime.datetime(datetime.MINYEAR, 1, 1).replace(tzinfo=UTC)
-    ))
-
-    return xblocks
 
 
 def _is_credit_requirement(xblock):

--- a/openedx/core/djangoapps/credit/tests/test_partition_schemes.py
+++ b/openedx/core/djangoapps/credit/tests/test_partition_schemes.py
@@ -8,6 +8,7 @@ import unittest
 from mock import Mock
 
 from django.conf import settings
+from django.test import TestCase
 
 from lms.djangoapps.verify_student.models import (
     VerificationCheckpoint,
@@ -19,6 +20,7 @@ from student.models import CourseEnrollment
 from student.tests.factories import UserFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
+from xmodule.partitions.partitions import UserPartition, UserPartitionError
 
 
 @ddt.ddt
@@ -154,3 +156,18 @@ class ReverificationPartitionTest(ModuleStoreTestCase):
                 self.checkpoint_location
             )
         )
+
+
+class TestExtension(TestCase):
+    """ Ensure that the scheme extension is correctly plugged in (via entry
+    point in setup.py)
+    """
+
+    def test_get_scheme(self):
+        # test that 'VerificationPartitionScheme' is present
+        self.assertEqual(UserPartition.get_scheme('verification'), VerificationPartitionScheme)
+
+        # now test that exception is raised if we try to access a non existing
+        # user partition scheme
+        with self.assertRaisesRegexp(UserPartitionError, 'Unrecognized scheme'):
+            UserPartition.get_scheme('other')

--- a/openedx/core/djangoapps/credit/tests/test_partition_schemes.py
+++ b/openedx/core/djangoapps/credit/tests/test_partition_schemes.py
@@ -68,6 +68,7 @@ class ReverificationPartitionTest(ModuleStoreTestCase):
         user_partition = UserPartition.get_scheme('verification')
         group_configuration_parameters = {'location': unicode(self.checkpoint_location)}
 
+        # pylint: disable=invalid-name
         self.verification_partition_configuration = UserPartition(
             id=0,
             name='Verification Checkpoint',
@@ -211,6 +212,7 @@ class TestCourseTaggingWithVerPartitions(ModuleStoreTestCase):
     """
 
     def _add_icrv_with_gated_contents(self, parent, gated_content_parent, counter):
+        """Add ICRV block and gated content block"""
         self.icrv_x_block = ItemFactory.create(
             parent=parent, category='edx-reverification-block', display_name='Test Unit X Block 1'
         )
@@ -218,19 +220,19 @@ class TestCourseTaggingWithVerPartitions(ModuleStoreTestCase):
         self.gated_vertical = ItemFactory.create(
             parent=gated_content_parent,
             category='vertical',
-            display_name='Vertical with gated contents %s'.format(
+            display_name='Vertical with gated contents {}'.format(
                 counter
             )
         )
         self.gated_problem1 = ItemFactory.create(
             parent=self.gated_vertical,
             category='problem',
-            display_name='Problem  %s'.format(counter)
+            display_name='Problem {}'.format(counter)
         )
         self.gated_problem2 = ItemFactory.create(
             parent=self.gated_vertical,
             category='problem',
-            display_name='Problem  %s'.format(counter)
+            display_name='Problem {}'.format(counter)
         )
 
     def setUp(self):
@@ -239,15 +241,25 @@ class TestCourseTaggingWithVerPartitions(ModuleStoreTestCase):
         # Create the course
         self.course = CourseFactory.create(org="MIT", course="DemoX", run="CS101")
 
-        self.section_alone = ItemFactory.create(parent=self.course, category='chapter', display_name='Test Alone Section')
+        self.section_alone = ItemFactory.create(
+            parent=self.course, category='chapter', display_name='Test Alone Section'
+        )
 
-        self.section_with_tree = ItemFactory.create(parent=self.course, category='chapter', display_name='Test Section Tree')
+        self.section_with_tree = ItemFactory.create(
+            parent=self.course, category='chapter', display_name='Test Section Tree'
+        )
 
-        self.subsection_alone = ItemFactory.create(parent=self.section_with_tree, category='sequential', display_name='Test Subsection No Tree')
+        self.subsection_alone = ItemFactory.create(
+            parent=self.section_with_tree, category='sequential', display_name='Test Subsection No Tree'
+        )
 
-        self.subsection_with_tree = ItemFactory.create(parent=self.section_with_tree, category='sequential', display_name='Test Subsection With Tree')
+        self.subsection_with_tree = ItemFactory.create(
+            parent=self.section_with_tree, category='sequential', display_name='Test Subsection With Tree'
+        )
 
-        self.icrv_parent_vertical = ItemFactory.create(parent=self.subsection_with_tree, category='vertical', display_name='Test Unit X Block Parent')
+        self.icrv_parent_vertical = ItemFactory.create(
+            parent=self.subsection_with_tree, category='vertical', display_name='Test Unit X Block Parent'
+        )
 
         self.icrv_x_block = ItemFactory.create(
             parent=self.icrv_parent_vertical, category='edx-reverification-block', display_name='Test Unit X Block 1'
@@ -315,53 +327,58 @@ class TestCourseTaggingWithVerPartitions(ModuleStoreTestCase):
 
         # Assert icrv xblock has 2 access groups
         icrv_xblock_groups = [VerificationPartitionScheme.VERIFIED_ALLOW, VerificationPartitionScheme.VERIFIED_DENY]
+        # pylint: disable=invalid-name
         access_groups_of_verification_partition = self._get_access_groups_of_verification_partition(icrv_x_block)
         self.assertEqual(len(access_groups_of_verification_partition), 2)
         self.assertTrue(set(access_groups_of_verification_partition) == set(icrv_xblock_groups))
 
         # Gated/ Siblings of ICRV Vertical or problems
         gated_vertical_groups = [VerificationPartitionScheme.NON_VERIFIED, VerificationPartitionScheme.VERIFIED_ALLOW]
+        # pylint: disable=invalid-name
         access_groups_of_verification_partition = self._get_access_groups_of_verification_partition(gated_vertical)
         self.assertEqual(len(access_groups_of_verification_partition), 2)
         self.assertTrue(set(access_groups_of_verification_partition) == set(gated_vertical_groups))
 
+        # pylint: disable=invalid-name
         access_groups_of_verification_partition = self._get_access_groups_of_verification_partition(gated_problem1)
         self.assertEqual(len(access_groups_of_verification_partition), 2)
         self.assertTrue(set(access_groups_of_verification_partition) == set(gated_vertical_groups))
 
+        # pylint: disable=invalid-name
         access_groups_of_verification_partition = self._get_access_groups_of_verification_partition(gated_problem2)
         self.assertEqual(len(access_groups_of_verification_partition), 2)
         self.assertTrue(set(access_groups_of_verification_partition) == set(gated_vertical_groups))
 
     def test_tagging_content_multiple_icrv(self):
-        self.section_with_tree2 = ItemFactory.create(
+        section_with_tree2 = ItemFactory.create(
             parent=self.course, category='chapter', display_name='Test Section Tree 2'
         )
-        self.subsection_alone2 = ItemFactory.create(
-            parent=self.section_with_tree2, category='sequential', display_name='Test Subsection No Tree2'
+
+        subsection_alone2 = ItemFactory.create(
+            parent=section_with_tree2, category='sequential', display_name='Test Subsection No Tree parent 2'
         )
-        self.icrv_parent_subsec2 = ItemFactory.create(
-            parent=self.section_with_tree2, category='sequential', display_name='Test Subsection No Tree parent 2'
+        icrv_parent_subsec2 = ItemFactory.create(
+            parent=section_with_tree2, category='sequential', display_name='Test Subsection Tree parent 2'
         )
 
-        self.icrv_x_block2 = ItemFactory.create(
-            parent=self.icrv_parent_subsec2,
+        icrv_x_block2 = ItemFactory.create(
+            parent=icrv_parent_subsec2,
             category='edx-reverification-block',
             display_name='Test Unit X Block 2'
         )
 
-        self.gated_vertical2 = ItemFactory.create(
-            parent=self.icrv_parent_subsec2,
+        gated_vertical2 = ItemFactory.create(
+            parent=icrv_parent_subsec2,
             category='vertical',
             display_name='Vertical with gated contents 2'
         )
-        self.gated_problem21 = ItemFactory.create(
-            parent=self.gated_vertical2,
+        gated_problem21 = ItemFactory.create(
+            parent=gated_vertical2,
             category='problem',
             display_name='Problem 21'
         )
-        self.gated_problem22 = ItemFactory.create(
-            parent=self.gated_vertical2,
+        gated_problem22 = ItemFactory.create(
+            parent=gated_vertical2,
             category='problem',
             display_name='Problem 22'
         )
@@ -413,67 +430,68 @@ class TestCourseTaggingWithVerPartitions(ModuleStoreTestCase):
         icrv_xblock_groups = [VerificationPartitionScheme.VERIFIED_ALLOW, VerificationPartitionScheme.VERIFIED_DENY]
         self._assert_partitions(icrv_x_block, icrv_xblock_groups)
 
-        gated_contents_group_access = [VerificationPartitionScheme.NON_VERIFIED, VerificationPartitionScheme.VERIFIED_ALLOW]
+        gated_contents_group_access = [
+            VerificationPartitionScheme.NON_VERIFIED, VerificationPartitionScheme.VERIFIED_ALLOW
+        ]
         self._assert_partitions(gated_vertical, gated_contents_group_access)
 
         self._assert_partitions(gated_problem1, gated_contents_group_access)
 
         self._assert_partitions(gated_problem2, gated_contents_group_access)
 
-        section_with_tree2 = modulestore().get_item(self.section_with_tree2.location)
-        icrv_parent_subsec2 = modulestore().get_item(self.icrv_parent_subsec2.location)
-        icrv_x_block2 = modulestore().get_item(self.icrv_x_block2.location)
+        section_with_tree2 = modulestore().get_item(section_with_tree2.location)
+        icrv_parent_subsec2_loc = modulestore().get_item(icrv_parent_subsec2.location)
+        icrv_x_block2_loc = modulestore().get_item(icrv_x_block2.location)
 
-        subsection_alone2 = modulestore().get_item(self.subsection_alone2.location)
+        subsection_alone2_loc = modulestore().get_item(subsection_alone2.location)
 
-        gated_vertical2 = modulestore().get_item(self.gated_vertical2.location)
-        gated_problem21 = modulestore().get_item(self.gated_problem21.location)
-        gated_problem22 = modulestore().get_item(self.gated_problem22.location)
+        gated_vertical2_loc = modulestore().get_item(gated_vertical2.location)
+        gated_problem21_loc = modulestore().get_item(gated_problem21.location)
+        gated_problem22_loc = modulestore().get_item(gated_problem22.location)
 
         # Assert subsection with no child don't have any access group
         self.assertTrue(section_with_tree2.group_access == {})
-        self.assertTrue(subsection_alone2.group_access == {})
-        self.assertTrue(icrv_parent_subsec2.group_access == {})
+        self.assertTrue(subsection_alone2_loc.group_access == {})
+        self.assertTrue(icrv_parent_subsec2_loc.group_access == {})
 
-        self._assert_partitions(icrv_x_block2, icrv_xblock_groups)
-        self._assert_partitions(gated_vertical2, gated_contents_group_access)
-        self._assert_partitions(gated_problem21, gated_contents_group_access)
-        self._assert_partitions(gated_problem22, gated_contents_group_access)
+        self._assert_partitions(icrv_x_block2_loc, icrv_xblock_groups)
+        self._assert_partitions(gated_vertical2_loc, gated_contents_group_access)
+        self._assert_partitions(gated_problem21_loc, gated_contents_group_access)
+        self._assert_partitions(gated_problem22_loc, gated_contents_group_access)
 
     def test_tagging_content_multiple_icrv_delete_icrv(self):
-        self.section_with_tree2 = ItemFactory.create(
+        section_with_tree2 = ItemFactory.create(
             parent=self.course, category='chapter', display_name='Test Section Tree 2'
         )
-        self.subsection_alone2 = ItemFactory.create(
-            parent=self.section_with_tree2, category='sequential', display_name='Test Subsection No Tree2'
+        subsection_alone2 = ItemFactory.create(
+            parent=section_with_tree2, category='sequential', display_name='Test Subsection No Tree2'
         )
-        self.icrv_parent_subsec2 = ItemFactory.create(
-            parent=self.section_with_tree2, category='sequential', display_name='Test Subsection No Tree parent 2'
+        icrv_parent_subsec2 = ItemFactory.create(
+            parent=section_with_tree2, category='sequential', display_name='Test Subsection No Tree parent 2'
         )
 
-        self.icrv_x_block2 = ItemFactory.create(
-            parent=self.icrv_parent_subsec2,
+        icrv_x_block2 = ItemFactory.create(
+            parent=icrv_parent_subsec2,
             category='edx-reverification-block',
             display_name='Test Unit X Block 2'
         )
 
-        self.gated_vertical2 = ItemFactory.create(
-            parent=self.icrv_parent_subsec2,
+        gated_vertical2 = ItemFactory.create(
+            parent=icrv_parent_subsec2,
             category='vertical',
             display_name='Vertical with gated contents 2'
         )
-        self.gated_problem21 = ItemFactory.create(
-            parent=self.gated_vertical2,
+        gated_problem21 = ItemFactory.create(
+            parent=gated_vertical2,
             category='problem',
             display_name='Problem 21'
         )
-        self.gated_problem22 = ItemFactory.create(
-            parent=self.gated_vertical2,
+        gated_problem22 = ItemFactory.create(
+            parent=gated_vertical2,
             category='problem',
             display_name='Problem 22'
         )
 
-        # tag_course_content_with_partition_scheme(self.course.id, partition_scheme='verification')
         on_course_publish(self.course.id)
         course = modulestore().get_course(self.course.id)
 
@@ -520,32 +538,34 @@ class TestCourseTaggingWithVerPartitions(ModuleStoreTestCase):
         icrv_xblock_groups = [VerificationPartitionScheme.VERIFIED_ALLOW, VerificationPartitionScheme.VERIFIED_DENY]
         self._assert_partitions(icrv_x_block, icrv_xblock_groups)
 
-        gated_contents_group_access = [VerificationPartitionScheme.NON_VERIFIED, VerificationPartitionScheme.VERIFIED_ALLOW]
+        gated_contents_group_access = [
+            VerificationPartitionScheme.NON_VERIFIED, VerificationPartitionScheme.VERIFIED_ALLOW
+        ]
         self._assert_partitions(gated_vertical, gated_contents_group_access)
 
         self._assert_partitions(gated_problem1, gated_contents_group_access)
 
         self._assert_partitions(gated_problem2, gated_contents_group_access)
 
-        section_with_tree2 = modulestore().get_item(self.section_with_tree2.location)
-        icrv_parent_subsec2 = modulestore().get_item(self.icrv_parent_subsec2.location)
-        icrv_x_block2 = modulestore().get_item(self.icrv_x_block2.location)
+        section_with_tree2_loc = modulestore().get_item(section_with_tree2.location)
+        icrv_parent_subsec2_loc = modulestore().get_item(icrv_parent_subsec2.location)
+        icrv_x_block2_loc = modulestore().get_item(icrv_x_block2.location)
 
-        subsection_alone2 = modulestore().get_item(self.subsection_alone2.location)
+        subsection_alone2_loc = modulestore().get_item(subsection_alone2.location)
 
-        gated_vertical2 = modulestore().get_item(self.gated_vertical2.location)
-        gated_problem21 = modulestore().get_item(self.gated_problem21.location)
-        gated_problem22 = modulestore().get_item(self.gated_problem22.location)
+        gated_vertical2_loc = modulestore().get_item(gated_vertical2.location)
+        gated_problem21_loc = modulestore().get_item(gated_problem21.location)
+        gated_problem22_loc = modulestore().get_item(gated_problem22.location)
 
         # Assert subsection with no child don't have any access group
-        self.assertTrue(section_with_tree2.group_access == {})
-        self.assertTrue(subsection_alone2.group_access == {})
-        self.assertTrue(icrv_parent_subsec2.group_access == {})
+        self.assertTrue(section_with_tree2_loc.group_access == {})
+        self.assertTrue(subsection_alone2_loc.group_access == {})
+        self.assertTrue(icrv_parent_subsec2_loc.group_access == {})
 
-        self._assert_partitions(icrv_x_block2, icrv_xblock_groups)
-        self._assert_partitions(gated_vertical2, gated_contents_group_access)
-        self._assert_partitions(gated_problem21, gated_contents_group_access)
-        self._assert_partitions(gated_problem22, gated_contents_group_access)
+        self._assert_partitions(icrv_x_block2_loc, icrv_xblock_groups)
+        self._assert_partitions(gated_vertical2_loc, gated_contents_group_access)
+        self._assert_partitions(gated_problem21_loc, gated_contents_group_access)
+        self._assert_partitions(gated_problem22_loc, gated_contents_group_access)
 
         # Delete the first ICRV block
         with modulestore().branch_setting(ModuleStoreEnum.Branch.draft_preferred, self.course.id):
@@ -556,90 +576,93 @@ class TestCourseTaggingWithVerPartitions(ModuleStoreTestCase):
 
         tag_course_content_with_partition_scheme(self.course.id, partition_scheme='verification')
 
-        section_with_tree2 = modulestore().get_item(self.section_with_tree2.location)
-        icrv_parent_subsec2 = modulestore().get_item(self.icrv_parent_subsec2.location)
-        icrv_x_block2 = modulestore().get_item(self.icrv_x_block2.location)
+        section_with_tree2_loc = modulestore().get_item(section_with_tree2.location)
+        icrv_parent_subsec2_loc = modulestore().get_item(icrv_parent_subsec2.location)
+        icrv_x_block2_loc = modulestore().get_item(icrv_x_block2.location)
 
-        subsection_alone2 = modulestore().get_item(self.subsection_alone2.location)
+        subsection_alone2 = modulestore().get_item(subsection_alone2.location)
 
-        gated_vertical2 = modulestore().get_item(self.gated_vertical2.location)
-        gated_problem21 = modulestore().get_item(self.gated_problem21.location)
-        gated_problem22 = modulestore().get_item(self.gated_problem22.location)
+        gated_vertical2_loc = modulestore().get_item(gated_vertical2.location)
+        gated_problem21_loc = modulestore().get_item(gated_problem21.location)
+        gated_problem22_loc = modulestore().get_item(gated_problem22.location)
 
         # Assert subsection with no child don't have any access group
-        self.assertTrue(section_with_tree2.group_access == {})
+        self.assertTrue(section_with_tree2_loc.group_access == {})
         self.assertTrue(subsection_alone2.group_access == {})
-        self.assertTrue(icrv_parent_subsec2.group_access == {})
+        self.assertTrue(icrv_parent_subsec2_loc.group_access == {})
 
-        self._assert_partitions(icrv_x_block2, icrv_xblock_groups)
-        self._assert_partitions(gated_vertical2, gated_contents_group_access)
-        self._assert_partitions(gated_problem21, gated_contents_group_access)
-        self._assert_partitions(gated_problem22, gated_contents_group_access)
+        self._assert_partitions(icrv_x_block2_loc, icrv_xblock_groups)
+        self._assert_partitions(gated_vertical2_loc, gated_contents_group_access)
+        self._assert_partitions(gated_problem21_loc, gated_contents_group_access)
+        self._assert_partitions(gated_problem22_loc, gated_contents_group_access)
 
         self._assert_icrv_subtree()
 
     def test_single_partition_with_multiple_icrv(self):
-        self.icrv_x_block2 = ItemFactory.create(
+        icrv_x_block2 = ItemFactory.create(
             parent=self.icrv_parent_vertical, category='edx-reverification-block', display_name='Test Unit X Block 2'
         )
-        self.icrv_sibling_problem = ItemFactory.create(
+        icrv_sibling_problem = ItemFactory.create(
             parent=self.icrv_parent_vertical,
             category='problem',
             display_name='ICRV Sibling Problem'
         )
         on_course_publish(self.course.id)
-        icrv_x_block2 = modulestore().get_item(self.icrv_x_block2.location)
+        icrv_x_block2_loc = modulestore().get_item(icrv_x_block2.location)
         icrv_x_block = modulestore().get_item(self.icrv_x_block.location)
-        icrv_sibling_problem = modulestore().get_item(self.icrv_sibling_problem.location)
+        icrv_sibling_problem_loc = modulestore().get_item(icrv_sibling_problem.location)
         icrv_xblock_groups = [VerificationPartitionScheme.VERIFIED_ALLOW, VerificationPartitionScheme.VERIFIED_DENY]
         sibling_problem_groups = [VerificationPartitionScheme.NON_VERIFIED, VerificationPartitionScheme.VERIFIED_ALLOW]
-        self._assert_partitions(icrv_x_block2, icrv_xblock_groups)
+        self._assert_partitions(icrv_x_block2_loc, icrv_xblock_groups)
         self._assert_partitions(icrv_x_block, icrv_xblock_groups)
-        self._assert_partitions(icrv_sibling_problem, sibling_problem_groups)
+        self._assert_partitions(icrv_sibling_problem_loc, sibling_problem_groups)
 
     def test_sequential_icrv_vertical_problem(self):
-        self.section_with_tree3 = ItemFactory.create(
+        section_with_tree3 = ItemFactory.create(
             parent=self.course, category='chapter', display_name='Test Section Tree 3'
         )
-        self.subsection_with_problem3 = ItemFactory.create(
-            parent=self.section_with_tree3, category='sequential', display_name='Test Subsection No Tree3'
+        subsection_with_problem3 = ItemFactory.create(
+            parent=section_with_tree3, category='sequential', display_name='Test Subsection No Tree3'
         )
 
-        self.icrv_x_block3 = ItemFactory.create(
-            parent=self.section_with_tree3,
+        icrv_x_block3 = ItemFactory.create(
+            parent=section_with_tree3,
             category='edx-reverification-block',
             display_name='Test Unit X Block 3'
         )
 
-        self.gated_vertical3 = ItemFactory.create(
-            parent=self.subsection_with_problem3,
+        gated_vertical3 = ItemFactory.create(
+            parent=subsection_with_problem3,
             category='vertical',
             display_name='Vertical with gated contents 3'
         )
-        self.gated_problem31 = ItemFactory.create(
-            parent=self.gated_vertical3,
+        gated_problem31 = ItemFactory.create(
+            parent=gated_vertical3,
             category='problem',
             display_name='Problem 31'
         )
-        self.gated_problem32 = ItemFactory.create(
-            parent=self.gated_vertical3,
+        gated_problem32 = ItemFactory.create(
+            parent=gated_vertical3,
             category='problem',
             display_name='Problem 32'
         )
         on_course_publish(self.course.id)
-        icrv_x_block3 = modulestore().get_item(self.icrv_x_block3.location)
+        icrv_x_block3_loc = modulestore().get_item(icrv_x_block3.location)
         icrv_xblock_groups = [VerificationPartitionScheme.VERIFIED_ALLOW, VerificationPartitionScheme.VERIFIED_DENY]
-        self._assert_partitions(icrv_x_block3, icrv_xblock_groups)
+        self._assert_partitions(icrv_x_block3_loc, icrv_xblock_groups)
 
-        gated_vertical3 = modulestore().get_item(self.gated_vertical3.location)
-        gated_problem31 = modulestore().get_item(self.gated_problem31.location)
-        gated_problem32 = modulestore().get_item(self.gated_problem32.location)
-        gated_contents_group_access = [VerificationPartitionScheme.NON_VERIFIED, VerificationPartitionScheme.VERIFIED_ALLOW]
-        self._assert_partitions(gated_vertical3, gated_contents_group_access)
-        self._assert_partitions(gated_problem31, gated_contents_group_access)
-        self._assert_partitions(gated_problem32, gated_contents_group_access)
+        gated_vertical3_loc = modulestore().get_item(gated_vertical3.location)
+        gated_problem31_loc = modulestore().get_item(gated_problem31.location)
+        gated_problem32_loc = modulestore().get_item(gated_problem32.location)
+        gated_contents_group_access = [
+            VerificationPartitionScheme.NON_VERIFIED, VerificationPartitionScheme.VERIFIED_ALLOW
+        ]
+        self._assert_partitions(gated_vertical3_loc, gated_contents_group_access)
+        self._assert_partitions(gated_problem31_loc, gated_contents_group_access)
+        self._assert_partitions(gated_problem32_loc, gated_contents_group_access)
 
-    def _get_access_groups_of_verification_partition(self, xblock):
+    def _get_access_groups_of_verification_partition(self, xblock):  # pylint: disable=invalid-name
+        """Return group access for the provided xblock."""
         group_access = []
         for partition_id, group_access in xblock.group_access.items():
             verification_partition = self._get_verification_partition_from_xblock(partition_id, xblock)
@@ -648,16 +671,24 @@ class TestCourseTaggingWithVerPartitions(ModuleStoreTestCase):
         return group_access
 
     def _get_verification_partition_from_xblock(self, partition_id, xblock):
+        """Return verification partition for partition id in the provided
+         xblock.
+        """
         for partition in xblock.user_partitions:
             if partition.id == partition_id and partition.scheme == VerificationPartitionScheme:
                 return partition
 
     def _assert_partitions(self, xblock, expected_group_access):
+        """Test the partition scheme for the provided xblock with the
+        expected group access.
+        """
+        # pylint: disable=invalid-name
         access_groups_of_verification_partition = self._get_access_groups_of_verification_partition(xblock)
         self.assertEqual(len(access_groups_of_verification_partition), 2)
         self.assertTrue(set(access_groups_of_verification_partition) == set(expected_group_access))
 
     def _assert_icrv_subtree(self):
+        """Test ICRV subtree."""
         course = modulestore().get_course(self.course.id)
 
         course_user_partitions = course.user_partitions

--- a/openedx/core/djangoapps/credit/tests/test_partition_schemes.py
+++ b/openedx/core/djangoapps/credit/tests/test_partition_schemes.py
@@ -6,8 +6,6 @@ Tests for In-Course Reverification Access Control Partition scheme
 import ddt
 import unittest
 from mock import Mock
-
-from django.conf import settings
 from django.test import TestCase
 
 from lms.djangoapps.verify_student.models import (
@@ -15,12 +13,18 @@ from lms.djangoapps.verify_student.models import (
     VerificationStatus,
     SkippedReverification,
 )
-from openedx.core.djangoapps.credit.partition_schemes import VerificationPartitionScheme
 from student.models import CourseEnrollment
+from xmodule.partitions.partitions import UserPartition, UserPartitionError
+
+
+from django.conf import settings
+from xmodule.modulestore.django import modulestore
+from xmodule.modulestore import ModuleStoreEnum
+from openedx.core.djangoapps.credit.partition_schemes import VerificationPartitionScheme
+from openedx.core.djangoapps.credit.signals import tag_course_content_with_partition_scheme, on_course_publish
 from student.tests.factories import UserFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory
-from xmodule.partitions.partitions import UserPartition, UserPartitionError
+from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
 
 @ddt.ddt
@@ -171,3 +175,440 @@ class TestExtension(TestCase):
         # user partition scheme
         with self.assertRaisesRegexp(UserPartitionError, 'Unrecognized scheme'):
             UserPartition.get_scheme('other')
+
+
+@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+class TestCourseTaggingWithVerPartitions(ModuleStoreTestCase):
+    """
+    Test the tagging of the course tree with user partitions.
+    """
+
+    def _add_icrv_with_gated_contents(self, parent, gated_content_parent, counter):
+        self.icrv_x_block = ItemFactory.create(
+            parent=parent, category='edx-reverification-block', display_name='Test Unit X Block 1'
+        )
+
+        self.gated_vertical = ItemFactory.create(
+            parent=gated_content_parent,
+            category='vertical',
+            display_name='Vertical with gated contents %s'.format(
+                counter
+            )
+        )
+        self.gated_problem1 = ItemFactory.create(
+            parent=self.gated_vertical,
+            category='problem',
+            display_name='Problem  %s'.format(counter)
+        )
+        self.gated_problem2 = ItemFactory.create(
+            parent=self.gated_vertical,
+            category='problem',
+            display_name='Problem  %s'.format(counter)
+        )
+
+    def setUp(self):
+        super(TestCourseTaggingWithVerPartitions, self).setUp()
+        self.user = UserFactory.create()
+        # Create the course
+        self.course = CourseFactory.create(org="MIT", course="DemoX", run="CS101")
+
+        self.section_alone = ItemFactory.create(parent=self.course, category='chapter', display_name='Test Alone Section')
+
+        self.section_with_tree = ItemFactory.create(parent=self.course, category='chapter', display_name='Test Section Tree')
+
+        self.subsection_alone = ItemFactory.create(parent=self.section_with_tree, category='sequential', display_name='Test Subsection No Tree')
+
+        self.subsection_with_tree = ItemFactory.create(parent=self.section_with_tree, category='sequential', display_name='Test Subsection With Tree')
+
+        self.icrv_parent_vertical = ItemFactory.create(parent=self.subsection_with_tree, category='vertical', display_name='Test Unit X Block Parent')
+
+        self.icrv_x_block = ItemFactory.create(
+            parent=self.icrv_parent_vertical, category='edx-reverification-block', display_name='Test Unit X Block 1'
+        )
+
+        self.gated_vertical = ItemFactory.create(
+            parent=self.subsection_with_tree,
+            category='vertical',
+            display_name='Vertical with gated contents 1'
+        )
+        self.gated_problem1 = ItemFactory.create(
+            parent=self.gated_vertical,
+            category='problem',
+            display_name='Problem 1'
+        )
+        self.gated_problem2 = ItemFactory.create(
+            parent=self.gated_vertical,
+            category='problem',
+            display_name='Problem 1'
+        )
+
+    def test_tagging_content_single_icrv(self):
+        # tag_course_content_with_partition_scheme(self.course.id, partition_scheme='verification')
+        on_course_publish(self.course.id)
+        course = modulestore().get_course(self.course.id)
+
+        course_user_partitions = course.user_partitions
+
+        section_alone = modulestore().get_item(self.section_alone.location)
+
+        section_with_tree = modulestore().get_item(self.section_with_tree.location)
+        subsection_with_tree = modulestore().get_item(self.subsection_with_tree.location)
+        icrv_parent_vertical = modulestore().get_item(self.icrv_parent_vertical.location)
+        icrv_x_block = modulestore().get_item(self.icrv_x_block.location)
+
+        subsection_alone = modulestore().get_item(self.subsection_alone.location)
+
+        gated_vertical = modulestore().get_item(self.gated_vertical.location)
+        gated_problem1 = modulestore().get_item(self.gated_problem1.location)
+        gated_problem2 = modulestore().get_item(self.gated_problem2.location)
+
+        # Assert course has one partition and has three verification groups
+        self.assertEqual(len(course_user_partitions), 1)
+        self.assertEqual(len(course_user_partitions[0].groups), 3)
+        partition_groups = [
+            VerificationPartitionScheme.VERIFIED_ALLOW,
+            VerificationPartitionScheme.VERIFIED_DENY,
+            VerificationPartitionScheme.NON_VERIFIED
+        ]
+        course_user_partitions_groups = [
+            group.id for group in course_user_partitions[0].groups
+        ]
+        self.assertTrue(set(course_user_partitions_groups) == set(partition_groups))
+
+        # Assert subsection with no child don't have any access group
+        self.assertTrue(section_alone.group_access == {})
+        self.assertTrue(section_with_tree.group_access == {})
+        self.assertTrue(subsection_alone.group_access == {})
+
+        # Subsection grand parent of xblock
+        self.assertTrue(subsection_with_tree.group_access == {})
+
+        # Vertical parent of xblock
+        self.assertTrue(icrv_parent_vertical.group_access == {})
+
+        # Assert icrv xblock has 2 access groups
+        icrv_xblock_groups = [VerificationPartitionScheme.VERIFIED_ALLOW, VerificationPartitionScheme.VERIFIED_DENY]
+        access_groups_of_verification_partition = self._get_access_groups_of_verification_partition(icrv_x_block)
+        self.assertEqual(len(access_groups_of_verification_partition), 2)
+        self.assertTrue(set(access_groups_of_verification_partition) == set(icrv_xblock_groups))
+
+        # Gated/ Siblings of ICRV Vertical or problems
+        gated_vertical_groups = [VerificationPartitionScheme.NON_VERIFIED, VerificationPartitionScheme.VERIFIED_ALLOW]
+        access_groups_of_verification_partition = self._get_access_groups_of_verification_partition(gated_vertical)
+        self.assertEqual(len(access_groups_of_verification_partition), 2)
+        self.assertTrue(set(access_groups_of_verification_partition) == set(gated_vertical_groups))
+
+        access_groups_of_verification_partition = self._get_access_groups_of_verification_partition(gated_problem1)
+        self.assertEqual(len(access_groups_of_verification_partition), 2)
+        self.assertTrue(set(access_groups_of_verification_partition) == set(gated_vertical_groups))
+
+        access_groups_of_verification_partition = self._get_access_groups_of_verification_partition(gated_problem2)
+        self.assertEqual(len(access_groups_of_verification_partition), 2)
+        self.assertTrue(set(access_groups_of_verification_partition) == set(gated_vertical_groups))
+
+    def test_tagging_content_multiple_icrv(self):
+        self.section_with_tree2 = ItemFactory.create(
+            parent=self.course, category='chapter', display_name='Test Section Tree 2'
+        )
+        self.subsection_alone2 = ItemFactory.create(
+            parent=self.section_with_tree2, category='sequential', display_name='Test Subsection No Tree2'
+        )
+        self.icrv_parent_subsec2 = ItemFactory.create(
+            parent=self.section_with_tree2, category='sequential', display_name='Test Subsection No Tree parent 2'
+        )
+
+        self.icrv_x_block2 = ItemFactory.create(
+            parent=self.icrv_parent_subsec2,
+            category='edx-reverification-block',
+            display_name='Test Unit X Block 2'
+        )
+
+        self.gated_vertical2 = ItemFactory.create(
+            parent=self.icrv_parent_subsec2,
+            category='vertical',
+            display_name='Vertical with gated contents 2'
+        )
+        self.gated_problem21 = ItemFactory.create(
+            parent=self.gated_vertical2,
+            category='problem',
+            display_name='Problem 21'
+        )
+        self.gated_problem22 = ItemFactory.create(
+            parent=self.gated_vertical2,
+            category='problem',
+            display_name='Problem 22'
+        )
+
+        # tag_course_content_with_partition_scheme(self.course.id, partition_scheme='verification')
+        on_course_publish(self.course.id)
+        course = modulestore().get_course(self.course.id)
+
+        course_user_partitions = course.user_partitions
+
+        section_alone = modulestore().get_item(self.section_alone.location)
+
+        section_with_tree = modulestore().get_item(self.section_with_tree.location)
+        subsection_with_tree = modulestore().get_item(self.subsection_with_tree.location)
+        icrv_parent_vertical = modulestore().get_item(self.icrv_parent_vertical.location)
+        icrv_x_block = modulestore().get_item(self.icrv_x_block.location)
+
+        subsection_alone = modulestore().get_item(self.subsection_alone.location)
+
+        gated_vertical = modulestore().get_item(self.gated_vertical.location)
+        gated_problem1 = modulestore().get_item(self.gated_problem1.location)
+        gated_problem2 = modulestore().get_item(self.gated_problem2.location)
+
+        # Assert course has one partition and has three verification groups
+        self.assertEqual(len(course_user_partitions), 2)
+        self.assertEqual(len(course_user_partitions[0].groups), 3)
+        self.assertEqual(len(course_user_partitions[1].groups), 3)
+
+        partition_groups = [
+            VerificationPartitionScheme.VERIFIED_ALLOW,
+            VerificationPartitionScheme.VERIFIED_DENY,
+            VerificationPartitionScheme.NON_VERIFIED
+        ]
+        course_user_partitions_groups = [
+            group.id for group in course_user_partitions[0].groups
+        ]
+        self.assertTrue(set(course_user_partitions_groups) == set(partition_groups))
+
+        # Assert subsection with no child don't have any access group
+        self.assertTrue(section_alone.group_access == {})
+        self.assertTrue(section_with_tree.group_access == {})
+        self.assertTrue(subsection_alone.group_access == {})
+
+        # Subsection grand parent of xblock
+        self.assertTrue(subsection_alone.group_access == {})
+        self.assertTrue(subsection_with_tree.group_access == {})
+        self.assertTrue(icrv_parent_vertical.group_access == {})
+
+        icrv_xblock_groups = [VerificationPartitionScheme.VERIFIED_ALLOW, VerificationPartitionScheme.VERIFIED_DENY]
+        self._assert_partitions(icrv_x_block, icrv_xblock_groups)
+
+        gated_contents_group_access = [VerificationPartitionScheme.NON_VERIFIED, VerificationPartitionScheme.VERIFIED_ALLOW]
+        self._assert_partitions(gated_vertical, gated_contents_group_access)
+
+        self._assert_partitions(gated_problem1, gated_contents_group_access)
+
+        self._assert_partitions(gated_problem2, gated_contents_group_access)
+
+        section_with_tree2 = modulestore().get_item(self.section_with_tree2.location)
+        icrv_parent_subsec2 = modulestore().get_item(self.icrv_parent_subsec2.location)
+        icrv_x_block2 = modulestore().get_item(self.icrv_x_block2.location)
+
+        subsection_alone2 = modulestore().get_item(self.subsection_alone2.location)
+
+        gated_vertical2 = modulestore().get_item(self.gated_vertical2.location)
+        gated_problem21 = modulestore().get_item(self.gated_problem21.location)
+        gated_problem22 = modulestore().get_item(self.gated_problem22.location)
+
+        # Assert subsection with no child don't have any access group
+        self.assertTrue(section_with_tree2.group_access == {})
+        self.assertTrue(subsection_alone2.group_access == {})
+        self.assertTrue(icrv_parent_subsec2.group_access == {})
+
+        self._assert_partitions(icrv_x_block2, icrv_xblock_groups)
+        self._assert_partitions(gated_vertical2, gated_contents_group_access)
+        self._assert_partitions(gated_problem21, gated_contents_group_access)
+        self._assert_partitions(gated_problem22, gated_contents_group_access)
+
+    def test_tagging_content_multiple_icrv_delete_icrv(self):
+        self.section_with_tree2 = ItemFactory.create(
+            parent=self.course, category='chapter', display_name='Test Section Tree 2'
+        )
+        self.subsection_alone2 = ItemFactory.create(
+            parent=self.section_with_tree2, category='sequential', display_name='Test Subsection No Tree2'
+        )
+        self.icrv_parent_subsec2 = ItemFactory.create(
+            parent=self.section_with_tree2, category='sequential', display_name='Test Subsection No Tree parent 2'
+        )
+
+        self.icrv_x_block2 = ItemFactory.create(
+            parent=self.icrv_parent_subsec2,
+            category='edx-reverification-block',
+            display_name='Test Unit X Block 2'
+        )
+
+        self.gated_vertical2 = ItemFactory.create(
+            parent=self.icrv_parent_subsec2,
+            category='vertical',
+            display_name='Vertical with gated contents 2'
+        )
+        self.gated_problem21 = ItemFactory.create(
+            parent=self.gated_vertical2,
+            category='problem',
+            display_name='Problem 21'
+        )
+        self.gated_problem22 = ItemFactory.create(
+            parent=self.gated_vertical2,
+            category='problem',
+            display_name='Problem 22'
+        )
+
+        # tag_course_content_with_partition_scheme(self.course.id, partition_scheme='verification')
+        on_course_publish(self.course.id)
+        course = modulestore().get_course(self.course.id)
+
+        course_user_partitions = course.user_partitions
+
+        section_alone = modulestore().get_item(self.section_alone.location)
+
+        section_with_tree = modulestore().get_item(self.section_with_tree.location)
+        subsection_with_tree = modulestore().get_item(self.subsection_with_tree.location)
+        icrv_parent_vertical = modulestore().get_item(self.icrv_parent_vertical.location)
+        icrv_x_block = modulestore().get_item(self.icrv_x_block.location)
+
+        subsection_alone = modulestore().get_item(self.subsection_alone.location)
+
+        gated_vertical = modulestore().get_item(self.gated_vertical.location)
+        gated_problem1 = modulestore().get_item(self.gated_problem1.location)
+        gated_problem2 = modulestore().get_item(self.gated_problem2.location)
+
+        # Assert course has one partition and has three verification groups
+        self.assertEqual(len(course_user_partitions), 2)
+        self.assertEqual(len(course_user_partitions[0].groups), 3)
+        self.assertEqual(len(course_user_partitions[1].groups), 3)
+
+        partition_groups = [
+            VerificationPartitionScheme.VERIFIED_ALLOW,
+            VerificationPartitionScheme.VERIFIED_DENY,
+            VerificationPartitionScheme.NON_VERIFIED
+        ]
+        course_user_partitions_groups = [
+            group.id for group in course_user_partitions[0].groups
+        ]
+        self.assertTrue(set(course_user_partitions_groups) == set(partition_groups))
+
+        # Assert subsection with no child don't have any access group
+        self.assertTrue(section_alone.group_access == {})
+        self.assertTrue(section_with_tree.group_access == {})
+        self.assertTrue(subsection_alone.group_access == {})
+
+        # Subsection grand parent of xblock
+        self.assertTrue(subsection_alone.group_access == {})
+        self.assertTrue(subsection_with_tree.group_access == {})
+        self.assertTrue(icrv_parent_vertical.group_access == {})
+
+        icrv_xblock_groups = [VerificationPartitionScheme.VERIFIED_ALLOW, VerificationPartitionScheme.VERIFIED_DENY]
+        self._assert_partitions(icrv_x_block, icrv_xblock_groups)
+
+        gated_contents_group_access = [VerificationPartitionScheme.NON_VERIFIED, VerificationPartitionScheme.VERIFIED_ALLOW]
+        self._assert_partitions(gated_vertical, gated_contents_group_access)
+
+        self._assert_partitions(gated_problem1, gated_contents_group_access)
+
+        self._assert_partitions(gated_problem2, gated_contents_group_access)
+
+        section_with_tree2 = modulestore().get_item(self.section_with_tree2.location)
+        icrv_parent_subsec2 = modulestore().get_item(self.icrv_parent_subsec2.location)
+        icrv_x_block2 = modulestore().get_item(self.icrv_x_block2.location)
+
+        subsection_alone2 = modulestore().get_item(self.subsection_alone2.location)
+
+        gated_vertical2 = modulestore().get_item(self.gated_vertical2.location)
+        gated_problem21 = modulestore().get_item(self.gated_problem21.location)
+        gated_problem22 = modulestore().get_item(self.gated_problem22.location)
+
+        # Assert subsection with no child don't have any access group
+        self.assertTrue(section_with_tree2.group_access == {})
+        self.assertTrue(subsection_alone2.group_access == {})
+        self.assertTrue(icrv_parent_subsec2.group_access == {})
+
+        self._assert_partitions(icrv_x_block2, icrv_xblock_groups)
+        self._assert_partitions(gated_vertical2, gated_contents_group_access)
+        self._assert_partitions(gated_problem21, gated_contents_group_access)
+        self._assert_partitions(gated_problem22, gated_contents_group_access)
+
+        # Delete the first ICRV block
+        with modulestore().branch_setting(ModuleStoreEnum.Branch.draft_preferred, self.course.id):
+            modulestore().delete_item(self.icrv_x_block.location, self.user.id)
+
+        with modulestore().branch_setting(ModuleStoreEnum.Branch.draft_preferred):
+            modulestore().publish(self.icrv_parent_vertical.location, ModuleStoreEnum.UserID.test)
+
+        tag_course_content_with_partition_scheme(self.course.id, partition_scheme='verification')
+
+        section_with_tree2 = modulestore().get_item(self.section_with_tree2.location)
+        icrv_parent_subsec2 = modulestore().get_item(self.icrv_parent_subsec2.location)
+        icrv_x_block2 = modulestore().get_item(self.icrv_x_block2.location)
+
+        subsection_alone2 = modulestore().get_item(self.subsection_alone2.location)
+
+        gated_vertical2 = modulestore().get_item(self.gated_vertical2.location)
+        gated_problem21 = modulestore().get_item(self.gated_problem21.location)
+        gated_problem22 = modulestore().get_item(self.gated_problem22.location)
+
+        # Assert subsection with no child don't have any access group
+        self.assertTrue(section_with_tree2.group_access == {})
+        self.assertTrue(subsection_alone2.group_access == {})
+        self.assertTrue(icrv_parent_subsec2.group_access == {})
+
+        self._assert_partitions(icrv_x_block2, icrv_xblock_groups)
+        self._assert_partitions(gated_vertical2, gated_contents_group_access)
+        self._assert_partitions(gated_problem21, gated_contents_group_access)
+        self._assert_partitions(gated_problem22, gated_contents_group_access)
+
+        self._assert_icrv_subtree()
+
+    def _get_access_groups_of_verification_partition(self, xblock):
+        group_access = []
+        for partition_id, group_access in xblock.group_access.items():
+            verification_partition = self._get_verification_partition_from_xblock(partition_id, xblock)
+            if verification_partition:
+                return group_access
+        return group_access
+
+    def _get_verification_partition_from_xblock(self, partition_id, xblock):
+        for partition in xblock.user_partitions:
+            if partition.id == partition_id and partition.scheme == VerificationPartitionScheme:
+                return partition
+
+    def _assert_partitions(self, xblock, expected_group_access):
+        access_groups_of_verification_partition = self._get_access_groups_of_verification_partition(xblock)
+        self.assertEqual(len(access_groups_of_verification_partition), 2)
+        self.assertTrue(set(access_groups_of_verification_partition) == set(expected_group_access))
+
+    def _assert_icrv_subtree(self):
+        course = modulestore().get_course(self.course.id)
+
+        course_user_partitions = course.user_partitions
+        section_alone = modulestore().get_item(self.section_alone.location)
+
+        section_with_tree = modulestore().get_item(self.section_with_tree.location)
+        subsection_with_tree = modulestore().get_item(self.subsection_with_tree.location)
+        icrv_parent_vertical = modulestore().get_item(self.icrv_parent_vertical.location)
+
+        subsection_alone = modulestore().get_item(self.subsection_alone.location)
+
+        gated_vertical = modulestore().get_item(self.gated_vertical.location)
+        gated_problem1 = modulestore().get_item(self.gated_problem1.location)
+        gated_problem2 = modulestore().get_item(self.gated_problem2.location)
+
+        # Assert course has one partition and has three verification groups
+        self.assertEqual(len(course_user_partitions), 1)
+        self.assertEqual(len(course_user_partitions[0].groups), 3)
+
+        partition_groups = [
+            VerificationPartitionScheme.VERIFIED_ALLOW,
+            VerificationPartitionScheme.VERIFIED_DENY,
+            VerificationPartitionScheme.NON_VERIFIED
+        ]
+        course_user_partitions_groups = [
+            group.id for group in course_user_partitions[0].groups
+        ]
+        self.assertTrue(set(course_user_partitions_groups) == set(partition_groups))
+
+        # Assert subsection with no child don't have any access group
+        self.assertTrue(section_alone.group_access == {})
+        self.assertTrue(section_with_tree.group_access == {})
+        self.assertTrue(subsection_alone.group_access == {})
+
+        # Subsection grand parent of xblock
+        self.assertTrue(subsection_alone.group_access == {})
+        self.assertTrue(subsection_with_tree.group_access == {})
+        self.assertTrue(icrv_parent_vertical.group_access == {})
+
+        self.assertTrue(gated_vertical.group_access == {})
+        self.assertTrue(gated_problem1.group_access == {})
+        self.assertTrue(gated_problem2.group_access == {})

--- a/openedx/core/djangoapps/credit/tests/test_partition_schemes.py
+++ b/openedx/core/djangoapps/credit/tests/test_partition_schemes.py
@@ -349,7 +349,7 @@ class TestCourseTaggingWithVerPartitions(ModuleStoreTestCase):
         self.assertEqual(len(access_groups_of_verification_partition), 2)
         self.assertTrue(set(access_groups_of_verification_partition) == set(gated_vertical_groups))
 
-    def test_tagging_content_multiple_icrv(self):
+    def test_tagging_content_multiple_icrv(self):  # pylint: disable=too-many-statements
         section_with_tree2 = ItemFactory.create(
             parent=self.course, category='chapter', display_name='Test Section Tree 2'
         )
@@ -383,7 +383,6 @@ class TestCourseTaggingWithVerPartitions(ModuleStoreTestCase):
             display_name='Problem 22'
         )
 
-        # tag_course_content_with_partition_scheme(self.course.id, partition_scheme='verification')
         on_course_publish(self.course.id)
         course = modulestore().get_course(self.course.id)
 
@@ -459,7 +458,7 @@ class TestCourseTaggingWithVerPartitions(ModuleStoreTestCase):
         self._assert_partitions(gated_problem21_loc, gated_contents_group_access)
         self._assert_partitions(gated_problem22_loc, gated_contents_group_access)
 
-    def test_tagging_content_multiple_icrv_delete_icrv(self):
+    def test_tagging_content_multiple_icrv_delete_icrv(self):  # pylint: disable=too-many-statements
         section_with_tree2 = ItemFactory.create(
             parent=self.course, category='chapter', display_name='Test Section Tree 2'
         )

--- a/openedx/core/djangoapps/credit/tests/test_user_access.py
+++ b/openedx/core/djangoapps/credit/tests/test_user_access.py
@@ -1,0 +1,197 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for tagging course content against different user groups.
+"""
+
+import ddt
+import unittest
+
+from django.conf import settings
+
+from lms.djangoapps.courseware.access import _has_group_access
+from lms.djangoapps.verify_student.models import (
+    VerificationCheckpoint,
+    VerificationStatus,
+    SkippedReverification,
+)
+from student.models import CourseEnrollment
+from student.tests.factories import UserFactory
+from openedx.core.djangoapps.credit.signals import on_course_publish
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.django import modulestore
+
+@ddt.ddt
+@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+class UserAccessToContent(ModuleStoreTestCase):
+
+    SUBMITTED = "submitted"
+    APPROVED = "approved"
+    DENIED = "denied"
+    SKIPPED = "skipped"
+
+    def add_verification_status(self, user, status):
+        """Adding the verification status for a user."""
+
+        VerificationStatus.add_status_from_checkpoints(
+            checkpoints=[self.first_checkpoint],
+            user=user,
+            status=status
+        )
+
+    def created_user_and_enroll(self, enrollment_type):
+        """Create and enroll users with provided enrollment type."""
+
+        user = UserFactory.create()
+        CourseEnrollment.objects.create(
+            user=user,
+            course_id=self.course.id,
+            mode=enrollment_type,
+            is_active=True
+        )
+        return user
+
+    def setUp(self):
+        super(UserAccessToContent, self).setUp()
+        # Create the course
+        self.course = CourseFactory.create(org="MIT", course="DemoX", run="CS101")
+
+        self.section_alone = ItemFactory.create(parent=self.course, category='chapter', display_name='Test Alone Section')
+
+        self.section_with_tree = ItemFactory.create(parent=self.course, category='chapter', display_name='Test Section Tree')
+
+        self.subsection_alone = ItemFactory.create(parent=self.section_with_tree, category='sequential', display_name='Test Subsection No Tree')
+
+        self.subsection_with_tree = ItemFactory.create(parent=self.section_with_tree, category='sequential', display_name='Test Subsection With Tree')
+
+        self.icrv_parent_vertical = ItemFactory.create(parent=self.subsection_with_tree, category='vertical', display_name='Test Unit X Block Parent')
+
+        self.icrv_x_block = ItemFactory.create(
+            parent=self.icrv_parent_vertical, category='edx-reverification-block', display_name='Test Unit X Block 1'
+        )
+
+        self.icrv_x_block_sibling_problem = ItemFactory.create(
+            parent=self.icrv_parent_vertical,
+            category='problem',
+            display_name='Problem icrv sibling'
+        )
+
+        self.first_checkpoint = VerificationCheckpoint.objects.create(
+            course_id=self.course.id,
+            checkpoint_location=self.icrv_x_block.location
+        )
+
+        self.gated_vertical = ItemFactory.create(
+            parent=self.subsection_with_tree,
+            category='vertical',
+            display_name='Vertical with gated contents 1'
+        )
+        self.gated_problem1 = ItemFactory.create(
+            parent=self.gated_vertical,
+            category='problem',
+            display_name='Problem 1'
+        )
+        self.gated_problem2 = ItemFactory.create(
+            parent=self.gated_vertical,
+            category='problem',
+            display_name='Problem 1'
+        )
+
+    @ddt.data(
+        ("verified", SUBMITTED),
+        ("verified", APPROVED),
+        ("verified", DENIED),
+        ("verified", None),
+        ("verified", SKIPPED),
+        ("honor", False),
+
+    )
+    @ddt.unpack
+    def test_has_access_for_users(self, enrollment_type, verification_status):
+
+        on_course_publish(self.course.id)
+        course = modulestore().get_course(self.course.id)
+
+        section_alone = modulestore().get_item(self.section_alone.location)
+
+        section_with_tree = modulestore().get_item(self.section_with_tree.location)
+        subsection_alone = modulestore().get_item(self.subsection_alone.location)
+        subsection_with_tree = modulestore().get_item(self.subsection_with_tree.location)
+
+        icrv_parent_vertical = modulestore().get_item(self.icrv_parent_vertical.location)
+        icrv_xblock = modulestore().get_item(self.icrv_x_block.location)
+        icrv_xblock_sibling_problem = modulestore().get_item(self.icrv_x_block_sibling_problem.location)
+
+        gated_vertical = modulestore().get_item(self.gated_vertical.location)
+        gated_problem1 = modulestore().get_item(self.gated_problem1.location)
+        gated_problem2 = modulestore().get_item(self.gated_problem2.location)
+
+        # creating user and enroll them.
+        user = self.created_user_and_enroll(enrollment_type)
+        if verification_status:
+            self.add_verification_status(user, verification_status)
+
+        # user is verified and but has not attempted yet, user group will
+        # be VERIFIED_DENIED, denied users will have access to ICRV but
+        # exam content will be hidden
+        elif verification_status is None and enrollment_type == "verified":
+            self.assertTrue(_has_group_access(course, user, course.id).has_access)
+
+            self.assertTrue(_has_group_access(section_alone, user, course.id).has_access)
+            self.assertTrue(_has_group_access(section_with_tree, user, course.id).has_access)
+
+            self.assertTrue(_has_group_access(subsection_alone, user, course.id).has_access)
+            self.assertTrue(_has_group_access(subsection_with_tree, user, course.id).has_access)
+
+            self.assertTrue(_has_group_access(icrv_parent_vertical, user, course.id).has_access)
+            self.assertTrue(_has_group_access(icrv_xblock, user, course.id).has_access)
+            self.assertFalse(_has_group_access(icrv_xblock_sibling_problem, user, course.id).has_access)
+
+            self.assertFalse(_has_group_access(gated_vertical, user, course.id).has_access)
+            self.assertFalse(_has_group_access(gated_problem1, user, course.id).has_access)
+            self.assertFalse(_has_group_access(gated_problem2, user, course.id).has_access)
+
+        # user is in non-verified mode, user group will be NON_VERIFIED
+        # Non verified users will have access to all content excluding ICRVs
+        if enrollment_type == 'honor':
+            self.assertTrue(_has_group_access(course, user, course.id).has_access)
+
+            self.assertTrue(_has_group_access(section_alone, user, course.id).has_access)
+            self.assertTrue(_has_group_access(section_with_tree, user, course.id).has_access)
+
+            self.assertTrue(_has_group_access(subsection_alone, user, course.id).has_access)
+            self.assertTrue(_has_group_access(subsection_with_tree, user, course.id).has_access)
+
+            self.assertTrue(_has_group_access(icrv_parent_vertical, user, course.id).has_access)
+            self.assertFalse(_has_group_access(icrv_xblock, user, course.id).has_access)
+            self.assertTrue(_has_group_access(icrv_xblock_sibling_problem, user, course.id).has_access)
+
+            self.assertTrue(_has_group_access(gated_vertical, user, course.id).has_access)
+            self.assertTrue(_has_group_access(gated_problem1, user, course.id).has_access)
+            self.assertTrue(_has_group_access(gated_problem2, user, course.id).has_access)
+
+        # user has submitted, denied or approved, user group will be VERIFIED_ALLOW
+        elif enrollment_type == 'verified' and verification_status in [self.SUBMITTED, self.APPROVED, self.DENIED, self.SKIPPED]:
+            if verification_status == self.SKIPPED:
+                SkippedReverification.add_skipped_reverification_attempt(
+                checkpoint=self.first_checkpoint,
+                user_id=user.id,
+                course_id=self.course.id
+            )
+
+            # allowed users will have access to all content
+            self.assertTrue(_has_group_access(course, user, course.id).has_access)
+
+            self.assertTrue(_has_group_access(section_alone, user, course.id).has_access)
+            self.assertTrue(_has_group_access(section_with_tree, user, course.id).has_access)
+
+            self.assertTrue(_has_group_access(subsection_alone, user, course.id).has_access)
+            self.assertTrue(_has_group_access(subsection_with_tree, user, course.id).has_access)
+
+            self.assertTrue(_has_group_access(icrv_parent_vertical, user, course.id).has_access)
+            self.assertTrue(_has_group_access(icrv_xblock, user, course.id).has_access)
+            self.assertTrue(_has_group_access(icrv_xblock_sibling_problem, user, course.id).has_access)
+
+            self.assertTrue(_has_group_access(gated_vertical, user, course.id).has_access)
+            self.assertTrue(_has_group_access(gated_problem1, user, course.id).has_access)
+            self.assertTrue(_has_group_access(gated_problem2, user, course.id).has_access)

--- a/openedx/core/djangoapps/credit/tests/test_user_access.py
+++ b/openedx/core/djangoapps/credit/tests/test_user_access.py
@@ -128,7 +128,7 @@ class UserAccessToContent(ModuleStoreTestCase):
         ("verified", SKIPPED),
         ("honor", None),
     )
-    @ddt.unpack
+    @ddt.unpack  # pylint: disable=too-many-statements
     def test_has_access_for_users(self, enrollment_type, verification_status):
 
         on_course_publish(self.course.id)

--- a/openedx/core/djangoapps/credit/utils.py
+++ b/openedx/core/djangoapps/credit/utils.py
@@ -1,0 +1,60 @@
+"""
+Common utility methods useful for credit app
+"""
+
+import datetime
+from pytz import UTC
+
+from xmodule.modulestore.django import modulestore
+from xmodule.modulestore import ModuleStoreEnum
+
+
+def is_in_course_tree(block):
+    """ Check that the XBlock is in the course tree.
+
+    It is possible that the XBlock is not in the course tree if its parent has
+    been deleted and is now an orphan.
+
+    Args:
+        block (xblock): XBlock mixin
+
+    Returns:
+        bool: True or False
+    """
+    ancestor = block.get_parent()
+    while ancestor is not None and ancestor.location.category != "course":
+        ancestor = ancestor.get_parent()
+
+    return ancestor is not None
+
+
+def get_course_xblocks(course_key, category):
+    """ Retrieve all XBlocks in the course for a particular category.
+
+    Args:
+        course_key (CourseKey): Identifier for the course.
+        category (str): Category of XBlock.
+
+    Returns:
+        List of XBlocks that are published and haven't been deleted.
+
+    """
+    xblocks = [
+        block for block in modulestore().get_items(
+            course_key,
+            qualifiers={"category": category},
+            revision=ModuleStoreEnum.RevisionOption.published_only,
+        )
+        if is_in_course_tree(block)
+    ]
+
+    # Secondary sort on credit requirement name
+    xblocks = sorted(xblocks, key=lambda block: block.get_credit_requirement_display_name())
+
+    # Primary sort on start date
+    xblocks = sorted(xblocks, key=lambda block: (
+        block.start if block.start is not None
+        else datetime.datetime(datetime.MINYEAR, 1, 1).replace(tzinfo=UTC)
+    ))
+
+    return xblocks

--- a/openedx/core/djangoapps/credit/utils.py
+++ b/openedx/core/djangoapps/credit/utils.py
@@ -29,8 +29,8 @@ def get_course_xblocks(course_key, category):
     """ Retrieve all XBlocks in the course for a particular category.
 
     Args:
-        course_key (CourseKey): Identifier for the course.
-        category (str): Category of XBlock.
+        course_key (CourseKey): Identifier for the course
+        category (str): Category of XBlock
 
     Returns:
         List of XBlocks that are published and haven't been deleted.
@@ -50,7 +50,7 @@ def get_course_xblocks(course_key, category):
 
 def filter_by_scheme(course_user_partitions, filter_partition_schemes):
     """ Filter all user partitions for 'course_user_partitions' which have
-    scheme present in list 'filter_partition_schemes'
+    scheme present in list 'filter_partition_schemes'.
 
     Args:
         course_user_partitions (List): List of user partitions

--- a/openedx/core/djangoapps/credit/utils.py
+++ b/openedx/core/djangoapps/credit/utils.py
@@ -46,3 +46,23 @@ def get_course_xblocks(course_key, category):
     ]
 
     return xblocks
+
+
+def filter_by_scheme(course_user_partitions, filter_partition_schemes):
+    """ Filter all user partitions for 'course_user_partitions' which have
+    scheme present in list 'filter_partition_schemes'
+
+    Args:
+        course_user_partitions (List): List of user partitions
+        filter_partition_schemes (List): List of user partitions scheme names
+
+    Returns:
+        List of filtered user partitions.
+
+    """
+    filtered_user_partitions = []
+    for user_partition in course_user_partitions:
+        if user_partition.scheme.name not in filter_partition_schemes:
+            filtered_user_partitions.append(user_partition)
+
+    return filtered_user_partitions

--- a/openedx/core/djangoapps/credit/utils.py
+++ b/openedx/core/djangoapps/credit/utils.py
@@ -48,13 +48,13 @@ def get_course_xblocks(course_key, category):
     return xblocks
 
 
-def filter_by_scheme(course_user_partitions, filter_partition_schemes):
+def filter_by_scheme(course_user_partitions, filter_partition_scheme):
     """ Filter all user partitions for 'course_user_partitions' which have
-    scheme present in list 'filter_partition_schemes'.
+    scheme name as provided 'filter_partition_scheme'.
 
     Args:
         course_user_partitions (List): List of user partitions
-        filter_partition_schemes (List): List of user partitions scheme names
+        filter_partition_scheme (str): User partition scheme name
 
     Returns:
         List of filtered user partitions.
@@ -62,7 +62,7 @@ def filter_by_scheme(course_user_partitions, filter_partition_schemes):
     """
     filtered_user_partitions = []
     for user_partition in course_user_partitions:
-        if user_partition.scheme.name not in filter_partition_schemes:
+        if not user_partition.scheme.name == filter_partition_scheme:
             filtered_user_partitions.append(user_partition)
 
     return filtered_user_partitions

--- a/openedx/core/djangoapps/credit/utils.py
+++ b/openedx/core/djangoapps/credit/utils.py
@@ -48,13 +48,13 @@ def get_course_xblocks(course_key, category):
     return xblocks
 
 
-def filter_by_scheme(course_user_partitions, filter_partition_scheme):
-    """ Filter all user partitions for 'course_user_partitions' which have
+def exclude_by_scheme(course_user_partitions, partition_scheme):
+    """ Filter out all user partitions for 'course_user_partitions' which have
     scheme name as provided 'filter_partition_scheme'.
 
     Args:
         course_user_partitions (List): List of user partitions
-        filter_partition_scheme (str): User partition scheme name
+        partition_scheme (str): User partition scheme name for filtering out
 
     Returns:
         List of filtered user partitions.
@@ -62,7 +62,7 @@ def filter_by_scheme(course_user_partitions, filter_partition_scheme):
     """
     filtered_user_partitions = []
     for user_partition in course_user_partitions:
-        if not user_partition.scheme.name == filter_partition_scheme:
+        if not user_partition.scheme.name == partition_scheme:
             filtered_user_partitions.append(user_partition)
 
     return filtered_user_partitions

--- a/openedx/core/djangoapps/credit/utils.py
+++ b/openedx/core/djangoapps/credit/utils.py
@@ -81,3 +81,17 @@ def get_group_access_blocks(course_key):
     items = modulestore().get_items(course_key, settings={'group_access': {'$exists': True}})
 
     return items
+
+
+def get_course_partitions_used_ids(course):
+    """ Returns list of user partitions 'user_partitions' ids for the provided
+    course.
+
+    Args:
+        course (CourseDescriptorWithMixins): Course object
+
+    Returns:
+        List of user partitions id's.
+
+    """
+    return set([p.id for p in course.user_partitions])

--- a/openedx/core/djangoapps/credit/utils.py
+++ b/openedx/core/djangoapps/credit/utils.py
@@ -1,9 +1,6 @@
 """
-Common utility methods useful for credit app
+Common utility methods useful for credit app.
 """
-
-import datetime
-from pytz import UTC
 
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore import ModuleStoreEnum
@@ -47,14 +44,5 @@ def get_course_xblocks(course_key, category):
         )
         if is_in_course_tree(block)
     ]
-
-    # Secondary sort on credit requirement name
-    xblocks = sorted(xblocks, key=lambda block: block.get_credit_requirement_display_name())
-
-    # Primary sort on start date
-    xblocks = sorted(xblocks, key=lambda block: (
-        block.start if block.start is not None
-        else datetime.datetime(datetime.MINYEAR, 1, 1).replace(tzinfo=UTC)
-    ))
 
     return xblocks

--- a/openedx/core/djangoapps/credit/utils.py
+++ b/openedx/core/djangoapps/credit/utils.py
@@ -66,3 +66,18 @@ def filter_by_scheme(course_user_partitions, filter_partition_schemes):
             filtered_user_partitions.append(user_partition)
 
     return filtered_user_partitions
+
+
+def get_group_access_blocks(course_key):
+    """ Returns list of course blocks which have group access.
+
+    Args:
+        course_key (CourseKey): Identifier for the course
+
+    Returns:
+        List of xblocks.
+
+    """
+    items = modulestore().get_items(course_key, settings={'group_access': {'$exists': True}})
+
+    return items

--- a/setup.py
+++ b/setup.py
@@ -6,13 +6,14 @@ from setuptools import setup
 
 setup(
     name="Open edX",
-    version="0.4",
+    version="0.5",
     install_requires=["setuptools"],
     requires=[],
     # NOTE: These are not the names we should be installing.  This tree should
     # be reorganized to be a more conventional Python tree.
     packages=[
         "openedx.core.djangoapps.course_groups",
+        "openedx.core.djangoapps.credit",
         "openedx.core.djangoapps.user_api",
         "lms",
         "cms",


### PR DESCRIPTION
WIP: Tag credit course content with `VerificationPartitionScheme` groups for ICRV access control.

@awais786 @aamir-khan @ahsan-ul-haq @tasawernawaz @wedaly 
- update the version of `Open edX` in `setup.py`.
- add `credit` app in `packages` of `Open edX`.
- create main method `tag_course_content_with_partition_scheme` for course content tagging.
- create file `openedx/core/djangoapps/credit/utils.py` with method `get_course_xblocks` to get course xblocks with provided `category`.

**Remaining tasks:**
- create user partitions groups with scheme `VerificationPartitionScheme` and tag individual ICRV blocks with required user partition groups
- add tests

**Notes:**

> You might get error for `VerificationPartitionScheme` like: 
> **UserPartitionError: Unrecognized scheme verification**
> The problem appears to be that pip has not noticed the bump in the Open edX version number and so has not correctly reinstalled the package. The workaround is to execute the following from your devstack:
> **paver install_prereqs; pip install -e .**
> You can check that you have the correct version installed with the following command. It should show that you have version 0.5:
> **~/edx-platform$ pip list | grep Open-edX**
> **Open-edX (0.5, /edx/app/edxapp/edx-platform)**

 Depends on: https://github.com/edx/edx-platform/pull/9116
