### PR TITLE
Add app labels to ease Django 1.9 compatibility

### DIFF
--- a/common/djangoapps/xblock_django/models.py
+++ b/common/djangoapps/xblock_django/models.py
@@ -13,6 +13,9 @@ class XBlockDisableConfig(ConfigurationModel):
     Configuration for disabling XBlocks.
     """
 
+    class Meta(object):
+        app_label = 'xblock_django'
+
     disabled_blocks = TextField(
         default='', blank=True,
         help_text=_('Space-separated list of XBlocks which should not render.')

--- a/common/lib/xmodule/xmodule/modulestore/tests/persistent_factories.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/persistent_factories.py
@@ -33,7 +33,7 @@ class PersistentCourseFactory(SplitFactory):
     * user_id: (optional) defaults to 'test_user'
     * display_name (xblock field): will default to 'Robot Super Course' unless provided
     """
-    class Meta:
+    class Meta(object):
         """
         Factoryboy factory for the CourseDescriptor model
         """
@@ -60,7 +60,7 @@ class PersistentCourseFactory(SplitFactory):
 
 
 class ItemFactory(SplitFactory):
-    class Meta:
+    class Meta(object):
         """
         Factoryboy factory for the XModuleDescriptor model
         """

--- a/lms/djangoapps/ccx/models.py
+++ b/lms/djangoapps/ccx/models.py
@@ -25,6 +25,9 @@ class CustomCourseForEdX(models.Model):
     display_name = models.CharField(max_length=255)
     coach = models.ForeignKey(User, db_index=True)
 
+    class Meta(object):
+        app_label = 'lms.djangoapps.ccx'
+
     @lazy
     def course(self):
         """Return the CourseDescriptor of the course related to this CCX"""
@@ -104,6 +107,7 @@ class CcxFieldOverride(models.Model):
     field = models.CharField(max_length=255)
 
     class Meta(object):  # pylint: disable=missing-docstring
+        app_label = 'lms.djangoapps.ccx'
         unique_together = (('ccx', 'location', 'field'),)
 
     value = models.TextField(default='null')

--- a/lms/djangoapps/teams/serializers.py
+++ b/lms/djangoapps/teams/serializers.py
@@ -209,7 +209,7 @@ class BulkTeamCountTopicSerializer(BaseTopicSerializer):  # pylint: disable=abst
     Serializes a set of topics, adding the team_count field to each topic as a bulk operation.
     Requires that `context` is provided with a valid course_id in order to filter teams within the course.
     """
-    class Meta:  # pylint: disable=missing-docstring,old-style-class
+    class Meta(object):  # pylint: disable=missing-docstring
         list_serializer_class = BulkTeamCountTopicListSerializer
 
 

--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -29,6 +29,9 @@ class CourseOverview(TimeStampedModel):
     a course as part of a user dashboard or enrollment API.
     """
 
+    class Meta(object):
+        app_label = 'openedx.core.djangoapps.content'
+
     # IMPORTANT: Bump this whenever you modify this model and/or add a migration.
     VERSION = 1
 

--- a/openedx/core/djangoapps/content/course_structures/models.py
+++ b/openedx/core/djangoapps/content/course_structures/models.py
@@ -12,6 +12,10 @@ logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
 class CourseStructure(TimeStampedModel):
+
+    class Meta(object):
+        app_label = 'openedx.core.djangoapps.course_structures'
+
     course_id = CourseKeyField(max_length=255, db_index=True, unique=True, verbose_name='Course ID')
 
     # Right now the only thing we do with the structure doc is store it and


### PR DESCRIPTION
This silences some warnings from Django 1.8.
