### PR TITLE
Orphans in split breaks preview button in Studio

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/tests/test_mixed_modulestore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_mixed_modulestore.py
@@ -643,7 +643,7 @@ class TestMixedModuleStore(CommonMixedModuleStoreSetup):
         test_course = self.store.create_course('test_org', 'test_course', 'test_run', self.user_id)
 
         # create sequential and vertical to test against
-        sequential = self.store.create_item(self.user_id, test_course.id, 'sequential', 'test_sequential')
+        sequential = self.store.create_child(self.user_id, test_course.location, 'sequential', 'test_sequential')
         vertical = self.store.create_child(self.user_id, sequential.location, 'vertical', 'test_vertical')
 
         # publish sequential changes


### PR DESCRIPTION
[PLAT-833](https://openedx.atlassian.net/browse/PLAT-833)
### Reproduce
1. Go to unit: [MITx test course](https://studio.edge.edx.org/container/block-v1:MITx+S101+2015_T1+type@vertical+block@e9ec465f8bc949ae930ad5d8047e6e81)
2. Press Preview 

Expected behavior: would see content 
Actual Behavior: page not found 

To create in a fresh course: 
1. Create a new course and add a Problem competent.
2. Export course 
3. Change chapter file name in chapter folder. example. (0c1ec994774145e1a11d82d108e68203.xml to changed.xml) 
4. Change course.xml reference ex. (url_name="0c1ec994774145e1a11d82d108e68203" to url_name="changed") 
5. Import course 
6. Go to Studio and click on preview 

LMS is fine, and you can navigate to the unit on preview.edx.org. 
