### PR TITLE
Add details to the admin listing of LTI Consumers

### DIFF
--- a/lms/djangoapps/lti_provider/admin.py
+++ b/lms/djangoapps/lti_provider/admin.py
@@ -6,4 +6,10 @@ from django.contrib import admin
 
 from .models import LtiConsumer
 
-admin.site.register(LtiConsumer)
+
+class LtiConsumerAdmin(admin.ModelAdmin):
+    """Admin for LTI Consumer"""
+    search_fields = ('consumer_name', 'consumer_key', 'instance_guid')
+    list_display = ('id', 'consumer_name', 'consumer_key', 'instance_guid')
+
+admin.site.register(LtiConsumer, LtiConsumerAdmin)


### PR DESCRIPTION
This mimics the data displayed in our oauth2 client listing and allows
you to search on identifying fields.
