### PR TITLE
Update discussion events to include team_id when appropriate.

### DIFF
--- a/lms/djangoapps/django_comment_client/base/views.py
+++ b/lms/djangoapps/django_comment_client/base/views.py
@@ -94,6 +94,10 @@ def track_forum_event(request, event_name, course, obj, data, id_map=None):
     data['id'] = obj.id
     commentable_id = data['commentable_id']
 
+    team = get_team(commentable_id)
+    if team is not None:
+        data.update(team_id=team.team_id)
+
     if id_map is None:
         id_map = get_cached_discussion_id_map(course, [commentable_id], user)
 


### PR DESCRIPTION
## [TNL-3196](https://openedx.atlassian.net/browse/TNL-3196)

Updates the `edx.forum.{thread, response, comment}.created` events to include a `team_id` when appropriate.
### Testing
- [x] Unit, integration, acceptance tests as appropriate
- [x] Analytics
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @dan-f
- [x] Code review: @dianakhuang
  FYI @catong 
### Post-review
- [ ] Squash commits
