### PR TITLE
Allow deletion of teams.

### DIFF
--- a/common/test/acceptance/pages/lms/teams.py
+++ b/common/test/acceptance/pages/lms/teams.py
@@ -201,6 +201,11 @@ class BrowseTeamsPage(CoursePage, PaginatedUIMixin, TeamCardsMixin):
             lambda e: e.is_selected()
         ).results[0].text.strip()
 
+    @property
+    def team_names(self):
+        """Get all the team names on the page."""
+        return self.q(css=CARD_TITLE_CSS).map(lambda e: e.text).results
+
     def click_create_team_link(self):
         """ Click on create team link."""
         query = self.q(css=CREATE_TEAM_LINK_CSS)
@@ -230,9 +235,9 @@ class BrowseTeamsPage(CoursePage, PaginatedUIMixin, TeamCardsMixin):
         self.wait_for_ajax()
 
 
-class CreateOrEditTeamPage(CoursePage, FieldsMixin):
+class CreateEditDeleteTeamPage(CoursePage, FieldsMixin):
     """
-    Create team page.
+    Team page for creation, editing, and deletion.
     """
     def __init__(self, browser, course_id, topic):
         """
@@ -241,7 +246,7 @@ class CreateOrEditTeamPage(CoursePage, FieldsMixin):
         representation of a topic following the same convention as a
         course module's topic.
         """
-        super(CreateOrEditTeamPage, self).__init__(browser, course_id)
+        super(CreateEditDeleteTeamPage, self).__init__(browser, course_id)
         self.topic = topic
         self.url_path = "teams/#topics/{topic_id}/create-team".format(topic_id=self.topic['id'])
 
@@ -280,6 +285,20 @@ class CreateOrEditTeamPage(CoursePage, FieldsMixin):
         """Click on cancel team button"""
         self.q(css='.create-team .action-cancel').first.click()
         self.wait_for_ajax()
+
+    @property
+    def delete_team_button(self):
+        """Returns the 'delete team' button."""
+        return self.q(css='.action-delete').first
+
+    def confirm_delete_team_dialog(self):
+        """Click 'delete' on the warning dialog."""
+        confirm_prompt(self, require_notification=False)
+        self.wait_for_ajax()
+
+    def cancel_delete_team_dialog(self):
+        """Click 'delete' on the warning dialog."""
+        confirm_prompt(self, cancel=True)
 
 
 class TeamPage(CoursePage, PaginatedUIMixin):

--- a/common/test/acceptance/tests/lms/test_teams.py
+++ b/common/test/acceptance/tests/lms/test_teams.py
@@ -22,7 +22,14 @@ from ...pages.lms.auto_auth import AutoAuthPage
 from ...pages.lms.course_info import CourseInfoPage
 from ...pages.lms.learner_profile import LearnerProfilePage
 from ...pages.lms.tab_nav import TabNavPage
-from ...pages.lms.teams import TeamsPage, MyTeamsPage, BrowseTopicsPage, BrowseTeamsPage, CreateOrEditTeamPage, TeamPage
+from ...pages.lms.teams import (
+    TeamsPage,
+    MyTeamsPage,
+    BrowseTopicsPage,
+    BrowseTeamsPage,
+    CreateEditDeleteTeamPage,
+    TeamPage
+)
 
 
 TOPICS_PER_PAGE = 12
@@ -334,7 +341,7 @@ class BrowseTopicsTest(TeamsTabBase):
         browse_teams_page = BrowseTeamsPage(self.browser, self.course_id, topic)
         self.assertTrue(browse_teams_page.is_browser_on_page())
         browse_teams_page.click_create_team_link()
