### PR TITLE
bump version of edx-proctoring to 0.9.11

### DIFF
--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -729,7 +729,7 @@ class TestProctoringRendering(ModuleStoreTestCase):
             {
                 'status': 'eligible',
                 'short_description': 'Ungraded Practice Exam',
-                'suggested_icon': 'fa-lock',
+                'suggested_icon': 'fa-pencil-square-o',
                 'in_completed_state': False
             }
         ),
@@ -762,7 +762,7 @@ class TestProctoringRendering(ModuleStoreTestCase):
             {
                 'status': 'eligible',
                 'short_description': 'Proctored Option Available',
-                'suggested_icon': 'fa-lock',
+                'suggested_icon': 'fa-pencil-square-o',
                 'in_completed_state': False
             }
         ),
@@ -773,7 +773,7 @@ class TestProctoringRendering(ModuleStoreTestCase):
             {
                 'status': 'declined',
                 'short_description': 'Taking As Open Exam',
-                'suggested_icon': 'fa-unlock',
+                'suggested_icon': 'fa-pencil-square-o',
                 'in_completed_state': False
             }
         ),

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -58,7 +58,7 @@ git+https://github.com/edx/ecommerce-api-client.git@1.1.0#egg=ecommerce-api-clie
 -e git+https://github.com/edx/edx-user-state-client.git@30c0ad4b9f57f8d48d6943eb585ec8a9205f4469#egg=edx-user-state-client
 git+https://github.com/edx/edx-organizations.git@release-2015-09-22#egg=edx-organizations==0.1.6
 
-git+https://github.com/edx/edx-proctoring.git@0.9.6e#egg=edx-proctoring==0.9.6e
+git+https://github.com/edx/edx-proctoring.git@0.9.11#egg=edx-proctoring==0.9.11
 
 # Third Party XBlocks
 -e git+https://github.com/mitodl/edx-sga@172a90fd2738f8142c10478356b2d9ed3e55334a#egg=edx-sga


### PR DESCRIPTION
@feanil @e0d bumping edx-proctoring version for this weeks release.

Diffs: https://github.com/edx/edx-proctoring/compare/0.9.6e...0.9.11

There are migrations and they are backwards compatible (new tables and new nullable columns).

NOTE: the other change in this commit is to update a test to correspond with some changes in this new version (change the icons to use in the left nav bar)
