### PR TITLE
Christina/less assets

### DIFF
--- a/lms/djangoapps/branding/__init__.py
+++ b/lms/djangoapps/branding/__init__.py
@@ -4,6 +4,7 @@ from django.conf import settings
 
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
 from microsite_configuration import microsite
+from staticfiles.storage import staticfiles_storage
 
 
 def get_visible_courses():
@@ -65,14 +66,8 @@ def get_logo_url():
     university = microsite.get_value('university')
 
     if university is None and settings.FEATURES.get('IS_EDX_DOMAIN', False):
-        return '{static_url}images/edx-theme/edx-logo-77x36.png'.format(
-            static_url=settings.STATIC_URL
-        )
+        return staticfiles_storage.url('images/edx-theme/edx-logo-77x36.png')
     elif university:
-        return '{static_url}images/{uni}-on-edx-logo.png'.format(
-            static_url=settings.STATIC_URL, uni=university
-        )
+        return staticfiles_storage.url('images/{uni}-on-edx-logo.png'.format(uni=university))
     else:
-        return '{static_url}images/default-theme/logo.png'.format(
-            static_url=settings.STATIC_URL
-        )
+        return staticfiles_storage.url('images/default-theme/logo.png')

--- a/lms/djangoapps/student_account/views.py
+++ b/lms/djangoapps/student_account/views.py
@@ -381,6 +381,7 @@ def account_settings_context(request):
         'platform_name': settings.PLATFORM_NAME,
         'user_accounts_api_url': reverse("accounts_api", kwargs={'username': user.username}),
         'user_preferences_api_url': reverse('preferences_api', kwargs={'username': user.username}),
+        'disable_courseware_js': True,
     }
 
     if third_party_auth.is_enabled():

--- a/lms/djangoapps/student_profile/views.py
+++ b/lms/djangoapps/student_profile/views.py
@@ -92,6 +92,7 @@ def learner_profile_context(logged_in_user, profile_username, user_is_staff, bui
             'country_options': list(countries),
             'language_options': settings.ALL_LANGUAGES,
             'platform_name': microsite.get_value('platform_name', settings.PLATFORM_NAME),
-        }
+        },
+        'disable_courseware_js': True,
     }
     return context

--- a/lms/djangoapps/teams/views.py
+++ b/lms/djangoapps/teams/views.py
@@ -102,7 +102,8 @@ class TeamsDashboardView(View):
             "languages": settings.ALL_LANGUAGES,
             "countries": list(countries),
             "username": user.username,
