### PR TITLE
Make LMS courseware tooltips better

### DIFF
--- a/common/lib/xmodule/xmodule/seq_module.py
+++ b/common/lib/xmodule/xmodule/seq_module.py
@@ -179,7 +179,9 @@ class SequenceModule(SequenceFields, ProctoringFields, XModule):
             rendered_child = child.render(STUDENT_VIEW, context)
             fragment.add_frag_resources(rendered_child)
 
-            titles = child.get_content_titles()
+            # `titles` is a list of titles to inject into the sequential tooltip display.
+            # We omit any blank titles to avoid blank lines in the tooltip display.
+            titles = [title.strip() for title in child.get_content_titles() if title.strip()]
             childinfo = {
                 'content': rendered_child.content,
                 'title': "\n".join(titles),
@@ -193,13 +195,14 @@ class SequenceModule(SequenceFields, ProctoringFields, XModule):
                 childinfo['title'] = child.display_name_with_default
             contents.append(childinfo)
 
-        params = {'items': contents,
-                  'element_id': self.location.html_id(),
-                  'item_id': self.location.to_deprecated_string(),
-                  'position': self.position,
-                  'tag': self.location.category,
-                  'ajax_url': self.system.ajax_url,
-                  }
+        params = {
+            'items': contents,
+            'element_id': self.location.html_id(),
+            'item_id': self.location.to_deprecated_string(),
+            'position': self.position,
+            'tag': self.location.category,
+            'ajax_url': self.system.ajax_url,
+        }
 
         fragment.add_content(self.system.render_template("seq_module.html", params))
 

--- a/lms/templates/seq_module.html
+++ b/lms/templates/seq_module.html
@@ -17,7 +17,6 @@
            data-id="${item['id']}"
            data-element="${idx+1}"
            href="javascript:void(0);"
-           title="${item['title']|h}"
            data-page-title="${item['page_title']|h}"
            aria-controls="seq_contents_${idx}"
            id="tab_${idx}"


### PR DESCRIPTION
@talbs @cptvitamin 

This PR does two things.

One: Removes the title attribute from the sequential module, preventing double tooltip display. In the words of Mark, "TITLE IS FOR IFRAME ONLY. GET RID OF TITLE. yes, I'm shouting ;) biggest accessibility myth: title attribute is for accessibility. its only for mouse users, which makes it anti-accessible"
### Before:

![screen shot 2015-09-20 at 11 01 46 am](https://cloud.githubusercontent.com/assets/1985317/9981346/87f8cf36-5f88-11e5-85b6-1674575ea0d6.png)
### After:

![screen shot 2015-09-20 at 11 02 42 am](https://cloud.githubusercontent.com/assets/1985317/9981347/9a5b5a68-5f88-11e5-8570-0f70be73444e.png)

Two: This PR removes blank unit titles from tooltips. Units such as HTML and Inline Discussion don't have titles by default, and you can remove the title from any other type of unit. Currently, the title name appears as a blank new line in the tooltip; this PR omits those.
### Before:

(Note the title on the HTML unit, and the blank title on the following problem unit)

![screen shot 2015-09-20 at 11 05 27 am](https://cloud.githubusercontent.com/assets/1985317/9981368/1eb4625a-5f89-11e5-8f84-df698f98ae81.png)
### After:

![screen shot 2015-09-20 at 11 04 12 am](https://cloud.githubusercontent.com/assets/1985317/9981372/38d6e824-5f89-11e5-90a1-ab56676e675f.png)
