### PR TITLE
Fixing drag and drop labels

### DIFF
--- a/common/static/js/capa/drag_and_drop/draggables.js
+++ b/common/static/js/capa/drag_and_drop/draggables.js
@@ -289,7 +289,7 @@ define(['js/capa/drag_and_drop/draggable_events', 'js/capa/drag_and_drop/draggab
 
                 draggableObj.iconEl.appendTo(draggableObj.containerEl);
 
-                draggableObj.iconWidth = draggableObj.iconEl.width();
+                draggableObj.iconWidth = draggableObj.iconEl.width() + 1;
                 draggableObj.iconHeight = draggableObj.iconEl.height();
                 draggableObj.iconWidthSmall = draggableObj.iconWidth;
                 draggableObj.iconHeightSmall = draggableObj.iconHeight;


### PR DESCRIPTION
This PR fixes an issue with drag and drop labels. If text is sufficiently long, it may wordwrap when it shouldn't, as in the following example (see "AmpR gene" at the top):

![screen shot 2015-08-16 at 8 18 03 pm](https://cloud.githubusercontent.com/assets/6232546/9296157/059ffb80-4454-11e5-8a24-72540c0b7637.png)

It's quite wierd; with both firefox and chrome, unsetting the width style on the drag/drop div doesn't actually change the width of the box, but it does stop the text from wrapping when it shouldn't. I couldn't figure out the cause of this behavior. My fix was to increase the size of the box by one pixel, which sufficed to stop the wordwrap from occurring.

Here is the fixed version:

![screen shot 2015-08-16 at 8 18 25 pm](https://cloud.githubusercontent.com/assets/6232546/9296154/02216ade-4454-11e5-9e32-b7b32cc8c043.png)

If text is sufficiently long, then it wordwraps properly:

![screen shot 2015-08-16 at 8 18 37 pm](https://cloud.githubusercontent.com/assets/6232546/9296155/0414c4f8-4454-11e5-95c1-967ed6dfdeff.png)

I tried figuring out how to give the text the styling "text-align: center;" to be consistent with the bottom part, but I wasn't sufficiently fluent in javascript to follow what was actually being done, and my attempts didn't work. Perhaps somebody else can look into this.