-        create_team_page = CreateOrEditTeamPage(self.browser, self.course_id, topic)
+        create_team_page = CreateEditDeleteTeamPage(self.browser, self.course_id, topic)
         create_team_page.value_for_text_field(field_id='name', value='Team Name', press_enter=False)
         create_team_page.value_for_textarea_field(
             field_id='description',
@@ -705,7 +712,7 @@ class BrowseTeamsWithinTopicTest(TeamsTabBase):
 @attr('shard_5')
 class TeamFormActions(TeamsTabBase):
     """
-    Base class for create & edit team.
+    Base class for create, edit, and delete team.
     """
     TEAM_DESCRIPTION = 'The Avengers are a fictional team of superheroes.'
 
@@ -717,9 +724,9 @@ class TeamFormActions(TeamsTabBase):
         Verify that the page header correctly reflects the
         create team header, description and breadcrumb.
         """
-        self.assertEqual(self.create_or_edit_team_page.header_page_name, title)
-        self.assertEqual(self.create_or_edit_team_page.header_page_description, description)
-        self.assertEqual(self.create_or_edit_team_page.header_page_breadcrumbs, breadcrumbs)
+        self.assertEqual(self.create_edit_delete_team_page.header_page_name, title)
+        self.assertEqual(self.create_edit_delete_team_page.header_page_description, description)
+        self.assertEqual(self.create_edit_delete_team_page.header_page_breadcrumbs, breadcrumbs)
 
     def verify_and_navigate_to_create_team_page(self):
         """Navigates to the create team page and verifies."""
@@ -739,7 +746,7 @@ class TeamFormActions(TeamsTabBase):
 
         self.team_page.click_edit_team_button()
 
-        self.create_or_edit_team_page.wait_for_page()
+        self.create_edit_delete_team_page.wait_for_page()
 
         # Edit page header.
         self.verify_page_header(
@@ -762,33 +769,37 @@ class TeamFormActions(TeamsTabBase):
 
     def fill_create_or_edit_form(self):
         """Fill the create/edit team form fields with appropriate values."""
-        self.create_or_edit_team_page.value_for_text_field(field_id='name', value=self.TEAMS_NAME, press_enter=False)
-        self.create_or_edit_team_page.value_for_textarea_field(
+        self.create_edit_delete_team_page.value_for_text_field(
+            field_id='name',
+            value=self.TEAMS_NAME,
+            press_enter=False
+        )
+        self.create_edit_delete_team_page.value_for_textarea_field(
             field_id='description',
             value=self.TEAM_DESCRIPTION
         )
-        self.create_or_edit_team_page.value_for_dropdown_field(field_id='language', value='English')
-        self.create_or_edit_team_page.value_for_dropdown_field(field_id='country', value='Pakistan')
+        self.create_edit_delete_team_page.value_for_dropdown_field(field_id='language', value='English')
+        self.create_edit_delete_team_page.value_for_dropdown_field(field_id='country', value='Pakistan')
 
     def verify_all_fields_exist(self):
         """
         Verify the fields for create/edit page.
         """
         self.assertEqual(
-            self.create_or_edit_team_page.message_for_field('name'),
+            self.create_edit_delete_team_page.message_for_field('name'),
             'A name that identifies your team (maximum 255 characters).'
         )
         self.assertEqual(
-            self.create_or_edit_team_page.message_for_textarea_field('description'),
+            self.create_edit_delete_team_page.message_for_textarea_field('description'),
             'A short description of the team to help other learners understand '
             'the goals or direction of the team (maximum 300 characters).'
         )
         self.assertEqual(
-            self.create_or_edit_team_page.message_for_field('country'),
+            self.create_edit_delete_team_page.message_for_field('country'),
             'The country that team members primarily identify with.'
         )
         self.assertEqual(
-            self.create_or_edit_team_page.message_for_field('language'),
+            self.create_edit_delete_team_page.message_for_field('language'),
             'The language that team members primarily use to communicate with each other.'
         )
 
@@ -803,7 +814,7 @@ class CreateTeamTest(TeamFormActions):
         super(CreateTeamTest, self).setUp()
         self.set_team_configuration({'course_id': self.course_id, 'max_team_size': 10, 'topics': [self.topic]})
 
-        self.create_or_edit_team_page = CreateOrEditTeamPage(self.browser, self.course_id, self.topic)
+        self.create_edit_delete_team_page = CreateEditDeleteTeamPage(self.browser, self.course_id, self.topic)
         self.browse_teams_page = BrowseTeamsPage(self.browser, self.course_id, self.topic)
         self.browse_teams_page.visit()
 
@@ -831,14 +842,14 @@ class CreateTeamTest(TeamFormActions):
         Then I should see the error message and highlighted fields.
         """
         self.verify_and_navigate_to_create_team_page()
-        self.create_or_edit_team_page.submit_form()
+        self.create_edit_delete_team_page.submit_form()
 
         self.assertEqual(
-            self.create_or_edit_team_page.validation_message_text,
+            self.create_edit_delete_team_page.validation_message_text,
             'Check the highlighted fields below and try again.'
         )
-        self.assertTrue(self.create_or_edit_team_page.error_for_field(field_id='name'))
-        self.assertTrue(self.create_or_edit_team_page.error_for_field(field_id='description'))
+        self.assertTrue(self.create_edit_delete_team_page.error_for_field(field_id='name'))
+        self.assertTrue(self.create_edit_delete_team_page.error_for_field(field_id='description'))
 
     def test_user_can_see_error_message_for_incorrect_data(self):
         """
@@ -853,7 +864,7 @@ class CreateTeamTest(TeamFormActions):
         self.verify_and_navigate_to_create_team_page()
 
         # Fill the name field with >255 characters to see validation message.
-        self.create_or_edit_team_page.value_for_text_field(
+        self.create_edit_delete_team_page.value_for_text_field(
             field_id='name',
             value='EdX is a massive open online course (MOOC) provider and online learning platform. '
                   'It hosts online university-level courses in a wide range of disciplines to a worldwide '
@@ -865,13 +876,13 @@ class CreateTeamTest(TeamFormActions):
                   'edX has more than 4 million users taking more than 500 courses online.',
             press_enter=False
         )
-        self.create_or_edit_team_page.submit_form()
+        self.create_edit_delete_team_page.submit_form()
 
         self.assertEqual(
-            self.create_or_edit_team_page.validation_message_text,
+            self.create_edit_delete_team_page.validation_message_text,
             'Check the highlighted fields below and try again.'
         )
-        self.assertTrue(self.create_or_edit_team_page.error_for_field(field_id='name'))
+        self.assertTrue(self.create_edit_delete_team_page.error_for_field(field_id='name'))
 
     def test_user_can_create_new_team_successfully(self):
         """
@@ -893,7 +904,7 @@ class CreateTeamTest(TeamFormActions):
         self.verify_and_navigate_to_create_team_page()
 
         self.fill_create_or_edit_form()
-        self.create_or_edit_team_page.submit_form()
+        self.create_edit_delete_team_page.submit_form()
 
         # Verify that the page is shown for the new team
         team_page = TeamPage(self.browser, self.course_id)
@@ -925,7 +936,7 @@ class CreateTeamTest(TeamFormActions):
         self.assertTrue(self.browse_teams_page.get_pagination_header_text().startswith('Showing 0 out of 0 total'))
 
         self.verify_and_navigate_to_create_team_page()
-        self.create_or_edit_team_page.cancel_team()
+        self.create_edit_delete_team_page.cancel_team()
 
         self.assertTrue(self.browse_teams_page.is_browser_on_page())
         self.assertTrue(self.browse_teams_page.get_pagination_header_text().startswith('Showing 0 out of 0 total'))
@@ -934,6 +945,76 @@ class CreateTeamTest(TeamFormActions):
         self.teams_page.verify_team_count_in_first_topic(0)
 
         self.verify_my_team_count(0)
+
+
+@ddt.ddt
+class DeleteTeamTest(TeamFormActions):
+    """
+    Tests for deleting teams.
+    """
+
+    def setUp(self):
+        super(DeleteTeamTest, self).setUp()
+
+        self.set_team_configuration(
+            {'course_id': self.course_id, 'max_team_size': 10, 'topics': [self.topic]},
+            global_staff=True
+        )
+        self.create_edit_delete_team_page = CreateEditDeleteTeamPage(self.browser, self.course_id, self.topic)
+
+        self.team = self.create_teams(self.topic, num_teams=1)[0]
+        self.team_page = TeamPage(self.browser, self.course_id, team=self.team)
+        self.team_page.visit()
+
+    def test_cancel_delete(self):
+        """
+        Scenario: The user should be able to cancel the Delete Team dialog
+        Given I am staff user for a course with a team
+        When I visit the Team profile page
+        Then I should see the Edit Team button
+        And When I click edit team button
+        Then I should see the Delete Team button
+        When I click the delete team button
+        And I cancel the prompt
+        Then I should remain on the page
+        """
+        self.team_page.click_edit_team_button()
+        self.create_edit_delete_team_page.wait_for_page()
+        self.create_edit_delete_team_page.delete_team_button.click()
+        self.create_edit_delete_team_page.cancel_delete_team_dialog()
+        self.assertTrue(self.create_edit_delete_team_page.is_browser_on_page())
+
+    @ddt.data('Moderator', 'Community TA', 'Administrator', None)
+    def test_delete_team(self, role):
+        """
+        Scenario: The user should be able to see and navigate to the delete team page.
+        Given I am staff user for a course with a team
+        When I visit the Team profile page
+        Then I should see the Edit Team button
+        And When I click edit team button
+        Then I should see the Delete Team button
+        When I click the delete team button
+        And I confirm the prompt
+        Then I should see the browse teams page
+        And the team should not be present
+        """
+        # If role is None, remain logged in as global staff
+        if role is not None:
+            AutoAuthPage(
+                self.browser,
+                course_id=self.course_id,
+                staff=False,
+                roles=role
+            ).visit()
+        self.team_page.visit()
+        self.team_page.wait_for_page()
+        self.team_page.click_edit_team_button()
+        self.create_edit_delete_team_page.wait_for_page()
+        self.create_edit_delete_team_page.delete_team_button.click()
+        self.create_edit_delete_team_page.confirm_delete_team_dialog()
+        browse_teams_page = BrowseTeamsPage(self.browser, self.course_id, self.topic)
+        self.assertTrue(browse_teams_page.is_browser_on_page())
+        self.assertNotIn(self.team['name'], browse_teams_page.team_names)
 
 
 @ddt.ddt
@@ -949,7 +1030,7 @@ class EditTeamTest(TeamFormActions):
             {'course_id': self.course_id, 'max_team_size': 10, 'topics': [self.topic]},
             global_staff=True
         )
