### PR TITLE
Upgrading django-model-utils to 2.3.1

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -21,7 +21,7 @@ django-filter==0.6.0
 django-ipware==1.1.0
 django-kombu==0.9.4
 django-mako==0.1.5pre
-django-model-utils==1.4.0
+django-model-utils==2.3.1
 django-masquerade==0.1.6
 django-mptt==0.5.5
 django-openid-auth==0.4

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -39,8 +39,8 @@ git+https://github.com/edx/rfc6266.git@v0.0.5-edx#egg=rfc6266==0.0.5-edx
 -e git+https://github.com/edx/event-tracking.git@0.2.0#egg=event-tracking
 -e git+https://github.com/edx-solutions/django-splash.git@7579d052afcf474ece1239153cffe1c89935bc4f#egg=django-splash
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
--e git+https://github.com/edx/edx-ora2.git@release-2015-08-21T16.14#egg=edx-ora2
--e git+https://github.com/edx/edx-submissions.git@8b633d8dfa2040db0b0930dc53fca12290133d96#egg=edx-submissions
+-e git+https://github.com/edx/edx-ora2.git@release-2015-08-25T16.16#egg=edx-ora2
+-e git+https://github.com/edx/edx-submissions.git@9538ee8a971d04dc1cb05e88f6aa0c36b224455c#egg=edx-submissions
 -e git+https://github.com/edx/opaque-keys.git@27dc382ea587483b1e3889a3d19cbd90b9023a06#egg=opaque-keys
 git+https://github.com/edx/ease.git@release-2015-07-14#egg=ease==0.1.3
 git+https://github.com/edx/i18n-tools.git@v0.1.3#egg=i18n-tools==v0.1.3
@@ -48,7 +48,7 @@ git+https://github.com/edx/edx-oauth2-provider.git@0.5.6#egg=oauth2-provider==0.
 -e git+https://github.com/edx/edx-val.git@v0.0.5#egg=edx-val
 -e git+https://github.com/pmitros/RecommenderXBlock.git@518234bc354edbfc2651b9e534ddb54f96080779#egg=recommender-xblock
 -e git+https://github.com/edx/edx-search.git@release-2015-07-22#egg=edx-search
--e git+https://github.com/edx/edx-milestones.git@release-2015-06-17#egg=edx-milestones
+-e git+https://github.com/edx/edx-milestones.git@9b44a37edc3d63a23823c21a63cdd53ef47a7aa4#egg=edx-milestones
 git+https://github.com/edx/edx-lint.git@b109a40c61277c52dcb396bf15e33755f5dbf5fa#egg=edx_lint==0.2.4
 -e git+https://github.com/edx/xblock-utils.git@213a97a50276d6a2504d8133650b2930ead357a0#egg=xblock-utils
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive


### PR DESCRIPTION
Preparation for the [Django 1.8 upgrade](https://openedx.atlassian.net/wiki/display/TNL/Library+updates+needed+for+Django+upgrade+to+1.8)

Depends on https://github.com/edx/edx-milestones/pull/11 to be merged first.  I'm opening this PR now so the tests can run.

@symbolist Please review when you're able.
