### PR TITLE
Upgrade Paver to 1.2.4

### DIFF
--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -1,5 +1,5 @@
 # Requirements to run Paver
-Paver==1.2.1
+Paver==1.2.4
 psutil==1.2.1
 lazy==1.1
 path.py==7.2


### PR DESCRIPTION
Paver 1.2.1 does not work properly on OS X El Capitan, and Paver 1.2.4 seems to fix it. I realize that this is an unsupported configuration, but this should be an easy upgrade to make, and it makes it easier for people who want to tinker with other platforms.

links: [CHANGELOG](https://github.com/paver/paver/blob/master/docs/source/changelog.rst) & [full diff](https://github.com/paver/paver/compare/Paver-1.2...Paver-1.2.4)

```
(edx-platform)[singingwolfboy@mammoth:~/dev/edx-platform on db/upgrade-paver]
% paver --version
Paver 1.2.1
(edx-platform)[singingwolfboy@mammoth:~/dev/edx-platform on db/upgrade-paver]
% paver install_prereqs
Warning: could not find environment JSON file at '/Users/singingwolfboy/lms.env.json'
Traceback (most recent call last):
  File "/Users/singingwolfboy/.virtualenvs/edx-platform/bin/paver", line 11, in <module>
    sys.exit(main())
  File "/Users/singingwolfboy/.virtualenvs/edx-platform/lib/python2.7/site-packages/paver/tasks.py", line 883, in main
    _launch_pavement(args)
  File "/Users/singingwolfboy/.virtualenvs/edx-platform/lib/python2.7/site-packages/paver/tasks.py", line 863, in _launch_pavement
    _process_commands(args, auto_pending=auto_pending)
  File "/Users/singingwolfboy/.virtualenvs/edx-platform/lib/python2.7/site-packages/paver/tasks.py", line 802, in _process_commands
    task, args = _parse_command_line(args)
  File "/Users/singingwolfboy/.virtualenvs/edx-platform/lib/python2.7/site-packages/paver/tasks.py", line 713, in _parse_command_line
    task, taskname, args = _preparse(args)
  File "/Users/singingwolfboy/.virtualenvs/edx-platform/lib/python2.7/site-packages/paver/tasks.py", line 671, in _preparse
    task = environment.get_task(taskname)
  File "/Users/singingwolfboy/.virtualenvs/edx-platform/lib/python2.7/site-packages/paver/tasks.py", line 130, in get_task
    all_tasks = self.get_tasks()
  File "/Users/singingwolfboy/.virtualenvs/edx-platform/lib/python2.7/site-packages/paver/tasks.py", line 228, in get_tasks
    scan_module(self.pavement)
  File "/Users/singingwolfboy/.virtualenvs/edx-platform/lib/python2.7/site-packages/paver/tasks.py", line 227, in scan_module
    scan_module(item)
  File "/Users/singingwolfboy/.virtualenvs/edx-platform/lib/python2.7/site-packages/paver/tasks.py", line 227, in scan_module
    scan_module(item)
  File "/Users/singingwolfboy/.virtualenvs/edx-platform/lib/python2.7/site-packages/paver/tasks.py", line 227, in scan_module
    scan_module(item)
  File "/Users/singingwolfboy/.virtualenvs/edx-platform/lib/python2.7/site-packages/paver/tasks.py", line 227, in scan_module
    scan_module(item)
  File "/Users/singingwolfboy/.virtualenvs/edx-platform/lib/python2.7/site-packages/paver/tasks.py", line 227, in scan_module
    scan_module(item)
  File "/Users/singingwolfboy/.virtualenvs/edx-platform/lib/python2.7/site-packages/paver/tasks.py", line 223, in scan_module
    item = getattr(module, name, None)
  File "/Users/singingwolfboy/.virtualenvs/edx-platform/lib/python2.7/site-packages/six.py", line 92, in __get__
    result = self._resolve()
  File "/Users/singingwolfboy/.virtualenvs/edx-platform/lib/python2.7/site-packages/six.py", line 115, in _resolve
    return _import_module(self.mod)
  File "/Users/singingwolfboy/.virtualenvs/edx-platform/lib/python2.7/site-packages/six.py", line 82, in _import_module
    __import__(name)
ImportError: No module named urllib
(edx-platform)[singingwolfboy@mammoth:~/dev/edx-platform on db/upgrade-paver]
% pip install paver==1.2.4                                                  1 ↵
You are using pip version 7.1.0, however version 7.1.2 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
Collecting paver==1.2.4
  Using cached Paver-1.2.4-py2.py3-none-any.whl
Installing collected packages: paver
  Found existing installation: Paver 1.2.1
    Uninstalling Paver-1.2.1:
      Successfully uninstalled Paver-1.2.1
Successfully installed paver-1.2.4
(edx-platform)[singingwolfboy@mammoth:~/dev/edx-platform on db/upgrade-paver]
% paver install_prereqs
Warning: could not find environment JSON file at '/Users/singingwolfboy/lms.env.json'
---> pavelib.prereqs.install_prereqs
---> pavelib.prereqs.install_ruby_prereqs
Ruby prereqs unchanged, skipping...
---> pavelib.prereqs.install_node_prereqs
Node prereqs unchanged, skipping...
---> pavelib.prereqs.install_python_prereqs
# etc...
```