-        self.create_or_edit_team_page = CreateOrEditTeamPage(self.browser, self.course_id, self.topic)
+        self.create_edit_delete_team_page = CreateEditDeleteTeamPage(self.browser, self.course_id, self.topic)
 
         self.team = self.create_teams(self.topic, num_teams=1)[0]
         self.team_page = TeamPage(self.browser, self.course_id, team=self.team)
@@ -990,7 +1071,7 @@ class EditTeamTest(TeamFormActions):
         self.verify_and_navigate_to_edit_team_page()
 
         self.fill_create_or_edit_form()
-        self.create_or_edit_team_page.submit_form()
+        self.create_edit_delete_team_page.submit_form()
 
         self.team_page.wait_for_page()
 
@@ -1023,7 +1104,7 @@ class EditTeamTest(TeamFormActions):
         self.verify_and_navigate_to_edit_team_page()
 
         self.fill_create_or_edit_form()
-        self.create_or_edit_team_page.cancel_team()
+        self.create_edit_delete_team_page.cancel_team()
 
         self.team_page.wait_for_page()
 
@@ -1075,7 +1156,7 @@ class EditTeamTest(TeamFormActions):
         self.verify_and_navigate_to_edit_team_page()
 
         self.fill_create_or_edit_form()
-        self.create_or_edit_team_page.submit_form()
+        self.create_edit_delete_team_page.submit_form()
 
         self.team_page.wait_for_page()
 

