### PR TITLE
Upgrade django-filter to 0.11.0.

### DIFF
--- a/docs/shared/requirements.txt
+++ b/docs/shared/requirements.txt
@@ -11,7 +11,7 @@ celery==3.0.19
 distribute>=0.6.28, <0.7
 django-celery==3.0.17
 django-countries==1.5
-django-filter==0.6.0
+django-filter==0.11.0
 django-kombu==0.9.4
 django-mako==0.1.5pre
 django-masquerade==0.1.6

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -17,7 +17,7 @@ django-babel-underscore==0.3.0
 django-celery==3.1.16
 django-countries==3.3
 django-extensions==1.5.5
-django-filter==0.6.0
+django-filter==0.11.0
 django-ipware==1.1.0
 django-kombu==0.9.4
 django-mako==0.1.5pre


### PR DESCRIPTION
Preparation for the [Django 1.8 upgrade](https://openedx.atlassian.net/wiki/display/TNL/Library+updates+needed+for+Django+upgrade+to+1.8)

This requirement is used by the django rest framework.
