### PR TITLE
Smarter immutibility check for CourseTeamMembership

### DIFF
--- a/lms/djangoapps/teams/models.py
+++ b/lms/djangoapps/teams/models.py
@@ -173,10 +173,17 @@ class CourseTeamMembership(models.Model):
             # to set the value. Otherwise, we're trying to overwrite
             # an immutable field.
             current_value = getattr(self, name, None)
-            if value != current_value and current_value is not None:
-                raise ImmutableMembershipFieldException(
-                    "Field %r shouldn't change from %r to %r" % (name, current_value, value)
-                )
+            if value == current_value:
+                # This is an attempt to set an immutable value to the same value
+                # to which it's already set. Don't complain - just ignore the attempt.
+                return
+            else:
+                # This is an attempt to set an immutable value to a different value.
+                # Allow it *only* if the current value is None.
+                if current_value is not None:
+                    raise ImmutableMembershipFieldException(
+                        "Field %r shouldn't change from %r to %r" % (name, current_value, value)
+                    )
         super(CourseTeamMembership, self).__setattr__(name, value)
 
     def save(self, *args, **kwargs):

--- a/lms/djangoapps/teams/models.py
+++ b/lms/djangoapps/teams/models.py
@@ -173,7 +173,7 @@ class CourseTeamMembership(models.Model):
             # to set the value. Otherwise, we're trying to overwrite
             # an immutable field.
             current_value = getattr(self, name, None)
-            if current_value is not None:
+            if value != current_value and current_value is not None:
                 raise ImmutableMembershipFieldException(
                     "Field %r shouldn't change from %r to %r" % (name, current_value, value)
                 )

--- a/lms/djangoapps/teams/search_indexes.py
+++ b/lms/djangoapps/teams/search_indexes.py
@@ -13,7 +13,8 @@ from search.search_engine_base import SearchEngine
 from request_cache import get_request_or_stub
 
 from .errors import ElasticSearchConnectionError
-from .serializers import CourseTeamSerializer, CourseTeam
+from lms.djangoapps.teams.models import CourseTeam
+from .serializers import CourseTeamSerializer
 
 
 def if_search_enabled(f):

--- a/lms/djangoapps/teams/serializers.py
+++ b/lms/djangoapps/teams/serializers.py
@@ -11,7 +11,7 @@ from openedx.core.lib.api.serializers import CollapsedReferenceSerializer
 from openedx.core.lib.api.fields import ExpandableField
 from openedx.core.djangoapps.user_api.accounts.serializers import UserReadOnlySerializer
 
-from .models import CourseTeam, CourseTeamMembership
+from lms.djangoapps.teams.models import CourseTeam, CourseTeamMembership
 
 
 class CountryField(serializers.Field):

--- a/lms/djangoapps/teams/tests/test_views.py
+++ b/lms/djangoapps/teams/tests/test_views.py
@@ -24,8 +24,8 @@ from util.testing import EventTestMixin
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 from .factories import CourseTeamFactory, LAST_ACTIVITY_AT
-from ..models import CourseTeamMembership
-from ..search_indexes import CourseTeamIndexer, CourseTeam, course_team_post_save_callback
+from ..models import CourseTeam, CourseTeamMembership
+from ..search_indexes import CourseTeamIndexer, course_team_post_save_callback
 
 from django_comment_common.models import Role, FORUM_ROLE_COMMUNITY_TA
 from django_comment_common.utils import seed_permissions_roles

--- a/lms/djangoapps/teams/views.py
+++ b/lms/djangoapps/teams/views.py
@@ -40,7 +40,7 @@ from student.roles import CourseStaffRole
 from django_comment_client.utils import has_discussion_privileges
 from util.model_utils import truncate_fields
 from . import is_feature_enabled
-from .models import CourseTeam, CourseTeamMembership
+from lms.djangoapps.teams.models import CourseTeam, CourseTeamMembership
 from .serializers import (
     CourseTeamSerializer,
     CourseTeamCreationSerializer,


### PR DESCRIPTION
Rather than just check if the attribute is set with a non-None value,
check that the value is actually changing.

This exception was being triggered by Django setting .team to the value
it already kind of had through the _team_cache attribute.  Now it
doesn't raise an exception.

TNL-3479
