### PR TITLE
Making the query to find if microsites exist in the database faster

### DIFF
--- a/common/djangoapps/microsite_configuration/backends/database.py
+++ b/common/djangoapps/microsite_configuration/backends/database.py
@@ -18,10 +18,7 @@ class DatabaseMicrositeBackend(SettingsFileMicrositeBackend):
         """
         Returns whether there is any Microsite configuration settings
         """
-
-        # CDODGE: I believe this will be called on every request into edx-platform
-        # so it seems more expensive than it should be. Like set_config_by_domain
-        if Microsite.objects.count():
+        if Microsite.objects.all()[:1].exists():
             return True
         else:
             return False


### PR DESCRIPTION
This makes the query limit to 1, so a full count is not required. It works on a regular model now. To make it work with config_models we would need to filter is_enabled=True