--- a/lms/djangoapps/teams/static/teams/js/views/instructor_tools.js
+++ b/lms/djangoapps/teams/static/teams/js/views/instructor_tools.js
@@ -5,8 +5,9 @@
             'underscore',
             'gettext',
             'teams/js/views/team_utils',
+            'common/js/components/views/feedback_prompt',
             'text!teams/templates/instructor-tools.underscore'],
-        function (Backbone, _, gettext, TeamUtils, instructorToolbarTemplate) {
+        function (Backbone, _, gettext, TeamUtils, PromptView, instructorToolbarTemplate) {
             return Backbone.View.extend({
 
                 events: {
@@ -16,6 +17,9 @@
 
                 initialize: function(options) {
                     this.template = _.template(instructorToolbarTemplate);
+                    this.team = options.team;
+                    this.teamEvents = options.teamEvents;
+                    this.router = options.router;
                 },
 
                 render: function() {
@@ -25,14 +29,46 @@
 
                 deleteTeam: function (event) {
                     event.preventDefault();
-                    alert("You clicked the button!");
-                    //placeholder; will route to delete team page
+                    var self = this;
+                    var msg = new PromptView.Warning({
+                        title: gettext('Delete this team?'),
+                        message: gettext('Deleting a team removes it from the team listing view, and removes members from the team as well.'),
+                        actions: {
+                            primary: {
+                                text: gettext('Delete'),
+                                class: 'action-delete',
+                                click: function () {
+                                    msg.hide();
+                                    self.handleDelete();
+                                }
+                            },
+                            secondary: {
+                                text: gettext('Close'),
+                                class: 'action-cancel',
+                                click: function () {
+                                    msg.hide();
+                                }
+                            }
+                        }
+                    });
+                    msg.show()
                 },
 
                 editMembership: function (event) {
                     event.preventDefault();
                     alert("You clicked the button!");
                     //placeholder; will route to remove team member page
+                },
+
+                handleDelete: function () {
+                    var self = this;
+                    this.team.destroy().then(function () {
+                        self.teamEvents.trigger('teams:update', {
+                            action: 'delete',
+                            team: self.team
+                        });
+                        self.router.navigate('topics/' + self.team.get('topic_id'), {trigger: true});
+                    });
                 }
             });
         });

--- a/lms/djangoapps/teams/static/teams/js/views/instructor_tools.js
+++ b/lms/djangoapps/teams/static/teams/js/views/instructor_tools.js
@@ -1,0 +1,39 @@
+;(function (define) {
+    'use strict';
+
+    define(['backbone',
+            'underscore',
+            'gettext',
+            'teams/js/views/team_utils',
+            'text!teams/templates/instructor-tools.underscore'],
+        function (Backbone, _, gettext, TeamUtils, instructorToolbarTemplate) {
+            return Backbone.View.extend({
+
+                events: {
+                    'click .action-delete': 'deleteTeam',
+                    'click .action-edit-members': 'editMembership'
+                },
+
+                initialize: function(options) {
+                    this.template = _.template(instructorToolbarTemplate);
+                },
+
+                render: function() {
+                    this.$el.html(this.template);
+                    return this;
+                },
+
+                deleteTeam: function (event) {
+                    event.preventDefault();
+                    alert("You clicked the button!");
+                    //placeholder; will route to delete team page
+                },
+
+                editMembership: function (event) {
+                    event.preventDefault();
+                    alert("You clicked the button!");
+                    //placeholder; will route to remove team member page
+                }
+            });
+        });
+}).call(this, define || RequireJS.define);

--- a/lms/djangoapps/teams/static/teams/js/views/teams_tab.js
+++ b/lms/djangoapps/teams/static/teams/js/views/teams_tab.js
@@ -18,11 +18,12 @@
             'teams/js/views/topic_teams',
             'teams/js/views/edit_team',
             'teams/js/views/team_profile_header_actions',
+            'teams/js/views/instructor_tools',
             'text!teams/templates/teams_tab.underscore'],
         function (Backbone, _, gettext, HeaderView, HeaderModel, TabbedView,
                   TopicModel, TopicCollection, TeamModel, TeamCollection, TeamMembershipCollection,
                   TopicsView, TeamProfileView, MyTeamsView, TopicTeamsView, TeamEditView,
-                  TeamProfileHeaderActionsView, teamsTemplate) {
+                  TeamProfileHeaderActionsView, InstructorToolsView, teamsTemplate) {
             var TeamsHeaderModel = HeaderModel.extend({
                 initialize: function (attributes) {
                     _.extend(this.defaults, {nav_aria_label: gettext('teams')});
@@ -34,12 +35,15 @@
                 initialize: function (options) {
                     this.header = options.header;
                     this.main = options.main;
+                    this.instructorTools = options.instructorTools;
                 },
 
                 render: function () {
                     this.$el.html(_.template(teamsTemplate));
                     this.$('p.error').hide();
                     this.header.setElement(this.$('.teams-header')).render();
+                    if (this.instructorTools)
+                        this.instructorTools.setElement(this.$('.teams-instructor-tools-bar')).render();
                     this.main.setElement(this.$('.page-content')).render();
                     return this;
                 }
@@ -245,6 +249,7 @@
                                 },
                                 model: team
                             });
+                            var instructorToolsView = new InstructorToolsView();
                             editViewWithHeader = self.createViewWithHeader({
                                     mainView: view,
                                     subject: {
@@ -252,7 +257,8 @@
                                         description: gettext("If you make significant changes, make sure you notify members of the team before making these changes.")
                                     },
                                     parentTeam: team,
-                                    parentTopic: topic
+                                    parentTopic: topic,
+                                    instructorTools: instructorToolsView
                                 }
                             );
                             self.mainView = editViewWithHeader;
@@ -428,7 +434,8 @@
                     });
                     return new ViewWithHeader({
                         header: headerView,
-                        main: options.mainView
+                        main: options.mainView,
+                        instructorTools: options.instructorTools
                     });
                 },
 

