### PR TITLE
Enable teams and deprecate the advanced setting

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -168,7 +168,7 @@ FEATURES = {
     },
 
     # Teams feature
-    'ENABLE_TEAMS': False,
+    'ENABLE_TEAMS': True,
 
     # Show video bumper in Studio
     'ENABLE_VIDEO_BUMPER': False,

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -904,7 +904,8 @@ class CourseFields(object):
             "Enter configuration for the teams feature. Expects two entries: max_team_size and topics, where "
             "topics is a list of topics."
         ),
-        scope=Scope.settings
+        scope=Scope.settings,
+        deprecated=True,  # Deprecated until the teams feature is made generally available
     )
 
     enable_proctored_exams = Boolean(

--- a/common/test/acceptance/pages/studio/settings_advanced.py
+++ b/common/test/acceptance/pages/studio/settings_advanced.py
@@ -199,7 +199,6 @@ class AdvancedSettingsPage(CoursePage):
             'text_customization',
             'annotation_storage_url',
             'social_sharing_url',
-            'teams_configuration',
             'video_bumper',
             'cert_html_view_enabled',
             'enable_proctored_exams',

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -396,7 +396,7 @@ FEATURES = {
     'ENABLE_SOFTWARE_SECURE_FAKE': False,
 
     # Teams feature
-    'ENABLE_TEAMS': False,
+    'ENABLE_TEAMS': True,
 
     # Show video bumper in LMS
     'ENABLE_VIDEO_BUMPER': False,


### PR DESCRIPTION
https://openedx.atlassian.net/browse/TNL-2784

The intention here is to do a soft launch of teams:
- the feature flag has been enabled so that all the features work
- the advanced setting has been marked as deprecated so that it isn't shown to authors by default
