### PR TITLE
Fix model imports so they are always imported the same way.

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -789,6 +789,11 @@ INSTALLED_APPS = (
 
     # edX Proctoring
     'edx_proctoring',
+
+    # These are apps that aren't strictly needed by Studio, but are imported by
+    # other apps that are.  Django 1.8 wants to have imported models supported
+    # by installed apps.
+    'lms.djangoapps.verify_student',
 )
 
 

--- a/common/djangoapps/course_modes/admin.py
+++ b/common/djangoapps/course_modes/admin.py
@@ -26,7 +26,7 @@ from course_modes.models import CourseMode
 # The admin page will work in both LMS and Studio,
 # but the test suite for Studio will fail because
 # the verification deadline table won't exist.
-from verify_student import models as verification_models  # pylint: disable=import-error
+from lms.djangoapps.verify_student import models as verification_models
 
 
 class CourseModeForm(forms.ModelForm):

--- a/common/djangoapps/course_modes/tests/test_admin.py
+++ b/common/djangoapps/course_modes/tests/test_admin.py
@@ -21,7 +21,7 @@ from course_modes.admin import CourseModeForm
 # defined in the LMS and course_modes is in common.  However, the benefits
 # of putting all this configuration in one place outweigh the downsides.
 # Once the course admin tool is deployed, we can remove this dependency.
-from verify_student.models import VerificationDeadline  # pylint: disable=import-error
+from lms.djangoapps.verify_student.models import VerificationDeadline
 
 
 # We can only test this in the LMS because the course modes admin relies

--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -6,7 +6,7 @@ from pytz import UTC
 from django.core.urlresolvers import reverse, NoReverseMatch
 
 import third_party_auth
-from verify_student.models import VerificationDeadline, SoftwareSecurePhotoVerification  # pylint: disable=import-error
+from lms.djangoapps.verify_student.models import VerificationDeadline, SoftwareSecurePhotoVerification
 from course_modes.models import CourseMode
 
 

--- a/common/djangoapps/student/tests/test_verification_status.py
+++ b/common/djangoapps/student/tests/test_verification_status.py
@@ -20,7 +20,7 @@ from xmodule.modulestore.tests.factories import CourseFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from student.tests.factories import UserFactory, CourseEnrollmentFactory
 from course_modes.tests.factories import CourseModeFactory
-from verify_student.models import VerificationDeadline, SoftwareSecurePhotoVerification  # pylint: disable=import-error
+from lms.djangoapps.verify_student.models import VerificationDeadline, SoftwareSecurePhotoVerification
 from util.testing import UrlResetMixin
 
 

--- a/common/djangoapps/student/tests/tests.py
+++ b/common/djangoapps/student/tests/tests.py
@@ -35,7 +35,7 @@ from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, ModuleSt
 from bulk_email.models import Optout  # pylint: disable=import-error
 from certificates.models import CertificateStatuses  # pylint: disable=import-error
 from certificates.tests.factories import GeneratedCertificateFactory  # pylint: disable=import-error
-from verify_student.models import SoftwareSecurePhotoVerification
+from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification
 import shoppingcart  # pylint: disable=import-error
 
 # Explicitly import the cache from ConfigurationModel so we can reset it after each test

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -54,7 +54,7 @@ from student.models import (
     DashboardConfiguration, LinkedInAddToProfileConfiguration, ManualEnrollmentAudit, ALLOWEDTOENROLL_TO_ENROLLED)
 from student.forms import AccountCreationForm, PasswordResetFormNoActive
 
