### PR TITLE
Fake initial django migrations when runing update_db

### DIFF
--- a/pavelib/servers.py
+++ b/pavelib/servers.py
@@ -240,7 +240,7 @@ def update_db():
     """
     settings = getattr(options, 'settings', DEFAULT_SETTINGS)
     for system in ('lms', 'cms'):
-        sh(django_cmd(system, settings, 'migrate', '--traceback', '--pythonpath=.'))
+        sh(django_cmd(system, settings, 'migrate', '--fake-initial', '--traceback', '--pythonpath=.'))
 
 
 @task


### PR DESCRIPTION
As per https://docs.djangoproject.com/en/1.8/ref/django-admin/#django-admin-option---fake-initial.

@nedbat @doctoryes 
