### PR TITLE
Allow user partition version >= current version.

### DIFF
--- a/common/lib/xmodule/xmodule/partitions/partitions.py
+++ b/common/lib/xmodule/xmodule/partitions/partitions.py
@@ -161,7 +161,11 @@ class UserPartition(namedtuple("UserPartition", "id name description groups sche
         if value["version"] == 1:
             # If no scheme was provided, set it to the default ('random')
             scheme_id = UserPartition.VERSION_1_SCHEME
-        elif value["version"] == UserPartition.VERSION:
+
+        # Version changes should be backwards compatible in case the code
+        # gets rolled back.  If we see a version number greater than the current
+        # version, we should try to read it rather than raising an exception.
+        elif value["version"] >= UserPartition.VERSION:
             if "scheme" not in value:
                 raise TypeError("UserPartition dict {0} missing value key 'scheme'".format(value))
             scheme_id = value["scheme"]


### PR DESCRIPTION
If code is deployed that updates the user partition version,
then the code is rolled back, we may see user partition versions
greater than the currently deployed version.

The previous behavior was to raise a TypeError when this occurred;
the new behavior assumes that the newer version is backwards
compatible and tries to load the partition.

Replaces https://github.com/edx/edx-platform/pull/9385.
