### PR TITLE
Don't include empty strings when making commands in pavelib

### DIFF
--- a/pavelib/utils/cmd.py
+++ b/pavelib/utils/cmd.py
@@ -7,7 +7,7 @@ def cmd(*args):
     """
     Concatenate the arguments into a space-separated shell command.
     """
-    return " ".join([str(arg) for arg in args])
+    return " ".join(str(arg) for arg in args if arg)
 
 
 def django_cmd(sys, settings, *args):


### PR DESCRIPTION
This prevents ugly double spaces when omitting arguments.

[skip ci]
