### PR TITLE
Upgrade django-crum to 0.6.1

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -124,7 +124,7 @@ chrono==1.0.2
 coverage==4.0b3
 ddt==0.8.0
 diff-cover==0.8.0
-django-crum==0.5
+django-crum==0.6.1
 django_nose==1.4.1
 factory_boy==2.2.1
 flaky==2.0.3


### PR DESCRIPTION
Preparation for the [Django 1.8 upgrade](https://openedx.atlassian.net/wiki/display/TNL/Library+updates+needed+for+Django+upgrade+to+1.8)

@chrisndodge It looks like you added this dependency a few years back.  Would you be able to review this change?  From what I can tell, we have pretty good test coverage for this in `xmodule`.

FYI: @macdiesel @symbolist 
