### PR TITLE
Hotfix/2015-09-01: LTI Provider fixes

### DIFF
--- a/lms/djangoapps/lti_provider/models.py
+++ b/lms/djangoapps/lti_provider/models.py
@@ -26,7 +26,7 @@ class LtiConsumer(models.Model):
     consumer_name = models.CharField(max_length=255, unique=True)
     consumer_key = models.CharField(max_length=32, unique=True, db_index=True)
     consumer_secret = models.CharField(max_length=32, unique=True)
-    instance_guid = models.CharField(max_length=255, null=True, unique=True)
+    instance_guid = models.CharField(max_length=255, blank=True, null=True, unique=True)
 
     @staticmethod
     def get_or_supplement(instance_guid, consumer_key):

--- a/lms/djangoapps/lti_provider/tasks.py
+++ b/lms/djangoapps/lti_provider/tasks.py
@@ -44,7 +44,7 @@ def score_changed_handler(sender, **kwargs):  # pylint: disable=unused-argument
         )
 
 
-@CELERY_APP.task
+@CELERY_APP.task(name='lti_provider.tasks.send_outcome')
 def send_outcome(points_possible, points_earned, user_id, course_id, usage_id):
     """
     Calculate the score for a given user in a problem and send it to the


### PR DESCRIPTION
- Allow `LtiConsumer.instance_guid` to be set to blank in Django admin.
- Add an explicit name for the LTI provider outcome celery task.
- Add an `oauth_body_hash` header to the outcome grade passback.

@cpennington, @jibsheet, @maxrothman, @lamagnifica, @ebporter 
