### PR TITLE
Upgrade uglify-js to 2.4.24

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "dependencies": {
     "coffee-script": "1.6.1",
-    "uglify-js": "2.4.15"
+    "uglify-js": "2.4.24"
   },
   "devDependencies": {
     "jshint": "^2.7.0"


### PR DESCRIPTION
The latest version of uglify-js fixed a vulnerability which allows a specially crafted Javascript file to have altered functionality after minification.

Changelog between the versions we are running can be found in the Readme file from this diff: https://github.com/mishoo/UglifyJS2/compare/v2.4.15...v2.4.24#diff-04c6e90faac2675aa89e2176d2eec7d8

We use the command line without any special arguments so I don't expect any issues.

**Same as https://github.com/edx/edx-platform/pull/9537 but against the RC.**

@cpennington @edx/devops 
