### PR TITLE
Fixed CCX display name issue in enrollment/unenrollment email templates for non EDX members

### DIFF
--- a/lms/djangoapps/instructor/tests/test_enrollment.py
+++ b/lms/djangoapps/instructor/tests/test_enrollment.py
@@ -37,9 +37,7 @@ from opaque_keys.edx.locations import SlashSeparatedCourseKey
 
 from submissions import api as sub_api
 from student.models import anonymous_id_for_user
-from xmodule.modulestore.tests.django_utils import (
-    ModuleStoreTestCase, SharedModuleStoreTestCase, TEST_DATA_SPLIT_MODULESTORE
-)
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase, TEST_DATA_SPLIT_MODULESTORE
 
 
 @attr('shard_1')
@@ -576,23 +574,27 @@ class TestSendBetaRoleEmail(TestCase):
 
 
 @attr('shard_1')
-class TestGetEmailParamsCCX(ModuleStoreTestCase):
+class TestGetEmailParamsCCX(SharedModuleStoreTestCase):
     """
     Test what URLs the function get_email_params for CCX student enrollment.
     """
 
     MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
 
+    @classmethod
+    def setUpClass(cls):
+        super(TestGetEmailParamsCCX, cls).setUpClass()
+        cls.course = CourseFactory.create()
+
     @patch.dict('django.conf.settings.FEATURES', {'CUSTOM_COURSES_EDX': True})
     def setUp(self):
         super(TestGetEmailParamsCCX, self).setUp()
-
-        self.course = CourseFactory.create()
         self.coach = AdminFactory.create()
         role = CourseCcxCoachRole(self.course.id)
         role.add_users(self.coach)
         self.ccx = CcxFactory(course_id=self.course.id, coach=self.coach)
         self.course_key = CCXLocator.from_course_locator(self.course.id, self.ccx.id)
+
         # Explicitly construct what we expect the course URLs to be
         site = settings.SITE_NAME
         self.course_url = u'https://{}/courses/{}/'.format(
@@ -600,9 +602,7 @@ class TestGetEmailParamsCCX(ModuleStoreTestCase):
             self.course_key
         )
         self.course_about_url = self.course_url + 'about'
-        self.registration_url = u'https://{}/register'.format(
-            site,
-        )
+        self.registration_url = u'https://{}/register'.format(site)
 
     @patch.dict('django.conf.settings.FEATURES', {'CUSTOM_COURSES_EDX': True})
     def test_ccx_enrollment_email_params(self):
@@ -683,10 +683,14 @@ class TestRenderMessageToString(SharedModuleStoreTestCase):
         cls.subject_template = 'emails/enroll_email_allowedsubject.txt'
         cls.message_template = 'emails/enroll_email_allowedmessage.txt'
 
+    @patch.dict('django.conf.settings.FEATURES', {'CUSTOM_COURSES_EDX': True})
     def setUp(self):
         super(TestRenderMessageToString, self).setUp()
-        self.course_key = None
-        self.ccx = None
+        coach = AdminFactory.create()
+        role = CourseCcxCoachRole(self.course.id)
+        role.add_users(coach)
+        self.ccx = CcxFactory(course_id=self.course.id, coach=coach)
+        self.course_key = CCXLocator.from_course_locator(self.course.id, self.ccx.id)
 
     def get_email_params(self):
         """
@@ -702,12 +706,6 @@ class TestRenderMessageToString(SharedModuleStoreTestCase):
         """
         Returns a dictionary of parameters used to render an email for CCX.
         """
-        coach = AdminFactory.create()
-        role = CourseCcxCoachRole(self.course.id)
-        role.add_users(coach)
-        self.ccx = CcxFactory(course_id=self.course.id, coach=coach)
-        self.course_key = CCXLocator.from_course_locator(self.course.id, self.ccx.id)
-
         email_params = get_email_params(
             self.course,
             True,
@@ -730,12 +728,10 @@ class TestRenderMessageToString(SharedModuleStoreTestCase):
             language=language
         )
 
-    def get_subject_and_message_ccx(self):
+    def get_subject_and_message_ccx(self, subject_template, message_template):
         """
         Returns the subject and message rendered in the specified language for CCX.
         """
-        subject_template = 'emails/enroll_email_enrolledsubject.txt'
-        message_template = 'emails/enroll_email_enrolledmessage.txt'
         return render_message_to_string(
             subject_template,
             message_template,
@@ -758,11 +754,15 @@ class TestRenderMessageToString(SharedModuleStoreTestCase):
             self.assertIn("You have been", message)
 
     @patch.dict('django.conf.settings.FEATURES', {'CUSTOM_COURSES_EDX': True})
-    def test_render_message_ccx(self):
+    def test_render_enrollment_message_ccx_members(self):
         """
