### PR TITLE
MAYN-116 Including GTM code from microsite

### DIFF
--- a/lms/templates/google_tag_manager.html
+++ b/lms/templates/google_tag_manager.html
@@ -1,0 +1,4 @@
+<%doc>
+    Yet, installing google tag manager for microsite(s).
+    So intentionally left it blank
+</%doc>

--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -103,6 +103,7 @@ from branding import api as branding_api
     google_analytics_file = microsite.get_template_path('google_analytics.html')
 
     style_overrides_file = microsite.get_value('css_overrides_file')
+  google_tag_manager_file = microsite.get_template_path('google_tag_manager.html')
 %>
 
   % if header_extra_file:
@@ -124,6 +125,7 @@ from branding import api as branding_api
 </head>
 
 <body class="${static.dir_rtl()} <%block name='bodyclass'/> lang_${LANGUAGE_CODE}">
+<%include file="${google_tag_manager_file}" />
 <div id="page-prompt"></div>
 % if not disable_window_wrap:
   <div class="window-wrap" dir="${static.dir_rtl()}">


### PR DESCRIPTION
@bderusha @chrisndodge -- here is the cherry-picked commit containing the Google Tag Manager template detection logic for the MIT Professional Education microsite.
