### PR TITLE
settings.STUDIO_SHORT_NAME doesn't exist in LMS

### DIFF
--- a/lms/templates/courseware/info.html
+++ b/lms/templates/courseware/info.html
@@ -50,9 +50,7 @@ $(document).ready(function(){
       % if studio_url is not None and masquerade and masquerade.role == 'staff':
         <div class="wrap-instructor-info studio-view">
           <a class="instructor-info-action" href="${studio_url}">
-            ${_("View Updates in {studio_name}").format(
-                studio_name=settings.STUDIO_SHORT_NAME,
-            )}
+            ${_("View Updates in Studio")}
           </a>
         </div>
       % endif


### PR DESCRIPTION
@sarina: thanks for catching this in https://github.com/edx/edx-platform/pull/9210#discussion_r36634724 -- looks like we don't set this variable in the LMS, after all.
