### PR TITLE
Changed URL for rate limit test.

### DIFF
--- a/cms/djangoapps/course_creators/tests/test_admin.py
+++ b/cms/djangoapps/course_creators/tests/test_admin.py
@@ -166,10 +166,10 @@ class CourseCreatorAdminTest(TestCase):
             # try logging in 30 times, the default limit in the number of failed
             # login attempts in one 5 minute period before the rate gets limited
             for _ in xrange(30):
-                response = self.client.post('/admin/', post_params)
+                response = self.client.post('/admin/login/', post_params)
                 self.assertEquals(response.status_code, 200)
 
-            response = self.client.post('/admin/', post_params)
+            response = self.client.post('/admin/login/', post_params)
             # Since we are using the default rate limit behavior, we are
             # expecting this to return a 403 error to indicate that there have
             # been too many attempts


### PR DESCRIPTION
We just have the wrong URL here for logging in. If a user is not logged and accesses the root of the admin site, 1.4.x would render a login page:
https://github.com/django/django/blob/stable/1.4.x/django/contrib/admin/sites.py#L195
and 1.8.x redirects to the login page:
https://github.com/django/django/blob/stable/1.8.x/django/contrib/admin/sites.py#L229
