### PR TITLE
Upgrade pip to 7.1.0

### DIFF
--- a/requirements/edx/pre.txt
+++ b/requirements/edx/pre.txt
@@ -13,7 +13,7 @@ setuptools==18.0.1
 numpy==1.6.2
 
 # Needed to make sure that options in base.txt are allowed
-pip==6.0.8
+pip==7.1.0
 
 # Needed for meliae
 Cython==0.21.2


### PR DESCRIPTION
This upgrades pip from 6.0.8 to 7.1.0. There has
been a handful of fixes and improvements since 6.0.8.
See: https://pip.pypa.io/en/stable/news.html

In version 7.0.0 there were some backwards-incompatible
changes. Some deprecated pip options were removed. This
doesn't affect edX because edX wasn't using any of these
options.
