### PR TITLE
Implement model refreshing for Teams tab

### DIFF
--- a/common/static/common/js/spec_helpers/ajax_helpers.js
+++ b/common/static/common/js/spec_helpers/ajax_helpers.js
@@ -1,5 +1,7 @@
-define(['sinon', 'underscore'], function(sinon, _) {
-    var fakeServer, fakeRequests, expectRequest, expectJsonRequest, expectPostRequest,
+define(['sinon', 'underscore', 'URI'], function(sinon, _, URI) {
+    'use strict';
+
+    var fakeServer, fakeRequests, expectRequest, expectJsonRequest, expectPostRequest, expectJsonRequestURL,
         respondWithJson, respondWithError, respondWithTextError, respondWithNoContent;
 
     /* These utility methods are used by Jasmine tests to create a mock server or
@@ -66,6 +68,24 @@ define(['sinon', 'underscore'], function(sinon, _) {
         expect(request.url).toEqual(url);
         expect(request.method).toEqual(method);
         expect(JSON.parse(request.requestBody)).toEqual(jsonRequest);
+    };
+
+    /**
+     * Expect that a JSON request be made with the given URL and parameters.
+     * @param requests The collected requests
+     * @param expectedUrl The expected URL excluding the parameters
+     * @param expectedParameters An object representing the URL parameters
+     * @param requestIndex An optional index for the request (by default, the last request is used)
+     */
+    expectJsonRequestURL = function(requests, expectedUrl, expectedParameters, requestIndex) {
+        var request, parameters;
+        if (_.isUndefined(requestIndex)) {
+            requestIndex = requests.length - 1;
+        }
+        request = requests[requestIndex];
+        parameters = new URI(request.url).query(true);
+        delete parameters._;  // Ignore the cache-busting argument
+        expect(parameters).toEqual(expectedParameters);
     };
 
     /**
@@ -136,6 +156,7 @@ define(['sinon', 'underscore'], function(sinon, _) {
         'requests': fakeRequests,
         'expectRequest': expectRequest,
         'expectJsonRequest': expectJsonRequest,
+        'expectJsonRequestURL': expectJsonRequestURL,
         'expectPostRequest': expectPostRequest,
         'respondWithJson': respondWithJson,
         'respondWithError': respondWithError,

--- a/common/test/acceptance/tests/lms/test_teams.py
+++ b/common/test/acceptance/tests/lms/test_teams.py
@@ -113,6 +113,12 @@ class TeamsTabBase(UniqueCourseTest):
         ]
         map(assert_team_equal, expected_teams, team_card_names, team_card_descriptions)
 
+    def verify_my_team_count(self, expected_number_of_teams):
+        """ Verify the number of teams shown on "My Team". """
+
+        # We are doing these operations on this top-level page object to avoid reloading the page.
+        self.teams_page.verify_my_team_count(expected_number_of_teams)
+
 
 @ddt.ddt
 @attr('shard_5')
@@ -530,35 +536,6 @@ class BrowseTeamsWithinTopicTest(TeamsTabBase):
         self.browse_teams_page.go_to_page(1)
         self.verify_on_page(1, teams, 'Showing 1-10 out of 20 total', True)
 
-    @ddt.data(
-        ['Moderator', False]
-        ['Community TA', False],
-        ['Administrator', False]
-    )
-    def test_create_team(self, role, should_join_team):
-        """
-        Scenario: Team cards correctly reflect membership of the team.
-        Given I am enrolled in a course with a team configuration and a topic
-            containing one team
-        And I add myself to the team
-        When I visit the Teams page for that topic
-        Then I should see the correct page header
-        And I should see the team for that topic
-        And I should see that the team card shows my membership
-        When I visit the My Teams page
-        """
-        teams = self.create_teams(self.topic, 1)
-        self.browse_teams_page.visit()
-        self.verify_page_header()
-        self.verify_teams(self.browse_teams_page, teams)
-        self.create_membership(self.user_info['username'], teams[0]['id'])
-        self.browser.refresh()
-        self.browse_teams_page.wait_for_ajax()
-        self.assertEqual(
-            self.browse_teams_page.team_cards[0].find_element_by_css_selector('.member-count').text,
-            '1 / 10 Members'
-        )
-
     def test_navigation_links(self):
         """
         Scenario: User should be able to navigate to "browse all teams" and "search team description" links.
@@ -720,6 +697,9 @@ class CreateTeamTest(TeamsTabBase):
         And I click Create button
         Then I should see the page for my team
         And I should see the message that says "You are member of this team"
+        And the new team should be added to the list of teams within the topic
+        And the number of teams should be updated on the topic card
+        And if I switch to "My Team", the newly created team is displayed
         """
         self.verify_and_navigate_to_create_team_page()
 
@@ -733,6 +713,16 @@ class CreateTeamTest(TeamsTabBase):
         self.assertEqual(team_page.team_description, 'The Avengers are a fictional team of superheroes.')
         self.assertEqual(team_page.team_user_membership_text, 'You are a member of this team.')
 
+        # Verify the new team was added to the topic list
+        self.teams_page.click_specific_topic("Example Topic")
+        self.teams_page.verify_topic_team_count(1)
+
+        self.teams_page.click_all_topics()
+        self.teams_page.verify_team_count_in_first_topic(1)
+
+        # Verify that if one switches to "My Team" without reloading the page, the newly created team is shown.
+        self.verify_my_team_count(1)
+
     def test_user_can_cancel_the_team_creation(self):
         """
         Scenario: The user should be able to cancel the creation of new team.
@@ -741,6 +731,7 @@ class CreateTeamTest(TeamsTabBase):
         Then I should see the Create Team header and form
         When I click Cancel button
         Then I should see teams list page without any new team.
+        And if I switch to "My Team", it shows no teams
         """
         self.assertEqual(self.browse_teams_page.get_pagination_header_text(), 'Showing 0 out of 0 total')
 
@@ -749,6 +740,11 @@ class CreateTeamTest(TeamsTabBase):
 
         self.assertTrue(self.browse_teams_page.is_browser_on_page())
         self.assertEqual(self.browse_teams_page.get_pagination_header_text(), 'Showing 0 out of 0 total')
+
+        self.teams_page.click_all_topics()
+        self.teams_page.verify_team_count_in_first_topic(0)
+
+        self.verify_my_team_count(0)
 
 
 @attr('shard_5')
@@ -887,11 +883,7 @@ class TeamPageTest(TeamsTabBase):
         """
         self.assertEqual(
             self.team_page.team_capacity_text,
-            '{num_members} / {max_size} {members_text}'.format(
-                num_members=num_members,
-                max_size=max_size,
-                members_text='Member' if num_members == max_size else 'Members'
-            )
+            self.team_page.format_capacity_text(num_members, max_size)
         )
         self.assertEqual(self.team_page.team_location, 'Afghanistan')
         self.assertEqual(self.team_page.team_language, 'Afar')
@@ -980,6 +972,7 @@ class TeamPageTest(TeamsTabBase):
         Then there should be no Join Team button and no message
         And I should see the updated information under Team Details
         And I should see New Post button
+        And if I switch to "My Team", the team I have joined is displayed
         """
         self._set_team_configuration_and_membership(create_membership=False)
         self.team_page.visit()
@@ -988,6 +981,10 @@ class TeamPageTest(TeamsTabBase):
         self.assertFalse(self.team_page.join_team_button_present)
         self.assertFalse(self.team_page.join_team_message_present)
         self.assert_team_details(num_members=1, is_member=True)
+
+        # Verify that if one switches to "My Team" without reloading the page, the newly created team is shown.
+        self.teams_page.click_all_topics()
+        self.verify_my_team_count(1)
 
     def test_already_member_message(self):
         """
@@ -1042,6 +1039,7 @@ class TeamPageTest(TeamsTabBase):
         Then user should be removed from team
         And I should see Join Team button
         And I should not see New Post button
+        And if I switch to "My Team", the team I have left is not displayed
         """
         self._set_team_configuration_and_membership()
         self.team_page.visit()
@@ -1050,3 +1048,7 @@ class TeamPageTest(TeamsTabBase):
         self.team_page.click_leave_team_link()
         self.assert_team_details(num_members=0, is_member=False)
         self.assertTrue(self.team_page.join_team_button_present)
+
+        # Verify that if one switches to "My Team" without reloading the page, the old team no longer shows.
+        self.teams_page.click_all_topics()
+        self.verify_my_team_count(0)

--- a/common/test/acceptance/tests/lms/test_teams.py
+++ b/common/test/acceptance/tests/lms/test_teams.py
@@ -248,7 +248,7 @@ class MyTeamsTest(TeamsTabBase):
         self.assertEqual(len(self.my_teams_page.team_cards), 0, msg='Expected to see no team cards')
         self.assertEqual(
             self.my_teams_page.q(css='.page-content-main').text,
-            [u'You are not currently a member of any teams.']
+            [u'You are not currently a member of any team.']
         )
 
     def test_member_of_a_team(self):
@@ -530,7 +530,12 @@ class BrowseTeamsWithinTopicTest(TeamsTabBase):
         self.browse_teams_page.go_to_page(1)
         self.verify_on_page(1, teams, 'Showing 1-10 out of 20 total', True)
 
-    def test_teams_membership(self):
+    @ddt.data(
+        ['Moderator', False]
+        ['Community TA', False],
+        ['Administrator', False]
+    )
+    def test_create_team(self, role, should_join_team):
         """
         Scenario: Team cards correctly reflect membership of the team.
         Given I am enrolled in a course with a team configuration and a topic
@@ -540,6 +545,7 @@ class BrowseTeamsWithinTopicTest(TeamsTabBase):
         Then I should see the correct page header
         And I should see the team for that topic
         And I should see that the team card shows my membership
+        When I visit the My Teams page
         """
         teams = self.create_teams(self.topic, 1)
         self.browse_teams_page.visit()
@@ -548,11 +554,10 @@ class BrowseTeamsWithinTopicTest(TeamsTabBase):
         self.create_membership(self.user_info['username'], teams[0]['id'])
         self.browser.refresh()
         self.browse_teams_page.wait_for_ajax()
-        ## TODO: fix this!
-        # self.assertEqual(
-        #     self.browse_teams_page.team_cards[0].find_element_by_css_selector('.member-count').text,
-        #     '1 / 10 Members'
-        # )
+        self.assertEqual(
+            self.browse_teams_page.team_cards[0].find_element_by_css_selector('.member-count').text,
+            '1 / 10 Members'
+        )
 
     def test_navigation_links(self):
         """

--- a/lms/djangoapps/teams/static/teams/js/collections/base.js
+++ b/lms/djangoapps/teams/static/teams/js/collections/base.js
@@ -1,0 +1,43 @@
+;(function (define) {
+    'use strict';
+    define(['common/js/components/collections/paging_collection'],
+        function(PagingCollection) {
+            var BaseCollection = PagingCollection.extend({
+                initialize: function(options) {
+                    PagingCollection.prototype.initialize.call(this);
+
+                    this.course_id = options.course_id;
+                    this.perPage = options.per_page;
+
+                    this.teamEvents = options.teamEvents;
+                    this.teamEvents.bind('teams:update', this.onUpdate, this);
+                    this.isStale = false;
+                },
+
+                onUpdate: function(event) {
+                    this.isStale = true;
+                },
+
+                /**
+                 * Refreshes the collection if it has been marked as stale.
+                 * @param force If true, it will always refresh.
+                 * @returns {promise} Returns a promise representing the refresh
+                 */
+                refresh: function(force) {
+                    var self = this,
+                        deferred = $.Deferred();
+                    if (force || this.isStale) {
+                        this.fetch()
+                            .done(function() {
+                                self.isStale = false;
+                                deferred.resolve();
+                            });
+                    } else {
+                        deferred.resolve();
+                    }
+                    return deferred.promise();
+                }
+            });
+            return BaseCollection;
+        });
+}).call(this, define || RequireJS.define);

