### PR TITLE
TNL-3258 Reset group configuration model when a child content group i…

### DIFF
--- a/cms/static/js/models/group_configuration.js
+++ b/cms/static/js/models/group_configuration.js
@@ -36,8 +36,11 @@ function(Backbone, _, str, gettext, GroupModel, GroupCollection) {
         }],
 
         initialize: function(attributes, options) {
+            this.on('remove:groups', this.groupRemoved);
+
             this.canBeEmpty = options && options.canBeEmpty;
             this.setOriginalAttributes();
+
             return this;
         },
 
@@ -120,6 +123,10 @@ function(Backbone, _, str, gettext, GroupModel, GroupCollection) {
                     };
                 }
             }
+        },
+
+        groupRemoved: function () {
+            this.setOriginalAttributes();
         }
     });
 

--- a/common/test/acceptance/tests/studio/test_studio_settings.py
+++ b/common/test/acceptance/tests/studio/test_studio_settings.py
@@ -4,7 +4,6 @@ Acceptance tests for Studio's Setting pages
 """
 from __future__ import unicode_literals
 from nose.plugins.attrib import attr
-from unittest import skip
 
 from base_studio_test import StudioCourseTest
 from bok_choy.promise import EmptyPromise
@@ -152,7 +151,6 @@ class ContentGroupConfigurationTest(StudioCourseTest):
         config = self.group_configurations_page.content_groups[0]
         self.assertTrue(config.delete_button_is_disabled)
 
-    @skip("TNL-3258")
     def test_can_delete_unused_content_group(self):
         """
         Scenario: Ensure that the user can delete unused content group.


### PR DESCRIPTION
…s deleted (+5 squashed commits)

This would fix issues reported in [TNL-3258](https://openedx.atlassian.net/browse/TNL-3258) and [TNL-3441](https://openedx.atlassian.net/browse/TNL-3441)

@cahrens 
@andy-armstrong 

Please review.

@waheedahmed FYI
