### PR TITLE
Turn off enrollment counts on the instructor dashboard by default.

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -335,7 +335,7 @@ FEATURES = {
     'ALLOW_AUTOMATED_SIGNUPS': False,
 
     # Enable display of enrollment counts in instructor dash, analytics section
-    'DISPLAY_ANALYTICS_ENROLLMENTS': True,
+    'DISPLAY_ANALYTICS_ENROLLMENTS': False,
 
     # Show the mobile app links in the footer
     'ENABLE_FOOTER_MOBILE_APP_LINKS': False,


### PR DESCRIPTION
The goal of this change is to remove the enrollment numbers from display and direct users to Insights instead by switching `DISPLAY_ANALYTICS_ENROLLMENTS` to `False` by default (AN-4582).  

@feanil -- Is this all that is needed for the change to appear in prod or is there a production config that needs changing too?

**With enrollments turn on:**
![screen shot 2015-08-19 at 10 18 29 am](https://cloud.githubusercontent.com/assets/5265058/9358752/b969219c-465b-11e5-92f1-34a0228c0a6e.png)

**With enrollments turned off:**
![screen shot 2015-08-19 at 10 18 44 am](https://cloud.githubusercontent.com/assets/5265058/9358753/b9699b22-465b-11e5-9162-5743937baaef.png)

@sarina @WatsonEmily @lamagnifica
