### PR TITLE
Fix staticfiles import in microsite.py.

### DIFF
--- a/common/djangoapps/microsite_configuration/templatetags/microsite.py
+++ b/common/djangoapps/microsite_configuration/templatetags/microsite.py
@@ -6,7 +6,7 @@ from django import template
 from django.conf import settings
 from microsite_configuration import microsite
 from django.templatetags.static import static
-from staticfiles.storage import staticfiles_storage
+from django.contrib.staticfiles.storage import staticfiles_storage
 
 register = template.Library()
 


### PR DESCRIPTION
**Background**: `django-staticfiles` was replaced with `django.contrib.staticfiles` in dbcd1bf430d75b1fe2c7d3c7ed08fd48aad9b69d. The `common/djangoapps/microsite_configuration/templatetags/microsite.py` file was still trying to import the old staticfiles package, breaking the app on fresh installations.
**Discussions**: https://groups.google.com/forum/#!topic/openedx-ops/Ve_lBa3oGk8
**Partner information**: Affects all new installations.
**Merge deadline**: As soon as possible - this is breaking fresh installations.
**JIRA ticket**: https://openedx.atlassian.net/browse/OSPR-853

**How to reproduce**:

You will run into this issue if you install edx-platform into a new virtualenv. LMS and Studio will fail to start with `django.core.exceptions.ImproperlyConfigured: ImportError contentstore: cannot import name microsite`.

To test this on an existing devstack, you can uninstall existing packages:

```
pip freeze | grep -v "^-e" | xargs pip uninstall -y
```

Then re-install the declared dependencies:

```
for i in pre base github local paver post ; do pip install -r requirements/edx/$i.txt ; done
```

LMS/Studio will fail to start with the above error message.
