### PR TITLE
Addressing contrast for sr elements in courseware navigation

### DIFF
--- a/lms/static/sass/course/layout/_courseware_header.scss
+++ b/lms/static/sass/course/layout/_courseware_header.scss
@@ -18,6 +18,12 @@
     @include margin-left(10px);
     padding: ($baseline*0.75) 0 ($baseline*0.75) 0;
 
+    // setting sufficient contrast for sr elements
+    .sr {
+      color: $black;
+      background: $white;
+    }
+
     li {
       @include float(left);
       list-style: none;


### PR DESCRIPTION
This small piece of work provides sufficient contrast for `sr` (screen reader only) elements by defining fore and background colors.