-            "privileged": has_discussion_privileges(user, course_key)
+            "privileged": has_discussion_privileges(user, course_key),
+            "disable_courseware_js": True,
         }
         return render_to_response("teams/teams.html", context)
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1248,6 +1248,11 @@ main_vendor_js = base_vendor_js + [
 base_application_js = [
     'js/src/utility.js',
     'js/src/logger.js',
+    'js/my_courses_dropdown.js',
+    'js/src/string_utils.js',
+    'js/form.ext.js',
+    'js/src/ie_shim.js',
+    'js/src/accessibility_tools.js',
 ]
 
 dashboard_js = (
@@ -1267,14 +1272,9 @@ instructor_dash_js = (
 # JavaScript modules.
 student_account_js = [
     'js/utils/edx.utils.validate.js',
-    'js/form.ext.js',
-    'js/my_courses_dropdown.js',
     'js/toggle_login_modal.js',
     'js/sticky_filter.js',
     'js/query-params.js',
-    'js/src/accessibility_tools.js',
-    'js/src/ie_shim.js',
-    'js/src/string_utils.js',
     'js/student_account/models/LoginModel.js',
     'js/student_account/models/RegisterModel.js',
     'js/student_account/models/PasswordResetModel.js',
@@ -1289,14 +1289,9 @@ student_account_js = [
 ]
 
 verify_student_js = [
-    'js/form.ext.js',
-    'js/my_courses_dropdown.js',
     'js/toggle_login_modal.js',
     'js/sticky_filter.js',
     'js/query-params.js',
-    'js/src/accessibility_tools.js',
-    'js/src/ie_shim.js',
-    'js/src/string_utils.js',
     'js/verify_student/models/verification_model.js',
     'js/verify_student/views/error_view.js',
     'js/verify_student/views/image_input_view.js',
@@ -1487,14 +1482,9 @@ PIPELINE_JS = {
 
         # Application will contain all paths not in courseware_only_js
         'source_filenames': ['js/xblock/core.js'] + sorted(common_js) + sorted(project_js) + base_application_js + [
-            'js/form.ext.js',
-            'js/my_courses_dropdown.js',
             'js/toggle_login_modal.js',
             'js/sticky_filter.js',
             'js/query-params.js',
-            'js/src/accessibility_tools.js',
-            'js/src/ie_shim.js',
-            'js/src/string_utils.js',
         ],
         'output_filename': 'js/lms-application.js',
     },

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1258,7 +1258,12 @@ base_application_js = [
 dashboard_js = (
     sorted(rooted_glob(PROJECT_ROOT / 'static', 'js/dashboard/**/*.js'))
 )
-discussion_js = sorted(rooted_glob(COMMON_ROOT / 'static', 'coffee/src/discussion/**/*.js'))
+discussion_js = (
+    rooted_glob(PROJECT_ROOT / 'static', 'coffee/src/customwmd.js') +
+    rooted_glob(PROJECT_ROOT / 'static', 'coffee/src/mathjax_accessible.js') +
+    rooted_glob(PROJECT_ROOT / 'static', 'coffee/src/mathjax_delay_renderer.js') +
+    sorted(rooted_glob(COMMON_ROOT / 'static', 'coffee/src/discussion/**/*.js'))
+)
 
 discussion_vendor_js = [
     'js/Markdown.Converter.js',

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1259,6 +1259,18 @@ dashboard_js = (
     sorted(rooted_glob(PROJECT_ROOT / 'static', 'js/dashboard/**/*.js'))
 )
 discussion_js = sorted(rooted_glob(COMMON_ROOT / 'static', 'coffee/src/discussion/**/*.js'))
+
+discussion_vendor_js = [
+    'js/Markdown.Converter.js',
+    'js/Markdown.Sanitizer.js',
+    'js/Markdown.Editor.js',
+    'js/vendor/jquery.timeago.js',
+    'js/src/jquery.timeago.locale.js',
+    'js/vendor/jquery.truncate.js',
+    'js/jquery.ajaxfileupload.js',
+    'js/split.js'
+]
+
 staff_grading_js = sorted(rooted_glob(PROJECT_ROOT / 'static', 'coffee/src/staff_grading/**/*.js'))
 open_ended_js = sorted(rooted_glob(PROJECT_ROOT / 'static', 'coffee/src/open_ended/**/*.js'))
 notes_js = sorted(rooted_glob(PROJECT_ROOT / 'static', 'coffee/src/notes/**/*.js'))
@@ -1511,6 +1523,10 @@ PIPELINE_JS = {
     'discussion': {
         'source_filenames': discussion_js,
         'output_filename': 'js/discussion.js',
+    },
+    'discussion_vendor': {
+        'source_filenames': discussion_vendor_js,
+        'output_filename': 'js/discussion_vendor.js',
     },
     'staff_grading': {
         'source_filenames': staff_grading_js,

--- a/lms/templates/discussion/_js_head_dependencies.html
+++ b/lms/templates/discussion/_js_head_dependencies.html
@@ -1,14 +1,8 @@
 <%namespace name='static' file='../static_content.html'/>
 
-<script type="text/javascript" src="${static.url('js/split.js')}"></script>
-<script type="text/javascript" src="${static.url('js/vendor/jquery.truncate.js')}"></script>
-<script type="text/javascript" src="${static.url('js/jquery.ajaxfileupload.js')}"></script>
-<script type="text/javascript" src="${static.url('js/Markdown.Converter.js')}"></script>
-<script type="text/javascript" src="${static.url('js/Markdown.Sanitizer.js')}"></script>
-<script type="text/javascript" src="${static.url('js/Markdown.Editor.js')}"></script>
 <script type="text/javascript" src="${static.url('js/jquery.autocomplete.js')}"></script>
-<script type="text/javascript" src="${static.url('js/vendor/jquery.timeago.js')}"></script>
-<script type="text/javascript" src="${static.url('js/src/jquery.timeago.locale.js')}"></script>
 <script type="text/javascript" src="${static.url('js/src/tooltip_manager.js')}"></script>
+
+<%static:js group='discussion_vendor'/>
 
 <link href="${static.url('css/vendor/jquery.autocomplete.css')}" rel="stylesheet" type="text/css">


### PR DESCRIPTION
Fixes to reduce the number of JS files loaded on profile, account settings, and teams pages.

Also addresses an issue where some theming images were not cacheable.

@singingwolfboy FYI about https://github.com/edx/edx-platform/commit/a7c06fd296f348ba9d20a34c7f7db70a57b2eaf6

@wedaly and @benpatterson could you review?
@andy-armstrong and I pair programmed on this.

Note that this PR should provide no risk for anything besides the learner account/profile pages and the teams page (which is still in development); the risk for those pages is pretty low since they have comprehensive bok choy test coverage. For everything else, the same dependencies are still downloaded, just slightly reorganized in the pipeline groupings.
