### PR TITLE
Update edx-submissions hash

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -40,7 +40,7 @@ git+https://github.com/edx/rfc6266.git@v0.0.5-edx#egg=rfc6266==0.0.5-edx
 -e git+https://github.com/edx-solutions/django-splash.git@7579d052afcf474ece1239153cffe1c89935bc4f#egg=django-splash
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
 -e git+https://github.com/edx/edx-ora2.git@release-2015-08-21T16.14#egg=edx-ora2
--e git+https://github.com/edx/edx-submissions.git@906c7b7a27e1a8684834334a4bf7fb50a3aede30#egg=edx-submissions
+-e git+https://github.com/edx/edx-submissions.git@8b633d8dfa2040db0b0930dc53fca12290133d96#egg=edx-submissions
 -e git+https://github.com/edx/opaque-keys.git@27dc382ea587483b1e3889a3d19cbd90b9023a06#egg=opaque-keys
 git+https://github.com/edx/ease.git@release-2015-07-14#egg=ease==0.1.3
 git+https://github.com/edx/i18n-tools.git@v0.1.3#egg=i18n-tools==v0.1.3


### PR DESCRIPTION
Fixes an issue where install_prereqs would occasionally install an old version of pytz because edx-submissions included an old version in its requirements. More likely to happen in the solutions fork due to other requirements being involved-- this hash is the same one as it is using now to minimize code drift.

See https://github.com/edx/edx-submissions/pull/18

@bradenmacdonald 
