### PR TITLE
DOC-2268 - Fix instances of "register" on the course about page

### DIFF
--- a/lms/djangoapps/courseware/tests/test_about.py
+++ b/lms/djangoapps/courseware/tests/test_about.py
@@ -96,7 +96,7 @@ class AboutTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase, EventTrackingT
         url = reverse('about_course', args=[self.course.id.to_deprecated_string()])
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
-        self.assertIn("You are registered for this course", resp.content)
+        self.assertIn("You are enrolled in this course", resp.content)
         self.assertIn("View Courseware", resp.content)
 
     @override_settings(COURSE_ABOUT_VISIBILITY_PERMISSION="see_about_page")
@@ -244,7 +244,7 @@ class AboutWithCappedEnrollmentsTestCase(LoginEnrollmentTestCase, ModuleStoreTes
 
         self.enroll(self.course, verify=True)
 
-        # create a new account since the first account is already registered for the course
+        # create a new account since the first account is already enrolled in the course
         self.email = 'foo_second@test.com'
         self.password = 'bar'
         self.username = 'test_second'
@@ -307,7 +307,7 @@ class AboutWithInvitationOnly(ModuleStoreTestCase):
         url = reverse('about_course', args=[self.course.id.to_deprecated_string()])
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
-        self.assertIn(u"Register for {}".format(self.course.id.course), resp.content.decode('utf-8'))
+        self.assertIn(u"Enroll in {}".format(self.course.id.course), resp.content.decode('utf-8'))
 
         # Check that registration button is present
         self.assertIn(REG_STR, resp.content)
@@ -330,26 +330,26 @@ class AboutTestCaseShibCourse(LoginEnrollmentTestCase, ModuleStoreTestCase):
 
     def test_logged_in_shib_course(self):
         """
-        For shib courses, logged in users will see the register button, but get rejected once they click there
+        For shib courses, logged in users will see the enroll button, but get rejected once they click there
         """
         self.setup_user()
         url = reverse('about_course', args=[self.course.id.to_deprecated_string()])
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
         self.assertIn("OOGIE BLOOGIE", resp.content)
-        self.assertIn(u"Register for {}".format(self.course.id.course), resp.content.decode('utf-8'))
+        self.assertIn(u"Enroll in {}".format(self.course.id.course), resp.content.decode('utf-8'))
         self.assertIn(SHIB_ERROR_STR, resp.content)
         self.assertIn(REG_STR, resp.content)
 
     def test_anonymous_user_shib_course(self):
         """
-        For shib courses, anonymous users will also see the register button
+        For shib courses, anonymous users will also see the enroll button
         """
         url = reverse('about_course', args=[self.course.id.to_deprecated_string()])
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
         self.assertIn("OOGIE BLOOGIE", resp.content)
-        self.assertIn(u"Register for {}".format(self.course.id.course), resp.content.decode('utf-8'))
+        self.assertIn(u"Enroll in {}".format(self.course.id.course), resp.content.decode('utf-8'))
         self.assertIn(SHIB_ERROR_STR, resp.content)
         self.assertIn(REG_STR, resp.content)
 
@@ -472,7 +472,7 @@ class AboutPurchaseCourseTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase):
 
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
-        self.assertIn("You are registered for this course", resp.content)
+        self.assertIn("You are enrolled in this course", resp.content)
         self.assertIn("View Courseware", resp.content)
         self.assertNotIn("Add buyme to Cart <span>($10 USD)</span>", resp.content)
 
@@ -538,7 +538,7 @@ class AboutPurchaseCourseTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase):
         # for paywalled courses
         CourseEnrollment.enroll(self.user, course.id)
 
-        # create a new account since the first account is already registered for the course
+        # create a new account since the first account is already enrolled in the course
         email = 'foo_second@test.com'
         password = 'bar'
         username = 'test_second'

--- a/lms/djangoapps/courseware/tests/test_microsites.py
+++ b/lms/djangoapps/courseware/tests/test_microsites.py
@@ -212,14 +212,14 @@ class TestMicrosites(ModuleStoreTestCase, LoginEnrollmentTestCase):
         url = reverse('about_course', args=[self.course_with_visibility.id.to_deprecated_string()])
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
-        self.assertIn("Register for {}".format(self.course_with_visibility.id.course), resp.content)
+        self.assertIn("Enroll in {}".format(self.course_with_visibility.id.course), resp.content)
         self.assertNotIn("Add {} to Cart ($10)".format(self.course_with_visibility.id.course), resp.content)
 
         # now try on the microsite
         url = reverse('about_course', args=[self.course_with_visibility.id.to_deprecated_string()])
         resp = self.client.get(url, HTTP_HOST=settings.MICROSITE_TEST_HOSTNAME)
         self.assertEqual(resp.status_code, 200)
