### PR TITLE
Make studio forgot password link focusable

### DIFF
--- a/cms/templates/login.html
+++ b/cms/templates/login.html
@@ -30,9 +30,9 @@ from django.utils.translation import ugettext as _
             </li>
 
             <li class="field text required" id="field-password">
-              <a href="${forgot_password_link}" class="action action-forgotpassword" tabindex="-1">${_("Forgot password?")}</a>
               <label for="password">${_("Password")}</label>
               <input id="password" type="password" name="password" />
+              <a href="${forgot_password_link}" class="action action-forgotpassword">${_("Forgot password?")}</a>
             </li>
           </ol>
         </fieldset>


### PR DESCRIPTION
For AC-163.  This was pretty straight forward.  Removing `tabindex="-1"` from the link tag and moving the tag below the input box fixed it without changing the visual layout.  No styling changes were needed.

@clrux @cptvitamin Please review.
