### PR TITLE
Fix course info sidebar padding 

### DIFF
--- a/lms/static/sass/course/_info.scss
+++ b/lms/static/sass/course/_info.scss
@@ -78,6 +78,8 @@ div.info-wrapper {
   }
 
   section.handouts {
+    padding: 20px 30px;
+    margin: 0;
     @extend .sidebar;
     border-radius: 0 4px 4px 0;
     @include border-left(1px solid #ddd);
@@ -96,15 +98,20 @@ div.info-wrapper {
     h1 {
       @include text-align(left);
       margin-bottom: 0;
-      padding: 32px 26px 20px 26px;
+      padding: 12px 26px 20px 0;
       font-size: 18px;
       font-style: normal;
       font-weight: bold;
     }
 
+    ul {
+      background-color: #f6f6f6;
+      margin-bottom: 14px;
+    }
+
     ol {
+      margin-bottom: 14px;
       li {
-        margin: 0 26px 14px 26px;
         @include text-align(left);
 
         a {


### PR DESCRIPTION
Just a minor fix - [Add padding to Course Info sidebar](https://openedx.atlassian.net/browse/TNL-3095)

Before Fix  : 

<img width="1186" alt="screen shot 2015-08-20 at 4 28 48 pm" src="https://cloud.githubusercontent.com/assets/6991154/9382272/c1d024b8-4758-11e5-9ac0-c542ceea5b21.png">

After Fix : 
<img width="1215" alt="screen shot 2015-08-20 at 4 49 47 pm" src="https://cloud.githubusercontent.com/assets/6991154/9382555/830991f8-475b-11e5-9b8a-d1c44cee96f7.png">
