### PR TITLE
i18n fix

### DIFF
--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -193,12 +193,12 @@ class CapaFields(object):
         scope=Scope.settings
     )
     matlab_api_key = String(
-        display_name="Matlab API key",
-        help="Enter the API key provided by MathWorks for accessing the MATLAB Hosted Service. "
-             "This key is granted for exclusive use by this course for the specified duration. "
-             "Please do not share the API key with other courses and notify MathWorks immediately "
-             "if you believe the key is exposed or compromised. To obtain a key for your course, "
-             "or to report an issue, please contact moocsupport@mathworks.com",
+        display_name=_("Matlab API key"),
+        help=_("Enter the API key provided by MathWorks for accessing the MATLAB Hosted Service. "
+               "This key is granted for exclusive use by this course for the specified duration. "
+               "Please do not share the API key with other courses and notify MathWorks immediately "
+               "if you believe the key is exposed or compromised. To obtain a key for your course, "
+               "or to report an issue, please contact moocsupport@mathworks.com"),
         scope=Scope.settings
     )
 

--- a/common/lib/xmodule/xmodule/video_module/video_xfields.py
+++ b/common/lib/xmodule/xmodule/video_module/video_xfields.py
@@ -163,7 +163,7 @@ class VideoFields(object):
             "Specify whether access to this video is limited to browsers only, or if it can be "
             "accessed from other applications including mobile apps."
         ),
-        display_name="Video Available on Web Only",
+        display_name=_("Video Available on Web Only"),
         scope=Scope.settings,
         default=False
     )

--- a/common/static/common/templates/discussion/discussion-home.underscore
+++ b/common/static/common/templates/discussion/discussion-home.underscore
@@ -8,7 +8,10 @@
 
   <% if (window.ENABLE_DISCUSSION_HOME_PANEL) { %>
     <span class="label label-settings">
-      <%- interpolate(gettext("How to use %(platform_name)s discussions"), {platform_name: window.PLATFORM_NAME}, true) %>
+      <%- interpolate(
+            gettext("How to use %(platform_name)s discussions"),
+            {platform_name: window.PLATFORM_NAME}, true
+          ) %>
     </span>
     <table class="home-helpgrid">
       <tr class="helpgrid-row helpgrid-row-navigation">

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -583,7 +583,7 @@ def _section_analytics(course, access):
     insights_message = _("For analytics about your course, go to {analytics_dashboard_name}.")
 
     insights_message = insights_message.format(
-        analytics_dashboard_name='{0}{1}</a>'.format(link_start, settings.ANALYTICS_DASHBOARD_NAME)
+        analytics_dashboard_name=u'{0}{1}</a>'.format(link_start, settings.ANALYTICS_DASHBOARD_NAME)
     )
     section_data = {
         'section_key': 'instructor_analytics',

--- a/lms/templates/commerce/provider.underscore
+++ b/lms/templates/commerce/provider.underscore
@@ -1,9 +1,15 @@
 <div class="provider-wrapper">
   <div class="provider-info">
-    <%= interpolate(gettext("You still need to visit the %s website to complete the credit process."), [display_name]) %>
+    <%= interpolate(
+          gettext("You still need to visit the %(display_name)s website to complete the credit process."),
+          { display_name: displayname }, true
+        ) %>
   </div>
   <div class="provider-more-info">
-    <%= interpolate(gettext("To finalize course credit, %s requires %s learners to submit a credit request."), [provider_id.toUpperCase(), platformName]) %>
+    <%= interpolate(
+          gettext("To finalize course credit, %(provider_id)s requires %(platform_name)s learners to submit a credit request."),
+          { provider_id: provider_id.toUpperCase(), platform_name: platformName }, true
+        ) %>
   </div>
   <div class="provider-instructions">
     <%= fulfillment_instructions %>

--- a/lms/templates/commerce/receipt.underscore
+++ b/lms/templates/commerce/receipt.underscore
@@ -1,7 +1,10 @@
 <div class="wrapper-content-main payment-confirmation-step">
   <article class="content-main">
     <h3 class="title">
-      <%= interpolate(gettext( "Thank you! We have received your payment for %s"), ["<span class='course_name_placeholder'></span>"]) %>
+      <%= interpolate(
+            gettext( "Thank you! We have received your payment for %(course_name)s."),
+            { course_name: "<span class='course_name_placeholder'></span>" }, true
+          ) %>
     </h3>
 
     <% if ( receipt ) { %>

--- a/lms/templates/discovery/course_card.underscore
+++ b/lms/templates/discovery/course_card.underscore
@@ -12,7 +12,12 @@
                 <span class="course-code"><%= content.number %></span>
                 <span class="course-title"><%= content.display_name %></span>
             </h2>
-            <div class="course-date" aria-hidden="true"><%= interpolate(gettext("Starts: %s"), [start]) %></div>
+            <div class="course-date" aria-hidden="true">
+                <%= interpolate(
+                      gettext("Starts: %(start_date)s"),
+                      { start_date: start }, true
+                    ) %>
+            </div>
         </section>
         <div class="sr">
             <ul>

--- a/lms/templates/instructor/instructor_dashboard_2/cohort-form.underscore
+++ b/lms/templates/instructor/instructor_dashboard_2/cohort-form.underscore
@@ -95,7 +95,7 @@
                                             <%=
                                             interpolate(
                                                 // Translators: Any text between %(screen_reader_start)s and %(screen_reader_end)s is only read by screen readers and never shown in the browser.
-                                                '%(screen_reader_start)sWarning:%(screen_reader_end)s The previously selected content group was deleted. Select another content group.',
+                                                gettext('%(screen_reader_start)sWarning:%(screen_reader_end)s The previously selected content group was deleted. Select another content group.'),
                                                 {
                                                     screen_reader_start: '<span class="sr">',
                                                     screen_reader_end: '</span>'
@@ -115,7 +115,7 @@
                                         <%=
                                         interpolate(
                                             // Translators: Any text between %(screen_reader_start)s and %(screen_reader_end)s is only read by screen readers and never shown in the browser.
-                                            '%(screen_reader_start)sWarning:%(screen_reader_end)s No content groups exist.',
+                                            gettext('%(screen_reader_start)sWarning:%(screen_reader_end)s No content groups exist.'),
                                             {
                                                 screen_reader_start: '<span class="sr">',
                                                 screen_reader_end: '</span>'


### PR DESCRIPTION
1. Add missing '_()' in capa_base.py & video_xfields.py
2. Fix a bug in instructor_dashboard.py that causes crash when ANALYTICS_DASHBOARD_NAME contains non-ascii characters.
3. Workaround for mis-extractions inside .underscore files when using gettext along with interpolate.
