### PR TITLE
fix label for check/final check

### DIFF
--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -1424,8 +1424,8 @@ class CapaMixin(CapaFields):
         msg = _("Your answers have been saved.")
         if not self.max_attempts == 0:
             msg = _(
-                    "Your answers have been saved but not graded. Click {check} to grade them."
-                ).format(check=self.check_button_name())
+                    "Your answers have been saved but not graded. Click '{button_name}' to grade them."
+                ).format(button_name=self.check_button_name())
         return {
             'success': True,
             'msg': msg,

--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -1423,7 +1423,9 @@ class CapaMixin(CapaFields):
         self.track_function_unmask('save_problem_success', event_info)
         msg = _("Your answers have been saved.")
         if not self.max_attempts == 0:
-            msg = _("Your answers have been saved but not graded. Click '" + self.check_button_name() +  "' to grade them.")
+            msg = _(
+                    "Your answers have been saved but not graded. Click {check} to grade them."
+                ).format(check=self.check_button_name())
         return {
             'success': True,
             'msg': msg,

--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -1424,8 +1424,8 @@ class CapaMixin(CapaFields):
         msg = _("Your answers have been saved.")
         if not self.max_attempts == 0:
             msg = _(
-                    "Your answers have been saved but not graded. Click '{button_name}' to grade them."
-                ).format(button_name=self.check_button_name())
+                "Your answers have been saved but not graded. Click '{button_name}' to grade them."
+            ).format(button_name=self.check_button_name())
         return {
             'success': True,
             'msg': msg,

--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -1423,7 +1423,7 @@ class CapaMixin(CapaFields):
         self.track_function_unmask('save_problem_success', event_info)
         msg = _("Your answers have been saved.")
         if not self.max_attempts == 0:
-            msg = _("Your answers have been saved but not graded. Click 'Check' to grade them.")
+            msg = _("Your answers have been saved but not graded. Click '" + self.check_button_name() +  "' to grade them.")
         return {
             'success': True,
             'msg': msg,


### PR DESCRIPTION
**Description:** This label hadn't been updated to change its message depending on whether students were on their "final" submission attempt.

_Before PR_
![image](https://cloud.githubusercontent.com/assets/1844496/9791761/b7f8b5ba-57aa-11e5-9b9f-0df853f977b7.png)

_After PR_

![image](https://cloud.githubusercontent.com/assets/1844496/9791852/2a4688d6-57ab-11e5-9fb8-1382da1ff1cc.png)

**What JIRA ticket does this address (if any)?** None that I know of

**Who have you talked to at edX about this work?** Nobody yet! Simple PR, so I figured I'd just submit

**Why do you need this change?** This is a bug that one of the QA testers in my organization found, and the fix was located in the platform rather than within our theme.  It's a usability bug, and certainly is bound to come up for more organizations than just mine.

**What components are affected?** LMS

**What users are affected?** All edX students who have the opportunity to take an assessment with multiple possible submissions.

**Test instructions for manual testing:**
- Log into LMS as a student enrolled in a course that allows multiple submissions for a problem.  
- Fill out the problem, and hit "save" to save your answers before submitting
- Currently, when the final submission is sent in, the label at the bottom of the problem will always say "Your answers have been saved but not graded. Click 'Final Check' to grade them."  However, the button on the interface will say "Check" until the last submission.  
- Apply the changes from this PR, and confirm that the label changes as expected

**What are your concerns (the author’s) about the PR?**
It's possible that this isn't the best way to compose the string for this label, as it somewhat interferes with the _() _translate_ function.  If that's the case, I'll need some guidance.
