### PR TITLE
Change imports from path to use the stablest name.

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/export_convert_format.py
+++ b/cms/djangoapps/contentstore/management/commands/export_convert_format.py
@@ -5,7 +5,7 @@ to the archive format used by a different version of export.
 Sample invocation: ./manage.py export_convert_format mycourse.tar.gz ~/newformat/
 """
 import os
-from path import path
+from path import Path as path
 from django.core.management.base import BaseCommand, CommandError
 from django.conf import settings
 

--- a/cms/djangoapps/contentstore/management/commands/tests/test_export_convert_format.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_export_convert_format.py
@@ -6,7 +6,7 @@ from django.core.management import call_command, CommandError
 from django.conf import settings
 from tempfile import mkdtemp
 import shutil
-from path import path
+from path import Path as path
 from contentstore.management.commands.export_convert_format import Command, extract_source
 from xmodule.tests.helpers import directories_equal
 

--- a/cms/djangoapps/contentstore/management/commands/tests/test_import.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_import.py
@@ -3,7 +3,7 @@ Unittests for importing a course via management command
 """
 
 import os
-from path import path
+from path import Path as path
 import shutil
 import tempfile
 

--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -11,7 +11,7 @@ import ddt
 from datetime import timedelta
 from fs.osfs import OSFS
 from json import loads
-from path import path
+from path import Path as path
 from textwrap import dedent
 from uuid import uuid4
 from functools import wraps

--- a/cms/djangoapps/contentstore/views/import_export.py
+++ b/cms/djangoapps/contentstore/views/import_export.py
@@ -8,7 +8,7 @@ import os
 import re
 import shutil
 import tarfile
-from path import path
+from path import Path as path
 from tempfile import mkdtemp
 
 from django.conf import settings

--- a/cms/djangoapps/contentstore/views/tests/test_import_export.py
+++ b/cms/djangoapps/contentstore/views/tests/test_import_export.py
@@ -9,7 +9,7 @@ import os
 import shutil
 import tarfile
 import tempfile
-from path import path
+from path import Path as path
 from uuid import uuid4
 
 from django.test.utils import override_settings

--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -18,7 +18,7 @@ from .common import *
 from openedx.core.lib.logsettings import get_logger_config
 import os
 
-from path import path
+from path import Path as path
 from xmodule.modulestore.modulestore_settings import convert_module_store_setting_if_needed
 
 # SERVICE_VARIANT specifies name of the variant used, which decides what JSON

--- a/cms/envs/bok_choy.py
+++ b/cms/envs/bok_choy.py
@@ -11,7 +11,7 @@ from the same directory.
 """
 
 import os
-from path import path
+from path import Path as path
 
 # Pylint gets confused by path.py instances, which report themselves as class
 # objects. As a result, pylint applies the wrong regex in validating names,

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -46,7 +46,7 @@ from lms.envs.common import (
     # display credit eligibility table on the CMS or not.
     ENABLE_CREDIT_ELIGIBILITY, YOUTUBE_API_KEY
 )
-from path import path
+from path import Path as path
 from warnings import simplefilter
 
 from lms.djangoapps.lms_xblock.mixin import LmsBlockMixin

--- a/cms/envs/test.py
+++ b/cms/envs/test.py
@@ -20,7 +20,7 @@ sessions. Assumes structure:
 
 from .common import *
 import os
-from path import path
+from path import Path as path
 from warnings import filterwarnings, simplefilter
 from uuid import uuid4
 

--- a/cms/envs/yaml_config.py
+++ b/cms/envs/yaml_config.py
@@ -21,7 +21,7 @@ from openedx.core.lib.logsettings import get_logger_config
 from util.config_parse import convert_tokens
 import os
 
-from path import path
+from path import Path as path
 from xmodule.modulestore.modulestore_settings import convert_module_store_setting_if_needed
 
 # https://stackoverflow.com/questions/2890146/how-to-force-pyyaml-to-load-strings-as-unicode-objects

--- a/common/lib/capa/capa/checker.py
+++ b/common/lib/capa/capa/checker.py
@@ -7,7 +7,7 @@ from __future__ import unicode_literals
 import argparse
 import logging
 import sys
-from path import path
+from path import Path as path
 
 from cStringIO import StringIO
 

--- a/common/lib/xmodule/xmodule/assetstore/tests/test_asset_xml.py
+++ b/common/lib/xmodule/xmodule/assetstore/tests/test_asset_xml.py
@@ -2,7 +2,7 @@
 Test for asset XML generation / parsing.
 """
 
