### PR TITLE
Adding trailing_text to formulaequationinput

### DIFF
--- a/common/lib/capa/capa/inputtypes.py
+++ b/common/lib/capa/capa/inputtypes.py
@@ -1214,9 +1214,11 @@ class FormulaEquationInput(InputTypeBase):
 
     Example:
 
-    <formulaequationinput size="50" label="Enter the equation for motion"/>
+    <formulaequationinput size="50" label="Enter the equation for motion" />
 
     options: size -- width of the textbox.
+             trailing_text -- text to show after the input textbox when
+                              rendered, same as textline (useful for units)
     """
 
     template = "formulaequationinput.html"
@@ -1231,6 +1233,7 @@ class FormulaEquationInput(InputTypeBase):
             Attribute('size', '20'),
             Attribute('inline', False),
             Attribute('label', ''),
+            Attribute('trailing_text', ''),
         ]
 
     def _extra_context(self):

--- a/common/lib/capa/capa/templates/formulaequationinput.html
+++ b/common/lib/capa/capa/templates/formulaequationinput.html
@@ -9,6 +9,7 @@
         size="${size}"
         % endif
         />
+    ${trailing_text | h}
 
       <span class="status" id="${id}_status" data-tooltip="${status.display_tooltip}">
         <span class="sr">

--- a/common/lib/capa/capa/tests/test_input_templates.py
+++ b/common/lib/capa/capa/tests/test_input_templates.py
@@ -486,6 +486,7 @@ class FormulaEquationInputTemplateTest(TemplateTestCase):
             'label': 'test',
             'previewer': 'file.js',
             'reported_status': 'REPORTED_STATUS',
+            'trailing_text': None,
         }
         super(FormulaEquationInputTemplateTest, self).setUp()
 

--- a/common/lib/capa/capa/tests/test_inputtypes.py
+++ b/common/lib/capa/capa/tests/test_inputtypes.py
@@ -1126,8 +1126,52 @@ class FormulaEquationTest(unittest.TestCase):
             'size': self.size,
             'previewer': '/dummy-static/js/capa/src/formula_equation_preview.js',
             'inline': False,
+            'trailing_text': '',
         }
         self.assertEqual(context, expected)
+
+    def test_trailing_text_rendering(self):
+        """
+        Verify that the render context matches the expected render context with trailing_text
+        """
+        size = "42"
+        # store (xml_text, expected)
+        trailing_text = []
+        # standard trailing text
+        trailing_text.append(('m/s', 'm/s'))
+        # unicode trailing text
+        trailing_text.append((u'\xc3', u'\xc3'))
+        # html escaped trailing text
+        # this is the only one we expect to change
+        trailing_text.append(('a &lt; b', 'a < b'))
+
+        for xml_text, expected_text in trailing_text:
+            xml_str = u"""<formulaequationinput id="prob_1_2"
+                            size="{size}"
+                            trailing_text="{tt}"
+                            />""".format(size=size, tt=xml_text)
+
+            element = etree.fromstring(xml_str)
+
+            state = {'value': 'x^2+1/2', }
+            the_input = lookup_tag('formulaequationinput')(test_capa_system(), element, state)
+
+            context = the_input._get_render_context()  # pylint: disable=protected-access
+
+            expected = {
+                'STATIC_URL': '/dummy-static/',
+                'id': 'prob_1_2',
+                'value': 'x^2+1/2',
+                'status': inputtypes.Status('unanswered'),
+                'label': '',
+                'msg': '',
+                'size': size,
+                'previewer': '/dummy-static/js/capa/src/formula_equation_preview.js',
+                'inline': False,
+                'trailing_text': expected_text,
+            }
+
+            self.assertEqual(context, expected)
 
     def test_formcalc_ajax_sucess(self):
         """


### PR DESCRIPTION
This small PR adds the "trailing_text" option available in textline capa inputs to formulaequationinput inputs. This enables the trailing_text capability in the following example.

<pre>
&lt;problem>
  &lt;p>How long is 1 cm in millimeters?&lt;/p>
  &lt;numericalresponse answer="10">
    &lt;formulaequationinput trailing_text="mm"/>
  &lt;/numericalresponse>
&lt;/problem>
</pre>
