### PR TITLE
Fixed all tests in OwnLearnerProfilePageTest that were failing on Chrome

### DIFF
--- a/common/test/acceptance/pages/lms/learner_profile.py
+++ b/common/test/acceptance/pages/lms/learner_profile.py
@@ -217,11 +217,8 @@ class LearnerProfilePage(FieldsMixin, PageObject):
 
         self.browser.execute_script('$(".upload-submit").show();')
 
-        # First send_keys will initialize the jquery auto upload plugin.
-        self.q(css='.upload-button-input').results[0].send_keys(file_path)
         self.q(css='.upload-submit').first.click()
         self.q(css='.upload-button-input').results[0].send_keys(file_path)
-
         self.wait_for_ajax()
 
     @property


### PR DESCRIPTION
@benpatterson @jzoldak @muzaffaryousaf 
Please review. 
**To be specific, fixes:**
1. test_eventing_after_multiple_uploads
2. test_user_can_remove_profile_image
3. test_user_can_see_error_for_exceeding_max_file_size_limit
4. test_user_can_see_error_for_file_size_below_the_min_limit
5. test_user_can_see_error_for_wrong_file_type
6. test_user_can_upload_the_profile_image_with_success
