### PR TITLE
escape string literal also

### DIFF
--- a/lms/templates/certificates/_accomplishment-banner.html
+++ b/lms/templates/certificates/_accomplishment-banner.html
@@ -51,7 +51,7 @@ from django.template.defaultfilters import escapejs
                           share_text: '${facebook_share_text | escapejs}',
                           share_link: '${share_url}',
                           picture_link: '${full_course_image_url}',
-                          description: '${_('Click the link to see my certificate.')}'
+                          description: '${_('Click the link to see my certificate.') | escapejs}'
                           });">
                           <i class="icon fa fa-facebook-official" aria-hidden="true"></i>
                           <span class="action-label">${_("Post on Facebook")}</span>


### PR DESCRIPTION
@nedbat @mattdrayer this PR has continuation work for PR #9717. I'm js escaping a string literal i found which was used in JS. Other texts are urls or `facebook_app_id`. We cannot escape urls since it would make them invalid. i.e dash(-) would become \u002D and `facebook_app_id` is integer so no need to escape it also.
