### PR TITLE
Update edx-lint to 0.2.6

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -48,6 +48,7 @@ disable =
 	too-many-branches,
 	too-many-arguments,
 	too-many-locals,
+	unused-wildcard-import,
 	duplicate-code
 
 [REPORTS]
@@ -151,4 +152,4 @@ int-import-graph =
 [EXCEPTIONS]
 overgeneral-exceptions = Exception
 
-# 0f5810dfd8c52cdd91c425550319ae6040a8fe3e
+# 6a610602e4c093047ed189c9a0d4ba796c7d1622

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -49,7 +49,7 @@ git+https://github.com/edx/edx-oauth2-provider.git@0.5.6#egg=oauth2-provider==0.
 -e git+https://github.com/pmitros/RecommenderXBlock.git@518234bc354edbfc2651b9e534ddb54f96080779#egg=recommender-xblock
 -e git+https://github.com/edx/edx-search.git@release-2015-07-22#egg=edx-search
 -e git+https://github.com/edx/edx-milestones.git@9b44a37edc3d63a23823c21a63cdd53ef47a7aa4#egg=edx-milestones
-git+https://github.com/edx/edx-lint.git@b109a40c61277c52dcb396bf15e33755f5dbf5fa#egg=edx_lint==0.2.4
+git+https://github.com/edx/edx-lint.git@178819aae155f8f14db4ebb6866c867fb17d5000#egg=edx_lint==0.2.6
 -e git+https://github.com/edx/xblock-utils.git@213a97a50276d6a2504d8133650b2930ead357a0#egg=xblock-utils
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
 -e git+https://github.com/edx/edx-reverification-block.git@5e77525cab256a20a0cf182fcf5471369b284ff1#egg=edx-reverification-block

--- a/scripts/all-tests.sh
+++ b/scripts/all-tests.sh
@@ -11,7 +11,7 @@ set -e
 ###############################################################################
 
 # Violations thresholds for failing the build
-export PYLINT_THRESHOLD=6175
+export PYLINT_THRESHOLD=5999
 export JSHINT_THRESHOLD=3700
 
 doCheckVars() {


### PR DESCRIPTION
This gets us checking for tests inheriting from other tests.  When that 
happens, tests get run more than once, which is pointless.
