### PR TITLE
Upgrading django-sekizai

### DIFF
--- a/docs/shared/requirements.txt
+++ b/docs/shared/requirements.txt
@@ -15,7 +15,7 @@ django-filter==0.6.0
 django-mako==0.1.5pre
 django-mptt==0.5.5
 django-openid-auth==0.4
-django-sekizai==0.6.1
+django-sekizai==0.8.2
 django-ses==0.7.0
 django-storages==1.1.5
 django-threaded-multihost==1.4-1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -23,7 +23,7 @@ django-mako==0.1.5pre
 django-model-utils==2.3.1
 django-mptt==0.7.4
 django-openid-auth==0.4
-django-sekizai==0.6.1
+django-sekizai==0.8.2
 django-ses==0.7.0
 django-simple-history==1.6.3
 django-storages==1.1.5


### PR DESCRIPTION
Preparation for the [Django 1.8 upgrade](https://openedx.atlassian.net/wiki/display/TNL/Library+updates+needed+for+Django+upgrade+to+1.8)

This library is used in wiki templates, verified locally by creating article and editing it.

Jira ticket: https://openedx.atlassian.net/browse/TNL-2811
