### PR TITLE
Fixed test_about_me_field failing on chrome bok choy

### DIFF
--- a/common/test/acceptance/tests/lms/test_learner_profile.py
+++ b/common/test/acceptance/tests/lms/test_learner_profile.py
@@ -398,7 +398,7 @@ class OwnLearnerProfilePageTest(LearnerProfileTestMixin, WebAppTest):
 
         username, user_id = self.log_in_as_unique_user()
         profile_page = self.visit_profile_page(username, privacy=self.PRIVACY_PUBLIC)
-        self._test_textarea_field(profile_page, 'bio', 'Eat Sleep Code', 'Eat Sleep Code', 'display')
+        self._test_textarea_field(profile_page, 'bio', 'ThisIsIt', 'ThisIsIt', 'display')
         self._test_textarea_field(profile_page, 'bio', '', placeholder_value, 'placeholder')
 
         profile_page.make_field_editable('bio')


### PR DESCRIPTION
@benpatterson @jzoldak @andy-armstrong 
As https://code.google.com/p/chromedriver/issues/detail?id=1037 is still open, summary is that it doesn't support space in text fields and character 'e' is replaced by back space on Chrome browser so I changed '_test_textarea_field' new_value and displayed_value strings.
