### PR TITLE
Add node_modules to the path via the jenkins-common script instead of…

### DIFF
--- a/scripts/generic-ci-tests.sh
+++ b/scripts/generic-ci-tests.sh
@@ -70,7 +70,6 @@ case "$TEST_SUITE" in
 
         mkdir -p reports
         echo "Finding jshint violations and storing report..."
-        PATH=$PATH:node_modules/.bin
         paver run_jshint -l $JSHINT_THRESHOLD > jshint.log || { cat jshint.log; EXIT=1; }
         echo "Running code complexity report (python)."
         paver run_complexity > reports/code_complexity.log || echo "Unable to calculate code complexity. Ignoring error."

--- a/scripts/jenkins-common.sh
+++ b/scripts/jenkins-common.sh
@@ -34,3 +34,6 @@ fi
 
 # Activate the Python virtualenv
 source $HOME/edx-venv/bin/activate
+
+# add the node_js packages dir to PATH
+PATH=$PATH:node_modules/.bin


### PR DESCRIPTION
… all-tests.

The jenkins-common script is the better place for this particular setup, since that
script is doing similar setup steps to prepare the environment for running
various tests/subsequent scripts. This also will resolve downstream processes,
such as our jenkins AMI builder (for jenkins-worker images).
