### PR TITLE
Fixed split get_courses.

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
@@ -865,17 +865,18 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
 
         # collect ids and then query for those
         version_guids = []
-        id_version_map = {}
+        id_version_map = defaultdict(list)
         for course_index in matching_indexes:
             version_guid = course_index['versions'][branch]
             version_guids.append(version_guid)
-            id_version_map[version_guid] = course_index
+            id_version_map[version_guid].append(course_index)
 
         if not version_guids:
             return
 
         for entry in self.find_structures_by_id(version_guids):
-            yield entry, id_version_map[entry['_id']]
+            for course_index in id_version_map[entry['_id']]:
+                yield entry, course_index
 
     def _get_structures_for_branch_and_locator(self, branch, locator_factory, **kwargs):
 

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore.py
@@ -625,6 +625,26 @@ class SplitModuleCourseTests(SplitModuleTest):
         self.assertDictEqual(course.grade_cutoffs, {"Pass": 0.45})
 
     @patch('xmodule.tabs.CourseTab.from_json', side_effect=mock_tab_from_json)
+    def test_get_courses_with_same_course_index(self, _from_json):
+        """
+        Test that if two courses pointing to same course index,
+        get_courses should return both.
+        """
+        courses = modulestore().get_courses(branch=BRANCH_NAME_DRAFT)
+        # Should have gotten 3 draft courses.
+        self.assertEqual(len(courses), 3)
+
+        course_index = modulestore().get_course_index_info(courses[0].id)
+        # Creating a new course with same course index of another course.
+        new_draft_course = modulestore().create_course(
+            'testX', 'rerun_2.0', 'run_q2', 1, BRANCH_NAME_DRAFT, versions_dict=course_index['versions']
+        )
+        courses = modulestore().get_courses(branch=BRANCH_NAME_DRAFT)
+        # Should have gotten 4 draft courses.
+        self.assertEqual(len(courses), 4)
+        self.assertIn(new_draft_course.id.version_agnostic(), [c.id for c in courses])
+
+    @patch('xmodule.tabs.CourseTab.from_json', side_effect=mock_tab_from_json)
     def test_get_org_courses(self, _from_json):
         courses = modulestore().get_courses(branch=BRANCH_NAME_DRAFT, org='guestx')
 


### PR DESCRIPTION
[PLAT-747](https://openedx.atlassian.net/browse/PLAT-747)

If two courses are pointing to a same version then `get_courses()` was returning only one course.

**Actual behavior:** Returning only one course.
**Expected behavior:** Should return 2 courses.
### Steps To Reproduce:
1. Create split course
2. Create another split course
3. Drop into Mongo shell
4. update course 2's active_version entry such that its draft and publish branch point to course 1's draft and published branch
5. drop into django shell
6. set `store` to the split modulestore
7. run store.get_course on both courses, see that both return
8. run store.get_courses and see that one of the two courses isn't in it
