### PR TITLE
Fix Offline Grade Calculation

### DIFF
--- a/lms/djangoapps/instructor/tests/test_offline_gradecalc.py
+++ b/lms/djangoapps/instructor/tests/test_offline_gradecalc.py
@@ -1,0 +1,107 @@
+"""
+Tests for offline_gradecalc.py
+"""
+import json
+from mock import patch
+
+from courseware.models import OfflineComputedGrade
+from student.models import CourseEnrollment
+from student.tests.factories import UserFactory
+from xmodule.graders import Score
+from xmodule.modulestore import ModuleStoreEnum
+from xmodule.modulestore.django import modulestore
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory
+
+from ..offline_gradecalc import offline_grade_calculation, student_grades
+
+
+def mock_grade(_student, _request, course, **_kwargs):
+    """ Return some fake grade data to mock grades.grade() """
+    return {
+        'grade': u'Pass',
+        'totaled_scores': {
+            u'Homework': [
+                Score(earned=10.0, possible=10.0, graded=True, section=u'Subsection 1', module_id=None),
+            ]
+        },
+        'percent': 0.85,
+        'raw_scores': [
+            Score(
+                earned=5.0, possible=5.0, graded=True, section=u'Numerical Input',
+                module_id=course.id.make_usage_key('problem', 'problem1'),
+            ),
+            Score(
+                earned=5.0, possible=5.0, graded=True, section=u'Multiple Choice',
+                module_id=course.id.make_usage_key('problem', 'problem2'),
+            ),
+        ],
+        'section_breakdown': [
+            {'category': u'Homework', 'percent': 1.0, 'detail': u'Homework 1 - Test - 100% (10/10)', 'label': u'HW 01'},
+            {'category': u'Final Exam', 'prominent': True, 'percent': 0, 'detail': u'Final = 0%', 'label': u'Final'}
+        ],
+        'grade_breakdown': [
+            {'category': u'Homework', 'percent': 0.85, 'detail': u'Homework = 85.00% of a possible 85.00%'},
+            {'category': u'Final Exam', 'percent': 0.0, 'detail': u'Final Exam = 0.00% of a possible 15.00%'}
+        ]
+    }
+
+
+class TestOfflineGradeCalc(ModuleStoreTestCase):
+    """ Test Offline Grade Calculation with some mocked grades """
+    def setUp(self):
+        super(TestOfflineGradeCalc, self).setUp()
+
+        with modulestore().default_store(ModuleStoreEnum.Type.split):  # Test with split b/c old mongo keys are messy
+            self.course = CourseFactory.create()
+        self.user = UserFactory.create()
+        CourseEnrollment.enroll(self.user, self.course.id)
+
+        patcher = patch('courseware.grades.grade', new=mock_grade)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_output(self):
+        offline_grades = OfflineComputedGrade.objects
+        self.assertEqual(offline_grades.filter(user=self.user, course_id=self.course.id).count(), 0)
+        offline_grade_calculation(self.course.id)
+        result = offline_grades.get(user=self.user, course_id=self.course.id)
+        decoded = json.loads(result.gradeset)
+        self.assertEqual(decoded['grade'], "Pass")
+        self.assertEqual(decoded['percent'], 0.85)
+        self.assertEqual(decoded['totaled_scores'], {
+            "Homework": [
+                {"earned": 10.0, "possible": 10.0, "graded": True, "section": "Subsection 1", "module_id": None}
+            ]
+        })
+        self.assertEqual(decoded['raw_scores'], [
+            {
+                "earned": 5.0,
+                "possible": 5.0,
+                "graded": True,
+                "section": "Numerical Input",
+                "module_id": unicode(self.course.id.make_usage_key('problem', 'problem1')),
+            },
+            {
+                "earned": 5.0,
+                "possible": 5.0,
+                "graded": True,
+                "section": "Multiple Choice",
+                "module_id": unicode(self.course.id.make_usage_key('problem', 'problem2')),
+            }
+        ])
+        self.assertEqual(decoded['section_breakdown'], [
+            {"category": "Homework", "percent": 1.0, "detail": "Homework 1 - Test - 100% (10/10)", "label": "HW 01"},
+            {"category": "Final Exam", "label": "Final", "percent": 0, "detail": "Final = 0%", "prominent": True}
+        ])
+        self.assertEqual(decoded['grade_breakdown'], [
+            {"category": "Homework", "percent": 0.85, "detail": "Homework = 85.00% of a possible 85.00%"},
+            {"category": "Final Exam", "percent": 0.0, "detail": "Final Exam = 0.00% of a possible 15.00%"}
+        ])
+
+    def test_student_grades(self):
+        """ Test that the data returned by student_grades() and grades.grade() match """
+        offline_grade_calculation(self.course.id)
+        with patch('courseware.grades.grade', side_effect=AssertionError('Should not re-grade')):
+            result = student_grades(self.user, None, self.course, use_offline=True)
+        self.assertEqual(result, mock_grade(self.user, None, self.course))


