### PR TITLE
Preserve transactions that are expected to raise IntegrityErrors

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1416,7 +1416,8 @@ def _do_create_account(form):
     # TODO: Rearrange so that if part of the process fails, the whole process fails.
     # Right now, we can have e.g. no registration e-mail sent out and a zombie account
     try:
-        user.save()
+        with transaction.atomic():
+            user.save()
     except IntegrityError:
         # Figure out the cause of the integrity error
         if len(User.objects.filter(username=user.username)) > 0:

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -17,7 +17,7 @@ from django.views.decorators.http import require_POST
 from django.views.decorators.cache import cache_control
 from django.core.exceptions import ValidationError, PermissionDenied
 from django.core.mail.message import EmailMessage
-from django.db import IntegrityError
+from django.db import IntegrityError, transaction
 from django.core.urlresolvers import reverse
 from django.core.validators import validate_email
 from django.utils.translation import ugettext as _
@@ -437,11 +437,12 @@ def register_and_enroll_students(request, course_id):  # pylint: disable=too-man
                     password = generate_unique_password(generated_passwords)
 
                     try:
-                        enrollment_obj = create_and_enroll_user(email, username, name, country, password, course_id)
-                        reason = 'Enrolling via csv upload'
-                        ManualEnrollmentAudit.create_manual_enrollment_audit(
-                            request.user, email, UNENROLLED_TO_ENROLLED, reason, enrollment_obj
-                        )
+                        with transaction.atomic():
+                            enrollment_obj = create_and_enroll_user(email, username, name, country, password, course_id)
+                            reason = 'Enrolling via csv upload'
+                            ManualEnrollmentAudit.create_manual_enrollment_audit(
+                                request.user, email, UNENROLLED_TO_ENROLLED, reason, enrollment_obj
+                            )
                     except IntegrityError:
                         row_errors.append({
                             'username': username, 'email': email, 'response': _('Username {user} already exists.').format(user=username)})
@@ -1384,7 +1385,8 @@ def save_registration_code(user, course_id, mode_slug, invoice=None, order=None,
         invoice_item=invoice_item
     )
     try:
-        course_registration.save()
+        with transaction.atomic():
+            course_registration.save()
         return course_registration
     except IntegrityError:
         return save_registration_code(

--- a/lms/djangoapps/verify_student/models.py
+++ b/lms/djangoapps/verify_student/models.py
@@ -1324,6 +1324,7 @@ class SkippedReverification(models.Model):
         unique_together = (('user', 'course_id'),)
 
     @classmethod
+    @transaction.atomic
     def add_skipped_reverification_attempt(cls, checkpoint, user_id, course_id):
         """Create skipped reverification object.
 

--- a/lms/djangoapps/verify_student/services.py
+++ b/lms/djangoapps/verify_student/services.py
@@ -6,7 +6,7 @@ import logging
 
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.urlresolvers import reverse
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError
 
 from opaque_keys.edx.keys import CourseKey
 
@@ -99,8 +99,7 @@ class ReverificationService(object):
         # user can skip a reverification attempt only if that user has not already
         # skipped an attempt
         try:
-            with transaction.atomic():
-                SkippedReverification.add_skipped_reverification_attempt(checkpoint, user_id, course_key)
+            SkippedReverification.add_skipped_reverification_attempt(checkpoint, user_id, course_key)
         except IntegrityError:
             log.exception("Skipped attempt already exists for user %s: with course %s:", user_id, unicode(course_id))
 

--- a/lms/djangoapps/verify_student/services.py
+++ b/lms/djangoapps/verify_student/services.py
@@ -6,7 +6,7 @@ import logging
 
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.urlresolvers import reverse
-from django.db import IntegrityError
+from django.db import IntegrityError, transaction
 
 from opaque_keys.edx.keys import CourseKey
 
@@ -99,7 +99,8 @@ class ReverificationService(object):
         # user can skip a reverification attempt only if that user has not already
         # skipped an attempt
         try:
-            SkippedReverification.add_skipped_reverification_attempt(checkpoint, user_id, course_key)
+            with transaction.atomic():
+                SkippedReverification.add_skipped_reverification_attempt(checkpoint, user_id, course_key)
         except IntegrityError:
             log.exception("Skipped attempt already exists for user %s: with course %s:", user_id, unicode(course_id))
 

--- a/lms/djangoapps/verify_student/tests/test_models.py
+++ b/lms/djangoapps/verify_student/tests/test_models.py
@@ -6,7 +6,7 @@ import requests.exceptions
 import pytz
 
 from django.conf import settings
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError
 from django.test import TestCase
 from mock import patch
 from nose.tools import assert_is_none, assert_equals, assert_raises, assert_true, assert_false  # pylint: disable=no-name-in-module
@@ -770,10 +770,9 @@ class SkippedReverificationTest(ModuleStoreTestCase):
             checkpoint=self.checkpoint, user_id=self.user.id, course_id=unicode(self.course.id)
         )
         with self.assertRaises(IntegrityError):
-            with transaction.atomic():
-                SkippedReverification.add_skipped_reverification_attempt(
-                    checkpoint=self.checkpoint, user_id=self.user.id, course_id=unicode(self.course.id)
-                )
+            SkippedReverification.add_skipped_reverification_attempt(
+                checkpoint=self.checkpoint, user_id=self.user.id, course_id=unicode(self.course.id)
+            )
 
         # create skipped attempt for different user
         user2 = UserFactory.create()

--- a/lms/djangoapps/verify_student/tests/test_models.py
+++ b/lms/djangoapps/verify_student/tests/test_models.py
@@ -6,7 +6,7 @@ import requests.exceptions
 import pytz
 
 from django.conf import settings
-from django.db.utils import IntegrityError
+from django.db import IntegrityError, transaction
 from django.test import TestCase
 from mock import patch
 from nose.tools import assert_is_none, assert_equals, assert_raises, assert_true, assert_false  # pylint: disable=no-name-in-module
@@ -770,9 +770,10 @@ class SkippedReverificationTest(ModuleStoreTestCase):
             checkpoint=self.checkpoint, user_id=self.user.id, course_id=unicode(self.course.id)
         )
         with self.assertRaises(IntegrityError):
-            SkippedReverification.add_skipped_reverification_attempt(
-                checkpoint=self.checkpoint, user_id=self.user.id, course_id=unicode(self.course.id)
-            )
+            with transaction.atomic():
+                SkippedReverification.add_skipped_reverification_attempt(
+                    checkpoint=self.checkpoint, user_id=self.user.id, course_id=unicode(self.course.id)
+                )
 
         # create skipped attempt for different user
         user2 = UserFactory.create()


### PR DESCRIPTION
Preserve transactions that are expected to raise IntegrityErrors by wrapping them in transaction.atomic context managers.

https://openedx.atlassian.net/browse/TNL-3576

@symbolist I'm currently unsure how this will interact with your other transactional work - please review.

@macdiesel @alawibaba @muzaffaryousaf @muhammad-ammar Please review.
