### PR TITLE
Prevent publish orphans

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split_draft.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split_draft.py
@@ -198,6 +198,16 @@ class DraftVersioningModuleStore(SplitMongoModuleStore, ModuleStoreDraftAndPubli
                 branches_to_delete = [ModuleStoreEnum.BranchName.published, ModuleStoreEnum.BranchName.draft]
             elif revision is None:
                 branches_to_delete = [ModuleStoreEnum.BranchName.draft]
+                draft_location = location.for_branch(ModuleStoreEnum.BranchName.draft)
+                try:
+                    item = self.get_item(draft_location)
+                    if getattr(item, 'has_children', False):
+                        # If item have has_published_version then delete published children also.
+                        if self.has_published_version(item):
+                            branches_to_delete.insert(0, ModuleStoreEnum.BranchName.published)
+                except ItemNotFoundError:
+                    # Raises ValueError as in function description
+                    raise ValueError("Cannot delete a block that does not exist")
             else:
                 raise UnsupportedRevisionError(
                     [


### PR DESCRIPTION
[PLAT-799](https://openedx.atlassian.net/browse/PLAT-799)

**Problem**:
When we delete an item which is in published state then only draft children delete but not published ones  and producing published orphans.

**Solution**:
When delete an item call is send with `revision=None`  it deletes only `draft` children, now we check that if item have `published` version then delete the `published` children also.
