### PR TITLE
Fixed accessibility related issues in CCX

### DIFF
--- a/lms/static/js/spec/ccx/schedule_spec.js
+++ b/lms/static/js/spec/ccx/schedule_spec.js
@@ -164,7 +164,7 @@ define(['common/js/spec_helpers/ajax_helpers', 'js/ccx/schedule'],
                 view.save();
                 expect(requests.length).toEqual(1)
                 AjaxHelpers.expectJsonRequest(requests, 'POST', 'save_ccx', view.schedule);
-                expect($('#dirty-schedule #save-changes').text()).toEqual("Saving...");
+                expect($('#dirty-schedule #save-changes').text()).toEqual("Saving");
                 AjaxHelpers.respondWithJson(requests, {
                     data: view.schedule
                 });

--- a/lms/static/sass/course/ccx_coach/_dashboard.scss
+++ b/lms/static/sass/course/ccx_coach/_dashboard.scss
@@ -55,3 +55,22 @@ form.ccx-form {
         margin: 5px 0 5px 0;
     }
 }
+
+button.ccx-button-link {
+    background: none;
+    border: none;
+    padding: 0;
+    color: #069;
+    cursor: pointer;
+    &:after {
+        content: "\00a0 ";
+    }
+    &:active {
+        background: none;
+        border: none;
+        padding: 0;
+    }
+    &:hover {
+        color: brown;
+    }
+}

--- a/lms/templates/ccx/coach_dashboard.html
+++ b/lms/templates/ccx/coach_dashboard.html
@@ -38,7 +38,8 @@ from django.core.urlresolvers import reverse
       <section>
         <form action="${create_ccx_url}" method="POST">
           <input type="hidden" name="csrfmiddlewaretoken" value="${csrf_token}"/>
-          <input name="name" placeholder="Name your CCX"/><br/>
+          <label class="sr" for="ccx_name">${_('Name your CCX')}</label>
+          <input name="name" id="ccx_name" placeholder="${_('Name your CCX')}"/><br/>
           <button id="create-ccx">Coach a new Custom Course for EdX</button>
         </form>
       </section>

--- a/lms/templates/ccx/enrollment.html
+++ b/lms/templates/ccx/enrollment.html
@@ -4,19 +4,20 @@
   <form method="POST" action="ccx_invite">
   <input type="hidden" name="csrfmiddlewaretoken" value="${ csrf_token }">
   <h2> ${_("Batch Enrollment")} </h2>
-  <p>
-    <label for="student-ids">
+  <label for="student-ids" class="sr">${_("Email Addresses/Usernames")}</label>
+  <p id="label_student_ids" class="text-helper">
       ${_("Enter email addresses and/or usernames separated by new lines or commas.")}
-      ${_("You will not get notification for emails that bounce, so please double-check spelling.")} </label>
-    <textarea rows="6" name="student-ids" placeholder="${_("Email Addresses/Usernames")}" spellcheck="false"></textarea>
+      ${_("You will not get notification for emails that bounce, so please double-check spelling.")}
   </p>
+  <textarea rows="6" name="student-ids" id="student-ids" aria-describedby="label_student_ids" placeholder="${_("Email Addresses/Usernames")}" spellcheck="false"></textarea>
+
 
   <div class="enroll-option">
-    <input type="checkbox" name="auto-enroll" value="Auto-Enroll" checked="yes">
+    <input type="checkbox" name="auto-enroll" id="auto-enroll" value="Auto-Enroll" checked="yes" aria-describedby="auto-enroll-helper">
     <label style="display:inline" for="auto-enroll">${_("Auto Enroll")}</label>
     <div class="hint auto-enroll-hint">
       <span class="hint-caret"></span>
