### PR TITLE
Update django-openid-auth to version 0.6

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -22,7 +22,6 @@ django-ipware==1.1.0
 django-mako==0.1.5pre
 django-model-utils==2.3.1
 django-mptt==0.7.4
-django-openid-auth==0.4
 django-sekizai==0.8.2
 django-ses==0.7.0
 django-simple-history==1.6.3

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -12,6 +12,7 @@ git+https://github.com/edx/django-staticfiles.git@031bdeaea85798b8c284e2a09977df
 -e git+https://github.com/edx/django-pipeline.git@88ec8a011e481918fdc9d2682d4017c835acd8be#egg=django-pipeline
 -e git+https://github.com/edx/django-wiki.git@cd0b2b31997afccde519fe5b3365e61a9edb143f#egg=django-wiki
 -e git+https://github.com/edx/django-oauth2-provider.git@0.2.7-fork-edx-5#egg=django-oauth2-provider
+git+https://github.com/edx/django-openid-auth.git@0.6-fork-edx#egg=django_openid_auth==0.6
 -e git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=mongodb_proxy
 git+https://github.com/edx/nltk.git@2.0.6#egg=nltk==2.0.6
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev


### PR DESCRIPTION
Upgrade django-openid-auth to version 0.6.

We are pointing to a fork because 0.6 hasn't yet been released on PyPi, and the project is currently hosted on launchpad.  See the JIRA ticket for a longer discussion.

JIRA: [TNL-2829](https://openedx.atlassian.net/browse/TNL-2829)

From what I can tell, this library is being used by the `external_auth` app, which has unit tests.  My understanding is that this is used by MIT for on-campus SSO.

The feature flag that enables the URLs from this app (`AUTH_USE_OPENID`) is not enabled in either prod or edge, so this should be low-risk to deploy.

@macdiesel please review.
