### PR TITLE
Fix add component buttons to be backward compatible

### DIFF
--- a/cms/static/js/spec/views/pages/container_spec.js
+++ b/cms/static/js/spec/views/pages/container_spec.js
@@ -574,6 +574,25 @@ define(["jquery", "underscore", "underscore.string", "common/js/spec_helpers/aja
                             });
                         });
 
+                        it('also works for older-style add component links', function () {
+                            // Some third party xblocks (problem-builder in particular) expect add
+                            // event handlers on custom <a> add buttons which is what the platform
+                            // used to use instead of <button>s.
+                            // This can be removed once there is a proper API that XBlocks can use
+                            // to add children or allow authors to add children.
+                            renderContainerPage(this, mockContainerXBlockHtml);
+                            $(".add-xblock-component-button").each(function() {
+                                var htmlAsLink = $($(this).prop('outerHTML').replace(/(<\/?)button/g, "$1a"));
+                                $(this).replaceWith(htmlAsLink);
+                            });
+                            $(".add-xblock-component-button").first().click();
+                            EditHelpers.verifyXBlockRequest(requests, {
+                                "category": "discussion",
+                                "type": "discussion",
+                                "parent_locator": "locator-group-A"
+                            });
+                        });
+
                         it('shows a notification while creating', function () {
                             var notificationSpy = EditHelpers.createNotificationSpy();
                             renderContainerPage(this, mockContainerXBlockHtml);

--- a/cms/static/js/views/components/add_xblock.js
+++ b/cms/static/js/views/components/add_xblock.js
@@ -6,8 +6,8 @@ define(["jquery", "underscore", "gettext", "js/views/baseview", "common/js/compo
     function ($, _, gettext, BaseView, ViewUtils, AddXBlockButton, AddXBlockMenu) {
         var AddXBlockComponent = BaseView.extend({
             events: {
-                'click .new-component .new-component-type button.multiple-templates': 'showComponentTemplates',
-                'click .new-component .new-component-type button.single-template': 'createNewComponent',
+                'click .new-component .new-component-type .multiple-templates': 'showComponentTemplates',
+                'click .new-component .new-component-type .single-template': 'createNewComponent',
                 'click .new-component .cancel-button': 'closeNewComponent',
                 'click .new-component-templates .new-component-template .button-component': 'createNewComponent',
                 'click .new-component-templates .cancel-button': 'closeNewComponent'


### PR DESCRIPTION
This is a hotfix for an issue reported on a DavidsonNext course (`course-v1:DavidsonNext+Phy_APccx+2T2015` on edx.org studio): The changes in #9402 ([TNL-2153](https://openedx.atlassian.net/browse/TNL-2153)) broke editing of `problem-builder` blocks.

**Details**: Since there is no usable API for XBlocks to add children to themselves, and the problem-builder XBlock requires authors to configure it by adding child blocks, it renders its own "Add" buttons:
![screen shot 2015-09-11 at 1 23 13 pm](https://cloud.githubusercontent.com/assets/945577/9825461/46150726-5888-11e5-953f-3bfe08750a1d.png)

We used the same HTML as Studio uses, so that the same JS event logic would detect clicks on the buttons and add new children appropriately.

However, when the buttons were changed from `<a>` elements to `<button>`, the event handlers no longer listened for clicks on these custom buttons, and child blocks can no longer be added. Adding children is now impossible.

**Proposed fix**: This fix simply changes the event registration logic to not be specific to the type of HTML element. It's a simple fix and includes a [somewhat hacky] test.
### "FAQ"

**Why not just change your xblock to use `<button>` instead of `<a>`?** Because we are actively developing it and regularly pushing new versions to clients who are on Cypress as well as edx.org. If we fix it for edx.org it will break for users on Cypress. It will be hard to maintain two separate branches that must be kept separate and I'd rather avoid that for now.

**Why not just call the JavaScript `createNewComponent` method directly from your xblock's JS?**
That method is not accessible to custom JavaScript unfortunately.

**Why not change your xblock to use the `add-xblock-component-button-tpl` template?** That is likely to be more compatible, but only really moves the compatibility issue up one level of abstraction. It could still potentially break at any time whenever someone decides to change the HTML/CSS used in Studio. Also, the template currently requires the buttons to have a very short label and one of a few pre-existing icons, and adapting our block to that template will be quite a bit of work.

The only real long-term solution here is to add a stable API to studio that XBlocks can use to declare how/when children can be added.

CC @clytwynec @antoviaque @Kelketek @e-kolpakov @doctoryes 