-      <p>
+      <p class="text-helper" id="auto-enroll-helper">
 	${_("If this option is <em>checked</em>, users who have not yet registered for {platform_name} will be automatically enrolled.").format(platform_name=settings.PLATFORM_NAME)}
 	${_("If this option is left <em>unchecked</em>, users who have not yet registered for {platform_name} will not be enrolled, but will be allowed to enroll once they make an account.").format(platform_name=settings.PLATFORM_NAME)}
 	<br /><br />
@@ -26,11 +27,11 @@
   </div>
 
   <div class="enroll-option">
-    <input type="checkbox" name="email-students" value="Notify-students-by-email" checked="yes">
+    <input type="checkbox" name="email-students" id="email-students" value="Notify-students-by-email" checked="yes" aria-describedby="email-students-helper">
     <label style="display:inline" for="email-students">${_("Notify users by email")}</label>
     <div class="hint email-students-hint">
       <span class="hint-caret"></span>
-      <p>
+      <p class="text-helper" id="email-students-helper">
 	${_("If this option is <em>checked</em>, users will receive an email notification.")}
       </p>
     </div>
@@ -72,10 +73,11 @@
         </table>
       </div>
       <div class="bottom-bar">
-        <input name="student-id" class="add-field" placeholder="Enter username or email" type="text">
+        <label for="student-id" class="sr">${_("Enter username or email")}</label>
+        <input name="student-id" id="student-id" class="add-field" placeholder="${_("Enter username or email")}" type="text">
         <input name="student-action" class="add" value="Add Student" type="button">
       </div>
     </div>
   </div>
   </form>
-</div> 
+</div>

--- a/lms/templates/ccx/schedule.html
+++ b/lms/templates/ccx/schedule.html
@@ -29,22 +29,24 @@
   <div id="new-ccx-schedule"></div>
 </div>
 
-<section id="enter-date-modal" class="modal" aria-hidden="true">
-  <div class="inner-wrapper" role="dialog">
+<section id="enter-date-modal" class="modal"
+         tabindex="-1" role="dialog" aria-labelledby="ccx_schedule_set_date_heading">
+  <div class="inner-wrapper">
     <button class="close-modal">
-      <i class="icon fa fa-remove"></i>
-      <span class="sr">
-        ${_("Close")}
-      </span>
+      <i class="icon fa fa-remove" aria-hidden="true"></i>
+      <span class="sr">${_("Close")}</span>
     </button>
     <header>
-      <h2></h2>
+      <h2 id="ccx_schedule_set_date_heading"></h2>
     </header>
-    <form role="form">
+    <form>
       <div class="field datepair">
-        <label></label>
-        <input placeholder="Date" class="date" type="text" name="date"/ size="11">
-        <input placeholder="Time" class="time" type="text" name="time"/ size="6">
+        ## Translators: This explains to people using a screen reader how to interpret the format of YYYY-MM-DD
+        <label class="sr  form-label" for="ccx_dialog_date">${_('Date format four digit year dash two digit month dash two digit day')}</label>
+        <input placeholder="Date" class="date" type="text" name="date" id="ccx_dialog_date" size="11" />
+        ## Translators: This explains to people using a screen reader how to interpret the format of HH:MM
+        <label class="sr  form-label" for="ccx_dialog_time">${_('Time format two digit hours colon two digit minutes')}</label>
+        <input placeholder="Time" class="time" type="text" name="time" id="ccx_dialog_time" size="6" />
       </div>
       <div class="field">
         <button type="submit" class="btn btn-primary">${_('Set date')}</button>
@@ -54,44 +56,62 @@
 </section>
 
 <div class="ccx-schedule-sidebar">
-  <div class="ccx-sidebar-panel" id="dirty-schedule">
-    <h2>${_('Save changes')}</h2>
-    <form role="form">
-      <p>${_("You have unsaved changes.")}</p>
+  <div class="ccx-sidebar-panel" id="dirty-schedule" tabindex="-1" role="region"
+       aria-labelledby="ccx_schedule_save_changes_heading">
+    <h2 id="ccx_schedule_save_changes_heading">${_('Save changes')}</h2>
+    <form>
+      <p id="message_save" class="text-helper">${_("You have unsaved changes.")}</p>
       <div class="field">
         <br/>