-        self.assertNotIn("Register for {}".format(self.course_with_visibility.id.course), resp.content)
+        self.assertNotIn("Enroll in {}".format(self.course_with_visibility.id.course), resp.content)
         self.assertIn("Add {} to Cart <span>($10 USD)</span>".format(
             self.course_with_visibility.id.course
         ), resp.content)

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -66,7 +66,7 @@ from edxmako.shortcuts import marketing_link
     %if settings.FEATURES.get('RESTRICT_ENROLL_BY_REG_METHOD') and course.enrollment_domain:
       <%
         perms_error = _('The currently logged-in user account does not have permission to enroll in this course. '
-                        'You may need to {start_logout_tag}log out{end_tag} then try the register button again. '
+                        'You may need to {start_logout_tag}log out{end_tag} then try the enroll button again. '
                         'Please visit the {start_help_tag}help page{end_tag} for a possible solution.').format(
                           start_help_tag="<a href='{url}'>".format(url=marketing_link('FAQ')), end_tag='</a>',
                           start_logout_tag="<a href='{url}'>".format(url=reverse('logout'))
@@ -135,7 +135,7 @@ from edxmako.shortcuts import marketing_link
             <a href="${course_target}">
           %endif
 
-          <span class="register disabled">${_("You are registered for this course")}</span>
+          <span class="register disabled">${_("You are enrolled in this course")}</span>
 
           %if show_courseware_link:
             <strong>${_("View Courseware")}</strong>
@@ -174,7 +174,7 @@ from edxmako.shortcuts import marketing_link
           <div id="register_error"></div>
         %else:
           <a href="#" class="register">
-            ${_("Register for {course_name}").format(course_name=course.display_number_with_default) | h}
+            ${_("Enroll in {course_name}").format(course_name=course.display_number_with_default) | h}
           </a>
           <div id="register_error"></div>
         %endif
@@ -231,11 +231,11 @@ from edxmako.shortcuts import marketing_link
             ##       or something allowing themes to do whatever they
             ##       want here (and on this whole page, really).
             % if self.stanford_theme_enabled():
-              <a href="http://twitter.com/intent/tweet?text=I+just+registered+for+${course.number}+${get_course_about_section(course, 'title')}!+(http://class.stanford.edu)" class="share">
-                <i class="icon fa fa-twitter"></i><span class="sr">${_("Tweet that you've registered for this course")}</span>
+              <a href="http://twitter.com/intent/tweet?text=I+just+enrolled+in+${course.number}+${get_course_about_section(course, 'title')}!+(http://class.stanford.edu)" class="share">
+                <i class="icon fa fa-twitter"></i><span class="sr">${_("Tweet that you've enrolled in this course")}</span>
               </a>
-              <a href="mailto:?subject=Take%20a%20course%20at%20Stanford%20online!&body=I%20just%20registered%20for%20${course.number}%20${get_course_about_section(course, 'title')}+(http://class.stanford.edu)" class="share">
-                <i class="icon fa fa-envelope"></i><span class="sr">${_("Email someone to say you've registered for this course")}</span>
+              <a href="mailto:?subject=Take%20a%20course%20at%20Stanford%20online!&body=I%20just%20enrolled%20in%20${course.number}%20${get_course_about_section(course, 'title')}+(http://class.stanford.edu)" class="share">
+                <i class="icon fa fa-envelope"></i><span class="sr">${_("Email someone to say you've enrolled in this course")}</span>
               </a>
             % else:
               <%
@@ -244,7 +244,7 @@ from edxmako.shortcuts import marketing_link
 
                 ## Translators: This text will be automatically posted to the student's
                 ## Twitter account. {url} should appear at the end of the text.
-                tweet_text = _("I just registered for {number} {title} through {account}: {url}").format(
+                tweet_text = _("I just enrolled in {number} {title} through {account}: {url}").format(
                     number=course.number,
                     title=get_course_about_section(course, 'title'),
                     account=microsite.get_value('course_about_twitter_account', settings.PLATFORM_TWITTER_ACCOUNT),
@@ -259,7 +259,7 @@ from edxmako.shortcuts import marketing_link
 
                 email_subject = u"mailto:?subject={subject}&body={body}".format(
                     subject=_("Take a course with {platform} online").format(platform=platform_name),
-                    body=_("I just registered for {number} {title} through {platform} {url}").format(
+                    body=_("I just enrolled in {number} {title} through {platform} {url}").format(
                         number=course.number,
                         title=get_course_about_section(course, 'title'),
                         platform=platform_name,
@@ -271,13 +271,13 @@ from edxmako.shortcuts import marketing_link
                 ).replace(u" ", u"%20")
               %>
               <a href="${tweet_action}" class="share">
-                <i class="icon fa fa-twitter"></i><span class="sr">${_("Tweet that you've registered for this course")}</span>
+                <i class="icon fa fa-twitter"></i><span class="sr">${_("Tweet that you've enrolled in this course")}</span>
               </a>
               <a href="${facebook_link}" class="share">
-                <i class="icon fa fa-thumbs-up"></i><span class="sr">${_("Post a Facebook message to say you've registered for this course")}</span>
+                <i class="icon fa fa-thumbs-up"></i><span class="sr">${_("Post a Facebook message to say you've enrolled in this course")}</span>
               </a>
               <a href="${email_subject}" class="share">
-                <i class="icon fa fa-envelope"></i><span class="sr">${_("Email someone to say you've registered for this course")}</span>
+                <i class="icon fa fa-envelope"></i><span class="sr">${_("Email someone to say you've enrolled in this course")}</span>
               </a>
             % endif
           </div>


### PR DESCRIPTION
As per DOC-2268, "register" means to create an account on edx.org, and "enroll" means to sign up for a course. Make this change on the page `lms/templates/courseware/course_about.html`.
