### PR TITLE
TE-572 fix flaky pattern.

### DIFF
--- a/lms/djangoapps/courseware/features/problems.py
+++ b/lms/djangoapps/courseware/features/problems.py
@@ -173,7 +173,7 @@ def assert_answer_mark(_step, problem_type, isnt_marked, correctness):
     for sel in PROBLEM_DICT[problem_type][correctness]:
         if bool(isnt_marked):
             world.wait_for(lambda _: world.is_css_not_present(sel))  # pylint: disable=cell-var-from-loop
-            has_expected = world.is_css_not_present(sel)
+            has_expected = world.is_css_not_present(sel, wait_time=10)
         else:
             has_expected = world.is_css_present(sel, wait_time=10)
 

--- a/lms/djangoapps/courseware/features/problems.py
+++ b/lms/djangoapps/courseware/features/problems.py
@@ -175,6 +175,7 @@ def assert_answer_mark(_step, problem_type, isnt_marked, correctness):
             world.wait_for(lambda _: world.is_css_not_present(sel))  # pylint: disable=cell-var-from-loop
             has_expected = world.is_css_not_present(sel, wait_time=10)
         else:
+            world.wait_for_visible(sel)
             has_expected = world.is_css_present(sel, wait_time=10)
 
         # As soon as we find the selector, break out of the loop

--- a/lms/djangoapps/courseware/features/problems.py
+++ b/lms/djangoapps/courseware/features/problems.py
@@ -175,8 +175,7 @@ def assert_answer_mark(_step, problem_type, isnt_marked, correctness):
             world.wait_for(lambda _: world.is_css_not_present(sel))  # pylint: disable=cell-var-from-loop
             has_expected = world.is_css_not_present(sel)
         else:
-            world.css_find(sel)  # css_find includes a wait_for pattern
-            has_expected = world.is_css_present(sel)
+            has_expected = world.is_css_present(sel, wait_time=10)
 
         # As soon as we find the selector, break out of the loop
         if has_expected:

--- a/lms/djangoapps/courseware/features/problems_setup.py
+++ b/lms/djangoapps/courseware/features/problems_setup.py
@@ -42,7 +42,7 @@ PROBLEM_DICT = {
             'correct_option': 'Option 2'},
         'correct': ['span.correct'],
         'incorrect': ['span.incorrect'],
-        'unanswered': ['span.status.unanswered']},
+        'unanswered': ['span.unanswered']},
 
     'multiple choice': {
         'factory': MultipleChoiceResponseXMLFactory(),
@@ -52,7 +52,7 @@ PROBLEM_DICT = {
             'choice_names': ['choice_0', 'choice_1', 'choice_2', 'choice_3']},
         'correct': ['label.choicegroup_correct', 'span.correct'],
         'incorrect': ['label.choicegroup_incorrect', 'span.incorrect'],
-        'unanswered': ['span.status.unanswered']},
+        'unanswered': ['span.unanswered']},
 
     'checkbox': {
         'factory': ChoiceResponseXMLFactory(),
@@ -63,7 +63,7 @@ PROBLEM_DICT = {
             'choice_names': ['Choice 1', 'Choice 2', 'Choice 3', 'Choice 4']},
         'correct': ['span.correct'],
         'incorrect': ['span.incorrect'],
-        'unanswered': ['span.status.unanswered']},
+        'unanswered': ['span.unanswered']},
 
     'radio': {
         'factory': ChoiceResponseXMLFactory(),
@@ -74,7 +74,7 @@ PROBLEM_DICT = {
             'choice_names': ['Choice 1', 'Choice 2', 'Choice 3', 'Choice 4']},
         'correct': ['label.choicegroup_correct', 'span.correct'],
         'incorrect': ['label.choicegroup_incorrect', 'span.incorrect'],
-        'unanswered': ['span.status.unanswered']},
+        'unanswered': ['span.unanswered']},
 
     'string': {
         'factory': StringResponseXMLFactory(),

--- a/lms/djangoapps/courseware/features/problems_setup.py
+++ b/lms/djangoapps/courseware/features/problems_setup.py
@@ -42,7 +42,7 @@ PROBLEM_DICT = {
             'correct_option': 'Option 2'},
         'correct': ['span.correct'],
         'incorrect': ['span.incorrect'],
-        'unanswered': ['span.unanswered']},
+        'unanswered': ['span.status.unanswered']},
 
     'multiple choice': {
         'factory': MultipleChoiceResponseXMLFactory(),
@@ -52,7 +52,7 @@ PROBLEM_DICT = {
             'choice_names': ['choice_0', 'choice_1', 'choice_2', 'choice_3']},
         'correct': ['label.choicegroup_correct', 'span.correct'],
         'incorrect': ['label.choicegroup_incorrect', 'span.incorrect'],
-        'unanswered': ['span.unanswered']},
+        'unanswered': ['span.status.unanswered']},
 
     'checkbox': {
         'factory': ChoiceResponseXMLFactory(),
@@ -63,7 +63,7 @@ PROBLEM_DICT = {
             'choice_names': ['Choice 1', 'Choice 2', 'Choice 3', 'Choice 4']},
         'correct': ['span.correct'],
         'incorrect': ['span.incorrect'],
-        'unanswered': ['span.unanswered']},
+        'unanswered': ['span.status.unanswered']},
 
     'radio': {
         'factory': ChoiceResponseXMLFactory(),
@@ -74,7 +74,7 @@ PROBLEM_DICT = {
             'choice_names': ['Choice 1', 'Choice 2', 'Choice 3', 'Choice 4']},
         'correct': ['label.choicegroup_correct', 'span.correct'],
         'incorrect': ['label.choicegroup_incorrect', 'span.incorrect'],
-        'unanswered': ['span.unanswered']},
+        'unanswered': ['span.status.unanswered']},
 
     'string': {
         'factory': StringResponseXMLFactory(),


### PR DESCRIPTION
The `span.unanswered` css location is always present. The actual image
only appears when the .status class is also present. This commit hardens
the test to make it less flaky.
