### PR TITLE
Make pep8 ignore test_root/staticfiles directory.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,4 +29,4 @@ no-path-adjustment=1
 #   It's a little unusual, but we have good reasons for doing so, so we disable
 #   this rule.
 ignore=E501,E265,W602
-exclude=migrations,.git,.pycharm_helpers
+exclude=migrations,.git,.pycharm_helpers,test_root/staticfiles


### PR DESCRIPTION
This directory is placed under .gitignore, so we shouldn't be worried
about pep8 errors in Python files placed there.

@nedbat @singingwolfboy What do you think?
