### PR TITLE
Fixing discussion commands overlapping with text

### DIFF
--- a/lms/static/sass/discussion/views/_thread.scss
+++ b/lms/static/sass/discussion/views/_thread.scss
@@ -39,13 +39,13 @@ body.discussion, .discussion-module {
     .response-header-content {
       display: inline-block;
       vertical-align: top;
-      width: flex-grid(11,12);
+      width: flex-grid(8,12);
     }
 
     .response-header-actions {
-      position: absolute;
-      @include right($baseline);
-      top: ($baseline);
+      display: inline-block;
+      vertical-align: top;
+      width: flex-grid(4,12);
       @include float(right);
     }
   }


### PR DESCRIPTION
This PR cleans up the discussion forum CSS a little bit.

Presently, the header to a discussion forum question looks like the following:
![screen shot 2015-08-06 at 12 06 01 pm](https://cloud.githubusercontent.com/assets/6232546/9116754/028d7300-3c34-11e5-82ae-fe15369000ab.png)
Note how the text on the first line has wrapped early, in order to make enough space for the discussion commands in the upper right hand corner.

However, a response to a discussion forum question looks like the following:
![screen shot 2015-08-06 at 12 06 11 pm](https://cloud.githubusercontent.com/assets/6232546/9116774/2286b504-3c34-11e5-9116-c46758b8e95c.png)
You can see how the commands are overlapping with the text.

This code change adjusts the styling of the responses, so that no overlap occurs. Result:
![screen shot 2015-08-06 at 12 07 36 pm](https://cloud.githubusercontent.com/assets/6232546/9116798/460aa3c8-3c34-11e5-86d7-cd29fb724166.png)

There are a couple of idiosyncrasies in this fix.
- Firstly, the width of that box on the right is optimally about 25%. However, the flex grid is styled in 12ths, and 3/12s yields a percentage of 23.2%, which is just a bit too small. Giving it 4/12s is obviously too big. We could play around with different numbers, but everything on the platform seems to be styled in 12ths, so I left it as 4/12s.
- Secondly, you can see that the "0 votes" text is all the way to the left, when it should be over to the right. If you vote up the answer, and then unvote it, the "0 votes" is to the right, where it should be. This behavior is caused because of a style="display:inline;" that is originally set on the "a class='action-button action-vote'" element (NOT through CSS, but through inline styling), and I haven't been able to find where that is being set (python? javascript? template?).

I'm happy to discuss details.
