### PR TITLE
SOL-1199

### DIFF
--- a/common/test/acceptance/pages/studio/settings_certificates.py
+++ b/common/test/acceptance/pages/studio/settings_certificates.py
@@ -12,6 +12,7 @@ import os
 
 from bok_choy.promise import EmptyPromise
 from .course_page import CoursePage
+from common.test.acceptance.tests.helpers import disable_animations
 
 
 class CertificatesPage(CoursePage):
@@ -138,8 +139,10 @@ class CertificatesPage(CoursePage):
         """
         Clicks the main action presented by the prompt (such as 'Delete')
         """
+        disable_animations(self)
         self.wait_for_confirmation_prompt()
-        self.q(css='button.action-primary').first.click()
+        self.q(css='.prompt button.action-primary').first.click()
+        self.wait_for_element_invisibility('.prompt', 'wait for pop up to disappear')
         self.wait_for_ajax()
 
 
@@ -263,7 +266,7 @@ class Certificate(object):
         Returns whether or not the certificate delete icon is present.
         """
         EmptyPromise(
-            lambda: self.find_css('.actions .delete').present,
+            lambda: self.find_css('.actions .delete.action-icon').present,
             'Certificate delete button is displayed'
         ).fulfill()
 
@@ -323,8 +326,7 @@ class Certificate(object):
         Remove the first (possibly the only) certificate from the set
         """
         self.wait_for_certificate_delete_button()
-        self.find_css('.actions .delete').first.click()
-        self.page.wait_for_ajax()
+        self.find_css('.actions .delete.action-icon').first.click()
 
 
 class Signatory(object):

--- a/common/test/acceptance/tests/studio/test_studio_settings_certificates.py
+++ b/common/test/acceptance/tests/studio/test_studio_settings_certificates.py
@@ -107,7 +107,6 @@ class CertificatesTest(StudioCourseTest):
 
         self.assertIn("Updated Course Title Override 2", certificate.course_title)
 
-    @flaky  # TODO fix this, see SOL-1199
     def test_can_delete_certificate(self):
         """
         Scenario: Ensure that the user can delete certificate.


### PR DESCRIPTION
Hi @ziafazal , @asadiqbal08 ,

Kindly review this PR, it contains a solution for SOL-1199.

Description of SOL-1199:

First seen in build https://build.testeng.edx.org/job/edx-platform-bok-choy-pr/4425/ - build was over translations update, passed locally and on next Jenkins build (https://build.testeng.edx.org/job/edx-platform-bok-choy-pr/4441/)
common.test.acceptance.tests.studio.test_studio_settings_certificates.CertificatesTest.test_can_delete_certificate (from nosetests)
Error Message
1 != 0
-------------------- >> begin captured logging << --------------------
bok_choy.browser: INFO: Using local browser: firefox [Default is firefox]
--------------------- >> end captured logging << ---------------------
Stacktrace
  File "/usr/lib/python2.7/unittest/case.py", line 327, in run
    testMethod()
  File "/home/jenkins/workspace/edx-platform-test-subset/common/test/acceptance/tests/studio/test_studio_settings_certificates.py", line 136, in test_can_delete_certificate
    self.assertEqual(len(self.certificates_page.certificates), 0)
  File "/usr/lib/python2.7/unittest/case.py", line 511, in assertEqual
    assertion_func(first, second, msg=msg)
  File "/usr/lib/python2.7/unittest/case.py", line 504, in _baseAssertEqual
    raise self.failureException(msg)
'1 != 0\n-------------------- >> begin captured logging << --------------------\nbok_choy.browser: INFO: Using local browser: firefox [Default is firefox]\n--------------------- >> end captured logging << ---------------------'

cc: @mattdrayer 
