### PR TITLE
Fixed Chrome test cohort enabled disabled in Cohort Configuration Test

### DIFF
--- a/common/test/acceptance/pages/lms/instructor_dashboard.py
+++ b/common/test/acceptance/pages/lms/instructor_dashboard.py
@@ -548,6 +548,7 @@ class CohortManagementSection(PageObject):
         """
         if state != self.is_cohorted:
             self.q(css=self._bounded_selector('.cohorts-state')).first.click()
+            self.wait_for_ajax()
 
     def toggles_showing_of_discussion_topics(self):
         """


### PR DESCRIPTION
@benpatterson @jzoldak 
Please review. 
As tests on Chrome run faster then Firefox. After unchecking the checkbox, added wait for ajax call to complete before assert.
