### PR TITLE
Fix translate enrollment emails

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -239,3 +239,4 @@ Mirjam Škarica <mirjamskarica@gmail.com>
 Saleem Latif <saleem@edx.org>
 Julien Paillé <julien.paille@openfun.fr>
 Michael Frey <mfrey@edx.org>
+Xaver Y.R. Chen <yrchen@ATCity.org>

--- a/lms/djangoapps/instructor/enrollment.py
+++ b/lms/djangoapps/instructor/enrollment.py
@@ -417,9 +417,11 @@ def render_message_to_string(subject_template, message_template, param_dict, lan
     Returns two strings that correspond to the rendered, translated email
     subject and message.
     """
+    # Override the email language with the user's preference, if it is set
     if language is not None:
         with override_language(language):
             return get_subject_and_message(subject_template, message_template, param_dict)
+    # If language is None, this is a new user so we want to deliver the email in the platform language
     else:
         return get_subject_and_message(subject_template, message_template, param_dict)
 

--- a/lms/djangoapps/instructor/enrollment.py
+++ b/lms/djangoapps/instructor/enrollment.py
@@ -417,7 +417,10 @@ def render_message_to_string(subject_template, message_template, param_dict, lan
     Returns two strings that correspond to the rendered, translated email
     subject and message.
     """
-    with override_language(language):
+    if language is not None:
+        with override_language(language):
+            return get_subject_and_message(subject_template, message_template, param_dict)
+    else:
         return get_subject_and_message(subject_template, message_template, param_dict)
 
 

--- a/lms/djangoapps/instructor/tests/test_enrollment.py
+++ b/lms/djangoapps/instructor/tests/test_enrollment.py
@@ -756,6 +756,15 @@ class TestRenderMessageToString(SharedModuleStoreTestCase):
             self.assertIn("You have been", subject)
             self.assertIn("You have been", message)
 
+    def test_platform_language_is_used_for_new_user(self):
+        # simulate a new user
+        subject, message = self.get_subject_and_message(None)
+        language_after_rendering = get_language()
+
+        self.assertIn("You have been invited in platform language", subject)
+        self.assertIn("You have been invited in platform language", message)
+        self.assertEqual(settings.LANGUAGE_CODE, language_after_rendering)
+
     @patch.dict('django.conf.settings.FEATURES', {'CUSTOM_COURSES_EDX': True})
     def test_render_enrollment_message_ccx_members(self):
         """


### PR DESCRIPTION
Thanks for #6082 . We have localized enrollment emails in the student's language!

For now, If no user corresponds to a given email address (new user), the language argument will be pass as None and activate a NullTranslations() instance.

When the system already been localized that the language code is not "en", it will be a problem because the translation has been deactivated and fallback to use the original strings (in English).
