### PR TITLE
SOL-1247: use overridden course number and org

### DIFF
--- a/lms/djangoapps/certificates/tests/test_webview_views.py
+++ b/lms/djangoapps/certificates/tests/test_webview_views.py
@@ -254,6 +254,27 @@ class CertificatesViewsTests(ModuleStoreTestCase, EventTrackingTestCase):
         self.assertIn('refundable course', response.content)
 
     @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    def test_course_display_overrides(self):
+        """
+        Tests if `Course Number Display String` or `Course Organization Display` is set for a course
+        in advance settings
+        Then web certificate should display that course number and course org set in advance
+        settings instead of original course number and course org.
+        """
+        test_url = get_certificate_url(
+            user_id=self.user.id,
+            course_id=unicode(self.course.id)
+        )
+        self._add_course_certificates(count=1, signatory_count=2)
+        self.course.display_coursenumber = "overridden_number"
+        self.course.display_organization = "overridden_org"
+        self.store.update_item(self.course, self.user.id)
+
+        response = self.client.get(test_url)
+        self.assertIn('overridden_number', response.content)
+        self.assertIn('overridden_org', response.content)
+
+    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
     def test_certificate_view_without_org_logo(self):
         test_url = get_certificate_url(
             user_id=self.user.id,

--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -90,7 +90,7 @@ def _update_certificate_context(context, course, user, user_certificate):
     user_fullname = user.profile.name
     platform_name = microsite.get_value("platform_name", settings.PLATFORM_NAME)
     certificate_type = context.get('certificate_type')
-    partner_short_name = course.org
+    partner_short_name = course.display_organization if course.display_organization else course.org
     partner_long_name = None
     organizations = organization_api.get_course_organizations(course_id=course.id)
     if organizations:
@@ -129,7 +129,8 @@ def _update_certificate_context(context, course, user, user_certificate):
         )
     )
 
-    context['course_number'] = course.number
+    course_number = course.display_coursenumber if course.display_coursenumber else course.number
+    context['course_number'] = course_number
     try:
         badge = BadgeAssertion.objects.get(user=user, course_id=course.location.course_key)
     except BadgeAssertion.DoesNotExist:
@@ -239,13 +240,13 @@ def _update_certificate_context(context, course, user, user_certificate):
         platform_name=platform_name,
         user_name=user_fullname,
         partner_short_name=partner_short_name,
-        course_number=course.number
+        course_number=course_number
     )
 
     # Translators:  This text is bound to the HTML 'title' element of the page and appears in the browser title bar
     context['document_title'] = _("{partner_short_name} {course_number} Certificate | {platform_name}").format(
         partner_short_name=partner_short_name,
-        course_number=course.number,
+        course_number=course_number,
         platform_name=platform_name
     )
 


### PR DESCRIPTION
if _Course Number Display String_ or _Course Organization Display_ is set for a course in advance settings Then web certificate should display that course number and course org set in advance settings instead of original course number and course org.
@asadiqbal08 Please review.
@mattdrayer FYI.
