### PR TITLE
Remove "responsive" check before deciding whether to add a viewport tag.

### DIFF
--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -14,9 +14,7 @@ from branding import api as branding_api
 <head dir="${static.dir_rtl()}">
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    % if responsive:
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    % endif
 
 ## Define a couple of helper functions to make life easier when
 ## embedding theme conditionals into templates. All inheriting


### PR DESCRIPTION
We also need to ensure that this tag is presented when loading xblocks
via the mobile app anyway. Since we're fine just giving responsive
content to everyone we don't need this check any more.

JIRA: https://openedx.atlassian.net/browse/MA-960?filter=13805
