### PR TITLE
Fix duplicate calls to search API

### DIFF
--- a/common/static/common/js/components/collections/paging_collection.js
+++ b/common/static/common/js/components/collections/paging_collection.js
@@ -90,16 +90,20 @@
              */
             setPage: function (page) {
                 var oldPage = this.currentPage,
-                    self = this;
-                return this.goTo(page - (this.isZeroIndexed ? 1 : 0), {reset: true}).then(
+                    self = this,
+                    deferred = $.Deferred();
+                this.goTo(page - (this.isZeroIndexed ? 1 : 0), {reset: true}).then(
                     function () {
                         self.isStale = false;
                         self.trigger('page_changed');
+                        deferred.resolve();
                     },
                     function () {
                         self.currentPage = oldPage;
+                        deferred.fail();
                     }
                 );
+                return deferred.promise();
             },
 
 

--- a/common/test/acceptance/tests/helpers.py
+++ b/common/test/acceptance/tests/helpers.py
@@ -334,7 +334,7 @@ class EventsTestMixin(TestCase):
                 captured_events.append(event)
 
     @contextmanager
-    def assert_events_match_during(self, event_filter=None, expected_events=None):
+    def assert_events_match_during(self, event_filter=None, expected_events=None, in_order=True):
         """
         Context manager that ensures that events matching the `event_filter` and `expected_events` are emitted.
 
@@ -351,7 +351,7 @@ class EventsTestMixin(TestCase):
         with self.capture_events(event_filter, len(expected_events), captured_events):
             yield
 
-        self.assert_events_match(expected_events, captured_events)
+        self.assert_events_match(expected_events, captured_events, in_order=in_order)
 
     def wait_for_events(self, start_time=None, event_filter=None, number_of_matches=1, timeout=None):
         """
@@ -477,17 +477,29 @@ class EventsTestMixin(TestCase):
 
         self.assertEquals(len(matching_events), 0, description)
 
-    def assert_events_match(self, expected_events, actual_events):
+    def assert_events_match(self, expected_events, actual_events, in_order=True):
+        """Assert that each actual event matches one of the expected events.
+
+        Args:
+            expected_events (List): a list of dicts representing the expected events.
+            actual_events (List): a list of dicts that were actually recorded.
+            in_order (bool): if True then the events must be in the same order (defaults to True).
         """
-        Assert that each item in the expected events sequence matches its counterpart at the same index in the actual
-        events sequence.
-        """
-        for expected_event, actual_event in zip(expected_events, actual_events):
-            assert_event_matches(
-                expected_event,
-                actual_event,
-                tolerate=EventMatchTolerates.lenient()
-            )
+        if in_order:
+            for expected_event, actual_event in zip(expected_events, actual_events):
+                assert_event_matches(
+                    expected_event,
+                    actual_event,
+                    tolerate=EventMatchTolerates.lenient()
+                )
+        else:
+            for expected_event in expected_events:
+                actual_event = next(event for event in actual_events if is_matching_event(expected_event, event))
+                assert_event_matches(
+                    expected_event,
+                    actual_event or {},
+                    tolerate=EventMatchTolerates.lenient()
+                )
 
     def relative_path_to_absolute_uri(self, relative_path):
         """Return an aboslute URI given a relative path taking into account the test context."""

--- a/common/test/acceptance/tests/lms/test_teams.py
+++ b/common/test/acceptance/tests/lms/test_teams.py
@@ -9,7 +9,6 @@ from dateutil.parser import parse
 import ddt
 from nose.plugins.attrib import attr
 from uuid import uuid4
-from unittest import skip
 
 from ..helpers import EventsTestMixin, UniqueCourseTest
 from ...fixtures import LMS_BASE_URL
@@ -783,7 +782,6 @@ class BrowseTeamsWithinTopicTest(TeamsTabBase):
         self.browse_teams_page.click_browse_all_teams_link()
         self.assertTrue(self.topics_page.is_browser_on_page())
 
-    @skip("Skip until TNL-3198 (searching teams makes two AJAX requests) is resolved")
     def test_search(self):
         """
         Scenario: User should be able to search for a team
@@ -794,6 +792,7 @@ class BrowseTeamsWithinTopicTest(TeamsTabBase):
         And the search header should be shown
         And 0 results should be shown
         And my browser should fire a page viewed event for the search page
+        And a searched event should have been fired
         """
         # Note: all searches will return 0 results with the mock search server
         # used by Bok Choy.
@@ -801,21 +800,21 @@ class BrowseTeamsWithinTopicTest(TeamsTabBase):
         self.create_teams(self.topic, 5)
         self.browse_teams_page.visit()
         events = [{
-            'event_type': 'edx.team.searched',
-            'event': {
-                'search_text': search_text,
-                'topic_id': self.topic['id'],
-                'number_of_results': 0
-            }
-        }, {
             'event_type': 'edx.team.page_viewed',
             'event': {
                 'page_name': 'search-teams',
                 'topic_id': self.topic['id'],
                 'team_id': None
             }
+        }, {
+            'event_type': 'edx.team.searched',
+            'event': {
+                'search_text': search_text,
+                'topic_id': self.topic['id'],
+                'number_of_results': 0
+            }
         }]
-        with self.assert_events_match_during(self.only_team_events, expected_events=events):
+        with self.assert_events_match_during(self.only_team_events, expected_events=events, in_order=False):
             search_results_page = self.browse_teams_page.search(search_text)
         self.verify_search_header(search_results_page, search_text)
         self.assertTrue(search_results_page.get_pagination_header_text().startswith('Showing 0 out of 0 total'))

--- a/lms/djangoapps/teams/static/teams/js/spec/views/teams_spec.js
+++ b/lms/djangoapps/teams/static/teams/js/spec/views/teams_spec.js
@@ -24,7 +24,9 @@ define([
         it('can render itself', function () {
             var testTeamData = TeamSpecHelpers.createMockTeamData(1, 5),
                 teamsView = createTeamsView({
-                    teams: TeamSpecHelpers.createMockTeams(testTeamData)
+                    teams: TeamSpecHelpers.createMockTeams({
+                        results: testTeamData
+                    })
                 });
 
             expect(teamsView.$('.teams-paging-header').text()).toMatch('Showing 1-5 out of 6 total');

--- a/lms/djangoapps/teams/static/teams/js/spec/views/topic_teams_spec.js
+++ b/lms/djangoapps/teams/static/teams/js/spec/views/topic_teams_spec.js
@@ -44,7 +44,9 @@ define([
         it('can render itself', function () {
             var testTeamData = TeamSpecHelpers.createMockTeamData(1, 5),
                 teamsView = createTopicTeamsView({
-                    teams: TeamSpecHelpers.createMockTeams(testTeamData),
+                    teams: TeamSpecHelpers.createMockTeams({
+                        results: testTeamData
+                    }),
                     teamMemberships: TeamSpecHelpers.createMockTeamMemberships([])
                 });
 

--- a/lms/djangoapps/teams/static/teams/js/spec_helpers/team_spec_helpers.js
+++ b/lms/djangoapps/teams/static/teams/js/spec_helpers/team_spec_helpers.js
@@ -43,18 +43,22 @@ define([
         });
     };
 
-    var createMockTeams = function(teamData) {
-        if (!teamData) {
-            teamData = createMockTeamData(1, 5);
-        }
-        return new TeamCollection(
+    var createMockTeamsResponse = function(options) {
+        return _.extend(
             {
                 count: 6,
                 num_pages: 2,
                 current_page: 1,
                 start: 0,
-                results: teamData
+                results: createMockTeamData(1, 5)
             },
+            options
+        );
+    };
+
+    var createMockTeams = function(options) {
+        return new TeamCollection(
+            createMockTeamsResponse(options),
             {
                 teamEvents: teamEvents,
                 course_id: testCourseID,
@@ -325,6 +329,7 @@ define([
         testTeamDiscussionID: testTeamDiscussionID,
         testContext: testContext,
         createMockTeamData: createMockTeamData,
+        createMockTeamsResponse: createMockTeamsResponse,
         createMockTeams: createMockTeams,
         createMockTeamMembershipsData: createMockTeamMembershipsData,
         createMockTeamMemberships: createMockTeamMemberships,

--- a/lms/djangoapps/teams/static/teams/js/views/teams_tab.js
+++ b/lms/djangoapps/teams/static/teams/js/views/teams_tab.js
@@ -214,6 +214,7 @@
                             view.mainView = view.createTeamsListView({
                                 topic: topic,
                                 collection: view.teamsCollection,
+                                breadcrumbs: view.createBreadcrumbs(topic),
                                 title: gettext('Team Search'),
                                 description: interpolate(
                                     gettext('Showing results for "%(searchString)s"'),
@@ -337,6 +338,7 @@
                                         var teamsView = view.createTeamsListView({
                                             topic: topic,
                                             collection: collection,
+                                            breadcrumbs: view.createBreadcrumbs(),
                                             showSortControls: true
                                         });
                                         deferred.resolve(teamsView);
@@ -368,7 +370,7 @@
                             headerActionsView: searchFieldView,
                             title: options.title,
                             description: options.description,
-                            breadcrumbs: this.createBreadcrumbs()
+                            breadcrumbs: options.breadcrumbs
                         }),
                         searchUrl = 'topics/' + topic.get('id') + '/search';
                     // Listen to requests to sync the collection and redirect it as follows:
@@ -378,6 +380,11 @@
                     // 3. Otherwise, do nothing and remain on the current page.
                     // Note: Backbone makes this a no-op if redirecting to the current page.
                     this.listenTo(collection, 'sync', function() {
+                        // Clear the stale flag here as by definition the collection is up-to-date,
+                        // and the flag itself isn't guaranteed to be cleared yet. This is to ensure
+                        // that the collection doesn't unnecessarily get refreshed again.
+                        collection.isStale = false;
+
                         if (collection.searchString) {
                             Backbone.history.navigate(searchUrl, {trigger: true});
                         } else if (Backbone.history.getFragment() === searchUrl) {


### PR DESCRIPTION
https://openedx.atlassian.net/browse/TNL-3198

In order to fix the test, I had to introduce an optional parameter to allow the expected events to be fired in any order. There is no way to guarantee that the client-side event will happen before or after the server-side event.

Also fixed a regression with the search breadcrumbs where it wasn't possible to navigate back to the full list.
### Sandbox
- [x] http://andy-armstrong.sandbox.edx.org/courses/course-v1:AndyA+AA101+1/teams/#topics/solar
### Testing
- [x] Unit, integration, acceptance tests as appropriate
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @efischer19 
- [x] Code review: @peter-fogg

FYI: @bderusha @dan-f 
### Post-review
- [x] Squash commits
