### PR TITLE
Fix redirecting to topics page after joining a team.

### DIFF
--- a/common/test/acceptance/pages/lms/teams.py
+++ b/common/test/acceptance/pages/lms/teams.py
@@ -23,6 +23,10 @@ CREATE_TEAM_LINK_CSS = '.create-team'
 class TeamCardsMixin(object):
     """Provides common operations on the team card component."""
 
+    def view_first_team(self):
+        """Click the 'view' button of the first team card on the page."""
+        self.q(css='a.action-view').first.click()
+
     @property
     def team_cards(self):
         """Get all the team cards on the page."""

--- a/common/test/acceptance/tests/lms/test_teams.py
+++ b/common/test/acceptance/tests/lms/test_teams.py
@@ -1456,7 +1456,9 @@ class TeamPageTest(TeamsTabBase):
         And if I switch to "My Team", the team I have joined is displayed
         """
         self._set_team_configuration_and_membership(create_membership=False)
-        self.team_page.visit()
+        teams_page = BrowseTeamsPage(self.browser, self.course_id, self.topic)
+        teams_page.visit()
+        teams_page.view_first_team()
         self.assertTrue(self.team_page.join_team_button_present)
         expected_events = [
             {
@@ -1473,7 +1475,7 @@ class TeamPageTest(TeamsTabBase):
         self.assertFalse(self.team_page.join_team_message_present)
         self.assert_team_details(num_members=1, is_member=True)
 
-        # Verify that if one switches to "My Team" without reloading the page, the newly created team is shown.
+        # Verify that if one switches to "My Team" without reloading the page, the newly joined team is shown.
         self.teams_page.click_all_topics()
         self.verify_my_team_count(1)
 

--- a/lms/djangoapps/teams/static/teams/js/spec/views/teams_tab_spec.js
+++ b/lms/djangoapps/teams/static/teams/js/spec/views/teams_tab_spec.js
@@ -91,6 +91,17 @@ define([
                 AjaxHelpers.respondWithError(requests, 500);
                 expectError(teamsTabView, "Your request could not be completed due to a server problem. Reload the page and try again. If the issue persists, click the Help tab to report the problem.");
                 expectFocus(teamsTabView.$('.warning'));
+
+            it('does not navigate to the topics page when syncing its collection if not on the search page', function () {
+                var teamsTabView = createTeamsTabView(),
+                    collection = TeamSpecHelpers.createMockTeams();
+                teamsTabView.createTeamsListView({
+                    collection: collection,
+                    topic: TeamSpecHelpers.createMockTopic()
+                });
+                spyOn(Backbone.history, 'navigate');
+                collection.trigger('sync');
+                expect(Backbone.history.navigate).not.toHaveBeenCalled();
             });
         });
 
@@ -179,6 +190,12 @@ define([
                 // Perform a search
                 teamsTabView.$('.search-field').val('foo');
                 teamsTabView.$('.action-search').click();
+                // Note: this is a bit of a hack -- without it the URL
+                // fragment won't be what it would be in the real
+                // app. This line sets the fragment without triggering
+                // callbacks, allowing teams_tab.js to detect the
+                // fragment correctly.
+                Backbone.history.navigate('topics/' + TeamSpecHelpers.testTopicID + '/search', {trigger: false});
                 AjaxHelpers.respondWithJson(requests, {});
 
                 // Clear the search and submit it again

--- a/lms/djangoapps/teams/static/teams/js/views/teams_tab.js
+++ b/lms/djangoapps/teams/static/teams/js/views/teams_tab.js
@@ -317,15 +317,18 @@
                             title: options.title,
                             description: options.description,
                             breadcrumbs: options.breadcrumbs
-                        });
+                        }),
+                        searchUrl = 'topics/' + topic.get('id') + '/search';
                     // Listen to requests to sync the collection and redirect it as follows:
                     // 1. If the collection includes a search, show the search results page
-                    // 2. If not, then show the regular topic teams page
+                    // 2. If we're already on the search page, show the regular
+                    //    topic teams page.
+                    // 3. Otherwise, do nothing and remain on the current page.
                     // Note: Backbone makes this a no-op if redirecting to the current page.
                     this.listenTo(collection, 'sync', function() {
                         if (collection.searchString) {
-                            Backbone.history.navigate('topics/' + topic.get('id') + '/search', {trigger: true});
-                        } else {
+                            Backbone.history.navigate(searchUrl, {trigger: true});
+                        } else if (Backbone.history.getFragment() === searchUrl) {
                             Backbone.history.navigate('topics/' + topic.get('id'), {trigger: true});
                         }
                     });


### PR DESCRIPTION
## [TNL-3232](https://openedx.atlassian.net/browse/TNL-3232)

Fixes the user being redirected to the teams page in some cases after joining or leaving a team. Also fixes two other resulting bugs, [TNL-3226](https://openedx.atlassian.net/browse/TNL-3226) and [TNL-3227](https://openedx.atlassian.net/browse/TNL-3227).
### Sandbox
- [x] http://peter-fogg.sandbox.edx.org/
### Testing
- [x] Unit, integration, acceptance tests as appropriate
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @dianakhuang 
- [x] Code review: @andy-armstrong 
### Post-review
- [x] Squash commits
