### PR TITLE
Adds a comment to reduce confusion over remaining role name differences

### DIFF
--- a/cms/templates/manage_users.html
+++ b/cms/templates/manage_users.html
@@ -95,6 +95,7 @@ from django.core.urlresolvers import reverse
       <div class="bit">
         <h3 class="title-3">${_("Course Team Roles")}</h3>
         <p>${_("Course team members with the Staff role are course co-authors. They have full writing and editing privileges on all course content.")}</p>
+        ## Note that the "Admin" role below is identified as "Instructor" in the Django admin panel.
         <p>${_("Admins are course team members who can add and remove other course team members.")}</p>
         <p>${_("All course team members are automatically enrolled in the course and can access content in Studio, the LMS, and Insights.")}</p>
       </div>

--- a/lms/templates/instructor/instructor_dashboard_2/membership.html
+++ b/lms/templates/instructor/instructor_dashboard_2/membership.html
@@ -193,6 +193,7 @@ from openedx.core.djangoapps.course_groups.partition_scheme import get_cohorted_
       data-add-button-label="${_("Add Staff")}"
     ></div>
 
+    ## Note that "Admin" is identified as "Instructor" in the Django admin panel.
     <div class="auth-list-container"
       data-rolename="instructor"
       data-display-name="${_("Admin")}"
@@ -205,7 +206,8 @@ from openedx.core.djangoapps.course_groups.partition_scheme import get_cohorted_
       data-list-endpoint="${ section_data['list_course_role_members_url'] }"
       data-modify-endpoint="${ section_data['modify_access_url'] }"
       data-add-button-label="${_("Add Admin")}"
-    ></div>
+    >
+    </div>
 
     <div class="auth-list-container"
       data-rolename="beta"


### PR DESCRIPTION
@dsjen please take a look, especially at the syntax I used for the comment

Fixes DOC-2223
Background: 
TNL-1752 (and numerous other tickets) pointed out the difference in the role labels between Studio and the LMS, and that the instructor dashboard included inaccurate information about Studio access. The outcome was to use the labels "Staff" and "Admin" consistently in both applications.
- Interaction in Studio and roles are documented here:
  http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/building_course/creating_new_course.html#add-course-team-members
  - Interaction in the LMS and roles are documented here:
    http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/running_course/course_staffing.html#staffing

No change was made to the Django admin panel, which continues to use the role names that, previously, were surfaced only in the LMS. 
![screen shot 2015-08-19 at 12 25 52 pm](https://cloud.githubusercontent.com/assets/6392274/9386956/0bdc8f10-472c-11e5-96cf-bcd2423fe290.png)
The difference between the role names in Studio/LMS and the Django admin panel has caused confusion for infrequent contributors to the LMS. Surfacing the different names used in these two places, by adding comments to the code, was requested as a result of the RCA.
