### PR TITLE
SOL-1187: missing is_active attribute fix

### DIFF
--- a/cms/djangoapps/contentstore/views/certificates.py
+++ b/cms/djangoapps/contentstore/views/certificates.py
@@ -218,7 +218,7 @@ class CertificateManager(object):
         # including the actual 'certificates' list that we're working with in this context
         certificates = course.certificates.get('certificates', [])
         if only_active:
-            certificates = [certificate for certificate in certificates if certificate['is_active']]
+            certificates = [certificate for certificate in certificates if certificate.get('is_active', False)]
         return certificates
 
     @staticmethod

--- a/cms/djangoapps/contentstore/views/tests/test_certificates.py
+++ b/cms/djangoapps/contentstore/views/tests/test_certificates.py
@@ -446,6 +446,45 @@ class CertificatesDetailHandlerTestCase(EventTestMixin, CourseTestCase, Certific
         self.assertEqual(course_certificates[1].get('name'), u'New test certificate')
         self.assertEqual(course_certificates[1].get('description'), 'New test description')
 
+    def test_can_edit_certificate_without_is_active(self):
+        """
+        Tests user should be able to edit certificate, if is_active attribute is not present
+        for given certificate. Old courses might not have is_active attribute in certificate data.
+        """
+        certificates = [
+            {
+                'id': 1,
+                'name': 'certificate with is_active',
+                'description': 'Description ',
+                'signatories': [],
+                'version': CERTIFICATE_SCHEMA_VERSION,
+            }
+        ]
+        self.course.certificates = {'certificates': certificates}
+        self.save_course()
+
+        expected = {
+            u'id': 1,
+            u'version': CERTIFICATE_SCHEMA_VERSION,
+            u'name': u'New test certificate',
+            u'description': u'New test description',
+            u'is_active': True,
+            u'course_title': u'Course Title Override',
+            u'signatories': []
+
+        }
+
+        response = self.client.post(
+            self._url(cid=1),
+            data=json.dumps(expected),
+            content_type="application/json",
+            HTTP_ACCEPT="application/json",
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+        self.assertEqual(response.status_code, 201)
+        content = json.loads(response.content)
+        self.assertEqual(content, expected)
+
     def test_can_delete_certificate_with_signatories(self):
         """
         Delete certificate


### PR DESCRIPTION
@mattdrayer @asadiqbal08 This PR supports the fix if is_active attribute is not present in certificate data. It could happen to a certificate configuration created earlier than addition of is_active attribute.
