### PR TITLE
Remove django-followit and django-keyedcache

### DIFF
--- a/docs/shared/requirements.txt
+++ b/docs/shared/requirements.txt
@@ -12,8 +12,6 @@ distribute>=0.6.28, <0.7
 django-celery==3.0.17
 django-countries==1.5
 django-filter==0.6.0
-django-followit==0.0.3
-django-keyedcache==1.4-6
 django-kombu==0.9.4
 django-mako==0.1.5pre
 django-masquerade==0.1.6

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -18,9 +18,7 @@ django-celery==3.1.16
 django-countries==3.3
 django-extensions==1.2.5
 django-filter==0.6.0
-django-followit==0.0.3
 django-ipware==1.1.0
-django-keyedcache==1.4-6
 django-kombu==0.9.4
 django-mako==0.1.5pre
 django-model-utils==1.4.0


### PR DESCRIPTION
While [assessing dependencies for the Django upgrade](https://openedx.atlassian.net/wiki/display/TNL/Library+updates+needed+for+Django+upgrade+to+1.8), @symbolist discovered that `django-followit` and `django-keyedcache` were not being used in the application code.

No references to `followit` or `keyedcache` appear in the edx-platform code-base.  Uninstalling these and re-installing dependencies doesn't cause them to reappear, so we're not keeping these to pin the version of some other dependency.

@jimabramson I can't figure out who added these originally -- would you be able to review this?
