### PR TITLE
User partition scheme 'VerificationPartitionScheme' + tests

### DIFF
--- a/openedx/core/djangoapps/credit/partition_schemes.py
+++ b/openedx/core/djangoapps/credit/partition_schemes.py
@@ -1,0 +1,155 @@
+"""
+Provides partition support to the user service.
+"""
+
+import logging
+
+from course_modes.models import CourseMode
+from lms.djangoapps.verify_student.models import SkippedReverification, VerificationStatus
+from student.models import CourseEnrollment
+
+
+log = logging.getLogger(__name__)
+
+
+class VerificationPartitionScheme(object):
+    """
+    This scheme assigns users into the partition 'VerificationPartitionScheme'
+    groups. Initially all the gated exams content will be hidden except the
+    ICRV blocks for a 'verified' student until that student skips or submits
+    verification for an ICRV then the related gated exam content for that ICRV
+    will be displayed.
+
+    Following scenarios can be handled:
+
+    non_verified: When a student is not enrolled as 'verified'
+    all ICRV blocks will be hidden but the student will have access
+    to all the gated exams content.
+
+    verified_allow: When a student skips or submits or denied at any
+    ICRV checkpoint verification then that student will be allowed to access
+    the gated exam content of that ICRV.
+
+    verified_deny: When a student has failed (used all attempts) an ICRV verification,
+    all ICRV blocks will be hidden and the student will have access to all
+    the gated exams content.
+    """
+    NON_VERIFIED = 'non_verified'
+    VERIFIED_ALLOW = 'verified_allow'
+    VERIFIED_DENY = 'verified_deny'
+
+    @classmethod
+    def get_group_for_user(cls, course_key, user, user_partition):
+        """
+        Return the user's group depending their enrollment and verification
+        status.
+
+        Args:
+            course_key(CourseKey): CourseKey
+            user(User): user object
+            user_partition: location object
+
+        Returns:
+            string of allowed access group
+        """
+        checkpoint = user_partition.parameters['location']
+
+        if (
+                not is_enrolled_in_verified_mode(user, course_key)
+        ):
+            # the course content tagged with given 'user_partition' is
+            # accessible/visible to all the students
+            return cls.NON_VERIFIED
+        elif (
+                has_skipped_any_checkpoint(user, course_key) or
+                was_denied_at_any_checkpoint(user, course_key) or
+                has_completed_checkpoint(user, course_key, checkpoint)
+        ):
+            # the course content tagged with given 'user_partition' is
+            # accessible/visible to the students enrolled as `verified` users
+            # and has either `skipped any ICRV` or `was denied at any ICRV
+            # (used all attempts for an ICRV but still denied by the software
+            # secure)` or `has submitted/approved verification for given ICRV`
+            return cls.VERIFIED_ALLOW
+        else:
+            # the course content tagged with given 'user_partition' is
+            # accessible/visible to the students enrolled as `verified` users
+            # and has not yet submitted for the related ICRV
+            return cls.VERIFIED_DENY
+
+    @classmethod
+    def key_for_partition(cls, xblock_location_id):
+        """ Returns the key for partition scheme to use for look up and save
+        the user's group for a given 'VerificationPartitionScheme'.
+
+        Args:
+            xblock_location_id(str): Location of block in course
+
+        Returns:
+            String of the format 'verification:{location}'
+        """
+        return 'verification:{0}'.format(xblock_location_id)
+
+
+def is_enrolled_in_verified_mode(user, course_key):
+    """
+    Returns the Boolean value if given user for the given course is enrolled in
+    verified modes.
+
+    Args:
+        user(User): user object
+        course_key(CourseKey): CourseKey
+
+    Returns:
+        Boolean
+    """
+    enrollment_mode, __ = CourseEnrollment.enrollment_mode_for_user(user, course_key)
+    return enrollment_mode in CourseMode.VERIFIED_MODES
+
+
+def was_denied_at_any_checkpoint(user, course_key):
+    """Returns the Boolean value if given user with given course was denied for any
+    incourse verification checkpoint.
+
+    Args:
+        user(User): user object
+        course_key(CourseKey): CourseKey
+
+    Returns:
+        Boolean
+    """
+    return VerificationStatus.objects.filter(
+        user=user,
+        checkpoint__course_id=course_key,
+        status='denied'
+    ).exists()
+
+
+def has_skipped_any_checkpoint(user, course_key):
+    """Check existence of a user's skipped re-verification attempt for a
+    specific course.
+
+    Args:
+        user(User): user object
+        course_key(CourseKey): CourseKey
+
+    Returns:
+        Boolean
+    """
+    return SkippedReverification.check_user_skipped_reverification_exists(user, course_key)
+
+
+def has_completed_checkpoint(user, course_key, checkpoint):
+    """
+    Get re-verification status against a user for a 'course_id' and checkpoint.
+    Only 'approved' and 'submitted' statuses are considered as completed.
+
+    Args:
+        user (User): The user whose status we are retrieving.
+        course_key (CourseKey): The identifier for the course.
+        checkpoint (UsageKey): The location of the checkpoint in the course.
+
+    Returns:
+        unicode or None
+    """
+    return VerificationStatus.check_user_has_completed_checkpoint(user, course_key, checkpoint)

