### PR TITLE
add new column 'copy_id_photo_from' for 'SoftwareSecurePhotoVerificat…

### DIFF
--- a/lms/djangoapps/verify_student/management/commands/retry_failed_photo_verifications.py
+++ b/lms/djangoapps/verify_student/management/commands/retry_failed_photo_verifications.py
@@ -18,6 +18,6 @@ class Command(BaseCommand):
         print("Attempting to retry {0} failed PhotoVerification submissions".format(len(attempts_to_retry)))
         for index, attempt in enumerate(attempts_to_retry):
             print("Retrying submission #{0} (ID: {1}, User: {2})".format(index, attempt.id, attempt.user))
-            attempt.submit()
+            attempt.submit(copy_id_photo_from=attempt.copy_id_photo_from)
             print("Retry result: {0}".format(attempt.status))
         print("Done resubmitting failed photo verifications")

--- a/lms/djangoapps/verify_student/management/commands/retry_failed_photo_verifications.py
+++ b/lms/djangoapps/verify_student/management/commands/retry_failed_photo_verifications.py
@@ -11,13 +11,31 @@ class Command(BaseCommand):
     This method finds those PhotoVerifications with a status of
     MUST_RETRY and attempts to verify them.
     """
-    help = 'Retries SoftwareSecurePhotoVerifications that are in a state of \'must_retry\''
+    args = "<SoftwareSecurePhotoVerification id, SoftwareSecurePhotoVerification id, ...>"
+    help = (
+        "Retries SoftwareSecurePhotoVerifications passed as "
+        "arguments, or if no arguments are supplied, all that "
+        "are in a state of 'must_retry'"
+    )
 
     def handle(self, *args, **options):
-        attempts_to_retry = SoftwareSecurePhotoVerification.objects.filter(status='must_retry')
+        if args:
+            attempts_to_retry = SoftwareSecurePhotoVerification.objects.filter(
+                receipt_id__in=args
+            )
+            force_must_retry = True
+        else:
+            attempts_to_retry = SoftwareSecurePhotoVerification.objects.filter(status='must_retry')
+            force_must_retry = False
+
         print("Attempting to retry {0} failed PhotoVerification submissions".format(len(attempts_to_retry)))
         for index, attempt in enumerate(attempts_to_retry):
             print("Retrying submission #{0} (ID: {1}, User: {2})".format(index, attempt.id, attempt.user))
+
+            # Set the attempts status to 'must_retry' so that we can re-submit it
+            if force_must_retry:
+                attempt.status = 'must_retry'
+
             attempt.submit(copy_id_photo_from=attempt.copy_id_photo_from)
             print("Retry result: {0}".format(attempt.status))
         print("Done resubmitting failed photo verifications")

--- a/lms/djangoapps/verify_student/management/commands/set_software_secure_status.py
+++ b/lms/djangoapps/verify_student/management/commands/set_software_secure_status.py
@@ -1,0 +1,60 @@
+"""
+Manually set Software Secure verification status.
+"""
+
+import sys
+
+from django.core.management.base import BaseCommand
+from verify_student.models import (
+    SoftwareSecurePhotoVerification, VerificationCheckpoint, VerificationStatus
+)
+
+
+class Command(BaseCommand):
+    """
+    Command to trigger the actions that would normally follow Software Secure
+    returning with the results of a photo verification.
+    """
+
+    args = "<{approved, denied}, SoftwareSecurePhotoVerification id, [reason_for_denial]>"
+
+    def handle(self, *args, **kwargs):  # pylint: disable=unused-argument
+        from verify_student.views import _set_user_requirement_status
+
+        status_to_set = args[0]
+        receipt_id = args[1]
+
+        try:
+            attempt = SoftwareSecurePhotoVerification.objects.get(receipt_id=receipt_id)
+        except SoftwareSecurePhotoVerification.DoesNotExist:
+            self.stderr.write(
+                'SoftwareSecurePhotoVerification with id {id} could not be found.\n'.format(id=receipt_id)
+            )
+            sys.exit(1)
+
+        if status_to_set == 'approved':
+            self.stdout.write('Approving verification for {id}.\n'.format(id=receipt_id))
+            attempt.approve()
+            _set_user_requirement_status(attempt, 'reverification', 'satisfied')
+
+        elif status_to_set == 'denied':
+            self.stdout.write('Denying verification for {id}.\n'.format(id=receipt_id))
+            if len(args) >= 3:
+                reason_for_denial = args[2]
+            else:
+                reason_for_denial = 'Denied via management command.'
+            attempt.deny(reason_for_denial)
+            _set_user_requirement_status(attempt, 'reverification', 'failed', reason_for_denial)
+
+        else:
+            self.stdout.write('Cannot set id {id} to unrecognized status {status}'.format(
+                id=receipt_id, status=status_to_set
+            ))
+            sys.exit(1)
+
+        checkpoints = VerificationCheckpoint.objects.filter(photo_verification=attempt).all()
+        VerificationStatus.add_status_from_checkpoints(
+            checkpoints=checkpoints,
+            user=attempt.user,
+            status=status_to_set
+        )

--- a/lms/djangoapps/verify_student/migrations/0013_auto__add_field_softwaresecurephotoverification_copy_id_photo_from.py
+++ b/lms/djangoapps/verify_student/migrations/0013_auto__add_field_softwaresecurephotoverification_copy_id_photo_from.py
@@ -1,0 +1,134 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'SoftwareSecurePhotoVerification.copy_id_photo_from'
+        db.add_column('verify_student_softwaresecurephotoverification', 'copy_id_photo_from',
+                      self.gf('django.db.models.fields.related.ForeignKey')(to=orm['verify_student.SoftwareSecurePhotoVerification'], null=True, blank=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'SoftwareSecurePhotoVerification.copy_id_photo_from'
+        db.delete_column('verify_student_softwaresecurephotoverification', 'copy_id_photo_from_id')
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'verify_student.historicalverificationdeadline': {
+            'Meta': {'ordering': "(u'-history_date', u'-history_id')", 'object_name': 'HistoricalVerificationDeadline'},
+            'course_key': ('xmodule_django.models.CourseKeyField', [], {'max_length': '255', 'db_index': 'True'}),
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            'deadline': ('django.db.models.fields.DateTimeField', [], {}),
+            u'history_date': ('django.db.models.fields.DateTimeField', [], {}),
+            u'history_id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            u'history_type': ('django.db.models.fields.CharField', [], {'max_length': '1'}),
+            u'history_user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'+'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': "orm['auth.User']"}),
+            'id': ('django.db.models.fields.IntegerField', [], {'db_index': 'True', 'blank': 'True'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'})
+        },
+        'verify_student.incoursereverificationconfiguration': {
+            'Meta': {'ordering': "('-change_date',)", 'object_name': 'InCourseReverificationConfiguration'},
+            'change_date': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'changed_by': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']", 'null': 'True', 'on_delete': 'models.PROTECT'}),
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'verify_student.skippedreverification': {
+            'Meta': {'unique_together': "(('user', 'course_id'),)", 'object_name': 'SkippedReverification'},
+            'checkpoint': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'skipped_checkpoint'", 'to': "orm['verify_student.VerificationCheckpoint']"}),
+            'course_id': ('xmodule_django.models.CourseKeyField', [], {'max_length': '255', 'db_index': 'True'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"})
+        },
+        'verify_student.softwaresecurephotoverification': {
+            'Meta': {'ordering': "['-created_at']", 'object_name': 'SoftwareSecurePhotoVerification'},
+            'copy_id_photo_from': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['verify_student.SoftwareSecurePhotoVerification']", 'null': 'True', 'blank': 'True'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'display': ('django.db.models.fields.BooleanField', [], {'default': 'True', 'db_index': 'True'}),
+            'error_code': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'error_msg': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'face_image_url': ('django.db.models.fields.URLField', [], {'max_length': '255', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'photo_id_image_url': ('django.db.models.fields.URLField', [], {'max_length': '255', 'blank': 'True'}),
+            'photo_id_key': ('django.db.models.fields.TextField', [], {'max_length': '1024'}),
+            'receipt_id': ('django.db.models.fields.CharField', [], {'default': "'28d8227e-6c75-418a-b1ae-46b6b8e7557f'", 'max_length': '255', 'db_index': 'True'}),
+            'reviewing_service': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'reviewing_user': ('django.db.models.fields.related.ForeignKey', [], {'default': 'None', 'related_name': "'photo_verifications_reviewed'", 'null': 'True', 'to': "orm['auth.User']"}),
+            'status': ('model_utils.fields.StatusField', [], {'default': "'created'", 'max_length': '100', u'no_check_for_status': 'True'}),
+            'status_changed': ('model_utils.fields.MonitorField', [], {'default': 'datetime.datetime.now', u'monitor': "u'status'"}),
+            'submitted_at': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'db_index': 'True'}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"})
+        },
+        'verify_student.verificationcheckpoint': {
+            'Meta': {'unique_together': "(('course_id', 'checkpoint_location'),)", 'object_name': 'VerificationCheckpoint'},
+            'checkpoint_location': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'course_id': ('xmodule_django.models.CourseKeyField', [], {'max_length': '255', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'photo_verification': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['verify_student.SoftwareSecurePhotoVerification']", 'symmetrical': 'False'})
+        },
+        'verify_student.verificationdeadline': {
+            'Meta': {'object_name': 'VerificationDeadline'},
+            'course_key': ('xmodule_django.models.CourseKeyField', [], {'unique': 'True', 'max_length': '255', 'db_index': 'True'}),
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            'deadline': ('django.db.models.fields.DateTimeField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'})
+        },
+        'verify_student.verificationstatus': {
+            'Meta': {'object_name': 'VerificationStatus'},
+            'checkpoint': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'checkpoint_status'", 'to': "orm['verify_student.VerificationCheckpoint']"}),
+            'error': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'response': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'status': ('django.db.models.fields.CharField', [], {'max_length': '32', 'db_index': 'True'}),
+            'timestamp': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"})
+        }
+    }
+
+    complete_apps = ['verify_student']

--- a/lms/djangoapps/verify_student/migrations/0014_set_copy_id_photo_from.py
+++ b/lms/djangoapps/verify_student/migrations/0014_set_copy_id_photo_from.py
@@ -1,0 +1,148 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import DataMigration
+from django.db import models
+
+
+class Migration(DataMigration):
+
+    def forwards(self, orm):
+        """Add values for self referencing column 'copy_id_photo_from' in
+        table 'SoftwareSecurePhotoVerification'.
+
+        Set the 'copy_id_photo_from' column value to initial verification which
+        has the photo ID key.
+        """
+        verifications_without_photo_id = orm.SoftwareSecurePhotoVerification.objects.filter(
+            photo_id_key=''
+        )
+        for verification in verifications_without_photo_id:
+            # Get the initial verification of the user with the 'photo_id_key'
+            to_copy = orm.SoftwareSecurePhotoVerification.objects.filter(
+                user=verification.user,
+                status__in=["submitted", "approved"]
+            ).exclude(photo_id_key='')
+            to_copy = to_copy.latest('created_at') if to_copy.exists() else None
+
+            if to_copy:
+                verification.copy_id_photo_from = to_copy
+                verification.save()
+
+    def backwards(self, orm):
+        "Write your backwards methods here."
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'verify_student.historicalverificationdeadline': {
+            'Meta': {'ordering': "(u'-history_date', u'-history_id')", 'object_name': 'HistoricalVerificationDeadline'},
+            'course_key': ('xmodule_django.models.CourseKeyField', [], {'max_length': '255', 'db_index': 'True'}),
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            'deadline': ('django.db.models.fields.DateTimeField', [], {}),
+            u'history_date': ('django.db.models.fields.DateTimeField', [], {}),
+            u'history_id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            u'history_type': ('django.db.models.fields.CharField', [], {'max_length': '1'}),
+            u'history_user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'+'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': "orm['auth.User']"}),
+            'id': ('django.db.models.fields.IntegerField', [], {'db_index': 'True', 'blank': 'True'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'})
+        },
+        'verify_student.incoursereverificationconfiguration': {
+            'Meta': {'ordering': "('-change_date',)", 'object_name': 'InCourseReverificationConfiguration'},
+            'change_date': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'changed_by': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']", 'null': 'True', 'on_delete': 'models.PROTECT'}),
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'verify_student.skippedreverification': {
+            'Meta': {'unique_together': "(('user', 'course_id'),)", 'object_name': 'SkippedReverification'},
+            'checkpoint': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'skipped_checkpoint'", 'to': "orm['verify_student.VerificationCheckpoint']"}),
+            'course_id': ('xmodule_django.models.CourseKeyField', [], {'max_length': '255', 'db_index': 'True'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"})
+        },
+        'verify_student.softwaresecurephotoverification': {
+            'Meta': {'ordering': "['-created_at']", 'object_name': 'SoftwareSecurePhotoVerification'},
+            'copy_id_photo_from': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['verify_student.SoftwareSecurePhotoVerification']", 'null': 'True', 'blank': 'True'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'display': ('django.db.models.fields.BooleanField', [], {'default': 'True', 'db_index': 'True'}),
+            'error_code': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'error_msg': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'face_image_url': ('django.db.models.fields.URLField', [], {'max_length': '255', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'photo_id_image_url': ('django.db.models.fields.URLField', [], {'max_length': '255', 'blank': 'True'}),
+            'photo_id_key': ('django.db.models.fields.TextField', [], {'max_length': '1024'}),
+            'receipt_id': ('django.db.models.fields.CharField', [], {'default': "'8b8c982c-9872-4f8f-a249-01369acf5110'", 'max_length': '255', 'db_index': 'True'}),
+            'reviewing_service': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'reviewing_user': ('django.db.models.fields.related.ForeignKey', [], {'default': 'None', 'related_name': "'photo_verifications_reviewed'", 'null': 'True', 'to': "orm['auth.User']"}),
+            'status': ('model_utils.fields.StatusField', [], {'default': "'created'", 'max_length': '100', u'no_check_for_status': 'True'}),
+            'status_changed': ('model_utils.fields.MonitorField', [], {'default': 'datetime.datetime.now', u'monitor': "u'status'"}),
+            'submitted_at': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'db_index': 'True'}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"})
+        },
+        'verify_student.verificationcheckpoint': {
+            'Meta': {'unique_together': "(('course_id', 'checkpoint_location'),)", 'object_name': 'VerificationCheckpoint'},
+            'checkpoint_location': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'course_id': ('xmodule_django.models.CourseKeyField', [], {'max_length': '255', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'photo_verification': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['verify_student.SoftwareSecurePhotoVerification']", 'symmetrical': 'False'})
+        },
+        'verify_student.verificationdeadline': {
+            'Meta': {'object_name': 'VerificationDeadline'},
+            'course_key': ('xmodule_django.models.CourseKeyField', [], {'unique': 'True', 'max_length': '255', 'db_index': 'True'}),
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            'deadline': ('django.db.models.fields.DateTimeField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'})
+        },
+        'verify_student.verificationstatus': {
+            'Meta': {'object_name': 'VerificationStatus'},
+            'checkpoint': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'checkpoint_status'", 'to': "orm['verify_student.VerificationCheckpoint']"}),
+            'error': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'response': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'status': ('django.db.models.fields.CharField', [], {'max_length': '32', 'db_index': 'True'}),
+            'timestamp': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"})
+        }
+    }
+
+    complete_apps = ['verify_student']
+    symmetrical = True

--- a/lms/djangoapps/verify_student/models.py
+++ b/lms/djangoapps/verify_student/models.py
@@ -588,16 +588,23 @@ class SoftwareSecurePhotoVerification(PhotoVerification):
     photo_id_key = models.TextField(max_length=1024)
 
     IMAGE_LINK_DURATION = 5 * 60 * 60 * 24  # 5 days in seconds
+    copy_id_photo_from = models.ForeignKey("self", null=True, blank=True)
 
     @classmethod
     def get_initial_verification(cls, user):
-        """Get initial verification for a user
+        """Get initial verification for a user with the 'photo_id_key'.
+
         Arguments:
             user(User): user object
+
         Return:
             SoftwareSecurePhotoVerification (object)
         """
