### PR TITLE
One more pass at correct model imports

### DIFF
--- a/lms/djangoapps/django_comment_client/base/tests.py
+++ b/lms/djangoapps/django_comment_client/base/tests.py
@@ -24,7 +24,7 @@ from django_comment_client.tests.unicode import UnicodeTestMixin
 from django_comment_common.models import Role
 from django_comment_common.utils import seed_permissions_roles, ThreadContext
 from student.tests.factories import CourseEnrollmentFactory, UserFactory, CourseAccessRoleFactory
-from teams.tests.factories import CourseTeamFactory, CourseTeamMembershipFactory
+from lms.djangoapps.teams.tests.factories import CourseTeamFactory, CourseTeamMembershipFactory
 from util.testing import UrlResetMixin
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase

--- a/lms/djangoapps/django_comment_client/forum/tests.py
+++ b/lms/djangoapps/django_comment_client/forum/tests.py
@@ -35,7 +35,7 @@ from mock import patch, Mock, ANY, call
 
 from openedx.core.djangoapps.course_groups.models import CourseUserGroup
 
-from teams.tests.factories import CourseTeamFactory
+from lms.djangoapps.teams.tests.factories import CourseTeamFactory
 
 log = logging.getLogger(__name__)
 

--- a/lms/djangoapps/django_comment_client/tests/group_id.py
+++ b/lms/djangoapps/django_comment_client/tests/group_id.py
@@ -1,6 +1,6 @@
 import json
 import re
-from teams.tests.factories import CourseTeamFactory
+from lms.djangoapps.teams.tests.factories import CourseTeamFactory
 
 
 class GroupIdAssertionMixin(object):

--- a/lms/djangoapps/django_comment_client/tests/test_utils.py
+++ b/lms/djangoapps/django_comment_client/tests/test_utils.py
@@ -27,7 +27,7 @@ from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, TEST_DATA_MIXED_TOY_MODULESTORE
 from xmodule.modulestore.django import modulestore
 from opaque_keys.edx.locator import CourseLocator
-from teams.tests.factories import CourseTeamFactory
+from lms.djangoapps.teams.tests.factories import CourseTeamFactory
 
 
 @attr('shard_1')

--- a/lms/djangoapps/teams/management/commands/reindex_course_team.py
+++ b/lms/djangoapps/teams/management/commands/reindex_course_team.py
@@ -49,7 +49,7 @@ class Command(BaseCommand):
         """
         # This is ugly, but there is a really strange circular dependency that doesn't
         # happen anywhere else that I can't figure out how to avoid it :(
-        from teams.search_indexes import CourseTeamIndexer
+        from ...search_indexes import CourseTeamIndexer
 
         if len(args) == 0 and not options.get('all', False):
             raise CommandError(u"reindex_course_team requires one or more arguments: <course_team_id>")

--- a/lms/djangoapps/teams/management/commands/tests/test_reindex_course_team.py
+++ b/lms/djangoapps/teams/management/commands/tests/test_reindex_course_team.py
@@ -6,8 +6,8 @@ from mock import patch
 from django.core.management import call_command, CommandError
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from opaque_keys.edx.keys import CourseKey
-from teams.tests.factories import CourseTeamFactory
-from teams.search_indexes import CourseTeamIndexer
+from ....tests.factories import CourseTeamFactory
+from ....search_indexes import CourseTeamIndexer
 from search.search_engine_base import SearchEngine
 
 COURSE_KEY1 = CourseKey.from_string('edx/history/1')

--- a/lms/djangoapps/teams/models.py
+++ b/lms/djangoapps/teams/models.py
@@ -27,7 +27,7 @@ from xmodule_django.models import CourseKeyField
 from util.model_utils import slugify
 from student.models import LanguageField, CourseEnrollment
 from .errors import AlreadyOnTeamInCourse, NotEnrolledInCourseForTeam, ImmutableMembershipFieldException
-from teams import TEAM_DISCUSSION_CONTEXT
+from . import TEAM_DISCUSSION_CONTEXT
 
 
 @receiver(thread_voted)

--- a/lms/djangoapps/teams/plugins.py
+++ b/lms/djangoapps/teams/plugins.py
@@ -3,7 +3,7 @@ Definition of the course team feature.
 """
 from django.utils.translation import ugettext_noop
 from courseware.tabs import EnrolledTab
-from teams import is_feature_enabled
+from . import is_feature_enabled
 
 
 class TeamsTab(EnrolledTab):

--- a/lms/djangoapps/teams/search_indexes.py
+++ b/lms/djangoapps/teams/search_indexes.py
@@ -12,8 +12,8 @@ from functools import wraps
 from search.search_engine_base import SearchEngine
 from request_cache import get_request_or_stub
 
