### PR TITLE
Adjust create new team page breadcrumbs.

### DIFF
--- a/common/test/acceptance/tests/lms/test_teams.py
+++ b/common/test/acceptance/tests/lms/test_teams.py
@@ -654,7 +654,7 @@ class TeamFormActions(TeamsTabBase):
             title='Create a New Team',
             description='Create a new team if you can\'t find existing teams to '
                         'join, or if you would like to learn with friends you know.',
-            breadcrumbs=self.topic['name']
+            breadcrumbs='All Topics {topic_name}'.format(topic_name=self.topic['name'])
         )
 
     def verify_and_navigate_to_edit_team_page(self):

--- a/lms/djangoapps/teams/static/teams/js/views/teams_tab.js
+++ b/lms/djangoapps/teams/static/teams/js/views/teams_tab.js
@@ -194,27 +194,31 @@
                  * Render the create new team form.
                  */
                 newTeam: function (topicID) {
-                    var self = this;
-                    this.getTeamsView(topicID).done(function (teamsView) {
-                        self.mainView = new ViewWithHeader({
-                            header: new HeaderView({
-                                model: new TeamsHeaderModel({
-                                    description: gettext("Create a new team if you can't find existing teams to join, or if you would like to learn with friends you know."),
-                                    title: gettext("Create a New Team"),
-                                    breadcrumbs: [
-                                        {
-                                            title: teamsView.main.teamParams.topicName,
-                                            url: '#topics/' + teamsView.main.teamParams.topicID
-                                        }
-                                    ]
-                                })
-                            }),
-                            main: new TeamEditView({
-                                action: 'create',
-                                teamEvents: self.teamEvents,
-                                teamParams: teamsView.main.teamParams
-                            })
+                    var self = this,
+                        createViewWithHeader;
+                    this.getTopic(topicID).done(function (topic) {
+                        var view = new TeamEditView({
+                            action: 'create',
+                            teamEvents: self.teamEvents,
+                            teamParams: {
+                                courseID: self.courseID,
+                                topicID: topic.get('id'),
+                                teamsUrl: self.teamsUrl,
+                                topicName: topic.get('name'),
+                                languages: self.languages,
+                                countries: self.countries,
+                                teamsDetailUrl: self.teamsDetailUrl
+                            }
                         });
+                        createViewWithHeader = self.createViewWithHeader({
+                            mainView: view,
+                            subject: {
+                                name: gettext("Create a New Team"),
+                                description: gettext("Create a new team if you can't find existing teams to join, or if you would like to learn with friends you know.")
+                            },
+                            parentTopic: topic
+                        });
+                        self.mainView = createViewWithHeader;
                         self.render();
                     });
                 },


### PR DESCRIPTION
This PR fixes the breadcrumbs for create new Team page, earlier it was only the topic name. Now it will be `All Topics > topic name >`.

Ticket: https://openedx.atlassian.net/browse/TNL-2964
Sandbox: http://muzaffar-team-breadcrumbs.sandbox.edx.org/
