### PR TITLE
Fetch people.yaml file from private repo

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,7 +45,7 @@ PROJECT_ROOT = project_root()
 repo = Repo(PROJECT_ROOT)
 git = repo.git
 
-PEOPLE_YAML = "https://raw.githubusercontent.com/edx/repo-tools/master/people.yaml"
+PEOPLE_YAML = "https://raw.githubusercontent.com/edx/repo-tools-data/master/people.yaml"
 
 
 class memoized(object):
@@ -149,7 +149,10 @@ def create_github_creds():
     https://developer.github.com/v3/oauth_authorizations/#create-a-new-authorization
     """
     headers = {"User-Agent": "edx-release"}
-    payload = {"note": "edx-release"}
+    payload = {
+        "note": "edx-release",
+        "scopes": ["repo"],
+    }
     username = raw_input("Github username: ")
     password = getpass.getpass("Github password: ")
     response = requests.post(
@@ -300,6 +303,7 @@ class DoesNotExist(Exception):
         self.message = message
         self.commit = commit
         self.branch = branch
+        Exception.__init__(self, message)
 
 
 def get_merge_commit(commit, branch="master"):
@@ -371,10 +375,15 @@ def prs_by_email(start_ref, end_ref):
     The dictionary is alphabetically ordered by email address
     The pull request list is ordered by merge date
     """
+    username, token = get_github_creds()
+    headers = {
+        "Authorization": "token {}".format(token),
+        "User-Agent": "edx-release",
+    }
     # `emails` maps from other_emails to primary email, based on people.yaml.
     emails = {}
     try:
-        people_resp = requests.get(PEOPLE_YAML)
+        people_resp = requests.get(PEOPLE_YAML, headers=headers)
         people_resp.raise_for_status()
         people = yaml.safe_load(people_resp.text)
     except requests.exceptions.RequestException as e:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -382,21 +382,13 @@ def prs_by_email(start_ref, end_ref):
     }
     # `emails` maps from other_emails to primary email, based on people.yaml.
     emails = {}
-    try:
-        people_resp = requests.get(PEOPLE_YAML, headers=headers)
-        people_resp.raise_for_status()
-        people = yaml.safe_load(people_resp.text)
-    except requests.exceptions.RequestException as e:
-        # Hmm, muddle through without canonicalized emails...
-        message = (
-            "Warning: could not fetch people.yaml: {message}".format(message=e.message)
-        )
-        print(colorize("red", message), file=sys.stderr)
-    else:
-        for person in people.itervalues():
-            if 'other_emails' in person:
-                for other_email in person['other_emails']:
-                    emails[other_email] = person['email']
+    people_resp = requests.get(PEOPLE_YAML, headers=headers)
+    people_resp.raise_for_status()
+    people = yaml.safe_load(people_resp.text)
+    for person in people.itervalues():
+        if 'other_emails' in person:
+            for other_email in person['other_emails']:
+                emails[other_email] = person['email']
 
     unordered_data = collections.defaultdict(set)
     for pr_num in get_merged_prs(start_ref, end_ref):


### PR DESCRIPTION
Note that in order to fetch data from a private repo, we need a GitHub OAuth token with the `repo` scope. Anyone who already has a GitHub OAuth token saved on their computer that does _not_ have the `repo` scope will be unable to fetch this file until they clear their token cache, which consists of deleting the file `~/.config/edx-release` and making sure it isn't present in their `~/.netrc` file.

@nedbat 
