### PR TITLE
saleem-latif/SOL-1266: Move Course Number and Course Number Override below Course Title section

### DIFF
--- a/cms/static/sass/views/_certificates.scss
+++ b/cms/static/sass/views/_certificates.scss
@@ -52,7 +52,12 @@
   }
 
   .certificate-info-section{
-    overflow: auto;
+      overflow: auto;
+
+    .course-title-section, .course-number-section{
+      min-width: 47%;
+      @include margin-right(2%);
+    }
   }
 }
 

--- a/cms/templates/js/certificate-details.underscore
+++ b/cms/templates/js/certificate-details.underscore
@@ -30,7 +30,7 @@
                 <% } %>
              </div>
 
-            <div class='course-number-section pull-right'>
+            <div class='course-number-section pull-left'>
                 <div class="actual-course-number">
                         <span class="certificate-label"><b><%= gettext('Course Number') %>: </b> </span>
                         <span class="certificate-value"><%= course.get('num') %></span>


### PR DESCRIPTION
Hi @ziafazal , @asadiqbal08 ,

Kindly review the PR it contains changes for the feedback at [SOL-1266](https://openedx.atlassian.net/browse/SOL-1266).

**Feedback:**
If the course numbers are long, then the text will wrap and it'll look very strange. I like the UI as you have it now, but if the titles get very long like in the example attached I think we should stack them, left aligned.

cc: @mattdrayer 
