### PR TITLE
Update the XBlock commit hash in the requirements to the latest version.

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -33,7 +33,7 @@ git+https://github.com/hmarr/django-debug-toolbar-mongo.git@b0686a76f1ce3532088c
 git+https://github.com/edx/rfc6266.git@v0.0.5-edx#egg=rfc6266==0.0.5-edx
 
 # Our libraries:
--e git+https://github.com/edx/XBlock.git@d1ff8cf31a9b94916ce06ba06d4176bd72e15768#egg=XBlock
+-e git+https://github.com/edx/XBlock.git@32fca2a954745315be97b91ef0d5ad4eb38cf365#egg=XBlock
 -e git+https://github.com/edx/codejail.git@6b17c33a89bef0ac510926b1d7fea2748b73aadd#egg=codejail
 -e git+https://github.com/edx/js-test-tool.git@v0.1.6#egg=js_test_tool
 -e git+https://github.com/edx/event-tracking.git@0.2.0#egg=event-tracking


### PR DESCRIPTION
XBlock PRs pulled in by this change: [#305](https://github.com/edx/XBlock/pull/305), [#308](https://github.com/edx/XBlock/pull/308), [#311](https://github.com/edx/XBlock/pull/311), [#313](https://github.com/edx/XBlock/pull/313), [#314](https://github.com/edx/XBlock/pull/314), [#316](https://github.com/edx/XBlock/pull/316)

[See all commits between the old and the new versions.](https://github.com/edx/XBlock/compare/d1ff8cf31a9b94916ce06ba06d4176bd72e15768...32fca2a954745315be97b91ef0d5ad4eb38cf365)

CC @Shrhawk @tusbar
