### PR TITLE
Don't kill collectstatic for missing files

### DIFF
--- a/openedx/core/lib/django_require/staticstorage.py
+++ b/openedx/core/lib/django_require/staticstorage.py
@@ -2,12 +2,29 @@
 :class:`~django_require.staticstorage.OptimizedCachedRequireJsStorage`
 """
 
+import logging
+
 from pipeline.storage import PipelineCachedStorage
 from require.storage import OptimizedFilesMixin
+
+log = logging.getLogger(__name__)
 
 
 class OptimizedCachedRequireJsStorage(OptimizedFilesMixin, PipelineCachedStorage):
     """
     Custom storage backend that is used by Django-require.
     """
-    pass
+    def hashed_name(self, name, content=None):
+        """
+        Returns the MD5 hashed version of a file name.
+
+        Note: this overrides the default implementation to catch ValueErrors
+        which indicate that the file doesn't exist so that the collectstatic
+        process doesn't abort. Instead, a warning is logged and then the
+        original file name is returned.
+        """
+        try:
+            return super(OptimizedCachedRequireJsStorage, self).hashed_name(name, content)
+        except ValueError:
+            log.warn("File not found in OptimizedCachedRequireJsStorage: %r", name)
+            return name


### PR DESCRIPTION
## [TNL-726](https://openedx.atlassian.net/browse/TNL-726)

There have been a number of reports where folks find that their collectstatic call fails because the Django Pipeline is looking for a file which doesn't exist. This is frustrating because it means that the sandbox build operation is killed and so there is no way to get past the problem. 

This fix changes OptimizedCachedRequireJsStorage to override `hashed_name` to catch the missing file error, log it, but then return the original name as the hashed name. This seems reasonable since the pipeline is trying to update the hashed name in static files such as CSS, so returning the original name will mean that the update is just a no-op.
### Testing
- [x] Manual verification of collectstatic for files with references to missing paths
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @cahrens 
- [ ] Code review: @feanil 

FYI: @e-kolpakov 
### Post-review
- [ ] Squash commits
