### PR TITLE
Hiding find courses button from dashboard of edge.edx.org

### DIFF
--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -149,7 +149,7 @@ import json
     <section id="dashboard-search-results" class="search-results dashboard-search-results"></section>
   % endif
 
-  % if settings.FEATURES.get('IS_EDX_DOMAIN'):
+  % if settings.FEATURES.get('IS_EDX_DOMAIN') and settings.FEATURES.get('COURSES_ARE_BROWSABLE'):
     <div class="wrapper-find-courses">
       <p class="copy">Check out our recently launched courses and what's new in your favorite subjects</p>
       <p><a class="btn-find-courses" href="${marketing_link('COURSES')}">${_("Find New Courses")}</a></p>


### PR DESCRIPTION
ECOM-1996

Hiding find courses button from dashboard of edge.edx.org, because there is no public course catalog on the edge.edx.org.

Please review this @awais786 @zubair-arbi @ahsan-ul-haq @aamir-khan 
