### PR TITLE
Upgrade sorl-thumbnail to 12.3.

### DIFF
--- a/docs/shared/requirements.txt
+++ b/docs/shared/requirements.txt
@@ -53,7 +53,7 @@ pytz==2015.2
 PyYAML==3.10
 requests==2.3.0
 Shapely==1.2.16
-sorl-thumbnail==11.12
+sorl-thumbnail==12.3
 South==1.0.1
 sympy==0.7.1
 xmltodict==0.4.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -75,7 +75,7 @@ requests-oauthlib==0.4.1
 scipy==0.14.0
 Shapely==1.2.16
 singledispatch==3.4.0.2
-sorl-thumbnail==11.12
+sorl-thumbnail==12.3
 sortedcontainers==0.9.2
 South==1.0.1
 stevedore==0.14.1


### PR DESCRIPTION
Preparation for the [Django 1.8 upgrade](https://openedx.atlassian.net/wiki/display/TNL/Library+updates+needed+for+Django+upgrade+to+1.8)

This requirement is used by the wiki.  I tested this by visiting the wiki as a staff member and editing / creating articles.
