### PR TITLE
Pass responsive flag to xblock renderer

### DIFF
--- a/lms/djangoapps/courseware/views.py
+++ b/lms/djangoapps/courseware/views.py
@@ -1513,7 +1513,10 @@ def render_xblock(request, usage_key_string, check_if_enrolled=True):
             request, unicode(course_key), unicode(usage_key), disable_staff_debug_info=True, course=course
         )
 
+        responsive = block.has_support(getattr(block, 'student_view', None), 'multi_device')
+
         context = {
+            'responsive': responsive,
             'fragment': block.render('student_view', context=request.GET),
             'course': course,
             'disable_accordion': True,


### PR DESCRIPTION
The apps need web content to include <meta name="viewport" ... tags to
ensure that the content fits the containing web view.

This gets inserted automatically if the "responsive" flag is passed to
the template. This changes the render call to pass that flag if the
block has a responsive representation (called "multi_device" since
responsive is an over loaded term).

JIRA: https://openedx.atlassian.net/browse/MA-960?filter=13805
