### PR TITLE
Handle case of video in a content library with no transcripts.

### DIFF
--- a/common/lib/xmodule/xmodule/video_module/video_handlers.py
+++ b/common/lib/xmodule/xmodule/video_module/video_handlers.py
@@ -14,6 +14,7 @@ from xblock.core import XBlock
 
 from xmodule.exceptions import NotFoundError
 from xmodule.fields import RelativeTime
+from opaque_keys.edx.locator import CourseLocator
 
 from .transcripts_utils import (
     get_or_create_sjson,
@@ -164,6 +165,10 @@ class VideoStudentViewHandlers(object):
         response = Response(status=404)
         # Only do redirect for English
         if not self.transcript_language == 'en':
+            return response
+
+        # If this video lives in library, the code below is not relevant and will error.
+        if not isinstance(self.course_id, CourseLocator):
             return response
 
         video_id = request.GET.get('videoId', None)

--- a/lms/djangoapps/courseware/tests/test_video_handlers.py
+++ b/lms/djangoapps/courseware/tests/test_video_handlers.py
@@ -569,11 +569,7 @@ class TestTranscriptTranslationGetDispatch(TestVideo):
         Set course static_asset_path and ensure we get redirected to that path
         if it isn't found in the contentstore
         """
-        self.course.static_asset_path = 'dummy/static'
-        self.course.save()
-        store = modulestore()
-        with store.branch_setting(ModuleStoreEnum.Branch.draft_preferred, self.course.id):
-            store.update_item(self.course, self.user.id)
+        self._set_static_asset_path()
 
         if attach:
             attach(self.item, sub)
@@ -585,6 +581,27 @@ class TestTranscriptTranslationGetDispatch(TestVideo):
                 ('Location', '/static/dummy/static/subs_{}.srt.sjson'.format(sub)),
                 response.headerlist
             )
+
+    @patch('xmodule.video_module.VideoModule.course_id', return_value='not_a_course_locator')
+    def test_translation_static_non_course(self, __):
+        """
+        Test that get_static_transcript short-circuits in the case of a non-CourseLocator.
+        This fixes a bug for videos inside of content libraries.
+        """
+        self._set_static_asset_path()
+
+        # When course_id is not mocked out, these values would result in 307, as tested above.
+        request = Request.blank('/translation/en?videoId=12345')
+        response = self.item.transcript(request=request, dispatch='translation/en')
+        self.assertEqual(response.status, '404 Not Found')
+
+    def _set_static_asset_path(self):
+        """ Helper method for setting up the static_asset_path information """
+        self.course.static_asset_path = 'dummy/static'
+        self.course.save()
+        store = modulestore()
+        with store.branch_setting(ModuleStoreEnum.Branch.draft_preferred, self.course.id):
+            store.update_item(self.course, self.user.id)
 
 
 @attr('shard_1')


### PR DESCRIPTION
This partially addresses https://openedx.atlassian.net/browse/TNL-1776.

There are 2 issues in TNL-1776:
1) If a video lives within a content library and has no transcript, an ItemNotFoundError is thrown when rendering the video. This PR covers this case.
2) Newly created videos in Studio (both within courses and libraries) do not have a properly configured transcript. I will be investigating this side of the issue next.

I am working under the assumption that the get_static_transcript method is only relevant to courses that are created outside of Studio (and in particular, that get_static_transcript is not at all relevant to content libraries). If that is not true, I will need to make my bug fix smarter. I am hoping that my reviewers can shed light on the relationship between get_static_transcript and content libraries. Would a content library ever have "static_asset_path" or "data_dir"?

@bradenmacdonald @carsongee and @cpennington can you please review this "one-line change" PR and let me know if I need to take a more nuanced approach?