-        <button id="save-changes">${_("Save changes")}</button>
+        <button id="save-changes" aria-describedby="message_save">${_("Save changes")}</button>
       </div>
     </form>
   </div>
-  <div class="ccx-sidebar-panel" id="ajax-error">
+  <div class="ccx-sidebar-panel" id="ajax-error" tabindex="-1" role="region" aria-labelledby="ccx_schedule_error_message">
     <h2>${_('Error')}</h2>
-    <p>${_("There was an error saving changes.")}</p>
+    <p id="ccx_schedule_error_message" class="text-helper">${_("There was an error saving changes.")}</p>
   </div>
-  <div class="ccx-sidebar-panel">
-    <h2>${_('Schedule a Unit')}</h2>
+  <div class="ccx-sidebar-panel" aria-labelledby="ccx_schedule_unit"
+       id="ccx_schedule_unit_panel" role="region">
+    <h2 id="ccx_schedule_unit">${_('Schedule a Unit')}</h2>
     <form role="form" id="add-unit" name="add-unit" class="ccx-form">
       <div class="field">
-        <b>${_('Section')}</b><br/>
-        <select name="chapter"></select>
+        <label for="ccx_chapter" class="form-label"><b>${_('Section')}</b></label>
+        <select name="chapter" id="ccx_chapter" ></select>
       </div>
       <div class="field">
-        <b>${_('Subsection')}</b><br/>
-        <select name="sequential"></select>
+        <label for="ccx_sequential" class="form-label"><b>${_('Subsection')}</b></label>
+        <select name="sequential" id="ccx_sequential"></select>
       </div>
       <div class="field">
-        <b>${_('Unit')}</b><br/>
-        <select name="vertical"></select>
+        <label for="ccx_vertical" class="form-label"><b>${_('Unit')}</b></label>
+        <select name="vertical" id="ccx_vertical"></select>
       </div>
       <div class="field datepair">
-        <b>${_('Start Date')}</b><br/>
-        <input placeholder="Date" type="date" class="date" name="start_date"/>
-        <input placeholder="time" type="time" class="time" name="start_time"/>
+        <label for="ccx_start_date" class="form-label">
+            <b>${_('Start Date')}</b>
+            <span class="sr">
+              ## Translators: This explains to people using a screen reader how to interpret the format of YYYY-MM-DD
+              &nbsp;${_('format four digit year dash two digit month dash two digit day')}
+            </span>
+        </label>
+        <input placeholder="yyyy-mm-dd" type="text" class="date" name="start_date" id="ccx_start_date" />
+        ## Translators: This explains to people using a screen reader how to interpret the format of HH:MM
+        <label for="ccx_start_time" class="sr form-label">${_('Start time format two digit hours colon two digit minutes')}</label>
+        <input placeholder="time" type="text" class="time" name="start_time" id="ccx_start_time"/>
       </div>
       <div class="field datepair">
-        <b>${_('Due Date')}</b> ${_('(Optional)')}<br/>
-        <input placeholder="Date" type="date" class="date" name="due_date"/>
-        <input placeholder="time" type="time" class="time" name="due_time"/>
+        <label for="ccx_due_date" class="form-label">
+            <b>${_('Due Date')}</b> ${_('(Optional)')}
+            <span class="sr">
+                ## Translators: This explains to people using a screen reader how to interpret the format of YYYY-MM-DD
+                &nbsp;${_('format four digit year dash two digit month dash two digit day')}
+            </span>
+        </label>
+        <input placeholder="yyyy-mm-dd" type="text" class="date" name="due_date" id="ccx_due_date"/>
+        ## Translators: This explains to people using a screen reader how to interpret the format of HH:MM
+        <label for="ccx_due_time" class="sr form-label">${_('Due Time format two digit hours colon two digit minutes')}</label>
+        <input placeholder="time" type="text" class="time" name="due_time" id="ccx_due_time"/>
       </div>
       <div class="field">
         <br/>
