### PR TITLE
When comparing objects, consider scalar fields, not relations. TNL-3418

### DIFF
--- a/common/djangoapps/util/model_utils.py
+++ b/common/djangoapps/util/model_utils.py
@@ -41,15 +41,9 @@ def get_changed_fields_dict(instance, model_class):
         # an empty dict as a default value.
         return {}
     else:
-        field_names = [
-            # Suggested by https://docs.djangoproject.com/en/1.8/ref/models/meta/#migrating-from-the-old-api
-            f.name for f in model_class._meta.get_fields()
-            if not (
-                f.is_relation
-                or f.one_to_one
-                or (f.many_to_one and f.related_model)
-            )
-        ]
+        # We want to compare all of the scalar fields on the model, but none of
+        # the relations.
+        field_names = [f.name for f in model_class._meta.get_fields() if not f.is_relation]
         changed_fields = {
             field_name: getattr(old_model, field_name) for field_name in field_names
             if getattr(old_model, field_name) != getattr(instance, field_name)

--- a/lms/djangoapps/ccx/overrides.py
+++ b/lms/djangoapps/ccx/overrides.py
@@ -13,7 +13,7 @@ from courseware.field_overrides import FieldOverrideProvider  # pylint: disable=
 from opaque_keys.edx.keys import CourseKey, UsageKey
 from ccx_keys.locator import CCXLocator, CCXBlockUsageLocator
 
-from .models import CcxFieldOverride, CustomCourseForEdX
+from ccx.models import CcxFieldOverride, CustomCourseForEdX
 
 
 log = logging.getLogger(__name__)

--- a/lms/djangoapps/ccx/tasks.py
+++ b/lms/djangoapps/ccx/tasks.py
@@ -11,7 +11,7 @@ from ccx_keys.locator import CCXLocator
 from xmodule.modulestore.django import SignalHandler
 from lms import CELERY_APP
 
-from .models import CustomCourseForEdX
+from ccx.models import CustomCourseForEdX
 
 log = logging.getLogger("edx.ccx")
 

--- a/lms/djangoapps/ccx/tests/test_ccx_modulestore.py
+++ b/lms/djangoapps/ccx/tests/test_ccx_modulestore.py
@@ -14,7 +14,7 @@ from xmodule.modulestore.tests.django_utils import (
 from student.tests.factories import UserFactory
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
-from ..models import CustomCourseForEdX
+from ccx.models import CustomCourseForEdX
 
 
 class TestCCXModulestoreWrapper(SharedModuleStoreTestCase):

--- a/lms/djangoapps/ccx/tests/test_overrides.py
+++ b/lms/djangoapps/ccx/tests/test_overrides.py
@@ -16,10 +16,10 @@ from xmodule.modulestore.tests.django_utils import (
     TEST_DATA_SPLIT_MODULESTORE)
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
-from ..models import CustomCourseForEdX
-from ..overrides import override_field_for_ccx
+from ccx.models import CustomCourseForEdX
+from ccx.overrides import override_field_for_ccx
 
-from .test_views import flatten, iter_blocks
+from ccx.tests.test_views import flatten, iter_blocks
 
 
 @attr('shard_1')

--- a/lms/djangoapps/ccx/tests/test_views.py
+++ b/lms/djangoapps/ccx/tests/test_views.py
@@ -44,13 +44,9 @@ from xmodule.modulestore.tests.factories import (
 )
 from ccx_keys.locator import CCXLocator
 
-from ..models import (
-    CustomCourseForEdX,
-)
-from ..overrides import get_override_for_ccx, override_field_for_ccx
-from .factories import (
-    CcxFactory,
-)
+from ccx.models import CustomCourseForEdX
+from ccx.overrides import get_override_for_ccx, override_field_for_ccx
+from ccx.tests.factories import CcxFactory
 
 
 def intercept_renderer(path, context):

--- a/lms/djangoapps/ccx/utils.py
+++ b/lms/djangoapps/ccx/utils.py
@@ -5,7 +5,7 @@ Does not include any access control, be sure to check access before calling.
 """
 import logging
 
-from .models import CustomCourseForEdX
+from ccx.models import CustomCourseForEdX
 
 
 log = logging.getLogger("edx.ccx")

--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -48,8 +48,8 @@ from instructor.enrollment import (
     get_email_params,
 )
 
-from .models import CustomCourseForEdX
-from .overrides import (
+from ccx.models import CustomCourseForEdX
+from ccx.overrides import (
     clear_override_for_ccx,
     get_override_for_ccx,
     override_field_for_ccx,

--- a/lms/djangoapps/teams/tests/factories.py
+++ b/lms/djangoapps/teams/tests/factories.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 import factory
 from factory.django import DjangoModelFactory
 
-from ..models import CourseTeam, CourseTeamMembership
+from teams.models import CourseTeam, CourseTeamMembership
 
 
 LAST_ACTIVITY_AT = datetime(2015, 8, 15, 0, 0, 0, tzinfo=pytz.utc)

--- a/lms/djangoapps/teams/tests/test_models.py
+++ b/lms/djangoapps/teams/tests/test_models.py
@@ -23,8 +23,8 @@ from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from opaque_keys.edx.keys import CourseKey
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
 
-from .factories import CourseTeamFactory, CourseTeamMembershipFactory
-from ..models import CourseTeam, CourseTeamMembership
+from teams.tests.factories import CourseTeamFactory, CourseTeamMembershipFactory
+from teams.models import CourseTeam, CourseTeamMembership
 from teams import TEAM_DISCUSSION_CONTEXT
 
 COURSE_KEY1 = CourseKey.from_string('edx/history/1')

--- a/openedx/core/djangoapps/credit/partition_schemes.py
+++ b/openedx/core/djangoapps/credit/partition_schemes.py
@@ -17,7 +17,7 @@ import logging
 
 from django.core.cache import cache
 
-from lms.djangoapps.verify_student.models import SkippedReverification, VerificationStatus
+from verify_student.models import SkippedReverification, VerificationStatus
 from student.models import CourseEnrollment
 from xmodule.partitions.partitions import NoSuchUserPartitionGroupError
 

--- a/openedx/core/djangoapps/credit/tests/test_partition.py
+++ b/openedx/core/djangoapps/credit/tests/test_partition.py
@@ -8,7 +8,7 @@ import unittest
 
 from django.conf import settings
 
-from lms.djangoapps.verify_student.models import (
+from verify_student.models import (
     VerificationCheckpoint,
     VerificationStatus,
     SkippedReverification,


### PR DESCRIPTION
Also, the cherry-picked: Fix model imports so they are always imported
the same way.
