### PR TITLE
Upgrade django-extensions to 1.5.5

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -16,7 +16,7 @@ defusedxml==0.4.1
 django-babel-underscore==0.3.0
 django-celery==3.1.16
 django-countries==3.3
-django-extensions==1.2.5
+django-extensions==1.5.5
 django-filter==0.6.0
 django-followit==0.0.3
 django-keyedcache==1.4-6

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -40,8 +40,8 @@ git+https://github.com/edx/rfc6266.git@v0.0.5-edx#egg=rfc6266==0.0.5-edx
 -e git+https://github.com/edx/event-tracking.git@0.2.0#egg=event-tracking
 -e git+https://github.com/edx-solutions/django-splash.git@7579d052afcf474ece1239153cffe1c89935bc4f#egg=django-splash
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
--e git+https://github.com/edx/edx-ora2.git@release-2015-08-19T17.17#egg=edx-ora2
--e git+https://github.com/edx/edx-submissions.git@7c766502058e04bc9094e6cbe286e949794b80b3#egg=edx-submissions
+-e git+https://github.com/edx/edx-ora2.git@release-2015-08-21T16.14#egg=edx-ora2
+-e git+https://github.com/edx/edx-submissions.git@906c7b7a27e1a8684834334a4bf7fb50a3aede30#egg=edx-submissions
 -e git+https://github.com/edx/opaque-keys.git@27dc382ea587483b1e3889a3d19cbd90b9023a06#egg=opaque-keys
 git+https://github.com/edx/ease.git@release-2015-07-14#egg=ease==0.1.3
 git+https://github.com/edx/i18n-tools.git@v0.1.3#egg=i18n-tools==v0.1.3


### PR DESCRIPTION
Pre-work for the [Django 1.8 upgrade](https://openedx.atlassian.net/wiki/display/TNL/Library+updates+needed+for+Django+upgrade+to+1.8).

Updates django-extensions to 1.5.5.  The changes to edx-ora2 and edx-submissions make the same change in those repositories.  (See https://github.com/edx/edx-ora2/pull/715 and https://github.com/edx/edx-submissions/pull/17)

I tested this using the ORA2 problem in the demo course on devstack.

@rlucioni Could you please review this?  Last one in the upgrade dance for this particular requirement.
