### PR TITLE
Make BlockStructure caching more space-efficient (grouping, zlib).

### DIFF
--- a/lms/djangoapps/course_blocks/api.py
+++ b/lms/djangoapps/course_blocks/api.py
@@ -1,7 +1,7 @@
 """
 ...
 """
-from django.core.cache import get_cache
+from django.core.cache import cache
 
 from openedx.core.lib.block_cache.block_cache import get_blocks, clear_block_cache
 from xmodule.modulestore.django import modulestore
@@ -23,14 +23,9 @@ LMS_COURSE_TRANSFORMERS = [
 ]
 
 
-_COURSE_BLOCKS_CACHE = None
-
-
 def _get_cache():
-    global _COURSE_BLOCKS_CACHE
-    if not _COURSE_BLOCKS_CACHE:
-        _COURSE_BLOCKS_CACHE = get_cache('lms.course_blocks')
-    return _COURSE_BLOCKS_CACHE
+    """Function exists for mocking/testing, or if we want a custom cache."""
+    return cache
 
 
 def get_course_blocks(

--- a/openedx/core/lib/cache_utils.py
+++ b/openedx/core/lib/cache_utils.py
@@ -1,8 +1,9 @@
 """
 Utilities related to caching.
 """
-
+import cPickle as pickle
 import functools
+import zlib
 from xblock.core import XBlock
 
 
@@ -47,3 +48,13 @@ def hashvalue(arg):
         return unicode(arg.location)
     else:
         return unicode(arg)
+
+
+def zpickle(data):
+    """Given any data structure, returns a zlib compressed pickled serialization."""
+    return zlib.compress(pickle.dumps(data, pickle.HIGHEST_PROTOCOL))
+
+
+def zunpickle(zdata):
+    """Given a zlib compressed pickled serialization, returns the deserialized data."""
+    return pickle.loads(zlib.decompress(zdata))


### PR DESCRIPTION
Before this commit, BlockStructures were being cached with one
entry for the top level data (structure, course-wide transform
data), and an entry for each block's data. There can be thousands
of blocks in a course. While this makes it so that you can grab
a small subset of blocks without incurring much overhead,
splitting the block information means that the overall size of the
data stored for generating course-level views increases drastically,
since compression is less efficient.

Making this change yields about a 7X decrease in serialized data
size.

@nasthagiri 
