### PR TITLE
WIP: Add chromeless styling overrides for (mobile / LTI) course views

### DIFF
--- a/lms/static/sass/_build-course.scss
+++ b/lms/static/sass/_build-course.scss
@@ -68,4 +68,7 @@
 @import 'search/_search';
 
 // responsive
-@import 'base/layouts'; // temporary spot for responsive course
+@import 'base/layouts'; // temporary spot for respand inconsive course
+
+// chromeless overrides
+@import 'base/chromeless'; // styling overrides for chromless webviews (ex: mobile app, LTI

--- a/lms/static/sass/base/_chromeless.scss
+++ b/lms/static/sass/base/_chromeless.scss
@@ -1,0 +1,15 @@
+// chromeless - styling
+// ====================
+
+// Table of Contents
+// * +Component - Web View
+
+
+// overriding existing styles on the body element when view-chromeless is a class.
+
+body.view-chromeless {
+  
+  section.course-content {
+    padding: ($baseline/2);
+  }
+}

--- a/lms/templates/courseware/courseware-chromeless.html
+++ b/lms/templates/courseware/courseware-chromeless.html
@@ -10,7 +10,7 @@ from edxnotes.helpers import is_feature_enabled as is_edxnotes_enabled
  <% return _("{course_number} Courseware").format(course_number=course.display_number_with_default) %>
 </%def>
 
-<%block name="bodyclass">view-incourse view-courseware courseware ${course.css_class or ''}</%block>
+<%block name="bodyclass">view-incourse view-chromeless view-courseware courseware ${course.css_class or ''}</%block>
 <%block name="title"><title>
     % if section_title:
 ${page_title_breadcrumbs(section_title, course_name())}


### PR DESCRIPTION
## [UX-2752 ](https://openedx.atlassian.net/browse/UX-2752)

This PR adds in a chromeless styling override import, letting us specify styling overrides for courseware views such as mobile's component webview, or LTI views. More specifically, it changes the course content padding from 40px (LMS) to 10px (mobile / LTI). 
### Sandbox
- [ ] Build a sandbox for your branch and add a link here
### Reviewers

Please check the appropriate box after all relevant reviewers have finished and given the :+1:.
- [ ] Code review: @reviewer1
- [ ] Code review: ...
- [ ] UI strings review:
- [ ] UX review:
- [ ] Accessibility review:
- [ ] Product review:
