### PR TITLE
Modifying template for formulaequationinput and fixing CSS

### DIFF
--- a/common/lib/capa/capa/templates/formulaequationinput.html
+++ b/common/lib/capa/capa/templates/formulaequationinput.html
@@ -16,11 +16,12 @@
         </span>
       </span>
 
+      <p id="answer_${id}" class="answer"></p>
+
       <div id="input_${id}_preview" class="equation">
         \[\]
         <img src="${STATIC_URL}images/spinner.gif" class="loading" alt="Loading"/>
       </div>
-    <p id="answer_${id}" class="answer"></p>
   </div>
 
   <div class="script_placeholder" data-src="${previewer}"/>

--- a/common/lib/xmodule/xmodule/css/capa/display.scss
+++ b/common/lib/xmodule/xmodule/css/capa/display.scss
@@ -406,7 +406,6 @@ div.problem {
       margin-top: 3px;
 
       .MathJax_Display {
-        display: inline-block;
         width: auto;
       }
 
@@ -427,6 +426,11 @@ div.problem {
           background: #f1f1f1;
         }
       }
+    }
+
+    // Fix for formulaequationinput, overriding MathJax_Display default style to allow "loading" image to sit next to it
+    section.formulaequationinput div.equation .MathJax_Display {
+      display: inline-block !important;
     }
 
     // Hides equation previews in symbolic response problems when printing
@@ -713,13 +717,10 @@ div.problem {
       height: 46px;
     }
 
-    > .incorrect, .correct, .unanswered {
-
-      .status {
-        display: inline-block;
-        margin-top: ($baseline/2);
-        background: none;
-      }
+    .status {
+      display: inline-block;
+      margin-top: ($baseline/2);
+      background: none;
     }
 
     // CASE: incorrect answer
@@ -746,8 +747,8 @@ div.problem {
       }
     }
 
-    // CASE: unanswered
-    > .unanswered {
+    // CASE: unanswered and unsubmitted
+    > .unanswered, > .unsubmitted {
 
       input {
         border: 2px solid $gray-l4;


### PR DESCRIPTION
This PR cleans up the formulaequationinput problem type somewhat. It fixes two aspects:
- The answer (when shown) is now shown at the end of the textbox, just like in textline. Before this PR, it's shown below the answerbox (which takes up a lot of space).
- The spinner gif is supposed to show next to the math box, but doesn't because on an !important in the MathJax css file. This causes it to show as extra whitespace beneath the problem.

Presently:
![screen shot 2015-09-10 at 11 30 48 am](https://cloud.githubusercontent.com/assets/6232546/9792786/0261060c-57b0-11e5-9ded-4fc8129941b1.png)

Presently, with all elements showing:
![screen shot 2015-09-10 at 11 32 11 am](https://cloud.githubusercontent.com/assets/6232546/9792792/086d4eca-57b0-11e5-8dfd-1a16de566763.png)

New, with all elements showing:
![screen shot 2015-09-10 at 11 34 13 am](https://cloud.githubusercontent.com/assets/6232546/9792793/0a2f2648-57b0-11e5-806f-94f45734f28d.png)

New, with minimal elements showing:
![screen shot 2015-09-10 at 11 41 33 am](https://cloud.githubusercontent.com/assets/6232546/9792945/ecded132-57b0-11e5-90cf-0168f14c5d2f.png)