--- a/openedx/core/djangoapps/credit/tests/test_partition.py
+++ b/openedx/core/djangoapps/credit/tests/test_partition.py
@@ -1,0 +1,156 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for In-Course Reverification Access Control Partition scheme
+"""
+
+import ddt
+import unittest
+from mock import Mock
+
+from django.conf import settings
+
+from lms.djangoapps.verify_student.models import (
+    VerificationCheckpoint,
+    VerificationStatus,
+    SkippedReverification,
+)
+from openedx.core.djangoapps.credit.partition_schemes import VerificationPartitionScheme
+from student.models import CourseEnrollment
+from student.tests.factories import UserFactory
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory
+
+
+@ddt.ddt
+@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+class ReverificationPartitionTest(ModuleStoreTestCase):
+    """Tests for the Reverification Partition Scheme. """
+
+    SUBMITTED = "submitted"
+    APPROVED = "approved"
+    DENIED = "denied"
+
+    def setUp(self):
+        super(ReverificationPartitionTest, self).setUp()
+
+        # creating course, checkpoint location and user partition mock object.
+        self.course = CourseFactory.create()
+        self.checkpoint_location = u'i4x://{org}/{course}/edx-reverification-block/first_uuid'.format(
+            org=self.course.id.org, course=self.course.id.course
+        )
+        self.user_partition = Mock(user_partitions=[])
+        self.user_partition.parameters = {
+            "location": self.checkpoint_location
+        }
+
+        self.first_checkpoint = VerificationCheckpoint.objects.create(
+            course_id=self.course.id,
+            checkpoint_location=self.checkpoint_location
+        )
+
+    def created_user_and_enroll(self, enrollment_type):
+        """Create and enroll users with provided enrollment type."""
+
+        user = UserFactory.create()
+        CourseEnrollment.objects.create(
+            user=user,
+            course_id=self.course.id,
+            mode=enrollment_type,
+            is_active=True
+        )
+        return user
+
+    def add_verification_status(self, user, status):
+        """Adding the verification status for a user."""
+
+        VerificationStatus.add_status_from_checkpoints(
+            checkpoints=[self.first_checkpoint],
+            user=user,
+            status=status
+        )
+
+    @ddt.data(
+        ("verified", SUBMITTED),
+        ("verified", APPROVED),
+        ("verified", SUBMITTED),
+        ("verified", DENIED),
+        ("verified", None),
+        ("honor", False),
+    )
+    @ddt.unpack
+    def test_get_group_for_user(self, enrollment_type, verification_status):
+        # creating user and enroll them.
+        user = self.created_user_and_enroll(enrollment_type)
+        if verification_status:
+            self.add_verification_status(user, verification_status)
+
+        if enrollment_type == 'honor':
+            self.assertEqual(
+                VerificationPartitionScheme.NON_VERIFIED,
+                VerificationPartitionScheme.get_group_for_user(
+                    self.course.id,
+                    user,
+                    self.user_partition
+                )
+            )
+
+        elif (
+                verification_status in [
+                    self.SUBMITTED,
+                    self.APPROVED,
+                    self.DENIED
+                ]
+                and enrollment_type == 'verified'
+        ):
+            self.assertEqual(
+                VerificationPartitionScheme.VERIFIED_ALLOW,
+                VerificationPartitionScheme.get_group_for_user(
+                    self.course.id,
+                    user,
+                    self.user_partition
+                )
+            )
+
+        else:
+            self.assertEqual(
+                VerificationPartitionScheme.VERIFIED_DENY,
+                VerificationPartitionScheme.get_group_for_user(
+                    self.course.id,
+                    user,
+                    self.user_partition
+                )
+            )
+
+    def test_get_group_for_user_with_skipped(self):
+        # Check that a user is in verified allow group if that user has skipped
+        # any ICRV block.
+        user = self.created_user_and_enroll('verified')
+
+        SkippedReverification.add_skipped_reverification_attempt(
+            checkpoint=self.first_checkpoint,
+            user_id=user.id,
+            course_id=self.course.id
+        )
+
+        self.assertEqual(
+            VerificationPartitionScheme.VERIFIED_ALLOW,
+            VerificationPartitionScheme.get_group_for_user(
+                self.course.id,
+                user,
+                self.user_partition
+            )
+        )
+
+    def test_key_for_partition(self):
+        # Test that 'key_for_partition' method of partition scheme
+        # 'VerificationPartitionScheme' returns desired format for
+        # partition id.
+
+        self.assertEqual(
+            'verification:{}'.format(
+                self.checkpoint_location
+            ),
+            VerificationPartitionScheme.key_for_partition(
+                self.checkpoint_location
+            )
+        )

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         "openedx.user_partition_scheme": [
             "random = openedx.core.djangoapps.user_api.partition_schemes:RandomUserPartitionScheme",
             "cohort = openedx.core.djangoapps.course_groups.partition_scheme:CohortPartitionScheme",
+            "verification = openedx.core.djangoapps.credit.partition_schemes:VerificationPartitionScheme",
         ],
     }
 )


### PR DESCRIPTION
ECOM-1977

@aamir-khan @ahsan-ul-haq @tasawernawaz @zubair-arbi @wedaly 
- Create New user partition scheme `VerificationPartitionScheme`.
- Add method `get_group_for_user` to assign one group for three partition groups `['non_verified', 'verified_allow', 'verified_deny']` to users/students on the basis of partition, course and module's location.
- Add test cases.
- Add `VerificationPartitionScheme` in `setup.py` for `stevedore`.

Old PR against master: #9116
