### PR TITLE
Add current directory to the sass compilation path.

### DIFF
--- a/pavelib/assets.py
+++ b/pavelib/assets.py
@@ -132,7 +132,10 @@ def compile_coffeescript(*files):
 
 @task
 @no_help
-@cmdopts([('debug', 'd', 'Debug mode')])
+@cmdopts([
+    ('debug', 'd', 'Debug mode'),
+    ('force', '', 'Force full compilation'),
+])
 def compile_sass(options):
     """
     Compile Sass to CSS.
@@ -146,6 +149,9 @@ def compile_sass(options):
         parts.append("--sourcemap")
     else:
         parts.append("--style compressed --quiet")
+    if options.get('force'):
+        parts.append("--force")
+    parts.append("--load-path .")
     for load_path in SASS_LOAD_PATHS + SASS_DIRS.keys():
         parts.append("--load-path {path}".format(path=load_path))
 

--- a/pavelib/paver_tests/test_servers.py
+++ b/pavelib/paver_tests/test_servers.py
@@ -12,7 +12,7 @@ EXPECTED_COFFEE_COMMAND = (
 )
 EXPECTED_SASS_COMMAND = (
     "sass --update --cache-location /tmp/sass-cache --default-encoding utf-8 --style compressed"
-    " --quiet --load-path common/static --load-path common/static/sass"
+    " --quiet --load-path . --load-path common/static --load-path common/static/sass"
     " --load-path lms/static/sass --load-path lms/static/certificates/sass"
     " --load-path cms/static/sass --load-path common/static/sass"
     " lms/static/sass:lms/static/css lms/static/certificates/sass:lms/static/certificates/css"


### PR DESCRIPTION
This is the default in 3.2, but will need to be explicitly stated in Sass 3.4.

Also, added a --force parameter to compile_sass to make it easier to see what
warnings are current.
