### PR TITLE
Removing flaky decorator from test

### DIFF
--- a/common/test/acceptance/pages/lms/login_and_register.py
+++ b/common/test/acceptance/pages/lms/login_and_register.py
@@ -127,7 +127,7 @@ class CombinedLoginAndRegisterPage(PageObject):
     @property
     def url(self):
         """Return the URL for the combined login/registration page. """
-        url = "{base}/account/{login_or_register}".format(
+        url = "{base}/{login_or_register}".format(
             base=BASE_URL,
             login_or_register=self._start_page
         )

--- a/common/test/acceptance/tests/lms/test_lms.py
+++ b/common/test/acceptance/tests/lms/test_lms.py
@@ -109,7 +109,6 @@ class LoginFromCombinedPageTest(UniqueCourseTest):
         self.login_page.visit().toggle_form()
         self.assertEqual(self.login_page.current_form, "register")
 
-    @flaky  # TODO fix this, see ECOM-1165
     def test_password_reset_success(self):
         # Create a user account
         email, password = self._create_unique_user()  # pylint: disable=unused-variable


### PR DESCRIPTION
ECOM-1165

I have removed flaky decorator from test case. This test was marked as flaky prior to addressing this ticket: [ECOM-1734](https://openedx.atlassian.net/browse/ECOM-1734) [Related PR](https://github.com/edx/edx-platform/pull/8753).
Previously there were two different url endpoints for login, '**/login**' and '**accounts/login**' that may be causing this test to fail. Currently there is only one endpoint.

I was unable to reproduce it locally so I am going to remove the `flaky` decorator from this test.

Please review this @awais786 @zubair-arbi @ahsan-ul-haq @aamir-khan 
