### PR TITLE
Disable the pip version check message

### DIFF
--- a/pavelib/prereqs.py
+++ b/pavelib/prereqs.py
@@ -138,7 +138,7 @@ def python_prereqs_installation():
     Installs Python prerequisites
     """
     for req_file in PYTHON_REQ_FILES:
-        sh("pip install -q --exists-action w -r {req_file}".format(req_file=req_file))
+        sh("pip install -q --disable-pip-version-check --exists-action w -r {req_file}".format(req_file=req_file))
 
 
 @task


### PR DESCRIPTION
This message is being shown to people who should not be deciding whether to
upgrade pip, so it is just confusing and alarming noise.

Before:

```
---> pavelib.prereqs.install_prereqs
---> pavelib.prereqs.install_ruby_prereqs
Ruby prereqs unchanged, skipping...
---> pavelib.prereqs.install_node_prereqs
Node prereqs unchanged, skipping...
---> pavelib.prereqs.install_python_prereqs
pip install -q --exists-action w -r requirements/edx/pre.txt
You are using pip version 6.0.8, however version 7.1.2 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
pip install -q --exists-action w -r requirements/edx/github.txt
You are using pip version 6.0.8, however version 7.1.2 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
  Could not find a tag or branch '96e1922348bfe6d99201b9512a9ed946c87b7e0b', assuming commit.
  Could not find a tag or branch 'b0686a76f1ce3532088c4aee6e76b9abe61cc808', assuming commit.
  Could not find a tag or branch '88ec8a011e481918fdc9d2682d4017c835acd8be', assuming commit.
```

After:

```
---> pavelib.prereqs.install_prereqs
---> pavelib.prereqs.install_ruby_prereqs
Ruby prereqs unchanged, skipping...
---> pavelib.prereqs.install_node_prereqs
Node prereqs unchanged, skipping...
---> pavelib.prereqs.install_python_prereqs
pip install -q --disable-pip-version-check --exists-action w -r requirements/edx/pre.txt
pip install -q --disable-pip-version-check --exists-action w -r requirements/edx/github.txt
  Could not find a tag or branch '96e1922348bfe6d99201b9512a9ed946c87b7e0b', assuming commit.
  Could not find a tag or branch 'b0686a76f1ce3532088c4aee6e76b9abe61cc808', assuming commit.
  Could not find a tag or branch '88ec8a011e481918fdc9d2682d4017c835acd8be', assuming commit.
```
