### PR TITLE
LMS: increasing contrast of footer text

### DIFF
--- a/lms/static/sass/shared/_footer.scss
+++ b/lms/static/sass/shared/_footer.scss
@@ -116,7 +116,7 @@
     .copyright {
       margin: -2px 0 8px 0;
       font-size: em(11);
-      color: $gray-l2;
+      color: $gray; // WCAG 2.0 AA requirements
       @include text-align(left);
     }
 


### PR DESCRIPTION
This change increases the very light gray footer text to pass WCAG 2.0 AA requirements for contrast ratios.
## Reviewer(s)
- [x] @frrrances 

cc @cptvitamin 
