### PR TITLE
Team API Performance Improvements

### DIFF
--- a/lms/djangoapps/teams/errors.py
+++ b/lms/djangoapps/teams/errors.py
@@ -14,3 +14,8 @@ class NotEnrolledInCourseForTeam(TeamAPIRequestError):
 class AlreadyOnTeamInCourse(TeamAPIRequestError):
     """User is already a member of another team in the same course."""
     pass
+
+
+class ImmutableMembershipFieldException(Exception):
+    """An attempt was made to change an immutable field on a CourseTeamMembership model"""
+    pass

--- a/lms/djangoapps/teams/migrations/0005_add_course_id_and_topic_id_composite_index.py
+++ b/lms/djangoapps/teams/migrations/0005_add_course_id_and_topic_id_composite_index.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+import pytz
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Create a composite index of course_id and topic_id.
+        db.create_index('teams_courseteam', ['course_id', 'topic_id'])
+
+    def backwards(self, orm):
+        # Delete the composite index of course_id and topic_id.
+        db.delete_index('teams_courseteam', ['course_id', 'topic_id'])
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'teams.courseteam': {
+            'Meta': {'object_name': 'CourseTeam'},
+            'country': ('django_countries.fields.CountryField', [], {'max_length': '2', 'blank': 'True'}),
+            'course_id': ('xmodule_django.models.CourseKeyField', [], {'max_length': '255', 'db_index': 'True'}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '300'}),
+            'discussion_topic_id': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'language': ('student.models.LanguageField', [], {'max_length': '16', 'blank': 'True'}),
+            'last_activity_at': ('django.db.models.fields.DateTimeField', [], {}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'team_id': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'topic_id': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '255', 'blank': 'True'}),
+            'users': ('django.db.models.fields.related.ManyToManyField', [], {'db_index': 'True', 'related_name': "'teams'", 'symmetrical': 'False', 'through': "orm['teams.CourseTeamMembership']", 'to': "orm['auth.User']"})
+        },
+        'teams.courseteammembership': {
+            'Meta': {'unique_together': "(('user', 'team'),)", 'object_name': 'CourseTeamMembership'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_activity_at': ('django.db.models.fields.DateTimeField', [], {}),
+            'team': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'membership'", 'to': "orm['teams.CourseTeam']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"})
+        }
+    }
+
+    complete_apps = ['teams']

--- a/lms/djangoapps/teams/migrations/0006_add_team_size.py
+++ b/lms/djangoapps/teams/migrations/0006_add_team_size.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+from teams.models import CourseTeamMembership
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'CourseTeam.team_size'
+        db.add_column('teams_courseteam', 'team_size',
+                      self.gf('django.db.models.fields.IntegerField')(default=0, db_index=True),
+                      keep_default=False)
+
+        # Adding index on 'CourseTeam', fields ['last_activity_at']
+        db.create_index('teams_courseteam', ['last_activity_at'])
+
+        if not db.dry_run:
+            for team in orm.CourseTeam.objects.all():
+                team.team_size = CourseTeamMembership.objects.filter(team=team).count()
+                team.save()
+
+    def backwards(self, orm):
+        # Removing index on 'CourseTeam', fields ['last_activity_at']
+        db.delete_index('teams_courseteam', ['last_activity_at'])
+
+        # Deleting field 'CourseTeam.team_size'
+        db.delete_column('teams_courseteam', 'team_size')
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'teams.courseteam': {
+            'Meta': {'object_name': 'CourseTeam'},
+            'country': ('django_countries.fields.CountryField', [], {'max_length': '2', 'blank': 'True'}),
+            'course_id': ('xmodule_django.models.CourseKeyField', [], {'max_length': '255', 'db_index': 'True'}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '300'}),
+            'discussion_topic_id': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'language': ('student.models.LanguageField', [], {'max_length': '16', 'blank': 'True'}),
+            'last_activity_at': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'team_id': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'team_size': ('django.db.models.fields.IntegerField', [], {'default': '0', 'db_index': 'True'}),
+            'topic_id': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '255', 'blank': 'True'}),
+            'users': ('django.db.models.fields.related.ManyToManyField', [], {'db_index': 'True', 'related_name': "'teams'", 'symmetrical': 'False', 'through': "orm['teams.CourseTeamMembership']", 'to': "orm['auth.User']"})
+        },
+        'teams.courseteammembership': {
+            'Meta': {'unique_together': "(('user', 'team'),)", 'object_name': 'CourseTeamMembership'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_activity_at': ('django.db.models.fields.DateTimeField', [], {}),
+            'team': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'membership'", 'to': "orm['teams.CourseTeam']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"})
+        }
+    }
+
+    complete_apps = ['teams']

