### PR TITLE
Emit event when last_activity_at is updated.

### DIFF
--- a/lms/djangoapps/teams/models.py
+++ b/lms/djangoapps/teams/models.py
@@ -28,6 +28,7 @@ from xmodule_django.models import CourseKeyField
 from util.model_utils import slugify
 from student.models import LanguageField, CourseEnrollment
 from .errors import AlreadyOnTeamInCourse, NotEnrolledInCourseForTeam, ImmutableMembershipFieldException
+from teams.utils import emit_team_event
 from teams import TEAM_DISCUSSION_CONTEXT
 
 
@@ -247,3 +248,6 @@ class CourseTeamMembership(models.Model):
         membership.team.last_activity_at = now
         membership.team.save()
         membership.save()
+        emit_team_event('edx.team.activity_updated', membership.team.course_id, {
+            'team_id': membership.team_id,
+        })

--- a/lms/djangoapps/teams/tests/test_views.py
+++ b/lms/djangoapps/teams/tests/test_views.py
@@ -418,7 +418,7 @@ class TestListTeamsAPI(EventTestMixin, TeamAPITestCase):
     """Test cases for the team listing API endpoint."""
 
     def setUp(self):  # pylint: disable=arguments-differ
-        super(TestListTeamsAPI, self).setUp('teams.views.tracker')
+        super(TestListTeamsAPI, self).setUp('teams.utils.tracker')
 
     @ddt.data(
         (None, 401),
@@ -592,7 +592,7 @@ class TestCreateTeamAPI(EventTestMixin, TeamAPITestCase):
     """Test cases for the team creation endpoint."""
 
     def setUp(self):  # pylint: disable=arguments-differ
-        super(TestCreateTeamAPI, self).setUp('teams.views.tracker')
+        super(TestCreateTeamAPI, self).setUp('teams.utils.tracker')
 
     @ddt.data(
         (None, 401),
@@ -803,7 +803,7 @@ class TestDeleteTeamAPI(EventTestMixin, TeamAPITestCase):
     """Test cases for the team delete endpoint."""
 
     def setUp(self):  # pylint: disable=arguments-differ
-        super(TestDeleteTeamAPI, self).setUp('teams.views.tracker')
+        super(TestDeleteTeamAPI, self).setUp('teams.utils.tracker')
 
     @ddt.data(
         (None, 401),
@@ -853,7 +853,7 @@ class TestUpdateTeamAPI(EventTestMixin, TeamAPITestCase):
     """Test cases for the team update endpoint."""
 
     def setUp(self):  # pylint: disable=arguments-differ
-        super(TestUpdateTeamAPI, self).setUp('teams.views.tracker')
+        super(TestUpdateTeamAPI, self).setUp('teams.utils.tracker')
 
     @ddt.data(
         (None, 401),
@@ -1182,7 +1182,7 @@ class TestCreateMembershipAPI(EventTestMixin, TeamAPITestCase):
     """Test cases for the membership creation endpoint."""
 
     def setUp(self):  # pylint: disable=arguments-differ
-        super(TestCreateMembershipAPI, self).setUp('teams.views.tracker')
+        super(TestCreateMembershipAPI, self).setUp('teams.utils.tracker')
 
     @ddt.data(
         (None, 401),
@@ -1346,7 +1346,7 @@ class TestDeleteMembershipAPI(EventTestMixin, TeamAPITestCase):
     """Test cases for the membership deletion endpoint."""
 
     def setUp(self):  # pylint: disable=arguments-differ
-        super(TestDeleteMembershipAPI, self).setUp('teams.views.tracker')
+        super(TestDeleteMembershipAPI, self).setUp('teams.utils.tracker')
 
     @ddt.data(
         (None, 401),

--- a/lms/djangoapps/teams/utils.py
+++ b/lms/djangoapps/teams/utils.py
@@ -1,0 +1,14 @@
+"""Utility methods related to teams."""
+
+from eventtracking import tracker
+from track import contexts
+
+
+def emit_team_event(event_name, course_key, event_data):
+    """
+    Emit team events with the correct course id context.
+    """
+    context = contexts.course_context_from_course_id(course_key)
+
+    with tracker.get_tracker().context(event_name, context):
+        tracker.emit(event_name, event_data)

--- a/lms/djangoapps/teams/views.py
+++ b/lms/djangoapps/teams/views.py
@@ -39,8 +39,6 @@ from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 
 from courseware.courses import get_course_with_access, has_access
-from eventtracking import tracker
-from track import contexts
 from student.models import CourseEnrollment, CourseAccessRole
 from student.roles import CourseStaffRole
 from django_comment_client.utils import has_discussion_privileges
@@ -59,22 +57,13 @@ from .serializers import (
 )
 from .search_indexes import CourseTeamIndexer
 from .errors import AlreadyOnTeamInCourse, ElasticSearchConnectionError, NotEnrolledInCourseForTeam
+from .utils import emit_team_event
 
 TEAM_MEMBERSHIPS_PER_PAGE = 2
 TOPICS_PER_PAGE = 12
 MAXIMUM_SEARCH_SIZE = 100000
 
 log = logging.getLogger(__name__)
-
-
-def emit_team_event(event_name, course_key, event_data):
-    """
-    Emit team events with the correct course id context.
-    """
-    context = contexts.course_context_from_course_id(course_key)
-
-    with tracker.get_tracker().context(event_name, context):
-        tracker.emit(event_name, event_data)
 
 
 @receiver(post_save, sender=CourseTeam)


### PR DESCRIPTION
## [TNL-3303](https://openedx.atlassian.net/browse/TNL-3303)

Emit an event when last_activity_at for a team changes.
Discussed in https://openedx.atlassian.net/wiki/display/AN/Teams+Feature+Event+Design
### Testing
- [x] Unit, integration, acceptance tests as appropriate
- [x] Analytics
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @dianakhuang and @efischer19 
- [ ] Product review: @explorerleslie 

FYI: @stroilova and @catong 
### Post-review
- [x] Squash commits
