### PR TITLE
Remove edX branding from community pages

### DIFF
--- a/common/test/acceptance/tests/lms/test_learner_profile.py
+++ b/common/test/acceptance/tests/lms/test_learner_profile.py
@@ -381,12 +381,12 @@ class OwnLearnerProfilePageTest(LearnerProfileTestMixin, WebAppTest):
         And I reload the page.
         Then displayed about me should be `Eat Sleep Code` and about me field mode should be `display`
         Then I set empty value for about me.
-        Then displayed about me should be `Tell other edX learners a little about yourself: where you live,
-        what your interests are, why you're taking courses on edX, or what you hope to learn.` and about me
+        Then displayed about me should be `Tell other learners a little about yourself: where you live,
+        what your interests are, why you're taking courses, or what you hope to learn.` and about me
         field mode should be `placeholder`
         And I reload the page.
-        Then displayed about me should be `Tell other edX learners a little about yourself: where you live,
-        what your interests are, why you're taking courses on edX, or what you hope to learn.` and about me
+        Then displayed about me should be `Tell other learners a little about yourself: where you live,
+        what your interests are, why you're taking courses, or what you hope to learn.` and about me
         field mode should be `placeholder`
         And I make `about me` field editable
         Then `about me` field mode should be `edit`

--- a/lms/static/js/spec/student_profile/learner_profile_view_spec.js
+++ b/lms/static/js/spec/student_profile/learner_profile_view_spec.js
@@ -35,7 +35,7 @@ define(['backbone', 'jquery', 'underscore', 'common/js/spec_helpers/ajax_helpers
                     required: true,
                     editable: 'always',
                     showMessages: false,
-                    title: 'edX learners can see my:',
+                    title: 'learners can see my:',
                     valueAttribute: "account_privacy",
                     options: [
                         ['all_users', 'Full Profile'],
@@ -98,8 +98,8 @@ define(['backbone', 'jquery', 'underscore', 'common/js/spec_helpers/ajax_helpers
                         editable: editable,
                         showMessages: false,
                         title: 'About me',
-                        placeholderValue: "Tell other edX learners a little about yourself: where you live, " +
-                            "what your interests are, why you're taking courses on edX, or what you hope to learn.",
+                        placeholderValue: "Tell other learners a little about yourself: where you live, " +
+                            "what your interests are, why you're taking courses, or what you hope to learn.",
                         valueAttribute: "bio",
                         helpMessage: '',
                         messagePosition: 'header'

--- a/lms/static/js/spec/views/fields_spec.js
+++ b/lms/static/js/spec/views/fields_spec.js
@@ -234,8 +234,8 @@ define(['backbone', 'jquery', 'underscore', 'common/js/spec_helpers/ajax_helpers
                     title: 'About me',
                     valueAttribute: 'bio',
                     helpMessage: 'Wicked is good',
-                    placeholderValue: "Tell other edX learners a little about yourself: where you live, " +
-                        "what your interests are, why you’re taking courses on edX, or what you hope to learn.",
+                    placeholderValue: "Tell other learners a little about yourself: where you live, " +
+                        "what your interests are, why you’re taking courses, or what you hope to learn.",
                     editable: 'never',
                     persistChanges: true,
                     messagePosition: 'header'
@@ -265,8 +265,8 @@ define(['backbone', 'jquery', 'underscore', 'common/js/spec_helpers/ajax_helpers
                     title: 'About me',
                     valueAttribute: 'bio',
                     helpMessage: 'Wicked is good',
-                    placeholderValue: "Tell other edX learners a little about yourself: where you live, " +
-                        "what your interests are, why you’re taking courses on edX, or what you hope to learn.",
+                    placeholderValue: "Tell other learners a little about yourself: where you live, " +
+                        "what your interests are, why you’re taking courses, or what you hope to learn.",
                     editable: 'toggle',
                     persistChanges: true,
                     messagePosition: 'header'

--- a/lms/static/js/student_profile/views/learner_profile_factory.js
+++ b/lms/static/js/student_profile/views/learner_profile_factory.js
@@ -45,9 +45,7 @@
                 required: true,
                 editable: 'always',
                 showMessages: false,
-                title: interpolate_text(
-                    gettext('{platform_name} learners can see my:'), {platform_name: options.platform_name}
-                ),
+                title: gettext('learners can see my:'),
                 valueAttribute: "account_privacy",
                 options: [
                     ['private', gettext('Limited Profile')],

--- a/lms/templates/student_profile/learner_profile.underscore
+++ b/lms/templates/student_profile/learner_profile.underscore
@@ -19,7 +19,7 @@
                     <% if(ownProfile) { %>
                         <span class="profile-private--message" tabindex="0"><%- gettext("You are currently sharing a limited profile.") %></span>
                     <% } else {  %>
-                        <span class="profile-private--message" tabindex="0"><%- gettext("This edX learner is currently sharing a limited profile.") %></span>
+                        <span class="profile-private--message" tabindex="0"><%- gettext("This learner is currently sharing a limited profile.") %></span>
                     <% } %>
                 <% } %>
             </div>


### PR DESCRIPTION
This removes edx-specific branding, while also displaying the text
consistently across the platform.
