### PR TITLE
Reload user to grab session data before checking for it.

### DIFF
--- a/common/djangoapps/student/tests/test_login.py
+++ b/common/djangoapps/student/tests/test_login.py
@@ -284,6 +284,9 @@ class LoginTest(TestCase):
         response = client1.post(self.url, creds)
         self._assert_response(response, success=True)
 
+        # Reload the user from the database
+        self.user = User.objects.get(pk=self.user.pk)
+
         self.assertEqual(self.user.profile.get_meta()['session_id'], client1.session.session_key)
 
         # second login should log out the first


### PR DESCRIPTION
Fix for this error:

https://openedx.atlassian.net/browse/TNL-3529

The user's session data is written in the database and needs to be reloaded.