-        init_verification = cls.objects.filter(user=user, status__in=["submitted", "approved"])
+        init_verification = cls.objects.filter(
+            user=user,
+            status__in=["submitted", "approved"]
+        ).exclude(photo_id_key='')
+
         return init_verification.latest('created_at') if init_verification.exists() else None
 
     @status_before_must_be("created")

--- a/lms/djangoapps/verify_student/models.py
+++ b/lms/djangoapps/verify_student/models.py
@@ -663,10 +663,12 @@ class SoftwareSecurePhotoVerification(PhotoVerification):
 
     @status_before_must_be("must_retry", "ready", "submitted")
     def submit(self, copy_id_photo_from=None):
-        """
-        Submit our verification attempt to Software Secure for validation. This
-        will set our status to "submitted" if the post is successful, and
+        """Submit our verification attempt to Software Secure for validation.
+
+        This will set our status to "submitted" if the post is successful, and
         "must_retry" if the post fails.
+        This will also set the self referencing field 'copy_id_photo_from' on
+        the software secure photo validation object.
 
         Keyword Arguments:
             copy_id_photo_from (SoftwareSecurePhotoVerification): If provided, re-send the ID photo
@@ -674,6 +676,12 @@ class SoftwareSecurePhotoVerification(PhotoVerification):
                 are sent with previously-submitted ID photos.
 
         """
+        if copy_id_photo_from:
+            # Update the field 'copy_id_photo_from' with provided software
+            # secure photo verification object
+            self.copy_id_photo_from = copy_id_photo_from
+            self.save()
+
         try:
             response = self.send_request(copy_id_photo_from=copy_id_photo_from)
             if response.ok:

--- a/lms/djangoapps/verify_student/tests/test_models.py
+++ b/lms/djangoapps/verify_student/tests/test_models.py
@@ -472,6 +472,38 @@ class TestPhotoVerification(ModuleStoreTestCase):
             status = SoftwareSecurePhotoVerification.verification_status_for_user(user, course.id, enrollment_mode)
             self.assertEqual(status, output)
 
+    def test_initial_verification_for_user(self):
+        """Test that method 'get_initial_verification' of model
+        'SoftwareSecurePhotoVerification' always returns the initial
+        verification with field 'photo_id_key' set against a user.
+        """
+        user = UserFactory.create()
+
+        # No initial verification for the user
+        result = SoftwareSecurePhotoVerification.get_initial_verification(user=user)
+        self.assertIs(result, None)
+
+        # Make an initial verification with 'photo_id_key'
+        attempt = SoftwareSecurePhotoVerification(user=user, photo_id_key="dummy_photo_id_key")
+        attempt.status = 'approved'
+        attempt.save()
+
+        # Check that method 'get_initial_verification' returns the correct
+        # initial verification attempt
+        first_result = SoftwareSecurePhotoVerification.get_initial_verification(user=user)
+        self.assertIsNotNone(first_result)
+
+        # Now create a second verification without 'photo_id_key'
+        attempt = SoftwareSecurePhotoVerification(user=user)
+        attempt.status = 'submitted'
+        attempt.save()
+
+        # Test method 'get_initial_verification' still returns the correct
+        # initial verification attempt which have 'photo_id_key' set
+        second_result = SoftwareSecurePhotoVerification.get_initial_verification(user=user)
+        self.assertIsNotNone(second_result)
+        self.assertEqual(second_result, first_result)
+
 
 @ddt.ddt
 class VerificationCheckpointTest(ModuleStoreTestCase):

--- a/lms/djangoapps/verify_student/tests/test_views.py
+++ b/lms/djangoapps/verify_student/tests/test_views.py
@@ -1420,11 +1420,15 @@ class TestSubmitPhotosForVerification(TestCase):
             "Photo ID image is required if the user does not have an initial verification attempt."
         )
 
-        # Create the initial verification attempt
+        # Create the initial verification attempt with some dummy
+        # value set for field 'photo_id_key'
         self._submit_photos(
             face_image=self.IMAGE_DATA,
             photo_id_image=self.IMAGE_DATA,
         )
+        attempt = SoftwareSecurePhotoVerification.objects.get(user=self.user)
+        attempt.photo_id_key = "dummy_photo_id_key"
+        attempt.save()
 
         # Now the request should succeed
         self._submit_photos(face_image=self.IMAGE_DATA)
@@ -2037,7 +2041,7 @@ class TestInCourseReverifyView(ModuleStoreTestCase):
         """
         Helper method for initial verification.
         """
-        attempt = SoftwareSecurePhotoVerification(user=self.user)
+        attempt = SoftwareSecurePhotoVerification(user=self.user, photo_id_key="dummy_photo_id_key")
         attempt.mark_ready()
         attempt.save()
         attempt.submit()


### PR DESCRIPTION
…ion' model to track initial verification with 'photo_id_key'

@awais786 @aamir-khan @ahsan-ul-haq @tasawernawaz @cpennington 
- [x] Fix method `get_initial_verification` to get initial verification with `photo_id_key`
- [x] Add new self referencing column `copy_id_photo_from` for model `SoftwareSecurePhotoVerification`
- [x] Add migration for app `verify_student`
- [x] Add data migration for column `copy_id_photo_from` for app  `verify_student`
- [x] Modify management command to allow replay of submissions with copied photo ids
- [ ] Adjust logging level to create an audit log of submitted SoftwareSecure requests
- [x] Management command to simulate software secure success/failure
