### PR TITLE
Validating team size on join, server-side

### DIFF
--- a/lms/djangoapps/teams/views.py
+++ b/lms/djangoapps/teams/views.py
@@ -51,7 +51,6 @@ from .serializers import (
 )
 from .errors import AlreadyOnTeamInCourse, NotEnrolledInCourseForTeam
 
-
 TEAM_MEMBERSHIPS_PER_PAGE = 2
 TOPICS_PER_PAGE = 12
 
@@ -888,6 +887,13 @@ class MembershipListView(ExpandableFieldViewMixin, GenericAPIView):
             user = User.objects.get(username=username)
         except User.DoesNotExist:
             return Response(status=status.HTTP_404_NOT_FOUND)
+
+        course_module = modulestore().get_course(team.course_id)
+        if course_module.teams_max_size is not None and team.users.count() >= course_module.teams_max_size:
+            return Response(
+                build_api_error(ugettext_noop("This team is already full.")),
+                status=status.HTTP_400_BAD_REQUEST
+            )
 
         try:
             membership = team.add_user(user)


### PR DESCRIPTION
By doing this, we can prevent the bug where multiple users can join
a team simutaneously and push its enrollment over the defined
maximum value. Tests have also been added to confirm this behavior.

TNL-3061
