### PR TITLE
Increasing contrast in gray meta/date text on course dashboard

### DIFF
--- a/lms/static/sass/multicourse/_dashboard.scss
+++ b/lms/static/sass/multicourse/_dashboard.scss
@@ -365,7 +365,7 @@
 
         .info-date-block {
           @extend %t-title7;
-          color: $gray-l1;
+          color: $gray; // WCAG 2.0 AA compliant
           display: block;
         }
       }


### PR DESCRIPTION
This work changes the light gray course info text (the date of the course) from `$gray-l1` to `$gray` which passes WCAG 2.0 AA requirements. The visual change is subtle.
## Reviewer(s)
- [x] @frrrances 

cc @cptvitamin 
