### PR TITLE
Prevent over-expansion of team memberships.

### DIFF
--- a/lms/djangoapps/teams/serializers.py
+++ b/lms/djangoapps/teams/serializers.py
@@ -112,7 +112,8 @@ class MembershipSerializer(serializers.ModelSerializer):
             view_name='teams_detail',
             read_only=True,
         ),
-        expanded_serializer=CourseTeamSerializer(read_only=True)
+        expanded_serializer=CourseTeamSerializer(read_only=True),
+        exclude_expand_fields={'user'},
     )
 
     class Meta(object):

--- a/lms/djangoapps/teams/static/teams/js/spec_helpers/team_spec_helpers.js
+++ b/lms/djangoapps/teams/static/teams/js/spec_helpers/team_spec_helpers.js
@@ -68,8 +68,11 @@ define([
         return _.map(_.range(startIndex, stopIndex + 1), function (i) {
             return {
                 user: {
-                    'username': testUser,
-                    'url': 'https://openedx.example.com/api/user/v1/accounts/' + testUser
+                    username: testUser,
+                    url: 'https://openedx.example.com/api/user/v1/accounts/' + testUser,
+                    profile_image: {
+                        image_url_small: 'test_profile_image'
+                    }
                 },
                 team: teams[i-1]
             };

--- a/lms/djangoapps/teams/static/teams/js/views/team_card.js
+++ b/lms/djangoapps/teams/static/teams/js/views/team_card.js
@@ -32,11 +32,13 @@
 
             initialize: function (options) {
                 this.maxTeamSize = options.maxTeamSize;
+                this.memberships = options.memberships;
             },
 
             render: function () {
-                var allMemberships = _(this.model.get('membership'))
-                        .sortBy(function (member) {return new Date(member.last_activity_at);}).reverse(),
+                var allMemberships = _(this.memberships).sortBy(function (member) {
+                    return new Date(member.last_activity_at);
+                }).reverse(),
                     displayableMemberships = allMemberships.slice(0, 5),
                     maxMemberCount = this.maxTeamSize;
                 this.$el.html(this.template({
@@ -97,7 +99,7 @@
                 CardView.prototype.initialize.apply(this, arguments);
                 // TODO: show last activity detail view
                 this.detailViews = [
-                    new TeamMembershipView({model: this.teamModel(), maxTeamSize: this.maxTeamSize}),
+                    new TeamMembershipView({memberships: this.getMemberships(), maxTeamSize: this.maxTeamSize}),
                     new TeamCountryLanguageView({
                         model: this.teamModel(),
                         countries: this.countries,
@@ -105,11 +107,23 @@
                     }),
                     new TeamActivityView({date: this.teamModel().get('last_activity_at')})
                 ];
+                this.model.on('change:membership', function () {
+                    this.detailViews[0].memberships = this.getMemberships();
+                }, this);
             },
 
             teamModel: function () {
                 if (this.model.has('team')) { return this.model.get('team'); }
                 return this.model;
+            },
+
+            getMemberships: function () {
+                if (this.model.has('team')) {
+                    return [this.model.attributes];
+                }
+                else {
+                    return this.model.get('membership');
+                }
             },
 
             configuration: 'list_card',

--- a/lms/djangoapps/teams/tests/test_serializers.py
+++ b/lms/djangoapps/teams/tests/test_serializers.py
@@ -3,18 +3,24 @@
 Tests for custom Teams Serializers.
 """
 from django.core.paginator import Paginator
+from django.test.client import RequestFactory
 
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from student.tests.factories import CourseEnrollmentFactory, UserFactory
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
-from lms.djangoapps.teams.tests.factories import CourseTeamFactory
+from lms.djangoapps.teams.tests.factories import CourseTeamFactory, CourseTeamMembershipFactory
 from lms.djangoapps.teams.serializers import (
-    BaseTopicSerializer, PaginatedTopicSerializer, BulkTeamCountPaginatedTopicSerializer,
-    TopicSerializer, add_team_count
+    BaseTopicSerializer,
+    PaginatedTopicSerializer,
+    BulkTeamCountPaginatedTopicSerializer,
+    TopicSerializer,
+    MembershipSerializer,
+    add_team_count
 )
 
 
-class TopicTestCase(ModuleStoreTestCase):
+class SerializerTestCase(SharedModuleStoreTestCase):
     """
     Base test class to set up a course with topics
     """
@@ -22,7 +28,7 @@ class TopicTestCase(ModuleStoreTestCase):
         """
         Set up a course with a teams configuration.
         """
-        super(TopicTestCase, self).setUp()
+        super(SerializerTestCase, self).setUp()
         self.course = CourseFactory.create(
             teams_configuration={
                 "max_team_size": 10,
@@ -31,7 +37,46 @@ class TopicTestCase(ModuleStoreTestCase):
         )
 
 
-class BaseTopicSerializerTestCase(TopicTestCase):
+class MembershipSerializerTestCase(SerializerTestCase):
+    """
+    Tests for the membership serializer.
+    """
+
+    def setUp(self):
+        super(MembershipSerializerTestCase, self).setUp()
+        self.team = CourseTeamFactory.create(
+            course_id=self.course.id,
+            topic_id=self.course.teams_topics[0]['id']
+        )
+        self.user = UserFactory.create()
+        CourseEnrollmentFactory.create(user=self.user, course_id=self.course.id)
+        self.team_membership = CourseTeamMembershipFactory.create(team=self.team, user=self.user)
+
+    def test_membership_serializer_expand_user_and_team(self):
+        """Verify that the serializer only expands the user and team one level."""
+        data = MembershipSerializer(self.team_membership, context={
+            'expand': [u'team', u'user'],
+            'request': RequestFactory().get('/api/team/v0/team_membership')
+        }).data
+        username = self.user.username
+        self.assertEqual(data['user'], {
+            'url': 'http://testserver/api/user/v1/accounts/' + username,
+            'username': username,
+            'profile_image': {
+                'image_url_full': 'http://testserver/static/default_500.png',
+                'image_url_large': 'http://testserver/static/default_120.png',
+                'image_url_medium': 'http://testserver/static/default_50.png',
+                'image_url_small': 'http://testserver/static/default_30.png',
+                'has_image': False
+            }
+        })
+        self.assertEqual(data['team']['membership'][0]['user'], {
+            'url': 'http://testserver/api/user/v1/accounts/' + username,
+            'username': username
+        })
+
+
+class BaseTopicSerializerTestCase(SerializerTestCase):
     """
     Tests for the `BaseTopicSerializer`, which should not serialize team count
     data.
@@ -46,7 +91,7 @@ class BaseTopicSerializerTestCase(TopicTestCase):
             )
 
 
-class TopicSerializerTestCase(TopicTestCase):
+class TopicSerializerTestCase(SerializerTestCase):
     """
     Tests for the `TopicSerializer`, which should serialize team count data for
     a single topic.
@@ -95,7 +140,7 @@ class TopicSerializerTestCase(TopicTestCase):
             )
 
 
-class BasePaginatedTopicSerializerTestCase(TopicTestCase):
+class BasePaginatedTopicSerializerTestCase(SerializerTestCase):
     """
     Base class for testing the two paginated topic serializers.
     """


### PR DESCRIPTION
## [TNL-3202](https://openedx.atlassian.net/browse/TNL-3202)

Fixes team memberships have their users expanded both in the `user` field, and recursively in the `team` field. This prevents the serializer from making excessive database queries.

Note that this does require some front end changes, since we're passing different information along now. This led me to the messy pile that is `team_card.js`, which for some reason tries to use (bad) ad-hoc polymorphism over both team collections and team membership collections. I've been working for a while to refactor it, but I haven't gotten anywhere yet. Since this should really be in by tomorrow morning I've just hacked around the messiness. I do plan on getting back to this though; I intend to have a refactored version in next week's release.
### Testing
- [x] Unit, integration, acceptance tests as appropriate
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @dan-f 
- [x] Code review: @andy-armstrong 

FYI @bderusha 
### Post-review
- [ ] Squash commits
