### PR TITLE
Ignore more directories to speed up extracting i18n strings.

### DIFF
--- a/conf/locale/config.yaml
+++ b/conf/locale/config.yaml
@@ -90,12 +90,28 @@ dummy_locales:
 
 # Directories we don't search for strings.
 ignore_dirs:
-    - docs
-    - src
-    - i18n
-    - test_root
     - common/static/xmodule/modules
     - common/static/xmodule/descriptors
+    # Directories with no user-facing code.
+    - '*/migrations'
+    # Directories that are not our code.
+    - common/static/js/vendor/mathjax-MathJax-c9db6ac
+    - node_modules
+    # Directories containing files that can't have strings in them.
+    - conf
+    - docs
+    - '*/fonts'
+    - '*/img'
+    - '*/images'
+    - '*/sass'
+    - '*/css'
+    # Directories that only contain tests.
+    - common/test
+    - test_root
+    - '*/terrain'
+    - '*/spec'
+    - '*/tests'
+    - '*/features'
 
 
 # Third-party installed apps that we also extract strings from.  When adding a

--- a/lms/djangoapps/courseware/features/video.py
+++ b/lms/djangoapps/courseware/features/video.py
@@ -8,7 +8,6 @@ import time
 import requests
 from nose.tools import assert_equal, assert_true, assert_false
 from common import i_am_registered_for_the_course, visit_scenario_item
-from django.utils.translation import ugettext as _
 from django.conf import settings
 from cache_toolbox.core import del_cached_content
 from xmodule.contentstore.content import StaticContent
@@ -432,7 +431,7 @@ def error_message_is_shown(_step):
 @step('error message has correct text$')
 def error_message_has_correct_text(_step):
     selector = '.video .video-player h3'
-    text = _('ERROR: No playable video sources found!')
+    text = 'ERROR: No playable video sources found!'
     assert world.css_has_text(selector, text)
 
 


### PR DESCRIPTION
Also, remove the one use of _() in a test feature, since there's no
point.
