### PR TITLE
Fix user profile flaky tests.

### DIFF
--- a/common/test/acceptance/pages/lms/fields.py
+++ b/common/test/acceptance/pages/lms/fields.py
@@ -163,26 +163,19 @@ class FieldsMixin(object):
                 query.results[0].send_keys(u'\ue007')  # Press Enter
         return query.attrs('value')[0]
 
-    def value_for_textarea_field(self, field_id, value=None):
+    def set_value_for_textarea_field(self, field_id, value):
         """
-        Get or set the value of a textarea field.
+        Set the value of a textarea field.
         """
         self.wait_for_field(field_id)
-
         self.make_field_editable(field_id)
 
-        query = self.q(css='.u-field-{} textarea'.format(field_id))
-        if not query.present:
-            return None
+        field_selector = '.u-field-{} textarea'.format(field_id)
+        self.wait_for_element_presence(field_selector, 'Editable textarea is present.')
 
-        if value is not None:
-            query.fill(value)
-            query.results[0].send_keys(u'\ue004')  # Focus Out using TAB
-
-        if self.mode_for_field(field_id) == 'edit':
-            return query.text[0]
-        else:
-            return self.get_non_editable_mode_value(field_id)
+        query = self.q(css=field_selector)
+        query.fill(value)
+        query.results[0].send_keys(u'\ue004')  # Focus Out using TAB
 
     def get_non_editable_mode_value(self, field_id):
         """

--- a/common/test/acceptance/tests/lms/test_learner_profile.py
+++ b/common/test/acceptance/tests/lms/test_learner_profile.py
@@ -2,7 +2,6 @@
 """
 End-to-end tests for Student's Profile Page.
 """
-from flaky import flaky
 from contextlib import contextmanager
 
 from datetime import datetime
@@ -48,7 +47,7 @@ class LearnerProfileTestMixin(EventsTestMixin):
         """
         profile_page.value_for_dropdown_field('language_proficiencies', 'English')
         profile_page.value_for_dropdown_field('country', 'United Arab Emirates')
-        profile_page.value_for_textarea_field('bio', 'Nothing Special')
+        profile_page.set_value_for_textarea_field('bio', 'Nothing Special')
 
     def visit_profile_page(self, username, privacy=None):
         """
@@ -306,7 +305,7 @@ class OwnLearnerProfilePageTest(LearnerProfileTestMixin, WebAppTest):
         """
         Test behaviour of a textarea field.
         """
-        profile_page.value_for_textarea_field(field_id, new_value)
+        profile_page.set_value_for_textarea_field(field_id, new_value)
         self.assertEqual(profile_page.get_non_editable_mode_value(field_id), displayed_value)
         self.assertTrue(profile_page.mode_for_field(field_id), mode)
 
@@ -473,7 +472,6 @@ class OwnLearnerProfilePageTest(LearnerProfileTestMixin, WebAppTest):
 
         self.assert_default_image_has_public_access(profile_page)
 
-    @flaky  # TODO fix this, see TNL-2704
     def test_user_can_upload_the_profile_image_with_success(self):
         """
         Scenario: Upload profile image works correctly.
@@ -529,7 +527,6 @@ class OwnLearnerProfilePageTest(LearnerProfileTestMixin, WebAppTest):
             }
         })
 
-    @flaky  # TODO: fix TNL-3492
     def test_user_can_see_error_for_file_size_below_the_min_limit(self):
         """
         Scenario: Upload profile image does not work for < 100 Bytes image file.
@@ -641,7 +638,6 @@ class OwnLearnerProfilePageTest(LearnerProfileTestMixin, WebAppTest):
         self.assert_default_image_has_public_access(profile_page)
         self.assertFalse(profile_page.remove_link_present)
 
-    @flaky  # TNL-3514
     def test_eventing_after_multiple_uploads(self):
         """
         Scenario: An event is fired when a user with a profile image uploads another image
@@ -706,7 +702,6 @@ class DifferentUserLearnerProfilePageTest(LearnerProfileTestMixin, WebAppTest):
         self.verify_profile_page_is_private(profile_page, is_editable=False)
         self.verify_profile_page_view_event(username, different_user_id, visibility=self.PRIVACY_PRIVATE)
 
-    @flaky  # TODO fix this, see TNL-2199
     def test_different_user_public_profile(self):
         """
         Scenario: Verify that desired fields are shown when looking at a different user's public profile.

--- a/common/test/acceptance/tests/lms/test_teams.py
+++ b/common/test/acceptance/tests/lms/test_teams.py
@@ -425,7 +425,7 @@ class BrowseTopicsTest(TeamsTabBase):
         browse_teams_page.click_create_team_link()
         create_team_page = TeamManagementPage(self.browser, self.course_id, topic)
         create_team_page.value_for_text_field(field_id='name', value='Team Name', press_enter=False)
-        create_team_page.value_for_textarea_field(
+        create_team_page.set_value_for_textarea_field(
             field_id='description',
             value='Team description.'
         )
@@ -960,7 +960,7 @@ class TeamFormActions(TeamsTabBase):
             value=self.TEAMS_NAME,
             press_enter=False
         )
-        self.team_management_page.value_for_textarea_field(
+        self.team_management_page.set_value_for_textarea_field(
             field_id='description',
             value=self.TEAM_DESCRIPTION
         )


### PR DESCRIPTION
## [TNL-2704](https://openedx.atlassian.net/browse/TNL-2704)

Trying to read the value right after setting it in the bio field is flaky-- but nobody is using the return value anyway! There is a test that verifies that the bio field is properly set, but it uses a different method to get the value.

Related to TNL-2704, TNL-3492, TNL-3514, and TNL-2199.

Note that it doesn't actually address the failure stack trace in TNL-2199 (that's the only one that is different), but the test point associated with TNL-2199 has now run 30 times without failures in Jenkins, so I'm going to remove the flaky decorator with this PR and close TNL-2199 as Not Reproducible.
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @andy-armstrong 
- [x] Code review: @robrap 

FYI: @benpatterson 
### Post-review
- [x] Squash commits
