### PR TITLE
Update edX Reverification Block hash to the updated version

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -53,7 +53,7 @@ git+https://github.com/edx/edx-oauth2-provider.git@0.5.6#egg=oauth2-provider==0.
 git+https://github.com/edx/edx-lint.git@c5745631d2eee4e2efe8c31fa7b42fe2c12a0755#egg=edx_lint==0.2.7
 -e git+https://github.com/edx/xblock-utils.git@213a97a50276d6a2504d8133650b2930ead357a0#egg=xblock-utils
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
--e git+https://github.com/edx/edx-reverification-block.git@5e77525cab256a20a0cf182fcf5471369b284ff1#egg=edx-reverification-block
+-e git+https://github.com/edx/edx-reverification-block.git@5162ca169ca1486479e02f6ad2f538e6b8ae6f00#egg=edx-reverification-block
 git+https://github.com/edx/ecommerce-api-client.git@1.1.0#egg=ecommerce-api-client==1.1.0
 -e git+https://github.com/edx/edx-user-state-client.git@30c0ad4b9f57f8d48d6943eb585ec8a9205f4469#egg=edx-user-state-client
 -e git+https://github.com/edx/edx-organizations.git@release-2015-08-31#egg=edx-organizations


### PR DESCRIPTION
This PR will upgrade the version of `edx-reverification-block` from `5e77525cab256a20a0cf182fcf5471369b284ff1` to `5162ca169ca1486479e02f6ad2f538e6b8ae6f00`.

This upgrade will resolve the Bug that the statuses `Submitted, Approved, Denied` changed to close when due date have passed.

**Jira Ticket:** [ECOM-2225](https://openedx.atlassian.net/browse/ECOM-2225) **Addressed by:** [PR](https://github.com/edx/edx-reverification-block/pull/43)