--- a/lms/djangoapps/teams/static/teams/js/collections/team.js
+++ b/lms/djangoapps/teams/static/teams/js/collections/team.js
@@ -1,18 +1,22 @@
 ;(function (define) {
     'use strict';
-    define(['common/js/components/collections/paging_collection', 'teams/js/models/team', 'gettext'],
-        function(PagingCollection, TeamModel, gettext) {
-            var TeamCollection = PagingCollection.extend({
+    define(['teams/js/collections/base', 'teams/js/models/team', 'gettext'],
+        function(BaseCollection, TeamModel, gettext) {
+            var TeamCollection = BaseCollection.extend({
                 initialize: function(teams, options) {
-                    PagingCollection.prototype.initialize.call(this);
+                    var self = this;
+                    BaseCollection.prototype.initialize.call(this, options);
 
-                    this.course_id = options.course_id;
-                    this.server_api['topic_id'] = this.topic_id = options.topic_id;
-                    this.server_api['expand'] = 'user';
-                    this.perPage = options.per_page;
-                    this.server_api['course_id'] = function () { return encodeURIComponent(this.course_id); };
-                    this.server_api['order_by'] = function () { return 'name'; }; // TODO surface sort order in UI
-                    delete this.server_api['sort_order']; // Sort order is not specified for the Team API
+                    this.server_api = _.extend(
+                        {
+                            topic_id: this.topic_id = options.topic_id,
+                            expand: 'user',
+                            course_id: function () { return encodeURIComponent(self.course_id); },
+                            order_by: function () { return 'name'; } // TODO surface sort order in UI
+                        },
+                        BaseCollection.prototype.server_api
+                    );
+                    delete this.server_api.sort_order; // Sort order is not specified for the Team API
 
                     this.registerSortableField('name', gettext('name'));
                     this.registerSortableField('open_slots', gettext('open_slots'));
@@ -21,5 +25,5 @@
                 model: TeamModel
             });
             return TeamCollection;
-    });
+        });
 }).call(this, define || RequireJS.define);

--- a/lms/djangoapps/teams/static/teams/js/collections/team_membership.js
+++ b/lms/djangoapps/teams/static/teams/js/collections/team_membership.js
@@ -1,18 +1,24 @@
 ;(function (define) {
     'use strict';
-    define(['common/js/components/collections/paging_collection', 'teams/js/models/team_membership'],
-        function(PagingCollection, TeamMembershipModel) {
-            var TeamMembershipCollection = PagingCollection.extend({
+    define(['teams/js/collections/base', 'teams/js/models/team_membership'],
+        function(BaseCollection, TeamMembershipModel) {
+            var TeamMembershipCollection = BaseCollection.extend({
                 initialize: function(team_memberships, options) {
-                    PagingCollection.prototype.initialize.call(this);
+                    var self = this;
+                    BaseCollection.prototype.initialize.call(this, options);
 
-                    this.course_id = options.course_id;
+                    this.perPage = options.per_page || 10;
                     this.username = options.username;
                     this.privileged = options.privileged;
-                    this.perPage = options.per_page || 10;
-                    this.server_api['expand'] = 'team';
-                    this.server_api['course_id'] = function () { return encodeURIComponent(options.course_id); };
-                    this.server_api['username'] = this.username;
+
+                    this.server_api = _.extend(
+                        {
+                            expand: 'team',
+                            username: this.username,
+                            course_id: function () { return encodeURIComponent(self.course_id); }
+                        },
+                        BaseCollection.prototype.server_api
+                    );
                     delete this.server_api['sort_order']; // Sort order is not specified for the TeamMembership API
                     delete this.server_api['order_by']; // Order by is not specified for the TeamMembership API
                 },
@@ -28,5 +34,5 @@
                 }
             });
             return TeamMembershipCollection;
-    });
+        });
 }).call(this, define || RequireJS.define);

--- a/lms/djangoapps/teams/static/teams/js/spec/collections/topic_collection_spec.js
+++ b/lms/djangoapps/teams/static/teams/js/spec/collections/topic_collection_spec.js
@@ -1,5 +1,5 @@
-define(['URI', 'underscore', 'common/js/spec_helpers/ajax_helpers', 'teams/js/collections/topic'],
-    function (URI, _, AjaxHelpers, TopicCollection) {
+define(['backbone', 'URI', 'underscore', 'common/js/spec_helpers/ajax_helpers', 'teams/js/collections/topic'],
+    function (Backbone, URI, _, AjaxHelpers, TopicCollection) {
         'use strict';
         describe('TopicCollection', function () {
             var topicCollection;
@@ -39,7 +39,11 @@ define(['URI', 'underscore', 'common/js/spec_helpers/ajax_helpers', 'teams/js/co
                         ],
                         "sort_order": "name"
                     },
-                    {course_id: 'my/course/id', parse: true});
+                    {
+                        teamEvents:_.clone(Backbone.Events),
+                        course_id: 'my/course/id',
+                        parse: true
+                    });
             });
 
             var testRequestParam = function (self, param, value) {

--- a/lms/djangoapps/teams/static/teams/js/spec/views/edit_team_spec.js
+++ b/lms/djangoapps/teams/static/teams/js/spec/views/edit_team_spec.js
@@ -3,13 +3,13 @@ define([
     'underscore',
     'backbone',
     'common/js/spec_helpers/ajax_helpers',
-    'teams/js/views/edit_team'
-], function ($, _, Backbone, AjaxHelpers, TeamEditView) {
+    'teams/js/views/edit_team',
+    'teams/js/spec_helpers/team_spec_helpers'
+], function ($, _, Backbone, AjaxHelpers, TeamEditView, TeamSpecHelpers) {
     'use strict';
 
     describe('EditTeam', function () {
-        var teamEditView,
-            teamsUrl = '/api/team/v0/teams/',
+        var teamsUrl = '/api/team/v0/teams/',
             teamsData = {
                 id: null,
                 name: "TeamName",
@@ -22,7 +22,7 @@ define([
                 language: "a",
                 membership: []
             },
-            verifyValidation = function (requests, fieldsData) {
+            verifyValidation = function (requests, teamEditView, fieldsData) {
                 _.each(fieldsData, function (fieldData) {
                     teamEditView.$(fieldData[0]).val(fieldData[1]);
                 });
@@ -45,24 +45,11 @@ define([
                 });
 
                 expect(requests.length).toBe(0);
-            },
-            expectContent = function (selector, text) {
-                expect(teamEditView.$(selector).text().trim()).toBe(text);
-            },
-            verifyDropdownData = function (selector, expectedItems) {
-                var options = teamEditView.$(selector)[0].options;
-                var renderedItems = $.map(options, function( elem ) {
-                    return [[elem.value, elem.text]];
-                });
-                for (var i = 0; i < expectedItems.length; i++) {
-                    expect(renderedItems).toContain(expectedItems[i]);
-                }
             };
 
-        beforeEach(function () {
-            setFixtures('<div class="teams-content"></div>');
-            spyOn(Backbone.history, 'navigate');
-            teamEditView = new TeamEditView({
+        var createTeamEditView = function() {
+            return new TeamEditView({
+                teamEvents: TeamSpecHelpers.teamEvents,
                 el: $('.teams-content'),
                 teamParams: {
                     teamsUrl: teamsUrl,
@@ -73,6 +60,11 @@ define([
                     countries: [['c', 'ccc'], ['d', 'ddd']]
                 }
             }).render();
+        };
+
+        beforeEach(function () {
+            setFixtures('<div class="teams-content"></div>');
+            spyOn(Backbone.history, 'navigate');
         });
 
         it('can render itself correctly', function () {
@@ -82,7 +74,8 @@ define([
                 '.u-field-optional_description',
                 '.u-field-language',
                 '.u-field-country'
-            ];
+            ],
+                teamEditView = createTeamEditView();
 
             _.each(fieldClasses, function (fieldClass) {
                 expect(teamEditView.$el.find(fieldClass).length).toBe(1);
@@ -93,7 +86,8 @@ define([
         });
 
         it('can create a team', function () {
-            var requests = AjaxHelpers.requests(this);
+            var requests = AjaxHelpers.requests(this),
+                teamEditView = createTeamEditView();
 
             teamEditView.$('.u-field-name input').val(teamsData.name);
             teamEditView.$('.u-field-textarea textarea').val(teamsData.description);
@@ -109,46 +103,49 @@ define([
         });
 
         it('shows validation error message when field is empty', function () {
-            var requests = AjaxHelpers.requests(this);
-            verifyValidation(requests, [
+            var requests = AjaxHelpers.requests(this),
+                teamEditView = createTeamEditView();
+            verifyValidation(requests, teamEditView, [
                 ['.u-field-name input', 'Name', 'success'],
                 ['.u-field-textarea textarea', '', 'error']
             ]);
             teamEditView.render();
-            verifyValidation(requests, [
+            verifyValidation(requests, teamEditView, [
                 ['.u-field-name input', '', 'error'],
                 ['.u-field-textarea textarea', 'description', 'success']
             ]);
             teamEditView.render();
-            verifyValidation(requests, [
+            verifyValidation(requests, teamEditView, [
                 ['.u-field-name input', '', 'error'],
                 ['.u-field-textarea textarea', '', 'error']
             ]);
         });
 
         it('shows validation error message when field value length exceeded the limit', function () {
-            var requests = AjaxHelpers.requests(this);
-            var teamName = new Array(500 + 1).join( '$' );
-            var teamDescription = new Array(500 + 1).join( '$' );
+            var requests = AjaxHelpers.requests(this),
+                teamEditView = createTeamEditView(),
+                teamName = new Array(500 + 1).join( '$'),
+                teamDescription = new Array(500 + 1).join( '$' );
 
-            verifyValidation(requests, [
+            verifyValidation(requests, teamEditView, [
                 ['.u-field-name input', teamName, 'error'],
                 ['.u-field-textarea textarea', 'description', 'success']
             ]);
             teamEditView.render();
-            verifyValidation(requests, [
+            verifyValidation(requests, teamEditView, [
                 ['.u-field-name input', 'name', 'success'],
                 ['.u-field-textarea textarea', teamDescription, 'error']
             ]);
             teamEditView.render();
-            verifyValidation(requests, [
+            verifyValidation(requests, teamEditView, [
                 ['.u-field-name input', teamName, 'error'],
                 ['.u-field-textarea textarea', teamDescription, 'error']
             ]);
         });
 
         it("shows an error message for HTTP 500", function () {
-            var requests = AjaxHelpers.requests(this);
+            var teamEditView = createTeamEditView(),
+                requests = AjaxHelpers.requests(this);
 
             teamEditView.$('.u-field-name input').val(teamsData.name);
             teamEditView.$('.u-field-textarea textarea').val(teamsData.description);
@@ -163,6 +160,7 @@ define([
         });
 
         it("changes route on cancel click", function () {
+            var teamEditView = createTeamEditView();
             teamEditView.$('.create-team.form-actions .action-cancel').click();
             expect(Backbone.history.navigate.calls[0].args).toContain('topics/awesomeness');
         });

--- a/lms/djangoapps/teams/static/teams/js/spec/views/my_teams_spec.js
+++ b/lms/djangoapps/teams/static/teams/js/spec/views/my_teams_spec.js
@@ -3,8 +3,9 @@ define([
     'teams/js/collections/team',
     'teams/js/collections/team_membership',
     'teams/js/views/my_teams',
-    'teams/js/spec_helpers/team_spec_helpers'
-], function (Backbone, TeamCollection, TeamMembershipCollection, MyTeamsView, TeamSpecHelpers) {
+    'teams/js/spec_helpers/team_spec_helpers',
+    'common/js/spec_helpers/ajax_helpers'
+], function (Backbone, TeamCollection, TeamMembershipCollection, MyTeamsView, TeamSpecHelpers, AjaxHelpers) {
     'use strict';
     describe('My Teams View', function () {
         beforeEach(function () {
@@ -28,26 +29,51 @@ define([
         it('can render itself', function () {
             var teamMembershipsData = TeamSpecHelpers.createMockTeamMembershipsData(1, 5),
                 teamMemberships = TeamSpecHelpers.createMockTeamMemberships(teamMembershipsData),
-                teamsView = createMyTeamsView({
+                myTeamsView = createMyTeamsView({
                     teams: teamMemberships,
                     teamMemberships: teamMemberships
                 });
 
-            TeamSpecHelpers.verifyCards(teamsView, teamMembershipsData);
+            TeamSpecHelpers.verifyCards(myTeamsView, teamMembershipsData);
 
             // Verify that there is no header or footer
-            expect(teamsView.$('.teams-paging-header').text().trim()).toBe('');
-            expect(teamsView.$('.teams-paging-footer').text().trim()).toBe('');
+            expect(myTeamsView.$('.teams-paging-header').text().trim()).toBe('');
+            expect(myTeamsView.$('.teams-paging-footer').text().trim()).toBe('');
         });
 
         it('shows a message when the user is not a member of any teams', function () {
             var teamMemberships = TeamSpecHelpers.createMockTeamMemberships([]),
-                teamsView = createMyTeamsView({
+                myTeamsView = createMyTeamsView({
                     teams: teamMemberships,
                     teamMemberships: teamMemberships
                 });
-            TeamSpecHelpers.verifyCards(teamsView, []);
-            expect(teamsView.$el.text().trim()).toBe('You are not currently a member of any teams.');
+            TeamSpecHelpers.verifyCards(myTeamsView, []);
+            expect(myTeamsView.$el.text().trim()).toBe('You are not currently a member of any team.');
+        });
+
+        it('refreshes a stale membership collection when rendering', function() {
+            var requests = AjaxHelpers.requests(this),
+                teamMemberships = TeamSpecHelpers.createMockTeamMemberships([]),
+                myTeamsView = createMyTeamsView({
+                    teams: teamMemberships,
+                    teamMemberships: teamMemberships
+                });
+            TeamSpecHelpers.verifyCards(myTeamsView, []);
+            expect(myTeamsView.$el.text().trim()).toBe('You are not currently a member of any team.');
+            teamMemberships.teamEvents.trigger('teams:update', { action: 'create' });
+            myTeamsView.render();
+            AjaxHelpers.expectJsonRequestURL(
+                requests,
+                'foo',
+                {
+                    expand : 'team',
+                    username : 'testUser',
+                    course_id : 'my/course/id',
+                    page : '1',
+                    page_size : '10'
+                }
+            );
+            AjaxHelpers.respondWithJson(requests, {});
         });
     });
 });

--- a/lms/djangoapps/teams/static/teams/js/spec/views/team_join_spec.js
+++ b/lms/djangoapps/teams/static/teams/js/spec/views/team_join_spec.js
@@ -1,8 +1,7 @@
 define([
-    'underscore', 'common/js/spec_helpers/ajax_helpers', 'teams/js/models/team',
-    'teams/js/spec_helpers/team_spec_helpers',
-    'teams/js/views/team_join'
-], function (_, AjaxHelpers, TeamModel, TeamSpecHelpers, TeamJoinView) {
+    'backbone', 'underscore', 'common/js/spec_helpers/ajax_helpers', 'teams/js/models/team',
+    'teams/js/views/team_join', 'teams/js/spec_helpers/team_spec_helpers'
+], function (Backbone, _, AjaxHelpers, TeamModel, TeamJoinView, TeamSpecHelpers) {
     'use strict';
     describe('TeamJoinView', function () {
         var createTeamsUrl,
@@ -63,6 +62,7 @@ define([
             var teamJoinView = new TeamJoinView(
                 {
                     courseID: TeamSpecHelpers.testCourseID,
+                    teamEvents: TeamSpecHelpers.teamEvents,
                     model: model,
                     teamsUrl: createTeamsUrl(teamId),
                     maxTeamSize: maxTeamSize,

--- a/lms/djangoapps/teams/static/teams/js/spec/views/topic_card_spec.js
+++ b/lms/djangoapps/teams/static/teams/js/spec/views/topic_card_spec.js
@@ -5,11 +5,8 @@ define(['jquery',
     function ($, _, TopicCardView, Topic) {
 
         describe('topic card view', function () {
-            var view;
-
-            beforeEach(function () {
-                spyOn(TopicCardView.prototype, 'action');
-                view = new TopicCardView({
+            var createTopicCardView = function() {
+                return new TopicCardView({
                     model: new Topic({
                         'id': 'renewables',
                         'name': 'Renewable Energy',
@@ -17,9 +14,14 @@ define(['jquery',
                         'team_count': 34
                     })
                 });
+            };
+
+            beforeEach(function () {
+                spyOn(TopicCardView.prototype, 'action');
             });
 
             it('can render itself', function () {
+                var view = createTopicCardView();
                 expect(view.$el).toHaveClass('square-card');
                 expect(view.$el.find('.card-title').text()).toContain('Renewable Energy');
                 expect(view.$el.find('.card-description').text()).toContain('changes in <ⓡⓔⓝⓔⓦⓐⓑⓛⓔ> ʎƃɹǝuǝ');
@@ -28,6 +30,7 @@ define(['jquery',
             });
 
             it('navigates when action button is clicked', function () {
+                var view = createTopicCardView();
                 view.$el.find('.action').trigger('click');
                 // TODO test actual navigation once implemented
                 expect(view.action).toHaveBeenCalled();

--- a/lms/djangoapps/teams/static/teams/js/spec/views/topics_spec.js
+++ b/lms/djangoapps/teams/static/teams/js/spec/views/topics_spec.js
@@ -1,9 +1,10 @@
 define([
-    'teams/js/collections/topic', 'teams/js/views/topics'
-], function (TopicCollection, TopicsView) {
+    'backbone', 'teams/js/collections/topic', 'teams/js/views/topics',
+    'teams/js/spec_helpers/team_spec_helpers'
+], function (Backbone, TopicCollection, TopicsView, TeamSpecHelpers) {
     'use strict';
     describe('TopicsView', function () {
-        var initialTopics, topicCollection, topicsView,
+        var initialTopics, topicCollection, createTopicsView,
             generateTopics = function (startIndex, stopIndex) {
             return _.map(_.range(startIndex, stopIndex + 1), function (i) {
                 return {
@@ -13,6 +14,14 @@ define([
                     "team_count": 0
                 };
             });
+        };
+
+        createTopicsView = function() {
+            return new TopicsView({
+                teamEvents: TeamSpecHelpers.teamEvents,
+                el: '.topics-container',
+                collection: topicCollection
+            }).render();
         };
 
         beforeEach(function () {
@@ -26,13 +35,17 @@ define([
                     "start": 0,
                     "results": initialTopics
                 },
-                {course_id: 'my/course/id', parse: true}
+                {
+                    teamEvents: TeamSpecHelpers.teamEvents,
+                    course_id: 'my/course/id',
+                    parse: true
+                }
             );
-            topicsView = new TopicsView({el: '.topics-container', collection: topicCollection}).render();
         });
 
         it('can render the first of many pages', function () {
-            var footerEl = topicsView.$('.topics-paging-footer'),
+            var topicsView = createTopicsView(),
+                footerEl = topicsView.$('.topics-paging-footer'),
                 topicCards = topicsView.$('.topic-card');
             expect(topicsView.$('.topics-paging-header').text()).toMatch('Showing 1-5 out of 6 total');
             _.each(initialTopics, function (topic, index) {

--- a/lms/djangoapps/teams/static/teams/js/spec_helpers/team_spec_helpers.js
+++ b/lms/djangoapps/teams/static/teams/js/spec_helpers/team_spec_helpers.js
@@ -1,13 +1,15 @@
 define([
+    'backbone',
     'underscore',
     'teams/js/collections/team',
     'teams/js/collections/team_membership',
-], function (_, TeamCollection, TeamMembershipCollection) {
+], function (Backbone, _, TeamCollection, TeamMembershipCollection) {
     'use strict';
     var createMockPostResponse, createMockDiscussionResponse, createAnnotatedContentInfo, createMockThreadResponse,
         testCourseID = 'course/1',
         testUser = 'testUser',
         testTeamDiscussionID = "12345",
+        teamEvents = _.clone(Backbone.Events),
         testCountries = [
             ['', ''],
             ['US', 'United States'],
@@ -47,6 +49,7 @@ define([
                 results: teamData
             },
             {
+                teamEvents: teamEvents,
                 course_id: 'my/course/id',
                 parse: true
             }
@@ -79,6 +82,7 @@ define([
                 results: teamMembershipData
             },
             _.extend(_.extend({}, {
+                    teamEvents: teamEvents,
                     course_id: 'my/course/id',
                     parse: true,
                     url: 'api/teams/team_memberships',
@@ -225,6 +229,7 @@ define([
     };
 
     return {
+        teamEvents: teamEvents,
         testCourseID: testCourseID,
         testUser: testUser,
         testCountries: testCountries,

--- a/lms/djangoapps/teams/static/teams/js/views/edit_team.js
+++ b/lms/djangoapps/teams/static/teams/js/views/edit_team.js
@@ -20,6 +20,7 @@
                 },
 
                 initialize: function(options) {
+                    this.teamEvents = options.teamEvents;
                     this.courseID = options.teamParams.courseID;
                     this.topicID = options.teamParams.topicID;
                     this.collection = options.collection;
@@ -28,7 +29,7 @@
                     this.countries = options.teamParams.countries;
                     this.primaryButtonTitle = options.primaryButtonTitle || 'Submit';
 
-                   _.bindAll(this, 'goBackToTopic', 'createTeam');
+                    _.bindAll(this, 'goBackToTopic', 'createTeam');
 
                     this.teamModel = new TeamModel({});
                     this.teamModel.url = this.teamsUrl;
@@ -113,6 +114,10 @@
 
                     this.teamModel.save(data, { wait: true })
                         .done(function(result) {
+                            view.teamEvents.trigger('teams:update', {
+                                action: 'create',
+                                team: result
+                            });
                             Backbone.history.navigate(
                                 'teams/' + view.topicID + '/' + view.teamModel.id,
                                 {trigger: true}
@@ -175,10 +180,10 @@
                     if (screenReaderMessage) {
                         this.$('.screen-reader-message').text(screenReaderMessage);
                     }
-               },
+                },
 
-               goBackToTopic: function () {
-                   Backbone.history.navigate('topics/' + this.topicID, {trigger: true});
+                goBackToTopic: function () {
+                    Backbone.history.navigate('topics/' + this.topicID, {trigger: true});
                 }
             });
         });

--- a/lms/djangoapps/teams/static/teams/js/views/my_teams.js
+++ b/lms/djangoapps/teams/static/teams/js/views/my_teams.js
@@ -5,10 +5,17 @@
         function (Backbone, gettext, TeamsView) {
             var MyTeamsView = TeamsView.extend({
                 render: function() {
-                    TeamsView.prototype.render.call(this);
-                    if (this.collection.length === 0) {
-                        this.$el.append('<p>' + gettext('You are not currently a member of any teams.') + '</p>');
+                    var view = this;
+                    if (this.collection.isStale) {
+                        this.$el.html('');
                     }
+                    this.collection.refresh()
+                        .done(function() {
+                            TeamsView.prototype.render.call(view);
+                            if (view.collection.length === 0) {
+                                view.$el.append('<p>' + gettext('You are not currently a member of any team.') + '</p>');
+                            }
+                        });
                     return this;
                 },
 

--- a/lms/djangoapps/teams/static/teams/js/views/team_join.js
+++ b/lms/djangoapps/teams/static/teams/js/views/team_join.js
@@ -1,108 +1,114 @@
 ;(function (define) {
-'use strict';
+    'use strict';
 
-define(['backbone',
-        'underscore',
-        'gettext',
-        'teams/js/views/team_utils',
-        'text!teams/templates/team-join.underscore'],
-       function (Backbone, _, gettext, TeamUtils, teamJoinTemplate) {
-           return Backbone.View.extend({
+    define(['backbone',
+            'underscore',
+            'gettext',
+            'teams/js/views/team_utils',
+            'text!teams/templates/team-join.underscore'],
+        function (Backbone, _, gettext, TeamUtils, teamJoinTemplate) {
+            return Backbone.View.extend({
 
-               errorMessage: gettext("An error occurred. Try again."),
-               alreadyMemberMessage: gettext("You already belong to another team."),
-               teamFullMessage: gettext("This team is full."),
+                errorMessage: gettext("An error occurred. Try again."),
+                alreadyMemberMessage: gettext("You already belong to another team."),
+                teamFullMessage: gettext("This team is full."),
 
-               events: {
-                   "click .action-primary": "joinTeam"
-               },
+                events: {
+                    "click .action-primary": "joinTeam"
+                },
 
-               initialize: function(options) {
-                   this.template = _.template(teamJoinTemplate);
-                   this.courseID = options.courseID;
-                   this.maxTeamSize = options.maxTeamSize;
-                   this.currentUsername = options.currentUsername;
-                   this.teamMembershipsUrl = options.teamMembershipsUrl;
-                   _.bindAll(this, 'render', 'joinTeam', 'getUserTeamInfo');
-                   this.listenTo(this.model, "change", this.render);
-               },
+                initialize: function(options) {
+                    this.teamEvents = options.teamEvents;
+                    this.template = _.template(teamJoinTemplate);
+                    this.courseID = options.courseID;
+                    this.maxTeamSize = options.maxTeamSize;
+                    this.currentUsername = options.currentUsername;
+                    this.teamMembershipsUrl = options.teamMembershipsUrl;
+                    _.bindAll(this, 'render', 'joinTeam', 'getUserTeamInfo');
+                    this.listenTo(this.model, "change", this.render);
+                },
 
-               render: function() {
-                   var message,
-                       showButton,
-                       teamHasSpace;
+                render: function() {
+                    var view = this,
+                        message,
+                        showButton,
+                        teamHasSpace;
+                    this.getUserTeamInfo(this.currentUsername, view.maxTeamSize).done(function (info) {
+                        teamHasSpace = info.teamHasSpace;
 
-                   var view = this;
-                   this.getUserTeamInfo(this.currentUsername, view.maxTeamSize).done(function (info) {
-                       teamHasSpace = info.teamHasSpace;
+                        // if user is the member of current team then we wouldn't show anything
+                        if (!info.memberOfCurrentTeam) {
+                            showButton = !info.alreadyMember && teamHasSpace;
 
-                       // if user is the member of current team then we wouldn't show anything
-                       if (!info.memberOfCurrentTeam) {
-                           showButton = !info.alreadyMember && teamHasSpace;
+                            if (info.alreadyMember) {
+                                message = info.memberOfCurrentTeam ? '' : view.alreadyMemberMessage;
+                            } else if (!teamHasSpace) {
+                                message = view.teamFullMessage;
+                            }
+                        }
 
-                           if (info.alreadyMember) {
-                               message = info.memberOfCurrentTeam ? '' : view.alreadyMemberMessage;
-                           } else if (!teamHasSpace) {
-                               message = view.teamFullMessage;
-                           }
-                       }
+                        view.$el.html(view.template({showButton: showButton, message: message}));
+                    });
+                    return view;
+                },
 
-                       view.$el.html(view.template({showButton: showButton, message: message}));
-                   });
-                   return view;
-               },
+                joinTeam: function () {
+                    var view = this;
+                    $.ajax({
+                        type: 'POST',
+                        url: view.teamMembershipsUrl,
+                        data: {'username': view.currentUsername, 'team_id': view.model.get('id')}
+                    }).done(function (data) {
+                        view.model.fetch()
+                            .done(function() {
+                                view.teamEvents.trigger('teams:update', {
+                                    action: 'join',
+                                    team: view.model
+                                });
+                            });
+                    }).fail(function (data) {
+                        TeamUtils.parseAndShowMessage(data, view.errorMessage);
+                    });
+                },
 
-               joinTeam: function () {
-                   var view = this;
-                   $.ajax({
-                       type: 'POST',
-                       url: view.teamMembershipsUrl,
-                       data: {'username': view.currentUsername, 'team_id': view.model.get('id')}
-                   }).done(function (data) {
-                       view.model.fetch({});
-                   }).fail(function (data) {
-                       TeamUtils.parseAndShowMessage(data, view.errorMessage);
-                   });
-               },
+                getUserTeamInfo: function (username, maxTeamSize) {
+                    var deferred = $.Deferred();
+                    var info = {
+                        alreadyMember: false,
+                        memberOfCurrentTeam: false,
+                        teamHasSpace: false
+                    };
 
-               getUserTeamInfo: function (username, maxTeamSize) {
-                   var deferred = $.Deferred();
-                   var info = {
-                       alreadyMember: false,
-                       memberOfCurrentTeam: false,
-                       teamHasSpace: false
-                   };
+                    info.memberOfCurrentTeam = TeamUtils.isUserMemberOfTeam(this.model.get('membership'), username);
+                    var teamHasSpace = this.model.get('membership').length < maxTeamSize;
 
-                   info.memberOfCurrentTeam = TeamUtils.isUserMemberOfTeam(this.model.get('membership'), username);
-                   var teamHasSpace = this.model.get('membership').length < maxTeamSize;
+                    if (info.memberOfCurrentTeam) {
+                        info.alreadyMember = true;
+                        info.memberOfCurrentTeam = true;
+                        deferred.resolve(info);
+                    } else {
+                        if (teamHasSpace) {
+                            var view = this;
+                            $.ajax({
+                                type: 'GET',
+                                url: view.teamMembershipsUrl,
+                                data: {'username': username, 'course_id': view.courseID}
+                            }).done(function (data) {
+                                info.alreadyMember = (data.count > 0);
+                                info.memberOfCurrentTeam = false;
+                                info.teamHasSpace = teamHasSpace;
+                                deferred.resolve(info);
+                            }).fail(function (data) {
+                                TeamUtils.parseAndShowMessage(data, view.errorMessage);
+                                deferred.reject();
+                            });
+                        } else {
+                            deferred.resolve(info);
+                        }
+                    }
 
-                   if (info.memberOfCurrentTeam) {
-                       info.alreadyMember = true;
-                       info.memberOfCurrentTeam = true;
-                       deferred.resolve(info);
-                   } else {
-                       if (teamHasSpace) {
-                           var view = this;
-                           $.ajax({
-                               type: 'GET',
-                               url: view.teamMembershipsUrl,
-                               data: {'username': username, 'course_id': view.courseID}
-                           }).done(function (data) {
-                               info.alreadyMember = (data.count > 0);
-                               info.memberOfCurrentTeam = false;
-                               info.teamHasSpace = teamHasSpace;
-                               deferred.resolve(info);
-                           }).fail(function (data) {
-                               TeamUtils.parseAndShowMessage(data, view.errorMessage);
-                               deferred.reject();
-                           });
-                       } else {
-                           deferred.resolve(info);
-                       }
-                   }
-
-                   return deferred.promise();
-               }
-           });
-       });
+                    return deferred.promise();
+                }
+            });
+        });
 }).call(this, define || RequireJS.define);

--- a/lms/djangoapps/teams/static/teams/js/views/topic_teams.js
+++ b/lms/djangoapps/teams/static/teams/js/views/topic_teams.js
@@ -17,20 +17,26 @@
                 },
 
                 render: function() {
-                    TeamsView.prototype.render.call(this);
+                    var self = this;
+                    $.when(
+                        this.collection.refresh(),
+                        this.teamMemberships.refresh()
+                    ).done(function() {
+                        TeamsView.prototype.render.call(self);
 
-                    if (this.teamMemberships.canUserCreateTeam()) {
-                        var message = interpolate_text(
-                            _.escape(gettext("Try {browse_span_start}browsing all teams{span_end} or {search_span_start}searching team descriptions{span_end}. If you still can't find a team to join, {create_span_start}create a new team in this topic{span_end}.")),
-                            {
-                                'browse_span_start': '<a class="browse-teams" href="">',
-                                'search_span_start': '<a class="search-teams" href="">',
-                                'create_span_start': '<a class="create-team" href="">',
-                                'span_end': '</a>'
-                            }
-                        );
-                        this.$el.append(_.template(teamActionsTemplate, {message: message}));
-                    }
+                        if (self.teamMemberships.canUserCreateTeam()) {
+                            var message = interpolate_text(
+                                _.escape(gettext("Try {browse_span_start}browsing all teams{span_end} or {search_span_start}searching team descriptions{span_end}. If you still can't find a team to join, {create_span_start}create a new team in this topic{span_end}.")),
+                                {
+                                    'browse_span_start': '<a class="browse-teams" href="">',
+                                    'search_span_start': '<a class="search-teams" href="">',
+                                    'create_span_start': '<a class="create-team" href="">',
+                                    'span_end': '</a>'
+                                }
+                            );
+                            self.$el.append(_.template(teamActionsTemplate, {message: message}));
+                        }
+                    });
                     return this;
                 },
 

--- a/lms/djangoapps/teams/static/teams/js/views/topics.js
+++ b/lms/djangoapps/teams/static/teams/js/views/topics.js
@@ -1,9 +1,10 @@
 ;(function (define) {
     'use strict';
     define([
+        'gettext',
         'teams/js/views/topic_card',
         'common/js/components/views/paginated_view'
-    ], function (TopicCardView, PaginatedView) {
+    ], function (gettext, TopicCardView, PaginatedView) {
         var TopicsView = PaginatedView.extend({
             type: 'topics',
 
@@ -18,6 +19,16 @@
                     srInfo: this.srInfo
                 });
                 PaginatedView.prototype.initialize.call(this);
+            },
+
+            render: function() {
+                var self = this;
+                this.collection.refresh()
+                    .done(function() {
+                        self.collection.isStale = false;
+                        PaginatedView.prototype.render.call(self);
+                    });
+                return this;
             }
         });
         return TopicsView;


### PR DESCRIPTION
https://openedx.atlassian.net/browse/TNL-2976

This is (hopefully) a comprehensive fix for all the refresh problems that we were having with teams. The basic approach is that our three collections (topics, teams, and team memberships) all now inherit from a base collection which tracks whether the collection should be considered stale. It is each view's job to notice if the models that it is rendering are stale, and if so to first refetch them from the server. Hopefully this ensures that all the views are showing up-to-date information without requiring that every collection be updated on every change.
