### PR TITLE
Remove unnecessary breadcrumbs for Teams tab

### DIFF
--- a/lms/djangoapps/teams/static/teams/js/spec/views/teams_tab_spec.js
+++ b/lms/djangoapps/teams/static/teams/js/spec/views/teams_tab_spec.js
@@ -58,6 +58,14 @@ define([
         afterEach(Backbone.history.stop);
 
         describe('Navigation', function () {
+            it('does not render breadcrumbs for the top level tabs', function() {
+                var teamsTabView = createTeamsTabView();
+                teamsTabView.router.navigate('#my-teams', {trigger: true});
+                expect(teamsTabView.$('.breadcrumbs').length).toBe(0);
+                teamsTabView.router.navigate('#browse', {trigger: true});
+                expect(teamsTabView.$('.breadcrumbs').length).toBe(0);
+            });
+
             it('does not interfere with anchor links to #content', function () {
                 var teamsTabView = createTeamsTabView();
                 teamsTabView.router.navigate('#content', {trigger: true});

--- a/lms/djangoapps/teams/static/teams/js/views/teams_tab.js
+++ b/lms/djangoapps/teams/static/teams/js/views/teams_tab.js
@@ -220,7 +220,6 @@
                                     { searchString: view.teamsCollection.searchString },
                                     true
                                 ),
-                                breadcrumbs: view.createBreadcrumbs(topic),
                                 showSortControls: false
                             });
                             view.render();
@@ -239,6 +238,7 @@
                             topic: topic,
                             title: gettext("Create a New Team"),
                             description: gettext("Create a new team if you can't find an existing team to join, or if you would like to learn with friends you know."),
+                            breadcrumbs: view.createBreadcrumbs(topic),
                             mainView: new TeamEditView({
                                 action: 'create',
                                 teamEvents: view.teamEvents,
@@ -272,6 +272,7 @@
                         editViewWithHeader = self.createViewWithHeader({
                             title: gettext("Edit Team"),
                             description: gettext("If you make significant changes, make sure you notify members of the team before making these changes."),
+                            breadcrumbs: self.createBreadcrumbs(topic, team),
                             mainView: view,
                             topic: topic,
                             team: team,
@@ -297,6 +298,7 @@
                         });
                         self.mainView = self.createViewWithHeader({
                                 mainView: view,
+                                breadcrumbs: self.createBreadcrumbs(topic, team),
                                 title: gettext("Membership"),
                                 description: gettext("You can remove members from this team, especially if they have not participated in the team's activity."),
                                 topic: topic,
@@ -366,7 +368,7 @@
                             headerActionsView: null, // TODO: add back SearchFieldView when search is enabled
                             title: options.title,
                             description: options.description,
-                            breadcrumbs: options.breadcrumbs
+                            breadcrumbs: this.createBreadcrumbs()
                         }),
                         searchUrl = 'topics/' + topic.get('id') + '/search';
                     // Listen to requests to sync the collection and redirect it as follows:
@@ -433,7 +435,8 @@
                                     mainView: view,
                                     subject: team,
                                     topic: topic,
-                                    headerActionsView: TeamProfileActionsView
+                                    headerActionsView: TeamProfileActionsView,
+                                    breadcrumbs: self.createBreadcrumbs(topic)
                                 }
                             )
                         );
@@ -470,9 +473,6 @@
                         breadcrumbs = options.breadcrumbs,
                         title = options.title || subject.get('name'),
                         description = options.description || subject.get('description');
-                    if (!breadcrumbs) {
-                        breadcrumbs = this.createBreadcrumbs(options.topic, options.team);
-                    }
                     return new TeamsHeaderModel({
                         breadcrumbs: breadcrumbs,
                         title: title,


### PR DESCRIPTION
## [TNL-3249](https://openedx.atlassian.net/browse/TNL-3249)

I've removed the default breadcrumbs that were always being added, and instead added explicit logic to create breadcrumbs for each team. I think this makes the logic clearer, as well as fixing the bug.
### Sandbox
- [x] http://andy-armstrong.sandbox.edx.org/courses/course-v1:AndyA+AA101+1/teams/#browse
### Testing
- [x] Unit, integration, acceptance tests as appropriate
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @dan-f 
- [x] Code review: @efischer19 
### Post-review
- [x] Squash commits
