### PR TITLE
Do not render the discussion view twice in specs TNL-3007

### DIFF
--- a/lms/djangoapps/teams/static/teams/js/spec/views/team_discussion_spec.js
+++ b/lms/djangoapps/teams/static/teams/js/spec/views/team_discussion_spec.js
@@ -20,7 +20,6 @@ define([
             discussionView = new TeamDiscussionView({
                 el: '.discussion-module'
             });
-            discussionView.render();
             AjaxHelpers.expectRequest(
                 requests, 'GET',
                 interpolate(


### PR DESCRIPTION
TNL-3007

@efischer19 @benpatterson @andy-armstrong 

My theory of why the tests are flaky:
- TeamDiscussionView's initialize function already calls [the render function](https://github.com/edx/edx-platform/blob/master/lms/djangoapps/teams/static/teams/js/views/team_discussion.js#L11).
- `discussionModuleView.loadPage(this.$el);` triggers an ajax GET request to `/courses/%(courseID)s/discussion/forum/%(discussionID)s/inline?page=1&ajax=1`
- The explicit call to render triggered a second ajax request.
- Sometimes the second request would come in after whatever the next explicitly triggered request (e.g. by `createPost(requests, view, testTitle, testBody);` in the "can create a new post" spec), causing the testcase to fail
- This also explains why the "can render itself" spec didn't fail but the other ones did
- Still not sure though how to explain that if 1 failed all 5 would.
