### PR TITLE
Fix Mathjax rendering bug

### DIFF
--- a/common/lib/xmodule/xmodule/css/capa/display.scss
+++ b/common/lib/xmodule/xmodule/css/capa/display.scss
@@ -379,7 +379,7 @@ div.problem {
     }
 
     > span {
-      display: block;
+      display: inline-block;
       margin-bottom: lh(0.5);
     }
 


### PR DESCRIPTION
[Mathjax doesn't render inline inside choicehints](https://openedx.atlassian.net/browse/TNL-3252)

Just a minor fix to render Mathjax inline

**Before Fix** 
<img width="849" alt="screen shot 2015-09-15 at 10 10 20 pm" src="https://cloud.githubusercontent.com/assets/6991154/9883943/a049c436-5bf6-11e5-94d9-104dc891a2f1.png">

**After Fix**
<img width="849" alt="screen shot 2015-09-15 at 5 29 54 pm" src="https://cloud.githubusercontent.com/assets/6991154/9877738/2de00e14-5bd8-11e5-939f-9d37fb0370f3.png">

Verify [here](http://mathjax.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/courseware/667b93af8f014f47b1cb6851e16452cc/bf3aba8c97bf4340b991b8e2d31057e6/1?activate_block_id=block-v1%3AedX%2BDemoX%2BDemo_Course%2Btype%40vertical%2Bblock%40d3f805efec634a9b9f4c42cca8cd8f28) at sandbox.
