### PR TITLE
Make custom themes work on microsites.

### DIFF
--- a/common/djangoapps/edxmako/shortcuts.py
+++ b/common/djangoapps/edxmako/shortcuts.py
@@ -81,22 +81,21 @@ def open_source_footer_context_processor(request):
     """
     Checks the site name to determine whether to use the edX.org footer or the Open Source Footer.
     """
-    return dict(
-        [
-            ("IS_EDX_DOMAIN", settings.FEATURES.get('IS_EDX_DOMAIN', False))
-        ]
-    )
+    return {'IS_EDX_DOMAIN': settings.FEATURES.get('IS_EDX_DOMAIN', False)}
 
 
 def microsite_footer_context_processor(request):
     """
     Checks the site name to determine whether to use the edX.org footer or the Open Source Footer.
     """
-    return dict(
-        [
-            ("IS_REQUEST_IN_MICROSITE", microsite.is_request_in_microsite())
-        ]
-    )
+    return {'IS_REQUEST_IN_MICROSITE': microsite.is_request_in_microsite()}
+
+
+def custom_theme_context_processor(request):  # pylint: disable=unused-argument
+    """
+    Sets a boolean context variable to indicate whether the site uses a custom theme.
+    """
+    return {'THEME_ENABLED': settings.FEATURES.get('USE_CUSTOM_THEME', False)}
 
 
 def render_to_string(template_name, dictionary, context=None, namespace='main'):

--- a/common/djangoapps/edxmako/tests.py
+++ b/common/djangoapps/edxmako/tests.py
@@ -15,7 +15,8 @@ from edxmako import add_lookup, LOOKUP
 from edxmako.shortcuts import (
     marketing_link,
     render_to_string,
-    open_source_footer_context_processor
+    open_source_footer_context_processor,
+    custom_theme_context_processor
 )
 from student.tests.factories import UserFactory
 from util.testing import UrlResetMixin
@@ -49,6 +50,14 @@ class ShortcutsTests(UrlResetMixin, TestCase):
         }):
             result = open_source_footer_context_processor({})
             self.assertEquals(expected_result, result.get('IS_EDX_DOMAIN'))
+
+    @ddt.data(True, False)
+    def test_custom_theme(self, expected_result):
+        with patch.dict('django.conf.settings.FEATURES', {
+            'USE_CUSTOM_THEME': expected_result
+        }):
+            result = custom_theme_context_processor({})
+            self.assertEquals(expected_result, result.get('THEME_ENABLED'))
 
 
 class AddLookupTests(TestCase):

--- a/common/djangoapps/microsite_configuration/microsite.py
+++ b/common/djangoapps/microsite_configuration/microsite.py
@@ -72,10 +72,7 @@ def get_template_path(relative_path):
         search_path = os.path.join(microsite_template_path, relative_path)
 
         if os.path.isfile(search_path):
-            path = '/{0}/templates/{1}'.format(
-                get_value('microsite_name'),
-                relative_path
-            )
+            path = os.path.join(get_value('microsite_name'), 'templates', relative_path)
             return path
 
     return relative_path

--- a/common/djangoapps/microsite_configuration/templatetags/microsite.py
+++ b/common/djangoapps/microsite_configuration/templatetags/microsite.py
@@ -62,3 +62,13 @@ def microsite_css_overrides_file():
         return "<link href='{}' rel='stylesheet' type='text/css'>".format(static(file_path))
     else:
         return ""
+
+
+@register.filter(name="microsite_template_path")
+def microsite_template_path(relative_path):
+    """
+    Django filter that resolves relative path to a template. The resolved path can either
+    be in a microsite directory (as an override) or will just return what is passed in.
+    {% include "some template"|microsite_template_path %}
+    """
+    return microsite.get_template_path(relative_path)

--- a/common/djangoapps/microsite_configuration/tests/test_microsites.py
+++ b/common/djangoapps/microsite_configuration/tests/test_microsites.py
@@ -2,6 +2,7 @@
 """
 Tests microsite_configuration templatetags and helper functions.
 """
+from mock import patch
 from django.test import TestCase
 from django.conf import settings
 from microsite_configuration.templatetags import microsite
@@ -32,3 +33,14 @@ class MicroSiteTests(TestCase):
         expected = u'my | less specific | Page | edX'
         title = microsite.page_title_breadcrumbs_tag(None, *crumbs)
         self.assertEqual(expected, title)
+
+    def test_microsite_template_path(self):
+        relative_path = 'some_template.html'
+        resolved_path = 'resolved/path/to/some_template.html'
+        with patch(
+            'microsite_configuration.microsite.get_template_path',
+            return_value=resolved_path
+        ) as mock:
+            result = microsite.microsite_template_path(relative_path)
+            mock.assert_called_once_with(relative_path)
+            self.assertEqual(result, resolved_path)

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -539,6 +539,9 @@ TEMPLATE_CONTEXT_PROCESSORS = (
 
     # Allows the open edX footer to be leveraged in Django Templates.
     'edxmako.shortcuts.microsite_footer_context_processor',
+
+    # Allows custom theme overrides to be used in Django Templates.
+    'edxmako.shortcuts.custom_theme_context_processor',
 )
 
 # use the ratelimit backend to prevent brute force attacks

--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -86,13 +86,12 @@ from branding import api as branding_api
   <%block name="headextra"/>
 
 <%
-  if theme_enabled() and not is_microsite():
-    header_extra_file = 'theme-head-extra.html'
-    header_file = 'theme-header.html'
-    google_analytics_file = 'theme-google-analytics.html'
+  style_overrides_file = microsite.get_value('css_overrides_file')
 
