### PR TITLE
Fix IE10 issue with delete button.

### DIFF
--- a/cms/templates/js/content-group-details.underscore
+++ b/cms/templates/js/content-group-details.underscore
@@ -32,7 +32,7 @@
             </li>
         <% } else { %>
             <li class="action action-delete wrapper-delete-button" data-tooltip="<%= gettext('Cannot delete when in use by a unit') %>">
-                <button class="delete action-icon is-disabled" aria-disabled="true"><i class="icon fa fa-trash-o"></i><span><%= gettext("Delete") %></span></button>
+                <button class="delete action-icon is-disabled" aria-disabled="true" disabled="disabled"><i class="icon fa fa-trash-o"></i><span><%= gettext("Delete") %></span></button>
             </li>
         <% } %>
     </ul>


### PR DESCRIPTION
Delete button should not be clickable if in use by a unit.

[ On IE 10 when a Group is being used in a Unit, clicking on delete button on Group configurations page displays the Delete pop up, where as on other environments this button is not clickable - TNL-2882](https://openedx.atlassian.net/browse/TNL-2882)

Steps to Test  on [Sandbox](http://tnl2886.sandbox.edx.org/) :
1- Add a Group Configuration 
2- Go to Unit and add a unit 
3- Select the visibility of a unit and use that group 
4- Navigate to Group Configurations page and try to click the delete button

For ease; I have created a group here and used it in a unit, visit [Group Configuration Page](http://studio-tnl2886.sandbox.edx.org/group_configurations/course-v1:edX+DemoX+Demo_Course)
