### PR TITLE
Upgrade django-babel-underscore to latest version to get Django 1.8 support

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -13,7 +13,7 @@ celery==3.1.18
 cssselect==0.9.1
 dealer==2.0.4
 defusedxml==0.4.1
-django-babel-underscore==0.3.0
+django-babel-underscore==0.4.2
 django-celery==3.1.16
 django-countries==3.3
 django-extensions==1.5.5


### PR DESCRIPTION
TNL-3374
