### PR TITLE
Reset problem reset and msg property

### DIFF
--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -1418,6 +1418,13 @@ class CapaMixin(CapaFields):
 
         self.lcp.student_answers = answers
 
+        for answer_key in answers:
+            # Reset the correctness property to default(None) state
+            if self.lcp.correct_map.get_property(answer_key, 'correctness', None) in ['incorrect', 'correct']:
+                self.lcp.correct_map.set_property(answer_key, 'correctness', None)
+                # For problems with hints and feedback, we need to reset msg property to default state
+                self.lcp.correct_map.set_property(answer_key, 'msg', '')
+
         self.set_state_from_lcp()
 
         self.track_function_unmask('save_problem_success', event_info)


### PR DESCRIPTION
[Fix misleading behavior of incorrect answer after "check" ](https://openedx.atlassian.net/browse/TNL-1955)

When saving a choice, the `correctness` property of the problem is not updated. It should be reset to default state (`None`) when [`save_problem`](https://github.com/edx/edx-platform/blob/master/common/lib/xmodule/xmodule/capa_base.py#L1385) is called.

<h3>Steps to Reproduce</h3>
1. Attempt answer with a wrong choice.
2. Select another choice and click save
3. Refresh the page to observe that cross sign (x) is shown beside the the choice being saved.

To [verify](http://problemsave.sandbox.edx.org/courses/course-v1:mushtaq+101+2015/courseware/8d4e9acd217040ebaa1cf9b7bfc85787/1eeba390499d4720b1d04fba3814b478/1?activate_block_id=block-v1%3Amushtaq%2B101%2B2015%2Btype%40vertical%2Bblock%404cd4c94b9a5c40b7beff6002d51120df) this.

<h3>Expected Behaviour</h3>

It should not show user the cross sign (x) when he saves a answer choice; He may think he attempted it wrong (which may be correct).

<h3>Actual Behaviour</h3>

It shows user the cross sign (x).
