### PR TITLE
fix for TNL-3606: clearing the staticfiles finders cache during testing

### DIFF
--- a/lms/djangoapps/courseware/tests/test_comp_theming.py
+++ b/lms/djangoapps/courseware/tests/test_comp_theming.py
@@ -18,7 +18,7 @@ class TestComprehensiveTheming(TestCase):
         super(TestComprehensiveTheming, self).setUp()
 
         # Clear the internal staticfiles caches, to get test isolation.
-        staticfiles.finders._finders.clear()                    # pylint: disable=protected-access
+        staticfiles.finders.get_finder.cache_clear()
 
     @with_comp_theme(settings.REPO_ROOT / 'themes/red-theme')
     @unittest.skip("Disabled until we can release theming to production")


### PR DESCRIPTION
Hooray, we no longer have to access a private member of a module to clear the staticfiles finders cache!

@nedbat @doctoryes @alawibaba @symbolist @muhammad-ammar @muzaffaryousaf 
