### PR TITLE
A script to summarize nosetests.xml files

### DIFF
--- a/scripts/summarize_test_results.py
+++ b/scripts/summarize_test_results.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python
+"""Summarize the results of running all the tests.
+
+See the report_all_files docstring for details, or run this with --help.
+
+"""
+
+import collections
+import os
+
+import click
+from lxml import etree
+
+
+@click.command()
+@click.option("--errors/--no-errors", help="Show details of errors")
+@click.option("--names/--no-names", help="Show all test names")
+@click.option("--outcomes/--no-outcomes", help="Show pass/fail/error with names")
+@click.argument("start", default="reports")
+def report_all_files(errors, names, outcomes, start):
+    """Find all the nosetests.xml files, and report on them.
+
+    For every nosetests.xml file found, prints a summary of the number of
+    tests, fails, errors, etc.  If --details is used, then the error messages
+    from all of the fails and errors will be shown, most frequent first, with a
+    count of how many tests failed for that reason.
+
+    """
+    totals = TestResults()
+    for dirpath, _, filenames in os.walk(start):
+        if "nosetests.xml" in filenames:
+            results = report_file(
+                os.path.join(dirpath, "nosetests.xml"),
+                errors=errors,
+                names=names,
+                outcomes=outcomes,
+            )
+            totals += results
+
+    print "\nTotals:\n{}".format(totals)
+
+
+class Summable(object):
+    """An object whose attributes can be added together easily.
+
+    Subclass this and define `fields` on your derived class.
+
+    """
+    def __init__(self):
+        for name in self.fields:
+            setattr(self, name, 0)
+
+    @classmethod
+    def from_element(cls, element):
+        """Construct a Summable from an xml element with the same attributes."""
+        self = cls()
+        for name in self.fields:
+            setattr(self, name, int(element.get(name)))
+        return self
+
+    def __add__(self, other):
+        result = type(self)()
+        for name in self.fields:
+            setattr(result, name, getattr(self, name) + getattr(other, name))
+        return result
+
+
+class TestResults(Summable):
+    """A test result, makeable from a nosetests.xml <testsuite> element."""
+
+    fields = ["tests", "errors", "failures", "skip"]
+
+    def __str__(self):
+        msg = "{0.tests:4d} tests, {0.errors} errors, {0.failures} failures, {0.skip} skipped"
+        return msg.format(self)
+
+
+def error_line_from_error_element(element):
+    """Given an <error> element, get the important error line from it."""
+    return element.get("message").splitlines()[0]
+
+
+def report_file(path, errors, names, outcomes):
+    """Report on one nosetests.xml file."""
+    print "\n{}".format(path)
+    with open(path) as xml_file:
+        tree = etree.parse(xml_file)                # pylint: disable=no-member
+    suite = tree.xpath("/testsuite")[0]
+
+    results = TestResults.from_element(suite)
+    print results
+
+    if errors:
+        errors = collections.Counter()
+        for error_element in tree.xpath(".//error|.//failure"):
+            errors[error_line_from_error_element(error_element)] += 1
+
+        if errors:
+            print ""
+            for error_message, number in errors.most_common():
+                print "{0:4d}: {1}".format(number, error_message)
+
+    if names:
+        for testcase in tree.xpath(".//testcase"):
+            if outcomes:
+                result = testcase.xpath("*")
+                if result:
+                    outcome = result[0].tag
+                    if outcome == "system-out":
+                        outcome = "."
+                    else:
+                        outcome = outcome[0].upper()
+                else:
+                    outcome = "."
+            else:
+                outcome = ""
+            print "  {outcome} {classname}.{name}".format(
+                outcome=outcome,
+                classname=testcase.get("classname"),
+                name=testcase.get("name"),
+            )
+
+    return results
+
+
+if __name__ == "__main__":
+    report_all_files()                  # pylint: disable=no-value-for-parameter


### PR DESCRIPTION
On the Django 1.8 branch, we have massive numbers of test failures, due to common causes.  I wanted a way to see them at a glance.  This program does that.  Sample output from the 1.8 branch:

```
$ python scripts/summarize_test_results.py

reports/cms/nosetests.xml
3028 tests, 1426 errors, 6 failures, 1052 skipped

reports/common/lib/calc/nosetests.xml
  55 tests, 0 errors, 0 failures, 0 skipped

reports/common/lib/capa/nosetests.xml
 385 tests, 0 errors, 0 failures, 0 skipped

reports/common/lib/chem/nosetests.xml
  86 tests, 0 errors, 0 failures, 0 skipped

reports/common/lib/dogstats/nosetests.xml
   0 tests, 0 errors, 0 failures, 0 skipped

reports/common/lib/i18n/nosetests.xml
   2 tests, 0 errors, 0 failures, 0 skipped

reports/common/lib/safe_lxml/nosetests.xml
   0 tests, 0 errors, 0 failures, 0 skipped

reports/common/lib/sandbox-packages/nosetests.xml
  55 tests, 0 errors, 0 failures, 0 skipped

reports/common/lib/symmath/nosetests.xml
   9 tests, 0 errors, 0 failures, 0 skipped

reports/common/lib/xmodule/nosetests.xml
1459 tests, 0 errors, 0 failures, 86 skipped

reports/lms/nosetests.xml
6264 tests, 5404 errors, 14 failures, 26 skipped

reports/pavelib/paver_tests/nosetests.xml
  76 tests, 0 errors, 0 failures, 0 skipped

Totals:
11419 tests, 6830 errors, 20 failures, 1164 skipped


$ python scripts/summarize_test_results.py  --details

reports/cms/nosetests.xml
3028 tests, 1426 errors, 6 failures, 1052 skipped

 813: 'Options' object has no attribute 'module_name'
 482: 'User' object has no attribute 'exampleconfig'
  97: No module named transaction
   9: Invalid field name(s) given in select_related: 'restricted_country'. Choices are: restricted_course, country
   6: course_action_state_coursererunstate.should_display may not be NULL
   5: Cannot generate instances of abstract factory PersistentCourseFactory; Ensure PersistentCourseFactory.Meta.model is set and PersistentCourseFactory.Meta.abstract is either not set or False.
   3: list index out of range
   2: I/O operation on closed file.
   2: No JSON object could be decoded
   2: 'Project-Id-Version: ' not found in ''
   2: Conflicting 'softwaresecurephotoverification' models in application 'verify_student': <class 'verify_student.models.SoftwareSecurePhotoVerification'> and <class 'lms.djangoapps.verify_student.models.SoftwareSecurePhotoVerification'>.
   2: 'Project-Id-Version: ' not found in u''
   1: An unexpected error occurred when calling 'create_account' with arguments '(u'frank-underwood', u'\u1e55\xe1\u015b\u015b\u1e83\u0151\u0155d', u'frank@\xe9x\xe1\u1e3f\u1e55\u013a\xe9.\u0107\u0151\u1e3f')' and keyword arguments '{}': AttributeError("'Options' object has no attribute 'module_name'",)
   1: No module named hashcompat
   1: SystemExit not raised
   1: An unexpected error occurred when calling 'create_account' with arguments '(u'frank-underwood', u'\u1e55\xe1\u015b\u015b\u1e83\u0151\u0155d', u'frank+underwood@example.com')' and keyword arguments '{}': AttributeError("'Options' object has no attribute 'module_name'",)
   1: Conflicting 'studioconfig' models in application 'xblock_config': <class 'xblock_config.models.StudioConfig'> and <class 'cms.djangoapps.xblock_config.models.StudioConfig'>.
   1: 'NoneType' object has no attribute '__getitem__'
   1: False is not true

reports/common/lib/calc/nosetests.xml
  55 tests, 0 errors, 0 failures, 0 skipped

reports/common/lib/capa/nosetests.xml
 385 tests, 0 errors, 0 failures, 0 skipped

reports/common/lib/chem/nosetests.xml
  86 tests, 0 errors, 0 failures, 0 skipped

reports/common/lib/dogstats/nosetests.xml
   0 tests, 0 errors, 0 failures, 0 skipped

reports/common/lib/i18n/nosetests.xml
   2 tests, 0 errors, 0 failures, 0 skipped

reports/common/lib/safe_lxml/nosetests.xml
   0 tests, 0 errors, 0 failures, 0 skipped

reports/common/lib/sandbox-packages/nosetests.xml
  55 tests, 0 errors, 0 failures, 0 skipped

reports/common/lib/symmath/nosetests.xml
   9 tests, 0 errors, 0 failures, 0 skipped

reports/common/lib/xmodule/nosetests.xml
1459 tests, 0 errors, 0 failures, 86 skipped

reports/lms/nosetests.xml
6264 tests, 5404 errors, 14 failures, 26 skipped

4664: 'Options' object has no attribute 'module_name'
 516: No module named transaction
 100: no such table: third_party_auth_oauth2providerconfig
  29: Cannot generate instances of abstract factory ClientFactory; Ensure ClientFactory.Meta.model is set and ClientFactory.Meta.abstract is either not set or False.
  11: __init__() got an unexpected keyword argument 'mimetype'
  11: 'User' object has no attribute 'exampleconfig'
  10: no such table: third_party_auth_samlconfiguration
   9: Invalid field name(s) given in select_related: 'restricted_country'. Choices are: restricted_course, country
   7: An unexpected error occurred when calling 'create_account' with arguments '(u'heisenberg', u'\u1e05\u1e37\xfc\xeb\u1e61\u1e33\xff', u'walter@graymattertech.com')' and keyword arguments '{}': AttributeError("'Options' object has no attribute 'module_name'",)
   6: course_action_state_coursererunstate.should_display may not be NULL
   5: Conflicting 'customcourseforedx' models in application 'ccx': <class 'ccx.models.CustomCourseForEdX'> and <class 'lms.djangoapps.ccx.models.CustomCourseForEdX'>.
   5: An unexpected error occurred when calling 'create_account' with arguments '(u'frank-underwood', u'\u1e55\xe1\u015b\u015b\u1e83\u0151\u0155d', u'frank+underwood@example.com')' and keyword arguments '{}': AttributeError("'Options' object has no attribute 'module_name'",)
   4: 'module' object has no attribute 'enter_transaction_management'
   4: no such table: third_party_auth_ltiproviderconfig
   4: Can't pickle <type 'datetime.datetime'>: it's not the same object as datetime.datetime
   3: Conflicting 'courseteam' models in application 'teams': <class 'teams.models.CourseTeam'> and <class 'lms.djangoapps.teams.models.CourseTeam'>.
   3: list index out of range
   2: No JSON object could be decoded
   2: u' \u0166\u0247s\u0167 s\u0167\u023a\u0167\u1d7es' != None
   2: can't compare offset-naive and offset-aware datetimes
   2: 'Project-Id-Version: ' not found in ''
   2: Conflicting 'softwaresecurephotoverification' models in application 'verify_student': <class 'verify_student.models.SoftwareSecurePhotoVerification'> and <class 'lms.djangoapps.verify_student.models.SoftwareSecurePhotoVerification'>.
   2: I/O operation on closed file.
   2: False is not true
   2: 'Project-Id-Version: ' not found in u''
   1: An unexpected error occurred when calling 'create_account' with arguments '(u'frank-underwood', u'\u1e55\xe1\u015b\u015b\u1e83\u0151\u0155d', u'frank@\xe9x\xe1\u1e3f\u1e55\u013a\xe9.\u0107\u0151\u1e3f')' and keyword arguments '{}': AttributeError("'Options' object has no attribute 'module_name'",)
   1: No module named hashcompat
   1: u'Test global message' != None
   1: ".* ENABLE_TEAMS must be enabled .*" does not match "reindex_course_team requires one or more arguments: <course_team_id>"
   1: Undefined
   1: ".* requires one or more arguments .*" does not match "reindex_course_team requires one or more arguments: <course_team_id>"
   1: An unexpected error occurred when calling 'request_password_change' with arguments '(u'frank+underwood@example.com', 'example.com', False)' and keyword arguments '{}': AttributeError("'PasswordResetFormNoActive' object has no attribute 'error_messages'",)
   1: NoReverseMatch not raised
   1: ".* Argument {0} is not a course_team id .*" does not match "Argument team4 is not a course_team team_id"
   1: u'' != None
   1: 'NoneType' object has no attribute '__getitem__'

reports/pavelib/paver_tests/nosetests.xml
  76 tests, 0 errors, 0 failures, 0 skipped

Totals:
11419 tests, 6830 errors, 20 failures, 1164 skipped
```