-from path import path
+from path import Path as path
 from lxml import etree
 from contracts import ContractNotRespected
 import unittest

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -5,7 +5,7 @@ import logging
 from cStringIO import StringIO
 from math import exp
 from lxml import etree
-from path import path  # NOTE (THK): Only used for detecting presence of syllabus
+from path import Path as path
 import requests
 from datetime import datetime
 import dateutil.parser

--- a/common/lib/xmodule/xmodule/html_module.py
+++ b/common/lib/xmodule/xmodule/html_module.py
@@ -5,7 +5,7 @@ import copy
 import logging
 import textwrap
 from lxml import etree
-from path import path
+from path import Path as path
 from fs.errors import ResourceNotFoundError
 from pkg_resources import resource_string
 

--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -23,7 +23,7 @@ from bson.son import SON
 from datetime import datetime
 from fs.osfs import OSFS
 from mongodb_proxy import MongoProxy, autoretry_read
-from path import path
+from path import Path as path
 from pytz import UTC
 from contracts import contract, new_contract
 

--- a/common/lib/xmodule/xmodule/modulestore/perf_tests/test_asset_import_export.py
+++ b/common/lib/xmodule/xmodule/modulestore/perf_tests/test_asset_import_export.py
@@ -1,7 +1,7 @@
 """
 Performance test for asset metadata in the modulestore.
 """
-from path import path
+from path import Path as path
 import unittest
 from tempfile import mkdtemp
 import itertools

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
@@ -60,7 +60,7 @@ import logging
 from contracts import contract, new_contract
 from importlib import import_module
 from mongodb_proxy import autoretry_read
