### PR TITLE
Fixed test_new_textbook_uplaod test that was failing on Chrome

### DIFF
--- a/common/test/acceptance/pages/studio/textbooks.py
+++ b/common/test/acceptance/pages/studio/textbooks.py
@@ -49,23 +49,15 @@ class TextbooksPage(CoursePage):
         file_input = self.q(css=".upload-dialog input").results[0]
         file_input.send_keys(file_path)
         click_css(self, ".wrapper-modal-window-assetupload .action-upload", require_notification=False)
-        self.wait_for_element_absence(".upload dialog", "Upload modal closed")
+        self.wait_for_element_absence(".modal-window-overlay", "Upload modal closed")
 
     def click_textbook_submit_button(self):
         """
         Submit the new textbook form and check if it is rendered properly.
         """
-        def click_save():
-            """
-            Continue to click the save button until the form is no longer present. Without this,
-            the test sporadically fails because the click is too early.
-            """
-            save_button = self.q(css='#edit_textbook_form button[type="submit"]').results
-            if len(save_button) > 0:
-                save_button[0].click()
-            return not self.q(css="#edit_textbook_form").present
-
-        self.wait_for(click_save, "Editing form should close.")
+        self.wait_for_element_visibility('#edit_textbook_form button[type="submit"]', 'Save button visibility')
+        self.q(css='#edit_textbook_form button[type="submit"]').first.click()
+        self.wait_for_element_absence(".wrapper-form", "Add/Edit form closed")
 
     def is_view_live_link_worked(self):
         """

--- a/common/test/acceptance/tests/studio/test_studio_textbooks.py
+++ b/common/test/acceptance/tests/studio/test_studio_textbooks.py
@@ -46,6 +46,6 @@ class TextbooksTest(StudioCourseTest):
         self.textbook_page.open_add_textbook_form()
         self.textbook_page.upload_pdf_file('textbook.pdf')
         self.textbook_page.set_input_field_value('.edit-textbook #textbook-name-input', 'book_1')
-        self.textbook_page.set_input_field_value('.edit-textbook #chapter1-name', 'chapter_1')
+        self.textbook_page.set_input_field_value('.edit-textbook #chapter1-name', 'chap_1')
         self.textbook_page.click_textbook_submit_button()
         self.assertTrue(self.textbook_page.is_view_live_link_worked())


### PR DESCRIPTION
@benpatterson Please review.

1- It seemed like we were waiting for wrong element abscence in upload_pdf_file. Changed that. So now we didn't need the code to hit the Save button again and again. Removed that. 
2- Inputting elements in text fields on Chrome has a pending issue https://code.google.com/p/chromedriver/issues/detail?id=1037, to make our tests not dependant on this, changed the string "chapter_1" to "chap_1". 
Findings: If you visibly run the test, the letter "e" was being sent as backspace and cursor moved to the next feild and edited 'Chapter Asset' field (that doesn't happen on Firefox). 
