### PR TITLE
The stale flag needs to take into account its previous state.

### DIFF
--- a/lms/djangoapps/teams/static/teams/js/collections/topic.js
+++ b/lms/djangoapps/teams/static/teams/js/collections/topic.js
@@ -1,7 +1,7 @@
 ;(function (define) {
     'use strict';
-    define(['teams/js/collections/base', 'teams/js/models/topic', 'gettext', 'underscore'],
-        function(BaseCollection, TopicModel, gettext, _) {
+    define(['underscore', 'gettext', 'teams/js/collections/base', 'teams/js/models/topic'],
+        function(_, gettext, BaseCollection, TopicModel) {
             var TopicCollection = BaseCollection.extend({
                 initialize: function(topics, options) {
                     var self = this;
@@ -25,7 +25,7 @@
                 },
 
                 onUpdate: function(event) {
-                    this.isStale = event.action === 'create';
+                    this.isStale = this.isStale || event.action === 'create';
                 },
 
                 model: TopicModel

--- a/lms/djangoapps/teams/static/teams/js/spec/collections/topic_collection_spec.js
+++ b/lms/djangoapps/teams/static/teams/js/spec/collections/topic_collection_spec.js
@@ -1,48 +1,11 @@
-define(['backbone', 'URI', 'underscore', 'common/js/spec_helpers/ajax_helpers', 'teams/js/collections/topic'],
-    function (Backbone, URI, _, AjaxHelpers, TopicCollection) {
+define(['backbone', 'URI', 'underscore', 'common/js/spec_helpers/ajax_helpers',
+        'teams/js/spec_helpers/team_spec_helpers'],
+    function (Backbone, URI, _, AjaxHelpers, TeamSpecHelpers) {
         'use strict';
         describe('TopicCollection', function () {
             var topicCollection;
             beforeEach(function () {
-                topicCollection = new TopicCollection(
-                    {
-                        "count": 6,
-                        "current_page": 1,
-                        "start": 0,
-                        "results": [
-                            {
-                                "description": "asdf description",
-                                "name": "asdf",
-                                "id": "_asdf"
-                            },
-                            {
-                                "description": "bar description",
-                                "name": "bar",
-                                "id": "_bar"
-                            },
-                            {
-                                "description": "baz description",
-                                "name": "baz",
-                                "id": "_baz"
-                            },
-                            {
-                                "description": "foo description",
-                                "name": "foo",
-                                "id": "_foo"
-                            },
-                            {
-                                "description": "qwerty description",
-                                "name": "qwerty",
-                                "id": "_qwerty"
-                            }
-                        ],
-                        "sort_order": "name"
-                    },
-                    {
-                        teamEvents:_.clone(Backbone.Events),
-                        course_id: 'my/course/id',
-                        parse: true
-                    });
+                topicCollection = TeamSpecHelpers.createMockTopicCollection();
             });
 
             var testRequestParam = function (self, param, value) {

--- a/lms/djangoapps/teams/static/teams/js/spec_helpers/team_spec_helpers.js
+++ b/lms/djangoapps/teams/static/teams/js/spec_helpers/team_spec_helpers.js
@@ -3,9 +3,11 @@ define([
     'underscore',
     'teams/js/collections/team',
     'teams/js/collections/team_membership',
-], function (Backbone, _, TeamCollection, TeamMembershipCollection) {
+    'teams/js/collections/topic'
+], function (Backbone, _, TeamCollection, TeamMembershipCollection, TopicCollection) {
     'use strict';
     var createMockPostResponse, createMockDiscussionResponse, createAnnotatedContentInfo, createMockThreadResponse,
+        createMockTopicData, createMockTopicCollection,
         testCourseID = 'course/1',
         testUser = 'testUser',
         testTeamDiscussionID = "12345",
@@ -228,6 +230,38 @@ define([
         );
     };
 
+    createMockTopicData = function (startIndex, stopIndex) {
+        return _.map(_.range(startIndex, stopIndex + 1), function (i) {
+            return {
+                "description": "description " + i,
+                "name": "topic " + i,
+                "id": "id " + i,
+                "team_count": 0
+            };
+        });
+    };
+
+    createMockTopicCollection = function (topicData) {
+        topicData = topicData !== undefined ? topicData : createMockTopicData(1, 5);
+
+        return new TopicCollection(
+            {
+                count: topicData.length + 1,
+                current_page: 1,
+                num_pages: 2,
+                start: 0,
+                results: topicData,
+                sort_order: "name"
+            },
+            {
+                teamEvents: teamEvents,
+                course_id: 'my/course/id',
+                parse: true,
+                url: 'api/teams/topics'
+            }
+        );
+    };
+
     return {
         teamEvents: teamEvents,
         testCourseID: testCourseID,
@@ -244,6 +278,8 @@ define([
         createMockDiscussionResponse: createMockDiscussionResponse,
         createAnnotatedContentInfo: createAnnotatedContentInfo,
         createMockThreadResponse: createMockThreadResponse,
+        createMockTopicData: createMockTopicData,
+        createMockTopicCollection: createMockTopicCollection,
         verifyCards: verifyCards
     };
 });


### PR DESCRIPTION
Otherwise it can change from false to true without re-rendering. TNL-3072

@peter-fogg Please review (and FYI @andy-armstrong).

This was a one-line-change. I added a Jasmine test that covers the bug, and also did some test refactoring that Andy had requested in #9325.

I spent about an hour trying to also verify that the topics list component is properly re-rendering after a mock AJAX response is sent from the server; however, I didn't get very far, and given that we do check the rendering in bok choy tests, I think it is a better use of my time to move on to this sprint's deliverables.
