### PR TITLE
PHX-79 instructor dashboard view initialization removed from courseware

### DIFF
--- a/lms/static/coffee/src/instructor_dashboard/instructor_dashboard.coffee
+++ b/lms/static/coffee/src/instructor_dashboard/instructor_dashboard.coffee
@@ -185,6 +185,9 @@ setup_instructor_dashboard_sections = (idash_content) ->
   ,
     constructor: edx.instructor_dashboard.proctoring.ProctoredExamAllowanceView
     $element: idash_content.find ".#{CSS_IDASH_SECTION}#proctoring"
+  ,
+    constructor: edx.instructor_dashboard.proctoring.ProctoredExamAttemptView
+    $element: idash_content.find ".#{CSS_IDASH_SECTION}#proctoring"
   ]
 
   sections_to_initialize.map ({constructor, $element}) ->


### PR DESCRIPTION
Initialized the ProctoredAttempts backbone view for instructor dashboard.
