### PR TITLE
Remove django-masquerade

### DIFF
--- a/docs/shared/requirements.txt
+++ b/docs/shared/requirements.txt
@@ -14,7 +14,6 @@ django-countries==1.5
 django-filter==0.6.0
 django-kombu==0.9.4
 django-mako==0.1.5pre
-django-masquerade==0.1.6
 django-mptt==0.5.5
 django-openid-auth==0.4
 django-robots==0.9.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -22,7 +22,6 @@ django-ipware==1.1.0
 django-kombu==0.9.4
 django-mako==0.1.5pre
 django-model-utils==2.3.1
-django-masquerade==0.1.6
 django-mptt==0.7.4
 django-openid-auth==0.4
 django-robots==0.9.1


### PR DESCRIPTION
TNL-2811

Looks like this is not being used anywhere.