-from path import path
+from path import Path as path
 from pytz import UTC
 from bson.objectid import ObjectId
 

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_contentstore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_contentstore.py
@@ -130,18 +130,18 @@ class TestContentstore(unittest.TestCase):
         Test export
         """
         self.set_up_assets(deprecated)
-        root_dir = path.path(mkdtemp())
+        root_dir = path.Path(mkdtemp())
         try:
             self.contentstore.export_all_for_course(
                 self.course1_key, root_dir,
-                path.path(root_dir / "policy.json"),
+                path.Path(root_dir / "policy.json"),
             )
             for filename in self.course1_files:
-                filepath = path.path(root_dir / filename)
+                filepath = path.Path(root_dir / filename)
                 self.assertTrue(filepath.isfile(), "{} is not a file".format(filepath))
             for filename in self.course2_files:
                 if filename not in self.course1_files:
-                    filepath = path.path(root_dir / filename)
+                    filepath = path.Path(root_dir / filename)
                     self.assertFalse(filepath.isfile(), "{} is unexpected exported a file".format(filepath))
         finally:
             shutil.rmtree(root_dir)

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_cross_modulestore_import_export.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_cross_modulestore_import_export.py
@@ -14,7 +14,7 @@ and then for each combination of modulestores, performing the sequence:
 from contextlib import contextmanager, nested
 import itertools
 import os
-from path import path
+from path import Path as path
 import random
 from shutil import rmtree
 from tempfile import mkdtemp

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_mongo.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_mongo.py
@@ -7,7 +7,7 @@ Unit tests for the Mongo modulestore
 from nose.tools import assert_equals, assert_raises, \
     assert_not_equals, assert_false, assert_true, assert_greater, assert_is_instance, assert_is_none
 # pylint: enable=E0611
-from path import path
+from path import Path as path
 import pymongo
 import logging
 import shutil

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore.py
@@ -4,7 +4,7 @@
 from mock import patch
 import datetime
 from importlib import import_module
-from path import path
+from path import Path as path
 import random
 import re
 import unittest

--- a/common/lib/xmodule/xmodule/modulestore/xml.py
+++ b/common/lib/xmodule/xmodule/modulestore/xml.py
@@ -12,7 +12,7 @@ from cStringIO import StringIO
 from fs.osfs import OSFS
 from importlib import import_module
 from lxml import etree
-from path import path
+from path import Path as path
 from contextlib import contextmanager
 from lazy import lazy
 

--- a/common/lib/xmodule/xmodule/modulestore/xml_exporter.py
+++ b/common/lib/xmodule/xmodule/modulestore/xml_exporter.py
@@ -17,7 +17,7 @@ from fs.osfs import OSFS
 from json import dumps
 import json
 import os
-from path import path
+from path import Path as path
 import shutil
 from xmodule.modulestore.draft_and_published import DIRECT_ONLY_CATEGORIES
 from opaque_keys.edx.locator import CourseLocator, LibraryLocator

--- a/common/lib/xmodule/xmodule/modulestore/xml_importer.py
+++ b/common/lib/xmodule/xmodule/modulestore/xml_importer.py
@@ -25,7 +25,7 @@ from abc import abstractmethod
 from opaque_keys.edx.locator import LibraryLocator
 import os
 import mimetypes
-from path import path
+from path import Path as path
 import json
 import re
 from lxml import etree

--- a/common/lib/xmodule/xmodule/static_content.py
+++ b/common/lib/xmodule/xmodule/static_content.py
@@ -11,7 +11,7 @@ import errno
 import sys
 from collections import defaultdict
 from docopt import docopt
-from path import path
+from path import Path as path
 
 from xmodule.x_module import XModuleDescriptor
 

--- a/common/lib/xmodule/xmodule/tests/__init__.py
+++ b/common/lib/xmodule/xmodule/tests/__init__.py
@@ -20,7 +20,7 @@ from functools import wraps
 from lazy import lazy
 from mock import Mock, patch
 from operator import attrgetter
-from path import path
+from path import Path as path
 
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
 from xblock.field_data import DictFieldData

--- a/common/lib/xmodule/xmodule/tests/helpers.py
+++ b/common/lib/xmodule/xmodule/tests/helpers.py
@@ -3,7 +3,7 @@ Utility methods for unit tests.
 """
 
 import filecmp
-from path import path
+from path import Path as path
 
 
 def directories_equal(directory1, directory2):

--- a/common/lib/xmodule/xmodule/tests/test_content.py
+++ b/common/lib/xmodule/xmodule/tests/test_content.py
@@ -3,7 +3,7 @@
 import os
 import unittest
 import ddt
-from path import path
+from path import Path as path
 from xmodule.contentstore.content import StaticContent, StaticContentStream
 from xmodule.contentstore.content import ContentStore
 from opaque_keys.edx.locations import SlashSeparatedCourseKey, AssetLocation

--- a/common/lib/xmodule/xmodule/tests/test_export.py
+++ b/common/lib/xmodule/xmodule/tests/test_export.py
@@ -14,7 +14,7 @@ import uuid
 
 from datetime import datetime, timedelta, tzinfo
 from fs.osfs import OSFS
-from path import path
+from path import Path as path
 from tempfile import mkdtemp
 from textwrap import dedent
 

--- a/common/test/acceptance/fixtures/course.py
+++ b/common/test/acceptance/fixtures/course.py
@@ -9,7 +9,7 @@ import datetime
 
 from textwrap import dedent
 from collections import namedtuple
-from path import path
+from path import Path as path
 
 from opaque_keys.edx.keys import CourseKey
 

