### PR TITLE
Add course id contexts to teams events

### DIFF
--- a/common/test/acceptance/tests/lms/test_teams.py
+++ b/common/test/acceptance/tests/lms/test_teams.py
@@ -803,7 +803,6 @@ class BrowseTeamsWithinTopicTest(TeamsTabBase):
         events = [{
             'event_type': 'edx.team.searched',
             'event': {
-                'course_id': self.course_id,
                 'search_text': search_text,
                 'topic_id': self.topic['id'],
                 'number_of_results': 0
@@ -1043,15 +1042,11 @@ class CreateTeamTest(TeamFormActions):
 
         expected_events = [
             {
-                'event_type': 'edx.team.created',
-                'event': {
-                    'course_id': self.course_id,
-                }
+                'event_type': 'edx.team.created'
             },
             {
                 'event_type': 'edx.team.learner_added',
                 'event': {
-                    'course_id': self.course_id,
                     'add_method': 'added_on_create',
                 }
             }
@@ -1209,14 +1204,12 @@ class DeleteTeamTest(TeamFormActions):
                 {
                     'event_type': 'edx.team.deleted',
                     'event': {
-                        'course_id': self.course_id,
                         'team_id': self.team['id']
                     }
                 },
                 {
                     'event_type': 'edx.team.learner_removed',
                     'event': {
-                        'course_id': self.course_id,
                         'team_id': self.team['id'],
                         'remove_method': 'team_deleted',
                         'user_id': self.user_info['user_id']
@@ -1302,7 +1295,6 @@ class EditTeamTest(TeamFormActions):
             {
                 'event_type': 'edx.team.changed',
                 'event': {
-                    'course_id': self.course_id,
                     'team_id': self.team['id'],
                     'field': 'country',
                     'old': 'AF',
@@ -1313,7 +1305,6 @@ class EditTeamTest(TeamFormActions):
             {
                 'event_type': 'edx.team.changed',
                 'event': {
-                    'course_id': self.course_id,
                     'team_id': self.team['id'],
                     'field': 'name',
                     'old': self.team['name'],
@@ -1324,7 +1315,6 @@ class EditTeamTest(TeamFormActions):
             {
                 'event_type': 'edx.team.changed',
                 'event': {
-                    'course_id': self.course_id,
                     'team_id': self.team['id'],
                     'field': 'language',
                     'old': 'aa',
@@ -1335,7 +1325,6 @@ class EditTeamTest(TeamFormActions):
             {
                 'event_type': 'edx.team.changed',
                 'event': {
-                    'course_id': self.course_id,
                     'team_id': self.team['id'],
                     'field': 'description',
                     'old': self.team['description'],
@@ -1515,7 +1504,6 @@ class EditMembershipTest(TeamFormActions):
                 {
                     'event_type': 'edx.team.learner_removed',
                     'event': {
-                        'course_id': self.course_id,
                         'team_id': self.team['id'],
                         'remove_method': 'removed_by_admin',
                         'user_id': self.user_info['user_id']
@@ -1801,7 +1789,6 @@ class TeamPageTest(TeamsTabBase):
             {
                 'event_type': 'edx.team.learner_added',
                 'event': {
-                    'course_id': self.course_id,
                     'add_method': 'joined_from_team_view'
                 }
             }
@@ -1880,7 +1867,6 @@ class TeamPageTest(TeamsTabBase):
             {
                 'event_type': 'edx.team.learner_removed',
                 'event': {
-                    'course_id': self.course_id,
                     'remove_method': 'self_removal'
                 }
             }

--- a/lms/djangoapps/teams/tests/test_views.py
+++ b/lms/djangoapps/teams/tests/test_views.py
@@ -548,7 +548,6 @@ class TestListTeamsAPI(EventTestMixin, TeamAPITestCase):
 
         self.assert_event_emitted(
             'edx.team.searched',
-            course_id=unicode(self.test_course_2.id),
             search_text=text_search,
             topic_id=None,
             number_of_results=len(expected_team_names)
@@ -707,13 +706,11 @@ class TestCreateTeamAPI(EventTestMixin, TeamAPITestCase):
         self.assert_event_emitted(
             'edx.team.created',
             team_id=self._expected_team_id(team, 'fully-specified-team'),
-            course_id=unicode(self.test_course_1.id),
         )
 
         self.assert_event_emitted(
             'edx.team.learner_added',
             team_id=self._expected_team_id(team, 'fully-specified-team'),
-            course_id=unicode(self.test_course_1.id),
             user_id=self.users[creator].id,
             add_method='added_on_create'
         )
@@ -821,12 +818,10 @@ class TestDeleteTeamAPI(EventTestMixin, TeamAPITestCase):
             self.assert_event_emitted(
                 'edx.team.deleted',
                 team_id=self.solar_team.team_id,
-                course_id=unicode(self.test_course_1.id)
             )
             self.assert_event_emitted(
                 'edx.team.learner_removed',
                 team_id=self.solar_team.team_id,
-                course_id=unicode(self.test_course_1.id),
                 remove_method='team_deleted',
                 user_id=self.users['student_enrolled'].id
             )
@@ -840,12 +835,10 @@ class TestDeleteTeamAPI(EventTestMixin, TeamAPITestCase):
         self.assert_event_emitted(
             'edx.team.deleted',
             team_id=self.solar_team.team_id,
-            course_id=unicode(self.test_course_1.id)
         )
         self.assert_event_emitted(
             'edx.team.learner_removed',
             team_id=self.solar_team.team_id,
-            course_id=unicode(self.test_course_1.id),
             remove_method='team_deleted',
             user_id=self.users['student_enrolled'].id
         )
@@ -877,7 +870,6 @@ class TestUpdateTeamAPI(EventTestMixin, TeamAPITestCase):
             self.assert_event_emitted(
                 'edx.team.changed',
                 team_id=self.solar_team.team_id,
-                course_id=unicode(self.solar_team.course_id),
                 truncated=[],
                 field='name',
                 old=prev_name,
@@ -919,7 +911,6 @@ class TestUpdateTeamAPI(EventTestMixin, TeamAPITestCase):
             self.assert_event_emitted(
                 'edx.team.changed',
                 team_id=self.solar_team.team_id,
-                course_id=unicode(self.solar_team.course_id),
                 truncated=[],
                 field=key,
                 old=prev_value,
@@ -1220,7 +1211,6 @@ class TestCreateMembershipAPI(EventTestMixin, TeamAPITestCase):
                 'edx.team.learner_added',
                 team_id=self.solar_team.team_id,
                 user_id=self.users['student_enrolled_not_on_team'].id,
-                course_id=unicode(self.solar_team.course_id),
                 add_method=add_method
             )
         else:
@@ -1378,7 +1368,6 @@ class TestDeleteMembershipAPI(EventTestMixin, TeamAPITestCase):
             self.assert_event_emitted(
                 'edx.team.learner_removed',
                 team_id=self.solar_team.team_id,
-                course_id=unicode(self.solar_team.course_id),
                 user_id=self.users['student_enrolled'].id,
                 remove_method='removed_by_admin'
             )
@@ -1396,7 +1385,6 @@ class TestDeleteMembershipAPI(EventTestMixin, TeamAPITestCase):
         self.assert_event_emitted(
             'edx.team.learner_removed',
             team_id=self.solar_team.team_id,
-            course_id=unicode(self.solar_team.course_id),
             user_id=self.users['student_enrolled'].id,
             remove_method='self_removal'
         )


### PR DESCRIPTION
## [TNL-3248](https://openedx.atlassian.net/browse/TNL-3248)

This PR updates the team API analytics events to directly inject the `course_id` into the event context instead of leaving it in the event data as a separate field.

Note: we aren't testing the course id injection directly, but it should cause test failures if we are not passing through a valid `CourseKey`
### Testing
- [x] Unit, integration, acceptance tests as appropriate
- [x] Analytics
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @andy-armstrong 
- [x] Code review: @efischer19 
### Post-review
- [x] Squash commits
