### PR TITLE
Upgrading django-ses

### DIFF
--- a/docs/shared/requirements.txt
+++ b/docs/shared/requirements.txt
@@ -16,7 +16,7 @@ django-mako==0.1.5pre
 django-mptt==0.5.5
 django-openid-auth==0.4
 django-sekizai==0.6.1
-django-ses==0.4.1
+django-ses==0.7.0
 django-storages==1.1.5
 django-threaded-multihost==1.4-1
 django-method-override==0.1.0

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -24,7 +24,7 @@ django-model-utils==2.3.1
 django-mptt==0.7.4
 django-openid-auth==0.4
 django-sekizai==0.6.1
-django-ses==0.4.1
+django-ses==0.7.0
 django-simple-history==1.6.3
 django-storages==1.1.5
 django-threaded-multihost==1.4-1


### PR DESCRIPTION
Preparation for the [Django 1.8 upgrade](https://openedx.atlassian.net/wiki/display/TNL/Library+updates+needed+for+Django+upgrade+to+1.8)

Sandbox: http://django-ses.sandbox.edx.org/

Tested by sending following emails:
- SIGN UP
- BATCH ENROLLMENT
- BATCH BETA TESTER ADDITION
- BULK EMAILS 
