### PR TITLE
add ability to delete published orphans from courses (PLAT-832)

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/tests/test_delete_orphans.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_delete_orphans.py
@@ -3,6 +3,8 @@
 from django.core.management import call_command
 from contentstore.tests.test_orphan import TestOrphanBase
 
+from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore import ModuleStoreEnum
 
 class TestDeleteOrphan(TestOrphanBase):
     """
@@ -11,7 +13,7 @@ class TestDeleteOrphan(TestOrphanBase):
     """
     def setUp(self):
         super(TestDeleteOrphan, self).setUp()
-        self.course_id = self.course.id.to_deprecated_string()
+        self.course_id = unicode(self.course.id)
 
     def test_delete_orphans_no_commit(self):
         """
@@ -38,3 +40,45 @@ class TestDeleteOrphan(TestOrphanBase):
         self.assertFalse(self.store.has_item(self.course.id.make_usage_key('vertical', 'OrphanVert')))
         self.assertFalse(self.store.has_item(self.course.id.make_usage_key('chapter', 'OrphanChapter')))
         self.assertFalse(self.store.has_item(self.course.id.make_usage_key('html', 'OrphanHtml')))
+
+    def test_delete_orphans_published_branch(self):
+        """
+        Tests that if there are orphans only on the published branch,
+        running delete orphans with a course key that specifies
+        the published branch will delete the published orphan
+        """
+        course = CourseFactory.create(default_store=ModuleStoreEnum.Type.split)
+        # create an orphan
+        orphan = self.store.create_item(self.user.id, course.id, 'html', "OrphanHtml")
+        self.store.publish(orphan.location, self.user.id)
+
+        # grab the published branch of the course
+        published_branch = course.id.for_branch(
+            ModuleStoreEnum.BranchName.published
+        )
+
+        # assert that this orphan is present in both branches
+        self.assertOrphanCount(course.id, 1)
+        self.assertOrphanCount(published_branch, 1)
+
+        # delete this orphan from the draft branch without
+        # auto-publishing this change to the published draft
+        self.store.delete_item(
+            orphan.location, self.user.id, skip_auto_publish=True
+        )
+
+        # now there should be no orphans in the draft branch, but
+        # there should be one in published
+        self.assertOrphanCount(course.id, 0)
+        self.assertOrphanCount(published_branch, 1)
+
+        # call delete orphans, specifying the published branch
+        # of the course
+        call_command('delete_orphans', unicode(published_branch), 'commit')
+
+        # now all orphans should be deleted
+        self.assertOrphanCount(course.id, 0)
+        self.assertOrphanCount(published_branch, 0)
+
+    def assertOrphanCount(self, course_key, number):
+        self.assertEqual(len(self.store.get_orphans(course_key)), number)

--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -702,10 +702,14 @@ def _delete_orphans(course_usage_key, user_id, commit=False):
     """
     store = modulestore()
     items = store.get_orphans(course_usage_key)
+    branch = course_usage_key.branch
     if commit:
         for itemloc in items:
-            # need to delete all versions
-            store.delete_item(itemloc, user_id, revision=ModuleStoreEnum.RevisionOption.all)
+            revision = ModuleStoreEnum.RevisionOption.all
+            # specify branches when deleting orphans
+            if branch == ModuleStoreEnum.BranchName.published:
+                revision = ModuleStoreEnum.RevisionOption.published_only
+            store.delete_item(itemloc, user_id, revision=revision)
     return [unicode(item) for item in items]
 
 

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split_draft.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split_draft.py
@@ -175,7 +175,7 @@ class DraftVersioningModuleStore(SplitMongoModuleStore, ModuleStoreDraftAndPubli
             self._auto_publish_no_children(parent_usage_key, item.location.category, user_id, **kwargs)
             return item
 
-    def delete_item(self, location, user_id, revision=None, **kwargs):
+    def delete_item(self, location, user_id, revision=None, skip_auto_publish=False, **kwargs):
         """
         Delete the given item from persistence. kwargs allow modulestore specific parameters.
 
@@ -217,7 +217,8 @@ class DraftVersioningModuleStore(SplitMongoModuleStore, ModuleStoreDraftAndPubli
                 if (
                         branch == ModuleStoreEnum.BranchName.draft and
                         branched_location.block_type in (DIRECT_ONLY_CATEGORIES + ['vertical']) and
-                        parent_loc
+                        parent_loc and
+                        not skip_auto_publish
                 ):
                     # will publish if its not an orphan
                     self.publish(parent_loc.version_agnostic(), user_id, blacklist=EXCLUDE_ALL, **kwargs)


### PR DESCRIPTION
This PR changes `_delete_orphans` to allow the ability to specify whether we want to delete orphans just from the published branch of a given course. This is useful for combating bugs that may arise as a result of [PLAT-799](https://openedx.atlassian.net/browse/PLAT-799), such as [PLAT-832](https://openedx.atlassian.net/browse/PLAT-832).

@waheedahmed 
@cpennington 
May you please review?
