### PR TITLE
fixing issue with student re-verification.

### DIFF
--- a/lms/static/js/commerce/views/receipt_view.js
+++ b/lms/static/js/commerce/views/receipt_view.js
@@ -36,7 +36,7 @@ var edx = edx || {};
             this.username = this.$el.data('username');
             _.extend(context, {
                 receipt: this.receiptContext(data),
-                courseKey: this.course_key
+                courseKey: this.courseKey
             });
 
             this.$el.html(_.template(templateHtml, context));


### PR DESCRIPTION
Students unable to verify after submitting payment using otto. 
Issue was appearing for those courses which are purchases through otto. So on receipt page when api hits ecom db to retrieve data there was an invalid variable assignment in JS.
ECOM-2106
