### PR TITLE
Watch and process xmodule assets

### DIFF
--- a/pavelib/assets.py
+++ b/pavelib/assets.py
@@ -187,6 +187,8 @@ def compile_sass(options):
 
     sh(cmd(*parts))
 
+    print("\t\tFinished compiling sass.")
+
 
 def compile_templated_sass(systems, settings):
     """
@@ -196,6 +198,7 @@ def compile_templated_sass(systems, settings):
     """
     for sys in systems:
         sh(django_cmd(sys, settings, 'preprocess_assets'))
+        print("\t\tFinished preprocessing {} assets.".format(sys))
 
 
 def process_xmodule_assets():
@@ -203,6 +206,7 @@ def process_xmodule_assets():
     Process XModule static assets.
     """
     sh('xmodule_assets common/static/xmodule')
+    print("\t\tFinished processing xmodule assets.")
 
 
 def restart_django_servers():
@@ -216,6 +220,7 @@ def restart_django_servers():
         "touch", 'lms/urls.py', 'cms/urls.py',
     ))
 
+
 def collect_assets(systems, settings):
     """
     Collect static assets, including Django pipeline processing.
@@ -224,6 +229,7 @@ def collect_assets(systems, settings):
     """
     for sys in systems:
         sh(django_cmd(sys, settings, "collectstatic --noinput > /dev/null"))
+        print("\t\tFinished collecting {} assets.".format(sys))
 
 
 @task


### PR DESCRIPTION
Following up the [xmodule assets development issue](https://groups.google.com/forum/#!topic/openedx-ops/iyBWYh8WrYA) I've posted earlier in the group. I've created this fix.

> Modifying an Xmodule on edX platform is so painfully slow. I have no idea how other developers can live with that!
> I have to restart the server for every JavaScript change.

The previous solution relied on `browser-sync`, now it is not. Instead, it is integrated in `pavelib/assets.py`

To make it clearer when I need to refresh the page, I've added four messages after the assets processing steps.
