### PR TITLE
Readonly for enrollment end date/time on edX (for non-global-staff)

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -903,11 +903,14 @@ def settings_handler(request, course_key_string):
 
             # see if the ORG of this course can be attributed to a 'Microsite'. In that case, the
             # course about page should be editable in Studio
-            about_page_editable = not microsite.get_value_for_org(
+            marketing_site_enabled = microsite.get_value_for_org(
                 course_module.location.org,
                 'ENABLE_MKTG_SITE',
                 settings.FEATURES.get('ENABLE_MKTG_SITE', False)
             )
+
+            about_page_editable = not marketing_site_enabled
+            enrollment_end_editable = GlobalStaff().has_user(request.user) or not marketing_site_enabled
 
             short_description_editable = settings.FEATURES.get('EDITABLE_SHORT_DESCRIPTION', True)
             settings_context = {
@@ -924,6 +927,7 @@ def settings_handler(request, course_key_string):
                 'credit_eligibility_enabled': credit_eligibility_enabled,
                 'is_credit_course': False,
                 'show_min_grade_warning': False,
+                'enrollment_end_editable': enrollment_end_editable,
             }
             if prerequisite_course_enabled:
                 courses, in_process_course_actions = get_courses_accessible_to_user(request)

--- a/cms/static/sass/views/_settings.scss
+++ b/cms/static/sass/views/_settings.scss
@@ -62,6 +62,27 @@
     margin-top: ($baseline);
   }
 
+  // specific fields - settings details
+  .settings-details {
+
+    // course details that should appear more like content than elements to change
+    .is-not-editable {
+
+      label {
+
+      }
+
+      input, textarea {
+        @extend %t-copy-lead1;
+        @extend %t-strong;
+        box-shadow: none;
+        border: none;
+        background: none;
+        margin: 0;
+      }
+    }
+  }
+
 
   // in form - elements
   .group-settings {
@@ -305,21 +326,10 @@
         }
       }
 
-      // course details that should appear more like content than elements to change
-      .field.is-not-editable {
-
-        label {
-
-        }
+      .is-not-editable {
 
         input, textarea {
-          @extend %t-copy-lead1;
-          @extend %t-strong;
-          box-shadow: none;
-          border: none;
-          background: none;
           padding: 0;
-          margin: 0;
         }
       }
 
@@ -436,6 +446,13 @@
         &:last-child {
           border: none;
           padding-bottom: 0;
+        }
+
+        .is-not-editable {
+
+          input, textarea {
+            padding: 10px;
+          }
         }
 
         .field {

--- a/cms/templates/settings.html
+++ b/cms/templates/settings.html
@@ -220,17 +220,25 @@ CMS.URL.UPLOAD_ASSET = '${upload_asset_url}';
                 <span class="tip tip-stacked timezone">${_("(UTC)")}</span>
               </div>
             </li>
-
+            <%
+              enrollment_end_readonly = "readonly aria-readonly=\"true\"" if not enrollment_end_editable else ""
+              enrollment_end_editable_class = "is-not-editable" if not enrollment_end_editable else ""
+            %>
             <li class="field-group field-group-enrollment-end" id="enrollment-end">
-              <div class="field date" id="field-enrollment-end-date">
+              <div class="field date ${enrollment_end_editable_class}" id="field-enrollment-end-date">
                 <label for="course-enrollment-end-date">${_("Enrollment End Date")}</label>
-                <input type="text" class="end-date date end" id="course-enrollment-end-date" placeholder="MM/DD/YYYY" autocomplete="off" />
-                <span class="tip tip-stacked">${_("Last day students can enroll")}</span>
+                <input type="text" class="end-date date end" id="course-enrollment-end-date" placeholder="MM/DD/YYYY" autocomplete="off" ${enrollment_end_readonly} />
+                <span class="tip tip-stacked">
+                  ${_("Last day students can enroll.")}
+                % if not enrollment_end_editable:
+                  ${_("Contact your edX Partner Manager to update these settings.")}
+                % endif
+                </span>
               </div>
 
-              <div class="field time" id="field-enrollment-end-time">
+              <div class="field time ${enrollment_end_editable_class}" id="field-enrollment-end-time">
                 <label for="course-enrollment-end-time">${_("Enrollment End Time")}</label>
-                <input type="text" class="time end" id="course-enrollment-end-time" value="" placeholder="HH:MM" autocomplete="off" />
+                <input type="text" class="time end" id="course-enrollment-end-time" value="" placeholder="HH:MM" autocomplete="off" ${enrollment_end_readonly} />
                 <span class="tip tip-stacked timezone">${_("(UTC)")}</span>
               </div>
             </li>


### PR DESCRIPTION
## [TNL-2694](https://openedx.atlassian.net/browse/TNL-2694)

Change the "Enrollment End Date" and "Enrollment End Time" on the Schedules and Details page of studio to be read-only for non-global-staff members for courses on edX.org.  Update helper text to inform non-global-staff to contact their edX PM to make changes to those fields.
### Sandbox
- [x] [Sandbox](http://studio-bderusha.sandbox.edx.org/settings/details/course-v1:edx+1010+101010101)

Notes:
- cms.env.json has feature set `"ENABLE_MKTG_SITE": true`.  Ping me if you want to test it out with that variable set to false (which makes fields editable for all users)
- Log in as bill+nonglobal@edx.org (pw: edx) to view course as non-global staff
- Log in as staff to view course as global staff
### Testing
- [x] i18n
- [x] RTL
- [x] Unit tests
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @andy-armstrong 
- [x] Code review: @cahrens 
- [x] UI strings review: @catong
- [x] Product review: @explorerleslie 

FYI - @chrisndodge 
### Post-review
- [x] Squash commits
