### PR TITLE
Adjust the i18n extraction rules to get all the strings we should get.

### DIFF
--- a/common/lib/capa/capa/templates/jstextline.html
+++ b/common/lib/capa/capa/templates/jstextline.html
@@ -19,7 +19,7 @@
   % endif
 
   <span class="status ${status.classname}" id="status_${id}" aria-describedby="input_${id}">
-    <span class="sr">${status.display_name</span>
+    <span class="sr">${status.display_name}</span>
   </span>
   % if msg:
     <br/>

--- a/conf/locale/babel_mako.cfg
+++ b/conf/locale/babel_mako.cfg
@@ -1,13 +1,30 @@
-# Extraction from Mako templates
-[mako: cms/templates/**.html]
+# Extraction from Mako templates.
+# Mako files can appear in a number of different places. Some we want to
+# extract strings from, some we don't.
+#
+# Extract from these directory trees:
+#
+#   cms/templates
+#   cms/djangoapps/APPNAME/templates
+#   common/templates
+#   common/djangoapps/APPNAME/templates
+#   lms/templates
+#   lms/djangoapps/APPNAME/templates
+#   common/lib/capa/capa/templates
+#
+# Don't extract from these directory trees:
+#   common/test/test_microsites/test_microsite/templates
+#
+
+[mako: */templates/**.html]
 input_encoding = utf-8
-[mako: lms/templates/**.html]
+[mako: */djangoapps/*/templates/**.html]
 input_encoding = utf-8
-[mako: lms/templates/**.mustache]
+[mako: */templates/**.mustache]
 input_encoding = utf-8
-[mako: common/templates/**.html]
+[mako: */templates/emails/**.txt]
 input_encoding = utf-8
-[mako: cms/templates/emails/**.txt]
+[mako: common/lib/capa/capa/templates/**.html]
 input_encoding = utf-8
-[mako: lms/templates/emails/**.txt]
+[mako: themes/**.html]
 input_encoding = utf-8

--- a/conf/locale/babel_underscore.cfg
+++ b/conf/locale/babel_underscore.cfg
@@ -1,9 +1,5 @@
 # Use this configuration file for extracting strings from .underscore files.
-[underscore: cms/templates/**.underscore]
-input_encoding = utf-8
-[underscore: common/templates/**.underscore]
-input_encoding = utf-8
-[underscore: lms/templates/**.underscore]
+[underscore: **.underscore]
 input_encoding = utf-8
 
 [extractors]


### PR DESCRIPTION
There's a move afoot to put assets inside individual Django apps,
instead of in upper-level "templates" directories.  These i18n
configuration files have to take this into account.

.underscore files are easy to find by their unique file extension, so
the rule can be simple.  Mako files are .html, so we have to be more
nuanced about it.  We don't want to get pure HTML files, and we don't
want to get .html files for tests, even if they are Mako templates.
