### PR TITLE
Add role="presentation" to .course-wrapper to prevent table

### DIFF
--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -161,10 +161,10 @@ ${fragment.foot_html()}
 % endif
 
 <div class="container">
-  <div class="course-wrapper">
+  <div class="course-wrapper" role="presentation">
 
 % if disable_accordion is UNDEFINED or not disable_accordion:
-    <div class="course-index" role="navigation">
+    <div class="course-index">
       <header id="open_close_accordion">
         <a href="#">${_("close")}</a>
       </header>


### PR DESCRIPTION
## Overview

This is for [AC-155](https://openedx.atlassian.net/browse/AC-155)
### Major changes

This adds `role="presentation"` to the course-wrapper div for the lms courseware tab to prevent it from being interpreted as a table by the screen reader.  This also allows the navigation and course content to be found more easily.  

The `role="navigfation"` is removed from a div element because there is already a `nav` element being used there. 
## Browsers

This work was checked in the following browsers:

| Platform | Browser | Version | Passed |
| --- | --- | --- | --- |
| Mac | Chrome | 44 | Yes |
|  | Safari | 7 | Yes |
|  | Firefox | 24 | Yes |
| Windows | Chrome | 44 | Yes |
|  | Firefox | 40 | Yes |
|  | IE | 10 | Yes |
## Sandbox

No sandbox yet.
## Reviewers

The following reviewers need to provide thumbs before this work can be merged.
- [x] @clrux 
- [x] @cptvitamin 
