### PR TITLE
Fix import error in test suite

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -159,6 +159,7 @@ Tim Babych <tim.babych@gmail.com>
 Brandon DeRosier <btd@cheesekeg.com>
 Daniel Li <swli@edx.org>
 Daniel Friedman <dfriedman@edx.org>
+Zia Fazal <zia.fazal@arbisoft.com>
 Asad Iqbal <aiqbal@edx.org>
 Peter Pinch <pdpinch@mit.edu>
 Muhammad Shoaib <mshoaib@edx.org>

--- a/AUTHORS
+++ b/AUTHORS
@@ -241,4 +241,5 @@ Julien Paillé <julien.paille@openfun.fr>
 Michael Frey <mfrey@edx.org>
 Hasnain Naveed <hasnain@edx.org>
 J. Cliff Dyer <cdyer@edx.org>
+Jamie Folsom <jfolsom@mit.edu>
 Dustin Gadal <Dustin.Gadal@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -241,3 +241,4 @@ Julien Paillé <julien.paille@openfun.fr>
 Michael Frey <mfrey@edx.org>
 Hasnain Naveed <hasnain@edx.org>
 J. Cliff Dyer <cdyer@edx.org>
+Dustin Gadal <Dustin.Gadal@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -242,4 +242,5 @@ Michael Frey <mfrey@edx.org>
 Hasnain Naveed <hasnain@edx.org>
 J. Cliff Dyer <cdyer@edx.org>
 Jamie Folsom <jfolsom@mit.edu>
+George Schneeloch <gschneel@mit.edu>
 Dustin Gadal <Dustin.Gadal@gmail.com>

--- a/common/lib/xmodule/xmodule/modulestore/tests/factories.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/factories.py
@@ -7,7 +7,7 @@ import pymongo.message
 import threading
 import traceback
 from collections import defaultdict
-from decorator import contextmanager
+from contextlib import contextmanager
 from uuid import uuid4
 
 from factory import Factory, Sequence, lazy_attribute_sequence, lazy_attribute


### PR DESCRIPTION
paver choked on this file trying to run LMS on DevStack. (`$paver devstack lms`)

`contextmanager` is imported from `contextlib` everywhere else in the codebase, and `decorator` appears to be unrelated as far as I can tell.
