### PR TITLE
TNL-2962 Add course_id filtering to team_membership API endpoint

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -231,3 +231,4 @@ Vedran Karačić <vedran@edx.org>
 William Ono <william.ono@ubc.ca>
 Dongwook Yoon <dy252@cornell.edu>
 Awais Qureshi <awais.qureshi@arbisoft.com>
+Eric Fischer <efischer@edx.org>


### PR DESCRIPTION
Adding tests for new course_id filtering behavior in team_membership endpoint. Behavior has been documented at https://openedx.atlassian.net/wiki/display/TNL/Team+API.

The tests are currently failing as I have yet to implement the actual behavior.
