### PR TITLE
Treating final grade as string

### DIFF
--- a/openedx/core/djangoapps/credit/api/provider.py
+++ b/openedx/core/djangoapps/credit/api/provider.py
@@ -162,7 +162,7 @@ def create_credit_request(course_key, provider_id, username):
                 "course_org": "HogwartsX",
                 "course_num": "Potions101",
                 "course_run": "1T2015",
-                "final_grade": 0.95,
+                "final_grade": "0.95",
                 "user_username": "ron",
                 "user_email": "ron@example.com",
                 "user_full_name": "Ron Weasley",
@@ -242,13 +242,13 @@ def create_credit_request(course_key, provider_id, username):
 
     # Retrieve the final grade from the eligibility table
     try:
-        final_grade = CreditRequirementStatus.objects.get(
+        final_grade = unicode(CreditRequirementStatus.objects.get(
             username=username,
             requirement__namespace="grade",
             requirement__name="grade",
             requirement__course__course_key=course_key,
             status="satisfied"
-        ).reason["final_grade"]
+        ).reason["final_grade"])
     except (CreditRequirementStatus.DoesNotExist, TypeError, KeyError):
         log.exception(
             "Could not retrieve final grade from the credit eligibility table "

--- a/openedx/core/djangoapps/credit/tests/test_api.py
+++ b/openedx/core/djangoapps/credit/tests/test_api.py
@@ -633,14 +633,10 @@ class CreditProviderIntegrationApiTests(CreditApiTestBase):
         self.assertTrue(parsed_date < datetime.datetime.now(pytz.UTC))
 
         # Validate course information
-        self.assertIn('course_org', parameters)
         self.assertEqual(parameters['course_org'], self.course_key.org)
-        self.assertIn('course_num', parameters)
         self.assertEqual(parameters['course_num'], self.course_key.course)
-        self.assertIn('course_run', parameters)
         self.assertEqual(parameters['course_run'], self.course_key.run)
-        self.assertIn('final_grade', parameters)
-        self.assertEqual(parameters['final_grade'], self.FINAL_GRADE)
+        self.assertEqual(parameters['final_grade'], unicode(self.FINAL_GRADE))
 
         # Validate user information
         for key in self.USER_INFO.keys():

--- a/openedx/core/djangoapps/credit/tests/test_views.py
+++ b/openedx/core/djangoapps/credit/tests/test_views.py
@@ -118,7 +118,7 @@ class CreditProviderViewTests(UrlResetMixin, TestCase):
         self.assertEqual(content["parameters"]["course_org"], "edX")
         self.assertEqual(content["parameters"]["course_num"], "DemoX")
         self.assertEqual(content["parameters"]["course_run"], "Demo_Course")
-        self.assertEqual(content["parameters"]["final_grade"], self.FINAL_GRADE)
+        self.assertEqual(content["parameters"]["final_grade"], unicode(self.FINAL_GRADE))
         self.assertEqual(content["parameters"]["user_username"], self.USERNAME)
         self.assertEqual(content["parameters"]["user_full_name"], self.USER_FULL_NAME)
         self.assertEqual(content["parameters"]["user_mailing_address"], "")

--- a/openedx/core/djangoapps/credit/views.py
+++ b/openedx/core/djangoapps/credit/views.py
@@ -111,7 +111,7 @@ def create_credit_request(request, provider_id):
                 course_org: "ASUx"
                 course_num: "DemoX"
                 course_run: "1T2015"
-                final_grade: 0.95,
+                final_grade: "0.95",
                 user_username: "john",
                 user_email: "john@example.com"
                 user_full_name: "John Smith"


### PR DESCRIPTION
Floating point values should be treated as strings to ensure values such as 1.0 are not converted to 1. Such conversion invalidates the signature generated for the credit request. Additionally, JSON has no concept of a floating point datatype.

ECOM-2172

@rlucioni @wedaly @jimabramson 

FYI @jibsheet 
