### PR TITLE
Re-disabling flaky tests

### DIFF
--- a/common/test/acceptance/tests/lms/test_lms_instructor_dashboard.py
+++ b/common/test/acceptance/tests/lms/test_lms_instructor_dashboard.py
@@ -222,6 +222,7 @@ class ProctoredExamsTest(BaseInstructorDashboardTest):
         # Start the proctored exam.
         self.courseware_page.start_timed_exam()
 
+    @flaky  # TODO fix this once more, see SOL-1183 and SOL-1182
     def test_can_add_remove_allowance(self):
         """
         Make sure that allowances can be added and removed.


### PR DESCRIPTION
This test is still sporadically failing, marking as flaky so PR
builds go more smoothly until it is fixed.

See https://build.testeng.edx.org/job/edx-platform-bok-choy-pr/4587/testReport/, also build number 4580.

FYI @muhhshoaib, this seems directly related to https://github.com/edx/edx-platform/commit/a7cec3283aac460c9e11440e37f16228a2613263
