### PR TITLE
Fix for Twitter compatibility

### DIFF
--- a/common/djangoapps/third_party_auth/models.py
+++ b/common/djangoapps/third_party_auth/models.py
@@ -12,7 +12,7 @@ from django.utils.translation import ugettext_lazy as _
 import json
 import logging
 from social.backends.base import BaseAuth
-from social.backends.oauth import BaseOAuth2
+from social.backends.oauth import OAuthAuth
 from social.backends.saml import SAMLAuth, SAMLIdentityProvider
 from social.exceptions import SocialAuthBaseException
 from social.utils import module_member
@@ -30,7 +30,7 @@ def _load_backend_classes(base_class=BaseAuth):
         if issubclass(auth_class, base_class):
             yield auth_class
 _PSA_BACKENDS = {backend_class.name: backend_class for backend_class in _load_backend_classes()}
-_PSA_OAUTH2_BACKENDS = [backend_class.name for backend_class in _load_backend_classes(BaseOAuth2)]
+_PSA_OAUTH2_BACKENDS = [backend_class.name for backend_class in _load_backend_classes(OAuthAuth)]
 _PSA_SAML_BACKENDS = [backend_class.name for backend_class in _load_backend_classes(SAMLAuth)]
 
 
@@ -166,6 +166,7 @@ class ProviderConfig(ConfigurationModel):
 class OAuth2ProviderConfig(ProviderConfig):
     """
     Configuration Entry for an OAuth2 based provider.
+    Also works for OAuth1 providers.
     """
     prefix = 'oa2'
     KEY_FIELDS = ('backend_name', )  # Backend name is unique
@@ -191,7 +192,7 @@ class OAuth2ProviderConfig(ProviderConfig):
     other_settings = models.TextField(blank=True, help_text="Optional JSON object with advanced settings, if any.")
 
     class Meta(object):  # pylint: disable=missing-docstring
-        verbose_name = "Provider Configuration (OAuth2)"
+        verbose_name = "Provider Configuration (OAuth)"
         verbose_name_plural = verbose_name
 
     def clean(self):

--- a/common/djangoapps/third_party_auth/strategy.py
+++ b/common/djangoapps/third_party_auth/strategy.py
@@ -3,7 +3,7 @@ A custom Strategy for python-social-auth that allows us to fetch configuration f
 ConfigurationModels rather than django.settings
 """
 from .models import OAuth2ProviderConfig
-from social.backends.oauth import BaseOAuth2
+from social.backends.oauth import OAuthAuth
 from social.strategies.django_strategy import DjangoStrategy
 
 
@@ -17,11 +17,11 @@ class ConfigurationModelStrategy(DjangoStrategy):
         Load the setting from a ConfigurationModel if possible, or fall back to the normal
         Django settings lookup.
 
-        BaseOAuth2 subclasses will call this method for every setting they want to look up.
+        OAuthAuth subclasses will call this method for every setting they want to look up.
         SAMLAuthBackend subclasses will call this method only after first checking if the
             setting 'name' is configured via SAMLProviderConfig.
         """
-        if isinstance(backend, BaseOAuth2):
+        if isinstance(backend, OAuthAuth):
             provider_config = OAuth2ProviderConfig.current(backend.name)
             if not provider_config.enabled:
                 raise Exception("Can't fetch setting of a disabled backend/provider.")

--- a/common/djangoapps/third_party_auth/tests/specs/test_twitter.py
+++ b/common/djangoapps/third_party_auth/tests/specs/test_twitter.py
@@ -1,0 +1,45 @@
+"""
+Separate integration test for Twitter which is an OAuth1 provider.
+"""
+
+from mock import patch
+from third_party_auth.tests.specs import base
+
+
+class TwitterIntegrationTest(base.Oauth2IntegrationTest):
+    """Integration tests for Twitter backend."""
+
+    def setUp(self):
+        super(TwitterIntegrationTest, self).setUp()
+        self.provider = self.configure_twitter_provider(
+            enabled=True,
+            key='twitter_oauth1_key',
+            secret='twitter_oauth1_secret',
+        )
+
+        # To test an OAuth1 provider, we need to patch an additional method:
+        patcher = patch(
+            'social.backends.twitter.TwitterOAuth.unauthorized_token',
+            create=True,
+            return_value="unauth_token"
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    TOKEN_RESPONSE_DATA = {
+        'access_token': 'access_token_value',
+        'token_type': 'bearer',
+    }
+    USER_RESPONSE_DATA = {
+        'id': 10101010,
+        'name': 'Bob Loblaw',
+        'description': 'A Twitter User',
+        'screen_name': 'bobloblaw',
+        'location': 'Twitterverse',
+        'followers_count': 77,
+        'verified': False,
+    }
+
+    def get_username(self):
+        response_data = self.get_response_data()
+        return response_data.get('screen_name')

--- a/common/djangoapps/third_party_auth/tests/testutil.py
+++ b/common/djangoapps/third_party_auth/tests/testutil.py
@@ -82,6 +82,16 @@ class ThirdPartyAuthTestMixin(object):
         kwargs.setdefault("secret", "test")
         return cls.configure_oauth_provider(**kwargs)
 
+    @classmethod
+    def configure_twitter_provider(cls, **kwargs):
+        """ Update the settings for the Twitter third party auth provider/backend """
+        kwargs.setdefault("name", "Twitter")
+        kwargs.setdefault("backend_name", "twitter")
+        kwargs.setdefault("icon_class", "fa-twitter")
+        kwargs.setdefault("key", "test")
+        kwargs.setdefault("secret", "test")
+        return cls.configure_oauth_provider(**kwargs)
+
 
 class TestCase(ThirdPartyAuthTestMixin, django.test.TestCase):
     """Base class for auth test cases."""

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -247,6 +247,7 @@ AUTHENTICATION_BACKENDS = (
     'social.backends.google.GoogleOAuth2',
     'social.backends.linkedin.LinkedinOAuth2',
     'social.backends.facebook.FacebookOAuth2',
+    'social.backends.twitter.TwitterOAuth',
     'third_party_auth.dummy.DummyBackend',
     'third_party_auth.saml.SAMLAuthBackend',
 ) + AUTHENTICATION_BACKENDS


### PR DESCRIPTION
**Description**: When I implemented #8155 I only checked support for OAuth2. However some Open edX users are using login backends such as Twitter that are based on OAuth1.

This PR tweaks the new configuration system so it is compatible with both OAuth1 and OAuth2 providers. 

I manually tested this fix and confirmed it works and allows Twitter login.

**Sandbox**: http://pr9313.sandbox.opencraft.com/login (you can test it out if you have a Twitter account)

**Setup Instructions**: https://groups.google.com/d/msg/openedx-ops/RerASgJQACM/UMFR_QfdHwAJ

**Reviewers**: @Kelketek and TBD
