### PR TITLE
Optimize memory and CPU usage.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -234,3 +234,4 @@ Awais Qureshi <awais.qureshi@arbisoft.com>
 Eric Fischer <efischer@edx.org>
 Brian Beggs <macdiesel@gmail.com>
 Bill DeRusha <bill@edx.org>
+Kevin Falcone <kevin@edx.org>

--- a/cms/djangoapps/contentstore/management/commands/delete_course.py
+++ b/cms/djangoapps/contentstore/management/commands/delete_course.py
@@ -18,18 +18,6 @@ from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
 
 
-def print_out_all_courses():
-    """
-    Print out all the courses available in the course_key format so that
-    the user can correct any course_key mistakes
-    """
-    courses = modulestore().get_courses_keys()
-    print 'Available courses:'
-    for course in courses:
-        print str(course)
-    print ''
-
-
 class Command(BaseCommand):
     """
     Delete a MongoDB backed course
@@ -58,8 +46,6 @@ class Command(BaseCommand):
         elif len(args) > 2:
             raise CommandError("Too many arguments! Expected <course_key> <commit>")
 
-        print_out_all_courses()
-
         if not modulestore().get_course(course_key):
             raise CommandError("Course with '%s' key not found." % args[0])
 
@@ -67,4 +53,4 @@ class Command(BaseCommand):
         if query_yes_no("Deleting course {0}. Confirm?".format(course_key), default="no"):
             if query_yes_no("Are you sure. This action cannot be undone!", default="no"):
                 delete_course_and_groups(course_key, ModuleStoreEnum.UserID.mgmt_command)
-                print_out_all_courses()
+                print "Deleted course {}".format(course_key)

--- a/common/lib/xmodule/xmodule/modulestore/mixed.py
+++ b/common/lib/xmodule/xmodule/modulestore/mixed.py
@@ -281,21 +281,6 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
         return courses.values()
 
     @strip_key
-    def get_courses_keys(self, **kwargs):
-        '''
-        Returns a list containing the top level XModuleDescriptors keys of the courses in this modulestore.
-        '''
-        courses = {}
-        for store in self.modulestores:
-            # filter out ones which were fetched from earlier stores but locations may not be ==
-            for course in store.get_courses(**kwargs):
-                course_id = self._clean_locator_for_mapping(course.id)
-                if course_id not in courses:
-                    # course is indeed unique. save it in result
-                    courses[course_id] = course
-        return courses.keys()
-
-    @strip_key
     def get_libraries(self, **kwargs):
         """
         Returns a list containing the top level XBlock of the libraries (LibraryRoot) in this modulestore.


### PR DESCRIPTION
The print_out_all_courses() routine consumes a ton of memory (2G and
causes noticable mongo usage spikes).  This actually causes other
processes on production boxes to be memory starved and killed
(such as worker children on edge when this was run recently).

The behavior of this script on production is
- Print several hundred courses
- Ask if you want to delete the one you specified
- print several hundred courses minus one
  On a sandbox with 5 courses, you could tell by eye that 1 is gone, but
  not in production (or even in stage).

The original PLAT-619 ticket for this suggested printing a course
listing on error, but instead it always printed the course listing.
Even in the error case, hundreds of course ids is confusing and obscures
the error message saying that your course_id is invalid.

You should be getting the course id from the UI or from ./manage.py lms
dump_course_ids, not by searching a list.
