### PR TITLE
LMS: setting fore/background colors for all sr elements

### DIFF
--- a/lms/static/sass/base/_base.scss
+++ b/lms/static/sass/base/_base.scss
@@ -327,6 +327,7 @@ mark {
 // UI - semantically hide text
 .sr {
   @extend %text-sr;
+  @extend %a11y-ensure-contrast;
 }
 
 // UI - skipnav

--- a/lms/static/sass/base/_mixins.scss
+++ b/lms/static/sass/base/_mixins.scss
@@ -135,6 +135,12 @@
   width: 1px;
 }
 
+// extends - ensures proper contrast for automated checkers
+%a11y-ensure-contrast {
+  background: $white;
+  color: $black;
+}
+
 // extends - UI - removes list styling/spacing when using uls, ols for navigation and less content-centric cases
 %ui-no-list {
   list-style: none;


### PR DESCRIPTION
This small piece of work defines explicit foreground and background colors for the `.sr` classes used throughout the platform. Any elements that have the `.sr` class applied will now have sufficient contrast to pass automated accessibility checkers.

I've decided to apply these two new rules to the `%text-hide` mixin (which extends `.sr`) rather than to the `.sr` class itself. I feel this is more robust and will provide more coverage.
## Sandbox

http://clrux-ac-170.sandbox.edx.org
## Notes

Note that there are no visual changes to this work. All `.sr` elements are hidden visually, but available to screen readers.
## Reviewers
- [x] @talbs
