### PR TITLE
bump edx-proctoring 0.9.6d

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -58,7 +58,7 @@ git+https://github.com/edx/ecommerce-api-client.git@1.1.0#egg=ecommerce-api-clie
 -e git+https://github.com/edx/edx-user-state-client.git@30c0ad4b9f57f8d48d6943eb585ec8a9205f4469#egg=edx-user-state-client
 -e git+https://github.com/edx/edx-organizations.git@release-2015-08-31#egg=edx-organizations
 
-git+https://github.com/edx/edx-proctoring.git@0.9.6b#egg=edx-proctoring==0.9.6b
+git+https://github.com/edx/edx-proctoring.git@0.9.6d#egg=edx-proctoring==0.9.6d
 
 # Third Party XBlocks
 -e git+https://github.com/mitodl/edx-sga@172a90fd2738f8142c10478356b2d9ed3e55334a#egg=edx-sga


### PR DESCRIPTION
Update edx-proctoring requirements to version 0.9.6d

Diffs are: https://github.com/edx/edx-proctoring/compare/0.9.6b...0.9.6d

No migrations
