### PR TITLE
Add IP to all python Segment tracking calls

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -1062,6 +1062,7 @@ class CourseEnrollment(models.Model):
                         'run': self.course_id.run,
                         'mode': self.mode,
                     }, context={
+                        'ip': tracking_context.get('ip'),
                         'Google Analytics': {
                             'clientId': tracking_context.get('client_id')
                         }

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1179,6 +1179,7 @@ def login_user(request, error=""):  # pylint: disable=too-many-statements,unused
                 'provider': None
             },
             context={
+                'ip': tracking_context.get('ip'),
                 'Google Analytics': {
                     'clientId': tracking_context.get('client_id')
                 }
@@ -1635,6 +1636,7 @@ def create_account_with_params(request, params):
                 'provider': third_party_provider.name if third_party_provider else None
             },
             context={
+                'ip': tracking_context.get('ip'),
                 'Google Analytics': {
                     'clientId': tracking_context.get('client_id')
                 }

--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -604,6 +604,7 @@ def login_analytics(strategy, auth_entry, *args, **kwargs):
                 'provider': getattr(kwargs['backend'], 'name')
             },
             context={
+                'ip': tracking_context.get('ip'),
                 'Google Analytics': {
                     'clientId': tracking_context.get('client_id')
                 }

--- a/lms/djangoapps/commerce/__init__.py
+++ b/lms/djangoapps/commerce/__init__.py
@@ -7,9 +7,12 @@ from eventtracking import tracker
 def create_tracking_context(user):
     """ Assembles attributes from user and request objects to be sent along
     in ecommerce api calls for tracking purposes. """
+    context_tracker = tracker.get_tracker().resolve_context()
+
     return {
         'lms_user_id': user.id,
-        'lms_client_id': tracker.get_tracker().resolve_context().get('client_id')
+        'lms_client_id': context_tracker.get('client_id'),
+        'lms_ip': context_tracker.get('ip'),
     }
 
 

--- a/lms/djangoapps/commerce/tests/__init__.py
+++ b/lms/djangoapps/commerce/tests/__init__.py
@@ -60,7 +60,7 @@ class EcommerceApiClientTest(TestCase):
         )
 
         mock_tracker = mock.Mock()
-        mock_tracker.resolve_context = mock.Mock(return_value={'client_id': self.TEST_CLIENT_ID})
+        mock_tracker.resolve_context = mock.Mock(return_value={'client_id': self.TEST_CLIENT_ID, 'ip': '127.0.0.1'})
         with mock.patch('commerce.tracker.get_tracker', return_value=mock_tracker):
             ecommerce_api_client(self.user).baskets(1).post()
 
@@ -75,6 +75,7 @@ class EcommerceApiClientTest(TestCase):
             'tracking_context': {
                 'lms_user_id': self.user.id,  # pylint: disable=no-member
                 'lms_client_id': self.TEST_CLIENT_ID,
+                'lms_ip': '127.0.0.1',
             },
         }
 

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -944,6 +944,7 @@ class GenerateUserCertTests(ModuleStoreTestCase):
                 },
 
                 context={
+                    'ip': '127.0.0.1',
                     'Google Analytics':
                     {'clientId': None}
                 }

--- a/lms/djangoapps/courseware/views.py
+++ b/lms/djangoapps/courseware/views.py
@@ -1395,6 +1395,7 @@ def _track_successful_certificate_generation(user_id, course_id):  # pylint: dis
                 'label': unicode(course_id)
             },
             context={
+                'ip': tracking_context.get('ip'),
                 'Google Analytics': {
                     'clientId': tracking_context.get('client_id')
                 }

--- a/lms/djangoapps/shoppingcart/models.py
+++ b/lms/djangoapps/shoppingcart/models.py
@@ -517,6 +517,7 @@ class Order(models.Model):
                     'currency': self.currency,
                     'products': [item.analytics_data() for item in orderitems]
                 }, context={
+                    'ip': tracking_context.get('ip'),
                     'Google Analytics': {
                         'clientId': tracking_context.get('client_id')
                     }

--- a/lms/djangoapps/shoppingcart/tests/test_models.py
+++ b/lms/djangoapps/shoppingcart/tests/test_models.py
@@ -265,7 +265,7 @@ class OrderTest(ModuleStoreTestCase):
                     }
                 ]
             },
-            context={'Google Analytics': {'clientId': None}}
+            context={'ip': None, 'Google Analytics': {'clientId': None}}
         )
 
     def test_purchase_item_failure(self):
@@ -860,7 +860,7 @@ class CertificateItemTest(ModuleStoreTestCase):
                     }
                 ]
             },
-            context={'Google Analytics': {'clientId': None}}
+            context={'ip': None, 'Google Analytics': {'clientId': None}}
         )
 
     def test_existing_enrollment(self):

--- a/lms/djangoapps/verify_student/tests/test_views.py
+++ b/lms/djangoapps/verify_student/tests/test_views.py
@@ -1963,6 +1963,7 @@ class TestInCourseReverifyView(ModuleStoreTestCase):
             },
 
             context={
+                'ip': '127.0.0.1',
                 'Google Analytics':
                 {'clientId': None}
             }
@@ -2020,6 +2021,7 @@ class TestInCourseReverifyView(ModuleStoreTestCase):
                 'checkpoint': self.reverification_assessment
             },
             context={
+                'ip': '127.0.0.1',
                 'Google Analytics':
                 {'clientId': None}
             }

--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -1105,6 +1105,7 @@ class SubmitPhotosView(View):
         if settings.SEGMENT_KEY:
             tracking_context = tracker.get_tracker().resolve_context()
             context = {
+                'ip': tracking_context.get('ip'),
                 'Google Analytics': {
                     'clientId': tracking_context.get('client_id')
                 }
@@ -1450,6 +1451,7 @@ class InCourseReverifyView(View):
                     'checkpoint': checkpoint
                 },
                 context={
+                    'ip': tracking_context.get('ip'),
                     'Google Analytics': {
                         'clientId': tracking_context.get('client_id')
                     }

--- a/openedx/core/djangoapps/user_api/preferences/api.py
+++ b/openedx/core/djangoapps/user_api/preferences/api.py
@@ -290,6 +290,7 @@ def _track_update_email_opt_in(user_id, organization, opt_in):
             'label': organization
         },
         context={
+            'ip': tracking_context.get('ip'),
             'Google Analytics': {
                 'clientId': tracking_context.get('client_id')
             }


### PR DESCRIPTION
[ECOM-2104](https://openedx.atlassian.net/browse/ECOM-2104)

Adding the `ip` to the context passed to Segment will prevent the requests from looking like the are originating from the Segment servers in Boardman, OR.
