### PR TITLE
update Reverification block hash

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -52,7 +52,7 @@ git+https://github.com/edx/edx-oauth2-provider.git@0.5.6#egg=oauth2-provider==0.
 git+https://github.com/edx/edx-lint.git@b109a40c61277c52dcb396bf15e33755f5dbf5fa#egg=edx_lint==0.2.4
 -e git+https://github.com/edx/xblock-utils.git@213a97a50276d6a2504d8133650b2930ead357a0#egg=xblock-utils
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
--e git+https://github.com/edx/edx-reverification-block.git@30fcf2fea305ed6649adcee9c831afaefba635c5#egg=edx-reverification-block
+-e git+https://github.com/edx/edx-reverification-block.git@5e77525cab256a20a0cf182fcf5471369b284ff1#egg=edx-reverification-block
 git+https://github.com/edx/ecommerce-api-client.git@1.1.0#egg=ecommerce-api-client==1.1.0
 -e git+https://github.com/edx/edx-user-state-client.git@30c0ad4b9f57f8d48d6943eb585ec8a9205f4469#egg=edx-user-state-client
 -e git+https://github.com/edx/edx-organizations.git@release-2015-08-31#egg=edx-organizations


### PR DESCRIPTION
This PR will upgrade the version of `edx-reverification-block` from `30fcf2fea305ed6649adcee9c831afaefba635c5` to `5e77525cab256a20a0cf182fcf5471369b284ff1`.

This upgrade will have the following UI related changes:
ICRV: Intro Message Styling & Copy, **Jira ticket:** [ECOM-2140](https://openedx.atlassian.net/browse/ECOM-2140), **Addressed by:** [PR](https://github.com/edx/edx-reverification-block/pull/39)
ICRV: Opt Out Warning Message copy and styling, **Jira ticket:** [ECOM-2141](https://openedx.atlassian.net/browse/ECOM-2141), **Addressed by:** [PR](https://github.com/edx/edx-reverification-block/pull/40)
ICRV: Verification Submitted message styling and copy, **Jira ticket:** [ECOM-2143](https://openedx.atlassian.net/browse/ECOM-2143), **Addressed by:** [PR](https://github.com/edx/edx-reverification-block/pull/40)
Added the compiled CSS in [PR](https://github.com/edx/edx-reverification-block/pull/41)

@zubair-arbi @awais786 @aamir-khan @tasawernawaz please review.
