### PR TITLE
Fix the issues in django management command tests.

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/import.py
+++ b/cms/djangoapps/contentstore/management/commands/import.py
@@ -1,8 +1,9 @@
 """
 Script for importing courseware from XML format
 """
+from optparse import make_option
 
-from django.core.management.base import BaseCommand, CommandError, make_option
+from django.core.management.base import BaseCommand, CommandError
 from django_comment_common.utils import (seed_permissions_roles,
                                          are_permissions_roles_seeded)
 from xmodule.modulestore.xml_importer import import_course_from_xml

--- a/cms/djangoapps/contentstore/management/commands/tests/test_reindex_courses.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_reindex_courses.py
@@ -47,7 +47,7 @@ class TestReindexCourse(ModuleStoreTestCase):
 
     def test_given_no_arguments_raises_command_error(self):
         """ Test that raises CommandError for incorrect arguments """
-        with self.assertRaisesRegexp(CommandError, ".* requires one or more arguments .*"):
+        with self.assertRaisesRegexp(CommandError, ".* requires one or more arguments.*"):
             call_command('reindex_course')
 
     @ddt.data('qwerty', 'invalid_key', 'xblock-v1:qwe+rty')

--- a/cms/djangoapps/contentstore/management/commands/tests/test_reindex_library.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_reindex_library.py
@@ -49,7 +49,7 @@ class TestReindexLibrary(ModuleStoreTestCase):
 
     def test_given_no_arguments_raises_command_error(self):
         """ Test that raises CommandError for incorrect arguments """
-        with self.assertRaisesRegexp(CommandError, ".* requires one or more arguments .*"):
+        with self.assertRaisesRegexp(CommandError, ".* requires one or more arguments.*"):
             call_command('reindex_library')
 
     @ddt.data('qwerty', 'invalid_key', 'xblock-v1:qwe+rty')

--- a/lms/djangoapps/teams/management/commands/tests/test_reindex_course_team.py
+++ b/lms/djangoapps/teams/management/commands/tests/test_reindex_course_team.py
@@ -31,7 +31,7 @@ class ReindexCourseTeamTest(SharedModuleStoreTestCase):
 
     def test_given_no_arguments_raises_command_error(self):
         """ Test that raises CommandError for incorrect arguments. """
-        with self.assertRaisesRegexp(CommandError, ".* requires one or more arguments .*"):
+        with self.assertRaisesRegexp(CommandError, ".* requires one or more arguments.*"):
             call_command('reindex_course_team')
 
     def test_teams_search_flag_disabled_raises_command_error(self):


### PR DESCRIPTION
This PR include these fixes for management commands:
- Wrong import for make_option. (TNL-3473)
- Empty space issue in regex assertions (TNL-3474)
