### PR TITLE
Add a class to the course number in the page header to facilitate hiding it in a theme.

### DIFF
--- a/lms/templates/navigation-edx.html
+++ b/lms/templates/navigation-edx.html
@@ -48,7 +48,11 @@ site_status_msg = get_site_status_msg(course_id)
     </h1>
 
     % if course and not disable_courseware_header:
-    <h2 class="course-header"><span class="provider">${course.display_org_with_default | h}:</span> ${course.display_number_with_default | h} ${course.display_name_with_default}</h2>
+    <h2 class="course-header">
+      <span class="provider">${course.display_org_with_default | h}:</span>
+      <span class="course-number">${course.display_number_with_default | h}</span>
+      <span class="course-name">${course.display_name_with_default}</span>
+    </h2>
     % endif
 
     % if user.is_authenticated():

--- a/lms/templates/navigation.html
+++ b/lms/templates/navigation.html
@@ -49,7 +49,7 @@ site_status_msg = get_site_status_msg(course_id)
 
     % if course:
     <h2 class="course-header"><span class="provider">${course.display_org_with_default | h}:</span>
-      ${course.display_number_with_default | h}
+      <span class="course-number">${course.display_number_with_default | h}</span>
       <%
         display_name = course.display_name_with_default
         if settings.FEATURES.get('CUSTOM_COURSES_EDX', False):
@@ -57,7 +57,7 @@ site_status_msg = get_site_status_msg(course_id)
           if ccx:
             display_name = ccx.display_name
       %>
-      ${display_name}</h2>
+      <span class="course-name">${display_name}</span></h2>
     % endif
 
     % if user.is_authenticated():


### PR DESCRIPTION
**Description**
This change adds an HTML class to the course number displayed in the page header before the title of the course.  This makes the number easily themeable without having to fork the template itself.  We used it to hide the number for one of our clients.  It might also be helpful for other CSS uses, like giving the number a different colour.

---

**JIRA Story** [OSPR-851](https://openedx.atlassian.net/browse/OSPR-851)
**Confluence / Product Asset** N/A
**Sandbox URL** [pr10125.sandbox.opencraft.com](http://pr10125.sandbox.opencraft.com/)
**Dependencies** N/A
**PR Author(s) Notes / To-Do** N/A
**Screenshots** N/A

---

**Reviewers**
- [x] Code: @mtyaka
- [ ] Code: (TBD)
- [ ] Product: (TBD)
