### PR TITLE
Instructor dashboard: Improve course timeline info

### DIFF
--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -353,7 +353,7 @@ def _section_course_info(course, access):
         'has_started': course.has_started(),
         'has_ended': course.has_ended(),
         'start_date': get_default_time_display(course.start),
-        'end_date': get_default_time_display(course.end),
+        'end_date': get_default_time_display(course.end) or _('No end date set'),
         'num_sections': len(course.children),
         'list_instructor_tasks_url': reverse('list_instructor_tasks', kwargs={'course_id': unicode(course_key)}),
     }


### PR DESCRIPTION
This PR is a follow-up to https://github.com/edx/edx-platform/pull/9146. It makes course timeline information displayed on the "Course Info" tab of the instructor dashboard more user-friendly by displaying "No end date set" if no end date has been set for the current course.

**Affected components**: LMS

**Affected users**: staff/instructors

**Screenshots**

Before:

![course-info-before](https://cloud.githubusercontent.com/assets/961441/9500306/e65bb6aa-4c24-11e5-8e32-0b94b13b2c32.png)

After:

![course-info-improved](https://cloud.githubusercontent.com/assets/961441/9500215/72f112f0-4c24-11e5-8abe-5fba236febc0.png)

**Testing**
1.  Go to the [sandbox](http://sandbox.opencraft.com/) and sign in as `staff@example.com`.
2.  Navigate to the [instructor dashboard](http://sandbox.opencraft.com/courses/OpenCraft/DECT101/2015/instructor) of the DECT101 course. Make sure you are looking at the "Course Info" tab.
3. Verify that the relevant part of the "Basic Course Information" section looks as shown in the "After" screenshot above.
4. View details for the DECT101 course in [Studio](http://sandbox.opencraft.com:18010/settings/details/OpenCraft/DECT101/2015) and confirm that no end date has been set for it.

**Partner Information**

Not an edX partner - 3rd party-hosted open edX instance
