### PR TITLE
Add teams eventing and tests.

### DIFF
--- a/lms/djangoapps/teams/tests/test_views.py
+++ b/lms/djangoapps/teams/tests/test_views.py
@@ -14,6 +14,7 @@ from rest_framework.test import APITestCase, APIClient
 
 from courseware.tests.factories import StaffFactory
 from common.test.utils import skip_signal
+from util.testing import EventTestMixin
 from student.tests.factories import UserFactory, AdminFactory, CourseEnrollmentFactory
 from student.models import CourseEnrollment
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
@@ -529,8 +530,11 @@ class TestListTeamsAPI(TeamAPITestCase):
 
 
 @ddt.ddt
-class TestCreateTeamAPI(TeamAPITestCase):
+class TestCreateTeamAPI(EventTestMixin, TeamAPITestCase):
     """Test cases for the team creation endpoint."""
+
+    def setUp(self):  # pylint: disable=arguments-differ
+        super(TestCreateTeamAPI, self).setUp('teams.views.tracker')
 
     @ddt.data(
         (None, 401),
@@ -549,11 +553,15 @@ class TestCreateTeamAPI(TeamAPITestCase):
             teams = self.get_teams_list(user=user)
             self.assertIn("New Team", [team['name'] for team in teams['results']])
 
+    def _expected_team_id(self, team, expected_prefix):
+        """ Return the team id that we'd expect given this team data and this prefix. """
+        return expected_prefix + '-' + team['discussion_topic_id']
+
     def verify_expected_team_id(self, team, expected_prefix):
         """ Verifies that the team id starts with the specified prefix and ends with the discussion_topic_id """
         self.assertIn('id', team)
         self.assertIn('discussion_topic_id', team)
-        self.assertEqual(team['id'], expected_prefix + '-' + team['discussion_topic_id'])
+        self.assertEqual(team['id'], self._expected_team_id(team, expected_prefix))
 
     def test_naming(self):
         new_teams = [
@@ -640,6 +648,19 @@ class TestCreateTeamAPI(TeamAPITestCase):
         self.verify_expected_team_id(team, 'fully-specified-team')
         del team['id']
 
+        self.assert_event_emitted(
+            'edx.team.created',
+            team_id=self._expected_team_id(team, 'fully-specified-team'),
+            course_id=unicode(self.test_course_1.id),
+        )
+
+        self.assert_event_emitted(
+            'edx.team.learner_added',
+            team_id=self._expected_team_id(team, 'fully-specified-team'),
+            course_id=unicode(self.test_course_1.id),
+            user_id=self.users[creator].id,
+            add_method='added_on_create'
+        )
         # Remove date_created and discussion_topic_id because they change between test runs
         del team['date_created']
         del team['discussion_topic_id']
@@ -1026,8 +1047,11 @@ class TestListMembershipAPI(TeamAPITestCase):
 
 
 @ddt.ddt
-class TestCreateMembershipAPI(TeamAPITestCase):
+class TestCreateMembershipAPI(EventTestMixin, TeamAPITestCase):
     """Test cases for the membership creation endpoint."""
+
+    def setUp(self):  # pylint: disable=arguments-differ
+        super(TestCreateMembershipAPI, self).setUp('teams.views.tracker')
 
     @ddt.data(
         (None, 401),
@@ -1052,6 +1076,18 @@ class TestCreateMembershipAPI(TeamAPITestCase):
             self.assertEqual(membership['team']['team_id'], self.solar_team.team_id)
             memberships = self.get_membership_list(200, {'team_id': self.solar_team.team_id})
             self.assertEqual(memberships['count'], 2)
+
+            add_method = 'joined_from_team_view' if user == 'student_enrolled_not_on_team' else 'added_by_another_user'
+
+            self.assert_event_emitted(
+                'edx.team.learner_added',
+                team_id=self.solar_team.team_id,
+                user_id=self.users['student_enrolled_not_on_team'].id,
+                course_id=unicode(self.solar_team.course_id),
+                add_method=add_method
+            )
+        else:
+            self.assert_no_events_were_emitted()
 
     def test_no_username(self):
         response = self.post_create_membership(400, {'team_id': self.solar_team.team_id})
@@ -1176,8 +1212,11 @@ class TestDetailMembershipAPI(TeamAPITestCase):
 
 
 @ddt.ddt
-class TestDeleteMembershipAPI(TeamAPITestCase):
+class TestDeleteMembershipAPI(EventTestMixin, TeamAPITestCase):
     """Test cases for the membership deletion endpoint."""
+
+    def setUp(self):  # pylint: disable=arguments-differ
+        super(TestDeleteMembershipAPI, self).setUp('teams.views.tracker')
 
     @ddt.data(
         (None, 401),
@@ -1197,6 +1236,18 @@ class TestDeleteMembershipAPI(TeamAPITestCase):
             status,
             user=user
         )
+
+        if status == 204:
+            remove_method = 'self_removal' if user == 'student_enrolled' else 'removed_by_admin'
+            self.assert_event_emitted(
+                'edx.team.learner_removed',
+                team_id=self.solar_team.team_id,
+                course_id=unicode(self.solar_team.course_id),
+                user_id=self.users['student_enrolled'].id,
+                remove_method=remove_method
+            )
+        else:
+            self.assert_no_events_were_emitted()
 
     def test_bad_team(self):
         self.delete_membership('no_such_team', self.users['student_enrolled'].username, 404)


### PR DESCRIPTION
## [TNL-3185](https://openedx.atlassian.net/browse/TNL-3185) & [TNL-3186](https://openedx.atlassian.net/browse/TNL-3186)

Implements 3 of the events from the [Teams Events Spec](https://openedx.atlassian.net/wiki/display/AN/Teams+Feature+Event+Design): `edx.team.created`, `edx.team.learner_added`, `edx.team.learner_removed`. Also includes unit and bok choy tests.
### Testing
- [x] Unit, integration, acceptance tests as appropriate
- [x] Analytics
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @dan-f 
- [x] Code review: @peter-fogg  
### Post-review
- [x] Squash commits
