### PR TITLE
Fixing spacing in tooltip

### DIFF
--- a/lms/templates/seq_module.html
+++ b/lms/templates/seq_module.html
@@ -23,7 +23,7 @@
            id="tab_${idx}"
            tabindex="0">
             <i class="icon fa seq_${item['type']}" aria-hidden="true"></i>
-            <p><span class="sr">${item['type']}</span> ${item['title']}</p>
+            <p><span class="sr">${item['type']}</span>${item['title']}</p>
           </a>
         </li>
         % endfor


### PR DESCRIPTION
This is a teensy-tiny PR (one space character, no more, no less!) to fix a spacing issue in tooltips in the sequence bar in the LMS.

Currently, the tooltip looks like the following for more than one element in a vertical.

![screen shot 2015-09-06 at 3 35 14 pm](https://cloud.githubusercontent.com/assets/6232546/9706222/72c21108-54ad-11e5-8e26-b9ee2f5f604d.png)

Note that the first element of the vertical is indented by a space, but the second element isn't. This PR removes that first indentation.
