### PR TITLE
Video player (2 of 2): adding closed captioning

### DIFF
--- a/cms/static/cms/js/require-config.js
+++ b/cms/static/cms/js/require-config.js
@@ -284,6 +284,9 @@ require.config({
             exports: "osda",
             deps: ["annotator", "annotator-harvardx", "video.dev", "vjs.youtube", "rangeslider", "share-annotator", "richText-annotator", "reply-annotator", "tags-annotator", "flagging-annotator", "grouping-annotator", "diacritic-annotator", "openseadragon", "jquery-Watch", "catch", "handlebars", "URI"]
         },
+        "draggabilly": {
+            exports: "Draggabilly"
+        }
         // end of annotation tool files
     }
 });

--- a/cms/static/coffee/spec/main.coffee
+++ b/cms/static/coffee/spec/main.coffee
@@ -206,6 +206,9 @@ requirejs.config({
         },
         "coffee/src/ajax_prefix": {
             deps: ["jquery"]
+        },
+        "draggabilly": {
+            exports: "Draggabilly"
         }
     }
 });

--- a/cms/static/coffee/spec/main_squire.coffee
+++ b/cms/static/coffee/spec/main_squire.coffee
@@ -176,6 +176,9 @@ requirejs.config({
         },
         "coffee/src/ajax_prefix": {
             deps: ["jquery"]
+        },
+        "draggabilly": {
+            exports: "Draggabilly"
         }
     }
 });

--- a/cms/static/js_test_squire.yml
+++ b/cms/static/js_test_squire.yml
@@ -63,6 +63,7 @@ lib_paths:
     - xmodule_js/common_static/js/vendor/jQuery-File-Upload/js/jquery.fileupload-process.js
     - xmodule_js/common_static/js/vendor/jQuery-File-Upload/js/jquery.fileupload-validate.js
     - xmodule_js/common_static/js/vendor/requirejs/text.js
+    - xmodule_js/common_static/js/vendor/draggabilly.pkgd.js
 
 # Paths to source JavaScript files
 src_paths:

--- a/common/lib/xmodule/xmodule/css/video/display.scss
+++ b/common/lib/xmodule/xmodule/css/video/display.scss
@@ -247,6 +247,41 @@ html:not('.afontgarde') .icon-fallback-img {
       }
     }
 
