### PR TITLE
Fixing IntegrityError: certificates_badgeimageconfiguration

### DIFF
--- a/lms/djangoapps/certificates/migrations/0001_initial.py
+++ b/lms/djangoapps/certificates/migrations/0001_initial.py
@@ -34,7 +34,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('mode', models.CharField(help_text='The course mode for this badge image. For example, "verified" or "honor".', unique=True, max_length=125)),
                 ('icon', models.ImageField(help_text='Badge images must be square PNG files. The file size should be under 250KB.', upload_to=b'badges', validators=[certificates.models.validate_badge_image])),
-                ('default', models.BooleanField(help_text='Set this value to True if you want this image to be the default image for any course modes that do not have a specified badge image. You can have only one default image.')),
+                ('default', models.BooleanField(default=False, help_text='Set this value to True if you want this image to be the default image for any course modes that do not have a specified badge image. You can have only one default image.')),
             ],
         ),
         migrations.CreateModel(

--- a/lms/djangoapps/certificates/models.py
+++ b/lms/djangoapps/certificates/models.py
@@ -647,6 +647,7 @@ class BadgeImageConfiguration(models.Model):
         validators=[validate_badge_image]
     )
     default = models.BooleanField(
+        default=False,
         help_text=_(
             u"Set this value to True if you want this image to be the default image for any course modes "
             u"that do not have a specified badge image. You can have only one default image."


### PR DESCRIPTION
This PR fix such errors `django.db.utils.IntegrityError: certificates_badgeimageconfiguration.default may not be NULL`

TNL-3536
