### PR TITLE
Fixed test about me field test failing on chrome

### DIFF
--- a/common/test/acceptance/pages/lms/fields.py
+++ b/common/test/acceptance/pages/lms/fields.py
@@ -182,6 +182,7 @@ class FieldsMixin(object):
         Return value of field in `display` or `placeholder` mode.
         """
         self.wait_for_field(field_id)
+        self.wait_for_ajax()
 
         return self.q(css='.u-field-{} .u-field-value .u-field-value-readonly'.format(field_id)).text[0]
 

--- a/common/test/acceptance/tests/lms/test_learner_profile.py
+++ b/common/test/acceptance/tests/lms/test_learner_profile.py
@@ -375,10 +375,10 @@ class OwnLearnerProfilePageTest(LearnerProfileTestMixin, WebAppTest):
         Given that I am a registered user.
         And I visit my Profile page.
         And I set the profile visibility to public and set default values for public fields.
-        Then I set about me value to `Eat Sleep Code`.
-        Then displayed about me should be `Eat Sleep Code` and about me field mode should be `display`
+        Then I set about me value to `ThisIsIt`.
+        Then displayed about me should be `ThisIsIt` and about me field mode should be `display`
         And I reload the page.
-        Then displayed about me should be `Eat Sleep Code` and about me field mode should be `display`
+        Then displayed about me should be `ThisIsIt` and about me field mode should be `display`
         Then I set empty value for about me.
         Then displayed about me should be `Tell other edX learners a little about yourself: where you live,
         what your interests are, why you're taking courses on edX, or what you hope to learn.` and about me


### PR DESCRIPTION
@cahrens @benpatterson @jzoldak 
Please review. It seemed like the test was waiting for wait_for_field and as chrome runs faster then firefox it was returning the list before it was changed (on chrome). 