-from lms.djangoapps.teams.errors import ElasticSearchConnectionError
-from lms.djangoapps.teams.serializers import CourseTeamSerializer, CourseTeam
+from .errors import ElasticSearchConnectionError
+from .serializers import CourseTeamSerializer, CourseTeam
 
 
 def if_search_enabled(f):

--- a/lms/djangoapps/teams/serializers.py
+++ b/lms/djangoapps/teams/serializers.py
@@ -11,7 +11,7 @@ from openedx.core.lib.api.serializers import CollapsedReferenceSerializer
 from openedx.core.lib.api.fields import ExpandableField
 from openedx.core.djangoapps.user_api.accounts.serializers import UserReadOnlySerializer
 
-from lms.djangoapps.teams.models import CourseTeam, CourseTeamMembership
+from .models import CourseTeam, CourseTeamMembership
 
 
 class CountryField(serializers.Field):

--- a/lms/djangoapps/teams/tests/test_views.py
+++ b/lms/djangoapps/teams/tests/test_views.py
@@ -23,9 +23,9 @@ from student.models import CourseEnrollment
 from util.testing import EventTestMixin
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
-from lms.djangoapps.teams.tests.factories import CourseTeamFactory, LAST_ACTIVITY_AT
-from lms.djangoapps.teams.models import CourseTeamMembership
-from lms.djangoapps.teams.search_indexes import CourseTeamIndexer, CourseTeam, course_team_post_save_callback
+from .factories import CourseTeamFactory, LAST_ACTIVITY_AT
+from ..models import CourseTeamMembership
+from ..search_indexes import CourseTeamIndexer, CourseTeam, course_team_post_save_callback
 
 from django_comment_common.models import Role, FORUM_ROLE_COMMUNITY_TA
 from django_comment_common.utils import seed_permissions_roles

--- a/lms/djangoapps/teams/views.py
+++ b/lms/djangoapps/teams/views.py
@@ -40,8 +40,8 @@ from student.roles import CourseStaffRole
 from django_comment_client.utils import has_discussion_privileges
 from teams import is_feature_enabled
 from util.model_utils import truncate_fields
-from lms.djangoapps.teams.models import CourseTeam, CourseTeamMembership
-from lms.djangoapps.teams.serializers import (
+from .models import CourseTeam, CourseTeamMembership
+from .serializers import (
     CourseTeamSerializer,
     CourseTeamCreationSerializer,
     TopicSerializer,
@@ -49,8 +49,8 @@ from lms.djangoapps.teams.serializers import (
     MembershipSerializer,
     add_team_count
 )
-from lms.djangoapps.teams.search_indexes import CourseTeamIndexer
-from lms.djangoapps.teams.errors import AlreadyOnTeamInCourse, ElasticSearchConnectionError, NotEnrolledInCourseForTeam
+from .search_indexes import CourseTeamIndexer
+from .errors import AlreadyOnTeamInCourse, ElasticSearchConnectionError, NotEnrolledInCourseForTeam
 
 TEAM_MEMBERSHIPS_PER_PAGE = 2
 TOPICS_PER_PAGE = 12

--- a/lms/djangoapps/teams/views.py
+++ b/lms/djangoapps/teams/views.py
@@ -38,8 +38,8 @@ from track import contexts
 from student.models import CourseEnrollment, CourseAccessRole
 from student.roles import CourseStaffRole
 from django_comment_client.utils import has_discussion_privileges
-from teams import is_feature_enabled
 from util.model_utils import truncate_fields
+from . import is_feature_enabled
 from .models import CourseTeam, CourseTeamMembership
 from .serializers import (
     CourseTeamSerializer,

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -436,8 +436,8 @@ if settings.COURSEWARE_ENABLED:
     if settings.FEATURES["ENABLE_TEAMS"]:
         # Teams endpoints
         urlpatterns += (
-            url(r'^api/team/', include('teams.api_urls')),
-            url(r'^courses/{}/teams'.format(settings.COURSE_ID_PATTERN), include('teams.urls'), name="teams_endpoints"),
+            url(r'^api/team/', include('lms.djangoapps.teams.api_urls')),
+            url(r'^courses/{}/teams'.format(settings.COURSE_ID_PATTERN), include('lms.djangoapps.teams.urls'), name="teams_endpoints"),
         )
 
     if settings.FEATURES.get('ENABLE_RENDER_XBLOCK_API'):


### PR DESCRIPTION
Sven Marnach challenged my assertion that relative imports were bad, and
he is right: they are fine as long as all of the absolute imports are
correct.  This fixes the absolute imports, and restores the original
relative imports.
