### PR TITLE
Fix black box for On-Demand certs on Progress page

### DIFF
--- a/lms/static/sass/course/_auto-cert.scss
+++ b/lms/static/sass/course/_auto-cert.scss
@@ -1,4 +1,4 @@
-.wrapper-auto-cert {
+.wrapper-msg.wrapper-auto-cert {
     @include margin(0, 0, 0, 0); // Overrides .wrapper-msg
     @include padding(0, 0, 0, 0); // Overrides .wrapper-msg
     background: none; // Overrides .wrapper-msg


### PR DESCRIPTION
**Description**
SO URGENT! This PR fixes the black box for the on-demand cert message on the Progress page that was introduced by bringing the Studio styles over for system-feedback:

https://github.com/edx/edx-platform/blame/master/lms/static/sass/_build-lms.scss#L78-L80

Before: 

![progress-before](https://cloud.githubusercontent.com/assets/4327102/10029549/84bf3648-6140-11e5-88d3-011413939b51.png)

After: 

![progress-after](https://cloud.githubusercontent.com/assets/4327102/10029559/8dfc33be-6140-11e5-83fc-cfd04c55b137.png)

**Follow-on work**
Move the [added imports](https://github.com/edx/edx-platform/blame/master/lms/static/sass/_build-lms.scss#L78-L80) earlier in the compile where they should be.

**Reviewers**
- [ ] @marcotuts 
- [ ] @andy-armstrong  

**FYI**
@griffresch 
