### PR TITLE
TE-1042 include diff-cover for js.

### DIFF
--- a/scripts/generic-ci-tests.sh
+++ b/scripts/generic-ci-tests.sh
@@ -112,6 +112,7 @@ END
 
     "js-unit")
         paver test_js --coverage
+        paver diff_coverage
         ;;
 
     "commonlib-js-unit")


### PR DESCRIPTION
Note that because js testing occurs on a different CI job than python
unit testing, files will not be clobbered by this change. The python unit
testing job also creates the same-named report through the diff_coverage
task.
