### PR TITLE
fetch transcript for html5 if 404

### DIFF
--- a/common/lib/xmodule/xmodule/js/spec/video/video_caption_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_caption_spec.js
@@ -622,6 +622,49 @@
                 expect(Caption.hideSubtitlesEl).toBeHidden();
             });
 
+            msg = 'on error: for Html5 player an attempt to fetch transcript ' +
+                    'with youtubeId if there are no additional transcripts';
+            it(msg, function () {
+                spyOn(Caption, 'fetchAvailableTranslations');
+                spyOn(Caption, 'fetchCaption').andCallThrough();
+                $.ajax.andCallFake(function (settings) {
+                    _.result(settings, 'error');
+                });
+
+                state.config.transcriptLanguages = {};
+                state.videoType = 'html5';
+
+                Caption.fetchCaption();
+
+                expect(Caption.fetchAvailableTranslations).not.toHaveBeenCalled();
+                expect($.ajaxWithPrefix.mostRecentCall.args[0]['data'])
+                    .toEqual({'videoId':'Z5KLxerq05Y'});
+                expect(Caption.hideCaptions.mostRecentCall.args)
+                    .toEqual([true, false]);
+                expect(Caption.fetchCaption.mostRecentCall.args[0]).toEqual(true);
+                expect(Caption.fetchCaption.callCount).toEqual(2);
+            });
+
+            msg = 'on success: when fetchCaption called with fetch_with_youtubeId to ' +
+                    'get transcript with youtubeId for html5';
+            it(msg, function () {
+                spyOn(Caption, 'fetchAvailableTranslations');
+                spyOn(Caption, 'fetchCaption').andCallThrough();
+
+                Caption.loaded = true;
+                state.config.transcriptLanguages = {};
+                state.videoType = 'html5';
+
+                Caption.fetchCaption(true);
+
+                expect(Caption.fetchAvailableTranslations).not.toHaveBeenCalled();
+                expect($.ajaxWithPrefix.mostRecentCall.args[0]['data'])
+                    .toEqual({'videoId':'Z5KLxerq05Y'});
+                expect(Caption.hideCaptions).toHaveBeenCalledWith(false);
+                expect(Caption.fetchCaption.mostRecentCall.args[0]).toEqual(true);
+                expect(Caption.fetchCaption.callCount).toEqual(1);
+            });
+
             msg = 'on error: fetch available translations if there are ' +
                     'additional transcripts';
             xit(msg, function () {

--- a/common/test/acceptance/tests/video/test_video_module.py
+++ b/common/test/acceptance/tests/video/test_video_module.py
@@ -404,6 +404,35 @@ class YouTubeVideoTest(VideoBaseTest):
 
         self.assertTrue(self.video.is_video_rendered('html5'))
 
+    def test_html5_video_rendered_with_youtube_captions(self):
+        """
+        Scenario: User should see Youtube captions for If there are no transcripts
+        available for HTML5 mode
+        Given that I have uploaded a .srt.sjson file to assets for Youtube mode
+        And the YouTube API is blocked
+        And the course has a Video component in "Youtube_HTML5" mode
+        And Video component rendered in HTML5 mode
+        And Html5 mode video has no transcripts
+        When I see the captions for HTML5 mode video
+        Then I should see the Youtube captions
+        """
+        self.assets.append('subs_3_yD_cEKoCk.srt.sjson')
+        # configure youtube server
+        self.youtube_configuration.update({
+            'time_to_response': 2.0,
+            'youtube_api_blocked': True,
+        })
+
+        data = {'sub': '3_yD_cEKoCk'}
+        self.metadata = self.metadata_for_mode('youtube_html5', additional_data=data)
+
+        self.navigate_to_video()
+
+        self.assertTrue(self.video.is_video_rendered('html5'))
+        # check if caption button is visible
+        self.assertTrue(self.video.is_button_shown('CC'))
+        self._verify_caption_text('Welcome to edX.')
+
     def test_download_transcript_button_works_correctly(self):
         """
         Scenario: Download Transcript button works correctly


### PR DESCRIPTION
[MA-824](https://openedx.atlassian.net/browse/MA-824)

**Steps to reproduce :**
1) Create a video component with `youtube` and `.mp4` url
2) Upload an transcript to video component (create copies of transcript with youtube_id, mp4(name of video) and filename that is uploaded)
3) Delete all transcripts except youtube_id one
**Result:**
Caption are visible for youtube but not for html5

**Problem:**
When and transcript is loaded to an video component having `youtube` and `.mp4` urls both and another copy of same transcript is created with `youtube_id` so we have two transcripts for same video one with `youtube_id` and one with `transcript_file_name` uploaded.If we delete transcript with `transcript_file_name` then the caption will load for youtube but not for html5

**Solution:**
So if transcript is not found for html5 we already have a functionality that fetch from available translations for an video, further if there are no available translations of an video but it has transcript with `youtube_id` we can make attempt to fetch the video transcript with `youtube_id`
