### PR TITLE
Bump Problem Builder to include fix from pb PR 71

### DIFF
--- a/requirements/edx/edx-private.txt
+++ b/requirements/edx/edx-private.txt
@@ -2,7 +2,7 @@
 
 # For Harvard courses:
 -e git+https://github.com/gsehub/xblock-mentoring.git@4d1cce78dc232d5da6ffd73817b5c490e87a6eee#egg=xblock-mentoring
--e git+https://github.com/open-craft/problem-builder.git@859df4155c0031b5a70e7f7e9744b67b3ed331d7#egg=xblock-problem-builder
+-e git+https://github.com/open-craft/problem-builder.git@1cb40ca523502ca2a8a2abe5aef4d1b6735cb5c7#egg=xblock-problem-builder
 
 # Oppia XBlock
 -e git+https://github.com/oppia/xblock.git@cd5479ee1138abfa278857d0113a45c2d05a983f#egg=oppia-xblock


### PR DESCRIPTION
This bumps the version of problem builder used in `private.txt` so that it includes the fix from https://github.com/open-craft/problem-builder/pull/71 . That is the only change included with this new hash.

This fixes [TNL-3563](https://openedx.atlassian.net/browse/TNL-3563). The problem-builder PR has already been reviewed by OpenCraft and by an edX engineer.
