### PR TITLE
Translate education/gender options in registration form LOC-73

### DIFF
--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -999,6 +999,32 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, ApiTestCase):
             }
         )
 
+    @mock.patch('openedx.core.djangoapps.user_api.views._')
+    def test_register_form_level_of_education_translations(self, fake_gettext):
+        fake_gettext.side_effect = lambda text: text + ' TRANSLATED'
+
+        self._assert_reg_field(
+            {"level_of_education": "optional"},
+            {
+                "name": "level_of_education",
+                "type": "select",
+                "required": False,
+                "label": "Highest level of education completed TRANSLATED",
+                "options": [
+                    {"value": "", "name": "--", "default": True},
+                    {"value": "p", "name": "Doctorate TRANSLATED"},
+                    {"value": "m", "name": "Master's or professional degree TRANSLATED"},
+                    {"value": "b", "name": "Bachelor's degree TRANSLATED"},
+                    {"value": "a", "name": "Associate degree TRANSLATED"},
+                    {"value": "hs", "name": "Secondary/high school TRANSLATED"},
+                    {"value": "jhs", "name": "Junior secondary/junior high/middle school TRANSLATED"},
+                    {"value": "el", "name": "Elementary/primary school TRANSLATED"},
+                    {"value": "none", "name": "None TRANSLATED"},
+                    {"value": "other", "name": "Other TRANSLATED"},
+                ],
+            }
+        )
+
     def test_register_form_gender(self):
         self._assert_reg_field(
             {"gender": "optional"},
@@ -1012,6 +1038,26 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, ApiTestCase):
                     {"value": "m", "name": "Male"},
                     {"value": "f", "name": "Female"},
                     {"value": "o", "name": "Other"},
+                ],
+            }
+        )
+
+    @mock.patch('openedx.core.djangoapps.user_api.views._')
+    def test_register_form_gender_translations(self, fake_gettext):
+        fake_gettext.side_effect = lambda text: text + ' TRANSLATED'
+
+        self._assert_reg_field(
+            {"gender": "optional"},
+            {
+                "name": "gender",
+                "type": "select",
+                "required": False,
+                "label": "Gender TRANSLATED",
+                "options": [
+                    {"value": "", "name": "--", "default": True},
+                    {"value": "m", "name": "Male TRANSLATED"},
+                    {"value": "f", "name": "Female TRANSLATED"},
+                    {"value": "o", "name": "Other TRANSLATED"},
                 ],
             }
         )

--- a/openedx/core/djangoapps/user_api/views.py
+++ b/openedx/core/djangoapps/user_api/views.py
@@ -449,11 +449,13 @@ class RegistrationView(APIView):
         # form used to select the user's highest completed level of education.
         education_level_label = _(u"Highest level of education completed")
 
+        # The labels are marked for translation in UserProfile model definition.
+        options = [(name, _(label)) for name, label in UserProfile.LEVEL_OF_EDUCATION_CHOICES]  # pylint: disable=translation-of-non-string
         form_desc.add_field(
             "level_of_education",
             label=education_level_label,
             field_type="select",
-            options=UserProfile.LEVEL_OF_EDUCATION_CHOICES,
+            options=options,
             include_default_option=True,
             required=required
         )
@@ -472,11 +474,13 @@ class RegistrationView(APIView):
         # form used to select the user's gender.
         gender_label = _(u"Gender")
 
+        # The labels are marked for translation in UserProfile model definition.
+        options = [(name, _(label)) for name, label in UserProfile.GENDER_CHOICES]  # pylint: disable=translation-of-non-string
         form_desc.add_field(
             "gender",
             label=gender_label,
             field_type="select",
-            options=UserProfile.GENDER_CHOICES,
+            options=options,
             include_default_option=True,
             required=required
         )


### PR DESCRIPTION
## Background

The level of education and gender choices on the new combined login/registration page are not being translated. Code in this pull request runs the choice labels through gettext before displaying them on the registration page.

**Partner information**: not an edX partner - 3rd party-hosted open edX instance
**Jira tickets**: https://openedx.atlassian.net/browse/OSPR-878, https://openedx.atlassian.net/browse/LOC-73
**Sandbox URL**: http://pr10182.sandbox.opencraft.com/
## How to test
- Enable the combined login/registration page by setting `ENABLE_COMBINED_LOGIN_REGISTRATION` to `true` inside the `FEATURES` map in your `lms.env.json` file.
- In `lms.env.json` set the `LANGUAGE_CODE` variable to a language other than English that provides translations for the education level and gender options, for example French (`"LANGUAGE_CODE": "fr"`).
- Navigate to `/registration`.
- Observe contents of the gender and level of education dropdowns. Without this patch, the options are displayed in English. With this patch applied, the options are translated to the selected language.
## Screenshots
### Before:

![screen shot 2015-10-15 at 08 24 33](https://cloud.githubusercontent.com/assets/32585/10506799/d7e73cb6-731b-11e5-935b-1ca538b4ace1.png)
### After:

![screen shot 2015-10-15 at 08 24 50](https://cloud.githubusercontent.com/assets/32585/10506805/dd8e571c-731b-11e5-8946-5544923a3b83.png)

---

**Settings**

``` yaml
EDXAPP_LANGUAGE_CODE: fr
EDXAPP_FEATURES:
  ENABLE_COMBINED_LOGIN_REGISTRATION: true
```
