### PR TITLE
Allow fullscreen within lti

### DIFF
--- a/lms/templates/lti.html
+++ b/lms/templates/lti.html
@@ -45,6 +45,9 @@ from django.utils.translation import ugettext as _
             class="ltiLaunchFrame"
             name="ltiFrame-${element_id}"
             src="${form_url}"
+            allowfullscreen="true"
+            webkitallowfullscreen="true"
+            mozallowfullscreen="true"
         ></iframe>
     % endif
 % elif not hide_launch:


### PR DESCRIPTION
**Affected Courses**: 2 courses are affected (JapanX 2015 and "The Book") with a combined enrollment of 15K students/users
**Ideal Fix Deployment**: Week of October 5th
**Partner Information**: HarvardX

**Background:** Though you can configure the iframe in an iframe component to go to fullscreen, the LTI component does not let you configure that. This will allow any LTI consumers to go into fullscreen mode, should they desire.  

**Studio Changes:** None.

**LMS Changes:** Just added the attribute to allow fullscreen in an iframe.
