### PR TITLE
Enroll CCX coaches in the courses to which they're added

### DIFF
--- a/lms/djangoapps/instructor/access.py
+++ b/lms/djangoapps/instructor/access.py
@@ -19,6 +19,10 @@ from student.roles import (
     CourseStaffRole,
 )
 
+from instructor.enrollment import (
+    enroll_email,
+    get_email_params,
+)
 
 log = logging.getLogger(__name__)
 
@@ -75,6 +79,15 @@ def _change_access(course, user, level, action):
         raise ValueError("unrecognized level '{}'".format(level))
 
     if action == 'allow':
+        if level == 'ccx_coach':
+            email_params = get_email_params(course, True)
+            enroll_email(
+                course_id=course.id,
+                student_email=user.email,
+                auto_enroll=True,
+                email_students=True,
+                email_params=email_params,
+            )
         role.add_users(user)
     elif action == 'revoke':
         role.remove_users(user)

--- a/lms/djangoapps/instructor/tests/test_access.py
+++ b/lms/djangoapps/instructor/tests/test_access.py
@@ -8,7 +8,7 @@ from student.tests.factories import UserFactory
 from xmodule.modulestore.tests.factories import CourseFactory
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 
-from student.roles import CourseBetaTesterRole, CourseStaffRole
+from student.roles import CourseBetaTesterRole, CourseStaffRole, CourseCcxCoachRole
 
 from django_comment_common.models import (Role,
                                           FORUM_ROLE_MODERATOR)
@@ -67,6 +67,11 @@ class TestInstructorAccessAllow(SharedModuleStoreTestCase):
         allow_access(self.course, user, 'staff')
         allow_access(self.course, user, 'staff')
         self.assertTrue(CourseStaffRole(self.course.id).has_user(user))
+
+    def test_allow_ccx_coach(self):
+        user = UserFactory()
+        allow_access(self.course, user, 'ccx_coach')
+        self.assertTrue(CourseCcxCoachRole(self.course.id).has_user(user))
 
     def test_allow_beta(self):
         """ Test allow beta against list beta. """


### PR DESCRIPTION
Hi EdX,

First PR for me. I'm a new member of the [MIT ODL engineering team](http://odl.mit.edu/about/our-team/jamie-folsom). (I think that means I'm covered by our institutional agreement?) This one is a small change that addresses a rough edge of CCX. 

**Motivation:** MIT ODL issue https://github.com/mitocw/edx-platform/issues/37. A user who is registered but not enrolled in the course, when added as a CCX coach, is not enrolled, and therefore can't see the courseware which s/he is the coach of. In other words, users must be both enrolled manually and added as CCX coaches manually. This PR makes that one step.

**Changes**: Only LMS is affected by this change, and apart from the behavior described below, under "How to test", the only user-visible effect is that the CCX coach gets an email notifying her/him that they've been enrolled in the course. For an instructor adding a coach, there is now one fewer step. This PR makes no change to the behavior of LMS in the case that the user being added is not registered at all.

**How to test**:
[First, enable CCX](http://edx-installing-configuring-and-running.readthedocs.org/en/latest/configuration/enable_ccx.html).

_Before checking out this PR (ie, while running edx-platform master):_
1. Visit the instructor dashboard, (eg: ``/courses/course-v1:edX+DemoX+Demo_Course/instructor#view-membership`)
2. From the "Course Team Management" block, select "CCX Coaches": 
   ![image](https://cloud.githubusercontent.com/assets/882377/10201819/e720cea0-677b-11e5-82f6-d58c2a53949a.png)
3. Enter the username or email of a user who is _not_ currently enrolled in the course:
   ![image](https://cloud.githubusercontent.com/assets/882377/10199750/5d640ea8-6770-11e5-890b-931c9c7d12b9.png)
4. Note that if you then attempt to unenroll that same user, you get a message, indicating that the user is not enrolled in the course:
   ![image](https://cloud.githubusercontent.com/assets/882377/10201828/f1cf4250-677b-11e5-8a0d-9cde1ac267ab.png)

_After checking out this PR:_
1. Repeat steps 1 and 2 above
2. Remove that user as a CCX coach.
3. Add that user as a CCX coach.
4. Unenroll that user from the course, and you will see that the user's been unenrolled successfully, indicating that the user was enrolled in the process of being added as a CCX coach:
   ![image](https://cloud.githubusercontent.com/assets/882377/10201835/f86c562a-677b-11e5-9ddd-ca4286814307.png)

Fixes https://github.com/mitocw/edx-platform/issues/37
