### PR TITLE
Fix "AttributeError: 'NoneType' object has no attribute 'encode' errors

### DIFF
--- a/common/djangoapps/student/tests/test_login.py
+++ b/common/djangoapps/student/tests/test_login.py
@@ -504,7 +504,7 @@ class LoginOAuthTokenMixin(ThirdPartyOAuthTestMixin):
         self._setup_provider_response(success=True)
         response = self.client.post(self.url, {"access_token": "dummy"})
         self.assertEqual(response.status_code, 204)
-        self.assertEqual(self.client.session['_auth_user_id'], self.user.id)  # pylint: disable=no-member
+        self.assertEqual(int(self.client.session['_auth_user_id']), self.user.id)  # pylint: disable=no-member
 
     def test_invalid_token(self):
         self._setup_provider_response(success=False)

--- a/common/djangoapps/third_party_auth/settings.py
+++ b/common/djangoapps/third_party_auth/settings.py
@@ -24,12 +24,6 @@ def apply_settings(django_settings):
     # Params not in this whitelist will be silently dropped.
     django_settings.FIELDS_STORED_IN_SESSION = _FIELDS_STORED_IN_SESSION
 
-    # Register and configure python-social-auth with Django.
-    django_settings.INSTALLED_APPS += (
-        'social.apps.django_app.default',
-        'third_party_auth',
-    )
-
     # Inject exception middleware to make redirects fire.
     django_settings.MIDDLEWARE_CLASSES += _MIDDLEWARE_CLASSES
 

--- a/lms/startup.py
+++ b/lms/startup.py
@@ -24,6 +24,10 @@ def run():
     """
     Executed during django startup
     """
+    # To override the settings before executing the autostartup() for python-social-auth
+    if settings.FEATURES.get('ENABLE_THIRD_PARTY_AUTH', False):
+        enable_third_party_auth()
+
     django.setup()
 
     autostartup()
@@ -35,9 +39,6 @@ def run():
 
     if settings.FEATURES.get('USE_MICROSITES', False):
         enable_microsites()
-
-    if settings.FEATURES.get('ENABLE_THIRD_PARTY_AUTH', False):
-        enable_third_party_auth()
 
     # Initialize Segment analytics module by setting the write_key.
     if settings.LMS_SEGMENT_KEY:


### PR DESCRIPTION
This PR fixes "AttributeError: 'NoneType' object has no attribute 'encode'" errors.

**Problem:**
We are using custom class for Django Strategy which lives here `common/djangoapps/third_party_auth/settings.py:ConfigurationModelStrategy` and is overridden in third_party_auth/settings.py file. For some reason python-social-auth was using default class instead of our custom overridden class. 
After debugging, it turned out that our settings file was getting load after the third party libraries resulting into usage of default DjangoStrategy class because it was not present when python-social-auth library sets the default classes.

TNL-3533
