### PR TITLE
SOL-1190: line breaks in signatory title are not reflected in the cert

### DIFF
--- a/cms/templates/js/signatory-details.underscore
+++ b/cms/templates/js/signatory-details.underscore
@@ -15,7 +15,7 @@
         </div>
         <div>
           <span class="signatory-title-label"><b><%= gettext("Title") %>:</b>&nbsp;</span>
-          <span class="signatory-title-value"><%= title %></span>
+          <span class="signatory-title-value"><%= title.replace(new RegExp('\r?\n','g'), '<br />') %></span>
         </div>
         <div>
           <span class="signatory-organization-label"><b><%= gettext("Organization") %>:</b>&nbsp;</span>

--- a/common/test/acceptance/pages/studio/settings_certificates.py
+++ b/common/test/acceptance/pages/studio/settings_certificates.py
@@ -51,6 +51,12 @@ class CertificatesPage(CoursePage):
 
         return True
 
+    def get_first_signatory_title(self):
+        """
+        Return signatory title for the first signatory in certificate.
+        """
+        return self.q(css='.signatory-title-value').first.html[0]
+
     ################
     # Properties
     ################

--- a/common/test/acceptance/tests/studio/test_studio_settings_certificates.py
+++ b/common/test/acceptance/tests/studio/test_studio_settings_certificates.py
@@ -1,10 +1,9 @@
 """
 Acceptance tests for Studio's Setting pages
 """
-from unittest import skip
+import re
 from .base_studio_test import StudioCourseTest
 from ...pages.studio.settings_certificates import CertificatesPage
-from flaky import flaky
 
 
 class CertificatesTest(StudioCourseTest):
@@ -196,3 +195,26 @@ class CertificatesTest(StudioCourseTest):
         certificate.course_title = "Title Override"
         certificate.click_cancel_edit_certificate()
         self.assertEqual(len(self.certificates_page.certificates), 0)
+
+    def test_line_breaks_in_signatory_title(self):
+        """
+        Scenario: Ensure that line breaks are properly reflected in certificate
+
+        Given I have a certificate with signatories
+        When I add signatory title with new line character
+        Then I see line break in certificate title
+        """
+        self.certificates_page.visit()
+        certificate = self.create_and_verify_certificate(
+            "Course Title Override",
+            0,
+            [self.make_signatory_data('Signatory title with new line character \n')]
+        )
+
+        certificate.wait_for_certificate_delete_button()
+
+        # Make sure certificate is created
+        self.assertEqual(len(self.certificates_page.certificates), 1)
+
+        signatory_title = self.certificates_page.get_first_signatory_title()
+        self.assertNotEqual([], re.findall(r'<br\s*/?>', signatory_title))

--- a/lms/templates/certificates/_accomplishment-rendering.html
+++ b/lms/templates/certificates/_accomplishment-rendering.html
@@ -1,4 +1,5 @@
 <%! from django.utils.translation import ugettext as _ %>
+<%! from django.template.defaultfilters import linebreaks %>
 <%namespace name='static' file='../static_content.html'/>
 <%
 course_mode_class = course_mode if course_mode else ''
@@ -50,7 +51,7 @@ course_mode_class = course_mode if course_mode else ''
 
                                     <h4 class="signatory-name hd-5">${signatory['name']}</h4>
                                     <p class="signatory-credentials copy copy-micro">
-                                        <span class="role">${signatory['title']}</span>
+                                        <span class="role">${signatory['title']|linebreaks}</span>
                                         <span class="organization">${signatory['organization']}</span>
                                     </p>
                                 </div>


### PR DESCRIPTION
Hi @ziafazal , @asadiqbal08 ,

Kindly review this PR, it contains fix for SOL-1190.

Description of SOL-1190:
line breaks in signatory title are not reflected in the cert.

cc: @mattdrayer 
