### PR TITLE
Upgrade django-babel-underscore to 0.3.0

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -13,7 +13,7 @@ celery==3.1.18
 cssselect==0.9.1
 dealer==2.0.4
 defusedxml==0.4.1
-django-babel-underscore==0.1.0
+django-babel-underscore==0.3.0
 django-celery==3.1.16
 django-countries==3.3
 django-extensions==1.2.5


### PR DESCRIPTION
Preparation for the [upgrade to Django 1.8](https://openedx.atlassian.net/wiki/display/TNL/Library+updates+needed+for+Django+upgrade+to+1.8).

From what I can tell, this is used by the translation pipeline but not the application code.  I was able to run  `paver i18n_generate` successfully after updating this requirement.

@sarina would you be able to review this?
FYI: @symbolist @macdiesel 
