### PR TITLE
SOL-1192: include Null in filters while making a decision to pick right custom template

### DIFF
--- a/lms/djangoapps/certificates/api.py
+++ b/lms/djangoapps/certificates/api.py
@@ -14,6 +14,7 @@ from opaque_keys.edx.keys import CourseKey
 
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from xmodule.modulestore.django import modulestore
+from xmodule_django.models import CourseKeyField
 from util.organizations_helpers import get_course_organizations
 
 from certificates.models import (
@@ -396,6 +397,7 @@ def get_certificate_template(course_key, mode):
     if not template and org_id and mode:
         template = CertificateTemplate.objects.filter(
             organization_id=org_id,
+            course_key=CourseKeyField.Empty,
             mode=mode,
             is_active=True
         )
@@ -403,11 +405,15 @@ def get_certificate_template(course_key, mode):
     if not template and org_id:
         template = CertificateTemplate.objects.filter(
             organization_id=org_id,
+            course_key=CourseKeyField.Empty,
+            mode=None,
             is_active=True
         )
     # if we still don't template find by only course mode
     if not template and mode:
         template = CertificateTemplate.objects.filter(
+            organization_id=None,
+            course_key=CourseKeyField.Empty,
             mode=mode,
             is_active=True
         )


### PR DESCRIPTION
@mattdrayer @asadiqbal08 This PR supports SOL-1192.
This PR is following this custom template decision matrix.
1. Match by org+course+mode
2. Match by org+NULL+mode
3. Match by org+NULL+NULL
4. Match by NULL+NULL+mode
