### PR TITLE
asadiqbal08/SOL-1035: Signatory fields should use placeholders and not text values

### DIFF
--- a/cms/static/js/certificates/models/signatory.js
+++ b/cms/static/js/certificates/models/signatory.js
@@ -14,9 +14,9 @@ function(_, str, Backbone, BackboneRelational, gettext) {
     var Signatory = Backbone.RelationalModel.extend({
         idAttribute: "id",
         defaults: {
-            name: 'Name of the signatory',
-            title: 'Title of the signatory',
-            organization: 'Organization of the signatory',
+            name: '',
+            title: '',
+            organization: '',
             signature_image_path: ''
         },
 

--- a/cms/static/js/certificates/spec/views/certificate_details_spec.js
+++ b/cms/static/js/certificates/spec/views/certificate_details_spec.js
@@ -164,11 +164,9 @@ function(_, Course, CertificatesCollection, CertificateModel, CertificateDetails
 
             it('displays certificate signatories details', function(){
                 this.view.$('.show-details').click();
-                expect(this.view.$(SELECTORS.signatory_name_value)).toContainText(/^[A-Za-z\s]{10,40}/);
-                expect(this.view.$(SELECTORS.signatory_title_value)).toContainText('Title of the signatory');
-                expect(
-                    this.view.$(SELECTORS.signatory_organization_value)
-                ).toContainText('Organization of the signatory');
+                expect(this.view.$(SELECTORS.signatory_name_value)).toContainText('');
+                expect(this.view.$(SELECTORS.signatory_title_value)).toContainText('');
+                expect(this.view.$(SELECTORS.signatory_organization_value)).toContainText('');
             });
 
             it('supports in-line editing of signatory information', function() {


### PR DESCRIPTION
@mattdrayer in this pr i just removed the default value from signatory model so we can see the placeholder text. 
###### state = WIP as waiting for a response from QA side.
