### PR TITLE
Upgrade django-cors-headers to 1.1.0

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -116,7 +116,7 @@ transifex-client==0.10
 ipaddr==2.1.11
 
 # Used to allow to configure CORS headers for cross-domain requests
-django-cors-headers==0.13
+django-cors-headers==1.1.0
 
 # Debug toolbar
 django_debug_toolbar==1.2.2


### PR DESCRIPTION
More preparation for the [Django upgrade to 1.8](https://openedx.atlassian.net/wiki/display/TNL/Library+updates+needed+for+Django+upgrade+to+1.8).

This library is used to allow cross-domain requests to courses.edx.org, primarily by the marketing site and the E-Commerce service.  I validated the change by issuing a cross-domain request to devstack and verifying the headers:

![image](https://cloud.githubusercontent.com/assets/2948394/9394064/dd1b3e56-473a-11e5-8c1e-e2e01dd2d71a.png)

@clintonb would you be able to review this change?

FYI: @AlasdairSwan @ndubbaka @ronaldmulero This is unlikely to change anything in production, but when this is available in a staging environment we should go through the auto-enrollment flow from the marketing site to make sure.