@@ -102,7 +122,7 @@
         <button id="add-all">${_('Add All Units')}</button>
       </div>
     </form>
-    <div id="all-units-added">
+    <div id="all-units-added" tabindex="-1" role="region">
       ${_("All units have been added.")}
     </div>
   </div>
@@ -118,11 +138,20 @@ $(function() {
     //ccx_schedule.render();
     $('.datepair .time').timepicker({
         'showDuration': true,
-        'timeFormat': 'G:i'
+        'timeFormat': 'G:i',
+        'autoclose': true
     });
     $('.datepair .date').datepicker({
         'dateFormat': 'yy-mm-dd',
         'autoclose': true
+    });
+    $('.datepair .date').change(function() {
+       var date = $(this).datepicker( "getDate" );
+       if (date) {
+           $(this).val(date.getFullYear() + "-" +
+                   ('0' + (date.getMonth() + 1)).slice(-2) + "-" +
+                   ('0' + date.getDate()).slice(-2));
+       }
     });
 });
 </script>

--- a/lms/templates/ccx/schedule.underscore
+++ b/lms/templates/ccx/schedule.underscore
@@ -1,49 +1,97 @@
+  <div align="right">
+    <button id="ccx_expand_all_btn" class="ccx-button-link">
+      <i class="fa fa-expand" aria-hidden="true"></i> <%- gettext('Expand All') %>
+    </button>
+    <button id="ccx_collapse_all_btn" class="ccx-button-link">
+      <i class="fa fa-compress" aria-hidden="true"></i> <%- gettext('Collapse All') %>
+    </button>
+  </div>
+  <br/>
   <table class="ccx-schedule">
     <thead>
       <tr>
         <th><%- gettext('Unit') %></th>
         <th><%- gettext('Start Date') %></th>
         <th><%- gettext('Due Date') %></th>
-        <th><a href="#" id="remove-all">
+        <td><button id="remove-all" class="ccx-button-link">
           <i class="fa fa-remove"></i> <%- gettext('remove all') %>
