### PR TITLE
MAYN-119: Hide shopping Cart menu

### DIFF
--- a/lms/djangoapps/shoppingcart/tests/test_views.py
+++ b/lms/djangoapps/shoppingcart/tests/test_views.py
@@ -1360,6 +1360,28 @@ class ShoppingCartViewsTests(ModuleStoreTestCase, XssTestMixin):
             }
         )
 
+    def test_shopping_cart_navigation_link_not_in_microsite(self):
+        """
+        Tests shopping cart link is available in navigation header if request is not from a microsite.
+        """
+        CourseEnrollment.enroll(self.user, self.course_key)
+        self.add_course_to_user_cart(self.testing_course.id)
+        resp = self.client.get(reverse('courseware', kwargs={'course_id': unicode(self.course.id)}))
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn('<a class="shopping-cart"', resp.content)
+
+    def test_shopping_cart_navigation_link_in_microsite(self):
+        """
+        Tests shopping cart link is not available in navigation header if request is from a microsite.
+        """
+        CourseEnrollment.enroll(self.user, self.course_key)
+        self.add_course_to_user_cart(self.testing_course.id)
+        with patch('microsite_configuration.microsite.is_request_in_microsite',
+                   Mock(return_value=True)):
+            resp = self.client.get(reverse('courseware', kwargs={'course_id': unicode(self.course.id)}))
+            self.assertEqual(resp.status_code, 200)
+            self.assertNotIn('<a class="shopping-cart"', resp.content)
+
 
 class ReceiptRedirectTest(ModuleStoreTestCase):
     """Test special-case redirect from the receipt page. """

--- a/lms/templates/navigation.html
+++ b/lms/templates/navigation.html
@@ -97,7 +97,7 @@ site_status_msg = get_site_status_msg(course_id)
         </ul>
       </li>
     </ol>
-      % if should_display_shopping_cart_func(): # see shoppingcart.context_processor.user_has_cart_context_processor
+      % if should_display_shopping_cart_func() and not microsite.is_request_in_microsite(): # see shoppingcart.context_processor.user_has_cart_context_processor
         <ol class="user">
           <li class="primary">
             <a class="shopping-cart" href="${reverse('shoppingcart.views.show_cart')}">


### PR DESCRIPTION
@mattdrayer @griffresch this PR supports MAYN-119. Shopping Cart menu should not be visible in case of white label site.