-    style_overrides_file = None
-
+  if theme_enabled():
+    header_extra_file = microsite.get_template_path('theme-head-extra.html')
+    header_file = microsite.get_template_path('theme-header.html')
+    google_analytics_file = microsite.get_template_path('theme-google-analytics.html')
   else:
     header_extra_file = None
 
@@ -102,8 +101,6 @@ from branding import api as branding_api
         header_file = microsite.get_template_path('navigation.html')
 
     google_analytics_file = microsite.get_template_path('google_analytics.html')
-
-    style_overrides_file = microsite.get_value('css_overrides_file')
 %>
 
   % if header_extra_file:
@@ -142,8 +139,8 @@ from branding import api as branding_api
     % if not disable_footer:
         <%block name="footer">
           ## Can be overridden by child templates wanting to hide the footer.
-          % if theme_enabled() and not is_microsite():
-            <%include file="theme-footer.html" />
+          % if theme_enabled():
+            <%include file="${microsite.get_template_path('theme-footer.html')}" />
           % elif settings.FEATURES.get('IS_EDX_DOMAIN', False) and not is_microsite():
               <%include file="footer-edx-v3.html" />
           % else:

--- a/lms/templates/main_django.html
+++ b/lms/templates/main_django.html
@@ -21,6 +21,10 @@
   {% block headextra %}{% endblock %}
   {% render_block "css" %}
 
+  {% if THEME_ENABLED %}
+    {% include "theme-head-extra.html"|microsite_template_path %}
+  {% endif %}
+
   {% microsite_css_overrides_file %}
 
   <meta name="path_prefix" content="{{EDX_ROOT_URL}}">
@@ -30,22 +34,24 @@
   <div class="window-wrap" dir="${static.dir_rtl()}">
     <a class="nav-skip" href="{% block nav_skip %}#content{% endblock %}">{% trans "Skip to main content" %}</a>
     {% with course=request.course %}
-      {% if IS_EDX_DOMAIN %}
+      {% if THEME_ENABLED %}
+        {% include "theme-header.html"|microsite_template_path %}
+      {% elif IS_EDX_DOMAIN and not IS_REQUEST_IN_MICROSITE %}
         {% include "navigation-edx.html" %}
       {% else %}
-        {% include "navigation.html" %}
+        {% include "navigation.html"|microsite_template_path %}
       {% endif %}
     {% endwith %}
     <div class="content-wrapper" id="content">
       {% block body %}{% endblock %}
       {% block bodyextra %}{% endblock %}
     </div>
-    {% if IS_REQUEST_IN_MICROSITE %}
-    {# For now we don't support overriden Django templates in microsites. Leave footer blank for now which is better than saying Edx.#}
-    {% elif IS_EDX_DOMAIN %}
+    {% if THEME_ENABLED %}
+      {% include "theme-footer.html"|microsite_template_path %}
+    {% elif IS_EDX_DOMAIN and not IS_REQUEST_IN_MICROSITE %}
       {% include "footer-edx-v3.html" %}
     {% else %}
-      {% include "footer.html" %}
+      {% include "footer.html"|microsite_template_path %}
     {% endif %}
 
   </div>


### PR DESCRIPTION
**Background**: Custom themes currently don't work on microsites. Custom theme only works on the base site (and only if there is no default microsite configured), while requests to microsites use the default edX theme with optional microsite template overrides. In most cases this is not the desired behavior - when you install a custom theme you will most likely want it to work on the base site as well as any configured microsites. Custom themes and microsites were previously discussed [here](https://groups.google.com/forum/#!topic/edx-code/YVfnnX9xCKM). The discussion resulted in the patch at https://github.com/edx/edx-platform/pull/3495 which enabled microsite template overrides to work on sites with custom themes, but it has a side-effect of completely disabling custom themes on microsites. This patch enables custom themes on microsites while still allowing microsites to override specific templates.
**JIRA ticket**: https://openedx.atlassian.net/browse/OSPR-748
**Partner information**: not an edX partner - 3rd party-hosted open edX instance
**Reviewers**: @smarnach & TBD

This patch enables custom themes on microsites. Microsites can still override specific templates, although when a custom theme is enabled, microsites have to override theme templates (theme-header.html, theme-footer.html...) rather than default edX templates (navigation.html, footer.html...). I believe this makes sense since with a custom theme installed, microsites will be building upon the theme rather that the default edX look.

This patch also makes the [main_django.html template](https://github.com/edx/edx-platform/blob/8e1d0f7f23794783a85fe6938839942b510221a3/lms/templates/main_django.html) custom theme friendly, so that custom themes don't have to [override the entire file](https://github.com/IONISx/edx-theme/blob/41bc8aba4021dceed5305dfbd855a6c48abaf56e/templates/main_django.html). It also makes the main_django.html template microsite override friendly.

Note that this change is NOT backwards compatible. If an Open edX instance was configured with both a custom theme and microsites, the microsites will start using the custom theme after deploying this patch, while they were using the default edX theme before the patch.
If desired, we could add a flag to microsite configuration to disable custom theme on the microsite level. I didn't implement it yet, because I'm not sure how useful that would be, but will be happy to do it if there is need for it.

To test this change, install a custom theme, for example https://github.com/Stanford-Online/edx-theme. Ensure that the custom theme is working, then configure a microsite (https://github.com/edx/edx-platform/wiki/Microsites-Theming). If you visit the microsite without this patch, you will see the default edX theme. If you visit the microsite with this patch applied, you will see the custom theme.
