### PR TITLE
Fixing Teams "does not have the attribute 'tracker'" errors.

### DIFF
--- a/lms/djangoapps/teams/tests/test_views.py
+++ b/lms/djangoapps/teams/tests/test_views.py
@@ -466,7 +466,7 @@ class TestListTeamsAPI(EventTestMixin, TeamAPITestCase):
     """Test cases for the team listing API endpoint."""
 
     def setUp(self):  # pylint: disable=arguments-differ
-        super(TestListTeamsAPI, self).setUp('lms.djangoapps.teams.views.tracker')
+        super(TestListTeamsAPI, self).setUp('lms.djangoapps.teams.utils.tracker')
 
     @ddt.data(
         (None, 401),
@@ -640,7 +640,7 @@ class TestCreateTeamAPI(EventTestMixin, TeamAPITestCase):
     """Test cases for the team creation endpoint."""
 
     def setUp(self):  # pylint: disable=arguments-differ
-        super(TestCreateTeamAPI, self).setUp('lms.djangoapps.teams.views.tracker')
+        super(TestCreateTeamAPI, self).setUp('lms.djangoapps.teams.utils.tracker')
 
 
     @ddt.data(
@@ -852,7 +852,7 @@ class TestDeleteTeamAPI(EventTestMixin, TeamAPITestCase):
     """Test cases for the team delete endpoint."""
 
     def setUp(self):  # pylint: disable=arguments-differ
-        super(TestDeleteTeamAPI, self).setUp('lms.djangoapps.teams.views.tracker')
+        super(TestDeleteTeamAPI, self).setUp('lms.djangoapps.teams.utils.tracker')
 
 
     @ddt.data(
@@ -903,7 +903,7 @@ class TestUpdateTeamAPI(EventTestMixin, TeamAPITestCase):
     """Test cases for the team update endpoint."""
 
     def setUp(self):  # pylint: disable=arguments-differ
-        super(TestUpdateTeamAPI, self).setUp('lms.djangoapps.teams.views.tracker')
+        super(TestUpdateTeamAPI, self).setUp('lms.djangoapps.teams.utils.tracker')
 
 
     @ddt.data(
@@ -1233,7 +1233,7 @@ class TestCreateMembershipAPI(EventTestMixin, TeamAPITestCase):
     """Test cases for the membership creation endpoint."""
 
     def setUp(self):  # pylint: disable=arguments-differ
-        super(TestCreateMembershipAPI, self).setUp('lms.djangoapps.teams.views.tracker')
+        super(TestCreateMembershipAPI, self).setUp('lms.djangoapps.teams.utils.tracker')
 
     @ddt.data(
         (None, 401),
@@ -1397,7 +1397,7 @@ class TestDeleteMembershipAPI(EventTestMixin, TeamAPITestCase):
     """Test cases for the membership deletion endpoint."""
 
     def setUp(self):  # pylint: disable=arguments-differ
-        super(TestDeleteMembershipAPI, self).setUp('lms.djangoapps.teams.views.tracker')
+        super(TestDeleteMembershipAPI, self).setUp('lms.djangoapps.teams.utils.tracker')
 
     @ddt.data(
         (None, 401),


### PR DESCRIPTION
TNL-3595