-        Test email template renders for CCX.
+        Test enrollment email template renders for CCX.
+        For EDX members.
         """
-        subject, message = self.get_subject_and_message_ccx()
+        subject_template = 'emails/enroll_email_enrolledsubject.txt'
+        message_template = 'emails/enroll_email_enrolledmessage.txt'
+
+        subject, message = self.get_subject_and_message_ccx(subject_template, message_template)
         self.assertIn(self.ccx.display_name, subject)
         self.assertIn(self.ccx.display_name, message)
         site = settings.SITE_NAME
@@ -771,3 +771,45 @@ class TestRenderMessageToString(SharedModuleStoreTestCase):
             self.course_key
         )
         self.assertIn(course_url, message)
+
+    @patch.dict('django.conf.settings.FEATURES', {'CUSTOM_COURSES_EDX': True})
+    def test_render_unenrollment_message_ccx_members(self):
+        """
+        Test unenrollment email template renders for CCX.
+        For EDX members.
+        """
+        subject_template = 'emails/unenroll_email_subject.txt'
+        message_template = 'emails/unenroll_email_enrolledmessage.txt'
+
+        subject, message = self.get_subject_and_message_ccx(subject_template, message_template)
+        self.assertIn(self.ccx.display_name, subject)
+        self.assertIn(self.ccx.display_name, message)
+
+    @patch.dict('django.conf.settings.FEATURES', {'CUSTOM_COURSES_EDX': True})
+    def test_render_enrollment_message_ccx_non_members(self):
+        """
+        Test enrollment email template renders for CCX.
+        For non EDX members.
+        """
+        subject_template = 'emails/enroll_email_allowedsubject.txt'
+        message_template = 'emails/enroll_email_allowedmessage.txt'
+
+        subject, message = self.get_subject_and_message_ccx(subject_template, message_template)
+        self.assertIn(self.ccx.display_name, subject)
+        self.assertIn(self.ccx.display_name, message)
+        site = settings.SITE_NAME
+        registration_url = u'https://{}/register'.format(site)
+        self.assertIn(registration_url, message)
+
+    @patch.dict('django.conf.settings.FEATURES', {'CUSTOM_COURSES_EDX': True})
+    def test_render_unenrollment_message_ccx_non_members(self):
+        """
+        Test unenrollment email template renders for CCX.
+        For non EDX members.
+        """
+        subject_template = 'emails/unenroll_email_subject.txt'
+        message_template = 'emails/unenroll_email_allowedmessage.txt'
+
+        subject, message = self.get_subject_and_message_ccx(subject_template, message_template)
+        self.assertIn(self.ccx.display_name, subject)
+        self.assertIn(self.ccx.display_name, message)

--- a/lms/templates/emails/enroll_email_allowedmessage.txt
+++ b/lms/templates/emails/enroll_email_allowedmessage.txt
@@ -4,7 +4,7 @@ ${_("Dear student,")}
 
 ${_("You have been invited to join {course_name} at {site_name} by a "
 	"member of the course staff.").format(
-		course_name=course.display_name_with_default,
+		course_name=display_name or course.display_name_with_default,
 		site_name=site_name
 	)}
 % if is_shib_course:
@@ -26,13 +26,13 @@ ${_("To finish your registration, please visit {registration_url} and fill "
 % if auto_enroll:
 ${_("Once you have registered and activated your account, you will see "
 	"{course_name} listed on your dashboard.").format(
-		course_name=course.display_name_with_default
+		course_name=display_name or course.display_name_with_default
 	)}
 % elif course_about_url is not None:
 ${_("Once you have registered and activated your account, visit {course_about_url} "
 	"to join the course.").format(course_about_url=course_about_url)}
 % else:
-${_("You can then enroll in {course_name}.").format(course_name=course.display_name_with_default)}
+${_("You can then enroll in {course_name}.").format(course_name=display_name or course.display_name_with_default)}
 % endif
 % endif
 

--- a/lms/templates/emails/enroll_email_allowedsubject.txt
+++ b/lms/templates/emails/enroll_email_allowedsubject.txt
@@ -1,5 +1,5 @@
 <%! from django.utils.translation import ugettext as _ %>
 
 ${_("You have been invited to register for {course_name}").format(
-		course_name=course.display_name_with_default
+		course_name=display_name or course.display_name_with_default
 	)}

--- a/lms/templates/emails/unenroll_email_allowedmessage.txt
+++ b/lms/templates/emails/unenroll_email_allowedmessage.txt
@@ -4,7 +4,7 @@ ${_("Dear Student,")}
 
 ${_("You have been un-enrolled from course {course_name} by a member "
     "of the course staff. Please disregard the invitation "
-    "previously sent.").format(course_name=course.display_name_with_default)}
+    "previously sent.").format(course_name=display_name or course.display_name_with_default)}
 
 ----
 ${_("This email was automatically sent from {site_name} "

--- a/lms/templates/emails/unenroll_email_enrolledmessage.txt
+++ b/lms/templates/emails/unenroll_email_enrolledmessage.txt
@@ -5,7 +5,7 @@ ${_("Dear {full_name}").format(full_name=full_name)}
 ${_("You have been un-enrolled in {course_name} at {site_name} by a member "
     "of the course staff. The course will no longer appear on your "
     "{site_name} dashboard.").format(
-    	course_name=course.display_name_with_default, site_name=site_name
+    	course_name=display_name or course.display_name_with_default, site_name=site_name
     )}
 
 ${_("Your other courses have not been affected.")}

--- a/lms/templates/emails/unenroll_email_subject.txt
+++ b/lms/templates/emails/unenroll_email_subject.txt
@@ -1,5 +1,5 @@
 <%! from django.utils.translation import ugettext as _ %>
 
 ${_("You have been un-enrolled from {course_name}").format(
-	course_name=course.display_name_with_default
+	course_name=display_name or course.display_name_with_default
 )}


### PR DESCRIPTION
### Background

It appears that when we switched CCX to use the standard enrollment table, we also switched to using the standard email templates for enrollment. Unfortunately, those templates use the name of the master course, not the CCX for non EDX members and in unenrollment of EDX members.

The CCX url issue was fixed in https://github.com/edx/edx-platform/pull/9448. 
But there is a remaining issue of the display name for non EDX user in invitation/unenrollment emails.
### What is done in this PR

**Studio Updates:** None.

**LMS Updates:** Fixed URL and course title in CCX enrollment/unenrollment email.
### Testing
- Try to enroll student from Enrollment tab CCX, section BATCH ENROLLMENT (Auto email should checked)
- Try to unenroll student from Enrollment tab CCX, section BATCH ENROLLMENT (Auto email should checked)
- Try to enroll student from Enrollment tab CCX with no ccx custom display name, section BATCH ENROLLMENT (Auto email should checked)
- Try to unenroll student from Enrollment tab CCX with no ccx custom display name, section BATCH ENROLLMENT (Auto email should checked)

Same steps for non EDX users.

Issue https://github.com/mitocw/edx-platform/issues/67
Parent PR https://github.com/edx/edx-platform/pull/9448

@pdpinch @pwilkins
- ![screen shot 2015-08-19 at 3 05 33 pm](https://cloud.githubusercontent.com/assets/10431250/9353700/cb6c8064-4683-11e5-9f97-4dd5913b5cd3.png)
- ![screen shot 2015-08-19 at 3 06 20 pm](https://cloud.githubusercontent.com/assets/10431250/9353709/e12d0842-4683-11e5-88b3-7a5c095ec496.png)
- ![screen shot 2015-08-19 at 3 04 49 pm](https://cloud.githubusercontent.com/assets/10431250/9353717/f11d1260-4683-11e5-958b-96bccc85395a.png)