### PR DESCRIPTION
### Rationale

I tried using offline grade calculation (for an analytics project), and found it to be broken:

```
edxapp@precise64:~/edx-platform$ ./manage.py lms compute_grades course-v1:Typologex+TNT+20150803 --settings=devstack
args =  ('course-v1:Typologex+TNT+20150803',)
-----------------------------------------------------------------------------
Computing grades for course-v1:Typologex+TNT+20150803
6 enrolled students
...
Traceback (most recent call last):
  File "./manage.py", line 116, in <module>
    execute_from_command_line([sys.argv[0]] + django_args)
...
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/instructor/management/commands/compute_grades.py", line 50, in handle
    offline_grade_calculation(course_key)
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/instructor/offline_gradecalc.py", line 53, in offline_grade_calculation
    gs = enc.encode(gradeset)
  File "/usr/lib/python2.7/json/encoder.py", line 201, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python2.7/json/encoder.py", line 264, in iterencode
    return _iterencode(o, 0)
  File "/usr/lib/python2.7/json/encoder.py", line 178, in default
    raise TypeError(repr(o) + " is not JSON serializable")
TypeError: BlockUsageLocator(CourseLocator(u'Typologex', u'TNT', u'20150803', None, None), u'problem', u'problem3') is not JSON serializable
```
### Changes

This fix makes two changes:
1. I changed the JSON serializer so that it can handle `OpaqueKey`s.
2. There was code in a custom JSON serializer that seems designed to expand the `Score` `namedtuple` (objects found in the grade details) from tuples to dicts. However, it was written by overriding `JSONEncoder._iterencode` which [is not overridable](https://github.com/python/cpython/blob/2.7/Lib/json/encoder.py#L266) and has not been since [Python 2.7](https://github.com/python/cpython/commit/a9167a468f1de0d325ff3596389768b4c2b5e1b3).
   - This change is potentially backwards-incompatible, since it slightly changes the values in the JSON object stored in the database. It does what I think the code _intended_ to do, but not what it was actually doing in practice (but unfortunately there were no tests for this code). I'm not sure who is using this offline computation and may be affected by this change:
     - [Old database value format](https://gist.github.com/bradenmacdonald/0e0fae215829dffcc9e7) vs [New database value format](https://gist.github.com/bradenmacdonald/10457955bd980dde0829)
     - However I am only talking above about how this is represented in the database. In terms of how this is actually used, it seems it is only ever used through the `student_grades(use_offline=True)` method, and I have added a test to make sure that that method returns data formatted consistently whether `use_offline` is True or False.
### Test instructions
1. On a devstack, try computing offline grades for a course using a command like:
   
   ./manage.py lms compute_grades course-v1:Typologex+TNT+20150803 --settings=devstack

but change the course identifier shown above to a course on your system with gradable user activity.
1. Go to the legacy instructor dash. In the "Grades" section it should now show a prompt, "Pre-computed grades ${offline_grade_log} available: Use?". Check the checkbox, then download the grades.
### Sandbox

The auto-provisioned sandbox is at http://pr9330.sandbox.opencraft.com/ in case it is useful.
### Partner information

Not an edX partner - this change is for a third party-hosted open edX instance.
