### PR TITLE
Diabled CSRF protection for Credit Course API endpoints

### DIFF
--- a/openedx/core/djangoapps/credit/views.py
+++ b/openedx/core/djangoapps/credit/views.py
@@ -12,6 +12,7 @@ from django.http import (
     HttpResponseForbidden,
     Http404
 )
+from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST, require_GET
 from opaque_keys import InvalidKeyError
@@ -379,6 +380,9 @@ class CreditCourseViewSet(mixins.CreateModelMixin, mixins.UpdateModelMixin, view
     authentication_classes = (authentication.OAuth2Authentication, authentication.SessionAuthentication,)
     permission_classes = (permissions.IsAuthenticated, permissions.IsAdminUser)
 
+    # This CSRF exemption only applies when authenticating without SessionAuthentication.
+    # SessionAuthentication will enforce CSRF protection.
+    @method_decorator(csrf_exempt)
     def dispatch(self, request, *args, **kwargs):
         # Convert the course ID/key from a string to an actual CourseKey object.
         course_id = kwargs.get(self.lookup_field, None)


### PR DESCRIPTION
CSRF protection needs to be disabled so that requests made using OAuth and other non-session-based authentication mechanisms can be properly processed. If session authentication is used, DRF will enforce CSRF protection.

XCOM-524

Replaces #9526

@rlucioni @jimabramson 
