### PR TITLE
Upgrade django-mptt to 0.7.4

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -23,7 +23,7 @@ django-kombu==0.9.4
 django-mako==0.1.5pre
 django-model-utils==1.4.0
 django-masquerade==0.1.6
-django-mptt==0.5.5
+django-mptt==0.7.4
 django-openid-auth==0.4
 django-robots==0.9.1
 django-sekizai==0.6.1


### PR DESCRIPTION
Preparation for the [Django 1.8 upgrade](https://openedx.atlassian.net/wiki/display/TNL/Library+updates+needed+for+Django+upgrade+to+1.8)

This requirement is used by the wiki.  I tested this by visiting the wiki as a staff member and editing / creating articles, then viewing those articles as a student.

@symbolist please review.
