### PR TITLE
Overriding white color for messages on dashboard

### DIFF
--- a/lms/static/sass/multicourse/_dashboard.scss
+++ b/lms/static/sass/multicourse/_dashboard.scss
@@ -574,6 +574,7 @@
         padding: ($baseline/2) $baseline;
         background: $gray-l5;
         border: 1px solid $gray-l4;
+        color: $base-font-color; // Overrides the normal white color in this one case
 
         // STATE: shown
         &.is-shown {


### PR DESCRIPTION
@adampalay This fixes the dashboard white on light gray issue. It should be scoped to this view only so there shouldn't be conflicts.
