### PR TITLE
Add search specific feature flag in front of search features

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -170,6 +170,9 @@ FEATURES = {
     # Teams feature
     'ENABLE_TEAMS': True,
 
+    # Teams search feature
+    'ENABLE_TEAMS_SEARCH': False,
+
     # Show video bumper in Studio
     'ENABLE_VIDEO_BUMPER': False,
 

--- a/cms/envs/test.py
+++ b/cms/envs/test.py
@@ -281,5 +281,8 @@ SEARCH_ENGINE = "search.tests.mock_search_engine.MockSearchEngine"
 # teams feature
 FEATURES['ENABLE_TEAMS'] = True
 
+# teams search
+FEATURES['ENABLE_TEAMS_SEARCH'] = True
+
 # Dummy secret key for dev/test
 SECRET_KEY = '85920908f28904ed733fe576320db18cabd7b6cd'

--- a/lms/djangoapps/teams/management/commands/reindex_course_team.py
+++ b/lms/djangoapps/teams/management/commands/reindex_course_team.py
@@ -53,8 +53,8 @@ class Command(BaseCommand):
 
         if len(args) == 0 and not options.get('all', False):
             raise CommandError(u"reindex_course_team requires one or more arguments: <course_team_id>")
-        elif not settings.FEATURES.get('ENABLE_TEAMS', False):
-            raise CommandError(u"ENABLE_TEAMS must be enabled to use course team indexing")
+        elif not settings.FEATURES.get('ENABLE_TEAMS_SEARCH', False):
+            raise CommandError(u"ENABLE_TEAMS_SEARCH must be enabled to use course team indexing")
 
         if options.get('all', False):
             course_teams = CourseTeam.objects.all()

--- a/lms/djangoapps/teams/management/commands/tests/test_reindex_course_team.py
+++ b/lms/djangoapps/teams/management/commands/tests/test_reindex_course_team.py
@@ -39,9 +39,9 @@ class ReindexCourseTeamTest(SharedModuleStoreTestCase):
     def test_teams_search_flag_disabled_raises_command_error(self):
         """ Test that raises CommandError for disabled feature flag. """
         with mock.patch('django.conf.settings.FEATURES') as features:
-            features.return_value = {"ENABLE_TEAMS": False}
+            features.return_value = {"ENABLE_TEAMS_SEARCH": False}
             with self.assertRaises(SystemExit), nostderr():
-                with self.assertRaisesRegexp(CommandError, ".* ENABLE_TEAMS must be enabled .*"):
+                with self.assertRaisesRegexp(CommandError, ".* ENABLE_TEAMS_SEARCH must be enabled .*"):
                     call_command('reindex_course_team')
 
     def test_given_invalid_team_id_raises_command_error(self):

--- a/lms/djangoapps/teams/search_indexes.py
+++ b/lms/djangoapps/teams/search_indexes.py
@@ -19,7 +19,7 @@ class CourseTeamIndexer(object):
     """
     INDEX_NAME = "course_team_index"
     DOCUMENT_TYPE_NAME = "course_team"
-    ENABLE_SEARCH_KEY = "ENABLE_TEAMS"
+    ENABLE_SEARCH_KEY = "ENABLE_TEAMS_SEARCH"
 
     def __init__(self, course_team):
         self.course_team = course_team

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -633,7 +633,7 @@ PDF_RECEIPT_COBRAND_LOGO_HEIGHT_MM = ENV_TOKENS.get(
 if FEATURES.get('ENABLE_COURSEWARE_SEARCH') or \
    FEATURES.get('ENABLE_DASHBOARD_SEARCH') or \
    FEATURES.get('ENABLE_COURSE_DISCOVERY') or \
-   FEATURES.get('ENABLE_TEAMS'):
+   FEATURES.get('ENABLE_TEAMS_SEARCH'):
     # Use ElasticSearch as the search engine herein
     SEARCH_ENGINE = "search.elastic.ElasticSearchEngine"
 


### PR DESCRIPTION
After multiple methods of trying to catch this connection error at different levels, I think the fastest and easiest solution is to put all of search behind its own feature flag again until we can sort this whole thing out.
