### PR TITLE
A faster way to clean the .pyc files

### DIFF
--- a/pavelib/utils/test/utils.py
+++ b/pavelib/utils/test/utils.py
@@ -18,7 +18,10 @@ def clean_test_files():
     Clean fixture files used by tests and .pyc files
     """
     sh("git clean -fqdx test_root/logs test_root/data test_root/staticfiles test_root/uploads")
-    sh("find . -type f -name \"*.pyc\" -not -path './.git/*' -delete")
+    # This find command removes all the *.pyc files that aren't in the .git
+    # directory.  See this blog post for more details:
+    # http://nedbatchelder.com/blog/201505/be_careful_deleting_files_around_git.html
+    sh(r"find . -name '.git' -prune -o -name '*.pyc' -exec rm {} \;")
     sh("rm -rf test_root/log/auto_screenshots/*")
     sh("rm -rf /tmp/mako_[cl]ms")
 


### PR DESCRIPTION
On my devstack, the old line takes about 5.5 seconds, the new line takes
about 1.3 seconds.

For background: http://nedbatchelder.com/blog/201505/be_careful_deleting_files_around_git.html