--- a/lms/djangoapps/teams/migrations/0007_auto__del_field_courseteam_is_active.py
+++ b/lms/djangoapps/teams/migrations/0007_auto__del_field_courseteam_is_active.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Deleting field 'CourseTeam.is_active'
+        db.delete_column('teams_courseteam', 'is_active')
+
+
+    def backwards(self, orm):
+        # Adding field 'CourseTeam.is_active'
+        db.add_column('teams_courseteam', 'is_active',
+                      self.gf('django.db.models.fields.BooleanField')(default=True),
+                      keep_default=False)
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'teams.courseteam': {
+            'Meta': {'object_name': 'CourseTeam'},
+            'country': ('django_countries.fields.CountryField', [], {'max_length': '2', 'blank': 'True'}),
+            'course_id': ('xmodule_django.models.CourseKeyField', [], {'max_length': '255', 'db_index': 'True'}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '300'}),
+            'discussion_topic_id': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('student.models.LanguageField', [], {'max_length': '16', 'blank': 'True'}),
+            'last_activity_at': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'team_id': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'team_size': ('django.db.models.fields.IntegerField', [], {'default': '0', 'db_index': 'True'}),
+            'topic_id': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '255', 'blank': 'True'}),
+            'users': ('django.db.models.fields.related.ManyToManyField', [], {'db_index': 'True', 'related_name': "'teams'", 'symmetrical': 'False', 'through': "orm['teams.CourseTeamMembership']", 'to': "orm['auth.User']"})
+        },
+        'teams.courseteammembership': {
+            'Meta': {'unique_together': "(('user', 'team'),)", 'object_name': 'CourseTeamMembership'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_activity_at': ('django.db.models.fields.DateTimeField', [], {}),
+            'team': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'membership'", 'to': "orm['teams.CourseTeam']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"})
+        }
+    }
+
+    complete_apps = ['teams']

--- a/lms/djangoapps/teams/serializers.py
+++ b/lms/djangoapps/teams/serializers.py
@@ -51,7 +51,6 @@ class CourseTeamSerializer(serializers.ModelSerializer):
             "id",
             "discussion_topic_id",
             "name",
-            "is_active",
             "course_id",
             "topic_id",
             "date_created",

