### PR TITLE
updated responsive body class to .is-view-in-course

### DIFF
--- a/lms/djangoapps/teams/templates/teams/teams.html
+++ b/lms/djangoapps/teams/templates/teams/teams.html
@@ -5,7 +5,7 @@
 <%namespace name='static' file='/static_content.html'/>
 <%inherit file="/main.html" />
 
-<%block name="bodyclass">view-teams is-in-course course js</%block>
+<%block name="bodyclass">view-teams view-in-course course js</%block>
 <%block name="pagetitle">${_("Teams")}</%block>
 
 <%block name="headextra">

--- a/lms/static/sass/base/_layouts.scss
+++ b/lms/static/sass/base/_layouts.scss
@@ -3,8 +3,7 @@
 
 // overriding existing styles on the body element
 // .view-incourse scopes these rules to be specific to student being in a course
-body.view-incourse,
-body.is-in-course {
+body.view-in-course {
   background-color: $body-bg;
 
   // keep application of widths to window-wrap
@@ -59,10 +58,15 @@ body.is-in-course {
   .profile-wrapper,
   .instructor-dashboard-wrapper-2,
   .wiki-wrapper,
-  .teams-wrapper {
+  .teams-wrapper,
+  .static_tab_wrapper {
     max-width: 1180px;
     margin: 0 auto;
     padding: 0;
+  }
+
+  .static_tab_wrapper {
+    padding: 2em 2.5em;
   }
 
   // post-container footer (creative commons)
@@ -81,12 +85,16 @@ body.is-in-course {
 
   // site footer
   .wrapper-footer {
-    margin-top: $baseline;
+    margin-top: ($baseline*2);
     padding-right: 2%;
     padding-left: 2%;
 
-    footer#footer-openedx { // TODO check edX footer when it launches
+    footer#footer-openedx { // shame selector to match existing
       min-width: auto;
     }
+  }
+
+  footer#footer-edx-v3 { // shame selector to match existing
+    margin-top: ($baseline*2);
   }
 }

--- a/lms/static/sass/shared/_footer.scss
+++ b/lms/static/sass/shared/_footer.scss
@@ -5,6 +5,7 @@
 
 .wrapper-footer {
   @extend %ui-print-excluded;
+  margin-top: ($baseline*2);
   box-shadow: 0 -1px 5px 0 $shadow-l1;
   border-top: 1px solid tint($m-gray, 50%);
   padding: 25px ($baseline/2) ($baseline*1.5) ($baseline/2);

--- a/lms/templates/courseware/courseware-chromeless.html
+++ b/lms/templates/courseware/courseware-chromeless.html
@@ -10,7 +10,7 @@ from edxnotes.helpers import is_feature_enabled as is_edxnotes_enabled
  <% return _("{course_number} Courseware").format(course_number=course.display_number_with_default) %>
 </%def>
 
-<%block name="bodyclass">view-incourse view-courseware courseware ${course.css_class or ''}</%block>
+<%block name="bodyclass">view-in-course view-courseware courseware ${course.css_class or ''}</%block>
 <%block name="title"><title>
     % if section_title:
 ${page_title_breadcrumbs(section_title, course_name())}

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -14,7 +14,7 @@ from edxnotes.helpers import is_feature_enabled as is_edxnotes_enabled
  <% return _("{course_number} Courseware").format(course_number=course.display_number_with_default) %>
 </%def>
 
-<%block name="bodyclass">view-incourse view-courseware courseware ${course.css_class or ''}</%block>
+<%block name="bodyclass">view-in-course view-courseware courseware ${course.css_class or ''}</%block>
 <%block name="title"><title>
     % if section_title:
 ${page_title_breadcrumbs(section_title, course_name())}

--- a/lms/templates/courseware/info.html
+++ b/lms/templates/courseware/info.html
@@ -42,7 +42,7 @@ $(document).ready(function(){
   </script>
 </%block>
 
-<%block name="bodyclass">view-incourse view-course-info ${course.css_class or ''}</%block>
+<%block name="bodyclass">view-in-course view-course-info ${course.css_class or ''}</%block>
 <section class="container">
   <div class="info-wrapper">
     % if user.is_authenticated():

--- a/lms/templates/courseware/progress.html
+++ b/lms/templates/courseware/progress.html
@@ -7,7 +7,7 @@ from util.date_utils import get_time_display, DEFAULT_SHORT_DATE_FORMAT
 from django.conf import settings
 from django.utils.http import urlquote_plus
 %>
-<%block name="bodyclass">view-incourse view-progress</%block>
+<%block name="bodyclass">view-in-course view-progress</%block>
 
 <%block name="headextra">
 <%static:css group='style-course-vendor'/>

--- a/lms/templates/courseware/static_tab.html
+++ b/lms/templates/courseware/static_tab.html
@@ -1,5 +1,5 @@
 <%inherit file="/main.html" />
-<%block name="bodyclass">view-incourse view-statictab ${course.css_class or ''}</%block>
+<%block name="bodyclass">view-in-course view-statictab ${course.css_class or ''}</%block>
 <%namespace name='static' file='/static_content.html'/>
 
 <%block name="headextra">

--- a/lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html
+++ b/lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html
@@ -4,7 +4,7 @@
 from django.utils.translation import ugettext as _
 from django.core.urlresolvers import reverse
 %>
-<%block name="bodyclass">view-incourse view-instructordash</%block>
+<%block name="bodyclass">view-in-course view-instructordash</%block>
 
 ## ----- Tips on adding something to the new instructor dashboard -----
 ## 1. add your input element, e.g. in instructor_dashboard2/data_download.html

--- a/lms/templates/wiki/base.html
+++ b/lms/templates/wiki/base.html
@@ -3,7 +3,7 @@
 
 {% block title %}<title>{% block pagetitle %}{% endblock %} | {% trans "Wiki" %} | {% platform_name %}</title>{% endblock %}
 
-{% block bodyclass %}view-incourse view-wiki{% endblock %}
+{% block bodyclass %}view-in-course view-wiki{% endblock %}
 
 {% block headextra %}
   <script type="text/javascript" src="/i18n.js"></script>


### PR DESCRIPTION
Cleanup story that came out of https://github.com/edx/edx-platform/pull/9310 to make the responsive body class consistent and add margin to the new edX footer. The content area of each course tab should be centered, shrink to 760px with a bit of margin on the sides (except Discussions), and have appropriate space between the content box and the footer. 

Sandbox: 
http://frrrances.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/info

Reviewers: 
- [x] @talbs 
- [x] @marcotuts 