--- a/common/test/acceptance/pages/studio/textbooks.py
+++ b/common/test/acceptance/pages/studio/textbooks.py
@@ -3,7 +3,7 @@ Course Textbooks page.
 """
 
 import requests
-from path import path  # pylint: disable=no-name-in-module
+from path import Path as path
 from .course_page import CoursePage
 from .utils import click_css
 

--- a/common/test/acceptance/tests/helpers.py
+++ b/common/test/acceptance/tests/helpers.py
@@ -12,7 +12,7 @@ import os
 import urlparse
 from contextlib import contextmanager
 from datetime import datetime
-from path import path
+from path import Path as path
 from bok_choy.javascript import js_defined
 from bok_choy.web_app_test import WebAppTest
 from bok_choy.promise import EmptyPromise, Promise

--- a/docs/en_us/enrollment_api/source/conf.py
+++ b/docs/en_us/enrollment_api/source/conf.py
@@ -5,7 +5,7 @@
 # pylint: disable=unused-argument
 
 import os
-from path import path
+from path import Path as path
 import sys
 import mock
 

--- a/docs/en_us/platform_api/source/conf.py
+++ b/docs/en_us/platform_api/source/conf.py
@@ -5,7 +5,7 @@
 # pylint: disable=unused-argument
 
 import os
-from path import path
+from path import Path as path
 import sys
 import mock
 

--- a/lms/djangoapps/certificates/tests/test_models.py
+++ b/lms/djangoapps/certificates/tests/test_models.py
@@ -5,8 +5,7 @@ from django.core.files.images import ImageFile
 from django.test import TestCase
 from django.test.utils import override_settings
 from nose.plugins.attrib import attr
-# pylint: disable=no-name-in-module
-from path import path
+from path import Path as path
 
 from opaque_keys.edx.locator import CourseLocator
 from certificates.models import (

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -3,7 +3,7 @@ from fs.errors import ResourceNotFoundError
 import logging
 import inspect
 
-from path import path
+from path import Path as path
 from django.http import Http404
 from django.conf import settings
 

--- a/lms/djangoapps/courseware/management/commands/clean_xml.py
+++ b/lms/djangoapps/courseware/management/commands/clean_xml.py
@@ -4,7 +4,7 @@ import sys
 import traceback
 
 from fs.osfs import OSFS
-from path import path
+from path import Path as path
 
 from django.core.management.base import BaseCommand
 

--- a/lms/djangoapps/courseware/management/commands/export_course.py
+++ b/lms/djangoapps/courseware/management/commands/export_course.py
@@ -12,7 +12,7 @@ import tarfile
 from tempfile import mktemp, mkdtemp
 from textwrap import dedent
 
-from path import path
+from path import Path as path
 
 from django.core.management.base import BaseCommand, CommandError
 

--- a/lms/djangoapps/courseware/management/commands/tests/test_dump_course.py
+++ b/lms/djangoapps/courseware/management/commands/tests/test_dump_course.py
@@ -4,7 +4,7 @@
 
 import json
 from nose.plugins.attrib import attr
-from path import path
+from path import Path as path
 import shutil
 from StringIO import StringIO
 import tarfile

--- a/lms/djangoapps/dashboard/sysadmin.py
+++ b/lms/djangoapps/dashboard/sysadmin.py
@@ -28,7 +28,7 @@ from django.views.decorators.http import condition
 from django.views.decorators.csrf import ensure_csrf_cookie
 from edxmako.shortcuts import render_to_response
 import mongoengine
-from path import path
+from path import Path as path
 
 from courseware.courses import get_course_by_id
 import dashboard.git_import as git_import

--- a/lms/djangoapps/debug/management/commands/dump_xml_courses.py
+++ b/lms/djangoapps/debug/management/commands/dump_xml_courses.py
@@ -10,7 +10,7 @@ of each of its fields (including those fields that are set as default values).
 from __future__ import print_function
 
 import json
-from path import path
+from path import Path as path
 
 from django.core.management.base import BaseCommand, CommandError
 from django.conf import settings

--- a/lms/djangoapps/lms_migration/management/commands/create_groups.py
+++ b/lms/djangoapps/lms_migration/management/commands/create_groups.py
@@ -9,7 +9,7 @@ import os
 from django.core.management.base import BaseCommand
 from django.conf import settings
 from django.contrib.auth.models import Group
-from path import path
+from path import Path as path
 from lxml import etree
 
 

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -23,7 +23,7 @@ from .common import *
 from openedx.core.lib.logsettings import get_logger_config
 import os
 
-from path import path
+from path import Path as path
 from xmodule.modulestore.modulestore_settings import convert_module_store_setting_if_needed
 
 # SERVICE_VARIANT specifies name of the variant used, which decides what JSON

--- a/lms/envs/bok_choy.py
+++ b/lms/envs/bok_choy.py
@@ -11,7 +11,7 @@ from the same directory.
 """
 
 import os
