### PR TITLE
Add page viewed events to teams app.

### DIFF
--- a/lms/djangoapps/teams/static/teams/js/utils/team_analytics.js
+++ b/lms/djangoapps/teams/static/teams/js/utils/team_analytics.js
@@ -1,0 +1,23 @@
+/**
+ * Utility methods for emitting teams events. See the event spec:
+ * https://openedx.atlassian.net/wiki/display/AN/Teams+Feature+Event+Design
+ */
+;(function (define) {
+    'use strict';
+
+    define([
+        'logger'
+    ], function (Logger) {
+        var TeamAnalytics = {
+            emitPageViewed: function (page_name, topic_id, team_id) {
+                Logger.log('edx.team.page_viewed', {
+                    page_name: page_name,
+                    topic_id: topic_id,
+                    team_id: team_id
+                });
+            }
+        };
+
+        return TeamAnalytics;
+    });
+}).call(this, define || RequireJS.define);

--- a/lms/djangoapps/teams/static/teams/js/views/teams_tab.js
+++ b/lms/djangoapps/teams/static/teams/js/views/teams_tab.js
@@ -7,12 +7,13 @@
             'common/js/components/views/search_field',
             'js/components/header/views/header',
             'js/components/header/models/header',
-            'js/components/tabbed/views/tabbed_view',
             'teams/js/models/topic',
             'teams/js/collections/topic',
             'teams/js/models/team',
             'teams/js/collections/team',
             'teams/js/collections/team_membership',
+            'teams/js/utils/team_analytics',
+            'teams/js/views/teams_tabbed_view',
             'teams/js/views/topics',
             'teams/js/views/team_profile',
             'teams/js/views/my_teams',
@@ -21,9 +22,9 @@
             'teams/js/views/team_profile_header_actions',
             'teams/js/views/team_utils',
             'text!teams/templates/teams_tab.underscore'],
-        function (Backbone, _, gettext, SearchFieldView, HeaderView, HeaderModel, TabbedView,
-                  TopicModel, TopicCollection, TeamModel, TeamCollection, TeamMembershipCollection,
-                  TopicsView, TeamProfileView, MyTeamsView, TopicTeamsView, TeamEditView,
+        function (Backbone, _, gettext, SearchFieldView, HeaderView, HeaderModel,
+                  TopicModel, TopicCollection, TeamModel, TeamCollection, TeamMembershipCollection, TeamAnalytics,
+                  TeamsTabbedView, TopicsView, TeamProfileView, MyTeamsView, TopicTeamsView, TeamEditView,
                   TeamProfileHeaderActionsView, TeamUtils, teamsTemplate) {
             var TeamsHeaderModel = HeaderModel.extend({
                 initialize: function () {
@@ -118,7 +119,7 @@
                     this.mainView = this.tabbedView = this.createViewWithHeader({
                         title: gettext("Teams"),
                         description: gettext("See all teams in your course, organized by topic. Join a team to collaborate with other learners who are interested in the same topic as you are."),
-                        mainView: new TabbedView({
+                        mainView: new TeamsTabbedView({
                             tabs: [{
                                 title: gettext('My Team'),
                                 url: 'my-teams',
@@ -180,6 +181,7 @@
                     this.getTeamsView(topicID).done(function (teamsView) {
                         self.teamsView = self.mainView = teamsView;
                         self.render();
+                        TeamAnalytics.emitPageViewed('single-topic', topicID, null);
                     });
                 },
 
@@ -205,6 +207,7 @@
                                 showSortControls: false
                             });
                             view.render();
+                            TeamAnalytics.emitPageViewed('search-teams', topicID, null);
                         });
                     }
                 },
@@ -227,6 +230,7 @@
                             })
                         });
                         view.render();
+                        TeamAnalytics.emitPageViewed('new-team', topicID, null);
                     });
                 },
 
@@ -254,6 +258,7 @@
                             });
                             self.mainView = editViewWithHeader;
                             self.render();
+                            TeamAnalytics.emitPageViewed('edit-team', topicID, teamID);
                         });
                     });
                 },
@@ -340,6 +345,7 @@
                     this.getBrowseTeamView(topicID, teamID).done(function (browseTeamView) {
                         self.mainView = browseTeamView;
                         self.render();
+                        TeamAnalytics.emitPageViewed('single-team', topicID, teamID);
                     });
                 },
 

--- a/lms/djangoapps/teams/static/teams/js/views/teams_tabbed_view.js
+++ b/lms/djangoapps/teams/static/teams/js/views/teams_tabbed_view.js
@@ -1,0 +1,24 @@
+/**
+ * A custom TabbedView for Teams.
+ */
+;(function (define) {
+    'use strict';
+
+    define([
+        'js/components/tabbed/views/tabbed_view',
+        'teams/js/utils/team_analytics'
+    ], function (TabbedView, TeamAnalytics) {
+        var TeamsTabbedView = TabbedView.extend({
+            /**
+             * Overrides TabbedView.prototype.setActiveTab in order to
+             * log page viewed events.
+             */
+            setActiveTab: function (index) {
+                TabbedView.prototype.setActiveTab.call(this, index);
+                TeamAnalytics.emitPageViewed(this.getTabMeta(index).tab.url, null, null);
+            }
+        });
+
+        return TeamsTabbedView;
+    });
+}).call(this, define || RequireJS.define);

--- a/lms/static/js/components/tabbed/views/tabbed_view.js
+++ b/lms/static/js/components/tabbed/views/tabbed_view.js
@@ -59,16 +59,10 @@
                    },
 
                    setActiveTab: function (index) {
-                       var tab, tabEl, view;
-                       if (typeof index === 'string') {
-                           tab = this.urlMap[index];
-                           tabEl = this.$('a[data-url='+index+']');
-                       }
-                       else {
-                           tab = this.tabs[index];
-                           tabEl = this.$('a[data-index='+index+']');
-                       }
-                       view = tab.view;
+                       var tabMeta = this.getTabMeta(index),
+                           tab = tabMeta.tab,
+                           tabEl = tabMeta.element,
+                           view = tab.view;
                        this.$('a.is-active').removeClass('is-active').attr('aria-selected', 'false');
                        tabEl.addClass('is-active').attr('aria-selected', 'true');
                        view.setElement(this.$('.page-content-main')).render();
@@ -81,6 +75,22 @@
                    switchTab: function (event) {
                        event.preventDefault();
                        this.setActiveTab($(event.currentTarget).data('index'));
+                   },
+
+                   /**
+                    * Get the tab by name or index. Returns an object
+                    * encapsulating the tab object and its element.
+                    */
+                   getTabMeta: function (tabNameOrIndex) {
+                       var tab, element;
+                       if (typeof tabNameOrIndex === 'string') {
+                           tab = this.urlMap[tabNameOrIndex];
+                           element = this.$('a[data-url='+tabNameOrIndex+']');
+                       }  else {
+                           tab = this.tabs[tabNameOrIndex];
+                           element = this.$('a[data-index='+tabNameOrIndex+']');
+                       }
+                       return {'tab': tab, 'element': element};
                    }
                });
                return TabbedView;


### PR DESCRIPTION
## [TNL-1388](https://openedx.atlassian.net/browse/TNL-1388)

Add page_viewed events for the various teams UI pages. Events are fired from the browser, since the concept of "pages" in our app is defined by our Backbone views.
### Testing
- [x] Unit, integration, acceptance tests as appropriate
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @dianakhuang 
- [x] Code review: @peter-fogg 
### Post-review
- [x] Squash commits