--- a/lms/djangoapps/teams/static/teams/js/models/team.js
+++ b/lms/djangoapps/teams/static/teams/js/models/team.js
@@ -8,7 +8,6 @@
             defaults: {
                 id: null,
                 name: '',
-                is_active: null,
                 course_id: '',
                 topic_id: '',
                 date_created: '',

--- a/lms/djangoapps/teams/static/teams/js/spec/views/edit_team_spec.js
+++ b/lms/djangoapps/teams/static/teams/js/spec/views/edit_team_spec.js
@@ -14,7 +14,6 @@ define([
             createTeamData = {
                 id: null,
                 name: "TeamName",
-                is_active: null,
                 course_id: "a/b/c",
                 topic_id: "awesomeness",
                 date_created: "",

--- a/lms/djangoapps/teams/static/teams/js/spec_helpers/team_spec_helpers.js
+++ b/lms/djangoapps/teams/static/teams/js/spec_helpers/team_spec_helpers.js
@@ -32,7 +32,6 @@ define([
                 id: "id " + i,
                 language: testLanguages[i%4][0],
                 country: testCountries[i%4][0],
-                is_active: true,
                 membership: [],
                 last_activity_at: ''
             };

--- a/lms/djangoapps/teams/tests/test_views.py
+++ b/lms/djangoapps/teams/tests/test_views.py
@@ -208,13 +208,8 @@ class TeamAPITestCase(APITestCase, SharedModuleStoreTestCase):
             )
             self.test_team_2 = CourseTeamFactory.create(name='Wind Team', course_id=self.test_course_1.id)
             self.test_team_3 = CourseTeamFactory.create(name='Nuclear Team', course_id=self.test_course_1.id)
-            self.test_team_4 = CourseTeamFactory.create(
-                name='Coal Team',
-                course_id=self.test_course_1.id,
-                is_active=False
-            )
-            self.test_team_5 = CourseTeamFactory.create(name='Another Team', course_id=self.test_course_2.id)
-            self.test_team_6 = CourseTeamFactory.create(
+            self.test_team_4 = CourseTeamFactory.create(name='Another Team', course_id=self.test_course_2.id)
+            self.test_team_5 = CourseTeamFactory.create(
                 name='Public Profile Team',
                 course_id=self.test_course_2.id,
                 topic_id='topic_6'
@@ -234,7 +229,6 @@ class TeamAPITestCase(APITestCase, SharedModuleStoreTestCase):
             self.test_team_3,
             self.test_team_4,
             self.test_team_5,
-            self.test_team_6,
             self.test_team_7,
         )}
 
@@ -245,8 +239,8 @@ class TeamAPITestCase(APITestCase, SharedModuleStoreTestCase):
 
         self.test_team_1.add_user(self.users['student_enrolled'])
         self.test_team_3.add_user(self.users['student_enrolled_both_courses_other_team'])
-        self.test_team_5.add_user(self.users['student_enrolled_both_courses_other_team'])
-        self.test_team_6.add_user(self.users['student_enrolled_public_profile'])
+        self.test_team_4.add_user(self.users['student_enrolled_both_courses_other_team'])
+        self.test_team_5.add_user(self.users['student_enrolled_public_profile'])
 
     def build_membership_data_raw(self, username, team):
         """Assembles a membership creation payload based on the raw values provided."""
@@ -400,7 +394,7 @@ class TeamAPITestCase(APITestCase, SharedModuleStoreTestCase):
 
     def verify_expanded_team(self, team):
         """Verifies that fields exist on the returned team json indicating that it is expanded."""
-        for field in ['id', 'name', 'is_active', 'course_id', 'topic_id', 'date_created', 'description']:
+        for field in ['id', 'name', 'course_id', 'topic_id', 'date_created', 'description']:
             self.assertIn(field, team)
 
 
@@ -445,9 +439,6 @@ class TestListTeamsAPI(TeamAPITestCase):
 
     def test_filter_topic_id(self):
         self.verify_names({'course_id': self.test_course_1.id, 'topic_id': 'topic_0'}, 200, [u'Sólar team'])
-
-    def test_filter_include_inactive(self):
-        self.verify_names({'include_inactive': True}, 200, ['Coal Team', 'Nuclear Team', u'Sólar team', 'Wind Team'])
 
     @ddt.data(
         (None, 200, ['Nuclear Team', u'Sólar team', 'Wind Team']),
@@ -673,7 +664,6 @@ class TestCreateTeamAPI(TeamAPITestCase):
             'name': 'Fully specified team',
             'language': 'fr',
             'country': 'CA',
-            'is_active': True,
             'topic_id': 'great-topic',
             'course_id': str(self.test_course_1.id),
             'description': 'Another fantastic team'
@@ -723,7 +713,7 @@ class TestDetailTeamAPI(TeamAPITestCase):
 
     def test_expand_public_user(self):
         result = self.get_team_detail(
-            self.test_team_6.team_id,
+            self.test_team_5.team_id,
             200,
             {'expand': 'user'},
             user='student_enrolled_public_profile'
@@ -1025,7 +1015,7 @@ class TestListMembershipAPI(TeamAPITestCase):
     def test_expand_public_user(self):
         result = self.get_membership_list(
             200,
-            {'team_id': self.test_team_6.team_id, 'expand': 'user'},
+            {'team_id': self.test_team_5.team_id, 'expand': 'user'},
             user='student_enrolled_public_profile'
         )
         self.verify_expanded_public_user(result['results'][0]['user'])
@@ -1113,7 +1103,7 @@ class TestCreateMembershipAPI(TeamAPITestCase):
     def test_over_max_team_size_in_course_2(self):
         response = self.post_create_membership(
             400,
-            self.build_membership_data('student_enrolled_other_course_not_on_team', self.test_team_5),
+            self.build_membership_data('student_enrolled_other_course_not_on_team', self.test_team_4),
             user='student_enrolled_other_course_not_on_team'
         )
         self.assertIn('full', json.loads(response.content)['developer_message'])
@@ -1167,7 +1157,7 @@ class TestDetailMembershipAPI(TeamAPITestCase):
 
     def test_expand_public_user(self):
         result = self.get_membership_detail(
-            self.test_team_6.team_id,
+            self.test_team_5.team_id,
             self.users['student_enrolled_public_profile'].username,
             200,
             {'expand': 'user'},

--- a/lms/djangoapps/teams/tests/test_views.py
+++ b/lms/djangoapps/teams/tests/test_views.py
@@ -122,7 +122,7 @@ class TeamAPITestCase(APITestCase, SharedModuleStoreTestCase):
                     'id': 'topic_{}'.format(i),
                     'name': name,
                     'description': 'Description for topic {}.'.format(i)
-                } for i, name in enumerate([u'sólar power', 'Wind Power', 'Nuclear Power', 'Coal Power'])
+                } for i, name in enumerate([u'Sólar power', 'Wind Power', 'Nuclear Power', 'Coal Power'])
             ]
         }
         cls.test_course_1 = CourseFactory.create(
@@ -201,9 +201,8 @@ class TeamAPITestCase(APITestCase, SharedModuleStoreTestCase):
             sender=CourseTeam,
             dispatch_uid='teams.signals.course_team_post_save_callback'
         ):
-            # 'solar team' is intentionally lower case to test case insensitivity in name ordering
             self.test_team_1 = CourseTeamFactory.create(
-                name=u'sólar team',
+                name=u'Sólar team',
                 course_id=self.test_course_1.id,
                 topic_id='topic_0'
             )
@@ -445,24 +444,24 @@ class TestListTeamsAPI(TeamAPITestCase):
         )
 
     def test_filter_topic_id(self):
-        self.verify_names({'course_id': self.test_course_1.id, 'topic_id': 'topic_0'}, 200, [u'sólar team'])
+        self.verify_names({'course_id': self.test_course_1.id, 'topic_id': 'topic_0'}, 200, [u'Sólar team'])
 
     def test_filter_include_inactive(self):
-        self.verify_names({'include_inactive': True}, 200, ['Coal Team', 'Nuclear Team', u'sólar team', 'Wind Team'])
+        self.verify_names({'include_inactive': True}, 200, ['Coal Team', 'Nuclear Team', u'Sólar team', 'Wind Team'])
 
     @ddt.data(
-        (None, 200, ['Nuclear Team', u'sólar team', 'Wind Team']),
-        ('name', 200, ['Nuclear Team', u'sólar team', 'Wind Team']),
-        # Note that "Nuclear Team" and "solar team" have the same open_slots.
-        # "solar team" comes first due to secondary sort by last_activity_at.
-        ('open_slots', 200, ['Wind Team', u'sólar team', 'Nuclear Team']),
+        (None, 200, ['Nuclear Team', u'Sólar team', 'Wind Team']),
+        ('name', 200, ['Nuclear Team', u'Sólar team', 'Wind Team']),
+        # Note that "Nuclear Team" and "Solar team" have the same open_slots.
+        # "Solar team" comes first due to secondary sort by last_activity_at.
+        ('open_slots', 200, ['Wind Team', u'Sólar team', 'Nuclear Team']),
         # Note that "Wind Team" and "Nuclear Team" have the same last_activity_at.
         # "Wind Team" comes first due to secondary sort by open_slots.
-        ('last_activity_at', 200, [u'sólar team', 'Wind Team', 'Nuclear Team']),
+        ('last_activity_at', 200, [u'Sólar team', 'Wind Team', 'Nuclear Team']),
     )
     @ddt.unpack
     def test_order_by(self, field, status, names):
-        # Make "solar team" the most recently active team.
+        # Make "Solar team" the most recently active team.
         # The CourseTeamFactory sets the last_activity_at to a fixed time (in the past), so all of the
         # other teams have the same last_activity_at.
         with skip_signal(
@@ -471,7 +470,7 @@ class TestListTeamsAPI(TeamAPITestCase):
             sender=CourseTeam,
             dispatch_uid='teams.signals.course_team_post_save_callback'
         ):
-            solar_team = self.test_team_name_id_map[u'sólar team']
+            solar_team = self.test_team_name_id_map[u'Sólar team']
             solar_team.last_activity_at = datetime.utcnow().replace(tzinfo=pytz.utc)
             solar_team.save()
 
@@ -810,11 +809,11 @@ class TestListTopicsAPI(TeamAPITestCase):
         self.get_topics_list(400)
 
     @ddt.data(
-        (None, 200, ['Coal Power', 'Nuclear Power', u'sólar power', 'Wind Power'], 'name'),
-        ('name', 200, ['Coal Power', 'Nuclear Power', u'sólar power', 'Wind Power'], 'name'),
-        # Note that "Nuclear Power" and "solar power" both have 2 teams. "Coal Power" and "Window Power"
+        (None, 200, ['Coal Power', 'Nuclear Power', u'Sólar power', 'Wind Power'], 'name'),
+        ('name', 200, ['Coal Power', 'Nuclear Power', u'Sólar power', 'Wind Power'], 'name'),
+        # Note that "Nuclear Power" and "Solar power" both have 2 teams. "Coal Power" and "Window Power"
         # both have 0 teams. The secondary sort is alphabetical by name.
-        ('team_count', 200, ['Nuclear Power', u'sólar power', 'Coal Power', 'Wind Power'], 'team_count'),
+        ('team_count', 200, ['Nuclear Power', u'Sólar power', 'Coal Power', 'Wind Power'], 'team_count'),
         ('no_such_field', 400, [], None),
     )
     @ddt.unpack
@@ -865,7 +864,7 @@ class TestListTopicsAPI(TeamAPITestCase):
             'page': 1,
             'order_by': 'team_count'
         })
