### PR TITLE
mattdrayer/update-gencert-modes: Added prof-ed modes to set

### DIFF
--- a/lms/djangoapps/certificates/models.py
+++ b/lms/djangoapps/certificates/models.py
@@ -109,7 +109,7 @@ class CertificateWhitelist(models.Model):
 
 class GeneratedCertificate(models.Model):
 
-    MODES = Choices('verified', 'honor', 'audit')
+    MODES = Choices('verified', 'honor', 'audit', 'professional', 'no-id-professional')
 
     VERIFIED_CERTS_MODES = [CourseMode.VERIFIED, CourseMode.CREDIT_MODE]
 


### PR DESCRIPTION
@frrrances -- added prof-ed modes to the set of possible choices.

@chrisndodge -- I tried a variety of approaches to tie into the course_modes list, but ran into all sorts of issues working with the Django Admin "choices" object plus various references throughout the system.  So this is the quick fix and we'll have to leave the larger refactor for another time.
