### PR TITLE
Fixing status indicator positioning

### DIFF
--- a/common/lib/xmodule/xmodule/css/capa/display.scss
+++ b/common/lib/xmodule/xmodule/css/capa/display.scss
@@ -43,7 +43,6 @@ $incorrect: $red;
 
   &:after {
     @extend %use-font-awesome;
-    @include margin-left(17px);
     color: $color;
     font-size: 1.2em;
     content: $fontAwesomeIcon;
@@ -184,7 +183,7 @@ div.problem {
         @include status-icon($partiallycorrect, "\f00c");
         border: 2px solid $partiallycorrect;
 
-        // keep green for correct answers on hover. 
+        // keep green for correct answers on hover.
         &:hover {
           border-color: $partiallycorrect;
         }
@@ -770,8 +769,8 @@ div.problem {
 
     // CASE: partially correct answer
     > .partially-correct {
-      
-      input { 
+
+      input {
         border: 2px solid $partiallycorrect;
       }
 


### PR DESCRIPTION
This one-line PR fixes an issue with status indicators in checkbox capa problems.

The current styling has the indicator lying outside it's box. This is especially evident when using a checkbox problem and displaying a hint/message to the student, as shown in the following examples:
![screen shot 2015-08-16 at 5 52 34 pm](https://cloud.githubusercontent.com/assets/6232546/9295621/a92ad67a-4441-11e5-9b86-bac4c8ac1540.png)
![screen shot 2015-08-16 at 5 52 59 pm](https://cloud.githubusercontent.com/assets/6232546/9295623/aaa87584-4441-11e5-8204-71fd207e909a.png)
![screen shot 2015-08-16 at 5 53 14 pm](https://cloud.githubusercontent.com/assets/6232546/9295625/ad57d64e-4441-11e5-9a50-04f4555bc592.png)

With this fix, the indicator is placed back in it's box (an extraneous extra spacing is removed).
![screen shot 2015-08-16 at 5 53 25 pm](https://cloud.githubusercontent.com/assets/6232546/9295629/bb127320-4441-11e5-948f-0bf126c03e4b.png)

Note that I've used software to highlight the bounding boxes here.

A warning: this does change the CSS for a mixin; I've tested a few situations where it's used, but I might not have caught all of them.

Code to generate the example for the above screenshots:

<pre>&lt;script type="text/python" system_path="python_lib">
def partialcredit(answer_ids, student_answers, new_cmap, old_cmap):
    new_cmap.set_hint_and_mode(answer_ids[0], "This is a hint", 'always')
&lt;/script>

&lt;choiceresponse>
  &lt;checkboxgroup>
    &lt;choice correct="true">
      &lt;text>This is true.&lt;/text>
    &lt;/choice>
  &lt;/checkboxgroup>
  &lt;hintgroup hintfn="partialcredit"/>
&lt;/choiceresponse></pre>
