### PR TITLE
Make new masquerading code compatible to existing session data.

### DIFF
--- a/lms/djangoapps/courseware/masquerade.py
+++ b/lms/djangoapps/courseware/masquerade.py
@@ -40,6 +40,16 @@ class CourseMasquerade(object):
         self.group_id = group_id
         self.user_name = user_name
 
+    def __setstate__(self, state):
+        """
+        Ensure that all attributes are initialised when unpickling CourseMasquerade objects.
+
+        Users might still have CourseMasquerade objects from older versions of the code in their
+        session.  These old objects might not have all attributes set, possibly resulting in
+        AttributeErrors.
+        """
+        self.__init__(**state)
+
 
 @require_POST
 @login_required

--- a/lms/djangoapps/courseware/tests/test_masquerade.py
+++ b/lms/djangoapps/courseware/tests/test_masquerade.py
@@ -2,6 +2,7 @@
 Unit tests for masquerade.
 """
 import json
+import pickle
 from mock import patch
 from nose.plugins.attrib import attr
 from datetime import datetime
@@ -12,6 +13,7 @@ from django.utils.timezone import UTC
 
 from capa.tests.response_xml_factory import OptionResponseXMLFactory
 from courseware.masquerade import (
+    CourseMasquerade,
     MasqueradingKeyValueStore,
     handle_ajax,
     setup_masquerade,
@@ -394,3 +396,19 @@ class MasqueradingKeyValueStoreTest(TestCase):
                 self.kvs.get(key)
 
         self.assertEqual(self.kvs.get('c'), 'OpenCraft')
+
+
+class CourseMasqueradeTest(TestCase):
+    """
+    Unit tests for the CourseMasquerade class.
+    """
+    def test_unpickling_sets_all_attributes(self):
+        """
+        Make sure that old CourseMasquerade objects receive missing attributes when unpickled from
+        the session.
+        """
+        cmasq = CourseMasquerade(7)
+        del cmasq.user_name
+        pickled_cmasq = pickle.dumps(cmasq)
+        unpickled_cmasq = pickle.loads(pickled_cmasq)
+        self.assertEqual(unpickled_cmasq.user_name, None)


### PR DESCRIPTION
The new masquerading code introduced in PR #8775 adds a new attribute to `CourseMasquerade` objects stored in the user's session.  When users who have an active masquerading configuration access instances with the new code, and AttributeError occurs when trying to access the attribute user_name.

This fix ensures that CourseMasquerade objects receive all required attributes when they are unpickled from the session.

The code has already been reviewed by @e-kolpakov in PR #9177.

**JIRA ticket:** [SOL-1109](https://openedx.atlassian.net/browse/SOL-1109)
**Sandbox** [sandbox3.opencraft.com](http://sandbox3.opencraft.com/) (This is simply an instance with the code from this PR installed;  not sure what it is useful for since there isn't really a way of manually creating session data that would trigger the bug, so you can't test that the bug has actually been fixed.)
**Reviewers:** @e-kolpakov (in PR #9177), TBD
