### PR TITLE
CRI-40 Don't assume user in request context when grading

### DIFF
--- a/lms/djangoapps/courseware/grades.py
+++ b/lms/djangoapps/courseware/grades.py
@@ -306,7 +306,7 @@ def grade(student, request, course, keep_raw_scores=False, field_data_cache=None
         grade_summary = _grade(student, request, course, keep_raw_scores, field_data_cache, scores_client)
         responses = GRADES_UPDATED.send_robust(
             sender=None,
-            username=request.user.username,
+            username=student.username,
             grade_summary=grade_summary,
             course_key=course.id,
             deadline=course.end

--- a/lms/djangoapps/instructor/tests/test_legacy_raw_download_csv.py
+++ b/lms/djangoapps/instructor/tests/test_legacy_raw_download_csv.py
@@ -5,6 +5,8 @@ Create course and answer a problem to test raw grade CSV
 
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
+from instructor.utils import DummyRequest
+from instructor.views.legacy import get_student_grade_summary_data
 from nose.plugins.attrib import attr
 
 from courseware.tests.test_submitting_problems import TestSubmittingProblems
@@ -24,7 +26,7 @@ class TestRawGradeCSV(TestSubmittingProblems):
         super(TestRawGradeCSV, self).setUp()
 
         self.instructor = 'view2@test.com'
-        self.create_account('u2', self.instructor, self.password)
+        self.student_user2 = self.create_account('u2', self.instructor, self.password)
         self.activate_user(self.instructor)
         CourseStaffRole(self.course.id).add_users(User.objects.get(email=self.instructor))
         self.logout()
@@ -38,14 +40,20 @@ class TestRawGradeCSV(TestSubmittingProblems):
         self.add_dropdown_to_section(self.homework.location, 'p3', 1)
         self.refresh_course()
 
+    def answer_question(self):
+        """
+        Answer a question correctly in the course
+        """
+        self.login(self.instructor, self.password)
+        resp = self.submit_question_answer('p2', {'2_1': 'Correct'})
+        self.assertEqual(resp.status_code, 200)
+
     def test_download_raw_grades_dump(self):
         """
         Grab raw grade report and make sure all grades are reported.
         """
         # Answer second problem correctly with 2nd user to expose bug
-        self.login(self.instructor, self.password)
-        resp = self.submit_question_answer('p2', {'2_1': 'Correct'})
-        self.assertEqual(resp.status_code, 200)
+        self.answer_question()
 
         url = reverse('instructor_dashboard_legacy', kwargs={'course_id': self.course.id.to_deprecated_string()})
         msg = "url = {0}\n".format(url)
@@ -58,3 +66,53 @@ class TestRawGradeCSV(TestSubmittingProblems):
 "2","u2","username","view2@test.com","","0.0","1.0","0.0"
 '''
         self.assertEqual(body, expected_csv, msg)
+
+    def test_grade_summary_data(self):
+        """
+        Test grade summary data report generation
+        """
+        self.answer_question()
+
+        request = DummyRequest()
+        data = get_student_grade_summary_data(request, self.course, get_raw_scores=False)
+        expected_data = {
+            'students': [self.student_user, self.student_user2],
+            'header': [
+                u'ID', u'Username', u'Full Name', u'edX email', u'External email',
+                u'HW 01', u'HW 02', u'HW 03', u'HW 04', u'HW 05', u'HW 06', u'HW 07',
+                u'HW 08', u'HW 09', u'HW 10', u'HW 11', u'HW 12', u'HW Avg', u'Lab 01',
+                u'Lab 02', u'Lab 03', u'Lab 04', u'Lab 05', u'Lab 06', u'Lab 07',
+                u'Lab 08', u'Lab 09', u'Lab 10', u'Lab 11', u'Lab 12', u'Lab Avg', u'Midterm',
+                u'Final'
+            ],
+            'data': [
+                [
+                    1, u'u1', u'username', u'view@test.com', '', 0.0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0.0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+                ],
+                [
+                    2, u'u2', u'username', u'view2@test.com', '', 0.3333333333333333, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0.03333333333333333, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0
+                ]
+            ],
+            'assignments': [
+                u'HW 01', u'HW 02', u'HW 03', u'HW 04', u'HW 05', u'HW 06', u'HW 07', u'HW 08',
+                u'HW 09', u'HW 10', u'HW 11', u'HW 12', u'HW Avg', u'Lab 01', u'Lab 02',
+                u'Lab 03', u'Lab 04', u'Lab 05', u'Lab 06', u'Lab 07', u'Lab 08', u'Lab 09',
+                u'Lab 10', u'Lab 11', u'Lab 12', u'Lab Avg', u'Midterm', u'Final'
+            ]
+        }
+
+        for key in ['assignments', 'header']:
+            self.assertListEqual(expected_data[key], data[key])
+
+        for index, student in enumerate(expected_data['students']):
+            self.assertEqual(
+                student.username,
+                data['students'][index].username
+            )
+            self.assertListEqual(
+                expected_data['data'][index],
+                data['data'][index]
+            )


### PR DESCRIPTION
This fixes the dump_grades management command (CRI-40) and adds a regression test to make sure student_grade_summary_data won't break again.