--- a/lms/djangoapps/teams/static/teams/js/views/teams_tab.js
+++ b/lms/djangoapps/teams/static/teams/js/views/teams_tab.js
@@ -249,7 +249,11 @@
                                 },
                                 model: team
                             });
-                            var instructorToolsView = new InstructorToolsView();
+                            var instructorToolsHeader = new InstructorToolsView({
+                                team: team,
+                                teamEvents: self.teamEvents,
+                                router: self.router
+                            });
                             editViewWithHeader = self.createViewWithHeader({
                                     mainView: view,
                                     subject: {

--- a/lms/djangoapps/teams/static/teams/templates/instructor-tools.underscore
+++ b/lms/djangoapps/teams/static/teams/templates/instructor-tools.underscore
@@ -1,0 +1,13 @@
+<div class="wrapper-msg">
+    <span class="left-floater">
+        <%- gettext("Instructor tools") %>
+    </span>
+    <span class="right-floater">
+        <button class="action-delete">
+            <%- gettext("Delete Team") %>
+        </button>
+        <button class="action-edit-members">
+            <%- gettext("Edit Membership") %>
+        </button>
+    </span>
+</div>

--- a/lms/djangoapps/teams/static/teams/templates/teams_tab.underscore
+++ b/lms/djangoapps/teams/static/teams/templates/teams_tab.underscore
@@ -7,6 +7,7 @@
     </div>
 </div>
 <div class="teams-header"></div>
+<div class="teams-instructor-tools-bar"></div>
 <div class="teams-main">
     <div class="page-content"></div>
 </div>

--- a/lms/djangoapps/teams/tests/test_views.py
+++ b/lms/djangoapps/teams/tests/test_views.py
@@ -19,6 +19,7 @@ from student.models import CourseEnrollment
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 from .factories import CourseTeamFactory, LAST_ACTIVITY_AT
+from ..models import CourseTeamMembership
 from ..search_indexes import CourseTeamIndexer, CourseTeam, course_team_post_save_callback
 
 from django_comment_common.models import Role, FORUM_ROLE_COMMUNITY_TA
@@ -327,6 +328,10 @@ class TeamAPITestCase(APITestCase, SharedModuleStoreTestCase):
     def get_team_detail(self, team_id, expected_status=200, data=None, **kwargs):
         """Gets detailed team information for team_id. Verifies expected_status."""
         return self.make_call(reverse('teams_detail', args=[team_id]), expected_status, 'get', data, **kwargs)
+
+    def delete_team(self, team_id, expected_status, **kwargs):
+        """Delete the given team. Verifies expected_status."""
+        return self.make_call(reverse('teams_detail', args=[team_id]), expected_status, 'delete', **kwargs)
 
     def patch_team_detail(self, team_id, expected_status, data=None, **kwargs):
         """Patches the team with team_id using data. Verifies expected_status."""
@@ -719,6 +724,32 @@ class TestDetailTeamAPI(TeamAPITestCase):
             user='student_enrolled_public_profile'
         )
         self.verify_expanded_public_user(result['membership'][0]['user'])
+
+
+@ddt.ddt
+class TestDeleteTeamAPI(TeamAPITestCase):
+    """Test cases for the team delete endpoint."""
+
+    @ddt.data(
+        (None, 401),
+        ('student_inactive', 401),
+        ('student_unenrolled', 403),
+        ('student_enrolled', 403),
+        ('staff', 204),
+        ('course_staff', 204),
+        ('community_ta', 204)
+    )
+    @ddt.unpack
+    def test_access(self, user, status):
+        self.delete_team(self.solar_team.team_id, status, user=user)
+
+    def test_does_not_exist(self):
+        self.delete_team('nonexistent', 404)
+
+    def test_memberships_deleted(self):
+        self.assertEqual(CourseTeamMembership.objects.filter(team=self.solar_team).count(), 1)
+        self.delete_team(self.solar_team.team_id, 204, user='staff')
+        self.assertEqual(CourseTeamMembership.objects.filter(team=self.solar_team).count(), 0)
 
 
 @ddt.ddt

--- a/lms/djangoapps/teams/views.py
+++ b/lms/djangoapps/teams/views.py
@@ -1,6 +1,8 @@
 """HTTP endpoints for the Teams API."""
 
-from django.shortcuts import render_to_response
+import logging
+
+from django.shortcuts import get_object_or_404, render_to_response
 from django.http import Http404
 from django.conf import settings
 from django.core.paginator import Paginator
@@ -56,6 +58,9 @@ from .errors import AlreadyOnTeamInCourse, NotEnrolledInCourseForTeam
 TEAM_MEMBERSHIPS_PER_PAGE = 2
 TOPICS_PER_PAGE = 12
 MAXIMUM_SEARCH_SIZE = 100000
+
+
+log = logging.getLogger(__name__)
 
 
 class TeamsDashboardView(View):
@@ -457,7 +462,7 @@ class TeamsDetailView(ExpandableFieldViewMixin, RetrievePatchAPIView):
     """
         **Use Cases**
 
-            Get or update a course team's information. Updates are supported
+            Get, update, or delete a course team's information. Updates are supported
             only through merge patch.
 
         **Example Requests**:
@@ -465,6 +470,8 @@ class TeamsDetailView(ExpandableFieldViewMixin, RetrievePatchAPIView):
             GET /api/team/v0/teams/{team_id}}
 
             PATCH /api/team/v0/teams/{team_id} "application/merge-patch+json"
+
+            DELETE /api/team/v0/teams/{team_id}
 
         **Query Parameters for GET**
 
@@ -530,6 +537,20 @@ class TeamsDetailView(ExpandableFieldViewMixin, RetrievePatchAPIView):
             If the update could not be completed due to validation errors, this
             method returns a 400 error with all error messages in the
             "field_errors" field of the returned JSON.
+
+        **Response Values for DELETE**
+
+            Only staff can delete teams. When a team is deleted, all
+            team memberships associated with that team are also
+            deleted.
+
+            If the user is anonymous of inactive, a 401 is returned.
+
+            If the user is not course or global staff and does not
+            have discussion privileges, a 403 is returned.
+
+            If the user is logged in and the team does not exist, a 404 is returned.
+
     """
     authentication_classes = (OAuth2Authentication, SessionAuthentication)
     permission_classes = (permissions.IsAuthenticated, IsStaffOrPrivilegedOrReadOnly, IsEnrolledOrIsStaff,)
@@ -540,6 +561,15 @@ class TeamsDetailView(ExpandableFieldViewMixin, RetrievePatchAPIView):
     def get_queryset(self):
         """Returns the queryset used to access the given team."""
         return CourseTeam.objects.all()
+
+    def delete(self, request, team_id):
+        """DELETE /api/team/v0/teams/{team_id}"""
+        team = get_object_or_404(CourseTeam, team_id=team_id)
+        self.check_object_permissions(request, team)
+        # Note: also deletes all team memberships associated with this team
+        log.info('user %d deleted team %s', request.user.id, team_id)
+        team.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
 
 class TopicListView(GenericAPIView):

--- a/lms/static/sass/_developer.scss
+++ b/lms/static/sass/_developer.scss
@@ -232,3 +232,44 @@
     }
   }
 }
