### PR TITLE
Updating reset link colors

### DIFF
--- a/lms/static/sass/base/_base.scss
+++ b/lms/static/sass/base/_base.scss
@@ -84,7 +84,7 @@ p {
     @include transition(all 0.1s linear 0s);
 
     &:hover, &:focus {
-      color: $link-color;
+      color: $link-hover;
       text-decoration: underline;
     }
   }
@@ -96,7 +96,9 @@ a, a:visited {
   text-decoration: none;
   @include transition(all 0.1s linear 0s);
 
-  &:hover, &:focus {
+  &:hover,
+  &:focus {
+    color: $link-hover;
     text-decoration: underline;
   }
 

--- a/lms/static/sass/base/_reset.scss
+++ b/lms/static/sass/base/_reset.scss
@@ -9,9 +9,9 @@ html { font-size: 100%; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 10
 html, button, input, select, textarea { font-family: sans-serif; color: #222; }
 body { margin: 0; font-size: 1em; line-height: 1.4; }
 
-a { color: #00e; }
-a:visited { color: #551a8b; }
-a:hover, a:focus { color: #06e; }
+a { color: #005584; } // from the Pattern Library http://ux.edx.org/elements/colors/
+a:visited { color: #003655; } // from the Pattern Library http://ux.edx.org/elements/colors/
+a:hover, a:focus { color: #0079BC; } // from the Pattern Library http://ux.edx.org/elements/colors/
 abbr[title] { border-bottom: 1px dotted; }
 b, strong { font-weight: bold; }
 blockquote { margin: 1em 40px; }

--- a/lms/static/sass/base/_variables.scss
+++ b/lms/static/sass/base/_variables.scss
@@ -463,7 +463,7 @@ $border-color-l4: $m-gray-l4;
 // MISC: links and buttons
 $link-color: $blue;
 $link-color-d1: $blue;
-$link-hover: $pink;
+$link-hover: $blue-l1; // from our Pattern Library http://ux.edx.org/elements/colors/
 $site-status-color: $pink;
 $button-color: $blue;
 $button-archive-color: rgb(238,238,238); // #eeeeee


### PR DESCRIPTION
This quick fix addresses the HEX colors in our `_reset.scss` file for links. A recent merged piece of work simplified link styles allowing them to rely more on inheritance, rather than on a bunch of deeply specified (and often overwritten and conflicting styles). However this caused visual discrepancies on the course dashboard, mainly with the link colors. I discovered the reset file was using an incorrect color blue.
- [x] @talbs 
