### PR TITLE
SOL-1226: scroll to top after saving

### DIFF
--- a/cms/static/js/certificates/spec/views/certificate_details_spec.js
+++ b/cms/static/js/certificates/spec/views/certificate_details_spec.js
@@ -174,6 +174,12 @@ function(_, Course, CertificatesCollection, CertificateModel, CertificateDetails
                 this.view.$('.action-delete .delete').click();
             });
 
+            it('should scroll to top after rendering if necessary', function () {
+                $.smoothScroll = jasmine.createSpy('jQuery.smoothScroll');
+                appendSetFixtures(this.view.render().el);
+                expect($.smoothScroll).toHaveBeenCalled();
+            });
+
         });
 
         describe('Signatory details', function(){

--- a/cms/static/js/certificates/views/certificate_details.js
+++ b/cms/static/js/certificates/views/certificate_details.js
@@ -8,7 +8,8 @@ define([ // jshint ignore:line
     'js/views/baseview',
     'js/certificates/models/signatory',
     'js/certificates/views/signatory_details',
-    'common/js/components/utils/view_utils'
+    'common/js/components/utils/view_utils',
+    'jquery.smoothScroll'
 ],
 function($, _, str, gettext, BaseView, SignatoryModel, SignatoryDetailsView, ViewUtils) {
     'use strict';
@@ -72,7 +73,11 @@ function($, _, str, gettext, BaseView, SignatoryModel, SignatoryDetailsView, Vie
             if(this.model.collection.length > 0 && window.certWebPreview) {
                 window.certWebPreview.show();
             }
-
+            $.smoothScroll({
+                offset: 0,
+                easing: 'swing',
+                speed: 1000
+            });
             return this;
         }
     });

--- a/common/test/acceptance/pages/studio/settings_certificates.py
+++ b/common/test/acceptance/pages/studio/settings_certificates.py
@@ -11,6 +11,7 @@ The methods in these classes are organized into several conceptual buckets:
 import os
 
 from bok_choy.promise import EmptyPromise
+from ...tests.helpers import disable_animations
 from .course_page import CoursePage
 
 
@@ -284,6 +285,7 @@ class Certificate(object):
         """
         Create a new certificate.
         """
+        disable_animations(self.page)
         self.find_css('.action-primary').first.click()
         self.page.wait_for_ajax()
 


### PR DESCRIPTION
@mattdrayer  @asadiqbal08 this PR supports SOL-1226. When save button is clicked after entering certificate information, user is taken to the bottom of the screen, it should rather take to the top of screen.
