### PR TITLE
Keep favicon.ico redirection permanent

### DIFF
--- a/lms/urls.py
+++ b/lms/urls.py
@@ -153,7 +153,7 @@ urlpatterns += (
 favicon_path = microsite.get_value('favicon_path', settings.FAVICON_PATH)
 urlpatterns += (url(
     r'^favicon\.ico$',
-    RedirectView.as_view(url=settings.STATIC_URL + favicon_path)
+    RedirectView.as_view(url=settings.STATIC_URL + favicon_path, permanent=True)
 ),)
 
 # Semi-static views only used by edX, not by themes


### PR DESCRIPTION
The current default is True, in Django 1.9, it will be False.
This also removes one of the yellow warnings. :+1: 

cc @nedbat @doctoryes @macdiesel 
