### PR TITLE
Remove unnecessary New Relic trace.

### DIFF
--- a/lms/djangoapps/teams/views.py
+++ b/lms/djangoapps/teams/views.py
@@ -5,7 +5,6 @@ from django.http import Http404
 from django.conf import settings
 from django.core.paginator import Paginator
 from django.views.generic.base import View
-import newrelic.agent
 from rest_framework.generics import GenericAPIView
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
@@ -284,7 +283,6 @@ class TeamsListView(ExpandableFieldViewMixin, GenericAPIView):
     pagination_serializer_class = PaginationSerializer
     serializer_class = CourseTeamSerializer
 
-    @newrelic.agent.function_trace()
     def get(self, request):
         """GET /api/team/v0/teams/"""
         result_filter = {


### PR DESCRIPTION
@cahrens @dianakhuang I added this a while ago when investigating why `TeamsListView.get` was slow, but forgot to take it out after the performance issue was fixed. I don't see any good reason to keep it around.