-        self.assertEqual(["Wind Power", u'sólar power'], [topic['name'] for topic in topics['results']])
+        self.assertEqual(["Wind Power", u'Sólar power'], [topic['name'] for topic in topics['results']])
 
         topics = self.get_topics_list(data={
             'course_id': self.test_course_1.id,
@@ -981,7 +980,7 @@ class TestListMembershipAPI(TeamAPITestCase):
     @ddt.data(
         ('student_enrolled_both_courses_other_team', 'TestX/TS101/Test_Course', 200, 'Nuclear Team'),
         ('student_enrolled_both_courses_other_team', 'MIT/6.002x/Circuits', 200, 'Another Team'),
-        ('student_enrolled', 'TestX/TS101/Test_Course', 200, u'sólar team'),
+        ('student_enrolled', 'TestX/TS101/Test_Course', 200, u'Sólar team'),
         ('student_enrolled', 'MIT/6.002x/Circuits', 400, ''),
     )
     @ddt.unpack

--- a/lms/djangoapps/teams/views.py
+++ b/lms/djangoapps/teams/views.py
@@ -361,8 +361,8 @@ class TeamsListView(ExpandableFieldViewMixin, GenericAPIView):
             queryset = CourseTeam.objects.filter(**result_filter)
             order_by_input = request.QUERY_PARAMS.get('order_by', 'name')
             if order_by_input == 'name':
-                queryset = queryset.extra(select={'lower_name': "lower(name)"})
-                queryset = queryset.order_by('lower_name')
+                # MySQL does case-insensitive order_by.
+                queryset = queryset.order_by('name')
             elif order_by_input == 'open_slots':
                 queryset = queryset.annotate(team_size=Count('users'))
                 queryset = queryset.order_by('team_size', '-last_activity_at')


### PR DESCRIPTION
@peter-fogg and @bderusha this PR does the following:

1) Adds a composite index for course_id and topic_id (recommended by looking at expensive queries)
2) Takes advantage of the fact that order_by is case-insensitive in MySQL to avoid an expensive "to lower-case" operation. Note that the alphabetical ordering of teams isn't actually exposed by our teams UI at all, so this is just helpful for the testing of the API as a whole.