+
+//efischer; scratch space to make things up and see what happens
+.wrapper-msg {
+  @include clearfix();
+  max-width: grid-width(12);
+  margin: 0 auto;
+  border-top: 3px solid $orange;
+
+  .left-floater {
+    float: left;
+    text-transform: uppercase;
+    font-weight: $font-semibold;
+    color: $white;
+    line-height: $body-line-height;
+  }
+
+  .right-floater {
+    float: right;
+    line-height: $body-line-height;
+
+    button {
+      background: transparent;
+      border: 1px solid transparent;
+      color: $white;
+      box-shadow: 0 0 0 0;
+      font-weight: $font-regular;
+      text-shadow: 0 0;
+
+      &:hover {
+        color: $orange;
+        background: transparent;
+        border: 1px solid $orange;
+        box-shadow: 0 0 0 0;
+      }
+
+      &:focus {
+        box-shadow: 0 0 0 0;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## [TNL-1915](https://openedx.atlassian.net/browse/TNL-1915)

Allows deletion of teams by privileged users, using the standard Teams definition of privileged. Team memberships are permanently deleted along with teams.
### Sandbox
- [x] http://peter-fogg.sandbox.edx.org/courses/course-v1:TeamsX+T101+2015/teams/#my-teams
### Testing
- [ ] i18n
- [ ] RTL
- [x] Unit, integration, acceptance tests as appropriate
### Reviewers

Please check the appropriate box after all relevant reviewers have finished and given the :+1:.
- [ ] Code review: @cahrens 
- [ ] Code review: @andy-armstrong 
- [ ] UI strings: @catong 
- [ ] Product review: @explorerleslie 
- FYI @cptvitamin @andywaldrop @marcotuts 
