### PR TITLE
Upgrade to MathJax 2.5.

### DIFF
--- a/cms/static/cms/js/require-config.js
+++ b/cms/static/cms/js/require-config.js
@@ -70,7 +70,7 @@ require.config({
         // end of Annotation tool files
 
         // externally hosted files
-        "mathjax": "//cdn.mathjax.org/mathjax/2.4-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&delayStartupUntil=configured",
+        "mathjax": "//cdn.mathjax.org/mathjax/2.5-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&delayStartupUntil=configured",
         "youtube": [
             // youtube URL does not end in ".js". We add "?noext" to the path so
             // that require.js adds the ".js" to the query component of the URL,

--- a/cms/static/coffee/spec/main.coffee
+++ b/cms/static/coffee/spec/main.coffee
@@ -51,7 +51,7 @@ requirejs.config({
         "URI": "xmodule_js/common_static/js/vendor/URI.min",
         "mock-ajax": "xmodule_js/common_static/js/vendor/mock-ajax",
 
-        "mathjax": "//cdn.mathjax.org/mathjax/2.4-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&delayStartupUntil=configured",
+        "mathjax": "//cdn.mathjax.org/mathjax/2.5-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&delayStartupUntil=configured",
         "youtube": "//www.youtube.com/player_api?noext",
 
         "coffee/src/ajax_prefix": "xmodule_js/common_static/coffee/src/ajax_prefix",

--- a/cms/static/coffee/spec/main_squire.coffee
+++ b/cms/static/coffee/spec/main_squire.coffee
@@ -42,7 +42,7 @@ requirejs.config({
         "domReady": "xmodule_js/common_static/js/vendor/domReady",
         "URI": "xmodule_js/common_static/js/vendor/URI.min",
 
-        "mathjax": "//cdn.mathjax.org/mathjax/2.4-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&delayStartupUntil=configured",
+        "mathjax": "//cdn.mathjax.org/mathjax/2.5-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&delayStartupUntil=configured",
         "youtube": "//www.youtube.com/player_api?noext",
 
         "coffee/src/ajax_prefix": "xmodule_js/common_static/coffee/src/ajax_prefix"

--- a/common/templates/mathjax_include.html
+++ b/common/templates/mathjax_include.html
@@ -50,4 +50,4 @@
 <!-- This must appear after all mathjax-config blocks, so it is after the imports from the other templates.
      It can't be run through static.url because MathJax uses crazy url introspection to do lazy loading of
      MathJax extension libraries -->
-<script type="text/javascript" src="https://cdn.mathjax.org/mathjax/2.4-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full"></script>
+<script type="text/javascript" src="https://cdn.mathjax.org/mathjax/2.5-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full"></script>

--- a/common/test/acceptance/tests/lms/test_lms_problems.py
+++ b/common/test/acceptance/tests/lms/test_lms_problems.py
@@ -275,19 +275,28 @@ class ProblemWithMathjax(ProblemsTest):
         problem_page = ProblemPage(self.browser)
         self.assertEqual(problem_page.problem_name, "MATHJAX TEST PROBLEM")
 
-        # Verify Mathjax have been rendered
-        self.assertTrue(problem_page.mathjax_rendered_in_problem, "MathJax did not rendered in body")
+        # Verify MathJax has been rendered
+        problem_page.wait_for(
+            lambda: problem_page.mathjax_rendered_in_problem,
+            description="MathJax rendered in body"
+        )
 
         # The hint button rotates through multiple hints
         problem_page.click_hint()
         self.assertIn("Hint (1 of 2): mathjax should work1", problem_page.hint_text)
-        self.assertTrue(problem_page.mathjax_rendered_in_hint, "MathJax did not rendered in problem hint")
+        problem_page.wait_for(
+            lambda: problem_page.mathjax_rendered_in_hint,
+            description="MathJax rendered in hint"
+        )
 
         # Rotate the hint and check the problem hint
         problem_page.click_hint()
 
         self.assertIn("Hint (2 of 2): mathjax should work2", problem_page.hint_text)
-        self.assertTrue(problem_page.mathjax_rendered_in_hint, "MathJax did not rendered in problem hint")
+        problem_page.wait_for(
+            lambda: problem_page.mathjax_rendered_in_hint,
+            description="MathJax rendered in hint"
+        )
 
 
 class ProblemPartialCredit(ProblemsTest):

--- a/lms/static/js/spec/main.js
+++ b/lms/static/js/spec/main.js
@@ -49,7 +49,7 @@
             'jasmine.async': 'xmodule_js/common_static/js/vendor/jasmine.async',
             'draggabilly': 'xmodule_js/common_static/js/vendor/draggabilly.pkgd',
             'domReady': 'xmodule_js/common_static/js/vendor/domReady',
-            'mathjax': '//cdn.mathjax.org/mathjax/2.4-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&delayStartupUntil=configured',
+            'mathjax': '//cdn.mathjax.org/mathjax/2.5-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&delayStartupUntil=configured',
             'youtube': '//www.youtube.com/player_api?noext',
             'coffee/src/ajax_prefix': 'xmodule_js/common_static/coffee/src/ajax_prefix',
             'coffee/src/instructor_dashboard/student_admin': 'coffee/src/instructor_dashboard/student_admin',

--- a/lms/static/js/spec/main.js
+++ b/lms/static/js/spec/main.js
@@ -49,7 +49,7 @@
             'jasmine.async': 'xmodule_js/common_static/js/vendor/jasmine.async',
             'draggabilly': 'xmodule_js/common_static/js/vendor/draggabilly.pkgd',
             'domReady': 'xmodule_js/common_static/js/vendor/domReady',
-            'mathjax': '//cdn.mathjax.org/mathjax/2.5-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&delayStartupUntil=configured',
+            'mathjax': '//cdn.mathjax.org/mathjax/2.5-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&delayStartupUntil=configured', // jshint ignore:line
             'youtube': '//www.youtube.com/player_api?noext',
             'coffee/src/ajax_prefix': 'xmodule_js/common_static/coffee/src/ajax_prefix',
             'coffee/src/instructor_dashboard/student_admin': 'coffee/src/instructor_dashboard/student_admin',


### PR DESCRIPTION
## [TNL-3495](https://openedx.atlassian.net/browse/TNL-3495)

Upgrade from MathJax 2.4 to 2.5. This may introduce performance improvements for users (in particular, rendering speed), and it fixes a CAT-2 bug, TNL-3365.
### Sandbox
- [x] http://mathjax.sandbox.edx.org/courses/course-v1:math+jax+x/courseware/4add5954d71b4fe3b46c9533526b7231/b29120ddd1834140946f98c5104af450/ (log in as honor)
### Testing
- [x] Performance

Sitespeed reports--
2.4 https://build.testeng.edx.org/job/get-sitespeed-report/87/SiteSpeedIO_Report/index.html
2.5 https://build.testeng.edx.org/job/get-sitespeed-report/88/SiteSpeedIO_Report/index.html
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @dianakhuang 
- [x] Code review: @robrap
- [x] Product review: @explorerleslie (FYI)

FYI @ormsbee @benpatterson 
### Post-review
- [x] Squash commits
