### PR TITLE
SOL-1053 

### DIFF
--- a/common/test/acceptance/pages/studio/settings_certificates.py
+++ b/common/test/acceptance/pages/studio/settings_certificates.py
@@ -139,7 +139,7 @@ class CertificatesPage(CoursePage):
         Clicks the main action presented by the prompt (such as 'Delete')
         """
         self.wait_for_confirmation_prompt()
-        self.q(css='a.button.action-primary').first.click()
+        self.q(css='button.action-primary').first.click()
         self.wait_for_ajax()
 
 

--- a/common/test/acceptance/tests/studio/test_studio_settings_certificates.py
+++ b/common/test/acceptance/tests/studio/test_studio_settings_certificates.py
@@ -106,7 +106,6 @@ class CertificatesTest(StudioCourseTest):
 
         self.assertIn("Updated Course Title Override 2", certificate.course_title)
 
-    @skip  # TODO fix this, see SOL-1053
     def test_can_delete_certificate(self):
         """
         Scenario: Ensure that the user can delete certificate.


### PR DESCRIPTION
Hi @ziafazal , @asadiqbal08 ,

Kindly review this PR, it contains changes for ticket SOL-1053.

Description of SOL-1053:

Failed in this master build:
https://build.testeng.edx.org/job/edx-platform-bok-choy-master/165
common.test.acceptance.tests.studio.test_studio_settings_certificates.CertificatesTest.test_can_delete_certificate
Error Message
Promise not satisfied: Create first certificate button is displayed
-------------------- >> begin captured logging << --------------------
bok_choy.browser: INFO: Using local browser: firefox [Default is firefox]
--------------------- >> end captured logging << ---------------------

Solution:
Selector for "Delete" button in confirm popup while deleting a certificate needed to be corrected.

cc: @mattdrayer