-from path import path
+from path import Path as path
 from tempfile import mkdtemp
 
 # Pylint gets confused by path.py instances, which report themselves as class

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -33,7 +33,7 @@ import sys
 import os
 import imp
 
-from path import path
+from path import Path as path
 from warnings import simplefilter
 from django.utils.translation import ugettext_lazy as _
 

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -20,7 +20,7 @@ sessions. Assumes structure:
 
 from .common import *
 import os
-from path import path
+from path import Path as path
 from uuid import uuid4
 from warnings import filterwarnings, simplefilter
 

--- a/lms/envs/yaml_config.py
+++ b/lms/envs/yaml_config.py
@@ -20,7 +20,7 @@ from openedx.core.lib.logsettings import get_logger_config
 from util.config_parse import convert_tokens
 import os
 
-from path import path
+from path import Path as path
 
 # https://stackoverflow.com/questions/2890146/how-to-force-pyyaml-to-load-strings-as-unicode-objects
 from yaml import Loader, SafeLoader

--- a/pavelib/i18n.py
+++ b/pavelib/i18n.py
@@ -3,7 +3,7 @@ Internationalization tasks
 """
 import sys
 import subprocess
-from path import path
+from path import Path as path
 from paver.easy import task, cmdopts, needs, sh
 
 try:

--- a/pavelib/paver_tests/test_paver_quality.py
+++ b/pavelib/paver_tests/test_paver_quality.py
@@ -2,7 +2,7 @@
 Tests for paver quality tasks
 """
 import os
-from path import path  # pylint: disable=no-name-in-module
+from path import Path as path
 import tempfile
 import unittest
 from mock import patch, MagicMock, mock_open

--- a/pavelib/utils/envs.py
+++ b/pavelib/utils/envs.py
@@ -6,7 +6,7 @@ import os
 import sys
 import json
 from lazy import lazy
-from path import path
+from path import Path as path
 import memcache
 
 

--- a/scripts/all-tests.sh
+++ b/scripts/all-tests.sh
@@ -11,7 +11,7 @@ set -e
 ###############################################################################
 
 # Violations thresholds for failing the build
-export PYLINT_THRESHOLD=6275
+export PYLINT_THRESHOLD=6175
 export JSHINT_THRESHOLD=3700
 
 doCheckVars() {

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -14,7 +14,7 @@ import json
 import getpass
 
 try:
-    from path import path
+    from path import Path as path
     from git import Repo, Commit
     from git.refs.symbolic import SymbolicReference
     from dateutil.parser import parse as parse_datestring


### PR DESCRIPTION
The old line:

```
from path import path
```

produced pylint errors because of the baroque way that path.py defined
"path".  We tried to get them to change how they defined it, but they deleted
the name instead: https://github.com/jaraco/path.py/issues/102

(Jason then changed his mind, but this is a better way to use path.py, it
avoids the pylint error at least.)

The "path" name and the "Path" name refer to the same class.
