### PR TITLE
Hide upgrade message on student dashboard for credit enrollments

### DIFF
--- a/common/djangoapps/course_modes/models.py
+++ b/common/djangoapps/course_modes/models.py
@@ -106,6 +106,9 @@ class CourseMode(models.Model):
     # Modes that allow a student to earn credit with a university partner
     CREDIT_MODES = [CREDIT_MODE]
 
+    # Modes that are allowed to upsell
+    UPSELL_TO_VERIFIED_MODES = [HONOR]
+
     class Meta(object):
         """ meta attributes of this model """
         unique_together = ('course_id', 'mode_slug', 'currency')

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -469,9 +469,9 @@ def complete_course_mode_info(course_id, enrollment, modes=None):
         modes = CourseMode.modes_for_course_dict(course_id)
 
     mode_info = {'show_upsell': False, 'days_for_upsell': None}
-    # we want to know if the user is already verified and if verified is an
-    # option
-    if 'verified' in modes and enrollment.mode != 'verified':
+    # we want to know if the user is already enrolled as verified or credit and
+    # if verified is an option.
+    if CourseMode.VERIFIED in modes and enrollment.mode in CourseMode.UPSELL_TO_VERIFIED_MODES:
         mode_info['show_upsell'] = True
         # if there is an expiration date, find out how long from now it is
         if modes['verified'].expiration_datetime:

--- a/lms/djangoapps/certificates/models.py
+++ b/lms/djangoapps/certificates/models.py
@@ -111,6 +111,8 @@ class GeneratedCertificate(models.Model):
 
     MODES = Choices('verified', 'honor', 'audit')
 
+    VERIFIED_CERTS_MODES = [CourseMode.VERIFIED, CourseMode.CREDIT_MODE]
+
     user = models.ForeignKey(User)
     course_id = CourseKeyField(max_length=255, blank=True, default=None)
     verify_uuid = models.CharField(max_length=32, blank=True, default='')


### PR DESCRIPTION
In case of credit courses if the student becomes eligible for credit, their enrollment mode will be changed in the LMS from "verified" to "credit". The system should ensure that "credit" mode privileges are a superset of "verified" mode privileges. It should not prompt credit students to upgrade to verified track.
For certificates in case of credit mode generate verified certificate.
