### PR TITLE
Remove membership field from team serializer in the membership list endpoint.

### DIFF
--- a/lms/djangoapps/teams/serializers.py
+++ b/lms/djangoapps/teams/serializers.py
@@ -90,6 +90,18 @@ class CourseTeamCreationSerializer(serializers.ModelSerializer):
         )
 
 
+class CourseTeamSerializerWithoutMembership(CourseTeamSerializer):
+    """The same as the `CourseTeamSerializer`, but elides the membership field.
+
+    Intended to be used as a sub-serializer for serializing team
+    memberships, since the membership field is redundant in that case.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(CourseTeamSerializerWithoutMembership, self).__init__(*args, **kwargs)
+        del self.fields['membership']
+
+
 class MembershipSerializer(serializers.ModelSerializer):
     """Serializes CourseTeamMemberships with information about both teams and users."""
     profile_configuration = deepcopy(settings.ACCOUNT_VISIBILITY_CONFIGURATION)
@@ -112,8 +124,7 @@ class MembershipSerializer(serializers.ModelSerializer):
             view_name='teams_detail',
             read_only=True,
         ),
-        expanded_serializer=CourseTeamSerializer(read_only=True),
-        exclude_expand_fields={'user'},
+        expanded_serializer=CourseTeamSerializerWithoutMembership(read_only=True),
     )
 
     class Meta(object):

--- a/lms/djangoapps/teams/tests/test_serializers.py
+++ b/lms/djangoapps/teams/tests/test_serializers.py
@@ -70,10 +70,7 @@ class MembershipSerializerTestCase(SerializerTestCase):
                 'has_image': False
             }
         })
-        self.assertEqual(data['team']['membership'][0]['user'], {
-            'url': 'http://testserver/api/user/v1/accounts/' + username,
-            'username': username
-        })
+        self.assertNotIn('membership', data['team'])
 
 
 class BaseTopicSerializerTestCase(SerializerTestCase):

--- a/openedx/core/lib/api/fields.py
+++ b/openedx/core/lib/api/fields.py
@@ -10,21 +10,18 @@ class ExpandableField(Field):
     Kwargs:
       collapsed_serializer (Serializer): the serializer to use for a non-expanded representation.
       expanded_serializer (Serializer): the serializer to use for an expanded representation.
-      exclude_expand_fields (set(str)): a set of fields which will not be expanded by sub-serializers.
     """
     def __init__(self, **kwargs):
         """Sets up the ExpandableField with the collapsed and expanded versions of the serializer."""
         assert 'collapsed_serializer' in kwargs and 'expanded_serializer' in kwargs
         self.collapsed = kwargs.pop('collapsed_serializer')
         self.expanded = kwargs.pop('expanded_serializer')
-        self.exclude_expand_fields = kwargs.pop('exclude_expand_fields', set())
         super(ExpandableField, self).__init__(**kwargs)
 
     def field_to_native(self, obj, field_name):
         """Converts obj to a native representation, using the expanded serializer if the context requires it."""
         if 'expand' in self.context and field_name in self.context['expand']:
             self.expanded.initialize(self, field_name)
-            self.expanded.context['expand'] = list(set(self.expanded.context['expand']) - self.exclude_expand_fields)
             return self.expanded.field_to_native(obj, field_name)
         else:
             self.collapsed.initialize(self, field_name)


### PR DESCRIPTION
## [TNL-3281](https://openedx.atlassian.net/browse/TNL-3281)

Removes the `membership` field from teams when they're being serialized as part of a team membership. The results of serialization should look something along the lines of this:

``` json
{
   "count": 1,
   "results": [
      {
         "user": {
           "fields": "..."
         },
         "team": {
            "id": "test-team-f3d67c4d1ab94f50bd33eef82fa7fe50",
            "discussion_topic_id": "f3d67c4d1ab94f50bd33eef82fa7fe50",
            "name": "test team",
            "course_id": "edX/DemoX/Demo_Course",
            "topic_id": "test topic",
            "date_created": "2015-09-08T17:59:19Z",
            "description": "description",
            "country": "US",
            "language": "es",
            "last_activity_at": "2015-09-08T17:59:19Z"
         },
         "date_joined": "2015-09-14T14:37:05Z",
         "last_activity_at": "2015-09-14T14:37:05Z"
      }
   ]
}
```
### Sandbox
- [x] http://team-membership.sandbox.edx.org/courses/course-v1:TeamsX+T101+2015/teams/#my-teams
### Testing
- [x] Unit, integration, acceptance tests as appropriate
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @bderusha 
- [x] Code review: @cahrens 
### Post-review
- [x] Squash commits
