### PR TITLE
Emit INFO-level messages when a mode does not have a SKU

### DIFF
--- a/lms/djangoapps/commerce/api/v0/views.py
+++ b/lms/djangoapps/commerce/api/v0/views.py
@@ -111,7 +111,7 @@ class BasketsView(APIView):
             # If there are no course modes with SKUs, enroll the user without contacting the external API.
             msg = Messages.NO_SKU_ENROLLED.format(enrollment_mode=CourseMode.HONOR, course_id=course_id,
                                                   username=user.username)
-            log.debug(msg)
+            log.info(msg)
             self._enroll(course_key, user)
             self._handle_marketing_opt_in(request, course_key, user)
             return DetailResponse(msg)


### PR DESCRIPTION
Having access to this message in Splunk will make it significantly easier to identify honor courses that have not been migrated to Otto. XCOM-553.

@clintonb and @jimabramson, please review. @peter-fogg, FYI. Thanks for letting us onto the RC train!
