### PR TITLE
More descriptive dashboard title

### DIFF
--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -76,7 +76,7 @@ import json
 <section class="container dashboard" id="dashboard-main">
   <section class="my-courses" id="my-courses" role="main" aria-label="Content">
     <header class="wrapper-header-courses">
-      <h2 class="header-courses">${_("Current Courses")}</h2>
+      <h2 class="header-courses">${_("My Courses")}</h2>
     </header>
 
 


### PR DESCRIPTION
It's not clear what the **current** means. Especially when the dashboard displays all of current, archived and self-paced courses.

Therefore I think that **My Courses** is more descriptive than **Current Courses**.

@marcotuts Could you please advise? Since you are the original author of this piece of code.

P.S. I thought about changing this to **Dashboard** instead to make it consistent with the `<title>` of the page, any ideas?

```
<%block name="pagetitle">${_("Dashboard")}</%block>
```
