### PR TITLE
Add watchdog to our requirements, pavelib uses it.

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -150,6 +150,7 @@ rednose==0.4.3
 selenium==2.42.1
 splinter==0.5.4
 testtools==0.9.34
+watchdog==0.7.1
 
 # Used for Segment.io analytics
 analytics-python==0.4.4


### PR DESCRIPTION
@benpatterson @JZ Not sure why this wasn't in the requirements.