-        </a></th>
+        </button></td>
       </tr>
     </thead>
     <tbody>
       <% _.each(chapters, function(chapter) { %>
         <tr class="chapter collapsed" data-location="<%= chapter.location %>" data-depth="1">
           <td class="unit">
-            <a href="#"><i class="fa fa-caret-right toggle-collapse"></i></a>
-            <%= chapter.display_name %>
+            <button class="toggle-collapse ccx-button-link" aria-expanded="false">
+              <i class="fa fa-caret-right"></i>
+              <span class="sr"><%- gettext('toggle chapter') %>&nbsp;<%= chapter.display_name %></span>
+            </button>
+            <span class="sr"><%- gettext('Section') %>&nbsp;</span><%= chapter.display_name %>
           </td>
-          <td class="date start-date"><a><%= chapter.start %></a></td>
-          <td class="date due-date"><a><%= chapter.due %></a></td>
-          <td><a href="#" class="remove-unit">
-            <i class="fa fa-remove"></i> <%- gettext('remove') %>
-          </a></td>
+          <td class="date start-date">
+            <button class="ccx-button-link">
+              <%= chapter.start %>
+              <span class="sr"><%- gettext('Click to change') %></span>
+            </button>
+          </td>
+          <td class="date due-date">
+            <button class="ccx-button-link">
+              <%= chapter.due %>
+              <span class="sr"><%- gettext('Click to change') %></span>
+            </button>
+          </td>
+          <td><button class="remove-unit ccx-button-link" aria-label="Remove chapter <%= chapter.display_name %>">
+            <i class="fa fa-remove" aria-hidden="true"></i> <%- gettext('remove') %>
+          </button></td>
         </tr>
         <% _.each(chapter.children, function(child) { %>
           <tr class="sequential collapsed" data-depth="2"
               data-location="<%= chapter.location %> <%= child.location %>">
             <td class="unit">
-              <a href="#"><i class="fa fa-caret-right toggle-collapse"></i></a>
-              <%= child.display_name %>
+              <button class="toggle-collapse ccx-button-link" aria-expanded="false">
+                 <i class="fa fa-caret-right"></i>
+                 <span class="sr"><%- gettext('toggle subsection') %>&nbsp;<%= child.display_name %></span>
+              </button>
+              <span class="sr"><%- gettext('Subsection') %>&nbsp;</span><%= child.display_name %>
             </td>
-            <td class="date start-date"><a><%= child.start %></a></td>
-            <td class="date due-date"><a><%= child.due %></a></td>
-            <td><a href="#" class="remove-unit">
-              <i class="fa fa-remove"></i> <%- gettext('remove') %>
-            </a></td>
+            <td class="date start-date">
+              <button class="ccx-button-link">
+                <%= child.start %>
+                <span class="sr"><%- gettext('Click to change') %></span>
+              </button>
+            </td>
+            <td class="date due-date">
+              <button class="ccx-button-link">
+                <%= child.due %>
+                <span class="sr"><%- gettext('Click to change') %></span>
+              </button>
+            </td>
+            <td><button class="remove-unit ccx-button-link" aria-label="Remove subsection <%= child.display_name %>">
+              <i class="fa fa-remove" aria-hidden="true"></i> <%- gettext('remove') %>
+            </button></td>
           </tr>
           <% _.each(child.children, function(subchild) { %>
             <tr class="vertical" data-dapth="3"
                 data-location="<%= chapter.location %> <%= child.location %> <%= subchild.location %>">
-              <td class="unit">&nbsp;<%= subchild.display_name %></td>
-              <td class="date start-date"><a><%= subchild.start %></a></td>
-              <td class="date due-date"><a><%= subchild.due %></a></td>
-              <td><a href="#" class="remove-unit">
-                <i class="fa fa-remove"></i> <%- gettext('remove') %>
-              </a></td>
+              <td class="unit">&nbsp;
+                 <span class="sr"><%- gettext('Unit') %>&nbsp;</span>
+                 <%= subchild.display_name %>
+              </td>
+              <td class="date start-date">
+                <button class="ccx-button-link">
+                  <%= subchild.start %>
+                  <span class="sr"><%- gettext('Click to change') %></span>
+                </button>
+              </td>
+              <td class="date due-date">
+                <button class="ccx-button-link">
+                  <%= subchild.due %>
+                  <span class="sr"><%- gettext('Click to change') %></span>
+                </button>
+              </td>
+              <td><button class="remove-unit ccx-button-link" aria-label="Remove unit <%= subchild.display_name %>">
+                <i class="fa fa-remove" aria-hidden="true"></i> <%- gettext('remove') %>
+              </button></td>
           <% }); %>
         <% }); %>
       <% }); %>

--- a/lms/templates/instructor/instructor_dashboard_2/membership.html
+++ b/lms/templates/instructor/instructor_dashboard_2/membership.html
@@ -25,7 +25,8 @@ from openedx.core.djangoapps.course_groups.partition_scheme import get_cohorted_
       </table>
     </div>
     <div class="bottom-bar">
-      <input type="text" name="add-field" class="add-field" placeholder="{{add_placeholder}}">
+      <label for="add-field" class="sr">{{add_placeholder}}</label>
+      <input type="text" id="add-field" name="add-field" class="add-field" placeholder="{{add_placeholder}}">
       <input type="button" name="add" class="add" value="{{add_btn_label}}">
     </div>
   </div>


### PR DESCRIPTION
### Background

