### PR TITLE
Add logic to handle not searching when focus is passed to the clear search button

### DIFF
--- a/common/static/common/js/components/views/search_field.js
+++ b/common/static/common/js/components/views/search_field.js
@@ -14,12 +14,15 @@
                     'submit .search-form': 'performSearch',
                     'blur .search-form': 'onFocusOut',
                     'keyup .search-field': 'refreshState',
-                    'click .action-clear': 'clearSearch'
+                    'click .action-clear': 'clearSearch',
+                    'mouseover .action-clear': 'setMouseOverState',
+                    'mouseout .action-clear': 'setMouseOutState',
                 },
 
                 initialize: function(options) {
                     this.type = options.type;
                     this.label = options.label;
+                    this.mouseOverClear = false;
                 },
 
                 refreshState: function() {
@@ -43,10 +46,18 @@
                     return this;
                 },
 
+                setMouseOverState: function(event) {
+                    this.mouseOverClear = true;
+                },
+
+                setMouseOutState: function(event) {
+                    this.mouseOverClear = false;
+                },
+
                 onFocusOut: function(event) {
                     // If the focus is going anywhere but the clear search
                     // button then treat it as a request to search.
-                    if (!$(event.relatedTarget).hasClass('action-clear')) {
+                    if (!this.mouseOverClear) {
                         this.performSearch(event);
                     }
                 },


### PR DESCRIPTION
## [TNL-3238](https://openedx.atlassian.net/browse/TNL-3238)

Explicitly track when the clear-search element is being moused over so we don't search when focus is lost when it is clicked.
### Sandbox
- [x] [Sandbox](http://bderusha.sandbox.edx.org/courses/course-v1:edx+TEAM101+2015_09_14/teams/#browse) Log in as staff
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @andy-armstrong 
- [x] Code review: @peter-fogg 
### Post-review
- [ ] Squash commits
