### PR TITLE
save_cxx slow transaction

### DIFF
--- a/lms/djangoapps/ccx/tests/test_overrides.py
+++ b/lms/djangoapps/ccx/tests/test_overrides.py
@@ -94,15 +94,35 @@ class TestFieldOverrides(ModuleStoreTestCase):
         override_field_for_ccx(self.ccx, chapter, 'start', ccx_start)
         self.assertEquals(chapter.start, ccx_start)
 
-    def test_override_num_queries(self):
+    def test_override_num_queries_new_field(self):
         """
-        Test that overriding and accessing a field produce same number of queries.
+        Test that for creating new field executed only create query
         """
         ccx_start = datetime.datetime(2014, 12, 25, 00, 00, tzinfo=pytz.UTC)
         chapter = self.ccx.course.get_children()[0]
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(1):
             override_field_for_ccx(self.ccx, chapter, 'start', ccx_start)
-            dummy = chapter.start
+
+    def test_override_num_queries_update_existing_field(self):
+        """
+        Test that overriding existing field executed create, fetch and update queries.
+        """
+        ccx_start = datetime.datetime(2014, 12, 25, 00, 00, tzinfo=pytz.UTC)
+        new_ccx_start = datetime.datetime(2015, 12, 25, 00, 00, tzinfo=pytz.UTC)
+        chapter = self.ccx.course.get_children()[0]
+        override_field_for_ccx(self.ccx, chapter, 'start', ccx_start)
+        with self.assertNumQueries(2):
+            override_field_for_ccx(self.ccx, chapter, 'start', new_ccx_start)
+
+    def test_override_num_queries_field_value_not_changed(self):
+        """
+        Test that if value of field does not changed no query execute.
+        """
+        ccx_start = datetime.datetime(2014, 12, 25, 00, 00, tzinfo=pytz.UTC)
+        chapter = self.ccx.course.get_children()[0]
+        override_field_for_ccx(self.ccx, chapter, 'start', ccx_start)
+        with self.assertNumQueries(0):
+            override_field_for_ccx(self.ccx, chapter, 'start', ccx_start)
 
     def test_overriden_field_access_produces_no_extra_queries(self):
         """
@@ -110,11 +130,8 @@ class TestFieldOverrides(ModuleStoreTestCase):
         """
         ccx_start = datetime.datetime(2014, 12, 25, 00, 00, tzinfo=pytz.UTC)
         chapter = self.ccx.course.get_children()[0]
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(1):
             override_field_for_ccx(self.ccx, chapter, 'start', ccx_start)
-            dummy1 = chapter.start
-            dummy2 = chapter.start
-            dummy3 = chapter.start
 
     def test_override_is_inherited(self):
         """


### PR DESCRIPTION
[PLAT-795](https://openedx.atlassian.net/browse/PLAT-795)

**Problem:**
When we change the schedule attributes ( 'due', 'start' etc) of an single item for ccx enable course we are traversing the whole course and during this we are hitting the db again and again which making the transaction `save_ccx` very slow.

**Solution:**
We can speed up the transaction time by making less queries to db and we can use bulk_operations, hashing query instance and eliminate extra queries to achieve this result.
Following techniques are used for faster transaction:
1. Use the `bulk_delete` using django orm `filter` objects
2. Hash the instances of CcxFieldOverride model so instead of filtering in the whole table first tried to fetch this from [override_cache](https://github.com/edx/edx-platform/blob/845e1d62966011be1efc86d673fd8749b0c980d8/lms/djangoapps/ccx/overrides.py#L106) and if its not found fall back to fetch from model.
3. Some extra queries are performed, we perform update query [save()](https://github.com/edx/edx-platform/blob/845e1d62966011be1efc86d673fd8749b0c980d8/lms/djangoapps/ccx/overrides.py#L148) on each node instance whether is changed or not to avoid make unnecessary update call introduce new flag `has_changes`, this flag will also handle the case where we didn't need to call `save()` just like when we create new instance this flag will help to prevent to make call to extra `save()`.
## Result Comparison

**Master Branch:**
<img width="1255" alt="master" src="https://cloud.githubusercontent.com/assets/7054417/9715557/4b8277c2-5516-11e5-85c4-c50f9d7a6671.png">

**Current Branch:**
<img width="1260" alt="ccx_branch" src="https://cloud.githubusercontent.com/assets/7054417/9715582/82e03876-5516-11e5-99ad-963b6b6febd9.png">
