### PR TITLE
Add Peer Instruction (PI) XBlock

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1005,6 +1005,9 @@ ADVANCED_COMPONENT_TYPES = [
 
     # In-course reverification checkpoint
     'edx-reverification-block',
+
+    # Peer instruction tool
+    'ubcpi',
 ]
 
 # Adding components in this list will disable the creation of new problem for

--- a/requirements/edx/edx-private.txt
+++ b/requirements/edx/edx-private.txt
@@ -18,3 +18,6 @@
 # This repository contains schoolyourself-xblock, which is used in
 # edX's "AlgebraX" and "GeometryX" courses.
 -e git+https://github.com/schoolyourself/schoolyourself-xblock.git@5e4d37716e3e72640e832e961f7cc0d38d4ec47b#egg=schoolyourself-xblock
+
+# Peer instruction xblock
+ubcpi-xblock==0.4.4


### PR DESCRIPTION
This xblock allow instructors to use peer instruction pedagogy (https://en.wikipedia.org/wiki/Peer_instruction) in edx environment.

Please see more details and source code: https://github.com/ubc/ubcpi
Some instructions on how to use it: https://github.com/ubc/ubcpi/wiki
Here are some discussion around PI: https://groups.google.com/d/msg/edx-code/rMmWKJgELUk/LIb46ObF8-AJ

Here is the PR on ubcpi repo for review: https://github.com/ubc/ubcpi/pull/27
