### PR TITLE
Upgrading django-simple-history to 1.6.3

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -28,7 +28,7 @@ django-openid-auth==0.4
 django-robots==0.9.1
 django-sekizai==0.6.1
 django-ses==0.4.1
-django-simple-history==1.6.1
+django-simple-history==1.6.3
 django-storages==1.1.5
 django-threaded-multihost==1.4-1
 django-method-override==0.1.0


### PR DESCRIPTION
Preparation for the [Django 1.8 upgrade](https://openedx.atlassian.net/wiki/display/TNL/Library+updates+needed+for+Django+upgrade+to+1.8)

This library is being used in the following models:
- CourseEnrollment
- VerificationDeadline
- CreditRequirementStatus

Jira ticket: https://openedx.atlassian.net/browse/TNL-2811
