### PR TITLE
Remove skip from test_annotatable

### DIFF
--- a/common/test/acceptance/tests/test_annotatable.py
+++ b/common/test/acceptance/tests/test_annotatable.py
@@ -2,7 +2,6 @@
 """
 E2E tests for the LMS.
 """
-from unittest import skip
 
 from .helpers import UniqueCourseTest
 from ..pages.studio.auto_auth import AutoAuthPage
@@ -119,7 +118,6 @@ class AnnotatableProblemTest(UniqueCourseTest):
         )
         return annotation_component_page
 
-    @skip  # TODO fix TNL-1590
     def test_annotation_component(self):
         """
         Test annotation components links to annotation problems.


### PR DESCRIPTION
@benpatterson  Please review this. I have run this test 61 times now in Jenkins, and it has passed every time. Don't know if something has changed, but without a way to get screenshots and additional information, I think it is best to just re-enable the test and see what happens.
