### PR TITLE
Add lms/envs/aws.py entry for LTI_AGGREGATE_SCORE_PASSBACK_DELAY

### DIFF
--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -690,8 +690,13 @@ CREDIT_PROVIDER_SECRET_KEYS = AUTH_TOKENS.get("CREDIT_PROVIDER_SECRET_KEYS", {})
 if FEATURES.get('ENABLE_LTI_PROVIDER'):
     INSTALLED_APPS += ('lti_provider',)
     AUTHENTICATION_BACKENDS += ('lti_provider.users.LtiBackend', )
+
 LTI_USER_EMAIL_DOMAIN = ENV_TOKENS.get('LTI_USER_EMAIL_DOMAIN', 'lti.example.com')
 
+# For more info on this, see the notes in common.py
+LTI_AGGREGATE_SCORE_PASSBACK_DELAY = ENV_TOKENS.get(
+    'LTI_AGGREGATE_SCORE_PASSBACK_DELAY', LTI_AGGREGATE_SCORE_PASSBACK_DELAY
+)
 
 ##################### Credit Provider help link ####################
 CREDIT_HELP_LINK_URL = ENV_TOKENS.get('CREDIT_HELP_LINK_URL', CREDIT_HELP_LINK_URL)


### PR DESCRIPTION
@sarina, @mcgachey: The config followup from #9023. Meant to do this last night but fell asleep early. :-P

@jibsheet: This is unrelated to the hotfix in progress, but we'll want to have this and it's corresponding value in the config repo before next week's release.
