### PR TITLE
Upgrade mock-django in platform & released version for edx-search.

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -130,7 +130,7 @@ django_nose==1.4.1
 factory_boy==2.2.1
 flaky==2.0.3
 freezegun==0.1.11
-mock-django==0.6.6
+mock-django==0.6.9
 mock==1.0.1
 moto==0.3.1
 nose-exclude

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -48,7 +48,7 @@ git+https://github.com/edx/i18n-tools.git@v0.1.3#egg=i18n-tools==v0.1.3
 git+https://github.com/edx/edx-oauth2-provider.git@0.5.6#egg=oauth2-provider==0.5.6
 -e git+https://github.com/edx/edx-val.git@v0.0.5#egg=edx-val
 -e git+https://github.com/pmitros/RecommenderXBlock.git@518234bc354edbfc2651b9e534ddb54f96080779#egg=recommender-xblock
--e git+https://github.com/edx/edx-search.git@release-2015-07-22#egg=edx-search
+-e git+https://github.com/edx/edx-search.git@release-2015-09-04#egg=edx-search
 -e git+https://github.com/edx/edx-milestones.git@9b44a37edc3d63a23823c21a63cdd53ef47a7aa4#egg=edx-milestones
 git+https://github.com/edx/edx-lint.git@c5745631d2eee4e2efe8c31fa7b42fe2c12a0755#egg=edx_lint==0.2.7
 -e git+https://github.com/edx/xblock-utils.git@213a97a50276d6a2504d8133650b2930ead357a0#egg=xblock-utils


### PR DESCRIPTION
Preparation for the [Django 1.8 upgrade](https://openedx.atlassian.net/wiki/display/TNL/Library+updates+needed+for+Django+upgrade+to+1.8)
