### PR TITLE
Doc Label fix for Intersphinx

### DIFF
--- a/docs/en_us/platform_api/source/enrollment/index.rst
+++ b/docs/en_us/platform_api/source/enrollment/index.rst
@@ -1,4 +1,4 @@
-.. _edX Platform Enrollment API Version 1.0:
+.. _edX Platform Enrollment API:
 
 ########################################
 Enrollment API Version 1.0

--- a/docs/en_us/platform_api/source/user/index.rst
+++ b/docs/en_us/platform_api/source/user/index.rst
@@ -1,4 +1,4 @@
-.. _edX Platform User API Version 1.0:
+.. _edX Platform User API:
 
 #################################
 User API Version 1.0


### PR DESCRIPTION
@lamagnifica   quick fix to get intersphinx links from RN working.  (can't have . in label)
