### PR TITLE
Add jshint to run_quality.

### DIFF
--- a/pavelib/paver_tests/test_paver_quality.py
+++ b/pavelib/paver_tests/test_paver_quality.py
@@ -187,7 +187,7 @@ class TestPaverRunQuality(unittest.TestCase):
     @patch('__builtin__.open', mock_open())
     def test_failure_on_diffquality_pep8(self):
         """
-        If pep8 finds errors, pylint should still be run
+        If pep8 finds errors, pylint and jshint should still be run
         """
         # Mock _get_pep8_violations to return a violation
         _mock_pep8_violations = MagicMock(
@@ -198,10 +198,10 @@ class TestPaverRunQuality(unittest.TestCase):
                 pavelib.quality.run_quality("")
                 self.assertRaises(BuildFailure)
 
-        # Test that both pep8 and pylint were called by counting the calls to _get_pep8_violations
-        # (for pep8) and sh (for diff-quality pylint)
+        # Test that pep8, pylint, and jshint were called by counting the calls to
+        # _get_pep8_violations (for pep8) and sh (for diff-quality pylint & jshint)
         self.assertEqual(_mock_pep8_violations.call_count, 1)
-        self.assertEqual(self._mock_paver_sh.call_count, 1)
+        self.assertEqual(self._mock_paver_sh.call_count, 2)
 
     @patch('__builtin__.open', mock_open())
     def test_failure_on_diffquality_pylint(self):
@@ -219,8 +219,28 @@ class TestPaverRunQuality(unittest.TestCase):
         # Test that both pep8 and pylint were called by counting the calls
         # Assert that _get_pep8_violations (which calls "pep8") is called once
         self.assertEqual(_mock_pep8_violations.call_count, 1)
-        # And assert that sh was called once (for the call to "pylint")
-        self.assertEqual(self._mock_paver_sh.call_count, 1)
+        # And assert that sh was called twice (for the calls to pylint & jshint). This means that even in
+        # the event of a diff-quality pylint failure, jshint is still called.
+        self.assertEqual(self._mock_paver_sh.call_count, 2)
+
+    @patch('__builtin__.open', mock_open())
+    def test_failure_on_diffquality_jshint(self):
+        """
+        If diff-quality fails on jshint, the paver task should also fail
+        """
+
+        # Underlying sh call must fail when it is running the jshint diff-quality task
+        self._mock_paver_sh.side_effect = CustomShMock().fail_on_jshint
+        _mock_pep8_violations = MagicMock(return_value=(0, []))
+        with patch('pavelib.quality._get_pep8_violations', _mock_pep8_violations):
+            with self.assertRaises(SystemExit):
+                pavelib.quality.run_quality("")
+                self.assertRaises(BuildFailure)
+        # Test that both pep8 and pylint were called by counting the calls
+        # Assert that _get_pep8_violations (which calls "pep8") is called once
+        self.assertEqual(_mock_pep8_violations.call_count, 1)
+        # And assert that sh was called once (for the calls to pep8 and pylint)
+        self.assertEqual(self._mock_paver_sh.call_count, 2)
 
     @patch('__builtin__.open', mock_open())
     def test_other_exception(self):
@@ -243,8 +263,8 @@ class TestPaverRunQuality(unittest.TestCase):
             pavelib.quality.run_quality("")
         # Assert that _get_pep8_violations (which calls "pep8") is called once
         self.assertEqual(_mock_pep8_violations.call_count, 1)
-        # And assert that sh was called once (for the call to "pylint")
-        self.assertEqual(self._mock_paver_sh.call_count, 1)
+        # And assert that sh was called once (for the call to "pylint" & "jshint")
+        self.assertEqual(self._mock_paver_sh.call_count, 2)
 
 
 class CustomShMock(object):
@@ -259,6 +279,17 @@ class CustomShMock(object):
         is going to fail when we pass in a percentage ("p") requirement.
         """
         if "pylint" in arg:
+            # Essentially mock diff-quality exiting with 1
+            paver.easy.sh("exit 1")
+        else:
+            return
+
+    def fail_on_jshint(self, arg):
+        """
+        For our tests, we need the call for diff-quality running pep8 reports to fail, since that is what
+        is going to fail when we pass in a percentage ("p") requirement.
+        """
+        if "jshint" in arg:
             # Essentially mock diff-quality exiting with 1
             paver.easy.sh("exit 1")
         else:

--- a/pavelib/paver_tests/test_paver_quality.py
+++ b/pavelib/paver_tests/test_paver_quality.py
@@ -239,7 +239,7 @@ class TestPaverRunQuality(unittest.TestCase):
         # Test that both pep8 and pylint were called by counting the calls
         # Assert that _get_pep8_violations (which calls "pep8") is called once
         self.assertEqual(_mock_pep8_violations.call_count, 1)
-        # And assert that sh was called once (for the calls to pep8 and pylint)
+        # And assert that sh was called twice (for the calls to pep8 and pylint)
         self.assertEqual(self._mock_paver_sh.call_count, 2)
 
     @patch('__builtin__.open', mock_open())
@@ -263,7 +263,7 @@ class TestPaverRunQuality(unittest.TestCase):
             pavelib.quality.run_quality("")
         # Assert that _get_pep8_violations (which calls "pep8") is called once
         self.assertEqual(_mock_pep8_violations.call_count, 1)
-        # And assert that sh was called once (for the call to "pylint" & "jshint")
+        # And assert that sh was called twice (for the call to "pylint" & "jshint")
         self.assertEqual(self._mock_paver_sh.call_count, 2)
 
 

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -127,7 +127,7 @@ bok-choy==0.4.3
 chrono==1.0.2
 coverage==3.7.1
 ddt==0.8.0
-diff-cover==0.7.3
+diff-cover==0.8.0
 django-crum==0.5
 django_nose==1.3
 factory_boy==2.2.1

--- a/scripts/circle-ci-tests.sh
+++ b/scripts/circle-ci-tests.sh
@@ -44,13 +44,14 @@ case $CIRCLE_NODE_INDEX in
         # fails and aborts the job because nothing is displayed for > 10 minutes.
         paver run_pylint -l $PYLINT_THRESHOLD | tee pylint.log || EXIT=1
 
-        # Run quality task. Pass in the 'fail-under' percentage to diff-quality
-        paver run_quality -p 100 || EXIT=1
-
         mkdir -p reports
         echo "Finding jshint violations and storing report..."
         PATH=$PATH:node_modules/.bin
         paver run_jshint -l $JSHINT_THRESHOLD > jshint.log || { cat jshint.log; EXIT=1; }
+
+        # Run quality task. Pass in the 'fail-under' percentage to diff-quality
+        paver run_quality -p 100 || EXIT=1
+
         echo "Running code complexity report (python)."
         paver run_complexity > reports/code_complexity.log || echo "Unable to calculate code complexity. Ignoring error."
 

--- a/scripts/generic-ci-tests.sh
+++ b/scripts/generic-ci-tests.sh
@@ -67,8 +67,6 @@ case "$TEST_SUITE" in
         paver run_pep8 > pep8.log || { cat pep8.log; EXIT=1; }
         echo "Finding pylint violations and storing in report..."
         paver run_pylint -l $PYLINT_THRESHOLD || { cat pylint.log; EXIT=1; }
-        # Run quality task. Pass in the 'fail-under' percentage to diff-quality
-        paver run_quality -p 100 || EXIT=1
 
         mkdir -p reports
         echo "Finding jshint violations and storing report..."
@@ -76,6 +74,9 @@ case "$TEST_SUITE" in
         paver run_jshint -l $JSHINT_THRESHOLD > jshint.log || { cat jshint.log; EXIT=1; }
         echo "Running code complexity report (python)."
         paver run_complexity > reports/code_complexity.log || echo "Unable to calculate code complexity. Ignoring error."
+        # Run quality task. Pass in the 'fail-under' percentage to diff-quality
+        paver run_quality -p 100 || EXIT=1
+
         # Need to create an empty test result so the post-build
         # action doesn't fail the build.
         cat > reports/quality.xml <<END


### PR DESCRIPTION
The platform includes jshint as a development tool, and our
builds are enforcing a limit on total number of jshint violations.
This commit will enforce no new jshint violations on a per-change
basis, much like pylint and pep8 are enforced. So with this change,
we'll be enforcing our linting requirements consistently, regardless
of type of violations.
