### PR TITLE
In cohort courses, student progress pages differ from the grade report.

### DIFF
--- a/lms/djangoapps/courseware/grades.py
+++ b/lms/djangoapps/courseware/grades.py
@@ -15,6 +15,7 @@ from django.core.cache import cache
 import dogstats_wrapper as dog_stats_api
 
 from courseware import courses
+from courseware.access import has_access
 from courseware.model_data import FieldDataCache, ScoresClient
 from student.models import anonymous_id_for_user
 from util.module_utils import yield_dynamic_descriptor_descendants
@@ -405,6 +406,10 @@ def _grade(student, request, course, keep_raw_scores, field_data_cache, scores_c
 
                 descendants = yield_dynamic_descriptor_descendants(section_descriptor, student.id, create_module)
                 for module_descriptor in descendants:
+                    user_access = has_access(student, 'load', module_descriptor, module_descriptor.location.course_key)
+                    if not user_access:
+                        continue
+
                     (correct, total) = get_score(
                         student,
                         module_descriptor,


### PR DESCRIPTION
[TNL-3204](https://openedx.atlassian.net/browse/TNL-3204)
### Reproduce:

https://edge.edx.org/courses/course-v1:JAx+33+test_course_33/info
This course has two cohorts, each with an associated content group. Each cohort can see a 3-question quiz worth 100 points in total.
1. Observe that jtestuser1 and jtestuser2 have 80 and 100, respectively, when viewing the student progress pages.
2. On the instructor dashboard, generate the grade report and problem grade report - observe that the students have 40 and 71, respectively.
### SQL queries and time.

Without change: 20 queries in 32.28ms
With change: 20 queries in 40.85ms

I tried refreshing the student progress page several time and noted down the following SQL time differences in Django debug toolbar. 

| has_access Change | Min | Max |
| --- | --- | --- |
| Yes | 20 queries in 13.34 ms | 20 queries in 15.37ms |
| No | 20 queries in 12.66 ms | 20 queries in 14.92ms |
### Good to look while reviewing

It would be helpful to know/verify while reviewing the PR that the change `has_access` in `lms/djangoapps/courseware/grades.py` will not disturb things anywhere else. 

Already reviewed in https://github.com/edx/edx-platform/pull/9719
