### PR TITLE
Right align text above action buttons

### DIFF
--- a/lms/static/sass/views/_teams.scss
+++ b/lms/static/sass/views/_teams.scss
@@ -575,7 +575,10 @@
 
   .join-team-message {
     @extend %t-copy-sub1;
+    @include text-align(right);
     color: $gray-l1;
+    display: block;
+    margin-bottom: ($baseline/4);
   }
 
   .team-actions {


### PR DESCRIPTION
## [TNL-3234](https://openedx.atlassian.net/browse/TNL-3234)

Align text above the 'edit team' button

Before:
![screen shot 2015-09-14 at 1 56 19 pm](https://cloud.githubusercontent.com/assets/444835/9857648/b21a78ee-5ae9-11e5-9135-3295a515bc37.png)

After:
![screen shot 2015-09-14 at 1 56 29 pm](https://cloud.githubusercontent.com/assets/444835/9857641/aa3adc0e-5ae9-11e5-8f6d-a39c00897f69.png)
### Sandbox
- [x] [Sandbox](http://bderusha.sandbox.edx.org/courses/course-v1:edx+TEAM101+2015_09_14/teams/#topics/topic0) Log in as staff
### Testing
- [x] RTL
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @efischer19
- [x] Code review: @andy-armstrong 
- [x] Product review: @explorerleslie 

FYI - @frrrances 
### Post-review
- [x] Squash commits
