### PR TITLE
Fixed vote bug in discussion api

### DIFF
--- a/lms/djangoapps/discussion_api/api.py
+++ b/lms/djangoapps/discussion_api/api.py
@@ -670,6 +670,7 @@ def update_thread(request, thread_id, update_data):
     # Only save thread object if some of the edited fields are in the thread data, not extra actions
     if set(update_data) - set(actions_form.fields):
         serializer.save()
+        cc_thread, context = _get_thread_and_context(request, thread_id)
         thread_edited.send(sender=None, user=request.user, post=cc_thread)
     api_thread = serializer.data
     _do_extra_actions(api_thread, cc_thread, update_data.keys(), actions_form, context)

--- a/lms/djangoapps/discussion_api/api.py
+++ b/lms/djangoapps/discussion_api/api.py
@@ -670,7 +670,6 @@ def update_thread(request, thread_id, update_data):
     # Only save thread object if some of the edited fields are in the thread data, not extra actions
     if set(update_data) - set(actions_form.fields):
         serializer.save()
-        cc_thread, context = _get_thread_and_context(request, thread_id)
         thread_edited.send(sender=None, user=request.user, post=cc_thread)
     api_thread = serializer.data
     _do_extra_actions(api_thread, cc_thread, update_data.keys(), actions_form, context)

--- a/lms/djangoapps/discussion_api/tests/test_api.py
+++ b/lms/djangoapps/discussion_api/tests/test_api.py
@@ -1970,7 +1970,6 @@ class UpdateThreadTest(
                 "pinned": ["False"],
             }
         )
-        self.assertEqual(1,2)
 
     def test_nonexistent_thread(self):
         self.register_get_thread_error_response("test_thread", 404)
