### PR TITLE
TNL-3305 HTML Editing Bok Choy Test

### DIFF
--- a/common/test/acceptance/pages/studio/html_component_editor.py
+++ b/common/test/acceptance/pages/studio/html_component_editor.py
@@ -7,25 +7,62 @@ class HtmlComponentEditorView(ComponentEditorView):
     """
     Represents the rendered view of an HTML component editor.
     """
-    def set_content_and_save(self, content):
+
+    editor_mode_css = '.edit-xblock-modal .editor-modes .editor-button'
+
+    def set_content_and_save(self, content, raw=False):
+        """Types content into the html component and presses Save.
+
+        Arguments:
+            content (str): The content to be used.
+            raw (bool): If true, edits in 'raw HTML' mode.
         """
-        Types content into the html component and presses Save.
-        """
-        self.set_content(content)
+        if raw:
+            self.set_raw_content(content)
+        else:
+            self.set_content(content)
+
         self.save()
 
-    def set_content_and_cancel(self, content):
+    def set_content_and_cancel(self, content, raw=False):
+        """Types content into the html component and presses Cancel to abort.
+
+        Arguments:
+            content (str): The content to be used.
+            raw (bool): If true, edits in 'raw HTML' mode.
         """
-        Types content into the html component and presses Cancel to abort the change.
-        """
-        self.set_content(content)
+        if raw:
+            self.set_raw_content(content)
+        else:
+            self.set_content(content)
+
         self.cancel()
 
     def set_content(self, content):
+        """Types content into the html component, leaving the component open.
+
+        Arguments:
+            content (str): The content to be used.
         """
-        Types content into the html component, leaving the component open.
-        """
-        self.q(css='.edit-xblock-modal .editor-modes .editor-button').click()
-        editor = self.q(css=self._bounded_selector('.html-editor .mce-edit-area'))[0]
+        self.q(css=self.editor_mode_css).click()
+
+        selector = '.html-editor .mce-edit-area'
+        editor = self.q(css=self._bounded_selector(selector))[0]
         ActionChains(self.browser).click(editor).\
-            send_keys([Keys.CONTROL, 'a']).key_up(Keys.CONTROL).send_keys(content).perform()
+            send_keys([Keys.CONTROL, 'a']).key_up(Keys.CONTROL).\
+            send_keys(content).perform()
+
+    def set_raw_content(self, content):
+        """Types content in raw html mode, leaving the component open.
+
+        Arguments:
+            content (str): The content to be used.
+        """
+        self.q(css=self.editor_mode_css).click()
+        self.q(css='[aria-label="Edit HTML"]').click()
+
+        #Focus goes to the editor by default
+        ActionChains(self.browser).send_keys([Keys.CONTROL, 'a']).\
+            key_up(Keys.CONTROL).send_keys(content).perform()
+
+        self.q(css='.mce-foot .mce-primary').click()

--- a/common/test/acceptance/tests/studio/test_studio_container.py
+++ b/common/test/acceptance/tests/studio/test_studio_container.py
@@ -293,6 +293,24 @@ class EditContainerTest(NestedVerticalTest):
         container = self.go_to_nested_container_page()
         self.modify_display_name_and_verify(container)
 
+    def test_edit_raw_html(self):
+        """
+        Test the raw html editing functionality.
+        """
+        modified_content = "<p>modified content</p>"
+
+        #navigate to and open the component for editing
+        unit = self.go_to_unit_page()
+        container = unit.xblocks[1].go_to_container()
+        component = container.xblocks[1].children[0]
+        component.edit()
+
+        html_editor = HtmlComponentEditorView(self.browser, component.locator)
+        html_editor.set_content_and_save(modified_content, raw=True)
+
+        #note we're expecting the <p> tags to have been removed
+        self.assertEqual(component.student_content, "modified content")
+
 
 class EditVisibilityModalTest(ContainerBase):
     """


### PR DESCRIPTION
## [TNL-3305](https://openedx.atlassian.net/browse/TNL-3305)

Adding a bok choy test to cover the scenario described in the ticket. HTML editing was previously not covered by acceptance tests.
### Sandbox

N/A, it's just a testing change
### Testing
- [x] Acceptance tests as appropriate [efischer: I visually inspected this while running locally, it seems to be doing what we want]
- other types of testing (i18n, a11y, RTL) are not applicable to this PR
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @cahrens 
- [x] Code review: @andy-armstrong 
- no product, UX, a11y, or doc review needed
### Devops assistance

We should be alright without devops on this one.
### Post-review
- [x] Squash commits
