### PR TITLE
update django-wiki hash

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -9,7 +9,7 @@
 
 # Third-party:
 -e git+https://github.com/cyberdelia/django-pipeline.git@1.5.3#egg=django-pipeline
-git+https://github.com/edx/django-wiki.git@dc121c3b400ca02ced2158d5ac1ad135933a396f#egg=django-wiki==0.0.2
+git+https://github.com/edx/django-wiki.git@a4e0d0f2b7f87e0824e643429efc4e8894febf87#egg=django-wiki==0.0.2
 -e git+https://github.com/edx/django-oauth2-provider.git@django1.8-upgrade#egg=django-oauth2-provider
 -e git+https://github.com/edx/django-rest-framework-oauth.git@f0b503fda8c254a38f97fef802ded4f5fe367f7a#egg=djangorestframework-oauth
 git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0


### PR DESCRIPTION
TNL-3620

hash is updated due to removal of deprecation warning in django-wiki. Please see https://github.com/edx/django-wiki/pull/11
