### PR TITLE
Adding team deleted event

### DIFF
--- a/lms/djangoapps/teams/static/teams/js/spec/views/edit_team_members_spec.js
+++ b/lms/djangoapps/teams/static/teams/js/spec/views/edit_team_members_spec.js
@@ -90,7 +90,11 @@ define([
             verifyTeamMembersView(view);
 
             deleteTeamMemember(view, true);
-            AjaxHelpers.expectJsonRequest(requests, 'DELETE', '/api/team/v0/team_membership/av,frodo', null);
+            AjaxHelpers.expectJsonRequest(
+                requests, 
+                'DELETE', 
+                '/api/team/v0/team_membership/av,frodo?admin=true'
+            );
             AjaxHelpers.respondWithNoContent(requests);
             expect(view.teamEvents.trigger).toHaveBeenCalledWith(
                 'teams:update', {
@@ -112,7 +116,11 @@ define([
             verifyTeamMembersView(view);
 
             deleteTeamMemember(view, true);
-            AjaxHelpers.expectJsonRequest(requests, 'DELETE', '/api/team/v0/team_membership/av,frodo', null);
+            AjaxHelpers.expectJsonRequest(
+                requests, 
+                'DELETE', 
+                '/api/team/v0/team_membership/av,frodo?admin=true' 
+            );
             AjaxHelpers.respondWithError(requests);
             expect(TeamUtils.showMessage).toHaveBeenCalledWith(
                 'An error occurred while removing the member from the team. Try again.',

--- a/lms/djangoapps/teams/static/teams/js/views/edit_team_members.js
+++ b/lms/djangoapps/teams/static/teams/js/views/edit_team_members.js
@@ -85,7 +85,7 @@
                         function () {
                             $.ajax({
                                 type: 'DELETE',
-                                url: self.teamMembershipDetailUrl + username
+                                url: self.teamMembershipDetailUrl.concat(username, '?admin=true')
                             }).done(function () {
                                 self.teamEvents.trigger('teams:update', {
                                     action: 'leave',


### PR DESCRIPTION
## [TNL-3199](https://openedx.atlassian.net/browse/TNL-3199)

This relies on @peter-fogg's delete changes currently living in the big "instructor tools" PR, https://github.com/edx/edx-platform/pull/9520, so this is currently branched from there for easier diff viewing. Once that change is merged into master, this will follow. I have no plans of including this change in that PR before it merges.
