### PR TITLE
Fix SplitMongoModuleStore.make_course_usage_key to work for CCX.

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
@@ -70,6 +70,7 @@ from xmodule.errortracker import null_error_tracker
 from opaque_keys.edx.locator import (
     BlockUsageLocator, DefinitionLocator, CourseLocator, LibraryLocator, VersionTree, LocalId,
 )
+from ccx_keys.locator import CCXLocator, CCXBlockUsageLocator
 from xmodule.modulestore.exceptions import InsufficientSpecificationError, VersionConflictError, DuplicateItemError, \
     DuplicateCourseError
 from xmodule.modulestore import (
@@ -953,7 +954,8 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
         Return a valid :class:`~opaque_keys.edx.keys.UsageKey` for this modulestore
         that matches the supplied course_key.
         """
-        return BlockUsageLocator(course_key, 'course', 'course')
+        locator_cls = CCXBlockUsageLocator if isinstance(course_key, CCXLocator) else BlockUsageLocator
+        return locator_cls(course_key, 'course', 'course')
 
     def _get_structure(self, structure_id, depth, head_validation=True, **kwargs):
         """

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_mongo.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_mongo.py
@@ -758,6 +758,13 @@ class TestMongoModuleStore(TestMongoModuleStoreBase):
         # Clean up the data so we don't break other tests which apparently expect a particular state
         self.draft_store.delete_course(course.id, self.dummy_user)
 
+    def test_make_course_usage_key(self):
+        """Test that we get back the appropriate usage key for the root of a course key."""
+        course_key = CourseLocator(org="edX", course="101", run= "2015")
+        root_block_key = self.draft_store.make_course_usage_key(course_key)
+        self.assertEqual(root_block_key.block_type, "course")
+        self.assertEqual(root_block_key.name, "2015")
+
 
 class TestMongoModuleStoreWithNoAssetCollection(TestMongoModuleStore):
     '''

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore.py
@@ -10,6 +10,7 @@ import re
 import unittest
 import uuid
 
+import ddt
 from contracts import contract
 from nose.plugins.attrib import attr
 from django.core.cache import get_cache, InvalidCacheBackendError
@@ -23,7 +24,8 @@ from xmodule.modulestore.exceptions import (
     DuplicateItemError, DuplicateCourseError,
     InsufficientSpecificationError
 )
-from opaque_keys.edx.locator import CourseLocator, BlockUsageLocator, VersionTree, LocalId
+from opaque_keys.edx.locator import CourseKey, CourseLocator, BlockUsageLocator, VersionTree, LocalId
+from ccx_keys.locator import CCXBlockUsageLocator
 from xmodule.modulestore.inheritance import InheritanceMixin
 from xmodule.x_module import XModuleMixin
 from xmodule.fields import Date, Timedelta
@@ -596,6 +598,7 @@ class TestHasChildrenAtDepth(SplitModuleTest):
         self.assertFalse(ch3.has_children_at_depth(1))
 
 
+@ddt.ddt
 class SplitModuleCourseTests(SplitModuleTest):
     '''
     Course CRUD operation tests
@@ -887,6 +890,22 @@ class SplitModuleCourseTests(SplitModuleTest):
 
         version_history = modulestore().get_block_generations(second_problem.location)
         self.assertNotEqual(version_history.locator.version_guid, first_problem.location.version_guid)
+
+    @ddt.data(
+        ("course-v1:edx+test_course+test_run", BlockUsageLocator),
+        ("ccx-v1:edX+test_course+test_run+ccx@1", CCXBlockUsageLocator),
+    )
+    @ddt.unpack
+    def test_make_course_usage_key(self, course_id, root_block_cls):
+        """Test that we get back the appropriate usage key for the root of a course key.
+
+        In particular, we want to make sure that it properly handles CCX courses.
+        """
+        course_key = CourseKey.from_string(course_id)
+        root_block_key = modulestore().make_course_usage_key(course_key)
+        self.assertIsInstance(root_block_key, root_block_cls)
+        self.assertEqual(root_block_key.block_type, "course")
+        self.assertEqual(root_block_key.name, "course")
 
 
 class TestCourseStructureCache(SplitModuleTest):

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -215,6 +215,8 @@ CORS_ALLOW_CREDENTIALS = True
 CORS_ORIGIN_WHITELIST = ()
 CORS_ORIGIN_ALLOW_ALL = True
 
+################################ CCX ###############################
+FEATURES['CUSTOM_COURSES_EDX'] = True
 
 #####################################################################
 # See if the developer has any local overrides.


### PR DESCRIPTION
CCX courses usage keys are of type `CCXBlockUsageLocator`, not `BlockUsageLocator` like everything else.
