### PR TITLE
Backport of SEC-20: Allow sensitive third party auth data to be kept in lms.auth.json

### DIFF
--- a/common/djangoapps/third_party_auth/admin.py
+++ b/common/djangoapps/third_party_auth/admin.py
@@ -9,7 +9,17 @@ from config_models.admin import ConfigurationModelAdmin, KeyedConfigurationModel
 from .models import OAuth2ProviderConfig, SAMLProviderConfig, SAMLConfiguration, SAMLProviderData
 from .tasks import fetch_saml_metadata
 
-admin.site.register(OAuth2ProviderConfig, KeyedConfigurationModelAdmin)
+
+class OAuth2ProviderConfigAdmin(KeyedConfigurationModelAdmin):
+    """ Django Admin class for OAuth2ProviderConfig """
+    def get_list_display(self, request):
+        """ Don't show every single field in the admin change list """
+        return (
+            'name', 'enabled', 'backend_name', 'secondary', 'skip_registration_form',
+            'skip_email_verification', 'change_date', 'changed_by', 'edit_link',
+        )
+
+admin.site.register(OAuth2ProviderConfig, OAuth2ProviderConfigAdmin)
 
 
 class SAMLProviderConfigAdmin(KeyedConfigurationModelAdmin):
@@ -55,10 +65,12 @@ class SAMLConfigurationAdmin(ConfigurationModelAdmin):
 
     def key_summary(self, inst):
         """ Short summary of the key pairs configured """
-        if not inst.public_key or not inst.private_key:
+        public_key = inst.get_setting('SP_PUBLIC_CERT')
+        private_key = inst.get_setting('SP_PRIVATE_KEY')
+        if not public_key or not private_key:
             return u'<em>Key pair incomplete/missing</em>'
-        pub1, pub2 = inst.public_key[0:10], inst.public_key[-10:]
-        priv1, priv2 = inst.private_key[0:10], inst.private_key[-10:]
+        pub1, pub2 = public_key[0:10], public_key[-10:]
+        priv1, priv2 = private_key[0:10], private_key[-10:]
         return u'Public: {}…{}<br>Private: {}…{}'.format(pub1, pub2, priv1, priv2)
     key_summary.allow_tags = True
 

--- a/common/djangoapps/third_party_auth/models.py
+++ b/common/djangoapps/third_party_auth/models.py
@@ -178,7 +178,16 @@ class OAuth2ProviderConfig(ProviderConfig):
         )
     )
     key = models.TextField(blank=True, verbose_name="Client ID")
-    secret = models.TextField(blank=True, verbose_name="Client Secret")
+    secret = models.TextField(
+        blank=True,
+        verbose_name="Client Secret",
+        help_text=(
+            'For increased security, you can avoid storing this in your database by leaving '
+            ' this field blank and setting '
+            'SOCIAL_AUTH_OAUTH_SECRETS = {"(backend name)": "secret", ...} '
+            'in your instance\'s Django settings (or lms.auth.json)'
+        )
+    )
     other_settings = models.TextField(blank=True, help_text="Optional JSON object with advanced settings, if any.")
 
     class Meta(object):  # pylint: disable=missing-docstring
@@ -192,8 +201,13 @@ class OAuth2ProviderConfig(ProviderConfig):
 
     def get_setting(self, name):
         """ Get the value of a setting, or raise KeyError """
-        if name in ("KEY", "SECRET"):
-            return getattr(self, name.lower())
+        if name == "KEY":
+            return self.key
+        if name == "SECRET":
+            if self.secret:
+                return self.secret
+            # To allow instances to avoid storing secrets in the DB, the secret can also be set via Django:
+            return getattr(settings, 'SOCIAL_AUTH_OAUTH_SECRETS', {}).get(self.backend_name, '')
         if self.other_settings:
             other_settings = json.loads(self.other_settings)
             assert isinstance(other_settings, dict), "other_settings should be a JSON object (dictionary)"
@@ -310,10 +324,22 @@ class SAMLConfiguration(ConfigurationModel):
         help_text=(
             'To generate a key pair as two files, run '
             '"openssl req -new -x509 -days 3652 -nodes -out saml.crt -keyout saml.key". '
-            'Paste the contents of saml.key here.'
-        )
+            'Paste the contents of saml.key here. '
+            'For increased security, you can avoid storing this in your database by leaving '
+            'this field blank and setting it via the SOCIAL_AUTH_SAML_SP_PRIVATE_KEY setting '
+            'in your instance\'s Django settings (or lms.auth.json).'
+        ),
+        blank=True,
     )
