### PR TITLE
asadiqbal08/SOL-1255: Remove all character limits in signatory fields

### DIFF
--- a/cms/static/js/certificates/models/signatory.js
+++ b/cms/static/js/certificates/models/signatory.js
@@ -33,11 +33,6 @@ function(_, str, Backbone, BackboneRelational, gettext) {
 
         validate: function(attrs) {
             var errors = null;
-            if(_.has(attrs, 'name') && attrs.name.length > 40) {
-                errors = _.extend({
-                    'name': gettext('Signatory name should not be more than 40 characters long.')
-                }, errors);
-            }
             if(_.has(attrs, 'title')){
                 var title = attrs.title;
                 var lines = title.split(/\r\n|\r|\n/);
@@ -46,13 +41,6 @@ function(_, str, Backbone, BackboneRelational, gettext) {
                         'title': gettext('Signatory title should span over maximum of 2 lines.')
                     }, errors);
                 }
-                else if ((lines.length > 1 && (lines[0].length > 53 && lines[1].length > 53)) ||
-                    (lines.length === 1 && title.length > 106)) {
-                    errors = _.extend({
-                        'title': gettext('Signatory title should have maximum of 40 characters per line.')
-                    }, errors);
-                }
-
             }
             if (errors !== null){
                 return errors;

--- a/cms/static/js/certificates/spec/views/certificate_details_spec.js
+++ b/cms/static/js/certificates/spec/views/certificate_details_spec.js
@@ -252,7 +252,7 @@ function(_, Course, CertificatesCollection, CertificateModel, CertificateDetails
                 });
 
                 setValuesToInputs(this.view, {
-                    inputSignatoryTitle: 'This is a certificate signatory title that has waaaaaaay more than 106 characters, in order to cause an exception.'
+                    inputSignatoryTitle: 'Signatory Title \non three \nlines'
                 });
 
                 setValuesToInputs(this.view, {

--- a/cms/static/js/certificates/spec/views/certificate_editor_spec.js
+++ b/cms/static/js/certificates/spec/views/certificate_editor_spec.js
@@ -228,10 +228,10 @@ function(_, Course, CertificateModel, SignatoryModel, CertificatesCollection, Ce
                 }
             );
 
-            it('signatories should not save when fields have too many characters per line', function() {
+            it('signatories should save when fields have too many characters per line', function() {
                 this.view.$(SELECTORS.addSignatoryButton).click();
                 setValuesToInputs(this.view, {
-                    inputCertificateName: 'New Certificate Name'
+                    inputCertificateName: 'New Certificate Name that has too many characters without any limit'
                 });
 
                 setValuesToInputs(this.view, {
@@ -243,7 +243,7 @@ function(_, Course, CertificateModel, SignatoryModel, CertificatesCollection, Ce
                 });
 
                 this.view.$(SELECTORS.saveCertificateButton).click();
-                expect(this.view.$('.certificate-edit-error')).toHaveClass('is-shown');
+                expect(this.view.$('.certificate-edit-error')).not.toHaveClass('is-shown');
             });
 
             it('signatories should not save when title span on more than 2 lines', function() {

--- a/cms/templates/js/signatory-editor.underscore
+++ b/cms/templates/js/signatory-editor.underscore
@@ -11,16 +11,16 @@
             <legend class="sr"><%= gettext("Certificate Signatory Configuration") %></legend>
             <div class="input-wrap field text add-signatory-name <% if(error && error.name) { print('error'); } %>">
                 <label for="signatory-name-<%= signatory_number %>"><%= gettext("Name ") %></label>
-                <input id="signatory-name-<%= signatory_number %>" class="collection-name-input input-text signatory-name-input" name="signatory-name" type="text" placeholder="<%= gettext("Name of the signatory") %>" value="<%= name %>"  aria-describedby="signatory-name-<%= signatory_number %>-tip" maxlength="40" />
-                <span id="signatory-name-<%= signatory_number %>-tip" class="tip tip-stacked"><%= gettext("The name of this signatory as it should appear on certificates. Maximum 40 characters.") %></span>
+                <input id="signatory-name-<%= signatory_number %>" class="collection-name-input input-text signatory-name-input" name="signatory-name" type="text" placeholder="<%= gettext("Name of the signatory") %>" value="<%= name %>"  aria-describedby="signatory-name-<%= signatory_number %>-tip" />
+                <span id="signatory-name-<%= signatory_number %>-tip" class="tip tip-stacked"><%= gettext("The name of this signatory as it should appear on certificates.") %></span>
                 <% if(error && error.name) { %>
                   <span class="message-error"><%= error.name %></span>
                 <% } %>
             </div>
             <div class="input-wrap field text add-signatory-title <% if(error && error.title) { print('error'); } %>">
                 <label for="signatory-title-<%= signatory_number %>"><%= gettext("Title ") %></label>
-                <textarea id="signatory-title-<%= signatory_number %>" class="collection-name-input text input-text signatory-title-input" name="signatory-title" cols="40" rows="2" placeholder="<%= gettext("Title of the signatory") %>"  aria-describedby="signatory-title-<%= signatory_number %>-tip" maxlength="106"><%= title %></textarea>
-                <span id="signatory-title-<%= signatory_number %>-tip" class="tip tip-stacked"><%= gettext("The title of this signatory as it should appear on certificates.  Maximum of 106 characters.") %></span>
+                <textarea id="signatory-title-<%= signatory_number %>" class="collection-name-input text input-text signatory-title-input" name="signatory-title" placeholder="<%= gettext("Title of the signatory") %>"  aria-describedby="signatory-title-<%= signatory_number %>-tip" ><%= title %></textarea>
+                <span id="signatory-title-<%= signatory_number %>-tip" class="tip tip-stacked"><%= gettext("Titles more than 100 characters may prevent students from printing their certificate on a single page.") %></span>
                 <% if(error && error.title) { %>
                   <span class="message-error"><%= error.title %></span>
                 <% } %>


### PR DESCRIPTION
##### Task: SOL-1255

PMs have been using the new web certs functionality for several weeks. They have reported difficulty dealing with character limits on the name and especially title fields for signatories. Some professors have very long titles, 150+ characters.

Example:
Professor Graham Galloway
Head of Education, The Centre for Advanced Imaging, The University of Queensland
Director of Operations, National Imaging Facility, Australia

PMs have asked that we remove the character limits. It will be on them to use the preview functionality to ensure that the certificate looks good in both Web and Print view. 
##### Acceptance Criteria
- Remove Character limits from all fields in certificate entry in Studio
- Add help text below the title fields: "Titles more than 100 characters may prevent students from printing their certificate on a single page"
