### PR TITLE
Refactor GroupConfiguration to allow multiple user partitions

### DIFF
--- a/cms/djangoapps/contentstore/course_group_config.py
+++ b/cms/djangoapps/contentstore/course_group_config.py
@@ -10,7 +10,7 @@ from django.utils.translation import ugettext as _
 from contentstore.utils import reverse_usage_url
 from xmodule.partitions.partitions import UserPartition
 from xmodule.split_test_module import get_split_user_partitions
-from openedx.core.djangoapps.course_groups.partition_scheme import get_cohorted_user_partition
+from openedx.core.djangoapps.course_groups.partition_scheme import get_cohorted_user_partition_for_course
 
 MINIMUM_GROUP_ID = 100
 
@@ -199,6 +199,8 @@ class GroupConfiguration(object):
         """
         Returns all units names and their urls.
 
+        This will return only groups for the cohort user partition.
+
         Returns:
         {'group_id':
             [
@@ -214,25 +216,22 @@ class GroupConfiguration(object):
         }
         """
         usage_info = {}
-        for item in items:
-            if hasattr(item, 'group_access') and item.group_access:
-                (__, group_ids), = item.group_access.items()
-                for group_id in group_ids:
-                    if group_id not in usage_info:
-                        usage_info[group_id] = []
+        for item, group_id in GroupConfiguration._iterate_items_and_content_group_ids(course, items):
+            if group_id not in usage_info:
+                usage_info[group_id] = []
 
-                    unit = item.get_parent()
-                    if not unit:
-                        log.warning("Unable to find parent for component %s", item.location)
-                        continue
+            unit = item.get_parent()
+            if not unit:
+                log.warning("Unable to find parent for component %s", item.location)
+                continue
 
-                    usage_info = GroupConfiguration._get_usage_info(
-                        course,
-                        unit=unit,
-                        item=item,
-                        usage_info=usage_info,
-                        group_id=group_id
-                    )
+            usage_info = GroupConfiguration._get_usage_info(
+                course,
+                unit=unit,
+                item=item,
+                usage_info=usage_info,
+                group_id=group_id
+            )
 
         return usage_info
 
@@ -250,6 +249,8 @@ class GroupConfiguration(object):
         """
         Returns all items names and their urls.
 
+        This will return only groups for the cohort user partition.
+
         Returns:
         {'group_id':
             [
@@ -265,22 +266,37 @@ class GroupConfiguration(object):
         }
         """
         usage_info = {}
-        for item in items:
-            if hasattr(item, 'group_access') and item.group_access:
-                (__, group_ids), = item.group_access.items()
-                for group_id in group_ids:
-                    if group_id not in usage_info:
-                        usage_info[group_id] = []
+        for item, group_id in GroupConfiguration._iterate_items_and_content_group_ids(course, items):
+            if group_id not in usage_info:
+                usage_info[group_id] = []
 
-                    usage_info = GroupConfiguration._get_usage_info(
-                        course,
-                        unit=item,
-                        item=item,
-                        usage_info=usage_info,
-                        group_id=group_id
-                    )
+            usage_info = GroupConfiguration._get_usage_info(
+                course,
+                unit=item,
+                item=item,
+                usage_info=usage_info,
+                group_id=group_id
+            )
 
         return usage_info
+
+    @staticmethod
+    def _iterate_items_and_content_group_ids(course, items):
+        """
+        Iterate through items and content group IDs in a course.
+
+        This will yield group IDs *only* for cohort user partitions.
+
+        Yields: tuple of (item, group_id)
+        """
+        content_group_configuration = get_cohorted_user_partition_for_course(course)
+        if content_group_configuration is not None:
+            for item in items:
+                if hasattr(item, 'group_access') and item.group_access:
+                    group_ids = item.group_access.get(content_group_configuration.id, [])
+
+                    for group_id in group_ids:
+                        yield item, group_id
 
     @staticmethod
     def update_usage_info(store, course, configuration):
@@ -329,7 +345,7 @@ class GroupConfiguration(object):
         the client explicitly creates a group within the partition and
         POSTs back.
         """
-        content_group_configuration = get_cohorted_user_partition(course.id)
+        content_group_configuration = get_cohorted_user_partition_for_course(course)
         if content_group_configuration is None:
             content_group_configuration = UserPartition(
                 id=generate_int_id(MINIMUM_GROUP_ID, MYSQL_MAX_INT, GroupConfiguration.get_used_ids(course)),

--- a/openedx/core/djangoapps/course_groups/partition_scheme.py
+++ b/openedx/core/djangoapps/course_groups/partition_scheme.py
@@ -107,6 +107,14 @@ def get_cohorted_user_partition(course_key):
     one cohorted user partition.
     """
     course = courses.get_course_by_id(course_key)
+    return get_cohorted_user_partition_for_course(course)
+
+
+def get_cohorted_user_partition_for_course(course):  # pylint: disable=invalid-name
+    """
+    Retrieve the first user partition in the course which uses the CohortPartitionScheme.
+    Unlike `get_cohorted_user_partition`, this does NOT look up the course by its course key.
+    """
     for user_partition in course.user_partitions:
         if user_partition.scheme == CohortPartitionScheme:
             return user_partition


### PR DESCRIPTION
The code used to assume that a single user partition was defined
for cohorted courses.  This change looks up groups for the user partition
specifically for cohorted courses, for compatibility with other
user partitions.

@zubair-arbi I believe this should resolve the `ValueError` you were seeing on the ICRV feature branch.

@jimabramson and @dsego could I trouble you both for a review?  @dsego it looks like this is used primarily by courseware search -- how would I go about testing this?
