### PR TITLE
Use OneToOne fields for unique foreign keys

### DIFF
--- a/cms/djangoapps/course_creators/models.py
+++ b/cms/djangoapps/course_creators/models.py
@@ -36,7 +36,7 @@ class CourseCreator(models.Model):
         (DENIED, _(u'denied')),
     )
 
-    user = models.ForeignKey(User, help_text=_("Studio user"), unique=True)
+    user = models.OneToOneField(User, help_text=_("Studio user"))
     state_changed = models.DateTimeField('state last updated', auto_now_add=True,
                                          help_text=_("The date when state was last updated"))
     state = models.CharField(max_length=24, blank=False, choices=STATES, default=UNREQUESTED,

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -186,7 +186,7 @@ class UserStanding(models.Model):
         (ACCOUNT_ENABLED, u"Account Enabled"),
     )
 
-    user = models.ForeignKey(User, db_index=True, related_name='standing', unique=True)
+    user = models.OneToOneField(User, db_index=True, related_name='standing')
     account_status = models.CharField(
         blank=True, max_length=31, choices=USER_STANDING_CHOICES
     )
@@ -464,7 +464,7 @@ class Registration(models.Model):
     class Meta(object):  # pylint: disable=missing-docstring
         db_table = "auth_registration"
 
-    user = models.ForeignKey(User, unique=True)
+    user = models.OneToOneField(User)
     activation_key = models.CharField(('activation key'), max_length=32, unique=True, db_index=True)
 
     def register(self, user):

--- a/lms/djangoapps/lti_provider/models.py
+++ b/lms/djangoapps/lti_provider/models.py
@@ -132,7 +132,7 @@ class LtiUser(models.Model):
     """
     lti_consumer = models.ForeignKey(LtiConsumer)
     lti_user_id = models.CharField(max_length=255)
-    edx_user = models.ForeignKey(User, unique=True)
+    edx_user = models.OneToOneField(User)
 
     class Meta(object):
         """

--- a/lms/djangoapps/psychometrics/models.py
+++ b/lms/djangoapps/psychometrics/models.py
@@ -20,7 +20,7 @@ class PsychometricData(models.Model):
     checktimes is extracted from tracking logs, or added by capa module via psychometrics callback.
     """
 
-    studentmodule = models.ForeignKey(StudentModule, db_index=True, unique=True)   # contains student, module_state_key, course_id
+    studentmodule = models.OneToOneField(StudentModule, db_index=True)   # contains student, module_state_key, course_id
 
     done = models.BooleanField(default=False)
     attempts = models.IntegerField(default=0)			# extracted from studentmodule.state


### PR DESCRIPTION
This fixes a few of the yellow warnings.

cc @nedbat @doctoryes @macdiesel 