(copied verbatim from **Mark Sadecki's** CCX Accessibility audit - July 17, 2015)

Unfortunately, there are some significant issues with the way the Schedule Table is implemented. In summary, there is nothing that programmatically indicates the relationship between the nested table rows. They only appear related visually by their padding-left. Also, the controls to expand/collapse have no accessible text and are not associated with the Section/Subsection/Unit name. All of these objects are conveyed as equal table rows.
#### Schedule Tab tree
- Keep the table structure
- Add screen reader text[4] that follows each “title” in the Unit column that identifies it as a “Section”, “Subsection”, or “Unit”
- Add screen reader text for each toggle control that indicates what clicking it will do (either “Expand” or - - “Collapse” this will toggle according to its current state)
- Add controls before the table to “Expand All”/“Collapse All”
#### Date picker

The accessibility of the date and time pickers associated with type=“date” and type=“time” input fields is the responsibility of the user agent. Some UAs will allow the user to manually type a date. For this to work though, it has to be in the right format. Suggest adding help text to these form fields which indicates what the acceptable format is e.g. yyyy-mm-dd or 2015–07–17. The current placeholder indicates that yyyy/mm/dd is acceptable. However Firefox and Safari accept the yyyy-mm-dd format. This makes the current placeholder misleading.
#### Save Changes

After adding a new unit to the schedule, the Save Changes block is added to the DOM. A screen reader user would not know this has happened. Since an action is required (“Save Changes”) it is appropriate to move focus to this new content. Suggest adding a tabindex=“–1” to this div and moving focus() to it. Saving Changes moves the focus back tot he Schedule a Unit div, and I think that is an acceptable workflow.
#### Other issues
- The “Set date” and “Set time” links should really be buttons.
- When you click them, focus[2] must be moved to the modal dialog that opens.
- The date and time inputs in the dialog box suffer from the same label issues as in “Schedule a Unit” above
- Focus must remain trapped in the dialog box until it is closed.
- “Remove” links are all identical and provide no context. It would be helpful to add screen reader text that includes the name of the Unit that would be removed.
- All of the toggle controls need accessible text.
- All icon fonts ) need aria-hidden=“true” added to them.

**Studio Updates:** None.

**LMS Updates:** CCX schedule tab is now fix to meet edX Accessibility Guidelines.  
### What is done in this PR
- Added Expand all button
- Added Collapse all button
- Added expand/collapse status to tree
- Added labels to remove link, expand/collapse links
- Made set date links, buttons in tree
- Added focus to set date dialog
- Added placeholder alternatives for screen readers in set date dialog
- Trapped focus to  set date until it is open
- Added tab index to alerts  like error message, save changes, all unit saved etc
- Added labels and roles to alerts line  error message, save changes, all unit saved etc
- On any change made to schedule put focus to save changes alert.
- Fixed date picker issues where it was showing 2 date picker on chrome and was accepting format mm/dd/yy where in other browsers it was taking format yyyy-mm-dd
- Fixed time picker issue on chrome.
- Added screen reader text that follows each “title” in the Unit column that identifies it as a “Section”, “Subsection”, or “Unit”
- Explicit label issue 
### Testing

You can use screen reading tools like chromeVox (A chrome browser plugin) or command+F5 on mac to verify this PR.
Also read http://edx-partner-course-staff.readthedocs.org/en/latest/getting_started/accessibility.html

Issue https://github.com/mitocw/edx-platform/issues/22
issue https://github.com/jazkarta/edx-platform/issues/120
issue https://github.com/jazkarta/edx-platform/issues/63
issue https://github.com/jazkarta/edx-platform/issues/30
issue https://github.com/jazkarta/edx-platform/issues/121
Issue https://github.com/mitocw/edx-platform/issues/21
EDX https://github.com/edx/edx-platform/pull/7855
EDX https://github.com/edx/edx-platform/pull/7921
EDX https://github.com/edx/edx-platform/pull/7873
@pdpinch @bdero 

![screen shot 2015-08-10 at 9 38 37 pm 2](https://cloud.githubusercontent.com/assets/10431250/9177058/6c14de0e-3fa8-11e5-994a-3a9308d2d17e.png)
