### PR TITLE
Fix correct answer position in dropdown problem template.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -237,3 +237,4 @@ Bill DeRusha <bill@edx.org>
 Kevin Falcone <kevin@edx.org>
 Mirjam Škarica <mirjamskarica@gmail.com>
 Saleem Latif <saleem@edx.org>
+Julien Paillé <julien.paille@openfun.fr>

--- a/common/lib/capa/capa/templates/optioninput.html
+++ b/common/lib/capa/capa/templates/optioninput.html
@@ -12,7 +12,6 @@
       % endfor
     </select>
 
-  <span id="answer_${id}"></span>  
   <div class="indicator-container">
     <span class="status ${status.classname}"
         id="status_${id}"
@@ -20,6 +19,7 @@
       <span class="sr">${value|h} - ${status.display_name}</span>
     </span>
   </div>
+  <p class="answer" id="answer_${id}"></p>
   % if msg:
       <span class="message">${msg|n}</span>
   % endif


### PR DESCRIPTION
The correct answer is now correctly displayed after the button "show answer" is pressed. This parallels the way the answer is shown in other types of problems, particularly numerical and formula equation input types.

Before:

![bef-dropdown-answer](https://cloud.githubusercontent.com/assets/2971857/9643511/c31ba2d8-51c2-11e5-9974-bc88d13acb91.png)

After:

![after-dropdown-answer](https://cloud.githubusercontent.com/assets/2971857/9643517/d09f8eec-51c2-11e5-9a43-b8b84030c3ec.png)