-from verify_student.models import SoftwareSecurePhotoVerification  # pylint: disable=import-error
+from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification
 from certificates.models import CertificateStatuses, certificate_status_for_student
 from certificates.api import (  # pylint: disable=import-error
     get_certificate_url,

--- a/common/lib/xmodule/xmodule/modulestore/django.py
+++ b/common/lib/xmodule/xmodule/modulestore/django.py
@@ -214,7 +214,7 @@ def modulestore():
             # should be updated to have a setting that enumerates modulestore
             # wrappers and then uses that setting to wrap the modulestore in
             # appropriate wrappers depending on enabled features.
-            from ccx.modulestore import CCXModulestoreWrapper  # pylint: disable=import-error
+            from lms.djangoapps.ccx.modulestore import CCXModulestoreWrapper
             _MIXED_MODULESTORE = CCXModulestoreWrapper(_MIXED_MODULESTORE)
 
     return _MIXED_MODULESTORE

--- a/lms/djangoapps/ccx/overrides.py
+++ b/lms/djangoapps/ccx/overrides.py
@@ -13,7 +13,7 @@ from courseware.field_overrides import FieldOverrideProvider  # pylint: disable=
 from opaque_keys.edx.keys import CourseKey, UsageKey
 from ccx_keys.locator import CCXLocator, CCXBlockUsageLocator
 
-from .models import CcxFieldOverride, CustomCourseForEdX
+from lms.djangoapps.ccx.models import CcxFieldOverride, CustomCourseForEdX
 
 
 log = logging.getLogger(__name__)

--- a/lms/djangoapps/ccx/tasks.py
+++ b/lms/djangoapps/ccx/tasks.py
@@ -11,7 +11,7 @@ from ccx_keys.locator import CCXLocator
 from xmodule.modulestore.django import SignalHandler
 from lms import CELERY_APP
 
-from .models import CustomCourseForEdX
+from lms.djangoapps.ccx.models import CustomCourseForEdX
 
 log = logging.getLogger("edx.ccx")
 

--- a/lms/djangoapps/ccx/tests/factories.py
+++ b/lms/djangoapps/ccx/tests/factories.py
@@ -4,7 +4,7 @@ Dummy factories for tests
 from factory import SubFactory
 from factory.django import DjangoModelFactory
 from student.tests.factories import UserFactory
-from ccx.models import CustomCourseForEdX  # pylint: disable=import-error
+from lms.djangoapps.ccx.models import CustomCourseForEdX
 
 
 class CcxFactory(DjangoModelFactory):  # pylint: disable=missing-docstring

--- a/lms/djangoapps/ccx/tests/test_ccx_modulestore.py
+++ b/lms/djangoapps/ccx/tests/test_ccx_modulestore.py
@@ -14,7 +14,7 @@ from xmodule.modulestore.tests.django_utils import (
 from student.tests.factories import UserFactory
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
-from ..models import CustomCourseForEdX
+from lms.djangoapps.ccx.models import CustomCourseForEdX
 
 
 class TestCCXModulestoreWrapper(SharedModuleStoreTestCase):

--- a/lms/djangoapps/ccx/tests/test_field_override_performance.py
+++ b/lms/djangoapps/ccx/tests/test_field_override_performance.py
@@ -27,7 +27,7 @@ from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, \
 from xmodule.modulestore.tests.factories import check_mongo_calls_range, CourseFactory, check_sum_of_calls
 from xmodule.modulestore.tests.utils import ProceduralCourseTestMixin
 from ccx_keys.locator import CCXLocator
-from ccx.tests.factories import CcxFactory
+from lms.djangoapps.ccx.tests.factories import CcxFactory
 
 
 @attr('shard_1')

--- a/lms/djangoapps/ccx/tests/test_overrides.py
+++ b/lms/djangoapps/ccx/tests/test_overrides.py
@@ -16,10 +16,10 @@ from xmodule.modulestore.tests.django_utils import (
     TEST_DATA_SPLIT_MODULESTORE)
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
-from ..models import CustomCourseForEdX
-from ..overrides import override_field_for_ccx
+from lms.djangoapps.ccx.models import CustomCourseForEdX
+from lms.djangoapps.ccx.overrides import override_field_for_ccx
 
-from .test_views import flatten, iter_blocks
+from lms.djangoapps.ccx.tests.test_views import flatten, iter_blocks
 
 
 @attr('shard_1')

--- a/lms/djangoapps/ccx/tests/test_tasks.py
+++ b/lms/djangoapps/ccx/tests/test_tasks.py
@@ -4,9 +4,7 @@ Tests for celery tasks defined in tasks module
 
 from mock_django import mock_signal_receiver
 
-from ccx.tests.factories import (  # pylint: disable=import-error
-    CcxFactory,
-)
+from lms.djangoapps.ccx.tests.factories import CcxFactory
 from student.roles import CourseCcxCoachRole  # pylint: disable=import-error
 from student.tests.factories import (  # pylint: disable=import-error
     AdminFactory,
@@ -21,7 +19,7 @@ from openedx.core.djangoapps.content.course_overviews.models import CourseOvervi
 
 from ccx_keys.locator import CCXLocator
 
-from ..tasks import send_ccx_course_published
+from lms.djangoapps.ccx.tasks import send_ccx_course_published
 
 
 class TestSendCCXCoursePublished(ModuleStoreTestCase):

--- a/lms/djangoapps/ccx/tests/test_utils.py
+++ b/lms/djangoapps/ccx/tests/test_utils.py
@@ -3,9 +3,7 @@ test utils
 """
 from nose.plugins.attrib import attr
 
-from ccx.tests.factories import (  # pylint: disable=import-error
-    CcxFactory,
-)
+from lms.djangoapps.ccx.tests.factories import CcxFactory
 from student.roles import CourseCcxCoachRole  # pylint: disable=import-error
 from student.tests.factories import (  # pylint: disable=import-error
     AdminFactory,
@@ -33,7 +31,7 @@ class TestGetCCXFromCCXLocator(ModuleStoreTestCase):
 
     def call_fut(self, course_id):
         """call the function under test in this test case"""
-        from ccx.utils import get_ccx_from_ccx_locator
+        from lms.djangoapps.ccx.utils import get_ccx_from_ccx_locator
         return get_ccx_from_ccx_locator(course_id)
 
     def test_non_ccx_locator(self):

--- a/lms/djangoapps/ccx/tests/test_views.py
+++ b/lms/djangoapps/ccx/tests/test_views.py
@@ -44,13 +44,9 @@ from xmodule.modulestore.tests.factories import (
 )
 from ccx_keys.locator import CCXLocator
 
-from ..models import (
-    CustomCourseForEdX,
-)
-from ..overrides import get_override_for_ccx, override_field_for_ccx
-from .factories import (
-    CcxFactory,
-)
+from lms.djangoapps.ccx.models import CustomCourseForEdX
+from lms.djangoapps.ccx.overrides import get_override_for_ccx, override_field_for_ccx
+from lms.djangoapps.ccx.tests.factories import CcxFactory
 
 
 def intercept_renderer(path, context):

--- a/lms/djangoapps/ccx/utils.py
+++ b/lms/djangoapps/ccx/utils.py
@@ -5,7 +5,7 @@ Does not include any access control, be sure to check access before calling.
 """
 import logging
 
-from .models import CustomCourseForEdX
+from lms.djangoapps.ccx.models import CustomCourseForEdX
 
 
 log = logging.getLogger("edx.ccx")

--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -48,9 +48,8 @@ from instructor.enrollment import (
     get_email_params,
 )
 
-from .models import CustomCourseForEdX
-from .overrides import (
-    clear_override_for_ccx,
+from lms.djangoapps.ccx.models import CustomCourseForEdX
+from lms.djangoapps.ccx.overrides import (
     get_override_for_ccx,
     override_field_for_ccx,
     clear_ccx_field_info_from_ccx_map,

--- a/lms/djangoapps/certificates/queue.py
+++ b/lms/djangoapps/certificates/queue.py
@@ -17,7 +17,7 @@ from capa.xqueue_interface import XQueueInterface
 from capa.xqueue_interface import make_xheader, make_hashkey
 from course_modes.models import CourseMode
 from student.models import UserProfile, CourseEnrollment
-from verify_student.models import SoftwareSecurePhotoVerification
+from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification
 
 from certificates.models import (
     GeneratedCertificate,

--- a/lms/djangoapps/certificates/tests/test_queue.py
+++ b/lms/djangoapps/certificates/tests/test_queue.py
@@ -29,7 +29,7 @@ from certificates.models import (
     GeneratedCertificate,
     CertificateStatuses,
 )
-from verify_student.tests.factories import SoftwareSecurePhotoVerificationFactory
+from lms.djangoapps.verify_student.tests.factories import SoftwareSecurePhotoVerificationFactory
 
 
 @ddt.ddt

--- a/lms/djangoapps/commerce/api/v1/models.py
+++ b/lms/djangoapps/commerce/api/v1/models.py
@@ -7,7 +7,7 @@ from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from course_modes.models import CourseMode
-from verify_student.models import VerificationDeadline
+from lms.djangoapps.verify_student.models import VerificationDeadline
 
 log = logging.getLogger(__name__)
 

--- a/lms/djangoapps/commerce/api/v1/tests/test_views.py
+++ b/lms/djangoapps/commerce/api/v1/tests/test_views.py
@@ -16,7 +16,7 @@ from xmodule.modulestore.tests.factories import CourseFactory
 
 from course_modes.models import CourseMode
 from student.tests.factories import UserFactory
-from verify_student.models import VerificationDeadline
+from lms.djangoapps.verify_student.models import VerificationDeadline
 
 PASSWORD = 'test'
 JSON_CONTENT_TYPE = 'application/json'

--- a/lms/djangoapps/commerce/views.py
+++ b/lms/djangoapps/commerce/views.py
@@ -7,7 +7,7 @@ from django.views.decorators.csrf import csrf_exempt
 
 from edxmako.shortcuts import render_to_response
 from microsite_configuration import microsite
-from verify_student.models import SoftwareSecurePhotoVerification
+from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification
 from shoppingcart.processors.CyberSource2 import is_user_payment_error
 from django.utils.translation import ugettext as _
 

--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -77,7 +77,7 @@ from util.json_request import JsonResponse
 from util.model_utils import slugify
 from util.sandboxing import can_execute_unsafe_code, get_python_lib_zip
 from util import milestones_helpers
-from verify_student.services import ReverificationService
+from lms.djangoapps.verify_student.services import ReverificationService
 
 from edx_proctoring.services import ProctoringService
 from openedx.core.djangoapps.credit.services import CreditService

--- a/lms/djangoapps/django_comment_client/forum/views.py
+++ b/lms/djangoapps/django_comment_client/forum/views.py
@@ -27,7 +27,7 @@ from openedx.core.djangoapps.course_groups.cohorts import (
 from courseware.tabs import EnrolledTab
 from courseware.access import has_access
 from xmodule.modulestore.django import modulestore
-from ccx.overrides import get_current_ccx
+from lms.djangoapps.ccx.overrides import get_current_ccx
 
 from django_comment_common.utils import ThreadContext
 from django_comment_client.permissions import has_permission, get_team

--- a/lms/djangoapps/django_comment_client/permissions.py
+++ b/lms/djangoapps/django_comment_client/permissions.py
@@ -10,7 +10,7 @@ from lms.lib.comment_client import Thread
 from opaque_keys.edx.keys import CourseKey
 
 from django_comment_common.models import all_permissions_for_user_in_course
-from teams.models import CourseTeam
+from lms.djangoapps.teams.models import CourseTeam
 
 
 def has_permission(user, permission, course_id=None):

--- a/lms/djangoapps/instructor/tests/test_enrollment.py
+++ b/lms/djangoapps/instructor/tests/test_enrollment.py
@@ -18,7 +18,7 @@ from student.tests.factories import UserFactory
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
-from ccx.tests.factories import CcxFactory
+from lms.djangoapps.ccx.tests.factories import CcxFactory
 from student.models import CourseEnrollment, CourseEnrollmentAllowed
 from student.roles import CourseCcxCoachRole  # pylint: disable=import-error
 from student.tests.factories import (  # pylint: disable=import-error

--- a/lms/djangoapps/instructor_task/tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tasks_helper.py
@@ -63,7 +63,7 @@ from opaque_keys.edx.keys import UsageKey
 from openedx.core.djangoapps.course_groups.cohorts import add_user_to_cohort, is_course_cohorted
 from student.models import CourseEnrollment, CourseAccessRole
 from teams.models import CourseTeamMembership
-from verify_student.models import SoftwareSecurePhotoVerification
+from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification
 
 # define different loggers for use within tasks and on client side
 TASK_LOG = logging.getLogger('edx.celery.task')

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -28,7 +28,7 @@ from shoppingcart.models import Order, PaidCourseRegistration, CourseRegistratio
     CourseRegistrationCodeInvoiceItem, InvoiceTransaction, Coupon
 from student.tests.factories import UserFactory, CourseModeFactory
 from student.models import CourseEnrollment, CourseEnrollmentAllowed, ManualEnrollmentAudit, ALLOWEDTOENROLL_TO_ENROLLED
-from verify_student.tests.factories import SoftwareSecurePhotoVerificationFactory
+from lms.djangoapps.verify_student.tests.factories import SoftwareSecurePhotoVerificationFactory
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 from xmodule.partitions.partitions import Group, UserPartition
 from instructor_task.models import ReportStore

--- a/lms/djangoapps/shoppingcart/models.py
+++ b/lms/djangoapps/shoppingcart/models.py
@@ -32,7 +32,7 @@ from django.core.mail.message import EmailMessage
 from xmodule.modulestore.django import modulestore
 from eventtracking import tracker
 
-from courseware.courses import get_course_by_id
+import courseware
 from config_models.models import ConfigurationModel
 from course_modes.models import CourseMode
 from edxmako.shortcuts import render_to_string
@@ -330,7 +330,7 @@ class Order(models.Model):
         csv_writer.writerow(['Course Name', 'Registration Code', 'URL'])
         for item in orderitems:
             course_id = item.course_id
-            course = get_course_by_id(getattr(item, 'course_id'), depth=0)
+            course = courseware.courses.get_course_by_id(item.course_id, depth=0)
             registration_codes = CourseRegistrationCode.objects.filter(course_id=course_id, order=self)
             course_info.append((course.display_name, ' (' + course.start_datetime_text() + '-' + course.end_datetime_text() + ')'))
             for registration_code in registration_codes:
@@ -758,7 +758,7 @@ class OrderItem(TimeStampedModel):
         """
         course_key = getattr(self, 'course_id', None)
         if course_key:
-            course = get_course_by_id(course_key, depth=0)
+            course = courseware.courses.get_course_by_id(course_key, depth=0)
             return course.display_name
         else:
             raise Exception(

--- a/lms/djangoapps/teams/management/commands/reindex_course_team.py
+++ b/lms/djangoapps/teams/management/commands/reindex_course_team.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from optparse import make_option
 from textwrap import dedent
 
-from teams.models import CourseTeam
+from lms.djangoapps.teams.models import CourseTeam
 
 
 class Command(BaseCommand):

--- a/lms/djangoapps/teams/search_indexes.py
+++ b/lms/djangoapps/teams/search_indexes.py
@@ -12,8 +12,8 @@ from functools import wraps
 from search.search_engine_base import SearchEngine
 from request_cache import get_request_or_stub
 
-from .errors import ElasticSearchConnectionError
-from .serializers import CourseTeamSerializer, CourseTeam
+from lms.djangoapps.teams.errors import ElasticSearchConnectionError
+from lms.djangoapps.teams.serializers import CourseTeamSerializer, CourseTeam
 
 
 def if_search_enabled(f):

--- a/lms/djangoapps/teams/serializers.py
+++ b/lms/djangoapps/teams/serializers.py
@@ -11,7 +11,7 @@ from openedx.core.lib.api.serializers import CollapsedReferenceSerializer
 from openedx.core.lib.api.fields import ExpandableField
 from openedx.core.djangoapps.user_api.accounts.serializers import UserReadOnlySerializer
 
-from .models import CourseTeam, CourseTeamMembership
+from lms.djangoapps.teams.models import CourseTeam, CourseTeamMembership
 
 
 class CountryField(serializers.Field):

--- a/lms/djangoapps/teams/tests/factories.py
+++ b/lms/djangoapps/teams/tests/factories.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 import factory
 from factory.django import DjangoModelFactory
 
-from ..models import CourseTeam, CourseTeamMembership
+from lms.djangoapps.teams.models import CourseTeam, CourseTeamMembership
 
 
 LAST_ACTIVITY_AT = datetime(2015, 8, 15, 0, 0, 0, tzinfo=pytz.utc)

--- a/lms/djangoapps/teams/tests/test_models.py
+++ b/lms/djangoapps/teams/tests/test_models.py
@@ -23,9 +23,9 @@ from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from opaque_keys.edx.keys import CourseKey
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
 
-from .factories import CourseTeamFactory, CourseTeamMembershipFactory
-from teams.models import CourseTeam, CourseTeamMembership
-from teams import TEAM_DISCUSSION_CONTEXT
+from lms.djangoapps.teams.tests.factories import CourseTeamFactory, CourseTeamMembershipFactory
+from lms.djangoapps.teams.models import CourseTeam, CourseTeamMembership
+from lms.djangoapps.teams import TEAM_DISCUSSION_CONTEXT
 from util.testing import EventTestMixin
 
 COURSE_KEY1 = CourseKey.from_string('edx/history/1')

--- a/lms/djangoapps/teams/tests/test_views.py
+++ b/lms/djangoapps/teams/tests/test_views.py
@@ -23,9 +23,9 @@ from common.test.utils import skip_signal
 from student.tests.factories import UserFactory, AdminFactory, CourseEnrollmentFactory
 from student.models import CourseEnrollment
 from util.testing import EventTestMixin
-from .factories import CourseTeamFactory, LAST_ACTIVITY_AT
-from ..models import CourseTeamMembership
-from ..search_indexes import CourseTeamIndexer, CourseTeam, course_team_post_save_callback
+from lms.djangoapps.teams.tests.factories import CourseTeamFactory, LAST_ACTIVITY_AT
+from lms.djangoapps.teams.models import CourseTeamMembership
+from lms.djangoapps.teams.search_indexes import CourseTeamIndexer, CourseTeam, course_team_post_save_callback
 from django_comment_common.models import Role, FORUM_ROLE_COMMUNITY_TA
 from django_comment_common.utils import seed_permissions_roles
 

--- a/lms/djangoapps/teams/views.py
+++ b/lms/djangoapps/teams/views.py
@@ -38,8 +38,8 @@ from student.roles import CourseStaffRole
 from django_comment_client.utils import has_discussion_privileges
 from teams import is_feature_enabled
 from util.model_utils import truncate_fields
-from .models import CourseTeam, CourseTeamMembership
-from .serializers import (
+from lms.djangoapps.teams.models import CourseTeam, CourseTeamMembership
+from lms.djangoapps.teams.serializers import (
     CourseTeamSerializer,
     CourseTeamCreationSerializer,
     TopicSerializer,
@@ -47,9 +47,9 @@ from .serializers import (
     MembershipSerializer,
     add_team_count
 )
-from .search_indexes import CourseTeamIndexer
-from .errors import AlreadyOnTeamInCourse, ElasticSearchConnectionError, NotEnrolledInCourseForTeam
-from .utils import emit_team_event
+from lms.djangoapps.teams.search_indexes import CourseTeamIndexer
+from lms.djangoapps.teams.errors import AlreadyOnTeamInCourse, ElasticSearchConnectionError, NotEnrolledInCourseForTeam
+from lms.djangoapps.teams.utils import emit_team_event
 
 TEAM_MEMBERSHIPS_PER_PAGE = 2
 TOPICS_PER_PAGE = 12

--- a/lms/djangoapps/verify_student/admin.py
+++ b/lms/djangoapps/verify_student/admin.py
@@ -1,5 +1,5 @@
 from ratelimitbackend import admin
-from verify_student.models import (
+from lms.djangoapps.verify_student.models import (
     SoftwareSecurePhotoVerification,
     VerificationStatus,
     SkippedReverification,

--- a/lms/djangoapps/verify_student/management/commands/retry_failed_photo_verifications.py
+++ b/lms/djangoapps/verify_student/management/commands/retry_failed_photo_verifications.py
@@ -2,7 +2,7 @@
 Django admin commands related to verify_student
 """
 
-from verify_student.models import SoftwareSecurePhotoVerification
+from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification
 from django.core.management.base import BaseCommand
 
 

--- a/lms/djangoapps/verify_student/management/commands/tests/test_verify_student.py
+++ b/lms/djangoapps/verify_student/management/commands/tests/test_verify_student.py
@@ -10,9 +10,9 @@ from django.test import TestCase
 from django.conf import settings
 
 from student.tests.factories import UserFactory
-from verify_student.models import SoftwareSecurePhotoVerification
+from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification
 from django.core.management import call_command
-from verify_student.tests.test_models import (
+from lms.djangoapps.verify_student.tests.test_models import (
     MockKey, MockS3Connection, mock_software_secure_post,
     mock_software_secure_post_error, FAKE_SETTINGS,
 )
@@ -20,9 +20,9 @@ from verify_student.tests.test_models import (
 
 # Lots of patching to stub in our own settings, S3 substitutes, and HTTP posting
 @patch.dict(settings.VERIFY_STUDENT, FAKE_SETTINGS)
-@patch('verify_student.models.S3Connection', new=MockS3Connection)
-@patch('verify_student.models.Key', new=MockKey)
-@patch('verify_student.models.requests.post', new=mock_software_secure_post)
+@patch('lms.djangoapps.verify_student.models.S3Connection', new=MockS3Connection)
+@patch('lms.djangoapps.verify_student.models.Key', new=MockKey)
+@patch('lms.djangoapps.verify_student.models.requests.post', new=mock_software_secure_post)
 class TestVerifyStudentCommand(TestCase):
     """
     Tests for django admin commands in the verify_student module
@@ -48,9 +48,9 @@ class TestVerifyStudentCommand(TestCase):
         """
         # set up some fake data to use...
         self.create_and_submit("SuccessfulSally")
-        with patch('verify_student.models.requests.post', new=mock_software_secure_post_error):
+        with patch('lms.djangoapps.verify_student.models.requests.post', new=mock_software_secure_post_error):
             self.create_and_submit("RetryRoger")
-        with patch('verify_student.models.requests.post', new=mock_software_secure_post_error):
+        with patch('lms.djangoapps.verify_student.models.requests.post', new=mock_software_secure_post_error):
             self.create_and_submit("RetryRick")
         # check to make sure we had two successes and two failures; otherwise we've got problems elsewhere
         assert_equals(len(SoftwareSecurePhotoVerification.objects.filter(status="submitted")), 1)

--- a/lms/djangoapps/verify_student/models.py
+++ b/lms/djangoapps/verify_student/models.py
@@ -36,7 +36,7 @@ from config_models.models import ConfigurationModel
 from course_modes.models import CourseMode
 from model_utils.models import StatusModel, TimeStampedModel
 from model_utils import Choices
-from verify_student.ssencrypt import (
+from lms.djangoapps.verify_student.ssencrypt import (
     random_aes_key, encrypt_and_encode,
     generate_signed_message, rsa_encrypt
 )

--- a/lms/djangoapps/verify_student/services.py
+++ b/lms/djangoapps/verify_student/services.py
@@ -11,7 +11,7 @@ from django.db import IntegrityError
 from opaque_keys.edx.keys import CourseKey
 
 from student.models import User, CourseEnrollment
-from verify_student.models import VerificationCheckpoint, VerificationStatus, SkippedReverification
+from lms.djangoapps.verify_student.models import VerificationCheckpoint, VerificationStatus, SkippedReverification
 
 
 log = logging.getLogger(__name__)

--- a/lms/djangoapps/verify_student/tests/factories.py
+++ b/lms/djangoapps/verify_student/tests/factories.py
@@ -3,7 +3,7 @@ Factories related to student verification.
 """
 
 from factory.django import DjangoModelFactory
-from verify_student.models import SoftwareSecurePhotoVerification
+from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification
 
 
 class SoftwareSecurePhotoVerificationFactory(DjangoModelFactory):

--- a/lms/djangoapps/verify_student/tests/fake_software_secure.py
+++ b/lms/djangoapps/verify_student/tests/fake_software_secure.py
@@ -9,7 +9,7 @@ from django.utils.decorators import method_decorator
 from django.views.generic.base import View
 
 from edxmako.shortcuts import render_to_response
-from verify_student.models import SoftwareSecurePhotoVerification
+from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification
 
 
 class SoftwareSecureFakeView(View):

--- a/lms/djangoapps/verify_student/tests/test_fake_software_secure.py
+++ b/lms/djangoapps/verify_student/tests/test_fake_software_secure.py
@@ -7,7 +7,7 @@ from django.test import TestCase
 from mock import patch
 from student.tests.factories import UserFactory
 from util.testing import UrlResetMixin
-from verify_student.models import SoftwareSecurePhotoVerification
+from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification
 
 
 class SoftwareSecureFakeViewTest(UrlResetMixin, TestCase):

--- a/lms/djangoapps/verify_student/tests/test_models.py
+++ b/lms/djangoapps/verify_student/tests/test_models.py
@@ -17,7 +17,7 @@ from xmodule.modulestore.tests.factories import CourseFactory
 
 from opaque_keys.edx.keys import CourseKey
 
-from verify_student.models import (
+from lms.djangoapps.verify_student.models import (
     SoftwareSecurePhotoVerification,
     VerificationException, VerificationCheckpoint,
     VerificationStatus, SkippedReverification,
@@ -127,9 +127,9 @@ def mock_software_secure_post_unavailable(url, headers=None, data=None, **kwargs
 
 # Lots of patching to stub in our own settings, S3 substitutes, and HTTP posting
 @patch.dict(settings.VERIFY_STUDENT, FAKE_SETTINGS)
-@patch('verify_student.models.S3Connection', new=MockS3Connection)
-@patch('verify_student.models.Key', new=MockKey)
-@patch('verify_student.models.requests.post', new=mock_software_secure_post)
+@patch('lms.djangoapps.verify_student.models.S3Connection', new=MockS3Connection)
+@patch('lms.djangoapps.verify_student.models.Key', new=MockKey)
+@patch('lms.djangoapps.verify_student.models.requests.post', new=mock_software_secure_post)
 @ddt.ddt
 class TestPhotoVerification(ModuleStoreTestCase):
 
@@ -227,12 +227,12 @@ class TestPhotoVerification(ModuleStoreTestCase):
         assert_equals(attempt.status, "submitted")
 
         # We post, but Software Secure doesn't like what we send for some reason
-        with patch('verify_student.models.requests.post', new=mock_software_secure_post_error):
+        with patch('lms.djangoapps.verify_student.models.requests.post', new=mock_software_secure_post_error):
             attempt = self.create_and_submit()
             assert_equals(attempt.status, "must_retry")
 
         # We try to post, but run into an error (in this case a newtork connection error)
-        with patch('verify_student.models.requests.post', new=mock_software_secure_post_unavailable):
+        with patch('lms.djangoapps.verify_student.models.requests.post', new=mock_software_secure_post_unavailable):
             attempt = self.create_and_submit()
             assert_equals(attempt.status, "must_retry")
 
@@ -465,7 +465,9 @@ class TestPhotoVerification(ModuleStoreTestCase):
         user = UserFactory.create()
         course = CourseFactory.create()
 
-        with patch('verify_student.models.SoftwareSecurePhotoVerification.user_is_verified') as mock_verification:
+        with patch(
+            'lms.djangoapps.verify_student.models.SoftwareSecurePhotoVerification.user_is_verified'
+        ) as mock_verification:
 
             mock_verification.return_value = status
 

--- a/lms/djangoapps/verify_student/tests/test_services.py
+++ b/lms/djangoapps/verify_student/tests/test_services.py
@@ -8,8 +8,8 @@ from course_modes.models import CourseMode
 from course_modes.tests.factories import CourseModeFactory
 from student.models import CourseEnrollment
 from student.tests.factories import UserFactory
-from verify_student.models import VerificationCheckpoint, VerificationStatus, SkippedReverification
-from verify_student.services import ReverificationService
+from lms.djangoapps.verify_student.models import VerificationCheckpoint, VerificationStatus, SkippedReverification
+from lms.djangoapps.verify_student.services import ReverificationService
 
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory

--- a/lms/djangoapps/verify_student/tests/test_ssencrypt.py
+++ b/lms/djangoapps/verify_student/tests/test_ssencrypt.py
@@ -1,7 +1,7 @@
 import base64
 from nose.tools import assert_equals
 
-from verify_student.ssencrypt import (
+from lms.djangoapps.verify_student.ssencrypt import (
     aes_decrypt, aes_encrypt, encrypt_and_encode, decode_and_decrypt,
     rsa_decrypt, rsa_encrypt
 )

--- a/lms/djangoapps/verify_student/tests/test_views.py
+++ b/lms/djangoapps/verify_student/tests/test_views.py
@@ -42,11 +42,11 @@ from student.tests.factories import UserFactory, CourseEnrollmentFactory
 from student.models import CourseEnrollment
 from util.date_utils import get_default_time_display
 from util.testing import UrlResetMixin
-from verify_student.views import (
+from lms.djangoapps.verify_student.views import (
     checkout_with_ecommerce_service, render_to_response, PayAndVerifyView,
     _compose_message_reverification_email
 )
-from verify_student.models import (
+from lms.djangoapps.verify_student.models import (
     VerificationDeadline, SoftwareSecurePhotoVerification,
     VerificationCheckpoint, VerificationStatus
 )

--- a/lms/djangoapps/verify_student/urls.py
+++ b/lms/djangoapps/verify_student/urls.py
@@ -3,7 +3,7 @@
 from django.conf import settings
 from django.conf.urls import patterns, url
 
-from verify_student import views
+from lms.djangoapps.verify_student import views
 
 
 urlpatterns = patterns(
@@ -111,7 +111,7 @@ urlpatterns = patterns(
 
 # Fake response page for incourse reverification ( software secure )
 if settings.FEATURES.get('ENABLE_SOFTWARE_SECURE_FAKE'):
-    from verify_student.tests.fake_software_secure import SoftwareSecureFakeView
+    from lms.djangoapps.verify_student.tests.fake_software_secure import SoftwareSecureFakeView
     urlpatterns += patterns(
         'verify_student.tests.fake_software_secure',
         url(r'^software-secure-fake-response', SoftwareSecureFakeView.as_view()),

--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -46,14 +46,14 @@ from shoppingcart.models import Order, CertificateItem
 from shoppingcart.processors import (
     get_signed_purchase_params, get_purchase_endpoint
 )
-from verify_student.ssencrypt import has_valid_signature
-from verify_student.models import (
+from lms.djangoapps.verify_student.ssencrypt import has_valid_signature
+from lms.djangoapps.verify_student.models import (
     VerificationDeadline,
     SoftwareSecurePhotoVerification,
     VerificationCheckpoint,
     VerificationStatus,
 )
-from verify_student.image import decode_image_data, InvalidImageData
+from lms.djangoapps.verify_student.image import decode_image_data, InvalidImageData
 from util.json_request import JsonResponse
 from util.date_utils import get_default_time_display
 from xmodule.modulestore.django import modulestore

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -665,9 +665,9 @@ ECOMMERCE_API_TIMEOUT = ENV_TOKENS.get('ECOMMERCE_API_TIMEOUT', ECOMMERCE_API_TI
 
 ##### Custom Courses for EdX #####
 if FEATURES.get('CUSTOM_COURSES_EDX'):
-    INSTALLED_APPS += ('ccx',)
+    INSTALLED_APPS += ('lms.djangoapps.ccx',)
     FIELD_OVERRIDE_PROVIDERS += (
-        'ccx.overrides.CustomCoursesForEdxOverrideProvider',
+        'lms.djangoapps.ccx.overrides.CustomCoursesForEdxOverrideProvider',
     )
 
 ##### Individual Due Date Extensions #####

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1939,6 +1939,7 @@ INSTALLED_APPS = (
 
     # edX Mobile API
     'mobile_api',
+    'social.apps.django_app.default',
 
     # Surveys
     'survey',

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1912,7 +1912,7 @@ INSTALLED_APPS = (
     'enrollment',
 
     # Student Identity Verification
-    'verify_student',
+    'lms.djangoapps.verify_student',
 
     # Dark-launching languages
     'dark_lang',
@@ -1962,7 +1962,7 @@ INSTALLED_APPS = (
     'openedx.core.djangoapps.credit',
 
     # Course teams
-    'teams',
+    'lms.djangoapps.teams',
 
     'xblock_django',
 )

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -508,7 +508,7 @@ FACEBOOK_APP_ID = "Test"
 FACEBOOK_API_VERSION = "v2.2"
 
 ######### custom courses #########
-INSTALLED_APPS += ('ccx',)
+INSTALLED_APPS += ('lms.djangoapps.ccx',)
 FEATURES['CUSTOM_COURSES_EDX'] = True
 
 # Set dummy values for profile image settings.

--- a/lms/envs/yaml_config.py
+++ b/lms/envs/yaml_config.py
@@ -303,9 +303,9 @@ GRADES_DOWNLOAD_ROUTING_KEY = HIGH_MEM_QUEUE
 
 ##### Custom Courses for EdX #####
 if FEATURES.get('CUSTOM_COURSES_EDX'):
-    INSTALLED_APPS += ('ccx',)
+    INSTALLED_APPS += ('lms.djangoapps.ccx',)
     FIELD_OVERRIDE_PROVIDERS += (
-        'ccx.overrides.CustomCoursesForEdxOverrideProvider',
+        'lms.djangoapps.ccx.overrides.CustomCoursesForEdxOverrideProvider',
     )
 
 ##### Individual Due Date Extensions #####

--- a/lms/templates/navigation.html
+++ b/lms/templates/navigation.html
@@ -7,7 +7,7 @@ from django.utils.translation import ugettext as _
 
 from microsite_configuration import microsite
 from microsite_configuration.templatetags.microsite import platform_name
-from ccx.overrides import get_current_ccx
+from lms.djangoapps.ccx.overrides import get_current_ccx
 
 # App that handles subdomain specific branding
 import branding

--- a/lms/templates/verify_student/missed_deadline.html
+++ b/lms/templates/verify_student/missed_deadline.html
@@ -1,6 +1,6 @@
 <%!
 from django.utils.translation import ugettext as _
-from verify_student.views import PayAndVerifyView
+from lms.djangoapps.verify_student.views import PayAndVerifyView
 %>
 <%namespace name='static' file='../static_content.html'/>
 

--- a/lms/templates/verify_student/pay_and_verify.html
+++ b/lms/templates/verify_student/pay_and_verify.html
@@ -1,7 +1,7 @@
 <%!
 import json
 from django.utils.translation import ugettext as _
-from verify_student.views import PayAndVerifyView
+from lms.djangoapps.verify_student.views import PayAndVerifyView
 %>
 <%namespace name='static' file='../static_content.html'/>
 

--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -108,7 +108,7 @@ class CourseOverview(TimeStampedModel):
         start = course.start
         end = course.end
         if isinstance(course.id, CCXLocator):
-            from ccx.utils import get_ccx_from_ccx_locator  # pylint: disable=import-error
+            from lms.djangoapps.ccx.utils import get_ccx_from_ccx_locator
             ccx = get_ccx_from_ccx_locator(course.id)
             display_name = ccx.display_name
             start = ccx.start

--- a/themes/red-theme/lms/templates/header.html
+++ b/themes/red-theme/lms/templates/header.html
@@ -12,7 +12,7 @@ from status.status import get_site_status_msg
 
 from microsite_configuration import microsite
 from microsite_configuration.templatetags.microsite import platform_name
-from ccx.overrides import get_current_ccx
+from lms.djangoapps.ccx.overrides import get_current_ccx
 %>
 
 ## Provide a hook for themes to inject branding on top.


### PR DESCRIPTION
Django 1.8 refuses to use models that have been imported twice. This fixes
that problem, and is safe for master.
