### PR TITLE
Make the message to the end user consistent across as requirement typ…

### DIFF
--- a/lms/djangoapps/courseware/tests/test_credit_requirements.py
+++ b/lms/djangoapps/courseware/tests/test_credit_requirements.py
@@ -112,7 +112,7 @@ class ProgressPageCreditRequirementsTest(ModuleStoreTestCase):
             response,
             "{}, you have met the requirements for credit in this course.".format(self.USER_FULL_NAME)
         )
-        self.assertContains(response, "Verified on {date}".format(date=self._now_formatted_date()))
+        self.assertContains(response, "Completed {date}".format(date=self._now_formatted_date()))
         self.assertContains(response, "95%")
 
     def test_credit_requirements_not_eligible(self):

--- a/lms/templates/courseware/progress.html
+++ b/lms/templates/courseware/progress.html
@@ -136,12 +136,10 @@ from django.utils.http import urlquote_plus
                                     <span>${_("Verification Failed" )}</span>
                                 %elif requirement['status'] == 'satisfied':
                                     <i class="fa fa-check"></i>
-                                    % if requirement['namespace'] == 'reverification':
-                                    <span>Verified on ${get_time_display(requirement['status_date'], DEFAULT_SHORT_DATE_FORMAT, settings.TIME_ZONE)}</span>
-                                    % elif requirement['namespace'] == 'grade' and 'final_grade' in requirement['reason']:
+                                    % if requirement['namespace'] == 'grade' and 'final_grade' in requirement['reason']:
                                     <span>${int(requirement['reason']['final_grade'] * 100)}%</span>
                                     % else:
-                                    <span>Completed</span>
+                                    <span>${_("Completed")} ${get_time_display(requirement['status_date'], DEFAULT_SHORT_DATE_FORMAT, settings.TIME_ZONE)}</span>
                                     % endif
                                 %endif
                             %else:


### PR DESCRIPTION
…es, except for grade requirements
