### PR TITLE
Speed up Instructor Dash tests + add manual reset for SharedModuleStoreTestCase

### DIFF
--- a/lms/djangoapps/instructor/tests/test_access.py
+++ b/lms/djangoapps/instructor/tests/test_access.py
@@ -6,7 +6,7 @@ from nose.tools import raises
 from nose.plugins.attrib import attr
 from student.tests.factories import UserFactory
 from xmodule.modulestore.tests.factories import CourseFactory
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 
 from student.roles import CourseBetaTesterRole, CourseStaffRole
 
@@ -19,13 +19,15 @@ from instructor.access import (allow_access,
 
 
 @attr('shard_1')
-class TestInstructorAccessList(ModuleStoreTestCase):
+class TestInstructorAccessList(SharedModuleStoreTestCase):
     """ Test access listings. """
+    @classmethod
+    def setUpClass(cls):
+        super(TestInstructorAccessList, cls).setUpClass()
+        cls.course = CourseFactory.create()
+
     def setUp(self):
         super(TestInstructorAccessList, self).setUp()
-
-        self.course = CourseFactory.create()
-
         self.instructors = [UserFactory.create() for _ in xrange(4)]
         for user in self.instructors:
             allow_access(self.course, user, 'instructor')
@@ -43,8 +45,13 @@ class TestInstructorAccessList(ModuleStoreTestCase):
 
 
 @attr('shard_1')
-class TestInstructorAccessAllow(ModuleStoreTestCase):
+class TestInstructorAccessAllow(SharedModuleStoreTestCase):
     """ Test access allow. """
+    @classmethod
+    def setUpClass(cls):
+        super(TestInstructorAccessAllow, cls).setUpClass()
+        cls.course = CourseFactory.create()
+
     def setUp(self):
         super(TestInstructorAccessAllow, self).setUp()
 
@@ -79,13 +86,15 @@ class TestInstructorAccessAllow(ModuleStoreTestCase):
 
 
 @attr('shard_1')
-class TestInstructorAccessRevoke(ModuleStoreTestCase):
+class TestInstructorAccessRevoke(SharedModuleStoreTestCase):
     """ Test access revoke. """
+    @classmethod
+    def setUpClass(cls):
+        super(TestInstructorAccessRevoke, cls).setUpClass()
+        cls.course = CourseFactory.create()
+
     def setUp(self):
         super(TestInstructorAccessRevoke, self).setUp()
-
-        self.course = CourseFactory.create()
-
         self.staff = [UserFactory.create() for _ in xrange(4)]
         for user in self.staff:
             allow_access(self.course, user, 'staff')
@@ -115,15 +124,17 @@ class TestInstructorAccessRevoke(ModuleStoreTestCase):
 
 
 @attr('shard_1')
-class TestInstructorAccessForum(ModuleStoreTestCase):
+class TestInstructorAccessForum(SharedModuleStoreTestCase):
     """
     Test forum access control.
     """
+    @classmethod
+    def setUpClass(cls):
+        super(TestInstructorAccessForum, cls).setUpClass()
+        cls.course = CourseFactory.create()
+
     def setUp(self):
         super(TestInstructorAccessForum, self).setUp()
-
-        self.course = CourseFactory.create()
-
         self.mod_role = Role.objects.create(
             course_id=self.course.id,
             name=FORUM_ROLE_MODERATOR

--- a/lms/djangoapps/instructor/tests/test_api_email_localization.py
+++ b/lms/djangoapps/instructor/tests/test_api_email_localization.py
@@ -13,15 +13,19 @@ from student.models import CourseEnrollment
 from student.tests.factories import UserFactory
 from openedx.core.djangoapps.user_api.preferences.api import set_user_preference
 from xmodule.modulestore.tests.factories import CourseFactory
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 
 
 @attr('shard_1')
-class TestInstructorAPIEnrollmentEmailLocalization(ModuleStoreTestCase):
+class TestInstructorAPIEnrollmentEmailLocalization(SharedModuleStoreTestCase):
     """
     Test whether the enroll, unenroll and beta role emails are sent in the
     proper language, i.e: the student's language.
     """
+    @classmethod
+    def setUpClass(cls):
+        super(TestInstructorAPIEnrollmentEmailLocalization, cls).setUpClass()
+        cls.course = CourseFactory.create()
 
     def setUp(self):
         super(TestInstructorAPIEnrollmentEmailLocalization, self).setUp()
@@ -29,7 +33,6 @@ class TestInstructorAPIEnrollmentEmailLocalization(ModuleStoreTestCase):
         # Platform language is English, instructor's language is Chinese,
         # student's language is French, so the emails should all be sent in
         # French.
-        self.course = CourseFactory.create()
         self.instructor = InstructorFactory(course_key=self.course.id)
         set_user_preference(self.instructor, LANGUAGE_KEY, 'zh-cn')
         self.client.login(username=self.instructor.username, password='test')

--- a/lms/djangoapps/instructor/tests/test_certificates.py
+++ b/lms/djangoapps/instructor/tests/test_certificates.py
@@ -8,7 +8,7 @@ from nose.plugins.attrib import attr
 from django.core.urlresolvers import reverse
 from django.test.utils import override_settings
 from django.conf import settings
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 from config_models.models import cache
 from courseware.tests.factories import GlobalStaffFactory, InstructorFactory, UserFactory
@@ -18,19 +18,23 @@ from certificates import api as certs_api
 
 @attr('shard_1')
 @ddt.ddt
-class CertificatesInstructorDashTest(ModuleStoreTestCase):
+class CertificatesInstructorDashTest(SharedModuleStoreTestCase):
     """Tests for the certificate panel of the instructor dash. """
 
     ERROR_REASON = "An error occurred!"
     DOWNLOAD_URL = "http://www.example.com/abcd123/cert.pdf"
 
+    @classmethod
+    def setUpClass(cls):
+        super(CertificatesInstructorDashTest, cls).setUpClass()
+        cls.course = CourseFactory.create()
+        cls.url = reverse(
+            'instructor_dashboard',
+            kwargs={'course_id': unicode(cls.course.id)}
+        )
+
     def setUp(self):
         super(CertificatesInstructorDashTest, self).setUp()
-        self.course = CourseFactory.create()
-        self.url = reverse(
-            'instructor_dashboard',
-            kwargs={'course_id': unicode(self.course.id)}
-        )
         self.global_staff = GlobalStaffFactory()
         self.instructor = InstructorFactory(course_key=self.course.id)
 
@@ -189,12 +193,15 @@ class CertificatesInstructorDashTest(ModuleStoreTestCase):
 @attr('shard_1')
 @override_settings(CERT_QUEUE='certificates')
 @ddt.ddt
-class CertificatesInstructorApiTest(ModuleStoreTestCase):
+class CertificatesInstructorApiTest(SharedModuleStoreTestCase):
     """Tests for the certificates end-points in the instructor dash API. """
+    @classmethod
+    def setUpClass(cls):
+        super(CertificatesInstructorApiTest, cls).setUpClass()
+        cls.course = CourseFactory.create()
 
     def setUp(self):
         super(CertificatesInstructorApiTest, self).setUp()
-        self.course = CourseFactory.create()
         self.global_staff = GlobalStaffFactory()
         self.instructor = InstructorFactory(course_key=self.course.id)
 

--- a/lms/djangoapps/instructor/tests/test_ecommerce.py
+++ b/lms/djangoapps/instructor/tests/test_ecommerce.py
@@ -13,18 +13,26 @@ from course_modes.models import CourseMode
 from student.roles import CourseFinanceAdminRole
 from shoppingcart.models import Coupon, CourseRegistrationCode
 from student.tests.factories import AdminFactory
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
 
 @attr('shard_1')
-class TestECommerceDashboardViews(ModuleStoreTestCase):
+class TestECommerceDashboardViews(SharedModuleStoreTestCase):
     """
     Check for E-commerce view on the new instructor dashboard
     """
+    @classmethod
+    def setUpClass(cls):
+        super(TestECommerceDashboardViews, cls).setUpClass()
+        cls.course = CourseFactory.create()
+
+        # URL for instructor dash
+        cls.url = reverse('instructor_dashboard', kwargs={'course_id': cls.course.id.to_deprecated_string()})
+        cls.e_commerce_link = '<a href="" data-section="e-commerce">E-Commerce</a>'
+
     def setUp(self):
         super(TestECommerceDashboardViews, self).setUp()
-        self.course = CourseFactory.create()
 
         # Create instructor account
         self.instructor = AdminFactory.create()
@@ -34,9 +42,6 @@ class TestECommerceDashboardViews(ModuleStoreTestCase):
             mode_display_name='honor', min_price=10, currency='usd'
         )
         mode.save()
-        # URL for instructor dash
-        self.url = reverse('instructor_dashboard', kwargs={'course_id': self.course.id.to_deprecated_string()})
-        self.e_commerce_link = '<a href="" data-section="e-commerce">E-Commerce</a>'
         CourseFinanceAdminRole(self.course.id).add_users(self.instructor)
 
     def test_pass_e_commerce_tab_in_instructor_dashboard(self):

--- a/lms/djangoapps/instructor/tests/test_email.py
+++ b/lms/djangoapps/instructor/tests/test_email.py
@@ -11,29 +11,35 @@ from nose.plugins.attrib import attr
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
 
 from bulk_email.models import CourseAuthorization
-from xmodule.modulestore.tests.django_utils import TEST_DATA_MIXED_TOY_MODULESTORE, ModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import (
+    TEST_DATA_MIXED_TOY_MODULESTORE, SharedModuleStoreTestCase
+)
 from student.tests.factories import AdminFactory
 from xmodule.modulestore.tests.factories import CourseFactory
 
 
 @attr('shard_1')
-class TestNewInstructorDashboardEmailViewMongoBacked(ModuleStoreTestCase):
+class TestNewInstructorDashboardEmailViewMongoBacked(SharedModuleStoreTestCase):
     """
     Check for email view on the new instructor dashboard
     for Mongo-backed courses
     """
+    @classmethod
+    def setUpClass(cls):
+        super(TestNewInstructorDashboardEmailViewMongoBacked, cls).setUpClass()
+        cls.course = CourseFactory.create()
+
+        # URL for instructor dash
+        cls.url = reverse('instructor_dashboard', kwargs={'course_id': cls.course.id.to_deprecated_string()})
+        # URL for email view
+        cls.email_link = '<a href="" data-section="send_email">Email</a>'
+
     def setUp(self):
         super(TestNewInstructorDashboardEmailViewMongoBacked, self).setUp()
-        self.course = CourseFactory.create()
 
         # Create instructor account
         instructor = AdminFactory.create()
         self.client.login(username=instructor.username, password="test")
-
-        # URL for instructor dash
-        self.url = reverse('instructor_dashboard', kwargs={'course_id': self.course.id.to_deprecated_string()})
-        # URL for email view
-        self.email_link = '<a href="" data-section="send_email">Email</a>'
 
     # In order for bulk email to work, we must have both the ENABLE_INSTRUCTOR_EMAIL_FLAG
     # set to True and for the course to be Mongo-backed.
@@ -101,16 +107,25 @@ class TestNewInstructorDashboardEmailViewMongoBacked(ModuleStoreTestCase):
 
 
 @attr('shard_1')
-class TestNewInstructorDashboardEmailViewXMLBacked(ModuleStoreTestCase):
+class TestNewInstructorDashboardEmailViewXMLBacked(SharedModuleStoreTestCase):
     """
     Check for email view on the new instructor dashboard
     """
 
     MODULESTORE = TEST_DATA_MIXED_TOY_MODULESTORE
 
+    @classmethod
+    def setUpClass(cls):
+        super(TestNewInstructorDashboardEmailViewXMLBacked, cls).setUpClass()
+        cls.course_key = SlashSeparatedCourseKey('edX', 'toy', '2012_Fall')
+
+        # URL for instructor dash
+        cls.url = reverse('instructor_dashboard', kwargs={'course_id': cls.course_key.to_deprecated_string()})
+        # URL for email view
+        cls.email_link = '<a href="" data-section="send_email">Email</a>'
+
     def setUp(self):
         super(TestNewInstructorDashboardEmailViewXMLBacked, self).setUp()
-        self.course_key = SlashSeparatedCourseKey('edX', 'toy', '2012_Fall')
 
         # Create instructor account
         instructor = AdminFactory.create()

--- a/lms/djangoapps/instructor/tests/test_hint_manager.py
+++ b/lms/djangoapps/instructor/tests/test_hint_manager.py
@@ -8,14 +8,21 @@ from courseware.models import XModuleUserStateSummaryField
 from courseware.tests.factories import UserStateSummaryFactory
 import instructor.hint_manager as view
 from student.tests.factories import UserFactory
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
 # pylint: disable=missing-docstring
 
 
 @attr('shard_1')
-class HintManagerTest(ModuleStoreTestCase):
+class HintManagerTest(SharedModuleStoreTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(HintManagerTest, cls).setUpClass()
+        cls.course = CourseFactory.create(org='Me', number='19.002', display_name='test_course')
+        cls.url = '/courses/Me/19.002/test_course/hint_manager'
+        cls.course_id = cls.course.id
+        cls.problem_id = cls.course_id.make_usage_key('crowdsource_hinter', 'crowdsource_hinter_001')
 
     def setUp(self):
         """
@@ -24,13 +31,9 @@ class HintManagerTest(ModuleStoreTestCase):
         """
         super(HintManagerTest, self).setUp()
 
-        self.course = CourseFactory.create(org='Me', number='19.002', display_name='test_course')
-        self.url = '/courses/Me/19.002/test_course/hint_manager'
         self.user = UserFactory.create(username='robot', email='robot@edx.org', password='test', is_staff=True)
         self.c = Client()
         self.c.login(username='robot', password='test')
-        self.course_id = self.course.id
-        self.problem_id = self.course_id.make_usage_key('crowdsource_hinter', 'crowdsource_hinter_001')
         UserStateSummaryFactory.create(
             field_name='hints',
             usage_id=self.problem_id,

--- a/lms/djangoapps/instructor/tests/test_legacy_enrollment.py
+++ b/lms/djangoapps/instructor/tests/test_legacy_enrollment.py
@@ -12,7 +12,7 @@ from django.core.urlresolvers import reverse
 from courseware.tests.helpers import LoginEnrollmentTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 from student.tests.factories import UserFactory, CourseEnrollmentFactory, AdminFactory
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from student.models import CourseEnrollment, CourseEnrollmentAllowed
 from instructor.views.legacy import get_and_clean_student_list, send_mail_to_student
 from django.core import mail
@@ -22,18 +22,20 @@ USER_COUNT = 4
 
 @attr('shard_1')
 @ddt.ddt
-class TestInstructorEnrollsStudent(ModuleStoreTestCase, LoginEnrollmentTestCase):
+class TestInstructorEnrollsStudent(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     Check Enrollment/Unenrollment with/without auto-enrollment on activation and with/without email notification
     """
+    @classmethod
+    def setUpClass(cls):
+        super(TestInstructorEnrollsStudent, cls).setUpClass()
+        cls.course = CourseFactory.create()
 
     def setUp(self):
         super(TestInstructorEnrollsStudent, self).setUp()
 
         instructor = AdminFactory.create()
         self.client.login(username=instructor.username, password='test')
-
-        self.course = CourseFactory.create()
 
         self.users = [
             UserFactory.create(username="student%d" % i, email="student%d@test.com" % i)

--- a/lms/djangoapps/instructor/tests/test_legacy_xss.py
+++ b/lms/djangoapps/instructor/tests/test_legacy_xss.py
@@ -9,7 +9,7 @@ from nose.plugins.attrib import attr
 
 from student.tests.factories import UserFactory, CourseEnrollmentFactory
 from edxmako.tests import mako_middleware_process_request
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
 from instructor.views import legacy
@@ -18,12 +18,16 @@ from instructor.views import legacy
 
 
 @attr('shard_1')
-class TestXss(ModuleStoreTestCase):
+class TestXss(SharedModuleStoreTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestXss, cls).setUpClass()
+        cls._course = CourseFactory.create()
+
     def setUp(self):
         super(TestXss, self).setUp()
 
         self._request_factory = RequestFactory()
-        self._course = CourseFactory.create()
         self._evil_student = UserFactory.create(
             email="robot+evil@edx.org",
             username="evil-robot",

--- a/lms/djangoapps/instructor/tests/test_registration_codes.py
+++ b/lms/djangoapps/instructor/tests/test_registration_codes.py
@@ -15,19 +15,22 @@ import json
 from student.tests.factories import UserFactory, CourseModeFactory
 from django.core.urlresolvers import reverse
 from django.test.utils import override_settings
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 
 
 @attr('shard_1')
 @override_settings(REGISTRATION_CODE_LENGTH=8)
-class TestCourseRegistrationCodeStatus(ModuleStoreTestCase):
+class TestCourseRegistrationCodeStatus(SharedModuleStoreTestCase):
     """
     Test registration code status.
     """
+    @classmethod
+    def setUpClass(cls):
+        super(TestCourseRegistrationCodeStatus, cls).setUpClass()
+        cls.course = CourseFactory.create()
 
     def setUp(self):
         super(TestCourseRegistrationCodeStatus, self).setUp()
-        self.course = CourseFactory.create()
         CourseModeFactory.create(course_id=self.course.id, min_price=50)
         self.instructor = InstructorFactory(course_key=self.course.id)
         self.client.login(username=self.instructor.username, password='test')

--- a/lms/djangoapps/instructor/tests/test_services.py
+++ b/lms/djangoapps/instructor/tests/test_services.py
@@ -3,7 +3,7 @@ Tests for the InstructorService
 """
 
 import json
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 from courseware.models import StudentModule
 from instructor.services import InstructorService
@@ -15,30 +15,30 @@ from student.tests.factories import UserFactory
 
 
 @attr('shard_1')
-class InstructorServiceTests(ModuleStoreTestCase):
+class InstructorServiceTests(SharedModuleStoreTestCase):
     """
     Tests for the InstructorService
     """
+    @classmethod
+    def setUpClass(cls):
+        super(InstructorServiceTests, cls).setUpClass()
+        cls.course = CourseFactory.create()
+        cls.problem_location = msk_from_problem_urlname(
+            cls.course.id,
+            'robot-some-problem-urlname'
+        )
+        cls.other_problem_location = msk_from_problem_urlname(
+            cls.course.id,
+            'robot-some-other_problem-urlname'
+        )
+        cls.problem_urlname = unicode(cls.problem_location)
+        cls.other_problem_urlname = unicode(cls.other_problem_location)
 
     def setUp(self):
         super(InstructorServiceTests, self).setUp()
 
-        self.course = CourseFactory.create()
         self.student = UserFactory()
         CourseEnrollment.enroll(self.student, self.course.id)
-
-        self.problem_location = msk_from_problem_urlname(
-            self.course.id,
-            'robot-some-problem-urlname'
-        )
-
-        self.other_problem_location = msk_from_problem_urlname(
-            self.course.id,
-            'robot-some-other_problem-urlname'
-        )
-
-        self.problem_urlname = unicode(self.problem_location)
-        self.other_problem_urlname = unicode(self.other_problem_location)
 
         self.service = InstructorService()
         self.module_to_reset = StudentModule.objects.create(

--- a/lms/djangoapps/instructor/tests/test_spoc_gradebook.py
+++ b/lms/djangoapps/instructor/tests/test_spoc_gradebook.py
@@ -6,7 +6,7 @@ from django.core.urlresolvers import reverse
 from nose.plugins.attrib import attr
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 from student.tests.factories import UserFactory, CourseEnrollmentFactory, AdminFactory
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from capa.tests.response_xml_factory import StringResponseXMLFactory
 from courseware.tests.factories import StudentModuleFactory
 from xmodule.modulestore.django import modulestore
@@ -16,7 +16,7 @@ USER_COUNT = 11
 
 
 @attr('shard_1')
-class TestGradebook(ModuleStoreTestCase):
+class TestGradebook(SharedModuleStoreTestCase):
     """
     Test functionality of the spoc gradebook. Sets up a course with assignments and
     students who've scored various scores on these assignments. Base class for further
@@ -24,45 +24,48 @@ class TestGradebook(ModuleStoreTestCase):
     """
     grading_policy = None
 
+    @classmethod
+    def setUpClass(cls):
+        super(TestGradebook, cls).setUpClass()
+
+        # Create a course with the desired grading policy (from our class attribute)
+        kwargs = {}
+        if cls.grading_policy is not None:
+            kwargs['grading_policy'] = cls.grading_policy
+        cls.course = CourseFactory.create(**kwargs)
+
+        # Now give it some content
+        with cls.store.bulk_operations(cls.course.id, emit_signals=False):
+            chapter = ItemFactory.create(
+                parent_location=cls.course.location,
+                category="sequential",
+            )
+            section = ItemFactory.create(
+                parent_location=chapter.location,
+                category="sequential",
+                metadata={'graded': True, 'format': 'Homework'}
+            )
+            cls.items = [
+                ItemFactory.create(
+                    parent_location=section.location,
+                    category="problem",
+                    data=StringResponseXMLFactory().build_xml(answer='foo'),
+                    metadata={'rerandomize': 'always'}
+                )
+                for __ in xrange(USER_COUNT - 1)
+            ]
+
     def setUp(self):
         super(TestGradebook, self).setUp()
 
         instructor = AdminFactory.create()
         self.client.login(username=instructor.username, password='test')
-
-        # remove the caches
-        modulestore().request_cache = None
-        modulestore().metadata_inheritance_cache_subsystem = None
-
-        kwargs = {}
-        if self.grading_policy is not None:
-            kwargs['grading_policy'] = self.grading_policy
-
-        self.course = CourseFactory.create(**kwargs)
-        chapter = ItemFactory.create(
-            parent_location=self.course.location,
-            category="sequential",
-        )
-        section = ItemFactory.create(
-            parent_location=chapter.location,
-            category="sequential",
-            metadata={'graded': True, 'format': 'Homework'}
-        )
-
         self.users = [UserFactory.create() for _ in xrange(USER_COUNT)]
 
         for user in self.users:
             CourseEnrollmentFactory.create(user=user, course_id=self.course.id)
 
-        for i in xrange(USER_COUNT - 1):
-            category = "problem"
-            item = ItemFactory.create(
-                parent_location=section.location,
-                category=category,
-                data=StringResponseXMLFactory().build_xml(answer='foo'),
-                metadata={'rerandomize': 'always'}
-            )
-
+        for i, item in enumerate(self.items):
             for j, user in enumerate(self.users):
                 StudentModuleFactory.create(
                     grade=1 if i < j else 0,

--- a/lms/djangoapps/instructor/tests/test_tools.py
+++ b/lms/djangoapps/instructor/tests/test_tools.py
@@ -14,7 +14,7 @@ from nose.plugins.attrib import attr
 from courseware.field_overrides import OverrideFieldData  # pylint: disable=import-error
 from student.tests.factories import UserFactory  # pylint: disable=import-error
 from xmodule.fields import Date
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 from opaque_keys.edx.keys import CourseKey
 
@@ -102,23 +102,17 @@ class TestParseDatetime(unittest.TestCase):
 
 
 @attr('shard_1')
-class TestFindUnit(ModuleStoreTestCase):
+class TestFindUnit(SharedModuleStoreTestCase):
     """
     Test the find_unit function.
     """
-
-    def setUp(self):
-        """
-        Fixtures.
-        """
-        super(TestFindUnit, self).setUp()
-
-        course = CourseFactory.create()
-        week1 = ItemFactory.create(parent=course)
-        homework = ItemFactory.create(parent=week1)
-
-        self.course = course
-        self.homework = homework
+    @classmethod
+    def setUpClass(cls):
+        super(TestFindUnit, cls).setUpClass()
+        cls.course = CourseFactory.create()
+        with cls.store.bulk_operations(cls.course.id, emit_signals=False):
+            week1 = ItemFactory.create(parent=cls.course)
+            cls.homework = ItemFactory.create(parent=week1)
 
     def test_find_unit_success(self):
         """


### PR DESCRIPTION
Two items in this PR:
1. I added a manual `reset_modulestore()` method to `SharedModuleStoreTestCase` so that if you have a method that modifies something, you can manually invoke it afterwards to clean up after the test.
2. Speedup of Instructor Dashboard tests.

@cpennington, @jzoldak 
