### PR TITLE
Fix Model instances without primary key value are not hash-able issues.

### DIFF
--- a/lms/djangoapps/commerce/api/v1/models.py
+++ b/lms/djangoapps/commerce/api/v1/models.py
@@ -88,6 +88,7 @@ class Course(object):
             merged_mode.currency = posted_mode.currency
             merged_mode.sku = posted_mode.sku
             merged_mode.expiration_datetime = posted_mode.expiration_datetime
+            merged_mode.save()
 
             merged_modes.add(merged_mode)
             merged_mode_keys.add(merged_mode.mode_slug)


### PR DESCRIPTION
This PR fixes TypeError: Model instances without primary key value are unhashable.

TNL-3539
