### PR TITLE
Fix help description for test's --fail_fast flag

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -247,3 +247,4 @@ George Schneeloch <gschneel@mit.edu>
 Dustin Gadal <Dustin.Gadal@gmail.com>
 Robert Raposa <rraposa@edx.org>
 Giovanni Di Milia <gdimilia@mit.edu>
+Justin Abrahms <abrahms@mit.edu>

--- a/pavelib/tests.py
+++ b/pavelib/tests.py
@@ -25,7 +25,7 @@ __test__ = False  # do not collect
     ("system=", "s", "System to act on"),
     ("test_id=", "t", "Test id"),
     ("failed", "f", "Run only failed tests"),
-    ("fail_fast", "x", "Run only failed tests"),
+    ("fail_fast", "x", "Fail suite on first failed test"),
     ("fasttest", "a", "Run without collectstatic"),
     ('extra_args=', 'e', 'adds as extra args to the test command'),
     ('cov_args=', 'c', 'adds as args to coverage for the test run'),


### PR DESCRIPTION
Looks like we missed an error due to copy+paste.

Confirmed behavior will stop execution after the first failing test per suite (eg: lms will stop running on a single broken test, but will proceed to cms).