@@ -2179,9 +2178,9 @@ class UpdateThreadTest(
             self.register_get_user_response(self.user2, upvoted_ids=["test_thread"])
             vote_count += 1
 
-        for (current_vote, user_vote, request) in [
-            (current_user1_vote, user1_vote, self.request) ,
-            (current_user2_vote, user2_vote, self.request2)]:
+        for (current_vote, user_vote, request) in \
+                [(current_user1_vote, user1_vote, self.request),
+                 (current_user2_vote, user2_vote, self.request2)]:
 
             self.register_thread_votes_response("test_thread")
             self.register_thread(overrides={"votes": {"up_count": vote_count}})
@@ -2574,9 +2573,9 @@ class UpdateCommentTest(
             self.register_get_user_response(self.user2, upvoted_ids=["test_comment"])
             vote_count += 1
 
-        for (current_vote, user_vote, request) in [
-            (current_user1_vote, user1_vote, self.request) ,
-            (current_user2_vote, user2_vote, self.request2)]:
+        for (current_vote, user_vote, request) in \
+                [(current_user1_vote, user1_vote, self.request),
+                 (current_user2_vote, user2_vote, self.request2)]:
 
             self.register_comment_votes_response("test_comment")
             self.register_comment(overrides={"votes": {"up_count": vote_count}})

--- a/lms/djangoapps/discussion_api/tests/test_api.py
+++ b/lms/djangoapps/discussion_api/tests/test_api.py
@@ -1890,8 +1890,6 @@ class UpdateThreadTest(
         self.request2.user = self.user2
         CourseEnrollmentFactory.create(user=self.user2, course_id=self.course.id)
 
-
-
     def register_thread(self, overrides=None):
         """
         Make a thread with appropriate data overridden by the overrides
@@ -2211,8 +2209,6 @@ class UpdateThreadTest(
         else:
             vote_count -= 1
             self.assertEqual(result["vote_count"], vote_count)
-
-
 
     @ddt.data(*itertools.product([True, False], [True, False]))
     @ddt.unpack

--- a/lms/djangoapps/discussion_api/tests/test_api.py
+++ b/lms/djangoapps/discussion_api/tests/test_api.py
@@ -1970,6 +1970,7 @@ class UpdateThreadTest(
                 "pinned": ["False"],
             }
         )
+        self.assertEqual(1,2)
 
     def test_nonexistent_thread(self):
         self.register_get_thread_error_response("test_thread", 404)
@@ -2178,37 +2179,25 @@ class UpdateThreadTest(
             self.register_get_user_response(self.user2, upvoted_ids=["test_thread"])
             vote_count += 1
 
-        self.register_thread_votes_response("test_thread")
-        self.register_thread(overrides={"votes": {"up_count": vote_count}})
+        for (current_vote, user_vote, request) in [
+            (current_user1_vote, user1_vote, self.request) ,
+            (current_user2_vote, user2_vote, self.request2)]:
 
-        # first user vote
-        data = {"voted": user1_vote}
-        result = update_thread(self.request, "test_thread", data)
-        if current_user1_vote == user1_vote:
-            self.assertEqual(result["vote_count"], vote_count)
-        elif user1_vote:
-            vote_count += 1
-            self.assertEqual(result["vote_count"], vote_count)
-            self.register_get_user_response(self.user, upvoted_ids=["test_thread"])
-        else:
-            vote_count -= 1
-            self.assertEqual(result["vote_count"], vote_count)
-            self.register_get_user_response(self.user, upvoted_ids=[])
+            self.register_thread_votes_response("test_thread")
+            self.register_thread(overrides={"votes": {"up_count": vote_count}})
 
-        self.register_thread_votes_response("test_thread")
-        self.register_thread(overrides={"votes": {"up_count": vote_count}})
-
-        # second user vote
-        data = {"voted": user2_vote}
-        result = update_thread(self.request2, "test_thread", data)
-        if current_user2_vote == user2_vote:
-            self.assertEqual(result["vote_count"], vote_count)
-        elif user2_vote:
-            vote_count += 1
-            self.assertEqual(result["vote_count"], vote_count)
-        else:
-            vote_count -= 1
-            self.assertEqual(result["vote_count"], vote_count)
+            data = {"voted": user_vote}
+            result = update_thread(request, "test_thread", data)
+            if current_vote == user_vote:
+                self.assertEqual(result["vote_count"], vote_count)
+            elif user_vote:
+                vote_count += 1
+                self.assertEqual(result["vote_count"], vote_count)
+                self.register_get_user_response(self.user, upvoted_ids=["test_thread"])
+            else:
+                vote_count -= 1
+                self.assertEqual(result["vote_count"], vote_count)
+                self.register_get_user_response(self.user, upvoted_ids=[])
 
     @ddt.data(*itertools.product([True, False], [True, False]))
     @ddt.unpack
@@ -2577,7 +2566,6 @@ class UpdateCommentTest(
         """
         Tests vote_count increases and decreases correctly from different users
         """
-        #setup
         vote_count = 0
         if current_user1_vote:
             self.register_get_user_response(self.user, upvoted_ids=["test_comment"])
@@ -2586,37 +2574,25 @@ class UpdateCommentTest(
             self.register_get_user_response(self.user2, upvoted_ids=["test_comment"])
             vote_count += 1
 
-        self.register_comment_votes_response("test_comment")
-        self.register_comment(overrides={"votes": {"up_count": vote_count}})
+        for (current_vote, user_vote, request) in [
+            (current_user1_vote, user1_vote, self.request) ,
+            (current_user2_vote, user2_vote, self.request2)]:
 
-        # first user vote
-        data = {"voted": user1_vote}
-        result = update_comment(self.request, "test_comment", data)
-        if current_user1_vote == user1_vote:
-            self.assertEqual(result["vote_count"], vote_count)
-        elif user1_vote:
-            vote_count += 1
-            self.assertEqual(result["vote_count"], vote_count)
-            self.register_get_user_response(self.user, upvoted_ids=["test_comment"])
-        else:
-            vote_count -= 1
-            self.assertEqual(result["vote_count"], vote_count)
-            self.register_get_user_response(self.user, upvoted_ids=[])
+            self.register_comment_votes_response("test_comment")
+            self.register_comment(overrides={"votes": {"up_count": vote_count}})
 
-        self.register_comment_votes_response("test_thread")
-        self.register_comment(overrides={"votes": {"up_count": vote_count}})
-
-        # second user vote
-        data = {"voted": user2_vote}
-        result = update_comment(self.request2, "test_comment", data)
-        if current_user2_vote == user2_vote:
-            self.assertEqual(result["vote_count"], vote_count)
-        elif user2_vote:
-            vote_count += 1
-            self.assertEqual(result["vote_count"], vote_count)
-        else:
-            vote_count -= 1
-            self.assertEqual(result["vote_count"], vote_count)
+            data = {"voted": user_vote}
+            result = update_comment(request, "test_comment", data)
+            if current_vote == user_vote:
+                self.assertEqual(result["vote_count"], vote_count)
+            elif user_vote:
+                vote_count += 1
+                self.assertEqual(result["vote_count"], vote_count)
+                self.register_get_user_response(self.user, upvoted_ids=["test_comment"])
+            else:
+                vote_count -= 1
+                self.assertEqual(result["vote_count"], vote_count)
+                self.register_get_user_response(self.user, upvoted_ids=[])
 
     @ddt.data(*itertools.product([True, False], [True, False]))
     @ddt.unpack


### PR DESCRIPTION
Fixed a voting bug in the discussion API. The response object was not returning the updated vote_count although the actual change was made in the database.

Updated unit tests which previously did not check the `vote_count`.

@nasthagiri @tlindaliu 
