### PR TITLE
Automatic account provisioning for opted-in SAML providers

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1374,9 +1374,20 @@ def change_setting(request):
 
 
 class AccountValidationError(Exception):
+    """ Exception thrown if some account validation error happened """
     def __init__(self, message, field):
         super(AccountValidationError, self).__init__(message)
         self.field = field
+
+
+class AccountUserNameValidationError(AccountValidationError):
+    """ Exception thrown if attempted to create account with username already taken """
+    pass
+
+
+class AccountEmailAlreadyExistsValidationError(AccountValidationError):
+    """ Exception thrown if attempted to create account with email already used by other account """
+    pass
 
 
 @receiver(post_save, sender=User)
@@ -1420,12 +1431,12 @@ def _do_create_account(form):
     except IntegrityError:
         # Figure out the cause of the integrity error
         if len(User.objects.filter(username=user.username)) > 0:
-            raise AccountValidationError(
+            raise AccountUserNameValidationError(
                 _("An account with the Public Username '{username}' already exists.").format(username=user.username),
                 field="username"
             )
         elif len(User.objects.filter(email=user.email)) > 0:
-            raise AccountValidationError(
+            raise AccountEmailAlreadyExistsValidationError(
                 _("An account with the Email '{email}' already exists.").format(email=user.email),
                 field="email"
             )
@@ -1459,7 +1470,8 @@ def _do_create_account(form):
     return (user, profile, registration)
 
 
-def create_account_with_params(request, params):
+# pylint: disable=too-many-statements
+def create_account_with_params(request, params, skip_email=False):
     """
     Given a request and a dict of parameters (which may or may not have come
     from the request), create an account for the requesting user, including
@@ -1553,7 +1565,8 @@ def create_account_with_params(request, params):
         (user, profile, registration) = _do_create_account(form)
 
         # next, link the account with social auth, if provided via the API.
-        # (If the user is using the normal register page, the social auth pipeline does the linking, not this code)
+        # (If the user is using the normal register page or account is automatically provisioned,
+        # the social auth pipeline does the linking, not this code)
         if should_link_with_social_auth:
             backend_name = params['provider']
             request.social_strategy = social_utils.load_strategy(request)
@@ -1637,11 +1650,12 @@ def create_account_with_params(request, params):
     # the other for *new* systems. we need to be careful about
     # changing settings on a running system to make sure no users are
     # left in an inconsistent state (or doing a migration if they are).
-    send_email = (
-        not settings.FEATURES.get('SKIP_EMAIL_VALIDATION', None) and
-        not settings.FEATURES.get('AUTOMATIC_AUTH_FOR_TESTING') and
-        not (do_external_auth and settings.FEATURES.get('BYPASS_ACTIVATION_EMAIL_FOR_EXTAUTH')) and
-        not (
+    send_email = not (
+        skip_email or
+        settings.FEATURES.get('SKIP_EMAIL_VALIDATION', False) or
+        settings.FEATURES.get('AUTOMATIC_AUTH_FOR_TESTING', False) or
+        (do_external_auth and settings.FEATURES.get('BYPASS_ACTIVATION_EMAIL_FOR_EXTAUTH')) or
+        (
             third_party_provider and third_party_provider.skip_email_verification and
             user.email == running_pipeline['kwargs'].get('details', {}).get('email')
         )

--- a/common/djangoapps/third_party_auth/migrations/0004_auto__add_field_samlproviderconfig_autoprovision_account__add_field_oa.py
+++ b/common/djangoapps/third_party_auth/migrations/0004_auto__add_field_samlproviderconfig_autoprovision_account__add_field_oa.py
@@ -1,0 +1,129 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'SAMLProviderConfig.autoprovision_account'
+        db.add_column('third_party_auth_samlproviderconfig', 'autoprovision_account',
+                      self.gf('django.db.models.fields.BooleanField')(default=False),
+                      keep_default=False)
+
+        # Adding field 'OAuth2ProviderConfig.autoprovision_account'
+        db.add_column('third_party_auth_oauth2providerconfig', 'autoprovision_account',
+                      self.gf('django.db.models.fields.BooleanField')(default=False),
+                      keep_default=False)
+
+    def backwards(self, orm):
+        # Deleting field 'SAMLProviderConfig.autoprovision_account'
+        db.delete_column('third_party_auth_samlproviderconfig', 'autoprovision_account')
+
+        # Deleting field 'OAuth2ProviderConfig.autoprovision_account'
+        db.delete_column('third_party_auth_oauth2providerconfig', 'autoprovision_account')
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'third_party_auth.oauth2providerconfig': {
+            'Meta': {'object_name': 'OAuth2ProviderConfig'},
+            'autoprovision_account': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'backend_name': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'}),
+            'change_date': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'changed_by': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']", 'null': 'True', 'on_delete': 'models.PROTECT'}),
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'icon_class': ('django.db.models.fields.CharField', [], {'default': "'fa-sign-in'", 'max_length': '50'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'other_settings': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'secondary': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'secret': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'skip_email_verification': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'skip_registration_form': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        'third_party_auth.samlconfiguration': {
+            'Meta': {'object_name': 'SAMLConfiguration'},
+            'change_date': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'changed_by': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']", 'null': 'True', 'on_delete': 'models.PROTECT'}),
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'entity_id': ('django.db.models.fields.CharField', [], {'default': "'http://saml.example.com'", 'max_length': '255'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'org_info_str': ('django.db.models.fields.TextField', [], {'default': '\'{"en-US": {"url": "http://www.example.com", "displayname": "Example Inc.", "name": "example"}}\''}),
+            'other_config_str': ('django.db.models.fields.TextField', [], {'default': '\'{\\n"SECURITY_CONFIG": {"metadataCacheDuration": 604800, "signMetadata": false}\\n}\''}),
+            'private_key': ('django.db.models.fields.TextField', [], {}),
+            'public_key': ('django.db.models.fields.TextField', [], {})
+        },
+        'third_party_auth.samlproviderconfig': {
+            'Meta': {'object_name': 'SAMLProviderConfig'},
+            'attr_email': ('django.db.models.fields.CharField', [], {'max_length': '128', 'blank': 'True'}),
+            'attr_first_name': ('django.db.models.fields.CharField', [], {'max_length': '128', 'blank': 'True'}),
+            'attr_full_name': ('django.db.models.fields.CharField', [], {'max_length': '128', 'blank': 'True'}),
+            'attr_last_name': ('django.db.models.fields.CharField', [], {'max_length': '128', 'blank': 'True'}),
+            'attr_user_permanent_id': ('django.db.models.fields.CharField', [], {'max_length': '128', 'blank': 'True'}),
+            'attr_username': ('django.db.models.fields.CharField', [], {'max_length': '128', 'blank': 'True'}),
+            'autoprovision_account': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'backend_name': ('django.db.models.fields.CharField', [], {'default': "'tpa-saml'", 'max_length': '50'}),
+            'change_date': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'changed_by': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']", 'null': 'True', 'on_delete': 'models.PROTECT'}),
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'entity_id': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'icon_class': ('django.db.models.fields.CharField', [], {'default': "'fa-sign-in'", 'max_length': '50'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'idp_slug': ('django.db.models.fields.SlugField', [], {'max_length': '30'}),
+            'metadata_source': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'other_settings': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'secondary': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'skip_email_verification': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'skip_registration_form': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        'third_party_auth.samlproviderdata': {
+            'Meta': {'ordering': "('-fetched_at',)", 'object_name': 'SAMLProviderData'},
+            'entity_id': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'expires_at': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'db_index': 'True'}),
+            'fetched_at': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'public_key': ('django.db.models.fields.TextField', [], {}),
+            'sso_url': ('django.db.models.fields.URLField', [], {'max_length': '200'})
+        }
+    }
+
+    complete_apps = ['third_party_auth']

--- a/common/djangoapps/third_party_auth/models.py
+++ b/common/djangoapps/third_party_auth/models.py
@@ -98,6 +98,15 @@ class ProviderConfig(ConfigurationModel):
             "email, and their account will be activated immediately upon registration."
         ),
     )
+    autoprovision_account = models.BooleanField(
+        default=False,
+        help_text=_(
+            "If this option is selected, users will not be required to confirm their details even if "
+            "some required data is missing or fails validation (e.g. duplicate email). Instead, fake or generated "
+            "values will be used. This setting forces skipping email verification, so 'Skip email verification' "
+            "setting have no effect."
+        )
+    )
     prefix = None  # used for provider_id. Set to a string value in subclass
     backend_name = None  # Set to a field or fixed value in subclass
     accepts_logins = True  # Whether to display a sign-in button when the provider is enabled

--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -56,12 +56,12 @@ rather than spreading them across two functions in the pipeline.
 
 See http://psa.matiasaguirre.net/docs/pipeline.html for more docs.
 """
-
 import random
 import string  # pylint: disable=deprecated-module
 from collections import OrderedDict
 import urllib
 import analytics
+from django.conf import settings
 from eventtracking import tracker
 
 from django.contrib.auth.models import User
@@ -73,6 +73,7 @@ from social.apps.django_app.default import models
 from social.exceptions import AuthException
 from social.pipeline import partial
 from social.pipeline.social_auth import associate_by_email
+from social.pipeline.user import create_user as social_create_user
 
 import student
 
@@ -160,6 +161,20 @@ class NotActivatedException(AuthException):
         return (
             _('This account has not yet been activated. An activation email has been re-sent to {email_address}.')
             .format(email_address=self.email)
+        )
+
+
+class EmailAlreadyInUseException(AuthException):
+    """ Raised when new user account is created with an email already used by another account """
+    def __init__(self, backend, email):
+        self.email = email
+        super(EmailAlreadyInUseException, self).__init__(backend, email)
+
+    def __str__(self):
+        return (
+            _('Email {email_address} is already used in our system. To link your accounts, '
+              'sign in now using your {platform_name} password.')
+            .format(email_address=self.email, platform_name=settings.PLATFORM_NAME)
         )
 
 
@@ -478,18 +493,34 @@ def ensure_user_information(strategy, auth_entry, backend=None, user=None, socia
         """Redirects to the registration page."""
         return redirect(AUTH_DISPATCH_URLS[AUTH_ENTRY_REGISTER])
 
-    def should_force_account_creation():
-        """ For some third party providers, we auto-create user accounts """
-        current_provider = provider.Registry.get_from_pipeline({'backend': backend.name, 'kwargs': kwargs})
+    def get_provider():
+        """
+        Gets third-party provider for request
+        """
+        return provider.Registry.get_from_pipeline({'backend': backend.name, 'kwargs': kwargs})
+
+    def should_autoprovision_account():
+        """ For some third party providers we trust the provider so much that we automatically provision the account """
+        current_provider = get_provider()
+        return current_provider and current_provider.autoprovision_account
+
+    def autosubmit_registration_form():
+        """ For some third party providers, we auto-submit registration forms """
+        current_provider = get_provider()
         return current_provider and current_provider.skip_email_verification
 
     if not user:
+        if should_autoprovision_account():
+            # User has authenticated with the third party provider and provider is configured
+            # to automatically provision edX account, which is done via strategy.create_user in next pipeline step
+            return {'autoprovision': True}
+
         if auth_entry in [AUTH_ENTRY_LOGIN_API, AUTH_ENTRY_REGISTER_API]:
             return HttpResponseBadRequest()
         elif auth_entry == AUTH_ENTRY_LOGIN:
             # User has authenticated with the third party provider but we don't know which edX
             # account corresponds to them yet, if any.
-            if should_force_account_creation():
+            if autosubmit_registration_form():
                 return dispatch_to_register()
             return dispatch_to_login()
         elif auth_entry == AUTH_ENTRY_REGISTER:
@@ -527,6 +558,22 @@ def ensure_user_information(strategy, auth_entry, backend=None, user=None, socia
             raise NotActivatedException(backend, user.email)
         # else: The user must have just successfully registered their account, so we proceed.
         # We know they did not just login, because the login process rejects unverified users.
+
+
+@partial.partial
+def create_user(strategy, details, user=None, *args, **kwargs):
+    """
+    Substitution method for stock social create_user that catches email validation error and redirects to login
+    """
+    from student.views import AccountEmailAlreadyExistsValidationError
+    try:
+        return social_create_user(strategy, details, user, *args, **kwargs)
+    except AccountEmailAlreadyExistsValidationError as exc:
+        logger.exception(exc.message)
+        # We're raising an exception that inherits from AuthException. Such exceptions are properly handled
+        # by social auth pipeline: their string representation (see __str__ method) is displayed to user on the page
+        # we're redirecting to.
+        raise EmailAlreadyInUseException(exc.message, details['email'])
 
 
 @partial.partial

--- a/common/djangoapps/third_party_auth/settings.py
+++ b/common/djangoapps/third_party_auth/settings.py
@@ -9,7 +9,6 @@ If true, it:
     a) loads this module.
     b) calls apply_settings(), passing in the Django settings
 """
-
 _FIELDS_STORED_IN_SESSION = ['auth_entry', 'next']
 _MIDDLEWARE_CLASSES = (
     'third_party_auth.middleware.ExceptionMiddleware',
@@ -53,7 +52,7 @@ def apply_settings(django_settings):
         'social.pipeline.user.get_username',
         'third_party_auth.pipeline.set_pipeline_timeout',
         'third_party_auth.pipeline.ensure_user_information',
-        'social.pipeline.user.create_user',
+        'third_party_auth.pipeline.create_user',
         'social.pipeline.social_auth.associate_user',
         'social.pipeline.social_auth.load_extra_data',
         'social.pipeline.user.user_details',
@@ -85,3 +84,12 @@ def apply_settings(django_settings):
         'social.apps.django_app.context_processors.backends',
         'social.apps.django_app.context_processors.login_redirect',
     )
+
+    # These fields are grabbed from third party auth response and passed to strategy.create_user
+    # If autoprovisioning an account we want as much data preserved as possible, so we try to get those as well
+    # If they are not available it would just pass None and should not crash, unless consuming code depends on those
+    # values being set, which is not the case by the time of writing
+    if not hasattr(django_settings, 'SOCIAL_AUTH_USER_FIELDS'):
+        django_settings.SOCIAL_AUTH_USER_FIELDS = getattr(
+            django_settings, 'USER_FIELDS', ['username', 'email', 'first_name', 'last_name', 'fullname']
+        )

--- a/common/djangoapps/third_party_auth/strategy.py
+++ b/common/djangoapps/third_party_auth/strategy.py
@@ -2,9 +2,13 @@
 A custom Strategy for python-social-auth that allows us to fetch configuration from
 ConfigurationModels rather than django.settings
 """
+import logging
 from .models import OAuth2ProviderConfig
 from social.backends.oauth import OAuthAuth
 from social.strategies.django_strategy import DjangoStrategy
+
+
+log = logging.getLogger(__name__)
 
 
 class ConfigurationModelStrategy(DjangoStrategy):
@@ -34,3 +38,44 @@ class ConfigurationModelStrategy(DjangoStrategy):
         # At this point, we know 'name' is not set in a [OAuth2|LTI|SAML]ProviderConfig row.
         # It's probably a global Django setting like 'FIELDS_STORED_IN_SESSION':
         return super(ConfigurationModelStrategy, self).setting(name, default, backend)
+
+    def _ensure_passes_length_check(self, user_data, key, fallback, min_length=2):
+        """
+        Ensures that value we get from user_data is meets length requirements. IF it is shorter than required, fallback
+        is used
+        """
+        assert len(fallback) >= min_length
+        value = user_data.get(key)
+        if value and len(value) >= min_length:
+            return value
+        return fallback
+
+    def create_user(self, *args, **kwargs):
+        """
+        # Creates user using information provided by pipeline. This method is called in create_user pipeline step.
+        # Unless the workflow is changed, create_user immediately terminates if the user already found/
+        # So far, user is either created in ensure_user_information via registration form or account needs to be
+        # autoprovisioned. So, this method is only called when autoprovisioning account.
+        """
+        from student.views import create_account_with_params
+        from .pipeline import make_random_password
+
+        user_fields = dict(kwargs)
+        # needs to be >2 chars to pass validation
+        name = self._ensure_passes_length_check(
+            user_fields, 'fullname', self.setting("THIRD_PARTY_AUTH_FALLBACK_FULL_NAME")
+        )
+        password = self._ensure_passes_length_check(user_fields, 'password', make_random_password())
+
+        user_fields['name'] = name
+        user_fields['password'] = password
+        user_fields['honor_code'] = True
+        user_fields['terms_of_service'] = True
+
+        if not user_fields.get('email'):
+            user_fields['email'] = "{username}@{domain}".format(
+                username=user_fields['username'], domain=self.setting("FAKE_EMAIL_DOMAIN")
+            )
+
+        # when autoprovisioning we need to skip email activation, hence skip_email is True
+        return create_account_with_params(self.request, user_fields, skip_email=True)

--- a/common/djangoapps/third_party_auth/tests/specs/test_testshib.py
+++ b/common/djangoapps/third_party_auth/tests/specs/test_testshib.py
@@ -27,6 +27,7 @@ class TestShibIntegrationTest(testutil.SAMLTestCase):
         super(TestShibIntegrationTest, self).setUp()
         self.login_page_url = reverse('signin_user')
         self.register_page_url = reverse('register_user')
+        self.dashboard_page_url = reverse('dashboard')
         self.enable_saml(
             private_key=self._get_private_key(),
             public_key=self._get_public_key(),
@@ -141,7 +142,56 @@ class TestShibIntegrationTest(testutil.SAMLTestCase):
         continue_response = self.client.get(TPA_TESTSHIB_COMPLETE_URL)
         # And we should be redirected to the dashboard:
         self.assertEqual(continue_response.status_code, 302)
-        self.assertEqual(continue_response['Location'], self.url_prefix + reverse('dashboard'))
+        self.assertEqual(continue_response['Location'], self.url_prefix + self.dashboard_page_url)
+
+        # Now check that we can login again:
+        self.client.logout()
+        self._test_return_login()
+
+    def test_autoprovision_from_login(self):
+        self._configure_testshib_provider(autoprovision_account=True)
+        self._freeze_time(timestamp=1434326820)  # This is the time when the saved request/response was recorded.
+
+        # check that we don't have a user we're autoprovisioning account for
+        self.assert_user_does_not_exist('myself')
+
+        # The user goes to the register page, and sees a button to register with TestShib:
+        self._check_login_page()
+
+        self._test_autoprovision(TPA_TESTSHIB_LOGIN_URL)
+
+    def test_autoprovision_from_register(self):
+        self._configure_testshib_provider(autoprovision_account=True)
+        self._freeze_time(timestamp=1434326820)  # This is the time when the saved request/response was recorded.
+
+        # check that we don't have a user we're autoprovisioning account for
+        self.assert_user_does_not_exist('myself')
+
+        # The user goes to the register page, and sees a button to register with TestShib:
+        self._check_register_page()
+
+        self._test_autoprovision(TPA_TESTSHIB_REGISTER_URL)
+
+    def _test_autoprovision(self, entry_point):
+        """ Actual autoprovision code """
+        # The user clicks on the TestShib button:
+        try_entry_response = self.client.get(entry_point)
+        # The user should be redirected to TestShib:
+        self.assertEqual(try_entry_response.status_code, 302)
+        self.assertTrue(try_entry_response['Location'].startswith(TESTSHIB_SSO_URL))
+
+        # Now the user will authenticate with the SAML provider
+        self._fake_testshib_login_and_return()
+
+        # Then there's one more redirect to set logged_in cookie
+        continue_response = self.client.get(TPA_TESTSHIB_COMPLETE_URL)
+
+        # We should be redirected to the dashboard screen since profile should be created and logged in
+        self.assertEqual(continue_response.status_code, 302)
+        self.assertEqual(continue_response['Location'], self.url_prefix + self.dashboard_page_url)
+
+        # assert account is created and activated
+        self.assert_account_created(username='myself', email='myself@testshib.org', full_name='Me Myself And I')
 
         # Now check that we can login again:
         self.client.logout()
@@ -167,7 +217,7 @@ class TestShibIntegrationTest(testutil.SAMLTestCase):
         # And then we should be redirected to the dashboard:
         login_response = self.client.get(TPA_TESTSHIB_COMPLETE_URL)
         self.assertEqual(login_response.status_code, 302)
-        self.assertEqual(login_response['Location'], self.url_prefix + reverse('dashboard'))
+        self.assertEqual(login_response['Location'], self.url_prefix + self.dashboard_page_url)
         # Now we are logged in:
         dashboard_response = self.client.get(reverse('dashboard'))
         self.assertEqual(dashboard_response.status_code, 200)
@@ -204,6 +254,7 @@ class TestShibIntegrationTest(testutil.SAMLTestCase):
         kwargs.setdefault('metadata_source', TESTSHIB_METADATA_URL)
         kwargs.setdefault('icon_class', 'fa-university')
         kwargs.setdefault('attr_email', 'urn:oid:1.3.6.1.4.1.5923.1.1.1.6')  # eduPersonPrincipalName
+        kwargs.setdefault('autoprovision_account', False)
         self.configure_saml_provider(**kwargs)
 
         if fetch_metadata:

--- a/common/djangoapps/third_party_auth/tests/test_pipeline.py
+++ b/common/djangoapps/third_party_auth/tests/test_pipeline.py
@@ -1,7 +1,9 @@
 """Unit tests for third_party_auth/pipeline.py."""
 
 import random
+import mock
 
+from student.views import AccountEmailAlreadyExistsValidationError
 from third_party_auth import pipeline
 from third_party_auth.tests import testutil
 import unittest
@@ -43,3 +45,38 @@ class ProviderUserStateTestCase(testutil.TestCase):
         google_provider = self.configure_google_provider(enabled=True)
         state = pipeline.ProviderUserState(google_provider, object(), 1000)
         self.assertEqual(google_provider.provider_id + '_unlink_form', state.get_unlink_form_name())
+
+
+@unittest.skipUnless(testutil.AUTH_FEATURE_ENABLED, 'third_party_auth not enabled')
+class TestCreateUser(testutil.TestCase):
+    """
+    Tests for custom create_user step
+    """
+    def _raise_email_in_use_exception(self, *unused_args, **unused_kwargs):
+        """ Helper to raise AccountEmailAlreadyExistsValidationError """
+        raise AccountEmailAlreadyExistsValidationError(mock.Mock(), mock.Mock())
+
+    def test_create_user_normal_scenario(self):
+        """  Tests happy path - user is created and results are returned intact """
+        retval = mock.Mock()
+        with mock.patch("third_party_auth.pipeline.social_create_user") as patched_social_create_user:
+            patched_social_create_user.return_value = retval
+            strategy, details, user, idx = mock.Mock(), {'email': 'qwe@asd.com'}, mock.Mock(), 1
+
+            # pylint: disable=redundant-keyword-arg
+            result = pipeline.create_user(strategy, idx, details=details, user=user)
+
+            self.assertEqual(result, retval)
+
+    def test_create_user_exception_scenario(self):
+        """
+        Tests sad path - expected exception is thrown, captured and transformed into AuthException subclass instance
+        """
+        with mock.patch("third_party_auth.pipeline.social_create_user") as patched_social_create_user:
+            patched_social_create_user.side_effect = self._raise_email_in_use_exception
+
+            strategy, details, user = mock.Mock(), {'email': 'qwe@asd.com'}, mock.Mock()
+
+            with self.assertRaises(pipeline.EmailAlreadyInUseException):
+                # pylint: disable=redundant-keyword-arg
+                pipeline.create_user(strategy, 1, details=details, user=user)

--- a/common/djangoapps/third_party_auth/tests/test_strategy.py
+++ b/common/djangoapps/third_party_auth/tests/test_strategy.py
@@ -1,0 +1,97 @@
+""" unittests for strategy.py """
+import unittest
+import ddt
+import mock
+from unittest import TestCase
+from third_party_auth.strategy import ConfigurationModelStrategy
+from third_party_auth.tests import testutil
+
+
+@ddt.ddt
+@mock.patch('student.views.create_account_with_params')
+@unittest.skipUnless(testutil.AUTH_FEATURE_ENABLED, 'third_party_auth not enabled')
+class TestStrategy(TestCase):
+    """ Unit tests for authentication strategy """
+    def setUp(self):
+        super(TestStrategy, self).setUp()
+        self.request_mock = mock.Mock()
+        self.strategy = ConfigurationModelStrategy(mock.Mock(), request=self.request_mock)
+
+    def _get_last_call_args(self, patched_create_account):
+        """ Helper to get last call arguments from a mock """
+        args, unused_kwargs = patched_create_account.call_args
+        return args
+
+    def test_create_user_sets_tos_and_honor_code(self, patched_create_account):
+        self.strategy.create_user(username='myself')
+
+        self.assertTrue(patched_create_account.called)
+        request, user_data = self._get_last_call_args(patched_create_account)
+
+        self.assertEqual(request, self.request_mock)
+        self.assertTrue(user_data['terms_of_service'])
+        self.assertTrue(user_data['honor_code'])
+
+    @ddt.data(
+        (None, 'Fallback Name', 'Fallback Name'),
+        ('q', 'Other Name', 'Other Name'),
+        ('q2', 'Other Name', 'q2'),
+        ('qwe', 'Other Name', 'qwe'),
+        ('user1', 'Fallback Name', 'user1')
+    )
+    @ddt.unpack
+    def test_create_user_sets_name(self, full_name, fallback_name, expected_name, patched_create_account):
+        with mock.patch.object(self.strategy, 'setting', mock.Mock()) as patched_setting:
+            patched_setting.return_value = fallback_name
+            self.strategy.create_user(username='myself', fullname=full_name)
+
+            # it is actually always called, but this assertion is relaxed to allow not actually going to settings
+            # if there's no point in that
+            if expected_name == fallback_name:
+                self.assertIn(mock.call("THIRD_PARTY_AUTH_FALLBACK_FULL_NAME"), patched_setting.mock_calls)
+
+        _, user_data = self._get_last_call_args(patched_create_account)
+        self.assertEqual(user_data['name'], expected_name)
+
+    def test_sets_password_if_missing(self, patched_create_account):
+        self.strategy.create_user(username='myself', fullname='myself')
+        _, user_data = self._get_last_call_args(patched_create_account)
+
+        self.assertIn('password', user_data)
+
+    @ddt.data(
+        (None, False),
+        ('q', False),
+        ('12', False),
+        ('456', True),
+        ('$up3r_$e(ur3_p/|$$w0rd', True),
+    )
+    @ddt.unpack
+    def test_passes_password_if_specified(self, password, should_match, patched_create_account):
+        self.strategy.create_user(username='myself', fullname='myself', password=password)
+        _, user_data = self._get_last_call_args(patched_create_account)
+
+        self.assertIn('password', user_data)
+        if should_match:
+            self.assertEqual(user_data['password'], password)
+
+    @ddt.data(
+        (None, 'fallback_domain.com', 'myself@fallback_domain.com'),
+        ('', 'other_domain.com', 'myself@other_domain.com'),
+        ('qwe@asd.com', 'fallback_domain.com', 'qwe@asd.com'),
+        ('zxc@darpa.gov.mil.edu', 'fallback_domain.com', 'zxc@darpa.gov.mil.edu'),
+    )
+    @ddt.unpack
+    def test_sets_email_if_not_provided(self, email, fallback_domain, expected_email, patched_create_account):
+        with mock.patch.object(self.strategy, 'setting', mock.Mock()) as patched_setting:
+            patched_setting.return_value = fallback_domain
+            # fullname is needed to avoid calling setting twice
+            self.strategy.create_user(username='myself', fullname='myself', email=email)
+
+            # it is actually always called, but this assertion is relaxed to allow not actually going to settings
+            # if there's no point in that
+            if email != expected_email:
+                self.assertIn(mock.call("FAKE_EMAIL_DOMAIN"), patched_setting.mock_calls)
+
+        _, user_data = self._get_last_call_args(patched_create_account)
+        self.assertEqual(user_data['email'], expected_email)

--- a/common/djangoapps/third_party_auth/tests/testutil.py
+++ b/common/djangoapps/third_party_auth/tests/testutil.py
@@ -119,6 +119,19 @@ class ThirdPartyAuthTestMixin(object):
         with open(os.path.join(os.path.dirname(__file__), 'data', filename)) as f:
             return f.read()
 
+    def assert_user_does_not_exist(self, username):
+        """ Asserts that user with specified username does not exist """
+        with self.assertRaises(User.DoesNotExist):
+            User.objects.get(username=username)
+
+    def assert_account_created(self, username, email, full_name, activated=True):
+        """ Asserts that user with specified username exists, activated and have specified full name and email """
+        user = User.objects.get(username=username)
+        self.assertIsNotNone(user.profile)
+        self.assertEqual(user.email, email)
+        self.assertEqual(user.profile.name, full_name)
+        self.assertEqual(user.is_active, activated)
+
 
 class TestCase(ThirdPartyAuthTestMixin, django.test.TestCase):
     """Base class for auth test cases."""

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -578,6 +578,14 @@ if FEATURES.get('ENABLE_THIRD_PARTY_AUTH'):
             'schedule': datetime.timedelta(hours=ENV_TOKENS.get('THIRD_PARTY_AUTH_SAML_FETCH_PERIOD_HOURS', 24)),
         }
 
+    # FAKE EMAIL DOMAIN setting is used to generate an email for an automatically provisioned account in case
+    # it is not provided by IdP (which should'nt normally be the case for providers with automatic provisioning)
+    FAKE_EMAIL_DOMAIN = ENV_TOKENS.get('FAKE_EMAIL_DOMAIN', 'fake-email-domain.foo')
+
+    # This setting is used as a user full name when automatically provisioning an account in case
+    # IdP provided name is empty, missing or does not pass minimal length check
+    THIRD_PARTY_AUTH_FALLBACK_FULL_NAME = ENV_TOKENS.get('THIRD_PARTY_AUTH_FALLBACK_FULL_NAME', "Unknown")
+
 ##### OAUTH2 Provider ##############
 if FEATURES.get('ENABLE_OAUTH2_PROVIDER'):
     OAUTH_OIDC_ISSUER = ENV_TOKENS['OAUTH_OIDC_ISSUER']

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -253,6 +253,9 @@ AUTHENTICATION_BACKENDS = (
     'third_party_auth.lti.LTIAuthBackend',
 ) + AUTHENTICATION_BACKENDS
 
+FAKE_EMAIL_DOMAIN = 'fake-email-domain.foo'
+THIRD_PARTY_AUTH_FALLBACK_FULL_NAME = "Unknown"
+
 ################################## OPENID #####################################
 FEATURES['AUTH_USE_OPENID'] = True
 FEATURES['AUTH_USE_OPENID_PROVIDER'] = True


### PR DESCRIPTION
**Description:** Forward port of https://github.com/edx-solutions/edx-platform/pull/511
**JIRA:** [YONK-80](https://openedx.atlassian.net/browse/YONK-80)
**Background:** This change adds automatic account provisioning for opt-in IdPs (configured in admin backend). If provider is opted-in, the data coming from it will be used to automatically create user account, requiring no user interaction. If some required data is missing or invalid (i.e. username or email), fake data is generated to still provision the account.
There's an existing setting "Skip Registration Form", which does the similar thing (automatically creates an account); the difference between the two is that "Skip Registration Form" actually redirects user to real Reg Form and automatically submits it on page load. As a result, the reg workflow is still in place, and if there are any validation issues, user will be see the reg form and all the messages. With Autoprovisioning, account is created completely automatically - reg form is not used; instead, an account is created in a single request. If some data is missing or does not pass validation an attempt is made to fake it; only if it fails the user will be redirected to login/registration form and see the errors, or is asked to log in into existing account.
**Author concerns:** So far, automatic provisioning overrides `Skip Email Verification` provider setting and always skips email verification. This might or might not be a good idea. On one hand, IdP is trusted so much that data coming from it is automatically used and no user interaction is required. On the other hand, it might make sense to still allow normal email verification for such kind of providers.
**Sandboxes:** [LMS](http://pr9651.sandbox.opencraft.com/), [Studio](http://studio.pr9651.sandbox.opencraft.com/)
**Testing instructions:**
_When using provided sandboxes, steps 1-3 are already performed, so you can skip them_
1. Follow instructions at [Shibboleth Configuration](https://openedx.atlassian.net/wiki/display/OpenOPS/New+Shibboleth+Configuration) docs until step 6.
2. The easiest way to set up a second part of SAML authentication process is to use http://testshib.org
2.1. Export edX SSO metadata to a file.
2.2. Import them at ["Register" step](https://www.testshib.org/register.html) of testshib configuration (make sure the filename is unique)
2.3. When editing SAML provider config (step 6 in Shibboleth Config guide), check "Autoprovision account" checkbox and set `urn:oid:1.3.6.1.4.1.5923.1.1.1.6` as email hint (testshib does not send email, but sends [eduPersonPrincipalName](http://www.internet2.edu/products-services/trust-identity-middleware/mace-registries/internet2-object-identifier-oid-registrations/) which looks like an email and is just enough for testing purposes). 
3. If you have aliases for lms in your environemnt (i.e. localhost:8000 and lms.local both point to LMS), make sure you're accessing signin view from the same hostname your exported metadata lists as `AssertionConsumerService[@Location]` attribute.
4. Go to login or registration form
5. Click on the testshib SSO provider
![testshib](https://cloud.githubusercontent.com/assets/3330048/9581432/1dc3233a-5008-11e5-8047-14e247f22db3.png)
6. Use any username and password testhib provides (myself, alterego or superego)
7. Clicking "login" in Testhib should redirect to LMS and automatically provision an account for new user. Subsequent logins with same user should log him into an existing account

---

**Settings**

``` yaml
EDXAPP_FEATURES:
  ENABLE_THIRD_PARTY_AUTH: true
```
