### PR TITLE
Fix flaky team discussion test

### DIFF
--- a/common/static/coffee/src/discussion/views/discussion_thread_edit_view.js
+++ b/common/static/coffee/src/discussion/views/discussion_thread_edit_view.js
@@ -73,11 +73,9 @@
                     url: DiscussionUtil.urlFor('update_thread', this.model.id),
                     type: 'POST',
                     dataType: 'json',
-                    async: false, // @TODO when the rest of the stuff below is made to work properly..
                     data: postData,
                     error: DiscussionUtil.formErrorHandler(this.$('.post-errors')),
                     success: function() {
-                        // @TODO: Move this out of the callback, this makes it feel sluggish
                         this.$('.edit-post-title').val('').attr('prev-text', '');
                         this.$('.edit-post-body textarea').val('').attr('prev-text', '');
                         this.$('.wmd-preview p').html('');

--- a/common/static/coffee/src/discussion/views/thread_response_view.coffee
+++ b/common/static/coffee/src/discussion/views/thread_response_view.coffee
@@ -211,12 +211,10 @@ if Backbone?
           url: url
           type: "POST"
           dataType: 'json'
-          async: false # TODO when the rest of the stuff below is made to work properly..
           data:
               body: newBody
           error: DiscussionUtil.formErrorHandler(@$(".edit-post-form-errors"))
           success: (response, textStatus) =>
-              # TODO: Move this out of the callback, this makes it feel sluggish
               @editView.$(".edit-post-body textarea").val("").attr("prev-text", "")
               @editView.$(".wmd-preview p").html("")
 

--- a/lms/djangoapps/teams/static/teams/js/spec/views/team_profile_spec.js
+++ b/lms/djangoapps/teams/static/teams/js/spec/views/team_profile_spec.js
@@ -21,7 +21,9 @@ define([
             ];
 
         beforeEach(function () {
-            setFixtures('<div id="page-prompt"></div><div class="teams-content"><div class="msg-content"><div class="copy"></div></div></div>');
+            setFixtures('<div id="page-prompt"></div>' +
+                '<div class="teams-content"><div class="msg-content"><div class="copy"></div></div></div>' +
+                '<div class="profile-view"></div>');
             DiscussionSpecHelper.setUnderscoreFixtures();
         });
 
@@ -40,6 +42,7 @@ define([
         createTeamProfileView = function(requests, options) {
             teamModel = new TeamModel(createTeamModelData(options), { parse: true });
             profileView = new TeamProfileView({
+                el: $('.profile-view'),
                 teamEvents: TeamSpecHelpers.teamEvents,
                 courseID: TeamSpecHelpers.testCourseID,
                 context: TeamSpecHelpers.testContext,


### PR DESCRIPTION
## [TNL-3247](https://openedx.atlassian.net/browse/TNL-3247)

This re-enables the flaky team discussion test and then tries a few things:
- removes synchronous AJAX calls from discussion posting as this is deprecated functionality which can't be tested with sinon
- updates the profile view tests to attach the view to the DOM before testing, as some of the discussion code expects itself to be attached. This was throwing errors in sinon that could have led to problems
- removes the one-time JQuery initialization that was failing in a flaky way, and replaced it with simple function calls to achieve the same functionality (showing and hiding loading indicators)
### Sandbox
- [x] http://andy-armstrong.sandbox.edx.org/
### Testing
- [x] Manual testing
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @cahrens 
- [x] Code review: @efischer19 

FYI: @jzoldak @benpatterson 
### Post-review
- [x] Squash commits
