### PR TITLE
TNL-3316: Error on Insights performance report

### DIFF
--- a/openedx/core/djangoapps/content/course_structures/api/v0/serializers.py
+++ b/openedx/core/djangoapps/content/course_structures/api/v0/serializers.py
@@ -1,6 +1,8 @@
 """
 API Serializers
 """
+from collections import defaultdict
+
 from rest_framework import serializers
 
 
@@ -10,6 +12,19 @@ class GradingPolicySerializer(serializers.Serializer):
     count = serializers.IntegerField(source='min_count')
     dropped = serializers.IntegerField(source='drop_count')
     weight = serializers.FloatField()
+
+    def to_representation(self, obj):
+        """
+        Return a representation of the grading policy.
+        """
+        # Backwards compatibility with the behavior of DRF v2.
+        # When the grader dictionary was missing keys, DRF v2 would default to None;
+        # DRF v3 unhelpfully raises an exception.
+        return dict(
+            super(GradingPolicySerializer, self).to_representation(
+                defaultdict(lambda: None, obj)
+            )
+        )
 
 
 # pylint: disable=invalid-name


### PR DESCRIPTION
Preserve DRF v2 behavior of defaulting to None
for missing keys in the grading policy dictionary.

JIRA: [TNL-3316](https://openedx.atlassian.net/browse/TNL-3316)

@macdiesel @dsjen please review.
