### PR TITLE
Upgrade django-ipware to 1.1.0

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -19,6 +19,7 @@ django-countries==3.3
 django-extensions==1.2.5
 django-filter==0.6.0
 django-followit==0.0.3
+django-ipware==1.1.0
 django-keyedcache==1.4-6
 django-kombu==0.9.4
 django-mako==0.1.5pre

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -16,7 +16,6 @@ git+https://github.com/edx/django-staticfiles.git@031bdeaea85798b8c284e2a09977df
 git+https://github.com/edx/nltk.git@2.0.6#egg=nltk==2.0.6
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev
 -e git+https://github.com/eventbrite/zendesk.git@d53fe0e81b623f084e91776bcf6369f8b7b63879#egg=zendesk
--e git+https://github.com/un33k/django-ipware.git@42cb1bb1dc680a60c6452e8bb2b843c2a0382c90#egg=django-ipware
 -e git+https://github.com/appliedsec/pygeoip.git@95e69341cebf5a6a9fbf7c4f5439d458898bdc3b#egg=pygeoip
 -e git+https://github.com/jazkarta/edx-jsme.git@c5bfa5d361d6685d8c643838fc0055c25f8b7999#egg=edx-jsme
 -e git+https://github.com/pmitros/django-pyfs.git@d175715e0fe3367ec0f1ee429c242d603f6e8b10#egg=djpyfs


### PR DESCRIPTION
Pre-work for the [Django 1.8 upgrade](https://openedx.atlassian.net/wiki/display/TNL/Library+updates+needed+for+Django+upgrade+to+1.8).

`django-ipware` is used to determine a user's IP address from HTTP request headers to enforce embargo rules.  There are extensive unit tests of this functionality, both in the `embargo` app itself and at integration points that call the embargo API.

I was a little concerned about how `pip` would handle switching from a GitHub hash to a PyPi version, but it seemed to do the right thing in devstack (removing the old dependency and installing the new one).

@dianakhuang would you be able to review this change?
