### PR TITLE
Use an updated Django REST Framework to fix 1.8 issues

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -28,7 +28,11 @@ django-ses==0.7.0
 django-simple-history==1.6.3
 django-storages-redux==1.3
 django-method-override==0.1.0
-djangorestframework>=3.1,<3.2
+
+# We need a fix to DRF 3.2.x, for now use it from our own cherry-picked repo
+#djangorestframework>=3.1,<3.2
+git+https://github.com/edx/django-rest-framework.git@3c72cb5ee5baebc4328947371195eae2077197b0#egg=djangorestframework==3.2.3
+
 django==1.8.4
 elasticsearch==0.4.5
 facebook-sdk==0.4.0


### PR DESCRIPTION
TNL-3373

Django REST Framework has a pull request to fix this problem: 
https://github.com/tomchristie/django-rest-framework/pull/3407

We want it now, though, so I picked it onto their tip in my own fork. Once
they merge it and release, we can put this back to an official release.
