### PR TITLE
Fixed KeyError in CCX

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -243,3 +243,4 @@ Michael Frey <mfrey@edx.org>
 Hasnain Naveed <hasnain@edx.org>
 J. Cliff Dyer <cdyer@edx.org>
 Jamie Folsom <jfolsom@mit.edu>
+George Schneeloch <gschneel@mit.edu>

--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -254,7 +254,7 @@ def save_ccx(request, course, ccx=None):
     grader = policy['GRADER']
     for section in grader:
         count = graded.get(section.get('type'), 0)
-        if count < section['min_count']:
+        if count < section.get('min_count', 0):
             changed = True
             section['min_count'] = count
     if changed:


### PR DESCRIPTION
This PR addresses a bug in CCX where a grading policy missing a `min_count` field causes a KeyError when the CCX schedule is updated in LMS. (This doesn't affect CMS.) The fix uses a value of 0 in place of a missing `min_count` field. The included test will reproduce the error if the fix is removed.

This is my first PR to edX, please let me know if I need to adjust anything. I work for MIT ODL so I don't think I'll need to sign a contribution agreement. Thanks!
