### PR TITLE
Fixed 2 bok choy tests failing on chrome

### DIFF
--- a/common/test/acceptance/pages/studio/settings_advanced.py
+++ b/common/test/acceptance/pages/studio/settings_advanced.py
@@ -48,11 +48,26 @@ class AdvancedSettingsPage(CoursePage):
         self.browser.refresh()
         self.wait_for_page()
 
+    def coordinates_for_scrolling(self, coordinates_for):
+        """
+        Get the x and y coordinates of elements
+        """
+        cordinates_dict = self.browser.find_element_by_css_selector(coordinates_for)
+        location = cordinates_dict.location
+        for key, val in location.iteritems():
+            if key == 'x':
+                x_axis = val
+            elif key == 'y':
+                y_axis = val
+        return x_axis, y_axis
+
     def undo_changes_via_modal(self):
         """
         Trigger clicking event of the undo changes button in the modal.
         Wait for the undoing process to load via ajax call.
+        Before that Scroll so the button is clickable on all browsers
         """
+        self.browser.execute_script("window.scrollTo" + str(self.coordinates_for_scrolling(UNDO_BUTTON_SELECTOR)))
         self.q(css=UNDO_BUTTON_SELECTOR).click()
         self.wait_for_ajax()
 
@@ -60,7 +75,9 @@ class AdvancedSettingsPage(CoursePage):
         """
         Trigger click event of the manual changes button in the modal.
         No need to wait for any ajax.
+        Before that Scroll so the button is clickable on all browsers
         """
+        self.browser.execute_script("window.scrollTo" + str(self.coordinates_for_scrolling(MANUAL_BUTTON_SELECTOR)))
         self.q(css=MANUAL_BUTTON_SELECTOR).click()
 
     def is_validation_modal_present(self):

--- a/common/test/acceptance/tests/studio/test_studio_settings.py
+++ b/common/test/acceptance/tests/studio/test_studio_settings.py
@@ -306,7 +306,7 @@ class AdvancedSettingsValidationTest(StudioCourseTest):
         # Let modal popup
         self.advanced_settings.wait_for_modal_load()
 
-        # Press Undo Changes button
+        # Click Undo Changes button
         self.advanced_settings.undo_changes_via_modal()
 
         # Check that changes are undone
@@ -337,8 +337,6 @@ class AdvancedSettingsValidationTest(StudioCourseTest):
 
         # Iterate through the wrong values and make sure they're still displayed
         for key, val in inputs.iteritems():
-            print self.advanced_settings.get(key)
-            print val
             self.assertEquals(
                 str(self.advanced_settings.get(key)),
                 str(val),


### PR DESCRIPTION
test_undo_changes and test_manaul_change in test_studio_settings.py
@benpatterson @jzoldak 
Please Review.
I still can't figure out the reason why Chrome won't reset Course Announcement Date field back to its default value but changing the field to Course Advertised Start Date (which inputs/outputs the same values like Course Announcement Date field) completes our test successfully. There might be an issue with the undo button. Se Won Jang was the author but can't find him to tag for review. 
