### PR TITLE
Readd CcxMembership model for migration

### DIFF
--- a/lms/djangoapps/ccx/models.py
+++ b/lms/djangoapps/ccx/models.py
@@ -9,6 +9,7 @@ from django.db import models
 from django.utils.timezone import UTC
 
 from lazy import lazy
+from student.models import CourseEnrollment, AlreadyEnrolledError  # pylint: disable=import-error
 from xmodule_django.models import CourseKeyField, LocationKeyField  # pylint: disable=import-error
 from xmodule.error_module import ErrorDescriptor
 from xmodule.modulestore.django import modulestore
@@ -93,6 +94,43 @@ class CustomCourseForEdX(models.Model):
         if format_string == 'DATE_TIME':
             value += u' UTC'
         return value
+
+
+class CcxMembership(models.Model):
+    """
+    Which students are in a CCX?
+    """
+    ccx = models.ForeignKey(CustomCourseForEdX, db_index=True)
+    student = models.ForeignKey(User, db_index=True)
+    active = models.BooleanField(default=False)
+
+    @classmethod
+    def auto_enroll(cls, student, future_membership):
+        """convert future_membership to an active membership
+        """
+        if not future_membership.auto_enroll:
+            msg = "auto enrollment not allowed for {}"
+            raise ValueError(msg.format(future_membership))
+        membership = cls(
+            ccx=future_membership.ccx, student=student, active=True
+        )
+        try:
+            CourseEnrollment.enroll(
+                student, future_membership.ccx.course_id, check_access=True
+            )
+        except AlreadyEnrolledError:
+            # if the user is already enrolled in the course, great!
+            pass
+
+        membership.save()
+        future_membership.delete()
+
+    @classmethod
+    def memberships_for_user(cls, user, active=True):
+        """
+        active memberships for a user
+        """
+        return cls.objects.filter(student=user, active__exact=active)
 
 
 class CcxFieldOverride(models.Model):


### PR DESCRIPTION
There is a CCX migration which requires the CcxMembership model, but the PR simultaneously removed the model.
