### PR TITLE
Align On-demand cert message with pattern library styles

### DIFF
--- a/lms/static/sass/course/_auto-cert.scss
+++ b/lms/static/sass/course/_auto-cert.scss
@@ -12,9 +12,8 @@
     .auto-cert-message {
         margin: $baseline 0;
         padding: $baseline;
-        border: 1px solid $m-blue-d1;
-        border-radius: 3px;
-        background: $m-blue-l4;
+        border-left: 3px solid $m-blue-d1;
+        background: $gray-l5;
 
         .has-actions {
 


### PR DESCRIPTION
**Description** 
This PR aligns the on-demand cert message box on the Progress page with the new Pattern Library visual styles for messages. 

**Before**
<img width="1222" alt="cert-message-before" src="https://cloud.githubusercontent.com/assets/4327102/10035901/9137d3a8-616d-11e5-972c-663a3c2fca37.png">

**After**

<img width="1220" alt="cert-message-after" src="https://cloud.githubusercontent.com/assets/4327102/10035884/6deb7ec2-616d-11e5-89af-b763964997bb.png">

**Reviewers**
- [x] @talbs 
- [ ] @marcotuts 