+    .closed-captions {
+      display: none;
+      position: absolute;
+      width: 85%;
+      max-height: ($baseline * 3);
+      left: 5%;
+      top: 70%;
+      border-radius: ($baseline / 5);
+      padding: 8px ($baseline / 2) 8px ($baseline * 1.5);
+      background: rgba(0, 0, 0, .35);
+      color: $yellow;
+
+      &:before {
+        position: absolute;
+        display: inline-block;
+        top: 50%;
+        @include margin-left(-($baseline));
+        margin-top: -.5em;
+        font-family: 'FontAwesome';
+        content: "\f142";
+        color: $white;
+        opacity: 0.5;
+      }
+
+      &:hover,
+      &.is-dragging {
+        background: rgba(0, 0, 0, .75);
+        cursor: move;
+
+        &:before {
+          opacity: 1.0;
+        }
+      }
+    }
+
     .video-player {
       overflow: hidden;
       min-height: 300px;
@@ -701,39 +736,44 @@ html:not('.afontgarde') .icon-fallback-img {
   .subtitles {
     @include float(left);
     overflow: auto;
-    margin: 0;
     max-height: 460px;
     width: flex-grid(3, 9);
     padding: 0;
     font-size: 14px;
-    list-style: none;
     visibility: visible;
 
-    li {
-      @extend %ui-fake-link;
-      margin-bottom: 8px;
-      border: 0;
+    .subtitles-menu {
+      height: 100%;
+      margin: 0;
       padding: 0;
-      color: #0074b5; // AA compliant
-      line-height: lh();
+      list-style: none;
 
-      &.current {
-        color: #333;
-        font-weight: 700;
-      }
+      li {
+        @extend %ui-fake-link;
+        margin-bottom: 8px;
+        border: 0;
+        padding: 0;
+        color: #0074b5; // AA compliant
+        line-height: lh();
 
-      &.focused {
-        outline: #000 dotted thin;
-        outline-offset: -1px;
-      }
+        &.current {
+          color: #333;
+          font-weight: 700;
+        }
 
-      &:hover,
-      &:focus {
-        text-decoration: underline;
-      }
+        &.focused {
+          outline: #000 dotted thin;
+          outline-offset: -1px;
+        }
 
-      &:empty {
-        margin-bottom: 0;
+        &:hover,
+        &:focus {
+          text-decoration: underline;
+        }
+
+        &:empty {
+          margin-bottom: 0;
+        }
       }
     }
   }

--- a/common/lib/xmodule/xmodule/css/video/display.scss
+++ b/common/lib/xmodule/xmodule/css/video/display.scss
@@ -248,15 +248,17 @@ html:not('.afontgarde') .icon-fallback-img {
     }
 
     .closed-captions {
-      display: none;
       position: absolute;
       width: 85%;
-      max-height: ($baseline * 3);
       left: 5%;
       top: 70%;
+    }
+
+    .closed-captions.is-visible {
+      max-height: ($baseline * 3);
       border-radius: ($baseline / 5);
       padding: 8px ($baseline / 2) 8px ($baseline * 1.5);
-      background: rgba(0, 0, 0, .35);
+      background: rgba(0, 0, 0, .75);
       color: $yellow;
 
       &:before {
@@ -273,7 +275,7 @@ html:not('.afontgarde') .icon-fallback-img {
 
       &:hover,
       &.is-dragging {
-        background: rgba(0, 0, 0, .75);
+        background: rgba(0, 0, 0, 1.0);
         cursor: move;
 
         &:before {

--- a/common/lib/xmodule/xmodule/js/fixtures/video_all.html
+++ b/common/lib/xmodule/xmodule/js/fixtures/video_all.html
@@ -17,6 +17,7 @@
               <div id="id"></div>
             </section>
             <div class="video-player-post"></div>
+            <div class="closed-captions"></div>
             <section class="video-controls is-hidden">
               <div class="slider"></div>
               <div>

--- a/common/lib/xmodule/xmodule/js/js_test.yml
+++ b/common/lib/xmodule/xmodule/js/js_test.yml
@@ -58,6 +58,7 @@ lib_paths:
     - common_static/js/src/utility.js
     - public/js/split_test_staff.js
     - common_static/js/src/accessibility_tools.js
+    - common_static/js/vendor/draggabilly.pkgd.js
     - common_static/js/vendor/moment.min.js
     - spec/main_requirejs.js
 

--- a/common/lib/xmodule/xmodule/js/spec/main_requirejs.js
+++ b/common/lib/xmodule/xmodule/js/spec/main_requirejs.js
@@ -1,7 +1,11 @@
 (function(requirejs) {
     requirejs.config({
         paths: {
+            "draggabilly": "xmodule/include/common_static/js/vendor/draggabilly.pkgd",
             "moment": "xmodule/include/common_static/js/vendor/moment.min"
+        },
+        "draggabilly": {
+            exports: "Draggabilly"
         },
         "moment": {
             exports: "moment"

--- a/common/lib/xmodule/xmodule/js/spec/video/video_caption_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_caption_spec.js
@@ -48,6 +48,11 @@
                     });
                 });
 
+                it('adds the captioning control to the video player', function() {
+                    state = jasmine.initializePlayer();
+                    expect($('.video')).toContain('.toggle-captions');
+                });
+
                 it('fetch the transcript in HTML5 mode', function () {
                     runs(function () {
                         state = jasmine.initializePlayer();
@@ -122,16 +127,16 @@
 
                 it('bind the mouse movement', function () {
                     state = jasmine.initializePlayer();
-                    expect($('.subtitles')).toHandle('mouseover');
-                    expect($('.subtitles')).toHandle('mouseout');
-                    expect($('.subtitles')).toHandle('mousemove');
-                    expect($('.subtitles')).toHandle('mousewheel');
-                    expect($('.subtitles')).toHandle('DOMMouseScroll');
+                    expect($('.subtitles-menu')).toHandle('mouseover');
+                    expect($('.subtitles-menu')).toHandle('mouseout');
+                    expect($('.subtitles-menu')).toHandle('mousemove');
+                    expect($('.subtitles-menu')).toHandle('mousewheel');
+                    expect($('.subtitles-menu')).toHandle('DOMMouseScroll');
                  });
 
                  it('bind the scroll', function () {
                     state = jasmine.initializePlayer();
-                    expect($('.subtitles'))
+                    expect($('.subtitles-menu'))
                         .toHandleWith('scroll', state.videoControl.showControls);
                  });
 
@@ -155,6 +160,54 @@
                     'pause': plugin.pause,
                     'play': plugin.play,
                     'destroy': plugin.destroy
+                });
+            });
+
+            describe('renderCaptions', function() {
+
+                describe('is rendered', function() {
+                    var KEY = $.ui.keyCode,
+
+                        keyPressEvent = function(key) {
+                            return $.Event('keydown', { keyCode: key });
+                        };
+
+                    it('toggle the captions on control click', function() {
+                        state = jasmine.initializePlayer();
+
+                        $('.toggle-captions').click();
+                        expect($('.closed-captions')).toHaveClass('is-visible');
+                        $('.toggle-captions').click();
+                        expect($('.closed-captions')).not.toHaveClass('is-visible');
+                    });
+
+                    it('toggles the captions on keypress ENTER', function() {
+                        state = jasmine.initializePlayer();
+
+                        $('.toggle-captions').focus();
+                        $('.toggle-captions').trigger(keyPressEvent(KEY.ENTER));
+                        expect($('.toggle-captions')).toHaveClass('is-active');
+                        expect($('.closed-captions')).toHaveClass('is-visible');
+
+                        $('.toggle-captions').focus();
+                        $('.toggle-captions').trigger(keyPressEvent(KEY.ENTER));
+                        expect($('.toggle-captions')).not.toHaveClass('is-active');
+                        expect($('.closed-captions')).not.toHaveClass('is-visible');
+                    });
+
+                    it('toggles the captions on keypress SPACE', function() {
+                        state = jasmine.initializePlayer();
+
+                        $('.toggle-captions').focus();
+                        $('.toggle-captions').trigger(keyPressEvent(KEY.SPACE));
+                        expect($('.toggle-captions')).toHaveClass('is-active');
+                        expect($('.closed-captions')).toHaveClass('is-visible');
+
+                        $('.toggle-captions').focus();
+                        $('.toggle-captions').trigger(keyPressEvent(KEY.SPACE));
+                        expect($('.toggle-captions')).not.toHaveClass('is-active');
+                        expect($('.closed-captions')).not.toHaveClass('is-visible');
+                    });
                 });
             });
 
@@ -444,7 +497,7 @@
                     runs(function () {
                         $(window).trigger(jQuery.Event('mousemove'));
                         jasmine.Clock.tick(state.config.captionsFreezeTime);
-                        $('.subtitles').trigger(jQuery.Event('mouseenter'));
+                        $('.subtitles-menu').trigger(jQuery.Event('mouseenter'));
                         jasmine.Clock.tick(state.config.captionsFreezeTime);
                     });
                 });
@@ -459,7 +512,7 @@
                 describe('when the cursor is moving', function () {
                     it('reset the freezing timeout', function () {
                         runs(function () {
-                            $('.subtitles').trigger(jQuery.Event('mousemove'));
+                            $('.subtitles-menu').trigger(jQuery.Event('mousemove'));
                             expect(window.clearTimeout).toHaveBeenCalled();
                         });
                     });
@@ -468,7 +521,7 @@
                 describe('when the mouse is scrolling', function () {
                     it('reset the freezing timeout', function () {
                         runs(function () {
-                            $('.subtitles').trigger(jQuery.Event('mousewheel'));
+                            $('.subtitles-menu').trigger(jQuery.Event('mousewheel'));
                             expect(window.clearTimeout).toHaveBeenCalled();
                         });
                     });
@@ -486,7 +539,7 @@
 
                 describe('always', function () {
                     beforeEach(function () {
-                        $('.subtitles').trigger(jQuery.Event('mouseout'));
+                        $('.subtitles-menu').trigger(jQuery.Event('mouseout'));
                     });
 
                     it('reset the freezing timeout', function () {
@@ -501,9 +554,9 @@
                 describe('when the player is playing', function () {
                     beforeEach(function () {
                         state.videoCaption.playing = true;
-                        $('.subtitles li[data-index]:first')
+                        $('.subtitles-menu li[data-index]:first')
                             .addClass('current');
-                        $('.subtitles').trigger(jQuery.Event('mouseout'));
+                        $('.subtitles-menu').trigger(jQuery.Event('mouseout'));
                     });
 
                     it('scroll the transcript', function () {
@@ -514,7 +567,7 @@
                 describe('when the player is not playing', function () {
                     beforeEach(function () {
                         state.videoCaption.playing = false;
-                        $('.subtitles').trigger(jQuery.Event('mouseout'));
+                        $('.subtitles-menu').trigger(jQuery.Event('mouseout'));
                     });
 
                     it('does not scroll the transcript', function () {

--- a/common/lib/xmodule/xmodule/js/spec/video/video_caption_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_caption_spec.js
@@ -51,6 +51,7 @@
                 it('adds the captioning control to the video player', function() {
                     state = jasmine.initializePlayer();
                     expect($('.video')).toContain('.toggle-captions');
+                    expect($('.video')).toContain('.closed-captions');
                 });
 
                 it('fetch the transcript in HTML5 mode', function () {
@@ -165,46 +166,81 @@
 
             describe('renderCaptions', function() {
 
-                describe('is rendered', function() {
-                    var KEY = $.ui.keyCode,
+                var KEY = $.ui.keyCode;
 
-                        keyPressEvent = function(key) {
-                            return $.Event('keydown', { keyCode: key });
-                        };
+                function keyPressEvent(key) {
+                    return $.Event('keydown', { keyCode: key });
+                }
+
+                describe('is rendered', function() {
 
                     it('toggle the captions on control click', function() {
                         state = jasmine.initializePlayer();
 
                         $('.toggle-captions').click();
+                        expect($('.toggle-captions')).toHaveClass('is-active');
                         expect($('.closed-captions')).toHaveClass('is-visible');
+
                         $('.toggle-captions').click();
+                        expect($('.toggle-captions')).not.toHaveClass('is-active');
                         expect($('.closed-captions')).not.toHaveClass('is-visible');
                     });
 
                     it('toggles the captions on keypress ENTER', function() {
-                        state = jasmine.initializePlayer();
+                        // what i originally had
+                        // state = jasmine.initializePlayer();
 
-                        $('.toggle-captions').focus();
-                        $('.toggle-captions').trigger(keyPressEvent(KEY.ENTER));
-                        expect($('.toggle-captions')).toHaveClass('is-active');
-                        expect($('.closed-captions')).toHaveClass('is-visible');
+                        // $('.toggle-captions').focus().trigger(keyPressEvent(KEY.ENTER));
+                        // expect($('.toggle-captions')).toHaveClass('is-active');
+                        // expect($('.closed-captions')).toHaveClass('is-visible');
 
-                        $('.toggle-captions').focus();
-                        $('.toggle-captions').trigger(keyPressEvent(KEY.ENTER));
-                        expect($('.toggle-captions')).not.toHaveClass('is-active');
-                        expect($('.closed-captions')).not.toHaveClass('is-visible');
+                        // $('.toggle-captions').focus().trigger(keyPressEvent(KEY.ENTER));
+                        // expect($('.toggle-captions')).not.toHaveClass('is-active');
+                        // expect($('.closed-captions')).not.toHaveClass('is-visible');
+
+                        // using examples from the platform, should work?
+                        runs(function() {
+                            state = jasmine.initializePlayer();
+
+                            $('.toggle-captions').focus();
+                            $('.toggle-captions').trigger(keyPressEvent(KEY.ENTER));
+                        });
+
+                        waitsFor(function() {
+                            return $('.toggle-captions').hasClass('is-active');
+                        }, "closed captions to be enabled", 5000);
+
+                        runs(function() {
+                            expect($('.toggle-captions')).toHaveClass('is-active');
+                            expect($('.closed-captions')).toHaveClass('is-visible');
+                        });
+
+                        // trying setTimeout, which does work, but should it?
+                        // state = jasmine.initializePlayer();
+
+                        // $('.toggle-captions').trigger(keyPressEvent(KEY.ENTER));
+
+                        // setTimeout(function() {
+                        //     expect($('.toggle-captions')).toHaveClass('is-active');
+                        //     expect($('.closed-captions')).toHaveClass('is-visible');
+                        // }, 500);
+
+                        // $('.toggle-captions').focus().trigger(keyPressEvent(KEY.ENTER));
+
+                        // setTimeout(function() {
+                        //     expect($('.toggle-captions')).not.toHaveClass('is-active');
+                        //     expect($('.closed-captions')).not.toHaveClass('is-visible');
+                        // }, 500);
                     });
 
                     it('toggles the captions on keypress SPACE', function() {
                         state = jasmine.initializePlayer();
 
-                        $('.toggle-captions').focus();
-                        $('.toggle-captions').trigger(keyPressEvent(KEY.SPACE));
+                        $('.toggle-captions').focus().trigger(keyPressEvent(KEY.SPACE));
                         expect($('.toggle-captions')).toHaveClass('is-active');
                         expect($('.closed-captions')).toHaveClass('is-visible');
 
-                        $('.toggle-captions').focus();
-                        $('.toggle-captions').trigger(keyPressEvent(KEY.SPACE));
+                        $('.toggle-captions').focus().trigger(keyPressEvent(KEY.SPACE));
                         expect($('.toggle-captions')).not.toHaveClass('is-active');
                         expect($('.closed-captions')).not.toHaveClass('is-visible');
                     });
@@ -216,9 +252,9 @@
                 describe('is rendered', function () {
                     var KEY = $.ui.keyCode,
 
-                        keyPressEvent = function(key) {
-                            return $.Event('keydown', { keyCode: key });
-                        };
+                    keyPressEvent = function(key) {
+                        return $.Event('keydown', { keyCode: key });
+                    };
 
                     it('if languages more than 1', function () {
                         state = jasmine.initializePlayer();

--- a/common/lib/xmodule/xmodule/js/spec/video/video_player_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_player_spec.js
@@ -92,7 +92,8 @@ function (VideoPlayer) {
                         showinfo: 0,
                         enablejsapi: 1,
                         modestbranding: 1,
-                        html5: 1
+                        html5: 1,
+                        cc_load_policy: 0
                     },
                     videoId: 'cogebirgzzM',
                     events: events
@@ -118,7 +119,8 @@ function (VideoPlayer) {
                         rel: 0,
                         showinfo: 0,
                         enablejsapi: 1,
-                        modestbranding: 1
+                        modestbranding: 1,
+                        cc_load_policy: 0
                     },
                     videoId: 'abcdefghijkl',
                     events: jasmine.any(Object)

--- a/common/lib/xmodule/xmodule/js/src/video/03_video_player.js
+++ b/common/lib/xmodule/xmodule/js/src/video/03_video_player.js
@@ -139,7 +139,8 @@ function (HTML5Video, Resizer) {
             rel: 0,
             showinfo: 0,
             enablejsapi: 1,
-            modestbranding: 1
+            modestbranding: 1,
+            cc_load_policy: 0
         };
 
         if (!state.isFlashMode()) {

--- a/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
@@ -205,8 +205,8 @@
                     keyCode = event.keyCode;
 
                 switch(keyCode) {
+                    // KEY.ENTER works inherently so we don't need to script it explicitly
                     case KEY.SPACE:
-                    case KEY.ENTER:
                         event.preventDefault();
                         this.toggleClosedCaptions();
                 }
@@ -1081,6 +1081,11 @@
 
             showClosedCaptions: function() {
                 this.state.el.addClass('has-captions');
+
+                this.captionDisplayEl
+                    .show()
+                    .addClass('is-visible');
+
                 this.captionControlEl
                     .addClass('is-active')
                     .find('.control-text')
@@ -1093,22 +1098,19 @@
                     this.captionDisplayEl
                         .text(gettext('(Captions will appear here once the video plays.)'));
                 }
-
-                this.captionDisplayEl
-                    .show()
-                    .addClass('is-visible');
             },
 
             hideClosedCaptions: function() {
                 this.state.el.removeClass('has-captions');
-                this.captionControlEl
-                    .removeClass('is-active')
-                    .find('.control-text')
-                        .text(gettext('Turn on closed captioning'));
 
                 this.captionDisplayEl
                     .hide()
                     .removeClass('is-visible');
+
+                this.captionControlEl
+                    .removeClass('is-active')
+                    .find('.control-text')
+                        .text(gettext('Turn on closed captioning'));
             },
 
             updateCaptioningCookie: function(method) {

--- a/common/static/common/js/spec/main_requirejs.js
+++ b/common/static/common/js/spec/main_requirejs.js
@@ -32,7 +32,8 @@
             'jasmine-imagediff': 'js/vendor/jasmine-imagediff',
             'jasmine-stealth': 'js/vendor/jasmine-stealth',
             'jasmine.async': 'js/vendor/jasmine.async',
-            'URI': 'js/vendor/URI.min'
+            'URI': 'js/vendor/URI.min',
+            'draggabilly': 'js/vendor/draggabilly.pkgd'
         },
         shim: {
             'gettext': {
@@ -149,6 +150,9 @@
             },
             "sinon": {
                 exports: "sinon"
+            },
+            "draggabilly": {
+                exports: "Draggabilly"
             }
         }
     });

--- a/common/test/acceptance/pages/lms/video/video.py
+++ b/common/test/acceptance/pages/lms/video/video.py
@@ -16,6 +16,7 @@ log = logging.getLogger('VideoPage')
 VIDEO_BUTTONS = {
     'transcript': '.lang',
     'transcript_button': '.toggle-transcript',
+    'cc_button': '.toggle-captions',
     'volume': '.volume',
     'play': '.video_control.play',
     'pause': '.video_control.pause',
@@ -28,10 +29,11 @@ VIDEO_BUTTONS = {
 }
 
 CSS_CLASS_NAMES = {
-    'closed_captions': '.video.closed',
+    'captions_closed': '.video.closed',
     'captions_rendered': '.video.is-captions-rendered',
     'captions': '.subtitles',
-    'captions_text': '.subtitles > li',
+    'captions_text': '.subtitles li',
+    'closed_captions': '.closed-captions',
     'error_message': '.video .video-player h3',
     'video_container': '.video',
     'video_sources': '.video-player video source',
@@ -293,6 +295,18 @@ class VideoPage(PageObject):
         """
         self._captions_visibility(False)
 
+    def show_closed_captions(self):
+        """
+        Make closed captions visible.
+        """
+        self._closed_captions_visibility(True)
+
+    def hide_closed_captions(self):
+        """
+        Make closed captions invisible.
+        """
+        self._closed_captions_visibility(False)
+
     def is_captions_visible(self):
         """
         Get current visibility sate of captions.
@@ -302,8 +316,20 @@ class VideoPage(PageObject):
 
         """
         self.wait_for_ajax()
-        caption_state_selector = self.get_element_selector(CSS_CLASS_NAMES['closed_captions'])
-        return not self.q(css=caption_state_selector).present
+        caption_state_selector = self.get_element_selector(CSS_CLASS_NAMES['captions'])
+        return self.q(css=caption_state_selector).visible
+
+    def is_closed_captions_visible(self):
+        """
+        Get current visibility sate of closed captions.
+
+        Returns:
+            bool: True means captions are visible, False means captions are not visible
+
+        """
+        self.wait_for_ajax()
+        closed_caption_state_selector = self.get_element_selector(CSS_CLASS_NAMES['closed_captions'])
+        return not self.q(css=closed_caption_state_selector).invisible
 
     @wait_for_js
     def _captions_visibility(self, captions_new_state):
@@ -327,7 +353,24 @@ class VideoPage(PageObject):
 
             # Verify that captions state is toggled/changed
             EmptyPromise(lambda: self.is_captions_visible() == captions_new_state,
-                         "Captions are {state}".format(state=state)).fulfill()
+                         "Transcripts are {state}".format(state=state)).fulfill()
+
+    @wait_for_js
+    def _closed_captions_visibility(self, closed_captions_new_state):
+        """
+        Set the video closed captioning visibility state.
+
+        Arguments:
+            closed_captions_new_state (bool): True means show closed captioning
+        """
+        states = {True: 'shown', False: 'hidden'}
+        state = states[closed_captions_new_state]
+
+        self.click_player_button('cc_button')
+
+        # Make sure that the captions are visible
+        EmptyPromise(lambda: self.is_closed_captions_visible() == closed_captions_new_state,
+                     "Closed captions are {state}".format(state=state)).fulfill()
 
     @property
     def captions_text(self):
@@ -342,6 +385,22 @@ class VideoPage(PageObject):
 
         captions_selector = self.get_element_selector(CSS_CLASS_NAMES['captions_text'])
         subs = self.q(css=captions_selector).html
+
+        return ' '.join(subs)
+
+    @property
+    def closed_captions_text(self):
+        """
+        Extract closed captioning text.
+
+        Returns:
+            str: closed captions Text.
+
+        """
+        self.wait_for_closed_captions()
+
+        closed_captions_selector = self.get_element_selector(CSS_CLASS_NAMES['closed_captions'])
+        subs = self.q(css=closed_captions_selector).html
 
         return ' '.join(subs)
 
@@ -493,6 +552,12 @@ class VideoPage(PageObject):
 
         response = requests.get(url, **kwargs)
         return response.status_code < 400, response.headers, response.content
+
+    def get_cookie(self, cookie_name):
+        """
+        Searches for and returns `cookie_name`
+        """
+        return self.browser.get_cookie(cookie_name)
 
     def downloaded_transcript_contains_text(self, transcript_format, text_to_search):
         """
@@ -836,6 +901,20 @@ class VideoPage(PageObject):
         """
         captions_rendered_selector = self.get_element_selector(CSS_CLASS_NAMES['captions_rendered'])
         self.wait_for_element_presence(captions_rendered_selector, 'Captions Rendered')
+
+    def wait_for_closed_captions(self):
+        """
+        Wait until closed captions are rendered completely.
+        """
+        cc_rendered_selector = self.get_element_selector(CSS_CLASS_NAMES['closed_captions'])
+        self.wait_for_element_visibility(cc_rendered_selector, 'Closed captions rendered')
+
+    def wait_for_closed_captions_to_be_hidden(self):
+        """
+        Waits for the closed captions to be turned off completely.
+        """
+        cc_rendered_selector = self.get_element_selector(CSS_CLASS_NAMES['closed_captions'])
+        self.wait_for_element_invisibility(cc_rendered_selector, 'Closed captions hidden')
 
 
 def _parse_time_str(time_str):

--- a/common/test/acceptance/pages/studio/video/video.py
+++ b/common/test/acceptance/pages/studio/video/video.py
@@ -13,11 +13,11 @@ from selenium.webdriver.common.keys import Keys
 
 
 CLASS_SELECTORS = {
-    'video_container': 'div.video',
+    'video_container': '.video',
     'video_init': '.is-initialized',
     'video_xmodule': '.xmodule_VideoModule',
     'video_spinner': '.video-wrapper .spinner',
-    'video_controls': 'section.video-controls',
+    'video_controls': '.video-controls',
     'attach_asset': '.upload-dialog > input[type="file"]',
     'upload_dialog': '.wrapper-modal-window-assetupload',
     'xblock': '.add-xblock-component',
@@ -264,7 +264,7 @@ class VideoComponentPage(VideoPage):
             line_number (int): caption line number
 
         """
-        caption_line_selector = ".subtitles > li[data-index='{index}']".format(index=line_number - 1)
+        caption_line_selector = ".subtitles li[data-index='{index}']".format(index=line_number - 1)
         self.q(css=caption_line_selector).results[0].send_keys(Keys.ENTER)
 
     def is_caption_line_focused(self, line_number):
@@ -275,7 +275,7 @@ class VideoComponentPage(VideoPage):
             line_number (int): caption line number
 
         """
-        caption_line_selector = ".subtitles > li[data-index='{index}']".format(index=line_number - 1)
+        caption_line_selector = ".subtitles li[data-index='{index}']".format(index=line_number - 1)
         attributes = self.q(css=caption_line_selector).attrs('class')
 
         return 'focused' in attributes
@@ -504,7 +504,7 @@ class VideoComponentPage(VideoPage):
         As all the captions lines are exactly same so only getting partial lines will work.
         """
         self.wait_for_captions()
-        selector = '.subtitles > li:nth-child({})'
+        selector = '.subtitles li:nth-child({})'
         return ' '.join([self.q(css=selector.format(i)).text[0] for i in range(1, 6)])
 
     def set_url_field(self, url, field_number):

--- a/common/test/acceptance/tests/video/test_studio_video_editor.py
+++ b/common/test/acceptance/tests/video/test_studio_video_editor.py
@@ -142,7 +142,7 @@ class VideoEditorTest(CMSVideoBaseTest):
         self.open_advanced_tab()
         self.video.upload_translation('1mb_transcripts.srt', 'uk')
         self.save_unit_settings()
-        self.assertTrue(self.video.is_captions_visible())
+        self.video.wait_for(self.video.is_captions_visible, 'Captions are visible', timeout=10)
         unicode_text = "Привіт, edX вітає вас.".decode('utf-8')
         self.assertIn(unicode_text, self.video.captions_lines())
 

--- a/common/test/acceptance/tests/video/test_studio_video_module.py
+++ b/common/test/acceptance/tests/video/test_studio_video_module.py
@@ -255,7 +255,6 @@ class CMSVideoTest(CMSVideoBaseTest):
         Then when I view the video it does show the captions
         """
         self._create_course_unit(subtitles=True)
-
         self.assertTrue(self.video.is_captions_visible())
 
     def test_captions_toggling(self):

--- a/common/test/acceptance/tests/video/test_video_module.py
+++ b/common/test/acceptance/tests/video/test_video_module.py
@@ -212,9 +212,9 @@ class YouTubeVideoTest(VideoBaseTest):
         # Verify that video has rendered in "Youtube" mode
         self.assertTrue(self.video.is_video_rendered('youtube'))
 
-    def test_cc_button_wo_english_transcript(self):
+    def test_transcript_button_wo_english_transcript(self):
         """
-        Scenario: CC button works correctly w/o english transcript in Youtube mode
+        Scenario: Transcript button works correctly w/o english transcript in Youtube mode
         Given the course has a Video component in "Youtube" mode
         And I have defined a non-english transcript for the video
         And I have uploaded a non-english transcript file to assets
@@ -226,13 +226,38 @@ class YouTubeVideoTest(VideoBaseTest):
         self.navigate_to_video()
         self.video.show_captions()
 
-        # Verify that we see "好 各位同学" text in the captions
+        # Verify that we see "好 各位同学" text in the transcript
         unicode_text = "好 各位同学".decode('utf-8')
         self.assertIn(unicode_text, self.video.captions_text)
 
-    def test_cc_button_transcripts_and_sub_fields_empty(self):
+    def test_cc_button(self):
         """
-        Scenario: CC button works correctly if transcripts and sub fields are empty,
+        Scenario: CC button works correctly with transcript in YouTube mode
+        Given the course has a video component in "Youtube" mode
+        And I have defined a transcript for the video
+        Then I see the closed captioning element over the video
+        """
+        data = {'transcripts': {'zh': 'chinese_transcripts.srt'}}
+        self.metadata = self.metadata_for_mode('youtube', data)
+        self.assets.append('chinese_transcripts.srt')
+        self.navigate_to_video()
+
+        # Show captions and make sure they're visible and cookie is set
+        self.video.show_closed_captions()
+        self.video.wait_for_closed_captions()
+        self.assertTrue(self.video.is_closed_captions_visible)
+        self.video.reload_page()
+        self.assertEqual(self.video.get_cookie('show_closed_captions')['value'], 'true')
+
+        # Hide captions and make sure they're hidden and cookie is unset
+        self.video.hide_closed_captions()
+        self.video.wait_for_closed_captions_to_be_hidden()
+        self.video.reload_page()
+        self.assertIsNone(self.video.get_cookie('show_closed_captions'))
+
+    def test_transcript_button_transcripts_and_sub_fields_empty(self):
+        """
+        Scenario: Transcript button works correctly if transcripts and sub fields are empty,
             but transcript file exists in assets (Youtube mode of Video component)
         Given the course has a Video component in "Youtube" mode
         And I have uploaded a .srt.sjson file to assets
@@ -247,11 +272,11 @@ class YouTubeVideoTest(VideoBaseTest):
         # Verify that we see "Welcome to edX." text in the captions
         self.assertIn('Welcome to edX.', self.video.captions_text)
 
-    def test_cc_button_hidden_no_translations(self):
+    def test_transcript_button_hidden_no_translations(self):
         """
-        Scenario: CC button is hidden if no translations
+        Scenario: Transcript button is hidden if no translations
         Given the course has a Video component in "Youtube" mode
-        Then the "CC" button is hidden
+        Then the "Transcript" button is hidden
         """
         self.navigate_to_video()
         self.assertFalse(self.video.is_button_shown('transcript_button'))
@@ -522,6 +547,16 @@ class YouTubeVideoTest(VideoBaseTest):
             timeout=5
         )
 
+    def _verify_closed_caption_text(self, text):
+        """
+        Scenario: returns True if the captions are visible, False is else
+        """
+        self.video.wait_for(
+            lambda: (text in self.video.closed_captions_text),
+            u'Closed captions contain "{}" text'.format(text),
+            timeout=5
+        )
+
     def test_video_language_menu_working(self):
         """
         Scenario: Language menu works correctly in Video component
@@ -553,6 +588,46 @@ class YouTubeVideoTest(VideoBaseTest):
 
         self.video.select_language('en')
         self._verify_caption_text('Welcome to edX.')
+
+    def test_video_language_menu_working_closed_captions(self):
+        """
+        Scenario: Language menu works correctly in Video component, checks closed captions
+        Given the course has a Video component in "Youtube" mode
+        And I have defined multiple language transcripts for the videos
+        And I make sure captions are closed
+        And I see video menu "language" with correct items
+        And I select language with code "zh"
+        Then I see "好 各位同学" text in the closed captions
+        And I select language with code "en"
+        Then I see "Welcome to edX." text in the closed captions
+        """
+        self.assets.extend(['chinese_transcripts.srt', 'subs_3_yD_cEKoCk.srt.sjson'])
+        data = {'transcripts': {"zh": "chinese_transcripts.srt"}, 'sub': '3_yD_cEKoCk'}
+        self.metadata = self.metadata_for_mode('youtube', additional_data=data)
+
+        # go to video
+        self.navigate_to_video()
+        self.video.show_closed_captions()
+
+        correct_languages = {'en': 'English', 'zh': 'Chinese'}
+        self.assertEqual(self.video.caption_languages, correct_languages)
+
+        # Change the language to Chinese and check for correct text
+        self.video.select_language('zh')
+        self.video.click_player_button('play')
+        self.video.wait_for_position('0:02')
+        self.video.click_player_button('pause')
+        self.video.seek('0:00')
+        unicode_text = "好 各位同学".decode('utf-8')
+        self._verify_closed_caption_text(unicode_text)
+
+        # Change the language to English and check for correct text
+        self.video.select_language('en')
+        self.video.click_player_button('play')
+        self.video.wait_for_position('0:02')
+        self.video.click_player_button('pause')
+        self.video.seek('0:01')
+        self._verify_closed_caption_text('Welcome to edX.')
 
     def test_multiple_videos_in_sequentials_load_and_work(self):
         """

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1285,6 +1285,7 @@ main_vendor_js = base_vendor_js + [
     'js/vendor/afontgarde/modernizr.fontface-generatedcontent.js',
     'js/vendor/afontgarde/afontgarde.js',
     'js/vendor/afontgarde/edx-icons.js',
+    'js/vendor/draggabilly.pkgd.js',
 ]
 
 # Common files used by both RequireJS code and non-RequireJS code

--- a/lms/static/lms/js/require-config.js
+++ b/lms/static/lms/js/require-config.js
@@ -54,6 +54,7 @@
             "URI": "js/vendor/URI.min",
             "string_utils": "js/src/string_utils",
             "utility": "js/src/utility",
+            "draggabilly": "js/vendor/draggabilly.pkgd",
 
             // Files needed by OVA
             "annotator": "js/vendor/ova/annotator-full",
@@ -193,6 +194,9 @@
             },
             "moment-with-locales": {
                 exports: "moment"
+            },
+            "draggabilly": {
+                exports: "Draggabilly"
             }
         }
     });

--- a/lms/templates/video.html
+++ b/lms/templates/video.html
@@ -26,6 +26,7 @@
               <h3 class="hidden">${_('No playable video sources found.')}</h3>
           </section>
           <div class="video-player-post"></div>
+          <div class="closed-captions"></div>
           <section class="video-controls is-hidden">
               <div>
                   <div class="vcr"><div class="vidtime">0:00 / 0:00</div></div>


### PR DESCRIPTION
This pull request is the second of two parts and adds closed-captioning to our video player. It is part of [AC-188](https://openedx.atlassian.net/browse/AC-188).
## Notable changes
- adds a "CC" button to the grouped button container with the transcript and language control
- relies on Draggabilly, which is already included and loaded in the platform
- sets a cookie so the captioning option persists through video viewing across the platform
- allows placement of the captions within the video container for personalization
## Browsers

This has been tested in the following browsers:

| Platform | Browser | Version | Passed |
| --- | --- | --- | --- |
| Mac | Chrome | 45 | Yes |
|  | Safari | 8 | Yes |
|  | Firefox | 40 | Yes |
| Windows | Chrome | 45 | Yes |
|  | Firefox | 40 | Yes |
|  | IE | 10 | Yes |
|  | IE | 11 | Yes |
## Sandbox

https://clrux-ac-188.sandbox.edx.org/courses/course-v1:edX+AV101+2015_T3/courseware/C_01/lecture_01/
## Reviewers
- [x] Frances (FED and Sass)
- [ ] Mark (Accessibility)
- [ ] Christine (JS + Tests)
- [ ] Carol (Documentation)
- [ ] T&L review (JS + Tests)
