### PR TITLE
LMS: replacing proctoring markup from accordion

### DIFF
--- a/lms/templates/courseware/accordion.html
+++ b/lms/templates/courseware/accordion.html
@@ -33,10 +33,37 @@ else:
                     formatted_string = get_time_display(section['due'], due_date_display_format, coerce_tz=settings.TIME_ZONE_DISPLAYED_FOR_DEADLINES)
                     due_date = '' if len(formatted_string)==0 else _('due {date}').format(date=formatted_string)
                 %>
-                <p class="subtitle">${section['format']} ${due_date}</p>
-                % if 'graded' in section and section['graded']:
-                    <span class="menu-icon icon fa fa-pencil-square-o" aria-hidden="true"></span>
-                    <span class="sr">This content is graded</span>
+
+                ## There is behavior differences between
+                ## rending of sections which have proctoring/timed examinations
+                ## and those that do not.
+                ##
+                ## Proctoring exposes a exam status message field as well as
+                ## a status icon
+
+                % if section['format'] or due_date or 'proctoring' in section:
+                <p class="subtitle">
+                    % if 'proctoring' in section:
+                        ## Display the proctored exam status icon and status message
+                        <span class="menu-icon icon fa fa-pencil-square-o" aria-hidden="true"></span>
+                        <span class="subtitle-name">${section['proctoring'].get('short_description', '')}</span>
+
+                        ## completed proctored exam statuses should not show the due date
+                        ## since the exam has already been submitted by the user
+                        % if not section['proctoring'].get('in_completed_state', False):
+                            <span class="subtitle-name">${due_date}</span>
+                        % endif
+                    % else:
+                        ## non-proctored section, we just show the exam format and the due date
+                        ## this is the standard case in edx-platform
+                        <span class="subtitle-name">${section['format']} ${due_date}</span>
+
+                        % if 'graded' in section and section['graded']:
+                            <span class="menu-icon icon fa fa-pencil-square-o" aria-hidden="true"></span>
+                            <span class="sr">${_("This content is graded")}</span>
+                        % endif
+                    % endif
+                </p>
                 % endif
             </a>
         </div>


### PR DESCRIPTION
This work replaces markup required by proctoring from a recent merge that revamped the courseware accordion.
## Reviewer
- [x] @chrisndodge 
