### PR TITLE
[WIP] TNL-143: Escape characters in Textbook modal

### DIFF
--- a/cms/static/coffee/spec/main.coffee
+++ b/cms/static/coffee/spec/main.coffee
@@ -247,6 +247,7 @@ define([
     "js/spec/views/assets_spec",
     "js/spec/views/baseview_spec",
     "js/spec/views/container_spec",
+    "js/spec/views/edit_chapter_spec"
     "js/spec/views/paged_container_spec",
     "js/spec/views/group_configuration_spec",
     "js/spec/views/unit_outline_spec",
@@ -257,7 +258,7 @@ define([
     "js/spec/views/license_spec",
     "js/spec/views/paging_spec",
     "js/spec/views/login_studio_spec",
-
+    "js/spec/views/utils/view_utils_spec",
     "js/spec/views/pages/container_spec",
     "js/spec/views/pages/container_subviews_spec",
     "js/spec/views/pages/group_configurations_spec",

--- a/cms/static/js/spec/views/edit_chapter_spec.js
+++ b/cms/static/js/spec/views/edit_chapter_spec.js
@@ -1,0 +1,27 @@
+define(['jquery', 'underscore', 'js/views/edit_chapter', 'js/models/course'],
+    function ($, _, EditChapter, Course) {
+    'use strict';
+
+        describe('EditChapter', function () {
+
+                beforeEach(function() {
+                    window.course = new Course({
+                        id: '1',
+                        name: '&amp;lt;Vedran&#39;s course&amp;gt;',
+                        url_name: 'course_name',
+                        org: 'course_org',
+                        num: 'course_num',
+                        revision: 'course_rev'
+                    });
+                });
+
+            describe('openUploadDialog', function() {
+
+                it('displays the encoded name of the course', function () {
+                    var title = _.template(('Upload a new PDF to "<%= name %>"'),
+                        {name: course.get('name')});
+                    expect(title).toBe('Upload a new PDF to "&amp;lt;Vedran&#39;s course&amp;gt;"');
+                });
+            });
+        });
+});

--- a/cms/static/js/spec/views/edit_chapter_spec.js
+++ b/cms/static/js/spec/views/edit_chapter_spec.js
@@ -8,12 +8,7 @@ define(['jquery', 'underscore', 'js/views/edit_chapter', 'js/models/course', 'js
 
             beforeEach(function() {
                 var course = new Course({
-                    id: '1',
                     name: '&amp;lt;Vedran&#39;s course&amp;gt;',
-                    url_name: 'course_name',
-                    org: 'course_org',
-                    num: 'course_num',
-                    revision: 'course_rev'
                 });
                 this.model = new ChapterModel({name: 'test-model'});
                 this.collection = new ChapterCollection(this.model);

--- a/cms/static/js/spec/views/edit_chapter_spec.js
+++ b/cms/static/js/spec/views/edit_chapter_spec.js
@@ -1,27 +1,29 @@
-define(['jquery', 'underscore', 'js/views/edit_chapter', 'js/models/course'],
-    function ($, _, EditChapter, Course) {
+define(['jquery', 'underscore', 'js/views/edit_chapter', 'js/models/course', 'js/collections/chapter', 'js/models/chapter', "js/spec_helpers/modal_helpers"],
+    function ($, _, EditChapter, Course, ChapterCollection, ChapterModel, ModelHelpers) {
     'use strict';
+    describe('EditChapter', function () {
 
-        describe('EditChapter', function () {
+        describe('openUploadDialog', function() {
+            var edit_chapter_fixture = readFixtures('edit-chapter.underscore');
 
-                beforeEach(function() {
-                    window.course = new Course({
-                        id: '1',
-                        name: '&amp;lt;Vedran&#39;s course&amp;gt;',
-                        url_name: 'course_name',
-                        org: 'course_org',
-                        num: 'course_num',
-                        revision: 'course_rev'
-                    });
+            beforeEach(function() {
+                var course = new Course({
+                    id: '1',
+                    name: '&amp;lt;Vedran&#39;s course&amp;gt;',
+                    url_name: 'course_name',
+                    org: 'course_org',
+                    num: 'course_num',
+                    revision: 'course_rev'
                 });
-
-            describe('openUploadDialog', function() {
-
-                it('displays the encoded name of the course', function () {
-                    var title = _.template(('Upload a new PDF to "<%= name %>"'),
-                        {name: course.get('name')});
-                    expect(title).toBe('Upload a new PDF to "&amp;lt;Vedran&#39;s course&amp;gt;"');
-                });
+                this.model = new ChapterModel({name: 'test-model'});
+                this.collection = new ChapterCollection(this.model);
+            });
+            it('displays the encoded name of the course', function () {
+                setFixtures(edit_chapter_fixture);
+                var test = new EditChapter({model: this.model});
+                $('.action-upload').click();
+                expect($('#modal-window-title').text()).toBe(2);
             });
         });
+    });
 });

--- a/cms/static/js/views/edit_chapter.js
+++ b/cms/static/js/views/edit_chapter.js
@@ -54,7 +54,7 @@ define(["js/views/baseview", "underscore", "underscore.string", "jquery", "gette
                 asset_path: this.$("input.chapter-asset-path").val()
             });
             var msg = new FileUploadModel({
-                title: _.template(gettext("Upload a new PDF to “<%= name %>”"),
+                title: _.template(gettext("Upload a new PDF to “<%= name %>”"))(
                     {name: course.get('name')}),
                 message: gettext("Please select a PDF file to upload."),
                 mimeTypes: ['application/pdf']

--- a/cms/static/js/views/edit_chapter.js
+++ b/cms/static/js/views/edit_chapter.js
@@ -54,8 +54,8 @@ define(["js/views/baseview", "underscore", "underscore.string", "jquery", "gette
                 asset_path: this.$("input.chapter-asset-path").val()
             });
             var msg = new FileUploadModel({
-                title: _.template(gettext("Upload a new PDF to “<%= name %>”"))(
-                    {name: course.escape('name')}),
+                title: _.template(gettext("Upload a new PDF to “<%= name %>”"),
+                    {name: course.get('name')}),
                 message: gettext("Please select a PDF file to upload."),
                 mimeTypes: ['application/pdf']
             });


### PR DESCRIPTION
This is a fix for:
https://openedx.atlassian.net/browse/TNL-143
the modal now doesn't escape escapable characters in the course name.
The 'name' attibute of the 'course' global variable is encoded at the
creation of a course, and therefor I've used an encoded name in the
test.

<img width="894" alt="screen shot 2015-08-17 at 3 26 01 pm" src="https://cloud.githubusercontent.com/assets/2808092/9306131/b181be00-44f6-11e5-8cb3-3d87f739783c.png">

Continuation of https://github.com/edx/edx-platform/pull/8954
