### PR TITLE
Updated partially correct capa icon

### DIFF
--- a/common/lib/xmodule/xmodule/css/capa/display.scss
+++ b/common/lib/xmodule/xmodule/css/capa/display.scss
@@ -181,7 +181,7 @@ div.problem {
       }
 
       &.choicegroup_partially-correct {
-        @include status-icon($partiallycorrect, "\f00c");
+        @include status-icon($partiallycorrect, "\f069");
         border: 2px solid $partiallycorrect;
 
         // keep green for correct answers on hover. 
@@ -245,7 +245,7 @@ div.problem {
 
       // CASE: partially correct answer
       &.partially-correct {
-        @include status-icon($partiallycorrect, "\f00c");
+        @include status-icon($partiallycorrect, "\f069");
       }
 
       // CASE: incorrect answer
@@ -776,7 +776,7 @@ div.problem {
       }
 
       .status {
-        @include status-icon($partiallycorrect, "\f00c");
+        @include status-icon($partiallycorrect, "\f069");
       }
     }
 


### PR DESCRIPTION
## [UX-2753](https://openedx.atlassian.net/browse/UX-2753)

The following change is a way to more clearly visually differentiate partial credit without tackling the work necessary to clean up capa status messaging and point labeling. Thanks to @frrrances for the suggestion, as well as feedback from other teams that led to us revisiting this and coming up with an improvement that should help all students who interact with partial credit problems.

cc'ed @Colin-Fredericks as the original author of this feature.
### Sandbox

([pr9529.sandbox.edx.org](http://studio-pr9529.sandbox.edx.org/container/block-v1:edX+132123+1232344231+type@vertical+block@29232fbf31bf49368d380b570fb52db8))
### Reviewers

Please check the appropriate box after all relevant reviewers have finished and given the :+1:.
- [x] UX review: @frrrances 
- [x] Product review: @explorerleslie 
- [X] Documentation review: @lamagnifica 
- FYIs: @Colin-Fredericks
### Screenshot

![image](https://cloud.githubusercontent.com/assets/2023680/9556118/591df1fe-4da0-11e5-9f47-3f2da66f9da8.png)
