### PR TITLE
Delete course entry from CourseAboutSearchIndex

### DIFF
--- a/cms/djangoapps/contentstore/courseware_index.py
+++ b/cms/djangoapps/contentstore/courseware_index.py
@@ -640,3 +640,22 @@ class CourseAboutSearchIndexer(object):
             "Successfully added %s course to the course discovery index",
             course_id
         )
+
+    @classmethod
+    def _get_location_info(cls, normalized_structure_key):
+        """ Builds location info dictionary """
+        return {"course": unicode(normalized_structure_key), "org": normalized_structure_key.org}
+
+    @classmethod
+    def remove_deleted_items(cls, structure_key):
+        """ Remove item from Course About Search_index """
+        searcher = SearchEngine.get_search_engine(cls.INDEX_NAME)
+        if not searcher:
+            return
+
+        response = searcher.search(
+            doc_type=cls.DISCOVERY_DOCUMENT_TYPE,
+            field_dictionary=cls._get_location_info(structure_key)
+        )
+        result_ids = [result["data"]["id"] for result in response["results"]]
+        searcher.remove(cls.DISCOVERY_DOCUMENT_TYPE, result_ids)

--- a/openedx/core/djangoapps/content/course_overviews/signals.py
+++ b/openedx/core/djangoapps/content/course_overviews/signals.py
@@ -24,3 +24,7 @@ def _listen_for_course_delete(sender, course_key, **kwargs):  # pylint: disable=
     invalidates the corresponding CourseOverview cache entry if one exists.
     """
     CourseOverview.objects.filter(id=course_key).delete()
+    # import CourseAboutSearchIndexer inline due to cyclic import
+    from cms.djangoapps.contentstore.courseware_index import CourseAboutSearchIndexer
+    # Delete course entry from Course About Search_index
+    CourseAboutSearchIndexer.remove_deleted_items(course_key)


### PR DESCRIPTION
[PLAT-875](https://openedx.atlassian.net/browse/PLAT-875)

**Steps to Reproduce :**
1) Create course in Studio
2) On Lms side search the course at for example at http://localhost:8000/courses it will show the course
3) Now Delete the course
4) Again on Lms side search this course it will still appear at http://localhost:8000/courses even it is  deleted

**Problem:**
We use `CourseAboutSearchIndexer` for course discovery  at lms side and when we delete the course , the course still remains in `CourseAboutSearchIndexer`.

**Solution:**
We are catching the `course_deleted` signal at [here](https://github.com/edx/edx-platform/blob/062e979e0ed14161d0f882091a06e032ca76bb3e/openedx/core/djangoapps/content/course_overviews/signals.py#L21) ,So when a course is deleted we will also remove the course entry from `CourseAboutSearchIndexer` at `course_deleted` signal.

**Update:**
This PR does not fix the Plat-875 but while investigating, I found the above mentioned issue. So this PR is a possible fix for that.

@dsego , @adampalay FYI