-    public_key = models.TextField(help_text="Public key certificate.")
+    public_key = models.TextField(
+        help_text=(
+            'Public key certificate. '
+            'For increased security, you can avoid storing this in your database by leaving '
+            'this field blank and setting it via the SOCIAL_AUTH_SAML_SP_PUBLIC_CERT setting '
+            'in your instance\'s Django settings (or lms.auth.json).'
+        ),
+        blank=True,
+    )
     entity_id = models.CharField(max_length=255, default="http://saml.example.com", verbose_name="Entity ID")
     org_info_str = models.TextField(
         verbose_name="Organization Info",
@@ -360,9 +386,15 @@ class SAMLConfiguration(ConfigurationModel):
         if name == "SP_ENTITY_ID":
             return self.entity_id
         if name == "SP_PUBLIC_CERT":
-            return self.public_key
+            if self.public_key:
+                return self.public_key
+            # To allow instances to avoid storing keys in the DB, the key pair can also be set via Django:
+            return getattr(settings, 'SOCIAL_AUTH_SAML_SP_PUBLIC_CERT', '')
         if name == "SP_PRIVATE_KEY":
-            return self.private_key
+            if self.private_key:
+                return self.private_key
+            # To allow instances to avoid storing keys in the DB, the private key can also be set via Django:
+            return getattr(settings, 'SOCIAL_AUTH_SAML_SP_PRIVATE_KEY', '')
         other_config = json.loads(self.other_config_str)
         if name in ("TECHNICAL_CONTACT", "SUPPORT_CONTACT"):
             contact = {

--- a/common/djangoapps/third_party_auth/models.py
+++ b/common/djangoapps/third_party_auth/models.py
@@ -363,11 +363,14 @@ class SAMLConfiguration(ConfigurationModel):
             return self.public_key
         if name == "SP_PRIVATE_KEY":
             return self.private_key
-        if name == "TECHNICAL_CONTACT":
-            return {"givenName": "Technical Support", "emailAddress": settings.TECH_SUPPORT_EMAIL}
-        if name == "SUPPORT_CONTACT":
-            return {"givenName": "SAML Support", "emailAddress": settings.TECH_SUPPORT_EMAIL}
         other_config = json.loads(self.other_config_str)
+        if name in ("TECHNICAL_CONTACT", "SUPPORT_CONTACT"):
+            contact = {
+                "givenName": "{} Support".format(settings.PLATFORM_NAME),
+                "emailAddress": settings.TECH_SUPPORT_EMAIL
+            }
+            contact.update(other_config.get(name, {}))
+            return contact
         return other_config[name]  # SECURITY_CONFIG, SP_EXTRA, or similar extra settings
 
 

--- a/common/djangoapps/third_party_auth/tests/test_provider.py
+++ b/common/djangoapps/third_party_auth/tests/test_provider.py
@@ -24,7 +24,7 @@ class RegistryTest(testutil.TestCase):
         enabled_providers = provider.Registry.enabled()
         self.assertEqual(len(enabled_providers), 1)
         self.assertEqual(enabled_providers[0].name, "Google")
-        self.assertEqual(enabled_providers[0].secret, "opensesame")
+        self.assertEqual(enabled_providers[0].get_setting("SECRET"), "opensesame")
 
         self.configure_google_provider(enabled=False)
         enabled_providers = provider.Registry.enabled()
@@ -33,7 +33,17 @@ class RegistryTest(testutil.TestCase):
         self.configure_google_provider(enabled=True, secret="alohomora")
         enabled_providers = provider.Registry.enabled()
         self.assertEqual(len(enabled_providers), 1)
-        self.assertEqual(enabled_providers[0].secret, "alohomora")
+        self.assertEqual(enabled_providers[0].get_setting("SECRET"), "alohomora")
+
+    def test_secure_configuration(self):
+        """ Test that some sensitive values can be configured via Django settings """
+        self.configure_google_provider(enabled=True, secret="")
+        enabled_providers = provider.Registry.enabled()
+        self.assertEqual(len(enabled_providers), 1)
+        self.assertEqual(enabled_providers[0].name, "Google")
+        self.assertEqual(enabled_providers[0].get_setting("SECRET"), "")
+        with self.settings(SOCIAL_AUTH_OAUTH_SECRETS={'google-oauth2': 'secret42'}):
+            self.assertEqual(enabled_providers[0].get_setting("SECRET"), "secret42")
 
     def test_cannot_load_arbitrary_backends(self):
         """ Test that only backend_names listed in settings.AUTHENTICATION_BACKENDS can be used """

--- a/common/djangoapps/third_party_auth/tests/testutil.py
+++ b/common/djangoapps/third_party_auth/tests/testutil.py
@@ -114,6 +114,15 @@ class SAMLTestCase(TestCase):
         with open(os.path.join(os.path.dirname(__file__), 'data', filename)) as f:
             return f.read()
 
+    def enable_saml(self, **kwargs):
+        """ Enable SAML support (via SAMLConfiguration, not for any particular provider) """
+        if 'private_key' not in kwargs:
+            kwargs['private_key'] = self._get_private_key()
+        if 'public_key' not in kwargs:
+            kwargs['public_key'] = self._get_public_key()
+        kwargs.setdefault('entity_id', "https://saml.example.none")
+        super(SAMLTestCase, self).enable_saml(**kwargs)
+
 
 @contextmanager
 def simulate_running_pipeline(pipeline_target, backend, email=None, fullname=None, username=None):

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -551,6 +551,15 @@ if FEATURES.get('ENABLE_THIRD_PARTY_AUTH'):
     # The reduced session expiry time during the third party login pipeline. (Value in seconds)
     SOCIAL_AUTH_PIPELINE_TIMEOUT = ENV_TOKENS.get('SOCIAL_AUTH_PIPELINE_TIMEOUT', 600)
 
+    # Most provider configuration is done via ConfigurationModels but for a few sensitive values
+    # we allow configuration via AUTH_TOKENS instead (optionally).
+    # The SAML private/public key values do not need the delimiter lines (such as
+    # "-----BEGIN PRIVATE KEY-----", "-----END PRIVATE KEY-----" etc.) but they may be included
+    # if you want (though it's easier to format the key values as JSON without the delimiters).
+    SOCIAL_AUTH_SAML_SP_PRIVATE_KEY = AUTH_TOKENS.get('SOCIAL_AUTH_SAML_SP_PRIVATE_KEY', '')
+    SOCIAL_AUTH_SAML_SP_PUBLIC_CERT = AUTH_TOKENS.get('SOCIAL_AUTH_SAML_SP_PUBLIC_CERT', '')
+    SOCIAL_AUTH_OAUTH_SECRETS = AUTH_TOKENS.get('SOCIAL_AUTH_OAUTH_SECRETS', {})
+
     # third_party_auth config moved to ConfigurationModels. This is for data migration only:
     THIRD_PARTY_AUTH_OLD_CONFIG = AUTH_TOKENS.get('THIRD_PARTY_AUTH', None)
 


### PR DESCRIPTION
This is a backport of security fix [SEC-20](https://openedx.atlassian.net/browse/SEC-20) to Cypress.

This fixes the issue where sensitive data (e.g. private keys) had to be stored in the database. It is not in itself a security vulnerability but when combined with some other vulnerability could provide increased surface area for an attack.

This also includes #9125 (Make email addresses in SAML metadata fully configurable) since it's a somewhat related single-commit bugfix that will be good to have fixed on Cypress, and including it makes the rebase trivial.

**JIRA**: [OPEN-881](https://openedx.atlassian.net/browse/OPEN-881)

**Dependencies**: None

**Note**: The code diff is identical to the previously-reviewed code. No changes were needed during the rebase.

**Sandbox**: http://pr9859.sandbox.opencraft.com/

**Test Instructions**:
1. Sign in to http://pr9859.sandbox.opencraft.com/admin/ (username 'admin', password is the usual three digit password for sandbox/devstack users)
2. Go to http://pr9859.sandbox.opencraft.com/admin/third_party_auth/samlconfiguration/ and note that no SAML keys are visible in the `SAMLConfiguration` entry (and thus are not saved in the database). Also note the custom value of `TECHNICAL_CONTACT` and `SUPPORT_CONTACT` set in the `SAMLConfiguration` entry.
3. View [the metadata](http://pr9859.sandbox.opencraft.com/auth/saml/metadata.xml) and confirm the custom email addresses are shown. ("Customized Name 1" / "custom1@example.com"). If the metadata is visible, then the public key has been successfully loaded from `~/lms.auth.json`.
4. (Here I would say to test with TestShib, but someone else has uploaded a metadata file that is breaking metadata uploads on TestShib for everyone, so I haven't been able to get the sandbox authorized by TestShib yet :-/ )

**Reviewers**: @Kelketek and @sarina 
