### PR TITLE
SOL-449: Flaky Milestones acceptance test

### DIFF
--- a/common/test/acceptance/pages/studio/settings.py
+++ b/common/test/acceptance/pages/studio/settings.py
@@ -4,11 +4,13 @@ Course Schedule and Details Settings page.
 """
 from __future__ import unicode_literals
 from bok_choy.promise import EmptyPromise
+from bok_choy.javascript import requirejs
 
 from .course_page import CoursePage
 from .utils import press_the_notification_button
 
 
+@requirejs('js/factories/settings')
 class SettingsPage(CoursePage):
     """
     Course Schedule and Details Settings page.
@@ -21,6 +23,13 @@ class SettingsPage(CoursePage):
     ################
     def is_browser_on_page(self):
         return self.q(css='body.view-settings').present
+
+    def wait_for_require_js(self):
+        """
+        Wait for require-js to load javascript files.
+        """
+        if hasattr(self, 'wait_for_js'):
+            self.wait_for_js()  # pylint: disable=no-member
 
     def refresh_and_wait_for_load(self):
         """
@@ -182,4 +191,5 @@ class SettingsPage(CoursePage):
                 lambda: self.q(css='body.view-settings').present,
                 'Page is refreshed'
             ).fulfill()
+        self.wait_for_require_js()
         self.wait_for_ajax()

--- a/common/test/acceptance/tests/studio/test_studio_settings_details.py
+++ b/common/test/acceptance/tests/studio/test_studio_settings_details.py
@@ -40,7 +40,6 @@ class SettingsMilestonesTest(StudioCourseTest):
 
         self.assertTrue(self.settings_detail.pre_requisite_course_options)
 
-    @skip  # TODO: fix this. SOL-449
     def test_prerequisite_course_save_successfully(self):
         """
          Scenario: Selecting course from Pre-Requisite course drop down save the selected course as pre-requisite


### PR DESCRIPTION
Hi @asadiqbal08 , @ziafazal ,

Kindly review this PR, it contains a solution for SOL-449.

Description of SOL-449:

This test has failed several times for me in Jenkins over the past week (apologies if this has already been reported but I couldn't find it).

acceptance.tests.studio.test_studio_settings_details.SettingsMilestonesTest.test_prerequisite_course_save_successfully (from nosetests)

Failing for the past 1 build (Since Failed#828 )
Took 41 sec.
Error Message

Promise not satisfied: Save is confirmed
-------------------- >> begin captured logging << --------------------
bok_choy.browser: INFO: Using local browser: firefox [Default is firefox]
--------------------- >> end captured logging << ---------------------
Stacktrace

  File "/usr/lib/python2.7/unittest/case.py", line 327, in run
    testMethod()
  File "/home/jenkins/workspace/edx-platform-test-subset/common/test/acceptance/tests/studio/test_studio_settings_details.py", line 110, in test_prerequisite_course_save_successfully
    self.settings_detail.save_changes()
  File "/home/jenkins/edx-venv/src/bok-choy/bok_choy/page_object.py", line 64, in wrapper
    return method(self, _args, *_kwargs)
  File "/home/jenkins/workspace/edx-platform-test-subset/common/test/acceptance/pages/studio/settings.py", line 81, in save_changes
    'Save is confirmed'
  File "/home/jenkins/edx-venv/src/bok-choy/bok_choy/promise.py", line 96, in fulfill
    raise BrokenPromise(self)
'Promise not satisfied: Save is confirmed\n-------------------- >> begin captured logging << --------------------\nbok_choy.browser: INFO: Using local browser: firefox [Default is firefox]\n--------------------- >> end captured logging << ---------------------'

cc: @mattdrayer 
